### PR TITLE
fix: allow OpenCode and Kilo free models without detected auth

### DIFF
--- a/backend/internal/adapters/agent/kilocode/auth.go
+++ b/backend/internal/adapters/agent/kilocode/auth.go
@@ -18,7 +18,9 @@ import (
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
-// AuthStatus returns the plugin's local authentication status.
+// AuthStatus returns the plugin's local authentication status. Missing
+// credentials remain unknown because Kilo can still run eligible public free
+// models without a provider login.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
 	binary, err := p.ResolveBinary(ctx)
 	if err != nil {
@@ -188,7 +190,7 @@ func kilocodeAuthListStatus(output string) (ports.AgentAuthStatus, bool) {
 		return ports.AgentAuthStatusAuthorized, true
 	}
 	if strings.Contains(text, "0 credentials") && strings.Contains(text, "0 environment variable") {
-		return ports.AgentAuthStatusUnauthorized, true
+		return ports.AgentAuthStatusUnknown, true
 	}
 	return ports.AgentAuthStatusUnknown, false
 }

--- a/backend/internal/adapters/agent/kilocode/auth_test.go
+++ b/backend/internal/adapters/agent/kilocode/auth_test.go
@@ -157,9 +157,9 @@ exit 1
 	}
 }
 
-func TestKilocodeAuthListStatusUnauthorizedWhenEmpty(t *testing.T) {
+func TestKilocodeAuthListStatusUnknownWhenEmpty(t *testing.T) {
 	status, ok := kilocodeAuthListStatus("0 credentials\n0 environment variables")
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if !ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -166,8 +166,9 @@ func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (por
 	return info, ok, nil
 }
 
-// AuthStatus checks whether opencode has at least one configured provider
-// credential.
+// AuthStatus checks whether opencode has a configured provider credential.
+// Missing credentials remain unknown because opencode can still run its public
+// free models without a provider login.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
 	binary, err := p.opencodeBinary(ctx)
 	if err != nil {
@@ -187,7 +188,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	}
 	text := strings.ToLower(string(out))
 	if strings.Contains(text, "0 credentials") {
-		return ports.AgentAuthStatusUnauthorized, nil
+		return ports.AgentAuthStatusUnknown, nil
 	}
 	if strings.Contains(text, "credential") && err == nil {
 		return ports.AgentAuthStatusAuthorized, nil
@@ -265,7 +266,7 @@ func opencodeAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	if strings.TrimSpace(string(data)) == "" {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, true, nil
 	}
 
 	var entries map[string]json.RawMessage
@@ -273,7 +274,7 @@ func opencodeAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	if len(entries) == 0 {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, true, nil
 	}
 	for key, value := range entries {
 		if strings.TrimSpace(key) == "" {
@@ -284,7 +285,7 @@ func opencodeAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
-	return ports.AgentAuthStatusUnauthorized, true, nil
+	return ports.AgentAuthStatusUnknown, true, nil
 }
 
 func opencodeDBAuthStatus(ctx context.Context, path string) (ports.AgentAuthStatus, bool, error) {
@@ -315,7 +316,7 @@ func opencodeDBAuthStatus(ctx context.Context, path string) (ports.AgentAuthStat
 	if authorized {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
-	return ports.AgentAuthStatusUnauthorized, true, nil
+	return ports.AgentAuthStatusUnknown, true, nil
 }
 
 func opencodeDBHasAuthorizedAccount(ctx context.Context, db *sql.DB) (authorized, known bool, err error) {

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -47,7 +47,7 @@ func TestOpenCodeLocalAuthStatusAuthorizedWithAuthFile(t *testing.T) {
 	}
 }
 
-func TestOpenCodeLocalAuthStatusUnauthorizedWithEmptyAuthFile(t *testing.T) {
+func TestOpenCodeLocalAuthStatusUnknownWithEmptyAuthFile(t *testing.T) {
 	clearOpenCodeAuthEnv(t)
 	writeOpenCodeAuthFile(t, `{}`)
 
@@ -55,8 +55,8 @@ func TestOpenCodeLocalAuthStatusUnauthorizedWithEmptyAuthFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if !ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 
@@ -165,7 +165,7 @@ func TestOpenCodeLocalAuthStatusAuthorizedWithControlDBAccount(t *testing.T) {
 	}
 }
 
-func TestOpenCodeLocalAuthStatusUnauthorizedWithEmptyDBAccounts(t *testing.T) {
+func TestOpenCodeLocalAuthStatusUnknownWithEmptyDBAccounts(t *testing.T) {
 	clearOpenCodeAuthEnv(t)
 	dataDir := writeOpenCodeDB(t, func(db *sql.DB) {
 		if _, err := db.Exec(`
@@ -205,8 +205,30 @@ func TestOpenCodeLocalAuthStatusUnauthorizedWithEmptyDBAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if !ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestOpenCodeAuthStatusUnknownWithZeroCredentials(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture")
+	}
+	clearOpenCodeAuthEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	binary := filepath.Join(t.TempDir(), "opencode")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nprintf '0 credentials\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := (&Plugin{resolvedBinary: binary}).AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("AuthStatus = %q, want %q", status, ports.AgentAuthStatusUnknown)
 	}
 }
 


### PR DESCRIPTION
## Summary

OpenCode and Kilo can run eligible public free models without stored provider credentials. AO currently interprets those valid credential-free states as `unauthorized`, which surfaces as **Needs auth** and incorrectly implies the agents cannot be used.

This change:

- maps OpenCode and Kilo no-credential states to `unknown` instead of `unauthorized`
- preserves positive credential and account detection as `authorized`
- covers OpenCode `0 credentials`, empty `auth.json`, and an empty account database
- covers Kilo `0 credentials` together with `0 environment variables`
- keeps readiness advisory while leaving agent spawn as the authoritative runtime validation
- adds regression tests for the affected credential-free states

No frontend or API schema changes are required because AO already supports the `unknown` auth state.

Official references: [OpenCode free models](https://opencode.ai/docs/models/#free-models), [Kilo free model](https://kilo.ai/docs/getting-started/using-kilo-for-free), and [Kilo anonymous request handling](https://kilo.ai/docs/contributing/architecture/cloud-security).

Closes #3356

## Testing

- `go test ./internal/adapters/agent/kilocode ./internal/adapters/agent/opencode`
- `go test ./internal/adapters/agent/registry ./internal/service/agent ./internal/cli`
- `go test ./...`
- GitHub Actions: all checks passing