### PR TITLE
fix(sidebar): color session dots from the board's attention zones

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1004,7 +1004,10 @@ describe("Sidebar", () => {
 		expect(sessionDot("merged task")).toHaveClass("bg-status-merged", "animate-status-pulse");
 	});
 
-	it("renders a static gray dot for idle activity across session statuses", () => {
+	// Issue #3099: an idle agent only reads as gray when the session has no
+	// attention signal; sessions parked in a board attention zone keep that
+	// zone's color so the sidebar mirrors the board.
+	it("colors idle sessions from their board attention zone, not agent activity", () => {
 		renderSidebar({
 			workspaces: [
 				{
@@ -1024,20 +1027,35 @@ describe("Sidebar", () => {
 							status: "draft",
 							activity: { state: "idle", lastActivityAt: "2026-06-30T00:00:00Z" },
 						},
+						{
+							...session,
+							id: "proj-1-idle-ready",
+							title: "idle ready task",
+							status: "mergeable",
+							activity: { state: "idle", lastActivityAt: "2026-06-30T00:00:00Z" },
+						},
+						{
+							...session,
+							id: "proj-1-idle-changes",
+							title: "idle changes task",
+							status: "changes_requested",
+							activity: { state: "idle", lastActivityAt: "2026-06-30T00:00:00Z" },
+						},
 					],
 				},
 			],
 		});
 
-		const idleActivityDot = screen
-			.getByLabelText("Open idle activity task")
-			.querySelector<HTMLElement>("span.rounded-full");
-		const idleDraftDot = screen.getByLabelText("Open idle draft task").querySelector<HTMLElement>("span.rounded-full");
+		const sessionDot = (title: string) =>
+			screen.getByLabelText(`Open ${title}`).querySelector<HTMLElement>("span.rounded-full");
 
-		expect(idleActivityDot).toHaveClass("bg-status-idle");
-		expect(idleDraftDot).toHaveClass("bg-status-idle");
-		expect(idleActivityDot).not.toHaveClass("animate-status-pulse");
-		expect(idleDraftDot).not.toHaveClass("animate-status-pulse");
+		expect(sessionDot("idle activity task")).toHaveClass("bg-status-idle");
+		expect(sessionDot("idle draft task")).toHaveClass("bg-status-in-review");
+		expect(sessionDot("idle ready task")).toHaveClass("bg-status-ready");
+		expect(sessionDot("idle changes task")).toHaveClass("bg-status-needs-you");
+		for (const title of ["idle activity task", "idle draft task", "idle ready task", "idle changes task"]) {
+			expect(sessionDot(title)).not.toHaveClass("animate-status-pulse");
+		}
 	});
 
 	it("keeps merged sessions in the list until they are terminated", () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -110,8 +110,9 @@ function useSelection() {
 	};
 }
 
-// Activity controls motion; live PR context controls an active session's
-// color. Idle activity remains visible as a static gray dot.
+// Color mirrors the board's attention zone for the same session (needs-you /
+// in-review / ready-to-merge); activity controls motion, and only sessions in
+// the working zone fall back to raw activity tones (idle stays a gray dot).
 function SessionDot({ session }: { session: WorkspaceSession }) {
 	const dot = getSessionDotView(session);
 	return <span aria-hidden="true" className={cn("mt-px h-1.5 w-1.5 shrink-0 rounded-full", dot.className)} />;

--- a/frontend/src/renderer/lib/session-presentation.test.ts
+++ b/frontend/src/renderer/lib/session-presentation.test.ts
@@ -3,6 +3,7 @@ import {
 	attentionZone,
 	getAgentActivityView,
 	getAttentionZoneView,
+	getAttentionZoneViewForZone,
 	getSessionDotView,
 	getSessionStatusView,
 	getSessionTimelinePillView,
@@ -164,13 +165,11 @@ describe("session presentation", () => {
 		expect(dot?.className).not.toContain("bg-status-needs-you");
 	});
 
-	it("keeps a static gray sidebar dot while the agent is idle", () => {
+	it("keeps a static gray sidebar dot while an agent without attention signals is idle", () => {
 		const dot = getSessionDotView(
 			sessionWith({
-				status: "draft",
-				scmStatus: "draft",
+				status: "idle",
 				activity: { state: "idle", lastActivityAt: "" },
-				prs: [{ ...openPr, state: "draft" }],
 			}),
 		);
 
@@ -178,19 +177,71 @@ describe("session presentation", () => {
 		expect(dot.className).not.toContain("animate-status-pulse");
 	});
 
+	// The issue-#3099 regression: sessions sitting in In Review / Ready to Merge
+	// rendered idle gray in the sidebar while their board cards showed color.
+	it.each([
+		["needs_input", "bg-status-needs-you"],
+		["exited", "bg-status-needs-you"],
+		["no_signal", "bg-status-needs-you"],
+		["ci_failed", "bg-status-needs-you"],
+		["changes_requested", "bg-status-needs-you"],
+		["unknown", "bg-status-needs-you"],
+		["review_pending", "bg-status-in-review"],
+		["pr_open", "bg-status-in-review"],
+		["draft", "bg-status-in-review"],
+		["approved", "bg-status-ready"],
+		["mergeable", "bg-status-ready"],
+		["merged", "bg-status-merged"],
+		["terminated", "bg-status-terminated"],
+	] as const)("colors an idle session with %s status like its board attention zone", (status, expectedClass) => {
+		const dot = getSessionDotView(
+			sessionWith({
+				status,
+				activity: { state: "idle", lastActivityAt: "" },
+			}),
+		);
+
+		expect(dot.className).toBe(expectedClass);
+		if (status !== "merged") {
+			expect(expectedClass).toBe(getAttentionZoneViewForZone(attentionZone(status)).dotClassName);
+		}
+	});
+
+	it("colors sessions with no activity payload from their attention zone too", () => {
+		expect(getSessionDotView(sessionWith({ status: "mergeable" })).className).toBe("bg-status-ready");
+		expect(getSessionDotView(sessionWith({ status: "pr_open", prs: [openPr] })).className).toBe(
+			"bg-status-in-review",
+		);
+	});
+
+	it("pulses the attention-zone color while the agent is actively running", () => {
+		const dot = getSessionDotView(
+			sessionWith({
+				status: "changes_requested",
+				activity: { state: "active", lastActivityAt: "" },
+				prs: [{ ...openPr, review: "changes_requested" }],
+			}),
+		);
+
+		expect(dot.className).toBe("bg-status-needs-you animate-status-pulse");
+	});
+
 	it.each([
 		["waiting_input", "bg-status-needs-you"],
 		["blocked", "bg-status-needs-you"],
 		["exited", "bg-status-exited"],
 		["unknown", "bg-status-unknown"],
-	] as const)("keeps the raw %s activity tone when the agent is not active", (state, expectedClass) => {
-		expect(getSessionDotView(sessionWith({ activity: { state, lastActivityAt: "" }, prs: [openPr] }))?.className).toBe(
-			expectedClass,
-		);
-		expect(
-			getSessionDotView(sessionWith({ activity: { state, lastActivityAt: "" }, prs: [openPr] }))?.className,
-		).not.toContain("animate-status-pulse");
-	});
+	] as const)(
+		"keeps the raw %s activity tone when a working-zone agent is not active",
+		(state, expectedClass) => {
+			expect(getSessionDotView(sessionWith({ activity: { state, lastActivityAt: "" } }))?.className).toBe(
+				expectedClass,
+			);
+			expect(getSessionDotView(sessionWith({ activity: { state, lastActivityAt: "" } }))?.className).not.toContain(
+				"animate-status-pulse",
+			);
+		},
+	);
 
 	it("uses a muted accent treatment for In Review instead of idle gray", () => {
 		expect(getAttentionZoneView("review_pending")).toMatchObject({

--- a/frontend/src/renderer/lib/session-presentation.ts
+++ b/frontend/src/renderer/lib/session-presentation.ts
@@ -254,15 +254,30 @@ function fallbackSCMStatus(prs: PullRequestFacts[]): SessionStatus | undefined {
 	return prs.some((pr) => pr.state === "merged") ? "merged" : undefined;
 }
 
-export function getSessionDotView(session: Pick<WorkspaceSession, "activity" | "scmStatus" | "prs">): {
+export function getSessionDotView(session: Pick<WorkspaceSession, "status" | "activity" | "scmStatus" | "prs">): {
 	className: string;
 } {
 	const activity = getAgentActivityView(session.activity);
-	if (activity.state !== "active") return { className: activity.dotClassName };
+	const zone = attentionZone(session.status);
 
-	const contextStatus = session.scmStatus ?? fallbackSCMStatus(session.prs) ?? "working";
+	// The working zone carries no PR/attention signal, so agent runtime is the
+	// story — mirroring the board's split Idle/Working lane: an active agent
+	// pulses with its live PR context tint, everything else keeps its raw
+	// activity tone (idle gray, waiting/blocked needs-you, ...).
+	if (zone === "working") {
+		if (activity.state !== "active") return { className: activity.dotClassName };
+		const contextStatus = session.scmStatus ?? fallbackSCMStatus(session.prs) ?? "working";
+		return {
+			className: `${activeSessionDotClassNames[contextStatus] ?? "bg-status-working"} animate-status-pulse`,
+		};
+	}
+
+	// Every other zone mirrors the board column color so needs-you / in-review /
+	// ready-to-merge sessions never read as idle gray; merged keeps the board's
+	// merged-lane tone. Activity still controls motion.
+	const dotClassName = session.status === "merged" ? "bg-status-merged" : attentionZoneViews[zone].dotClassName;
 	return {
-		className: `${activeSessionDotClassNames[contextStatus] ?? "bg-status-working"} animate-status-pulse`,
+		className: activity.state === "active" ? `${dotClassName} animate-status-pulse` : dotClassName,
 	};
 }
 


### PR DESCRIPTION
Fixes #3099

## Summary

Sidebar session dots rendered idle gray for any session whose agent wasn't actively running — even when its board card sat in **In Review** (blue) or **Ready to Merge** (green). `getSessionDotView` colored the dot from raw agent activity (`idle` → gray) and only consulted PR/status context while the agent was `active`, so the sidebar and board disagreed for the same session.

The dot now derives its color from `attentionZone(session.status)` — the exact mapping the board columns use — so both surfaces read from the same status source and render the same color:

- **Needs you / In review / Ready to merge** zones → the zone's dot color (`bg-status-needs-you` / `bg-status-in-review` / `bg-status-ready`), regardless of agent activity.
- **Merged** keeps the board's merged-lane tone (`bg-status-merged`), mirroring the board's split Merge lane.
- **Working zone** (no PR/attention signal) keeps the existing activity tones — idle gray, waiting/blocked needs-you, active teal — mirroring the board's split Idle/Working lane.
- Activity still controls motion: an actively-running agent pulses in every zone.

Also updated the stale `SessionDot` comment in `Sidebar.tsx` to describe the new semantics.

## Tests

- Rewrote the two tests that enshrined the regression (idle + draft → gray) and added table-driven coverage asserting the sidebar dot class equals the board zone's `dotClassName` for every attention-zone status, plus pulse/no-pulse and missing-activity cases (`session-presentation.test.ts`, `Sidebar.test.tsx`).
- `npm run typecheck` clean; full frontend suite passes (89 files, 1159 tests).

## Risks / notes

- `getSessionDotView` now requires `status` in its `Pick`; its only caller (Sidebar) already passes the full session.
- Sessions whose daemon-derived `status` is `exited`/`no_signal`/`unknown` now show the needs-you tone (their board column color) instead of exited/unknown grays — that is the intended attention-zone alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)