### PR TITLE
add customizable keybindings

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -127,6 +127,10 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 					set: async () => undefined,
 				},
+				keybindings: {
+					get: async () => ({}),
+					set: async (overrides) => overrides,
+				},
 				updates: {
 					getStatus: async () => ({ state: "idle" }),
 					check: async () => undefined,
@@ -475,6 +479,10 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				updateSettings: {
 					get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 					set: async () => undefined,
+				},
+				keybindings: {
+					get: async () => ({}),
+					set: async (overrides) => overrides,
 				},
 				updates: {
 					getStatus: async () => ({ state: "idle" }),

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -130,6 +130,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 				keybindings: {
 					get: async () => ({}),
 					set: async (overrides) => overrides,
+					setRecording: async () => undefined,
 				},
 				updates: {
 					getStatus: async () => ({ state: "idle" }),
@@ -483,6 +484,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				keybindings: {
 					get: async () => ({}),
 					set: async (overrides) => overrides,
+					setRecording: async () => undefined,
 				},
 				updates: {
 					getStatus: async () => ({ state: "idle" }),

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -28,6 +28,7 @@ import {
 } from "./main/auto-updater";
 import { listFeatureBuilds, getActiveFeatureBuild } from "./main/feature-builds";
 import { readUpdateSettings, type UpdateSettings, type UpdateStatus } from "./main/update-settings";
+import { readKeybindingOverrides, writeKeybindingOverrides } from "./main/keybinding-settings";
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, existsSync, openSync } from "node:fs";
@@ -40,7 +41,10 @@ import { type DaemonLaunchSpec, resolveDaemonLaunch } from "./shared/daemon-laun
 import { createListenPortScanner, defaultRunFilePath, parseRunFile } from "./shared/daemon-discovery";
 import type { DaemonStatus } from "./shared/daemon-status";
 import { attachAppShortcuts } from "./main/app-shortcuts";
-import { KEYBOARD_SHORTCUTS_HELP_CHANNEL } from "./shared/shortcuts";
+import {
+	KEYBOARD_SHORTCUTS_HELP_CHANNEL,
+	type KeybindingOverrides,
+} from "./shared/shortcuts";
 import {
 	type DaemonProbe,
 	expectedDaemonPort,
@@ -102,6 +106,7 @@ let daemonStartEpoch = 0;
 let daemonStatus: DaemonStatus = { state: "stopped" };
 let daemonOutput = "";
 let browserViewHost: BrowserViewHost | null = null;
+let keybindingOverrides: KeybindingOverrides = {};
 // Held for the app lifetime. Dropping it (on any exit) triggers daemon self-stop.
 let supervisorLink: SupervisorLinkHandle | null = null;
 
@@ -325,7 +330,7 @@ function createWindow(): void {
 	// contents holds focus — the shell renderer, xterm's helper textarea, or a
 	// browser-preview view (wired per-view in the browser host).
 	const isMac = process.platform === "darwin";
-	attachAppShortcuts(mainWindow.webContents, isMac, mainWindow.webContents);
+	attachAppShortcuts(mainWindow.webContents, isMac, mainWindow.webContents, false, () => keybindingOverrides);
 
 	browserViewHost = createBrowserViewHost({
 		mainWindow,
@@ -335,6 +340,7 @@ function createWindow(): void {
 		annotatePreloadPath: annotatePreloadPath(),
 		rendererOrigin: RENDERER_ORIGIN,
 		isMac,
+		getKeybindingOverrides: () => keybindingOverrides,
 	});
 
 	void mainWindow.loadURL(rendererUrl());
@@ -1374,6 +1380,14 @@ ipcMain.handle("updateSettings:set", async (_event, settings: UpdateSettings) =>
 	await setUpdateSettings(path.dirname(runFile), settings);
 });
 
+ipcMain.handle("keybindings:get", (): KeybindingOverrides => keybindingOverrides);
+ipcMain.handle("keybindings:set", async (_event, overrides: KeybindingOverrides): Promise<KeybindingOverrides> => {
+	const runFile = runFilePath();
+	if (!runFile) return keybindingOverrides;
+	keybindingOverrides = await writeKeybindingOverrides(path.dirname(runFile), overrides);
+	return keybindingOverrides;
+});
+
 ipcMain.handle("featureBuilds:list", () => listFeatureBuilds());
 ipcMain.handle("featureBuilds:getActive", () => getActiveFeatureBuild());
 
@@ -1501,6 +1515,11 @@ app.whenReady().then(async () => {
 		await writeAppStateOnLaunch();
 	} catch (err) {
 		console.error("failed to write app-state marker:", err);
+	}
+
+	const keybindingRunFile = runFilePath();
+	if (keybindingRunFile) {
+		keybindingOverrides = await readKeybindingOverrides(path.dirname(keybindingRunFile));
 	}
 
 	registerRendererProtocol();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -107,6 +107,7 @@ let daemonStatus: DaemonStatus = { state: "stopped" };
 let daemonOutput = "";
 let browserViewHost: BrowserViewHost | null = null;
 let keybindingOverrides: KeybindingOverrides = {};
+let keybindingRecordingActive = false;
 // Held for the app lifetime. Dropping it (on any exit) triggers daemon self-stop.
 let supervisorLink: SupervisorLinkHandle | null = null;
 
@@ -330,7 +331,14 @@ function createWindow(): void {
 	// contents holds focus — the shell renderer, xterm's helper textarea, or a
 	// browser-preview view (wired per-view in the browser host).
 	const isMac = process.platform === "darwin";
-	attachAppShortcuts(mainWindow.webContents, isMac, mainWindow.webContents, false, () => keybindingOverrides);
+	attachAppShortcuts(
+		mainWindow.webContents,
+		isMac,
+		mainWindow.webContents,
+		false,
+		() => keybindingOverrides,
+		() => keybindingRecordingActive,
+	);
 
 	browserViewHost = createBrowserViewHost({
 		mainWindow,
@@ -341,6 +349,7 @@ function createWindow(): void {
 		rendererOrigin: RENDERER_ORIGIN,
 		isMac,
 		getKeybindingOverrides: () => keybindingOverrides,
+		isKeybindingRecording: () => keybindingRecordingActive,
 	});
 
 	void mainWindow.loadURL(rendererUrl());
@@ -360,8 +369,15 @@ function createWindow(): void {
 	};
 	mainWindow.on("enter-full-screen", pushFullScreen);
 	mainWindow.on("leave-full-screen", pushFullScreen);
+	mainWindow.on("blur", () => {
+		keybindingRecordingActive = false;
+	});
+	mainWindow.webContents.on("render-process-gone", () => {
+		keybindingRecordingActive = false;
+	});
 
 	mainWindow.on("closed", () => {
+		keybindingRecordingActive = false;
 		browserViewHost?.dispose();
 		browserViewHost = null;
 		mainWindow = null;
@@ -1386,6 +1402,10 @@ ipcMain.handle("keybindings:set", async (_event, overrides: KeybindingOverrides)
 	if (!runFile) return keybindingOverrides;
 	keybindingOverrides = await writeKeybindingOverrides(path.dirname(runFile), overrides);
 	return keybindingOverrides;
+});
+ipcMain.handle("keybindings:setRecording", (event, active: unknown): void => {
+	if (event.sender !== mainWindow?.webContents || typeof active !== "boolean") return;
+	keybindingRecordingActive = active;
 });
 
 ipcMain.handle("featureBuilds:list", () => listFeatureBuilds());

--- a/frontend/src/main/app-shortcuts.ts
+++ b/frontend/src/main/app-shortcuts.ts
@@ -1,18 +1,14 @@
 import {
 	FOCUS_TERMINAL_SHORTCUT_CHANNEL,
 	KEYBOARD_SHORTCUTS_HELP_CHANNEL,
-	matchesFocusTerminalShortcut,
-	matchesKeyboardShortcutsHelpShortcut,
-	matchesNextSessionShortcut,
-	matchesNewSessionShortcut,
-	matchesNewShellTerminalShortcut,
-	matchesOpenSettingsShortcut,
-	matchesPreviousSessionShortcut,
+	matchesAppShortcut,
 	NEXT_SESSION_SHORTCUT_CHANNEL,
 	NEW_SESSION_SHORTCUT_CHANNEL,
 	NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL,
 	OPEN_SETTINGS_SHORTCUT_CHANNEL,
 	PREVIOUS_SESSION_SHORTCUT_CHANNEL,
+	type AppShortcutId,
+	type KeybindingOverrides,
 	type ShortcutChord,
 } from "../shared/shortcuts";
 
@@ -44,14 +40,24 @@ type ShortcutTargetContents = {
 	send: (channel: string) => void;
 };
 
-const appShortcutChannel = (chord: ShortcutChord, isMac: boolean): string | null => {
-	if (matchesNewSessionShortcut(chord, isMac)) return NEW_SESSION_SHORTCUT_CHANNEL;
-	if (matchesNewShellTerminalShortcut(chord, isMac)) return NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL;
-	if (matchesKeyboardShortcutsHelpShortcut(chord, isMac)) return KEYBOARD_SHORTCUTS_HELP_CHANNEL;
-	if (matchesOpenSettingsShortcut(chord, isMac)) return OPEN_SETTINGS_SHORTCUT_CHANNEL;
-	if (matchesPreviousSessionShortcut(chord, isMac)) return PREVIOUS_SESSION_SHORTCUT_CHANNEL;
-	if (matchesNextSessionShortcut(chord, isMac)) return NEXT_SESSION_SHORTCUT_CHANNEL;
-	if (matchesFocusTerminalShortcut(chord, isMac)) return FOCUS_TERMINAL_SHORTCUT_CHANNEL;
+const mainShortcutChannels: readonly [AppShortcutId, string][] = [
+	["new-session", NEW_SESSION_SHORTCUT_CHANNEL],
+	["new-shell-terminal", NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL],
+	["keyboard-shortcuts", KEYBOARD_SHORTCUTS_HELP_CHANNEL],
+	["open-settings", OPEN_SETTINGS_SHORTCUT_CHANNEL],
+	["previous-session", PREVIOUS_SESSION_SHORTCUT_CHANNEL],
+	["next-session", NEXT_SESSION_SHORTCUT_CHANNEL],
+	["focus-terminal", FOCUS_TERMINAL_SHORTCUT_CHANNEL],
+];
+
+const appShortcutChannel = (
+	chord: ShortcutChord,
+	isMac: boolean,
+	overrides: KeybindingOverrides,
+): string | null => {
+	for (const [id, channel] of mainShortcutChannels) {
+		if (matchesAppShortcut(id, chord, isMac, overrides)) return channel;
+	}
 	return null;
 };
 
@@ -63,6 +69,7 @@ export function attachAppShortcuts(
 	isMac: boolean,
 	target: ShortcutTargetContents,
 	focusTarget = false,
+	getOverrides: () => KeybindingOverrides = () => ({}),
 ): void {
 	contents.on("before-input-event", (event, input) => {
 		if (input.type !== "keyDown" || input.isAutoRepeat) return;
@@ -76,6 +83,7 @@ export function attachAppShortcuts(
 				alt: input.alt,
 			},
 			isMac,
+			getOverrides(),
 		);
 		if (!channel) return;
 

--- a/frontend/src/main/app-shortcuts.ts
+++ b/frontend/src/main/app-shortcuts.ts
@@ -70,9 +70,13 @@ export function attachAppShortcuts(
 	target: ShortcutTargetContents,
 	focusTarget = false,
 	getOverrides: () => KeybindingOverrides = () => ({}),
+	isRecording: () => boolean = () => false,
 ): void {
 	contents.on("before-input-event", (event, input) => {
 		if (input.type !== "keyDown" || input.isAutoRepeat) return;
+		// Let the renderer's capture listener receive application-owned chords
+		// while the user is recording a replacement binding.
+		if (isRecording()) return;
 		const channel = appShortcutChannel(
 			{
 				key: input.key,

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -100,6 +100,7 @@ export type BrowserViewHostOptions = {
 	// to the shell. Defaults to non-mac when omitted (tests).
 	isMac?: boolean;
 	getKeybindingOverrides?: () => KeybindingOverrides;
+	isKeybindingRecording?: () => boolean;
 };
 
 export type BrowserViewHost = {
@@ -251,6 +252,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			options.mainWindow.webContents,
 			true,
 			options.getKeybindingOverrides,
+			options.isKeybindingRecording,
 		);
 		view.webContents.on("focus", () => {
 			lastFocusedViewId = viewId;

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -16,6 +16,7 @@ import type {
 	BrowserAnnotationSubmitPayload,
 } from "../shared/browser-annotations";
 import { attachAppShortcuts } from "./app-shortcuts";
+import type { KeybindingOverrides } from "../shared/shortcuts";
 
 export type BrowserRect = Pick<Rectangle, "x" | "y" | "width" | "height">;
 
@@ -98,6 +99,7 @@ export type BrowserViewHostOptions = {
 	// Platform flag for application shortcuts forwarded from each preview view
 	// to the shell. Defaults to non-mac when omitted (tests).
 	isMac?: boolean;
+	getKeybindingOverrides?: () => KeybindingOverrides;
 };
 
 export type BrowserViewHost = {
@@ -243,7 +245,13 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		// The preview is a separate WebContentsView, so renderer-window keydown
 		// listeners never see keys typed here. Forward application shortcuts to the
 		// shell renderer so they still work with the panel focused.
-		attachAppShortcuts(view.webContents, Boolean(options.isMac), options.mainWindow.webContents, true);
+		attachAppShortcuts(
+			view.webContents,
+			Boolean(options.isMac),
+			options.mainWindow.webContents,
+			true,
+			options.getKeybindingOverrides,
+		);
 		view.webContents.on("focus", () => {
 			lastFocusedViewId = viewId;
 		});

--- a/frontend/src/main/keybinding-settings.test.ts
+++ b/frontend/src/main/keybinding-settings.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { coerceKeybindingOverrides } from "./keybinding-settings";
+
+describe("coerceKeybindingOverrides", () => {
+	it("keeps valid application bindings and ignores unknown commands", () => {
+		expect(
+			coerceKeybindingOverrides({
+				"focus-terminal": [{ key: "j", ctrl: true }],
+				"unknown-command": [{ key: "q", ctrl: true }],
+			}),
+		).toEqual({
+			"focus-terminal": [
+				{ key: "j", ctrl: true, meta: false, shift: false, alt: false },
+			],
+		});
+	});
+
+	it("rejects plain typing keys but preserves an explicitly unassigned command", () => {
+		expect(
+			coerceKeybindingOverrides({
+				"open-settings": [{ key: "s" }],
+				"command-palette": [],
+			}),
+		).toEqual({
+			"open-settings": [],
+			"command-palette": [],
+		});
+	});
+
+	it("allows safe standalone function keys", () => {
+		expect(
+			coerceKeybindingOverrides({
+				"focus-terminal": [{ key: "F6" }],
+			}),
+		).toEqual({
+			"focus-terminal": [
+				{ key: "F6", ctrl: false, meta: false, shift: false, alt: false },
+			],
+		});
+	});
+
+	it("does not accept overrides for the fixed indexed project shortcut", () => {
+		expect(
+			coerceKeybindingOverrides({
+				"open-project": [{ key: "p", ctrl: true }],
+			}),
+		).toEqual({});
+	});
+});

--- a/frontend/src/main/keybinding-settings.test.ts
+++ b/frontend/src/main/keybinding-settings.test.ts
@@ -15,28 +15,24 @@ describe("coerceKeybindingOverrides", () => {
 		});
 	});
 
-	it("rejects plain typing keys but preserves an explicitly unassigned command", () => {
+	it("falls back to defaults for corrupt non-empty arrays but preserves an intentional unassignment", () => {
 		expect(
 			coerceKeybindingOverrides({
 				"open-settings": [{ key: "s" }],
 				"command-palette": [],
 			}),
 		).toEqual({
-			"open-settings": [],
 			"command-palette": [],
 		});
 	});
 
-	it("allows safe standalone function keys", () => {
+	it("rejects standalone function keys and terminal-critical chords", () => {
 		expect(
 			coerceKeybindingOverrides({
 				"focus-terminal": [{ key: "F6" }],
+				"open-settings": [{ key: "c", ctrl: true }],
 			}),
-		).toEqual({
-			"focus-terminal": [
-				{ key: "F6", ctrl: false, meta: false, shift: false, alt: false },
-			],
-		});
+		).toEqual({});
 	});
 
 	it("does not accept overrides for the fixed indexed project shortcut", () => {
@@ -45,5 +41,12 @@ describe("coerceKeybindingOverrides", () => {
 				"open-project": [{ key: "p", ctrl: true }],
 			}),
 		).toEqual({});
+	});
+
+	it("applies platform-aware reserved shortcut validation", () => {
+		expect(coerceKeybindingOverrides({ "focus-terminal": [{ key: "q", meta: true }] }, true)).toEqual({});
+		expect(coerceKeybindingOverrides({ "focus-terminal": [{ key: "q", meta: true }] }, false)).toEqual({
+			"focus-terminal": [{ key: "q", ctrl: false, meta: true, shift: false, alt: false }],
+		});
 	});
 });

--- a/frontend/src/main/keybinding-settings.ts
+++ b/frontend/src/main/keybinding-settings.ts
@@ -1,0 +1,89 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+	APP_SHORTCUTS,
+	type AppShortcutId,
+	type KeybindingOverrides,
+	type ShortcutBinding,
+} from "../shared/shortcuts";
+
+export const KEYBINDING_SETTINGS_FILE_NAME = "keybindings.json";
+
+const customizableIds = new Set<AppShortcutId>(
+	APP_SHORTCUTS.filter((shortcut) => shortcut.customizable !== false).map((shortcut) => shortcut.id),
+);
+
+let settingsOperationQueue: Promise<void> = Promise.resolve();
+
+function coerceBinding(raw: unknown): ShortcutBinding | null {
+	if (!raw || typeof raw !== "object") return null;
+	const value = raw as Record<string, unknown>;
+	if (typeof value.key !== "string" || value.key.length === 0 || value.key.length > 32) return null;
+	const code = typeof value.code === "string" && value.code.length > 0 && value.code.length <= 32 ? value.code : undefined;
+	const candidate: ShortcutBinding = {
+		key: value.key,
+		...(code ? { code } : {}),
+		ctrl: value.ctrl === true,
+		meta: value.meta === true,
+		shift: value.shift === true,
+		alt: value.alt === true,
+	};
+	// Application-wide shortcuts must not consume ordinary typing.
+	if (!candidate.ctrl && !candidate.meta && !candidate.alt && !/^F(?:[1-9]|1\d|2[0-4])$/.test(candidate.key)) return null;
+	return candidate;
+}
+
+export function coerceKeybindingOverrides(raw: unknown): KeybindingOverrides {
+	if (!raw || typeof raw !== "object") return {};
+	const source = raw as Record<string, unknown>;
+	const overrides: KeybindingOverrides = {};
+	for (const id of customizableIds) {
+		const rawBindings = source[id];
+		if (!Array.isArray(rawBindings)) continue;
+		const bindings = rawBindings
+			.slice(0, 2)
+			.map(coerceBinding)
+			.filter((candidate): candidate is ShortcutBinding => candidate !== null);
+		overrides[id] = bindings;
+	}
+	return overrides;
+}
+
+async function readUnlocked(stateDir: string): Promise<KeybindingOverrides> {
+	try {
+		const raw = await readFile(path.join(stateDir, KEYBINDING_SETTINGS_FILE_NAME), "utf8");
+		return coerceKeybindingOverrides(JSON.parse(raw));
+	} catch {
+		return {};
+	}
+}
+
+async function writeUnlocked(stateDir: string, overrides: KeybindingOverrides): Promise<KeybindingOverrides> {
+	const next = coerceKeybindingOverrides(overrides);
+	await mkdir(stateDir, { recursive: true, mode: 0o750 });
+	const file = path.join(stateDir, KEYBINDING_SETTINGS_FILE_NAME);
+	const tmp = path.join(stateDir, `.keybindings-${process.pid}-${Date.now()}.json`);
+	await writeFile(tmp, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+	await rename(tmp, file);
+	return next;
+}
+
+function runSettingsOperation<T>(operation: () => Promise<T>): Promise<T> {
+	const queued = settingsOperationQueue.then(operation, operation);
+	settingsOperationQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	return queued;
+}
+
+export async function readKeybindingOverrides(stateDir: string): Promise<KeybindingOverrides> {
+	return readUnlocked(stateDir);
+}
+
+export async function writeKeybindingOverrides(
+	stateDir: string,
+	overrides: KeybindingOverrides,
+): Promise<KeybindingOverrides> {
+	return runSettingsOperation(() => writeUnlocked(stateDir, overrides));
+}

--- a/frontend/src/main/keybinding-settings.ts
+++ b/frontend/src/main/keybinding-settings.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
 	APP_SHORTCUTS,
+	shortcutBindingValidationError,
 	type AppShortcutId,
 	type KeybindingOverrides,
 	type ShortcutBinding,
@@ -15,7 +16,7 @@ const customizableIds = new Set<AppShortcutId>(
 
 let settingsOperationQueue: Promise<void> = Promise.resolve();
 
-function coerceBinding(raw: unknown): ShortcutBinding | null {
+function coerceBinding(raw: unknown, isMac: boolean): ShortcutBinding | null {
 	if (!raw || typeof raw !== "object") return null;
 	const value = raw as Record<string, unknown>;
 	if (typeof value.key !== "string" || value.key.length === 0 || value.key.length > 32) return null;
@@ -28,12 +29,11 @@ function coerceBinding(raw: unknown): ShortcutBinding | null {
 		shift: value.shift === true,
 		alt: value.alt === true,
 	};
-	// Application-wide shortcuts must not consume ordinary typing.
-	if (!candidate.ctrl && !candidate.meta && !candidate.alt && !/^F(?:[1-9]|1\d|2[0-4])$/.test(candidate.key)) return null;
+	if (shortcutBindingValidationError(candidate, isMac)) return null;
 	return candidate;
 }
 
-export function coerceKeybindingOverrides(raw: unknown): KeybindingOverrides {
+export function coerceKeybindingOverrides(raw: unknown, isMac = process.platform === "darwin"): KeybindingOverrides {
 	if (!raw || typeof raw !== "object") return {};
 	const source = raw as Record<string, unknown>;
 	const overrides: KeybindingOverrides = {};
@@ -42,8 +42,11 @@ export function coerceKeybindingOverrides(raw: unknown): KeybindingOverrides {
 		if (!Array.isArray(rawBindings)) continue;
 		const bindings = rawBindings
 			.slice(0, 2)
-			.map(coerceBinding)
+			.map((binding) => coerceBinding(binding, isMac))
 			.filter((candidate): candidate is ShortcutBinding => candidate !== null);
+		// Preserve an intentional empty array as "unassigned". If a non-empty
+		// persisted value contains no valid bindings, omit it so defaults recover.
+		if (rawBindings.length > 0 && bindings.length === 0) continue;
 		overrides[id] = bindings;
 	}
 	return overrides;

--- a/frontend/src/main/new-session-shortcut.test.ts
+++ b/frontend/src/main/new-session-shortcut.test.ts
@@ -143,4 +143,23 @@ describe("attachAppShortcuts", () => {
 		expect(target.send).toHaveBeenCalledWith(channel);
 		expect(event.preventDefault).toHaveBeenCalledTimes(1);
 	});
+
+	it("reads live user overrides without reattaching the listener", () => {
+		const source = fakeSource();
+		const target = fakeTarget();
+		let overrides = {};
+		attachAppShortcuts(source, false, target, false, () => overrides);
+
+		source.emit({ key: "T", control: true, shift: true });
+		overrides = {
+			"focus-terminal": [
+				{ key: "j", ctrl: true, meta: false, shift: false, alt: false },
+			],
+		};
+		source.emit({ key: "T", control: true, shift: true });
+		source.emit({ key: "j", control: true });
+
+		expect(target.send).toHaveBeenCalledTimes(2);
+		expect(target.send).toHaveBeenLastCalledWith(FOCUS_TERMINAL_SHORTCUT_CHANNEL);
+	});
 });

--- a/frontend/src/main/new-session-shortcut.test.ts
+++ b/frontend/src/main/new-session-shortcut.test.ts
@@ -162,4 +162,20 @@ describe("attachAppShortcuts", () => {
 		expect(target.send).toHaveBeenCalledTimes(2);
 		expect(target.send).toHaveBeenLastCalledWith(FOCUS_TERMINAL_SHORTCUT_CHANNEL);
 	});
+
+	it("does not intercept application shortcuts while a binding is being recorded", () => {
+		const source = fakeSource();
+		const target = fakeTarget();
+		let recording = true;
+		attachAppShortcuts(source, false, target, false, () => ({}), () => recording);
+
+		const recordingEvent = source.emit({ key: "/", control: true });
+		recording = false;
+		const activeEvent = source.emit({ key: "/", control: true });
+
+		expect(recordingEvent.preventDefault).not.toHaveBeenCalled();
+		expect(activeEvent.preventDefault).toHaveBeenCalledTimes(1);
+		expect(target.send).toHaveBeenCalledTimes(1);
+		expect(target.send).toHaveBeenCalledWith(KEYBOARD_SHORTCUTS_HELP_CHANNEL);
+	});
 });

--- a/frontend/src/preload.test.ts
+++ b/frontend/src/preload.test.ts
@@ -92,3 +92,13 @@ describe("preload application shortcut bridges", () => {
 		expect(electronMocks.off).toHaveBeenCalledWith(channel, wrapped);
 	});
 });
+
+describe("preload keybinding recording bridge", () => {
+	it("tells the main process when shortcut capture starts and stops", async () => {
+		await exposedBridge().keybindings.setRecording(true);
+		await exposedBridge().keybindings.setRecording(false);
+
+		expect(electronMocks.invoke).toHaveBeenNthCalledWith(1, "keybindings:setRecording", true);
+		expect(electronMocks.invoke).toHaveBeenNthCalledWith(2, "keybindings:setRecording", false);
+	});
+});

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
-import { FOCUS_TERMINAL_SHORTCUT_CHANNEL, KEYBOARD_SHORTCUTS_HELP_CHANNEL, NEXT_SESSION_SHORTCUT_CHANNEL, NEW_SESSION_SHORTCUT_CHANNEL, NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL, OPEN_SETTINGS_SHORTCUT_CHANNEL, PREVIOUS_SESSION_SHORTCUT_CHANNEL } from "./shared/shortcuts";
+import { FOCUS_TERMINAL_SHORTCUT_CHANNEL, KEYBOARD_SHORTCUTS_HELP_CHANNEL, NEXT_SESSION_SHORTCUT_CHANNEL, NEW_SESSION_SHORTCUT_CHANNEL, NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL, OPEN_SETTINGS_SHORTCUT_CHANNEL, PREVIOUS_SESSION_SHORTCUT_CHANNEL, type KeybindingOverrides } from "./shared/shortcuts";
 import type { BrowserNavState, BrowserRect } from "./main/browser-view-host";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { TelemetryBootstrap } from "./shared/telemetry";
@@ -205,6 +205,11 @@ const api = {
 	updateSettings: {
 		get: () => ipcRenderer.invoke("updateSettings:get") as Promise<UpdateSettings>,
 		set: (settings: UpdateSettings) => ipcRenderer.invoke("updateSettings:set", settings) as Promise<void>,
+	},
+	keybindings: {
+		get: () => ipcRenderer.invoke("keybindings:get") as Promise<KeybindingOverrides>,
+		set: (overrides: KeybindingOverrides) =>
+			ipcRenderer.invoke("keybindings:set", overrides) as Promise<KeybindingOverrides>,
 	},
 	updates: {
 		getStatus: () => ipcRenderer.invoke("updates:getStatus") as Promise<UpdateStatus>,

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -210,6 +210,7 @@ const api = {
 		get: () => ipcRenderer.invoke("keybindings:get") as Promise<KeybindingOverrides>,
 		set: (overrides: KeybindingOverrides) =>
 			ipcRenderer.invoke("keybindings:set", overrides) as Promise<KeybindingOverrides>,
+		setRecording: (active: boolean) => ipcRenderer.invoke("keybindings:setRecording", active) as Promise<void>,
 	},
 	updates: {
 		getStatus: () => ipcRenderer.invoke("updates:getStatus") as Promise<UpdateStatus>,

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -13,17 +13,15 @@ import {
 } from "../lib/command-palette";
 import { iconForCommand } from "../lib/command-palette-icons";
 import { isDialogOrMenuOpen } from "../lib/dom-selectors";
+import { isMacPlatform } from "../lib/platform";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { useShell } from "../lib/shell-context";
 import { findProjectOrchestrator, hasConfiguredOrchestratorAgent } from "../types/workspace";
 import { useUiStore } from "../stores/ui-store";
+import { matchesRendererShortcut } from "../stores/keybindings-store";
 import { CreateProjectFlow } from "./CreateProjectFlow";
 import { NewTaskDialog } from "./NewTaskDialog";
 import { CommandDialog, CommandEmpty, CommandFooter, CommandGroup, CommandInput, CommandItem, CommandList } from "./ui/command";
-
-function isMacPlatform(): boolean {
-	return typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
-}
 
 function terminalHasFocus(): boolean {
 	if (typeof document === "undefined") return false;
@@ -216,19 +214,26 @@ export function CommandPalette() {
 				return;
 			}
 
-			if (event.altKey || event.shiftKey || event.key.toLowerCase() !== "k") return;
-
-			const isMac = isMacPlatform();
-			const paletteModifier = isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
-			if (!paletteModifier) return;
+			if (!matchesRendererShortcut("command-palette", event)) return;
 
 			if (isOpen) {
 				event.preventDefault();
 				closePalette();
 				return;
 			}
-			// Returns without preventDefault so a focused terminal keeps Ctrl+K for readline's kill-to-end-of-line.
-			if (!isMac && terminalHasFocus()) return;
+			// Preserve the default Ctrl+K readline command in terminals. A user
+			// who deliberately assigns a different palette binding expects it to
+			// work there too.
+			if (
+				!isMacPlatform() &&
+				terminalHasFocus() &&
+				event.key.toLowerCase() === "k" &&
+				event.ctrlKey &&
+				!event.metaKey &&
+				!event.altKey &&
+				!event.shiftKey
+			)
+				return;
 			if (isDialogOrMenuOpen()) return;
 			event.preventDefault();
 			setOpen(true);

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -21,6 +21,9 @@ const {
 	openExternal,
 	featListBuilds,
 	featGetActive,
+	getKeybindings,
+	setKeybindings,
+	setKeybindingRecording,
 } = vi.hoisted(() => ({
 	getUpdate: vi.fn(),
 	setUpdate: vi.fn(),
@@ -37,6 +40,9 @@ const {
 	openExternal: vi.fn(),
 	featListBuilds: vi.fn(),
 	featGetActive: vi.fn(),
+	getKeybindings: vi.fn(),
+	setKeybindings: vi.fn(),
+	setKeybindingRecording: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
@@ -53,6 +59,11 @@ vi.mock("../lib/bridge", () => ({
 		clipboard: { writeText },
 		daemon: { getStatus: getDaemonStatus },
 		updateSettings: { get: getUpdate, set: setUpdate },
+		keybindings: {
+			get: getKeybindings,
+			set: setKeybindings,
+			setRecording: setKeybindingRecording,
+		},
 		updates: {
 			getStatus: updGetStatus,
 			check: updCheck,
@@ -92,6 +103,9 @@ beforeEach(() => {
 		getDaemonStatus,
 		featListBuilds,
 		featGetActive,
+		getKeybindings,
+		setKeybindings,
+		setKeybindingRecording,
 	]) {
 		m.mockReset();
 	}
@@ -109,6 +123,9 @@ beforeEach(() => {
 	openExternal.mockResolvedValue(undefined);
 	featListBuilds.mockResolvedValue([]);
 	featGetActive.mockResolvedValue(null);
+	getKeybindings.mockResolvedValue({});
+	setKeybindings.mockImplementation(async (overrides) => overrides);
+	setKeybindingRecording.mockResolvedValue(undefined);
 	// Feature Releases lives behind Developer Mode; reset to the default (off).
 	useUiStore.getState().setDeveloperMode(false);
 });

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
-import { Mail } from "lucide-react";
+import { Keyboard, Mail } from "lucide-react";
 import { ConnectMobileModal } from "./ConnectMobileModal";
 import { DeveloperModeSection } from "./settings/DeveloperModeSection";
 import { GeneralSettingsSection } from "./settings/GeneralSettingsSection";
@@ -10,17 +10,26 @@ import { SettingsPageShell } from "./settings/SettingsPageShell";
 import { SettingsPanel } from "./settings/SettingsPanel";
 import { SettingsSection } from "./settings/SettingsSection";
 import { UpdatesSection } from "./settings/UpdatesSection";
+import { KeyboardShortcutsSettingsDialog } from "./settings/KeyboardShortcutsSettingsDialog";
 
 export function GlobalSettingsForm() {
 	const navigate = useNavigate();
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [reportProblemOpen, setReportProblemOpen] = useState(false);
+	const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
 
 	return (
 		<>
 			<SettingsPageShell>
 				<SettingsPanel onClose={() => navigate({ to: "/" })}>
 					<GeneralSettingsSection onConnectMobile={() => setMobileOpen(true)} />
+					<SettingsSection title="Preferences">
+						<SettingsLinkRow
+							icon={Keyboard}
+							label="Keyboard shortcuts"
+							onClick={() => setKeyboardShortcutsOpen(true)}
+						/>
+					</SettingsSection>
 					<UpdatesSection />
 					<DeveloperModeSection />
 					<SettingsSection title="Get help">
@@ -30,6 +39,10 @@ export function GlobalSettingsForm() {
 			</SettingsPageShell>
 			<ConnectMobileModal open={mobileOpen} onOpenChange={setMobileOpen} />
 			<ReportProblemDialog open={reportProblemOpen} onOpenChange={setReportProblemOpen} />
+			<KeyboardShortcutsSettingsDialog
+				open={keyboardShortcutsOpen}
+				onOpenChange={setKeyboardShortcutsOpen}
+			/>
 		</>
 	);
 }

--- a/frontend/src/renderer/components/KeyboardShortcutsDialog.test.tsx
+++ b/frontend/src/renderer/components/KeyboardShortcutsDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { KeyboardShortcutsDialog } from "./KeyboardShortcutsDialog";
 
@@ -39,5 +39,14 @@ describe("KeyboardShortcutsDialog", () => {
 		render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} isMac={false} />);
 
 		expect(screen.queryByText("Open command palette")).not.toBeInTheDocument();
+	});
+
+	it("offers a direct path to customize shortcuts", () => {
+		const onCustomize = vi.fn();
+		render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} onCustomize={onCustomize} isMac={false} />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Customize" }));
+
+		expect(onCustomize).toHaveBeenCalledTimes(1);
 	});
 });

--- a/frontend/src/renderer/components/KeyboardShortcutsDialog.tsx
+++ b/frontend/src/renderer/components/KeyboardShortcutsDialog.tsx
@@ -1,10 +1,17 @@
-import { APP_SHORTCUTS, SHORTCUT_CATEGORIES, shortcutKeys } from "../../shared/shortcuts";
+import {
+	APP_SHORTCUTS,
+	effectiveShortcutBindings,
+	SHORTCUT_CATEGORIES,
+	shortcutBindingKeys,
+} from "../../shared/shortcuts";
 import { useCommandPaletteEnabled } from "../hooks/useCommandPaletteEnabled";
+import { useKeybindingsStore } from "../stores/keybindings-store";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog";
 
 type KeyboardShortcutsDialogProps = {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	onCustomize?: () => void;
 	isMac?: boolean;
 };
 
@@ -15,8 +22,14 @@ function isMacPlatform(): boolean {
 	return platform.toLowerCase().includes("mac");
 }
 
-export function KeyboardShortcutsDialog({ open, onOpenChange, isMac = isMacPlatform() }: KeyboardShortcutsDialogProps) {
+export function KeyboardShortcutsDialog({
+	open,
+	onOpenChange,
+	onCustomize,
+	isMac = isMacPlatform(),
+}: KeyboardShortcutsDialogProps) {
 	const isCommandPaletteEnabled = useCommandPaletteEnabled();
+	const overrides = useKeybindingsStore((state) => state.overrides);
 	const availableShortcuts = APP_SHORTCUTS.filter(
 		(shortcut) => shortcut.id !== "command-palette" || isCommandPaletteEnabled,
 	);
@@ -44,18 +57,26 @@ export function KeyboardShortcutsDialog({ open, onOpenChange, isMac = isMacPlatf
 									{shortcuts.map((shortcut) => (
 										<div className="flex min-h-11 items-center justify-between gap-5 py-1.5" key={shortcut.id}>
 											<p className="min-w-0 text-control font-medium text-foreground">{shortcut.label}</p>
-											<div
-												className="flex shrink-0 items-center gap-1"
-												aria-label={shortcutKeys(shortcut, isMac).join("+")}
-											>
-												{shortcutKeys(shortcut, isMac).map((key) => (
-													<kbd
-														className="inline-flex min-w-7 items-center justify-center rounded-sm border border-border-strong bg-surface px-1.5 py-1 font-mono text-caption font-medium text-muted-foreground shadow-sm"
-														key={key}
-													>
-														{key}
-													</kbd>
-												))}
+											<div className="flex shrink-0 flex-col items-end gap-1">
+												{effectiveShortcutBindings(shortcut.id, isMac, overrides).map((binding, bindingIndex) => {
+													const keys = shortcutBindingKeys(binding, isMac);
+													return (
+														<div
+															className="flex items-center gap-1"
+															aria-label={keys.join("+")}
+															key={`${binding.key}-${bindingIndex}`}
+														>
+															{keys.map((key) => (
+																<kbd
+																	className="inline-flex min-w-7 items-center justify-center rounded-sm border border-border-strong bg-surface px-1.5 py-1 font-mono text-caption font-medium text-muted-foreground shadow-sm"
+																	key={key}
+																>
+																	{key}
+																</kbd>
+															))}
+														</div>
+													);
+												})}
 											</div>
 										</div>
 									))}
@@ -64,6 +85,17 @@ export function KeyboardShortcutsDialog({ open, onOpenChange, isMac = isMacPlatf
 						);
 					})}
 				</div>
+				{onCustomize ? (
+					<div className="flex justify-end border-t border-border px-5 py-3">
+						<button
+							type="button"
+							className="rounded-md bg-accent px-3 py-2 text-control font-medium text-accent-foreground transition-opacity hover:opacity-90"
+							onClick={onCustomize}
+						>
+							Customize
+						</button>
+					</div>
+				) : null}
 			</DialogContent>
 		</Dialog>
 	);

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -387,7 +387,7 @@ describe("SessionView", () => {
 		expect(handle.expand).not.toHaveBeenCalled();
 		expect(handle.collapse).not.toHaveBeenCalled();
 
-		fireEvent.keyDown(window, { key: "B", metaKey: true, shiftKey: true });
+		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 
 		expect(inspectorOpen("sess-1")).toBe(false);
 		expect(handle.collapse).toHaveBeenCalledTimes(1);
@@ -406,7 +406,7 @@ describe("SessionView", () => {
 		expect(handle.expand).not.toHaveBeenCalled();
 		expect(handle.collapse).not.toHaveBeenCalled();
 
-		fireEvent.keyDown(window, { key: "B", metaKey: true, shiftKey: true });
+		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 
 		expect(inspectorOpen("sess-1")).toBe(true);
 		expect(handle.expand).toHaveBeenCalledTimes(1);
@@ -418,7 +418,7 @@ describe("SessionView", () => {
 		render(<SessionView sessionId="sess-1" />);
 		const handle = panels.get("inspector")!.handle;
 
-		fireEvent.keyDown(window, { key: "B", metaKey: true, shiftKey: true });
+		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 		expect(inspectorOpen("sess-1")).toBe(false);
 		expect(handle.collapse).toHaveBeenCalledTimes(1);
 
@@ -523,7 +523,7 @@ describe("SessionView", () => {
 		expect(panelSizes("inspector")[0]).toBe("0%");
 		expect(handle.collapse).not.toHaveBeenCalled();
 
-		fireEvent.keyDown(window, { key: "B", metaKey: true, shiftKey: true });
+		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 
 		expect(inspectorOpen("sess-2")).toBe(true);
 		expect(handle.expand).toHaveBeenCalledTimes(1);

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -15,6 +15,7 @@ import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { hidesShellTopbar } from "../lib/platform";
 import { isOrchestratorSession, sessionIsActive } from "../types/workspace";
 import type { TerminalTarget } from "../types/terminal";
+import { matchesRendererShortcut } from "../stores/keybindings-store";
 
 const INSPECTOR_MIN_PERCENT = 22;
 const INSPECTOR_MAX_PERCENT = 45;
@@ -260,8 +261,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	useEffect(() => {
 		if (!hasInspector) return;
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if (event.key.toLowerCase() !== "b" || !event.shiftKey) return;
-			if (!event.metaKey && !event.ctrlKey) return;
+			if (!matchesRendererShortcut("toggle-inspector", event)) return;
 			event.preventDefault();
 			toggleInspector(sessionId);
 		};

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
 import { ChevronRight, LayoutDashboard, MoreVertical, Pencil, Plus, RefreshCw, Search, Settings, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { UpdateStatus } from "../../main/update-settings";
-import { APP_SHORTCUTS, shortcutKeys } from "../../shared/shortcuts";
+import { effectiveShortcutBindings, shortcutBindingLabel } from "../../shared/shortcuts";
 import {
 	hasConfiguredOrchestratorAgent,
 	newestActiveOrchestrator,
@@ -48,6 +48,7 @@ import { OrchestratorIcon } from "./icons";
 import aoLogo from "../../../assets/ao-logo.svg";
 import { cn } from "../lib/utils";
 import { useUiStore } from "../stores/ui-store";
+import { useKeybindingsStore } from "../stores/keybindings-store";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { CreateProjectFlow, type CreateProjectInput } from "./CreateProjectFlow";
 import { ResizeHandle } from "./ResizeHandle";
@@ -784,12 +785,9 @@ function RestartToUpdateRailButton({ status }: { status: UpdateStatus }) {
 }
 
 function SidebarSearchButton({ onOpen }: { onOpen: () => void }) {
-	const paletteShortcut = APP_SHORTCUTS.find((shortcut) => shortcut.id === "command-palette");
-	const shortcutLabel = paletteShortcut
-		? shortcutKeys(paletteShortcut, isMac).join(isMac ? "" : "+")
-		: isMac
-			? "⌘K"
-			: "Ctrl+K";
+	const overrides = useKeybindingsStore((state) => state.overrides);
+	const paletteBinding = effectiveShortcutBindings("command-palette", isMac, overrides)[0];
+	const shortcutLabel = paletteBinding ? shortcutBindingLabel(paletteBinding, isMac) : "Unassigned";
 	const { state } = useSidebar();
 	const isCollapsed = state === "collapsed";
 	return (

--- a/frontend/src/renderer/components/settings/KeyboardShortcutsSettingsDialog.test.tsx
+++ b/frontend/src/renderer/components/settings/KeyboardShortcutsSettingsDialog.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { KeybindingOverrides } from "../../../shared/shortcuts";
+import { useKeybindingsStore } from "../../stores/keybindings-store";
+import { TooltipProvider } from "../ui/tooltip";
+import { KeyboardShortcutsSettingsDialog } from "./KeyboardShortcutsSettingsDialog";
+
+const persistBindings = vi.fn(async (overrides: KeybindingOverrides) => overrides);
+const setRecording = vi.fn(async () => undefined);
+
+function renderDialog(isMac = false) {
+	return render(
+		<TooltipProvider>
+			<KeyboardShortcutsSettingsDialog open onOpenChange={vi.fn()} isMac={isMac} />
+		</TooltipProvider>,
+	);
+}
+
+describe("KeyboardShortcutsSettingsDialog", () => {
+	beforeEach(() => {
+		persistBindings.mockClear();
+		setRecording.mockClear();
+		window.ao!.keybindings.set = persistBindings;
+		window.ao!.keybindings.setRecording = setRecording;
+		useKeybindingsStore.setState({ overrides: {}, loaded: true });
+	});
+
+	it("records an application-owned chord and makes Undo keyboard-accessible in the dialog", async () => {
+		const user = userEvent.setup();
+		renderDialog();
+
+		await user.click(screen.getByRole("button", { name: "Change New session" }));
+		await waitFor(() => expect(setRecording).toHaveBeenCalledWith(true));
+
+		fireEvent.keyDown(window, { key: "j", code: "KeyJ", ctrlKey: true });
+
+		const toast = await screen.findByRole("status");
+		expect(toast).toHaveTextContent("Shortcut updated");
+		expect(useKeybindingsStore.getState().overrides["new-session"]).toEqual([
+			{ key: "j", ctrl: true, meta: false, shift: false, alt: false },
+		]);
+		expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Undo" }));
+		await waitFor(() => expect(useKeybindingsStore.getState().overrides).toEqual({}));
+		expect(setRecording).toHaveBeenCalledWith(false);
+	});
+
+	it("opens a real modal for conflicts, supports Escape, and can reassign the chord", async () => {
+		const user = userEvent.setup();
+		renderDialog();
+
+		await user.click(screen.getByRole("button", { name: "Change New session" }));
+		fireEvent.keyDown(window, { key: "/", code: "Slash", ctrlKey: true });
+
+		expect(await screen.findByRole("dialog", { name: "Shortcut already in use" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Reassign" })).toBeEnabled();
+		await user.keyboard("{Escape}");
+		await waitFor(() =>
+			expect(screen.queryByRole("dialog", { name: "Shortcut already in use" })).not.toBeInTheDocument(),
+		);
+		expect(persistBindings).not.toHaveBeenCalled();
+
+		await user.click(screen.getByRole("button", { name: "Change New session" }));
+		fireEvent.keyDown(window, { key: "/", code: "Slash", ctrlKey: true });
+		await user.click(await screen.findByRole("button", { name: "Reassign" }));
+
+		await waitFor(() => {
+			expect(useKeybindingsStore.getState().overrides["new-session"]?.[0]?.key).toBe("/");
+			expect(useKeybindingsStore.getState().overrides["keyboard-shortcuts"]).toEqual([]);
+		});
+	});
+
+	it("ignores AltGraph/lock keys, blocks dangerous chords, and releases recording on blur", async () => {
+		const user = userEvent.setup();
+		renderDialog();
+
+		await user.click(screen.getByRole("button", { name: "Change Focus terminal" }));
+		fireEvent.keyDown(window, { key: "AltGraph", ctrlKey: true, altKey: true });
+		fireEvent.keyDown(window, { key: "CapsLock" });
+		expect(persistBindings).not.toHaveBeenCalled();
+
+		fireEvent.keyDown(window, { key: "c", code: "KeyC", ctrlKey: true });
+		expect(await screen.findByRole("status")).toHaveTextContent("Shortcut is reserved");
+		expect(screen.getByText(/Press shortcut/)).toBeInTheDocument();
+
+		fireEvent.blur(window);
+		await waitFor(() => expect(setRecording).toHaveBeenLastCalledWith(false));
+		expect(screen.queryByText(/Press shortcut/)).not.toBeInTheDocument();
+	});
+
+	it("adds, removes, resets, and resets all bindings", async () => {
+		const user = userEvent.setup();
+		useKeybindingsStore.setState({
+			overrides: {
+				"focus-terminal": [{ key: "j", ctrl: true, meta: false, shift: false, alt: false }],
+				"toggle-sidebar": [{ key: "s", ctrl: false, meta: false, shift: false, alt: true }],
+			},
+			loaded: true,
+		});
+		renderDialog();
+
+		await user.click(screen.getByRole("button", { name: "Add alternative for Focus terminal" }));
+		fireEvent.keyDown(window, { key: "k", code: "KeyK", altKey: true });
+		await waitFor(() => expect(useKeybindingsStore.getState().overrides["focus-terminal"]).toHaveLength(2));
+
+		await user.click(screen.getByRole("button", { name: "Remove Ctrl+J from Focus terminal" }));
+		await waitFor(() => expect(useKeybindingsStore.getState().overrides["focus-terminal"]).toHaveLength(1));
+
+		await user.click(screen.getByRole("button", { name: "Reset Focus terminal" }));
+		await waitFor(() =>
+			expect(Object.hasOwn(useKeybindingsStore.getState().overrides, "focus-terminal")).toBe(false),
+		);
+
+		await user.click(screen.getByRole("button", { name: "Reset all" }));
+		await user.click(screen.getByRole("button", { name: "Reset all" }));
+		await waitFor(() => expect(useKeybindingsStore.getState().overrides).toEqual({}));
+	});
+
+	it("uses the platform prop for displayed and recorded bindings", async () => {
+		const user = userEvent.setup();
+		renderDialog(true);
+
+		expect(screen.getByText("⌘N")).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "Change Focus terminal" }));
+		fireEvent.keyDown(window, { key: "j", code: "KeyJ", metaKey: true });
+
+		await waitFor(() =>
+			expect(useKeybindingsStore.getState().overrides["focus-terminal"]?.[0]?.meta).toBe(true),
+		);
+		expect(await screen.findByRole("status")).toHaveTextContent("⌘J");
+	});
+});

--- a/frontend/src/renderer/components/settings/KeyboardShortcutsSettingsDialog.tsx
+++ b/frontend/src/renderer/components/settings/KeyboardShortcutsSettingsDialog.tsx
@@ -1,0 +1,486 @@
+import { Check, Keyboard, Pencil, Plus, RotateCcw, Search, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+	APP_SHORTCUTS,
+	effectiveShortcutBindings,
+	matchesShortcutBinding,
+	shortcutBindingLabel,
+	type AppShortcutId,
+	type KeybindingOverrides,
+	type ShortcutBinding,
+} from "../../../shared/shortcuts";
+import { isMacPlatform } from "../../lib/platform";
+import { cn } from "../../lib/utils";
+import { useKeybindingsStore } from "../../stores/keybindings-store";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	settingsDialogBodyClass,
+	settingsDialogContentClass,
+	settingsDialogFooterClass,
+	settingsDialogHeaderClass,
+} from "../ui/dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+
+type RecordingState = { id: AppShortcutId; mode: "replace" | "add" };
+type ConflictState = {
+	targetId: AppShortcutId;
+	conflictingId: AppShortcutId;
+	binding: ShortcutBinding;
+	mode: RecordingState["mode"];
+};
+type ToastState = {
+	title: string;
+	body?: string;
+	undo?: () => Promise<void>;
+};
+
+const isMac = isMacPlatform();
+const modifierKeys = new Set(["Alt", "Control", "Meta", "Shift"]);
+
+function eventBinding(event: KeyboardEvent): ShortcutBinding | null {
+	if (modifierKeys.has(event.key)) return null;
+	if (!event.ctrlKey && !event.metaKey && !event.altKey && !/^F(?:[1-9]|1\d|2[0-4])$/.test(event.key)) return null;
+	return {
+		key: event.key.length === 1 ? event.key.toLowerCase() : event.key,
+		...(event.code === "Backquote" ? { code: event.code } : {}),
+		ctrl: event.ctrlKey,
+		meta: event.metaKey,
+		shift: event.shiftKey,
+		alt: event.altKey,
+	};
+}
+
+function definition(id: AppShortcutId) {
+	return APP_SHORTCUTS.find((shortcut) => shortcut.id === id);
+}
+
+export function KeyboardShortcutsSettingsDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const overrides = useKeybindingsStore((state) => state.overrides);
+	const setOverrides = useKeybindingsStore((state) => state.setOverrides);
+	const resetBinding = useKeybindingsStore((state) => state.resetBinding);
+	const resetAll = useKeybindingsStore((state) => state.resetAll);
+	const [query, setQuery] = useState("");
+	const [recording, setRecording] = useState<RecordingState | null>(null);
+	const [conflict, setConflict] = useState<ConflictState | null>(null);
+	const [confirmResetAll, setConfirmResetAll] = useState(false);
+	const [toast, setToast] = useState<ToastState | null>(null);
+	const toastTimerRef = useRef<number | undefined>(undefined);
+
+	const showToast = (next: ToastState) => {
+		if (toastTimerRef.current !== undefined) window.clearTimeout(toastTimerRef.current);
+		setToast(next);
+		toastTimerRef.current = window.setTimeout(() => setToast(null), 3500);
+	};
+
+	useEffect(
+		() => () => {
+			if (toastTimerRef.current !== undefined) window.clearTimeout(toastTimerRef.current);
+		},
+		[],
+	);
+
+	const filteredShortcuts = useMemo(() => {
+		const needle = query.trim().toLowerCase();
+		if (!needle) return APP_SHORTCUTS;
+		return APP_SHORTCUTS.filter((shortcut) => {
+			const labels = effectiveShortcutBindings(shortcut.id, isMac, overrides)
+				.map((candidate) => shortcutBindingLabel(candidate, isMac))
+				.join(" ");
+			return `${shortcut.label} ${shortcut.category} ${labels}`.toLowerCase().includes(needle);
+		});
+	}, [overrides, query]);
+
+	const applyBinding = async (
+		targetId: AppShortcutId,
+		candidate: ShortcutBinding,
+		mode: RecordingState["mode"],
+		conflictingId?: AppShortcutId,
+	) => {
+		const before = overrides;
+		const next: KeybindingOverrides = { ...overrides };
+		const currentTarget = effectiveShortcutBindings(targetId, isMac, overrides);
+		next[targetId] = mode === "add" ? [...currentTarget, candidate].slice(-2) : [candidate];
+		if (conflictingId) {
+			next[conflictingId] = effectiveShortcutBindings(conflictingId, isMac, overrides).filter(
+				(existing) => !matchesShortcutBinding(candidate, existing),
+			);
+		}
+		await setOverrides(next);
+		const targetLabel = definition(targetId)?.label ?? targetId;
+		const conflictLabel = conflictingId ? definition(conflictingId)?.label : undefined;
+		showToast({
+			title: conflictingId ? "Shortcut reassigned" : "Shortcut updated",
+			body: conflictingId
+				? `${shortcutBindingLabel(candidate, isMac)} moved from ${conflictLabel} to ${targetLabel}`
+				: `${targetLabel} → ${shortcutBindingLabel(candidate, isMac)}`,
+			undo: async () => {
+				await setOverrides(before);
+				showToast({ title: "Shortcut change undone" });
+			},
+		});
+	};
+
+	useEffect(() => {
+		if (!open || !recording) return;
+		const handleKeyDown = (event: KeyboardEvent) => {
+			event.preventDefault();
+			event.stopPropagation();
+			if (event.key === "Escape") {
+				setRecording(null);
+				return;
+			}
+			if (event.repeat) return;
+			const candidate = eventBinding(event);
+			if (!candidate) {
+				if (!modifierKeys.has(event.key)) {
+					showToast({
+						title: "Add a modifier",
+						body: "Use Ctrl, Alt, Cmd, or a function key such as F6.",
+					});
+				}
+				return;
+			}
+			if (
+				recording.mode === "add" &&
+				effectiveShortcutBindings(recording.id, isMac, overrides).some((existing) =>
+					matchesShortcutBinding(candidate, existing),
+				)
+			) {
+				showToast({
+					title: "Shortcut already assigned",
+					body: `${shortcutBindingLabel(candidate, isMac)} is already available for this command.`,
+				});
+				setRecording(null);
+				return;
+			}
+			const conflicting = APP_SHORTCUTS.find(
+				(shortcut) =>
+					shortcut.id !== recording.id &&
+					effectiveShortcutBindings(shortcut.id, isMac, overrides).some((existing) =>
+						matchesShortcutBinding(candidate, existing),
+					),
+			);
+			if (conflicting) {
+				if (conflicting.customizable === false) {
+					showToast({
+						title: "Shortcut is reserved",
+						body: `${shortcutBindingLabel(candidate, isMac)} is used by ${conflicting.label}.`,
+					});
+					return;
+				}
+				setConflict({
+					targetId: recording.id,
+					conflictingId: conflicting.id,
+					binding: candidate,
+					mode: recording.mode,
+				});
+				setRecording(null);
+				return;
+			}
+			void applyBinding(recording.id, candidate, recording.mode).catch(() =>
+				showToast({ title: "Could not update shortcut", body: "Your previous binding is still active." }),
+			);
+			setRecording(null);
+		};
+		window.addEventListener("keydown", handleKeyDown, true);
+		return () => window.removeEventListener("keydown", handleKeyDown, true);
+	}, [open, overrides, recording]);
+
+	const handleResetBinding = async (id: AppShortcutId) => {
+		const before = overrides;
+		await resetBinding(id);
+		showToast({
+			title: "Shortcut restored",
+			body: `${definition(id)?.label ?? id} now uses its default binding.`,
+			undo: async () => {
+				await setOverrides(before);
+				showToast({ title: "Shortcut change undone" });
+			},
+		});
+	};
+
+	const handleRemoveBinding = async (id: AppShortcutId, index: number) => {
+		const before = overrides;
+		const current = effectiveShortcutBindings(id, isMac, overrides);
+		const removed = current[index];
+		await setOverrides({ ...overrides, [id]: current.filter((_, candidateIndex) => candidateIndex !== index) });
+		showToast({
+			title: "Shortcut removed",
+			body: removed ? `${definition(id)?.label ?? id} no longer uses ${shortcutBindingLabel(removed, isMac)}.` : undefined,
+			undo: async () => {
+				await setOverrides(before);
+				showToast({ title: "Shortcut change undone" });
+			},
+		});
+	};
+
+	return (
+		<>
+			<Dialog
+				open={open}
+				onOpenChange={(next) => {
+					setRecording(null);
+					setConflict(null);
+					setConfirmResetAll(false);
+					onOpenChange(next);
+				}}
+			>
+				<DialogContent className={cn(settingsDialogContentClass, "w-[min(760px,calc(100vw-var(--space-8)))]")}>
+					<DialogHeader className={settingsDialogHeaderClass}>
+						<DialogTitle className="settings-dialog-title">Keyboard shortcuts</DialogTitle>
+						<DialogDescription className="text-control leading-4 text-settings-muted">
+							Change application commands without affecting terminal or text-editing shortcuts.
+						</DialogDescription>
+					</DialogHeader>
+
+					<div className={cn(settingsDialogBodyClass, "gap-3")}>
+						<label className="relative">
+							<Search
+								className="pointer-events-none absolute left-3 top-1/2 size-icon-base -translate-y-1/2 text-settings-muted"
+								aria-hidden="true"
+							/>
+							<input
+								type="search"
+								className="settings-field-control h-10 w-full pl-9"
+								placeholder="Search commands or key combinations"
+								value={query}
+								onChange={(event) => setQuery(event.target.value)}
+							/>
+						</label>
+
+						<div className="flex flex-col gap-2">
+							{filteredShortcuts.map((shortcut) => {
+								const bindings = effectiveShortcutBindings(shortcut.id, isMac, overrides);
+								const modified = Object.hasOwn(overrides, shortcut.id);
+								const isRecording = recording?.id === shortcut.id;
+								return (
+									<div
+										className="rounded-(--radius-settings-row) border border-(--color-border-settings-input) bg-(--color-bg-settings-row) px-3.5 py-3"
+										key={shortcut.id}
+									>
+										<div className="flex items-center gap-3">
+											<div className="min-w-0 flex-1">
+												<div className="flex items-center gap-2">
+													<span className="text-sm font-medium text-settings-label">{shortcut.label}</span>
+													{modified ? (
+														<span className="rounded-full bg-settings-menu-selected px-2 py-0.5 text-micro text-settings-muted">
+															Modified
+														</span>
+													) : null}
+												</div>
+												<span className="text-caption text-settings-muted">{shortcut.category}</span>
+											</div>
+
+											{shortcut.customizable === false ? (
+												<span className="text-caption text-settings-muted">Fixed indexed shortcut</span>
+											) : isRecording ? (
+												<div className="flex min-w-52 items-center gap-2 rounded-md border border-(--color-settings-accent) px-3 py-2 text-caption text-settings-label">
+													<Keyboard className="size-icon-base animate-pulse" aria-hidden="true" />
+													Press shortcut · Esc to cancel
+												</div>
+											) : (
+												<div className="flex flex-wrap items-center justify-end gap-1.5">
+													{bindings.length === 0 ? (
+														<span className="text-caption text-settings-muted">Unassigned</span>
+													) : (
+														bindings.map((candidate, index) => (
+															<span
+																className="inline-flex items-center rounded-md border border-(--color-border-settings-input) bg-(--color-bg-settings-input)"
+																key={`${candidate.key}-${index}`}
+															>
+																<kbd className="px-2 py-1.5 font-mono text-caption text-settings-label">
+																	{shortcutBindingLabel(candidate, isMac)}
+																</kbd>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<button
+																			type="button"
+																			className="mr-1 inline-flex size-5 items-center justify-center rounded text-settings-muted hover:bg-settings-menu-selected hover:text-settings-label"
+																			aria-label={`Remove ${shortcutBindingLabel(candidate, isMac)} from ${shortcut.label}`}
+																			onClick={() => void handleRemoveBinding(shortcut.id, index)}
+																		>
+																			<X className="size-3" aria-hidden="true" />
+																		</button>
+																	</TooltipTrigger>
+																	<TooltipContent>Remove</TooltipContent>
+																</Tooltip>
+															</span>
+														))
+													)}
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<button
+																type="button"
+																className="inline-flex size-8 items-center justify-center rounded-md text-settings-muted hover:bg-settings-menu-selected hover:text-settings-label"
+																aria-label={`Change ${shortcut.label}`}
+																onClick={() => setRecording({ id: shortcut.id, mode: "replace" })}
+															>
+																<Pencil className="size-icon-base" aria-hidden="true" />
+															</button>
+														</TooltipTrigger>
+														<TooltipContent>Change</TooltipContent>
+													</Tooltip>
+													{bindings.length < 2 ? (
+														<Tooltip>
+															<TooltipTrigger asChild>
+																<button
+																	type="button"
+																	className="inline-flex size-8 items-center justify-center rounded-md text-settings-muted hover:bg-settings-menu-selected hover:text-settings-label"
+																	aria-label={`Add alternative for ${shortcut.label}`}
+																	onClick={() => setRecording({ id: shortcut.id, mode: "add" })}
+																>
+																	<Plus className="size-icon-base" aria-hidden="true" />
+																</button>
+															</TooltipTrigger>
+															<TooltipContent>Add</TooltipContent>
+														</Tooltip>
+													) : null}
+													{modified ? (
+														<Tooltip>
+															<TooltipTrigger asChild>
+																<button
+																	type="button"
+																	className="inline-flex size-8 items-center justify-center rounded-md text-settings-muted hover:bg-settings-menu-selected hover:text-settings-label"
+																	aria-label={`Reset ${shortcut.label}`}
+																	onClick={() => void handleResetBinding(shortcut.id)}
+																>
+																	<RotateCcw className="size-icon-base" aria-hidden="true" />
+																</button>
+															</TooltipTrigger>
+															<TooltipContent>Reset</TooltipContent>
+														</Tooltip>
+													) : null}
+												</div>
+											)}
+										</div>
+									</div>
+								);
+							})}
+							{filteredShortcuts.length === 0 ? (
+								<p className="py-8 text-center text-sm text-settings-muted">No matching commands.</p>
+							) : null}
+						</div>
+					</div>
+
+					<div className={settingsDialogFooterClass}>
+						{confirmResetAll ? (
+							<>
+								<span className="mr-auto text-caption text-settings-muted">Restore every shortcut to its default?</span>
+								<button type="button" className="settings-footer-button" onClick={() => setConfirmResetAll(false)}>
+									Cancel
+								</button>
+								<button
+									type="button"
+									className="settings-footer-button border-transparent bg-settings-accent text-white"
+									onClick={() => {
+										void resetAll().then(() => {
+											setConfirmResetAll(false);
+											showToast({ title: "Keyboard shortcuts restored to defaults" });
+										});
+									}}
+								>
+									Reset all
+								</button>
+							</>
+						) : (
+							<button
+								type="button"
+								className="settings-footer-button mr-auto"
+								disabled={Object.keys(overrides).length === 0}
+								onClick={() => setConfirmResetAll(true)}
+							>
+								<RotateCcw className="size-icon-base" aria-hidden="true" />
+								Reset all
+							</button>
+						)}
+					</div>
+				</DialogContent>
+			</Dialog>
+
+			{conflict ? (
+				<div className="fixed inset-0 z-[calc(var(--z-overlay)+1)] grid place-items-center bg-black/45 px-4">
+					<div
+						className="w-full max-w-md rounded-(--radius-settings-dialog-lg) border border-(--color-border-settings-dialog) bg-settings-dialog p-5 shadow-[var(--shadow-settings-dialog)]"
+						role="alertdialog"
+						aria-labelledby="keybinding-conflict-title"
+					>
+						<h2 id="keybinding-conflict-title" className="settings-dialog-title">
+							Shortcut already in use
+						</h2>
+						<p className="mt-2 text-sm text-settings-muted">
+							{shortcutBindingLabel(conflict.binding, isMac)} is assigned to{" "}
+							{definition(conflict.conflictingId)?.label}. Reassign it to {definition(conflict.targetId)?.label}?
+						</p>
+						<div className="mt-5 flex justify-end gap-3">
+							<button type="button" className="settings-footer-button" onClick={() => setConflict(null)}>
+								Cancel
+							</button>
+							<button
+								type="button"
+								className="settings-footer-button border-transparent bg-settings-accent text-white"
+								onClick={() => {
+									const pending = conflict;
+									setConflict(null);
+									void applyBinding(
+										pending.targetId,
+										pending.binding,
+										pending.mode,
+										pending.conflictingId,
+									).catch(() =>
+										showToast({
+											title: "Could not reassign shortcut",
+											body: "Your previous bindings are still active.",
+										}),
+									);
+								}}
+							>
+								Reassign
+							</button>
+						</div>
+					</div>
+				</div>
+			) : null}
+
+			{toast ? (
+				<div
+					className="pointer-events-auto fixed bottom-4 right-4 z-[calc(var(--z-overlay)+2)] flex w-[min(24rem,calc(100vw-2rem))] items-start gap-3 rounded-xl border border-(--color-border-settings-dialog) bg-settings-dialog px-4 py-3 shadow-[var(--shadow-settings-dialog)]"
+					role="status"
+					aria-live="polite"
+				>
+					<Check className="mt-0.5 size-icon-base shrink-0 text-success" aria-hidden="true" />
+					<div className="min-w-0 flex-1">
+						<p className="text-sm font-medium text-settings-label">{toast.title}</p>
+						{toast.body ? <p className="mt-0.5 text-caption text-settings-muted">{toast.body}</p> : null}
+					</div>
+					{toast.undo ? (
+						<button
+							type="button"
+							className="text-caption font-medium text-settings-label hover:underline"
+							onClick={() => void toast.undo?.()}
+						>
+							Undo
+						</button>
+					) : null}
+					<button
+						type="button"
+						className="text-settings-muted hover:text-settings-label"
+						aria-label="Dismiss notification"
+						onClick={() => setToast(null)}
+					>
+						<X className="size-icon-base" aria-hidden="true" />
+					</button>
+				</div>
+			) : null}
+		</>
+	);
+}

--- a/frontend/src/renderer/components/settings/KeyboardShortcutsSettingsDialog.tsx
+++ b/frontend/src/renderer/components/settings/KeyboardShortcutsSettingsDialog.tsx
@@ -5,11 +5,13 @@ import {
 	effectiveShortcutBindings,
 	matchesShortcutBinding,
 	shortcutBindingLabel,
+	shortcutBindingValidationError,
 	type AppShortcutId,
 	type KeybindingOverrides,
 	type ShortcutBinding,
 } from "../../../shared/shortcuts";
 import { isMacPlatform } from "../../lib/platform";
+import { aoBridge } from "../../lib/bridge";
 import { cn } from "../../lib/utils";
 import { useKeybindingsStore } from "../../stores/keybindings-store";
 import {
@@ -24,6 +26,7 @@ import {
 	settingsDialogHeaderClass,
 } from "../ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+import { ConfirmDialog } from "../ConfirmDialog";
 
 type RecordingState = { id: AppShortcutId; mode: "replace" | "add" };
 type ConflictState = {
@@ -38,12 +41,22 @@ type ToastState = {
 	undo?: () => Promise<void>;
 };
 
-const isMac = isMacPlatform();
-const modifierKeys = new Set(["Alt", "Control", "Meta", "Shift"]);
+const ignoredRecordingKeys = new Set([
+	"Alt",
+	"AltGraph",
+	"CapsLock",
+	"Control",
+	"Dead",
+	"Meta",
+	"NumLock",
+	"Process",
+	"ScrollLock",
+	"Shift",
+	"Unidentified",
+]);
 
 function eventBinding(event: KeyboardEvent): ShortcutBinding | null {
-	if (modifierKeys.has(event.key)) return null;
-	if (!event.ctrlKey && !event.metaKey && !event.altKey && !/^F(?:[1-9]|1\d|2[0-4])$/.test(event.key)) return null;
+	if (ignoredRecordingKeys.has(event.key) || event.getModifierState?.("AltGraph")) return null;
 	return {
 		key: event.key.length === 1 ? event.key.toLowerCase() : event.key,
 		...(event.code === "Backquote" ? { code: event.code } : {}),
@@ -61,20 +74,25 @@ function definition(id: AppShortcutId) {
 export function KeyboardShortcutsSettingsDialog({
 	open,
 	onOpenChange,
+	isMac = isMacPlatform(),
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	isMac?: boolean;
 }) {
 	const overrides = useKeybindingsStore((state) => state.overrides);
 	const setOverrides = useKeybindingsStore((state) => state.setOverrides);
 	const resetBinding = useKeybindingsStore((state) => state.resetBinding);
 	const resetAll = useKeybindingsStore((state) => state.resetAll);
 	const [query, setQuery] = useState("");
-	const [recording, setRecording] = useState<RecordingState | null>(null);
+	const [recording, setRecordingState] = useState<RecordingState | null>(null);
 	const [conflict, setConflict] = useState<ConflictState | null>(null);
 	const [confirmResetAll, setConfirmResetAll] = useState(false);
 	const [toast, setToast] = useState<ToastState | null>(null);
 	const toastTimerRef = useRef<number | undefined>(undefined);
+	const openRef = useRef(open);
+	const recordingRequestRef = useRef(0);
+	openRef.current = open;
 
 	const showToast = (next: ToastState) => {
 		if (toastTimerRef.current !== undefined) window.clearTimeout(toastTimerRef.current);
@@ -84,10 +102,53 @@ export function KeyboardShortcutsSettingsDialog({
 
 	useEffect(
 		() => () => {
+			openRef.current = false;
+			recordingRequestRef.current += 1;
 			if (toastTimerRef.current !== undefined) window.clearTimeout(toastTimerRef.current);
+			void aoBridge.keybindings.setRecording(false);
 		},
 		[],
 	);
+
+	useEffect(() => {
+		if (open) return;
+		setRecordingState(null);
+		void aoBridge.keybindings.setRecording(false);
+	}, [open]);
+
+	useEffect(() => {
+		if (!recording) return;
+		const handleBlur = () => {
+			setRecordingState(null);
+			void aoBridge.keybindings.setRecording(false);
+		};
+		window.addEventListener("blur", handleBlur);
+		return () => window.removeEventListener("blur", handleBlur);
+	}, [recording]);
+
+	const beginRecording = async (next: RecordingState) => {
+		const request = recordingRequestRef.current + 1;
+		recordingRequestRef.current = request;
+		try {
+			await aoBridge.keybindings.setRecording(true);
+			if (!openRef.current || request !== recordingRequestRef.current) {
+				await aoBridge.keybindings.setRecording(false);
+				return;
+			}
+			setRecordingState(next);
+		} catch {
+			showToast({
+				title: "Could not record shortcut",
+				body: "Try reopening keyboard shortcut settings.",
+			});
+		}
+	};
+
+	const endRecording = () => {
+		recordingRequestRef.current += 1;
+		setRecordingState(null);
+		void aoBridge.keybindings.setRecording(false);
+	};
 
 	const filteredShortcuts = useMemo(() => {
 		const needle = query.trim().toLowerCase();
@@ -98,7 +159,7 @@ export function KeyboardShortcutsSettingsDialog({
 				.join(" ");
 			return `${shortcut.label} ${shortcut.category} ${labels}`.toLowerCase().includes(needle);
 		});
-	}, [overrides, query]);
+	}, [isMac, overrides, query]);
 
 	const applyBinding = async (
 		targetId: AppShortcutId,
@@ -136,18 +197,17 @@ export function KeyboardShortcutsSettingsDialog({
 			event.preventDefault();
 			event.stopPropagation();
 			if (event.key === "Escape") {
-				setRecording(null);
+				endRecording();
 				return;
 			}
 			if (event.repeat) return;
 			const candidate = eventBinding(event);
 			if (!candidate) {
-				if (!modifierKeys.has(event.key)) {
-					showToast({
-						title: "Add a modifier",
-						body: "Use Ctrl, Alt, Cmd, or a function key such as F6.",
-					});
-				}
+				return;
+			}
+			const validationError = shortcutBindingValidationError(candidate, isMac);
+			if (validationError) {
+				showToast({ title: "Shortcut is reserved", body: validationError });
 				return;
 			}
 			if (
@@ -160,7 +220,7 @@ export function KeyboardShortcutsSettingsDialog({
 					title: "Shortcut already assigned",
 					body: `${shortcutBindingLabel(candidate, isMac)} is already available for this command.`,
 				});
-				setRecording(null);
+				endRecording();
 				return;
 			}
 			const conflicting = APP_SHORTCUTS.find(
@@ -184,17 +244,17 @@ export function KeyboardShortcutsSettingsDialog({
 					binding: candidate,
 					mode: recording.mode,
 				});
-				setRecording(null);
+				endRecording();
 				return;
 			}
 			void applyBinding(recording.id, candidate, recording.mode).catch(() =>
 				showToast({ title: "Could not update shortcut", body: "Your previous binding is still active." }),
 			);
-			setRecording(null);
+			endRecording();
 		};
 		window.addEventListener("keydown", handleKeyDown, true);
 		return () => window.removeEventListener("keydown", handleKeyDown, true);
-	}, [open, overrides, recording]);
+	}, [isMac, open, overrides, recording]);
 
 	const handleResetBinding = async (id: AppShortcutId) => {
 		const before = overrides;
@@ -229,13 +289,21 @@ export function KeyboardShortcutsSettingsDialog({
 			<Dialog
 				open={open}
 				onOpenChange={(next) => {
-					setRecording(null);
+					endRecording();
 					setConflict(null);
 					setConfirmResetAll(false);
 					onOpenChange(next);
 				}}
 			>
-				<DialogContent className={cn(settingsDialogContentClass, "w-[min(760px,calc(100vw-var(--space-8)))]")}>
+				<DialogContent
+					className={cn(settingsDialogContentClass, "relative w-[min(760px,calc(100vw-var(--space-8)))]")}
+					onEscapeKeyDown={(event) => {
+						if (recording) {
+							event.preventDefault();
+							endRecording();
+						}
+					}}
+				>
 					<DialogHeader className={settingsDialogHeaderClass}>
 						<DialogTitle className="settings-dialog-title">Keyboard shortcuts</DialogTitle>
 						<DialogDescription className="text-control leading-4 text-settings-muted">
@@ -323,7 +391,7 @@ export function KeyboardShortcutsSettingsDialog({
 																type="button"
 																className="inline-flex size-8 items-center justify-center rounded-md text-settings-muted hover:bg-settings-menu-selected hover:text-settings-label"
 																aria-label={`Change ${shortcut.label}`}
-																onClick={() => setRecording({ id: shortcut.id, mode: "replace" })}
+																onClick={() => void beginRecording({ id: shortcut.id, mode: "replace" })}
 															>
 																<Pencil className="size-icon-base" aria-hidden="true" />
 															</button>
@@ -337,7 +405,7 @@ export function KeyboardShortcutsSettingsDialog({
 																	type="button"
 																	className="inline-flex size-8 items-center justify-center rounded-md text-settings-muted hover:bg-settings-menu-selected hover:text-settings-label"
 																	aria-label={`Add alternative for ${shortcut.label}`}
-																	onClick={() => setRecording({ id: shortcut.id, mode: "add" })}
+																	onClick={() => void beginRecording({ id: shortcut.id, mode: "add" })}
 																>
 																	<Plus className="size-icon-base" aria-hidden="true" />
 																</button>
@@ -404,83 +472,72 @@ export function KeyboardShortcutsSettingsDialog({
 							</button>
 						)}
 					</div>
+
+					{toast ? (
+						<div
+							className="pointer-events-auto absolute bottom-4 right-4 z-[calc(var(--z-overlay)+2)] flex w-[min(24rem,calc(100%-2rem))] items-start gap-3 rounded-xl border border-(--color-border-settings-dialog) bg-settings-dialog px-4 py-3 shadow-[var(--shadow-settings-dialog)]"
+							role="status"
+							aria-live="polite"
+							aria-atomic="true"
+						>
+							<Check className="mt-0.5 size-icon-base shrink-0 text-success" aria-hidden="true" />
+							<div className="min-w-0 flex-1">
+								<p className="text-sm font-medium text-settings-label">{toast.title}</p>
+								{toast.body ? <p className="mt-0.5 text-caption text-settings-muted">{toast.body}</p> : null}
+							</div>
+							{toast.undo ? (
+								<button
+									type="button"
+									className="text-caption font-medium text-settings-label hover:underline"
+									onClick={() => void toast.undo?.()}
+								>
+									Undo
+								</button>
+							) : null}
+							<button
+								type="button"
+								className="text-settings-muted hover:text-settings-label"
+								aria-label="Dismiss notification"
+								onClick={() => setToast(null)}
+							>
+								<X className="size-icon-base" aria-hidden="true" />
+							</button>
+						</div>
+					) : null}
 				</DialogContent>
 			</Dialog>
 
-			{conflict ? (
-				<div className="fixed inset-0 z-[calc(var(--z-overlay)+1)] grid place-items-center bg-black/45 px-4">
-					<div
-						className="w-full max-w-md rounded-(--radius-settings-dialog-lg) border border-(--color-border-settings-dialog) bg-settings-dialog p-5 shadow-[var(--shadow-settings-dialog)]"
-						role="alertdialog"
-						aria-labelledby="keybinding-conflict-title"
-					>
-						<h2 id="keybinding-conflict-title" className="settings-dialog-title">
-							Shortcut already in use
-						</h2>
-						<p className="mt-2 text-sm text-settings-muted">
-							{shortcutBindingLabel(conflict.binding, isMac)} is assigned to{" "}
-							{definition(conflict.conflictingId)?.label}. Reassign it to {definition(conflict.targetId)?.label}?
-						</p>
-						<div className="mt-5 flex justify-end gap-3">
-							<button type="button" className="settings-footer-button" onClick={() => setConflict(null)}>
-								Cancel
-							</button>
-							<button
-								type="button"
-								className="settings-footer-button border-transparent bg-settings-accent text-white"
-								onClick={() => {
-									const pending = conflict;
-									setConflict(null);
-									void applyBinding(
-										pending.targetId,
-										pending.binding,
-										pending.mode,
-										pending.conflictingId,
-									).catch(() =>
-										showToast({
-											title: "Could not reassign shortcut",
-											body: "Your previous bindings are still active.",
-										}),
-									);
-								}}
-							>
-								Reassign
-							</button>
-						</div>
-					</div>
-				</div>
-			) : null}
-
-			{toast ? (
-				<div
-					className="pointer-events-auto fixed bottom-4 right-4 z-[calc(var(--z-overlay)+2)] flex w-[min(24rem,calc(100vw-2rem))] items-start gap-3 rounded-xl border border-(--color-border-settings-dialog) bg-settings-dialog px-4 py-3 shadow-[var(--shadow-settings-dialog)]"
-					role="status"
-					aria-live="polite"
-				>
-					<Check className="mt-0.5 size-icon-base shrink-0 text-success" aria-hidden="true" />
-					<div className="min-w-0 flex-1">
-						<p className="text-sm font-medium text-settings-label">{toast.title}</p>
-						{toast.body ? <p className="mt-0.5 text-caption text-settings-muted">{toast.body}</p> : null}
-					</div>
-					{toast.undo ? (
-						<button
-							type="button"
-							className="text-caption font-medium text-settings-label hover:underline"
-							onClick={() => void toast.undo?.()}
-						>
-							Undo
-						</button>
-					) : null}
-					<button
-						type="button"
-						className="text-settings-muted hover:text-settings-label"
-						aria-label="Dismiss notification"
-						onClick={() => setToast(null)}
-					>
-						<X className="size-icon-base" aria-hidden="true" />
-					</button>
-				</div>
-			) : null}
+			<ConfirmDialog
+				open={conflict !== null}
+				title="Shortcut already in use"
+				description={
+					conflict
+						? `${shortcutBindingLabel(conflict.binding, isMac)} is assigned to ${
+								definition(conflict.conflictingId)?.label
+							}. Reassign it to ${definition(conflict.targetId)?.label}?`
+						: ""
+				}
+				confirmLabel="Reassign"
+				onOpenChange={(next) => {
+					if (!next) setConflict(null);
+				}}
+				onConfirm={() => {
+					if (!conflict) return;
+					const pending = conflict;
+					setConflict(null);
+					void applyBinding(
+						pending.targetId,
+						pending.binding,
+						pending.mode,
+						pending.conflictingId,
+					).catch(() =>
+						showToast({
+							title: "Could not reassign shortcut",
+							body: "Your previous bindings are still active.",
+						}),
+					);
+				}}
+			/>
 		</>
 	);
 }

--- a/frontend/src/renderer/components/ui/sidebar.tsx
+++ b/frontend/src/renderer/components/ui/sidebar.tsx
@@ -19,8 +19,6 @@ const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "var(--size-sidebar-default)";
 const SIDEBAR_WIDTH_MOBILE = "var(--size-sidebar-mobile)";
 const SIDEBAR_WIDTH_ICON = "var(--size-sidebar-icon)";
-const SIDEBAR_KEYBOARD_SHORTCUT = "b";
-
 type SidebarContextProps = {
 	state: "expanded" | "collapsed";
 	open: boolean;
@@ -49,11 +47,13 @@ function SidebarProvider({
 	className,
 	style,
 	children,
+	keyboardShortcut = true,
 	...props
 }: React.ComponentProps<"div"> & {
 	defaultOpen?: boolean;
 	open?: boolean;
 	onOpenChange?: (open: boolean) => void;
+	keyboardShortcut?: boolean;
 }) {
 	const isMobile = useIsMobile();
 	const [openMobile, setOpenMobile] = React.useState(false);
@@ -84,8 +84,9 @@ function SidebarProvider({
 
 	// Adds a keyboard shortcut to toggle the sidebar.
 	React.useEffect(() => {
+		if (!keyboardShortcut) return;
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
+			if (event.key === "b" && (event.metaKey || event.ctrlKey)) {
 				event.preventDefault();
 				toggleSidebar();
 			}
@@ -93,7 +94,7 @@ function SidebarProvider({
 
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [toggleSidebar]);
+	}, [keyboardShortcut, toggleSidebar]);
 
 	// We add a state so that we can do data-state="expanded" or "collapsed".
 	// This makes it easier to style the sidebar with Tailwind classes.

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -132,6 +132,10 @@ export const aoBridge: AoBridge =
 			get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 			set: async () => undefined,
 		},
+		keybindings: {
+			get: async () => ({}),
+			set: async (overrides) => overrides,
+		},
 		updates: {
 			getStatus: async () => ({ state: "idle" }),
 			check: async () => undefined,

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -135,6 +135,7 @@ export const aoBridge: AoBridge =
 		keybindings: {
 			get: async () => ({}),
 			set: async (overrides) => overrides,
+			setRecording: async () => undefined,
 		},
 		updates: {
 			getStatus: async () => ({ state: "idle" }),

--- a/frontend/src/renderer/routes/__root.tsx
+++ b/frontend/src/renderer/routes/__root.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { TooltipProvider } from "../components/ui/tooltip";
 import type { QueryClient } from "@tanstack/react-query";
 import { captureRendererEvent, routeSurface } from "../lib/telemetry";
+import { useKeybindingsStore } from "../stores/keybindings-store";
 
 export const Route = createRootRouteWithContext<{
 	queryClient: QueryClient;
@@ -12,12 +13,17 @@ export const Route = createRootRouteWithContext<{
 
 function RootComponent() {
 	const location = useRouterState({ select: (state) => state.location });
+	const loadKeybindings = useKeybindingsStore((state) => state.load);
 
 	useEffect(() => {
 		void captureRendererEvent("ao.renderer.route_viewed", {
 			surface: routeSurface(location.pathname),
 		});
 	}, [location.pathname]);
+
+	useEffect(() => {
+		void loadKeybindings();
+	}, [loadKeybindings]);
 
 	return (
 		<TooltipProvider>

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -7,6 +7,7 @@ import { DaemonFailureBanner } from "../components/DaemonFailureBanner";
 import { NotificationRuntime } from "../components/NotificationCenter";
 import { GlobalNewTaskDialog } from "../components/GlobalNewTaskDialog";
 import { KeyboardShortcutsDialog } from "../components/KeyboardShortcutsDialog";
+import { KeyboardShortcutsSettingsDialog } from "../components/settings/KeyboardShortcutsSettingsDialog";
 import { ShellTopbar } from "../components/ShellTopbar";
 import { OrchestratorReplacementDialog } from "../components/OrchestratorReplacementDialog";
 import { Sidebar } from "../components/Sidebar";
@@ -35,6 +36,7 @@ import {
 	hidesShellTopbar,
 } from "../lib/platform";
 import { useUiStore } from "../stores/ui-store";
+import { matchesRendererShortcut } from "../stores/keybindings-store";
 import { sessionIsActive, toProjectKind, type WorkspaceSummary } from "../types/workspace";
 import type { components } from "../../api/schema";
 
@@ -122,6 +124,7 @@ function ShellLayout() {
 	// Seeded to the current value so a mount never opens a terminal unasked.
 	const handledShellNonceRef = useRef(newShellTerminalNonce);
 	const [isKeyboardShortcutsOpen, setIsKeyboardShortcutsOpen] = useState(false);
+	const [isKeyboardShortcutsSettingsOpen, setIsKeyboardShortcutsSettingsOpen] = useState(false);
 	const [isSidebarPeekOpen, setIsSidebarPeekOpen] = useState(false);
 	const sidebarPeekCloseTimerRef = useRef<number | undefined>(undefined);
 	const routeParams = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
@@ -420,11 +423,14 @@ function ShellLayout() {
 		return () => mediaQuery.removeEventListener("change", handleChange);
 	}, [themePreference, syncSystemTheme]);
 
-	// ⌘B lives in SidebarProvider (shadcn's built-in shortcut), which routes
-	// through onOpenChange back into the ui-store.
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if ((event.metaKey || event.ctrlKey) && /^[1-9]$/.test(event.key)) {
+			if (matchesRendererShortcut("toggle-sidebar", event)) {
+				event.preventDefault();
+				toggleSidebar();
+				return;
+			}
+			if (matchesRendererShortcut("open-project", event)) {
 				const workspace = workspaces[Number(event.key) - 1];
 				if (workspace) {
 					event.preventDefault();
@@ -434,7 +440,7 @@ function ShellLayout() {
 		};
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [navigate, workspaces]);
+	}, [navigate, toggleSidebar, workspaces]);
 
 	// New session (⌘N / Ctrl+Shift+N) is detected in the main process and
 	// delivered here, so it fires even when focus is inside xterm or a native
@@ -515,7 +521,18 @@ function ShellLayout() {
 		<ShellProvider value={{ daemonStatus, createProject, initializeProjectRepository }}>
 			<NotificationRuntime />
 			<GlobalNewTaskDialog />
-			<KeyboardShortcutsDialog open={isKeyboardShortcutsOpen} onOpenChange={setIsKeyboardShortcutsOpen} />
+			<KeyboardShortcutsDialog
+				open={isKeyboardShortcutsOpen}
+				onOpenChange={setIsKeyboardShortcutsOpen}
+				onCustomize={() => {
+					setIsKeyboardShortcutsOpen(false);
+					setIsKeyboardShortcutsSettingsOpen(true);
+				}}
+			/>
+			<KeyboardShortcutsSettingsDialog
+				open={isKeyboardShortcutsSettingsOpen}
+				onOpenChange={setIsKeyboardShortcutsSettingsOpen}
+			/>
 			{/* Shell chrome: Win/Linux hang the sidebar under a topbar. macOS uses a
           titlebar strip above the off-canvas sidebar. Session and board actions
           render inside the center panel when the shell topbar is hidden. */}
@@ -531,6 +548,7 @@ function ShellLayout() {
             the drag-resizable --ao-sidebar-w set on :root by useResizable. */}
 				<SidebarProvider
 					className="min-h-0 flex-1 overflow-x-hidden"
+					keyboardShortcut={false}
 					onOpenChange={(open) => {
 						cancelSidebarPeekClose();
 						setIsSidebarPeekOpen(false);

--- a/frontend/src/renderer/stores/keybindings-store.ts
+++ b/frontend/src/renderer/stores/keybindings-store.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+import {
+	effectiveShortcutBindings,
+	matchesAppShortcut,
+	type AppShortcutId,
+	type KeybindingOverrides,
+	type ShortcutBinding,
+	type ShortcutChord,
+} from "../../shared/shortcuts";
+import { aoBridge } from "../lib/bridge";
+import { isMacPlatform } from "../lib/platform";
+
+type KeybindingsState = {
+	overrides: KeybindingOverrides;
+	loaded: boolean;
+	load: () => Promise<void>;
+	setOverrides: (overrides: KeybindingOverrides) => Promise<void>;
+	setBindings: (id: AppShortcutId, bindings: readonly ShortcutBinding[]) => Promise<void>;
+	resetBinding: (id: AppShortcutId) => Promise<void>;
+	resetAll: () => Promise<void>;
+};
+
+async function persist(overrides: KeybindingOverrides): Promise<KeybindingOverrides> {
+	return aoBridge.keybindings.set(overrides);
+}
+
+export const useKeybindingsStore = create<KeybindingsState>((set, get) => ({
+	overrides: {},
+	loaded: false,
+	load: async () => {
+		if (get().loaded) return;
+		const overrides = await aoBridge.keybindings.get();
+		set({ overrides, loaded: true });
+	},
+	setOverrides: async (candidate) => {
+		const overrides = await persist(candidate);
+		set({ overrides, loaded: true });
+	},
+	setBindings: async (id, bindings) => {
+		const overrides = await persist({ ...get().overrides, [id]: bindings });
+		set({ overrides, loaded: true });
+	},
+	resetBinding: async (id) => {
+		const next = { ...get().overrides };
+		delete next[id];
+		const overrides = await persist(next);
+		set({ overrides, loaded: true });
+	},
+	resetAll: async () => {
+		const overrides = await persist({});
+		set({ overrides, loaded: true });
+	},
+}));
+
+export function keyboardEventChord(event: KeyboardEvent): ShortcutChord {
+	return {
+		key: event.key,
+		code: event.code,
+		ctrl: event.ctrlKey,
+		meta: event.metaKey,
+		shift: event.shiftKey,
+		alt: event.altKey,
+	};
+}
+
+export function matchesRendererShortcut(id: AppShortcutId, event: KeyboardEvent): boolean {
+	return matchesAppShortcut(id, keyboardEventChord(event), isMacPlatform(), useKeybindingsStore.getState().overrides);
+}
+
+export function currentShortcutBindings(id: AppShortcutId): readonly ShortcutBinding[] {
+	return effectiveShortcutBindings(id, isMacPlatform(), useKeybindingsStore.getState().overrides);
+}

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -177,6 +177,7 @@ if (typeof window !== "undefined") {
 		keybindings: {
 			get: async () => ({}),
 			set: async (overrides) => overrides,
+			setRecording: async () => undefined,
 		},
 		updates: {
 			getStatus: async () => ({ state: "idle" }),

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -174,6 +174,10 @@ if (typeof window !== "undefined") {
 			get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 			set: async () => undefined,
 		},
+		keybindings: {
+			get: async () => ({}),
+			set: async (overrides) => overrides,
+		},
 		updates: {
 			getStatus: async () => ({ state: "idle" }),
 			check: async () => undefined,

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Suspense, type ComponentType, type PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { KeybindingOverrides } from "../../shared/shortcuts";
 import { useUiStore } from "../stores/ui-store";
 import type { WorkspaceSummary } from "../types/workspace";
 
@@ -47,6 +48,9 @@ const shellMocks = vi.hoisted(() => {
 			state.focusTerminalListener = listener;
 			return vi.fn();
 		}),
+		getKeybindings: vi.fn(async () => ({})),
+		setKeybindings: vi.fn(async (overrides: KeybindingOverrides) => overrides),
+		setKeybindingRecording: vi.fn(async () => undefined),
 		queryClient: {
 			ensureQueryData: vi.fn(),
 			fetchQuery: vi.fn(),
@@ -80,6 +84,11 @@ vi.mock("../lib/bridge", () => ({
 			onPreviousSessionShortcut: shellMocks.onPreviousSessionShortcut,
 			onNextSessionShortcut: shellMocks.onNextSessionShortcut,
 			onFocusTerminalShortcut: shellMocks.onFocusTerminalShortcut,
+		},
+		keybindings: {
+			get: shellMocks.getKeybindings,
+			set: shellMocks.setKeybindings,
+			setRecording: shellMocks.setKeybindingRecording,
 		},
 		window: {},
 	},

--- a/frontend/src/shared/shortcuts.test.ts
+++ b/frontend/src/shared/shortcuts.test.ts
@@ -9,7 +9,9 @@ import {
 	matchesNewShellTerminalShortcut,
 	matchesOpenSettingsShortcut,
 	matchesPreviousSessionShortcut,
-	shortcutKeys,
+	defaultShortcutBindings,
+	matchesShortcutBinding,
+	shortcutBindingValidationError,
 	type ShortcutChord,
 } from "./shortcuts";
 
@@ -127,10 +129,10 @@ describe("additional application shortcuts", () => {
 });
 
 describe("shortcut catalog", () => {
-	it("provides platform labels for every shortcut", () => {
+	it("provides runtime defaults for every shortcut on each platform", () => {
 		for (const shortcut of APP_SHORTCUTS) {
-			expect(shortcutKeys(shortcut, true).length).toBeGreaterThan(0);
-			expect(shortcutKeys(shortcut, false).length).toBeGreaterThan(0);
+			expect(defaultShortcutBindings(shortcut.id, true).length).toBeGreaterThan(0);
+			expect(defaultShortcutBindings(shortcut.id, false).length).toBeGreaterThan(0);
 		}
 	});
 
@@ -143,5 +145,28 @@ describe("shortcut catalog", () => {
 		expect(matchesAppShortcut("focus-terminal", chord({ key: "t", ctrl: true, shift: true }), false, overrides)).toBe(
 			false,
 		);
+	});
+});
+
+describe("shortcut binding matching and validation", () => {
+	it("matches either the logical key or physical code when both are available", () => {
+		const candidate = chord({ key: "`", code: "Backquote", ctrl: true });
+
+		expect(matchesShortcutBinding(chord({ key: "`", code: "IntlBackslash", ctrl: true }), candidate)).toBe(true);
+		expect(matchesShortcutBinding(chord({ key: "§", code: "Backquote", ctrl: true }), candidate)).toBe(true);
+	});
+
+	it("requires a modifier and reserves terminal-critical control chords", () => {
+		expect(shortcutBindingValidationError(chord({ key: "F6" }), false)).not.toBeNull();
+		expect(shortcutBindingValidationError(chord({ key: "c", ctrl: true }), false)).not.toBeNull();
+		expect(shortcutBindingValidationError(chord({ key: "v", ctrl: true, shift: true }), false)).not.toBeNull();
+		expect(shortcutBindingValidationError(chord({ key: "d", ctrl: true }), false)).not.toBeNull();
+		expect(shortcutBindingValidationError(chord({ key: "j", ctrl: true }), false)).toBeNull();
+	});
+
+	it("reserves common platform window and editing chords", () => {
+		expect(shortcutBindingValidationError(chord({ key: "q", meta: true }), true)).not.toBeNull();
+		expect(shortcutBindingValidationError(chord({ key: "F4", alt: true }), false)).not.toBeNull();
+		expect(shortcutBindingValidationError(chord({ key: "j", meta: true }), true)).toBeNull();
 	});
 });

--- a/frontend/src/shared/shortcuts.test.ts
+++ b/frontend/src/shared/shortcuts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	APP_SHORTCUTS,
+	matchesAppShortcut,
 	matchesFocusTerminalShortcut,
 	matchesKeyboardShortcutsHelpShortcut,
 	matchesNextSessionShortcut,
@@ -131,5 +132,16 @@ describe("shortcut catalog", () => {
 			expect(shortcutKeys(shortcut, true).length).toBeGreaterThan(0);
 			expect(shortcutKeys(shortcut, false).length).toBeGreaterThan(0);
 		}
+	});
+
+	it("uses a user override instead of the default binding", () => {
+		const overrides = {
+			"focus-terminal": [chord({ key: "j", ctrl: true })],
+		};
+
+		expect(matchesAppShortcut("focus-terminal", chord({ key: "j", ctrl: true }), false, overrides)).toBe(true);
+		expect(matchesAppShortcut("focus-terminal", chord({ key: "t", ctrl: true, shift: true }), false, overrides)).toBe(
+			false,
+		);
 	});
 });

--- a/frontend/src/shared/shortcuts.ts
+++ b/frontend/src/shared/shortcuts.ts
@@ -19,12 +19,25 @@ export type AppShortcutId =
 
 export type ShortcutCategory = "General" | "Navigation" | "Session";
 
+export type ShortcutBinding = {
+	key: string;
+	code?: string;
+	ctrl: boolean;
+	meta: boolean;
+	shift: boolean;
+	alt: boolean;
+};
+
+export type KeybindingOverrides = Partial<Record<AppShortcutId, readonly ShortcutBinding[]>>;
+
 export type ShortcutDefinition = {
 	id: AppShortcutId;
 	label: string;
 	category: ShortcutCategory;
 	mac: readonly string[];
 	windowsLinux: readonly string[];
+	/** Indexed project selection is a family of nine bindings, not one command. */
+	customizable?: boolean;
 };
 
 export const SHORTCUT_CATEGORIES: readonly ShortcutCategory[] = ["General", "Navigation", "Session"];
@@ -80,6 +93,7 @@ export const APP_SHORTCUTS: readonly ShortcutDefinition[] = [
 		category: "Navigation",
 		mac: ["⌘", "1–9"],
 		windowsLinux: ["Ctrl", "1–9"],
+		customizable: false,
 	},
 	{
 		id: "previous-session",
@@ -115,6 +129,113 @@ export function shortcutKeys(shortcut: ShortcutDefinition, isMac: boolean): read
 	return isMac ? shortcut.mac : shortcut.windowsLinux;
 }
 
+const binding = (
+	key: string,
+	modifiers: Partial<Pick<ShortcutBinding, "ctrl" | "meta" | "shift" | "alt" | "code">>,
+): ShortcutBinding => ({
+	key,
+	ctrl: false,
+	meta: false,
+	shift: false,
+	alt: false,
+	...modifiers,
+});
+
+export function defaultShortcutBindings(id: AppShortcutId, isMac: boolean): readonly ShortcutBinding[] {
+	switch (id) {
+		case "new-session":
+			return [isMac ? binding("n", { meta: true }) : binding("n", { ctrl: true, shift: true })];
+		case "new-shell-terminal":
+			// Preserve both the advertised create-terminal chord and the familiar
+			// VS Code toggle/focus alias.
+			return [
+				binding("`", { code: "Backquote", ctrl: true, shift: true }),
+				binding("`", { code: "Backquote", ctrl: true }),
+			];
+		case "keyboard-shortcuts":
+			return [isMac ? binding("/", { meta: true }) : binding("/", { ctrl: true })];
+		case "toggle-sidebar":
+			return [isMac ? binding("b", { meta: true }) : binding("b", { ctrl: true })];
+		case "open-project":
+			return [isMac ? binding("1-9", { meta: true }) : binding("1-9", { ctrl: true })];
+		case "toggle-inspector":
+			return [isMac ? binding("b", { meta: true, shift: true }) : binding("b", { ctrl: true, shift: true })];
+		case "command-palette":
+			return [isMac ? binding("k", { meta: true }) : binding("k", { ctrl: true })];
+		case "open-settings":
+			return [isMac ? binding(",", { meta: true }) : binding(",", { ctrl: true })];
+		case "previous-session":
+			return [isMac ? binding("ArrowUp", { meta: true, alt: true }) : binding("PageUp", { ctrl: true })];
+		case "next-session":
+			return [isMac ? binding("ArrowDown", { meta: true, alt: true }) : binding("PageDown", { ctrl: true })];
+		case "focus-terminal":
+			return [isMac ? binding("t", { meta: true, shift: true }) : binding("t", { ctrl: true, shift: true })];
+	}
+}
+
+export function effectiveShortcutBindings(
+	id: AppShortcutId,
+	isMac: boolean,
+	overrides: KeybindingOverrides = {},
+): readonly ShortcutBinding[] {
+	return overrides[id] ?? defaultShortcutBindings(id, isMac);
+}
+
+function normalizedKey(key: string): string {
+	if (key === "Up") return "arrowup";
+	if (key === "Down") return "arrowdown";
+	return key.toLowerCase();
+}
+
+export function matchesShortcutBinding(chord: ShortcutChord, candidate: ShortcutBinding): boolean {
+	const keyMatches =
+		candidate.key === "1-9"
+			? /^[1-9]$/.test(chord.key)
+			: candidate.code !== undefined
+				? chord.code !== undefined
+					? candidate.code === chord.code
+					: normalizedKey(candidate.key) === normalizedKey(chord.key) ||
+						normalizedKey(candidate.code) === normalizedKey(chord.key)
+				: normalizedKey(candidate.key) === normalizedKey(chord.key);
+	return (
+		keyMatches &&
+		chord.ctrl === candidate.ctrl &&
+		chord.meta === candidate.meta &&
+		chord.shift === candidate.shift &&
+		chord.alt === candidate.alt
+	);
+}
+
+export function matchesAppShortcut(
+	id: AppShortcutId,
+	chord: ShortcutChord,
+	isMac: boolean,
+	overrides: KeybindingOverrides = {},
+): boolean {
+	return effectiveShortcutBindings(id, isMac, overrides).some((candidate) => matchesShortcutBinding(chord, candidate));
+}
+
+export function shortcutBindingKeys(binding: ShortcutBinding, isMac: boolean): readonly string[] {
+	const keys: string[] = [];
+	if (binding.ctrl) keys.push("Ctrl");
+	if (binding.meta) keys.push(isMac ? "⌘" : "Meta");
+	if (binding.alt) keys.push(isMac ? "⌥" : "Alt");
+	if (binding.shift) keys.push("Shift");
+	const labels: Record<string, string> = {
+		ArrowUp: "↑",
+		ArrowDown: "↓",
+		PageUp: "PageUp",
+		PageDown: "PageDown",
+		Backquote: "`",
+	};
+	keys.push(labels[binding.code ?? binding.key] ?? binding.key.toUpperCase());
+	return keys;
+}
+
+export function shortcutBindingLabel(binding: ShortcutBinding, isMac: boolean): string {
+	return shortcutBindingKeys(binding, isMac).join(isMac ? "" : "+");
+}
+
 // IPC channel the main process uses to tell the renderer shell to open the New
 // Task flow. Lives here (not in main/) so the main process, preload, and
 // renderer can all reference one constant without crossing bundle boundaries.
@@ -132,10 +253,7 @@ export const FOCUS_TERMINAL_SHORTCUT_CHANNEL = "app:focus-terminal";
 // (main-process before-input-event) so it fires even when focus is inside
 // xterm's helper textarea or a native Browser-preview WebContentsView.
 export function matchesNewSessionShortcut(chord: ShortcutChord, isMac: boolean): boolean {
-	if (chord.key.toLowerCase() !== "n") return false;
-	return isMac
-		? chord.meta && !chord.ctrl && !chord.alt && !chord.shift
-		: chord.ctrl && chord.shift && !chord.alt && !chord.meta;
+	return matchesAppShortcut("new-session", chord, isMac);
 }
 
 // New standalone terminal, bound to the backtick chords VS Code / Cursor /
@@ -149,52 +267,28 @@ export function matchesNewSessionShortcut(chord: ShortcutChord, isMac: boolean):
 // tradeoff (no pane shell can receive these chords while AO owns them) matches
 // VS Code.
 export function matchesNewShellTerminalShortcut(chord: ShortcutChord, _isMac: boolean): boolean {
-	// Match on the physical `code` (Backquote), not the character: with Shift
-	// held the character is layout-shifted — US Ctrl+Shift+` reports key "~", not
-	// "`" — so keying off `key` would miss the advertised Ctrl+Shift+` chord. Fall
-	// back to the `key` spelling for chords supplied without a code. Shift is
-	// optional (Ctrl+` and Ctrl+Shift+` both open a terminal); ⌘/Alt must not hold.
-	const isBackquote = chord.code === "Backquote" || chord.key === "`" || chord.key === "Backquote";
-	if (!isBackquote) return false;
-	return chord.ctrl && !chord.meta && !chord.alt;
+	return matchesAppShortcut("new-shell-terminal", chord, _isMac);
 }
 
 // Keyboard shortcut help: ⌘/ on macOS, Ctrl+/ on Windows/Linux. This is also
 // handled at the application level so the terminal and Browser preview cannot
 // swallow the command before the shell sees it.
 export function matchesKeyboardShortcutsHelpShortcut(chord: ShortcutChord, isMac: boolean): boolean {
-	if (chord.key !== "/") return false;
-	return isMac
-		? chord.meta && !chord.ctrl && !chord.alt && !chord.shift
-		: chord.ctrl && !chord.meta && !chord.alt && !chord.shift;
+	return matchesAppShortcut("keyboard-shortcuts", chord, isMac);
 }
 
 export function matchesOpenSettingsShortcut(chord: ShortcutChord, isMac: boolean): boolean {
-	if (chord.key !== ",") return false;
-	return isMac
-		? chord.meta && !chord.ctrl && !chord.alt && !chord.shift
-		: chord.ctrl && !chord.meta && !chord.alt && !chord.shift;
+	return matchesAppShortcut("open-settings", chord, isMac);
 }
 
 export function matchesPreviousSessionShortcut(chord: ShortcutChord, isMac: boolean): boolean {
-	if (isMac) {
-		return (chord.key === "ArrowUp" || chord.key === "Up") && chord.meta && chord.alt && !chord.ctrl && !chord.shift;
-	}
-	return chord.key === "PageUp" && chord.ctrl && !chord.meta && !chord.alt && !chord.shift;
+	return matchesAppShortcut("previous-session", chord, isMac);
 }
 
 export function matchesNextSessionShortcut(chord: ShortcutChord, isMac: boolean): boolean {
-	if (isMac) {
-		return (
-			(chord.key === "ArrowDown" || chord.key === "Down") && chord.meta && chord.alt && !chord.ctrl && !chord.shift
-		);
-	}
-	return chord.key === "PageDown" && chord.ctrl && !chord.meta && !chord.alt && !chord.shift;
+	return matchesAppShortcut("next-session", chord, isMac);
 }
 
 export function matchesFocusTerminalShortcut(chord: ShortcutChord, isMac: boolean): boolean {
-	if (chord.key.toLowerCase() !== "t") return false;
-	return isMac
-		? chord.meta && chord.shift && !chord.ctrl && !chord.alt
-		: chord.ctrl && chord.shift && !chord.meta && !chord.alt;
+	return matchesAppShortcut("focus-terminal", chord, isMac);
 }

--- a/frontend/src/shared/shortcuts.ts
+++ b/frontend/src/shared/shortcuts.ts
@@ -34,100 +34,72 @@ export type ShortcutDefinition = {
 	id: AppShortcutId;
 	label: string;
 	category: ShortcutCategory;
-	mac: readonly string[];
-	windowsLinux: readonly string[];
 	/** Indexed project selection is a family of nine bindings, not one command. */
 	customizable?: boolean;
 };
 
 export const SHORTCUT_CATEGORIES: readonly ShortcutCategory[] = ["General", "Navigation", "Session"];
 
-// The user-facing shortcut catalog. Keep bindings here so the help dialog does
-// not duplicate platform labels from the handlers that implement them.
+// The user-facing shortcut catalog. Bindings live exclusively in
+// defaultShortcutBindings so runtime matching and displayed labels cannot drift.
 export const APP_SHORTCUTS: readonly ShortcutDefinition[] = [
 	{
 		id: "new-session",
 		label: "New session",
 		category: "General",
-		mac: ["⌘", "N"],
-		windowsLinux: ["Ctrl", "Shift", "N"],
 	},
 	{
 		id: "new-shell-terminal",
 		label: "New terminal",
 		category: "General",
-		mac: ["Ctrl", "Shift", "`"],
-		windowsLinux: ["Ctrl", "Shift", "`"],
 	},
 	{
 		id: "keyboard-shortcuts",
 		label: "Show keyboard shortcuts",
 		category: "General",
-		mac: ["⌘", "/"],
-		windowsLinux: ["Ctrl", "/"],
 	},
 	{
 		id: "command-palette",
 		label: "Open command palette",
 		category: "General",
-		mac: ["⌘", "K"],
-		windowsLinux: ["Ctrl", "K"],
 	},
 	{
 		id: "open-settings",
 		label: "Open settings",
 		category: "General",
-		mac: ["⌘", ","],
-		windowsLinux: ["Ctrl", ","],
 	},
 	{
 		id: "toggle-sidebar",
 		label: "Toggle sidebar",
 		category: "General",
-		mac: ["⌘", "B"],
-		windowsLinux: ["Ctrl", "B"],
 	},
 	{
 		id: "open-project",
 		label: "Open project 1–9",
 		category: "Navigation",
-		mac: ["⌘", "1–9"],
-		windowsLinux: ["Ctrl", "1–9"],
 		customizable: false,
 	},
 	{
 		id: "previous-session",
 		label: "Previous session",
 		category: "Navigation",
-		mac: ["⌘", "Alt", "↑"],
-		windowsLinux: ["Ctrl", "PageUp"],
 	},
 	{
 		id: "next-session",
 		label: "Next session",
 		category: "Navigation",
-		mac: ["⌘", "Alt", "↓"],
-		windowsLinux: ["Ctrl", "PageDown"],
 	},
 	{
 		id: "toggle-inspector",
 		label: "Toggle inspector",
 		category: "Session",
-		mac: ["⌘", "Shift", "B"],
-		windowsLinux: ["Ctrl", "Shift", "B"],
 	},
 	{
 		id: "focus-terminal",
 		label: "Focus terminal",
 		category: "Session",
-		mac: ["⌘", "Shift", "T"],
-		windowsLinux: ["Ctrl", "Shift", "T"],
 	},
 ];
-
-export function shortcutKeys(shortcut: ShortcutDefinition, isMac: boolean): readonly string[] {
-	return isMac ? shortcut.mac : shortcut.windowsLinux;
-}
 
 const binding = (
 	key: string,
@@ -191,19 +163,59 @@ export function matchesShortcutBinding(chord: ShortcutChord, candidate: Shortcut
 	const keyMatches =
 		candidate.key === "1-9"
 			? /^[1-9]$/.test(chord.key)
-			: candidate.code !== undefined
-				? chord.code !== undefined
-					? candidate.code === chord.code
-					: normalizedKey(candidate.key) === normalizedKey(chord.key) ||
-						normalizedKey(candidate.code) === normalizedKey(chord.key)
-				: normalizedKey(candidate.key) === normalizedKey(chord.key);
+			: normalizedKey(candidate.key) === normalizedKey(chord.key);
+	const codeMatches =
+		candidate.code !== undefined &&
+		(chord.code !== undefined
+			? normalizedKey(candidate.code) === normalizedKey(chord.code)
+			: normalizedKey(candidate.code) === normalizedKey(chord.key));
 	return (
-		keyMatches &&
+		(keyMatches || codeMatches) &&
 		chord.ctrl === candidate.ctrl &&
 		chord.meta === candidate.meta &&
 		chord.shift === candidate.shift &&
 		chord.alt === candidate.alt
 	);
+}
+
+/**
+ * Application shortcuts are intercepted before the focused terminal or text
+ * field sees them. Reject bindings that would consume ordinary input, terminal
+ * control sequences, or common OS editing/window commands.
+ */
+export function shortcutBindingValidationError(binding: ShortcutBinding, isMac: boolean): string | null {
+	if (
+		["alt", "altgraph", "capslock", "control", "dead", "meta", "numlock", "process", "scrolllock", "shift", "unidentified"].includes(
+			normalizedKey(binding.key),
+		)
+	) {
+		return "Press a non-modifier key with Ctrl, Alt, or Cmd.";
+	}
+	if (!binding.ctrl && !binding.meta && !binding.alt) {
+		return "Use Ctrl, Alt, or Cmd with another key.";
+	}
+
+	const key = normalizedKey(binding.key);
+	if (binding.ctrl && !binding.meta && !binding.alt) {
+		if (key === "c" || key === "v") {
+			return "That shortcut is reserved for terminal copy, paste, or interrupt.";
+		}
+		if (!binding.shift && ["d", "z", "\\", "s", "q"].includes(key)) {
+			return "That shortcut is reserved for terminal control.";
+		}
+	}
+
+	if (isMac && binding.meta && !binding.ctrl && !binding.alt) {
+		if (["a", "c", "h", "m", "q", "s", "v", "w", "x", "z"].includes(key)) {
+			return "That shortcut is reserved by macOS or standard editing commands.";
+		}
+	}
+
+	if (!isMac && binding.alt && !binding.ctrl && !binding.meta && key === "f4") {
+		return "That shortcut is reserved for closing the window.";
+	}
+
+	return null;
 }
 
 export function matchesAppShortcut(


### PR DESCRIPTION
## What

Add customizable application keyboard shortcuts while preserving the existing platform defaults.

Users can now:

- Open the keybinding editor from Settings or directly from the `Ctrl/Cmd+/` shortcut reference.
- Replace bindings or add up to two alternatives.
- Search commands by name, category, or key combination.
- Detect conflicts and explicitly reassign bindings.
- Remove or reset individual bindings.
- Reset all shortcuts to their defaults.
- Undo changes from an in-app confirmation toast.

The shortcut reference and sidebar hints display the effective user bindings.

## Why

Application shortcuts were previously hardcoded across the Electron main process and several renderer components. Users could not adapt them to their preferences, and displayed shortcut labels could drift from runtime behavior.

This provides one shared resolution path for built-in defaults and persisted user overrides.

## How

- Added shared default, effective-binding, matching, and display utilities.
- Persisted validated overrides atomically in `~/.ao/keybindings.json`.
- Passed live overrides through Electron shortcut interception, including browser preview web contents.
- Updated renderer-owned commands such as sidebar, command palette, project navigation, and inspector actions to use the shared matcher.
- Added a searchable keybinding editor with recording, conflict handling, alternatives, reset controls, hover tooltips, and toast feedback.
- Kept ordinary terminal and text-editing shortcuts outside the customizable application-command scope.
- Kept project `1–9` navigation fixed because it represents nine indexed actions rather than one rebindable command.

## Testing

- `npm run typecheck`
- `npx vitest run --config vite.renderer.config.ts src/shared/shortcuts.test.ts src/main/new-session-shortcut.test.ts src/main/keybinding-settings.test.ts src/renderer/components/KeyboardShortcutsDialog.test.tsx`
  - 39 tests passed.
- `npx vitest run --config vite.renderer.config.ts src/renderer/components/KeyboardShortcutsDialog.test.tsx`
  - 4 tests passed after adding the direct Customize action.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Remote CI checks pass

<img width="928" height="831" alt="Screenshot 2026-07-27 101053" src="https://github.com/user-attachments/assets/c876068c-29ce-45c4-9805-cde50d6388b4" />
<img width="707" height="828" alt="Screenshot 2026-07-27 101128" src="https://github.com/user-attachments/assets/d176bc8e-aff7-408e-bc06-76a99c374486" />
<img width="465" height="72" alt="Screenshot 2026-07-27 101208" src="https://github.com/user-attachments/assets/42e4492e-814f-407a-a68e-2dc6ced7fb60" />
<img width="553" height="257" alt="Screenshot 2026-07-27 101257" src="https://github.com/user-attachments/assets/c6cf46c9-770d-4c6a-bfa0-9b71884fd619" />
