### PR TITLE
fix(browser): lock annotation selection while prompting

### DIFF
--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserAnnotationPageSubmitPayload } from "./shared/browser-annotations";
+
+const electronMocks = vi.hoisted(() => {
+	const listeners = new Map<string, (...args: unknown[]) => void>();
+	return {
+		listeners,
+		on: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
+			listeners.set(channel, listener);
+		}),
+		send: vi.fn(),
+	};
+});
+
+vi.mock("electron", () => ({
+	ipcRenderer: {
+		on: electronMocks.on,
+		send: electronMocks.send,
+	},
+}));
+
+await import("./annotate-preload");
+
+type Bounds = {
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+};
+
+function setAnnotationMode(enabled: boolean): void {
+	const listener = electronMocks.listeners.get("browser:annotation:setMode");
+	if (!listener) throw new Error("annotation mode listener was not registered");
+	listener({}, { enabled });
+}
+
+function elementWithBounds(id: string, bounds: Bounds): HTMLButtonElement {
+	const element = document.createElement("button");
+	element.id = id;
+	Object.defineProperty(element, "getBoundingClientRect", {
+		configurable: true,
+		value: () =>
+			({
+				x: bounds.left,
+				y: bounds.top,
+				left: bounds.left,
+				top: bounds.top,
+				right: bounds.left + bounds.width,
+				bottom: bounds.top + bounds.height,
+				width: bounds.width,
+				height: bounds.height,
+				toJSON: () => ({}),
+			}) as DOMRect,
+	});
+	document.body.appendChild(element);
+	return element;
+}
+
+function dispatchPageEvent(element: Element, type: string): Event {
+	const event = new MouseEvent(type, { bubbles: true, cancelable: true });
+	element.dispatchEvent(event);
+	return event;
+}
+
+function overlayRoot(): ShadowRoot {
+	const host = document.querySelector<HTMLDivElement>("[data-ao-annotation-root]");
+	if (!host?.shadowRoot) throw new Error("annotation overlay was not rendered");
+	return host.shadowRoot;
+}
+
+function highlightStyle(): CSSStyleDeclaration {
+	const highlight = overlayRoot().querySelector<HTMLDivElement>(".highlight");
+	if (!highlight) throw new Error("annotation highlight was not rendered");
+	return highlight.style;
+}
+
+function submitPrompt(instruction: string): BrowserAnnotationPageSubmitPayload {
+	const root = overlayRoot();
+	const textarea = root.querySelector<HTMLTextAreaElement>("textarea");
+	const form = root.querySelector<HTMLFormElement>("form");
+	if (!textarea || !form) throw new Error("annotation prompt was not rendered");
+	textarea.value = instruction;
+	form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+	const submitCall = electronMocks.send.mock.calls.find(([channel]) => channel === "browser:annotation:submit");
+	if (!submitCall) throw new Error("annotation submit was not sent");
+	return submitCall[1] as BrowserAnnotationPageSubmitPayload;
+}
+
+describe("annotate preload", () => {
+	beforeEach(() => {
+		document.body.innerHTML = "";
+		electronMocks.send.mockClear();
+		setAnnotationMode(true);
+	});
+
+	afterEach(() => {
+		setAnnotationMode(false);
+		document.body.innerHTML = "";
+		electronMocks.send.mockClear();
+	});
+
+	it("keeps the selected highlight locked while the prompt is open", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+		const second = elementWithBounds("second", { left: 240, top: 160, width: 80, height: 30 });
+
+		dispatchPageEvent(first, "pointermove");
+		dispatchPageEvent(first, "click");
+		dispatchPageEvent(second, "pointermove");
+
+		expect(highlightStyle().left).toBe("12px");
+		expect(highlightStyle().top).toBe("24px");
+		expect(highlightStyle().width).toBe("120px");
+		expect(highlightStyle().height).toBe("40px");
+	});
+
+	it("ignores underlying page clicks while the prompt is open", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+		const second = elementWithBounds("second", { left: 240, top: 160, width: 80, height: 30 });
+		const secondClick = vi.fn();
+		second.addEventListener("click", secondClick);
+
+		dispatchPageEvent(first, "click");
+		const ignoredClick = dispatchPageEvent(second, "click");
+
+		expect(ignoredClick.defaultPrevented).toBe(true);
+		expect(secondClick).not.toHaveBeenCalled();
+		expect(highlightStyle().left).toBe("12px");
+		expect(highlightStyle().top).toBe("24px");
+	});
+
+	it("submits the captured selected element after an ignored page click", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+		const second = elementWithBounds("second", { left: 240, top: 160, width: 80, height: 30 });
+
+		dispatchPageEvent(first, "click");
+		dispatchPageEvent(second, "click");
+
+		const payload = submitPrompt("Make this button blue.");
+
+		expect(payload.instruction).toBe("Make this button blue.");
+		expect(payload.context.selector).toBe("button#first");
+	});
+
+	it("keeps prompt controls active for cancel and escape", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+
+		dispatchPageEvent(first, "click");
+		overlayRoot().querySelector<HTMLButtonElement>('[data-action="cancel"]')?.click();
+
+		expect(electronMocks.send).toHaveBeenCalledWith("browser:annotation:cancel", { reason: "cancel" });
+		expect(document.querySelector("[data-ao-annotation-root]")).toBeNull();
+
+		electronMocks.send.mockClear();
+		setAnnotationMode(true);
+		dispatchPageEvent(first, "click");
+		document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+
+		expect(electronMocks.send).toHaveBeenCalledWith("browser:annotation:cancel", { reason: "escape" });
+		expect(document.querySelector("[data-ao-annotation-root]")).toBeNull();
+	});
+});

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -57,7 +57,7 @@ function removeListeners(): void {
 }
 
 function handlePointerMove(event: PointerEvent): void {
-	if (!enabled || isOverlayEvent(event)) return;
+	if (!enabled || selectedContext || isOverlayEvent(event)) return;
 	const target = annotationTarget(event.target);
 	if (!target || target === selectedElement) return;
 	selectedElement = target;
@@ -67,6 +67,12 @@ function handlePointerMove(event: PointerEvent): void {
 
 function handleClick(event: MouseEvent): void {
 	if (!enabled || isOverlayEvent(event)) return;
+	if (selectedContext) {
+		event.preventDefault();
+		event.stopPropagation();
+		event.stopImmediatePropagation();
+		return;
+	}
 	const target = annotationTarget(event.target);
 	if (!target) return;
 	event.preventDefault();


### PR DESCRIPTION
Fixes the browser annotation picker so once a user selects an element and the annotation dialog opens, the selected highlight stays locked on that element.
Hovering or clicking other page elements no longer changes the highlight or captured annotation context until the user sends, cancels, or presses Esc.

Also adds a focused preload regression test covering locked hover behavior, ignored underlying page clicks, preserved submit context, and cancel/Esc cleanup.