### PR TITLE
feat(macos): release hardening (update e2e, verify script, dmg maker, single-publisher rule)

### DIFF
--- a/.github/workflows/mac-update-e2e.yml
+++ b/.github/workflows/mac-update-e2e.yml
@@ -1,0 +1,139 @@
+name: macOS update e2e
+
+# End-to-end macOS auto-update test (#3288 workstream 0): install version N-1,
+# point it at version N's REAL published feed, and prove the update downloads,
+# stages, installs, and that the relaunched app both reports N and is alive.
+#
+# This is the check that would have caught both #3034 and the 29 Jul incident
+# before any user saw them. The interesting logic lives in
+# frontend/scripts/e2e-mac-update.mjs; this job only supplies a real macOS host
+# and a real signed baseline install.
+#
+# Deliberately NOT wired into any release workflow yet:
+#   - The release workflows are paused, and un-pausing them is a separate
+#     decision that does not belong to this change.
+#   - macOS runner minutes are materially more expensive than Linux, and this
+#     project ships nightlies frequently. #3288 recommends making this a hard
+#     required gate on promotion to the STABLE channel specifically (the exact
+#     transition that failed in production), and treating nightly-to-nightly
+#     coverage as optional pending real per-run cost data. The "cost" step below
+#     prints the wall clock so that question can be settled with numbers.
+#
+# To wire it as a stable-promotion gate later, call it from the release
+# workflow:
+#
+#   update-e2e:
+#     uses: ./.github/workflows/mac-update-e2e.yml
+#     with:
+#       baseline_tag: v<previous stable>
+#       target_version: <new version>
+#
+# Requires: the baseline release's signed macOS zip must be published, and the
+# target version's release + latest-mac.yml feed must already be live, since the
+# app resolves the update through the real GitHub feed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      baseline_tag:
+        description: "Release tag to install as N-1 (e.g. v0.10.3)"
+        required: true
+        type: string
+      target_version:
+        description: "Version the app must end up on, no leading v (e.g. 0.10.4)"
+        required: true
+        type: string
+      channel:
+        description: "Update channel to run the test on"
+        required: false
+        default: latest
+        type: string
+  workflow_call:
+    inputs:
+      baseline_tag:
+        required: true
+        type: string
+      target_version:
+        required: true
+        type: string
+      channel:
+        required: false
+        default: latest
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  update-e2e:
+    # macos-latest is Apple silicon, so the arm64 asset is the one under test.
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Record start time
+        id: clock
+        run: echo "started=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Download the baseline (N-1) macOS build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASELINE_TAG: ${{ inputs.baseline_tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/baseline"
+          # The version-free alias is published for every release (see
+          # frontend/docs/desktop-release.md), so this name is stable across tags.
+          gh release download "$BASELINE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'agent-orchestrator-darwin-arm64.zip' \
+            --dir "$RUNNER_TEMP/baseline"
+
+      - name: Verify the baseline artifact is sealed, notarized and stapled
+        # Same canonical script the release pipeline's post-staple gate uses.
+        # An unsigned or unstapled baseline cannot auto-update, so a failure
+        # here is a real signal, not harness noise.
+        run: frontend/scripts/verify-mac-artifact.sh "$RUNNER_TEMP/baseline/agent-orchestrator-darwin-arm64.zip"
+
+      - name: Install the baseline into /Applications
+        run: |
+          set -euo pipefail
+          rm -rf "/Applications/Agent Orchestrator.app"
+          # ditto, never unzip: plain unzip leaves stray AppleDouble files inside
+          # the bundle and breaks the seal (see verify-mac-artifact.sh).
+          ditto -x -k "$RUNNER_TEMP/baseline/agent-orchestrator-darwin-arm64.zip" /Applications
+          plutil -extract CFBundleShortVersionString raw -o - \
+            "/Applications/Agent Orchestrator.app/Contents/Info.plist"
+
+      - name: Run the update end to end
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          node frontend/scripts/e2e-mac-update.mjs \
+            --app "/Applications/Agent Orchestrator.app" \
+            --expect-version "$TARGET_VERSION" \
+            --channel "$CHANNEL"
+
+      - name: Verify the installed app after the update
+        # The swap is done by ShipIt, not by our signing pipeline, so re-run the
+        # full trio on what actually ended up on disk.
+        if: always()
+        run: frontend/scripts/verify-mac-artifact.sh "/Applications/Agent Orchestrator.app"
+
+      - name: Report runner cost
+        if: always()
+        env:
+          STARTED: ${{ steps.clock.outputs.started }}
+        run: |
+          set -euo pipefail
+          elapsed=$(( $(date +%s) - STARTED ))
+          # macOS minutes bill at a multiplier; #3288 asks for real numbers before
+          # deciding whether nightly-to-nightly coverage is worth running.
+          echo "macOS update e2e wall clock: $(( elapsed / 60 ))m $(( elapsed % 60 ))s" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,9 @@ For code entry points:
 
 - The **desktop app** (GitHub Releases) is the canonical, auto-updating install path. Point users there first.
 - **npm still works but is no longer recommended.** `0.10.0` is the final version published to npm; the `@aoagents/ao` package is frozen and will not receive further updates. It remains a legacy on-ramp for users who already have `ao` on their PATH, where `ao start` fetches and opens the desktop build. Do not add features, docs, or flows that treat npm as the intended way to install AO.
+- **Exactly one publisher.** Only the designated release conductor runs a real publish, on any channel. Divergent artifacts from multiple publishers made the 28-29 Jul macOS incident unreadable. Use the fork dev loop for test builds. Full rule and rationale: `frontend/docs/desktop-release.md`, "Hard rule: exactly one publisher".
+- **Verify macOS artifacts with `frontend/scripts/verify-mac-artifact.sh`, never by hand.** It extracts with `ditto -x -k` and runs `codesign --verify --deep --strict`, `spctl -a -vv -t exec`, `xcrun stapler validate`. Plain `unzip` breaks the seal and yields a convincing false failure; `spctl` without `-vv` prints nothing at all on success.
+- **macOS ships both a `.zip` and a `.dmg`.** The dmg is first install only. The zip and `latest-mac.yml` must keep publishing forever: electron-updater cannot install an update from a dmg. macOS differential updates are permanently disabled (full download only); see issues #3151 and #3267.
 
 ## Coding conventions
 

--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -24,6 +24,40 @@ on `main`; the PR-based flow below supersedes it.
   merge commit. Nightlies stamp the version at build time from the highest
   `desktop-v*` tag, so they are unaffected by whatever `main` currently carries.
 
+## Hard rule: exactly one publisher
+
+**Only the designated release conductor runs a real publish.** There is no ad
+hoc human-triggered publish outside that identity, on any channel, for any
+reason, including "just this once to test something".
+
+Why this is a rule and not a preference: between 22 and 24 Jul two different
+publishers emitted divergent macOS zip formats on alternating days. When the
+28-29 Jul signing incident hit, the evidence was unreadable, because builds
+differed for reasons that had nothing to do with the bug being investigated.
+Two days were spent chasing a false "the signing pipeline corrupts the seal"
+conclusion that a hand-run `unzip` had manufactured. A single publisher makes
+consecutive releases byte-comparable, so a real regression shows up as a real
+difference.
+
+What this means in practice:
+
+- The release conductor identity owns every publish that produces a
+  user-facing artifact: stable, nightly, and feature releases.
+- Approving a release run is a different act from publishing one. Any approver
+  on the list below can approve; only the conductor triggers.
+- If you need a build to test something, cut it on the fork dev loop (see
+  "Fork test releases" below). Never on the canonical repo.
+- If the conductor is unavailable, hand the role over explicitly and record the
+  handover. Do not publish "on their behalf" from a second identity.
+- If two artifacts for the same version ever exist and differ, treat every
+  conclusion drawn from either one as void until the divergence is explained.
+
+Verification of artifacts is a separate concern and is not owned by any single
+identity: anyone can and should run
+`frontend/scripts/verify-mac-artifact.sh <artifact>`, which is the only
+supported way to check a macOS artifact by hand. Do not type the checks out
+manually; that is how the 28-29 Jul misdiagnosis happened.
+
 ## Prerequisites
 
 - Push access to `AgentWrapper/agent-orchestrator` (the tag push is the trigger).
@@ -126,14 +160,34 @@ gh api repos/AgentWrapper/agent-orchestrator/releases/latest --jq '.tag_name'
 curl -sL https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/latest-mac.yml | head -3
 ```
 
-Expected assets (17): versioned installers for every platform
+Verify the macOS artifacts with the shared script rather than by hand:
+
+```bash
+gh release download vX.Y.Z -R AgentWrapper/agent-orchestrator \
+  --pattern 'agent-orchestrator-darwin-*.zip' --dir /tmp/relcheck
+frontend/scripts/verify-mac-artifact.sh /tmp/relcheck/agent-orchestrator-darwin-arm64.zip
+```
+
+It extracts with `ditto -x -k` (plain `unzip` breaks the seal and produces a
+convincing false failure) and runs `codesign --verify --deep --strict`,
+`spctl -a -vv -t exec` and `xcrun stapler validate`.
+
+Expected assets: versioned installers for every platform
 (`Agent.Orchestrator-darwin-{arm64,x64}-X.Y.Z.zip`, `Agent.Orchestrator.Setup.X.Y.Z.exe`,
-`Agent.Orchestrator-X.Y.Z.AppImage`, deb, rpm) plus their `.blockmap` sidecars,
-the five version-free aliases `ao start` fetches
+`Agent.Orchestrator-X.Y.Z.AppImage`, deb, rpm) plus `.blockmap` sidecars for
+Windows and Linux only (macOS ships none by policy since #3151, so mac clients
+always take the full-download path), the version-free aliases `ao start` fetches
 (`agent-orchestrator-darwin-arm64.zip`, `agent-orchestrator-darwin-x64.zip`,
 `agent-orchestrator-win32-x64.exe`, `agent-orchestrator-linux-x64.AppImage`,
 and the deb/rpm published under versioned names), and the electron-updater
 feeds `latest.yml`, `latest-mac.yml`, `latest-linux.yml`.
+
+Once the macOS dmg maker's output is published, each release additionally
+carries `Agent Orchestrator-X.Y.Z-{arm64,x64}.dmg` for first install. The dmg is
+purely additive: `MacUpdater` can only install an update from a zip
+(`findFile(files, "zip", ["pkg", "dmg"])`), so the macOS zip and
+`latest-mac.yml` keep publishing permanently. See issue #3267 for the rollout
+order, including when the download-page and README links flip from zip to dmg.
 
 If a platform leg fails, re-run the failed jobs from the Actions UI; the
 stable-alias upload steps use `--clobber`, so re-runs replace assets safely.

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -1,6 +1,7 @@
 import type { ForgeConfig } from "@electron-forge/shared-types";
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import MakerNSIS from "./makers/maker-nsis";
+import MakerDMG, { sealDmg } from "./makers/maker-dmg";
 import MakerAppImage from "./makers/maker-appimage";
 import { writeFileSync } from "node:fs";
 
@@ -80,6 +81,22 @@ const config: ForgeConfig = {
 			].join("\n");
 			writeFileSync("app-update.yml", yml);
 		},
+		// The dmg container is NOT signed, notarized or stapled by any maker
+		// (neither Forge's maker-dmg nor app-builder-lib's dmg target does it), and
+		// the .app's own stapled ticket does not propagate through an unsealed
+		// container. So seal it here, after the maker has produced it, reusing the
+		// same credentials packagerConfig already consumes (#3267 decision 3).
+		// The .app inside was already signed + notarized + stapled by
+		// packagerConfig above, before any maker ran; nothing here touches it.
+		postMake: async (_forgeConfig, makeResults) => {
+			for (const result of makeResults) {
+				if (result.platform !== "darwin") continue;
+				for (const artifact of result.artifacts) {
+					if (artifact.endsWith(".dmg")) await sealDmg(artifact);
+				}
+			}
+			return makeResults;
+		},
 	},
 	rebuildConfig: {},
 	makers: [
@@ -97,7 +114,21 @@ const config: ForgeConfig = {
 			},
 			["win32"],
 		),
+		// macOS auto-update artifact. This entry can NEVER be removed:
+		// MacUpdater.doDownloadUpdate looks for a "zip" and explicitly excludes
+		// .pkg/.dmg, throwing ERR_UPDATER_ZIP_FILE_NOT_FOUND otherwise, so the zip
+		// and latest-mac.yml must keep publishing forever (#3267 decision 2).
 		{ name: "@electron-forge/maker-zip", platforms: ["darwin"], config: {} },
+		// macOS FIRST-INSTALL artifact, additive to the zip above: a dmg has no
+		// user-driven extraction step, so a third-party unzip tool can no longer
+		// break the signature seal on the way in (see makers/maker-dmg.ts, #3267).
+		new MakerDMG(
+			{
+				appId: "dev.agent-orchestrator.desktop",
+				productName: "Agent Orchestrator",
+			},
+			["darwin"],
+		),
 		// Linux fetch-and-run artifact for `ao start`: a single self-contained
 		// AppImage the Go bootstrapper downloads and runs directly (see
 		// makers/maker-appimage.ts). The deb/rpm makers below stay for users who

--- a/frontend/makers/maker-dmg.test.ts
+++ b/frontend/makers/maker-dmg.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Capture buildForge's args without pulling in electron-builder's real machinery.
+const buildForge = vi.fn<(forge: { dir: string }, options: any) => Promise<string[]>>(async () => [
+	"/out/make/Agent Orchestrator-0.10.3-arm64.dmg",
+]);
+vi.mock("app-builder-lib", () => ({ buildForge }));
+
+// Capture the commands sealDmg would run, without ever spawning codesign or
+// xcrun. maker-dmg promisifies execFile at module load, so the stub has to keep
+// the callback shape promisify expects.
+const commands: Array<[string, string[]]> = [];
+let nextError: Error | undefined;
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	const execFile = (cmd: string, args: string[], optsOrCb: unknown, maybeCb?: unknown) => {
+		const done = (typeof optsOrCb === "function" ? optsOrCb : maybeCb) as (
+			err: Error | null,
+			stdout?: string,
+			stderr?: string,
+		) => void;
+		commands.push([cmd, args]);
+		if (nextError) {
+			const err = nextError;
+			nextError = undefined;
+			done(err);
+			return;
+		}
+		done(null, "", "");
+	};
+	return { ...actual, default: { ...actual, execFile }, execFile };
+});
+
+import MakerDMG, { sealDmg } from "./maker-dmg";
+
+const makeOptions = {
+	dir: "/tmp/app/Agent Orchestrator-darwin-arm64",
+	makeDir: "/tmp/app/make",
+	appName: "Agent Orchestrator",
+	targetPlatform: "darwin" as const,
+	targetArch: "arm64" as const,
+	forgeConfig: {} as never,
+	packageJSON: {},
+};
+
+beforeEach(() => {
+	buildForge.mockClear();
+	commands.length = 0;
+	nextError = undefined;
+	vi.spyOn(console, "log").mockImplementation(() => undefined);
+	vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+describe("MakerDMG", () => {
+	it("targets darwin and only builds on macOS (hdiutil is not portable)", () => {
+		const maker = new MakerDMG();
+		expect(maker.name).toBe("dmg");
+		expect(maker.defaultPlatforms).toEqual(["darwin"]);
+		expect(maker.isSupportedOnCurrentPlatform()).toBe(process.platform === "darwin");
+	});
+
+	it("builds a dmg target for the requested arch and forwards config", async () => {
+		const maker = new MakerDMG({ appId: "dev.agent-orchestrator.desktop" }, ["darwin"]);
+		await maker.prepareConfig(makeOptions.targetArch);
+		const artifacts = await maker.make(makeOptions);
+
+		expect(artifacts).toEqual(["/out/make/Agent Orchestrator-0.10.3-arm64.dmg"]);
+		const [forgeOptions, options] = buildForge.mock.calls[0];
+		expect(forgeOptions).toEqual({ dir: makeOptions.dir });
+		expect(options.mac).toEqual(["dmg:arm64"]);
+		// electron-builder must not try to publish; the workflow does that.
+		expect(options.config.publish).toBeNull();
+		expect(options.config.appId).toBe("dev.agent-orchestrator.desktop");
+		expect(options.config.productName).toBe("Agent Orchestrator");
+	});
+
+	it("never lets electron-builder re-sign the already notarized .app", () => {
+		// packagerConfig.osxSign/osxNotarize seal the bundle before any maker runs.
+		// identity: null is what keeps this maker from touching that seal.
+		return new MakerDMG().make(makeOptions).then(() => {
+			const [, options] = buildForge.mock.calls.at(-1)!;
+			expect(options.config.mac.identity).toBeNull();
+		});
+	});
+
+	it("leaves the dmg container unsigned for the postMake seal to handle", async () => {
+		await new MakerDMG().make(makeOptions);
+		const [, options] = buildForge.mock.calls.at(-1)!;
+		// electron-builder's docs warn that dmg.sign conflicts with notarization;
+		// sealDmg signs + notarizes + staples the container instead.
+		expect(options.config.dmg.sign).toBe(false);
+	});
+});
+
+describe("sealDmg", () => {
+	const dmg = "/out/make/app.dmg";
+
+	it("does nothing when there is no signing material (unsigned local builds)", async () => {
+		await sealDmg(dmg, {});
+		expect(commands).toEqual([]);
+	});
+
+	it("signs, notarizes with a keychain profile, and staples", async () => {
+		await sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "Developer ID Application: Someone (TEAMID)", AO_NOTARY_PROFILE: "ao" });
+
+		expect(commands[0]).toEqual([
+			"codesign",
+			["--sign", "Developer ID Application: Someone (TEAMID)", "--timestamp", "--force", dmg],
+		]);
+		expect(commands[1]).toEqual(["xcrun", ["notarytool", "submit", dmg, "--keychain-profile", "ao", "--wait"]]);
+		expect(commands[2]).toEqual(["xcrun", ["stapler", "staple", dmg]]);
+	});
+
+	it("uses the App Store Connect API key trio when that is what CI provides", async () => {
+		await sealDmg(dmg, {
+			APPLE_SIGNING_IDENTITY: "id",
+			APPLE_API_KEY: "/tmp/key.p8",
+			APPLE_API_KEY_ID: "KEYID",
+			APPLE_API_ISSUER: "ISSUER",
+		});
+		expect(commands[1][1]).toEqual([
+			"notarytool",
+			"submit",
+			dmg,
+			"--key",
+			"/tmp/key.p8",
+			"--key-id",
+			"KEYID",
+			"--issuer",
+			"ISSUER",
+			"--wait",
+		]);
+	});
+
+	it("falls back to the keychain identity prefix when only CSC_LINK is set", async () => {
+		await sealDmg(dmg, { CSC_LINK: "base64p12" });
+		expect(commands[0][1]).toEqual(["--sign", "Developer ID Application", "--timestamp", "--force", dmg]);
+	});
+
+	it("signs but skips notarization when no notary credentials are present", async () => {
+		await sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "id" });
+		expect(commands).toHaveLength(1);
+		expect(commands[0][0]).toBe("codesign");
+	});
+
+	it("fails the build when signing fails and credentials were present", async () => {
+		nextError = new Error("codesign: no identity found");
+		await expect(sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "id" })).rejects.toThrow(/no identity found/);
+	});
+});

--- a/frontend/makers/maker-dmg.ts
+++ b/frontend/makers/maker-dmg.ts
@@ -1,0 +1,154 @@
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { MakerBase, type MakerOptions } from "@electron-forge/maker-base";
+import type { ForgePlatform } from "@electron-forge/shared-types";
+
+const run = promisify(execFile);
+
+// macOS first-install distribution as a .dmg, so a user never runs an
+// extraction step and the class of failure where a third-party unzip tool
+// mishandles AppleDouble entries and breaks the code signature seal cannot
+// happen at all. Full decision record: issue #3267, tracked as #3288
+// workstream 6.
+//
+// This is ADDITIVE. The .zip must keep publishing forever:
+// MacUpdater.doDownloadUpdate calls `findFile(files, "zip", ["pkg", "dmg"])`
+// and throws ERR_UPDATER_ZIP_FILE_NOT_FOUND when it is absent, and findFile
+// explicitly excludes .pkg and .dmg from candidates. There is no code path in
+// electron-updater that can install an update from a .dmg, so the dmg is
+// first-install only and never replaces the darwin maker-zip entry.
+//
+// Why bridge to app-builder-lib's `buildForge` instead of using Forge's own
+// @electron-forge/maker-dmg: maker-dmg wraps electron-installer-dmg -> appdmg,
+// neither of which have any notarize/staple code, and app-builder-lib's dmg
+// target has the same limitation (dmg.sign defaults to false and its own docs
+// warn against enabling it alongside notarization). So no maker solves signing
+// for us and we need the same explicit postMake seal either way. Given that,
+// consistency wins: app-builder-lib is already a direct dependency and already
+// proven for a second-target bridge in maker-nsis.ts, so this reuses that
+// pattern instead of pulling a second packaging engine into the tree for one
+// platform. buildForge also needs no host tooling beyond hdiutil.
+
+export type MakerDMGConfig = {
+	// electron-builder appId; keep in sync with packagerConfig.appBundleId.
+	appId?: string;
+	// Volume/product name shown when the dmg is mounted. Defaults to appName.
+	productName?: string;
+	// Any extra electron-builder `dmg` options, merged over our defaults.
+	dmg?: Record<string, unknown>;
+};
+
+export default class MakerDMG extends MakerBase<MakerDMGConfig> {
+	name = "dmg";
+	defaultPlatforms: ForgePlatform[] = ["darwin"];
+
+	// hdiutil is macOS only, so unlike the NSIS bridge this cannot cross-build.
+	isSupportedOnCurrentPlatform(): boolean {
+		return process.platform === "darwin";
+	}
+
+	async make({ dir, targetArch, appName }: MakerOptions): Promise<string[]> {
+		const { buildForge } = await import("app-builder-lib");
+		const cfg = this.config ?? {};
+		// Mirror buildForge's own output layout (<dir>/../make) so artifacts land
+		// where Forge's publisher expects them.
+		const output = path.join(path.dirname(path.resolve(dir)), "make");
+		return buildForge(
+			{ dir },
+			{
+				mac: [`dmg:${targetArch}`],
+				config: {
+					appId: cfg.appId,
+					productName: cfg.productName ?? appName,
+					directories: { output },
+					// Forge owns publishing (the workflow uploads via `gh release`).
+					// `null` stops electron-builder from inferring a GitHub publish
+					// target from package.json `repository` and trying to upload.
+					publish: null,
+					mac: {
+						// The .app inside is ALREADY signed, notarized and stapled by
+						// Forge's packagerConfig.osxSign/osxNotarize, which run before any
+						// maker. `identity: null` guarantees electron-builder never
+						// re-signs it and breaks that seal; we only want its dmg target.
+						identity: null,
+					},
+					dmg: {
+						// Left unsigned on purpose. electron-builder's own docs: "Signing
+						// is not required and will lead to unwanted errors in combination
+						// with notarization requirements." The dmg container is sealed
+						// afterwards by sealDmg() in forge.config.ts's postMake hook.
+						sign: false,
+						...cfg.dmg,
+					},
+				},
+			},
+		);
+	}
+}
+
+// resolveSigningIdentity mirrors packagerConfig.osxSign's credential shapes.
+// APPLE_SIGNING_IDENTITY is the explicit identity used in CI and in the local
+// runbook. With only CSC_LINK set, electron-osx-sign discovers the identity
+// from the keychain it imported the .p12 into; `codesign` does the same given
+// the common prefix, so that is the fallback. Undefined means "no signing
+// material", which is a legitimate state (unsigned local and testing builds).
+function resolveSigningIdentity(env: NodeJS.ProcessEnv): string | undefined {
+	if (env.APPLE_SIGNING_IDENTITY) return env.APPLE_SIGNING_IDENTITY;
+	if (env.CSC_LINK) return "Developer ID Application";
+	return undefined;
+}
+
+// resolveNotaryArgs mirrors packagerConfig.osxNotarize's two credential shapes:
+// an AO_NOTARY_PROFILE notarytool keychain profile locally, or the App Store
+// Connect API key trio in CI.
+function resolveNotaryArgs(env: NodeJS.ProcessEnv): string[] | undefined {
+	if (env.AO_NOTARY_PROFILE) return ["--keychain-profile", env.AO_NOTARY_PROFILE];
+	if (env.APPLE_API_KEY && env.APPLE_API_KEY_ID && env.APPLE_API_ISSUER) {
+		return ["--key", env.APPLE_API_KEY, "--key-id", env.APPLE_API_KEY_ID, "--issuer", env.APPLE_API_ISSUER];
+	}
+	return undefined;
+}
+
+/**
+ * sealDmg signs, notarizes and staples one .dmg.
+ *
+ * Neither maker-dmg nor app-builder-lib's dmg target does any of this, and the
+ * .app's own stapled ticket does not propagate through an unsealed dmg
+ * container, so the container needs its own explicit seal (#3267 decision 3).
+ * Credentials are the exact same env vars packagerConfig already consumes; no
+ * new secrets are introduced.
+ *
+ * With no signing material present this is a no-op with a warning, so unsigned
+ * local builds and the unsigned desktop-testing pipeline still produce a dmg.
+ * When credentials ARE present, any failure throws and fails the build: a
+ * silently unsigned dmg published as a release asset is exactly the outcome
+ * this work exists to prevent.
+ */
+export async function sealDmg(dmgPath: string, env: NodeJS.ProcessEnv = process.env): Promise<void> {
+	const identity = resolveSigningIdentity(env);
+	if (!identity) {
+		console.warn(`[dmg] no signing material (APPLE_SIGNING_IDENTITY / CSC_LINK); leaving ${dmgPath} unsigned`);
+		return;
+	}
+
+	console.log(`[dmg] signing ${dmgPath}`);
+	await run("codesign", ["--sign", identity, "--timestamp", "--force", dmgPath]);
+
+	const notaryArgs = resolveNotaryArgs(env);
+	if (!notaryArgs) {
+		console.warn(`[dmg] no notarization credentials (AO_NOTARY_PROFILE / APPLE_API_KEY); ${dmgPath} is not notarized`);
+		return;
+	}
+
+	console.log(`[dmg] notarizing ${dmgPath} (this waits on Apple)`);
+	await run("xcrun", ["notarytool", "submit", dmgPath, ...notaryArgs, "--wait"], {
+		// Notarization routinely takes several minutes.
+		maxBuffer: 10 * 1024 * 1024,
+	});
+
+	console.log(`[dmg] stapling ${dmgPath}`);
+	await run("xcrun", ["stapler", "staple", dmgPath]);
+}
+
+export { MakerDMG };

--- a/frontend/scripts/blockmap.mjs
+++ b/frontend/scripts/blockmap.mjs
@@ -11,12 +11,19 @@ const { buildBlockMap } = require("app-builder-lib/out/targets/blockmap/blockmap
 
 // writeBlockmap creates "<filePath>.blockmap" (gzip sidecar) and returns the
 // file's base64 sha512 + byte size, exactly as electron-updater reads them from
-// the feed yml. We deliberately do NOT surface blockMapSize: omitting it from
-// the yml forces the client onto the sidecar differential path on win/linux
-// (verified against NsisUpdater / AppImage). mac zips skip writeBlockmap
-// entirely (see feed.mjs's hashFile) — no sidecar means MacUpdater's
-// differential attempt fails and falls back to a full zip download instead
-// (see #3034).
+// the feed yml. We deliberately do NOT surface blockMapSize.
+//
+// What omitting blockMapSize actually does, per platform (verified against the
+// published electron-updater@6.8.9 tarball, #3288 workstream 3):
+//   win:   selects the sidecar differential path in NsisUpdater, via
+//          AppUpdater.differentialDownloadInstaller. Sidecars are load-bearing.
+//   linux: does NOT select a sidecar path. AppImageUpdater has no sidecar path
+//          at all; it uses FileWithEmbeddedBlockMapDifferentialDownloader,
+//          reading the blockmap from the AppImage tail and requiring
+//          blockMapSize. Without it, linux differential updates are off
+//          entirely and the sidecars we write for linux are read by nobody.
+//   mac:   never calls writeBlockmap (see feed.mjs's hashFile), so MacUpdater
+//          always takes the full zip download (#3034, #3151, #3267 decision 4).
 export async function writeBlockmap(filePath) {
 	const { sha512, size } = await buildBlockMap(filePath, "gzip", `${filePath}.blockmap`);
 	return { sha512, size };

--- a/frontend/scripts/e2e-mac-update.mjs
+++ b/frontend/scripts/e2e-mac-update.mjs
@@ -1,0 +1,257 @@
+// End-to-end macOS auto-update harness (#3288 workstream 0).
+//
+// Does what a real user does: takes an already-installed version N-1 bundle,
+// points it at the real published feed, and proves that version N downloads,
+// STAGES, installs on quit, and that the relaunched app both reports version N
+// and is actually alive.
+//
+// Dependency-free ESM (mirrors feed.mjs / nightly-version.mjs) so CI runs
+// `node scripts/e2e-mac-update.mjs ...` directly and vitest unit-tests the pure
+// argument parsing. macOS only: the whole point is Squirrel.Mac's ShipIt swap.
+//
+// Four things about this flow are counter-intuitive and were verified against
+// the published electron-updater@6.8.9 tarball. Do not "simplify" them:
+//
+//  1. The app signals staging through AO_E2E_UPDATE_SENTINEL, which hangs off
+//     the NATIVE updater's update-downloaded event (see auto-updater.ts).
+//     electron-updater's own update-downloaded fires BEFORE Squirrel is told to
+//     fetch, so keying on it stages nothing and the test flaps.
+//  2. A plain macOS quit INSTALLS but does NOT relaunch. Relaunch only happens
+//     through electron-updater's quitAndInstall(). So this harness quits the
+//     app, waits out the ShipIt swap, and relaunches the app itself.
+//  3. There is no completion signal for the ShipIt swap, so the wait is a
+//     bounded poll on the installed bundle's Info.plist version, never a fixed
+//     sleep.
+//  4. Liveness is the daemon's running.json + loopback /healthz, the same
+//     check backend/internal/cli/e2e_test.go uses. "A process exists" is not
+//     proof the app came up.
+//
+// usage:
+//   node scripts/e2e-mac-update.mjs --app "/Applications/Agent Orchestrator.app" \
+//     --expect-version 0.10.4 [--state-dir ~/.ao] [--channel latest|nightly]
+import { spawn, execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+const DEFAULTS = {
+	channel: "latest",
+	// A full mac zip is a few hundred MB; be generous but bounded.
+	downloadTimeoutMs: 20 * 60 * 1000,
+	// ShipIt's ditto swap of an unpacked bundle.
+	swapTimeoutMs: 5 * 60 * 1000,
+	// Cold start plus daemon boot.
+	launchTimeoutMs: 3 * 60 * 1000,
+	pollIntervalMs: 2000,
+};
+
+class UsageError extends Error {}
+
+// parseArgs turns argv into harness options. Pure, so the flag contract is unit
+// tested without launching anything. Throws UsageError on misuse (exit 2).
+export function parseArgs(argv) {
+	const opts = { ...DEFAULTS };
+	for (let i = 0; i < argv.length; i += 1) {
+		const flag = argv[i];
+		const value = argv[i + 1];
+		const needsValue = () => {
+			if (value === undefined || value.startsWith("--")) throw new UsageError(`${flag} needs a value`);
+			i += 1;
+			return value;
+		};
+		switch (flag) {
+			case "--app":
+				opts.app = needsValue();
+				break;
+			case "--expect-version":
+				opts.expectVersion = needsValue();
+				break;
+			case "--state-dir":
+				opts.stateDir = needsValue();
+				break;
+			case "--run-file":
+				opts.runFile = needsValue();
+				break;
+			case "--channel":
+				opts.channel = needsValue();
+				if (opts.channel !== "latest" && opts.channel !== "nightly") {
+					throw new UsageError(`--channel must be latest or nightly, got ${opts.channel}`);
+				}
+				break;
+			case "--download-timeout":
+				opts.downloadTimeoutMs = positiveSeconds(flag, needsValue());
+				break;
+			case "--swap-timeout":
+				opts.swapTimeoutMs = positiveSeconds(flag, needsValue());
+				break;
+			case "--launch-timeout":
+				opts.launchTimeoutMs = positiveSeconds(flag, needsValue());
+				break;
+			default:
+				throw new UsageError(`unknown flag: ${flag}`);
+		}
+	}
+	if (!opts.app) throw new UsageError("--app is required");
+	if (!opts.expectVersion) throw new UsageError("--expect-version is required");
+	if (!opts.app.endsWith(".app")) throw new UsageError(`--app must point at a .app bundle, got ${opts.app}`);
+	opts.stateDir ??= join(homedir(), ".ao");
+	opts.runFile ??= join(opts.stateDir, "running.json");
+	opts.appName = basename(opts.app, ".app");
+	return opts;
+}
+
+function positiveSeconds(flag, raw) {
+	const seconds = Number(raw);
+	if (!Number.isFinite(seconds) || seconds <= 0) throw new UsageError(`${flag} must be a positive number of seconds`);
+	return seconds * 1000;
+}
+
+// bundleVersion reads CFBundleShortVersionString straight off the installed
+// bundle, so it observes what ShipIt actually swapped in rather than trusting
+// anything the app reports about itself.
+export function bundleVersion(appPath) {
+	const plist = join(appPath, "Contents", "Info.plist");
+	return execFileSync("plutil", ["-extract", "CFBundleShortVersionString", "raw", "-o", "-", plist], {
+		encoding: "utf8",
+	}).trim();
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// waitFor polls until check() returns truthy or the budget runs out. Bounded
+// polling, never a fixed sleep: the ShipIt swap has no completion signal and
+// its duration varies with bundle size and disk speed.
+async function waitFor(label, timeoutMs, check) {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		let result;
+		try {
+			result = await check();
+		} catch {
+			result = false;
+		}
+		if (result) return result;
+		if (Date.now() >= deadline) throw new Error(`timed out after ${Math.round(timeoutMs / 1000)}s waiting for ${label}`);
+		await sleep(DEFAULTS.pollIntervalMs);
+	}
+}
+
+// seedUpdateSettings writes ~/.ao/update-settings.json before first launch.
+// ensureUpdatePrefs only shows its first-run dialog when no settings file
+// exists, so pre-seeding is what makes the whole flow non-interactive. Shape
+// must match UpdateSettings in src/main/update-settings.ts.
+function seedUpdateSettings(stateDir, channel) {
+	mkdirSync(stateDir, { recursive: true });
+	const settings = { enabled: true, channel, nightlyAck: channel === "nightly", feature: null };
+	writeFileSync(join(stateDir, "update-settings.json"), `${JSON.stringify(settings, null, 2)}\n`, { mode: 0o600 });
+}
+
+function quitApp(appName) {
+	try {
+		execFileSync("osascript", ["-e", `tell application "${appName}" to quit`], { stdio: "ignore" });
+	} catch {
+		// Already gone, or never registered with LaunchServices. Either is fine.
+	}
+}
+
+async function isDaemonAlive(runFile) {
+	if (!existsSync(runFile)) return false;
+	const { port } = JSON.parse(readFileSync(runFile, "utf8"));
+	if (!port) return false;
+	// Same liveness contract as backend/internal/cli/e2e_test.go: loopback only.
+	const res = await fetch(`http://127.0.0.1:${port}/healthz`, { signal: AbortSignal.timeout(5000) });
+	return res.ok;
+}
+
+async function run(opts) {
+	if (process.platform !== "darwin") throw new UsageError(`macOS only; host is ${process.platform}`);
+	if (!existsSync(opts.app)) throw new UsageError(`no such app bundle: ${opts.app}`);
+
+	const startVersion = bundleVersion(opts.app);
+	console.log(`installed baseline: ${startVersion}`);
+	if (startVersion === opts.expectVersion) {
+		throw new UsageError(`baseline is already ${opts.expectVersion}; --expect-version must be the NEW version`);
+	}
+
+	// A stale instance would hold the daemon port and confuse the liveness check.
+	quitApp(opts.appName);
+
+	const sentinel = join(tmpdir(), `ao-e2e-update-sentinel-${process.pid}.json`);
+	rmSync(sentinel, { force: true });
+	rmSync(opts.runFile, { force: true });
+	seedUpdateSettings(opts.stateDir, opts.channel);
+
+	// Launched as a child process rather than via `open` so the sentinel env var
+	// reaches the app. The RELAUNCH below deliberately uses `open -a` instead,
+	// because by then the bundle has been swapped underneath us.
+	console.log(`launching ${opts.app} (channel: ${opts.channel})`);
+	const child = spawn(join(opts.app, "Contents", "MacOS", readExecutableName(opts.app)), [], {
+		env: { ...process.env, AO_E2E_UPDATE_SENTINEL: sentinel },
+		stdio: "inherit",
+		detached: false,
+	});
+	const exited = new Promise((resolve) => child.once("exit", resolve));
+
+	try {
+		await waitFor("the native updater to stage the update", opts.downloadTimeoutMs, () => existsSync(sentinel));
+		console.log(`update staged: ${readFileSync(sentinel, "utf8").trim()}`);
+	} finally {
+		// Even on failure, do not leave a packaged app running on the runner.
+		quitApp(opts.appName);
+	}
+
+	// Squirrel installs the staged update during termination. It does NOT
+	// relaunch (see the header note), so this quit is the install step only.
+	await Promise.race([exited, sleep(60_000)]);
+
+	await waitFor(`the ShipIt swap to land ${opts.expectVersion}`, opts.swapTimeoutMs, () => {
+		const current = bundleVersion(opts.app);
+		if (current !== startVersion) console.log(`bundle version now: ${current}`);
+		return current === opts.expectVersion;
+	});
+	console.log(`installed bundle is now ${opts.expectVersion}`);
+
+	console.log("relaunching the updated app");
+	rmSync(opts.runFile, { force: true });
+	execFileSync("open", ["-a", opts.app]);
+
+	await waitFor("the relaunched app's daemon to answer /healthz", opts.launchTimeoutMs, () =>
+		isDaemonAlive(opts.runFile),
+	);
+
+	// Re-read after relaunch: a bundle that reverted mid-launch would still have
+	// passed the swap poll above.
+	const finalVersion = bundleVersion(opts.app);
+	if (finalVersion !== opts.expectVersion) {
+		throw new Error(`relaunched bundle reports ${finalVersion}, expected ${opts.expectVersion}`);
+	}
+
+	quitApp(opts.appName);
+	rmSync(sentinel, { force: true });
+	console.log(`PASS: ${startVersion} updated to ${finalVersion}, relaunched, daemon alive`);
+}
+
+// readExecutableName pulls CFBundleExecutable out of the bundle instead of
+// hardcoding "agent-orchestrator", so a rename of packagerConfig.executableName
+// does not silently break the harness.
+function readExecutableName(appPath) {
+	const plist = join(appPath, "Contents", "Info.plist");
+	return execFileSync("plutil", ["-extract", "CFBundleExecutable", "raw", "-o", "-", plist], {
+		encoding: "utf8",
+	}).trim();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	let opts;
+	try {
+		opts = parseArgs(process.argv.slice(2));
+	} catch (err) {
+		process.stderr.write(`${err.message}\n`);
+		process.stderr.write("usage: node e2e-mac-update.mjs --app <bundle.app> --expect-version <version>\n");
+		process.exit(2);
+	}
+	run(opts).catch((err) => {
+		process.stderr.write(`${err.stack || err}\n`);
+		process.exit(err instanceof UsageError ? 2 : 1);
+	});
+}

--- a/frontend/scripts/e2e-mac-update.test.mjs
+++ b/frontend/scripts/e2e-mac-update.test.mjs
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "./e2e-mac-update.mjs";
+
+// The harness itself needs a real macOS runner, a real signed N-1 install and a
+// real published N feed, so it cannot run here. What IS testable anywhere is the
+// flag contract: a typo in the CI job's arguments should fail loudly at parse
+// time rather than half-run an update test and report a confusing timeout.
+
+describe("e2e-mac-update parseArgs", () => {
+	const required = ["--app", "/Applications/Agent Orchestrator.app", "--expect-version", "0.10.4"];
+
+	it("parses the required flags and defaults the state dir to ~/.ao", () => {
+		const opts = parseArgs(required);
+		expect(opts.app).toBe("/Applications/Agent Orchestrator.app");
+		expect(opts.expectVersion).toBe("0.10.4");
+		expect(opts.appName).toBe("Agent Orchestrator");
+		// All app state lives under ~/.ao only (see AGENTS.md hard rules).
+		expect(opts.stateDir).toBe(join(homedir(), ".ao"));
+		expect(opts.runFile).toBe(join(homedir(), ".ao", "running.json"));
+		expect(opts.channel).toBe("latest");
+	});
+
+	it("requires --app and --expect-version", () => {
+		expect(() => parseArgs([])).toThrow(/--app is required/);
+		expect(() => parseArgs(["--app", "/x/Foo.app"])).toThrow(/--expect-version is required/);
+	});
+
+	it("rejects an --app path that is not a bundle", () => {
+		expect(() => parseArgs(["--app", "/Applications/Foo", "--expect-version", "1.0.0"])).toThrow(/\.app bundle/);
+	});
+
+	it("rejects an unknown channel", () => {
+		expect(() => parseArgs([...required, "--channel", "beta"])).toThrow(/latest or nightly/);
+	});
+
+	it("accepts the nightly channel", () => {
+		expect(parseArgs([...required, "--channel", "nightly"]).channel).toBe("nightly");
+	});
+
+	it("rejects a flag with a missing value", () => {
+		expect(() => parseArgs(["--app", "--expect-version", "0.10.4"])).toThrow(/--app needs a value/);
+	});
+
+	it("rejects unknown flags", () => {
+		expect(() => parseArgs([...required, "--turbo"])).toThrow(/unknown flag: --turbo/);
+	});
+
+	it("converts timeout flags from seconds to milliseconds and rejects nonpositive values", () => {
+		expect(parseArgs([...required, "--swap-timeout", "90"]).swapTimeoutMs).toBe(90_000);
+		expect(() => parseArgs([...required, "--swap-timeout", "0"])).toThrow(/positive number of seconds/);
+		expect(() => parseArgs([...required, "--download-timeout", "soon"])).toThrow(/positive number of seconds/);
+	});
+
+	it("allows overriding the state dir and run file", () => {
+		const opts = parseArgs([...required, "--state-dir", "/tmp/ao-e2e", "--run-file", "/tmp/ao-e2e/run.json"]);
+		expect(opts.stateDir).toBe("/tmp/ao-e2e");
+		expect(opts.runFile).toBe("/tmp/ao-e2e/run.json");
+	});
+});

--- a/frontend/scripts/feed.mjs
+++ b/frontend/scripts/feed.mjs
@@ -38,10 +38,25 @@ export function feedFilename(channel, platform) {
 
 // buildYml serializes one platform's feed. files is [{ url, sha512, size }];
 // for mac the arm64 entry comes first. The deprecated top-level path/sha512
-// point at files[0]. blockMapSize is never written (forces sidecar
-// differential on win/linux; mac has no sidecar at all — see #3034 — so it
-// always takes electron-updater's full-download path regardless). When
-// important is true, emits `important: true` after releaseDate so the
+// point at files[0].
+//
+// blockMapSize is never written. Per platform that means (verified against the
+// published electron-updater@6.8.9 tarball, see #3288 workstream 3):
+//   win:   NsisUpdater takes AppUpdater.differentialDownloadInstaller, which
+//          fetches the "<installer>.blockmap" sidecar. Omitting blockMapSize is
+//          what selects that sidecar path, so win sidecars are load-bearing.
+//   linux: AppImageUpdater NEVER fetches a sidecar. It uses
+//          FileWithEmbeddedBlockMapDifferentialDownloader, which reads the
+//          blockmap from the AppImage's own tail at
+//          `fileSize - (blockMapSize + 4)` and therefore hard-requires
+//          blockMapSize in the yml. With it absent, linux differential updates
+//          cannot run at all and every client falls back to a full download.
+//          The linux .blockmap sidecars we publish are consumed by nothing (see
+//          the note in generateFeeds).
+//   mac:   no sidecar is generated at all (see hashFile), so MacUpdater always
+//          takes the full-download path. Settled permanent baseline, #3151/#3267.
+//
+// When important is true, emits `important: true` after releaseDate so the
 // in-app update prompt is escalated.
 export function buildYml(version, files, releaseDate, important = false) {
 	const lines = [`version: ${version}`, "files:"];
@@ -59,7 +74,15 @@ export function buildYml(version, files, releaseDate, important = false) {
 
 // generateFeeds writes the yml + sidecar blockmaps for every platform present in
 // dir. version may carry +build metadata (nightly); strip it for the yml.
-// mac zips skip the blockmap sidecar entirely (see hashFile) — see #3034.
+// mac zips skip the blockmap sidecar entirely (see hashFile); see #3034/#3151.
+//
+// The linux sidecars this still writes are dead weight: AppImageUpdater reads
+// its blockmap from the AppImage tail, never from a sidecar, and needs a
+// blockMapSize we never emit (see buildYml). Generation is kept deliberately
+// rather than dropped, because the release publish guard lives in a separate
+// private pipeline that currently asserts on the linux sidecar filenames;
+// dropping the files here would red that guard out of band. Removing both
+// together is tracked as its own decision on #3288 workstream 3.
 export async function generateFeeds(dir, rawVersion, channel, releaseDate, important = false) {
 	const version = rawVersion.split("+")[0];
 	const sel = selectInstallers(readdirSync(dir), version);
@@ -96,13 +119,19 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
 // hashFile computes the same {sha512, size} shape writeBlockmap returns, but
 // without writing a .blockmap sidecar file. Used for mac zips specifically:
-// Squirrel.Mac's ShipIt install step runs `ditto` against the extracted
-// update cache, which fails when the cache lacks AppleDouble ("._*") metadata
-// — content @electron-forge/maker-zip's output never had, unlike
-// electron-builder's ditto-based zips. A sidecar-driven differential update
-// against that mismatched format is the likely corruption source (issue
-// #3034). Skipping the sidecar for mac forces electron-updater's MacUpdater
-// onto a full-zip download every time instead of a diff.
+// Squirrel.Mac's ShipIt install step runs `ditto` against the extracted update
+// cache and fails on a corrupt one, which is the #3034 failure signature.
+//
+// The original zip-format theory (that ShipIt failed because
+// @electron-forge/maker-zip's output lacked the AppleDouble "._*" entries
+// electron-builder's ditto-based zips carry) did NOT hold. A production
+// nightly-to-stable channel switch reproduced the same corruption against a
+// target zip that was already correctly ditto-built with its full AppleDouble
+// set. The defect is in the differential download/patch-apply mechanism itself,
+// not in the zip format (#3267 decision 4). Skipping the sidecar for mac is
+// therefore the actual fix, not a workaround: it forces MacUpdater onto a full
+// zip download every time. Permanent baseline, #3151; #3267 decision 4 records
+// the evidence bar for ever revisiting it.
 export function hashFile(filePath) {
 	const data = readFileSync(filePath);
 	const sha512 = createHash("sha512").update(data).digest("base64");

--- a/frontend/scripts/verify-mac-artifact.sh
+++ b/frontend/scripts/verify-mac-artifact.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# verify-mac-artifact.sh <path-to-.zip-or-.app>
+#
+# The one canonical way to check that a shipped macOS artifact is sealed,
+# notarized and stapled. CI gates and humans debugging by hand must both use
+# this script, never a hand-typed variant.
+#
+# Why this exists (#3288 workstreams 1 and 2): on 28-29 Jul a human ran the
+# check by hand, extracted the zip with plain `unzip`, and got a convincing but
+# wrong "the signing pipeline corrupts the seal" answer. That paused all
+# releases for two days. One script removes that failure mode by construction.
+#
+# The rules encoded here, all verified empirically on macOS 27.0. Do not
+# "simplify" them; several contradict widely repeated advice:
+#
+#   1. Extract with `ditto -x -k`, NEVER `unzip`. Our zips embed AppleDouble
+#      entries per directory (ditto without --sequesterRsrc). Plain unzip
+#      materializes them as stray "._*" files inside the bundle, which breaks
+#      the seal and makes codesign report a corrupt artifact that is in fact
+#      fine. backend/internal/cli/start.go already encodes this rule in Go for
+#      the `ao start` bootstrapper; this makes it reusable standalone.
+#
+#   2. `spctl -a -t exec` needs `-vv`. Without it an ACCEPTED artifact prints
+#      nothing at all and merely exits 0, so any grep for "Notarized Developer
+#      ID" can never match and the gate silently proves nothing.
+#
+#   3. `spctl` alone does not prove stapling. It can satisfy the notarization
+#      check through Apple's online lookup, so it passes on a
+#      notarized-but-unstapled artifact whenever the runner has network.
+#      `xcrun stapler validate` is the check that proves the ticket is attached
+#      to the bytes we ship, and it gates cleanly on exit code.
+#
+# Exit codes: 0 all checks passed, 1 a check failed, 2 usage error.
+
+set -euo pipefail
+
+usage() {
+	cat >&2 <<'EOF'
+usage: verify-mac-artifact.sh <path-to-.zip-or-.app>
+
+Verifies a macOS release artifact is signed, notarized and stapled:
+  codesign --verify --deep --strict
+  spctl -a -vv -t exec
+  xcrun stapler validate
+
+A .zip is extracted with `ditto -x -k` first (never `unzip`), and the single
+.app bundle inside it is checked.
+EOF
+}
+
+# --- Argument validation (exit 2). Runs before any macOS-only tooling is
+# touched, so the usage paths are testable on any platform.
+
+if [[ $# -ne 1 ]]; then
+	usage
+	exit 2
+fi
+
+case "$1" in
+-h | --help)
+	usage
+	exit 2
+	;;
+esac
+
+ARTIFACT="$1"
+
+if [[ ! -e "$ARTIFACT" ]]; then
+	echo "verify-mac-artifact: no such file: $ARTIFACT" >&2
+	exit 2
+fi
+
+case "$ARTIFACT" in
+*.zip)
+	if [[ ! -f "$ARTIFACT" ]]; then
+		echo "verify-mac-artifact: expected a .zip file, got a directory: $ARTIFACT" >&2
+		exit 2
+	fi
+	;;
+*.app)
+	if [[ ! -d "$ARTIFACT" ]]; then
+		echo "verify-mac-artifact: expected an .app bundle directory: $ARTIFACT" >&2
+		exit 2
+	fi
+	;;
+*)
+	echo "verify-mac-artifact: unsupported artifact type: $ARTIFACT (expected .zip or .app)" >&2
+	usage
+	exit 2
+	;;
+esac
+
+# --- Everything below needs a real macOS host with the Xcode command line
+# tools. Checked explicitly so a Linux runner fails with a clear message rather
+# than a bare "codesign: command not found".
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+	echo "verify-mac-artifact: macOS only (codesign/spctl/stapler); host is $(uname -s)" >&2
+	exit 2
+fi
+
+for tool in codesign spctl xcrun ditto; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		echo "verify-mac-artifact: required tool not found: $tool" >&2
+		exit 2
+	fi
+done
+
+WORKDIR=""
+cleanup() {
+	if [[ -n "$WORKDIR" ]]; then rm -rf "$WORKDIR"; fi
+}
+trap cleanup EXIT
+
+APP="$ARTIFACT"
+if [[ "$ARTIFACT" == *.zip ]]; then
+	WORKDIR="$(mktemp -d)"
+	echo "==> extracting with ditto (never unzip): $ARTIFACT"
+	# `ditto -x -k` is the only extraction that preserves the seal. See rule 1.
+	ditto -x -k "$ARTIFACT" "$WORKDIR"
+	# `-maxdepth 1` deliberately: a nested .app (helpers inside the bundle) must
+	# not be mistaken for the top-level one. Collected with a read loop rather
+	# than mapfile, which macOS's stock bash 3.2 does not have.
+	app_count=0
+	while IFS= read -r candidate; do
+		APP="$candidate"
+		app_count=$((app_count + 1))
+	done < <(find "$WORKDIR" -maxdepth 1 -name '*.app' -print)
+	if [[ $app_count -ne 1 ]]; then
+		echo "verify-mac-artifact: expected exactly one .app in $ARTIFACT, found $app_count" >&2
+		exit 1
+	fi
+fi
+
+echo "==> verifying: $APP"
+
+failed=0
+run_check() {
+	local label="$1"
+	shift
+	echo "--> $label: $*"
+	if "$@"; then
+		echo "    ok: $label"
+	else
+		echo "::error::verify-mac-artifact: $label failed for $APP" >&2
+		failed=1
+	fi
+}
+
+# Seal intact. --deep walks nested code (helpers, frameworks, the bundled
+# daemon); --strict rejects the loosened defaults.
+run_check "codesign" codesign --verify --deep --strict --verbose=2 "$APP"
+
+# Gatekeeper would accept it. -vv is mandatory (rule 2); expect
+# "accepted" plus "source=Notarized Developer ID".
+run_check "spctl" spctl -a -vv -t exec "$APP"
+
+# The notarization ticket is actually attached to these bytes (rule 3).
+run_check "stapler" xcrun stapler validate "$APP"
+
+if [[ $failed -ne 0 ]]; then
+	echo "verify-mac-artifact: FAILED for $ARTIFACT" >&2
+	exit 1
+fi
+
+echo "verify-mac-artifact: OK ($ARTIFACT)"

--- a/frontend/scripts/verify-mac-artifact.test.mjs
+++ b/frontend/scripts/verify-mac-artifact.test.mjs
@@ -1,0 +1,106 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { execFile } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, statSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Smoke coverage for scripts/verify-mac-artifact.sh.
+//
+// Honest scope: the three real checks (codesign, spctl, stapler) cannot be
+// exercised here. Mocking them convincingly would require real Apple signing
+// material, and a mock that always passes proves nothing about the gate. The
+// meaningful verification of the core logic is the release pipeline's
+// post-staple gate running this script against real published artifacts
+// (#3288 workstream 1).
+//
+// What IS covered here, on any platform with no signing material at all:
+// the script parses, and every usage/precondition path exits 2 with a clear
+// message before touching macOS-only tooling. That is the half that a
+// non-macOS CI runner can honestly assert.
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "verify-mac-artifact.sh");
+
+function run(args) {
+	return new Promise((resolve) => {
+		execFile("bash", [SCRIPT, ...args], (err, stdout, stderr) => {
+			resolve({ code: err?.code ?? 0, stdout, stderr });
+		});
+	});
+}
+
+let dir;
+beforeAll(() => {
+	dir = mkdtempSync(join(tmpdir(), "verify-mac-artifact-"));
+});
+afterAll(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("verify-mac-artifact.sh", () => {
+	it("is committed executable so CI and humans invoke it the same way", () => {
+		expect(statSync(SCRIPT).mode & 0o111).not.toBe(0);
+	});
+
+	it("parses under bash", async () => {
+		const { code } = await new Promise((resolve) => {
+			execFile("bash", ["-n", SCRIPT], (err) => resolve({ code: err?.code ?? 0 }));
+		});
+		expect(code).toBe(0);
+	});
+
+	it("exits 2 with usage when given no arguments", async () => {
+		const { code, stderr } = await run([]);
+		expect(code).toBe(2);
+		expect(stderr).toContain("usage: verify-mac-artifact.sh");
+	});
+
+	it("exits 2 when given more than one argument", async () => {
+		const { code } = await run(["a.zip", "b.zip"]);
+		expect(code).toBe(2);
+	});
+
+	it("exits 2 for a nonexistent file", async () => {
+		const missing = join(dir, "not-here.zip");
+		const { code, stderr } = await run([missing]);
+		expect(code).toBe(2);
+		expect(stderr).toContain("no such file");
+	});
+
+	it("exits 2 for a non-zip, non-app input", async () => {
+		const txt = join(dir, "notes.txt");
+		writeFileSync(txt, "not an artifact\n");
+		const { code, stderr } = await run([txt]);
+		expect(code).toBe(2);
+		expect(stderr).toContain("unsupported artifact type");
+	});
+
+	it("exits 2 when a .zip path is actually a directory", async () => {
+		const fake = join(dir, "bundle.zip");
+		mkdirSync(fake, { recursive: true });
+		const { code, stderr } = await run([fake]);
+		expect(code).toBe(2);
+		expect(stderr).toContain("expected a .zip file");
+	});
+
+	it("exits 2 when a .app path is not a directory", async () => {
+		const fake = join(dir, "Fake.app");
+		writeFileSync(fake, "");
+		const { code, stderr } = await run([fake]);
+		expect(code).toBe(2);
+		expect(stderr).toContain("expected an .app bundle directory");
+	});
+
+	it("encodes the verified command set (ditto, spctl -vv, stapler validate)", async () => {
+		const { readFileSync } = await import("node:fs");
+		const src = readFileSync(SCRIPT, "utf8");
+		// These exact forms are load-bearing and were each verified empirically;
+		// see the header comment. A drive-by "simplification" of any of them
+		// silently turns the gate into a no-op, so pin them here.
+		expect(src).toContain("ditto -x -k");
+		expect(src).not.toMatch(/^\s*unzip /m);
+		expect(src).toContain("codesign --verify --deep --strict");
+		expect(src).toContain("spctl -a -vv -t exec");
+		expect(src).toContain("xcrun stapler validate");
+	});
+});

--- a/frontend/src/landing/packages/shared/src/constants.ts
+++ b/frontend/src/landing/packages/shared/src/constants.ts
@@ -33,6 +33,13 @@ export const PLATFORMS = {
 
 export const GITHUB_STARS_URL = "https://api.github.com/repos/AgentWrapper/agent-orchestrator";
 
+// macOS still points at the .zip on purpose. The .dmg first-install artifact is
+// built by frontend/makers/maker-dmg.ts, but no published release carries it yet,
+// so flipping these two links (and the two macOS rows in README.md) to
+// "...-darwin-{arch}.dmg" would 404 until a real release publishes both formats.
+// That flip is rollout step 6 in issue #3267 and must happen only after a real
+// release has been cut and the dmg verified. The .zip keeps publishing forever
+// either way, because electron-updater cannot auto-update from a .dmg.
 export const DOWNLOAD_URL_MAC_ARM64 = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-arm64.zip";
 export const DOWNLOAD_URL_MAC_X64 = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-x64.zip";
 export const DOWNLOAD_URL_WINDOWS = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-win32-x64.exe";

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1,6 +1,6 @@
 import { autoUpdater } from "electron-updater";
-import { app, BrowserWindow, dialog } from "electron";
-import { existsSync } from "node:fs";
+import { app, BrowserWindow, dialog, autoUpdater as nativeAutoUpdater } from "electron";
+import { existsSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -296,12 +296,51 @@ async function runRetirementPoll(stateDir: string): Promise<void> {
 	}
 }
 
+// AO_E2E_UPDATE_SENTINEL is the absolute path the end-to-end mac update test
+// (scripts/e2e-mac-update.mjs) asks the app to write once an update is actually
+// STAGED on disk and ready for the ShipIt swap. Unset in every real build, so
+// this is a complete no-op for users.
+export const E2E_UPDATE_SENTINEL_ENV = "AO_E2E_UPDATE_SENTINEL";
+
+// installE2EUpdateSentinel hangs the sentinel off the NATIVE macOS updater
+// (require("electron").autoUpdater, i.e. Squirrel.Mac), NOT electron-updater's
+// own "update-downloaded".
+//
+// That distinction is load-bearing and was verified against the published
+// electron-updater@6.8.9 tarball. In MacUpdater.updateDownloaded(),
+// dispatchUpdateDownloaded(event) fires FIRST and only then does
+// `if (this.autoInstallOnAppQuit) { this.nativeUpdater.checkForUpdates() }`
+// kick Squirrel into fetching from the local proxy server. So electron-updater
+// announces "downloaded" BEFORE Squirrel has fetched or staged anything: a
+// harness that quits on that signal stages nothing, installs nothing, and
+// reports a false failure or flaps. The native event is the one MacUpdater
+// itself listens to in order to set squirrelDownloadedUpdate = true, and it is
+// the only signal that means "staged, will swap on quit". See #3288.
+//
+// macOS only in practice: NsisUpdater and AppImageUpdater never drive the
+// native updater, so this listener simply never fires off darwin.
+function installE2EUpdateSentinel(): void {
+	const sentinelPath = process.env[E2E_UPDATE_SENTINEL_ENV];
+	if (!sentinelPath) return;
+	nativeAutoUpdater.on("update-downloaded", (_event, _notes, releaseName) => {
+		try {
+			// Written synchronously: the harness quits the app right after seeing
+			// this file, so an async write could lose the race with termination.
+			writeFileSync(sentinelPath, `${JSON.stringify({ stagedAt: Date.now(), releaseName: releaseName ?? null })}\n`);
+			console.info(`[e2e] native updater staged ${releaseName ?? "an update"}; wrote ${sentinelPath}`);
+		} catch (err) {
+			console.error("[e2e] failed to write update sentinel:", err);
+		}
+	});
+}
+
 // wireUpdaterEvents registers electron-updater listeners once and forwards each
 // to the renderer as an UpdateStatus. Idempotent: safe to call on every entry
 // point (launch auto-check and manual check).
 function wireUpdaterEvents(): void {
 	if (eventsWired) return;
 	eventsWired = true;
+	installE2EUpdateSentinel();
 	// With a build staged, "checking" briefly hides the sidebar restart row; that
 	// is acceptable and self-healing: the available / not-available handlers below
 	// restore the enriched downloaded status right after.


### PR DESCRIPTION
Implements the public-repo workstreams of #3288 (macOS release hardening). Workstream 1 and the workstream 3 publish guard live in the private signing/release pipeline and are not touched here.

One PR by request, kept reviewable as one commit per workstream:

| Commit | Workstream |
| --- | --- |
| `feat(updater): add env-gated e2e sentinel and macOS update test harness` | 0 |
| `feat(scripts): add shared macOS artifact verification script` | 2 |
| `docs(scripts): correct blockmap sidecar model for linux and mac` | 3 (public part) |
| `docs(release): add the single-publisher rule and shared verify step` | 4 |
| `feat(macos): add dmg first-install maker with explicit sign, notarize, staple` | 6 |

## Workstream 0: end-to-end update test

- `frontend/src/main/auto-updater.ts`: an `AO_E2E_UPDATE_SENTINEL` sentinel that writes a marker file once an update is actually staged. It is a complete no-op when the env var is unset, which is always the case in a user-facing build.
- `frontend/scripts/e2e-mac-update.mjs`: the harness. Installs nothing itself; it takes an already-installed N-1 bundle, points it at the real feed, and proves N downloads, stages, installs on quit, and that the relaunched app reports N and is alive.
- `frontend/scripts/e2e-mac-update.test.mjs`: unit tests for the flag contract.
- `.github/workflows/mac-update-e2e.yml`: the macOS CI job.

Three things here are counter-intuitive and are per #3288's verified facts, so flagging them for review:

1. **The sentinel keys off the NATIVE `require("electron").autoUpdater` event, not electron-updater's.** In `MacUpdater.updateDownloaded()`, `dispatchUpdateDownloaded(event)` fires first and only then does `nativeUpdater.checkForUpdates()` kick Squirrel into fetching from the local proxy. Keying on electron-updater's `update-downloaded` means quitting before anything is staged, so nothing installs and the test flaps.
2. **A plain macOS quit installs but does NOT relaunch.** The harness quits the app to trigger the install, then relaunches it itself with `open -a`.
3. **The ShipIt swap has no completion signal**, so the wait is a bounded poll on the installed bundle's `Info.plist` `CFBundleShortVersionString`, never a fixed sleep. Liveness reuses the `running.json` plus loopback `/healthz` pattern from `backend/internal/cli/e2e_test.go`.

The workflow is `workflow_dispatch` plus `workflow_call` only, and is deliberately not wired into any release workflow. Those are paused, and #3288 asks for real per-run cost data before deciding whether nightly-to-nightly coverage is worth macOS runner minutes. The job prints its wall clock to the step summary so that question can be settled with numbers. The header comment shows the two-line snippet to wire it as a stable-promotion gate when that decision is made.

## Workstream 2: shared verify script

`frontend/scripts/verify-mac-artifact.sh <path-to-.zip-or-.app>`, plus a smoke test. Extracts with `ditto -x -k` (never `unzip`), then runs the three checks:

```
codesign --verify --deep --strict
spctl -a -vv -t exec
xcrun stapler validate
```

`-vv` on spctl is mandatory: without it an accepted artifact prints nothing at all and merely exits 0, so any grep for `Notarized Developer ID` can never match. `spctl` alone does not prove stapling either (it can satisfy the check through Apple's online lookup), which is why `stapler validate` is the gate. Exit codes follow the repo convention: 2 for usage errors, 1 for a failed check.

It accepts a `.app` directly as well as a `.zip`, so the update-e2e job can verify what ShipIt actually swapped onto disk with the same script. The private pipeline's post-staple gate (workstream 1) should shell out to this rather than reimplementing the checks.

The workflow 1 gate is the meaningful verification of the core logic; see the honest-coverage note below.

## Workstream 3, public part: blockmap comment drift

`feed.mjs` and `blockmap.mjs` both claimed that omitting `blockMapSize` "forces sidecar differential" on win and linux. True for win, false for linux: `AppImageUpdater` never fetches a sidecar. It uses `FileWithEmbeddedBlockMapDifferentialDownloader`, which reads the blockmap from the AppImage's own tail and hard-requires `blockMapSize`, which `feed.mjs` never writes. So linux differential updates are already off, and every linux `.blockmap` we publish is read by nobody. Both comments now state the real per-platform model.

Also corrected the mac rationale in `hashFile`, which still asserted the AppleDouble zip-format theory as the likely corruption source. #3267 decision 4 disproved that with a production repro against a correctly ditto-built zip carrying its full AppleDouble set. Leaving a known-false rationale in place is the exact failure mode this workstream exists to fix. This is comment-only; no behavior change.

**On dropping linux sidecar generation: kept, deliberately.** Two reasons, both documented in the code. The release publish guard lives in the separate private pipeline and currently asserts on the hardcoded linux sidecar filenames, so deleting the files here reds that guard out of band while another worker is actively rewriting it. And #3288 itself flags this as a behavior change deserving its own decision rather than something to fold in. The dead-weight status is now written down at the generation site so the eventual removal is a two-line change made together with the guard.

## Workstream 4: single publisher, documented

New "Hard rule: exactly one publisher" section at the top of `frontend/docs/desktop-release.md`, with the reason stated plainly: between 22 and 24 Jul two publishers emitted divergent macOS zip formats on alternating days, which made the 28-29 Jul incident evidence unreadable. It also separates approving a release (any approver) from triggering one (conductor only), and points people at the fork dev loop for test builds.

Cross-referenced from `AGENTS.md`'s Distribution section, along with two adjacent rules that kept getting re-derived wrong: use `verify-mac-artifact.sh` rather than hand-typed checks, and macOS ships both a zip and a dmg with the zip publishing forever.

While in `desktop-release.md`, corrected the release verification section: it still claimed every installer ships a `.blockmap` sidecar, which stopped being true for macOS at #3151.

## Workstream 6: macOS dmg distribution

`frontend/makers/maker-dmg.ts` bridges `app-builder-lib`'s `buildForge` with a `mac: ["dmg:<arch>"]` target, mirroring `maker-nsis.ts` closely. Per #3267 decision 1, Forge's own `maker-dmg` (electron-installer-dmg to appdmg) has no notarize or staple code and neither does app-builder-lib's dmg target, so no maker solves signing for us; given that, consistency with the existing bridge wins over adding a second packaging engine for one platform.

- **Strictly additive.** The darwin `maker-zip` entry is untouched, and now carries a comment saying it can never be removed: `MacUpdater.doDownloadUpdate` calls `findFile(files, "zip", ["pkg", "dmg"])` and throws `ERR_UPDATER_ZIP_FILE_NOT_FOUND` when absent. A dmg can never be the auto-update artifact.
- **The dmg container gets its own explicit seal.** A new `hooks.postMake` in `forge.config.ts` calls `sealDmg()`: `codesign --sign --timestamp`, then `xcrun notarytool submit --wait`, then `xcrun stapler staple`. It reuses exactly the credentials `packagerConfig` already consumes (`APPLE_SIGNING_IDENTITY`/`CSC_LINK`, and either `AO_NOTARY_PROFILE` or the `APPLE_API_KEY` trio). No new secrets.
- **`mac.identity` is `null`** so electron-builder can never re-sign the already signed, notarized and stapled `.app` that `packagerConfig` produced before any maker ran.
- **`dmg.sign` is false**, per electron-builder's own warning that signing during dmg creation conflicts with notarization. The container is sealed afterwards instead.
- **No credentials means a warned no-op**, not a build failure, so unsigned local builds and the unsigned desktop-testing pipeline still produce a dmg. When credentials ARE present, any failure throws and fails the build: a silently unsigned dmg published as a release asset is the outcome this work exists to prevent.

**Download links intentionally NOT flipped in this PR.** `DOWNLOAD_URL_MAC_ARM64`/`_X64` and the two macOS README rows still point at the `.zip`. No published release carries a dmg yet, so flipping them at merge time would 404 for every macOS visitor until the next release, and the release workflows are paused. #3267 decision 8 step 6 makes this ordering explicit: flip only after a real release has published both formats and the dmg is verified. There is now a comment at the constants explaining the pending flip and naming the README rows, so the rollout step is discoverable from the code rather than only from the issue. Say the word if you would rather take the flip here and accept the gap.

The private-pipeline handoff for dmg asset passthrough is in #3267 and is owned elsewhere.

## Verified here

- `npm run frontend:typecheck` (`tsc --noEmit`): clean.
- Full frontend vitest suite: 1216 passing, 0 failing. That includes the new `frontend/scripts/verify-mac-artifact.test.mjs` (9), `frontend/scripts/e2e-mac-update.test.mjs` (9) and `frontend/makers/maker-dmg.test.ts` (10).
- `verify-mac-artifact.sh` parses under `bash -n`, is committed executable, and every usage/precondition path exits 2 with the right message. Portability detail: it avoids `mapfile` because macOS ships bash 3.2.
- `.github/workflows/mac-update-e2e.yml` parses as YAML.
- The maker's `buildForge` call shape is asserted against a mocked `app-builder-lib`, and `sealDmg`'s exact command lines are asserted against a stubbed `execFile` for all five credential combinations, including the failure path.

## NOT verified here, and why

Being explicit rather than implying more coverage than exists.

- **Nothing was signed, notarized or stapled.** No Apple credentials in this environment. `sealDmg`'s command construction is unit-tested, but no real `codesign`, `notarytool` or `stapler` invocation was ever made. First real exercise is a signed build.
- **The three verification commands were never run against a real artifact.** Fully mocking `codesign`/`spctl`/`xcrun` needs real signing material, and a mock that always passes proves nothing about a gate. So the smoke test deliberately covers only the usage and precondition paths, which is the half a runner with no signing material can honestly assert. The meaningful verification is the private pipeline's post-staple gate (workstream 1) running this script against real published artifacts. #3288 recommends dry-running it against several past releases before making it blocking.
- **No dmg was actually produced.** `npm run make` does not complete in this worktree: it dies during electron-packager's "Finalizing package" step, before any maker runs. Confirmed environmental rather than caused by this change, since plain `npm run package` on otherwise unmodified code dies at the identical step. So `buildForge` accepting `mac: ["dmg:arm64"]` end to end, and `hdiutil` producing a mountable image, are both unverified and need a macOS build to confirm.
- **The postMake hook has never executed.** Same reason.
- **The update e2e job has never run.** It needs a real macOS runner, a real signed N-1 release with its `agent-orchestrator-darwin-arm64.zip` alias, and a live N feed. None of that exists here. The sentinel's event wiring is per source reading of the pinned `electron-updater@6.8.9` tarball, not observed at runtime. The first real run should be a `workflow_dispatch` against two existing published releases before anyone considers making it a gate.
- **Timeout defaults in the harness (20 min download, 5 min swap, 3 min launch) are estimates**, not measured. All three are flags, so the first real run can tune them.

## Out of scope, confirmed untouched

No changes to the private signing/release pipeline. No release workflow un-paused. No re-enabling of mac differential updates. No broader `AgentWrapper` to `Untrivial-ai` org rename.

Closes nothing on its own; #3288 stays open for workstreams 1 and 3's guard.

Refs #3288, #3267, #3151, #3034.
