### PR TITLE
fix: expand maximized session file diffs

### DIFF
--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -278,6 +278,17 @@ describe("SessionFilesView", () => {
 		expect(screen.getByLabelText("Session files").querySelector("header")).toHaveClass("h-11", "px-1.5");
 	});
 
+	it("uses the full session panel width while maximized", async () => {
+		const { unmount } = renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+		const railList = await screen.findByRole("list");
+		expect(railList.parentElement).toHaveClass("max-w-[1200px]");
+		unmount();
+
+		renderWithQuery(<SessionFilesView isMaximized onClose={vi.fn()} sessionId="sess-1" />);
+		const maximizedList = await screen.findByRole("list");
+		expect(maximizedList.parentElement).not.toHaveClass("max-w-[1200px]");
+	});
+
 	it("lets the caller toggle between rail and maximized layouts", async () => {
 		const onToggleMaximized = vi.fn();
 		renderWithQuery(<SessionFilesView onClose={vi.fn()} onToggleMaximized={onToggleMaximized} sessionId="sess-1" />);

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -254,7 +254,7 @@ export function SessionFilesView({
 			</header>
 
 			<div className="min-h-0 flex-1 overflow-auto bg-background">
-				<div className="mx-auto flex w-full max-w-[1200px] flex-col px-0 py-1">
+				<div className={cn("flex w-full flex-col px-0 py-1", !isMaximized && "mx-auto max-w-[1200px]")}>
 					<ReviewFileList
 						error={filesQuery.error}
 						expandedPaths={expandedPaths}


### PR DESCRIPTION
## What

Remove the inner 1200px width cap from the session Files view when it is maximized, so the diff uses the available session-panel width.

## Why

The maximized file diff viewer stayed scoped to the session panel, but its content was still centered inside max-w-[1200px], leaving large useless gutters on wide session panels.

## How

- Reuse the existing isMaximized prop in SessionFilesView.
- Keep the centered max-width wrapper for the normal inspector rail.
- Drop mx-auto max-w-[1200px] only in maximized mode.
- Leave the maximize overlay scoped to the session panel; it does not cover the full AO window.

## Testing

- npm.cmd run test -- SessionFilesView.test.tsx - 12/12 passed
- npm.cmd run typecheck - passed
- npm.cmd run test - attempted; unrelated Windows/env failures in scripts/verify-mac-artifact.test.mjs and src/main/supervisor-link.test.ts

## Checklist

- [x] Branched from main (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (go, frontend, etc.)