### PR TITLE
fix(terminal): number a session's terminal tabs and retire them on exit

### DIFF
--- a/backend/internal/service/shellterm/service.go
+++ b/backend/internal/service/shellterm/service.go
@@ -245,6 +245,17 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 		return ShellTerminal{}, fmt.Errorf("open shell terminal %s: runtime: %w", handleID, err)
 	}
 
+	title := shellTerminalTitle(workingDir)
+	if in.SessionID != "" {
+		// Safe to count here: the session gate is held for the whole open, so
+		// two concurrent opens for one session cannot pick the same number.
+		ordinal, err := s.nextSessionTerminalOrdinal(ctx, in.SessionID)
+		if err != nil {
+			return ShellTerminal{}, err
+		}
+		title = sessionShellTerminalTitle(ordinal)
+	}
+
 	rec := ShellTerminalRecord{
 		HandleID: handle.ID,
 		// The resolved project, not the requested one: a session-scoped open
@@ -253,7 +264,7 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 		ProjectID:  projectID,
 		SessionID:  in.SessionID,
 		WorkingDir: workingDir,
-		Title:      shellTerminalTitle(workingDir),
+		Title:      title,
 		AppRunID:   s.appRunID,
 		CreatedAt:  s.now().UTC(),
 	}
@@ -498,6 +509,25 @@ func (s *Service) BeginSessionTeardown(ctx context.Context, sessionID domain.Ses
 // It also returns the project the shell ended up attributed to, which is not
 // always the requested one: a session-scoped open may carry no project id, and
 // the session's own project is what the persisted row should record.
+// nextSessionTerminalOrdinal picks the number for a session's next terminal
+// tab. It takes one past the highest number already in use rather than a count,
+// so closing "Terminal 1" while "Terminal 2" is open does not hand the next
+// tab a name that is already on screen. A tab the user renamed no longer
+// matches and simply stops reserving its number.
+func (s *Service) nextSessionTerminalOrdinal(ctx context.Context, sessionID domain.SessionID) (int, error) {
+	recs, err := s.store.SelectShellTerminalsBySessionID(ctx, sessionID)
+	if err != nil {
+		return 0, fmt.Errorf("open shell terminal: count terminals for session %s: %w", sessionID, err)
+	}
+	highest := 0
+	for _, rec := range recs {
+		if n, ok := sessionTerminalOrdinal(rec.Title); ok && n > highest {
+			highest = n
+		}
+	}
+	return highest + 1, nil
+}
+
 func (s *Service) resolveShellTerminalWorkingDir(ctx context.Context, projectID domain.ProjectID, sessionID domain.SessionID) (workingDir string, resolvedProjectID domain.ProjectID, err error) {
 	if sessionID != "" {
 		if s.sessions == nil {

--- a/backend/internal/service/shellterm/service.go
+++ b/backend/internal/service/shellterm/service.go
@@ -233,6 +233,23 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 		return ShellTerminal{}, fmt.Errorf("open shell terminal: handle id: %w", err)
 	}
 
+	// Resolve the tab name BEFORE the runtime exists. This reads the store, and
+	// a store failure after Create would strand a PTY that nothing can find:
+	// no row means neither shutdown nor the app-run reaper can ever destroy it.
+	// Doing it here means the only failure that can leave a runtime behind is
+	// the insert below, which already rolls back.
+	//
+	// Counting is safe: the session gate is held for the whole open, so two
+	// concurrent opens for one session cannot pick the same number.
+	title := shellTerminalTitle(workingDir)
+	if in.SessionID != "" {
+		ordinal, err := s.nextSessionTerminalOrdinal(ctx, in.SessionID)
+		if err != nil {
+			return ShellTerminal{}, err
+		}
+		title = sessionShellTerminalTitle(ordinal)
+	}
+
 	// SessionID is the runtime adapters' name for "what to call this PTY"; it
 	// is not a session row and no sessions record is ever created. The
 	// shellterm- prefix keeps the two namespaces disjoint.
@@ -243,17 +260,6 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 	})
 	if err != nil {
 		return ShellTerminal{}, fmt.Errorf("open shell terminal %s: runtime: %w", handleID, err)
-	}
-
-	title := shellTerminalTitle(workingDir)
-	if in.SessionID != "" {
-		// Safe to count here: the session gate is held for the whole open, so
-		// two concurrent opens for one session cannot pick the same number.
-		ordinal, err := s.nextSessionTerminalOrdinal(ctx, in.SessionID)
-		if err != nil {
-			return ShellTerminal{}, err
-		}
-		title = sessionShellTerminalTitle(ordinal)
 	}
 
 	rec := ShellTerminalRecord{

--- a/backend/internal/service/shellterm/service_test.go
+++ b/backend/internal/service/shellterm/service_test.go
@@ -1103,3 +1103,78 @@ func TestShellTerminalTitleFallsBackForRootlessPaths(t *testing.T) {
 		t.Errorf("title = %q, want %q", got, "portfolio")
 	}
 }
+
+// Every shell in a session starts in that session's worktree, so naming tabs
+// after the directory put the identical label on all of them. Session tabs are
+// numbered instead; standalone tabs keep the directory, which is what tells
+// shells from different projects apart on /terminals.
+func TestSessionTerminalTitlesAreNumberedWithinTheSession(t *testing.T) {
+	if got := sessionShellTerminalTitle(1); got != "Terminal 1" {
+		t.Errorf("first session tab = %q, want %q", got, "Terminal 1")
+	}
+	if got := sessionShellTerminalTitle(3); got != "Terminal 3" {
+		t.Errorf("third session tab = %q, want %q", got, "Terminal 3")
+	}
+}
+
+func TestSessionTerminalOrdinalOnlyParsesGeneratedTitles(t *testing.T) {
+	for _, tc := range []struct {
+		title string
+		want  int
+		ok    bool
+	}{
+		{"Terminal 1", 1, true},
+		{"Terminal 12", 12, true},
+		{"Terminal 0", 0, false},     // never generated; 1-based
+		{"Terminal", 0, false},       // no number
+		{"Terminal x", 0, false},     // not a number
+		{"my build shell", 0, false}, // user rename stops reserving a number
+		{"portfolio", 0, false},      // a standalone tab's directory title
+	} {
+		got, ok := sessionTerminalOrdinal(tc.title)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("sessionTerminalOrdinal(%q) = (%d, %t), want (%d, %t)", tc.title, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// Closing "Terminal 1" while "Terminal 2" is open must not hand the next tab a
+// name that is already on screen, so the ordinal comes from the highest in use
+// rather than the count.
+func TestNextSessionTerminalOrdinalSkipsNamesStillInUse(t *testing.T) {
+	st := &fakeShellTerminalStore{}
+	svc := newTestService(newFakeShellRuntime(), st, &fakeProjectRootLocator{})
+	ctx := context.Background()
+
+	for _, rec := range []ShellTerminalRecord{
+		{HandleID: "h-2", SessionID: "sess-1", Title: "Terminal 2"},
+		{HandleID: "h-9", SessionID: "sess-1", Title: "my build shell"},
+		{HandleID: "h-1", SessionID: "other", Title: "Terminal 7"},
+	} {
+		if err := st.InsertShellTerminal(ctx, rec); err != nil {
+			t.Fatalf("seed %s: %v", rec.HandleID, err)
+		}
+	}
+
+	got, err := svc.nextSessionTerminalOrdinal(ctx, "sess-1")
+	if err != nil {
+		t.Fatalf("nextSessionTerminalOrdinal: %v", err)
+	}
+	// 3, not 2 (Terminal 2 is still open) and not 8 (another session's tabs
+	// must not push this session's numbering along).
+	if got != 3 {
+		t.Errorf("next ordinal = %d, want 3", got)
+	}
+}
+
+func TestNextSessionTerminalOrdinalStartsAtOne(t *testing.T) {
+	svc := newTestService(newFakeShellRuntime(), &fakeShellTerminalStore{}, &fakeProjectRootLocator{})
+
+	got, err := svc.nextSessionTerminalOrdinal(context.Background(), "sess-empty")
+	if err != nil {
+		t.Fatalf("nextSessionTerminalOrdinal: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("first ordinal = %d, want 1", got)
+	}
+}

--- a/backend/internal/service/shellterm/service_test.go
+++ b/backend/internal/service/shellterm/service_test.go
@@ -66,8 +66,9 @@ func (f *fakeShellRuntime) IsAlive(_ context.Context, handle ports.RuntimeHandle
 
 // fakeShellTerminalStore is an in-memory Store keyed by handle id.
 type fakeShellTerminalStore struct {
-	records   []ShellTerminalRecord
-	insertErr error
+	records      []ShellTerminalRecord
+	insertErr    error
+	bySessionErr error
 }
 
 func (f *fakeShellTerminalStore) InsertShellTerminal(_ context.Context, rec ShellTerminalRecord) error {
@@ -108,6 +109,9 @@ func (f *fakeShellTerminalStore) SelectShellTerminalsByAppRunID(_ context.Contex
 }
 
 func (f *fakeShellTerminalStore) SelectShellTerminalsBySessionID(_ context.Context, sessionID domain.SessionID) ([]ShellTerminalRecord, error) {
+	if f.bySessionErr != nil {
+		return nil, f.bySessionErr
+	}
 	var out []ShellTerminalRecord
 	for _, rec := range f.records {
 		if rec.SessionID == sessionID {
@@ -1176,5 +1180,34 @@ func TestNextSessionTerminalOrdinalStartsAtOne(t *testing.T) {
 	}
 	if got != 1 {
 		t.Errorf("first ordinal = %d, want 1", got)
+	}
+}
+
+// Regression: the tab ordinal is read from the store, and that read used to
+// happen AFTER runtime.Create. A store failure there returned with a live PTY
+// and no row pointing at it, so neither shutdown nor the app-run reaper could
+// ever find it — a tmux session leaked for the life of the machine. The lookup
+// now runs before Create, so this failure cannot strand a runtime at all.
+func TestOpenShellTerminalLeavesNoRuntimeWhenOrdinalLookupFails(t *testing.T) {
+	rt := newFakeShellRuntime()
+	st := &fakeShellTerminalStore{bySessionErr: errors.New("store unavailable")}
+	sessions := &fakeSessionWorkspaceLocator{
+		sessions: map[domain.SessionID]fakeSessionWorkspace{
+			"sess-1": {workspacePath: "/wt/sess-1", projectID: "proj"},
+		},
+	}
+	svc := newTestServiceWithSessions(rt, st, &fakeProjectRootLocator{}, sessions)
+
+	_, err := svc.OpenShellTerminal(context.Background(), OpenShellTerminalInput{SessionID: "sess-1"})
+	if err == nil {
+		t.Fatal("a store failure while naming the tab must fail the open")
+	}
+	// The point of the fix: no PTY was ever spawned, so there is nothing to leak
+	// and nothing to roll back.
+	if len(rt.created) != 0 {
+		t.Fatalf("runtime.Create called %d times; the ordinal lookup must happen first", len(rt.created))
+	}
+	if len(st.records) != 0 {
+		t.Fatalf("store holds %d records after a failed open, want 0", len(st.records))
 	}
 }

--- a/backend/internal/service/shellterm/types.go
+++ b/backend/internal/service/shellterm/types.go
@@ -15,7 +15,10 @@
 package shellterm
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -43,10 +46,11 @@ type OpenShellTerminalInput struct {
 	SessionID domain.SessionID `json:"sessionId,omitempty"`
 }
 
-// shellTerminalTitle labels a tab by the directory the shell started in, which
-// is the only thing that distinguishes one shell pane from another in the UI.
-// A path that has no usable base (a bare root, or an empty string) falls back
-// to a generic label rather than rendering an empty tab.
+// shellTerminalTitle labels a standalone tab by the directory the shell started
+// in. Those shells come from the board or /terminals and can span projects, so
+// the directory is what tells them apart. A path with no usable base (a bare
+// root, or an empty string) falls back to a generic label rather than
+// rendering an empty tab.
 func shellTerminalTitle(workingDir string) string {
 	base := filepath.Base(workingDir)
 	switch base {
@@ -54,4 +58,28 @@ func shellTerminalTitle(workingDir string) string {
 		return "Shell"
 	}
 	return base
+}
+
+// sessionShellTerminalTitle numbers a session's tabs instead of naming them.
+// Every shell in a session starts in that session's worktree, so the directory
+// was identical on every tab and told the user nothing; the session itself is
+// already the first tab in the strip. ordinal is 1-based.
+func sessionShellTerminalTitle(ordinal int) string {
+	return fmt.Sprintf("%s%d", sessionShellTerminalPrefix, ordinal)
+}
+
+const sessionShellTerminalPrefix = "Terminal "
+
+// sessionTerminalOrdinal reads back a title this package generated. A title the
+// user renamed does not parse and reports false, so it stops reserving a number.
+func sessionTerminalOrdinal(title string) (int, bool) {
+	rest, found := strings.CutPrefix(title, sessionShellTerminalPrefix)
+	if !found {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
 }

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -70,7 +70,9 @@ describe("CenterPane toolbar session label", () => {
 	it("uses the inspector tab height for the terminal header", () => {
 		render(<CenterPane session={worker} theme="dark" daemonReady />);
 
-		const header = screen.getByText("TERMINAL").parentElement?.parentElement;
+		// Anchored on the tab strip, not a heading: the "TERMINAL" label is gone.
+		const header = document.querySelector(".h-inspector-tabs");
+		expect(header).not.toBeNull();
 		expect(header).toHaveClass("h-inspector-tabs");
 	});
 
@@ -91,7 +93,7 @@ describe("CenterPane toolbar session label", () => {
 
 		// The display controls float over the terminal body, not the tab bar,
 		// so tabs and controls can never overlap.
-		const tabBarRow = screen.getByText("TERMINAL").closest("div")?.parentElement;
+		const tabBarRow = document.querySelector(".h-inspector-tabs");
 		expect(tabBarRow).not.toBeNull();
 		expect(tabBarRow?.contains(screen.getByRole("button", { name: /fullscreen/i }))).toBe(false);
 	});

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -22,6 +22,8 @@ type CenterPaneProps = {
 	onSelectSessionTerminal?: () => void;
 	onSelectShellTerminal?: (handleId: string) => void;
 	onCloseShellTerminal?: (handleId: string) => void;
+	/** A shell whose PTY exited on its own; its tab is retired. */
+	onShellExited?: (handleId: string) => void;
 	onRenameShellTerminal?: (handleId: string, title: string) => void;
 	/** Opens a new standalone shell tab (the "+" at the end of the tab bar). */
 	onNewShellTerminal?: () => void;
@@ -53,6 +55,7 @@ export function CenterPane({
 	onSelectSessionTerminal,
 	onSelectShellTerminal,
 	onCloseShellTerminal,
+	onShellExited,
 	onRenameShellTerminal,
 	onNewShellTerminal,
 }: CenterPaneProps) {
@@ -216,6 +219,7 @@ export function CenterPane({
 				<TerminalPane
 					daemonReady={daemonReady}
 					fontSize={fontSize}
+					onShellExited={onShellExited}
 					session={session}
 					terminalTarget={target}
 					theme={theme}

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -22,8 +22,10 @@ type CenterPaneProps = {
 	onSelectSessionTerminal?: () => void;
 	onSelectShellTerminal?: (handleId: string) => void;
 	onCloseShellTerminal?: (handleId: string) => void;
-	/** A shell whose PTY exited on its own; its tab is retired. */
+	/** A shell pane reported its PTY ended; the owner re-checks with the daemon. */
 	onShellExited?: (handleId: string) => void;
+	/** Bumped to force a fresh attachment when a reported exit turns out false. */
+	attachEpoch?: number;
 	onRenameShellTerminal?: (handleId: string, title: string) => void;
 	/** Opens a new standalone shell tab (the "+" at the end of the tab bar). */
 	onNewShellTerminal?: () => void;
@@ -56,6 +58,7 @@ export function CenterPane({
 	onSelectShellTerminal,
 	onCloseShellTerminal,
 	onShellExited,
+	attachEpoch,
 	onRenameShellTerminal,
 	onNewShellTerminal,
 }: CenterPaneProps) {
@@ -220,6 +223,7 @@ export function CenterPane({
 				<TerminalPane
 					daemonReady={daemonReady}
 					fontSize={fontSize}
+					attachEpoch={attachEpoch}
 					onShellExited={onShellExited}
 					session={session}
 					terminalTarget={target}

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -124,16 +124,17 @@ export function CenterPane({
 			className="terminal-pane-frame flex h-full min-h-0 min-w-flex-min flex-col"
 			onWheelCapture={handleWheelZoom}
 		>
-			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border px-5">
+			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border pl-2 pr-5">
+				{/* No "TERMINAL" heading: the tabs say what this is, and the label was
+				    spending the widest column in the strip to repeat it. */}
 				<div className="flex min-w-flex-min flex-1 items-center gap-3">
-					<span className="shrink-0 font-mono text-caption font-semibold uppercase tracking-wide-lg text-muted-foreground">
-						TERMINAL
-					</span>
 					<button
 						aria-label="Scroll tabs left"
 						className={cn(
-							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none disabled:opacity-0",
-							!tabsOverflow.canScrollLeft && "invisible",
+							"inline-flex shrink-0 items-center justify-center overflow-hidden rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none",
+							// visibility:hidden still reserves the box, which left a dead
+							// column where the strip should start. Collapse it instead.
+							tabsOverflow.canScrollLeft ? "size-control-sm" : "pointer-events-none size-0 opacity-0",
 						)}
 						disabled={!tabsOverflow.canScrollLeft}
 						onClick={() => tabsOverflow.scrollByDirection(-1)}
@@ -173,8 +174,8 @@ export function CenterPane({
 					<button
 						aria-label="Scroll tabs right"
 						className={cn(
-							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none disabled:opacity-0",
-							!tabsOverflow.canScrollRight && "invisible",
+							"inline-flex shrink-0 items-center justify-center overflow-hidden rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none",
+							tabsOverflow.canScrollRight ? "size-control-sm" : "pointer-events-none size-0 opacity-0",
 						)}
 						disabled={!tabsOverflow.canScrollRight}
 						onClick={() => tabsOverflow.scrollByDirection(1)}

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -208,11 +208,13 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 }));
 // Standalone shell terminals are orthogonal to the split under test, and their
 // real hooks would need a QueryClientProvider this suite deliberately omits.
+const refreshShellTerminalsMock = vi.fn();
 vi.mock("../hooks/useShellTerminals", () => ({
 	useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
 	useOpenShellTerminal: () => ({ mutate: vi.fn() }),
 	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
 	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
+	useRefreshShellTerminals: () => refreshShellTerminalsMock,
 }));
 
 // jsdom has no layout engine, so the real react-resizable-panels would never

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, type ReactNode, type Ref } from "react";
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { SessionView } from "./SessionView";
 import { useUiStore } from "../stores/ui-store";
@@ -90,18 +90,28 @@ vi.mock("./CenterPane", () => ({
 		shellTerminals = [],
 		onSelectShellTerminal,
 		onSelectSessionTerminal,
+		onShellExited,
+		attachEpoch,
 	}: {
 		session?: WorkspaceSession;
 		shellTerminals?: Array<{ handleId: string; title: string }>;
 		onSelectShellTerminal?: (handleId: string) => void;
 		onSelectSessionTerminal?: () => void;
+		onShellExited?: (handleId: string) => void;
+		attachEpoch?: number;
 	}) => (
 		<div>
 			terminal center
 			<div data-testid="shell-tabs">{shellTerminals.map((s) => s.title).join(",")}</div>
+			<div data-testid="attach-epoch">{String(attachEpoch ?? 0)}</div>
 			{shellTerminals.map((s) => (
 				<button key={s.handleId} type="button" onClick={() => onSelectShellTerminal?.(s.handleId)}>
 					select {s.title}
+				</button>
+			))}
+			{shellTerminals.map((s) => (
+				<button key={`exit-${s.handleId}`} type="button" onClick={() => onShellExited?.(s.handleId)}>
+					report exit {s.title}
 				</button>
 			))}
 			<button type="button" onClick={() => onSelectSessionTerminal?.()}>
@@ -208,7 +218,7 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 }));
 // Standalone shell terminals are orthogonal to the split under test, and their
 // real hooks would need a QueryClientProvider this suite deliberately omits.
-const refreshShellTerminalsMock = vi.fn();
+const refreshShellTerminalsMock = vi.fn(async () => shellTerminalsState.data);
 vi.mock("../hooks/useShellTerminals", () => ({
 	useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
 	useOpenShellTerminal: () => ({ mutate: vi.fn() }),
@@ -403,6 +413,59 @@ describe("SessionView", () => {
 		expect(screen.getByTestId("session-tab")).not.toHaveTextContent("do the other thing");
 		expect(screen.getByTestId("shell-tabs")).not.toHaveTextContent("sess-2-shell");
 		expect(screen.queryByTestId("available-project-tabs")).not.toBeInTheDocument();
+	});
+
+	// A pane reporting "exited" is not proof the shell died: the attach loop
+	// reports the same after giving up on a failing liveness probe. If the
+	// daemon still lists the shell it is alive, and the pane — which holds
+	// "exited" forever once it lands there — must be remounted to reconnect,
+	// not left telling the user to close a live terminal.
+	it("re-attaches instead of closing when the daemon still has the shell", async () => {
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				sessionId: "sess-1",
+				title: "Terminal 1",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+		];
+		render(<SessionView sessionId="sess-1" />);
+
+		// Select it so the pane is pointed at the shell.
+		fireEvent.click(screen.getByRole("button", { name: "select Terminal 1" }));
+		expect(screen.getByTestId("attach-epoch")).toHaveTextContent("0");
+
+		fireEvent.click(screen.getByRole("button", { name: "report exit Terminal 1" }));
+
+		// The daemon kept it, so the pane remounts and the tab stays put.
+		await waitFor(() => expect(screen.getByTestId("attach-epoch")).toHaveTextContent("1"));
+		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("Terminal 1");
+		expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("shell");
+	});
+
+	// The other half: the daemon confirms it is gone, so the pane goes back to
+	// the session rather than remounting an attachment to a dead handle.
+	it("hands the pane back to the session when the daemon drops the shell", async () => {
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				sessionId: "sess-1",
+				title: "Terminal 1",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+		];
+		render(<SessionView sessionId="sess-1" />);
+		fireEvent.click(screen.getByRole("button", { name: "select Terminal 1" }));
+		expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("shell");
+
+		// The refresh reports it pruned.
+		shellTerminalsState.data = [];
+		fireEvent.click(screen.getByRole("button", { name: "report exit Terminal 1" }));
+
+		await waitFor(() => expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("worker"));
+		expect(screen.getByTestId("attach-epoch")).toHaveTextContent("0");
 	});
 
 	// Regression: react-resizable-panels v4 treats bare numeric sizes as PIXELS

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -89,6 +89,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const openShellTerminal = useOpenShellTerminal();
 	const closeShellTerminal = useCloseShellTerminal();
 	const refreshShellTerminals = useRefreshShellTerminals();
+	const [shellAttachEpochs, setShellAttachEpochs] = useState<Record<string, number>>({});
 	const renameShellTerminal = useRenameShellTerminal();
 	const activeShellTerminalHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
 	const setActiveShellTerminal = useUiStore((state) => state.setActiveShellTerminal);
@@ -135,15 +136,27 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	);
 
 	// A pane reporting "exited" is a hint, not proof: the attach loop reports it
-	// after giving up on a failing liveness probe too. Drop the dead view but
-	// let the daemon decide whether the shell itself is really gone.
+	// after giving up on a failing liveness probe too. Ask the daemon, then act
+	// on its answer.
+	//
+	// Still in the list -> the shell is alive and this was an attachment
+	// failure. The pane holds "exited" forever once it lands there, so the tab
+	// would sit on "Terminal ended" telling the user to close a live shell.
+	// Bumping the epoch remounts the attachment and reconnects it instead.
+	//
+	// Gone from the list -> the daemon confirmed it died; give the pane back to
+	// the session.
 	const handleShellExited = useCallback(
-		(handleId: string) => {
+		async (handleId: string) => {
+			const shells = await refreshShellTerminals();
+			if (shells.some((shell) => shell.handleId === handleId)) {
+				setShellAttachEpochs((current) => ({ ...current, [handleId]: (current[handleId] ?? 0) + 1 }));
+				return;
+			}
 			setTerminalTarget((current) =>
 				current.kind === "shell" && current.handleId === handleId ? { kind: "worker" } : current,
 			);
 			if (activeShellTerminalHandleId === handleId) setActiveShellTerminal(null);
-			refreshShellTerminals();
 		},
 		[activeShellTerminalHandleId, refreshShellTerminals, setActiveShellTerminal],
 	);
@@ -388,6 +401,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					<CenterPane
 						daemonReady={daemonStatus.state === "ready"}
 						onCloseShellTerminal={closeShellTerminalByHandle}
+						attachEpoch={terminalTarget.kind === "shell" ? (shellAttachEpochs[terminalTarget.handleId] ?? 0) : 0}
 						onShellExited={handleShellExited}
 						onNewShellTerminal={addShellTerminal}
 						onRenameShellTerminal={renameShellTerminalByHandle}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -372,6 +372,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					<CenterPane
 						daemonReady={daemonStatus.state === "ready"}
 						onCloseShellTerminal={closeShellTerminalByHandle}
+						onShellExited={closeShellTerminalByHandle}
 						onNewShellTerminal={addShellTerminal}
 						onRenameShellTerminal={renameShellTerminalByHandle}
 						onSelectSessionTerminal={selectSessionTerminal}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -13,6 +13,7 @@ import { useBrowserView } from "../hooks/useBrowserView";
 import {
 	useCloseShellTerminal,
 	useOpenShellTerminal,
+	useRefreshShellTerminals,
 	useRenameShellTerminal,
 	useShellTerminals,
 } from "../hooks/useShellTerminals";
@@ -87,6 +88,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	);
 	const openShellTerminal = useOpenShellTerminal();
 	const closeShellTerminal = useCloseShellTerminal();
+	const refreshShellTerminals = useRefreshShellTerminals();
 	const renameShellTerminal = useRenameShellTerminal();
 	const activeShellTerminalHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
 	const setActiveShellTerminal = useUiStore((state) => state.setActiveShellTerminal);
@@ -130,6 +132,20 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			closeShellTerminal.mutate(handleId);
 		},
 		[closeShellTerminal, activeShellTerminalHandleId, setActiveShellTerminal],
+	);
+
+	// A pane reporting "exited" is a hint, not proof: the attach loop reports it
+	// after giving up on a failing liveness probe too. Drop the dead view but
+	// let the daemon decide whether the shell itself is really gone.
+	const handleShellExited = useCallback(
+		(handleId: string) => {
+			setTerminalTarget((current) =>
+				current.kind === "shell" && current.handleId === handleId ? { kind: "worker" } : current,
+			);
+			if (activeShellTerminalHandleId === handleId) setActiveShellTerminal(null);
+			refreshShellTerminals();
+		},
+		[activeShellTerminalHandleId, refreshShellTerminals, setActiveShellTerminal],
 	);
 
 	// Selecting the session's own pane also drops the active shell, so the effect
@@ -372,7 +388,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					<CenterPane
 						daemonReady={daemonStatus.state === "ready"}
 						onCloseShellTerminal={closeShellTerminalByHandle}
-						onShellExited={closeShellTerminalByHandle}
+						onShellExited={handleShellExited}
 						onNewShellTerminal={addShellTerminal}
 						onRenameShellTerminal={renameShellTerminalByHandle}
 						onSelectSessionTerminal={selectSessionTerminal}

--- a/frontend/src/renderer/components/ShellTerminalsView.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.test.tsx
@@ -6,6 +6,7 @@ vi.mock("../hooks/useShellTerminals", () => ({
 	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
 	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
 	useShellTerminals: () => ({ data: [] }),
+	useRefreshShellTerminals: () => vi.fn(),
 }));
 
 vi.mock("../lib/shell-context", () => ({

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -107,6 +107,7 @@ export function ShellTerminalsView() {
 					<TerminalPane
 						daemonReady={daemonStatus.state === "ready"}
 						fontSize={12}
+						onShellExited={(handleId) => closeShellTerminal.mutate(handleId)}
 						terminalTarget={{ kind: "shell", handleId: active.handleId, title: active.title }}
 						theme={theme}
 					/>

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
 import {
 	useCloseShellTerminal,
@@ -28,6 +28,17 @@ export function ShellTerminalsView() {
 	const shellTerminals = (useShellTerminals().data ?? []).filter((s) => !s.sessionId);
 	const closeShellTerminal = useCloseShellTerminal();
 	const refreshShellTerminals = useRefreshShellTerminals();
+	const [attachEpochs, setAttachEpochs] = useState<Record<string, number>>({});
+	// See SessionView: "exited" is a hint. If the daemon still lists the shell it
+	// is alive and the pane must re-attach rather than sit on "Terminal ended".
+	const handleShellExited = useCallback(
+		async (handleId: string) => {
+			const shells = await refreshShellTerminals();
+			if (!shells.some((shell) => shell.handleId === handleId)) return;
+			setAttachEpochs((current) => ({ ...current, [handleId]: (current[handleId] ?? 0) + 1 }));
+		},
+		[refreshShellTerminals],
+	);
 	const renameShellTerminal = useRenameShellTerminal();
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);
 	const activeHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
@@ -113,7 +124,8 @@ export function ShellTerminalsView() {
 					<TerminalPane
 						daemonReady={daemonStatus.state === "ready"}
 						fontSize={12}
-						onShellExited={() => refreshShellTerminals()}
+						attachEpoch={active ? (attachEpochs[active.handleId] ?? 0) : 0}
+						onShellExited={handleShellExited}
 						terminalTarget={{ kind: "shell", handleId: active.handleId, title: active.title }}
 						theme={theme}
 					/>

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -1,7 +1,12 @@
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { useEffect } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
-import { useCloseShellTerminal, useRenameShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
+import {
+	useCloseShellTerminal,
+	useRefreshShellTerminals,
+	useRenameShellTerminal,
+	useShellTerminals,
+} from "../hooks/useShellTerminals";
 import { useShell } from "../lib/shell-context";
 import { cn } from "../lib/utils";
 import { useResolvedTheme, useUiStore } from "../stores/ui-store";
@@ -22,6 +27,7 @@ export function ShellTerminalsView() {
 	// shells belong to that session's tab strip, not this global list.
 	const shellTerminals = (useShellTerminals().data ?? []).filter((s) => !s.sessionId);
 	const closeShellTerminal = useCloseShellTerminal();
+	const refreshShellTerminals = useRefreshShellTerminals();
 	const renameShellTerminal = useRenameShellTerminal();
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);
 	const activeHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
@@ -107,7 +113,7 @@ export function ShellTerminalsView() {
 					<TerminalPane
 						daemonReady={daemonStatus.state === "ready"}
 						fontSize={12}
-						onShellExited={(handleId) => closeShellTerminal.mutate(handleId)}
+						onShellExited={() => refreshShellTerminals()}
 						terminalTarget={{ kind: "shell", handleId: active.handleId, title: active.title }}
 						theme={theme}
 					/>

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -371,10 +371,12 @@ describe("terminal link preview", () => {
 	});
 });
 
-// A shell whose PTY exits can never be attached again, so its tab is retired
-// rather than parked in the strip showing "TERMINAL ENDED". Nothing else tells
-// the client: the shell list is only refetched around this client's own
-// open/close, so without this the dead tab sat there until the next mutation.
+// A shell whose PTY exits should not sit in the strip showing "TERMINAL ENDED":
+// nothing else tells the client, since the shell list is only refetched around
+// this client's own open/close. The pane reports the exit as a HINT — it is not
+// proof of death, because the attach loop reports the same "exited" after it
+// gives up on a failing liveness probe — so the callers re-check with the
+// daemon rather than closing anything.
 describe("TerminalPane shell exit", () => {
 	function renderShellPane(onShellExited: (handleId: string) => void, state: string) {
 		terminalState.value = state;
@@ -395,7 +397,7 @@ describe("TerminalPane shell exit", () => {
 		return { ...result, restore: () => { window.ao = previousAO; } };
 	}
 
-	it("retires the tab when the shell's PTY exits", async () => {
+	it("reports the exit once so the caller can re-check with the daemon", async () => {
 		const onShellExited = vi.fn();
 		const { restore } = renderShellPane(onShellExited, "exited");
 		await waitFor(() => expect(onShellExited).toHaveBeenCalledWith("sh-a"));

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -370,3 +370,62 @@ describe("terminal link preview", () => {
 		}
 	});
 });
+
+// A shell whose PTY exits can never be attached again, so its tab is retired
+// rather than parked in the strip showing "TERMINAL ENDED". Nothing else tells
+// the client: the shell list is only refetched around this client's own
+// open/close, so without this the dead tab sat there until the next mutation.
+describe("TerminalPane shell exit", () => {
+	function renderShellPane(onShellExited: (handleId: string) => void, state: string) {
+		terminalState.value = state;
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const previousAO = window.ao;
+		window.ao = {} as typeof window.ao;
+		const result = render(
+			<QueryClientProvider client={queryClient}>
+				<TerminalPane
+					daemonReady
+					fontSize={12}
+					onShellExited={onShellExited}
+					terminalTarget={{ kind: "shell", handleId: "sh-a", title: "Terminal 1" }}
+					theme="dark"
+				/>
+			</QueryClientProvider>,
+		);
+		return { ...result, restore: () => { window.ao = previousAO; } };
+	}
+
+	it("retires the tab when the shell's PTY exits", async () => {
+		const onShellExited = vi.fn();
+		const { restore } = renderShellPane(onShellExited, "exited");
+		await waitFor(() => expect(onShellExited).toHaveBeenCalledWith("sh-a"));
+		expect(onShellExited).toHaveBeenCalledOnce();
+		restore();
+	});
+
+	it("leaves a live shell alone", async () => {
+		const onShellExited = vi.fn();
+		const { restore } = renderShellPane(onShellExited, "attached");
+		await waitFor(() => expect(screen.getByTestId("xterm")).toBeInTheDocument());
+		expect(onShellExited).not.toHaveBeenCalled();
+		restore();
+	});
+
+	// A session pane that ends still has a row, a status, and a restore path, so
+	// its tab must survive. Only shells are retired.
+	it("does not retire a session pane that ended", async () => {
+		const onShellExited = vi.fn();
+		terminalState.value = "exited";
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const previousAO = window.ao;
+		window.ao = {} as typeof window.ao;
+		render(
+			<QueryClientProvider client={queryClient}>
+				<TerminalPane daemonReady fontSize={12} onShellExited={onShellExited} session={worker} theme="dark" />
+			</QueryClientProvider>,
+		);
+		await waitFor(() => expect(screen.getByText("Terminal ended")).toBeInTheDocument());
+		expect(onShellExited).not.toHaveBeenCalled();
+		window.ao = previousAO;
+	});
+});

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -20,18 +20,37 @@ type TerminalPaneProps = {
 	terminalTarget?: TerminalTarget;
 	fontSize: number;
 	/**
-	 * Fired once when a shell pane's PTY exits on its own (the user typed
-	 * `exit`, or killed the process). Nothing else tells the client: the shell
-	 * list is only refetched around this client's own open/close.
+	 * Fired once when a shell pane reports its PTY ended (the user typed `exit`,
+	 * killed the process — or the attach loop gave up). Nothing else tells the
+	 * client: the shell list is only refetched around this client's own
+	 * open/close.
 	 */
 	onShellExited?: (handleId: string) => void;
+	/**
+	 * Bumped to force a fresh attachment for the same handle. A pane that
+	 * reported "exited" holds that state forever, so when the daemon says the
+	 * shell is in fact still alive, the only way back to a live terminal is to
+	 * remount the attachment.
+	 */
+	attachEpoch?: number;
 };
 
-export function TerminalPane({ session, theme, daemonReady, terminalTarget, fontSize, onShellExited }: TerminalPaneProps) {
-	const terminalKey =
+export function TerminalPane({
+	session,
+	theme,
+	daemonReady,
+	terminalTarget,
+	fontSize,
+	onShellExited,
+	attachEpoch = 0,
+}: TerminalPaneProps) {
+	const handleKey =
 		terminalTarget?.kind === "reviewer" || terminalTarget?.kind === "shell"
 			? terminalTarget.handleId
 			: (session?.terminalHandleId ?? "empty");
+	// The epoch is part of the key so a bump remounts the attachment for the
+	// same handle, which is what recovers a pane stuck on a false "exited".
+	const terminalKey = `${handleKey}:${attachEpoch}`;
 
 	if (!window.ao) {
 		// A standalone shell has no agent and no branch, so it previews as a plain

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -283,10 +283,19 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 		!isSessionActive;
 
 	// A shell whose PTY exits leaves a tab that can never be attached again, so
-	// retire it instead of parking a dead pane in the strip. Reported once per
-	// pane: the component is keyed by handle, so a later shell on the same tab
-	// mounts fresh. Only for shells — a session pane that ends still has a row,
-	// a status, and a restore path, so its tab must stay.
+	// retire it instead of parking a dead pane in the strip.
+	//
+	// This is a HINT, never a close. "exited" does not prove the shell died:
+	// attachment.fail() reaches the same markExited() after the liveness probe
+	// or the attach itself errors past the retry cap, and a probe error is not
+	// proof of death. Destroying on that would kill a live shell and whatever
+	// is running in it. So this only asks the daemon to re-check — its list
+	// prunes a shell it can confirm is gone and deliberately KEEPS one whose
+	// probe errored.
+	//
+	// Reported once per pane: the component is keyed by handle, so a later
+	// shell on the same tab mounts fresh. Only for shells — a session pane that
+	// ends still has a row, a status, and a restore path, so its tab must stay.
 	const reportedShellExitRef = useRef(false);
 	useEffect(() => {
 		if (state !== "exited") return;

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -19,9 +19,15 @@ type TerminalPaneProps = {
 	daemonReady: boolean;
 	terminalTarget?: TerminalTarget;
 	fontSize: number;
+	/**
+	 * Fired once when a shell pane's PTY exits on its own (the user typed
+	 * `exit`, or killed the process). Nothing else tells the client: the shell
+	 * list is only refetched around this client's own open/close.
+	 */
+	onShellExited?: (handleId: string) => void;
 };
 
-export function TerminalPane({ session, theme, daemonReady, terminalTarget, fontSize }: TerminalPaneProps) {
+export function TerminalPane({ session, theme, daemonReady, terminalTarget, fontSize, onShellExited }: TerminalPaneProps) {
 	const terminalKey =
 		terminalTarget?.kind === "reviewer" || terminalTarget?.kind === "shell"
 			? terminalTarget.handleId
@@ -85,6 +91,7 @@ export function TerminalPane({ session, theme, daemonReady, terminalTarget, font
 			theme={theme}
 			daemonReady={daemonReady}
 			fontSize={fontSize}
+			onShellExited={onShellExited}
 			terminalTarget={terminalTarget}
 		/>
 	);
@@ -220,7 +227,7 @@ function bannerText(state: TerminalSessionState, error?: string): string | undef
 	return undefined;
 }
 
-function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSize }: TerminalPaneProps) {
+function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSize, onShellExited }: TerminalPaneProps) {
 	const attachSession =
 		session && terminalTarget?.kind === "reviewer"
 			? { ...session, terminalHandleId: terminalTarget.handleId }
@@ -274,6 +281,20 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 		terminalTarget?.kind !== "shell" &&
 		session !== undefined &&
 		!isSessionActive;
+
+	// A shell whose PTY exits leaves a tab that can never be attached again, so
+	// retire it instead of parking a dead pane in the strip. Reported once per
+	// pane: the component is keyed by handle, so a later shell on the same tab
+	// mounts fresh. Only for shells — a session pane that ends still has a row,
+	// a status, and a restore path, so its tab must stay.
+	const reportedShellExitRef = useRef(false);
+	useEffect(() => {
+		if (state !== "exited") return;
+		if (terminalTarget?.kind !== "shell") return;
+		if (reportedShellExitRef.current) return;
+		reportedShellExitRef.current = true;
+		onShellExited?.(terminalTarget.handleId);
+	}, [state, terminalTarget, onShellExited]);
 
 	const handleReady = useCallback((handle: AttachableTerminal) => {
 		setTerminal(handle);

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -4,6 +4,7 @@
 // must not invalidate session state when they come and go.
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 import type { components } from "../../api/schema";
 import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { mockShellTerminals } from "../lib/mock-data";
@@ -77,6 +78,22 @@ export const shellTerminalsQueryOptions = {
 
 export function useShellTerminals() {
 	return useQuery(shellTerminalsQueryOptions);
+}
+
+/**
+ * Asks the daemon to re-check its shell list. Used when a pane reports that its
+ * PTY ended: that signal is not proof of death (the attach loop reports the
+ * same "exited" after it gives up on a failing liveness probe), so the client
+ * must not close anything itself. The daemon's list prunes only shells it can
+ * confirm are gone and keeps ones whose probe errored, which is exactly the
+ * conservative rule this needs.
+ */
+export function useRefreshShellTerminals() {
+	const queryClient = useQueryClient();
+	return useCallback(
+		() => void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey }),
+		[queryClient],
+	);
 }
 
 export type OpenShellTerminalInput = { projectId?: string; sessionId?: string };

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -81,19 +81,23 @@ export function useShellTerminals() {
 }
 
 /**
- * Asks the daemon to re-check its shell list. Used when a pane reports that its
- * PTY ended: that signal is not proof of death (the attach loop reports the
- * same "exited" after it gives up on a failing liveness probe), so the client
- * must not close anything itself. The daemon's list prunes only shells it can
- * confirm are gone and keeps ones whose probe errored, which is exactly the
- * conservative rule this needs.
+ * Asks the daemon to re-check its shell list and resolves to the refreshed
+ * list. Used when a pane reports that its PTY ended: that signal is not proof
+ * of death (the attach loop reports the same "exited" after it gives up on a
+ * failing liveness probe), so the client must not close anything itself. The
+ * daemon's list prunes only shells it can confirm are gone and keeps ones whose
+ * probe errored, which is exactly the conservative rule this needs.
+ *
+ * The returned list is what tells the caller which happened: a handle still in
+ * it means the shell is alive and the pane must re-attach rather than sit on a
+ * stale "exited".
  */
 export function useRefreshShellTerminals() {
 	const queryClient = useQueryClient();
-	return useCallback(
-		() => void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey }),
-		[queryClient],
-	);
+	return useCallback(async (): Promise<ShellTerminal[]> => {
+		await queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+		return queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? [];
+	}, [queryClient]);
 }
 
 export type OpenShellTerminalInput = { projectId?: string; sessionId?: string };

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -40,6 +40,20 @@ function toShellTerminal(t: components["schemas"]["ShellTerminalResponse"]): She
 let previewShellTerminals: ShellTerminal[] = [...mockShellTerminals];
 let previewShellSeq = 0;
 
+// Same rule the daemon uses: one past the highest number already on screen for
+// this session, so closing "Terminal 1" does not hand the next tab that name
+// while "Terminal 2" is still open.
+function previewSessionTerminalTitle(sessionId: string): string {
+	const highest = previewShellTerminals
+		.filter((shell) => shell.sessionId === sessionId)
+		.reduce((max, shell) => {
+			const match = /^Terminal (\d+)$/.exec(shell.title);
+			const n = match ? Number(match[1]) : 0;
+			return n > max ? n : max;
+		}, 0);
+	return `Terminal ${highest + 1}`;
+}
+
 async function fetchShellTerminals(): Promise<ShellTerminal[]> {
 	if (usePreviewData) {
 		return previewShellTerminals;
@@ -78,12 +92,18 @@ export function useOpenShellTerminal() {
 		mutationFn: async ({ projectId, sessionId }: OpenShellTerminalInput = {}): Promise<ShellTerminal> => {
 			if (usePreviewData) {
 				previewShellSeq += 1;
+				// Mirror the daemon: a session's shells start in that session's
+				// worktree and are numbered within it, standalone shells start in
+				// the project root and are named after it. The mock used to stamp
+				// the project name on every tab, which is not what the app does.
 				const shell: ShellTerminal = {
 					handleId: `shellterm-preview-${previewShellSeq}`,
 					projectId,
 					sessionId,
-					workingDir: `/Users/demo/Projects/${projectId ?? "ao"}`,
-					title: projectId ?? "shell",
+					workingDir: sessionId
+						? `/Users/demo/.ao/data/worktrees/${projectId ?? "ao"}/${sessionId}`
+						: `/Users/demo/Projects/${projectId ?? "ao"}`,
+					title: sessionId ? previewSessionTerminalTitle(sessionId) : (projectId ?? "shell"),
 					createdAt: new Date().toISOString(),
 				};
 				previewShellTerminals = [...previewShellTerminals, shell];


### PR DESCRIPTION
Stacked on https://github.com/Untrivial-ai/agent-orchestrator/pull/3298 and targets its branch, so the diff here is only the tab naming and exit handling.

## Problem

**Naming.** Every shell in a session starts in that session's worktree, so `filepath.Base(workingDir)` put the identical label on every tab: three terminals in one session all read `ao-22`. The function's own comment claimed the directory "is the only thing that distinguishes one shell pane from another in the UI", which is exactly what it failed to do.

**Exit.** A shell whose PTY ended left a tab that could never be attached again, showing "TERMINAL ENDED" until something else happened to refetch. The daemon already prunes dead shells on list, but nothing told the client — `useShellTerminals.ts` says so outright: "shell terminals only change when this client opens or closes one". They also change when the shell exits on its own.

**Preview mock.** It stamped the project name on every tab, which the daemon never produces. That is why the naming bug looked different from what it actually was, and it makes the browser dev build misleading for anyone demoing from it.

## Change

- A session's tabs are numbered: `Terminal 1`, `Terminal 2`. The session is already the first tab in the strip, so repeating its worktree name on every terminal added nothing.
- Standalone shells (board, `/terminals`) keep the directory name. Those can span projects, so the directory is what tells them apart there.
- The number is **one past the highest still in use**, not a count, so closing `Terminal 1` while `Terminal 2` is open does not hand the next tab a name already on screen. A tab the user renamed no longer parses and stops reserving its number.
- A shell whose PTY exits retires its tab through the existing close path. Shells only: a session pane that ends still has a row, a status, and a restore path, so its tab stays.
- The preview mock now mirrors the daemon on both counts.

## Verification

Driven against a real daemon (isolated `HOME`, scratch data dir, own port) with a real session spawned via `--harness fake`:

```
### session terminals are numbered
  open -> Terminal 1
  open -> Terminal 2
  open -> Terminal 3
  strip: ['Terminal 1', 'Terminal 2', 'Terminal 3']

### close Terminal 1, open again -> must not reissue a live name
  after close: ['Terminal 2', 'Terminal 3']
  next open -> Terminal 4

### standalone open in the same daemon still uses the directory
  -> data
  strip: ['Terminal 2', 'Terminal 3', 'Terminal 4', 'data']
```

Also driven against a real daemon: a shell whose tmux session is killed out from under it disappears from `GET /shell-terminals` (`['data']` then `[]`), which is the daemon half of the exit path.

Renderer driven in a browser: two clicks on `+` give `Terminal 1` and `Terminal 2`, no tab is named after the project, right click produces no picker, and the session tab has no close button. Closing `Terminal 1` and reopening gives `Terminal 3`.

## Not verified by running

The renderer's retire-on-exit needs a live PTY, which only exists in the Electron app. The daemon-side prune and the renderer's reporting logic are each covered, but the two have not been exercised together end to end. Worth a manual check by whoever reviews this.

## Known limitation

Only the attached pane notices an exit. If a background tab's shell exits while you are on another tab, that tab lingers until you select it or open/close something. Fixing it properly wants a daemon push when a PTY dies rather than polling the list.
