### PR TITLE
fix: correct synthetic new-file diff line count

### DIFF
--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -346,6 +346,66 @@ func TestGetWorkspaceFileReturnsContentAndDiff(t *testing.T) {
 	}
 }
 
+func TestGetWorkspaceFileNewFileDiffLineCounts(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		diff    string
+	}{
+		{
+			name:    "with trailing newline",
+			content: "hello\nworld\n",
+			diff: strings.Join([]string{
+				"diff --git a/notes.txt b/notes.txt",
+				"new file mode 100644",
+				"--- /dev/null",
+				"+++ b/notes.txt",
+				"@@ -0,0 +1,2 @@",
+				"+hello",
+				"+world",
+				"",
+			}, "\n"),
+		},
+		{
+			name:    "without trailing newline",
+			content: "hello\nworld",
+			diff: strings.Join([]string{
+				"diff --git a/notes.txt b/notes.txt",
+				"new file mode 100644",
+				"--- /dev/null",
+				"+++ b/notes.txt",
+				"@@ -0,0 +1,2 @@",
+				"+hello",
+				"+world",
+				"",
+			}, "\n"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newWorkspaceRepo(t)
+			writeWorkspaceFile(t, repo, "notes.txt", tc.content)
+			st := newFakeStore()
+			st.sessions["ao-1"] = domain.SessionRecord{ID: "ao-1", Metadata: domain.SessionMetadata{WorkspacePath: repo}}
+
+			got, err := (&Service{store: st}).GetWorkspaceFile(context.Background(), "ao-1", "notes.txt")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != WorkspaceFileAdded {
+				t.Fatalf("status = %s, want %s", got.Status, WorkspaceFileAdded)
+			}
+			if got.Additions != 2 || got.Deletions != 0 {
+				t.Fatalf("counts = +%d -%d, want +2 -0", got.Additions, got.Deletions)
+			}
+			if got.Diff != tc.diff {
+				t.Fatalf("diff mismatch:\nwant:\n%s\ngot:\n%s", tc.diff, got.Diff)
+			}
+		})
+	}
+}
+
 func TestListWorkspaceFilesScratchUsesFilesystem(t *testing.T) {
 	root := t.TempDir()
 	writeWorkspaceFile(t, root, "README.md", "one\ntwo\n")

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -519,8 +519,8 @@ func gitTracked(ctx context.Context, root, rel string) bool {
 
 func syntheticAddedFileDiff(rel, content string) string {
 	lines := strings.SplitAfter(content, "\n")
-	if len(lines) == 1 && lines[0] == "" {
-		lines = nil
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", rel, rel)


### PR DESCRIPTION
## Summary
- Drop the sentinel empty split element when building synthetic diffs for untracked added files ending in a newline
- Add regression coverage for new-file diffs with and without a trailing newline, including addition counts matching the hunk

Fixes #2923

## Tests
- cd backend && go test ./internal/service/session
- cd backend && env -u AO_RUNTIME_LAUNCH_ID -u AO_SESSION_ID -u AO_PROJECT_ID go test ./internal/cli
- cd backend && env -u AO_RUNTIME_LAUNCH_ID -u AO_SESSION_ID -u AO_PROJECT_ID go test ./...

## Notes
- A plain `go test ./...` in this AO worker environment failed in `backend/internal/cli` because inherited `AO_RUNTIME_LAUNCH_ID`/`AO_SESSION_ID`/`AO_PROJECT_ID` variables changed CLI test expectations; rerunning with those variables unset passed.