### PR TITLE
fix: ignore daemon SIGPIPE from closed log pipes

### DIFF
--- a/backend/internal/cli/e2e_test.go
+++ b/backend/internal/cli/e2e_test.go
@@ -18,6 +18,7 @@ package cli_test
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -63,6 +64,20 @@ type env struct {
 func newEnv(t *testing.T) env {
 	t.Helper()
 	dir := t.TempDir()
+	return env{
+		runFile: filepath.Join(dir, "running.json"),
+		dataDir: filepath.Join(dir, "data"),
+		port:    freePort(t),
+	}
+}
+
+func newShortSocketEnv(t *testing.T) env {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ao-e2e-")
+	if err != nil {
+		return newEnv(t)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	return env{
 		runFile: filepath.Join(dir, "running.json"),
 		dataDir: filepath.Join(dir, "data"),
@@ -162,6 +177,11 @@ func (e env) startDaemon(t *testing.T) {
 		<-waitDone
 	})
 
+	e.waitReady(t)
+}
+
+func (e env) waitReady(t *testing.T) {
+	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)
 	for {
 		out, _ := e.run(t, "status", "--json")
@@ -270,6 +290,78 @@ func TestE2E_Lifecycle(t *testing.T) {
 	}
 	if _, err := os.Stat(e.runFile); !os.IsNotExist(err) {
 		t.Fatal("run-file should be removed after stop")
+	}
+}
+
+func TestE2E_DaemonSurvivesClosedLogPipeAndCleansRunFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGPIPE is POSIX-only")
+	}
+
+	e := newShortSocketEnv(t)
+	logRead, logWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	cmd := exec.Command(aoBin, "daemon")
+	cmd.Env = e.environ("")
+	cmd.Stdout = logWrite
+	cmd.Stderr = logWrite
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn ao daemon: %v", err)
+	}
+	_ = logWrite.Close()
+
+	waitDone := make(chan error, 1)
+	processDone := make(chan struct{})
+	go func() {
+		waitDone <- cmd.Wait()
+		close(processDone)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-processDone:
+			return
+		default:
+		}
+		_ = cmd.Process.Kill()
+		<-processDone
+	})
+
+	drainDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, logRead)
+		close(drainDone)
+	}()
+
+	e.waitReady(t)
+
+	supervisorConn, err := net.DialTimeout("unix", filepath.Join(filepath.Dir(e.runFile), "supervise.sock"), 5*time.Second)
+	if err != nil {
+		t.Fatalf("connect supervisor socket: %v", err)
+	}
+
+	// Simulate the desktop supervisor's stdout/stderr reader going away while
+	// its watchdog connection drops. The following health request forces an
+	// access-log write to the closed pipe before supervisor-grace shutdown.
+	_ = logRead.Close()
+	<-drainDone
+	_ = supervisorConn.Close()
+
+	body := httpGet(t, e.port, "/healthz")
+	mustContain(t, body, "agent-orchestrator-daemon")
+
+	select {
+	case err := <-waitDone:
+		if err != nil {
+			t.Fatalf("daemon exited after closed log pipe: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("daemon did not self-stop after supervisor disconnect")
+	}
+	if _, err := os.Stat(e.runFile); !os.IsNotExist(err) {
+		t.Fatal("run-file should be removed after supervisor-disconnect shutdown")
 	}
 }
 

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -39,6 +39,8 @@ import (
 // Run starts the daemon and blocks until it exits. SIGINT/SIGTERM drive
 // graceful shutdown through the HTTP server and background workers.
 func Run() error {
+	ignoreBrokenPipeSignal()
+
 	cfg, err := config.Load()
 	if err != nil {
 		return err

--- a/backend/internal/daemon/sigpipe_unix.go
+++ b/backend/internal/daemon/sigpipe_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+var (
+	brokenPipeSignal     = make(chan os.Signal, 1)
+	ignoreBrokenPipeOnce sync.Once
+)
+
+func ignoreBrokenPipeSignal() {
+	ignoreBrokenPipeOnce.Do(func() {
+		// A daemon spawned by the desktop supervisor logs to stdout/stderr pipes.
+		// If that supervisor exits first, POSIX may deliver SIGPIPE on the next
+		// write to fd 1 or 2. Catch and discard it so the write returns EPIPE and
+		// the daemon can follow its normal supervisor-disconnect shutdown path.
+		signal.Notify(brokenPipeSignal, syscall.SIGPIPE)
+	})
+}

--- a/backend/internal/daemon/sigpipe_unix_test.go
+++ b/backend/internal/daemon/sigpipe_unix_test.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestIgnoreBrokenPipeSignalAllowsClosedStdoutStderr(t *testing.T) {
+	if os.Getenv("AO_SIGPIPE_HELPER") == "1" {
+		ignoreBrokenPipeSignal()
+		_, _ = os.Stderr.Write([]byte("closed pipe\n"))
+		os.Exit(0)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestIgnoreBrokenPipeSignalAllowsClosedStdoutStderr")
+	cmd.Env = append(os.Environ(), "AO_SIGPIPE_HELPER=1")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	_ = w.Close()
+	_ = r.Close()
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("helper exited after writing to closed stderr: %v", err)
+	}
+}

--- a/backend/internal/daemon/sigpipe_windows.go
+++ b/backend/internal/daemon/sigpipe_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package daemon
+
+func ignoreBrokenPipeSignal() {}


### PR DESCRIPTION
## Summary
- register a POSIX SIGPIPE handler when the daemon starts so closed supervisor stdout/stderr pipes cannot kill the process
- keep Windows behavior as a no-op and rely on the existing owned run-file cleanup path during graceful shutdown
- add subprocess and e2e regressions covering closed stderr/stdout pipes and running.json cleanup after supervisor disconnect

Fixes #3182

## Tests
- go test ./internal/daemon -run TestIgnoreBrokenPipeSignalAllowsClosedStdoutStderr -count=1
- go test -tags e2e ./internal/cli -run TestE2E_DaemonSurvivesClosedLogPipeAndCleansRunFile -count=1 -v
- env -u AO_SESSION_ID -u AO_RUNTIME_LAUNCH_ID -u AO_LAUNCH_ID -u AO_PROJECT_ID -u AO_DATA_DIR -u AO_RUN_FILE -u AO_PORT go test ./internal/daemon ./internal/httpd
- env -u AO_SESSION_ID -u AO_RUNTIME_LAUNCH_ID -u AO_LAUNCH_ID -u AO_PROJECT_ID -u AO_DATA_DIR -u AO_RUN_FILE -u AO_PORT go test ./internal/cli
- env -u AO_SESSION_ID -u AO_RUNTIME_LAUNCH_ID -u AO_LAUNCH_ID -u AO_PROJECT_ID -u AO_DATA_DIR -u AO_RUN_FILE -u AO_PORT npm run lint

## Notes
- An initial full backend test run hit a local tmux integration timeout in TestRuntimeIntegration; rerunning that package passed, and npm run lint later passed the full backend test suite and golangci-lint.
