### PR TITLE
fix(preview): keep poller previews entrypoint-only

### DIFF
--- a/backend/internal/preview/poller.go
+++ b/backend/internal/preview/poller.go
@@ -42,6 +42,9 @@ type entryState struct {
 	path    string
 	modUnix int64
 	size    int64
+	// pollerOwned is true when the poller created the current workspace preview
+	// automatically, as opposed to the user explicitly choosing it via ao preview.
+	pollerOwned bool
 	// cleared is set when the poller itself cleared the preview URL because the
 	// workspace entry was missing. When the file reappears, shouldRefresh uses
 	// this to re-discover even though the revision was bumped by the clear.
@@ -113,22 +116,23 @@ func (p *Poller) Poll(ctx context.Context) error {
 			continue
 		}
 		storedEntry, workspaceOwned := StoredWorkspaceEntry(sess.Metadata.PreviewURL, sess.ID)
+		previous, seenBefore := p.seen[sess.ID]
+		pollerOwned := seenBefore && previous.pollerOwned && workspaceOwned && storedEntry == previous.path
 		entry, ok := Entry{}, false
 		if workspaceOwned {
 			entry, ok = EntryAtPath(sess.Metadata.WorkspacePath, storedEntry)
 		}
 		if !ok {
-			// A session the user has never explicitly previewed
-			// (workspaceOwned == false) is only auto-previewed when it has a
-			// real static-frontend entrypoint (index.html variants). The
-			// mostRecentPreviewable .md/.html fallback is intentionally NOT
-			// applied here, otherwise every new session in a Markdown-rich repo
-			// auto-opens its browser to an arbitrary repo doc. Once a session
-			// has been explicitly previewed (workspaceOwned == true), full
-			// DiscoverEntry — including the document fallback — keeps the
-			// preview fresh. See issue #2859.
+			// Never-previewed sessions and previews auto-created by this poller
+			// only rediscover real static-frontend entrypoints. Explicit
+			// workspace previews keep the full document fallback so user-chosen
+			// Markdown/report previews can stay fresh. See issue #2859.
 			if workspaceOwned {
-				entry, ok = DiscoverEntry(sess.Metadata.WorkspacePath)
+				if pollerOwned {
+					entry, ok = DiscoverWebEntrypoint(sess.Metadata.WorkspacePath)
+				} else {
+					entry, ok = DiscoverEntry(sess.Metadata.WorkspacePath)
+				}
 			} else {
 				entry, ok = DiscoverWebEntrypoint(sess.Metadata.WorkspacePath)
 			}
@@ -144,7 +148,7 @@ func (p *Poller) Poll(ctx context.Context) error {
 			continue
 		}
 		state := stateFor(entry)
-		previous, seenBefore := p.seen[sess.ID]
+		state.pollerOwned = pollerOwned
 		if seenBefore && previous == state {
 			continue
 		}
@@ -161,6 +165,7 @@ func (p *Poller) Poll(ctx context.Context) error {
 		if _, err := p.setter.SetPreview(ctx, sess.ID, target); err != nil {
 			return fmt.Errorf("preview poller set preview %s: %w", sess.ID, err)
 		}
+		state.pollerOwned = state.pollerOwned || !workspaceOwned
 		p.seen[sess.ID] = state
 	}
 	for id := range p.seen {

--- a/backend/internal/preview/poller_test.go
+++ b/backend/internal/preview/poller_test.go
@@ -263,6 +263,37 @@ func TestPollerDoesNotAutoPreviewMarkdownOnlyNewSession(t *testing.T) {
 	}
 }
 
+func TestPollerDoesNotFallbackToMarkdownAfterAutoPreviewedEntrypointDeleted(t *testing.T) {
+	workspace := t.TempDir()
+	entry := filepath.Join(workspace, "index.html")
+	writeFile(t, entry, "<main>app</main>")
+	writeFile(t, filepath.Join(workspace, "README.md"), "# project")
+	svc := &fakePreviewSessions{sessions: []domain.SessionRecord{workerSession("ao-1", workspace, "")}}
+	poller := NewPoller(svc, svc, "http://127.0.0.1:3001", PollerConfig{Logger: discardLogger()})
+
+	if err := poller.Poll(context.Background()); err != nil {
+		t.Fatalf("first Poll: %v", err)
+	}
+	assertSets(t, svc.sets, previewSet{
+		id:  "ao-1",
+		url: mustFileURL(t, "http://127.0.0.1:3001", "ao-1", "index.html"),
+	})
+
+	if err := os.Remove(entry); err != nil {
+		t.Fatalf("remove index.html: %v", err)
+	}
+	if err := poller.Poll(context.Background()); err != nil {
+		t.Fatalf("second Poll: %v", err)
+	}
+	assertSets(t, svc.sets,
+		previewSet{
+			id:  "ao-1",
+			url: mustFileURL(t, "http://127.0.0.1:3001", "ao-1", "index.html"),
+		},
+		previewSet{id: "ao-1", url: ""},
+	)
+}
+
 func TestPollerKeepsMarkdownPreviewFreshOnceExplicitlySet(t *testing.T) {
 	// Once a session has been explicitly previewed against a workspace Markdown
 	// file (workspaceOwned), the poller must still keep that preview fresh — the
@@ -279,6 +310,21 @@ func TestPollerKeepsMarkdownPreviewFreshOnceExplicitlySet(t *testing.T) {
 	assertSets(t, svc.sets, previewSet{
 		id:  "ao-1",
 		url: mustFileURL(t, "http://127.0.0.1:3001", "ao-1", relative),
+	})
+}
+
+func TestPollerKeepsDocumentFallbackForDeletedExplicitPreview(t *testing.T) {
+	workspace := t.TempDir()
+	writeFile(t, filepath.Join(workspace, "README.md"), "# project")
+	svc := &fakePreviewSessions{sessions: []domain.SessionRecord{workerSession("ao-1", workspace, "docs/report.md")}}
+	poller := NewPoller(svc, svc, "http://127.0.0.1:3001", PollerConfig{Logger: discardLogger()})
+
+	if err := poller.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	assertSets(t, svc.sets, previewSet{
+		id:  "ao-1",
+		url: mustFileURL(t, "http://127.0.0.1:3001", "ao-1", "README.md"),
 	})
 }
 


### PR DESCRIPTION
@nikhilachale addressed your comment on PR #2860 as it was merged before i could push it

 ## Summary

  - Track preview URLs created automatically by the preview poller separately from explicit user-selected previews.
  - Prevent poller-owned previews from falling back to Markdown/report files after the auto-discovered `index.html` is deleted.
  - Preserve document fallback behavior for explicit workspace previews.
  - Add regression coverage for the two-poll delete case plus a preservation test for explicit preview fallback.

  ## Tests

  - `go test ./internal/preview -count=1`
  - `go test ./internal/httpd/controllers -run SetPreview -count=1`
  - `git diff --check HEAD~1..HEAD`