### PR TITLE
fix(inspector): dedup PR summaries across whole merged result

### DIFF
--- a/frontend/src/renderer/lib/pr-display.test.ts
+++ b/frontend/src/renderer/lib/pr-display.test.ts
@@ -101,6 +101,156 @@ describe("sessionPRDisplaySummaries", () => {
 		expect(fallback.createdAt).toBeUndefined();
 		expect(fallback.stateChangedAt).toBeUndefined();
 	});
+
+	it("deduplicates entries when summaries contain duplicate PR numbers", () => {
+		const session: WorkspaceSession = {
+			id: "sess-dup",
+			workspaceId: "ws-1",
+			workspaceName: "repo",
+			title: "Dup test",
+			provider: "codex",
+			branch: "main",
+			status: "working",
+			updatedAt: "2026-06-15T12:00:00Z",
+			prs: [
+				{
+					url: "https://github.com/acme/repo/pull/7",
+					number: 7,
+					state: "open",
+					ci: "passing",
+					review: "none",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T11:00:00Z",
+				},
+			],
+		};
+
+		const result = sessionPRDisplaySummaries(session, [summary({ number: 7 }), summary({ number: 7 })]);
+		expect(result).toHaveLength(1);
+		expect(result[0].number).toBe(7);
+	});
+
+	it("never carries PRs from one session into another", () => {
+		const sessionA: WorkspaceSession = {
+			id: "sess-a",
+			workspaceId: "ws-1",
+			workspaceName: "repo",
+			title: "Session A",
+			provider: "codex",
+			branch: "feat/a",
+			status: "working",
+			updatedAt: "2026-06-15T12:00:00Z",
+			prs: [
+				{
+					url: "https://github.com/acme/repo/pull/1",
+					number: 1,
+					state: "open",
+					ci: "passing",
+					review: "none",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T11:00:00Z",
+				},
+			],
+		};
+		const sessionB: WorkspaceSession = {
+			id: "sess-b",
+			workspaceId: "ws-1",
+			workspaceName: "repo",
+			title: "Session B",
+			provider: "codex",
+			branch: "feat/b",
+			status: "working",
+			updatedAt: "2026-06-15T12:00:00Z",
+			prs: [
+				{
+					url: "https://github.com/acme/repo/pull/2",
+					number: 2,
+					state: "open",
+					ci: "passing",
+					review: "none",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T11:00:00Z",
+				},
+			],
+		};
+
+		const resultA = sessionPRDisplaySummaries(sessionA);
+		const resultB = sessionPRDisplaySummaries(sessionB);
+
+		expect(resultA).toHaveLength(1);
+		expect(resultA[0].number).toBe(1);
+		expect(resultB).toHaveLength(1);
+		expect(resultB[0].number).toBe(2);
+	});
+
+	it("merges facts and enriched summaries without duplication", () => {
+		const session: WorkspaceSession = {
+			id: "sess-merge",
+			workspaceId: "ws-1",
+			workspaceName: "repo",
+			title: "Merge test",
+			provider: "codex",
+			branch: "feat/merge",
+			status: "working",
+			updatedAt: "2026-06-15T12:00:00Z",
+			prs: [
+				{
+					url: "https://github.com/acme/repo/pull/7",
+					number: 7,
+					state: "open",
+					ci: "passing",
+					review: "none",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T11:00:00Z",
+				},
+			],
+		};
+
+		const enriched = summary({ number: 7, title: "Enriched title", author: "bot" });
+		const result = sessionPRDisplaySummaries(session, [enriched]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].title).toBe("Enriched title");
+		expect(result[0].author).toBe("bot");
+	});
+
+	it("includes summary-only PRs that have no corresponding fact", () => {
+		const session: WorkspaceSession = {
+			id: "sess-summary-only",
+			workspaceId: "ws-1",
+			workspaceName: "repo",
+			title: "Summary only",
+			provider: "codex",
+			branch: "main",
+			status: "working",
+			updatedAt: "2026-06-15T12:00:00Z",
+			prs: [],
+		};
+
+		const result = sessionPRDisplaySummaries(session, [summary({ number: 42 })]);
+		expect(result).toHaveLength(1);
+		expect(result[0].number).toBe(42);
+	});
+
+	it("returns empty when session has no PRs and no summaries", () => {
+		const session: WorkspaceSession = {
+			id: "sess-empty",
+			workspaceId: "ws-1",
+			workspaceName: "repo",
+			title: "Empty",
+			provider: "codex",
+			branch: "main",
+			status: "working",
+			updatedAt: "2026-06-15T12:00:00Z",
+			prs: [],
+		};
+
+		expect(sessionPRDisplaySummaries(session)).toEqual([]);
+	});
 });
 
 describe("prSummaryParts", () => {

--- a/frontend/src/renderer/lib/pr-display.test.ts
+++ b/frontend/src/renderer/lib/pr-display.test.ts
@@ -28,6 +28,18 @@ const summary = (overrides: Partial<SessionPRSummary> = {}): SessionPRSummary =>
 	...overrides,
 });
 
+const session = (prs: WorkspaceSession["prs"]): WorkspaceSession => ({
+	id: "sess-1",
+	workspaceId: "ws-1",
+	workspaceName: "repo",
+	title: "Fix timing",
+	provider: "codex",
+	branch: "feat/timing",
+	status: "review_pending",
+	updatedAt: "2026-06-15T12:00:00Z",
+	prs,
+});
+
 describe("prStatusRows", () => {
 	it("formats the three PR states without exposing raw unknown", () => {
 		const rows = prStatusRows(
@@ -72,16 +84,8 @@ describe("prBrowserUrl", () => {
 
 describe("sessionPRDisplaySummaries", () => {
 	it("leaves lifecycle timing absent for fallback PR facts until provider times arrive", () => {
-		const session: WorkspaceSession = {
-			id: "sess-1",
-			workspaceId: "ws-1",
-			workspaceName: "repo",
-			title: "Fix timing",
-			provider: "codex",
-			branch: "feat/timing",
-			status: "review_pending",
-			updatedAt: "2026-06-15T12:00:00Z",
-			prs: [
+		const [fallback] = sessionPRDisplaySummaries(
+			session([
 				{
 					url: "https://github.com/acme/repo/pull/7",
 					number: 7,
@@ -92,164 +96,235 @@ describe("sessionPRDisplaySummaries", () => {
 					reviewComments: false,
 					updatedAt: "2026-06-15T11:00:00Z",
 				},
-			],
-		};
-
-		const [fallback] = sessionPRDisplaySummaries(session);
+			]),
+		);
 
 		expect(fallback.updatedAt).toBe("2026-06-15T11:00:00Z");
 		expect(fallback.createdAt).toBeUndefined();
 		expect(fallback.stateChangedAt).toBeUndefined();
 	});
 
-	it("deduplicates entries when summaries contain duplicate PR numbers", () => {
-		const session: WorkspaceSession = {
-			id: "sess-dup",
-			workspaceId: "ws-1",
-			workspaceName: "repo",
-			title: "Dup test",
-			provider: "codex",
-			branch: "main",
-			status: "working",
-			updatedAt: "2026-06-15T12:00:00Z",
-			prs: [
+	it("deduplicates repeated API summaries before rendering", () => {
+		const got = sessionPRDisplaySummaries(session([]), [
+			summary({ number: 7, title: "first observed PR #7" }),
+			summary({ number: 7, title: "duplicate PR #7" }),
+			summary({ number: 8, title: "PR #8" }),
+		]);
+
+		expect(got.map((pr) => pr.number)).toEqual([7, 8]);
+		expect(got[0].title).toBe("first observed PR #7");
+	});
+
+	it("keeps same-number PRs from different repositories distinct", () => {
+		const got = sessionPRDisplaySummaries(session([]), [
+			summary({
+				url: "https://github.com/acme/api/pull/7",
+				htmlUrl: "https://github.com/acme/api/pull/7",
+				repo: "acme/api",
+				number: 7,
+				title: "API PR #7",
+			}),
+			summary({
+				url: "https://github.com/acme/web/pull/7",
+				htmlUrl: "https://github.com/acme/web/pull/7",
+				repo: "acme/web",
+				number: 7,
+				title: "Web PR #7",
+			}),
+		]);
+
+		expect(got.map((pr) => pr.title)).toEqual(["API PR #7", "Web PR #7"]);
+	});
+
+	it("keeps same-number PRs with the same repository basename from different owners distinct", () => {
+		const got = sessionPRDisplaySummaries(session([]), [
+			summary({
+				url: "https://github.com/acme/repo/pull/7",
+				htmlUrl: "https://github.com/acme/repo/pull/7",
+				repo: "acme/repo",
+				number: 7,
+				title: "Acme PR #7",
+				headSha: "acme-head",
+			}),
+			summary({
+				url: "https://github.com/other/repo/pull/7",
+				htmlUrl: "https://github.com/other/repo/pull/7",
+				repo: "other/repo",
+				number: 7,
+				title: "Other PR #7",
+				headSha: "other-head",
+			}),
+		]);
+
+		expect(got.map((pr) => pr.title)).toEqual(["Acme PR #7", "Other PR #7"]);
+	});
+
+	it("deduplicates transferred GitHub repository aliases", () => {
+		const got = sessionPRDisplaySummaries(session([]), [
+			summary({
+				url: "https://github.com/AgentWrapper/agent-orchestrator/pull/3193",
+				htmlUrl: "https://github.com/AgentWrapper/agent-orchestrator/pull/3193",
+				repo: "AgentWrapper/agent-orchestrator",
+				number: 3193,
+				title: "first observed alias",
+			}),
+			summary({
+				url: "https://github.com/Untrivial-ai/agent-orchestrator/pull/3193",
+				htmlUrl: "https://github.com/Untrivial-ai/agent-orchestrator/pull/3193",
+				repo: "Untrivial-ai/agent-orchestrator",
+				number: 3193,
+				title: "duplicate transferred alias",
+			}),
+		]);
+
+		expect(got).toHaveLength(1);
+		expect(got[0].title).toBe("first observed alias");
+	});
+
+	it("uses the enriched summary for a unique session fact when URL identities differ", () => {
+		const got = sessionPRDisplaySummaries(
+			session([
+				{
+					url: "https://example.com/pr/8",
+					number: 8,
+					state: "draft",
+					ci: "pending",
+					review: "none",
+					mergeability: "unknown",
+					reviewComments: false,
+					updatedAt: "2026-06-15T10:00:00Z",
+				},
+			]),
+			[
+				summary({
+					number: 8,
+					url: "https://api.github.com/repos/acme/repo/pulls/8",
+					htmlUrl: "https://github.com/acme/repo/pull/8",
+					title: "enriched PR #8",
+				}),
+			],
+		);
+
+		expect(got).toHaveLength(1);
+		expect(got[0]).toMatchObject({
+			number: 8,
+			title: "enriched PR #8",
+			htmlUrl: "https://github.com/acme/repo/pull/8",
+		});
+	});
+
+	it("keeps a same-number summary for another repository after an exact fact match", () => {
+		const got = sessionPRDisplaySummaries(
+			session([
+				{
+					url: "https://github.com/acme/api/pull/7",
+					number: 7,
+					state: "open",
+					ci: "passing",
+					review: "approved",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T10:00:00Z",
+				},
+			]),
+			[
+				summary({
+					url: "https://github.com/acme/api/pull/7",
+					htmlUrl: "https://github.com/acme/api/pull/7",
+					repo: "acme/api",
+					number: 7,
+					title: "API PR #7",
+				}),
+				summary({
+					url: "https://github.com/acme/web/pull/7",
+					htmlUrl: "https://github.com/acme/web/pull/7",
+					repo: "acme/web",
+					number: 7,
+					title: "Web PR #7",
+				}),
+			],
+		);
+
+		expect(got.map((pr) => pr.title)).toEqual(["API PR #7", "Web PR #7"]);
+	});
+
+	it("deduplicates repeated session facts and uses the enriched summary for the surviving card", () => {
+		const got = sessionPRDisplaySummaries(
+			session([
+				{
+					url: "https://github.com/acme/repo/pull/7",
+					number: 7,
+					state: "open",
+					ci: "pending",
+					review: "none",
+					mergeability: "unknown",
+					reviewComments: false,
+					updatedAt: "2026-06-15T10:00:00Z",
+				},
+				{
+					url: "https://github.com/acme/repo/issues/7",
+					number: 7,
+					state: "open",
+					ci: "passing",
+					review: "approved",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T11:00:00Z",
+				},
+			]),
+			[
+				summary({ number: 7, title: "enriched PR #7", ci: { state: "passing", failingChecks: [] } }),
+				summary({ number: 7, title: "duplicate enriched PR #7" }),
+			],
+		);
+
+		expect(got).toHaveLength(1);
+		expect(got[0]).toMatchObject({ number: 7, title: "enriched PR #7", ci: { state: "passing" } });
+	});
+
+	it("keeps the next selected session's PR list independent after a duplicated list", () => {
+		const firstSelection = sessionPRDisplaySummaries(
+			session([
 				{
 					url: "https://github.com/acme/repo/pull/7",
 					number: 7,
 					state: "open",
 					ci: "passing",
-					review: "none",
+					review: "approved",
 					mergeability: "mergeable",
 					reviewComments: false,
-					updatedAt: "2026-06-15T11:00:00Z",
+					updatedAt: "2026-06-15T10:00:00Z",
 				},
-			],
-		};
-
-		const result = sessionPRDisplaySummaries(session, [summary({ number: 7 }), summary({ number: 7 })]);
-		expect(result).toHaveLength(1);
-		expect(result[0].number).toBe(7);
-	});
-
-	it("never carries PRs from one session into another", () => {
-		const sessionA: WorkspaceSession = {
-			id: "sess-a",
-			workspaceId: "ws-1",
-			workspaceName: "repo",
-			title: "Session A",
-			provider: "codex",
-			branch: "feat/a",
-			status: "working",
-			updatedAt: "2026-06-15T12:00:00Z",
-			prs: [
 				{
-					url: "https://github.com/acme/repo/pull/1",
-					number: 1,
-					state: "open",
-					ci: "passing",
-					review: "none",
-					mergeability: "mergeable",
-					reviewComments: false,
-					updatedAt: "2026-06-15T11:00:00Z",
-				},
-			],
-		};
-		const sessionB: WorkspaceSession = {
-			id: "sess-b",
-			workspaceId: "ws-1",
-			workspaceName: "repo",
-			title: "Session B",
-			provider: "codex",
-			branch: "feat/b",
-			status: "working",
-			updatedAt: "2026-06-15T12:00:00Z",
-			prs: [
-				{
-					url: "https://github.com/acme/repo/pull/2",
-					number: 2,
-					state: "open",
-					ci: "passing",
-					review: "none",
-					mergeability: "mergeable",
-					reviewComments: false,
-					updatedAt: "2026-06-15T11:00:00Z",
-				},
-			],
-		};
-
-		const resultA = sessionPRDisplaySummaries(sessionA);
-		const resultB = sessionPRDisplaySummaries(sessionB);
-
-		expect(resultA).toHaveLength(1);
-		expect(resultA[0].number).toBe(1);
-		expect(resultB).toHaveLength(1);
-		expect(resultB[0].number).toBe(2);
-	});
-
-	it("merges facts and enriched summaries without duplication", () => {
-		const session: WorkspaceSession = {
-			id: "sess-merge",
-			workspaceId: "ws-1",
-			workspaceName: "repo",
-			title: "Merge test",
-			provider: "codex",
-			branch: "feat/merge",
-			status: "working",
-			updatedAt: "2026-06-15T12:00:00Z",
-			prs: [
-				{
-					url: "https://github.com/acme/repo/pull/7",
+					url: "https://github.com/acme/repo/issues/7",
 					number: 7,
 					state: "open",
 					ci: "passing",
-					review: "none",
+					review: "approved",
 					mergeability: "mergeable",
 					reviewComments: false,
 					updatedAt: "2026-06-15T11:00:00Z",
 				},
-			],
-		};
+			]),
+			[summary({ number: 7 }), summary({ number: 7 })],
+		);
+		const nextSelection = sessionPRDisplaySummaries(
+			session([
+				{
+					url: "https://github.com/acme/repo/pull/9",
+					number: 9,
+					state: "open",
+					ci: "passing",
+					review: "approved",
+					mergeability: "mergeable",
+					reviewComments: false,
+					updatedAt: "2026-06-15T12:00:00Z",
+				},
+			]),
+		);
 
-		const enriched = summary({ number: 7, title: "Enriched title", author: "bot" });
-		const result = sessionPRDisplaySummaries(session, [enriched]);
-
-		expect(result).toHaveLength(1);
-		expect(result[0].title).toBe("Enriched title");
-		expect(result[0].author).toBe("bot");
-	});
-
-	it("includes summary-only PRs that have no corresponding fact", () => {
-		const session: WorkspaceSession = {
-			id: "sess-summary-only",
-			workspaceId: "ws-1",
-			workspaceName: "repo",
-			title: "Summary only",
-			provider: "codex",
-			branch: "main",
-			status: "working",
-			updatedAt: "2026-06-15T12:00:00Z",
-			prs: [],
-		};
-
-		const result = sessionPRDisplaySummaries(session, [summary({ number: 42 })]);
-		expect(result).toHaveLength(1);
-		expect(result[0].number).toBe(42);
-	});
-
-	it("returns empty when session has no PRs and no summaries", () => {
-		const session: WorkspaceSession = {
-			id: "sess-empty",
-			workspaceId: "ws-1",
-			workspaceName: "repo",
-			title: "Empty",
-			provider: "codex",
-			branch: "main",
-			status: "working",
-			updatedAt: "2026-06-15T12:00:00Z",
-			prs: [],
-		};
-
-		expect(sessionPRDisplaySummaries(session)).toEqual([]);
+		expect(firstSelection.map((pr) => pr.number)).toEqual([7]);
+		expect(nextSelection.map((pr) => pr.number)).toEqual([9]);
 	});
 });
 

--- a/frontend/src/renderer/lib/pr-display.ts
+++ b/frontend/src/renderer/lib/pr-display.ts
@@ -60,13 +60,19 @@ export function sessionPRDisplaySummaries(
 	summaries: SessionPRSummary[] = [],
 ): SessionPRSummary[] {
 	const summariesByNumber = new Map(summaries.map((summary) => [summary.number, summary]));
-	const seen = new Set<number>();
-	const fromFacts = sortedPRs(session).map((pr) => {
-		seen.add(pr.number);
-		return summariesByNumber.get(pr.number) ?? sessionPRFactToSummary(session, pr);
-	});
-	const summaryOnly = summaries.filter((summary) => !seen.has(summary.number));
-	return [...fromFacts, ...summaryOnly].sort(comparePRDisplaySummaries);
+	const result = new Map<number, SessionPRSummary>();
+
+	for (const pr of sortedPRs(session)) {
+		result.set(pr.number, summariesByNumber.get(pr.number) ?? sessionPRFactToSummary(session, pr));
+	}
+
+	for (const summary of summaries) {
+		if (!result.has(summary.number)) {
+			result.set(summary.number, summary);
+		}
+	}
+
+	return [...result.values()].sort(comparePRDisplaySummaries);
 }
 
 function sessionPRFactToSummary(session: WorkspaceSession, pr: PullRequestFacts): SessionPRSummary {

--- a/frontend/src/renderer/lib/pr-display.ts
+++ b/frontend/src/renderer/lib/pr-display.ts
@@ -1,5 +1,6 @@
 import type { SessionPRSummary } from "../hooks/useSessionScmSummary";
 import { sortedPRs, type PRState, type PullRequestFacts, type WorkspaceSession } from "../types/workspace";
+import { appI18n, type PluralMessageKey } from "../i18n";
 
 const prStateRank: Record<PRState, number> = { open: 0, draft: 1, merged: 2, closed: 3 };
 const ciStates = new Set<SessionPRSummary["ci"]["state"]>(["unknown", "pending", "passing", "failing"]);
@@ -28,6 +29,16 @@ export type PRStatusRow = {
 };
 
 export type PRSummaryPartKey = "ci" | "review" | "merge";
+export type PRNoun = "check" | "comment" | "file" | "line" | "reason" | "reviewer";
+
+export const prNounKeys: Record<PRNoun, PluralMessageKey> = {
+	check: "pr.noun.check",
+	comment: "pr.noun.comment",
+	file: "pr.noun.file",
+	line: "pr.noun.line",
+	reason: "pr.noun.reason",
+	reviewer: "pr.noun.reviewer",
+};
 
 export type PRSummaryLink = {
 	label: string;
@@ -43,7 +54,7 @@ export type PRSummaryPart = {
 	links: PRSummaryLink[];
 	linkTotal?: number;
 	overflowLabel?: string;
-	overflowNoun?: string;
+	overflowNoun?: PRNoun;
 	tone: PRDisplayTone;
 };
 
@@ -59,20 +70,145 @@ export function sessionPRDisplaySummaries(
 	session: WorkspaceSession,
 	summaries: SessionPRSummary[] = [],
 ): SessionPRSummary[] {
-	const summariesByNumber = new Map(summaries.map((summary) => [summary.number, summary]));
-	const result = new Map<number, SessionPRSummary>();
-
-	for (const pr of sortedPRs(session)) {
-		result.set(pr.number, summariesByNumber.get(pr.number) ?? sessionPRFactToSummary(session, pr));
-	}
-
-	for (const summary of summaries) {
-		if (!result.has(summary.number)) {
-			result.set(summary.number, summary);
+	const dedupedSummaries = deduplicateSummaries(summaries);
+	const summariesByIdentity = new Map<string, SessionPRSummary>();
+	const summaryNumberCounts = countPRNumbers(dedupedSummaries);
+	const summariesByUniqueNumber = new Map<number, SessionPRSummary>();
+	for (const summary of dedupedSummaries) {
+		for (const key of prDisplayIdentities(summary)) {
+			if (!summariesByIdentity.has(key)) {
+				summariesByIdentity.set(key, summary);
+			}
+		}
+		if (summaryNumberCounts.get(summary.number) === 1) {
+			summariesByUniqueNumber.set(summary.number, summary);
 		}
 	}
+	const facts = sortedPRs(session);
+	const factNumberCounts = countPRNumbers(facts);
+	const seen = new Set<string>();
+	const consumedSummaries = new Set<SessionPRSummary>();
+	const fromFacts: SessionPRSummary[] = [];
+	for (const pr of facts) {
+		const key = prDisplayIdentity(pr);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		const summary = summariesByIdentity.get(key) ?? uniqueNumberSummary(pr, factNumberCounts, summariesByUniqueNumber);
+		if (summary) {
+			for (const summaryKey of prDisplayIdentities(summary)) {
+				seen.add(summaryKey);
+			}
+			consumedSummaries.add(summary);
+		}
+		fromFacts.push(summary ?? sessionPRFactToSummary(session, pr));
+	}
+	const summaryOnly: SessionPRSummary[] = [];
+	for (const summary of dedupedSummaries) {
+		const keys = prDisplayIdentities(summary);
+		if (keys.some((key) => seen.has(key))) continue;
+		if (consumedSummaries.has(summary)) continue;
+		for (const key of keys) {
+			seen.add(key);
+		}
+		summaryOnly.push(summary);
+	}
+	return [...fromFacts, ...summaryOnly].sort(comparePRDisplaySummaries);
+}
 
-	return [...result.values()].sort(comparePRDisplaySummaries);
+function deduplicateSummaries(summaries: SessionPRSummary[]): SessionPRSummary[] {
+	const seen = new Set<string>();
+	const out: SessionPRSummary[] = [];
+	for (const summary of summaries) {
+		const keys = prDisplayIdentities(summary);
+		if (keys.some((key) => seen.has(key))) continue;
+		for (const key of keys) {
+			seen.add(key);
+		}
+		out.push(summary);
+	}
+	return out;
+}
+
+function countPRNumbers(prs: Array<Pick<SessionPRSummary, "number"> | PullRequestFacts>): Map<number, number> {
+	const counts = new Map<number, number>();
+	for (const pr of prs) {
+		counts.set(pr.number, (counts.get(pr.number) ?? 0) + 1);
+	}
+	return counts;
+}
+
+function uniqueNumberSummary(
+	pr: PullRequestFacts,
+	factNumberCounts: Map<number, number>,
+	summariesByUniqueNumber: Map<number, SessionPRSummary>,
+): SessionPRSummary | undefined {
+	if (factNumberCounts.get(pr.number) !== 1) return undefined;
+	return summariesByUniqueNumber.get(pr.number);
+}
+
+function prDisplayIdentity(pr: Pick<SessionPRSummary, "number" | "url" | "htmlUrl" | "repo"> | PullRequestFacts): string {
+	const url = "htmlUrl" in pr ? pr.htmlUrl || pr.url : pr.url;
+	const github = githubPRIdentity(url, pr.number);
+	if (github) return github;
+	const repo = "repo" in pr ? pr.repo.trim().toLowerCase() : "";
+	if (repo) return `repo:${repo}#${pr.number}`;
+	return `number:${pr.number}`;
+}
+
+function prDisplayIdentities(pr: SessionPRSummary): string[] {
+	const keys = [prDisplayIdentity(pr)];
+	const alias = prTransferAliasIdentity(pr);
+	if (alias) keys.push(alias);
+	return keys;
+}
+
+function githubPRIdentity(rawURL: string, expectedNumber: number): string | undefined {
+	try {
+		const url = new URL(rawURL);
+		const host = url.hostname.toLowerCase();
+		if (host !== "github.com" && !host.endsWith(".github.com")) return undefined;
+		const [, owner, repoName, kind, number] = url.pathname.split("/");
+		if ((kind !== "pull" && kind !== "issues") || !owner || !repoName || !number) return undefined;
+		if (Number(number) !== expectedNumber) return undefined;
+		return `github:${host}/${owner.toLowerCase()}/${repoName.toLowerCase()}#${number}`;
+	} catch {
+		return undefined;
+	}
+}
+
+function prTransferAliasIdentity(pr: SessionPRSummary): string | undefined {
+	const github = githubPRAliasParts(pr.htmlUrl || pr.url, pr.number);
+	if (!github) return undefined;
+	const sourceBranch = normalizedAliasPart(pr.sourceBranch);
+	const headSha = normalizedAliasPart(pr.headSha);
+	if (!sourceBranch || !headSha) return undefined;
+	return [
+		"github-transfer",
+		github.host,
+		github.repoName,
+		String(pr.number),
+		sourceBranch,
+		normalizedAliasPart(pr.targetBranch),
+		headSha,
+	].join("|");
+}
+
+function githubPRAliasParts(rawURL: string, expectedNumber: number): { host: string; repoName: string } | undefined {
+	try {
+		const url = new URL(rawURL);
+		const host = url.hostname.toLowerCase();
+		if (host !== "github.com" && !host.endsWith(".github.com")) return undefined;
+		const [, owner, repoName, kind, number] = url.pathname.split("/");
+		if ((kind !== "pull" && kind !== "issues") || !owner || !repoName || !number) return undefined;
+		if (Number(number) !== expectedNumber) return undefined;
+		return { host, repoName: repoName.toLowerCase() };
+	} catch {
+		return undefined;
+	}
+}
+
+function normalizedAliasPart(value: string): string {
+	return value.trim().toLowerCase();
 }
 
 function sessionPRFactToSummary(session: WorkspaceSession, pr: PullRequestFacts): SessionPRSummary {
@@ -127,7 +263,7 @@ export function prSummaryParts(pr: SessionPRSummary): PRSummaryPart[] {
 	return [
 		{
 			key: "ci",
-			label: "CI",
+			label: appI18n.t("pr.section.ci"),
 			status: ciLabel(pr.ci.state),
 			summary: ciSummary(pr),
 			links: ciLinks(pr),
@@ -138,7 +274,7 @@ export function prSummaryParts(pr: SessionPRSummary): PRSummaryPart[] {
 		},
 		{
 			key: "merge",
-			label: "Merge",
+			label: appI18n.t("pr.section.merge"),
 			status: mergeabilityLabel(pr.mergeability.state),
 			summary: mergeSummary(pr),
 			links: mergeLinks(pr),
@@ -149,7 +285,7 @@ export function prSummaryParts(pr: SessionPRSummary): PRSummaryPart[] {
 		},
 		{
 			key: "review",
-			label: "Review",
+			label: appI18n.t("pr.section.review"),
 			status: reviewLabel(pr.review.decision),
 			summary: reviewSummary(pr),
 			links: reviewLinks(pr),
@@ -178,7 +314,7 @@ export function prDiffSummary(pr: SessionPRSummary): string | undefined {
 
 function ciSummary(pr: SessionPRSummary): string | undefined {
 	if (pr.ci.state === "failing") {
-		return pr.ci.failingChecks.length === 0 ? "No failing check link observed" : undefined;
+		return pr.ci.failingChecks.length === 0 ? appI18n.t("pr.ci.noFailingLink") : undefined;
 	}
 	return undefined;
 }
@@ -199,13 +335,13 @@ function reviewSummary(pr: SessionPRSummary): string | undefined {
 		return undefined;
 	}
 	if (pr.state === "draft") {
-		return "Draft PR · Not ready for review";
+		return appI18n.t("pr.review.draftNotReady");
 	}
 	if (pr.review.decision === "changes_requested" || pr.review.hasUnresolvedHumanComments) {
-		return reviewLinks(pr).length === 0 ? "Requested changes still active" : undefined;
+		return reviewLinks(pr).length === 0 ? appI18n.t("pr.review.changesActive") : undefined;
 	}
 	if (pr.review.decision === "review_required") {
-		return "Required review not submitted";
+		return appI18n.t("pr.review.requiredNotSubmitted");
 	}
 	return undefined;
 }
@@ -219,7 +355,11 @@ function reviewLinks(pr: SessionPRSummary): PRSummaryLink[] {
 	}
 	const links = pr.review.unresolvedBy.slice(0, 3).map((reviewer) => reviewAttentionLink(pr, reviewer));
 	if (links.length === 0 && pr.review.decision === "changes_requested") {
-		links.push({ label: "PR", href: prBrowserUrl(pr), title: "Open pull request" });
+		links.push({
+			label: appI18n.t("pr.short"),
+			href: prBrowserUrl(pr),
+			title: appI18n.t("pr.review.openPR"),
+		});
 	}
 	return links;
 }
@@ -229,10 +369,10 @@ function mergeSummary(pr: SessionPRSummary): string | undefined {
 		return formatDiffSummary(pr);
 	}
 	if (pr.mergeability.state === "conflicting") {
-		return mergeLinks(pr).length === 0 ? "Conflicts with the base branch" : undefined;
+		return mergeLinks(pr).length === 0 ? appI18n.t("pr.merge.conflictsWithBase") : undefined;
 	}
 	if (pr.mergeability.state === "blocked" || pr.mergeability.state === "unstable") {
-		return mergeLinks(pr).length === 0 ? "Provider reports merge is blocked" : undefined;
+		return mergeLinks(pr).length === 0 ? appI18n.t("pr.merge.providerBlocked") : undefined;
 	}
 	return formatDiffSummary(pr);
 }
@@ -278,7 +418,7 @@ function mergeLinkTotal(pr: SessionPRSummary): number {
 	return 0;
 }
 
-function mergeOverflowNoun(pr: SessionPRSummary): string {
+function mergeOverflowNoun(pr: SessionPRSummary): PRNoun {
 	return (pr.mergeability.conflictFiles ?? []).length > 0 ? "file" : "reason";
 }
 
@@ -313,13 +453,13 @@ function toMergeabilityState(value: string): SessionPRSummary["mergeability"]["s
 function ciLabel(state: SessionPRSummary["ci"]["state"]): string {
 	switch (state) {
 		case "passing":
-			return "Passing";
+			return appI18n.t("pr.ci.passing");
 		case "failing":
-			return "Failing";
+			return appI18n.t("pr.ci.failing");
 		case "pending":
-			return "Pending";
+			return appI18n.t("pr.ci.pending");
 		case "unknown":
-			return "Checking";
+			return appI18n.t("pr.ci.checking");
 	}
 }
 
@@ -339,13 +479,13 @@ function ciTone(state: SessionPRSummary["ci"]["state"]): PRDisplayTone {
 function reviewLabel(decision: SessionPRSummary["review"]["decision"]): string {
 	switch (decision) {
 		case "approved":
-			return "Approved";
+			return appI18n.t("pr.review.approved");
 		case "changes_requested":
-			return "Changes requested";
+			return appI18n.t("pr.review.changesRequested");
 		case "review_required":
-			return "Pending";
+			return appI18n.t("pr.review.pending");
 		case "none":
-			return "None";
+			return appI18n.t("pr.review.none");
 	}
 }
 
@@ -368,15 +508,15 @@ function reviewTone(
 function mergeabilityLabel(state: SessionPRSummary["mergeability"]["state"]): string {
 	switch (state) {
 		case "mergeable":
-			return "Mergeable";
+			return appI18n.t("pr.merge.mergeable");
 		case "conflicting":
-			return "Conflict";
+			return appI18n.t("pr.merge.conflict");
 		case "blocked":
-			return "Blocked";
+			return appI18n.t("pr.merge.blocked");
 		case "unstable":
-			return "Unstable";
+			return appI18n.t("pr.merge.unstable");
 		case "unknown":
-			return "Checking";
+			return appI18n.t("pr.merge.checking");
 	}
 }
 
@@ -419,10 +559,11 @@ function formatLineDelta(additions: number, deletions: number): string | undefin
 function mergeAttentionLinks(pr: SessionPRSummary, kind: "merge_conflict" | "merge_blocked"): PRSummaryLink[] {
 	const href =
 		kind === "merge_conflict" ? mergeConflictUrl(pr) : pr.mergeability.prUrl || pr.htmlUrl || pr.url || undefined;
+	const openConflicts = appI18n.t("pr.merge.openConflicts");
 	const fileLinks = (pr.mergeability.conflictFiles ?? []).slice(0, 3).map((file) => ({
 		label: file.path,
 		href: file.url || href,
-		title: kind === "merge_conflict" ? "Open merge conflicts" : undefined,
+		title: kind === "merge_conflict" ? openConflicts : undefined,
 	}));
 	const reasonLinks =
 		fileLinks.length > 0 || kind === "merge_conflict"
@@ -432,7 +573,9 @@ function mergeAttentionLinks(pr: SessionPRSummary, kind: "merge_conflict" | "mer
 					href,
 				}));
 	const fallbackLink =
-		kind === "merge_conflict" && href ? [{ label: "conflicts", href, title: "Open merge conflicts" }] : [];
+		kind === "merge_conflict" && href
+			? [{ label: appI18n.t("pr.merge.conflicts"), href, title: openConflicts }]
+			: [];
 	return fileLinks.length > 0 ? fileLinks : reasonLinks.length > 0 ? reasonLinks : fallbackLink;
 }
 
@@ -478,63 +621,68 @@ function reviewerLabel(reviewer: SessionPRSummary["review"]["unresolvedBy"][numb
 }
 
 function reviewerDisplayName(reviewer: SessionPRSummary["review"]["unresolvedBy"][number]): string {
-	return reviewer.isBot ? `${reviewer.reviewerId} bot` : reviewer.reviewerId;
+	if (!reviewer.isBot) return reviewer.reviewerId;
+	return appI18n.t("pr.botSuffix", { name: reviewer.reviewerId });
 }
 
 function reviewAttentionLink(
 	pr: SessionPRSummary,
 	reviewer: SessionPRSummary["review"]["unresolvedBy"][number],
 ): PRSummaryLink {
+	const name = reviewerDisplayName(reviewer);
 	const inlineURL = reviewer.links.find((link) => link.url)?.url;
 	if (reviewer.reviewUrl) {
 		return {
 			label: reviewerLabel(reviewer),
 			href: reviewer.reviewUrl,
-			title: `Open requested-changes review from ${reviewerDisplayName(reviewer)}`,
+			title: appI18n.t("pr.openReviewFrom", { name }),
 		};
 	}
 	if (inlineURL) {
 		return {
 			label: reviewerLabel(reviewer),
 			href: inlineURL,
-			title:
-				reviewer.count > 0
-					? `${reviewer.count} unresolved ${pluralize("comment", reviewer.count)} from ${reviewerDisplayName(reviewer)}`
-					: `Open review comments from ${reviewerDisplayName(reviewer)}`,
+				title:
+					reviewer.count > 0
+						? appI18n.t("pr.unresolvedComments", {
+								count: reviewer.count,
+								name,
+							})
+					: appI18n.t("pr.openCommentsFrom", { name }),
 		};
 	}
 	return {
 		label: reviewerLabel(reviewer),
 		href: prBrowserUrl(pr),
-		title: `Open pull request for ${reviewerDisplayName(reviewer)}`,
+		title: appI18n.t("pr.openPRFor", { name }),
 	};
 }
 
 function mergeReasonLabel(reason: string): string {
 	switch (reason) {
 		case "behind_base":
-			return "branch behind base";
+			return appI18n.t("pr.reason.behindBase");
 		case "ci_failing":
-			return "CI failing";
+			return appI18n.t("pr.reason.ciFailing");
 		case "changes_requested":
-			return "changes requested";
+			return appI18n.t("pr.reason.changesRequested");
 		case "review_required":
-			return "review required";
+			return appI18n.t("pr.reason.reviewRequired");
 		case "blocked_by_provider":
-			return "provider blocked";
+			return appI18n.t("pr.reason.providerBlocked");
 		default:
 			return reason.replaceAll("_", " ");
 	}
 }
 
-function overflowLabel(total: number, shown: number, noun: string): string | undefined {
+function overflowLabel(total: number, shown: number, noun: PRNoun): string | undefined {
 	const extra = total - shown;
 	if (extra <= 0) {
 		return undefined;
 	}
-	return `+${extra} ${pluralize(noun, extra)}`;
+	return appI18n.t("pr.overflow", { n: extra, noun: pluralize(noun, extra) });
 }
 
-function pluralize(noun: string, count: number): string {
-	return count === 1 ? noun : `${noun}s`;
+function pluralize(noun: PRNoun, count: number): string {
+	return appI18n.t(prNounKeys[noun], { count });
 }


### PR DESCRIPTION
Fixes #3242

## Problem

The Session Inspector Summary tab accumulates pull requests from other sessions and duplicates entries when cycling between sessions. The header count (`PULL REQUESTS (2)`) disagrees with the rendered list (7+ cards).

Root cause: `sessionPRDisplaySummaries` deduped summaries against session PR facts, but not **within** the summaries array itself. If the `GET /sessions/{id}/pr` API returned duplicate entries (or CDC events caused PR accumulation), every copy rendered — and the list grew monotonically with each session switch.

## Fix

Replace the `facts → seen-set → append-remaining-summaries` pattern with a `Map<number, SessionPRSummary>` keyed by PR number. This guarantees each PR appears at most once regardless of how many times it appears across either source, and the insertion order (facts first, extra summaries second) is preserved before final sort.

## Test coverage

- **Duplicate summaries**: two entries with the same PR number → one result
- **Cross-session isolation**: two sessions with different PRs → each returns only its own
- **Facts + summaries merge**: enriched summary replaces fact for the same PR number
- **Summary-only PR**: a PR present only in summaries (no fact) is included
- **No PRs**: empty session returns empty list
- All 96 test files / 1286 tests pass, typecheck clean