### PR TITLE
feat(web): show orchestrator activity on the board

### DIFF
--- a/frontend/src/renderer/components/OrchestratorActivityIndicator.tsx
+++ b/frontend/src/renderer/components/OrchestratorActivityIndicator.tsx
@@ -1,0 +1,16 @@
+import type { WorkspaceSession } from "../types/workspace";
+import { getAgentActivityView, getSessionDotView } from "../lib/session-presentation";
+import { cn } from "../lib/utils";
+
+export function OrchestratorActivityIndicator({ session }: { session: WorkspaceSession }) {
+	const activity = getAgentActivityView(session.activity);
+	const dot = getSessionDotView(session);
+
+	return (
+		<span
+			aria-label={`Orchestrator activity: ${activity.label}`}
+			className={cn("size-dot-sm shrink-0 rounded-full", dot.className)}
+			role="status"
+		/>
+	);
+}

--- a/frontend/src/renderer/components/OrchestratorActivityIndicator.tsx
+++ b/frontend/src/renderer/components/OrchestratorActivityIndicator.tsx
@@ -1,16 +1,9 @@
 import type { WorkspaceSession } from "../types/workspace";
-import { getAgentActivityView, getSessionDotView } from "../lib/session-presentation";
+import { getSessionDotView } from "../lib/session-presentation";
 import { cn } from "../lib/utils";
 
 export function OrchestratorActivityIndicator({ session }: { session: WorkspaceSession }) {
-	const activity = getAgentActivityView(session.activity);
 	const dot = getSessionDotView(session);
 
-	return (
-		<span
-			aria-label={`Orchestrator activity: ${activity.label}`}
-			className={cn("size-dot-sm shrink-0 rounded-full", dot.className)}
-			role="status"
-		/>
-	);
+	return <span aria-hidden="true" className={cn("size-dot-sm shrink-0 rounded-full", dot.className)} />;
 }

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -115,6 +115,46 @@ describe("SessionsBoard", () => {
 		expect(screen.getByRole("button", { name: "New task" })).toBeInTheDocument();
 	});
 
+	it.each([
+		["active", "Working", "bg-status-working", true],
+		["idle", "Idle", "bg-status-idle", false],
+	] as const)("shows %s orchestrator activity in the in-panel board toolbar", (state, label, tone, pulses) => {
+		boardActionsInPanelMock.mockReturnValue(true);
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "solkit-ui",
+					path: "/tmp/solkit-ui",
+					sessions: [
+						{
+							id: "orch-1",
+							workspaceId: "p1",
+							workspaceName: "solkit-ui",
+							title: "orchestrator",
+							provider: "codex",
+							kind: "orchestrator",
+							branch: "main",
+							status: "working",
+							activity: { state, lastActivityAt: "2026-01-01T00:00:00Z" },
+							updatedAt: "2026-01-01T00:00:00Z",
+							prs: [],
+						},
+					],
+				},
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+
+		const indicator = screen.getByRole("status", { name: `Orchestrator activity: ${label}` });
+		expect(indicator).toHaveClass(tone);
+		expect(indicator).toHaveClass(pulses ? "animate-status-pulse" : "size-dot-sm");
+		if (!pulses) expect(indicator).not.toHaveClass("animate-status-pulse");
+	});
+
 	it("shows the Board crumb on the root board when actions live in the panel", () => {
 		boardActionsInPanelMock.mockReturnValue(true);
 		workspaceQueryMock.mockReturnValue({

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -149,7 +149,9 @@ describe("SessionsBoard", () => {
 
 		renderBoard("p1");
 
-		const indicator = screen.getByRole("status", { name: `Orchestrator activity: ${label}` });
+		const button = screen.getByRole("button", { name: `Orchestrator, ${label}` });
+		const indicator = button.querySelector("span.size-dot-sm") as HTMLElement;
+		expect(indicator).toHaveAttribute("aria-hidden", "true");
 		expect(indicator).toHaveClass(tone);
 		expect(indicator).toHaveClass(pulses ? "animate-status-pulse" : "size-dot-sm");
 		if (!pulses) expect(indicator).not.toHaveClass("animate-status-pulse");

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -38,6 +38,7 @@ import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery
 import { NotificationCenter } from "./NotificationCenter";
 import { BoardWelcome, ProjectBoardEmpty } from "./BoardEmptyStates";
 import { OrchestratorIcon } from "./icons";
+import { OrchestratorActivityIndicator } from "./OrchestratorActivityIndicator";
 import { AgentAvatar } from "./AgentAvatar";
 import { TopbarButton, TopbarKillError, topbarProjectLabelClass } from "./TopbarButton";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
@@ -269,6 +270,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				variant="primary"
 			>
 				<OrchestratorIcon className="size-icon-md" aria-hidden="true" />
+				{orchestrator ? <OrchestratorActivityIndicator session={orchestrator} /> : null}
 				{isProjectRestarting
 					? "Restarting..."
 					: isSpawning

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -24,6 +24,7 @@ import {
 import {
 	attentionZone,
 	boardAttentionZoneOrder,
+	getAgentActivityView,
 	getAttentionZoneViewForZone,
 	getSessionStatusView,
 	isSessionIdle,
@@ -94,6 +95,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const boardLabel = workspace?.name ?? (projectId ? "" : "Board");
 	const sessions = workspaces.flatMap((w) => workerSessions(w.sessions));
 	const orchestrator = projectId ? newestActiveOrchestrator(workspaces[0]?.sessions ?? []) : undefined;
+	const orchestratorActivityLabel = orchestrator ? getAgentActivityView(orchestrator.activity).label : undefined;
 	const [isSpawning, setIsSpawning] = useState(false);
 	const [spawnError, setSpawnError] = useState<string | null>(null);
 	const restartingProjectIds = useUiStore((state) => state.restartingProjectIds);
@@ -264,7 +266,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				New task
 			</TopbarButton>
 			<TopbarButton
-				aria-label={orchestrator ? "Orchestrator" : "Spawn Orchestrator"}
+				aria-label={orchestratorActivityLabel ? `Orchestrator, ${orchestratorActivityLabel}` : "Spawn Orchestrator"}
 				disabled={isSpawning || isProjectRestarting}
 				onClick={() => void openOrchestrator()}
 				variant="primary"

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -198,6 +198,26 @@ describe("ShellTopbar status pill", () => {
 });
 
 describe("ShellTopbar orchestrator actions", () => {
+	it.each([
+		["active", "Working", "bg-status-working", true],
+		["waiting_input", "Input Needed", "bg-status-needs-you", false],
+	] as const)("shows %s orchestrator activity on the project board", (state, label, tone, pulses) => {
+		renderTopbarSessions(
+			[
+				{
+					...orchestrator,
+					activity: { state, lastActivityAt: "2026-06-10T00:00:00Z" },
+				},
+			],
+			"",
+		);
+
+		const indicator = screen.getByRole("status", { name: `Orchestrator activity: ${label}` });
+		expect(indicator).toHaveClass(tone);
+		expect(indicator).toHaveClass(pulses ? "animate-status-pulse" : "size-dot-sm");
+		if (!pulses) expect(indicator).not.toHaveClass("animate-status-pulse");
+	});
+
 	it("marks Kanban as the primary action on orchestrator sessions", () => {
 		renderTopbar(orchestrator);
 

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -212,7 +212,9 @@ describe("ShellTopbar orchestrator actions", () => {
 			"",
 		);
 
-		const indicator = screen.getByRole("status", { name: `Orchestrator activity: ${label}` });
+		const button = screen.getByRole("button", { name: `Orchestrator, ${label}` });
+		const indicator = button.querySelector("span.size-dot-sm") as HTMLElement;
+		expect(indicator).toHaveAttribute("aria-hidden", "true");
 		expect(indicator).toHaveClass(tone);
 		expect(indicator).toHaveClass(pulses ? "animate-status-pulse" : "size-dot-sm");
 		if (!pulses) expect(indicator).not.toHaveClass("animate-status-pulse");

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -71,6 +71,7 @@ export function ShellTopbar() {
 	const project = projectId ? all.find((workspace) => workspace.id === projectId) : undefined;
 	const projectLabel = project?.name ?? session?.workspaceName ?? (projectId ? "" : "Board");
 	const orchestrator = projectId ? findProjectOrchestrator(all, projectId) : undefined;
+	const orchestratorActivityLabel = orchestrator ? getAgentActivityView(orchestrator.activity).label : undefined;
 	const isProjectRestarting = projectId ? restartingProjectIds.has(projectId) : false;
 
 	const openBoard = () =>
@@ -186,7 +187,7 @@ export function ShellTopbar() {
 							New task
 						</TopbarButton>
 						<TopbarButton
-							aria-label={orchestrator ? "Orchestrator" : "Spawn Orchestrator"}
+							aria-label={orchestratorActivityLabel ? `Orchestrator, ${orchestratorActivityLabel}` : "Spawn Orchestrator"}
 							disabled={isSpawning || isProjectRestarting}
 							onClick={() => void openOrchestrator()}
 							style={noDragStyle}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -17,6 +17,7 @@ import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
 import { useUiStore } from "../stores/ui-store";
 import { OrchestratorIcon } from "./icons";
+import { OrchestratorActivityIndicator } from "./OrchestratorActivityIndicator";
 import { getAgentActivityView } from "../lib/session-presentation";
 import { isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { StatusPill } from "./StatusPill";
@@ -192,6 +193,7 @@ export function ShellTopbar() {
 							variant="primary"
 						>
 							<OrchestratorIcon className="size-icon-lg" aria-hidden="true" />
+							{orchestrator ? <OrchestratorActivityIndicator session={orchestrator} /> : null}
 							{isProjectRestarting
 								? "Restarting…"
 								: isSpawning


### PR DESCRIPTION
Closes #3141

## What

- Shows the running orchestrator's activity beside the board toolbar action.
- Reuses the same activity colors and pulse behavior as worker sessions.
- Covers both the in-panel board toolbar and the shell topbar layouts.

## Why

The orchestrator is intentionally excluded from worker cards, so the project board had no quick way to tell whether it was working, idle, or waiting for input.

## Before

<img width="1280" height="720" alt="Before: orchestrator button without activity indicator" src="https://github.com/user-attachments/assets/43258c52-fce6-4951-943b-24519a882ee0" />

## After

<img width="1280" height="720" alt="After: orchestrator button with working activity indicator" src="https://github.com/user-attachments/assets/fb051805-0d23-4b89-837c-bf720f1c3e89" />

## Testing

- `npm --prefix frontend test -- --run src/renderer/components/SessionsBoard.test.tsx src/renderer/components/ShellTopbar.test.tsx` — 54 passed after rebasing onto latest `main`
- `npm run frontend:typecheck`
- `npm --prefix frontend run typecheck:e2e`
- Full frontend suite — 1,153 passed
- Renderer smoke — 20 passed

## Checklist

- [x] Branched from latest `main`
- [x] One focused change linked to the issue
- [x] Tests cover both toolbar layouts and active/non-active activity states
- [x] Relevant frontend checks pass