### PR TITLE
fix(landing): avoid duplicated docs branding

### DIFF
--- a/frontend/src/landing/src/app/docs/[[...slug]]/page.tsx
+++ b/frontend/src/landing/src/app/docs/[[...slug]]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({
   const doc = getDocPage(slug ?? []);
   if (!doc) return { title: "Docs" };
   return {
-    title: `${doc.title} | Agent Orchestrator Docs`,
+    title: `${doc.title} · Docs`,
     description: doc.description,
     alternates: { canonical: doc.url },
     openGraph: {


### PR DESCRIPTION
## What changed

- changed docs child titles from `{page} | Agent Orchestrator Docs` to `{page} · Docs`
- retained the root metadata template as the single source of product branding

## Why

The child title already contained `Agent Orchestrator`, so the root template appended the brand a second time on every docs page.

## Impact

Quickstart now resolves to `Quickstart · Docs | Agent Orchestrator` instead of the repetitive 57-character title.

## Validation

- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- verified resulting Quickstart title is 38 characters

Closes #3290