### PR TITLE
fix: attach PRs after repo transfer

### DIFF
--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -497,14 +497,7 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 			if !found || !p.ArchivedAt.IsZero() {
 				continue
 			}
-			if p.RepoOriginURL == "" && p.Path != "" {
-				if url := resolveGitOriginURL(p.Path); url != "" {
-					p.RepoOriginURL = url
-					if err := o.store.UpsertProject(ctx, p); err != nil {
-						o.logger.Warn("scm observer: backfill origin URL persist failed", "project", p.ID, "err", err)
-					}
-				}
-			}
+			p = o.refreshProjectOriginURL(ctx, p)
 			projects[sess.ProjectID] = p
 			proj = p
 			if origin, ok := o.provider.ParseRepository(p.RepoOriginURL); ok {
@@ -550,6 +543,34 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 		}
 	}
 	return out, sessionRepos, nil
+}
+
+func (o *Observer) refreshProjectOriginURL(ctx context.Context, p domain.ProjectRecord) domain.ProjectRecord {
+	if strings.TrimSpace(p.Path) == "" {
+		return p
+	}
+	url := resolveGitOriginURLFunc(p.Path)
+	if strings.TrimSpace(url) == "" {
+		return p
+	}
+	current, currentOK := o.provider.ParseRepository(url)
+	if !currentOK {
+		return p
+	}
+	if persisted, persistedOK := o.provider.ParseRepository(p.RepoOriginURL); persistedOK && sameRepoIdentity(persisted, current) {
+		return p
+	}
+	p.RepoOriginURL = url
+	if err := o.store.UpsertProject(ctx, p); err != nil {
+		o.logger.Warn("scm observer: refresh origin URL persist failed", "project", p.ID, "err", err)
+	}
+	return p
+}
+
+func sameRepoIdentity(a, b ports.SCMRepo) bool {
+	return strings.EqualFold(a.Provider, b.Provider) &&
+		strings.EqualFold(a.Host, b.Host) &&
+		strings.EqualFold(repoFullName(a), repoFullName(b))
 }
 
 // resolveScanRepos returns the deduped set of repos whose open-PR lists should be
@@ -1486,6 +1507,8 @@ func resolveGitOriginURL(path string) string {
 	}
 	return strings.TrimSpace(string(out))
 }
+
+var resolveGitOriginURLFunc = resolveGitOriginURL
 
 // gitRemoteURLs lists the fetch URL of every git remote configured at path. It
 // returns nil on any error (missing repo, no git, no remotes). The observer uses

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -915,6 +915,58 @@ func TestPoll_DiscoversCrossForkPRFromUpstreamRemote(t *testing.T) {
 	}
 }
 
+func TestPoll_DiscoversPRAfterProjectOriginTransfer(t *testing.T) {
+	dir := t.TempDir()
+	mustGit(t, "init", dir)
+	mustGit(t, "-C", dir, "remote", "add", "origin", "https://github.com/new-owner/r.git")
+
+	movedRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "new-owner", Name: "r", Repo: "new-owner/r"}
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "ao/p-1/root"}}},
+		projects: map[string]domain.ProjectRecord{"p": {
+			ID:            "p",
+			Path:          dir,
+			RepoOriginURL: "https://github.com/old-owner/r.git",
+		}},
+		prs:    map[domain.SessionID][]domain.PullRequest{},
+		checks: map[string][]domain.PullRequestCheck{},
+	}
+	movedObs := ports.SCMObservation{
+		Fetched: true, Provider: "github", Host: "github.com", Repo: "new-owner/r",
+		PR:           ports.SCMPRObservation{URL: "https://github.com/new-owner/r/pull/3250", Number: 3250, State: "open", SourceBranch: "ao/p-1/fix", HeadRepo: "new-owner/r", TargetBranch: "main", HeadSHA: "sha1", Title: "PR"},
+		CI:           ports.SCMCIObservation{Summary: string(domain.CIPassing), HeadSHA: "sha1"},
+		Review:       ports.SCMReviewObservation{Decision: string(domain.ReviewNone)},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeMergeable), Mergeable: true},
+	}
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{prKey(movedRepo, 0): {ETag: "moved"}},
+		openPRs: map[string][]ports.SCMPRObservation{
+			prKey(movedRepo, 0): {{URL: "https://github.com/new-owner/r/pull/3250", Number: 3250, SourceBranch: "ao/p-1/fix", HeadRepo: "new-owner/r", TargetBranch: "main", HeadSHA: "sha1"}},
+		},
+		observations: map[string]ports.SCMObservation{prKey(movedRepo, 3250): movedObs},
+	}
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.projects["p"].RepoOriginURL; got != "https://github.com/new-owner/r.git" {
+		t.Fatalf("project origin = %q, want moved origin", got)
+	}
+	if len(store.writes) == 0 {
+		t.Fatal("expected moved-repo PR write")
+	}
+	if got := store.writes[0].pr.Repo; got != "new-owner/r" {
+		t.Fatalf("written repo = %q, want new-owner/r", got)
+	}
+	if got := store.writes[0].pr.SessionID; got != "p-1" {
+		t.Fatalf("session id = %q, want p-1", got)
+	}
+	if len(lc.observed) != 1 {
+		t.Fatalf("lifecycle observations = %d, want 1", len(lc.observed))
+	}
+}
+
 // A PR on a scanned upstream remote whose head lives in some third-party fork
 // (not this project's origin) must never be attributed, even though its branch
 // name matches a session. Scanning extra remotes stays safe.

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2647,7 +2647,7 @@ func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issu
 		env[EnvBrowserCapability] = m.browserCapabilities.Token(id)
 	}
 	env[EnvBrowserRuntimeToken] = ""
-	path, err := HookPATH(m.executable, os.Getenv, projectEnv)
+	path, err := HookPATH(m.executable, os.Getenv, env)
 	if err != nil {
 		m.logger.Warn("session PATH not pinned to the daemon binary; `ao hooks` callbacks may resolve to a different ao and activity tracking will stall",
 			"session", id, "error", err)
@@ -2658,12 +2658,14 @@ func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issu
 }
 
 // HookPATH builds the PATH value pinned into a spawned session: the daemon
-// executable's directory prepended to the base PATH (the project's PATH
-// override when set, else the daemon's inherited PATH — matching what the
-// runtime would have exported anyway). An error means the pin cannot be
-// applied: the executable is unresolvable, or is not named "ao", in which case
-// prepending its directory would not change what `ao` resolves to. Exported so
-// the reviewer launcher can pin its pane's PATH the same way.
+// executable's directory first, AO's wrapper bin second, then the base PATH (the
+// project's PATH override when set, else the daemon's inherited PATH — matching
+// what the runtime would have exported anyway). This keeps bare `ao` hook
+// commands tied to the running daemon while letting AO's gh/git wrappers beat
+// Homebrew/system binaries. An error means the daemon pin cannot be applied: the
+// executable is unresolvable, or is not named "ao", in which case prepending its
+// directory would not change what `ao` resolves to. Exported so the reviewer
+// launcher can pin its pane's PATH the same way.
 func HookPATH(executable func() (string, error), getenv func(string) string, projectEnv map[string]string) (string, error) {
 	exe, err := executable()
 	if err != nil {
@@ -2681,10 +2683,39 @@ func HookPATH(executable func() (string, error), getenv func(string) string, pro
 		base = getenv("PATH")
 	}
 	dir := filepath.Dir(exe)
-	if base == "" {
-		return dir, nil
+	parts := []string{dir}
+	if wrapperDir := hookWrapperBinDir(projectEnv, getenv); wrapperDir != "" && !samePath(dir, wrapperDir) {
+		parts = append(parts, wrapperDir)
 	}
-	return dir + string(os.PathListSeparator) + base, nil
+	if base != "" {
+		parts = append(parts, base)
+	}
+	return strings.Join(parts, string(os.PathListSeparator)), nil
+}
+
+func hookWrapperBinDir(env map[string]string, getenv func(string) string) string {
+	if dataDir := strings.TrimSpace(env[EnvDataDir]); dataDir != "" && filepath.Base(filepath.Clean(dataDir)) == "data" {
+		return filepath.Join(filepath.Dir(filepath.Clean(dataDir)), "bin")
+	}
+	if runFile := strings.TrimSpace(getenv("AO_RUN_FILE")); runFile != "" {
+		return filepath.Join(filepath.Dir(filepath.Clean(runFile)), "bin")
+	}
+	if home := strings.TrimSpace(getenv("HOME")); home != "" {
+		return filepath.Join(home, ".ao", "bin")
+	}
+	if home := strings.TrimSpace(getenv("USERPROFILE")); home != "" {
+		return filepath.Join(home, ".ao", "bin")
+	}
+	return ""
+}
+
+func samePath(a, b string) bool {
+	cleanA := filepath.Clean(a)
+	cleanB := filepath.Clean(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(cleanA, cleanB)
+	}
+	return cleanA == cleanB
 }
 
 // provisionWorkspace applies the project's per-workspace setup after the

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -4003,6 +4003,7 @@ func pathPinManager(executable func() (string, error)) (*Manager, *fakeStore, *f
 	m := New(Deps{
 		Runtime: rt, Agents: fakeAgents{}, Workspace: &fakeWorkspace{}, Store: st,
 		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+		DataDir:  filepath.Join(string(os.PathSeparator), "ao", "data"),
 		LookPath: lookPath, Executable: executable,
 		Logger: slog.New(slog.NewTextHandler(logBuf, nil)),
 	})
@@ -4017,7 +4018,7 @@ func pathPinManager(executable func() (string, error)) (*Manager, *fakeStore, *f
 // kills activity tracking).
 func TestSpawnAndRestore_PinHookPATHToDaemonBinary(t *testing.T) {
 	daemonExe := filepath.Join(t.TempDir(), "ao")
-	want := filepath.Dir(daemonExe) + string(os.PathListSeparator) + "/usr/bin"
+	want := strings.Join([]string{filepath.Dir(daemonExe), filepath.Join(string(os.PathSeparator), "ao", "bin"), "/usr/bin"}, string(os.PathListSeparator))
 	executable := func() (string, error) { return daemonExe, nil }
 
 	cases := []struct {
@@ -4094,7 +4095,7 @@ func TestSpawn_ProjectPATHIsPinBase(t *testing.T) {
 	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
 		t.Fatal(err)
 	}
-	want := filepath.Dir(daemonExe) + string(os.PathListSeparator) + "/proj/bin"
+	want := strings.Join([]string{filepath.Dir(daemonExe), filepath.Join(string(os.PathSeparator), "ao", "bin"), "/proj/bin"}, string(os.PathListSeparator))
 	if got := rt.lastCfg.Env["PATH"]; got != want {
 		t.Fatalf("runtime env PATH = %q, want %q", got, want)
 	}
@@ -4123,7 +4124,7 @@ func TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH(t *testi
 			t.Fatal(err)
 		}
 	}
-	want := strings.Join([]string{binDir, nodeDir, filepath.Dir(daemonExe), "/usr/bin"}, string(os.PathListSeparator))
+	want := strings.Join([]string{binDir, nodeDir, filepath.Dir(daemonExe), filepath.Join(home, ".ao", "bin"), "/usr/bin"}, string(os.PathListSeparator))
 
 	for _, operation := range []string{"spawn", "restore"} {
 		t.Run(operation, func(t *testing.T) {
@@ -4138,6 +4139,7 @@ func TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH(t *testi
 			m := New(Deps{
 				Runtime: rt, Agents: singleAgent{agent: agent}, Workspace: &fakeWorkspace{path: "/ws/mer-1"},
 				Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+				DataDir: filepath.Join(home, ".ao", "data"),
 				LookPath: func(name string) (string, error) {
 					if name == "node" {
 						return "", exec.ErrNotFound
@@ -4182,6 +4184,7 @@ func TestSpawn_DoesNotAddNodeRuntimeForNativeBinary(t *testing.T) {
 	m := New(Deps{
 		Runtime: rt, Agents: singleAgent{agent: launchArgvAgent{argv: []string{agentBin}}}, Workspace: &fakeWorkspace{},
 		Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+		DataDir: filepath.Join(string(os.PathSeparator), "ao", "data"),
 		LookPath: func(name string) (string, error) {
 			if name == "node" {
 				nodeLookups++

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -71,8 +71,15 @@ func TestHookPATH(t *testing.T) {
 			name:       "project PATH override is the base",
 			executable: exeOK,
 			daemonPATH: "/usr/bin",
-			projectEnv: map[string]string{"PATH": "/proj/bin"},
-			want:       daemonDir + sep + "/proj/bin",
+			projectEnv: map[string]string{"PATH": "/proj/bin", EnvDataDir: "/home/me/.ao/data"},
+			want:       daemonDir + sep + "/home/me/.ao/bin" + sep + "/proj/bin",
+		},
+		{
+			name:       "wrapper bin precedes inherited PATH when data dir is known",
+			executable: exeOK,
+			daemonPATH: "/usr/bin",
+			projectEnv: map[string]string{EnvDataDir: "/home/me/.ao/data"},
+			want:       daemonDir + sep + "/home/me/.ao/bin" + sep + "/usr/bin",
 		},
 		{
 			name:       "empty base PATH yields the daemon dir alone",


### PR DESCRIPTION
## Summary

- refresh stale project GitHub origins from the local origin remote before SCM discovery
- keep daemon `ao` pinned first in spawned session PATH while placing AO wrapper bin ahead of system `gh`/`git`
- add regressions for moved-repo PR discovery and wrapper PATH precedence

Fixes #3252

## Tests

- `go test ./internal/observe/scm`
- `go test ./internal/session_manager`
- `env -u AO_SESSION_ID -u AO_RUNTIME_LAUNCH_ID -u AO_PROJECT_ID -u AO_ISSUE_ID go test ./...`

## Notes

- A plain `go test ./...` inside an AO worker inherits AO session env vars and currently makes unrelated `internal/cli` tests fail; rerunning with those vars unset passes.