### PR TITLE
fix(ci): stop skipping deploys after the org rename

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -21,9 +21,6 @@ jobs:
   build:
     # Pages deploy is canonical-repo only. Forks copy this workflow but cannot
     # create/enable GitHub Pages with GITHUB_TOKEN, which otherwise fails red.
-    # Tested against the fork flag rather than a hardcoded owner/name: an org
-    # rename silently turns a hardcoded check false, which skips both jobs and
-    # freezes the live site with no red run to notice.
     if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -21,7 +21,10 @@ jobs:
   build:
     # Pages deploy is canonical-repo only. Forks copy this workflow but cannot
     # create/enable GitHub Pages with GITHUB_TOKEN, which otherwise fails red.
-    if: github.repository == 'AgentWrapper/agent-orchestrator'
+    # Tested against the fork flag rather than a hardcoded owner/name: an org
+    # rename silently turns a hardcoded check false, which skips both jobs and
+    # freezes the live site with no red run to notice.
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +49,7 @@ jobs:
           path: frontend/src/landing/out
 
   deploy:
-    if: github.repository == 'AgentWrapper/agent-orchestrator'
+    if: ${{ !github.event.repository.fork }}
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release-latest-guard.yml
+++ b/.github/workflows/release-latest-guard.yml
@@ -14,7 +14,7 @@ jobs:
     # Stable /releases/latest only exists on the canonical repo. Forks copy
     # this workflow (including the hourly schedule) but have no desktop
     # release, so the check fails red every hour.
-    if: github.repository == 'AgentWrapper/agent-orchestrator'
+    if: github.repository == 'Untrivial-ai/agent-orchestrator'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

The repo was renamed from `AgentWrapper` to `Untrivial-ai`. Two workflows gate their jobs on a hardcoded `github.repository`, so both have been silently skipping ever since:

| File | Effect of the stale guard |
| --- | --- |
| `deploy-landing.yml` (both jobs) | landing site frozen since 2026-07-28 04:56Z |
| `release-latest-guard.yml` | hourly stable-release check has been a no-op |

`git remote` still showed the old org because GitHub silently redirects renamed owners, which is why this was easy to miss. The runs are green-but-skipped, so nothing ever went red.

## How this surfaced

A shared link to `/design-partners` kept previewing a screenshot of a different product, even after #3234 replaced the image and merged. Evidence that the deploy, not the image or any CDN, was the problem:

- Facebook's Sharing Debugger re-scraped on demand and still returned the old image, which rules out FB's scrape cache
- `https://aoagents.dev/og-image.png` returns the pre-#3234 bytes (281238) with `age=0` and `cf-cache-status: REVALIDATED`, so Cloudflare is revalidating and the origin hands back the old file
- `/`, `/og-image.png`, `/favicon.svg`, and `/design-partners/` all report the **same** `last-modified: 2026-07-28 04:57:22 GMT`. One shared timestamp across unrelated files is a whole-deployment stamp, and it predates the #3234 merge at 19:53Z
- Run `30393906460`, triggered by the #3234 merge, has `build` and `deploy` both `skipped`

## Blast radius

Two landing commits are built but unpublished:

- `a10c98c8` fix(landing): make the design-partners roadmap accordion fit mobile (#3199)
- `6210c7f1` fix(landing): use an AO-branded OG preview image (#3234)

The guards are **job-level**, so `workflow_dispatch` skipped as well. The deploy could not be re-run by hand, which is why this needed a code change rather than a button.

## Why two different conditions

Deliberate, not an inconsistency:

- **`deploy-landing.yml` → `${{ !github.event.repository.fork }}`.** This is what the existing comment says the intent is ("forks cannot create/enable GitHub Pages"), and it survives future renames. Triggers are `push` and `workflow_dispatch`, both of which carry a `repository` payload.
- **`release-latest-guard.yml` → explicit `Untrivial-ai/agent-orchestrator`.** This one also runs on `schedule`, where the `repository` payload is not reliably present. A null fork flag would read as "not a fork" and run on forks, which is exactly what the check exists to prevent.

## Test plan

`.github/workflows/deploy-landing.yml` is in its own `paths` filter, so merging this triggers a deploy that also publishes the backlog above.

```bash
# want a last-modified newer than 2026-07-28 04:57:22, and 170232 bytes
curl -sI https://aoagents.dev/og-image.png | grep -iE 'last-modified|content-length'
```

Then re-scrape in the Facebook Sharing Debugger. X caches by URL for about a week with no manual purge, so if the link is actively circulating, renaming the asset is the only reliable bust. Query strings do not work here, GitHub Pages strips them.

- [x] Both YAML files parse; guards read as intended
- [x] No functional `if: github.repository` guard references the old org
- [ ] Post-merge: deploy run succeeds instead of skipping
- [ ] Post-merge: live `/og-image.png` is 170232 bytes

## Not touched

`frontend-release.yml` lines 13, 21, 26 mention `AgentWrapper` in **comments** describing the fork-publishing flow. No functional effect, and the issue link still redirects. Worth a docs pass, left out to keep this diff behavioral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)