### PR TITLE
fix(landing): shorten design partner title

### DIFF
--- a/frontend/src/landing/src/app/design-partners/page.tsx
+++ b/frontend/src/landing/src/app/design-partners/page.tsx
@@ -27,7 +27,7 @@ const FALLBACK_STATS = {
 } as const;
 
 export const metadata: Metadata = {
-  title: "Design Partner Program - Agent Orchestrator",
+  title: "Design Partner Program",
   description:
     "Mission control for your agent fleet: shared sessions, ROI observability, and an engine room your org fully owns. Your engineers get leverage; your leadership gets answers.",
   openGraph: {


### PR DESCRIPTION
## What changed

- shortened the Design Partners child metadata title to `Design Partner Program`
- retained the root metadata template as the single source of product branding

## Why

The previous child title already included `Agent Orchestrator`, so the root template appended the brand again and produced a repetitive 64-character title.

## Impact

The page now resolves to `Design Partner Program | Agent Orchestrator`, a clean 43-character title without duplicated branding.

## Validation

- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- verified resulting title is 43 characters

Closes #3291