### PR TITLE
feat: per-role Codex model and reasoning configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,34 @@ Reviewer agents are configured separately. The current reviewer harnesses are:
 
 **If it runs in a terminal, it runs on Agent Orchestrator.**
 
+### Per-role Codex model and reasoning
+
+Project defaults can be overridden independently for workers and orchestrators:
+
+```yaml
+orchestrator:
+  agent: codex
+  agentConfig:
+    model: gpt-5.6-sol
+    reasoningEffort: high
+
+worker:
+  agent: codex
+  agentConfig:
+    model: gpt-5.6-terra
+    reasoningEffort: medium
+```
+
+Role values override project-wide defaults. Valid reasoning efforts: `low`,
+`medium`, `high`, `xhigh`. AO forwards resolved values to both launch and
+native resume; no change to `~/.codex/config.toml` is required. Store config
+through `ao project set-config <id> --config-json '<JSON object>'`.
+
+The desktop model picker offers `gpt-5.6-sol`, `gpt-5.6-terra`,
+`gpt-5.6-luna`, and `gpt-5.5`. Custom model IDs remain supported. The “Sol
+orchestrates, Terra works” preset configures a Sol/high orchestrator and
+Terra/medium workers in one action.
+
 ## Install
 
 Download the latest desktop build for your platform:

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -91,6 +91,12 @@ func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 				Type:        ports.ConfigFieldString,
 				Description: "Model override passed to `codex --model`.",
 			},
+			{
+				Key:         "reasoningEffort",
+				Type:        ports.ConfigFieldEnum,
+				Description: "Reasoning effort passed to Codex as `model_reasoning_effort`.",
+				Enum:        []string{"low", "medium", "high", "xhigh"},
+			},
 		},
 	}, nil
 }
@@ -115,6 +121,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	appendTerminalCompatibilityFlags(&cmd)
 	appendWorkspaceTrustFlag(&cmd, cfg.WorkspacePath)
 	appendModelFlag(&cmd, cfg.Config)
+	appendReasoningEffortFlag(&cmd, cfg.Config)
 
 	if cfg.SystemPrompt != "" {
 		cmd = append(cmd, "-c", "developer_instructions="+codexTOMLConfigString(cfg.SystemPrompt))
@@ -157,6 +164,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	appendTerminalCompatibilityFlags(&cmd)
 	appendWorkspaceTrustFlag(&cmd, cfg.Session.WorkspacePath)
 	appendModelFlag(&cmd, cfg.Config)
+	appendReasoningEffortFlag(&cmd, cfg.Config)
 	if cfg.SystemPrompt != "" {
 		cmd = append(cmd, "-c", "developer_instructions="+codexTOMLConfigString(cfg.SystemPrompt))
 	} else if cfg.SystemPromptFile != "" {
@@ -377,6 +385,12 @@ func appendTerminalCompatibilityFlags(cmd *[]string) {
 func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
 	if model := strings.TrimSpace(cfg.Model); model != "" {
 		*cmd = append(*cmd, "--model", model)
+	}
+}
+
+func appendReasoningEffortFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if effort := strings.TrimSpace(cfg.ReasoningEffort); effort != "" {
+		*cmd = append(*cmd, "-c", `model_reasoning_effort="`+effort+`"`)
 	}
 }
 

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -54,6 +54,7 @@ func TestGetLaunchCommandBuildsCrossPlatformArgv(t *testing.T) {
 
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		Permissions:      ports.PermissionModeBypassPermissions,
+		Config:           ports.AgentConfig{Model: " gpt-5.6-sol ", ReasoningEffort: "high"},
 		Prompt:           "-fix this",
 		SystemPromptFile: filepath.Join("tmp", "prompt with spaces.md"),
 		SystemPrompt:     "inline wins",
@@ -76,6 +77,8 @@ func TestGetLaunchCommandBuildsCrossPlatformArgv(t *testing.T) {
 	}
 	want = append(want,
 		"-c", `projects={`+codexTOMLConfigString(workspace)+`={trust_level="trusted"}}`,
+		"--model", "gpt-5.6-sol",
+		"-c", `model_reasoning_effort="high"`,
 		"-c", "developer_instructions="+codexTOMLConfigString("inline wins"),
 		"--", "-fix this",
 	)
@@ -105,17 +108,30 @@ func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "codex"}
 
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
-		Config: ports.AgentConfig{Model: "  gpt-5.4-mini  "},
+		Config: ports.AgentConfig{Model: "  gpt-5.6-sol  ", ReasoningEffort: "high"},
 		Prompt: "fix this",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !containsSubsequence(cmd, []string{"--model", "gpt-5.4-mini"}) {
-		t.Fatalf("command %#v missing trimmed --model flag", cmd)
+	if !containsSubsequence(cmd, []string{"--model", "gpt-5.6-sol", "-c", `model_reasoning_effort="high"`}) {
+		t.Fatalf("command %#v missing model/reasoning flags", cmd)
 	}
-	if containsSubsequence(cmd, []string{"--model", "  gpt-5.4-mini  "}) {
+	if containsSubsequence(cmd, []string{"--model", "  gpt-5.6-sol  "}) {
 		t.Fatalf("command %#v used untrimmed model", cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankReasoningEffort(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "codex"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{Config: ports.AgentConfig{ReasoningEffort: " \t "}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, arg := range cmd {
+		if strings.Contains(arg, "model_reasoning_effort") {
+			t.Fatalf("command %#v contains reasoning effort for blank value", cmd)
+		}
 	}
 }
 
@@ -338,6 +354,12 @@ func TestGetConfigSpecReportsModelField(t *testing.T) {
 			Type:        ports.ConfigFieldString,
 			Description: "Model override passed to `codex --model`.",
 		},
+		{
+			Key:         "reasoningEffort",
+			Type:        ports.ConfigFieldEnum,
+			Description: "Reasoning effort passed to Codex as `model_reasoning_effort`.",
+			Enum:        []string{"low", "medium", "high", "xhigh"},
+		},
 	}
 	if !reflect.DeepEqual(spec.Fields, want) {
 		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
@@ -519,6 +541,7 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 
 	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
 		Permissions:      ports.PermissionModeAuto,
+		Config:           ports.AgentConfig{Model: " gpt-5.6-terra ", ReasoningEffort: "medium"},
 		SystemPrompt:     "restore inline wins",
 		SystemPromptFile: filepath.Join("tmp", "restore-system.md"),
 		Session: ports.SessionRef{
@@ -547,6 +570,8 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 	}
 	want = append(want,
 		"-c", `projects={`+codexTOMLConfigString(workspace)+`={trust_level="trusted"}}`,
+		"--model", "gpt-5.6-terra",
+		"-c", `model_reasoning_effort="medium"`,
 		"-c", "developer_instructions="+codexTOMLConfigString("restore inline wins"),
 		"thread-123",
 	)
@@ -559,7 +584,7 @@ func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "codex"}
 
 	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
-		Config: ports.AgentConfig{Model: "  gpt-5.4-mini  "},
+		Config: ports.AgentConfig{Model: "  gpt-5.6-terra  ", ReasoningEffort: "medium"},
 		Session: ports.SessionRef{
 			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "thread-123"},
 		},
@@ -570,8 +595,30 @@ func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
 	if !ok {
 		t.Fatal("ok = false, want true")
 	}
-	if !containsSubsequence(cmd, []string{"--model", "gpt-5.4-mini"}) {
-		t.Fatalf("restore command %#v missing trimmed --model flag", cmd)
+	if !containsSubsequence(cmd, []string{"--model", "gpt-5.6-terra", "-c", `model_reasoning_effort="medium"`}) {
+		t.Fatalf("restore command %#v missing model/reasoning flags", cmd)
+	}
+}
+
+func TestGetRestoreCommandOmitsBlankReasoningEffort(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "codex"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{ReasoningEffort: " \t "},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "thread-123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	for _, arg := range cmd {
+		if strings.Contains(arg, "model_reasoning_effort") {
+			t.Fatalf("restore command %#v contains reasoning effort for blank value", cmd)
+		}
 	}
 }
 

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -75,8 +75,9 @@ type workspaceRepoDetails struct {
 
 // agentConfig mirrors the daemon's typed domain.AgentConfig for the CLI client.
 type agentConfig struct {
-	Model       string `json:"model,omitempty"`
-	Permissions string `json:"permissions,omitempty"`
+	Model           string `json:"model,omitempty"`
+	ReasoningEffort string `json:"reasoningEffort,omitempty"`
+	Permissions     string `json:"permissions,omitempty"`
 }
 
 // roleOverride mirrors domain.RoleOverride.

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -95,6 +95,16 @@ func TestBuildProjectConfigTrackerIntakeFlags(t *testing.T) {
 	}
 }
 
+func TestBuildProjectConfigPreservesRoleReasoningEffort(t *testing.T) {
+	got, err := buildProjectConfig(projectSetConfigOptions{configJSON: `{"orchestrator":{"agent":"codex","agentConfig":{"model":"gpt-5.6-sol","reasoningEffort":"high"}},"worker":{"agent":"codex","agentConfig":{"model":"gpt-5.6-terra","reasoningEffort":"medium"}}}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Orchestrator.AgentConfig.ReasoningEffort != "high" || got.Worker.AgentConfig.ReasoningEffort != "medium" {
+		t.Fatalf("reasoning efforts = orchestrator %q worker %q, want high/medium", got.Orchestrator.AgentConfig.ReasoningEffort, got.Worker.AgentConfig.ReasoningEffort)
+	}
+}
+
 func TestProjectList_Success(t *testing.T) {
 	cfg := setConfigEnv(t)
 	srv, capture := projectServer(t, http.StatusOK, `{"projects":[{"id":"zeta","name":"Zeta","sessionPrefix":"zeta"},{"id":"alpha","name":"Alpha","sessionPrefix":"alpha","resolveError":"config missing"}]}`)

--- a/backend/internal/domain/agentconfig.go
+++ b/backend/internal/domain/agentconfig.go
@@ -1,6 +1,9 @@
 package domain
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // PermissionMode controls how much review an agent requires before acting. It
 // lives in domain (not ports) so the typed AgentConfig can carry it; ports
@@ -25,6 +28,8 @@ const (
 type AgentConfig struct {
 	// Model overrides the agent's default model (e.g. claude-opus-4-5).
 	Model string `json:"model,omitempty"`
+	// ReasoningEffort overrides the agent's reasoning effort when supported.
+	ReasoningEffort string `json:"reasoningEffort,omitempty"`
 	// Permissions sets the agent's starting permission mode. Empty is treated
 	// like the adapter's default mode.
 	Permissions PermissionMode `json:"permissions,omitempty"`
@@ -41,8 +46,18 @@ func (c AgentConfig) IsZero() bool {
 func (c AgentConfig) Validate() error {
 	switch c.Permissions {
 	case "", PermissionModeDefault, PermissionModeAcceptEdits, PermissionModeAuto, PermissionModeBypassPermissions:
-		return nil
 	default:
 		return fmt.Errorf("invalid permissions %q: want one of default, accept-edits, auto, bypass-permissions", c.Permissions)
 	}
+
+	effort := strings.TrimSpace(c.ReasoningEffort)
+	switch effort {
+	case "":
+		return nil
+	case "low", "medium", "high", "xhigh":
+		if effort == c.ReasoningEffort {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid reasoning effort %q: want one of low, medium, high, xhigh", c.ReasoningEffort)
 }

--- a/backend/internal/domain/projectconfig_test.go
+++ b/backend/internal/domain/projectconfig_test.go
@@ -10,6 +10,9 @@ func TestProjectConfigValidate(t *testing.T) {
 	}{
 		{"empty ok", ProjectConfig{}, false},
 		{"good agent config", ProjectConfig{AgentConfig: AgentConfig{Model: "m", Permissions: PermissionModeAuto}}, false},
+		{"good reasoning effort", ProjectConfig{AgentConfig: AgentConfig{ReasoningEffort: "high"}}, false},
+		{"blank reasoning effort", ProjectConfig{AgentConfig: AgentConfig{ReasoningEffort: " \t "}}, false},
+		{"bad reasoning effort", ProjectConfig{AgentConfig: AgentConfig{ReasoningEffort: "extreme"}}, true},
 		{"bad permission", ProjectConfig{AgentConfig: AgentConfig{Permissions: "yolo"}}, true},
 		{"good session prefix", ProjectConfig{SessionPrefix: "ao"}, false},
 		{"session prefix with slash", ProjectConfig{SessionPrefix: "ao/project"}, true},
@@ -18,6 +21,8 @@ func TestProjectConfigValidate(t *testing.T) {
 		{"good role override", ProjectConfig{Worker: RoleOverride{Harness: HarnessCodex}}, false},
 		{"unknown role harness", ProjectConfig{Orchestrator: RoleOverride{Harness: "nope"}}, true},
 		{"bad role agent config", ProjectConfig{Worker: RoleOverride{AgentConfig: AgentConfig{Permissions: "nope"}}}, true},
+		{"good role reasoning effort", ProjectConfig{Worker: RoleOverride{AgentConfig: AgentConfig{ReasoningEffort: "medium"}}}, false},
+		{"bad role reasoning effort", ProjectConfig{Orchestrator: RoleOverride{AgentConfig: AgentConfig{ReasoningEffort: "max"}}}, true},
 		{"good symlinks", ProjectConfig{Symlinks: []string{".env", "configs/dev.toml"}}, false},
 		{"symlink absolute path", ProjectConfig{Symlinks: []string{"/etc/passwd"}}, true},
 		{"symlink parent escape", ProjectConfig{Symlinks: []string{"../escape"}}, true},

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2577,6 +2577,8 @@ components:
           type: string
         permissions:
           type: string
+        reasoningEffort:
+          type: string
       type: object
     AgentInfo:
       properties:

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -232,6 +232,39 @@ func TestProjectsAPI_UpdateSettings(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_JSON")
 }
 
+func TestProjectsAPI_ReasoningEffortRoundTrip(t *testing.T) {
+	srv := newTestServer(t)
+	repo := gitRepo(t, "reasoning-effort")
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/projects", `{"path":`+quote(repo)+`,"projectId":"reasoning"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("seed create = %d, want 201; body=%s", status, body)
+	}
+
+	config := `{"config":{"orchestrator":{"agent":"codex","agentConfig":{"model":"gpt-5.6-sol","reasoningEffort":"high"}},"worker":{"agent":"codex","agentConfig":{"model":"gpt-5.6-terra","reasoningEffort":"medium"}}}}`
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/projects/reasoning/config", config)
+	if status != http.StatusOK {
+		t.Fatalf("PUT config = %d, want 200; body=%s", status, body)
+	}
+
+	body, status, _ = doRequest(t, srv, "GET", "/api/v1/projects/reasoning", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET project = %d, want 200; body=%s", status, body)
+	}
+	var get struct {
+		Project struct {
+			Config domain.ProjectConfig `json:"config"`
+		} `json:"project"`
+	}
+	mustJSON(t, body, &get)
+	if got := get.Project.Config.Orchestrator.AgentConfig; got.Model != "gpt-5.6-sol" || got.ReasoningEffort != "high" {
+		t.Fatalf("orchestrator config = %#v, want gpt-5.6-sol/high", got)
+	}
+	if got := get.Project.Config.Worker.AgentConfig; got.Model != "gpt-5.6-terra" || got.ReasoningEffort != "medium" {
+		t.Fatalf("worker config = %#v, want gpt-5.6-terra/medium", got)
+	}
+}
+
 func TestProjectsAPI_AddValidationAndConflicts(t *testing.T) {
 
 	srv := newTestServer(t)

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -781,6 +781,9 @@ func effectiveAgentConfig(kind domain.SessionKind, cfg domain.ProjectConfig) por
 	if override.Model != "" {
 		merged.Model = override.Model
 	}
+	if strings.TrimSpace(override.ReasoningEffort) != "" {
+		merged.ReasoningEffort = override.ReasoningEffort
+	}
 	if override.Permissions != "" {
 		merged.Permissions = override.Permissions
 	}

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -121,9 +121,13 @@ func TestHookPATH(t *testing.T) {
 
 func TestEffectiveHarnessAndAgentConfig(t *testing.T) {
 	cfg := domain.ProjectConfig{
-		AgentConfig:  domain.AgentConfig{Model: "base", Permissions: domain.PermissionModeAuto},
-		Worker:       domain.RoleOverride{Harness: domain.HarnessCodex, AgentConfig: domain.AgentConfig{Model: "worker"}},
-		Orchestrator: domain.RoleOverride{Harness: domain.HarnessClaudeCode},
+		AgentConfig: domain.AgentConfig{Model: "base-model", ReasoningEffort: "low", Permissions: domain.PermissionModeAuto},
+		Worker: domain.RoleOverride{Harness: domain.HarnessCodex, AgentConfig: domain.AgentConfig{
+			Model: "gpt-5.6-terra", ReasoningEffort: "medium",
+		}},
+		Orchestrator: domain.RoleOverride{Harness: domain.HarnessClaudeCode, AgentConfig: domain.AgentConfig{
+			Model: "gpt-5.6-sol", ReasoningEffort: "high",
+		}},
 	}
 
 	// Explicit harness always wins.
@@ -140,12 +144,24 @@ func TestEffectiveHarnessAndAgentConfig(t *testing.T) {
 
 	// Role override merges over the base agent config (set fields win; unset keep base).
 	got := effectiveAgentConfig(domain.KindWorker, cfg)
-	if got.Model != "worker" || got.Permissions != domain.PermissionModeAuto {
-		t.Fatalf("merged worker config = %#v, want model=worker permissions=auto", got)
+	if got.Model != "gpt-5.6-terra" || got.ReasoningEffort != "medium" || got.Permissions != domain.PermissionModeAuto {
+		t.Fatalf("merged worker config = %#v, want model=gpt-5.6-terra reasoning=medium permissions=auto", got)
 	}
-	// Orchestrator has no agent-config override, so the base config is used as-is.
-	if got := effectiveAgentConfig(domain.KindOrchestrator, cfg); got.Model != "base" {
-		t.Fatalf("orchestrator config = %#v, want base", got)
+	if got := effectiveAgentConfig(domain.KindOrchestrator, cfg); got.Model != "gpt-5.6-sol" || got.ReasoningEffort != "high" || got.Permissions != domain.PermissionModeAuto {
+		t.Fatalf("orchestrator config = %#v, want model=gpt-5.6-sol reasoning=high permissions=auto", got)
+	}
+}
+
+func TestEffectiveAgentConfigBlankRoleReasoningEffortKeepsBase(t *testing.T) {
+	cfg := domain.ProjectConfig{
+		AgentConfig: domain.AgentConfig{ReasoningEffort: "high"},
+		Worker: domain.RoleOverride{AgentConfig: domain.AgentConfig{
+			ReasoningEffort: " \t ",
+		}},
+	}
+
+	if got := effectiveAgentConfig(domain.KindWorker, cfg); got.ReasoningEffort != "high" {
+		t.Fatalf("worker reasoning effort = %q, want inherited base value %q", got.ReasoningEffort, "high")
 	}
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Start with [architecture.md](architecture.md) for the current backend model and
 | [backend-code-structure.md](backend-code-structure.md) | Package ownership rules for the Go backend: domain, services, ports, adapters, storage, HTTP, CLI, and daemon wiring. |
 | [cli/README.md](cli/README.md)                         | CLI commands and daemon control surface.                                                                              |
 | [development.md](development.md)                       | Prerequisites, build steps, running tests, and troubleshooting for local development.                                 |
+| [per-role-agent-config.md](per-role-agent-config.md)   | Per-role model and reasoning configuration: resolution rules, Codex mapping, session lifecycle, and verification.     |
 | [STATUS.md](STATUS.md)                                 | What is shipped on `main` today and what is still in flight.                                                          |
 | [stack.md](stack.md)                                   | Accepted library/runtime choices, pending stack decisions, and dependencies explicitly avoided for V1.                |
 | [telemetry.md](telemetry.md)                           | Telemetry collection, privacy safeguards, configuration, and PostHog dashboard guidance.                              |

--- a/docs/per-role-agent-config.md
+++ b/docs/per-role-agent-config.md
@@ -1,0 +1,152 @@
+# Per-role agent model and reasoning configuration
+
+Workers and orchestrators can be pointed at different models and different
+reasoning efforts within one project — for example a stronger, higher-reasoning
+model orchestrating while cheaper, faster workers do the runs.
+
+This document describes the shape that ships for Codex, the resolution rules,
+and the behaviour worth knowing before changing or extending it. Everything
+below was verified against Codex; treat the provider-specific parts as Codex
+facts, not as a cross-provider contract.
+
+## Configuration shape
+
+Role blocks carry an `agentConfig` alongside the project-wide default:
+
+```yaml
+agentConfig:
+  model: gpt-5.5
+  reasoningEffort: low
+
+orchestrator:
+  agent: codex
+  agentConfig:
+    model: gpt-5.6-sol
+    reasoningEffort: high
+
+worker:
+  agent: codex
+  agentConfig:
+    model: gpt-5.6-terra
+    reasoningEffort: medium
+```
+
+Set it from the desktop settings form, the project API, or the CLI:
+
+```bash
+ao project set-config <id> --config-json '<JSON object>'
+```
+
+## Resolution rules
+
+`effectiveAgentConfig(kind, cfg)` in `backend/internal/session_manager/manager.go`
+copies the project-wide `agentConfig` first, then layers **only non-empty** role
+values over it. The same resolved value is used for new sessions and for native
+resume.
+
+| Role value                  | Result                          |
+| --------------------------- | ------------------------------- |
+| set                         | overrides the project default   |
+| absent or empty             | inherits the project default    |
+| whitespace only (`" \t "`)  | inherits the project default    |
+
+The whitespace case is deliberate: a blank role field in the settings form must
+read as "inherit", not as "override with nothing". Reasoning effort is validated
+in `domain.AgentConfig.Validate` against `low`, `medium`, `high`, and `xhigh`.
+
+## Data flow
+
+```text
+Project settings UI / project API / CLI
+        ↓
+ProjectConfig.agentConfig + worker.agentConfig + orchestrator.agentConfig
+        ↓
+session_manager.effectiveAgentConfig(kind, config)
+        ↓
+Codex adapter
+        ↓
+launch or restore argv
+```
+
+## Codex mapping
+
+The Codex adapter (`backend/internal/adapters/agent/codex/codex.go`) emits model
+and reasoning as separate arguments, on both the launch and the restore path:
+
+```text
+--model gpt-5.6-sol
+-c model_reasoning_effort="high"
+```
+
+Values are trimmed before use, and an empty value emits no argument at all. The
+global `~/.codex/config.toml` is never written to, and no database migration is
+involved — this rides on the existing project configuration.
+
+The desktop picker offers `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, and
+`gpt-5.5`, plus a free-text custom model ID. Keep the custom escape hatch: a
+hard-coded list alone goes stale as soon as a provider ships a new model.
+
+## Session lifecycle: configuration binds at process start
+
+Model and reasoning are fixed into argv when the agent process starts. Saving
+new project values does **not** mutate a session that is already running.
+
+- New worker and orchestrator sessions pick up the new values.
+- Restore/resume picks them up, because that starts a new process.
+- An already-running orchestrator keeps reporting its original model and effort.
+- The settings form only replaces a running orchestrator when the agent/provider
+  changes — not when only the model or reasoning effort changes.
+
+This is the single most confusing part in practice: the project API can already
+report Sol/high and Terra/medium while a long-lived orchestrator process still
+shows its old values. That is expected, not a bug.
+
+## Verifying a change end to end
+
+Evidence quality, strongest first:
+
+1. **Process argv** of the running agent — definitive.
+2. **Codex terminal header** — a good smoke test.
+3. **Answer quality** — not evidence of anything; never conclude from it.
+
+Notes that save time:
+
+- Running `/model` by hand mutates the session and invalidates a startup test.
+- Test the real user path. "New Task" creates a worker through the session API
+  and takes its model/reasoning from project configuration even though the
+  dialog does not show those fields; the desktop orchestrator goes through the
+  orchestrator API. An isolated CLI spawn does not cover the desktop lifecycle.
+- Matching a daemon binary hash does not prove which arguments an
+  already-running process was started with. Check process age and argv too.
+
+## Windows notes
+
+- PowerShell 5.1 can quote inline JSON differently than expected when calling
+  native CLIs. Prefer the UI/API, or quote defensively.
+- Stop stale desktop and daemon processes before a real end-to-end test; several
+  can be alive at once and serve old configuration.
+- `go test ./...` is not fully green on Windows for reasons unrelated to this
+  feature (Unix paths, `.sock` files, POSIX file modes, missing `sh`, CRLF
+  expectations, ConPTY registry access, directory locks). Run the packages you
+  touched, and let CI cover the rest.
+
+## Extending to other providers
+
+The shape transfers; the provider facts do not. Re-derive each of these from the
+provider's real CLI and official documentation before implementing:
+
+- the model list and model ID format
+- valid reasoning values — `low|medium|high|xhigh` is a Codex vocabulary
+- the flag or config mechanism — `model_reasoning_effort` is Codex-specific
+- whether launch and resume accept configuration the same way
+
+The reusable pattern:
+
+1. Express provider capabilities as an agent config spec.
+2. Merge the project-wide base with per-role overrides.
+3. Treat empty overrides as inheritance.
+4. Assert exact argv for the launch and resume paths separately.
+5. Cover domain, API, CLI, and UI round trips.
+6. Offer known models in a picker, but keep a custom ID escape hatch.
+7. Show the resolved effective values before saving.
+8. Keep running processes conceptually distinct from newly started ones.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -873,6 +873,7 @@ export interface components {
         AgentConfig: {
             model?: string;
             permissions?: string;
+            reasoningEffort?: string;
         };
         AgentInfo: {
             /**

--- a/frontend/src/renderer/components/ModelOverrideSelect.test.tsx
+++ b/frontend/src/renderer/components/ModelOverrideSelect.test.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ModelOverrideSelect } from "./ModelOverrideSelect";
+
+const TRIGGER = { name: "Model override" };
+
+async function chooseOption(trigger: HTMLElement, option: string) {
+	await userEvent.click(trigger);
+	await userEvent.click(await screen.findByRole("menuitem", { name: new RegExp(option, "i") }));
+}
+
+describe("ModelOverrideSelect", () => {
+	it("offers every verified Codex model plus inherit and custom choices", async () => {
+		render(<ModelOverrideSelect ariaLabel="Model override" value="" onChange={() => undefined} />);
+		await userEvent.click(screen.getByRole("button", TRIGGER));
+
+		for (const name of ["Agent default", "GPT-5.6 Sol", "GPT-5.6 Terra", "GPT-5.6 Luna", "GPT-5.5", "Custom model ID"]) {
+			expect(await screen.findByRole("menuitem", { name: new RegExp(name, "i") })).toBeInTheDocument();
+		}
+	});
+
+	it("emits the exact known model ID", async () => {
+		const onChange = vi.fn();
+		render(<ModelOverrideSelect ariaLabel="Model override" value="" onChange={onChange} />);
+
+		await chooseOption(screen.getByRole("button", TRIGGER), "GPT-5.6 Luna");
+
+		expect(onChange).toHaveBeenLastCalledWith("gpt-5.6-luna");
+	});
+
+	it("shows only the selected model short label in the trigger", () => {
+		render(<ModelOverrideSelect ariaLabel="Model override" value="gpt-5.6-sol" onChange={() => undefined} />);
+
+		expect(screen.getByRole("button", TRIGGER)).toHaveTextContent("GPT-5.6 Sol");
+		expect(screen.getByRole("button", TRIGGER)).not.toHaveTextContent("Latest frontier agentic coding model");
+	});
+
+	it("preserves and edits an existing custom model ID", async () => {
+		const onChange = vi.fn();
+		function ControlledPicker() {
+			const [value, setValue] = useState("future-codex-model");
+			return (
+				<ModelOverrideSelect
+					ariaLabel="Model override"
+					value={value}
+					onChange={(next) => {
+						setValue(next);
+						onChange(next);
+					}}
+				/>
+			);
+		}
+		render(<ControlledPicker />);
+
+		const custom = screen.getByRole("textbox", { name: "Custom model ID" });
+		expect(custom).toHaveValue("future-codex-model");
+		await userEvent.clear(custom);
+		await userEvent.type(custom, "future-codex-model-2");
+
+		expect(onChange).toHaveBeenLastCalledWith("future-codex-model-2");
+	});
+
+	it("keeps custom mode while typing a model ID with a known-model prefix", async () => {
+		function ControlledPicker() {
+			const [value, setValue] = useState("");
+			return <ModelOverrideSelect ariaLabel="Model override" value={value} onChange={setValue} />;
+		}
+		render(<ControlledPicker />);
+
+		await chooseOption(screen.getByRole("button", TRIGGER), "Custom model ID");
+		const custom = screen.getByRole("textbox", { name: "Custom model ID" });
+		await userEvent.type(custom, "gpt-5.5-preview");
+
+		expect(screen.getByRole("textbox", { name: "Custom model ID" })).toHaveValue("gpt-5.5-preview");
+		expect(screen.getByRole("button", TRIGGER)).toHaveTextContent("Custom model ID");
+	});
+
+	it("emits an empty string for inheritance", async () => {
+		const onChange = vi.fn();
+		render(<ModelOverrideSelect ariaLabel="Model override" value="gpt-5.6-sol" onChange={onChange} />);
+
+		await chooseOption(screen.getByRole("button", TRIGGER), "Agent default");
+
+		expect(onChange).toHaveBeenLastCalledWith("");
+	});
+
+	it("closes custom mode when a parent resets its value to inherit", () => {
+		const { rerender } = render(
+			<ModelOverrideSelect ariaLabel="Model override" value="future-codex-model" onChange={() => undefined} />,
+		);
+		expect(screen.getByRole("textbox", { name: "Custom model ID" })).toBeInTheDocument();
+
+		rerender(<ModelOverrideSelect ariaLabel="Model override" value="" onChange={() => undefined} />);
+
+		expect(screen.queryByRole("textbox", { name: "Custom model ID" })).not.toBeInTheDocument();
+	});
+
+	it("returns to inherit when a preset resets an edited custom model", async () => {
+		function ControlledPicker() {
+			const [value, setValue] = useState("future-codex-model");
+			return (
+				<>
+					<ModelOverrideSelect ariaLabel="Model override" value={value} onChange={setValue} />
+					<button type="button" onClick={() => setValue("")}>
+						Apply preset
+					</button>
+				</>
+			);
+		}
+		render(<ControlledPicker />);
+
+		const custom = screen.getByRole("textbox", { name: "Custom model ID" });
+		await userEvent.clear(custom);
+		await userEvent.type(custom, "edited-custom-model");
+		await userEvent.click(screen.getByRole("button", { name: "Apply preset" }));
+
+		expect(screen.queryByRole("textbox", { name: "Custom model ID" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", TRIGGER)).toHaveTextContent("Agent default");
+	});
+});

--- a/frontend/src/renderer/components/ModelOverrideSelect.tsx
+++ b/frontend/src/renderer/components/ModelOverrideSelect.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState, type ReactElement } from "react";
+import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
+import { Input } from "./ui/input";
+
+const INHERIT_VALUE = "__inherit__";
+const CUSTOM_VALUE = "__custom__";
+
+export type ModelOverrideSelectProps = {
+	ariaLabel: string;
+	value: string;
+	onChange: (value: string) => void;
+	inheritLabel?: string;
+};
+
+export const CODEX_MODEL_OPTIONS = [
+	{ value: "gpt-5.6-sol", label: "GPT-5.6 Sol", description: "Latest frontier agentic coding model" },
+	{ value: "gpt-5.6-terra", label: "GPT-5.6 Terra", description: "Balanced coding model for everyday work" },
+	{ value: "gpt-5.6-luna", label: "GPT-5.6 Luna", description: "Fast and affordable agentic coding model" },
+	{ value: "gpt-5.5", label: "GPT-5.5", description: "Frontier model for complex coding and research" },
+] as const;
+
+const MODEL_DESCRIPTIONS = new Map<string, string>(
+	CODEX_MODEL_OPTIONS.map((option) => [option.value, option.description]),
+);
+
+export function ModelOverrideSelect({
+	ariaLabel,
+	value,
+	onChange,
+	inheritLabel = "Agent default",
+}: ModelOverrideSelectProps): ReactElement {
+	const known = CODEX_MODEL_OPTIONS.some((option) => option.value === value);
+	const [customMode, setCustomMode] = useState(value !== "" && !known);
+	const [customDraft, setCustomDraft] = useState(known ? "" : value);
+	const localCustomEdit = useRef<string | null>(null);
+	const selectValue = customMode ? CUSTOM_VALUE : value || INHERIT_VALUE;
+
+	useEffect(() => {
+		if (localCustomEdit.current === value) {
+			localCustomEdit.current = null;
+			return;
+		}
+		localCustomEdit.current = null;
+		if (value === "" || CODEX_MODEL_OPTIONS.some((option) => option.value === value)) {
+			setCustomMode(false);
+		} else {
+			setCustomMode(true);
+			setCustomDraft(value);
+		}
+	}, [value]);
+
+	function handleValueChange(next: string) {
+		if (next === CUSTOM_VALUE) {
+			setCustomDraft(known ? "" : value);
+			setCustomMode(true);
+			return;
+		}
+		setCustomMode(false);
+		onChange(next === INHERIT_VALUE ? "" : next);
+	}
+
+	const options = [
+		{ value: INHERIT_VALUE, label: inheritLabel },
+		...CODEX_MODEL_OPTIONS.map((option) => ({ value: option.value, label: option.label })),
+		{ value: CUSTOM_VALUE, label: "Custom model ID" },
+	];
+
+	return (
+		<div className="flex min-w-0 flex-1 flex-col items-end gap-2">
+			<SettingsOptionMenu
+				aria-label={ariaLabel}
+				value={selectValue}
+				options={options}
+				onChange={handleValueChange}
+				renderMenuItem={(option) => {
+					const description = MODEL_DESCRIPTIONS.get(option.value);
+					return (
+						<span className="flex flex-col items-start gap-0.5">
+							<span>{option.label}</span>
+							{description ? <span className="text-xs text-settings-muted">{description}</span> : null}
+						</span>
+					);
+				}}
+			/>
+			{customMode ? (
+				<Input
+					aria-label="Custom model ID"
+					className="h-control-form w-full"
+					value={customDraft}
+					onChange={(event) => {
+						const next = event.target.value;
+						setCustomDraft(next);
+						localCustomEdit.current = next;
+						onChange(next);
+					}}
+					placeholder="Enter exact model ID"
+				/>
+			) : null}
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -186,6 +186,106 @@ describe("ProjectSettingsForm", () => {
 		expect(screen.getByText("tg_content_factory_5863f66be3")).toBeInTheDocument();
 	});
 
+	it("applies the Sol and Terra preset and shows the effective role configuration", async () => {
+		mockProject({
+			id: "proj-1",
+			name: "Project One",
+			kind: "single_repo",
+			path: "/repo/project-one",
+			repo: "",
+			defaultBranch: "main",
+			config: {
+				worker: { agent: "codex" },
+				orchestrator: { agent: "codex" },
+				agentConfig: {
+					model: "old-default-model",
+					reasoningEffort: "low",
+					permissions: "auto",
+				},
+			},
+		});
+
+		renderSettings();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Apply Sol and Terra preset" }));
+
+		expect(screen.getByText("Worker")).toBeInTheDocument();
+		expect(screen.getByText("gpt-5.6-terra · Medium")).toBeInTheDocument();
+		expect(screen.getByText("Orchestrator")).toBeInTheDocument();
+		expect(screen.getByText("gpt-5.6-sol · High")).toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
+		expect(putMock).toHaveBeenCalledWith(
+			"/api/v1/projects/{id}",
+			expect.objectContaining({
+				body: expect.objectContaining({
+					config: expect.objectContaining({
+						agentConfig: {
+							reasoningEffort: "low",
+							permissions: "auto",
+						},
+						worker: {
+							agent: "codex",
+							agentConfig: { model: "gpt-5.6-terra", reasoningEffort: "medium" },
+						},
+						orchestrator: {
+							agent: "codex",
+							agentConfig: { model: "gpt-5.6-sol", reasoningEffort: "high" },
+						},
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("resolves inherited values and preserves a custom orchestrator model", async () => {
+		mockProject({
+			id: "proj-1",
+			name: "Project One",
+			kind: "single_repo",
+			path: "/repo/project-one",
+			repo: "",
+			defaultBranch: "main",
+			config: {
+				agentConfig: { model: "gpt-5.5", reasoningEffort: "low" },
+				worker: { agent: "codex", agentConfig: {} },
+				orchestrator: {
+					agent: "codex",
+					agentConfig: { model: "private-codex-model", reasoningEffort: "xhigh" },
+				},
+			},
+		});
+
+		renderSettings();
+
+		expect(await screen.findByText("Worker")).toBeInTheDocument();
+		expect(screen.getByText("gpt-5.5 · Low")).toBeInTheDocument();
+		expect(screen.getByText("Orchestrator")).toBeInTheDocument();
+		expect(screen.getByText("private-codex-model · XHigh")).toBeInTheDocument();
+		expect(screen.getByRole("textbox", { name: "Custom model ID" })).toHaveValue("private-codex-model");
+
+		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
+		expect(putMock).toHaveBeenCalledWith(
+			"/api/v1/projects/{id}",
+			expect.objectContaining({
+				body: expect.objectContaining({
+					config: expect.objectContaining({
+						agentConfig: { model: "gpt-5.5", reasoningEffort: "low" },
+						worker: { agent: "codex" },
+						orchestrator: {
+							agent: "codex",
+							agentConfig: { model: "private-codex-model", reasoningEffort: "xhigh" },
+						},
+					}),
+				}),
+			}),
+		);
+	});
+
 	it("loads the current project settings and saves the exposed fields without dropping hidden config", async () => {
 		mockProject({
 			id: "proj-1",
@@ -202,11 +302,15 @@ describe("ProjectSettingsForm", () => {
 				postCreate: ["npm install"],
 				worker: {
 					agent: "codex",
-					agentConfig: { model: "worker-model" },
+					agentConfig: { model: "gpt-5.6-terra", reasoningEffort: "medium" },
 				},
-				orchestrator: { agent: "claude-code" },
+				orchestrator: {
+					agent: "claude-code",
+					agentConfig: { model: "gpt-5.6-sol", reasoningEffort: "high" },
+				},
 				agentConfig: {
 					model: "claude-opus-4-5",
+					reasoningEffort: "low",
 					permissions: "auto",
 				},
 				reviewers: [{ harness: "claude-code" }],
@@ -218,7 +322,13 @@ describe("ProjectSettingsForm", () => {
 		expect(await screen.findByText("git@github.com:acme/project-one.git")).toBeInTheDocument();
 		expect(screen.getByLabelText("Default branch")).toHaveValue("develop");
 		expect(screen.getByLabelText("Session prefix")).toHaveValue("po");
-		expect(screen.getByLabelText("Model override")).toHaveValue("claude-opus-4-5");
+		expect(screen.getByLabelText("Default model override")).toHaveTextContent("Custom model ID");
+		expect(screen.getByRole("textbox", { name: "Custom model ID" })).toHaveValue("claude-opus-4-5");
+		expect(screen.getByRole("button", { name: "Default reasoning effort" })).toHaveTextContent("Low");
+		expect(screen.getByLabelText("Worker model override")).toHaveTextContent("GPT-5.6 Terra");
+		expect(screen.getByRole("button", { name: "Worker reasoning effort" })).toHaveTextContent("Medium");
+		expect(screen.getByLabelText("Orchestrator model override")).toHaveTextContent("GPT-5.6 Sol");
+		expect(screen.getByRole("button", { name: "Orchestrator reasoning effort" })).toHaveTextContent("High");
 
 		const workerAgent = screen.getByRole("button", { name: "Default worker agent" });
 		const orchestratorAgent = screen.getByRole("button", { name: "Default orchestrator agent" });
@@ -233,8 +343,11 @@ describe("ProjectSettingsForm", () => {
 		await userEvent.type(screen.getByLabelText("Default branch"), "release");
 		await userEvent.clear(screen.getByLabelText("Session prefix"));
 		await userEvent.type(screen.getByLabelText("Session prefix"), "rel");
-		await userEvent.clear(screen.getByLabelText("Model override"));
-		await userEvent.type(screen.getByLabelText("Model override"), "gpt-5-codex");
+		await userEvent.clear(screen.getByRole("textbox", { name: "Custom model ID" }));
+		await userEvent.type(screen.getByRole("textbox", { name: "Custom model ID" }), "gpt-5-codex");
+		await chooseOption(screen.getByRole("button", { name: "Default reasoning effort" }), "XHigh");
+		await chooseOption(screen.getByRole("button", { name: "Worker reasoning effort" }), "Low");
+		await chooseOption(screen.getByRole("button", { name: "Orchestrator reasoning effort" }), "Medium");
 		await chooseOption(workerAgent, "OpenCode");
 		await chooseOption(orchestratorAgent, "Goose");
 		await userEvent.click(permissionMode);
@@ -255,11 +368,15 @@ describe("ProjectSettingsForm", () => {
 					postCreate: ["npm install"],
 					worker: {
 						agent: "opencode",
-						agentConfig: { model: "worker-model" },
+						agentConfig: { model: "gpt-5.6-terra", reasoningEffort: "low" },
 					},
-					orchestrator: { agent: "goose" },
+					orchestrator: {
+						agent: "goose",
+						agentConfig: { model: "gpt-5.6-sol", reasoningEffort: "medium" },
+					},
 					agentConfig: {
 						model: "gpt-5-codex",
+						reasoningEffort: "xhigh",
 						permissions: "bypass-permissions",
 					},
 					reviewers: [{ harness: "claude-code" }],

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -6,6 +6,7 @@ import {
 	Fingerprint,
 	FolderGit2,
 	FolderOpen,
+	Gauge,
 	GitBranch,
 	Hash,
 	Layers,
@@ -31,6 +32,7 @@ import { newestActiveOrchestrator } from "../types/workspace";
 import { AgentAvatar } from "./AgentAvatar";
 import { RequiredAgentField } from "./CreateProjectAgentSheet";
 import { buildIntake, deriveGitHubRepo, IntakeFields, type IntakeForm, intakeNeedsRule } from "./IntakeFields";
+import { ModelOverrideSelect } from "./ModelOverrideSelect";
 import { AgentSelectMenuItem } from "./settings/AgentSelectMenuItem";
 import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
 import { SettingsPageShell } from "./settings/SettingsPageShell";
@@ -42,6 +44,11 @@ type Project = components["schemas"]["Project"];
 type ProjectConfig = components["schemas"]["ProjectConfig"];
 type TrackerIntakeConfig = components["schemas"]["TrackerIntakeConfig"];
 
+type EffectiveRoleConfig = {
+	model: string;
+	reasoningEffort: string;
+};
+
 const PERMISSION_MODE_OPTIONS = [
 	{ value: "default", label: "Default" },
 	{ value: "accept-edits", label: "Accept edits" },
@@ -51,7 +58,26 @@ const PERMISSION_MODE_OPTIONS = [
 
 const KNOWN_REVIEWER_HARNESS_IDS = new Set(["claude-code", "codex", "opencode"]);
 
+const REASONING_EFFORT_OPTIONS = [
+	{ value: "low", label: "Low" },
+	{ value: "medium", label: "Medium" },
+	{ value: "high", label: "High" },
+	{ value: "xhigh", label: "XHigh" },
+] as const;
+
 const projectQueryKey = (id: string) => ["project", id] as const;
+
+export function effectiveRoleConfig(
+	baseModel: string,
+	baseReasoningEffort: string,
+	roleModel: string,
+	roleReasoningEffort: string,
+): EffectiveRoleConfig {
+	return {
+		model: roleModel || baseModel || "Agent default",
+		reasoningEffort: roleReasoningEffort || baseReasoningEffort || "Agent default",
+	};
+}
 
 export function ProjectSettingsForm({ projectId }: { projectId: string }) {
 	const navigate = useNavigate();
@@ -106,7 +132,12 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 		sessionPrefix: config.sessionPrefix ?? "",
 		workerAgent: config.worker?.agent ?? "",
 		orchestratorAgent: config.orchestrator?.agent ?? "",
-		model: config.agentConfig?.model ?? "",
+		defaultModel: config.agentConfig?.model ?? "",
+		defaultReasoningEffort: config.agentConfig?.reasoningEffort ?? "",
+		workerModel: config.worker?.agentConfig?.model ?? "",
+		workerReasoningEffort: config.worker?.agentConfig?.reasoningEffort ?? "",
+		orchestratorModel: config.orchestrator?.agentConfig?.model ?? "",
+		orchestratorReasoningEffort: config.orchestrator?.agentConfig?.reasoningEffort ?? "",
 		permissions: config.agentConfig?.permissions ?? "",
 		reviewerHarness: config.reviewers?.[0]?.harness ?? "",
 		intakeEnabled: intake.enabled ?? false,
@@ -139,6 +170,31 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 		}));
 	const effectiveIntakeRepo = form.intakeRepo.trim() || deriveGitHubRepo(project.repo);
 	const intakeIncomplete = !isScratchProject && intakeNeedsRule(intakeForm);
+	const effectiveWorker = effectiveRoleConfig(
+		form.defaultModel,
+		form.defaultReasoningEffort,
+		form.workerModel,
+		form.workerReasoningEffort,
+	);
+	const effectiveOrchestrator = effectiveRoleConfig(
+		form.defaultModel,
+		form.defaultReasoningEffort,
+		form.orchestratorModel,
+		form.orchestratorReasoningEffort,
+	);
+
+	function applyCodexRolePreset() {
+		setForm((current) => ({
+			...current,
+			workerAgent: "codex",
+			orchestratorAgent: "codex",
+			defaultModel: "",
+			workerModel: "gpt-5.6-terra",
+			workerReasoningEffort: "medium",
+			orchestratorModel: "gpt-5.6-sol",
+			orchestratorReasoningEffort: "high",
+		}));
+	}
 
 	const mutation = useMutation({
 		mutationFn: async () => {
@@ -147,11 +203,20 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 			const next: ProjectConfig = isScratchProject
 				? {
 						...scratchSupportedConfig(config),
-						worker: { ...config.worker, agent: form.workerAgent },
-						orchestrator: { ...config.orchestrator, agent: form.orchestratorAgent },
+						worker: {
+							...config.worker,
+							agent: form.workerAgent,
+							agentConfig: blankToUndefined({ ...config.worker?.agentConfig, model: form.workerModel || undefined, reasoningEffort: form.workerReasoningEffort || undefined }),
+						},
+						orchestrator: {
+							...config.orchestrator,
+							agent: form.orchestratorAgent,
+							agentConfig: blankToUndefined({ ...config.orchestrator?.agentConfig, model: form.orchestratorModel || undefined, reasoningEffort: form.orchestratorReasoningEffort || undefined }),
+						},
 						agentConfig: blankToUndefined({
 							...config.agentConfig,
-							model: form.model || undefined,
+							model: form.defaultModel || undefined,
+							reasoningEffort: form.defaultReasoningEffort || undefined,
 							permissions: form.permissions || undefined,
 						}),
 					}
@@ -159,11 +224,20 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 						...config,
 						defaultBranch: form.defaultBranch || undefined,
 						sessionPrefix: form.sessionPrefix || undefined,
-						worker: { ...config.worker, agent: form.workerAgent },
-						orchestrator: { ...config.orchestrator, agent: form.orchestratorAgent },
+						worker: {
+							...config.worker,
+							agent: form.workerAgent,
+							agentConfig: blankToUndefined({ ...config.worker?.agentConfig, model: form.workerModel || undefined, reasoningEffort: form.workerReasoningEffort || undefined }),
+						},
+						orchestrator: {
+							...config.orchestrator,
+							agent: form.orchestratorAgent,
+							agentConfig: blankToUndefined({ ...config.orchestrator?.agentConfig, model: form.orchestratorModel || undefined, reasoningEffort: form.orchestratorReasoningEffort || undefined }),
+						},
 						agentConfig: blankToUndefined({
 							...config.agentConfig,
-							model: form.model || undefined,
+							model: form.defaultModel || undefined,
+							reasoningEffort: form.defaultReasoningEffort || undefined,
 							permissions: form.permissions || undefined,
 						}),
 						reviewers: form.reviewerHarness ? [{ harness: form.reviewerHarness }] : undefined,
@@ -327,14 +401,73 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 				{missingRequiredAgent && (
 					<p className="px-1 text-xs leading-row text-error">Worker and orchestrator agents are required.</p>
 				)}
-				<SettingsInputRow
-					icon={Sparkles}
-					label="Model override"
-					id="model"
-					value={form.model}
-					placeholder="(agent default)"
-					onChange={(value) => setForm((f) => ({ ...f, model: value }))}
-				/>
+				<SettingsRow icon={Sparkles} label="Codex role preset">
+					<button
+						type="button"
+						className="settings-option-trigger inline-flex items-center gap-1.5"
+						onClick={applyCodexRolePreset}
+					>
+						Apply Sol and Terra preset
+					</button>
+				</SettingsRow>
+				<SettingsRow icon={Sparkles} label="Default model override">
+					<ModelOverrideSelect
+						ariaLabel="Default model override"
+						value={form.defaultModel}
+						onChange={(value) => setForm((f) => ({ ...f, defaultModel: value }))}
+					/>
+				</SettingsRow>
+				<SettingsRow icon={Gauge} label="Default reasoning effort">
+					<ReasoningEffortSelect
+						ariaLabel="Default reasoning effort"
+						value={form.defaultReasoningEffort}
+						onChange={(v) => setForm((f) => ({ ...f, defaultReasoningEffort: v }))}
+					/>
+				</SettingsRow>
+				<SettingsRow icon={Bot} label="Worker model override">
+					<ModelOverrideSelect
+						ariaLabel="Worker model override"
+						value={form.workerModel}
+						inheritLabel="Inherit default model"
+						onChange={(value) => setForm((f) => ({ ...f, workerModel: value }))}
+					/>
+				</SettingsRow>
+				<SettingsRow icon={Gauge} label="Worker reasoning effort">
+					<ReasoningEffortSelect
+						ariaLabel="Worker reasoning effort"
+						value={form.workerReasoningEffort}
+						onChange={(v) => setForm((f) => ({ ...f, workerReasoningEffort: v }))}
+					/>
+				</SettingsRow>
+				<SettingsRow icon={Network} label="Orchestrator model override">
+					<ModelOverrideSelect
+						ariaLabel="Orchestrator model override"
+						value={form.orchestratorModel}
+						inheritLabel="Inherit default model"
+						onChange={(value) => setForm((f) => ({ ...f, orchestratorModel: value }))}
+					/>
+				</SettingsRow>
+				<SettingsRow icon={Gauge} label="Orchestrator reasoning effort">
+					<ReasoningEffortSelect
+						ariaLabel="Orchestrator reasoning effort"
+						value={form.orchestratorReasoningEffort}
+						onChange={(v) => setForm((f) => ({ ...f, orchestratorReasoningEffort: v }))}
+					/>
+				</SettingsRow>
+				<div className="px-1 text-xs leading-row">
+					<p className="mb-2 font-medium text-settings-label">Effective configuration</p>
+					<div className="grid grid-cols-[minmax(0,110px)_minmax(0,1fr)] gap-x-3 gap-y-1.5">
+						<span className="text-settings-muted">Worker</span>
+						<span className="text-settings-label">
+							{effectiveWorker.model} · {reasoningEffortLabel(effectiveWorker.reasoningEffort)}
+						</span>
+						<span className="text-settings-muted">Orchestrator</span>
+						<span className="text-settings-label">
+							{effectiveOrchestrator.model} · {reasoningEffortLabel(effectiveOrchestrator.reasoningEffort)}
+						</span>
+					</div>
+					<p className="mt-2 text-settings-muted">Applies to new launches and restored sessions.</p>
+				</div>
 				<SettingsRow icon={Shield} label="Permission mode">
 					<PermissionModeSelect
 						value={form.permissions}
@@ -490,6 +623,34 @@ function PermissionModeSelect({ value, onChange }: { value: string; onChange: (v
 			onChange={(v) => onChange(v === "__default__" ? "" : v)}
 		/>
 	);
+}
+
+function ReasoningEffortSelect({
+	ariaLabel,
+	value,
+	onChange,
+}: {
+	ariaLabel: string;
+	value: string;
+	onChange: (value: string) => void;
+}) {
+	const options = [
+		{ value: "__default__", label: "Agent default" },
+		...REASONING_EFFORT_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label })),
+	];
+
+	return (
+		<SettingsOptionMenu
+			aria-label={ariaLabel}
+			value={value || "__default__"}
+			options={options}
+			onChange={(v) => onChange(v === "__default__" ? "" : v)}
+		/>
+	);
+}
+
+function reasoningEffortLabel(value: string): string {
+	return REASONING_EFFORT_OPTIONS.find((option) => option.value === value)?.label ?? value;
 }
 
 const REVIEWER_AGENT_PRIORITY = ["claude-code", "codex", "cursor", "opencode", "aider"] as const;

--- a/frontend/src/renderer/lib/command-palette.test.ts
+++ b/frontend/src/renderer/lib/command-palette.test.ts
@@ -98,6 +98,19 @@ describe("buildCommands grouping", () => {
 		const orch = buildCommands({ workspaces: workspaces(), currentSessionId: "orch" });
 		expect(byId(orch).has("current-copy-branch")).toBe(false);
 	});
+
+	it("omits Copy branch for a branchless current session", () => {
+		const branchless = buildCommands({
+			workspaces: [
+				{
+					...workspaces()[0]!,
+					sessions: [session({ id: "scratch-worker", branch: undefined })],
+				},
+			],
+			currentSessionId: "scratch-worker",
+		});
+		expect(byId(branchless).has("current-copy-branch")).toBe(false);
+	});
 });
 
 describe("buildCommands attention", () => {


### PR DESCRIPTION
## What

Lets a project configure the Codex **model** and **reasoning effort** separately for workers and orchestrators — in the project config, the CLI, and the desktop settings UI.

## Why

A common setup is a stronger, higher-reasoning model orchestrating while cheaper, faster workers do the runs (for example a Sol/high orchestrator over Terra/medium workers). Today `agentConfig` only carries a model override and cannot express reasoning effort at all, so per-role tuning is not possible.

Closes #3188.

Note that per-role **model** support for Codex was already handled in #2769; what is missing is reasoning effort, and a picker so model IDs are not typed by hand.

## How

**Backend**

- Add `reasoningEffort` to `domain.AgentConfig`, validated against `low` / `medium` / `high` / `xhigh`.
- `effectiveAgentConfig` merges role overrides over the project-wide defaults, so worker and orchestrator resolve independently. A blank or whitespace-only role value **inherits** the project default rather than clearing it — a blank field in the settings form must read as "inherit", not "override with nothing".
- The Codex adapter advertises `reasoningEffort` in `GetConfigSpec` and forwards the resolved value as `-c model_reasoning_effort="<effort>"` on **both** launch and native resume, mirroring the existing model override.
- The CLI mirrors the new field in its `agentConfig` DTO.
- Regenerated `openapi.yaml` and `frontend/src/api/schema.ts`.

No `~/.codex/config.toml` writes and no migration: this rides on the existing project configuration.

**Frontend**

- New `ModelOverrideSelect`: GPT-5.6 Sol / Terra / Luna and GPT-5.5, an "Agent default" (inherit) option, and a custom model ID input so unlisted or future model IDs stay reachable.
- `ProjectSettingsForm` gains per-role model and reasoning controls, a resolved effective-configuration summary, and a one-click "Sol orchestrates, Terra works" preset.

**Docs**

- README section on the config shape and the desktop picker.
- New `docs/per-role-agent-config.md`: resolution rules, the Codex argv mapping, the lifecycle caveat below, how to verify a change, Windows testing caveats, and what must be re-derived before extending the pattern to another provider.

**Behaviour reviewers should know:** model and reasoning bind into argv when the agent process starts, so saving new values does not mutate an already-running session. New sessions and resume pick them up; a long-lived orchestrator keeps its original values until it is replaced. This is easy to misread as a bug, so it is written up in the new doc.

**Rebase note:** `ProjectSettingsForm` was rebased across the editable-display-name change (#2970). The per-role controls now save through `PUT /api/v1/projects/{id}` with `{displayName, config}`, and the tests assert that contract. The rewritten `ReviewerSelect` from that change is preserved as-is.

**Intentional omissions**

- One commit here is test-only: coverage for a **branchless** session in the command palette. `main` already guards that case in `command-palette.ts`, but nothing exercised it. Say the word and I will drop it to keep this PR strictly to the Codex feature.
- A Windows named-pipe fix for `src/main/supervisor-link.test.ts` and a local `.worktrees/` ignore entry were left out as unrelated; happy to send either separately.

## Testing

- `npm --prefix frontend run typecheck` — passes.
- `npm --prefix frontend run test` — 1101 passing, including the new `ModelOverrideSelect`, `ProjectSettingsForm`, and command-palette specs.
  - The only failures are 4 pre-existing, Windows-only cases in the unrelated `src/main/supervisor-link.test.ts` (`listen EACCES` on `.sock` paths). That file is untouched here and passes on Linux CI.
- `npm run api:ts` — regenerates `schema.ts` with no drift.
- Backend Go tests were **not run locally** — no Go toolchain in this environment. Backend behaviour is covered by added/updated table tests in `codex_test.go`, `agentconfig` / `projectconfig` tests, `projects_test.go`, `project_test.go`, and `provision_test.go`, and I am relying on the `go` CI workflow to gate them. Please flag anything you want re-verified.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.) — frontend typecheck and tests pass locally; backend Go tests deferred to CI
