### PR TITLE
feat: fetch GitHub stars and forks from the API

### DIFF
--- a/frontend/src/landing/src/app/components/GitHubStarCounter/GitHubStarCounter.tsx
+++ b/frontend/src/landing/src/app/components/GitHubStarCounter/GitHubStarCounter.tsx
@@ -1,59 +1,13 @@
 import { COMPANY } from "@ao/shared/constants";
-
-interface GitHubRepoResponse {
-	stargazers_count: number;
-}
-
-function getGitHubApiUrl(): string {
-	// Extract owner/repo from COMPANY.GITHUB_URL (e.g., "https://github.com/AgentWrapper/agent-orchestrator")
-	const match = COMPANY.GITHUB_URL.match(/github\.com\/([^/]+\/[^/]+)/);
-	if (!match) {
-		throw new Error("Invalid GitHub URL format");
-	}
-	return `https://api.github.com/repos/${match[1]}`;
-}
-
-async function getGitHubStars(): Promise<number | null> {
-	try {
-		const response = await fetch(getGitHubApiUrl(), {
-			headers: {
-				Accept: "application/vnd.github.v3+json",
-			},
-			next: {
-				revalidate: 3600, // Revalidate every hour
-			},
-		});
-
-		if (!response.ok) {
-			console.error(
-				"[marketing/GitHubStarCounter] Failed to fetch GitHub stars:",
-				response.status,
-			);
-			return null;
-		}
-
-		const data: GitHubRepoResponse = await response.json();
-		return data.stargazers_count;
-	} catch (error) {
-		console.error(
-			"[marketing/GitHubStarCounter] Error fetching GitHub stars:",
-			error,
-		);
-		return null;
-	}
-}
-
-function formatStarCount(count: number): string {
-	if (count >= 1000) {
-		return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
-	}
-	return count.toString();
-}
+import {
+	formatCompactCount,
+	getGitHubRepoStats,
+} from "@/lib/github-stats";
 
 export async function GitHubStarCounter() {
-	const stars = await getGitHubStars();
+	const stats = await getGitHubRepoStats();
 
-	if (stars === null) {
+	if (stats === null) {
 		return null;
 	}
 
@@ -63,7 +17,7 @@ export async function GitHubStarCounter() {
 			target="_blank"
 			rel="noopener noreferrer"
 			className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors p-1 sm:p-2"
-			aria-label={`${stars} GitHub stars`}
+			aria-label={`${stats.stars} GitHub stars`}
 		>
 			<svg
 				width="20"
@@ -76,7 +30,7 @@ export async function GitHubStarCounter() {
 				<path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
 			</svg>
 			<span className="text-sm font-normal tabular-nums">
-				{formatStarCount(stars)}
+				{formatCompactCount(stats.stars)}
 			</span>
 		</a>
 	);

--- a/frontend/src/landing/src/app/design-partners/page.tsx
+++ b/frontend/src/landing/src/app/design-partners/page.tsx
@@ -1,6 +1,11 @@
-import { COMPANY } from "@ao/shared/constants";
+import { AGENT_HARNESSES, COMPANY } from "@ao/shared/constants";
 import type { Metadata } from "next";
 import Image from "next/image";
+import {
+  formatStatPlus,
+  getGitHubRepoStats,
+  monthsSince,
+} from "@/lib/github-stats";
 import {
   RoadmapSlideshow,
   type RoadmapPhase,
@@ -13,6 +18,13 @@ const MAILTO_HREF = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
 )}&body=${encodeURIComponent(
   "Hi Prateek,\n\nWe're interested in the AO design partner program.\n\nCompany:\nEngineering team size:\nAgent harnesses we use today (Claude Code / Codex / Cursor / ...):\nWhat we want out of AO:\n",
 )}`;
+
+/** Shown only if the GitHub API request fails. */
+const FALLBACK_STATS = {
+  stars: 8400,
+  forks: 1200,
+  months: 5,
+} as const;
 
 export const metadata: Metadata = {
   title: "Design Partner Program - Agent Orchestrator",
@@ -28,13 +40,6 @@ export const metadata: Metadata = {
     canonical: `${COMPANY.MARKETING_URL}/design-partners`,
   },
 };
-
-const STATS = [
-  { value: "8,400+", label: "stars in 5 months" },
-  { value: "1,200+", label: "forks" },
-  { value: "23", label: "agent harnesses" },
-  { value: "Nightly", label: "desktop releases" },
-];
 
 const partnerGets = [
   {
@@ -177,7 +182,22 @@ function TextLink({
   );
 }
 
-export default function DesignPartnersPage() {
+export default async function DesignPartnersPage() {
+  const repo = await getGitHubRepoStats();
+  const stars = repo?.stars ?? FALLBACK_STATS.stars;
+  const forks = repo?.forks ?? FALLBACK_STATS.forks;
+  const months = repo ? monthsSince(repo.createdAt) : FALLBACK_STATS.months;
+
+  const stats = [
+    {
+      value: formatStatPlus(stars),
+      label: `stars in ${months} month${months === 1 ? "" : "s"}`,
+    },
+    { value: formatStatPlus(forks), label: "forks" },
+    { value: String(AGENT_HARNESSES), label: "agent harnesses" },
+    { value: "Nightly", label: "desktop releases" },
+  ];
+
   return (
     <main className="bg-background text-foreground">
       <section className="relative overflow-hidden px-4 pb-20 pt-24 sm:px-8 sm:pb-28 sm:pt-32 lg:px-[30px] lg:pt-36">
@@ -228,7 +248,7 @@ export default function DesignPartnersPage() {
           </div>
 
           <div className="mt-16 grid overflow-hidden rounded-xl border border-border sm:grid-cols-2 lg:grid-cols-4">
-            {STATS.map((stat) => (
+            {stats.map((stat) => (
               <div
                 key={stat.label}
                 className="border-b border-border px-6 py-5 sm:border-r sm:[&:nth-child(2n)]:border-r-0 lg:border-b-0 lg:[&:nth-child(2n)]:border-r lg:last:border-r-0"

--- a/frontend/src/landing/src/app/page.tsx
+++ b/frontend/src/landing/src/app/page.tsx
@@ -7,7 +7,7 @@ import {
   OrganizationJsonLd,
 } from "@/components/JsonLd";
 import { getGitHubRepoStats } from "@/lib/github-stats";
-import { FAQ_ITEMS } from "./components/FAQSection";
+import { FAQ_ITEMS } from "./components/FAQSection/constants";
 import { HeroSection } from "./components/HeroSection";
 
 const TrustedBySection = dynamic(() =>

--- a/frontend/src/landing/src/app/page.tsx
+++ b/frontend/src/landing/src/app/page.tsx
@@ -6,6 +6,7 @@ import {
   HomeWebPageJsonLd,
   OrganizationJsonLd,
 } from "@/components/JsonLd";
+import { getGitHubRepoStats } from "@/lib/github-stats";
 import { FAQ_ITEMS } from "./components/FAQSection";
 import { HeroSection } from "./components/HeroSection";
 
@@ -31,45 +32,15 @@ export const metadata: Metadata = {
   },
 };
 
-interface GitHubRepoResponse {
-  stargazers_count?: number;
-}
-
-function getGitHubApiUrl() {
-  const match = COMPANY.GITHUB_URL.match(/github\.com\/([^/]+\/[^/]+)/);
-  return match ? `https://api.github.com/repos/${match[1]}` : null;
-}
-
-async function getGitHubStars(): Promise<number | null> {
-  const apiUrl = getGitHubApiUrl();
-  if (!apiUrl) return null;
-
-  try {
-    const response = await fetch(apiUrl, {
-      headers: { Accept: "application/vnd.github.v3+json" },
-      next: { revalidate: 3600 },
-    });
-
-    if (!response.ok) return null;
-
-    const data = (await response.json()) as GitHubRepoResponse;
-    return typeof data.stargazers_count === "number"
-      ? data.stargazers_count
-      : null;
-  } catch {
-    return null;
-  }
-}
-
 export default async function Home() {
-  const stars = await getGitHubStars();
+  const stats = await getGitHubRepoStats();
 
   return (
     <main className="flex flex-col bg-background">
       <FAQPageJsonLd items={FAQ_ITEMS} />
       <HomeWebPageJsonLd />
       <OrganizationJsonLd />
-      <HeroSection initialStars={stars} />
+      <HeroSection initialStars={stats?.stars ?? null} />
       <TrustedBySection />
       <FeaturesSection />
       <VideoSection />

--- a/frontend/src/landing/src/lib/github-stats.ts
+++ b/frontend/src/landing/src/lib/github-stats.ts
@@ -1,0 +1,76 @@
+import { COMPANY, GITHUB_STARS_URL } from "@ao/shared/constants";
+
+export interface GitHubRepoStats {
+  stars: number;
+  forks: number;
+  createdAt: string | null;
+}
+
+interface GitHubRepoResponse {
+  stargazers_count?: number;
+  forks_count?: number;
+  created_at?: string;
+}
+
+function getGitHubApiUrl(): string | null {
+  if (GITHUB_STARS_URL) return GITHUB_STARS_URL;
+
+  const match = COMPANY.GITHUB_URL.match(/github\.com\/([^/]+\/[^/]+)/);
+  return match ? `https://api.github.com/repos/${match[1]}` : null;
+}
+
+/** Compact hero-style count: 8600 → "8.6k". */
+export function formatCompactCount(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  return count.toString();
+}
+
+/** Marketing stat style: 8642 → "8,600+". */
+export function formatStatPlus(count: number): string {
+  if (count >= 100) {
+    const rounded = Math.floor(count / 100) * 100;
+    return `${rounded.toLocaleString("en-US")}+`;
+  }
+  return count.toLocaleString("en-US");
+}
+
+/** Whole months since the repo was created (min 1). */
+export function monthsSince(createdAt: string | null, now = Date.now()): number {
+  if (!createdAt) return 1;
+  const created = Date.parse(createdAt);
+  if (Number.isNaN(created)) return 1;
+  const msPerMonth = 30.44 * 24 * 60 * 60 * 1000;
+  return Math.max(1, Math.round((now - created) / msPerMonth));
+}
+
+export async function getGitHubRepoStats(): Promise<GitHubRepoStats | null> {
+  const apiUrl = getGitHubApiUrl();
+  if (!apiUrl) return null;
+
+  try {
+    const response = await fetch(apiUrl, {
+      headers: { Accept: "application/vnd.github.v3+json" },
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as GitHubRepoResponse;
+    if (
+      typeof data.stargazers_count !== "number" ||
+      typeof data.forks_count !== "number"
+    ) {
+      return null;
+    }
+
+    return {
+      stars: data.stargazers_count,
+      forks: data.forks_count,
+      createdAt: typeof data.created_at === "string" ? data.created_at : null,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a shared `getGitHubRepoStats()` helper (hourly revalidation) for stars, forks, and repo age
- Wire the design partners page to live star/fork counts (with fallbacks if the API fails)
- Reuse the same helper for the hero “Star on GitHub” count

## Test plan
- [ ] Home hero shows a live star count (e.g. `8.6k`) next to “Star on GitHub”
- [ ] `/design-partners` shows live stars/forks instead of `8,400+` / `1,200+`
- [ ] “stars in N months” matches repo age from GitHub `created_at`
- [ ] With GitHub API blocked/failing, design partners still renders fallback stats