### PR TITLE
feat(review): add Kilo Code reviewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Reviewer agents are configured separately. The current reviewer harnesses are:
 <p>
   <a href="https://aoagents.dev/docs/plugins/agents/claude-code"><img src="frontend/src/renderer/assets/agents/claude-code.svg" alt="" width="16" height="16" valign="middle" /> <code>claude-code</code></a> ·
   <a href="https://aoagents.dev/docs/plugins/agents/codex"><img src="frontend/src/renderer/assets/agents/codex.svg" alt="" width="16" height="16" valign="middle" /> <code>codex</code></a> ·
-  <a href="https://aoagents.dev/docs/plugins/agents/opencode"><img src="frontend/src/renderer/assets/agents/opencode.svg" alt="" width="16" height="16" valign="middle" /> <code>opencode</code></a>
+  <a href="https://aoagents.dev/docs/plugins/agents/opencode"><img src="frontend/src/renderer/assets/agents/opencode.svg" alt="" width="16" height="16" valign="middle" /> <code>opencode</code></a> ·
+  <a href="https://aoagents.dev/docs/plugins/agents"><img src="frontend/src/renderer/assets/agents/kilocode.svg" alt="" width="16" height="16" valign="middle" /> <code>kilocode</code></a>
 </p>
 
 **If it runs in a terminal, it runs on Agent Orchestrator.**

--- a/backend/internal/adapters/reviewer/kilocode/kilocode.go
+++ b/backend/internal/adapters/reviewer/kilocode/kilocode.go
@@ -102,6 +102,7 @@ func withReviewerConfig(argv []string, taskPromptRoot, systemPromptFile string) 
 			"git show*":                     "allow",
 			"git status*":                   "allow",
 			"ao review submit *":            "allow",
+			"printf *":                      "allow",
 			"printf * | gh api *":           "allow",
 			"printf * | ao review submit *": "allow",
 		},

--- a/backend/internal/adapters/reviewer/kilocode/kilocode.go
+++ b/backend/internal/adapters/reviewer/kilocode/kilocode.go
@@ -1,0 +1,154 @@
+// Package kilocode adapts the Kilo Code worker agent for code-review sessions.
+package kilocode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	workeragent "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kilocode"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const configAssignmentPrefix = "KILO_CONFIG_CONTENT="
+
+// Reviewer is the Kilo Code code-review adapter.
+type Reviewer struct {
+	agent ports.Agent
+}
+
+// New builds the Kilo Code reviewer adapter.
+func New() *Reviewer {
+	return &Reviewer{agent: workeragent.New()}
+}
+
+// Harness identifies this reviewer in the reviewer registry.
+func (r *Reviewer) Harness() domain.ReviewerHarness {
+	return domain.ReviewerKiloCode
+}
+
+var _ ports.Reviewer = (*Reviewer)(nil)
+var _ ports.ReviewerCanceller = (*Reviewer)(nil)
+
+// ReviewCommand launches Kilo Code with the same hidden system-prompt agent as
+// the worker adapter, then replaces its normal permission config with the
+// reviewer-only read/report policy. The persistent TUI form is intentional:
+// AO reuses reviewer panes and injects later review tasks into them.
+func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
+	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		SessionID:        inv.ReviewerID,
+		WorkspacePath:    inv.WorkspacePath,
+		Prompt:           inv.Prompt,
+		SystemPrompt:     inv.SystemPrompt,
+		SystemPromptFile: inv.SystemPromptFile,
+		Permissions:      ports.PermissionModeDefault,
+	})
+	if err != nil {
+		return ports.ReviewCommandSpec{}, err
+	}
+	argv, err = withReviewerConfig(argv, inv.TaskPromptRoot, inv.SystemPromptFile)
+	if err != nil {
+		return ports.ReviewCommandSpec{}, err
+	}
+	return ports.ReviewCommandSpec{Argv: argv}, nil
+}
+
+func withReviewerConfig(argv []string, taskPromptRoot, systemPromptFile string) ([]string, error) {
+	config := map[string]any{}
+	assignmentIndex := -1
+	for i, arg := range argv {
+		if !strings.HasPrefix(arg, configAssignmentPrefix) {
+			continue
+		}
+		assignmentIndex = i
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(arg, configAssignmentPrefix)), &config); err != nil {
+			return nil, fmt.Errorf("decode Kilo Code launch config: %w", err)
+		}
+		break
+	}
+
+	configPath := ""
+	if taskPromptRoot != "" && systemPromptFile != "" {
+		agent, ok := config["agent"]
+		if ok {
+			hiddenConfig := map[string]any{"agent": agent}
+			replaceAgentPrompts(hiddenConfig, "{file:./"+filepath.Base(systemPromptFile)+"}")
+			data, err := json.Marshal(hiddenConfig)
+			if err != nil {
+				return nil, fmt.Errorf("encode Kilo Code hidden reviewer config: %w", err)
+			}
+			configPath = filepath.Join(taskPromptRoot, "kilo.json")
+			if err := os.WriteFile(configPath, append(data, '\n'), 0o600); err != nil {
+				return nil, fmt.Errorf("write Kilo Code hidden reviewer config: %w", err)
+			}
+			delete(config, "agent")
+		}
+	}
+
+	permission := map[string]any{
+		"*":    "deny",
+		"read": "allow",
+		"glob": "allow",
+		"grep": "allow",
+		"bash": map[string]string{
+			"*":                             "deny",
+			"gh api *":                      "allow",
+			"git diff*":                     "allow",
+			"git log*":                      "allow",
+			"git show*":                     "allow",
+			"git status*":                   "allow",
+			"ao review submit *":            "allow",
+			"printf * | gh api *":           "allow",
+			"printf * | ao review submit *": "allow",
+		},
+	}
+	if taskPromptRoot != "" {
+		promptPattern := filepath.ToSlash(filepath.Join(taskPromptRoot, "**"))
+		permission["external_directory"] = map[string]string{promptPattern: "allow"}
+	}
+	config["permission"] = permission
+	data, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("encode Kilo Code reviewer config: %w", err)
+	}
+	assignment := configAssignmentPrefix + string(data)
+
+	if assignmentIndex >= 0 {
+		out := append([]string(nil), argv...)
+		out[assignmentIndex] = assignment
+		if configPath != "" {
+			out = append(out[:assignmentIndex+1], append([]string{"KILO_CONFIG=" + configPath}, out[assignmentIndex+1:]...)...)
+		}
+		return out, nil
+	}
+	return append([]string{"env", assignment}, argv...), nil
+}
+
+func replaceAgentPrompts(config map[string]any, prompt string) {
+	agents, ok := config["agent"].(map[string]any)
+	if !ok {
+		return
+	}
+	for _, value := range agents {
+		settings, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		settings["prompt"] = prompt
+	}
+}
+
+// ReviewMessage returns the centrally-authored task for an existing pane.
+func (r *Reviewer) ReviewMessage(_ context.Context, inv ports.ReviewInvocation) (string, error) {
+	return inv.Prompt, nil
+}
+
+// ReviewCancel stops the active Kilo Code reviewer turn while preserving the
+// terminal pane for inspection.
+func (r *Reviewer) ReviewCancel(context.Context) (ports.ReviewCancelSpec, error) {
+	return ports.ReviewCancelSpec{Mode: ports.ReviewCancelInterrupt, Interrupts: 2}, nil
+}

--- a/backend/internal/adapters/reviewer/kilocode/kilocode_test.go
+++ b/backend/internal/adapters/reviewer/kilocode/kilocode_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -90,7 +91,8 @@ func TestReviewCommandPreservesAgentAndAppliesReadOnlyPolicy(t *testing.T) {
 	}
 	if config.Permission.Bash["*"] != "deny" ||
 		config.Permission.Bash["gh api *"] != "allow" ||
-		config.Permission.Bash["ao review submit *"] != "allow" {
+		config.Permission.Bash["ao review submit *"] != "allow" ||
+		config.Permission.Bash["printf *"] != "allow" {
 		t.Fatalf("bash policy = %#v", config.Permission.Bash)
 	}
 	wantPromptPattern := filepath.ToSlash(filepath.Join("ao", "prompts", "reviewer", "**"))
@@ -143,6 +145,41 @@ func TestReviewCommandBuildsKiloCodeArgvWithHiddenPrompts(t *testing.T) {
 	}
 }
 
+func TestBashPolicyAllowsEveryParsedReportingPipelineStage(t *testing.T) {
+	bash := reviewerBashPolicy(t)
+	tests := []struct {
+		name   string
+		stages []string
+	}{
+		{
+			name: "GitHub review",
+			stages: []string{
+				`printf '%s' '{ "event": "COMMENT", "body": "ready" }'`,
+				`gh api --method POST repos/o/r/pulls/1/reviews --input - --jq '.id'`,
+			},
+		},
+		{
+			name: "AO bookkeeping",
+			stages: []string{
+				`printf '%s' '{ "reviews": [] }'`,
+				`ao review submit --session sess-1 --reviews -`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, stage := range tt.stages {
+				if !bashAllowsCommand(t, bash, stage) {
+					t.Fatalf("parsed pipeline stage is denied: %q; policy = %#v", stage, bash)
+				}
+			}
+		})
+	}
+	if bashAllowsCommand(t, bash, `rm -rf /`) {
+		t.Fatalf("arbitrary command is allowed by policy: %#v", bash)
+	}
+}
+
 func TestReviewCommandAddsConfigWhenWorkerHasNoInlineConfig(t *testing.T) {
 	agent := &captureAgent{argv: []string{"kilocode"}}
 	got, err := (&Reviewer{agent: agent}).ReviewCommand(context.Background(), ports.ReviewInvocation{})
@@ -152,6 +189,45 @@ func TestReviewCommandAddsConfigWhenWorkerHasNoInlineConfig(t *testing.T) {
 	if len(got.Argv) != 3 || got.Argv[0] != "env" || !strings.HasPrefix(got.Argv[1], configAssignmentPrefix) || got.Argv[2] != "kilocode" {
 		t.Fatalf("argv = %#v", got.Argv)
 	}
+}
+
+func reviewerBashPolicy(t *testing.T) map[string]string {
+	t.Helper()
+	argv, err := withReviewerConfig([]string{"kilocode"}, "", "")
+	if err != nil {
+		t.Fatalf("withReviewerConfig: %v", err)
+	}
+	var config struct {
+		Permission struct {
+			Bash map[string]string `json:"bash"`
+		} `json:"permission"`
+	}
+	raw := strings.TrimPrefix(argv[1], configAssignmentPrefix)
+	if err := json.Unmarshal([]byte(raw), &config); err != nil {
+		t.Fatalf("reviewer config: %v", err)
+	}
+	return config.Permission.Bash
+}
+
+func bashAllowsCommand(t *testing.T, policy map[string]string, command string) bool {
+	t.Helper()
+	for pattern, action := range policy {
+		if action == "deny" {
+			continue
+		}
+		parts := strings.Split(pattern, "*")
+		for i, part := range parts {
+			parts[i] = regexp.QuoteMeta(part)
+		}
+		matcher, err := regexp.Compile("^" + strings.Join(parts, ".*") + "$")
+		if err != nil {
+			t.Fatalf("compile pattern %q: %v", pattern, err)
+		}
+		if matcher.MatchString(command) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestReviewCommandPropagatesUnavailableCLI(t *testing.T) {

--- a/backend/internal/adapters/reviewer/kilocode/kilocode_test.go
+++ b/backend/internal/adapters/reviewer/kilocode/kilocode_test.go
@@ -1,0 +1,181 @@
+package kilocode
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type captureAgent struct {
+	got  ports.LaunchConfig
+	argv []string
+	err  error
+}
+
+func (a *captureAgent) GetConfigSpec(context.Context) (ports.ConfigSpec, error) {
+	return ports.ConfigSpec{}, nil
+}
+func (a *captureAgent) GetLaunchCommand(_ context.Context, cfg ports.LaunchConfig) ([]string, error) {
+	a.got = cfg
+	return a.argv, a.err
+}
+func (a *captureAgent) GetPromptDeliveryStrategy(context.Context, ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	return ports.PromptDeliveryInCommand, nil
+}
+func (a *captureAgent) GetAgentHooks(context.Context, ports.WorkspaceHookConfig) error { return nil }
+func (a *captureAgent) GetRestoreCommand(context.Context, ports.RestoreConfig) ([]string, bool, error) {
+	return nil, false, nil
+}
+func (a *captureAgent) SessionInfo(context.Context, ports.SessionRef) (ports.SessionInfo, bool, error) {
+	return ports.SessionInfo{}, false, nil
+}
+
+func TestReviewCommandPreservesAgentAndAppliesReadOnlyPolicy(t *testing.T) {
+	agent := &captureAgent{argv: []string{
+		"env",
+		`KILO_CONFIG_CONTENT={"agent":{"ao-review-w1":{"prompt":"review only"}}}`,
+		"kilocode",
+		"--agent", "ao-review-w1",
+		"--prompt", "review it",
+	}}
+	r := &Reviewer{agent: agent}
+
+	got, err := r.ReviewCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID:     "review-w1",
+		WorkspacePath:  "/ws/w1",
+		Prompt:         "review it",
+		SystemPrompt:   "review only",
+		TaskPromptRoot: filepath.Join("ao", "prompts", "reviewer"),
+	})
+	if err != nil {
+		t.Fatalf("ReviewCommand: %v", err)
+	}
+
+	if agent.got.Permissions != ports.PermissionModeDefault {
+		t.Fatalf("permissions = %q, want default before reviewer policy overlay", agent.got.Permissions)
+	}
+	if agent.got.WorkspacePath != "/ws/w1" || agent.got.Prompt != "review it" || agent.got.SystemPrompt != "review only" {
+		t.Fatalf("launch config = %+v", agent.got)
+	}
+	if got.Argv[0] != "env" || got.Argv[2] != "kilocode" {
+		t.Fatalf("argv = %#v", got.Argv)
+	}
+
+	var config struct {
+		Agent      map[string]any `json:"agent"`
+		Permission struct {
+			CatchAll          string            `json:"*"`
+			Read              string            `json:"read"`
+			Bash              map[string]string `json:"bash"`
+			ExternalDirectory map[string]string `json:"external_directory"`
+		} `json:"permission"`
+	}
+	raw := strings.TrimPrefix(got.Argv[1], configAssignmentPrefix)
+	if err := json.Unmarshal([]byte(raw), &config); err != nil {
+		t.Fatalf("reviewer config: %v", err)
+	}
+	if _, ok := config.Agent["ao-review-w1"]; !ok {
+		t.Fatalf("generated reviewer agent was lost: %s", raw)
+	}
+	if config.Permission.CatchAll != "deny" || config.Permission.Read != "allow" {
+		t.Fatalf("permission policy = %+v", config.Permission)
+	}
+	if config.Permission.Bash["*"] != "deny" ||
+		config.Permission.Bash["gh api *"] != "allow" ||
+		config.Permission.Bash["ao review submit *"] != "allow" {
+		t.Fatalf("bash policy = %#v", config.Permission.Bash)
+	}
+	wantPromptPattern := filepath.ToSlash(filepath.Join("ao", "prompts", "reviewer", "**"))
+	if !reflect.DeepEqual(config.Permission.ExternalDirectory, map[string]string{wantPromptPattern: "allow"}) {
+		t.Fatalf("external directory = %#v", config.Permission.ExternalDirectory)
+	}
+}
+
+func TestReviewCommandBuildsKiloCodeArgvWithHiddenPrompts(t *testing.T) {
+	binDir := t.TempDir()
+	binaryName := "kilocode"
+	binaryBody := "#!/bin/sh\n"
+	if runtime.GOOS == "windows" {
+		binaryName = "kilocode.cmd"
+		binaryBody = "@echo off\r\n"
+	}
+	if err := os.WriteFile(filepath.Join(binDir, binaryName), []byte(binaryBody), 0o755); err != nil {
+		t.Fatalf("write fake Kilo Code CLI: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	promptRoot := t.TempDir()
+	systemPath := filepath.Join(promptRoot, "system.md")
+	if err := os.WriteFile(systemPath, []byte("review system prompt\n"), 0o600); err != nil {
+		t.Fatalf("write system prompt: %v", err)
+	}
+
+	spec, err := New().ReviewCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID:       "review-w1",
+		WorkspacePath:    t.TempDir(),
+		Prompt:           "Read the AO review task.",
+		SystemPromptFile: systemPath,
+		TaskPromptRoot:   promptRoot,
+	})
+	if err != nil {
+		t.Fatalf("ReviewCommand: %v", err)
+	}
+	joinedArgv := strings.Join(spec.Argv, "\n")
+	for _, want := range []string{
+		"KILO_CONFIG_CONTENT=",
+		"--agent\nao-review-w1",
+		"--prompt\nRead the AO review task.",
+	} {
+		if !strings.Contains(joinedArgv, want) {
+			t.Fatalf("argv missing %q: %#v", want, spec.Argv)
+		}
+	}
+	if strings.Contains(joinedArgv, "review system prompt") {
+		t.Fatalf("hidden system prompt leaked into visible argv: %#v", spec.Argv)
+	}
+}
+
+func TestReviewCommandAddsConfigWhenWorkerHasNoInlineConfig(t *testing.T) {
+	agent := &captureAgent{argv: []string{"kilocode"}}
+	got, err := (&Reviewer{agent: agent}).ReviewCommand(context.Background(), ports.ReviewInvocation{})
+	if err != nil {
+		t.Fatalf("ReviewCommand: %v", err)
+	}
+	if len(got.Argv) != 3 || got.Argv[0] != "env" || !strings.HasPrefix(got.Argv[1], configAssignmentPrefix) || got.Argv[2] != "kilocode" {
+		t.Fatalf("argv = %#v", got.Argv)
+	}
+}
+
+func TestReviewCommandPropagatesUnavailableCLI(t *testing.T) {
+	agent := &captureAgent{err: errors.New(`kilocode binary not found`)}
+	_, err := (&Reviewer{agent: agent}).ReviewCommand(context.Background(), ports.ReviewInvocation{})
+	if err == nil || !strings.Contains(err.Error(), "binary not found") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestReviewCommandRejectsMalformedWorkerConfig(t *testing.T) {
+	agent := &captureAgent{argv: []string{"env", "KILO_CONFIG_CONTENT={", "kilocode"}}
+	_, err := (&Reviewer{agent: agent}).ReviewCommand(context.Background(), ports.ReviewInvocation{})
+	if err == nil || !strings.Contains(err.Error(), "decode Kilo Code launch config") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestReviewMessageReturnsTaskPrompt(t *testing.T) {
+	got, err := (&Reviewer{}).ReviewMessage(context.Background(), ports.ReviewInvocation{Prompt: "next review"})
+	if err != nil {
+		t.Fatalf("ReviewMessage: %v", err)
+	}
+	if got != "next review" {
+		t.Fatalf("message = %q", got)
+	}
+}

--- a/backend/internal/adapters/reviewer/registry.go
+++ b/backend/internal/adapters/reviewer/registry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/reviewer/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/reviewer/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/reviewer/kilocode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/reviewer/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -25,6 +26,7 @@ func Constructors() []Adapter {
 	return []Adapter{
 		claudecode.New(),
 		codex.New(),
+		kilocode.New(),
 		opencode.New(),
 	}
 }

--- a/backend/internal/domain/projectconfig_test.go
+++ b/backend/internal/domain/projectconfig_test.go
@@ -30,6 +30,7 @@ func TestProjectConfigValidate(t *testing.T) {
 		{"agent rules file bare dot", ProjectConfig{AgentRulesFile: "."}, true},
 		{"good reviewers", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerClaudeCode}}}, false},
 		{"good codex reviewer", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerCodex}}}, false},
+		{"good Kilo Code reviewer", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerKiloCode}}}, false},
 		{"good opencode reviewer", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerOpenCode}}}, false},
 		{"unknown reviewer harness", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: "nope"}}}, true},
 		{"worker-only harness is not auto a reviewer", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerHarness(HarnessAider)}}}, true},
@@ -113,6 +114,9 @@ func TestResolveReviewerHarness(t *testing.T) {
 	}
 	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessOpenCode); got != ReviewerOpenCode {
 		t.Fatalf("opencode worker = %q, want reviewer opencode", got)
+	}
+	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessKilocode); got != ReviewerKiloCode {
+		t.Fatalf("Kilo Code worker = %q, want reviewer kilocode", got)
 	}
 
 	// A worker harness that is not itself a reviewer (e.g. crush, aider) falls

--- a/backend/internal/domain/reviewerharness.go
+++ b/backend/internal/domain/reviewerharness.go
@@ -12,6 +12,7 @@ type ReviewerHarness string
 const (
 	ReviewerClaudeCode ReviewerHarness = "claude-code"
 	ReviewerCodex      ReviewerHarness = "codex"
+	ReviewerKiloCode   ReviewerHarness = "kilocode"
 	ReviewerOpenCode   ReviewerHarness = "opencode"
 )
 
@@ -20,6 +21,7 @@ const (
 var AllReviewerHarnesses = []ReviewerHarness{
 	ReviewerClaudeCode,
 	ReviewerCodex,
+	ReviewerKiloCode,
 	ReviewerOpenCode,
 }
 

--- a/frontend/src/landing/content/docs/configuration/projects.mdx
+++ b/frontend/src/landing/content/docs/configuration/projects.mdx
@@ -158,6 +158,22 @@ worker:
 
 Use this when planning/review needs a stronger model but routine implementation can use a faster or cheaper worker.
 
+## Choose A Reviewer
+
+Reviewer agents are configured independently from worker and orchestrator agents:
+
+```yaml
+reviewers:
+  - harness: kilocode
+```
+
+Built-in reviewer harnesses are `claude-code`, `codex`, `opencode`, and `kilocode`. Kilo Code requires the
+[`@kilocode/cli`](https://kilo.ai/docs/code-with-ai/platforms/cli) package and a configured model provider (`/connect`,
+`kilo auth login`, or a supported provider environment variable). AO launches Kilo Code in the worker checkout with a
+read-only review policy and its own GitHub/AO reporting instructions. It does not invoke Kilo's local `/review` command
+or parse `kilo run --format json`; the reviewer posts through `gh api` and records its verdict through
+`ao review submit`, like the other AO reviewer harnesses.
+
 ## Tracker And SCM
 
 AO usually infers tracker and SCM from the registered repository. Override them only when needed.

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -67,6 +67,7 @@ const agentCatalogResponse = {
 			{ id: "claude-code", label: "Claude Code" },
 			{ id: "codex", label: "Codex" },
 			{ id: "goose", label: "Goose" },
+			{ id: "kilocode", label: "Kilo Code" },
 			{ id: "kiro", label: "Kiro" },
 			{ id: "opencode", label: "OpenCode" },
 		],
@@ -74,12 +75,14 @@ const agentCatalogResponse = {
 			{ id: "claude-code", label: "Claude Code", authStatus: "authorized" },
 			{ id: "codex", label: "Codex", authStatus: "authorized" },
 			{ id: "goose", label: "Goose", authStatus: "authorized" },
+			{ id: "kilocode", label: "Kilo Code", authStatus: "authorized" },
 			{ id: "kiro", label: "Kiro", authStatus: "unknown" },
 			{ id: "opencode", label: "OpenCode", authStatus: "authorized" },
 		],
 		authorized: [
 			{ id: "claude-code", label: "Claude Code", authStatus: "authorized" },
 			{ id: "codex", label: "Codex", authStatus: "authorized" },
+			{ id: "kilocode", label: "Kilo Code", authStatus: "authorized" },
 			{ id: "goose", label: "Goose", authStatus: "authorized" },
 			{ id: "opencode", label: "OpenCode", authStatus: "authorized" },
 		],
@@ -410,9 +413,31 @@ describe("ProjectSettingsForm", () => {
 			"Codex",
 			"OpenCode",
 			"Goose",
+			"Kilo Code",
 			"KiroAuth unknown",
 		]);
-		expect(options[4]).not.toHaveAttribute("aria-disabled", "true");
+		expect(options[5]).not.toHaveAttribute("aria-disabled", "true");
+	});
+
+	it("offers Kilo Code as a configured reviewer", async () => {
+		mockProject({
+			id: "proj-1",
+			name: "Project One",
+			kind: "single_repo",
+			path: "/repo/project-one",
+			repo: "",
+			defaultBranch: "main",
+			config: {
+				worker: { agent: "codex" },
+				orchestrator: { agent: "claude-code" },
+			},
+		});
+
+		renderSettings();
+
+		const reviewer = await screen.findByRole("button", { name: "Default reviewer agent" });
+		await userEvent.click(reviewer);
+		expect(await screen.findByRole("menuitem", { name: "Kilo Code" })).toBeEnabled();
 	});
 
 	it("shows scratch identity and saves only scratch-supported settings", async () => {

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -49,7 +49,7 @@ const PERMISSION_MODE_OPTIONS = [
 	{ value: "bypass-permissions", label: "Bypass permissions" },
 ] as const;
 
-const KNOWN_REVIEWER_HARNESS_IDS = new Set(["claude-code", "codex", "opencode"]);
+const KNOWN_REVIEWER_HARNESS_IDS = new Set(["claude-code", "codex", "kilocode", "opencode"]);
 
 const projectQueryKey = (id: string) => ["project", id] as const;
 
@@ -492,7 +492,7 @@ function PermissionModeSelect({ value, onChange }: { value: string; onChange: (v
 	);
 }
 
-const REVIEWER_AGENT_PRIORITY = ["claude-code", "codex", "cursor", "opencode", "aider"] as const;
+const REVIEWER_AGENT_PRIORITY = ["claude-code", "codex", "opencode", "kilocode"] as const;
 const REVIEWER_AGENT_PRIORITY_RANK = new Map<string, number>(
 	REVIEWER_AGENT_PRIORITY.map((agent, index) => [agent, index]),
 );


### PR DESCRIPTION
## Summary

- add `kilocode` as a first-class AO reviewer harness, registered independently from worker harnesses
- derive the adapter from the existing OpenCode reviewer design: reuse the Kilo worker command builder, keep AO reviewer panes persistent for follow-up tasks, store standing/task prompts outside the worktree, and apply a read-only inspection/reporting policy
- allow only repository inspection plus the required `gh api` and `ao review submit` reporting commands; preserve AO cancellation and runtime failure behavior
- expose Kilo Code in project configuration and the desktop reviewer selector, with domain, adapter, UI, and documentation coverage

## Official Kilo Code CLI findings

Sources:
- https://kilo.ai/docs/code-with-ai/platforms/cli
- https://kilo.ai/docs/code-with-ai/platforms/cli-reference
- https://kilo.ai/docs/contributing/architecture/cli-runtime
- https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/package.json

The current package is `@kilocode/cli`. `kilo` is the primary executable and the package also installs `kilocode` as an official alias. Headless automation is `kilo run --auto <message>`; `kilo run` supports `--agent`, `--dir`, and `--format default|json`. Documented headless exits are 0 for success, 1 for initialization/execution failure, and 124 for timeout. Authentication is configured through `/connect`, `kilo auth login`, provider config/environment variables, and inspected with `kilo auth list`.

AO intentionally uses the existing persistent Kilo worker/TUI command path instead of `kilo run --auto`, because reviewer panes receive later review tasks. AO does not parse Kilo JSON events; the reviewer posts through `gh api` and records results through `ao review submit`.

## Tests

- `go test ./internal/adapters/reviewer/kilocode ./internal/adapters/reviewer ./internal/domain ./internal/review` — passed
- `env -u AO_SESSION_ID AO_RUN_FILE=/tmp/ao-agent-orchestrator-195-no-daemon.json AO_DATA_DIR=/tmp/ao-agent-orchestrator-195-data TMPDIR=/tmp go test -p 1 ./...` — passed
- `go test ./internal/adapters/agent/kilocode -run TestAuthStatusUnknownWhenKeyOnlyComesFromInteractiveShell -count=1` — passed
- `npm run typecheck` in `frontend/` — passed
- `npx vitest run --config vite.renderer.config.ts src/renderer/components/ProjectSettingsForm.test.tsx` — passed
- `git diff --check` — passed
- `npm run build` in `frontend/` — not available on current `main`; npm reports `Missing script: build`

## Known limitations

- reviewer auth remains advisory through the existing agent catalog; launch/preflight validates binary availability, while provider/auth failures use the existing runtime failure path
- Kilo headless JSON output is not an AO result contract
- this change does not implement Cursor
- the frontend package currently has no `build` script