### PR TITLE
fix(terminal): number session tabs, retire dead ones, tidy the strip

### DIFF
--- a/backend/internal/service/shellterm/service.go
+++ b/backend/internal/service/shellterm/service.go
@@ -233,6 +233,23 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 		return ShellTerminal{}, fmt.Errorf("open shell terminal: handle id: %w", err)
 	}
 
+	// Resolve the tab name BEFORE the runtime exists. This reads the store, and
+	// a store failure after Create would strand a PTY that nothing can find:
+	// no row means neither shutdown nor the app-run reaper can ever destroy it.
+	// Doing it here means the only failure that can leave a runtime behind is
+	// the insert below, which already rolls back.
+	//
+	// Counting is safe: the session gate is held for the whole open, so two
+	// concurrent opens for one session cannot pick the same number.
+	title := shellTerminalTitle(workingDir)
+	if in.SessionID != "" {
+		ordinal, err := s.nextSessionTerminalOrdinal(ctx, in.SessionID)
+		if err != nil {
+			return ShellTerminal{}, err
+		}
+		title = sessionShellTerminalTitle(ordinal)
+	}
+
 	// SessionID is the runtime adapters' name for "what to call this PTY"; it
 	// is not a session row and no sessions record is ever created. The
 	// shellterm- prefix keeps the two namespaces disjoint.
@@ -253,7 +270,7 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 		ProjectID:  projectID,
 		SessionID:  in.SessionID,
 		WorkingDir: workingDir,
-		Title:      shellTerminalTitle(workingDir),
+		Title:      title,
 		AppRunID:   s.appRunID,
 		CreatedAt:  s.now().UTC(),
 	}
@@ -498,6 +515,25 @@ func (s *Service) BeginSessionTeardown(ctx context.Context, sessionID domain.Ses
 // It also returns the project the shell ended up attributed to, which is not
 // always the requested one: a session-scoped open may carry no project id, and
 // the session's own project is what the persisted row should record.
+// nextSessionTerminalOrdinal picks the number for a session's next terminal
+// tab. It takes one past the highest number already in use rather than a count,
+// so closing "Terminal 1" while "Terminal 2" is open does not hand the next
+// tab a name that is already on screen. A tab the user renamed no longer
+// matches and simply stops reserving its number.
+func (s *Service) nextSessionTerminalOrdinal(ctx context.Context, sessionID domain.SessionID) (int, error) {
+	recs, err := s.store.SelectShellTerminalsBySessionID(ctx, sessionID)
+	if err != nil {
+		return 0, fmt.Errorf("open shell terminal: count terminals for session %s: %w", sessionID, err)
+	}
+	highest := 0
+	for _, rec := range recs {
+		if n, ok := sessionTerminalOrdinal(rec.Title); ok && n > highest {
+			highest = n
+		}
+	}
+	return highest + 1, nil
+}
+
 func (s *Service) resolveShellTerminalWorkingDir(ctx context.Context, projectID domain.ProjectID, sessionID domain.SessionID) (workingDir string, resolvedProjectID domain.ProjectID, err error) {
 	if sessionID != "" {
 		if s.sessions == nil {

--- a/backend/internal/service/shellterm/service_test.go
+++ b/backend/internal/service/shellterm/service_test.go
@@ -66,8 +66,9 @@ func (f *fakeShellRuntime) IsAlive(_ context.Context, handle ports.RuntimeHandle
 
 // fakeShellTerminalStore is an in-memory Store keyed by handle id.
 type fakeShellTerminalStore struct {
-	records   []ShellTerminalRecord
-	insertErr error
+	records      []ShellTerminalRecord
+	insertErr    error
+	bySessionErr error
 }
 
 func (f *fakeShellTerminalStore) InsertShellTerminal(_ context.Context, rec ShellTerminalRecord) error {
@@ -108,6 +109,9 @@ func (f *fakeShellTerminalStore) SelectShellTerminalsByAppRunID(_ context.Contex
 }
 
 func (f *fakeShellTerminalStore) SelectShellTerminalsBySessionID(_ context.Context, sessionID domain.SessionID) ([]ShellTerminalRecord, error) {
+	if f.bySessionErr != nil {
+		return nil, f.bySessionErr
+	}
 	var out []ShellTerminalRecord
 	for _, rec := range f.records {
 		if rec.SessionID == sessionID {
@@ -1101,5 +1105,109 @@ func TestShellTerminalTitleFallsBackForRootlessPaths(t *testing.T) {
 	}
 	if got := shellTerminalTitle("/repos/portfolio"); got != "portfolio" {
 		t.Errorf("title = %q, want %q", got, "portfolio")
+	}
+}
+
+// Every shell in a session starts in that session's worktree, so naming tabs
+// after the directory put the identical label on all of them. Session tabs are
+// numbered instead; standalone tabs keep the directory, which is what tells
+// shells from different projects apart on /terminals.
+func TestSessionTerminalTitlesAreNumberedWithinTheSession(t *testing.T) {
+	if got := sessionShellTerminalTitle(1); got != "Terminal 1" {
+		t.Errorf("first session tab = %q, want %q", got, "Terminal 1")
+	}
+	if got := sessionShellTerminalTitle(3); got != "Terminal 3" {
+		t.Errorf("third session tab = %q, want %q", got, "Terminal 3")
+	}
+}
+
+func TestSessionTerminalOrdinalOnlyParsesGeneratedTitles(t *testing.T) {
+	for _, tc := range []struct {
+		title string
+		want  int
+		ok    bool
+	}{
+		{"Terminal 1", 1, true},
+		{"Terminal 12", 12, true},
+		{"Terminal 0", 0, false},     // never generated; 1-based
+		{"Terminal", 0, false},       // no number
+		{"Terminal x", 0, false},     // not a number
+		{"my build shell", 0, false}, // user rename stops reserving a number
+		{"portfolio", 0, false},      // a standalone tab's directory title
+	} {
+		got, ok := sessionTerminalOrdinal(tc.title)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("sessionTerminalOrdinal(%q) = (%d, %t), want (%d, %t)", tc.title, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// Closing "Terminal 1" while "Terminal 2" is open must not hand the next tab a
+// name that is already on screen, so the ordinal comes from the highest in use
+// rather than the count.
+func TestNextSessionTerminalOrdinalSkipsNamesStillInUse(t *testing.T) {
+	st := &fakeShellTerminalStore{}
+	svc := newTestService(newFakeShellRuntime(), st, &fakeProjectRootLocator{})
+	ctx := context.Background()
+
+	for _, rec := range []ShellTerminalRecord{
+		{HandleID: "h-2", SessionID: "sess-1", Title: "Terminal 2"},
+		{HandleID: "h-9", SessionID: "sess-1", Title: "my build shell"},
+		{HandleID: "h-1", SessionID: "other", Title: "Terminal 7"},
+	} {
+		if err := st.InsertShellTerminal(ctx, rec); err != nil {
+			t.Fatalf("seed %s: %v", rec.HandleID, err)
+		}
+	}
+
+	got, err := svc.nextSessionTerminalOrdinal(ctx, "sess-1")
+	if err != nil {
+		t.Fatalf("nextSessionTerminalOrdinal: %v", err)
+	}
+	// 3, not 2 (Terminal 2 is still open) and not 8 (another session's tabs
+	// must not push this session's numbering along).
+	if got != 3 {
+		t.Errorf("next ordinal = %d, want 3", got)
+	}
+}
+
+func TestNextSessionTerminalOrdinalStartsAtOne(t *testing.T) {
+	svc := newTestService(newFakeShellRuntime(), &fakeShellTerminalStore{}, &fakeProjectRootLocator{})
+
+	got, err := svc.nextSessionTerminalOrdinal(context.Background(), "sess-empty")
+	if err != nil {
+		t.Fatalf("nextSessionTerminalOrdinal: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("first ordinal = %d, want 1", got)
+	}
+}
+
+// Regression: the tab ordinal is read from the store, and that read used to
+// happen AFTER runtime.Create. A store failure there returned with a live PTY
+// and no row pointing at it, so neither shutdown nor the app-run reaper could
+// ever find it — a tmux session leaked for the life of the machine. The lookup
+// now runs before Create, so this failure cannot strand a runtime at all.
+func TestOpenShellTerminalLeavesNoRuntimeWhenOrdinalLookupFails(t *testing.T) {
+	rt := newFakeShellRuntime()
+	st := &fakeShellTerminalStore{bySessionErr: errors.New("store unavailable")}
+	sessions := &fakeSessionWorkspaceLocator{
+		sessions: map[domain.SessionID]fakeSessionWorkspace{
+			"sess-1": {workspacePath: "/wt/sess-1", projectID: "proj"},
+		},
+	}
+	svc := newTestServiceWithSessions(rt, st, &fakeProjectRootLocator{}, sessions)
+
+	_, err := svc.OpenShellTerminal(context.Background(), OpenShellTerminalInput{SessionID: "sess-1"})
+	if err == nil {
+		t.Fatal("a store failure while naming the tab must fail the open")
+	}
+	// The point of the fix: no PTY was ever spawned, so there is nothing to leak
+	// and nothing to roll back.
+	if len(rt.created) != 0 {
+		t.Fatalf("runtime.Create called %d times; the ordinal lookup must happen first", len(rt.created))
+	}
+	if len(st.records) != 0 {
+		t.Fatalf("store holds %d records after a failed open, want 0", len(st.records))
 	}
 }

--- a/backend/internal/service/shellterm/types.go
+++ b/backend/internal/service/shellterm/types.go
@@ -15,7 +15,10 @@
 package shellterm
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -43,10 +46,11 @@ type OpenShellTerminalInput struct {
 	SessionID domain.SessionID `json:"sessionId,omitempty"`
 }
 
-// shellTerminalTitle labels a tab by the directory the shell started in, which
-// is the only thing that distinguishes one shell pane from another in the UI.
-// A path that has no usable base (a bare root, or an empty string) falls back
-// to a generic label rather than rendering an empty tab.
+// shellTerminalTitle labels a standalone tab by the directory the shell started
+// in. Those shells come from the board or /terminals and can span projects, so
+// the directory is what tells them apart. A path with no usable base (a bare
+// root, or an empty string) falls back to a generic label rather than
+// rendering an empty tab.
 func shellTerminalTitle(workingDir string) string {
 	base := filepath.Base(workingDir)
 	switch base {
@@ -54,4 +58,28 @@ func shellTerminalTitle(workingDir string) string {
 		return "Shell"
 	}
 	return base
+}
+
+// sessionShellTerminalTitle numbers a session's tabs instead of naming them.
+// Every shell in a session starts in that session's worktree, so the directory
+// was identical on every tab and told the user nothing; the session itself is
+// already the first tab in the strip. ordinal is 1-based.
+func sessionShellTerminalTitle(ordinal int) string {
+	return fmt.Sprintf("%s%d", sessionShellTerminalPrefix, ordinal)
+}
+
+const sessionShellTerminalPrefix = "Terminal "
+
+// sessionTerminalOrdinal reads back a title this package generated. A title the
+// user renamed does not parse and reports false, so it stops reserving a number.
+func sessionTerminalOrdinal(title string) (int, bool) {
+	rest, found := strings.CutPrefix(title, sessionShellTerminalPrefix)
+	if !found {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
 }

--- a/frontend/src/renderer/components/AgentAvatar.tsx
+++ b/frontend/src/renderer/components/AgentAvatar.tsx
@@ -70,6 +70,15 @@ type AgentAvatarProps = {
  * hover title, so surfaces that show the logo in place of visible agent text —
  * e.g. the archive cards — still name the agent for screen readers.
  */
+/**
+ * Whether this agent has a real brand mark. Surfaces that only want a logo —
+ * not the initial-letter fallback — can skip rendering entirely; a bare letter
+ * tile is noise in a dense row like the terminal tab strip.
+ */
+export function hasAgentLogo(provider: string): boolean {
+	return Boolean(LOGOS[provider]);
+}
+
 export function AgentAvatar({ provider, className, decorative = false }: AgentAvatarProps) {
 	const logo = LOGOS[provider];
 	if (logo) {

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -15,9 +15,8 @@ import { useUiStore, type Theme } from "../stores/ui-store";
 import type { TerminalTarget } from "../types/terminal";
 import { isOrchestratorSession, type WorkspaceSession } from "../types/workspace";
 import { ShellTerminalTab } from "./ShellTerminalTab";
-import { AgentAvatar } from "./AgentAvatar";
+import { AgentAvatar, hasAgentLogo } from "./AgentAvatar";
 import { TerminalPane } from "./TerminalPane";
-import { AgentAvatar } from "./AgentAvatar";
 import { SessionTopbarPortal } from "./SessionTopbarPortal";
 import { Button } from "./ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -401,7 +400,11 @@ function SessionPaneTab({ label, isActive, onSelect, session }: SessionPaneTabPr
 					: "text-muted-foreground hover:bg-raised hover:text-foreground",
 			)}
 		>
-			{session ? <AgentAvatar className="size-icon-base" decorative provider={session.provider} /> : null}
+			{/* Logo only, never the initial-letter fallback: an agent without a mark
+			    (e.g. the fake harness) would put a bare letter tile in the strip. */}
+			{session?.provider && hasAgentLogo(session.provider) ? (
+				<AgentAvatar className="size-icon-base" decorative provider={session.provider} />
+			) : null}
 			<button
 				ref={ref}
 				aria-current={isActive}

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -15,6 +15,7 @@ import { useUiStore, type Theme } from "../stores/ui-store";
 import type { TerminalTarget } from "../types/terminal";
 import { isOrchestratorSession, type WorkspaceSession } from "../types/workspace";
 import { ShellTerminalTab } from "./ShellTerminalTab";
+import { AgentAvatar } from "./AgentAvatar";
 import { TerminalPane } from "./TerminalPane";
 import { AgentAvatar } from "./AgentAvatar";
 import { SessionTopbarPortal } from "./SessionTopbarPortal";
@@ -377,6 +378,8 @@ export function CenterPane({
 
 type SessionPaneTabProps = {
 	label: string;
+	/** Agent behind this session, shown as its logo so the tab reads as the agent's. */
+	provider?: string;
 	isActive: boolean;
 	onSelect?: () => void;
 	session?: WorkspaceSession;

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -37,6 +37,10 @@ type CenterPaneProps = {
 	onNewShellTerminal?: () => void;
 	/** Session actions consolidated into the terminal bar by SessionView. */
 	topbarActions?: ReactNode;
+	/** A shell pane reported its PTY ended; the owner re-checks with the daemon. */
+	onShellExited?: (handleId: string) => void;
+	/** Bumped to force a fresh attachment when a reported exit turns out false. */
+	attachEpoch?: number;
 };
 
 const terminalFontSizeStorageKey = "ao.terminal.fontSize";
@@ -71,6 +75,8 @@ export function CenterPane({
 	onRenameShellTerminal,
 	onNewShellTerminal,
 	topbarActions,
+	onShellExited,
+	attachEpoch,
 }: CenterPaneProps) {
 	const { t } = useTranslation();
 	const paneRef = useRef<HTMLDivElement | null>(null);
@@ -356,8 +362,10 @@ export function CenterPane({
 				role="tabpanel"
 			>
 				<TerminalPane
+					attachEpoch={attachEpoch}
 					daemonReady={daemonReady}
 					fontSize={fontSize}
+					onShellExited={onShellExited}
 					session={session}
 					terminalTarget={target}
 					theme={theme}

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, type ReactNode, type Ref } from "react";
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { SessionView } from "./SessionView";
 import { useUiStore } from "../stores/ui-store";
@@ -106,6 +106,8 @@ vi.mock("./CenterPane", () => ({
 		onSelectShellTerminal,
 		onSelectSessionTerminal,
 		onNewShellTerminal,
+		onShellExited,
+		attachEpoch,
 	}: {
 		terminalTarget?: { kind: string; handleId?: string };
 		session?: WorkspaceSession;
@@ -114,6 +116,8 @@ vi.mock("./CenterPane", () => ({
 		onSelectShellTerminal?: (handleId: string) => void;
 		onSelectSessionTerminal?: () => void;
 		onNewShellTerminal?: () => void;
+		onShellExited?: (handleId: string) => void;
+		attachEpoch?: number;
 	}) => (
 		<div>
 			terminal center
@@ -122,6 +126,7 @@ vi.mock("./CenterPane", () => ({
 			</div>
 			<div data-testid="session-tab">{session?.title ?? ""}</div>
 			<div data-testid="shell-tabs">{shellTerminals.map((s) => s.title).join(",")}</div>
+			<div data-testid="attach-epoch">{String(attachEpoch ?? 0)}</div>
 			{shellTerminals.map((s) => (
 				<button key={s.handleId} type="button" onClick={() => onSelectShellTerminal?.(s.handleId)}>
 					select {s.title}
@@ -130,6 +135,11 @@ vi.mock("./CenterPane", () => ({
 			{shellTerminals.map((s) => (
 				<button key={`close-${s.handleId}`} type="button" onClick={() => onCloseShellTerminal?.(s.handleId)}>
 					close {s.title}
+				</button>
+			))}
+			{shellTerminals.map((s) => (
+				<button key={`exit-${s.handleId}`} type="button" onClick={() => onShellExited?.(s.handleId)}>
+					report exit {s.title}
 				</button>
 			))}
 			<button type="button" onClick={() => onSelectSessionTerminal?.()}>
@@ -246,11 +256,13 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 }));
 // Standalone shell terminals are orthogonal to the split under test, and their
 // real hooks would need a QueryClientProvider this suite deliberately omits.
+const refreshShellTerminalsMock = vi.fn(async () => shellTerminalsState.data);
 vi.mock("../hooks/useShellTerminals", () => ({
 	useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
 	useOpenShellTerminal: () => ({ mutate: openShellTerminalMock }),
 	useCloseShellTerminal: () => ({ mutate: closeShellTerminalMock }),
 	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
+	useRefreshShellTerminals: () => refreshShellTerminalsMock,
 }));
 
 // jsdom has no layout engine, so the real react-resizable-panels would never
@@ -479,6 +491,56 @@ describe("SessionView", () => {
 		expect(closeShellTerminalMock).toHaveBeenCalledWith("sh-a");
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("worker");
 		expect(useUiStore.getState().activeShellTerminalHandleId).toBeNull();
+	});
+
+	// A pane reporting "exited" is not proof the shell died: the attach loop
+	// reports the same after giving up on a failing liveness probe. If the
+	// daemon still lists the shell it is alive, and the pane — which holds
+	// "exited" forever once it lands there — must be remounted to reconnect,
+	// not left telling the user to close a live terminal.
+	it("re-attaches instead of closing when the daemon still has the shell", async () => {
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				sessionId: "sess-1",
+				title: "Terminal 1",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+		];
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "select Terminal 1" }));
+		expect(screen.getByTestId("attach-epoch")).toHaveTextContent("0");
+
+		fireEvent.click(screen.getByRole("button", { name: "report exit Terminal 1" }));
+
+		await waitFor(() => expect(screen.getByTestId("attach-epoch")).toHaveTextContent("1"));
+		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("Terminal 1");
+		expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("shell");
+	});
+
+	// The other half: the daemon confirms it is gone, so the pane goes back to
+	// the session rather than remounting an attachment to a dead handle.
+	it("hands the pane back to the session when the daemon drops the shell", async () => {
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				sessionId: "sess-1",
+				title: "Terminal 1",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+		];
+		render(<SessionView sessionId="sess-1" />);
+		fireEvent.click(screen.getByRole("button", { name: "select Terminal 1" }));
+		expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("shell");
+
+		shellTerminalsState.data = [];
+		fireEvent.click(screen.getByRole("button", { name: "report exit Terminal 1" }));
+
+		await waitFor(() => expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("worker"));
+		expect(screen.getByTestId("attach-epoch")).toHaveTextContent("0");
 	});
 
 	// Regression: react-resizable-panels v4 treats bare numeric sizes as PIXELS

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -14,6 +14,7 @@ import { useBrowserView } from "../hooks/useBrowserView";
 import {
 	useCloseShellTerminal,
 	useOpenShellTerminal,
+	useRefreshShellTerminals,
 	useRenameShellTerminal,
 	useShellTerminals,
 } from "../hooks/useShellTerminals";
@@ -96,6 +97,8 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	);
 	const openShellTerminal = useOpenShellTerminal();
 	const closeShellTerminal = useCloseShellTerminal();
+	const refreshShellTerminals = useRefreshShellTerminals();
+	const [shellAttachEpochs, setShellAttachEpochs] = useState<Record<string, number>>({});
 	const renameShellTerminal = useRenameShellTerminal();
 	const activeShellTerminalHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
 	const setActiveShellTerminal = useUiStore((state) => state.setActiveShellTerminal);
@@ -141,6 +144,32 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			});
 		},
 		[shellTerminals, setActiveShellTerminal],
+	);
+
+	// A pane reporting "exited" is a hint, not proof: the attach loop reports it
+	// after giving up on a failing liveness probe too. Ask the daemon, then act
+	// on its answer.
+	//
+	// Still in the list -> the shell is alive and this was an attachment
+	// failure. The pane holds "exited" forever once it lands there, so the tab
+	// would sit on "Terminal ended" telling the user to close a live shell.
+	// Bumping the epoch remounts the attachment and reconnects it instead.
+	//
+	// Gone from the list -> the daemon confirmed it died; give the pane back to
+	// the session.
+	const handleShellExited = useCallback(
+		async (handleId: string) => {
+			const shells = await refreshShellTerminals();
+			if (shells.some((shell) => shell.handleId === handleId)) {
+				setShellAttachEpochs((current) => ({ ...current, [handleId]: (current[handleId] ?? 0) + 1 }));
+				return;
+			}
+			setTerminalTarget((current) =>
+				current.kind === "shell" && current.handleId === handleId ? { kind: "worker" } : current,
+			);
+			if (activeShellTerminalHandleId === handleId) setActiveShellTerminal(null);
+		},
+		[activeShellTerminalHandleId, refreshShellTerminals, setActiveShellTerminal],
 	);
 
 	const closeShellTerminalByHandle = useCallback(
@@ -445,8 +474,10 @@ export function SessionView({ sessionId }: SessionViewProps) {
             be strings. Numeric sizes here once clamped the inspector to 45px. */}
 				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%">
 					<CenterPane
+						attachEpoch={terminalTarget.kind === "shell" ? (shellAttachEpochs[terminalTarget.handleId] ?? 0) : 0}
 						daemonReady={daemonStatus.state === "ready"}
 						onCloseShellTerminal={closeShellTerminalByHandle}
+						onShellExited={handleShellExited}
 						onNewShellTerminal={addShellTerminal}
 						onRenameShellTerminal={renameShellTerminalByHandle}
 						onSelectSessionTerminal={selectSessionTerminal}

--- a/frontend/src/renderer/components/ShellTerminalsView.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.test.tsx
@@ -6,6 +6,7 @@ vi.mock("../hooks/useShellTerminals", () => ({
 	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
 	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
 	useShellTerminals: () => ({ data: [] }),
+	useRefreshShellTerminals: () => vi.fn(async () => []),
 }));
 
 vi.mock("../lib/shell-context", () => ({

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -1,9 +1,14 @@
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { defaultShortcutBindings, shortcutBindingLabel } from "../../shared/shortcuts";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
-import { useCloseShellTerminal, useRenameShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
+import {
+	useCloseShellTerminal,
+	useRefreshShellTerminals,
+	useRenameShellTerminal,
+	useShellTerminals,
+} from "../hooks/useShellTerminals";
 import { useShell } from "../lib/shell-context";
 import { aoBridge } from "../lib/bridge";
 import { isMacPlatform } from "../lib/platform";
@@ -31,6 +36,18 @@ export function ShellTerminalsView() {
 	// shells belong to that session's tab strip, not this global list.
 	const shellTerminals = (useShellTerminals().data ?? []).filter((s) => !s.sessionId);
 	const closeShellTerminal = useCloseShellTerminal();
+	const refreshShellTerminals = useRefreshShellTerminals();
+	const [attachEpochs, setAttachEpochs] = useState<Record<string, number>>({});
+	// See SessionView: "exited" is a hint. If the daemon still lists the shell it
+	// is alive and the pane must re-attach rather than sit on "Terminal ended".
+	const handleShellExited = useCallback(
+		async (handleId: string) => {
+			const shells = await refreshShellTerminals();
+			if (!shells.some((shell) => shell.handleId === handleId)) return;
+			setAttachEpochs((current) => ({ ...current, [handleId]: (current[handleId] ?? 0) + 1 }));
+		},
+		[refreshShellTerminals],
+	);
 	const renameShellTerminal = useRenameShellTerminal();
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);
 	const activeHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
@@ -132,6 +149,8 @@ export function ShellTerminalsView() {
 					<TerminalPane
 						daemonReady={daemonStatus.state === "ready"}
 						fontSize={12}
+						attachEpoch={attachEpochs[active.handleId] ?? 0}
+						onShellExited={handleShellExited}
 						terminalTarget={{
 							generation: active.createdAt,
 							kind: "shell",

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -753,3 +753,64 @@ describe("terminal link preview", () => {
 		}
 	});
 });
+
+// A shell whose PTY exits should not sit in the strip showing "TERMINAL ENDED":
+// nothing else tells the client, since the shell list is only refetched around
+// this client's own open/close. The pane reports the exit as a HINT — it is not
+// proof of death, because the attach loop reports the same "exited" after it
+// gives up on a failing liveness probe — so the callers re-check with the
+// daemon rather than closing anything.
+describe("TerminalPane shell exit", () => {
+	function renderShellPane(onShellExited: (handleId: string) => void, state: string) {
+		terminalState.value = state;
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const previousAO = window.ao;
+		window.ao = {} as typeof window.ao;
+		const result = render(
+			<QueryClientProvider client={queryClient}>
+				<TerminalPane
+					daemonReady
+					fontSize={12}
+					onShellExited={onShellExited}
+					terminalTarget={{ kind: "shell", handleId: "sh-a", title: "Terminal 1" }}
+					theme="dark"
+				/>
+			</QueryClientProvider>,
+		);
+		return { ...result, restore: () => { window.ao = previousAO; } };
+	}
+
+	it("reports the exit once so the caller can re-check with the daemon", async () => {
+		const onShellExited = vi.fn();
+		const { restore } = renderShellPane(onShellExited, "exited");
+		await waitFor(() => expect(onShellExited).toHaveBeenCalledWith("sh-a"));
+		expect(onShellExited).toHaveBeenCalledOnce();
+		restore();
+	});
+
+	it("leaves a live shell alone", async () => {
+		const onShellExited = vi.fn();
+		const { restore } = renderShellPane(onShellExited, "attached");
+		await waitFor(() => expect(screen.getByTestId("xterm")).toBeInTheDocument());
+		expect(onShellExited).not.toHaveBeenCalled();
+		restore();
+	});
+
+	// A session pane that ends still has a row, a status, and a restore path, so
+	// its tab must survive. Only shells are retired.
+	it("does not retire a session pane that ended", async () => {
+		const onShellExited = vi.fn();
+		terminalState.value = "exited";
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const previousAO = window.ao;
+		window.ao = {} as typeof window.ao;
+		render(
+			<QueryClientProvider client={queryClient}>
+				<TerminalPane daemonReady fontSize={12} onShellExited={onShellExited} session={worker} theme="dark" />
+			</QueryClientProvider>,
+		);
+		await waitFor(() => expect(screen.getByText("Terminal ended")).toBeInTheDocument());
+		expect(onShellExited).not.toHaveBeenCalled();
+		window.ao = previousAO;
+	});
+});

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -772,7 +772,7 @@ describe("TerminalPane shell exit", () => {
 					daemonReady
 					fontSize={12}
 					onShellExited={onShellExited}
-					terminalTarget={{ kind: "shell", handleId: "sh-a", title: "Terminal 1" }}
+					terminalTarget={{ kind: "shell", handleId: "sh-a", title: "Terminal 1", generation: "2026-07-24T00:00:00Z" }}
 					theme="dark"
 				/>
 			</QueryClientProvider>,

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -46,6 +46,20 @@ type TerminalPaneProps = {
 	fontSize: number;
 	/** Provider-owned shared transport lease factory. */
 	createMux?: () => TerminalMux;
+	/**
+	 * Fired once when a shell pane reports its PTY ended (the user typed `exit`,
+	 * killed the process — or the attach loop gave up). Nothing else tells the
+	 * client: the shell list is only refetched around this client's own
+	 * open/close.
+	 */
+	onShellExited?: (handleId: string) => void;
+	/**
+	 * Bumped to force a fresh attachment for the same handle. A pane that
+	 * reported "exited" holds that state forever, so when the daemon says the
+	 * shell is in fact still alive, the only way back to a live terminal is to
+	 * remount the attachment.
+	 */
+	attachEpoch?: number;
 };
 
 type TerminalCacheDescriptor = {
@@ -110,12 +124,17 @@ function terminalPropsMatch(left: TerminalPaneProps, right: TerminalPaneProps): 
 function cacheDescriptor(
 	session: WorkspaceSession | undefined,
 	terminalTarget: TerminalTarget | undefined,
+	attachEpoch = 0,
 ): TerminalCacheDescriptor | null {
 	if (terminalTarget?.kind === "shell") {
 		if (!terminalTargetBelongsToSession(terminalTarget, session?.id)) return null;
 		const ownerKey = `shell:${session?.id ?? "standalone"}:${terminalTarget.handleId}`;
 		return {
-			cacheKey: `${ownerKey}|handle:${terminalTarget.handleId}|generation:${terminalTarget.generation}`,
+			// The epoch is part of the key, not just the props: a bump must produce
+			// a cache MISS so `activate` discards the old (possibly wedged) entry
+			// for this owner and mounts a fresh one, the same way a new `generation`
+			// already does for a replaced PTY.
+			cacheKey: `${ownerKey}|handle:${terminalTarget.handleId}|generation:${terminalTarget.generation}|epoch:${attachEpoch}`,
 			generation: terminalTarget.generation,
 			handleId: terminalTarget.handleId,
 			kind: "shell",
@@ -635,6 +654,8 @@ export function TerminalPane({
 	daemonReady,
 	terminalTarget: requestedTerminalTarget,
 	fontSize,
+	onShellExited,
+	attachEpoch = 0,
 }: TerminalPaneProps) {
 	const terminalTarget =
 		requestedTerminalTarget &&
@@ -646,6 +667,9 @@ export function TerminalPane({
 		terminalTarget?.kind === "reviewer" || terminalTarget?.kind === "shell"
 			? terminalTarget.handleId
 			: (session?.terminalHandleId ?? "empty");
+	// The epoch is folded into the key too so the non-cached fallback below
+	// remounts on a bump the same way the cached path's cacheKey does.
+	const attachKey = `${terminalKey}:${attachEpoch}`;
 
 	if (!window.ao) {
 		// A standalone shell has no agent and no branch, so it previews as a plain
@@ -698,19 +722,20 @@ export function TerminalPane({
 		);
 	}
 
-	const props = { session, theme, daemonReady, terminalTarget, fontSize };
-	const descriptor = cacheDescriptor(session, terminalTarget);
+	const props = { session, theme, daemonReady, terminalTarget, fontSize, onShellExited };
+	const descriptor = cacheDescriptor(session, terminalTarget, attachEpoch);
 	if (cache && descriptor) {
 		return <CachedTerminalSlot descriptor={descriptor} props={props} />;
 	}
 
 	return (
 		<AttachedTerminal
-			key={terminalKey}
+			key={attachKey}
 			session={session}
 			theme={theme}
 			daemonReady={daemonReady}
 			fontSize={fontSize}
+			onShellExited={onShellExited}
 			terminalTarget={terminalTarget}
 		/>
 	);
@@ -853,6 +878,7 @@ function AttachedTerminal({
 	terminalTarget,
 	fontSize,
 	createMux,
+	onShellExited,
 	isVisible = true,
 	onFatal,
 	onTerminalReady,
@@ -933,6 +959,30 @@ function AttachedTerminal({
 			current = false;
 		};
 	}, [replayPaintPending, replaySettled, terminal]);
+	// A shell whose PTY exits leaves a tab that can never be attached again, so
+	// retire it instead of parking a dead pane in the strip.
+	//
+	// This is a HINT, never a close. "exited" does not prove the shell died:
+	// attach() reaches the same state after the liveness probe or the attach
+	// itself errors past the retry cap, and a probe error is not proof of
+	// death. Destroying on that would kill a live shell and whatever is
+	// running in it. So this only asks the daemon to re-check — its list
+	// prunes a shell it can confirm is gone and deliberately KEEPS one whose
+	// probe errored.
+	//
+	// Reported once per pane: the component is keyed by handle (+ attach
+	// epoch), so a later shell on the same tab, or a forced re-attach, mounts
+	// fresh. Only for shells — a session pane that ends still has a row, a
+	// status, and a restore path, so its tab must stay.
+	const reportedShellExitRef = useRef(false);
+	useEffect(() => {
+		if (state !== "exited") return;
+		if (terminalTarget?.kind !== "shell") return;
+		if (reportedShellExitRef.current) return;
+		reportedShellExitRef.current = true;
+		onShellExited?.(terminalTarget.handleId);
+	}, [state, terminalTarget, onShellExited]);
+
 	const handleId = shellTerminalHandleId ?? attachSession?.terminalHandleId;
 	const provider = terminalTarget?.kind === "reviewer" ? terminalTarget.harness : session?.provider;
 	const isSessionActive = session ? sessionIsActive(session) : false;

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -4,6 +4,7 @@
 // must not invalidate session state when they come and go.
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 import type { components } from "../../api/schema";
 import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { mockShellTerminals } from "../lib/mock-data";
@@ -40,6 +41,20 @@ function toShellTerminal(t: components["schemas"]["ShellTerminalResponse"]): She
 let previewShellTerminals: ShellTerminal[] = [...mockShellTerminals];
 let previewShellSeq = 0;
 
+// Same rule the daemon uses: one past the highest number already on screen for
+// this session, so closing "Terminal 1" does not hand the next tab that name
+// while "Terminal 2" is still open.
+function previewSessionTerminalTitle(sessionId: string): string {
+	const highest = previewShellTerminals
+		.filter((shell) => shell.sessionId === sessionId)
+		.reduce((max, shell) => {
+			const match = /^Terminal (\d+)$/.exec(shell.title);
+			const n = match ? Number(match[1]) : 0;
+			return n > max ? n : max;
+		}, 0);
+	return `Terminal ${highest + 1}`;
+}
+
 async function fetchShellTerminals(): Promise<ShellTerminal[]> {
 	if (usePreviewData) {
 		return previewShellTerminals;
@@ -65,6 +80,26 @@ export function useShellTerminals() {
 	return useQuery(shellTerminalsQueryOptions);
 }
 
+/**
+ * Asks the daemon to re-check its shell list and resolves to the refreshed
+ * list. Used when a pane reports that its PTY ended: that signal is not proof
+ * of death (the attach loop reports the same "exited" after it gives up on a
+ * failing liveness probe), so the client must not close anything itself. The
+ * daemon's list prunes only shells it can confirm are gone and keeps ones whose
+ * probe errored, which is exactly the conservative rule this needs.
+ *
+ * The returned list is what tells the caller which happened: a handle still in
+ * it means the shell is alive and the pane must re-attach rather than sit on a
+ * stale "exited".
+ */
+export function useRefreshShellTerminals() {
+	const queryClient = useQueryClient();
+	return useCallback(async (): Promise<ShellTerminal[]> => {
+		await queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+		return queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? [];
+	}, [queryClient]);
+}
+
 export type OpenShellTerminalInput = { projectId?: string; sessionId?: string };
 
 /**
@@ -78,12 +113,18 @@ export function useOpenShellTerminal() {
 		mutationFn: async ({ projectId, sessionId }: OpenShellTerminalInput = {}): Promise<ShellTerminal> => {
 			if (usePreviewData) {
 				previewShellSeq += 1;
+				// Mirror the daemon: a session's shells start in that session's
+				// worktree and are numbered within it, standalone shells start in
+				// the project root and are named after it. The mock used to stamp
+				// the project name on every tab, which is not what the app does.
 				const shell: ShellTerminal = {
 					handleId: `shellterm-preview-${previewShellSeq}`,
 					projectId,
 					sessionId,
-					workingDir: `/Users/demo/Projects/${projectId ?? "ao"}`,
-					title: projectId ?? "shell",
+					workingDir: sessionId
+						? `/Users/demo/.ao/data/worktrees/${projectId ?? "ao"}/${sessionId}`
+						: `/Users/demo/Projects/${projectId ?? "ao"}`,
+					title: sessionId ? previewSessionTerminalTitle(sessionId) : (projectId ?? "shell"),
 					createdAt: new Date().toISOString(),
 				};
 				previewShellTerminals = [...previewShellTerminals, shell];
@@ -117,8 +158,19 @@ export function useCloseShellTerminal() {
 			});
 			if (error) throw error;
 		},
+		// Drop the tab before the request goes out. The daemon's DELETE reaps the
+		// pane's leftover processes before it answers, so waiting on the round
+		// trip left a dead tab on screen for seconds after the click.
+		onMutate: async (handleId) => {
+			await queryClient.cancelQueries({ queryKey: shellTerminalsQueryKey });
+			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
+				(current ?? []).filter((shell) => shell.handleId !== handleId),
+			);
+		},
 		// Settled, not success: a close that 404s means the daemon already lost
-		// the shell, and the stale tab still needs to disappear.
+		// the shell, and the stale tab still needs to disappear. This refetch is
+		// also the rollback — a close that genuinely failed leaves the shell in
+		// the daemon's list, so it comes straight back into the strip.
 		onSettled: () => {
 			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
 		},


### PR DESCRIPTION
Replaces https://github.com/Untrivial-ai/agent-orchestrator/pull/3298, which conflicted with `main` and is now largely redundant.

## Why a new branch

https://github.com/Untrivial-ai/agent-orchestrator/pull/3275 landed the same cross-session removal #3298 was carrying: the dropdown gone, `+` calling `onNewShellTerminal` directly, and the same props dropped (`projectSessions`, `availableProjectSessions`, `onAddProjectSession`, `onCloseProjectSession`, `onSelectProjectSession`, `tabOwnerSessionId`), plus `sessionTabsByOwner` and the `tabOwner` search param. Resolving #3298's five conflicting files would have meant merging duplicate code, so this is only the part `main` does not already have, rebuilt on top of it.

It also carries https://github.com/Untrivial-ai/agent-orchestrator/pull/3329, which was merged into #3298's branch rather than `main` and so never reached it, including all three review fixes from that PR.

## Changes

**Naming.** Every shell in a session starts in that session's worktree, so `filepath.Base(workingDir)` put the identical label on every tab — three terminals in one session all read `ao-22`. Session tabs are numbered instead; the session is already the first tab in the strip. Standalone shells (board, `/terminals`) keep the directory name, which is what tells shells from different projects apart there.

The number is **one past the highest still in use**, not a count, so closing `Terminal 1` while `Terminal 2` is open does not hand the next tab a name already on screen. A renamed tab no longer parses and stops reserving its number.

**Exit handling.** A shell whose PTY ended left a tab that could never be attached again. The daemon already prunes dead shells on list, but nothing told the client — the list is only refetched around this client's own open/close.

The pane now reports the exit as a **hint, never a close**. `attachment.fail()` reaches the same `markExited()` after the liveness probe or the attach errors past the retry cap, and the attach loop's own comment says a probe error is not proof of death — destroying on that would kill a live shell and whatever is running in it. So the renderer asks the daemon, whose list prunes only what it can confirm is gone and keeps anything whose probe errored. If the shell is still listed, the attachment is remounted (an attach epoch in `TerminalPane`'s key) so the pane reconnects rather than sitting on "Terminal ended" over a live shell.

**Ordering.** The ordinal is resolved before `runtime.Create`, so a store failure cannot leave a PTY with no row pointing at it — nothing could then find it to reap.

**Strip chrome.** The `TERMINAL` heading is gone; the tabs already say what it is. That exposed a second gap: the scroll chevrons were hidden with `invisible`, which is `visibility: hidden` and still reserves the full box, leaving a dead column before the first tab. They collapse to zero size now and stay mounted so focus is not dropped mid-scroll.

**Preview mock.** It stamped the project name on every tab, which the daemon never produces, making the browser dev build misleading.

## Verification

Driven against a real daemon (isolated `HOME`, scratch data dir, own port) with a real session via `--harness fake`, on this branch's code:

```
### session terminals are numbered
  open -> Terminal 1
  open -> Terminal 2
  open -> Terminal 3

### close Terminal 1, open again -> must not reissue a live name
  after close: ['Terminal 2', 'Terminal 3']
  next open  -> Terminal 4

### standalone open in the same daemon still uses the directory
  -> data
```

Also driven earlier against a real daemon: a shell whose tmux session is killed out from under it disappears from `GET /shell-terminals`, the daemon half of the exit path.

`npm test` 1286 passing, `npm run typecheck` clean, Go build and the shellterm/tmux package tests pass, `gofmt` clean.

The regression tests were each checked to fail without their fix: the false-exit test fails without the epoch bump, and the leaked-runtime test fails with the old `Create`-then-lookup ordering.

## Not verified by running

The renderer's retire-on-exit needs a live PTY, which only exists in the Electron app. The daemon prune and the renderer's reporting are each covered, but not the two joined end to end.

## Known limitation

Only the attached pane notices an exit. A background tab whose shell dies lingers until you select it or open/close something. The real fix is a daemon push when a PTY dies rather than polling the list.
