### PR TITLE
fix(topbar): stop worker branch label reading as a button; tooltip for cropped names

### DIFF
--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useUiStore } from "../stores/ui-store";
 import type { SessionActivityState, WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { ShellTopbar, TopbarKillButton } from "./ShellTopbar";
+import { TooltipProvider } from "./ui/tooltip";
 
 const { navigateMock, onKilledMock, paramsMock, postMock, spawnMock, useWorkspaceQueryMock } = vi.hoisted(() => ({
 	navigateMock: vi.fn(),
@@ -112,7 +113,9 @@ function renderTopbarSessions(sessions: WorkspaceSession[], sessionId: string) {
 	const queryClient = new QueryClient();
 	const topbar = () => (
 		<QueryClientProvider client={queryClient}>
-			<ShellTopbar />
+			<TooltipProvider delayDuration={0}>
+				<ShellTopbar />
+			</TooltipProvider>
 		</QueryClientProvider>
 	);
 	const result = render(topbar());
@@ -207,6 +210,61 @@ describe("ShellTopbar status pill", () => {
 	});
 });
 
+// jsdom has no layout, so scrollWidth/clientWidth are always 0 and the branch
+// never measures as cropped. Shadow the Element.prototype getters to simulate a
+// name wider than its container; returns a restore fn.
+function stubCroppedText() {
+	Object.defineProperty(HTMLElement.prototype, "scrollWidth", { configurable: true, get: () => 300 });
+	Object.defineProperty(HTMLElement.prototype, "clientWidth", { configurable: true, get: () => 100 });
+	return () => {
+		delete (HTMLElement.prototype as { scrollWidth?: number }).scrollWidth;
+		delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth;
+	};
+}
+
+describe("ShellTopbar worker branch (#3173)", () => {
+	it("renders the branch as plain text, not a button", () => {
+		renderTopbar(sessionWith());
+
+		const branch = screen.getByText("ao/sess-1");
+		expect(branch.closest("button")).toBeNull();
+		expect(branch.closest('[role="button"]')).toBeNull();
+	});
+
+	it("separates the branch from the status pill with a divider", () => {
+		const { container } = renderTopbar(sessionWith());
+
+		expect(container.querySelector(".w-px.bg-border")).not.toBeNull();
+	});
+
+	it("renders no divider for branchless sessions", () => {
+		const { container } = renderTopbar(sessionWith({ branch: undefined }));
+
+		expect(container.querySelector(".w-px.bg-border")).toBeNull();
+	});
+
+	it("shows no tooltip while the full branch name fits", async () => {
+		renderTopbar(sessionWith());
+
+		await userEvent.hover(screen.getByText("ao/sess-1"));
+
+		expect(screen.queryByRole("tooltip")).toBeNull();
+	});
+
+	it("reveals the full branch in a tooltip when the name is cropped", async () => {
+		const restore = stubCroppedText();
+		try {
+			renderTopbar(sessionWith({ branch: "ao/agent-orchestrator-53/root" }));
+
+			await userEvent.hover(screen.getByText("ao/agent-orchestrator-53/root"));
+
+			expect(await screen.findByRole("tooltip")).toHaveTextContent("ao/agent-orchestrator-53/root");
+		} finally {
+			restore();
+		}
+	});
+});
+
 describe("ShellTopbar orchestrator actions", () => {
 	it.each([
 		["active", "Working", "bg-status-working", true],
@@ -255,7 +313,9 @@ describe("ShellTopbar orchestrator actions", () => {
 		paramsMock.sessionId = "sess-1";
 		render(
 			<QueryClientProvider client={new QueryClient()}>
-				<ShellTopbar />
+				<TooltipProvider>
+					<ShellTopbar />
+				</TooltipProvider>
 			</QueryClientProvider>,
 		);
 

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -373,8 +373,9 @@ function ProjectTerminationFeedback({ projectId }: { projectId: string | undefin
 // window runs out of space); while it is actually cropped, the full branch is
 // recoverable from a tooltip. The Tooltip root stays mounted and only the
 // content is gated on the cropped state, so the measured span never remounts
-// out from under its ResizeObserver.
-export function SessionBranchLabel({ branch }: { branch: string }) {
+// out from under its ResizeObserver. The trigger opts out of the macOS drag
+// region (noDragStyle) — inside it, Electron would swallow the hover.
+function SessionBranchLabel({ branch }: { branch: string }) {
 	const textRef = useRef<HTMLSpanElement | null>(null);
 	const [isCropped, setIsCropped] = useState(false);
 
@@ -391,7 +392,10 @@ export function SessionBranchLabel({ branch }: { branch: string }) {
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<div className="inline-flex min-w-0 cursor-default items-center gap-1 font-mono text-2xs leading-none text-passive">
+				<div
+					className="inline-flex min-w-0 cursor-default items-center gap-1 font-mono text-2xs leading-none text-passive"
+					style={noDragStyle}
+				>
 					<GitBranch className="size-icon-2xs shrink-0" aria-hidden="true" />
 					<span ref={textRef} className="truncate">
 						{branch}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { GitBranch, LayoutDashboard, PanelRightClose, PanelRightOpen, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { NotificationCenter } from "./NotificationCenter";
 import {
 	findProjectOrchestrator,
@@ -27,6 +27,7 @@ import { isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { StatusPill } from "./StatusPill";
 import { TopbarButton, TopbarKillError, topbarHeaderClass, topbarProjectLabelClass } from "./TopbarButton";
 import { SessionTerminationPopover } from "./SessionTerminationPopover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 const isMac = isMacPlatform();
 const boardActionsInPanel = usesBoardActionsInPanel();
@@ -156,10 +157,12 @@ export function ShellTopbar() {
 				) : isSessionRoute ? (
 					<div className="flex min-w-0 items-center gap-3">
 						{session?.branch ? (
-							<div className="inline-flex min-w-0 items-center gap-1 font-mono text-2xs leading-none text-passive">
-								<GitBranch className="size-icon-2xs shrink-0" aria-hidden="true" />
-								<span className="truncate">{session.branch}</span>
-							</div>
+							<>
+								<SessionBranchLabel branch={session.branch} />
+								{/* Hairline divider so the static branch text can't be read as
+								    part of the status pill's chip (#3173). */}
+								<span aria-hidden="true" className="h-3.5 w-px shrink-0 bg-border" />
+							</>
 						) : null}
 						{session ? <SessionStatusPill session={session} /> : null}
 					</div>
@@ -364,6 +367,42 @@ function ProjectTerminationFeedback({ projectId }: { projectId: string | undefin
 		</div>
 	);
 }
+// Static branch identity for worker sessions (#3173). Deliberately plain text —
+// no fill, border, or hover state — so it reads as a label, not a control. The
+// name keeps all available row width (min-w-0 + truncate only bite when the
+// window runs out of space); while it is actually cropped, the full branch is
+// recoverable from a tooltip. The Tooltip root stays mounted and only the
+// content is gated on the cropped state, so the measured span never remounts
+// out from under its ResizeObserver.
+export function SessionBranchLabel({ branch }: { branch: string }) {
+	const textRef = useRef<HTMLSpanElement | null>(null);
+	const [isCropped, setIsCropped] = useState(false);
+
+	useEffect(() => {
+		const el = textRef.current;
+		if (!el) return;
+		const measure = () => setIsCropped(el.scrollWidth > el.clientWidth);
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [branch]);
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<div className="inline-flex min-w-0 cursor-default items-center gap-1 font-mono text-2xs leading-none text-passive">
+					<GitBranch className="size-icon-2xs shrink-0" aria-hidden="true" />
+					<span ref={textRef} className="truncate">
+						{branch}
+					</span>
+				</div>
+			</TooltipTrigger>
+			{isCropped ? <TooltipContent className="font-mono text-2xs">{branch}</TooltipContent> : null}
+		</Tooltip>
+	);
+}
+
 function SessionStatusPill({ session }: { session: WorkspaceSession }) {
 	const { label, tone, breathe } = getAgentActivityView(session.activity);
 	return (


### PR DESCRIPTION
## Summary

Fixes #3173 — the worker session topbar's branch identifier was cropped on narrow windows with no way to recover the full name, and its proximity to the status pill made the static text read as a clickable chip.

- The branch stays plain mono text (no fill/border/hover affordance) and a hairline divider now separates it from the status pill, so the two no longer merge into one button-like chip.
- The name keeps the full row width where space allows; when it is actually cropped (measured with a ResizeObserver on the truncating span), the full branch is recoverable from a shadcn/Radix tooltip. The Tooltip root stays mounted and only its content is gated on the cropped state, so the measured span never remounts out from under its observer.
- `WindowTitlebar.tsx` needs no change — it is the Windows-only menu bar and renders no session name; the session identity lives solely in `ShellTopbar`.

## Tests

- New `ShellTopbar worker branch (#3173)` suite: branch renders as plain text (not a button), divider present/absent with/without a branch, no tooltip while the name fits, tooltip with the full branch when cropped (layout metrics stubbed since jsdom has no layout).
- Full frontend suite: 89 files / 1149 tests pass; `npm run typecheck` clean.
- Verified visually in a browser against the live daemon (vite `dev:web` proxy): full name + divider at wide widths, ellipsis at tight widths, tooltip showing `ao/agent-orchestrator-63/root` on hover.

## Risks / notes

- Existing tests that render `ShellTopbar` directly now wrap it in `TooltipProvider` (the app already provides one at the root route).
- At very tight widths the collapsed-sidebar TitlebarNav overlay can sit above the topbar text in the browser preview harness; that is pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)