### PR TITLE
fix: qwen auth probe opens browser; agent refresh hangs forever

### DIFF
--- a/backend/internal/adapters/agent/qwen/auth.go
+++ b/backend/internal/adapters/agent/qwen/auth.go
@@ -7,16 +7,17 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
+// It checks environment variables and the Qwen settings file for API keys, but
+// does NOT invoke the qwen CLI — qwen auth status opens a browser to
+// chat.qwen.ai for login, which is inappropriate for a background probe.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
-	if err != nil {
+	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
 	if status, ok, err := qwenLocalAuthStatus(ctx); err != nil {
@@ -24,7 +25,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 var qwenAPIKeyEnvVars = []string{

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -15,6 +15,7 @@ var (
 	agentInstallProbeTimeout = 2 * time.Second
 	agentAuthProbeTimeout    = 10 * time.Second
 	agentRefreshMinInterval  = 10 * time.Second
+	agentRefreshTimeout      = 30 * time.Second
 )
 
 type probeResult struct {
@@ -105,16 +106,19 @@ func (s *Service) Refresh(ctx context.Context) (Inventory, error) {
 	}
 	s.mu.RUnlock()
 
+	probeCtx, probeCancel := context.WithTimeout(ctx, agentRefreshTimeout)
+	defer probeCancel()
+
 	results := make(chan probeResult, len(s.agents))
 	var wg sync.WaitGroup
 	for _, item := range s.agents {
-		if err := ctx.Err(); err != nil {
+		if err := probeCtx.Err(); err != nil {
 			return Inventory{}, err
 		}
 		wg.Add(1)
 		go func(item agentregistry.HarnessAgent) {
 			defer wg.Done()
-			results <- probeAgent(ctx, item)
+			results <- probeAgent(probeCtx, item)
 		}(item)
 	}
 	wg.Wait()


### PR DESCRIPTION
**Root cause:** The Qwen auth probe (`AuthStatus`) fell back to `authprobe.CLIStatus` which runs `qwen auth status`. The `qwen` CLI\s auth status command opens `chat.qwen.ai` in a browser and blocks waiting for login. This is inappropriate for a background probe — the daemon runs it at startup and during agent catalog refresh, causing the browser to open repeatedly.

**Downstream effect:** Since `Refresh` had no overall timeout, a single stuck probe (qwen) locked `refreshMu` forever. Every subsequent "Refresh agents" click in the UI also hangs, and the agent inventory is never populated — `installed` and `authorized` remain permanently empty.

**Changes:**

`backend/internal/adapters/agent/qwen/auth.go`
- Remove `authprobe.CLIStatus` fallback from `AuthStatus`. Return `unknown` when no local credentials (env vars or settings file) are found, instead of invoking the qwen CLI.
- Remove unused `authprobe` import.

`backend/internal/service/agent/service.go`
- Add `agentRefreshTimeout = 30s` and wrap the probe phase in a timeout context, so a stuck probe can\t prevent `Refresh` from ever completing.
- Probes now use this derived context instead of the caller\s context directly.

**Verification:**
- Qwen probe completes in ~362µs (was hanging + opening browser)
- Full agent catalog refresh completes in ~45µs (rate-limited)
- Installed agents correctly detected: claude-code, opencode, pi, qwen, droid, cursor, cline, kilocode, fake
- All backend tests pass