### PR TITLE
perf(landing): preload design partners artwork

### DIFF
--- a/frontend/src/landing/src/app/design-partners/page.tsx
+++ b/frontend/src/landing/src/app/design-partners/page.tsx
@@ -1,6 +1,7 @@
 import { AGENT_HARNESSES, COMPANY } from "@ao/shared/constants";
 import type { Metadata } from "next";
 import Image from "next/image";
+import { preload } from "react-dom";
 import {
   formatStatPlus,
   getGitHubRepoStats,
@@ -139,6 +140,12 @@ const phases: RoadmapPhase[] = [
   },
 ];
 
+const DESIGN_PARTNER_IMAGES = [
+  "/design-partners/hero-car-engine-olive.png",
+  "/design-partners/shared-workspace-olive.png",
+  ...phases.map((phase) => phase.image),
+];
+
 function ArrowIcon({ className = "" }: { className?: string }) {
   return (
     <svg
@@ -183,6 +190,11 @@ function TextLink({
 }
 
 export default async function DesignPartnersPage() {
+  // Emitted before the stats await so the browser can fetch artwork in parallel.
+  for (const image of DESIGN_PARTNER_IMAGES) {
+    preload(image, { as: "image" });
+  }
+
   const repo = await getGitHubRepoStats();
   const stars = repo?.stars ?? FALLBACK_STATS.stars;
   const forks = repo?.forks ?? FALLBACK_STATS.forks;

--- a/frontend/src/landing/src/app/design-partners/page.tsx
+++ b/frontend/src/landing/src/app/design-partners/page.tsx
@@ -140,8 +140,10 @@ const phases: RoadmapPhase[] = [
   },
 ];
 
-const DESIGN_PARTNER_IMAGES = [
-  "/design-partners/hero-car-engine-olive.png",
+// The hero is excluded: its <Image priority> already preloads it, and as the LCP
+// element it should stay the only image competing for early bandwidth. These are
+// all below the fold, so they warm the cache at low priority instead.
+const BELOW_FOLD_IMAGES = [
   "/design-partners/shared-workspace-olive.png",
   ...phases.map((phase) => phase.image),
 ];
@@ -191,8 +193,8 @@ function TextLink({
 
 export default async function DesignPartnersPage() {
   // Emitted before the stats await so the browser can fetch artwork in parallel.
-  for (const image of DESIGN_PARTNER_IMAGES) {
-    preload(image, { as: "image" });
+  for (const image of BELOW_FOLD_IMAGES) {
+    preload(image, { as: "image", fetchPriority: "low" });
   }
 
   const repo = await getGitHubRepoStats();


### PR DESCRIPTION
## Summary

The design partners page renders six large PNGs. Four live inside the roadmap slideshow and were only requested once their slide mounted, so advancing the roadmap showed a blank frame while the image downloaded.

This emits `preload` hints from the server component so the browser starts fetching them during the initial HTML parse, with one important constraint on priority.

## Why the hints are low priority

The landing app sets `images.unoptimized`, so these are served as raw PNGs totalling **9.4MB** (1.3–1.8MB each). A naive `preload` of all six is a net loss: `rel=preload` is a mandatory high-priority fetch, so ~8MB of below-the-fold artwork would contend with the 1.4MB hero, which is the LCP element.

So:

- The **hero is excluded**. Its `<Image priority>` already preloads it, and it stays the only image competing for early bandwidth.
- The **other five are `fetchPriority: "low"`**, warming the cache without delaying the LCP.

Hints are emitted before the `getGitHubRepoStats()` await, so they go out while the server is still waiting on the GitHub API rather than after it.

## Test plan

- [x] `npm run build` in `frontend/src/landing` succeeds
- [x] Diffed the prerendered `design-partners.html` against a `main` baseline build. Baseline emits one hero preload (from `next/image priority`); this branch keeps that untouched and adds five `fetchPriority="low"` hints:

```html
<link rel="preload" as="image" href="/design-partners/hero-car-engine-olive.png"/>
<link rel="preload" href="/design-partners/shared-workspace-olive.png" as="image" fetchPriority="low"/>
<link rel="preload" href="/design-partners/roadmap-fleet-olive.png" as="image" fetchPriority="low"/>
<link rel="preload" href="/design-partners/roadmap-mission-control-olive.png" as="image" fetchPriority="low"/>
<link rel="preload" href="/design-partners/roadmap-roi-olive.png" as="image" fetchPriority="low"/>
<link rel="preload" href="/design-partners/roadmap-engine-room-olive.png" as="image" fetchPriority="low"/>
```

- [ ] Confirm on the deploy preview that roadmap slides no longer pop in blank, and that hero LCP is unchanged

## Follow-up worth filing separately

The deeper issue is that 9.4MB of unoptimized PNGs ship on this page at all. Compressing them or serving WebP/AVIF would help far more than any preload strategy, but that is out of scope here.

## Notes

Rebased onto latest `main`; the only conflict was with #3197, which made this page `async` to fetch GitHub stats. Both changes are preserved.