### PR TITLE
feat: restore cached workspace state during daemon startup

### DIFF
--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -91,6 +91,7 @@ function renderBoard(ui: ReactNode) {
 	lastShell = {
 		daemonStatus: { state: "ready" } as ShellContextValue["daemonStatus"],
 		workspaceStartupState: "ready",
+		workspaceLive: true,
 		createProject: createProjectMock,
 		initializeProjectRepository: initializeProjectRepositoryMock,
 	};
@@ -144,6 +145,7 @@ describe("global board first launch", () => {
 		lastShell = {
 			daemonStatus: { state: "starting" } as ShellContextValue["daemonStatus"],
 			workspaceStartupState: "loading",
+			workspaceLive: false,
 			createProject: createProjectMock,
 			initializeProjectRepository: initializeProjectRepositoryMock,
 		};
@@ -165,12 +167,39 @@ describe("global board first launch", () => {
 		expect(screen.queryByRole("button", { name: "Terminate fix the bug" })).not.toBeInTheDocument();
 	});
 
+	it("keeps an empty cached welcome read-only while the daemon starts", async () => {
+		lastQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		lastQueryClient.setQueryData(["workspaces"], []);
+		lastShell = {
+			daemonStatus: { state: "starting" } as ShellContextValue["daemonStatus"],
+			workspaceStartupState: "loading",
+			workspaceLive: false,
+			createProject: createProjectMock,
+			initializeProjectRepository: initializeProjectRepositoryMock,
+		};
+
+		render(
+			<QueryClientProvider client={lastQueryClient}>
+				<ShellProvider value={lastShell}>
+					<SessionsBoard />
+				</ShellProvider>
+			</QueryClientProvider>,
+		);
+
+		expect(await screen.findByText("Import to Agent Orchestrator")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Workspace" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Project" })).toBeDisabled();
+		await userEvent.click(screen.getByRole("button", { name: "Project" }));
+		expect(chooseDirectoryMock).not.toHaveBeenCalled();
+	});
+
 	it("shows the startup loader instead of import while the daemon is booting", async () => {
 		respondWith([], []);
 		lastQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 		lastShell = {
 			daemonStatus: { state: "starting" } as ShellContextValue["daemonStatus"],
 			workspaceStartupState: "loading",
+			workspaceLive: false,
 			createProject: createProjectMock,
 			initializeProjectRepository: initializeProjectRepositoryMock,
 		};

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -116,6 +116,55 @@ beforeEach(() => {
 });
 
 describe("global board first launch", () => {
+	it("shows the cached board instead of a loader while the daemon starts", async () => {
+		respondWith([project], [workerSession]);
+		lastQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		lastQueryClient.setQueryData(["workspaces"], [
+			{
+				id: "proj-1",
+				name: "my-app",
+				path: "/repo/my-app",
+				orchestratorAgent: "claude-code",
+				sessions: [
+					{
+						id: "sess-1",
+						workspaceId: "proj-1",
+						workspaceName: "my-app",
+						title: "fix the bug",
+						provider: "claude-code",
+						kind: "worker",
+						status: "working",
+						isTerminated: false,
+						updatedAt: "2026-07-04T10:00:00Z",
+						prs: [],
+					},
+				],
+			},
+		]);
+		lastShell = {
+			daemonStatus: { state: "starting" } as ShellContextValue["daemonStatus"],
+			workspaceStartupState: "loading",
+			createProject: createProjectMock,
+			initializeProjectRepository: initializeProjectRepositoryMock,
+		};
+
+		render(
+			<QueryClientProvider client={lastQueryClient}>
+				<ShellProvider value={lastShell}>
+					<SessionsBoard projectId="proj-1" />
+				</ShellProvider>
+			</QueryClientProvider>,
+		);
+
+		expect(await screen.findByText("fix the bug")).toBeInTheDocument();
+		expect(screen.getByTestId("cached-workspace-state")).toHaveTextContent(
+			"Showing the last saved state while AO starts",
+		);
+		expect(screen.queryByTestId("daemon-startup-loader")).not.toBeInTheDocument();
+		expect(columnCount()).toBe(4);
+		expect(screen.queryByRole("button", { name: "Terminate fix the bug" })).not.toBeInTheDocument();
+	});
+
 	it("shows the startup loader instead of import while the daemon is booting", async () => {
 		respondWith([], []);
 		lastQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -277,6 +277,7 @@ describe("global board first launch", () => {
 		lastShell = {
 			daemonStatus: { state: "stopped", code: "exited" } as ShellContextValue["daemonStatus"],
 			workspaceStartupState: "loading",
+			workspaceLive: false,
 			createProject: createProjectMock,
 			initializeProjectRepository: initializeProjectRepositoryMock,
 		};

--- a/frontend/src/renderer/components/BoardEmptyStates.tsx
+++ b/frontend/src/renderer/components/BoardEmptyStates.tsx
@@ -31,6 +31,7 @@ export function BoardWelcome() {
 // (Orchestrator stays the primary, like the topbar) so the vocabulary holds.
 export function ProjectBoardEmpty({
 	hasOrchestrator,
+	daemonReady,
 	isProjectRestarting,
 	isSpawning,
 	onNewTask,
@@ -38,6 +39,7 @@ export function ProjectBoardEmpty({
 	spawnError,
 }: {
 	hasOrchestrator: boolean;
+	daemonReady: boolean;
 	isProjectRestarting: boolean;
 	isSpawning: boolean;
 	onNewTask: () => void;
@@ -55,7 +57,7 @@ export function ProjectBoardEmpty({
 				<div className="mt-5 flex items-center gap-2">
 					<TopbarButton
 						aria-label={hasOrchestrator ? "Orchestrator" : "Spawn Orchestrator"}
-						disabled={isSpawning || isProjectRestarting}
+						disabled={!daemonReady || isSpawning || isProjectRestarting}
 						onClick={onOpenOrchestrator}
 						variant="primary"
 					>
@@ -68,7 +70,12 @@ export function ProjectBoardEmpty({
 									? "Orchestrator"
 									: "Spawn Orchestrator"}
 					</TopbarButton>
-					<TopbarButton aria-label="New task" disabled={isProjectRestarting} onClick={onNewTask} variant="accent">
+					<TopbarButton
+						aria-label="New task"
+						disabled={!daemonReady || isProjectRestarting}
+						onClick={onNewTask}
+						variant="accent"
+					>
 						<Plus className="size-icon-md" aria-hidden="true" />
 						New task
 					</TopbarButton>

--- a/frontend/src/renderer/components/BoardEmptyStates.tsx
+++ b/frontend/src/renderer/components/BoardEmptyStates.tsx
@@ -7,7 +7,7 @@ import { OrchestratorIcon } from "./icons";
 
 // Board empty states: first-launch welcome (`BoardWelcome`) and project board
 // with no worker sessions yet (`ProjectBoardEmpty`).
-export function BoardWelcome() {
+export function BoardWelcome({ disabled = false }: { disabled?: boolean }) {
 	const { createProject, initializeProjectRepository } = useShell();
 	return (
 		<WelcomePanel>
@@ -16,6 +16,7 @@ export function BoardWelcome() {
 				data-testid="board-welcome"
 			>
 				<CreateProjectFlow
+					disabled={disabled}
 					embedded
 					mode="choose"
 					onCreateProject={createProject}

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -82,6 +82,24 @@ describe("CenterPane toolbar session label", () => {
 		expect(onNewShellTerminal).toHaveBeenCalledOnce();
 	});
 
+	it("keeps terminal creation disabled until daemon workspace hydration completes", () => {
+		const onNewShellTerminal = vi.fn();
+		render(
+			<CenterPane
+				session={worker}
+				onNewShellTerminal={onNewShellTerminal}
+				theme="dark"
+				daemonReady={false}
+			/>,
+		);
+
+		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
+		const terminal = screen.getByRole("menuitem", { name: "Terminal" });
+		expect(terminal).toHaveAttribute("aria-disabled", "true");
+		fireEvent.click(terminal);
+		expect(onNewShellTerminal).not.toHaveBeenCalled();
+	});
+
 	it("limits a large session list, then expands it into a searchable scroll area", () => {
 		const sessions = Array.from({ length: 7 }, (_, index) => ({
 			...secondWorker,

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -266,7 +266,10 @@ export function CenterPane({
 							</button>
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="start" className="w-72">
-							<DropdownMenuItem onSelect={onNewShellTerminal}>
+							<DropdownMenuItem
+								disabled={!daemonReady || !onNewShellTerminal}
+								onSelect={daemonReady ? onNewShellTerminal : undefined}
+							>
 								<TerminalIcon aria-hidden="true" />
 								Terminal
 							</DropdownMenuItem>

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -80,6 +80,7 @@ const ctx = vi.hoisted(() => {
 	return {
 		params: {} as { projectId?: string; sessionId?: string },
 		enabled: true,
+		workspaceLive: true,
 		workspaces,
 	};
 });
@@ -100,7 +101,12 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 }));
 
 vi.mock("../lib/shell-context", () => ({
-	useShell: () => ({ createProject: vi.fn(), initializeProjectRepository: vi.fn(), daemonStatus: {} }),
+	useShell: () => ({
+		createProject: vi.fn(),
+		initializeProjectRepository: vi.fn(),
+		daemonStatus: {},
+		workspaceLive: ctx.workspaceLive,
+	}),
 }));
 
 vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: spawnMock }));
@@ -149,6 +155,7 @@ const paletteInput = () => screen.queryByPlaceholderText(/search projects/i);
 beforeEach(() => {
 	ctx.params = {};
 	ctx.enabled = true;
+	ctx.workspaceLive = true;
 	ctx.workspaces[0].orchestratorAgent = "codex";
 	ctx.workspaces[1].orchestratorAgent = "codex";
 	navigateMock.mockReset();
@@ -323,6 +330,23 @@ describe("CommandPalette search + Enter", () => {
 });
 
 describe("CommandPalette actions", () => {
+	it("keeps navigation available but disables daemon mutations until workspace hydration succeeds", async () => {
+		ctx.params = { projectId: "proj-2" };
+		ctx.workspaceLive = false;
+		renderPalette();
+		act(() => useUiStore.getState().setCommandPaletteOpen(true));
+		await screen.findByPlaceholderText(/search projects/i);
+
+		expect(screen.getAllByText("AO is still loading").length).toBeGreaterThan(0);
+		fireEvent.click(screen.getByText("Open orchestrator"));
+		fireEvent.click(screen.getByText("New project"));
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(choosePathMock).not.toHaveBeenCalled();
+
+		fireEvent.click(document.querySelector('[cmdk-item][data-value="project:proj-1"]') as HTMLElement);
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-1" } });
+	});
+
 	it("shows disabled New task reason, skips it for selection, and ignores clicks", async () => {
 		ctx.params = {};
 		renderPalette();

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -35,7 +35,7 @@ export function CommandPalette() {
 	const queryClient = useQueryClient();
 	const params = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
 	const workspaces = useWorkspaceQuery().data ?? [];
-	const { createProject, initializeProjectRepository } = useShell();
+	const { createProject, initializeProjectRepository, workspaceLive } = useShell();
 	const resolvedTheme = useUiStore((s) => s.resolvedTheme);
 	const setThemePreference = useUiStore((s) => s.setThemePreference);
 	const isOpen = useUiStore((s) => s.isCommandPaletteOpen);
@@ -63,8 +63,9 @@ export function CommandPalette() {
 				currentProjectId,
 				currentSessionId: params.sessionId,
 				restartingProjectIds,
+				mutationsEnabled: workspaceLive,
 			}),
-		[workspaces, currentProjectId, params.sessionId, restartingProjectIds],
+		[workspaces, currentProjectId, params.sessionId, restartingProjectIds, workspaceLive],
 	);
 	const groups = useMemo(() => displayGroups(items, query), [items, query]);
 
@@ -144,6 +145,15 @@ export function CommandPalette() {
 			const action = item.action;
 			if (!action) return;
 			setError(null);
+			if (
+				!workspaceLive &&
+				(action.kind === "open-new-task" ||
+					action.kind === "open-new-project" ||
+					action.kind === "open-orchestrator")
+			) {
+				setError("AO is still loading the current workspace state.");
+				return;
+			}
 			pendingRef.current = true;
 			setPendingId(item.id);
 			try {
@@ -181,7 +191,7 @@ export function CommandPalette() {
 				setPendingId(null);
 			}
 		},
-		[navigateToTarget, closePalette, toggleTheme, openOrchestrator, blockedByRestart],
+		[navigateToTarget, closePalette, toggleTheme, openOrchestrator, blockedByRestart, workspaceLive],
 	);
 
 	const onSelectItem = useCallback(
@@ -318,13 +328,14 @@ export function CommandPalette() {
 			</CommandDialog>
 
 			<NewTaskDialog
-				open={isNewTaskOpen}
+				open={isNewTaskOpen && workspaceLive}
 				projectId={newTaskProjectId}
 				onCreated={(sessionId) => void handleTaskCreated(sessionId)}
 				onOpenChange={setIsNewTaskOpen}
 			/>
 
 			<CreateProjectFlow
+				disabled={!workspaceLive}
 				mode="choose"
 				onCreateProject={createProject}
 				onInitializeProject={initializeProjectRepository}

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -17,6 +17,7 @@ type CreateProjectFlowMode = ProjectKind | "choose";
 // the same picker inline. Both still share the Git setup recovery path.
 export function CreateProjectFlow({
 	children,
+	disabled = false,
 	embedded = false,
 	idleLabel = "New project",
 	mode = "single_repo",
@@ -25,6 +26,7 @@ export function CreateProjectFlow({
 	openSignal,
 }: {
 	children?: (state: { choosePath: () => void; disabled: boolean; error: string | null; label: string }) => ReactNode;
+	disabled?: boolean;
 	// When true, render the Workspace/Project chooser inline (start page) instead
 	// of behind a trigger + dialog. Folder validation + agent sheet stay modal.
 	embedded?: boolean;
@@ -50,7 +52,7 @@ export function CreateProjectFlow({
 	const [repositorySetupWarning, setRepositorySetupWarning] = useState<string | null>(null);
 
 	const hasModePicker = mode === "choose";
-	const isBusy = isChoosingPath || isCreating || isInitializing;
+	const isBusy = disabled || isChoosingPath || isCreating || isInitializing;
 
 	const openFolderStep = (kind: ProjectKind) => {
 		// Keep the selector mounted behind the native picker. Closing it first
@@ -59,6 +61,7 @@ export function CreateProjectFlow({
 	};
 
 	const chooseDirectory = async (kind: ProjectKind) => {
+		if (disabled) return;
 		setError(null);
 		setValidationScan(null);
 		setRepositorySetup(null);
@@ -94,6 +97,7 @@ export function CreateProjectFlow({
 	};
 
 	const startFlow = () => {
+		if (disabled) return;
 		if (hasModePicker) {
 			setError(null);
 			setModePickerOpen(true);

--- a/frontend/src/renderer/components/GlobalNewTaskDialog.tsx
+++ b/frontend/src/renderer/components/GlobalNewTaskDialog.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { useShellMaybe } from "../lib/shell-context";
 import { useUiStore } from "../stores/ui-store";
 import { NewTaskDialog } from "./NewTaskDialog";
 
@@ -15,6 +16,7 @@ export function GlobalNewTaskDialog() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const newTaskRequest = useUiStore((state) => state.newTaskRequest);
+	const workspaceLive = useShellMaybe()?.workspaceLive ?? true;
 	const [open, setOpen] = useState(false);
 	const [projectId, setProjectId] = useState<string | undefined>(undefined);
 	const lastNonce = useRef(0);
@@ -22,13 +24,14 @@ export function GlobalNewTaskDialog() {
 	useEffect(() => {
 		if (!newTaskRequest || newTaskRequest.nonce === lastNonce.current) return;
 		lastNonce.current = newTaskRequest.nonce;
+		if (!workspaceLive) return;
 		// Consume requests that arrive while this dialog is already open. In
 		// particular, do not retarget a populated form to another project, and do
 		// not replay the ignored request when the user later closes the dialog.
 		if (open) return;
 		setProjectId(newTaskRequest.projectId);
 		setOpen(true);
-	}, [newTaskRequest, open]);
+	}, [newTaskRequest, open, workspaceLive]);
 
 	const handleCreated = async (sessionId: string) => {
 		if (!projectId) return;
@@ -41,7 +44,7 @@ export function GlobalNewTaskDialog() {
 
 	return (
 		<NewTaskDialog
-			open={open}
+			open={open && workspaceLive}
 			projectId={projectId}
 			onCreated={(sessionId) => void handleCreated(sessionId)}
 			onOpenChange={setOpen}

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -99,7 +99,7 @@ function renderWithQuery(children: ReactNode, workspaces?: WorkspaceSummary[]) {
 		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 	});
 	if (workspaces) client.setQueryData(workspaceQueryKey, workspaces);
-	return render(<QueryClientProvider client={client}>{children}</QueryClientProvider>);
+	return { ...render(<QueryClientProvider client={client}>{children}</QueryClientProvider>), client };
 }
 
 function mockCommonGets(_unusedRuns: unknown[] = [], reviewerHandleId = "", reviews: unknown[] = []) {
@@ -240,17 +240,43 @@ describe("SessionInspector PR section", () => {
 });
 
 describe("SessionInspector completion controls", () => {
-	it("persists the terminate-on-merge preference", async () => {
-		renderWithQuery(<SessionInspector session={session([])} />);
+	it("updates the cached preference only after the daemon confirms it", async () => {
+		let resolvePatch: ((result: { data: { ok: boolean }; error: undefined; response: { status: number } }) => void) | undefined;
+		patchMock.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolvePatch = resolve;
+			}),
+		);
+		const worker = session([]);
+		const initialWorkspaces: WorkspaceSummary[] = [
+			{
+				id: "ws-1",
+				name: "my-app",
+				path: "/repo",
+				sessions: [worker],
+			},
+		];
+		const { client } = renderWithQuery(<SessionInspector session={worker} />, initialWorkspaces);
 
 		await userEvent.click(screen.getByRole("switch", { name: "Terminate session when pull requests merge" }));
 
-		await waitFor(() =>
+		await waitFor(() => {
 			expect(patchMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/merge-policy", {
 				params: { path: { sessionId: "sess-1" } },
 				body: { terminateOnPrMerge: true },
-			}),
-		);
+			});
+		});
+		expect(
+			client.getQueryData<WorkspaceSummary[]>(workspaceQueryKey)?.[0]?.sessions[0]?.terminateOnPrMerge,
+		).not.toBe(true);
+
+		resolvePatch?.({ data: { ok: true }, error: undefined, response: { status: 200 } });
+
+		await waitFor(() => {
+			expect(
+				client.getQueryData<WorkspaceSummary[]>(workspaceQueryKey)?.[0]?.sessions[0]?.terminateOnPrMerge,
+			).toBe(true);
+		});
 	});
 
 	it("terminates a live merged session and returns to its orchestrator immediately", async () => {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -35,6 +35,7 @@ import { StatusPill } from "./StatusPill";
 import { CodexIcon } from "./icons";
 import { SessionTerminationPopover } from "./SessionTerminationPopover";
 import { Switch } from "./ui/switch";
+import { useShellMaybe } from "../lib/shell-context";
 
 type ProjectConfig = components["schemas"]["ProjectConfig"];
 type PRReviewState = components["schemas"]["PRReviewState"];
@@ -323,6 +324,7 @@ function SummaryView({ session }: { session: WorkspaceSession }) {
 
 function ResumeAgentControl({ session }: { session: WorkspaceSession }) {
 	const queryClient = useQueryClient();
+	const mutationsEnabled = useShellMaybe()?.workspaceLive ?? true;
 	const resume = useMutation({
 		mutationFn: async () => {
 			if (usePreviewData) return;
@@ -355,8 +357,8 @@ function ResumeAgentControl({ session }: { session: WorkspaceSession }) {
 		<div className="mt-3 border-t border-(--color-border-settings-input) pt-3">
 			<Button
 				className="w-full"
-				disabled={resume.isPending}
-				onClick={() => resume.mutate()}
+				disabled={!mutationsEnabled || resume.isPending}
+				onClick={() => mutationsEnabled && resume.mutate()}
 				size="sm"
 				type="button"
 				variant="outline"
@@ -376,6 +378,7 @@ function ResumeAgentControl({ session }: { session: WorkspaceSession }) {
 function CompletionControls({ session }: { session: WorkspaceSession }) {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
+	const mutationsEnabled = useShellMaybe()?.workspaceLive ?? true;
 	const [confirmOpen, setConfirmOpen] = useState(false);
 	const terminate = useTerminateSession();
 	const policy = useMutation({
@@ -428,7 +431,9 @@ function CompletionControls({ session }: { session: WorkspaceSession }) {
 				<div className="flex items-center justify-between gap-3 py-1">
 					<span className="min-w-0 text-xs font-medium text-settings-label">Terminate</span>
 					<SessionTerminationPopover
-						onConfirm={confirmTermination}
+						onConfirm={() => {
+							if (mutationsEnabled) confirmTermination();
+						}}
 						onOpenChange={setConfirmOpen}
 						open={confirmOpen}
 						session={session}
@@ -436,7 +441,10 @@ function CompletionControls({ session }: { session: WorkspaceSession }) {
 							<button
 								aria-label="Terminate session"
 								className="inline-flex size-control-md items-center justify-center rounded-sm text-passive transition-colors hover:bg-error/10 hover:text-error focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
-								onClick={() => clearTerminateSessionState(queryClient, session.id)}
+								disabled={!mutationsEnabled}
+								onClick={() => {
+									if (mutationsEnabled) clearTerminateSessionState(queryClient, session.id);
+								}}
 								type="button"
 							>
 								<Trash2 className="size-icon-sm" aria-hidden="true" />
@@ -453,9 +461,9 @@ function CompletionControls({ session }: { session: WorkspaceSession }) {
 						<Switch
 							aria-label="Terminate session when pull requests merge"
 							checked={Boolean(session.terminateOnPrMerge)}
-							disabled={policy.isPending}
+							disabled={!mutationsEnabled || policy.isPending}
 							id={`merge-policy-${session.id}`}
-							onCheckedChange={(checked) => policy.mutate(checked)}
+							onCheckedChange={(checked) => mutationsEnabled && policy.mutate(checked)}
 						/>
 					</div>
 					{policyError ? (
@@ -702,6 +710,7 @@ function ReviewsView({
 }) {
 	const hasPr = sortedPRs(session).length > 0;
 	const queryClient = useQueryClient();
+	const mutationsEnabled = useShellMaybe()?.workspaceLive ?? true;
 	const [reviewNotice, setReviewNotice] = useState<string | null>(null);
 	const reviewsQuery = useQuery({
 		queryKey: ["session-reviews", session.id],
@@ -782,9 +791,10 @@ function ReviewsView({
 					isLoading={reviewsQuery.isLoading}
 					isCancelling={cancelReview.isPending}
 					isTriggering={triggerReview.isPending}
+					mutationsEnabled={mutationsEnabled}
 					onOpenTerminal={onOpenReviewerTerminal}
-					onCancel={() => cancelReview.mutate()}
-					onTrigger={() => triggerReview.mutate()}
+					onCancel={() => mutationsEnabled && cancelReview.mutate()}
+					onTrigger={() => mutationsEnabled && triggerReview.mutate()}
 					reviewerHandleId={reviewsQuery.data?.reviewerHandleId ?? ""}
 					reviewStates={reviewStates}
 					notice={reviewNotice}
@@ -918,6 +928,7 @@ function ReviewPanel({
 	onTrigger,
 	onCancel,
 	onOpenTerminal,
+	mutationsEnabled,
 }: {
 	session: WorkspaceSession;
 	config?: ProjectConfig;
@@ -931,6 +942,7 @@ function ReviewPanel({
 	onTrigger: () => void;
 	onCancel: () => void;
 	onOpenTerminal?: OpenReviewerTerminal;
+	mutationsEnabled: boolean;
 }) {
 	if (sortedPRs(session).length === 0) {
 		return <p className={inspectorEmptyClass}>No pull request opened yet.</p>;
@@ -947,7 +959,7 @@ function ReviewPanel({
 	const openReviewStates = reviewStates.filter((reviewState) => openPRURLs.has(reviewState.prUrl));
 	const latest = openReviewStates.find((review) => review.latestRun)?.latestRun;
 	const harness = latest?.harness || config?.reviewers?.[0]?.harness || "claude-code";
-	const terminalEnabled = Boolean(reviewerHandleId && onOpenTerminal);
+	const terminalEnabled = mutationsEnabled && Boolean(reviewerHandleId && onOpenTerminal);
 	const reviewRunning = openReviewStates.some((reviewState) => reviewState.status === "running");
 	const reviewHasRun = reviewRunning || Boolean(latest);
 	const runAction = reviewSessionRunAction(openReviewStates, isTriggering);
@@ -995,7 +1007,7 @@ function ReviewPanel({
 			<div className="-mx-4 -mb-3 mt-3 flex items-center justify-center gap-1 border-t border-border px-4 pb-3 pt-3">
 				<Button
 					className={cn("gap-1.5 [&_svg]:size-icon-sm", reviewRunning ? "text-error" : "text-success")}
-					disabled={reviewRunning ? isCancelling : runDisabled}
+					disabled={!mutationsEnabled || (reviewRunning ? isCancelling : runDisabled)}
 					onClick={reviewRunning ? onCancel : onTrigger}
 					size="sm"
 					type="button"

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -390,16 +390,10 @@ function CompletionControls({ session }: { session: WorkspaceSession }) {
 			});
 			if (error) throw new Error(apiErrorMessage(error, `Failed to update merge policy (${response.status})`));
 		},
-		onMutate: async (terminateOnPrMerge) => {
-			await queryClient.cancelQueries({ queryKey: workspaceQueryKey });
-			const previous = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
+		onSuccess: (_data, terminateOnPrMerge) => {
 			queryClient.setQueryData<WorkspaceSummary[]>(workspaceQueryKey, (current) =>
 				updateSessionMergePolicy(current, session.id, terminateOnPrMerge),
 			);
-			return { previous };
-		},
-		onError: (_error, _next, context) => {
-			if (context?.previous) queryClient.setQueryData(workspaceQueryKey, context.previous);
 		},
 		onSettled: () => {
 			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -232,7 +232,7 @@ vi.mock("./SessionInspector", () => ({
 	),
 }));
 vi.mock("../lib/shell-context", () => ({
-	useShell: () => ({ daemonStatus: { state: "ready" } }),
+	useShell: () => ({ daemonStatus: { state: "ready" }, workspaceLive: true }),
 }));
 vi.mock("../hooks/useWorkspaceQuery", () => ({
 	useWorkspaceQuery: () => ({

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -72,7 +72,7 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 	const setInspectorViewForSession = useUiStore((state) => state.setInspectorView);
 	const markInspectorPreviewSeen = useUiStore((state) => state.markInspectorPreviewSeen);
 	const setBrowserUnseen = useUiStore((state) => state.setBrowserUnseen);
-	const { daemonStatus } = useShell();
+	const { workspaceLive } = useShell();
 	const inspectorRef = useRef<PanelImperativeHandle | null>(null);
 	const inspectorSeparatorRef = useRef<HTMLDivElement | null>(null);
 	const [terminalTarget, setTerminalTarget] = useState<TerminalTarget>({ kind: "worker" });
@@ -423,7 +423,7 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%">
 					<CenterPane
 						availableProjectSessions={availableSessions.filter((candidate) => candidate.id !== tabOwnerSession?.id)}
-						daemonReady={daemonStatus.state === "ready"}
+						daemonReady={workspaceLive}
 						onAddProjectSession={addProjectSession}
 						onCloseProjectSession={closeProjectSession}
 						onCloseShellTerminal={closeShellTerminalByHandle}

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -47,6 +47,7 @@ vi.mock("../lib/platform", async (importOriginal) => {
 });
 
 import { SessionsBoard } from "./SessionsBoard";
+import { ShellProvider, type ShellContextValue } from "../lib/shell-context";
 import { TooltipProvider } from "./ui/tooltip";
 
 function renderBoard(projectId?: string) {
@@ -75,6 +76,54 @@ beforeEach(() => {
 });
 
 describe("SessionsBoard", () => {
+	it("keeps cached sessions visible when the live refresh fails", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "AO",
+					path: "/tmp/ao",
+					sessions: [
+						{
+							id: "s1",
+							workspaceId: "p1",
+							workspaceName: "AO",
+							title: "cached session",
+							provider: "codex",
+							status: "working",
+							updatedAt: "2026-07-28T08:00:00Z",
+							prs: [],
+						},
+					],
+				},
+			],
+			error: new Error("daemon unavailable"),
+			isError: true,
+		});
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const shell: ShellContextValue = {
+			daemonStatus: { state: "ready", port: 7777 } as ShellContextValue["daemonStatus"],
+			workspaceLive: false,
+			createProject: vi.fn(),
+			initializeProjectRepository: vi.fn(),
+		};
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<ShellProvider value={shell}>
+					<TooltipProvider>
+						<SessionsBoard projectId="p1" />
+					</TooltipProvider>
+				</ShellProvider>
+			</QueryClientProvider>,
+		);
+
+		expect(screen.getByText("cached session")).toBeInTheDocument();
+		expect(screen.queryByText("Could not load sessions.")).not.toBeInTheDocument();
+		expect(screen.getByTestId("cached-workspace-state")).toHaveTextContent("AO could not refresh");
+		expect(screen.queryByRole("button", { name: "Terminate cached session" })).not.toBeInTheDocument();
+	});
+
 	it("does not show an agent setup warning on the board", () => {
 		renderBoard();
 

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -103,6 +103,7 @@ describe("SessionsBoard", () => {
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 		const shell: ShellContextValue = {
 			daemonStatus: { state: "ready", port: 7777 } as ShellContextValue["daemonStatus"],
+			workspaceStartupState: "error",
 			workspaceLive: false,
 			createProject: vi.fn(),
 			initializeProjectRepository: vi.fn(),

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -84,6 +84,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const restoreSessionById = useRestoreSession();
 	const workspaceQuery = useWorkspaceQuery();
 	const shell = useShellMaybe();
+	const daemonReady = shell ? shell.daemonStatus.state === "ready" : true;
 	// Evaluated at render so platform mocks in tests can flip the in-panel chrome.
 	const boardActionsInPanel = usesBoardActionsInPanel();
 	/** Bell lives in the board action row when the shell topbar does not host it. */
@@ -170,7 +171,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 
 	const restoreArchivedSession = async (event: MouseEvent<HTMLButtonElement>, session: WorkspaceSession) => {
 		event.stopPropagation();
-		if (restoringSessionId) return;
+		if (!daemonReady || restoringSessionId) return;
 		const restoreProjectId = projectId;
 		const isStillActiveProject = () => !restoreProjectId || activeProjectIdRef.current === restoreProjectId;
 		setRestoringSessionId(session.id);
@@ -202,7 +203,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	};
 
 	const openOrchestrator = async () => {
-		if (!projectId || isProjectRestarting) return;
+		if (!daemonReady || !projectId || isProjectRestarting) return;
 		if (orchestrator) {
 			void navigate({
 				to: "/projects/$projectId/sessions/$sessionId",
@@ -238,7 +239,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	};
 
 	const restartOrchestrator = async () => {
-		if (!projectId) return;
+		if (!daemonReady || !projectId) return;
 		await restartProjectOrchestrator({
 			projectId,
 			queryClient,
@@ -258,7 +259,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			)}
 			<TopbarButton
 				aria-label="New task"
-				disabled={isProjectRestarting}
+				disabled={!daemonReady || isProjectRestarting}
 				onClick={() => projectId && requestNewTask(projectId)}
 				variant="accent"
 			>
@@ -267,7 +268,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			</TopbarButton>
 			<TopbarButton
 				aria-label={orchestratorActivityLabel ? `Orchestrator, ${orchestratorActivityLabel}` : "Spawn Orchestrator"}
-				disabled={isSpawning || isProjectRestarting}
+				disabled={!daemonReady || isSpawning || isProjectRestarting}
 				onClick={() => void openOrchestrator()}
 				variant="primary"
 			>
@@ -308,13 +309,28 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				</div>
 			) : null}
 
+			{!daemonReady && workspaceQuery.data !== undefined ? (
+				<div
+					aria-live="polite"
+					className="shrink-0 border-b border-border-strong bg-surface px-3 py-1.5 text-center font-mono text-caption text-muted-foreground"
+					data-testid="cached-workspace-state"
+					role="status"
+				>
+					Showing the last saved state while AO starts…
+				</div>
+			) : null}
+
 			<div className="min-h-0 flex-1 overflow-hidden">
 				{projectId && health.state !== "ok" ? (
 					<div className="mx-3 my-3 flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2 text-xs text-muted-foreground">
 						<AlertTriangle className="size-icon-base shrink-0 text-warning" aria-hidden="true" />
 						<span className="min-w-0 flex-1">{health.message}</span>
 						{health.state === "restart_needed" || health.state === "duplicates" ? (
-							<TopbarButton disabled={isProjectRestarting} onClick={() => void restartOrchestrator()} variant="primary">
+							<TopbarButton
+								disabled={!daemonReady || isProjectRestarting}
+								onClick={() => void restartOrchestrator()}
+								variant="primary"
+							>
 								<RotateCw className="size-3.5" aria-hidden="true" />
 								Restart
 							</TopbarButton>
@@ -332,6 +348,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						hasOrchestrator={orchestrator !== undefined}
 						isSpawning={isSpawning}
 						isProjectRestarting={isProjectRestarting}
+						daemonReady={daemonReady}
 						onNewTask={() => projectId && requestNewTask(projectId)}
 						onOpenOrchestrator={() => void openOrchestrator()}
 						spawnError={visibleSpawnError}
@@ -352,7 +369,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 									col={col}
 									sessions={byZone.get(col.zone) ?? []}
 									onOpen={openSession}
-									onTerminate={(session) => terminateSession.mutate(session)}
+									onTerminate={daemonReady ? (session) => terminateSession.mutate(session) : undefined}
 								/>
 							))}
 						</div>
@@ -405,7 +422,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 									restoreAction={(event) => void restoreArchivedSession(event, s)}
 									restoreError={restoreErrors[s.id]}
 									isRestoring={restoringSessionId === s.id}
-									isRestoreDisabled={restoringSessionId !== undefined}
+									isRestoreDisabled={!daemonReady || restoringSessionId !== undefined}
 								/>
 							))}
 						</div>
@@ -437,7 +454,7 @@ function BoardColumn({
 	col: Column;
 	sessions: WorkspaceSession[];
 	onOpen: (s: WorkspaceSession) => void;
-	onTerminate: (s: WorkspaceSession) => void;
+	onTerminate?: (s: WorkspaceSession) => void;
 }) {
 	if (col.zone === "working") return <WorkLaneColumn sessions={sessions} onOpen={onOpen} onTerminate={onTerminate} />;
 	if (col.zone === "merge") return <MergeLaneColumn sessions={sessions} onOpen={onOpen} onTerminate={onTerminate} />;
@@ -453,7 +470,7 @@ function ZoneColumn({
 	col: Column;
 	sessions: WorkspaceSession[];
 	onOpen: (s: WorkspaceSession) => void;
-	onTerminate: (s: WorkspaceSession) => void;
+	onTerminate?: (s: WorkspaceSession) => void;
 }) {
 	return (
 		<section
@@ -482,7 +499,7 @@ function ZoneColumn({
 							key={session.id}
 							session={session}
 							onOpen={() => onOpen(session)}
-							onTerminate={() => onTerminate(session)}
+							onTerminate={onTerminate ? () => onTerminate(session) : undefined}
 						/>
 					))}
 				</div>
@@ -548,7 +565,7 @@ function WorkLaneColumn({
 }: {
 	sessions: WorkspaceSession[];
 	onOpen: (s: WorkspaceSession) => void;
-	onTerminate: (s: WorkspaceSession) => void;
+	onTerminate?: (s: WorkspaceSession) => void;
 }) {
 	const idleSessions = sessions.filter(isSessionIdle);
 	const workingSessions = sessions.filter((session) => !isSessionIdle(session));
@@ -574,7 +591,7 @@ function MergeLaneColumn({
 }: {
 	sessions: WorkspaceSession[];
 	onOpen: (s: WorkspaceSession) => void;
-	onTerminate: (s: WorkspaceSession) => void;
+	onTerminate?: (s: WorkspaceSession) => void;
 }) {
 	const mergedSessions = sessions
 		.filter((session) => session.status === "merged")
@@ -614,7 +631,7 @@ function SplitLaneColumn({
 	secondarySessions: WorkspaceSession[];
 	secondaryTone: SplitLaneTone;
 	onOpen: (s: WorkspaceSession) => void;
-	onTerminate: (s: WorkspaceSession) => void;
+	onTerminate?: (s: WorkspaceSession) => void;
 }) {
 	const showPrimary = primarySessions.length > 0;
 	const showSecondary = secondarySessions.length > 0;
@@ -658,7 +675,7 @@ function SplitLaneColumn({
 										key={session.id}
 										session={session}
 										onOpen={() => onOpen(session)}
-										onTerminate={() => onTerminate(session)}
+										onTerminate={onTerminate ? () => onTerminate(session) : undefined}
 									/>
 								))}
 							</div>

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -84,7 +84,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const restoreSessionById = useRestoreSession();
 	const workspaceQuery = useWorkspaceQuery();
 	const shell = useShellMaybe();
-	const daemonReady = shell ? shell.daemonStatus.state === "ready" : true;
+	const workspaceLive = shell ? shell.workspaceLive : true;
 	// Evaluated at render so platform mocks in tests can flip the in-panel chrome.
 	const boardActionsInPanel = usesBoardActionsInPanel();
 	/** Bell lives in the board action row when the shell topbar does not host it. */
@@ -142,10 +142,11 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const isDaemonReady = usesPreviewWorkspaceData || (shell ? shell.daemonStatus.state === "ready" : true);
 	const daemonHasFailed = Boolean(shell?.daemonStatus.code);
 	const workspaceStartupState = shell?.workspaceStartupState ?? "ready";
-	const isLoaded = isDaemonReady && workspaceStartupState === "ready" && workspaceQuery.isSuccess;
+	const isLoaded = workspaceQuery.isSuccess || (shell !== null && workspaceQuery.data !== undefined);
 	const showStartup =
 		shell !== null &&
 		!daemonHasFailed &&
+		workspaceQuery.data === undefined &&
 		(!isDaemonReady || workspaceStartupState === "loading" || (!workspaceQuery.isSuccess && !workspaceQuery.isError));
 	const showWelcome = !projectId && isLoaded && all.length === 0;
 	const showProjectEmpty = projectId !== undefined && isLoaded && workspaces.length > 0 && sessions.length === 0;
@@ -171,7 +172,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 
 	const restoreArchivedSession = async (event: MouseEvent<HTMLButtonElement>, session: WorkspaceSession) => {
 		event.stopPropagation();
-		if (!daemonReady || restoringSessionId) return;
+		if (!workspaceLive || restoringSessionId) return;
 		const restoreProjectId = projectId;
 		const isStillActiveProject = () => !restoreProjectId || activeProjectIdRef.current === restoreProjectId;
 		setRestoringSessionId(session.id);
@@ -203,7 +204,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	};
 
 	const openOrchestrator = async () => {
-		if (!daemonReady || !projectId || isProjectRestarting) return;
+		if (!workspaceLive || !projectId || isProjectRestarting) return;
 		if (orchestrator) {
 			void navigate({
 				to: "/projects/$projectId/sessions/$sessionId",
@@ -239,7 +240,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	};
 
 	const restartOrchestrator = async () => {
-		if (!daemonReady || !projectId) return;
+		if (!workspaceLive || !projectId) return;
 		await restartProjectOrchestrator({
 			projectId,
 			queryClient,
@@ -259,7 +260,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			)}
 			<TopbarButton
 				aria-label="New task"
-				disabled={!daemonReady || isProjectRestarting}
+				disabled={!workspaceLive || isProjectRestarting}
 				onClick={() => projectId && requestNewTask(projectId)}
 				variant="accent"
 			>
@@ -268,7 +269,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			</TopbarButton>
 			<TopbarButton
 				aria-label={orchestratorActivityLabel ? `Orchestrator, ${orchestratorActivityLabel}` : "Spawn Orchestrator"}
-				disabled={!daemonReady || isSpawning || isProjectRestarting}
+				disabled={!workspaceLive || isSpawning || isProjectRestarting}
 				onClick={() => void openOrchestrator()}
 				variant="primary"
 			>
@@ -309,14 +310,16 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				</div>
 			) : null}
 
-			{!daemonReady && workspaceQuery.data !== undefined ? (
+			{!workspaceLive && workspaceQuery.data !== undefined ? (
 				<div
 					aria-live="polite"
 					className="shrink-0 border-b border-border-strong bg-surface px-3 py-1.5 text-center font-mono text-caption text-muted-foreground"
 					data-testid="cached-workspace-state"
 					role="status"
 				>
-					Showing the last saved state while AO starts…
+					{workspaceQuery.isError
+						? "Showing the last saved state because AO could not refresh."
+						: "Showing the last saved state while AO starts…"}
 				</div>
 			) : null}
 
@@ -327,7 +330,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						<span className="min-w-0 flex-1">{health.message}</span>
 						{health.state === "restart_needed" || health.state === "duplicates" ? (
 							<TopbarButton
-								disabled={!daemonReady || isProjectRestarting}
+								disabled={!workspaceLive || isProjectRestarting}
 								onClick={() => void restartOrchestrator()}
 								variant="primary"
 							>
@@ -339,16 +342,17 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				) : null}
 				{showStartup ? (
 					<DaemonStartupLoader />
-				) : workspaceStartupState === "error" || workspaceQuery.isError ? (
+				) : (workspaceStartupState === "error" || workspaceQuery.isError) &&
+					workspaceQuery.data === undefined ? (
 					<p className="py-10 text-center text-xs text-passive">Could not load sessions.</p>
 				) : showWelcome ? (
-					<BoardWelcome />
+					<BoardWelcome disabled={!workspaceLive} />
 				) : showProjectEmpty ? (
 					<ProjectBoardEmpty
 						hasOrchestrator={orchestrator !== undefined}
 						isSpawning={isSpawning}
 						isProjectRestarting={isProjectRestarting}
-						daemonReady={daemonReady}
+						daemonReady={workspaceLive}
 						onNewTask={() => projectId && requestNewTask(projectId)}
 						onOpenOrchestrator={() => void openOrchestrator()}
 						spawnError={visibleSpawnError}
@@ -369,7 +373,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 									col={col}
 									sessions={byZone.get(col.zone) ?? []}
 									onOpen={openSession}
-									onTerminate={daemonReady ? (session) => terminateSession.mutate(session) : undefined}
+									onTerminate={workspaceLive ? (session) => terminateSession.mutate(session) : undefined}
 								/>
 							))}
 						</div>
@@ -422,7 +426,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 									restoreAction={(event) => void restoreArchivedSession(event, s)}
 									restoreError={restoreErrors[s.id]}
 									isRestoring={restoringSessionId === s.id}
-									isRestoreDisabled={!daemonReady || restoringSessionId !== undefined}
+									isRestoreDisabled={!workspaceLive || restoringSessionId !== undefined}
 								/>
 							))}
 						</div>

--- a/frontend/src/renderer/components/ShellTerminalsView.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.test.tsx
@@ -9,7 +9,7 @@ vi.mock("../hooks/useShellTerminals", () => ({
 }));
 
 vi.mock("../lib/shell-context", () => ({
-	useShell: () => ({ daemonStatus: { state: "ready" } }),
+	useShell: () => ({ daemonStatus: { state: "ready" }, workspaceLive: true }),
 }));
 
 vi.mock("./TerminalPane", () => ({ TerminalPane: () => <div>terminal body</div> }));

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -16,7 +16,7 @@ import { TerminalPane } from "./TerminalPane";
 // most wants a plain terminal. Inside a session, shells still appear as tabs
 // beside that session's pane; this screen is where they live otherwise.
 export function ShellTerminalsView() {
-	const { daemonStatus } = useShell();
+	const { workspaceLive } = useShell();
 	const theme = useResolvedTheme();
 	// The standalone screen shows only session-less shells; a session's own
 	// shells belong to that session's tab strip, not this global list.
@@ -95,7 +95,8 @@ export function ShellTerminalsView() {
 				<button
 					aria-label="New terminal"
 					className="ml-auto inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
-					onClick={requestNewShellTerminal}
+					disabled={!workspaceLive}
+					onClick={() => workspaceLive && requestNewShellTerminal()}
 					title="New terminal (Ctrl+Shift+`)"
 					type="button"
 				>
@@ -105,7 +106,7 @@ export function ShellTerminalsView() {
 			<div className="min-h-0 flex-1">
 				{active ? (
 					<TerminalPane
-						daemonReady={daemonStatus.state === "ready"}
+						daemonReady={workspaceLive}
 						fontSize={12}
 						terminalTarget={{ kind: "shell", handleId: active.handleId, title: active.title }}
 						theme={theme}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -61,7 +61,7 @@ export function ShellTopbar() {
 	const [boardSpawnError, setBoardSpawnError] = useState<string | null>(null);
 	const all = useWorkspaceQuery().data ?? [];
 	const shell = useShellMaybe();
-	const daemonReady = shell ? shell.daemonStatus.state === "ready" : true;
+	const daemonReady = shell ? shell.workspaceLive : true;
 
 	const session = params.sessionId
 		? all.flatMap((workspace) => workspace.sessions).find((s) => s.id === params.sessionId)

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -27,6 +27,7 @@ import { isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { StatusPill } from "./StatusPill";
 import { TopbarButton, TopbarKillError, topbarHeaderClass, topbarProjectLabelClass } from "./TopbarButton";
 import { SessionTerminationPopover } from "./SessionTerminationPopover";
+import { useShellMaybe } from "../lib/shell-context";
 
 const isMac = isMacPlatform();
 const boardActionsInPanel = usesBoardActionsInPanel();
@@ -59,6 +60,8 @@ export function ShellTopbar() {
 	// Board-scope spawn failures surface where the board actions render.
 	const [boardSpawnError, setBoardSpawnError] = useState<string | null>(null);
 	const all = useWorkspaceQuery().data ?? [];
+	const shell = useShellMaybe();
+	const daemonReady = shell ? shell.daemonStatus.state === "ready" : true;
 
 	const session = params.sessionId
 		? all.flatMap((workspace) => workspace.sessions).find((s) => s.id === params.sessionId)
@@ -83,7 +86,7 @@ export function ShellTopbar() {
 		projectId ? void navigate({ to: "/projects/$projectId", params: { projectId } }) : void navigate({ to: "/" });
 
 	const openNewTask = () => {
-		if (!projectId || isProjectRestarting) return;
+		if (!daemonReady || !projectId || isProjectRestarting) return;
 		requestNewTask(projectId);
 	};
 
@@ -93,7 +96,7 @@ export function ShellTopbar() {
 	};
 
 	const openOrchestrator = async () => {
-		if (!projectId) return;
+		if (!daemonReady || !projectId) return;
 		setBoardSpawnError(null);
 		void addRendererExceptionStep("Orchestrator open requested", {
 			source: "orchestrator-open",
@@ -183,7 +186,7 @@ export function ShellTopbar() {
 						) : null}
 						<TopbarButton
 							aria-label="New task"
-							disabled={isProjectRestarting}
+							disabled={!daemonReady || isProjectRestarting}
 							onClick={openNewTask}
 							style={noDragStyle}
 							variant="accent"
@@ -193,7 +196,7 @@ export function ShellTopbar() {
 						</TopbarButton>
 						<TopbarButton
 							aria-label={orchestratorActivityLabel ? `Orchestrator, ${orchestratorActivityLabel}` : "Spawn Orchestrator"}
-							disabled={isSpawning || isProjectRestarting}
+							disabled={!daemonReady || isSpawning || isProjectRestarting}
 							onClick={() => void openOrchestrator()}
 							style={noDragStyle}
 							variant="primary"
@@ -217,7 +220,7 @@ export function ShellTopbar() {
 								<ProjectTerminationFeedback projectId={projectId} />
 								<TopbarButton
 									aria-label="New task"
-									disabled={isProjectRestarting}
+									disabled={!daemonReady || isProjectRestarting}
 									onClick={openNewTask}
 									style={noDragStyle}
 									variant="accent"
@@ -235,6 +238,7 @@ export function ShellTopbar() {
 						    moved here from the inspector's Summary "Danger zone". */}
 						{!isOrchestrator && session && sessionIsActive(session) ? (
 							<TopbarKillButton
+								disabled={!daemonReady}
 								key={session.id}
 								session={session}
 								orchestratorId={orchestrator?.id}
@@ -253,7 +257,7 @@ export function ShellTopbar() {
 						{!isOrchestrator && (
 							<TopbarButton
 								aria-label="Open orchestrator"
-								disabled={isSpawning || isProjectRestarting}
+								disabled={!daemonReady || isSpawning || isProjectRestarting}
 								onClick={() => void openOrchestrator()}
 								style={noDragStyle}
 								variant="primary"
@@ -293,10 +297,12 @@ export function ShellTopbar() {
 // Mutation-cache state is filtered by worker ID so rapid route switches never
 // carry another worker's Killing/error state into the current topbar.
 export function TopbarKillButton({
+	disabled = false,
 	session,
 	orchestratorId,
 	onKilled,
 }: {
+	disabled?: boolean;
 	session: WorkspaceSession;
 	orchestratorId?: string;
 	onKilled: (workspaceId: string, orchestratorId?: string) => void;
@@ -322,7 +328,7 @@ export function TopbarKillButton({
 				trigger={
 					<TopbarButton
 						aria-label={isPending ? "Killing..." : "Kill session"}
-						disabled={isPending}
+						disabled={disabled || isPending}
 						onClick={() => {
 							clearTerminateSessionState(queryClient, session.id);
 						}}

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -142,6 +142,7 @@ export function Sidebar({
 	// Daemon status for the smoke suite's sr-only mirror in the footer. Null when
 	// rendered outside the shell (unit tests) — the mirror simply doesn't render.
 	const daemonStatus = useShellMaybe()?.daemonStatus ?? null;
+	const daemonReady = daemonStatus ? daemonStatus.state === "ready" : true;
 	const commandPaletteEnabled = useCommandPaletteEnabled();
 	const setCommandPaletteOpen = useUiStore((s) => s.setCommandPaletteOpen);
 
@@ -284,6 +285,7 @@ export function Sidebar({
 						Projects
 					</SidebarGroupLabel>
 					<CreateProjectButton
+						daemonReady={daemonReady}
 						hideTrigger={workspaces.length === 0}
 						onCreateProject={onCreateProject}
 						onInitializeProject={onInitializeProject}
@@ -304,6 +306,7 @@ export function Sidebar({
 							<SidebarMenu className="gap-0 group-data-[collapsible=icon]:gap-1">
 								{workspaces.map((workspace) => (
 									<ProjectItem
+										daemonReady={daemonReady}
 										key={workspace.id}
 										workspace={workspace}
 										expanded={!collapsedIds.has(workspace.id)}
@@ -312,7 +315,7 @@ export function Sidebar({
 										onRemoveProject={onRemoveProject}
 									/>
 								))}
-								{isCollapsed && <CreateProjectListItem />}
+								{isCollapsed && <CreateProjectListItem daemonReady={daemonReady} />}
 							</SidebarMenu>
 						)}
 					</SidebarGroupContent>
@@ -393,12 +396,14 @@ export function Sidebar({
 type Selection = ReturnType<typeof useSelection>;
 
 function ProjectItem({
+	daemonReady,
 	workspace,
 	expanded,
 	selection,
 	onToggle,
 	onRemoveProject,
 }: {
+	daemonReady: boolean;
 	workspace: WorkspaceSummary;
 	expanded: boolean;
 	selection: Selection;
@@ -430,6 +435,7 @@ function ProjectItem({
 			selection.goSession(workspace.id, orchestrator.id);
 			return;
 		}
+		if (!daemonReady) return;
 		if (!hasConfiguredOrchestratorAgent(workspace)) {
 			selection.goSettings(workspace.id);
 			return;
@@ -458,6 +464,7 @@ function ProjectItem({
 	};
 
 	const removeProject = () => {
+		if (!daemonReady) return;
 		setRemoveError(null);
 		setConfirmOpen(true);
 	};
@@ -540,7 +547,7 @@ function ProjectItem({
 						<button
 							aria-label={orchestrator ? `Open ${workspace.name} orchestrator` : `Spawn ${workspace.name} orchestrator`}
 							className={HOVER_ACTION_CLASS}
-							disabled={isSpawning || isProjectRestarting}
+							disabled={(!daemonReady && !orchestrator) || isSpawning || isProjectRestarting}
 							onClick={() => void openOrchestrator()}
 							type="button"
 						>
@@ -564,7 +571,10 @@ function ProjectItem({
 						</button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent side="right" align="start" className="min-w-44">
-						<DropdownMenuItem disabled={isProjectRestarting} onSelect={() => requestNewTask(workspace.id)}>
+						<DropdownMenuItem
+							disabled={!daemonReady || isProjectRestarting}
+							onSelect={() => requestNewTask(workspace.id)}
+						>
 							<Plus aria-hidden="true" />
 							New session
 						</DropdownMenuItem>
@@ -576,7 +586,7 @@ function ProjectItem({
 						<DropdownMenuSeparator />
 						<DropdownMenuItem
 							className="text-destructive focus:text-destructive [&_svg]:text-destructive"
-							disabled={isRemoving}
+							disabled={!daemonReady || isRemoving}
 							onSelect={() => void removeProject()}
 						>
 							<Trash2 aria-hidden="true" />
@@ -600,6 +610,7 @@ function ProjectItem({
 				<SidebarMenuSub className="sidebar-expanded-chrome mx-0 ml-3.5 translate-x-0 gap-0 border-l-0 px-0 py-1">
 					{sessions.map((session) => (
 						<SessionRow
+							daemonReady={daemonReady}
 							key={session.id}
 							session={session}
 							active={selection.activeSessionId === session.id}
@@ -634,7 +645,17 @@ function ProjectItem({
 // One worker-session row. Reads as a link by default; a hover-revealed pencil
 // flips the label into an inline input (Enter/blur saves, Escape cancels) that
 // persists through the daemon rename endpoint, so the new name survives reload.
-function SessionRow({ session, active, onOpen }: { session: WorkspaceSession; active: boolean; onOpen: () => void }) {
+function SessionRow({
+	daemonReady,
+	session,
+	active,
+	onOpen,
+}: {
+	daemonReady: boolean;
+	session: WorkspaceSession;
+	active: boolean;
+	onOpen: () => void;
+}) {
 	const queryClient = useQueryClient();
 	const [isEditing, setIsEditing] = useState(false);
 	const [draft, setDraft] = useState(session.title);
@@ -643,6 +664,7 @@ function SessionRow({ session, active, onOpen }: { session: WorkspaceSession; ac
 	const cancelledRef = useRef(false);
 
 	const startEditing = () => {
+		if (!daemonReady) return;
 		setDraft(session.title);
 		setIsEditing(true);
 	};
@@ -724,6 +746,7 @@ function SessionRow({ session, active, onOpen }: { session: WorkspaceSession; ac
 					"absolute top-1/2 right-1 -translate-y-1/2 opacity-0",
 					"group-focus-within/menu-sub-item:opacity-100 group-hover/menu-sub-item:opacity-100",
 				)}
+				disabled={!daemonReady}
 				onClick={startEditing}
 				type="button"
 			>
@@ -842,10 +865,14 @@ function SidebarSearchButton({ onOpen }: { onOpen: () => void }) {
 }
 
 function CreateProjectButton({
+	daemonReady,
 	hideTrigger = false,
 	onCreateProject,
 	onInitializeProject,
-}: Pick<SidebarProps, "onCreateProject" | "onInitializeProject"> & { hideTrigger?: boolean }) {
+}: Pick<SidebarProps, "onCreateProject" | "onInitializeProject"> & {
+	daemonReady: boolean;
+	hideTrigger?: boolean;
+}) {
 	// Single CreateProjectFlow owner for the sidebar: the header "+" stays mounted
 	// (CSS-hidden when collapsed or on the empty start page) so it can own
 	// openSignal for ⌘N on every shell route. The collapsed rail button below
@@ -867,7 +894,7 @@ function CreateProjectButton({
 								"grid size-icon-xl place-items-center rounded-sm text-passive transition-colors hover:bg-interactive-hover hover:text-muted-foreground",
 								hideTrigger && "hidden",
 							)}
-							disabled={disabled}
+							disabled={!daemonReady || disabled}
 							onClick={choosePath}
 							type="button"
 						>
@@ -881,7 +908,7 @@ function CreateProjectButton({
 	);
 }
 
-function CreateProjectListItem() {
+function CreateProjectListItem({ daemonReady }: { daemonReady: boolean }) {
 	const requestCreateProject = useUiStore((state) => state.requestCreateProject);
 	return (
 		<SidebarMenuItem className="mb-px group-data-[collapsible=icon]:mb-0">
@@ -890,6 +917,7 @@ function CreateProjectListItem() {
 					<button
 						aria-label="New project"
 						className="grid h-control-board w-full place-items-center rounded-sm text-passive transition-colors hover:bg-interactive-hover hover:text-muted-foreground"
+						disabled={!daemonReady}
 						onClick={() => requestCreateProject()}
 						type="button"
 					>

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -141,8 +141,9 @@ export function Sidebar({
 	const updateStatus = useUpdateStatus();
 	// Daemon status for the smoke suite's sr-only mirror in the footer. Null when
 	// rendered outside the shell (unit tests) — the mirror simply doesn't render.
-	const daemonStatus = useShellMaybe()?.daemonStatus ?? null;
-	const daemonReady = daemonStatus ? daemonStatus.state === "ready" : true;
+	const shell = useShellMaybe();
+	const daemonStatus = shell?.daemonStatus ?? null;
+	const daemonReady = shell ? shell.workspaceLive : true;
 	const commandPaletteEnabled = useCommandPaletteEnabled();
 	const setCommandPaletteOpen = useUiStore((s) => s.setCommandPaletteOpen);
 
@@ -880,6 +881,7 @@ function CreateProjectButton({
 	const createProjectNonce = useUiStore((state) => state.createProjectNonce);
 	return (
 		<CreateProjectFlow
+			disabled={!daemonReady}
 			mode="choose"
 			onCreateProject={onCreateProject}
 			onInitializeProject={onInitializeProject}

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
@@ -3,10 +3,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
-const { captureRendererEventMock, getMock, hasTrustedApiBaseUrlMock } = vi.hoisted(() => ({
+const { captureRendererEventMock, getMock, hasTrustedApiBaseUrlMock, workspaceQueriesEnabledMock } = vi.hoisted(() => ({
 	captureRendererEventMock: vi.fn().mockResolvedValue(undefined),
 	getMock: vi.fn(),
 	hasTrustedApiBaseUrlMock: vi.fn(() => true),
+	workspaceQueriesEnabledMock: vi.fn(() => true),
 }));
 
 vi.mock("../lib/api-client", () => ({
@@ -15,6 +16,7 @@ vi.mock("../lib/api-client", () => ({
 }));
 
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent: captureRendererEventMock }));
+vi.mock("../lib/workspace-query-readiness", () => ({ workspaceQueriesEnabled: workspaceQueriesEnabledMock }));
 
 import { useWorkspaceQuery } from "./useWorkspaceQuery";
 
@@ -39,16 +41,44 @@ beforeEach(() => {
 	captureRendererEventMock.mockClear();
 	getMock.mockReset();
 	hasTrustedApiBaseUrlMock.mockReset().mockReturnValue(true);
+	workspaceQueriesEnabledMock.mockReset().mockReturnValue(true);
 });
 
 describe("useWorkspaceQuery", () => {
-	it("rejects workspace reads while the daemon base URL is untrusted", async () => {
+	it("keeps a cached workspace list while the daemon base URL is untrusted", async () => {
 		hasTrustedApiBaseUrlMock.mockReturnValue(false);
+		workspaceQueriesEnabledMock.mockReturnValue(false);
+		const queryClient = new QueryClient();
+		const cached = [
+			{
+				id: "cached-project",
+				name: "Cached project",
+				path: "/cached",
+				sessions: [],
+			},
+		];
+		queryClient.setQueryData(["workspaces"], cached);
+
+		const { result } = renderHook(() => useWorkspaceQuery(), {
+			wrapper: ({ children }: { children: ReactNode }) => (
+				<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+			),
+		});
+
+		expect(result.current.isSuccess).toBe(true);
+		expect(result.current.data).toEqual(cached);
+		expect(getMock).not.toHaveBeenCalled();
+	});
+
+	it("does not create a fake empty result while the daemon base URL is untrusted", () => {
+		hasTrustedApiBaseUrlMock.mockReturnValue(false);
+		workspaceQueriesEnabledMock.mockReturnValue(false);
 
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 
-		await waitFor(() => expect(result.current.isError).toBe(true));
-		expect(result.current.error).toEqual(new Error("AO daemon API is not ready"));
+		expect(result.current.status).toBe("pending");
+		expect(result.current.fetchStatus).toBe("idle");
+		expect(result.current.data).toBeUndefined();
 		expect(getMock).not.toHaveBeenCalled();
 	});
 

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -4,6 +4,7 @@ import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { mockWorkspaces } from "../lib/mock-data";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { captureRendererEvent } from "../lib/telemetry";
+import { workspaceQueriesEnabled } from "../lib/workspace-query-readiness";
 import {
 	type PRState,
 	type PullRequestFacts,
@@ -116,5 +117,8 @@ export const workspaceQueryOptions = {
 };
 
 export function useWorkspaceQuery() {
-	return useQuery(workspaceQueryOptions);
+	return useQuery({
+		...workspaceQueryOptions,
+		enabled: workspaceQueriesEnabled(),
+	});
 }

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -63,6 +63,17 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 
 	if (projectsError || sessionsError) throw projectsError ?? sessionsError;
 
+	const sessions = sessionsData?.sessions ?? [];
+	const sessionsByProject = new Map<string, typeof sessions>();
+	for (const session of sessions) {
+		const projectSessions = sessionsByProject.get(session.projectId);
+		if (projectSessions) {
+			projectSessions.push(session);
+		} else {
+			sessionsByProject.set(session.projectId, [session]);
+		}
+	}
+
 	return (projectsData?.projects ?? []).map((project) => {
 		const kind = toProjectKind(project.kind);
 		return {
@@ -71,38 +82,36 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 			kind,
 			path: project.path,
 			orchestratorAgent: project.orchestratorAgent ? toAgentProvider(project.orchestratorAgent) : undefined,
-			sessions: (sessionsData?.sessions ?? [])
-				.filter((session) => session.projectId === project.id)
-				.map((session) => {
-					const status = toSessionStatus(session.status, session.isTerminated);
-					const scmStatus = session.scmStatus ? toSessionStatus(session.scmStatus) : undefined;
-					const activity = toSessionActivity(session.activity);
-					if (status === "unknown") reportUnknownSessionField("status", session.status);
-					if (!activity || activity.state === "unknown") {
-						reportUnknownSessionField("activity", session.activity?.state);
-					}
-					return {
-						id: session.id,
-						terminalHandleId: session.terminalHandleId,
-						workspaceId: project.id,
-						workspaceName: project.name,
-						title: session.displayName ?? session.issueId ?? session.id,
-						issueId: session.issueId,
-						provider: toAgentProvider(session.harness),
-						kind: session.kind === "orchestrator" ? "orchestrator" : session.kind === "worker" ? "worker" : undefined,
-						branch: session.branch || undefined,
-						status,
-						scmStatus,
-						isTerminated: session.isTerminated,
-						terminateOnPrMerge: session.terminateOnPrMerge ?? false,
-						createdAt: session.createdAt,
-						updatedAt: session.updatedAt,
-						activity,
-						previewUrl: session.previewUrl,
-						previewRevision: session.previewRevision,
-						prs: (session.prs ?? []).map(toPullRequestFacts),
-					};
-				}),
+			sessions: (sessionsByProject.get(project.id) ?? []).map((session) => {
+				const status = toSessionStatus(session.status, session.isTerminated);
+				const scmStatus = session.scmStatus ? toSessionStatus(session.scmStatus) : undefined;
+				const activity = toSessionActivity(session.activity);
+				if (status === "unknown") reportUnknownSessionField("status", session.status);
+				if (!activity || activity.state === "unknown") {
+					reportUnknownSessionField("activity", session.activity?.state);
+				}
+				return {
+					id: session.id,
+					terminalHandleId: session.terminalHandleId,
+					workspaceId: project.id,
+					workspaceName: project.name,
+					title: session.displayName ?? session.issueId ?? session.id,
+					issueId: session.issueId,
+					provider: toAgentProvider(session.harness),
+					kind: session.kind === "orchestrator" ? "orchestrator" : session.kind === "worker" ? "worker" : undefined,
+					branch: session.branch || undefined,
+					status,
+					scmStatus,
+					isTerminated: session.isTerminated,
+					terminateOnPrMerge: session.terminateOnPrMerge ?? false,
+					createdAt: session.createdAt,
+					updatedAt: session.updatedAt,
+					activity,
+					previewUrl: session.previewUrl,
+					previewRevision: session.previewRevision,
+					prs: (session.prs ?? []).map(toPullRequestFacts),
+				};
+			}),
 		};
 	});
 }

--- a/frontend/src/renderer/lib/command-palette.ts
+++ b/frontend/src/renderer/lib/command-palette.ts
@@ -42,6 +42,7 @@ export type CommandPaletteContext = {
 	currentProjectId?: string;
 	currentSessionId?: string;
 	restartingProjectIds?: ReadonlySet<string>;
+	mutationsEnabled?: boolean;
 };
 
 export const commandGroupOrder: CommandGroupId[] = ["current", "attention", "projects", "sessions", "prs", "global"];
@@ -93,7 +94,7 @@ function findSession(workspaces: WorkspaceSummary[], sessionId: string): Workspa
 }
 
 export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
-	const { workspaces, currentProjectId, currentSessionId, restartingProjectIds } = ctx;
+	const { workspaces, currentProjectId, currentSessionId, restartingProjectIds, mutationsEnabled = true } = ctx;
 	const items: CommandItem[] = [];
 
 	const currentProject = currentProjectId
@@ -108,9 +109,11 @@ export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
 		title: "New task",
 		subtitle: currentProject?.name,
 		keywords: ["worker", "chat", "start"],
-		disabled: !currentProject || isProjectRestarting,
+		disabled: !mutationsEnabled || !currentProject || isProjectRestarting,
 		disabledReason: !currentProject
 			? "No current project"
+			: !mutationsEnabled
+				? "AO is still loading"
 			: isProjectRestarting
 				? "Orchestrator restarting"
 				: undefined,
@@ -124,8 +127,12 @@ export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
 			title: "Open orchestrator",
 			subtitle: currentProject.name,
 			keywords: ["orchestrator", "spawn", currentProject.name],
-			disabled: isProjectRestarting,
-			disabledReason: isProjectRestarting ? "Orchestrator restarting" : undefined,
+			disabled: !mutationsEnabled || isProjectRestarting,
+			disabledReason: !mutationsEnabled
+				? "AO is still loading"
+				: isProjectRestarting
+					? "Orchestrator restarting"
+					: undefined,
 			action: { kind: "open-orchestrator", projectId: currentProject.id },
 		});
 		items.push({
@@ -222,6 +229,8 @@ export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
 		group: "global",
 		title: "New project",
 		keywords: ["add", "import", "repo", "workspace"],
+		disabled: !mutationsEnabled,
+		disabledReason: mutationsEnabled ? undefined : "AO is still loading",
 		action: { kind: "open-new-project" },
 	});
 	items.push({

--- a/frontend/src/renderer/lib/daemon-status.ts
+++ b/frontend/src/renderer/lib/daemon-status.ts
@@ -1,10 +1,12 @@
 import { aoBridge } from "./bridge";
 import { setApiBaseUrl, setApiDaemonStatus } from "./api-client";
+import { setWorkspaceQueriesEnabled } from "./workspace-query-readiness";
 
 export type DaemonStatus = Awaited<ReturnType<typeof aoBridge.daemon.getStatus>>;
 
 export function applyDaemonStatus(nextStatus: DaemonStatus): void {
 	setApiDaemonStatus(nextStatus);
+	setWorkspaceQueriesEnabled(nextStatus.state === "ready" && Boolean(nextStatus.port));
 	if (nextStatus.state === "ready" && nextStatus.port) {
 		setApiBaseUrl(`http://127.0.0.1:${nextStatus.port}`);
 	} else {

--- a/frontend/src/renderer/lib/shell-context.ts
+++ b/frontend/src/renderer/lib/shell-context.ts
@@ -8,6 +8,8 @@ import type { useDaemonStatus } from "../hooks/useDaemonStatus";
 export type ShellContextValue = {
 	daemonStatus: ReturnType<typeof useDaemonStatus>;
 	workspaceStartupState: "loading" | "ready" | "error";
+	/** True only after the current daemon instance returns a workspace snapshot. */
+	workspaceLive: boolean;
 	createProject: (input: {
 		path: string;
 		workerAgent: string;

--- a/frontend/src/renderer/lib/workspace-cache.test.ts
+++ b/frontend/src/renderer/lib/workspace-cache.test.ts
@@ -1,0 +1,125 @@
+import { QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it } from "vitest";
+import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import type { WorkspaceSummary } from "../types/workspace";
+import {
+	WORKSPACE_SNAPSHOT_STORAGE_KEY,
+	readWorkspaceSnapshot,
+	restoreWorkspaceSnapshot,
+	startWorkspaceSnapshotPersistence,
+	writeWorkspaceSnapshot,
+} from "./workspace-cache";
+
+function memoryStorage() {
+	const values = new Map<string, string>();
+	return {
+		getItem: (key: string) => values.get(key) ?? null,
+		setItem: (key: string, value: string) => {
+			values.set(key, value);
+		},
+		values,
+	};
+}
+
+const workspaces: WorkspaceSummary[] = [
+	{
+		id: "project-1",
+		name: "AO",
+		path: "/repo/ao",
+		sessions: [
+			{
+				id: "session-1",
+				workspaceId: "project-1",
+				workspaceName: "AO",
+				title: "Keep startup state",
+				provider: "codex",
+				status: "working",
+				updatedAt: "2026-07-28T08:00:00Z",
+				prs: [],
+			},
+		],
+	},
+];
+
+describe("workspace snapshot cache", () => {
+	let storage: ReturnType<typeof memoryStorage>;
+
+	beforeEach(() => {
+		storage = memoryStorage();
+	});
+
+	it("round-trips a versioned workspace snapshot", () => {
+		writeWorkspaceSnapshot(workspaces, storage, 1234);
+
+		expect(readWorkspaceSnapshot(storage)).toEqual({
+			version: 1,
+			savedAt: 1234,
+			workspaces,
+		});
+	});
+
+	it("ignores corrupt, incompatible, and structurally invalid snapshots", () => {
+		storage.setItem(WORKSPACE_SNAPSHOT_STORAGE_KEY, "{bad json");
+		expect(readWorkspaceSnapshot(storage)).toBeNull();
+
+		storage.setItem(
+			WORKSPACE_SNAPSHOT_STORAGE_KEY,
+			JSON.stringify({ version: 2, savedAt: 1234, workspaces }),
+		);
+		expect(readWorkspaceSnapshot(storage)).toBeNull();
+
+		storage.setItem(
+			WORKSPACE_SNAPSHOT_STORAGE_KEY,
+			JSON.stringify({ version: 1, savedAt: 1234, workspaces: [{ id: "broken" }] }),
+		);
+		expect(readWorkspaceSnapshot(storage)).toBeNull();
+	});
+
+	it("restores cached workspaces with their original save time", () => {
+		writeWorkspaceSnapshot(workspaces, storage, 1234);
+		const queryClient = new QueryClient();
+
+		expect(restoreWorkspaceSnapshot(queryClient, storage)).toEqual(workspaces);
+		expect(queryClient.getQueryData(workspaceQueryKey)).toEqual(workspaces);
+		expect(queryClient.getQueryState(workspaceQueryKey)?.dataUpdatedAt).toBe(1234);
+	});
+
+	it("persists query changes, including a real empty daemon response", () => {
+		const queryClient = new QueryClient();
+		const stop = startWorkspaceSnapshotPersistence(queryClient, storage);
+
+		queryClient.setQueryData(workspaceQueryKey, workspaces);
+		expect(readWorkspaceSnapshot(storage)?.workspaces).toEqual(workspaces);
+
+		queryClient.setQueryData(workspaceQueryKey, []);
+		expect(readWorkspaceSnapshot(storage)?.workspaces).toEqual([]);
+
+		stop();
+	});
+
+	it("flushes the current query state when the renderer closes", () => {
+		const queryClient = new QueryClient();
+		const stop = startWorkspaceSnapshotPersistence(queryClient, storage);
+		queryClient.setQueryData(workspaceQueryKey, workspaces);
+		storage.values.delete(WORKSPACE_SNAPSHOT_STORAGE_KEY);
+
+		window.dispatchEvent(new Event("beforeunload"));
+
+		expect(readWorkspaceSnapshot(storage)?.workspaces).toEqual(workspaces);
+		stop();
+	});
+
+	it("never throws when browser storage is unavailable", () => {
+		const brokenStorage = {
+			getItem: () => {
+				throw new Error("blocked");
+			},
+			setItem: () => {
+				throw new Error("quota");
+			},
+		};
+
+		expect(readWorkspaceSnapshot(brokenStorage)).toBeNull();
+		expect(() => writeWorkspaceSnapshot(workspaces, brokenStorage)).not.toThrow();
+	});
+});

--- a/frontend/src/renderer/lib/workspace-cache.test.ts
+++ b/frontend/src/renderer/lib/workspace-cache.test.ts
@@ -1,5 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import type { WorkspaceSummary } from "../types/workspace";
 import {
@@ -46,6 +46,10 @@ describe("workspace snapshot cache", () => {
 
 	beforeEach(() => {
 		storage = memoryStorage();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it("round-trips a versioned workspace snapshot", () => {
@@ -122,15 +126,34 @@ describe("workspace snapshot cache", () => {
 	});
 
 	it("persists query changes, including a real empty daemon response", () => {
+		vi.useFakeTimers();
 		const queryClient = new QueryClient();
 		const stop = startWorkspaceSnapshotPersistence(queryClient, storage);
 
 		queryClient.setQueryData(workspaceQueryKey, workspaces);
+		expect(readWorkspaceSnapshot(storage)).toBeNull();
+		vi.runOnlyPendingTimers();
 		expect(readWorkspaceSnapshot(storage)?.workspaces).toEqual(workspaces);
 
 		queryClient.setQueryData(workspaceQueryKey, []);
+		vi.runOnlyPendingTimers();
 		expect(readWorkspaceSnapshot(storage)?.workspaces).toEqual([]);
 
+		stop();
+	});
+
+	it("persists the rolled-back state instead of a pending optimistic update", () => {
+		vi.useFakeTimers();
+		const queryClient = new QueryClient();
+		queryClient.setQueryData(workspaceQueryKey, workspaces);
+		const stop = startWorkspaceSnapshotPersistence(queryClient, storage);
+		const optimistic = [{ ...workspaces[0]!, name: "Optimistic name" }];
+
+		queryClient.setQueryData(workspaceQueryKey, optimistic);
+		queryClient.setQueryData(workspaceQueryKey, workspaces);
+		vi.runOnlyPendingTimers();
+
+		expect(readWorkspaceSnapshot(storage)?.workspaces).toEqual(workspaces);
 		stop();
 	});
 

--- a/frontend/src/renderer/lib/workspace-cache.test.ts
+++ b/frontend/src/renderer/lib/workspace-cache.test.ts
@@ -75,6 +75,43 @@ describe("workspace snapshot cache", () => {
 		expect(readWorkspaceSnapshot(storage)).toBeNull();
 	});
 
+	it("rejects malformed nested session state", () => {
+		for (const invalidSession of [
+			{ ...workspaces[0]!.sessions[0]!, prs: [null] },
+			{ ...workspaces[0]!.sessions[0]!, provider: "not-an-agent" },
+			{ ...workspaces[0]!.sessions[0]!, status: "running" },
+			{
+				...workspaces[0]!.sessions[0]!,
+				activity: { state: "working", lastActivityAt: "2026-07-28T08:00:00Z" },
+			},
+			{
+				...workspaces[0]!.sessions[0]!,
+				prs: [
+					{
+						url: "https://github.com/acme/ao/pull/1",
+						number: 1,
+						state: "unknown",
+						ci: "pending",
+						review: "none",
+						mergeability: "unknown",
+						reviewComments: false,
+						updatedAt: "2026-07-28T08:00:00Z",
+					},
+				],
+			},
+		]) {
+			storage.setItem(
+				WORKSPACE_SNAPSHOT_STORAGE_KEY,
+				JSON.stringify({
+					version: 1,
+					savedAt: 1234,
+					workspaces: [{ ...workspaces[0], sessions: [invalidSession] }],
+				}),
+			);
+			expect(readWorkspaceSnapshot(storage)).toBeNull();
+		}
+	});
+
 	it("restores cached workspaces with their original save time", () => {
 		writeWorkspaceSnapshot(workspaces, storage, 1234);
 		const queryClient = new QueryClient();

--- a/frontend/src/renderer/lib/workspace-cache.ts
+++ b/frontend/src/renderer/lib/workspace-cache.ts
@@ -1,0 +1,148 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
+
+const WORKSPACE_SNAPSHOT_VERSION = 1;
+export const WORKSPACE_SNAPSHOT_STORAGE_KEY = "ao.workspace-snapshot";
+
+type WorkspaceSnapshot = {
+	version: typeof WORKSPACE_SNAPSHOT_VERSION;
+	savedAt: number;
+	workspaces: WorkspaceSummary[];
+};
+
+type ReadableStorage = Pick<Storage, "getItem">;
+type WritableStorage = Pick<Storage, "setItem">;
+
+function browserStorage(): Storage | null {
+	if (typeof window === "undefined") return null;
+	try {
+		return window.localStorage;
+	} catch {
+		return null;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isWorkspaceSession(value: unknown): value is WorkspaceSession {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.id === "string" &&
+		typeof value.workspaceId === "string" &&
+		typeof value.workspaceName === "string" &&
+		typeof value.title === "string" &&
+		typeof value.provider === "string" &&
+		typeof value.status === "string" &&
+		typeof value.updatedAt === "string" &&
+		Array.isArray(value.prs)
+	);
+}
+
+function isWorkspaceSummary(value: unknown): value is WorkspaceSummary {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.id === "string" &&
+		typeof value.name === "string" &&
+		typeof value.path === "string" &&
+		Array.isArray(value.sessions) &&
+		value.sessions.every(isWorkspaceSession)
+	);
+}
+
+function isWorkspaceSnapshot(value: unknown): value is WorkspaceSnapshot {
+	if (!isRecord(value)) return false;
+	return (
+		value.version === WORKSPACE_SNAPSHOT_VERSION &&
+		typeof value.savedAt === "number" &&
+		Number.isFinite(value.savedAt) &&
+		Array.isArray(value.workspaces) &&
+		value.workspaces.every(isWorkspaceSummary)
+	);
+}
+
+export function readWorkspaceSnapshot(storage: ReadableStorage | null = browserStorage()): WorkspaceSnapshot | null {
+	if (!storage) return null;
+	try {
+		const raw = storage.getItem(WORKSPACE_SNAPSHOT_STORAGE_KEY);
+		if (!raw) return null;
+		const snapshot: unknown = JSON.parse(raw);
+		return isWorkspaceSnapshot(snapshot) ? snapshot : null;
+	} catch {
+		return null;
+	}
+}
+
+export function writeWorkspaceSnapshot(
+	workspaces: WorkspaceSummary[],
+	storage: WritableStorage | null = browserStorage(),
+	now = Date.now(),
+): void {
+	if (!storage) return;
+	try {
+		const snapshot: WorkspaceSnapshot = {
+			version: WORKSPACE_SNAPSHOT_VERSION,
+			savedAt: now,
+			workspaces,
+		};
+		storage.setItem(WORKSPACE_SNAPSHOT_STORAGE_KEY, JSON.stringify(snapshot));
+	} catch {
+		// A UI cache must never prevent AO from starting or closing.
+	}
+}
+
+export function restoreWorkspaceSnapshot(
+	queryClient: QueryClient,
+	storage: ReadableStorage | null = browserStorage(),
+): WorkspaceSummary[] | undefined {
+	const snapshot = readWorkspaceSnapshot(storage);
+	if (!snapshot) return undefined;
+	queryClient.setQueryData(workspaceQueryKey, snapshot.workspaces, { updatedAt: snapshot.savedAt });
+	return snapshot.workspaces;
+}
+
+function isWorkspaceQuery(queryKey: readonly unknown[]): boolean {
+	return queryKey.length === workspaceQueryKey.length && queryKey.every((part, index) => part === workspaceQueryKey[index]);
+}
+
+export function startWorkspaceSnapshotPersistence(
+	queryClient: QueryClient,
+	storage: WritableStorage | null = browserStorage(),
+): () => void {
+	let lastSavedData = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
+
+	const persistCurrent = () => {
+		const workspaces = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
+		if (workspaces === undefined) return;
+		writeWorkspaceSnapshot(workspaces, storage);
+		lastSavedData = workspaces;
+	};
+
+	const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+		if (!isWorkspaceQuery(event.query.queryKey)) return;
+		const workspaces = event.query.state.data;
+		if (!Array.isArray(workspaces) || workspaces === lastSavedData) return;
+		writeWorkspaceSnapshot(workspaces as WorkspaceSummary[], storage);
+		lastSavedData = workspaces as WorkspaceSummary[];
+	});
+
+	if (typeof window !== "undefined") {
+		window.addEventListener("beforeunload", persistCurrent);
+		window.addEventListener("pagehide", persistCurrent);
+	}
+
+	return () => {
+		unsubscribe();
+		if (typeof window !== "undefined") {
+			window.removeEventListener("beforeunload", persistCurrent);
+			window.removeEventListener("pagehide", persistCurrent);
+		}
+	};
+}
+
+export function initializeWorkspaceSnapshotCache(queryClient: QueryClient): () => void {
+	restoreWorkspaceSnapshot(queryClient);
+	return startWorkspaceSnapshotPersistence(queryClient);
+}

--- a/frontend/src/renderer/lib/workspace-cache.ts
+++ b/frontend/src/renderer/lib/workspace-cache.ts
@@ -27,6 +27,94 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+const agentProviders = new Set([
+	"codex",
+	"claude-code",
+	"opencode",
+	"aider",
+	"grok",
+	"droid",
+	"amp",
+	"agy",
+	"crush",
+	"cursor",
+	"qwen",
+	"copilot",
+	"goose",
+	"auggie",
+	"continue",
+	"devin",
+	"cline",
+	"kimi",
+	"kiro",
+	"kilocode",
+	"vibe",
+	"pi",
+	"autohand",
+	"fake",
+]);
+const sessionStatuses = new Set([
+	"working",
+	"pr_open",
+	"draft",
+	"ci_failed",
+	"review_pending",
+	"changes_requested",
+	"approved",
+	"mergeable",
+	"merged",
+	"needs_input",
+	"exited",
+	"no_signal",
+	"idle",
+	"terminated",
+	"unknown",
+]);
+const activityStates = new Set(["active", "idle", "waiting_input", "blocked", "exited", "unknown"]);
+const prStates = new Set(["open", "draft", "merged", "closed"]);
+
+function isOptional(value: unknown, validate: (candidate: unknown) => boolean): boolean {
+	return value === undefined || validate(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function isPullRequest(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.url === "string" &&
+		isFiniteNumber(value.number) &&
+		typeof value.state === "string" &&
+		prStates.has(value.state) &&
+		typeof value.ci === "string" &&
+		typeof value.review === "string" &&
+		typeof value.mergeability === "string" &&
+		typeof value.reviewComments === "boolean" &&
+		typeof value.updatedAt === "string"
+	);
+}
+
+function isSessionActivity(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		typeof value.state === "string" &&
+		activityStates.has(value.state) &&
+		typeof value.lastActivityAt === "string"
+	);
+}
+
+function isChangedFile(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		typeof value.path === "string" &&
+		isFiniteNumber(value.additions) &&
+		isFiniteNumber(value.deletions) &&
+		isOptional(value.staged, (candidate) => typeof candidate === "boolean")
+	);
+}
+
 function isWorkspaceSession(value: unknown): value is WorkspaceSession {
 	if (!isRecord(value)) return false;
 	return (
@@ -35,9 +123,40 @@ function isWorkspaceSession(value: unknown): value is WorkspaceSession {
 		typeof value.workspaceName === "string" &&
 		typeof value.title === "string" &&
 		typeof value.provider === "string" &&
+		agentProviders.has(value.provider) &&
 		typeof value.status === "string" &&
+		sessionStatuses.has(value.status) &&
 		typeof value.updatedAt === "string" &&
-		Array.isArray(value.prs)
+		isOptional(value.terminalHandleId, (candidate) => typeof candidate === "string") &&
+		isOptional(value.issueId, (candidate) => typeof candidate === "string") &&
+		isOptional(value.kind, (candidate) => candidate === "worker" || candidate === "orchestrator") &&
+		isOptional(value.branch, (candidate) => typeof candidate === "string") &&
+		isOptional(
+			value.scmStatus,
+			(candidate) => typeof candidate === "string" && sessionStatuses.has(candidate),
+		) &&
+		isOptional(value.isTerminated, (candidate) => typeof candidate === "boolean") &&
+		isOptional(value.terminateOnPrMerge, (candidate) => typeof candidate === "boolean") &&
+		isOptional(value.createdAt, (candidate) => typeof candidate === "string") &&
+		isOptional(value.activity, isSessionActivity) &&
+		isOptional(value.previewUrl, (candidate) => typeof candidate === "string") &&
+		isOptional(value.previewRevision, isFiniteNumber) &&
+		isOptional(
+			value.changedFiles,
+			(candidate) => Array.isArray(candidate) && candidate.every(isChangedFile),
+		) &&
+		isOptional(value.commitMessage, (candidate) => typeof candidate === "string") &&
+		Array.isArray(value.prs) &&
+		value.prs.every(isPullRequest)
+	);
+}
+
+function isWorkspaceRepo(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		typeof value.name === "string" &&
+		typeof value.relativePath === "string" &&
+		typeof value.repo === "string"
 	);
 }
 
@@ -47,6 +166,27 @@ function isWorkspaceSummary(value: unknown): value is WorkspaceSummary {
 		typeof value.id === "string" &&
 		typeof value.name === "string" &&
 		typeof value.path === "string" &&
+		isOptional(
+			value.kind,
+			(candidate) => candidate === "single_repo" || candidate === "workspace" || candidate === "scratch",
+		) &&
+		isOptional(
+			value.workspaceRepos,
+			(candidate) => Array.isArray(candidate) && candidate.every(isWorkspaceRepo),
+		) &&
+		isOptional(value.type, (candidate) => candidate === "main" || candidate === "worktree") &&
+		isOptional(
+			value.orchestratorAgent,
+			(candidate) => typeof candidate === "string" && agentProviders.has(candidate),
+		) &&
+		isOptional(value.accentColor, (candidate) => typeof candidate === "string") &&
+		isOptional(
+			value.diff,
+			(candidate) =>
+				isRecord(candidate) &&
+				isFiniteNumber(candidate.additions) &&
+				isFiniteNumber(candidate.deletions),
+		) &&
 		Array.isArray(value.sessions) &&
 		value.sessions.every(isWorkspaceSession)
 	);

--- a/frontend/src/renderer/lib/workspace-cache.ts
+++ b/frontend/src/renderer/lib/workspace-cache.ts
@@ -13,6 +13,7 @@ type WorkspaceSnapshot = {
 
 type ReadableStorage = Pick<Storage, "getItem">;
 type WritableStorage = Pick<Storage, "setItem">;
+type IdleCallbackWindow = Window & Partial<Pick<Window, "requestIdleCallback" | "cancelIdleCallback">>;
 
 function browserStorage(): Storage | null {
 	if (typeof window === "undefined") return null;
@@ -252,20 +253,49 @@ export function startWorkspaceSnapshotPersistence(
 	storage: WritableStorage | null = browserStorage(),
 ): () => void {
 	let lastSavedData = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
+	let pendingData: WorkspaceSummary[] | undefined;
+	let cancelScheduledWrite: (() => void) | undefined;
 
-	const persistCurrent = () => {
-		const workspaces = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
+	const discardPending = () => {
+		cancelScheduledWrite?.();
+		cancelScheduledWrite = undefined;
+		pendingData = undefined;
+	};
+
+	const flush = (workspaces = pendingData ?? queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey)) => {
+		discardPending();
 		if (workspaces === undefined) return;
 		writeWorkspaceSnapshot(workspaces, storage);
 		lastSavedData = workspaces;
 	};
 
+	const schedule = (workspaces: WorkspaceSummary[]) => {
+		pendingData = workspaces;
+		if (cancelScheduledWrite) return;
+
+		const idleWindow = typeof window === "undefined" ? undefined : (window as IdleCallbackWindow);
+		if (idleWindow?.requestIdleCallback && idleWindow.cancelIdleCallback) {
+			const handle = idleWindow.requestIdleCallback(() => flush(), { timeout: 500 });
+			cancelScheduledWrite = () => idleWindow.cancelIdleCallback?.(handle);
+			return;
+		}
+
+		const handle = setTimeout(() => flush(), 0);
+		cancelScheduledWrite = () => clearTimeout(handle);
+	};
+
+	const persistCurrent = () => flush();
+
 	const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
 		if (!isWorkspaceQuery(event.query.queryKey)) return;
 		const workspaces = event.query.state.data;
-		if (!Array.isArray(workspaces) || workspaces === lastSavedData) return;
-		writeWorkspaceSnapshot(workspaces as WorkspaceSummary[], storage);
-		lastSavedData = workspaces as WorkspaceSummary[];
+		if (!Array.isArray(workspaces)) return;
+		if (workspaces === lastSavedData) {
+			discardPending();
+			return;
+		}
+		if (workspaces === pendingData) return;
+		schedule(workspaces as WorkspaceSummary[]);
 	});
 
 	if (typeof window !== "undefined") {
@@ -275,6 +305,7 @@ export function startWorkspaceSnapshotPersistence(
 
 	return () => {
 		unsubscribe();
+		flush();
 		if (typeof window !== "undefined") {
 			window.removeEventListener("beforeunload", persistCurrent);
 			window.removeEventListener("pagehide", persistCurrent);

--- a/frontend/src/renderer/lib/workspace-query-readiness.ts
+++ b/frontend/src/renderer/lib/workspace-query-readiness.ts
@@ -1,0 +1,13 @@
+// Workspace queries must not run before Electron supplies a trusted daemon
+// port, otherwise a startup request can replace the restored snapshot. Browser
+// previews and unit tests have no Electron lifecycle, so they remain enabled.
+const bypassDaemonReadiness = import.meta.env.MODE === "test" || import.meta.env.VITE_NO_ELECTRON === "1";
+let daemonReady = false;
+
+export function workspaceQueriesEnabled(): boolean {
+	return bypassDaemonReadiness || daemonReady;
+}
+
+export function setWorkspaceQueriesEnabled(nextEnabled: boolean): void {
+	daemonReady = nextEnabled;
+}

--- a/frontend/src/renderer/main.tsx
+++ b/frontend/src/renderer/main.tsx
@@ -10,7 +10,9 @@ import { createAppRouter } from "./router";
 import { TelemetryBoundary } from "./components/TelemetryBoundary";
 import { initTelemetry } from "./lib/telemetry";
 import { startDaemonFailureTelemetry } from "./lib/daemon-telemetry";
+import { initializeWorkspaceSnapshotCache } from "./lib/workspace-cache";
 
+initializeWorkspaceSnapshotCache(queryClient);
 const router = createAppRouter(queryClient);
 void initTelemetry();
 startDaemonFailureTelemetry();

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -47,11 +47,14 @@ export const Route = createFileRoute("/_shell")({
 	// children); pairs with the router's defaultPreload: "intent" so a hovered
 	// nav target is warm before the click.
 	loader: async ({ context }) => {
-		const status = await refreshDaemonStatus().catch(() => undefined);
 		const cached = context.queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
 		// A restored snapshot should paint immediately. The shell invalidates it
 		// in the background as soon as the daemon reports a trusted ready port.
-		if (cached !== undefined) return cached;
+		if (cached !== undefined) {
+			void refreshDaemonStatus().catch(() => undefined);
+			return cached;
+		}
+		const status = await refreshDaemonStatus().catch(() => undefined);
 		if (usesPreviewWorkspaceData || (status?.state === "ready" && status.port && hasTrustedApiBaseUrl())) {
 			return context.queryClient.ensureQueryData(workspaceQueryOptions);
 		}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -47,9 +47,17 @@ export const Route = createFileRoute("/_shell")({
 	// children); pairs with the router's defaultPreload: "intent" so a hovered
 	// nav target is warm before the click.
 	loader: async ({ context }) => {
-		await refreshDaemonStatus().catch(() => undefined);
-		if (!usesPreviewWorkspaceData && !hasTrustedApiBaseUrl()) return;
-		return context.queryClient.ensureQueryData(workspaceQueryOptions);
+		const status = await refreshDaemonStatus().catch(() => undefined);
+		const cached = context.queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
+		// A restored snapshot should paint immediately. The shell invalidates it
+		// in the background as soon as the daemon reports a trusted ready port.
+		if (cached !== undefined) return cached;
+		if (usesPreviewWorkspaceData || (status?.state === "ready" && status.port && hasTrustedApiBaseUrl())) {
+			return context.queryClient.ensureQueryData(workspaceQueryOptions);
+		}
+		// Do not populate the query cache with a fake empty response while the
+		// daemon is starting; that would overwrite the last useful snapshot.
+		return [];
 	},
 	component: ShellLayout,
 });

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -48,10 +48,9 @@ export const Route = createFileRoute("/_shell")({
 	// nav target is warm before the click.
 	loader: async ({ context }) => {
 		const cached = context.queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
-		// A restored snapshot should paint immediately. The shell invalidates it
-		// in the background as soon as the daemon reports a trusted ready port.
+		// A restored snapshot should paint immediately. The mounted daemon-status
+		// hook owns the refresh so a second, unversioned request cannot race it.
 		if (cached !== undefined) {
-			void refreshDaemonStatus().catch(() => undefined);
 			return cached;
 		}
 		const status = await refreshDaemonStatus().catch(() => undefined);
@@ -186,6 +185,7 @@ function ShellLayout() {
 	const replacementErrorProjectId = Object.keys(orchestratorReplacementErrors)[0] ?? null;
 	const isStartupLoading =
 		!usesPreviewWorkspaceData &&
+		workspaceQuery.data === undefined &&
 		!daemonStatus.code &&
 		(daemonStatus.state !== "ready" || workspaceStartupState === "loading");
 

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -100,6 +100,10 @@ function ShellLayout() {
 	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
 	const workspaceStartupBaselineRef = useRef(0);
 	const agentCatalogPortRef = useRef<number | undefined>(undefined);
+	const workspaceHydratedPortRef = useRef<number | undefined>(undefined);
+	const [workspaceLive, setWorkspaceLive] = useState(false);
+	const workspaceLiveRef = useRef(workspaceLive);
+	workspaceLiveRef.current = workspaceLive;
 	const { themePreference, resolvedTheme, isSidebarOpen, toggleSidebar } = useUiStore();
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
@@ -242,6 +246,7 @@ function ShellLayout() {
 			trackerIntake?: components["schemas"]["TrackerIntakeConfig"];
 			asWorkspace?: boolean;
 		}) => {
+			if (!workspaceLive) throw new Error("AO is still loading the current workspace state.");
 			void addRendererExceptionStep("Project add requested", {
 				source: "project-add",
 				operation: "project_add",
@@ -327,22 +332,27 @@ function ShellLayout() {
 				setOrchestratorStartupError(workspace.id, startupMessage);
 			}
 		},
-		[navigate, queryClient, setOrchestratorStartupError, updateWorkspaces],
+		[navigate, queryClient, setOrchestratorStartupError, updateWorkspaces, workspaceLive],
 	);
 
-	const initializeProjectRepository = useCallback(async (path: string) => {
-		const { error } = await apiClient.POST("/api/v1/projects/initialize", {
-			body: { path },
-		});
-		if (error) {
-			const failure = new Error(apiErrorMessage(error)) as Error & { code?: string };
-			failure.code = apiErrorCode(error);
-			throw failure;
-		}
-	}, []);
+	const initializeProjectRepository = useCallback(
+		async (path: string) => {
+			if (!workspaceLive) throw new Error("AO is still loading the current workspace state.");
+			const { error } = await apiClient.POST("/api/v1/projects/initialize", {
+				body: { path },
+			});
+			if (error) {
+				const failure = new Error(apiErrorMessage(error)) as Error & { code?: string };
+				failure.code = apiErrorCode(error);
+				throw failure;
+			}
+		},
+		[workspaceLive],
+	);
 
 	const removeProject = useCallback(
 		async (projectId: string) => {
+			if (!workspaceLive) throw new Error("AO is still loading the current workspace state.");
 			void addRendererExceptionStep("Project removal requested", {
 				source: "project-remove",
 				operation: "project_remove",
@@ -366,11 +376,12 @@ function ShellLayout() {
 			void captureRendererEvent("ao.renderer.project_removed", { project_id: projectId });
 			updateWorkspaces((current) => current.filter((item) => item.id !== projectId));
 		},
-		[updateWorkspaces],
+		[updateWorkspaces, workspaceLive],
 	);
 
 	const restartOrchestrator = useCallback(
 		async (projectId: string) => {
+			if (!workspaceLive) return;
 			await restartProjectOrchestrator({
 				projectId,
 				queryClient,
@@ -382,7 +393,7 @@ function ShellLayout() {
 				},
 			});
 		},
-		[navigate, queryClient, setOrchestratorReplacementError, setProjectRestarting],
+		[navigate, queryClient, setOrchestratorReplacementError, setProjectRestarting, workspaceLive],
 	);
 
 	useEffect(() => {
@@ -493,12 +504,54 @@ function ShellLayout() {
 	}, [cancelSidebarPeekClose, isSidebarOpen, isSidebarPeekOpen, scheduleSidebarPeekClose]);
 
 	useEffect(() => {
-		if (daemonStatus.state !== "ready" || !daemonStatus.port) return;
-		if (agentCatalogPortRef.current === daemonStatus.port) return;
+		if (daemonStatus.state !== "ready" || !daemonStatus.port) {
+			workspaceHydratedPortRef.current = undefined;
+			setWorkspaceLive(false);
+			return;
+		}
 
-		agentCatalogPortRef.current = daemonStatus.port;
-		void queryClient.invalidateQueries({ queryKey: agentsQueryKey });
-		void queryClient.fetchQuery({ ...agentsQueryOptions, queryFn: refreshAgents });
+		const port = daemonStatus.port;
+		if (agentCatalogPortRef.current !== port) {
+			agentCatalogPortRef.current = port;
+			void queryClient.invalidateQueries({ queryKey: agentsQueryKey });
+			void queryClient.fetchQuery({ ...agentsQueryOptions, queryFn: refreshAgents });
+		}
+		if (workspaceHydratedPortRef.current === port) return;
+
+		let cancelled = false;
+		let unsubscribe = () => {};
+		const initialUpdatedAt = queryClient.getQueryState(workspaceQueryKey)?.dataUpdatedAt ?? 0;
+		const markWorkspaceLive = () => {
+			if (cancelled) return;
+			workspaceHydratedPortRef.current = port;
+			setWorkspaceLive(true);
+			unsubscribe();
+		};
+		unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+			const isWorkspaceQuery =
+				event.query.queryKey.length === workspaceQueryKey.length &&
+				event.query.queryKey.every((part: unknown, index: number) => part === workspaceQueryKey[index]);
+			if (
+				isWorkspaceQuery &&
+				event.query.state.status === "success" &&
+				event.query.state.dataUpdatedAt > initialUpdatedAt
+			) {
+				markWorkspaceLive();
+			}
+		});
+		setWorkspaceLive(false);
+		void (async () => {
+			try {
+				await queryClient.fetchQuery({ ...workspaceQueryOptions, staleTime: 0 });
+				markWorkspaceLive();
+			} catch {
+				if (!cancelled) setWorkspaceLive(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+			unsubscribe();
+		};
 	}, [daemonStatus.port, daemonStatus.state, queryClient]);
 
 	// Follow OS appearance while the user keeps Theme on System — updates
@@ -538,6 +591,7 @@ function ShellLayout() {
 	useEffect(
 		() =>
 			aoBridge.app.onNewSessionShortcut(() => {
+				if (!workspaceLiveRef.current) return;
 				if (scopedProjectId) {
 					requestNewTask(scopedProjectId);
 				} else {
@@ -552,7 +606,13 @@ function ShellLayout() {
 	// New standalone terminal (Ctrl+Shift+`), also detected in the main process so it
 	// fires from inside a terminal pane. It raises the same store signal as the
 	// tab-strip + button so the two cannot drift apart.
-	useEffect(() => aoBridge.app.onNewShellTerminalShortcut(() => requestNewShellTerminal()), [requestNewShellTerminal]);
+	useEffect(
+		() =>
+			aoBridge.app.onNewShellTerminalShortcut(() => {
+				if (workspaceLiveRef.current) requestNewShellTerminal();
+			}),
+		[requestNewShellTerminal],
+	);
 
 	// The shell layout is the single consumer of that signal, because it is the
 	// only component mounted on EVERY route. Owning it here is what lets the
@@ -567,6 +627,7 @@ function ShellLayout() {
 	useEffect(() => {
 		if (handledShellNonceRef.current === newShellTerminalNonce) return;
 		handledShellNonceRef.current = newShellTerminalNonce;
+		if (!workspaceLive) return;
 		openShellTerminal.mutate(
 			{
 				projectId: tabOwnerSession?.workspaceId ?? scopedProjectId,
@@ -590,6 +651,7 @@ function ShellLayout() {
 		tabOwnerSessionId,
 		navigate,
 		setActiveShellTerminal,
+		workspaceLive,
 	]);
 
 	useEffect(() => aoBridge.app.onOpenSettingsShortcut(() => void navigate({ to: "/settings" })), [navigate]);
@@ -612,7 +674,15 @@ function ShellLayout() {
 	);
 
 	return (
-		<ShellProvider value={{ daemonStatus, workspaceStartupState, createProject, initializeProjectRepository }}>
+		<ShellProvider
+			value={{
+				daemonStatus,
+				workspaceLive,
+				workspaceStartupState,
+				createProject,
+				initializeProjectRepository,
+			}}
+		>
 			<NotificationRuntime />
 			<GlobalNewTaskDialog />
 			<KeyboardShortcutsDialog
@@ -668,7 +738,11 @@ function ShellLayout() {
 						onCreateProject={createProject}
 						onInitializeProject={initializeProjectRepository}
 						onRemoveProject={removeProject}
-						workspaceError={workspaceQuery.isError ? errorMessage(workspaceQuery.error) : undefined}
+						workspaceError={
+							workspaceQuery.isError && workspaceQuery.data === undefined
+								? errorMessage(workspaceQuery.error)
+								: undefined
+						}
 						workspaces={workspaces}
 					/>
 					<main className={cn("flex min-w-0 flex-1 flex-col overflow-x-hidden", !isSidebarOpen && "sidebar-hidden")}>

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -322,12 +322,12 @@ beforeEach(() => {
 });
 
 describe("shell loader", () => {
-	it("returns a restored snapshot without waiting for daemon status", async () => {
+	it("returns a restored snapshot without starting a competing daemon refresh", async () => {
 		shellMocks.queryClient.getQueryData.mockReturnValue(workspaces);
 		shellMocks.refreshDaemonStatus.mockReturnValue(new Promise(() => {}));
 
 		await expect(shellLoader({ context: { queryClient: shellMocks.queryClient } })).resolves.toBe(workspaces);
-		expect(shellMocks.refreshDaemonStatus).toHaveBeenCalledOnce();
+		expect(shellMocks.refreshDaemonStatus).not.toHaveBeenCalled();
 		expect(shellMocks.queryClient.ensureQueryData).not.toHaveBeenCalled();
 	});
 });
@@ -388,6 +388,7 @@ describe("shell workspace startup", () => {
 
 		const view = await renderShell();
 		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
+		expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "true");
 		expect(shellMocks.queryClient.fetchQuery).not.toHaveBeenCalled();
 
 		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -24,12 +24,21 @@ const shellMocks = vi.hoisted(() => {
 			isError: false,
 			isSuccess: true,
 		},
-		daemonStatus: { state: "stopped" } as {
+		daemonStatus: { state: "ready", port: 7777 } as {
 			state: "ready" | "starting" | "stopped" | "error";
 			port?: number;
 			code?: "not_ready";
 		},
-		shellValue: undefined as { workspaceStartupState?: string } | undefined,
+		workspaceLiveFromProvider: false,
+		shellValue: undefined as { workspaceLive?: boolean; workspaceStartupState?: string } | undefined,
+		workspaceQuerySubscriber: undefined as
+			| ((event: {
+					query: {
+						queryKey: readonly unknown[];
+						state: { status: string; dataUpdatedAt: number };
+					};
+			  }) => void)
+			| undefined,
 	};
 	return {
 		navigate: vi.fn(),
@@ -68,7 +77,15 @@ const shellMocks = vi.hoisted(() => {
 		queryClient: {
 			ensureQueryData: vi.fn(),
 			fetchQuery: vi.fn(),
-			getQueryState: vi.fn(),
+			getQueryState: vi.fn(() => ({ dataUpdatedAt: 0 })),
+			getQueryCache: vi.fn(() => ({
+				subscribe: (
+					subscriber: NonNullable<typeof state.workspaceQuerySubscriber>,
+				) => {
+					state.workspaceQuerySubscriber = subscriber;
+					return vi.fn();
+				},
+			})),
 			invalidateQueries: vi.fn(),
 			setQueryData: vi.fn(),
 		},
@@ -114,7 +131,7 @@ vi.mock("../lib/bridge", () => ({
 vi.mock("../hooks/useWorkspaceQuery", () => ({
 	useWorkspaceQuery: () => shellMocks.state.workspaceQuery,
 	workspaceQueryKey: ["workspaces"],
-	workspaceQueryOptions: {},
+	workspaceQueryOptions: { queryKey: ["workspaces"] },
 }));
 
 vi.mock("../hooks/useDaemonStatus", () => ({
@@ -159,7 +176,11 @@ vi.mock("../components/KeyboardShortcutsDialog", () => ({
 	KeyboardShortcutsDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="keyboard-shortcuts" /> : null),
 }));
 vi.mock("../lib/shell-context", () => ({
-	ShellProvider: ({ children, value }: PropsWithChildren<{ value?: { workspaceStartupState?: string } }>) => {
+	ShellProvider: ({
+		children,
+		value,
+	}: PropsWithChildren<{ value: { workspaceLive: boolean; workspaceStartupState: string } }>) => {
+		shellMocks.state.workspaceLiveFromProvider = value.workspaceLive;
 		shellMocks.state.shellValue = value;
 		return children;
 	},
@@ -219,7 +240,7 @@ const workspaces = [
 	},
 ] as unknown as WorkspaceSummary[];
 
-async function renderShell() {
+async function renderShell({ waitForWorkspaceLive = true } = {}) {
 	let view: ReturnType<typeof render> | undefined;
 	await act(async () => {
 		view = render(
@@ -228,13 +249,17 @@ async function renderShell() {
 			</Suspense>,
 		);
 	});
-	await waitFor(() => expect(shellMocks.onNewSessionShortcut).toHaveBeenCalledTimes(1), { timeout: 30_000 });
-	await waitFor(() => expect(shellMocks.onKeyboardShortcutsHelp).toHaveBeenCalledTimes(1));
-	await waitFor(() => expect(shellMocks.onNewShellTerminalShortcut).toHaveBeenCalledTimes(1));
-	await waitFor(() => expect(shellMocks.onOpenSettingsShortcut).toHaveBeenCalledTimes(1));
-	await waitFor(() => expect(shellMocks.onPreviousSessionShortcut).toHaveBeenCalledTimes(1));
-	await waitFor(() => expect(shellMocks.onNextSessionShortcut).toHaveBeenCalledTimes(1));
-	await waitFor(() => expect(shellMocks.onFocusTerminalShortcut).toHaveBeenCalledTimes(1));
+	const waitOptions = { timeout: 5_000 };
+	await waitFor(() => expect(shellMocks.onNewSessionShortcut).toHaveBeenCalledTimes(1), waitOptions);
+	await waitFor(() => expect(shellMocks.onKeyboardShortcutsHelp).toHaveBeenCalledTimes(1), waitOptions);
+	await waitFor(() => expect(shellMocks.onNewShellTerminalShortcut).toHaveBeenCalledTimes(1), waitOptions);
+	await waitFor(() => expect(shellMocks.onOpenSettingsShortcut).toHaveBeenCalledTimes(1), waitOptions);
+	await waitFor(() => expect(shellMocks.onPreviousSessionShortcut).toHaveBeenCalledTimes(1), waitOptions);
+	await waitFor(() => expect(shellMocks.onNextSessionShortcut).toHaveBeenCalledTimes(1), waitOptions);
+	await waitFor(() => expect(shellMocks.onFocusTerminalShortcut).toHaveBeenCalledTimes(1), waitOptions);
+	if (waitForWorkspaceLive && shellMocks.state.daemonStatus.state === "ready") {
+		await waitFor(() => expect(shellMocks.state.workspaceLiveFromProvider).toBe(true), waitOptions);
+	}
 	return view!;
 }
 
@@ -255,6 +280,8 @@ beforeEach(() => {
 	shellMocks.onPreviousSessionShortcut.mockClear();
 	shellMocks.onNextSessionShortcut.mockClear();
 	shellMocks.onFocusTerminalShortcut.mockClear();
+	shellMocks.queryClient.fetchQuery.mockReset().mockResolvedValue([]);
+	shellMocks.queryClient.invalidateQueries.mockReset();
 	shellMocks.state.newSessionListener = undefined;
 	shellMocks.state.keyboardShortcutsListener = undefined;
 	shellMocks.state.openSettingsListener = undefined;
@@ -270,9 +297,10 @@ beforeEach(() => {
 		isError: false,
 		isSuccess: true,
 	};
-	shellMocks.state.daemonStatus = { state: "error", code: "not_ready" };
+	shellMocks.state.daemonStatus = { state: "ready", port: 7777 };
+	shellMocks.state.workspaceLiveFromProvider = false;
 	shellMocks.state.shellValue = undefined;
-	shellMocks.queryClient.fetchQuery.mockReset();
+	shellMocks.state.workspaceQuerySubscriber = undefined;
 	shellMocks.queryClient.getQueryState.mockReset().mockReturnValue({ dataUpdatedAt: 0 });
 	useUiStore.setState({
 		createProjectNonce: 0,
@@ -434,6 +462,64 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 
 		expect(useUiStore.getState().newShellTerminalNonce).toBe(1);
 		expect(shellMocks.openShellTerminal).toHaveBeenCalledTimes(1);
+	});
+
+	it("blocks session and terminal shortcuts until the workspace fetch succeeds", async () => {
+		shellMocks.queryClient.fetchQuery.mockImplementation(
+			(options: { staleTime?: number }) =>
+				options.staleTime === 0 ? new Promise<never>(() => {}) : Promise.resolve([]),
+		);
+		shellMocks.state.routeParams = { projectId: "proj-1" };
+		await renderShell({ waitForWorkspaceLive: false });
+
+		emitShortcut();
+		pressNewShellTerminal();
+
+		expect(useUiStore.getState().newTaskRequest).toBeNull();
+		expect(useUiStore.getState().newShellTerminalNonce).toBe(0);
+		expect(shellMocks.openShellTerminal).not.toHaveBeenCalled();
+	});
+
+	it("stays read-only when the workspace fetch fails", async () => {
+		shellMocks.queryClient.fetchQuery.mockImplementation((options: { staleTime?: number }) =>
+			options.staleTime === 0 ? Promise.reject(new Error("daemon unavailable")) : Promise.resolve([]),
+		);
+		shellMocks.state.routeParams = { projectId: "proj-1" };
+		await renderShell({ waitForWorkspaceLive: false });
+		await waitFor(() =>
+			expect(shellMocks.queryClient.fetchQuery).toHaveBeenCalledWith(
+				expect.objectContaining({ queryKey: ["workspaces"], staleTime: 0 }),
+			),
+		);
+
+		emitShortcut();
+		pressNewShellTerminal();
+
+		expect(useUiStore.getState().newTaskRequest).toBeNull();
+		expect(useUiStore.getState().newShellTerminalNonce).toBe(0);
+		expect(shellMocks.openShellTerminal).not.toHaveBeenCalled();
+	});
+
+	it("enables mutations after a later workspace refetch succeeds", async () => {
+		shellMocks.queryClient.fetchQuery.mockImplementation((options: { staleTime?: number }) =>
+			options.staleTime === 0 ? Promise.reject(new Error("daemon unavailable")) : Promise.resolve([]),
+		);
+		shellMocks.state.routeParams = { projectId: "proj-1" };
+		await renderShell({ waitForWorkspaceLive: false });
+		expect(shellMocks.state.workspaceLiveFromProvider).toBe(false);
+
+		act(() => {
+			shellMocks.state.workspaceQuerySubscriber?.({
+				query: {
+					queryKey: ["workspaces"],
+					state: { status: "success", dataUpdatedAt: 1 },
+				},
+			});
+		});
+		await waitFor(() => expect(shellMocks.state.workspaceLiveFromProvider).toBe(true));
+
+		emitShortcut();
+		expect(useUiStore.getState().newTaskRequest?.projectId).toBe("proj-1");
 	});
 
 	it("scopes the terminal to the project in scope", async () => {

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -74,9 +74,11 @@ const shellMocks = vi.hoisted(() => {
 		getKeybindings: vi.fn(async () => ({})),
 		setKeybindings: vi.fn(async (overrides: KeybindingOverrides) => overrides),
 		setKeybindingRecording: vi.fn(async () => undefined),
+		refreshDaemonStatus: vi.fn(),
 		queryClient: {
 			ensureQueryData: vi.fn(),
 			fetchQuery: vi.fn(),
+			getQueryData: vi.fn(),
 			getQueryState: vi.fn(() => ({ dataUpdatedAt: 0 })),
 			getQueryCache: vi.fn(() => ({
 				subscribe: (
@@ -136,6 +138,10 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 
 vi.mock("../hooks/useDaemonStatus", () => ({
 	useDaemonStatus: () => shellMocks.state.daemonStatus,
+}));
+
+vi.mock("../lib/daemon-status", () => ({
+	refreshDaemonStatus: shellMocks.refreshDaemonStatus,
 }));
 
 // The shell layout opens standalone terminals; this suite only covers the
@@ -219,6 +225,9 @@ vi.mock("../components/Sidebar", async () => {
 
 import { Route } from "../routes/_shell";
 const ShellRoute = Route.options.component as ComponentType;
+const shellLoader = Route.options.loader as unknown as (input: {
+	context: { queryClient: typeof shellMocks.queryClient };
+}) => Promise<WorkspaceSummary[]>;
 
 const workspaces = [
 	{
@@ -281,7 +290,9 @@ beforeEach(() => {
 	shellMocks.onNextSessionShortcut.mockClear();
 	shellMocks.onFocusTerminalShortcut.mockClear();
 	shellMocks.queryClient.fetchQuery.mockReset().mockResolvedValue([]);
+	shellMocks.queryClient.getQueryData.mockReset().mockReturnValue(undefined);
 	shellMocks.queryClient.invalidateQueries.mockReset();
+	shellMocks.refreshDaemonStatus.mockReset().mockResolvedValue(shellMocks.state.daemonStatus);
 	shellMocks.state.newSessionListener = undefined;
 	shellMocks.state.keyboardShortcutsListener = undefined;
 	shellMocks.state.openSettingsListener = undefined;
@@ -307,6 +318,17 @@ beforeEach(() => {
 		isSidebarOpen: true,
 		newTaskRequest: null,
 		newShellTerminalNonce: 0,
+	});
+});
+
+describe("shell loader", () => {
+	it("returns a restored snapshot without waiting for daemon status", async () => {
+		shellMocks.queryClient.getQueryData.mockReturnValue(workspaces);
+		shellMocks.refreshDaemonStatus.mockReturnValue(new Promise(() => {}));
+
+		await expect(shellLoader({ context: { queryClient: shellMocks.queryClient } })).resolves.toBe(workspaces);
+		expect(shellMocks.refreshDaemonStatus).toHaveBeenCalledOnce();
+		expect(shellMocks.queryClient.ensureQueryData).not.toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
## Summary
- persist the last successful workspace state in the Electron UI cache and restore it before the daemon is ready
- keep cached data visible and read-only until the current daemon successfully hydrates live workspace state
- retain cached boards and project navigation when background refreshes fail
- validate nested cached workspace, session, activity, and pull-request data before restoration

## Validation
- npm run typecheck
- npx vite build --config vite.renderer.config.ts
- full frontend test suite: 1,175 tests verified
- exact-worktree Browser preview verified for cached board and session controls