### PR TITLE
fix(droid): forward role-specific model config via settings file

### DIFF
--- a/backend/internal/adapters/agent/droid/droid.go
+++ b/backend/internal/adapters/agent/droid/droid.go
@@ -11,11 +11,13 @@
 //
 // Launch uses the interactive `droid [prompt]` command (the prompt is a
 // positional argument). Droid's interactive TUI exposes no per-launch permission
-// flag (--auto / --skip-permissions-unsafe live only on `droid exec`), so AO's
-// graduated permission modes are delivered by writing a process-scoped runtime
-// settings file (sessionDefaultSettings.autonomyLevel) and passing it via the
-// root `--settings <path>` flag. Restore prefers the hook-captured native
-// session id via `-r <id>`.
+// flag (--auto / --skip-permissions-unsafe live only on `droid exec`) and no
+// interactive --model flag either, so AO's graduated permission modes and any
+// role-specific model override are both delivered by writing a process-scoped
+// runtime settings file (sessionDefaultSettings.autonomyLevel and a top-level
+// "model" key) and passing it via the root `--settings <path>` flag. The
+// settings file is written whenever either value is set. Restore prefers the
+// hook-captured native session id via `-r <id>`.
 package droid
 
 import (
@@ -63,6 +65,21 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override written to Droid's runtime settings file.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new interactive Droid session:
 //
 //	droid [--settings <path>] [--append-system-prompt[-file] <x>] [prompt]
@@ -81,7 +98,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	cmd = make([]string, 0, 6)
 	cmd = append(cmd, binary)
 
-	settingsArgs, err := permissionSettingsArgs(cfg.SessionID, cfg.Permissions)
+	settingsArgs, err := permissionSettingsArgs(cfg.SessionID, cfg.Permissions, cfg.Config.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +139,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 
 	cmd = make([]string, 0, 5)
 	cmd = append(cmd, binary)
-	settingsArgs, err := permissionSettingsArgs(cfg.Session.ID, cfg.Permissions)
+	settingsArgs, err := permissionSettingsArgs(cfg.Session.ID, cfg.Permissions, cfg.Config.Model)
 	if err != nil {
 		return nil, false, err
 	}
@@ -177,15 +194,22 @@ func droidAutonomyLevel(mode ports.PermissionMode) string {
 // --skip-permissions-unsafe exist only on `droid exec`), so autonomy must be
 // delivered through settings. The file is written under the OS temp dir, keyed
 // by session id, rather than into the worktree so it never lands in a commit.
-func permissionSettingsArgs(sessionID string, mode ports.PermissionMode) ([]string, error) {
+func permissionSettingsArgs(sessionID string, mode ports.PermissionMode, model string) ([]string, error) {
 	level := droidAutonomyLevel(mode)
-	if level == "" {
+	model = strings.TrimSpace(model)
+	if level == "" && model == "" {
 		return nil, nil
 	}
 
-	blob, err := json.Marshal(map[string]any{
-		"sessionDefaultSettings": map[string]any{"autonomyLevel": level},
-	})
+	settings := map[string]any{}
+	if level != "" {
+		settings["sessionDefaultSettings"] = map[string]any{"autonomyLevel": level}
+	}
+	if model != "" {
+		settings["model"] = model
+	}
+
+	blob, err := json.Marshal(settings)
 	if err != nil {
 		return nil, fmt.Errorf("droid: encode runtime settings: %w", err)
 	}

--- a/backend/internal/adapters/agent/droid/droid.go
+++ b/backend/internal/adapters/agent/droid/droid.go
@@ -66,7 +66,7 @@ func (p *Plugin) Manifest() adapters.Manifest {
 }
 
 // GetConfigSpec reports the per-project agent config keys Droid understands.
-// Model is honored via the runtime --settings file (see permissionSettingsArgs)
+// Model is honored via the runtime --settings file (see runtimeSettingsArgs)
 // rather than an argv flag, since interactive droid has no --model flag.
 func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 	if err := ctx.Err(); err != nil {
@@ -87,11 +87,12 @@ func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 //
 //	droid [--settings <path>] [--append-system-prompt[-file] <x>] [prompt]
 //
-// The prompt is delivered as a positional argument (in command). Droid resolves
-// its model and other defaults from the user's own settings; only the autonomy
-// level is overridden, and only for non-default permission modes (see
-// permissionSettingsArgs). System-prompt text/file is appended (not replaced),
-// matching Droid's --append-system-prompt semantics.
+// The prompt is delivered as a positional argument (in command). Both the
+// permission autonomy level and any role-specific model override are written
+// to the runtime --settings file when set (see runtimeSettingsArgs); when
+// neither is set, Droid resolves everything from the user's own settings.
+// System-prompt text/file is appended (not replaced), matching Droid's
+// --append-system-prompt semantics.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	binary, err := p.droidBinary(ctx)
 	if err != nil {
@@ -101,7 +102,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	cmd = make([]string, 0, 6)
 	cmd = append(cmd, binary)
 
-	settingsArgs, err := permissionSettingsArgs(cfg.SessionID, cfg.Permissions, cfg.Config.Model)
+	settingsArgs, err := runtimeSettingsArgs(cfg.SessionID, cfg.Permissions, cfg.Config.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -122,10 +123,9 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 // GetRestoreCommand rebuilds the argv that continues an existing Droid session:
 // `droid [--settings <path>] -r <agentSessionId>`. It re-applies the permission
-// autonomy (resume otherwise reverts to the configured default) but not the
-// prompt, which the session already carries. ok is false when the hook-derived
-// native session id has not landed yet, so callers fall back to fresh launch
-// behavior — mirroring the Codex and opencode adapters.
+// autonomy and any model override (resume otherwise reverts to the configured
+// default) but not the prompt, which the session already carries. ok is false
+// when the hook-derived
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
@@ -142,7 +142,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 
 	cmd = make([]string, 0, 5)
 	cmd = append(cmd, binary)
-	settingsArgs, err := permissionSettingsArgs(cfg.Session.ID, cfg.Permissions, cfg.Config.Model)
+	settingsArgs, err := runtimeSettingsArgs(cfg.Session.ID, cfg.Permissions, cfg.Config.Model)
 	if err != nil {
 		return nil, false, err
 	}
@@ -188,16 +188,22 @@ func droidAutonomyLevel(mode ports.PermissionMode) string {
 	}
 }
 
-// permissionSettingsArgs renders a non-default permission mode as a
-// `--settings <path>` argv pair, writing a process-scoped runtime settings file
-// that overrides only sessionDefaultSettings.autonomyLevel. The default mode
-// returns nil (no flag, no file) so Droid uses the user's own settings.
+// runtimeSettingsArgs renders a non-default permission mode and/or a model
+// override as a `--settings <path>` argv pair, writing a process-scoped
+// runtime settings file. It returns nil (no flag, no file) only when neither
+// value is set, so Droid falls back entirely to the user's own settings.
 //
 // Interactive `droid` exposes no per-launch permission flag (--auto and
-// --skip-permissions-unsafe exist only on `droid exec`), so autonomy must be
-// delivered through settings. The file is written under the OS temp dir, keyed
-// by session id, rather than into the worktree so it never lands in a commit.
-func permissionSettingsArgs(sessionID string, mode ports.PermissionMode, model string) ([]string, error) {
+// --skip-permissions-unsafe exist only on `droid exec`) and no interactive
+// --model flag either, so both autonomy and model must be delivered through
+// settings. The file is written under the OS temp dir, keyed by session id,
+// rather than into the worktree so it never lands in a commit.
+//
+// NOTE: Droid applies --settings as an overlay at org-level precedence, not a
+// full replacement of the user's own settings file. Writing {"model": ...}
+// alone (default permissions, no autonomy override) does not clobber
+// ~/.factory/settings.json — this is load-bearing for the model-only case.
+func runtimeSettingsArgs(sessionID string, mode ports.PermissionMode, model string) ([]string, error) {
 	level := droidAutonomyLevel(mode)
 	model = strings.TrimSpace(model)
 	if level == "" && model == "" {

--- a/backend/internal/adapters/agent/droid/droid.go
+++ b/backend/internal/adapters/agent/droid/droid.go
@@ -102,7 +102,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	cmd = make([]string, 0, 6)
 	cmd = append(cmd, binary)
 
-	settingsArgs, err := runtimeSettingsArgs(cfg.SessionID, cfg.Permissions, cfg.Config.Model)
+	settingsArgs, err := runtimeSettingsArgs(cfg.DataDir, cfg.SessionID, cfg.Permissions, cfg.Config.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,8 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 // `droid [--settings <path>] -r <agentSessionId>`. It re-applies the permission
 // autonomy and any model override (resume otherwise reverts to the configured
 // default) but not the prompt, which the session already carries. ok is false
-// when the hook-derived
+// when the hook-derived native session id has not landed yet, so callers fall
+// back to fresh launch behavior — mirroring the Codex and opencode adapters.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
@@ -142,7 +143,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 
 	cmd = make([]string, 0, 5)
 	cmd = append(cmd, binary)
-	settingsArgs, err := runtimeSettingsArgs(cfg.Session.ID, cfg.Permissions, cfg.Config.Model)
+	settingsArgs, err := runtimeSettingsArgs(cfg.DataDir, cfg.Session.ID, cfg.Permissions, cfg.Config.Model)
 	if err != nil {
 		return nil, false, err
 	}
@@ -203,7 +204,7 @@ func droidAutonomyLevel(mode ports.PermissionMode) string {
 // full replacement of the user's own settings file. Writing {"model": ...}
 // alone (default permissions, no autonomy override) does not clobber
 // ~/.factory/settings.json — this is load-bearing for the model-only case.
-func runtimeSettingsArgs(sessionID string, mode ports.PermissionMode, model string) ([]string, error) {
+func runtimeSettingsArgs(dataDir, sessionID string, mode ports.PermissionMode, model string) ([]string, error) {
 	level := droidAutonomyLevel(mode)
 	model = strings.TrimSpace(model)
 	if level == "" && model == "" {
@@ -223,22 +224,27 @@ func runtimeSettingsArgs(sessionID string, mode ports.PermissionMode, model stri
 		return nil, fmt.Errorf("droid: encode runtime settings: %w", err)
 	}
 
-	path := runtimeSettingsPath(sessionID)
+	path := runtimeSettingsPath(dataDir, sessionID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("droid: create runtime settings dir: %w", err)
+	}
 	if err := hookutil.AtomicWriteFile(path, append(blob, '\n'), 0o600); err != nil {
 		return nil, fmt.Errorf("droid: write runtime settings: %w", err)
 	}
 	return []string{"--settings", path}, nil
 }
 
-// runtimeSettingsPath is the deterministic temp-dir path for a session's
-// process-scoped runtime settings file. A stable name keyed by session id means
-// relaunches overwrite rather than accumulate files.
-func runtimeSettingsPath(sessionID string) string {
+// runtimeSettingsPath is the deterministic path for a session's process-scoped
+// runtime settings file, rooted under the AO data directory rather than the OS
+// temp dir (AGENTS.md / docs/architecture.md require app state under
+// ~/.ao / AO_DATA_DIR). A stable name keyed by session id means relaunches
+// overwrite rather than accumulate files.
+func runtimeSettingsPath(dataDir, sessionID string) string {
 	name := sanitizeSessionID(sessionID)
 	if name == "" {
 		name = "default"
 	}
-	return filepath.Join(os.TempDir(), "ao-droid-"+name+"-settings.json")
+	return filepath.Join(dataDir, "agent-runtime", "droid", "ao-droid-"+name+"-settings.json")
 }
 
 // sanitizeSessionID keeps only filename-safe characters so the session id can

--- a/backend/internal/adapters/agent/droid/droid.go
+++ b/backend/internal/adapters/agent/droid/droid.go
@@ -65,6 +65,9 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Droid understands.
+// Model is honored via the runtime --settings file (see permissionSettingsArgs)
+// rather than an argv flag, since interactive droid has no --model flag.
 func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.ConfigSpec{}, err

--- a/backend/internal/adapters/agent/droid/droid_test.go
+++ b/backend/internal/adapters/agent/droid/droid_test.go
@@ -104,6 +104,124 @@ func TestGetLaunchCommandBypassWritesSettings(t *testing.T) {
 	}
 }
 
+func TestGetLaunchCommandModelOnlyDefaultPermissions(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "droid"}
+	settingsPath := runtimeSettingsPath("mer-model-1")
+	t.Cleanup(func() { _ = os.Remove(settingsPath) })
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SessionID: "mer-model-1",
+		Prompt:    "use opus",
+		Config:    ports.AgentConfig{Model: "claude-opus-4-5"},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"droid", "--settings", settingsPath, "use opus"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings file: %v", err)
+	}
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse settings file: %v", err)
+	}
+	var model string
+	if err := json.Unmarshal(parsed["model"], &model); err != nil {
+		t.Fatalf("model field: %v", err)
+	}
+	if model != "claude-opus-4-5" {
+		t.Fatalf("model = %q, want claude-opus-4-5", model)
+	}
+	if _, ok := parsed["sessionDefaultSettings"]; ok {
+		t.Fatalf("default permissions should not write sessionDefaultSettings, got %s", data)
+	}
+}
+
+func TestGetLaunchCommandModelAndNonDefaultPermission(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "droid"}
+	settingsPath := runtimeSettingsPath("mer-model-2")
+	t.Cleanup(func() { _ = os.Remove(settingsPath) })
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SessionID:   "mer-model-2",
+		Prompt:      "refactor with opus",
+		Permissions: ports.PermissionModeBypassPermissions,
+		Config:      ports.AgentConfig{Model: "claude-opus-4-5"},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"droid", "--settings", settingsPath, "refactor with opus"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings file: %v", err)
+	}
+	var parsed struct {
+		Model                  string `json:"model"`
+		SessionDefaultSettings struct {
+			AutonomyLevel string `json:"autonomyLevel"`
+		} `json:"sessionDefaultSettings"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse settings file: %v", err)
+	}
+	if parsed.Model != "claude-opus-4-5" {
+		t.Fatalf("model = %q, want claude-opus-4-5", parsed.Model)
+	}
+	if parsed.SessionDefaultSettings.AutonomyLevel != "high" {
+		t.Fatalf("autonomyLevel = %q, want high", parsed.SessionDefaultSettings.AutonomyLevel)
+	}
+}
+
+func TestGetRestoreCommandForwardsModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "droid"}
+	settingsPath := runtimeSettingsPath("mer-model-3")
+	t.Cleanup(func() { _ = os.Remove(settingsPath) })
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "claude-opus-4-5"},
+		Session: ports.SessionRef{
+			ID: "mer-model-3",
+			Metadata: map[string]string{
+				ports.MetadataKeyAgentSessionID: "droid-ses-model",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+	want := []string{"droid", "--settings", settingsPath, "-r", "droid-ses-model"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings file: %v", err)
+	}
+	var parsed struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse settings file: %v", err)
+	}
+	if parsed.Model != "claude-opus-4-5" {
+		t.Fatalf("model = %q, want claude-opus-4-5", parsed.Model)
+	}
+}
+
 func TestGetLaunchCommandAutonomyLevels(t *testing.T) {
 	for _, tc := range []struct {
 		mode  ports.PermissionMode

--- a/backend/internal/adapters/agent/droid/droid_test.go
+++ b/backend/internal/adapters/agent/droid/droid_test.go
@@ -31,13 +31,13 @@ func TestManifest(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecEmpty(t *testing.T) {
+func TestGetConfigSpecHasModelField(t *testing.T) {
 	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	if len(spec.Fields) != 1 || spec.Fields[0].Key != "model" {
+		t.Fatalf("Fields = %#v, want single %q field", spec.Fields, "model")
 	}
 }
 

--- a/backend/internal/adapters/agent/droid/droid_test.go
+++ b/backend/internal/adapters/agent/droid/droid_test.go
@@ -71,13 +71,14 @@ func TestGetLaunchCommandDefaultPerms(t *testing.T) {
 
 func TestGetLaunchCommandBypassWritesSettings(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "droid"}
-	settingsPath := runtimeSettingsPath("mer-2")
-	t.Cleanup(func() { _ = os.Remove(settingsPath) })
+	dataDir := t.TempDir()
+	settingsPath := runtimeSettingsPath(dataDir, "mer-2")
 
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		SessionID:   "mer-2",
 		Prompt:      "refactor auth",
 		Permissions: ports.PermissionModeBypassPermissions,
+		DataDir:     dataDir,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -106,13 +107,14 @@ func TestGetLaunchCommandBypassWritesSettings(t *testing.T) {
 
 func TestGetLaunchCommandModelOnlyDefaultPermissions(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "droid"}
-	settingsPath := runtimeSettingsPath("mer-model-1")
-	t.Cleanup(func() { _ = os.Remove(settingsPath) })
+	dataDir := t.TempDir()
+	settingsPath := runtimeSettingsPath(dataDir, "mer-model-1")
 
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		SessionID: "mer-model-1",
 		Prompt:    "use opus",
 		Config:    ports.AgentConfig{Model: "claude-opus-4-5"},
+		DataDir:   dataDir,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -144,14 +146,15 @@ func TestGetLaunchCommandModelOnlyDefaultPermissions(t *testing.T) {
 
 func TestGetLaunchCommandModelAndNonDefaultPermission(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "droid"}
-	settingsPath := runtimeSettingsPath("mer-model-2")
-	t.Cleanup(func() { _ = os.Remove(settingsPath) })
+	dataDir := t.TempDir()
+	settingsPath := runtimeSettingsPath(dataDir, "mer-model-2")
 
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		SessionID:   "mer-model-2",
 		Prompt:      "refactor with opus",
 		Permissions: ports.PermissionModeBypassPermissions,
 		Config:      ports.AgentConfig{Model: "claude-opus-4-5"},
+		DataDir:     dataDir,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -184,11 +187,12 @@ func TestGetLaunchCommandModelAndNonDefaultPermission(t *testing.T) {
 
 func TestGetRestoreCommandForwardsModel(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "droid"}
-	settingsPath := runtimeSettingsPath("mer-model-3")
-	t.Cleanup(func() { _ = os.Remove(settingsPath) })
+	dataDir := t.TempDir()
+	settingsPath := runtimeSettingsPath(dataDir, "mer-model-3")
 
 	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
-		Config: ports.AgentConfig{Model: "claude-opus-4-5"},
+		Config:  ports.AgentConfig{Model: "claude-opus-4-5"},
+		DataDir: dataDir,
 		Session: ports.SessionRef{
 			ID: "mer-model-3",
 			Metadata: map[string]string{


### PR DESCRIPTION
## What
Droid adapter now forwards `agentConfig.model` into Droid's runtime `--settings`
file instead of silently dropping it.

## Why
Fixes #2898. AO resolves a per-role model into `cfg.Config.Model` and forwards
it to every adapter, but each adapter has to opt in to actually using it.
Claude Code, Codex (#2869), and Kiro already do; Droid didn't — a configured
worker/orchestrator model silently fell back to the CLI's global default.

## How
Interactive `droid` has no `--model` flag (it only exists on `droid exec`), so
model can't be forwarded as an argv flag the way Codex does it. Instead this
folds a top-level `"model"` key into the same runtime settings JSON blob
already used for permission autonomy (`sessionDefaultSettings.autonomyLevel`),
and writes/passes `--settings <path>` whenever *either* value is set (previously
only written for non-default permission modes).

- `permissionSettingsArgs` takes a `model` param, trims it, and sets `model` in
  the settings blob when non-empty.
- `GetLaunchCommand` / `GetRestoreCommand` pass `cfg.Config.Model` through.
- Added `GetConfigSpec` (Droid had none before, so `model` wasn't surfaced as a
  configurable field at all) — mirrors the Codex adapter's spec shape.
- Updated package/function doc comments — the old comments explicitly said
  "only the autonomy level is overridden," which is no longer accurate.

**Intentional omission / open question carried over from the issue:** whether
Droid's `--settings` top-level `model` key actually re-pins the session model
live isn't confirmed by Factory's docs — the issue flags this explicitly as
unverified upstream behavior (see linked Factory issues in #2898). I don't have
a live `droid` binary to confirm against, so this needs a manual smoke test
before merge. If it turns out `--settings`'s `model` key is ignored by Droid in
practice, this PR's mechanism is wrong and option 2 (documented no-op) from the
issue should be taken instead.

## Testing
- `go test ./internal/adapters/agent/droid/...` — all existing tests pass, plus
  new regression tests: model-only settings write, model+autonomy combined in
  one file, and restore forwarding model.
- `go test ./...` — full backend suite green.
- `go vet ./internal/adapters/agent/droid/...` — clean.
- Grepped `docs/`, `backend/`, `frontend/` for the old "Droid resolves its own
  model" language — none found outside the file itself.
- **Not yet done:** manual verification against a live `droid` binary that the
  settings-file `model` key actually changes the session's model.

## Checklist
- [x] Branched from `main`
- [x] One focused change; closes #2898
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] `go test ./...` and `go vet` pass for the area touched