### PR TITLE
feat: add daemon startup loader

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -87,6 +87,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					getStatus: async () => status,
 					start: async () => status,
 					stop: async () => ({ state: "stopped" }),
+					restart: async () => status,
 					onStatus: (listener: (s: typeof status) => void) => {
 						listener(status);
 						return unsubscribe();
@@ -448,6 +449,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					getStatus: async () => status,
 					start: async () => status,
 					stop: async () => ({ state: "stopped" }),
+					restart: async () => status,
 					onStatus: (listener: (s: typeof status) => void) => {
 						listener(status);
 						return unsubscribe();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -389,6 +389,7 @@ function createWindow(): void {
 // this window is reported with its captured output instead of being treated as
 // ready on an assumed port.
 const PORT_DISCOVERY_TIMEOUT_MS = 30_000;
+const DAEMON_RESTART_STOP_TIMEOUT_MS = 5_000;
 const RUN_FILE_POLL_MS = 300;
 // Accept run-files stamped slightly before our spawn timestamp: the daemon's
 // clock reading and ours race within normal scheduling jitter.
@@ -1102,9 +1103,41 @@ function stopDaemon(): DaemonStatus {
 	return daemonStatus;
 }
 
+async function restartDaemon(): Promise<DaemonStatus> {
+	const child = daemonProcess;
+	if (!child) return startDaemon();
+
+	const exited = new Promise<boolean>((resolve) => {
+		let settled = false;
+		const finish = (didExit: boolean) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			child.off("exit", onExit);
+			resolve(didExit);
+		};
+		const onExit = () => finish(true);
+		const timer = setTimeout(() => finish(false), DAEMON_RESTART_STOP_TIMEOUT_MS);
+		child.once("exit", onExit);
+	});
+
+	stopDaemon();
+	if (!(await exited)) {
+		setDaemonStatus({
+			state: "error",
+			message: "AO daemon did not stop within 5 seconds, so the restart was cancelled.",
+			details: daemonOutput.trim() || undefined,
+			code: "not_ready",
+		});
+		return daemonStatus;
+	}
+	return startDaemon();
+}
+
 ipcMain.handle("daemon:getStatus", () => refreshDaemonStatus());
 ipcMain.handle("daemon:start", () => startDaemon());
 ipcMain.handle("daemon:stop", () => stopDaemon());
+ipcMain.handle("daemon:restart", () => restartDaemon());
 ipcMain.handle("app:getVersion", () => app.getVersion());
 ipcMain.handle("app:openExternal", async (_event, url: string) => {
 	await openAllowedAppExternalURL(url, shell);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -101,6 +101,7 @@ app.setPath("userData", path.join(os.homedir(), ".ao", "electron"));
 let mainWindow: BrowserWindow | null = null;
 let daemonProcess: ChildProcess | null = null;
 let daemonStoppingProcess: ChildProcess | null = null;
+let daemonRestartAfterExitProcess: ChildProcess | null = null;
 let daemonStartPromise: Promise<DaemonStatus> | null = null;
 let daemonStartEpoch = 0;
 let daemonStatus: DaemonStatus = { state: "stopped" };
@@ -1013,7 +1014,10 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	// attempting workspace requests against an assumed port.
 	fallbackTimer = setTimeout(() => {
 		if (portConfirmed || daemonProcess !== child || daemonStoppingProcess === child) return;
-		stopDiscovery();
+		// Keep running.json polling alive after surfacing the timeout. In
+		// keep-daemon mode there are no stdout/stderr scanners, so the run file is
+		// the only way a slow-but-successful boot can still recover to ready.
+		fallbackTimer = undefined;
 		setDaemonStatus({
 			state: "error",
 			message: "AO daemon did not finish starting within 30 seconds.",
@@ -1055,6 +1059,11 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		// failures. Preserve the clean stopped status instead.
 		if (daemonStoppingProcess === child) {
 			daemonStoppingProcess = null;
+			if (daemonRestartAfterExitProcess === child) {
+				daemonRestartAfterExitProcess = null;
+				void startDaemonForRestart();
+				return;
+			}
 			setDaemonStatus({ state: "stopped" });
 			return;
 		}
@@ -1087,6 +1096,9 @@ function killDaemon(child: ChildProcess): void {
 function stopDaemon(): DaemonStatus {
 	daemonStartEpoch += 1;
 	daemonStartPromise = null;
+	// An explicit stop (or a newer restart request) cancels any deferred restart
+	// left waiting for a previously slow child to exit.
+	daemonRestartAfterExitProcess = null;
 	if (!daemonProcess) {
 		setDaemonStatus({ state: "stopped" });
 		return daemonStatus;
@@ -1103,9 +1115,27 @@ function stopDaemon(): DaemonStatus {
 	return daemonStatus;
 }
 
+function reportDaemonRestartFailure(error: unknown): DaemonStatus {
+	setDaemonStatus({
+		state: "error",
+		message: `Could not restart the AO daemon: ${error instanceof Error ? error.message : String(error)}`,
+		details: daemonOutput.trim() || undefined,
+		code: "spawn_failed",
+	});
+	return daemonStatus;
+}
+
+async function startDaemonForRestart(): Promise<DaemonStatus> {
+	try {
+		return await startDaemon();
+	} catch (error) {
+		return reportDaemonRestartFailure(error);
+	}
+}
+
 async function restartDaemon(): Promise<DaemonStatus> {
 	const child = daemonProcess;
-	if (!child) return startDaemon();
+	if (!child) return startDaemonForRestart();
 
 	const exited = new Promise<boolean>((resolve) => {
 		let settled = false;
@@ -1122,22 +1152,35 @@ async function restartDaemon(): Promise<DaemonStatus> {
 	});
 
 	stopDaemon();
+	// Register the deferred intent immediately after signaling the child. The
+	// exit can race the five-second UI timeout, so waiting until after the
+	// timeout to set this would occasionally miss the only exit event.
+	daemonRestartAfterExitProcess = child;
 	if (!(await exited)) {
+		// The process may still honor SIGTERM after the UI timeout. Keep the
+		// restart intent attached to that exact child so its eventual exit starts
+		// a replacement instead of collapsing back to a code-less stopped state.
 		setDaemonStatus({
 			state: "error",
-			message: "AO daemon did not stop within 5 seconds, so the restart was cancelled.",
+			message: "AO daemon is still stopping. It will restart automatically when shutdown completes.",
 			details: daemonOutput.trim() || undefined,
 			code: "not_ready",
 		});
 		return daemonStatus;
 	}
-	return startDaemon();
+	return startDaemonForRestart();
 }
 
 ipcMain.handle("daemon:getStatus", () => refreshDaemonStatus());
 ipcMain.handle("daemon:start", () => startDaemon());
 ipcMain.handle("daemon:stop", () => stopDaemon());
-ipcMain.handle("daemon:restart", () => restartDaemon());
+ipcMain.handle("daemon:restart", async () => {
+	try {
+		return await restartDaemon();
+	} catch (error) {
+		return reportDaemonRestartFailure(error);
+	}
+});
 ipcMain.handle("app:getVersion", () => app.getVersion());
 ipcMain.handle("app:openExternal", async (_event, url: string) => {
 	await openAllowedAppExternalURL(url, shell);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -385,9 +385,10 @@ function createWindow(): void {
 }
 
 // How long the supervisor waits for the daemon to confirm its bound port (via
-// the listen log line or running.json) before reporting the configured port as
-// a best-effort fallback.
-const PORT_DISCOVERY_TIMEOUT_MS = 15_000;
+// the listen log line or running.json). A daemon that cannot confirm startup in
+// this window is reported with its captured output instead of being treated as
+// ready on an assumed port.
+const PORT_DISCOVERY_TIMEOUT_MS = 30_000;
 const RUN_FILE_POLL_MS = 300;
 // Accept run-files stamped slightly before our spawn timestamp: the daemon's
 // clock reading and ours race within normal scheduling jitter.
@@ -1006,16 +1007,26 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		}, RUN_FILE_POLL_MS);
 	}
 
-	// Last resort: neither source confirmed (e.g. an older daemon build). Report
-	// the configured port so the renderer is not stuck on "starting" forever.
+	// Neither source confirmed startup. Surface the captured process output so
+	// the renderer can explain why boot stalled instead of spinning forever or
+	// attempting workspace requests against an assumed port.
 	fallbackTimer = setTimeout(() => {
 		if (portConfirmed || daemonProcess !== child || daemonStoppingProcess === child) return;
 		stopDiscovery();
 		setDaemonStatus({
-			state: "ready",
-			port: resolvedDaemonPort(),
-			message: "Daemon port not confirmed from logs or running.json; assuming the configured port.",
-			code: "port_unconfirmed",
+			state: "error",
+			message: "AO daemon did not finish starting within 30 seconds.",
+			details:
+				daemonOutput.trim() ||
+				[
+					"No startup output was captured.",
+					`Executable: ${launch.command}`,
+					`Working directory: ${launch.cwd}`,
+					`Expected port confirmation from: ${handshakePath ?? "running.json"}`,
+				].join("\n"),
+			code: "not_ready",
+			executablePath: launch.command,
+			workingDirectory: launch.cwd,
 		});
 	}, PORT_DISCOVERY_TIMEOUT_MS);
 

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -138,6 +138,7 @@ const api = {
 		getStatus: () => ipcRenderer.invoke("daemon:getStatus") as Promise<DaemonStatus>,
 		start: () => ipcRenderer.invoke("daemon:start") as Promise<DaemonStatus>,
 		stop: () => ipcRenderer.invoke("daemon:stop") as Promise<DaemonStatus>,
+		restart: () => ipcRenderer.invoke("daemon:restart") as Promise<DaemonStatus>,
 		onStatus: (listener: (status: DaemonStatus) => void) => {
 			const wrapped = (_event: Electron.IpcRendererEvent, status: DaemonStatus) => listener(status);
 			ipcRenderer.on("daemon:status", wrapped);

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -90,6 +90,7 @@ function renderBoard(ui: ReactNode) {
 	lastQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	lastShell = {
 		daemonStatus: { state: "ready" } as ShellContextValue["daemonStatus"],
+		workspaceStartupState: "ready",
 		createProject: createProjectMock,
 		initializeProjectRepository: initializeProjectRepositoryMock,
 	};
@@ -115,6 +116,29 @@ beforeEach(() => {
 });
 
 describe("global board first launch", () => {
+	it("shows the startup loader instead of import while the daemon is booting", async () => {
+		respondWith([], []);
+		lastQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		lastShell = {
+			daemonStatus: { state: "starting" } as ShellContextValue["daemonStatus"],
+			workspaceStartupState: "loading",
+			createProject: createProjectMock,
+			initializeProjectRepository: initializeProjectRepositoryMock,
+		};
+		render(
+			<QueryClientProvider client={lastQueryClient}>
+				<ShellProvider value={lastShell}>
+					<SessionsBoard />
+				</ShellProvider>
+			</QueryClientProvider>,
+		);
+
+		expect(await screen.findByTestId("daemon-startup-loader")).toBeInTheDocument();
+		expect(screen.getByText("Agent Orchestrator")).toBeInTheDocument();
+		expect(screen.queryByText("Import to Agent Orchestrator")).not.toBeInTheDocument();
+		expect(columnCount()).toBe(0);
+	});
+
 	it("shows the import chooser instead of empty columns when no projects exist", async () => {
 		respondWith([], []);
 		renderBoard(<SessionsBoard />);

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -133,7 +133,7 @@ describe("global board first launch", () => {
 			</QueryClientProvider>,
 		);
 
-		expect(await screen.findByTestId("daemon-startup-loader")).toBeInTheDocument();
+		expect(await screen.findByTestId("daemon-startup-loader")).toHaveClass("ao-startup-screen");
 		expect(screen.getByText("Agent Orchestrator")).toBeInTheDocument();
 		expect(screen.queryByText("Import to Agent Orchestrator")).not.toBeInTheDocument();
 		expect(columnCount()).toBe(0);

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -134,7 +134,9 @@ describe("global board first launch", () => {
 		);
 
 		expect(await screen.findByTestId("daemon-startup-loader")).toHaveClass("ao-startup-screen");
+		expect(screen.getByRole("status", { name: "Agent Orchestrator is starting" })).toBeInTheDocument();
 		expect(screen.getByText("Agent Orchestrator")).toBeInTheDocument();
+		expect(screen.getByText("Starting local services")).toHaveAttribute("aria-hidden", "true");
 		expect(screen.queryByText("Import to Agent Orchestrator")).not.toBeInTheDocument();
 		expect(columnCount()).toBe(0);
 	});
@@ -188,6 +190,28 @@ describe("global board first launch", () => {
 
 		expect(await screen.findByText("fix the bug")).toBeInTheDocument();
 		expect(screen.queryByText("Import to Agent Orchestrator")).not.toBeInTheDocument();
+		expect(columnCount()).toBe(4);
+	});
+
+	it("keeps populated columns visible after the daemon reports a startup failure", async () => {
+		respondWith([project], [workerSession]);
+		lastQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		lastShell = {
+			daemonStatus: { state: "stopped", code: "exited" } as ShellContextValue["daemonStatus"],
+			workspaceStartupState: "loading",
+			createProject: createProjectMock,
+			initializeProjectRepository: initializeProjectRepositoryMock,
+		};
+		render(
+			<QueryClientProvider client={lastQueryClient}>
+				<ShellProvider value={lastShell}>
+					<SessionsBoard />
+				</ShellProvider>
+			</QueryClientProvider>,
+		);
+
+		expect(await screen.findByText("fix the bug")).toBeInTheDocument();
+		expect(screen.queryByTestId("daemon-startup-loader")).not.toBeInTheDocument();
 		expect(columnCount()).toBe(4);
 	});
 });

--- a/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
@@ -1,9 +1,13 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { aoBridge } from "../lib/bridge";
 import { DaemonFailureBanner } from "./DaemonFailureBanner";
 
 describe("DaemonFailureBanner", () => {
-	afterEach(() => vi.useRealTimers());
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
 
 	it("shows the daemon failure message, code, and actionable hint", () => {
 		render(
@@ -57,5 +61,31 @@ describe("DaemonFailureBanner", () => {
 		const { container } = render(<DaemonFailureBanner status={{ state: "starting" }} />);
 
 		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("restarts a daemon that timed out during startup", async () => {
+		const restart = vi.spyOn(aoBridge.daemon, "restart").mockResolvedValue({ state: "starting" });
+		render(
+			<DaemonFailureBanner
+				status={{
+					state: "error",
+					code: "not_ready",
+					message: "AO daemon did not finish starting within 30 seconds.",
+				}}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Restart daemon" }));
+
+		await waitFor(() => expect(restart).toHaveBeenCalledTimes(1));
+	});
+
+	it("shows a restart failure inline", async () => {
+		vi.spyOn(aoBridge.daemon, "restart").mockRejectedValue(new Error("Daemon did not stop"));
+		render(<DaemonFailureBanner status={{ state: "error", code: "not_ready" }} />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Restart daemon" }));
+
+		expect(await screen.findByText("Daemon did not stop")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
@@ -24,6 +24,7 @@ describe("DaemonFailureBanner", () => {
 		expect(screen.getByRole("alert")).toHaveTextContent("AO daemon failed to start");
 		expect(screen.getByRole("alert")).toHaveTextContent("AO daemon exited with code 1");
 		expect(screen.getByText("exited")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Restart daemon" })).toBeInTheDocument();
 		fireEvent.click(screen.getByRole("button", { name: "Show details" }));
 		expect(screen.getByText("go: go.mod requires go >= 1.25.7")).toBeInTheDocument();
 	});

--- a/frontend/src/renderer/components/DaemonFailureBanner.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.tsx
@@ -18,6 +18,11 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 	const details = status.details?.trim();
 	const hint = daemonFailureHint(status);
 	const title = daemonFailureTitle(status);
+	const canRestart =
+		status.code === "not_ready" ||
+		status.code === "spawn_failed" ||
+		status.code === "exited" ||
+		status.code === "daemon_unreachable";
 	useEffect(() => {
 		setCopied(false);
 		return () => {
@@ -65,7 +70,7 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 					<p className="font-medium text-(--color-text-import-title)">{title}</p>
 					<p className="mt-0.5 wrap-break-word text-[var(--color-text-import-muted)]">{daemonFailureMessage(status)}</p>
 					{hint ? <p className="mt-1 text-[var(--color-text-import-muted)]">{hint}</p> : null}
-					{status.code === "not_ready" ? (
+					{canRestart ? (
 						<button
 							type="button"
 							className="mt-2 inline-flex h-control-md items-center rounded-md bg-accent-strong px-3 font-semibold text-accent-foreground transition-[filter,opacity] hover:brightness-110 disabled:cursor-wait disabled:opacity-60"

--- a/frontend/src/renderer/components/DaemonFailureBanner.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.tsx
@@ -12,6 +12,8 @@ export function DaemonFailureBanner({ status }: { status: DaemonStatus }) {
 function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 	const [detailsOpen, setDetailsOpen] = useState(false);
 	const [copied, setCopied] = useState(false);
+	const [restarting, setRestarting] = useState(false);
+	const [restartError, setRestartError] = useState<string | null>(null);
 	const copiedTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const details = status.details?.trim();
 	const hint = daemonFailureHint(status);
@@ -37,6 +39,20 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 			copiedTimeout.current = null;
 		}, 2_000);
 	};
+	const restartDaemon = async () => {
+		setRestarting(true);
+		setRestartError(null);
+		try {
+			const nextStatus = await aoBridge.daemon.restart();
+			if (nextStatus.state === "error" || nextStatus.state === "stopped") {
+				setRestartError(daemonFailureMessage(nextStatus));
+			}
+		} catch (error) {
+			setRestartError(error instanceof Error ? error.message : "Could not restart the AO daemon.");
+		} finally {
+			setRestarting(false);
+		}
+	};
 	return (
 		<section
 			aria-live="assertive"
@@ -49,6 +65,17 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 					<p className="font-medium text-(--color-text-import-title)">{title}</p>
 					<p className="mt-0.5 wrap-break-word text-[var(--color-text-import-muted)]">{daemonFailureMessage(status)}</p>
 					{hint ? <p className="mt-1 text-[var(--color-text-import-muted)]">{hint}</p> : null}
+					{status.code === "not_ready" ? (
+						<button
+							type="button"
+							className="mt-2 inline-flex h-control-md items-center rounded-md bg-accent-strong px-3 font-semibold text-accent-foreground transition-[filter,opacity] hover:brightness-110 disabled:cursor-wait disabled:opacity-60"
+							disabled={restarting}
+							onClick={() => void restartDaemon()}
+						>
+							{restarting ? "Restarting…" : "Restart daemon"}
+						</button>
+					) : null}
+					{restartError ? <p className="mt-2 text-error">{restartError}</p> : null}
 					{details ? (
 						<div className="mt-2 flex items-center gap-3">
 							<button

--- a/frontend/src/renderer/components/DaemonStartupLoader.tsx
+++ b/frontend/src/renderer/components/DaemonStartupLoader.tsx
@@ -35,9 +35,9 @@ export function DaemonStartupLoader() {
 				<div className="grid h-28 w-32 place-items-center" aria-hidden="true">
 					<img className="ao-startup-logo h-22 w-25 object-contain" src={aoLogo} alt="" />
 				</div>
-				<p className="mt-5 text-md font-semibold tracking-tight text-foreground">Agent Orchestrator</p>
+				<p className="mt-5 text-base font-semibold tracking-tight text-foreground">Agent Orchestrator</p>
 				<p className="mt-2 min-h-5 text-md-sm text-muted-foreground">
-					<span className="ao-startup-status" key={phrase}>
+					<span aria-hidden="true" className="ao-startup-status" key={phrase}>
 						{phrase}
 					</span>
 				</p>

--- a/frontend/src/renderer/components/DaemonStartupLoader.tsx
+++ b/frontend/src/renderer/components/DaemonStartupLoader.tsx
@@ -27,7 +27,7 @@ export function DaemonStartupLoader() {
 			aria-busy="true"
 			aria-label="Agent Orchestrator is starting"
 			aria-live="polite"
-			className="flex h-full min-h-0 items-center justify-center bg-background text-foreground"
+			className="ao-startup-screen flex items-center justify-center bg-background text-foreground"
 			data-testid="daemon-startup-loader"
 			role="status"
 		>

--- a/frontend/src/renderer/components/DaemonStartupLoader.tsx
+++ b/frontend/src/renderer/components/DaemonStartupLoader.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import aoLogo from "../../../assets/ao-logo.svg";
+
+const STARTUP_PHRASES = [
+	"Starting local services",
+	"Connecting to the daemon",
+	"Loading workspaces",
+	"Preparing your board",
+] as const;
+
+const PHRASE_INTERVAL_MS = 2_200;
+
+export function DaemonStartupLoader() {
+	const [phraseIndex, setPhraseIndex] = useState(0);
+
+	useEffect(() => {
+		const timer = window.setInterval(() => {
+			setPhraseIndex((current) => (current + 1) % STARTUP_PHRASES.length);
+		}, PHRASE_INTERVAL_MS);
+		return () => window.clearInterval(timer);
+	}, []);
+
+	const phrase = STARTUP_PHRASES[phraseIndex];
+
+	return (
+		<div
+			aria-busy="true"
+			aria-label="Agent Orchestrator is starting"
+			aria-live="polite"
+			className="flex h-full min-h-0 items-center justify-center bg-background text-foreground"
+			data-testid="daemon-startup-loader"
+			role="status"
+		>
+			<div className="ao-startup-content flex -translate-y-[3vh] flex-col items-center text-center">
+				<div className="grid h-28 w-32 place-items-center" aria-hidden="true">
+					<img className="ao-startup-logo h-22 w-25 object-contain" src={aoLogo} alt="" />
+				</div>
+				<p className="mt-5 text-md font-semibold tracking-tight text-foreground">Agent Orchestrator</p>
+				<p className="mt-2 min-h-5 text-md-sm text-muted-foreground">
+					<span className="ao-startup-status" key={phrase}>
+						{phrase}
+					</span>
+				</p>
+				<div className="ao-startup-dots mt-3 flex h-4 items-center gap-1.5" aria-hidden="true">
+					<span />
+					<span />
+					<span />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/DaemonStartupLoader.tsx
+++ b/frontend/src/renderer/components/DaemonStartupLoader.tsx
@@ -27,7 +27,7 @@ export function DaemonStartupLoader() {
 			aria-busy="true"
 			aria-label="Agent Orchestrator is starting"
 			aria-live="polite"
-			className="ao-startup-screen flex items-center justify-center bg-background text-foreground"
+			className="ao-startup-screen flex h-full w-full items-center justify-center bg-background text-foreground"
 			data-testid="daemon-startup-loader"
 			role="status"
 		>

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -34,7 +34,7 @@ import {
 import { useSessionScmSummary, type SessionPRSummary } from "../hooks/useSessionScmSummary";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useTerminateSession } from "../hooks/useTerminateSession";
-import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { usesPreviewWorkspaceData, useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { NotificationCenter } from "./NotificationCenter";
 import { BoardWelcome, ProjectBoardEmpty } from "./BoardEmptyStates";
 import { OrchestratorIcon } from "./icons";
@@ -138,7 +138,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	// query has resolved, so the welcome never flashes over real data): the
 	// global board teaches the app before any project exists, and a fresh
 	// project board invites the first task instead of showing four zeros.
-	const isDaemonReady = shell ? shell.daemonStatus.state === "ready" : true;
+	const isDaemonReady = usesPreviewWorkspaceData || (shell ? shell.daemonStatus.state === "ready" : true);
 	const workspaceStartupState = shell?.workspaceStartupState ?? "ready";
 	const isLoaded = isDaemonReady && workspaceStartupState === "ready" && workspaceQuery.isSuccess;
 	const showStartup =

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -51,6 +51,8 @@ import { useUiStore } from "../stores/ui-store";
 import { RestoreUnavailableDialog } from "./RestoreUnavailableDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { SessionTerminationDialog } from "./SessionTerminationDialog";
+import { DaemonStartupLoader } from "./DaemonStartupLoader";
+import { useShellMaybe } from "../lib/shell-context";
 
 type SessionsBoardProps = {
 	/** When set, the board shows only this project's sessions. */
@@ -82,6 +84,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const queryClient = useQueryClient();
 	const restoreSessionById = useRestoreSession();
 	const workspaceQuery = useWorkspaceQuery();
+	const shell = useShellMaybe();
 	// Evaluated at render so platform mocks in tests can flip the in-panel chrome.
 	const boardActionsInPanel = usesBoardActionsInPanel();
 	/** Bell lives in the board action row when the shell topbar does not host it. */
@@ -135,7 +138,12 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	// query has resolved, so the welcome never flashes over real data): the
 	// global board teaches the app before any project exists, and a fresh
 	// project board invites the first task instead of showing four zeros.
-	const isLoaded = workspaceQuery.isSuccess;
+	const isDaemonReady = shell ? shell.daemonStatus.state === "ready" : true;
+	const workspaceStartupState = shell?.workspaceStartupState ?? "ready";
+	const isLoaded = isDaemonReady && workspaceStartupState === "ready" && workspaceQuery.isSuccess;
+	const showStartup =
+		shell !== null &&
+		(!isDaemonReady || workspaceStartupState === "loading" || (!workspaceQuery.isSuccess && !workspaceQuery.isError));
 	const showWelcome = !projectId && isLoaded && all.length === 0;
 	const showProjectEmpty = projectId !== undefined && isLoaded && workspaces.length > 0 && sessions.length === 0;
 	// Archived sessions cost one quiet line under the board until expanded.
@@ -289,7 +297,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			    Win/Linux keep the crumb and actions in the framed ShellTopbar.
 			    Welcome skips the row — a dangling "Board" above the import
 			    chooser was review feedback on #2432. */}
-			{!showWelcome && boardActionsInPanel && (boardLabel || actions) ? (
+			{!showWelcome && !showStartup && boardActionsInPanel && (boardLabel || actions) ? (
 				<div
 					className="center-panel-titlebar flex h-toolbar shrink-0 items-center gap-2 border-b border-border-strong pr-4.5"
 					style={dragStyle}
@@ -317,7 +325,9 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						) : null}
 					</div>
 				) : null}
-				{workspaceQuery.isError ? (
+				{showStartup ? (
+					<DaemonStartupLoader />
+				) : workspaceStartupState === "error" || workspaceQuery.isError ? (
 					<p className="py-10 text-center text-xs text-passive">Could not load sessions.</p>
 				) : showWelcome ? (
 					<BoardWelcome />

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -140,10 +140,12 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	// global board teaches the app before any project exists, and a fresh
 	// project board invites the first task instead of showing four zeros.
 	const isDaemonReady = usesPreviewWorkspaceData || (shell ? shell.daemonStatus.state === "ready" : true);
+	const daemonHasFailed = Boolean(shell?.daemonStatus.code);
 	const workspaceStartupState = shell?.workspaceStartupState ?? "ready";
 	const isLoaded = isDaemonReady && workspaceStartupState === "ready" && workspaceQuery.isSuccess;
 	const showStartup =
 		shell !== null &&
+		!daemonHasFailed &&
 		(!isDaemonReady || workspaceStartupState === "loading" || (!workspaceQuery.isSuccess && !workspaceQuery.isError));
 	const showWelcome = !projectId && isLoaded && all.length === 0;
 	const showProjectEmpty = projectId !== undefined && isLoaded && workspaces.length > 0 && sessions.length === 0;

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -34,7 +34,7 @@ import {
 import { useSessionScmSummary, type SessionPRSummary } from "../hooks/useSessionScmSummary";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useTerminateSession } from "../hooks/useTerminateSession";
-import { usesPreviewWorkspaceData, useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { NotificationCenter } from "./NotificationCenter";
 import { BoardWelcome, ProjectBoardEmpty } from "./BoardEmptyStates";
 import { OrchestratorIcon } from "./icons";
@@ -45,6 +45,7 @@ import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { prBrowserUrl, sessionPRDisplaySummaries } from "../lib/pr-display";
 import { formatTimeCompact } from "../lib/format-time";
 import { aoBridge } from "../lib/bridge";
+import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { cn } from "../lib/utils";
 import { isLinuxPlatform, isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { useUiStore } from "../stores/ui-store";

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
@@ -42,13 +42,13 @@ beforeEach(() => {
 });
 
 describe("useWorkspaceQuery", () => {
-	it("returns an empty workspace list while the daemon base URL is untrusted", async () => {
+	it("rejects workspace reads while the daemon base URL is untrusted", async () => {
 		hasTrustedApiBaseUrlMock.mockReturnValue(false);
 
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 
-		await waitFor(() => expect(result.current.isSuccess).toBe(true));
-		expect(result.current.data).toEqual([]);
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(result.current.error).toEqual(new Error("AO daemon API is not ready"));
 		expect(getMock).not.toHaveBeenCalled();
 	});
 

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -27,7 +27,7 @@ function toPullRequestFacts(pr: components["schemas"]["SessionPRFacts"]): PullRe
 }
 
 export const workspaceQueryKey = ["workspaces"] as const;
-const usePreviewData = import.meta.env.VITE_NO_ELECTRON === "1";
+export const usesPreviewWorkspaceData = import.meta.env.VITE_NO_ELECTRON === "1";
 const reportedUnknownSessionFields = new Set<string>();
 
 function reportUnknownSessionField(field: "status" | "activity", value?: string): void {
@@ -46,7 +46,7 @@ function reportUnknownSessionField(field: "status" | "activity", value?: string)
 type FakeAgentSeam = { snapshot: () => WorkspaceSummary[] };
 
 async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
-	if (usePreviewData) {
+	if (usesPreviewWorkspaceData) {
 		const fake =
 			typeof window !== "undefined"
 				? (window as unknown as { __aoFakeAgent?: FakeAgentSeam }).__aoFakeAgent

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -54,7 +54,7 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 		return fake ? fake.snapshot() : mockWorkspaces;
 	}
 	if (!hasTrustedApiBaseUrl()) {
-		return [];
+		throw new Error("AO daemon API is not ready");
 	}
 
 	const [{ data: projectsData, error: projectsError }, { data: sessionsData, error: sessionsError }] =

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
 import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { mockWorkspaces } from "../lib/mock-data";
+import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { captureRendererEvent } from "../lib/telemetry";
 import {
 	type PRState,
@@ -27,7 +28,6 @@ function toPullRequestFacts(pr: components["schemas"]["SessionPRFacts"]): PullRe
 }
 
 export const workspaceQueryKey = ["workspaces"] as const;
-export const usesPreviewWorkspaceData = import.meta.env.VITE_NO_ELECTRON === "1";
 const reportedUnknownSessionFields = new Set<string>();
 
 function reportUnknownSessionField(field: "status" | "activity", value?: string): void {

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -49,6 +49,7 @@ export const aoBridge: AoBridge =
 			}),
 			start: async () => ({ state: "starting" }),
 			stop: async () => ({ state: "stopped" }),
+			restart: async () => ({ state: "starting" }),
 			onStatus: () => () => undefined,
 		},
 		telemetry: {

--- a/frontend/src/renderer/lib/preview-mode.ts
+++ b/frontend/src/renderer/lib/preview-mode.ts
@@ -1,0 +1,1 @@
+export const usesPreviewWorkspaceData = import.meta.env.VITE_NO_ELECTRON === "1";

--- a/frontend/src/renderer/lib/shell-context.ts
+++ b/frontend/src/renderer/lib/shell-context.ts
@@ -7,6 +7,7 @@ import type { useDaemonStatus } from "../hooks/useDaemonStatus";
 // it lives in the shell and is handed down here rather than re-run per route.
 export type ShellContextValue = {
 	daemonStatus: ReturnType<typeof useDaemonStatus>;
+	workspaceStartupState: "loading" | "ready" | "error";
 	createProject: (input: {
 		path: string;
 		workerAgent: string;

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -18,14 +18,10 @@ import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useA
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useOpenShellTerminal } from "../hooks/useShellTerminals";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
-import {
-	useWorkspaceQuery,
-	usesPreviewWorkspaceData,
-	workspaceQueryKey,
-	workspaceQueryOptions,
-} from "../hooks/useWorkspaceQuery";
+import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
 import { apiClient, apiErrorCode, apiErrorMessage } from "../lib/api-client";
 import { refreshDaemonStatus } from "../lib/daemon-status";
+import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
 import { ShellProvider } from "../lib/shell-context";
 import { restartProjectOrchestrator } from "../lib/restart-orchestrator";

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -90,7 +90,6 @@ function ShellLayout() {
 	const daemonStatus = useDaemonStatus(queryClient);
 	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
 	const workspaceStartupBaselineRef = useRef(0);
-	const sidebarWasCollapsedForStartupRef = useRef(false);
 	const agentCatalogPortRef = useRef<number | undefined>(undefined);
 	const { themePreference, resolvedTheme, isSidebarOpen, toggleSidebar } = useUiStore();
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
@@ -169,10 +168,6 @@ function ShellLayout() {
 	const setOrchestratorReplacementError = useUiStore((state) => state.setOrchestratorReplacementError);
 	const setOrchestratorStartupError = useUiStore((state) => state.setOrchestratorStartupError);
 	const replacementErrorProjectId = Object.keys(orchestratorReplacementErrors)[0] ?? null;
-	const isStartupLoading =
-		!usesPreviewWorkspaceData &&
-		!daemonStatus.code &&
-		(daemonStatus.state !== "ready" || workspaceStartupState === "loading");
 
 	const cancelSidebarPeekClose = useCallback(() => {
 		if (sidebarPeekCloseTimerRef.current === undefined) return;
@@ -454,21 +449,6 @@ function ShellLayout() {
 
 	useEffect(() => cancelSidebarPeekClose, [cancelSidebarPeekClose]);
 
-	// Keep the startup treatment in the content pane: temporarily collapse the
-	// sidebar while the daemon and workspace list hydrate, then pin it open once
-	// the first load completes (or startup reports a failure).
-	useEffect(() => {
-		if (isStartupLoading) {
-			sidebarWasCollapsedForStartupRef.current = true;
-			cancelSidebarPeekClose();
-			setIsSidebarPeekOpen(false);
-			return;
-		}
-		if (!sidebarWasCollapsedForStartupRef.current) return;
-		sidebarWasCollapsedForStartupRef.current = false;
-		if (!isSidebarOpen) toggleSidebar();
-	}, [cancelSidebarPeekClose, isSidebarOpen, isStartupLoading, toggleSidebar]);
-
 	useEffect(() => {
 		if (!isSidebarPeekOpen || isSidebarOpen) return;
 
@@ -653,7 +633,7 @@ function ShellLayout() {
 						setIsSidebarPeekOpen(false);
 						if (open !== isSidebarOpen) toggleSidebar();
 					}}
-					open={!isStartupLoading && (isSidebarOpen || isSidebarPeekOpen)}
+					open={isSidebarOpen || isSidebarPeekOpen}
 					style={
 						{
 							"--sidebar-width": "var(--ao-sidebar-w, var(--size-sidebar-default))",

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -89,6 +89,7 @@ function ShellLayout() {
 	const workspaces = workspaceQuery.data ?? [];
 	const daemonStatus = useDaemonStatus(queryClient);
 	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
+	const workspaceStartupBaselineRef = useRef(0);
 	const agentCatalogPortRef = useRef<number | undefined>(undefined);
 	const { themePreference, resolvedTheme, isSidebarOpen, toggleSidebar } = useUiStore();
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
@@ -382,18 +383,22 @@ function ShellLayout() {
 	useEffect(() => {
 		let active = true;
 		if (usesPreviewWorkspaceData) {
+			workspaceStartupBaselineRef.current = 0;
 			setWorkspaceStartupState("ready");
 			return () => {
 				active = false;
 			};
 		}
 		if (daemonStatus.state !== "ready" || !daemonStatus.port) {
+			workspaceStartupBaselineRef.current = 0;
 			setWorkspaceStartupState("loading");
 			return () => {
 				active = false;
 			};
 		}
 
+		workspaceStartupBaselineRef.current =
+			queryClient.getQueryState(workspaceQueryKey)?.dataUpdatedAt ?? 0;
 		setWorkspaceStartupState("loading");
 		void queryClient
 			.fetchQuery(workspaceQueryOptions)
@@ -408,6 +413,28 @@ function ShellLayout() {
 			active = false;
 		};
 	}, [daemonStatus.port, daemonStatus.state, queryClient]);
+
+	// The first confirmed fetch may fail transiently even though the daemon is
+	// ready. React Query keeps polling and the event transport may invalidate
+	// the workspace query later, so let a newer successful result recover the
+	// shell without requiring a daemon restart or port change.
+	useEffect(() => {
+		if (
+			usesPreviewWorkspaceData ||
+			daemonStatus.state !== "ready" ||
+			workspaceStartupState === "ready" ||
+			!workspaceQuery.isSuccess ||
+			workspaceQuery.dataUpdatedAt <= workspaceStartupBaselineRef.current
+		) {
+			return;
+		}
+		setWorkspaceStartupState("ready");
+	}, [
+		daemonStatus.state,
+		workspaceQuery.dataUpdatedAt,
+		workspaceQuery.isSuccess,
+		workspaceStartupState,
+	]);
 
 	// Keep Electron's nativeTheme in step with the shell so the embedded preview
 	// WebContentsView (which follows prefers-color-scheme) flips at the same time.

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
+import { isCancelledError, useQueryClient } from "@tanstack/react-query";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { CommandPalette } from "../components/CommandPalette";
 import { CenterPanelShell } from "../components/CenterPanelShell";
@@ -19,7 +19,7 @@ import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useOpenShellTerminal } from "../hooks/useShellTerminals";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
-import { apiClient, apiErrorCode, apiErrorMessage } from "../lib/api-client";
+import { apiClient, apiErrorCode, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { refreshDaemonStatus } from "../lib/daemon-status";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
@@ -48,6 +48,7 @@ export const Route = createFileRoute("/_shell")({
 	// nav target is warm before the click.
 	loader: async ({ context }) => {
 		await refreshDaemonStatus().catch(() => undefined);
+		if (!usesPreviewWorkspaceData && !hasTrustedApiBaseUrl()) return;
 		return context.queryClient.ensureQueryData(workspaceQueryOptions);
 	},
 	component: ShellLayout,
@@ -90,7 +91,6 @@ function ShellLayout() {
 	const daemonStatus = useDaemonStatus(queryClient);
 	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
 	const workspaceStartupBaselineRef = useRef(0);
-	const sidebarWasCollapsedForStartupRef = useRef(false);
 	const agentCatalogPortRef = useRef<number | undefined>(undefined);
 	const { themePreference, resolvedTheme, isSidebarOpen, toggleSidebar } = useUiStore();
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
@@ -406,9 +406,12 @@ function ShellLayout() {
 			queryClient.getQueryState(workspaceQueryKey)?.dataUpdatedAt ?? 0;
 		setWorkspaceStartupState("loading");
 		void queryClient
-			.fetchQuery(workspaceQueryOptions)
-			.catch(() => {
-				if (active) setWorkspaceStartupState("error");
+			.fetchQuery({ ...workspaceQueryOptions, staleTime: 0 })
+			.then(() => {
+				if (active) setWorkspaceStartupState("ready");
+			})
+			.catch((error) => {
+				if (active && !isCancelledError(error)) setWorkspaceStartupState("error");
 			});
 
 		return () => {
@@ -454,21 +457,6 @@ function ShellLayout() {
 
 	useEffect(() => cancelSidebarPeekClose, [cancelSidebarPeekClose]);
 
-	// Keep the startup treatment in the content pane: temporarily collapse the
-	// sidebar while the daemon and workspace list hydrate, then pin it open once
-	// the first load completes (or startup reports a failure).
-	useEffect(() => {
-		if (isStartupLoading) {
-			sidebarWasCollapsedForStartupRef.current = true;
-			cancelSidebarPeekClose();
-			setIsSidebarPeekOpen(false);
-			return;
-		}
-		if (!sidebarWasCollapsedForStartupRef.current) return;
-		sidebarWasCollapsedForStartupRef.current = false;
-		if (!isSidebarOpen) toggleSidebar();
-	}, [cancelSidebarPeekClose, isSidebarOpen, isStartupLoading, toggleSidebar]);
-
 	useEffect(() => {
 		if (!isSidebarPeekOpen || isSidebarOpen) return;
 
@@ -503,7 +491,6 @@ function ShellLayout() {
 		agentCatalogPortRef.current = daemonStatus.port;
 		void queryClient.invalidateQueries({ queryKey: agentsQueryKey });
 		void queryClient.fetchQuery({ ...agentsQueryOptions, queryFn: refreshAgents });
-		void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 	}, [daemonStatus.port, daemonStatus.state, queryClient]);
 
 	// Follow OS appearance while the user keeps Theme on System — updates

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -87,6 +87,7 @@ function ShellLayout() {
 	const workspaceQuery = useWorkspaceQuery();
 	const workspaces = workspaceQuery.data ?? [];
 	const daemonStatus = useDaemonStatus(queryClient);
+	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
 	const agentCatalogPortRef = useRef<number | undefined>(undefined);
 	const { themePreference, resolvedTheme, isSidebarOpen, toggleSidebar } = useUiStore();
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
@@ -147,7 +148,11 @@ function ShellLayout() {
 			? workspaces.find((workspace) => workspace.sessions.some((session) => session.id === routeParams.sessionId))?.id
 			: undefined;
 	// First-launch root board only (no projects in scope).
-	const isWelcomeBoard = Boolean(matchRoute({ to: "/" })) && workspaces.length === 0;
+	const isWelcomeBoard =
+		Boolean(matchRoute({ to: "/" })) &&
+		workspaceStartupState === "ready" &&
+		workspaceQuery.isSuccess &&
+		workspaces.length === 0;
 	const isSettingsRoute =
 		Boolean(matchRoute({ to: "/settings", fuzzy: true })) ||
 		Boolean(matchRoute({ to: "/projects/$projectId/settings", fuzzy: true }));
@@ -369,6 +374,34 @@ function ShellLayout() {
 		applyDocumentTheme(resolvedTheme);
 	}, [resolvedTheme]);
 
+	// A daemon port is not enough to render a trustworthy empty state: the
+	// route loader may have cached [] before Electron reported the port. Fetch
+	// once against each ready daemon before allowing the board to decide
+	// between projects and the first-run import flow.
+	useEffect(() => {
+		let active = true;
+		if (daemonStatus.state !== "ready" || !daemonStatus.port) {
+			setWorkspaceStartupState("loading");
+			return () => {
+				active = false;
+			};
+		}
+
+		setWorkspaceStartupState("loading");
+		void queryClient
+			.fetchQuery(workspaceQueryOptions)
+			.then(() => {
+				if (active) setWorkspaceStartupState("ready");
+			})
+			.catch(() => {
+				if (active) setWorkspaceStartupState("error");
+			});
+
+		return () => {
+			active = false;
+		};
+	}, [daemonStatus.port, daemonStatus.state, queryClient]);
+
 	// Keep Electron's nativeTheme in step with the shell so the embedded preview
 	// WebContentsView (which follows prefers-color-scheme) flips at the same time.
 	// Send the preference, not the resolved theme, so "system" keeps both surfaces
@@ -533,7 +566,7 @@ function ShellLayout() {
 	);
 
 	return (
-		<ShellProvider value={{ daemonStatus, createProject, initializeProjectRepository }}>
+		<ShellProvider value={{ daemonStatus, workspaceStartupState, createProject, initializeProjectRepository }}>
 			<NotificationRuntime />
 			<GlobalNewTaskDialog />
 			<KeyboardShortcutsDialog

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -18,7 +18,12 @@ import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useA
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useOpenShellTerminal } from "../hooks/useShellTerminals";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
-import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
+import {
+	useWorkspaceQuery,
+	usesPreviewWorkspaceData,
+	workspaceQueryKey,
+	workspaceQueryOptions,
+} from "../hooks/useWorkspaceQuery";
 import { apiClient, apiErrorCode, apiErrorMessage } from "../lib/api-client";
 import { refreshDaemonStatus } from "../lib/daemon-status";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
@@ -380,6 +385,12 @@ function ShellLayout() {
 	// between projects and the first-run import flow.
 	useEffect(() => {
 		let active = true;
+		if (usesPreviewWorkspaceData) {
+			setWorkspaceStartupState("ready");
+			return () => {
+				active = false;
+			};
+		}
 		if (daemonStatus.state !== "ready" || !daemonStatus.port) {
 			setWorkspaceStartupState("loading");
 			return () => {

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -402,9 +402,6 @@ function ShellLayout() {
 		setWorkspaceStartupState("loading");
 		void queryClient
 			.fetchQuery(workspaceQueryOptions)
-			.then(() => {
-				if (active) setWorkspaceStartupState("ready");
-			})
 			.catch(() => {
 				if (active) setWorkspaceStartupState("error");
 			});

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -90,6 +90,7 @@ function ShellLayout() {
 	const daemonStatus = useDaemonStatus(queryClient);
 	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
 	const workspaceStartupBaselineRef = useRef(0);
+	const sidebarWasCollapsedForStartupRef = useRef(false);
 	const agentCatalogPortRef = useRef<number | undefined>(undefined);
 	const { themePreference, resolvedTheme, isSidebarOpen, toggleSidebar } = useUiStore();
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
@@ -168,6 +169,10 @@ function ShellLayout() {
 	const setOrchestratorReplacementError = useUiStore((state) => state.setOrchestratorReplacementError);
 	const setOrchestratorStartupError = useUiStore((state) => state.setOrchestratorStartupError);
 	const replacementErrorProjectId = Object.keys(orchestratorReplacementErrors)[0] ?? null;
+	const isStartupLoading =
+		!usesPreviewWorkspaceData &&
+		!daemonStatus.code &&
+		(daemonStatus.state !== "ready" || workspaceStartupState === "loading");
 
 	const cancelSidebarPeekClose = useCallback(() => {
 		if (sidebarPeekCloseTimerRef.current === undefined) return;
@@ -449,6 +454,21 @@ function ShellLayout() {
 
 	useEffect(() => cancelSidebarPeekClose, [cancelSidebarPeekClose]);
 
+	// Keep the startup treatment in the content pane: temporarily collapse the
+	// sidebar while the daemon and workspace list hydrate, then pin it open once
+	// the first load completes (or startup reports a failure).
+	useEffect(() => {
+		if (isStartupLoading) {
+			sidebarWasCollapsedForStartupRef.current = true;
+			cancelSidebarPeekClose();
+			setIsSidebarPeekOpen(false);
+			return;
+		}
+		if (!sidebarWasCollapsedForStartupRef.current) return;
+		sidebarWasCollapsedForStartupRef.current = false;
+		if (!isSidebarOpen) toggleSidebar();
+	}, [cancelSidebarPeekClose, isSidebarOpen, isStartupLoading, toggleSidebar]);
+
 	useEffect(() => {
 		if (!isSidebarPeekOpen || isSidebarOpen) return;
 
@@ -633,7 +653,7 @@ function ShellLayout() {
 						setIsSidebarPeekOpen(false);
 						if (open !== isSidebarOpen) toggleSidebar();
 					}}
-					open={isSidebarOpen || isSidebarPeekOpen}
+					open={!isStartupLoading && (isSidebarOpen || isSidebarPeekOpen)}
 					style={
 						{
 							"--sidebar-width": "var(--ao-sidebar-w, var(--size-sidebar-default))",

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -975,6 +975,71 @@ select {
 	}
 }
 
+@keyframes ao-startup-logo-breathe {
+	0%,
+	100% {
+		opacity: 0.86;
+		transform: translateY(0);
+	}
+	50% {
+		opacity: 1;
+		transform: translateY(-2px);
+	}
+}
+
+@keyframes ao-startup-status-in {
+	from {
+		opacity: 0;
+		filter: blur(2px);
+		transform: translateY(3px);
+	}
+	to {
+		opacity: 1;
+		filter: blur(0);
+		transform: translateY(0);
+	}
+}
+
+@keyframes ao-startup-dot-pulse {
+	0%,
+	70%,
+	100% {
+		opacity: 0.25;
+		transform: translateY(0);
+	}
+	35% {
+		opacity: 1;
+		transform: translateY(-3px);
+	}
+}
+
+.ao-startup-logo {
+	animation: ao-startup-logo-breathe 3.2s ease-in-out infinite;
+	filter: drop-shadow(0 7px 20px rgb(0 0 0 / 0.28));
+}
+
+.ao-startup-status {
+	display: inline-block;
+	animation: ao-startup-status-in 240ms ease-out;
+}
+
+.ao-startup-dots span {
+	width: 4px;
+	height: 4px;
+	animation: ao-startup-dot-pulse 1.4s ease-in-out infinite;
+	border-radius: var(--radius-full);
+	background: var(--color-accent);
+	opacity: 0.25;
+}
+
+.ao-startup-dots span:nth-child(2) {
+	animation-delay: 160ms;
+}
+
+.ao-startup-dots span:nth-child(3) {
+	animation-delay: 320ms;
+}
+
 @keyframes overlay-in {
 	from {
 		opacity: 0;
@@ -1025,6 +1090,12 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 }
 
 @media (prefers-reduced-motion: reduce) {
+	.ao-startup-logo,
+	.ao-startup-status,
+	.ao-startup-dots span {
+		animation: none;
+	}
+
 	.sidebar-expanded-chrome {
 		transition: none;
 	}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1013,6 +1013,12 @@ select {
 	}
 }
 
+.ao-startup-screen {
+	position: fixed;
+	z-index: calc(var(--z-overlay) - 1);
+	inset: 0;
+}
+
 .ao-startup-logo {
 	animation: ao-startup-logo-breathe 3.2s ease-in-out infinite;
 	filter: drop-shadow(0 7px 20px rgb(0 0 0 / 0.28));

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1014,9 +1014,10 @@ select {
 }
 
 .ao-startup-screen {
-	position: fixed;
-	z-index: calc(var(--z-overlay) - 1);
-	inset: 0;
+	position: relative;
+	flex: 1 1 0%;
+	min-width: 0;
+	min-height: 0;
 }
 
 .ao-startup-logo {

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -91,6 +91,7 @@ if (typeof window !== "undefined") {
 			getStatus: async () => ({ state: "stopped" }),
 			start: async () => ({ state: "starting" }),
 			stop: async () => ({ state: "stopped" }),
+			restart: async () => ({ state: "starting" }),
 			onStatus: () => () => undefined,
 		},
 		telemetry: {

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -277,6 +277,43 @@ beforeEach(() => {
 });
 
 describe("shell workspace startup", () => {
+	it("stays loading until React observes the newer workspace result", async () => {
+		let resolveFetch: ((value: WorkspaceSummary[]) => void) | undefined;
+		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };
+		shellMocks.state.workspaceQuery = {
+			data: [],
+			dataUpdatedAt: 100,
+			isError: false,
+			isSuccess: true,
+		};
+		shellMocks.queryClient.getQueryState.mockReturnValue({ dataUpdatedAt: 100 });
+		shellMocks.queryClient.fetchQuery.mockReturnValueOnce(
+			new Promise<WorkspaceSummary[]>((resolve) => {
+				resolveFetch = resolve;
+			}),
+		);
+
+		const view = await renderShell();
+		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
+
+		await act(async () => resolveFetch?.(workspaces));
+		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
+
+		shellMocks.state.workspaceQuery = {
+			data: workspaces,
+			dataUpdatedAt: 200,
+			isError: false,
+			isSuccess: true,
+		};
+		view.rerender(
+			<Suspense fallback={null}>
+				<ShellRoute />
+			</Suspense>,
+		);
+
+		await waitFor(() => expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("ready"));
+	});
+
 	it("recovers after a newer workspace query succeeds", async () => {
 		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };
 		shellMocks.state.workspaceQuery = {

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -17,6 +17,14 @@ const shellMocks = vi.hoisted(() => {
 		routeParams: {} as { projectId?: string; sessionId?: string },
 		routeSearch: {} as { tabOwner?: string },
 		workspaces: [] as WorkspaceSummary[],
+		workspaceQuery: {
+			data: [] as WorkspaceSummary[],
+			dataUpdatedAt: 0,
+			isError: false,
+			isSuccess: true,
+		},
+		daemonStatus: { state: "stopped" } as { state: "ready" | "starting" | "stopped"; port?: number },
+		shellValue: undefined as { workspaceStartupState?: string } | undefined,
 	};
 	return {
 		navigate: vi.fn(),
@@ -55,6 +63,7 @@ const shellMocks = vi.hoisted(() => {
 		queryClient: {
 			ensureQueryData: vi.fn(),
 			fetchQuery: vi.fn(),
+			getQueryState: vi.fn(),
 			invalidateQueries: vi.fn(),
 			setQueryData: vi.fn(),
 		},
@@ -97,13 +106,13 @@ vi.mock("../lib/bridge", () => ({
 }));
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
-	useWorkspaceQuery: () => ({ data: shellMocks.state.workspaces, isError: false }),
+	useWorkspaceQuery: () => shellMocks.state.workspaceQuery,
 	workspaceQueryKey: ["workspaces"],
 	workspaceQueryOptions: {},
 }));
 
 vi.mock("../hooks/useDaemonStatus", () => ({
-	useDaemonStatus: () => ({ state: "stopped" }),
+	useDaemonStatus: () => shellMocks.state.daemonStatus,
 }));
 
 // The shell layout opens standalone terminals; this suite only covers the
@@ -144,7 +153,10 @@ vi.mock("../components/KeyboardShortcutsDialog", () => ({
 	KeyboardShortcutsDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="keyboard-shortcuts" /> : null),
 }));
 vi.mock("../lib/shell-context", () => ({
-	ShellProvider: ({ children }: PropsWithChildren) => children,
+	ShellProvider: ({ children, value }: PropsWithChildren<{ value?: { workspaceStartupState?: string } }>) => {
+		shellMocks.state.shellValue = value;
+		return children;
+	},
 }));
 vi.mock("../components/ui/sidebar", () => ({
 	SidebarProvider: ({ children, open }: PropsWithChildren<{ open?: boolean }>) => (
@@ -179,6 +191,7 @@ vi.mock("../components/Sidebar", async () => {
 });
 
 import { Route } from "../routes/_shell";
+const ShellRoute = Route.options.component as ComponentType;
 
 const workspaces = [
 	{
@@ -201,9 +214,9 @@ const workspaces = [
 ] as unknown as WorkspaceSummary[];
 
 async function renderShell() {
-	const ShellRoute = Route.options.component as ComponentType;
+	let view: ReturnType<typeof render> | undefined;
 	await act(async () => {
-		render(
+		view = render(
 			<Suspense fallback={null}>
 				<ShellRoute />
 			</Suspense>,
@@ -216,6 +229,7 @@ async function renderShell() {
 	await waitFor(() => expect(shellMocks.onPreviousSessionShortcut).toHaveBeenCalledTimes(1));
 	await waitFor(() => expect(shellMocks.onNextSessionShortcut).toHaveBeenCalledTimes(1));
 	await waitFor(() => expect(shellMocks.onFocusTerminalShortcut).toHaveBeenCalledTimes(1));
+	return view!;
 }
 
 function emitShortcut() {
@@ -244,11 +258,50 @@ beforeEach(() => {
 	shellMocks.state.routeParams = {};
 	shellMocks.state.routeSearch = {};
 	shellMocks.state.workspaces = workspaces;
+	shellMocks.state.workspaceQuery = {
+		data: workspaces,
+		dataUpdatedAt: 0,
+		isError: false,
+		isSuccess: true,
+	};
+	shellMocks.state.daemonStatus = { state: "stopped" };
+	shellMocks.state.shellValue = undefined;
+	shellMocks.queryClient.fetchQuery.mockReset();
+	shellMocks.queryClient.getQueryState.mockReset().mockReturnValue({ dataUpdatedAt: 0 });
 	useUiStore.setState({
 		createProjectNonce: 0,
 		isSidebarOpen: true,
 		newTaskRequest: null,
 		newShellTerminalNonce: 0,
+	});
+});
+
+describe("shell workspace startup", () => {
+	it("recovers after a newer workspace query succeeds", async () => {
+		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };
+		shellMocks.state.workspaceQuery = {
+			data: workspaces,
+			dataUpdatedAt: 100,
+			isError: false,
+			isSuccess: true,
+		};
+		shellMocks.queryClient.getQueryState.mockReturnValue({ dataUpdatedAt: 100 });
+		shellMocks.queryClient.fetchQuery.mockRejectedValueOnce(new Error("temporary failure"));
+
+		const view = await renderShell();
+		await waitFor(() => expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("error"));
+
+		shellMocks.state.workspaceQuery = {
+			...shellMocks.state.workspaceQuery,
+			dataUpdatedAt: 200,
+		};
+		view.rerender(
+			<Suspense fallback={null}>
+				<ShellRoute />
+			</Suspense>,
+		);
+
+		await waitFor(() => expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("ready"));
 	});
 });
 

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -23,11 +23,7 @@ const shellMocks = vi.hoisted(() => {
 			isError: false,
 			isSuccess: true,
 		},
-		daemonStatus: { state: "stopped" } as {
-			state: "ready" | "starting" | "stopped" | "error";
-			port?: number;
-			code?: "not_ready";
-		},
+		daemonStatus: { state: "stopped" } as { state: "ready" | "starting" | "stopped"; port?: number },
 		shellValue: undefined as { workspaceStartupState?: string } | undefined,
 	};
 	return {
@@ -268,7 +264,7 @@ beforeEach(() => {
 		isError: false,
 		isSuccess: true,
 	};
-	shellMocks.state.daemonStatus = { state: "error", code: "not_ready" };
+	shellMocks.state.daemonStatus = { state: "stopped" };
 	shellMocks.state.shellValue = undefined;
 	shellMocks.queryClient.fetchQuery.mockReset();
 	shellMocks.queryClient.getQueryState.mockReset().mockReturnValue({ dataUpdatedAt: 0 });
@@ -283,7 +279,6 @@ beforeEach(() => {
 describe("shell workspace startup", () => {
 	it("stays loading until React observes the newer workspace result", async () => {
 		let resolveFetch: ((value: WorkspaceSummary[]) => void) | undefined;
-		useUiStore.setState({ isSidebarOpen: false });
 		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };
 		shellMocks.state.workspaceQuery = {
 			data: [],
@@ -300,7 +295,6 @@ describe("shell workspace startup", () => {
 
 		const view = await renderShell();
 		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
-		expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "false");
 
 		await act(async () => resolveFetch?.(workspaces));
 		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
@@ -318,8 +312,6 @@ describe("shell workspace startup", () => {
 		);
 
 		await waitFor(() => expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("ready"));
-		await waitFor(() => expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "true"));
-		expect(useUiStore.getState().isSidebarOpen).toBe(true);
 	});
 
 	it("recovers after a newer workspace query succeeds", async () => {

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -23,7 +23,11 @@ const shellMocks = vi.hoisted(() => {
 			isError: false,
 			isSuccess: true,
 		},
-		daemonStatus: { state: "stopped" } as { state: "ready" | "starting" | "stopped"; port?: number },
+		daemonStatus: { state: "stopped" } as {
+			state: "ready" | "starting" | "stopped" | "error";
+			port?: number;
+			code?: "not_ready";
+		},
 		shellValue: undefined as { workspaceStartupState?: string } | undefined,
 	};
 	return {
@@ -264,7 +268,7 @@ beforeEach(() => {
 		isError: false,
 		isSuccess: true,
 	};
-	shellMocks.state.daemonStatus = { state: "stopped" };
+	shellMocks.state.daemonStatus = { state: "error", code: "not_ready" };
 	shellMocks.state.shellValue = undefined;
 	shellMocks.queryClient.fetchQuery.mockReset();
 	shellMocks.queryClient.getQueryState.mockReset().mockReturnValue({ dataUpdatedAt: 0 });
@@ -279,6 +283,7 @@ beforeEach(() => {
 describe("shell workspace startup", () => {
 	it("stays loading until React observes the newer workspace result", async () => {
 		let resolveFetch: ((value: WorkspaceSummary[]) => void) | undefined;
+		useUiStore.setState({ isSidebarOpen: false });
 		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };
 		shellMocks.state.workspaceQuery = {
 			data: [],
@@ -295,6 +300,7 @@ describe("shell workspace startup", () => {
 
 		const view = await renderShell();
 		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
+		expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "false");
 
 		await act(async () => resolveFetch?.(workspaces));
 		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
@@ -312,6 +318,8 @@ describe("shell workspace startup", () => {
 		);
 
 		await waitFor(() => expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("ready"));
+		await waitFor(() => expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "true"));
+		expect(useUiStore.getState().isSidebarOpen).toBe(true);
 	});
 
 	it("recovers after a newer workspace query succeeds", async () => {

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -226,7 +226,7 @@ async function renderShell() {
 			</Suspense>,
 		);
 	});
-	await waitFor(() => expect(shellMocks.onNewSessionShortcut).toHaveBeenCalledTimes(1));
+	await waitFor(() => expect(shellMocks.onNewSessionShortcut).toHaveBeenCalledTimes(1), { timeout: 30_000 });
 	await waitFor(() => expect(shellMocks.onKeyboardShortcutsHelp).toHaveBeenCalledTimes(1));
 	await waitFor(() => expect(shellMocks.onNewShellTerminalShortcut).toHaveBeenCalledTimes(1));
 	await waitFor(() => expect(shellMocks.onOpenSettingsShortcut).toHaveBeenCalledTimes(1));

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CancelledError } from "@tanstack/react-query";
 import { Suspense, type ComponentType, type PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { KeybindingOverrides } from "../../shared/shortcuts";
@@ -75,7 +76,8 @@ const shellMocks = vi.hoisted(() => {
 	};
 });
 
-vi.mock("@tanstack/react-query", () => ({
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@tanstack/react-query")>()),
 	useQueryClient: () => shellMocks.queryClient,
 }));
 
@@ -281,7 +283,7 @@ beforeEach(() => {
 });
 
 describe("shell workspace startup", () => {
-	it("stays loading until React observes the newer workspace result", async () => {
+	it("forces a confirmed fetch and preserves a collapsed sidebar preference", async () => {
 		let resolveFetch: ((value: WorkspaceSummary[]) => void) | undefined;
 		useUiStore.setState({ isSidebarOpen: false });
 		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };
@@ -301,25 +303,54 @@ describe("shell workspace startup", () => {
 		const view = await renderShell();
 		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
 		expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "false");
+		expect(shellMocks.queryClient.fetchQuery).toHaveBeenCalledWith(expect.objectContaining({ staleTime: 0 }));
 
 		await act(async () => resolveFetch?.(workspaces));
-		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
 
+		await waitFor(() => expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("ready"));
+		expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "false");
+		expect(useUiStore.getState().isSidebarOpen).toBe(false);
+		view.unmount();
+	});
+
+	it("does not turn a cancelled confirmed fetch into a startup error", async () => {
+		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };
 		shellMocks.state.workspaceQuery = {
-			data: workspaces,
-			dataUpdatedAt: 200,
+			data: [],
+			dataUpdatedAt: 100,
 			isError: false,
 			isSuccess: true,
 		};
+		shellMocks.queryClient.getQueryState.mockReturnValue({ dataUpdatedAt: 100 });
+		shellMocks.queryClient.fetchQuery.mockRejectedValueOnce(new CancelledError());
+
+		await renderShell();
+
+		await waitFor(() =>
+			expect(shellMocks.queryClient.fetchQuery).toHaveBeenCalledWith(expect.objectContaining({ staleTime: 0 })),
+		);
+		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
+	});
+
+	it("forces a workspace fetch when a daemon returns ready on the same port", async () => {
+		shellMocks.state.daemonStatus = { state: "starting", port: 4777 };
+		shellMocks.queryClient.fetchQuery.mockResolvedValue(workspaces);
+
+		const view = await renderShell();
+		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
+		expect(shellMocks.queryClient.fetchQuery).not.toHaveBeenCalled();
+
+		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };
 		view.rerender(
 			<Suspense fallback={null}>
 				<ShellRoute />
 			</Suspense>,
 		);
 
+		await waitFor(() =>
+			expect(shellMocks.queryClient.fetchQuery).toHaveBeenCalledWith(expect.objectContaining({ staleTime: 0 })),
+		);
 		await waitFor(() => expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("ready"));
-		await waitFor(() => expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "true"));
-		expect(useUiStore.getState().isSidebarOpen).toBe(true);
 	});
 
 	it("recovers after a newer workspace query succeeds", async () => {


### PR DESCRIPTION
## Summary

- show an animated AO startup loader inside the main content panel while the desktop daemon and workspace data initialize
- preserve the persisted sidebar preference while startup temporarily controls only the rendered layout
- require an authoritative workspace request after daemon readiness, bypassing stale cache entries and rejecting untrusted API reads instead of caching placeholder data
- keep same-port daemon restarts recoverable and ignore cancelled confirmed fetches without flashing a false workspace error
- keep populated board columns visible when daemon startup has already failed, so diagnostics and restart controls remain usable
- avoid welcome-board chrome and empty-state flashes while startup hydration is still in progress
- keep the rotating loader copy visual-only for assistive technology and use a valid themed wordmark size
- report a durable startup failure after 30 seconds with captured daemon stdout/stderr and launch details
- provide a **Restart daemon** action that stops the old process, preserves restart intent across slow shutdowns, and starts a replacement
- continue readiness discovery after the timeout so a slow daemon can still recover automatically
- keep restart failures actionable by surfacing durable error status and retaining retry controls

## Validation

- `npm run typecheck`
- `npm run typecheck:e2e`
- focused startup/board/workspace regressions: 43 passed
- complete frontend Vitest suite: 1,162 passed
- renderer smoke suite: 20 passed
- rendered the exact worktree in the in-app browser and inspected the board layout
