### PR TITLE
fix(landing): apply content signals to allowed crawlers

### DIFF
--- a/frontend/src/landing/src/app/robots.txt/route.ts
+++ b/frontend/src/landing/src/app/robots.txt/route.ts
@@ -12,6 +12,9 @@ Allow: /
 Disallow: /api/
 Disallow: /_next/
 
+# Content Signals (https://contentsignals.org)
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
 # AI assistants and AI search crawlers - explicitly welcome
 User-Agent: ChatGPT-User
 Allow: /
@@ -37,9 +40,6 @@ Disallow: /
 
 User-Agent: Bytespider
 Disallow: /
-
-# Content Signals (https://contentsignals.org)
-Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 Sitemap: ${baseUrl}/sitemap.xml
 `;

--- a/frontend/src/landing/src/app/robots.txt/route.ts
+++ b/frontend/src/landing/src/app/robots.txt/route.ts
@@ -15,24 +15,54 @@ Disallow: /_next/
 # Content Signals (https://contentsignals.org)
 Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
-# AI assistants and AI search crawlers - explicitly welcome
+# AI assistants, search, and training crawlers - explicitly welcome
 User-Agent: ChatGPT-User
 Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 User-Agent: OAI-SearchBot
 Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+User-Agent: GPTBot
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 User-Agent: Claude-User
 Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 User-Agent: Claude-SearchBot
 Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 User-Agent: PerplexityBot
 Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 User-Agent: GoogleOther
 Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+User-Agent: Google-Extended
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+User-Agent: Applebot-Extended
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+User-Agent: Bingbot
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+User-Agent: meta-externalagent
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+User-Agent: DuckAssistBot
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 # Bulk-scraping crawlers - not welcome
 User-Agent: CCBot


### PR DESCRIPTION
## Summary

- apply Content-Signal permissions to the wildcard and every explicitly allowed crawler group
- explicitly welcome GPTBot, Google-Extended, Applebot-Extended, Bingbot, meta-externalagent, and DuckAssistBot
- preserve the existing CCBot and Bytespider blocks and sitemap output

## Root cause

Content-Signal is scoped to its robots.txt user-agent group. Its previous placement after the Bytespider group associated the site-wide permissions with a blocked crawler, while named allowed groups did not inherit the wildcard directive.

## Validation

- landing production build: npm.cmd run build
- group-level assertion: every Allow: / group has Content-Signal and blocked groups do not
- git diff --check

Closes #3364