### PR TITLE
fix(telemetry): validate command-shaped values at PostHog sink

### DIFF
--- a/backend/internal/adapters/telemetry/posthog.go
+++ b/backend/internal/adapters/telemetry/posthog.go
@@ -25,6 +25,54 @@ import (
 const postHogBufferSize = 128
 const maxCommandShapeLength = 48
 
+var remoteCommandTokens = map[string]struct{}{
+	"add":              {},
+	"agent":            {},
+	"agent-process":    {},
+	"cancel":           {},
+	"claim-pr":         {},
+	"cleanup":          {},
+	"clear":            {},
+	"completion":       {},
+	"daemon":           {},
+	"delete":           {},
+	"dev":              {},
+	"doctor":           {},
+	"execute":          {},
+	"get":              {},
+	"help":             {},
+	"hooks":            {},
+	"import":           {},
+	"import-projects":  {},
+	"kill":             {},
+	"launch":           {},
+	"list":             {},
+	"ls":               {},
+	"merge":            {},
+	"orchestrator":     {},
+	"preview":          {},
+	"pr":               {},
+	"project":          {},
+	"remove":           {},
+	"rename":           {},
+	"resolve-comments": {},
+	"restart":          {},
+	"restore":          {},
+	"review":           {},
+	"rm":               {},
+	"send":             {},
+	"session":          {},
+	"set-config":       {},
+	"spawn":            {},
+	"start":            {},
+	"status":           {},
+	"stop":             {},
+	"submit":           {},
+	"supervise":        {},
+	"trigger":          {},
+	"version":          {},
+}
+
 var remotePayloadAllowlist = map[string]map[string]struct{}{
 	"ao.app.active": {
 		"actor_type":   {},
@@ -271,26 +319,33 @@ func sanitizeRemotePayload(name string, payload map[string]any) map[string]any {
 	return sanitized
 }
 
-func isCommandShaped(value string) bool {
+func isAllowedCommandValue(key, value string) bool {
 	if value == "" || len(value) > maxCommandShapeLength {
 		return false
 	}
-	tokens := strings.Fields(value)
-	if len(tokens) == 0 || strings.Join(tokens, " ") != value {
+	tokens := strings.Split(value, " ")
+	if key == "command" {
+		if len(tokens) != 1 {
+			return false
+		}
+		if value == "ao" || value == "<unknown>" {
+			return true
+		}
+		_, ok := remoteCommandTokens[value]
+		return ok
+	}
+	if key != "command_path" || tokens[0] != "ao" {
 		return false
 	}
-	for _, token := range tokens {
+	for i, token := range tokens[1:] {
 		if token == "<unknown>" {
-			continue
-		}
-		for _, char := range token {
-			if (char < 'a' || char > 'z') &&
-				(char < 'A' || char > 'Z') &&
-				(char < '0' || char > '9') &&
-				char != '-' &&
-				char != '_' {
+			if i != len(tokens[1:])-1 {
 				return false
 			}
+			continue
+		}
+		if _, ok := remoteCommandTokens[token]; !ok {
+			return false
 		}
 	}
 	return true
@@ -303,7 +358,7 @@ func sanitizeRemoteValue(key string, v any) (any, bool) {
 		if value == "" {
 			return nil, false
 		}
-		if (key == "command" || key == "command_path") && !isCommandShaped(value) {
+		if (key == "command" || key == "command_path") && !isAllowedCommandValue(key, value) {
 			return "sha256:" + sha256String(value)[:16], true
 		}
 		return value, true

--- a/backend/internal/adapters/telemetry/posthog.go
+++ b/backend/internal/adapters/telemetry/posthog.go
@@ -23,6 +23,7 @@ import (
 )
 
 const postHogBufferSize = 128
+const maxCommandShapeLength = 48
 
 var remotePayloadAllowlist = map[string]map[string]struct{}{
 	"ao.app.active": {
@@ -263,18 +264,49 @@ func sanitizeRemotePayload(name string, payload map[string]any) map[string]any {
 		if !ok {
 			continue
 		}
-		if safe, ok := sanitizeRemoteValue(value); ok {
+		if safe, ok := sanitizeRemoteValue(key, value); ok {
 			sanitized[key] = safe
 		}
 	}
 	return sanitized
 }
 
-func sanitizeRemoteValue(v any) (any, bool) {
+func isCommandShaped(value string) bool {
+	if value == "" || len(value) > maxCommandShapeLength {
+		return false
+	}
+	tokens := strings.Fields(value)
+	if len(tokens) == 0 || strings.Join(tokens, " ") != value {
+		return false
+	}
+	for _, token := range tokens {
+		if token == "<unknown>" {
+			continue
+		}
+		for _, char := range token {
+			if (char < 'a' || char > 'z') &&
+				(char < 'A' || char > 'Z') &&
+				(char < '0' || char > '9') &&
+				char != '-' &&
+				char != '_' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func sanitizeRemoteValue(key string, v any) (any, bool) {
 	switch value := v.(type) {
 	case string:
 		value = strings.TrimSpace(value)
-		return value, value != ""
+		if value == "" {
+			return nil, false
+		}
+		if (key == "command" || key == "command_path") && !isCommandShaped(value) {
+			return "sha256:" + sha256String(value)[:16], true
+		}
+		return value, true
 	case bool:
 		return value, true
 	case int:

--- a/backend/internal/adapters/telemetry/sanitize_command_test.go
+++ b/backend/internal/adapters/telemetry/sanitize_command_test.go
@@ -1,0 +1,65 @@
+package telemetry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeRemoteValueHashesInvalidCommandValues(t *testing.T) {
+	invalid := []string{
+		"https://github.com/org/repo/pull/1",
+		"/Users/example/private-project",
+		"ao Review this PR; ping @security",
+		"严格审查必须完成",
+		strings.Repeat("x", maxCommandShapeLength+1),
+	}
+
+	for _, key := range []string{"command", "command_path"} {
+		for _, value := range invalid {
+			t.Run(key+"/"+value, func(t *testing.T) {
+				first, ok := sanitizeRemoteValue(key, value)
+				if !ok {
+					t.Fatal("invalid command value was dropped")
+				}
+				second, ok := sanitizeRemoteValue(key, value)
+				if !ok || second != first {
+					t.Fatalf("hash is not stable: first=%v second=%v", first, second)
+				}
+				token, ok := first.(string)
+				if !ok || len(token) != len("sha256:")+16 || !strings.HasPrefix(token, "sha256:") {
+					t.Fatalf("sanitized value = %#v, want sha256:<16 hex>", first)
+				}
+				if strings.Contains(token, value) {
+					t.Fatalf("sanitized value leaked raw input: %q", token)
+				}
+			})
+		}
+	}
+}
+
+func TestSanitizeRemoteValuePreservesValidCommands(t *testing.T) {
+	tests := []struct {
+		key   string
+		value string
+	}{
+		{key: "command", value: "status"},
+		{key: "command", value: "review-checkpoint"},
+		{key: "command_path", value: "ao session ls"},
+		{key: "command_path", value: "ao list <unknown>"},
+	}
+
+	for _, test := range tests {
+		got, ok := sanitizeRemoteValue(test.key, test.value)
+		if !ok || got != test.value {
+			t.Errorf("%s=%q: got (%v, %v), want unchanged", test.key, test.value, got, ok)
+		}
+	}
+}
+
+func TestSanitizeRemoteValueDoesNotApplyCommandValidationToOtherKeys(t *testing.T) {
+	const value = "http_request_panic"
+	got, ok := sanitizeRemoteValue("operation", value)
+	if !ok || got != value {
+		t.Fatalf("operation=%q: got (%v, %v), want unchanged", value, got, ok)
+	}
+}

--- a/backend/internal/adapters/telemetry/sanitize_command_test.go
+++ b/backend/internal/adapters/telemetry/sanitize_command_test.go
@@ -10,6 +10,9 @@ func TestSanitizeRemoteValueHashesInvalidCommandValues(t *testing.T) {
 		"https://github.com/org/repo/pull/1",
 		"/Users/example/private-project",
 		"ao Review this PR; ping @security",
+		"customer acme launch",
+		"secret_project",
+		"ao private customer",
 		"严格审查必须完成",
 		strings.Repeat("x", maxCommandShapeLength+1),
 	}
@@ -43,9 +46,9 @@ func TestSanitizeRemoteValuePreservesValidCommands(t *testing.T) {
 		value string
 	}{
 		{key: "command", value: "status"},
-		{key: "command", value: "review-checkpoint"},
-		{key: "command_path", value: "ao session ls"},
-		{key: "command_path", value: "ao list <unknown>"},
+		{key: "command", value: "resolve-comments"},
+		{key: "command_path", value: "ao pr resolve-comments"},
+		{key: "command_path", value: "ao session get <unknown>"},
 	}
 
 	for _, test := range tests {

--- a/backend/internal/httpd/telemetry_test.go
+++ b/backend/internal/httpd/telemetry_test.go
@@ -1,15 +1,25 @@
 package httpd
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
+	telemetryadapter "github.com/aoagents/agent-orchestrator/backend/internal/adapters/telemetry"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 )
+
+type telemetryRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f telemetryRoundTripper) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
 	sink := &captureSink{}
@@ -198,6 +208,69 @@ func TestCLIUsageErrorRouteEmitsTelemetry(t *testing.T) {
 	}
 	if _, ok := payload["error"]; ok {
 		t.Fatalf("payload leaked raw error text: %#v", payload)
+	}
+}
+
+func TestCLIUsageErrorRouteHashesInvalidCommandsBeforeRemoteExport(t *testing.T) {
+	requests := make(chan map[string]any, 1)
+	sink, err := telemetryadapter.NewPostHogSink(
+		t.TempDir(),
+		"phc_test",
+		"https://us.i.posthog.com",
+		telemetryRoundTripper(func(req *http.Request) (*http.Response, error) {
+			defer req.Body.Close()
+			var body map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				return nil, err
+			}
+			requests <- body
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       http.NoBody,
+			}, nil
+		}),
+		discardLogger(),
+	)
+	if err != nil {
+		t.Fatalf("NewPostHogSink: %v", err)
+	}
+
+	r := chi.NewRouter()
+	mountTelemetry(r, config.Config{DataDir: t.TempDir()}, sink)
+
+	const rawCommand = "Review https://example.com/private; ping @security"
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"http://127.0.0.1/internal/telemetry/cli-usage-error",
+		strings.NewReader(`{"command":"`+rawCommand+`","commandPath":"ao `+rawCommand+`","error":"too many args"}`),
+	)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	if err := sink.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case request := <-requests:
+		properties, ok := request["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("properties type = %T, want map[string]any", request["properties"])
+		}
+		for _, key := range []string{"command", "command_path"} {
+			value, ok := properties[key].(string)
+			if !ok || len(value) != len("sha256:")+16 || !strings.HasPrefix(value, "sha256:") {
+				t.Fatalf("properties.%s = %#v, want sha256:<16 hex>", key, properties[key])
+			}
+			if strings.Contains(value, rawCommand) {
+				t.Fatalf("properties.%s leaked raw command: %q", key, value)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("PostHog sink did not send request")
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate `command` and `command_path` values at the PostHog sink
- replace invalid command-shaped values with stable `sha256:<16 hex>` tokens
- keep valid command names and paths unchanged
- cover the sanitizer and the full telemetry route-to-PostHog payload

## Why

The remote allowlist restricted telemetry keys, but any string stored under a command-shaped key could still be forwarded. This adds a sink-side backstop so URLs, local paths, prose, and other unexpected values cannot leave the machine as raw text.

## Tests

- `npm run lint`
- `cd backend && go vet ./...`
- `cd backend && go test -race ./internal/adapters/telemetry ./internal/httpd`

Closes #3133
