### PR TITLE
Show the keyboard shortcut editor above its backdrop

### DIFF
--- a/frontend/src/renderer/components/settings/KeyboardShortcutsSettingsDialog.tsx
+++ b/frontend/src/renderer/components/settings/KeyboardShortcutsSettingsDialog.tsx
@@ -296,7 +296,7 @@ export function KeyboardShortcutsSettingsDialog({
 				}}
 			>
 				<DialogContent
-					className={cn(settingsDialogContentClass, "relative w-[min(760px,calc(100vw-var(--space-8)))]")}
+					className={cn(settingsDialogContentClass, "w-[min(760px,calc(100vw-var(--space-8)))]")}
 					onEscapeKeyDown={(event) => {
 						if (recording) {
 							event.preventDefault();


### PR DESCRIPTION
## Issue

Opening the keyboard shortcut editor displayed only the blurred backdrop because its `relative` class replaced the shared dialog’s `fixed` positioning.
This was a small issue missed by me in #3157.

## Fix

Remove the conflicting positioning class so the editor remains centered and visible.

## Validation

- Manual testing passed