### PR TITLE
fix(landing): correct hero subheadline spelling

### DIFF
--- a/frontend/src/landing/packages/shared/src/constants.ts
+++ b/frontend/src/landing/packages/shared/src/constants.ts
@@ -47,7 +47,7 @@ export const DOWNLOAD_URL_LINUX = "https://github.com/AgentWrapper/agent-orchest
 
 export const AGENT_HARNESSES = 23;
 export const TAGLINE = "Stop babysitting agents. Start merging real work.";
-export const HERO_SUBHEADLINE = "Run a fleet of coding agents while keeping branches, reviews, and CI failures managable.";
+export const HERO_SUBHEADLINE = "Run a fleet of coding agents while keeping branches, reviews, and CI failures manageable.";
 export const HERO_SECONDARY_SUBHEADLINE = "Isolated workspaces for Claude Code, Codex, and any CLI agent. Review every change from one dashboard. Free and open source.";
 
 export const NAV_ITEMS = [


### PR DESCRIPTION
## Summary

- correct managable to manageable in the shared landing hero subheadline
- leave all other landing copy unchanged

## Why

The misspelling is rendered directly in the public homepage hero.

## Validation

- npm.cmd --prefix frontend/src/landing run build

Closes #3339