### PR TITLE
feat(cli): add ao agent probe

### DIFF
--- a/backend/internal/cli/agent.go
+++ b/backend/internal/cli/agent.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -11,6 +14,10 @@ import (
 type agentListOptions struct {
 	refresh bool
 	json    bool
+}
+
+type agentProbeOptions struct {
+	json bool
 }
 
 // agentInfo mirrors the daemon's agent Info body for the CLI client.
@@ -33,6 +40,7 @@ func newAgentCommand(ctx *commandContext) *cobra.Command {
 		Short: "Inspect agent catalog readiness",
 	}
 	cmd.AddCommand(newAgentListCommand(ctx))
+	cmd.AddCommand(newAgentProbeCommand(ctx))
 	return cmd
 }
 
@@ -57,6 +65,77 @@ func newAgentListCommand(ctx *commandContext) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.refresh, "refresh", false, "Refresh local install/auth probes before listing")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output raw agent catalog JSON")
 	return cmd
+}
+
+func newAgentProbeCommand(ctx *commandContext) *cobra.Command {
+	var opts agentProbeOptions
+	cmd := &cobra.Command{
+		Use:   "probe <agent>",
+		Short: "Run a fresh readiness probe for one agent",
+		Long:  "Probe one supported agent for local install and auth readiness. Results are advisory; spawn remains the authoritative validation point.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return usageError{err}
+			}
+			if strings.TrimSpace(args[0]) == "" {
+				return usageError{errors.New("agent id is required")}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.probeAgent(cmd.Context(), cmd, strings.TrimSpace(args[0]), opts)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output raw probe JSON")
+	return cmd
+}
+
+func (c *commandContext) probeAgent(ctx context.Context, cmd *cobra.Command, agentID string, opts agentProbeOptions) error {
+	result, err := c.probeSpawnAgent(ctx, agentID)
+	if err != nil {
+		return err
+	}
+	if opts.json {
+		return writeJSON(cmd.OutOrStdout(), result)
+	}
+	return writeAgentProbe(cmd, result)
+}
+
+func writeAgentProbe(cmd *cobra.Command, result agentProbeResult) error {
+	out := cmd.OutOrStdout()
+	id := result.Agent.ID
+	if id == "" {
+		id = "(unknown)"
+	}
+	label := result.Agent.Label
+	if label == "" {
+		label = id
+	}
+	install := "not installed"
+	if result.Installed {
+		install = "installed"
+	}
+	supported := "unsupported"
+	if result.Supported {
+		supported = "supported"
+	}
+	auth := result.Agent.AuthStatus
+	if auth == "" {
+		auth = "unknown"
+	}
+	lines := []string{
+		fmt.Sprintf("agent: %s", id),
+		fmt.Sprintf("label: %s", label),
+		fmt.Sprintf("supported: %s", supported),
+		fmt.Sprintf("install: %s", install),
+		fmt.Sprintf("auth: %s", auth),
+	}
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(out, line); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func writeAgentList(cmd *cobra.Command, inv agentInventory) error {

--- a/backend/internal/cli/agent_test.go
+++ b/backend/internal/cli/agent_test.go
@@ -93,3 +93,70 @@ func TestAgentListJSONEmitsRawCatalog(t *testing.T) {
 		t.Fatalf("inventory = %#v", inv)
 	}
 }
+
+func TestAgentProbe_Success(t *testing.T) {
+	cfg := setConfigEnv(t)
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appendPrimaryRequest(&requests, r)
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/codex/probe" {
+			_, _ = io.WriteString(w, `{"agent":{"id":"codex","label":"Codex","authStatus":"authorized"},"supported":true,"installed":true}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "agent", "probe", "codex")
+	if err != nil {
+		t.Fatalf("agent probe failed: %v stderr=%s", err, errOut)
+	}
+	for _, want := range []string{"agent: codex", "label: Codex", "supported: supported", "install: installed", "auth: authorized"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("probe output missing %q:\n%s", want, out)
+		}
+	}
+	want := []string{"POST /api/v1/agents/codex/probe"}
+	if !reflect.DeepEqual(requests, want) {
+		t.Fatalf("requests=%#v want %#v", requests, want)
+	}
+}
+
+func TestAgentProbe_JSON(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/codex/probe" {
+			_, _ = io.WriteString(w, `{"agent":{"id":"codex","label":"Codex","authStatus":"unauthorized"},"supported":true,"installed":true}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "agent", "probe", "codex", "--json")
+	if err != nil {
+		t.Fatalf("agent probe --json failed: %v stderr=%s", err, errOut)
+	}
+	var got agentProbeResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("probe json decode failed: %v\n%s", err, out)
+	}
+	if !got.Supported || !got.Installed || got.Agent.ID != "codex" || got.Agent.AuthStatus != "unauthorized" {
+		t.Fatalf("unexpected probe JSON: %#v", got)
+	}
+}
+
+func TestAgentProbe_MissingAgentIsUsageError(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, Deps{}, "agent", "probe")
+	if err == nil {
+		t.Fatal("expected missing agent id to fail")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (err=%v)", got, err)
+	}
+}

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -45,6 +45,7 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 | `ao project rm <id>`                | `DELETE /api/v1/projects/{id}`                 |
 | `ao agent ls`                       | `GET /api/v1/agents`                           |
 | `ao agent ls --refresh`             | `POST /api/v1/agents/refresh`                  |
+| `ao agent probe <agent>`            | `POST /api/v1/agents/{agent}/probe`            |
 | `ao spawn`                          | `POST /api/v1/sessions`                        |
 | `ao session ls`                     | `GET /api/v1/sessions`                         |
 | `ao session get <id>`               | `GET /api/v1/sessions/{id}`                    |
@@ -62,7 +63,8 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 
 `ao agent ls` prints the daemon-supported agent catalog with local install/auth
 readiness. Use `--refresh` to rerun the bounded local probes and `--json` to
-print the raw inventory response.
+print the raw inventory response. `ao agent probe <agent>` runs a fresh probe
+for one agent (also advisory; spawn remains authoritative).
 
 `ao spawn` resolves project context in this order: explicit `--project`,
 `AO_PROJECT_ID`, `AO_SESSION_ID` (by fetching the current session from the


### PR DESCRIPTION
## Summary
- Add `ao agent probe <agent>` wrapping `POST /agents/{agent}/probe`
- Lets operators doctor one agent's install/auth readiness without spawning
- Reuses the same probe client spawn already uses privately

## Test plan
- [x] `go test ./internal/cli/ -run TestAgentProbe`
- [x] Manually: `ao agent probe codex` / `--json`