### PR TITLE
feat: improve browser native view integration

### DIFF
--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -5,6 +5,7 @@ import {
 	type BrowserAnnotationContext,
 	type BrowserAnnotationPageSubmitPayload,
 } from "./shared/browser-annotations";
+import { promptPositionForRect } from "./shared/browser-annotation-overlay";
 
 let enabled = false;
 let selectedElement: Element | null = null;
@@ -117,38 +118,80 @@ function ensureOverlay(): ShadowRoot {
 				position: fixed;
 				box-sizing: border-box;
 				border: 2px solid #4d8dff;
-				border-radius: 6px;
-				background: rgba(77, 141, 255, 0.12);
-				box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.08);
+				border-radius: 8px;
+				background: rgba(77, 141, 255, 0.11);
+				box-shadow:
+					0 0 0 9999px rgba(0, 0, 0, 0.10),
+					0 0 0 1px rgba(255, 255, 255, 0.20),
+					0 12px 36px rgba(0, 0, 0, 0.24);
 				pointer-events: none;
+				transition:
+					left 120ms ease,
+					top 120ms ease,
+					width 120ms ease,
+					height 120ms ease,
+					border-color 120ms ease,
+					background 120ms ease;
 			}
 			.prompt {
 				position: fixed;
-				width: min(360px, calc(100vw - 24px));
+				width: min(380px, calc(100vw - 24px));
 				box-sizing: border-box;
 				border: 1px solid rgba(255, 255, 255, 0.14);
 				border-radius: 8px;
-				background: #15171b;
+				background: rgba(18, 20, 24, 0.98);
 				color: #f4f5f7;
-				box-shadow: 0 16px 40px rgba(0, 0, 0, 0.42);
-				padding: 10px;
+				box-shadow:
+					0 0 0 1px rgba(255, 255, 255, 0.06),
+					0 18px 52px rgba(0, 0, 0, 0.48);
+				padding: 12px;
 				font: 13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 				pointer-events: auto;
+				animation: prompt-in 140ms ease-out;
+			}
+			.prompt__header {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 10px;
+				margin-bottom: 9px;
+				color: rgba(244, 245, 247, 0.82);
+				font-size: 12px;
+				font-weight: 650;
+			}
+			.prompt__target {
+				min-width: 0;
+				max-width: 170px;
+				overflow: hidden;
+				border-radius: 999px;
+				background: rgba(77, 141, 255, 0.14);
+				color: #9fc0ff;
+				padding: 3px 7px;
+				font: 11px/1.2 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 			.prompt textarea {
 				width: 100%;
-				min-height: 92px;
+				min-height: 102px;
 				box-sizing: border-box;
 				resize: vertical;
 				border: 1px solid rgba(255, 255, 255, 0.12);
 				border-radius: 6px;
-				background: #0a0b0d;
+				background: rgba(7, 8, 10, 0.92);
 				color: #f4f5f7;
-				padding: 8px;
+				padding: 9px 10px;
 				font: inherit;
 				outline: none;
+				transition:
+					border-color 120ms ease,
+					box-shadow 120ms ease,
+					background 120ms ease;
 			}
-			.prompt textarea:focus { border-color: #4d8dff; }
+			.prompt textarea:focus {
+				border-color: #4d8dff;
+				box-shadow: 0 0 0 3px rgba(77, 141, 255, 0.16);
+			}
 			.actions {
 				display: flex;
 				justify-content: flex-end;
@@ -163,6 +206,16 @@ function ensureOverlay(): ShadowRoot {
 				color: #f4f5f7;
 				padding: 0 10px;
 				font: inherit;
+				transition:
+					background 120ms ease,
+					border-color 120ms ease,
+					transform 120ms ease;
+			}
+			.actions button:hover {
+				background: #242830;
+			}
+			.actions button:active {
+				transform: translateY(1px);
 			}
 			.actions button[type="submit"] {
 				border-color: #4d8dff;
@@ -180,6 +233,22 @@ function ensureOverlay(): ShadowRoot {
 				font: 12px/1.3 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 				box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 				pointer-events: none;
+				animation: prompt-in 140ms ease-out;
+			}
+			@keyframes prompt-in {
+				from { opacity: 0; transform: translateY(4px) scale(0.985); }
+				to { opacity: 1; transform: translateY(0) scale(1); }
+			}
+			@media (prefers-reduced-motion: reduce) {
+				.highlight,
+				.prompt textarea,
+				.actions button {
+					transition: none;
+				}
+				.prompt,
+				.hint {
+					animation: none;
+				}
 			}
 		</style>
 		<div class="highlight" hidden></div>
@@ -217,6 +286,10 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 	const { left, top } = promptPosition(rect);
 	mount.innerHTML = `
 		<form class="prompt" style="left: ${left}px; top: ${top}px;">
+			<div class="prompt__header">
+				<span>Annotate selection</span>
+				<span class="prompt__target">${escapeHTML(promptTargetLabel(context))}</span>
+			</div>
 			<textarea aria-label="Annotation request" placeholder="Describe what to change"></textarea>
 			<div class="actions">
 				<button type="button" data-action="cancel">Cancel</button>
@@ -244,12 +317,14 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 }
 
 function promptPosition(rect: DOMRect): { left: number; top: number } {
-	const width = Math.min(360, window.innerWidth - 24);
-	const height = 150;
-	const left = clamp(rect.left, 12, Math.max(12, window.innerWidth - width - 12));
-	const below = rect.bottom + 8;
-	const top = below + height <= window.innerHeight - 12 ? below : Math.max(12, rect.top - height - 8);
-	return { left, top };
+	return promptPositionForRect(rect, {
+		width: window.innerWidth,
+		height: window.innerHeight,
+		promptWidth: Math.min(380, window.innerWidth - 24),
+		promptHeight: 180,
+		gutter: 12,
+		gap: 8,
+	});
 }
 
 function cleanupOverlay(): void {
@@ -266,6 +341,19 @@ function isOverlayEvent(event: Event): boolean {
 	return Boolean(host && event.composedPath().includes(host));
 }
 
-function clamp(value: number, min: number, max: number): number {
-	return Math.min(max, Math.max(min, value));
+function promptTargetLabel(context: BrowserAnnotationContext): string {
+	if (context.ariaLabel) return context.ariaLabel;
+	if (context.visibleText) return context.visibleText;
+	if (context.id) return `${context.tag}#${context.id}`;
+	if (context.classes.length > 0) return `${context.tag}.${context.classes[0]}`;
+	return context.tag;
+}
+
+function escapeHTML(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
 }

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -75,6 +75,7 @@ function setupHost() {
 	const view = {
 		webContents,
 		setBounds: vi.fn(),
+		setBorderRadius: vi.fn(),
 		setVisible: vi.fn(),
 	};
 	const handlers = new Map<string, InvokeHandler>();
@@ -172,10 +173,11 @@ function setupTabHost() {
 			loadURL: ReturnType<typeof vi.fn>;
 			openWindow: (url: string) => void;
 			close: ReturnType<typeof vi.fn>;
-		};
-		setBounds: ReturnType<typeof vi.fn>;
-		setVisible: ReturnType<typeof vi.fn>;
-	}> = [];
+			};
+			setBounds: ReturnType<typeof vi.fn>;
+			setBorderRadius: ReturnType<typeof vi.fn>;
+			setVisible: ReturnType<typeof vi.fn>;
+		}> = [];
 	let nextID = 100;
 	const makeView = () => {
 		let currentURL = "";
@@ -254,7 +256,7 @@ function setupTabHost() {
 				}
 			},
 		};
-		const view = { webContents, setBounds: vi.fn(), setVisible: vi.fn() };
+		const view = { webContents, setBounds: vi.fn(), setBorderRadius: vi.fn(), setVisible: vi.fn() };
 		views.push(view);
 		return view;
 	};
@@ -410,6 +412,42 @@ describe("agent browser runtime", () => {
 		const callback = vi.fn();
 		setPermissionRequestHandler.mock.calls[0][0]({}, "camera", callback);
 		expect(callback).toHaveBeenCalledWith(false);
+	});
+
+	it("rounds every native browser tab view to match the renderer shell", async () => {
+		const { host, views } = setupTabHost();
+
+		await host.execute("sess-1", "tabs");
+		await host.execute("sess-1", "tab-new");
+
+		expect(views).toHaveLength(2);
+		for (const view of views) {
+			expect(view.setBorderRadius).toHaveBeenCalled();
+			expect(view.setBorderRadius.mock.calls.every(([radius]) => radius === 8)).toBe(true);
+		}
+	});
+
+	it("emits started and finished browser activity with one command id", async () => {
+		const { host, sent } = setupHost();
+
+		await host.execute("sess-1", "tabs");
+
+		const activity = sent.filter((event) => event.channel === "browser:agentActivity");
+		expect(activity).toHaveLength(2);
+		expect(activity[0].payload).toMatchObject({
+			viewId: "0:sess-1",
+			active: true,
+			action: "tabs",
+			phase: "started",
+			commandId: expect.any(String),
+		});
+		expect(activity[1].payload).toMatchObject({
+			viewId: "0:sess-1",
+			active: false,
+			action: "tabs",
+			phase: "finished",
+			commandId: (activity[0].payload as { commandId: string }).commandId,
+		});
 	});
 
 	it("rejects local files and implicit searches from agent-originated navigation", async () => {
@@ -751,15 +789,23 @@ describe("agent browser runtime", () => {
 
 		const pendingSnapshot = host.execute("sess-1", "snapshot");
 		await vi.waitFor(() =>
-			expect(sent).toContainEqual({
-				channel: "browser:agentActivity",
-				payload: {
-					viewId: "0:sess-1",
-					active: true,
-					action: "snapshot",
-				},
-			}),
+			expect(sent).toContainEqual(
+				expect.objectContaining({
+					channel: "browser:agentActivity",
+					payload: expect.objectContaining({
+						viewId: "0:sess-1",
+						active: true,
+						action: "snapshot",
+						phase: "started",
+						commandId: expect.any(String),
+					}),
+				}),
+			),
 		);
+		const startedActivity = sent.find(({ channel, payload }) => {
+			if (channel !== "browser:agentActivity") return false;
+			return (payload as { active?: boolean; action?: string }).active === true;
+		})?.payload as { commandId: string };
 		await vi.waitFor(() => expect(debuggerSendCommand).toHaveBeenCalledWith("Accessibility.getFullAXTree"));
 
 		resolveSnapshot({ nodes: [] });
@@ -770,8 +816,20 @@ describe("agent browser runtime", () => {
 				.filter(({ channel }) => channel === "browser:agentActivity")
 				.map(({ payload }) => payload),
 		).toEqual([
-			{ viewId: "0:sess-1", active: true, action: "snapshot" },
-			{ viewId: "0:sess-1", active: false, action: "snapshot" },
+			expect.objectContaining({
+				viewId: "0:sess-1",
+				active: true,
+				action: "snapshot",
+				phase: "started",
+				commandId: startedActivity.commandId,
+			}),
+			expect.objectContaining({
+				viewId: "0:sess-1",
+				active: false,
+				action: "snapshot",
+				phase: "finished",
+				commandId: startedActivity.commandId,
+			}),
 		]);
 	});
 
@@ -1106,6 +1164,7 @@ describe("browser:setBounds parked", () => {
 	it("moves the view offscreen at full size while keeping it visible", async () => {
 		const { emit, invoke, view } = setupHost();
 		await invoke("browser:ensure", "sess-1");
+		view.setBorderRadius.mockClear();
 
 		emit("browser:setBounds", 1, {
 			viewId: "1:sess-1",
@@ -1115,6 +1174,10 @@ describe("browser:setBounds parked", () => {
 		});
 
 		expect(view.setBounds).toHaveBeenLastCalledWith({ x: -10_000, y: 0, width: 320, height: 240 });
+		expect(view.setBorderRadius).toHaveBeenLastCalledWith(8);
+		expect(view.setBounds.mock.invocationCallOrder.at(-1)).toBeLessThan(
+			view.setBorderRadius.mock.invocationCallOrder.at(-1)!,
+		);
 		expect(view.setVisible).toHaveBeenLastCalledWith(true);
 	});
 });
@@ -1123,6 +1186,7 @@ describe("browser:setBounds", () => {
 	it("converts page-zoomed renderer slot bounds before positioning the native view", async () => {
 		const { emit, invoke, view } = setupHost();
 		await invoke("browser:ensure", "sess-1");
+		view.setBorderRadius.mockClear();
 
 		emit("browser:setBounds", 1.25, {
 			viewId: "1:sess-1",
@@ -1131,6 +1195,10 @@ describe("browser:setBounds", () => {
 		});
 
 		expect(view.setBounds).toHaveBeenLastCalledWith({ x: 125, y: 25, width: 400, height: 300 });
+		expect(view.setBorderRadius).toHaveBeenLastCalledWith(8);
+		expect(view.setBounds.mock.invocationCallOrder.at(-1)).toBeLessThan(
+			view.setBorderRadius.mock.invocationCallOrder.at(-1)!,
+		);
 		expect(view.setVisible).toHaveBeenLastCalledWith(true);
 	});
 });

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -52,6 +52,8 @@ export type BrowserAgentActivityState = {
 	viewId: string;
 	active: boolean;
 	action: string;
+	phase?: "started" | "finished";
+	commandId?: string;
 };
 
 type BrowserBoundsInput = {
@@ -99,6 +101,7 @@ type BrowserWebContents = Pick<
 type BrowserViewLike = View & {
 	webContents: BrowserWebContents;
 	setBounds: (bounds: BrowserRect) => void;
+	setBorderRadius?: (radius: number) => void;
 	setVisible?: (visible: boolean) => void;
 };
 
@@ -222,6 +225,7 @@ type BrowserNetworkCapture = {
 // Hidden targets still need a real viewport for screenshots, responsive
 // layout, scrolling, and pointer automation before the panel is first shown.
 const OFFSCREEN_BOUNDS: BrowserRect = { x: -10_000, y: -10_000, width: 1280, height: 720 };
+const BROWSER_VIEW_BORDER_RADIUS = 8;
 const DEFAULT_NETWORK_CAPTURE_SECONDS = 60;
 const MAX_NETWORK_CAPTURE_SECONDS = 300;
 const MAX_NETWORK_REQUESTS = 200;
@@ -301,13 +305,26 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	const forgetIfFocused = (viewId: string): void => {
 		if (lastFocusedViewId === viewId) lastFocusedViewId = null;
 	};
-	const setAgentBrowserActivity = (session: BrowserSessionEntry, action: string, active: boolean): void => {
+	const setAgentBrowserActivity = (
+		session: BrowserSessionEntry,
+		action: string,
+		active: boolean,
+		commandId?: string,
+		phase?: BrowserAgentActivityState["phase"],
+	): void => {
 		session.agentBrowserCommands = Math.max(0, session.agentBrowserCommands + (active ? 1 : -1));
 		options.mainWindow.webContents.send("browser:agentActivity", {
 			viewId: session.viewId,
 			active: session.agentBrowserCommands > 0,
 			action,
+			...(phase ? { phase } : {}),
+			...(commandId ? { commandId } : {}),
 		} satisfies BrowserAgentActivityState);
+	};
+	const applyBrowserViewBounds = (view: BrowserViewLike, bounds: BrowserRect, visible?: boolean): void => {
+		view.setBounds(bounds);
+		if (visible !== undefined) view.setVisible?.(visible);
+		view.setBorderRadius?.(BROWSER_VIEW_BORDER_RADIUS);
 	};
 	let pendingMirror: { viewId: string; expires: number; frame: WebFrameMain } | null = null;
 
@@ -356,9 +373,9 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 				sandbox: true,
 			},
 		});
-		view.setBounds(OFFSCREEN_BOUNDS);
-		view.setVisible?.(false);
+		applyBrowserViewBounds(view, OFFSCREEN_BOUNDS, false);
 		options.mainWindow.contentView.addChildView(view);
+		view.setBorderRadius?.(BROWSER_VIEW_BORDER_RADIUS);
 		view.webContents.session?.setPermissionCheckHandler?.(() => false);
 		view.webContents.session?.setPermissionRequestHandler?.((_contents, _permission, callback) => callback(false));
 
@@ -473,8 +490,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		const previous = session.tabs.get(session.activeTabId);
 		if (previous && previous !== next) {
 			invalidateRefs(previous);
-			previous.view.setVisible?.(false);
-			previous.view.setBounds(OFFSCREEN_BOUNDS);
+			applyBrowserViewBounds(previous.view, OFFSCREEN_BOUNDS, false);
 		}
 		session.activeTabId = tabId;
 		invalidateRefs(next);
@@ -507,12 +523,14 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 
 	function applySessionBounds(session: BrowserSessionEntry, entry: BrowserEntry): void {
 		if (!session.visible) {
-			entry.view.setVisible?.(false);
-			entry.view.setBounds(OFFSCREEN_BOUNDS);
+			applyBrowserViewBounds(entry.view, OFFSCREEN_BOUNDS, false);
 			return;
 		}
-		entry.view.setBounds(session.bounds);
-		entry.view.setVisible?.(session.parked || (session.bounds.width > 0 && session.bounds.height > 0));
+		applyBrowserViewBounds(
+			entry.view,
+			session.bounds,
+			session.parked || (session.bounds.width > 0 && session.bounds.height > 0),
+		);
 	}
 
 	const isRendererOwned = (event: IpcMainInvokeEvent | IpcMainEvent, viewId: string): boolean =>
@@ -635,8 +653,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	};
 
 	const destroyTabView = (entry: BrowserEntry): void => {
-		entry.view.setVisible?.(false);
-		entry.view.setBounds(OFFSCREEN_BOUNDS);
+		applyBrowserViewBounds(entry.view, OFFSCREEN_BOUNDS, false);
 		options.mainWindow.contentView.removeChildView?.(entry.view);
 		if (entry.view.webContents.debugger?.isAttached()) {
 			entry.view.webContents.debugger.detach();
@@ -790,7 +807,8 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			}
 			const session = ensureSession(sessionId);
 			const entry = activeEntry(session);
-			setAgentBrowserActivity(session, action, true);
+			const commandId = randomUUID();
+			setAgentBrowserActivity(session, action, true, commandId, "started");
 			try {
 				switch (action) {
 				case "open": {
@@ -899,7 +917,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 					throw browserError("INVALID_ARGUMENT", `Unsupported browser action: ${action}`);
 				}
 			} finally {
-				setAgentBrowserActivity(session, action, false);
+				setAgentBrowserActivity(session, action, false, commandId, "finished");
 			}
 		},
 		dispose: () => {

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -24,11 +24,14 @@ const hookState = vi.hoisted(() => ({
 	stop: vi.fn(),
 	selectTab: vi.fn(),
 	closeTab: vi.fn(),
+	prepareForOverlay: vi.fn(async () => undefined),
 	setAnnotationMode: vi.fn(),
 	tabs: [{ id: "t1", url: "", title: "", active: true }],
 	activeTabId: "t1",
 	tabNotice: "",
 	agentBrowserActive: false,
+	agentBrowserActivity: null as { active: boolean; action?: string; phase?: "started" | "finished" } | null,
+	visualTransition: null as { kind: "tab-switch" | "popout"; snapshotUrl: string } | null,
 	previewUrl: undefined as string | undefined,
 	navState: {
 		viewId: "42:sess-1",
@@ -56,8 +59,11 @@ vi.mock("../hooks/useBrowserView", () => ({
 			activeTabId: hookState.activeTabId,
 			tabNotice: hookState.tabNotice,
 			agentBrowserActive: hookState.agentBrowserActive,
+			agentBrowserActivity: hookState.agentBrowserActivity,
+			visualTransition: hookState.visualTransition,
 			selectTab: hookState.selectTab,
 			closeTab: hookState.closeTab,
+			prepareForOverlay: hookState.prepareForOverlay,
 			annotationMode: false,
 			setAnnotationMode: hookState.setAnnotationMode,
 		};
@@ -136,6 +142,7 @@ describe("BrowserPanel", () => {
 		hookState.stop.mockReset();
 		hookState.selectTab.mockReset();
 		hookState.closeTab.mockReset();
+		hookState.prepareForOverlay.mockReset();
 		hookState.setAnnotationMode.mockReset();
 		hookState.setAnnotationMode.mockResolvedValue(undefined);
 		postMock.mockReset();
@@ -159,6 +166,8 @@ describe("BrowserPanel", () => {
 		hookState.activeTabId = "t1";
 		hookState.tabNotice = "";
 		hookState.agentBrowserActive = false;
+		hookState.agentBrowserActivity = null;
+		hookState.visualTransition = null;
 		hookState.navState = {
 			viewId: "42:sess-1",
 			url: "",
@@ -248,11 +257,23 @@ describe("BrowserPanel", () => {
 
 	it("toggles pop-out mode", async () => {
 		const onTogglePopOut = vi.fn();
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
 		render(<BrowserPanel active onTogglePopOut={onTogglePopOut} poppedOut={false} session={session} />);
 
 		await userEvent.click(screen.getByRole("button", { name: /pop out/i }));
 
 		expect(onTogglePopOut).toHaveBeenCalledWith(true);
+	});
+
+	it("does not pop out an empty browser", async () => {
+		const onTogglePopOut = vi.fn();
+		render(<BrowserPanel active onTogglePopOut={onTogglePopOut} poppedOut={false} session={session} />);
+
+		const popOut = screen.getByRole("button", { name: /pop out/i });
+		expect(popOut).toBeDisabled();
+		await userEvent.click(popOut);
+
+		expect(onTogglePopOut).not.toHaveBeenCalled();
 	});
 
 	it("enables annotation mode from the toolbar when a page is loaded", async () => {
@@ -299,6 +320,59 @@ describe("BrowserPanel", () => {
 
 		expect(screen.getByRole("button", { name: /annotate/i })).toBeEnabled();
 		expect(screen.getByText("Agent using browser")).toBeInTheDocument();
+	});
+
+	it("shows the concrete browser action while the agent controls the page", () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		hookState.agentBrowserActive = true;
+		hookState.agentBrowserActivity = { active: true, action: "click", phase: "started" };
+
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		expect(screen.getByText("Agent clicking")).toBeInTheDocument();
+		expect(screen.queryByText("Agent using browser")).not.toBeInTheDocument();
+	});
+
+	it("renders a captured transition frame over the native browser slot", () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		hookState.visualTransition = { kind: "tab-switch", snapshotUrl: "data:image/jpeg;base64,snapshot" };
+
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		const frame = screen.getByTestId("browser-transition-frame");
+		expect(frame).toHaveAttribute("src", "data:image/jpeg;base64,snapshot");
+	});
+
+	it("renders the premium browser shell hooks in the default view", () => {
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		expect(screen.getByTestId("browser-toolbar")).toHaveClass("browser-panel__toolbar");
+		expect(screen.getByTestId("browser-viewport")).toHaveClass("browser-panel__viewport");
+	});
+
+	it("keeps URL icon placement controlled by the browser shell CSS", () => {
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		const icon = screen.getByTestId("browser-url-icon");
+		expect(icon).toHaveClass("browser-panel__url-icon");
+		expect(icon).not.toHaveClass("top-1/2");
+		expect(icon).not.toHaveClass("-translate-y-1/2");
+	});
+
+	it("warms the browser tabs menu before opening it above the native browser", async () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		hookState.tabs = [
+			{ id: "t1", url: "http://localhost:3000/", title: "First app", active: true },
+			{ id: "t2", url: "http://localhost:4173/", title: "Second app", active: false },
+		];
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		await userEvent.click(screen.getByRole("button", { name: /browser tabs/i }));
+
+		expect(hookState.prepareForOverlay).toHaveBeenCalled();
+		expect(await screen.findByRole("menu")).not.toHaveAttribute("data-ao-browser-native-overlay");
+		expect(screen.getByText("First app").closest('[role="menuitem"]')).toHaveClass("cursor-pointer");
+		expect(screen.getByRole("menuitem", { name: "Close tab First app" })).toHaveClass("cursor-pointer");
 	});
 
 	it("disables annotation mode when no page is loaded", () => {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useRef, useState, type FormEvent, type KeyboardEvent, type PointerEvent } from "react";
 import {
 	ArrowLeft,
 	ArrowRight,
@@ -239,7 +239,10 @@ export function BrowserPanelView({
 		tabNotice,
 		selectTab,
 		closeTab,
+		prepareForOverlay,
 		agentBrowserActive,
+		agentBrowserActivity,
+		visualTransition,
 		annotationMode,
 		setAnnotationMode,
 	} = browserView;
@@ -248,7 +251,10 @@ export function BrowserPanelView({
 		annotationQueue;
 	const showStaticPreview = !window.ao?.browser && navState.url !== "";
 	const canAnnotate = Boolean(window.ao?.browser && viewId && navState.url);
+	const canPopOut = poppedOut || Boolean(navState.url);
 	const canRetryAnnotation = status === "error" && queuedCount > 0;
+	const [tabsMenuOpen, setTabsMenuOpen] = useState(false);
+	const tabsMenuWarmupRef = useRef<Promise<void> | null>(null);
 
 	useEffect(() => {
 		setUrlInput(navState.url);
@@ -294,6 +300,49 @@ export function BrowserPanelView({
 		}
 	};
 
+	const prepareTabsMenuFrame = useCallback(() => {
+		if (!tabsMenuWarmupRef.current) {
+			tabsMenuWarmupRef.current = prepareForOverlay().finally(() => {
+				tabsMenuWarmupRef.current = null;
+			});
+		}
+		return tabsMenuWarmupRef.current;
+	}, [prepareForOverlay]);
+
+	const warmTabsMenuFrame = useCallback(() => {
+		void prepareTabsMenuFrame();
+	}, [prepareTabsMenuFrame]);
+
+	const openTabsMenu = useCallback(async () => {
+		if (tabs.length === 0) return;
+		await prepareTabsMenuFrame();
+		setTabsMenuOpen(true);
+	}, [prepareTabsMenuFrame, tabs.length]);
+
+	const handleTabsMenuOpenChange = useCallback(
+		(next: boolean) => {
+			if (!next) {
+				setTabsMenuOpen(false);
+				return;
+			}
+			void openTabsMenu();
+		},
+		[openTabsMenu],
+	);
+
+	const handleTabsTriggerPointerDown = (event: PointerEvent<HTMLButtonElement>) => {
+		if (tabsMenuOpen || tabs.length === 0) return;
+		event.preventDefault();
+		void openTabsMenu();
+	};
+
+	const handleTabsTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+		if (tabsMenuOpen || tabs.length === 0) return;
+		if (event.key !== "Enter" && event.key !== " " && event.key !== "ArrowDown") return;
+		event.preventDefault();
+		void openTabsMenu();
+	};
+
 	const annotationStatusLabel =
 		status === "picking"
 			? "Pick element"
@@ -308,15 +357,22 @@ export function BrowserPanelView({
 						: status === "error"
 							? error
 							: "";
+	const agentStatusLabel = agentActivityLabel(agentBrowserActivity, agentBrowserActive);
 
 	return (
 		<div
-			className="flex h-full min-h-browser-min flex-col overflow-hidden rounded-lg border border-border bg-background"
+			className={cn(
+				"browser-panel flex h-full min-h-browser-min flex-col overflow-hidden rounded-lg border border-border bg-background",
+				poppedOut && "browser-panel--popped-out",
+				agentStatusLabel && "browser-panel--agent-active",
+			)}
 			data-testid="browser-panel"
+			data-transition={visualTransition?.kind}
 			role="tabpanel"
 		>
 			<form
-				className="flex shrink-0 min-w-0 items-center gap-1 border-b border-border bg-surface p-1.5"
+				className="browser-panel__toolbar flex shrink-0 min-w-0 items-center gap-1 border-b border-border bg-surface p-1.5"
+				data-testid="browser-toolbar"
 				onSubmit={submit}
 			>
 				<Button
@@ -381,19 +437,20 @@ export function BrowserPanelView({
 					>
 						{annotationStatusLabel}
 					</span>
-				) : agentBrowserActive ? (
+				) : agentStatusLabel ? (
 					<span className="browser-panel__annotation-status" role="status" aria-live="polite">
-						Agent using browser
+						{agentStatusLabel}
 					</span>
 				) : null}
-				<div className="relative min-w-0 flex-1">
-					<Globe2
-						aria-hidden="true"
-						className="pointer-events-none absolute left-2.25 top-1/2 size-icon-md -translate-y-1/2 text-passive"
-					/>
+					<div className="browser-panel__url-wrap relative min-w-0 flex-1">
+						<Globe2
+							aria-hidden="true"
+							className="browser-panel__url-icon"
+							data-testid="browser-url-icon"
+						/>
 					<Input
 						aria-label="Browser URL"
-						className="h-browser-url pl-browser-url font-mono text-xs"
+						className="browser-panel__url-input h-browser-url pl-browser-url font-mono text-xs"
 						onChange={(event) => setUrlInput(event.target.value)}
 						placeholder="localhost:5173"
 						value={urlInput}
@@ -404,12 +461,16 @@ export function BrowserPanelView({
 						{tabNotice}
 					</span>
 				) : null}
-				<DropdownMenu modal={false}>
+				<DropdownMenu modal={false} onOpenChange={handleTabsMenuOpenChange} open={tabsMenuOpen}>
 					<DropdownMenuTrigger asChild>
 						<Button
 							aria-label={`Browser tabs (${tabs.length})`}
-							className={cn("gap-1 px-2", tabs.length > 1 && "bg-accent-weak text-accent")}
+							className={cn("browser-panel__tabs-trigger gap-1 px-2", tabs.length > 1 && "bg-accent-weak text-accent")}
 							disabled={tabs.length === 0}
+							onFocus={warmTabsMenuFrame}
+							onKeyDown={handleTabsTriggerKeyDown}
+							onPointerDown={handleTabsTriggerPointerDown}
+							onPointerEnter={warmTabsMenuFrame}
 							size="sm"
 							title={`${tabs.length} browser ${tabs.length === 1 ? "tab" : "tabs"}`}
 							type="button"
@@ -426,7 +487,7 @@ export function BrowserPanelView({
 							return (
 								<div className="flex min-w-0 items-center gap-0.5" key={tab.id}>
 									<DropdownMenuItem
-										className="min-w-0 flex-1 py-2"
+										className="min-w-0 flex-1 cursor-pointer py-2"
 										onSelect={() => void selectTab(tab.id)}
 										textValue={`${label.title} ${label.subtitle}`}
 									>
@@ -440,7 +501,7 @@ export function BrowserPanelView({
 									</DropdownMenuItem>
 									<DropdownMenuItem
 										aria-label={`Close tab ${label.title}`}
-										className="size-8 shrink-0 justify-center px-0"
+										className="size-8 shrink-0 cursor-pointer justify-center px-0"
 										disabled={tabs.length === 1}
 										onSelect={() => void closeTab(tab.id)}
 										title={tabs.length === 1 ? "The only tab cannot be closed" : `Close ${label.title}`}
@@ -454,8 +515,13 @@ export function BrowserPanelView({
 				</DropdownMenu>
 				<Button
 					aria-label={poppedOut ? "Return to panel" : "Pop out"}
-					onClick={() => onTogglePopOut(!poppedOut)}
+					disabled={!canPopOut}
+					onClick={() => {
+						if (!canPopOut) return;
+						onTogglePopOut(!poppedOut);
+					}}
 					size="icon-sm"
+					title={canPopOut ? undefined : "Open a page before maximizing the browser"}
 					type="button"
 					variant="ghost"
 				>
@@ -466,12 +532,23 @@ export function BrowserPanelView({
 					)}
 				</Button>
 			</form>
-			<div className="relative min-h-0 flex-1 overflow-hidden bg-background">
+			<div
+				className="browser-panel__viewport relative min-h-0 flex-1 overflow-hidden bg-background"
+				data-testid="browser-viewport"
+			>
 				<div className="absolute inset-0 min-h-px min-w-px" ref={slotRef} />
 				{mirrorStream ? (
 					<MirrorVideo stream={mirrorStream} />
 				) : mirrorUrl ? (
-					<img alt="" className="absolute inset-0 h-full w-full object-cover" src={mirrorUrl} />
+					<img alt="" className="absolute inset-0 h-full w-full object-fill" src={mirrorUrl} />
+				) : null}
+				{visualTransition ? (
+					<img
+						alt=""
+						className="browser-panel__transition-frame"
+						data-testid="browser-transition-frame"
+						src={visualTransition.snapshotUrl}
+					/>
 				) : null}
 				{showStaticPreview ? <StaticPreview url={navState.url} /> : null}
 				{navState.url === "" ? (
@@ -493,6 +570,49 @@ export function BrowserPanelView({
 			</div>
 		</div>
 	);
+}
+
+function agentActivityLabel(activity: BrowserViewModel["agentBrowserActivity"], active: boolean): string {
+	if (!active && !activity?.active) return "";
+	const action = activity?.active ? activity.action : "";
+	if (!action) return "Agent using browser";
+	return `Agent ${browserActionVerb(action)}`;
+}
+
+function browserActionVerb(action: string): string {
+	switch (action) {
+		case "click":
+			return "clicking";
+		case "fill":
+		case "type":
+			return "typing";
+		case "press":
+			return "pressing";
+		case "hover":
+			return "hovering";
+		case "scroll":
+			return "scrolling";
+		case "open":
+			return "opening";
+		case "wait":
+			return "waiting";
+		case "snapshot":
+			return "reading";
+		case "highlight":
+			return "highlighting";
+		case "unhighlight":
+			return "clearing highlight";
+		case "tab-new":
+			return "opening tab";
+		case "tab-select":
+			return "switching tabs";
+		case "tab-close":
+			return "closing tab";
+		case "tabs":
+			return "checking tabs";
+		default:
+			return "using browser";
+	}
 }
 
 function browserTabLabel(title: string, url: string): { title: string; subtitle: string } {

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -195,6 +195,149 @@ describe("useBrowserView", () => {
 		expect(result.current.agentBrowserActive).toBe(false);
 	});
 
+	it("holds a captured frame while selecting a tab so the native handoff does not flash", async () => {
+		const bridge = setupBridge();
+		const slot = createSlot();
+		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+		await waitFor(() => expect(result.current.viewId).toBe("42:sess-1"));
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "http://localhost:3000/",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+		act(() => result.current.slotRef(slot));
+
+		vi.useFakeTimers();
+		try {
+			await act(async () => {
+				await result.current.selectTab("t2");
+			});
+
+			expect(bridge.capture).toHaveBeenCalledWith("42:sess-1");
+			expect(result.current.visualTransition).toMatchObject({
+				kind: "tab-switch",
+				snapshotUrl: "data:image/jpeg;base64,snapshot",
+			});
+
+			act(() => {
+				vi.advanceTimersByTime(260);
+			});
+			expect(result.current.visualTransition).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not block tab switching on a slow transition capture", async () => {
+		const bridge = setupBridge();
+		const slot = createSlot();
+		bridge.capture.mockImplementation(
+			() => new Promise((resolve) => window.setTimeout(() => resolve("data:image/jpeg;base64,late"), 10_000)),
+		);
+		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+		await waitFor(() => expect(result.current.viewId).toBe("42:sess-1"));
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "http://localhost:3000/",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+		act(() => result.current.slotRef(slot));
+
+		vi.useFakeTimers();
+		try {
+			let switchPromise: Promise<void> | undefined;
+			await act(async () => {
+				switchPromise = result.current.selectTab("t2");
+				await vi.advanceTimersByTimeAsync(180);
+			});
+
+			expect(bridge.capture).toHaveBeenCalledWith("42:sess-1");
+			expect(bridge.selectTab).toHaveBeenCalledWith({ viewId: "42:sess-1", tabId: "t2" });
+			await act(async () => {
+				await switchPromise;
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("remeasures the live native view while moving between panel and maximized browser slots", async () => {
+		const bridge = setupBridge();
+		const slot = createSlot();
+		const { result, rerender } = renderHook(
+			({ poppedOut }) => useBrowserView({ sessionId: "sess-1", active: true, poppedOut }),
+			{ initialProps: { poppedOut: false } },
+		);
+		await waitFor(() => expect(result.current.viewId).toBe("42:sess-1"));
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "http://localhost:3000/",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+		act(() => result.current.slotRef(slot));
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 12, y: 34, width: 320, height: 240 },
+				visible: true,
+			}),
+		);
+		bridge.setBounds.mockClear();
+
+		act(() => {
+			rerender({ poppedOut: true });
+		});
+
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 12, y: 34, width: 320, height: 240 },
+				visible: true,
+			}),
+		);
+		expect(bridge.capture).not.toHaveBeenCalled();
+		expect(bridge.setBounds.mock.calls.some(([payload]) => payload.parked)).toBe(false);
+		expect(result.current.visualTransition).toBeNull();
+	});
+
+	it("primes a browser frame before opening renderer overlays above the native view", async () => {
+		const bridge = setupBridge();
+		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+		await waitFor(() => expect(result.current.viewId).toBe("42:sess-1"));
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "http://localhost:3000/",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+
+		await act(async () => {
+			await result.current.prepareForOverlay();
+		});
+
+		expect(bridge.capture).toHaveBeenCalledWith("42:sess-1");
+		expect(result.current.mirrorUrl).toBe("data:image/jpeg;base64,snapshot");
+	});
+
 	it("clamps the native view to its resizable-panel column when the slot overspills", async () => {
 		const bridge = setupBridge();
 		// The slot is wider than its column (e.g. the `min-w-[280px]` wrapper on a

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type {
+	BrowserAgentActivityState,
 	BrowserNavState,
 	BrowserRect,
 	BrowserTabState,
@@ -9,6 +10,11 @@ import type { BrowserAnnotationCancelPayload, BrowserAnnotationSubmitPayload } f
 import { OPEN_DIALOG_OR_MENU_SELECTOR } from "../lib/dom-selectors";
 
 export type { BrowserNavState };
+
+export type BrowserVisualTransition = {
+	kind: "tab-switch" | "popout";
+	snapshotUrl: string;
+};
 
 type UseBrowserViewOptions = {
 	sessionId: string;
@@ -50,7 +56,10 @@ export type BrowserViewModel = {
 	tabNotice: string;
 	selectTab: (tabId: string) => Promise<void>;
 	closeTab: (tabId: string) => Promise<void>;
+	prepareForOverlay: () => Promise<void>;
 	agentBrowserActive: boolean;
+	agentBrowserActivity: BrowserAgentActivityState | null;
+	visualTransition: BrowserVisualTransition | null;
 	destroy: () => void;
 	annotationMode: boolean;
 	setAnnotationMode: (enabled: boolean) => Promise<void>;
@@ -72,6 +81,8 @@ const EMPTY_TABS_STATE: BrowserTabsState = {
 };
 
 const HIDDEN_RECT: BrowserRect = { x: 0, y: 0, width: 0, height: 0 };
+const VISUAL_TRANSITION_DURATION_MS = 240;
+const VISUAL_TRANSITION_CAPTURE_TIMEOUT_MS = 120;
 
 // The native WebContentsView is a window-level overlay, so DOM `overflow:
 // hidden` never clips it — it paints wherever the slot's bounding box lands.
@@ -124,10 +135,13 @@ export function useBrowserView({
 	const [tabsState, setTabsState] = useState<BrowserTabsState>(EMPTY_TABS_STATE);
 	const [tabNotice, setTabNotice] = useState("");
 	const [agentBrowserActive, setAgentBrowserActive] = useState(false);
+	const [agentBrowserActivity, setAgentBrowserActivity] = useState<BrowserAgentActivityState | null>(null);
+	const [visualTransition, setVisualTransition] = useState<BrowserVisualTransition | null>(null);
 	const slotNodeRef = useRef<HTMLDivElement | null>(null);
 	const viewIdRef = useRef("");
 	const annotationModeRef = useRef(false);
 	const activeRef = useRef(active);
+	const poppedOutRef = useRef(poppedOut);
 	const frameRef = useRef<number | null>(null);
 	const settleTimerRef = useRef<number | null>(null);
 	const observerRef = useRef<ResizeObserver | null>(null);
@@ -137,6 +151,7 @@ export function useBrowserView({
 	const mirrorTokenRef = useRef(0);
 	const mirrorTimerRef = useRef<number | null>(null);
 	const tabNoticeTimerRef = useRef<number | null>(null);
+	const visualTransitionTimerRef = useRef<number | null>(null);
 	const mirrorStreamRef = useRef<MediaStream | null>(null);
 	const hasNativeBrowser = Boolean(window.ao?.browser);
 
@@ -156,6 +171,45 @@ export function useBrowserView({
 		if (!id) return;
 		window.ao?.browser.setBounds({ viewId: id, rect: HIDDEN_RECT, visible: false });
 	}, []);
+
+	const clearVisualTransitionTimer = useCallback(() => {
+		if (visualTransitionTimerRef.current === null) return;
+		window.clearTimeout(visualTransitionTimerRef.current);
+		visualTransitionTimerRef.current = null;
+	}, []);
+
+	const clearMirrorTimer = useCallback(() => {
+		if (mirrorTimerRef.current === null) return;
+		window.clearTimeout(mirrorTimerRef.current);
+		mirrorTimerRef.current = null;
+	}, []);
+
+	const showVisualTransition = useCallback(
+		async (kind: BrowserVisualTransition["kind"], timeoutCapture = true) => {
+			const id = viewIdRef.current;
+			if (!id || !hasNativeBrowser || !hasUrlRef.current) return;
+			const capture = window.ao?.browser.capture?.(id).catch(() => "");
+			if (!capture) return;
+			let timeoutId: number | null = null;
+			const snapshotUrl = timeoutCapture
+				? await Promise.race([
+						capture,
+						new Promise<string>((resolve) => {
+							timeoutId = window.setTimeout(() => resolve(""), VISUAL_TRANSITION_CAPTURE_TIMEOUT_MS);
+						}),
+					])
+				: await capture;
+			if (timeoutId !== null) window.clearTimeout(timeoutId);
+			if (!snapshotUrl || viewIdRef.current !== id) return;
+			clearVisualTransitionTimer();
+			setVisualTransition({ kind, snapshotUrl });
+			visualTransitionTimerRef.current = window.setTimeout(() => {
+				visualTransitionTimerRef.current = null;
+				setVisualTransition(null);
+			}, VISUAL_TRANSITION_DURATION_MS);
+		},
+		[clearVisualTransitionTimer, hasNativeBrowser],
+	);
 
 	const measureAndSend = useCallback(() => {
 		// measureAndSend runs both from the scheduleMeasure() rAF callback and as a
@@ -256,6 +310,9 @@ export function useBrowserView({
 		setTabsState(EMPTY_TABS_STATE);
 		setTabNotice("");
 		setAgentBrowserActive(false);
+		setAgentBrowserActivity(null);
+		setVisualTransition(null);
+		clearVisualTransitionTimer();
 		if (tabNoticeTimerRef.current !== null) {
 			window.clearTimeout(tabNoticeTimerRef.current);
 			tabNoticeTimerRef.current = null;
@@ -300,7 +357,7 @@ export function useBrowserView({
 			}
 			viewIdRef.current = "";
 		};
-	}, [hasNativeBrowser, scheduleSettleMeasure, sendHiddenBounds, sessionId]);
+	}, [clearVisualTransitionTimer, hasNativeBrowser, scheduleSettleMeasure, sendHiddenBounds, sessionId]);
 
 	useEffect(() => {
 		return window.ao?.browser.onNavState((state) => {
@@ -327,14 +384,16 @@ export function useBrowserView({
 		return window.ao?.browser.onAgentActivity((state) => {
 			if (state.viewId !== viewIdRef.current) return;
 			setAgentBrowserActive(state.active);
+			setAgentBrowserActivity(state);
 		});
 	}, []);
 
 	useEffect(
 		() => () => {
 			if (tabNoticeTimerRef.current !== null) window.clearTimeout(tabNoticeTimerRef.current);
+			clearVisualTransitionTimer();
 		},
-		[],
+		[clearVisualTransitionTimer],
 	);
 
 	useEffect(() => {
@@ -345,14 +404,36 @@ export function useBrowserView({
 		}
 	}, [active, navState.url, poppedOut, scheduleSettleMeasure, sendHiddenBounds]);
 
+	useEffect(() => {
+		if (poppedOutRef.current === poppedOut) return;
+		poppedOutRef.current = poppedOut;
+		if (!hasNativeBrowser || !activeRef.current || !hasUrlRef.current) {
+			scheduleSettleMeasure();
+			return;
+		}
+		measureAndSend();
+		window.setTimeout(() => {
+			measureAndSend();
+		}, 0);
+		scheduleSettleMeasure();
+	}, [hasNativeBrowser, measureAndSend, poppedOut, scheduleSettleMeasure]);
+
 	const stopMirrorStream = useCallback(() => {
 		mirrorStreamRef.current?.getTracks().forEach((track) => track.stop());
 		mirrorStreamRef.current = null;
 		setMirrorStream(null);
 	}, []);
 
+	const prepareForOverlay = useCallback(async () => {
+		const id = viewIdRef.current;
+		if (!id || !hasNativeBrowser || !activeRef.current || !hasUrlRef.current) return;
+		clearMirrorTimer();
+		const frame = await (window.ao?.browser.capture?.(id) ?? Promise.resolve("")).catch(() => "");
+		if (frame && viewIdRef.current === id) setMirrorUrl(frame);
+	}, [clearMirrorTimer, hasNativeBrowser]);
+
 	const runMirror = useCallback(
-		(id: string) => {
+		(id: string, liveFrames = true) => {
 			const token = ++mirrorTokenRef.current;
 			const live = () => mirrorTokenRef.current === token && modalOpenRef.current && viewIdRef.current === id;
 			const streamMirror = async (): Promise<boolean> => {
@@ -375,13 +456,14 @@ export function useBrowserView({
 					const frame = await pending.catch(() => "");
 					if (!live()) return;
 					if (frame) setMirrorUrl(frame);
+					if (!liveFrames) return;
 					await new Promise((resolve) => {
 						window.setTimeout(resolve, 66);
 					});
 				}
 			};
 			const tick = async () => {
-				const streamed = await streamMirror().catch(() => false);
+				const streamed = liveFrames ? await streamMirror().catch(() => false) : false;
 				if (streamed || !live()) return;
 				await frameMirror();
 			};
@@ -392,20 +474,16 @@ export function useBrowserView({
 
 	useEffect(() => {
 		if (!hasNativeBrowser) return;
-		const clearMirrorTimer = () => {
-			if (mirrorTimerRef.current === null) return;
-			window.clearTimeout(mirrorTimerRef.current);
-			mirrorTimerRef.current = null;
-		};
 		const update = () => {
-			const open = document.querySelector(OPEN_DIALOG_OR_MENU_SELECTOR) !== null;
+			const openOverlay = document.querySelector(OPEN_DIALOG_OR_MENU_SELECTOR);
+			const open = openOverlay !== null;
 			if (open === modalOpenRef.current) return;
 			modalOpenRef.current = open;
 			if (open) {
 				clearMirrorTimer();
 				const id = viewIdRef.current;
 				if (id && activeRef.current && hasUrlRef.current) {
-					runMirror(id);
+					runMirror(id, openOverlay?.getAttribute("role") !== "menu");
 					// Park the native view synchronously, in the same tick the overlay
 					// opened. `modalOpenRef` is already true, so measureAndSend() emits
 					// the `parked: true` bounds now instead of a frame later — deferring
@@ -449,7 +527,7 @@ export function useBrowserView({
 			mirrorTokenRef.current += 1;
 			stopMirrorStream();
 		};
-	}, [hasNativeBrowser, measureAndSend, runMirror, scheduleSettleMeasure, sendHiddenBounds, stopMirrorStream]);
+	}, [clearMirrorTimer, hasNativeBrowser, measureAndSend, runMirror, scheduleSettleMeasure, sendHiddenBounds, stopMirrorStream]);
 
 	useEffect(() => {
 		const handle = () => scheduleMeasure();
@@ -497,10 +575,11 @@ export function useBrowserView({
 		async (tabId: string) => {
 			const viewId = viewIdRef.current;
 			if (!viewId || !hasNativeBrowser) return;
+			await showVisualTransition("tab-switch");
 			const state = await window.ao!.browser.selectTab({ viewId, tabId });
 			if (viewIdRef.current === state.viewId) setTabsState(state);
 		},
-		[hasNativeBrowser],
+		[hasNativeBrowser, showVisualTransition],
 	);
 
 	const closeTab = useCallback(
@@ -585,15 +664,18 @@ export function useBrowserView({
 			setAnnotationModeState(false);
 		}
 		mirrorTokenRef.current += 1;
+		clearMirrorTimer();
 		stopMirrorStream();
 		setMirrorUrl("");
+		setVisualTransition(null);
+		clearVisualTransitionTimer();
 		sendHiddenBounds(id);
 		window.ao?.browser.destroy(id);
 		viewIdRef.current = "";
 		setViewId("");
 		setNavState(EMPTY_NAV_STATE);
 		setTabsState(EMPTY_TABS_STATE);
-	}, [sendHiddenBounds, stopMirrorStream]);
+	}, [clearMirrorTimer, clearVisualTransitionTimer, sendHiddenBounds, stopMirrorStream]);
 
 	// Termination invalidates the complete session-owned browser, including all
 	// tabs, captures, profile state, and target mappings. `clear` remains the
@@ -619,7 +701,10 @@ export function useBrowserView({
 		tabNotice,
 		selectTab,
 		closeTab,
+		prepareForOverlay,
 		agentBrowserActive,
+		agentBrowserActivity,
+		visualTransition,
 		destroy,
 		annotationMode,
 		setAnnotationMode,

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2237,7 +2237,26 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	overflow: hidden;
 	border: 1px solid var(--border);
 	border-radius: 8px;
-	background: var(--bg);
+	background:
+		linear-gradient(180deg, color-mix(in srgb, var(--color-bg-secondary) 92%, transparent), transparent 118px),
+		linear-gradient(135deg, color-mix(in srgb, var(--color-accent) 10%, transparent), transparent 42%),
+		var(--bg);
+	box-shadow:
+		0 0 0 1px color-mix(in srgb, var(--color-border) 42%, transparent),
+		0 20px 48px color-mix(in srgb, black 18%, transparent),
+		0 8px 18px color-mix(in srgb, black 10%, transparent);
+	transition:
+		border-color var(--duration-normal) ease,
+		box-shadow var(--duration-normal) ease,
+		background var(--duration-normal) ease;
+}
+
+.browser-panel--agent-active {
+	border-color: color-mix(in srgb, var(--color-accent) 42%, var(--color-border));
+	box-shadow:
+		0 0 0 1px color-mix(in srgb, var(--color-accent) 20%, transparent),
+		0 0 28px color-mix(in srgb, var(--color-accent) 10%, transparent),
+		var(--elevation-sm);
 }
 
 /* Maximized browser overlay: a fixed layer over the app workspace (portaled to
@@ -2250,12 +2269,13 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	position: fixed;
 	inset: env(titlebar-area-height, 0px) 0 0;
 	z-index: 40;
-	background: var(--bg);
+	background: color-mix(in srgb, var(--bg) 94%, black);
 }
 
 .browser-popout-overlay .browser-panel {
 	border: 0;
 	border-radius: 0;
+	box-shadow: none;
 }
 
 .browser-panel__toolbar {
@@ -2264,15 +2284,44 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	gap: 5px;
 	flex-shrink: 0;
 	min-width: 0;
-	padding: 7px;
-	border-bottom: 1px solid var(--border);
-	background: var(--surface);
+	min-height: 44px;
+	padding: 7px 8px;
+	border-bottom: 1px solid color-mix(in srgb, var(--color-border) 72%, transparent);
+	background:
+		linear-gradient(180deg, color-mix(in srgb, var(--surface) 98%, white 2%), var(--surface)),
+		var(--surface);
+	box-shadow:
+		inset 0 1px 0 color-mix(in srgb, white 7%, transparent),
+		0 1px 0 color-mix(in srgb, black 22%, transparent);
+	backdrop-filter: blur(10px);
 }
 
-.browser-panel__url {
+.browser-panel__url,
+.browser-panel__url-wrap {
+	display: flex;
+	align-items: center;
 	position: relative;
 	min-width: 0;
 	flex: 1;
+}
+
+.browser-panel__toolbar button {
+	border-radius: 7px;
+	transition:
+		background var(--duration-fast) ease,
+		color var(--duration-fast) ease,
+		transform var(--duration-fast) ease,
+		box-shadow var(--duration-fast) ease;
+}
+
+.browser-panel__toolbar button:not(:disabled):hover {
+	transform: translateY(-1px);
+	box-shadow: 0 5px 12px color-mix(in srgb, black 12%, transparent);
+}
+
+.browser-panel__toolbar button:not(:disabled):active {
+	transform: translateY(0);
+	box-shadow: none;
 }
 
 .browser-panel__annotate-btn[aria-pressed="true"] {
@@ -2289,6 +2338,9 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	line-height: 1;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	transition:
+		color var(--duration-fast) ease,
+		opacity var(--duration-fast) ease;
 }
 
 .browser-panel__annotation-status--error {
@@ -2298,10 +2350,11 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 
 .browser-panel__url-icon {
 	position: absolute;
-	left: 9px;
+	left: 10px;
 	top: 50%;
-	width: 14px;
-	height: 14px;
+	z-index: 1;
+	width: 15px;
+	height: 15px;
 	transform: translateY(-50%);
 	color: var(--fg-passive);
 	pointer-events: none;
@@ -2310,8 +2363,27 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 .browser-panel__url-input {
 	height: 29px;
 	padding-left: 29px;
+	border-color: color-mix(in srgb, var(--color-border) 72%, transparent);
+	border-radius: 7px;
+	background:
+		linear-gradient(180deg, color-mix(in srgb, var(--bg) 90%, white 2%), var(--bg));
+	box-shadow:
+		inset 0 1px 0 color-mix(in srgb, white 6%, transparent),
+		0 1px 8px color-mix(in srgb, black 9%, transparent);
 	font-family: var(--font-mono);
 	font-size: 12px;
+}
+
+.browser-panel__url-input:focus {
+	box-shadow:
+		0 0 0 3px color-mix(in srgb, var(--color-accent) 18%, transparent),
+		inset 0 1px 0 color-mix(in srgb, white 6%, transparent);
+}
+
+.browser-panel__tabs-trigger {
+	min-width: 42px;
+	border: 1px solid color-mix(in srgb, var(--color-border) 56%, transparent);
+	background: color-mix(in srgb, var(--surface) 86%, var(--bg));
 }
 
 .browser-panel__content {
@@ -2320,6 +2392,42 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	min-height: 0;
 	overflow: hidden;
 	background: var(--bg);
+}
+
+.browser-panel__viewport {
+	position: relative;
+	flex: 1;
+	min-height: 0;
+	margin: 8px;
+	overflow: hidden;
+	border: 0;
+	border-radius: 8px;
+	background:
+		radial-gradient(circle at 50% 0%, color-mix(in srgb, var(--color-accent) 8%, transparent), transparent 34%),
+		var(--bg);
+	box-shadow:
+		inset 0 0 0 1px color-mix(in srgb, var(--color-border) 28%, transparent),
+		inset 0 1px 0 color-mix(in srgb, white 3%, transparent),
+		0 12px 26px color-mix(in srgb, black 14%, transparent);
+}
+
+.browser-popout-overlay .browser-panel__viewport {
+	margin: 0;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+}
+
+.browser-panel__transition-frame {
+	position: absolute;
+	inset: 0;
+	z-index: 2;
+	width: 100%;
+	height: 100%;
+	object-fit: fill;
+	background: var(--bg);
+	pointer-events: none;
+	animation: browser-transition-frame 240ms ease-out forwards;
 }
 
 .browser-panel__slot {
@@ -2354,4 +2462,42 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	background: color-mix(in srgb, var(--red) 8%, var(--bg));
 	color: var(--red);
 	font-size: 12px;
+}
+
+@keyframes browser-transition-frame {
+	0% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
+@keyframes browser-popout-in {
+	from {
+		opacity: 0.94;
+		transform: scale(0.992);
+	}
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.browser-popout-overlay,
+	.browser-panel__transition-frame {
+		animation: none;
+	}
+
+	.browser-panel,
+	.browser-panel__annotation-status,
+	.browser-panel__toolbar button {
+		transition: none;
+	}
+
+	.browser-panel__toolbar button:not(:disabled):hover,
+	.browser-panel__toolbar button:not(:disabled):active {
+		transform: none;
+	}
 }

--- a/frontend/src/shared/browser-annotation-overlay.test.ts
+++ b/frontend/src/shared/browser-annotation-overlay.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { promptPositionForRect } from "./browser-annotation-overlay";
+
+describe("browser annotation overlay helpers", () => {
+	it("places the prompt below the selected element when there is room", () => {
+		expect(
+			promptPositionForRect(
+				{ left: 40, top: 80, bottom: 110 },
+				{ width: 800, height: 600, promptWidth: 360, promptHeight: 150, gutter: 12, gap: 8 },
+			),
+		).toEqual({ left: 40, top: 118 });
+	});
+
+	it("clamps the prompt horizontally and flips above near the viewport bottom", () => {
+		expect(
+			promptPositionForRect(
+				{ left: 760, top: 520, bottom: 560 },
+				{ width: 800, height: 600, promptWidth: 360, promptHeight: 150, gutter: 12, gap: 8 },
+			),
+		).toEqual({ left: 428, top: 362 });
+	});
+});

--- a/frontend/src/shared/browser-annotation-overlay.ts
+++ b/frontend/src/shared/browser-annotation-overlay.ts
@@ -1,0 +1,31 @@
+export type AnnotationRectLike = Pick<DOMRect, "left" | "top" | "bottom">;
+
+export type AnnotationPromptViewport = {
+	width: number;
+	height: number;
+	promptWidth: number;
+	promptHeight: number;
+	gutter: number;
+	gap: number;
+};
+
+export function promptPositionForRect(
+	rect: AnnotationRectLike,
+	viewport: AnnotationPromptViewport,
+): { left: number; top: number } {
+	const left = clamp(
+		rect.left,
+		viewport.gutter,
+		Math.max(viewport.gutter, viewport.width - viewport.promptWidth - viewport.gutter),
+	);
+	const below = rect.bottom + viewport.gap;
+	const top =
+		below + viewport.promptHeight <= viewport.height - viewport.gutter
+			? below
+			: Math.max(viewport.gutter, rect.top - viewport.promptHeight - viewport.gap);
+	return { left, top };
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(max, Math.max(min, value));
+}


### PR DESCRIPTION
## What

Improve the in-app browser UX around native view rendering, tabs, popout, agent activity, and annotations.

## Why

The browser panel felt visually boxy and inconsistent because renderer overlays and the native WebContentsView did not behave as one polished browser surface. Tab overlays could glitch or render behind native content, maximize could show awkward transitions, and annotation/browser-agent feedback needed clearer states.

## How

- Polishes the browser shell, toolbar, URL control, tab menu, and viewport styling.
- Coordinates native WebContentsView bounds, visibility, parking, and radius through the browser host.
- Warms a frame before opening the browser tabs menu so the native view can park without blinking.
- Keeps renderer overlays above the native browser while preserving existing tab selection/closing behavior.
- Improves browser annotation queue UX and agent browser activity labels.

## Testing

- npm.cmd run test -- browser-view-host.test.ts BrowserPanel.test.tsx useBrowserView.test.tsx browser-annotation-overlay.test.ts
- npm.cmd run typecheck
- git diff --check

## Checklist

- [x] Branched from main (continuing this feature branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched