### PR TITLE
fix(landing): keep the mobile preview's controls above the 24px target minimum

### DIFF
--- a/frontend/src/landing/src/app/components/FeaturesSection/components/MobileAppDemo/MobileAppDemo.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/MobileAppDemo/MobileAppDemo.tsx
@@ -32,7 +32,13 @@ const mobileTheme = {
 /**
  * Design size of the phone. The frame is rendered at exactly this size on every
  * breakpoint and scaled to fit its slot, so the scale factors below are just
- * (slot height / PHONE_HEIGHT): 280/390 and 360/390.
+ * (slot height / PHONE_HEIGHT): 335/390 and 360/390. Keep the two in step —
+ * changing a slot height without its scale factor is what made the mock
+ * overflow its own screen in the first place.
+ *
+ * The base slot is 335px rather than something smaller because the scale
+ * applies to the controls too: below 0.858 the 28px FAB drops under the 24px
+ * WCAG 2.2 minimum target size.
  */
 const PHONE_HEIGHT = 390;
 const PHONE_WIDTH = Math.round(PHONE_HEIGHT * 0.48);
@@ -111,7 +117,7 @@ export function MobileAppDemo() {
   );
 
   return (
-    <div className="flex h-[280px] w-full items-center justify-center sm:h-[360px] lg:h-[390px]">
+    <div className="flex h-[335px] w-full items-center justify-center sm:h-[360px] lg:h-[390px]">
       {/*
         The screen is authored at one fixed size (PHONE_WIDTH x PHONE_HEIGHT) because
         everything inside it is absolute — 5px labels, a 28px status bar, a 44px tab bar.
@@ -119,7 +125,7 @@ export function MobileAppDemo() {
         narrower screen, so scale the whole phone instead and keep its proportions.
       */}
       <div
-        className="shrink-0 origin-center scale-[0.718] sm:scale-[0.923] lg:scale-100"
+        className="shrink-0 origin-center scale-[0.859] sm:scale-[0.923] lg:scale-100"
         style={{ width: PHONE_WIDTH, height: PHONE_HEIGHT }}
       >
         <div


### PR DESCRIPTION
Follow-up to #3184, from reviewing it.

## Problem

#3184 fixed the phone mock's proportions by rendering it at a fixed 187×390 design size and scaling the frame into its slot. That was right, but the scale applies to the controls too, and the mock is deliberately tappable (#3174 "make mobile preview interactive").

At the base breakpoint the slot was 280px tall, so scale was `280/390 = 0.718`:

| control | class | before #3184 | after #3184 | now |
|---|---|---|---|---|
| FAB | `size-7` (28px) | 28px ✅ | **20.1px ❌** | **24.1px ✅** |
| "Open conversation" CTA | `min-h-8` (32px) | 32px ✅ | **23.0px ❌** | 27.5px ✅ |
| bottom tabs | `min-h-10` (40px) | 40px ✅ | 28.7px ✅ | 34.4px ✅ |
| session cards | `min-h-11` (44px) | 44px ✅ | 31.6px ✅ | 37.8px ✅ |
| project chips | `min-h-5` (20px) | 20px ❌ | 14.4px ❌ | 17.2px ❌ |

WCAG 2.2 SC 2.5.8 (AA) wants 24×24 CSS px. Two controls regressed from passing to failing.

## Fix

Raise the base slot from `h-[280px]` to `h-[335px]`, which moves the scale to `0.859` and puts the smallest control (the 28px FAB) at 24.1px. One breakpoint changes; `sm` and `lg` are untouched.

335 isn't arbitrary: it's the smallest slot height where `28 × (h/390) ≥ 24`.

## Verification

Measured live in the browser at 390×844:

```
painted frame  161 × 335
FAB            24.1px
tabs / cards   46.4px
chips          17.2px   (pre-existing, see below)
horizontal overflow: none
```

`tsc --noEmit` clean, `next build` green.

Side benefit: the 5px UI labels go from 3.6px to 4.3px, so the mock reads as a UI rather than as texture. Cost is 55px of extra section height on mobile.

## Left alone deliberately

- **Project chips (17.2px)** — `min-h-5` was already 20px and under the minimum before #3184. Raising them to clear 24px means `min-h-7`, which changes the mock's visual density. Separate call, not a regression fix.
- **~12 focusable buttons in a decorative preview** — the chips, cards, tabs and FAB are real `<button>`s with no `aria-hidden`, so keyboard users tab through a marketing mock. Pre-existing from #3174. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)