### PR TITLE
feat(landing): expose complete docs hierarchy in llms

### DIFF
--- a/frontend/src/landing/src/lib/llms.ts
+++ b/frontend/src/landing/src/lib/llms.ts
@@ -2,6 +2,7 @@ import { COMPANY } from "@ao/shared/constants";
 import { FAQ_ITEMS } from "@/app/components/FAQSection/constants";
 import { getBlogPosts } from "./blog";
 import { getComparisonPages } from "./compare";
+import { getDocPage, getDocsNav, type DocsNavItem } from "./docs";
 
 export function stripMdxSyntax(content: string): string {
 	return (
@@ -27,7 +28,15 @@ export function buildLlmsHeader(): string[] {
 	];
 }
 
-export function buildWhenToUseSection(): string[] {
+export function buildWhenToUseSection(
+	{ referenceDocumentationSection = false }: {
+		referenceDocumentationSection?: boolean;
+	} = {},
+): string[] {
+	const documentationDirection = referenceDocumentationSection
+		? "To learn the product, use the Documentation section below."
+		: "To learn the product, start with the docs index at https://aoagents.dev/docs/.";
+
 	return [
 		"## When to use Agent Orchestrator",
 		"",
@@ -38,43 +47,94 @@ export function buildWhenToUseSection(): string[] {
 		"- Schedule recurring agent runs (automations) that execute a prompt on a cron-like schedule in a fresh or existing workspace.",
 		"- Review diffs, manage ports, and monitor many concurrent agent sessions from one dashboard.",
 		"",
-		"Agent Orchestrator is not a coding agent itself; it is the local workspace and orchestration layer the agents run in. If you are an AI agent inside an AO-managed session, use the installed `ao` CLI. To learn the product, start with the docs index at https://aoagents.dev/docs/.",
+		`Agent Orchestrator is not a coding agent itself; it is the local workspace and orchestration layer the agents run in. If you are an AI agent inside an AO-managed session, use the installed \`ao\` CLI. ${documentationDirection}`,
 	];
 }
 
-export function buildDeveloperResourcesSection(): string[] {
+export function buildDeveloperResourcesSection(
+	{ includeDocumentationLinks = true }: {
+		includeDocumentationLinks?: boolean;
+	} = {},
+): string[] {
 	const baseUrl = COMPANY.MARKETING_URL;
 	const docsUrl = COMPANY.DOCS_URL;
 	return [
 		"## Developer resources",
 		"",
-		`- [Documentation](${docsUrl}/): product and workflow documentation`,
-		`- [Quickstart](${docsUrl}/quickstart/): install and first-run guide`,
-		`- [CLI](${docsUrl}/cli/): local \`ao\` command reference`,
+		...(includeDocumentationLinks
+			? [
+					`- [Documentation](${docsUrl}/): product and workflow documentation`,
+					`- [Quickstart](${docsUrl}/quickstart/): install and first-run guide`,
+					`- [CLI](${docsUrl}/cli/): local \`ao\` command reference`,
+				]
+			: []),
 		`- [Agent instructions](${baseUrl}/agents.md): when and how AI agents should use Agent Orchestrator`,
 		`- [Blog llms.txt](${baseUrl}/blog/llms.txt): scoped index of blog posts`,
 		`- [GitHub](${COMPANY.GITHUB_URL}): source code and releases`,
 	];
 }
 
+function docSlugFromUrl(url: string): string[] {
+	const path = url.replace(/^\/docs\/?/, "");
+	return path ? path.split("/") : [];
+}
+
+function renderDocumentationItem(item: DocsNavItem, depth: number): string[] {
+	const indent = "  ".repeat(depth);
+	if (item.separator) return [`${indent}- **${item.title}**`];
+
+	const page = item.url ? getDocPage(docSlugFromUrl(item.url)) : undefined;
+	const href = item.url
+		? `${COMPANY.MARKETING_URL}${item.url.endsWith("/") ? item.url : `${item.url}/`}`
+		: undefined;
+	const link = href ? `[${item.title}](${href})` : item.title;
+	const label = item.items && item.items.length > 0 ? `**${link}**` : link;
+	const description = page?.description ? `: ${page.description}` : "";
+	const lines = [`${indent}- ${label}${description}`];
+
+	for (const child of item.items ?? []) {
+		lines.push(...renderDocumentationItem(child, depth + 1));
+	}
+
+	return lines;
+}
+
+export function buildDocumentationSection(): string[] {
+	const overview = getDocPage([]);
+	const overviewDescription = overview?.description
+		? `: ${overview.description}`
+		: "";
+	const lines = [
+		"## Documentation",
+		"",
+		`- **[Documentation overview](${COMPANY.DOCS_URL}/)**${overviewDescription}`,
+	];
+
+	for (const item of getDocsNav()) {
+		if (item.separator) {
+			if (lines[lines.length - 1] !== "") lines.push("");
+			lines.push(`### ${item.title}`, "");
+			continue;
+		}
+		lines.push(...renderDocumentationItem(item, 0));
+	}
+
+	return lines;
+}
+
 export function buildLlmsTxt(): string {
 	const posts = getBlogPosts();
 	const comparisons = getComparisonPages();
 	const baseUrl = COMPANY.MARKETING_URL;
-	const docsUrl = COMPANY.DOCS_URL;
 
 	const lines: string[] = [
 		...buildLlmsHeader(),
 		"",
-		...buildWhenToUseSection(),
+		...buildWhenToUseSection({ referenceDocumentationSection: true }),
 		"",
-		...buildDeveloperResourcesSection(),
+		...buildDeveloperResourcesSection({ includeDocumentationLinks: false }),
 		"",
-		"## Docs",
-		"",
-		`- [Documentation](${docsUrl}/)`,
-		`- [Quickstart](${docsUrl}/quickstart/)`,
-		`- [GitHub](${COMPANY.GITHUB_URL})`,
+		...buildDocumentationSection(),
 		"",
 		"## Blog",
 		"",


### PR DESCRIPTION
## Summary

- generate a structured Documentation section from the existing docs meta.json navigation
- expose all 55 docs URLs exactly once, with 11 overview pages as bold parents and 44 leaf pages nested beneath them
- preserve Getting Started, Learn, Reference, and Help ordering
- include frontmatter descriptions for every linked page
- remove duplicate documentation links from the llms.txt Developer resources block without changing other shared-builder consumers

## Why

The current llms.txt directly exposes only 3 of 55 documentation pages. A metadata-driven hierarchy gives models the complete installation, guide, configuration, troubleshooting, and plugin surface without flattening indexes and leaf pages into one noisy list.

## Validation

- npm.cmd --prefix frontend/src/landing run build
- rendered buildLlmsTxt with tsx and verified 55 unique documentation URLs with no gaps or duplicates
- verified all four metadata separator groups are present

## Related work

This branch is independently based on main and does not include the platform and CI copy changes from #3344.

Closes #3362