### PR TITLE
fix(landing): refresh llms platform and CI guidance

### DIFF
--- a/frontend/src/landing/src/app/llms-full.txt/route.ts
+++ b/frontend/src/landing/src/app/llms-full.txt/route.ts
@@ -1,7 +1,12 @@
 import { COMPANY } from "@ao/shared/constants";
 import { getBlogPosts } from "@/lib/blog";
 import { getComparisonPages } from "@/lib/compare";
-import { stripMdxSyntax } from "@/lib/llms";
+import {
+	buildDeveloperResourcesSection,
+	buildLlmsHeader,
+	buildWhenToUseSection,
+	stripMdxSyntax,
+} from "@/lib/llms";
 import { FAQ_ITEMS } from "../components/FAQSection/constants";
 
 
@@ -11,24 +16,17 @@ export async function GET() {
 	const posts = getBlogPosts();
 	const comparisons = getComparisonPages();
 	const baseUrl = COMPANY.MARKETING_URL;
-	const docsUrl = COMPANY.DOCS_URL;
 
 	const sections: string[] = [];
 
-	// Header section (same as llms.txt)
+	// Header and guidance sections (same as llms.txt)
 	sections.push(
 		[
-			`# ${COMPANY.NAME}`,
+			...buildLlmsHeader(),
 			"",
-			"> Run 10+ parallel coding agents on your machine",
+			...buildWhenToUseSection(),
 			"",
-			`${COMPANY.NAME} is an open-source desktop application that lets developers run multiple AI coding agents in parallel, each in its own isolated Git worktree. It works with any CLI-based agent including Claude Code, OpenCode, and OpenAI Codex. Agents can work on different branches or features simultaneously without conflicts. ${COMPANY.NAME} is free, does not proxy API calls, and supports macOS with Windows and Linux coming soon.`,
-			"",
-			"## Docs",
-			"",
-			`- [Documentation](${docsUrl}/)`,
-			`- [Quickstart](${docsUrl}/quickstart/)`,
-			`- [GitHub](${COMPANY.GITHUB_URL})`,
+			...buildDeveloperResourcesSection(),
 		].join("\n"),
 	);
 

--- a/frontend/src/landing/src/lib/llms.ts
+++ b/frontend/src/landing/src/lib/llms.ts
@@ -24,7 +24,7 @@ export function buildLlmsHeader(): string[] {
 		"",
 		"> Run 10+ parallel coding agents on your machine",
 		"",
-		`${COMPANY.NAME} is an open-source desktop application that lets developers run multiple AI coding agents in parallel, each in its own isolated Git worktree. It works with any CLI-based agent including Claude Code, OpenCode, and OpenAI Codex. Agents can work on different branches or features simultaneously without conflicts. ${COMPANY.NAME} is free, does not proxy API calls, and supports macOS with Windows and Linux coming soon.`,
+		`${COMPANY.NAME} is an open-source desktop application that lets developers run multiple AI coding agents in parallel, each in its own isolated Git worktree. It works with any CLI-based agent including Claude Code, OpenCode, and OpenAI Codex. Agents can work on different branches or features simultaneously without conflicts. ${COMPANY.NAME} is free, does not proxy API calls, and supports macOS, Windows, and Linux.`,
 	];
 }
 
@@ -45,6 +45,7 @@ export function buildWhenToUseSection(
 		"- Run several coding agents (Claude Code, Codex, OpenCode, or any CLI agent) at the same time on one repository without them stepping on each other, each agent gets an isolated Git worktree and its own branch.",
 		"- Orchestrate agent work through the desktop app and local `ao` CLI: create workspaces, launch agents with a prompt, open terminals, and track tasks.",
 		"- Schedule recurring agent runs (automations) that execute a prompt on a cron-like schedule in a fresh or existing workspace.",
+		"- Automatically route CI failures and review feedback to the agent session that owns the branch, so the right agent can handle failures without manual babysitting.",
 		"- Review diffs, manage ports, and monitor many concurrent agent sessions from one dashboard.",
 		"",
 		`Agent Orchestrator is not a coding agent itself; it is the local workspace and orchestration layer the agents run in. If you are an AI agent inside an AO-managed session, use the installed \`ao\` CLI. ${documentationDirection}`,


### PR DESCRIPTION
## Summary

- update machine-readable product copy to state support for macOS, Windows, and Linux
- describe automatic routing of CI failures and review feedback to the agent session that owns the branch
- remove the redundant Docs section already covered by Developer resources
- reuse the shared header and guidance builders in llms-full.txt to prevent content drift

## Why

The existing llms content understated current platform support, omitted a core feedback-loop capability, and duplicated resource links. llms-full.txt also maintained a separate stale header.

## Validation

- npm.cmd --prefix frontend/src/landing run build
- source assertions cover platform support, CI routing, duplicate Docs removal, and shared llms-full builders

Closes #3343