### PR TITLE
Fix/terminal pane chrome

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -173,22 +173,50 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.queryByRole("button", { name: "Scroll tabs right" })).not.toBeInTheDocument();
 	});
 
-	it("scrolls the tab strip horizontally with the mouse wheel", () => {
-		const shells = makeShells(8);
-		render(<CenterPane session={worker} shellTerminals={shells} theme="dark" daemonReady />);
+	it("closes a session tab on a single click without selecting it", () => {
+		const onCloseProjectSession = vi.fn();
+		const onSelectProjectSession = vi.fn();
+		render(
+			<CenterPane
+				session={worker}
+				projectSessions={[worker, secondWorker]}
+				tabOwnerSessionId={worker.id}
+				onCloseProjectSession={onCloseProjectSession}
+				onSelectProjectSession={onSelectProjectSession}
+				theme="dark"
+				daemonReady
+			/>,
+		);
 
-		const scrollRegion = document.querySelector(".overflow-x-auto") as HTMLElement;
-		Object.defineProperty(scrollRegion, "clientWidth", { value: 100, configurable: true });
-		Object.defineProperty(scrollRegion, "scrollWidth", { value: 500, configurable: true });
-		const scrollBy = vi.fn();
-		Object.defineProperty(scrollRegion, "scrollBy", { value: scrollBy, configurable: true });
+		const close = screen.getByRole("button", { name: "Close session tab review the change" });
+		fireEvent.mouseDown(close, { button: 0 });
+		expect(onCloseProjectSession).toHaveBeenCalledOnce();
+		expect(onCloseProjectSession).toHaveBeenCalledWith(secondWorker);
+		fireEvent.click(close);
+		expect(onCloseProjectSession).toHaveBeenCalledOnce();
+		expect(onSelectProjectSession).not.toHaveBeenCalled();
+	});
 
-		fireEvent.wheel(scrollRegion, { deltaY: 80 });
-		expect(scrollBy).toHaveBeenCalledWith({ left: 80 });
+	it("closes a shell tab on a single click without selecting it", () => {
+		const onCloseShellTerminal = vi.fn();
+		const onSelectShellTerminal = vi.fn();
+		render(
+			<CenterPane
+				session={worker}
+				shellTerminals={makeShells(1)}
+				onCloseShellTerminal={onCloseShellTerminal}
+				onSelectShellTerminal={onSelectShellTerminal}
+				theme="dark"
+				daemonReady
+			/>,
+		);
 
-		// Ctrl+wheel is terminal font zoom, not tab scrolling.
-		scrollBy.mockClear();
-		fireEvent.wheel(scrollRegion, { deltaY: 80, ctrlKey: true });
-		expect(scrollBy).not.toHaveBeenCalled();
+		const close = screen.getByRole("button", { name: "Close terminal agent-orchestrator-0" });
+		fireEvent.mouseDown(close, { button: 0 });
+		expect(onCloseShellTerminal).toHaveBeenCalledOnce();
+		expect(onCloseShellTerminal).toHaveBeenCalledWith("h-0");
+		fireEvent.click(close);
+		expect(onCloseShellTerminal).toHaveBeenCalledOnce();
+		expect(onSelectShellTerminal).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -130,8 +130,7 @@ describe("CenterPane toolbar session label", () => {
 	it("uses the inspector tab height for the terminal header", () => {
 		render(<CenterPane session={worker} theme="dark" daemonReady />);
 
-		const header = screen.getByText("TERMINAL").parentElement?.parentElement;
-		expect(header).toHaveClass("h-inspector-tabs");
+		expect(screen.getByTestId("terminal-tab-bar")).toHaveClass("h-inspector-tabs");
 	});
 
 	it("lets tabs shrink into a scrollable strip instead of overflowing onto the controls", () => {
@@ -146,14 +145,14 @@ describe("CenterPane toolbar session label", () => {
 			expect(tab).toHaveClass("min-w-flex-min");
 			expect(tab).not.toHaveClass("min-w-0");
 		}
-		// jsdom reports no overflow, so the indicator stays mounted but disabled to preserve focus.
-		expect(screen.getByRole("button", { name: "Scroll tabs right" })).toBeDisabled();
+		// jsdom reports no overflow, so scroll indicators stay out of the tab bar.
+		expect(screen.queryByRole("button", { name: "Scroll tabs right" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Scroll tabs left" })).not.toBeInTheDocument();
 
 		// The display controls float over the terminal body, not the tab bar,
 		// so tabs and controls can never overlap.
-		const tabBarRow = screen.getByText("TERMINAL").closest("div")?.parentElement;
-		expect(tabBarRow).not.toBeNull();
-		expect(tabBarRow?.contains(screen.getByRole("button", { name: /fullscreen/i }))).toBe(false);
+		const tabBarRow = screen.getByTestId("terminal-tab-bar");
+		expect(tabBarRow.contains(screen.getByRole("button", { name: /fullscreen/i }))).toBe(false);
 	});
 
 	it("reveals scroll chevrons only when the tab strip actually overflows", () => {
@@ -165,13 +164,13 @@ describe("CenterPane toolbar session label", () => {
 		Object.defineProperty(scrollRegion, "scrollWidth", { value: 500, configurable: true });
 		fireEvent.scroll(scrollRegion);
 
-		expect(screen.getByRole("button", { name: "Scroll tabs right" })).toBeEnabled();
-		expect(screen.getByRole("button", { name: "Scroll tabs left" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Scroll tabs right" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Scroll tabs left" })).not.toBeInTheDocument();
 
 		Object.defineProperty(scrollRegion, "scrollLeft", { value: 400, configurable: true });
 		fireEvent.scroll(scrollRegion);
-		expect(screen.getByRole("button", { name: "Scroll tabs left" })).toBeEnabled();
-		expect(screen.getByRole("button", { name: "Scroll tabs right" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Scroll tabs left" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Scroll tabs right" })).not.toBeInTheDocument();
 	});
 
 	it("scrolls the tab strip horizontally with the mouse wheel", () => {

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -171,24 +171,22 @@ export function CenterPane({
 			className="terminal-pane-frame flex h-full min-h-0 min-w-flex-min flex-col"
 			onWheelCapture={handleWheelZoom}
 		>
-			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border px-5">
-				<div className="flex min-w-flex-min flex-1 items-center gap-3">
-					<span className="shrink-0 font-mono text-caption font-semibold uppercase tracking-wide-lg text-muted-foreground">
-						TERMINAL
-					</span>
-					<button
-						aria-label="Scroll tabs left"
-						className={cn(
-							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none disabled:opacity-0",
-							!tabsOverflow.canScrollLeft && "invisible",
-						)}
-						disabled={!tabsOverflow.canScrollLeft}
-						onClick={() => tabsOverflow.scrollByDirection(-1)}
-						title="Scroll tabs left"
-						type="button"
-					>
-						<ChevronLeft aria-hidden="true" className="size-icon-md" />
-					</button>
+			<div
+				className="flex h-inspector-tabs shrink-0 items-center border-b border-border px-2.5"
+				data-testid="terminal-tab-bar"
+			>
+				<div className="flex min-w-flex-min flex-1 items-center gap-2">
+					{tabsOverflow.canScrollLeft ? (
+						<button
+							aria-label="Scroll tabs left"
+							className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
+							onClick={() => tabsOverflow.scrollByDirection(-1)}
+							title="Scroll tabs left"
+							type="button"
+						>
+							<ChevronLeft aria-hidden="true" className="size-icon-md" />
+						</button>
+					) : null}
 					{/* Each originating session owns a private set of pinned worker and
 					    shell tabs. The + menu is the only way to add to that layout. */}
 					<div
@@ -232,19 +230,17 @@ export function CenterPane({
 							/>
 						))}
 					</div>
-					<button
-						aria-label="Scroll tabs right"
-						className={cn(
-							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none disabled:opacity-0",
-							!tabsOverflow.canScrollRight && "invisible",
-						)}
-						disabled={!tabsOverflow.canScrollRight}
-						onClick={() => tabsOverflow.scrollByDirection(1)}
-						title="Scroll tabs right"
-						type="button"
-					>
-						<ChevronRight aria-hidden="true" className="size-icon-md" />
-					</button>
+					{tabsOverflow.canScrollRight ? (
+						<button
+							aria-label="Scroll tabs right"
+							className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
+							onClick={() => tabsOverflow.scrollByDirection(1)}
+							title="Scroll tabs right"
+							type="button"
+						>
+							<ChevronRight aria-hidden="true" className="size-icon-md" />
+						</button>
+					) : null}
 					<DropdownMenu
 						open={isTabLauncherOpen}
 						onOpenChange={(open) => {
@@ -355,7 +351,7 @@ export function CenterPane({
 				/>
 				{/* Display controls float over the terminal's top-right corner with no
 				    chrome of their own, so they read as part of the terminal itself. */}
-				<div className="absolute right-3 top-2 z-10 flex shrink-0 items-center gap-3 font-mono text-passive/70">
+				<div className="absolute right-2 top-1 z-10 flex shrink-0 items-center gap-3 font-mono text-passive/70">
 					<button
 						aria-label="Decrease terminal font size"
 						className="inline-flex size-control-sm items-center justify-center rounded-sm bg-transparent text-control leading-none transition-[background,color,opacity] duration-fast hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:cursor-default disabled:opacity-35 disabled:hover:bg-transparent disabled:hover:text-passive"

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -432,7 +432,19 @@ function SessionPaneTab({ label, isActive, onSelect, onClose }: SessionPaneTabPr
 				<button
 					aria-label={`Close session tab ${label}`}
 					className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-passive opacity-0 transition-[background,color,opacity] group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-interactive-hover hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
+					onMouseDown={(event) => {
+						if (event.button !== 0) return;
+						event.preventDefault();
+						event.stopPropagation();
+						onClose();
+					}}
 					onClick={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+					}}
+					onKeyDown={(event) => {
+						if (event.key !== "Enter" && event.key !== " ") return;
+						event.preventDefault();
 						event.stopPropagation();
 						onClose();
 					}}

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -234,12 +234,17 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 }));
 // Standalone shell terminals are orthogonal to the split under test, and their
 // real hooks would need a QueryClientProvider this suite deliberately omits.
-vi.mock("../hooks/useShellTerminals", () => ({
-	useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
-	useOpenShellTerminal: () => ({ mutate: vi.fn() }),
-	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
-	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
-}));
+// Pure helpers come from the real module; only the React Query hooks are stubbed.
+vi.mock("../hooks/useShellTerminals", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../hooks/useShellTerminals")>();
+	return {
+		...actual,
+		useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
+		useOpenShellTerminal: () => ({ mutate: vi.fn() }),
+		useCloseShellTerminal: () => ({ mutate: vi.fn() }),
+		useRenameShellTerminal: () => ({ mutate: vi.fn() }),
+	};
+});
 
 // jsdom has no layout engine, so the real react-resizable-panels would never
 // produce meaningful sizes — record the props SessionView passes and expose a

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, startTransition } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "@tanstack/react-router";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
@@ -12,6 +12,9 @@ import { useResolvedTheme, useUiStore, type InspectorView } from "../stores/ui-s
 import { useShell } from "../lib/shell-context";
 import { useBrowserView } from "../hooks/useBrowserView";
 import {
+	beginOpenShellTerminalActivation,
+	isLatestOpenShellTerminalActivation,
+	isPendingShellHandleId,
 	useCloseShellTerminal,
 	useOpenShellTerminal,
 	useRenameShellTerminal,
@@ -22,6 +25,7 @@ import { hidesShellTopbar } from "../lib/platform";
 import { isOrchestratorSession, sessionIsActive, workerSessions, type WorkspaceSession } from "../types/workspace";
 import type { TerminalTarget } from "../types/terminal";
 import { matchesRendererShortcut } from "../stores/keybindings-store";
+import { buildTerminalStripTabs, previousTerminalStripTab, type TerminalStripTab } from "../lib/terminal-strip-tabs";
 
 const INSPECTOR_MIN_PERCENT = 22;
 const INSPECTOR_MAX_PERCENT = 45;
@@ -119,13 +123,6 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 		},
 		[addSessionTab, ownerSessionId, selectProjectSession],
 	);
-	const closeProjectSession = useCallback(
-		(projectSession: WorkspaceSession) => {
-			removeSessionTab(ownerSessionId, projectSession.id);
-			if (projectSession.id === sessionId && tabOwnerSession) selectProjectSession(tabOwnerSession);
-		},
-		[ownerSessionId, removeSessionTab, selectProjectSession, sessionId, tabOwnerSession],
-	);
 
 	// Shell terminals opened inside a session live beside its pane as extra tabs.
 	//
@@ -150,12 +147,16 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 	);
 
 	const addShellTerminal = useCallback(() => {
+		const activationGeneration = beginOpenShellTerminalActivation();
 		openShellTerminal.mutate(
-			{ projectId: tabOwnerSession?.workspaceId, sessionId: ownerSessionId },
+			{ projectId: tabOwnerSession?.workspaceId, sessionId: ownerSessionId, activationGeneration },
 			{
-				onSuccess: (shell) => {
-					setActiveShellTerminal(shell.handleId);
-					setTerminalTarget({ kind: "shell", handleId: shell.handleId, title: shell.title });
+				onSuccess: (shell, variables) => {
+					if (!isLatestOpenShellTerminalActivation(variables.activationGeneration)) return;
+					startTransition(() => {
+						setActiveShellTerminal(shell.handleId);
+						setTerminalTarget({ kind: "shell", handleId: shell.handleId, title: shell.title });
+					});
 				},
 			},
 		);
@@ -163,33 +164,111 @@ export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) 
 
 	const selectShellTerminal = useCallback(
 		(handleId: string) => {
+			if (isPendingShellHandleId(handleId)) return;
 			const shell = shellTerminals.find((s) => s.handleId === handleId);
 			if (!shell) return;
-			setActiveShellTerminal(shell.handleId);
-			setTerminalTarget({ kind: "shell", handleId: shell.handleId, title: shell.title });
+			startTransition(() => {
+				setActiveShellTerminal(shell.handleId);
+				setTerminalTarget({ kind: "shell", handleId: shell.handleId, title: shell.title });
+			});
 		},
 		[shellTerminals, setActiveShellTerminal],
-	);
-
-	const closeShellTerminalByHandle = useCallback(
-		(handleId: string) => {
-			// Fall back to the session pane first: leaving the target pointed at a
-			// handle that is being destroyed would attach to a dead PTY.
-			setTerminalTarget((current) =>
-				current.kind === "shell" && current.handleId === handleId ? { kind: "worker" } : current,
-			);
-			if (activeShellTerminalHandleId === handleId) setActiveShellTerminal(null);
-			closeShellTerminal.mutate(handleId);
-		},
-		[closeShellTerminal, activeShellTerminalHandleId, setActiveShellTerminal],
 	);
 
 	// Selecting the session's own pane also drops the active shell, so the effect
 	// above does not immediately pull the view back to that shell.
 	const selectSessionTerminal = useCallback(() => {
-		setActiveShellTerminal(null);
-		setTerminalTarget({ kind: "worker" });
+		startTransition(() => {
+			setActiveShellTerminal(null);
+			setTerminalTarget({ kind: "worker" });
+		});
 	}, [setActiveShellTerminal]);
+
+	const activateTerminalStripTab = useCallback(
+		(tab: TerminalStripTab | undefined) => {
+			if (!tab) {
+				selectSessionTerminal();
+				return;
+			}
+			if (tab.kind === "shell") {
+				if (isPendingShellHandleId(tab.handleId)) {
+					selectSessionTerminal();
+					return;
+				}
+				selectShellTerminal(tab.handleId);
+				return;
+			}
+			const projectSession = allSessions.find((candidate) => candidate.id === tab.sessionId);
+			if (!projectSession) {
+				selectSessionTerminal();
+				return;
+			}
+			if (projectSession.id === sessionId) {
+				selectSessionTerminal();
+				return;
+			}
+			selectProjectSession(projectSession);
+		},
+		[allSessions, selectProjectSession, selectSessionTerminal, selectShellTerminal, sessionId],
+	);
+
+	const closeProjectSession = useCallback(
+		(projectSession: WorkspaceSession) => {
+			const viewingClosedSession =
+				projectSession.id === sessionId && terminalTarget.kind !== "shell";
+			removeSessionTab(ownerSessionId, projectSession.id);
+			if (viewingClosedSession) {
+				activateTerminalStripTab(
+					previousTerminalStripTab(
+						buildTerminalStripTabs(
+							projectSessions.map((item) => item.id),
+							shellTerminals.map((item) => item.handleId),
+						),
+						{ kind: "session", sessionId: projectSession.id },
+					),
+				);
+			}
+		},
+		[
+			activateTerminalStripTab,
+			ownerSessionId,
+			projectSessions,
+			removeSessionTab,
+			sessionId,
+			shellTerminals,
+			terminalTarget.kind,
+		],
+	);
+
+	const closeShellTerminalByHandle = useCallback(
+		(handleId: string) => {
+			const viewingClosedShell =
+				terminalTarget.kind === "shell" && terminalTarget.handleId === handleId;
+			if (viewingClosedShell) {
+				activateTerminalStripTab(
+					previousTerminalStripTab(
+						buildTerminalStripTabs(
+							projectSessions.map((item) => item.id),
+							shellTerminals.map((item) => item.handleId),
+						),
+						{ kind: "shell", handleId },
+					),
+				);
+			} else if (activeShellTerminalHandleId === handleId) {
+				setActiveShellTerminal(null);
+			}
+			closeShellTerminal.mutate(handleId);
+		},
+		[
+			activateTerminalStripTab,
+			activeShellTerminalHandleId,
+			closeShellTerminal,
+			projectSessions,
+			setActiveShellTerminal,
+			shellTerminals,
+			terminalTarget,
+		],
+	);
 
 	// The shell layout owns opening (it is mounted on every route, so the button
 	// and Ctrl+Shift+` work everywhere); this view only follows the result. When a new

--- a/frontend/src/renderer/components/ShellTerminalTab.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.test.tsx
@@ -82,6 +82,28 @@ describe("ShellTerminalTab rename", () => {
 		fireEvent.click(screen.getByRole("button", { name: "ao" }));
 		expect(onSelect).toHaveBeenCalled();
 	});
+
+	it("closes on a single click without selecting or entering rename", () => {
+		const { onSelect, onClose, onRename } = renderTab();
+		const close = screen.getByRole("button", { name: "Close terminal ao" });
+		fireEvent.mouseDown(close, { button: 0 });
+		expect(onClose).toHaveBeenCalledOnce();
+		fireEvent.click(close);
+		expect(onClose).toHaveBeenCalledOnce();
+		expect(onSelect).not.toHaveBeenCalled();
+		expect(onRename).not.toHaveBeenCalled();
+		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+	});
+
+	it("closes on a single click even while the tab is being renamed", () => {
+		const { onClose } = renderTab();
+		fireEvent.doubleClick(screen.getByRole("button", { name: "ao" }));
+		expect(screen.getByRole("textbox", { name: /rename terminal/i })).toBeInTheDocument();
+
+		const close = screen.getByRole("button", { name: "Close terminal ao" });
+		fireEvent.mouseDown(close, { button: 0 });
+		expect(onClose).toHaveBeenCalledOnce();
+	});
 });
 
 describe("ShellTerminalTab rename gesture per platform", () => {

--- a/frontend/src/renderer/components/ShellTerminalTab.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.tsx
@@ -133,8 +133,27 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 			<button
 				aria-label={`Close terminal ${shell.title}`}
 				className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-passive opacity-0 transition-[background,color,opacity] group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
-				onClick={(event) => {
+				onMouseDown={(event) => {
+					// Close on mousedown so a focused rename input cannot blur and
+					// re-render before click — that swallows the gesture, the pane
+					// falls back to the session tab, and the shell tab stays open.
+					if (event.button !== 0) return;
+					event.preventDefault();
 					event.stopPropagation();
+					lastClickAtRef.current = 0;
+					onClose();
+				}}
+				onClick={(event) => {
+					// Pointer already closed on mousedown; keep click from selecting
+					// the tab or starting a rename via the container handlers.
+					event.preventDefault();
+					event.stopPropagation();
+				}}
+				onKeyDown={(event) => {
+					if (event.key !== "Enter" && event.key !== " ") return;
+					event.preventDefault();
+					event.stopPropagation();
+					lastClickAtRef.current = 0;
 					onClose();
 				}}
 				onDoubleClick={(event) => event.stopPropagation()}

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { useEffect } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
 import { useCloseShellTerminal, useRenameShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
+import { adjacentShellStripTab } from "../lib/terminal-strip-tabs";
 import { useShell } from "../lib/shell-context";
 import { cn } from "../lib/utils";
 import { useResolvedTheme, useUiStore } from "../stores/ui-store";
@@ -32,11 +33,23 @@ export function ShellTerminalsView() {
 	// to a dead handle.
 	const active = shellTerminals.find((s) => s.handleId === activeHandleId);
 	const tabsOverflow = useOverflowScroll<HTMLDivElement>(shellTerminals.map((t) => t.handleId).join("|"));
+	const closeShellTab = (handleId: string) => {
+		if (activeHandleId === handleId) {
+			const nextHandleId = adjacentShellStripTab(
+				shellTerminals.map((shell) => shell.handleId),
+				handleId,
+			);
+			setActiveShellTerminal(nextHandleId ?? null);
+		}
+		closeShellTerminal.mutate(handleId);
+	};
 	useEffect(() => {
 		if (shellTerminals.length === 0) {
 			if (activeHandleId !== null) setActiveShellTerminal(null);
 			return;
 		}
+		// Daemon-side prune (or a stale active id) with tabs still open: land on
+		// the first remaining tab instead of an empty pane.
 		if (!active) setActiveShellTerminal(shellTerminals[0].handleId);
 	}, [shellTerminals, active, activeHandleId, setActiveShellTerminal]);
 
@@ -71,7 +84,7 @@ export function ShellTerminalsView() {
 							<ShellTerminalTab
 								key={shell.handleId}
 								isActive={isActive}
-								onClose={() => closeShellTerminal.mutate(shell.handleId)}
+								onClose={() => closeShellTab(shell.handleId)}
 								onRename={(title) => renameShellTerminal.mutate({ handleId: shell.handleId, title })}
 								onSelect={() => setActiveShellTerminal(shell.handleId)}
 								shell={shell}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -396,11 +396,9 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 					}
 				/>
 			)}
-			{/* p-2 keeps the xterm content off the pane edges; the host fills the
-			    remaining content box, so FitAddon still measures it correctly and
-			    the absolute overlays (empty state, banner) keep covering the
-			    full padding box. */}
-			<div className="relative min-h-0 flex-1 p-2">
+			{/* xterm fills the content box edge-to-edge; FitAddon measures this host
+			    directly. Overlays (empty state, banner, replay cover) stay absolute. */}
+			<div className="relative min-h-0 flex-1">
 				<XtermTerminal
 					ariaLabel={terminalTarget?.kind === "shell" ? "Shell terminal" : "Session terminal"}
 					fontSize={fontSize}
@@ -420,7 +418,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 				)}
 				{showReplayCover && <ReplayCover />}
 				{banner && (
-					<div className="absolute inset-x-3 top-2 rounded-md border border-border bg-surface/95 px-3 py-1.5 font-mono text-caption text-muted-foreground">
+					<div className="absolute inset-x-2 top-1 rounded-md border border-border bg-surface/95 px-3 py-1.5 font-mono text-caption text-muted-foreground">
 						{banner}
 					</div>
 				)}

--- a/frontend/src/renderer/hooks/useShellTerminals.test.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.test.ts
@@ -1,0 +1,214 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	beginOpenShellTerminalActivation,
+	isLatestOpenShellTerminalActivation,
+	isPendingShellHandleId,
+	shellTerminalsQueryKey,
+	useCloseShellTerminal,
+	useOpenShellTerminal,
+	type ShellTerminal,
+} from "./useShellTerminals";
+
+vi.mock("../lib/api-client", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/api-client")>();
+	return {
+		...actual,
+		hasTrustedApiBaseUrl: () => true,
+		apiClient: {
+			POST: vi.fn(),
+			GET: vi.fn(),
+			DELETE: vi.fn(),
+		},
+	};
+});
+
+const { apiClient } = await import("../lib/api-client");
+
+function wrapper(queryClient: QueryClient) {
+	return ({ children }: { children: ReactNode }) =>
+		createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useOpenShellTerminal", () => {
+	afterEach(() => {
+		vi.mocked(apiClient.POST).mockReset();
+		vi.mocked(apiClient.DELETE).mockReset();
+		vi.mocked(apiClient.GET).mockReset();
+	});
+
+	it("adds an optimistic tab immediately and replaces it on success without refetching", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		const created: ShellTerminal = {
+			handleId: "sh-real",
+			projectId: "proj-1",
+			sessionId: "sess-1",
+			workingDir: "/tmp/ws",
+			title: "agent-orchestrator-1",
+			createdAt: "2026-07-29T00:00:00Z",
+		};
+		vi.mocked(apiClient.POST).mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					setTimeout(
+						() =>
+							resolve({
+								data: { shellTerminal: created },
+								error: undefined,
+							}),
+						20,
+					);
+				}),
+		);
+
+		const { result } = renderHook(() => useOpenShellTerminal(), { wrapper: wrapper(queryClient) });
+		const generation = beginOpenShellTerminalActivation();
+		await act(async () => {
+			result.current.mutate({ projectId: "proj-1", sessionId: "sess-1", activationGeneration: generation });
+		});
+
+		const pendingTabs = queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey);
+		expect(pendingTabs?.some((tab) => isPendingShellHandleId(tab.handleId))).toBe(true);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		const tabs = queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey);
+		expect(tabs).toEqual([created]);
+		expect(vi.mocked(apiClient.GET)).not.toHaveBeenCalled();
+		expect(isLatestOpenShellTerminalActivation(generation)).toBe(true);
+	});
+
+	it("does not resurrect a pending tab closed before POST completes", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		const created: ShellTerminal = {
+			handleId: "sh-real",
+			projectId: "proj-1",
+			sessionId: "sess-1",
+			workingDir: "/tmp/ws",
+			title: "agent-orchestrator-1",
+			createdAt: "2026-07-29T00:00:00Z",
+		};
+		let resolvePost: ((value: unknown) => void) | undefined;
+		vi.mocked(apiClient.POST).mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolvePost = resolve;
+				}),
+		);
+		vi.mocked(apiClient.DELETE).mockResolvedValue({ data: undefined, error: undefined });
+
+		const open = renderHook(() => useOpenShellTerminal(), { wrapper: wrapper(queryClient) });
+		const close = renderHook(() => useCloseShellTerminal(), { wrapper: wrapper(queryClient) });
+
+		await act(async () => {
+			open.result.current.mutate({ projectId: "proj-1", sessionId: "sess-1" });
+		});
+		const pendingId = queryClient
+			.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey)
+			?.find((tab) => isPendingShellHandleId(tab.handleId))?.handleId;
+		expect(pendingId).toBeDefined();
+
+		await act(async () => {
+			close.result.current.mutate(pendingId!);
+		});
+		expect(queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey)).toEqual([]);
+
+		await act(async () => {
+			resolvePost?.({ data: { shellTerminal: created }, error: undefined });
+		});
+		await waitFor(() => expect(open.result.current.isSuccess).toBe(true));
+
+		expect(queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey)).toEqual([]);
+		expect(vi.mocked(apiClient.DELETE)).toHaveBeenCalledWith("/api/v1/shell-terminals/{handleId}", {
+			params: { path: { handleId: "sh-real" } },
+		});
+		expect(vi.mocked(apiClient.GET)).not.toHaveBeenCalled();
+	});
+
+	it("on open failure only removes its placeholder, not tabs closed meanwhile", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		const kept: ShellTerminal = {
+			handleId: "sh-kept",
+			projectId: "proj-1",
+			workingDir: "/tmp/ws",
+			title: "kept",
+			createdAt: "2026-07-29T00:00:00Z",
+		};
+		const doomed: ShellTerminal = {
+			handleId: "sh-doomed",
+			projectId: "proj-1",
+			workingDir: "/tmp/ws",
+			title: "doomed",
+			createdAt: "2026-07-29T00:00:00Z",
+		};
+		queryClient.setQueryData(shellTerminalsQueryKey, [kept, doomed]);
+
+		let rejectPost: ((reason?: unknown) => void) | undefined;
+		vi.mocked(apiClient.POST).mockImplementation(
+			() =>
+				new Promise((_resolve, reject) => {
+					rejectPost = reject;
+				}),
+		);
+		vi.mocked(apiClient.DELETE).mockResolvedValue({ data: undefined, error: undefined });
+
+		const open = renderHook(() => useOpenShellTerminal(), { wrapper: wrapper(queryClient) });
+		const close = renderHook(() => useCloseShellTerminal(), { wrapper: wrapper(queryClient) });
+
+		await act(async () => {
+			open.result.current.mutate({ projectId: "proj-1" });
+		});
+		expect(
+			queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey)?.some((t) => isPendingShellHandleId(t.handleId)),
+		).toBe(true);
+
+		await act(async () => {
+			close.result.current.mutate("sh-doomed");
+		});
+		expect(queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey)?.map((t) => t.handleId)).not.toContain(
+			"sh-doomed",
+		);
+
+		await act(async () => {
+			rejectPost?.(new Error("boom"));
+		});
+		await waitFor(() => expect(open.result.current.isError).toBe(true));
+
+		const tabs = queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? [];
+		expect(tabs.map((t) => t.handleId)).toEqual(["sh-kept"]);
+		expect(tabs.some((t) => isPendingShellHandleId(t.handleId))).toBe(false);
+	});
+});
+
+describe("useCloseShellTerminal", () => {
+	afterEach(() => {
+		vi.mocked(apiClient.DELETE).mockReset();
+		vi.mocked(apiClient.GET).mockReset();
+	});
+
+	it("keeps a closed tab removed when the daemon reports it is already gone", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		const existing: ShellTerminal = {
+			handleId: "sh-real",
+			projectId: "proj-1",
+			workingDir: "/tmp/ws",
+			title: "agent-orchestrator-1",
+			createdAt: "2026-07-29T00:00:00Z",
+		};
+		queryClient.setQueryData(shellTerminalsQueryKey, [existing]);
+		vi.mocked(apiClient.DELETE).mockResolvedValue({
+			data: undefined,
+			error: { code: "SHELL_TERMINAL_NOT_FOUND", message: "No such shell terminal" },
+		});
+
+		const { result } = renderHook(() => useCloseShellTerminal(), { wrapper: wrapper(queryClient) });
+		await act(async () => {
+			result.current.mutate("sh-real");
+		});
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey)).toEqual([]);
+		expect(vi.mocked(apiClient.GET)).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -276,14 +276,14 @@ export function useCloseShellTerminal() {
 			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) => {
 				const list = current ?? [];
 				if (list.some((shell) => shell.handleId === handleId)) return list;
-				const index = context.previous?.findIndex((shell) => shell.handleId === handleId) ?? list.length;
+				const index = context?.previous?.findIndex((shell) => shell.handleId === handleId) ?? list.length;
 				const next = [...list];
 				next.splice(Math.min(Math.max(index, 0), next.length), 0, restored);
 				return next;
 			});
 			if (usePreviewData) {
 				if (previewShellTerminals.some((s) => s.handleId === handleId)) return;
-				const index = context.previous?.findIndex((s) => s.handleId === handleId) ?? previewShellTerminals.length;
+				const index = context?.previous?.findIndex((s) => s.handleId === handleId) ?? previewShellTerminals.length;
 				const next = [...previewShellTerminals];
 				next.splice(Math.min(Math.max(index, 0), next.length), 0, restored);
 				previewShellTerminals = next;

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -5,7 +5,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
-import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
+import { apiClient, apiErrorCode, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { mockShellTerminals } from "../lib/mock-data";
 
 export type ShellTerminal = {
@@ -21,6 +21,62 @@ export type ShellTerminal = {
 
 export const shellTerminalsQueryKey = ["shell-terminals"] as const;
 const usePreviewData = import.meta.env.VITE_NO_ELECTRON === "1";
+const PENDING_SHELL_PREFIX = "shell-pending-";
+
+/** Optimistic tabs the user closed before POST completed — open must not resurrect them. */
+const cancelledOptimisticShellIds = new Set<string>();
+
+/**
+ * Real daemon handles the user already dismissed (e.g. closed a pending tab whose
+ * POST later succeeded). Filtered out of list fetches so a failed cleanup DELETE
+ * cannot resurrect them on reload.
+ */
+const dismissedDaemonHandleIds = new Set<string>();
+
+/** True for optimistic placeholder tabs that are not yet attachable. */
+export function isPendingShellHandleId(handleId: string): boolean {
+	return handleId.startsWith(PENDING_SHELL_PREFIX);
+}
+
+function isShellTerminalNotFound(error: unknown): boolean {
+	return apiErrorCode(error) === "SHELL_TERMINAL_NOT_FOUND";
+}
+
+function cancelOptimisticShell(handleId: string): void {
+	if (isPendingShellHandleId(handleId)) {
+		cancelledOptimisticShellIds.add(handleId);
+	}
+}
+
+function consumeCancelledOptimisticShell(optimisticId: string): boolean {
+	if (!cancelledOptimisticShellIds.has(optimisticId)) return false;
+	cancelledOptimisticShellIds.delete(optimisticId);
+	return true;
+}
+
+function dismissDaemonShell(handleId: string): void {
+	dismissedDaemonHandleIds.add(handleId);
+}
+
+function clearDismissedDaemonShell(handleId: string): void {
+	dismissedDaemonHandleIds.delete(handleId);
+}
+
+function withoutDismissed(shells: ShellTerminal[]): ShellTerminal[] {
+	if (dismissedDaemonHandleIds.size === 0) return shells;
+	return shells.filter((shell) => !dismissedDaemonHandleIds.has(shell.handleId));
+}
+
+async function deleteShellOnDaemon(handleId: string): Promise<boolean> {
+	const { error } = await apiClient.DELETE("/api/v1/shell-terminals/{handleId}", {
+		params: { path: { handleId } },
+	});
+	if (!error || isShellTerminalNotFound(error)) {
+		clearDismissedDaemonShell(handleId);
+		return true;
+	}
+	return false;
+}
 
 function toShellTerminal(t: components["schemas"]["ShellTerminalResponse"]): ShellTerminal {
 	return {
@@ -49,12 +105,12 @@ async function fetchShellTerminals(): Promise<ShellTerminal[]> {
 	}
 	const { data, error } = await apiClient.GET("/api/v1/shell-terminals");
 	if (error) throw error;
-	return (data?.shellTerminals ?? []).map(toShellTerminal);
+	return withoutDismissed((data?.shellTerminals ?? []).map(toShellTerminal));
 }
 
 // No refetchInterval: shell terminals only change when this client opens or
-// closes one, and both mutations invalidate the query. Polling would spend a
-// liveness probe per shell per interval for no new information.
+// closes one. Open/close update the cache in place; rename still invalidates.
+// Polling would spend a liveness probe per shell per interval for no new information.
 export const shellTerminalsQueryOptions = {
 	queryKey: shellTerminalsQueryKey,
 	queryFn: fetchShellTerminals,
@@ -67,6 +123,36 @@ export function useShellTerminals() {
 
 export type OpenShellTerminalInput = { projectId?: string; sessionId?: string };
 
+/** Variables for open-shell mutation; activationGeneration is client-only. */
+export type OpenShellTerminalVariables = OpenShellTerminalInput & {
+	/** When set, only the latest generation may switch the active pane on success. */
+	activationGeneration?: number;
+};
+
+let openShellActivationGeneration = 0;
+let optimisticShellSeq = 0;
+
+/** Mark the start of an open-shell request; pass the value through mutate(). */
+export function beginOpenShellTerminalActivation(): number {
+	return ++openShellActivationGeneration;
+}
+
+/** True when no generation was passed, or this open is still the most recent one. */
+export function isLatestOpenShellTerminalActivation(generation: number | undefined): boolean {
+	return generation === undefined || generation === openShellActivationGeneration;
+}
+
+function createOptimisticShell(input: OpenShellTerminalInput, optimisticId: string): ShellTerminal {
+	return {
+		handleId: optimisticId,
+		projectId: input.projectId,
+		sessionId: input.sessionId,
+		workingDir: "",
+		title: "Terminal",
+		createdAt: new Date().toISOString(),
+	};
+}
+
 /**
  * Opens a shell in the given project's root (or the daemon data dir when
  * omitted). When sessionId is set the shell is scoped to that session and only
@@ -75,7 +161,10 @@ export type OpenShellTerminalInput = { projectId?: string; sessionId?: string };
 export function useOpenShellTerminal() {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: async ({ projectId, sessionId }: OpenShellTerminalInput = {}): Promise<ShellTerminal> => {
+		mutationFn: async ({
+			projectId,
+			sessionId,
+		}: OpenShellTerminalVariables = {}): Promise<ShellTerminal> => {
 			if (usePreviewData) {
 				previewShellSeq += 1;
 				const shell: ShellTerminal = {
@@ -97,8 +186,47 @@ export function useOpenShellTerminal() {
 			if (!data) throw new Error("Daemon returned no shell terminal");
 			return toShellTerminal(data.shellTerminal);
 		},
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+		onMutate: async (input) => {
+			if (usePreviewData) return undefined;
+			await queryClient.cancelQueries({ queryKey: shellTerminalsQueryKey });
+			const optimisticId = `${PENDING_SHELL_PREFIX}${++optimisticShellSeq}`;
+			const optimistic = createOptimisticShell(input, optimisticId);
+			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) => [
+				...(current ?? []),
+				optimistic,
+			]);
+			return { optimisticId };
+		},
+		onSuccess: (shell, _input, context) => {
+			if (usePreviewData) {
+				void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+				return;
+			}
+			// User closed the placeholder tab while POST was in flight — discard the
+			// server row so a later reload does not resurrect a dismissed shell.
+			if (context?.optimisticId && consumeCancelledOptimisticShell(context.optimisticId)) {
+				dismissDaemonShell(shell.handleId);
+				void deleteShellOnDaemon(shell.handleId);
+				return;
+			}
+			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) => {
+				const list = current ?? [];
+				if (context?.optimisticId) {
+					return list.map((item) => (item.handleId === context.optimisticId ? shell : item));
+				}
+				if (list.some((item) => item.handleId === shell.handleId)) return list;
+				return [...list, shell];
+			});
+		},
+		onError: (_error, _input, context) => {
+			// Only drop this open's placeholder — never restore a full snapshot, which
+			// would resurrect tabs the user closed while the request was in flight.
+			const optimisticId = context?.optimisticId;
+			if (!optimisticId) return;
+			cancelledOptimisticShellIds.delete(optimisticId);
+			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
+				(current ?? []).filter((shell) => shell.handleId !== optimisticId),
+			);
 		},
 	});
 }
@@ -112,15 +240,54 @@ export function useCloseShellTerminal() {
 				previewShellTerminals = previewShellTerminals.filter((s) => s.handleId !== handleId);
 				return;
 			}
+			if (isPendingShellHandleId(handleId)) {
+				return;
+			}
 			const { error } = await apiClient.DELETE("/api/v1/shell-terminals/{handleId}", {
 				params: { path: { handleId } },
 			});
 			if (error) throw error;
 		},
-		// Settled, not success: a close that 404s means the daemon already lost
-		// the shell, and the stale tab still needs to disappear.
-		onSettled: () => {
-			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+		// Drop the tab from the cache immediately so the strip does not keep showing
+		// a shell the pane has already left (close switches the active target first,
+		// then awaits DELETE). Without this the first click looks like it only
+		// selected the session tab, and a later click finally removes the shell.
+		onMutate: async (handleId) => {
+			if (isPendingShellHandleId(handleId)) {
+				cancelOptimisticShell(handleId);
+			}
+			await queryClient.cancelQueries({ queryKey: shellTerminalsQueryKey });
+			const previous = queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey);
+			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
+				(current ?? []).filter((shell) => shell.handleId !== handleId),
+			);
+			if (usePreviewData) {
+				previewShellTerminals = previewShellTerminals.filter((s) => s.handleId !== handleId);
+			}
+			return { previous };
+		},
+		onError: (error, handleId, context) => {
+			// Pending ids never hit the daemon; 404 means the row is already gone.
+			// Keep the optimistic removal instead of rolling back the whole strip.
+			if (isPendingShellHandleId(handleId) || isShellTerminalNotFound(error)) return;
+			const restored = context?.previous?.find((shell) => shell.handleId === handleId);
+			if (!restored) return;
+			// Re-insert only this shell — other tabs closed during the request stay closed.
+			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) => {
+				const list = current ?? [];
+				if (list.some((shell) => shell.handleId === handleId)) return list;
+				const index = context.previous?.findIndex((shell) => shell.handleId === handleId) ?? list.length;
+				const next = [...list];
+				next.splice(Math.min(Math.max(index, 0), next.length), 0, restored);
+				return next;
+			});
+			if (usePreviewData) {
+				if (previewShellTerminals.some((s) => s.handleId === handleId)) return;
+				const index = context.previous?.findIndex((s) => s.handleId === handleId) ?? previewShellTerminals.length;
+				const next = [...previewShellTerminals];
+				next.splice(Math.min(Math.max(index, 0), next.length), 0, restored);
+				previewShellTerminals = next;
+			}
 		},
 	});
 }

--- a/frontend/src/renderer/lib/terminal-strip-tabs.test.ts
+++ b/frontend/src/renderer/lib/terminal-strip-tabs.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+	adjacentShellStripTab,
+	buildTerminalStripTabs,
+	previousShellStripTab,
+	previousTerminalStripTab,
+} from "./terminal-strip-tabs";
+
+describe("terminal strip tab navigation", () => {
+	const tabs = buildTerminalStripTabs(["owner", "pinned"], ["sh-1", "sh-2"]);
+
+	it("returns the session tab to the left of a pinned session", () => {
+		expect(previousTerminalStripTab(tabs, { kind: "session", sessionId: "pinned" })).toEqual({
+			kind: "session",
+			sessionId: "owner",
+		});
+	});
+
+	it("returns the last session tab to the left of the first shell", () => {
+		expect(previousTerminalStripTab(tabs, { kind: "shell", handleId: "sh-1" })).toEqual({
+			kind: "session",
+			sessionId: "pinned",
+		});
+	});
+
+	it("returns the shell tab to the left of a later shell", () => {
+		expect(previousTerminalStripTab(tabs, { kind: "shell", handleId: "sh-2" })).toEqual({
+			kind: "shell",
+			handleId: "sh-1",
+		});
+	});
+
+	it("returns undefined when there is no tab to the left", () => {
+		expect(previousTerminalStripTab(tabs, { kind: "session", sessionId: "owner" })).toBeUndefined();
+		expect(previousShellStripTab(["only"], "only")).toBeUndefined();
+	});
+
+	it("falls back to the next shell when closing the leftmost shell tab", () => {
+		expect(adjacentShellStripTab(["sh-1", "sh-2", "sh-3"], "sh-1")).toBe("sh-2");
+		expect(adjacentShellStripTab(["sh-1", "sh-2", "sh-3"], "sh-3")).toBe("sh-2");
+		expect(adjacentShellStripTab(["only"], "only")).toBeUndefined();
+	});
+});

--- a/frontend/src/renderer/lib/terminal-strip-tabs.ts
+++ b/frontend/src/renderer/lib/terminal-strip-tabs.ts
@@ -1,0 +1,44 @@
+/** One tab in the session pane strip: pinned session tabs, then shell tabs. */
+export type TerminalStripTab =
+	| { kind: "session"; sessionId: string }
+	| { kind: "shell"; handleId: string };
+
+export function buildTerminalStripTabs(sessionIds: string[], shellHandleIds: string[]): TerminalStripTab[] {
+	return [
+		...sessionIds.map((sessionId) => ({ kind: "session" as const, sessionId })),
+		...shellHandleIds.map((handleId) => ({ kind: "shell" as const, handleId })),
+	];
+}
+
+function stripTabKey(tab: TerminalStripTab): string {
+	return tab.kind === "session" ? `session:${tab.sessionId}` : `shell:${tab.handleId}`;
+}
+
+/** Tab immediately to the left of `closed` in the strip, if any. */
+export function previousTerminalStripTab(
+	tabs: TerminalStripTab[],
+	closed: TerminalStripTab,
+): TerminalStripTab | undefined {
+	const closedKey = stripTabKey(closed);
+	const index = tabs.findIndex((tab) => stripTabKey(tab) === closedKey);
+	if (index <= 0) return undefined;
+	return tabs[index - 1];
+}
+
+/** Tab immediately to the left of the shell at `handleId`, if any. */
+export function previousShellStripTab(shellHandleIds: string[], handleId: string): string | undefined {
+	const index = shellHandleIds.indexOf(handleId);
+	if (index <= 0) return undefined;
+	return shellHandleIds[index - 1];
+}
+
+/**
+ * Neighbor to activate after closing `handleId`: prefer the tab to the left,
+ * otherwise the tab to the right (so closing the first tab does not blank the pane).
+ */
+export function adjacentShellStripTab(shellHandleIds: string[], handleId: string): string | undefined {
+	const index = shellHandleIds.indexOf(handleId);
+	if (index < 0) return undefined;
+	if (index > 0) return shellHandleIds[index - 1];
+	return shellHandleIds[index + 1];
+}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useRef, useState, startTransition } from "react";
 import { CommandPalette } from "../components/CommandPalette";
 import { CenterPanelShell } from "../components/CenterPanelShell";
 import { DaemonFailureBanner } from "../components/DaemonFailureBanner";
@@ -16,7 +16,7 @@ import { TitlebarNav } from "../components/TitlebarNav";
 import { WindowTitlebar } from "../components/WindowTitlebar";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
-import { useOpenShellTerminal } from "../hooks/useShellTerminals";
+import { beginOpenShellTerminalActivation, isLatestOpenShellTerminalActivation, useOpenShellTerminal } from "../hooks/useShellTerminals";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
 import { apiClient, apiErrorCode, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
@@ -559,17 +559,22 @@ function ShellLayout() {
 	useEffect(() => {
 		if (handledShellNonceRef.current === newShellTerminalNonce) return;
 		handledShellNonceRef.current = newShellTerminalNonce;
+		const activationGeneration = beginOpenShellTerminalActivation();
 		openShellTerminal.mutate(
 			{
 				projectId: tabOwnerSession?.workspaceId ?? scopedProjectId,
 				sessionId: tabOwnerSessionId ?? routeParams.sessionId,
+				activationGeneration,
 			},
 			{
-				onSuccess: (shell) => {
-					setActiveShellTerminal(shell.handleId);
-					if (!routeParams.sessionId) {
-						void navigate({ to: "/terminals" });
-					}
+				onSuccess: (shell, variables) => {
+					if (!isLatestOpenShellTerminalActivation(variables.activationGeneration)) return;
+					startTransition(() => {
+						setActiveShellTerminal(shell.handleId);
+						if (!routeParams.sessionId) {
+							void navigate({ to: "/terminals" });
+						}
+					});
 				},
 			},
 		);

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -123,9 +123,13 @@ vi.mock("../hooks/useDaemonStatus", () => ({
 
 // The shell layout opens standalone terminals; this suite only covers the
 // shortcut subscriptions, so the mutation is stubbed rather than driven.
-vi.mock("../hooks/useShellTerminals", () => ({
-	useOpenShellTerminal: () => ({ mutate: shellMocks.openShellTerminal }),
-}));
+vi.mock("../hooks/useShellTerminals", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../hooks/useShellTerminals")>();
+	return {
+		...actual,
+		useOpenShellTerminal: () => ({ mutate: shellMocks.openShellTerminal }),
+	};
+});
 
 vi.mock("../hooks/useAgentsQuery", () => ({
 	agentsQueryKey: ["agents"],


### PR DESCRIPTION
## Summary
- Drop the redundant TERMINAL label, remove xterm edge padding, and show tab-scroll chevrons only when the strip overflows.
- Close terminal tabs on a single click (mousedown), and activate the previous neighbor (or next on `/terminals` when closing the leftmost tab).
- Open shells optimistically with latest-wins activation so rapid opens stay responsive; avoid refetch storms and prevent dismissed tabs from resurrecting after close/reload.

## Test plan
- [ ] Open a session with several shell tabs — strip has no TERMINAL label; content sits flush under the tab bar
- [ ] With few tabs, scroll chevrons are hidden; with enough tabs to overflow, chevrons appear and scroll
- [ ] Click ✕ on a middle shell tab once — tab closes and the previous tab becomes active
- [ ] On `/terminals`, close the leftmost tab — the next tab activates (pane does not go blank)
- [ ] Rapidly open several terminals via + / Ctrl+Shift+` — UI stays responsive; tabs appear promptly; only the latest takes focus
- [ ] Close all shell tabs, reload the app — closed tabs do not reappear
- [ ] Close a pending tab before POST finishes — it stays gone after the request completes / on reload
- [ ] `cd frontend && npm test -- --run src/renderer/hooks/useShellTerminals.test.ts src/renderer/lib/terminal-strip-tabs.test.ts src/renderer/components/ShellTerminalTab.test.tsx src/renderer/components/CenterPane.test.tsx`

## Before
<img width="993" height="778" alt="image" src="https://github.com/user-attachments/assets/62f336a3-df61-4873-9493-7a8f2f881a95" />

## After
<img width="1470" height="926" alt="image" src="https://github.com/user-attachments/assets/dcf59eb1-4220-4af5-930e-28d245a08f59" />
