### PR TITLE
feat(landing): hero polish, download fixes, and marquee cleanup

### DIFF
--- a/frontend/src/landing/packages/shared/src/constants.ts
+++ b/frontend/src/landing/packages/shared/src/constants.ts
@@ -39,7 +39,7 @@ export const DOWNLOAD_URL_WINDOWS = "https://github.com/AgentWrapper/agent-orche
 export const DOWNLOAD_URL_LINUX = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.AppImage";
 
 export const AGENT_HARNESSES = 23;
-export const TAGLINE = "Turn agent chaos into managable work.";
+export const TAGLINE = "Stop babysitting agents. Start merging real work.";
 export const HERO_SUBHEADLINE = "Run a fleet of coding agents while keeping branches, reviews, and CI failures managable.";
 export const HERO_SECONDARY_SUBHEADLINE = "Isolated workspaces for Claude Code, Codex, and any CLI agent. Review every change from one dashboard. Free and open source.";
 

--- a/frontend/src/landing/src/app/components/DownloadButton/DownloadButton.tsx
+++ b/frontend/src/landing/src/app/components/DownloadButton/DownloadButton.tsx
@@ -65,6 +65,25 @@ function getDownloadPlatform(platform: Platform): DownloadPlatform {
   return "apple";
 }
 
+function MonitorIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+      className="size-4 shrink-0"
+      aria-hidden="true"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <path d="M8 21h8M12 17v4" />
+    </svg>
+  );
+}
+
 function PlatformIcon({ platform }: { platform: DownloadPlatform }) {
   if (platform === "windows") return <WindowsIcon />;
   if (platform === "linux") return <LinuxIcon />;
@@ -84,11 +103,18 @@ export function DownloadButton({
 }: DownloadButtonProps) {
   const { platform } = usePlatform();
   const downloadPlatform = getDownloadPlatform(platform);
+  // AO is a desktop app, so a phone can't run any build — point mobile visitors
+  // at the desktop download with a label that sets that expectation.
+  const isMobile = platform === Platform.Mobile;
   const sizeClasses =
     size === "sm"
       ? "h-8 px-3 text-sm"
       : "px-3 sm:px-6 py-2 sm:py-3 text-sm sm:text-base";
-  const label = getLabel(size, downloadPlatform);
+  const label = isMobile
+    ? size === "sm"
+      ? "Get for desktop"
+      : "Get AO for desktop"
+    : getLabel(size, downloadPlatform);
 
   const buttonClasses = `bg-foreground text-background ${sizeClasses} rounded-2xl tracking-[-0.5px] font-semibold hover:opacity-90 transition-opacity flex items-center gap-2 whitespace-nowrap shrink-0 ${className}`;
 
@@ -98,7 +124,7 @@ export function DownloadButton({
       className={buttonClasses}
       onClick={() => track("download_clicked")}
     >
-      <PlatformIcon platform={downloadPlatform} />
+      {isMobile ? <MonitorIcon /> : <PlatformIcon platform={downloadPlatform} />}
       {label}
     </Link>
   );

--- a/frontend/src/landing/src/app/components/FeaturesSection/constants.ts
+++ b/frontend/src/landing/src/app/components/FeaturesSection/constants.ts
@@ -38,7 +38,7 @@ export const FEATURES: Feature[] = [
     tag: "Mobile companion",
     title: "Your fleet goes where you go",
     description:
-      "Pair the AO mobile app with your desktop over LAN or Tailscale. Watch every session, open a terminal, and get notified when an agent needs you—while execution and code stay on your machine.",
+      "Pair the AO mobile app with your desktop over LAN or Tailscale. Watch every session, open a terminal, and get notified when an agent needs you - while execution and code stay on your machine.",
     colors: ["#2563eb", "#1d4ed8", "#1e3a8a", "#1a1a2e"],
   },
 ];

--- a/frontend/src/landing/src/app/components/HeroSection/HeroSection.tsx
+++ b/frontend/src/landing/src/app/components/HeroSection/HeroSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { COMPANY, HERO_SUBHEADLINE, TAGLINE } from "@ao/shared/constants";
+import { Star } from "lucide-react";
 import { useState } from "react";
 import { FaGithub } from "react-icons/fa";
 import { isMacPlatform, usePlatform } from "../../hooks/useOS";
@@ -60,15 +61,27 @@ export function HeroSection({ initialStars }: HeroSectionProps) {
 
             <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4 mt-6 sm:mt-8">
               <DownloadButton className="rounded-3xl" />
-              <button
-                type="button"
-                className="px-4 py-2.5 sm:px-6 sm:py-3 rounded-3xl text-sm sm:text-base tracking-[-0.5px] font-normal bg-background border border-border text-foreground hover:bg-muted transition-colors flex items-center gap-2"
-                onClick={() => window.open(COMPANY.GITHUB_URL, "_blank")}
+              <a
+                href={COMPANY.GITHUB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
                 aria-label={githubButtonLabel}
+                className="inline-flex items-center gap-2.5 rounded-3xl border border-border bg-background px-5 py-2.5 sm:py-3 text-sm sm:text-base font-normal tracking-[-0.5px] text-foreground transition-colors hover:bg-muted"
               >
-                {githubButtonLabel}
-                <FaGithub className="size-4" />
-              </button>
+                <FaGithub className="size-4" aria-hidden="true" />
+                <span>Star on GitHub</span>
+                {initialStars !== null ? (
+                  <span className="flex items-center gap-1 pl-0.5 text-muted-foreground">
+                    <Star
+                      className="size-3.5 fill-yellow-400 text-yellow-400"
+                      aria-hidden="true"
+                    />
+                    <span className="tabular-nums">
+                      {formatStarCount(initialStars)}
+                    </span>
+                  </span>
+                ) : null}
+              </a>
             </div>
 
             {showInstallCommand ? (

--- a/frontend/src/landing/src/app/components/TrustedBySection/TrustedBySection.tsx
+++ b/frontend/src/landing/src/app/components/TrustedBySection/TrustedBySection.tsx
@@ -1,8 +1,3 @@
-"use client";
-
-import { Pause, Play } from "lucide-react";
-import { useState } from "react";
-
 type Agent = { name: string; src: string };
 
 // All 23 supported agents, each with its brand logo. Most come from the app's
@@ -67,8 +62,6 @@ function AgentGroup({ duplicate = false }: { duplicate?: boolean }) {
 }
 
 export function TrustedBySection() {
-  const [paused, setPaused] = useState(false);
-
   return (
     <section className="py-16 sm:py-24 bg-background overflow-hidden">
       <div className="max-w-7xl mx-auto text-center">
@@ -76,33 +69,13 @@ export function TrustedBySection() {
           Use the agents you already trust.
         </h2>
 
-        {/* Animated marquee: ~10 logos visible as they flow. Hidden for
-            reduced-motion users, who get the full static list below. */}
-        <div
-          className="agent-marquee group relative mx-auto w-full max-w-2xl overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]"
-          data-paused={paused}
-        >
+        {/* Animated marquee: ~10 logos visible as they flow. Pauses on hover;
+            reduced-motion users get the full static list below. */}
+        <div className="agent-marquee group relative mx-auto w-full max-w-2xl overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]">
           <div className="agent-marquee__track flex w-max">
             <AgentGroup />
             <AgentGroup duplicate />
           </div>
-        </div>
-
-        {/* Operable pause/play control (WCAG 2.2.2) — keyboard and touch
-            reachable, not just hover. Hidden under reduced motion. */}
-        <div className="agent-marquee-control mt-5 flex justify-center">
-          <button
-            type="button"
-            onClick={() => setPaused((p) => !p)}
-            className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-xs text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
-          >
-            {paused ? (
-              <Play className="size-3" aria-hidden="true" />
-            ) : (
-              <Pause className="size-3" aria-hidden="true" />
-            )}
-            {paused ? "Play agent logos" : "Pause agent logos"}
-          </button>
         </div>
 
         {/* Reduced-motion fallback: every agent, wrapping, fully visible. */}
@@ -124,13 +97,11 @@ export function TrustedBySection() {
           animation: agent-marquee-scroll 45s linear infinite;
           will-change: transform;
         }
-        .agent-marquee:hover .agent-marquee__track,
-        .agent-marquee[data-paused="true"] .agent-marquee__track {
+        .agent-marquee:hover .agent-marquee__track {
           animation-play-state: paused;
         }
         @media (prefers-reduced-motion: reduce) {
-          .agent-marquee,
-          .agent-marquee-control { display: none; }
+          .agent-marquee { display: none; }
           .agent-static { display: flex; }
         }
       `}</style>

--- a/frontend/src/landing/src/lib/analytics/index.ts
+++ b/frontend/src/landing/src/lib/analytics/index.ts
@@ -16,7 +16,15 @@ export function track(
 	event: string,
 	properties?: Record<string, unknown>,
 ): void {
-	posthog.capture(event, properties);
+	// Best-effort: a throw from analytics must never escape into the caller.
+	// Several callers navigate right after (e.g. the download click handler), and
+	// PostHog's capture throws when called before init — which happens whenever
+	// NEXT_PUBLIC_POSTHOG_KEY is unset (local dev) — aborting that navigation.
+	try {
+		posthog.capture(event, properties);
+	} catch (error) {
+		console.warn("PostHog capture failed", error);
+	}
 
 	const redditEvent = REDDIT_EVENT_MAP[event];
 	if (redditEvent) {


### PR DESCRIPTION
A batch of landing tweaks.

## Hero
- New tagline: **"Stop babysitting agents. Start merging real work."** (text only; hero styling unchanged).
- Reworks the GitHub button into a single clean pill — GitHub icon + "Star on GitHub" + a subtle yellow star with the tabular star count — and switches from `button + window.open` to a real `<a href>` for proper link semantics.

<img width="1412" height="477" alt="image" src="https://github.com/user-attachments/assets/d4e4ccc5-3848-4cfb-af08-b51bab7586b5" />


## Download button
- **Bug fix:** clicking Download did nothing in local dev. `track("download_clicked")` ran `posthog.capture()` unguarded, which throws when PostHog isn't initialized (no `NEXT_PUBLIC_POSTHOG_KEY`) — and that throw, inside the Next `<Link>`'s onClick, aborted the navigation. Now wrapped so analytics can never break the click (mirrors the existing Reddit-pixel guard). Also fixes the same latent issue for every other `track()` caller that navigates.
- **Mobile:** the button fell through to "Download for Mac" (Apple icon) on phones. AO is a desktop app, so mobile now shows **"Get AO for desktop"** with a monitor icon, still linking to `/download`.

<img width="768" height="1026" alt="image" src="https://github.com/user-attachments/assets/920c0db6-4dcd-44e4-ace9-75528795fc65" />


## Agents marquee
- Removes the redundant pause/play control; the marquee still pauses on hover and reduced-motion users still get the full static logo list.

<img width="1168" height="340" alt="image" src="https://github.com/user-attachments/assets/5ba2321a-08ec-42cd-b844-20055c0a9aa0" />


Scope: landing only — `HeroSection`, `DownloadButton`, `TrustedBySection`, `FeaturesSection` constants, `shared` tagline, and the `analytics` helper.