### PR TITLE
feat: offer to relaunch sessions when the project default permission mode changes (#2504)

### DIFF
--- a/backend/internal/cli/dto_drift_e2e_test.go
+++ b/backend/internal/cli/dto_drift_e2e_test.go
@@ -39,8 +39,8 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 	agentsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/agent"
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
-	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
+	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 )
 
 // fakeSessionService captures the ports.SpawnConfig the controller decodes from

--- a/backend/internal/cli/dto_drift_e2e_test.go
+++ b/backend/internal/cli/dto_drift_e2e_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 	agentsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/agent"
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
+	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
 )
 
@@ -86,6 +87,14 @@ func (f *fakeSessionService) Kill(context.Context, domain.SessionID) (bool, erro
 
 func (f *fakeSessionService) RollbackSpawn(context.Context, domain.SessionID) (sessionsvc.RollbackOutcome, error) {
 	return sessionsvc.RollbackOutcome{}, nil
+}
+
+func (f *fakeSessionService) AffectedByPermissionChange(context.Context, domain.ProjectID) ([]sessionmanager.AffectedSession, error) {
+	return nil, nil
+}
+
+func (f *fakeSessionService) RelaunchForPermissionChange(context.Context, domain.ProjectID) ([]sessionmanager.RelaunchOutcome, error) {
+	return nil, nil
 }
 
 func (f *fakeSessionService) Cleanup(context.Context, domain.ProjectID) (sessionsvc.CleanupOutcome, error) {

--- a/backend/internal/cli/spawn_test.go
+++ b/backend/internal/cli/spawn_test.go
@@ -18,10 +18,18 @@ func authorizedAgentsJSON(agent string) string {
 	return `{"supported":[` + info + `],"installed":[` + info + `],"authorized":[` + info + `]}`
 }
 
+func setSpawnConfigEnv(t *testing.T) testConfig {
+	t.Helper()
+	cfg := setConfigEnv(t)
+	t.Setenv("AO_PROJECT_ID", "")
+	t.Setenv("AO_SESSION_ID", "")
+	return cfg
+}
+
 // TestSpawnCommand_MissingProjectContext asserts `ao spawn` gives a project
 // setup hint when neither --project, AO_PROJECT_ID, nor cwd can resolve one.
 func TestSpawnCommand_MissingProjectContext(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		appendPrimaryRequest(&requests, r)
@@ -63,7 +71,7 @@ func TestProjectAddCommand_RequiresPath(t *testing.T) {
 }
 
 func TestSpawnClaimPRWiring(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		appendPrimaryRequest(&requests, r)
@@ -103,7 +111,7 @@ func TestSpawnClaimPRWiring(t *testing.T) {
 }
 
 func TestSpawnClaimPRFailureRollsBackSession(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	sessions := map[string]bool{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -176,7 +184,7 @@ func TestSpawnCommand_RejectsOverlongName(t *testing.T) {
 }
 
 func TestSpawnResolvesProjectFromEnvAndDefaultAgent(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -220,7 +228,7 @@ func TestSpawnResolvesProjectFromEnvAndDefaultAgent(t *testing.T) {
 }
 
 func TestSpawnResolvesProjectFromAOSessionID(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -260,7 +268,7 @@ func TestSpawnResolvesProjectFromAOSessionID(t *testing.T) {
 }
 
 func TestSpawnAOSessionIDFailureRequiresProject(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		appendPrimaryRequest(&requests, r)
@@ -288,7 +296,7 @@ func TestSpawnAOSessionIDFailureRequiresProject(t *testing.T) {
 }
 
 func TestSpawnResolvesProjectFromCWD(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	repo := filepath.Join(t.TempDir(), "repo")
 	subdir := filepath.Join(repo, "pkg")
 	if err := os.MkdirAll(subdir, 0o755); err != nil {
@@ -335,7 +343,7 @@ func TestSpawnResolvesProjectFromCWD(t *testing.T) {
 }
 
 func TestSpawnDefaultsToScratchWhenOnlyActiveProject(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -386,7 +394,7 @@ func TestSpawnScratchRejectsGitOnlyFlags(t *testing.T) {
 		{name: "claim pr", args: []string{"spawn", "--project", "scratch", "--agent", "codex", "--name", "Scratch Task", "--claim-pr", "142"}, wantErr: "scratch projects do not support --claim-pr"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := setConfigEnv(t)
+			cfg := setSpawnConfigEnv(t)
 			var requests []string
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				appendPrimaryRequest(&requests, r)
@@ -414,7 +422,7 @@ func TestSpawnScratchRejectsGitOnlyFlags(t *testing.T) {
 }
 
 func TestSpawnStaleUnauthorizedAgentRefreshesProbesThenAllows(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -456,7 +464,7 @@ func TestSpawnStaleUnauthorizedAgentRefreshesProbesThenAllows(t *testing.T) {
 }
 
 func TestSpawnFreshUnauthorizedWarnsAndAllows(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -498,7 +506,7 @@ func TestSpawnFreshUnauthorizedWarnsAndAllows(t *testing.T) {
 }
 
 func TestSpawnUnavailableFreshProbeWarnsAndAllows(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -541,7 +549,7 @@ func TestSpawnUnavailableFreshProbeWarnsAndAllows(t *testing.T) {
 }
 
 func TestSpawnUnsupportedAgentRefreshesThenBlocks(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		appendPrimaryRequest(&requests, r)
@@ -569,7 +577,7 @@ func TestSpawnUnsupportedAgentRefreshesThenBlocks(t *testing.T) {
 }
 
 func TestSpawnNotInstalledAgentRefreshesThenBlocks(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		appendPrimaryRequest(&requests, r)
@@ -599,7 +607,7 @@ func TestSpawnNotInstalledAgentRefreshesThenBlocks(t *testing.T) {
 }
 
 func TestSpawnStaleNotInstalledFreshInstalledWarnsAndAllows(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -641,7 +649,7 @@ func TestSpawnStaleNotInstalledFreshInstalledWarnsAndAllows(t *testing.T) {
 }
 
 func TestSpawnUnavailableFreshProbeForNotInstalledWarnsAndAllows(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -684,7 +692,7 @@ func TestSpawnUnavailableFreshProbeForNotInstalledWarnsAndAllows(t *testing.T) {
 }
 
 func TestSpawnFreshProbeServerErrorBlocks(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		appendPrimaryRequest(&requests, r)
@@ -715,7 +723,7 @@ func TestSpawnFreshProbeServerErrorBlocks(t *testing.T) {
 }
 
 func TestSpawnSkipAgentCheckBypassesOnlyPreflight(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var requests []string
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -750,7 +758,7 @@ func TestSpawnSkipAgentCheckBypassesOnlyPreflight(t *testing.T) {
 }
 
 func TestSpawnUnknownAuthRefreshesWarnsAndAllows(t *testing.T) {
-	cfg := setConfigEnv(t)
+	cfg := setSpawnConfigEnv(t)
 	var req spawnRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -40,6 +40,10 @@ type SessionMetadata struct {
 	// even when PreviewURL is unchanged. The desktop browser panel keys
 	// navigation on it so a repeated `ao preview <same-url>` still refreshes.
 	PreviewRevision int64 `json:"previewRevision,omitempty"`
+	// Permissions records the permission mode this session's agent was actually
+	// launched with, so a project-default change can tell which running sessions
+	// diverge and offer to relaunch them.
+	Permissions PermissionMode `json:"permissions,omitempty"`
 }
 
 // SessionRecord is the persistence shape. It intentionally stores only durable

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -806,6 +806,74 @@ paths:
       summary: Replace a project's per-project config
       tags:
       - projects
+  /api/v1/projects/{id}/permission-relaunch:
+    post:
+      operationId: relaunchForPermissionChange
+      parameters:
+      - description: Project identifier (registry key).
+        in: path
+        name: id
+        required: true
+        schema:
+          description: Project identifier (registry key).
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RelaunchForPermissionChangeResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+      summary: Kill and restore running worker sessions whose permission mode diverges
+        from the project default
+      tags:
+      - sessions
+  /api/v1/projects/{id}/permission-relaunch/affected:
+    get:
+      operationId: affectedByPermissionChange
+      parameters:
+      - description: Project identifier (registry key).
+        in: path
+        name: id
+        required: true
+        schema:
+          description: Project identifier (registry key).
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AffectedByPermissionChangeResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+      summary: List running worker sessions affected by a project permission mode
+        change
+      tags:
+      - sessions
   /api/v1/projects/initialize:
     post:
       operationId: initializeProjectRepository
@@ -2247,6 +2315,37 @@ components:
       required:
       - path
       type: object
+    AffectedByPermissionChangeResponse:
+      properties:
+        affected:
+          items:
+            $ref: '#/components/schemas/AffectedSessionItem'
+          type: array
+        count:
+          type: integer
+      required:
+      - affected
+      - count
+      type: object
+    AffectedSessionItem:
+      properties:
+        fromMode:
+          type: string
+        kind:
+          type: string
+        sessionId:
+          type: string
+        title:
+          type: string
+        toMode:
+          type: string
+      required:
+      - sessionId
+      - title
+      - kind
+      - fromMode
+      - toMode
+      type: object
     AgentConfig:
       properties:
         model:
@@ -3054,6 +3153,33 @@ components:
           type: string
       required:
       - token
+      type: object
+    RelaunchForPermissionChangeResponse:
+      properties:
+        failed:
+          type: integer
+        relaunched:
+          type: integer
+        results:
+          items:
+            $ref: '#/components/schemas/RelaunchOutcomeItem'
+          type: array
+      required:
+      - results
+      - relaunched
+      - failed
+      type: object
+    RelaunchOutcomeItem:
+      properties:
+        error:
+          type: string
+        ok:
+          type: boolean
+        sessionId:
+          type: string
+      required:
+      - sessionId
+      - ok
       type: object
     RemoveProjectResult:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -222,9 +222,9 @@ var schemaNames = map[string]string{
 	"DomainReviewRun":     "ReviewRun",
 	"ReviewPRReviewState": "PRReviewState",
 	// httpd/controllers: permission relaunch wire envelopes
-	"ControllersAffectedSessionItem":                "AffectedSessionItem",
-	"ControllersAffectedByPermissionChangeResponse": "AffectedByPermissionChangeResponse",
-	"ControllersRelaunchOutcomeItem":                "RelaunchOutcomeItem",
+	"ControllersAffectedSessionItem":                 "AffectedSessionItem",
+	"ControllersAffectedByPermissionChangeResponse":  "AffectedByPermissionChangeResponse",
+	"ControllersRelaunchOutcomeItem":                 "RelaunchOutcomeItem",
 	"ControllersRelaunchForPermissionChangeResponse": "RelaunchForPermissionChangeResponse",
 	// httpd/controllers: import wire envelopes
 	"ControllersImportStatusResponse": "ImportStatusResponse",

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -221,6 +221,11 @@ var schemaNames = map[string]string{
 	// domain review entities
 	"DomainReviewRun":     "ReviewRun",
 	"ReviewPRReviewState": "PRReviewState",
+	// httpd/controllers: permission relaunch wire envelopes
+	"ControllersAffectedSessionItem":                "AffectedSessionItem",
+	"ControllersAffectedByPermissionChangeResponse": "AffectedByPermissionChangeResponse",
+	"ControllersRelaunchOutcomeItem":                "RelaunchOutcomeItem",
+	"ControllersRelaunchForPermissionChangeResponse": "RelaunchForPermissionChangeResponse",
 	// httpd/controllers: import wire envelopes
 	"ControllersImportStatusResponse": "ImportStatusResponse",
 	"ControllersImportRunResponse":    "ImportRunResponse",
@@ -1017,6 +1022,26 @@ func sessionOperations() []operation {
 				{http.StatusNotFound, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},
 				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodGet, path: "/api/v1/projects/{id}/permission-relaunch/affected", id: "affectedByPermissionChange", tag: "sessions",
+			summary:    "List running worker sessions affected by a project permission mode change",
+			pathParams: []any{controllers.ProjectIDParam{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.AffectedByPermissionChangeResponse{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodPost, path: "/api/v1/projects/{id}/permission-relaunch", id: "relaunchForPermissionChange", tag: "sessions",
+			summary:    "Kill and restore running worker sessions whose permission mode diverges from the project default",
+			pathParams: []any{controllers.ProjectIDParam{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.RelaunchForPermissionChangeResponse{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
 			},
 		},
 	}

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -733,7 +733,7 @@ type ResolveCommentsResponse struct {
 
 // MobileStatusResponse is the body of the Connect Mobile status/enable/disable/
 // regenerate endpoints. Password is populated only transiently, on enable and
-// regenerate responses (empty otherwise) — it is never persisted in plaintext.
+// regenerate responses (empty otherwise), it is never persisted in plaintext.
 type MobileStatusResponse struct {
 	Enabled  bool   `json:"enabled"`
 	Host     string `json:"host"`
@@ -774,4 +774,33 @@ type PushDeviceEnvelope struct {
 type UnregisterPushDeviceResponse struct {
 	Token   string `json:"token"`
 	Deleted bool   `json:"deleted"`
+}
+
+// AffectedSessionItem is one session entry in AffectedByPermissionChangeResponse.
+type AffectedSessionItem struct {
+	SessionID string `json:"sessionId"`
+	Title     string `json:"title"`
+	Kind      string `json:"kind"`
+	FromMode  string `json:"fromMode"`
+	ToMode    string `json:"toMode"`
+}
+
+// AffectedByPermissionChangeResponse is the body of GET /api/v1/projects/{id}/permission-relaunch/affected.
+type AffectedByPermissionChangeResponse struct {
+	Affected []AffectedSessionItem `json:"affected"`
+	Count    int                   `json:"count"`
+}
+
+// RelaunchOutcomeItem is one session result in RelaunchForPermissionChangeResponse.
+type RelaunchOutcomeItem struct {
+	SessionID string `json:"sessionId"`
+	OK        bool   `json:"ok"`
+	Error     string `json:"error,omitempty"`
+}
+
+// RelaunchForPermissionChangeResponse is the body of POST /api/v1/projects/{id}/permission-relaunch.
+type RelaunchForPermissionChangeResponse struct {
+	Results    []RelaunchOutcomeItem `json:"results"`
+	Relaunched int                   `json:"relaunched"`
+	Failed     int                   `json:"failed"`
 }

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	previewutil "github.com/aoagents/agent-orchestrator/backend/internal/preview"
 	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
+	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 )
 
 const (
@@ -78,6 +79,8 @@ type SessionService interface {
 	ClaimPR(ctx context.Context, id domain.SessionID, ref string, opts sessionsvc.ClaimPROptions) (sessionsvc.ClaimPRResult, error)
 	ListWorkspaceFiles(ctx context.Context, id domain.SessionID) (sessionsvc.WorkspaceFiles, error)
 	GetWorkspaceFile(ctx context.Context, id domain.SessionID, path string) (sessionsvc.WorkspaceFileDetail, error)
+	AffectedByPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionmanager.AffectedSession, error)
+	RelaunchForPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionmanager.RelaunchOutcome, error)
 }
 
 // ActivityRecorder applies an agent activity-state signal to a session. It is
@@ -121,6 +124,8 @@ func (c *SessionsController) Register(r chi.Router) {
 	r.Get("/orchestrators", c.listOrchestrators)
 	r.Post("/orchestrators", c.spawnOrchestrator)
 	r.Get("/orchestrators/{id}", c.getOrchestrator)
+	r.Get("/projects/{id}/permission-relaunch/affected", c.affectedByPermissionChange)
+	r.Post("/projects/{id}/permission-relaunch", c.relaunchForPermissionChange)
 }
 
 func (c *SessionsController) list(w http.ResponseWriter, r *http.Request) {
@@ -795,6 +800,56 @@ func (c *SessionsController) getOrchestrator(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	envelope.WriteJSON(w, http.StatusOK, SessionResponse{Session: sessionView(sess)})
+}
+
+func (c *SessionsController) affectedByPermissionChange(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", "/api/v1/projects/{id}/permission-relaunch/affected")
+		return
+	}
+	affected, err := c.Svc.AffectedByPermissionChange(r.Context(), projectID(r))
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	items := make([]AffectedSessionItem, len(affected))
+	for i, a := range affected {
+		items[i] = AffectedSessionItem{
+			SessionID: string(a.SessionID),
+			Title:     a.Title,
+			Kind:      string(a.Kind),
+			FromMode:  string(a.FromMode),
+			ToMode:    string(a.ToMode),
+		}
+	}
+	envelope.WriteJSON(w, http.StatusOK, AffectedByPermissionChangeResponse{Affected: items, Count: len(items)})
+}
+
+func (c *SessionsController) relaunchForPermissionChange(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/projects/{id}/permission-relaunch")
+		return
+	}
+	outcomes, err := c.Svc.RelaunchForPermissionChange(r.Context(), projectID(r))
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	results := make([]RelaunchOutcomeItem, len(outcomes))
+	relaunched, failed := 0, 0
+	for i, o := range outcomes {
+		results[i] = RelaunchOutcomeItem{
+			SessionID: string(o.SessionID),
+			OK:        o.OK,
+			Error:     o.Error,
+		}
+		if o.OK {
+			relaunched++
+		} else {
+			failed++
+		}
+	}
+	envelope.WriteJSON(w, http.StatusOK, RelaunchForPermissionChangeResponse{Results: results, Relaunched: relaunched, Failed: failed})
 }
 
 func sessionID(r *http.Request) domain.SessionID {

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	previewutil "github.com/aoagents/agent-orchestrator/backend/internal/preview"
 	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
+	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 )
 
 type fakeSessionService struct {
@@ -37,6 +38,8 @@ type fakeSessionService struct {
 	claimErr        error
 	listPRErr       error
 	workspaceErr    error
+	affectedResult  []sessionmanager.AffectedSession
+	relaunchResult  []sessionmanager.RelaunchOutcome
 }
 
 func newFakeSessionService() *fakeSessionService {
@@ -267,6 +270,14 @@ func (f *fakeSessionService) GetWorkspaceFile(_ context.Context, id domain.Sessi
 		return f.workspaceFile, nil
 	}
 	return sessionsvc.WorkspaceFileDetail{SessionID: id, Path: path}, nil
+}
+
+func (f *fakeSessionService) AffectedByPermissionChange(_ context.Context, _ domain.ProjectID) ([]sessionmanager.AffectedSession, error) {
+	return f.affectedResult, nil
+}
+
+func (f *fakeSessionService) RelaunchForPermissionChange(_ context.Context, _ domain.ProjectID) ([]sessionmanager.RelaunchOutcome, error) {
+	return f.relaunchResult, nil
 }
 
 func newSessionTestServer(t *testing.T, svc *fakeSessionService) *httptest.Server {
@@ -1413,5 +1424,55 @@ func TestSessionsAPI_ClaimPRErrors(t *testing.T) {
 			body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/pr/claim", tc.body)
 			assertErrorCode(t, body, status, tc.code, tc.want)
 		})
+	}
+}
+
+func TestSessionsAPI_PermissionRelaunch(t *testing.T) {
+	svc := newFakeSessionService()
+	svc.affectedResult = []sessionmanager.AffectedSession{
+		{SessionID: "ao-1", Title: "my worker", Kind: domain.KindWorker, FromMode: domain.PermissionModeDefault, ToMode: domain.PermissionModeAuto},
+	}
+	svc.relaunchResult = []sessionmanager.RelaunchOutcome{
+		{SessionID: "ao-1", OK: true},
+	}
+	srv := newSessionTestServer(t, svc)
+
+	// GET affected
+	body, status, _ := doRequest(t, srv, "GET", "/api/v1/projects/proj-1/permission-relaunch/affected", "")
+	if status != http.StatusOK {
+		t.Fatalf("GET affected = %d, want 200; body=%s", status, body)
+	}
+	var affected struct {
+		Affected []struct {
+			SessionID string `json:"sessionId"`
+			FromMode  string `json:"fromMode"`
+			ToMode    string `json:"toMode"`
+		} `json:"affected"`
+		Count int `json:"count"`
+	}
+	mustJSON(t, body, &affected)
+	if affected.Count != 1 || affected.Affected[0].SessionID != "ao-1" {
+		t.Fatalf("affected response = %#v", affected)
+	}
+	if affected.Affected[0].FromMode != "default" || affected.Affected[0].ToMode != "auto" {
+		t.Fatalf("modes = from=%q to=%q", affected.Affected[0].FromMode, affected.Affected[0].ToMode)
+	}
+
+	// POST relaunch
+	body, status, _ = doRequest(t, srv, "POST", "/api/v1/projects/proj-1/permission-relaunch", "")
+	if status != http.StatusOK {
+		t.Fatalf("POST relaunch = %d, want 200; body=%s", status, body)
+	}
+	var relaunched struct {
+		Results []struct {
+			SessionID string `json:"sessionId"`
+			OK        bool   `json:"ok"`
+		} `json:"results"`
+		Relaunched int `json:"relaunched"`
+		Failed     int `json:"failed"`
+	}
+	mustJSON(t, body, &relaunched)
+	if relaunched.Relaunched != 1 || relaunched.Failed != 0 {
+		t.Fatalf("relaunch response = %#v", relaunched)
 	}
 }

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -52,6 +52,8 @@ type commander interface {
 	Send(ctx context.Context, id domain.SessionID, message string) error
 	Cleanup(ctx context.Context, project domain.ProjectID) (sessionmanager.CleanupResult, error)
 	RollbackSpawn(ctx context.Context, id domain.SessionID) (deleted, killed bool, err error)
+	AffectedByPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionmanager.AffectedSession, error)
+	RelaunchForPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionmanager.RelaunchOutcome, error)
 }
 
 // RollbackOutcome reports what happened in a rollback: either the seed row was
@@ -459,6 +461,20 @@ func restoreModeView(mode sessionmanager.RestoreMode) RestoreModeView {
 func (s *Service) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	freed, err := s.manager.Kill(ctx, id)
 	return freed, toAPIError(err)
+}
+
+// AffectedByPermissionChange returns the running worker sessions whose
+// launched permission mode differs from the project's current effective mode.
+func (s *Service) AffectedByPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionmanager.AffectedSession, error) {
+	affected, err := s.manager.AffectedByPermissionChange(ctx, projectID)
+	return affected, toAPIError(err)
+}
+
+// RelaunchForPermissionChange kills then restores each running worker session
+// whose permission mode diverges from the project's current effective mode.
+func (s *Service) RelaunchForPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionmanager.RelaunchOutcome, error) {
+	outcomes, err := s.manager.RelaunchForPermissionChange(ctx, projectID)
+	return outcomes, toAPIError(err)
 }
 
 // RollbackSpawn deletes a seed-state session row, or falls back to a Kill if

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -587,6 +587,13 @@ func (f *fakeCommander) Send(_ context.Context, id domain.SessionID, message str
 	f.sentMessages = append(f.sentMessages, message)
 	return nil
 }
+
+func (f *fakeCommander) AffectedByPermissionChange(_ context.Context, _ domain.ProjectID) ([]sessionmanager.AffectedSession, error) {
+	return nil, nil
+}
+func (f *fakeCommander) RelaunchForPermissionChange(_ context.Context, _ domain.ProjectID) ([]sessionmanager.RelaunchOutcome, error) {
+	return nil, nil
+}
 func (f *fakeCommander) Cleanup(_ context.Context, project domain.ProjectID) (sessionmanager.CleanupResult, error) {
 	f.cleanupProjects = append(f.cleanupProjects, project)
 	if f.cleanupErr != nil {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -506,6 +506,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		RuntimeHandleID:   handle.ID,
 		RuntimeLaunchID:   launchID,
 		Prompt:            prompt,
+		Permissions:       agentConfig.Permissions,
 	}
 	if err := m.lcm.MarkSpawned(ctx, id, metadata); err != nil {
 		runtimeDestroyed := m.runtime.Destroy(ctx, handle) == nil
@@ -1187,6 +1188,7 @@ func (m *Manager) relaunchSession(ctx context.Context, operation string, rec dom
 		RuntimeLaunchID:   launchID,
 		AgentSessionID:    rec.Metadata.AgentSessionID,
 		Prompt:            rec.Metadata.Prompt,
+		Permissions:       agentConfig.Permissions,
 	}
 	if err := m.lcm.MarkSpawned(ctx, rec.ID, metadata); err != nil {
 		_ = m.runtime.Destroy(ctx, handle)

--- a/backend/internal/session_manager/permission_relaunch.go
+++ b/backend/internal/session_manager/permission_relaunch.go
@@ -1,0 +1,101 @@
+package sessionmanager
+
+import (
+	"context"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// AffectedSession describes a running worker session whose launched permission
+// mode differs from the project's current effective mode.
+type AffectedSession struct {
+	SessionID domain.SessionID
+	Title     string
+	Kind      domain.SessionKind
+	FromMode  domain.PermissionMode
+	ToMode    domain.PermissionMode
+}
+
+// RelaunchOutcome reports what happened for one session in a batch relaunch.
+type RelaunchOutcome struct {
+	SessionID domain.SessionID
+	OK        bool
+	Error     string
+}
+
+// normalizePermission maps the empty string (unset) to the default mode.
+func normalizePermission(p domain.PermissionMode) domain.PermissionMode {
+	if p == "" {
+		return domain.PermissionModeDefault
+	}
+	return p
+}
+
+// AffectedByPermissionChange returns the running worker sessions for a project
+// whose launched permission mode differs from the project's current effective
+// mode. Terminated sessions, the orchestrator, and sessions without a
+// restorable workspace are excluded.
+func (m *Manager) AffectedByPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]AffectedSession, error) {
+	project, err := m.loadProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	recs, err := m.store.ListSessions(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	var affected []AffectedSession
+	for _, rec := range recs {
+		if rec.IsTerminated {
+			continue
+		}
+		if rec.Kind == domain.KindOrchestrator {
+			continue
+		}
+		if rec.Metadata.WorkspacePath == "" || rec.Metadata.Branch == "" {
+			continue
+		}
+		current := effectiveAgentConfig(rec.Kind, project.Config)
+		if normalizePermission(rec.Metadata.Permissions) == normalizePermission(current.Permissions) {
+			continue
+		}
+		title := rec.DisplayName
+		if title == "" {
+			title = string(rec.ID)
+		}
+		affected = append(affected, AffectedSession{
+			SessionID: rec.ID,
+			Title:     title,
+			Kind:      rec.Kind,
+			FromMode:  normalizePermission(rec.Metadata.Permissions),
+			ToMode:    normalizePermission(current.Permissions),
+		})
+	}
+	return affected, nil
+}
+
+// RelaunchForPermissionChange kills then restores each running worker session
+// whose permission mode differs from the project's current effective mode.
+// Each session is processed sequentially. Kill errors skip the Restore step
+// but do not abort the batch; Restore errors are recorded and the loop
+// continues. The orchestrator is never touched.
+func (m *Manager) RelaunchForPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]RelaunchOutcome, error) {
+	affected, err := m.AffectedByPermissionChange(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	outcomes := make([]RelaunchOutcome, 0, len(affected))
+	for _, a := range affected {
+		id := a.SessionID
+		if _, killErr := m.Kill(ctx, id); killErr != nil {
+			outcomes = append(outcomes, RelaunchOutcome{SessionID: id, OK: false, Error: killErr.Error()})
+			continue
+		}
+		if _, restoreErr := m.RestoreWithMode(ctx, id); restoreErr != nil {
+			outcomes = append(outcomes, RelaunchOutcome{SessionID: id, OK: false, Error: restoreErr.Error()})
+			continue
+		}
+		outcomes = append(outcomes, RelaunchOutcome{SessionID: id, OK: true})
+	}
+	return outcomes, nil
+}

--- a/backend/internal/session_manager/permission_relaunch_test.go
+++ b/backend/internal/session_manager/permission_relaunch_test.go
@@ -1,0 +1,182 @@
+package sessionmanager
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// mkWorkerRec builds a minimal live worker session record for permission tests.
+func mkWorkerRec(id domain.SessionID, projectID domain.ProjectID, perm domain.PermissionMode) domain.SessionRecord {
+	return domain.SessionRecord{
+		ID:        id,
+		ProjectID: projectID,
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/" + string(id),
+			Branch:        "ao/" + string(id) + "/root",
+			Permissions:   perm,
+		},
+		Activity: domain.Activity{State: domain.ActivityIdle},
+	}
+}
+
+func TestAffectedByPermissionChange(t *testing.T) {
+	type sessionSetup struct {
+		id           domain.SessionID
+		kind         domain.SessionKind
+		terminated   bool
+		workspace    string
+		branch       string
+		storedPerm   domain.PermissionMode
+		displayName  string
+	}
+	cases := []struct {
+		name        string
+		projectPerm domain.PermissionMode
+		sessions    []sessionSetup
+		wantIDs     []domain.SessionID
+	}{
+		{
+			name:        "terminated excluded",
+			projectPerm: domain.PermissionModeAuto,
+			sessions: []sessionSetup{
+				{id: "s-1", kind: domain.KindWorker, terminated: true, workspace: "/ws/s-1", branch: "b/s-1", storedPerm: domain.PermissionModeDefault},
+			},
+			wantIDs: nil,
+		},
+		{
+			name:        "orchestrator excluded",
+			projectPerm: domain.PermissionModeAuto,
+			sessions: []sessionSetup{
+				{id: "s-1", kind: domain.KindOrchestrator, workspace: "/ws/s-1", branch: "b/s-1", storedPerm: domain.PermissionModeDefault},
+			},
+			wantIDs: nil,
+		},
+		{
+			name:        "non-restorable missing workspace excluded",
+			projectPerm: domain.PermissionModeAuto,
+			sessions: []sessionSetup{
+				{id: "s-1", kind: domain.KindWorker, workspace: "", branch: "b/s-1", storedPerm: domain.PermissionModeDefault},
+			},
+			wantIDs: nil,
+		},
+		{
+			name:        "non-restorable missing branch excluded",
+			projectPerm: domain.PermissionModeAuto,
+			sessions: []sessionSetup{
+				{id: "s-1", kind: domain.KindWorker, workspace: "/ws/s-1", branch: "", storedPerm: domain.PermissionModeDefault},
+			},
+			wantIDs: nil,
+		},
+		{
+			name:        "unchanged mode excluded",
+			projectPerm: domain.PermissionModeAuto,
+			sessions: []sessionSetup{
+				{id: "s-1", kind: domain.KindWorker, workspace: "/ws/s-1", branch: "b/s-1", storedPerm: domain.PermissionModeAuto},
+			},
+			wantIDs: nil,
+		},
+		{
+			name:        "changed mode included",
+			projectPerm: domain.PermissionModeAuto,
+			sessions: []sessionSetup{
+				{id: "s-1", kind: domain.KindWorker, workspace: "/ws/s-1", branch: "b/s-1", storedPerm: domain.PermissionModeDefault},
+			},
+			wantIDs: []domain.SessionID{"s-1"},
+		},
+		{
+			name:        "empty stored treated as default differs from auto",
+			projectPerm: domain.PermissionModeAuto,
+			sessions: []sessionSetup{
+				{id: "s-1", kind: domain.KindWorker, workspace: "/ws/s-1", branch: "b/s-1", storedPerm: ""},
+			},
+			wantIDs: []domain.SessionID{"s-1"},
+		},
+		{
+			name:        "empty stored treated as default same as default excluded",
+			projectPerm: domain.PermissionModeDefault,
+			sessions: []sessionSetup{
+				{id: "s-1", kind: domain.KindWorker, workspace: "/ws/s-1", branch: "b/s-1", storedPerm: ""},
+			},
+			wantIDs: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := newFakeStore()
+			// Set up project with the desired permission mode.
+			st.projects["proj"] = domain.ProjectRecord{
+				ID: "proj",
+				Config: domain.ProjectConfig{
+					AgentConfig: domain.AgentConfig{Permissions: tc.projectPerm},
+					Worker:      domain.RoleOverride{Harness: domain.HarnessClaudeCode},
+				},
+			}
+			for _, s := range tc.sessions {
+				rec := domain.SessionRecord{
+					ID:        s.id,
+					ProjectID: "proj",
+					Kind:      s.kind,
+					Harness:   domain.HarnessClaudeCode,
+					IsTerminated: s.terminated,
+					DisplayName: s.displayName,
+					Metadata: domain.SessionMetadata{
+						WorkspacePath: s.workspace,
+						Branch:        s.branch,
+						Permissions:   s.storedPerm,
+					},
+					Activity: domain.Activity{State: domain.ActivityIdle},
+				}
+				st.sessions[s.id] = rec
+			}
+			lookPath := func(string) (string, error) { return "/bin/true", nil }
+			m := New(Deps{
+				Runtime:   &fakeRuntime{},
+				Agents:    fakeAgents{},
+				Workspace: &fakeWorkspace{},
+				Store:     st,
+				Messenger: &fakeMessenger{},
+				Lifecycle: &fakeLCM{store: st},
+				LookPath:  lookPath,
+			})
+			affected, err := m.AffectedByPermissionChange(ctx, "proj")
+			if err != nil {
+				t.Fatalf("AffectedByPermissionChange: %v", err)
+			}
+			if len(affected) != len(tc.wantIDs) {
+				t.Fatalf("len(affected) = %d, want %d; got %v", len(affected), len(tc.wantIDs), affected)
+			}
+			gotIDs := map[domain.SessionID]bool{}
+			for _, a := range affected {
+				gotIDs[a.SessionID] = true
+			}
+			for _, wantID := range tc.wantIDs {
+				if !gotIDs[wantID] {
+					t.Fatalf("want session %q in affected, but got %v", wantID, affected)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizePermission(t *testing.T) {
+	cases := []struct {
+		in   domain.PermissionMode
+		want domain.PermissionMode
+	}{
+		{"", domain.PermissionModeDefault},
+		{domain.PermissionModeDefault, domain.PermissionModeDefault},
+		{domain.PermissionModeAuto, domain.PermissionModeAuto},
+		{domain.PermissionModeAcceptEdits, domain.PermissionModeAcceptEdits},
+		{domain.PermissionModeBypassPermissions, domain.PermissionModeBypassPermissions},
+	}
+	for _, tc := range cases {
+		got := normalizePermission(tc.in)
+		if got != tc.want {
+			t.Errorf("normalizePermission(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/session_manager/permission_relaunch_test.go
+++ b/backend/internal/session_manager/permission_relaunch_test.go
@@ -24,13 +24,13 @@ func mkWorkerRec(id domain.SessionID, projectID domain.ProjectID, perm domain.Pe
 
 func TestAffectedByPermissionChange(t *testing.T) {
 	type sessionSetup struct {
-		id           domain.SessionID
-		kind         domain.SessionKind
-		terminated   bool
-		workspace    string
-		branch       string
-		storedPerm   domain.PermissionMode
-		displayName  string
+		id          domain.SessionID
+		kind        domain.SessionKind
+		terminated  bool
+		workspace   string
+		branch      string
+		storedPerm  domain.PermissionMode
+		displayName string
 	}
 	cases := []struct {
 		name        string
@@ -117,12 +117,12 @@ func TestAffectedByPermissionChange(t *testing.T) {
 			}
 			for _, s := range tc.sessions {
 				rec := domain.SessionRecord{
-					ID:        s.id,
-					ProjectID: "proj",
-					Kind:      s.kind,
-					Harness:   domain.HarnessClaudeCode,
+					ID:           s.id,
+					ProjectID:    "proj",
+					Kind:         s.kind,
+					Harness:      domain.HarnessClaudeCode,
 					IsTerminated: s.terminated,
-					DisplayName: s.displayName,
+					DisplayName:  s.displayName,
 					Metadata: domain.SessionMetadata{
 						WorkspacePath: s.workspace,
 						Branch:        s.branch,

--- a/backend/internal/session_manager/permission_relaunch_test.go
+++ b/backend/internal/session_manager/permission_relaunch_test.go
@@ -6,22 +6,6 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
-// mkWorkerRec builds a minimal live worker session record for permission tests.
-func mkWorkerRec(id domain.SessionID, projectID domain.ProjectID, perm domain.PermissionMode) domain.SessionRecord {
-	return domain.SessionRecord{
-		ID:        id,
-		ProjectID: projectID,
-		Kind:      domain.KindWorker,
-		Harness:   domain.HarnessClaudeCode,
-		Metadata: domain.SessionMetadata{
-			WorkspacePath: "/ws/" + string(id),
-			Branch:        "ao/" + string(id) + "/root",
-			Permissions:   perm,
-		},
-		Activity: domain.Activity{State: domain.ActivityIdle},
-	}
-}
-
 func TestAffectedByPermissionChange(t *testing.T) {
 	type sessionSetup struct {
 		id          domain.SessionID

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -332,6 +332,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/projects/{id}/permission-relaunch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Kill and restore running worker sessions whose permission mode diverges from the project default */
+        post: operations["relaunchForPermissionChange"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{id}/permission-relaunch/affected": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List running worker sessions affected by a project permission mode change */
+        get: operations["affectedByPermissionChange"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/projects/initialize": {
         parameters: {
             query?: never;
@@ -817,6 +851,17 @@ export interface components {
             path: string;
             projectId?: null | string;
         };
+        AffectedByPermissionChangeResponse: {
+            affected: components["schemas"]["AffectedSessionItem"][];
+            count: number;
+        };
+        AffectedSessionItem: {
+            fromMode: string;
+            kind: string;
+            sessionId: string;
+            title: string;
+            toMode: string;
+        };
         AgentConfig: {
             model?: string;
             permissions?: string;
@@ -1129,6 +1174,16 @@ export interface components {
             platform?: "ios" | "android";
             /** @description Expo push token, e.g. ExponentPushToken[...]. */
             token: string;
+        };
+        RelaunchForPermissionChangeResponse: {
+            failed: number;
+            relaunched: number;
+            results: components["schemas"]["RelaunchOutcomeItem"][];
+        };
+        RelaunchOutcomeItem: {
+            error?: string;
+            ok: boolean;
+            sessionId: string;
         };
         RemoveProjectResult: {
             projectId: string;
@@ -2516,6 +2571,88 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    relaunchForPermissionChange: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project identifier (registry key). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RelaunchForPermissionChangeResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    affectedByPermissionChange: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project identifier (registry key). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AffectedByPermissionChangeResponse"];
                 };
             };
             /** @description Not Found */

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -30,6 +30,7 @@ import { cn } from "../lib/utils";
 import { newestActiveOrchestrator } from "../types/workspace";
 import { AgentAvatar } from "./AgentAvatar";
 import { RequiredAgentField } from "./CreateProjectAgentSheet";
+import { RelaunchSessionsDialog } from "./RelaunchSessionsDialog";
 import { buildIntake, deriveGitHubRepo, IntakeFields, type IntakeForm, intakeNeedsRule } from "./IntakeFields";
 import { AgentSelectMenuItem } from "./settings/AgentSelectMenuItem";
 import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
@@ -116,7 +117,9 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 	const [savedAt, setSavedAt] = useState<number | null>(null);
 	const [replacementError, setReplacementError] = useState<string | null>(null);
 	const [validationError, setValidationError] = useState<string | null>(null);
+	const [relaunchOpen, setRelaunchOpen] = useState(false);
 	const initialOrchestratorAgent = config.orchestrator?.agent ?? "";
+	const initialPermissions = config.agentConfig?.permissions ?? "";
 	const missingRequiredAgent = form.workerAgent === "" || form.orchestratorAgent === "";
 	const agentsQuery = useQuery(agentsQueryOptions);
 	const agentCatalog = agentsQuery.data;
@@ -174,6 +177,7 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 				body: { displayName, config: next },
 			});
 			if (error) throw new Error(apiErrorMessage(error));
+			const permissionChanged = form.permissions !== initialPermissions;
 			if (
 				form.orchestratorAgent !== initialOrchestratorAgent ||
 				(activeOrchestrator && activeOrchestrator.provider !== form.orchestratorAgent)
@@ -183,10 +187,11 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 				} catch (error) {
 					return {
 						replacementError: error instanceof Error ? error.message : "Could not replace orchestrator",
+						permissionChanged,
 					};
 				}
 			}
-			return { replacementError: null };
+			return { replacementError: null, permissionChanged };
 		},
 		onSuccess: (result) => {
 			void captureRendererEvent("ao.renderer.settings_save_succeeded", { project_id: projectId });
@@ -195,6 +200,7 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 			setValidationError(null);
 			void queryClient.invalidateQueries({ queryKey: ["project", projectId] });
 			onSaved();
+			if (result.permissionChanged) setRelaunchOpen(true);
 		},
 		onError: () => {
 			void captureRendererEvent("ao.renderer.settings_save_failed", { project_id: projectId });
@@ -202,6 +208,7 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 	});
 
 	return (
+		<>
 		<form
 			className="flex w-full flex-col gap-(--size-settings-section-gap)"
 			onSubmit={(event) => {
@@ -385,6 +392,13 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 				</SettingsSection>
 			)}
 		</form>
+		<RelaunchSessionsDialog
+			open={relaunchOpen}
+			projectId={projectId}
+			onOpenChange={setRelaunchOpen}
+			onDone={onSaved}
+		/>
+	</>
 	);
 }
 

--- a/frontend/src/renderer/components/RelaunchSessionsDialog.test.tsx
+++ b/frontend/src/renderer/components/RelaunchSessionsDialog.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getMock, postMock } = vi.hoisted(() => ({
+	getMock: vi.fn(),
+	postMock: vi.fn(),
+}));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: {
+		GET: getMock,
+		POST: postMock,
+	},
+	apiErrorMessage: (error: unknown, fallback = "Request failed") => {
+		if (error instanceof Error) return error.message;
+		if (typeof error === "object" && error !== null && "message" in error) {
+			return String((error as { message: unknown }).message);
+		}
+		return fallback;
+	},
+}));
+
+import { RelaunchSessionsDialog } from "./RelaunchSessionsDialog";
+
+function renderDialog(open = true) {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+	const onOpenChange = vi.fn();
+	const onDone = vi.fn();
+	render(
+		<QueryClientProvider client={queryClient}>
+			<RelaunchSessionsDialog
+				open={open}
+				projectId="proj-1"
+				onOpenChange={onOpenChange}
+				onDone={onDone}
+			/>
+		</QueryClientProvider>,
+	);
+	return { queryClient, onOpenChange, onDone };
+}
+
+beforeEach(() => {
+	getMock.mockReset();
+	postMock.mockReset();
+});
+
+describe("RelaunchSessionsDialog", () => {
+	it("renders confirm and relaunch button when count > 0", async () => {
+		getMock.mockResolvedValue({
+			data: {
+				count: 2,
+				affected: [
+					{ sessionId: "s1", title: "Fix auth", kind: "worker", fromMode: "default", toMode: "auto" },
+					{ sessionId: "s2", title: "Add tests", kind: "worker", fromMode: "default", toMode: "auto" },
+				],
+			},
+			error: undefined,
+		});
+
+		renderDialog();
+
+		// findByRole waits for the async query to settle
+		const relaunchBtn = await screen.findByRole("button", { name: "Relaunch 2 sessions" });
+		expect(relaunchBtn).toBeInTheDocument();
+		expect(screen.getByText("Fix auth")).toBeInTheDocument();
+		expect(screen.getByText("Add tests")).toBeInTheDocument();
+	});
+
+	it("calls apiClient.POST with the relaunch path on confirm", async () => {
+		getMock.mockResolvedValue({
+			data: {
+				count: 2,
+				affected: [
+					{ sessionId: "s1", title: "Fix auth", kind: "worker", fromMode: "default", toMode: "auto" },
+					{ sessionId: "s2", title: "Add tests", kind: "worker", fromMode: "default", toMode: "auto" },
+				],
+			},
+			error: undefined,
+		});
+		postMock.mockResolvedValue({
+			data: {
+				relaunched: 2,
+				failed: 0,
+				results: [
+					{ sessionId: "s1", ok: true },
+					{ sessionId: "s2", ok: true },
+				],
+			},
+			error: undefined,
+		});
+
+		renderDialog();
+
+		const relaunchBtn = await screen.findByRole("button", { name: "Relaunch 2 sessions" });
+		await userEvent.click(relaunchBtn);
+
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		expect(postMock).toHaveBeenCalledWith("/api/v1/projects/{id}/permission-relaunch", {
+			params: { path: { id: "proj-1" } },
+		});
+	});
+});

--- a/frontend/src/renderer/components/RelaunchSessionsDialog.test.tsx
+++ b/frontend/src/renderer/components/RelaunchSessionsDialog.test.tsx
@@ -35,12 +35,7 @@ function renderDialog(open = true) {
 	const onDone = vi.fn();
 	render(
 		<QueryClientProvider client={queryClient}>
-			<RelaunchSessionsDialog
-				open={open}
-				projectId="proj-1"
-				onOpenChange={onOpenChange}
-				onDone={onDone}
-			/>
+			<RelaunchSessionsDialog open={open} projectId="proj-1" onOpenChange={onOpenChange} onDone={onDone} />
 		</QueryClientProvider>,
 	);
 	return { queryClient, onOpenChange, onDone };

--- a/frontend/src/renderer/components/RelaunchSessionsDialog.tsx
+++ b/frontend/src/renderer/components/RelaunchSessionsDialog.tsx
@@ -1,0 +1,132 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { Button } from "./ui/button";
+
+type RelaunchSessionsDialogProps = {
+	open: boolean;
+	projectId: string;
+	onOpenChange: (open: boolean) => void;
+	onDone?: () => void;
+};
+
+export function RelaunchSessionsDialog({ open, projectId, onOpenChange, onDone }: RelaunchSessionsDialogProps) {
+	const queryClient = useQueryClient();
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | undefined>();
+	const [result, setResult] = useState<{ relaunched: number; failed: number; failedIds: string[] } | undefined>();
+
+	const affectedQuery = useQuery({
+		queryKey: ["permission-relaunch-affected", projectId],
+		queryFn: async () => {
+			const { data, error: apiErr } = await apiClient.GET("/api/v1/projects/{id}/permission-relaunch/affected", {
+				params: { path: { id: projectId } },
+			});
+			if (apiErr) throw new Error(apiErrorMessage(apiErr));
+			return data!;
+		},
+		enabled: open,
+	});
+
+	// Auto-dismiss when loaded and nothing affected
+	useEffect(() => {
+		if (affectedQuery.data && affectedQuery.data.count === 0) {
+			onOpenChange(false);
+		}
+	}, [affectedQuery.data, onOpenChange]);
+
+	const relaunch = async () => {
+		setBusy(true);
+		setError(undefined);
+		try {
+			const { data, error: apiErr } = await apiClient.POST("/api/v1/projects/{id}/permission-relaunch", {
+				params: { path: { id: projectId } },
+			});
+			if (apiErr) throw new Error(apiErrorMessage(apiErr));
+			const failedIds = (data!.results ?? []).filter((r) => !r.ok).map((r) => r.sessionId);
+			setResult({ relaunched: data!.relaunched, failed: data!.failed, failedIds });
+			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			onDone?.();
+			if (data!.failed === 0) {
+				onOpenChange(false);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Relaunch failed");
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	const count = affectedQuery.data?.count ?? 0;
+	const affected = affectedQuery.data?.affected ?? [];
+	const plural = count === 1 ? "" : "s";
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+			<Dialog.Portal>
+				<Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+				<Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[420px] -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-surface p-5 shadow-lg">
+					<Dialog.Title className="text-sm font-medium text-foreground">
+						Relaunch sessions with the new permission mode?
+					</Dialog.Title>
+					{affectedQuery.isLoading && (
+						<div className="mt-4 flex justify-center">
+							<Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+						</div>
+					)}
+					{affectedQuery.isError && (
+						<div className="mt-3 text-[12px] text-destructive">
+							{affectedQuery.error instanceof Error ? affectedQuery.error.message : "Failed to load affected sessions"}
+						</div>
+					)}
+					{affectedQuery.data && count > 0 && !result && (
+						<>
+							<Dialog.Description className="mt-2 text-[13px] text-muted-foreground">
+								This restarts each agent in place. Your branch and uncommitted work are kept and the conversation resumes.
+								Any in-progress agent turn is interrupted. The orchestrator is not affected.
+							</Dialog.Description>
+							<ul className="mt-3 flex flex-col gap-1">
+								{affected.map((item) => (
+									<li key={item.sessionId} className="text-[12px] text-muted-foreground">
+										<span className="font-medium text-foreground">{item.title}</span>
+										{" "}
+										<span className="text-passive">
+											{item.fromMode || "default"} {"->"} {item.toMode || "default"}
+										</span>
+									</li>
+								))}
+							</ul>
+						</>
+					)}
+					{result && (
+						<div className="mt-3 flex flex-col gap-1">
+							<p className="text-[13px] text-muted-foreground">
+								Relaunched {result.relaunched}, failed {result.failed}.
+							</p>
+							{result.failed > 0 && result.failedIds.length > 0 && (
+								<p className="text-[12px] text-destructive">
+									Failed sessions: {result.failedIds.join(", ")}
+								</p>
+							)}
+						</div>
+					)}
+					{error && <div className="mt-3 text-[12px] text-destructive">{error}</div>}
+					<div className="mt-4 flex justify-end gap-2">
+						<Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+							{result ? "Close" : "Cancel"}
+						</Button>
+						{!result && count > 0 && (
+							<Button onClick={relaunch} disabled={busy || affectedQuery.isLoading}>
+								{busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+								Relaunch {count} session{plural}
+							</Button>
+						)}
+					</div>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/frontend/src/renderer/components/RelaunchSessionsDialog.tsx
+++ b/frontend/src/renderer/components/RelaunchSessionsDialog.tsx
@@ -85,14 +85,13 @@ export function RelaunchSessionsDialog({ open, projectId, onOpenChange, onDone }
 					{affectedQuery.data && count > 0 && !result && (
 						<>
 							<Dialog.Description className="mt-2 text-[13px] text-muted-foreground">
-								This restarts each agent in place. Your branch and uncommitted work are kept and the conversation resumes.
-								Any in-progress agent turn is interrupted. The orchestrator is not affected.
+								This restarts each agent in place. Your branch and uncommitted work are kept and the conversation
+								resumes. Any in-progress agent turn is interrupted. The orchestrator is not affected.
 							</Dialog.Description>
 							<ul className="mt-3 flex flex-col gap-1">
 								{affected.map((item) => (
 									<li key={item.sessionId} className="text-[12px] text-muted-foreground">
-										<span className="font-medium text-foreground">{item.title}</span>
-										{" "}
+										<span className="font-medium text-foreground">{item.title}</span>{" "}
 										<span className="text-passive">
 											{item.fromMode || "default"} {"->"} {item.toMode || "default"}
 										</span>
@@ -107,9 +106,7 @@ export function RelaunchSessionsDialog({ open, projectId, onOpenChange, onDone }
 								Relaunched {result.relaunched}, failed {result.failed}.
 							</p>
 							{result.failed > 0 && result.failedIds.length > 0 && (
-								<p className="text-[12px] text-destructive">
-									Failed sessions: {result.failedIds.join(", ")}
-								</p>
+								<p className="text-[12px] text-destructive">Failed sessions: {result.failedIds.join(", ")}</p>
 							)}
 						</div>
 					)}


### PR DESCRIPTION
Closes #2504.

Rebased resolution of conflicts from #2636 onto latest `main`.

When a project's default permission mode changes in Project Settings, running sessions keep their old mode. This adds an opt-in offer to relaunch (kill + restore) the affected sessions with the new mode.

## Backend
- Persist launched permission mode on the session (`SessionMetadata.Permissions`)
- `Manager.AffectedByPermissionChange` / `RelaunchForPermissionChange`
- Endpoints: `GET/POST .../permission-relaunch` (+ OpenAPI)

## Frontend
- `RelaunchSessionsDialog` wired from settings save when mode changes and sessions are affected

## Conflict resolution (rebase onto main)
- `session_manager/manager.go`: kept `RuntimeLaunchID` from main; added `Permissions: agentConfig.Permissions` on spawn + restore
- `ProjectSettingsForm.tsx`: kept modern settings UI from main; retained relaunch dialog wiring (dropped obsolete Card-layout style rewrite)
- Migration renumbers from PR CI commits dropped: `0030_session_cleanup_facts.sql` already on main; removed conflicting `0029_session_cleanup_facts.sql` duplicate
- Kept main's EvalSymlinks path assertions in scratch/wiring tests

## Testing
- `go test ./internal/session_manager/ ./internal/httpd/controllers/ ./internal/service/session/` — pass

Supersedes / continues #2636 (origin head not writable from this worker identity; rebased branch pushed to `AllBeingsFuture:ao/agent-orchestrator-39/relaunch-perm-mode`).