### PR TITLE
fix(agy): honor cfg.Config.Model via --model flag on launch/restore

### DIFF
--- a/backend/internal/adapters/agent/agy/agy.go
+++ b/backend/internal/adapters/agent/agy/agy.go
@@ -59,10 +59,28 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys the Agy (Antigravity)
+// CLI understands: a model override passed via --model. Confirmed via
+// `agy --help`: "--model  Model for the current CLI session".
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `agy --model` (e.g. gemini-3-pro).",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start an interactive Agy session.
 // Shape:
 //
-//	agy --add-dir <WorkspacePath> [--dangerously-skip-permissions] [--prompt-interactive <Prompt>]
+//	agy --add-dir <WorkspacePath> [--dangerously-skip-permissions] [--model <Model>] [--prompt-interactive <Prompt>]
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	binary, err := p.agyBinary(ctx)
 	if err != nil {
@@ -79,6 +97,8 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		cmd = append(cmd, "--dangerously-skip-permissions")
 	}
 
+	appendModelFlag(&cmd, cfg.Config)
+
 	if cfg.Prompt != "" {
 		cmd = append(cmd, "--prompt-interactive", cfg.Prompt)
 	}
@@ -87,7 +107,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Agy session:
-// `agy --add-dir <WorkspacePath> [--dangerously-skip-permissions] --conversation <agentSessionId>`.
+// `agy --add-dir <WorkspacePath> [--dangerously-skip-permissions] [--model <Model>] --conversation <agentSessionId>`.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
@@ -112,6 +132,8 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if cfg.Permissions == ports.PermissionModeBypassPermissions {
 		cmd = append(cmd, "--dangerously-skip-permissions")
 	}
+
+	appendModelFlag(&cmd, cfg.Config)
 
 	cmd = append(cmd, "--conversation", agentSessionID)
 	return cmd, true, nil
@@ -156,4 +178,15 @@ func (p *Plugin) agyBinary(ctx context.Context) (string, error) {
 	}
 	p.resolvedBinary = binary
 	return binary, nil
+}
+
+// appendModelFlag appends `--model <trimmed>` when cfg.Model is set,
+// mirroring the Codex adapter's pattern (see #2869). A blank or
+// whitespace-only value is omitted so agy falls back to its own default
+// model resolution exactly as an unconfigured launch would. Confirmed via
+// `agy --help`: "--model  Model for the current CLI session".
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
 }

--- a/backend/internal/adapters/agent/agy/agy_test.go
+++ b/backend/internal/adapters/agent/agy/agy_test.go
@@ -26,6 +26,31 @@ func TestGetLaunchCommand(t *testing.T) {
 		Permissions:   ports.PermissionModeBypassPermissions,
 		Prompt:        "fix this",
 		WorkspacePath: "/tmp/ws",
+		Config:        ports.AgentConfig{Model: "gemini-3-pro"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"agy",
+		"--add-dir", "/tmp/ws",
+		"--dangerously-skip-permissions",
+		"--model", "gemini-3-pro",
+		"--prompt-interactive", "fix this",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandNoModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "agy"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions:   ports.PermissionModeBypassPermissions,
+		Prompt:        "fix this",
+		WorkspacePath: "/tmp/ws",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -58,6 +83,7 @@ func TestGetRestoreCommand(t *testing.T) {
 
 	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
 		Permissions: ports.PermissionModeBypassPermissions,
+		Config:      ports.AgentConfig{Model: "gemini-3-flash"},
 		Session: ports.SessionRef{
 			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "native-id-123"},
 			WorkspacePath: "/tmp/ws",
@@ -74,6 +100,7 @@ func TestGetRestoreCommand(t *testing.T) {
 		"agy",
 		"--add-dir", "/tmp/ws",
 		"--dangerously-skip-permissions",
+		"--model", "gemini-3-flash",
 		"--conversation", "native-id-123",
 	}
 	if !reflect.DeepEqual(cmd, want) {
@@ -210,5 +237,24 @@ func TestAuthStatus(t *testing.T) {
 	}
 	if status != ports.AgentAuthStatusAuthorized {
 		t.Errorf("AuthStatus() = %v, want AgentAuthStatusAuthorized", status)
+	}
+}
+
+func TestGetConfigSpecReportsModelField(t *testing.T) {
+	plugin := &Plugin{}
+
+	spec, err := plugin.GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `agy --model` (e.g. gemini-3-pro).",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
 	}
 }


### PR DESCRIPTION
## What
Forwards the per-role model override (`cfg.Config.Model`) to the `agy` (Antigravity) CLI as a `--model` flag on both session launch and session restore, and declares a `GetConfigSpec` entry for it.

## Why
Fixes #2901.

AO resolves a per-role model and forwards it to every adapter as `cfg.Config.Model`, but each adapter has to opt in to actually passing it to its CLI. The `agy` adapter never did, so a configured worker/orchestrator silently fell back to agy's default model instead of the one set in `agentConfig.model`.

## How
- Verified via `agy --help` that a launch-time flag exists (`--model  Model for the current CLI session`) — this was previously unconfirmed per the issue, so it settles the "does agy even support this" question in favor of applying the mechanical fix.
- Mirrors the pattern from the Codex adapter fix (#2869): an `appendModelFlag(cmd *[]string, cfg ports.AgentConfig)` helper that appends `--model <trimmed value>` only when set, called from both `GetLaunchCommand` and `GetRestoreCommand`.
- Added `GetConfigSpec` (previously inherited empty from `agentbase.Base`), declaring the `model` field with the same shape used by the Codex/Copilot adapters, so the config layer/UI know this adapter now supports a model override.
- Intentional omission worth flagging: unlike the Copilot adapter (#2895), which deliberately does *not* forward `--model` on restore pending verification of `--model` + `--resume` composition, this PR forwards on both launch **and** restore. I found no equivalent warning for `agy` in `--help` or available docs, so I didn't add the same restriction — but a reviewer with a real `agy` install should sanity-check this.

## Testing
```
go build ./...
go test ./internal/adapters/agent/agy/...
golangci-lint run ./internal/adapters/agent/agy/...
```
All pass, 0 lint issues. Covered:
- `TestGetLaunchCommand` — model set, flag appears in the right position.
- `TestGetLaunchCommandNoModel` — model unset, flag omitted entirely.
- `TestGetRestoreCommand` — model set, flag appears alongside `--conversation`.
- `TestGetConfigSpecReportsModelField` — config spec reports the `model` field.

Not yet verified locally: an actual `agy --model <x> --print "..."` run against a real `agy` binary, to confirm the flag changes model selection at runtime rather than just being accepted without erroring.

## Checklist
- [x] Branched from `main` (`fix/agy-model-override`)
- [x] One focused change; links the related issue (#2901)
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.) — pending CI run after push