### PR TITLE
fix(terminal): scope the tab strip to one session, restore one-click new terminal

### DIFF
--- a/backend/internal/service/shellterm/service.go
+++ b/backend/internal/service/shellterm/service.go
@@ -233,6 +233,23 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 		return ShellTerminal{}, fmt.Errorf("open shell terminal: handle id: %w", err)
 	}
 
+	// Resolve the tab name BEFORE the runtime exists. This reads the store, and
+	// a store failure after Create would strand a PTY that nothing can find:
+	// no row means neither shutdown nor the app-run reaper can ever destroy it.
+	// Doing it here means the only failure that can leave a runtime behind is
+	// the insert below, which already rolls back.
+	//
+	// Counting is safe: the session gate is held for the whole open, so two
+	// concurrent opens for one session cannot pick the same number.
+	title := shellTerminalTitle(workingDir)
+	if in.SessionID != "" {
+		ordinal, err := s.nextSessionTerminalOrdinal(ctx, in.SessionID)
+		if err != nil {
+			return ShellTerminal{}, err
+		}
+		title = sessionShellTerminalTitle(ordinal)
+	}
+
 	// SessionID is the runtime adapters' name for "what to call this PTY"; it
 	// is not a session row and no sessions record is ever created. The
 	// shellterm- prefix keeps the two namespaces disjoint.
@@ -253,7 +270,7 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 		ProjectID:  projectID,
 		SessionID:  in.SessionID,
 		WorkingDir: workingDir,
-		Title:      shellTerminalTitle(workingDir),
+		Title:      title,
 		AppRunID:   s.appRunID,
 		CreatedAt:  s.now().UTC(),
 	}
@@ -498,6 +515,25 @@ func (s *Service) BeginSessionTeardown(ctx context.Context, sessionID domain.Ses
 // It also returns the project the shell ended up attributed to, which is not
 // always the requested one: a session-scoped open may carry no project id, and
 // the session's own project is what the persisted row should record.
+// nextSessionTerminalOrdinal picks the number for a session's next terminal
+// tab. It takes one past the highest number already in use rather than a count,
+// so closing "Terminal 1" while "Terminal 2" is open does not hand the next
+// tab a name that is already on screen. A tab the user renamed no longer
+// matches and simply stops reserving its number.
+func (s *Service) nextSessionTerminalOrdinal(ctx context.Context, sessionID domain.SessionID) (int, error) {
+	recs, err := s.store.SelectShellTerminalsBySessionID(ctx, sessionID)
+	if err != nil {
+		return 0, fmt.Errorf("open shell terminal: count terminals for session %s: %w", sessionID, err)
+	}
+	highest := 0
+	for _, rec := range recs {
+		if n, ok := sessionTerminalOrdinal(rec.Title); ok && n > highest {
+			highest = n
+		}
+	}
+	return highest + 1, nil
+}
+
 func (s *Service) resolveShellTerminalWorkingDir(ctx context.Context, projectID domain.ProjectID, sessionID domain.SessionID) (workingDir string, resolvedProjectID domain.ProjectID, err error) {
 	if sessionID != "" {
 		if s.sessions == nil {

--- a/backend/internal/service/shellterm/service_test.go
+++ b/backend/internal/service/shellterm/service_test.go
@@ -66,8 +66,9 @@ func (f *fakeShellRuntime) IsAlive(_ context.Context, handle ports.RuntimeHandle
 
 // fakeShellTerminalStore is an in-memory Store keyed by handle id.
 type fakeShellTerminalStore struct {
-	records   []ShellTerminalRecord
-	insertErr error
+	records      []ShellTerminalRecord
+	insertErr    error
+	bySessionErr error
 }
 
 func (f *fakeShellTerminalStore) InsertShellTerminal(_ context.Context, rec ShellTerminalRecord) error {
@@ -108,6 +109,9 @@ func (f *fakeShellTerminalStore) SelectShellTerminalsByAppRunID(_ context.Contex
 }
 
 func (f *fakeShellTerminalStore) SelectShellTerminalsBySessionID(_ context.Context, sessionID domain.SessionID) ([]ShellTerminalRecord, error) {
+	if f.bySessionErr != nil {
+		return nil, f.bySessionErr
+	}
 	var out []ShellTerminalRecord
 	for _, rec := range f.records {
 		if rec.SessionID == sessionID {
@@ -1101,5 +1105,109 @@ func TestShellTerminalTitleFallsBackForRootlessPaths(t *testing.T) {
 	}
 	if got := shellTerminalTitle("/repos/portfolio"); got != "portfolio" {
 		t.Errorf("title = %q, want %q", got, "portfolio")
+	}
+}
+
+// Every shell in a session starts in that session's worktree, so naming tabs
+// after the directory put the identical label on all of them. Session tabs are
+// numbered instead; standalone tabs keep the directory, which is what tells
+// shells from different projects apart on /terminals.
+func TestSessionTerminalTitlesAreNumberedWithinTheSession(t *testing.T) {
+	if got := sessionShellTerminalTitle(1); got != "Terminal 1" {
+		t.Errorf("first session tab = %q, want %q", got, "Terminal 1")
+	}
+	if got := sessionShellTerminalTitle(3); got != "Terminal 3" {
+		t.Errorf("third session tab = %q, want %q", got, "Terminal 3")
+	}
+}
+
+func TestSessionTerminalOrdinalOnlyParsesGeneratedTitles(t *testing.T) {
+	for _, tc := range []struct {
+		title string
+		want  int
+		ok    bool
+	}{
+		{"Terminal 1", 1, true},
+		{"Terminal 12", 12, true},
+		{"Terminal 0", 0, false},     // never generated; 1-based
+		{"Terminal", 0, false},       // no number
+		{"Terminal x", 0, false},     // not a number
+		{"my build shell", 0, false}, // user rename stops reserving a number
+		{"portfolio", 0, false},      // a standalone tab's directory title
+	} {
+		got, ok := sessionTerminalOrdinal(tc.title)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("sessionTerminalOrdinal(%q) = (%d, %t), want (%d, %t)", tc.title, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// Closing "Terminal 1" while "Terminal 2" is open must not hand the next tab a
+// name that is already on screen, so the ordinal comes from the highest in use
+// rather than the count.
+func TestNextSessionTerminalOrdinalSkipsNamesStillInUse(t *testing.T) {
+	st := &fakeShellTerminalStore{}
+	svc := newTestService(newFakeShellRuntime(), st, &fakeProjectRootLocator{})
+	ctx := context.Background()
+
+	for _, rec := range []ShellTerminalRecord{
+		{HandleID: "h-2", SessionID: "sess-1", Title: "Terminal 2"},
+		{HandleID: "h-9", SessionID: "sess-1", Title: "my build shell"},
+		{HandleID: "h-1", SessionID: "other", Title: "Terminal 7"},
+	} {
+		if err := st.InsertShellTerminal(ctx, rec); err != nil {
+			t.Fatalf("seed %s: %v", rec.HandleID, err)
+		}
+	}
+
+	got, err := svc.nextSessionTerminalOrdinal(ctx, "sess-1")
+	if err != nil {
+		t.Fatalf("nextSessionTerminalOrdinal: %v", err)
+	}
+	// 3, not 2 (Terminal 2 is still open) and not 8 (another session's tabs
+	// must not push this session's numbering along).
+	if got != 3 {
+		t.Errorf("next ordinal = %d, want 3", got)
+	}
+}
+
+func TestNextSessionTerminalOrdinalStartsAtOne(t *testing.T) {
+	svc := newTestService(newFakeShellRuntime(), &fakeShellTerminalStore{}, &fakeProjectRootLocator{})
+
+	got, err := svc.nextSessionTerminalOrdinal(context.Background(), "sess-empty")
+	if err != nil {
+		t.Fatalf("nextSessionTerminalOrdinal: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("first ordinal = %d, want 1", got)
+	}
+}
+
+// Regression: the tab ordinal is read from the store, and that read used to
+// happen AFTER runtime.Create. A store failure there returned with a live PTY
+// and no row pointing at it, so neither shutdown nor the app-run reaper could
+// ever find it — a tmux session leaked for the life of the machine. The lookup
+// now runs before Create, so this failure cannot strand a runtime at all.
+func TestOpenShellTerminalLeavesNoRuntimeWhenOrdinalLookupFails(t *testing.T) {
+	rt := newFakeShellRuntime()
+	st := &fakeShellTerminalStore{bySessionErr: errors.New("store unavailable")}
+	sessions := &fakeSessionWorkspaceLocator{
+		sessions: map[domain.SessionID]fakeSessionWorkspace{
+			"sess-1": {workspacePath: "/wt/sess-1", projectID: "proj"},
+		},
+	}
+	svc := newTestServiceWithSessions(rt, st, &fakeProjectRootLocator{}, sessions)
+
+	_, err := svc.OpenShellTerminal(context.Background(), OpenShellTerminalInput{SessionID: "sess-1"})
+	if err == nil {
+		t.Fatal("a store failure while naming the tab must fail the open")
+	}
+	// The point of the fix: no PTY was ever spawned, so there is nothing to leak
+	// and nothing to roll back.
+	if len(rt.created) != 0 {
+		t.Fatalf("runtime.Create called %d times; the ordinal lookup must happen first", len(rt.created))
+	}
+	if len(st.records) != 0 {
+		t.Fatalf("store holds %d records after a failed open, want 0", len(st.records))
 	}
 }

--- a/backend/internal/service/shellterm/types.go
+++ b/backend/internal/service/shellterm/types.go
@@ -15,7 +15,10 @@
 package shellterm
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -43,10 +46,11 @@ type OpenShellTerminalInput struct {
 	SessionID domain.SessionID `json:"sessionId,omitempty"`
 }
 
-// shellTerminalTitle labels a tab by the directory the shell started in, which
-// is the only thing that distinguishes one shell pane from another in the UI.
-// A path that has no usable base (a bare root, or an empty string) falls back
-// to a generic label rather than rendering an empty tab.
+// shellTerminalTitle labels a standalone tab by the directory the shell started
+// in. Those shells come from the board or /terminals and can span projects, so
+// the directory is what tells them apart. A path with no usable base (a bare
+// root, or an empty string) falls back to a generic label rather than
+// rendering an empty tab.
 func shellTerminalTitle(workingDir string) string {
 	base := filepath.Base(workingDir)
 	switch base {
@@ -54,4 +58,28 @@ func shellTerminalTitle(workingDir string) string {
 		return "Shell"
 	}
 	return base
+}
+
+// sessionShellTerminalTitle numbers a session's tabs instead of naming them.
+// Every shell in a session starts in that session's worktree, so the directory
+// was identical on every tab and told the user nothing; the session itself is
+// already the first tab in the strip. ordinal is 1-based.
+func sessionShellTerminalTitle(ordinal int) string {
+	return fmt.Sprintf("%s%d", sessionShellTerminalPrefix, ordinal)
+}
+
+const sessionShellTerminalPrefix = "Terminal "
+
+// sessionTerminalOrdinal reads back a title this package generated. A title the
+// user renamed does not parse and reports false, so it stops reserving a number.
+func sessionTerminalOrdinal(title string) (int, bool) {
+	rest, found := strings.CutPrefix(title, sessionShellTerminalPrefix)
+	if !found {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
 }

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -70,7 +70,9 @@ describe("CenterPane toolbar session label", () => {
 	it("uses the inspector tab height for the terminal header", () => {
 		render(<CenterPane session={worker} theme="dark" daemonReady />);
 
-		const header = screen.getByText("TERMINAL").parentElement?.parentElement;
+		// Anchored on the tab strip, not a heading: the "TERMINAL" label is gone.
+		const header = document.querySelector(".h-inspector-tabs");
+		expect(header).not.toBeNull();
 		expect(header).toHaveClass("h-inspector-tabs");
 	});
 
@@ -91,7 +93,7 @@ describe("CenterPane toolbar session label", () => {
 
 		// The display controls float over the terminal body, not the tab bar,
 		// so tabs and controls can never overlap.
-		const tabBarRow = screen.getByText("TERMINAL").closest("div")?.parentElement;
+		const tabBarRow = document.querySelector(".h-inspector-tabs");
 		expect(tabBarRow).not.toBeNull();
 		expect(tabBarRow?.contains(screen.getByRole("button", { name: /fullscreen/i }))).toBe(false);
 	});

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -18,12 +18,6 @@ const worker = {
 	updatedAt: "2026-06-10T00:00:00Z",
 	prs: [],
 } satisfies WorkspaceSession;
-const secondWorker = {
-	...worker,
-	id: "sess-2",
-	title: "review the change",
-	branch: "ao/sess-2",
-} satisfies WorkspaceSession;
 
 describe("CenterPane toolbar session label", () => {
 	const makeShells = (count: number) =>
@@ -40,102 +34,27 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.queryByText("sess-1")).not.toBeInTheDocument();
 	});
 
-	it("renders project sessions as tabs and opens a sibling session", () => {
-		const onSelectProjectSession = vi.fn();
-		render(
-			<CenterPane
-				session={worker}
-				projectSessions={[worker, secondWorker]}
-				onSelectProjectSession={onSelectProjectSession}
-				theme="dark"
-				daemonReady
-			/>,
-		);
-
-		expect(screen.getByRole("button", { name: "do the thing" })).toHaveAttribute("aria-current", "true");
-		fireEvent.click(screen.getByRole("button", { name: "review the change" }));
-		expect(onSelectProjectSession).toHaveBeenCalledWith(secondWorker);
-	});
-
-	it("opens a terminal on left click without showing the launcher", () => {
+	// One click, one terminal. #3138 put this behind a dropdown whose first item
+	// was "Terminal", so the everyday action cost two clicks.
+	it("opens a terminal on a single click, with no menu in between", () => {
 		const onNewShellTerminal = vi.fn();
-		render(
-			<CenterPane
-				session={worker}
-				projectSessions={[worker]}
-				availableProjectSessions={[secondWorker]}
-				onNewShellTerminal={onNewShellTerminal}
-				theme="dark"
-				daemonReady
-			/>,
-		);
+		render(<CenterPane session={worker} onNewShellTerminal={onNewShellTerminal} theme="dark" daemonReady />);
 
-		const trigger = screen.getByRole("button", { name: "New terminal" });
-		fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
-		fireEvent.click(trigger);
+		fireEvent.click(screen.getByRole("button", { name: "New terminal" }));
 
 		expect(onNewShellTerminal).toHaveBeenCalledOnce();
-		expect(screen.queryByRole("menuitem", { name: /review the change/ })).not.toBeInTheDocument();
+		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 	});
 
-	it("adds workers and terminals through the right-click launcher", () => {
-		const onAddProjectSession = vi.fn();
-		const onNewShellTerminal = vi.fn();
-		render(
-			<CenterPane
-				session={worker}
-				projectSessions={[worker]}
-				availableProjectSessions={[secondWorker]}
-				onAddProjectSession={onAddProjectSession}
-				onNewShellTerminal={onNewShellTerminal}
-				theme="dark"
-				daemonReady
-			/>,
-		);
+	// The strip belongs to one session: its own tab, then the shells it opened.
+	// No other session can be pinned in, and the session's own tab has no X —
+	// ending a session is the topbar's Kill, not a stray click here.
+	it("shows the session as a single unclosable tab", () => {
+		render(<CenterPane session={worker} theme="dark" daemonReady />);
 
-		expect(screen.queryByRole("button", { name: "review the change" })).not.toBeInTheDocument();
-		fireEvent.contextMenu(screen.getByRole("button", { name: "New terminal" }));
-		fireEvent.click(screen.getByRole("menuitem", { name: /review the change/ }));
-		expect(onAddProjectSession).toHaveBeenCalledWith(secondWorker);
-
-		fireEvent.contextMenu(screen.getByRole("button", { name: "New terminal" }));
-		fireEvent.click(screen.getByRole("menuitem", { name: "Terminal" }));
-		expect(onNewShellTerminal).toHaveBeenCalledOnce();
-	});
-
-	it("limits a large session list, then expands it into a searchable scroll area", () => {
-		const sessions = Array.from({ length: 7 }, (_, index) => ({
-			...secondWorker,
-			id: `sess-${index + 2}`,
-			title: `Worker ${index + 1}`,
-		}));
-		render(
-			<CenterPane
-				session={worker}
-				projectSessions={[worker]}
-				availableProjectSessions={sessions}
-				theme="dark"
-				daemonReady
-			/>,
-		);
-
-		fireEvent.contextMenu(screen.getByRole("button", { name: "New terminal" }));
-		const search = screen.getByRole("textbox", { name: "Search sessions" });
-		const terminal = screen.getByRole("menuitem", { name: "Terminal" });
-		expect(terminal.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-		expect(screen.getByRole("menuitem", { name: /Worker 5/ })).toBeInTheDocument();
-		expect(screen.queryByRole("menuitem", { name: /Worker 6/ })).not.toBeInTheDocument();
-
-		fireEvent.click(screen.getByRole("menuitem", { name: "Show all sessions" }));
-		const lastSession = screen.getByRole("menuitem", { name: /Worker 7/ });
-		expect(lastSession).toBeInTheDocument();
-		expect(lastSession.parentElement).toHaveClass("h-52", "overflow-y-auto");
-
-		fireEvent.change(screen.getByRole("textbox", { name: "Search sessions" }), {
-			target: { value: "Worker 7" },
-		});
-		expect(screen.getByRole("menuitem", { name: /Worker 7/ })).toBeInTheDocument();
-		expect(screen.queryByRole("menuitem", { name: /Worker 1/ })).not.toBeInTheDocument();
+		const sessionTab = screen.getByRole("button", { name: "do the thing" });
+		expect(sessionTab).toHaveAttribute("aria-current", "true");
+		expect(screen.queryByRole("button", { name: /^Close session tab/ })).not.toBeInTheDocument();
 	});
 
 	it("shows 'Orchestrator' for an orchestrator session", () => {

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -57,7 +57,28 @@ describe("CenterPane toolbar session label", () => {
 		expect(onSelectProjectSession).toHaveBeenCalledWith(secondWorker);
 	});
 
-	it("adds workers and terminals only through the tab launcher", () => {
+	it("opens a terminal on left click without showing the launcher", () => {
+		const onNewShellTerminal = vi.fn();
+		render(
+			<CenterPane
+				session={worker}
+				projectSessions={[worker]}
+				availableProjectSessions={[secondWorker]}
+				onNewShellTerminal={onNewShellTerminal}
+				theme="dark"
+				daemonReady
+			/>,
+		);
+
+		const trigger = screen.getByRole("button", { name: "New terminal" });
+		fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+		fireEvent.click(trigger);
+
+		expect(onNewShellTerminal).toHaveBeenCalledOnce();
+		expect(screen.queryByRole("menuitem", { name: /review the change/ })).not.toBeInTheDocument();
+	});
+
+	it("adds workers and terminals through the right-click launcher", () => {
 		const onAddProjectSession = vi.fn();
 		const onNewShellTerminal = vi.fn();
 		render(
@@ -73,11 +94,11 @@ describe("CenterPane toolbar session label", () => {
 		);
 
 		expect(screen.queryByRole("button", { name: "review the change" })).not.toBeInTheDocument();
-		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
+		fireEvent.contextMenu(screen.getByRole("button", { name: "New terminal" }));
 		fireEvent.click(screen.getByRole("menuitem", { name: /review the change/ }));
 		expect(onAddProjectSession).toHaveBeenCalledWith(secondWorker);
 
-		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
+		fireEvent.contextMenu(screen.getByRole("button", { name: "New terminal" }));
 		fireEvent.click(screen.getByRole("menuitem", { name: "Terminal" }));
 		expect(onNewShellTerminal).toHaveBeenCalledOnce();
 	});
@@ -98,7 +119,7 @@ describe("CenterPane toolbar session label", () => {
 			/>,
 		);
 
-		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
+		fireEvent.contextMenu(screen.getByRole("button", { name: "New terminal" }));
 		const search = screen.getByRole("textbox", { name: "Search sessions" });
 		const terminal = screen.getByRole("menuitem", { name: "Terminal" });
 		expect(terminal.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -1,14 +1,4 @@
-import {
-	ChevronLeft,
-	ChevronRight,
-	Maximize2,
-	Minimize2,
-	Plus,
-	Search,
-	Shield,
-	Terminal as TerminalIcon,
-	X,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, Maximize2, Minimize2, Plus, Shield, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type WheelEvent } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
 import { useTruncatedText } from "../hooks/useTruncatedText";
@@ -20,24 +10,9 @@ import type { TerminalTarget } from "../types/terminal";
 import { isOrchestratorSession, type WorkspaceSession } from "../types/workspace";
 import { ShellTerminalTab } from "./ShellTerminalTab";
 import { TerminalPane } from "./TerminalPane";
-import { Input } from "./ui/input";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
 
 type CenterPaneProps = {
 	session?: WorkspaceSession;
-	/** Tabs pinned to the originating session's private layout. */
-	projectSessions?: WorkspaceSession[];
-	availableProjectSessions?: WorkspaceSession[];
-	tabOwnerSessionId?: string;
-	onAddProjectSession?: (session: WorkspaceSession) => void;
-	onCloseProjectSession?: (session: WorkspaceSession) => void;
-	onSelectProjectSession?: (session: WorkspaceSession) => void;
 	theme: Theme;
 	daemonReady: boolean;
 	terminalTarget?: TerminalTarget;
@@ -55,7 +30,6 @@ type CenterPaneProps = {
 const terminalFontSizeStorageKey = "ao.terminal.fontSize";
 const WHEEL_ZOOM_THRESHOLD = 80;
 const WHEEL_ZOOM_RESET_MS = 250;
-const COMPACT_SESSION_LIMIT = 5;
 
 function clampTerminalFontSize(size: number): number {
 	return Math.min(TERMINAL_FONT_SIZE_MAX, Math.max(TERMINAL_FONT_SIZE_MIN, size));
@@ -71,12 +45,6 @@ function initialTerminalFontSize(): number {
 
 export function CenterPane({
 	session,
-	projectSessions,
-	availableProjectSessions = [],
-	tabOwnerSessionId,
-	onAddProjectSession,
-	onCloseProjectSession,
-	onSelectProjectSession,
 	theme,
 	daemonReady,
 	terminalTarget,
@@ -93,25 +61,7 @@ export function CenterPane({
 	const lastWheelZoomAtRef = useRef(0);
 	const [fontSize, setFontSize] = useState(initialTerminalFontSize);
 	const [isFullscreen, setIsFullscreen] = useState(false);
-	const [isTabLauncherOpen, setIsTabLauncherOpen] = useState(false);
-	const [showAllSessions, setShowAllSessions] = useState(false);
-	const [sessionSearch, setSessionSearch] = useState("");
-	const sessionTabs = projectSessions?.length ? projectSessions : session ? [session] : [];
-	const effectiveTabOwnerSessionId = tabOwnerSessionId ?? session?.id;
-	const hasMoreSessions = availableProjectSessions.length > COMPACT_SESSION_LIMIT;
-	const normalizedSessionSearch = sessionSearch.trim().toLowerCase();
-	const filteredSessions = normalizedSessionSearch
-		? availableProjectSessions.filter((candidate) =>
-				`${candidate.title} ${candidate.workspaceName}`.toLowerCase().includes(normalizedSessionSearch),
-			)
-		: availableProjectSessions;
-	const expandedSessionList = showAllSessions || normalizedSessionSearch.length > 0;
-	const visibleSessions = expandedSessionList
-		? filteredSessions
-		: filteredSessions.slice(0, COMPACT_SESSION_LIMIT);
-	const tabOverflowWatch = `${sessionTabs.map((item) => item.id).join("|")}|${shellTerminals
-		.map((terminal) => terminal.handleId)
-		.join("|")}`;
+	const tabOverflowWatch = `${session?.id ?? ""}|${shellTerminals.map((terminal) => terminal.handleId).join("|")}`;
 	const tabsOverflow = useOverflowScroll<HTMLDivElement>(tabOverflowWatch);
 	const target = terminalTarget ?? { kind: "worker" };
 
@@ -189,35 +139,20 @@ export function CenterPane({
 					>
 						<ChevronLeft aria-hidden="true" className="size-icon-md" />
 					</button>
-					{/* Each originating session owns a private set of pinned worker and
-					    shell tabs. The + menu is the only way to add to that layout. */}
+					{/* The first tab is the session itself and has no close affordance:
+					    ending a session is the topbar's Kill, not a stray click here.
+					    Every tab after it is a shell the user opened with +, scoped to
+					    this session — another session's terminals never appear here. */}
 					<div
 						ref={tabsOverflow.ref}
 						className="scrollbar-none flex min-w-flex-min flex-1 items-center gap-3 overflow-x-auto"
 					>
-						{sessionTabs.length > 0 ? (
-							sessionTabs.map((projectSession) => {
-								const isCurrent = projectSession.id === session?.id;
-								return (
-									<SessionPaneTab
-										key={projectSession.id}
-										isActive={isCurrent && target.kind !== "shell"}
-										label={
-											isOrchestratorSession(projectSession) ? "Orchestrator" : projectSession.title
-										}
-										onSelect={
-											isCurrent
-												? onSelectSessionTerminal
-												: () => onSelectProjectSession?.(projectSession)
-										}
-										onClose={
-											projectSession.id !== effectiveTabOwnerSessionId
-												? () => onCloseProjectSession?.(projectSession)
-												: undefined
-										}
-									/>
-								);
-							})
+						{session ? (
+							<SessionPaneTab
+								isActive={target.kind !== "shell"}
+								label={isOrchestratorSession(session) ? "Orchestrator" : session.title}
+								onSelect={onSelectSessionTerminal}
+							/>
 						) : (
 							<SessionPaneTab isActive={target.kind !== "shell"} label="No session" />
 						)}
@@ -245,104 +180,18 @@ export function CenterPane({
 					>
 						<ChevronRight aria-hidden="true" className="size-icon-md" />
 					</button>
-					<DropdownMenu
-						open={isTabLauncherOpen}
-						onOpenChange={(open) => {
-							setIsTabLauncherOpen(open);
-							if (!open) {
-								setShowAllSessions(false);
-								setSessionSearch("");
-							}
-						}}
-					>
-						<DropdownMenuTrigger asChild>
-							{/* Plain left click is the old one-click "new terminal"; the session
-							    launcher lives behind right click (and ArrowDown for keyboards). */}
-							<button
-								aria-label="New terminal"
-								className="inline-flex h-control-sm shrink-0 items-center gap-px rounded-sm px-1 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
-								onClick={onNewShellTerminal}
-								onContextMenu={(event) => {
-									event.preventDefault();
-									setIsTabLauncherOpen(true);
-								}}
-								onKeyDown={(event) => {
-									// Activate ourselves so Radix cannot claim Enter/Space for the menu.
-									if (event.key === "Enter" || event.key === " ") {
-										event.preventDefault();
-										onNewShellTerminal?.();
-									}
-								}}
-								onPointerDown={(event) => {
-									// Suppress Radix's open-on-primary-pointerdown; click adds a terminal.
-									if (event.button === 0) event.preventDefault();
-								}}
-								title="New terminal (Ctrl+Shift+`). Right-click to add a session tab."
-								type="button"
-							>
-								<Plus aria-hidden="true" className="size-icon-md" />
-							</button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="start" className="w-72">
-							<DropdownMenuItem onSelect={onNewShellTerminal}>
-								<TerminalIcon aria-hidden="true" />
-								Terminal
-							</DropdownMenuItem>
-							<DropdownMenuSeparator />
-							{hasMoreSessions ? (
-								<div className="relative px-1 pb-1">
-									<Search
-										aria-hidden="true"
-										className="pointer-events-none absolute top-1/2 left-3 size-icon-md -translate-y-[calc(50%+2px)] text-passive"
-									/>
-									<Input
-										aria-label="Search sessions"
-										className="h-control-board pl-8"
-										onChange={(event) => setSessionSearch(event.target.value)}
-										onKeyDown={(event) => event.stopPropagation()}
-										placeholder="Search sessions"
-										value={sessionSearch}
-									/>
-								</div>
-							) : null}
-							<div className={cn(expandedSessionList && "h-52 overflow-y-auto overscroll-contain")}>
-								{visibleSessions.length > 0 ? (
-									visibleSessions.map((candidate) => {
-										const isOpen = sessionTabs.some((tab) => tab.id === candidate.id);
-										return (
-											<DropdownMenuItem
-												key={candidate.id}
-												disabled={isOpen}
-												onSelect={() => onAddProjectSession?.(candidate)}
-											>
-												<span className="size-2 shrink-0 rounded-full bg-passive" aria-hidden="true" />
-												<span className="min-w-0 flex-1 truncate">{candidate.title}</span>
-												<span className="max-w-20 truncate text-micro text-passive">
-													{isOpen ? "Open" : candidate.workspaceName}
-												</span>
-											</DropdownMenuItem>
-										);
-									})
-								) : (
-									<DropdownMenuItem disabled>No sessions found</DropdownMenuItem>
-								)}
-							</div>
-							{hasMoreSessions && !expandedSessionList ? (
-								<>
-									<DropdownMenuSeparator />
-									<DropdownMenuItem
-										className="justify-center text-foreground"
-										onSelect={(event) => {
-											event.preventDefault();
-											setShowAllSessions(true);
-										}}
-									>
-										Show all sessions
-									</DropdownMenuItem>
-								</>
-							) : null}
-						</DropdownMenuContent>
-					</DropdownMenu>
+					{/* One click, one terminal — the same action Ctrl+Shift+` fires. */}
+					{onNewShellTerminal && (
+						<button
+							aria-label="New terminal"
+							className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
+							onClick={onNewShellTerminal}
+							title="New terminal (Ctrl+Shift+`)"
+							type="button"
+						>
+							<Plus aria-hidden="true" className="size-icon-md" />
+						</button>
+					)}
 				</div>
 			</div>
 			{target.kind === "reviewer" ? (

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -256,10 +256,28 @@ export function CenterPane({
 						}}
 					>
 						<DropdownMenuTrigger asChild>
+							{/* Plain left click is the old one-click "new terminal"; the session
+							    launcher lives behind right click (and ArrowDown for keyboards). */}
 							<button
-								aria-label="Add tab"
+								aria-label="New terminal"
 								className="inline-flex h-control-sm shrink-0 items-center gap-px rounded-sm px-1 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
-								title="Add tab"
+								onClick={onNewShellTerminal}
+								onContextMenu={(event) => {
+									event.preventDefault();
+									setIsTabLauncherOpen(true);
+								}}
+								onKeyDown={(event) => {
+									// Activate ourselves so Radix cannot claim Enter/Space for the menu.
+									if (event.key === "Enter" || event.key === " ") {
+										event.preventDefault();
+										onNewShellTerminal?.();
+									}
+								}}
+								onPointerDown={(event) => {
+									// Suppress Radix's open-on-primary-pointerdown; click adds a terminal.
+									if (event.button === 0) event.preventDefault();
+								}}
+								title="New terminal (Ctrl+Shift+`). Right-click to add a session tab."
 								type="button"
 							>
 								<Plus aria-hidden="true" className="size-icon-md" />

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -22,6 +22,10 @@ type CenterPaneProps = {
 	onSelectSessionTerminal?: () => void;
 	onSelectShellTerminal?: (handleId: string) => void;
 	onCloseShellTerminal?: (handleId: string) => void;
+	/** A shell pane reported its PTY ended; the owner re-checks with the daemon. */
+	onShellExited?: (handleId: string) => void;
+	/** Bumped to force a fresh attachment when a reported exit turns out false. */
+	attachEpoch?: number;
 	onRenameShellTerminal?: (handleId: string, title: string) => void;
 	/** Opens a new standalone shell tab (the "+" at the end of the tab bar). */
 	onNewShellTerminal?: () => void;
@@ -53,6 +57,8 @@ export function CenterPane({
 	onSelectSessionTerminal,
 	onSelectShellTerminal,
 	onCloseShellTerminal,
+	onShellExited,
+	attachEpoch,
 	onRenameShellTerminal,
 	onNewShellTerminal,
 }: CenterPaneProps) {
@@ -121,16 +127,17 @@ export function CenterPane({
 			className="terminal-pane-frame flex h-full min-h-0 min-w-flex-min flex-col"
 			onWheelCapture={handleWheelZoom}
 		>
-			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border px-5">
+			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border pl-2 pr-5">
+				{/* No "TERMINAL" heading: the tabs say what this is, and the label was
+				    spending the widest column in the strip to repeat it. */}
 				<div className="flex min-w-flex-min flex-1 items-center gap-3">
-					<span className="shrink-0 font-mono text-caption font-semibold uppercase tracking-wide-lg text-muted-foreground">
-						TERMINAL
-					</span>
 					<button
 						aria-label="Scroll tabs left"
 						className={cn(
-							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none disabled:opacity-0",
-							!tabsOverflow.canScrollLeft && "invisible",
+							"inline-flex shrink-0 items-center justify-center overflow-hidden rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none",
+							// visibility:hidden still reserves the box, which left a dead
+							// column where the strip should start. Collapse it instead.
+							tabsOverflow.canScrollLeft ? "size-control-sm" : "pointer-events-none size-0 opacity-0",
 						)}
 						disabled={!tabsOverflow.canScrollLeft}
 						onClick={() => tabsOverflow.scrollByDirection(-1)}
@@ -170,8 +177,8 @@ export function CenterPane({
 					<button
 						aria-label="Scroll tabs right"
 						className={cn(
-							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none disabled:opacity-0",
-							!tabsOverflow.canScrollRight && "invisible",
+							"inline-flex shrink-0 items-center justify-center overflow-hidden rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none",
+							tabsOverflow.canScrollRight ? "size-control-sm" : "pointer-events-none size-0 opacity-0",
 						)}
 						disabled={!tabsOverflow.canScrollRight}
 						onClick={() => tabsOverflow.scrollByDirection(1)}
@@ -216,6 +223,8 @@ export function CenterPane({
 				<TerminalPane
 					daemonReady={daemonReady}
 					fontSize={fontSize}
+					attachEpoch={attachEpoch}
+					onShellExited={onShellExited}
 					session={session}
 					terminalTarget={target}
 					theme={theme}

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -86,23 +86,15 @@ const { workspaces, workspaceQueryState, panels, shellTerminalsState } = vi.hois
 vi.mock("./ShellTopbar", () => ({ ShellTopbar: () => null }));
 vi.mock("./CenterPane", () => ({
 	CenterPane: ({
+		session,
 		shellTerminals = [],
 		onSelectShellTerminal,
 		onSelectSessionTerminal,
-		projectSessions = [],
-		availableProjectSessions = [],
-		onAddProjectSession,
-		onCloseProjectSession,
-		onSelectProjectSession,
 	}: {
+		session?: WorkspaceSession;
 		shellTerminals?: Array<{ handleId: string; title: string }>;
 		onSelectShellTerminal?: (handleId: string) => void;
 		onSelectSessionTerminal?: () => void;
-		projectSessions?: WorkspaceSession[];
-		availableProjectSessions?: WorkspaceSession[];
-		onAddProjectSession?: (session: WorkspaceSession) => void;
-		onCloseProjectSession?: (session: WorkspaceSession) => void;
-		onSelectProjectSession?: (session: WorkspaceSession) => void;
 	}) => (
 		<div>
 			terminal center
@@ -115,25 +107,7 @@ vi.mock("./CenterPane", () => ({
 			<button type="button" onClick={() => onSelectSessionTerminal?.()}>
 				select agent tab
 			</button>
-			<div data-testid="project-tabs">
-				{projectSessions.map((session) => (
-					<button key={session.id} type="button" onClick={() => onSelectProjectSession?.(session)}>
-						{session.title}
-					</button>
-				))}
-			</div>
-			<div data-testid="available-project-tabs">
-				{availableProjectSessions.map((session) => (
-					<button key={session.id} type="button" onClick={() => onAddProjectSession?.(session)}>
-						Add {session.title}
-					</button>
-				))}
-			</div>
-			{projectSessions.slice(1).map((session) => (
-				<button key={session.id} type="button" onClick={() => onCloseProjectSession?.(session)}>
-					Close {session.title}
-				</button>
-			))}
+			<div data-testid="session-tab">{session?.title ?? ""}</div>
 		</div>
 	),
 }));
@@ -342,7 +316,7 @@ describe("SessionView", () => {
 		}
 		workspaceQueryState.data = workspaces;
 		workspaceQueryState.isLoading = false;
-		useUiStore.setState({ inspectorSessions: {}, visibleTerminalKindBySession: {}, sessionTabsByOwner: {} });
+		useUiStore.setState({ inspectorSessions: {}, visibleTerminalKindBySession: {} });
 		panels.clear();
 		browserDestroy.mockReset();
 		browserViewOptions.current = undefined;
@@ -408,64 +382,25 @@ describe("SessionView", () => {
 		expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBeUndefined();
 	});
 
-	it("starts with only the owner tab and pins another worker through the add menu", () => {
-		render(<SessionView sessionId="sess-1" />);
-
-		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the thing");
-		expect(screen.getByTestId("project-tabs")).not.toHaveTextContent("do the other thing");
-		expect(screen.getByTestId("available-project-tabs")).toHaveTextContent("Add do the other thing");
-
-		fireEvent.click(screen.getByRole("button", { name: "Add do the other thing" }));
-		expect(useUiStore.getState().sessionTabsByOwner["sess-1"]).toEqual(["sess-2"]);
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "sess-2" },
-			search: { tabOwner: "sess-1" },
-		});
-	});
-
-	it("offers and pins live worker sessions from other projects", () => {
-		render(<SessionView sessionId="sess-1" />);
-
-		fireEvent.click(screen.getByRole("button", { name: "Add cross-project task" }));
-		expect(useUiStore.getState().sessionTabsByOwner["sess-1"]).toEqual(["sess-cross-project"]);
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-2", sessionId: "sess-cross-project" },
-			search: { tabOwner: "sess-1" },
-		});
-	});
-
-	it("keeps pinned worker and shell tabs private to their owner session", () => {
-		useUiStore.getState().addSessionTab("sess-1", "sess-2");
+	// A session's tab strip is its own: the only worker tab is this session, and
+	// no other session's terminals can be pinned into it (#3138 allowed that and
+	// it made the strip ambiguous about which session you were typing into).
+	it("shows only this session as the worker tab", () => {
 		shellTerminalsState.data = [
-			{
-				handleId: "sh-a",
-				sessionId: "sess-1",
-				title: "owner-shell",
-				workingDir: "/p",
-				createdAt: "2026-07-24T00:00:00Z",
-			},
 			{
 				handleId: "sh-b",
 				sessionId: "sess-2",
-				title: "worker-shell",
+				title: "sess-2-shell",
 				workingDir: "/q",
 				createdAt: "2026-07-24T00:00:00Z",
 			},
 		];
-		const { rerender } = render(<SessionView sessionId="sess-2" tabOwnerSessionId="sess-1" />);
+		render(<SessionView sessionId="sess-1" />);
 
-		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the thing");
-		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the other thing");
-		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("owner-shell");
-		expect(screen.getByTestId("shell-tabs")).not.toHaveTextContent("worker-shell");
-
-		rerender(<SessionView sessionId="sess-2" />);
-		expect(screen.getByTestId("project-tabs")).not.toHaveTextContent("do the thing");
-		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the other thing");
-		expect(screen.getByTestId("shell-tabs")).not.toHaveTextContent("owner-shell");
-		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("worker-shell");
+		expect(screen.getByTestId("session-tab")).toHaveTextContent("do the thing");
+		expect(screen.getByTestId("session-tab")).not.toHaveTextContent("do the other thing");
+		expect(screen.getByTestId("shell-tabs")).not.toHaveTextContent("sess-2-shell");
+		expect(screen.queryByTestId("available-project-tabs")).not.toBeInTheDocument();
 	});
 
 	// Regression: react-resizable-panels v4 treats bare numeric sizes as PIXELS

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, type ReactNode, type Ref } from "react";
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { SessionView } from "./SessionView";
 import { useUiStore } from "../stores/ui-store";
@@ -90,18 +90,28 @@ vi.mock("./CenterPane", () => ({
 		shellTerminals = [],
 		onSelectShellTerminal,
 		onSelectSessionTerminal,
+		onShellExited,
+		attachEpoch,
 	}: {
 		session?: WorkspaceSession;
 		shellTerminals?: Array<{ handleId: string; title: string }>;
 		onSelectShellTerminal?: (handleId: string) => void;
 		onSelectSessionTerminal?: () => void;
+		onShellExited?: (handleId: string) => void;
+		attachEpoch?: number;
 	}) => (
 		<div>
 			terminal center
 			<div data-testid="shell-tabs">{shellTerminals.map((s) => s.title).join(",")}</div>
+			<div data-testid="attach-epoch">{String(attachEpoch ?? 0)}</div>
 			{shellTerminals.map((s) => (
 				<button key={s.handleId} type="button" onClick={() => onSelectShellTerminal?.(s.handleId)}>
 					select {s.title}
+				</button>
+			))}
+			{shellTerminals.map((s) => (
+				<button key={`exit-${s.handleId}`} type="button" onClick={() => onShellExited?.(s.handleId)}>
+					report exit {s.title}
 				</button>
 			))}
 			<button type="button" onClick={() => onSelectSessionTerminal?.()}>
@@ -208,11 +218,13 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 }));
 // Standalone shell terminals are orthogonal to the split under test, and their
 // real hooks would need a QueryClientProvider this suite deliberately omits.
+const refreshShellTerminalsMock = vi.fn(async () => shellTerminalsState.data);
 vi.mock("../hooks/useShellTerminals", () => ({
 	useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
 	useOpenShellTerminal: () => ({ mutate: vi.fn() }),
 	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
 	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
+	useRefreshShellTerminals: () => refreshShellTerminalsMock,
 }));
 
 // jsdom has no layout engine, so the real react-resizable-panels would never
@@ -401,6 +413,59 @@ describe("SessionView", () => {
 		expect(screen.getByTestId("session-tab")).not.toHaveTextContent("do the other thing");
 		expect(screen.getByTestId("shell-tabs")).not.toHaveTextContent("sess-2-shell");
 		expect(screen.queryByTestId("available-project-tabs")).not.toBeInTheDocument();
+	});
+
+	// A pane reporting "exited" is not proof the shell died: the attach loop
+	// reports the same after giving up on a failing liveness probe. If the
+	// daemon still lists the shell it is alive, and the pane — which holds
+	// "exited" forever once it lands there — must be remounted to reconnect,
+	// not left telling the user to close a live terminal.
+	it("re-attaches instead of closing when the daemon still has the shell", async () => {
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				sessionId: "sess-1",
+				title: "Terminal 1",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+		];
+		render(<SessionView sessionId="sess-1" />);
+
+		// Select it so the pane is pointed at the shell.
+		fireEvent.click(screen.getByRole("button", { name: "select Terminal 1" }));
+		expect(screen.getByTestId("attach-epoch")).toHaveTextContent("0");
+
+		fireEvent.click(screen.getByRole("button", { name: "report exit Terminal 1" }));
+
+		// The daemon kept it, so the pane remounts and the tab stays put.
+		await waitFor(() => expect(screen.getByTestId("attach-epoch")).toHaveTextContent("1"));
+		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("Terminal 1");
+		expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("shell");
+	});
+
+	// The other half: the daemon confirms it is gone, so the pane goes back to
+	// the session rather than remounting an attachment to a dead handle.
+	it("hands the pane back to the session when the daemon drops the shell", async () => {
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				sessionId: "sess-1",
+				title: "Terminal 1",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+		];
+		render(<SessionView sessionId="sess-1" />);
+		fireEvent.click(screen.getByRole("button", { name: "select Terminal 1" }));
+		expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("shell");
+
+		// The refresh reports it pruned.
+		shellTerminalsState.data = [];
+		fireEvent.click(screen.getByRole("button", { name: "report exit Terminal 1" }));
+
+		await waitFor(() => expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("worker"));
+		expect(screen.getByTestId("attach-epoch")).toHaveTextContent("0");
 	});
 
 	// Regression: react-resizable-panels v4 treats bare numeric sizes as PIXELS

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { useNavigate } from "@tanstack/react-router";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
 import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
@@ -19,7 +18,7 @@ import {
 } from "../hooks/useShellTerminals";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { hidesShellTopbar } from "../lib/platform";
-import { isOrchestratorSession, sessionIsActive, workerSessions, type WorkspaceSession } from "../types/workspace";
+import { isOrchestratorSession, sessionIsActive } from "../types/workspace";
 import type { TerminalTarget } from "../types/terminal";
 import { matchesRendererShortcut } from "../stores/keybindings-store";
 
@@ -27,7 +26,6 @@ const INSPECTOR_MIN_PERCENT = 22;
 const INSPECTOR_MAX_PERCENT = 45;
 const inspectorSplitStorageKey = "ao.inspector.split";
 const shellTopbarHiddenByPlatform = hidesShellTopbar();
-const emptySessionTabIds: string[] = [];
 
 function initialSplitPercent(): number {
 	const raw = typeof window === "undefined" ? null : window.localStorage?.getItem(inspectorSplitStorageKey);
@@ -45,7 +43,6 @@ function previewRevealKey(previewUrl?: string, previewRevision?: number): string
 
 type SessionViewProps = {
 	sessionId: string;
-	tabOwnerSessionId?: string;
 };
 
 // The session detail screen: terminal + git rail. On Win/Linux the shell owns
@@ -60,8 +57,7 @@ type SessionViewProps = {
 // imperative API from the ui-store (topbar button / ⌘⇧B), animated by the
 // flex-grow transition in styles.css. Content keeps a stable min-width inside
 // the clipped panel so nothing reflows mid-animation; split width persists.
-export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) {
-	const navigate = useNavigate();
+export function SessionView({ sessionId }: SessionViewProps) {
 	const workspaceQuery = useWorkspaceQuery();
 	const workspaces = workspaceQuery.data ?? [];
 	const theme = useResolvedTheme();
@@ -80,62 +76,14 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
 
 	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
-	const allSessions = workspaces.flatMap((workspace) => workspace.sessions);
-	const tabOwnerSession = allSessions.find((candidate) => candidate.id === tabOwnerSessionId) ?? session;
-	const ownerSessionId = tabOwnerSession?.id ?? sessionId;
-	const storedSessionTabIds = useUiStore((state) => state.sessionTabsByOwner[ownerSessionId] ?? emptySessionTabIds);
-	const addSessionTab = useUiStore((state) => state.addSessionTab);
-	const removeSessionTab = useUiStore((state) => state.removeSessionTab);
-	const availableSessions = workspaces.flatMap((workspace) =>
-		workerSessions(workspace.sessions).filter((candidate) => candidate.isTerminated !== true),
-	);
-	const projectSessions = tabOwnerSession
-		? [
-				tabOwnerSession,
-				...storedSessionTabIds
-					.map((tabId) => allSessions.find((candidate) => candidate.id === tabId))
-					.filter((projectSession): projectSession is WorkspaceSession =>
-						Boolean(projectSession && projectSession.isTerminated !== true && projectSession.id !== tabOwnerSession.id),
-					),
-			]
-		: [];
-	if (session && !projectSessions.some((projectSession) => projectSession.id === session.id)) {
-		projectSessions.push(session);
-	}
-	const selectProjectSession = useCallback(
-		(projectSession: WorkspaceSession) => {
-			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId: projectSession.workspaceId, sessionId: projectSession.id },
-				search: projectSession.id === ownerSessionId ? {} : { tabOwner: ownerSessionId },
-			});
-		},
-		[navigate, ownerSessionId],
-	);
-	const addProjectSession = useCallback(
-		(projectSession: WorkspaceSession) => {
-			addSessionTab(ownerSessionId, projectSession.id);
-			selectProjectSession(projectSession);
-		},
-		[addSessionTab, ownerSessionId, selectProjectSession],
-	);
-	const closeProjectSession = useCallback(
-		(projectSession: WorkspaceSession) => {
-			removeSessionTab(ownerSessionId, projectSession.id);
-			if (projectSession.id === sessionId && tabOwnerSession) selectProjectSession(tabOwnerSession);
-		},
-		[ownerSessionId, removeSessionTab, selectProjectSession, sessionId, tabOwnerSession],
-	);
 
-	// Shell terminals opened inside a session live beside its pane as extra tabs.
-	//
-	// Scope shells to the tab layout's originating session. Navigating to a
-	// pinned worker keeps the owner's shell tabs; opening that worker directly
-	// from the sidebar uses its own separate shell set.
+	// Shell terminals opened inside a session live beside its pane as extra tabs,
+	// scoped to that session: a session's strip never shows another session's
+	// terminals.
 	const allShellTerminals = useShellTerminals().data ?? [];
 	const shellTerminals = useMemo(
-		() => allShellTerminals.filter((shell) => shell.sessionId === ownerSessionId),
-		[allShellTerminals, ownerSessionId],
+		() => allShellTerminals.filter((shell) => shell.sessionId === sessionId),
+		[allShellTerminals, sessionId],
 	);
 	const openShellTerminal = useOpenShellTerminal();
 	const closeShellTerminal = useCloseShellTerminal();
@@ -151,7 +99,7 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 
 	const addShellTerminal = useCallback(() => {
 		openShellTerminal.mutate(
-			{ projectId: tabOwnerSession?.workspaceId, sessionId: ownerSessionId },
+			{ projectId: session?.workspaceId, sessionId },
 			{
 				onSuccess: (shell) => {
 					setActiveShellTerminal(shell.handleId);
@@ -159,7 +107,7 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 				},
 			},
 		);
-	}, [openShellTerminal, ownerSessionId, setActiveShellTerminal, tabOwnerSession?.workspaceId]);
+	}, [openShellTerminal, sessionId, setActiveShellTerminal, session?.workspaceId]);
 
 	const selectShellTerminal = useCallback(
 		(handleId: string) => {
@@ -422,21 +370,15 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
             be strings. Numeric sizes here once clamped the inspector to 45px. */}
 				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%">
 					<CenterPane
-						availableProjectSessions={availableSessions.filter((candidate) => candidate.id !== tabOwnerSession?.id)}
 						daemonReady={daemonStatus.state === "ready"}
-						onAddProjectSession={addProjectSession}
-						onCloseProjectSession={closeProjectSession}
 						onCloseShellTerminal={closeShellTerminalByHandle}
 						onNewShellTerminal={addShellTerminal}
 						onRenameShellTerminal={renameShellTerminalByHandle}
-						onSelectProjectSession={selectProjectSession}
 						onSelectSessionTerminal={selectSessionTerminal}
 						onSelectShellTerminal={selectShellTerminal}
 						onSelectWorkerTerminal={selectSessionTerminal}
 						session={session}
-						projectSessions={projectSessions}
 						shellTerminals={shellTerminals}
-						tabOwnerSessionId={ownerSessionId}
 						terminalTarget={terminalTarget}
 						theme={theme}
 					/>

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -13,6 +13,7 @@ import { useBrowserView } from "../hooks/useBrowserView";
 import {
 	useCloseShellTerminal,
 	useOpenShellTerminal,
+	useRefreshShellTerminals,
 	useRenameShellTerminal,
 	useShellTerminals,
 } from "../hooks/useShellTerminals";
@@ -87,6 +88,8 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	);
 	const openShellTerminal = useOpenShellTerminal();
 	const closeShellTerminal = useCloseShellTerminal();
+	const refreshShellTerminals = useRefreshShellTerminals();
+	const [shellAttachEpochs, setShellAttachEpochs] = useState<Record<string, number>>({});
 	const renameShellTerminal = useRenameShellTerminal();
 	const activeShellTerminalHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
 	const setActiveShellTerminal = useUiStore((state) => state.setActiveShellTerminal);
@@ -130,6 +133,32 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			closeShellTerminal.mutate(handleId);
 		},
 		[closeShellTerminal, activeShellTerminalHandleId, setActiveShellTerminal],
+	);
+
+	// A pane reporting "exited" is a hint, not proof: the attach loop reports it
+	// after giving up on a failing liveness probe too. Ask the daemon, then act
+	// on its answer.
+	//
+	// Still in the list -> the shell is alive and this was an attachment
+	// failure. The pane holds "exited" forever once it lands there, so the tab
+	// would sit on "Terminal ended" telling the user to close a live shell.
+	// Bumping the epoch remounts the attachment and reconnects it instead.
+	//
+	// Gone from the list -> the daemon confirmed it died; give the pane back to
+	// the session.
+	const handleShellExited = useCallback(
+		async (handleId: string) => {
+			const shells = await refreshShellTerminals();
+			if (shells.some((shell) => shell.handleId === handleId)) {
+				setShellAttachEpochs((current) => ({ ...current, [handleId]: (current[handleId] ?? 0) + 1 }));
+				return;
+			}
+			setTerminalTarget((current) =>
+				current.kind === "shell" && current.handleId === handleId ? { kind: "worker" } : current,
+			);
+			if (activeShellTerminalHandleId === handleId) setActiveShellTerminal(null);
+		},
+		[activeShellTerminalHandleId, refreshShellTerminals, setActiveShellTerminal],
 	);
 
 	// Selecting the session's own pane also drops the active shell, so the effect
@@ -372,6 +401,8 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					<CenterPane
 						daemonReady={daemonStatus.state === "ready"}
 						onCloseShellTerminal={closeShellTerminalByHandle}
+						attachEpoch={terminalTarget.kind === "shell" ? (shellAttachEpochs[terminalTarget.handleId] ?? 0) : 0}
+						onShellExited={handleShellExited}
 						onNewShellTerminal={addShellTerminal}
 						onRenameShellTerminal={renameShellTerminalByHandle}
 						onSelectSessionTerminal={selectSessionTerminal}

--- a/frontend/src/renderer/components/ShellTerminalsView.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.test.tsx
@@ -6,6 +6,7 @@ vi.mock("../hooks/useShellTerminals", () => ({
 	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
 	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
 	useShellTerminals: () => ({ data: [] }),
+	useRefreshShellTerminals: () => vi.fn(),
 }));
 
 vi.mock("../lib/shell-context", () => ({

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -1,7 +1,12 @@
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
-import { useCloseShellTerminal, useRenameShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
+import {
+	useCloseShellTerminal,
+	useRefreshShellTerminals,
+	useRenameShellTerminal,
+	useShellTerminals,
+} from "../hooks/useShellTerminals";
 import { useShell } from "../lib/shell-context";
 import { cn } from "../lib/utils";
 import { useResolvedTheme, useUiStore } from "../stores/ui-store";
@@ -22,6 +27,18 @@ export function ShellTerminalsView() {
 	// shells belong to that session's tab strip, not this global list.
 	const shellTerminals = (useShellTerminals().data ?? []).filter((s) => !s.sessionId);
 	const closeShellTerminal = useCloseShellTerminal();
+	const refreshShellTerminals = useRefreshShellTerminals();
+	const [attachEpochs, setAttachEpochs] = useState<Record<string, number>>({});
+	// See SessionView: "exited" is a hint. If the daemon still lists the shell it
+	// is alive and the pane must re-attach rather than sit on "Terminal ended".
+	const handleShellExited = useCallback(
+		async (handleId: string) => {
+			const shells = await refreshShellTerminals();
+			if (!shells.some((shell) => shell.handleId === handleId)) return;
+			setAttachEpochs((current) => ({ ...current, [handleId]: (current[handleId] ?? 0) + 1 }));
+		},
+		[refreshShellTerminals],
+	);
 	const renameShellTerminal = useRenameShellTerminal();
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);
 	const activeHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
@@ -107,6 +124,8 @@ export function ShellTerminalsView() {
 					<TerminalPane
 						daemonReady={daemonStatus.state === "ready"}
 						fontSize={12}
+						attachEpoch={active ? (attachEpochs[active.handleId] ?? 0) : 0}
+						onShellExited={handleShellExited}
 						terminalTarget={{ kind: "shell", handleId: active.handleId, title: active.title }}
 						theme={theme}
 					/>

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -370,3 +370,64 @@ describe("terminal link preview", () => {
 		}
 	});
 });
+
+// A shell whose PTY exits should not sit in the strip showing "TERMINAL ENDED":
+// nothing else tells the client, since the shell list is only refetched around
+// this client's own open/close. The pane reports the exit as a HINT — it is not
+// proof of death, because the attach loop reports the same "exited" after it
+// gives up on a failing liveness probe — so the callers re-check with the
+// daemon rather than closing anything.
+describe("TerminalPane shell exit", () => {
+	function renderShellPane(onShellExited: (handleId: string) => void, state: string) {
+		terminalState.value = state;
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const previousAO = window.ao;
+		window.ao = {} as typeof window.ao;
+		const result = render(
+			<QueryClientProvider client={queryClient}>
+				<TerminalPane
+					daemonReady
+					fontSize={12}
+					onShellExited={onShellExited}
+					terminalTarget={{ kind: "shell", handleId: "sh-a", title: "Terminal 1" }}
+					theme="dark"
+				/>
+			</QueryClientProvider>,
+		);
+		return { ...result, restore: () => { window.ao = previousAO; } };
+	}
+
+	it("reports the exit once so the caller can re-check with the daemon", async () => {
+		const onShellExited = vi.fn();
+		const { restore } = renderShellPane(onShellExited, "exited");
+		await waitFor(() => expect(onShellExited).toHaveBeenCalledWith("sh-a"));
+		expect(onShellExited).toHaveBeenCalledOnce();
+		restore();
+	});
+
+	it("leaves a live shell alone", async () => {
+		const onShellExited = vi.fn();
+		const { restore } = renderShellPane(onShellExited, "attached");
+		await waitFor(() => expect(screen.getByTestId("xterm")).toBeInTheDocument());
+		expect(onShellExited).not.toHaveBeenCalled();
+		restore();
+	});
+
+	// A session pane that ends still has a row, a status, and a restore path, so
+	// its tab must survive. Only shells are retired.
+	it("does not retire a session pane that ended", async () => {
+		const onShellExited = vi.fn();
+		terminalState.value = "exited";
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const previousAO = window.ao;
+		window.ao = {} as typeof window.ao;
+		render(
+			<QueryClientProvider client={queryClient}>
+				<TerminalPane daemonReady fontSize={12} onShellExited={onShellExited} session={worker} theme="dark" />
+			</QueryClientProvider>,
+		);
+		await waitFor(() => expect(screen.getByText("Terminal ended")).toBeInTheDocument());
+		expect(onShellExited).not.toHaveBeenCalled();
+		window.ao = previousAO;
+	});
+});

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -19,13 +19,38 @@ type TerminalPaneProps = {
 	daemonReady: boolean;
 	terminalTarget?: TerminalTarget;
 	fontSize: number;
+	/**
+	 * Fired once when a shell pane reports its PTY ended (the user typed `exit`,
+	 * killed the process — or the attach loop gave up). Nothing else tells the
+	 * client: the shell list is only refetched around this client's own
+	 * open/close.
+	 */
+	onShellExited?: (handleId: string) => void;
+	/**
+	 * Bumped to force a fresh attachment for the same handle. A pane that
+	 * reported "exited" holds that state forever, so when the daemon says the
+	 * shell is in fact still alive, the only way back to a live terminal is to
+	 * remount the attachment.
+	 */
+	attachEpoch?: number;
 };
 
-export function TerminalPane({ session, theme, daemonReady, terminalTarget, fontSize }: TerminalPaneProps) {
-	const terminalKey =
+export function TerminalPane({
+	session,
+	theme,
+	daemonReady,
+	terminalTarget,
+	fontSize,
+	onShellExited,
+	attachEpoch = 0,
+}: TerminalPaneProps) {
+	const handleKey =
 		terminalTarget?.kind === "reviewer" || terminalTarget?.kind === "shell"
 			? terminalTarget.handleId
 			: (session?.terminalHandleId ?? "empty");
+	// The epoch is part of the key so a bump remounts the attachment for the
+	// same handle, which is what recovers a pane stuck on a false "exited".
+	const terminalKey = `${handleKey}:${attachEpoch}`;
 
 	if (!window.ao) {
 		// A standalone shell has no agent and no branch, so it previews as a plain
@@ -85,6 +110,7 @@ export function TerminalPane({ session, theme, daemonReady, terminalTarget, font
 			theme={theme}
 			daemonReady={daemonReady}
 			fontSize={fontSize}
+			onShellExited={onShellExited}
 			terminalTarget={terminalTarget}
 		/>
 	);
@@ -220,7 +246,7 @@ function bannerText(state: TerminalSessionState, error?: string): string | undef
 	return undefined;
 }
 
-function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSize }: TerminalPaneProps) {
+function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSize, onShellExited }: TerminalPaneProps) {
 	const attachSession =
 		session && terminalTarget?.kind === "reviewer"
 			? { ...session, terminalHandleId: terminalTarget.handleId }
@@ -274,6 +300,29 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 		terminalTarget?.kind !== "shell" &&
 		session !== undefined &&
 		!isSessionActive;
+
+	// A shell whose PTY exits leaves a tab that can never be attached again, so
+	// retire it instead of parking a dead pane in the strip.
+	//
+	// This is a HINT, never a close. "exited" does not prove the shell died:
+	// attachment.fail() reaches the same markExited() after the liveness probe
+	// or the attach itself errors past the retry cap, and a probe error is not
+	// proof of death. Destroying on that would kill a live shell and whatever
+	// is running in it. So this only asks the daemon to re-check — its list
+	// prunes a shell it can confirm is gone and deliberately KEEPS one whose
+	// probe errored.
+	//
+	// Reported once per pane: the component is keyed by handle, so a later
+	// shell on the same tab mounts fresh. Only for shells — a session pane that
+	// ends still has a row, a status, and a restore path, so its tab must stay.
+	const reportedShellExitRef = useRef(false);
+	useEffect(() => {
+		if (state !== "exited") return;
+		if (terminalTarget?.kind !== "shell") return;
+		if (reportedShellExitRef.current) return;
+		reportedShellExitRef.current = true;
+		onShellExited?.(terminalTarget.handleId);
+	}, [state, terminalTarget, onShellExited]);
 
 	const handleReady = useCallback((handle: AttachableTerminal) => {
 		setTerminal(handle);

--- a/frontend/src/renderer/hooks/useShellTerminals.test.tsx
+++ b/frontend/src/renderer/hooks/useShellTerminals.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const { deleteMock } = vi.hoisted(() => ({ deleteMock: vi.fn() }));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { DELETE: deleteMock },
+	hasTrustedApiBaseUrl: () => true,
+}));
+
+import { shellTerminalsQueryKey, useCloseShellTerminal, type ShellTerminal } from "./useShellTerminals";
+
+const shells: ShellTerminal[] = [
+	{ handleId: "sh-a", workingDir: "/p", title: "one", createdAt: "2026-07-29T00:00:00Z" },
+	{ handleId: "sh-b", workingDir: "/q", title: "two", createdAt: "2026-07-29T00:00:00Z" },
+];
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+	return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function cachedHandleIds() {
+	return (queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? []).map((s) => s.handleId);
+}
+
+beforeEach(() => {
+	deleteMock.mockReset();
+	queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	queryClient.setQueryData(shellTerminalsQueryKey, shells);
+});
+
+describe("useCloseShellTerminal", () => {
+	// The daemon reaps the pane's leftover processes before answering the DELETE,
+	// which took seconds. Waiting on that round trip left a dead tab on screen,
+	// so the close must land in the cache before the request resolves.
+	it("drops the tab before the daemon answers", async () => {
+		let resolveDelete: (value: { error: undefined }) => void = () => undefined;
+		deleteMock.mockReturnValue(
+			new Promise<{ error: undefined }>((resolve) => {
+				resolveDelete = resolve;
+			}),
+		);
+
+		const { result } = renderHook(() => useCloseShellTerminal(), { wrapper });
+		result.current.mutate("sh-a");
+
+		// Still in flight, and the tab is already gone.
+		await waitFor(() => expect(cachedHandleIds()).toEqual(["sh-b"]));
+		expect(deleteMock).toHaveBeenCalledOnce();
+
+		resolveDelete({ error: undefined });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	// The refetch on settle is the rollback: a close that genuinely failed leaves
+	// the shell in the daemon's list, so it comes straight back into the strip.
+	it("restores the tab when the close fails", async () => {
+		deleteMock.mockResolvedValue({ error: { message: "boom" } });
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+		const { result } = renderHook(() => useCloseShellTerminal(), { wrapper });
+		result.current.mutate("sh-a");
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: shellTerminalsQueryKey });
+	});
+});

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -117,8 +117,19 @@ export function useCloseShellTerminal() {
 			});
 			if (error) throw error;
 		},
+		// Drop the tab before the request goes out. The daemon's DELETE reaps the
+		// pane's leftover processes before it answers, so waiting on the round
+		// trip left a dead tab on screen for seconds after the click.
+		onMutate: async (handleId) => {
+			await queryClient.cancelQueries({ queryKey: shellTerminalsQueryKey });
+			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
+				(current ?? []).filter((shell) => shell.handleId !== handleId),
+			);
+		},
 		// Settled, not success: a close that 404s means the daemon already lost
-		// the shell, and the stale tab still needs to disappear.
+		// the shell, and the stale tab still needs to disappear. This refetch is
+		// also the rollback — a close that genuinely failed leaves the shell in
+		// the daemon's list, so it comes straight back into the strip.
 		onSettled: () => {
 			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
 		},

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -4,6 +4,7 @@
 // must not invalidate session state when they come and go.
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 import type { components } from "../../api/schema";
 import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { mockShellTerminals } from "../lib/mock-data";
@@ -40,6 +41,20 @@ function toShellTerminal(t: components["schemas"]["ShellTerminalResponse"]): She
 let previewShellTerminals: ShellTerminal[] = [...mockShellTerminals];
 let previewShellSeq = 0;
 
+// Same rule the daemon uses: one past the highest number already on screen for
+// this session, so closing "Terminal 1" does not hand the next tab that name
+// while "Terminal 2" is still open.
+function previewSessionTerminalTitle(sessionId: string): string {
+	const highest = previewShellTerminals
+		.filter((shell) => shell.sessionId === sessionId)
+		.reduce((max, shell) => {
+			const match = /^Terminal (\d+)$/.exec(shell.title);
+			const n = match ? Number(match[1]) : 0;
+			return n > max ? n : max;
+		}, 0);
+	return `Terminal ${highest + 1}`;
+}
+
 async function fetchShellTerminals(): Promise<ShellTerminal[]> {
 	if (usePreviewData) {
 		return previewShellTerminals;
@@ -65,6 +80,26 @@ export function useShellTerminals() {
 	return useQuery(shellTerminalsQueryOptions);
 }
 
+/**
+ * Asks the daemon to re-check its shell list and resolves to the refreshed
+ * list. Used when a pane reports that its PTY ended: that signal is not proof
+ * of death (the attach loop reports the same "exited" after it gives up on a
+ * failing liveness probe), so the client must not close anything itself. The
+ * daemon's list prunes only shells it can confirm are gone and keeps ones whose
+ * probe errored, which is exactly the conservative rule this needs.
+ *
+ * The returned list is what tells the caller which happened: a handle still in
+ * it means the shell is alive and the pane must re-attach rather than sit on a
+ * stale "exited".
+ */
+export function useRefreshShellTerminals() {
+	const queryClient = useQueryClient();
+	return useCallback(async (): Promise<ShellTerminal[]> => {
+		await queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+		return queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? [];
+	}, [queryClient]);
+}
+
 export type OpenShellTerminalInput = { projectId?: string; sessionId?: string };
 
 /**
@@ -78,12 +113,18 @@ export function useOpenShellTerminal() {
 		mutationFn: async ({ projectId, sessionId }: OpenShellTerminalInput = {}): Promise<ShellTerminal> => {
 			if (usePreviewData) {
 				previewShellSeq += 1;
+				// Mirror the daemon: a session's shells start in that session's
+				// worktree and are numbered within it, standalone shells start in
+				// the project root and are named after it. The mock used to stamp
+				// the project name on every tab, which is not what the app does.
 				const shell: ShellTerminal = {
 					handleId: `shellterm-preview-${previewShellSeq}`,
 					projectId,
 					sessionId,
-					workingDir: `/Users/demo/Projects/${projectId ?? "ao"}`,
-					title: projectId ?? "shell",
+					workingDir: sessionId
+						? `/Users/demo/.ao/data/worktrees/${projectId ?? "ao"}/${sessionId}`
+						: `/Users/demo/Projects/${projectId ?? "ao"}`,
+					title: sessionId ? previewSessionTerminalTitle(sessionId) : (projectId ?? "shell"),
 					createdAt: new Date().toISOString(),
 				};
 				previewShellTerminals = [...previewShellTerminals, shell];

--- a/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
@@ -1,16 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SessionView } from "../components/SessionView";
 
-type SessionSearch = { tabOwner?: string };
-
 export const Route = createFileRoute("/_shell/projects/$projectId_/sessions/$sessionId")({
-	validateSearch: (search: Record<string, unknown>): SessionSearch =>
-		typeof search.tabOwner === "string" ? { tabOwner: search.tabOwner } : {},
 	component: ProjectSessionRoute,
 });
 
 function ProjectSessionRoute() {
 	const { sessionId } = Route.useParams();
-	const { tabOwner } = Route.useSearch();
-	return <SessionView sessionId={sessionId} tabOwnerSessionId={tabOwner} />;
+	return <SessionView sessionId={sessionId} />;
 }

--- a/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
@@ -1,16 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SessionView } from "../components/SessionView";
 
-type SessionSearch = { tabOwner?: string };
-
 export const Route = createFileRoute("/_shell/sessions/$sessionId")({
-	validateSearch: (search: Record<string, unknown>): SessionSearch =>
-		typeof search.tabOwner === "string" ? { tabOwner: search.tabOwner } : {},
 	component: SessionRoute,
 });
 
 function SessionRoute() {
 	const { sessionId } = Route.useParams();
-	const { tabOwner } = Route.useSearch();
-	return <SessionView sessionId={sessionId} tabOwnerSessionId={tabOwner} />;
+	return <SessionView sessionId={sessionId} />;
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { CommandPalette } from "../components/CommandPalette";
@@ -133,11 +133,6 @@ function ShellLayout() {
 	const [isSidebarPeekOpen, setIsSidebarPeekOpen] = useState(false);
 	const sidebarPeekCloseTimerRef = useRef<number | undefined>(undefined);
 	const routeParams = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
-	const routeSearch = useSearch({ strict: false }) as { tabOwner?: string };
-	const tabOwnerSession = routeSearch.tabOwner
-		? workspaces.flatMap((workspace) => workspace.sessions).find((session) => session.id === routeSearch.tabOwner)
-		: undefined;
-	const tabOwnerSessionId = tabOwnerSession?.id;
 	useEffect(() => {
 		document.addEventListener("click", handleModifierLinkClick);
 		return () => document.removeEventListener("click", handleModifierLinkClick);
@@ -560,10 +555,7 @@ function ShellLayout() {
 		if (handledShellNonceRef.current === newShellTerminalNonce) return;
 		handledShellNonceRef.current = newShellTerminalNonce;
 		openShellTerminal.mutate(
-			{
-				projectId: tabOwnerSession?.workspaceId ?? scopedProjectId,
-				sessionId: tabOwnerSessionId ?? routeParams.sessionId,
-			},
+			{ projectId: scopedProjectId, sessionId: routeParams.sessionId },
 			{
 				onSuccess: (shell) => {
 					setActiveShellTerminal(shell.handleId);
@@ -578,8 +570,6 @@ function ShellLayout() {
 		openShellTerminal,
 		scopedProjectId,
 		routeParams.sessionId,
-		tabOwnerSession?.workspaceId,
-		tabOwnerSessionId,
 		navigate,
 		setActiveShellTerminal,
 	]);

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -35,38 +35,3 @@ describe("ui-store developerMode persistence", () => {
 		expect(window.localStorage.getItem("ao.developerMode")).toBe("false");
 	});
 });
-
-describe("ui-store session tab persistence", () => {
-	beforeEach(() => {
-		window.localStorage.clear();
-		vi.resetModules();
-	});
-
-	it("keeps added tabs isolated by owner session and restores them", async () => {
-		let store = (await import("./ui-store")).useUiStore;
-		store.getState().addSessionTab("session-a", "session-c");
-		store.getState().addSessionTab("session-a", "session-d");
-		store.getState().addSessionTab("session-b", "session-c");
-
-		expect(store.getState().sessionTabsByOwner).toEqual({
-			"session-a": ["session-c", "session-d"],
-			"session-b": ["session-c"],
-		});
-
-		vi.resetModules();
-		store = (await import("./ui-store")).useUiStore;
-		expect(store.getState().sessionTabsByOwner["session-a"]).toEqual(["session-c", "session-d"]);
-	});
-
-	it("deduplicates additions and removes only the requested owner's tab", async () => {
-		const { useUiStore: store } = await import("./ui-store");
-		store.getState().addSessionTab("session-a", "session-c");
-		store.getState().addSessionTab("session-a", "session-c");
-		store.getState().addSessionTab("session-b", "session-c");
-		store.getState().removeSessionTab("session-a", "session-c");
-
-		expect(store.getState().sessionTabsByOwner).toEqual({
-			"session-b": ["session-c"],
-		});
-	});
-});

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -34,8 +34,6 @@ type UiState = {
 	workbenchTab: WorkbenchTab;
 	isSidebarOpen: boolean;
 	inspectorSessions: Record<string, InspectorSessionState>;
-	/** Extra worker tabs pinned to each originating session's terminal strip. */
-	sessionTabsByOwner: Record<string, string[]>;
 	isCommandPaletteOpen: boolean;
 	themePreference: ThemePreference;
 	/** Resolved light/dark for React consumers; may track OS while preference is system. */
@@ -78,8 +76,6 @@ type UiState = {
 	setInspectorOpen: (sessionId: string, isOpen: boolean) => void;
 	toggleInspector: (sessionId: string) => void;
 	setInspectorView: (sessionId: string, view: InspectorView) => void;
-	addSessionTab: (ownerSessionId: string, sessionId: string) => void;
-	removeSessionTab: (ownerSessionId: string, sessionId: string) => void;
 	markInspectorPreviewSeen: (sessionId: string, previewKey: string) => void;
 	setBrowserUnseen: (sessionId: string, unseen: boolean) => void;
 	setCommandPaletteOpen: (open: boolean) => void;
@@ -96,7 +92,6 @@ type UiState = {
 
 const sidebarStorageKey = "ao.sidebar.open";
 const developerModeStorageKey = "ao.developerMode";
-const sessionTabsStorageKey = "ao.sessionTabs";
 
 function getLocalStorage() {
 	if (typeof window === "undefined" || !window.localStorage) return null;
@@ -111,28 +106,6 @@ function initialDeveloperMode() {
 	return getLocalStorage()?.getItem(developerModeStorageKey) === "true";
 }
 
-function initialSessionTabs(): Record<string, string[]> {
-	const raw = getLocalStorage()?.getItem(sessionTabsStorageKey);
-	if (!raw) return {};
-	try {
-		const parsed = JSON.parse(raw) as unknown;
-		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-		return Object.fromEntries(
-			Object.entries(parsed).flatMap(([ownerSessionId, sessionIds]) =>
-				Array.isArray(sessionIds) && sessionIds.every((sessionId) => typeof sessionId === "string")
-					? [[ownerSessionId, sessionIds]]
-					: [],
-			),
-		);
-	} catch {
-		return {};
-	}
-}
-
-function storeSessionTabs(sessionTabsByOwner: Record<string, string[]>) {
-	getLocalStorage()?.setItem(sessionTabsStorageKey, JSON.stringify(sessionTabsByOwner));
-}
-
 function inspectorState(sessions: Record<string, InspectorSessionState>, sessionId: string): InspectorSessionState {
 	return sessions[sessionId] ?? { isOpen: true, view: "summary" };
 }
@@ -143,7 +116,6 @@ export const useUiStore = create<UiState>((set) => ({
 	workbenchTab: "changes",
 	isSidebarOpen: initialSidebarOpen(),
 	inspectorSessions: {},
-	sessionTabsByOwner: initialSessionTabs(),
 	isCommandPaletteOpen: false,
 	themePreference: initialThemePreference,
 	resolvedTheme: resolveTheme(initialThemePreference),
@@ -208,28 +180,6 @@ export const useUiStore = create<UiState>((set) => ({
 					[sessionId]: { ...current, view, browserUnseen },
 				},
 			};
-		}),
-	addSessionTab: (ownerSessionId, sessionId) =>
-		set((state) => {
-			const current = state.sessionTabsByOwner[ownerSessionId] ?? [];
-			if (ownerSessionId === sessionId || current.includes(sessionId)) return state;
-			const sessionTabsByOwner = {
-				...state.sessionTabsByOwner,
-				[ownerSessionId]: [...current, sessionId],
-			};
-			storeSessionTabs(sessionTabsByOwner);
-			return { sessionTabsByOwner };
-		}),
-	removeSessionTab: (ownerSessionId, sessionId) =>
-		set((state) => {
-			const current = state.sessionTabsByOwner[ownerSessionId] ?? [];
-			if (!current.includes(sessionId)) return state;
-			const remaining = current.filter((id) => id !== sessionId);
-			const sessionTabsByOwner = { ...state.sessionTabsByOwner };
-			if (remaining.length > 0) sessionTabsByOwner[ownerSessionId] = remaining;
-			else delete sessionTabsByOwner[ownerSessionId];
-			storeSessionTabs(sessionTabsByOwner);
-			return { sessionTabsByOwner };
 		}),
 	markInspectorPreviewSeen: (sessionId, previewKey) =>
 		set((state) => {

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -16,7 +16,6 @@ const shellMocks = vi.hoisted(() => {
 		nextSessionListener: undefined as (() => void) | undefined,
 		focusTerminalListener: undefined as (() => void) | undefined,
 		routeParams: {} as { projectId?: string; sessionId?: string },
-		routeSearch: {} as { tabOwner?: string },
 		workspaces: [] as WorkspaceSummary[],
 		workspaceQuery: {
 			data: [] as WorkspaceSummary[],
@@ -88,7 +87,6 @@ vi.mock("@tanstack/react-router", async (importOriginal) => ({
 	useMatchRoute: () => () => false,
 	useNavigate: () => shellMocks.navigate,
 	useParams: () => shellMocks.state.routeParams,
-	useSearch: () => shellMocks.state.routeSearch,
 }));
 
 vi.mock("../lib/bridge", () => ({
@@ -262,7 +260,6 @@ beforeEach(() => {
 	shellMocks.state.nextSessionListener = undefined;
 	shellMocks.state.focusTerminalListener = undefined;
 	shellMocks.state.routeParams = {};
-	shellMocks.state.routeSearch = {};
 	shellMocks.state.workspaces = workspaces;
 	shellMocks.state.workspaceQuery = {
 		data: workspaces,
@@ -453,19 +450,6 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 	// session's own worktree instead of the registered project root.
 	it("scopes the terminal to the session in scope", async () => {
 		shellMocks.state.routeParams = { sessionId: "sess-1" };
-		await renderShell();
-
-		pressNewShellTerminal();
-
-		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
-			expect.objectContaining({ projectId: "proj-1", sessionId: "sess-1" }),
-			expect.anything(),
-		);
-	});
-
-	it("scopes the terminal to the originating session while viewing one of its pinned tabs", async () => {
-		shellMocks.state.routeParams = { projectId: "proj-2", sessionId: "sess-cross" };
-		shellMocks.state.routeSearch = { tabOwner: "sess-1" };
 		await renderShell();
 
 		pressNewShellTerminal();


### PR DESCRIPTION
## Problem

https://github.com/Untrivial-ai/agent-orchestrator/pull/3138 let a session's terminal strip pin tabs for *other* sessions, across projects. Two things came out of that:

- The strip stopped being about one session. Session 1's tab bar could show session 2's terminal, which makes it ambiguous which session you are typing into.
- The everyday action, "open a terminal", moved behind a dropdown whose first item was "Terminal", so one click became two.

## Change

The strip is one session's own again: its tab, then the shells it opened.

- The `+` opens a terminal on a single click. The session launcher, its search box, and the "Show all sessions" list are gone.
- The session's own tab is the first tab and has no close affordance. Ending a session stays the topbar's Kill.
- Removed the cross-session plumbing: the `tabOwner` search param on both session routes, `sessionTabsByOwner` and its localStorage persistence, and the add/close/select project-session props on `CenterPane`. Net 543 deletions against 149 insertions.
- Closing a shell now drops the tab optimistically instead of waiting on the round trip.

## On the close latency

The optimistic update is only half of it. The daemon's DELETE blocks for about 5 seconds before answering, which is a separate bug with its own root cause on the Go side; that fix is https://github.com/Untrivial-ai/agent-orchestrator/pull/3328. This PR makes the tab disappear on click regardless of how long the daemon takes.

## Verification

Drove the renderer in a browser: `+` adds a terminal with no menu in the DOM, right click no longer produces a launcher, the session tab has no close button, and the tab disappears on click. A unit test pins the optimistic behavior properly by holding the DELETE unresolved and asserting the tab has already left the query cache, which the browser run could not prove on its own since the preview build has no daemon.

`npm test` (1184 tests, 92 files) and `npm run typecheck` both pass.

## Pre-existing failures, not addressed here

`frontend/e2e/shell-terminal-tabs.spec.ts` has two failures that #3138 introduced. Confirmed against a detached worktree at `6b6190deb`, so they predate this branch, and they fail at the same points with it applied:

- The board-route test expects a "New terminal" button on `/#/projects/:id`, and nothing renders one there anymore.
- The session-route test gets further with this branch (the button is found and opens a terminal again) but then fails at `getByTitle("Session terminal")`: the session tab only carries that title when its label is not truncated (`CenterPane.tsx`), and the demo label truncates.

Both are worth their own fix. The second overlaps the tab-bar visual pass, which is deliberately not in this PR.
