### PR TITLE
fix: replace terminal tab strip session picker with a new-terminal button

### DIFF
--- a/frontend/e2e/shell-terminal-tabs.spec.ts
+++ b/frontend/e2e/shell-terminal-tabs.spec.ts
@@ -12,13 +12,19 @@ test("opens, selects, and closes standalone shell terminals from the tab strip",
 	const closeButtons = page.getByRole("button", { name: /^Close terminal / });
 	const initialCount = await closeButtons.count();
 
-	// The topbar action opens a shell and makes it the active pane.
+	// The button at the end of the tab strip opens a shell and makes it the
+	// active pane. It creates a terminal directly — no menu, no session picker.
 	await page.getByRole("button", { name: "New terminal" }).click();
+	await expect(page.getByRole("menu")).toHaveCount(0);
 	await expect(closeButtons).toHaveCount(initialCount + 1);
 
-	// Selecting the session tab hands the pane back to the agent. Matched by
-	// title, not role-name: the tab's accessible name is the session's title.
-	const sessionTab = page.getByTitle("Session terminal");
+	// Selecting the session tab hands the pane back to the agent. Matched by the
+	// session's own title: the tab's accessible name is that title, and its
+	// title attribute falls back to the label once the strip truncates it.
+	// Scoped to the terminal panel: the sidebar carries the same session name.
+	const sessionTab = page
+		.getByTestId("terminal")
+		.getByRole("button", { name: "Build screenshot-ready dashboard data" });
 	await sessionTab.click();
 	await expect(sessionTab).toHaveAttribute("aria-current", "true");
 

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -18,12 +18,6 @@ const worker = {
 	updatedAt: "2026-06-10T00:00:00Z",
 	prs: [],
 } satisfies WorkspaceSession;
-const secondWorker = {
-	...worker,
-	id: "sess-2",
-	title: "review the change",
-	branch: "ao/sess-2",
-} satisfies WorkspaceSession;
 
 describe("CenterPane toolbar session label", () => {
 	const makeShells = (count: number) =>
@@ -40,81 +34,22 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.queryByText("sess-1")).not.toBeInTheDocument();
 	});
 
-	it("renders project sessions as tabs and opens a sibling session", () => {
-		const onSelectProjectSession = vi.fn();
-		render(
-			<CenterPane
-				session={worker}
-				projectSessions={[worker, secondWorker]}
-				onSelectProjectSession={onSelectProjectSession}
-				theme="dark"
-				daemonReady
-			/>,
-		);
+	it("renders only this session's own tab, never a sibling session", () => {
+		render(<CenterPane session={worker} theme="dark" daemonReady />);
 
 		expect(screen.getByRole("button", { name: "do the thing" })).toHaveAttribute("aria-current", "true");
-		fireEvent.click(screen.getByRole("button", { name: "review the change" }));
-		expect(onSelectProjectSession).toHaveBeenCalledWith(secondWorker);
-	});
-
-	it("adds workers and terminals only through the tab launcher", () => {
-		const onAddProjectSession = vi.fn();
-		const onNewShellTerminal = vi.fn();
-		render(
-			<CenterPane
-				session={worker}
-				projectSessions={[worker]}
-				availableProjectSessions={[secondWorker]}
-				onAddProjectSession={onAddProjectSession}
-				onNewShellTerminal={onNewShellTerminal}
-				theme="dark"
-				daemonReady
-			/>,
-		);
-
 		expect(screen.queryByRole("button", { name: "review the change" })).not.toBeInTheDocument();
-		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
-		fireEvent.click(screen.getByRole("menuitem", { name: /review the change/ }));
-		expect(onAddProjectSession).toHaveBeenCalledWith(secondWorker);
-
-		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
-		fireEvent.click(screen.getByRole("menuitem", { name: "Terminal" }));
-		expect(onNewShellTerminal).toHaveBeenCalledOnce();
 	});
 
-	it("limits a large session list, then expands it into a searchable scroll area", () => {
-		const sessions = Array.from({ length: 7 }, (_, index) => ({
-			...secondWorker,
-			id: `sess-${index + 2}`,
-			title: `Worker ${index + 1}`,
-		}));
-		render(
-			<CenterPane
-				session={worker}
-				projectSessions={[worker]}
-				availableProjectSessions={sessions}
-				theme="dark"
-				daemonReady
-			/>,
-		);
+	// The button used to open a dropdown that also listed every session across
+	// every project (#3208); it now only ever creates a terminal.
+	it("opens a new terminal straight from the tab-strip button", () => {
+		const onNewShellTerminal = vi.fn();
+		render(<CenterPane session={worker} onNewShellTerminal={onNewShellTerminal} theme="dark" daemonReady />);
 
-		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
-		const search = screen.getByRole("textbox", { name: "Search sessions" });
-		const terminal = screen.getByRole("menuitem", { name: "Terminal" });
-		expect(terminal.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-		expect(screen.getByRole("menuitem", { name: /Worker 5/ })).toBeInTheDocument();
-		expect(screen.queryByRole("menuitem", { name: /Worker 6/ })).not.toBeInTheDocument();
-
-		fireEvent.click(screen.getByRole("menuitem", { name: "Show all sessions" }));
-		const lastSession = screen.getByRole("menuitem", { name: /Worker 7/ });
-		expect(lastSession).toBeInTheDocument();
-		expect(lastSession.parentElement).toHaveClass("h-52", "overflow-y-auto");
-
-		fireEvent.change(screen.getByRole("textbox", { name: "Search sessions" }), {
-			target: { value: "Worker 7" },
-		});
-		expect(screen.getByRole("menuitem", { name: /Worker 7/ })).toBeInTheDocument();
-		expect(screen.queryByRole("menuitem", { name: /Worker 1/ })).not.toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "New terminal" }));
+		expect(onNewShellTerminal).toHaveBeenCalledOnce();
+		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 	});
 
 	it("shows 'Orchestrator' for an orchestrator session", () => {

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -1,14 +1,4 @@
-import {
-	ChevronLeft,
-	ChevronRight,
-	Maximize2,
-	Minimize2,
-	Plus,
-	Search,
-	Shield,
-	Terminal as TerminalIcon,
-	X,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, Maximize2, Minimize2, Shield, Terminal as TerminalIcon, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type WheelEvent } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
 import { useTruncatedText } from "../hooks/useTruncatedText";
@@ -20,24 +10,9 @@ import type { TerminalTarget } from "../types/terminal";
 import { isOrchestratorSession, type WorkspaceSession } from "../types/workspace";
 import { ShellTerminalTab } from "./ShellTerminalTab";
 import { TerminalPane } from "./TerminalPane";
-import { Input } from "./ui/input";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
 
 type CenterPaneProps = {
 	session?: WorkspaceSession;
-	/** Tabs pinned to the originating session's private layout. */
-	projectSessions?: WorkspaceSession[];
-	availableProjectSessions?: WorkspaceSession[];
-	tabOwnerSessionId?: string;
-	onAddProjectSession?: (session: WorkspaceSession) => void;
-	onCloseProjectSession?: (session: WorkspaceSession) => void;
-	onSelectProjectSession?: (session: WorkspaceSession) => void;
 	theme: Theme;
 	daemonReady: boolean;
 	terminalTarget?: TerminalTarget;
@@ -48,14 +23,13 @@ type CenterPaneProps = {
 	onSelectShellTerminal?: (handleId: string) => void;
 	onCloseShellTerminal?: (handleId: string) => void;
 	onRenameShellTerminal?: (handleId: string, title: string) => void;
-	/** Opens a new standalone shell tab (the "+" at the end of the tab bar). */
+	/** Opens a new shell tab in this session's worktree (the button at the end of the tab bar). */
 	onNewShellTerminal?: () => void;
 };
 
 const terminalFontSizeStorageKey = "ao.terminal.fontSize";
 const WHEEL_ZOOM_THRESHOLD = 80;
 const WHEEL_ZOOM_RESET_MS = 250;
-const COMPACT_SESSION_LIMIT = 5;
 
 function clampTerminalFontSize(size: number): number {
 	return Math.min(TERMINAL_FONT_SIZE_MAX, Math.max(TERMINAL_FONT_SIZE_MIN, size));
@@ -71,12 +45,6 @@ function initialTerminalFontSize(): number {
 
 export function CenterPane({
 	session,
-	projectSessions,
-	availableProjectSessions = [],
-	tabOwnerSessionId,
-	onAddProjectSession,
-	onCloseProjectSession,
-	onSelectProjectSession,
 	theme,
 	daemonReady,
 	terminalTarget,
@@ -93,25 +61,7 @@ export function CenterPane({
 	const lastWheelZoomAtRef = useRef(0);
 	const [fontSize, setFontSize] = useState(initialTerminalFontSize);
 	const [isFullscreen, setIsFullscreen] = useState(false);
-	const [isTabLauncherOpen, setIsTabLauncherOpen] = useState(false);
-	const [showAllSessions, setShowAllSessions] = useState(false);
-	const [sessionSearch, setSessionSearch] = useState("");
-	const sessionTabs = projectSessions?.length ? projectSessions : session ? [session] : [];
-	const effectiveTabOwnerSessionId = tabOwnerSessionId ?? session?.id;
-	const hasMoreSessions = availableProjectSessions.length > COMPACT_SESSION_LIMIT;
-	const normalizedSessionSearch = sessionSearch.trim().toLowerCase();
-	const filteredSessions = normalizedSessionSearch
-		? availableProjectSessions.filter((candidate) =>
-				`${candidate.title} ${candidate.workspaceName}`.toLowerCase().includes(normalizedSessionSearch),
-			)
-		: availableProjectSessions;
-	const expandedSessionList = showAllSessions || normalizedSessionSearch.length > 0;
-	const visibleSessions = expandedSessionList
-		? filteredSessions
-		: filteredSessions.slice(0, COMPACT_SESSION_LIMIT);
-	const tabOverflowWatch = `${sessionTabs.map((item) => item.id).join("|")}|${shellTerminals
-		.map((terminal) => terminal.handleId)
-		.join("|")}`;
+	const tabOverflowWatch = `${session?.id ?? ""}|${shellTerminals.map((terminal) => terminal.handleId).join("|")}`;
 	const tabsOverflow = useOverflowScroll<HTMLDivElement>(tabOverflowWatch);
 	const target = terminalTarget ?? { kind: "worker" };
 
@@ -189,35 +139,18 @@ export function CenterPane({
 					>
 						<ChevronLeft aria-hidden="true" className="size-icon-md" />
 					</button>
-					{/* Each originating session owns a private set of pinned worker and
-					    shell tabs. The + menu is the only way to add to that layout. */}
+					{/* The session's own pane plus the shells opened from this strip; the
+					    terminal button at the end adds a shell in the session's worktree. */}
 					<div
 						ref={tabsOverflow.ref}
 						className="scrollbar-none flex min-w-flex-min flex-1 items-center gap-3 overflow-x-auto"
 					>
-						{sessionTabs.length > 0 ? (
-							sessionTabs.map((projectSession) => {
-								const isCurrent = projectSession.id === session?.id;
-								return (
-									<SessionPaneTab
-										key={projectSession.id}
-										isActive={isCurrent && target.kind !== "shell"}
-										label={
-											isOrchestratorSession(projectSession) ? "Orchestrator" : projectSession.title
-										}
-										onSelect={
-											isCurrent
-												? onSelectSessionTerminal
-												: () => onSelectProjectSession?.(projectSession)
-										}
-										onClose={
-											projectSession.id !== effectiveTabOwnerSessionId
-												? () => onCloseProjectSession?.(projectSession)
-												: undefined
-										}
-									/>
-								);
-							})
+						{session ? (
+							<SessionPaneTab
+								isActive={target.kind !== "shell"}
+								label={isOrchestratorSession(session) ? "Orchestrator" : session.title}
+								onSelect={onSelectSessionTerminal}
+							/>
 						) : (
 							<SessionPaneTab isActive={target.kind !== "shell"} label="No session" />
 						)}
@@ -245,86 +178,15 @@ export function CenterPane({
 					>
 						<ChevronRight aria-hidden="true" className="size-icon-md" />
 					</button>
-					<DropdownMenu
-						open={isTabLauncherOpen}
-						onOpenChange={(open) => {
-							setIsTabLauncherOpen(open);
-							if (!open) {
-								setShowAllSessions(false);
-								setSessionSearch("");
-							}
-						}}
+					<button
+						aria-label="New terminal"
+						className="inline-flex h-control-sm shrink-0 items-center gap-px rounded-sm px-1 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
+						onClick={onNewShellTerminal}
+						title="New terminal"
+						type="button"
 					>
-						<DropdownMenuTrigger asChild>
-							<button
-								aria-label="Add tab"
-								className="inline-flex h-control-sm shrink-0 items-center gap-px rounded-sm px-1 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
-								title="Add tab"
-								type="button"
-							>
-								<Plus aria-hidden="true" className="size-icon-md" />
-							</button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="start" className="w-72">
-							<DropdownMenuItem onSelect={onNewShellTerminal}>
-								<TerminalIcon aria-hidden="true" />
-								Terminal
-							</DropdownMenuItem>
-							<DropdownMenuSeparator />
-							{hasMoreSessions ? (
-								<div className="relative px-1 pb-1">
-									<Search
-										aria-hidden="true"
-										className="pointer-events-none absolute top-1/2 left-3 size-icon-md -translate-y-[calc(50%+2px)] text-passive"
-									/>
-									<Input
-										aria-label="Search sessions"
-										className="h-control-board pl-8"
-										onChange={(event) => setSessionSearch(event.target.value)}
-										onKeyDown={(event) => event.stopPropagation()}
-										placeholder="Search sessions"
-										value={sessionSearch}
-									/>
-								</div>
-							) : null}
-							<div className={cn(expandedSessionList && "h-52 overflow-y-auto overscroll-contain")}>
-								{visibleSessions.length > 0 ? (
-									visibleSessions.map((candidate) => {
-										const isOpen = sessionTabs.some((tab) => tab.id === candidate.id);
-										return (
-											<DropdownMenuItem
-												key={candidate.id}
-												disabled={isOpen}
-												onSelect={() => onAddProjectSession?.(candidate)}
-											>
-												<span className="size-2 shrink-0 rounded-full bg-passive" aria-hidden="true" />
-												<span className="min-w-0 flex-1 truncate">{candidate.title}</span>
-												<span className="max-w-20 truncate text-micro text-passive">
-													{isOpen ? "Open" : candidate.workspaceName}
-												</span>
-											</DropdownMenuItem>
-										);
-									})
-								) : (
-									<DropdownMenuItem disabled>No sessions found</DropdownMenuItem>
-								)}
-							</div>
-							{hasMoreSessions && !expandedSessionList ? (
-								<>
-									<DropdownMenuSeparator />
-									<DropdownMenuItem
-										className="justify-center text-foreground"
-										onSelect={(event) => {
-											event.preventDefault();
-											setShowAllSessions(true);
-										}}
-									>
-										Show all sessions
-									</DropdownMenuItem>
-								</>
-							) : null}
-						</DropdownMenuContent>
-					</DropdownMenu>
+						<TerminalIcon aria-hidden="true" className="size-icon-md" />
+					</button>
 				</div>
 			</div>
 			{target.kind === "reviewer" ? (

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -6,6 +6,7 @@ import { useUiStore } from "../stores/ui-store";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 
 const navigateMock = vi.hoisted(() => vi.fn());
+const openShellTerminalMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,
@@ -86,26 +87,21 @@ const { workspaces, workspaceQueryState, panels, shellTerminalsState } = vi.hois
 vi.mock("./ShellTopbar", () => ({ ShellTopbar: () => null }));
 vi.mock("./CenterPane", () => ({
 	CenterPane: ({
+		session,
 		shellTerminals = [],
 		onSelectShellTerminal,
 		onSelectSessionTerminal,
-		projectSessions = [],
-		availableProjectSessions = [],
-		onAddProjectSession,
-		onCloseProjectSession,
-		onSelectProjectSession,
+		onNewShellTerminal,
 	}: {
+		session?: WorkspaceSession;
 		shellTerminals?: Array<{ handleId: string; title: string }>;
 		onSelectShellTerminal?: (handleId: string) => void;
 		onSelectSessionTerminal?: () => void;
-		projectSessions?: WorkspaceSession[];
-		availableProjectSessions?: WorkspaceSession[];
-		onAddProjectSession?: (session: WorkspaceSession) => void;
-		onCloseProjectSession?: (session: WorkspaceSession) => void;
-		onSelectProjectSession?: (session: WorkspaceSession) => void;
+		onNewShellTerminal?: () => void;
 	}) => (
 		<div>
 			terminal center
+			<div data-testid="session-tab">{session?.title ?? ""}</div>
 			<div data-testid="shell-tabs">{shellTerminals.map((s) => s.title).join(",")}</div>
 			{shellTerminals.map((s) => (
 				<button key={s.handleId} type="button" onClick={() => onSelectShellTerminal?.(s.handleId)}>
@@ -115,25 +111,9 @@ vi.mock("./CenterPane", () => ({
 			<button type="button" onClick={() => onSelectSessionTerminal?.()}>
 				select agent tab
 			</button>
-			<div data-testid="project-tabs">
-				{projectSessions.map((session) => (
-					<button key={session.id} type="button" onClick={() => onSelectProjectSession?.(session)}>
-						{session.title}
-					</button>
-				))}
-			</div>
-			<div data-testid="available-project-tabs">
-				{availableProjectSessions.map((session) => (
-					<button key={session.id} type="button" onClick={() => onAddProjectSession?.(session)}>
-						Add {session.title}
-					</button>
-				))}
-			</div>
-			{projectSessions.slice(1).map((session) => (
-				<button key={session.id} type="button" onClick={() => onCloseProjectSession?.(session)}>
-					Close {session.title}
-				</button>
-			))}
+			<button type="button" onClick={() => onNewShellTerminal?.()}>
+				new terminal
+			</button>
 		</div>
 	),
 }));
@@ -236,7 +216,7 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 // real hooks would need a QueryClientProvider this suite deliberately omits.
 vi.mock("../hooks/useShellTerminals", () => ({
 	useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
-	useOpenShellTerminal: () => ({ mutate: vi.fn() }),
+	useOpenShellTerminal: () => ({ mutate: openShellTerminalMock }),
 	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
 	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
 }));
@@ -342,12 +322,13 @@ describe("SessionView", () => {
 		}
 		workspaceQueryState.data = workspaces;
 		workspaceQueryState.isLoading = false;
-		useUiStore.setState({ inspectorSessions: {}, visibleTerminalKindBySession: {}, sessionTabsByOwner: {} });
+		useUiStore.setState({ inspectorSessions: {}, visibleTerminalKindBySession: {} });
 		panels.clear();
 		browserDestroy.mockReset();
 		browserViewOptions.current = undefined;
 		shellTerminalsState.data = [];
 		navigateMock.mockReset();
+		openShellTerminalMock.mockReset();
 	});
 
 	// Regression: shell terminals are an app-wide list, so without a per-session
@@ -408,64 +389,23 @@ describe("SessionView", () => {
 		expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBeUndefined();
 	});
 
-	it("starts with only the owner tab and pins another worker through the add menu", () => {
+	// The strip only ever shows the session on screen — pinning another session's
+	// terminal as a tab (and the cross-project picker that did it) is gone (#3208).
+	it("shows only the session on screen in the tab strip", () => {
 		render(<SessionView sessionId="sess-1" />);
 
-		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the thing");
-		expect(screen.getByTestId("project-tabs")).not.toHaveTextContent("do the other thing");
-		expect(screen.getByTestId("available-project-tabs")).toHaveTextContent("Add do the other thing");
-
-		fireEvent.click(screen.getByRole("button", { name: "Add do the other thing" }));
-		expect(useUiStore.getState().sessionTabsByOwner["sess-1"]).toEqual(["sess-2"]);
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "sess-2" },
-			search: { tabOwner: "sess-1" },
-		});
+		expect(screen.getByTestId("session-tab")).toHaveTextContent("do the thing");
+		expect(screen.getByTestId("session-tab")).not.toHaveTextContent("do the other thing");
+		expect(screen.queryByRole("button", { name: /^Add / })).not.toBeInTheDocument();
 	});
 
-	it("offers and pins live worker sessions from other projects", () => {
-		render(<SessionView sessionId="sess-1" />);
+	// The daemon roots a shell in the session's worktree when it is given that
+	// session's id, so a new terminal must name the session actually on screen.
+	it("opens new terminals in the on-screen session's worktree", () => {
+		render(<SessionView sessionId="sess-2" />);
 
-		fireEvent.click(screen.getByRole("button", { name: "Add cross-project task" }));
-		expect(useUiStore.getState().sessionTabsByOwner["sess-1"]).toEqual(["sess-cross-project"]);
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-2", sessionId: "sess-cross-project" },
-			search: { tabOwner: "sess-1" },
-		});
-	});
-
-	it("keeps pinned worker and shell tabs private to their owner session", () => {
-		useUiStore.getState().addSessionTab("sess-1", "sess-2");
-		shellTerminalsState.data = [
-			{
-				handleId: "sh-a",
-				sessionId: "sess-1",
-				title: "owner-shell",
-				workingDir: "/p",
-				createdAt: "2026-07-24T00:00:00Z",
-			},
-			{
-				handleId: "sh-b",
-				sessionId: "sess-2",
-				title: "worker-shell",
-				workingDir: "/q",
-				createdAt: "2026-07-24T00:00:00Z",
-			},
-		];
-		const { rerender } = render(<SessionView sessionId="sess-2" tabOwnerSessionId="sess-1" />);
-
-		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the thing");
-		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the other thing");
-		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("owner-shell");
-		expect(screen.getByTestId("shell-tabs")).not.toHaveTextContent("worker-shell");
-
-		rerender(<SessionView sessionId="sess-2" />);
-		expect(screen.getByTestId("project-tabs")).not.toHaveTextContent("do the thing");
-		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the other thing");
-		expect(screen.getByTestId("shell-tabs")).not.toHaveTextContent("owner-shell");
-		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("worker-shell");
+		fireEvent.click(screen.getByRole("button", { name: "new terminal" }));
+		expect(openShellTerminalMock).toHaveBeenCalledWith({ projectId: "proj-1", sessionId: "sess-2" }, expect.anything());
 	});
 
 	// Regression: react-resizable-panels v4 treats bare numeric sizes as PIXELS

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { useNavigate } from "@tanstack/react-router";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
 import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
@@ -19,7 +18,7 @@ import {
 } from "../hooks/useShellTerminals";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { hidesShellTopbar } from "../lib/platform";
-import { isOrchestratorSession, sessionIsActive, workerSessions, type WorkspaceSession } from "../types/workspace";
+import { isOrchestratorSession, sessionIsActive } from "../types/workspace";
 import type { TerminalTarget } from "../types/terminal";
 import { matchesRendererShortcut } from "../stores/keybindings-store";
 
@@ -27,7 +26,6 @@ const INSPECTOR_MIN_PERCENT = 22;
 const INSPECTOR_MAX_PERCENT = 45;
 const inspectorSplitStorageKey = "ao.inspector.split";
 const shellTopbarHiddenByPlatform = hidesShellTopbar();
-const emptySessionTabIds: string[] = [];
 
 function initialSplitPercent(): number {
 	const raw = typeof window === "undefined" ? null : window.localStorage?.getItem(inspectorSplitStorageKey);
@@ -45,7 +43,6 @@ function previewRevealKey(previewUrl?: string, previewRevision?: number): string
 
 type SessionViewProps = {
 	sessionId: string;
-	tabOwnerSessionId?: string;
 };
 
 // The session detail screen: terminal + git rail. On Win/Linux the shell owns
@@ -60,8 +57,7 @@ type SessionViewProps = {
 // imperative API from the ui-store (topbar button / ⌘⇧B), animated by the
 // flex-grow transition in styles.css. Content keeps a stable min-width inside
 // the clipped panel so nothing reflows mid-animation; split width persists.
-export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) {
-	const navigate = useNavigate();
+export function SessionView({ sessionId }: SessionViewProps) {
 	const workspaceQuery = useWorkspaceQuery();
 	const workspaces = workspaceQuery.data ?? [];
 	const theme = useResolvedTheme();
@@ -80,62 +76,13 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
 
 	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
-	const allSessions = workspaces.flatMap((workspace) => workspace.sessions);
-	const tabOwnerSession = allSessions.find((candidate) => candidate.id === tabOwnerSessionId) ?? session;
-	const ownerSessionId = tabOwnerSession?.id ?? sessionId;
-	const storedSessionTabIds = useUiStore((state) => state.sessionTabsByOwner[ownerSessionId] ?? emptySessionTabIds);
-	const addSessionTab = useUiStore((state) => state.addSessionTab);
-	const removeSessionTab = useUiStore((state) => state.removeSessionTab);
-	const availableSessions = workspaces.flatMap((workspace) =>
-		workerSessions(workspace.sessions).filter((candidate) => candidate.isTerminated !== true),
-	);
-	const projectSessions = tabOwnerSession
-		? [
-				tabOwnerSession,
-				...storedSessionTabIds
-					.map((tabId) => allSessions.find((candidate) => candidate.id === tabId))
-					.filter((projectSession): projectSession is WorkspaceSession =>
-						Boolean(projectSession && projectSession.isTerminated !== true && projectSession.id !== tabOwnerSession.id),
-					),
-			]
-		: [];
-	if (session && !projectSessions.some((projectSession) => projectSession.id === session.id)) {
-		projectSessions.push(session);
-	}
-	const selectProjectSession = useCallback(
-		(projectSession: WorkspaceSession) => {
-			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId: projectSession.workspaceId, sessionId: projectSession.id },
-				search: projectSession.id === ownerSessionId ? {} : { tabOwner: ownerSessionId },
-			});
-		},
-		[navigate, ownerSessionId],
-	);
-	const addProjectSession = useCallback(
-		(projectSession: WorkspaceSession) => {
-			addSessionTab(ownerSessionId, projectSession.id);
-			selectProjectSession(projectSession);
-		},
-		[addSessionTab, ownerSessionId, selectProjectSession],
-	);
-	const closeProjectSession = useCallback(
-		(projectSession: WorkspaceSession) => {
-			removeSessionTab(ownerSessionId, projectSession.id);
-			if (projectSession.id === sessionId && tabOwnerSession) selectProjectSession(tabOwnerSession);
-		},
-		[ownerSessionId, removeSessionTab, selectProjectSession, sessionId, tabOwnerSession],
-	);
 
-	// Shell terminals opened inside a session live beside its pane as extra tabs.
-	//
-	// Scope shells to the tab layout's originating session. Navigating to a
-	// pinned worker keeps the owner's shell tabs; opening that worker directly
-	// from the sidebar uses its own separate shell set.
+	// Shell terminals opened inside a session live beside its pane as extra tabs,
+	// scoped to the session on screen so each session has its own shell set.
 	const allShellTerminals = useShellTerminals().data ?? [];
 	const shellTerminals = useMemo(
-		() => allShellTerminals.filter((shell) => shell.sessionId === ownerSessionId),
-		[allShellTerminals, ownerSessionId],
+		() => allShellTerminals.filter((shell) => shell.sessionId === sessionId),
+		[allShellTerminals, sessionId],
 	);
 	const openShellTerminal = useOpenShellTerminal();
 	const closeShellTerminal = useCloseShellTerminal();
@@ -149,9 +96,12 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 		[renameShellTerminal],
 	);
 
+	// Scoped to the session on screen so the daemon roots the shell in that
+	// session's worktree (the project id is only the fallback when the session's
+	// workspace can no longer be resolved).
 	const addShellTerminal = useCallback(() => {
 		openShellTerminal.mutate(
-			{ projectId: tabOwnerSession?.workspaceId, sessionId: ownerSessionId },
+			{ projectId: session?.workspaceId, sessionId },
 			{
 				onSuccess: (shell) => {
 					setActiveShellTerminal(shell.handleId);
@@ -159,7 +109,7 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 				},
 			},
 		);
-	}, [openShellTerminal, ownerSessionId, setActiveShellTerminal, tabOwnerSession?.workspaceId]);
+	}, [openShellTerminal, sessionId, session?.workspaceId, setActiveShellTerminal]);
 
 	const selectShellTerminal = useCallback(
 		(handleId: string) => {
@@ -422,21 +372,15 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
             be strings. Numeric sizes here once clamped the inspector to 45px. */}
 				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%">
 					<CenterPane
-						availableProjectSessions={availableSessions.filter((candidate) => candidate.id !== tabOwnerSession?.id)}
 						daemonReady={daemonStatus.state === "ready"}
-						onAddProjectSession={addProjectSession}
-						onCloseProjectSession={closeProjectSession}
 						onCloseShellTerminal={closeShellTerminalByHandle}
 						onNewShellTerminal={addShellTerminal}
 						onRenameShellTerminal={renameShellTerminalByHandle}
-						onSelectProjectSession={selectProjectSession}
 						onSelectSessionTerminal={selectSessionTerminal}
 						onSelectShellTerminal={selectShellTerminal}
 						onSelectWorkerTerminal={selectSessionTerminal}
 						session={session}
-						projectSessions={projectSessions}
 						shellTerminals={shellTerminals}
-						tabOwnerSessionId={ownerSessionId}
 						terminalTarget={terminalTarget}
 						theme={theme}
 					/>

--- a/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
@@ -1,16 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SessionView } from "../components/SessionView";
 
-type SessionSearch = { tabOwner?: string };
-
 export const Route = createFileRoute("/_shell/projects/$projectId_/sessions/$sessionId")({
-	validateSearch: (search: Record<string, unknown>): SessionSearch =>
-		typeof search.tabOwner === "string" ? { tabOwner: search.tabOwner } : {},
 	component: ProjectSessionRoute,
 });
 
 function ProjectSessionRoute() {
 	const { sessionId } = Route.useParams();
-	const { tabOwner } = Route.useSearch();
-	return <SessionView sessionId={sessionId} tabOwnerSessionId={tabOwner} />;
+	return <SessionView sessionId={sessionId} />;
 }

--- a/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
@@ -1,16 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SessionView } from "../components/SessionView";
 
-type SessionSearch = { tabOwner?: string };
-
 export const Route = createFileRoute("/_shell/sessions/$sessionId")({
-	validateSearch: (search: Record<string, unknown>): SessionSearch =>
-		typeof search.tabOwner === "string" ? { tabOwner: search.tabOwner } : {},
 	component: SessionRoute,
 });
 
 function SessionRoute() {
 	const { sessionId } = Route.useParams();
-	const { tabOwner } = Route.useSearch();
-	return <SessionView sessionId={sessionId} tabOwnerSessionId={tabOwner} />;
+	return <SessionView sessionId={sessionId} />;
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { CommandPalette } from "../components/CommandPalette";
@@ -133,11 +133,6 @@ function ShellLayout() {
 	const [isSidebarPeekOpen, setIsSidebarPeekOpen] = useState(false);
 	const sidebarPeekCloseTimerRef = useRef<number | undefined>(undefined);
 	const routeParams = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
-	const routeSearch = useSearch({ strict: false }) as { tabOwner?: string };
-	const tabOwnerSession = routeSearch.tabOwner
-		? workspaces.flatMap((workspace) => workspace.sessions).find((session) => session.id === routeSearch.tabOwner)
-		: undefined;
-	const tabOwnerSessionId = tabOwnerSession?.id;
 	useEffect(() => {
 		document.addEventListener("click", handleModifierLinkClick);
 		return () => document.removeEventListener("click", handleModifierLinkClick);
@@ -560,10 +555,7 @@ function ShellLayout() {
 		if (handledShellNonceRef.current === newShellTerminalNonce) return;
 		handledShellNonceRef.current = newShellTerminalNonce;
 		openShellTerminal.mutate(
-			{
-				projectId: tabOwnerSession?.workspaceId ?? scopedProjectId,
-				sessionId: tabOwnerSessionId ?? routeParams.sessionId,
-			},
+			{ projectId: scopedProjectId, sessionId: routeParams.sessionId },
 			{
 				onSuccess: (shell) => {
 					setActiveShellTerminal(shell.handleId);
@@ -578,8 +570,6 @@ function ShellLayout() {
 		openShellTerminal,
 		scopedProjectId,
 		routeParams.sessionId,
-		tabOwnerSession?.workspaceId,
-		tabOwnerSessionId,
 		navigate,
 		setActiveShellTerminal,
 	]);

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -35,38 +35,3 @@ describe("ui-store developerMode persistence", () => {
 		expect(window.localStorage.getItem("ao.developerMode")).toBe("false");
 	});
 });
-
-describe("ui-store session tab persistence", () => {
-	beforeEach(() => {
-		window.localStorage.clear();
-		vi.resetModules();
-	});
-
-	it("keeps added tabs isolated by owner session and restores them", async () => {
-		let store = (await import("./ui-store")).useUiStore;
-		store.getState().addSessionTab("session-a", "session-c");
-		store.getState().addSessionTab("session-a", "session-d");
-		store.getState().addSessionTab("session-b", "session-c");
-
-		expect(store.getState().sessionTabsByOwner).toEqual({
-			"session-a": ["session-c", "session-d"],
-			"session-b": ["session-c"],
-		});
-
-		vi.resetModules();
-		store = (await import("./ui-store")).useUiStore;
-		expect(store.getState().sessionTabsByOwner["session-a"]).toEqual(["session-c", "session-d"]);
-	});
-
-	it("deduplicates additions and removes only the requested owner's tab", async () => {
-		const { useUiStore: store } = await import("./ui-store");
-		store.getState().addSessionTab("session-a", "session-c");
-		store.getState().addSessionTab("session-a", "session-c");
-		store.getState().addSessionTab("session-b", "session-c");
-		store.getState().removeSessionTab("session-a", "session-c");
-
-		expect(store.getState().sessionTabsByOwner).toEqual({
-			"session-b": ["session-c"],
-		});
-	});
-});

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -34,8 +34,6 @@ type UiState = {
 	workbenchTab: WorkbenchTab;
 	isSidebarOpen: boolean;
 	inspectorSessions: Record<string, InspectorSessionState>;
-	/** Extra worker tabs pinned to each originating session's terminal strip. */
-	sessionTabsByOwner: Record<string, string[]>;
 	isCommandPaletteOpen: boolean;
 	themePreference: ThemePreference;
 	/** Resolved light/dark for React consumers; may track OS while preference is system. */
@@ -78,8 +76,6 @@ type UiState = {
 	setInspectorOpen: (sessionId: string, isOpen: boolean) => void;
 	toggleInspector: (sessionId: string) => void;
 	setInspectorView: (sessionId: string, view: InspectorView) => void;
-	addSessionTab: (ownerSessionId: string, sessionId: string) => void;
-	removeSessionTab: (ownerSessionId: string, sessionId: string) => void;
 	markInspectorPreviewSeen: (sessionId: string, previewKey: string) => void;
 	setBrowserUnseen: (sessionId: string, unseen: boolean) => void;
 	setCommandPaletteOpen: (open: boolean) => void;
@@ -96,7 +92,6 @@ type UiState = {
 
 const sidebarStorageKey = "ao.sidebar.open";
 const developerModeStorageKey = "ao.developerMode";
-const sessionTabsStorageKey = "ao.sessionTabs";
 
 function getLocalStorage() {
 	if (typeof window === "undefined" || !window.localStorage) return null;
@@ -111,28 +106,6 @@ function initialDeveloperMode() {
 	return getLocalStorage()?.getItem(developerModeStorageKey) === "true";
 }
 
-function initialSessionTabs(): Record<string, string[]> {
-	const raw = getLocalStorage()?.getItem(sessionTabsStorageKey);
-	if (!raw) return {};
-	try {
-		const parsed = JSON.parse(raw) as unknown;
-		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-		return Object.fromEntries(
-			Object.entries(parsed).flatMap(([ownerSessionId, sessionIds]) =>
-				Array.isArray(sessionIds) && sessionIds.every((sessionId) => typeof sessionId === "string")
-					? [[ownerSessionId, sessionIds]]
-					: [],
-			),
-		);
-	} catch {
-		return {};
-	}
-}
-
-function storeSessionTabs(sessionTabsByOwner: Record<string, string[]>) {
-	getLocalStorage()?.setItem(sessionTabsStorageKey, JSON.stringify(sessionTabsByOwner));
-}
-
 function inspectorState(sessions: Record<string, InspectorSessionState>, sessionId: string): InspectorSessionState {
 	return sessions[sessionId] ?? { isOpen: true, view: "summary" };
 }
@@ -143,7 +116,6 @@ export const useUiStore = create<UiState>((set) => ({
 	workbenchTab: "changes",
 	isSidebarOpen: initialSidebarOpen(),
 	inspectorSessions: {},
-	sessionTabsByOwner: initialSessionTabs(),
 	isCommandPaletteOpen: false,
 	themePreference: initialThemePreference,
 	resolvedTheme: resolveTheme(initialThemePreference),
@@ -208,28 +180,6 @@ export const useUiStore = create<UiState>((set) => ({
 					[sessionId]: { ...current, view, browserUnseen },
 				},
 			};
-		}),
-	addSessionTab: (ownerSessionId, sessionId) =>
-		set((state) => {
-			const current = state.sessionTabsByOwner[ownerSessionId] ?? [];
-			if (ownerSessionId === sessionId || current.includes(sessionId)) return state;
-			const sessionTabsByOwner = {
-				...state.sessionTabsByOwner,
-				[ownerSessionId]: [...current, sessionId],
-			};
-			storeSessionTabs(sessionTabsByOwner);
-			return { sessionTabsByOwner };
-		}),
-	removeSessionTab: (ownerSessionId, sessionId) =>
-		set((state) => {
-			const current = state.sessionTabsByOwner[ownerSessionId] ?? [];
-			if (!current.includes(sessionId)) return state;
-			const remaining = current.filter((id) => id !== sessionId);
-			const sessionTabsByOwner = { ...state.sessionTabsByOwner };
-			if (remaining.length > 0) sessionTabsByOwner[ownerSessionId] = remaining;
-			else delete sessionTabsByOwner[ownerSessionId];
-			storeSessionTabs(sessionTabsByOwner);
-			return { sessionTabsByOwner };
 		}),
 	markInspectorPreviewSeen: (sessionId, previewKey) =>
 		set((state) => {

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -16,7 +16,7 @@ const shellMocks = vi.hoisted(() => {
 		nextSessionListener: undefined as (() => void) | undefined,
 		focusTerminalListener: undefined as (() => void) | undefined,
 		routeParams: {} as { projectId?: string; sessionId?: string },
-		routeSearch: {} as { tabOwner?: string },
+		routeSearch: {} as Record<string, unknown>,
 		workspaces: [] as WorkspaceSummary[],
 		workspaceQuery: {
 			data: [] as WorkspaceSummary[],
@@ -463,15 +463,16 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 		);
 	});
 
-	it("scopes the terminal to the originating session while viewing one of its pinned tabs", async () => {
+	// Session terminals always belong to the session on screen — there is no
+	// longer an "owner" session whose worktree could be borrowed here (#3208).
+	it("scopes the terminal to the session on screen, not the route's project alone", async () => {
 		shellMocks.state.routeParams = { projectId: "proj-2", sessionId: "sess-cross" };
-		shellMocks.state.routeSearch = { tabOwner: "sess-1" };
 		await renderShell();
 
 		pressNewShellTerminal();
 
 		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
-			expect.objectContaining({ projectId: "proj-1", sessionId: "sess-1" }),
+			expect.objectContaining({ projectId: "proj-2", sessionId: "sess-cross" }),
 			expect.anything(),
 		);
 	});


### PR DESCRIPTION
Fixes #3208

## Problem

PR #3138 turned the "+" at the end of the terminal tab strip into a `DropdownMenu`
listing every worker session, so Session B's terminal could be pinned as a tab on
Session A's page. `availableSessions` in `SessionView.tsx` flattened **all**
workspaces, so sessions from other projects showed up too. Users expect "+" to
create a terminal, not browse sessions.

## Changes

**`CenterPane.tsx`** — the dropdown is gone. The button at the end of the strip is
now a terminal icon (`aria-label="New terminal"`) that calls `onNewShellTerminal`
directly. Dropped with it: `isTabLauncherOpen` / `showAllSessions` / `sessionSearch`
state, `COMPACT_SESSION_LIMIT`, the search `Input`, and the
`projectSessions` / `availableProjectSessions` / `onAddProjectSession` /
`onCloseProjectSession` / `onSelectProjectSession` / `tabOwnerSessionId` props. The
strip now renders the session's own tab plus its shells.

**`SessionView.tsx`** — new shells open with `{ projectId: session?.workspaceId, sessionId }`,
i.e. the session on screen, instead of the pinning owner's ids. The daemon's
`resolveShellTerminalWorkingDir` prefers `SessionWorkspace(sessionID)` over the
project root, so this is what puts the terminal in the right worktree. Shell-tab
filtering keys on `sessionId` for the same reason.

**Dead-code removal** — the picker was the only writer of the pinning state, so
leaving it would strand tabs pinned before the upgrade (they'd rehydrate from
localStorage with no way to remove them). Removed `sessionTabsByOwner`,
`addSessionTab`, `removeSessionTab` and the `ao.sessionTabs` persistence from
`ui-store.ts`; the `?tabOwner=` search param from both session routes and
`_shell.tsx` (the Ctrl+Shift+` handler now scopes to the route's own session).

## Verification

- **Manual, real desktop app.** Clicking the button on a live session opened a shell
  in `~/.ao/dev/data/worktrees/ao/orchestrator/ao-orchestrator` — the session
  worktree, not the project root at `E:\ao`.
- **Daemon contract, live.** `POST /api/v1/shell-terminals` with `{projectId, sessionId}`
  (what the renderer now sends) returns `workingDir` = the session worktree;
  with `{projectId}` alone it returns the project root. That difference is the fix.
- **Renderer, driven in a browser.** Exactly one "New terminal" button, `menu` and
  `menuitem` counts both 0 on click, shell tabs 0 → 1 → 2 and back on close, and a
  second session shows none of the first session's shells.
- **Unit:** typecheck clean; affected suites pass. Full suite last run at 1180 passed /
  4 failed — all in `src/main/supervisor-link.test.ts` (`listen EACCES` on unix
  sockets), pre-existing on Windows and untouched here.
- **e2e:** `shell-terminal-tabs.spec.ts` test 1 passes again (see below).

## Notes for the reviewer

- **`shell-terminal-tabs.spec.ts` was already broken by #3138.** It expects a tab-strip
  button named "New terminal", which #3138 had renamed to "Add tab". This PR restores
  that name, and I fixed the spec's session-tab selector (the old `getByTitle("Session terminal")`
  stopped matching once the label truncates, and a plain role+name match collides with
  the sidebar). It now passes.
- **One test in that file is still red and I left it alone:**
  `opens a terminal from the board, where no session view is mounted` expects a
  board-level "New terminal" button. No such button exists anywhere in the codebase —
  the board's only entry point is Ctrl+Shift+`, which is an Electron menu accelerator
  and unreachable in the browser-based e2e run. Fixing it means either restoring a
  board button or dropping the test; that's a product call, not part of this fix. The
  regression it guarded is covered by `shell-new-session-shortcut.test.tsx`.
- **Unrelated, but worth a follow-up:** `playwright.config.ts` uses
  `VITE_NO_ELECTRON=1 npm run dev:web`, which fails on Windows
  (`'VITE_NO_ELECTRON' is not recognized`). I started the dev server by hand to run e2e.
- The repo has no Prettier config or format script, so I matched the surrounding style
  by hand rather than running a formatter (a default Prettier run reflows these files
  completely).
  
---

cc @illegalcall 