### PR TITLE
fix(landing): remove stale API llms robots rule

### DIFF
--- a/frontend/src/landing/src/app/robots.txt/route.ts
+++ b/frontend/src/landing/src/app/robots.txt/route.ts
@@ -9,7 +9,6 @@ export function GET() {
 	const content = `# Default: open to all crawlers
 User-Agent: *
 Allow: /
-Allow: /api/llms.txt
 Disallow: /api/
 Disallow: /_next/
 


### PR DESCRIPTION
## Summary

- remove the obsolete Allow rule for /api/llms.txt from the generated robots.txt
- preserve root-site crawler access and the broader /api/ disallow policy

## Why

The /api/llms.txt route was intentionally removed and now returns 404, so advertising an exception for it is stale and misleading.

## Validation

- npm.cmd --prefix frontend/src/landing run build
- source assertions confirm Allow: / and Disallow: /api/ remain while the stale rule is absent

Closes #3341