### PR TITLE
fix: prevent foreign PR auto-attribution

### DIFF
--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -41,8 +42,11 @@ type ProviderOptions struct {
 // loop in v1 — the loop is a follow-up PR (#35); this adapter is the
 // observation primitive that loop will call.
 type Provider struct {
-	client *Client
-	logger *slog.Logger
+	client           *Client
+	logger           *slog.Logger
+	identityMu       sync.Mutex
+	identity         ports.SCMIdentity
+	identityResolved bool
 }
 
 // NewProvider returns a Provider. If opts.Client is supplied it is used
@@ -89,6 +93,33 @@ func (p *Provider) SCMCredentialsAvailable(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// AuthenticatedIdentity returns the account associated with the active GitHub
+// token. Successful results are cached for the provider's lifetime.
+func (p *Provider) AuthenticatedIdentity(ctx context.Context) (ports.SCMIdentity, error) {
+	p.identityMu.Lock()
+	defer p.identityMu.Unlock()
+	if p.identityResolved {
+		return p.identity, nil
+	}
+	resp, err := p.client.doREST(ctx, http.MethodGet, "/user", nil, nil)
+	if err != nil {
+		return ports.SCMIdentity{}, err
+	}
+	var user struct {
+		Login string `json:"login"`
+		Type  string `json:"type"`
+	}
+	if err := json.Unmarshal(resp.Body, &user); err != nil {
+		return ports.SCMIdentity{}, fmt.Errorf("github scm: decode authenticated user: %w", err)
+	}
+	p.identity = ports.SCMIdentity{
+		Login: strings.TrimSpace(user.Login),
+		Human: strings.EqualFold(strings.TrimSpace(user.Type), "User"),
+	}
+	p.identityResolved = true
+	return p.identity, nil
 }
 
 // Observe fetches the current state of one PR by its github.com URL and

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -106,6 +106,45 @@ func newProviderForTest(t *testing.T, f *fakeGH) *Provider {
 
 func ctx() context.Context { return context.Background() }
 
+func TestAuthenticatedIdentityCachesHumanUser(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodGet, "/user", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"login": "Alice", "type": "User"})
+	})
+	p := newProviderForTest(t, f)
+
+	first, err := p.AuthenticatedIdentity(ctx())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := p.AuthenticatedIdentity(ctx())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != (ports.SCMIdentity{Login: "Alice", Human: true}) || second != first {
+		t.Fatalf("identities = %#v, %#v", first, second)
+	}
+	if got := f.callsTo(http.MethodGet, "/user"); got != 1 {
+		t.Fatalf("GET /user calls = %d, want 1", got)
+	}
+}
+
+func TestAuthenticatedIdentityClassifiesBot(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodGet, "/user", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"login": "ao-bot", "type": "Bot"})
+	})
+	p := newProviderForTest(t, f)
+
+	got, err := p.AuthenticatedIdentity(ctx())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != (ports.SCMIdentity{Login: "ao-bot", Human: false}) {
+		t.Fatalf("identity = %#v", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Fixture builders. Each test composes a REST pull + GraphQL response so
 // it can pin the exact shape it cares about without sharing global state

--- a/backend/internal/daemon/scm_wiring.go
+++ b/backend/internal/daemon/scm_wiring.go
@@ -25,7 +25,10 @@ func startSCMObserver(ctx context.Context, store *sqlite.Store, lcm *lifecycle.M
 		logSCMProviderDisabled(logger, err)
 		return closedDone()
 	}
-	observer := scmobserve.New(provider, store, lcm, scmobserve.Config{Logger: logger})
+	observer := scmobserve.New(provider, store, lcm, scmobserve.Config{
+		Logger:           logger,
+		IdentityResolver: provider,
+	})
 	return observer.Start(ctx)
 }
 

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -75,6 +75,10 @@ type credentialChecker interface {
 	SCMCredentialsAvailable(ctx context.Context) (bool, error)
 }
 
+type authenticatedIdentityProvider interface {
+	AuthenticatedIdentity(ctx context.Context) (ports.SCMIdentity, error)
+}
+
 // Config holds optional observer knobs. Zero values use production defaults.
 type Config struct {
 	// Tick is the fast PR/CI polling interval. Zero uses DefaultTickInterval.
@@ -714,6 +718,7 @@ func pendingRepoRefreshes(guards map[string]repoGuardState) map[string]bool {
 // NotModified against a known ETag are skipped, since nothing new can have
 // appeared since the last poll.
 func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRepo, subjects map[string]*subject, guards map[string]repoGuardState, now time.Time, markRepoFailed func(ports.SCMRepo)) {
+	identity, identityKnown := o.authenticatedIdentity(ctx)
 	byRepo := map[string][]sessionRepo{}
 	repos := map[string]ports.SCMRepo{}
 	for _, sr := range sessionRepos {
@@ -739,6 +744,9 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 		}
 		for _, pr := range pulls {
 			if pr.Number <= 0 || pr.SourceBranch == "" {
+				continue
+			}
+			if identityKnown && !strings.EqualFold(strings.TrimSpace(pr.Author), identity.Login) {
 				continue
 			}
 			key := prKey(repo, pr.Number)
@@ -794,6 +802,24 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 	}
 }
 
+func (o *Observer) authenticatedIdentity(ctx context.Context) (ports.SCMIdentity, bool) {
+	provider, ok := o.provider.(authenticatedIdentityProvider)
+	if !ok {
+		return ports.SCMIdentity{}, false
+	}
+	identity, err := provider.AuthenticatedIdentity(ctx)
+	if err != nil {
+		o.logger.Debug("scm observer: authenticated identity unavailable; preserving branch-based discovery", "err", err)
+		return ports.SCMIdentity{}, false
+	}
+	identity.Login = strings.TrimSpace(identity.Login)
+	if !identity.Human || identity.Login == "" {
+		o.logger.Debug("scm observer: authenticated human identity unavailable; preserving branch-based discovery")
+		return ports.SCMIdentity{}, false
+	}
+	return identity, true
+}
+
 // matchSession picks the session that owns sourceBranch. A session owns the
 // branch when it is an exact match or a stacked descendant ("branch/..."). The
 // default worker branch is a leaf named "<namespace>/root"; for that shape the
@@ -821,6 +847,11 @@ func candidatesForHeadRepo(candidates []sessionRepo, headRepo string) []sessionR
 }
 
 func matchSession(candidates []sessionRepo, sourceBranch string) (sessionRepo, bool) {
+	for _, sr := range candidates {
+		if sr.branch != "" && sr.branch == sourceBranch {
+			return sr, true
+		}
+	}
 	var best sessionRepo
 	bestLen := -1
 	for _, sr := range candidates {

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -75,10 +75,6 @@ type credentialChecker interface {
 	SCMCredentialsAvailable(ctx context.Context) (bool, error)
 }
 
-type authenticatedIdentityProvider interface {
-	AuthenticatedIdentity(ctx context.Context) (ports.SCMIdentity, error)
-}
-
 // Config holds optional observer knobs. Zero values use production defaults.
 type Config struct {
 	// Tick is the fast PR/CI polling interval. Zero uses DefaultTickInterval.
@@ -91,6 +87,8 @@ type Config struct {
 	Logger *slog.Logger
 	// CacheMax bounds each in-memory ETag/review cache. Zero uses DefaultCacheMax.
 	CacheMax int
+	// IdentityResolver resolves the active SCM account lazily. Nil preserves branch-based discovery.
+	IdentityResolver ports.SCMIdentityResolver
 }
 
 // ObserverCache stores provider ETags and review polling timestamps in memory.
@@ -156,6 +154,8 @@ type Observer struct {
 	credentialsChecked bool
 	// disabled is set after the credential gate reports unavailable credentials.
 	disabled bool
+	// identityResolver is the explicitly wired source of the active SCM account.
+	identityResolver ports.SCMIdentityResolver
 	// Cache holds bounded in-memory provider ETags and review poll timestamps.
 	Cache ObserverCache
 }
@@ -163,7 +163,7 @@ type Observer struct {
 // New constructs an Observer with default cadence/cache settings for zero
 // values in cfg.
 func New(provider Provider, store Store, lifecycle Lifecycle, cfg Config) *Observer {
-	o := &Observer{provider: provider, store: store, lifecycle: lifecycle, tick: cfg.Tick, reviewInterval: cfg.ReviewInterval, clock: cfg.Clock, logger: cfg.Logger, Cache: newCache(cfg.CacheMax)}
+	o := &Observer{provider: provider, store: store, lifecycle: lifecycle, tick: cfg.Tick, reviewInterval: cfg.ReviewInterval, clock: cfg.Clock, logger: cfg.Logger, identityResolver: cfg.IdentityResolver, Cache: newCache(cfg.CacheMax)}
 	if o.tick <= 0 {
 		o.tick = DefaultTickInterval
 	}
@@ -803,11 +803,10 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 }
 
 func (o *Observer) authenticatedIdentity(ctx context.Context) (ports.SCMIdentity, bool) {
-	provider, ok := o.provider.(authenticatedIdentityProvider)
-	if !ok {
+	if o.identityResolver == nil {
 		return ports.SCMIdentity{}, false
 	}
-	identity, err := provider.AuthenticatedIdentity(ctx)
+	identity, err := o.identityResolver.AuthenticatedIdentity(ctx)
 	if err != nil {
 		o.logger.Debug("scm observer: authenticated identity unavailable; preserving branch-based discovery", "err", err)
 		return ports.SCMIdentity{}, false

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -137,6 +137,16 @@ type fakeProvider struct {
 	fetchBatches     [][]ports.SCMPRRef
 	logCalls         int
 	reviewCalls      int
+	identity         ports.SCMIdentity
+	identityErr      error
+	identityCalls    int
+}
+
+func (p *fakeProvider) AuthenticatedIdentity(context.Context) (ports.SCMIdentity, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.identityCalls++
+	return p.identity, p.identityErr
 }
 
 func (p *fakeProvider) SCMCredentialsAvailable(context.Context) (bool, error) {
@@ -546,6 +556,61 @@ func TestPoll_RepoETag200DiscoversPRAndRefreshesSamePoll(t *testing.T) {
 	}
 }
 
+func TestPoll_DiscoversOnlyPRsFromAuthenticatedHuman(t *testing.T) {
+	store := testStoreWithSession()
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
+		openPRs: map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {
+			{URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "feat", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha1", Author: "other"},
+			{URL: "https://github.com/o/r/pull/2", Number: 2, SourceBranch: "feat", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha2", Author: "ALICE"},
+		}},
+		observations: map[string]ports.SCMObservation{prKey(testRepo, 2): testObs(2)},
+		identity:     ports.SCMIdentity{Login: "alice", Human: true},
+	}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.fetchBatches) != 1 || len(provider.fetchBatches[0]) != 1 || provider.fetchBatches[0][0].Number != 2 {
+		t.Fatalf("fetched PRs = %#v, want only authenticated author's PR #2", provider.fetchBatches)
+	}
+	for _, write := range store.writes {
+		if write.pr.Number == 1 {
+			t.Fatal("foreign author's PR was persisted")
+		}
+	}
+}
+
+func TestPoll_PreservesBranchDiscoveryWithoutHumanIdentity(t *testing.T) {
+	tests := []struct {
+		name        string
+		identity    ports.SCMIdentity
+		identityErr error
+	}{
+		{name: "lookup error", identityErr: errors.New("identity unavailable")},
+		{name: "bot account", identity: ports.SCMIdentity{Login: "ao-bot", Human: false}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := testStoreWithSession()
+			provider := &fakeProvider{
+				repoGuards:   map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
+				openPRs:      map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {{URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "feat", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha1", Author: "other"}}},
+				observations: map[string]ports.SCMObservation{prKey(testRepo, 1): testObs(1)},
+				identity:     tt.identity,
+				identityErr:  tt.identityErr,
+			}
+			obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+			if err := obs.Poll(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if len(provider.fetchBatches) != 1 || provider.fetchBatches[0][0].Number != 1 {
+				t.Fatalf("branch fallback did not discover PR: %#v", provider.fetchBatches)
+			}
+		})
+	}
+}
+
 // A session whose branch is the prefix of two open PRs (its root plus a stacked
 // child on branch "feat/child") picks up both PRs in a single poll.
 func TestPoll_DiscoversStackedChildByBranchPrefix(t *testing.T) {
@@ -606,6 +671,18 @@ func TestPoll_DiscoversSiblingUnderRootSessionNamespace(t *testing.T) {
 	}
 	if len(lc.observed) != 1 {
 		t.Fatalf("lifecycle observations = %d, want 1", len(lc.observed))
+	}
+}
+
+func TestMatchSession_PrefersExactBranchOverNamespaceMatch(t *testing.T) {
+	exact := sessionRepo{session: domain.SessionRecord{ID: "exact"}, branch: "ao/p-1"}
+	namespace := sessionRepo{session: domain.SessionRecord{ID: "namespace"}, branch: "ao/p-1/root"}
+	got, ok := matchSession([]sessionRepo{namespace, exact}, "ao/p-1")
+	if !ok {
+		t.Fatal("expected a matching session")
+	}
+	if got.session.ID != exact.session.ID {
+		t.Fatalf("matched session = %q, want exact branch owner %q", got.session.ID, exact.session.ID)
 	}
 }
 

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -142,6 +142,17 @@ type fakeProvider struct {
 	identityCalls    int
 }
 
+type fakeIdentityResolver struct {
+	identity ports.SCMIdentity
+	err      error
+	calls    int
+}
+
+func (r *fakeIdentityResolver) AuthenticatedIdentity(context.Context) (ports.SCMIdentity, error) {
+	r.calls++
+	return r.identity, r.err
+}
+
 func (p *fakeProvider) AuthenticatedIdentity(context.Context) (ports.SCMIdentity, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -236,7 +247,7 @@ func (l *fakeLifecycle) ApplySCMObservation(_ context.Context, _ domain.SessionI
 }
 
 func newTestObserver(store *fakeStore, provider *fakeProvider, lc Lifecycle, now time.Time) *Observer {
-	return New(provider, store, lc, Config{Clock: func() time.Time { return now }, Tick: time.Hour, Logger: quietSlog(), CacheMax: 128})
+	return New(provider, store, lc, Config{Clock: func() time.Time { return now }, Tick: time.Hour, Logger: quietSlog(), CacheMax: 128, IdentityResolver: provider})
 }
 
 func TestDispatchOrderIsDeterministic(t *testing.T) {
@@ -565,11 +576,20 @@ func TestPoll_DiscoversOnlyPRsFromAuthenticatedHuman(t *testing.T) {
 			{URL: "https://github.com/o/r/pull/2", Number: 2, SourceBranch: "feat", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha2", Author: "ALICE"},
 		}},
 		observations: map[string]ports.SCMObservation{prKey(testRepo, 2): testObs(2)},
-		identity:     ports.SCMIdentity{Login: "alice", Human: true},
 	}
-	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+	identity := &fakeIdentityResolver{identity: ports.SCMIdentity{Login: "alice", Human: true}}
+	obs := New(provider, store, &fakeLifecycle{}, Config{
+		Clock:            func() time.Time { return time.Unix(1, 0).UTC() },
+		Tick:             time.Hour,
+		Logger:           quietSlog(),
+		CacheMax:         128,
+		IdentityResolver: identity,
+	})
 	if err := obs.Poll(context.Background()); err != nil {
 		t.Fatal(err)
+	}
+	if identity.calls != 1 {
+		t.Fatalf("identity resolver calls = %d, want 1", identity.calls)
 	}
 	if len(provider.fetchBatches) != 1 || len(provider.fetchBatches[0]) != 1 || provider.fetchBatches[0][0].Number != 2 {
 		t.Fatalf("fetched PRs = %#v, want only authenticated author's PR #2", provider.fetchBatches)

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -88,6 +88,14 @@ type SCMChanged struct {
 	Review bool
 }
 
+// SCMIdentity describes the account authenticated with the SCM provider.
+type SCMIdentity struct {
+	// Login is the provider login/name of the authenticated account.
+	Login string
+	// Human is true when the provider identifies the account as a human user.
+	Human bool
+}
+
 // SCMPRObservation carries provider-neutral PR metadata.
 type SCMPRObservation struct {
 	// URL is the canonical PR URL used as the persistence key.

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -5,6 +5,7 @@
 package ports
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -94,6 +95,12 @@ type SCMIdentity struct {
 	Login string
 	// Human is true when the provider identifies the account as a human user.
 	Human bool
+}
+
+// SCMIdentityResolver lazily resolves the account authenticated with the
+// active SCM provider.
+type SCMIdentityResolver interface {
+	AuthenticatedIdentity(ctx context.Context) (SCMIdentity, error)
 }
 
 // SCMPRObservation carries provider-neutral PR metadata.


### PR DESCRIPTION
## What changed

- resolve and cache the human account authenticated with the GitHub provider
- ignore foreign-authored PRs during automatic branch-based discovery
- keep the existing discovery fallback when identity is unavailable or belongs to a bot/app
- prefer true exact branch matches over namespace-prefix matches
- add regression coverage for owner filtering, case-insensitive logins, fallback behavior, caching, and exact-match priority

## Why

The SCM observer previously attributed PRs using only the head repository and branch name. In shared repositories, another developer could create a PR from a colliding branch name and have it attached to the wrong AO session, potentially causing incorrect lifecycle behavior.

Authenticated identity remains provider-scoped and in memory; it is not persisted on sessions. Explicit `ao pr claim` remains the override when another user opens a PR for a session branch.

## Verification

- `go test ./internal/observe/scm ./internal/adapters/scm/github`
- `go test -race ./internal/observe/scm`
- `go test -race ./internal/adapters/scm/github`
- `npm run lint`
- `go build ./...`
- `git diff --check`

Fixes #3259
