### PR TITLE
fix(dev): give a dev run its own Electron profile under ~/.ao

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -97,7 +97,14 @@ if (process.platform === "win32") {
 // inside ~/.ao alongside the daemon's data dir and running.json. sessionData and
 // crashDumps derive from userData, so this one override reparents them all.
 // Must run before app ready.
-app.setPath("userData", path.join(os.homedir(), ".ao", "electron"));
+// Dev runs get their own profile under the same ~/.ao root: the packaged app
+// keeps this directory open, and two Chromium instances sharing one profile
+// corrupt its LevelDB stores. Mirrors how dev already isolates running.json and
+// the daemon data dir into ~/.ao/dev.
+app.setPath(
+	"userData",
+	app.isPackaged ? path.join(os.homedir(), ".ao", "electron") : path.join(os.homedir(), ".ao", "dev", "electron"),
+);
 
 let mainWindow: BrowserWindow | null = null;
 let daemonProcess: ChildProcess | null = null;


### PR DESCRIPTION
## Problem

`src/main.ts` pins Electron's `userData` to `~/.ao/electron` unconditionally, so `npm run dev` shares the packaged app's Chromium profile with it. Two Electron instances on one profile contend for its LevelDB stores (cookies, local and session storage), which is a real risk any time someone runs the dev app while the installed one is open — the normal case when developing AO with AO.

Dev mode already isolates the other two pieces of state, `running.json` and the daemon data dir, into `~/.ao/dev`. The profile was the one that did not follow.

## Change

A dev run gets `~/.ao/dev/electron`; the packaged app keeps `~/.ao/electron` exactly as before. Everything still resolves under `~/.ao`, so the hard rule in AGENTS.md and CLAUDE.md is unaffected.

## Related, not fixed here

There is a second isolation gap next door at `main.ts:494`:

```js
if (!process.env.AO_DATA_DIR) devExtras.AO_DATA_DIR = path.join(os.homedir(), ".ao", DEV_STATE_SUBDIR, "data");
```

"User-set env vars take priority" means a dev run inherits `AO_DATA_DIR` when one is already set. Every AO worker session exports it, so `npm run dev` launched from inside a worker points its daemon at the **production** database, and two daemons end up supervising the same tmux runtimes. I hit this directly: the symptom is terminals flapping on "Terminal disconnected — reattaching…" across the whole app.

Left out of this PR because the fix is a judgement call, not a one-liner. Options are to ignore an inherited `AO_DATA_DIR` in dev, to require an explicit opt-in flag to share production state, or to refuse to start when dev would land on the packaged app's data dir. Happy to take it in a follow-up once someone picks.
