### PR TITLE
fix(claudecode): remove ~/.claude.json trust entry on workspace teardown

### DIFF
--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -213,6 +214,41 @@ func (p *Plugin) PreLaunch(ctx context.Context, cfg ports.LaunchConfig) error {
 		return err
 	}
 	return ensureWorkspaceTrusted(cfgPath, cfg.WorkspacePath)
+}
+
+// CleanupWorkspace removes the durable trust entry AO recorded for a session
+// workspace. It is the symmetric counterpart of PreLaunch: PreLaunch adds
+// projects[cfg.WorkspacePath] to ~/.claude.json so Claude Code's trust
+// dialog does not block the headless spawn, and CleanupWorkspace removes it
+// once the workspace is actually torn down.
+//
+// Without this, every spawned worktree leaves a permanent entry behind and
+// ~/.claude.json accumulates indefinitely. Claude Code's sandbox profile
+// builder derives one deny-path per known project dir from this file, so
+// unbounded growth eventually pushes the profile past ARG_MAX and every
+// subsequent Bash spawn fails with E2BIG.
+//
+// The manager invokes CleanupWorkspace only after the workspace Destroy
+// succeeds — its ErrWorkspaceDirty branch returns early without calling it,
+// so a workspace that still has dirty state on disk is never silently
+// removed from the trust list. A missing config or a missing entry is a
+// no-op, not an error, so a torn-down workspace that was never trusted (or
+// was already cleaned up) does not surface a spurious failure.
+func (p *Plugin) CleanupWorkspace(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WorkspacePath) == "" {
+		return errors.New("claudecode.CleanupWorkspace: WorkspacePath is required")
+	}
+	cfgPath, err := claudeConfigPath()
+	if err != nil {
+		return err
+	}
+	if err := removeWorkspaceTrustEntry(cfgPath, cfg.WorkspacePath); err != nil {
+		return fmt.Errorf("claudecode.CleanupWorkspace: %w", err)
+	}
+	return nil
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Claude Code
@@ -558,6 +594,74 @@ func ensureWorkspaceTrusted(configPath, workspacePath string) error {
 
 	// Atomic write: temp file in the same directory, then rename. Matches
 	// how Claude Code itself updates this file, so concurrent updates are
+	// last-writer-wins rather than corrupting.
+	dir := filepath.Dir(configPath)
+	tmp, err := os.CreateTemp(dir, ".claude.json.tmp-*")
+	if err != nil {
+		return fmt.Errorf("claude-code: create temp config: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once renamed
+
+	if _, err := tmp.Write(out); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("claude-code: write temp config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("claude-code: close temp config: %w", err)
+	}
+	if err := os.Rename(tmpName, configPath); err != nil {
+		return fmt.Errorf("claude-code: replace config: %w", err)
+	}
+	return nil
+}
+
+// removeWorkspaceTrustEntry deletes projects[workspacePath] from the Claude
+// Code config, preserving every other key. It mirrors ensureWorkspaceTrusted's
+// atomic temp-file + rename write so concurrent updates remain last-writer-wins
+// instead of corrupting, and reuses claudeTrustMu so a concurrent trust
+// registration cannot race the removal.
+//
+// A missing config file or missing entry is a no-op: nothing was ever trusted
+// under that path, so there is nothing to remove and we deliberately avoid a
+// rewrite so the file's mtime does not move for work that did no work.
+func removeWorkspaceTrustEntry(configPath, workspacePath string) error {
+	claudeTrustMu.Lock()
+	defer claudeTrustMu.Unlock()
+
+	data, err := os.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		// No config: nothing was ever trusted, nothing to remove.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("claude-code: read %s: %w", configPath, err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+
+	root := map[string]any{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("claude-code: parse %s: %w", configPath, err)
+	}
+
+	projects, _ := root["projects"].(map[string]any)
+	if projects == nil {
+		return nil
+	}
+	if _, present := projects[workspacePath]; !present {
+		// Never registered: no write, no rename, no race window.
+		return nil
+	}
+	delete(projects, workspacePath)
+
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fmt.Errorf("claude-code: encode %s: %w", configPath, err)
+	}
+
+	// Atomic write mirrors ensureWorkspaceTrusted so concurrent updates are
 	// last-writer-wins rather than corrupting.
 	dir := filepath.Dir(configPath)
 	tmp, err := os.CreateTemp(dir, ".claude.json.tmp-*")

--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -623,8 +623,8 @@ func ensureWorkspaceTrusted(configPath, workspacePath string) error {
 // registration cannot race the removal.
 //
 // A missing config file or missing entry is a no-op: nothing was ever trusted
-// under that path, so there is nothing to remove and we deliberately avoid a
-// rewrite so the file's mtime does not move for work that did no work.
+// under that path, so there is nothing to remove. The no-op is implemented
+// without a rewrite so a no-op cleanup does not touch the file's mtime.
 func removeWorkspaceTrustEntry(configPath, workspacePath string) error {
 	claudeTrustMu.Lock()
 	defer claudeTrustMu.Unlock()

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -3,9 +3,12 @@ package claudecode
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -760,4 +763,189 @@ func containsSubsequence(values, needle []string) bool {
 		}
 	}
 	return false
+}
+
+func TestRemoveWorkspaceTrustEntryRemovesTrackedEntry(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".claude.json")
+	// Seed an existing config with an unrelated project, a top-level key, and
+	// the entry we expect to remove -- proves the cleanup preserves everything
+	// else.
+	seed := `{"userID":"abc","projects":{"/existing/proj":{"hasTrustDialogAccepted":true,"lastCost":1.5},"/w":{"hasTrustDialogAccepted":true,"history":[]}}}`
+	if err := os.WriteFile(cfgPath, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeWorkspaceTrustEntry(cfgPath, "/w"); err != nil {
+		t.Fatalf("removeWorkspaceTrustEntry: %v", err)
+	}
+
+	root := readJSON(t, cfgPath)
+	projects := root["projects"].(map[string]any)
+
+	// The tracked entry is gone.
+	if _, present := projects["/w"]; present {
+		t.Fatalf("expected /w entry removed; projects = %#v", projects)
+	}
+	// Unrelated project preserved with its other fields.
+	existing := projects["/existing/proj"].(map[string]any)
+	if existing["hasTrustDialogAccepted"] != true || existing["lastCost"].(float64) != 1.5 {
+		t.Fatalf("unrelated project clobbered: %#v", existing)
+	}
+	// Top-level key preserved.
+	if root["userID"] != "abc" {
+		t.Fatalf("top-level key clobbered: %#v", root["userID"])
+	}
+}
+
+func TestRemoveWorkspaceTrustEntryAbsentEntryIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(cfgPath, []byte(`{"projects":{"/existing":{"hasTrustDialogAccepted":true}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info1, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cleanup for an entry that was never registered.
+	if err := removeWorkspaceTrustEntry(cfgPath, "/never-tracked"); err != nil {
+		t.Fatalf("removeWorkspaceTrustEntry: %v", err)
+	}
+
+	// No-op confirmed by unchanged mtime (no atomic-rename rewrite).
+	info2, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info1.ModTime().Equal(info2.ModTime()) {
+		t.Fatal("expected no rewrite when entry absent")
+	}
+	root := readJSON(t, cfgPath)
+	projects := root["projects"].(map[string]any)
+	if _, present := projects["/existing"]; !present {
+		t.Fatalf("unrelated entry removed: %#v", projects)
+	}
+}
+
+func TestRemoveWorkspaceTrustEntryMissingConfigIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".claude.json") // does not exist
+
+	// Cleanup against a never-written config: nothing to remove, no error.
+	if err := removeWorkspaceTrustEntry(cfgPath, "/w"); err != nil {
+		t.Fatalf("removeWorkspaceTrustEntry: %v", err)
+	}
+
+	// The missing config stays missing -- we deliberately do not create it
+	// just to write an empty projects map.
+	if _, err := os.Stat(cfgPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no config file created; stat = %v", err)
+	}
+}
+
+func TestRemoveWorkspaceTrustEntryEmptyConfigIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(cfgPath, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info1, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeWorkspaceTrustEntry(cfgPath, "/w"); err != nil {
+		t.Fatalf("removeWorkspaceTrustEntry: %v", err)
+	}
+
+	info2, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info1.ModTime().Equal(info2.ModTime()) {
+		t.Fatal("expected no rewrite on empty config")
+	}
+}
+
+func TestRemoveWorkspaceTrustEntryConcurrencySafety(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".claude.json")
+	work := "/w"
+
+	// Seed: register the workspace, then race many cleanup callers against it.
+	if err := ensureWorkspaceTrusted(cfgPath, work); err != nil {
+		t.Fatal(err)
+	}
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if err := removeWorkspaceTrustEntry(cfgPath, work); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent removeWorkspaceTrustEntry error: %v", err)
+	}
+
+	// The file must remain valid JSON after the race and the entry must be
+	// gone: a torn write would either fail to parse or leave the entry behind.
+	root := readJSON(t, cfgPath)
+	projects, ok := root["projects"].(map[string]any)
+	if !ok {
+		t.Fatalf("projects not a map after concurrent cleanup: %#v", root["projects"])
+	}
+	if _, present := projects[work]; present {
+		t.Fatalf("entry not removed under concurrency: %#v", projects)
+	}
+}
+
+// TestSpawnCleanupCycleIsBalanced is the adversarial proof that a full
+// trust-register/cleanup cycle does not leak entries into ~/.claude.json's
+// projects map: after each cycle the projects map size returns to its
+// pre-cycle size, not just stays bounded. A bounded-but-growing map would
+// still be detected by the live daemon's E2BIG failure mode.
+func TestSpawnCleanupCycleIsBalanced(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".claude.json")
+	pre := map[string]bool{"/keep/me": true}
+	seed := `{"projects":{"/keep/me":{"hasTrustDialogAccepted":true}}}`
+	if err := os.WriteFile(cfgPath, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	const cycles = 25
+	for i := 0; i < cycles; i++ {
+		work := filepath.Join("/cycle", filepath.Base(dir), "iter-"+itoa(i))
+		if err := ensureWorkspaceTrusted(cfgPath, work); err != nil {
+			t.Fatalf("iter %d trust: %v", i, err)
+		}
+		if err := removeWorkspaceTrustEntry(cfgPath, work); err != nil {
+			t.Fatalf("iter %d cleanup: %v", i, err)
+		}
+
+		root := readJSON(t, cfgPath)
+		projects := root["projects"].(map[string]any)
+		for key := range projects {
+			if !pre[key] {
+				t.Fatalf("iter %d: leaked entry %q in projects map; got %#v", i, key, projects)
+			}
+		}
+		if len(projects) != len(pre) {
+			t.Fatalf("iter %d: projects size = %d, want %d; got %#v", i, len(projects), len(pre), projects)
+		}
+	}
+}
+
+func itoa(i int) string {
+	return strconv.Itoa(i)
 }

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -909,12 +909,13 @@ func TestRemoveWorkspaceTrustEntryConcurrencySafety(t *testing.T) {
 	}
 }
 
-// TestSpawnCleanupCycleIsBalanced is the adversarial proof that a full
-// trust-register/cleanup cycle does not leak entries into ~/.claude.json's
-// projects map: after each cycle the projects map size returns to its
-// pre-cycle size, not just stays bounded. A bounded-but-growing map would
-// still be detected by the live daemon's E2BIG failure mode.
-func TestSpawnCleanupCycleIsBalanced(t *testing.T) {
+// TestTrustEntryRegisterCleanupCycleIsBalanced is the adversarial proof that
+// a full trust-register/cleanup cycle does not leak entries into
+// ~/.claude.json's projects map: after each cycle the projects map size
+// returns to its pre-cycle size, not just stays bounded. A
+// bounded-but-growing map would still be detected by the live daemon's E2BIG
+// failure mode.
+func TestTrustEntryRegisterCleanupCycleIsBalanced(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, ".claude.json")
 	pre := map[string]bool{"/keep/me": true}
@@ -925,7 +926,7 @@ func TestSpawnCleanupCycleIsBalanced(t *testing.T) {
 
 	const cycles = 25
 	for i := 0; i < cycles; i++ {
-		work := filepath.Join("/cycle", filepath.Base(dir), "iter-"+itoa(i))
+		work := filepath.Join("/cycle", filepath.Base(dir), "iter-"+strconv.Itoa(i))
 		if err := ensureWorkspaceTrusted(cfgPath, work); err != nil {
 			t.Fatalf("iter %d trust: %v", i, err)
 		}
@@ -944,8 +945,4 @@ func TestSpawnCleanupCycleIsBalanced(t *testing.T) {
 			t.Fatalf("iter %d: projects size = %d, want %d; got %#v", i, len(projects), len(pre), projects)
 		}
 	}
-}
-
-func itoa(i int) string {
-	return strconv.Itoa(i)
 }


### PR DESCRIPTION
## What

Adds `CleanupWorkspace` on the claudecode adapter so each spawned worktree's trust entry is removed from `~/.claude.json` when the workspace is actually torn down. The matching add (PreLaunch) was already wired; the symmetric removal was missing.

## Why

Claude Code's PreLaunch records `projects[workspacePath].hasTrustDialogAccepted = true` in `~/.claude.json` so its first-run "trust this folder" dialog does not block the headless spawn. Nothing was removing those entries on teardown.

On a long-running daemon the `projects` map grew without bound (measured: 1,256 entries, of which 1,186 -- 94% -- pointed at directories that no longer existed). `~/.claude.json` therefore grows without bound for the lifetime of the install, and AO is the writer that creates the entries on each spawn, so AO should remove them on teardown. Unbounded growth of a config file the tool writes per session is the bug on its own terms; this PR makes the cleanup symmetric with the registration so the file size stays bounded by the number of currently-live workspaces rather than the total ever-spawned.

A search of the issue tracker did not surface a prior report for this accumulation. The closest existing reports discuss the *missing*-entry side of the same dialog (entries never registered, so the dialog blocks the first spawn). This PR addresses the symmetric, opposite failure: entries registered correctly, never removed. Happy to file a tracking issue first if maintainers prefer.

## How

Mirrors the cursor adapter's existing cleanup template (`backend/internal/adapters/agent/cursor/hooks.go:153-164` and `removeCursorWorkspaceTrust`):

- `Plugin.CleanupWorkspace(ctx, ports.WorkspaceHookConfig) error` -- public entry point, derives the config path via `claudeConfigPath()` and delegates to the helper.
- `removeWorkspaceTrustEntry(cfgPath, workspacePath)` -- reads the config, deletes `projects[workspacePath]`, writes back via the same `os.CreateTemp` + `os.Rename` atomic pattern `ensureWorkspaceTrusted` already uses (`backend/internal/adapters/agent/claudecode/claudecode.go:517-581`), reusing `claudeTrustMu` so a concurrent PreLaunch on another workspace cannot race the removal.
- Missing config file or missing entry is a no-op (no rewrite, mtime preserved) rather than an error, so a torn-down workspace that was never trusted does not surface a spurious failure.

**Why the entry is removed whole, not just the trust flag.** AO is the only writer of the entry -- `ensureWorkspaceTrusted` created it -- so leaving an empty `{hasTrustDialogAccepted: true}` shell behind would still consume a deny-path slot in the sandbox profile and defeat the point of the cleanup.

**Path normalization: not needed on this side, by construction.** The trust entry is keyed by the raw `cfg.WorkspacePath` string in both `ensureWorkspaceTrusted` (PreLaunch) and `removeWorkspaceTrustEntry` (CleanupWorkspace), with no `filepath.Abs` or `filepath.Clean`. The cursor adapter normalizes via `filepath.Abs` on both sides (`cursor/hooks.go:220, 294`) because it derives a *filename* from the path (sanitized into a per-project subdir), so the absolute path is needed for the matching side too. The claudecode adapter stores the path as a map key, used identically on both sides, so normalization would only matter if the same logical workspace could arrive spelled differently on the two paths. It cannot: both call sites hand the SAME `ws.Path` field through `Manager.prepareWorkspace` (`session_manager/manager.go:384, :1043`) and `Manager.cleanupAgentWorkspace` (`session_manager/manager.go:2640-2667`), so the add and remove paths are guaranteed to see the identical string.

## Intentional omissions

**No adapter-level test for the still-present-workspace case.** The guarantee does not live in `removeWorkspaceTrustEntry` -- the helper operates on the JSON file directly and does not consult the filesystem. It lives in `Manager.Kill` (`session_manager/manager.go:770-802`), which calls `cleanupAgentWorkspace` only on the success branches (the `cleaned` and `freed=true` arms). The `ErrWorkspaceDirty` branch (line 788-797 for standalone worktrees, 773-779 for workspace projects) returns `false, nil` early without reaching `cleanupAgentWorkspace`, so a workspace that still has dirty state on disk is never silently removed from the trust list. That wiring is unchanged in this PR and is already exercised by the 191 passing `session_manager` tests. Adding a second adapter-level test for a guarantee enforced by a different layer would duplicate coverage and risk drifting from the real dispatch path.

## Testing

```
cd backend && go build ./... && go test ./internal/adapters/agent/claudecode/... && go test ./internal/session_manager/... && go vet ./...
```

- `go build ./...` -- Success
- `go vet ./...` -- No issues found
- `go test ./internal/adapters/agent/claudecode/...` -- 69 passed (includes 6 new tests)
- `go test ./internal/session_manager/...` -- 191 passed (existing dispatch unchanged; the `workspaceCleaner` call site is wired into the pre-existing `cleanupAgentWorkspace`, not added fresh)

**New tests** (in `backend/internal/adapters/agent/claudecode/claudecode_test.go`, mirroring the existing `ensureWorkspaceTrusted*` fixture shape):

| Test | Asserts |
| --- | --- |
| `TestRemoveWorkspaceTrustEntryRemovesTrackedEntry` | entry removed; unrelated projects + top-level keys preserved |
| `TestRemoveWorkspaceTrustEntryAbsentEntryIsNoOp` | absent entry -> no error, mtime unchanged (no rewrite) |
| `TestRemoveWorkspaceTrustEntryMissingConfigIsNoOp` | missing `~/.claude.json` -> no error, file stays missing |
| `TestRemoveWorkspaceTrustEntryEmptyConfigIsNoOp` | empty file -> no error, mtime unchanged |
| `TestRemoveWorkspaceTrustEntryConcurrencySafety` | 32 concurrent cleanups of one entry leave a valid JSON file with the entry gone |
| `TestTrustEntryRegisterCleanupCycleIsBalanced` | **adversarial**: 25 full `ensureWorkspaceTrusted` -> `removeWorkspaceTrustEntry` cycles using the production helpers (not a hand-seeded map); asserts the projects map returns to its pre-cycle size and member set every iteration -- bounded-but-growing would still leak entries forever, so the assertion is exact-set-equality, not just size floor |

**Dirty-refusal verification.** `Manager.Kill` (`session_manager/manager.go:770-802`) calls `cleanupAgentWorkspace` only on the success branches (the `cleaned` and `freed=true` arms). The `ErrWorkspaceDirty` branch (line 773-779 for workspace projects, line 788-797 for standalone worktrees) returns `false, nil` without calling cleanup. Adapter-side, `removeWorkspaceTrustEntry` operates on the config file directly and does not consult the filesystem, so a still-present workspace directory does not change its behavior -- but the manager-level guarantee means the function is never even called for a dirty workspace.

## Checklist

- [x] Branched from `main` (sibling under session namespace)
- [x] One focused change
- [x] Follows `AGENTS.md` conventions and PR hygiene (conventional commit, narrow tests first)
- [x] Tests added for user-visible behavior
- [x] Relevant CI checks pass for the area touched (`go build`, `go vet`, `go test ./internal/adapters/agent/claudecode/...`, `go test ./internal/session_manager/...`)

Co-Authored-By: Claude <noreply@anthropic.com>