### PR TITLE
fix: hide PR and Completion when empty

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -222,9 +222,10 @@ describe("SessionInspector PR section", () => {
 		expect(prSection("Pull request").getByText("open")).toHaveClass("text-[9px]", "leading-none");
 	});
 
-	it("shows the empty state when there are no PRs", () => {
+	it("hides the pull request section when there are no PRs", () => {
 		renderWithQuery(<SessionInspector session={session([])} />);
-		expect(screen.getByText("No pull request opened yet.")).toBeInTheDocument();
+		expect(screen.queryByText("Pull request")).not.toBeInTheDocument();
+		expect(screen.queryByText("No pull request opened yet.")).not.toBeInTheDocument();
 	});
 
 	it("links each PR to its url", () => {
@@ -239,7 +240,7 @@ describe("SessionInspector PR section", () => {
 
 describe("SessionInspector completion controls", () => {
 	it("persists the terminate-on-merge preference", async () => {
-		renderWithQuery(<SessionInspector session={session([])} />);
+		renderWithQuery(<SessionInspector session={session([pr(7, "open")])} />);
 
 		await userEvent.click(screen.getByRole("switch", { name: "Terminate session when pull requests merge" }));
 
@@ -297,6 +298,15 @@ describe("SessionInspector completion controls", () => {
 
 		expect(screen.queryByText("Completion")).not.toBeInTheDocument();
 		expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+	});
+
+	it("hides completion controls when there are no PRs and the session is not merged", () => {
+		renderWithQuery(<SessionInspector session={session([])} />);
+
+		expect(screen.queryByText("Completion")).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("switch", { name: "Terminate session when pull requests merge" }),
+		).not.toBeInTheDocument();
 	});
 });
 

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -287,21 +287,23 @@ function SummaryView({ session }: { session: WorkspaceSession }) {
 	const prSectionTitle = prSummaries.length > 1 ? `Pull requests (${prSummaries.length})` : "Pull request";
 	const issueId = canonicalTrackerIssueId(session.issueId);
 
+	const hasPRs = prSummaries.length > 0;
+	const showCompletion =
+		session.kind !== "orchestrator" && (hasPRs || session.status === "merged");
+
 	return (
 		<div role="tabpanel">
-			<Section title={prSectionTitle}>
-				{prSummaries.length === 0 ? (
-					<p className={inspectorEmptyClass}>No pull request opened yet.</p>
-				) : (
+			{hasPRs ? (
+				<Section title={prSectionTitle}>
 					<div className="flex flex-col gap-1.5">
 						{prSummaries.map((pr) => (
 							<PRSummaryCard key={pr.number} pr={pr} />
 						))}
 					</div>
-				)}
-			</Section>
+				</Section>
+			) : null}
 
-			{session.kind !== "orchestrator" ? <CompletionControls session={session} /> : null}
+			{showCompletion ? <CompletionControls session={session} /> : null}
 
 			<Section title="Activity">
 				<ActivityTimeline prs={prSummaries} session={session} />


### PR DESCRIPTION
## Summary
- Hide the Summary inspector **Pull request** section when the session has no PRs (no empty-state card).
- Hide **Completion** unless there are PRs or the session status is `merged`.
- Update unit tests for the new visibility rules.

## Test plan
- [ ] Open a session with no PRs → Pull request and Completion sections are absent; Activity/Overview still show.
- [ ] Open a session with a PR → Pull request cards and Terminate on merge appear.
- [ ] Open a merged, non-terminated session → Completion terminate control still appears.
- [ ] `npx vitest run src/renderer/components/SessionInspector.test.tsx`

## Before
<img width="515" height="782" alt="image" src="https://github.com/user-attachments/assets/26a2705f-22b3-46c0-9189-6710f1bfb233" />

## After 
<img width="555" height="893" alt="image" src="https://github.com/user-attachments/assets/c4cb7231-e6c9-4cd6-be53-2a36a6b3ed41" />
