### PR TITLE
feat(cli): add ao session resume

### DIFF
--- a/backend/internal/cli/session.go
+++ b/backend/internal/cli/session.go
@@ -77,6 +77,13 @@ type restoreSessionResponse struct {
 	Session   sessionDTO `json:"session"`
 }
 
+type resumeAgentResponse struct {
+	OK         bool       `json:"ok"`
+	SessionID  string     `json:"sessionId"`
+	ResumeMode string     `json:"resumeMode,omitempty"`
+	Session    sessionDTO `json:"session"`
+}
+
 type renameSessionResponse struct {
 	SessionID   string `json:"sessionId"`
 	DisplayName string `json:"displayName"`
@@ -145,6 +152,7 @@ func newSessionCommand(ctx *commandContext) *cobra.Command {
 	cmd.AddCommand(newSessionGetCommand(ctx))
 	cmd.AddCommand(newSessionKillCommand(ctx))
 	cmd.AddCommand(newSessionRestoreCommand(ctx))
+	cmd.AddCommand(newSessionResumeCommand(ctx))
 	cmd.AddCommand(newSessionRenameCommand(ctx))
 	cmd.AddCommand(newSessionCleanupCommand(ctx))
 	cmd.AddCommand(newSessionClaimPRCommand(ctx))
@@ -222,6 +230,27 @@ func newSessionRestoreCommand(ctx *commandContext) *cobra.Command {
 		},
 	}
 	addSessionProjectFlag(cmd.Flags(), &opts.project, "Project id to scope the lookup")
+	return cmd
+}
+
+func newSessionResumeCommand(ctx *commandContext) *cobra.Command {
+	var opts sessionOptions
+	cmd := &cobra.Command{
+		Use:   "resume <id>",
+		Short: "Resume the agent in an existing session",
+		Long:  "Resume the coding agent for a live session (native resume, saved prompt, or fresh start depending on harness support).",
+		Args:  oneSessionIDArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := normalizeSessionID(args[0])
+			if err != nil {
+				return err
+			}
+			return ctx.resumeSessionAgent(cmd.Context(), cmd, id, opts)
+		},
+	}
+	f := cmd.Flags()
+	addSessionProjectFlag(f, &opts.project, "Project id to scope the lookup")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
 	return cmd
 }
 
@@ -466,6 +495,45 @@ func (c *commandContext) restoreSession(ctx context.Context, cmd *cobra.Command,
 	}
 	if res.Session.ProjectID != "" {
 		if _, err := fmt.Fprintf(out, "  project: %s\n", res.Session.ProjectID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *commandContext) resumeSessionAgent(ctx context.Context, cmd *cobra.Command, id string, opts sessionOptions) error {
+	if opts.project != "" {
+		if _, err := c.fetchScopedSession(ctx, id, opts.project); err != nil {
+			return err
+		}
+	}
+	var res resumeAgentResponse
+	if err := c.postJSON(ctx, "sessions/"+url.PathEscape(id)+"/resume-agent", struct{}{}, &res); err != nil {
+		return err
+	}
+	if opts.json {
+		return writeJSON(cmd.OutOrStdout(), res)
+	}
+	out := cmd.OutOrStdout()
+	sessionID := res.SessionID
+	if sessionID == "" {
+		sessionID = id
+	}
+	if _, err := fmt.Fprintf(out, "session %s agent resumed\n", sessionID); err != nil {
+		return err
+	}
+	if res.ResumeMode != "" {
+		if _, err := fmt.Fprintf(out, "  mode: %s\n", res.ResumeMode); err != nil {
+			return err
+		}
+	}
+	if res.Session.ProjectID != "" {
+		if _, err := fmt.Fprintf(out, "  project: %s\n", res.Session.ProjectID); err != nil {
+			return err
+		}
+	}
+	if res.Session.Status != "" {
+		if _, err := fmt.Fprintf(out, "  status: %s\n", res.Session.Status); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/cli/session_test.go
+++ b/backend/internal/cli/session_test.go
@@ -88,6 +88,8 @@ func sessionCommandServer(t *testing.T) (*httptest.Server, *sessionRequestLog) {
 			_, _ = io.WriteString(w, `{"ok":true,"sessionId":"demo-1","freed":true}`)
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/demo-1/restore":
 			_, _ = io.WriteString(w, `{"ok":true,"sessionId":"demo-1","session":`+sessionJSON("demo-1", "demo", "worker", "idle", false)+`}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/demo-1/resume-agent":
+			_, _ = io.WriteString(w, `{"ok":true,"sessionId":"demo-1","resumeMode":"native","session":`+sessionJSON("demo-1", "demo", "worker", "working", false)+`}`)
 		case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/sessions/demo-1":
 			var req sessionRenameRequest
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -283,6 +285,48 @@ func TestSessionRestore_SuccessWithProjectScope(t *testing.T) {
 	want := []string{"GET /api/v1/sessions/demo-1", "POST /api/v1/sessions/demo-1/restore"}
 	if got := log.all(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("requests = %#v, want %#v", got, want)
+	}
+}
+
+func TestSessionResume_SuccessWithProjectScope(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, log := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "resume", "demo-1", "-p", "demo")
+	if err != nil {
+		t.Fatalf("session resume failed: %v\nstderr=%s", err, errOut)
+	}
+	for _, want := range []string{"session demo-1 agent resumed", "mode: native", "project: demo", "status: working"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("resume output missing %q:\n%s", want, out)
+		}
+	}
+	want := []string{"GET /api/v1/sessions/demo-1", "POST /api/v1/sessions/demo-1/resume-agent"}
+	if got := log.all(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("requests = %#v, want %#v", got, want)
+	}
+}
+
+func TestSessionResume_JSONOutputDecodes(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "resume", "demo-1", "--json")
+	if err != nil {
+		t.Fatalf("session resume --json failed: %v\nstderr=%s", err, errOut)
+	}
+	var got resumeAgentResponse
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("session resume --json output is not decodable: %v\noutput=%s", err, out)
+	}
+	if !got.OK || got.SessionID != "demo-1" || got.ResumeMode != "native" {
+		t.Fatalf("unexpected resume JSON: %#v", got)
 	}
 }
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -50,6 +50,7 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 | `ao session get <id>`               | `GET /api/v1/sessions/{id}`                    |
 | `ao session kill <id>`              | `POST /api/v1/sessions/{id}/kill`              |
 | `ao session restore <id>`           | `POST /api/v1/sessions/{id}/restore`           |
+| `ao session resume <id>`            | `POST /api/v1/sessions/{id}/resume-agent`      |
 | `ao session rename <id> <name>`     | `PATCH /api/v1/sessions/{id}`                  |
 | `ao session cleanup`                | `POST /api/v1/sessions/cleanup`                |
 | `ao session claim-pr <id> <pr-ref>` | `POST /api/v1/sessions/{id}/pr/claim`          |


### PR DESCRIPTION
## Summary
- Add `ao session resume <id>` wrapping existing `POST /sessions/{id}/resume-agent`
- Desktop already uses this route; CLI could not resume without raw HTTP
- Includes `--json` and `--project` scope plus docs/table update

## Test plan
- [x] `go test ./internal/cli/ -run TestSessionResume`
- [x] Manually: `ao session resume <live-session-id>` against a running daemon