### PR TITLE
fix(lifecycle): stop duplicate and stale worker-idle nudges to the orchestrator (#3038)

### DIFF
--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -304,6 +304,17 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		m.mu.Unlock()
 		return nil
 	}
+	// A new instruction submitted to a worker starts a new completion
+	// generation: its next active->idle is a genuine completion of newly
+	// assigned work, so reopen reporting. Re-arming keys on new work arriving
+	// (user-prompt-submit) — the issue's "completion-generation" — rather than
+	// on incidental needs-input transitions, which are unrelated to whether new
+	// work was assigned (a mid-run permission dialog must not decide it). Placed
+	// before the staleness guards so it lands regardless of same-state early
+	// returns; clearing at worst allows one extra nudge, never a lost one.
+	if rec.Kind == domain.KindWorker && s.Event == "user-prompt-submit" {
+		delete(m.reportedIdle, id)
+	}
 	if s.LaunchID != "" && s.LaunchID != rec.Metadata.RuntimeLaunchID {
 		m.mu.Unlock()
 		return nil
@@ -381,14 +392,11 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	// A worker's active->idle transition creates a durable worker_idle event in
 	// the same write as the activity change, so a crash can't persist the idle
 	// state while losing the pending delivery. It is enqueued at most once per
-	// attention episode (see reportedIdle): re-idles and poke-induced idles are
-	// suppressed, and a worker entering a real needs-input state reopens
-	// reporting for its next completion.
+	// completion generation (see reportedIdle): re-idles and poke-induced idles
+	// within the same generation are suppressed, and a new instruction
+	// (user-prompt-submit, handled above) reopens reporting for the next one.
 	var idleEvent *domain.WorkerIdleEvent
-	switch {
-	case next.Kind == domain.KindWorker && !prevState.NeedsInput() && next.Activity.State.NeedsInput():
-		delete(m.reportedIdle, id)
-	case crossedToIdle(prevState, next):
+	if crossedToIdle(prevState, next) {
 		if _, reported := m.reportedIdle[id]; !reported {
 			idleEvent = &domain.WorkerIdleEvent{
 				ID:           uuid.NewString(),
@@ -513,33 +521,41 @@ func (m *Manager) DispatchPendingWorkerIdleEvents(ctx context.Context, project d
 		slog.Default().Error("lifecycle: list pending worker events", "project", project, "err", err)
 		return
 	}
-	if len(events) == 0 {
-		return
-	}
-	ev := events[0]
-	// Re-check the worker at delivery time, not just at enqueue. A completion
-	// enqueued minutes ago is stale if the worker has since been killed (no one
-	// to inspect) or opened a PR (its work is already in review and visible to
-	// the orchestrator). In both cases the nudge is noise, so drain the event
-	// without sending rather than leave it pending to retry forever.
-	if worker, ok, err := m.store.GetSession(ctx, ev.WorkerID); err != nil {
-		slog.Default().Error("lifecycle: read worker for idle delivery", "worker", ev.WorkerID, "err", err)
-		return
-	} else if !ok || worker.IsTerminated || m.workerHasOpenPR(ctx, ev.WorkerID) {
+	// Walk the pending events: drain stale ones (their worker was killed, so
+	// there is nothing to inspect) without sending, and deliver the first live
+	// one. Draining does not change the orchestrator's state, so — unlike a
+	// delivery — it produces no re-trigger; continuing the walk here clears a
+	// backlog of stale events in a single pass instead of one per 2-minute
+	// sweep. Only ONE live event is delivered per pass: the nudge moves the
+	// orchestrator out of idle asynchronously via its activity hook, so sending
+	// more now would dump the backlog into one turn before that state settles.
+	for _, ev := range events {
+		worker, found, err := m.store.GetSession(ctx, ev.WorkerID)
+		if err != nil {
+			slog.Default().Error("lifecycle: read worker for idle delivery", "worker", ev.WorkerID, "err", err)
+			return
+		}
+		// A killed worker's completion is stale: the nudge says "inspect it",
+		// and there is nothing to inspect. Drain and move on. An open PR is
+		// intentionally NOT drained — "report its status and any PR to the
+		// human" is exactly what a just-opened-a-PR completion is for.
+		if !found || worker.IsTerminated {
+			if err := m.store.MarkWorkerIdleEventDelivered(ctx, ev.ID, m.clock()); err != nil {
+				slog.Default().Error("lifecycle: drain stale worker idle", "event", ev.ID, "err", err)
+			}
+			continue
+		}
+		outcome, err := m.guard.NudgeCoordination(ctx, orch.ID, m.workerIdleNudgeMessage(ctx, ev.WorkerID), m.steerActive)
+		if err != nil {
+			slog.Default().Error("lifecycle: deliver worker idle", "worker", ev.WorkerID, "orchestrator", orch.ID, "err", err)
+		}
+		if outcome != sessionguard.Sent {
+			return
+		}
 		if err := m.store.MarkWorkerIdleEventDelivered(ctx, ev.ID, m.clock()); err != nil {
-			slog.Default().Error("lifecycle: drain stale worker idle", "event", ev.ID, "err", err)
+			slog.Default().Error("lifecycle: mark worker idle delivered", "event", ev.ID, "err", err)
 		}
 		return
-	}
-	outcome, err := m.guard.NudgeCoordination(ctx, orch.ID, m.workerIdleNudgeMessage(ctx, ev.WorkerID), m.steerActive)
-	if err != nil {
-		slog.Default().Error("lifecycle: deliver worker idle", "worker", ev.WorkerID, "orchestrator", orch.ID, "err", err)
-	}
-	if outcome != sessionguard.Sent {
-		return
-	}
-	if err := m.store.MarkWorkerIdleEventDelivered(ctx, ev.ID, m.clock()); err != nil {
-		slog.Default().Error("lifecycle: mark worker idle delivered", "event", ev.ID, "err", err)
 	}
 }
 
@@ -604,25 +620,6 @@ func (m *Manager) liveOrchestrator(ctx context.Context, project domain.ProjectID
 		}
 	}
 	return domain.SessionRecord{}, false, nil
-}
-
-// workerHasOpenPR reports whether the worker owns a pull request that is
-// neither merged nor closed. Such a worker's output is already in review and
-// visible to the orchestrator, so an "it went idle" nudge adds nothing. A read
-// error is treated as "no open PR" — failing open here only risks one extra
-// nudge, never a suppressed real signal.
-func (m *Manager) workerHasOpenPR(ctx context.Context, worker domain.SessionID) bool {
-	prs, err := m.store.ListPRsBySession(ctx, worker)
-	if err != nil {
-		slog.Default().Warn("lifecycle: list worker PRs for idle delivery", "worker", worker, "err", err)
-		return false
-	}
-	for _, pr := range prs {
-		if !pr.Merged && !pr.Closed {
-			return true
-		}
-	}
-	return false
 }
 
 // workerIdleNudgeMessage tells the orchestrator to inspect the worker with a

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -108,6 +108,17 @@ type Manager struct {
 	// This coordination is intentionally memory-only: a daemon crash leaves the
 	// durable session exited, so the user can safely retry the resume.
 	pendingLaunches map[domain.SessionID]pendingLaunch
+	// reportedIdle holds the workers already reported to the orchestrator for
+	// their current attention episode. A worker is reported at most once per
+	// episode: an active->idle transition enqueues a nudge only when the worker
+	// is absent from this set. The set is cleared when the worker enters a real
+	// needs-input state (a fresh "I need you" that reopens reporting), on
+	// spawn/restore, and on termination. This collapses the duplicate nudges and
+	// the poke-induced re-arms (an idle caused by an inbound message never passes
+	// through needs_input, so it stays suppressed). In-memory by design: a daemon
+	// restart forgets it and at worst allows one extra nudge — fail-safe, never a
+	// lost completion, matching the flights map's philosophy. Guarded by mu.
+	reportedIdle map[domain.SessionID]struct{}
 	// steerActive reports whether a harness can safely receive a write during an
 	// active turn (input steers the run) rather than only while idle. Supplied by
 	// the agent adapter via WithActiveSteering; the default answers false, so an
@@ -133,6 +144,7 @@ func New(store sessionStore, messenger ports.AgentMessenger, opts ...Option) *Ma
 		react:           newReactionState(),
 		flights:         map[domain.SessionID]*toolFlight{},
 		pendingLaunches: map[domain.SessionID]pendingLaunch{},
+		reportedIdle:    map[domain.SessionID]struct{}{},
 		steerActive:     func(domain.AgentHarness) bool { return false },
 	}
 	if messenger != nil {
@@ -246,6 +258,7 @@ func (m *Manager) ApplyRuntimeObservation(ctx context.Context, id domain.Session
 		// (later observations return early on cur.IsTerminated). Runs under
 		// m.mu — mutate holds it across this callback.
 		delete(m.flights, id)
+		delete(m.reportedIdle, id)
 		return next, true
 	})
 }
@@ -287,6 +300,7 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	now := m.clock()
 	if rec.IsTerminated {
 		delete(m.flights, id)
+		delete(m.reportedIdle, id)
 		m.mu.Unlock()
 		return nil
 	}
@@ -366,15 +380,24 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	next.UpdatedAt = now
 	// A worker's active->idle transition creates a durable worker_idle event in
 	// the same write as the activity change, so a crash can't persist the idle
-	// state while losing the pending delivery.
+	// state while losing the pending delivery. It is enqueued at most once per
+	// attention episode (see reportedIdle): re-idles and poke-induced idles are
+	// suppressed, and a worker entering a real needs-input state reopens
+	// reporting for its next completion.
 	var idleEvent *domain.WorkerIdleEvent
-	if crossedToIdle(prevState, next) {
-		idleEvent = &domain.WorkerIdleEvent{
-			ID:           uuid.NewString(),
-			ProjectID:    next.ProjectID,
-			WorkerID:     next.ID,
-			TransitionAt: next.Activity.LastActivityAt,
-			CreatedAt:    now,
+	switch {
+	case next.Kind == domain.KindWorker && !prevState.NeedsInput() && next.Activity.State.NeedsInput():
+		delete(m.reportedIdle, id)
+	case crossedToIdle(prevState, next):
+		if _, reported := m.reportedIdle[id]; !reported {
+			idleEvent = &domain.WorkerIdleEvent{
+				ID:           uuid.NewString(),
+				ProjectID:    next.ProjectID,
+				WorkerID:     next.ID,
+				TransitionAt: next.Activity.LastActivityAt,
+				CreatedAt:    now,
+			}
+			m.reportedIdle[id] = struct{}{}
 		}
 	}
 	if err := m.persistActivity(ctx, next, idleEvent); err != nil {
@@ -494,6 +517,20 @@ func (m *Manager) DispatchPendingWorkerIdleEvents(ctx context.Context, project d
 		return
 	}
 	ev := events[0]
+	// Re-check the worker at delivery time, not just at enqueue. A completion
+	// enqueued minutes ago is stale if the worker has since been killed (no one
+	// to inspect) or opened a PR (its work is already in review and visible to
+	// the orchestrator). In both cases the nudge is noise, so drain the event
+	// without sending rather than leave it pending to retry forever.
+	if worker, ok, err := m.store.GetSession(ctx, ev.WorkerID); err != nil {
+		slog.Default().Error("lifecycle: read worker for idle delivery", "worker", ev.WorkerID, "err", err)
+		return
+	} else if !ok || worker.IsTerminated || m.workerHasOpenPR(ctx, ev.WorkerID) {
+		if err := m.store.MarkWorkerIdleEventDelivered(ctx, ev.ID, m.clock()); err != nil {
+			slog.Default().Error("lifecycle: drain stale worker idle", "event", ev.ID, "err", err)
+		}
+		return
+	}
 	outcome, err := m.guard.NudgeCoordination(ctx, orch.ID, m.workerIdleNudgeMessage(ctx, ev.WorkerID), m.steerActive)
 	if err != nil {
 		slog.Default().Error("lifecycle: deliver worker idle", "worker", ev.WorkerID, "orchestrator", orch.ID, "err", err)
@@ -567,6 +604,25 @@ func (m *Manager) liveOrchestrator(ctx context.Context, project domain.ProjectID
 		}
 	}
 	return domain.SessionRecord{}, false, nil
+}
+
+// workerHasOpenPR reports whether the worker owns a pull request that is
+// neither merged nor closed. Such a worker's output is already in review and
+// visible to the orchestrator, so an "it went idle" nudge adds nothing. A read
+// error is treated as "no open PR" — failing open here only risks one extra
+// nudge, never a suppressed real signal.
+func (m *Manager) workerHasOpenPR(ctx context.Context, worker domain.SessionID) bool {
+	prs, err := m.store.ListPRsBySession(ctx, worker)
+	if err != nil {
+		slog.Default().Warn("lifecycle: list worker PRs for idle delivery", "worker", worker, "err", err)
+		return false
+	}
+	for _, pr := range prs {
+		if !pr.Merged && !pr.Closed {
+			return true
+		}
+	}
+	return false
 }
 
 // workerIdleNudgeMessage tells the orchestrator to inspect the worker with a
@@ -813,6 +869,9 @@ func (m *Manager) MarkSpawned(ctx context.Context, id domain.SessionID, metadata
 	rec.FirstSignalAt = time.Time{}
 	rec.Metadata = mergeMetadata(rec.Metadata, metadata)
 	rec.UpdatedAt = now
+	// A fresh spawn/restore is a new attention episode: its first completion is
+	// reportable again even if a prior episode already reported this id.
+	delete(m.reportedIdle, id)
 	return m.store.UpdateSession(ctx, rec)
 }
 
@@ -825,6 +884,7 @@ func (m *Manager) MarkTerminated(ctx context.Context, id domain.SessionID) error
 		cur.IsTerminated = true
 		cur.Activity = domain.Activity{State: domain.ActivityExited, LastActivityAt: now}
 		delete(m.flights, id) // runs under m.mu (mutate holds it)
+		delete(m.reportedIdle, id)
 		return cur, true
 	})
 }

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -2305,7 +2305,7 @@ func TestActivity_WorkerReportedOncePerEpisode(t *testing.T) {
 	}
 }
 
-func TestActivity_WorkerReReportsAfterNeedsInput(t *testing.T) {
+func TestActivity_WorkerReReportsAfterNewPrompt(t *testing.T) {
 	m, st, msg := newManager()
 	now := time.Now()
 	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
@@ -2315,20 +2315,42 @@ func TestActivity_WorkerReReportsAfterNeedsInput(t *testing.T) {
 	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle, Timestamp: now}); err != nil {
 		t.Fatal(err)
 	}
-	// The worker enters a real needs-input state: a fresh episode that reopens
-	// reporting for its next completion.
-	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityWaitingInput, Timestamp: now.Add(time.Minute)}); err != nil {
+	// New work is submitted to the worker: this begins a new completion
+	// generation (the issue's key), so its next completion is reportable again.
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityActive, Event: "user-prompt-submit", Timestamp: now.Add(time.Minute)}); err != nil {
 		t.Fatal(err)
 	}
-	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityActive, Timestamp: now.Add(2 * time.Minute)}); err != nil {
-		t.Fatal(err)
-	}
-	// Completion #2 is reportable again.
-	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle, Timestamp: now.Add(3 * time.Minute)}); err != nil {
+	// Completion #2 of the newly assigned work.
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle, Timestamp: now.Add(2 * time.Minute)}); err != nil {
 		t.Fatal(err)
 	}
 	if len(msg.msgs) != 2 {
-		t.Fatalf("nudges = %d, want 2 (re-armed after needs-input)", len(msg.msgs))
+		t.Fatalf("nudges = %d, want 2 (re-armed after new instruction)", len(msg.msgs))
+	}
+}
+
+// A permission dialog (blocked) mid-run is not new work and must NOT reopen
+// reporting: whether the orchestrator hears about a completion cannot depend on
+// whether a harness happened to emit a needs-input transition.
+func TestActivity_WorkerBlockedMidRunDoesNotReReport(t *testing.T) {
+	m, st, msg := newManager()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
+
+	// Completion #1 reported.
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle, Timestamp: now}); err != nil {
+		t.Fatal(err)
+	}
+	// Worker continues the SAME task: hits a permission dialog, resolves it, and
+	// finishes again — no new instruction arrived.
+	for i, st2 := range []domain.ActivityState{domain.ActivityActive, domain.ActivityBlocked, domain.ActivityActive, domain.ActivityIdle} {
+		if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: st2, Timestamp: now.Add(time.Duration(i+1) * time.Minute)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("nudges = %d, want 1 (a mid-run permission dialog is not new work)", len(msg.msgs))
 	}
 }
 
@@ -2351,16 +2373,35 @@ func TestDispatch_DrainsTerminatedWorkerWithoutNudge(t *testing.T) {
 	}
 }
 
-func TestDispatch_OpenPRDrainsMergedPRStillNudges(t *testing.T) {
+// A worker whose last act was opening a PR must STILL be reported: the nudge's
+// whole job is "report its status and any PR to the human". Only a terminated
+// worker is drained; an open PR is not.
+func TestDispatch_OpenPRWorkerStillNudges(t *testing.T) {
 	st := newFakeStore()
 	now := time.Now()
 	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
-	// mer-8 has an open PR (work already in review): nudge is noise, drain it.
 	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
 	st.prs["mer-8"] = []domain.PullRequest{{URL: "pr-open"}}
-	// mer-9's only PR is merged: its idle is still a real completion to report.
+	st.idleEvents = []domain.WorkerIdleEvent{{ID: "wie_8", ProjectID: "mer", WorkerID: "mer-8", TransitionAt: now, CreatedAt: now}}
+	msg := &fakeMessenger{}
+	m := New(st, msg)
+
+	m.DispatchPendingWorkerIdleEvents(ctx, "mer")
+	if len(msg.msgs) != 1 || !strings.Contains(msg.msgs[0], "mer-8") {
+		t.Fatalf("open-PR worker not nudged: msgs = %v", msg.msgs)
+	}
+}
+
+// A drain must advance to the next pending event in the SAME pass, not wait for
+// the 2-minute recovery sweep: a terminated worker's event is drained and a
+// live worker's event is delivered in one dispatch.
+func TestDispatch_DrainAdvancesToNextPendingEvent(t *testing.T) {
+	st := newFakeStore()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	// mer-8 was killed (stale event); mer-9 is live and its completion matters.
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, IsTerminated: true, Activity: domain.Activity{State: domain.ActivityExited, LastActivityAt: now}}
 	st.sessions["mer-9"] = domain.SessionRecord{ID: "mer-9", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
-	st.prs["mer-9"] = []domain.PullRequest{{URL: "pr-merged", Merged: true}}
 	st.idleEvents = []domain.WorkerIdleEvent{
 		{ID: "wie_8", ProjectID: "mer", WorkerID: "mer-8", TransitionAt: now, CreatedAt: now},
 		{ID: "wie_9", ProjectID: "mer", WorkerID: "mer-9", TransitionAt: now.Add(time.Second), CreatedAt: now.Add(time.Second)},
@@ -2368,18 +2409,13 @@ func TestDispatch_OpenPRDrainsMergedPRStillNudges(t *testing.T) {
 	msg := &fakeMessenger{}
 	m := New(st, msg)
 
-	// Cycle 1 drains the open-PR worker without sending.
-	m.DispatchPendingWorkerIdleEvents(ctx, "mer")
-	if len(msg.msgs) != 0 {
-		t.Fatalf("nudged for an open-PR worker: %d, want 0", len(msg.msgs))
-	}
-	// Cycle 2 delivers the merged-PR worker's completion.
+	// One pass: drains the stale event AND delivers the live one.
 	m.DispatchPendingWorkerIdleEvents(ctx, "mer")
 	if len(msg.msgs) != 1 || !strings.Contains(msg.msgs[0], "mer-9") {
-		t.Fatalf("merged-PR worker not nudged: msgs = %v", msg.msgs)
+		t.Fatalf("live worker not nudged in same pass: msgs = %v", msg.msgs)
 	}
 	if pending, _ := st.ListPendingWorkerIdleEvents(ctx); len(pending) != 0 {
-		t.Fatalf("events not fully processed: pending = %d, want 0", len(pending))
+		t.Fatalf("stale event not drained in same pass: pending = %d, want 0", len(pending))
 	}
 }
 

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -2275,6 +2275,114 @@ func TestDispatch_DeliversAtMostOnePerCycleAndDrainsOnReturnToIdle(t *testing.T)
 	}
 }
 
+func TestActivity_WorkerReportedOncePerEpisode(t *testing.T) {
+	m, st, msg := newManager()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
+
+	// First completion is reported once.
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle, Timestamp: now}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("first idle nudges = %d, want 1", len(msg.msgs))
+	}
+
+	// A re-idle with no intervening needs-input (e.g. an auto-mode turn boundary
+	// or an orchestrator poke) must NOT produce a second nudge.
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityActive, Timestamp: now.Add(time.Minute)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle, Timestamp: now.Add(2 * time.Minute)}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("re-idle nudges = %d, want 1 (report-once per episode)", len(msg.msgs))
+	}
+	if pending, _ := st.ListPendingWorkerIdleEvents(ctx); len(pending) != 0 {
+		t.Fatalf("pending after re-idle = %d, want 0 (no new event enqueued)", len(pending))
+	}
+}
+
+func TestActivity_WorkerReReportsAfterNeedsInput(t *testing.T) {
+	m, st, msg := newManager()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
+
+	// Completion #1 reported.
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle, Timestamp: now}); err != nil {
+		t.Fatal(err)
+	}
+	// The worker enters a real needs-input state: a fresh episode that reopens
+	// reporting for its next completion.
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityWaitingInput, Timestamp: now.Add(time.Minute)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityActive, Timestamp: now.Add(2 * time.Minute)}); err != nil {
+		t.Fatal(err)
+	}
+	// Completion #2 is reportable again.
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle, Timestamp: now.Add(3 * time.Minute)}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 2 {
+		t.Fatalf("nudges = %d, want 2 (re-armed after needs-input)", len(msg.msgs))
+	}
+}
+
+func TestDispatch_DrainsTerminatedWorkerWithoutNudge(t *testing.T) {
+	st := newFakeStore()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	// The worker was killed after the event was enqueued: nothing to inspect.
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, IsTerminated: true, Activity: domain.Activity{State: domain.ActivityExited, LastActivityAt: now}}
+	st.idleEvents = []domain.WorkerIdleEvent{{ID: "wie_1", ProjectID: "mer", WorkerID: "mer-8", TransitionAt: now, CreatedAt: now}}
+	msg := &fakeMessenger{}
+	m := New(st, msg)
+
+	m.DispatchPendingWorkerIdleEvents(ctx, "mer")
+	if len(msg.msgs) != 0 {
+		t.Fatalf("nudged for a terminated worker: %d, want 0", len(msg.msgs))
+	}
+	if pending, _ := st.ListPendingWorkerIdleEvents(ctx); len(pending) != 0 {
+		t.Fatalf("stale event not drained: pending = %d, want 0", len(pending))
+	}
+}
+
+func TestDispatch_OpenPRDrainsMergedPRStillNudges(t *testing.T) {
+	st := newFakeStore()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	// mer-8 has an open PR (work already in review): nudge is noise, drain it.
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	st.prs["mer-8"] = []domain.PullRequest{{URL: "pr-open"}}
+	// mer-9's only PR is merged: its idle is still a real completion to report.
+	st.sessions["mer-9"] = domain.SessionRecord{ID: "mer-9", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	st.prs["mer-9"] = []domain.PullRequest{{URL: "pr-merged", Merged: true}}
+	st.idleEvents = []domain.WorkerIdleEvent{
+		{ID: "wie_8", ProjectID: "mer", WorkerID: "mer-8", TransitionAt: now, CreatedAt: now},
+		{ID: "wie_9", ProjectID: "mer", WorkerID: "mer-9", TransitionAt: now.Add(time.Second), CreatedAt: now.Add(time.Second)},
+	}
+	msg := &fakeMessenger{}
+	m := New(st, msg)
+
+	// Cycle 1 drains the open-PR worker without sending.
+	m.DispatchPendingWorkerIdleEvents(ctx, "mer")
+	if len(msg.msgs) != 0 {
+		t.Fatalf("nudged for an open-PR worker: %d, want 0", len(msg.msgs))
+	}
+	// Cycle 2 delivers the merged-PR worker's completion.
+	m.DispatchPendingWorkerIdleEvents(ctx, "mer")
+	if len(msg.msgs) != 1 || !strings.Contains(msg.msgs[0], "mer-9") {
+		t.Fatalf("merged-PR worker not nudged: msgs = %v", msg.msgs)
+	}
+	if pending, _ := st.ListPendingWorkerIdleEvents(ctx); len(pending) != 0 {
+		t.Fatalf("events not fully processed: pending = %d, want 0", len(pending))
+	}
+}
+
 func TestDispatch_UnsettledOrchestratorRetainsUntilFirstSignal(t *testing.T) {
 	st := newFakeStore()
 	now := time.Now()


### PR DESCRIPTION
## What

Fixes the noise in the "[AO] Worker … has gone idle" nudges reported in #3038. Instead of removing the worker-idle outbox, this keeps the feature and closes the three bug classes with targeted guards.

## Why (live evidence)

Pulled from a running daemon's `worker_idle_events` table: **88 nudge events, one worker (`zero_to_one-23`) generated 25 of them in a single evening** while it was only ever `idle` (not terminated, not done). Root cause: the outbox enqueued on *every* worker `active→idle`, with no delivery-time recheck.

Three distinct symptoms (matching the issue's follow-up report):
1. **Delivery after kill** — event enqueued on idle, delivered later with no terminal check.
2. **Duplicates** — every re-idle re-enqueued (auto-mode turn boundaries, retries).
3. **Re-arm on human/orchestrator poke** — a done/`review_pending` worker flapping `active→idle` after a message re-nudged as if freshly finished.

## Changes (no schema change)

- **Report-once-per-episode** (`ApplyActivitySignal`): an in-memory `reportedIdle` set enqueues at most one nudge per attention episode. Re-idles are suppressed; a worker entering a real `needs_input`/`blocked` state reopens reporting; spawn/restore and termination reset it. A poke-induced idle never passes through `needs_input`, so it is naturally suppressed — this collapses both the duplicates (#2) and the poke re-arms (#3). In-memory by design, mirroring the existing `flights` map: a daemon restart at worst allows one extra nudge, never a lost completion.
- **Delivery-time recheck** (`DispatchPendingWorkerIdleEvents`): re-reads the worker right before sending and drains the event (marks delivered without sending) when the worker is **terminated** or owns an **open PR** (work already in review and visible to the orchestrator). Fixes #1 and stops nudging review_pending workers.

Net effect: workers still show idle in the sidebar; the orchestrator just stops being auto-poked repeatedly for the same completion.

## Tests

`go test ./internal/lifecycle/` (incl. `-race`) green. Added coverage:
- `TestActivity_WorkerReportedOncePerEpisode` — re-idle produces no second nudge.
- `TestActivity_WorkerReReportsAfterNeedsInput` — a genuine needs-input episode re-arms reporting.
- `TestDispatch_DrainsTerminatedWorkerWithoutNudge` — terminated worker's event is drained, not sent.
- `TestDispatch_OpenPRDrainsMergedPRStillNudges` — open-PR worker drained; merged-PR worker still nudges.

Pre-existing failures in `internal/cli`, `adapters/workspace/scratch`, `adapters/agent/kilocode`, and `daemon` are environment-related (macOS `/private/var` path canonicalization, spawn tests needing a live daemon) and reproduce on a clean baseline; none touch `internal/lifecycle`.

## Alternative considered

Full removal of the outbox (what the issue literally proposes). This PR is the "keep it, make it correct" option. If maintainers prefer removal, that is a larger, cleaner delete (trigger, dispatch, store, table via a new drop-migration, daemon sweep) and can be done instead.

Refs #3038