### PR TITLE
feat(frontend): restyle project settings to match global settings page

### DIFF
--- a/frontend/src/renderer/components/AgentAvatar.tsx
+++ b/frontend/src/renderer/components/AgentAvatar.tsx
@@ -51,6 +51,8 @@ const LOGOS: Record<string, string> = {
 type AgentAvatarProps = {
 	provider: string;
 	className?: string;
+	/** When true, the logo is purely decorative (label is shown beside it). */
+	decorative?: boolean;
 };
 
 /**
@@ -63,16 +65,17 @@ type AgentAvatarProps = {
  * hover title, so surfaces that show the logo in place of visible agent text —
  * e.g. the archive cards — still name the agent for screen readers.
  */
-export function AgentAvatar({ provider, className }: AgentAvatarProps) {
+export function AgentAvatar({ provider, className, decorative = false }: AgentAvatarProps) {
 	const logo = LOGOS[provider];
 	if (logo) {
 		return (
 			<img
 				src={logo}
-				alt={provider}
+				alt={decorative ? "" : provider}
+				aria-hidden={decorative || undefined}
 				className={cn("size-icon-xl shrink-0 object-contain", className)}
 				draggable={false}
-				title={provider}
+				title={decorative ? undefined : provider}
 			/>
 		);
 	}

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
@@ -38,7 +38,8 @@ function renderSheet(onSubmit = vi.fn().mockResolvedValue(undefined)) {
 
 async function chooseOption(trigger: HTMLElement, optionName: string) {
 	await userEvent.click(trigger);
-	await userEvent.click(await screen.findByRole("option", { name: optionName }));
+	const escaped = optionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	await userEvent.click(await screen.findByRole("option", { name: new RegExp(escaped, "i") }));
 }
 
 describe("CreateProjectAgentSheet", () => {

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -381,7 +381,8 @@ export const RequiredAgentField = memo(function RequiredAgentField({
 					disabled={disabled}
 					onChange={onChange}
 					triggerClassName={invalid ? "text-error" : undefined}
-					menuClassName="min-w-60"
+					menuClassName="settings-agent-menu-surface"
+					menuItemClassName="settings-agent-menu-item"
 					renderTrigger={(selected, triggerPlaceholder) => (
 						<>
 							{selected ? <AgentAvatar provider={selected.value} className="size-icon-lg" /> : null}
@@ -398,7 +399,6 @@ export const RequiredAgentField = memo(function RequiredAgentField({
 								selected={selected}
 								status={agent.status}
 								statusTone={agent.statusTone}
-								warning={agent.warning}
 								disabled={agent.disabled}
 							/>
 						);
@@ -443,7 +443,6 @@ export const RequiredAgentField = memo(function RequiredAgentField({
 								selected={value === agent.id}
 								status={agent.status}
 								statusTone={agent.statusTone}
-								warning={agent.warning}
 								disabled={agent.disabled}
 							/>
 						</SelectItem>

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -1,12 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as Dialog from "@radix-ui/react-dialog";
-import { TriangleAlert, X } from "lucide-react";
+import { TriangleAlert, X, type LucideIcon } from "lucide-react";
 import { memo, useEffect, useState } from "react";
 import type { components } from "../../api/schema";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { AGENT_OPTIONS } from "../lib/agent-options";
+import { agentLabelCompare, buildRankedAgentOptions } from "../lib/agent-select-options";
 import { cn } from "../lib/utils";
+import { AgentAvatar } from "./AgentAvatar";
 import { buildIntake, type IntakeForm, IntakeFields, intakeNeedsRule } from "./IntakeFields";
+import { AgentSelectMenuItem } from "./settings/AgentSelectMenuItem";
+import { SettingsRow } from "./settings/SettingsRow";
+import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
 import type { ProjectKind } from "../types/workspace";
 import { Button } from "./ui/button";
 import { Label } from "./ui/label";
@@ -27,10 +32,6 @@ const DEFAULT_AGENT_PRIORITY = ["claude-code", "codex", "cursor", "opencode", "a
 const DEFAULT_AGENT_PRIORITY_RANK = new Map<string, number>(
 	DEFAULT_AGENT_PRIORITY.map((agent, index) => [agent, index]),
 );
-
-function agentLabelCompare(a: AgentInfo, b: AgentInfo): number {
-	return a.label.localeCompare(b.label) || a.id.localeCompare(b.id);
-}
 
 type CreateProjectAgentSheetProps = {
 	error?: string | null;
@@ -324,6 +325,7 @@ export function CreateProjectAgentSheet({
 export const RequiredAgentField = memo(function RequiredAgentField({
 	authorized,
 	disabled = false,
+	icon,
 	id,
 	invalid = false,
 	installed,
@@ -335,9 +337,11 @@ export const RequiredAgentField = memo(function RequiredAgentField({
 	labelClassName,
 	contentClassName,
 	value,
+	variant = "stacked",
 }: {
 	authorized?: AgentInfo[];
 	disabled?: boolean;
+	icon?: LucideIcon;
 	id: string;
 	invalid?: boolean;
 	installed?: AgentInfo[];
@@ -349,31 +353,60 @@ export const RequiredAgentField = memo(function RequiredAgentField({
 	labelClassName?: string;
 	contentClassName?: string;
 	value: string;
+	variant?: "stacked" | "settings-row";
 }) {
 	const fallbackAgents: AgentInfo[] = AGENT_OPTIONS.map((agent) => ({ id: agent, label: agent }));
-	const supportedAgents = supported ?? fallbackAgents;
-	const installedAgents = installed ?? supportedAgents;
-	const authorizedAgents = authorized ?? supportedAgents;
-	const authorizedIds = new Set(authorizedAgents.map((agent) => agent.id));
-	const installedById = new Map(installedAgents.map((agent) => [agent.id, agent]));
-	const options = supportedAgents
-		.map((agent) => {
-			const installedAgent = installedById.get(agent.id);
-			const authStatus = installedAgent?.authStatus;
-			const isAuthorized = authorizedIds.has(agent.id) || authStatus === "authorized";
-			const isAuthUnknown = Boolean(installedAgent) && !isAuthorized && authStatus !== "unauthorized";
-			const isSelectable = isAuthorized || isAuthUnknown;
-			const rank = isAuthorized ? 0 : isAuthUnknown ? 1 : installedAgent ? 2 : 3;
-			return {
-				...agent,
-				disabled: !isSelectable,
-				priorityRank: DEFAULT_AGENT_PRIORITY_RANK.get(agent.id) ?? Number.MAX_SAFE_INTEGER,
-				rank,
-				reason: !installedAgent ? "Needs install" : isAuthUnknown ? "Auth unknown" : !isAuthorized ? "Needs auth" : "",
-				warning: isAuthUnknown,
-			};
-		})
-		.sort((a, b) => a.rank - b.rank || a.priorityRank - b.priorityRank || agentLabelCompare(a, b));
+	const options = buildRankedAgentOptions({
+		supported,
+		installed,
+		authorized,
+		priorityRank: DEFAULT_AGENT_PRIORITY_RANK,
+		fallbackAgents,
+	});
+
+	if (variant === "settings-row") {
+		const menuOptions = options.map((agent) => ({
+			value: agent.id,
+			label: agent.label,
+			disabled: agent.disabled,
+		}));
+
+		return (
+			<SettingsRow icon={icon} label={label}>
+				<SettingsOptionMenu
+					aria-label={label}
+					value={value}
+					placeholder={placeholder}
+					options={menuOptions}
+					disabled={disabled}
+					onChange={onChange}
+					triggerClassName={invalid ? "text-error" : undefined}
+					menuClassName="min-w-60"
+					renderTrigger={(selected, triggerPlaceholder) => (
+						<>
+							{selected ? <AgentAvatar provider={selected.value} className="size-icon-lg" /> : null}
+							<span className="min-w-0 truncate">{selected?.label ?? triggerPlaceholder}</span>
+						</>
+					)}
+					renderMenuItem={(option, selected) => {
+						const agent = options.find((entry) => entry.id === option.value);
+						if (!agent) return option.label;
+						return (
+							<AgentSelectMenuItem
+								agentId={agent.id}
+								label={agent.label}
+								selected={selected}
+								status={agent.status}
+								statusTone={agent.statusTone}
+								warning={agent.warning}
+								disabled={agent.disabled}
+							/>
+						);
+					}}
+				/>
+			</SettingsRow>
+		);
+	}
 
 	return (
 		<div className="flex flex-col gap-1.5">
@@ -385,6 +418,7 @@ export const RequiredAgentField = memo(function RequiredAgentField({
 					id={id}
 					size="sm"
 					className={cn("w-full text-control", triggerClassName)}
+					aria-label={label}
 					aria-invalid={invalid || undefined}
 				>
 					<SelectValue placeholder={placeholder} />
@@ -403,15 +437,15 @@ export const RequiredAgentField = memo(function RequiredAgentField({
 							disabled={agent.disabled}
 							className="[&>span:last-child]:w-full"
 						>
-							<span className="flex min-w-0 w-full items-center justify-between gap-4">
-								<span className="truncate">{agent.label}</span>
-								{agent.reason && (
-									<span className="inline-flex shrink-0 items-center gap-1 text-caption text-muted-foreground">
-										{agent.warning && <TriangleAlert className="size-3 text-warning" aria-hidden="true" />}
-										{agent.reason}
-									</span>
-								)}
-							</span>
+							<AgentSelectMenuItem
+								agentId={agent.id}
+								label={agent.label}
+								selected={value === agent.id}
+								status={agent.status}
+								statusTone={agent.statusTone}
+								warning={agent.warning}
+								disabled={agent.disabled}
+							/>
 						</SelectItem>
 					))}
 				</SelectContent>

--- a/frontend/src/renderer/components/IntakeFields.tsx
+++ b/frontend/src/renderer/components/IntakeFields.tsx
@@ -1,7 +1,9 @@
-import { Info } from "lucide-react";
+import { FolderGit2, Inbox, Info, TriangleAlert, UserRound } from "lucide-react";
 import type { components } from "../../api/schema";
 import { cn } from "../lib/utils";
 import { Label } from "./ui/label";
+import { SettingsRow } from "./settings/SettingsRow";
+import { Switch } from "./ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 
 type TrackerIntakeConfig = components["schemas"]["TrackerIntakeConfig"];
@@ -85,6 +87,7 @@ export function IntakeFields({
 	compact = false,
 	controlClassName,
 	labelClassName,
+	variant = "default",
 }: {
 	form: IntakeForm;
 	onChange: (patch: Partial<IntakeForm>) => void;
@@ -94,8 +97,55 @@ export function IntakeFields({
 	compact?: boolean;
 	controlClassName?: string;
 	labelClassName?: string;
+	variant?: "default" | "settings";
 }) {
 	const needsRule = intakeNeedsRule(form);
+	if (variant === "settings") {
+		return (
+			<div className="flex flex-col gap-1.5">
+				<SettingsRow icon={Inbox} label="Enable issue intake">
+					<Switch
+						aria-label="Enable issue intake"
+						checked={form.enabled}
+						onCheckedChange={(enabled) => onChange({ enabled })}
+					/>
+				</SettingsRow>
+				{form.enabled && (
+					<>
+						{repoPreview && (
+							<SettingsRow icon={FolderGit2} label="Repository">
+								{repoPreview.value ? (
+									<a
+										href={`https://github.com/${repoPreview.value}`}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="settings-row-value text-settings-accent hover:underline"
+									>
+										{repoPreview.value}
+									</a>
+								) : (
+									<span className="settings-row-value">
+										Could not detect a GitHub repo from this project's git origin.
+									</span>
+								)}
+							</SettingsRow>
+						)}
+						<SettingsRow icon={UserRound} label="Assignee">
+							<input
+								id="intakeAssignee"
+								aria-label="Assignee"
+								className="settings-inline-input"
+								value={form.assignee}
+								onChange={(e) => onChange({ assignee: e.target.value })}
+								placeholder="type username or * for any"
+							/>
+						</SettingsRow>
+						{needsRule && <IntakeAssigneeError />}
+					</>
+				)}
+			</div>
+		);
+	}
 	return (
 		<div className="flex flex-col gap-4">
 			{!compact && (
@@ -162,12 +212,19 @@ export function IntakeFields({
 							placeholder="type username or * for any"
 						/>
 					</IntakeField>
-					{!compact && needsRule && (
-						<p className="text-xs leading-row text-error">Enabling intake requires an assignee.</p>
-					)}
+					{!compact && needsRule && <IntakeAssigneeError />}
 				</>
 			)}
 		</div>
+	);
+}
+
+function IntakeAssigneeError() {
+	return (
+		<p className="flex items-center gap-1.5 px-1 text-xs leading-row text-error">
+			<TriangleAlert className="size-3 shrink-0 text-error" aria-hidden="true" />
+			Enabling intake requires an assignee.
+		</p>
 	);
 }
 

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -406,10 +406,10 @@ describe("ProjectSettingsForm", () => {
 		await userEvent.click(workerAgent);
 		const options = await screen.findAllByRole("menuitem");
 		expect(options.map((option) => option.textContent)).toEqual([
-			"Claude CodeAuthorized",
-			"CodexAuthorized",
-			"OpenCodeAuthorized",
-			"GooseAuthorized",
+			"Claude Code",
+			"Codex",
+			"OpenCode",
+			"Goose",
 			"KiroAuth unknown",
 		]);
 		expect(options[4]).not.toHaveAttribute("aria-disabled", "true");

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -3,11 +3,20 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getMock, putMock, postMock } = vi.hoisted(() => ({
+const { getMock, putMock, postMock, navigateMock } = vi.hoisted(() => ({
 	getMock: vi.fn(),
 	putMock: vi.fn(),
 	postMock: vi.fn(),
+	navigateMock: vi.fn(),
 }));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+	return {
+		...actual,
+		useNavigate: () => navigateMock,
+	};
+});
 
 vi.mock("../lib/api-client", () => ({
 	apiClient: {
@@ -48,7 +57,8 @@ function renderSettings(projectId = "proj-1", workspaces?: WorkspaceSummary[]) {
 
 async function chooseOption(trigger: HTMLElement, optionName: string) {
 	await userEvent.click(trigger);
-	await userEvent.click(await screen.findByRole("option", { name: optionName }));
+	const escaped = optionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	await userEvent.click(await screen.findByRole("menuitem", { name: new RegExp(escaped, "i") }));
 }
 
 const agentCatalogResponse = {
@@ -94,6 +104,7 @@ beforeEach(() => {
 	getMock.mockReset();
 	putMock.mockReset();
 	postMock.mockReset();
+	navigateMock.mockReset();
 	putMock.mockResolvedValue({ data: { project: {} }, error: undefined });
 	postMock.mockResolvedValue({
 		data: { orchestrator: { id: "proj-1-orch-2" } },
@@ -103,6 +114,49 @@ beforeEach(() => {
 });
 
 describe("ProjectSettingsForm", () => {
+	it("closes project settings with the close button", async () => {
+		mockProject({
+			id: "proj-1",
+			name: "Project One",
+			kind: "single_repo",
+			path: "/repo/project-one",
+			repo: "",
+			defaultBranch: "main",
+			config: {
+				worker: { agent: "codex" },
+				orchestrator: { agent: "claude-code" },
+			},
+		});
+
+		renderSettings();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Close settings" }));
+
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-1" } });
+	});
+
+	it("closes project settings with Escape", async () => {
+		mockProject({
+			id: "proj-1",
+			name: "Project One",
+			kind: "single_repo",
+			path: "/repo/project-one",
+			repo: "",
+			defaultBranch: "main",
+			config: {
+				worker: { agent: "codex" },
+				orchestrator: { agent: "claude-code" },
+			},
+		});
+
+		renderSettings();
+		await screen.findByLabelText("Settings");
+
+		await userEvent.keyboard("{Escape}");
+
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-1" } });
+	});
+
 	it("atomically saves the project display name and config without changing its stable ID", async () => {
 		mockProject({
 			id: "tg_content_factory_5863f66be3",
@@ -166,10 +220,10 @@ describe("ProjectSettingsForm", () => {
 		expect(screen.getByLabelText("Session prefix")).toHaveValue("po");
 		expect(screen.getByLabelText("Model override")).toHaveValue("claude-opus-4-5");
 
-		const workerAgent = screen.getByRole("combobox", { name: "Default worker agent" });
-		const orchestratorAgent = screen.getByRole("combobox", { name: "Default orchestrator agent" });
-		const permissionMode = screen.getByRole("combobox", { name: "Permission mode" });
-		const reviewerAgent = screen.getByRole("combobox", { name: "Default reviewer agent" });
+		const workerAgent = screen.getByRole("button", { name: "Default worker agent" });
+		const orchestratorAgent = screen.getByRole("button", { name: "Default orchestrator agent" });
+		const permissionMode = screen.getByRole("button", { name: "Permission mode" });
+		const reviewerAgent = screen.getByRole("button", { name: "Default reviewer agent" });
 		expect(workerAgent).toHaveTextContent("codex");
 		expect(orchestratorAgent).toHaveTextContent("claude-code");
 		expect(permissionMode).toHaveTextContent("Auto");
@@ -183,7 +237,8 @@ describe("ProjectSettingsForm", () => {
 		await userEvent.type(screen.getByLabelText("Model override"), "gpt-5-codex");
 		await chooseOption(workerAgent, "OpenCode");
 		await chooseOption(orchestratorAgent, "Goose");
-		await chooseOption(permissionMode, "Bypass permissions");
+		await userEvent.click(permissionMode);
+		await userEvent.click(await screen.findByRole("menuitem", { name: "Bypass permissions" }));
 
 		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
@@ -287,8 +342,8 @@ describe("ProjectSettingsForm", () => {
 		renderSettings();
 
 		expect(await screen.findByText("Worker and orchestrator agents are required.")).toBeInTheDocument();
-		expect(screen.getByRole("combobox", { name: "Default worker agent" })).toHaveTextContent("Select worker agent");
-		expect(screen.getByRole("combobox", { name: "Default orchestrator agent" })).toHaveTextContent(
+		expect(screen.getByRole("button", { name: "Default worker agent" })).toHaveTextContent("Select worker agent");
+		expect(screen.getByRole("button", { name: "Default orchestrator agent" })).toHaveTextContent(
 			"Select orchestrator agent",
 		);
 
@@ -325,9 +380,9 @@ describe("ProjectSettingsForm", () => {
 
 		renderSettings();
 
-		expect(await screen.findByRole("combobox", { name: "Default worker agent" })).toBeDisabled();
-		expect(screen.getByRole("combobox", { name: "Default orchestrator agent" })).toBeDisabled();
-		expect(screen.getByRole("combobox", { name: "Default reviewer agent" })).toBeDisabled();
+		expect(await screen.findByRole("button", { name: "Default worker agent" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Default orchestrator agent" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Default reviewer agent" })).toBeDisabled();
 	});
 
 	it("shows unknown-auth agents as selectable with a warning in project settings", async () => {
@@ -347,14 +402,14 @@ describe("ProjectSettingsForm", () => {
 		renderSettings();
 
 		await waitFor(() => expect(screen.getAllByText("/repo/project-one").length).toBeGreaterThan(0));
-		const workerAgent = screen.getByRole("combobox", { name: "Default worker agent" });
+		const workerAgent = screen.getByRole("button", { name: "Default worker agent" });
 		await userEvent.click(workerAgent);
-		const options = await screen.findAllByRole("option");
+		const options = await screen.findAllByRole("menuitem");
 		expect(options.map((option) => option.textContent)).toEqual([
-			"Claude Code",
-			"Codex",
-			"OpenCode",
-			"Goose",
+			"Claude CodeAuthorized",
+			"CodexAuthorized",
+			"OpenCodeAuthorized",
+			"GooseAuthorized",
 			"KiroAuth unknown",
 		]);
 		expect(options[4]).not.toHaveAttribute("aria-disabled", "true");
@@ -388,7 +443,8 @@ describe("ProjectSettingsForm", () => {
 
 		renderSettings("scratch");
 
-		expect((await screen.findByText("kind")).closest("div")).toHaveTextContent("scratch");
+		const kindRow = (await screen.findByText("kind")).closest(".settings-row-bar");
+		expect(kindRow).toHaveTextContent("scratch");
 		expect(screen.queryByLabelText("Default branch")).not.toBeInTheDocument();
 		expect(screen.queryByLabelText("Session prefix")).not.toBeInTheDocument();
 		expect(screen.queryByText("Reviewers")).not.toBeInTheDocument();
@@ -535,7 +591,7 @@ describe("ProjectSettingsForm", () => {
 			},
 		]);
 
-		const orchestratorAgent = await screen.findByRole("combobox", { name: "Default orchestrator agent" });
+		const orchestratorAgent = await screen.findByRole("button", { name: "Default orchestrator agent" });
 		expect(orchestratorAgent).toHaveTextContent("goose");
 
 		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
@@ -575,7 +631,7 @@ describe("ProjectSettingsForm", () => {
 		const queryClient = renderSettings();
 		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-		const orchestratorAgent = await screen.findByRole("combobox", { name: "Default orchestrator agent" });
+		const orchestratorAgent = await screen.findByRole("button", { name: "Default orchestrator agent" });
 		await chooseOption(orchestratorAgent, "goose");
 		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -1,20 +1,42 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
-import { TriangleAlert } from "lucide-react";
+import {
+	Bot,
+	Fingerprint,
+	FolderGit2,
+	FolderOpen,
+	GitBranch,
+	Hash,
+	Layers,
+	Link,
+	Network,
+	RefreshCw,
+	ScanEye,
+	Shield,
+	Sparkles,
+	Tag,
+	TriangleAlert,
+	type LucideIcon,
+} from "lucide-react";
 import type { components } from "../../api/schema";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { buildRankedAgentOptions } from "../lib/agent-select-options";
 import { captureRendererEvent } from "../lib/telemetry";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
+import { cn } from "../lib/utils";
 import { newestActiveOrchestrator } from "../types/workspace";
+import { AgentAvatar } from "./AgentAvatar";
 import { RequiredAgentField } from "./CreateProjectAgentSheet";
-import { DashboardSubhead } from "./DashboardSubhead";
 import { buildIntake, deriveGitHubRepo, IntakeFields, type IntakeForm, intakeNeedsRule } from "./IntakeFields";
-import { Button } from "./ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
-import { Label } from "./ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { AgentSelectMenuItem } from "./settings/AgentSelectMenuItem";
+import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
+import { SettingsPageShell } from "./settings/SettingsPageShell";
+import { SettingsPanel } from "./settings/SettingsPanel";
+import { SettingsRow } from "./settings/SettingsRow";
+import { SettingsSection } from "./settings/SettingsSection";
 
 type Project = components["schemas"]["Project"];
 type ProjectConfig = components["schemas"]["ProjectConfig"];
@@ -32,7 +54,9 @@ const KNOWN_REVIEWER_HARNESS_IDS = new Set(["claude-code", "codex", "opencode"])
 const projectQueryKey = (id: string) => ["project", id] as const;
 
 export function ProjectSettingsForm({ projectId }: { projectId: string }) {
+	const navigate = useNavigate();
 	const queryClient = useQueryClient();
+	const closeSettings = () => navigate({ to: "/projects/$projectId", params: { projectId } });
 
 	const query = useQuery({
 		queryKey: projectQueryKey(projectId),
@@ -46,27 +70,25 @@ export function ProjectSettingsForm({ projectId }: { projectId: string }) {
 		},
 	});
 
-	if (query.isLoading) {
-		return <CenteredNote>Loading project settings…</CenteredNote>;
-	}
-	if (query.isError || !query.data) {
-		return (
-			<CenteredNote>{query.error instanceof Error ? query.error.message : "Could not load project."}</CenteredNote>
-		);
-	}
-
 	return (
-		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
-			<DashboardSubhead title="Settings" subtitle={query.data.path} />
-			<div className="min-h-0 flex-1 overflow-y-auto p-4.5">
-				<SettingsBody
-					key={projectId}
-					project={query.data}
-					onSaved={() => queryClient.invalidateQueries({ queryKey: workspaceQueryKey })}
-					projectId={projectId}
-				/>
-			</div>
-		</div>
+		<SettingsPageShell>
+			<SettingsPanel onClose={closeSettings} subtitle={query.data?.path}>
+				{query.isLoading ? (
+					<p className="text-sm text-settings-muted">Loading project settings…</p>
+				) : query.isError || !query.data ? (
+					<p className="text-sm text-error">
+						{query.error instanceof Error ? query.error.message : "Could not load project."}
+					</p>
+				) : (
+					<SettingsBody
+						key={projectId}
+						project={query.data}
+						onSaved={() => queryClient.invalidateQueries({ queryKey: workspaceQueryKey })}
+						projectId={projectId}
+					/>
+				)}
+			</SettingsPanel>
+		</SettingsPageShell>
 	);
 }
 
@@ -103,9 +125,6 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 		onSuccess: (next) => queryClient.setQueryData(agentsQueryKey, next),
 	});
 
-	// Git projects can derive owner/repo from origin when trackerIntake.repo is unset.
-	// Scratch hides tracker intake entirely, so this display-only preview is only
-	// rendered for git-backed projects.
 	const intakeForm: IntakeForm = {
 		enabled: form.intakeEnabled,
 		repo: form.intakeRepo,
@@ -125,8 +144,6 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 		mutationFn: async () => {
 			void captureRendererEvent("ao.renderer.settings_save_requested", { project_id: projectId });
 			const displayName = form.displayName.trim();
-			// PUT replaces the whole config; merge the edited fields over what loaded
-			// so we don't drop env/symlinks/postCreate the form doesn't expose.
 			const next: ProjectConfig = isScratchProject
 				? {
 						...scratchSupportedConfig(config),
@@ -186,7 +203,7 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 
 	return (
 		<form
-			className="mx-auto flex max-w-2xl flex-col gap-4"
+			className="flex w-full flex-col gap-(--size-settings-section-gap)"
 			onSubmit={(event) => {
 				event.preventDefault();
 				setSavedAt(null);
@@ -207,223 +224,273 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 				mutation.mutate();
 			}}
 		>
-			<Card>
-				<CardHeader>
-					<CardTitle className="text-control">Identity</CardTitle>
-				</CardHeader>
-				<CardContent className="flex flex-col gap-4 font-mono text-xs text-muted-foreground">
-					<Field label="Project name" htmlFor="projectName">
-						<input
-							id="projectName"
-							className="h-control-form w-full rounded-md border border-input bg-transparent px-2.5 font-sans text-control text-foreground placeholder:text-passive focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-weak"
-							value={form.displayName}
-							onChange={(e) => setForm((f) => ({ ...f, displayName: e.target.value }))}
-						/>
-					</Field>
-					<ReadonlyRow label="id" value={project.id} />
-					<ReadonlyRow label="kind" value={projectKindLabel(project.kind)} />
-					<ReadonlyRow label="path" value={project.path} />
-					<ReadonlyRow label="repo" value={project.repo || "—"} />
-				</CardContent>
-			</Card>
+			<SettingsSection title="Identity">
+				<SettingsInputRow
+					icon={Tag}
+					label="Project name"
+					id="projectName"
+					value={form.displayName}
+					onChange={(value) => setForm((f) => ({ ...f, displayName: value }))}
+				/>
+				<SettingsValueRow icon={Fingerprint} label="id" value={project.id} mono />
+				<SettingsValueRow icon={Layers} label="kind" value={projectKindLabel(project.kind)} />
+				<SettingsValueRow icon={FolderOpen} label="path" value={project.path} mono />
+				<SettingsValueRow icon={Link} label="repo" value={project.repo || "—"} mono />
+			</SettingsSection>
 
 			{project.kind === "workspace" && (
-				<Card>
-					<CardHeader>
-						<CardTitle className="text-[13px]">Workspace repos</CardTitle>
-					</CardHeader>
-					<CardContent className="flex flex-col gap-2">
-						{project.workspaceRepos?.length ? (
-							project.workspaceRepos.map((repo) => (
-								<div
-									key={repo.name}
-									className="grid grid-cols-[minmax(0,120px)_minmax(0,1fr)] gap-3 rounded-md border border-border px-3 py-2 font-mono text-[12px]"
-								>
-									<span className="truncate text-foreground">{repo.name}</span>
-									<span className="min-w-0 truncate text-muted-foreground">
-										{repo.relativePath}
-										{repo.repo ? ` · ${repo.repo}` : ""}
-									</span>
-								</div>
-							))
-						) : (
-							<p className="text-[12px] text-muted-foreground">No child repositories are registered.</p>
-						)}
-					</CardContent>
-				</Card>
-			)}
-
-			{!isScratchProject && (
-				<Card>
-					<CardHeader>
-						<CardTitle className="text-control">Worktrees</CardTitle>
-					</CardHeader>
-					<CardContent className="flex flex-col gap-4">
-						<Field label="Default branch" htmlFor="defaultBranch">
-							<input
-								id="defaultBranch"
-								className="h-control-form w-full rounded-md border border-input bg-transparent px-2.5 text-control text-foreground placeholder:text-passive focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-weak"
-								value={form.defaultBranch}
-								onChange={(e) => setForm((f) => ({ ...f, defaultBranch: e.target.value }))}
-								placeholder="main"
-							/>
-						</Field>
-						<Field label="Session prefix" htmlFor="sessionPrefix">
-							<input
-								id="sessionPrefix"
-								className="h-control-form w-full rounded-md border border-input bg-transparent px-2.5 text-control text-foreground placeholder:text-passive focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-weak"
-								value={form.sessionPrefix}
-								onChange={(e) => setForm((f) => ({ ...f, sessionPrefix: e.target.value }))}
-								placeholder="ao"
-							/>
-						</Field>
-					</CardContent>
-				</Card>
-			)}
-
-			<Card>
-				<CardHeader>
-					<CardTitle className="text-control">Agents</CardTitle>
-				</CardHeader>
-				<CardContent className="flex flex-col gap-4">
-					<RequiredAgentField
-						id="workerAgent"
-						value={form.workerAgent}
-						placeholder="Select worker agent"
-						label="Default worker agent"
-						authorized={agentCatalog?.authorized}
-						installed={agentCatalog?.installed}
-						supported={agentCatalog?.supported}
-						disabled={agentsQuery.isFetching && agentCatalog === undefined}
-						invalid={validationError !== null && form.workerAgent === ""}
-						onChange={(v) => setForm((f) => ({ ...f, workerAgent: v }))}
-					/>
-					<RequiredAgentField
-						id="orchestratorAgent"
-						value={form.orchestratorAgent}
-						placeholder="Select orchestrator agent"
-						label="Default orchestrator agent"
-						authorized={agentCatalog?.authorized}
-						installed={agentCatalog?.installed}
-						supported={agentCatalog?.supported}
-						disabled={agentsQuery.isFetching && agentCatalog === undefined}
-						invalid={validationError !== null && form.orchestratorAgent === ""}
-						onChange={(v) => setForm((f) => ({ ...f, orchestratorAgent: v }))}
-					/>
-					<div className="flex items-center justify-between gap-3 text-xs leading-row text-muted-foreground">
-						<span>Agent availability is cached.</span>
-						<button
-							type="button"
-							className="shrink-0 rounded text-foreground underline-offset-2 hover:underline disabled:pointer-events-none disabled:opacity-50"
-							disabled={refreshAgentsMutation.isPending}
-							onClick={() => refreshAgentsMutation.mutate()}
-						>
-							{refreshAgentsMutation.isPending ? "Refreshing..." : "Refresh agents"}
-						</button>
-					</div>
-					{refreshAgentsMutation.isError && (
-						<p className="text-xs leading-row text-error">
-							{refreshAgentsMutation.error instanceof Error
-								? refreshAgentsMutation.error.message
-								: "Could not refresh agent catalog."}
-						</p>
+				<SettingsSection title="Workspace repos">
+					{project.workspaceRepos?.length ? (
+						project.workspaceRepos.map((repo) => (
+							<SettingsRow key={repo.name} icon={FolderGit2} label={repo.name}>
+								<span className="settings-row-value font-mono tracking-settings-mono">
+									{repo.relativePath}
+									{repo.repo ? ` · ${repo.repo}` : ""}
+								</span>
+							</SettingsRow>
+						))
+					) : (
+						<p className="px-1 text-xs text-settings-muted">No child repositories are registered.</p>
 					)}
-					{missingRequiredAgent && (
-						<p className="text-xs leading-row text-error">Worker and orchestrator agents are required.</p>
-					)}
-					<Field label="Model override" htmlFor="model">
-						<input
-							id="model"
-							className="h-control-form w-full rounded-md border border-input bg-transparent px-2.5 text-control text-foreground placeholder:text-passive focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-weak"
-							value={form.model}
-							onChange={(e) => setForm((f) => ({ ...f, model: e.target.value }))}
-							placeholder="(agent default)"
-						/>
-					</Field>
-					<Field label="Permission mode" htmlFor="permissionMode">
-						<PermissionModeSelect
-							id="permissionMode"
-							value={form.permissions}
-							onChange={(v) => setForm((f) => ({ ...f, permissions: v }))}
-						/>
-					</Field>
-				</CardContent>
-			</Card>
-
-			{!isScratchProject && (
-				<Card>
-					<CardHeader>
-						<CardTitle className="text-control">Reviewers</CardTitle>
-					</CardHeader>
-					<CardContent className="flex flex-col gap-4">
-						<Field label="Default reviewer agent" htmlFor="reviewerHarness">
-							<ReviewerSelect
-								id="reviewerHarness"
-								value={form.reviewerHarness}
-								onChange={(v) => setForm((f) => ({ ...f, reviewerHarness: v }))}
-								authorized={agentCatalog?.authorized}
-								installed={agentCatalog?.installed}
-								supported={agentCatalog?.supported}
-								disabled={agentsQuery.isFetching && agentCatalog === undefined}
-							/>
-						</Field>
-					</CardContent>
-				</Card>
+				</SettingsSection>
 			)}
 
 			{!isScratchProject && (
-				<Card>
-					<CardHeader>
-						<CardTitle className="text-control">Tracker intake</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<IntakeFields form={intakeForm} onChange={patchIntake} repoPreview={{ value: effectiveIntakeRepo }} />
-					</CardContent>
-				</Card>
+				<SettingsSection title="Worktrees">
+					<SettingsInputRow
+						icon={GitBranch}
+						label="Default branch"
+						id="defaultBranch"
+						value={form.defaultBranch}
+						placeholder="main"
+						onChange={(value) => setForm((f) => ({ ...f, defaultBranch: value }))}
+					/>
+					<SettingsInputRow
+						icon={Hash}
+						label="Session prefix"
+						id="sessionPrefix"
+						value={form.sessionPrefix}
+						placeholder="ao"
+						onChange={(value) => setForm((f) => ({ ...f, sessionPrefix: value }))}
+					/>
+				</SettingsSection>
 			)}
 
-			<div className="flex items-center gap-3">
-				<Button type="submit" variant="primary" disabled={mutation.isPending}>
-					{mutation.isPending ? "Saving…" : "Save changes"}
-				</Button>
-				{validationError && <span className="text-xs text-error">{validationError}</span>}
-				{mutation.isError && (
-					<span className="text-xs text-error">
-						{mutation.error instanceof Error ? mutation.error.message : "Save failed"}
-					</span>
+			<SettingsSection title="Agents">
+				<RequiredAgentField
+					id="workerAgent"
+					variant="settings-row"
+					icon={Bot}
+					value={form.workerAgent}
+					placeholder="Select worker agent"
+					label="Default worker agent"
+					authorized={agentCatalog?.authorized}
+					installed={agentCatalog?.installed}
+					supported={agentCatalog?.supported}
+					disabled={agentsQuery.isFetching && agentCatalog === undefined}
+					invalid={validationError !== null && form.workerAgent === ""}
+					onChange={(v) => setForm((f) => ({ ...f, workerAgent: v }))}
+				/>
+				<RequiredAgentField
+					id="orchestratorAgent"
+					variant="settings-row"
+					icon={Network}
+					value={form.orchestratorAgent}
+					placeholder="Select orchestrator agent"
+					label="Default orchestrator agent"
+					authorized={agentCatalog?.authorized}
+					installed={agentCatalog?.installed}
+					supported={agentCatalog?.supported}
+					disabled={agentsQuery.isFetching && agentCatalog === undefined}
+					invalid={validationError !== null && form.orchestratorAgent === ""}
+					onChange={(v) => setForm((f) => ({ ...f, orchestratorAgent: v }))}
+				/>
+				<SettingsRow icon={RefreshCw} label="Refresh agents">
+					<button
+						type="button"
+						aria-label="Refresh agents"
+						className="settings-option-trigger inline-flex items-center gap-1.5 disabled:pointer-events-none disabled:opacity-50"
+						disabled={refreshAgentsMutation.isPending}
+						onClick={() => refreshAgentsMutation.mutate()}
+					>
+						<RefreshCw className={cn("size-icon-base", refreshAgentsMutation.isPending && "animate-spin")} aria-hidden="true" />
+						{refreshAgentsMutation.isPending ? "Refreshing…" : "Refresh"}
+					</button>
+				</SettingsRow>
+				{refreshAgentsMutation.isError && (
+					<p className="px-1 text-xs leading-row text-error">
+						{refreshAgentsMutation.error instanceof Error
+							? refreshAgentsMutation.error.message
+							: "Could not refresh agent catalog."}
+					</p>
 				)}
-				{savedAt && !mutation.isPending && !mutation.isError && <span className="text-xs text-success">Saved.</span>}
-				{replacementError && !mutation.isPending && !mutation.isError && (
-					<span className="text-xs text-warning">Orchestrator restart failed: {replacementError}</span>
+				{missingRequiredAgent && (
+					<p className="px-1 text-xs leading-row text-error">Worker and orchestrator agents are required.</p>
 				)}
-			</div>
+				<SettingsInputRow
+					icon={Sparkles}
+					label="Model override"
+					id="model"
+					value={form.model}
+					placeholder="(agent default)"
+					onChange={(value) => setForm((f) => ({ ...f, model: value }))}
+				/>
+				<SettingsRow icon={Shield} label="Permission mode">
+					<PermissionModeSelect
+						value={form.permissions}
+						onChange={(v) => setForm((f) => ({ ...f, permissions: v }))}
+					/>
+				</SettingsRow>
+				{isScratchProject && (
+					<SaveChangesFooter
+						isPending={mutation.isPending}
+						validationError={validationError}
+						mutationError={mutation.isError ? mutation.error : null}
+						savedAt={savedAt}
+						replacementError={replacementError}
+					/>
+				)}
+			</SettingsSection>
+
+			{!isScratchProject && (
+				<SettingsSection title="Reviewers">
+					<SettingsRow icon={ScanEye} label="Default reviewer agent">
+						<ReviewerSelect
+							value={form.reviewerHarness}
+							onChange={(v) => setForm((f) => ({ ...f, reviewerHarness: v }))}
+							authorized={agentCatalog?.authorized}
+							installed={agentCatalog?.installed}
+							supported={agentCatalog?.supported}
+							disabled={agentsQuery.isFetching && agentCatalog === undefined}
+						/>
+					</SettingsRow>
+				</SettingsSection>
+			)}
+
+			{!isScratchProject && (
+				<SettingsSection title="Tracker intake">
+					<IntakeFields
+						variant="settings"
+						form={intakeForm}
+						onChange={patchIntake}
+						repoPreview={{ value: effectiveIntakeRepo }}
+					/>
+					<SaveChangesFooter
+						isPending={mutation.isPending}
+						validationError={validationError}
+						mutationError={mutation.isError ? mutation.error : null}
+						savedAt={savedAt}
+						replacementError={replacementError}
+					/>
+				</SettingsSection>
+			)}
 		</form>
 	);
 }
 
-function PermissionModeSelect({
+function SaveChangesFooter({
+	isPending,
+	validationError,
+	mutationError,
+	savedAt,
+	replacementError,
+}: {
+	isPending: boolean;
+	validationError: string | null;
+	mutationError: unknown;
+	savedAt: number | null;
+	replacementError: string | null;
+}) {
+	return (
+		<div className="flex flex-col items-start">
+			<button
+				type="submit"
+				className="settings-footer-button settings-footer-button-primary"
+				disabled={isPending}
+			>
+				{isPending ? "Saving…" : "Save changes"}
+			</button>
+			{validationError && (
+				<span className="inline-flex items-center gap-1.5 text-xs text-error">
+					<TriangleAlert className="size-3 shrink-0 text-error" aria-hidden="true" />
+					{validationError}
+				</span>
+			)}
+			{mutationError != null && (
+				<span className="text-xs text-error">
+					{mutationError instanceof Error ? mutationError.message : "Save failed"}
+				</span>
+			)}
+			{savedAt && !isPending && !mutationError && <span className="text-xs text-success">Saved.</span>}
+			{replacementError && !isPending && !mutationError && (
+				<span className="text-xs text-warning">Orchestrator restart failed: {replacementError}</span>
+			)}
+		</div>
+	);
+}
+
+function SettingsInputRow({
+	icon,
+	label,
 	id,
 	value,
 	onChange,
+	placeholder,
 }: {
+	icon?: LucideIcon;
+	label: string;
 	id: string;
 	value: string;
 	onChange: (value: string) => void;
+	placeholder?: string;
 }) {
 	return (
-		<Select value={value || "__default__"} onValueChange={(v) => onChange(v === "__default__" ? "" : v)}>
-			<SelectTrigger id={id} className="h-control-form w-full text-control">
-				<SelectValue />
-			</SelectTrigger>
-			<SelectContent>
-				<SelectItem value="__default__">Project default</SelectItem>
-				{PERMISSION_MODE_OPTIONS.map((opt) => (
-					<SelectItem key={opt.value} value={opt.value}>
-						{opt.label}
-					</SelectItem>
-				))}
-			</SelectContent>
-		</Select>
+		<SettingsRow icon={icon} label={label}>
+			<input
+				id={id}
+				aria-label={label}
+				className="settings-inline-input"
+				value={value}
+				onChange={(event) => onChange(event.target.value)}
+				placeholder={placeholder}
+			/>
+		</SettingsRow>
+	);
+}
+
+function SettingsValueRow({
+	icon,
+	label,
+	value,
+	mono = false,
+}: {
+	icon?: LucideIcon;
+	label: string;
+	value: string;
+	mono?: boolean;
+}) {
+	return (
+		<SettingsRow icon={icon} label={label}>
+			<span className={cn("settings-row-value", mono && "font-mono tracking-settings-mono")} title={value}>
+				{value}
+			</span>
+		</SettingsRow>
+	);
+}
+
+function PermissionModeSelect({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+	const options = [
+		{ value: "__default__", label: "Project default" },
+		...PERMISSION_MODE_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label })),
+	];
+
+	return (
+		<SettingsOptionMenu
+			aria-label="Permission mode"
+			value={value || "__default__"}
+			options={options}
+			onChange={(v) => onChange(v === "__default__" ? "" : v)}
+		/>
 	);
 }
 
@@ -432,12 +499,7 @@ const REVIEWER_AGENT_PRIORITY_RANK = new Map<string, number>(
 	REVIEWER_AGENT_PRIORITY.map((agent, index) => [agent, index]),
 );
 
-function agentLabelCompare(a: components["schemas"]["AgentInfo"], b: components["schemas"]["AgentInfo"]): number {
-	return a.label.localeCompare(b.label) || a.id.localeCompare(b.id);
-}
-
 function ReviewerSelect({
-	id,
 	value,
 	onChange,
 	disabled = false,
@@ -445,7 +507,6 @@ function ReviewerSelect({
 	installed,
 	supported,
 }: {
-	id: string;
 	value: string;
 	onChange: (value: string) => void;
 	disabled?: boolean;
@@ -459,81 +520,55 @@ function ReviewerSelect({
 	}));
 	const filteredSupported = (supported ?? fallbackAgents).filter((a) => KNOWN_REVIEWER_HARNESS_IDS.has(a.id));
 	const supportedAgents = filteredSupported.length > 0 ? filteredSupported : fallbackAgents;
-	const installedAgents = installed ?? supportedAgents;
-	const authorizedAgents = authorized ?? supportedAgents;
-	const authorizedIds = new Set(authorizedAgents.map((agent) => agent.id));
-	const installedById = new Map(installedAgents.map((agent) => [agent.id, agent]));
-	const options = supportedAgents
-		.map((agent) => {
-			const installedAgent = installedById.get(agent.id);
-			const authStatus = installedAgent?.authStatus;
-			const isAuthorized = authorizedIds.has(agent.id) || authStatus === "authorized";
-			const isAuthUnknown = Boolean(installedAgent) && !isAuthorized && authStatus !== "unauthorized";
-			const isSelectable = isAuthorized || isAuthUnknown;
-			const rank = isAuthorized ? 0 : isAuthUnknown ? 1 : installedAgent ? 2 : 3;
-			return {
-				...agent,
-				disabled: !isSelectable,
-				priorityRank: REVIEWER_AGENT_PRIORITY_RANK.get(agent.id) ?? Number.MAX_SAFE_INTEGER,
-				rank,
-				reason: !installedAgent ? "Needs install" : isAuthUnknown ? "Auth unknown" : !isAuthorized ? "Needs auth" : "",
-				warning: isAuthUnknown,
-			};
-		})
-		.sort((a, b) => a.rank - b.rank || a.priorityRank - b.priorityRank || agentLabelCompare(a, b));
+	const options = buildRankedAgentOptions({
+		supported: supportedAgents,
+		installed,
+		authorized,
+		priorityRank: REVIEWER_AGENT_PRIORITY_RANK,
+		fallbackAgents,
+	});
+
+	const menuOptions = [
+		{ value: "__default__", label: "Project default" },
+		...options.map((agent) => ({ value: agent.id, label: agent.label, disabled: agent.disabled })),
+	];
+	const selectedValue = value || "__default__";
 
 	return (
-		<Select
-			value={value || "__default__"}
-			onValueChange={(v) => onChange(v === "__default__" ? "" : v)}
+		<SettingsOptionMenu
+			aria-label="Default reviewer agent"
+			value={selectedValue}
+			options={menuOptions}
 			disabled={disabled}
-		>
-			<SelectTrigger id={id} size="sm" className="w-full text-control">
-				<SelectValue />
-			</SelectTrigger>
-			<SelectContent position="popper" side="bottom" align="start" sideOffset={4} className="max-h-select-menu-max!">
-				<SelectItem value="__default__">Project default</SelectItem>
-				{options.map((agent) => (
-					<SelectItem key={agent.id} value={agent.id} disabled={agent.disabled} className="[&>span:last-child]:w-full">
-						<span className="flex min-w-0 w-full items-center justify-between gap-4">
-							<span className="truncate">{agent.label}</span>
-							{agent.reason && (
-								<span className="inline-flex shrink-0 items-center gap-1 text-caption text-muted-foreground">
-									{agent.warning && <TriangleAlert className="size-3 text-warning" aria-hidden="true" />}
-									{agent.reason}
-								</span>
-							)}
-						</span>
-					</SelectItem>
-				))}
-			</SelectContent>
-		</Select>
-	);
-}
-
-function Field({ label, htmlFor, children }: { label: string; htmlFor?: string; children: React.ReactNode }) {
-	return (
-		<div className="flex flex-col gap-1.5">
-			<Label htmlFor={htmlFor} className="text-xs text-muted-foreground">
-				{label}
-			</Label>
-			{children}
-		</div>
-	);
-}
-
-function ReadonlyRow({ label, value }: { label: string; value: string }) {
-	return (
-		<div className="flex items-center gap-3">
-			<span className="w-12 shrink-0 text-passive">{label}</span>
-			<span className="min-w-0 flex-1 truncate text-foreground">{value}</span>
-		</div>
-	);
-}
-
-function CenteredNote({ children }: { children: React.ReactNode }) {
-	return (
-		<div className="grid h-full place-items-center bg-background p-6 text-center text-xs text-passive">{children}</div>
+			menuClassName="min-w-60"
+			onChange={(v) => onChange(v === "__default__" ? "" : v)}
+			renderTrigger={(selected) => (
+				<>
+					{selected && selected.value !== "__default__" ? (
+						<AgentAvatar provider={selected.value} className="size-icon-lg" />
+					) : null}
+					<span className="min-w-0 truncate">{selected?.label ?? "Project default"}</span>
+				</>
+			)}
+			renderMenuItem={(option, selected) => {
+				if (option.value === "__default__") {
+					return <AgentSelectMenuItem label={option.label} selected={selected} />;
+				}
+				const agent = options.find((entry) => entry.id === option.value);
+				if (!agent) return option.label;
+				return (
+					<AgentSelectMenuItem
+						agentId={agent.id}
+						label={agent.label}
+						selected={selected}
+						status={agent.status}
+						statusTone={agent.statusTone}
+						warning={agent.warning}
+						disabled={agent.disabled}
+					/>
+				);
+			}}
+		/>
 	);
 }
 
@@ -555,8 +590,6 @@ function scratchSupportedConfig(config: ProjectConfig): ProjectConfig {
 	return supported;
 }
 
-// Drop an object whose every value is undefined so we send `undefined` (omit)
-// rather than an empty {} the daemon would persist.
 function blankToUndefined<T extends object>(obj: T): T | undefined {
 	return Object.values(obj).some((v) => v !== undefined) ? obj : undefined;
 }

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -540,7 +540,8 @@ function ReviewerSelect({
 			value={selectedValue}
 			options={menuOptions}
 			disabled={disabled}
-			menuClassName="min-w-60"
+			menuClassName="settings-agent-menu-surface"
+			menuItemClassName="settings-agent-menu-item"
 			onChange={(v) => onChange(v === "__default__" ? "" : v)}
 			renderTrigger={(selected) => (
 				<>
@@ -563,7 +564,6 @@ function ReviewerSelect({
 						selected={selected}
 						status={agent.status}
 						statusTone={agent.statusTone}
-						warning={agent.warning}
 						disabled={agent.disabled}
 					/>
 				);

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -232,10 +232,10 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 					value={form.displayName}
 					onChange={(value) => setForm((f) => ({ ...f, displayName: value }))}
 				/>
-				<SettingsValueRow icon={Fingerprint} label="id" value={project.id} mono />
+				<SettingsValueRow icon={Fingerprint} label="id" value={project.id} />
 				<SettingsValueRow icon={Layers} label="kind" value={projectKindLabel(project.kind)} />
-				<SettingsValueRow icon={FolderOpen} label="path" value={project.path} mono />
-				<SettingsValueRow icon={Link} label="repo" value={project.repo || "—"} mono />
+				<SettingsValueRow icon={FolderOpen} label="path" value={project.path} />
+				<SettingsValueRow icon={Link} label="repo" value={project.repo || "—"} />
 			</SettingsSection>
 
 			{project.kind === "workspace" && (
@@ -243,7 +243,7 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 					{project.workspaceRepos?.length ? (
 						project.workspaceRepos.map((repo) => (
 							<SettingsRow key={repo.name} icon={FolderGit2} label={repo.name}>
-								<span className="settings-row-value font-mono tracking-settings-mono">
+								<span className="settings-row-value">
 									{repo.relativePath}
 									{repo.repo ? ` · ${repo.repo}` : ""}
 								</span>
@@ -462,16 +462,14 @@ function SettingsValueRow({
 	icon,
 	label,
 	value,
-	mono = false,
 }: {
 	icon?: LucideIcon;
 	label: string;
 	value: string;
-	mono?: boolean;
 }) {
 	return (
 		<SettingsRow icon={icon} label={label}>
-			<span className={cn("settings-row-value", mono && "font-mono tracking-settings-mono")} title={value}>
+			<span className="settings-row-value" title={value}>
 				{value}
 			</span>
 		</SettingsRow>

--- a/frontend/src/renderer/components/settings/AgentSelectMenuItem.tsx
+++ b/frontend/src/renderer/components/settings/AgentSelectMenuItem.tsx
@@ -1,0 +1,51 @@
+import { Check, TriangleAlert } from "lucide-react";
+import type { AgentStatusTone } from "../../lib/agent-select-options";
+import { cn } from "../../lib/utils";
+import { AgentAvatar } from "../AgentAvatar";
+
+const STATUS_TONE_CLASS: Record<AgentStatusTone, string> = {
+	success: "text-success",
+	warning: "text-warning",
+	muted: "text-settings-muted",
+};
+
+export function AgentSelectMenuItem({
+	agentId,
+	label,
+	selected,
+	status,
+	statusTone,
+	warning = false,
+	disabled = false,
+}: {
+	agentId?: string;
+	label: string;
+	selected: boolean;
+	status?: string;
+	statusTone?: AgentStatusTone;
+	warning?: boolean;
+	disabled?: boolean;
+}) {
+	return (
+		<span className={cn("flex min-w-0 w-full items-center gap-2", disabled && "opacity-45")}>
+			{agentId ? (
+				<AgentAvatar provider={agentId} className="size-icon-lg" decorative />
+			) : (
+				<span className="size-icon-lg shrink-0" aria-hidden="true" />
+			)}
+			<span className="min-w-0 flex-1 truncate">{label}</span>
+			{status ? (
+				<span
+					className={cn(
+						"inline-flex shrink-0 items-center gap-1 text-caption",
+						STATUS_TONE_CLASS[statusTone ?? "muted"],
+					)}
+				>
+					{warning && <TriangleAlert className="size-3 shrink-0" aria-hidden="true" />}
+					{status}
+				</span>
+			) : null}
+			{selected ? <Check className="size-3 shrink-0 text-settings-label" aria-hidden="true" /> : null}
+		</span>
+	);
+}

--- a/frontend/src/renderer/components/settings/AgentSelectMenuItem.tsx
+++ b/frontend/src/renderer/components/settings/AgentSelectMenuItem.tsx
@@ -1,4 +1,4 @@
-import { Check, TriangleAlert } from "lucide-react";
+import { Check } from "lucide-react";
 import type { AgentStatusTone } from "../../lib/agent-select-options";
 import { cn } from "../../lib/utils";
 import { AgentAvatar } from "../AgentAvatar";
@@ -15,7 +15,6 @@ export function AgentSelectMenuItem({
 	selected,
 	status,
 	statusTone,
-	warning = false,
 	disabled = false,
 }: {
 	agentId?: string;
@@ -23,11 +22,10 @@ export function AgentSelectMenuItem({
 	selected: boolean;
 	status?: string;
 	statusTone?: AgentStatusTone;
-	warning?: boolean;
 	disabled?: boolean;
 }) {
 	return (
-		<span className={cn("flex min-w-0 w-full items-center gap-2", disabled && "opacity-45")}>
+		<span className={cn("flex min-w-0 w-full items-center gap-3", disabled && "opacity-45")}>
 			{agentId ? (
 				<AgentAvatar provider={agentId} className="size-icon-lg" decorative />
 			) : (
@@ -35,15 +33,7 @@ export function AgentSelectMenuItem({
 			)}
 			<span className="min-w-0 flex-1 truncate">{label}</span>
 			{status ? (
-				<span
-					className={cn(
-						"inline-flex shrink-0 items-center gap-1 text-caption",
-						STATUS_TONE_CLASS[statusTone ?? "muted"],
-					)}
-				>
-					{warning && <TriangleAlert className="size-3 shrink-0" aria-hidden="true" />}
-					{status}
-				</span>
+				<span className={cn("shrink-0 text-caption", STATUS_TONE_CLASS[statusTone ?? "muted"])}>{status}</span>
 			) : null}
 			{selected ? <Check className="size-3 shrink-0 text-settings-label" aria-hidden="true" /> : null}
 		</span>

--- a/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
+++ b/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
@@ -20,6 +20,7 @@ export function SettingsOptionMenu<T extends string>({
 	renderTrigger,
 	triggerClassName,
 	menuClassName,
+	menuItemClassName,
 	"aria-label": ariaLabel,
 }: {
 	value: T;
@@ -31,6 +32,7 @@ export function SettingsOptionMenu<T extends string>({
 	renderTrigger?: (selected: SettingsOption<T> | undefined, placeholder?: string) => ReactNode;
 	triggerClassName?: string;
 	menuClassName?: string;
+	menuItemClassName?: string;
 	"aria-label": string;
 }) {
 	const selected = options.find((option) => option.value === value);
@@ -77,6 +79,7 @@ export function SettingsOptionMenu<T extends string>({
 							"focus:border-settings-menu focus:bg-settings-menu-selected focus:text-settings-label",
 							"data-highlighted:border-settings-menu data-highlighted:bg-settings-menu-selected data-highlighted:text-settings-label",
 							option.value === value && "border-settings-menu bg-settings-menu-selected",
+							menuItemClassName,
 						)}
 					>
 						{renderMenuItem ? (

--- a/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
+++ b/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
@@ -7,6 +7,7 @@ export type SettingsOption<T extends string> = {
 	value: T;
 	label: string;
 	icon?: ReactNode;
+	disabled?: boolean;
 };
 
 export function SettingsOptionMenu<T extends string>({
@@ -16,7 +17,9 @@ export function SettingsOptionMenu<T extends string>({
 	disabled,
 	placeholder,
 	renderMenuItem,
+	renderTrigger,
 	triggerClassName,
+	menuClassName,
 	"aria-label": ariaLabel,
 }: {
 	value: T;
@@ -25,7 +28,9 @@ export function SettingsOptionMenu<T extends string>({
 	disabled?: boolean;
 	placeholder?: string;
 	renderMenuItem?: (option: SettingsOption<T>, selected: boolean) => ReactNode;
+	renderTrigger?: (selected: SettingsOption<T> | undefined, placeholder?: string) => ReactNode;
 	triggerClassName?: string;
+	menuClassName?: string;
 	"aria-label": string;
 }) {
 	const selected = options.find((option) => option.value === value);
@@ -41,7 +46,14 @@ export function SettingsOptionMenu<T extends string>({
 					)}
 					aria-label={ariaLabel}
 				>
-					<span className="min-w-0 truncate">{selected?.label ?? placeholder}</span>
+					{renderTrigger ? (
+						renderTrigger(selected, placeholder)
+					) : (
+						<>
+							{selected?.icon}
+							<span className="min-w-0 truncate">{selected?.label ?? placeholder}</span>
+						</>
+					)}
 					<ChevronDown className="size-icon-sm shrink-0 opacity-70" aria-hidden="true" />
 				</button>
 			</DropdownMenuTrigger>
@@ -50,18 +62,21 @@ export function SettingsOptionMenu<T extends string>({
 			    and rounded-lg. */}
 			<DropdownMenuContent
 				align="end"
-				className="settings-menu-surface rounded-(--radius-settings-panel) border-settings-menu bg-settings-menu"
+				className={cn(
+					"settings-menu-surface overflow-y-auto! overflow-x-hidden! max-h-select-menu-max! rounded-(--radius-settings-panel) border-settings-menu bg-settings-menu",
+					menuClassName,
+				)}
 			>
 				{options.map((option) => (
 					<DropdownMenuItem
 						key={option.value}
+						disabled={option.disabled}
 						onSelect={() => onChange(option.value)}
 						className={cn(
 							"settings-menu-item min-w-0 cursor-default outline-none",
 							"focus:border-settings-menu focus:bg-settings-menu-selected focus:text-settings-label",
 							"data-highlighted:border-settings-menu data-highlighted:bg-settings-menu-selected data-highlighted:text-settings-label",
 							option.value === value && "border-settings-menu bg-settings-menu-selected",
-							"[&_svg]:size-icon-lg [&_svg]:shrink-0 [&_svg]:text-settings-muted",
 						)}
 					>
 						{renderMenuItem ? (

--- a/frontend/src/renderer/components/settings/SettingsPanel.tsx
+++ b/frontend/src/renderer/components/settings/SettingsPanel.tsx
@@ -6,7 +6,16 @@ import { isDialogOrMenuOpen } from "../../lib/dom-selectors";
  * Figma "Settings Container": centered column, max-width 768px,
  * padding 64px 32px 80px, gap 32px between header and sections.
  */
-export function SettingsPanel({ children, onClose }: { children: ReactNode; onClose: () => void }) {
+export function SettingsPanel({
+	children,
+	onClose,
+	subtitle,
+}: {
+	children: ReactNode;
+	onClose: () => void;
+	/** Optional path or context shown beside the title (project settings). */
+	subtitle?: string;
+}) {
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
 			if (event.key !== "Escape" || event.defaultPrevented || isDialogOrMenuOpen()) return;
@@ -26,7 +35,14 @@ export function SettingsPanel({ children, onClose }: { children: ReactNode; onCl
 		>
 			<div className="flex w-full max-w-(--size-settings-content-width) flex-col items-stretch gap-(--size-settings-section-gap) px-(--size-settings-panel-padding-x) pb-(--size-settings-panel-padding-bottom) pt-(--size-settings-panel-padding-top)">
 				<div className="flex shrink-0 items-start justify-between gap-4 self-stretch">
-					<h1 className="text-settings-heading font-bold text-settings-title">Settings</h1>
+					<div className="flex min-w-0 items-baseline gap-3">
+						<h1 className="text-settings-heading font-bold text-settings-title">Settings</h1>
+						{subtitle ? (
+							<span className="truncate font-mono text-md-sm text-settings-muted" title={subtitle}>
+								{subtitle}
+							</span>
+						) : null}
+					</div>
 					<button type="button" onClick={onClose} className="settings-close-button" aria-label="Close settings">
 						<X className="size-5" aria-hidden="true" strokeWidth={2.25} />
 					</button>

--- a/frontend/src/renderer/lib/agent-select-options.ts
+++ b/frontend/src/renderer/lib/agent-select-options.ts
@@ -10,7 +10,6 @@ export type RankedAgentOption = AgentInfo & {
 	rank: number;
 	status: string;
 	statusTone: AgentStatusTone;
-	warning: boolean;
 };
 
 export function agentLabelCompare(a: AgentInfo, b: AgentInfo): number {
@@ -21,17 +20,17 @@ function agentStatus(
 	installedAgent: AgentInfo | undefined,
 	isAuthorized: boolean,
 	isAuthUnknown: boolean,
-): Pick<RankedAgentOption, "status" | "statusTone" | "warning"> {
+): Pick<RankedAgentOption, "status" | "statusTone"> {
 	if (!installedAgent) {
-		return { status: "Needs install", statusTone: "muted", warning: false };
+		return { status: "Needs install", statusTone: "muted" };
 	}
 	if (isAuthUnknown) {
-		return { status: "Auth unknown", statusTone: "warning", warning: true };
+		return { status: "Auth unknown", statusTone: "warning" };
 	}
 	if (!isAuthorized) {
-		return { status: "Needs auth", statusTone: "warning", warning: false };
+		return { status: "Needs auth", statusTone: "warning" };
 	}
-	return { status: "Authorized", statusTone: "success", warning: false };
+	return { status: "Authorized", statusTone: "success" };
 }
 
 export function buildRankedAgentOptions({

--- a/frontend/src/renderer/lib/agent-select-options.ts
+++ b/frontend/src/renderer/lib/agent-select-options.ts
@@ -30,7 +30,8 @@ function agentStatus(
 	if (!isAuthorized) {
 		return { status: "Needs auth", statusTone: "warning" };
 	}
-	return { status: "Authorized", statusTone: "success" };
+	// Authorized agents stay clean — only surface problem statuses in the menu.
+	return { status: "", statusTone: "success" };
 }
 
 export function buildRankedAgentOptions({

--- a/frontend/src/renderer/lib/agent-select-options.ts
+++ b/frontend/src/renderer/lib/agent-select-options.ts
@@ -1,0 +1,75 @@
+import type { components } from "../../api/schema";
+
+type AgentInfo = components["schemas"]["AgentInfo"];
+
+export type AgentStatusTone = "success" | "warning" | "muted";
+
+export type RankedAgentOption = AgentInfo & {
+	disabled: boolean;
+	priorityRank: number;
+	rank: number;
+	status: string;
+	statusTone: AgentStatusTone;
+	warning: boolean;
+};
+
+export function agentLabelCompare(a: AgentInfo, b: AgentInfo): number {
+	return a.label.localeCompare(b.label) || a.id.localeCompare(b.id);
+}
+
+function agentStatus(
+	installedAgent: AgentInfo | undefined,
+	isAuthorized: boolean,
+	isAuthUnknown: boolean,
+): Pick<RankedAgentOption, "status" | "statusTone" | "warning"> {
+	if (!installedAgent) {
+		return { status: "Needs install", statusTone: "muted", warning: false };
+	}
+	if (isAuthUnknown) {
+		return { status: "Auth unknown", statusTone: "warning", warning: true };
+	}
+	if (!isAuthorized) {
+		return { status: "Needs auth", statusTone: "warning", warning: false };
+	}
+	return { status: "Authorized", statusTone: "success", warning: false };
+}
+
+export function buildRankedAgentOptions({
+	supported,
+	installed,
+	authorized,
+	priorityRank,
+	fallbackAgents,
+	filter,
+}: {
+	supported?: AgentInfo[];
+	installed?: AgentInfo[];
+	authorized?: AgentInfo[];
+	priorityRank: Map<string, number>;
+	fallbackAgents: AgentInfo[];
+	filter?: (agent: AgentInfo) => boolean;
+}): RankedAgentOption[] {
+	const supportedAgents = (supported ?? fallbackAgents).filter((agent) => (filter ? filter(agent) : true));
+	const installedAgents = installed ?? supportedAgents;
+	const authorizedAgents = authorized ?? supportedAgents;
+	const authorizedIds = new Set(authorizedAgents.map((agent) => agent.id));
+	const installedById = new Map(installedAgents.map((agent) => [agent.id, agent]));
+
+	return supportedAgents
+		.map((agent) => {
+			const installedAgent = installedById.get(agent.id);
+			const authStatus = installedAgent?.authStatus;
+			const isAuthorized = authorizedIds.has(agent.id) || authStatus === "authorized";
+			const isAuthUnknown = Boolean(installedAgent) && !isAuthorized && authStatus !== "unauthorized";
+			const isSelectable = isAuthorized || isAuthUnknown;
+			const rank = isAuthorized ? 0 : isAuthUnknown ? 1 : installedAgent ? 2 : 3;
+			return {
+				...agent,
+				disabled: !isSelectable,
+				priorityRank: priorityRank.get(agent.id) ?? Number.MAX_SAFE_INTEGER,
+				rank,
+				...agentStatus(installedAgent, isAuthorized, isAuthUnknown),
+			};
+		})
+		.sort((a, b) => a.rank - b.rank || a.priorityRank - b.priorityRank || agentLabelCompare(a, b));
+}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -509,6 +509,17 @@ button.settings-row-bar {
 	box-shadow: var(--elevation-md);
 }
 
+@utility settings-agent-menu-surface {
+	min-width: var(--size-settings-agent-menu-min-width);
+	padding: var(--space-3);
+	gap: var(--space-2);
+}
+
+@utility settings-agent-menu-item {
+	padding-inline: var(--space-4);
+	padding-block: var(--space-3);
+}
+
 @utility settings-field-label {
 	font-size: var(--font-size-base);
 	font-weight: var(--font-weight-medium);

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -593,6 +593,7 @@ button.settings-row-bar {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	text-align: right;
+	/* Match settings-option-trigger (Refresh / agent selects) size. */
 	font-size: var(--font-size-base);
 	line-height: 1.25rem;
 	color: var(--color-text-settings-muted);

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -343,6 +343,10 @@
 	background-color: var(--color-settings-accent);
 }
 
+@utility text-settings-accent {
+	color: var(--color-settings-accent);
+}
+
 @utility bg-settings-switch-on {
 	background-color: var(--color-settings-switch-on);
 }
@@ -490,10 +494,13 @@ button.settings-row-bar {
 
 @utility settings-menu-surface {
 	display: flex;
-	min-width: 11rem;
-	width: max-content;
-	max-width: min(18rem, calc(100vw - 2rem));
+	width: min(var(--size-settings-menu-width), calc(100vw - 2rem));
+	min-width: var(--size-settings-menu-min-width);
+	max-height: var(--size-select-menu-max);
 	flex-direction: column;
+	overflow-x: hidden;
+	overflow-y: auto;
+	overscroll-behavior: contain;
 	border-radius: var(--radius-settings-panel);
 	border: 1px solid var(--color-border-settings-menu);
 	background-color: var(--color-bg-settings-menu);
@@ -532,6 +539,54 @@ button.settings-row-bar {
 	}
 }
 
+@utility settings-inline-input {
+	width: auto;
+	max-width: min(var(--size-settings-inline-input-max), var(--size-settings-inline-input-max-percent));
+	min-width: var(--size-settings-inline-input-min);
+	flex: 0 1 auto;
+	height: var(--size-settings-inline-input-height);
+	border: 1px solid var(--color-border-settings-input);
+	border-radius: var(--radius-lg);
+	background-color: var(--color-bg-settings-input);
+	padding-inline: calc(var(--spacing) * 2.5);
+	font-size: var(--font-size-base);
+	line-height: 1.25rem;
+	color: var(--color-text-settings-input);
+	text-align: right;
+	outline: none;
+	box-shadow: none;
+	transition-property: border-color, box-shadow, color;
+	transition-duration: var(--duration-normal);
+
+	&::placeholder {
+		color: var(--color-text-settings-placeholder);
+	}
+
+	&:hover {
+		color: var(--color-text-settings-row);
+	}
+
+	&:focus-visible {
+		border-color: var(--bridge-accent);
+		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		color: var(--color-text-settings-row);
+		outline: none;
+	}
+}
+
+@utility settings-row-value {
+	min-width: 0;
+	max-width: min(var(--size-settings-row-value-max), var(--size-settings-row-value-max-percent));
+	flex: 0 1 auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	text-align: right;
+	font-size: var(--font-size-base);
+	line-height: 1.25rem;
+	color: var(--color-text-settings-muted);
+}
+
 @utility settings-footer-button {
 	display: inline-flex;
 	height: var(--size-settings-action-height);
@@ -557,6 +612,24 @@ button.settings-row-bar {
 
 	&:focus-visible {
 		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+	}
+}
+
+@utility settings-footer-button-primary {
+	border-color: transparent;
+	background-color: var(--color-settings-accent);
+	padding-inline: var(--size-settings-footer-button-padding-x);
+	color: var(--color-settings-footer-button-primary-fg);
+	transition-property: opacity;
+	transition-duration: var(--duration-normal);
+
+	&:hover {
+		opacity: 0.9;
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
 	}
 }
 

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -244,6 +244,7 @@
 	--size-notification-width: 460px;
 	--size-notification-max-height: 420px;
 	--size-select-menu-max: 320px; /* agent/select dropdown scroll cap (was max-h-80) */
+	--size-settings-menu-width: 18rem; /* settings option menus — max width cap */
 	--size-notification-icon: 26px;
 	/* DaemonFailureBanner floating toast (was w-[min(22rem,…)] / max-h-40). */
 	--size-daemon-failure-toast: 22rem;
@@ -348,6 +349,15 @@
 	--size-settings-section-inner-gap: 12px;
 	--size-settings-row-padding: 16px;
 	--size-settings-row-icon-gap: 12px;
+	--size-settings-menu-min-width: 11rem;
+	--size-settings-inline-input-min: 3.5rem;
+	--size-settings-inline-input-max: 12rem;
+	--size-settings-inline-input-max-percent: 42%;
+	--size-settings-inline-input-height: 28px;
+	--size-settings-row-value-max: 20rem;
+	--size-settings-row-value-max-percent: 55%;
+	--size-settings-footer-button-padding-x: 20px;
+	--color-settings-footer-button-primary-fg: #ffffff;
 	--size-settings-dialog: 575px;
 	--size-settings-dialog-max-h: 680px;
 	--color-border-settings-dialog: #2d2d34;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -245,6 +245,7 @@
 	--size-notification-max-height: 420px;
 	--size-select-menu-max: 320px; /* agent/select dropdown scroll cap (was max-h-80) */
 	--size-settings-menu-width: 18rem; /* settings option menus — max width cap */
+	--size-settings-agent-menu-min-width: 20rem; /* agent harness picker — wider rows */
 	--size-notification-icon: 26px;
 	/* DaemonFailureBanner floating toast (was w-[min(22rem,…)] / max-h-40). */
 	--size-daemon-failure-toast: 22rem;


### PR DESCRIPTION
## Summary
- Restyle the project settings page to use the same shell, section headers, and row-based layout as global Settings (`SettingsPageShell`, `SettingsPanel`, `SettingsSection`, `SettingsRow`).
- Replace card/form controls with settings-styled rows: borderless `SettingsOptionMenu` dropdowns for agents/reviewer/permission mode, compact tokenized inline inputs, and read-only value rows.
- Move **Save changes** into the Tracker intake section (or Agents for scratch projects), directly below intake controls.
- Cap all settings option menus to a fixed width and max height with scroll instead of expanding to fit every item (applies to project settings and global settings menus).
- Add settings design tokens and utilities (`settings-inline-input`, `settings-row-value`, `settings-footer-button-primary`) and extend `RequiredAgentField` / `IntakeFields` with settings variants.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/renderer/components/ProjectSettingsForm.test.tsx`
- [x] `npx vitest run src/renderer/components/GlobalSettingsForm.test.tsx`
- [x] `npx vitest run src/renderer/components/CreateProjectAgentSheet.test.tsx`
- [ ] Manually open project settings from sidebar → verify layout matches global Settings
- [ ] Verify agent/reviewer/permission dropdowns scroll when catalog is long
- [ ] Save project name, branch, agents, intake — confirm PUT payload unchanged
- [ ] Close via X and Escape → returns to project board
- [ ] Scratch project: save button appears under Agents; git project: under Tracker intake
## Before
<img width="1459" height="944" alt="image" src="https://github.com/user-attachments/assets/d716fa14-2704-40e0-bef8-33616fc374cd" />
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/71c7a190-e8b2-459d-b608-2ff9be4fda72" />


## After
<img width="908" height="900" alt="image" src="https://github.com/user-attachments/assets/56d43bf5-9f17-463f-8f81-68cace288c72" />
<img width="959" height="930" alt="image" src="https://github.com/user-attachments/assets/775e2271-242d-4078-a1b8-3d0b13e1234a" />

<img width="557" height="380" alt="image" src="https://github.com/user-attachments/assets/4c6f4eca-610e-4e96-9a1c-f12f05ffaa3c" />
