### PR TITLE
feat(runtime): Daytona sandbox runtime adapter (phase 2)

### DIFF
--- a/backend/internal/adapters/runtime/daytona/attach.go
+++ b/backend/internal/adapters/runtime/daytona/attach.go
@@ -1,0 +1,92 @@
+// attach.go - Daytona Attach: a ports.Stream over the sandbox's PTY
+// WebSocket. Every AO client attach creates its own fresh PTY session running
+// `tmux attach`, so multiple viewers share the tmux window exactly like the
+// local tmux adapter (largest client drives the shared grid via tmux's
+// window-size largest). All connectivity is outbound: daemon → Daytona's
+// toolbox proxy; the sandbox exposes no inbound port.
+package daytona
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+var _ ports.Attacher = (*Runtime)(nil)
+
+// Attach opens a fresh attach Stream for the session, sized rows x cols from
+// birth (0 means unknown; the terminal manager resizes on join). ctx
+// cancellation terminates the stream.
+func (r *Runtime) Attach(ctx context.Context, handle ports.RuntimeHandle, rows, cols uint16) (ports.Stream, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return nil, err
+	}
+	sb, found, err := r.sandboxForHandle(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("daytona runtime: no sandbox for session %s", id)
+	}
+	if sb.State != StateStarted {
+		return nil, fmt.Errorf("daytona runtime: sandbox for session %s is %s; cannot attach while parked", id, sb.State)
+	}
+	if rows == 0 {
+		rows = 50
+	}
+	if cols == 0 {
+		cols = 220
+	}
+	conn, err := r.client.OpenPTY(ctx, sb.ID, PTYSpec{
+		ID:   attachPTYID(id),
+		Rows: rows,
+		Cols: cols,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("daytona runtime: open pty for %s: %w", id, err)
+	}
+	// Daytona's PTY create takes no command: the PTY runs the sandbox user's
+	// shell, and the first input line execs the tmux attach client. tmux's
+	// full-screen repaint immediately overwrites the echoed command line.
+	if _, err := conn.Write([]byte(attachCommand(id))); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("daytona runtime: start attach for %s: %w", id, err)
+	}
+	s := &ptyStream{conn: conn}
+	go func() {
+		<-ctx.Done()
+		_ = s.Close()
+	}()
+	return s, nil
+}
+
+// attachPTYID names one attach's PTY session; unique per attach so concurrent
+// viewers never collide on Daytona's per-sandbox PTY id namespace.
+func attachPTYID(handle string) string {
+	var suffix [4]byte
+	_, _ = rand.Read(suffix[:])
+	base := handle
+	if len(base) > 32 {
+		base = base[:32]
+	}
+	return "ao-attach-" + base + "-" + hex.EncodeToString(suffix[:])
+}
+
+// ptyStream adapts a PTYConn to ports.Stream (Resize signature).
+type ptyStream struct {
+	conn PTYConn
+}
+
+var _ ports.Stream = (*ptyStream)(nil)
+
+func (s *ptyStream) Read(b []byte) (int, error)  { return s.conn.Read(b) }
+func (s *ptyStream) Write(b []byte) (int, error) { return s.conn.Write(b) }
+func (s *ptyStream) Close() error                { return s.conn.Close() }
+
+func (s *ptyStream) Resize(rows, cols uint16) error {
+	return s.conn.Resize(rows, cols)
+}

--- a/backend/internal/adapters/runtime/daytona/client.go
+++ b/backend/internal/adapters/runtime/daytona/client.go
@@ -1,0 +1,474 @@
+package daytona
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/coder/websocket"
+)
+
+// SandboxState is Daytona's sandbox state enum (the subset the adapter
+// branches on; unknown values flow through unmodified).
+type SandboxState string
+
+const (
+	StateCreating        SandboxState = "creating"
+	StateStarting        SandboxState = "starting"
+	StateStarted         SandboxState = "started"
+	StateStopping        SandboxState = "stopping"
+	StateStopped         SandboxState = "stopped"
+	StateRestoring       SandboxState = "restoring"
+	StateResuming        SandboxState = "resuming"
+	StatePullingSnapshot SandboxState = "pulling_snapshot"
+	StateArchiving       SandboxState = "archiving"
+	StateArchived        SandboxState = "archived"
+	StateError           SandboxState = "error"
+	StateBuildFailed     SandboxState = "build_failed"
+	StateDestroying      SandboxState = "destroying"
+	StateDestroyed       SandboxState = "destroyed"
+)
+
+// Transitional reports whether the state is on its way to a steady state, so
+// pollers keep waiting instead of failing.
+func (s SandboxState) Transitional() bool {
+	switch s {
+	case StateCreating, StateStarting, StateStopping, StateRestoring,
+		StateResuming, StatePullingSnapshot, StateArchiving, StateDestroying:
+		return true
+	}
+	return false
+}
+
+// Sandbox is the subset of Daytona's sandbox object the adapter uses.
+type Sandbox struct {
+	ID     string            `json:"id"`
+	Name   string            `json:"name"`
+	State  SandboxState      `json:"state"`
+	Labels map[string]string `json:"labels"`
+	// ToolboxProxyURL is the base for the per-sandbox toolbox API; requests go
+	// to {ToolboxProxyURL}/{ID}/... with the same bearer key.
+	ToolboxProxyURL string `json:"toolboxProxyUrl"`
+	ErrorReason     string `json:"errorReason"`
+}
+
+// CreateSandboxRequest mirrors Daytona's CreateSandbox body (fields we use).
+type CreateSandboxRequest struct {
+	Name     string            `json:"name,omitempty"`
+	Snapshot string            `json:"snapshot,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty"`
+	Target   string            `json:"target,omitempty"`
+	CPU      int               `json:"cpu,omitempty"`
+	Memory   int               `json:"memory,omitempty"`
+	Disk     int               `json:"disk,omitempty"`
+	// AutoStopInterval is minutes without activity before Daytona stops the
+	// sandbox (0 disables). Stopping kills processes but preserves the disk —
+	// this is the park mechanism in the cost model.
+	AutoStopInterval    *int `json:"autoStopInterval,omitempty"`
+	AutoArchiveInterval *int `json:"autoArchiveInterval,omitempty"`
+	AutoDeleteInterval  *int `json:"autoDeleteInterval,omitempty"`
+}
+
+// ExecRequest is one toolbox `POST /process/execute` call: a shell command run
+// inside the sandbox.
+type ExecRequest struct {
+	Command string `json:"command"`
+	Cwd     string `json:"cwd,omitempty"`
+	// TimeoutSeconds bounds the command inside the sandbox (Daytona defaults to
+	// 10s when zero).
+	TimeoutSeconds int `json:"timeout,omitempty"`
+}
+
+// ExecResult carries the command's combined output and exit code.
+type ExecResult struct {
+	ExitCode int    `json:"exitCode"`
+	Result   string `json:"result"`
+}
+
+// PTYSpec asks the toolbox for a fresh interactive PTY (the sandbox user's
+// shell; Daytona's PTY create takes no command).
+type PTYSpec struct {
+	ID   string
+	Cwd  string
+	Rows uint16
+	Cols uint16
+}
+
+// PTYConn is one live PTY WebSocket: Read yields terminal output bytes, Write
+// sends input bytes, Resize resizes the remote PTY, Close tears down the
+// connection AND deletes the PTY session in the sandbox.
+type PTYConn interface {
+	io.ReadWriteCloser
+	Resize(rows, cols uint16) error
+}
+
+// Client is the adapter's seam onto Daytona. The production implementation is
+// apiClient (thin REST); tests substitute a fake.
+type Client interface {
+	CreateSandbox(ctx context.Context, req CreateSandboxRequest) (Sandbox, error)
+	// GetSandbox returns ErrSandboxNotFound (wrapped) when no sandbox has that id.
+	GetSandbox(ctx context.Context, id string) (Sandbox, error)
+	// ListSandboxes returns sandboxes carrying every given label.
+	ListSandboxes(ctx context.Context, labels map[string]string) ([]Sandbox, error)
+	StartSandbox(ctx context.Context, id string) error
+	StopSandbox(ctx context.Context, id string) error
+	DeleteSandbox(ctx context.Context, id string) error
+	// Exec runs a shell command in the sandbox via the toolbox API. A non-zero
+	// exit code is returned in ExecResult with err == nil; err reports
+	// transport/API failures only, so callers can tell "command failed"
+	// (definitive) from "probe failed" (inconclusive).
+	Exec(ctx context.Context, sandboxID string, req ExecRequest) (ExecResult, error)
+	// OpenPTY creates a PTY session in the sandbox and dials its WebSocket.
+	OpenPTY(ctx context.Context, sandboxID string, spec PTYSpec) (PTYConn, error)
+	// GitClone clones a repository inside the sandbox via the toolbox git API
+	// (credentials travel in the request body, never on a command line).
+	GitClone(ctx context.Context, sandboxID string, req GitCloneRequest) error
+}
+
+// GitCloneRequest mirrors the toolbox `POST /git/clone` body (fields we use).
+type GitCloneRequest struct {
+	URL      string `json:"url"`
+	Path     string `json:"path"`
+	Branch   string `json:"branch,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// ErrSandboxNotFound reports a sandbox id/name Daytona does not know (404) —
+// a definitive "gone", distinct from transport failures.
+var ErrSandboxNotFound = errors.New("daytona: sandbox not found")
+
+// DefaultAPIURL is Daytona's public platform API base.
+const DefaultAPIURL = "https://app.daytona.io/api"
+
+// ClientOptions configures the REST client. APIKey is required; APIURL
+// defaults to DefaultAPIURL; HTTPClient defaults to http.DefaultClient.
+type ClientOptions struct {
+	APIKey     string
+	APIURL     string
+	HTTPClient *http.Client
+}
+
+// NewClient builds the production REST client for Daytona's platform and
+// toolbox APIs.
+func NewClient(opts ClientOptions) (*apiClient, error) {
+	if strings.TrimSpace(opts.APIKey) == "" {
+		return nil, errors.New("daytona: api key is required")
+	}
+	base := strings.TrimRight(opts.APIURL, "/")
+	if base == "" {
+		base = DefaultAPIURL
+	}
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &apiClient{apiURL: base, apiKey: opts.APIKey, http: httpClient}, nil
+}
+
+// apiClient is the thin REST implementation of Client.
+type apiClient struct {
+	apiURL string
+	apiKey string
+	http   *http.Client
+}
+
+var _ Client = (*apiClient)(nil)
+
+// apiError is a non-2xx platform/toolbox response.
+type apiError struct {
+	Status int
+	Body   string
+}
+
+func (e *apiError) Error() string {
+	body := e.Body
+	if len(body) > 512 {
+		body = body[:512] + "…"
+	}
+	return fmt.Sprintf("daytona: HTTP %d: %s", e.Status, body)
+}
+
+func (c *apiClient) do(ctx context.Context, method, urlStr string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("daytona: marshal request: %w", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, urlStr, reader)
+	if err != nil {
+		return fmt.Errorf("daytona: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("daytona: %s %s: %w", method, urlStr, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return fmt.Errorf("daytona: read response: %w", err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("%w: %s %s", ErrSandboxNotFound, method, urlStr)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return &apiError{Status: resp.StatusCode, Body: string(data)}
+	}
+	if out != nil && len(data) > 0 {
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("daytona: decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *apiClient) platformURL(parts ...string) string {
+	escaped := make([]string, len(parts))
+	for i, p := range parts {
+		escaped[i] = url.PathEscape(p)
+	}
+	return c.apiURL + "/" + strings.Join(escaped, "/")
+}
+
+func (c *apiClient) CreateSandbox(ctx context.Context, req CreateSandboxRequest) (Sandbox, error) {
+	var sb Sandbox
+	err := c.do(ctx, http.MethodPost, c.platformURL("sandbox"), req, &sb)
+	return sb, err
+}
+
+func (c *apiClient) GetSandbox(ctx context.Context, id string) (Sandbox, error) {
+	var sb Sandbox
+	err := c.do(ctx, http.MethodGet, c.platformURL("sandbox", id), nil, &sb)
+	return sb, err
+}
+
+// ListSandboxes filters by labels using the platform list endpoint's
+// JSON-encoded `labels` query parameter.
+func (c *apiClient) ListSandboxes(ctx context.Context, labels map[string]string) ([]Sandbox, error) {
+	u := c.platformURL("sandbox")
+	if len(labels) > 0 {
+		encoded, err := json.Marshal(labels)
+		if err != nil {
+			return nil, fmt.Errorf("daytona: encode labels: %w", err)
+		}
+		u += "?labels=" + url.QueryEscape(string(encoded))
+	}
+	// The list endpoint may respond either with a bare array or a paginated
+	// {items: []} envelope depending on API version; accept both.
+	var raw json.RawMessage
+	if err := c.do(ctx, http.MethodGet, u, nil, &raw); err != nil {
+		return nil, err
+	}
+	var list []Sandbox
+	if err := json.Unmarshal(raw, &list); err == nil {
+		return list, nil
+	}
+	var envelope struct {
+		Items []Sandbox `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("daytona: decode sandbox list: %w", err)
+	}
+	return envelope.Items, nil
+}
+
+func (c *apiClient) StartSandbox(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodPost, c.platformURL("sandbox", id, "start"), nil, nil)
+}
+
+func (c *apiClient) StopSandbox(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodPost, c.platformURL("sandbox", id, "stop"), nil, nil)
+}
+
+func (c *apiClient) DeleteSandbox(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodDelete, c.platformURL("sandbox", id), nil, nil)
+}
+
+// toolboxURL resolves the sandbox's toolbox base ({toolboxProxyUrl}/{id})
+// and appends the path parts.
+func (c *apiClient) toolboxURL(ctx context.Context, sandboxID string, parts ...string) (string, error) {
+	sb, err := c.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return "", err
+	}
+	if sb.ToolboxProxyURL == "" {
+		return "", fmt.Errorf("daytona: sandbox %s has no toolbox proxy url", sandboxID)
+	}
+	base := strings.TrimRight(sb.ToolboxProxyURL, "/") + "/" + url.PathEscape(sb.ID)
+	for _, p := range parts {
+		base += "/" + p
+	}
+	return base, nil
+}
+
+func (c *apiClient) Exec(ctx context.Context, sandboxID string, req ExecRequest) (ExecResult, error) {
+	u, err := c.toolboxURL(ctx, sandboxID, "process", "execute")
+	if err != nil {
+		return ExecResult{}, err
+	}
+	var res ExecResult
+	if err := c.do(ctx, http.MethodPost, u, req, &res); err != nil {
+		return ExecResult{}, err
+	}
+	return res, nil
+}
+
+func (c *apiClient) GitClone(ctx context.Context, sandboxID string, req GitCloneRequest) error {
+	u, err := c.toolboxURL(ctx, sandboxID, "git", "clone")
+	if err != nil {
+		return err
+	}
+	return c.do(ctx, http.MethodPost, u, req, nil)
+}
+
+// ptyExitControlSubprotocol asks Daytona's PTY WebSocket to send a JSON
+// control frame carrying the exit code when the PTY process ends.
+const ptyExitControlSubprotocol = "X-Daytona-Pty-Exit-Control"
+
+func (c *apiClient) OpenPTY(ctx context.Context, sandboxID string, spec PTYSpec) (PTYConn, error) {
+	createURL, err := c.toolboxURL(ctx, sandboxID, "process", "pty")
+	if err != nil {
+		return nil, err
+	}
+	createBody := map[string]any{
+		"id":   spec.ID,
+		"cols": int(spec.Cols),
+		"rows": int(spec.Rows),
+	}
+	if spec.Cwd != "" {
+		createBody["cwd"] = spec.Cwd
+	}
+	var created struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := c.do(ctx, http.MethodPost, createURL, createBody, &created); err != nil {
+		return nil, err
+	}
+	sessionID := created.SessionID
+	if sessionID == "" {
+		sessionID = spec.ID
+	}
+
+	connectURL, err := c.toolboxURL(ctx, sandboxID, "process", "pty", url.PathEscape(sessionID), "connect")
+	if err != nil {
+		return nil, err
+	}
+	wsURL := strings.Replace(strings.Replace(connectURL, "https://", "wss://", 1), "http://", "ws://", 1)
+	//nolint:bodyclose // coder/websocket owns the hijacked connection; resp body is drained internally.
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPClient:   c.http,
+		HTTPHeader:   http.Header{"Authorization": {"Bearer " + c.apiKey}},
+		Subprotocols: []string{ptyExitControlSubprotocol},
+	})
+	if err != nil {
+		c.deletePTY(ctx, sandboxID, sessionID)
+		return nil, fmt.Errorf("daytona: dial pty %s: %w", sessionID, err)
+	}
+	// Terminal streams are unbounded; do not cap reads at the library default.
+	conn.SetReadLimit(-1)
+	return &ptyConn{
+		client:    c,
+		sandboxID: sandboxID,
+		sessionID: sessionID,
+		conn:      conn,
+	}, nil
+}
+
+// deletePTY best-effort removes a PTY session; failures are dropped (the
+// sandbox reaps dead PTYs with the process tree).
+func (c *apiClient) deletePTY(ctx context.Context, sandboxID, sessionID string) {
+	u, err := c.toolboxURL(ctx, sandboxID, "process", "pty", url.PathEscape(sessionID))
+	if err != nil {
+		return
+	}
+	_ = c.do(ctx, http.MethodDelete, u, nil, nil)
+}
+
+// ptyConn adapts the Daytona PTY WebSocket to PTYConn. Binary frames carry
+// terminal bytes in both directions; JSON text control frames
+// ({type:"control", status:"connected"|"exited"}) are consumed internally.
+type ptyConn struct {
+	client    *apiClient
+	sandboxID string
+	sessionID string
+	conn      *websocket.Conn
+	// buf holds the unread tail of the last frame.
+	buf []byte
+}
+
+var _ PTYConn = (*ptyConn)(nil)
+
+func (p *ptyConn) Read(b []byte) (int, error) {
+	for len(p.buf) == 0 {
+		typ, data, err := p.conn.Read(context.Background())
+		if err != nil {
+			status := websocket.CloseStatus(err)
+			if status == websocket.StatusNormalClosure || status == websocket.StatusGoingAway {
+				return 0, io.EOF
+			}
+			return 0, err
+		}
+		if typ == websocket.MessageText && isControlFrame(data) {
+			var ctrl struct {
+				Status string `json:"status"`
+			}
+			if json.Unmarshal(data, &ctrl) == nil && ctrl.Status == "exited" {
+				return 0, io.EOF
+			}
+			continue
+		}
+		p.buf = data
+	}
+	n := copy(b, p.buf)
+	p.buf = p.buf[n:]
+	return n, nil
+}
+
+// isControlFrame reports whether a text frame is a Daytona control message
+// rather than terminal output that happened to arrive as text.
+func isControlFrame(data []byte) bool {
+	var ctrl struct {
+		Type string `json:"type"`
+	}
+	return json.Unmarshal(data, &ctrl) == nil && ctrl.Type == "control"
+}
+
+func (p *ptyConn) Write(b []byte) (int, error) {
+	if err := p.conn.Write(context.Background(), websocket.MessageBinary, b); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+func (p *ptyConn) Resize(rows, cols uint16) error {
+	ctx, cancel := context.WithTimeout(context.Background(), resizeTimeout)
+	defer cancel()
+	u, err := p.client.toolboxURL(ctx, p.sandboxID, "process", "pty", url.PathEscape(p.sessionID), "resize")
+	if err != nil {
+		return err
+	}
+	body := map[string]int{"rows": int(rows), "cols": int(cols)}
+	return p.client.do(ctx, http.MethodPost, u, body, nil)
+}
+
+func (p *ptyConn) Close() error {
+	err := p.conn.Close(websocket.StatusNormalClosure, "detach")
+	ctx, cancel := context.WithTimeout(context.Background(), resizeTimeout)
+	defer cancel()
+	p.client.deletePTY(ctx, p.sandboxID, p.sessionID)
+	return err
+}

--- a/backend/internal/adapters/runtime/daytona/client.go
+++ b/backend/internal/adapters/runtime/daytona/client.go
@@ -132,6 +132,19 @@ type Client interface {
 	// GitClone clones a repository inside the sandbox via the toolbox git API
 	// (credentials travel in the request body, never on a command line).
 	GitClone(ctx context.Context, sandboxID string, req GitCloneRequest) error
+	// GitSetCredentials stores git credentials inside the sandbox
+	// (toolbox `POST /git/credentials`) so subsequent in-sandbox git
+	// network operations — the adapter's fetch/ls-remote and the agent's own
+	// pushes — authenticate against the host. Body-only, like GitClone.
+	GitSetCredentials(ctx context.Context, sandboxID string, req GitCredentialsRequest) error
+}
+
+// GitCredentialsRequest mirrors the toolbox GitAuthenticateRequest body.
+type GitCredentialsRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Host     string `json:"host,omitempty"`
+	Protocol string `json:"protocol,omitempty"`
 }
 
 // GitCloneRequest mirrors the toolbox `POST /git/clone` body (fields we use).
@@ -331,6 +344,14 @@ func (c *apiClient) Exec(ctx context.Context, sandboxID string, req ExecRequest)
 
 func (c *apiClient) GitClone(ctx context.Context, sandboxID string, req GitCloneRequest) error {
 	u, err := c.toolboxURL(ctx, sandboxID, "git", "clone")
+	if err != nil {
+		return err
+	}
+	return c.do(ctx, http.MethodPost, u, req, nil)
+}
+
+func (c *apiClient) GitSetCredentials(ctx context.Context, sandboxID string, req GitCredentialsRequest) error {
+	u, err := c.toolboxURL(ctx, sandboxID, "git", "credentials")
 	if err != nil {
 		return err
 	}

--- a/backend/internal/adapters/runtime/daytona/client.go
+++ b/backend/internal/adapters/runtime/daytona/client.go
@@ -18,6 +18,8 @@ import (
 // branches on; unknown values flow through unmodified).
 type SandboxState string
 
+// Daytona sandbox states: steady (started/stopped/archived/paused/error/
+// destroyed) plus the transitional states Transitional() reports.
 const (
 	StateCreating        SandboxState = "creating"
 	StateStarting        SandboxState = "starting"

--- a/backend/internal/adapters/runtime/daytona/commands.go
+++ b/backend/internal/adapters/runtime/daytona/commands.go
@@ -1,0 +1,282 @@
+package daytona
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// The adapter drives tmux INSIDE the sandbox through the toolbox exec API, so
+// every command is a single shell string. These builders mirror
+// adapters/runtime/tmux/commands.go semantics (exact-match targets, -l literal
+// send-keys, capture-pane history window) with shell quoting applied here
+// because exec takes a command line, not argv.
+
+var sessionIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// shellQuote single-quotes s for POSIX sh.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func shellJoin(argv []string) string {
+	parts := make([]string, len(argv))
+	for i, a := range argv {
+		parts[i] = shellQuote(a)
+	}
+	return strings.Join(parts, " ")
+}
+
+// sessionName maps an AO session id onto a tmux session name, using the same
+// sanitisation as the tmux adapter so ids stay consistent across runtimes.
+func sessionName(id domain.SessionID) (string, error) {
+	raw := string(id)
+	if raw == "" {
+		return "", fmt.Errorf("daytona runtime: session id is required")
+	}
+	if sessionIDPattern.MatchString(raw) && len(raw) <= 48 {
+		return raw, nil
+	}
+	return sanitizedSessionName(raw), nil
+}
+
+func sanitizedSessionName(raw string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range raw {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
+		if valid {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	base := strings.Trim(b.String(), "-")
+	if base == "" {
+		base = "session"
+	}
+	if len(base) > 32 {
+		base = strings.TrimRight(base[:32], "-")
+	}
+	sum := sha256.Sum256([]byte(raw))
+	return base + "-" + hex.EncodeToString(sum[:4])
+}
+
+func handleID(handle ports.RuntimeHandle) (string, error) {
+	id := handle.ID
+	if id == "" {
+		return "", fmt.Errorf("daytona runtime: session id is required")
+	}
+	if !sessionIDPattern.MatchString(id) {
+		return "", fmt.Errorf("daytona runtime: invalid handle id %q", id)
+	}
+	return id, nil
+}
+
+// exactTarget wraps id in tmux's exact-match prefix so session-selection
+// commands never prefix-match a sibling session.
+func exactTarget(id string) string {
+	return "=" + id
+}
+
+func newSessionCommand(id, cwd, launchCmd string) string {
+	return "tmux new-session -d -s " + shellQuote(id) +
+		" -x 220 -y 50 -c " + shellQuote(cwd) +
+		" sh -c " + shellQuote(launchCmd) +
+		" && tmux set-option -t " + shellQuote(id) + " status off" +
+		" && tmux set-option -t " + shellQuote(id) + " mouse on" +
+		" && tmux set-option -t " + shellQuote(id) + " window-size largest"
+}
+
+func respawnPaneCommand(id, cwd, launchCmd string) string {
+	return "tmux respawn-pane -k -t " + shellQuote(id+":0.0") +
+		" -c " + shellQuote(cwd) +
+		" sh -c " + shellQuote(launchCmd)
+}
+
+func hasSessionCommand(id string) string {
+	return "tmux has-session -t " + shellQuote(exactTarget(id))
+}
+
+func killSessionCommand(id string) string {
+	return "tmux kill-session -t " + shellQuote(exactTarget(id))
+}
+
+func sendKeysLiteralCommand(id, chunk string) string {
+	return "tmux send-keys -t " + shellQuote(id) + " -l " + shellQuote(chunk)
+}
+
+func sendEnterCommand(id string) string {
+	return "tmux send-keys -t " + shellQuote(id) + " Enter"
+}
+
+func sendInterruptCommand(id string) string {
+	return "tmux send-keys -t " + shellQuote(id) + " C-c"
+}
+
+func capturePaneCommand(id string, lines int) string {
+	return fmt.Sprintf("tmux capture-pane -t %s -p -S -%d", shellQuote(id), lines)
+}
+
+func panePIDCommand(id string) string {
+	return "tmux display-message -p -t " + shellQuote(id+":0.0") + " '#{pane_pid}'"
+}
+
+func processTableCommand() string {
+	return "ps -ww -axo pid=,ppid=,args="
+}
+
+// attachCommand is written as the first input line of a fresh PTY (Daytona's
+// PTY create takes no command): exec replaces the shell so detach ends the
+// PTY, -u forces UTF-8 (the toolbox PTY env has no locale; see tmux adapter
+// issue #2484), and -T RGB advertises truecolor to match AO's xterm renderer.
+func attachCommand(id string) string {
+	return "exec tmux -u -T RGB attach-session -t " + shellQuote(exactTarget(id)) + "\n"
+}
+
+// buildLaunchCommand builds the sh -c command string that runs inside the
+// sandbox's tmux pane. It mirrors the tmux adapter's launch line — cd guard,
+// NO_COLOR unset, sorted env exports with PATH last, argv, then a keep-alive
+// interactive shell — with one deliberate difference: when the caller supplies
+// no PATH, none is exported (the daemon host's PATH is meaningless inside the
+// sandbox, so the snapshot's own PATH must win).
+func buildLaunchCommand(cfg ports.RuntimeConfig) string {
+	var b strings.Builder
+	b.WriteString("cd ")
+	b.WriteString(shellQuote(cfg.WorkspacePath))
+	b.WriteString(" || exit; ")
+	if _, configured := cfg.Env["NO_COLOR"]; !configured {
+		b.WriteString("unset NO_COLOR; ")
+	}
+	for _, key := range sortedKeys(cfg.Env) {
+		if key == "PATH" || key == "COLORTERM" {
+			continue
+		}
+		b.WriteString("export ")
+		b.WriteString(key)
+		b.WriteString("=")
+		b.WriteString(shellQuote(cfg.Env[key]))
+		b.WriteString("; ")
+	}
+	b.WriteString("export COLORTERM='truecolor'; ")
+	if path := cfg.Env["PATH"]; path != "" {
+		b.WriteString("export PATH=")
+		b.WriteString(shellQuote(path))
+		b.WriteString("; ")
+	}
+	b.WriteString(shellJoin(cfg.Argv))
+	b.WriteString(`; exec "${SHELL:-/bin/sh}" -i`)
+	return b.String()
+}
+
+func validateEnvKeys(env map[string]string) error {
+	for key := range env {
+		if !validEnvKey(key) {
+			return fmt.Errorf("daytona runtime: invalid env key %q", key)
+		}
+	}
+	return nil
+}
+
+func validEnvKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i, r := range key {
+		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
+			continue
+		}
+		if i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sessionMissingOutput reports whether a failed tmux command's output is
+// definitively "session does not exist" rather than a transient failure.
+func sessionMissingOutput(out string) bool {
+	s := strings.ToLower(out)
+	return strings.Contains(s, "can't find session") ||
+		strings.Contains(s, "no server running") ||
+		strings.Contains(s, "error connecting") ||
+		strings.Contains(s, "session not found")
+}
+
+// -- text helpers (identical contracts to the tmux adapter) --
+
+func chunks(s string, maxBytes int) []string {
+	if s == "" {
+		return []string{""}
+	}
+	if maxBytes <= 0 || len(s) <= maxBytes {
+		return []string{s}
+	}
+	parts := []string{}
+	for s != "" {
+		if len(s) <= maxBytes {
+			parts = append(parts, s)
+			break
+		}
+		end := maxBytes
+		for end > 0 && !utf8.ValidString(s[:end]) {
+			end--
+		}
+		if end == 0 {
+			_, size := utf8.DecodeRuneInString(s)
+			end = size
+		}
+		parts = append(parts, s[:end])
+		s = s[end:]
+	}
+	return parts
+}
+
+func tailLines(s string, n int) string {
+	if n <= 0 || s == "" {
+		return ""
+	}
+	lines := strings.SplitAfter(s, "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "")
+}
+
+func trimTrailingBlankLines(s string) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.SplitAfter(s, "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	for len(lines) > 0 && strings.TrimRight(lines[len(lines)-1], "\r\n") == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return strings.Join(lines, "")
+}

--- a/backend/internal/adapters/runtime/daytona/daytona.go
+++ b/backend/internal/adapters/runtime/daytona/daytona.go
@@ -1,0 +1,523 @@
+// Package daytona implements AO's runtime and workspace ports against
+// Daytona (daytona.io) cloud sandboxes: one sandbox per session, running the
+// same tmux semantics the local tmux adapter provides, driven through
+// Daytona's toolbox exec API. Terminal attach streams over Daytona's PTY
+// WebSocket — outbound connections only, no inbound port on the sandbox.
+// Design doc: docs/cloud/daytona-runtime.md.
+package daytona
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	// LabelSession is the sandbox label carrying the AO runtime handle id. The
+	// adapter finds a session's sandbox by this label instead of an in-memory
+	// map, so a daemon restart re-adopts cloud sessions the same way boot
+	// reconcile re-adopts tmux ones.
+	LabelSession = "ao/session"
+	// LabelProject carries the AO project id for operator-facing inventory.
+	LabelProject = "ao/project"
+
+	defaultExecTimeout   = 30 * time.Second
+	defaultChunkBytes    = 16 * 1024
+	defaultEnterDelay    = 300 * time.Millisecond
+	defaultStartTimeout  = 2 * time.Minute
+	defaultCreateTimeout = 5 * time.Minute
+	statePollInterval    = 2 * time.Second
+	resizeTimeout        = 10 * time.Second
+)
+
+// Options configures the Daytona Runtime (and are shared by the Workspace
+// adapter, which is built from the same values via NewWorkspace).
+type Options struct {
+	// Client talks to Daytona. Required (build one with NewClient).
+	Client Client
+	// ExecTimeout bounds one toolbox exec round-trip; default 30s (network,
+	// unlike the tmux adapter's local 5s).
+	ExecTimeout time.Duration
+	// ChunkSize bounds one send-keys literal chunk; default 16 KiB.
+	ChunkSize int
+	// EnterDelay is the pause between pasting a non-empty message and the
+	// trailing Enter (issue #2342); default 300ms.
+	EnterDelay time.Duration
+	// StartTimeout bounds waiting for a sandbox to reach started when waking a
+	// stopped/archived one; default 2m.
+	StartTimeout time.Duration
+}
+
+func (o Options) withDefaults() Options {
+	if o.ExecTimeout <= 0 {
+		o.ExecTimeout = defaultExecTimeout
+	}
+	if o.ChunkSize <= 0 {
+		o.ChunkSize = defaultChunkBytes
+	}
+	if o.EnterDelay <= 0 {
+		o.EnterDelay = defaultEnterDelay
+	}
+	if o.StartTimeout <= 0 {
+		o.StartTimeout = defaultStartTimeout
+	}
+	return o
+}
+
+// core holds the client plus the sandbox lookup/wake/exec helpers shared by
+// the Runtime and Workspace adapters (both drive the same per-session
+// sandbox).
+type core struct {
+	client       Client
+	execTimeout  time.Duration
+	startTimeout time.Duration
+}
+
+// Runtime runs agent sessions inside tmux within a per-session Daytona
+// sandbox. It implements ports.Runtime plus the optional capabilities the
+// daemon wires (Attacher, RuntimeRestarter, SupervisedProcessInspector) and
+// the runtimeselect union methods (SendMessage, Interrupt, GetOutput).
+type Runtime struct {
+	core
+	chunkSize  int
+	enterDelay time.Duration
+}
+
+var (
+	_ ports.Runtime                    = (*Runtime)(nil)
+	_ ports.Attacher                   = (*Runtime)(nil)
+	_ ports.RuntimeRestarter           = (*Runtime)(nil)
+	_ ports.SupervisedProcessInspector = (*Runtime)(nil)
+)
+
+// New builds a Daytona Runtime. Options.Client is required.
+func New(opts Options) (*Runtime, error) {
+	if opts.Client == nil {
+		return nil, errors.New("daytona runtime: client is required")
+	}
+	opts = opts.withDefaults()
+	return &Runtime{
+		core: core{
+			client:       opts.Client,
+			execTimeout:  opts.ExecTimeout,
+			startTimeout: opts.StartTimeout,
+		},
+		chunkSize:  opts.ChunkSize,
+		enterDelay: opts.EnterDelay,
+	}, nil
+}
+
+// sandboxForHandle finds the session's sandbox by label. found=false with a
+// nil error is definitive "no sandbox" (deleted); an error is an inconclusive
+// probe failure.
+func (r *core) sandboxForHandle(ctx context.Context, id string) (Sandbox, bool, error) {
+	list, err := r.client.ListSandboxes(ctx, map[string]string{LabelSession: id})
+	if err != nil {
+		return Sandbox{}, false, fmt.Errorf("daytona runtime: list sandboxes for %s: %w", id, err)
+	}
+	for _, sb := range list {
+		if sb.State != StateDestroyed && sb.State != StateDestroying {
+			return sb, true, nil
+		}
+	}
+	return Sandbox{}, false, nil
+}
+
+// ensureStarted wakes a stopped/archived sandbox and waits for started.
+// Already-running sandboxes return immediately.
+func (r *core) ensureStarted(ctx context.Context, sb Sandbox) (Sandbox, error) {
+	switch sb.State {
+	case StateStarted:
+		return sb, nil
+	case StateStopped, StateArchived:
+		if err := r.client.StartSandbox(ctx, sb.ID); err != nil {
+			return sb, fmt.Errorf("daytona runtime: start sandbox %s: %w", sb.ID, err)
+		}
+	case StateError, StateBuildFailed:
+		return sb, fmt.Errorf("daytona runtime: sandbox %s is in state %s: %s", sb.ID, sb.State, sb.ErrorReason)
+	case StateDestroyed, StateDestroying:
+		return sb, fmt.Errorf("daytona runtime: sandbox %s is destroyed", sb.ID)
+	}
+	return r.waitForState(ctx, sb.ID, StateStarted, r.startTimeout)
+}
+
+// waitForState polls until the sandbox reaches want, a terminal error state,
+// or the timeout elapses.
+func (r *core) waitForState(ctx context.Context, sandboxID string, want SandboxState, timeout time.Duration) (Sandbox, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		sb, err := r.client.GetSandbox(ctx, sandboxID)
+		if err != nil {
+			return Sandbox{}, fmt.Errorf("daytona runtime: poll sandbox %s: %w", sandboxID, err)
+		}
+		switch {
+		case sb.State == want:
+			return sb, nil
+		case sb.State == StateError || sb.State == StateBuildFailed:
+			return sb, fmt.Errorf("daytona runtime: sandbox %s entered state %s: %s", sandboxID, sb.State, sb.ErrorReason)
+		case !sb.State.Transitional() && sb.State != want:
+			return sb, fmt.Errorf("daytona runtime: sandbox %s settled in state %s, want %s", sandboxID, sb.State, want)
+		}
+		if time.Now().After(deadline) {
+			return sb, fmt.Errorf("daytona runtime: sandbox %s did not reach %s within %s (state %s)", sandboxID, want, timeout, sb.State)
+		}
+		select {
+		case <-ctx.Done():
+			return sb, ctx.Err()
+		case <-time.After(statePollInterval):
+		}
+	}
+}
+
+// exec runs one shell command in the sandbox with the adapter's timeout.
+// A non-zero exit is returned as (result, execError) so callers can inspect
+// output; transport failures come back unwrapped from the client.
+func (r *core) exec(ctx context.Context, sandboxID, command string) (ExecResult, error) {
+	return r.execWithTimeout(ctx, sandboxID, command, r.execTimeout)
+}
+
+func (r *core) execWithTimeout(ctx context.Context, sandboxID, command string, timeout time.Duration) (ExecResult, error) {
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	res, err := r.client.Exec(execCtx, sandboxID, ExecRequest{
+		Command:        command,
+		TimeoutSeconds: int(timeout / time.Second),
+	})
+	if err != nil {
+		return ExecResult{}, err
+	}
+	if res.ExitCode != 0 {
+		return res, &execError{command: command, exitCode: res.ExitCode, output: res.Result}
+	}
+	return res, nil
+}
+
+// execError is a command that ran in the sandbox and exited non-zero — a
+// definitive command failure, distinct from transport errors.
+type execError struct {
+	command  string
+	exitCode int
+	output   string
+}
+
+func (e *execError) Error() string {
+	out := strings.TrimSpace(e.output)
+	if len(out) > 512 {
+		out = out[:512] + "…"
+	}
+	return fmt.Sprintf("command exited %d: %s", e.exitCode, out)
+}
+
+// Create launches the agent inside the session's sandbox: the sandbox must
+// already exist (Workspace.Create provisions it); Create wakes it if parked,
+// then starts a tmux session running the launch command with the caller's env
+// exported — including the control-plane-injected agent credentials.
+func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
+	id, err := sessionName(cfg.SessionID)
+	if err != nil {
+		return ports.RuntimeHandle{}, err
+	}
+	if cfg.WorkspacePath == "" {
+		return ports.RuntimeHandle{}, errors.New("daytona runtime: workspace path is required")
+	}
+	if len(cfg.Argv) == 0 {
+		return ports.RuntimeHandle{}, errors.New("daytona runtime: launch command is required")
+	}
+	if err := validateEnvKeys(cfg.Env); err != nil {
+		return ports.RuntimeHandle{}, err
+	}
+	sb, found, err := r.sandboxForHandle(ctx, id)
+	if err != nil {
+		return ports.RuntimeHandle{}, err
+	}
+	if !found {
+		return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: no sandbox for session %s (workspace not provisioned?)", id)
+	}
+	sb, err = r.ensureStarted(ctx, sb)
+	if err != nil {
+		return ports.RuntimeHandle{}, err
+	}
+
+	launchCmd := buildLaunchCommand(cfg)
+	if _, err := r.exec(ctx, sb.ID, newSessionCommand(id, cfg.WorkspacePath, launchCmd)); err != nil {
+		return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: create session %s: %w", id, err)
+	}
+
+	handle := ports.RuntimeHandle{ID: id}
+	alive, err := r.IsAlive(ctx, handle)
+	if err != nil {
+		_ = r.Destroy(context.WithoutCancel(ctx), handle)
+		return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: verify session %s: %w", id, err)
+	}
+	if !alive {
+		_ = r.Destroy(context.WithoutCancel(ctx), handle)
+		return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: session %s exited before ready", id)
+	}
+	return handle, nil
+}
+
+// Restart replaces the agent process inside the existing sandbox tmux session,
+// preserving the terminal identity. It also transparently wakes a parked
+// sandbox: when the stop killed tmux, the session is recreated instead of
+// respawned — same handle either way.
+func (r *Runtime) Restart(ctx context.Context, handle ports.RuntimeHandle, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return ports.RuntimeHandle{}, err
+	}
+	expected, err := sessionName(cfg.SessionID)
+	if err != nil {
+		return ports.RuntimeHandle{}, err
+	}
+	if expected != id {
+		return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: restart handle %s does not match session %s", id, cfg.SessionID)
+	}
+	if cfg.WorkspacePath == "" {
+		return ports.RuntimeHandle{}, errors.New("daytona runtime: workspace path is required")
+	}
+	if len(cfg.Argv) == 0 {
+		return ports.RuntimeHandle{}, errors.New("daytona runtime: launch command is required")
+	}
+	if err := validateEnvKeys(cfg.Env); err != nil {
+		return ports.RuntimeHandle{}, err
+	}
+	sb, found, err := r.sandboxForHandle(ctx, id)
+	if err != nil {
+		return ports.RuntimeHandle{}, err
+	}
+	if !found {
+		return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: no sandbox for session %s", id)
+	}
+	sb, err = r.ensureStarted(ctx, sb)
+	if err != nil {
+		return ports.RuntimeHandle{}, err
+	}
+
+	launchCmd := buildLaunchCommand(cfg)
+	if _, err := r.exec(ctx, sb.ID, respawnPaneCommand(id, cfg.WorkspacePath, launchCmd)); err != nil {
+		var execErr *execError
+		if !errors.As(err, &execErr) {
+			return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: restart session %s: %w", id, err)
+		}
+		// The tmux session died with a sandbox stop; recreate it in place.
+		if _, err := r.exec(ctx, sb.ID, newSessionCommand(id, cfg.WorkspacePath, launchCmd)); err != nil {
+			return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: restart session %s: %w", id, err)
+		}
+	}
+	alive, err := r.IsAlive(ctx, handle)
+	if err != nil {
+		return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: verify restarted session %s: %w", id, err)
+	}
+	if !alive {
+		return ports.RuntimeHandle{}, fmt.Errorf("daytona runtime: session %s exited during restart", id)
+	}
+	return handle, nil
+}
+
+// Destroy kills the sandbox's tmux session. The sandbox itself is torn down by
+// Workspace.Destroy (it holds the checkout); a missing sandbox or an
+// already-gone tmux session is success (idempotent double-kill). A parked
+// (stopped) sandbox has no processes to kill, so it is also success.
+func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error {
+	id, err := handleID(handle)
+	if err != nil {
+		return err
+	}
+	sb, found, err := r.sandboxForHandle(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !found || sb.State != StateStarted {
+		return nil
+	}
+	if _, err := r.exec(ctx, sb.ID, killSessionCommand(id)); err != nil {
+		var execErr *execError
+		if errors.As(err, &execErr) && sessionMissingOutput(execErr.output) {
+			return nil
+		}
+		return fmt.Errorf("daytona runtime: destroy session %s: %w", id, err)
+	}
+	return nil
+}
+
+// IsAlive reports whether the session's terminal still exists. A parked
+// (stopped/archived) sandbox reports alive: the terminal identity is
+// restorable in place via Restart, and reporting dead would let the reaper
+// terminate every idle-parked cloud session. The agent-process question is
+// separate (IsSupervisedProcessAlive), matching issue #2802's split. Probe
+// failures return an error, never proof of death.
+func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return false, err
+	}
+	sb, found, err := r.sandboxForHandle(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
+	}
+	switch sb.State {
+	case StateStopped, StateArchived, StateStopping, StateArchiving:
+		return true, nil // parked: fs (and terminal identity) preserved
+	case StateError, StateBuildFailed:
+		return false, nil
+	case StateStarted:
+		// fall through to the tmux probe
+	default:
+		if sb.State.Transitional() {
+			return true, nil
+		}
+		return false, nil
+	}
+	if _, err := r.exec(ctx, sb.ID, hasSessionCommand(id)); err != nil {
+		// Only output that definitively says "session/server missing" is proof
+		// of death; any other failure (tmux absent, shell OOM, transport) is an
+		// inconclusive probe so the reaper never kills on a transient error.
+		var execErr *execError
+		if errors.As(err, &execErr) && sessionMissingOutput(execErr.output) {
+			return false, nil
+		}
+		return false, fmt.Errorf("daytona runtime: probe session %s: %w", id, err)
+	}
+	return true, nil
+}
+
+// IsSupervisedProcessAlive reports whether the managed agent workload for ref
+// is still running inside the sandbox, using the same pane-descendant walk as
+// the tmux adapter (issue #2802: pane-exists != agent-alive). A parked sandbox
+// reports false with no error — Daytona stop killed the processes, which is
+// exactly the "agent exited, session restorable" state.
+func (r *Runtime) IsSupervisedProcessAlive(ctx context.Context, handle ports.RuntimeHandle, ref ports.SupervisedProcessRef) (bool, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return false, err
+	}
+	sb, found, err := r.sandboxForHandle(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
+	}
+	if sb.State == StateStopped || sb.State == StateArchived {
+		return false, nil
+	}
+	if sb.State != StateStarted {
+		return false, fmt.Errorf("daytona runtime: sandbox %s in transitional state %s", sb.ID, sb.State)
+	}
+	paneOut, err := r.exec(ctx, sb.ID, panePIDCommand(id))
+	if err != nil {
+		return false, fmt.Errorf("daytona runtime: inspect pane pid %s: %w", id, err)
+	}
+	panePID, err := strconv.Atoi(strings.TrimSpace(paneOut.Result))
+	if err != nil || panePID <= 0 {
+		return false, fmt.Errorf("daytona runtime: invalid pane pid %q", strings.TrimSpace(paneOut.Result))
+	}
+	tableOut, err := r.exec(ctx, sb.ID, processTableCommand())
+	if err != nil {
+		return false, fmt.Errorf("daytona runtime: inspect process tree %s: %w", id, err)
+	}
+	entries, err := parseProcessTable(tableOut.Result)
+	if err != nil {
+		return false, fmt.Errorf("daytona runtime: parse process tree %s: %w", id, err)
+	}
+	return containsManagedWorkload(entries, panePID, string(ref.SessionID), ref.LaunchID), nil
+}
+
+// SendMessage sends literal text to the session then presses Enter to submit;
+// an empty message presses Enter alone (the ports.AgentMessenger nudge
+// contract). Chunking and the pre-Enter delay mirror the tmux adapter
+// (issue #2342).
+func (r *Runtime) SendMessage(ctx context.Context, handle ports.RuntimeHandle, message string) error {
+	id, err := handleID(handle)
+	if err != nil {
+		return err
+	}
+	sb, found, err := r.sandboxForHandle(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("daytona runtime: no sandbox for session %s", id)
+	}
+	enterCtx := ctx
+	if message != "" {
+		for _, chunk := range chunks(message, r.chunkSize) {
+			if _, err := r.exec(ctx, sb.ID, sendKeysLiteralCommand(id, chunk)); err != nil {
+				return fmt.Errorf("daytona runtime: send message %s: %w", id, err)
+			}
+		}
+		// The chunks are already in the pane: detach the pause + Enter from the
+		// caller's cancellation so an abandoned send can't strand an
+		// unsubmitted draft (see tmux adapter).
+		var cancel context.CancelFunc
+		enterCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), r.enterDelay+r.execTimeout)
+		defer cancel()
+		if r.enterDelay > 0 {
+			select {
+			case <-enterCtx.Done():
+				return enterCtx.Err()
+			case <-time.After(r.enterDelay):
+			}
+		}
+	}
+	if _, err := r.exec(enterCtx, sb.ID, sendEnterCommand(id)); err != nil {
+		return fmt.Errorf("daytona runtime: send enter %s: %w", id, err)
+	}
+	return nil
+}
+
+// Interrupt sends Ctrl-C to the foreground process without destroying the
+// terminal session.
+func (r *Runtime) Interrupt(ctx context.Context, handle ports.RuntimeHandle) error {
+	id, err := handleID(handle)
+	if err != nil {
+		return err
+	}
+	sb, found, err := r.sandboxForHandle(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("daytona runtime: no sandbox for session %s", id)
+	}
+	if _, err := r.exec(ctx, sb.ID, sendInterruptCommand(id)); err != nil {
+		return fmt.Errorf("daytona runtime: interrupt session %s: %w", id, err)
+	}
+	return nil
+}
+
+// GetOutput returns the last `lines` lines of the session's terminal
+// scrollback via capture-pane. A parked sandbox has no tmux server, so its
+// scrollback is unavailable until the session is restarted.
+func (r *Runtime) GetOutput(ctx context.Context, handle ports.RuntimeHandle, lines int) (string, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return "", err
+	}
+	if lines <= 0 {
+		return "", errors.New("daytona runtime: lines must be positive")
+	}
+	sb, found, err := r.sandboxForHandle(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("daytona runtime: no sandbox for session %s", id)
+	}
+	if sb.State != StateStarted {
+		return "", fmt.Errorf("daytona runtime: sandbox for session %s is %s; scrollback unavailable while parked", id, sb.State)
+	}
+	out, err := r.exec(ctx, sb.ID, capturePaneCommand(id, lines))
+	if err != nil {
+		return "", fmt.Errorf("daytona runtime: capture output %s: %w", id, err)
+	}
+	return tailLines(trimTrailingBlankLines(out.Result), lines), nil
+}

--- a/backend/internal/adapters/runtime/daytona/daytona.go
+++ b/backend/internal/adapters/runtime/daytona/daytona.go
@@ -130,7 +130,19 @@ func (r *core) sandboxForHandle(ctx context.Context, id string) (Sandbox, bool, 
 
 // ensureStarted wakes a stopped/archived sandbox and waits for started.
 // Already-running sandboxes return immediately.
+//
+// A transitional state settles FIRST, then the steady state is acted on. This
+// ordering is load-bearing (caught live): the list endpoint lags GetSandbox,
+// so a freshly-parked sandbox can still read `stopping` here — waiting for
+// `started` on that would spin until timeout without ever issuing the start,
+// because stopping settles into stopped.
 func (r *core) ensureStarted(ctx context.Context, sb Sandbox) (Sandbox, error) {
+	if sb.State.Transitional() {
+		var err error
+		if sb, err = r.waitForSettled(ctx, sb.ID, r.startTimeout); err != nil {
+			return sb, err
+		}
+	}
 	switch sb.State {
 	case StateStarted:
 		return sb, nil
@@ -138,17 +150,86 @@ func (r *core) ensureStarted(ctx context.Context, sb Sandbox) (Sandbox, error) {
 		if err := r.client.StartSandbox(ctx, sb.ID); err != nil {
 			return sb, fmt.Errorf("daytona runtime: start sandbox %s: %w", sb.ID, err)
 		}
+		// Tolerate still seeing the pre-start steady state: Daytona applies
+		// state transitions asynchronously, so the first polls after
+		// StartSandbox can still report stopped/archived.
+		return r.waitForState(ctx, sb.ID, StateStarted, r.startTimeout, StateStopped, StateArchived)
 	case StateError, StateBuildFailed:
 		return sb, fmt.Errorf("daytona runtime: sandbox %s is in state %s: %s", sb.ID, sb.State, sb.ErrorReason)
-	case StateDestroyed, StateDestroying:
-		return sb, fmt.Errorf("daytona runtime: sandbox %s is destroyed", sb.ID)
+	default:
+		return sb, fmt.Errorf("daytona runtime: sandbox %s cannot be started from state %s", sb.ID, sb.State)
 	}
-	return r.waitForState(ctx, sb.ID, StateStarted, r.startTimeout)
+}
+
+// deleteAndWait deletes a sandbox and waits until Daytona stops reporting it
+// (deletion is async: the API 200s while the sandbox is still listed). AO's
+// teardown paths treat a returned destroy as "gone", so the adapter owns the
+// wait rather than every caller re-discovering the lag.
+func (r *core) deleteAndWait(ctx context.Context, sandboxID string) error {
+	if err := r.client.DeleteSandbox(ctx, sandboxID); err != nil {
+		if errors.Is(err, ErrSandboxNotFound) {
+			return nil
+		}
+		return err
+	}
+	deadline := time.Now().Add(r.startTimeout)
+	for {
+		sb, err := r.client.GetSandbox(ctx, sandboxID)
+		switch {
+		case errors.Is(err, ErrSandboxNotFound):
+			return nil
+		case err != nil:
+			return fmt.Errorf("daytona: confirm delete of sandbox %s: %w", sandboxID, err)
+		case sb.State == StateDestroyed:
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("daytona: sandbox %s still %s after delete", sandboxID, sb.State)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(statePollInterval):
+		}
+	}
+}
+
+// waitForSettled polls until the sandbox leaves every transitional state,
+// whatever it settles into.
+func (r *core) waitForSettled(ctx context.Context, sandboxID string, timeout time.Duration) (Sandbox, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		sb, err := r.client.GetSandbox(ctx, sandboxID)
+		if err != nil {
+			return Sandbox{}, fmt.Errorf("daytona runtime: poll sandbox %s: %w", sandboxID, err)
+		}
+		if !sb.State.Transitional() {
+			return sb, nil
+		}
+		if time.Now().After(deadline) {
+			return sb, fmt.Errorf("daytona runtime: sandbox %s stuck in transitional state %s after %s", sandboxID, sb.State, timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return sb, ctx.Err()
+		case <-time.After(statePollInterval):
+		}
+	}
 }
 
 // waitForState polls until the sandbox reaches want, a terminal error state,
-// or the timeout elapses.
-func (r *core) waitForState(ctx context.Context, sandboxID string, want SandboxState, timeout time.Duration) (Sandbox, error) {
+// or the timeout elapses. States listed in tolerate are treated like
+// transitional ones — kept polling through — for the window where an async
+// state change was requested but the sandbox still reports its origin state.
+func (r *core) waitForState(ctx context.Context, sandboxID string, want SandboxState, timeout time.Duration, tolerate ...SandboxState) (Sandbox, error) {
+	tolerated := func(s SandboxState) bool {
+		for _, t := range tolerate {
+			if s == t {
+				return true
+			}
+		}
+		return false
+	}
 	deadline := time.Now().Add(timeout)
 	for {
 		sb, err := r.client.GetSandbox(ctx, sandboxID)
@@ -160,7 +241,7 @@ func (r *core) waitForState(ctx context.Context, sandboxID string, want SandboxS
 			return sb, nil
 		case sb.State == StateError || sb.State == StateBuildFailed:
 			return sb, fmt.Errorf("daytona runtime: sandbox %s entered state %s: %s", sandboxID, sb.State, sb.ErrorReason)
-		case !sb.State.Transitional() && sb.State != want:
+		case !sb.State.Transitional() && !tolerated(sb.State):
 			return sb, fmt.Errorf("daytona runtime: sandbox %s settled in state %s, want %s", sandboxID, sb.State, want)
 		}
 		if time.Now().After(deadline) {
@@ -383,6 +464,22 @@ func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool
 		var execErr *execError
 		if errors.As(err, &execErr) && sessionMissingOutput(execErr.output) {
 			return false, nil
+		}
+		// A sandbox observed `started` can be mid-stop by the time the exec
+		// lands (Daytona stop is async; the toolbox proxy 502s during it —
+		// seen live). Re-read the state: if it left `started`, answer from the
+		// fresh state instead of surfacing a probe error for a healthy park.
+		if fresh, freshErr := r.client.GetSandbox(ctx, sb.ID); freshErr == nil && fresh.State != StateStarted {
+			switch fresh.State {
+			case StateStopped, StateArchived, StateStopping, StateArchiving:
+				return true, nil // parked mid-probe
+			case StateError, StateBuildFailed, StateDestroyed, StateDestroying:
+				return false, nil
+			default:
+				if fresh.State.Transitional() {
+					return true, nil
+				}
+			}
 		}
 		return false, fmt.Errorf("daytona runtime: probe session %s: %w", id, err)
 	}

--- a/backend/internal/adapters/runtime/daytona/daytona_test.go
+++ b/backend/internal/adapters/runtime/daytona/daytona_test.go
@@ -368,6 +368,30 @@ func TestRestartFallsBackToNewSessionAfterPark(t *testing.T) {
 	}
 }
 
+func TestRestartWakesSandboxStillReportedStopping(t *testing.T) {
+	// Live regression (PR #3254): the list endpoint lags GetSandbox, so a
+	// freshly-parked sandbox can be listed as `stopping`. ensureStarted must
+	// settle that into `stopped` and THEN issue the start — the old code
+	// waited for `started` without ever starting, and timed out.
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStopping)
+	fc.settleAfterGets = 2
+	fc.settleTo = StateStopped
+	fc.onExec("tmux respawn-pane", ExecResult{ExitCode: 1, Result: "can't find pane: s1:0.0"}, nil)
+	rt := newTestRuntime(t, fc)
+
+	if _, err := rt.Restart(context.Background(), ports.RuntimeHandle{ID: "s1"}, ports.RuntimeConfig{
+		SessionID:     "s1",
+		WorkspacePath: "/w",
+		Argv:          []string{"claude"},
+	}); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	if len(fc.started) != 1 {
+		t.Fatalf("StartSandbox calls = %d, want 1 (wake must be issued after the state settles)", len(fc.started))
+	}
+}
+
 func TestIsSupervisedProcessAlive(t *testing.T) {
 	table := `  1     0 /sbin/init
    40     1 tmux server

--- a/backend/internal/adapters/runtime/daytona/daytona_test.go
+++ b/backend/internal/adapters/runtime/daytona/daytona_test.go
@@ -1,0 +1,424 @@
+package daytona
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/tmux"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func newTestRuntime(t *testing.T, fc *fakeClient) *Runtime {
+	t.Helper()
+	rt, err := New(Options{
+		Client:       fc,
+		ExecTimeout:  2 * time.Second,
+		EnterDelay:   time.Millisecond,
+		StartTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return rt
+}
+
+func TestSessionNameMatchesTmuxAdapter(t *testing.T) {
+	// Handles must be identical across runtimes so a session migrated between
+	// adapters keeps one identity (and operator attach hints stay truthful).
+	for _, id := range []string{"agent-orchestrator-70", "weird id/with:chars", strings.Repeat("x", 60)} {
+		got, err := sessionName(domain.SessionID(id))
+		if err != nil {
+			t.Fatalf("sessionName(%q): %v", id, err)
+		}
+		if want := tmux.SessionName(id); got != want {
+			t.Errorf("sessionName(%q) = %q, want tmux.SessionName %q", id, got, want)
+		}
+	}
+}
+
+func TestBuildLaunchCommand(t *testing.T) {
+	cmd := buildLaunchCommand(ports.RuntimeConfig{
+		SessionID:     "s1",
+		WorkspacePath: "/home/daytona/ao/s1",
+		Argv:          []string{"claude", "--append-system-prompt", "be nice"},
+		Env: map[string]string{
+			"CLAUDE_CODE_OAUTH_TOKEN": "tok-123",
+			"AO_SESSION_ID":           "s1",
+		},
+	})
+	for _, want := range []string{
+		"cd '/home/daytona/ao/s1' || exit",
+		"unset NO_COLOR",
+		"export CLAUDE_CODE_OAUTH_TOKEN='tok-123'",
+		"export AO_SESSION_ID='s1'",
+		"export COLORTERM='truecolor'",
+		"'claude' '--append-system-prompt' 'be nice'",
+		`exec "${SHELL:-/bin/sh}" -i`,
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("launch command missing %q\ncmd: %s", want, cmd)
+		}
+	}
+	// The daemon host's PATH must never leak into the sandbox: no PATH export
+	// unless the caller set one.
+	if strings.Contains(cmd, "export PATH=") {
+		t.Errorf("launch command exports PATH without caller opt-in\ncmd: %s", cmd)
+	}
+	withPath := buildLaunchCommand(ports.RuntimeConfig{
+		SessionID:     "s1",
+		WorkspacePath: "/w",
+		Argv:          []string{"claude"},
+		Env:           map[string]string{"PATH": "/custom/bin", "ZZZ": "last-check"},
+	})
+	pathIdx := strings.Index(withPath, "export PATH='/custom/bin'")
+	zzzIdx := strings.Index(withPath, "export ZZZ=")
+	if pathIdx == -1 || zzzIdx == -1 || pathIdx < zzzIdx {
+		t.Errorf("PATH must be exported last so explicit overrides win\ncmd: %s", withPath)
+	}
+}
+
+func TestCreateRequiresProvisionedSandbox(t *testing.T) {
+	fc := newFakeClient()
+	rt := newTestRuntime(t, fc)
+	_, err := rt.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     "s1",
+		WorkspacePath: "/home/daytona/ao/s1",
+		Argv:          []string{"claude"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "no sandbox") {
+		t.Fatalf("err = %v, want no-sandbox error", err)
+	}
+}
+
+func TestCreateLaunchesTmuxWithEnvAndKeepAlive(t *testing.T) {
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStarted)
+	rt := newTestRuntime(t, fc)
+
+	handle, err := rt.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     "s1",
+		WorkspacePath: "/home/daytona/ao/s1",
+		Argv:          []string{"claude", "--append-system-prompt", "be nice"},
+		Env: map[string]string{
+			"CLAUDE_CODE_OAUTH_TOKEN": "tok-123",
+			"AO_SESSION_ID":           "s1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if handle.ID != "s1" {
+		t.Errorf("handle = %q, want s1", handle.ID)
+	}
+	news := fc.commandsMatching("tmux new-session")
+	if len(news) != 1 {
+		t.Fatalf("new-session commands = %d, want 1\nall: %v", len(news), fc.commands())
+	}
+	cmd := news[0]
+	// Env/argv mechanics are covered by TestBuildLaunchCommand; here assert the
+	// outer tmux wiring: the launch line rides inside sh -c (shell-quoted, so
+	// inner quotes appear escaped) and the session gets the same option set as
+	// the local tmux adapter.
+	for _, want := range []string{
+		"tmux new-session -d -s 's1' -x 220 -y 50 -c '/home/daytona/ao/s1' sh -c ",
+		"CLAUDE_CODE_OAUTH_TOKEN=",
+		"set-option -t 's1' status off",
+		"set-option -t 's1' mouse on",
+		"set-option -t 's1' window-size largest",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("create command missing %q\ncmd: %s", want, cmd)
+		}
+	}
+}
+
+func TestCreateWakesParkedSandbox(t *testing.T) {
+	fc := newFakeClient()
+	id := fc.seedSandbox("s1", StateStopped)
+	rt := newTestRuntime(t, fc)
+	if _, err := rt.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     "s1",
+		WorkspacePath: "/w",
+		Argv:          []string{"claude"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(fc.started) != 1 || fc.started[0] != id {
+		t.Errorf("started = %v, want [%s]", fc.started, id)
+	}
+}
+
+func TestCreateFailsWhenSessionExitsBeforeReady(t *testing.T) {
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStarted)
+	fc.onExec("tmux has-session", ExecResult{ExitCode: 1, Result: "can't find session: s1"}, nil)
+	rt := newTestRuntime(t, fc)
+	_, err := rt.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     "s1",
+		WorkspacePath: "/w",
+		Argv:          []string{"claude"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "exited before ready") {
+		t.Fatalf("err = %v, want exited-before-ready", err)
+	}
+}
+
+func TestIsAlive(t *testing.T) {
+	t.Run("no sandbox is definitively dead", func(t *testing.T) {
+		fc := newFakeClient()
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsAlive(context.Background(), ports.RuntimeHandle{ID: "s1"})
+		if err != nil || alive {
+			t.Fatalf("alive=%v err=%v, want false nil", alive, err)
+		}
+	})
+	t.Run("parked sandbox is alive", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStopped)
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsAlive(context.Background(), ports.RuntimeHandle{ID: "s1"})
+		if err != nil || !alive {
+			t.Fatalf("alive=%v err=%v, want true nil (parked must not be reaped)", alive, err)
+		}
+		if len(fc.commands()) != 0 {
+			t.Errorf("parked probe must not exec, got %v", fc.commands())
+		}
+	})
+	t.Run("missing tmux session is definitively dead", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("tmux has-session", ExecResult{ExitCode: 1, Result: "can't find session: s1"}, nil)
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsAlive(context.Background(), ports.RuntimeHandle{ID: "s1"})
+		if err != nil || alive {
+			t.Fatalf("alive=%v err=%v, want false nil", alive, err)
+		}
+	})
+	t.Run("unrecognized exec failure is an inconclusive probe", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("tmux has-session", ExecResult{ExitCode: 127, Result: "sh: tmux: command not found"}, nil)
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsAlive(context.Background(), ports.RuntimeHandle{ID: "s1"})
+		if err == nil || alive {
+			t.Fatalf("alive=%v err=%v, want false with probe error (never kill on a transient)", alive, err)
+		}
+	})
+	t.Run("list failure is an inconclusive probe", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.listErr = errors.New("network down")
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsAlive(context.Background(), ports.RuntimeHandle{ID: "s1"})
+		if err == nil || alive {
+			t.Fatalf("alive=%v err=%v, want false with probe error", alive, err)
+		}
+	})
+	t.Run("error-state sandbox is dead", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateError)
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsAlive(context.Background(), ports.RuntimeHandle{ID: "s1"})
+		if err != nil || alive {
+			t.Fatalf("alive=%v err=%v, want false nil", alive, err)
+		}
+	})
+}
+
+func TestDestroy(t *testing.T) {
+	t.Run("kills tmux session, keeps sandbox", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		rt := newTestRuntime(t, fc)
+		if err := rt.Destroy(context.Background(), ports.RuntimeHandle{ID: "s1"}); err != nil {
+			t.Fatalf("Destroy: %v", err)
+		}
+		if got := fc.commandsMatching("tmux kill-session"); len(got) != 1 {
+			t.Errorf("kill-session commands = %v", got)
+		}
+		if len(fc.deleted) != 0 {
+			t.Errorf("Destroy must not delete the sandbox (Workspace.Destroy owns that), deleted=%v", fc.deleted)
+		}
+	})
+	t.Run("missing sandbox is idempotent success", func(t *testing.T) {
+		fc := newFakeClient()
+		rt := newTestRuntime(t, fc)
+		if err := rt.Destroy(context.Background(), ports.RuntimeHandle{ID: "s1"}); err != nil {
+			t.Fatalf("Destroy: %v", err)
+		}
+	})
+	t.Run("parked sandbox is success without exec", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStopped)
+		rt := newTestRuntime(t, fc)
+		if err := rt.Destroy(context.Background(), ports.RuntimeHandle{ID: "s1"}); err != nil {
+			t.Fatalf("Destroy: %v", err)
+		}
+		if len(fc.commands()) != 0 {
+			t.Errorf("no exec expected against a parked sandbox, got %v", fc.commands())
+		}
+	})
+	t.Run("already-gone tmux session is success", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("tmux kill-session", ExecResult{ExitCode: 1, Result: "can't find session: s1"}, nil)
+		rt := newTestRuntime(t, fc)
+		if err := rt.Destroy(context.Background(), ports.RuntimeHandle{ID: "s1"}); err != nil {
+			t.Fatalf("Destroy: %v", err)
+		}
+	})
+}
+
+func TestGetOutput(t *testing.T) {
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStarted)
+	fc.onExec("tmux capture-pane", ExecResult{Result: "a\nb\nc\n\n\n"}, nil)
+	rt := newTestRuntime(t, fc)
+	out, err := rt.GetOutput(context.Background(), ports.RuntimeHandle{ID: "s1"}, 2)
+	if err != nil {
+		t.Fatalf("GetOutput: %v", err)
+	}
+	if out != "b\nc\n" {
+		t.Errorf("out = %q, want trailing blanks trimmed and tail 2", out)
+	}
+
+	t.Run("parked scrollback is unavailable", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStopped)
+		rt := newTestRuntime(t, fc)
+		if _, err := rt.GetOutput(context.Background(), ports.RuntimeHandle{ID: "s1"}, 10); err == nil {
+			t.Fatal("want error for parked sandbox scrollback")
+		}
+	})
+}
+
+func TestSendMessageChunksAndSubmits(t *testing.T) {
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStarted)
+	rt := newTestRuntime(t, fc)
+	rt.chunkSize = 4
+
+	if err := rt.SendMessage(context.Background(), ports.RuntimeHandle{ID: "s1"}, "hello wörld"); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	sends := fc.commandsMatching("send-keys -t 's1' -l")
+	if len(sends) < 3 {
+		t.Errorf("expected >=3 literal chunks for chunkSize=4, got %d: %v", len(sends), sends)
+	}
+	var joined strings.Builder
+	for _, s := range sends {
+		start := strings.Index(s, "-l ") + 3
+		joined.WriteString(unquoteShell(s[start:]))
+	}
+	if joined.String() != "hello wörld" {
+		t.Errorf("reassembled chunks = %q, want original message (UTF-8 safe)", joined.String())
+	}
+	enters := fc.commandsMatching("send-keys -t 's1' Enter")
+	if len(enters) != 1 {
+		t.Errorf("enter commands = %v, want exactly 1", enters)
+	}
+
+	t.Run("empty message sends only Enter", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		rt := newTestRuntime(t, fc)
+		if err := rt.SendMessage(context.Background(), ports.RuntimeHandle{ID: "s1"}, ""); err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+		if got := fc.commands(); len(got) != 1 || !strings.Contains(got[0], "Enter") {
+			t.Errorf("commands = %v, want single Enter", got)
+		}
+	})
+}
+
+// unquoteShell reverses shellQuote for test reassembly.
+func unquoteShell(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "'")
+	s = strings.TrimSuffix(s, "'")
+	return strings.ReplaceAll(s, `'\''`, "'")
+}
+
+func TestRestartFallsBackToNewSessionAfterPark(t *testing.T) {
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStopped)
+	// After the wake, tmux is empty: respawn-pane cannot find the session.
+	fc.onExec("tmux respawn-pane", ExecResult{ExitCode: 1, Result: "can't find pane: s1:0.0"}, nil)
+	rt := newTestRuntime(t, fc)
+
+	handle, err := rt.Restart(context.Background(), ports.RuntimeHandle{ID: "s1"}, ports.RuntimeConfig{
+		SessionID:     "s1",
+		WorkspacePath: "/w",
+		Argv:          []string{"claude", "--resume", "abc"},
+	})
+	if err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	if handle.ID != "s1" {
+		t.Errorf("handle changed to %q; restart must preserve terminal identity", handle.ID)
+	}
+	if len(fc.started) != 1 {
+		t.Errorf("expected sandbox wake, started=%v", fc.started)
+	}
+	if got := fc.commandsMatching("tmux new-session"); len(got) != 1 {
+		t.Errorf("expected new-session fallback, got %v", fc.commands())
+	}
+}
+
+func TestIsSupervisedProcessAlive(t *testing.T) {
+	table := `  1     0 /sbin/init
+   40     1 tmux server
+  100    40 -sh
+  200   100 ao agent-process supervise --session s1 --launch L1 -- claude
+  300   200 claude
+`
+	t.Run("matching supervisor generation is alive", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("display-message", ExecResult{Result: "100\n"}, nil)
+		fc.onExec("ps -ww", ExecResult{Result: table}, nil)
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsSupervisedProcessAlive(context.Background(), ports.RuntimeHandle{ID: "s1"},
+			ports.SupervisedProcessRef{SessionID: "s1", LaunchID: "L1"})
+		if err != nil || !alive {
+			t.Fatalf("alive=%v err=%v, want true nil", alive, err)
+		}
+	})
+	t.Run("stale launch generation is dead", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("display-message", ExecResult{Result: "100\n"}, nil)
+		fc.onExec("ps -ww", ExecResult{Result: table}, nil)
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsSupervisedProcessAlive(context.Background(), ports.RuntimeHandle{ID: "s1"},
+			ports.SupervisedProcessRef{SessionID: "s1", LaunchID: "L2"})
+		if err != nil || alive {
+			t.Fatalf("alive=%v err=%v, want false nil (old generation)", alive, err)
+		}
+	})
+	t.Run("parked sandbox means agent exited", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStopped)
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsSupervisedProcessAlive(context.Background(), ports.RuntimeHandle{ID: "s1"},
+			ports.SupervisedProcessRef{SessionID: "s1", LaunchID: "L1"})
+		if err != nil || alive {
+			t.Fatalf("alive=%v err=%v, want false nil (stop killed the agent)", alive, err)
+		}
+	})
+	t.Run("bare keep-alive shell with no children is exited", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("display-message", ExecResult{Result: "100\n"}, nil)
+		fc.onExec("ps -ww", ExecResult{Result: "  1 0 /sbin/init\n  100 40 -sh\n"}, nil)
+		rt := newTestRuntime(t, fc)
+		alive, err := rt.IsSupervisedProcessAlive(context.Background(), ports.RuntimeHandle{ID: "s1"},
+			ports.SupervisedProcessRef{SessionID: "s1", LaunchID: "L1"})
+		if err != nil || alive {
+			t.Fatalf("alive=%v err=%v, want false nil (pane exists but agent gone, #2802)", alive, err)
+		}
+	})
+}

--- a/backend/internal/adapters/runtime/daytona/fake_test.go
+++ b/backend/internal/adapters/runtime/daytona/fake_test.go
@@ -37,6 +37,13 @@ type fakeClient struct {
 	// startsAs lets tests make StartSandbox leave the sandbox in a given state
 	// (default: started immediately).
 	startsAs SandboxState
+
+	// settleAfterGets/settleTo simulate Daytona's async transitions: after N
+	// GetSandbox calls, any sandbox in a transitional state settles to
+	// settleTo. Zero means states never settle on their own.
+	settleAfterGets int
+	settleTo        SandboxState
+	getCalls        int
 }
 
 type execCall struct {
@@ -121,6 +128,10 @@ func (f *fakeClient) GetSandbox(_ context.Context, id string) (Sandbox, error) {
 	sb, ok := f.sandboxes[id]
 	if !ok {
 		return Sandbox{}, fmt.Errorf("%w: %s", ErrSandboxNotFound, id)
+	}
+	f.getCalls++
+	if f.settleAfterGets > 0 && f.getCalls >= f.settleAfterGets && sb.State.Transitional() {
+		sb.State = f.settleTo
 	}
 	return *sb, nil
 }

--- a/backend/internal/adapters/runtime/daytona/fake_test.go
+++ b/backend/internal/adapters/runtime/daytona/fake_test.go
@@ -21,6 +21,7 @@ type fakeClient struct {
 	execHandlers []execHandler
 
 	gitClones []GitCloneRequest
+	gitCreds  []GitCredentialsRequest
 
 	createErr error
 	listErr   error
@@ -228,6 +229,16 @@ func (f *fakeClient) GitClone(_ context.Context, sandboxID string, req GitCloneR
 		return fmt.Errorf("%w: %s", ErrSandboxNotFound, sandboxID)
 	}
 	f.gitClones = append(f.gitClones, req)
+	return nil
+}
+
+func (f *fakeClient) GitSetCredentials(_ context.Context, sandboxID string, req GitCredentialsRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.sandboxes[sandboxID]; !ok {
+		return fmt.Errorf("%w: %s", ErrSandboxNotFound, sandboxID)
+	}
+	f.gitCreds = append(f.gitCreds, req)
 	return nil
 }
 

--- a/backend/internal/adapters/runtime/daytona/fake_test.go
+++ b/backend/internal/adapters/runtime/daytona/fake_test.go
@@ -1,0 +1,223 @@
+package daytona
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// fakeClient is the in-memory Daytona used by unit/contract tests, mirroring
+// how the tmux tests fake their runner: commands are recorded verbatim and
+// responses are scripted per command substring.
+type fakeClient struct {
+	mu        sync.Mutex
+	nextID    int
+	sandboxes map[string]*Sandbox
+
+	execCalls []execCall
+	// execHandlers are consulted in order; the first whose substring matches
+	// the command answers it. Unmatched commands succeed with empty output.
+	execHandlers []execHandler
+
+	gitClones []GitCloneRequest
+
+	createErr error
+	listErr   error
+	startErr  error
+	stopErr   error
+	deleteErr error
+	gitErr    error
+
+	createdReqs []CreateSandboxRequest
+	started     []string
+	stopped     []string
+	deleted     []string
+
+	// startsAs lets tests make StartSandbox leave the sandbox in a given state
+	// (default: started immediately).
+	startsAs SandboxState
+}
+
+type execCall struct {
+	sandboxID string
+	command   string
+}
+
+type execHandler struct {
+	substr string
+	result ExecResult
+	err    error
+}
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{sandboxes: map[string]*Sandbox{}}
+}
+
+// seedSandbox registers a sandbox for a session handle in the given state and
+// returns its id.
+func (f *fakeClient) seedSandbox(handle string, state SandboxState) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextID++
+	id := fmt.Sprintf("sb-%d", f.nextID)
+	f.sandboxes[id] = &Sandbox{
+		ID:     id,
+		Name:   "ao-" + handle,
+		State:  state,
+		Labels: map[string]string{LabelSession: handle},
+	}
+	return id
+}
+
+// onExec scripts a response for commands containing substr.
+func (f *fakeClient) onExec(substr string, result ExecResult, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.execHandlers = append(f.execHandlers, execHandler{substr: substr, result: result, err: err})
+}
+
+func (f *fakeClient) commands() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.execCalls))
+	for i, c := range f.execCalls {
+		out[i] = c.command
+	}
+	return out
+}
+
+func (f *fakeClient) commandsMatching(substr string) []string {
+	var out []string
+	for _, c := range f.commands() {
+		if strings.Contains(c, substr) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func (f *fakeClient) CreateSandbox(_ context.Context, req CreateSandboxRequest) (Sandbox, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.createErr != nil {
+		return Sandbox{}, f.createErr
+	}
+	f.createdReqs = append(f.createdReqs, req)
+	f.nextID++
+	id := fmt.Sprintf("sb-%d", f.nextID)
+	labels := map[string]string{}
+	for k, v := range req.Labels {
+		labels[k] = v
+	}
+	sb := &Sandbox{ID: id, Name: req.Name, State: StateStarted, Labels: labels}
+	f.sandboxes[id] = sb
+	return *sb, nil
+}
+
+func (f *fakeClient) GetSandbox(_ context.Context, id string) (Sandbox, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	sb, ok := f.sandboxes[id]
+	if !ok {
+		return Sandbox{}, fmt.Errorf("%w: %s", ErrSandboxNotFound, id)
+	}
+	return *sb, nil
+}
+
+func (f *fakeClient) ListSandboxes(_ context.Context, labels map[string]string) ([]Sandbox, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var out []Sandbox
+	for _, sb := range f.sandboxes {
+		match := true
+		for k, v := range labels {
+			if sb.Labels[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			out = append(out, *sb)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeClient) StartSandbox(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.startErr != nil {
+		return f.startErr
+	}
+	f.started = append(f.started, id)
+	if sb, ok := f.sandboxes[id]; ok {
+		if f.startsAs != "" {
+			sb.State = f.startsAs
+		} else {
+			sb.State = StateStarted
+		}
+	}
+	return nil
+}
+
+func (f *fakeClient) StopSandbox(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.stopErr != nil {
+		return f.stopErr
+	}
+	f.stopped = append(f.stopped, id)
+	if sb, ok := f.sandboxes[id]; ok {
+		sb.State = StateStopped
+	}
+	return nil
+}
+
+func (f *fakeClient) DeleteSandbox(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.deleted = append(f.deleted, id)
+	delete(f.sandboxes, id)
+	return nil
+}
+
+func (f *fakeClient) Exec(_ context.Context, sandboxID string, req ExecRequest) (ExecResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.sandboxes[sandboxID]; !ok {
+		return ExecResult{}, fmt.Errorf("%w: %s", ErrSandboxNotFound, sandboxID)
+	}
+	f.execCalls = append(f.execCalls, execCall{sandboxID: sandboxID, command: req.Command})
+	for _, h := range f.execHandlers {
+		if strings.Contains(req.Command, h.substr) {
+			return h.result, h.err
+		}
+	}
+	return ExecResult{ExitCode: 0}, nil
+}
+
+func (f *fakeClient) OpenPTY(context.Context, string, PTYSpec) (PTYConn, error) {
+	return nil, fmt.Errorf("fake: pty not scripted")
+}
+
+func (f *fakeClient) GitClone(_ context.Context, sandboxID string, req GitCloneRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.gitErr != nil {
+		return f.gitErr
+	}
+	if _, ok := f.sandboxes[sandboxID]; !ok {
+		return fmt.Errorf("%w: %s", ErrSandboxNotFound, sandboxID)
+	}
+	f.gitClones = append(f.gitClones, req)
+	return nil
+}
+
+var _ Client = (*fakeClient)(nil)

--- a/backend/internal/adapters/runtime/daytona/process.go
+++ b/backend/internal/adapters/runtime/daytona/process.go
@@ -1,0 +1,100 @@
+package daytona
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Process-table inspection for IsSupervisedProcessAlive, mirroring the tmux
+// adapter's semantics (issue #2802): the initial launch is identified by its
+// exact `ao agent-process supervise --session … --launch … --` supervisor;
+// once no supervisor remains under the pane, any child of the preserved
+// interactive shell counts as a manually resumed workload.
+
+type processEntry struct {
+	pid     int
+	ppid    int
+	command string
+}
+
+func parseProcessTable(out string) ([]processEntry, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	entries := make([]processEntry, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid pid in %q", line)
+		}
+		ppid, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid parent pid in %q", line)
+		}
+		entries = append(entries, processEntry{pid: pid, ppid: ppid, command: strings.Join(fields[2:], " ")})
+	}
+	return entries, nil
+}
+
+func descendantPIDs(entries []processEntry, rootPID int) map[int]bool {
+	descendants := map[int]bool{rootPID: true}
+	for changed := true; changed; {
+		changed = false
+		for _, entry := range entries {
+			if descendants[entry.pid] || !descendants[entry.ppid] {
+				continue
+			}
+			descendants[entry.pid] = true
+			changed = true
+		}
+	}
+	return descendants
+}
+
+func containsManagedWorkload(entries []processEntry, rootPID int, sessionID, launchID string) bool {
+	descendants := descendantPIDs(entries, rootPID)
+	hasChild := false
+	hasSupervisor := false
+	for _, entry := range entries {
+		if entry.pid == rootPID || !descendants[entry.pid] {
+			continue
+		}
+		hasChild = true
+		if !isAnySupervisorCommand(entry.command) {
+			continue
+		}
+		hasSupervisor = true
+		if isSupervisorCommand(entry.command, sessionID, launchID) {
+			return true
+		}
+	}
+	// A supervisor in the pane tree must match the current generation. Once no
+	// supervisor remains, the pane root is the preserved interactive shell and
+	// any child is a workload the operator launched from that shell.
+	return hasChild && !hasSupervisor
+}
+
+func isAnySupervisorCommand(command string) bool {
+	fields := strings.Fields(command)
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] == "agent-process" && fields[i+1] == "supervise" {
+			return true
+		}
+	}
+	return false
+}
+
+func isSupervisorCommand(command, sessionID, launchID string) bool {
+	fields := strings.Fields(command)
+	for i := 0; i+6 < len(fields); i++ {
+		if fields[i] == "agent-process" && fields[i+1] == "supervise" &&
+			fields[i+2] == "--session" && fields[i+3] == sessionID &&
+			fields[i+4] == "--launch" && fields[i+5] == launchID && fields[i+6] == "--" {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/adapters/runtime/daytona/smoke_live_test.go
+++ b/backend/internal/adapters/runtime/daytona/smoke_live_test.go
@@ -1,0 +1,289 @@
+package daytona
+
+// Live smoke tests against the real Daytona API. They are skipped unless
+// DAYTONA_API_KEY is set (mirroring how tmux_integration_test gates on a real
+// tmux); CI never runs them. Optional env:
+//
+//	DAYTONA_API_URL          – API base override (default https://app.daytona.io/api)
+//	AO_DAYTONA_SNAPSHOT      – snapshot with tmux/git (and for the agent test,
+//	                           an agent CLI) preinstalled; default: Daytona's
+//	                           default snapshot, with a best-effort tmux install
+//	AO_DAYTONA_AGENT_ARGV    – JSON argv for the real-agent demo test, e.g.
+//	                           ["claude","-p","say hello"]
+//
+// Cost note: each test creates one default-size sandbox (~$0.067/h) and
+// deletes it on exit; a full run is a few sandbox-minutes.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func liveClient(t *testing.T) *apiClient {
+	t.Helper()
+	key := os.Getenv("DAYTONA_API_KEY")
+	if key == "" {
+		t.Skip("DAYTONA_API_KEY not set; skipping live Daytona smoke test")
+	}
+	c, err := NewClient(ClientOptions{APIKey: key, APIURL: os.Getenv("DAYTONA_API_URL")})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+// ensureTmux makes tmux available in the sandbox, installing it when the
+// snapshot lacks it. Skips the calling test when installation is impossible.
+func ensureTmux(t *testing.T, c Client, sandboxID string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	res, err := c.Exec(ctx, sandboxID, ExecRequest{
+		Command: "tmux -V || (sudo apt-get update -qq && sudo apt-get install -y -qq tmux) || " +
+			"(apt-get update -qq && apt-get install -y -qq tmux)",
+		TimeoutSeconds: 170,
+	})
+	if err != nil {
+		t.Fatalf("ensure tmux: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Skipf("snapshot has no tmux and install failed (exit %d): %s — set AO_DAYTONA_SNAPSHOT to a tmux-equipped snapshot", res.ExitCode, res.Result)
+	}
+}
+
+func liveWorkspace(t *testing.T, c Client) *Workspace {
+	t.Helper()
+	ws, err := NewWorkspace(WorkspaceOptions{
+		Client:   c,
+		Snapshot: os.Getenv("AO_DAYTONA_SNAPSHOT"),
+		ResolveRepo: func(context.Context, ports.WorkspaceConfig) (RepoRemote, error) {
+			return RepoRemote{URL: "https://github.com/octocat/Hello-World.git", DefaultBranch: "master"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	return ws
+}
+
+// smokeSessionID is unique per run so concurrent/aborted runs never collide on
+// sandbox labels.
+func smokeSessionID(t *testing.T) string {
+	return fmt.Sprintf("ao-smoke-%s-%d", strings.ToLower(t.Name()[strings.LastIndex(t.Name(), "_")+1:]), time.Now().Unix())
+}
+
+func TestLive_ClientSandboxLifecycle(t *testing.T) {
+	c := liveClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	sb, err := c.CreateSandbox(ctx, CreateSandboxRequest{
+		Snapshot: os.Getenv("AO_DAYTONA_SNAPSHOT"),
+		Labels:   map[string]string{LabelSession: smokeSessionID(t)},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox: %v", err)
+	}
+	t.Cleanup(func() { _ = c.DeleteSandbox(context.Background(), sb.ID) })
+	core := core{client: c, execTimeout: 60 * time.Second, startTimeout: 2 * time.Minute}
+	if _, err := core.waitForState(ctx, sb.ID, StateStarted, 5*time.Minute); err != nil {
+		t.Fatalf("wait started: %v", err)
+	}
+
+	res, err := c.Exec(ctx, sb.ID, ExecRequest{Command: "echo live-smoke-$((20+3))", TimeoutSeconds: 30})
+	if err != nil || res.ExitCode != 0 || !strings.Contains(res.Result, "live-smoke-23") {
+		t.Fatalf("exec: res=%+v err=%v", res, err)
+	}
+
+	// PTY round-trip: write a command, expect its output back over the socket.
+	pty, err := c.OpenPTY(ctx, sb.ID, PTYSpec{ID: "ao-smoke-pty", Rows: 24, Cols: 80})
+	if err != nil {
+		t.Fatalf("OpenPTY: %v", err)
+	}
+	defer func() { _ = pty.Close() }()
+	if _, err := pty.Write([]byte("echo pty-rt-$((40+2))\n")); err != nil {
+		t.Fatalf("pty write: %v", err)
+	}
+	if err := pty.Resize(30, 100); err != nil {
+		t.Errorf("pty resize: %v", err)
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	var seen strings.Builder
+	buf := make([]byte, 4096)
+	for time.Now().Before(deadline) && !strings.Contains(seen.String(), "pty-rt-42") {
+		n, err := pty.Read(buf)
+		if n > 0 {
+			seen.Write(buf[:n])
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("pty read: %v (seen: %q)", err, seen.String())
+		}
+	}
+	if !strings.Contains(seen.String(), "pty-rt-42") {
+		t.Fatalf("pty output missing marker; seen: %q", seen.String())
+	}
+}
+
+// TestLive_RuntimeSessionLifecycle is the exit-criteria flow minus the real
+// agent binary: workspace (sandbox + clone) → tmux-hosted process → output
+// capture → message round-trip → park → wake/restart → teardown.
+func TestLive_RuntimeSessionLifecycle(t *testing.T) {
+	c := liveClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	sessionID := smokeSessionID(t)
+	ws := liveWorkspace(t, c)
+	rt, err := New(Options{Client: c, ExecTimeout: 60 * time.Second, StartTimeout: 3 * time.Minute})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	info, err := ws.Create(ctx, ports.WorkspaceConfig{
+		ProjectID: "ao-smoke",
+		SessionID: domain.SessionID(sessionID),
+		Branch:    "ao/smoke/root",
+	})
+	if err != nil {
+		t.Fatalf("workspace create: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.ForceDestroy(context.Background(), info) })
+
+	handleName, _ := sessionName(info.SessionID)
+	sb, found, err := rt.sandboxForHandle(ctx, handleName)
+	if err != nil || !found {
+		t.Fatalf("sandbox lookup: found=%v err=%v", found, err)
+	}
+	ensureTmux(t, c, sb.ID)
+
+	handle, err := rt.Create(ctx, ports.RuntimeConfig{
+		SessionID:     info.SessionID,
+		WorkspacePath: info.Path,
+		Argv:          []string{"sh", "-c", "echo agent-started; cat"},
+		Env:           map[string]string{"AO_SESSION_ID": string(info.SessionID)},
+	})
+	if err != nil {
+		t.Fatalf("runtime create: %v", err)
+	}
+
+	waitForOutput(t, rt, handle, "agent-started", 30*time.Second)
+	if err := rt.SendMessage(ctx, handle, "ping-round-trip"); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	waitForOutput(t, rt, handle, "ping-round-trip", 30*time.Second)
+
+	// Park → wake: stop kills tmux; Restart must transparently rebuild the
+	// terminal under the same handle.
+	if err := ws.Park(ctx, info); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	alive, err := rt.IsAlive(ctx, handle)
+	if err != nil || !alive {
+		t.Fatalf("parked IsAlive = %v/%v, want true (parked is not dead)", alive, err)
+	}
+	if _, err := rt.Restart(ctx, handle, ports.RuntimeConfig{
+		SessionID:     info.SessionID,
+		WorkspacePath: info.Path,
+		Argv:          []string{"sh", "-c", "echo agent-restarted; cat"},
+	}); err != nil {
+		t.Fatalf("restart after park: %v", err)
+	}
+	waitForOutput(t, rt, handle, "agent-restarted", 30*time.Second)
+
+	if err := rt.Destroy(ctx, handle); err != nil {
+		t.Fatalf("runtime destroy: %v", err)
+	}
+	if err := ws.Destroy(ctx, info); err != nil {
+		t.Fatalf("workspace destroy: %v", err)
+	}
+	if _, found, _ := rt.sandboxForHandle(ctx, handleName); found {
+		t.Fatal("sandbox survived workspace destroy")
+	}
+}
+
+// TestLive_RealAgentSession launches a real agent CLI (argv from
+// AO_DAYTONA_AGENT_ARGV, e.g. ["claude","-p","say hello"]) inside the sandbox
+// with the caller's credential env injected, and asserts the agent produced
+// terminal output — the phase-2 exit-criteria demo. Requires a snapshot with
+// the agent CLI preinstalled.
+func TestLive_RealAgentSession(t *testing.T) {
+	argvJSON := os.Getenv("AO_DAYTONA_AGENT_ARGV")
+	if argvJSON == "" {
+		t.Skip("AO_DAYTONA_AGENT_ARGV not set; skipping real-agent demo")
+	}
+	var argv []string
+	if err := json.Unmarshal([]byte(argvJSON), &argv); err != nil || len(argv) == 0 {
+		t.Fatalf("AO_DAYTONA_AGENT_ARGV must be a JSON string array: %v", err)
+	}
+	c := liveClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	ws := liveWorkspace(t, c)
+	rt, err := New(Options{Client: c, ExecTimeout: 60 * time.Second, StartTimeout: 3 * time.Minute})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	info, err := ws.Create(ctx, ports.WorkspaceConfig{
+		ProjectID: "ao-smoke",
+		SessionID: domain.SessionID(smokeSessionID(t)),
+		Branch:    "ao/smoke/agent",
+	})
+	if err != nil {
+		t.Fatalf("workspace create: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.ForceDestroy(context.Background(), info) })
+
+	env := map[string]string{"AO_SESSION_ID": string(info.SessionID)}
+	if tok := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"); tok != "" {
+		env["CLAUDE_CODE_OAUTH_TOKEN"] = tok
+	}
+	handle, err := rt.Create(ctx, ports.RuntimeConfig{
+		SessionID:     info.SessionID,
+		WorkspacePath: info.Path,
+		Argv:          argv,
+		Env:           env,
+	})
+	if err != nil {
+		t.Fatalf("runtime create: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Minute)
+	for time.Now().Before(deadline) {
+		out, err := rt.GetOutput(ctx, handle, 200)
+		if err == nil && len(strings.TrimSpace(out)) > 0 {
+			t.Logf("agent output:\n%s", out)
+			return
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatal("agent produced no terminal output within 5m")
+}
+
+func waitForOutput(t *testing.T, rt *Runtime, handle ports.RuntimeHandle, marker string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		out, err := rt.GetOutput(context.Background(), handle, 200)
+		if err == nil {
+			last = out
+			if strings.Contains(out, marker) {
+				return
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("marker %q not seen in output within %s; last output:\n%s", marker, timeout, last)
+}

--- a/backend/internal/adapters/runtime/daytona/smoke_live_test.go
+++ b/backend/internal/adapters/runtime/daytona/smoke_live_test.go
@@ -17,6 +17,7 @@ package daytona
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -124,7 +125,7 @@ func TestLive_ClientSandboxLifecycle(t *testing.T) {
 		if n > 0 {
 			seen.Write(buf[:n])
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/backend/internal/adapters/runtime/daytona/workspace.go
+++ b/backend/internal/adapters/runtime/daytona/workspace.go
@@ -1,0 +1,594 @@
+package daytona
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Workspace provisions a session's isolated checkout INSIDE its Daytona
+// sandbox: Create makes the sandbox (from the configured snapshot, with the
+// control plane's boot env injected) and clones the project repo into it;
+// Destroy tears the sandbox down after the same dirty-worktree refusal the
+// local gitworktree adapter enforces. Every git operation runs in the sandbox
+// via the toolbox API, mirroring the local adapter's command sequences.
+type Workspace struct {
+	core
+	opts          WorkspaceOptions
+	createTimeout time.Duration
+	logger        *slog.Logger
+}
+
+var _ ports.Workspace = (*Workspace)(nil)
+
+// RepoRemote tells the workspace adapter where a project's repository lives
+// from the sandbox's point of view, plus clone credentials for private repos.
+type RepoRemote struct {
+	// URL is the clone URL (https). Required.
+	URL string
+	// DefaultBranch is the branch session branches are created from when the
+	// workspace config does not name one.
+	DefaultBranch string
+	// Username/Password authenticate the clone (e.g. "x-access-token" + a
+	// GitHub token). They travel in the toolbox git API body, never on a
+	// command line.
+	Username string
+	Password string
+}
+
+// WorkspaceOptions configures the Daytona Workspace adapter.
+type WorkspaceOptions struct {
+	// Client talks to Daytona. Required.
+	Client Client
+	// Snapshot is the Daytona snapshot sandboxes are created from. It must have
+	// tmux, git, and the agent harness (agent CLIs + `ao` Linux binary)
+	// preinstalled; see docs/cloud/daytona-runtime.md. Required for Create.
+	Snapshot string
+	// Target picks the Daytona region ("us"/"eu"); empty uses the org default.
+	Target string
+	// CPU/MemoryGiB/DiskGiB size the sandbox; zero uses Daytona defaults.
+	CPU       int
+	MemoryGiB int
+	DiskGiB   int
+	// AutoStopMinutes is Daytona's inactivity auto-stop (the park mechanism in
+	// the cost model). 0 applies the adapter default (15); -1 disables
+	// auto-stop entirely.
+	AutoStopMinutes int
+	// AutoArchiveMinutes is how long a stopped sandbox waits before archiving
+	// to object storage; 0 keeps Daytona's default.
+	AutoArchiveMinutes int
+	// BootEnv is injected into the sandbox at creation — this is where the
+	// control plane places agent inference credentials (e.g.
+	// CLAUDE_CODE_OAUTH_TOKEN) and the hooks-path env (AO_API_BASE,
+	// AO_API_TOKEN). See the design doc's control-plane contract.
+	BootEnv map[string]string
+	// WorkspaceRoot is the directory inside the sandbox that holds session
+	// checkouts; default /home/daytona/ao.
+	WorkspaceRoot string
+	// ResolveRepo maps a workspace config onto a clone URL + credentials. The
+	// default resolver reads the `origin` remote of cfg.RepoPath on the daemon
+	// host (the hybrid local-daemon/cloud-runtime setup); the cloud control
+	// plane substitutes its own resolver.
+	ResolveRepo func(ctx context.Context, cfg ports.WorkspaceConfig) (RepoRemote, error)
+	// GitUserName/GitUserEmail configure commit identity inside the sandbox so
+	// agents can commit out of the box. Defaults: "AO Agent" /
+	// "ao-agent@users.noreply.github.com"; set either to "-" to skip.
+	GitUserName  string
+	GitUserEmail string
+	// ExecTimeout / StartTimeout mirror Options. CreateTimeout bounds sandbox
+	// creation (snapshot pull) and the initial clone; default 5m.
+	ExecTimeout   time.Duration
+	StartTimeout  time.Duration
+	CreateTimeout time.Duration
+	// Logger receives provisioning diagnostics; nil defaults to slog.Default().
+	Logger *slog.Logger
+}
+
+const (
+	defaultWorkspaceRoot   = "/home/daytona/ao"
+	defaultAutoStopMinutes = 15
+	defaultGitUserName     = "AO Agent"
+	defaultGitUserEmail    = "ao-agent@users.noreply.github.com"
+)
+
+// NewWorkspace builds the Daytona Workspace adapter.
+func NewWorkspace(opts WorkspaceOptions) (*Workspace, error) {
+	if opts.Client == nil {
+		return nil, errors.New("daytona workspace: client is required")
+	}
+	if err := validateEnvKeys(opts.BootEnv); err != nil {
+		return nil, fmt.Errorf("daytona workspace: boot env: %w", err)
+	}
+	if opts.WorkspaceRoot == "" {
+		opts.WorkspaceRoot = defaultWorkspaceRoot
+	}
+	if opts.AutoStopMinutes == 0 {
+		opts.AutoStopMinutes = defaultAutoStopMinutes
+	}
+	if opts.ResolveRepo == nil {
+		opts.ResolveRepo = resolveRepoFromLocalOrigin
+	}
+	if opts.GitUserName == "" {
+		opts.GitUserName = defaultGitUserName
+	}
+	if opts.GitUserEmail == "" {
+		opts.GitUserEmail = defaultGitUserEmail
+	}
+	execTimeout := opts.ExecTimeout
+	if execTimeout <= 0 {
+		execTimeout = defaultExecTimeout
+	}
+	startTimeout := opts.StartTimeout
+	if startTimeout <= 0 {
+		startTimeout = defaultStartTimeout
+	}
+	createTimeout := opts.CreateTimeout
+	if createTimeout <= 0 {
+		createTimeout = defaultCreateTimeout
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Workspace{
+		core: core{
+			client:       opts.Client,
+			execTimeout:  execTimeout,
+			startTimeout: startTimeout,
+		},
+		opts:          opts,
+		createTimeout: createTimeout,
+		logger:        logger,
+	}, nil
+}
+
+// resolveRepoFromLocalOrigin is the default resolver for the hybrid setup
+// where the daemon runs next to the canonical repo: it reads the repo's
+// `origin` URL on the daemon host. Credentials are left empty (public repos,
+// or a snapshot with ambient git credentials).
+func resolveRepoFromLocalOrigin(ctx context.Context, cfg ports.WorkspaceConfig) (RepoRemote, error) {
+	if cfg.RepoPath == "" {
+		return RepoRemote{}, errors.New("daytona workspace: no repo path to resolve a clone URL from; configure WorkspaceOptions.ResolveRepo")
+	}
+	out, err := exec.CommandContext(ctx, "git", "-C", cfg.RepoPath, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return RepoRemote{}, fmt.Errorf("daytona workspace: resolve origin of %s: %w", cfg.RepoPath, err)
+	}
+	return RepoRemote{URL: strings.TrimSpace(string(out))}, nil
+}
+
+// workspacePath is the checkout directory for a session inside its sandbox.
+func (w *Workspace) workspacePath(name string) string {
+	return strings.TrimRight(w.opts.WorkspaceRoot, "/") + "/" + name
+}
+
+// Create provisions the session's sandbox and clones the repo/branch into it.
+func (w *Workspace) Create(ctx context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
+	name, err := sessionName(cfg.SessionID)
+	if err != nil {
+		return ports.WorkspaceInfo{}, err
+	}
+	if w.opts.Snapshot == "" {
+		return ports.WorkspaceInfo{}, errors.New("daytona workspace: snapshot is required to create sandboxes")
+	}
+	remote, err := w.opts.ResolveRepo(ctx, cfg)
+	if err != nil {
+		return ports.WorkspaceInfo{}, err
+	}
+	if remote.URL == "" {
+		return ports.WorkspaceInfo{}, errors.New("daytona workspace: repo resolver returned an empty clone URL")
+	}
+
+	sb, found, err := w.sandboxForHandle(ctx, name)
+	if err != nil {
+		return ports.WorkspaceInfo{}, err
+	}
+	if !found {
+		sb, err = w.createSandbox(ctx, name, cfg)
+		if err != nil {
+			return ports.WorkspaceInfo{}, err
+		}
+	} else {
+		if sb, err = w.ensureStarted(ctx, sb); err != nil {
+			return ports.WorkspaceInfo{}, err
+		}
+	}
+
+	path := w.workspacePath(name)
+	branch, err := w.provisionCheckout(ctx, sb, path, cfg, remote)
+	if err != nil {
+		// The sandbox without a checkout is useless; tear it down so a retried
+		// spawn does not find a half-provisioned sandbox.
+		if delErr := w.client.DeleteSandbox(context.WithoutCancel(ctx), sb.ID); delErr != nil {
+			w.logger.Warn("daytona workspace: cleanup after failed provision", "sandbox", sb.ID, "error", delErr)
+		}
+		return ports.WorkspaceInfo{}, err
+	}
+	return ports.WorkspaceInfo{
+		Path:      path,
+		Branch:    branch,
+		SessionID: cfg.SessionID,
+		ProjectID: cfg.ProjectID,
+	}, nil
+}
+
+func (w *Workspace) createSandbox(ctx context.Context, name string, cfg ports.WorkspaceConfig) (Sandbox, error) {
+	autoStop := w.opts.AutoStopMinutes
+	if autoStop < 0 {
+		autoStop = 0 // Daytona: 0 disables auto-stop
+	}
+	req := CreateSandboxRequest{
+		Name:     "ao-" + name,
+		Snapshot: w.opts.Snapshot,
+		Env:      w.opts.BootEnv,
+		Labels: map[string]string{
+			LabelSession: name,
+			LabelProject: string(cfg.ProjectID),
+		},
+		Target:           w.opts.Target,
+		CPU:              w.opts.CPU,
+		Memory:           w.opts.MemoryGiB,
+		Disk:             w.opts.DiskGiB,
+		AutoStopInterval: &autoStop,
+	}
+	if w.opts.AutoArchiveMinutes > 0 {
+		v := w.opts.AutoArchiveMinutes
+		req.AutoArchiveInterval = &v
+	}
+	sb, err := w.client.CreateSandbox(ctx, req)
+	if err != nil {
+		return Sandbox{}, fmt.Errorf("daytona workspace: create sandbox for %s: %w", name, err)
+	}
+	if sb.State == StateStarted {
+		return sb, nil
+	}
+	sb, err = w.waitForState(ctx, sb.ID, StateStarted, w.createTimeout)
+	if err != nil {
+		if delErr := w.client.DeleteSandbox(context.WithoutCancel(ctx), sb.ID); delErr != nil {
+			w.logger.Warn("daytona workspace: cleanup after failed create", "sandbox", sb.ID, "error", delErr)
+		}
+		return Sandbox{}, err
+	}
+	return sb, nil
+}
+
+// provisionCheckout clones the repo (base branch when set) and creates or
+// checks out the session branch, returning the effective branch name. An
+// existing valid checkout is reused (idempotent retry after a partial spawn).
+func (w *Workspace) provisionCheckout(ctx context.Context, sb Sandbox, path string, cfg ports.WorkspaceConfig, remote RepoRemote) (string, error) {
+	// Already provisioned? (`git -C path rev-parse` succeeds only for a repo.)
+	if _, err := w.exec(ctx, sb.ID, "git -C "+shellQuote(path)+" rev-parse --is-inside-work-tree"); err == nil {
+		return w.currentBranch(ctx, sb.ID, path)
+	}
+
+	baseBranch := cfg.BaseBranch
+	if baseBranch == "" {
+		baseBranch = remote.DefaultBranch
+	}
+	cloneCtx, cancel := context.WithTimeout(ctx, w.createTimeout)
+	defer cancel()
+	if err := w.client.GitClone(cloneCtx, sb.ID, GitCloneRequest{
+		URL:      remote.URL,
+		Path:     path,
+		Branch:   baseBranch,
+		Username: remote.Username,
+		Password: remote.Password,
+	}); err != nil {
+		return "", fmt.Errorf("daytona workspace: clone %s: %w", remote.URL, err)
+	}
+	if err := w.configureGitIdentity(ctx, sb.ID, path); err != nil {
+		return "", err
+	}
+
+	branch := cfg.Branch
+	if branch == "" {
+		// Scratch-style session: stay on the cloned branch.
+		return w.currentBranch(ctx, sb.ID, path)
+	}
+	if err := validateBranchName(branch); err != nil {
+		return "", err
+	}
+	// Prefer resuming an existing remote branch (restore of a prior session);
+	// otherwise create the session branch from the cloned base.
+	script := "cd " + shellQuote(path) + " && " +
+		"if git fetch origin " + shellQuote(branch) + " >/dev/null 2>&1; then " +
+		"git checkout -B " + shellQuote(branch) + " FETCH_HEAD; else " +
+		"git checkout -B " + shellQuote(branch) + "; fi"
+	if _, err := w.execWithTimeout(ctx, sb.ID, script, w.createTimeout); err != nil {
+		return "", fmt.Errorf("daytona workspace: checkout branch %s: %w", branch, err)
+	}
+	return branch, nil
+}
+
+func (w *Workspace) configureGitIdentity(ctx context.Context, sandboxID, path string) error {
+	if w.opts.GitUserName == "-" || w.opts.GitUserEmail == "-" {
+		return nil
+	}
+	script := "cd " + shellQuote(path) +
+		" && git config user.name " + shellQuote(w.opts.GitUserName) +
+		" && git config user.email " + shellQuote(w.opts.GitUserEmail)
+	if _, err := w.exec(ctx, sandboxID, script); err != nil {
+		return fmt.Errorf("daytona workspace: configure git identity: %w", err)
+	}
+	return nil
+}
+
+func (w *Workspace) currentBranch(ctx context.Context, sandboxID, path string) (string, error) {
+	out, err := w.exec(ctx, sandboxID, "git -C "+shellQuote(path)+" rev-parse --abbrev-ref HEAD")
+	if err != nil {
+		return "", fmt.Errorf("daytona workspace: read current branch: %w", err)
+	}
+	return strings.TrimSpace(out.Result), nil
+}
+
+// branchNamePattern conservatively bounds branch names before they are placed
+// in a shell command (they are also shell-quoted; this is defense in depth and
+// mirrors ports.ErrWorkspaceBranchInvalid semantics).
+var branchNamePattern = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+func validateBranchName(branch string) error {
+	if !branchNamePattern.MatchString(branch) || strings.HasPrefix(branch, "-") || strings.Contains(branch, "..") {
+		return fmt.Errorf("%w: %q", ports.ErrWorkspaceBranchInvalid, branch)
+	}
+	return nil
+}
+
+// Restore brings a torn-down session's workspace back: it wakes the existing
+// sandbox when one survives, or re-provisions from the remote when the sandbox
+// was deleted (the session branch is fetched if it exists on the remote).
+func (w *Workspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
+	name, err := sessionName(cfg.SessionID)
+	if err != nil {
+		return ports.WorkspaceInfo{}, err
+	}
+	sb, found, err := w.sandboxForHandle(ctx, name)
+	if err != nil {
+		return ports.WorkspaceInfo{}, err
+	}
+	if !found {
+		return w.Create(ctx, cfg)
+	}
+	if sb, err = w.ensureStarted(ctx, sb); err != nil {
+		return ports.WorkspaceInfo{}, err
+	}
+	path := w.workspacePath(name)
+	if _, err := w.exec(ctx, sb.ID, "git -C "+shellQuote(path)+" rev-parse --is-inside-work-tree"); err != nil {
+		return ports.WorkspaceInfo{}, fmt.Errorf("daytona workspace: restore %s: checkout missing: %w: %v", name, ports.ErrWorkspaceStale, err)
+	}
+	branch, err := w.currentBranch(ctx, sb.ID, path)
+	if err != nil {
+		return ports.WorkspaceInfo{}, err
+	}
+	return ports.WorkspaceInfo{
+		Path:      path,
+		Branch:    branch,
+		SessionID: cfg.SessionID,
+		ProjectID: cfg.ProjectID,
+	}, nil
+}
+
+// Destroy tears the sandbox down unless the checkout holds uncommitted work —
+// the same refusal the local adapter enforces (never force-delete dirty
+// worktrees). A parked sandbox is woken for the dirty check and re-parked if
+// the check refuses.
+func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error {
+	name, err := sessionName(info.SessionID)
+	if err != nil {
+		return err
+	}
+	sb, found, err := w.sandboxForHandle(ctx, name)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil // already gone: idempotent
+	}
+	wasParked := sb.State == StateStopped || sb.State == StateArchived
+	if sb, err = w.ensureStarted(ctx, sb); err != nil {
+		return fmt.Errorf("daytona workspace: wake sandbox for dirty check: %w", err)
+	}
+	dirty, err := w.isDirty(ctx, sb.ID, info.Path)
+	if err != nil {
+		return err
+	}
+	if dirty {
+		if wasParked {
+			if stopErr := w.client.StopSandbox(ctx, sb.ID); stopErr != nil {
+				w.logger.Warn("daytona workspace: re-park after dirty refusal", "sandbox", sb.ID, "error", stopErr)
+			}
+		}
+		return fmt.Errorf("daytona workspace: %s: %w", name, ports.ErrWorkspaceDirty)
+	}
+	if err := w.client.DeleteSandbox(ctx, sb.ID); err != nil {
+		return fmt.Errorf("daytona workspace: delete sandbox %s: %w", sb.ID, err)
+	}
+	return nil
+}
+
+// ForceDestroy deletes the sandbox unconditionally. Only safe after
+// StashUncommitted captured the session's work (and, for cloud sessions, only
+// truly durable once preserve refs are pushed to the remote — see the design
+// doc's limitations).
+func (w *Workspace) ForceDestroy(ctx context.Context, info ports.WorkspaceInfo) error {
+	name, err := sessionName(info.SessionID)
+	if err != nil {
+		return err
+	}
+	sb, found, err := w.sandboxForHandle(ctx, name)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+	if err := w.client.DeleteSandbox(ctx, sb.ID); err != nil {
+		return fmt.Errorf("daytona workspace: delete sandbox %s: %w", sb.ID, err)
+	}
+	return nil
+}
+
+func (w *Workspace) isDirty(ctx context.Context, sandboxID, path string) (bool, error) {
+	out, err := w.exec(ctx, sandboxID, "git -C "+shellQuote(path)+" status --porcelain")
+	if err != nil {
+		var execErr *execError
+		if errors.As(err, &execErr) {
+			// Not a git repo any more: stale, nothing to protect.
+			return false, fmt.Errorf("daytona workspace: dirty check %s: %w: %v", path, ports.ErrWorkspaceStale, err)
+		}
+		return false, fmt.Errorf("daytona workspace: dirty check %s: %w", path, err)
+	}
+	return strings.TrimSpace(out.Result) != "", nil
+}
+
+// preserveRefPattern bounds ref names accepted by ApplyPreserved before they
+// enter a shell command (also shell-quoted; defense in depth).
+var preserveRefPattern = regexp.MustCompile(`^refs/ao/preserved/[A-Za-z0-9._-]+$`)
+
+// StashUncommitted captures all uncommitted work as a commit object at
+// refs/ao/preserved/<session-id> without mutating the working tree, mirroring
+// the local gitworktree sequence (temp index → add -A → write-tree →
+// commit-tree → update-ref). Returns "" when the worktree is clean.
+func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceInfo) (string, error) {
+	name, err := sessionName(info.SessionID)
+	if err != nil {
+		return "", err
+	}
+	if info.Path == "" {
+		return "", errors.New("daytona workspace: path is required for StashUncommitted")
+	}
+	sb, found, err := w.sandboxForHandle(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("daytona workspace: stash %s: sandbox missing: %w", name, ports.ErrWorkspaceStale)
+	}
+	if sb, err = w.ensureStarted(ctx, sb); err != nil {
+		return "", err
+	}
+	ref := "refs/ao/preserved/" + name
+	// Exit 3 = stale (not a repo), exit 4 = clean (nothing to preserve).
+	script := "cd " + shellQuote(info.Path) + " || exit 3; " +
+		"git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 3; " +
+		`[ -z "$(git status --porcelain)" ] && exit 4; ` +
+		`IDX="$(mktemp -u)"; ` +
+		"GIT_INDEX_FILE=\"$IDX\" git add -A && " +
+		"TREE=$(GIT_INDEX_FILE=\"$IDX\" git write-tree) && " +
+		"COMMIT=$(git commit-tree \"$TREE\" -p HEAD -m " + shellQuote("ao: preserved uncommitted work for "+name) + ") && " +
+		"git update-ref " + shellQuote(ref) + " \"$COMMIT\"; " +
+		`STATUS=$?; rm -f "$IDX"; exit $STATUS`
+	if _, err := w.exec(ctx, sb.ID, script); err != nil {
+		var execErr *execError
+		if errors.As(err, &execErr) {
+			switch execErr.exitCode {
+			case 3:
+				return "", fmt.Errorf("daytona workspace: stash %s: %w", name, ports.ErrWorkspaceStale)
+			case 4:
+				return "", nil
+			}
+		}
+		return "", fmt.Errorf("daytona workspace: stash %s: %w", name, err)
+	}
+	return ref, nil
+}
+
+// ApplyPreserved replays a StashUncommitted capture via cherry-pick
+// --no-commit; on conflict the ref is kept, markers stay in the tree, and
+// ports.ErrPreservedConflict is returned (wrapped).
+func (w *Workspace) ApplyPreserved(ctx context.Context, info ports.WorkspaceInfo, ref string) error {
+	name, err := sessionName(info.SessionID)
+	if err != nil {
+		return err
+	}
+	if ref == "" {
+		return errors.New("daytona workspace: ApplyPreserved: ref must not be empty")
+	}
+	if !preserveRefPattern.MatchString(ref) {
+		return fmt.Errorf("daytona workspace: ApplyPreserved: invalid ref %q", ref)
+	}
+	sb, found, err := w.sandboxForHandle(ctx, name)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("daytona workspace: apply preserved %s: sandbox missing: %w", name, ports.ErrWorkspaceStale)
+	}
+	if sb, err = w.ensureStarted(ctx, sb); err != nil {
+		return err
+	}
+	// Exit 5 = conflict (cherry-pick left markers; ref must survive).
+	script := "cd " + shellQuote(info.Path) + " && " +
+		"SHA=$(git rev-parse --verify --quiet " + shellQuote(ref) + ") && " +
+		"{ git cherry-pick --no-commit \"$SHA\" || exit 5; } && " +
+		"git update-ref -d " + shellQuote(ref)
+	if _, err := w.exec(ctx, sb.ID, script); err != nil {
+		var execErr *execError
+		if errors.As(err, &execErr) && execErr.exitCode == 5 {
+			return fmt.Errorf("daytona workspace: apply preserved %s: %w: %v", name, ports.ErrPreservedConflict, err)
+		}
+		return fmt.Errorf("daytona workspace: apply preserved %s: %w", name, err)
+	}
+	return nil
+}
+
+// AddExclude appends ignore patterns to the checkout's .git/info/exclude
+// (idempotent), so daemon-generated files never surface as untracked changes.
+func (w *Workspace) AddExclude(ctx context.Context, info ports.WorkspaceInfo, patterns ...string) error {
+	if len(patterns) == 0 {
+		return nil
+	}
+	name, err := sessionName(info.SessionID)
+	if err != nil {
+		return err
+	}
+	sb, found, err := w.sandboxForHandle(ctx, name)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("daytona workspace: add exclude %s: sandbox missing: %w", name, ports.ErrWorkspaceStale)
+	}
+	if sb, err = w.ensureStarted(ctx, sb); err != nil {
+		return err
+	}
+	var b strings.Builder
+	b.WriteString("cd " + shellQuote(info.Path) + " && ")
+	b.WriteString(`D="$(git rev-parse --git-common-dir)" && mkdir -p "$D/info"`)
+	for _, p := range patterns {
+		q := shellQuote(p)
+		b.WriteString(" && { grep -qxF " + q + ` "$D/info/exclude" 2>/dev/null || echo ` + q + ` >> "$D/info/exclude"; }`)
+	}
+	if _, err := w.exec(ctx, sb.ID, b.String()); err != nil {
+		return fmt.Errorf("daytona workspace: add exclude: %w", err)
+	}
+	return nil
+}
+
+// Park stops the session's sandbox so an idle agent stops burning
+// compute-hours (fs preserved, processes killed; see the cost model in
+// docs/cloud/daytona-runtime.md). The lifecycle owner calls this from its
+// idle policy; waking happens implicitly through Runtime.Restart.
+func (w *Workspace) Park(ctx context.Context, info ports.WorkspaceInfo) error {
+	name, err := sessionName(info.SessionID)
+	if err != nil {
+		return err
+	}
+	sb, found, err := w.sandboxForHandle(ctx, name)
+	if err != nil {
+		return err
+	}
+	if !found || sb.State != StateStarted {
+		return nil
+	}
+	if err := w.client.StopSandbox(ctx, sb.ID); err != nil {
+		return fmt.Errorf("daytona workspace: park %s: %w", name, err)
+	}
+	return nil
+}

--- a/backend/internal/adapters/runtime/daytona/workspace.go
+++ b/backend/internal/adapters/runtime/daytona/workspace.go
@@ -358,7 +358,7 @@ func (w *Workspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (por
 	}
 	path := w.workspacePath(name)
 	if _, err := w.exec(ctx, sb.ID, "git -C "+shellQuote(path)+" rev-parse --is-inside-work-tree"); err != nil {
-		return ports.WorkspaceInfo{}, fmt.Errorf("daytona workspace: restore %s: checkout missing: %w: %v", name, ports.ErrWorkspaceStale, err)
+		return ports.WorkspaceInfo{}, fmt.Errorf("daytona workspace: restore %s: checkout missing: %w: %w", name, ports.ErrWorkspaceStale, err)
 	}
 	branch, err := w.currentBranch(ctx, sb.ID, path)
 	if err != nil {
@@ -438,7 +438,7 @@ func (w *Workspace) isDirty(ctx context.Context, sandboxID, path string) (bool, 
 		var execErr *execError
 		if errors.As(err, &execErr) {
 			// Not a git repo any more: stale, nothing to protect.
-			return false, fmt.Errorf("daytona workspace: dirty check %s: %w: %v", path, ports.ErrWorkspaceStale, err)
+			return false, fmt.Errorf("daytona workspace: dirty check %s: %w: %w", path, ports.ErrWorkspaceStale, err)
 		}
 		return false, fmt.Errorf("daytona workspace: dirty check %s: %w", path, err)
 	}
@@ -529,7 +529,7 @@ func (w *Workspace) ApplyPreserved(ctx context.Context, info ports.WorkspaceInfo
 	if _, err := w.exec(ctx, sb.ID, script); err != nil {
 		var execErr *execError
 		if errors.As(err, &execErr) && execErr.exitCode == 5 {
-			return fmt.Errorf("daytona workspace: apply preserved %s: %w: %v", name, ports.ErrPreservedConflict, err)
+			return fmt.Errorf("daytona workspace: apply preserved %s: %w: %w", name, ports.ErrPreservedConflict, err)
 		}
 		return fmt.Errorf("daytona workspace: apply preserved %s: %w", name, err)
 	}

--- a/backend/internal/adapters/runtime/daytona/workspace.go
+++ b/backend/internal/adapters/runtime/daytona/workspace.go
@@ -47,9 +47,10 @@ type RepoRemote struct {
 type WorkspaceOptions struct {
 	// Client talks to Daytona. Required.
 	Client Client
-	// Snapshot is the Daytona snapshot sandboxes are created from. It must have
-	// tmux, git, and the agent harness (agent CLIs + `ao` Linux binary)
-	// preinstalled; see docs/cloud/daytona-runtime.md. Required for Create.
+	// Snapshot is the Daytona snapshot sandboxes are created from. Production
+	// snapshots must have tmux, git, and the agent harness (agent CLIs + `ao`
+	// Linux binary) preinstalled; see docs/cloud/daytona-runtime.md. Empty
+	// falls back to Daytona's default snapshot (useful only for smoke tests).
 	Snapshot string
 	// Target picks the Daytona region ("us"/"eu"); empty uses the org default.
 	Target string
@@ -174,9 +175,6 @@ func (w *Workspace) Create(ctx context.Context, cfg ports.WorkspaceConfig) (port
 	name, err := sessionName(cfg.SessionID)
 	if err != nil {
 		return ports.WorkspaceInfo{}, err
-	}
-	if w.opts.Snapshot == "" {
-		return ports.WorkspaceInfo{}, errors.New("daytona workspace: snapshot is required to create sandboxes")
 	}
 	remote, err := w.opts.ResolveRepo(ctx, cfg)
 	if err != nil {

--- a/backend/internal/adapters/runtime/daytona/workspace.go
+++ b/backend/internal/adapters/runtime/daytona/workspace.go
@@ -404,7 +404,7 @@ func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error
 		}
 		return fmt.Errorf("daytona workspace: %s: %w", name, ports.ErrWorkspaceDirty)
 	}
-	if err := w.client.DeleteSandbox(ctx, sb.ID); err != nil {
+	if err := w.deleteAndWait(ctx, sb.ID); err != nil {
 		return fmt.Errorf("daytona workspace: delete sandbox %s: %w", sb.ID, err)
 	}
 	return nil
@@ -426,7 +426,7 @@ func (w *Workspace) ForceDestroy(ctx context.Context, info ports.WorkspaceInfo) 
 	if !found {
 		return nil
 	}
-	if err := w.client.DeleteSandbox(ctx, sb.ID); err != nil {
+	if err := w.deleteAndWait(ctx, sb.ID); err != nil {
 		return fmt.Errorf("daytona workspace: delete sandbox %s: %w", sb.ID, err)
 	}
 	return nil
@@ -586,6 +586,13 @@ func (w *Workspace) Park(ctx context.Context, info ports.WorkspaceInfo) error {
 		return nil
 	}
 	if err := w.client.StopSandbox(ctx, sb.ID); err != nil {
+		return fmt.Errorf("daytona workspace: park %s: %w", name, err)
+	}
+	// Daytona's stop is async (the sandbox reports `started`, then `stopping`,
+	// while the toolbox proxy 502s — observed live). Wait for the steady state
+	// so "parked" means parked to callers and their next probe; tolerate the
+	// lingering `started` reads from before the stop is applied.
+	if _, err := w.waitForState(ctx, sb.ID, StateStopped, w.startTimeout, StateStarted); err != nil {
 		return fmt.Errorf("daytona workspace: park %s: %w", name, err)
 	}
 	return nil

--- a/backend/internal/adapters/runtime/daytona/workspace.go
+++ b/backend/internal/adapters/runtime/daytona/workspace.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -188,7 +189,8 @@ func (w *Workspace) Create(ctx context.Context, cfg ports.WorkspaceConfig) (port
 	if err != nil {
 		return ports.WorkspaceInfo{}, err
 	}
-	if !found {
+	createdHere := !found
+	if createdHere {
 		sb, err = w.createSandbox(ctx, name, cfg)
 		if err != nil {
 			return ports.WorkspaceInfo{}, err
@@ -202,10 +204,16 @@ func (w *Workspace) Create(ctx context.Context, cfg ports.WorkspaceConfig) (port
 	path := w.workspacePath(name)
 	branch, err := w.provisionCheckout(ctx, sb, path, cfg, remote)
 	if err != nil {
-		// The sandbox without a checkout is useless; tear it down so a retried
-		// spawn does not find a half-provisioned sandbox.
-		if delErr := w.client.DeleteSandbox(context.WithoutCancel(ctx), sb.ID); delErr != nil {
-			w.logger.Warn("daytona workspace: cleanup after failed provision", "sandbox", sb.ID, "error", delErr)
+		// A sandbox THIS call created has no checkout worth keeping; tear it
+		// down so a retried spawn does not find a half-provisioned sandbox. An
+		// adopted sandbox is left alone: it may hold a prior provision's
+		// checkout (possibly with uncommitted work), and the failure here may
+		// be transient — deleting it would be the one destructive path in the
+		// adapter (flagged in review).
+		if createdHere {
+			if delErr := w.client.DeleteSandbox(context.WithoutCancel(ctx), sb.ID); delErr != nil {
+				w.logger.Warn("daytona workspace: cleanup after failed provision", "sandbox", sb.ID, "error", delErr)
+			}
 		}
 		return ports.WorkspaceInfo{}, err
 	}
@@ -259,11 +267,23 @@ func (w *Workspace) createSandbox(ctx context.Context, name string, cfg ports.Wo
 
 // provisionCheckout clones the repo (base branch when set) and creates or
 // checks out the session branch, returning the effective branch name. An
-// existing valid checkout is reused (idempotent retry after a partial spawn).
+// existing valid checkout is reused (idempotent retry after a partial spawn)
+// after reconciling it onto the session branch.
 func (w *Workspace) provisionCheckout(ctx context.Context, sb Sandbox, path string, cfg ports.WorkspaceConfig, remote RepoRemote) (string, error) {
-	// Already provisioned? (`git -C path rev-parse` succeeds only for a repo.)
-	if _, err := w.exec(ctx, sb.ID, "git -C "+shellQuote(path)+" rev-parse --is-inside-work-tree"); err == nil {
-		return w.currentBranch(ctx, sb.ID, path)
+	// Already provisioned? Only a definitive git failure (execError: not a
+	// repo) means "not provisioned"; a transport failure aborts inconclusively
+	// — otherwise a transient toolbox hiccup against a healthy checkout would
+	// route into a doomed re-clone (flagged in review).
+	probeErr := func() error {
+		_, err := w.exec(ctx, sb.ID, "git -C "+shellQuote(path)+" rev-parse --is-inside-work-tree")
+		return err
+	}()
+	if probeErr == nil {
+		return w.reconcileExistingCheckout(ctx, sb, path, cfg, remote)
+	}
+	var execErr *execError
+	if !errors.As(probeErr, &execErr) {
+		return "", fmt.Errorf("daytona workspace: probe checkout %s: %w", path, probeErr)
 	}
 
 	baseBranch := cfg.BaseBranch
@@ -281,6 +301,9 @@ func (w *Workspace) provisionCheckout(ctx context.Context, sb Sandbox, path stri
 	}); err != nil {
 		return "", fmt.Errorf("daytona workspace: clone %s: %w", remote.URL, err)
 	}
+	if err := w.seedGitCredentials(ctx, sb.ID, remote); err != nil {
+		return "", err
+	}
 	if err := w.configureGitIdentity(ctx, sb.ID, path); err != nil {
 		return "", err
 	}
@@ -290,19 +313,86 @@ func (w *Workspace) provisionCheckout(ctx context.Context, sb Sandbox, path stri
 		// Scratch-style session: stay on the cloned branch.
 		return w.currentBranch(ctx, sb.ID, path)
 	}
-	if err := validateBranchName(branch); err != nil {
+	return branch, w.checkoutSessionBranch(ctx, sb.ID, path, branch)
+}
+
+// reconcileExistingCheckout reuses a surviving checkout but makes sure the
+// session branch is actually checked out: a prior provision can die between
+// clone and checkout (daemon crash), and returning the cloned base branch
+// would silently run the session on base (flagged in review).
+func (w *Workspace) reconcileExistingCheckout(ctx context.Context, sb Sandbox, path string, cfg ports.WorkspaceConfig, remote RepoRemote) (string, error) {
+	if cfg.Branch == "" {
+		return w.currentBranch(ctx, sb.ID, path)
+	}
+	current, err := w.currentBranch(ctx, sb.ID, path)
+	if err != nil {
 		return "", err
 	}
-	// Prefer resuming an existing remote branch (restore of a prior session);
-	// otherwise create the session branch from the cloned base.
-	script := "cd " + shellQuote(path) + " && " +
-		"if git fetch origin " + shellQuote(branch) + " >/dev/null 2>&1; then " +
-		"git checkout -B " + shellQuote(branch) + " FETCH_HEAD; else " +
-		"git checkout -B " + shellQuote(branch) + "; fi"
-	if _, err := w.execWithTimeout(ctx, sb.ID, script, w.createTimeout); err != nil {
-		return "", fmt.Errorf("daytona workspace: checkout branch %s: %w", branch, err)
+	if current == cfg.Branch {
+		return cfg.Branch, nil
 	}
-	return branch, nil
+	if err := w.seedGitCredentials(ctx, sb.ID, remote); err != nil {
+		return "", err
+	}
+	if err := w.checkoutSessionBranch(ctx, sb.ID, path, cfg.Branch); err != nil {
+		return "", err
+	}
+	return cfg.Branch, nil
+}
+
+// seedGitCredentials stores the repo credentials inside the sandbox via the
+// toolbox credentials API (body-only, like the clone) so in-sandbox git
+// network operations — checkoutSessionBranch's ls-remote/fetch and the
+// agent's own pushes — authenticate against private remotes.
+func (w *Workspace) seedGitCredentials(ctx context.Context, sandboxID string, remote RepoRemote) error {
+	if remote.Username == "" && remote.Password == "" {
+		return nil
+	}
+	host := ""
+	if u, err := url.Parse(remote.URL); err == nil {
+		host = u.Host
+	}
+	if err := w.client.GitSetCredentials(ctx, sandboxID, GitCredentialsRequest{
+		Username: remote.Username,
+		Password: remote.Password,
+		Host:     host,
+		Protocol: "https",
+	}); err != nil {
+		return fmt.Errorf("daytona workspace: seed git credentials: %w", err)
+	}
+	return nil
+}
+
+// checkoutSessionBranch resumes the remote session branch when it exists, or
+// creates it from the current HEAD (the cloned base). Branch existence is
+// decided by `git ls-remote --exit-code` — exit 2 is definitively "no such
+// ref" — because a bare fetch-and-fallback conflates auth/network failures
+// with branch-missing and would silently restart a restored session from base
+// (flagged in review). Script exit codes: 3 = path gone, 6 = fetch/checkout
+// failed, 7 = remote unverifiable (auth/network).
+func (w *Workspace) checkoutSessionBranch(ctx context.Context, sandboxID, path, branch string) error {
+	if err := validateBranchName(branch); err != nil {
+		return err
+	}
+	b := shellQuote(branch)
+	script := "cd " + shellQuote(path) + " || exit 3; " +
+		"git ls-remote --exit-code --heads origin " + b + " >/dev/null 2>&1; rc=$?; " +
+		"if [ \"$rc\" -eq 0 ]; then { git fetch origin " + b + " && git checkout -B " + b + " FETCH_HEAD; } || exit 6; " +
+		"elif [ \"$rc\" -eq 2 ]; then git checkout -B " + b + " || exit 6; " +
+		"else exit 7; fi"
+	if _, err := w.execWithTimeout(ctx, sandboxID, script, w.createTimeout); err != nil {
+		var execErr *execError
+		if errors.As(err, &execErr) {
+			switch execErr.exitCode {
+			case 3:
+				return fmt.Errorf("daytona workspace: checkout branch %s: %w", branch, ports.ErrWorkspaceStale)
+			case 7:
+				return fmt.Errorf("daytona workspace: checkout branch %s: cannot verify remote branch (network or credentials): %w", branch, err)
+			}
+		}
+		return fmt.Errorf("daytona workspace: checkout branch %s: %w", branch, err)
+	}
+	return nil
 }
 
 func (w *Workspace) configureGitIdentity(ctx context.Context, sandboxID, path string) error {
@@ -358,7 +448,14 @@ func (w *Workspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (por
 	}
 	path := w.workspacePath(name)
 	if _, err := w.exec(ctx, sb.ID, "git -C "+shellQuote(path)+" rev-parse --is-inside-work-tree"); err != nil {
-		return ports.WorkspaceInfo{}, fmt.Errorf("daytona workspace: restore %s: checkout missing: %w: %w", name, ports.ErrWorkspaceStale, err)
+		// Stale only on a definitive git failure; a toolbox transport error is
+		// an inconclusive probe, matching the execError-gated stale checks in
+		// isDirty/StashUncommitted (review consistency note).
+		var execErr *execError
+		if errors.As(err, &execErr) {
+			return ports.WorkspaceInfo{}, fmt.Errorf("daytona workspace: restore %s: checkout missing: %w: %w", name, ports.ErrWorkspaceStale, err)
+		}
+		return ports.WorkspaceInfo{}, fmt.Errorf("daytona workspace: restore %s: probe checkout: %w", name, err)
 	}
 	branch, err := w.currentBranch(ctx, sb.ID, path)
 	if err != nil {
@@ -394,7 +491,18 @@ func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error
 	}
 	dirty, err := w.isDirty(ctx, sb.ID, info.Path)
 	if err != nil {
-		return err
+		// A stale checkout (path gone / not a repo) has nothing to protect:
+		// proceed to teardown, mirroring gitworktree's success on an
+		// unregistered path. Returning the error instead made the session
+		// unkillable — the kill path only special-cases ErrWorkspaceDirty, so
+		// every retry failed identically while the sandbox kept billing
+		// (review finding 1). Transport errors still abort: they are
+		// inconclusive, and the sandbox might hold uncommitted work.
+		if !errors.Is(err, ports.ErrWorkspaceStale) {
+			return err
+		}
+		w.logger.Warn("daytona workspace: stale checkout at destroy; deleting sandbox", "sandbox", sb.ID, "path", info.Path, "error", err)
+		dirty = false
 	}
 	if dirty {
 		if wasParked {

--- a/backend/internal/adapters/runtime/daytona/workspace_test.go
+++ b/backend/internal/adapters/runtime/daytona/workspace_test.go
@@ -1,0 +1,325 @@
+package daytona
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func newTestWorkspace(t *testing.T, fc *fakeClient) *Workspace {
+	t.Helper()
+	ws, err := NewWorkspace(WorkspaceOptions{
+		Client:   fc,
+		Snapshot: "ao-agent-snapshot:1",
+		BootEnv:  map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "tok"},
+		ResolveRepo: func(context.Context, ports.WorkspaceConfig) (RepoRemote, error) {
+			return RepoRemote{URL: "https://github.com/acme/app.git", DefaultBranch: "main"}, nil
+		},
+		ExecTimeout:   2 * time.Second,
+		StartTimeout:  time.Second,
+		CreateTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	return ws
+}
+
+func TestWorkspaceCreateProvisionsSandboxAndClone(t *testing.T) {
+	fc := newFakeClient()
+	// Fresh checkout: the is-inside-work-tree probe must fail first.
+	fc.onExec("rev-parse --is-inside-work-tree", ExecResult{ExitCode: 128, Result: "not a git repository"}, nil)
+	ws := newTestWorkspace(t, fc)
+
+	info, err := ws.Create(context.Background(), ports.WorkspaceConfig{
+		ProjectID:  "proj-1",
+		SessionID:  "s1",
+		Branch:     "ao/s1/root",
+		BaseBranch: "develop",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if info.Path != "/home/daytona/ao/s1" {
+		t.Errorf("path = %q", info.Path)
+	}
+	if info.Branch != "ao/s1/root" {
+		t.Errorf("branch = %q", info.Branch)
+	}
+	if len(fc.createdReqs) != 1 {
+		t.Fatalf("created %d sandboxes, want 1", len(fc.createdReqs))
+	}
+	req := fc.createdReqs[0]
+	if req.Snapshot != "ao-agent-snapshot:1" {
+		t.Errorf("snapshot = %q", req.Snapshot)
+	}
+	if req.Labels[LabelSession] != "s1" || req.Labels[LabelProject] != "proj-1" {
+		t.Errorf("labels = %v", req.Labels)
+	}
+	if req.Env["CLAUDE_CODE_OAUTH_TOKEN"] != "tok" {
+		t.Errorf("boot env missing injected credential: %v", req.Env)
+	}
+	if req.AutoStopInterval == nil || *req.AutoStopInterval != defaultAutoStopMinutes {
+		t.Errorf("autoStopInterval = %v, want default %d", req.AutoStopInterval, defaultAutoStopMinutes)
+	}
+	if len(fc.gitClones) != 1 {
+		t.Fatalf("git clones = %d, want 1", len(fc.gitClones))
+	}
+	clone := fc.gitClones[0]
+	if clone.URL != "https://github.com/acme/app.git" || clone.Path != "/home/daytona/ao/s1" || clone.Branch != "develop" {
+		t.Errorf("clone = %+v", clone)
+	}
+	if got := fc.commandsMatching("checkout -B 'ao/s1/root'"); len(got) != 1 {
+		t.Errorf("expected session branch checkout, commands: %v", fc.commands())
+	}
+}
+
+func TestWorkspaceCreateDisablesAutoStopWhenNegative(t *testing.T) {
+	fc := newFakeClient()
+	fc.onExec("rev-parse --is-inside-work-tree", ExecResult{ExitCode: 128}, nil)
+	ws, err := NewWorkspace(WorkspaceOptions{
+		Client:          fc,
+		Snapshot:        "snap",
+		AutoStopMinutes: -1,
+		ResolveRepo: func(context.Context, ports.WorkspaceConfig) (RepoRemote, error) {
+			return RepoRemote{URL: "https://x/r.git"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	if _, err := ws.Create(context.Background(), ports.WorkspaceConfig{SessionID: "s1", Branch: "b"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got := fc.createdReqs[0].AutoStopInterval; got == nil || *got != 0 {
+		t.Errorf("autoStopInterval = %v, want 0 (disabled)", got)
+	}
+}
+
+func TestWorkspaceCreateCleansUpOnCloneFailure(t *testing.T) {
+	fc := newFakeClient()
+	fc.onExec("rev-parse --is-inside-work-tree", ExecResult{ExitCode: 128}, nil)
+	fc.gitErr = errors.New("clone denied")
+	ws := newTestWorkspace(t, fc)
+	_, err := ws.Create(context.Background(), ports.WorkspaceConfig{SessionID: "s1", Branch: "b"})
+	if err == nil || !strings.Contains(err.Error(), "clone") {
+		t.Fatalf("err = %v, want clone failure", err)
+	}
+	if len(fc.deleted) != 1 {
+		t.Errorf("half-provisioned sandbox must be deleted, deleted=%v", fc.deleted)
+	}
+}
+
+func TestWorkspaceDestroy(t *testing.T) {
+	t.Run("clean checkout deletes the sandbox", func(t *testing.T) {
+		fc := newFakeClient()
+		id := fc.seedSandbox("s1", StateStarted)
+		fc.onExec("status --porcelain", ExecResult{Result: ""}, nil)
+		ws := newTestWorkspace(t, fc)
+		if err := ws.Destroy(context.Background(), ports.WorkspaceInfo{SessionID: "s1", Path: "/home/daytona/ao/s1"}); err != nil {
+			t.Fatalf("Destroy: %v", err)
+		}
+		if len(fc.deleted) != 1 || fc.deleted[0] != id {
+			t.Errorf("deleted = %v, want [%s]", fc.deleted, id)
+		}
+	})
+	t.Run("dirty checkout refuses and keeps the sandbox", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("status --porcelain", ExecResult{Result: " M main.go\n"}, nil)
+		ws := newTestWorkspace(t, fc)
+		err := ws.Destroy(context.Background(), ports.WorkspaceInfo{SessionID: "s1", Path: "/home/daytona/ao/s1"})
+		if !errors.Is(err, ports.ErrWorkspaceDirty) {
+			t.Fatalf("err = %v, want ErrWorkspaceDirty", err)
+		}
+		if len(fc.deleted) != 0 {
+			t.Errorf("dirty sandbox must never be deleted, deleted=%v", fc.deleted)
+		}
+	})
+	t.Run("dirty parked sandbox is re-parked after refusal", func(t *testing.T) {
+		fc := newFakeClient()
+		id := fc.seedSandbox("s1", StateStopped)
+		fc.onExec("status --porcelain", ExecResult{Result: " M main.go\n"}, nil)
+		ws := newTestWorkspace(t, fc)
+		err := ws.Destroy(context.Background(), ports.WorkspaceInfo{SessionID: "s1", Path: "/home/daytona/ao/s1"})
+		if !errors.Is(err, ports.ErrWorkspaceDirty) {
+			t.Fatalf("err = %v, want ErrWorkspaceDirty", err)
+		}
+		if len(fc.started) != 1 || len(fc.stopped) != 1 || fc.stopped[0] != id {
+			t.Errorf("expected wake for dirty check then re-park; started=%v stopped=%v", fc.started, fc.stopped)
+		}
+	})
+	t.Run("missing sandbox is idempotent success", func(t *testing.T) {
+		fc := newFakeClient()
+		ws := newTestWorkspace(t, fc)
+		if err := ws.Destroy(context.Background(), ports.WorkspaceInfo{SessionID: "s1", Path: "/p"}); err != nil {
+			t.Fatalf("Destroy: %v", err)
+		}
+	})
+}
+
+func TestWorkspaceForceDestroySkipsDirtyCheck(t *testing.T) {
+	fc := newFakeClient()
+	id := fc.seedSandbox("s1", StateStopped)
+	ws := newTestWorkspace(t, fc)
+	if err := ws.ForceDestroy(context.Background(), ports.WorkspaceInfo{SessionID: "s1", Path: "/p"}); err != nil {
+		t.Fatalf("ForceDestroy: %v", err)
+	}
+	if len(fc.deleted) != 1 || fc.deleted[0] != id {
+		t.Errorf("deleted = %v, want [%s]", fc.deleted, id)
+	}
+	if len(fc.started) != 0 {
+		t.Errorf("ForceDestroy must not wake the sandbox, started=%v", fc.started)
+	}
+}
+
+func TestStashUncommitted(t *testing.T) {
+	info := ports.WorkspaceInfo{SessionID: "s1", Path: "/home/daytona/ao/s1"}
+	t.Run("clean tree returns empty ref", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("git update-ref", ExecResult{ExitCode: 4}, nil)
+		ws := newTestWorkspace(t, fc)
+		ref, err := ws.StashUncommitted(context.Background(), info)
+		if err != nil || ref != "" {
+			t.Fatalf("ref=%q err=%v, want empty nil", ref, err)
+		}
+	})
+	t.Run("stale checkout maps to ErrWorkspaceStale", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("git update-ref", ExecResult{ExitCode: 3}, nil)
+		ws := newTestWorkspace(t, fc)
+		_, err := ws.StashUncommitted(context.Background(), info)
+		if !errors.Is(err, ports.ErrWorkspaceStale) {
+			t.Fatalf("err = %v, want ErrWorkspaceStale", err)
+		}
+	})
+	t.Run("dirty tree returns the preserve ref", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		ws := newTestWorkspace(t, fc)
+		ref, err := ws.StashUncommitted(context.Background(), info)
+		if err != nil {
+			t.Fatalf("StashUncommitted: %v", err)
+		}
+		if ref != "refs/ao/preserved/s1" {
+			t.Errorf("ref = %q", ref)
+		}
+	})
+	t.Run("missing sandbox is stale", func(t *testing.T) {
+		fc := newFakeClient()
+		ws := newTestWorkspace(t, fc)
+		_, err := ws.StashUncommitted(context.Background(), info)
+		if !errors.Is(err, ports.ErrWorkspaceStale) {
+			t.Fatalf("err = %v, want ErrWorkspaceStale", err)
+		}
+	})
+}
+
+func TestApplyPreserved(t *testing.T) {
+	info := ports.WorkspaceInfo{SessionID: "s1", Path: "/home/daytona/ao/s1"}
+	t.Run("conflict keeps ref and maps sentinel", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("cherry-pick", ExecResult{ExitCode: 5, Result: "conflict"}, nil)
+		ws := newTestWorkspace(t, fc)
+		err := ws.ApplyPreserved(context.Background(), info, "refs/ao/preserved/s1")
+		if !errors.Is(err, ports.ErrPreservedConflict) {
+			t.Fatalf("err = %v, want ErrPreservedConflict", err)
+		}
+	})
+	t.Run("invalid ref is rejected before any exec", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		ws := newTestWorkspace(t, fc)
+		err := ws.ApplyPreserved(context.Background(), info, "refs/heads/main; rm -rf /")
+		if err == nil || !strings.Contains(err.Error(), "invalid ref") {
+			t.Fatalf("err = %v, want invalid ref", err)
+		}
+		if len(fc.commands()) != 0 {
+			t.Errorf("no exec expected for invalid ref, got %v", fc.commands())
+		}
+	})
+	t.Run("clean apply succeeds", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		ws := newTestWorkspace(t, fc)
+		if err := ws.ApplyPreserved(context.Background(), info, "refs/ao/preserved/s1"); err != nil {
+			t.Fatalf("ApplyPreserved: %v", err)
+		}
+	})
+}
+
+func TestAddExcludeIsIdempotentScript(t *testing.T) {
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStarted)
+	ws := newTestWorkspace(t, fc)
+	if err := ws.AddExclude(context.Background(), ports.WorkspaceInfo{SessionID: "s1", Path: "/p"}, "/.ao-attachments/"); err != nil {
+		t.Fatalf("AddExclude: %v", err)
+	}
+	cmds := fc.commands()
+	if len(cmds) != 1 || !strings.Contains(cmds[0], "grep -qxF '/.ao-attachments/'") {
+		t.Errorf("commands = %v", cmds)
+	}
+}
+
+func TestWorkspaceRestore(t *testing.T) {
+	t.Run("wakes surviving sandbox and reuses checkout", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStopped)
+		fc.onExec("rev-parse --abbrev-ref HEAD", ExecResult{Result: "ao/s1/root\n"}, nil)
+		ws := newTestWorkspace(t, fc)
+		info, err := ws.Restore(context.Background(), ports.WorkspaceConfig{SessionID: "s1", Branch: "ao/s1/root"})
+		if err != nil {
+			t.Fatalf("Restore: %v", err)
+		}
+		if len(fc.started) != 1 {
+			t.Errorf("expected wake, started=%v", fc.started)
+		}
+		if info.Branch != "ao/s1/root" || info.Path != "/home/daytona/ao/s1" {
+			t.Errorf("info = %+v", info)
+		}
+		if len(fc.gitClones) != 0 {
+			t.Errorf("surviving checkout must not be re-cloned")
+		}
+	})
+	t.Run("deleted sandbox re-provisions from remote", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.onExec("rev-parse --is-inside-work-tree", ExecResult{ExitCode: 128}, nil)
+		ws := newTestWorkspace(t, fc)
+		info, err := ws.Restore(context.Background(), ports.WorkspaceConfig{SessionID: "s1", Branch: "ao/s1/root"})
+		if err != nil {
+			t.Fatalf("Restore: %v", err)
+		}
+		if len(fc.gitClones) != 1 {
+			t.Errorf("expected a fresh clone, clones=%d", len(fc.gitClones))
+		}
+		if info.Branch != "ao/s1/root" {
+			t.Errorf("branch = %q", info.Branch)
+		}
+	})
+}
+
+func TestParkStopsStartedSandbox(t *testing.T) {
+	fc := newFakeClient()
+	id := fc.seedSandbox("s1", StateStarted)
+	ws := newTestWorkspace(t, fc)
+	if err := ws.Park(context.Background(), ports.WorkspaceInfo{SessionID: "s1"}); err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+	if len(fc.stopped) != 1 || fc.stopped[0] != id {
+		t.Errorf("stopped = %v, want [%s]", fc.stopped, id)
+	}
+	// Parking an already-parked sandbox is a no-op.
+	if err := ws.Park(context.Background(), ports.WorkspaceInfo{SessionID: "s1"}); err != nil {
+		t.Fatalf("Park (parked): %v", err)
+	}
+	if len(fc.stopped) != 1 {
+		t.Errorf("second park must no-op, stopped=%v", fc.stopped)
+	}
+}

--- a/backend/internal/adapters/runtime/daytona/workspace_test.go
+++ b/backend/internal/adapters/runtime/daytona/workspace_test.go
@@ -323,3 +323,127 @@ func TestParkStopsStartedSandbox(t *testing.T) {
 		t.Errorf("second park must no-op, stopped=%v", fc.stopped)
 	}
 }
+
+// -- review 4803249501 regressions --
+
+func TestWorkspaceDestroyStaleCheckoutStillDeletesSandbox(t *testing.T) {
+	// Finding 1: a stale checkout (path gone / not a repo) has nothing to
+	// protect. Returning the stale error made the session unkillable (the kill
+	// path only special-cases ErrWorkspaceDirty) and leaked a billing sandbox.
+	fc := newFakeClient()
+	id := fc.seedSandbox("s1", StateStarted)
+	fc.onExec("status --porcelain", ExecResult{ExitCode: 128, Result: "fatal: not a git repository"}, nil)
+	ws := newTestWorkspace(t, fc)
+	if err := ws.Destroy(context.Background(), ports.WorkspaceInfo{SessionID: "s1", Path: "/home/daytona/ao/s1"}); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if len(fc.deleted) != 1 || fc.deleted[0] != id {
+		t.Errorf("deleted = %v, want [%s]", fc.deleted, id)
+	}
+
+	t.Run("transport error still aborts", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("status --porcelain", ExecResult{}, errors.New("toolbox 502"))
+		ws := newTestWorkspace(t, fc)
+		if err := ws.Destroy(context.Background(), ports.WorkspaceInfo{SessionID: "s1", Path: "/p"}); err == nil {
+			t.Fatal("want error on inconclusive dirty probe")
+		}
+		if len(fc.deleted) != 0 {
+			t.Errorf("must not delete on an inconclusive probe, deleted=%v", fc.deleted)
+		}
+	})
+}
+
+func TestWorkspaceCreateReusedCheckoutReconcilesBranch(t *testing.T) {
+	// Finding 2: a provision that died between clone and checkout leaves the
+	// checkout on the base branch; reuse must move it to the session branch.
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStarted)
+	fc.onExec("rev-parse --abbrev-ref HEAD", ExecResult{Result: "develop\n"}, nil)
+	ws := newTestWorkspace(t, fc)
+	info, err := ws.Create(context.Background(), ports.WorkspaceConfig{
+		SessionID: "s1", Branch: "ao/s1/root", BaseBranch: "develop",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if info.Branch != "ao/s1/root" {
+		t.Errorf("branch = %q, want session branch", info.Branch)
+	}
+	if got := fc.commandsMatching("checkout -B 'ao/s1/root'"); len(got) != 1 {
+		t.Errorf("expected branch reconcile checkout, commands: %v", fc.commands())
+	}
+	if len(fc.gitClones) != 0 {
+		t.Errorf("reuse must not re-clone")
+	}
+}
+
+func TestWorkspaceCreateProbeTransportErrorAbortsWithoutDeleting(t *testing.T) {
+	// Finding 3: a transient toolbox failure on the provisioned-probe must not
+	// route into re-clone/cleanup, and an ADOPTED sandbox must never be
+	// deleted by the failure path (it may hold uncommitted work).
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStarted)
+	fc.onExec("rev-parse --is-inside-work-tree", ExecResult{}, errors.New("toolbox 502"))
+	ws := newTestWorkspace(t, fc)
+	_, err := ws.Create(context.Background(), ports.WorkspaceConfig{SessionID: "s1", Branch: "b"})
+	if err == nil || !strings.Contains(err.Error(), "probe checkout") {
+		t.Fatalf("err = %v, want inconclusive probe error", err)
+	}
+	if len(fc.deleted) != 0 {
+		t.Errorf("adopted sandbox must survive a failed provision, deleted=%v", fc.deleted)
+	}
+	if len(fc.gitClones) != 0 {
+		t.Errorf("must not clone after an inconclusive probe")
+	}
+}
+
+func TestCheckoutSessionBranchSeparatesMissingFromUnverifiable(t *testing.T) {
+	// Finding 4: fetch failure must not be read as branch-missing — that
+	// silently restarts a restored session from base.
+	t.Run("unverifiable remote fails hard", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.seedSandbox("s1", StateStarted)
+		fc.onExec("rev-parse --is-inside-work-tree", ExecResult{ExitCode: 128}, nil)
+		fc.onExec("ls-remote", ExecResult{ExitCode: 7}, nil)
+		ws := newTestWorkspace(t, fc)
+		_, err := ws.Create(context.Background(), ports.WorkspaceConfig{SessionID: "s1", Branch: "ao/s1/root"})
+		if err == nil || !strings.Contains(err.Error(), "cannot verify remote branch") {
+			t.Fatalf("err = %v, want unverifiable-remote failure", err)
+		}
+	})
+	t.Run("clone credentials are seeded for in-sandbox git", func(t *testing.T) {
+		fc := newFakeClient()
+		fc.onExec("rev-parse --is-inside-work-tree", ExecResult{ExitCode: 128}, nil)
+		ws, err := NewWorkspace(WorkspaceOptions{
+			Client:   fc,
+			Snapshot: "snap",
+			ResolveRepo: func(context.Context, ports.WorkspaceConfig) (RepoRemote, error) {
+				return RepoRemote{URL: "https://github.com/acme/private.git", Username: "x-access-token", Password: "tok"}, nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewWorkspace: %v", err)
+		}
+		if _, err := ws.Create(context.Background(), ports.WorkspaceConfig{SessionID: "s1", Branch: "b"}); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if len(fc.gitCreds) != 1 || fc.gitCreds[0].Host != "github.com" || fc.gitCreds[0].Password != "tok" {
+			t.Errorf("gitCreds = %+v, want seeded github.com credentials", fc.gitCreds)
+		}
+	})
+}
+
+func TestWorkspaceRestoreTransportErrorIsNotStale(t *testing.T) {
+	// Finding 5: a toolbox hiccup during the restore probe must surface as an
+	// inconclusive error, not report the checkout stale.
+	fc := newFakeClient()
+	fc.seedSandbox("s1", StateStarted)
+	fc.onExec("rev-parse --is-inside-work-tree", ExecResult{}, errors.New("toolbox 502"))
+	ws := newTestWorkspace(t, fc)
+	_, err := ws.Restore(context.Background(), ports.WorkspaceConfig{SessionID: "s1", Branch: "b"})
+	if err == nil || errors.Is(err, ports.ErrWorkspaceStale) {
+		t.Fatalf("err = %v, want non-stale inconclusive error", err)
+	}
+}

--- a/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
+++ b/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/conpty"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/daytona"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/tmux"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -24,9 +25,13 @@ type Runtime interface {
 	GetOutput(ctx context.Context, handle ports.RuntimeHandle, lines int) (string, error)
 }
 
-// Compile-time assertions: both adapters must implement the union interface.
+// Compile-time assertions: every runtime adapter must implement the union
+// interface. daytona is not part of platform selection below — cloud sessions
+// pick it per-session (control-plane wiring, phase 3) — but it must satisfy
+// the same contract the daemon wires.
 var _ Runtime = (*tmux.Runtime)(nil)
 var _ Runtime = (*conpty.Runtime)(nil)
+var _ Runtime = (*daytona.Runtime)(nil)
 
 // New returns the per-platform runtime: tmux on Darwin/Linux, conpty on Windows.
 // log is accepted for signature stability with callers but is currently unused.

--- a/backend/internal/cli/client.go
+++ b/backend/internal/cli/client.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
@@ -94,6 +96,16 @@ func (c *commandContext) postLoopbackJSON(ctx context.Context, path string, body
 	return c.doJSONPath(ctx, http.MethodPost, path, body, nil)
 }
 
+// remoteAPIBase reports the AO_API_BASE override: inside a cloud sandbox
+// there is no loopback daemon or run-file, so the runtime adapter injects the
+// calling daemon's reachable API base (plus a sandbox-scoped bearer token in
+// AO_API_TOKEN) and hook commands talk to that instead. Empty means local
+// loopback discovery as always. See docs/cloud/daytona-runtime.md.
+func remoteAPIBase() (base, token string) {
+	return strings.TrimRight(strings.TrimSpace(os.Getenv("AO_API_BASE")), "/"),
+		strings.TrimSpace(os.Getenv("AO_API_TOKEN"))
+}
+
 func (c *commandContext) doJSONPath(ctx context.Context, method, path string, body, out any) error {
 	return c.doJSONPathWithHeaders(ctx, method, path, body, out, nil)
 }
@@ -104,19 +116,26 @@ func (c *commandContext) doJSONPathWithHeaders(
 	body, out any,
 	headers map[string]string,
 ) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return err
-	}
-	info, err := runfile.Read(cfg.RunFilePath)
-	if err != nil {
-		return err
-	}
-	if info == nil {
-		return fmt.Errorf("AO daemon is not running — start it with `ao start`")
-	}
-	if !c.deps.ProcessAlive(info.PID) {
-		return fmt.Errorf("AO daemon is not running (stale run-file at %s) — start it with `ao start`", cfg.RunFilePath)
+	remoteBase, remoteToken := remoteAPIBase()
+	var url string
+	if remoteBase != "" {
+		url = remoteBase + path
+	} else {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		info, err := runfile.Read(cfg.RunFilePath)
+		if err != nil {
+			return err
+		}
+		if info == nil {
+			return fmt.Errorf("AO daemon is not running — start it with `ao start`")
+		}
+		if !c.deps.ProcessAlive(info.PID) {
+			return fmt.Errorf("AO daemon is not running (stale run-file at %s) — start it with `ao start`", cfg.RunFilePath)
+		}
+		url = fmt.Sprintf("http://%s:%d%s", config.LoopbackHost, info.Port, path)
 	}
 
 	var reader io.Reader = http.NoBody
@@ -127,13 +146,15 @@ func (c *commandContext) doJSONPathWithHeaders(
 		}
 		reader = bytes.NewReader(payload)
 	}
-	url := fmt.Sprintf("http://%s:%d%s", config.LoopbackHost, info.Port, path)
-	req, err := http.NewRequestWithContext(ctx, method, url, reader) // #nosec G704 -- daemon host is fixed loopback; path is an internal API route.
+	req, err := http.NewRequestWithContext(ctx, method, url, reader) // #nosec G704 -- daemon host is fixed loopback or the operator-provided AO_API_BASE; path is an internal API route.
 	if err != nil {
 		return err
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if remoteBase != "" && remoteToken != "" {
+		req.Header.Set("Authorization", "Bearer "+remoteToken)
 	}
 	for name, value := range headers {
 		req.Header.Set(name, value)

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -796,3 +796,53 @@ func TestHooks_DaemonErrorIsSwallowed(t *testing.T) {
 		t.Errorf("expected the failure surfaced to stderr, got %q", errOut)
 	}
 }
+
+// TestHooks_RemoteAPIBase covers the sandbox hooks path: with AO_API_BASE set
+// (no run-file, no loopback daemon), the activity report goes to that base
+// with the AO_API_TOKEN bearer header — how agents inside a cloud sandbox
+// reach the calling daemon (docs/cloud/daytona-runtime.md).
+func TestHooks_RemoteAPIBase(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	setConfigEnv(t) // isolate AO_DATA_DIR; deliberately no run-file written
+
+	var gotAuth string
+	capture := &activityCapture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/activity") {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		capture.body = string(body)
+		capture.path = r.URL.Path
+		capture.hits++
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AO_API_BASE", srv.URL+"/") // trailing slash must not double up
+	t.Setenv("AO_API_TOKEN", "sandbox-token-1")
+
+	_, errOut, err := executeCLI(t, Deps{
+		In: strings.NewReader(`{"reason":"logout"}`),
+		// ProcessAlive would fail the loopback path; the remote base must not
+		// consult it at all.
+		ProcessAlive: func(int) bool { t.Error("remote base must not probe the local daemon"); return false },
+	}, "hooks", "claude-code", "session-end")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.hits != 1 {
+		t.Fatalf("remote base was not called (hits=%d, stderr=%s)", capture.hits, errOut)
+	}
+	if capture.path != "/api/v1/sessions/ao-7/activity" {
+		t.Errorf("path = %q, want /api/v1/sessions/ao-7/activity", capture.path)
+	}
+	if gotAuth != "Bearer sandbox-token-1" {
+		t.Errorf("Authorization = %q, want Bearer sandbox-token-1", gotAuth)
+	}
+	if got := capturedState(t, capture); got != "exited" {
+		t.Errorf("state = %q, want exited", got)
+	}
+}

--- a/docs/cloud/daytona-runtime.md
+++ b/docs/cloud/daytona-runtime.md
@@ -187,13 +187,42 @@ here as the adapter's requirements):
 2. Minting + validating the per-session `AO_API_TOKEN` (scope: that session's
    activity/hook routes only). The loopback listener stays unauthenticated and
    unchanged; the token authenticates only the cloud-facing surface.
-3. An `ao` Linux binary inside the sandbox snapshot (or a bootstrap download
-   URL) so hook commands resolve. The adapter prepends its directory to the
-   session `PATH` exactly like local spawns do.
+3. An `ao` Linux binary inside the sandbox snapshot so hook commands resolve —
+   the repo's snapshot image (`test/daytona-snapshot/Dockerfile`, §5a) builds
+   it from source and installs it at `/usr/local/bin/ao`.
 4. Agent credentials as env vars at `Runtime.Create` (`cfg.Env`), e.g.
    `CLAUDE_CODE_OAUTH_TOKEN` — the adapter passes `cfg.Env` into the tmux
    launch line inside the sandbox verbatim (same export mechanics as the tmux
    adapter, quoted, `PATH` last).
+
+## 5a. The agent snapshot
+
+`test/daytona-snapshot/Dockerfile` builds the custom Daytona snapshot the
+adapter expects: tmux, git, `ps` (procps — the #2802 liveness walk needs it),
+node + the Claude Code CLI (pin via `--build-arg CLAUDE_CODE_VERSION=<x.y.z>`),
+and the `ao` Linux binary built from this repo (stage 1, CGO-free), under the
+Daytona-convention `daytona` user with home `/home/daytona` (matching the
+adapter's default `WorkspaceRoot`).
+
+Build from the repo root and register (Daytona requires amd64 + pinned tags):
+
+```bash
+docker build --platform linux/amd64 \
+  -f test/daytona-snapshot/Dockerfile -t ao-agent-sandbox:<version> .
+daytona snapshot push ao-agent-sandbox:<version> --name ao-agent-sandbox:<version>
+# or: docker push ghcr.io/<org>/ao-agent-sandbox:<version> && \
+#     daytona snapshot create ao-agent-sandbox:<version> --image ghcr.io/<org>/ao-agent-sandbox:<version>
+```
+
+Point the adapter (or the live tests' `AO_DAYTONA_SNAPSHOT`) at the snapshot
+name. The real-agent demo then runs without any runtime package installs:
+
+```bash
+cd backend
+DAYTONA_API_KEY=… AO_DAYTONA_SNAPSHOT=ao-agent-sandbox:<version> \
+AO_DAYTONA_AGENT_ARGV='["claude","-p","say hello"]' CLAUDE_CODE_OAUTH_TOKEN=… \
+go test ./internal/adapters/runtime/daytona/ -run TestLive -v
+```
 
 ## 5. Idle/suspend mapping and the cost model
 

--- a/docs/cloud/daytona-runtime.md
+++ b/docs/cloud/daytona-runtime.md
@@ -207,8 +207,11 @@ adapter's default `WorkspaceRoot`).
 Build from the repo root and register (Daytona requires amd64 + pinned tags):
 
 ```bash
-docker build --platform linux/amd64 \
-  -f test/daytona-snapshot/Dockerfile -t ao-agent-sandbox:<version> .
+# --provenance/--sbom off: the Daytona CLI cannot inspect buildx attestation
+# manifest lists ("failed to check image architecture") — verified live.
+docker buildx build --provenance=false --sbom=false --platform linux/amd64 \
+  -f test/daytona-snapshot/Dockerfile -t ao-agent-sandbox:<version> --load .
+daytona login --api-key $DAYTONA_API_KEY   # the CLI ignores the env var for push
 daytona snapshot push ao-agent-sandbox:<version> --name ao-agent-sandbox:<version>
 # or: docker push ghcr.io/<org>/ao-agent-sandbox:<version> && \
 #     daytona snapshot create ao-agent-sandbox:<version> --image ghcr.io/<org>/ao-agent-sandbox:<version>

--- a/docs/cloud/daytona-runtime.md
+++ b/docs/cloud/daytona-runtime.md
@@ -255,7 +255,41 @@ that ladder:
   (after `StashUncommitted` captured work as a git ref — which for cloud
   sessions can be pushed to the remote as a preserve ref; see limitations).
 
-## 6. Phase-2 scope, limitations, follow-ups
+## 6. Live validation results (2026-07-28, real Daytona account)
+
+The full live suite passes against production Daytona using the maintainer's
+test org, the pushed `ao-agent-sandbox:dev` snapshot, and a real
+`CLAUDE_CODE_OAUTH_TOKEN` (all credentials via env; never committed):
+
+| Test | Result | What it proves |
+| --- | --- | --- |
+| `TestLive_ClientSandboxLifecycle` | PASS, 4.4s | sandbox create→started in ~2–3s, exec, PTY-WebSocket byte round-trip + resize, delete |
+| `TestLive_RuntimeSessionLifecycle` | PASS, 14.4s | workspace create (sandbox + clone) → tmux agent → scrollback → send round-trip → park (stop) → wake (`Restart`, same handle) → synchronous teardown |
+| `TestLive_RealAgentSession` | PASS, 13.6s | **real Claude Code, authenticated with no browser flow** via `CLAUDE_CODE_OAUTH_TOKEN` boot-env injection, answered a prompt; keep-alive shell held after agent exit |
+
+Observed behaviors that shaped the adapter (each now regression-tested):
+
+- **Stop/delete are async**: the API 200s while state lags (`stopping` /
+  still-listed); the toolbox proxy 502s mid-stop. Park waits for `stopped`,
+  destroys wait for gone, and a failed liveness exec re-reads sandbox state
+  before reporting.
+- **The list endpoint trails `GET /sandbox/{id}`**: a freshly-parked sandbox
+  can be listed as `stopping`, so wake settles the state first, then starts —
+  otherwise the start is never issued (reproduced twice before the fix).
+- Daytona's current default snapshot (`daytonaio/sandbox:0.8.0`) already
+  ships tmux, so even snapshot-less smoke runs work; the custom snapshot is
+  still required for agent CLIs + `ao` and is 0.21 GB vs 7.6 GB.
+
+**Validated at the port level, pending daemon wiring (phase 3):** terminal
+streaming is proven over the PTY WebSocket (`Attach`/`Stream` contract), but
+in-app rendering needs the daemon to select this runtime per session —
+`runtimeselect.New()` still picks tmux/conpty by OS, so merging this PR
+changes nothing for local installs. **Confirmed gap:** activity/hook events
+cannot reach a loopback-only local daemon from the sandbox; the CLI side
+(`AO_API_BASE` + bearer) is unit-tested, and the control plane must provide
+the reachable base + per-session tokens (§4).
+
+## 6a. Phase-2 scope, limitations, follow-ups
 
 - The adapter lives in `backend/internal/adapters/runtime/daytona/` and is not
   yet wired into `runtimeselect` platform selection (cloud sessions are

--- a/docs/cloud/daytona-runtime.md
+++ b/docs/cloud/daytona-runtime.md
@@ -1,0 +1,240 @@
+# Daytona sandbox runtime adapter (AO Cloud, phase 2)
+
+Status: design + phase-2 implementation notes. Locked decisions (2026-07-28):
+sandboxes run on [Daytona](https://daytona.io) — no owned Firecracker/K8s; agent
+inference credentials are injected at sandbox boot as env vars by the control
+plane (e.g. `CLAUDE_CODE_OAUTH_TOKEN` yields a logged-in Claude Code with no
+browser flow).
+
+This document records (1) the Daytona API surface the adapter builds on, (2)
+how the adapter maps AO's runtime/workspace ports onto that surface so the
+**unmodified** session manager + lifecycle manager can run a cloud session,
+(3) the terminal attach story, (4) the hooks path, and (5) the cost model for
+parked agents.
+
+## 1. Daytona API survey (verified 2026-07-28)
+
+Sources: [Sandboxes](https://www.daytona.io/docs/en/sandboxes/),
+[Snapshots](https://www.daytona.io/docs/en/snapshots/),
+[API keys](https://www.daytona.io/docs/en/api-keys/),
+[Billing](https://www.daytona.io/docs/en/billing/),
+[Pricing](https://www.daytona.io/pricing),
+[platform OpenAPI](https://www.daytona.io/docs/openapi.json),
+[toolbox OpenAPI](https://www.daytona.io/docs/toolbox-openapi.json), and the
+official Go SDK source (`github.com/daytona/clients/sdk-go` v0.201.0).
+
+**Product model.** A *sandbox* (the "workspace" term is legacy) is an isolated
+runtime with its own kernel/fs/network; container class by default (also
+linux-vm/windows/gpu). Sub-90ms cold start from an active snapshot. Default
+resources 1 vCPU / 1 GiB / 3 GiB disk; regions `us`/`eu` via the `target`
+param. Custom snapshots (`POST /snapshots`, amd64 image or Dockerfile, pinned
+tag) are how we preinstall the agent harness (tmux, git, node, agent CLIs,
+`ao` Linux binary).
+
+**Auth.** Base URL `https://app.daytona.io/api`; every request carries
+`Authorization: Bearer <org-scoped API key>` (dashboard → Keys, or
+`POST /api-keys`; scopes incl. `write:sandboxes`). SDK convention env vars:
+`DAYTONA_API_KEY`, `DAYTONA_API_URL`, `DAYTONA_TARGET` — the adapter reuses
+them.
+
+**Lifecycle (platform API).** `POST /sandbox` (create; body `CreateSandbox`:
+`snapshot`, `env{}`, `labels{}`, `target`, `cpu/memory/disk`,
+`autoStopInterval`, `autoArchiveInterval`, `autoDeleteInterval`,
+`ttlMinutes`, …), `GET /sandbox` (list; `labels` filter),
+`GET/DELETE /sandbox/{idOrName}`, `POST /sandbox/{idOrName}/start|stop|archive`,
+`PUT /sandbox/{id}/labels`, `POST /sandbox/{id}/autostop/{interval}`.
+State enum (steady states): `started`, `stopped`, `archived`, `paused`,
+`error`, `destroyed`; transitional: `creating/starting/stopping/restoring/
+pulling_snapshot/archiving/resuming/…`. The `Sandbox` object carries
+`toolboxProxyUrl` — the per-sandbox exec/fs/git surface below.
+
+**Stop semantics.** Stopping a container sandbox terminates it: **filesystem
+preserved, memory lost, all processes killed**; `start` restores the disk but
+relaunches nothing. Auto-stop defaults to 15 min without API/user activity
+(`0` disables). Stopped sandboxes can auto-archive (fs → object storage).
+
+**Toolbox API** (base `{toolboxProxyUrl}/{sandboxId}`, same bearer key):
+
+- Exec: `POST /process/execute` `{command, cwd, envs{}, timeout(s)}` →
+  `{result, exitCode}` — the adapter's workhorse (all tmux/git commands).
+- Sessions: `POST /process/session`, `POST /process/session/{id}/exec`
+  (`runAsync`), log streaming over WebSocket — used for long-running installs.
+- **PTY**: `POST /process/pty` `{id, cols, rows, cwd, envs}` →
+  `GET /process/pty/{id}/connect` upgrades to a **WebSocket** (subprotocol
+  `X-Daytona-Pty-Exit-Control`): binary frames = terminal bytes both ways;
+  JSON text frames `{type:"control", status:"connected"|"exited", exitCode}`;
+  `POST /process/pty/{id}/resize` `{cols, rows}`; `DELETE /process/pty/{id}`.
+  The PTY runs the sandbox user's shell (no command param) — the adapter's
+  attach writes `exec tmux -u attach …` as the first input line.
+- Git: `POST /git/clone` `{url, path, branch, username, password}` plus
+  status/add/commit/…; plain `git` over exec also works (we use exec so the
+  command sequences mirror the local gitworktree adapter exactly).
+- Files: upload/download/mkdir under `/files/*` (control-plane concern for
+  spawn attachments).
+
+**Go SDK.** Official: `github.com/daytona/clients/sdk-go` (v0.201.0,
+Apache-2.0), wrapping generated platform + toolbox clients, gorilla/websocket
+and a socket.io state feed. The adapter instead ships a **thin REST client**
+(~300 lines over `net/http` + the repo's existing `coder/websocket`): the
+surface we need is 10 endpoints, the fake-client seam for tests wants our own
+narrow interface anyway, and it avoids a large new dependency tree. Revisit if
+the surface grows.
+
+**Pricing** (2026-07): vCPU $0.0504/h, RAM $0.0162/GiB-h, disk $0.000108/GiB-h
+(first 5 GiB free), per-second metering. Default sandbox ≈ **$0.067/h
+running**, ≈ **$0.0003/h stopped** (disk only), **$0 archived**.
+
+## 2. The AO seam being satisfied
+
+The daemon consumes runtimes through two port surfaces (see
+`backend/internal/ports/outbound.go`):
+
+- `ports.Runtime` — `Create / Destroy / GetOutput / IsAlive` (the reaper and
+  session manager's contract), plus the optional capabilities the daemon wires
+  when present: `ports.Attacher` (terminal streams), `ports.RuntimeRestarter`
+  (agent resume without a new terminal identity),
+  `ports.SupervisedProcessInspector` (agent-alive vs pane-alive, issue #2802),
+  and the `runtimeselect.Runtime` union (`Interrupt`, `SendMessage`,
+  `GetOutput`).
+- `ports.Workspace` — the isolated checkout: `Create / Destroy / Restore /
+  ForceDestroy / StashUncommitted / ApplyPreserved / AddExclude`.
+
+The tmux adapter satisfies these against a **local** tmux server; the Daytona
+adapter satisfies them against a **remote sandbox that itself runs tmux**:
+
+| AO call | tmux adapter | daytona adapter |
+| --- | --- | --- |
+| `Workspace.Create` | `git worktree add` under `~/.ao/worktrees` | ensure sandbox for session (create from snapshot, labels `ao/session=<id>`), `git clone --branch` inside sandbox |
+| `Runtime.Create` | `tmux new-session` with env-exporting launch line | Daytona exec: same launch line inside sandbox tmux |
+| `Runtime.IsAlive` | `tmux has-session` | sandbox state probe + `tmux has-session` via exec |
+| `IsSupervisedProcessAlive` | `ps` walk under pane pid | same `ps` walk via sandbox exec |
+| `Runtime.GetOutput` | `tmux capture-pane` | `tmux capture-pane` via exec |
+| `SendMessage`/`Interrupt` | `tmux send-keys` | `tmux send-keys` via exec |
+| `Attach` | local PTY around `tmux attach` | remote PTY session running `tmux attach`, streamed over Daytona's API (outbound WebSocket) |
+| `Runtime.Destroy` | `tmux kill-session` + reap | `tmux kill-session` via exec (sandbox teardown is Workspace.Destroy) |
+| `Workspace.Destroy` | `git worktree remove` (dirty-refusal) | `git status --porcelain` guard, then delete sandbox |
+
+Running tmux **inside** the sandbox is deliberate: it preserves every semantics
+AO already depends on (scrollback, multiple attach clients, keep-alive shell
+after agent exit, `send-keys` paste-then-Enter contract, capture-pane output)
+without inventing a new PTY host, and the sandbox snapshot pins the tmux
+version.
+
+Handles: `RuntimeHandle.ID` is the same sanitized session name the tmux
+adapter uses. The sandbox is found by label (`ao/session=<ao session id>`), not
+by an in-memory map, so a daemon restart can re-adopt cloud sessions the same
+way boot reconcile re-adopts tmux ones.
+
+### Liveness (issue #2802: pane-exists != agent-alive)
+
+`IsAlive` answers "does the terminal session still exist": sandbox exists AND
+(sandbox running AND tmux session present) OR sandbox is parked (stopped) with
+AO's park marker. Probe failures (API errors, network) return `(false, err)` —
+never proof of death; the reaper treats them as failed probes.
+
+Agent-process liveness is separate: `IsSupervisedProcessAlive` runs the same
+process-table walk as tmux (`ps -ww -axo pid=,ppid=,args=` under the pane pid,
+matching the `ao agent-process supervise --session … --launch …` marker) via
+sandbox exec. A stopped (parked) sandbox reports the supervised process dead —
+which is true: Daytona stop kills processes — and AO's existing exited→resume
+flow relaunches the agent on wake via `RuntimeRestarter.Restart`
+(start sandbox + `tmux respawn`-equivalent).
+
+## 3. Terminal attach: outbound-only streaming
+
+Requirement: terminal bytes must reach AO's terminal manager without any
+inbound port on the sandbox.
+
+The adapter's `Attach(handle, rows, cols)` creates a fresh PTY session inside
+the sandbox via the toolbox API (`POST /process/pty`, sized rows×cols from
+birth), dials its `/connect` WebSocket, and immediately writes
+`exec tmux -u -T RGB attach-session -t <handle>` as the first input line (the
+PTY create API takes no command; tmux's full-screen repaint hides the echoed
+line). The WebSocket is wrapped in a `ports.Stream`: binary frames = bytes
+both ways, `Resize` = `POST /process/pty/{id}/resize`, close deletes the PTY
+session. This mirrors the conpty adapter's loopback-stream shape
+(`backend/internal/adapters/runtime/conpty/attach.go`): dial, pump frames into
+an `io.Pipe`, close on ctx cancellation.
+
+Connectivity is **outbound from the daemon to Daytona's API proxy** and
+**outbound from the sandbox to Daytona's control plane**; the sandbox itself
+exposes no inbound port. Each AO client attach opens its own PTY/attach —
+matching tmux semantics where the largest client drives the shared grid.
+
+## 4. Hooks path: activity events from inside the sandbox
+
+Agents launched by AO run `ao hooks <agent> <event>` from their native hook
+config. On local runtimes the CLI finds the daemon via `running.json` on
+loopback. Inside a sandbox there is no loopback daemon, so the adapter injects:
+
+- `AO_API_BASE` — the base URL where the calling daemon's API is reachable
+  from the sandbox (control-plane-provided; see below).
+- `AO_API_TOKEN` — a sandbox-scoped bearer token minted per session.
+- The usual `AO_SESSION_ID`, `AO_PROJECT_ID`, `AO_RUNTIME_LAUNCH_ID`,
+  `AO_DATA_DIR` (pointing at a sandbox-local dir for `hooks.log`).
+
+`ao hooks` (and the shared CLI client) honors `AO_API_BASE`: when set, requests
+go to `<AO_API_BASE>/api/v1/…` with `Authorization: Bearer $AO_API_TOKEN`
+instead of loopback run-file discovery. This is the only daemon-side code
+change outside the adapter package.
+
+**What the control plane must provide** (phase 1/3 responsibility, documented
+here as the adapter's requirements):
+
+1. A reachable `AO_API_BASE` for sandboxes (e.g. the cloud control plane's
+   public API, which forwards `POST /sessions/{id}/activity` to the owning
+   daemon, or a tunnel URL for a local daemon).
+2. Minting + validating the per-session `AO_API_TOKEN` (scope: that session's
+   activity/hook routes only). The loopback listener stays unauthenticated and
+   unchanged; the token authenticates only the cloud-facing surface.
+3. An `ao` Linux binary inside the sandbox snapshot (or a bootstrap download
+   URL) so hook commands resolve. The adapter prepends its directory to the
+   session `PATH` exactly like local spawns do.
+4. Agent credentials as env vars at `Runtime.Create` (`cfg.Env`), e.g.
+   `CLAUDE_CODE_OAUTH_TOKEN` — the adapter passes `cfg.Env` into the tmux
+   launch line inside the sandbox verbatim (same export mechanics as the tmux
+   adapter, quoted, `PATH` last).
+
+## 5. Idle/suspend mapping and the cost model
+
+Daytona bills running sandboxes per resource-hour; stopped sandboxes cost only
+storage; archived sandboxes cost cold storage. AO maps its session states onto
+that ladder:
+
+| AO state | Daytona state | What survives | Burn (default 1cpu/1GiB/3GiB) |
+| --- | --- | --- | --- |
+| active / waiting_input | started | everything | ≈ $0.067/h |
+| idle past park threshold | stopped ("parked") | filesystem (repo, agent transcript; tmux/processes do **not** — stop kills them) | ≈ $0.0003/h (disk only) |
+| terminated (worktree preserved) | archived or deleted | archived: filesystem in object storage | $0 |
+
+- **Parking**: the adapter sets Daytona's auto-stop interval at create time
+  (default: 15 minutes, configurable via `Options.AutoStopMinutes`) so an
+  agent that goes quiet stops burning compute even if AO never issues an
+  explicit stop. AO-side, a parked sandbox's agent reads as exited (it is), and
+  the session stays restorable.
+- **Waking**: `RuntimeRestarter.Restart` starts the sandbox (warm start,
+  seconds) and relaunches the agent through AO's existing resume flow (native
+  transcript resume when the harness supports it — Claude Code does via its
+  session id). Terminal scrollback from before the park is lost (tmux died
+  with the stop); the agent transcript is not (it lives on the sandbox disk).
+- **Teardown**: `Workspace.Destroy` refuses when the sandbox worktree is dirty
+  (`git status --porcelain` non-empty) mirroring the local dirty-worktree
+  refusal, then deletes the sandbox. `ForceDestroy` deletes unconditionally
+  (after `StashUncommitted` captured work as a git ref — which for cloud
+  sessions can be pushed to the remote as a preserve ref; see limitations).
+
+## 6. Phase-2 scope, limitations, follow-ups
+
+- The adapter lives in `backend/internal/adapters/runtime/daytona/` and is not
+  yet wired into `runtimeselect` platform selection (cloud sessions are
+  selected per-session by the control plane, not per-OS; wiring lands with the
+  control plane in phase 3).
+- `session_manager` local file writes (spawn attachments, per-project
+  provisioning symlinks) assume a local worktree; for cloud sessions those are
+  control-plane concerns (upload via Daytona fs API). Documented, not blocked
+  on: the runtime/workspace ports themselves are fully satisfied.
+- `StashUncommitted`/`ApplyPreserved` run their git operations inside the
+  sandbox; preserve refs live on the sandbox disk (and survive stop/archive),
+  but are lost if the sandbox is deleted without `ao` pushing them. Follow-up:
+  push preserve refs to the origin remote under `refs/ao/preserved/*`.
+- Live smoke test is gated on `DAYTONA_API_KEY` (skips otherwise).

--- a/test/daytona-snapshot/Dockerfile
+++ b/test/daytona-snapshot/Dockerfile
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1
+# AO agent sandbox snapshot for the Daytona runtime adapter
+# (backend/internal/adapters/runtime/daytona; design: docs/cloud/daytona-runtime.md).
+#
+# Bakes in everything the adapter and a real agent session need, so nothing is
+# apt-installed at runtime:
+#   - tmux        the in-sandbox terminal runtime (attach/scrollback/send-keys)
+#   - git         workspace clone + preserve-ref operations
+#   - procps      `ps` for the supervised-process liveness walk (issue #2802)
+#   - node + Claude Code CLI   the agent harness
+#   - ao          this repo's CLI (built from source in stage 1) so agent hook
+#                 commands (`ao hooks …`) resolve; they reach the calling
+#                 daemon via AO_API_BASE/AO_API_TOKEN injected at sandbox boot
+#
+# Build from the REPO ROOT (the ao build stage copies backend/):
+#   docker build --platform linux/amd64 \
+#     -f test/daytona-snapshot/Dockerfile -t ao-agent-sandbox:<version> .
+#
+# Daytona requires amd64 images with a pinned tag (no :latest). Push either
+# with the Daytona CLI (builds/uploads the local image):
+#   daytona snapshot push ao-agent-sandbox:<version> --name ao-agent-sandbox:<version>
+# or through a registry:
+#   docker tag ao-agent-sandbox:<version> ghcr.io/<org>/ao-agent-sandbox:<version>
+#   docker push ghcr.io/<org>/ao-agent-sandbox:<version>
+#   daytona snapshot create ao-agent-sandbox:<version> --image ghcr.io/<org>/ao-agent-sandbox:<version>
+#
+# Then run the live demo:
+#   DAYTONA_API_KEY=… AO_DAYTONA_SNAPSHOT=ao-agent-sandbox:<version> \
+#   AO_DAYTONA_AGENT_ARGV='["claude","-p","say hello"]' CLAUDE_CODE_OAUTH_TOKEN=… \
+#   go test ./internal/adapters/runtime/daytona/ -run TestLive -v   # from backend/
+
+FROM golang:1.25-bookworm AS ao-build
+WORKDIR /src
+COPY backend/ ./backend/
+# Pure-Go build (modernc sqlite): CGO off keeps the binary portable across the
+# snapshot's glibc without needing build toolchains in the final image.
+RUN cd backend && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -ldflags="-s -w" -o /out/ao ./cmd/ao
+
+FROM node:22-bookworm-slim
+
+# Pin the agent CLI at build time for reproducible snapshots:
+#   docker build --build-arg CLAUDE_CODE_VERSION=<x.y.z> …
+# The default "latest" is fine for smoke; pin for production snapshots.
+ARG CLAUDE_CODE_VERSION=latest
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        tmux git procps curl ca-certificates ripgrep locales sudo openssh-client \
+    && rm -rf /var/lib/apt/lists/* \
+    && sed -i 's/^# *en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen \
+    && locale-gen
+
+# tmux -u is forced by the adapter's attach, but a real UTF-8 locale keeps
+# every other tool (git, node, agent CLIs) from mangling non-ASCII output.
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && npm cache clean --force
+
+COPY --from=ao-build /out/ao /usr/local/bin/ao
+
+# Daytona's default sandbox user convention: `daytona`, home /home/daytona —
+# the adapter's default WorkspaceRoot (/home/daytona/ao) assumes it. Passwordless
+# sudo mirrors Daytona's stock images so operators can debug interactively.
+RUN useradd -m -s /bin/bash daytona \
+    && echo "daytona ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/daytona \
+    && chmod 0440 /etc/sudoers.d/daytona
+
+USER daytona
+WORKDIR /home/daytona
+
+# Daytona supplies its own sandbox supervisor/entrypoint; this is only the
+# fallback when the image is run outside Daytona (e.g. local docker smoke).
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
Phase 2 of AO Cloud: a Daytona-backed sandbox runtime + workspace adapter, so the unmodified session manager / lifecycle manager can run a cloud session. Runs in parallel with the phase-2 control-plane work — this PR deliberately touches nothing under `backend/cmd/ao-cloud` or `backend/internal/cloud/`.

Design doc (API survey + port mapping + attach story + hooks contract + cost model): `docs/cloud/daytona-runtime.md` — written from verified 2026 Daytona docs, both OpenAPI specs, and the official Go SDK source.

## What's implemented (`backend/internal/adapters/runtime/daytona/`)

- **Thin REST client** (`client.go`): platform API (create/list-by-label/start/stop/delete) + per-sandbox toolbox API (exec, git clone, PTY-over-WebSocket via the repo's existing `coder/websocket`). No new dependency tree; a narrow `Client` interface is the test seam. Live state is found by sandbox label `ao/session=<handle>` — no in-memory maps, so daemon restarts re-adopt cloud sessions like boot reconcile re-adopts tmux ones.
- **Runtime** (`daytona.go`, `attach.go`, `process.go`): tmux **inside** the sandbox, driven over toolbox exec, mirroring the tmux adapter's semantics (launch line with env exports + keep-alive shell, exact-match targets, chunked `send-keys` + delayed Enter #2342, capture-pane scrollback). Implements `ports.Runtime`, `ports.Attacher` (fresh PTY per attach running `tmux attach`; outbound-only, no inbound sandbox ports), `ports.RuntimeRestarter` (wake-from-park rebuilds tmux under the same handle), `ports.SupervisedProcessInspector` (#2802 pane-descendant walk via remote `ps`), and the `runtimeselect.Runtime` union (compile-time assert added).
- **Workspace** (`workspace.go`): sandbox provision (snapshot + boot-env credential injection per the locked custody model) + clone + session-branch checkout; dirty-refusal `Destroy`, `ForceDestroy`, remote `StashUncommitted`/`ApplyPreserved` (same temp-index / cherry-pick sequences as gitworktree), `AddExclude`, and `Park` (Daytona stop).
- **Hooks path** (`internal/cli/client.go`): `ao hooks` (and the whole CLI client) honors `AO_API_BASE` + `AO_API_TOKEN` — inside a sandbox there is no loopback daemon, so activity events post to the injected base with a bearer token. The loopback listener is untouched (still 127.0.0.1, unauthenticated).
- **Idle/cost mapping**: sandbox auto-stop (default 15 min, configurable/disable-able) + explicit `Park`. Parked = `IsAlive true` / supervised-process dead → AO's existing exited→resume flow wakes it via `Restart`. Cost: ~$0.067/h running (default size), ~$0.0003/h parked, $0 archived.

## Tests

- `go build ./...`, `go vet ./...`, full `go test ./...` and `-race` on the touched packages — green (the 5 pre-existing `internal/cli` spawn-test failures under an AO worker shell come from inherited `AO_SESSION_ID` env; they pass with a scrubbed env, unrelated to this PR).
- Contract tests over an in-memory fake Daytona (mirroring the tmux fake-runner seam): launch-line construction (no host-PATH leakage), parked-liveness, never-kill-on-transient probes, #2802 generations, dirty refusal + re-park, preserve-ref stale/clean/conflict mapping, chunked send round-trip, handle parity with `tmux.SessionName`.
- Live smoke (`smoke_live_test.go`), **skipped unless `DAYTONA_API_KEY` is set**: (1) sandbox+exec+PTY WebSocket round-trip, (2) full lifecycle — workspace create (clone) → tmux-hosted process → output capture → message round-trip → park → wake/restart → clean teardown, (3) opt-in real-agent demo via `AO_DAYTONA_AGENT_ARGV` (e.g. `["claude","-p","say hello"]`) with `CLAUDE_CODE_OAUTH_TOKEN` injected.

## Live validation (2026-07-28) — DONE, all green against real Daytona

Run with the maintainer's test org + the pushed `ao-agent-sandbox:dev` snapshot + a real `CLAUDE_CODE_OAUTH_TOKEN` (credentials via env only):

| Test | Result | Proves |
| --- | --- | --- |
| `TestLive_ClientSandboxLifecycle` | **PASS 4.4s** | sandbox create→started ~2–3s, exec, PTY-WebSocket round-trip + resize, delete |
| `TestLive_RuntimeSessionLifecycle` | **PASS 14.4s** | workspace (sandbox+clone) → tmux agent → scrollback → send round-trip → park → wake (same handle) → synchronous teardown |
| `TestLive_RealAgentSession` | **PASS 13.6s** | real Claude Code **authenticated with no browser flow** (boot-env token injection), answered a prompt; keep-alive shell held after exit |

The live runs surfaced three real async-state behaviors (stop/delete return 200 while state lags; list trails GET) — fixed + regression-tested in 475d285f8. Terminal streaming is validated at the port level (PTY WebSocket ↔ `ports.Stream`); in-app rendering awaits phase-3 per-session runtime selection — **merging this PR changes nothing for local installs** (`runtimeselect` still picks tmux/conpty by OS; no `AO_RUNTIME=daytona` gate is included). Confirmed gap: sandbox→daemon activity events need the control plane's reachable `AO_API_BASE` + per-session token (CLI side unit-tested). Full details: `docs/cloud/daytona-runtime.md` §6.

## What I need from you (maintainer) — ✅ both provided; live suite green

1. A Daytona org + API key (https://app.daytona.io/dashboard/keys, scopes: write/delete sandboxes) exported as `DAYTONA_API_KEY` to run the live smoke: `cd backend && go test ./internal/adapters/runtime/daytona/ -run TestLive -v`. ~$200 free credit covers this many times over (each run is a few sandbox-minutes).
2. For the full real-agent demo: a custom snapshot with tmux/git/node + Claude Code (+ the `ao` Linux binary for hooks) — `daytona snapshot create ao-agent --dockerfile …`; I can write that Dockerfile as a follow-up. Until then the lifecycle test best-effort apt-installs tmux into the default snapshot.

## Known gaps / follow-ups (documented in the design doc)

- Control plane must supply: reachable `AO_API_BASE` + per-session token minting/validation, the agent-harness snapshot, repo-URL resolver + git credentials for private repos (the default resolver reads local `origin` for the hybrid local-daemon setup).
- Spawn attachments / per-project provisioning write local files today — cloud sessions need those uploaded via the toolbox fs API (control-plane concern, phase 3).
- Preserve refs live on the sandbox disk; pushing them to `refs/ao/preserved/*` on origin is a follow-up.
- Parked sessions lose tmux scrollback (Daytona stop kills processes); agent transcripts survive on disk and native resume works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
