### PR TITLE
feat: add Copilot reviewer

### DIFF
--- a/backend/internal/adapters/agent/copilot/copilot_test.go
+++ b/backend/internal/adapters/agent/copilot/copilot_test.go
@@ -735,6 +735,75 @@ func TestGetAgentHooksInstallsSessionCopilotAgent(t *testing.T) {
 	}
 }
 
+func TestInstallAgentProfileDoesNotInstallLifecycleHooks(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "copilot"}
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	systemPromptFile := filepath.Join(t.TempDir(), "system.md")
+	if err := os.WriteFile(systemPromptFile, []byte("review without modifying files\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := plugin.InstallAgentProfile(context.Background(), ports.WorkspaceHookConfig{
+		DataDir:          t.TempDir(),
+		SessionID:        "review-sess-1",
+		SystemPromptFile: systemPromptFile,
+		WorkspacePath:    workspace,
+	})
+	if err != nil {
+		t.Fatalf("InstallAgentProfile: %v", err)
+	}
+	profilePath := filepath.Join(workspace, ".github", "agents", "ao-review-sess-1.agent.md")
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "review without modifying files") {
+		t.Fatalf("hidden system prompt missing from profile:\n%s", data)
+	}
+	if _, err := os.Stat(copilotHooksPath(workspace)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("profile-only install created lifecycle hooks: %v", err)
+	}
+	exclude, err := os.ReadFile(filepath.Join(workspace, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(exclude), "/.github/agents/ao-review-sess-1.agent.md\n") {
+		t.Fatalf("profile is not git-excluded:\n%s", exclude)
+	}
+}
+
+func TestInstallAgentProfilePreservesUserOwnedProfile(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "copilot"}
+	workspace := t.TempDir()
+	profilePath := filepath.Join(workspace, ".github", "agents", "ao-review-sess-1.agent.md")
+	if err := os.MkdirAll(filepath.Dir(profilePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const userProfile = "---\nname: user-owned\n---\nkeep me\n"
+	if err := os.WriteFile(profilePath, []byte(userProfile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := plugin.InstallAgentProfile(context.Background(), ports.WorkspaceHookConfig{
+		SessionID:     "review-sess-1",
+		SystemPrompt:  "AO replacement",
+		WorkspacePath: workspace,
+	})
+	if err != nil {
+		t.Fatalf("InstallAgentProfile: %v", err)
+	}
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != userProfile {
+		t.Fatalf("user-owned profile changed:\n%s", data)
+	}
+}
+
 func TestGetAgentHooksIgnoresSessionCopilotAgentInLinkedWorktreeCommonExclude(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "copilot"}
 	dir := t.TempDir()
@@ -776,7 +845,7 @@ func TestGetAgentHooksIgnoresSessionCopilotAgentInLinkedWorktreeCommonExclude(t 
 	}
 }
 
-func TestGetAgentHooksUpdatesManagedSessionCopilotAgent(t *testing.T) {
+func TestInstallAgentProfileUpdatesManagedSessionCopilotAgent(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "copilot"}
 	workspace := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(workspace, ".git", "info"), 0o755); err != nil {
@@ -784,11 +853,11 @@ func TestGetAgentHooksUpdatesManagedSessionCopilotAgent(t *testing.T) {
 	}
 
 	cfg := ports.WorkspaceHookConfig{DataDir: t.TempDir(), SessionID: "sess-1", SystemPrompt: "old rules", WorkspacePath: workspace}
-	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+	if err := plugin.InstallAgentProfile(context.Background(), cfg); err != nil {
 		t.Fatal(err)
 	}
 	cfg.SystemPrompt = "new rules"
-	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+	if err := plugin.InstallAgentProfile(context.Background(), cfg); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/adapters/agent/copilot/hooks.go
+++ b/backend/internal/adapters/agent/copilot/hooks.go
@@ -87,28 +87,44 @@ var copilotManagedHooks = []copilotHookSpec{
 	{Event: "agentStop", Command: "stop"},
 }
 
+// InstallAgentProfile installs only AO's per-session Copilot custom-agent
+// profile. Reviewers use this directly because their lifecycle is owned by the
+// review launcher, not the worker activity hooks.
+func (p *Plugin) InstallAgentProfile(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WorkspacePath) == "" {
+		return errors.New("copilot.InstallAgentProfile: WorkspacePath is required")
+	}
+	if err := installCopilotAgent(cfg.WorkspacePath, cfg.SessionID, cfg.SystemPrompt, cfg.SystemPromptFile); err != nil {
+		return fmt.Errorf("copilot.InstallAgentProfile: %w", err)
+	}
+	return nil
+}
+
 // GetAgentHooks installs AO's Copilot workspace integration:
-//   - .github/hooks/ao.json for normalized activity-state signals.
 //   - .github/agents/ao-<session>.agent.md for an explicit per-session role.
+//   - .github/hooks/ao.json for normalized activity-state signals.
 //
 // The launch command selects that profile with --agent=ao-<session>. Avoid
 // writing a repository-root AGENTS.md here so AO does not compete with
 // project-owned instructions.
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if strings.TrimSpace(cfg.WorkspacePath) == "" {
-		return errors.New("copilot.GetAgentHooks: WorkspacePath is required")
-	}
-	if err := installCopilotAgent(cfg.WorkspacePath, cfg.SessionID, cfg.SystemPrompt, cfg.SystemPromptFile); err != nil {
+	if err := p.InstallAgentProfile(ctx, cfg); err != nil {
 		return fmt.Errorf("copilot.GetAgentHooks: %w", err)
 	}
+	if err := installCopilotHooks(cfg.WorkspacePath); err != nil {
+		return fmt.Errorf("copilot.GetAgentHooks: %w", err)
+	}
+	return nil
+}
 
-	hooksPath := copilotHooksPath(cfg.WorkspacePath)
+func installCopilotHooks(workspacePath string) error {
+	hooksPath := copilotHooksPath(workspacePath)
 	file, err := readCopilotHooks(hooksPath)
 	if err != nil {
-		return fmt.Errorf("copilot.GetAgentHooks: %w", err)
+		return err
 	}
 
 	if file.Hooks == nil {
@@ -128,10 +144,10 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	}
 
 	if err := writeCopilotHooks(hooksPath, file); err != nil {
-		return fmt.Errorf("copilot.GetAgentHooks: %w", err)
+		return err
 	}
 	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(hooksPath), copilotHooksFileName); err != nil {
-		return fmt.Errorf("copilot.GetAgentHooks: gitignore: %w", err)
+		return fmt.Errorf("gitignore: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/adapters/reviewer/copilot/copilot.go
+++ b/backend/internal/adapters/reviewer/copilot/copilot.go
@@ -1,0 +1,128 @@
+// Package copilot adapts the GitHub Copilot CLI worker for persistent,
+// restricted AO code-review sessions.
+package copilot
+
+import (
+	"context"
+
+	workeragent "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/copilot"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const availableTools = "bash,view,grep,glob"
+
+var allowedTools = []string{
+	"read",
+	"shell(git diff:*)",
+	"shell(git log:*)",
+	"shell(git show:*)",
+	"shell(git status:*)",
+	"shell(printf:*)",
+	"shell(gh api:*)",
+	"shell(ao review submit:*)",
+}
+
+var deniedTools = []string{
+	"write",
+	"shell(git push:*)",
+	"shell(git commit:*)",
+	"shell(git checkout:*)",
+	"shell(git reset:*)",
+	"shell(git clean:*)",
+	"shell(git apply:*)",
+	"shell(git merge:*)",
+	"shell(git rebase:*)",
+	"shell(git cherry-pick:*)",
+}
+
+type agent interface {
+	ports.Agent
+	InstallAgentProfile(context.Context, ports.WorkspaceHookConfig) error
+}
+
+// Reviewer is the GitHub Copilot CLI code-review adapter.
+type Reviewer struct {
+	agent agent
+}
+
+// New builds the Copilot reviewer adapter.
+func New() *Reviewer {
+	return &Reviewer{agent: workeragent.New()}
+}
+
+// Harness identifies this reviewer in the reviewer registry.
+func (r *Reviewer) Harness() domain.ReviewerHarness {
+	return domain.ReviewerCopilot
+}
+
+var _ ports.Reviewer = (*Reviewer)(nil)
+var _ ports.ReviewerCanceller = (*Reviewer)(nil)
+
+// PreLaunch installs only the AO-owned custom-agent profile. Reviewer panes do
+// not use worker lifecycle hooks, so this must not create .github/hooks/ao.json.
+func (r *Reviewer) PreLaunch(ctx context.Context, inv ports.ReviewInvocation) error {
+	return r.agent.InstallAgentProfile(ctx, ports.WorkspaceHookConfig{
+		DataDir:          inv.DataDir,
+		SessionID:        inv.ReviewerID,
+		WorkspacePath:    inv.WorkspacePath,
+		SystemPromptFile: inv.SystemPromptFile,
+	})
+}
+
+// ReviewCommand launches one persistent interactive pane with a narrow,
+// read-only Copilot policy. PermissionModeDefault is intentional: the worker
+// adapter maps auto to --allow-all-tools, which would defeat this policy.
+func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
+	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		DataDir:          inv.DataDir,
+		SessionID:        inv.ReviewerID,
+		WorkspacePath:    inv.WorkspacePath,
+		Prompt:           inv.Prompt,
+		SystemPromptFile: inv.SystemPromptFile,
+		Permissions:      ports.PermissionModeDefault,
+	})
+	if err != nil {
+		return ports.ReviewCommandSpec{}, err
+	}
+
+	policy := []string{"--available-tools", availableTools}
+	for _, tool := range allowedTools {
+		policy = append(policy, "--allow-tool", tool)
+	}
+	for _, tool := range deniedTools {
+		policy = append(policy, "--deny-tool", tool)
+	}
+	if inv.TaskPromptRoot != "" {
+		policy = append(policy, "--add-dir", inv.TaskPromptRoot)
+	}
+	policy = append(policy,
+		"--allow-url", "github.com",
+		"--allow-url", "api.github.com",
+		"--disable-builtin-mcps",
+		"--no-ask-user",
+	)
+	return ports.ReviewCommandSpec{Argv: insertBeforeInteractive(argv, policy...)}, nil
+}
+
+// ReviewMessage returns the centrally-authored task for the existing pane.
+func (r *Reviewer) ReviewMessage(_ context.Context, inv ports.ReviewInvocation) (string, error) {
+	return inv.Prompt, nil
+}
+
+// ReviewCancel interrupts twice, matching Copilot's interactive cancellation.
+func (r *Reviewer) ReviewCancel(context.Context) (ports.ReviewCancelSpec, error) {
+	return ports.ReviewCancelSpec{Mode: ports.ReviewCancelInterrupt, Interrupts: 2}, nil
+}
+
+func insertBeforeInteractive(argv []string, extra ...string) []string {
+	for i, arg := range argv {
+		if arg == "--interactive" || arg == "-i" {
+			out := make([]string, 0, len(argv)+len(extra))
+			out = append(out, argv[:i]...)
+			out = append(out, extra...)
+			return append(out, argv[i:]...)
+		}
+	}
+	return append(argv, extra...)
+}

--- a/backend/internal/adapters/reviewer/copilot/copilot_test.go
+++ b/backend/internal/adapters/reviewer/copilot/copilot_test.go
@@ -1,0 +1,270 @@
+package copilot
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type captureAgent struct {
+	launchConfig  ports.LaunchConfig
+	launchErr     error
+	profileConfig ports.WorkspaceHookConfig
+	profileErr    error
+}
+
+func (a *captureAgent) GetConfigSpec(context.Context) (ports.ConfigSpec, error) {
+	return ports.ConfigSpec{}, nil
+}
+
+func (a *captureAgent) GetLaunchCommand(_ context.Context, cfg ports.LaunchConfig) ([]string, error) {
+	a.launchConfig = cfg
+	if a.launchErr != nil {
+		return nil, a.launchErr
+	}
+	return []string{"copilot", "--agent=ao-review-w1", "--interactive", cfg.Prompt}, nil
+}
+
+func (a *captureAgent) GetPromptDeliveryStrategy(context.Context, ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	return ports.PromptDeliveryInCommand, nil
+}
+
+func (a *captureAgent) GetAgentHooks(context.Context, ports.WorkspaceHookConfig) error {
+	return nil
+}
+
+func (a *captureAgent) InstallAgentProfile(_ context.Context, cfg ports.WorkspaceHookConfig) error {
+	a.profileConfig = cfg
+	return a.profileErr
+}
+
+func (a *captureAgent) GetRestoreCommand(context.Context, ports.RestoreConfig) ([]string, bool, error) {
+	return nil, false, nil
+}
+
+func (a *captureAgent) SessionInfo(context.Context, ports.SessionRef) (ports.SessionInfo, bool, error) {
+	return ports.SessionInfo{}, false, nil
+}
+
+func TestPreLaunchInstallsOnlyReviewerProfileInputs(t *testing.T) {
+	agent := &captureAgent{}
+	r := &Reviewer{agent: agent}
+	inv := ports.ReviewInvocation{
+		DataDir:          "/ao",
+		ReviewerID:       "review-w1",
+		WorkspacePath:    "/ws/w1",
+		SystemPromptFile: "/ao/prompts/w1/reviewer/system.md",
+	}
+
+	if err := r.PreLaunch(context.Background(), inv); err != nil {
+		t.Fatalf("PreLaunch: %v", err)
+	}
+	want := ports.WorkspaceHookConfig{
+		DataDir:          inv.DataDir,
+		SessionID:        inv.ReviewerID,
+		WorkspacePath:    inv.WorkspacePath,
+		SystemPromptFile: inv.SystemPromptFile,
+	}
+	if !reflect.DeepEqual(agent.profileConfig, want) {
+		t.Fatalf("profile config = %#v, want %#v", agent.profileConfig, want)
+	}
+}
+
+func TestPreLaunchPropagatesProfileError(t *testing.T) {
+	want := errors.New("profile failed")
+	agent := &captureAgent{profileErr: want}
+	if err := (&Reviewer{agent: agent}).PreLaunch(context.Background(), ports.ReviewInvocation{}); !errors.Is(err, want) {
+		t.Fatalf("PreLaunch error = %v, want %v", err, want)
+	}
+}
+
+func TestReviewCommandUsesRestrictedPersistentPolicy(t *testing.T) {
+	agent := &captureAgent{}
+	r := &Reviewer{agent: agent}
+	promptRoot := filepath.Join("/ao", "prompts", "w1", "reviewer")
+	spec, err := r.ReviewCommand(context.Background(), ports.ReviewInvocation{
+		DataDir:          "/ao",
+		ReviewerID:       "review-w1",
+		WorkspacePath:    "/ws/w1",
+		Prompt:           "Read the hidden task.",
+		SystemPromptFile: filepath.Join(promptRoot, "system.md"),
+		TaskPromptRoot:   promptRoot,
+	})
+	if err != nil {
+		t.Fatalf("ReviewCommand: %v", err)
+	}
+
+	if agent.launchConfig.Permissions != ports.PermissionModeDefault {
+		t.Fatalf("permissions = %q, want default", agent.launchConfig.Permissions)
+	}
+	if agent.launchConfig.Prompt != "Read the hidden task." ||
+		agent.launchConfig.SystemPrompt != "" ||
+		agent.launchConfig.SystemPromptFile != filepath.Join(promptRoot, "system.md") {
+		t.Fatalf("launch config exposes or loses hidden prompt: %#v", agent.launchConfig)
+	}
+
+	interactive := slices.Index(spec.Argv, "--interactive")
+	if interactive < 0 || interactive != len(spec.Argv)-2 {
+		t.Fatalf("interactive prompt placement = %#v", spec.Argv)
+	}
+	for i, arg := range spec.Argv {
+		if i > interactive && arg != "Read the hidden task." {
+			t.Fatalf("policy argument appears after --interactive: %#v", spec.Argv)
+		}
+	}
+
+	policy := parsePolicy(t, spec.Argv[:interactive])
+	if got := policy.single("--available-tools"); got != availableTools {
+		t.Fatalf("available tools = %q, want %q", got, availableTools)
+	}
+	if got := policy.values["--add-dir"]; !slices.Equal(got, []string{promptRoot}) {
+		t.Fatalf("prompt root access = %#v, want exactly %#v", got, []string{promptRoot})
+	}
+	if got := policy.values["--allow-tool"]; !slices.Equal(got, allowedTools) {
+		t.Fatalf("allowed tools = %#v, want %#v", got, allowedTools)
+	}
+	if got := policy.values["--deny-tool"]; !slices.Equal(got, deniedTools) {
+		t.Fatalf("denied tools = %#v, want %#v", got, deniedTools)
+	}
+	if got := policy.values["--allow-url"]; !slices.Equal(got, []string{"github.com", "api.github.com"}) {
+		t.Fatalf("allowed urls = %#v", got)
+	}
+	for _, flag := range []string{"--disable-builtin-mcps", "--no-ask-user"} {
+		if !policy.flags[flag] {
+			t.Fatalf("missing %s in %#v", flag, spec.Argv)
+		}
+	}
+	for _, broad := range []string{"--allow-all", "--allow-all-tools", "--allow-all-paths"} {
+		if slices.Contains(spec.Argv, broad) {
+			t.Fatalf("broad permission %q present in %#v", broad, spec.Argv)
+		}
+	}
+}
+
+func TestReviewPolicyAllowsReviewCommandsAndDeniesWritesAndGitMutations(t *testing.T) {
+	for _, want := range []string{
+		"read",
+		"shell(git diff:*)",
+		"shell(git log:*)",
+		"shell(git show:*)",
+		"shell(git status:*)",
+		"shell(printf:*)",
+		"shell(gh api:*)",
+		"shell(ao review submit:*)",
+	} {
+		if !slices.Contains(allowedTools, want) {
+			t.Errorf("allowed policy missing %q: %#v", want, allowedTools)
+		}
+	}
+	for _, want := range []string{
+		"write",
+		"shell(git push:*)",
+		"shell(git commit:*)",
+		"shell(git checkout:*)",
+		"shell(git reset:*)",
+		"shell(git clean:*)",
+		"shell(git apply:*)",
+		"shell(git merge:*)",
+		"shell(git rebase:*)",
+		"shell(git cherry-pick:*)",
+	} {
+		if !slices.Contains(deniedTools, want) {
+			t.Errorf("denied policy missing %q: %#v", want, deniedTools)
+		}
+	}
+}
+
+func TestReviewMessageAndCancellation(t *testing.T) {
+	r := &Reviewer{}
+	msg, err := r.ReviewMessage(context.Background(), ports.ReviewInvocation{Prompt: "next hidden task"})
+	if err != nil || msg != "next hidden task" {
+		t.Fatalf("ReviewMessage = (%q, %v)", msg, err)
+	}
+	cancel, err := r.ReviewCancel(context.Background())
+	if err != nil {
+		t.Fatalf("ReviewCancel: %v", err)
+	}
+	if cancel.Mode != ports.ReviewCancelInterrupt || cancel.Interrupts != 2 {
+		t.Fatalf("cancel = %#v", cancel)
+	}
+}
+
+func TestReviewCommandReportsMissingCopilotBinary(t *testing.T) {
+	agent := &captureAgent{launchErr: ports.ErrAgentBinaryNotFound}
+	_, err := (&Reviewer{agent: agent}).ReviewCommand(context.Background(), ports.ReviewInvocation{})
+	if !errors.Is(err, ports.ErrAgentBinaryNotFound) {
+		t.Fatalf("ReviewCommand error = %v, want ErrAgentBinaryNotFound", err)
+	}
+}
+
+type parsedPolicy struct {
+	values map[string][]string
+	flags  map[string]bool
+}
+
+func (p parsedPolicy) single(flag string) string {
+	values := p.values[flag]
+	if len(values) != 1 {
+		return ""
+	}
+	return values[0]
+}
+
+func parsePolicy(t *testing.T, argv []string) parsedPolicy {
+	t.Helper()
+	withValue := map[string]bool{
+		"--available-tools": true,
+		"--allow-tool":      true,
+		"--deny-tool":       true,
+		"--add-dir":         true,
+		"--allow-url":       true,
+	}
+	got := parsedPolicy{values: map[string][]string{}, flags: map[string]bool{}}
+	for i := 0; i < len(argv); i++ {
+		arg := argv[i]
+		if withValue[arg] {
+			if i+1 >= len(argv) {
+				t.Fatalf("%s has no value in %#v", arg, argv)
+			}
+			i++
+			got.values[arg] = append(got.values[arg], argv[i])
+			continue
+		}
+		if strings.HasPrefix(arg, "--") && arg != "--agent=ao-review-w1" {
+			got.flags[arg] = true
+		}
+	}
+	return got
+}
+
+func TestNewReviewerRealCommandSelectsCustomAgent(t *testing.T) {
+	binDir := t.TempDir()
+	binaryName := "copilot"
+	if runtime.GOOS == "windows" {
+		binaryName = "copilot.cmd"
+	}
+	if err := os.WriteFile(filepath.Join(binDir, binaryName), []byte(""), 0o755); err != nil {
+		t.Fatalf("write fake copilot: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	spec, err := New().ReviewCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID:       "review-w1",
+		Prompt:           "review",
+		SystemPromptFile: "/ao/system.md",
+	})
+	if err != nil {
+		t.Fatalf("ReviewCommand: %v", err)
+	}
+	if !slices.Contains(spec.Argv, "--agent=ao-review-w1") {
+		t.Fatalf("custom agent missing from %#v", spec.Argv)
+	}
+}

--- a/backend/internal/adapters/reviewer/registry.go
+++ b/backend/internal/adapters/reviewer/registry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/reviewer/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/reviewer/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/reviewer/copilot"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/reviewer/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -25,6 +26,7 @@ func Constructors() []Adapter {
 	return []Adapter{
 		claudecode.New(),
 		codex.New(),
+		copilot.New(),
 		opencode.New(),
 	}
 }

--- a/backend/internal/domain/projectconfig_test.go
+++ b/backend/internal/domain/projectconfig_test.go
@@ -30,6 +30,7 @@ func TestProjectConfigValidate(t *testing.T) {
 		{"agent rules file bare dot", ProjectConfig{AgentRulesFile: "."}, true},
 		{"good reviewers", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerClaudeCode}}}, false},
 		{"good codex reviewer", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerCodex}}}, false},
+		{"good copilot reviewer", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerCopilot}}}, false},
 		{"good opencode reviewer", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerOpenCode}}}, false},
 		{"unknown reviewer harness", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: "nope"}}}, true},
 		{"worker-only harness is not auto a reviewer", ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerHarness(HarnessAider)}}}, true},
@@ -110,6 +111,9 @@ func TestResolveReviewerHarness(t *testing.T) {
 	}
 	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessCodex); got != ReviewerCodex {
 		t.Fatalf("codex worker = %q, want reviewer codex", got)
+	}
+	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessCopilot); got != ReviewerCopilot {
+		t.Fatalf("copilot worker = %q, want reviewer copilot", got)
 	}
 	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessOpenCode); got != ReviewerOpenCode {
 		t.Fatalf("opencode worker = %q, want reviewer opencode", got)

--- a/backend/internal/domain/reviewerharness.go
+++ b/backend/internal/domain/reviewerharness.go
@@ -12,6 +12,7 @@ type ReviewerHarness string
 const (
 	ReviewerClaudeCode ReviewerHarness = "claude-code"
 	ReviewerCodex      ReviewerHarness = "codex"
+	ReviewerCopilot    ReviewerHarness = "copilot"
 	ReviewerOpenCode   ReviewerHarness = "opencode"
 )
 
@@ -20,6 +21,7 @@ const (
 var AllReviewerHarnesses = []ReviewerHarness{
 	ReviewerClaudeCode,
 	ReviewerCodex,
+	ReviewerCopilot,
 	ReviewerOpenCode,
 }
 

--- a/backend/internal/ports/reviewer.go
+++ b/backend/internal/ports/reviewer.go
@@ -66,6 +66,9 @@ type ReviewInvocation struct {
 	ReviewIndex int
 	// WorkspacePath is the worker's checkout the reviewer reads.
 	WorkspacePath string
+	// DataDir is AO's owned state root. Reviewer prelaunch hooks may use it for
+	// profile installation but must not write outside AO/workspace boundaries.
+	DataDir string
 	// Prompt and SystemPrompt are the review instructions AO authored centrally,
 	// mirroring the worker's LaunchConfig.Prompt / SystemPrompt split: SystemPrompt
 	// carries the standing reviewer role, Prompt the per-pass task. A prompt-driven

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -133,6 +133,7 @@ func (l *agentLauncher) invocation(spec LaunchSpec) ports.ReviewInvocation {
 		ReviewQueue:     spec.ReviewQueue,
 		ReviewIndex:     spec.ReviewIndex,
 		WorkspacePath:   spec.WorkspacePath,
+		DataDir:         l.dataDir,
 		Prompt:          prompt,
 		SystemPrompt:    systemPrompt,
 	}

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -154,7 +154,7 @@ func TestLauncherSpawnReturnsStableHandle(t *testing.T) {
 	if len(rt.createCfg.Env) != 0 {
 		t.Fatalf("expected no env, got %v", rt.createCfg.Env)
 	}
-	if reviewer.gotInv.RunID != "run-1" || reviewer.gotInv.TargetSHA != "sha1" || reviewer.gotInv.ReviewerID != "review-mer-1" {
+	if reviewer.gotInv.RunID != "run-1" || reviewer.gotInv.TargetSHA != "sha1" || reviewer.gotInv.ReviewerID != "review-mer-1" || reviewer.gotInv.DataDir != dataDir {
 		t.Fatalf("invocation = %+v", reviewer.gotInv)
 	}
 	if !strings.HasPrefix(reviewer.gotInv.Prompt, reviewerTaskMessagePrefix) || reviewer.gotInv.SystemPrompt != "" || reviewer.gotInv.SystemPromptFile == "" || reviewer.gotInv.TaskPromptFile == "" {
@@ -212,7 +212,7 @@ func TestLauncherSpawnRunsReviewerPreLaunch(t *testing.T) {
 	if !reviewer.prelaunched {
 		t.Fatal("expected reviewer pre-launch to run")
 	}
-	if reviewer.gotPre.ReviewerID != "review-mer-1" || reviewer.gotPre.WorkspacePath != "/ws/mer-1" {
+	if reviewer.gotPre.ReviewerID != "review-mer-1" || reviewer.gotPre.WorkspacePath != "/ws/mer-1" || reviewer.gotPre.DataDir == "" {
 		t.Fatalf("prelaunch invocation = %+v", reviewer.gotPre)
 	}
 	if rt.createCfg.WorkspacePath == "" {

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -66,6 +66,7 @@ const agentCatalogResponse = {
 		supported: [
 			{ id: "claude-code", label: "Claude Code" },
 			{ id: "codex", label: "Codex" },
+			{ id: "copilot", label: "GitHub Copilot" },
 			{ id: "goose", label: "Goose" },
 			{ id: "kiro", label: "Kiro" },
 			{ id: "opencode", label: "OpenCode" },
@@ -73,6 +74,7 @@ const agentCatalogResponse = {
 		installed: [
 			{ id: "claude-code", label: "Claude Code", authStatus: "authorized" },
 			{ id: "codex", label: "Codex", authStatus: "authorized" },
+			{ id: "copilot", label: "GitHub Copilot", authStatus: "authorized" },
 			{ id: "goose", label: "Goose", authStatus: "authorized" },
 			{ id: "kiro", label: "Kiro", authStatus: "unknown" },
 			{ id: "opencode", label: "OpenCode", authStatus: "authorized" },
@@ -80,6 +82,7 @@ const agentCatalogResponse = {
 		authorized: [
 			{ id: "claude-code", label: "Claude Code", authStatus: "authorized" },
 			{ id: "codex", label: "Codex", authStatus: "authorized" },
+			{ id: "copilot", label: "GitHub Copilot", authStatus: "authorized" },
 			{ id: "goose", label: "Goose", authStatus: "authorized" },
 			{ id: "opencode", label: "OpenCode", authStatus: "authorized" },
 		],
@@ -409,10 +412,129 @@ describe("ProjectSettingsForm", () => {
 			"Claude Code",
 			"Codex",
 			"OpenCode",
+			"GitHub Copilot",
 			"Goose",
 			"KiroAuth unknown",
 		]);
-		expect(options[4]).not.toHaveAttribute("aria-disabled", "true");
+		expect(options[5]).not.toHaveAttribute("aria-disabled", "true");
+	});
+
+	it("shows Copilot as a reviewer option and saves it in the reviewers payload", async () => {
+		mockProject({
+			id: "proj-1",
+			name: "Project One",
+			kind: "single_repo",
+			path: "/repo/project-one",
+			repo: "",
+			defaultBranch: "main",
+			config: {
+				worker: { agent: "codex" },
+				orchestrator: { agent: "claude-code" },
+			},
+		});
+
+		renderSettings();
+
+		const reviewer = await screen.findByRole("button", { name: "Default reviewer agent" });
+		await userEvent.click(reviewer);
+		const copilot = await screen.findByRole("menuitem", { name: "GitHub Copilot" });
+		expect(copilot).not.toHaveAttribute("aria-disabled", "true");
+		await userEvent.click(copilot);
+		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
+		expect(putMock).toHaveBeenCalledWith(
+			"/api/v1/projects/{id}",
+			expect.objectContaining({
+				body: expect.objectContaining({
+					config: expect.objectContaining({ reviewers: [{ harness: "copilot" }] }),
+				}),
+			}),
+		);
+	});
+
+	it("disables the Copilot reviewer when its binary is missing", async () => {
+		getMock.mockImplementation(async (path: string) => {
+			if (path === "/api/v1/agents") {
+				return {
+					data: {
+						supported: [{ id: "copilot", label: "GitHub Copilot" }],
+						installed: [],
+						authorized: [],
+					},
+					error: undefined,
+				};
+			}
+			return {
+				data: {
+					status: "ok",
+					project: {
+						id: "proj-1",
+						name: "Project One",
+						kind: "single_repo",
+						path: "/repo/project-one",
+						repo: "",
+						defaultBranch: "main",
+						config: {
+							worker: { agent: "codex" },
+							orchestrator: { agent: "claude-code" },
+						},
+					},
+				},
+				error: undefined,
+			};
+		});
+
+		renderSettings();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Default reviewer agent" }));
+		const copilot = (await screen.findAllByRole("menuitem")).find((option) =>
+			option.textContent?.includes("GitHub Copilot"),
+		);
+		expect(copilot).toHaveTextContent("Needs install");
+		expect(copilot).toHaveAttribute("aria-disabled", "true");
+	});
+
+	it("shows the standard unknown-auth warning for an installed Copilot reviewer", async () => {
+		getMock.mockImplementation(async (path: string) => {
+			if (path === "/api/v1/agents") {
+				return {
+					data: {
+						supported: [{ id: "copilot", label: "GitHub Copilot" }],
+						installed: [{ id: "copilot", label: "GitHub Copilot", authStatus: "unknown" }],
+						authorized: [],
+					},
+					error: undefined,
+				};
+			}
+			return {
+				data: {
+					status: "ok",
+					project: {
+						id: "proj-1",
+						name: "Project One",
+						kind: "single_repo",
+						path: "/repo/project-one",
+						repo: "",
+						defaultBranch: "main",
+						config: {
+							worker: { agent: "codex" },
+							orchestrator: { agent: "claude-code" },
+						},
+					},
+				},
+				error: undefined,
+			};
+		});
+
+		renderSettings();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Default reviewer agent" }));
+		const copilot = (await screen.findAllByRole("menuitem")).find((option) =>
+			option.textContent?.includes("GitHub Copilot"),
+		);
+		expect(copilot).toHaveTextContent("Auth unknown");
+		expect(copilot).not.toHaveAttribute("aria-disabled", "true");
 	});
 
 	it("shows scratch identity and saves only scratch-supported settings", async () => {

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -49,7 +49,7 @@ const PERMISSION_MODE_OPTIONS = [
 	{ value: "bypass-permissions", label: "Bypass permissions" },
 ] as const;
 
-const KNOWN_REVIEWER_HARNESS_IDS = new Set(["claude-code", "codex", "opencode"]);
+const KNOWN_REVIEWER_HARNESS_IDS = new Set(["claude-code", "codex", "copilot", "opencode"]);
 
 const projectQueryKey = (id: string) => ["project", id] as const;
 
@@ -492,7 +492,7 @@ function PermissionModeSelect({ value, onChange }: { value: string; onChange: (v
 	);
 }
 
-const REVIEWER_AGENT_PRIORITY = ["claude-code", "codex", "cursor", "opencode", "aider"] as const;
+const REVIEWER_AGENT_PRIORITY = ["claude-code", "codex", "copilot", "cursor", "opencode", "aider"] as const;
 const REVIEWER_AGENT_PRIORITY_RANK = new Map<string, number>(
 	REVIEWER_AGENT_PRIORITY.map((agent, index) => [agent, index]),
 );


### PR DESCRIPTION
## Summary
- add GitHub Copilot CLI as a persistent AO reviewer with a narrow read-only command policy
- split Copilot custom-agent profile installation from worker lifecycle hooks
- register Copilot in reviewer resolution and project settings

## Tests
- go test ./internal/adapters/agent/copilot ./internal/adapters/reviewer/copilot ./internal/adapters/reviewer ./internal/domain ./internal/review
- ProjectSettingsForm Vitest: 17 passed
- npm run frontend:typecheck
- golangci-lint v2.12.2
- git diff --check
- Copilot CLI 1.0.76 parser check with the exact allow/deny policy

## Known limitations
- Full npm run lint was attempted repeatedly, but unrelated shared-host integration tests collided with concurrent AO sessions: the fake lifecycle timing test observed scheduler-delayed sleeps, and the tmux integration test reused a globally named session. Focused packages and golangci-lint pass.
- Real security smoke omitted because no designated safe test PR was available.