### PR TITLE
Collect Claude and Codex session token usage

### DIFF
--- a/backend/internal/adapters/agent/claudecode/hooks.go
+++ b/backend/internal/adapters/agent/claudecode/hooks.go
@@ -43,6 +43,7 @@ var claudeManagedHooks = []hooksjson.HookSpec{
 	{Event: "PermissionRequest", Command: claudeHookCommandPrefix + "permission-request"},
 	{Event: "Stop", Command: claudeHookCommandPrefix + "stop"},
 	{Event: "Notification", Command: claudeHookCommandPrefix + "notification"},
+	{Event: "SubagentStop", Command: claudeHookCommandPrefix + "subagent-stop"},
 	{Event: "SessionEnd", Command: claudeHookCommandPrefix + "session-end"},
 }
 

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -41,12 +41,22 @@ const (
 // native payload when present. All four are optional: an old daemon decodes
 // the body leniently and simply ignores them.
 type setActivityAPIRequest struct {
-	State          string `json:"state,omitempty"`
-	Event          string `json:"event,omitempty"`
-	ToolName       string `json:"toolName,omitempty"`
-	ToolUseID      string `json:"toolUseId,omitempty"`
-	AgentSessionID string `json:"agentSessionId,omitempty"`
-	LaunchID       string `json:"launchId,omitempty"`
+	State          string             `json:"state,omitempty"`
+	Event          string             `json:"event,omitempty"`
+	ToolName       string             `json:"toolName,omitempty"`
+	ToolUseID      string             `json:"toolUseId,omitempty"`
+	AgentSessionID string             `json:"agentSessionId,omitempty"`
+	LaunchID       string             `json:"launchId,omitempty"`
+	Usage          *usageHookMetadata `json:"usage,omitempty"`
+}
+
+type usageHookMetadata struct {
+	Harness                string `json:"harness"`
+	TranscriptPath         string `json:"transcriptPath,omitempty"`
+	ModelID                string `json:"modelId,omitempty"`
+	SubagentID             string `json:"subagentId,omitempty"`
+	SubagentTranscriptPath string `json:"subagentTranscriptPath,omitempty"`
+	SourceCLIVersion       string `json:"sourceCliVersion,omitempty"`
 }
 
 // maxActivityMetaLen caps the correlation fields lifted from a native hook
@@ -103,6 +113,35 @@ func hookAgentSessionID(payload []byte) string {
 	return id
 }
 
+func hookUsageMetadata(agent string, payload []byte) *usageHookMetadata {
+	harness := domain.AgentHarness(agent)
+	if harness != domain.HarnessClaudeCode && harness != domain.HarnessCodex {
+		return nil
+	}
+	var native struct {
+		TranscriptPath         string `json:"transcript_path"`
+		Model                  string `json:"model"`
+		SubagentID             string `json:"agent_id"`
+		SubagentTranscriptPath string `json:"agent_transcript_path"`
+		CLIVersion             string `json:"cli_version"`
+	}
+	if json.Unmarshal(payload, &native) != nil {
+		return nil
+	}
+	meta := &usageHookMetadata{
+		Harness:                agent,
+		TranscriptPath:         strings.TrimSpace(native.TranscriptPath),
+		ModelID:                strings.TrimSpace(native.Model),
+		SubagentID:             strings.TrimSpace(native.SubagentID),
+		SubagentTranscriptPath: strings.TrimSpace(native.SubagentTranscriptPath),
+		SourceCLIVersion:       strings.TrimSpace(native.CLIVersion),
+	}
+	if meta.TranscriptPath == "" && meta.SubagentTranscriptPath == "" && meta.ModelID == "" && meta.SourceCLIVersion == "" {
+		return nil
+	}
+	return meta
+}
+
 type sessionStartHookOutput struct {
 	HookSpecificOutput struct {
 		HookEventName     string `json:"hookEventName"`
@@ -154,7 +193,8 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 	if activitydispatch.SupportsHarness(domain.AgentHarness(agent)) {
 		agentSessionID = hookAgentSessionID(payload)
 	}
-	if !hasActivity && agentSessionID == "" {
+	usage := hookUsageMetadata(agent, payload)
+	if !hasActivity && agentSessionID == "" && usage == nil {
 		// Unknown agent, or an event carrying neither activity nor resumable
 		// session metadata: report nothing.
 		return nil
@@ -168,6 +208,7 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 		ToolUseID:      toolUseID,
 		AgentSessionID: agentSessionID,
 		LaunchID:       validLaunchID(os.Getenv("AO_RUNTIME_LAUNCH_ID")),
+		Usage:          usage,
 	}
 	if hasActivity {
 		req.State = string(state)

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -55,6 +55,40 @@ func capturedState(t *testing.T, capture *activityCapture) string {
 	return req.State
 }
 
+func TestHooks_ReportsUsageTranscriptMetadata(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true,"sessionId":"ao-7","state":""}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		In: strings.NewReader(`{
+			"session_id":"native-7",
+			"transcript_path":"/home/user/.claude/projects/p/native-7.jsonl",
+			"model":"claude-sonnet",
+			"agent_id":"sub-2",
+			"agent_transcript_path":"/home/user/.claude/projects/p/agent-sub-2.jsonl"
+		}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "claude-code", "subagent-stop")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if req.AgentSessionID != "native-7" || req.Usage == nil {
+		t.Fatalf("request = %+v", req)
+	}
+	if req.Usage.Harness != "claude-code" ||
+		req.Usage.TranscriptPath != "/home/user/.claude/projects/p/native-7.jsonl" ||
+		req.Usage.SubagentID != "sub-2" ||
+		req.Usage.SubagentTranscriptPath != "/home/user/.claude/projects/p/agent-sub-2.jsonl" {
+		t.Fatalf("usage metadata = %+v", req.Usage)
+	}
+}
+
 func TestHooks_NotificationReportsBlocked(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	cfg := setConfigEnv(t)

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -201,8 +201,15 @@ func Run() error {
 	if roots, rootsErr := usagesvc.DefaultSourceRoots(); rootsErr != nil {
 		log.Warn("usage collection disabled", "err", rootsErr)
 	} else {
-		usageObserver = usageobserver.New(store, usageobserver.Config{Logger: log})
-		usageCollector = usagesvc.NewCollector(store, roots, usageObserver.Wake)
+		usageCollector = usagesvc.NewCollector(store, roots, func() {
+			if usageObserver != nil {
+				usageObserver.Wake()
+			}
+		})
+		usageObserver = usageobserver.New(store, usageobserver.Config{
+			Logger:    log,
+			Reconcile: usageCollector.ReconcileSources,
+		})
 	}
 	// Push-device registry: persisted phones that receive OS push notifications.
 	// A load failure must not block boot — degrade to no push rather than refusing

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
 	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
 	"github.com/aoagents/agent-orchestrator/backend/internal/notify"
+	usageobserver "github.com/aoagents/agent-orchestrator/backend/internal/observe/usage"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/preview"
 	"github.com/aoagents/agent-orchestrator/backend/internal/push"
@@ -31,6 +32,7 @@ import (
 	importsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/importer"
 	notificationsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/notification"
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
+	usagesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/usage"
 	"github.com/aoagents/agent-orchestrator/backend/internal/skillassets"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 	"github.com/aoagents/agent-orchestrator/backend/internal/terminal"
@@ -192,6 +194,16 @@ func Run() error {
 	// terminal mux) as session panes, but keep their own ids, storage, and
 	// lifetime — see internal/service/shellterm.
 	shellTermSvc := startShellTerminals(ctx, cfg, runtimeAdapter, store, projectSvc, log)
+	var (
+		usageCollector *usagesvc.Collector
+		usageObserver  *usageobserver.Observer
+	)
+	if roots, rootsErr := usagesvc.DefaultSourceRoots(); rootsErr != nil {
+		log.Warn("usage collection disabled", "err", rootsErr)
+	} else {
+		usageObserver = usageobserver.New(store, usageobserver.Config{Logger: log})
+		usageCollector = usagesvc.NewCollector(store, roots, usageObserver.Wake)
+	}
 	// Push-device registry: persisted phones that receive OS push notifications.
 	// A load failure must not block boot — degrade to no push rather than refusing
 	// to start the daemon. pushRegistry (interface) is assigned only when load
@@ -231,6 +243,7 @@ func Run() error {
 		CDC:                store,
 		Events:             cdcPipe.Broadcaster,
 		Activity:           lcStack.LCM,
+		UsageHooks:         usageCollector,
 		Telemetry:          telemetrySink,
 		Mobile:             mc,
 		DevImport: devimportsvc.New(devimportsvc.Deps{
@@ -250,6 +263,10 @@ func Run() error {
 		return err
 	}
 	previewDone := preview.NewPoller(store, sessionSvc, "http://"+srv.Addr().String(), preview.PollerConfig{Logger: log}).Start(ctx)
+	var usageDone <-chan struct{}
+	if usageObserver != nil {
+		usageDone = usageObserver.Start(ctx)
+	}
 
 	// Late-bind: the LAN listener shares the exact loopback router instance so
 	// the LAN surface and loopback surface never drift apart.
@@ -273,6 +290,11 @@ func Run() error {
 	}
 	if reconcileErr := lcStack.ReconcileRuntime(ctx); reconcileErr != nil {
 		log.Error("reconcile agent processes on boot failed", "err", reconcileErr)
+	}
+	if usageCollector != nil {
+		if backfillErr := usageCollector.BackfillActive(ctx); backfillErr != nil {
+			log.Warn("backfill active usage sources failed", "err", backfillErr)
+		}
 	}
 
 	// Redeliver any worker_idle events left pending across the restart, now that
@@ -312,6 +334,9 @@ func Run() error {
 	// runs before the cancel: a non-signal exit path would hang otherwise.
 	stop()
 	<-previewDone
+	if usageDone != nil {
+		<-usageDone
+	}
 	lcStack.Stop()
 	lanStopCtx, lanCancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
 	defer lanCancel()

--- a/backend/internal/domain/usage.go
+++ b/backend/internal/domain/usage.go
@@ -148,6 +148,8 @@ type UsageSourceRecord struct {
 	BaselineCacheWriteTokens  int64
 	BaselineOutputTokens      int64
 	BaselineReasoningTokens   int64
+	CurrentModelID            string
+	CurrentProvider           string
 	ParserVersion             string
 	State                     UsageSourceState
 	FailureCount              int64
@@ -167,7 +169,9 @@ type UsageSourceContext struct {
 	ProjectID        ProjectID
 	Harness          AgentHarness
 	NativeRootID     string
+	InitialModelID   string
 	SourceCLIVersion string
+	BindingState     UsageBindingState
 }
 
 // UsageTokenMetrics is the normalized token vector stored on every usage event
@@ -312,6 +316,8 @@ type SourceCursorState struct {
 	BaselineCacheWriteTokens  int64
 	BaselineOutputTokens      int64
 	BaselineReasoningTokens   int64
+	CurrentModelID            string
+	CurrentProvider           string
 	FailureCount              int64
 	AnomalyCount              int64
 	NextRetryAt               *time.Time

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -23,6 +23,7 @@ type APIDeps struct {
 	Projects           projectsvc.Manager
 	Sessions           controllers.SessionService
 	Activity           controllers.ActivityRecorder
+	UsageHooks         controllers.UsageHookRecorder
 	PRs                prsvc.ActionManager
 	Reviews            reviewsvc.Manager
 	Notifications      controllers.NotificationService
@@ -69,6 +70,7 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 		sessions: &controllers.SessionsController{
 			Svc:      deps.Sessions,
 			Activity: deps.Activity,
+			Usage:    deps.UsageHooks,
 		},
 		prs:           &controllers.PRsController{Svc: deps.PRs},
 		reviews:       &controllers.ReviewsController{Svc: deps.Reviews},

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2434,6 +2434,26 @@ components:
       required:
       - data
       type: object
+    ControllersUsageHookMetadata:
+      properties:
+        harness:
+          enum:
+          - claude-code
+          - codex
+          type: string
+        modelId:
+          type: string
+        sourceCliVersion:
+          type: string
+        subagentId:
+          type: string
+        subagentTranscriptPath:
+          type: string
+        transcriptPath:
+          type: string
+      required:
+      - harness
+      type: object
     DegradedProject:
       properties:
         id:
@@ -3565,6 +3585,9 @@ components:
         toolUseId:
           description: Native tool-use id, for tool-use hook events.
           type: string
+        usage:
+          $ref: '#/components/schemas/ControllersUsageHookMetadata'
+          description: Provider transcript metadata used by the local usage observer.
       type: object
     SetActivityResponse:
       properties:

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -533,12 +533,25 @@ type ClaimPRResponse struct {
 // state-only semantics.
 // AgentSessionID may arrive without State on metadata-only SessionStart hooks.
 type SetActivityRequest struct {
-	State          string `json:"state,omitempty" enum:"active,idle,waiting_input,blocked,exited" description:"Agent activity state reported by an agent hook. Optional for metadata-only hooks."`
-	Event          string `json:"event,omitempty" description:"AO hook sub-command that produced this state (e.g. post-tool-use)."`
-	ToolName       string `json:"toolName,omitempty" description:"Native tool name, for tool-use hook events."`
-	ToolUseID      string `json:"toolUseId,omitempty" description:"Native tool-use id, for tool-use hook events."`
-	AgentSessionID string `json:"agentSessionId,omitempty" description:"Native agent session identifier used to resume its transcript."`
-	LaunchID       string `json:"launchId,omitempty" description:"AO process generation that produced the signal."`
+	State          string             `json:"state,omitempty" enum:"active,idle,waiting_input,blocked,exited" description:"Agent activity state reported by an agent hook. Optional for metadata-only hooks."`
+	Event          string             `json:"event,omitempty" description:"AO hook sub-command that produced this state (e.g. post-tool-use)."`
+	ToolName       string             `json:"toolName,omitempty" description:"Native tool name, for tool-use hook events."`
+	ToolUseID      string             `json:"toolUseId,omitempty" description:"Native tool-use id, for tool-use hook events."`
+	AgentSessionID string             `json:"agentSessionId,omitempty" description:"Native agent session identifier used to resume its transcript."`
+	LaunchID       string             `json:"launchId,omitempty" description:"AO process generation that produced the signal."`
+	Usage          *UsageHookMetadata `json:"usage,omitempty" description:"Provider transcript metadata used by the local usage observer."`
+}
+
+// UsageHookMetadata is the transcript metadata carried by supported Claude
+// Code and Codex hooks. It contains paths and identifiers only, never prompt or
+// response content.
+type UsageHookMetadata struct {
+	Harness                domain.AgentHarness `json:"harness" enum:"claude-code,codex"`
+	TranscriptPath         string              `json:"transcriptPath,omitempty"`
+	ModelID                string              `json:"modelId,omitempty"`
+	SubagentID             string              `json:"subagentId,omitempty"`
+	SubagentTranscriptPath string              `json:"subagentTranscriptPath,omitempty"`
+	SourceCLIVersion       string              `json:"sourceCliVersion,omitempty"`
 }
 
 // SetActivityResponse is the body of POST /api/v1/sessions/{sessionId}/activity.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	previewutil "github.com/aoagents/agent-orchestrator/backend/internal/preview"
 	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
+	usagesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/usage"
 )
 
 const (
@@ -89,11 +90,18 @@ type ActivityRecorder interface {
 	ApplyActivitySignal(ctx context.Context, id domain.SessionID, s ports.ActivitySignal) error
 }
 
+// UsageHookRecorder consumes transcript metadata from the same native hook
+// callback without changing activity-state semantics.
+type UsageHookRecorder interface {
+	RecordHook(ctx context.Context, id domain.SessionID, signal usagesvc.HookSignal) error
+}
+
 // SessionsController owns the session routes. Nil keeps routes registered but
 // returns OpenAPI-backed 501s.
 type SessionsController struct {
 	Svc      SessionService
 	Activity ActivityRecorder
+	Usage    UsageHookRecorder
 }
 
 // Register mounts the session routes on the supplied router.
@@ -685,7 +693,7 @@ func (c *SessionsController) send(w http.ResponseWriter, r *http.Request) {
 // lifecycle.Manager so the reaper and hooks never race on the session's
 // activity/termination columns.
 func (c *SessionsController) activity(w http.ResponseWriter, r *http.Request) {
-	if c.Activity == nil {
+	if c.Activity == nil && c.Usage == nil {
 		apispec.NotImplemented(w, r, "POST", "/api/v1/sessions/{sessionId}/activity")
 		return
 	}
@@ -704,7 +712,7 @@ func (c *SessionsController) activity(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	agentSessionID := capActivityMeta(domain.SanitizeControlChars(strings.TrimSpace(in.AgentSessionID)))
-	if state == "" && agentSessionID == "" {
+	if state == "" && agentSessionID == "" && in.Usage == nil {
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "ACTIVITY_OR_SESSION_ID_REQUIRED", "Activity state or agent session ID is required", nil)
 		return
 	}
@@ -722,13 +730,30 @@ func (c *SessionsController) activity(w http.ResponseWriter, r *http.Request) {
 		AgentSessionID: agentSessionID,
 		LaunchID:       capActivityMeta(domain.SanitizeControlChars(strings.TrimSpace(in.LaunchID))),
 	}
-	if err := c.Activity.ApplyActivitySignal(r.Context(), sessionID(r), sig); err != nil {
-		if errors.Is(err, ports.ErrSessionNotFound) {
-			envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "SESSION_NOT_FOUND", "Unknown session", nil)
+	if c.Activity != nil && (sig.Valid || sig.AgentSessionID != "") {
+		if err := c.Activity.ApplyActivitySignal(r.Context(), sessionID(r), sig); err != nil {
+			if errors.Is(err, ports.ErrSessionNotFound) {
+				envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "SESSION_NOT_FOUND", "Unknown session", nil)
+				return
+			}
+			envelope.WriteError(w, r, err)
 			return
 		}
-		envelope.WriteError(w, r, err)
-		return
+	}
+	if c.Usage != nil && (in.Usage != nil || in.Event == "session-end" || in.Event == "process-exited") {
+		usageSignal := usagesvc.HookSignal{Event: in.Event, NativeSessionID: agentSessionID}
+		if in.Usage != nil {
+			usageSignal.Harness = in.Usage.Harness
+			usageSignal.TranscriptPath = in.Usage.TranscriptPath
+			usageSignal.ModelID = in.Usage.ModelID
+			usageSignal.SubagentID = in.Usage.SubagentID
+			usageSignal.SubagentTranscriptPath = in.Usage.SubagentTranscriptPath
+			usageSignal.SourceCLIVersion = in.Usage.SourceCLIVersion
+		}
+		if err := c.Usage.RecordHook(r.Context(), sessionID(r), usageSignal); err != nil {
+			envelope.WriteError(w, r, err)
+			return
+		}
 	}
 	envelope.WriteJSON(w, http.StatusOK, SetActivityResponse{OK: true, SessionID: sessionID(r), State: in.State})
 }

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -740,7 +740,8 @@ func (c *SessionsController) activity(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if c.Usage != nil && (in.Usage != nil || in.Event == "session-end" || in.Event == "process-exited") {
+	if c.Usage != nil &&
+		(in.Usage != nil || in.Event == "session-start" || in.Event == "session-end" || in.Event == "process-exited") {
 		usageSignal := usagesvc.HookSignal{Event: in.Event, NativeSessionID: agentSessionID}
 		if in.Usage != nil {
 			usageSignal.Harness = in.Usage.Harness

--- a/backend/internal/httpd/controllers/sessions_activity_test.go
+++ b/backend/internal/httpd/controllers/sessions_activity_test.go
@@ -86,6 +86,55 @@ func TestSessionsAPI_ActivityForwardsUsageMetadataWithoutChangingActivity(t *tes
 	}
 }
 
+func TestSessionsAPI_ActivityForwardsMetadataOnlySessionStartToUsage(t *testing.T) {
+	usage := &fakeUsageHookRecorder{}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithControl(
+		config.Config{},
+		log,
+		nil,
+		httpd.APIDeps{UsageHooks: usage},
+		httpd.ControlDeps{},
+	))
+	t.Cleanup(srv.Close)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/activity",
+		`{"event":"session-start","agentSessionId":"codex-native-1"}`)
+	if status != http.StatusOK {
+		t.Fatalf("activity = %d, want 200; body=%s", status, body)
+	}
+	if usage.calls != 1 || usage.gotID != "ao-1" {
+		t.Fatalf("usage calls=%d id=%q", usage.calls, usage.gotID)
+	}
+	if usage.gotSignal.Event != "session-start" ||
+		usage.gotSignal.NativeSessionID != "codex-native-1" ||
+		usage.gotSignal.Harness != "" {
+		t.Fatalf("usage signal = %+v", usage.gotSignal)
+	}
+}
+
+func TestSessionsAPI_ActivityDoesNotForwardUnrelatedMetadataOnlyEventToUsage(t *testing.T) {
+	usage := &fakeUsageHookRecorder{}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithControl(
+		config.Config{},
+		log,
+		nil,
+		httpd.APIDeps{UsageHooks: usage},
+		httpd.ControlDeps{},
+	))
+	t.Cleanup(srv.Close)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/activity",
+		`{"event":"stop","agentSessionId":"codex-native-1"}`)
+	if status != http.StatusOK {
+		t.Fatalf("activity = %d, want 200; body=%s", status, body)
+	}
+	if usage.calls != 0 {
+		t.Fatalf("usage calls=%d, want 0", usage.calls)
+	}
+}
+
 func TestSessionsAPI_ActivityAppliesSignal(t *testing.T) {
 	rec := &fakeActivityRecorder{}
 	srv := newActivityTestServer(t, rec)

--- a/backend/internal/httpd/controllers/sessions_activity_test.go
+++ b/backend/internal/httpd/controllers/sessions_activity_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	usagesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/usage"
 )
 
 type fakeActivityRecorder struct {
@@ -21,6 +22,19 @@ type fakeActivityRecorder struct {
 	gotSignal ports.ActivitySignal
 	calls     int
 	err       error
+}
+
+type fakeUsageHookRecorder struct {
+	gotID     domain.SessionID
+	gotSignal usagesvc.HookSignal
+	calls     int
+}
+
+func (f *fakeUsageHookRecorder) RecordHook(_ context.Context, id domain.SessionID, signal usagesvc.HookSignal) error {
+	f.calls++
+	f.gotID = id
+	f.gotSignal = signal
+	return nil
 }
 
 func (f *fakeActivityRecorder) ApplyActivitySignal(_ context.Context, id domain.SessionID, s ports.ActivitySignal) error {
@@ -40,6 +54,36 @@ func newActivityTestServer(t *testing.T, rec *fakeActivityRecorder) *httptest.Se
 	srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, deps, httpd.ControlDeps{}))
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func TestSessionsAPI_ActivityForwardsUsageMetadataWithoutChangingActivity(t *testing.T) {
+	usage := &fakeUsageHookRecorder{}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{UsageHooks: usage}, httpd.ControlDeps{}))
+	t.Cleanup(srv.Close)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/activity", `{
+		"event":"subagent-stop",
+		"agentSessionId":"native-1",
+		"usage":{
+			"harness":"claude-code",
+			"transcriptPath":"/tmp/main.jsonl",
+			"modelId":"claude-sonnet",
+			"subagentId":"sub-1",
+			"subagentTranscriptPath":"/tmp/sub.jsonl"
+		}
+	}`)
+	if status != http.StatusOK {
+		t.Fatalf("activity = %d, want 200; body=%s", status, body)
+	}
+	if usage.calls != 1 || usage.gotID != "ao-1" {
+		t.Fatalf("usage calls=%d id=%q", usage.calls, usage.gotID)
+	}
+	if usage.gotSignal.NativeSessionID != "native-1" ||
+		usage.gotSignal.Harness != domain.HarnessClaudeCode ||
+		usage.gotSignal.SubagentTranscriptPath != "/tmp/sub.jsonl" {
+		t.Fatalf("usage signal = %+v", usage.gotSignal)
+	}
 }
 
 func TestSessionsAPI_ActivityAppliesSignal(t *testing.T) {

--- a/backend/internal/observe/usage/observer.go
+++ b/backend/internal/observe/usage/observer.go
@@ -39,6 +39,7 @@ type Config struct {
 	SourceLimit int64
 	ChunkBytes  int64
 	RecordBytes int
+	Reconcile   func(context.Context, int64) error
 	Clock       func() time.Time
 	Logger      *slog.Logger
 }
@@ -50,6 +51,7 @@ type Observer struct {
 	sourceLimit int64
 	chunkBytes  int64
 	recordBytes int
+	reconcile   func(context.Context, int64) error
 	now         func() time.Time
 	logger      *slog.Logger
 	wake        chan struct{}
@@ -81,6 +83,7 @@ func New(store observerStore, cfg Config) *Observer {
 		sourceLimit: cfg.SourceLimit,
 		chunkBytes:  cfg.ChunkBytes,
 		recordBytes: cfg.RecordBytes,
+		reconcile:   cfg.Reconcile,
 		now:         cfg.Clock,
 		logger:      cfg.Logger,
 		wake:        make(chan struct{}, 1),
@@ -127,11 +130,17 @@ func (o *Observer) pollAndLog(ctx context.Context) {
 // Poll processes one bounded batch of registered sources.
 func (o *Observer) Poll(ctx context.Context) error {
 	now := o.now().UTC()
+	var errs []error
+	if o.reconcile != nil {
+		if err := o.reconcile(ctx, o.sourceLimit); err != nil {
+			errs = append(errs, fmt.Errorf("reconcile usage sources: %w", err))
+		}
+	}
 	sources, err := o.store.ListObserverReadyUsageSources(ctx, now, o.sourceLimit)
 	if err != nil {
-		return err
+		errs = append(errs, err)
+		return errors.Join(errs...)
 	}
-	var errs []error
 	for _, source := range sources {
 		if err := o.processSource(ctx, source.ID, now); err != nil {
 			errs = append(errs, err)
@@ -170,6 +179,22 @@ func (o *Observer) processSource(ctx context.Context, sourceID int64, now time.T
 		parsed.Cursor.State = domain.UsageSourceComplete
 	}
 	if _, err := o.store.ApplyUsageChunk(ctx, source.Source.ID, source.Source.ByteOffset, parsed.Cursor, parsed.Events); err != nil {
+		if errors.Is(err, domain.ErrUsageSourceEventConflict) {
+			if _, markErr := o.store.MarkUsageSourceState(
+				ctx,
+				source.Source.ID,
+				domain.UsageSourceComplete,
+				domain.UsageErrorSourceEventConflict,
+				nil,
+				now,
+			); markErr != nil {
+				return errors.Join(err, markErr)
+			}
+			if source.BindingState == domain.UsageBindingFinalizing {
+				return o.completeBinding(ctx, source.Source.BindingID, now)
+			}
+			return nil
+		}
 		return fmt.Errorf("apply usage source %d: %w", source.Source.ID, err)
 	}
 	if parsed.Cursor.State == domain.UsageSourceComplete {

--- a/backend/internal/observe/usage/observer.go
+++ b/backend/internal/observe/usage/observer.go
@@ -1,0 +1,320 @@
+package usage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	usagesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/usage"
+)
+
+const (
+	// DefaultPollInterval is the normal transcript collection cadence.
+	DefaultPollInterval = 30 * time.Second
+	defaultSourceLimit  = 64
+	defaultChunkBytes   = 8 << 20
+	defaultRecordBytes  = 1 << 20
+)
+
+type observerStore interface {
+	ListObserverReadyUsageSources(context.Context, time.Time, int64) ([]domain.UsageSourceRecord, error)
+	GetUsageSourceForIngestion(context.Context, int64) (domain.UsageSourceContext, bool, error)
+	ApplyUsageChunk(context.Context, int64, int64, domain.SourceCursorState, []domain.ModelUsageEvent) (domain.ApplyUsageChunkResult, error)
+	MarkUsageSourceState(context.Context, int64, domain.UsageSourceState, string, *time.Time, time.Time) (bool, error)
+	MarkUsageSourceFailure(context.Context, int64, int64, string, time.Time, time.Time) (bool, error)
+	InsertUsageSource(context.Context, domain.UsageSourceRecord) (domain.UsageSourceRecord, error)
+	ListUsageSourcesForBinding(context.Context, int64) ([]domain.UsageSourceRecord, error)
+	UpdateUsageBindingState(context.Context, int64, domain.UsageBindingState, string, time.Time) (bool, error)
+}
+
+// Config controls the bounded usage transcript observer.
+type Config struct {
+	Tick        time.Duration
+	SourceLimit int64
+	ChunkBytes  int64
+	RecordBytes int
+	Clock       func() time.Time
+	Logger      *slog.Logger
+}
+
+// Observer incrementally tails registered transcript files.
+type Observer struct {
+	store       observerStore
+	tick        time.Duration
+	sourceLimit int64
+	chunkBytes  int64
+	recordBytes int
+	now         func() time.Time
+	logger      *slog.Logger
+	wake        chan struct{}
+}
+
+// New constructs a usage observer with production-safe bounds.
+func New(store observerStore, cfg Config) *Observer {
+	if cfg.Tick <= 0 {
+		cfg.Tick = DefaultPollInterval
+	}
+	if cfg.SourceLimit <= 0 {
+		cfg.SourceLimit = defaultSourceLimit
+	}
+	if cfg.ChunkBytes <= 0 {
+		cfg.ChunkBytes = defaultChunkBytes
+	}
+	if cfg.RecordBytes <= 0 {
+		cfg.RecordBytes = defaultRecordBytes
+	}
+	if cfg.Clock == nil {
+		cfg.Clock = time.Now
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &Observer{
+		store:       store,
+		tick:        cfg.Tick,
+		sourceLimit: cfg.SourceLimit,
+		chunkBytes:  cfg.ChunkBytes,
+		recordBytes: cfg.RecordBytes,
+		now:         cfg.Clock,
+		logger:      cfg.Logger,
+		wake:        make(chan struct{}, 1),
+	}
+}
+
+// Wake requests an immediate collection pass without blocking a hook.
+func (o *Observer) Wake() {
+	select {
+	case o.wake <- struct{}{}:
+	default:
+	}
+}
+
+// Start performs an immediate pass, then polls on the configured cadence or a
+// hook-triggered wake.
+func (o *Observer) Start(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(o.tick)
+		defer ticker.Stop()
+		o.pollAndLog(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				o.pollAndLog(ctx)
+			case <-o.wake:
+				o.pollAndLog(ctx)
+			}
+		}
+	}()
+	return done
+}
+
+func (o *Observer) pollAndLog(ctx context.Context) {
+	if err := o.Poll(ctx); err != nil && ctx.Err() == nil {
+		o.logger.Warn("usage observer poll failed", "err", err)
+	}
+}
+
+// Poll processes one bounded batch of registered sources.
+func (o *Observer) Poll(ctx context.Context) error {
+	now := o.now().UTC()
+	sources, err := o.store.ListObserverReadyUsageSources(ctx, now, o.sourceLimit)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, source := range sources {
+		if err := o.processSource(ctx, source.ID, now); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (o *Observer) processSource(ctx context.Context, sourceID int64, now time.Time) error {
+	source, ok, err := o.store.GetUsageSourceForIngestion(ctx, sourceID)
+	if err != nil || !ok {
+		return err
+	}
+	info, err := os.Stat(source.Source.ArtifactPath)
+	if err != nil || !info.Mode().IsRegular() {
+		return o.retrySource(ctx, source.Source, domain.UsageErrorArtifactMissing, now, err)
+	}
+	identity, err := usagesvc.SourceIdentity(source.Source.ArtifactPath)
+	if err != nil {
+		return o.retrySource(ctx, source.Source, domain.UsageErrorSourceReadFailed, now, err)
+	}
+	if source.Source.FileIdentity != identity || info.Size() < source.Source.ByteOffset {
+		return o.replaceSource(ctx, source, identity, now)
+	}
+
+	chunk, err := readJSONLChunk(source.Source.ArtifactPath, source.Source.ByteOffset, o.chunkBytes, o.recordBytes, source.Source.LastErrorCode)
+	if err != nil {
+		return o.retrySource(ctx, source.Source, domain.UsageErrorSourceReadFailed, now, err)
+	}
+	parsed := parseRecords(source, chunk.records, chunk.nextOffset, now)
+	if chunk.anomalies > 0 {
+		parsed.Cursor.AnomalyCount += int64(chunk.anomalies)
+		parsed.Cursor.LastErrorCode = chunk.errorCode
+	}
+	if source.BindingState == domain.UsageBindingFinalizing && chunk.atEOF {
+		parsed.Cursor.State = domain.UsageSourceComplete
+	}
+	if _, err := o.store.ApplyUsageChunk(ctx, source.Source.ID, source.Source.ByteOffset, parsed.Cursor, parsed.Events); err != nil {
+		return fmt.Errorf("apply usage source %d: %w", source.Source.ID, err)
+	}
+	if parsed.Cursor.State == domain.UsageSourceComplete {
+		return o.completeBinding(ctx, source.Source.BindingID, now)
+	}
+	return nil
+}
+
+func (o *Observer) replaceSource(ctx context.Context, source domain.UsageSourceContext, identity string, now time.Time) error {
+	if _, err := o.store.MarkUsageSourceState(ctx, source.Source.ID, domain.UsageSourceComplete, domain.UsageErrorArtifactReplaced, nil, now); err != nil {
+		return err
+	}
+	_, err := o.store.InsertUsageSource(ctx, domain.UsageSourceRecord{
+		BindingID:       source.Source.BindingID,
+		Kind:            source.Source.Kind,
+		NativeSessionID: source.Source.NativeSessionID,
+		SubagentID:      source.Source.SubagentID,
+		ArtifactPath:    source.Source.ArtifactPath,
+		FileIdentity:    identity,
+		Generation:      source.Source.Generation + 1,
+		CurrentModelID:  source.Source.CurrentModelID,
+		CurrentProvider: source.Source.CurrentProvider,
+		ParserVersion:   source.Source.ParserVersion,
+		State:           domain.UsageSourcePending,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	return err
+}
+
+func (o *Observer) retrySource(ctx context.Context, source domain.UsageSourceRecord, code string, now time.Time, cause error) error {
+	failures := source.FailureCount + 1
+	delay := retryDelay(failures)
+	next := now.Add(delay)
+	if _, err := o.store.MarkUsageSourceFailure(ctx, source.ID, failures, code, next, now); err != nil {
+		return err
+	}
+	if cause == nil {
+		cause = errors.New(code)
+	}
+	return fmt.Errorf("usage source %d: %w", source.ID, cause)
+}
+
+func (o *Observer) completeBinding(ctx context.Context, bindingID int64, now time.Time) error {
+	sources, err := o.store.ListUsageSourcesForBinding(ctx, bindingID)
+	if err != nil {
+		return err
+	}
+	state := domain.UsageBindingComplete
+	for _, source := range sources {
+		if source.State != domain.UsageSourceComplete {
+			return nil
+		}
+		if source.AnomalyCount > 0 || source.LastErrorCode != "" {
+			state = domain.UsageBindingPartial
+		}
+	}
+	_, err = o.store.UpdateUsageBindingState(ctx, bindingID, state, "", now)
+	return err
+}
+
+func retryDelay(failure int64) time.Duration {
+	switch failure {
+	case 1:
+		return 30 * time.Second
+	case 2:
+		return time.Minute
+	case 3:
+		return 2 * time.Minute
+	default:
+		return 5 * time.Minute
+	}
+}
+
+type jsonlChunk struct {
+	records    []jsonlRecord
+	nextOffset int64
+	atEOF      bool
+	anomalies  int
+	errorCode  string
+}
+
+func readJSONLChunk(path string, offset, maxBytes int64, maxRecord int, previousError string) (jsonlChunk, error) {
+	file, err := os.Open(path) //nolint:gosec // path was validated at registration.
+	if err != nil {
+		return jsonlChunk{}, err
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return jsonlChunk{}, err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxBytes))
+	if err != nil {
+		return jsonlChunk{}, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return jsonlChunk{}, err
+	}
+	chunk := jsonlChunk{nextOffset: offset}
+	if len(data) == 0 {
+		chunk.atEOF = offset >= info.Size()
+		return chunk, nil
+	}
+
+	start := 0
+	if previousError == domain.UsageErrorRecordTooLarge {
+		newline := bytes.IndexByte(data, '\n')
+		if newline < 0 {
+			chunk.nextOffset += int64(len(data))
+			chunk.anomalies = 1
+			chunk.errorCode = domain.UsageErrorRecordTooLarge
+			return chunk, nil
+		}
+		start = newline + 1
+		chunk.nextOffset += int64(start)
+	}
+	lastNewline := bytes.LastIndexByte(data[start:], '\n')
+	if lastNewline < 0 {
+		if len(data)-start > maxRecord {
+			chunk.nextOffset += int64(len(data) - start)
+			chunk.anomalies++
+			chunk.errorCode = domain.UsageErrorRecordTooLarge
+		}
+		return chunk, nil
+	}
+	completeEnd := start + lastNewline + 1
+	cursor := start
+	for cursor < completeEnd {
+		relative := bytes.IndexByte(data[cursor:completeEnd], '\n')
+		if relative < 0 {
+			break
+		}
+		end := cursor + relative
+		line := bytes.TrimSuffix(data[cursor:end], []byte{'\r'})
+		lineOffset := offset + int64(cursor)
+		if len(line) > maxRecord {
+			chunk.anomalies++
+			chunk.errorCode = domain.UsageErrorRecordTooLarge
+		} else if len(bytes.TrimSpace(line)) > 0 {
+			chunk.records = append(chunk.records, jsonlRecord{Data: append([]byte(nil), line...), Offset: lineOffset})
+		}
+		cursor = end + 1
+	}
+	chunk.nextOffset = offset + int64(completeEnd)
+	chunk.atEOF = chunk.nextOffset >= info.Size()
+	return chunk, nil
+}

--- a/backend/internal/observe/usage/observer_integration_test.go
+++ b/backend/internal/observe/usage/observer_integration_test.go
@@ -1,0 +1,131 @@
+package usage
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	usagesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/usage"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+func TestObserverPersistsAppendOnlyUsageAcrossRestartAndFinalization(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Unix(1700000000, 0).UTC()
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "usage", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	session, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: "usage",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessCodex,
+		Activity:  domain.Activity{State: domain.ActivityActive, LastActivityAt: now},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
+		SessionID:    session.ID,
+		Harness:      domain.HarnessCodex,
+		NativeRootID: "native-1",
+		State:        domain.UsageBindingActive,
+		FirstSeenAt:  now,
+		LastSeenAt:   now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := t.TempDir() + "/rollout.jsonl"
+	initial := `{"type":"session_meta","payload":{"model_provider":"openai"}}` + "\n" +
+		`{"type":"turn_context","payload":{"model":"gpt-5.6"}}` + "\n" +
+		string(codexTokenLine("2026-07-01T10:00:00Z", 100, 60, 0, 20, 5)) + "\n"
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := usagesvc.SourceIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := store.InsertUsageSource(ctx, domain.UsageSourceRecord{
+		BindingID:     binding.ID,
+		Kind:          domain.UsageSourceCodexRollout,
+		ArtifactPath:  path,
+		FileIdentity:  identity,
+		ParserVersion: usagesvc.CodexRolloutParserVersion,
+		State:         domain.UsageSourcePending,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observer := New(store, Config{Clock: func() time.Time { return now }})
+	if err := observer.Poll(ctx); err != nil {
+		t.Fatalf("first poll: %v", err)
+	}
+	assertTokenAggregate(t, store, session.ID, 120)
+
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write(append(codexTokenLine("2026-07-01T10:00:01Z", 150, 90, 0, 30, 8), '\n')); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	_ = file.Close()
+	now = now.Add(30 * time.Second)
+	if err := observer.Poll(ctx); err != nil {
+		t.Fatalf("append poll: %v", err)
+	}
+	assertTokenAggregate(t, store, session.ID, 180)
+
+	restarted := New(store, Config{Clock: func() time.Time { return now }})
+	if err := restarted.Poll(ctx); err != nil {
+		t.Fatalf("restart poll: %v", err)
+	}
+	assertTokenAggregate(t, store, session.ID, 180)
+
+	if _, err := store.UpdateUsageBindingState(ctx, binding.ID, domain.UsageBindingFinalizing, "", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := restarted.Poll(ctx); err != nil {
+		t.Fatalf("final poll: %v", err)
+	}
+	got, ok, err := store.GetUsageSourceForIngestion(ctx, source.ID)
+	if err != nil || !ok {
+		t.Fatalf("source ok=%v err=%v", ok, err)
+	}
+	if got.Source.State != domain.UsageSourceComplete {
+		t.Fatalf("source state = %s", got.Source.State)
+	}
+	bindings, err := store.ListUsageBindingsForSession(ctx, session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].State != domain.UsageBindingComplete {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
+func assertTokenAggregate(t *testing.T, store *sqlite.Store, sessionID domain.SessionID, total int64) {
+	t.Helper()
+	aggregates, err := store.ListUsageModelAggregates(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got int64
+	for _, aggregate := range aggregates {
+		got += aggregate.Tokens.InputTokens + aggregate.Tokens.OutputTokens
+	}
+	if got != total {
+		t.Fatalf("total tokens = %d, want %d; aggregates=%+v", got, total, aggregates)
+	}
+}

--- a/backend/internal/observe/usage/observer_integration_test.go
+++ b/backend/internal/observe/usage/observer_integration_test.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,6 +11,191 @@ import (
 	usagesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/usage"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
+
+func TestObserverDiscoversAndCollectsCodexSourceCreatedAfterStartup(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Unix(1700000000, 0).UTC()
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "usage", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	session, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: "usage",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessCodex,
+		Activity:  domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
+		Metadata:  domain.SessionMetadata{AgentSessionID: "native-late"},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(t.TempDir(), "sessions")
+	collector := usagesvc.NewCollector(store, usagesvc.SourceRoots{CodexSessions: root}, nil)
+	if err := collector.BackfillActive(ctx); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	path := filepath.Join(root, "2026", "07", "28", "rollout-native-late.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"type":"session_meta","payload":{"model_provider":"openai"}}` + "\n" +
+		`{"type":"turn_context","payload":{"model":"gpt-5.6"}}` + "\n" +
+		string(codexTokenLine("2026-07-28T10:00:00Z", 100, 60, 0, 20, 5)) + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	observer := New(store, Config{
+		Clock:     func() time.Time { return now },
+		Reconcile: collector.ReconcileSources,
+	})
+	if err := observer.Poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	assertTokenAggregate(t, store, session.ID, 120)
+}
+
+func TestObserverCompletesCodexExitWhoseSourceAppearsLate(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Unix(1700000000, 0).UTC()
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "usage", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	session, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: "usage",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessCodex,
+		Activity:  domain.Activity{State: domain.ActivityExited, LastActivityAt: now},
+		Metadata:  domain.SessionMetadata{AgentSessionID: "native-final"},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(t.TempDir(), "sessions")
+	collector := usagesvc.NewCollector(store, usagesvc.SourceRoots{CodexSessions: root}, nil)
+	if err := collector.BackfillActive(ctx); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	path := filepath.Join(root, "2026", "07", "28", "rollout-native-final.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"type":"session_meta","payload":{"model_provider":"openai"}}` + "\n" +
+		`{"type":"turn_context","payload":{"model":"gpt-5.6"}}` + "\n" +
+		string(codexTokenLine("2026-07-28T10:00:00Z", 100, 60, 0, 20, 5)) + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	observer := New(store, Config{
+		Clock:     func() time.Time { return now },
+		Reconcile: collector.ReconcileSources,
+	})
+	if err := observer.Poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	assertTokenAggregate(t, store, session.ID, 120)
+	bindings, err := store.ListUsageBindingsForSession(ctx, session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].State != domain.UsageBindingComplete {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
+func TestObserverPreservesCursorWhenCodexRolloutMovesToArchive(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Unix(1700000000, 0).UTC()
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "usage", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	session, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: "usage",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessCodex,
+		Activity:  domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
+		Metadata:  domain.SessionMetadata{AgentSessionID: "native-move"},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionsRoot := filepath.Join(t.TempDir(), "sessions")
+	archiveRoot := filepath.Join(t.TempDir(), "archived_sessions")
+	activePath := filepath.Join(sessionsRoot, "2026", "07", "28", "rollout-native-move.jsonl")
+	if err := os.MkdirAll(filepath.Dir(activePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	initial := `{"type":"session_meta","payload":{"model_provider":"openai"}}` + "\n" +
+		`{"type":"turn_context","payload":{"model":"gpt-5.6"}}` + "\n" +
+		string(codexTokenLine("2026-07-28T10:00:00Z", 100, 60, 0, 20, 5)) + "\n"
+	if err := os.WriteFile(activePath, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	collector := usagesvc.NewCollector(store, usagesvc.SourceRoots{
+		CodexSessions: sessionsRoot,
+		CodexArchived: archiveRoot,
+	}, nil)
+	if err := collector.BackfillActive(ctx); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	observer := New(store, Config{
+		Clock:     func() time.Time { return now },
+		Reconcile: collector.ReconcileSources,
+	})
+	if err := observer.Poll(ctx); err != nil {
+		t.Fatalf("initial poll: %v", err)
+	}
+	assertTokenAggregate(t, store, session.ID, 120)
+
+	archivedPath := filepath.Join(archiveRoot, filepath.Base(activePath))
+	if err := os.MkdirAll(filepath.Dir(archivedPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(activePath, archivedPath); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(30 * time.Second)
+	_ = observer.Poll(ctx) // Records the missing old path and schedules recovery.
+	now = now.Add(30 * time.Second)
+	if err := observer.Poll(ctx); err != nil {
+		t.Fatalf("relocation poll: %v", err)
+	}
+	assertTokenAggregate(t, store, session.ID, 120)
+
+	file, err := os.OpenFile(archivedPath, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write(append(codexTokenLine("2026-07-28T10:01:00Z", 150, 90, 0, 30, 8), '\n')); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	_ = file.Close()
+	now = now.Add(30 * time.Second)
+	if err := observer.Poll(ctx); err != nil {
+		t.Fatalf("archived append poll: %v", err)
+	}
+	assertTokenAggregate(t, store, session.ID, 180)
+}
 
 func TestObserverPersistsAppendOnlyUsageAcrossRestartAndFinalization(t *testing.T) {
 	ctx := context.Background()
@@ -96,6 +282,26 @@ func TestObserverPersistsAppendOnlyUsageAcrossRestartAndFinalization(t *testing.
 	}
 	assertTokenAggregate(t, store, session.ID, 180)
 
+	replacement := `{"type":"session_meta","payload":{"model_provider":"openai-replacement"}}` + "\n" +
+		`{"type":"turn_context","payload":{"model":"gpt-5.6-mini"}}` + "\n" +
+		string(codexTokenLine("2026-07-01T11:00:00Z", 10, 5, 0, 2, 1)) + "\n"
+	if err := os.WriteFile(path, []byte(replacement), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := restarted.Poll(ctx); err != nil {
+		t.Fatalf("replacement generation: %v", err)
+	}
+	if err := restarted.Poll(ctx); err != nil {
+		t.Fatalf("replacement ingest: %v", err)
+	}
+	assertTokenAggregate(t, store, session.ID, 192)
+	sources, err := store.ListUsageSourcesForBinding(ctx, binding.ID)
+	if err != nil || len(sources) != 2 ||
+		sources[0].State != domain.UsageSourceComplete ||
+		sources[0].LastErrorCode != domain.UsageErrorArtifactReplaced {
+		t.Fatalf("replacement sources=%+v err=%v", sources, err)
+	}
+
 	if _, err := store.UpdateUsageBindingState(ctx, binding.ID, domain.UsageBindingFinalizing, "", now); err != nil {
 		t.Fatal(err)
 	}
@@ -110,8 +316,112 @@ func TestObserverPersistsAppendOnlyUsageAcrossRestartAndFinalization(t *testing.
 		t.Fatalf("source state = %s", got.Source.State)
 	}
 	bindings, err := store.ListUsageBindingsForSession(ctx, session.ID)
-	if err != nil || len(bindings) != 1 || bindings[0].State != domain.UsageBindingComplete {
+	if err != nil || len(bindings) != 1 || bindings[0].State != domain.UsageBindingPartial {
 		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
+func TestObserverStopsRetryingConflictingNativeEvent(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Unix(1700000000, 0).UTC()
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "usage", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	session, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: "usage",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Activity:  domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
+		SessionID:    session.ID,
+		Harness:      domain.HarnessClaudeCode,
+		NativeRootID: "claude-root",
+		State:        domain.UsageBindingActive,
+		FirstSeenAt:  now,
+		LastSeenAt:   now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "claude-root.jsonl")
+	line := `{"type":"assistant","uuid":"native-message","message":{"id":"msg-1","model":"claude-x","stop_reason":"end_turn","usage":{"input_tokens":8,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2}}}` + "\n"
+	if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := usagesvc.SourceIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := store.InsertUsageSource(ctx, domain.UsageSourceRecord{
+		BindingID:       binding.ID,
+		Kind:            domain.UsageSourceClaudeMain,
+		NativeSessionID: "claude-root",
+		ArtifactPath:    path,
+		FileIdentity:    identity,
+		ParserVersion:   usagesvc.ClaudeJSONLParserVersion,
+		State:           domain.UsageSourcePending,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	contextSource, ok, err := store.GetUsageSourceForIngestion(ctx, source.ID)
+	if err != nil || !ok {
+		t.Fatalf("source ok=%v err=%v", ok, err)
+	}
+	parsed := parseRecords(contextSource, []jsonlRecord{{Data: []byte(line), Offset: 0}}, int64(len(line)), now)
+	conflict := parsed.Events[0]
+	conflict.SourceUsageHash = "sha256:different"
+	if _, err := store.ApplyUsageChunk(ctx, source.ID, 0, domain.SourceCursorState{
+		ByteOffset: 0,
+		State:      domain.UsageSourcePending,
+		UpdatedAt:  now,
+	}, []domain.ModelUsageEvent{conflict}); err != nil {
+		t.Fatal(err)
+	}
+
+	observer := New(store, Config{Clock: func() time.Time { return now }})
+	if err := observer.Poll(ctx); err != nil {
+		t.Fatalf("conflict poll: %v", err)
+	}
+	got, ok, err := store.GetUsageSourceForIngestion(ctx, source.ID)
+	if err != nil || !ok {
+		t.Fatalf("source ok=%v err=%v", ok, err)
+	}
+	if got.Source.State != domain.UsageSourceComplete ||
+		got.Source.LastErrorCode != domain.UsageErrorSourceEventConflict {
+		t.Fatalf("source=%+v", got.Source)
+	}
+}
+
+func TestRetryDelayUsesBoundedBackoff(t *testing.T) {
+	tests := []struct {
+		failure int64
+		want    time.Duration
+	}{
+		{failure: 1, want: 30 * time.Second},
+		{failure: 2, want: time.Minute},
+		{failure: 3, want: 2 * time.Minute},
+		{failure: 4, want: 5 * time.Minute},
+		{failure: 20, want: 5 * time.Minute},
+	}
+	for _, test := range tests {
+		if got := retryDelay(test.failure); got != test.want {
+			t.Errorf("retryDelay(%d)=%s, want %s", test.failure, got, test.want)
+		}
 	}
 }
 

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -122,9 +122,16 @@ func parseClaude(source domain.UsageSourceContext, records []jsonlRecord, now ti
 				Confidence: domain.CostConfidenceNone,
 			},
 			TokenConfidence: domain.TokenConfidenceParsed,
-			SourceEventKey:  fmt.Sprintf("%d:claude:%s", source.Source.ID, keyID),
-			ParserVersion:   source.Source.ParserVersion,
-			CreatedAt:       now,
+			SourceEventKey: stableSourceEventKey(
+				"claude",
+				source.NativeRootID,
+				string(source.Source.Kind),
+				source.Source.NativeSessionID,
+				source.Source.SubagentID,
+				keyID,
+			),
+			ParserVersion: source.Source.ParserVersion,
+			CreatedAt:     now,
 		}
 		event.SourceUsageHash = usageHash(event)
 		result.Events = append(result.Events, event)
@@ -168,12 +175,12 @@ func parseCodex(source domain.UsageSourceContext, records []jsonlRecord, now tim
 				result.Cursor.CurrentModelID = firstNonEmpty(payload.Model, result.Cursor.CurrentModelID)
 			}
 		case "event_msg":
-			parseCodexEvent(source, record, envelope, now, result)
+			parseCodexEvent(source, envelope, now, result)
 		}
 	}
 }
 
-func parseCodexEvent(source domain.UsageSourceContext, record jsonlRecord, envelope codexEnvelope, now time.Time, result *parseResult) {
+func parseCodexEvent(source domain.UsageSourceContext, envelope codexEnvelope, now time.Time, result *parseResult) {
 	var payload struct {
 		Type string `json:"type"`
 		Info *struct {
@@ -234,12 +241,16 @@ func parseCodexEvent(source domain.UsageSourceContext, record jsonlRecord, envel
 			Confidence: domain.CostConfidenceNone,
 		},
 		TokenConfidence: domain.TokenConfidenceParsed,
-		SourceEventKey: fmt.Sprintf(
-			"%d:codex:%d:%d:%d",
-			source.Source.ID,
-			record.Offset,
-			total.InputTokens,
-			total.OutputTokens,
+		SourceEventKey: stableSourceEventKey(
+			"codex",
+			source.NativeRootID,
+			source.Source.NativeSessionID,
+			envelope.Timestamp,
+			strconv.FormatInt(total.InputTokens, 10),
+			strconv.FormatInt(total.CachedInputTokens, 10),
+			strconv.FormatInt(total.CacheWriteInputTokens, 10),
+			strconv.FormatInt(total.OutputTokens, 10),
+			strconv.FormatInt(total.ReasoningOutputTokens, 10),
 		),
 		ParserVersion: source.Source.ParserVersion,
 		CreatedAt:     now,
@@ -282,6 +293,15 @@ func usageHash(event domain.ModelUsageEvent) string {
 		event.Tokens.ReasoningTokens,
 	})
 	return fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+}
+
+func stableSourceEventKey(prefix string, parts ...string) string {
+	hash := sha256.New()
+	for _, part := range parts {
+		_, _ = fmt.Fprintf(hash, "%d:", len(part))
+		_, _ = hash.Write([]byte(part))
+	}
+	return fmt.Sprintf("%s:sha256:%x", prefix, hash.Sum(nil))
 }
 
 func parseTimestamp(value string, fallback time.Time) time.Time {

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -1,0 +1,305 @@
+package usage
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type jsonlRecord struct {
+	Data   []byte
+	Offset int64
+}
+
+type parseResult struct {
+	Events []domain.ModelUsageEvent
+	Cursor domain.SourceCursorState
+}
+
+func parseRecords(source domain.UsageSourceContext, records []jsonlRecord, nextOffset int64, now time.Time) parseResult {
+	result := parseResult{Cursor: cursorFromSource(source.Source, nextOffset, now)}
+	switch source.Source.Kind {
+	case domain.UsageSourceClaudeMain, domain.UsageSourceClaudeSubagent:
+		parseClaude(source, records, now, &result)
+	case domain.UsageSourceCodexRollout:
+		parseCodex(source, records, now, &result)
+	default:
+		result.Cursor.AnomalyCount++
+		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
+	}
+	return result
+}
+
+func cursorFromSource(source domain.UsageSourceRecord, nextOffset int64, now time.Time) domain.SourceCursorState {
+	return domain.SourceCursorState{
+		ByteOffset:                nextOffset,
+		State:                     domain.UsageSourceActive,
+		BaselineInputTokens:       source.BaselineInputTokens,
+		BaselineCachedInputTokens: source.BaselineCachedInputTokens,
+		BaselineCacheWriteTokens:  source.BaselineCacheWriteTokens,
+		BaselineOutputTokens:      source.BaselineOutputTokens,
+		BaselineReasoningTokens:   source.BaselineReasoningTokens,
+		CurrentModelID:            source.CurrentModelID,
+		CurrentProvider:           source.CurrentProvider,
+		FailureCount:              0,
+		AnomalyCount:              source.AnomalyCount,
+		LastObservedAt:            &now,
+		UpdatedAt:                 now,
+	}
+}
+
+type claudeTranscriptRecord struct {
+	Type        string `json:"type"`
+	UUID        string `json:"uuid"`
+	IsSidechain bool   `json:"isSidechain"`
+	Timestamp   string `json:"timestamp"`
+	Message     struct {
+		ID         string  `json:"id"`
+		Model      string  `json:"model"`
+		StopReason *string `json:"stop_reason"`
+		Usage      *struct {
+			InputTokens              int64 `json:"input_tokens"`
+			CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+			OutputTokens             int64 `json:"output_tokens"`
+			CacheCreation            *struct {
+				Ephemeral5mInputTokens int64 `json:"ephemeral_5m_input_tokens"`
+				Ephemeral1hInputTokens int64 `json:"ephemeral_1h_input_tokens"`
+			} `json:"cache_creation"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+func parseClaude(source domain.UsageSourceContext, records []jsonlRecord, now time.Time, result *parseResult) {
+	for _, record := range records {
+		var native claudeTranscriptRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "assistant" || native.Message.Usage == nil || native.Message.StopReason == nil || strings.TrimSpace(*native.Message.StopReason) == "" {
+			continue
+		}
+		if source.Source.Kind == domain.UsageSourceClaudeMain && native.IsSidechain {
+			continue
+		}
+		usage := native.Message.Usage
+		input := usage.InputTokens + usage.CacheCreationInputTokens + usage.CacheReadInputTokens
+		if input < 0 || usage.OutputTokens < 0 {
+			recordMalformed(result)
+			continue
+		}
+		var cache5m, cache1h *int64
+		if usage.CacheCreation != nil {
+			cache5m = int64Ptr(usage.CacheCreation.Ephemeral5mInputTokens)
+			cache1h = int64Ptr(usage.CacheCreation.Ephemeral1hInputTokens)
+		}
+		model := firstNonEmpty(native.Message.Model, result.Cursor.CurrentModelID, source.InitialModelID, "unknown")
+		result.Cursor.CurrentModelID = model
+		result.Cursor.CurrentProvider = firstNonEmpty(result.Cursor.CurrentProvider, "claude-code")
+		observedAt := parseTimestamp(native.Timestamp, now)
+		keyID := firstNonEmpty(native.Message.ID, native.UUID, strconv.FormatInt(record.Offset, 10))
+		event := domain.ModelUsageEvent{
+			Provider:   result.Cursor.CurrentProvider,
+			ModelID:    model,
+			ObservedAt: observedAt,
+			Tokens: domain.UsageTokenMetrics{
+				InputTokens:         input,
+				UncachedInputTokens: usage.InputTokens,
+				CacheReadTokens:     usage.CacheReadInputTokens,
+				CacheWriteTokens:    usage.CacheCreationInputTokens,
+				CacheWrite5mTokens:  cache5m,
+				CacheWrite1hTokens:  cache1h,
+				OutputTokens:        usage.OutputTokens,
+			},
+			Cost: domain.UsageCostMetrics{
+				CostBasis:  domain.CostBasisUnavailable,
+				Confidence: domain.CostConfidenceNone,
+			},
+			TokenConfidence: domain.TokenConfidenceParsed,
+			SourceEventKey:  fmt.Sprintf("%d:claude:%s", source.Source.ID, keyID),
+			ParserVersion:   source.Source.ParserVersion,
+			CreatedAt:       now,
+		}
+		event.SourceUsageHash = usageHash(event)
+		result.Events = append(result.Events, event)
+	}
+}
+
+type codexEnvelope struct {
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type codexTokenVector struct {
+	InputTokens           int64 `json:"input_tokens"`
+	CachedInputTokens     int64 `json:"cached_input_tokens"`
+	CacheWriteInputTokens int64 `json:"cache_write_input_tokens"`
+	OutputTokens          int64 `json:"output_tokens"`
+	ReasoningOutputTokens int64 `json:"reasoning_output_tokens"`
+}
+
+func parseCodex(source domain.UsageSourceContext, records []jsonlRecord, now time.Time, result *parseResult) {
+	for _, record := range records {
+		var envelope codexEnvelope
+		if err := json.Unmarshal(record.Data, &envelope); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		switch envelope.Type {
+		case "session_meta":
+			var payload struct {
+				ModelProvider string `json:"model_provider"`
+			}
+			if json.Unmarshal(envelope.Payload, &payload) == nil {
+				result.Cursor.CurrentProvider = firstNonEmpty(payload.ModelProvider, result.Cursor.CurrentProvider)
+			}
+		case "turn_context":
+			var payload struct {
+				Model string `json:"model"`
+			}
+			if json.Unmarshal(envelope.Payload, &payload) == nil {
+				result.Cursor.CurrentModelID = firstNonEmpty(payload.Model, result.Cursor.CurrentModelID)
+			}
+		case "event_msg":
+			parseCodexEvent(source, record, envelope, now, result)
+		}
+	}
+}
+
+func parseCodexEvent(source domain.UsageSourceContext, record jsonlRecord, envelope codexEnvelope, now time.Time, result *parseResult) {
+	var payload struct {
+		Type string `json:"type"`
+		Info *struct {
+			Total codexTokenVector `json:"total_token_usage"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil || payload.Type != "token_count" || payload.Info == nil {
+		return
+	}
+	total := payload.Info.Total
+	if total.InputTokens < 0 || total.CachedInputTokens < 0 || total.CacheWriteInputTokens < 0 ||
+		total.OutputTokens < 0 || total.ReasoningOutputTokens < 0 {
+		recordMalformed(result)
+		return
+	}
+	if total.InputTokens < result.Cursor.BaselineInputTokens ||
+		total.CachedInputTokens < result.Cursor.BaselineCachedInputTokens ||
+		total.CacheWriteInputTokens < result.Cursor.BaselineCacheWriteTokens ||
+		total.OutputTokens < result.Cursor.BaselineOutputTokens ||
+		total.ReasoningOutputTokens < result.Cursor.BaselineReasoningTokens {
+		result.Cursor.AnomalyCount++
+		result.Cursor.LastErrorCode = domain.UsageErrorNonMonotonicCumulativeUsage
+		setCodexBaseline(&result.Cursor, total)
+		return
+	}
+	input := total.InputTokens - result.Cursor.BaselineInputTokens
+	cached := total.CachedInputTokens - result.Cursor.BaselineCachedInputTokens
+	cacheWrite := total.CacheWriteInputTokens - result.Cursor.BaselineCacheWriteTokens
+	output := total.OutputTokens - result.Cursor.BaselineOutputTokens
+	reasoning := total.ReasoningOutputTokens - result.Cursor.BaselineReasoningTokens
+	setCodexBaseline(&result.Cursor, total)
+	if input == 0 && output == 0 && cacheWrite == 0 {
+		return
+	}
+	uncached := input - cached - cacheWrite
+	if uncached < 0 {
+		uncached = 0
+		result.Cursor.AnomalyCount++
+		result.Cursor.LastErrorCode = domain.UsageErrorNonMonotonicCumulativeUsage
+	}
+	model := firstNonEmpty(result.Cursor.CurrentModelID, source.InitialModelID, "unknown")
+	provider := firstNonEmpty(result.Cursor.CurrentProvider, "openai")
+	observedAt := parseTimestamp(envelope.Timestamp, now)
+	event := domain.ModelUsageEvent{
+		Provider:   provider,
+		ModelID:    model,
+		ObservedAt: observedAt,
+		Tokens: domain.UsageTokenMetrics{
+			InputTokens:         input,
+			UncachedInputTokens: uncached,
+			CacheReadTokens:     cached,
+			CacheWriteTokens:    cacheWrite,
+			OutputTokens:        output,
+			ReasoningTokens:     int64Ptr(reasoning),
+		},
+		Cost: domain.UsageCostMetrics{
+			CostBasis:  domain.CostBasisUnavailable,
+			Confidence: domain.CostConfidenceNone,
+		},
+		TokenConfidence: domain.TokenConfidenceParsed,
+		SourceEventKey: fmt.Sprintf(
+			"%d:codex:%d:%d:%d",
+			source.Source.ID,
+			record.Offset,
+			total.InputTokens,
+			total.OutputTokens,
+		),
+		ParserVersion: source.Source.ParserVersion,
+		CreatedAt:     now,
+	}
+	event.SourceUsageHash = usageHash(event)
+	result.Events = append(result.Events, event)
+}
+
+func setCodexBaseline(cursor *domain.SourceCursorState, total codexTokenVector) {
+	cursor.BaselineInputTokens = total.InputTokens
+	cursor.BaselineCachedInputTokens = total.CachedInputTokens
+	cursor.BaselineCacheWriteTokens = total.CacheWriteInputTokens
+	cursor.BaselineOutputTokens = total.OutputTokens
+	cursor.BaselineReasoningTokens = total.ReasoningOutputTokens
+}
+
+func recordMalformed(result *parseResult) {
+	result.Cursor.AnomalyCount++
+	result.Cursor.LastErrorCode = domain.UsageErrorMalformedJSONL
+}
+
+func usageHash(event domain.ModelUsageEvent) string {
+	data, _ := json.Marshal(struct {
+		Provider string
+		Model    string
+		Input    int64
+		Uncached int64
+		Read     int64
+		Write    int64
+		Output   int64
+		Reason   *int64
+	}{
+		event.Provider,
+		event.ModelID,
+		event.Tokens.InputTokens,
+		event.Tokens.UncachedInputTokens,
+		event.Tokens.CacheReadTokens,
+		event.Tokens.CacheWriteTokens,
+		event.Tokens.OutputTokens,
+		event.Tokens.ReasoningTokens,
+	})
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+}
+
+func parseTimestamp(value string, fallback time.Time) time.Time {
+	if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value)); err == nil {
+		return parsed.UTC()
+	}
+	return fallback
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" && len(value) <= 256 {
+			return value
+		}
+	}
+	return ""
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
+}

--- a/backend/internal/observe/usage/parser_test.go
+++ b/backend/internal/observe/usage/parser_test.go
@@ -1,0 +1,165 @@
+package usage
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestParseClaudeFinalUsageAndSkipMainSidechain(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	source := usageSource(domain.UsageSourceClaudeMain)
+	records := []jsonlRecord{
+		{Offset: 0, Data: []byte(`{"type":"assistant","isSidechain":true,"uuid":"side","timestamp":"2026-07-01T10:00:00Z","message":{"id":"msg-side","model":"claude-x","stop_reason":"end_turn","usage":{"input_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5}}}`)},
+		{Offset: 300, Data: []byte(`{"type":"assistant","isSidechain":false,"uuid":"main","timestamp":"2026-07-01T10:01:00Z","message":{"id":"msg-main","model":"claude-x","stop_reason":"tool_use","usage":{"input_tokens":10,"cache_creation_input_tokens":3,"cache_read_input_tokens":7,"output_tokens":4,"cache_creation":{"ephemeral_5m_input_tokens":2,"ephemeral_1h_input_tokens":1}}}}`)},
+		{Offset: 600, Data: []byte(`{"type":"assistant","message":{"id":"stream","model":"claude-x","stop_reason":null,"usage":{"input_tokens":100,"output_tokens":20}}}`)},
+	}
+
+	result := parseRecords(source, records, 700, now)
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	got := result.Events[0]
+	if got.Tokens.InputTokens != 20 || got.Tokens.UncachedInputTokens != 10 ||
+		got.Tokens.CacheReadTokens != 7 || got.Tokens.CacheWriteTokens != 3 ||
+		got.Tokens.OutputTokens != 4 {
+		t.Fatalf("tokens = %+v", got.Tokens)
+	}
+	if got.Tokens.CacheWrite5mTokens == nil || *got.Tokens.CacheWrite5mTokens != 2 ||
+		got.Tokens.CacheWrite1hTokens == nil || *got.Tokens.CacheWrite1hTokens != 1 {
+		t.Fatalf("cache split = %+v", got.Tokens)
+	}
+	if got.ModelID != "claude-x" || got.Cost.CostBasis != domain.CostBasisUnavailable {
+		t.Fatalf("event = %+v", got)
+	}
+}
+
+func TestParseClaudeSubagentIncludesSidechainTranscript(t *testing.T) {
+	source := usageSource(domain.UsageSourceClaudeSubagent)
+	record := jsonlRecord{Data: []byte(`{"type":"assistant","isSidechain":true,"uuid":"sub","message":{"id":"msg-sub","model":"claude-x","stop_reason":"end_turn","usage":{"input_tokens":8,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2}}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000000, 0).UTC())
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want subagent usage", len(result.Events))
+	}
+}
+
+func TestParseCodexCumulativeDeltasAndRepeats(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	source := usageSource(domain.UsageSourceCodexRollout)
+	records := []jsonlRecord{
+		{Offset: 0, Data: []byte(`{"type":"session_meta","payload":{"model_provider":"openai"}}`)},
+		{Offset: 100, Data: []byte(`{"type":"turn_context","payload":{"model":"gpt-5.6"}}`)},
+		{Offset: 200, Data: codexTokenLine("2026-07-01T10:00:00Z", 100, 60, 10, 20, 5)},
+		{Offset: 300, Data: codexTokenLine("2026-07-01T10:00:01Z", 100, 60, 10, 20, 5)},
+		{Offset: 400, Data: codexTokenLine("2026-07-01T10:00:02Z", 160, 90, 10, 35, 8)},
+	}
+	result := parseRecords(source, records, 500, now)
+	if len(result.Events) != 2 {
+		t.Fatalf("events = %d, want 2", len(result.Events))
+	}
+	if got := result.Events[0].Tokens; got.InputTokens != 100 || got.UncachedInputTokens != 30 ||
+		got.CacheReadTokens != 60 || got.CacheWriteTokens != 10 || got.OutputTokens != 20 {
+		t.Fatalf("first tokens = %+v", got)
+	}
+	if got := result.Events[1].Tokens; got.InputTokens != 60 || got.UncachedInputTokens != 30 ||
+		got.CacheReadTokens != 30 || got.OutputTokens != 15 ||
+		got.ReasoningTokens == nil || *got.ReasoningTokens != 3 {
+		t.Fatalf("delta tokens = %+v", got)
+	}
+	if result.Cursor.BaselineInputTokens != 160 || result.Cursor.CurrentModelID != "gpt-5.6" ||
+		result.Cursor.CurrentProvider != "openai" {
+		t.Fatalf("cursor = %+v", result.Cursor)
+	}
+}
+
+func TestParseCodexCounterResetNeverEmitsNegativeUsage(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	source := usageSource(domain.UsageSourceCodexRollout)
+	source.Source.BaselineInputTokens = 500
+	source.Source.BaselineCachedInputTokens = 300
+	source.Source.BaselineOutputTokens = 50
+	result := parseRecords(source, []jsonlRecord{{
+		Offset: 20,
+		Data:   codexTokenLine("2026-07-01T10:00:00Z", 10, 5, 0, 2, 1),
+	}}, 100, now)
+	if len(result.Events) != 0 {
+		t.Fatalf("events = %+v, want no negative delta event", result.Events)
+	}
+	if result.Cursor.AnomalyCount != 1 ||
+		result.Cursor.LastErrorCode != domain.UsageErrorNonMonotonicCumulativeUsage ||
+		result.Cursor.BaselineInputTokens != 10 {
+		t.Fatalf("cursor = %+v", result.Cursor)
+	}
+}
+
+func TestReadJSONLChunkRetainsPartialTailAndSkipsOversizedRecord(t *testing.T) {
+	path := t.TempDir() + "/rollout.jsonl"
+	if err := osWrite(path, `{"a":1}`+"\n"+`{"b":`); err != nil {
+		t.Fatal(err)
+	}
+	first, err := readJSONLChunk(path, 0, 1024, 32, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.records) != 1 || first.atEOF || first.nextOffset != int64(len(`{"a":1}`+"\n")) {
+		t.Fatalf("first chunk = %+v", first)
+	}
+	if err := osAppend(path, `2}`+"\n"); err != nil {
+		t.Fatal(err)
+	}
+	second, err := readJSONLChunk(path, first.nextOffset, 1024, 32, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second.records) != 1 || !second.atEOF {
+		t.Fatalf("second chunk = %+v", second)
+	}
+
+	if err := osWrite(path, strings.Repeat("x", 40)+"\n"); err != nil {
+		t.Fatal(err)
+	}
+	large, err := readJSONLChunk(path, 0, 1024, 16, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if large.anomalies != 1 || large.errorCode != domain.UsageErrorRecordTooLarge || large.nextOffset != 41 {
+		t.Fatalf("oversized chunk = %+v", large)
+	}
+}
+
+func usageSource(kind domain.UsageSourceKind) domain.UsageSourceContext {
+	return domain.UsageSourceContext{
+		Source: domain.UsageSourceRecord{
+			ID:            7,
+			Kind:          kind,
+			ParserVersion: "test/v1",
+			State:         domain.UsageSourceActive,
+		},
+		InitialModelID: "fallback-model",
+	}
+}
+
+func codexTokenLine(timestamp string, input, cached, cacheWrite, output, reasoning int64) []byte {
+	return []byte(fmt.Sprintf(
+		`{"timestamp":%q,"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":%d,"cached_input_tokens":%d,"cache_write_input_tokens":%d,"output_tokens":%d,"reasoning_output_tokens":%d}}}}`,
+		timestamp, input, cached, cacheWrite, output, reasoning,
+	))
+}
+
+func osWrite(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+func osAppend(path, content string) error {
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	_, err = file.WriteString(content)
+	return err
+}

--- a/backend/internal/observe/usage/parser_test.go
+++ b/backend/internal/observe/usage/parser_test.go
@@ -96,6 +96,107 @@ func TestParseCodexCounterResetNeverEmitsNegativeUsage(t *testing.T) {
 	}
 }
 
+func TestParserEventKeysSurvivePhysicalSourceReplacement(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	claudeRecord := jsonlRecord{
+		Offset: 120,
+		Data: []byte(
+			`{"type":"assistant","uuid":"native-message","message":{"id":"msg-1","model":"claude-x","stop_reason":"end_turn","usage":{"input_tokens":8,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2}}}`,
+		),
+	}
+	firstClaude := usageSource(domain.UsageSourceClaudeMain)
+	firstClaude.NativeRootID = "claude-root"
+	firstClaude.Source.NativeSessionID = "claude-root"
+	secondClaude := firstClaude
+	secondClaude.Source.ID = 99
+
+	firstClaudeResult := parseRecords(firstClaude, []jsonlRecord{claudeRecord}, 400, now)
+	secondClaudeResult := parseRecords(secondClaude, []jsonlRecord{claudeRecord}, 400, now)
+	if len(firstClaudeResult.Events) != 1 || len(secondClaudeResult.Events) != 1 ||
+		firstClaudeResult.Events[0].SourceEventKey != secondClaudeResult.Events[0].SourceEventKey {
+		t.Fatalf("claude keys=%+v/%+v", firstClaudeResult.Events, secondClaudeResult.Events)
+	}
+
+	codexRecords := []jsonlRecord{
+		{Offset: 0, Data: []byte(`{"type":"turn_context","payload":{"model":"gpt-5.6"}}`)},
+		{Offset: 100, Data: codexTokenLine("2026-07-28T10:00:00Z", 100, 60, 0, 20, 5)},
+	}
+	firstCodex := usageSource(domain.UsageSourceCodexRollout)
+	firstCodex.NativeRootID = "codex-root"
+	firstCodex.Source.NativeSessionID = "codex-root"
+	secondCodex := firstCodex
+	secondCodex.Source.ID = 100
+	firstCodexResult := parseRecords(firstCodex, codexRecords, 300, now)
+	secondCodexResult := parseRecords(secondCodex, codexRecords, 300, now)
+	if len(firstCodexResult.Events) != 1 || len(secondCodexResult.Events) != 1 ||
+		firstCodexResult.Events[0].SourceEventKey != secondCodexResult.Events[0].SourceEventKey {
+		t.Fatalf("codex keys=%+v/%+v", firstCodexResult.Events, secondCodexResult.Events)
+	}
+}
+
+func TestParserEventKeysSeparateSubagentsAndCounterResetEpochs(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	record := jsonlRecord{
+		Offset: 20,
+		Data: []byte(
+			`{"type":"assistant","uuid":"native-message","message":{"id":"msg-1","model":"claude-x","stop_reason":"end_turn","usage":{"input_tokens":8,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2}}}`,
+		),
+	}
+	firstSubagent := usageSource(domain.UsageSourceClaudeSubagent)
+	firstSubagent.NativeRootID = "claude-root"
+	firstSubagent.Source.NativeSessionID = "claude-root"
+	firstSubagent.Source.SubagentID = "sub-1"
+	secondSubagent := firstSubagent
+	secondSubagent.Source.ID = 9
+	secondSubagent.Source.SubagentID = "sub-2"
+	firstResult := parseRecords(firstSubagent, []jsonlRecord{record}, 300, now)
+	secondResult := parseRecords(secondSubagent, []jsonlRecord{record}, 300, now)
+	if firstResult.Events[0].SourceEventKey == secondResult.Events[0].SourceEventKey {
+		t.Fatalf("distinct subagents shared key %q", firstResult.Events[0].SourceEventKey)
+	}
+
+	codex := usageSource(domain.UsageSourceCodexRollout)
+	codex.NativeRootID = "codex-root"
+	firstEpoch := parseRecords(codex, []jsonlRecord{
+		{Data: []byte(`{"type":"turn_context","payload":{"model":"gpt-5.6"}}`)},
+		{Data: codexTokenLine("2026-07-28T10:00:00Z", 10, 5, 0, 2, 1)},
+	}, 200, now)
+	secondEpoch := parseRecords(codex, []jsonlRecord{
+		{Data: []byte(`{"type":"turn_context","payload":{"model":"gpt-5.6"}}`)},
+		{Data: codexTokenLine("2026-07-28T11:00:00Z", 10, 5, 0, 2, 1)},
+	}, 200, now)
+	if firstEpoch.Events[0].SourceEventKey == secondEpoch.Events[0].SourceEventKey {
+		t.Fatalf("distinct Codex epochs shared key %q", firstEpoch.Events[0].SourceEventKey)
+	}
+}
+
+func TestParsersTrackProviderModelChanges(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	claude := usageSource(domain.UsageSourceClaudeMain)
+	claudeResult := parseRecords(claude, []jsonlRecord{
+		{Data: []byte(`{"type":"assistant","uuid":"one","message":{"id":"msg-1","model":"claude-a","stop_reason":"end_turn","usage":{"input_tokens":8,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2}}}`)},
+		{Data: []byte(`{"type":"assistant","uuid":"two","message":{"id":"msg-2","model":"claude-b","stop_reason":"end_turn","usage":{"input_tokens":9,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":3}}}`)},
+	}, 500, now)
+	if len(claudeResult.Events) != 2 ||
+		claudeResult.Events[0].ModelID != "claude-a" ||
+		claudeResult.Events[1].ModelID != "claude-b" {
+		t.Fatalf("claude events=%+v", claudeResult.Events)
+	}
+
+	codex := usageSource(domain.UsageSourceCodexRollout)
+	codexResult := parseRecords(codex, []jsonlRecord{
+		{Data: []byte(`{"type":"turn_context","payload":{"model":"gpt-a"}}`)},
+		{Data: codexTokenLine("2026-07-28T10:00:00Z", 10, 5, 0, 2, 1)},
+		{Data: []byte(`{"type":"turn_context","payload":{"model":"gpt-b"}}`)},
+		{Data: codexTokenLine("2026-07-28T10:01:00Z", 20, 10, 0, 4, 2)},
+	}, 500, now)
+	if len(codexResult.Events) != 2 ||
+		codexResult.Events[0].ModelID != "gpt-a" ||
+		codexResult.Events[1].ModelID != "gpt-b" {
+		t.Fatalf("codex events=%+v", codexResult.Events)
+	}
+}
+
 func TestReadJSONLChunkRetainsPartialTailAndSkipsOversizedRecord(t *testing.T) {
 	path := t.TempDir() + "/rollout.jsonl"
 	if err := osWrite(path, `{"a":1}`+"\n"+`{"b":`); err != nil {

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -21,6 +21,7 @@ const sourceIdentityRecordBytes = 64 << 10
 const (
 	maxUsageMetadataBytes = 256
 	maxUsagePathBytes     = 4096
+	defaultDiscoveryLimit = 64
 )
 
 var nativeUsageIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
@@ -67,7 +68,9 @@ type collectorStore interface {
 	GetSession(context.Context, domain.SessionID) (domain.SessionRecord, bool, error)
 	ListAllSessions(context.Context) ([]domain.SessionRecord, error)
 	UpsertUsageBinding(context.Context, domain.UsageBindingRecord) (domain.UsageBindingRecord, error)
+	GetUsageBinding(context.Context, domain.SessionID, domain.AgentHarness, string) (domain.UsageBindingRecord, bool, error)
 	ListUsageBindingsForSession(context.Context, domain.SessionID) ([]domain.UsageBindingRecord, error)
+	ListUsageDiscoveryBindings(context.Context, int64) ([]domain.UsageBindingRecord, error)
 	UpdateUsageBindingState(context.Context, int64, domain.UsageBindingState, string, time.Time) (bool, error)
 	InsertUsageSource(context.Context, domain.UsageSourceRecord) (domain.UsageSourceRecord, error)
 	ListUsageSourcesForBinding(context.Context, int64) ([]domain.UsageSourceRecord, error)
@@ -125,9 +128,27 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 		return nil
 	}
 
+	finalizing := signal.Event == "session-end" || signal.Event == "process-exited"
+	existing, exists, err := c.store.GetUsageBinding(ctx, sessionID, session.Harness, signal.NativeSessionID)
+	if err != nil {
+		return err
+	}
 	state := domain.UsageBindingActive
-	if signal.Event == "session-end" || signal.Event == "process-exited" {
+	if exists {
+		state = existing.State
+	}
+	switch {
+	case finalizing:
 		state = domain.UsageBindingFinalizing
+	case signal.Event == "session-start":
+		state = domain.UsageBindingActive
+	case exists && (state == domain.UsageBindingComplete || state == domain.UsageBindingPartial) &&
+		(strings.TrimSpace(signal.TranscriptPath) != "" || strings.TrimSpace(signal.SubagentTranscriptPath) != ""):
+		state = domain.UsageBindingFinalizing
+	}
+	lastErrorCode := ""
+	if session.Harness == domain.HarnessCodex && strings.TrimSpace(signal.TranscriptPath) == "" {
+		lastErrorCode = domain.UsageErrorSourceDiscoveryPending
 	}
 	binding, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
 		SessionID:        sessionID,
@@ -136,6 +157,7 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 		InitialModelID:   boundedUsageMetadata(signal.ModelID),
 		SourceCLIVersion: boundedUsageMetadata(signal.SourceCLIVersion),
 		State:            state,
+		LastErrorCode:    lastErrorCode,
 		FirstSeenAt:      now,
 		LastSeenAt:       now,
 		UpdatedAt:        now,
@@ -144,22 +166,68 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 		return err
 	}
 
-	if path := strings.TrimSpace(signal.TranscriptPath); path != "" {
+	mainPath := strings.TrimSpace(signal.TranscriptPath)
+	if mainPath == "" && session.Harness == domain.HarnessCodex {
+		mainPath = c.discoverPath(session.Harness, signal.NativeSessionID)
+	}
+	if mainPath != "" {
 		kind := domain.UsageSourceClaudeMain
 		if session.Harness == domain.HarnessCodex {
 			kind = domain.UsageSourceCodexRollout
 		}
-		if err := c.registerSource(ctx, binding, kind, signal.NativeSessionID, "", path, signal.ModelID, now); err != nil {
+		if err := c.registerSource(
+			ctx,
+			binding,
+			kind,
+			signal.NativeSessionID,
+			"",
+			mainPath,
+			signal.ModelID,
+			now,
+			signal.Event == "session-start",
+		); err != nil {
+			return err
+		}
+		sourceErrorCode := ""
+		if c.codexDiscoveryStillPending(signal.Event, signal.TranscriptPath, mainPath) {
+			sourceErrorCode = domain.UsageErrorSourceDiscoveryPending
+		}
+		if _, err := c.store.UpdateUsageBindingState(ctx, binding.ID, state, sourceErrorCode, now); err != nil {
 			return err
 		}
 	}
 	if path := strings.TrimSpace(signal.SubagentTranscriptPath); path != "" && session.Harness == domain.HarnessClaudeCode {
-		if err := c.registerSource(ctx, binding, domain.UsageSourceClaudeSubagent, signal.NativeSessionID, boundedUsageMetadata(signal.SubagentID), path, signal.ModelID, now); err != nil {
+		if err := c.registerSource(
+			ctx,
+			binding,
+			domain.UsageSourceClaudeSubagent,
+			signal.NativeSessionID,
+			boundedUsageMetadata(signal.SubagentID),
+			path,
+			signal.ModelID,
+			now,
+			false,
+		); err != nil {
 			return err
 		}
 	}
 	if signal.Event == "session-start" {
 		if err := c.reactivateBinding(ctx, binding, now); err != nil {
+			return err
+		}
+		if c.codexDiscoveryStillPending(signal.Event, signal.TranscriptPath, mainPath) {
+			if _, err := c.store.UpdateUsageBindingState(
+				ctx,
+				binding.ID,
+				domain.UsageBindingActive,
+				domain.UsageErrorSourceDiscoveryPending,
+				now,
+			); err != nil {
+				return err
+			}
+		}
+	} else if state == domain.UsageBindingFinalizing {
+		if err := c.settleFinalizingBinding(ctx, binding.ID, now); err != nil {
 			return err
 		}
 	}
@@ -179,38 +247,156 @@ func (c *Collector) BackfillActive(ctx context.Context) error {
 		if session.IsTerminated || !SupportedHarness(session.Harness) {
 			continue
 		}
-		nativeID := strings.TrimSpace(session.Metadata.AgentSessionID)
+		nativeID := boundedUsageMetadata(session.Metadata.AgentSessionID)
 		if nativeID == "" || !nativeUsageIDPattern.MatchString(nativeID) {
 			continue
 		}
-		path := c.discoverPath(session.Harness, nativeID)
-		if path == "" {
-			now := c.now().UTC()
-			_, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
-				SessionID:     session.ID,
-				Harness:       session.Harness,
-				NativeRootID:  nativeID,
-				State:         domain.UsageBindingDiscovering,
-				LastErrorCode: domain.UsageErrorSourceDiscoveryPending,
-				FirstSeenAt:   now,
-				LastSeenAt:    now,
-				UpdatedAt:     now,
-			})
-			if err != nil {
-				errs = append(errs, err)
-			}
-			continue
+		if err := c.backfillSession(ctx, session, nativeID); err != nil {
+			errs = append(errs, err)
 		}
-		if err := c.RecordHook(ctx, session.ID, HookSignal{
-			Harness:         session.Harness,
-			Event:           "session-start",
-			NativeSessionID: nativeID,
-			TranscriptPath:  path,
-		}); err != nil {
+	}
+	c.notify()
+	return errors.Join(errs...)
+}
+
+func (c *Collector) backfillSession(ctx context.Context, session domain.SessionRecord, nativeID string) error {
+	now := c.now().UTC()
+	existing, exists, err := c.store.GetUsageBinding(ctx, session.ID, session.Harness, nativeID)
+	if err != nil {
+		return err
+	}
+	path := c.discoverPath(session.Harness, nativeID)
+	if exists && (existing.State == domain.UsageBindingComplete || existing.State == domain.UsageBindingPartial) {
+		return nil
+	}
+
+	state := existing.State
+	if !exists {
+		state = domain.UsageBindingActive
+		switch {
+		case session.Activity.State == domain.ActivityExited:
+			state = domain.UsageBindingFinalizing
+		case path == "":
+			state = domain.UsageBindingDiscovering
+		}
+	} else if session.Activity.State == domain.ActivityExited &&
+		(state == domain.UsageBindingDiscovering || state == domain.UsageBindingActive) {
+		state = domain.UsageBindingFinalizing
+	} else if state == domain.UsageBindingDiscovering && path != "" {
+		state = domain.UsageBindingActive
+	}
+	lastErrorCode := ""
+	if path == "" {
+		lastErrorCode = domain.UsageErrorSourceDiscoveryPending
+	}
+	binding, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
+		SessionID:        session.ID,
+		Harness:          session.Harness,
+		NativeRootID:     nativeID,
+		InitialModelID:   existing.InitialModelID,
+		SourceCLIVersion: existing.SourceCLIVersion,
+		State:            state,
+		LastErrorCode:    lastErrorCode,
+		FirstSeenAt:      now,
+		LastSeenAt:       now,
+		UpdatedAt:        now,
+	})
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		return nil
+	}
+
+	kind := domain.UsageSourceClaudeMain
+	if session.Harness == domain.HarnessCodex {
+		kind = domain.UsageSourceCodexRollout
+	}
+	if err := c.registerSource(ctx, binding, kind, nativeID, "", path, "", now, false); err != nil {
+		return err
+	}
+	if session.Harness == domain.HarnessClaudeCode {
+		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
+			return err
+		}
+	}
+	if state == domain.UsageBindingFinalizing {
+		return c.settleFinalizingBinding(ctx, binding.ID, now)
+	}
+	return nil
+}
+
+// ReconcileSources discovers provider artifacts that hooks could not name,
+// appeared after their hook, or moved between provider-owned directories.
+// The caller bounds each pass so discovery cannot monopolize the daemon.
+func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
+	if limit <= 0 {
+		limit = defaultDiscoveryLimit
+	}
+	bindings, err := c.store.ListUsageDiscoveryBindings(ctx, limit)
+	if err != nil {
+		return err
+	}
+	now := c.now().UTC()
+	var errs []error
+	for _, binding := range bindings {
+		if err := c.reconcileBinding(ctx, binding, now); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBindingRecord, now time.Time) error {
+	session, ok, err := c.store.GetSession(ctx, binding.SessionID)
+	if err != nil || !ok {
+		return err
+	}
+	if session.IsTerminated {
+		return nil
+	}
+
+	targetState := binding.State
+	if session.Activity.State == domain.ActivityExited &&
+		(binding.State == domain.UsageBindingDiscovering || binding.State == domain.UsageBindingActive) {
+		targetState = domain.UsageBindingFinalizing
+	}
+
+	path := c.discoverPath(binding.Harness, binding.NativeRootID)
+	if path == "" {
+		_, err = c.store.UpdateUsageBindingState(ctx, binding.ID, targetState, domain.UsageErrorSourceDiscoveryPending, now)
+		return err
+	}
+	if targetState == domain.UsageBindingDiscovering {
+		targetState = domain.UsageBindingActive
+	}
+
+	kind := domain.UsageSourceClaudeMain
+	if binding.Harness == domain.HarnessCodex {
+		kind = domain.UsageSourceCodexRollout
+	}
+	if err := c.registerSource(ctx, binding, kind, binding.NativeRootID, "", path, binding.InitialModelID, now, false); err != nil {
+		return err
+	}
+	if binding.Harness == domain.HarnessClaudeCode {
+		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
+			return err
+		}
+	}
+	lastErrorCode := ""
+	if binding.Harness == domain.HarnessCodex &&
+		binding.LastErrorCode == domain.UsageErrorSourceDiscoveryPending &&
+		targetState == domain.UsageBindingActive &&
+		!pathWithinRoot(path, c.roots.CodexSessions) {
+		lastErrorCode = domain.UsageErrorSourceDiscoveryPending
+	}
+	if _, err := c.store.UpdateUsageBindingState(ctx, binding.ID, targetState, lastErrorCode, now); err != nil {
+		return err
+	}
+	if targetState == domain.UsageBindingFinalizing {
+		return c.settleFinalizingBinding(ctx, binding.ID, now)
+	}
+	return nil
 }
 
 func (c *Collector) registerSource(
@@ -222,6 +408,7 @@ func (c *Collector) registerSource(
 	path string,
 	modelID string,
 	now time.Time,
+	reactivateExisting bool,
 ) error {
 	resolved, identity, size, err := c.validateSourcePath(binding.Harness, path)
 	if err != nil {
@@ -233,6 +420,7 @@ func (c *Collector) registerSource(
 	}
 	var latest *domain.UsageSourceRecord
 	var identityMatch *domain.UsageSourceRecord
+	var latestKind *domain.UsageSourceRecord
 	var generation int64
 	for i := range sources {
 		source := &sources[i]
@@ -242,20 +430,30 @@ func (c *Collector) registerSource(
 		if source.ArtifactPath == resolved && (latest == nil || source.Generation > latest.Generation) {
 			latest = source
 		}
+		if source.Kind == kind && (latestKind == nil || source.Generation > latestKind.Generation ||
+			(source.Generation == latestKind.Generation && source.ID > latestKind.ID)) {
+			latestKind = source
+		}
 		if source.FileIdentity == identity && size >= source.ByteOffset &&
 			(identityMatch == nil || source.Generation > identityMatch.Generation) {
 			identityMatch = source
 		}
 	}
 	if latest != nil && latest.FileIdentity == identity && size >= latest.ByteOffset {
-		_, err := c.store.ReactivateUsageSource(ctx, latest.ID, now)
-		return err
+		if reactivateExisting || latest.State == domain.UsageSourceError {
+			_, err := c.store.ReactivateUsageSource(ctx, latest.ID, now)
+			return err
+		}
+		return nil
 	}
 	if latest != nil {
 		_, _ = c.store.MarkUsageSourceState(ctx, latest.ID, domain.UsageSourceComplete, domain.UsageErrorArtifactReplaced, nil, now)
 		generation = latest.Generation + 1
 	} else if len(sources) > 0 {
 		generation++
+	}
+	if latest == nil && kind == domain.UsageSourceCodexRollout && latestKind != nil {
+		_, _ = c.store.MarkUsageSourceState(ctx, latestKind.ID, domain.UsageSourceComplete, "", nil, now)
 	}
 	capability := CapabilityFor(binding.Harness)
 	record := domain.UsageSourceRecord{
@@ -287,6 +485,73 @@ func (c *Collector) registerSource(
 	return err
 }
 
+func (c *Collector) registerDiscoveredClaudeSubagents(
+	ctx context.Context,
+	binding domain.UsageBindingRecord,
+	mainPath string,
+	now time.Time,
+	reactivateExisting bool,
+) error {
+	var errs []error
+	for _, path := range discoverClaudeSubagentPaths(mainPath) {
+		name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		subagentID := strings.TrimPrefix(name, "agent-")
+		if err := c.registerSource(
+			ctx,
+			binding,
+			domain.UsageSourceClaudeSubagent,
+			binding.NativeRootID,
+			boundedUsageMetadata(subagentID),
+			path,
+			binding.InitialModelID,
+			now,
+			reactivateExisting,
+		); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func discoverClaudeSubagentPaths(mainPath string) []string {
+	base := strings.TrimSuffix(mainPath, filepath.Ext(mainPath))
+	pattern := filepath.Join(base, "subagents", "agent-*.jsonl")
+	paths, _ := filepath.Glob(pattern)
+	if len(paths) > 128 {
+		paths = paths[:128]
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		left, leftErr := os.Stat(paths[i])
+		right, rightErr := os.Stat(paths[j])
+		if leftErr != nil {
+			return false
+		}
+		if rightErr != nil {
+			return true
+		}
+		return left.ModTime().Before(right.ModTime())
+	})
+	return paths
+}
+
+func (c *Collector) settleFinalizingBinding(ctx context.Context, bindingID int64, now time.Time) error {
+	sources, err := c.store.ListUsageSourcesForBinding(ctx, bindingID)
+	if err != nil || len(sources) == 0 {
+		return err
+	}
+	state := domain.UsageBindingComplete
+	for _, source := range sources {
+		if source.State != domain.UsageSourceComplete {
+			return nil
+		}
+		if source.AnomalyCount > 0 || source.LastErrorCode != "" {
+			state = domain.UsageBindingPartial
+		}
+	}
+	_, err = c.store.UpdateUsageBindingState(ctx, bindingID, state, "", now)
+	return err
+}
+
 func (c *Collector) reactivateBinding(ctx context.Context, binding domain.UsageBindingRecord, now time.Time) error {
 	if _, err := c.store.UpdateUsageBindingState(ctx, binding.ID, domain.UsageBindingActive, "", now); err != nil {
 		return err
@@ -295,7 +560,32 @@ func (c *Collector) reactivateBinding(ctx context.Context, binding domain.UsageB
 	if err != nil {
 		return err
 	}
+	var latestMain *domain.UsageSourceRecord
+	for i := range sources {
+		source := &sources[i]
+		if source.Kind != domain.UsageSourceCodexRollout && source.Kind != domain.UsageSourceClaudeMain {
+			continue
+		}
+		if latestMain == nil || source.Generation > latestMain.Generation ||
+			(source.Generation == latestMain.Generation && source.ID > latestMain.ID) {
+			latestMain = source
+		}
+	}
+	if latestMain != nil {
+		_, err = c.store.ReactivateUsageSource(ctx, latestMain.ID, now)
+	}
+	return err
+}
+
+func (c *Collector) reactivateIncompleteSources(ctx context.Context, bindingID int64, now time.Time) error {
+	sources, err := c.store.ListUsageSourcesForBinding(ctx, bindingID)
+	if err != nil {
+		return err
+	}
 	for _, source := range sources {
+		if source.State == domain.UsageSourceComplete {
+			continue
+		}
 		if _, err := c.store.ReactivateUsageSource(ctx, source.ID, now); err != nil {
 			return err
 		}
@@ -312,14 +602,8 @@ func (c *Collector) finalizeSession(ctx context.Context, sessionID domain.Sessio
 		if _, err := c.store.UpdateUsageBindingState(ctx, binding.ID, domain.UsageBindingFinalizing, "", now); err != nil {
 			return err
 		}
-		sources, err := c.store.ListUsageSourcesForBinding(ctx, binding.ID)
-		if err != nil {
+		if err := c.reactivateIncompleteSources(ctx, binding.ID, now); err != nil {
 			return err
-		}
-		for _, source := range sources {
-			if _, err := c.store.ReactivateUsageSource(ctx, source.ID, now); err != nil {
-				return err
-			}
 		}
 	}
 	c.notify()
@@ -376,6 +660,32 @@ func (c *Collector) allowedRoots(harness domain.AgentHarness) []string {
 	default:
 		return nil
 	}
+}
+
+func (c *Collector) codexDiscoveryStillPending(event, hookPath, discoveredPath string) bool {
+	if strings.TrimSpace(hookPath) != "" {
+		return false
+	}
+	if strings.TrimSpace(discoveredPath) == "" {
+		return true
+	}
+	return event == "session-start" && !pathWithinRoot(discoveredPath, c.roots.CodexSessions)
+}
+
+func pathWithinRoot(path, root string) bool {
+	if strings.TrimSpace(path) == "" || strings.TrimSpace(root) == "" {
+		return false
+	}
+	resolvedPath, err := filepath.EvalSymlinks(filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(filepath.Clean(root))
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedPath)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func (c *Collector) discoverPath(harness domain.AgentHarness, nativeID string) string {

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -1,0 +1,463 @@
+package usage
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+const sourceIdentityRecordBytes = 64 << 10
+const (
+	maxUsageMetadataBytes = 256
+	maxUsagePathBytes     = 4096
+)
+
+var nativeUsageIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// HookSignal is the usage-specific metadata carried by an AO agent hook.
+type HookSignal struct {
+	Harness                domain.AgentHarness
+	Event                  string
+	NativeSessionID        string
+	ModelID                string
+	TranscriptPath         string
+	SubagentID             string
+	SubagentTranscriptPath string
+	SourceCLIVersion       string
+}
+
+// SourceRoots are the provider-owned directories from which AO may read usage
+// transcripts.
+type SourceRoots struct {
+	ClaudeProjects string
+	CodexSessions  string
+	CodexArchived  string
+}
+
+// DefaultSourceRoots resolves the native Claude Code and Codex transcript
+// directories for the current user.
+func DefaultSourceRoots() (SourceRoots, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return SourceRoots{}, fmt.Errorf("resolve home directory: %w", err)
+	}
+	codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	if codexHome == "" {
+		codexHome = filepath.Join(home, ".codex")
+	}
+	return SourceRoots{
+		ClaudeProjects: filepath.Join(home, ".claude", "projects"),
+		CodexSessions:  filepath.Join(codexHome, "sessions"),
+		CodexArchived:  filepath.Join(codexHome, "archived_sessions"),
+	}, nil
+}
+
+type collectorStore interface {
+	GetSession(context.Context, domain.SessionID) (domain.SessionRecord, bool, error)
+	ListAllSessions(context.Context) ([]domain.SessionRecord, error)
+	UpsertUsageBinding(context.Context, domain.UsageBindingRecord) (domain.UsageBindingRecord, error)
+	ListUsageBindingsForSession(context.Context, domain.SessionID) ([]domain.UsageBindingRecord, error)
+	UpdateUsageBindingState(context.Context, int64, domain.UsageBindingState, string, time.Time) (bool, error)
+	InsertUsageSource(context.Context, domain.UsageSourceRecord) (domain.UsageSourceRecord, error)
+	ListUsageSourcesForBinding(context.Context, int64) ([]domain.UsageSourceRecord, error)
+	MarkUsageSourceState(context.Context, int64, domain.UsageSourceState, string, *time.Time, time.Time) (bool, error)
+	ReactivateUsageSource(context.Context, int64, time.Time) (bool, error)
+}
+
+// Collector registers provider transcript files and coordinates their source
+// lifecycle. Parsing remains in the observer package.
+type Collector struct {
+	store collectorStore
+	roots SourceRoots
+	wake  func()
+	now   func() time.Time
+}
+
+// NewCollector constructs a transcript source registrar.
+func NewCollector(store collectorStore, roots SourceRoots, wake func()) *Collector {
+	return &Collector{store: store, roots: roots, wake: wake, now: time.Now}
+}
+
+// RecordHook registers transcript metadata and updates collection lifecycle for
+// one native hook callback.
+func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, signal HookSignal) error {
+	session, ok, err := c.store.GetSession(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("usage session %s not found", sessionID)
+	}
+	if !SupportedHarness(session.Harness) {
+		return nil
+	}
+	if signal.Harness != "" && signal.Harness != session.Harness {
+		return fmt.Errorf("usage hook harness %s does not match session harness %s", signal.Harness, session.Harness)
+	}
+	signal.Harness = session.Harness
+	signal.NativeSessionID = boundedUsageMetadata(signal.NativeSessionID)
+	if signal.NativeSessionID == "" {
+		signal.NativeSessionID = boundedUsageMetadata(session.Metadata.AgentSessionID)
+	}
+	if signal.NativeSessionID == "" {
+		signal.NativeSessionID = nativeIDFromTranscript(signal.TranscriptPath)
+	}
+
+	now := c.now().UTC()
+	if signal.Event == "session-end" || signal.Event == "process-exited" {
+		if err := c.finalizeSession(ctx, sessionID, now); err != nil {
+			return err
+		}
+	}
+	if signal.NativeSessionID == "" {
+		c.notify()
+		return nil
+	}
+
+	state := domain.UsageBindingActive
+	if signal.Event == "session-end" || signal.Event == "process-exited" {
+		state = domain.UsageBindingFinalizing
+	}
+	binding, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
+		SessionID:        sessionID,
+		Harness:          session.Harness,
+		NativeRootID:     signal.NativeSessionID,
+		InitialModelID:   boundedUsageMetadata(signal.ModelID),
+		SourceCLIVersion: boundedUsageMetadata(signal.SourceCLIVersion),
+		State:            state,
+		FirstSeenAt:      now,
+		LastSeenAt:       now,
+		UpdatedAt:        now,
+	})
+	if err != nil {
+		return err
+	}
+
+	if path := strings.TrimSpace(signal.TranscriptPath); path != "" {
+		kind := domain.UsageSourceClaudeMain
+		if session.Harness == domain.HarnessCodex {
+			kind = domain.UsageSourceCodexRollout
+		}
+		if err := c.registerSource(ctx, binding, kind, signal.NativeSessionID, "", path, signal.ModelID, now); err != nil {
+			return err
+		}
+	}
+	if path := strings.TrimSpace(signal.SubagentTranscriptPath); path != "" && session.Harness == domain.HarnessClaudeCode {
+		if err := c.registerSource(ctx, binding, domain.UsageSourceClaudeSubagent, signal.NativeSessionID, boundedUsageMetadata(signal.SubagentID), path, signal.ModelID, now); err != nil {
+			return err
+		}
+	}
+	if signal.Event == "session-start" {
+		if err := c.reactivateBinding(ctx, binding, now); err != nil {
+			return err
+		}
+	}
+	c.notify()
+	return nil
+}
+
+// BackfillActive discovers transcript files only for live/resumable AO
+// sessions. It deliberately does not import terminated session history.
+func (c *Collector) BackfillActive(ctx context.Context) error {
+	sessions, err := c.store.ListAllSessions(ctx)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, session := range sessions {
+		if session.IsTerminated || !SupportedHarness(session.Harness) {
+			continue
+		}
+		nativeID := strings.TrimSpace(session.Metadata.AgentSessionID)
+		if nativeID == "" || !nativeUsageIDPattern.MatchString(nativeID) {
+			continue
+		}
+		path := c.discoverPath(session.Harness, nativeID)
+		if path == "" {
+			now := c.now().UTC()
+			_, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
+				SessionID:     session.ID,
+				Harness:       session.Harness,
+				NativeRootID:  nativeID,
+				State:         domain.UsageBindingDiscovering,
+				LastErrorCode: domain.UsageErrorSourceDiscoveryPending,
+				FirstSeenAt:   now,
+				LastSeenAt:    now,
+				UpdatedAt:     now,
+			})
+			if err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+		if err := c.RecordHook(ctx, session.ID, HookSignal{
+			Harness:         session.Harness,
+			Event:           "session-start",
+			NativeSessionID: nativeID,
+			TranscriptPath:  path,
+		}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *Collector) registerSource(
+	ctx context.Context,
+	binding domain.UsageBindingRecord,
+	kind domain.UsageSourceKind,
+	nativeSessionID string,
+	subagentID string,
+	path string,
+	modelID string,
+	now time.Time,
+) error {
+	resolved, identity, size, err := c.validateSourcePath(binding.Harness, path)
+	if err != nil {
+		return err
+	}
+	sources, err := c.store.ListUsageSourcesForBinding(ctx, binding.ID)
+	if err != nil {
+		return err
+	}
+	var latest *domain.UsageSourceRecord
+	var identityMatch *domain.UsageSourceRecord
+	var generation int64
+	for i := range sources {
+		source := &sources[i]
+		if source.Generation >= generation {
+			generation = source.Generation
+		}
+		if source.ArtifactPath == resolved && (latest == nil || source.Generation > latest.Generation) {
+			latest = source
+		}
+		if source.FileIdentity == identity && size >= source.ByteOffset &&
+			(identityMatch == nil || source.Generation > identityMatch.Generation) {
+			identityMatch = source
+		}
+	}
+	if latest != nil && latest.FileIdentity == identity && size >= latest.ByteOffset {
+		_, err := c.store.ReactivateUsageSource(ctx, latest.ID, now)
+		return err
+	}
+	if latest != nil {
+		_, _ = c.store.MarkUsageSourceState(ctx, latest.ID, domain.UsageSourceComplete, domain.UsageErrorArtifactReplaced, nil, now)
+		generation = latest.Generation + 1
+	} else if len(sources) > 0 {
+		generation++
+	}
+	capability := CapabilityFor(binding.Harness)
+	record := domain.UsageSourceRecord{
+		BindingID:       binding.ID,
+		Kind:            kind,
+		NativeSessionID: nativeSessionID,
+		SubagentID:      subagentID,
+		ArtifactPath:    resolved,
+		FileIdentity:    identity,
+		Generation:      generation,
+		CurrentModelID:  boundedUsageMetadata(modelID),
+		ParserVersion:   capability.ParserVersion,
+		State:           domain.UsageSourcePending,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if latest == nil && identityMatch != nil {
+		_, _ = c.store.MarkUsageSourceState(ctx, identityMatch.ID, domain.UsageSourceComplete, "", nil, now)
+		record.ByteOffset = identityMatch.ByteOffset
+		record.BaselineInputTokens = identityMatch.BaselineInputTokens
+		record.BaselineCachedInputTokens = identityMatch.BaselineCachedInputTokens
+		record.BaselineCacheWriteTokens = identityMatch.BaselineCacheWriteTokens
+		record.BaselineOutputTokens = identityMatch.BaselineOutputTokens
+		record.BaselineReasoningTokens = identityMatch.BaselineReasoningTokens
+		record.CurrentModelID = firstString(boundedUsageMetadata(modelID), identityMatch.CurrentModelID)
+		record.CurrentProvider = identityMatch.CurrentProvider
+	}
+	_, err = c.store.InsertUsageSource(ctx, record)
+	return err
+}
+
+func (c *Collector) reactivateBinding(ctx context.Context, binding domain.UsageBindingRecord, now time.Time) error {
+	if _, err := c.store.UpdateUsageBindingState(ctx, binding.ID, domain.UsageBindingActive, "", now); err != nil {
+		return err
+	}
+	sources, err := c.store.ListUsageSourcesForBinding(ctx, binding.ID)
+	if err != nil {
+		return err
+	}
+	for _, source := range sources {
+		if _, err := c.store.ReactivateUsageSource(ctx, source.ID, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Collector) finalizeSession(ctx context.Context, sessionID domain.SessionID, now time.Time) error {
+	bindings, err := c.store.ListUsageBindingsForSession(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	for _, binding := range bindings {
+		if _, err := c.store.UpdateUsageBindingState(ctx, binding.ID, domain.UsageBindingFinalizing, "", now); err != nil {
+			return err
+		}
+		sources, err := c.store.ListUsageSourcesForBinding(ctx, binding.ID)
+		if err != nil {
+			return err
+		}
+		for _, source := range sources {
+			if _, err := c.store.ReactivateUsageSource(ctx, source.ID, now); err != nil {
+				return err
+			}
+		}
+	}
+	c.notify()
+	return nil
+}
+
+func (c *Collector) validateSourcePath(harness domain.AgentHarness, path string) (string, string, int64, error) {
+	if len(path) > maxUsagePathBytes {
+		return "", "", 0, errors.New(domain.UsageErrorArtifactPathRejected)
+	}
+	if !filepath.IsAbs(path) || strings.ToLower(filepath.Ext(path)) != ".jsonl" {
+		return "", "", 0, fmt.Errorf("%s: %w", path, errors.New(domain.UsageErrorArtifactPathRejected))
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(path))
+	if err != nil {
+		return "", "", 0, fmt.Errorf("%s: %w", path, err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", "", 0, fmt.Errorf("%s: %w", path, errors.New(domain.UsageErrorArtifactMissing))
+	}
+	roots := c.allowedRoots(harness)
+	allowed := false
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		resolvedRoot, rootErr := filepath.EvalSymlinks(filepath.Clean(root))
+		if rootErr != nil {
+			continue
+		}
+		rel, relErr := filepath.Rel(resolvedRoot, resolved)
+		if relErr == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return "", "", 0, fmt.Errorf("%s: %w", path, errors.New(domain.UsageErrorArtifactPathRejected))
+	}
+	identity, err := SourceIdentity(resolved)
+	if err != nil {
+		return "", "", 0, err
+	}
+	return resolved, identity, info.Size(), nil
+}
+
+func (c *Collector) allowedRoots(harness domain.AgentHarness) []string {
+	switch harness {
+	case domain.HarnessClaudeCode:
+		return []string{c.roots.ClaudeProjects}
+	case domain.HarnessCodex:
+		return []string{c.roots.CodexSessions, c.roots.CodexArchived}
+	default:
+		return nil
+	}
+}
+
+func (c *Collector) discoverPath(harness domain.AgentHarness, nativeID string) string {
+	var patterns []string
+	switch harness {
+	case domain.HarnessClaudeCode:
+		patterns = []string{filepath.Join(c.roots.ClaudeProjects, "*", nativeID+".jsonl")}
+	case domain.HarnessCodex:
+		patterns = []string{
+			filepath.Join(c.roots.CodexSessions, "*", "*", "*", "*"+nativeID+"*.jsonl"),
+			filepath.Join(c.roots.CodexArchived, "*"+nativeID+"*.jsonl"),
+		}
+	}
+	type candidate struct {
+		path string
+		mod  time.Time
+	}
+	var matches []candidate
+	for _, pattern := range patterns {
+		paths, _ := filepath.Glob(pattern)
+		if len(paths) > 128 {
+			paths = paths[:128]
+		}
+		for _, path := range paths {
+			if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() {
+				matches = append(matches, candidate{path: path, mod: info.ModTime()})
+			}
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].mod.After(matches[j].mod) })
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[0].path
+}
+
+func (c *Collector) notify() {
+	if c.wake != nil {
+		c.wake()
+	}
+}
+
+func nativeIDFromTranscript(path string) string {
+	base := strings.TrimSuffix(filepath.Base(strings.TrimSpace(path)), filepath.Ext(path))
+	if nativeUsageIDPattern.MatchString(base) {
+		return base
+	}
+	return ""
+}
+
+func firstString(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func boundedUsageMetadata(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > maxUsageMetadataBytes {
+		return ""
+	}
+	return value
+}
+
+// SourceIdentity returns a stable identity for an append-only transcript. The
+// provider's first record contains native session metadata and does not change
+// as later records are appended.
+func SourceIdentity(path string) (string, error) {
+	file, err := os.Open(path) //nolint:gosec // validated provider-owned path.
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	reader := bufio.NewReaderSize(file, sourceIdentityRecordBytes)
+	first, err := reader.ReadSlice('\n')
+	if err != nil && !errors.Is(err, bufio.ErrBufferFull) && !errors.Is(err, io.EOF) {
+		if len(first) == 0 {
+			return "", err
+		}
+	}
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(first)), nil
+}

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1,0 +1,174 @@
+package usage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+func TestCollectorRegistersFinalizesAndReactivatesSource(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCodex, "native-1", false)
+	root := filepath.Join(t.TempDir(), "sessions")
+	path := filepath.Join(root, "2026", "07", "27", "rollout-native-1.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{\"type\":\"session_meta\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wakes := 0
+	collector := NewCollector(store, SourceRoots{CodexSessions: root}, func() { wakes++ })
+	now := time.Unix(1700000000, 0).UTC()
+	collector.now = func() time.Time { return now }
+
+	err := collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness:         domain.HarnessCodex,
+		Event:           "session-start",
+		NativeSessionID: "native-1",
+		TranscriptPath:  path,
+		ModelID:         "gpt-5.6",
+	})
+	if err != nil {
+		t.Fatalf("record start: %v", err)
+	}
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+	if bindings[0].State != domain.UsageBindingActive || sources[0].State != domain.UsageSourceActive ||
+		sources[0].CurrentModelID != "gpt-5.6" || wakes == 0 {
+		t.Fatalf("registered binding=%+v source=%+v wakes=%d", bindings[0], sources[0], wakes)
+	}
+
+	if err := collector.RecordHook(context.Background(), session.ID, HookSignal{Event: "process-exited"}); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	bindings, _ = store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if bindings[0].State != domain.UsageBindingFinalizing {
+		t.Fatalf("finalized binding state = %s", bindings[0].State)
+	}
+
+	if _, err := store.MarkUsageSourceState(context.Background(), sources[0].ID, domain.UsageSourceComplete, "", nil, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness:         domain.HarnessCodex,
+		Event:           "session-start",
+		NativeSessionID: "native-1",
+		TranscriptPath:  path,
+	}); err != nil {
+		t.Fatalf("reactivate: %v", err)
+	}
+	sources, _ = store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if sources[0].State != domain.UsageSourceActive {
+		t.Fatalf("reactivated source state = %s", sources[0].State)
+	}
+}
+
+func TestCollectorRejectsPathOutsideProviderRootAndSymlinkEscape(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessClaudeCode, "claude-1", false)
+	base := t.TempDir()
+	root := filepath.Join(base, "projects")
+	outside := filepath.Join(base, "outside.jsonl")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	collector := NewCollector(store, SourceRoots{ClaudeProjects: root}, nil)
+	signal := HookSignal{
+		Harness:         domain.HarnessClaudeCode,
+		Event:           "session-start",
+		NativeSessionID: "claude-1",
+		TranscriptPath:  outside,
+	}
+	if err := collector.RecordHook(context.Background(), session.ID, signal); err == nil {
+		t.Fatal("outside path accepted")
+	}
+
+	link := filepath.Join(root, "escape.jsonl")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	signal.TranscriptPath = link
+	if err := collector.RecordHook(context.Background(), session.ID, signal); err == nil {
+		t.Fatal("symlink escape accepted")
+	}
+}
+
+func TestCollectorBackfillsOnlyNonTerminatedSupportedSessions(t *testing.T) {
+	store := collectorTestStore(t)
+	active := collectorTestSession(t, store, domain.HarnessClaudeCode, "active-native", false)
+	_ = collectorTestSession(t, store, domain.HarnessClaudeCode, "terminated-native", true)
+	_ = collectorTestSession(t, store, domain.HarnessAider, "unsupported-native", false)
+	root := filepath.Join(t.TempDir(), "projects")
+	path := filepath.Join(root, "workspace", "active-native.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	collector := NewCollector(store, SourceRoots{ClaudeProjects: root}, nil)
+	if err := collector.BackfillActive(context.Background()); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), active.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("active bindings=%+v err=%v", bindings, err)
+	}
+	counts, err := store.CountUsageRowsForSession(context.Background(), active.ID)
+	if err != nil || counts.SourceCount != 1 {
+		t.Fatalf("active counts=%+v err=%v", counts, err)
+	}
+}
+
+func collectorTestStore(t *testing.T) *sqlite.Store {
+	t.Helper()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.UpsertProject(context.Background(), domain.ProjectRecord{
+		ID:           "usage-test",
+		Path:         t.TempDir(),
+		RegisteredAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func collectorTestSession(t *testing.T, store *sqlite.Store, harness domain.AgentHarness, nativeID string, terminated bool) domain.SessionRecord {
+	t.Helper()
+	now := time.Now().UTC()
+	session, err := store.CreateSession(context.Background(), domain.SessionRecord{
+		ProjectID:    "usage-test",
+		Kind:         domain.KindWorker,
+		Harness:      harness,
+		Activity:     domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
+		IsTerminated: terminated,
+		Metadata: domain.SessionMetadata{
+			AgentSessionID: nativeID,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return session
+}

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -135,6 +135,333 @@ func TestCollectorBackfillsOnlyNonTerminatedSupportedSessions(t *testing.T) {
 	}
 }
 
+func TestCollectorReconcilesCodexSourceCreatedAfterDaemonStart(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCodex, "native-late", false)
+	root := filepath.Join(t.TempDir(), "sessions")
+	collector := NewCollector(store, SourceRoots{CodexSessions: root}, nil)
+
+	if err := collector.BackfillActive(context.Background()); err != nil {
+		t.Fatalf("initial backfill: %v", err)
+	}
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].State != domain.UsageBindingDiscovering {
+		t.Fatalf("initial bindings=%+v err=%v", bindings, err)
+	}
+
+	path := filepath.Join(root, "2026", "07", "28", "rollout-native-late.jsonl")
+	writeUsageFixture(t, path, `{"type":"session_meta"}`+"\n")
+	if err := collector.ReconcileSources(context.Background(), 8); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	bindings, _ = store.ListUsageBindingsForSession(context.Background(), session.ID)
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bindings[0].State != domain.UsageBindingActive || sources[0].ArtifactPath != resolvedPath {
+		t.Fatalf("binding/source=%+v/%+v", bindings[0], sources[0])
+	}
+}
+
+func TestCollectorDiscoversFinalizingCodexSourceAndArchivedRelocation(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSessionWithActivity(t, store, domain.HarnessCodex, "native-exit", false, domain.ActivityExited)
+	sessionsRoot := filepath.Join(t.TempDir(), "sessions")
+	archiveRoot := filepath.Join(t.TempDir(), "archived_sessions")
+	collector := NewCollector(store, SourceRoots{CodexSessions: sessionsRoot, CodexArchived: archiveRoot}, nil)
+
+	if err := collector.BackfillActive(context.Background()); err != nil {
+		t.Fatalf("backfill finalizing: %v", err)
+	}
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].State != domain.UsageBindingFinalizing {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+
+	activePath := filepath.Join(sessionsRoot, "2026", "07", "28", "rollout-native-exit.jsonl")
+	writeUsageFixture(t, activePath, `{"type":"session_meta"}`+"\n")
+	if err := collector.ReconcileSources(context.Background(), 8); err != nil {
+		t.Fatalf("discover active path: %v", err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 {
+		t.Fatalf("active sources=%+v err=%v", sources, err)
+	}
+
+	archivedPath := filepath.Join(archiveRoot, filepath.Base(activePath))
+	if err := os.MkdirAll(filepath.Dir(archivedPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(activePath, archivedPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := collector.ReconcileSources(context.Background(), 8); err != nil {
+		t.Fatalf("discover archived path: %v", err)
+	}
+	sources, err = store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("relocated sources=%+v err=%v", sources, err)
+	}
+	resolvedArchivedPath, err := filepath.EvalSymlinks(archivedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sources[0].State != domain.UsageSourceComplete || sources[1].ArtifactPath != resolvedArchivedPath ||
+		sources[1].ByteOffset != sources[0].ByteOffset {
+		t.Fatalf("relocated sources=%+v", sources)
+	}
+}
+
+func TestCollectorBackfillPreservesCompletedExitedBinding(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSessionWithActivity(t, store, domain.HarnessCodex, "native-complete", false, domain.ActivityExited)
+	root := filepath.Join(t.TempDir(), "sessions")
+	path := filepath.Join(root, "2026", "07", "28", "rollout-native-complete.jsonl")
+	writeUsageFixture(t, path, `{"type":"session_meta"}`+"\n")
+	now := time.Now().UTC()
+	binding, err := store.UpsertUsageBinding(context.Background(), domain.UsageBindingRecord{
+		SessionID:    session.ID,
+		Harness:      session.Harness,
+		NativeRootID: "native-complete",
+		State:        domain.UsageBindingComplete,
+		FirstSeenAt:  now,
+		LastSeenAt:   now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := SourceIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := store.InsertUsageSource(context.Background(), domain.UsageSourceRecord{
+		BindingID:     binding.ID,
+		Kind:          domain.UsageSourceCodexRollout,
+		ArtifactPath:  path,
+		FileIdentity:  identity,
+		ParserVersion: CodexRolloutParserVersion,
+		State:         domain.UsageSourceComplete,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	collector := NewCollector(store, SourceRoots{CodexSessions: root}, nil)
+	if err := collector.BackfillActive(context.Background()); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	gotBinding, _, err := store.GetUsageBinding(context.Background(), session.ID, session.Harness, "native-complete")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotSource, ok, err := store.GetUsageSourceForIngestion(context.Background(), source.ID)
+	if err != nil || !ok {
+		t.Fatalf("source ok=%v err=%v", ok, err)
+	}
+	if gotBinding.State != domain.UsageBindingComplete || gotSource.Source.State != domain.UsageSourceComplete {
+		t.Fatalf("backfill reopened completed usage: binding=%s source=%s", gotBinding.State, gotSource.Source.State)
+	}
+}
+
+func TestCollectorBackfillDiscoversClaudeSubagentSources(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessClaudeCode, "claude-root", false)
+	root := filepath.Join(t.TempDir(), "projects")
+	mainPath := filepath.Join(root, "workspace", "claude-root.jsonl")
+	subagentPath := filepath.Join(root, "workspace", "claude-root", "subagents", "agent-sub-7.jsonl")
+	writeUsageFixture(t, mainPath, `{"type":"assistant"}`+"\n")
+	writeUsageFixture(t, subagentPath, `{"type":"assistant"}`+"\n")
+
+	collector := NewCollector(store, SourceRoots{ClaudeProjects: root}, nil)
+	if err := collector.BackfillActive(context.Background()); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+	if sources[0].Kind != domain.UsageSourceClaudeMain ||
+		sources[1].Kind != domain.UsageSourceClaudeSubagent ||
+		sources[1].SubagentID != "sub-7" {
+		t.Fatalf("sources=%+v", sources)
+	}
+}
+
+func TestCollectorDiscoveryLimitRotatesPendingBindings(t *testing.T) {
+	store := collectorTestStore(t)
+	first := collectorTestSession(t, store, domain.HarnessCodex, "native-first", false)
+	second := collectorTestSession(t, store, domain.HarnessCodex, "native-second", false)
+	root := filepath.Join(t.TempDir(), "sessions")
+	collector := NewCollector(store, SourceRoots{CodexSessions: root}, nil)
+	now := time.Unix(1700000000, 0).UTC()
+	collector.now = func() time.Time {
+		now = now.Add(time.Second)
+		return now
+	}
+	if err := collector.BackfillActive(context.Background()); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	secondPath := filepath.Join(root, "2026", "07", "28", "rollout-native-second.jsonl")
+	writeUsageFixture(t, secondPath, `{"type":"session_meta"}`+"\n")
+	if err := collector.ReconcileSources(context.Background(), 1); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if err := collector.ReconcileSources(context.Background(), 1); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	firstBindings, _ := store.ListUsageBindingsForSession(context.Background(), first.ID)
+	secondBindings, _ := store.ListUsageBindingsForSession(context.Background(), second.ID)
+	firstSources, _ := store.ListUsageSourcesForBinding(context.Background(), firstBindings[0].ID)
+	secondSources, _ := store.ListUsageSourcesForBinding(context.Background(), secondBindings[0].ID)
+	if len(firstSources) != 0 || len(secondSources) != 1 {
+		t.Fatalf("first/second sources=%+v/%+v", firstSources, secondSources)
+	}
+}
+
+func TestCollectorResumeReactivatesOnlyLatestMainSource(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCodex, "native-resume", false)
+	now := time.Now().UTC()
+	binding, err := store.UpsertUsageBinding(context.Background(), domain.UsageBindingRecord{
+		SessionID:    session.ID,
+		Harness:      session.Harness,
+		NativeRootID: "native-resume",
+		State:        domain.UsageBindingComplete,
+		FirstSeenAt:  now,
+		LastSeenAt:   now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldSource, err := store.InsertUsageSource(context.Background(), domain.UsageSourceRecord{
+		BindingID:     binding.ID,
+		Kind:          domain.UsageSourceCodexRollout,
+		ArtifactPath:  "/tmp/usage-old.jsonl",
+		FileIdentity:  "old",
+		Generation:    0,
+		ParserVersion: CodexRolloutParserVersion,
+		State:         domain.UsageSourceComplete,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	latestSource, err := store.InsertUsageSource(context.Background(), domain.UsageSourceRecord{
+		BindingID:     binding.ID,
+		Kind:          domain.UsageSourceCodexRollout,
+		ArtifactPath:  "/tmp/usage-latest.jsonl",
+		FileIdentity:  "latest",
+		Generation:    1,
+		ParserVersion: CodexRolloutParserVersion,
+		State:         domain.UsageSourceComplete,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	collector := NewCollector(store, SourceRoots{}, nil)
+	if err := collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Event:           "session-start",
+		NativeSessionID: "native-resume",
+	}); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	oldContext, _, _ := store.GetUsageSourceForIngestion(context.Background(), oldSource.ID)
+	latestContext, _, _ := store.GetUsageSourceForIngestion(context.Background(), latestSource.ID)
+	if oldContext.Source.State != domain.UsageSourceComplete || latestContext.Source.State != domain.UsageSourceActive {
+		t.Fatalf("old/latest states=%s/%s", oldContext.Source.State, latestContext.Source.State)
+	}
+}
+
+func TestCollectorResumeKeepsDiscoveringAfterOnlyArchivedRolloutMatches(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCodex, "native-resume-late", false)
+	sessionsRoot := filepath.Join(t.TempDir(), "sessions")
+	archiveRoot := filepath.Join(t.TempDir(), "archived_sessions")
+	archivedPath := filepath.Join(archiveRoot, "rollout-native-resume-late.jsonl")
+	content := `{"type":"session_meta"}` + "\n"
+	writeUsageFixture(t, archivedPath, content)
+	now := time.Now().UTC()
+	binding, err := store.UpsertUsageBinding(context.Background(), domain.UsageBindingRecord{
+		SessionID:    session.ID,
+		Harness:      session.Harness,
+		NativeRootID: "native-resume-late",
+		State:        domain.UsageBindingComplete,
+		FirstSeenAt:  now,
+		LastSeenAt:   now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := SourceIdentity(archivedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedArchivedPath, err := filepath.EvalSymlinks(archivedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archivedSource, err := store.InsertUsageSource(context.Background(), domain.UsageSourceRecord{
+		BindingID:     binding.ID,
+		Kind:          domain.UsageSourceCodexRollout,
+		ArtifactPath:  resolvedArchivedPath,
+		FileIdentity:  identity,
+		ParserVersion: CodexRolloutParserVersion,
+		State:         domain.UsageSourceComplete,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collector := NewCollector(store, SourceRoots{CodexSessions: sessionsRoot, CodexArchived: archiveRoot}, nil)
+	if err := collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Event:           "session-start",
+		NativeSessionID: "native-resume-late",
+	}); err != nil {
+		t.Fatalf("resume start: %v", err)
+	}
+	resumedBinding, _, err := store.GetUsageBinding(context.Background(), session.ID, session.Harness, "native-resume-late")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumedBinding.State != domain.UsageBindingActive ||
+		resumedBinding.LastErrorCode != domain.UsageErrorSourceDiscoveryPending {
+		t.Fatalf("resumed binding=%+v", resumedBinding)
+	}
+
+	activePath := filepath.Join(sessionsRoot, "2026", "07", "28", "rollout-native-resume-late.jsonl")
+	writeUsageFixture(t, activePath, content)
+	if err := collector.ReconcileSources(context.Background(), 8); err != nil {
+		t.Fatalf("reconcile active rollout: %v", err)
+	}
+	resumedBinding, _, _ = store.GetUsageBinding(context.Background(), session.ID, session.Harness, "native-resume-late")
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), binding.ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+	oldContext, _, _ := store.GetUsageSourceForIngestion(context.Background(), archivedSource.ID)
+	if resumedBinding.LastErrorCode != "" || oldContext.Source.State != domain.UsageSourceComplete {
+		t.Fatalf("binding/old source=%+v/%+v", resumedBinding, oldContext.Source)
+	}
+}
+
 func collectorTestStore(t *testing.T) *sqlite.Store {
 	t.Helper()
 	store, err := sqlite.Open(t.TempDir())
@@ -153,13 +480,24 @@ func collectorTestStore(t *testing.T) *sqlite.Store {
 }
 
 func collectorTestSession(t *testing.T, store *sqlite.Store, harness domain.AgentHarness, nativeID string, terminated bool) domain.SessionRecord {
+	return collectorTestSessionWithActivity(t, store, harness, nativeID, terminated, domain.ActivityIdle)
+}
+
+func collectorTestSessionWithActivity(
+	t *testing.T,
+	store *sqlite.Store,
+	harness domain.AgentHarness,
+	nativeID string,
+	terminated bool,
+	activity domain.ActivityState,
+) domain.SessionRecord {
 	t.Helper()
 	now := time.Now().UTC()
 	session, err := store.CreateSession(context.Background(), domain.SessionRecord{
 		ProjectID:    "usage-test",
 		Kind:         domain.KindWorker,
 		Harness:      harness,
-		Activity:     domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
+		Activity:     domain.Activity{State: activity, LastActivityAt: now},
 		IsTerminated: terminated,
 		Metadata: domain.SessionMetadata{
 			AgentSessionID: nativeID,
@@ -171,4 +509,14 @@ func collectorTestSession(t *testing.T, store *sqlite.Store, harness domain.Agen
 		t.Fatal(err)
 	}
 	return session
+}
+
+func writeUsageFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -302,6 +302,8 @@ type UsageSource struct {
 	LastObservedAt            sql.NullTime
 	CreatedAt                 time.Time
 	UpdatedAt                 time.Time
+	CurrentModelID            string
+	CurrentProvider           string
 }
 
 type WorkerIdleEvent struct {

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -543,23 +543,15 @@ func (q *Queries) ListObserverReadyUsageSources(ctx context.Context, arg ListObs
 	return items, nil
 }
 
-const listUnresolvedCodexBindings = `-- name: ListUnresolvedCodexBindings :many
+const listUsageBindingsForSession = `-- name: ListUsageBindingsForSession :many
 SELECT id, session_id, harness, native_root_id, initial_model_id, source_cli_version, state, last_error_code, first_seen_at, last_seen_at, updated_at
 FROM usage_bindings
-WHERE harness = 'codex'
-  AND state IN ('discovering', 'active')
-  AND NOT EXISTS (
-      SELECT 1
-      FROM usage_sources
-      WHERE usage_sources.binding_id = usage_bindings.id
-        AND usage_sources.kind = 'codex_rollout'
-  )
+WHERE session_id = ?
 ORDER BY first_seen_at, id
-LIMIT ?
 `
 
-func (q *Queries) ListUnresolvedCodexBindings(ctx context.Context, limit int64) ([]UsageBinding, error) {
-	rows, err := q.db.QueryContext(ctx, listUnresolvedCodexBindings, limit)
+func (q *Queries) ListUsageBindingsForSession(ctx context.Context, sessionID domain.SessionID) ([]UsageBinding, error) {
+	rows, err := q.db.QueryContext(ctx, listUsageBindingsForSession, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -593,15 +585,39 @@ func (q *Queries) ListUnresolvedCodexBindings(ctx context.Context, limit int64) 
 	return items, nil
 }
 
-const listUsageBindingsForSession = `-- name: ListUsageBindingsForSession :many
-SELECT id, session_id, harness, native_root_id, initial_model_id, source_cli_version, state, last_error_code, first_seen_at, last_seen_at, updated_at
-FROM usage_bindings
-WHERE session_id = ?
-ORDER BY first_seen_at, id
+const listUsageDiscoveryBindings = `-- name: ListUsageDiscoveryBindings :many
+SELECT ub.id, ub.session_id, ub.harness, ub.native_root_id, ub.initial_model_id, ub.source_cli_version, ub.state, ub.last_error_code, ub.first_seen_at, ub.last_seen_at, ub.updated_at
+FROM usage_bindings ub
+JOIN sessions s ON s.id = ub.session_id
+WHERE s.is_terminated = 0
+  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.state IN ('discovering', 'active', 'finalizing')
+  AND (
+      ub.harness = 'claude-code'
+      OR ub.state = 'discovering'
+      OR ub.state = 'finalizing'
+      OR ub.last_error_code = 'source_discovery_pending'
+      OR NOT EXISTS (
+          SELECT 1
+          FROM usage_sources us
+          WHERE us.binding_id = ub.id
+            AND us.kind = 'codex_rollout'
+      )
+      OR EXISTS (
+          SELECT 1
+          FROM usage_sources us
+          WHERE us.binding_id = ub.id
+            AND us.kind = 'codex_rollout'
+            AND us.state = 'error'
+            AND us.last_error_code IN ('artifact_missing', 'source_read_failed')
+      )
+  )
+ORDER BY ub.updated_at, ub.id
+LIMIT ?
 `
 
-func (q *Queries) ListUsageBindingsForSession(ctx context.Context, sessionID domain.SessionID) ([]UsageBinding, error) {
-	rows, err := q.db.QueryContext(ctx, listUsageBindingsForSession, sessionID)
+func (q *Queries) ListUsageDiscoveryBindings(ctx context.Context, limit int64) ([]UsageBinding, error) {
+	rows, err := q.db.QueryContext(ctx, listUsageDiscoveryBindings, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -183,6 +183,8 @@ SELECT
     us.baseline_cache_write_tokens,
     us.baseline_output_tokens,
     us.baseline_reasoning_tokens,
+    us.current_model_id,
+    us.current_provider,
     us.parser_version,
     us.state AS source_state,
     us.failure_count,
@@ -195,7 +197,9 @@ SELECT
     ub.session_id,
     ub.harness,
     ub.native_root_id,
+    ub.initial_model_id,
     ub.source_cli_version,
+    ub.state AS binding_state,
     s.project_id
 FROM usage_sources us
 JOIN usage_bindings ub ON ub.id = us.binding_id
@@ -218,6 +222,8 @@ type GetUsageSourceWithBindingAndSessionRow struct {
 	BaselineCacheWriteTokens  int64
 	BaselineOutputTokens      int64
 	BaselineReasoningTokens   int64
+	CurrentModelID            string
+	CurrentProvider           string
 	ParserVersion             string
 	SourceState               domain.UsageSourceState
 	FailureCount              int64
@@ -230,7 +236,9 @@ type GetUsageSourceWithBindingAndSessionRow struct {
 	SessionID                 domain.SessionID
 	Harness                   domain.AgentHarness
 	NativeRootID              string
+	InitialModelID            string
 	SourceCliVersion          string
+	BindingState              domain.UsageBindingState
 	ProjectID                 domain.ProjectID
 }
 
@@ -252,6 +260,8 @@ func (q *Queries) GetUsageSourceWithBindingAndSession(ctx context.Context, id in
 		&i.BaselineCacheWriteTokens,
 		&i.BaselineOutputTokens,
 		&i.BaselineReasoningTokens,
+		&i.CurrentModelID,
+		&i.CurrentProvider,
 		&i.ParserVersion,
 		&i.SourceState,
 		&i.FailureCount,
@@ -264,7 +274,9 @@ func (q *Queries) GetUsageSourceWithBindingAndSession(ctx context.Context, id in
 		&i.SessionID,
 		&i.Harness,
 		&i.NativeRootID,
+		&i.InitialModelID,
 		&i.SourceCliVersion,
+		&i.BindingState,
 		&i.ProjectID,
 	)
 	return i, err
@@ -352,10 +364,11 @@ INSERT INTO usage_sources (
     binding_id, kind, native_session_id, subagent_id, artifact_path,
     file_identity, generation, byte_offset, baseline_input_tokens,
     baseline_cached_input_tokens, baseline_cache_write_tokens,
-    baseline_output_tokens, baseline_reasoning_tokens, parser_version,
+    baseline_output_tokens, baseline_reasoning_tokens, current_model_id,
+    current_provider, parser_version,
     state, failure_count, anomaly_count, next_retry_at, last_error_code,
     last_observed_at, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (binding_id, artifact_path, generation) DO UPDATE SET
     native_session_id = CASE
         WHEN excluded.native_session_id <> '' THEN excluded.native_session_id
@@ -369,9 +382,17 @@ ON CONFLICT (binding_id, artifact_path, generation) DO UPDATE SET
         WHEN excluded.file_identity <> '' THEN excluded.file_identity
         ELSE usage_sources.file_identity
     END,
+    current_model_id = CASE
+        WHEN excluded.current_model_id <> '' THEN excluded.current_model_id
+        ELSE usage_sources.current_model_id
+    END,
+    current_provider = CASE
+        WHEN excluded.current_provider <> '' THEN excluded.current_provider
+        ELSE usage_sources.current_provider
+    END,
     parser_version = excluded.parser_version,
     updated_at = excluded.updated_at
-RETURNING id, binding_id, kind, native_session_id, subagent_id, artifact_path, file_identity, generation, byte_offset, baseline_input_tokens, baseline_cached_input_tokens, baseline_cache_write_tokens, baseline_output_tokens, baseline_reasoning_tokens, parser_version, state, failure_count, anomaly_count, next_retry_at, last_error_code, last_observed_at, created_at, updated_at
+RETURNING id, binding_id, kind, native_session_id, subagent_id, artifact_path, file_identity, generation, byte_offset, baseline_input_tokens, baseline_cached_input_tokens, baseline_cache_write_tokens, baseline_output_tokens, baseline_reasoning_tokens, parser_version, state, failure_count, anomaly_count, next_retry_at, last_error_code, last_observed_at, created_at, updated_at, current_model_id, current_provider
 `
 
 type InsertUsageSourceParams struct {
@@ -388,6 +409,8 @@ type InsertUsageSourceParams struct {
 	BaselineCacheWriteTokens  int64
 	BaselineOutputTokens      int64
 	BaselineReasoningTokens   int64
+	CurrentModelID            string
+	CurrentProvider           string
 	ParserVersion             string
 	State                     domain.UsageSourceState
 	FailureCount              int64
@@ -414,6 +437,8 @@ func (q *Queries) InsertUsageSource(ctx context.Context, arg InsertUsageSourcePa
 		arg.BaselineCacheWriteTokens,
 		arg.BaselineOutputTokens,
 		arg.BaselineReasoningTokens,
+		arg.CurrentModelID,
+		arg.CurrentProvider,
 		arg.ParserVersion,
 		arg.State,
 		arg.FailureCount,
@@ -449,12 +474,14 @@ func (q *Queries) InsertUsageSource(ctx context.Context, arg InsertUsageSourcePa
 		&i.LastObservedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.CurrentModelID,
+		&i.CurrentProvider,
 	)
 	return i, err
 }
 
 const listObserverReadyUsageSources = `-- name: ListObserverReadyUsageSources :many
-SELECT id, binding_id, kind, native_session_id, subagent_id, artifact_path, file_identity, generation, byte_offset, baseline_input_tokens, baseline_cached_input_tokens, baseline_cache_write_tokens, baseline_output_tokens, baseline_reasoning_tokens, parser_version, state, failure_count, anomaly_count, next_retry_at, last_error_code, last_observed_at, created_at, updated_at
+SELECT id, binding_id, kind, native_session_id, subagent_id, artifact_path, file_identity, generation, byte_offset, baseline_input_tokens, baseline_cached_input_tokens, baseline_cache_write_tokens, baseline_output_tokens, baseline_reasoning_tokens, parser_version, state, failure_count, anomaly_count, next_retry_at, last_error_code, last_observed_at, created_at, updated_at, current_model_id, current_provider
 FROM usage_sources
 WHERE state IN ('pending', 'active', 'error')
   AND (next_retry_at IS NULL OR next_retry_at <= ?)
@@ -500,6 +527,8 @@ func (q *Queries) ListObserverReadyUsageSources(ctx context.Context, arg ListObs
 			&i.LastObservedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.CurrentModelID,
+			&i.CurrentProvider,
 		); err != nil {
 			return nil, err
 		}
@@ -606,6 +635,94 @@ func (q *Queries) ListUsageBindingsForSession(ctx context.Context, sessionID dom
 	return items, nil
 }
 
+const listUsageSourcesForBinding = `-- name: ListUsageSourcesForBinding :many
+SELECT id, binding_id, kind, native_session_id, subagent_id, artifact_path, file_identity, generation, byte_offset, baseline_input_tokens, baseline_cached_input_tokens, baseline_cache_write_tokens, baseline_output_tokens, baseline_reasoning_tokens, parser_version, state, failure_count, anomaly_count, next_retry_at, last_error_code, last_observed_at, created_at, updated_at, current_model_id, current_provider
+FROM usage_sources
+WHERE binding_id = ?
+ORDER BY generation, id
+`
+
+func (q *Queries) ListUsageSourcesForBinding(ctx context.Context, bindingID int64) ([]UsageSource, error) {
+	rows, err := q.db.QueryContext(ctx, listUsageSourcesForBinding, bindingID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UsageSource{}
+	for rows.Next() {
+		var i UsageSource
+		if err := rows.Scan(
+			&i.ID,
+			&i.BindingID,
+			&i.Kind,
+			&i.NativeSessionID,
+			&i.SubagentID,
+			&i.ArtifactPath,
+			&i.FileIdentity,
+			&i.Generation,
+			&i.ByteOffset,
+			&i.BaselineInputTokens,
+			&i.BaselineCachedInputTokens,
+			&i.BaselineCacheWriteTokens,
+			&i.BaselineOutputTokens,
+			&i.BaselineReasoningTokens,
+			&i.ParserVersion,
+			&i.State,
+			&i.FailureCount,
+			&i.AnomalyCount,
+			&i.NextRetryAt,
+			&i.LastErrorCode,
+			&i.LastObservedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.CurrentModelID,
+			&i.CurrentProvider,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const markUsageSourceFailure = `-- name: MarkUsageSourceFailure :execrows
+UPDATE usage_sources SET
+    state = 'error',
+    failure_count = ?,
+    last_error_code = ?,
+    next_retry_at = ?,
+    updated_at = ?
+WHERE id = ?
+`
+
+type MarkUsageSourceFailureParams struct {
+	FailureCount  int64
+	LastErrorCode string
+	NextRetryAt   sql.NullTime
+	UpdatedAt     time.Time
+	ID            int64
+}
+
+func (q *Queries) MarkUsageSourceFailure(ctx context.Context, arg MarkUsageSourceFailureParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markUsageSourceFailure,
+		arg.FailureCount,
+		arg.LastErrorCode,
+		arg.NextRetryAt,
+		arg.UpdatedAt,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const markUsageSourceState = `-- name: MarkUsageSourceState :execrows
 UPDATE usage_sources SET
     state = ?,
@@ -631,6 +748,29 @@ func (q *Queries) MarkUsageSourceState(ctx context.Context, arg MarkUsageSourceS
 		arg.UpdatedAt,
 		arg.ID,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const reactivateUsageSource = `-- name: ReactivateUsageSource :execrows
+UPDATE usage_sources SET
+    state = 'active',
+    failure_count = 0,
+    next_retry_at = NULL,
+    last_error_code = '',
+    updated_at = ?
+WHERE id = ?
+`
+
+type ReactivateUsageSourceParams struct {
+	UpdatedAt time.Time
+	ID        int64
+}
+
+func (q *Queries) ReactivateUsageSource(ctx context.Context, arg ReactivateUsageSourceParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, reactivateUsageSource, arg.UpdatedAt, arg.ID)
 	if err != nil {
 		return 0, err
 	}
@@ -676,6 +816,8 @@ UPDATE usage_sources SET
     baseline_cache_write_tokens = ?,
     baseline_output_tokens = ?,
     baseline_reasoning_tokens = ?,
+    current_model_id = ?,
+    current_provider = ?,
     state = ?,
     failure_count = ?,
     anomaly_count = ?,
@@ -693,6 +835,8 @@ type UpdateUsageSourceCursorParams struct {
 	BaselineCacheWriteTokens  int64
 	BaselineOutputTokens      int64
 	BaselineReasoningTokens   int64
+	CurrentModelID            string
+	CurrentProvider           string
 	State                     domain.UsageSourceState
 	FailureCount              int64
 	AnomalyCount              int64
@@ -711,6 +855,8 @@ func (q *Queries) UpdateUsageSourceCursor(ctx context.Context, arg UpdateUsageSo
 		arg.BaselineCacheWriteTokens,
 		arg.BaselineOutputTokens,
 		arg.BaselineReasoningTokens,
+		arg.CurrentModelID,
+		arg.CurrentProvider,
 		arg.State,
 		arg.FailureCount,
 		arg.AnomalyCount,

--- a/backend/internal/storage/sqlite/migrations/0038_usage_source_parser_context.sql
+++ b/backend/internal/storage/sqlite/migrations/0038_usage_source_parser_context.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE usage_sources ADD COLUMN current_model_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_sources ADD COLUMN current_provider TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE usage_sources DROP COLUMN current_provider;
+ALTER TABLE usage_sources DROP COLUMN current_model_id;

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -78,18 +78,34 @@ WHERE state IN ('pending', 'active', 'error')
 ORDER BY updated_at, id
 LIMIT ?;
 
--- name: ListUnresolvedCodexBindings :many
-SELECT *
-FROM usage_bindings
-WHERE harness = 'codex'
-  AND state IN ('discovering', 'active')
-  AND NOT EXISTS (
-      SELECT 1
-      FROM usage_sources
-      WHERE usage_sources.binding_id = usage_bindings.id
-        AND usage_sources.kind = 'codex_rollout'
+-- name: ListUsageDiscoveryBindings :many
+SELECT ub.*
+FROM usage_bindings ub
+JOIN sessions s ON s.id = ub.session_id
+WHERE s.is_terminated = 0
+  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.state IN ('discovering', 'active', 'finalizing')
+  AND (
+      ub.harness = 'claude-code'
+      OR ub.state = 'discovering'
+      OR ub.state = 'finalizing'
+      OR ub.last_error_code = 'source_discovery_pending'
+      OR NOT EXISTS (
+          SELECT 1
+          FROM usage_sources us
+          WHERE us.binding_id = ub.id
+            AND us.kind = 'codex_rollout'
+      )
+      OR EXISTS (
+          SELECT 1
+          FROM usage_sources us
+          WHERE us.binding_id = ub.id
+            AND us.kind = 'codex_rollout'
+            AND us.state = 'error'
+            AND us.last_error_code IN ('artifact_missing', 'source_read_failed')
+      )
   )
-ORDER BY first_seen_at, id
+ORDER BY ub.updated_at, ub.id
 LIMIT ?;
 
 -- name: GetUsageSourceWithBindingAndSession :one

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -34,10 +34,11 @@ INSERT INTO usage_sources (
     binding_id, kind, native_session_id, subagent_id, artifact_path,
     file_identity, generation, byte_offset, baseline_input_tokens,
     baseline_cached_input_tokens, baseline_cache_write_tokens,
-    baseline_output_tokens, baseline_reasoning_tokens, parser_version,
+    baseline_output_tokens, baseline_reasoning_tokens, current_model_id,
+    current_provider, parser_version,
     state, failure_count, anomaly_count, next_retry_at, last_error_code,
     last_observed_at, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (binding_id, artifact_path, generation) DO UPDATE SET
     native_session_id = CASE
         WHEN excluded.native_session_id <> '' THEN excluded.native_session_id
@@ -51,9 +52,23 @@ ON CONFLICT (binding_id, artifact_path, generation) DO UPDATE SET
         WHEN excluded.file_identity <> '' THEN excluded.file_identity
         ELSE usage_sources.file_identity
     END,
+    current_model_id = CASE
+        WHEN excluded.current_model_id <> '' THEN excluded.current_model_id
+        ELSE usage_sources.current_model_id
+    END,
+    current_provider = CASE
+        WHEN excluded.current_provider <> '' THEN excluded.current_provider
+        ELSE usage_sources.current_provider
+    END,
     parser_version = excluded.parser_version,
     updated_at = excluded.updated_at
 RETURNING *;
+
+-- name: ListUsageSourcesForBinding :many
+SELECT *
+FROM usage_sources
+WHERE binding_id = ?
+ORDER BY generation, id;
 
 -- name: ListObserverReadyUsageSources :many
 SELECT *
@@ -93,6 +108,8 @@ SELECT
     us.baseline_cache_write_tokens,
     us.baseline_output_tokens,
     us.baseline_reasoning_tokens,
+    us.current_model_id,
+    us.current_provider,
     us.parser_version,
     us.state AS source_state,
     us.failure_count,
@@ -105,7 +122,9 @@ SELECT
     ub.session_id,
     ub.harness,
     ub.native_root_id,
+    ub.initial_model_id,
     ub.source_cli_version,
+    ub.state AS binding_state,
     s.project_id
 FROM usage_sources us
 JOIN usage_bindings ub ON ub.id = us.binding_id
@@ -120,6 +139,8 @@ UPDATE usage_sources SET
     baseline_cache_write_tokens = ?,
     baseline_output_tokens = ?,
     baseline_reasoning_tokens = ?,
+    current_model_id = ?,
+    current_provider = ?,
     state = ?,
     failure_count = ?,
     anomaly_count = ?,
@@ -132,6 +153,24 @@ WHERE id = ?;
 -- name: MarkUsageSourceState :execrows
 UPDATE usage_sources SET
     state = ?,
+    last_error_code = ?,
+    next_retry_at = ?,
+    updated_at = ?
+WHERE id = ?;
+
+-- name: ReactivateUsageSource :execrows
+UPDATE usage_sources SET
+    state = 'active',
+    failure_count = 0,
+    next_retry_at = NULL,
+    last_error_code = '',
+    updated_at = ?
+WHERE id = ?;
+
+-- name: MarkUsageSourceFailure :execrows
+UPDATE usage_sources SET
+    state = 'error',
+    failure_count = ?,
     last_error_code = ?,
     next_retry_at = ?,
     updated_at = ?

--- a/backend/internal/storage/sqlite/store/usage_store.go
+++ b/backend/internal/storage/sqlite/store/usage_store.go
@@ -92,6 +92,20 @@ func (s *Store) InsertUsageSource(ctx context.Context, rec domain.UsageSourceRec
 	return usageSourceFromGen(row), nil
 }
 
+// ListUsageSourcesForBinding returns all source generations for one native
+// session binding.
+func (s *Store) ListUsageSourcesForBinding(ctx context.Context, bindingID int64) ([]domain.UsageSourceRecord, error) {
+	rows, err := s.qr.ListUsageSourcesForBinding(ctx, bindingID)
+	if err != nil {
+		return nil, fmt.Errorf("list usage sources for binding %d: %w", bindingID, err)
+	}
+	out := make([]domain.UsageSourceRecord, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, usageSourceFromGen(row))
+	}
+	return out, nil
+}
+
 // ListObserverReadyUsageSources returns sources eligible for observer work.
 func (s *Store) ListObserverReadyUsageSources(ctx context.Context, now time.Time, limit int64) ([]domain.UsageSourceRecord, error) {
 	rows, err := s.qr.ListObserverReadyUsageSources(ctx, gen.ListObserverReadyUsageSourcesParams{
@@ -152,6 +166,39 @@ func (s *Store) MarkUsageSourceState(ctx context.Context, id int64, state domain
 	return n > 0, nil
 }
 
+// ReactivateUsageSource makes a completed or failed source eligible for an
+// immediate resumed-session poll and clears transient retry state.
+func (s *Store) ReactivateUsageSource(ctx context.Context, id int64, updatedAt time.Time) (bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	n, err := s.qw.ReactivateUsageSource(ctx, gen.ReactivateUsageSourceParams{
+		ID:        id,
+		UpdatedAt: timeOrNow(updatedAt),
+	})
+	if err != nil {
+		return false, fmt.Errorf("reactivate usage source %d: %w", id, err)
+	}
+	return n > 0, nil
+}
+
+// MarkUsageSourceFailure records a failed observer attempt and its bounded
+// retry schedule.
+func (s *Store) MarkUsageSourceFailure(ctx context.Context, id, failureCount int64, lastErrorCode string, nextRetryAt, updatedAt time.Time) (bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	n, err := s.qw.MarkUsageSourceFailure(ctx, gen.MarkUsageSourceFailureParams{
+		ID:            id,
+		FailureCount:  failureCount,
+		LastErrorCode: lastErrorCode,
+		NextRetryAt:   sql.NullTime{Time: nextRetryAt.UTC(), Valid: true},
+		UpdatedAt:     timeOrNow(updatedAt),
+	})
+	if err != nil {
+		return false, fmt.Errorf("mark usage source %d failure: %w", id, err)
+	}
+	return n > 0, nil
+}
+
 // ApplyUsageChunk atomically writes parsed usage events and advances the source
 // cursor/baselines. The cursor never moves unless all event writes commit.
 func (s *Store) ApplyUsageChunk(ctx context.Context, sourceID, expectedOffset int64, nextState domain.SourceCursorState, events []domain.ModelUsageEvent) (domain.ApplyUsageChunkResult, error) {
@@ -198,6 +245,8 @@ func (s *Store) ApplyUsageChunk(ctx context.Context, sourceID, expectedOffset in
 			BaselineCacheWriteTokens:  nextState.BaselineCacheWriteTokens,
 			BaselineOutputTokens:      nextState.BaselineOutputTokens,
 			BaselineReasoningTokens:   nextState.BaselineReasoningTokens,
+			CurrentModelID:            nextState.CurrentModelID,
+			CurrentProvider:           nextState.CurrentProvider,
 			State:                     usageSourceStateOrDefault(nextState.State),
 			FailureCount:              nextState.FailureCount,
 			AnomalyCount:              nextState.AnomalyCount,
@@ -279,6 +328,8 @@ func usageSourceFromGen(row gen.UsageSource) domain.UsageSourceRecord {
 		BaselineCacheWriteTokens:  row.BaselineCacheWriteTokens,
 		BaselineOutputTokens:      row.BaselineOutputTokens,
 		BaselineReasoningTokens:   row.BaselineReasoningTokens,
+		CurrentModelID:            row.CurrentModelID,
+		CurrentProvider:           row.CurrentProvider,
 		ParserVersion:             row.ParserVersion,
 		State:                     row.State,
 		FailureCount:              row.FailureCount,
@@ -308,6 +359,8 @@ func usageSourceContextFromGen(row gen.GetUsageSourceWithBindingAndSessionRow) d
 			BaselineCacheWriteTokens:  row.BaselineCacheWriteTokens,
 			BaselineOutputTokens:      row.BaselineOutputTokens,
 			BaselineReasoningTokens:   row.BaselineReasoningTokens,
+			CurrentModelID:            row.CurrentModelID,
+			CurrentProvider:           row.CurrentProvider,
 			ParserVersion:             row.ParserVersion,
 			State:                     row.SourceState,
 			FailureCount:              row.FailureCount,
@@ -322,7 +375,9 @@ func usageSourceContextFromGen(row gen.GetUsageSourceWithBindingAndSessionRow) d
 		ProjectID:        row.ProjectID,
 		Harness:          row.Harness,
 		NativeRootID:     row.NativeRootID,
+		InitialModelID:   row.InitialModelID,
 		SourceCLIVersion: row.SourceCliVersion,
+		BindingState:     row.BindingState,
 	}
 }
 
@@ -341,6 +396,8 @@ func usageSourceInsertParams(rec domain.UsageSourceRecord) gen.InsertUsageSource
 		BaselineCacheWriteTokens:  rec.BaselineCacheWriteTokens,
 		BaselineOutputTokens:      rec.BaselineOutputTokens,
 		BaselineReasoningTokens:   rec.BaselineReasoningTokens,
+		CurrentModelID:            rec.CurrentModelID,
+		CurrentProvider:           rec.CurrentProvider,
 		ParserVersion:             rec.ParserVersion,
 		State:                     usageSourceStateOrDefault(rec.State),
 		FailureCount:              rec.FailureCount,

--- a/backend/internal/storage/sqlite/store/usage_store.go
+++ b/backend/internal/storage/sqlite/store/usage_store.go
@@ -122,12 +122,12 @@ func (s *Store) ListObserverReadyUsageSources(ctx context.Context, now time.Time
 	return out, nil
 }
 
-// ListUnresolvedCodexUsageBindings returns pathless Codex bindings whose
-// rollout files still need discovery.
-func (s *Store) ListUnresolvedCodexUsageBindings(ctx context.Context, limit int64) ([]domain.UsageBindingRecord, error) {
-	rows, err := s.qr.ListUnresolvedCodexBindings(ctx, limit)
+// ListUsageDiscoveryBindings returns live-session bindings that may need a
+// main source, a relocated source, or newly-created subagent sources.
+func (s *Store) ListUsageDiscoveryBindings(ctx context.Context, limit int64) ([]domain.UsageBindingRecord, error) {
+	rows, err := s.qr.ListUsageDiscoveryBindings(ctx, limit)
 	if err != nil {
-		return nil, fmt.Errorf("list unresolved codex usage bindings: %w", err)
+		return nil, fmt.Errorf("list usage discovery bindings: %w", err)
 	}
 	out := make([]domain.UsageBindingRecord, 0, len(rows))
 	for _, row := range rows {

--- a/backend/internal/storage/sqlite/store/usage_store_test.go
+++ b/backend/internal/storage/sqlite/store/usage_store_test.go
@@ -126,6 +126,8 @@ func TestApplyUsageChunkAtomicReplayAndAggregates(t *testing.T) {
 		BaselineCacheWriteTokens:  10,
 		BaselineOutputTokens:      20,
 		BaselineReasoningTokens:   3,
+		CurrentModelID:            "gpt-5.6",
+		CurrentProvider:           "openai",
 		LastObservedAt:            &now,
 		UpdatedAt:                 now,
 	}, []domain.ModelUsageEvent{event})
@@ -144,6 +146,8 @@ func TestApplyUsageChunkAtomicReplayAndAggregates(t *testing.T) {
 		BaselineCacheWriteTokens:  10,
 		BaselineOutputTokens:      20,
 		BaselineReasoningTokens:   3,
+		CurrentModelID:            "gpt-5.6",
+		CurrentProvider:           "openai",
 		LastObservedAt:            &now,
 		UpdatedAt:                 now.Add(time.Second),
 	}, []domain.ModelUsageEvent{event})
@@ -184,7 +188,9 @@ func TestApplyUsageChunkAtomicReplayAndAggregates(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("get source context: ok=%v err=%v", ok, err)
 	}
-	if ctxRow.Source.ByteOffset != 120 || ctxRow.ProjectID != sess.ProjectID || ctxRow.NativeRootID != "root-thread" {
+	if ctxRow.Source.ByteOffset != 120 || ctxRow.ProjectID != sess.ProjectID || ctxRow.NativeRootID != "root-thread" ||
+		ctxRow.Source.CurrentModelID != "gpt-5.6" || ctxRow.Source.CurrentProvider != "openai" ||
+		ctxRow.InitialModelID != "gpt-5" || ctxRow.BindingState != domain.UsageBindingActive {
 		t.Fatalf("source context = %+v", ctxRow)
 	}
 }
@@ -281,6 +287,7 @@ func seedUsageSource(t *testing.T, s *sqlite.Store, sess domain.SessionRecord, n
 		SessionID:        sess.ID,
 		Harness:          sess.Harness,
 		NativeRootID:     "root-thread",
+		InitialModelID:   "gpt-5",
 		SourceCLIVersion: "0.145.0",
 		State:            domain.UsageBindingActive,
 		FirstSeenAt:      now,

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -883,6 +883,15 @@ export interface components {
             data: string;
             mimeType?: string;
         };
+        ControllersUsageHookMetadata: {
+            /** @enum {string} */
+            harness: "claude-code" | "codex";
+            modelId?: string;
+            sourceCliVersion?: string;
+            subagentId?: string;
+            subagentTranscriptPath?: string;
+            transcriptPath?: string;
+        };
         DegradedProject: {
             id: string;
             /** @enum {string} */
@@ -1324,6 +1333,8 @@ export interface components {
             toolName?: string;
             /** @description Native tool-use id, for tool-use hook events. */
             toolUseId?: string;
+            /** @description Provider transcript metadata used by the local usage observer. */
+            usage?: components["schemas"]["ControllersUsageHookMetadata"];
         };
         SetActivityResponse: {
             ok: boolean;


### PR DESCRIPTION
## Summary

- register validated Claude Code and Codex transcript sources from existing AO hooks
- poll sources every 30 seconds with immediate wakeups, durable cursors, bounded retries, and resume/finalization handling
- normalize Claude assistant usage and Codex cumulative token deltas without persisting transcript content
- backfill only active or resumable AO sessions

## Stack

Depends on #2928.

## Validation

- `go test ./internal/service/usage ./internal/observe/usage ./internal/storage/sqlite/store`
- focused CLI hook and HTTP activity tests
- HTTP OpenAPI parity and drift tests
- frontend typecheck
- touched-package golangci-lint
- full Go suite passed except one unrelated kilocode interactive-shell timeout; the failed test passed on immediate isolated rerun