### PR TITLE
test(board): cover every lane and harness in the browser-preview fixtures

### DIFF
--- a/frontend/src/renderer/lib/mock-data.ts
+++ b/frontend/src/renderer/lib/mock-data.ts
@@ -1,4 +1,11 @@
-import type { PRState, PullRequestFacts, WorkspaceSummary } from "../types/workspace";
+import type {
+	AgentProvider,
+	PRState,
+	PullRequestFacts,
+	SessionStatus,
+	WorkspaceSession,
+	WorkspaceSummary,
+} from "../types/workspace";
 import type { SessionPRSummary } from "../hooks/useSessionScmSummary";
 import type { ShellTerminal } from "../hooks/useShellTerminals";
 
@@ -35,6 +42,98 @@ export const mockShellTerminals: ShellTerminal[] = [
 		createdAt: now,
 	},
 ];
+
+/**
+ * One session per harness AO hasn't already placed in `ao-demo` / `docs-site`,
+ * spread across every status so the browser preview shows the whole board at
+ * once: both halves of each split column, and the archive.
+ *
+ * `agy`, `auggie` and `autohand` ship no brand mark, so they also stand in for
+ * the lettered fallback. The `fake` harness is deliberately absent — it is a
+ * test double, not something a user picks.
+ */
+const galleryRow = (
+	provider: AgentProvider,
+	title: string,
+	branch: string,
+	status: SessionStatus,
+	minutes: number,
+	prs: PullRequestFacts[] = [],
+	terminated = false,
+): WorkspaceSession => ({
+	id: `gallery-${provider}`,
+	terminalHandleId: `gallery-${provider}/terminal_0`,
+	workspaceId: "agent-gallery",
+	workspaceName: "agent-gallery",
+	title,
+	provider,
+	branch,
+	status,
+	...(terminated ? { isTerminated: true } : {}),
+	createdAt: hoursAgo(Math.max(1, Math.round(minutes / 60) + 2)),
+	updatedAt: minutesAgo(minutes),
+	activity: {
+		state: status === "working" ? "active" : status === "needs_input" ? "waiting_input" : "idle",
+		lastActivityAt: minutesAgo(minutes),
+	},
+	prs,
+});
+
+const agentGalleryWorkspace: WorkspaceSummary = {
+	id: "agent-gallery",
+	name: "agent-gallery",
+	path: "/demo/agent-gallery",
+	type: "main",
+	orchestratorAgent: "claude-code",
+	accentColor: "var(--color-project-accent-violet)",
+	sessions: [
+		// Working column — the idle half, then the active half.
+		galleryRow("kimi", "Profile the board render path", "gallery/board-render-profile", "idle", 64),
+		galleryRow("droid", "Extract the diff gutter component", "gallery/diff-gutter", "idle", 88),
+		galleryRow("devin", "Backfill session lifecycle tests", "gallery/lifecycle-tests", "working", 3),
+		galleryRow("crush", "Tune the worktree prune schedule", "gallery/worktree-prune", "working", 9),
+		// Needs you — every reason the lane collapses together.
+		galleryRow("pi", "Confirm the destructive reset copy", "gallery/reset-copy", "needs_input", 12),
+		galleryRow("cline", "Port the settings form to shadcn", "gallery/settings-shadcn", "exited", 41),
+		galleryRow("kilocode", "Trace the dropped CDC frames", "gallery/cdc-frames", "no_signal", 73),
+		galleryRow("qwen", "Fix the flaky preview poller test", "gallery/preview-poller", "ci_failed", 27, [
+			demoPr(501, "open", "failing", "none"),
+		]),
+		galleryRow("goose", "Rework the archive empty state", "gallery/archive-empty", "changes_requested", 35, [
+			demoPr(502, "open", "passing", "changes_requested"),
+		]),
+		// In review.
+		galleryRow("vibe", "Add keyboard nav to the board", "gallery/board-keyboard-nav", "review_pending", 18, [
+			demoPr(503, "open", "passing", "none"),
+		]),
+		galleryRow("continue", "Split the telemetry reservoir", "gallery/telemetry-reservoir", "draft", 55, [
+			demoPr(504, "draft", "pending", "none", "unknown"),
+		]),
+		galleryRow("kiro", "Cache the agent mark lookups", "gallery/mark-lookup-cache", "pr_open", 8, [
+			demoPr(505, "open", "pending", "none", "unknown"),
+		]),
+		// Ready to merge, then merged.
+		galleryRow("agy", "Document the harness registry", "gallery/harness-registry-docs", "mergeable", 6, [
+			demoPr(506, "open", "passing", "approved"),
+		]),
+		galleryRow("auggie", "Align the sidebar project rows", "gallery/sidebar-rows", "approved", 21, [
+			demoPr(507, "open", "passing", "approved"),
+		]),
+		galleryRow("autohand", "Retire the legacy status pill", "gallery/legacy-status-pill", "merged", 96, [
+			demoPr(508, "merged", "passing", "approved"),
+		]),
+		// Archive.
+		galleryRow(
+			"amp",
+			"Spike: virtualise the board columns",
+			"gallery/virtualise-columns",
+			"terminated",
+			150,
+			[],
+			true,
+		),
+	],
+};
 
 export const mockWorkspaces: WorkspaceSummary[] = [
 	{
@@ -170,6 +269,78 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 				activity: { state: "idle", lastActivityAt: minutesAgo(46) },
 				prs: [demoPr(324, "open", "failing", "none")],
 			},
+			{
+				id: "demo-idle",
+				terminalHandleId: "demo-idle/terminal_0",
+				workspaceId: "ao-demo",
+				workspaceName: "ao-demo",
+				title: "Audit board empty states",
+				provider: "amp",
+				branch: "demo/board-empty-states",
+				status: "idle",
+				createdAt: hoursAgo(4),
+				updatedAt: minutesAgo(52),
+				activity: { state: "idle", lastActivityAt: minutesAgo(52) },
+				prs: [],
+			},
+			{
+				id: "demo-unknown",
+				terminalHandleId: "demo-unknown/terminal_0",
+				workspaceId: "ao-demo",
+				workspaceName: "ao-demo",
+				title: "Reconcile a session the daemon lost track of",
+				provider: "copilot",
+				branch: "demo/orphaned-session",
+				status: "unknown",
+				createdAt: hoursAgo(11),
+				updatedAt: hoursAgo(2),
+				activity: { state: "unknown", lastActivityAt: hoursAgo(2) },
+				prs: [],
+			},
+			{
+				id: "demo-merged",
+				terminalHandleId: "demo-merged/terminal_0",
+				workspaceId: "ao-demo",
+				workspaceName: "ao-demo",
+				title: "Ship the agent mark registry",
+				provider: "codex",
+				branch: "demo/agent-mark-registry",
+				status: "merged",
+				createdAt: hoursAgo(14),
+				updatedAt: hoursAgo(1),
+				activity: { state: "exited", lastActivityAt: hoursAgo(1) },
+				prs: [demoPr(325, "merged", "passing", "approved")],
+			},
+			{
+				id: "demo-archived-merged",
+				terminalHandleId: "demo-archived-merged/terminal_0",
+				workspaceId: "ao-demo",
+				workspaceName: "ao-demo",
+				title: "Drop the per-card status pill",
+				provider: "cursor",
+				branch: "demo/card-status-pill",
+				status: "merged",
+				isTerminated: true,
+				createdAt: hoursAgo(20),
+				updatedAt: hoursAgo(3),
+				activity: { state: "exited", lastActivityAt: hoursAgo(3) },
+				prs: [demoPr(326, "merged", "passing", "approved")],
+			},
+			{
+				id: "demo-archived-abandoned",
+				terminalHandleId: "demo-archived-abandoned/terminal_0",
+				workspaceId: "ao-demo",
+				workspaceName: "ao-demo",
+				title: "Spike: inline diff in the board card",
+				provider: "opencode",
+				branch: "demo/inline-diff-spike",
+				status: "terminated",
+				isTerminated: true,
+				createdAt: hoursAgo(30),
+				updatedAt: hoursAgo(6),
+				activity: { state: "exited", lastActivityAt: hoursAgo(6) },
+				prs: [],
+			},
 		],
 	},
 	{
@@ -208,8 +379,24 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 				activity: { state: "idle", lastActivityAt: minutesAgo(22) },
 				prs: [demoPr(411, "open", "passing", "approved")],
 			},
+			{
+				id: "docs-archived",
+				terminalHandleId: "docs-archived/terminal_0",
+				workspaceId: "docs-site",
+				workspaceName: "docs-site",
+				title: "Rewrite the CLI reference intro",
+				provider: "claude-code",
+				branch: "demo/cli-reference-intro",
+				status: "terminated",
+				isTerminated: true,
+				createdAt: hoursAgo(26),
+				updatedAt: hoursAgo(9),
+				activity: { state: "exited", lastActivityAt: hoursAgo(9) },
+				prs: [demoPr(412, "closed", "passing", "none")],
+			},
 		],
 	},
+	agentGalleryWorkspace,
 ];
 
 const prSummary = (sessionId: string, number: number, overrides: Partial<SessionPRSummary> = {}): SessionPRSummary => {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -422,6 +422,7 @@
 	/* Mock project accent swatches (sidebar dots) */
 	--color-project-accent-mint: #6ee7b7;
 	--color-project-accent-sky: #93c5fd;
+	--color-project-accent-violet: #c4b5fd;
 
 	/* Terminal ANSI palette. Keep this independent from product status colors:
 	   agent TUIs own the semantic meaning of these slots. */


### PR DESCRIPTION
The `dev:web` fixtures only exercised part of the board, which made several surfaces impossible to see while working on them.

**Missing before:** any idle session, any merged session, anything archived, and 16 of the 24 harnesses.

**Now covered:** all 15 statuses and 23 of the 24 harnesses.

- `ao-demo` and `docs-site` gain the states they lacked — idle, merged, `unknown`, and a few archived sessions
- a third `agent-gallery` project carries one session per remaining harness, spread across every status, so both halves of each split lane and the archive all have content

`agy`, `auggie` and `autohand` ship no brand mark, so they double as coverage for the lettered fallback. The `fake` harness is deliberately absent — it's a test double, not something a user picks.

Adds `--color-project-accent-violet` for the new project's sidebar dot; the file only had mint and sky.

**Scope:** fixture-only. This is the `VITE_NO_ELECTRON` preview path (`useWorkspaceQuery` falls back to `mockWorkspaces`), so the packaged app is untouched. Independent of #3177 — no shared files, either can land first.

**Checks:** typecheck clean, 1174 unit tests pass, CI green. The one failure in a full-suite run is `shell-new-session-shortcut.test.tsx`, which passes in isolation and also fails on a clean `main` — pre-existing, not from this change.