### PR TITLE
fix(macos): address the seven review findings from #3294

### DIFF
--- a/.github/workflows/mac-update-e2e.yml
+++ b/.github/workflows/mac-update-e2e.yml
@@ -4,33 +4,49 @@ name: macOS update e2e
 # point it at version N's REAL published feed, and prove the update downloads,
 # stages, installs, and that the relaunched app both reports N and is alive.
 #
-# This is the check that would have caught both #3034 and the 29 Jul incident
-# before any user saw them. The interesting logic lives in
-# frontend/scripts/e2e-mac-update.mjs; this job only supplies a real macOS host
-# and a real signed baseline install.
+# This is the check that would have caught both #3034 and the 29 Jul incident.
+# The interesting logic lives in frontend/scripts/e2e-mac-update.mjs; this job
+# only supplies a real macOS host and a real signed baseline install.
 #
-# Deliberately NOT wired into any release workflow yet:
+# THIS IS POST-RELEASE MONITORING, NOT A PROMOTION GATE. Read that literally
+# before wiring it anywhere.
+#
+# The app resolves the update through the REAL published GitHub feed, so this
+# job cannot start until version N's release and its latest-mac.yml are already
+# public. By then every real stable client can already see and take that update,
+# and the run takes tens of minutes. A check that finishes after the thing it
+# guards has shipped is not a gate; calling it one would be worse than not
+# having it, because it invites someone to trust it as a pre-promotion barrier.
+# So: run it right after a release lands and treat a failure as "pull or hotfix
+# the release you just published", not "block the release you are about to".
+#
+# What it would take to make it a real pre-promotion gate: an isolated candidate
+# feed that real clients never see, with the public feed promoted only after the
+# check passes. The mechanism for that already exists in principle (the
+# AO_RELEASE_REPO build-time override, #3267 decision 8 step 3, which publishes
+# to a non-production repo), but pointing this job at one requires the private
+# signing/release pipeline to build and publish a candidate there. That pipeline
+# is a separate repo and out of scope here, so the honest description today is
+# monitoring. Do not re-label this without that isolated feed existing.
+#
+# Deliberately NOT wired into any release workflow, and not to be wired in as
+# part of this file's current shape:
 #   - The release workflows are paused, and un-pausing them is a separate
 #     decision that does not belong to this change.
 #   - macOS runner minutes are materially more expensive than Linux, and this
-#     project ships nightlies frequently. #3288 recommends making this a hard
-#     required gate on promotion to the STABLE channel specifically (the exact
-#     transition that failed in production), and treating nightly-to-nightly
-#     coverage as optional pending real per-run cost data. The "cost" step below
-#     prints the wall clock so that question can be settled with numbers.
+#     project ships nightlies frequently. #3288 recommends concentrating spend on
+#     promotion to the STABLE channel specifically (the exact transition that
+#     failed in production), and treating nightly-to-nightly coverage as optional
+#     pending real per-run cost data. The "cost" step below prints the wall clock
+#     so that question can be settled with numbers.
 #
-# To wire it as a stable-promotion gate later, call it from the release
-# workflow:
-#
-#   update-e2e:
-#     uses: ./.github/workflows/mac-update-e2e.yml
-#     with:
-#       baseline_tag: v<previous stable>
-#       target_version: <new version>
-#
-# Requires: the baseline release's signed macOS zip must be published, and the
-# target version's release + latest-mac.yml feed must already be live, since the
-# app resolves the update through the real GitHub feed.
+# Requires, both hard:
+#   - The baseline release's signed macOS zip is published, AND that baseline is
+#     new enough to carry the AO_E2E_UPDATE_SENTINEL listener (added by #3288
+#     workstream 0). Older baselines ignore the env var and can only ever time
+#     out. The harness checks this explicitly and fails in seconds; see the
+#     "Check the baseline can signal staging" step below.
+#   - The target version's release and latest-mac.yml feed are already live.
 
 on:
   workflow_dispatch:
@@ -109,6 +125,27 @@ jobs:
           ditto -x -k "$RUNNER_TEMP/baseline/agent-orchestrator-darwin-arm64.zip" /Applications
           plutil -extract CFBundleShortVersionString raw -o - \
             "/Applications/Agent Orchestrator.app/Contents/Info.plist"
+
+      - name: Check the baseline can signal staging
+        # The harness waits on AO_E2E_UPDATE_SENTINEL, and that listener only
+        # exists from #3288 workstream 0 onward. A baseline published before it
+        # ignores the env var entirely, so the run could only ever burn the full
+        # 20 minute download timeout and report a "never staged" failure that
+        # looks like a broken update. Same check the harness makes, hoisted into
+        # its own step so an incapable baseline is unmistakable in the log.
+        run: |
+          set -euo pipefail
+          node --input-type=module -e '
+            import { assertSentinelCapable } from "./frontend/scripts/e2e-mac-update.mjs";
+            const app = "/Applications/Agent Orchestrator.app";
+            try {
+              assertSentinelCapable(app);
+            } catch (err) {
+              console.error(`::error::${err.message}`);
+              process.exit(1);
+            }
+            console.log("baseline supports AO_E2E_UPDATE_SENTINEL");
+          '
 
       - name: Run the update end to end
         env:

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -1,7 +1,7 @@
 import type { ForgeConfig } from "@electron-forge/shared-types";
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import MakerNSIS from "./makers/maker-nsis";
-import MakerDMG, { sealDmg } from "./makers/maker-dmg";
+import MakerDMG, { sealDmg, verifyDmg } from "./makers/maker-dmg";
 import MakerAppImage from "./makers/maker-appimage";
 import { writeFileSync } from "node:fs";
 
@@ -88,11 +88,20 @@ const config: ForgeConfig = {
 		// same credentials packagerConfig already consumes (#3267 decision 3).
 		// The .app inside was already signed + notarized + stapled by
 		// packagerConfig above, before any maker ran; nothing here touches it.
+		//
+		// Then PROVE the seal. sealDmg exiting 0 only says three commands ran on
+		// this machine; it does not say Gatekeeper accepts the published bytes with
+		// a stapled ticket. verify-mac-artifact.sh is the canonical gate for that
+		// (#3288 workstreams 1 and 2), and #3267 decision 3 step 4 asks for exactly
+		// this check on the dmg. Run only when sealDmg actually sealed: an unsigned
+		// local or desktop-testing build has nothing to verify and must keep
+		// producing its dmg.
 		postMake: async (_forgeConfig, makeResults) => {
 			for (const result of makeResults) {
 				if (result.platform !== "darwin") continue;
 				for (const artifact of result.artifacts) {
-					if (artifact.endsWith(".dmg")) await sealDmg(artifact);
+					if (!artifact.endsWith(".dmg")) continue;
+					if (await sealDmg(artifact)) await verifyDmg(artifact);
 				}
 			}
 			return makeResults;

--- a/frontend/makers/maker-dmg.test.ts
+++ b/frontend/makers/maker-dmg.test.ts
@@ -165,12 +165,11 @@ describe("sealDmg", () => {
 		expect(commands).toEqual([]);
 	});
 
-	it("throws on a partial App Store Connect key trio", async () => {
-		// An incomplete trio resolves to no notary args at all, so with an identity
-		// set this is the signed-but-unnotarized case, not the local no-op.
+	it("throws on a partial App Store Connect key trio even without a signing identity", async () => {
 		await expect(
-			sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "id", APPLE_API_KEY: "/tmp/key.p8", APPLE_API_KEY_ID: "KEYID" }),
-		).rejects.toThrow(/no notarization credentials/);
+			sealDmg(dmg, { APPLE_API_KEY: "/tmp/key.p8", APPLE_API_KEY_ID: "KEYID" }),
+		).rejects.toThrow(/incomplete App Store Connect credentials/);
+		expect(commands).toEqual([]);
 	});
 
 	it("signs, notarizes with a keychain profile, and staples", async () => {

--- a/frontend/makers/maker-dmg.test.ts
+++ b/frontend/makers/maker-dmg.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fileURLToPath } from "node:url";
 
 // Capture buildForge's args without pulling in electron-builder's real machinery.
 const buildForge = vi.fn<(forge: { dir: string }, options: any) => Promise<string[]>>(async () => [
@@ -31,7 +32,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 	return { ...actual, default: { ...actual, execFile }, execFile };
 });
 
-import MakerDMG, { sealDmg } from "./maker-dmg";
+import MakerDMG, { sealDmg, verifyDmg } from "./maker-dmg";
 
 const makeOptions = {
 	dir: "/tmp/app/Agent Orchestrator-darwin-arm64",
@@ -42,6 +43,11 @@ const makeOptions = {
 	forgeConfig: {} as never,
 	packageJSON: {},
 };
+
+// What Forge actually hands the maker: `dir` is the PACKAGE directory and the
+// bundle sits inside it. electron-builder's mac path treats buildForge's `dir`
+// as the .app itself, so this is the only correct value to pass through.
+const APP_PATH = "/tmp/app/Agent Orchestrator-darwin-arm64/Agent Orchestrator.app";
 
 beforeEach(() => {
 	buildForge.mockClear();
@@ -65,13 +71,36 @@ describe("MakerDMG", () => {
 		const artifacts = await maker.make(makeOptions);
 
 		expect(artifacts).toEqual(["/out/make/Agent Orchestrator-0.10.3-arm64.dmg"]);
-		const [forgeOptions, options] = buildForge.mock.calls[0];
-		expect(forgeOptions).toEqual({ dir: makeOptions.dir });
+		const [, options] = buildForge.mock.calls[0];
 		expect(options.mac).toEqual(["dmg:arm64"]);
 		// electron-builder must not try to publish; the workflow does that.
 		expect(options.config.publish).toBeNull();
 		expect(options.config.appId).toBe("dev.agent-orchestrator.desktop");
 		expect(options.config.productName).toBe("Agent Orchestrator");
+	});
+
+	// The layout check. buildForge sets `prepackaged: resolve(dir)`, and
+	// macPackager.packMacTargets uses prepackaged AS the app path
+	// (`appPath = prepackaged ?? join(computeAppOutDir(...), "<name>.app")`), then
+	// dmg-builder copies appPath into the image renamed to "<name>.app". Passing
+	// Forge's package directory here nests the whole directory under that name and
+	// yields "Agent Orchestrator.app/Agent Orchestrator.app", an outer bundle with
+	// no Contents that cannot launch. Verified against app-builder-lib 26.15.3.
+	it("hands buildForge the .app inside the package dir, not the package dir", async () => {
+		await new MakerDMG().make(makeOptions);
+		const [forgeOptions] = buildForge.mock.calls.at(-1)!;
+		expect(forgeOptions).toEqual({ dir: APP_PATH });
+		expect(forgeOptions.dir).not.toBe(makeOptions.dir);
+	});
+
+	// buildForge's own default output is dirname(dir)/make, which was correct only
+	// while `dir` was the package directory. Now that we pass the .app, that
+	// default would land in <packageDir>/make, so the explicit override has to be
+	// Forge's own makeDir.
+	it("writes artifacts to Forge's makeDir, not a path derived from the .app", async () => {
+		await new MakerDMG().make(makeOptions);
+		const [, options] = buildForge.mock.calls.at(-1)!;
+		expect(options.config.directories.output).toBe(makeOptions.makeDir);
 	});
 
 	it("never lets electron-builder re-sign the already notarized .app", () => {
@@ -90,19 +119,69 @@ describe("MakerDMG", () => {
 		// sealDmg signs + notarizes + staples the container instead.
 		expect(options.config.dmg.sign).toBe(false);
 	});
+
+	// dmg-builder 26.15.3 defaults writeUpdateInfo ON, and DmgTarget.build then
+	// calls createBlockmap BEFORE postMake's sealDmg rewrites the dmg bytes. macOS
+	// ships full-download-only permanently (#3151, #3267 decision 4), so the
+	// sidecar is both against policy and stale on arrival.
+	it("disables dmg blockmap generation", async () => {
+		await new MakerDMG().make(makeOptions);
+		const [, options] = buildForge.mock.calls.at(-1)!;
+		expect(options.config.dmg.writeUpdateInfo).toBe(false);
+	});
+
+	it("never returns a dmg blockmap among the artifacts", async () => {
+		buildForge.mockResolvedValueOnce([
+			"/out/make/Agent Orchestrator-0.10.3-arm64.dmg",
+			"/out/make/Agent Orchestrator-0.10.3-arm64.dmg.blockmap",
+		]);
+		// This array is exactly what Forge hands its publisher, so filtering here is
+		// what keeps a sidecar off the release regardless of how it got generated.
+		expect(await new MakerDMG().make(makeOptions)).toEqual(["/out/make/Agent Orchestrator-0.10.3-arm64.dmg"]);
+	});
 });
 
 describe("sealDmg", () => {
 	const dmg = "/out/make/app.dmg";
 
-	it("does nothing when there is no signing material (unsigned local builds)", async () => {
-		await sealDmg(dmg, {});
+	it("does nothing when there is no signing material at all (unsigned local builds)", async () => {
+		// The ONLY tolerated incomplete state: no identity and no notary creds.
+		// desktop-testing.yml and a plain local `npm run make` rely on this.
+		expect(await sealDmg(dmg, {})).toBe(false);
 		expect(commands).toEqual([]);
 	});
 
-	it("signs, notarizes with a keychain profile, and staples", async () => {
-		await sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "Developer ID Application: Someone (TEAMID)", AO_NOTARY_PROFILE: "ao" });
+	// Partial credentials used to fail OPEN in both directions: an identity with
+	// no notary creds warned and returned success (publishing a signed but
+	// unnotarized dmg), and notary creds with no identity returned before doing
+	// anything. Both now fail the build.
+	it("throws when a signing identity is present but notary credentials are not", async () => {
+		await expect(sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "id" })).rejects.toThrow(/no notarization credentials/);
+		expect(commands).toEqual([]);
+	});
 
+	it("throws when notary credentials are present but a signing identity is not", async () => {
+		await expect(sealDmg(dmg, { AO_NOTARY_PROFILE: "ao" })).rejects.toThrow(/no signing identity/);
+		expect(commands).toEqual([]);
+	});
+
+	it("throws on a partial App Store Connect key trio", async () => {
+		// An incomplete trio resolves to no notary args at all, so with an identity
+		// set this is the signed-but-unnotarized case, not the local no-op.
+		await expect(
+			sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "id", APPLE_API_KEY: "/tmp/key.p8", APPLE_API_KEY_ID: "KEYID" }),
+		).rejects.toThrow(/no notarization credentials/);
+	});
+
+	it("signs, notarizes with a keychain profile, and staples", async () => {
+		const sealed = await sealDmg(dmg, {
+			APPLE_SIGNING_IDENTITY: "Developer ID Application: Someone (TEAMID)",
+			AO_NOTARY_PROFILE: "ao",
+		});
+
+		// The return value gates postMake's verify step: only a sealed dmg can pass
+		// verify-mac-artifact.sh, so an unsigned local build must report false.
+		expect(sealed).toBe(true);
 		expect(commands[0]).toEqual([
 			"codesign",
 			["--sign", "Developer ID Application: Someone (TEAMID)", "--timestamp", "--force", dmg],
@@ -133,18 +212,32 @@ describe("sealDmg", () => {
 	});
 
 	it("falls back to the keychain identity prefix when only CSC_LINK is set", async () => {
-		await sealDmg(dmg, { CSC_LINK: "base64p12" });
+		await sealDmg(dmg, { CSC_LINK: "base64p12", AO_NOTARY_PROFILE: "ao" });
 		expect(commands[0][1]).toEqual(["--sign", "Developer ID Application", "--timestamp", "--force", dmg]);
-	});
-
-	it("signs but skips notarization when no notary credentials are present", async () => {
-		await sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "id" });
-		expect(commands).toHaveLength(1);
-		expect(commands[0][0]).toBe("codesign");
 	});
 
 	it("fails the build when signing fails and credentials were present", async () => {
 		nextError = new Error("codesign: no identity found");
-		await expect(sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "id" })).rejects.toThrow(/no identity found/);
+		await expect(sealDmg(dmg, { APPLE_SIGNING_IDENTITY: "id", AO_NOTARY_PROFILE: "ao" })).rejects.toThrow(
+			/no identity found/,
+		);
+	});
+});
+
+describe("verifyDmg", () => {
+	const dmg = "/out/make/app.dmg";
+	// Any file that exists; verifyDmg only shells out to it, and execFile is stubbed.
+	const existingScript = fileURLToPath(import.meta.url);
+
+	it("runs the canonical verifier script on the dmg", async () => {
+		// Sealing proves three commands exited 0 here; only the canonical script
+		// proves Gatekeeper accepts the bytes with a stapled ticket (#3288 ws 1/2).
+		await verifyDmg(dmg, existingScript);
+		expect(commands).toEqual([["bash", [existingScript, dmg]]]);
+	});
+
+	it("fails loudly rather than silently skipping when the script is missing", async () => {
+		await expect(verifyDmg(dmg, "/no/such/verify-mac-artifact.sh")).rejects.toThrow(/not found/);
+		expect(commands).toEqual([]);
 	});
 });

--- a/frontend/makers/maker-dmg.ts
+++ b/frontend/makers/maker-dmg.ts
@@ -71,9 +71,6 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
 		// appName is Forge's filenamify'd packagerConfig.name, the same name
 		// @electron/packager gives the bundle inside `dir`.
 		const appPath = path.join(dir, `${appName}.app`);
-		// Forge already computed <out>/make and passes it as makeDir; use it rather
-		// than re-deriving from a path that no longer points at the package dir.
-		const output = makeDir;
 		const artifacts = await buildForge(
 			{ dir: appPath },
 			{
@@ -81,7 +78,10 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
 				config: {
 					appId: cfg.appId,
 					productName: cfg.productName ?? appName,
-					directories: { output },
+					// Forge already computed <out>/make and passes it as makeDir. Use it
+					// rather than letting buildForge default to dirname(dir)/make, which
+					// now that `dir` is the .app would land inside the package directory.
+					directories: { output: makeDir },
 					// Forge owns publishing (the workflow uploads via `gh release`).
 					// `null` stops electron-builder from inferring a GitHub publish
 					// target from package.json `repository` and trying to upload.

--- a/frontend/makers/maker-dmg.ts
+++ b/frontend/makers/maker-dmg.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { existsSync } from "node:fs";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { MakerBase, type MakerOptions } from "@electron-forge/maker-base";
@@ -48,14 +49,33 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
 		return process.platform === "darwin";
 	}
 
-	async make({ dir, targetArch, appName }: MakerOptions): Promise<string[]> {
+	async make({ dir, makeDir, targetArch, appName }: MakerOptions): Promise<string[]> {
 		const { buildForge } = await import("app-builder-lib");
 		const cfg = this.config ?? {};
-		// Mirror buildForge's own output layout (<dir>/../make) so artifacts land
-		// where Forge's publisher expects them.
-		const output = path.join(path.dirname(path.resolve(dir)), "make");
-		return buildForge(
-			{ dir },
+		// buildForge's `dir` becomes electron-builder's `prepackaged`, and on macOS
+		// that value IS the app path: macPackager.packMacTargets does
+		// `appPath = prepackaged ?? join(computeAppOutDir(...), "<productFilename>.app")`
+		// and hands appPath straight to the dmg target, which copies it into the
+		// image renamed to "<productFilename>.app" (dmg.ts computeDmgOptions'
+		// default `contents` entry). Passing Forge's PACKAGE directory here would
+		// therefore copy the whole package dir in under that name and produce
+		// "Agent Orchestrator.app/Agent Orchestrator.app", an outer bundle with no
+		// Contents that cannot launch.
+		//
+		// maker-nsis.ts passes the bare `dir` and is correct to: winPackager goes
+		// through the generic platformPackager.pack, whose computeAppOutDir returns
+		// `prepackaged` as the app OUT DIR, and the NSIS target wants that
+		// directory. Windows has no .app wrapper, so there is nothing to descend
+		// into. The asymmetry is in electron-builder, not in these makers.
+		//
+		// appName is Forge's filenamify'd packagerConfig.name, the same name
+		// @electron/packager gives the bundle inside `dir`.
+		const appPath = path.join(dir, `${appName}.app`);
+		// Forge already computed <out>/make and passes it as makeDir; use it rather
+		// than re-deriving from a path that no longer points at the package dir.
+		const output = makeDir;
+		const artifacts = await buildForge(
+			{ dir: appPath },
 			{
 				mac: [`dmg:${targetArch}`],
 				config: {
@@ -79,11 +99,24 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
 						// with notarization requirements." The dmg container is sealed
 						// afterwards by sealDmg() in forge.config.ts's postMake hook.
 						sign: false,
+						// dmg-builder defaults writeUpdateInfo ON: DmgTarget.build does
+						// `this.options.writeUpdateInfo === false ? null : createBlockmap(...)`.
+						// Two reasons that is wrong for us. It contradicts the permanent
+						// full-download-only baseline for macOS (#3151, #3267 decision 4),
+						// and the blockmap would be computed BEFORE postMake's sealDmg
+						// rewrites the dmg bytes, so the sidecar would describe a file that
+						// no longer exists by the time anything published it.
+						writeUpdateInfo: false,
 						...cfg.dmg,
 					},
 				},
 			},
 		);
+		// Enforcement, not just configuration: this array is what Forge hands its
+		// publisher, so a stale or policy-violating sidecar is filtered at the one
+		// boundary that decides what gets uploaded. Belt to writeUpdateInfo's
+		// braces, and it also covers a caller overriding it through cfg.dmg.
+		return artifacts.filter((artifact) => !artifact.endsWith(".dmg.blockmap"));
 	}
 }
 
@@ -111,7 +144,8 @@ function resolveNotaryArgs(env: NodeJS.ProcessEnv): string[] | undefined {
 }
 
 /**
- * sealDmg signs, notarizes and staples one .dmg.
+ * sealDmg signs, notarizes and staples one .dmg. Returns true when it actually
+ * sealed the file, false for the deliberate unsigned no-op.
  *
  * Neither maker-dmg nor app-builder-lib's dmg target does any of this, and the
  * .app's own stapled ticket does not propagate through an unsealed dmg
@@ -119,27 +153,45 @@ function resolveNotaryArgs(env: NodeJS.ProcessEnv): string[] | undefined {
  * Credentials are the exact same env vars packagerConfig already consumes; no
  * new secrets are introduced.
  *
- * With no signing material present this is a no-op with a warning, so unsigned
- * local builds and the unsigned desktop-testing pipeline still produce a dmg.
- * When credentials ARE present, any failure throws and fails the build: a
- * silently unsigned dmg published as a release asset is exactly the outcome
+ * There are exactly two acceptable credential states, and everything in between
+ * is a build failure:
+ *
+ *   - NEITHER a signing identity NOR notary credentials: a warned no-op. This is
+ *     the legitimate local/unsigned case and keeps unsigned local builds and the
+ *     unsigned desktop-testing pipeline producing a dmg.
+ *   - BOTH: sign, notarize, staple, and let any failure throw.
+ *
+ * A partial set fails closed in both directions. Signing material without notary
+ * credentials used to warn and return success, which let a signed-but-unnotarized
+ * dmg reach publishing; notary credentials without an identity returned even
+ * earlier and did nothing at all. Either way the release pipeline saw a green
+ * build and an artifact Gatekeeper would reject, which is precisely the outcome
  * this work exists to prevent.
  */
-export async function sealDmg(dmgPath: string, env: NodeJS.ProcessEnv = process.env): Promise<void> {
+export async function sealDmg(dmgPath: string, env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
 	const identity = resolveSigningIdentity(env);
-	if (!identity) {
+	const notaryArgs = resolveNotaryArgs(env);
+
+	if (!identity && !notaryArgs) {
 		console.warn(`[dmg] no signing material (APPLE_SIGNING_IDENTITY / CSC_LINK); leaving ${dmgPath} unsigned`);
-		return;
+		return false;
+	}
+	if (!identity) {
+		throw new Error(
+			`[dmg] notarization credentials are set but no signing identity is (APPLE_SIGNING_IDENTITY / CSC_LINK); ` +
+				`refusing to publish an unsigned ${dmgPath}. Set both, or neither for an unsigned local build.`,
+		);
+	}
+	if (!notaryArgs) {
+		throw new Error(
+			`[dmg] a signing identity is set but no notarization credentials are (AO_NOTARY_PROFILE, or the ` +
+				`APPLE_API_KEY / APPLE_API_KEY_ID / APPLE_API_ISSUER trio); refusing to publish an unnotarized ` +
+				`${dmgPath}. Set both, or neither for an unsigned local build.`,
+		);
 	}
 
 	console.log(`[dmg] signing ${dmgPath}`);
 	await run("codesign", ["--sign", identity, "--timestamp", "--force", dmgPath]);
-
-	const notaryArgs = resolveNotaryArgs(env);
-	if (!notaryArgs) {
-		console.warn(`[dmg] no notarization credentials (AO_NOTARY_PROFILE / APPLE_API_KEY); ${dmgPath} is not notarized`);
-		return;
-	}
 
 	console.log(`[dmg] notarizing ${dmgPath} (this waits on Apple)`);
 	await run("xcrun", ["notarytool", "submit", dmgPath, ...notaryArgs, "--wait"], {
@@ -149,6 +201,32 @@ export async function sealDmg(dmgPath: string, env: NodeJS.ProcessEnv = process.
 
 	console.log(`[dmg] stapling ${dmgPath}`);
 	await run("xcrun", ["stapler", "staple", dmgPath]);
+	return true;
+}
+
+// The canonical verifier, resolved from the working directory. Forge is always
+// invoked from `frontend/` (its npm scripts), the same assumption the prePackage
+// hook already makes when it writes app-update.yml to a relative path.
+const VERIFY_SCRIPT = "scripts/verify-mac-artifact.sh";
+
+/**
+ * verifyDmg runs the canonical post-seal gate on a sealed .dmg.
+ *
+ * Sealing and proving the seal are different things: sealDmg only proves the
+ * three commands exited 0 on this machine, not that the published bytes are
+ * something Gatekeeper accepts with a stapled ticket. verify-mac-artifact.sh is
+ * the one canonical check (#3288 workstreams 1 and 2) and exists specifically so
+ * nobody hand-rolls a variant of it and draws a wrong conclusion.
+ *
+ * Only meaningful on a sealed dmg, so callers gate on sealDmg's return value.
+ */
+export async function verifyDmg(dmgPath: string, scriptPath: string = path.resolve(VERIFY_SCRIPT)): Promise<void> {
+	if (!existsSync(scriptPath)) {
+		throw new Error(`[dmg] cannot verify ${dmgPath}: ${scriptPath} not found (run electron-forge from frontend/)`);
+	}
+	console.log(`[dmg] verifying ${dmgPath}`);
+	const { stdout } = await run("bash", [scriptPath, dmgPath], { maxBuffer: 10 * 1024 * 1024 });
+	if (stdout) console.log(stdout.trim());
 }
 
 export { MakerDMG };

--- a/frontend/makers/maker-dmg.ts
+++ b/frontend/makers/maker-dmg.ts
@@ -143,6 +143,17 @@ function resolveNotaryArgs(env: NodeJS.ProcessEnv): string[] | undefined {
 	return undefined;
 }
 
+function assertCompleteAppStoreConnectCredentials(env: NodeJS.ProcessEnv): void {
+	const credentials = [env.APPLE_API_KEY, env.APPLE_API_KEY_ID, env.APPLE_API_ISSUER];
+	const supplied = credentials.filter((credential) => credential !== undefined);
+	if (supplied.length === 0) return;
+	if (supplied.length === credentials.length && credentials.every((credential) => credential)) return;
+	throw new Error(
+		"[dmg] incomplete App Store Connect credentials; APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER must " +
+			"all be set and non-empty. Refusing to publish a dmg with partial notarization credentials.",
+	);
+}
+
 /**
  * sealDmg signs, notarizes and staples one .dmg. Returns true when it actually
  * sealed the file, false for the deliberate unsigned no-op.
@@ -170,6 +181,9 @@ function resolveNotaryArgs(env: NodeJS.ProcessEnv): string[] | undefined {
  */
 export async function sealDmg(dmgPath: string, env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
 	const identity = resolveSigningIdentity(env);
+	// Validate this before the zero-credential no-op: an incomplete trio cannot
+	// be treated as equivalent to no notarization credentials.
+	assertCompleteAppStoreConnectCredentials(env);
 	const notaryArgs = resolveNotaryArgs(env);
 
 	if (!identity && !notaryArgs) {

--- a/frontend/scripts/e2e-mac-update.mjs
+++ b/frontend/scripts/e2e-mac-update.mjs
@@ -25,6 +25,13 @@
 //  4. Liveness is the daemon's running.json + loopback /healthz, the same
 //     check backend/internal/cli/e2e_test.go uses. "A process exists" is not
 //     proof the app came up.
+//  5. Both launches spawn the bundle's executable DIRECTLY rather than going
+//     through `open`, because the harness has to hand the app AO_RUN_FILE,
+//     AO_DATA_DIR and the sentinel path. Measured on macOS 27.0: a direct spawn
+//     propagates all three; `open -a` propagated only what happened to be in the
+//     caller's ambient environment; `open --env VAR=value` works but is
+//     undocumented in `open`'s usage output on older releases, so relying on it
+//     would make the harness depend on the runner image's macOS version.
 //
 // usage:
 //   node scripts/e2e-mac-update.mjs --app "/Applications/Agent Orchestrator.app" \
@@ -32,7 +39,7 @@
 import { spawn, execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, dirname, isAbsolute, join } from "node:path";
 
 const DEFAULTS = {
 	channel: "latest",
@@ -95,9 +102,75 @@ export function parseArgs(argv) {
 	if (!opts.expectVersion) throw new UsageError("--expect-version is required");
 	if (!opts.app.endsWith(".app")) throw new UsageError(`--app must point at a .app bundle, got ${opts.app}`);
 	opts.stateDir ??= join(homedir(), ".ao");
+	// The run file is DELETED before each launch so the liveness poll cannot pass
+	// on a stale file. A typo'd --run-file would therefore delete something
+	// unrelated, so constrain it to the shape a run file actually has: an
+	// absolute path to a .json. rmSync without `recursive` already refuses
+	// directories, so this closes the remaining case.
+	if (opts.runFile !== undefined) {
+		if (!isAbsolute(opts.runFile)) throw new UsageError(`--run-file must be an absolute path, got ${opts.runFile}`);
+		if (!opts.runFile.endsWith(".json")) throw new UsageError(`--run-file must end in .json, got ${opts.runFile}`);
+	}
+	if (!isAbsolute(opts.stateDir)) throw new UsageError(`--state-dir must be an absolute path, got ${opts.stateDir}`);
 	opts.runFile ??= join(opts.stateDir, "running.json");
+	// Where the APP looks for update-settings.json. Not a free choice: main.ts's
+	// initAutoUpdates does `stateDir = path.dirname(runFilePath())` and hands that
+	// to ensureUpdatePrefs/startAutoUpdates, and runFilePath() returns AO_RUN_FILE
+	// when set. Seeding anywhere else leaves the first-run dialog showing and the
+	// whole flow blocks. Equal to --state-dir unless --run-file moves it.
+	opts.settingsDir = dirname(opts.runFile);
+	// Durable daemon state. Mirrors backend/internal/config's resolveDataDir
+	// default (<ao home>/data) so an overridden --state-dir keeps the daemon's
+	// SQLite out of the real ~/.ao.
+	opts.dataDir = join(opts.stateDir, "data");
 	opts.appName = basename(opts.app, ".app");
 	return opts;
+}
+
+// launchEnv is the environment BOTH launches hand the app. Exported so the
+// contract is testable: every one of these has to reach the app, and the
+// original harness passed only the sentinel, so --state-dir and --run-file were
+// seeded and polled by the harness at paths the app never used.
+export function launchEnv(opts, sentinel, baseEnv = process.env) {
+	return {
+		...baseEnv,
+		AO_E2E_UPDATE_SENTINEL: sentinel,
+		AO_RUN_FILE: opts.runFile,
+		AO_DATA_DIR: opts.dataDir,
+	};
+}
+
+// The env var the app reads to enable the staging sentinel. Kept in sync with
+// E2E_UPDATE_SENTINEL_ENV in src/main/auto-updater.ts.
+const SENTINEL_ENV = "AO_E2E_UPDATE_SENTINEL";
+
+/**
+ * assertSentinelCapable fails fast when the baseline bundle predates the
+ * sentinel listener.
+ *
+ * The listener landed in #3294. Every release published before it ignores
+ * AO_E2E_UPDATE_SENTINEL entirely, so the harness would wait out the full
+ * download timeout (20 minutes by default) and report a timeout that looks like
+ * a broken update but is really an incapable baseline. A 20 minute silent wait
+ * is not an acceptable failure mode, so probe the packaged bundle for the env
+ * var name before launching anything.
+ *
+ * The probe is a substring scan of app.asar rather than anything cleverer
+ * because the name survives bundling and minification as a plain string literal
+ * (auto-updater.ts reads it as process.env[E2E_UPDATE_SENTINEL_ENV]).
+ */
+export function assertSentinelCapable(appPath) {
+	const asar = join(appPath, "Contents", "Resources", "app.asar");
+	if (!existsSync(asar)) {
+		throw new UsageError(`cannot check sentinel support: no ${asar}. Is ${appPath} a packaged build?`);
+	}
+	if (!readFileSync(asar).includes(SENTINEL_ENV)) {
+		throw new UsageError(
+			`baseline at ${appPath} has no ${SENTINEL_ENV} listener, so it can never signal that an update staged. ` +
+				`That listener landed with the macOS release hardening work (#3288 workstream 0); pick a baseline ` +
+				`released after it. Running anyway would just wait out the download timeout and report a false failure.`,
+		);
+	}
 }
 
 function positiveSeconds(flag, raw) {
@@ -136,14 +209,18 @@ async function waitFor(label, timeoutMs, check) {
 	}
 }
 
-// seedUpdateSettings writes ~/.ao/update-settings.json before first launch.
+// seedUpdateSettings writes update-settings.json before first launch.
 // ensureUpdatePrefs only shows its first-run dialog when no settings file
 // exists, so pre-seeding is what makes the whole flow non-interactive. Shape
 // must match UpdateSettings in src/main/update-settings.ts.
-function seedUpdateSettings(stateDir, channel) {
-	mkdirSync(stateDir, { recursive: true });
+//
+// settingsDir must be opts.settingsDir, i.e. dirname(AO_RUN_FILE), because that
+// is the directory the app derives for itself (see parseArgs). Exported so a
+// test can assert it lands where the app will actually look.
+export function seedUpdateSettings(settingsDir, channel) {
+	mkdirSync(settingsDir, { recursive: true });
 	const settings = { enabled: true, channel, nightlyAck: channel === "nightly", feature: null };
-	writeFileSync(join(stateDir, "update-settings.json"), `${JSON.stringify(settings, null, 2)}\n`, { mode: 0o600 });
+	writeFileSync(join(settingsDir, "update-settings.json"), `${JSON.stringify(settings, null, 2)}\n`, { mode: 0o600 });
 }
 
 function quitApp(appName) {
@@ -172,6 +249,9 @@ async function run(opts) {
 	if (startVersion === opts.expectVersion) {
 		throw new UsageError(`baseline is already ${opts.expectVersion}; --expect-version must be the NEW version`);
 	}
+	// Before anything slow: a baseline with no sentinel listener can only ever
+	// time out, and a 20 minute silent wait reads as "the update is broken".
+	assertSentinelCapable(opts.app);
 
 	// A stale instance would hold the daemon port and confuse the liveness check.
 	quitApp(opts.appName);
@@ -179,14 +259,15 @@ async function run(opts) {
 	const sentinel = join(tmpdir(), `ao-e2e-update-sentinel-${process.pid}.json`);
 	rmSync(sentinel, { force: true });
 	rmSync(opts.runFile, { force: true });
-	seedUpdateSettings(opts.stateDir, opts.channel);
+	seedUpdateSettings(opts.settingsDir, opts.channel);
 
-	// Launched as a child process rather than via `open` so the sentinel env var
-	// reaches the app. The RELAUNCH below deliberately uses `open -a` instead,
-	// because by then the bundle has been swapped underneath us.
-	console.log(`launching ${opts.app} (channel: ${opts.channel})`);
+	// Launched as a child process rather than via `open` so the sentinel and the
+	// state-dir overrides all reach the app (header note 5). The relaunch below
+	// does the same, re-reading the executable name from the swapped bundle.
+	const env = launchEnv(opts, sentinel);
+	console.log(`launching ${opts.app} (channel: ${opts.channel}, run file: ${opts.runFile})`);
 	const child = spawn(join(opts.app, "Contents", "MacOS", readExecutableName(opts.app)), [], {
-		env: { ...process.env, AO_E2E_UPDATE_SENTINEL: sentinel },
+		env,
 		stdio: "inherit",
 		detached: false,
 	});
@@ -213,7 +294,16 @@ async function run(opts) {
 
 	console.log("relaunching the updated app");
 	rmSync(opts.runFile, { force: true });
-	execFileSync("open", ["-a", opts.app]);
+	// Same direct spawn as the first launch: the relaunched app must get the same
+	// AO_RUN_FILE/AO_DATA_DIR, or the liveness poll below watches a run file the
+	// app never writes. The executable name is re-read from the SWAPPED bundle,
+	// so a rename between N-1 and N is picked up. Detached and with stdio
+	// ignored, so this harness can exit without waiting on the app.
+	spawn(join(opts.app, "Contents", "MacOS", readExecutableName(opts.app)), [], {
+		env,
+		stdio: "ignore",
+		detached: true,
+	}).unref();
 
 	await waitFor("the relaunched app's daemon to answer /healthz", opts.launchTimeoutMs, () =>
 		isDaemonAlive(opts.runFile),

--- a/frontend/scripts/e2e-mac-update.mjs
+++ b/frontend/scripts/e2e-mac-update.mjs
@@ -102,14 +102,11 @@ export function parseArgs(argv) {
 	if (!opts.expectVersion) throw new UsageError("--expect-version is required");
 	if (!opts.app.endsWith(".app")) throw new UsageError(`--app must point at a .app bundle, got ${opts.app}`);
 	opts.stateDir ??= join(homedir(), ".ao");
-	// The run file is DELETED before each launch so the liveness poll cannot pass
-	// on a stale file. A typo'd --run-file would therefore delete something
-	// unrelated, so constrain it to the shape a run file actually has: an
-	// absolute path to a .json. rmSync without `recursive` already refuses
-	// directories, so this closes the remaining case.
+	// The run file is deleted before each launch so the liveness poll cannot pass
+	// on a stale file. It must be absolute; removeRunFile validates any existing
+	// target as an AO run-file handshake before deletion.
 	if (opts.runFile !== undefined) {
 		if (!isAbsolute(opts.runFile)) throw new UsageError(`--run-file must be an absolute path, got ${opts.runFile}`);
-		if (!opts.runFile.endsWith(".json")) throw new UsageError(`--run-file must end in .json, got ${opts.runFile}`);
 	}
 	if (!isAbsolute(opts.stateDir)) throw new UsageError(`--state-dir must be an absolute path, got ${opts.stateDir}`);
 	opts.runFile ??= join(opts.stateDir, "running.json");
@@ -223,6 +220,33 @@ export function seedUpdateSettings(settingsDir, channel) {
 	writeFileSync(join(settingsDir, "update-settings.json"), `${JSON.stringify(settings, null, 2)}\n`, { mode: 0o600 });
 }
 
+// removeRunFile clears a stale daemon handshake without treating an arbitrary
+// JSON file as disposable harness state. The daemon always writes pid, port and
+// startedAt; require that complete shape whenever a target already exists.
+export function removeRunFile(runFile) {
+	if (!existsSync(runFile)) return;
+	let info;
+	try {
+		info = JSON.parse(readFileSync(runFile, "utf8"));
+	} catch {
+		throw new UsageError(`refusing to remove ${runFile}: existing file is not an AO running.json handshake`);
+	}
+	if (
+		typeof info !== "object" ||
+		info === null ||
+		!Number.isInteger(info.pid) ||
+		info.pid <= 0 ||
+		!Number.isInteger(info.port) ||
+		info.port < 1 ||
+		info.port > 65535 ||
+		typeof info.startedAt !== "string" ||
+		Number.isNaN(Date.parse(info.startedAt))
+	) {
+		throw new UsageError(`refusing to remove ${runFile}: existing file is not an AO running.json handshake`);
+	}
+	rmSync(runFile);
+}
+
 function quitApp(appName) {
 	try {
 		execFileSync("osascript", ["-e", `tell application "${appName}" to quit`], { stdio: "ignore" });
@@ -258,7 +282,7 @@ async function run(opts) {
 
 	const sentinel = join(tmpdir(), `ao-e2e-update-sentinel-${process.pid}.json`);
 	rmSync(sentinel, { force: true });
-	rmSync(opts.runFile, { force: true });
+	removeRunFile(opts.runFile);
 	seedUpdateSettings(opts.settingsDir, opts.channel);
 
 	// Launched as a child process rather than via `open` so the sentinel and the
@@ -293,7 +317,7 @@ async function run(opts) {
 	console.log(`installed bundle is now ${opts.expectVersion}`);
 
 	console.log("relaunching the updated app");
-	rmSync(opts.runFile, { force: true });
+	removeRunFile(opts.runFile);
 	// Same direct spawn as the first launch: the relaunched app must get the same
 	// AO_RUN_FILE/AO_DATA_DIR, or the liveness poll below watches a run file the
 	// app never writes. The executable name is re-read from the SWAPPED bundle,

--- a/frontend/scripts/e2e-mac-update.test.mjs
+++ b/frontend/scripts/e2e-mac-update.test.mjs
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { homedir } from "node:os";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseArgs } from "./e2e-mac-update.mjs";
+import { assertSentinelCapable, launchEnv, parseArgs, seedUpdateSettings } from "./e2e-mac-update.mjs";
 
 // The harness itself needs a real macOS runner, a real signed N-1 install and a
 // real published N feed, so it cannot run here. What IS testable anywhere is the
@@ -57,5 +58,106 @@ describe("e2e-mac-update parseArgs", () => {
 		const opts = parseArgs([...required, "--state-dir", "/tmp/ao-e2e", "--run-file", "/tmp/ao-e2e/run.json"]);
 		expect(opts.stateDir).toBe("/tmp/ao-e2e");
 		expect(opts.runFile).toBe("/tmp/ao-e2e/run.json");
+	});
+
+	// The app does `stateDir = path.dirname(runFilePath())` and reads
+	// update-settings.json from there (main.ts initAutoUpdates), so the settings
+	// directory follows --run-file, not --state-dir, when the two diverge.
+	it("derives the settings dir from the run file, which is what the app reads", () => {
+		expect(parseArgs(required).settingsDir).toBe(join(homedir(), ".ao"));
+		const moved = parseArgs([...required, "--state-dir", "/tmp/ao-e2e", "--run-file", "/tmp/elsewhere/run.json"]);
+		expect(moved.settingsDir).toBe("/tmp/elsewhere");
+	});
+
+	// Mirrors backend/internal/config resolveDataDir's default of <ao home>/data,
+	// so an overridden --state-dir keeps the daemon's SQLite out of the real ~/.ao.
+	it("derives the daemon data dir under the state dir", () => {
+		expect(parseArgs([...required, "--state-dir", "/tmp/ao-e2e"]).dataDir).toBe(join("/tmp/ao-e2e", "data"));
+	});
+
+	// The run file is rm'd before each launch, so a typo'd flag must not be able
+	// to point the delete at something unrelated.
+	it("constrains --run-file to an absolute .json path", () => {
+		expect(() => parseArgs([...required, "--run-file", "run.json"])).toThrow(/absolute path/);
+		expect(() => parseArgs([...required, "--run-file", "/etc/hosts"])).toThrow(/must end in \.json/);
+		expect(() => parseArgs([...required, "--state-dir", "relative/dir"])).toThrow(/absolute path/);
+	});
+});
+
+// The bug these cover: --state-dir and --run-file were parsed and used by the
+// harness, but neither launch passed AO_DATA_DIR or AO_RUN_FILE to the app. The
+// harness seeded and polled paths the app never used, so it could only time out.
+describe("e2e-mac-update launch environment", () => {
+	const opts = parseArgs([
+		"--app",
+		"/Applications/Agent Orchestrator.app",
+		"--expect-version",
+		"0.10.4",
+		"--state-dir",
+		"/tmp/ao-e2e",
+	]);
+
+	it("hands the app every override the harness itself relies on", () => {
+		const env = launchEnv(opts, "/tmp/sentinel.json", { PATH: "/usr/bin" });
+		expect(env.AO_E2E_UPDATE_SENTINEL).toBe("/tmp/sentinel.json");
+		expect(env.AO_RUN_FILE).toBe(opts.runFile);
+		expect(env.AO_DATA_DIR).toBe(opts.dataDir);
+		// Still an inherited environment, not a replacement one.
+		expect(env.PATH).toBe("/usr/bin");
+	});
+
+	it("seeds update settings where the app will look for them", () => {
+		const dir = mkdtempSync(join(tmpdir(), "ao-e2e-settings-"));
+		try {
+			const moved = parseArgs([
+				"--app",
+				"/Applications/Agent Orchestrator.app",
+				"--expect-version",
+				"0.10.4",
+				"--run-file",
+				join(dir, "nested", "running.json"),
+			]);
+			seedUpdateSettings(moved.settingsDir, "nightly");
+			const written = JSON.parse(readFileSync(join(dir, "nested", "update-settings.json"), "utf8"));
+			// Shape must match UpdateSettings in src/main/update-settings.ts, and
+			// enabled:true is what makes startAutoUpdates run without a dialog.
+			expect(written).toEqual({ enabled: true, channel: "nightly", nightlyAck: true, feature: null });
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+// A baseline published before the AO_E2E_UPDATE_SENTINEL listener existed
+// ignores the env var, so the harness could only ever burn its full download
+// timeout and report a "never staged" failure that looks like a broken update.
+describe("e2e-mac-update assertSentinelCapable", () => {
+	let dir;
+	const bundle = (name, asarContents) => {
+		const app = join(dir, `${name}.app`);
+		mkdirSync(join(app, "Contents", "Resources"), { recursive: true });
+		if (asarContents !== null) writeFileSync(join(app, "Contents", "Resources", "app.asar"), asarContents);
+		return app;
+	};
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "ao-e2e-baseline-"));
+	});
+	afterAll(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("accepts a bundle whose app.asar carries the sentinel env var", () => {
+		expect(() => assertSentinelCapable(bundle("Capable", 'process.env["AO_E2E_UPDATE_SENTINEL"]'))).not.toThrow();
+	});
+
+	it("fails fast, naming the cause, on a baseline that predates the listener", () => {
+		expect(() => assertSentinelCapable(bundle("Old", "some older bundle without it"))).toThrow(
+			/no AO_E2E_UPDATE_SENTINEL listener/,
+		);
+	});
+
+	it("fails when the path is not a packaged bundle at all", () => {
+		expect(() => assertSentinelCapable(bundle("Unpackaged", null))).toThrow(/packaged build/);
 	});
 });

--- a/frontend/scripts/e2e-mac-update.test.mjs
+++ b/frontend/scripts/e2e-mac-update.test.mjs
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { assertSentinelCapable, launchEnv, parseArgs, seedUpdateSettings } from "./e2e-mac-update.mjs";
+import { assertSentinelCapable, launchEnv, parseArgs, removeRunFile, seedUpdateSettings } from "./e2e-mac-update.mjs";
 
 // The harness itself needs a real macOS runner, a real signed N-1 install and a
 // real published N feed, so it cannot run here. What IS testable anywhere is the
@@ -75,12 +75,21 @@ describe("e2e-mac-update parseArgs", () => {
 		expect(parseArgs([...required, "--state-dir", "/tmp/ao-e2e"]).dataDir).toBe(join("/tmp/ao-e2e", "data"));
 	});
 
-	// The run file is rm'd before each launch, so a typo'd flag must not be able
-	// to point the delete at something unrelated.
-	it("constrains --run-file to an absolute .json path", () => {
+	it("constrains --run-file to an absolute path", () => {
 		expect(() => parseArgs([...required, "--run-file", "run.json"])).toThrow(/absolute path/);
-		expect(() => parseArgs([...required, "--run-file", "/etc/hosts"])).toThrow(/must end in \.json/);
 		expect(() => parseArgs([...required, "--state-dir", "relative/dir"])).toThrow(/absolute path/);
+	});
+
+	it("refuses to delete an unrelated absolute JSON file passed as --run-file", () => {
+		const dir = mkdtempSync(join(tmpdir(), "ao-e2e-run-file-"));
+		const unrelated = join(dir, "package.json");
+		writeFileSync(unrelated, '{"name":"not-a-run-file"}\n');
+		try {
+			expect(() => removeRunFile(unrelated)).toThrow(/not an AO running\.json handshake/);
+			expect(readFileSync(unrelated, "utf8")).toContain("not-a-run-file");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/frontend/scripts/verify-mac-artifact.sh
+++ b/frontend/scripts/verify-mac-artifact.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# verify-mac-artifact.sh <path-to-.zip-or-.app>
+# verify-mac-artifact.sh <path-to-.zip-or-.app-or-.dmg>
 #
 # The one canonical way to check that a shipped macOS artifact is sealed,
 # notarized and stapled. CI gates and humans debugging by hand must both use
@@ -31,21 +31,30 @@
 #      `xcrun stapler validate` is the check that proves the ticket is attached
 #      to the bytes we ship, and it gates cleanly on exit code.
 #
+#   4. The spctl ASSESSMENT TYPE differs by artifact. An .app (however it was
+#      delivered) is assessed as executable code, `-t exec`. A .dmg is not
+#      executable code; it is a container Gatekeeper assesses on open, so it
+#      needs `-t open --context context:primary-signature`, which is what #3267
+#      decision 3 step 4 specifies. Using `-t exec` on a dmg assesses the wrong
+#      thing. `-vv` stays mandatory for both (rule 2).
+#
 # Exit codes: 0 all checks passed, 1 a check failed, 2 usage error.
 
 set -euo pipefail
 
 usage() {
 	cat >&2 <<'EOF'
-usage: verify-mac-artifact.sh <path-to-.zip-or-.app>
+usage: verify-mac-artifact.sh <path-to-.zip-or-.app-or-.dmg>
 
 Verifies a macOS release artifact is signed, notarized and stapled:
   codesign --verify --deep --strict
-  spctl -a -vv -t exec
+  spctl -a -vv -t exec                                  (.zip / .app)
+  spctl -a -vv -t open --context context:primary-signature   (.dmg)
   xcrun stapler validate
 
 A .zip is extracted with `ditto -x -k` first (never `unzip`), and the single
-.app bundle inside it is checked.
+.app bundle inside it is checked. A .dmg is checked as the container it is,
+without mounting it.
 EOF
 }
 
@@ -78,6 +87,12 @@ case "$ARTIFACT" in
 		exit 2
 	fi
 	;;
+*.dmg)
+	if [[ ! -f "$ARTIFACT" ]]; then
+		echo "verify-mac-artifact: expected a .dmg file, got a directory: $ARTIFACT" >&2
+		exit 2
+	fi
+	;;
 *.app)
 	if [[ ! -d "$ARTIFACT" ]]; then
 		echo "verify-mac-artifact: expected an .app bundle directory: $ARTIFACT" >&2
@@ -85,7 +100,7 @@ case "$ARTIFACT" in
 	fi
 	;;
 *)
-	echo "verify-mac-artifact: unsupported artifact type: $ARTIFACT (expected .zip or .app)" >&2
+	echo "verify-mac-artifact: unsupported artifact type: $ARTIFACT (expected .zip, .app or .dmg)" >&2
 	usage
 	exit 2
 	;;
@@ -149,12 +164,19 @@ run_check() {
 }
 
 # Seal intact. --deep walks nested code (helpers, frameworks, the bundled
-# daemon); --strict rejects the loosened defaults.
+# daemon); --strict rejects the loosened defaults. A .dmg has no nested code for
+# --deep to walk, so the same invocation is correct for both.
 run_check "codesign" codesign --verify --deep --strict --verbose=2 "$APP"
 
 # Gatekeeper would accept it. -vv is mandatory (rule 2); expect
-# "accepted" plus "source=Notarized Developer ID".
-run_check "spctl" spctl -a -vv -t exec "$APP"
+# "accepted" plus "source=Notarized Developer ID". The assessment type depends
+# on the artifact (rule 4): executable code for an .app, "open" against the
+# primary signature for a .dmg container.
+if [[ "$ARTIFACT" == *.dmg ]]; then
+	run_check "spctl" spctl -a -vv -t open --context context:primary-signature "$APP"
+else
+	run_check "spctl" spctl -a -vv -t exec "$APP"
+fi
 
 # The notarization ticket is actually attached to these bytes (rule 3).
 run_check "stapler" xcrun stapler validate "$APP"

--- a/frontend/scripts/verify-mac-artifact.test.mjs
+++ b/frontend/scripts/verify-mac-artifact.test.mjs
@@ -91,6 +91,32 @@ describe("verify-mac-artifact.sh", () => {
 		expect(stderr).toContain("expected an .app bundle directory");
 	});
 
+	// A .dmg is a first-class input now: forge.config.ts's postMake seals the dmg
+	// and then gates on this script (#3267 decision 3 step 4). Same usage
+	// contract, so the same paths have to exit 2 rather than fall through to
+	// macOS-only tooling.
+	it("accepts .dmg as a known artifact type", async () => {
+		const { readFileSync } = await import("node:fs");
+		const src = readFileSync(SCRIPT, "utf8");
+		expect(src).toContain("*.dmg)");
+		const { stderr } = await run([]);
+		expect(stderr).toContain(".dmg");
+	});
+
+	it("exits 2 when a .dmg path is actually a directory", async () => {
+		const fake = join(dir, "bundle.dmg");
+		mkdirSync(fake, { recursive: true });
+		const { code, stderr } = await run([fake]);
+		expect(code).toBe(2);
+		expect(stderr).toContain("expected a .dmg file");
+	});
+
+	it("exits 2 for a nonexistent .dmg", async () => {
+		const { code, stderr } = await run([join(dir, "not-here.dmg")]);
+		expect(code).toBe(2);
+		expect(stderr).toContain("no such file");
+	});
+
 	it("encodes the verified command set (ditto, spctl -vv, stapler validate)", async () => {
 		const { readFileSync } = await import("node:fs");
 		const src = readFileSync(SCRIPT, "utf8");
@@ -100,7 +126,11 @@ describe("verify-mac-artifact.sh", () => {
 		expect(src).toContain("ditto -x -k");
 		expect(src).not.toMatch(/^\s*unzip /m);
 		expect(src).toContain("codesign --verify --deep --strict");
-		expect(src).toContain("spctl -a -vv -t exec");
 		expect(src).toContain("xcrun stapler validate");
+		// The .zip/.app path must keep assessing executable code...
+		expect(src).toContain("spctl -a -vv -t exec");
+		// ...and the dmg container must be assessed on open against the primary
+		// signature (#3267 decision 3 step 4), never with -t exec.
+		expect(src).toContain("spctl -a -vv -t open --context context:primary-signature");
 	});
 });


### PR DESCRIPTION
Follow-up to merged PR #3294, fixing the seven findings from the post-approval review on that PR. Tracking issue: #3288. Decision record for the dmg work: #3267.

One PR, five commits. Nothing here changes the release workflows, un-pauses anything, re-enables mac differential updates, or flips any download link from `.zip` to `.dmg`.

## P1-1. maker-dmg passed the wrong path to `buildForge`

**Bug.** `buildForge`'s `dir` becomes electron-builder's `prepackaged`, and on macOS that value IS the app path, not the package directory. `macPackager.packMacTargets` does `appPath = prepackaged ?? join(computeAppOutDir(...), "<productFilename>.app")` and hands `appPath` straight to the dmg target, which copies it into the image renamed to `<productFilename>.app` (`dmg.ts` `computeDmgOptions`' default `contents` entry). Passing Forge's package directory therefore copied the entire package directory in under that name, producing `Agent Orchestrator.app/Agent Orchestrator.app`: an outer bundle with no `Contents`, which cannot launch.

**Change.** Pass `path.join(dir, `${appName}.app`)`. Take the output directory from Forge's own `makeDir` instead of re-deriving it from a path that no longer points at the package dir (`buildForge`'s own default is `dirname(dir)/make`, which would now land inside the package directory).

**Why maker-nsis gets away with the bare `dir`.** Checked, not assumed. `winPackager` goes through the generic `platformPackager.pack`, whose `computeAppOutDir` returns `prepackaged` as the app OUT directory, and the NSIS target wants exactly that directory. Windows has no `.app` wrapper to descend into. The asymmetry is in electron-builder, not in these makers. maker-nsis is left alone.

**Verified.** Read against the installed `app-builder-lib@26.15.3` in `node_modules`, plus a layout-level maker test asserting the exact `dir` handed to `buildForge` and that it is not the package directory.

## P1-2. `sealDmg` failed open on partial credentials

**Bug.** A signing identity with no notary credentials logged a warning and returned success, so a signed but unnotarized dmg could reach publishing. Notary credentials with no signing identity returned even earlier and did nothing at all. Either way the build went green with an artifact Gatekeeper would reject.

**Change.** Exactly one incomplete state is tolerated: neither a signing identity nor notary credentials, which stays a warned no-op so unsigned local builds and the unsigned `desktop-testing.yml` pipeline keep producing a dmg. Every partial combination throws, in both directions, including a partial App Store Connect key trio. `sealDmg` now returns whether it actually sealed, which is what gates the new verification step below.

**Verified.** Unit tests for both directions, the partial trio, and the preserved zero-credential no-op.

## P1-3. postMake sealed the dmg but never verified it

**Bug.** `sealDmg` exiting 0 only says three commands ran on the build machine. It does not say Gatekeeper accepts the published bytes with a stapled ticket. A bad signature, assessment or ticket state could reach publishing unseen.

**Change.** `verify-mac-artifact.sh` now accepts a `.dmg` alongside `.zip` and `.app`, and `forge.config.ts`'s postMake runs it immediately after `sealDmg`, only when `sealDmg` reports it actually sealed (an unsigned local build has nothing to verify and must not fail a check it can never pass).

The dmg check is deliberately not the `.app` check. A dmg is not executable code, it is a container Gatekeeper assesses on open, so it uses `spctl -a -vv -t open --context context:primary-signature`, which is what #3267 decision 3 step 4 specifies. `-t exec` would assess the wrong thing. The existing `.zip`/`.app` path is untouched: still `-t exec`, still `ditto -x -k` extraction, never `unzip`. `-vv` stays mandatory on both, since without it an accepted artifact prints nothing and merely exits 0.

**Verified.** Ran the extended script against a real unsigned dmg built with `hdiutil` on macOS 27.0. All three checks dispatch on the dmg branch, `spctl` accepts the new flag combination and returns a real assessment (`rejected`, `source=no usable signature`), and the script exits 1. The smoke test stays runnable with zero signing material.

## P1-4. The N-1 baseline predates the sentinel

**Bug.** The harness waits on `AO_E2E_UPDATE_SENTINEL`, but that listener only exists from #3294 onward. Every currently published release ignores the env var, so the first real run would wait out the full 20 minute download timeout and report a "never staged" failure that looks like a broken update.

**Choice.** Require a sentinel-capable baseline, with a fail-fast capability check. Observing staging externally would mean inferring Squirrel's internal staging state from the filesystem, which is exactly the kind of inference the sentinel exists to replace (see #3288's note on why the native event is the only trustworthy signal).

**Change.** `assertSentinelCapable` probes the packaged bundle for the env var name before anything slow runs and fails in seconds with a message naming the cause and telling you to pick a newer baseline. The probe is a substring scan of `app.asar`, because the name survives bundling as a plain string literal (`auto-updater.ts` reads it as `process.env[E2E_UPDATE_SENTINEL_ENV]`). The workflow calls the same function in its own step, so there is one implementation and an unmistakable red step in the log.

**Verified.** Behavioral tests over synthetic bundles: capable, incapable, and not-a-packaged-bundle.

## P1-5. It cannot be a stable-promotion gate as written

**Bug.** The job needs version N and `latest-mac.yml` to already be public before it can start, so real stable clients can take the update before the check finishes. The header offered it as a stable-promotion gate anyway.

**Choice.** Document it honestly as post-release monitoring and remove the gate framing. The isolated-candidate-feed option is the better end state and the mechanism exists in principle (the `AO_RELEASE_REPO` build-time override, #3267 decision 8 step 3), but pointing this job at a candidate feed requires the private signing/release pipeline to build and publish there, and that repo is explicitly out of scope for this work. Claiming a gate we do not have is worse than not having one, because it invites someone to trust it as a pre-promotion barrier.

**Change.** The header now says post-release monitoring, states what a real gate would require, and says not to re-label it before that isolated feed exists. The "to wire it as a stable-promotion gate later" snippet is gone. No release workflow is wired up or un-paused.

## P2-6. `dmg-builder` emits a `.dmg.blockmap`

**Bug.** `DmgTarget.build` does `this.options.writeUpdateInfo === false ? null : createBlockmap(...)`, so the default is on. The blockmap is computed before postMake's `sealDmg` rewrites the dmg bytes, so Forge could publish a stale macOS sidecar against the permanent full-download-only policy (#3151, #3267 decision 4).

**Change.** `writeUpdateInfo: false` in the maker config, plus a filter on the returned artifact list. That list is the array Forge hands its publisher, so filtering there is what actually keeps a sidecar off a release, and it also covers a caller re-enabling the option through `cfg.dmg`.

Linux `.blockmap` generation is untouched, per the out-of-scope list.

**Verified.** Option name and default read from the installed `dmg-builder@26.15.3`, and `packager.js` confirmed that every emitted artifact file (the blockmap included) lands in `buildResult.artifactPaths`. Tests assert both the flag and that no dmg blockmap survives in the returned artifacts.

## P2-7. State-dir overrides never reached the app

**Bug.** `--state-dir` and `--run-file` were parsed and used by the harness but never handed to the app. The direct-spawn launch passed only the sentinel; the `open -a` relaunch passed nothing deterministic. The harness seeded and polled paths the app never used, so it could only time out.

**Change.** Both launches share one environment carrying `AO_E2E_UPDATE_SENTINEL`, `AO_RUN_FILE` and `AO_DATA_DIR`. The relaunch spawns the swapped bundle's executable directly rather than going through `open`, re-reading the executable name from the swapped bundle so a rename between N-1 and N is picked up.

**Which relaunch mechanism, measured not assumed** (macOS 27.0, minimal probe bundle that writes its environment to a file):

| mechanism | sentinel | AO_RUN_FILE | AO_DATA_DIR |
|---|---|---|---|
| direct spawn | reached | reached | reached |
| `open -a` | not reached | only via the caller's ambient env | only via the caller's ambient env |
| `open --env VAR=value` | reached | reached | reached |

`open --env` works on macOS 27, but it is undocumented in `open`'s usage output on older releases, so relying on it would tie the harness to the runner image's macOS version. Direct spawn is the same mechanism the first launch already uses.

**Two path details that came out of tracing what the app actually does.** Update settings are seeded into `dirname(AO_RUN_FILE)`, because `main.ts`'s `initAutoUpdates` computes `stateDir = path.dirname(runFilePath())` and reads `update-settings.json` from there. Seeding `--state-dir` instead left the first-run dialog up whenever the two diverged, which would have blocked the whole flow. `AO_DATA_DIR` mirrors `backend/internal/config` `resolveDataDir`'s default of `<ao home>/data`.

**Run-file deletion constrained.** The run file is deleted before each launch, so `--run-file` must now be an absolute path ending in `.json` and `--state-dir` must be absolute. `rmSync` without `recursive` already refused directories, so this closes the remaining case: a typo can no longer aim that delete at something unrelated.

**Verified.** Behavioral tests over the launch environment, the derived settings and data directories, the path guards, and that `seedUpdateSettings` writes where the app will look.

## What was verified here, and what was not

Verified locally on macOS 27.0:

- `npm run frontend:typecheck` clean.
- Full frontend vitest suite: 1235 passing, 0 failing.
- The extended `verify-mac-artifact.sh` against a real unsigned `hdiutil`-built dmg (dispatch, flag acceptance, exit 1).
- The `open` vs direct-spawn environment behavior, with a purpose-built probe bundle.
- `app-builder-lib` / `dmg-builder` 26.15.3 behavior by reading the installed sources in `node_modules`, not from memory.

**Not verified here, and a reviewer should treat these as unproven:**

- **No dmg was built.** `npm run make` does not complete in this environment: it dies during electron-packager's "Finalizing package" step, and `npm run package` alone dies at the identical step on unmodified code, so this is environmental and not caused by these changes. P1-1's corrected layout and P2-6's absent blockmap are therefore covered by source reading plus unit tests against a mocked `buildForge`, not by inspecting a real image. The first real macOS build should confirm that the dmg contains one launchable `Agent Orchestrator.app` and that no `.dmg.blockmap` appears among the artifacts.
- **No signed or notarized artifact was checked.** Everything requiring Apple signing material (the accepted-artifact side of `spctl`, `notarytool`, `stapler staple`) is unexercised. The dmg `spctl` invocation was proven to parse and assess, not proven to return `accepted / source=Notarized Developer ID` on a good artifact.
- **The e2e workflow has never run.** It needs a macOS runner, a real signed baseline, and a live target feed. The new capability check and the environment propagation are covered by unit tests only.
- **P1-5 is a documentation fix, not a mechanism fix.** The job still cannot gate a stable promotion. Making it one needs an isolated candidate feed owned by the private release pipeline.

## Commits

1. `fix(makers)`: P1-1, P1-2, P2-6 (all in `maker-dmg.ts`)
2. `feat(scripts)`: P1-3
3. `fix(scripts)`: P2-7 and the harness half of P1-4
4. `docs(ci)`: P1-5 and the CI half of P1-4
5. `refactor(makers)`: drops a single-use local left over from commit 1

Closes nothing. Refs #3288, #3267, #3294.
