### PR TITLE
test(config): use portable override paths

### DIFF
--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -83,11 +83,15 @@ func TestLoadAbsolutizesRelativeOverrides(t *testing.T) {
 }
 
 func TestLoadOverrides(t *testing.T) {
+	overrideDir := t.TempDir()
+	runFilePath := filepath.Join(overrideDir, "ao-test-running.json")
+	dataDir := filepath.Join(overrideDir, "ao-test-data")
+
 	t.Setenv("AO_PORT", "4002")
 	t.Setenv("AO_REQUEST_TIMEOUT", "5s")
 	t.Setenv("AO_SHUTDOWN_TIMEOUT", "3s")
-	t.Setenv("AO_RUN_FILE", "/tmp/ao-test-running.json")
-	t.Setenv("AO_DATA_DIR", "/tmp/ao-test-data")
+	t.Setenv("AO_RUN_FILE", runFilePath)
+	t.Setenv("AO_DATA_DIR", dataDir)
 	t.Setenv("AO_TELEMETRY_EVENTS", "on")
 	t.Setenv("AO_TELEMETRY_METRICS", "off")
 	t.Setenv("AO_TELEMETRY_REMOTE", "posthog")
@@ -107,11 +111,11 @@ func TestLoadOverrides(t *testing.T) {
 	if cfg.ShutdownTimeout != 3*time.Second {
 		t.Errorf("ShutdownTimeout = %s, want 3s", cfg.ShutdownTimeout)
 	}
-	if cfg.RunFilePath != "/tmp/ao-test-running.json" {
-		t.Errorf("RunFilePath = %q, want /tmp/ao-test-running.json", cfg.RunFilePath)
+	if cfg.RunFilePath != runFilePath {
+		t.Errorf("RunFilePath = %q, want %q", cfg.RunFilePath, runFilePath)
 	}
-	if cfg.DataDir != "/tmp/ao-test-data" {
-		t.Errorf("DataDir = %q, want /tmp/ao-test-data", cfg.DataDir)
+	if cfg.DataDir != dataDir {
+		t.Errorf("DataDir = %q, want %q", cfg.DataDir, dataDir)
 	}
 	if !cfg.Telemetry.Events || cfg.Telemetry.Metrics {
 		t.Fatalf("Telemetry toggles = %+v", cfg.Telemetry)


### PR DESCRIPTION
## What

  Make TestLoadOverrides use platform-native temporary paths instead of hard-coded /tmp/... paths.

  ## Why

  The test failed on Windows because filepath.Abs correctly normalizes /tmp/... to the current drive, such as D:\tmp\..., while the test expected the original
  POSIX path string.

  This is a test portability issue only. Production path normalization remains unchanged.

  ## How

  - Create an absolute temporary directory with t.TempDir().
  - Build the run-file and data-directory paths with filepath.Join.
  - Compare the loaded configuration against those generated paths.
  - Leave config.go and runtime behavior unchanged.

  ## Testing

  Validated on Windows:

  cd backend
  go test ./internal/config -count=1
  go vet ./internal/config

  Both commands pass.

  No screenshots are applicable because this change only affects a backend unit test.

  ## Checklist

  - [x] Branched from main (or continuing an existing PR branch)
  - [x] One focused change; links the related issue when applicable
  - [x] Follows AGENTS.md (https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
  - [x] Tests added/updated for user-visible behavior where it makes sense
  - [x] Relevant CI checks pass for the area touched (go, frontend, etc.)