### PR TITLE
fix(landing): add a descriptive homepage title

### DIFF
--- a/frontend/src/landing/src/app/layout.tsx
+++ b/frontend/src/landing/src/app/layout.tsx
@@ -29,7 +29,7 @@ const siteDescription =
 export const metadata: Metadata = {
   metadataBase: new URL(COMPANY.MARKETING_URL),
   title: {
-    default: COMPANY.NAME,
+    default: `Run Coding Agents in Parallel | ${COMPANY.NAME}`,
     template: `%s | ${COMPANY.NAME}`,
   },
   description: siteDescription,


### PR DESCRIPTION
## Changes

- replace the bare homepage metadata default with `Run Coding Agents in Parallel | Agent Orchestrator`
- preserve the existing `%s | Agent Orchestrator` template for child pages

## Why

The homepage did not define its own title and inherited `Agent Orchestrator`, leaving the primary search headline without a product description or relevant keywords.

## Impact

The homepage title is now descriptive, 50 characters long, and contains the brand once. Child-page title behavior is unchanged.

## Root cause

The root metadata default used `COMPANY.NAME`, while the homepage metadata only supplied a canonical URL.

## Checks

- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

Closes #3297