### PR TITLE
feat(candidate-run): add observer lifecycle boundary

### DIFF
--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -114,7 +114,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	appendSessionHookFlags(&cmd)
 	appendTerminalCompatibilityFlags(&cmd)
 	appendWorkspaceTrustFlag(&cmd, cfg.WorkspacePath)
-	appendModelFlag(&cmd, cfg.Config)
+	appendExecutionProfileFlags(&cmd, cfg.Config)
 
 	if cfg.SystemPrompt != "" {
 		cmd = append(cmd, "-c", "developer_instructions="+codexTOMLConfigString(cfg.SystemPrompt))
@@ -156,7 +156,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	appendSessionHookFlags(&cmd)
 	appendTerminalCompatibilityFlags(&cmd)
 	appendWorkspaceTrustFlag(&cmd, cfg.Session.WorkspacePath)
-	appendModelFlag(&cmd, cfg.Config)
+	appendExecutionProfileFlags(&cmd, cfg.Config)
 	if cfg.SystemPrompt != "" {
 		cmd = append(cmd, "-c", "developer_instructions="+codexTOMLConfigString(cfg.SystemPrompt))
 	} else if cfg.SystemPromptFile != "" {
@@ -374,12 +374,6 @@ func appendTerminalCompatibilityFlags(cmd *[]string) {
 	}
 }
 
-func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
-	if model := strings.TrimSpace(cfg.Model); model != "" {
-		*cmd = append(*cmd, "--model", model)
-	}
-}
-
 func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
 	switch ports.NormalizePermissionMode(permissions) {
 	case ports.PermissionModeDefault:
@@ -393,6 +387,18 @@ func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
 		*cmd = append(*cmd, "--ask-for-approval", "on-request", "-c", `approvals_reviewer="auto_review"`)
 	case ports.PermissionModeBypassPermissions:
 		*cmd = append(*cmd, "--dangerously-bypass-approvals-and-sandbox")
+	}
+}
+
+func appendExecutionProfileFlags(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
+	if effort := strings.TrimSpace(cfg.Effort); effort != "" {
+		*cmd = append(*cmd, "-c", "model_reasoning_effort="+codexTOMLBasicString(effort))
+	}
+	if sandbox := strings.TrimSpace(cfg.Sandbox); sandbox != "" {
+		*cmd = append(*cmd, "--sandbox", sandbox)
 	}
 }
 

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -258,6 +258,37 @@ func TestGetLaunchCommandMapsApprovalModes(t *testing.T) {
 	}
 }
 
+func TestGetLaunchCommandBindsCandidateExecutionProfile(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "codex"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{
+			Model:   "gpt-5.6-codex",
+			Effort:  "high",
+			Sandbox: "workspace-write",
+		},
+		Permissions: ports.PermissionModeAcceptEdits,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"--model", "gpt-5.6-codex",
+		"-c", `model_reasoning_effort="high"`,
+		"--sandbox", "workspace-write",
+	}
+	if !containsSubsequence(cmd, want) {
+		t.Fatalf("command %#v does not contain the exact execution profile %#v", cmd, want)
+	}
+	if !containsSubsequence(cmd, []string{"--ask-for-approval", "on-request"}) {
+		t.Fatalf("command %#v does not enforce on-request approval", cmd)
+	}
+	if contains(cmd, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Fatalf("command %#v bypasses the candidate sandbox", cmd)
+	}
+}
+
 func TestAppendWorkspaceTrustFlagCoversLiteralAndResolvedPaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation needs extra privileges on Windows")
@@ -572,6 +603,43 @@ func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
 	}
 	if !containsSubsequence(cmd, []string{"--model", "gpt-5.4-mini"}) {
 		t.Fatalf("restore command %#v missing trimmed --model flag", cmd)
+	}
+}
+
+func TestGetRestoreCommandBindsCandidateExecutionProfile(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "codex"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{
+			Model:   "gpt-5.6-codex",
+			Effort:  "high",
+			Sandbox: "workspace-write",
+		},
+		Permissions: ports.PermissionModeAcceptEdits,
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "thread-123"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+
+	want := []string{
+		"--model", "gpt-5.6-codex",
+		"-c", `model_reasoning_effort="high"`,
+		"--sandbox", "workspace-write",
+	}
+	if !containsSubsequence(cmd, want) {
+		t.Fatalf("restore command %#v does not contain the exact execution profile %#v", cmd, want)
+	}
+	if !containsSubsequence(cmd, []string{"--ask-for-approval", "on-request"}) {
+		t.Fatalf("restore command %#v does not enforce on-request approval", cmd)
+	}
+	if contains(cmd, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Fatalf("restore command %#v bypasses the candidate sandbox", cmd)
 	}
 }
 

--- a/backend/internal/adapters/candidaterun/client.go
+++ b/backend/internal/adapters/candidaterun/client.go
@@ -75,18 +75,20 @@ type activationProfile struct {
 }
 
 type preparedRun struct {
-	CandidateSlug   string         `json:"candidateSlug"`
-	RunID           string         `json:"runId"`
-	Scenario        string         `json:"scenario"`
-	Repository      string         `json:"repository"`
-	ControllerOwner string         `json:"controllerOwner"`
-	Dispatcher      string         `json:"dispatcher"`
-	Tasks           []preparedTask `json:"tasks"`
+	CandidateSlug           string         `json:"candidateSlug"`
+	RunID                   string         `json:"runId"`
+	Scenario                string         `json:"scenario"`
+	Repository              string         `json:"repository"`
+	ControllerOwner         string         `json:"controllerOwner"`
+	Dispatcher              string         `json:"dispatcher"`
+	ActivationProfileDigest string         `json:"activationProfileDigest"`
+	Tasks                   []preparedTask `json:"tasks"`
 }
 
 type preparedTask struct {
 	Slot             string `json:"slot"`
 	IssueNumber      int    `json:"issueNumber"`
+	SchedulingOrder  *int   `json:"schedulingOrder"`
 	IdempotencyKey   string `json:"idempotencyKey"`
 	AllocationKey    string `json:"allocationKey"`
 	SourceWriterMode string `json:"sourceWriterMode"`
@@ -637,6 +639,15 @@ func loadBinding(configPath string) (binding, error) {
 	}
 	if cfg.prepared.RunID == "" || cfg.prepared.Repository == "" || cfg.prepared.ControllerOwner == "" || cfg.prepared.Dispatcher == "" || len(cfg.prepared.Tasks) == 0 {
 		return binding{}, errors.New("candidate run prepared binding is incomplete")
+	}
+	if !sha256Pattern.MatchString(cfg.prepared.ActivationProfileDigest) {
+		return binding{}, errors.New("candidate run prepared activation profile digest is invalid")
+	}
+	for i := range cfg.prepared.Tasks {
+		order := cfg.prepared.Tasks[i].SchedulingOrder
+		if order == nil || *order != i {
+			return binding{}, fmt.Errorf("candidate run prepared task %d scheduling order must be %d", i+1, i)
+		}
 	}
 	if cfg.ControllerClaim.EventID == "" || cfg.ControllerClaim.ClaimID == "" {
 		return binding{}, errors.New("candidate run controller claim is incomplete")

--- a/backend/internal/adapters/candidaterun/client.go
+++ b/backend/internal/adapters/candidaterun/client.go
@@ -1,0 +1,686 @@
+// Package candidaterun connects Agent Orchestrator to the external
+// digest-bound fixture candidate-run kernel in observer mode. AO remains the
+// dispatcher; the sidecar can only configure the run journal and observe
+// AO-native lifecycle facts.
+package candidaterun
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+//go:embed observer.mjs
+var observerProgram string
+
+var (
+	sha256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	issuePattern  = regexp.MustCompile(`^github:([^/\s]+/[^#\s]+)#([1-9]\d*)$`)
+)
+
+type binding struct {
+	SchemaVersion    int             `json:"schemaVersion"`
+	NodeBinary       string          `json:"nodeBinary"`
+	JournalDirectory string          `json:"journalDirectory"`
+	Kernel           kernelBinding   `json:"kernel"`
+	ControllerClaim  controllerClaim `json:"controllerClaim"`
+	Codex            codexBinding    `json:"codex"`
+	ActivationRaw    json.RawMessage `json:"activationProfile"`
+	PreparedRaw      json.RawMessage `json:"prepared"`
+	activation       activationProfile
+	prepared         preparedRun
+}
+
+type kernelBinding struct {
+	ModulePath string `json:"modulePath"`
+	SHA256     string `json:"sha256"`
+}
+
+type controllerClaim struct {
+	EventID   string `json:"eventId"`
+	ClaimID   string `json:"claimId"`
+	ClaimedAt string `json:"claimedAt"`
+}
+
+type codexBinding struct {
+	Harness        string `json:"harness"`
+	ApprovalPolicy string `json:"approvalPolicy"`
+}
+
+type activationProfile struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	CandidateSlug string `json:"candidateSlug"`
+	Model         string `json:"model"`
+	Effort        string `json:"effort"`
+	Sandbox       string `json:"sandbox"`
+}
+
+type preparedRun struct {
+	CandidateSlug   string         `json:"candidateSlug"`
+	RunID           string         `json:"runId"`
+	Scenario        string         `json:"scenario"`
+	Repository      string         `json:"repository"`
+	ControllerOwner string         `json:"controllerOwner"`
+	Dispatcher      string         `json:"dispatcher"`
+	Tasks           []preparedTask `json:"tasks"`
+}
+
+type preparedTask struct {
+	Slot             string `json:"slot"`
+	IssueNumber      int    `json:"issueNumber"`
+	IdempotencyKey   string `json:"idempotencyKey"`
+	AllocationKey    string `json:"allocationKey"`
+	SourceWriterMode string `json:"sourceWriterMode"`
+	Branch           string `json:"branch"`
+}
+
+type readyFrame struct {
+	Type                 string `json:"type"`
+	ControllerInstanceID string `json:"controllerInstanceId"`
+}
+
+type responseFrame struct {
+	ID     int64           `json:"id"`
+	OK     bool            `json:"ok"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}
+
+type observedTask struct {
+	claim          ports.CandidateRunClaim
+	receipt        ports.CandidateRunAllocationReceipt
+	startRequested bool
+	started        bool
+	stopped        bool
+	pullRequests   map[string]bool
+}
+
+// Client owns one long-lived observer sidecar and serializes all frames over
+// its stdio pipes. It is safe for concurrent callers.
+type Client struct {
+	binding              binding
+	controllerInstanceID string
+	command              *exec.Cmd
+	stdin                io.WriteCloser
+	scanner              *bufio.Scanner
+	stderr               *bytes.Buffer
+	logger               *slog.Logger
+	clock                func() time.Time
+
+	mu       sync.Mutex
+	nextID   int64
+	closed   bool
+	stateMu  sync.Mutex
+	claimed  map[string]ports.CandidateRunClaim
+	sessions map[domain.SessionID]*observedTask
+}
+
+var _ ports.CandidateRunStarter = (*Client)(nil)
+
+// Open validates the non-secret binding, starts the embedded observer bridge,
+// and waits for the kernel's durable run-configuration acknowledgement.
+func Open(ctx context.Context, configPath string, logger *slog.Logger) (*Client, error) {
+	cfg, err := loadBinding(configPath)
+	if err != nil {
+		return nil, err
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	cmd := exec.CommandContext(
+		ctx,
+		cfg.NodeBinary,
+		"--input-type=module",
+		"--eval",
+		observerProgram,
+		"--",
+		configPath,
+	)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("candidate run observer stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("candidate run observer stdout: %w", err)
+	}
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("candidate run observer start: %w", err)
+	}
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	if !scanner.Scan() {
+		waitErr := cmd.Wait()
+		return nil, sidecarExitError("candidate run observer configure", scanner.Err(), waitErr, stderr.String())
+	}
+	var ready readyFrame
+	if err := json.Unmarshal(scanner.Bytes(), &ready); err != nil {
+		_ = stdin.Close()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("candidate run observer ready frame: %w", err)
+	}
+	if ready.Type != "ready" || strings.TrimSpace(ready.ControllerInstanceID) == "" {
+		_ = stdin.Close()
+		_ = cmd.Wait()
+		return nil, errors.New("candidate run observer returned an invalid ready frame")
+	}
+	return &Client{
+		binding:              cfg,
+		controllerInstanceID: ready.ControllerInstanceID,
+		command:              cmd,
+		stdin:                stdin,
+		scanner:              scanner,
+		stderr:               stderr,
+		logger:               logger,
+		clock:                func() time.Time { return time.Now().UTC() },
+		claimed:              map[string]ports.CandidateRunClaim{},
+		sessions:             map[domain.SessionID]*observedTask{},
+	}, nil
+}
+
+// ExecutionProfile returns the exact non-secret Codex runtime binding.
+func (c *Client) ExecutionProfile() ports.CandidateRunExecutionProfile {
+	return ports.CandidateRunExecutionProfile{
+		Harness:        domain.AgentHarness(c.binding.Codex.Harness),
+		Model:          c.binding.activation.Model,
+		Effort:         c.binding.activation.Effort,
+		Sandbox:        c.binding.activation.Sandbox,
+		ApprovalPolicy: c.binding.Codex.ApprovalPolicy,
+	}
+}
+
+// Claim durably acknowledges AO's task claim before any session row or native
+// workspace can be created.
+func (c *Client) Claim(ctx context.Context, request ports.CandidateRunClaimRequest) (ports.CandidateRunClaim, error) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	repository, issueNumber, err := parseCanonicalIssueID(request.IssueID)
+	if err != nil {
+		return ports.CandidateRunClaim{}, err
+	}
+	if repository != c.binding.prepared.Repository {
+		return ports.CandidateRunClaim{}, fmt.Errorf("candidate run issue repository %q does not match prepared repository", repository)
+	}
+	var task *preparedTask
+	for i := range c.binding.prepared.Tasks {
+		if c.binding.prepared.Tasks[i].IssueNumber == issueNumber {
+			task = &c.binding.prepared.Tasks[i]
+			break
+		}
+	}
+	if task == nil {
+		return ports.CandidateRunClaim{}, fmt.Errorf("candidate run issue %d is not a prepared task", issueNumber)
+	}
+	if branch := strings.TrimSpace(request.RequestedBranch); branch != "" && branch != task.Branch {
+		return ports.CandidateRunClaim{}, fmt.Errorf("candidate run requested branch %q does not match prepared branch %q", branch, task.Branch)
+	}
+	if _, exists := c.claimed[task.Slot]; exists {
+		return ports.CandidateRunClaim{}, fmt.Errorf("candidate run task %s is already claimed by this AO process", task.Slot)
+	}
+	instanceDigest := sha256.Sum256([]byte(c.controllerInstanceID))
+	claim := ports.CandidateRunClaim{
+		Slot:                 task.Slot,
+		ClaimID:              fmt.Sprintf("agent-orchestrator:%s:%s:%s", c.binding.prepared.RunID, task.Slot, hex.EncodeToString(instanceDigest[:6])),
+		ControllerInstanceID: c.controllerInstanceID,
+		Repository:           c.binding.prepared.Repository,
+		IssueNumber:          task.IssueNumber,
+		Branch:               task.Branch,
+		AllocationKey:        task.AllocationKey,
+		IdempotencyKey:       task.IdempotencyKey,
+		SourceWriterMode:     task.SourceWriterMode,
+	}
+	at := c.clock().UTC().Format(time.RFC3339Nano)
+	event := map[string]any{
+		"eventId": "claim:" + task.Slot + ":" + hex.EncodeToString(instanceDigest[:6]),
+		"type":    "task-claimed",
+		"slot":    task.Slot,
+		"at":      at,
+		"payload": map[string]any{
+			"claimId":                    claim.ClaimID,
+			"dispatcher":                 c.binding.prepared.Dispatcher,
+			"controllerInstanceId":       c.controllerInstanceID,
+			"continuationTriggerEventId": nil,
+			"allocationKey":              task.AllocationKey,
+			"idempotencyKey":             task.IdempotencyKey,
+		},
+	}
+	if err := c.observe(ctx, event); err != nil {
+		return ports.CandidateRunClaim{}, fmt.Errorf("candidate run claim %s: %w", task.Slot, err)
+	}
+	c.claimed[task.Slot] = claim
+	return claim, nil
+}
+
+// RecordAllocation records the native worktree result before AO provisions the
+// workspace or asks an agent adapter for a launch command.
+func (c *Client) RecordAllocation(
+	ctx context.Context,
+	claim ports.CandidateRunClaim,
+	sessionID domain.SessionID,
+	workspace string,
+) error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	preparedClaim, ok := c.claimed[claim.Slot]
+	if !ok || preparedClaim.ClaimID != claim.ClaimID {
+		return fmt.Errorf("candidate run allocation has no acknowledged claim for slot %s", claim.Slot)
+	}
+	if strings.TrimSpace(string(sessionID)) == "" {
+		return errors.New("candidate run allocation runtime task ID is required")
+	}
+	if !filepath.IsAbs(workspace) {
+		return errors.New("candidate run allocation workspace must be absolute")
+	}
+	if _, exists := c.sessions[sessionID]; exists {
+		return fmt.Errorf("candidate run session %s already has an allocation", sessionID)
+	}
+	receipt := ports.CandidateRunAllocationReceipt{
+		SchemaVersion:   1,
+		Slot:            claim.Slot,
+		AllocationKey:   claim.AllocationKey,
+		ClaimID:         claim.ClaimID,
+		RuntimeTaskID:   string(sessionID),
+		RuntimeHostID:   nil,
+		Workspace:       workspace,
+		RequestedBranch: claim.Branch,
+		SourceWriter:    "agent-orchestrator:" + string(sessionID),
+		AllocatedAt:     c.clock().UTC().Format(time.RFC3339Nano),
+	}
+	event := map[string]any{
+		"eventId": "allocation:" + claim.Slot + ":" + claim.ClaimID,
+		"type":    "task-allocated",
+		"slot":    claim.Slot,
+		"at":      receipt.AllocatedAt,
+		"payload": map[string]any{"allocationReceipt": receipt},
+	}
+	if err := c.observe(ctx, event); err != nil {
+		return fmt.Errorf("candidate run allocation %s: %w", claim.Slot, err)
+	}
+	c.sessions[sessionID] = &observedTask{
+		claim:        claim,
+		receipt:      receipt,
+		pullRequests: map[string]bool{},
+	}
+	return nil
+}
+
+// RecordSessionStartRequested records runtime launch intent synchronously
+// before AO invokes the native runtime adapter.
+func (c *Client) RecordSessionStartRequested(ctx context.Context, sessionID domain.SessionID) error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	task, ok := c.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("candidate run session %s has no allocation", sessionID)
+	}
+	if task.startRequested {
+		return fmt.Errorf("candidate run session %s already recorded start intent", sessionID)
+	}
+	at := c.clock().UTC().Format(time.RFC3339Nano)
+	event := map[string]any{
+		"eventId": "session-start-request:" + task.claim.Slot + ":" + task.claim.ClaimID,
+		"type":    "session-start-requested",
+		"slot":    task.claim.Slot,
+		"at":      at,
+		"payload": map[string]any{
+			"allocationReceiptDigest": canonicalDigest(task.receipt),
+			"claimId":                 task.claim.ClaimID,
+			"dispatcher":              c.binding.prepared.Dispatcher,
+			"mode":                    "observer",
+		},
+	}
+	if err := c.observe(ctx, event); err != nil {
+		return fmt.Errorf("candidate run start intent %s: %w", sessionID, err)
+	}
+	task.startRequested = true
+	return nil
+}
+
+// RecordSessionStarted records the returned native runtime handle after
+// RecordSessionStartRequested has been durably acknowledged.
+func (c *Client) RecordSessionStarted(ctx context.Context, sessionID domain.SessionID) error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	task, ok := c.sessions[sessionID]
+	if !ok || !task.startRequested {
+		return fmt.Errorf("candidate run session %s has no acknowledged start intent", sessionID)
+	}
+	if task.started {
+		return fmt.Errorf("candidate run session %s is already started", sessionID)
+	}
+	at := c.clock().UTC().Format(time.RFC3339Nano)
+	event := map[string]any{
+		"eventId": "session:" + task.claim.Slot + ":" + task.claim.ClaimID,
+		"type":    "session-started",
+		"slot":    task.claim.Slot,
+		"at":      at,
+		"payload": map[string]any{"sessionId": string(sessionID)},
+	}
+	if err := c.observe(ctx, event); err != nil {
+		return fmt.Errorf("candidate run session started %s: %w", sessionID, err)
+	}
+	task.started = true
+	return nil
+}
+
+// RecordPullRequest records a provider observation only after AO's own session
+// has started. Repository, issue, and branch binding are revalidated by the
+// external kernel before the event is acknowledged.
+func (c *Client) RecordPullRequest(
+	ctx context.Context,
+	sessionID domain.SessionID,
+	observation ports.SCMObservation,
+) error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	task, ok := c.sessions[sessionID]
+	if !ok || !task.started {
+		return fmt.Errorf("candidate run session %s is not started", sessionID)
+	}
+	url := strings.TrimSpace(observation.PR.URL)
+	if url == "" {
+		url = strings.TrimSpace(observation.PR.HTMLURL)
+	}
+	if observation.PR.Number < 1 || url == "" {
+		return errors.New("candidate run pull request number and URL are required")
+	}
+	if task.pullRequests[url] {
+		return nil
+	}
+	at := observation.ObservedAt.UTC()
+	if at.IsZero() {
+		at = c.clock().UTC()
+	}
+	event := map[string]any{
+		"eventId": fmt.Sprintf("pr:%s:%d", task.claim.Slot, observation.PR.Number),
+		"type":    "pull-request-opened",
+		"slot":    task.claim.Slot,
+		"at":      at.Format(time.RFC3339Nano),
+		"payload": map[string]any{
+			"repository":  observation.Repo,
+			"issueNumber": task.claim.IssueNumber,
+			"branch":      observation.PR.SourceBranch,
+			"url":         url,
+		},
+	}
+	if err := c.observe(ctx, event); err != nil {
+		return fmt.Errorf("candidate run pull request %s: %w", url, err)
+	}
+	task.pullRequests[url] = true
+	return nil
+}
+
+// RecordStopped appends worker and zero-running-descendant evidence only after
+// the native runtime adapter has returned a complete teardown proof.
+func (c *Client) RecordStopped(
+	ctx context.Context,
+	sessionID domain.SessionID,
+	reason string,
+	proof ports.RuntimeStopProof,
+) error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	task, ok := c.sessions[sessionID]
+	if !ok || !task.started {
+		return fmt.Errorf("candidate run session %s is not started", sessionID)
+	}
+	if task.stopped {
+		return nil
+	}
+	if strings.TrimSpace(reason) == "" || strings.TrimSpace(proof.ProcessID) == "" {
+		return errors.New("candidate run stop reason and process ID are required")
+	}
+	if proof.DescendantsRunning != 0 {
+		return fmt.Errorf("candidate run stop has %d running descendants", proof.DescendantsRunning)
+	}
+	for _, id := range proof.DescendantIDs {
+		if strings.TrimSpace(id) == "" {
+			return errors.New("candidate run stop descendant IDs must be nonblank")
+		}
+	}
+	at := c.clock().UTC().Format(time.RFC3339Nano)
+	workerEvent := map[string]any{
+		"eventId": "stop:" + task.claim.Slot + ":" + string(sessionID),
+		"type":    "worker-stopped",
+		"slot":    task.claim.Slot,
+		"at":      at,
+		"payload": map[string]any{
+			"processId": proof.ProcessID,
+			"reason":    reason,
+			"sessionId": string(sessionID),
+		},
+	}
+	if err := c.observe(ctx, workerEvent); err != nil {
+		return fmt.Errorf("candidate run worker stop %s: %w", sessionID, err)
+	}
+	descendantEvent := map[string]any{
+		"eventId": "descendants:" + task.claim.Slot + ":" + string(sessionID),
+		"type":    "descendants-stopped",
+		"slot":    task.claim.Slot,
+		"at":      at,
+		"payload": map[string]any{
+			"descendantIds":      proof.DescendantIDs,
+			"descendantsRunning": proof.DescendantsRunning,
+			"processId":          proof.ProcessID,
+		},
+	}
+	if err := c.observe(ctx, descendantEvent); err != nil {
+		return fmt.Errorf("candidate run descendant stop %s: %w", sessionID, err)
+	}
+	task.stopped = true
+	return nil
+}
+
+func (c *Client) observe(ctx context.Context, event map[string]any) error {
+	var result json.RawMessage
+	return c.request(ctx, "observe", map[string]any{"event": event}, &result)
+}
+
+func canonicalDigest(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	var canonical any
+	if err := json.Unmarshal(raw, &canonical); err != nil {
+		panic(err)
+	}
+	raw, err = json.Marshal(canonical)
+	if err != nil {
+		panic(err)
+	}
+	digest := sha256.Sum256(raw)
+	return hex.EncodeToString(digest[:])
+}
+
+func (c *Client) request(ctx context.Context, method string, params, result any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if c.closed {
+		return errors.New("candidate run observer is closed")
+	}
+	c.nextID++
+	request := map[string]any{"id": c.nextID, "method": method, "params": params}
+	frame, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+	if _, err := c.stdin.Write(append(frame, '\n')); err != nil {
+		return fmt.Errorf("candidate run observer write: %w", err)
+	}
+	if !c.scanner.Scan() {
+		return sidecarExitError("candidate run observer response", c.scanner.Err(), nil, c.stderr.String())
+	}
+	var response responseFrame
+	if err := json.Unmarshal(c.scanner.Bytes(), &response); err != nil {
+		return fmt.Errorf("candidate run observer response frame: %w", err)
+	}
+	if response.ID != c.nextID {
+		return fmt.Errorf("candidate run observer response id %d does not match request %d", response.ID, c.nextID)
+	}
+	if !response.OK {
+		if strings.TrimSpace(response.Error) == "" {
+			return errors.New("candidate run observer rejected request")
+		}
+		return errors.New(response.Error)
+	}
+	if result != nil && len(response.Result) > 0 {
+		if err := json.Unmarshal(response.Result, result); err != nil {
+			return fmt.Errorf("candidate run observer result: %w", err)
+		}
+	}
+	return nil
+}
+
+// Close ends the sidecar without issuing a kernel stop operation. Observer mode
+// owns no run stop authority.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	stdin := c.stdin
+	cmd := c.command
+	c.mu.Unlock()
+	if err := stdin.Close(); err != nil {
+		return fmt.Errorf("candidate run observer close stdin: %w", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		return sidecarExitError("candidate run observer exit", nil, err, c.stderr.String())
+	}
+	return nil
+}
+
+func loadBinding(configPath string) (binding, error) {
+	if !filepath.IsAbs(configPath) {
+		return binding{}, errors.New("candidate run config path must be absolute")
+	}
+	info, err := os.Lstat(configPath)
+	if err != nil {
+		return binding{}, fmt.Errorf("candidate run config: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return binding{}, errors.New("candidate run config must be a regular non-link file")
+	}
+	file, err := os.Open(configPath)
+	if err != nil {
+		return binding{}, fmt.Errorf("candidate run config: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	decoder := json.NewDecoder(io.LimitReader(file, 2*1024*1024))
+	decoder.DisallowUnknownFields()
+	var cfg binding
+	if err := decoder.Decode(&cfg); err != nil {
+		return binding{}, fmt.Errorf("candidate run config: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return binding{}, err
+	}
+	if cfg.SchemaVersion != 1 {
+		return binding{}, errors.New("candidate run config schemaVersion must be 1")
+	}
+	if err := json.Unmarshal(cfg.ActivationRaw, &cfg.activation); err != nil {
+		return binding{}, fmt.Errorf("candidate run activation profile: %w", err)
+	}
+	if err := json.Unmarshal(cfg.PreparedRaw, &cfg.prepared); err != nil {
+		return binding{}, fmt.Errorf("candidate run prepared binding: %w", err)
+	}
+	for label, value := range map[string]string{
+		"node binary":       cfg.NodeBinary,
+		"journal directory": cfg.JournalDirectory,
+		"kernel module":     cfg.Kernel.ModulePath,
+	} {
+		if !filepath.IsAbs(value) {
+			return binding{}, fmt.Errorf("candidate run %s path must be absolute", label)
+		}
+	}
+	if !sha256Pattern.MatchString(cfg.Kernel.SHA256) {
+		return binding{}, errors.New("candidate run kernel sha256 is invalid")
+	}
+	if cfg.activation.SchemaVersion != 2 {
+		return binding{}, errors.New("candidate run activation profile must use schemaVersion 2")
+	}
+	if cfg.activation.CandidateSlug == "" || cfg.activation.CandidateSlug != cfg.prepared.CandidateSlug {
+		return binding{}, errors.New("candidate run activation and prepared candidate slugs do not match")
+	}
+	if cfg.Codex.Harness != "codex" || cfg.Codex.ApprovalPolicy != "on-request" {
+		return binding{}, errors.New("candidate run Codex binding must use codex with on-request approval")
+	}
+	if cfg.activation.Model == "" || cfg.activation.Effort == "" || cfg.activation.Sandbox != "workspace-write" {
+		return binding{}, errors.New("candidate run activation profile must bind model, effort, and workspace-write sandbox")
+	}
+	if cfg.prepared.RunID == "" || cfg.prepared.Repository == "" || cfg.prepared.ControllerOwner == "" || cfg.prepared.Dispatcher == "" || len(cfg.prepared.Tasks) == 0 {
+		return binding{}, errors.New("candidate run prepared binding is incomplete")
+	}
+	if cfg.ControllerClaim.EventID == "" || cfg.ControllerClaim.ClaimID == "" {
+		return binding{}, errors.New("candidate run controller claim is incomplete")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, cfg.ControllerClaim.ClaimedAt); err != nil {
+		return binding{}, errors.New("candidate run controller claimedAt must be ISO")
+	}
+	return cfg, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err == io.EOF {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("candidate run config: %w", err)
+	}
+	return errors.New("candidate run config contains trailing JSON")
+}
+
+func parseCanonicalIssueID(issueID domain.IssueID) (string, int, error) {
+	match := issuePattern.FindStringSubmatch(string(issueID))
+	if match == nil {
+		return "", 0, fmt.Errorf("candidate run issue ID %q is not canonical GitHub owner/repo#number", issueID)
+	}
+	number, err := strconv.Atoi(match[2])
+	if err != nil {
+		return "", 0, fmt.Errorf("candidate run issue ID %q has an invalid number", issueID)
+	}
+	return match[1], number, nil
+}
+
+func sidecarExitError(prefix string, scanErr, waitErr error, stderr string) error {
+	detail := strings.TrimSpace(stderr)
+	switch {
+	case scanErr != nil:
+		return fmt.Errorf("%s: %w", prefix, scanErr)
+	case detail != "" && waitErr != nil:
+		return fmt.Errorf("%s: %w: %s", prefix, waitErr, detail)
+	case detail != "":
+		return fmt.Errorf("%s: %s", prefix, detail)
+	case waitErr != nil:
+		return fmt.Errorf("%s: %w", prefix, waitErr)
+	default:
+		return fmt.Errorf("%s: sidecar closed without a frame", prefix)
+	}
+}

--- a/backend/internal/adapters/candidaterun/client_test.go
+++ b/backend/internal/adapters/candidaterun/client_test.go
@@ -317,6 +317,69 @@ func TestObserverSidecarRejectsKernelDigestDrift(t *testing.T) {
 	}
 }
 
+func TestLoadBindingRequiresActivationProfileDigest(t *testing.T) {
+	configPath := writeTestConfig(t)
+	mutateTestConfig(t, configPath, func(config map[string]any) {
+		delete(config["prepared"].(map[string]any), "activationProfileDigest")
+	})
+
+	_, err := loadBinding(configPath)
+	if err == nil || !strings.Contains(err.Error(), "activation profile digest") {
+		t.Fatalf("loadBinding error = %v, want missing activation profile digest rejection", err)
+	}
+}
+
+func TestObserverSidecarRejectsActivationProfileDigestDrift(t *testing.T) {
+	configPath := writeTestConfig(t)
+	mutateTestConfig(t, configPath, func(config map[string]any) {
+		config["prepared"].(map[string]any)["activationProfileDigest"] =
+			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	})
+
+	client, err := Open(context.Background(), configPath, nil)
+	if err == nil {
+		_ = client.Close()
+		t.Fatal("Open error = nil, want canonical activation profile digest rejection")
+	}
+	if !strings.Contains(err.Error(), "activation profile digest drifted") {
+		t.Fatalf("Open error = %v, want canonical activation profile digest rejection", err)
+	}
+}
+
+func TestLoadBindingRequiresZeroBasedSchedulingOrder(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(task map[string]any)
+	}{
+		{
+			name: "missing",
+			mutate: func(task map[string]any) {
+				delete(task, "schedulingOrder")
+			},
+		},
+		{
+			name: "drifted",
+			mutate: func(task map[string]any) {
+				task["schedulingOrder"] = 1
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			configPath := writeTestConfig(t)
+			mutateTestConfig(t, configPath, func(config map[string]any) {
+				task := config["prepared"].(map[string]any)["tasks"].([]any)[0].(map[string]any)
+				test.mutate(task)
+			})
+
+			_, err := loadBinding(configPath)
+			if err == nil || !strings.Contains(err.Error(), "scheduling order") {
+				t.Fatalf("loadBinding error = %v, want %s scheduling order rejection", err, test.name)
+			}
+		})
+	}
+}
+
 func writeTestConfig(t *testing.T) string {
 	t.Helper()
 	nodeBinary, err := exec.LookPath("node")
@@ -338,6 +401,25 @@ func writeTestConfig(t *testing.T) string {
 	moduleDigest := sha256.Sum256(moduleBytes)
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "candidate-run.json")
+	activationProfile := map[string]any{
+		"schemaVersion":    2,
+		"candidateSlug":    "agent-orchestrator",
+		"candidateVersion": "0.10.3",
+		"adapterRevision":  "c89414ddb8cf4dc35e77417907e1ea663b79cf6b",
+		"adapterDigest":    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"workerRuntime":    "Codex CLI",
+		"modelProvider":    "OpenAI",
+		"modelAuthRoute":   "enterprise Codex subscription",
+		"authStatus":       "available",
+		"authStateScope":   "shared",
+		"model":            "gpt-5.6-codex",
+		"effort":           "high",
+		"sandbox":          "workspace-write",
+		"privacyPosture":   "enterprise policy",
+		"meteringPosture":  "subscription quota",
+		"lastVerifiedAt":   "2026-07-26T20:00:00.000Z",
+		"nextAuthAction":   "none",
+	}
 	config := map[string]any{
 		"schemaVersion":    1,
 		"nodeBinary":       nodeBinary,
@@ -355,25 +437,7 @@ func writeTestConfig(t *testing.T) string {
 			"harness":        "codex",
 			"approvalPolicy": "on-request",
 		},
-		"activationProfile": map[string]any{
-			"schemaVersion":    2,
-			"candidateSlug":    "agent-orchestrator",
-			"candidateVersion": "0.10.3",
-			"adapterRevision":  "c89414ddb8cf4dc35e77417907e1ea663b79cf6b",
-			"adapterDigest":    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			"workerRuntime":    "Codex CLI",
-			"modelProvider":    "OpenAI",
-			"modelAuthRoute":   "enterprise Codex subscription",
-			"authStatus":       "available",
-			"authStateScope":   "shared",
-			"model":            "gpt-5.6-codex",
-			"effort":           "high",
-			"sandbox":          "workspace-write",
-			"privacyPosture":   "enterprise policy",
-			"meteringPosture":  "subscription quota",
-			"lastVerifiedAt":   "2026-07-26T20:00:00.000Z",
-			"nextAuthAction":   "none",
-		},
+		"activationProfile": activationProfile,
 		"prepared": map[string]any{
 			"candidateSlug":      "agent-orchestrator",
 			"runId":              "AO-S1-001",
@@ -385,9 +449,13 @@ func writeTestConfig(t *testing.T) string {
 			"workspaceAllocator": "agent-orchestrator-worktree",
 			"initiationMode":     "automatic",
 			"workerLimit":        1,
+			"activationProfileDigest": canonicalDigest(
+				activationProfile,
+			),
 			"tasks": []map[string]any{{
 				"slot":             "A",
 				"issueNumber":      21,
+				"schedulingOrder":  0,
 				"idempotencyKey":   "agent-orchestrator:AO-S1-001:S1:A",
 				"allocationKey":    "agent-orchestrator:AO-S1-001:S1:A",
 				"workspaceMode":    "native-after-claim",
@@ -407,6 +475,26 @@ func writeTestConfig(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return configPath
+}
+
+func mutateTestConfig(t *testing.T, configPath string, mutate func(map[string]any)) {
+	t.Helper()
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(raw, &config); err != nil {
+		t.Fatal(err)
+	}
+	mutate(config)
+	raw, err = json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func readTestJournal(t *testing.T, dir string) []map[string]any {

--- a/backend/internal/adapters/candidaterun/client_test.go
+++ b/backend/internal/adapters/candidaterun/client_test.go
@@ -407,6 +407,7 @@ func writeTestConfig(t *testing.T) string {
 		"candidateVersion": "0.10.3",
 		"adapterRevision":  "c89414ddb8cf4dc35e77417907e1ea663b79cf6b",
 		"adapterDigest":    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"adapterArtifact":  "backend/internal/adapters/candidaterun/observer.mjs",
 		"workerRuntime":    "Codex CLI",
 		"modelProvider":    "OpenAI",
 		"modelAuthRoute":   "enterprise Codex subscription",

--- a/backend/internal/adapters/candidaterun/client_test.go
+++ b/backend/internal/adapters/candidaterun/client_test.go
@@ -1,0 +1,437 @@
+package candidaterun
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestObserverClientAcknowledgesClaimBeforeAllocation(t *testing.T) {
+	configPath := writeTestConfig(t)
+	client, err := Open(context.Background(), configPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+	client.clock = func() time.Time {
+		return time.Date(2026, 7, 26, 20, 1, 0, 0, time.UTC)
+	}
+
+	claim, err := client.Claim(context.Background(), ports.CandidateRunClaimRequest{
+		ProjectID:       "fixture",
+		IssueID:         "github:taymoork2/tenetfold-orchestration-fixture#21",
+		RequestedBranch: "",
+	})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if claim.Slot != "A" || claim.Branch != "fixture/agent-orchestrator/s1" {
+		t.Fatalf("claim = %#v, want prepared slot A and branch", claim)
+	}
+	if claim.ClaimID == "" || claim.ControllerInstanceID == "" {
+		t.Fatalf("claim = %#v, want process-bound identities", claim)
+	}
+
+	records := readTestJournal(t, filepath.Dir(configPath))
+	if len(records) != 2 {
+		t.Fatalf("journal records = %d, want configure plus claim", len(records))
+	}
+	if records[1]["type"] != "task-claimed" {
+		t.Fatalf("second record = %#v, want task-claimed", records[1])
+	}
+	payload := records[1]["payload"].(map[string]any)
+	if payload["controllerInstanceId"] != claim.ControllerInstanceID {
+		t.Fatalf("claim controller instance = %v, want %q", payload["controllerInstanceId"], claim.ControllerInstanceID)
+	}
+}
+
+func TestObserverClientRecordsReceiptBeforeSessionStart(t *testing.T) {
+	configPath := writeTestConfig(t)
+	client, err := Open(context.Background(), configPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+	client.clock = func() time.Time {
+		return time.Date(2026, 7, 26, 20, 2, 0, 0, time.UTC)
+	}
+	claim, err := client.Claim(context.Background(), ports.CandidateRunClaimRequest{
+		ProjectID: "fixture",
+		IssueID:   "github:taymoork2/tenetfold-orchestration-fixture#21",
+	})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	if err := client.RecordAllocation(
+		context.Background(),
+		claim,
+		"fixture-1",
+		"/tmp/fixture-1",
+	); err != nil {
+		t.Fatalf("RecordAllocation: %v", err)
+	}
+	if err := client.RecordSessionStartRequested(context.Background(), "fixture-1"); err != nil {
+		t.Fatalf("RecordSessionStartRequested: %v", err)
+	}
+	if err := client.RecordSessionStarted(context.Background(), "fixture-1"); err != nil {
+		t.Fatalf("RecordSessionStarted: %v", err)
+	}
+
+	records := readTestJournal(t, filepath.Dir(configPath))
+	var types []any
+	for _, record := range records {
+		types = append(types, record["type"])
+	}
+	wantTypes := []any{
+		"run-configured",
+		"task-claimed",
+		"task-allocated",
+		"session-start-requested",
+		"session-started",
+	}
+	if !reflect.DeepEqual(types, wantTypes) {
+		t.Fatalf("record types = %#v, want %#v", types, wantTypes)
+	}
+	receipt := records[2]["payload"].(map[string]any)["allocationReceipt"].(map[string]any)
+	if receipt["runtimeTaskId"] != "fixture-1" ||
+		receipt["workspace"] != "/tmp/fixture-1" ||
+		receipt["sourceWriter"] != "agent-orchestrator:fixture-1" ||
+		receipt["requestedBranch"] != claim.Branch {
+		t.Fatalf("allocation receipt = %#v, want complete AO-native identities", receipt)
+	}
+	if receipt["runtimeHostId"] != nil {
+		t.Fatalf("runtimeHostId = %#v, want explicit null", receipt["runtimeHostId"])
+	}
+}
+
+func TestObserverClientRejectsOffTargetPullRequest(t *testing.T) {
+	configPath := writeTestConfig(t)
+	client, err := Open(context.Background(), configPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+	client.clock = func() time.Time {
+		return time.Date(2026, 7, 26, 20, 3, 0, 0, time.UTC)
+	}
+	claim, err := client.Claim(context.Background(), ports.CandidateRunClaimRequest{
+		ProjectID: "fixture",
+		IssueID:   "github:taymoork2/tenetfold-orchestration-fixture#21",
+	})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if err := client.RecordAllocation(context.Background(), claim, "fixture-1", "/tmp/fixture-1"); err != nil {
+		t.Fatalf("RecordAllocation: %v", err)
+	}
+	if err := client.RecordSessionStartRequested(context.Background(), "fixture-1"); err != nil {
+		t.Fatalf("RecordSessionStartRequested: %v", err)
+	}
+	if err := client.RecordSessionStarted(context.Background(), "fixture-1"); err != nil {
+		t.Fatalf("RecordSessionStarted: %v", err)
+	}
+
+	offTarget := ports.SCMObservation{
+		ObservedAt: time.Date(2026, 7, 26, 20, 4, 0, 0, time.UTC),
+		Repo:       "other/repository",
+		PR: ports.SCMPRObservation{
+			Number:       84,
+			URL:          "https://github.com/other/repository/pull/84",
+			SourceBranch: "feat/off-target",
+		},
+	}
+	if err := client.RecordPullRequest(context.Background(), "fixture-1", offTarget); err == nil {
+		t.Fatal("RecordPullRequest off-target error = nil, want rejection")
+	}
+
+	onTarget := offTarget
+	onTarget.Repo = claim.Repository
+	onTarget.PR.URL = "https://github.com/taymoork2/tenetfold-orchestration-fixture/pull/84"
+	onTarget.PR.SourceBranch = claim.Branch
+	if err := client.RecordPullRequest(context.Background(), "fixture-1", onTarget); err != nil {
+		t.Fatalf("RecordPullRequest on-target: %v", err)
+	}
+
+	records := readTestJournal(t, filepath.Dir(configPath))
+	var pullRequests int
+	for _, record := range records {
+		if record["type"] == "pull-request-opened" {
+			pullRequests++
+		}
+	}
+	if pullRequests != 1 {
+		t.Fatalf("pull-request-opened records = %d, want only the target-bound observation", pullRequests)
+	}
+}
+
+func TestObserverClientRecordsStopOnlyWithZeroDescendantProof(t *testing.T) {
+	configPath := writeTestConfig(t)
+	client, err := Open(context.Background(), configPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+	client.clock = func() time.Time {
+		return time.Date(2026, 7, 26, 20, 5, 0, 0, time.UTC)
+	}
+	claim, err := client.Claim(context.Background(), ports.CandidateRunClaimRequest{
+		ProjectID: "fixture",
+		IssueID:   "github:taymoork2/tenetfold-orchestration-fixture#21",
+	})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if err := client.RecordAllocation(context.Background(), claim, "fixture-1", "/tmp/fixture-1"); err != nil {
+		t.Fatalf("RecordAllocation: %v", err)
+	}
+	if err := client.RecordSessionStartRequested(context.Background(), "fixture-1"); err != nil {
+		t.Fatalf("RecordSessionStartRequested: %v", err)
+	}
+	if err := client.RecordSessionStarted(context.Background(), "fixture-1"); err != nil {
+		t.Fatalf("RecordSessionStarted: %v", err)
+	}
+
+	if err := client.RecordStopped(context.Background(), "fixture-1", "operator stop", ports.RuntimeStopProof{
+		ProcessID:          "4242",
+		DescendantIDs:      []string{"4243", "4244"},
+		DescendantsRunning: 1,
+	}); err == nil {
+		t.Fatal("RecordStopped with a running descendant error = nil, want rejection")
+	}
+	if err := client.RecordStopped(context.Background(), "fixture-1", "operator stop", ports.RuntimeStopProof{
+		ProcessID:          "4242",
+		DescendantIDs:      []string{"4243", "4244"},
+		DescendantsRunning: 0,
+	}); err != nil {
+		t.Fatalf("RecordStopped: %v", err)
+	}
+
+	records := readTestJournal(t, filepath.Dir(configPath))
+	if got := records[len(records)-2]["type"]; got != "worker-stopped" {
+		t.Fatalf("penultimate record type = %v, want worker-stopped", got)
+	}
+	if got := records[len(records)-1]["type"]; got != "descendants-stopped" {
+		t.Fatalf("last record type = %v, want descendants-stopped", got)
+	}
+	descendants := records[len(records)-1]["payload"].(map[string]any)
+	if descendants["descendantsRunning"] != float64(0) {
+		t.Fatalf("descendantsRunning = %#v, want zero", descendants["descendantsRunning"])
+	}
+}
+
+func TestObserverSidecarRejectsLifecycleControlMethods(t *testing.T) {
+	client, err := Open(context.Background(), writeTestConfig(t), nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+
+	for _, method := range []string{"start", "resume", "stop"} {
+		t.Run(method, func(t *testing.T) {
+			var result json.RawMessage
+			err := client.request(context.Background(), method, map[string]any{}, &result)
+			if err == nil || !strings.Contains(err.Error(), "is not allowed") {
+				t.Fatalf("%s error = %v, want explicit observer-only rejection", method, err)
+			}
+		})
+	}
+}
+
+func TestObserverSidecarRejectsDuplicateJournalOwner(t *testing.T) {
+	configPath := writeTestConfig(t)
+	client, err := Open(context.Background(), configPath, nil)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+
+	duplicate, err := Open(context.Background(), configPath, nil)
+	if err == nil {
+		_ = duplicate.Close()
+		t.Fatal("second Open error = nil, want duplicate runtime owner rejection")
+	}
+}
+
+func TestObserverSidecarRejectsKernelDigestDrift(t *testing.T) {
+	configPath := writeTestConfig(t)
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(raw, &config); err != nil {
+		t.Fatal(err)
+	}
+	config["kernel"].(map[string]any)["sha256"] =
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	raw, err = json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := Open(context.Background(), configPath, nil)
+	if err == nil {
+		_ = client.Close()
+		t.Fatal("Open error = nil, want digest mismatch rejection")
+	}
+	if !strings.Contains(err.Error(), "kernel digest does not match") {
+		t.Fatalf("Open error = %v, want exact digest rejection", err)
+	}
+}
+
+func writeTestConfig(t *testing.T) string {
+	t.Helper()
+	nodeBinary, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required for the provider-free observer sidecar test")
+	}
+	nodeBinary, err = filepath.Abs(nodeBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modulePath, err := filepath.Abs(filepath.Join("testdata", "kernel.mjs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	moduleBytes, err := os.ReadFile(modulePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	moduleDigest := sha256.Sum256(moduleBytes)
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "candidate-run.json")
+	config := map[string]any{
+		"schemaVersion":    1,
+		"nodeBinary":       nodeBinary,
+		"journalDirectory": dir,
+		"kernel": map[string]any{
+			"modulePath": modulePath,
+			"sha256":     hex.EncodeToString(moduleDigest[:]),
+		},
+		"controllerClaim": map[string]any{
+			"eventId":   "configure-agent-orchestrator",
+			"claimId":   "agent-orchestrator:controller",
+			"claimedAt": "2026-07-26T20:00:00.000Z",
+		},
+		"codex": map[string]any{
+			"harness":        "codex",
+			"approvalPolicy": "on-request",
+		},
+		"activationProfile": map[string]any{
+			"schemaVersion":    2,
+			"candidateSlug":    "agent-orchestrator",
+			"candidateVersion": "0.10.3",
+			"adapterRevision":  "c89414ddb8cf4dc35e77417907e1ea663b79cf6b",
+			"adapterDigest":    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"workerRuntime":    "Codex CLI",
+			"modelProvider":    "OpenAI",
+			"modelAuthRoute":   "enterprise Codex subscription",
+			"authStatus":       "available",
+			"authStateScope":   "shared",
+			"model":            "gpt-5.6-codex",
+			"effort":           "high",
+			"sandbox":          "workspace-write",
+			"privacyPosture":   "enterprise policy",
+			"meteringPosture":  "subscription quota",
+			"lastVerifiedAt":   "2026-07-26T20:00:00.000Z",
+			"nextAuthAction":   "none",
+		},
+		"prepared": map[string]any{
+			"candidateSlug":      "agent-orchestrator",
+			"runId":              "AO-S1-001",
+			"scenario":           "S1",
+			"repository":         "taymoork2/tenetfold-orchestration-fixture",
+			"controllerOwner":    "portfolio-controller",
+			"dispatcher":         "agent-orchestrator",
+			"candidateRoleClass": "Orchestrator",
+			"workspaceAllocator": "agent-orchestrator-worktree",
+			"initiationMode":     "automatic",
+			"workerLimit":        1,
+			"tasks": []map[string]any{{
+				"slot":             "A",
+				"issueNumber":      21,
+				"idempotencyKey":   "agent-orchestrator:AO-S1-001:S1:A",
+				"allocationKey":    "agent-orchestrator:AO-S1-001:S1:A",
+				"workspaceMode":    "native-after-claim",
+				"sourceWriterMode": "agent-orchestrator-session",
+				"workspace":        nil,
+				"branch":           "fixture/agent-orchestrator/s1",
+				"sourceWriter":     nil,
+				"authorizedFiles":  []string{"src/work-items.mjs"},
+			}},
+		},
+	}
+	raw, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return configPath
+}
+
+func readTestJournal(t *testing.T, dir string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "fake-runtime-journal.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var records []map[string]any
+	for _, line := range splitNonblankLines(string(raw)) {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatal(err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func splitNonblankLines(value string) []string {
+	var lines []string
+	for _, line := range strings.Split(value, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/backend/internal/adapters/candidaterun/observer.mjs
+++ b/backend/internal/adapters/candidaterun/observer.mjs
@@ -1,0 +1,118 @@
+import { createHash, randomUUID } from "node:crypto";
+import { lstat, readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import readline from "node:readline";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+async function readBinding(configPath) {
+  if (!path.isAbsolute(configPath)) {
+    fail("candidate run config path must be absolute");
+  }
+  const entry = await lstat(configPath);
+  if (entry.isSymbolicLink() || !entry.isFile()) {
+    fail("candidate run config must be a regular non-link file");
+  }
+  const binding = JSON.parse(await readFile(configPath, "utf8"));
+  const allowed = new Set([
+    "schemaVersion",
+    "nodeBinary",
+    "journalDirectory",
+    "kernel",
+    "controllerClaim",
+    "codex",
+    "activationProfile",
+    "prepared",
+  ]);
+  for (const key of Object.keys(binding)) {
+    if (!allowed.has(key)) fail(`candidate run config ${key} is not allowed`);
+  }
+  if (binding.schemaVersion !== 1) {
+    fail("candidate run config schemaVersion must be 1");
+  }
+  if (binding.activationProfile?.schemaVersion !== 2) {
+    fail("candidate run activation profile must use schemaVersion 2");
+  }
+  return binding;
+}
+
+async function loadKernel(binding) {
+  const modulePath = binding.kernel?.modulePath;
+  if (!path.isAbsolute(modulePath ?? "")) {
+    fail("candidate run kernel module path must be absolute");
+  }
+  const entry = await lstat(modulePath);
+  if (entry.isSymbolicLink() || !entry.isFile()) {
+    fail("candidate run kernel module must be a regular non-link file");
+  }
+  const bytes = await readFile(modulePath);
+  const actual = createHash("sha256").update(bytes).digest("hex");
+  if (actual !== binding.kernel?.sha256) {
+    fail("candidate run kernel digest does not match");
+  }
+  return import(pathToFileURL(modulePath).href);
+}
+
+function writeFrame(frame) {
+  process.stdout.write(`${JSON.stringify(frame)}\n`);
+}
+
+const configPath = process.argv.at(-1);
+const binding = await readBinding(configPath);
+const candidateRun = await loadKernel(binding);
+const controllerInstanceId =
+  `agent-orchestrator:${process.pid}:${randomUUID()}`;
+const journal = candidateRun.createRuntimeJournal({
+  directory: binding.journalDirectory,
+  runId: binding.prepared.runId,
+  controllerId: binding.prepared.controllerOwner,
+});
+const kernel = candidateRun.createCandidateRunKernel({
+  mode: "observer",
+  prepared: binding.prepared,
+  activationProfile: binding.activationProfile,
+  controllerId: binding.prepared.controllerOwner,
+  controllerInstanceId,
+  journal,
+});
+const configureRequest = {
+  eventId: binding.controllerClaim.eventId,
+  claimId: binding.controllerClaim.claimId,
+  at: binding.controllerClaim.claimedAt,
+};
+const configured = await kernel.configure(configureRequest);
+writeFrame({ type: "ready", controllerInstanceId });
+
+const lines = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+  terminal: false,
+});
+
+for await (const line of lines) {
+  let request;
+  try {
+    request = JSON.parse(line);
+    if (!Number.isInteger(request.id) || request.id < 1) {
+      fail("candidate run observer request id is invalid");
+    }
+    let result;
+    if (request.method === "configure") {
+      result = await kernel.configure(configureRequest);
+    } else if (request.method === "observe") {
+      result = await kernel.observe(request.params?.event);
+    } else {
+      fail(`candidate run observer method ${String(request.method)} is not allowed`);
+    }
+    writeFrame({ id: request.id, ok: true, result });
+  } catch (error) {
+    writeFrame({
+      id: Number.isInteger(request?.id) ? request.id : 0,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/backend/internal/adapters/candidaterun/testdata/kernel.mjs
+++ b/backend/internal/adapters/candidaterun/testdata/kernel.mjs
@@ -1,6 +1,25 @@
+import { createHash } from "node:crypto";
 import { closeSync, openSync } from "node:fs";
 import { appendFile, readFile } from "node:fs/promises";
 import path from "node:path";
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+function activationProfileDigest(profile) {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(profile)))
+    .digest("hex");
+}
 
 export function createRuntimeJournal({ directory, runId, controllerId }) {
   const ownerPath = path.join(directory, "fake-runtime-owner");
@@ -53,6 +72,17 @@ export function createCandidateRunKernel({
   if (prepared.controllerOwner !== controllerId) {
     throw new Error("test kernel controller mismatch");
   }
+  if (
+    prepared.activationProfileDigest !==
+    activationProfileDigest(activationProfile)
+  ) {
+    throw new Error("test kernel activation profile digest drifted");
+  }
+  prepared.tasks.forEach((task, schedulingOrder) => {
+    if (task.schedulingOrder !== schedulingOrder) {
+      throw new Error("test kernel scheduling order drifted");
+    }
+  });
 
   return {
     configure(request) {

--- a/backend/internal/adapters/candidaterun/testdata/kernel.mjs
+++ b/backend/internal/adapters/candidaterun/testdata/kernel.mjs
@@ -69,6 +69,16 @@ export function createCandidateRunKernel({
   if (activationProfile.schemaVersion !== 2) {
     throw new Error("test kernel requires activation profile schema v2");
   }
+  if (
+    typeof activationProfile.adapterArtifact !== "string" ||
+    activationProfile.adapterArtifact.trim() === "" ||
+    typeof activationProfile.modelProvider !== "string" ||
+    activationProfile.modelProvider.trim() === ""
+  ) {
+    throw new Error(
+      "test kernel requires schema-v2 adapter artifact and model provider",
+    );
+  }
   if (prepared.controllerOwner !== controllerId) {
     throw new Error("test kernel controller mismatch");
   }

--- a/backend/internal/adapters/candidaterun/testdata/kernel.mjs
+++ b/backend/internal/adapters/candidaterun/testdata/kernel.mjs
@@ -1,0 +1,102 @@
+import { closeSync, openSync } from "node:fs";
+import { appendFile, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export function createRuntimeJournal({ directory, runId, controllerId }) {
+  const ownerPath = path.join(directory, "fake-runtime-owner");
+  closeSync(openSync(ownerPath, "wx", 0o600));
+  const journalPath = path.join(directory, "fake-runtime-journal.jsonl");
+
+  async function read() {
+    try {
+      return (await readFile(journalPath, "utf8"))
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map(JSON.parse);
+    } catch (error) {
+      if (error?.code === "ENOENT") return [];
+      throw error;
+    }
+  }
+
+  async function append(event) {
+    const record = { ...event, runId, controllerId };
+    await appendFile(journalPath, `${JSON.stringify(record)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    return record;
+  }
+
+  return {
+    read,
+    append,
+    async mutate(operation) {
+      return operation({ read, append });
+    },
+  };
+}
+
+export function createCandidateRunKernel({
+  mode,
+  prepared,
+  activationProfile,
+  controllerId,
+  controllerInstanceId,
+  journal,
+}) {
+  if (mode !== "observer") throw new Error("test kernel requires observer mode");
+  if (activationProfile.schemaVersion !== 2) {
+    throw new Error("test kernel requires activation profile schema v2");
+  }
+  if (prepared.controllerOwner !== controllerId) {
+    throw new Error("test kernel controller mismatch");
+  }
+
+  return {
+    configure(request) {
+      return journal.append({
+        eventId: request.eventId,
+        type: "run-configured",
+        slot: null,
+        at: request.at,
+        payload: {
+          mode,
+          controllerClaim: {
+            claimId: request.claimId,
+            controllerInstanceId,
+          },
+        },
+      });
+    },
+    async observe(event) {
+      const task = prepared.tasks.find(({ slot }) => slot === event.slot);
+      if (!task) throw new Error("test kernel unknown task");
+      if (
+        event.type === "task-claimed" &&
+        event.payload.controllerInstanceId !== controllerInstanceId
+      ) {
+        throw new Error("test kernel controller instance mismatch");
+      }
+      if (
+        event.type === "pull-request-opened" &&
+        (event.payload.repository !== prepared.repository ||
+          event.payload.issueNumber !== task.issueNumber ||
+          event.payload.branch !== task.branch)
+      ) {
+        throw new Error("test kernel off-target pull request");
+      }
+      return journal.append(event);
+    },
+    start() {
+      throw new Error("test kernel start must not be called");
+    },
+    resume() {
+      throw new Error("test kernel resume must not be called");
+    },
+    stop() {
+      throw new Error("test kernel stop must not be called");
+    },
+  };
+}

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -53,18 +53,20 @@ type Options struct {
 // Runtime runs agent sessions inside tmux sessions, driving them via the tmux
 // CLI. It implements ports.Runtime.
 type Runtime struct {
-	binary       string
-	shell        string
-	timeout      time.Duration
-	chunkSize    int
-	enterDelay   time.Duration
-	reapGrace    time.Duration
-	runner       runner
-	reapSessions func(ctx context.Context, pids []int, grace time.Duration)
+	binary        string
+	shell         string
+	timeout       time.Duration
+	chunkSize     int
+	enterDelay    time.Duration
+	reapGrace     time.Duration
+	runner        runner
+	reapSessions  func(ctx context.Context, pids []int, grace time.Duration)
+	proveSessions func(ctx context.Context, panePIDs []int, grace time.Duration) ([]int, int, error)
 }
 
 var _ ports.Runtime = (*Runtime)(nil)
 var _ ports.Attacher = (*Runtime)(nil)
+var _ ports.RuntimeStopProver = (*Runtime)(nil)
 
 type runner interface {
 	Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
@@ -171,14 +173,15 @@ func New(opts Options) *Runtime {
 		reapGrace = defaultReapGrace
 	}
 	return &Runtime{
-		binary:       binary,
-		shell:        shellPath,
-		timeout:      timeout,
-		chunkSize:    chunkSize,
-		enterDelay:   enterDelay,
-		reapGrace:    reapGrace,
-		runner:       execRunner{},
-		reapSessions: killSessionsByPID,
+		binary:        binary,
+		shell:         shellPath,
+		timeout:       timeout,
+		chunkSize:     chunkSize,
+		enterDelay:    enterDelay,
+		reapGrace:     reapGrace,
+		runner:        execRunner{},
+		reapSessions:  killSessionsByPID,
+		proveSessions: reapAndProveSessions,
 	}
 }
 
@@ -346,6 +349,193 @@ func (r *Runtime) paneSessionIDs(ctx context.Context, id string) []int {
 		}
 		ids = append(ids, pid)
 	}
+	return ids
+}
+
+// DestroyWithProof destroys an AO-owned tmux session and proves that no
+// process remains in the pane's native process session. Candidate runs require
+// this stronger boundary; ordinary AO sessions continue to use Destroy.
+func (r *Runtime) DestroyWithProof(ctx context.Context, handle ports.RuntimeHandle) (ports.RuntimeStopProof, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return ports.RuntimeStopProof{}, err
+	}
+	panePIDs, err := r.candidatePaneSessionIDs(ctx, id)
+	if err != nil {
+		return ports.RuntimeStopProof{}, err
+	}
+	if len(panePIDs) != 1 {
+		return ports.RuntimeStopProof{}, fmt.Errorf(
+			"tmux runtime: candidate session %s has %d panes; exactly one is required for a singular process proof",
+			id,
+			len(panePIDs),
+		)
+	}
+
+	out, destroyErr := r.run(ctx, killSessionArgs(id)...)
+	descendantPIDs, running, reapErr := r.proveSessions(ctx, panePIDs, r.reapGrace)
+	if destroyErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(destroyErr, &exitErr) || !killSessionMissingOutput(string(out)) {
+			return ports.RuntimeStopProof{}, fmt.Errorf("tmux runtime: destroy session %s: %w", id, destroyErr)
+		}
+	}
+	if reapErr != nil {
+		return ports.RuntimeStopProof{}, fmt.Errorf("tmux runtime: prove descendants stopped for %s: %w", id, reapErr)
+	}
+	if running != 0 {
+		return ports.RuntimeStopProof{}, fmt.Errorf(
+			"tmux runtime: prove descendants stopped for %s: %d processes remain",
+			id,
+			running,
+		)
+	}
+	descendantIDs := make([]string, len(descendantPIDs))
+	for i, pid := range descendantPIDs {
+		descendantIDs[i] = strconv.Itoa(pid)
+	}
+	return ports.RuntimeStopProof{
+		ProcessID:          strconv.Itoa(panePIDs[0]),
+		DescendantIDs:      descendantIDs,
+		DescendantsRunning: running,
+	}, nil
+}
+
+func (r *Runtime) candidatePaneSessionIDs(ctx context.Context, id string) ([]int, error) {
+	out, err := r.run(ctx, listPanePIDsArgs(id)...)
+	if err != nil {
+		return nil, fmt.Errorf("tmux runtime: list panes for %s: %w", id, err)
+	}
+	var ids []int
+	seen := make(map[int]struct{})
+	for _, line := range strings.Split(string(out), "\n") {
+		value := strings.TrimSpace(line)
+		if value == "" {
+			continue
+		}
+		pid, convErr := strconv.Atoi(value)
+		if convErr != nil || pid <= 1 {
+			return nil, fmt.Errorf("tmux runtime: invalid pane pid %q for %s", value, id)
+		}
+		if _, ok := seen[pid]; ok {
+			return nil, fmt.Errorf("tmux runtime: duplicate pane pid %d for %s", pid, id)
+		}
+		seen[pid] = struct{}{}
+		ids = append(ids, pid)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("tmux runtime: no pane pid for %s", id)
+	}
+	return ids, nil
+}
+
+// reapAndProveSessions terminates any process left in the tmux pane sessions
+// after kill-session and returns every descendant observed plus the final
+// survivor count. pgrep/pkill failures are evidence failures, not proof of
+// absence.
+func reapAndProveSessions(ctx context.Context, panePIDs []int, grace time.Duration) ([]int, int, error) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), grace+5*time.Second)
+	defer cancel()
+
+	observed := make(map[int]struct{})
+	survivors, err := sessionProcesses(cleanupCtx, panePIDs)
+	if err != nil {
+		return nil, 0, err
+	}
+	recordDescendants(observed, survivors, panePIDs)
+	if len(survivors) > 0 {
+		if err := signalSessionsStrict(cleanupCtx, panePIDs, "-TERM"); err != nil {
+			return sortedProcessIDs(observed), len(survivors), err
+		}
+	}
+
+	deadline := time.NewTimer(grace)
+	defer deadline.Stop()
+	deadlineC := deadline.C
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for len(survivors) > 0 {
+		select {
+		case <-cleanupCtx.Done():
+			return sortedProcessIDs(observed), len(survivors), cleanupCtx.Err()
+		case <-deadlineC:
+			if err := signalSessionsStrict(cleanupCtx, panePIDs, "-KILL"); err != nil {
+				return sortedProcessIDs(observed), len(survivors), err
+			}
+			// Give SIGKILL delivery a bounded settling interval rather than
+			// treating an immediate pgrep race as a surviving descendant.
+			deadlineC = nil
+		case <-ticker.C:
+			survivors, err = sessionProcesses(cleanupCtx, panePIDs)
+			if err != nil {
+				return sortedProcessIDs(observed), 0, err
+			}
+			recordDescendants(observed, survivors, panePIDs)
+		}
+	}
+	return sortedProcessIDs(observed), 0, nil
+}
+
+func sessionProcesses(ctx context.Context, panePIDs []int) ([]int, error) {
+	seen := make(map[int]struct{})
+	for _, panePID := range panePIDs {
+		cmd := exec.CommandContext(ctx, "pgrep", "-s", strconv.Itoa(panePID))
+		out, err := cmd.Output()
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+				continue
+			}
+			return nil, fmt.Errorf("pgrep session %d: %w", panePID, err)
+		}
+		for _, line := range strings.Split(string(out), "\n") {
+			value := strings.TrimSpace(line)
+			if value == "" {
+				continue
+			}
+			pid, convErr := strconv.Atoi(value)
+			if convErr != nil || pid <= 1 {
+				return nil, fmt.Errorf("pgrep session %d returned invalid pid %q", panePID, value)
+			}
+			seen[pid] = struct{}{}
+		}
+	}
+	return sortedProcessIDs(seen), nil
+}
+
+func signalSessionsStrict(ctx context.Context, panePIDs []int, signal string) error {
+	for _, panePID := range panePIDs {
+		err := exec.CommandContext(ctx, "pkill", signal, "-s", strconv.Itoa(panePID)).Run()
+		if err == nil {
+			continue
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			continue
+		}
+		return fmt.Errorf("pkill %s session %d: %w", signal, panePID, err)
+	}
+	return nil
+}
+
+func recordDescendants(observed map[int]struct{}, processes, panePIDs []int) {
+	roots := make(map[int]struct{}, len(panePIDs))
+	for _, pid := range panePIDs {
+		roots[pid] = struct{}{}
+	}
+	for _, pid := range processes {
+		if _, isRoot := roots[pid]; !isRoot {
+			observed[pid] = struct{}{}
+		}
+	}
+}
+
+func sortedProcessIDs(processes map[int]struct{}) []int {
+	ids := make([]int, 0, len(processes))
+	for pid := range processes {
+		ids = append(ids, pid)
+	}
+	sort.Ints(ids)
 	return ids
 }
 

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -622,6 +622,34 @@ func TestDestroyReapsDiscoveredPaneSessions(t *testing.T) {
 	}
 }
 
+func TestDestroyWithProofReturnsZeroRunningDescendants(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	fr.outputs = [][]byte{[]byte("4242\n"), nil}
+	var reaped []int
+	r.proveSessions = func(_ context.Context, panePIDs []int, _ time.Duration) ([]int, int, error) {
+		reaped = append([]int(nil), panePIDs...)
+		return []int{4243, 4244}, 0, nil
+	}
+
+	proof, err := r.DestroyWithProof(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if err != nil {
+		t.Fatalf("DestroyWithProof: %v", err)
+	}
+	if got, want := reaped, []int{4242}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("reaped pane sessions = %#v, want %#v", got, want)
+	}
+	if proof.ProcessID != "4242" ||
+		!reflect.DeepEqual(proof.DescendantIDs, []string{"4243", "4244"}) ||
+		proof.DescendantsRunning != 0 {
+		t.Fatalf("proof = %#v, want process 4242 and zero running descendants", proof)
+	}
+	if len(fr.calls) != 2 ||
+		fr.calls[0].args[0] != "list-panes" ||
+		fr.calls[1].args[0] != "kill-session" {
+		t.Fatalf("tmux calls = %#v, want list-panes before kill-session", fr.calls)
+	}
+}
+
 // -- IsAlive tests --
 
 func TestIsAliveReturnsTrueOnExitZero(t *testing.T) {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -7,6 +7,7 @@ package config
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -91,6 +92,9 @@ type Config struct {
 	// Agent is the compatibility agent adapter id selected by AO_AGENT;
 	// startSession fails fast if no adapter with this id is registered.
 	Agent string
+	// CandidateRunConfigPath enables the candidate-owned observer sidecar when
+	// set to one exact absolute, non-secret activation binding.
+	CandidateRunConfigPath string
 	// AppRunID identifies one desktop-app launch. The Electron supervisor mints
 	// it and passes it down (AO_APP_RUN_ID), holding it constant across daemon
 	// restarts it performs, so standalone shell terminals can survive a daemon
@@ -129,6 +133,7 @@ func (c Config) Addr() string {
 //	AO_RUN_FILE          running.json path   (default ~/.ao/running.json)
 //	AO_DATA_DIR          durable state dir   (default ~/.ao/data)
 //	AO_AGENT             compatibility agent id (default claude-code)
+//	AO_CANDIDATE_RUN_CONFIG absolute observer binding path (default disabled)
 //	AO_APP_RUN_ID        desktop-app launch id, set by the Electron supervisor
 //	                     (default: a fresh id minted per daemon boot)
 //	AO_ALLOWED_ORIGINS   CORS origins, comma-separated (default DefaultAllowedOrigins)
@@ -182,6 +187,12 @@ func Load() (Config, error) {
 
 	if raw := os.Getenv("AO_AGENT"); raw != "" {
 		cfg.Agent = raw
+	}
+	if raw := strings.TrimSpace(os.Getenv("AO_CANDIDATE_RUN_CONFIG")); raw != "" {
+		if !filepath.IsAbs(raw) {
+			return Config{}, errors.New("AO_CANDIDATE_RUN_CONFIG must be an absolute path")
+		}
+		cfg.CandidateRunConfigPath = raw
 	}
 
 	// A missing AO_APP_RUN_ID means nothing is supervising this daemon, so this

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -10,7 +10,7 @@ import (
 func TestLoadDefaults(t *testing.T) {
 	// Clear every recognised var so we observe pure defaults regardless of the
 	// surrounding environment.
-	for _, k := range []string{"AO_PORT", "AO_REQUEST_TIMEOUT", "AO_SHUTDOWN_TIMEOUT", "AO_RUN_FILE", "AO_DATA_DIR", "AO_AGENT", "AO_ALLOWED_ORIGINS", "AO_TELEMETRY_EVENTS", "AO_TELEMETRY_METRICS", "AO_TELEMETRY_REMOTE", "AO_TELEMETRY_POSTHOG_KEY", "AO_TELEMETRY_POSTHOG_HOST"} {
+	for _, k := range []string{"AO_PORT", "AO_REQUEST_TIMEOUT", "AO_SHUTDOWN_TIMEOUT", "AO_RUN_FILE", "AO_DATA_DIR", "AO_AGENT", "AO_CANDIDATE_RUN_CONFIG", "AO_ALLOWED_ORIGINS", "AO_TELEMETRY_EVENTS", "AO_TELEMETRY_METRICS", "AO_TELEMETRY_REMOTE", "AO_TELEMETRY_POSTHOG_KEY", "AO_TELEMETRY_POSTHOG_HOST"} {
 		t.Setenv(k, "")
 	}
 
@@ -118,6 +118,22 @@ func TestLoadOverrides(t *testing.T) {
 	}
 	if cfg.Telemetry.Remote != TelemetryRemotePostHog || cfg.Telemetry.PostHogKey != "phc_test" || cfg.Telemetry.PostHogHost != "https://eu.i.posthog.com" {
 		t.Fatalf("Telemetry remote = %+v", cfg.Telemetry)
+	}
+}
+
+func TestLoadCandidateRunConfigRequiresAbsolutePath(t *testing.T) {
+	t.Setenv("AO_CANDIDATE_RUN_CONFIG", "/private/tmp/ao-candidate-run.json")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.CandidateRunConfigPath != "/private/tmp/ao-candidate-run.json" {
+		t.Fatalf("CandidateRunConfigPath = %q, want exact configured path", cfg.CandidateRunConfigPath)
+	}
+
+	t.Setenv("AO_CANDIDATE_RUN_CONFIG", "relative/candidate-run.json")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load with relative AO_CANDIDATE_RUN_CONFIG error = nil, want rejection")
 	}
 }
 

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/candidaterun"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/runtimeselect"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemon/supervisor"
@@ -100,6 +101,20 @@ func Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	var candidateRun ports.CandidateRunStarter
+	if cfg.CandidateRunConfigPath != "" {
+		client, openErr := candidaterun.Open(context.WithoutCancel(ctx), cfg.CandidateRunConfigPath, log)
+		if openErr != nil {
+			return fmt.Errorf("open candidate run observer: %w", openErr)
+		}
+		candidateRun = client
+		defer func() {
+			if closeErr := client.Close(); closeErr != nil {
+				log.Error("close candidate run observer", "err", closeErr)
+			}
+		}()
+	}
+
 	cdcPipe, err := startCDC(ctx, store, log)
 	if err != nil {
 		return err
@@ -146,7 +161,7 @@ func Run() error {
 	// selected runtime, routed git/scratch workspaces, the per-session agent
 	// resolver (AO_AGENT validated here for compatibility), and the agent
 	// messenger, then mount it on the API.
-	sessionSvc, reviewSvc, sessMgr, err := startSession(cfg, runtimeAdapter, store, lcStack.LCM, messenger, telemetrySink, agents, log)
+	sessionSvc, reviewSvc, sessMgr, err := startSession(cfg, runtimeAdapter, store, lcStack.LCM, messenger, telemetrySink, agents, candidateRun, log)
 	if err != nil {
 		stop()
 		lcStack.Stop()
@@ -156,7 +171,11 @@ func Run() error {
 		return fmt.Errorf("wire session service: %w", err)
 	}
 	lcStack.LCM.SetCompletionTerminator(sessMgr)
-	lcStack.scmDone = startSCMObserver(ctx, store, lcStack.LCM, log)
+	if candidateRun != nil {
+		lcStack.scmDone = startCandidateSCMObserver(ctx, store, lcStack.LCM, candidateRun, log)
+	} else {
+		lcStack.scmDone = startSCMObserver(ctx, store, lcStack.LCM, log)
+	}
 	projectSvc := projectsvc.NewWithDeps(projectsvc.Deps{Store: store, Sessions: sessionSvc, DefaultHarness: domain.AgentHarness(cfg.Agent), Telemetry: telemetrySink})
 	if err := seedScratchProjectOnBoot(ctx, cfg, projectSvc); err != nil {
 		stop()

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
 	activityobserver "github.com/aoagents/agent-orchestrator/backend/internal/observe/activity"
 	"github.com/aoagents/agent-orchestrator/backend/internal/observe/reaper"
+	scmobserve "github.com/aoagents/agent-orchestrator/backend/internal/observe/scm"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	reviewcore "github.com/aoagents/agent-orchestrator/backend/internal/review"
 	reviewsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/review"
@@ -155,7 +156,17 @@ type sessionLifecycle interface {
 // LCM, the per-session agent resolver, and the agent messenger. The returned
 // service is mounted at httpd APIDeps.Sessions. It also returns the manager so
 // the caller can wire Reconcile into the boot sequence.
-func startSession(cfg config.Config, runtime runtimeselect.Runtime, store *sqlite.Store, lcm *lifecycle.Manager, messenger ports.AgentMessenger, telemetry ports.EventSink, agents ports.AgentResolver, log *slog.Logger) (*sessionsvc.Service, reviewsvc.Manager, sessionLifecycle, error) {
+func startSession(
+	cfg config.Config,
+	runtime runtimeselect.Runtime,
+	store *sqlite.Store,
+	lcm *lifecycle.Manager,
+	messenger ports.AgentMessenger,
+	telemetry ports.EventSink,
+	agents ports.AgentResolver,
+	candidateRun ports.CandidateRunStarter,
+	log *slog.Logger,
+) (*sessionsvc.Service, reviewsvc.Manager, sessionLifecycle, error) {
 	gitWS, err := gitworktree.New(gitworktree.Options{
 		// Per-session worktrees live under the data dir, so a single AO_DATA_DIR
 		// override moves all durable per-user state together.
@@ -180,14 +191,15 @@ func startSession(cfg config.Config, runtime runtimeselect.Runtime, store *sqlit
 		Projects: store,
 	})
 	mgr := sessionmanager.New(sessionmanager.Deps{
-		Runtime:   runtime,
-		Agents:    agents,
-		Workspace: ws,
-		Store:     store,
-		Messenger: messenger,
-		Lifecycle: lcm,
-		DataDir:   cfg.DataDir,
-		Logger:    log,
+		Runtime:      runtime,
+		Agents:       agents,
+		Workspace:    ws,
+		Store:        store,
+		Messenger:    messenger,
+		Lifecycle:    lcm,
+		CandidateRun: candidateRun,
+		DataDir:      cfg.DataDir,
+		Logger:       log,
 	})
 	scmProvider, err := newGitHubSCMProvider(log)
 	if err != nil {
@@ -234,6 +246,29 @@ func startSession(cfg config.Config, runtime runtimeselect.Runtime, store *sqlit
 	})
 	reviewSvc := reviewsvc.New(reviewEngine, store, reviewsvc.WithLifecycleReducer(lcm))
 	return sessionSvc, reviewSvc, mgr, nil
+}
+
+// startCandidateSCMObserver wires the same provider-neutral SCM observer as the
+// normal daemon path while adding the AO-owned candidate target check before
+// lifecycle acknowledgement. Provider setup and credential resolution remain
+// lazy and read-only.
+func startCandidateSCMObserver(
+	ctx context.Context,
+	store *sqlite.Store,
+	lcm *lifecycle.Manager,
+	candidateRun ports.CandidateRunStarter,
+	logger *slog.Logger,
+) <-chan struct{} {
+	provider, err := newGitHubSCMProvider(logger)
+	if err != nil {
+		logSCMProviderDisabled(logger, err)
+		return closedDone()
+	}
+	observer := scmobserve.New(provider, store, lcm, scmobserve.Config{
+		Logger:       logger,
+		CandidateRun: candidateRun,
+	})
+	return observer.Start(ctx)
 }
 
 // runtimeMessageSender is the narrow part of the concrete runtime needed by

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -186,7 +186,7 @@ func TestWiring_StartSessionBuildsSessionService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildAgentResolver: %v", err)
 	}
-	svc, reviewSvc, lc, err := startSession(cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, log)
+	svc, reviewSvc, lc, err := startSession(cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, log)
 	if err != nil {
 		t.Fatalf("startSession: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestWiring_StartSessionSpawnsScratchWithoutGitRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildAgentResolver: %v", err)
 	}
-	svc, _, _, err := startSession(cfg, runtime, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, log)
+	svc, _, _, err := startSession(cfg, runtime, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, log)
 	if err != nil {
 		t.Fatalf("startSession: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken(t *testing.T) {
 	if agentsErr != nil {
 		t.Fatalf("buildAgentResolver: %v", agentsErr)
 	}
-	svc, _, _, err := startSession(cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, log)
+	svc, _, _, err := startSession(cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, log)
 	if err != nil {
 		t.Fatalf("startSession: %v", err)
 	}
@@ -339,6 +339,49 @@ func TestWiring_SeedScratchProjectOnBootUsesDataDir(t *testing.T) {
 	}
 }
 
+type candidateRunStub struct {
+	ports.CandidateRunStarter
+}
+
+func TestWiring_StartSessionInjectsCandidateObserverBoundary(t *testing.T) {
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	lcm := lifecycle.New(store, nil)
+	cfg := config.Config{DataDir: t.TempDir()}
+	rt := runtimeselect.New(nil)
+	messenger := newSessionMessenger(store, rt, log)
+	agents, err := buildAgentResolver(config.DefaultAgent, log)
+	if err != nil {
+		t.Fatalf("buildAgentResolver: %v", err)
+	}
+	candidateRun := &candidateRunStub{}
+	_, _, lc, err := startSession(
+		cfg,
+		rt,
+		store,
+		lcm,
+		messenger,
+		telemetryadapter.NoopSink{},
+		agents,
+		candidateRun,
+		log,
+	)
+	if err != nil {
+		t.Fatalf("startSession: %v", err)
+	}
+	if err := lc.RestoreAll(context.Background()); !errors.Is(err, sessionmanager.ErrCandidateRunResumeUnsupported) {
+		t.Fatalf("RestoreAll error = %v, want candidate observer resume rejection", err)
+	}
+	if err := lc.Reconcile(context.Background()); !errors.Is(err, sessionmanager.ErrCandidateRunResumeUnsupported) {
+		t.Fatalf("Reconcile error = %v, want candidate observer resume rejection", err)
+	}
+}
+
 // TestStartTrackerIntake_RunsEvenWithoutEnabledProjects is a regression test:
 // startTrackerIntake used to scan projects once at call time and skip starting
 // the observer loop entirely when none had intake enabled yet. Poll() itself
@@ -361,7 +404,7 @@ func TestStartTrackerIntake_RunsEvenWithoutEnabledProjects(t *testing.T) {
 	if agentsErr != nil {
 		t.Fatalf("buildAgentResolver: %v", agentsErr)
 	}
-	svc, _, _, err := startSession(cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, log)
+	svc, _, _, err := startSession(cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, log)
 	if err != nil {
 		t.Fatalf("startSession: %v", err)
 	}

--- a/backend/internal/domain/agentconfig.go
+++ b/backend/internal/domain/agentconfig.go
@@ -25,6 +25,13 @@ const (
 type AgentConfig struct {
 	// Model overrides the agent's default model (e.g. claude-opus-4-5).
 	Model string `json:"model,omitempty"`
+	// Effort pins the agent's native reasoning-effort setting for one resolved
+	// launch. It is runtime-only: candidate bindings, not project/API config,
+	// are authoritative for this value.
+	Effort string `json:"-"`
+	// Sandbox pins the agent's native filesystem/process sandbox mode for one
+	// resolved launch. It is runtime-only for the same reason as Effort.
+	Sandbox string `json:"-"`
 	// Permissions sets the agent's starting permission mode. Empty is treated
 	// like the adapter's default mode.
 	Permissions PermissionMode `json:"permissions,omitempty"`

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -71,6 +71,10 @@ type Lifecycle interface {
 	ApplySCMObservation(ctx context.Context, sessionID domain.SessionID, obs ports.SCMObservation) error
 }
 
+type candidateRunObserver interface {
+	RecordPullRequest(ctx context.Context, sessionID domain.SessionID, obs ports.SCMObservation) error
+}
+
 type credentialChecker interface {
 	SCMCredentialsAvailable(ctx context.Context) (bool, error)
 }
@@ -87,6 +91,10 @@ type Config struct {
 	Logger *slog.Logger
 	// CacheMax bounds each in-memory ETag/review cache. Zero uses DefaultCacheMax.
 	CacheMax int
+	// CandidateRun is the optional AO-owned observer boundary. It receives a
+	// target-bound PR observation after persistence and before lifecycle
+	// acknowledgement; rejection retains the pending semantic hashes for retry.
+	CandidateRun candidateRunObserver
 }
 
 // ObserverCache stores provider ETags and review polling timestamps in memory.
@@ -140,6 +148,9 @@ type Observer struct {
 	store Store
 	// lifecycle is notified after successful persistence of meaningful changes.
 	lifecycle Lifecycle
+	// candidateRun validates candidate PR target binding before lifecycle state
+	// can advance.
+	candidateRun candidateRunObserver
 	// tick is the active PR/CI polling cadence.
 	tick time.Duration
 	// reviewInterval is the minimum duration between review-thread fetches per PR.
@@ -159,7 +170,7 @@ type Observer struct {
 // New constructs an Observer with default cadence/cache settings for zero
 // values in cfg.
 func New(provider Provider, store Store, lifecycle Lifecycle, cfg Config) *Observer {
-	o := &Observer{provider: provider, store: store, lifecycle: lifecycle, tick: cfg.Tick, reviewInterval: cfg.ReviewInterval, clock: cfg.Clock, logger: cfg.Logger, Cache: newCache(cfg.CacheMax)}
+	o := &Observer{provider: provider, store: store, lifecycle: lifecycle, candidateRun: cfg.CandidateRun, tick: cfg.Tick, reviewInterval: cfg.ReviewInterval, clock: cfg.Clock, logger: cfg.Logger, Cache: newCache(cfg.CacheMax)}
 	if o.tick <= 0 {
 		o.tick = DefaultTickInterval
 	}
@@ -373,7 +384,8 @@ func (o *Observer) Poll(ctx context.Context) error {
 		// changed hashes at their local values until lifecycle succeeds; if the
 		// daemon restarts after a lifecycle failure, the stale hashes force the
 		// same observation to be fetched and delivered again.
-		if o.lifecycle != nil {
+		needsAcknowledgement := o.candidateRun != nil || o.lifecycle != nil
+		if needsAcknowledgement {
 			pendingOpts := opts
 			if prepared.Changed.Metadata {
 				pendingOpts.preserveLocalMetadataHash = true
@@ -391,14 +403,23 @@ func (o *Observer) Poll(ctx context.Context) error {
 			markRepoRefreshFailed(subj.repo)
 			continue
 		}
+		if o.candidateRun != nil {
+			if err := o.candidateRun.RecordPullRequest(ctx, subj.session.ID, prepared); err != nil {
+				o.logger.Error("scm observer: candidate run PR observation failed", "session", subj.session.ID, "pr", firstNonEmpty(prepared.PR.URL, prepared.PR.HTMLURL, local.URL), "err", err)
+				markRepoRefreshFailed(subj.repo)
+				continue
+			}
+		}
 		if o.lifecycle != nil {
 			if err := o.lifecycle.ApplySCMObservation(ctx, subj.session.ID, prepared); err != nil {
 				o.logger.Error("scm observer: lifecycle notification failed", "session", subj.session.ID, "pr", firstNonEmpty(prepared.PR.URL, prepared.PR.HTMLURL, local.URL), "err", err)
 				markRepoRefreshFailed(subj.repo)
 				continue
 			}
+		}
+		if needsAcknowledgement {
 			if err := o.store.WriteSCMObservation(ctx, finalPR, finalChecks, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
-				o.logger.Error("scm observer: DB lifecycle acknowledgement failed", "session", subj.session.ID, "pr", finalPR.URL, "err", err)
+				o.logger.Error("scm observer: DB observation acknowledgement failed", "session", subj.session.ID, "pr", finalPR.URL, "err", err)
 				markRepoRefreshFailed(subj.repo)
 				continue
 			}

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -223,6 +224,22 @@ func (l *fakeLifecycle) ApplySCMObservation(_ context.Context, _ domain.SessionI
 	}
 	l.observed = append(l.observed, obs)
 	return nil
+}
+
+type fakeCandidateRunObserver struct {
+	sessionIDs   []domain.SessionID
+	observations []ports.SCMObservation
+	err          error
+}
+
+func (o *fakeCandidateRunObserver) RecordPullRequest(
+	_ context.Context,
+	sessionID domain.SessionID,
+	obs ports.SCMObservation,
+) error {
+	o.sessionIDs = append(o.sessionIDs, sessionID)
+	o.observations = append(o.observations, obs)
+	return o.err
 }
 
 func newTestObserver(store *fakeStore, provider *fakeProvider, lc Lifecycle, now time.Time) *Observer {
@@ -1303,6 +1320,75 @@ func TestPoll_LifecycleFailureHoldsBackHashesForDurableRetry(t *testing.T) {
 	}
 	if last.CIHash != ciSemanticHash(changed.CI) {
 		t.Fatalf("CI hash not acknowledged after lifecycle success: got %q want %q", last.CIHash, ciSemanticHash(changed.CI))
+	}
+}
+
+func TestPoll_CandidateRunRejectsOffTargetPRBeforeLifecycleAcknowledgement(t *testing.T) {
+	store := testStoreWithSession()
+	local := knownPR(1)
+	local.MetadataHash = "old-metadata"
+	local.CIHash = "old-ci"
+	store.prs["p-1"] = []domain.PullRequest{local}
+	changed := testObs(1)
+	changed.PR.Title = "changed title"
+	provider := &fakeProvider{
+		repoGuards:   map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "repo2"}},
+		checkGuards:  map[string]ports.SCMGuardResult{commitKey(testRepo, "sha1"): {ETag: "ci2"}},
+		observations: map[string]ports.SCMObservation{prKey(testRepo, 1): changed},
+	}
+	lc := &fakeLifecycle{}
+	candidate := &fakeCandidateRunObserver{err: errors.New("prepared target rejected")}
+	obs := New(provider, store, lc, Config{
+		Clock:        func() time.Time { return time.Unix(500, 0).UTC() },
+		Tick:         time.Hour,
+		Logger:       quietSlog(),
+		CacheMax:     128,
+		CandidateRun: candidate,
+	})
+	obs.Cache.RepoPRListETag[prKey(testRepo, 0)] = "repo1"
+	obs.Cache.CommitChecksETag[commitKey(testRepo, "sha1")] = "ci1"
+
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(candidate.sessionIDs, []domain.SessionID{"p-1"}) {
+		t.Fatalf("candidate observations used sessions %#v, want p-1", candidate.sessionIDs)
+	}
+	if len(lc.observed) != 0 {
+		t.Fatalf("lifecycle received %d observations after candidate rejection, want zero", len(lc.observed))
+	}
+	if len(store.writes) != 1 ||
+		store.writes[0].pr.MetadataHash != local.MetadataHash ||
+		store.writes[0].pr.CIHash != local.CIHash {
+		t.Fatalf("candidate rejection must retain pending hashes, writes=%#v", store.writes)
+	}
+	if got := obs.Cache.RepoPRListETag[prKey(testRepo, 0)]; got != "repo1" {
+		t.Fatalf("repo ETag advanced after candidate rejection: got %q want repo1", got)
+	}
+	if got := obs.Cache.CommitChecksETag[commitKey(testRepo, "sha1")]; got != "ci1" {
+		t.Fatalf("commit ETag advanced after candidate rejection: got %q want ci1", got)
+	}
+
+	candidate.err = nil
+	store.prs["p-1"] = []domain.PullRequest{store.writes[0].pr}
+	restarted := New(provider, store, lc, Config{
+		Clock:        func() time.Time { return time.Unix(501, 0).UTC() },
+		Tick:         time.Hour,
+		Logger:       quietSlog(),
+		CacheMax:     128,
+		CandidateRun: candidate,
+	})
+	if err := restarted.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(candidate.observations) != 2 {
+		t.Fatalf("candidate observation retries = %d, want 2", len(candidate.observations))
+	}
+	if len(lc.observed) != 1 {
+		t.Fatalf("lifecycle observations after candidate acceptance = %d, want 1", len(lc.observed))
+	}
+	if len(store.writes) != 3 {
+		t.Fatalf("candidate retry should write pending facts then acknowledge hashes, got writes=%d", len(store.writes))
 	}
 }
 

--- a/backend/internal/ports/candidate_run.go
+++ b/backend/internal/ports/candidate_run.go
@@ -1,0 +1,86 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// CandidateRunExecutionProfile is the exact coding-worker profile admitted for
+// a candidate run. It contains no credential material.
+type CandidateRunExecutionProfile struct {
+	Harness        domain.AgentHarness
+	Model          string
+	Effort         string
+	Sandbox        string
+	ApprovalPolicy string
+}
+
+// CandidateRunClaimRequest identifies the tracker task AO is about to claim.
+// RequestedBranch may be empty; a non-empty value must match the prepared task.
+type CandidateRunClaimRequest struct {
+	ProjectID       domain.ProjectID
+	IssueID         domain.IssueID
+	RequestedBranch string
+}
+
+// CandidateRunClaim is the synchronous observer acknowledgement AO must obtain
+// before it creates a session row or allocates a worktree.
+type CandidateRunClaim struct {
+	Slot                 string
+	ClaimID              string
+	ControllerInstanceID string
+	Repository           string
+	IssueNumber          int
+	Branch               string
+	AllocationKey        string
+	IdempotencyKey       string
+	SourceWriterMode     string
+}
+
+// CandidateRunAllocationReceipt is the complete AO-native allocation identity
+// recorded after worktree creation and before provisioning or runtime launch.
+type CandidateRunAllocationReceipt struct {
+	SchemaVersion   int     `json:"schemaVersion"`
+	Slot            string  `json:"slot"`
+	AllocationKey   string  `json:"allocationKey"`
+	ClaimID         string  `json:"claimId"`
+	RuntimeTaskID   string  `json:"runtimeTaskId"`
+	RuntimeHostID   *string `json:"runtimeHostId"`
+	Workspace       string  `json:"workspace"`
+	RequestedBranch string  `json:"requestedBranch"`
+	SourceWriter    string  `json:"sourceWriter"`
+	AllocatedAt     string  `json:"allocatedAt"`
+}
+
+// RuntimeStopProof binds a destroyed runtime process to the complete set of
+// descendants observed at teardown and proves none remain running.
+type RuntimeStopProof struct {
+	ProcessID          string
+	DescendantIDs      []string
+	DescendantsRunning int
+}
+
+// RuntimeStopProver is an optional runtime capability required by admitted
+// candidate runs. Normal AO sessions may continue using Runtime.Destroy.
+type RuntimeStopProver interface {
+	DestroyWithProof(ctx context.Context, handle RuntimeHandle) (RuntimeStopProof, error)
+}
+
+// CandidateRunClaimer is the pre-allocation portion of the candidate-run
+// observer boundary.
+type CandidateRunClaimer interface {
+	ExecutionProfile() CandidateRunExecutionProfile
+	Claim(ctx context.Context, request CandidateRunClaimRequest) (CandidateRunClaim, error)
+}
+
+// CandidateRunStarter records the AO-native allocation and runtime start
+// boundary. Each call is synchronous and fail-closed.
+type CandidateRunStarter interface {
+	CandidateRunClaimer
+	RecordAllocation(ctx context.Context, claim CandidateRunClaim, sessionID domain.SessionID, workspace string) error
+	RecordSessionStartRequested(ctx context.Context, sessionID domain.SessionID) error
+	RecordSessionStarted(ctx context.Context, sessionID domain.SessionID) error
+	RecordPullRequest(ctx context.Context, sessionID domain.SessionID, observation SCMObservation) error
+	RecordStopped(ctx context.Context, sessionID domain.SessionID, reason string, proof RuntimeStopProof) error
+}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -48,6 +48,10 @@ var (
 	// ErrScratchBranchUnsupported means a caller tried to force git branch
 	// semantics onto a scratch project.
 	ErrScratchBranchUnsupported = errors.New("session: scratch projects do not support branches")
+	// ErrCandidateRunResumeUnsupported prevents AO from relaunching a session
+	// without a candidate-run resume observation. The observer boundary records
+	// native claim/start/stop facts but owns no resume transition.
+	ErrCandidateRunResumeUnsupported = errors.New("session: candidate run observer does not authorize resume")
 	// ErrNotResumable means a terminated session cannot be relaunched: its adapter
 	// cannot natively resume it AND it has no prompt to fresh-launch from, and it is
 	// not an orchestrator (orchestrators are promptless by design and relaunch fresh
@@ -165,10 +169,11 @@ type Manager struct {
 	// each call site re-deriving the check. Send/confirmActive use Deliver for
 	// its Outcome; Spawn/Restore use the interface-level Send for
 	// initial-prompt delivery, where a blocked session is impossible.
-	messenger *sessionguard.Guard
-	lcm       lifecycleRecorder
-	dataDir   string
-	clock     func() time.Time
+	messenger    *sessionguard.Guard
+	lcm          lifecycleRecorder
+	candidateRun ports.CandidateRunStarter
+	dataDir      string
+	clock        func() time.Time
 	// lookPath is exec.LookPath in production; tests substitute a stub so
 	// they don't need real binaries on PATH. Returns ports.ErrAgentBinaryNotFound
 	// when the binary is missing so the sentinel propagates through toAPIError.
@@ -220,6 +225,10 @@ type Deps struct {
 	Store     Store
 	Messenger ports.AgentMessenger
 	Lifecycle lifecycleRecorder
+	// CandidateRun is the optional observer-only evaluation boundary. When set,
+	// every claim/allocation/start transition is synchronously acknowledged
+	// before AO advances its native lifecycle.
+	CandidateRun ports.CandidateRunStarter
 	// DataDir is exported to spawned agents as AO_DATA_DIR so their hook
 	// commands can open the same store.
 	DataDir string
@@ -243,17 +252,18 @@ type Deps struct {
 // time.Now when Deps.Clock is nil.
 func New(d Deps) *Manager {
 	m := &Manager{
-		runtime:     d.Runtime,
-		agents:      d.Agents,
-		workspace:   d.Workspace,
-		store:       d.Store,
-		lcm:         d.Lifecycle,
-		dataDir:     d.DataDir,
-		clock:       d.Clock,
-		lookPath:    d.LookPath,
-		executable:  d.Executable,
-		newLaunchID: d.NewLaunchID,
-		resuming:    make(map[domain.SessionID]struct{}),
+		runtime:      d.Runtime,
+		agents:       d.Agents,
+		workspace:    d.Workspace,
+		store:        d.Store,
+		lcm:          d.Lifecycle,
+		candidateRun: d.CandidateRun,
+		dataDir:      d.DataDir,
+		clock:        d.Clock,
+		lookPath:     d.LookPath,
+		executable:   d.Executable,
+		newLaunchID:  d.NewLaunchID,
+		resuming:     make(map[domain.SessionID]struct{}),
 		sendConfirm: sendConfirmConfig{
 			pollInterval:    sendConfirmPollInterval,
 			attemptDeadline: sendConfirmAttemptDeadline,
@@ -323,6 +333,35 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	promptBytes := len(prompt)
 	systemPromptBytes := len(systemPrompt)
 
+	var candidateClaim *ports.CandidateRunClaim
+	var candidateProfile ports.CandidateRunExecutionProfile
+	if m.candidateRun != nil {
+		candidateProfile = m.candidateRun.ExecutionProfile()
+		if candidateProfile.Harness != cfg.Harness {
+			return domain.SessionRecord{}, 0, 0, fmt.Errorf(
+				"spawn: candidate run requires harness %q, got %q",
+				candidateProfile.Harness,
+				cfg.Harness,
+			)
+		}
+		if strings.TrimSpace(candidateProfile.Model) == "" ||
+			strings.TrimSpace(candidateProfile.Effort) == "" ||
+			candidateProfile.Sandbox != "workspace-write" ||
+			candidateProfile.ApprovalPolicy != "on-request" {
+			return domain.SessionRecord{}, 0, 0, errors.New("spawn: candidate run execution profile is incomplete or unsafe")
+		}
+		claim, err := m.candidateRun.Claim(ctx, ports.CandidateRunClaimRequest{
+			ProjectID:       cfg.ProjectID,
+			IssueID:         cfg.IssueID,
+			RequestedBranch: cfg.Branch,
+		})
+		if err != nil {
+			return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: candidate run claim: %w", err)
+		}
+		cfg.Branch = claim.Branch
+		candidateClaim = &claim
+	}
+
 	rec, err := m.store.CreateSession(ctx, seedRecord(cfg, m.clock()))
 	if err != nil {
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: create: %w", err)
@@ -345,6 +384,12 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		// in session lists (e.g. when gitworktree refuses the branch).
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: workspace: %w", id, err)
+	}
+	if candidateClaim != nil {
+		if err := m.candidateRun.RecordAllocation(ctx, *candidateClaim, id, ws.Path); err != nil {
+			m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, false)
+			return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: candidate run allocation: %w", id, err)
+		}
 	}
 
 	// Per-project workspace provisioning: symlink shared files, then run any
@@ -379,6 +424,12 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: no agent adapter for harness %q", id, cfg.Harness)
 	}
 	agentConfig := effectiveAgentConfig(cfg.Kind, project.Config)
+	if candidateClaim != nil {
+		agentConfig.Model = candidateProfile.Model
+		agentConfig.Effort = candidateProfile.Effort
+		agentConfig.Sandbox = candidateProfile.Sandbox
+		agentConfig.Permissions = ports.PermissionModeAcceptEdits
+	}
 	env := m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, project.Config.Env)
 	m.augmentAgentRuntimeEnv(agent, env)
 	if err := m.prepareWorkspace(ctx, agent, id, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
@@ -429,6 +480,12 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: prepare launch: %w", id, err)
 	}
 	defer m.lcm.CancelLaunch(id, launchID)
+	if candidateClaim != nil {
+		if err := m.candidateRun.RecordSessionStartRequested(ctx, id); err != nil {
+			m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
+			return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: candidate run start intent: %w", id, err)
+		}
+	}
 	handle, err := m.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     id,
 		WorkspacePath: ws.Path,
@@ -438,6 +495,20 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	if err != nil {
 		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: runtime: %w", id, err)
+	}
+	if candidateClaim != nil {
+		if err := m.candidateRun.RecordSessionStarted(ctx, id); err != nil {
+			if cleanupErr := m.destroySpawnRuntime(ctx, id, handle, "start observation rejected", false); cleanupErr != nil {
+				return domain.SessionRecord{}, 0, 0, fmt.Errorf(
+					"spawn %s: candidate run started: %w; runtime cleanup: %w",
+					id,
+					err,
+					cleanupErr,
+				)
+			}
+			m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
+			return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: candidate run started: %w", id, err)
+		}
 	}
 
 	metadata := domain.SessionMetadata{
@@ -449,14 +520,40 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		Prompt:            prompt,
 	}
 	if err := m.lcm.MarkSpawned(ctx, id, metadata); err != nil {
-		runtimeDestroyed := m.runtime.Destroy(ctx, handle) == nil
+		runtimeDestroyed := false
+		if candidateClaim != nil {
+			if cleanupErr := m.destroySpawnRuntime(ctx, id, handle, "session lifecycle rejected", true); cleanupErr != nil {
+				return domain.SessionRecord{}, 0, 0, fmt.Errorf(
+					"spawn %s: completed: %w; runtime cleanup: %w",
+					id,
+					err,
+					cleanupErr,
+				)
+			}
+			runtimeDestroyed = true
+		} else {
+			runtimeDestroyed = m.runtime.Destroy(ctx, handle) == nil
+		}
 		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject, runtimeDestroyed)
 		m.markSpawnFailedTerminated(ctx, id)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: completed: %w", id, err)
 	}
 	if delivery == ports.PromptDeliveryAfterStart && prompt != "" {
 		if err := m.deliverAfterStartPrompt(ctx, agent, launchCfg, handle, id, prompt); err != nil {
-			runtimeDestroyed := m.runtime.Destroy(ctx, handle) == nil
+			runtimeDestroyed := false
+			if candidateClaim != nil {
+				if cleanupErr := m.destroySpawnRuntime(ctx, id, handle, "initial prompt delivery failed", true); cleanupErr != nil {
+					return domain.SessionRecord{}, 0, 0, fmt.Errorf(
+						"spawn %s: deliver prompt: %w; runtime cleanup: %w",
+						id,
+						err,
+						cleanupErr,
+					)
+				}
+				runtimeDestroyed = true
+			} else {
+				runtimeDestroyed = m.runtime.Destroy(ctx, handle) == nil
+			}
 			workspaceDestroyed := m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject, runtimeDestroyed)
 			if runtimeDestroyed && workspaceDestroyed {
 				m.markSpawnFailedTerminatedWithoutWorkspace(ctx, id)
@@ -471,6 +568,32 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, 0, 0, err
 	}
 	return rec, promptBytes, systemPromptBytes, nil
+}
+
+func (m *Manager) destroySpawnRuntime(
+	ctx context.Context,
+	id domain.SessionID,
+	handle ports.RuntimeHandle,
+	reason string,
+	recordCandidateStop bool,
+) error {
+	if m.candidateRun == nil {
+		return m.runtime.Destroy(ctx, handle)
+	}
+	prover, ok := m.runtime.(ports.RuntimeStopProver)
+	if !ok {
+		return errors.New("candidate run runtime cannot prove descendant shutdown")
+	}
+	proof, err := prover.DestroyWithProof(ctx, handle)
+	if err != nil {
+		return err
+	}
+	if recordCandidateStop {
+		if err := m.candidateRun.RecordStopped(ctx, id, reason, proof); err != nil {
+			return fmt.Errorf("candidate run stop evidence: %w", err)
+		}
+	}
+	return nil
 }
 
 // loadProject loads the project record so spawn can resolve its per-project
@@ -762,9 +885,23 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	}
 
 	if handle.ID != "" {
-		if err := m.runtime.Destroy(ctx, handle); err != nil {
+		if m.candidateRun != nil {
+			prover, ok := m.runtime.(ports.RuntimeStopProver)
+			if !ok {
+				return false, fmt.Errorf("kill %s: candidate run runtime cannot prove descendant shutdown", id)
+			}
+			proof, err := prover.DestroyWithProof(ctx, handle)
+			if err != nil {
+				return false, fmt.Errorf("kill %s: runtime: %w", id, err)
+			}
+			if err := m.candidateRun.RecordStopped(ctx, id, "session killed", proof); err != nil {
+				return false, fmt.Errorf("kill %s: candidate run stop evidence: %w", id, err)
+			}
+		} else if err := m.runtime.Destroy(ctx, handle); err != nil {
 			return false, fmt.Errorf("kill %s: runtime: %w", id, err)
 		}
+	} else if m.candidateRun != nil {
+		return false, fmt.Errorf("kill %s: candidate run runtime handle is missing", id)
 	}
 	freed := false
 	if workspaceProject {
@@ -921,6 +1058,9 @@ func (m *Manager) retireWorkspaceProjectForReplacement(ctx context.Context, rec 
 // runs before any durable session write, so a failure never resurrects the row
 // or destroys the worktree (it may hold the agent's prior work).
 func (m *Manager) RestoreWithMode(ctx context.Context, id domain.SessionID) (RestoreResult, error) {
+	if m.candidateRun != nil {
+		return RestoreResult{}, fmt.Errorf("restore %s: %w", id, ErrCandidateRunResumeUnsupported)
+	}
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("restore %s: %w", id, err)
@@ -1312,6 +1452,9 @@ func (m *Manager) reconcileReap(ctx context.Context, rec domain.SessionRecord) e
 // Best-effort throughout: a per-session failure is logged and never aborts the
 // pass or blocks boot.
 func (m *Manager) Reconcile(ctx context.Context) error {
+	if m.candidateRun != nil {
+		return ErrCandidateRunResumeUnsupported
+	}
 	recs, err := m.store.ListAllSessions(ctx)
 	if err != nil {
 		return fmt.Errorf("reconcile: list sessions: %w", err)
@@ -1348,6 +1491,9 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 //
 // Failures on individual sessions are logged and do not abort the loop.
 func (m *Manager) RestoreAll(ctx context.Context) error {
+	if m.candidateRun != nil {
+		return ErrCandidateRunResumeUnsupported
+	}
 	recs, err := m.store.ListAllSessions(ctx)
 	if err != nil {
 		return fmt.Errorf("restore-all: list sessions: %w", err)

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -520,7 +520,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		Prompt:            prompt,
 	}
 	if err := m.lcm.MarkSpawned(ctx, id, metadata); err != nil {
-		runtimeDestroyed := false
+		var runtimeDestroyed bool
 		if candidateClaim != nil {
 			if cleanupErr := m.destroySpawnRuntime(ctx, id, handle, "session lifecycle rejected", true); cleanupErr != nil {
 				return domain.SessionRecord{}, 0, 0, fmt.Errorf(
@@ -540,7 +540,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	}
 	if delivery == ports.PromptDeliveryAfterStart && prompt != "" {
 		if err := m.deliverAfterStartPrompt(ctx, agent, launchCfg, handle, id, prompt); err != nil {
-			runtimeDestroyed := false
+			var runtimeDestroyed bool
 			if candidateClaim != nil {
 				if cleanupErr := m.destroySpawnRuntime(ctx, id, handle, "initial prompt delivery failed", true); cleanupErr != nil {
 					return domain.SessionRecord{}, 0, 0, fmt.Errorf(

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +36,7 @@ type fakeStore struct {
 	// sharedLog, when non-nil, receives an ordered call entry for each
 	// UpsertSessionWorktree invocation so ordering tests can compare across fakes.
 	sharedLog *[]string
+	order     *[]string
 }
 
 func newFakeStore() *fakeStore {
@@ -54,6 +56,9 @@ func (f *fakeStore) ListWorkspaceRepos(_ context.Context, projectID string) ([]d
 	return f.workspaceRepo[projectID], nil
 }
 func (f *fakeStore) CreateSession(_ context.Context, rec domain.SessionRecord) (domain.SessionRecord, error) {
+	if f.order != nil {
+		*f.order = append(*f.order, "create-session")
+	}
 	f.num++
 	rec.ID = domain.SessionID(fmt.Sprintf("%s-%d", rec.ProjectID, f.num))
 	f.sessions[rec.ID] = rec
@@ -174,6 +179,7 @@ type fakeRuntime struct {
 	createErr          error
 	destroyErr         error
 	created, destroyed int
+	provedStops        int
 	lastCfg            ports.RuntimeConfig
 	outputs            []string
 	outputCalls        int
@@ -182,6 +188,8 @@ type fakeRuntime struct {
 	aliveByHandle map[string]bool
 	aliveErr      error
 	destroyedIDs  []string
+	order         *[]string
+	stopProof     ports.RuntimeStopProof
 }
 
 type fakeRestartRuntime struct {
@@ -219,6 +227,9 @@ func (r *blockingRestartRuntime) Restart(_ context.Context, handle ports.Runtime
 }
 
 func (r *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
+	if r.order != nil {
+		*r.order = append(*r.order, "create-runtime")
+	}
 	if r.createErr != nil {
 		return ports.RuntimeHandle{}, r.createErr
 	}
@@ -227,9 +238,22 @@ func (r *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.
 	return ports.RuntimeHandle{ID: "h1"}, nil
 }
 func (r *fakeRuntime) Destroy(_ context.Context, handle ports.RuntimeHandle) error {
+	if r.order != nil {
+		*r.order = append(*r.order, "destroy-runtime")
+	}
 	r.destroyed++
 	r.destroyedIDs = append(r.destroyedIDs, handle.ID)
 	return r.destroyErr
+}
+func (r *fakeRuntime) DestroyWithProof(ctx context.Context, handle ports.RuntimeHandle) (ports.RuntimeStopProof, error) {
+	r.provedStops++
+	if err := r.Destroy(ctx, handle); err != nil {
+		return ports.RuntimeStopProof{}, err
+	}
+	if r.stopProof.ProcessID == "" {
+		return ports.RuntimeStopProof{ProcessID: "fake-process", DescendantsRunning: 0}, nil
+	}
+	return r.stopProof, nil
 }
 func (r *fakeRuntime) IsAlive(_ context.Context, handle ports.RuntimeHandle) (bool, error) {
 	if r.aliveErr != nil {
@@ -527,9 +551,13 @@ type fakeWorkspace struct {
 	// sharedLog, when non-nil, receives entries alongside calls so ordering
 	// tests can compare workspace calls against store calls in one sequence.
 	sharedLog *[]string
+	order     *[]string
 }
 
 func (w *fakeWorkspace) Create(_ context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
+	if w.order != nil {
+		*w.order = append(*w.order, "create-workspace")
+	}
 	if w.createErr != nil {
 		return ports.WorkspaceInfo{}, w.createErr
 	}
@@ -582,6 +610,9 @@ func (w *fakeWorkspace) CreateWorkspaceProject(_ context.Context, cfg ports.Work
 }
 func (w *fakeWorkspace) Destroy(_ context.Context, info ports.WorkspaceInfo) error {
 	w.lastDestroyInfo = info
+	if w.order != nil {
+		*w.order = append(*w.order, "destroy-workspace")
+	}
 	if info.RepoPath != "" {
 		entry := "Destroy:" + fakeWorkspaceRepoName(info)
 		w.calls = append(w.calls, entry)
@@ -671,6 +702,86 @@ func fakeWorkspaceRepoName(info ports.WorkspaceInfo) string {
 type fakeMessenger struct {
 	msgs []string
 	err  error
+}
+
+type fakeCandidateRun struct {
+	order           *[]string
+	claimErr        error
+	allocationErr   error
+	startRequestErr error
+	startedErr      error
+	stopErr         error
+	lastStopID      domain.SessionID
+	lastStopReason  string
+	lastStopProof   ports.RuntimeStopProof
+}
+
+func (f *fakeCandidateRun) ExecutionProfile() ports.CandidateRunExecutionProfile {
+	return ports.CandidateRunExecutionProfile{
+		Harness:        domain.HarnessCodex,
+		Model:          "gpt-5.6-codex",
+		Effort:         "high",
+		Sandbox:        "workspace-write",
+		ApprovalPolicy: "on-request",
+	}
+}
+
+func (f *fakeCandidateRun) Claim(context.Context, ports.CandidateRunClaimRequest) (ports.CandidateRunClaim, error) {
+	if f.order != nil {
+		*f.order = append(*f.order, "claim")
+	}
+	if f.claimErr != nil {
+		return ports.CandidateRunClaim{}, f.claimErr
+	}
+	return ports.CandidateRunClaim{
+		Slot:                 "A",
+		ClaimID:              "agent-orchestrator:run:A:process",
+		ControllerInstanceID: "agent-orchestrator:process",
+		Repository:           "taymoork2/tenetfold-orchestration-fixture",
+		IssueNumber:          21,
+		Branch:               "fixture/agent-orchestrator/s1",
+		AllocationKey:        "agent-orchestrator:run:A",
+		IdempotencyKey:       "agent-orchestrator:run:A",
+		SourceWriterMode:     "agent-orchestrator-session",
+	}, nil
+}
+
+func (f *fakeCandidateRun) RecordAllocation(context.Context, ports.CandidateRunClaim, domain.SessionID, string) error {
+	if f.order != nil {
+		*f.order = append(*f.order, "record-allocation")
+	}
+	return f.allocationErr
+}
+
+func (f *fakeCandidateRun) RecordSessionStartRequested(context.Context, domain.SessionID) error {
+	if f.order != nil {
+		*f.order = append(*f.order, "record-start-request")
+	}
+	return f.startRequestErr
+}
+
+func (f *fakeCandidateRun) RecordSessionStarted(context.Context, domain.SessionID) error {
+	if f.order != nil {
+		*f.order = append(*f.order, "record-started")
+	}
+	return f.startedErr
+}
+
+func (f *fakeCandidateRun) RecordPullRequest(context.Context, domain.SessionID, ports.SCMObservation) error {
+	if f.order != nil {
+		*f.order = append(*f.order, "record-pr")
+	}
+	return nil
+}
+
+func (f *fakeCandidateRun) RecordStopped(_ context.Context, id domain.SessionID, reason string, proof ports.RuntimeStopProof) error {
+	if f.order != nil {
+		*f.order = append(*f.order, "record-stopped")
+	}
+	f.lastStopID = id
+	f.lastStopReason = reason
+	f.lastStopProof = proof
+	return f.stopErr
 }
 
 func (m *fakeMessenger) Send(_ context.Context, _ domain.SessionID, msg string) error {
@@ -1035,6 +1146,254 @@ func TestResumeAgent_RejectsConcurrentRequest(t *testing.T) {
 	close(runtime.release)
 	if err := <-firstDone; err != nil {
 		t.Fatalf("first resume: %v", err)
+	}
+}
+
+func TestSpawn_CandidateRunOrdersNativeClaimAllocationAndRuntime(t *testing.T) {
+	var order []string
+	st := newFakeStore()
+	st.order = &order
+	st.projects["fixture"] = domain.ProjectRecord{
+		ID: "fixture",
+		Config: domain.ProjectConfig{
+			Worker: domain.RoleOverride{Harness: domain.HarnessCodex},
+		},
+	}
+	rt := &fakeRuntime{order: &order}
+	ws := &fakeWorkspace{order: &order}
+	agent := &recordingAgent{}
+	candidateRun := &fakeCandidateRun{order: &order}
+	m := New(Deps{
+		Runtime:      rt,
+		Agents:       singleAgent{agent: agent},
+		Workspace:    ws,
+		Store:        st,
+		Messenger:    &fakeMessenger{},
+		Lifecycle:    &fakeLCM{store: st},
+		CandidateRun: candidateRun,
+		LookPath:     func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	rec, _, _, err := m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "fixture",
+		IssueID:   "github:taymoork2/tenetfold-orchestration-fixture#21",
+		Kind:      domain.KindWorker,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	wantOrder := []string{
+		"claim",
+		"create-session",
+		"create-workspace",
+		"record-allocation",
+		"record-start-request",
+		"create-runtime",
+		"record-started",
+	}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Fatalf("candidate run order = %#v, want %#v", order, wantOrder)
+	}
+	if rec.Metadata.Branch != "fixture/agent-orchestrator/s1" {
+		t.Fatalf("spawned branch = %q, want prepared branch", rec.Metadata.Branch)
+	}
+	if got := agent.lastConfig; got.Model != "gpt-5.6-codex" ||
+		got.Effort != "high" ||
+		got.Sandbox != "workspace-write" ||
+		got.Permissions != domain.PermissionModeAcceptEdits {
+		t.Fatalf("agent config = %#v, want exact candidate execution profile", got)
+	}
+}
+
+func TestSpawn_CandidateRunAllocationRejectionReleasesOnlyNativeWorkspace(t *testing.T) {
+	var order []string
+	st := newFakeStore()
+	st.order = &order
+	st.projects["fixture"] = domain.ProjectRecord{
+		ID: "fixture",
+		Config: domain.ProjectConfig{
+			Worker: domain.RoleOverride{Harness: domain.HarnessCodex},
+		},
+	}
+	rt := &fakeRuntime{order: &order}
+	ws := &fakeWorkspace{order: &order}
+	candidateRun := &fakeCandidateRun{
+		order:         &order,
+		allocationErr: errors.New("observer rejected allocation"),
+	}
+	m := New(Deps{
+		Runtime:      rt,
+		Agents:       singleAgent{agent: &recordingAgent{}},
+		Workspace:    ws,
+		Store:        st,
+		Messenger:    &fakeMessenger{},
+		Lifecycle:    &fakeLCM{store: st},
+		CandidateRun: candidateRun,
+		LookPath:     func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	_, _, _, err := m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "fixture",
+		IssueID:   "github:taymoork2/tenetfold-orchestration-fixture#21",
+		Kind:      domain.KindWorker,
+	})
+	if err == nil || !strings.Contains(err.Error(), "candidate run allocation") {
+		t.Fatalf("Spawn error = %v, want allocation rejection", err)
+	}
+	wantOrder := []string{
+		"claim",
+		"create-session",
+		"create-workspace",
+		"record-allocation",
+		"destroy-workspace",
+	}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Fatalf("candidate allocation compensation order = %#v, want %#v", order, wantOrder)
+	}
+	if rt.created != 0 || len(st.sessions) != 0 {
+		t.Fatalf("allocation rejection created runtime=%d sessions=%d, want neither", rt.created, len(st.sessions))
+	}
+}
+
+func TestSpawn_CandidateRunStartedRejectionProvesTeardownBeforeWorkspaceRelease(t *testing.T) {
+	var order []string
+	st := newFakeStore()
+	st.order = &order
+	st.projects["fixture"] = domain.ProjectRecord{
+		ID: "fixture",
+		Config: domain.ProjectConfig{
+			Worker: domain.RoleOverride{Harness: domain.HarnessCodex},
+		},
+	}
+	rt := &fakeRuntime{order: &order}
+	ws := &fakeWorkspace{order: &order}
+	candidateRun := &fakeCandidateRun{
+		order:      &order,
+		startedErr: errors.New("observer rejected started event"),
+	}
+	m := New(Deps{
+		Runtime:      rt,
+		Agents:       singleAgent{agent: &recordingAgent{}},
+		Workspace:    ws,
+		Store:        st,
+		Messenger:    &fakeMessenger{},
+		Lifecycle:    &fakeLCM{store: st},
+		CandidateRun: candidateRun,
+		LookPath:     func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	_, _, _, err := m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "fixture",
+		IssueID:   "github:taymoork2/tenetfold-orchestration-fixture#21",
+		Kind:      domain.KindWorker,
+	})
+	if err == nil || !strings.Contains(err.Error(), "candidate run started") {
+		t.Fatalf("Spawn error = %v, want started-event rejection", err)
+	}
+	if rt.provedStops != 1 {
+		t.Fatalf("proof-capable runtime teardowns = %d, want 1", rt.provedStops)
+	}
+	destroyRuntime := slices.Index(order, "destroy-runtime")
+	destroyWorkspace := slices.Index(order, "destroy-workspace")
+	if destroyRuntime < 0 || destroyWorkspace < 0 || destroyRuntime > destroyWorkspace {
+		t.Fatalf("candidate started compensation order = %#v, want runtime proof before workspace release", order)
+	}
+	if len(st.sessions) != 0 {
+		t.Fatalf("started rejection left %d session rows, want seed row removed", len(st.sessions))
+	}
+}
+
+func TestKill_CandidateRunRecordsZeroDescendantsBeforeWorkspaceTeardown(t *testing.T) {
+	var order []string
+	st := newFakeStore()
+	st.projects["fixture"] = domain.ProjectRecord{
+		ID: "fixture",
+		Config: domain.ProjectConfig{
+			Worker: domain.RoleOverride{Harness: domain.HarnessCodex},
+		},
+	}
+	rt := &fakeRuntime{
+		order: &order,
+		stopProof: ports.RuntimeStopProof{
+			ProcessID:          "4242",
+			DescendantIDs:      []string{"4243"},
+			DescendantsRunning: 0,
+		},
+	}
+	ws := &fakeWorkspace{order: &order}
+	candidateRun := &fakeCandidateRun{order: &order}
+	m := New(Deps{
+		Runtime:      rt,
+		Agents:       singleAgent{agent: &recordingAgent{}},
+		Workspace:    ws,
+		Store:        st,
+		Messenger:    &fakeMessenger{},
+		Lifecycle:    &fakeLCM{store: st},
+		CandidateRun: candidateRun,
+		LookPath:     func(string) (string, error) { return "/bin/true", nil },
+	})
+	rec, _, _, err := m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "fixture",
+		IssueID:   "github:taymoork2/tenetfold-orchestration-fixture#21",
+		Kind:      domain.KindWorker,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	order = nil
+
+	freed, err := m.Kill(ctx, rec.ID)
+	if err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if !freed {
+		t.Fatal("Kill freed = false, want workspace released")
+	}
+	wantOrder := []string{"destroy-runtime", "record-stopped", "destroy-workspace"}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Fatalf("candidate stop order = %#v, want %#v", order, wantOrder)
+	}
+	if candidateRun.lastStopID != rec.ID ||
+		candidateRun.lastStopReason != "session killed" ||
+		!reflect.DeepEqual(candidateRun.lastStopProof.DescendantIDs, []string{"4243"}) ||
+		candidateRun.lastStopProof.DescendantsRunning != 0 {
+		t.Fatalf("candidate stop evidence = id %q reason %q proof %#v", candidateRun.lastStopID, candidateRun.lastStopReason, candidateRun.lastStopProof)
+	}
+}
+
+func TestRestore_CandidateRunRejectsUnobservedResumeBeforeWorkspace(t *testing.T) {
+	st := newFakeStore()
+	st.projects["fixture"] = domain.ProjectRecord{
+		ID: "fixture",
+		Config: domain.ProjectConfig{
+			Worker: domain.RoleOverride{Harness: domain.HarnessCodex},
+		},
+	}
+	seedTerminal(st, "fixture-1", domain.SessionMetadata{
+		WorkspacePath:  "/ws/fixture-1",
+		Branch:         "fixture/agent-orchestrator/s1",
+		AgentSessionID: "codex-session",
+	})
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	m := New(Deps{
+		Runtime:      rt,
+		Agents:       singleAgent{agent: &recordingAgent{}},
+		Workspace:    ws,
+		Store:        st,
+		Messenger:    &fakeMessenger{},
+		Lifecycle:    &fakeLCM{store: st},
+		CandidateRun: &fakeCandidateRun{},
+		LookPath:     func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	_, err := m.RestoreWithMode(ctx, "fixture-1")
+	if err == nil || !strings.Contains(err.Error(), "candidate run observer does not authorize resume") {
+		t.Fatalf("Restore error = %v, want candidate observer resume rejection", err)
+	}
+	if rt.created != 0 || len(ws.calls) != 0 {
+		t.Fatalf("candidate restore created runtime=%d workspace calls=%#v, want no effects", rt.created, ws.calls)
 	}
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Start with [architecture.md](architecture.md) for the current backend model and
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | [architecture.md](architecture.md)                     | Current backend model, package layout, status derivation, persistence/CDC, and load-bearing rules.                    |
 | [backend-code-structure.md](backend-code-structure.md) | Package ownership rules for the Go backend: domain, services, ports, adapters, storage, HTTP, CLI, and daemon wiring. |
+| [candidate-run-observer.md](candidate-run-observer.md) | Optional digest-bound observer integration for governed candidate evaluations, including authority and gaps.         |
 | [cli/README.md](cli/README.md)                         | CLI commands and daemon control surface.                                                                              |
 | [STATUS.md](STATUS.md)                                 | What is shipped on `main` today and what is still in flight.                                                          |
 | [stack.md](stack.md)                                   | Accepted library/runtime choices, pending stack decisions, and dependencies explicitly avoided for V1.                |

--- a/docs/candidate-run-observer.md
+++ b/docs/candidate-run-observer.md
@@ -1,0 +1,147 @@
+# Candidate-run observer boundary
+
+Agent Orchestrator can attach one external candidate-run kernel as an
+observer-only evaluation boundary. AO remains the sole dispatcher: it claims
+the prepared task, allocates the native git worktree, launches Codex, observes
+the pull request, and stops the runtime. The external module only configures its
+journal and acknowledges AO-native facts.
+
+This surface is disabled unless `AO_CANDIDATE_RUN_CONFIG` names an absolute
+binding file. Normal AO behavior is unchanged when the variable is absent.
+
+## Binding
+
+The binding is non-secret. It must not contain provider tokens, login material,
+or copied user configuration. Authentication is established separately before
+activation and represented here only by non-secret status and policy
+attestations in the schema-v2 activation profile.
+
+```json
+{
+  "schemaVersion": 1,
+  "nodeBinary": "/absolute/path/to/node",
+  "journalDirectory": "/absolute/path/to/run-journal",
+  "kernel": {
+    "modulePath": "/absolute/path/to/candidate-run.mjs",
+    "sha256": "<64-lowercase-hex>"
+  },
+  "controllerClaim": {
+    "eventId": "<controller-event-id>",
+    "claimId": "<controller-claim-id>",
+    "claimedAt": "2026-07-26T20:00:00.000Z"
+  },
+  "codex": {
+    "harness": "codex",
+    "approvalPolicy": "on-request"
+  },
+  "activationProfile": {
+    "schemaVersion": 2,
+    "candidateSlug": "agent-orchestrator",
+    "candidateVersion": "<exact-version>",
+    "adapterRevision": "<exact-source-revision>",
+    "adapterDigest": "<artifact-sha256>",
+    "workerRuntime": "Codex CLI",
+    "modelProvider": "OpenAI",
+    "modelAuthRoute": "<approved-enterprise-route>",
+    "authStatus": "available",
+    "authStateScope": "<approved-org-scope>",
+    "model": "<exact-codex-model>",
+    "effort": "<exact-effort>",
+    "sandbox": "workspace-write",
+    "privacyPosture": "<attested-policy>",
+    "meteringPosture": "<attested-quota>",
+    "lastVerifiedAt": "<ISO-8601>",
+    "nextAuthAction": "none"
+  },
+  "prepared": {
+    "candidateSlug": "agent-orchestrator",
+    "runId": "<run-id>",
+    "scenario": "<scenario-id>",
+    "repository": "<owner/repository>",
+    "controllerOwner": "<controller-id>",
+    "dispatcher": "agent-orchestrator",
+    "candidateRoleClass": "Orchestrator",
+    "workspaceAllocator": "agent-orchestrator-worktree",
+    "initiationMode": "automatic",
+    "workerLimit": 1,
+    "activationProfileDigest": "<canonical-profile-sha256>",
+    "tasks": [
+      {
+        "slot": "<slot>",
+        "issueNumber": 123,
+        "schedulingOrder": 0,
+        "idempotencyKey": "<idempotency-key>",
+        "allocationKey": "<allocation-key>",
+        "workspaceMode": "native-after-claim",
+        "sourceWriterMode": "agent-orchestrator-session",
+        "workspace": null,
+        "branch": "<prepared-branch>",
+        "sourceWriter": null,
+        "authorizedFiles": ["<authorized-path>"]
+      }
+    ]
+  }
+}
+```
+
+AO rejects a relative binding, a symlinked binding or kernel module, an
+unrecognized top-level field, a kernel digest mismatch, a non-v2 activation
+profile, a non-Codex harness, any approval policy other than `on-request`, or a
+profile without an exact model, effort, and `workspace-write` sandbox. AO also
+requires a lowercase SHA-256 activation-profile digest and requires every task
+to carry its zero-based array position as `schedulingOrder`. The digest value is
+produced and compared with the canonical activation profile by the external
+fixture kernel; AO does not implement a competing digest authority.
+
+The sidecar is one long-lived Node process owned by the AO daemon. Its protocol
+is newline-framed JSON over stdio. Only `configure` and `observe` are accepted;
+`start`, `resume`, `stop`, and every unknown method fail closed. The external
+module must expose the candidate-run kernel and journal factories used by the
+binding.
+
+## Lifecycle order
+
+For an admitted task, the session manager enforces:
+
+1. Resolve the prepared GitHub issue and synchronously acknowledge
+   `task-claimed`.
+2. Create the AO session row and native worktree.
+3. Record the complete allocation receipt before provisioning or runtime work.
+4. Construct Codex launch argv with the profile's exact model, effort,
+   `workspace-write` sandbox, and `on-request` approval policy.
+5. Acknowledge `session-start-requested`, then let AO's native runtime create
+   the session, then acknowledge `session-started`.
+6. Persist a GitHub PR observation with its semantic hashes held back, validate
+   the prepared repository, issue, and source branch through the candidate
+   kernel, then let the normal lifecycle reducer acknowledge it.
+7. On explicit session kill, destroy the native tmux session, terminate and
+   enumerate its pane-session descendants, require zero survivors, record
+   `worker-stopped` and `descendants-stopped`, and only then release the
+   worktree.
+
+Claim rejection has no session or workspace effect. Allocation or pre-runtime
+rejection removes only the clean AO-created workspace and seed row. A
+post-launch rejection requires proof-capable runtime teardown before AO may
+release that workspace. PR rejection leaves the prior semantic hash cursor in
+place so the observation is retried rather than treated as acknowledged.
+
+## Deliberate limits
+
+- AO's native worktree and runtime adapters remain authoritative. The external
+  module is not a second controller and cannot allocate a workspace or launch a
+  worker.
+- Candidate-mode boot reconciliation and session restore are rejected because
+  this observer protocol has no resume event. A run must use its isolated,
+  controller-approved AO data directory.
+- Closing the AO daemon does not imply a candidate stop. The run controller
+  must use the explicit AO session-kill path while the observer is available.
+- GitHub PR/review facts are observed through AO's existing GitHub adapter.
+  GitHub Projects V2 **Human Review** state is not implemented by this
+  boundary. A draft PR, a GitHub review decision, and the fixture's Human
+  Review gate are distinct facts.
+- The binding does not perform login, select an organization, inspect
+  credential values, attest privacy policy, or reserve quota. Those remain
+  activation checks owned by the admitting controller.
+- On macOS/Linux, `tmux` must already resolve on the daemon's `PATH`. A
+  controller may prepend a digest-pinned Nix store `bin` path; AO does not
+  install or update tmux.

--- a/docs/candidate-run-observer.md
+++ b/docs/candidate-run-observer.md
@@ -16,6 +16,10 @@ or copied user configuration. Authentication is established separately before
 activation and represented here only by non-secret status and policy
 attestations in the schema-v2 activation profile.
 
+This sample tracks the fixture candidate-run kernel contract at
+`617bf9b6793932a4bbc7d84e999684d8cb1d043a`; activation must separately pin
+the reviewed kernel module bytes with `kernel.sha256`.
+
 ```json
 {
   "schemaVersion": 1,
@@ -40,6 +44,7 @@ attestations in the schema-v2 activation profile.
     "candidateVersion": "<exact-version>",
     "adapterRevision": "<exact-source-revision>",
     "adapterDigest": "<artifact-sha256>",
+    "adapterArtifact": "<reviewed-adapter-artifact>",
     "workerRuntime": "Codex CLI",
     "modelProvider": "OpenAI",
     "modelAuthRoute": "<approved-enterprise-route>",
@@ -90,8 +95,9 @@ profile, a non-Codex harness, any approval policy other than `on-request`, or a
 profile without an exact model, effort, and `workspace-write` sandbox. AO also
 requires a lowercase SHA-256 activation-profile digest and requires every task
 to carry its zero-based array position as `schedulingOrder`. The digest value is
-produced and compared with the canonical activation profile by the external
-fixture kernel; AO does not implement a competing digest authority.
+produced and compared with the full canonical schema-v2 activation profile by
+the external fixture kernel, including `adapterArtifact` and `modelProvider`;
+AO does not implement a competing digest authority.
 
 The sidecar is one long-lived Node process owned by the AO daemon. Its protocol
 is newline-framed JSON over stdio. Only `configure` and `observe` are accepted;


### PR DESCRIPTION
## What

Add a provider-free candidate-run observer boundary while keeping Agent Orchestrator as the sole native dispatcher and workspace allocator.

- bind an external, digest-pinned framed-stdio observer sidecar
- claim before native workspace creation and record allocation before runtime launch
- validate controller-supplied activation-profile digests and zero-based task scheduling order
- enforce the prepared Codex model, effort, sandbox, and approval profile on launch and restore
- observe target-bound pull requests and prove zero descendants before workspace teardown

## Why

External evaluation needs durable lifecycle observations without introducing a second controller or granting the observer runtime-control authority.

## How

The daemon owns one long-lived configure/observe-only sidecar. The adapter rejects start, resume, and stop commands, fails closed on invalid prepared data or observations, and compensates only Agent Orchestrator-owned clean allocation/runtime state. The activation-profile digest remains controller-canonical and binds the full schema-v2 profile, including `modelProvider` and `adapterArtifact`.

GitHub Projects Human Review remains an explicit external read-only observation gap; a draft pull request is not treated as Human Review.

## Testing

- `go test ./internal/session_manager -run '^(TestSpawn_CandidateRunAllocationRejectionReleasesOnlyNativeWorkspace|TestSpawn_CandidateRunStartedRejectionProvesTeardownBeforeWorkspaceRelease|TestSpawn_AfterStartPromptFailureCleansUpSpawn|TestSpawn_AfterStartPromptFailureCleansUpWorkspaceProjectRows)$' -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs ./internal/session_manager`
- `npm run lint`

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
