### PR TITLE
fix(landing): add missing sitemap pages

### DIFF
--- a/frontend/src/landing/src/app/sitemap.ts
+++ b/frontend/src/landing/src/app/sitemap.ts
@@ -20,6 +20,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 1.0,
 		},
 		{
+			url: `${baseUrl}/download/`,
+			lastModified: new Date(),
+			changeFrequency: "weekly",
+			priority: 0.9,
+		},
+		{
+			url: `${baseUrl}/design-partners/`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.8,
+		},
+		{
 			url: `${baseUrl}/blog/`,
 			lastModified: new Date(),
 			changeFrequency: "daily",


### PR DESCRIPTION
## What changed

- added `/download/` to the sitemap with weekly crawl frequency and priority 0.9
- added `/design-partners/` with monthly crawl frequency and priority 0.8
- rebased onto the merged dead-URL cleanup and preserved its canonical trailing-slash sitemap entries

## Why

Both pages are live and strategically important, but search engines were not being told about them through the sitemap. `/download/` is the primary desktop conversion page, while `/design-partners/` supports enterprise lead generation.

## Impact

Future sitemap generations include both live conversion pages without restoring removed marketplace URLs or redirecting URL variants.

## Validation

- `npx tsc --noEmit`
- `npm run build`
- generated `out/sitemap.xml` check: 71 URLs, both required pages present, no removed marketplace routes, no non-canonical HTML paths
- `git diff --check`

Closes #3273