### PR TITLE
feat(cli): add --json to session kill/restore/rename/cleanup

### DIFF
--- a/backend/internal/cli/session.go
+++ b/backend/internal/cli/session.go
@@ -28,6 +28,7 @@ type sessionCleanupOptions struct {
 	project string
 	yes     bool
 	dryRun  bool
+	json    bool
 }
 
 type sessionClaimPROptions struct {
@@ -203,7 +204,9 @@ func newSessionKillCommand(ctx *commandContext) *cobra.Command {
 			return ctx.killSession(cmd.Context(), cmd, id, opts)
 		},
 	}
-	addSessionProjectFlag(cmd.Flags(), &opts.project, "Project id to scope the lookup")
+	f := cmd.Flags()
+	addSessionProjectFlag(f, &opts.project, "Project id to scope the lookup")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
 	return cmd
 }
 
@@ -221,7 +224,9 @@ func newSessionRestoreCommand(ctx *commandContext) *cobra.Command {
 			return ctx.restoreSession(cmd.Context(), cmd, id, opts)
 		},
 	}
-	addSessionProjectFlag(cmd.Flags(), &opts.project, "Project id to scope the lookup")
+	f := cmd.Flags()
+	addSessionProjectFlag(f, &opts.project, "Project id to scope the lookup")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
 	return cmd
 }
 
@@ -239,7 +244,9 @@ func newSessionRenameCommand(ctx *commandContext) *cobra.Command {
 			return ctx.renameSession(cmd.Context(), cmd, id, args[1], opts)
 		},
 	}
-	addSessionProjectFlag(cmd.Flags(), &opts.project, "Project id to scope the lookup")
+	f := cmd.Flags()
+	addSessionProjectFlag(f, &opts.project, "Project id to scope the lookup")
+	f.BoolVar(&opts.json, "json", false, "Output as JSON")
 	return cmd
 }
 
@@ -257,6 +264,7 @@ func newSessionCleanupCommand(ctx *commandContext) *cobra.Command {
 	addSessionProjectFlag(cmd.Flags(), &opts.project, "Filter by project ID")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Preview which sessions would be cleaned without removing anything")
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	return cmd
 }
 
@@ -440,6 +448,9 @@ func (c *commandContext) killSession(ctx context.Context, cmd *cobra.Command, id
 	if err := c.postJSON(ctx, "sessions/"+url.PathEscape(id)+"/kill", struct{}{}, &res); err != nil {
 		return err
 	}
+	if opts.json {
+		return writeJSON(cmd.OutOrStdout(), res)
+	}
 	if res.Freed {
 		_, err := fmt.Fprintf(cmd.OutOrStdout(), "session %s killed\n", res.SessionID)
 		return err
@@ -459,6 +470,9 @@ func (c *commandContext) restoreSession(ctx context.Context, cmd *cobra.Command,
 	var res restoreSessionResponse
 	if err := c.postJSON(ctx, "sessions/"+url.PathEscape(id)+"/restore", struct{}{}, &res); err != nil {
 		return err
+	}
+	if opts.json {
+		return writeJSON(cmd.OutOrStdout(), res)
 	}
 	out := cmd.OutOrStdout()
 	if _, err := fmt.Fprintf(out, "session %s restored\n", res.SessionID); err != nil {
@@ -483,6 +497,9 @@ func (c *commandContext) renameSession(ctx context.Context, cmd *cobra.Command, 
 	if err := c.patchJSON(ctx, "sessions/"+url.PathEscape(id), sessionRenameRequest{DisplayName: name}, &res); err != nil {
 		return err
 	}
+	if opts.json {
+		return writeJSON(cmd.OutOrStdout(), res)
+	}
 	sessionID := res.SessionID
 	if sessionID == "" {
 		sessionID = id
@@ -500,20 +517,38 @@ func (c *commandContext) cleanupSessions(ctx context.Context, cmd *cobra.Command
 		return err
 	}
 	out := cmd.OutOrStdout()
-	if _, err := fmt.Fprintln(out, "Checking for completed sessions..."); err != nil {
-		return err
+	if opts.json && opts.dryRun {
+		type dryRunOut struct {
+			DryRun     bool     `json:"dryRun"`
+			WouldClean []string `json:"wouldClean"`
+		}
+		ids := make([]string, 0, len(candidates))
+		for _, sess := range candidates {
+			ids = append(ids, sess.ID)
+		}
+		return writeJSON(out, dryRunOut{DryRun: true, WouldClean: ids})
 	}
-	if _, err := fmt.Fprintln(out); err != nil {
-		return err
+	if !opts.json {
+		if _, err := fmt.Fprintln(out, "Checking for completed sessions..."); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
 	}
 	if len(candidates) == 0 {
+		if opts.json {
+			return writeJSON(out, cleanupSessionsResponse{Cleaned: []string{}, Skipped: []cleanupSkippedSession{}})
+		}
 		_, err := fmt.Fprintln(out, "  No sessions to clean up.")
 		return err
 	}
-	labels := cleanupLabels(candidates, opts.project)
-	for _, label := range labels {
-		if _, err := fmt.Fprintf(out, "  Would clean %s\n", label); err != nil {
-			return err
+	if !opts.json {
+		labels := cleanupLabels(candidates, opts.project)
+		for _, label := range labels {
+			if _, err := fmt.Fprintf(out, "  Would clean %s\n", label); err != nil {
+				return err
+			}
 		}
 	}
 	if opts.dryRun {
@@ -526,6 +561,9 @@ func (c *commandContext) cleanupSessions(ctx context.Context, cmd *cobra.Command
 			return err
 		}
 		if !confirmed {
+			if opts.json {
+				return writeJSON(out, map[string]any{"aborted": true})
+			}
 			_, err := fmt.Fprintln(out, "aborted")
 			return err
 		}
@@ -537,6 +575,9 @@ func (c *commandContext) cleanupSessions(ctx context.Context, cmd *cobra.Command
 	var res cleanupSessionsResponse
 	if err := c.postJSON(ctx, apiPath("sessions/cleanup", params), struct{}{}, &res); err != nil {
 		return err
+	}
+	if opts.json {
+		return writeJSON(out, res)
 	}
 	cleaned := res.Cleaned
 	labelByID := cleanupLabelByID(candidates, opts.project)

--- a/backend/internal/cli/session_test.go
+++ b/backend/internal/cli/session_test.go
@@ -239,6 +239,26 @@ func TestSessionKill_SuccessWithProjectScope(t *testing.T) {
 	}
 }
 
+func TestSessionKill_JSONOutputDecodes(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "kill", "demo-1", "--json")
+	if err != nil {
+		t.Fatalf("session kill --json failed: %v\nstderr=%s", err, errOut)
+	}
+	var got killSessionResponse
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("kill --json decode failed: %v\n%s", err, out)
+	}
+	if got.SessionID != "demo-1" || !got.Freed {
+		t.Fatalf("unexpected kill JSON: %#v", got)
+	}
+}
+
 // TestSessionKill_PreservedWorkspaceNote: freed=false means the daemon
 // terminated the session but kept the worktree (uncommitted changes are never
 // force-deleted) — the CLI must say so instead of implying a full teardown.
@@ -286,6 +306,26 @@ func TestSessionRestore_SuccessWithProjectScope(t *testing.T) {
 	}
 }
 
+func TestSessionRestore_JSONOutputDecodes(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "restore", "demo-1", "--json")
+	if err != nil {
+		t.Fatalf("session restore --json failed: %v\nstderr=%s", err, errOut)
+	}
+	var got restoreSessionResponse
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("restore --json decode failed: %v\n%s", err, out)
+	}
+	if got.SessionID != "demo-1" || got.Session.ProjectID != "demo" {
+		t.Fatalf("unexpected restore JSON: %#v", got)
+	}
+}
+
 func TestSessionCleanup_YesSkipsPrompt(t *testing.T) {
 	cfg := setConfigEnv(t)
 	srv, log := sessionCommandServer(t)
@@ -312,6 +352,26 @@ func TestSessionCleanup_YesSkipsPrompt(t *testing.T) {
 	}
 	if got := log.all(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("requests = %#v, want %#v", got, want)
+	}
+}
+
+func TestSessionCleanup_JSONOutputDecodes(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "cleanup", "--project", "demo", "--yes", "--json")
+	if err != nil {
+		t.Fatalf("session cleanup --json failed: %v\nstderr=%s", err, errOut)
+	}
+	var got cleanupSessionsResponse
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("cleanup --json decode failed: %v\n%s", err, out)
+	}
+	if len(got.Cleaned) != 2 {
+		t.Fatalf("unexpected cleanup JSON: %#v", got)
 	}
 }
 
@@ -429,6 +489,26 @@ func TestSessionRename_SuccessWithProjectScope(t *testing.T) {
 	want := []string{"GET /api/v1/sessions/demo-1", "PATCH /api/v1/sessions/demo-1"}
 	if got := log.all(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("requests = %#v, want %#v", got, want)
+	}
+}
+
+func TestSessionRename_JSONOutputDecodes(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "rename", "demo-1", "JSON Name", "--json")
+	if err != nil {
+		t.Fatalf("session rename --json failed: %v\nstderr=%s", err, errOut)
+	}
+	var got renameSessionResponse
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("rename --json decode failed: %v\n%s", err, out)
+	}
+	if got.SessionID != "demo-1" || got.DisplayName != "JSON Name" {
+		t.Fatalf("unexpected rename JSON: %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Align mutating session commands with ls/get/claim-pr machine-readable output
- Scripts can drive the full session lifecycle without scraping prose

## Test plan
- [x] `go test ./internal/cli/ -run 'TestSessionKill_JSON|TestSessionRestore_JSON|TestSessionRename_JSON|TestSessionCleanup_JSON'`
- [x] Spot-check prose paths still work without `--json`