### PR TITLE
fix: sort merged board lane newest first

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -586,8 +586,12 @@ function MergeLaneColumn({
 	onOpen: (s: WorkspaceSession) => void;
 	onTerminate: (s: WorkspaceSession) => void;
 }) {
-	const mergedSessions = sessions.filter((session) => session.status === "merged");
-	const readySessions = sessions.filter((session) => session.status !== "merged");
+	const mergedSessions = sessions
+		.filter((session) => session.status === "merged")
+		.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+	const readySessions = sessions
+		.filter((session) => session.status !== "merged")
+		.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
 
 	return (
 		<SplitLaneColumn


### PR DESCRIPTION
## Summary
- sort ready-to-merge sessions by `updatedAt` descending
- sort merged sessions by `updatedAt` descending
- match the archive bar newest-first ordering

## Tests
- `npm run frontend:typecheck`

Fixes #3305