### PR TITLE
fix(landing): use official LinkedIn profile URL

### DIFF
--- a/frontend/src/landing/packages/shared/src/constants.ts
+++ b/frontend/src/landing/packages/shared/src/constants.ts
@@ -9,7 +9,7 @@ export const COMPANY = {
   TRUST_URL: "https://aoagents.dev/privacy/",
   MAIL_TO: "mailto:hello@aoagents.dev",
   X_URL: "https://x.com/aoagents",
-  LINKEDIN_URL: "https://linkedin.com/company/aoagents",
+  LINKEDIN_URL: "https://www.linkedin.com/company/agent-orchestrator",
   YOUTUBE_URL: "https://youtube.com/@aoagents",
   DISCORD_URL: "https://discord.com/invite/UZv7JjxbwG",
   EMAIL_DOMAIN: "@aoagents.dev",


### PR DESCRIPTION
## Summary

- replace the stale LinkedIn company URL with the live official Agent Orchestrator profile
- preserve the shared constant used by social links and Organization JSON-LD

## Why

The previous aoagents slug does not identify the live company page, weakening sameAs entity reconciliation and sending users to a stale location.

## Validation

- npm.cmd --prefix frontend/src/landing run build

Closes #3333