### PR TITLE
fix: use wait-based conpty pid liveness

### DIFF
--- a/backend/internal/adapters/runtime/conpty/pidalive_windows_test.go
+++ b/backend/internal/adapters/runtime/conpty/pidalive_windows_test.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package conpty
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestPidAliveReportsExitedUnreapedProcessAsDead(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	defer func() { _ = cmd.Wait() }()
+
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(cmd.Process.Pid))
+	if err != nil {
+		t.Fatalf("open child process: %v", err)
+	}
+	defer windows.CloseHandle(handle)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		status, err := windows.WaitForSingleObject(handle, 0)
+		if err != nil {
+			t.Fatalf("wait for child process: %v", err)
+		}
+		if status == uint32(windows.WAIT_OBJECT_0) {
+			if pidAlive(cmd.Process.Pid) {
+				t.Fatal("pidAlive returned true for exited unreaped process")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("child process did not exit before timeout")
+}

--- a/backend/internal/adapters/runtime/conpty/ptyregistry/pidalive_windows.go
+++ b/backend/internal/adapters/runtime/conpty/ptyregistry/pidalive_windows.go
@@ -3,17 +3,10 @@
 package ptyregistry
 
 import (
-	"golang.org/x/sys/windows"
+	"github.com/aoagents/agent-orchestrator/backend/internal/processalive"
 )
 
-// defaultPidAlive probes PID liveness via OpenProcess. SUCCESS means alive
-// (CloseHandle and return true). ERROR_ACCESS_DENIED mirrors EPERM: the
-// process exists but cannot be queried, so treat as alive.
+// defaultPidAlive probes PID liveness on Windows.
 func defaultPidAlive(pid int) bool {
-	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
-	if err == nil {
-		_ = windows.CloseHandle(h)
-		return true
-	}
-	return err == windows.ERROR_ACCESS_DENIED
+	return processalive.Alive(pid)
 }

--- a/backend/internal/adapters/runtime/conpty/ptyregistry/pidalive_windows_test.go
+++ b/backend/internal/adapters/runtime/conpty/ptyregistry/pidalive_windows_test.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package ptyregistry
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestDefaultPidAliveReportsExitedUnreapedProcessAsDead(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	defer func() { _ = cmd.Wait() }()
+
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(cmd.Process.Pid))
+	if err != nil {
+		t.Fatalf("open child process: %v", err)
+	}
+	defer windows.CloseHandle(handle)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		status, err := windows.WaitForSingleObject(handle, 0)
+		if err != nil {
+			t.Fatalf("wait for child process: %v", err)
+		}
+		if status == uint32(windows.WAIT_OBJECT_0) {
+			if defaultPidAlive(cmd.Process.Pid) {
+				t.Fatal("defaultPidAlive returned true for exited unreaped process")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("child process did not exit before timeout")
+}

--- a/backend/internal/processalive/process_windows_test.go
+++ b/backend/internal/processalive/process_windows_test.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package processalive
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestAliveReportsExitedUnreapedProcessAsDead(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	defer func() { _ = cmd.Wait() }()
+
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(cmd.Process.Pid))
+	if err != nil {
+		t.Fatalf("open child process: %v", err)
+	}
+	defer windows.CloseHandle(handle)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		status, err := windows.WaitForSingleObject(handle, 0)
+		if err != nil {
+			t.Fatalf("wait for child process: %v", err)
+		}
+		if status == uint32(windows.WAIT_OBJECT_0) {
+			if Alive(cmd.Process.Pid) {
+				t.Fatal("Alive returned true for exited unreaped process")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("child process did not exit before timeout")
+}


### PR DESCRIPTION
## Summary
- make the Windows ptyregistry PID probe delegate to processalive.Alive so exited process handles are checked with WaitForSingleObject
- add Windows-only regression tests for processalive.Alive, conpty.pidAlive, and ptyregistry.defaultPidAlive against exited-but-unreaped processes

## Root cause
The ptyregistry Windows liveness probe used OpenProcess success as proof that a process was still running. On Windows, a terminated process object can remain openable while handles still exist, so the probe could preserve dead pty-host entries.

Fixes #3080.

## Validation
- go test ./internal/processalive ./internal/adapters/runtime/conpty ./internal/adapters/runtime/conpty/ptyregistry
- GOOS=windows GOARCH=amd64 go test -c -o /tmp/processalive.test.exe ./internal/processalive
- GOOS=windows GOARCH=amd64 go test -c -o /tmp/conpty.test.exe ./internal/adapters/runtime/conpty
- GOOS=windows GOARCH=amd64 go test -c -o /tmp/ptyregistry.test.exe ./internal/adapters/runtime/conpty/ptyregistry
- git diff --check

## Notes
- Full backend go test ./... was attempted; affected packages passed, but the run failed in unrelated existing tests: internal/adapters/agent/kilocode TestAuthStatusUnknownWhenKeyOnlyComesFromInteractiveShell, internal/adapters/runtime/tmux TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell, and several internal/cli hook/spawn tests.