### PR TITLE
fix: dedupe inspector PR summaries

### DIFF
--- a/backend/internal/domain/pr.go
+++ b/backend/internal/domain/pr.go
@@ -18,6 +18,7 @@ type PRFacts struct {
 	ReviewComments bool // has unresolved review comments (any author) to address
 	SourceBranch   string
 	TargetBranch   string
+	HeadSHA        string
 	UpdatedAt      time.Time
 }
 

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -272,13 +272,18 @@ func (s *Service) listPRFacts(ctx context.Context, id domain.SessionID) ([]domai
 	if err != nil {
 		return nil, err
 	}
-	facts := make([]domain.PRFacts, 0, len(prs))
-	for _, pr := range prs {
-		comments, err := s.store.ListPRComments(ctx, pr.URL)
-		if err != nil {
-			return nil, err
+	groups := groupPullRequestAliases(prs)
+	facts := make([]domain.PRFacts, 0, len(groups))
+	for _, group := range groups {
+		var comments []domain.PullRequestComment
+		for _, pr := range group.aliases {
+			prComments, err := s.store.ListPRComments(ctx, pr.URL)
+			if err != nil {
+				return nil, err
+			}
+			comments = append(comments, prComments...)
 		}
-		facts = append(facts, pullRequestFacts(pr, comments))
+		facts = append(facts, pullRequestFacts(group.primary, comments))
 	}
 	sortPRFacts(facts)
 	return facts, nil
@@ -292,7 +297,7 @@ func pullRequestFacts(pr domain.PullRequest, comments []domain.PullRequestCommen
 			break
 		}
 	}
-	return domain.PRFacts{URL: pr.URL, Number: pr.Number, Draft: pr.Draft, Merged: pr.Merged, Closed: pr.Closed, CI: pr.CI, Review: pr.Review, Mergeability: pr.Mergeability, ReviewComments: unresolved, UpdatedAt: pr.UpdatedAt}
+	return domain.PRFacts{URL: pr.URL, Number: pr.Number, Draft: pr.Draft, Merged: pr.Merged, Closed: pr.Closed, CI: pr.CI, Review: pr.Review, Mergeability: pr.Mergeability, ReviewComments: unresolved, SourceBranch: pr.SourceBranch, TargetBranch: pr.TargetBranch, HeadSHA: pr.HeadSHA, UpdatedAt: pr.UpdatedAt}
 }
 
 func sortPRFacts(prs []domain.PRFacts) {

--- a/backend/internal/service/session/pr_alias.go
+++ b/backend/internal/service/session/pr_alias.go
@@ -1,0 +1,134 @@
+package session
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type pullRequestAliasGroup struct {
+	primary domain.PullRequest
+	aliases []domain.PullRequest
+}
+
+func groupPullRequestAliases(prs []domain.PullRequest) []pullRequestAliasGroup {
+	groups := make([]pullRequestAliasGroup, 0, len(prs))
+	byKey := map[string]int{}
+	for _, pr := range prs {
+		key := pullRequestAliasKey(pr.URL, pr.Number, pr.SourceBranch, pr.TargetBranch, pr.HeadSHA)
+		if key == "" {
+			groups = append(groups, pullRequestAliasGroup{primary: pr, aliases: []domain.PullRequest{pr}})
+			continue
+		}
+		if idx, ok := byKey[key]; ok {
+			groups[idx].aliases = append(groups[idx].aliases, pr)
+			if pr.UpdatedAt.After(groups[idx].primary.UpdatedAt) {
+				groups[idx].primary = pr
+			}
+			continue
+		}
+		byKey[key] = len(groups)
+		groups = append(groups, pullRequestAliasGroup{primary: pr, aliases: []domain.PullRequest{pr}})
+	}
+	return groups
+}
+
+func deduplicatePRFacts(prs []domain.PRFacts) []domain.PRFacts {
+	out := make([]domain.PRFacts, 0, len(prs))
+	byKey := map[string]int{}
+	for _, pr := range prs {
+		key := pullRequestAliasKey(pr.URL, pr.Number, pr.SourceBranch, pr.TargetBranch, pr.HeadSHA)
+		if key == "" {
+			out = append(out, pr)
+			continue
+		}
+		if idx, ok := byKey[key]; ok {
+			out[idx] = mergePRFacts(out[idx], pr)
+			continue
+		}
+		byKey[key] = len(out)
+		out = append(out, pr)
+	}
+	return out
+}
+
+func mergePRFacts(current, next domain.PRFacts) domain.PRFacts {
+	if next.UpdatedAt.After(current.UpdatedAt) {
+		next.ReviewComments = current.ReviewComments || next.ReviewComments
+		if next.SourceBranch == "" {
+			next.SourceBranch = current.SourceBranch
+		}
+		if next.TargetBranch == "" {
+			next.TargetBranch = current.TargetBranch
+		}
+		if next.HeadSHA == "" {
+			next.HeadSHA = current.HeadSHA
+		}
+		return next
+	}
+	current.ReviewComments = current.ReviewComments || next.ReviewComments
+	if current.SourceBranch == "" {
+		current.SourceBranch = next.SourceBranch
+	}
+	if current.TargetBranch == "" {
+		current.TargetBranch = next.TargetBranch
+	}
+	if current.HeadSHA == "" {
+		current.HeadSHA = next.HeadSHA
+	}
+	return current
+}
+
+func pullRequestAliasKey(rawURL string, number int, sourceBranch, targetBranch, headSHA string) string {
+	host, owner, repoName, parsedNumber, ok := githubPRURLIdentity(rawURL)
+	if !ok {
+		return ""
+	}
+	if number != 0 && parsedNumber != 0 && number != parsedNumber {
+		return ""
+	}
+	identityNumber := strconv.Itoa(parsedNumber)
+	branch := normalizedAliasPart(sourceBranch)
+	head := normalizedAliasPart(headSHA)
+	if branch == "" || head == "" {
+		return strings.Join([]string{"github", host, owner, repoName, identityNumber}, "|")
+	}
+	return strings.Join([]string{
+		"github-transfer",
+		host,
+		repoName,
+		identityNumber,
+		branch,
+		normalizedAliasPart(targetBranch),
+		head,
+	}, "|")
+}
+
+func normalizedAliasPart(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func githubPRURLIdentity(raw string) (host, owner, repoName string, number int, ok bool) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		return "", "", "", 0, false
+	}
+	host = strings.ToLower(u.Host)
+	if host != "github.com" && !strings.HasSuffix(host, ".github.com") {
+		return "", "", "", 0, false
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 {
+		return "", "", "", 0, false
+	}
+	if parts[2] != "pull" && parts[2] != "issues" {
+		return "", "", "", 0, false
+	}
+	n, err := strconv.Atoi(parts[3])
+	if err != nil || n <= 0 {
+		return "", "", "", 0, false
+	}
+	return host, strings.ToLower(parts[0]), strings.ToLower(parts[1]), n, true
+}

--- a/backend/internal/service/session/pr_summary.go
+++ b/backend/internal/service/session/pr_summary.go
@@ -119,25 +119,36 @@ func (s *Service) ListPRSummaries(ctx context.Context, id domain.SessionID) ([]P
 	if err != nil {
 		return nil, err
 	}
-	out := make([]PRSummary, 0, len(prs))
-	for _, pr := range prs {
-		checks, err := s.store.ListChecks(ctx, pr.URL)
-		if err != nil {
-			return nil, err
+	groups := groupPullRequestAliases(prs)
+	out := make([]PRSummary, 0, len(groups))
+	for _, group := range groups {
+		var checks []domain.PullRequestCheck
+		var threads []domain.PullRequestReviewThread
+		var reviews []domain.PullRequestReview
+		var comments []domain.PullRequestComment
+		for _, pr := range group.aliases {
+			prChecks, err := s.store.ListChecks(ctx, pr.URL)
+			if err != nil {
+				return nil, err
+			}
+			checks = append(checks, prChecks...)
+			prThreads, err := s.store.ListPRReviewThreads(ctx, pr.URL)
+			if err != nil {
+				return nil, err
+			}
+			threads = append(threads, prThreads...)
+			prReviews, err := s.store.ListPRReviews(ctx, pr.URL)
+			if err != nil {
+				return nil, err
+			}
+			reviews = append(reviews, prReviews...)
+			prComments, err := s.store.ListPRComments(ctx, pr.URL)
+			if err != nil {
+				return nil, err
+			}
+			comments = append(comments, prComments...)
 		}
-		threads, err := s.store.ListPRReviewThreads(ctx, pr.URL)
-		if err != nil {
-			return nil, err
-		}
-		reviews, err := s.store.ListPRReviews(ctx, pr.URL)
-		if err != nil {
-			return nil, err
-		}
-		comments, err := s.store.ListPRComments(ctx, pr.URL)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, summarizePR(pr, checks, reviews, threads, comments))
+		out = append(out, summarizePR(group.primary, checks, reviews, threads, comments))
 	}
 	sortPRSummaries(out)
 	return out, nil

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -683,6 +683,7 @@ func (s *Service) toSession(ctx context.Context, rec domain.SessionRecord) (doma
 	if err != nil {
 		return domain.Session{}, fmt.Errorf("pr facts %s: %w", rec.ID, err)
 	}
+	prs = deduplicatePRFacts(prs)
 	return domain.Session{
 		SessionRecord:    rec,
 		Status:           deriveStatus(rec, prs, s.now(), s.harnessSignals(rec.Harness)),

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -1620,6 +1620,140 @@ func TestListPRSummariesOnlyEmitsMergeReasonsForBlockedStates(t *testing.T) {
 	}
 }
 
+func TestListPRSummariesCollapsesTransferredRepoAliases(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker}
+	now := time.Date(2026, 7, 31, 10, 0, 0, 0, time.UTC)
+	oldURL := "https://github.com/AgentWrapper/agent-orchestrator/pull/3193"
+	newURL := "https://github.com/Untrivial-ai/agent-orchestrator/pull/3193"
+	stList := &multiPRFakeStore{fakeStore: st, prs: []domain.PullRequest{
+		{
+			URL:          oldURL,
+			SessionID:    "mer-1",
+			Number:       3193,
+			Provider:     "github",
+			Host:         "github.com",
+			Repo:         "AgentWrapper/agent-orchestrator",
+			SourceBranch: "ao/mer-1/fix-sigpipe",
+			TargetBranch: "main",
+			HeadSHA:      "same-head",
+			Title:        "old alias",
+			CI:           domain.CIFailing,
+			UpdatedAt:    now,
+		},
+		{
+			URL:          newURL,
+			HTMLURL:      newURL,
+			SessionID:    "mer-1",
+			Number:       3193,
+			Provider:     "github",
+			Host:         "github.com",
+			Repo:         "Untrivial-ai/agent-orchestrator",
+			SourceBranch: "ao/mer-1/fix-sigpipe",
+			TargetBranch: "main",
+			HeadSHA:      "same-head",
+			Title:        "new alias",
+			CI:           domain.CIFailing,
+			UpdatedAt:    now.Add(time.Minute),
+		},
+	}}
+	stList.checks[oldURL] = []domain.PullRequestCheck{{
+		Name: "old-check", CommitHash: "same-head", Status: domain.PRCheckFailed, Conclusion: "failure", URL: "https://ci.example/old",
+	}}
+	stList.checks[newURL] = []domain.PullRequestCheck{{
+		Name: "new-check", CommitHash: "same-head", Status: domain.PRCheckFailed, Conclusion: "failure", URL: "https://ci.example/new",
+	}}
+
+	got, err := (&Service{store: stList}).ListPRSummaries(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("summaries = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].URL != newURL || got[0].Title != "new alias" {
+		t.Fatalf("summary primary = %q %q, want new alias", got[0].URL, got[0].Title)
+	}
+	if names := failingCheckNames(got[0].CI.FailingChecks); !sameStrings(names, []string{"old-check", "new-check"}) {
+		t.Fatalf("failing checks = %v, want old and new alias checks", names)
+	}
+}
+
+func TestDeduplicatePRFactsKeepsSameNumberAcrossDifferentRepos(t *testing.T) {
+	now := time.Date(2026, 7, 31, 10, 0, 0, 0, time.UTC)
+	got := deduplicatePRFacts([]domain.PRFacts{
+		{
+			URL:          "https://github.com/acme/api/pull/7",
+			Number:       7,
+			SourceBranch: "fix-tests",
+			UpdatedAt:    now,
+		},
+		{
+			URL:          "https://github.com/acme/web/pull/7",
+			Number:       7,
+			SourceBranch: "fix-tests",
+			UpdatedAt:    now.Add(time.Minute),
+		},
+	})
+	if len(got) != 2 {
+		t.Fatalf("facts = %d, want distinct same-number PRs from different repos: %+v", len(got), got)
+	}
+}
+
+func TestDeduplicatePRFactsKeepsSameBasenameAcrossDifferentOwners(t *testing.T) {
+	now := time.Date(2026, 7, 31, 10, 0, 0, 0, time.UTC)
+	got := deduplicatePRFacts([]domain.PRFacts{
+		{
+			URL:          "https://github.com/acme/repo/pull/7",
+			Number:       7,
+			SourceBranch: "fix-tests",
+			TargetBranch: "main",
+			HeadSHA:      "acme-head",
+			UpdatedAt:    now,
+		},
+		{
+			URL:          "https://github.com/other/repo/pull/7",
+			Number:       7,
+			SourceBranch: "fix-tests",
+			TargetBranch: "main",
+			HeadSHA:      "other-head",
+			UpdatedAt:    now.Add(time.Minute),
+		},
+	})
+	if len(got) != 2 {
+		t.Fatalf("facts = %d, want distinct same-basename PRs from different owners: %+v", len(got), got)
+	}
+}
+
+func TestDeduplicatePRFactsCollapsesTransferredRepoAliasesWithSameHead(t *testing.T) {
+	now := time.Date(2026, 7, 31, 10, 0, 0, 0, time.UTC)
+	got := deduplicatePRFacts([]domain.PRFacts{
+		{
+			URL:            "https://github.com/AgentWrapper/agent-orchestrator/pull/3193",
+			Number:         3193,
+			ReviewComments: true,
+			SourceBranch:   "ao/mer-1/fix-sigpipe",
+			TargetBranch:   "main",
+			HeadSHA:        "same-head",
+			UpdatedAt:      now,
+		},
+		{
+			URL:          "https://github.com/Untrivial-ai/agent-orchestrator/pull/3193",
+			Number:       3193,
+			SourceBranch: "ao/mer-1/fix-sigpipe",
+			TargetBranch: "main",
+			HeadSHA:      "same-head",
+			UpdatedAt:    now.Add(time.Minute),
+		},
+	})
+	if len(got) != 1 {
+		t.Fatalf("facts = %d, want transferred aliases collapsed: %+v", len(got), got)
+	}
+	if got[0].URL != "https://github.com/Untrivial-ai/agent-orchestrator/pull/3193" || !got[0].ReviewComments {
+		t.Fatalf("merged facts = %+v, want newest URL and preserved comments", got[0])
+	}
+}
+
 type multiPRFakeStore struct {
 	*fakeStore
 	prs []domain.PullRequest
@@ -1636,4 +1770,29 @@ func containsString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func failingCheckNames(checks []PRFailingCheck) []string {
+	out := make([]string, 0, len(checks))
+	for _, check := range checks {
+		out = append(out, check.Name)
+	}
+	return out
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, value := range got {
+		seen[value]++
+	}
+	for _, value := range want {
+		seen[value]--
+		if seen[value] < 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/backend/internal/storage/sqlite/gen/pr.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr.sql.go
@@ -62,6 +62,7 @@ SELECT
     pr.review_decision,
     pr.ci_state,
     pr.mergeability,
+    pr.head_sha,
     pr.updated_at,
     EXISTS (
         SELECT 1
@@ -85,6 +86,7 @@ type GetDisplayPRFactsBySessionRow struct {
 	ReviewDecision domain.ReviewDecision
 	CIState        domain.CIState
 	Mergeability   domain.Mergeability
+	HeadSha        string
 	UpdatedAt      time.Time
 	ReviewComments bool
 }
@@ -99,6 +101,7 @@ func (q *Queries) GetDisplayPRFactsBySession(ctx context.Context, sessionID doma
 		&i.ReviewDecision,
 		&i.CIState,
 		&i.Mergeability,
+		&i.HeadSha,
 		&i.UpdatedAt,
 		&i.ReviewComments,
 	)
@@ -199,6 +202,7 @@ SELECT
     pr.mergeability,
     pr.source_branch,
     pr.target_branch,
+    pr.head_sha,
     pr.updated_at,
     EXISTS (
         SELECT 1
@@ -221,6 +225,7 @@ type ListPRFactsBySessionRow struct {
 	Mergeability   domain.Mergeability
 	SourceBranch   string
 	TargetBranch   string
+	HeadSha        string
 	UpdatedAt      time.Time
 	ReviewComments bool
 }
@@ -246,6 +251,7 @@ func (q *Queries) ListPRFactsBySession(ctx context.Context, sessionID domain.Ses
 			&i.Mergeability,
 			&i.SourceBranch,
 			&i.TargetBranch,
+			&i.HeadSha,
 			&i.UpdatedAt,
 			&i.ReviewComments,
 		); err != nil {

--- a/backend/internal/storage/sqlite/queries/pr.sql
+++ b/backend/internal/storage/sqlite/queries/pr.sql
@@ -101,6 +101,7 @@ SELECT
     pr.review_decision,
     pr.ci_state,
     pr.mergeability,
+    pr.head_sha,
     pr.updated_at,
     EXISTS (
         SELECT 1
@@ -129,6 +130,7 @@ SELECT
     pr.mergeability,
     pr.source_branch,
     pr.target_branch,
+    pr.head_sha,
     pr.updated_at,
     EXISTS (
         SELECT 1

--- a/backend/internal/storage/sqlite/store/pr_facts.go
+++ b/backend/internal/storage/sqlite/store/pr_facts.go
@@ -46,6 +46,7 @@ func (s *Store) ListPRFactsForSession(ctx context.Context, id domain.SessionID) 
 			ReviewComments: r.ReviewComments,
 			SourceBranch:   r.SourceBranch,
 			TargetBranch:   r.TargetBranch,
+			HeadSHA:        r.HeadSha,
 			UpdatedAt:      r.UpdatedAt,
 		})
 	}
@@ -64,6 +65,7 @@ func prFactsFromGen(r gen.GetDisplayPRFactsBySessionRow) domain.PRFacts {
 		Review:         r.ReviewDecision,
 		Mergeability:   r.Mergeability,
 		ReviewComments: r.ReviewComments,
+		HeadSHA:        r.HeadSha,
 		UpdatedAt:      r.UpdatedAt,
 	}
 }

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -295,7 +295,7 @@ function SummaryView({ session }: { session: WorkspaceSession }) {
 				) : (
 					<div className="flex flex-col gap-1.5">
 						{prSummaries.map((pr) => (
-							<PRSummaryCard key={pr.number} pr={pr} />
+							<PRSummaryCard key={pr.url || pr.htmlUrl || pr.number} pr={pr} />
 						))}
 					</div>
 				)}

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -977,7 +977,7 @@ function BoardPRGroup({ group, linksInteractive = true }: { group: BoardPRGroup;
 		>
 			<span>PR</span>
 			{group.prs.map((pr, index) => (
-				<span className="inline-flex items-center" key={pr.number}>
+				<span className="inline-flex items-center" key={pr.url || pr.htmlUrl || pr.number}>
 					{linksInteractive ? (
 						<a
 							className="text-passive underline-offset-2 transition-colors hover:text-foreground hover:underline"

--- a/frontend/src/renderer/lib/pr-display.test.ts
+++ b/frontend/src/renderer/lib/pr-display.test.ts
@@ -115,6 +115,139 @@ describe("sessionPRDisplaySummaries", () => {
 		expect(got[0].title).toBe("first observed PR #7");
 	});
 
+	it("keeps same-number PRs from different repositories distinct", () => {
+		const got = sessionPRDisplaySummaries(session([]), [
+			summary({
+				url: "https://github.com/acme/api/pull/7",
+				htmlUrl: "https://github.com/acme/api/pull/7",
+				repo: "acme/api",
+				number: 7,
+				title: "API PR #7",
+			}),
+			summary({
+				url: "https://github.com/acme/web/pull/7",
+				htmlUrl: "https://github.com/acme/web/pull/7",
+				repo: "acme/web",
+				number: 7,
+				title: "Web PR #7",
+			}),
+		]);
+
+		expect(got.map((pr) => pr.title)).toEqual(["API PR #7", "Web PR #7"]);
+	});
+
+	it("keeps same-number PRs with the same repository basename from different owners distinct", () => {
+		const got = sessionPRDisplaySummaries(session([]), [
+			summary({
+				url: "https://github.com/acme/repo/pull/7",
+				htmlUrl: "https://github.com/acme/repo/pull/7",
+				repo: "acme/repo",
+				number: 7,
+				title: "Acme PR #7",
+				headSha: "acme-head",
+			}),
+			summary({
+				url: "https://github.com/other/repo/pull/7",
+				htmlUrl: "https://github.com/other/repo/pull/7",
+				repo: "other/repo",
+				number: 7,
+				title: "Other PR #7",
+				headSha: "other-head",
+			}),
+		]);
+
+		expect(got.map((pr) => pr.title)).toEqual(["Acme PR #7", "Other PR #7"]);
+	});
+
+	it("deduplicates transferred GitHub repository aliases", () => {
+		const got = sessionPRDisplaySummaries(session([]), [
+			summary({
+				url: "https://github.com/AgentWrapper/agent-orchestrator/pull/3193",
+				htmlUrl: "https://github.com/AgentWrapper/agent-orchestrator/pull/3193",
+				repo: "AgentWrapper/agent-orchestrator",
+				number: 3193,
+				title: "first observed alias",
+			}),
+			summary({
+				url: "https://github.com/Untrivial-ai/agent-orchestrator/pull/3193",
+				htmlUrl: "https://github.com/Untrivial-ai/agent-orchestrator/pull/3193",
+				repo: "Untrivial-ai/agent-orchestrator",
+				number: 3193,
+				title: "duplicate transferred alias",
+			}),
+		]);
+
+		expect(got).toHaveLength(1);
+		expect(got[0].title).toBe("first observed alias");
+	});
+
+	it("uses the enriched summary for a unique session fact when URL identities differ", () => {
+		const got = sessionPRDisplaySummaries(
+			session([
+				{
+					url: "https://example.com/pr/8",
+					number: 8,
+					state: "draft",
+					ci: "pending",
+					review: "none",
+					mergeability: "unknown",
+					reviewComments: false,
+					updatedAt: "2026-06-15T10:00:00Z",
+				},
+			]),
+			[
+				summary({
+					number: 8,
+					url: "https://api.github.com/repos/acme/repo/pulls/8",
+					htmlUrl: "https://github.com/acme/repo/pull/8",
+					title: "enriched PR #8",
+				}),
+			],
+		);
+
+		expect(got).toHaveLength(1);
+		expect(got[0]).toMatchObject({
+			number: 8,
+			title: "enriched PR #8",
+			htmlUrl: "https://github.com/acme/repo/pull/8",
+		});
+	});
+
+	it("keeps a same-number summary for another repository after an exact fact match", () => {
+		const got = sessionPRDisplaySummaries(
+			session([
+				{
+					url: "https://github.com/acme/api/pull/7",
+					number: 7,
+					state: "open",
+					ci: "passing",
+					review: "approved",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T10:00:00Z",
+				},
+			]),
+			[
+				summary({
+					url: "https://github.com/acme/api/pull/7",
+					htmlUrl: "https://github.com/acme/api/pull/7",
+					repo: "acme/api",
+					number: 7,
+					title: "API PR #7",
+				}),
+				summary({
+					url: "https://github.com/acme/web/pull/7",
+					htmlUrl: "https://github.com/acme/web/pull/7",
+					repo: "acme/web",
+					number: 7,
+					title: "Web PR #7",
+				}),
+			],
+		);
+
+		expect(got.map((pr) => pr.title)).toEqual(["API PR #7", "Web PR #7"]);
+	});
+
 	it("deduplicates repeated session facts and uses the enriched summary for the surviving card", () => {
 		const got = sessionPRDisplaySummaries(
 			session([

--- a/frontend/src/renderer/lib/pr-display.test.ts
+++ b/frontend/src/renderer/lib/pr-display.test.ts
@@ -28,6 +28,18 @@ const summary = (overrides: Partial<SessionPRSummary> = {}): SessionPRSummary =>
 	...overrides,
 });
 
+const session = (prs: WorkspaceSession["prs"]): WorkspaceSession => ({
+	id: "sess-1",
+	workspaceId: "ws-1",
+	workspaceName: "repo",
+	title: "Fix timing",
+	provider: "codex",
+	branch: "feat/timing",
+	status: "review_pending",
+	updatedAt: "2026-06-15T12:00:00Z",
+	prs,
+});
+
 describe("prStatusRows", () => {
 	it("formats the three PR states without exposing raw unknown", () => {
 		const rows = prStatusRows(
@@ -72,16 +84,8 @@ describe("prBrowserUrl", () => {
 
 describe("sessionPRDisplaySummaries", () => {
 	it("leaves lifecycle timing absent for fallback PR facts until provider times arrive", () => {
-		const session: WorkspaceSession = {
-			id: "sess-1",
-			workspaceId: "ws-1",
-			workspaceName: "repo",
-			title: "Fix timing",
-			provider: "codex",
-			branch: "feat/timing",
-			status: "review_pending",
-			updatedAt: "2026-06-15T12:00:00Z",
-			prs: [
+		const [fallback] = sessionPRDisplaySummaries(
+			session([
 				{
 					url: "https://github.com/acme/repo/pull/7",
 					number: 7,
@@ -92,14 +96,102 @@ describe("sessionPRDisplaySummaries", () => {
 					reviewComments: false,
 					updatedAt: "2026-06-15T11:00:00Z",
 				},
-			],
-		};
-
-		const [fallback] = sessionPRDisplaySummaries(session);
+			]),
+		);
 
 		expect(fallback.updatedAt).toBe("2026-06-15T11:00:00Z");
 		expect(fallback.createdAt).toBeUndefined();
 		expect(fallback.stateChangedAt).toBeUndefined();
+	});
+
+	it("deduplicates repeated API summaries before rendering", () => {
+		const got = sessionPRDisplaySummaries(session([]), [
+			summary({ number: 7, title: "first observed PR #7" }),
+			summary({ number: 7, title: "duplicate PR #7" }),
+			summary({ number: 8, title: "PR #8" }),
+		]);
+
+		expect(got.map((pr) => pr.number)).toEqual([7, 8]);
+		expect(got[0].title).toBe("first observed PR #7");
+	});
+
+	it("deduplicates repeated session facts and uses the enriched summary for the surviving card", () => {
+		const got = sessionPRDisplaySummaries(
+			session([
+				{
+					url: "https://github.com/acme/repo/pull/7",
+					number: 7,
+					state: "open",
+					ci: "pending",
+					review: "none",
+					mergeability: "unknown",
+					reviewComments: false,
+					updatedAt: "2026-06-15T10:00:00Z",
+				},
+				{
+					url: "https://github.com/acme/repo/issues/7",
+					number: 7,
+					state: "open",
+					ci: "passing",
+					review: "approved",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T11:00:00Z",
+				},
+			]),
+			[
+				summary({ number: 7, title: "enriched PR #7", ci: { state: "passing", failingChecks: [] } }),
+				summary({ number: 7, title: "duplicate enriched PR #7" }),
+			],
+		);
+
+		expect(got).toHaveLength(1);
+		expect(got[0]).toMatchObject({ number: 7, title: "enriched PR #7", ci: { state: "passing" } });
+	});
+
+	it("keeps the next selected session's PR list independent after a duplicated list", () => {
+		const firstSelection = sessionPRDisplaySummaries(
+			session([
+				{
+					url: "https://github.com/acme/repo/pull/7",
+					number: 7,
+					state: "open",
+					ci: "passing",
+					review: "approved",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T10:00:00Z",
+				},
+				{
+					url: "https://github.com/acme/repo/issues/7",
+					number: 7,
+					state: "open",
+					ci: "passing",
+					review: "approved",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T11:00:00Z",
+				},
+			]),
+			[summary({ number: 7 }), summary({ number: 7 })],
+		);
+		const nextSelection = sessionPRDisplaySummaries(
+			session([
+				{
+					url: "https://github.com/acme/repo/pull/9",
+					number: 9,
+					state: "open",
+					ci: "passing",
+					review: "approved",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T12:00:00Z",
+				},
+			]),
+		);
+
+		expect(firstSelection.map((pr) => pr.number)).toEqual([7]);
+		expect(nextSelection.map((pr) => pr.number)).toEqual([9]);
 	});
 });
 

--- a/frontend/src/renderer/lib/pr-display.ts
+++ b/frontend/src/renderer/lib/pr-display.ts
@@ -59,13 +59,25 @@ export function sessionPRDisplaySummaries(
 	session: WorkspaceSession,
 	summaries: SessionPRSummary[] = [],
 ): SessionPRSummary[] {
-	const summariesByNumber = new Map(summaries.map((summary) => [summary.number, summary]));
+	const summariesByNumber = new Map<number, SessionPRSummary>();
+	for (const summary of summaries) {
+		if (!summariesByNumber.has(summary.number)) {
+			summariesByNumber.set(summary.number, summary);
+		}
+	}
 	const seen = new Set<number>();
-	const fromFacts = sortedPRs(session).map((pr) => {
+	const fromFacts: SessionPRSummary[] = [];
+	for (const pr of sortedPRs(session)) {
+		if (seen.has(pr.number)) continue;
 		seen.add(pr.number);
-		return summariesByNumber.get(pr.number) ?? sessionPRFactToSummary(session, pr);
-	});
-	const summaryOnly = summaries.filter((summary) => !seen.has(summary.number));
+		fromFacts.push(summariesByNumber.get(pr.number) ?? sessionPRFactToSummary(session, pr));
+	}
+	const summaryOnly: SessionPRSummary[] = [];
+	for (const summary of summaries) {
+		if (seen.has(summary.number)) continue;
+		seen.add(summary.number);
+		summaryOnly.push(summary);
+	}
 	return [...fromFacts, ...summaryOnly].sort(comparePRDisplaySummaries);
 }
 

--- a/frontend/src/renderer/lib/pr-display.ts
+++ b/frontend/src/renderer/lib/pr-display.ts
@@ -59,26 +59,145 @@ export function sessionPRDisplaySummaries(
 	session: WorkspaceSession,
 	summaries: SessionPRSummary[] = [],
 ): SessionPRSummary[] {
-	const summariesByNumber = new Map<number, SessionPRSummary>();
-	for (const summary of summaries) {
-		if (!summariesByNumber.has(summary.number)) {
-			summariesByNumber.set(summary.number, summary);
+	const dedupedSummaries = deduplicateSummaries(summaries);
+	const summariesByIdentity = new Map<string, SessionPRSummary>();
+	const summaryNumberCounts = countPRNumbers(dedupedSummaries);
+	const summariesByUniqueNumber = new Map<number, SessionPRSummary>();
+	for (const summary of dedupedSummaries) {
+		for (const key of prDisplayIdentities(summary)) {
+			if (!summariesByIdentity.has(key)) {
+				summariesByIdentity.set(key, summary);
+			}
+		}
+		if (summaryNumberCounts.get(summary.number) === 1) {
+			summariesByUniqueNumber.set(summary.number, summary);
 		}
 	}
-	const seen = new Set<number>();
+	const facts = sortedPRs(session);
+	const factNumberCounts = countPRNumbers(facts);
+	const seen = new Set<string>();
+	const consumedSummaries = new Set<SessionPRSummary>();
 	const fromFacts: SessionPRSummary[] = [];
-	for (const pr of sortedPRs(session)) {
-		if (seen.has(pr.number)) continue;
-		seen.add(pr.number);
-		fromFacts.push(summariesByNumber.get(pr.number) ?? sessionPRFactToSummary(session, pr));
+	for (const pr of facts) {
+		const key = prDisplayIdentity(pr);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		const summary = summariesByIdentity.get(key) ?? uniqueNumberSummary(pr, factNumberCounts, summariesByUniqueNumber);
+		if (summary) {
+			for (const summaryKey of prDisplayIdentities(summary)) {
+				seen.add(summaryKey);
+			}
+			consumedSummaries.add(summary);
+		}
+		fromFacts.push(summary ?? sessionPRFactToSummary(session, pr));
 	}
 	const summaryOnly: SessionPRSummary[] = [];
-	for (const summary of summaries) {
-		if (seen.has(summary.number)) continue;
-		seen.add(summary.number);
+	for (const summary of dedupedSummaries) {
+		const keys = prDisplayIdentities(summary);
+		if (keys.some((key) => seen.has(key))) continue;
+		if (consumedSummaries.has(summary)) continue;
+		for (const key of keys) {
+			seen.add(key);
+		}
 		summaryOnly.push(summary);
 	}
 	return [...fromFacts, ...summaryOnly].sort(comparePRDisplaySummaries);
+}
+
+function deduplicateSummaries(summaries: SessionPRSummary[]): SessionPRSummary[] {
+	const seen = new Set<string>();
+	const out: SessionPRSummary[] = [];
+	for (const summary of summaries) {
+		const keys = prDisplayIdentities(summary);
+		if (keys.some((key) => seen.has(key))) continue;
+		for (const key of keys) {
+			seen.add(key);
+		}
+		out.push(summary);
+	}
+	return out;
+}
+
+function countPRNumbers(prs: Array<Pick<SessionPRSummary, "number"> | PullRequestFacts>): Map<number, number> {
+	const counts = new Map<number, number>();
+	for (const pr of prs) {
+		counts.set(pr.number, (counts.get(pr.number) ?? 0) + 1);
+	}
+	return counts;
+}
+
+function uniqueNumberSummary(
+	pr: PullRequestFacts,
+	factNumberCounts: Map<number, number>,
+	summariesByUniqueNumber: Map<number, SessionPRSummary>,
+): SessionPRSummary | undefined {
+	if (factNumberCounts.get(pr.number) !== 1) return undefined;
+	return summariesByUniqueNumber.get(pr.number);
+}
+
+function prDisplayIdentity(pr: Pick<SessionPRSummary, "number" | "url" | "htmlUrl" | "repo"> | PullRequestFacts): string {
+	const url = "htmlUrl" in pr ? pr.htmlUrl || pr.url : pr.url;
+	const github = githubPRIdentity(url, pr.number);
+	if (github) return github;
+	const repo = "repo" in pr ? pr.repo.trim().toLowerCase() : "";
+	if (repo) return `repo:${repo}#${pr.number}`;
+	return `number:${pr.number}`;
+}
+
+function prDisplayIdentities(pr: SessionPRSummary): string[] {
+	const keys = [prDisplayIdentity(pr)];
+	const alias = prTransferAliasIdentity(pr);
+	if (alias) keys.push(alias);
+	return keys;
+}
+
+function githubPRIdentity(rawURL: string, expectedNumber: number): string | undefined {
+	try {
+		const url = new URL(rawURL);
+		const host = url.hostname.toLowerCase();
+		if (host !== "github.com" && !host.endsWith(".github.com")) return undefined;
+		const [, owner, repoName, kind, number] = url.pathname.split("/");
+		if ((kind !== "pull" && kind !== "issues") || !owner || !repoName || !number) return undefined;
+		if (Number(number) !== expectedNumber) return undefined;
+		return `github:${host}/${owner.toLowerCase()}/${repoName.toLowerCase()}#${number}`;
+	} catch {
+		return undefined;
+	}
+}
+
+function prTransferAliasIdentity(pr: SessionPRSummary): string | undefined {
+	const github = githubPRAliasParts(pr.htmlUrl || pr.url, pr.number);
+	if (!github) return undefined;
+	const sourceBranch = normalizedAliasPart(pr.sourceBranch);
+	const headSha = normalizedAliasPart(pr.headSha);
+	if (!sourceBranch || !headSha) return undefined;
+	return [
+		"github-transfer",
+		github.host,
+		github.repoName,
+		String(pr.number),
+		sourceBranch,
+		normalizedAliasPart(pr.targetBranch),
+		headSha,
+	].join("|");
+}
+
+function githubPRAliasParts(rawURL: string, expectedNumber: number): { host: string; repoName: string } | undefined {
+	try {
+		const url = new URL(rawURL);
+		const host = url.hostname.toLowerCase();
+		if (host !== "github.com" && !host.endsWith(".github.com")) return undefined;
+		const [, owner, repoName, kind, number] = url.pathname.split("/");
+		if ((kind !== "pull" && kind !== "issues") || !owner || !repoName || !number) return undefined;
+		if (Number(number) !== expectedNumber) return undefined;
+		return { host, repoName: repoName.toLowerCase() };
+	} catch {
+		return undefined;
+	}
+}
+
+function normalizedAliasPart(value: string): string {
+	return value.trim().toLowerCase();
 }
 
 function sessionPRFactToSummary(session: WorkspaceSession, pr: PullRequestFacts): SessionPRSummary {


### PR DESCRIPTION
## Summary
- Deduplicate PR display summaries by stable display identity instead of PR number alone, so transferred GitHub repo aliases collapse while same-number PRs from different repos stay distinct.
- Add backend session-service alias grouping for high-confidence transferred GitHub PR URLs, preserving the newest/current PR row while merging checks, reviews, threads, and comments from alias rows into the read model.
- Apply alias dedupe to session PR facts used by board/sidebar status and add regressions for transferred repo aliases, duplicate API summaries, duplicate session facts, mixed fact/summary URLs, and session switching after duplicates.

Closes #3242

## Tests
- go test ./internal/service/session
- npm --prefix frontend run typecheck
- cd frontend && npm test

## Notes
- npm --prefix frontend run build is not available in frontend/package.json; available package build-like scripts are package/make/publish.
