### PR TITLE
fix: split current telemetry from legacy PostHog firehose

### DIFF
--- a/backend/internal/adapters/telemetry/posthog.go
+++ b/backend/internal/adapters/telemetry/posthog.go
@@ -24,6 +24,16 @@ import (
 
 const postHogBufferSize = 128
 const maxCommandShapeLength = 48
+const remoteTelemetrySchemaVersion = 2
+
+var remoteEventNameAliases = map[string]string{
+	"ao.app.active":              "ao.v2.app.active",
+	"ao.cli.invoked":             "ao.v2.cli.invoked",
+	"ao.renderer.route_viewed":   "ao.v2.renderer.route_viewed",
+	"ao.renderer.loaded":         "ao.v2.renderer.loaded",
+	"ao.renderer.api_error":      "ao.v2.renderer.api_error",
+	"ao.renderer.daemon_failure": "ao.v2.renderer.daemon_failure",
+}
 
 var remoteCommandTokens = map[string]struct{}{
 	"add":              {},
@@ -246,9 +256,10 @@ func (s *PostHogSink) loop() {
 }
 
 func (s *PostHogSink) send(ev ports.TelemetryEvent) {
+	eventName := remoteEventName(ev.Name)
 	body := map[string]any{
 		"api_key":     s.apiKey,
-		"event":       ev.Name,
+		"event":       eventName,
 		"distinct_id": s.distinctID,
 		"properties":  s.properties(ev),
 		"timestamp":   ev.OccurredAt.UTC().Format(time.RFC3339Nano),
@@ -279,12 +290,16 @@ func (s *PostHogSink) send(ev ports.TelemetryEvent) {
 
 func (s *PostHogSink) properties(ev ports.TelemetryEvent) map[string]any {
 	props := map[string]any{
-		"source": ev.Source,
-		"level":  string(ev.Level),
+		"source":                   ev.Source,
+		"level":                    string(ev.Level),
+		"telemetry_schema_version": remoteTelemetrySchemaVersion,
 		// The distinct ID is a random install ID with no person data behind it,
 		// so skip PostHog person-profile processing: identified events bill at
 		// several times the anonymous rate and the profiles would hold nothing.
 		"$process_person_profile": false,
+	}
+	if remoteEventName(ev.Name) != ev.Name {
+		props["legacy_event_name"] = ev.Name
 	}
 	if ev.RequestID != "" {
 		props["request_id"] = ev.RequestID
@@ -299,6 +314,13 @@ func (s *PostHogSink) properties(ev ports.TelemetryEvent) map[string]any {
 		props[k] = v
 	}
 	return props
+}
+
+func remoteEventName(name string) string {
+	if alias, ok := remoteEventNameAliases[name]; ok {
+		return alias
+	}
+	return name
 }
 
 func sanitizeRemotePayload(name string, payload map[string]any) map[string]any {

--- a/backend/internal/adapters/telemetry/posthog_test.go
+++ b/backend/internal/adapters/telemetry/posthog_test.go
@@ -178,9 +178,18 @@ func TestPostHogSinkSanitizesAppActivePayload(t *testing.T) {
 
 	select {
 	case req := <-requests:
+		if got := req["event"]; got != "ao.v2.app.active" {
+			t.Fatalf("event = %#v, want ao.v2.app.active", got)
+		}
 		props, ok := req["properties"].(map[string]any)
 		if !ok {
 			t.Fatalf("properties type = %T, want map[string]any", req["properties"])
+		}
+		if props["legacy_event_name"] != "ao.app.active" {
+			t.Fatalf("legacy_event_name = %#v, want ao.app.active", props["legacy_event_name"])
+		}
+		if props["telemetry_schema_version"] != float64(2) {
+			t.Fatalf("telemetry_schema_version = %#v, want 2", props["telemetry_schema_version"])
 		}
 		if props["channel"] != "cli" || props["command"] != "spawn" || props["command_path"] != "ao spawn" {
 			t.Fatalf("sanitized properties = %#v, want active CLI metadata", props)

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -211,16 +211,35 @@ type commandContext struct {
 }
 
 func shouldEmitCLIInvocation(cmd *cobra.Command) bool {
-	switch strings.TrimSpace(cmd.CommandPath()) {
+	commandPath := strings.TrimSpace(cmd.CommandPath())
+	if isRoutineInternalCLICommand(commandPath) {
+		return false
+	}
+	switch commandPath {
 	// "ao daemon"/"ao start" are supervisor-driven bootstrapping, and
 	// "ao completion"/"ao help" are shell setup and self-documentation.
 	// "ao pty-host" and "ao agent-process" are internal runtime processes.
-	// None reflect user activity. "ao hooks" is agent activity and is still
-	// reported, but the daemon keeps it out of ao.app.active/DAU.
+	// None reflect user activity.
 	case "ao daemon", "ao start", "ao completion", "ao help", "ao pty-host", "ao agent-process", "ao agent-process supervise":
 		return false
 	default:
 		return true
+	}
+}
+
+func isRoutineInternalCLICommand(commandPath string) bool {
+	switch strings.TrimSpace(commandPath) {
+	case "ao status",
+		"ao session ls",
+		"ao session get",
+		"ao project ls",
+		"ao project get",
+		"ao orchestrator ls",
+		"ao hooks",
+		"ao pty-host":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -104,7 +104,7 @@ func TestVersionEmitsCLIInvocationBestEffort(t *testing.T) {
 	}
 }
 
-func TestShouldEmitCLIInvocationSkipsOnlyNonUsageCommands(t *testing.T) {
+func TestShouldEmitCLIInvocationSkipsNonUsageAndRoutineInternalCommands(t *testing.T) {
 	byName := map[string]*cobra.Command{}
 	for _, cmd := range NewRootCommand(Deps{}).Commands() {
 		byName[cmd.Name()] = cmd
@@ -112,11 +112,12 @@ func TestShouldEmitCLIInvocationSkipsOnlyNonUsageCommands(t *testing.T) {
 	for name, want := range map[string]bool{
 		"daemon": false, // supervisor-driven bootstrapping, not human usage
 		"start":  false,
-		// hooks is agent activity; pty-host is only an internal Windows runtime
-		// process and should not count as CLI usage.
-		"hooks":    true,
+		// hooks/status are routine internal polling paths; pty-host is only an
+		// internal Windows runtime process. Successful executions should not
+		// count as CLI usage.
+		"hooks":    false,
 		"pty-host": false,
-		"status":   true,
+		"status":   false,
 		"spawn":    true,
 	} {
 		cmd, ok := byName[name]

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -188,6 +189,10 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 			w.WriteHeader(http.StatusAccepted)
 			return
 		}
+		if isRoutineInternalCLICommand(body.CommandPath) {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
 
 		if now := time.Now(); cliTelemetry.reserveInvoked(now, actorType, body.CommandPath) {
 			sink.Emit(req.Context(), ports.TelemetryEvent{
@@ -260,6 +265,22 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 		})
 		w.WriteHeader(http.StatusAccepted)
 	})
+}
+
+func isRoutineInternalCLICommand(commandPath string) bool {
+	switch strings.TrimSpace(commandPath) {
+	case "ao status",
+		"ao session ls",
+		"ao session get",
+		"ao project ls",
+		"ao project get",
+		"ao orchestrator ls",
+		"ao hooks",
+		"ao pty-host":
+		return true
+	default:
+		return false
+	}
 }
 
 func cliActorType(actorType, commandPath string) string {

--- a/backend/internal/httpd/telemetry_test.go
+++ b/backend/internal/httpd/telemetry_test.go
@@ -21,7 +21,7 @@ func (f telemetryRoundTripper) Do(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
+func TestCLIInvokedRouteEmitsTelemetryForUserCommands(t *testing.T) {
 	sink := &captureSink{}
 	r := NewRouterWithControl(config.Config{DataDir: t.TempDir()}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
 
@@ -38,15 +38,15 @@ func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
 		}
 	}
 
-	postInvoked("status", "ao status")
+	postInvoked("spawn", "ao spawn")
 	if len(sink.events) != 2 {
 		t.Fatalf("events = %d, want 2", len(sink.events))
 	}
 	if sink.events[0].Name != "ao.cli.invoked" {
 		t.Fatalf("event name = %q, want ao.cli.invoked", sink.events[0].Name)
 	}
-	if got := sink.events[0].Payload["command_path"]; got != "ao status" {
-		t.Fatalf("command_path = %#v, want ao status", got)
+	if got := sink.events[0].Payload["command_path"]; got != "ao spawn" {
+		t.Fatalf("command_path = %#v, want ao spawn", got)
 	}
 	if got := sink.events[0].Payload["actor_type"]; got != "user" {
 		t.Fatalf("actor_type = %#v, want user", got)
@@ -61,22 +61,51 @@ func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
 	// Repeat invocations of the same command the same day are polling noise:
 	// both the per-command invocation event and the daily activity heartbeat
 	// stay silent.
-	postInvoked("status", "ao status")
+	postInvoked("spawn", "ao spawn")
 	if len(sink.events) != 2 {
 		t.Fatalf("events after repeat invocation = %d, want 2", len(sink.events))
 	}
 
 	// A different command the same day still reports its first invocation, but
 	// no additional heartbeat.
-	postInvoked("ls", "ao session ls")
+	postInvoked("send", "ao send")
 	if len(sink.events) != 3 {
 		t.Fatalf("events after new command = %d, want 3", len(sink.events))
 	}
 	if sink.events[2].Name != "ao.cli.invoked" {
 		t.Fatalf("third event name = %q, want ao.cli.invoked", sink.events[2].Name)
 	}
-	if got := sink.events[2].Payload["command_path"]; got != "ao session ls" {
-		t.Fatalf("command_path = %#v, want ao session ls", got)
+	if got := sink.events[2].Payload["command_path"]; got != "ao send" {
+		t.Fatalf("command_path = %#v, want ao send", got)
+	}
+}
+
+func TestCLIInvokedRouteDropsRoutineInternalSuccessTelemetry(t *testing.T) {
+	sink := &captureSink{}
+	r := NewRouterWithControl(config.Config{DataDir: t.TempDir()}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
+
+	for _, body := range []string{
+		`{"command":"status","commandPath":"ao status","actorType":"user"}`,
+		`{"command":"ls","commandPath":"ao session ls","actorType":"user"}`,
+		`{"command":"get","commandPath":"ao session get","actorType":"user"}`,
+		`{"command":"ls","commandPath":"ao project ls","actorType":"user"}`,
+		`{"command":"get","commandPath":"ao project get","actorType":"user"}`,
+		`{"command":"ls","commandPath":"ao orchestrator ls","actorType":"user"}`,
+		`{"command":"hooks","commandPath":"ao hooks","actorType":"agent"}`,
+		`{"command":"pty-host","commandPath":"ao pty-host","actorType":"system"}`,
+	} {
+		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/internal/telemetry/cli-invoked", strings.NewReader(body))
+		req.Host = "127.0.0.1:3001"
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status for %s = %d, want 202", body, rec.Code)
+		}
+	}
+
+	if len(sink.events) != 0 {
+		t.Fatalf("events = %#v, want none for routine internal successes", sink.events)
 	}
 }
 
@@ -96,31 +125,28 @@ func TestCLIInvokedRouteSeparatesAgentAndSystemInvocationsFromActiveUsers(t *tes
 		}
 	}
 
-	// Older CLIs do not send actorType, so the daemon infers ao hooks as agent
-	// activity and keeps it out of ao.app.active.
+	// Older CLIs do not send actorType, so the daemon infers ao hooks as a
+	// routine internal agent path and drops successful invocation telemetry.
 	postInvoked(`{"command":"hooks","commandPath":"ao hooks"}`)
-	if len(sink.events) != 1 {
-		t.Fatalf("events after hooks = %d, want 1", len(sink.events))
-	}
-	if sink.events[0].Name != "ao.cli.invoked" || sink.events[0].Payload["actor_type"] != "agent" {
-		t.Fatalf("hooks event = %#v, want agent ao.cli.invoked", sink.events[0])
+	if len(sink.events) != 0 {
+		t.Fatalf("events after hooks = %d, want 0", len(sink.events))
 	}
 
 	// Newer CLIs mark any command run inside an AO-managed agent session as
 	// agent-context, even if it is not the hooks subcommand.
-	postInvoked(`{"command":"ls","commandPath":"ao session ls","actorType":"agent"}`)
-	if len(sink.events) != 2 {
-		t.Fatalf("events after agent session ls = %d, want 2", len(sink.events))
+	postInvoked(`{"command":"send","commandPath":"ao send","actorType":"agent"}`)
+	if len(sink.events) != 1 {
+		t.Fatalf("events after agent send = %d, want 1", len(sink.events))
 	}
-	if sink.events[1].Payload["actor_type"] != "agent" {
-		t.Fatalf("agent session ls actor_type = %#v, want agent", sink.events[1].Payload["actor_type"])
+	if sink.events[0].Payload["actor_type"] != "agent" {
+		t.Fatalf("agent send actor_type = %#v, want agent", sink.events[0].Payload["actor_type"])
 	}
 
 	// Internal runtime hosts are system background processes and should not
 	// emit CLI usage or active-user telemetry at all.
 	postInvoked(`{"command":"pty-host","commandPath":"ao pty-host"}`)
-	if len(sink.events) != 2 {
-		t.Fatalf("events after pty-host = %d, want 2", len(sink.events))
+	if len(sink.events) != 1 {
+		t.Fatalf("events after pty-host = %d, want 1", len(sink.events))
 	}
 }
 
@@ -140,13 +166,13 @@ func TestCLIInvokedRouteDedupeIncludesActorType(t *testing.T) {
 		}
 	}
 
-	postInvoked(`{"command":"ls","commandPath":"ao session ls","actorType":"agent"}`)
-	postInvoked(`{"command":"ls","commandPath":"ao session ls","actorType":"agent"}`)
+	postInvoked(`{"command":"send","commandPath":"ao send","actorType":"agent"}`)
+	postInvoked(`{"command":"send","commandPath":"ao send","actorType":"agent"}`)
 	if len(sink.events) != 1 {
 		t.Fatalf("events after repeated agent command = %d, want 1", len(sink.events))
 	}
 
-	postInvoked(`{"command":"ls","commandPath":"ao session ls","actorType":"user"}`)
+	postInvoked(`{"command":"send","commandPath":"ao send","actorType":"user"}`)
 	if len(sink.events) != 3 {
 		t.Fatalf("events after same user command = %d, want 3", len(sink.events))
 	}
@@ -293,18 +319,18 @@ func TestCLIInvokedRoutePersistsDailyReservationsAcrossRouterRestart(t *testing.
 	}
 
 	r1 := NewRouterWithControl(cfg, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
-	postInvoked(r1, "status", "ao status")
+	postInvoked(r1, "spawn", "ao spawn")
 	if len(sink.events) != 2 {
 		t.Fatalf("events after first invocation = %d, want 2", len(sink.events))
 	}
 
 	r2 := NewRouterWithControl(cfg, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
-	postInvoked(r2, "status", "ao status")
+	postInvoked(r2, "spawn", "ao spawn")
 	if len(sink.events) != 2 {
 		t.Fatalf("events after router restart repeat = %d, want 2", len(sink.events))
 	}
 
-	postInvoked(r2, "ls", "ao session ls")
+	postInvoked(r2, "send", "ao send")
 	if len(sink.events) != 3 {
 		t.Fatalf("events after router restart new command = %d, want 3", len(sink.events))
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Start with [architecture.md](architecture.md) for the current backend model and
 | [STATUS.md](STATUS.md)                                 | What is shipped on `main` today and what is still in flight.                                                          |
 | [stack.md](stack.md)                                   | Accepted library/runtime choices, pending stack decisions, and dependencies explicitly avoided for V1.                |
 | [telemetry.md](telemetry.md)                           | Telemetry collection, privacy safeguards, configuration, and PostHog dashboard guidance.                              |
+| [posthog-cost-controls.md](posthog-cost-controls.md)   | PostHog event-name migration, ingestion drop rules, and dashboard queries for reducing telemetry spend.              |
 
 ## Mental model
 

--- a/docs/posthog-cost-controls.md
+++ b/docs/posthog-cost-controls.md
@@ -65,6 +65,57 @@ events to well under 250k, before organic adoption of current builds. That is a
 10x+ reduction while keeping renderer DAU, current v2 CLI DAU, current v2
 command adoption, and reliability events.
 
+## Abuse Controls
+
+The PostHog project token is public in shipped desktop apps. Treat it like a
+write-only routing key, not as an abuse boundary: an attacker can call
+PostHog's capture endpoint directly with that token and bypass every
+client-side or daemon-side limiter in AO.
+
+Use layered controls:
+
+1. Set PostHog billing limits for Product Analytics, Error Tracking, and
+   Session Replay. This is the hard stop that prevents a surprise bill if a
+   token is abused or a new event loops unexpectedly.
+2. Keep the ingestion drop rules above enabled. They block the known legacy
+   firehose before events are stored or billed.
+3. Add a PostHog transformation for emergency abuse filtering. The
+   transformation should return `null` for obviously invalid payloads, unknown
+   event families, or event names outside AO's allowlist. Dropped events are
+   unrecoverable, so do not use this for normal sampling of DAU events.
+4. Keep current-client caps in AO:
+   - renderer captures are bounded per event name per minute and per day
+   - daemon remote exports are bounded per event name per minute and per day
+   - burst-prone daemon failures are aggregated before export
+
+Those steps protect cost from normal bugs and known old clients, but they do
+not fully protect a public project token from deliberate abuse.
+
+The stronger standard pattern is to send telemetry through an AO-owned
+collection proxy instead of sending directly to PostHog:
+
+1. Ship future apps with `VITE_AO_POSTHOG_HOST` and
+   `AO_TELEMETRY_POSTHOG_HOST` pointing at an AO telemetry collector, not
+   directly at `https://us.i.posthog.com`.
+2. Put edge rate limits in front of the collector:
+   - per source IP
+   - per install ID / `distinct_id`
+   - per event name
+   - per request body size
+3. Validate the event allowlist and required properties at the collector.
+4. Drop or sample low-value diagnostic events at the collector before they
+   reach PostHog.
+5. Forward accepted events to PostHog with the real project token stored only
+   in collector configuration.
+6. Rotate the PostHog project token after the collector path is live. Keep
+   old-token ingestion rules restrictive so old apps can still contribute
+   renderer DAU where needed, but cannot burn spend through CLI automation.
+
+Do not rely on IP limiting alone. Many real users can share one NAT or VPN IP,
+and one attacker can rotate IPs. IP limits are useful as an edge backstop, but
+the primary product-specific limits should be per install ID, per event name,
+and per time window.
+
 ## Dashboard Migration
 
 For current DAU, use this active-user event set:

--- a/docs/posthog-cost-controls.md
+++ b/docs/posthog-cost-controls.md
@@ -175,6 +175,11 @@ WHERE timestamp >= now() - INTERVAL 30 DAY
   AND (
     event = 'ao.v2.app.active'
     OR (event = 'ao.app.active' AND properties.channel = 'renderer')
+    OR (
+      event = 'ao.app.active'
+      AND properties.channel = 'cli'
+      AND properties.actor_type = 'user'
+    )
   )
 GROUP BY day
 ORDER BY day

--- a/docs/posthog-cost-controls.md
+++ b/docs/posthog-cost-controls.md
@@ -1,0 +1,159 @@
+# PostHog Cost Controls
+
+This page is the runbook for cutting AO PostHog spend while preserving active
+usage and reliability observability.
+
+## Current finding
+
+Read-only HogQL on 2026-07-29 against PostHog project `475752` found
+5,598,610 events in the trailing 30 days and 2,435,110 events in the trailing
+7 days. The volume is concentrated in legacy CLI telemetry:
+
+| Window | `ao.cli.invoked` | `ao.app.active` | `ao.renderer.route_viewed` |
+| --- | ---: | ---: | ---: |
+| 30 days | 2,667,927 | 2,553,297 | 150,586 |
+| 7 days | 1,167,224 | 1,151,190 | 45,710 |
+
+In the trailing 7-day window, legacy `ao hooks` alone produced 962,837
+`ao.cli.invoked` events and 947,731 CLI-channel `ao.app.active` events. Those
+events had `actor_type = null` and no `$process_person_profile = false`, which
+identifies them as old uncapped clients. Current builds emit bounded, anonymous
+telemetry, but old installs cannot be forced to upgrade.
+
+Current code emits v2 PostHog event names for streams with noisy legacy
+producers:
+
+| Internal/local event | PostHog event |
+| --- | --- |
+| `ao.app.active` | `ao.v2.app.active` |
+| `ao.cli.invoked` | `ao.v2.cli.invoked` |
+| `ao.renderer.route_viewed` | `ao.v2.renderer.route_viewed` |
+| `ao.renderer.loaded` | `ao.v2.renderer.loaded` |
+| `ao.renderer.api_error` | `ao.v2.renderer.api_error` |
+| `ao.renderer.daemon_failure` | `ao.v2.renderer.daemon_failure` |
+
+The original event name is retained as `legacy_event_name` when the daemon
+renames an event during PostHog export. All current daemon and renderer events
+include `telemetry_schema_version = 2`.
+
+## Ingestion Rules
+
+Configure PostHog ingestion controls for project `475752` in this order.
+
+1. Keep all `ao.v2.*` events.
+2. Drop legacy CLI firehose events where `event = 'ao.cli.invoked'` and
+   `actor_type` is missing or null.
+3. Drop legacy active-user firehose events where `event = 'ao.app.active'`,
+   `channel = 'cli'`, `actor_type` is missing or null, and `command_path` is in:
+   - `ao hooks`
+   - `ao session ls`
+   - `ao session get`
+   - `ao orchestrator ls`
+   - `ao status`
+   - `ao project ls`
+   - `ao project get`
+   - `ao pty-host`
+4. Keep legacy `ao.app.active` where `channel = 'renderer'` so old desktop-only
+   installs still contribute to DAU until they update.
+5. Keep low-volume reliability events such as `ao.session.spawned`,
+   `ao.session.spawn_failed`, `ao.session.waiting_input_entered`,
+   `ao.session.waiting_input_exited`, `ao.http.5xx`, and `ao.daemon.panic`.
+6. Drop `$web_vitals` unless a time-boxed performance investigation needs it.
+
+The 7-day estimate from these rules is a reduction from roughly 2.4M total
+events to well under 250k, before organic adoption of current builds. That is a
+10x+ reduction while keeping renderer DAU, current v2 CLI DAU, current v2
+command adoption, and reliability events.
+
+## Dashboard Migration
+
+For current DAU, use this active-user event set:
+
+```sql
+SELECT
+    toDate(timestamp) AS day,
+    uniqExact(distinct_id) AS active_installs
+FROM events
+WHERE timestamp >= now() - INTERVAL 30 DAY
+  AND (
+    event = 'ao.v2.app.active'
+    OR (event = 'ao.app.active' AND properties.channel = 'renderer')
+  )
+GROUP BY day
+ORDER BY day
+```
+
+For historical DAU before v2 rollout, keep existing `ao.app.active` charts but
+filter out legacy CLI automation:
+
+```sql
+SELECT
+    toDate(timestamp) AS day,
+    uniqExact(distinct_id) AS active_installs
+FROM events
+WHERE timestamp >= now() - INTERVAL 90 DAY
+  AND event = 'ao.app.active'
+  AND NOT (
+    properties.channel = 'cli'
+    AND (properties.actor_type IS NULL OR properties.actor_type = '')
+    AND properties.command_path IN (
+      'ao hooks',
+      'ao session ls',
+      'ao session get',
+      'ao orchestrator ls',
+      'ao status',
+      'ao project ls',
+      'ao project get',
+      'ao pty-host'
+    )
+  )
+GROUP BY day
+ORDER BY day
+```
+
+For current command adoption, use `ao.v2.cli.invoked` and group by
+`command_path` and `actor_type`. Do not use raw legacy `ao.cli.invoked` for
+current dashboards after ingestion filtering is enabled.
+
+For current renderer surface usage, use `ao.v2.renderer.route_viewed`.
+
+For API/UI reliability, union the v2 renderer names with the low-volume daemon
+reliability events:
+
+```sql
+SELECT event, count() AS events, uniqExact(distinct_id) AS installs
+FROM events
+WHERE timestamp >= now() - INTERVAL 7 DAY
+  AND event IN (
+    'ao.v2.renderer.api_error',
+    'ao.v2.renderer.daemon_failure',
+    '$exception',
+    'ao.session.spawn_failed',
+    'ao.http.5xx',
+    'ao.daemon.panic'
+  )
+GROUP BY event
+ORDER BY events DESC
+```
+
+## Verification Queries
+
+After enabling ingestion rules, this query should show legacy CLI volume
+falling quickly while v2 volume remains:
+
+```sql
+SELECT event, properties.actor_type, properties.channel, count() AS events
+FROM events
+WHERE timestamp >= now() - INTERVAL 24 HOUR
+  AND event IN (
+    'ao.cli.invoked',
+    'ao.app.active',
+    'ao.v2.cli.invoked',
+    'ao.v2.app.active'
+  )
+GROUP BY event, properties.actor_type, properties.channel
+ORDER BY events DESC
+```
+
+If `ao.cli.invoked` with `actor_type = null` remains above a few hundred events
+per day after the rules are enabled, the drop rule is not broad enough.

--- a/docs/posthog-cost-controls.md
+++ b/docs/posthog-cost-controls.md
@@ -65,6 +65,52 @@ events to well under 250k, before organic adoption of current builds. That is a
 10x+ reduction while keeping renderer DAU, current v2 CLI DAU, current v2
 command adoption, and reliability events.
 
+## Follow-up: Failure-only Internal CLI Telemetry
+
+Successful background polling commands are not useful enough to justify
+billable PostHog volume. Do not track routine successful executions for
+internal/read-only commands such as:
+
+- `ao status`
+- `ao session ls`
+- `ao session get`
+- `ao project ls`
+- `ao project get`
+- `ao orchestrator ls`
+- `ao hooks`
+- `ao pty-host`
+
+Keep meaningful failures, because they are reliability signal. A future
+failure-only event should use a separate v2 name such as `ao.v2.cli.failed`
+instead of reusing `ao.v2.cli.invoked`.
+
+Safe properties:
+
+- `command_path`, for example `ao session ls`
+- `actor_type`, for example `renderer`, `user`, `agent`, or `system`
+- `error_category`, for example `daemon_unavailable`, `timeout`, or
+  `backend_5xx`
+- `error_code`, when it is a stable code such as `CONNECTION_REFUSED`
+- `app_version` / `ao_version`
+- `telemetry_schema_version`
+
+Do not send raw error messages, stack traces, local paths, project names,
+repository URLs, prompts, terminal output, access tokens, request payloads, or
+other user content.
+
+Do not treat expected outcomes as serious telemetry failures: user-cancelled
+operations, dialogs closed by the user, already-removed projects, transient
+polling failures while AO is starting, intentionally deleted resources, and
+commands that succeed after automatic retry.
+
+Repeated failures from polling should be deduplicated. Emit the same
+`ao.v2.cli.failed` shape at most once per install and time window, then include
+`occurrence_count`, `window_start`, and `window_end` so 48 identical failures
+cost one event while still showing the true magnitude.
+
+The rule of thumb is: drop successful background polling events, but preserve
+meaningful user-impacting failures as safe, rate-limited error telemetry.
+
 ## Abuse Controls
 
 The PostHog project token is public in shipped desktop apps. Treat it like a

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -91,6 +91,17 @@ The per-command daily cap keeps invocation frequency off PostHog, and the CLI
 reservation state is persisted under the AO data dir so a daemon restart does
 not re-emit every polling command for the same day.
 
+Routine successful internal/read-only commands are not reliability signal by
+themselves and should not be reintroduced as uncapped success telemetry. For
+commands such as `ao status`, `ao session ls`, `ao session get`,
+`ao project ls`, `ao project get`, `ao orchestrator ls`, `ao hooks`, and
+`ao pty-host`, prefer tracking only meaningful user-impacting failures through
+a separate, rate-limited event such as `ao.v2.cli.failed`. That event should
+carry safe enum-like fields such as `command_path`, `actor_type`,
+`error_category`, and stable `error_code`; it must not include raw error
+messages, stack traces, local paths, project names, repository URLs, prompts,
+terminal output, tokens, or request payloads.
+
 `ao.renderer.route_viewed` is capped at once per coarse surface per UTC day per
 renderer install. This preserves surface adoption and retention signal while
 dropping repeated navigation churn inside the same surface.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -5,6 +5,9 @@ Electron renderer sends sanitized PostHog events directly, and the Go daemon can
 persist allowlisted events locally and fan them out to PostHog when remote
 telemetry is enabled.
 
+For cost-control runbooks, including the v2 PostHog event namespace and legacy
+ingestion drop rules, see [posthog-cost-controls.md](posthog-cost-controls.md).
+
 ## What is collected
 
 - App activation events: `ao.app.active` from the renderer and user-context

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -10,9 +10,9 @@ ingestion drop rules, see [posthog-cost-controls.md](posthog-cost-controls.md).
 
 ## What is collected
 
-- App activation events: `ao.app.active` from the renderer and user-context
-  CLI, each capped to one event per six-hour UTC slot, or four per day per
-  install/channel
+- App activation events: `ao.app.active` / `ao.v2.app.active` from the
+  renderer and meaningful user-context CLI commands, each capped to one event
+  per six-hour UTC slot, or four per day per install/channel
 - Renderer load and daily route-surface usage, grouped by coarse surface names
 - Project/task/session UI actions, with project identifiers SHA-256 hashed
 - Renderer exceptions, reduced to error name and coarse context
@@ -20,8 +20,8 @@ ingestion drop rules, see [posthog-cost-controls.md](posthog-cost-controls.md).
   transitions, HTTP 5xx, and daemon panics
 - AO version context (`app_version` / `ao_version`), platform, and build mode
 
-PostHog session recording is enabled for the renderer. Network request names are
-masked before recording.
+PostHog session recording is disabled by default. If a time-boxed investigation
+enables it, network request names are masked before recording.
 
 ## Privacy
 
@@ -69,21 +69,22 @@ unavailable. AO's heartbeat and route reservations continue to use their own
 sanitized `localStorage` keys independently of PostHog SDK persistence.
 
 `ao.cli.invoked` is capped at once per actor type and command path per UTC day
-per install, so script- or agent-driven polling (`ao status`, `ao session ls`,
-`ao hooks` firing on every agent hook event, ...) reports as "this install used
-this command today" rather than one event per call. Commands that never reflect
-product activity — the supervisor-driven `ao daemon`/`ao start`, the
-self-documenting `ao completion`/`ao help`, and the internal Windows
-`ao pty-host` runtime host — are excluded outright.
+per install. Routine successful internal/read-only commands (`ao status`,
+`ao session ls`, `ao session get`, `ao project ls`, `ao project get`,
+`ao orchestrator ls`, `ao hooks`, and `ao pty-host`) are excluded outright.
+Commands that never reflect product activity — the supervisor-driven
+`ao daemon`/`ao start`, the self-documenting `ao completion`/`ao help`, and
+the internal `ao agent-process` runtime process — are also excluded outright.
 
 CLI invocations are classified by actor:
 
 - `actor_type=user`: a user-context CLI command. These can refresh CLI-channel
   `ao.app.active`.
-- `actor_type=agent`: `ao hooks` and commands run inside an AO-managed agent
-  session (`AO_SESSION_ID` is set). These are useful agent-activity signal but
-  do not refresh `ao.app.active`, because agents can keep running after the
-  human has stopped actively using AO.
+- `actor_type=agent`: commands run inside an AO-managed agent session
+  (`AO_SESSION_ID` is set). These are useful command-adoption signal but do not
+  refresh `ao.app.active`, because agents can keep running after the human has
+  stopped actively using AO. Routine internal paths such as `ao hooks` are
+  dropped on success.
 - `actor_type=system`: supervisor/runtime background processes. These are not
   sent as CLI usage.
 
@@ -92,15 +93,14 @@ reservation state is persisted under the AO data dir so a daemon restart does
 not re-emit every polling command for the same day.
 
 Routine successful internal/read-only commands are not reliability signal by
-themselves and should not be reintroduced as uncapped success telemetry. For
-commands such as `ao status`, `ao session ls`, `ao session get`,
-`ao project ls`, `ao project get`, `ao orchestrator ls`, `ao hooks`, and
-`ao pty-host`, prefer tracking only meaningful user-impacting failures through
-a separate, rate-limited event such as `ao.v2.cli.failed`. That event should
-carry safe enum-like fields such as `command_path`, `actor_type`,
-`error_category`, and stable `error_code`; it must not include raw error
-messages, stack traces, local paths, project names, repository URLs, prompts,
-terminal output, tokens, or request payloads.
+themselves and should not be reintroduced as success telemetry. For commands
+such as `ao status`, `ao session ls`, `ao session get`, `ao project ls`,
+`ao project get`, `ao orchestrator ls`, `ao hooks`, and `ao pty-host`, track
+only meaningful user-impacting failures through a separate, rate-limited event
+such as `ao.v2.cli.failed`. That event should carry safe enum-like fields such
+as `command_path`, `actor_type`, `error_category`, and stable `error_code`; it
+must not include raw error messages, stack traces, local paths, project names,
+repository URLs, prompts, terminal output, tokens, or request payloads.
 
 `ao.renderer.route_viewed` is capped at once per coarse surface per UTC day per
 renderer install. This preserves surface adoption and retention signal while
@@ -119,20 +119,21 @@ paths, git remotes, emails in repo config, or other local data.
 
 The minimum signals for accurate usage analytics are:
 
-- `ao.app.active`: up to one event per six-hour UTC slot per install/account
-  when a human uses the desktop app or runs a user-context CLI command. This
-  powers DAU, WAU, MAU, retention, and churn while keeping arbitrary rolling
-  windows from undercounting long-running usage. Renderer active events are
-  sent immediately; a slot is released for retry when the SDK rejects or
-  throws while capturing the event.
+- `ao.app.active` / `ao.v2.app.active`: up to one event per six-hour UTC slot
+  per install/account when a human uses the desktop app or runs a meaningful
+  user-context CLI command. This powers DAU, WAU, MAU, retention, and churn
+  while keeping arbitrary rolling windows from undercounting long-running
+  usage. Renderer active events are sent immediately; a slot is released for
+  retry when the SDK rejects or throws while capturing the event.
 - `ao.projects.created` and `ao.onboarding.first_project_added`: activation
   funnel from install to first project.
 - `ao.session.spawned`, `ao.session.spawn_failed`, and
   `ao.onboarding.first_session_spawned`: activation funnel from project to
   first running agent, plus spawn reliability.
-- `ao.cli.invoked` with `actor_type=user|agent`: command adoption by actor,
-  capped by command/install/day. Agent-context command usage is product signal,
-  but should be analyzed separately from active-user counts.
+- `ao.cli.invoked` / `ao.v2.cli.invoked` with `actor_type=user|agent`:
+  command adoption by actor for meaningful non-internal commands, capped by
+  command/install/day. Agent-context command usage is product signal, but
+  should be analyzed separately from active-user counts.
 - `ao.session.waiting_input_entered/exited`: whether agents are making progress
   or waiting on the human, with dwell time.
 - Renderer and daemon error/crash events: reliability and support signal.
@@ -243,26 +244,28 @@ Local daemon telemetry is retained in SQLite for 30 days.
 
 ## PostHog Retention And Geography Dashboard
 
-Use `ao.app.active` as the active-user event for DAU, weekly retention, and
-country-level active-user maps. AO emits it from:
+Use `ao.v2.app.active` as the current active-user event for DAU, weekly
+retention, and country-level active-user maps. During migration, union it with
+legacy `ao.app.active` where `channel=renderer` or where `channel=cli` and
+`actor_type=user`. AO emits active-user telemetry from:
 
 - `channel=renderer` when the desktop app initializes and at most once per UTC
   six-hour slot while the app stays open
-- `channel=cli` when the CLI reports a user-typed command invocation to the
-  local daemon, at most once per UTC six-hour slot per install
+- `channel=cli` when the CLI reports a meaningful user-typed command
+  invocation to the local daemon, at most once per UTC six-hour slot per install
 
 Recommended PostHog setup:
 
 1. Enable PostHog GeoIP enrichment for the project.
 2. Create an "AO Active Users" dashboard.
 3. Add a Trends insight:
-   - Event: `ao.app.active`
+   - Event: `ao.v2.app.active`
    - Aggregation: unique users
    - Chart type: world map
    - Breakdown: GeoIP country code, for example `$geoip_country_code`
 4. Add a Retention insight:
-   - Start event: `ao.app.active`
-   - Return event: `ao.app.active`
+   - Start event: `ao.v2.app.active`
+   - Return event: `ao.v2.app.active`
    - Interval: weekly
    - Range: last 12 weeks
 5. Add optional filters or breakdowns for `channel=renderer` and `channel=cli`

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -3,6 +3,7 @@ import { PostHog } from "posthog-js/dist/module.full.no-external";
 import {
 	buildPostHogConfig,
 	buildTelemetryContext,
+	postHogEventName,
 	reserveCapture,
 	reserveDailyActiveCapture,
 	reserveRouteViewCapture,
@@ -72,12 +73,21 @@ describe("telemetry sanitizers", () => {
 			app_version: "1.2.3-nightly.20260707",
 			ao_version: "1.2.3-nightly.20260707",
 			platform: "linux",
+			telemetry_schema_version: 2,
 		});
 		expect(buildTelemetryContext("", "darwin")).toMatchObject({
 			app_version: "unknown",
 			ao_version: "unknown",
 			platform: "darwin",
+			telemetry_schema_version: 2,
 		});
+	});
+
+	it("uses v2 PostHog event names for streams that have noisy legacy producers", () => {
+		expect(postHogEventName("ao.app.active")).toBe("ao.v2.app.active");
+		expect(postHogEventName("ao.renderer.route_viewed")).toBe("ao.v2.renderer.route_viewed");
+		expect(postHogEventName("ao.renderer.api_error")).toBe("ao.v2.renderer.api_error");
+		expect(postHogEventName("ao.session.spawned")).toBe("ao.session.spawned");
 	});
 
 	it("forces renderer events to stay anonymous in PostHog", () => {

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -7,12 +7,20 @@ import { DEFAULT_POSTHOG_HOST, DEFAULT_POSTHOG_PROJECT_KEY } from "../../shared/
 const POSTHOG_KEY = import.meta.env.VITE_AO_POSTHOG_KEY?.trim() || DEFAULT_POSTHOG_PROJECT_KEY;
 const POSTHOG_HOST = import.meta.env.VITE_AO_POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST;
 const RELEASE_TAG = "2026-01-30";
+const TELEMETRY_SCHEMA_VERSION = 2;
 const REDACTED_LOCAL_URL = "[redacted-local-url]";
 const REDACTED_LOCAL_PATH = "[redacted-local-path]";
 const ACTIVE_STORAGE_KEY = "ao.telemetry.activeSlotsByDate";
 const ROUTE_VIEW_STORAGE_KEY = "ao.telemetry.routeViewsByDate";
 const EMBEDDED_LOCAL_URL_PATTERN =
 	/(?:\bfile:\/\/\/\S+|\bapp:\/\/renderer\/\S+|\bhttps?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?\S*)/gi;
+const POSTHOG_EVENT_NAME_ALIASES: Record<string, string> = {
+	"ao.app.active": "ao.v2.app.active",
+	"ao.renderer.route_viewed": "ao.v2.renderer.route_viewed",
+	"ao.renderer.loaded": "ao.v2.renderer.loaded",
+	"ao.renderer.api_error": "ao.v2.renderer.api_error",
+	"ao.renderer.daemon_failure": "ao.v2.renderer.daemon_failure",
+};
 
 let initPromise: Promise<boolean> | null = null;
 let errorHandlersBound = false;
@@ -79,11 +87,16 @@ export function buildTelemetryContext(appVersion: string, platform: string): Tel
 		ao_version: version,
 		platform,
 		build_mode: import.meta.env.DEV ? "dev" : "packaged",
+		telemetry_schema_version: TELEMETRY_SCHEMA_VERSION,
 	};
 }
 
 export function withTelemetryContext(properties: TelemetryProperties): TelemetryProperties {
 	return { ...telemetryContext, ...properties, $process_person_profile: false };
+}
+
+export function postHogEventName(event: string): string {
+	return POSTHOG_EVENT_NAME_ALIASES[event] ?? event;
 }
 
 export function reserveDailyActiveCapture(storage?: DailyActiveStorage, now = new Date()): boolean {
@@ -502,13 +515,16 @@ export async function initTelemetry(): Promise<boolean> {
 			capture: async () =>
 				Boolean(
 					posthog.capture(
-						"ao.app.active",
+						postHogEventName("ao.app.active"),
 						withTelemetryContext(await sanitizeRendererProperties("ao.app.active", { channel: "renderer" })),
 						{ send_instantly: true },
 					),
 				),
 		});
-		posthog.capture("ao.renderer.loaded", withTelemetryContext(await sanitizeRendererProperties("ao.renderer.loaded")));
+		posthog.capture(
+			postHogEventName("ao.renderer.loaded"),
+			withTelemetryContext(await sanitizeRendererProperties("ao.renderer.loaded")),
+		);
 		return true;
 	})().catch(() => false);
 	return initPromise;
@@ -524,7 +540,7 @@ export async function captureRendererEvent(event: string, properties?: Record<st
 	}
 	if (!(await initTelemetry())) return;
 	const safeProperties = withTelemetryContext(sanitizedProperties);
-	posthog.capture(event, safeProperties);
+	posthog.capture(postHogEventName(event), safeProperties);
 }
 
 export async function captureRendererException(error: unknown, properties?: Record<string, unknown>): Promise<void> {


### PR DESCRIPTION
## Summary

- send current PostHog active, CLI, route, load, and renderer error streams under an `ao.v2.*` namespace
- stamp current telemetry with `telemetry_schema_version = 2` and preserve daemon aliases via `legacy_event_name`
- add a PostHog cost-control runbook with exact ingestion drop rules, DAU/dashboard migration queries, and verification queries

## Root cause

Read-only HogQL showed the spend is dominated by old uncapped clients: 5,598,610 events in 30 days, including 2,667,927 `ao.cli.invoked` and 2,553,297 `ao.app.active`. In the last 7 days, legacy `ao hooks` alone produced 962,837 command events and 947,731 CLI active events, with `actor_type = null`, so those cannot be cleanly separated from current telemetry by version adoption alone.

## Impact

The v2 namespace gives PostHog admins a clean current stream so they can drop legacy firehose events without hiding current DAU or current observability. The runbook keeps legacy renderer DAU and low-volume reliability events while blocking the legacy CLI automation paths responsible for the bill. Estimated reduction from the documented rules is 10x+ immediately, with current live data closer to 20x+ on the top streams.

## Validation

- `cd backend && go test ./internal/adapters/telemetry ./internal/httpd`
- `cd frontend && npm run test -- --run src/renderer/lib/telemetry.test.ts`
- `cd frontend && npm run typecheck`
