### PR TITLE
fix(notifications): use project name in titles and sync OS badge count

### DIFF
--- a/backend/internal/notify/enrich.go
+++ b/backend/internal/notify/enrich.go
@@ -73,6 +73,9 @@ func sessionLabel(intent Intent) string {
 	if v := strings.TrimSpace(intent.SessionDisplayName); v != "" {
 		return v
 	}
+	if intent.ProjectID != "" {
+		return string(intent.ProjectID)
+	}
 	if intent.SessionID != "" {
 		return string(intent.SessionID)
 	}

--- a/backend/internal/notify/enrich_test.go
+++ b/backend/internal/notify/enrich_test.go
@@ -1,0 +1,60 @@
+package notify
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestSessionLabelPrefersDisplayNameThenProjectID(t *testing.T) {
+	cases := []struct {
+		name   string
+		intent Intent
+		want   string
+	}{
+		{
+			name:   "display name wins",
+			intent: Intent{SessionDisplayName: "checkout-flow", SessionID: "mer-1", ProjectID: "mer"},
+			want:   "checkout-flow",
+		},
+		{
+			name:   "empty display name falls back to project id",
+			intent: Intent{SessionID: "mer-1", ProjectID: "mer"},
+			want:   "mer",
+		},
+		{
+			name:   "whitespace display name falls back to project id",
+			intent: Intent{SessionDisplayName: "   ", SessionID: "mer-1", ProjectID: "mer"},
+			want:   "mer",
+		},
+		{
+			name:   "missing project id falls back to session id",
+			intent: Intent{SessionID: "mer-1"},
+			want:   "mer-1",
+		},
+		{
+			name:   "empty intent defaults to session",
+			intent: Intent{},
+			want:   "session",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sessionLabel(tc.intent); got != tc.want {
+				t.Fatalf("sessionLabel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTitleForIntentUsesProjectIDNotSessionInstance(t *testing.T) {
+	intent := Intent{
+		Type:      domain.NotificationNeedsInput,
+		SessionID: "portfolio-10",
+		ProjectID: "portfolio",
+	}
+	if got := titleForIntent(intent); got != "portfolio needs input" {
+		t.Fatalf("title = %q, want %q", got, "portfolio needs input")
+	}
+}

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -136,6 +136,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 				},
 				notifications: {
 					show: async () => undefined,
+					setBadgeCount: async () => undefined,
 					onClick: unsubscribe,
 				},
 				appState: {
@@ -517,7 +518,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					onTabsState: unsubscribe,
 					onAgentActivity: unsubscribe,
 				},
-				notifications: { show: async () => undefined, onClick: unsubscribe },
+				notifications: { show: async () => undefined, setBadgeCount: async () => undefined, onClick: unsubscribe },
 				appState: { getMigration: async () => ({ status: "completed" }), setMigration: async () => undefined },
 				updateSettings: {
 					get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -64,6 +64,11 @@ import { readMigrationState, updateMigration, writeAppStateMarker, type Migratio
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { buildWindowsAppMenuTemplate } from "./main/menu";
 import { ancestorRepositorySetupWarning, scanImportFolder } from "./main/import-folder-scan";
+import {
+	readBadgeCount,
+	setAppBadgeCount,
+	writeBadgeCount,
+} from "./main/notification-badge";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -1428,6 +1433,19 @@ ipcMain.handle("notifications:show", (_event, notification: { id: string; title:
 	toast.show();
 });
 
+ipcMain.handle("notifications:setBadgeCount", async (_event, count: unknown) => {
+	const numericCount = typeof count === "number" && Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+	setAppBadgeCount(numericCount);
+	const runFile = runFilePath();
+	if (runFile) {
+		try {
+			await writeBadgeCount(path.dirname(runFile), numericCount);
+		} catch (err) {
+			console.error("failed to persist badge count:", err);
+		}
+	}
+});
+
 // Auto-update only runs for packaged builds reading the GitHub Releases feed
 // (see forge.config.ts publishers). In dev there is no feed, so it is skipped.
 // A live updater additionally requires a signed + notarized build — see
@@ -1523,6 +1541,18 @@ app.whenReady().then(async () => {
 	const keybindingRunFile = runFilePath();
 	if (keybindingRunFile) {
 		keybindingOverrides = await readKeybindingOverrides(path.dirname(keybindingRunFile));
+	}
+
+	// Restore the last known notification badge count early so the dock/taskbar
+	// badge is accurate before the renderer connects and refetches unread counts.
+	const badgeRunFile = runFilePath();
+	if (badgeRunFile) {
+		try {
+			const persistedCount = await readBadgeCount(path.dirname(badgeRunFile));
+			setAppBadgeCount(persistedCount);
+		} catch (err) {
+			console.error("failed to restore badge count:", err);
+		}
 	}
 
 	registerRendererProtocol();

--- a/frontend/src/main/notification-badge.test.ts
+++ b/frontend/src/main/notification-badge.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const electronMocks = vi.hoisted(() => ({
+	setBadgeCountMock: vi.fn(),
+	setOverlayIconMock: vi.fn(),
+	createFromDataURLMock: vi.fn((url: string) => ({ url })),
+	getAllWindowsMock: vi.fn(() => [] as Array<{ setOverlayIcon: ReturnType<typeof vi.fn> }>),
+}));
+
+vi.mock("electron", () => ({
+	app: { setBadgeCount: electronMocks.setBadgeCountMock },
+	BrowserWindow: { getAllWindows: electronMocks.getAllWindowsMock },
+	nativeImage: { createFromDataURL: electronMocks.createFromDataURLMock },
+}));
+
+import {
+	BADGE_COUNT_FILE_NAME,
+	clearAppBadgeCount,
+	getCurrentBadgeCount,
+	readBadgeCount,
+	setAppBadgeCount,
+	writeBadgeCount,
+} from "./notification-badge";
+
+let stateDir: string;
+
+beforeEach(async () => {
+	stateDir = await mkdtemp(path.join(os.tmpdir(), "ao-badge-test-"));
+	electronMocks.setBadgeCountMock.mockClear();
+	electronMocks.setOverlayIconMock.mockClear();
+	electronMocks.createFromDataURLMock.mockClear();
+	electronMocks.getAllWindowsMock.mockClear().mockReturnValue([]);
+});
+
+afterEach(async () => {
+	await rm(stateDir, { recursive: true, force: true });
+});
+
+describe("readBadgeCount", () => {
+	it("returns the persisted count", async () => {
+		await writeBadgeCount(stateDir, 5);
+		await expect(readBadgeCount(stateDir)).resolves.toBe(5);
+	});
+
+	it("returns 0 when the file is missing", async () => {
+		await expect(readBadgeCount(stateDir)).resolves.toBe(0);
+	});
+
+	it("returns 0 for corrupt JSON", async () => {
+		await writeFile(path.join(stateDir, BADGE_COUNT_FILE_NAME), "not json");
+		await expect(readBadgeCount(stateDir)).resolves.toBe(0);
+	});
+
+	it("returns 0 for negative counts", async () => {
+		await writeFile(path.join(stateDir, BADGE_COUNT_FILE_NAME), JSON.stringify({ count: -3 }));
+		await expect(readBadgeCount(stateDir)).resolves.toBe(0);
+	});
+});
+
+describe("writeBadgeCount", () => {
+	it("persists a non-negative count", async () => {
+		await writeBadgeCount(stateDir, 3);
+
+		const raw = await readFile(path.join(stateDir, BADGE_COUNT_FILE_NAME), "utf8");
+		expect(JSON.parse(raw)).toEqual({ count: 3 });
+	});
+
+	it("clamps negative counts to zero", async () => {
+		await writeBadgeCount(stateDir, -2);
+
+		const raw = await readFile(path.join(stateDir, BADGE_COUNT_FILE_NAME), "utf8");
+		expect(JSON.parse(raw)).toEqual({ count: 0 });
+	});
+
+	it("skips writing when the count has not changed", async () => {
+		await writeBadgeCount(stateDir, 4);
+		const first = await stat(path.join(stateDir, BADGE_COUNT_FILE_NAME));
+		await new Promise((r) => setTimeout(r, 20));
+		await writeBadgeCount(stateDir, 4);
+		const second = await stat(path.join(stateDir, BADGE_COUNT_FILE_NAME));
+
+		expect(second.mtimeMs).toBe(first.mtimeMs);
+	});
+});
+
+describe("setAppBadgeCount", () => {
+	it("sets the dock badge count on macOS/Linux", () => {
+		Object.defineProperty(process, "platform", { value: "darwin" });
+		setAppBadgeCount(4);
+
+		expect(electronMocks.setBadgeCountMock).toHaveBeenCalledWith(4);
+		expect(getCurrentBadgeCount()).toBe(4);
+	});
+
+	it("clamps fractional counts", () => {
+		Object.defineProperty(process, "platform", { value: "darwin" });
+		setAppBadgeCount(2.7);
+
+		expect(electronMocks.setBadgeCountMock).toHaveBeenCalledWith(2);
+	});
+
+	it("clears the badge when count is zero", () => {
+		Object.defineProperty(process, "platform", { value: "darwin" });
+		setAppBadgeCount(5);
+		clearAppBadgeCount();
+
+		expect(electronMocks.setBadgeCountMock).toHaveBeenLastCalledWith(0);
+		expect(getCurrentBadgeCount()).toBe(0);
+	});
+
+	it("overlays the taskbar icon on Windows", () => {
+		Object.defineProperty(process, "platform", { value: "win32" });
+		const win = { setOverlayIcon: electronMocks.setOverlayIconMock };
+		electronMocks.getAllWindowsMock.mockReturnValue([win]);
+
+		setAppBadgeCount(3);
+
+		expect(electronMocks.setOverlayIconMock).toHaveBeenCalledTimes(1);
+		expect(electronMocks.createFromDataURLMock).toHaveBeenCalledTimes(1);
+		expect(electronMocks.setBadgeCountMock).not.toHaveBeenCalled();
+	});
+
+	it("clears the Windows overlay when count is zero", () => {
+		Object.defineProperty(process, "platform", { value: "win32" });
+		const win = { setOverlayIcon: electronMocks.setOverlayIconMock };
+		electronMocks.getAllWindowsMock.mockReturnValue([win]);
+
+		setAppBadgeCount(0);
+
+		expect(electronMocks.setOverlayIconMock).toHaveBeenCalledWith(null, "");
+	});
+});
+
+describe("BADGE_COUNT_FILE_NAME", () => {
+	it("exposes the expected file name", () => {
+		expect(BADGE_COUNT_FILE_NAME).toBe("badge-count.json");
+	});
+});

--- a/frontend/src/main/notification-badge.ts
+++ b/frontend/src/main/notification-badge.ts
@@ -1,0 +1,94 @@
+import { app, BrowserWindow, nativeImage } from "electron";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+/** File holding the last known notification badge count under the electron state dir. */
+export const BADGE_COUNT_FILE_NAME = "badge-count.json";
+
+interface BadgeCountFile {
+	count: number;
+}
+
+let currentBadgeCount = 0;
+let lastPersistedCount: number | null = null;
+
+function coerceBadgeCount(raw: unknown): number {
+	if (raw === null || raw === undefined) return 0;
+	const value = typeof raw === "object" ? (raw as BadgeCountFile).count : raw;
+	if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+	return Math.max(0, Math.floor(value));
+}
+
+async function readBadgeCountUnlocked(stateDir: string): Promise<number> {
+	let raw: string;
+	try {
+		raw = await readFile(path.join(stateDir, BADGE_COUNT_FILE_NAME), "utf8");
+	} catch {
+		return 0;
+	}
+	try {
+		return coerceBadgeCount(JSON.parse(raw));
+	} catch {
+		return 0;
+	}
+}
+
+async function writeBadgeCountUnlocked(stateDir: string, count: number): Promise<void> {
+	await mkdir(stateDir, { recursive: true, mode: 0o750 });
+	const file = path.join(stateDir, BADGE_COUNT_FILE_NAME);
+	const data = `${JSON.stringify({ count }, null, 2)}\n`;
+	const tmp = path.join(stateDir, `.badge-count-${process.pid}-${Date.now()}.json`);
+	await writeFile(tmp, data, { mode: 0o600 });
+	await rename(tmp, file);
+}
+
+/** Read the persisted badge count, tolerating a missing or corrupt file. */
+export async function readBadgeCount(stateDir: string): Promise<number> {
+	return readBadgeCountUnlocked(stateDir);
+}
+
+/** Persist the badge count so it survives an app restart. */
+export async function writeBadgeCount(stateDir: string, count: number): Promise<void> {
+	const normalized = Math.max(0, Math.floor(count));
+	if (normalized === lastPersistedCount) return;
+	await writeBadgeCountUnlocked(stateDir, normalized);
+	lastPersistedCount = normalized;
+}
+
+function createWindowsOverlayImage(count: number): Electron.NativeImage {
+	const text = count > 99 ? "99+" : String(count);
+	const fontSize = text.length > 2 ? 7 : 10;
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="8" fill="#ef4444"/><text x="8" y="12" text-anchor="middle" fill="white" font-size="${fontSize}" font-family="system-ui, -apple-system, sans-serif" font-weight="600">${text}</text></svg>`;
+	const url = `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
+	return nativeImage.createFromDataURL(url);
+}
+
+/**
+ * Set the app's notification badge to the given count.
+ * On macOS/Linux this updates the dock/taskbar badge; on Windows it overlays the
+ * taskbar button. The count is clamped to a non-negative integer.
+ */
+export function setAppBadgeCount(count: number): void {
+	const normalized = Math.max(0, Math.floor(count));
+	currentBadgeCount = normalized;
+
+	if (process.platform === "win32") {
+		const win = BrowserWindow.getAllWindows()[0];
+		if (win) {
+			win.setOverlayIcon(normalized > 0 ? createWindowsOverlayImage(normalized) : null, "");
+		}
+		return;
+	}
+
+	app.setBadgeCount(normalized);
+}
+
+/** Clear the badge (equivalent to setting the count to zero). */
+export function clearAppBadgeCount(): void {
+	setAppBadgeCount(0);
+}
+
+/** The badge count last applied by this process (for tests and introspection). */
+export function getCurrentBadgeCount(): number {
+	return currentBadgeCount;
+}

--- a/frontend/src/preload.test.ts
+++ b/frontend/src/preload.test.ts
@@ -115,3 +115,11 @@ describe("preload uiSettings bridge", () => {
 		expect(electronMocks.invoke).toHaveBeenNthCalledWith(2, "uiSettings:set", { locale: "zh-CN" });
 	});
 });
+
+describe("preload notification badge bridge", () => {
+	it("forwards the badge count to the main process", async () => {
+		await exposedBridge().notifications.setBadgeCount(7);
+
+		expect(electronMocks.invoke).toHaveBeenCalledWith("notifications:setBadgeCount", 7);
+	});
+});

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -218,6 +218,7 @@ const api = {
 	notifications: {
 		show: (notification: { id: string; title: string; body?: string }) =>
 			ipcRenderer.invoke("notifications:show", notification) as Promise<void>,
+		setBadgeCount: (count: number) => ipcRenderer.invoke("notifications:setBadgeCount", count) as Promise<void>,
 		onClick: (listener: (id: string) => void) => {
 			const wrapped = (_event: Electron.IpcRendererEvent, id: string) => listener(id);
 			ipcRenderer.on("notifications:click", wrapped);

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -6,16 +6,25 @@ import type { NotificationDTO } from "../lib/notifications";
 import { useUiStore } from "../stores/ui-store";
 import { NotificationCenter, NotificationRuntime } from "./NotificationCenter";
 
-const { connectMock, fetchNextPageMock, markAllMock, markReadMock, navigateMock, notificationQueryMock, paramsMock } =
-	vi.hoisted(() => ({
-		connectMock: vi.fn(),
-		fetchNextPageMock: vi.fn(),
-		markAllMock: vi.fn(),
-		markReadMock: vi.fn(),
-		navigateMock: vi.fn(),
-		notificationQueryMock: vi.fn(),
-		paramsMock: vi.fn(),
-	}));
+const {
+	connectMock,
+	fetchNextPageMock,
+	markAllMock,
+	markReadMock,
+	navigateMock,
+	notificationQueryMock,
+	paramsMock,
+	setBadgeCountMock,
+} = vi.hoisted(() => ({
+	connectMock: vi.fn(),
+	fetchNextPageMock: vi.fn(),
+	markAllMock: vi.fn(),
+	markReadMock: vi.fn(),
+	navigateMock: vi.fn(),
+	notificationQueryMock: vi.fn(),
+	paramsMock: vi.fn(),
+	setBadgeCountMock: vi.fn(),
+}));
 
 const notifications: NotificationDTO[] = [
 	{
@@ -57,6 +66,15 @@ const notifications: NotificationDTO[] = [
 ];
 
 vi.mock("@tanstack/react-router", () => ({ useNavigate: () => navigateMock, useParams: () => paramsMock() }));
+
+vi.mock("../lib/bridge", () => ({
+	aoBridge: {
+		notifications: {
+			setBadgeCount: setBadgeCountMock,
+			onClick: () => () => undefined,
+		},
+	},
+}));
 
 vi.mock("../hooks/useNotificationsQuery", () => ({
 	useMarkAllNotificationsReadMutation: () => ({ isPending: false, mutateAsync: markAllMock }),
@@ -129,6 +147,7 @@ beforeEach(() => {
 	markReadMock.mockReset().mockResolvedValue(notifications[0]);
 	navigateMock.mockReset();
 	notificationQueryMock.mockReset().mockImplementation(notificationQueryResult);
+	setBadgeCountMock.mockReset().mockResolvedValue(undefined);
 	vi.spyOn(window, "open").mockImplementation(() => null);
 });
 
@@ -292,5 +311,12 @@ describe("NotificationCenter", () => {
 		await clickOpen();
 
 		expect(screen.getByText("The agent is waiting for your response.")).not.toHaveClass("line-clamp-2");
+	});
+
+	it("syncs the OS badge count with the unread notification count", async () => {
+		renderNotificationCenter();
+
+		await waitFor(() => expect(setBadgeCountMock).toHaveBeenCalledWith(2));
+		expect(setBadgeCountMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -133,6 +133,10 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 	const visibleNotifications = view === "unread" ? unread : all;
 	const { openPrimary, openSession } = useNotificationTargetNavigation();
 
+	useEffect(() => {
+		void aoBridge.notifications.setBadgeCount(unreadCount);
+	}, [unreadCount]);
+
 	const markOneRead = async (id: string) => {
 		setActionError(null);
 		void captureRendererEvent("ao.renderer.notification_mark_read_requested", { scope: "single" });

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -34,6 +34,8 @@ vi.mock("../lib/bridge", () => ({
 		},
 		notifications: {
 			show: (...args: unknown[]) => notificationShowMock(...args),
+			setBadgeCount: vi.fn(),
+			onClick: () => () => undefined,
 		},
 	},
 }));

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -129,6 +129,7 @@ export const aoBridge: AoBridge =
 		},
 		notifications: {
 			show: async () => undefined,
+			setBadgeCount: async () => undefined,
 			onClick: () => () => undefined,
 		},
 		appState: {

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -172,6 +172,7 @@ if (typeof window !== "undefined") {
 		},
 		notifications: {
 			show: async () => undefined,
+			setBadgeCount: async () => undefined,
 			onClick: () => () => undefined,
 		},
 		appState: {

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -107,6 +107,11 @@ vi.mock("../lib/bridge", () => ({
 			set: shellMocks.setKeybindings,
 			setRecording: shellMocks.setKeybindingRecording,
 		},
+		notifications: {
+			show: vi.fn(),
+			setBadgeCount: vi.fn(),
+			onClick: () => () => undefined,
+		},
 		window: {},
 	},
 }));


### PR DESCRIPTION
Fixes #3033.

## Summary

This PR addresses the two notification bugs reported in #3033:

1. **Notification titles included the session instance number** (e.g. `portfolio-10 needs input`). `sessionLabel()` in `backend/internal/notify/enrich.go` now falls back to `ProjectID` before `SessionID`, so the default title uses the clean project name while still respecting a user-set display name.

2. **The notification badge counter did not reset/read correctly across app restarts**. Added an OS-level badge that tracks the unread notification count, persists it next to `running.json`, restores it on launch, and updates it whenever the unread count changes (including on mark-read).

## Changes

- `backend/internal/notify/enrich.go`: prefer `ProjectID` over `SessionID` for the session label fallback.
- `backend/internal/notify/enrich_test.go`: tests for the new fallback behavior and title composition.
- `frontend/src/main/notification-badge.ts`: new module for setting the OS badge (`app.setBadgeCount` on macOS/Linux, `setOverlayIcon` on Windows) and persisting the count.
- `frontend/src/main/notification-badge.test.ts`: unit tests for persistence and platform-specific badge behavior.
- `frontend/src/main.ts`: restore badge count on startup and handle the `notifications:setBadgeCount` IPC.
- `frontend/src/preload.ts` + `bridge.ts`: expose `notifications.setBadgeCount` to the renderer.
- `frontend/src/renderer/components/NotificationCenter.tsx`: sync the badge count with the unread notification count.
- Tests updated for the new bridge shape in `NotificationCenter.test.tsx`, `SessionsBoard.test.tsx`, `shell-new-session-shortcut.test.tsx`, `preload.test.tsx`, and `setup.ts`.

## Verification

- `cd backend && go test ./internal/notify/... ./internal/service/notification/...` ✅ pass
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs internal/notify/...` ✅ pass
- `cd frontend && npm run typecheck` ✅ pass
- `cd frontend && npm run test` ✅ 1159 passed (one unrelated flaky run observed; passed on re-run)

## Known limitations

- The session instance counter in the durable session ID namespace is left unchanged. The issue notes this is by design; this PR only removes the instance number from notification titles and adds a separate notification badge counter.
- The backend CLI test suite has pre-existing failures (`internal/cli` spawn tests return HTTP 404) unrelated to these changes.
