### PR TITLE
fix(landing): deduplicate Organization structured data

### DIFF
--- a/frontend/src/landing/src/app/page.tsx
+++ b/frontend/src/landing/src/app/page.tsx
@@ -4,7 +4,6 @@ import dynamic from "next/dynamic";
 import {
   FAQPageJsonLd,
   HomeWebPageJsonLd,
-  OrganizationJsonLd,
 } from "@/components/JsonLd";
 import { getGitHubRepoStats } from "@/lib/github-stats";
 import { FAQ_ITEMS } from "./components/FAQSection/constants";
@@ -39,7 +38,6 @@ export default async function Home() {
     <main className="flex flex-col bg-background">
       <FAQPageJsonLd items={FAQ_ITEMS} />
       <HomeWebPageJsonLd />
-      <OrganizationJsonLd />
       <HeroSection initialStars={stats?.stars ?? null} />
       <TrustedBySection />
       <FeaturesSection />

--- a/frontend/src/landing/src/components/JsonLd/JsonLd.tsx
+++ b/frontend/src/landing/src/components/JsonLd/JsonLd.tsx
@@ -1,5 +1,9 @@
 import { COMPANY } from "@ao/shared/constants";
 
+const ORGANIZATION_ID = `${COMPANY.MARKETING_URL}/#organization`;
+const WEBSITE_ID = `${COMPANY.MARKETING_URL}/#website`;
+const SOFTWARE_ID = `${COMPANY.MARKETING_URL}/#software`;
+
 function serializeJsonLd(schema: unknown): string {
 	const json = JSON.stringify(schema);
 
@@ -34,7 +38,7 @@ export function OrganizationJsonLd() {
 	const schema = {
 		"@context": "https://schema.org",
 		"@type": "Organization",
-		"@id": `${COMPANY.MARKETING_URL}/#organization`,
+		"@id": ORGANIZATION_ID,
 		name: COMPANY.NAME,
 		url: COMPANY.MARKETING_URL,
 		logo: `${COMPANY.MARKETING_URL}/ao-logo.svg`,
@@ -68,7 +72,11 @@ export function SoftwareApplicationJsonLd() {
 	const schema = {
 		"@context": "https://schema.org",
 		"@type": "SoftwareApplication",
+		"@id": SOFTWARE_ID,
 		name: COMPANY.NAME,
+		publisher: {
+			"@id": ORGANIZATION_ID,
+		},
 		operatingSystem: "macOS, Windows, Linux",
 		applicationCategory: "DeveloperApplication",
 		applicationSubCategory: "Developer Tools",
@@ -121,6 +129,7 @@ export function ArticleJsonLd({
 		},
 		publisher: {
 			"@type": "Organization",
+			"@id": ORGANIZATION_ID,
 			name: COMPANY.NAME,
 			logo: {
 				"@type": "ImageObject",
@@ -174,6 +183,7 @@ export function ComparisonJsonLd({
 		...(keywords && keywords.length > 0 && { keywords }),
 		publisher: {
 			"@type": "Organization",
+			"@id": ORGANIZATION_ID,
 			name: COMPANY.NAME,
 			logo: {
 				"@type": "ImageObject",
@@ -201,8 +211,12 @@ export function WebsiteJsonLd() {
 	const schema = {
 		"@context": "https://schema.org",
 		"@type": "WebSite",
+		"@id": WEBSITE_ID,
 		name: COMPANY.NAME,
 		url: COMPANY.MARKETING_URL,
+		publisher: {
+			"@id": ORGANIZATION_ID,
+		},
 	};
 
 	return <JsonLdScript schema={schema} />;
@@ -217,6 +231,7 @@ export function HomeWebPageJsonLd() {
 		name: `${COMPANY.NAME}, Run 10+ parallel coding agents on your machine`,
 		isPartOf: {
 			"@type": "WebSite",
+			"@id": WEBSITE_ID,
 			name: COMPANY.NAME,
 			url: COMPANY.MARKETING_URL,
 		},
@@ -239,6 +254,7 @@ export function ServiceJsonLd() {
 			"Run and orchestrate parallel AI coding agents (Claude Code, Codex, OpenCode, and any CLI agent) in isolated Git worktrees, with diff review, persistent terminals, scheduled automations, and an MCP server for programmatic control.",
 		provider: {
 			"@type": "Organization",
+			"@id": ORGANIZATION_ID,
 			name: COMPANY.NAME,
 			url: COMPANY.MARKETING_URL,
 		},

--- a/frontend/src/landing/src/components/JsonLd/JsonLd.tsx
+++ b/frontend/src/landing/src/components/JsonLd/JsonLd.tsx
@@ -34,6 +34,7 @@ export function OrganizationJsonLd() {
 	const schema = {
 		"@context": "https://schema.org",
 		"@type": "Organization",
+		"@id": `${COMPANY.MARKETING_URL}/#organization`,
 		name: COMPANY.NAME,
 		url: COMPANY.MARKETING_URL,
 		logo: `${COMPANY.MARKETING_URL}/ao-logo.svg`,


### PR DESCRIPTION
## Summary

- give the site-wide Organization JSON-LD node a stable https://aoagents.dev/#organization identifier
- remove the duplicate OrganizationJsonLd render from the homepage
- retain RootLayout as the single site-wide owner

## Root cause

RootLayout already renders OrganizationJsonLd for every route, but the homepage rendered the same anonymous node again. This emitted two indistinguishable Organization entities on the homepage.

## Validation

- landing production build: npm.cmd run build
- git diff --check

Closes #3366