### PR TITLE
fix(landing): use canonical X profile URL

### DIFF
--- a/frontend/src/landing/packages/shared/src/constants.ts
+++ b/frontend/src/landing/packages/shared/src/constants.ts
@@ -8,7 +8,7 @@ export const COMPANY = {
   STATUS_URL: "https://status.aoagents.dev",
   TRUST_URL: "https://aoagents.dev/privacy/",
   MAIL_TO: "mailto:hello@aoagents.dev",
-  X_URL: "https://twitter.com/aoagents",
+  X_URL: "https://x.com/aoagents",
   LINKEDIN_URL: "https://linkedin.com/company/aoagents",
   YOUTUBE_URL: "https://youtube.com/@aoagents",
   DISCORD_URL: "https://discord.com/invite/UZv7JjxbwG",


### PR DESCRIPTION
## Summary

- replace the redirecting twitter.com organization profile URL with the direct x.com URL
- keep all footer, social-link, Markdown, and JSON-LD consumers on the shared constant

## Why

The Organization JSON-LD sameAs entry should reference the direct identity URL instead of relying on a permanent redirect.

## Validation

- npm.cmd --prefix frontend/src/landing run build

Closes #3332