### PR TITLE
fix(preview): don't auto-discover Markdown docs via bare ao preview

### DIFF
--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -857,7 +857,15 @@ func writeSessionPRError(w http.ResponseWriter, r *http.Request, err error) {
 }
 
 func discoverPreviewEntry(workspacePath string) (string, bool) {
-	entry, ok := previewutil.DiscoverEntry(workspacePath)
+	// Use DiscoverWebEntrypoint (index.html variants only), not DiscoverEntry
+	// (which falls back to mostRecentPreviewable — the newest .md/.html in the
+	// workspace). Bare `ao preview` (no args) hits this path, and agent
+	// harnesses run that automatically on new sessions via the using-ao skill.
+	// With the .md fallback, every new session in a Markdown-rich repo opened
+	// its browser panel to an arbitrary repo doc (e.g. test/cli/README.md)
+	// instead of staying empty. Mirrors the poller fix from PR #2860.
+	// See issue #2859.
+	entry, ok := previewutil.DiscoverWebEntrypoint(workspacePath)
 	return entry.Path, ok
 }
 

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -595,6 +595,26 @@ func TestSessionsAPI_SetPreviewEmptyURLAutodetectsIndex(t *testing.T) {
 	}
 }
 
+func TestSessionsAPI_SetPreviewEmptyURLDoesNotFallbackToMarkdown(t *testing.T) {
+	svc := newFakeSessionService()
+	workspace := t.TempDir()
+	// A Markdown-rich repo with no index.html: the old behavior fell back to
+	// mostRecentPreviewable and picked README.md. The fix restricts bare
+	// ao preview to real static entrypoints, so this should 404.
+	if err := os.WriteFile(filepath.Join(workspace, "README.md"), []byte("# project"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	s := svc.sessions["ao-1"]
+	s.Metadata = domain.SessionMetadata{WorkspacePath: workspace}
+	svc.sessions["ao-1"] = s
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/preview", `{}`)
+	if status != http.StatusNotFound {
+		t.Fatalf("set preview with only .md = %d, want 404; body=%s", status, body)
+	}
+}
+
 func TestSessionsAPI_SetPreviewEmptyURLPrefersWorkspaceEntryOverExistingTarget(t *testing.T) {
 	svc := newFakeSessionService()
 	workspace := t.TempDir()


### PR DESCRIPTION
Fixes #3255

## Summary

The HTTP controller path (`discoverPreviewEntry` in `sessions.go`) still used `DiscoverEntry` with the `mostRecentPreviewable` `.md`/`.html` fallback, even though PR #2860 fixed the poller to use `DiscoverWebEntrypoint` (index.html only) for new sessions.

Bare `ao preview` (no args) hits this path, and agent harnesses (Claude Code, Codex, etc.) run it automatically on new sessions via the `using-ao` skill — so every new session in a Markdown-rich repo opened its browser panel to an arbitrary repo doc (e.g. `test/cli/README.md`) instead of staying empty.

**One-line fix:** `DiscoverEntry` → `DiscoverWebEntrypoint` in `discoverPreviewEntry`, mirroring the poller fix from #2860 exactly.

This completes the incomplete fix of #2859 (which only fixed the poller path, not the HTTP controller path).

## Test

```bash
cd backend && go build ./... && go test ./internal/httpd/controllers/... -run TestSessionsAPI_ -count=1
# ok  github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers  0.908s

cd backend && go test ./internal/preview/... -count=1
# ok  github.com/aoagents/agent-orchestrator/backend/internal/preview  0.012s
```

New test `TestSessionsAPI_SetPreviewEmptyURLDoesNotFallbackToMarkdown` proves a `.md`-only workspace returns 404 on bare `ao preview` (was 200 with the old fallback).
