### PR TITLE
Record metadata-only SessionStart as a spawn receipt

### DIFF
--- a/backend/internal/adapters/agent/claudecode/activity_test.go
+++ b/backend/internal/adapters/agent/claudecode/activity_test.go
@@ -35,7 +35,9 @@ func TestDeriveActivityState(t *testing.T) {
 		{"session-end absent reason -> exited", "session-end", `{}`, domain.ActivityExited, true},
 		{"session-end clear -> no signal", "session-end", `{"reason":"clear"}`, "", false},
 		{"session-end resume -> no signal", "session-end", `{"reason":"resume"}`, "", false},
-		{"session-start -> no signal", "session-start", `{}`, "", false},
+		{"session-start without source -> no activity state", "session-start", `{}`, "", false},
+		{"session-start fresh spawn -> no activity state", "session-start", `{"source":"startup"}`, "", false},
+		{"session-start resume -> no activity state", "session-start", `{"source":"resume"}`, "", false},
 		{"unknown event -> no signal", "frobnicate", `{}`, "", false},
 	}
 	for _, tt := range tests {

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -409,9 +409,10 @@ func TestGetAgentHooksInstallsClaudeHooks(t *testing.T) {
 	if len(config.Permissions) == 0 {
 		t.Fatalf("unrelated settings clobbered: %s", data)
 	}
-	// SessionStart carries the required matcher; UserPromptSubmit omits it.
-	if m := matcherForCommand(config.Hooks["SessionStart"], "ao hooks claude-code session-start"); m == nil || *m != "startup" {
-		t.Fatalf("SessionStart matcher = %v, want startup", m)
+	// SessionStart covers both a fresh spawn and AO's resume path;
+	// UserPromptSubmit omits a matcher.
+	if m := matcherForCommand(config.Hooks["SessionStart"], "ao hooks claude-code session-start"); m == nil || *m != "startup|resume" {
+		t.Fatalf("SessionStart matcher = %v, want startup|resume", m)
 	}
 	if m := matcherForCommand(config.Hooks["UserPromptSubmit"], "ao hooks claude-code user-prompt-submit"); m != nil {
 		t.Fatalf("UserPromptSubmit matcher = %v, want none", m)
@@ -423,6 +424,47 @@ func TestGetAgentHooksInstallsClaudeHooks(t *testing.T) {
 	}
 	if m := matcherForCommand(config.Hooks["SessionEnd"], "ao hooks claude-code session-end"); m != nil {
 		t.Fatalf("SessionEnd matcher = %v, want none", m)
+	}
+}
+
+func TestGetAgentHooksMigratesStartupOnlySessionStartMatcher(t *testing.T) {
+	p := &Plugin{resolvedBinary: "claude"}
+	workspace := t.TempDir()
+	settingsPath := filepath.Join(workspace, ".claude", "settings.local.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"hooks":{"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"ao hooks claude-code session-start","timeout":30},{"type":"command","command":"custom startup hook","timeout":3}]}]}}`
+	if err := os.WriteFile(settingsPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config struct {
+		Hooks map[string][]hooksjson.MatcherGroup `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	groups := config.Hooks["SessionStart"]
+	if m := matcherForCommand(groups, "ao hooks claude-code session-start"); m == nil || *m != "startup|resume" {
+		t.Fatalf("migrated SessionStart matcher = %v, want startup|resume", m)
+	}
+	if got := countClaudeHookCommand(groups, "ao hooks claude-code session-start"); got != 1 {
+		t.Fatalf("managed SessionStart count = %d, want 1", got)
+	}
+	if got := countClaudeHookCommand(groups, "custom startup hook"); got != 1 {
+		t.Fatalf("custom startup hook count = %d, want 1", got)
+	}
+	if m := matcherForCommand(groups, "custom startup hook"); m == nil || *m != "startup" {
+		t.Fatalf("custom startup hook matcher = %v, want startup", m)
 	}
 }
 

--- a/backend/internal/adapters/agent/claudecode/hooks.go
+++ b/backend/internal/adapters/agent/claudecode/hooks.go
@@ -15,12 +15,14 @@ const (
 	claudeHookTimeout       = 30
 )
 
-// claudeStartupMatcher is referenced by pointer so SessionStart serializes with
-// its required "startup" matcher.
-var claudeStartupMatcher = "startup"
+// claudeSessionStartMatcher is referenced by pointer so SessionStart
+// serializes with both launch sources AO uses: a fresh start and a resume.
+// Claude filters SessionStart hooks by source, so startup-only silently drops
+// the callback from AO's `claude --resume` restore path.
+var claudeSessionStartMatcher = "startup|resume"
 
 // claudeManagedHooks is the source of truth for the hooks AO installs:
-// SessionStart (under the "startup" matcher), UserPromptSubmit, the tool-use
+// SessionStart (under the startup/resume matcher), UserPromptSubmit, the tool-use
 // trio (PreToolUse, PostToolUse, PostToolUseFailure), PermissionRequest,
 // Stop, Notification, and SessionEnd. They report normalized session metadata
 // and activity-state signals back into AO's store (see DeriveActivityState).
@@ -35,7 +37,7 @@ var claudeStartupMatcher = "startup"
 // dialog appears and carries the blocking tool_name; `ao hooks` writes nothing
 // to stdout, so installing it never injects a permission decision.
 var claudeManagedHooks = []hooksjson.HookSpec{
-	{Event: "SessionStart", Matcher: &claudeStartupMatcher, Command: claudeHookCommandPrefix + "session-start"},
+	{Event: "SessionStart", Matcher: &claudeSessionStartMatcher, Command: claudeHookCommandPrefix + "session-start"},
 	{Event: "UserPromptSubmit", Command: claudeHookCommandPrefix + "user-prompt-submit"},
 	{Event: "PreToolUse", Command: claudeHookCommandPrefix + "pre-tool-use"},
 	{Event: "PostToolUse", Command: claudeHookCommandPrefix + "post-tool-use"},

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -427,8 +427,8 @@ func (m *Manager) ApplyRuntimeObservation(ctx context.Context, id domain.Session
 }
 
 // ApplyActivitySignal records an authoritative agent activity signal and any
-// native agent session id carried alongside it. Metadata-only hooks leave the
-// existing activity and first-signal facts untouched.
+// native agent session id carried alongside it. A metadata-only session-start
+// is also a receipt for the current spawn, but it does not assert activity.
 func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, s ports.ActivitySignal) error {
 	s.AgentSessionID = strings.TrimSpace(s.AgentSessionID)
 	s.LatestUserPrompt = strings.TrimSpace(s.LatestUserPrompt)
@@ -462,7 +462,7 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 			}
 		}
 	}
-	if !s.Valid && s.AgentSessionID == "" && s.LatestUserPrompt == "" && s.LatestAssistantUpdate == "" && s.TranscriptPath == "" {
+	if !s.Valid && s.Event != "session-start" && s.AgentSessionID == "" && s.LatestUserPrompt == "" && s.LatestAssistantUpdate == "" && s.TranscriptPath == "" {
 		return nil
 	}
 	if s.LaunchID != "" {
@@ -533,15 +533,21 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		(s.LatestUserPrompt != "" && rec.Metadata.LatestUserPrompt != s.LatestUserPrompt) ||
 		(s.LatestAssistantUpdate != "" && rec.Metadata.LatestAssistantUpdate != s.LatestAssistantUpdate) ||
 		(s.TranscriptPath != "" && rec.Metadata.NativeTranscriptPath != s.TranscriptPath)
+	receiptChanged := !s.Valid && s.Event == "session-start" && rec.FirstSignalAt.IsZero()
 	if s.Valid {
 		s = m.applyToolPrecedenceLocked(id, rec.Activity.State, s)
 	}
-	if !s.Valid && !metadataChanged {
+	if !s.Valid && !metadataChanged && !receiptChanged {
 		m.mu.Unlock()
 		return nil
 	}
 	if !s.Valid {
-		applyActivityMetadata(&rec.Metadata, s)
+		if metadataChanged {
+			applyActivityMetadata(&rec.Metadata, s)
+		}
+		if receiptChanged {
+			rec.FirstSignalAt = timeOr(s.Timestamp, now)
+		}
 		rec.UpdatedAt = now
 		_, err := m.store.UpdateSessionFromActivitySignal(ctx, rec)
 		m.mu.Unlock()

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -978,6 +978,55 @@ func TestActivity_NewLaunchSignalWaitsForMarkSpawned(t *testing.T) {
 	}
 }
 
+func TestActivity_NewLaunchSessionStartReceiptWaitsForMarkSpawned(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	rec.Activity.State = domain.ActivityExited
+	rec.Metadata.RuntimeLaunchID = "launch-old"
+	st.sessions["mer-1"] = rec
+
+	if err := m.PrepareLaunch("mer-1", "launch-new"); err != nil {
+		t.Fatal(err)
+	}
+	signalAt := time.Unix(123, 0).UTC()
+	signalDone := make(chan error, 1)
+	go func() {
+		signalDone <- m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+			Event:          "session-start",
+			AgentSessionID: "native-new",
+			Timestamp:      signalAt,
+			LaunchID:       "launch-new",
+		})
+	}()
+
+	select {
+	case err := <-signalDone:
+		t.Fatalf("new-generation receipt completed before MarkSpawned: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	if err := m.MarkSpawned(ctx, "mer-1", domain.SessionMetadata{
+		RuntimeHandleID: "tmux-mer-1",
+		RuntimeLaunchID: "launch-new",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-signalDone; err != nil {
+		t.Fatal(err)
+	}
+
+	got := st.sessions["mer-1"]
+	if !got.FirstSignalAt.Equal(signalAt) {
+		t.Fatalf("first signal at = %v, want %v", got.FirstSignalAt, signalAt)
+	}
+	if got.Metadata.AgentSessionID != "native-new" {
+		t.Fatalf("agent session id = %q, want native-new", got.Metadata.AgentSessionID)
+	}
+	if got.Activity.State != domain.ActivityIdle {
+		t.Fatalf("receipt asserted activity: %+v", got.Activity)
+	}
+}
+
 func TestActivity_CancelledLaunchReleasesAndRejectsEarlySignal(t *testing.T) {
 	m, st, _ := newManager()
 	rec := working("mer-1")
@@ -2668,6 +2717,79 @@ func TestActivity_FirstSignalStampsReceipt(t *testing.T) {
 	}
 	if got := st.sessions["mer-1"]; !got.FirstSignalAt.Equal(stamped) {
 		t.Fatalf("first signal moved: %v -> %v", stamped, got.FirstSignalAt)
+	}
+}
+
+func TestActivity_MetadataOnlySessionStartStampsReceiptWithoutActivity(t *testing.T) {
+	m, st, _ := newManager()
+	signalAt := time.Unix(123, 0).UTC()
+	rec := domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Activity: domain.Activity{
+			State:          domain.ActivityIdle,
+			LastActivityAt: time.Unix(100, 0).UTC(),
+		},
+	}
+	st.sessions["mer-1"] = rec
+
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+		Event:          "session-start",
+		AgentSessionID: "native-1",
+		Timestamp:      signalAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := st.sessions["mer-1"]
+	if !got.FirstSignalAt.Equal(signalAt) {
+		t.Fatalf("first signal at = %v, want %v", got.FirstSignalAt, signalAt)
+	}
+	if got.Activity != rec.Activity {
+		t.Fatalf("metadata-only start changed activity: %+v -> %+v", rec.Activity, got.Activity)
+	}
+	if got.Metadata.AgentSessionID != "native-1" {
+		t.Fatalf("agent session id = %q, want native-1", got.Metadata.AgentSessionID)
+	}
+}
+
+func TestActivity_RepeatedMetadataOnlySessionStartDoesNotMoveReceipt(t *testing.T) {
+	m, st, _ := newManager()
+	stamped := time.Unix(123, 0).UTC()
+	rec := working("mer-1")
+	rec.FirstSignalAt = stamped
+	rec.Metadata.AgentSessionID = "native-1"
+	st.sessions["mer-1"] = rec
+
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+		Event:          "session-start",
+		AgentSessionID: "native-1",
+		Timestamp:      stamped.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions["mer-1"]; got != rec {
+		t.Fatalf("repeated receipt rewrote session: %+v", got)
+	}
+}
+
+func TestActivity_OtherMetadataOnlyEventDoesNotStampReceipt(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	st.sessions["mer-1"] = rec
+
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+		Event:          "metadata",
+		AgentSessionID: "native-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := st.sessions["mer-1"]
+	if !got.FirstSignalAt.IsZero() {
+		t.Fatalf("non-start metadata stamped receipt: %+v", got)
+	}
+	if got.Metadata.AgentSessionID != "native-1" {
+		t.Fatalf("agent session id = %q, want native-1", got.Metadata.AgentSessionID)
 	}
 }
 

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -2734,9 +2734,8 @@ func TestActivity_MetadataOnlySessionStartStampsReceiptWithoutActivity(t *testin
 	st.sessions["mer-1"] = rec
 
 	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
-		Event:          "session-start",
-		AgentSessionID: "native-1",
-		Timestamp:      signalAt,
+		Event:     "session-start",
+		Timestamp: signalAt,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -2747,9 +2746,6 @@ func TestActivity_MetadataOnlySessionStartStampsReceiptWithoutActivity(t *testin
 	}
 	if got.Activity != rec.Activity {
 		t.Fatalf("metadata-only start changed activity: %+v -> %+v", rec.Activity, got.Activity)
-	}
-	if got.Metadata.AgentSessionID != "native-1" {
-		t.Fatalf("agent session id = %q, want native-1", got.Metadata.AgentSessionID)
 	}
 }
 
@@ -2770,6 +2766,31 @@ func TestActivity_RepeatedMetadataOnlySessionStartDoesNotMoveReceipt(t *testing.
 	}
 	if got := st.sessions["mer-1"]; got != rec {
 		t.Fatalf("repeated receipt rewrote session: %+v", got)
+	}
+}
+
+func TestActivity_LateMetadataOnlySessionStartDoesNotOverwriteActivityOrReceipt(t *testing.T) {
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	activityAt := time.Unix(123, 0).UTC()
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+		Valid:     true,
+		State:     domain.ActivityActive,
+		Event:     "user-prompt-submit",
+		Timestamp: activityAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before := st.sessions["mer-1"]
+
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+		Event:     "session-start",
+		Timestamp: activityAt.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions["mer-1"]; got != before {
+		t.Fatalf("late receipt overwrote real activity or first receipt: %+v -> %+v", before, got)
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,7 @@ flowchart LR
 The only persistent session state is:
 
 - `activity_state` — What the agent last reported (`active`, `idle`, `waiting_input`, `blocked`, `exited`). `waiting_input` is an agent at an empty prompt awaiting its next instruction; `blocked` is an agent stopped on a pending permission/approval decision — automation must never inject input into a blocked session.
+- `first_signal_at` — Receipt time for the first hook callback in the current spawn or restore. A metadata-only `session-start` can establish this receipt without asserting or changing activity.
 - `is_terminated` — Whether the session should be treated as over
 - `session_mode` plus its runtime/provider handle and generation — The currently committed controller epoch
 - `session_interface_transitions` — Durable checkpoints for an in-progress or completed TUI↔Chat handoff


### PR DESCRIPTION
## Summary

- record metadata-only `session-start` as the durable first-signal receipt for the current spawn or restore
- keep the receipt independent from activity: it never asserts or changes active, idle, waiting, blocked, exited, notifications, or termination
- install Claude Code's `SessionStart` hook for exactly `startup|resume`, and migrate AO's existing startup-only hook without moving user-owned hooks
- add fresh-spawn, resume, first-receipt, repeated-callback, late-callback, and launch-generation regressions

Closes #3315

## Root cause

The shared callback path could already receive metadata-only `SessionStart`, but it did not treat that callback as proof that the current hook pipeline reached AO. Separately, Claude Code filters `SessionStart` by its native source matcher: AO installed only `startup`, so a `claude --resume` restore never delivered the callback at all.

## Overlap with #2604 / #2622

This PR overlaps [issue #2604](https://github.com/Untrivial-ai/agent-orchestrator/issues/2604) and [PR #2622](https://github.com/Untrivial-ai/agent-orchestrator/pull/2622) on the same proof-of-wiring failure. PR #2622 live-proved the missing Claude `resume` matcher; this revision carries that matcher correction forward.

The implementation differs deliberately:

- PR #2622 targets an older lifecycle shape with an `ActivitySignalOnly` sentinel and related domain/controller handling.
- This PR uses the current generic metadata-only callback boundary already shared by Claude Code and Codex.
- `first_signal_at` is stamped only when the first `session-start` callback arrives; a repeated or late callback cannot move the receipt or overwrite real activity.
- Current launch-generation fencing, metadata updates, and the activity-signal store CAS remain intact.

This PR does not close or supersede PR #2622; maintainers can decide how to reconcile the overlap.

## Scope

Intentionally excluded: route parsing, managed restore policy, controller/keeper behavior, and UI lanes.

## Verification

Exact head: `29655ba5131c26b03ff8301e54ee6ad0205c1bc8`

- `go test ./internal/adapters/agent/claudecode ./internal/lifecycle`
- `go test ./...`
- `go build ./...`
- `go test -race ./...`
- `go vet ./...`
- `npm run lint` — full Go tests plus golangci-lint v2.12.2, `0 issues`
- `git diff --check canonical/main...HEAD`
- `gofmt -l` on every changed Go file
- clean committed worktree

The first uncached all-package attempts hit existing three-second auth-probe timeouts in Kilocode/OpenCode under load. Each failing test passed in isolation, and the complete full, race, and lint commands then passed on rerun.

## Independent review

- fresh exact-head lifecycle/Claude-hook review: no findings
- separate root integration review: approved the same exact head with no blocking findings and independently passed `go test -race -count=1 ./internal/adapters/agent/claudecode ./internal/lifecycle ./internal/httpd/controllers ./internal/cli`

