### PR TITLE
fix: allow project setup inside ancestor repos

### DIFF
--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -235,6 +235,9 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 		return p, nil
 	}
 	if !isGitRepo(path) {
+		if root, ok := gitRepositoryRoot(ctx, path); ok && !samePath(root, comparablePath(path)) {
+			return Project{}, projectPathNotRepoRootError(path, root)
+		}
 		return Project{}, apierr.Invalid("NOT_A_GIT_REPO", "AO needs a Git repository with an initial commit before it can create agent workspaces.", nil)
 	}
 	if !repoHasCommit(ctx, path) {
@@ -329,15 +332,10 @@ func classifyRepositorySetupTarget(ctx context.Context, path string) (repository
 		return repositorySetupUnbornRepo, nil
 	}
 
-	if top, err := gitOutput(ctx, path, "rev-parse", "--show-toplevel"); err == nil {
-		root := normalizeGitReportedPath(path, strings.TrimSpace(top))
+	if root, ok := gitRepositoryRoot(ctx, path); ok {
 		selected := comparablePath(path)
 		if !samePath(root, selected) {
-			return repositorySetupPlainFolder, apierr.Invalid("PROJECT_PATH_NOT_REPO_ROOT", "Selected folder is inside a Git repository. Select the repository root instead.", map[string]any{
-				"path":         path,
-				"repoRoot":     root,
-				"suggestedFix": "Select the repository root folder, then try again.",
-			})
+			return repositorySetupPlainFolder, projectPathNotRepoRootError(path, root)
 		}
 		return repositorySetupPlainFolder, apierr.Invalid("UNSUPPORTED_GIT_REPO", "Selected folder contains an unsupported Git repository layout.", map[string]any{"path": path})
 	}
@@ -350,6 +348,22 @@ func classifyRepositorySetupTarget(ctx context.Context, path string) (repository
 	}
 
 	return repositorySetupPlainFolder, nil
+}
+
+func gitRepositoryRoot(ctx context.Context, path string) (string, bool) {
+	top, err := gitOutput(ctx, path, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", false
+	}
+	return normalizeGitReportedPath(path, strings.TrimSpace(top)), true
+}
+
+func projectPathNotRepoRootError(path, root string) error {
+	return apierr.Invalid("PROJECT_PATH_NOT_REPO_ROOT", "Selected folder is inside a Git repository. Select the repository root instead.", map[string]any{
+		"path":         path,
+		"repoRoot":     root,
+		"suggestedFix": "Select the repository root folder, then try again.",
+	})
 }
 
 func validateRepositorySetupPathSafety(path string) error {

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -235,9 +235,6 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 		return p, nil
 	}
 	if !isGitRepo(path) {
-		if root, ok := gitRepositoryRoot(ctx, path); ok && !samePath(root, comparablePath(path)) {
-			return Project{}, projectPathNotRepoRootError(path, root)
-		}
 		return Project{}, apierr.Invalid("NOT_A_GIT_REPO", "AO needs a Git repository with an initial commit before it can create agent workspaces.", nil)
 	}
 	if !repoHasCommit(ctx, path) {
@@ -332,14 +329,6 @@ func classifyRepositorySetupTarget(ctx context.Context, path string) (repository
 		return repositorySetupUnbornRepo, nil
 	}
 
-	if root, ok := gitRepositoryRoot(ctx, path); ok {
-		selected := comparablePath(path)
-		if !samePath(root, selected) {
-			return repositorySetupPlainFolder, projectPathNotRepoRootError(path, root)
-		}
-		return repositorySetupPlainFolder, apierr.Invalid("UNSUPPORTED_GIT_REPO", "Selected folder contains an unsupported Git repository layout.", map[string]any{"path": path})
-	}
-
 	if hasGitMetadata(path) {
 		return repositorySetupPlainFolder, apierr.Invalid("UNSUPPORTED_GIT_REPO", "Selected folder contains Git metadata that AO could not inspect.", map[string]any{
 			"path":         path,
@@ -348,22 +337,6 @@ func classifyRepositorySetupTarget(ctx context.Context, path string) (repository
 	}
 
 	return repositorySetupPlainFolder, nil
-}
-
-func gitRepositoryRoot(ctx context.Context, path string) (string, bool) {
-	top, err := gitOutput(ctx, path, "rev-parse", "--show-toplevel")
-	if err != nil {
-		return "", false
-	}
-	return normalizeGitReportedPath(path, strings.TrimSpace(top)), true
-}
-
-func projectPathNotRepoRootError(path, root string) error {
-	return apierr.Invalid("PROJECT_PATH_NOT_REPO_ROOT", "Selected folder is inside a Git repository. Select the repository root instead.", map[string]any{
-		"path":         path,
-		"repoRoot":     root,
-		"suggestedFix": "Select the repository root folder, then try again.",
-	})
 }
 
 func validateRepositorySetupPathSafety(path string) error {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -702,6 +702,22 @@ func TestManager_InitializeRepositoryRecovery(t *testing.T) {
 		}
 	})
 
+	t.Run("plain folder nested in parent repo is rejected before init", func(t *testing.T) {
+		configureCommitter(t)
+		parent := filepath.Join(t.TempDir(), "parent")
+		gitRepoWithCommitNoOrigin(t, parent)
+		dir := filepath.Join(parent, "universe")
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := m.InitializeRepository(ctx, project.InitializeRepositoryInput{Path: dir})
+		wantCode(t, err, "PROJECT_PATH_NOT_REPO_ROOT")
+		if _, statErr := os.Lstat(filepath.Join(dir, ".git")); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("unexpected nested .git after rejected init: %v", statErr)
+		}
+	})
+
 	t.Run("unborn git repo", func(t *testing.T) {
 		dir := t.TempDir()
 		if out, err := exec.Command("git", "init", "-b", "main", dir).CombinedOutput(); err != nil {
@@ -785,6 +801,22 @@ func TestManager_InitializeRepositoryRecovery(t *testing.T) {
 		}
 	})
 
+	t.Run("folder inside AO-managed worktrees is rejected before init", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		dir := filepath.Join(home, ".ao", "data", "worktrees", "project", "session")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := m.InitializeRepository(ctx, project.InitializeRepositoryInput{Path: dir})
+		wantCode(t, err, "PROJECT_SETUP_PATH_UNSAFE")
+		if _, statErr := os.Lstat(filepath.Join(dir, ".git")); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("unexpected .git after rejected AO worktree setup: %v", statErr)
+		}
+	})
+
 	t.Run("plain folder rolls back git init when staging fails", func(t *testing.T) {
 		dir := isolatedPlainFolder(t)
 		gitignore := []byte("node_modules/\n")
@@ -851,6 +883,16 @@ func TestManager_AddValidationAndConflicts(t *testing.T) {
 
 	_, err = m.Add(ctx, project.AddInput{Path: t.TempDir()}) // exists but not a git repo
 	wantCode(t, err, "NOT_A_GIT_REPO")
+
+	configureCommitter(t)
+	parent := filepath.Join(t.TempDir(), "parent")
+	gitRepoWithCommitNoOrigin(t, parent)
+	nestedPlain := filepath.Join(parent, "universe")
+	if err := os.Mkdir(nestedPlain, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err = m.Add(ctx, project.AddInput{Path: nestedPlain})
+	wantCode(t, err, "PROJECT_PATH_NOT_REPO_ROOT")
 
 	unborn := t.TempDir()
 	if out, err := exec.Command("git", "init", "-b", "main", unborn).CombinedOutput(); err != nil {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -702,7 +702,7 @@ func TestManager_InitializeRepositoryRecovery(t *testing.T) {
 		}
 	})
 
-	t.Run("plain folder nested in parent repo is rejected before init", func(t *testing.T) {
+	t.Run("plain folder nested in parent repo initializes as separate repo root", func(t *testing.T) {
 		configureCommitter(t)
 		parent := filepath.Join(t.TempDir(), "parent")
 		gitRepoWithCommitNoOrigin(t, parent)
@@ -711,10 +711,22 @@ func TestManager_InitializeRepositoryRecovery(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err := m.InitializeRepository(ctx, project.InitializeRepositoryInput{Path: dir})
-		wantCode(t, err, "PROJECT_PATH_NOT_REPO_ROOT")
-		if _, statErr := os.Lstat(filepath.Join(dir, ".git")); !errors.Is(statErr, os.ErrNotExist) {
-			t.Fatalf("unexpected nested .git after rejected init: %v", statErr)
+		if _, err := m.InitializeRepository(ctx, project.InitializeRepositoryInput{Path: dir}); err != nil {
+			t.Fatalf("InitializeRepository nested plain folder: %v", err)
+		}
+		if _, err := exec.Command("git", "-C", dir, "rev-parse", "--verify", "HEAD").CombinedOutput(); err != nil {
+			t.Fatalf("expected nested folder initial commit: %v", err)
+		}
+		top, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").CombinedOutput()
+		if err != nil {
+			t.Fatalf("git show-toplevel: %v (%s)", err, top)
+		}
+		want, err := filepath.EvalSymlinks(dir)
+		if err != nil {
+			t.Fatalf("EvalSymlinks: %v", err)
+		}
+		if got := strings.TrimSpace(string(top)); got != want {
+			t.Fatalf("show-toplevel = %q, want %q", got, want)
 		}
 	})
 
@@ -746,16 +758,25 @@ func TestManager_InitializeRepositoryRecovery(t *testing.T) {
 		wantCode(t, err, "PROJECT_ALREADY_INITIALIZED")
 	})
 
-	t.Run("repo subdirectory is rejected", func(t *testing.T) {
+	t.Run("repo subdirectory initializes as separate repo root", func(t *testing.T) {
 		repo := gitRepo(t)
 		subdir := filepath.Join(repo, "nested")
 		if err := os.Mkdir(subdir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		_, err := m.InitializeRepository(ctx, project.InitializeRepositoryInput{Path: subdir})
-		wantCode(t, err, "PROJECT_PATH_NOT_REPO_ROOT")
-		if _, statErr := os.Stat(filepath.Join(subdir, ".git")); !errors.Is(statErr, os.ErrNotExist) {
-			t.Fatalf("unexpected nested .git after rejected init: %v", statErr)
+		if _, err := m.InitializeRepository(ctx, project.InitializeRepositoryInput{Path: subdir}); err != nil {
+			t.Fatalf("InitializeRepository repo subdirectory: %v", err)
+		}
+		top, err := exec.Command("git", "-C", subdir, "rev-parse", "--show-toplevel").CombinedOutput()
+		if err != nil {
+			t.Fatalf("git show-toplevel: %v (%s)", err, top)
+		}
+		want, err := filepath.EvalSymlinks(subdir)
+		if err != nil {
+			t.Fatalf("EvalSymlinks: %v", err)
+		}
+		if got := strings.TrimSpace(string(top)); got != want {
+			t.Fatalf("show-toplevel = %q, want %q", got, want)
 		}
 	})
 
@@ -892,7 +913,7 @@ func TestManager_AddValidationAndConflicts(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = m.Add(ctx, project.AddInput{Path: nestedPlain})
-	wantCode(t, err, "PROJECT_PATH_NOT_REPO_ROOT")
+	wantCode(t, err, "NOT_A_GIT_REPO")
 
 	unborn := t.TempDir()
 	if out, err := exec.Command("git", "init", "-b", "main", unborn).CombinedOutput(); err != nil {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -29,14 +29,13 @@ import {
 import { listFeatureBuilds, getActiveFeatureBuild } from "./main/feature-builds";
 import { readUpdateSettings, type UpdateSettings, type UpdateStatus } from "./main/update-settings";
 import { readKeybindingOverrides, writeKeybindingOverrides } from "./main/keybinding-settings";
-import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, existsSync, openSync } from "node:fs";
-import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { promisify } from "node:util";
 import { type DaemonLaunchSpec, resolveDaemonLaunch } from "./shared/daemon-launch";
 import { createListenPortScanner, defaultRunFilePath, parseRunFile } from "./shared/daemon-discovery";
 import type { DaemonStatus } from "./shared/daemon-status";
@@ -62,6 +61,7 @@ import { keepDaemonAlive, shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { buildWindowsAppMenuTemplate } from "./main/menu";
+import { scanImportFolder } from "./main/import-folder-scan";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -110,40 +110,6 @@ let keybindingOverrides: KeybindingOverrides = {};
 let keybindingRecordingActive = false;
 // Held for the app lifetime. Dropping it (on any exit) triggers daemon self-stop.
 let supervisorLink: SupervisorLinkHandle | null = null;
-
-const execFileAsync = promisify(execFile);
-
-type GitRepoScanResult = {
-	name: string;
-	path: string;
-	relativePath: string;
-	branch: string;
-	remote: string;
-	hasRemote: boolean;
-	status: "ok" | "error";
-	reason?: string;
-};
-
-type ImportFolderScanResult = {
-	path: string;
-	repos: GitRepoScanResult[];
-};
-
-const IMPORT_SCAN_CONCURRENCY = 8;
-const IMPORT_SCAN_MAX_ENTRIES = 200;
-const IMPORT_SCAN_SKIP_DIRS = new Set([
-	".git",
-	"node_modules",
-	"dist",
-	"build",
-	".cache",
-	".turbo",
-	"target",
-	"coverage",
-	"tmp",
-	"temp",
-	"Library",
-]);
 
 const isDev = !app.isPackaged;
 
@@ -1201,156 +1167,12 @@ async function chooseDirectory(title: string): Promise<string | null> {
 	return result.filePaths[0] ?? null;
 }
 
-async function gitOutput(cwd: string, args: string[]): Promise<string> {
-	const { stdout } = await execFileAsync("git", args, { cwd, env: daemonEnv(), timeout: 5000 });
-	return String(stdout).trim();
-}
-
-async function isGitRepo(repoPath: string): Promise<boolean> {
-	try {
-		const gitInfo = await stat(path.join(repoPath, ".git"));
-		if (!gitInfo.isDirectory()) return false;
-		await gitOutput(repoPath, ["rev-parse", "--show-toplevel"]);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-async function resolveDefaultBranch(repoPath: string): Promise<string> {
-	try {
-		const ref = await gitOutput(repoPath, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
-		if (ref) return ref.replace(/^origin\//, "");
-	} catch {
-		// Fall back to the checked-out branch when origin/HEAD is unavailable.
-	}
-	try {
-		const branch = await gitOutput(repoPath, ["branch", "--show-current"]);
-		if (branch) return branch;
-	} catch {
-		// Detached or unreadable HEAD is represented below.
-	}
-	return "HEAD";
-}
-
-async function scanGitRepo(repoPath: string, rootPath: string): Promise<GitRepoScanResult | null> {
-	const relativePath = repoPath === rootPath ? "." : path.relative(rootPath, repoPath);
-	const name = path.basename(repoPath);
-	try {
-		const gitInfo = await stat(path.join(repoPath, ".git"));
-		if (!gitInfo.isDirectory()) {
-			return {
-				name,
-				path: repoPath,
-				relativePath,
-				branch: "HEAD",
-				remote: "",
-				hasRemote: false,
-				status: "error",
-				reason: "Linked worktree children cannot be imported.",
-			};
-		}
-	} catch {
-		try {
-			if ((await gitOutput(repoPath, ["rev-parse", "--is-bare-repository"])) === "true") {
-				return {
-					name,
-					path: repoPath,
-					relativePath,
-					branch: "HEAD",
-					remote: "",
-					hasRemote: false,
-					status: "error",
-					reason: "Bare repositories cannot be imported.",
-				};
-			}
-		} catch {
-			// Not a git repository.
-		}
-		return null;
-	}
-	if (!(await isGitRepo(repoPath))) return null;
-	const [branchResult, remoteResult, bareResult, headResult] = await Promise.allSettled([
-		resolveDefaultBranch(repoPath),
-		gitOutput(repoPath, ["remote", "get-url", "origin"]),
-		gitOutput(repoPath, ["rev-parse", "--is-bare-repository"]),
-		gitOutput(repoPath, ["rev-parse", "--verify", "HEAD"]),
-	]);
-	const validationReason = scanRepoValidationReason(
-		name,
-		branchResult.status === "fulfilled" && branchResult.value ? branchResult.value : "HEAD",
-		remoteResult.status === "fulfilled" && remoteResult.value.length > 0,
-		bareResult.status === "fulfilled" && bareResult.value === "true",
-		headResult.status === "fulfilled",
-	);
-	return {
-		name,
-		path: repoPath,
-		relativePath,
-		branch: branchResult.status === "fulfilled" && branchResult.value ? branchResult.value : "HEAD",
-		remote: remoteResult.status === "fulfilled" ? remoteResult.value : "",
-		hasRemote: remoteResult.status === "fulfilled" && remoteResult.value.length > 0,
-		status: validationReason ? "error" : "ok",
-		reason: validationReason,
-	};
-}
-
-function scanRepoValidationReason(
-	name: string,
-	branch: string,
-	hasRemote: boolean,
-	isBare: boolean,
-	hasHead: boolean,
-): string | undefined {
-	if (name === "__root__") return "Repository name is reserved by AO.";
-	if (isBare) return "Bare repositories cannot be imported.";
-	if (!hasHead) return "Repository must have at least one commit.";
-	if (branch === "HEAD") return "Repository must have a checked-out branch.";
-	if (!hasRemote) return "Origin remote is required.";
-	return undefined;
-}
-
-async function mapLimited<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-	const out = new Array<R>(items.length);
-	let next = 0;
-	await Promise.all(
-		Array.from({ length: Math.min(limit, items.length) }, async () => {
-			for (;;) {
-				const index = next++;
-				if (index >= items.length) return;
-				out[index] = await fn(items[index]);
-			}
-		}),
-	);
-	return out;
-}
-
-async function scanImportFolder(rootPath: string, mode: "project" | "workspace"): Promise<ImportFolderScanResult> {
-	if (mode === "project") {
-		const repo = await scanGitRepo(rootPath, rootPath);
-		return { path: rootPath, repos: repo ? [repo] : [] };
-	}
-
-	const entries = (await readdir(rootPath, { withFileTypes: true }))
-		.filter((entry) => entry.isDirectory() && !IMPORT_SCAN_SKIP_DIRS.has(entry.name))
-		.slice(0, IMPORT_SCAN_MAX_ENTRIES);
-	const repos = await mapLimited(entries, IMPORT_SCAN_CONCURRENCY, (entry) =>
-		scanGitRepo(path.join(rootPath, entry.name), rootPath),
-	);
-	return {
-		path: rootPath,
-		repos: repos
-			.filter((repo): repo is GitRepoScanResult => repo !== null)
-			.sort((a, b) => a.name.localeCompare(b.name)),
-	};
-}
-
 ipcMain.handle("app:chooseDirectory", async (_event, title?: string) => {
 	return chooseDirectory(typeof title === "string" && title.trim() ? title : "Choose a git repository");
 });
 ipcMain.handle("app:scanImportFolder", async (_event, input: { path: string; mode: "project" | "workspace" }) => {
 	await ensureShellEnv();
-	return scanImportFolder(input.path, input.mode);
+	return scanImportFolder(input.path, input.mode, { env: daemonEnv(), homeDir: os.homedir() });
 });
 ipcMain.handle("clipboard:writeText", (_event, text: string) => {
 	clipboard.writeText(text, "clipboard");

--- a/frontend/src/main/import-folder-scan.test.ts
+++ b/frontend/src/main/import-folder-scan.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { scanImportFolder } from "./import-folder-scan";
+
+const execFileAsync = promisify(execFile);
+
+const tempRoots: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await mkdtemp(path.join(os.tmpdir(), "ao-import-scan-"));
+	tempRoots.push(dir);
+	return dir;
+}
+
+async function git(args: string[], cwd?: string): Promise<string> {
+	const { stdout } = await execFileAsync("git", args, {
+		cwd,
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: "AO Test",
+			GIT_AUTHOR_EMAIL: "ao@example.com",
+			GIT_COMMITTER_NAME: "AO Test",
+			GIT_COMMITTER_EMAIL: "ao@example.com",
+		},
+	});
+	return String(stdout).trim();
+}
+
+async function committedRepo(dir: string): Promise<void> {
+	await git(["init", "-b", "main", dir]);
+	await writeFile(path.join(dir, "README.md"), "hello\n");
+	await git(["add", "README.md"], dir);
+	await git(["commit", "-m", "initial"], dir);
+	await git(["remote", "add", "origin", "https://example.com/repo.git"], dir);
+}
+
+beforeEach(() => {
+	tempRoots.length = 0;
+});
+
+afterEach(async () => {
+	await Promise.all(tempRoots.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("scanImportFolder", () => {
+	it("reports a plain project folder nested inside a parent repo instead of treating it as setup-ready", async () => {
+		const root = await tempDir();
+		const parent = path.join(root, "parent");
+		await committedRepo(parent);
+		const nested = path.join(parent, "universe");
+		await mkdir(nested);
+
+		const scan = await scanImportFolder(nested, "project");
+
+		expect(scan.repos).toHaveLength(1);
+		expect(scan.repos[0]).toMatchObject({
+			path: nested,
+			relativePath: ".",
+			status: "error",
+			hasRemote: false,
+		});
+		expect(scan.repos[0]?.reason).toContain("Selected folder is inside a Git repository");
+		expect(scan.repos[0]?.reason).toContain(parent);
+	});
+
+	it("reports a true project repository root as importable", async () => {
+		const root = await tempDir();
+		const repo = path.join(root, "repo");
+		await committedRepo(repo);
+
+		const scan = await scanImportFolder(repo, "project");
+
+		expect(scan.repos).toEqual([
+			expect.objectContaining({
+				name: "repo",
+				path: repo,
+				relativePath: ".",
+				branch: "main",
+				hasRemote: true,
+				status: "ok",
+			}),
+		]);
+	});
+
+	it("leaves a plain non-nested project folder setup-ready", async () => {
+		const root = await tempDir();
+		const selected = path.join(root, "plain");
+		await mkdir(selected);
+
+		const scan = await scanImportFolder(selected, "project", {
+			env: { ...process.env, GIT_CEILING_DIRECTORIES: root },
+		});
+
+		expect(scan).toEqual({ path: selected, repos: [] });
+	});
+
+	it("reports folders inside AO-managed worktrees before offering setup", async () => {
+		const home = await tempDir();
+		const selected = path.join(home, ".ao", "data", "worktrees", "project", "session");
+		await mkdir(selected, { recursive: true });
+
+		const scan = await scanImportFolder(selected, "project", { homeDir: home });
+
+		expect(scan.repos).toEqual([
+			expect.objectContaining({
+				path: selected,
+				relativePath: ".",
+				status: "error",
+				reason: "Selected folder is inside AO's internal data directory. Select a project folder outside ~/.ao.",
+			}),
+		]);
+	});
+});

--- a/frontend/src/main/import-folder-scan.test.ts
+++ b/frontend/src/main/import-folder-scan.test.ts
@@ -48,7 +48,7 @@ afterEach(async () => {
 });
 
 describe("scanImportFolder", () => {
-	it("reports a plain project folder nested inside a parent repo instead of treating it as setup-ready", async () => {
+	it("leaves a plain project folder nested inside a parent repo setup-ready with a warning", async () => {
 		const root = await tempDir();
 		const parent = path.join(root, "parent");
 		await committedRepo(parent);
@@ -57,15 +57,10 @@ describe("scanImportFolder", () => {
 
 		const scan = await scanImportFolder(nested, "project");
 
-		expect(scan.repos).toHaveLength(1);
-		expect(scan.repos[0]).toMatchObject({
-			path: nested,
-			relativePath: ".",
-			status: "error",
-			hasRemote: false,
-		});
-		expect(scan.repos[0]?.reason).toContain("Selected folder is inside a Git repository");
-		expect(scan.repos[0]?.reason).toContain(parent);
+		expect(scan.path).toBe(nested);
+		expect(scan.repos).toEqual([]);
+		expect(scan.setupWarning).toContain("Selected folder is inside an existing Git repository at ");
+		expect(scan.setupWarning).toContain("AO will initialize this folder as a separate repository.");
 	});
 
 	it("reports a true project repository root as importable", async () => {

--- a/frontend/src/main/import-folder-scan.ts
+++ b/frontend/src/main/import-folder-scan.ts
@@ -1,0 +1,263 @@
+import { execFile } from "node:child_process";
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type GitRepoScanResult = {
+	name: string;
+	path: string;
+	relativePath: string;
+	branch: string;
+	remote: string;
+	hasRemote: boolean;
+	status: "ok" | "error";
+	reason?: string;
+};
+
+export type ImportFolderScanResult = {
+	path: string;
+	repos: GitRepoScanResult[];
+};
+
+const IMPORT_SCAN_CONCURRENCY = 8;
+const IMPORT_SCAN_MAX_ENTRIES = 200;
+const IMPORT_SCAN_SKIP_DIRS = new Set([
+	".git",
+	"node_modules",
+	"dist",
+	"build",
+	".cache",
+	".turbo",
+	"target",
+	"coverage",
+	"tmp",
+	"temp",
+	"Library",
+]);
+
+type ScanOptions = {
+	env?: NodeJS.ProcessEnv;
+	homeDir?: string;
+};
+
+async function gitOutput(cwd: string, args: string[], options: ScanOptions = {}): Promise<string> {
+	const { stdout } = await execFileAsync("git", args, { cwd, env: options.env, timeout: 5000 });
+	return String(stdout).trim();
+}
+
+function comparablePath(value: string): string {
+	const resolved = path.resolve(value);
+	return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function samePath(a: string, b: string): boolean {
+	return comparablePath(a) === comparablePath(b);
+}
+
+function normalizeGitReportedPath(cwd: string, value: string): string {
+	if (!value) return "";
+	return path.resolve(cwd, value);
+}
+
+function isDescendantPath(child: string, parent: string): boolean {
+	const childKey = comparablePath(child);
+	const parentKey = comparablePath(parent);
+	return childKey === parentKey || childKey.startsWith(parentKey + path.sep);
+}
+
+function projectSetupSafetyReason(repoPath: string, options: ScanOptions = {}): string | undefined {
+	const home = options.homeDir?.trim();
+	if (!home) return undefined;
+	const aoState = path.join(home, ".ao");
+	if (isDescendantPath(repoPath, aoState)) {
+		return "Selected folder is inside AO's internal data directory. Select a project folder outside ~/.ao.";
+	}
+	return undefined;
+}
+
+async function isGitRepo(repoPath: string, options: ScanOptions = {}): Promise<boolean> {
+	try {
+		const gitInfo = await stat(path.join(repoPath, ".git"));
+		if (!gitInfo.isDirectory()) return false;
+		await gitOutput(repoPath, ["rev-parse", "--show-toplevel"], options);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function resolveDefaultBranch(repoPath: string, options: ScanOptions = {}): Promise<string> {
+	try {
+		const ref = await gitOutput(repoPath, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], options);
+		if (ref) return ref.replace(/^origin\//, "");
+	} catch {
+		// Fall back to the checked-out branch when origin/HEAD is unavailable.
+	}
+	try {
+		const branch = await gitOutput(repoPath, ["branch", "--show-current"], options);
+		if (branch) return branch;
+	} catch {
+		// Detached or unreadable HEAD is represented below.
+	}
+	return "HEAD";
+}
+
+async function scanGitRepo(
+	repoPath: string,
+	rootPath: string,
+	options: ScanOptions = {},
+): Promise<GitRepoScanResult | null> {
+	const relativePath = repoPath === rootPath ? "." : path.relative(rootPath, repoPath);
+	const name = path.basename(repoPath);
+	try {
+		const gitInfo = await stat(path.join(repoPath, ".git"));
+		if (!gitInfo.isDirectory()) {
+			return {
+				name,
+				path: repoPath,
+				relativePath,
+				branch: "HEAD",
+				remote: "",
+				hasRemote: false,
+				status: "error",
+				reason: "Linked worktree children cannot be imported.",
+			};
+		}
+	} catch {
+		try {
+			if ((await gitOutput(repoPath, ["rev-parse", "--is-bare-repository"], options)) === "true") {
+				return {
+					name,
+					path: repoPath,
+					relativePath,
+					branch: "HEAD",
+					remote: "",
+					hasRemote: false,
+					status: "error",
+					reason: "Bare repositories cannot be imported.",
+				};
+			}
+		} catch {
+			// Not a git repository.
+		}
+		try {
+			const top = normalizeGitReportedPath(
+				repoPath,
+				await gitOutput(repoPath, ["rev-parse", "--show-toplevel"], options),
+			);
+			if (top && !samePath(top, repoPath)) {
+				return {
+					name,
+					path: repoPath,
+					relativePath,
+					branch: "HEAD",
+					remote: "",
+					hasRemote: false,
+					status: "error",
+					reason: `Selected folder is inside a Git repository. Select the repository root instead: ${top}`,
+				};
+			}
+		} catch {
+			// Plain folder outside a Git repository.
+		}
+		return null;
+	}
+	if (!(await isGitRepo(repoPath, options))) return null;
+	const [branchResult, remoteResult, bareResult, headResult] = await Promise.allSettled([
+		resolveDefaultBranch(repoPath, options),
+		gitOutput(repoPath, ["remote", "get-url", "origin"], options),
+		gitOutput(repoPath, ["rev-parse", "--is-bare-repository"], options),
+		gitOutput(repoPath, ["rev-parse", "--verify", "HEAD"], options),
+	]);
+	const validationReason = scanRepoValidationReason(
+		name,
+		branchResult.status === "fulfilled" && branchResult.value ? branchResult.value : "HEAD",
+		remoteResult.status === "fulfilled" && remoteResult.value.length > 0,
+		bareResult.status === "fulfilled" && bareResult.value === "true",
+		headResult.status === "fulfilled",
+	);
+	return {
+		name,
+		path: repoPath,
+		relativePath,
+		branch: branchResult.status === "fulfilled" && branchResult.value ? branchResult.value : "HEAD",
+		remote: remoteResult.status === "fulfilled" ? remoteResult.value : "",
+		hasRemote: remoteResult.status === "fulfilled" && remoteResult.value.length > 0,
+		status: validationReason ? "error" : "ok",
+		reason: validationReason,
+	};
+}
+
+function scanRepoValidationReason(
+	name: string,
+	branch: string,
+	hasRemote: boolean,
+	isBare: boolean,
+	hasHead: boolean,
+): string | undefined {
+	if (name === "__root__") return "Repository name is reserved by AO.";
+	if (isBare) return "Bare repositories cannot be imported.";
+	if (!hasHead) return "Repository must have at least one commit.";
+	if (branch === "HEAD") return "Repository must have a checked-out branch.";
+	if (!hasRemote) return "Origin remote is required.";
+	return undefined;
+}
+
+async function mapLimited<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+	const out = new Array<R>(items.length);
+	let next = 0;
+	await Promise.all(
+		Array.from({ length: Math.min(limit, items.length) }, async () => {
+			for (;;) {
+				const index = next++;
+				if (index >= items.length) return;
+				out[index] = await fn(items[index]);
+			}
+		}),
+	);
+	return out;
+}
+
+export async function scanImportFolder(
+	rootPath: string,
+	mode: "project" | "workspace",
+	options: ScanOptions = {},
+): Promise<ImportFolderScanResult> {
+	if (mode === "project") {
+		const safetyReason = projectSetupSafetyReason(rootPath, options);
+		if (safetyReason) {
+			return {
+				path: rootPath,
+				repos: [
+					{
+						name: path.basename(rootPath),
+						path: rootPath,
+						relativePath: ".",
+						branch: "HEAD",
+						remote: "",
+						hasRemote: false,
+						status: "error",
+						reason: safetyReason,
+					},
+				],
+			};
+		}
+		const repo = await scanGitRepo(rootPath, rootPath, options);
+		return { path: rootPath, repos: repo ? [repo] : [] };
+	}
+
+	const entries = (await readdir(rootPath, { withFileTypes: true }))
+		.filter((entry) => entry.isDirectory() && !IMPORT_SCAN_SKIP_DIRS.has(entry.name))
+		.slice(0, IMPORT_SCAN_MAX_ENTRIES);
+	const repos = await mapLimited(entries, IMPORT_SCAN_CONCURRENCY, (entry) =>
+		scanGitRepo(path.join(rootPath, entry.name), rootPath, options),
+	);
+	return {
+		path: rootPath,
+		repos: repos
+			.filter((repo): repo is GitRepoScanResult => repo !== null)
+			.sort((a, b) => a.name.localeCompare(b.name)),
+	};
+}

--- a/frontend/src/main/import-folder-scan.ts
+++ b/frontend/src/main/import-folder-scan.ts
@@ -19,6 +19,7 @@ export type GitRepoScanResult = {
 export type ImportFolderScanResult = {
 	path: string;
 	repos: GitRepoScanResult[];
+	setupWarning?: string;
 };
 
 const IMPORT_SCAN_CONCURRENCY = 8;
@@ -73,6 +74,18 @@ function projectSetupSafetyReason(repoPath: string, options: ScanOptions = {}): 
 	const aoState = path.join(home, ".ao");
 	if (isDescendantPath(repoPath, aoState)) {
 		return "Selected folder is inside AO's internal data directory. Select a project folder outside ~/.ao.";
+	}
+	return undefined;
+}
+
+async function ancestorRepositorySetupWarning(repoPath: string, options: ScanOptions = {}): Promise<string | undefined> {
+	try {
+		const top = normalizeGitReportedPath(repoPath, await gitOutput(repoPath, ["rev-parse", "--show-toplevel"], options));
+		if (top && !samePath(top, repoPath)) {
+			return `Selected folder is inside an existing Git repository at ${top}. AO will initialize this folder as a separate repository.`;
+		}
+	} catch {
+		// No ancestor repository.
 	}
 	return undefined;
 }
@@ -141,26 +154,6 @@ async function scanGitRepo(
 			}
 		} catch {
 			// Not a git repository.
-		}
-		try {
-			const top = normalizeGitReportedPath(
-				repoPath,
-				await gitOutput(repoPath, ["rev-parse", "--show-toplevel"], options),
-			);
-			if (top && !samePath(top, repoPath)) {
-				return {
-					name,
-					path: repoPath,
-					relativePath,
-					branch: "HEAD",
-					remote: "",
-					hasRemote: false,
-					status: "error",
-					reason: `Selected folder is inside a Git repository. Select the repository root instead: ${top}`,
-				};
-			}
-		} catch {
-			// Plain folder outside a Git repository.
 		}
 		return null;
 	}
@@ -245,7 +238,12 @@ export async function scanImportFolder(
 			};
 		}
 		const repo = await scanGitRepo(rootPath, rootPath, options);
-		return { path: rootPath, repos: repo ? [repo] : [] };
+		if (repo) return { path: rootPath, repos: [repo] };
+		return {
+			path: rootPath,
+			repos: [],
+			setupWarning: await ancestorRepositorySetupWarning(rootPath, options),
+		};
 	}
 
 	const entries = (await readdir(rootPath, { withFileTypes: true }))

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -41,6 +41,7 @@ export type ImportRepoScan = {
 export type ImportFolderScan = {
 	path: string;
 	repos: ImportRepoScan[];
+	setupWarning?: string;
 };
 
 const api = {

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -43,6 +43,7 @@ type CreateProjectAgentSheetProps = {
 	open: boolean;
 	path: string | null;
 	repositorySetupNeeded?: boolean;
+	repositorySetupWarning?: string | null;
 };
 
 type SheetError = {
@@ -95,6 +96,7 @@ export function CreateProjectAgentSheet({
 	open,
 	path,
 	repositorySetupNeeded = false,
+	repositorySetupWarning = null,
 }: CreateProjectAgentSheetProps) {
 	const queryClient = useQueryClient();
 	const agentsQuery = useQuery({
@@ -259,7 +261,12 @@ export function CreateProjectAgentSheet({
 
 						{repositorySetupNeeded && (
 							<div className="rounded-lg border border-[var(--color-border-agents-sheet)] bg-[var(--color-bg-agents-sheet-control)]/80 px-3 py-2.5 text-xs leading-body-md text-[var(--color-text-agents-sheet-description)]">
-								If this folder needs Git setup, AO will initialize it and create the first commit before starting.
+								<p>If this folder needs Git setup, AO will initialize it and create the first commit before starting.</p>
+								{repositorySetupWarning && (
+									<p className="mt-2 text-warning">
+										{repositorySetupWarning}
+									</p>
+								)}
 							</div>
 						)}
 

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -68,8 +68,15 @@ export function CreateProjectFlow({
 				kind === "workspace" ? "Choose a workspace folder" : "Choose a project repository",
 			);
 			if (path && kind === "single_repo") {
-				const setupCode = await repositorySetupRequired(path);
-				setRepositorySetup(setupCode);
+				const preflight = await projectRepositoryPreflight(path);
+				if (preflight.blockingError) {
+					setError(preflight.blockingError);
+					setValidationScan(preflight.scan);
+					setModePickerOpen(false);
+					setFolderPickerOpen(true);
+					return;
+				}
+				setRepositorySetup(preflight.setupCode);
 			}
 			if (path) {
 				setModePickerOpen(false);
@@ -238,14 +245,48 @@ function isRepositorySetupRecoveryCode(code: string | undefined): code is "NOT_A
 	return code === "NOT_A_GIT_REPO" || code === "PROJECT_UNBORN";
 }
 
-async function repositorySetupRequired(path: string): Promise<"NOT_A_GIT_REPO" | "PROJECT_UNBORN" | null> {
+type RepositorySetupCode = "NOT_A_GIT_REPO" | "PROJECT_UNBORN";
+
+type ProjectRepositoryPreflight = {
+	blockingError: string | null;
+	scan: ImportFolderScan | null;
+	setupCode: RepositorySetupCode | null;
+};
+
+async function projectRepositoryPreflight(path: string): Promise<ProjectRepositoryPreflight> {
 	try {
 		const scan = await aoBridge.app.scanImportFolder({ path, mode: "project" });
-		if (scan.repos.length === 0) return "NOT_A_GIT_REPO";
-		return scan.repos[0]?.reason === "Repository must have at least one commit." ? "PROJECT_UNBORN" : null;
+		const reason = scan.repos[0]?.reason ?? "";
+		if (isProjectPreflightBlockingReason(reason)) {
+			return {
+				blockingError: projectPreflightBlockingMessage(reason),
+				scan,
+				setupCode: null,
+			};
+		}
+		if (scan.repos.length === 0) return { blockingError: null, scan, setupCode: "NOT_A_GIT_REPO" };
+		return {
+			blockingError: null,
+			scan,
+			setupCode: reason === "Repository must have at least one commit." ? "PROJECT_UNBORN" : null,
+		};
 	} catch {
-		return null;
+		return { blockingError: null, scan: null, setupCode: null };
 	}
+}
+
+function isProjectPreflightBlockingReason(reason: string): boolean {
+	return (
+		reason.startsWith("Selected folder is inside a Git repository.") ||
+		reason.startsWith("Selected folder is inside AO's internal data directory.")
+	);
+}
+
+function projectPreflightBlockingMessage(reason: string): string {
+	if (reason.startsWith("Selected folder is inside AO's internal data directory.")) {
+		return "Selected folder is inside AO's internal data directory. Select a project folder outside ~/.ao.";
+	}
+	return "Selected folder is inside a Git repository. Select the repository root instead.";
 }
 
 function shouldScanCreateFailure(message: string): boolean {

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -47,6 +47,7 @@ export function CreateProjectFlow({
 	const [isCreating, setIsCreating] = useState(false);
 	const [isInitializing, setIsInitializing] = useState(false);
 	const [repositorySetup, setRepositorySetup] = useState<"NOT_A_GIT_REPO" | "PROJECT_UNBORN" | null>(null);
+	const [repositorySetupWarning, setRepositorySetupWarning] = useState<string | null>(null);
 
 	const hasModePicker = mode === "choose";
 	const isBusy = isChoosingPath || isCreating || isInitializing;
@@ -61,6 +62,7 @@ export function CreateProjectFlow({
 		setError(null);
 		setValidationScan(null);
 		setRepositorySetup(null);
+		setRepositorySetupWarning(null);
 		setSelectedKind(kind);
 		setIsChoosingPath(true);
 		try {
@@ -77,6 +79,7 @@ export function CreateProjectFlow({
 					return;
 				}
 				setRepositorySetup(preflight.setupCode);
+				setRepositorySetupWarning(preflight.setupWarning);
 			}
 			if (path) {
 				setModePickerOpen(false);
@@ -117,6 +120,7 @@ export function CreateProjectFlow({
 				setIsInitializing(true);
 				await onInitializeProject(selectedPath);
 				setRepositorySetup(null);
+				setRepositorySetupWarning(null);
 				setIsInitializing(false);
 				setIsCreating(true);
 			}
@@ -231,6 +235,7 @@ export function CreateProjectFlow({
 				open={selectedPath !== null}
 				path={selectedPath}
 				repositorySetupNeeded={repositorySetup !== null}
+				repositorySetupWarning={repositorySetupWarning}
 			/>
 			{error && !hasModePicker && (
 				<span className="sr-only" role="status">
@@ -251,42 +256,33 @@ type ProjectRepositoryPreflight = {
 	blockingError: string | null;
 	scan: ImportFolderScan | null;
 	setupCode: RepositorySetupCode | null;
+	setupWarning: string | null;
 };
 
 async function projectRepositoryPreflight(path: string): Promise<ProjectRepositoryPreflight> {
 	try {
 		const scan = await aoBridge.app.scanImportFolder({ path, mode: "project" });
 		const reason = scan.repos[0]?.reason ?? "";
-		if (isProjectPreflightBlockingReason(reason)) {
+		if (reason.startsWith("Selected folder is inside AO's internal data directory.")) {
 			return {
-				blockingError: projectPreflightBlockingMessage(reason),
+				blockingError: reason,
 				scan,
 				setupCode: null,
+				setupWarning: null,
 			};
 		}
-		if (scan.repos.length === 0) return { blockingError: null, scan, setupCode: "NOT_A_GIT_REPO" };
+		if (scan.repos.length === 0) {
+			return { blockingError: null, scan, setupCode: "NOT_A_GIT_REPO", setupWarning: scan.setupWarning ?? null };
+		}
 		return {
 			blockingError: null,
 			scan,
 			setupCode: reason === "Repository must have at least one commit." ? "PROJECT_UNBORN" : null,
+			setupWarning: null,
 		};
 	} catch {
-		return { blockingError: null, scan: null, setupCode: null };
+		return { blockingError: null, scan: null, setupCode: null, setupWarning: null };
 	}
-}
-
-function isProjectPreflightBlockingReason(reason: string): boolean {
-	return (
-		reason.startsWith("Selected folder is inside a Git repository.") ||
-		reason.startsWith("Selected folder is inside AO's internal data directory.")
-	);
-}
-
-function projectPreflightBlockingMessage(reason: string): string {
-	if (reason.startsWith("Selected folder is inside AO's internal data directory.")) {
-		return "Selected folder is inside AO's internal data directory. Select a project folder outside ~/.ao.";
-	}
-	return "Selected folder is inside a Git repository. Select the repository root instead.";
 }
 
 function shouldScanCreateFailure(message: string): boolean {

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -491,38 +491,31 @@ describe("Sidebar", () => {
 		await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
 	});
 
-	it("rejects a plain project folder nested inside a parent repo before offering Git setup", async () => {
+	it("warns before initializing a plain project folder nested inside a parent repo", async () => {
 		const user = userEvent.setup();
 		const onCreateProject = vi.fn().mockResolvedValue(undefined) as CreateProjectHandler;
 		const onInitializeProject = vi.fn().mockResolvedValue(undefined) as InitializeProjectHandler;
 		window.ao!.app.chooseDirectory = vi.fn().mockResolvedValue("/repo/parent/universe");
 		window.ao!.app.scanImportFolder = vi.fn().mockResolvedValue({
 			path: "/repo/parent/universe",
-			repos: [
-				{
-					name: "universe",
-					path: "/repo/parent/universe",
-					relativePath: ".",
-					branch: "HEAD",
-					remote: "",
-					hasRemote: false,
-					status: "error",
-					reason: "Selected folder is inside a Git repository. Select the repository root instead: /repo/parent",
-				},
-			],
+			repos: [],
+			setupWarning:
+				"Selected folder is inside an existing Git repository at /repo/parent. AO will initialize this folder as a separate repository.",
 		});
 		renderSidebar({ onCreateProject, onInitializeProject });
 
 		await user.click(screen.getByLabelText("New project"));
 		await user.click(screen.getByRole("button", { name: /^Project/i }));
 
-		expect(await screen.findByText(/Import failed · project not registered/i)).toBeInTheDocument();
-		expect(screen.getByText("Selected folder is inside a Git repository. Select the repository root instead.")).toBeInTheDocument();
-		expect(screen.getByText(/Select the repository root instead: \/repo\/parent/)).toBeInTheDocument();
-		expect(screen.queryByRole("dialog", { name: "Project agents" })).not.toBeInTheDocument();
-		expect(screen.queryByText(/If this folder needs Git setup/i)).not.toBeInTheDocument();
+		expect(await screen.findByRole("dialog", { name: "Project agents" })).toBeInTheDocument();
+		expect(screen.getByText(/If this folder needs Git setup/i)).toBeInTheDocument();
+		expect(screen.getByText(/inside an existing Git repository at \/repo\/parent/i)).toBeInTheDocument();
 		expect(onInitializeProject).not.toHaveBeenCalled();
 		expect(onCreateProject).not.toHaveBeenCalled();
+
+		await user.click(screen.getByRole("button", { name: "Create and start" }));
+		await waitFor(() => expect(onInitializeProject).toHaveBeenCalledWith("/repo/parent/universe"));
+		await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
 	});
 
 	it("shows repository initialization recovery for git repos with no commits", async () => {

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -491,6 +491,40 @@ describe("Sidebar", () => {
 		await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
 	});
 
+	it("rejects a plain project folder nested inside a parent repo before offering Git setup", async () => {
+		const user = userEvent.setup();
+		const onCreateProject = vi.fn().mockResolvedValue(undefined) as CreateProjectHandler;
+		const onInitializeProject = vi.fn().mockResolvedValue(undefined) as InitializeProjectHandler;
+		window.ao!.app.chooseDirectory = vi.fn().mockResolvedValue("/repo/parent/universe");
+		window.ao!.app.scanImportFolder = vi.fn().mockResolvedValue({
+			path: "/repo/parent/universe",
+			repos: [
+				{
+					name: "universe",
+					path: "/repo/parent/universe",
+					relativePath: ".",
+					branch: "HEAD",
+					remote: "",
+					hasRemote: false,
+					status: "error",
+					reason: "Selected folder is inside a Git repository. Select the repository root instead: /repo/parent",
+				},
+			],
+		});
+		renderSidebar({ onCreateProject, onInitializeProject });
+
+		await user.click(screen.getByLabelText("New project"));
+		await user.click(screen.getByRole("button", { name: /^Project/i }));
+
+		expect(await screen.findByText(/Import failed · project not registered/i)).toBeInTheDocument();
+		expect(screen.getByText("Selected folder is inside a Git repository. Select the repository root instead.")).toBeInTheDocument();
+		expect(screen.getByText(/Select the repository root instead: \/repo\/parent/)).toBeInTheDocument();
+		expect(screen.queryByRole("dialog", { name: "Project agents" })).not.toBeInTheDocument();
+		expect(screen.queryByText(/If this folder needs Git setup/i)).not.toBeInTheDocument();
+		expect(onInitializeProject).not.toHaveBeenCalled();
+		expect(onCreateProject).not.toHaveBeenCalled();
+	});
+
 	it("shows repository initialization recovery for git repos with no commits", async () => {
 		const onCreateProject = vi.fn().mockResolvedValue(undefined) as CreateProjectHandler;
 		const onInitializeProject = vi.fn().mockResolvedValue(undefined) as InitializeProjectHandler;


### PR DESCRIPTION
## Summary
- align Project setup with Workspace setup: a selected plain folder can be initialized as its own repo root even when an ancestor directory is already a Git repo
- show a warning in the Project agent sheet when the selected plain folder is inside an existing ancestor Git repo, so accidental subdirectory selections are visible before initialization
- keep unsafe AO-state paths blocked up front and keep direct add validation as NOT_A_GIT_REPO until setup has run
- extract the Electron import-folder scanner into a tested main-process helper

Fixes #3228

## Tests
- go test ./internal/service/project
- npm test -- --run src/main/import-folder-scan.test.ts src/renderer/components/Sidebar.test.tsx
- npm run frontend:typecheck
- env -u AO_DATA_DIR -u AO_ISSUE_ID -u AO_OWNER -u AO_PROJECT_ID -u AO_RUNTIME_LAUNCH_ID -u AO_SESSION_ID -u AO_TELEMETRY_EVENTS -u AO_TELEMETRY_POSTHOG_HOST -u AO_TELEMETRY_POSTHOG_KEY -u AO_TELEMETRY_REMOTE npm run lint

## Notes
- Initial npm run lint failed because AO session environment variables affected existing CLI tests; rerun with AO_* session context cleared passed after clearing stale golangci-lint cache.