### PR TITLE
feat(cli): add ao session prs for concise PR summaries

### DIFF
--- a/backend/internal/cli/session.go
+++ b/backend/internal/cli/session.go
@@ -116,6 +116,36 @@ type claimPRResponse struct {
 	TakenOverFrom []string       `json:"takenOverFrom"`
 }
 
+// sessionPRSummaryDTO is the concise GET /sessions/{id}/pr summary shape used
+// by desktop V1. It intentionally omits CI log tails and review comment bodies.
+type sessionPRSummaryDTO struct {
+	URL          string    `json:"url"`
+	HTMLURL      string    `json:"htmlUrl,omitempty"`
+	Number       int       `json:"number"`
+	Title        string    `json:"title"`
+	State        string    `json:"state"`
+	Repo         string    `json:"repo,omitempty"`
+	SourceBranch string    `json:"sourceBranch,omitempty"`
+	TargetBranch string    `json:"targetBranch,omitempty"`
+	CI           struct {
+		State string `json:"state"`
+	} `json:"ci"`
+	Review struct {
+		Decision                   string `json:"decision"`
+		HasUnresolvedHumanComments bool   `json:"hasUnresolvedHumanComments"`
+	} `json:"review"`
+	Mergeability struct {
+		State   string   `json:"state"`
+		Reasons []string `json:"reasons"`
+	} `json:"mergeability"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type listSessionPRsResponse struct {
+	SessionID string                `json:"sessionId"`
+	PRs       []sessionPRSummaryDTO `json:"prs"`
+}
+
 type sessionListEntry struct {
 	ID             string     `json:"id"`
 	ProjectID      string     `json:"projectId"`
@@ -148,6 +178,7 @@ func newSessionCommand(ctx *commandContext) *cobra.Command {
 	cmd.AddCommand(newSessionRenameCommand(ctx))
 	cmd.AddCommand(newSessionCleanupCommand(ctx))
 	cmd.AddCommand(newSessionClaimPRCommand(ctx))
+	cmd.AddCommand(newSessionPRsCommand(ctx))
 	return cmd
 }
 
@@ -288,6 +319,27 @@ func newSessionClaimPRCommand(ctx *commandContext) *cobra.Command {
 	return cmd
 }
 
+func newSessionPRsCommand(ctx *commandContext) *cobra.Command {
+	var opts sessionOptions
+	cmd := &cobra.Command{
+		Use:   "prs <id>",
+		Short: "List concise PR summaries for a session",
+		Long:  "List the concise desktop V1 PR summaries for a session (identity, CI state, review decision, mergeability). Does not include raw CI logs or review comment bodies.",
+		Args:  oneSessionIDArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := normalizeSessionID(args[0])
+			if err != nil {
+				return err
+			}
+			return ctx.listSessionPRs(cmd.Context(), cmd, id, opts)
+		},
+	}
+	f := cmd.Flags()
+	addSessionProjectFlag(f, &opts.project, "Project id to scope the lookup")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
+	return cmd
+}
+
 func addSessionProjectFlag(flags interface {
 	StringVarP(*string, string, string, string, string)
 }, target *string, usage string) {
@@ -372,6 +424,58 @@ func writeClaimPRResult(cmd *cobra.Command, res claimPRResponse) error {
 	for _, owner := range res.TakenOverFrom {
 		if _, err := fmt.Fprintf(out, "  taking over from %s\n", owner); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func (c *commandContext) listSessionPRs(ctx context.Context, cmd *cobra.Command, id string, opts sessionOptions) error {
+	if opts.project != "" {
+		if _, err := c.fetchScopedSession(ctx, id, opts.project); err != nil {
+			return err
+		}
+	}
+	var res listSessionPRsResponse
+	if err := c.getJSON(ctx, "sessions/"+url.PathEscape(id)+"/pr", &res); err != nil {
+		return err
+	}
+	if opts.json {
+		return writeJSON(cmd.OutOrStdout(), res)
+	}
+	return writeSessionPRList(cmd, res)
+}
+
+func writeSessionPRList(cmd *cobra.Command, res listSessionPRsResponse) error {
+	out := cmd.OutOrStdout()
+	if len(res.PRs) == 0 {
+		_, err := fmt.Fprintf(out, "session %s has no claimed PRs\n", res.SessionID)
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "session %s (%d PR%s):\n", res.SessionID, len(res.PRs), pluralS(len(res.PRs))); err != nil {
+		return err
+	}
+	for _, pr := range res.PRs {
+		title := pr.Title
+		if title == "" {
+			title = "(no title)"
+		}
+		review := pr.Review.Decision
+		if pr.Review.HasUnresolvedHumanComments {
+			review += "+comments"
+		}
+		line := fmt.Sprintf("  #%d  %s  ci=%s  review=%s  merge=%s  %s",
+			pr.Number, pr.State, pr.CI.State, review, pr.Mergeability.State, title)
+		if _, err := fmt.Fprintln(out, line); err != nil {
+			return err
+		}
+		url := pr.HTMLURL
+		if url == "" {
+			url = pr.URL
+		}
+		if url != "" {
+			if _, err := fmt.Fprintf(out, "    %s\n", url); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/backend/internal/cli/session_test.go
+++ b/backend/internal/cli/session_test.go
@@ -82,6 +82,8 @@ func sessionCommandServer(t *testing.T) (*httptest.Server, *sessionRequestLog) {
 				return
 			}
 			_, _ = io.WriteString(w, `{"ok":true,"sessionId":"demo-1","prs":[{"url":`+jsonQuote(req.PR)+`,"number":142,"state":"open","ci":"passing","review":"review_required","mergeability":"mergeable","reviewComments":false,"updatedAt":"2026-06-04T12:00:00Z"}],"branchChanged":true,"takenOverFrom":["demo-0"]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions/demo-1/pr":
+			_, _ = io.WriteString(w, `{"sessionId":"demo-1","prs":[{"url":"https://github.com/aoagents/agent-orchestrator/pull/142","htmlUrl":"https://github.com/aoagents/agent-orchestrator/pull/142","number":142,"title":"Fix the bug","state":"open","repo":"aoagents/agent-orchestrator","sourceBranch":"fix/bug","targetBranch":"main","ci":{"state":"passing","failingChecks":[]},"review":{"decision":"review_required","hasUnresolvedHumanComments":false,"unresolvedBy":[]},"mergeability":{"state":"mergeable","reasons":[],"prUrl":"https://github.com/aoagents/agent-orchestrator/pull/142"},"updatedAt":"2026-06-04T12:00:00Z"}]}`)
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/cleanup":
 			_, _ = io.WriteString(w, `{"ok":true,"cleaned":["demo-old","demo-orch"],"skipped":[]}`)
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/demo-1/kill":
@@ -498,6 +500,52 @@ func TestSessionRename_ProjectMismatchDoesNotPatch(t *testing.T) {
 	want := []string{"GET /api/v1/sessions/demo-1"}
 	if got := log.all(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("requests = %#v, want %#v", got, want)
+	}
+}
+
+func TestSessionPRs_SuccessWithProjectScope(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, log := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "prs", "demo-1", "-p", "demo")
+	if err != nil {
+		t.Fatalf("session prs failed: %v\nstderr=%s", err, errOut)
+	}
+	for _, want := range []string{
+		"session demo-1 (1 PR):",
+		"#142  open  ci=passing  review=review_required  merge=mergeable  Fix the bug",
+		"https://github.com/aoagents/agent-orchestrator/pull/142",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("prs output missing %q:\n%s", want, out)
+		}
+	}
+	want := []string{"GET /api/v1/sessions/demo-1", "GET /api/v1/sessions/demo-1/pr"}
+	if got := log.all(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("requests = %#v, want %#v", got, want)
+	}
+}
+
+func TestSessionPRs_JSONOutputDecodes(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "prs", "demo-1", "--json")
+	if err != nil {
+		t.Fatalf("session prs --json failed: %v\nstderr=%s", err, errOut)
+	}
+	var got listSessionPRsResponse
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("prs --json decode failed: %v\n%s", err, out)
+	}
+	if got.SessionID != "demo-1" || len(got.PRs) != 1 || got.PRs[0].Number != 142 {
+		t.Fatalf("unexpected prs JSON: %#v", got)
 	}
 }
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -53,6 +53,7 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 | `ao session rename <id> <name>`     | `PATCH /api/v1/sessions/{id}`                  |
 | `ao session cleanup`                | `POST /api/v1/sessions/cleanup`                |
 | `ao session claim-pr <id> <pr-ref>` | `POST /api/v1/sessions/{id}/pr/claim`          |
+| `ao session prs <id>`               | `GET /api/v1/sessions/{id}/pr`                 |
 | `ao orchestrator ls`                | `GET /api/v1/orchestrators`                    |
 | `ao send`                           | `POST /api/v1/sessions/{id}/send`              |
 | `ao preview [url]`                  | `POST /api/v1/sessions/{id}/preview`           |


### PR DESCRIPTION
## Summary
- Add `ao session prs <id>` wrapping `GET /sessions/{id}/pr`
- Surfaces desktop V1 concise PR summaries (CI/review/mergeability) in CLI
- Does not expand into raw pr_* CDC facts

## Test plan
- [x] `go test ./internal/cli/ -run TestSessionPRs`
- [x] Manually list PRs for a session that has claimed a PR