### PR TITLE
fix: harden PostHog telemetry controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ ao start
 
 ## Telemetry
 
-Agent Orchestrator's Electron renderer sends anonymous usage events to PostHog for reliability and product understanding, and PostHog session recording is enabled with local paths and local URLs redacted before transmission. Set `VITE_AO_POSTHOG_KEY` to an empty string before building to disable transmission. See [docs/telemetry.md](docs/telemetry.md).
+Agent Orchestrator's Electron renderer sends anonymous usage events to PostHog for reliability and product understanding. PostHog session recording is disabled by default; if a time-boxed investigation enables it, local paths and local URLs are redacted before transmission. Set `VITE_AO_POSTHOG_KEY` to an empty string before building to disable transmission. See [docs/telemetry.md](docs/telemetry.md).
 
 ## License
 

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemon"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/processalive"
+	"github.com/aoagents/agent-orchestrator/backend/internal/telemetrymeta"
 )
 
 // Execute runs the ao CLI with process stdio.
@@ -211,8 +212,8 @@ type commandContext struct {
 }
 
 func shouldEmitCLIInvocation(cmd *cobra.Command) bool {
-	commandPath := strings.TrimSpace(cmd.CommandPath())
-	if isRoutineInternalCLICommand(commandPath) {
+	commandPath := telemetrymeta.NormalizeCommandPath(cmd.CommandPath())
+	if telemetrymeta.IsRoutineInternalCLICommand(commandPath) {
 		return false
 	}
 	switch commandPath {
@@ -224,22 +225,6 @@ func shouldEmitCLIInvocation(cmd *cobra.Command) bool {
 		return false
 	default:
 		return true
-	}
-}
-
-func isRoutineInternalCLICommand(commandPath string) bool {
-	switch strings.TrimSpace(commandPath) {
-	case "ao status",
-		"ao session ls",
-		"ao session get",
-		"ao project ls",
-		"ao project get",
-		"ao orchestrator ls",
-		"ao hooks",
-		"ao pty-host":
-		return true
-	default:
-		return false
 	}
 }
 

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemonmeta"
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+	"github.com/aoagents/agent-orchestrator/backend/internal/telemetrymeta"
 )
 
 func TestRootHelpDoesNotShowDaemon(t *testing.T) {
@@ -147,6 +148,39 @@ func TestCLIInvocationActorType(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-session-1")
 	if got := cliInvocationActorType(byName["status"]); got != "agent" {
 		t.Fatalf("status actor with session env = %q, want agent", got)
+	}
+}
+
+func TestTelemetryMetaClassifiesRegisteredCommandPaths(t *testing.T) {
+	systemCommands := map[string]struct{}{
+		"ao agent-process":           {},
+		"ao agent-process supervise": {},
+		"ao completion":              {},
+		"ao daemon":                  {},
+		"ao help":                    {},
+		"ao pty-host":                {},
+		"ao start":                   {},
+	}
+
+	var failures []string
+	var walk func(*cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		for _, child := range cmd.Commands() {
+			path := telemetrymeta.NormalizeCommandPath(child.CommandPath())
+			got := telemetrymeta.CLIActorType("", path)
+			if got == "system" {
+				_, explicitlySystem := systemCommands[path]
+				if !explicitlySystem && !telemetrymeta.IsRoutineInternalCLICommand(path) {
+					failures = append(failures, path)
+				}
+			}
+			walk(child)
+		}
+	}
+	walk(NewRootCommand(Deps{}))
+
+	if len(failures) > 0 {
+		t.Fatalf("actor-less command paths classified as system: %s", strings.Join(failures, ", "))
 	}
 }
 

--- a/backend/internal/httpd/cli_telemetry_reservoir.go
+++ b/backend/internal/httpd/cli_telemetry_reservoir.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/telemetrymeta"
 )
 
 const cliTelemetryStateFile = "telemetry_cli_daily.json"
@@ -84,7 +86,7 @@ func activeCaptureSlot(now time.Time) int {
 }
 
 func cliInvokedReservationKey(actorType, commandPath string) string {
-	return actorType + "\t" + commandPath
+	return actorType + "\t" + telemetrymeta.NormalizeCommandPath(commandPath)
 }
 
 func (r *cliTelemetryReservoir) load() {

--- a/backend/internal/httpd/cli_telemetry_reservoir_test.go
+++ b/backend/internal/httpd/cli_telemetry_reservoir_test.go
@@ -49,6 +49,22 @@ func TestCLITelemetryReservoirResetsOnNewUTCDay(t *testing.T) {
 	}
 }
 
+func TestCLITelemetryReservoirNormalizesCommandPathReservations(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+
+	r := newCLITelemetryReservoir(dir)
+	if !r.reserveInvoked(now, "user", "AO   SEND") {
+		t.Fatal("first normalized command reservation = false, want true")
+	}
+	if r.reserveInvoked(now, "user", "ao send") {
+		t.Fatal("same normalized command reservation = true, want false")
+	}
+	if !r.reserveInvoked(now, "agent", "ao send") {
+		t.Fatal("same normalized command with different actor = false, want true")
+	}
+}
+
 func TestCLITelemetryReservoirActiveReservationsUseSixHourSlots(t *testing.T) {
 	dir := t.TempDir()
 	r := newCLITelemetryReservoir(dir)

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -184,7 +184,7 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 			return
 		}
 		commandPath := telemetrymeta.NormalizeCommandPath(body.CommandPath)
-		actorType := cliActorType(body.ActorType, commandPath)
+		actorType := telemetrymeta.CLIActorType(body.ActorType, commandPath)
 		if actorType == "system" {
 			w.WriteHeader(http.StatusAccepted)
 			return
@@ -265,32 +265,6 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 		})
 		w.WriteHeader(http.StatusAccepted)
 	})
-}
-
-func cliActorType(actorType, commandPath string) string {
-	switch actorType {
-	case "agent", "user":
-		return actorType
-	case "system":
-		return "system"
-	}
-	commandPath = telemetrymeta.NormalizeCommandPath(commandPath)
-	switch commandPath {
-	case "ao hooks":
-		return "agent"
-	case "ao daemon", "ao start", "ao completion", "ao help", "ao pty-host":
-		return "system"
-	case "ao add", "ao agent", "ao cancel", "ao claim-pr", "ao cleanup", "ao clear", "ao delete",
-		"ao doctor", "ao import", "ao import-projects", "ao kill", "ao launch", "ao merge",
-		"ao preview", "ao project add", "ao project rm", "ao project set-config", "ao remove",
-		"ao rename", "ao resolve-comments", "ao restart", "ao restore", "ao review",
-		"ao review submit", "ao send", "ao session cleanup", "ao session kill",
-		"ao session rename", "ao session restore", "ao spawn", "ao stop", "ao submit",
-		"ao trigger", "ao version":
-		return "user"
-	default:
-		return "system"
-	}
 }
 
 // localControlRequest reports whether a control request is a trusted local

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -194,7 +194,7 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 			return
 		}
 
-		if now := time.Now(); cliTelemetry.reserveInvoked(now, actorType, body.CommandPath) {
+		if now := time.Now(); cliTelemetry.reserveInvoked(now, actorType, commandPath) {
 			sink.Emit(req.Context(), ports.TelemetryEvent{
 				Name:       "ao.cli.invoked",
 				Source:     "cli",

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -184,12 +183,13 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 			envelope.WriteAPIError(w, req, http.StatusBadRequest, "bad_request", "COMMAND_PATH_REQUIRED", "commandPath is required", nil)
 			return
 		}
-		actorType := cliActorType(body.ActorType, body.CommandPath)
+		commandPath := telemetrymeta.NormalizeCommandPath(body.CommandPath)
+		actorType := cliActorType(body.ActorType, commandPath)
 		if actorType == "system" {
 			w.WriteHeader(http.StatusAccepted)
 			return
 		}
-		if isRoutineInternalCLICommand(body.CommandPath) {
+		if telemetrymeta.IsRoutineInternalCLICommand(commandPath) {
 			w.WriteHeader(http.StatusAccepted)
 			return
 		}
@@ -203,7 +203,7 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 				RequestID:  middleware.GetReqID(req.Context()),
 				Payload: map[string]any{
 					"command":      body.Command,
-					"command_path": body.CommandPath,
+					"command_path": commandPath,
 					"actor_type":   actorType,
 				},
 			})
@@ -219,7 +219,7 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 					Payload: map[string]any{
 						"channel":      "cli",
 						"command":      body.Command,
-						"command_path": body.CommandPath,
+						"command_path": commandPath,
 						"actor_type":   actorType,
 					},
 				})
@@ -267,22 +267,6 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 	})
 }
 
-func isRoutineInternalCLICommand(commandPath string) bool {
-	switch strings.TrimSpace(commandPath) {
-	case "ao status",
-		"ao session ls",
-		"ao session get",
-		"ao project ls",
-		"ao project get",
-		"ao orchestrator ls",
-		"ao hooks",
-		"ao pty-host":
-		return true
-	default:
-		return false
-	}
-}
-
 func cliActorType(actorType, commandPath string) string {
 	switch actorType {
 	case "agent", "user":
@@ -290,13 +274,22 @@ func cliActorType(actorType, commandPath string) string {
 	case "system":
 		return "system"
 	}
+	commandPath = telemetrymeta.NormalizeCommandPath(commandPath)
 	switch commandPath {
 	case "ao hooks":
 		return "agent"
 	case "ao daemon", "ao start", "ao completion", "ao help", "ao pty-host":
 		return "system"
-	default:
+	case "ao add", "ao agent", "ao cancel", "ao claim-pr", "ao cleanup", "ao clear", "ao delete",
+		"ao doctor", "ao import", "ao import-projects", "ao kill", "ao launch", "ao merge",
+		"ao preview", "ao project add", "ao project rm", "ao project set-config", "ao remove",
+		"ao rename", "ao resolve-comments", "ao restart", "ao restore", "ao review",
+		"ao review submit", "ao send", "ao session cleanup", "ao session kill",
+		"ao session rename", "ao session restore", "ao spawn", "ao stop", "ao submit",
+		"ao trigger", "ao version":
 		return "user"
+	default:
+		return "system"
 	}
 }
 

--- a/backend/internal/httpd/telemetry_test.go
+++ b/backend/internal/httpd/telemetry_test.go
@@ -92,6 +92,9 @@ func TestCLIInvokedRouteDropsRoutineInternalSuccessTelemetry(t *testing.T) {
 		`{"command":"get","commandPath":"ao project get","actorType":"user"}`,
 		`{"command":"ls","commandPath":"ao orchestrator ls","actorType":"user"}`,
 		`{"command":"hooks","commandPath":"ao hooks","actorType":"agent"}`,
+		`{"command":"hooks","commandPath":"ao  hooks","actorType":"user"}`,
+		`{"command":"hooks","commandPath":"AO HOOKS","actorType":"user"}`,
+		`{"command":"hooks","commandPath":"ao hooks claude-code post-tool-use","actorType":"user"}`,
 		`{"command":"pty-host","commandPath":"ao pty-host","actorType":"system"}`,
 	} {
 		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/internal/telemetry/cli-invoked", strings.NewReader(body))
@@ -106,6 +109,23 @@ func TestCLIInvokedRouteDropsRoutineInternalSuccessTelemetry(t *testing.T) {
 
 	if len(sink.events) != 0 {
 		t.Fatalf("events = %#v, want none for routine internal successes", sink.events)
+	}
+}
+
+func TestCLIInvokedRouteDropsUnknownLegacyCommandPaths(t *testing.T) {
+	sink := &captureSink{}
+	r := NewRouterWithControl(config.Config{DataDir: t.TempDir()}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/internal/telemetry/cli-invoked", strings.NewReader(`{"command":"surprise","commandPath":"ao surprise"}`))
+	req.Host = "127.0.0.1:3001"
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	if len(sink.events) != 0 {
+		t.Fatalf("events = %#v, want none for unknown legacy command", sink.events)
 	}
 }
 

--- a/backend/internal/telemetrymeta/cli.go
+++ b/backend/internal/telemetrymeta/cli.go
@@ -30,3 +30,114 @@ var routineInternalCLICommands = []string{
 	"ao hooks",
 	"ao pty-host",
 }
+
+// CLIActorType infers the actor for legacy loopback CLI telemetry requests that
+// predate the explicit actor_type field. Unknown actor-less commands are treated
+// as system activity so foreign/local automation cannot inflate DAU by default.
+func CLIActorType(actorType, commandPath string) string {
+	switch actorType {
+	case "agent", "user":
+		return actorType
+	case "system":
+		return "system"
+	}
+
+	normalized := NormalizeCommandPath(commandPath)
+	if _, ok := legacyActorlessSystemCLICommands[normalized]; ok {
+		return "system"
+	}
+	if _, ok := legacyActorlessUserCLICommands[normalized]; ok {
+		return "user"
+	}
+	if normalized == "ao hooks" {
+		return "agent"
+	}
+	return "system"
+}
+
+var legacyActorlessSystemCLICommands = map[string]struct{}{
+	"ao agent-process":           {},
+	"ao agent-process supervise": {},
+	"ao completion":              {},
+	"ao daemon":                  {},
+	"ao help":                    {},
+	"ao pty-host":                {},
+	"ao start":                   {},
+}
+
+var legacyActorlessUserCLICommands = map[string]struct{}{
+	"ao agent":                  {},
+	"ao agent ls":               {},
+	"ao browser":                {},
+	"ao browser check":          {},
+	"ao browser click":          {},
+	"ao browser console":        {},
+	"ao browser errors":         {},
+	"ao browser fill":           {},
+	"ao browser get":            {},
+	"ao browser highlight":      {},
+	"ao browser hover":          {},
+	"ao browser network":        {},
+	"ao browser network clear":  {},
+	"ao browser network list":   {},
+	"ao browser network start":  {},
+	"ao browser network status": {},
+	"ao browser network stop":   {},
+	"ao browser open":           {},
+	"ao browser press":          {},
+	"ao browser screenshot":     {},
+	"ao browser scroll":         {},
+	"ao browser select":         {},
+	"ao browser snapshot":       {},
+	"ao browser tab":            {},
+	"ao browser tab close":      {},
+	"ao browser tab new":        {},
+	"ao browser tab select":     {},
+	"ao browser status":         {},
+	"ao browser tabs":           {},
+	"ao browser type":           {},
+	"ao browser uncheck":        {},
+	"ao browser unhighlight":    {},
+	"ao browser wait":           {},
+	"ao dev":                    {},
+	"ao dev import-projects":    {},
+	"ao doctor":                 {},
+	"ao import":                 {},
+	"ao launch":                 {},
+	"ao orchestrator":           {},
+	"ao orchestrator done":      {},
+	"ao pr":                     {},
+	"ao pr merge":               {},
+	"ao pr resolve-comments":    {},
+	"ao preview":                {},
+	"ao preview clear":          {},
+	"ao preview start":          {},
+	"ao preview status":         {},
+	"ao preview stop":           {},
+	"ao project":                {},
+	"ao project add":            {},
+	"ao project rm":             {},
+	"ao project set-config":     {},
+	"ao review":                 {},
+	"ao review cancel":          {},
+	"ao review ls":              {},
+	"ao review submit":          {},
+	"ao review trigger":         {},
+	"ao send":                   {},
+	"ao session":                {},
+	"ao session claim-pr":       {},
+	"ao session cleanup":        {},
+	"ao session kill":           {},
+	"ao session rename":         {},
+	"ao session restore":        {},
+	"ao spawn":                  {},
+	"ao stop":                   {},
+	"ao version":                {},
+
+	// Legacy commands observed in PostHog's current billing-period data.
+	"ao handoff":                   {},
+	"ao project orchestration get": {},
+	"ao project orchestration set": {},
+	"ao smoke list":                {},
+	"ao smoke set":                 {},
+}

--- a/backend/internal/telemetrymeta/cli.go
+++ b/backend/internal/telemetrymeta/cli.go
@@ -35,6 +35,11 @@ var routineInternalCLICommands = []string{
 // predate the explicit actor_type field. Unknown actor-less commands are treated
 // as system activity so foreign/local automation cannot inflate DAU by default.
 func CLIActorType(actorType, commandPath string) string {
+	normalized := NormalizeCommandPath(commandPath)
+	if _, ok := legacyActorlessSystemCLICommands[normalized]; ok {
+		return "system"
+	}
+
 	switch actorType {
 	case "agent", "user":
 		return actorType
@@ -42,10 +47,6 @@ func CLIActorType(actorType, commandPath string) string {
 		return "system"
 	}
 
-	normalized := NormalizeCommandPath(commandPath)
-	if _, ok := legacyActorlessSystemCLICommands[normalized]; ok {
-		return "system"
-	}
 	if _, ok := legacyActorlessUserCLICommands[normalized]; ok {
 		return "user"
 	}

--- a/backend/internal/telemetrymeta/cli.go
+++ b/backend/internal/telemetrymeta/cli.go
@@ -1,0 +1,32 @@
+package telemetrymeta
+
+import "strings"
+
+// NormalizeCommandPath canonicalizes command paths received from current CLIs
+// and best-effort legacy loopback callers before cost-control classification.
+func NormalizeCommandPath(commandPath string) string {
+	return strings.ToLower(strings.Join(strings.Fields(commandPath), " "))
+}
+
+// IsRoutineInternalCLICommand reports whether a successful CLI invocation is
+// routine desktop/agent plumbing rather than product usage.
+func IsRoutineInternalCLICommand(commandPath string) bool {
+	normalized := NormalizeCommandPath(commandPath)
+	for _, routine := range routineInternalCLICommands {
+		if normalized == routine || strings.HasPrefix(normalized, routine+" ") {
+			return true
+		}
+	}
+	return false
+}
+
+var routineInternalCLICommands = []string{
+	"ao status",
+	"ao session ls",
+	"ao session get",
+	"ao project ls",
+	"ao project get",
+	"ao orchestrator ls",
+	"ao hooks",
+	"ao pty-host",
+}

--- a/backend/internal/telemetrymeta/cli_test.go
+++ b/backend/internal/telemetrymeta/cli_test.go
@@ -1,0 +1,25 @@
+package telemetrymeta
+
+import "testing"
+
+func TestNormalizeCommandPath(t *testing.T) {
+	if got := NormalizeCommandPath("  AO   Hooks  claude-code  post-tool-use "); got != "ao hooks claude-code post-tool-use" {
+		t.Fatalf("NormalizeCommandPath = %q, want normalized lowercase fields", got)
+	}
+}
+
+func TestIsRoutineInternalCLICommandNormalizesLegacyShapes(t *testing.T) {
+	for _, commandPath := range []string{
+		"ao hooks",
+		"ao  hooks",
+		"AO HOOKS",
+		"ao hooks claude-code post-tool-use",
+		"ao session get sess-123",
+		"ao project ls",
+		"ao pty-host session-1",
+	} {
+		if !IsRoutineInternalCLICommand(commandPath) {
+			t.Errorf("IsRoutineInternalCLICommand(%q) = false, want true", commandPath)
+		}
+	}
+}

--- a/backend/internal/telemetrymeta/cli_test.go
+++ b/backend/internal/telemetrymeta/cli_test.go
@@ -23,3 +23,39 @@ func TestIsRoutineInternalCLICommandNormalizesLegacyShapes(t *testing.T) {
 		}
 	}
 }
+
+func TestCLIActorTypeKeepsKnownLegacyUserCommands(t *testing.T) {
+	for _, commandPath := range []string{
+		"ao agent ls",
+		"ao session claim-pr",
+		"ao dev import-projects",
+		"ao project orchestration get",
+		"ao project orchestration set",
+		"ao handoff",
+		"ao smoke list",
+		"ao smoke set",
+	} {
+		if got := CLIActorType("", commandPath); got != "user" {
+			t.Errorf("CLIActorType(%q) = %q, want user", commandPath, got)
+		}
+	}
+}
+
+func TestCLIActorTypeKeepsConservativeFallback(t *testing.T) {
+	for _, tc := range []struct {
+		actorType   string
+		commandPath string
+		want        string
+	}{
+		{actorType: "agent", commandPath: "ao surprise", want: "agent"},
+		{actorType: "user", commandPath: "ao surprise", want: "user"},
+		{actorType: "system", commandPath: "ao spawn", want: "system"},
+		{commandPath: "ao daemon", want: "system"},
+		{commandPath: "ao spawn", want: "user"},
+		{commandPath: "ao surprise", want: "system"},
+	} {
+		if got := CLIActorType(tc.actorType, tc.commandPath); got != tc.want {
+			t.Errorf("CLIActorType(%q, %q) = %q, want %q", tc.actorType, tc.commandPath, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/telemetrymeta/cli_test.go
+++ b/backend/internal/telemetrymeta/cli_test.go
@@ -41,6 +41,21 @@ func TestCLIActorTypeKeepsKnownLegacyUserCommands(t *testing.T) {
 	}
 }
 
+func TestCLIActorTypeSystemCommandsOverrideExplicitActor(t *testing.T) {
+	for _, tc := range []struct {
+		actorType   string
+		commandPath string
+	}{
+		{actorType: "user", commandPath: "ao daemon"},
+		{actorType: "agent", commandPath: "ao start"},
+		{actorType: "user", commandPath: "AO  AGENT-PROCESS  SUPERVISE"},
+	} {
+		if got := CLIActorType(tc.actorType, tc.commandPath); got != "system" {
+			t.Errorf("CLIActorType(%q, %q) = %q, want system", tc.actorType, tc.commandPath, got)
+		}
+	}
+}
+
 func TestCLIActorTypeKeepsConservativeFallback(t *testing.T) {
 	for _, tc := range []struct {
 		actorType   string

--- a/docs/posthog-cost-controls.md
+++ b/docs/posthog-cost-controls.md
@@ -60,10 +60,12 @@ Configure PostHog ingestion controls for project `475752` in this order.
    `ao.session.waiting_input_exited`, `ao.http.5xx`, and `ao.daemon.panic`.
 6. Drop `$web_vitals` unless a time-boxed performance investigation needs it.
 
-The 7-day estimate from these rules is a reduction from roughly 2.4M total
-events to well under 250k, before organic adoption of current builds. That is a
-10x+ reduction while keeping renderer DAU, current v2 CLI DAU, current v2
-command adoption, and reliability events.
+When these project-side ingestion controls are enabled, the 7-day estimate is a
+reduction from roughly 2.4M total events to well under 250k, before organic
+adoption of current builds. That is a 10x+ reduction while keeping renderer
+DAU, current v2 CLI DAU, current v2 command adoption, and reliability events.
+The app code alone does not enforce these PostHog UI rules for already-deployed
+legacy clients.
 
 ## Follow-up: Failure-only Internal CLI Telemetry
 

--- a/docs/posthog-cost-controls.md
+++ b/docs/posthog-cost-controls.md
@@ -44,7 +44,9 @@ Configure PostHog ingestion controls for project `475752` in this order.
 2. Drop legacy CLI firehose events where `event = 'ao.cli.invoked'` and
    `actor_type` is missing or null.
 3. Drop legacy active-user firehose events where `event = 'ao.app.active'`,
-   `channel = 'cli'`, `actor_type` is missing or null, and `command_path` is in:
+   `channel = 'cli'`, `actor_type` is missing or null, and normalized
+   `command_path` (lowercase with whitespace collapsed) equals one of these
+   routine paths, or starts with one of them followed by a space:
    - `ao hooks`
    - `ao session ls`
    - `ao session get`
@@ -191,6 +193,7 @@ For historical DAU before v2 rollout, keep existing `ao.app.active` charts but
 filter out legacy CLI automation:
 
 ```sql
+WITH lower(replaceRegexpAll(trim(BOTH ' ' FROM toString(properties.command_path)), '\\s+', ' ')) AS normalized_command_path
 SELECT
     toDate(timestamp) AS day,
     uniqExact(distinct_id) AS active_installs
@@ -200,15 +203,25 @@ WHERE timestamp >= now() - INTERVAL 90 DAY
   AND NOT (
     properties.channel = 'cli'
     AND (properties.actor_type IS NULL OR properties.actor_type = '')
-    AND properties.command_path IN (
-      'ao hooks',
-      'ao session ls',
-      'ao session get',
-      'ao orchestrator ls',
-      'ao status',
-      'ao project ls',
-      'ao project get',
-      'ao pty-host'
+    AND (
+      normalized_command_path IN (
+        'ao hooks',
+        'ao session ls',
+        'ao session get',
+        'ao orchestrator ls',
+        'ao status',
+        'ao project ls',
+        'ao project get',
+        'ao pty-host'
+      )
+      OR startsWith(normalized_command_path, 'ao hooks ')
+      OR startsWith(normalized_command_path, 'ao session ls ')
+      OR startsWith(normalized_command_path, 'ao session get ')
+      OR startsWith(normalized_command_path, 'ao orchestrator ls ')
+      OR startsWith(normalized_command_path, 'ao status ')
+      OR startsWith(normalized_command_path, 'ao project ls ')
+      OR startsWith(normalized_command_path, 'ao project get ')
+      OR startsWith(normalized_command_path, 'ao pty-host ')
     )
   )
 GROUP BY day

--- a/docs/posthog-cost-controls.md
+++ b/docs/posthog-cost-controls.md
@@ -224,36 +224,42 @@ For historical DAU before v2 rollout, keep existing `ao.app.active` charts but
 filter out legacy CLI automation:
 
 ```sql
-WITH lower(replaceRegexpAll(trim(BOTH ' ' FROM toString(properties.command_path)), '\\s+', ' ')) AS normalized_command_path
 SELECT
-    toDate(timestamp) AS day,
+    day,
     uniqExact(distinct_id) AS active_installs
-FROM events
-WHERE timestamp >= now() - INTERVAL 90 DAY
-  AND event = 'ao.app.active'
-  AND NOT (
-    properties.channel = 'cli'
+FROM (
+    SELECT
+        distinct_id,
+        toDate(timestamp) AS day,
+        lower(trim(replaceRegexpAll(toString(properties.command_path), '[[:space:]]+', ' '))) AS normalized_command_path,
+        properties.channel AS channel
+    FROM events
+    WHERE timestamp >= now() - INTERVAL 90 DAY
+      AND event = 'ao.app.active'
+)
+WHERE NOT (
+    channel = 'cli'
     AND (
-      normalized_command_path IN (
-        'ao hooks',
-        'ao session ls',
-        'ao session get',
-        'ao orchestrator ls',
-        'ao status',
-        'ao project ls',
-        'ao project get',
-        'ao pty-host'
-      )
-      OR startsWith(normalized_command_path, 'ao hooks ')
-      OR startsWith(normalized_command_path, 'ao session ls ')
-      OR startsWith(normalized_command_path, 'ao session get ')
-      OR startsWith(normalized_command_path, 'ao orchestrator ls ')
-      OR startsWith(normalized_command_path, 'ao status ')
-      OR startsWith(normalized_command_path, 'ao project ls ')
-      OR startsWith(normalized_command_path, 'ao project get ')
-      OR startsWith(normalized_command_path, 'ao pty-host ')
+        normalized_command_path IN (
+            'ao hooks',
+            'ao session ls',
+            'ao session get',
+            'ao orchestrator ls',
+            'ao status',
+            'ao project ls',
+            'ao project get',
+            'ao pty-host'
+        )
+        OR startsWith(normalized_command_path, 'ao hooks ')
+        OR startsWith(normalized_command_path, 'ao session ls ')
+        OR startsWith(normalized_command_path, 'ao session get ')
+        OR startsWith(normalized_command_path, 'ao orchestrator ls ')
+        OR startsWith(normalized_command_path, 'ao status ')
+        OR startsWith(normalized_command_path, 'ao project ls ')
+        OR startsWith(normalized_command_path, 'ao project get ')
+        OR startsWith(normalized_command_path, 'ao pty-host ')
     )
-  )
+)
 GROUP BY day
 ORDER BY day
 ```

--- a/docs/posthog-cost-controls.md
+++ b/docs/posthog-cost-controls.md
@@ -40,27 +40,49 @@ include `telemetry_schema_version = 2`.
 
 Configure PostHog ingestion controls for project `475752` in this order.
 
-1. Keep all `ao.v2.*` events.
-2. Drop legacy CLI firehose events where `event = 'ao.cli.invoked'` and
-   `actor_type` is missing or null.
-3. Drop legacy active-user firehose events where `event = 'ao.app.active'`,
-   `channel = 'cli'`, `actor_type` is missing or null, and normalized
-   `command_path` (lowercase with whitespace collapsed) equals one of these
-   routine paths, or starts with one of them followed by a space:
-   - `ao hooks`
-   - `ao session ls`
-   - `ao session get`
-   - `ao orchestrator ls`
-   - `ao status`
-   - `ao project ls`
-   - `ao project get`
-   - `ao pty-host`
+Define `normalized_command_path` as `command_path` lowercased, trimmed, and with
+repeated whitespace collapsed. A routine command is one where
+`normalized_command_path` equals one of these paths, or starts with one of them
+followed by a space:
+
+- `ao hooks`
+- `ao session ls`
+- `ao session get`
+- `ao orchestrator ls`
+- `ao status`
+- `ao project ls`
+- `ao project get`
+- `ao pty-host`
+
+1. Keep non-routine `ao.v2.*` events.
+2. Drop `ao.cli.invoked` when the command is routine, regardless of
+   `actor_type`.
+3. Drop `ao.app.active` when `channel = 'cli'` and the command is routine,
+   regardless of `actor_type`.
 4. Keep legacy `ao.app.active` where `channel = 'renderer'` so old desktop-only
    installs still contribute to DAU until they update.
 5. Keep low-volume reliability events such as `ao.session.spawned`,
    `ao.session.spawn_failed`, `ao.session.waiting_input_entered`,
    `ao.session.waiting_input_exited`, `ao.http.5xx`, and `ao.daemon.panic`.
 6. Drop `$web_vitals` unless a time-boxed performance investigation needs it.
+7. Apply the same routine-command drop as a defensive backstop to
+   `ao.v2.cli.invoked` and CLI-channel `ao.v2.app.active`, even though current
+   clients should suppress those routine events before transmission.
+
+`actor_type` is still useful for segmentation and analysis, but it must not be
+part of the ingestion cost-control predicate. The command describes the activity
+to exclude, while `actor_type` changed across client generations.
+
+Examples the ingestion rule should cover:
+
+| Event | Command path | Actor | Result |
+| --- | --- | --- | --- |
+| `ao.cli.invoked` | `ao hooks` | `agent` | Drop |
+| `ao.cli.invoked` | `AO  HOOKS` | `user` | Drop |
+| `ao.cli.invoked` | `ao hooks claude-code post-tool-use` | `user` | Drop |
+| `ao.app.active` (`channel = cli`) | `ao session get sess-123` | `user` | Drop |
+| `ao.cli.invoked` | `ao spawn` | `user` | Keep |
+| `ao.app.active` (`channel = renderer`) | n/a | `renderer` | Keep |
 
 When these project-side ingestion controls are enabled, the 7-day estimate is a
 reduction from roughly 2.4M total events to well under 250k, before organic
@@ -68,6 +90,15 @@ adoption of current builds. That is a 10x+ reduction while keeping renderer
 DAU, current v2 CLI DAU, current v2 command adoption, and reliability events.
 The app code alone does not enforce these PostHog UI rules for already-deployed
 legacy clients.
+
+Deployment boundary checklist:
+
+- Merging this PR protects clients that receive the next release.
+- Updating this Markdown does not modify the live PostHog project.
+- Update the live PostHog transformation separately with the same
+  actor-independent routine-command rule to stop already-deployed clients.
+- Verify the live transformation with the examples above, then check volume
+  shortly after enabling it and again after 24 hours.
 
 ## Follow-up: Failure-only Internal CLI Telemetry
 
@@ -202,7 +233,6 @@ WHERE timestamp >= now() - INTERVAL 90 DAY
   AND event = 'ao.app.active'
   AND NOT (
     properties.channel = 'cli'
-    AND (properties.actor_type IS NULL OR properties.actor_type = '')
     AND (
       normalized_command_path IN (
         'ao hooks',
@@ -272,5 +302,8 @@ GROUP BY event, properties.actor_type, properties.channel
 ORDER BY events DESC
 ```
 
-If `ao.cli.invoked` with `actor_type = null` remains above a few hundred events
-per day after the rules are enabled, the drop rule is not broad enough.
+If routine CLI commands still appear in `ao.cli.invoked`, `ao.app.active`,
+`ao.v2.cli.invoked`, or CLI-channel `ao.v2.app.active` after the rules are
+enabled, the drop rule is not broad enough. Check both exact and prefixed shapes
+such as `ao hooks`, `AO  HOOKS`, `ao hooks claude-code post-tool-use`, and
+`ao session get sess-123`.

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -33,6 +33,7 @@ describe("telemetry sanitizers", () => {
 
 		expect(config.persistence).toBe("memory");
 		expect(config.person_profiles).toBe("never");
+		expect(config.autocapture).toBe(false);
 		expect(config.capture_performance).toBe(false);
 		expect(config.disable_session_recording).toBe(true);
 		expect(config.bootstrap).toEqual({

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -34,6 +34,7 @@ describe("telemetry sanitizers", () => {
 		expect(config.persistence).toBe("memory");
 		expect(config.person_profiles).toBe("never");
 		expect(config.capture_performance).toBe(false);
+		expect(config.disable_session_recording).toBe(true);
 		expect(config.bootstrap).toEqual({
 			distinctID: "ins_stable-install-id",
 			isIdentifiedID: false,

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -473,6 +473,7 @@ export function buildPostHogConfig(distinctId: string): PostHogInitOptions {
 		capture_pageview: false,
 		capture_exceptions: false,
 		capture_performance: false,
+		disable_session_recording: true,
 		// AO owns the stable random installation ID. Memory-only SDK
 		// persistence prevents legacy identified state from replacing it after
 		// an upgrade; the AO-owned heartbeat and route reservations continue to


### PR DESCRIPTION
## Summary

Addresses Pulkit's post-merge telemetry follow-up notes from #3314 ( https://github.com/Untrivial-ai/agent-orchestrator/pull/3314#issuecomment-5137511549)

- explicitly disables PostHog session recording in renderer config and aligns the README with docs
- moves routine internal CLI command classification into a shared telemetry helper
- normalizes daemon-posted command paths before cost-control classification
- drops odd legacy/internal command shapes like `ao  hooks`, `AO HOOKS`, and `ao hooks claude-code post-tool-use`
- stops treating unknown legacy command paths without an explicit actor type as DAU-eligible user activity
- clarifies that the 10x+ spend estimate requires PostHog-side ingestion controls for already-deployed legacy clients

## Why

#3314 fixed the main PostHog spend issue, but the follow-up review found places where docs and code could drift or where old/foreign loopback callers could bypass the daemon-side routine-command gate through command-path variants.

## Validation

- `go test ./internal/cli ./internal/httpd ./internal/telemetrymeta ./internal/adapters/telemetry`
- `npm test -- --run src/renderer/lib/telemetry.test.ts`
- `npm run typecheck`