### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "agent-orchestrator",
 	"productName": "Agent Orchestrator",
-	"version": "0.10.3",
+	"version": "0.11.0",
 	"private": true,
 	"description": "Electron + TypeScript frontend for the agent-orchestrator rewrite",
 	"author": "Agent Orchestrator",


### PR DESCRIPTION
Bumps `frontend/package.json` to `0.11.0`, following the stable cut of [v0.11.0](https://github.com/AgentWrapper/agent-orchestrator/releases/tag/v0.11.0).

## Scope

Only `frontend/package.json` carries the app version. Every other `0.10.3` occurrence in the tree is a test fixture, doc prose, or a comment, and none of them should track the release:

- `frontend/scripts/nightly-version.test.mjs` fixtures
- `frontend/src/renderer/lib/build-channel.test.ts` fixtures
- `frontend/src/main/escalation-evaluator.ts` comment and its test fixture
- `frontend/docs/desktop-release.md` prose

The `frontend/src/landing/*` and `frontend/src/docs` sub-packages are private workspace packages pinned at `0.1.0`, unrelated to the app version.

## Release context

`v0.11.0` was cut from `a10c98c8`, signed and notarized, and published as `releases/latest`. The Homebrew cask was bumped to 0.11.0 with the signed zip hashes, and a `desktop-v0.11.0` tag was created so the nightly channel rolls to `0.11.1-nightly.*` rather than staying below stable.

## Tests

No behavior change. Version-derived logic is covered by the existing `nightly-version` and `build-channel` suites, which use their own fixtures rather than reading `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)