### PR TITLE
fix: update public links and privacy copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 **The orchestration layer for parallel AI coding agents**
 
-[![Stars](https://img.shields.io/github/stars/AgentWrapper/agent-orchestrator)](https://github.com/AgentWrapper/agent-orchestrator/stargazers)
-[![Contributors](https://img.shields.io/github/contributors/AgentWrapper/agent-orchestrator)](https://github.com/AgentWrapper/agent-orchestrator/graphs/contributors)
+[![Stars](https://img.shields.io/github/stars/Untrivial-ai/agent-orchestrator)](https://github.com/Untrivial-ai/agent-orchestrator/stargazers)
+[![Contributors](https://img.shields.io/github/contributors/Untrivial-ai/agent-orchestrator)](https://github.com/Untrivial-ai/agent-orchestrator/graphs/contributors)
 [![Twitter](https://img.shields.io/badge/Twitter-1DA1F2?logo=twitter&logoColor=white)](https://x.com/aoagents)
 [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/UZv7JjxbwG)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
@@ -138,10 +138,10 @@ Download the latest desktop build for your platform:
 
 | Platform              | Download                                                                                                                      |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| macOS (Apple silicon) | [Download](https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-arm64.zip)   |
-| macOS (Intel)         | [Download](https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-x64.zip)     |
-| Windows               | [Download](https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-win32-x64.exe)      |
-| Linux                 | [Download](https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.AppImage) |
+| macOS (Apple silicon) | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-arm64.zip)   |
+| macOS (Intel)         | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-x64.zip)     |
+| Windows               | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-win32-x64.exe)      |
+| Linux                 | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.AppImage) |
 
 After installing, open Agent Orchestrator and point it at the repository you want AO to manage. The desktop app runs the daemon for you, so no CLI is required. Installed desktop builds check for updates on launch and periodically while the app is running. See the [installation guide](https://aoagents.dev/docs/installation) for agent CLI setup and troubleshooting.
 
@@ -187,7 +187,7 @@ ao start
 
 ## Telemetry
 
-Agent Orchestrator's Electron renderer sends anonymous usage events to PostHog for reliability and product understanding, and PostHog session recording is enabled with local paths and local URLs redacted before transmission. Set `VITE_AO_POSTHOG_KEY` to an empty string before building to disable transmission. See [docs/telemetry.md](docs/telemetry.md).
+Agent Orchestrator's Electron renderer sends anonymous usage events to PostHog for reliability and product understanding. PostHog session recording is disabled by default; if a time-boxed investigation enables it, local paths and local URLs are redacted before transmission. Set `VITE_AO_POSTHOG_KEY` to an empty string before building to disable transmission. See [docs/telemetry.md](docs/telemetry.md).
 
 ## License
 

--- a/frontend/src/landing/content/docs/changelog.mdx
+++ b/frontend/src/landing/content/docs/changelog.mdx
@@ -26,6 +26,6 @@ April 25, 2026
 
 ## Sources
 
-- [Package changelogs on GitHub](https://github.com/AgentWrapper/agent-orchestrator/tree/main/packages)
-- [GitHub Releases](https://github.com/AgentWrapper/agent-orchestrator/releases)
-- [`main` commit history](https://github.com/AgentWrapper/agent-orchestrator/commits/main)
+- [Package changelogs on GitHub](https://github.com/Untrivial-ai/agent-orchestrator/tree/main/packages)
+- [GitHub Releases](https://github.com/Untrivial-ai/agent-orchestrator/releases)
+- [`main` commit history](https://github.com/Untrivial-ai/agent-orchestrator/commits/main)

--- a/frontend/src/landing/content/docs/examples.mdx
+++ b/frontend/src/landing/content/docs/examples.mdx
@@ -3,7 +3,7 @@ title: Examples
 description: Five annotated starter configurations covering GitHub, Linear, multi-project, auto-merge, and Codex setups.
 ---
 
-All examples live in the [`examples/` directory](https://github.com/AgentWrapper/agent-orchestrator/tree/main/examples) of the AO repository. Pick the one closest to your setup, copy it to your project root as `agent-orchestrator.yaml`, fill in your repo path and any API keys, and you're ready to spawn agents.
+All examples live in the [`examples/` directory](https://github.com/Untrivial-ai/agent-orchestrator/tree/main/examples) of the AO repository. Pick the one closest to your setup, copy it to your project root as `agent-orchestrator.yaml`, fill in your repo path and any API keys, and you're ready to spawn agents.
 
 ```bash
 cp examples/simple-github.yaml agent-orchestrator.yaml
@@ -35,7 +35,7 @@ projects:
 - No `defaults:` block needed — AO's built-in defaults (`tmux` runtime, `claude-code` agent, `worktree` workspace) apply automatically.
 - Replace `owner/my-app` and `~/my-app` with your actual GitHub slug and local checkout path.
 
-[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/simple-github.yaml)
+[View raw file on GitHub](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/examples/simple-github.yaml)
 
 ---
 
@@ -75,7 +75,7 @@ projects:
 - Requires a `LINEAR_API_KEY` environment variable (set it in your shell profile or CI secrets).
 - `agentRules` injects project-specific instructions into every agent's prompt — useful for enforcing commit conventions or test requirements.
 
-[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/linear-team.yaml)
+[View raw file on GitHub](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/examples/linear-team.yaml)
 
 ---
 
@@ -151,7 +151,7 @@ notificationRouting:
 - `notifiers.slack.webhook: ${SLACK_WEBHOOK_URL}` reads the webhook URL from an environment variable — never hardcode secrets in config files.
 - `notificationRouting` routes urgent and actionable events to both desktop and Slack, while lower-priority events go to Slack only.
 
-[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/multi-project.yaml)
+[View raw file on GitHub](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/examples/multi-project.yaml)
 
 ---
 
@@ -207,7 +207,7 @@ reactions:
 - `changes-requested.escalateAfter: 1h` ensures a human is notified if an agent can't resolve review comments within an hour.
 - `agent-stuck.threshold: 10m` triggers an urgent desktop notification if an agent goes silent for 10 minutes.
 
-[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/auto-merge.yaml)
+[View raw file on GitHub](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/examples/auto-merge.yaml)
 
 ---
 
@@ -251,7 +251,7 @@ projects:
 - `agentConfig.permissions: default` uses the plugin's built-in permission set — change to `full` to allow broader file access, or `readonly` to restrict writes.
 - Requires an `OPENAI_API_KEY` environment variable.
 
-[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/codex-integration.yaml)
+[View raw file on GitHub](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/examples/codex-integration.yaml)
 
 ---
 

--- a/frontend/src/landing/content/docs/guides/multi-project.mdx
+++ b/frontend/src/landing/content/docs/guides/multi-project.mdx
@@ -14,7 +14,7 @@ agent: claude-code
 
 projects:
   web:
-    repo: AgentWrapper/agent-orchestrator
+    repo: Untrivial-ai/agent-orchestrator
     agent: claude-code
 
   api:

--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -139,7 +139,7 @@ yarn global add @aoagents/ao
     <Tab value="from source">
 
 ```bash
-git clone https://github.com/AgentWrapper/agent-orchestrator
+git clone https://github.com/Untrivial-ai/agent-orchestrator
 cd agent-orchestrator
 pnpm install
 pnpm build

--- a/frontend/src/landing/content/docs/migration.mdx
+++ b/frontend/src/landing/content/docs/migration.mdx
@@ -21,7 +21,7 @@ npm uninstall -g @composio/agent-orchestrator
 npm install -g @aoagents/ao
 ```
 
-Your config and data directory (`~/.agent-orchestrator`) don't change — no data migration needed. Use the current GitHub repo URL (`AgentWrapper/agent-orchestrator`) for docs, releases, and issue links.
+Your config and data directory (`~/.agent-orchestrator`) don't change — no data migration needed. Use the current GitHub repo URL (`Untrivial-ai/agent-orchestrator`) for docs, releases, and issue links.
 
 ## `ao spawn <project> <issue>` → `ao spawn <issue>`
 

--- a/frontend/src/landing/content/docs/troubleshooting.mdx
+++ b/frontend/src/landing/content/docs/troubleshooting.mdx
@@ -104,7 +104,7 @@ Covers: install health, plugin resolution, notifier connectivity, stale temp fil
 ## Still stuck
 
 - Check the [FAQ](/docs/faq).
-- Open an issue: [`AgentWrapper/agent-orchestrator`](https://github.com/AgentWrapper/agent-orchestrator/issues).
+- Open an issue: [`Untrivial-ai/agent-orchestrator`](https://github.com/Untrivial-ai/agent-orchestrator/issues).
   When opening an issue, include:
 
 - Output of `ao --version`

--- a/frontend/src/landing/packages/shared/src/constants.ts
+++ b/frontend/src/landing/packages/shared/src/constants.ts
@@ -3,21 +3,18 @@ export const COMPANY = {
   SHORT_NAME: "AO",
   MARKETING_URL: "https://aoagents.dev",
   DOCS_URL: "https://aoagents.dev/docs",
-  GITHUB_URL: "https://github.com/AgentWrapper/agent-orchestrator",
-  GITHUB_REPO: "AgentWrapper/agent-orchestrator",
+  GITHUB_URL: "https://github.com/Untrivial-ai/agent-orchestrator",
+  GITHUB_REPO: "Untrivial-ai/agent-orchestrator",
   STATUS_URL: "https://status.aoagents.dev",
   TRUST_URL: "https://aoagents.dev/privacy/",
-  MAIL_TO: "mailto:hello@aoagents.dev",
+  MAIL_TO: "mailto:prateek@untrivial.ai",
   X_URL: "https://x.com/aoagents",
-  LINKEDIN_URL: "https://www.linkedin.com/company/agent-orchestrator",
-  YOUTUBE_URL: "https://youtube.com/@aoagents",
+  LINKEDIN_URL: "https://www.linkedin.com/company/agent-orchestrator/",
   DISCORD_URL: "https://discord.com/invite/UZv7JjxbwG",
-  EMAIL_DOMAIN: "@aoagents.dev",
-  FOUNDERS_MAIL_TO: "mailto:founders@aoagents.dev",
-  FOUNDERS_EMAIL: "founders@aoagents.dev",
-  REPORT_ISSUE_URL: "https://github.com/AgentWrapper/agent-orchestrator/issues/new",
+  FOUNDERS_EMAIL: "prateek@untrivial.ai",
+  REPORT_ISSUE_URL: "https://github.com/Untrivial-ai/agent-orchestrator/issues/new",
   LICENSE: "Apache-2.0",
-  LICENSE_URL: "https://github.com/AgentWrapper/agent-orchestrator/blob/main/LICENSE",
+  LICENSE_URL: "https://github.com/Untrivial-ai/agent-orchestrator/blob/main/LICENSE",
 } as const;
 
 export const THEME_STORAGE_KEY = "ao-theme";
@@ -31,7 +28,7 @@ export const PLATFORMS = {
   LINUX: "linux",
 } as const;
 
-export const GITHUB_STARS_URL = "https://api.github.com/repos/AgentWrapper/agent-orchestrator";
+export const GITHUB_STARS_URL = "https://api.github.com/repos/Untrivial-ai/agent-orchestrator";
 
 // macOS still points at the .zip on purpose. The .dmg first-install artifact is
 // built by frontend/makers/maker-dmg.ts, but no published release carries it yet,
@@ -40,10 +37,10 @@ export const GITHUB_STARS_URL = "https://api.github.com/repos/AgentWrapper/agent
 // That flip is rollout step 6 in issue #3267 and must happen only after a real
 // release has been cut and the dmg verified. The .zip keeps publishing forever
 // either way, because electron-updater cannot auto-update from a .dmg.
-export const DOWNLOAD_URL_MAC_ARM64 = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-arm64.zip";
-export const DOWNLOAD_URL_MAC_X64 = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-x64.zip";
-export const DOWNLOAD_URL_WINDOWS = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-win32-x64.exe";
-export const DOWNLOAD_URL_LINUX = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.AppImage";
+export const DOWNLOAD_URL_MAC_ARM64 = "https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-arm64.zip";
+export const DOWNLOAD_URL_MAC_X64 = "https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-x64.zip";
+export const DOWNLOAD_URL_WINDOWS = "https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-win32-x64.exe";
+export const DOWNLOAD_URL_LINUX = "https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.AppImage";
 
 export const AGENT_HARNESSES = 23;
 export const TAGLINE = "Stop babysitting agents. Start merging real work.";

--- a/frontend/src/landing/public/cli/install.sh
+++ b/frontend/src/landing/public/cli/install.sh
@@ -5,7 +5,7 @@
 #   curl -fsSL https://aoagents.dev/cli/install.sh | sh
 #
 # Installs the `ao` CLI via the Homebrew tap. For the desktop app, download it
-# from https://github.com/AgentWrapper/agent-orchestrator/releases/latest.
+# from https://github.com/Untrivial-ai/agent-orchestrator/releases/latest.
 
 set -eu
 
@@ -17,7 +17,7 @@ RESET='\033[0m'
 info() { printf "${GREEN}==>${RESET} %s\n" "$1" >&2; }
 error() { printf "${RED}error:${RESET} %s\n" "$1" >&2; exit 1; }
 
-RELEASES_URL="https://github.com/AgentWrapper/agent-orchestrator/releases/latest"
+RELEASES_URL="https://github.com/Untrivial-ai/agent-orchestrator/releases/latest"
 
 main() {
     printf "${BOLD}Installing Agent Orchestrator${RESET}\n\n"

--- a/frontend/src/landing/src/app/components/FeaturesSection/components/DelegationDemo/DelegationDemo.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/DelegationDemo/DelegationDemo.tsx
@@ -46,7 +46,7 @@ export function DelegationDemo() {
 
 	return (
 		<FeaturePreviewShell
-			title="AgentWrapper / agent-orchestrator"
+			title="Untrivial-ai / agent-orchestrator"
 			trailing={
 				<span className="rounded border border-[var(--preview-border)] px-1.5 py-0.5 font-mono text-[9px] text-[var(--preview-muted-foreground)]">
 					Orchestrator

--- a/frontend/src/landing/src/app/components/Footer/Footer.tsx
+++ b/frontend/src/landing/src/app/components/Footer/Footer.tsx
@@ -28,7 +28,7 @@ export function Footer() {
             </div>
           </div>
 
-          <div className="grid gap-8 sm:grid-cols-3">
+          <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 sm:gap-8">
             <FooterColumn
               title="Product"
               links={[
@@ -52,14 +52,17 @@ export function Footer() {
               ]}
             />
 
-            <FooterColumn
-              title="Community"
-              links={[
-                { href: COMPANY.GITHUB_URL, label: "GitHub", external: true },
-                { href: COMPANY.DISCORD_URL, label: "Discord", external: true },
-                { href: COMPANY.X_URL, label: "X", external: true },
-              ]}
-            />
+            <div className="col-span-2 sm:col-span-1">
+              <FooterColumn
+                title="Community"
+                links={[
+                  { href: COMPANY.GITHUB_URL, label: "GitHub", external: true },
+                  { href: COMPANY.DISCORD_URL, label: "Discord", external: true },
+                  { href: COMPANY.LINKEDIN_URL, label: "LinkedIn", external: true },
+                  { href: COMPANY.X_URL, label: "X", external: true },
+                ]}
+              />
+            </div>
           </div>
           </div>
         </div>
@@ -101,15 +104,15 @@ function FooterColumn({
                 href={link.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group flex min-h-8 items-center justify-between gap-3 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                className="group flex min-h-8 items-center justify-between gap-1 py-1.5 text-[13px] text-muted-foreground transition-colors hover:text-foreground sm:gap-3 sm:text-sm"
               >
                 {link.label}
-                <ArrowUpRight className="h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+                <ArrowUpRight className="hidden h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 sm:block" />
               </a>
             ) : (
               <Link
                 href={link.href}
-                className="flex min-h-8 items-center justify-between gap-3 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                className="flex min-h-8 items-center justify-between gap-1 py-1.5 text-[13px] text-muted-foreground transition-colors hover:text-foreground sm:gap-3 sm:text-sm"
               >
                 {link.label}
               </Link>

--- a/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.tsx
+++ b/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.tsx
@@ -45,8 +45,8 @@ interface TrackItem {
 	summary: string;
 }
 
-const repoName = "AgentWrapper/agent-orchestrator";
-const repoAvatar = "https://github.com/AgentWrapper.png?size=64";
+const repoName = "Untrivial-ai/agent-orchestrator";
+const repoAvatar = "https://github.com/Untrivial-ai.png?size=64";
 
 const previewTokenStyle = {
 	"--preview-background": "oklch(0.153 0.006 107.1)",

--- a/frontend/src/landing/src/app/components/SocialLinks/SocialLinks.tsx
+++ b/frontend/src/landing/src/app/components/SocialLinks/SocialLinks.tsx
@@ -66,25 +66,6 @@ export function SocialLinks({ className = "" }: SocialLinksProps) {
 				</svg>
 				<span>LinkedIn</span>
 			</a>
-			<a
-				href={COMPANY.YOUTUBE_URL}
-				target="_blank"
-				rel="noopener noreferrer"
-				className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-				aria-label="Subscribe on YouTube"
-			>
-				<svg
-					width="18"
-					height="18"
-					viewBox="0 0 24 24"
-					fill="currentColor"
-					xmlns="http://www.w3.org/2000/svg"
-				>
-					<title>YouTube</title>
-					<path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
-				</svg>
-				<span>YouTube</span>
-			</a>
 		</div>
 	);
 }

--- a/frontend/src/landing/src/app/docs/components/mdx.tsx
+++ b/frontend/src/landing/src/app/docs/components/mdx.tsx
@@ -215,7 +215,7 @@ export function PlatformSupport({
   );
 }
 
-const RELEASES_URL = "https://github.com/AgentWrapper/agent-orchestrator/releases";
+const RELEASES_URL = "https://github.com/Untrivial-ai/agent-orchestrator/releases";
 
 export function InstallDownloads() {
   return (

--- a/frontend/src/landing/src/app/index.md/route.ts
+++ b/frontend/src/landing/src/app/index.md/route.ts
@@ -48,7 +48,7 @@ export function GET() {
     ]),
     "## Contact",
     "",
-    `- Support: hello${COMPANY.EMAIL_DOMAIN}`,
+    `- Support: ${COMPANY.MAIL_TO.replace("mailto:", "")}`,
     `- Founders: ${COMPANY.FOUNDERS_EMAIL}`,
     `- [Discord](${COMPANY.DISCORD_URL})`,
     `- [X](${COMPANY.X_URL})`,

--- a/frontend/src/landing/src/app/privacy/page.tsx
+++ b/frontend/src/landing/src/app/privacy/page.tsx
@@ -118,32 +118,39 @@ const toc = [
 export default function PrivacyPage() {
   return (
     <main className="relative min-h-screen">
-      <div className="mx-auto max-w-[820px] px-6 pb-24 pt-[clamp(120px,13vw,180px)]">
-        <div className="font-mono text-sm text-muted-foreground">Legal</div>
-        <h1 className="mt-4 text-[clamp(34px,5vw,54px)] font-semibold leading-[1.04] tracking-[-0.03em] text-foreground">
-          Privacy Policy
-        </h1>
-        <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-          Last updated {LAST_UPDATED}
-        </p>
-
-        <div className="mt-9 rounded-[8px] border border-border bg-card/50 p-6 sm:p-7">
-          <p className="text-[15px] leading-[1.75] text-muted-foreground sm:text-[16px]">
-            <Strong>The short version.</Strong> Agent Orchestrator runs on your
-            own machine. No account is required, and no hosted AO service stores
-            your work. We never see your source code, prompts, agent output,
-            terminal contents, repository names, or file paths, and we never
-            sell or rent data to anyone. The desktop app sends{" "}
-            <Strong>anonymous, redacted usage telemetry</Strong> so we can tell
-            whether releases are stable — you can turn it off. Website analytics
-            stay off until you accept them. If you voluntarily join the
-            Windows/Linux waitlist, we process the email you submit only for
-            that purpose. The mobile app sends <Strong>no telemetry at all</Strong>{" "}
-            and talks only to the server you point it at.
+      <header className="relative">
+        <div className="relative mx-auto max-w-3xl px-6 pb-10 pt-16 md:pb-12 md:pt-20">
+          <div className="font-mono text-sm tracking-[0.5px] text-muted-foreground">
+            Legal
+          </div>
+          <h1 className="mt-4 text-[clamp(34px,5vw,54px)] font-semibold leading-[1.04] tracking-[-0.03em] text-foreground">
+            Privacy Policy
+          </h1>
+          <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+            Last updated {LAST_UPDATED}
           </p>
-        </div>
 
-        <nav aria-label="On this page" className="mt-10">
+          <div className="mt-8 rounded-[8px] border border-border bg-card/50 p-6 sm:p-7">
+            <p className="text-[15px] leading-[1.75] text-muted-foreground sm:text-[16px]">
+              <Strong>The short version.</Strong> Agent Orchestrator runs on your
+              own machine. No account is required, and no hosted AO service stores
+              your work. We never see your source code, prompts, agent output,
+              terminal contents, repository names, or file paths, and we never
+              sell or rent data to anyone. The desktop app sends{" "}
+              <Strong>anonymous, redacted usage telemetry</Strong> so we can tell
+              whether releases are stable — you can turn it off. Website analytics
+              stay off until you accept them. If you voluntarily join the
+              Windows/Linux waitlist, we process the email you submit only for
+              that purpose. The mobile app sends <Strong>no telemetry at all</Strong>{" "}
+              and talks only to the server you point it at.
+            </p>
+          </div>
+
+        </div>
+      </header>
+
+      <div className="relative mx-auto max-w-3xl px-6 pb-24 pt-12">
+        <nav aria-label="On this page">
           <h2 className="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
             On this page
           </h2>
@@ -165,7 +172,7 @@ export default function PrivacyPage() {
           <Section id="scope" title="What this policy covers">
             <p>
               Agent Orchestrator ("AO") is open-source software published by the
-              AgentWrapper project. This policy applies to:
+              Untrivial-ai project. This policy applies to:
             </p>
             <Bullets>
               <Bullet>
@@ -331,12 +338,12 @@ export default function PrivacyPage() {
               connection's IP address; AO itself never sends location data.
             </p>
             <p>
-              The desktop app also enables PostHog{" "}
-              <Strong>session recording</Strong> of the app's own interface for
-              debugging, with local paths, local URLs, and network request names
-              masked before transmission. This records the AO interface only —
-              never other applications, never your desktop, and never keystroke
-              content.
+              The desktop app does <Strong>not</Strong> currently send PostHog{" "}
+              <Strong>session recordings</Strong>. Session recording is disabled
+              by default; if a time-boxed investigation enables it, local paths,
+              local URLs, and network request names are masked before
+              transmission. It would cover the AO interface only — never other
+              applications, never your desktop, and never keystroke content.
             </p>
 
             <div className="rounded-[8px] border border-border bg-card/50 p-5">
@@ -347,7 +354,7 @@ export default function PrivacyPage() {
                 to stop daemon events. Because AO is open source, you can also
                 build it yourself with an empty <Code>VITE_AO_POSTHOG_KEY</Code>
                 , which removes transmission entirely. See{" "}
-                <Ext href="https://github.com/AgentWrapper/agent-orchestrator/blob/main/docs/telemetry.md">
+                <Ext href="https://github.com/Untrivial-ai/agent-orchestrator/blob/main/docs/telemetry.md">
                   docs/telemetry.md
                 </Ext>{" "}
                 for the full, source-level detail.

--- a/frontend/src/landing/src/components/JsonLd/JsonLd.tsx
+++ b/frontend/src/landing/src/components/JsonLd/JsonLd.tsx
@@ -53,10 +53,9 @@ export function OrganizationJsonLd() {
 		},
 		sameAs: [
 			COMPANY.GITHUB_URL,
-			"https://github.com/AgentWrapper",
+			"https://github.com/Untrivial-ai",
 			COMPANY.X_URL,
 			COMPANY.LINKEDIN_URL,
-			COMPANY.YOUTUBE_URL,
 		],
 	};
 

--- a/frontend/src/landing/src/lib/changelog.ts
+++ b/frontend/src/landing/src/lib/changelog.ts
@@ -15,7 +15,7 @@ const CHANGELOG_DIR = path.join(process.cwd(), "content/changelog");
 // Releases are pulled from GitHub at build time, so the changelog refreshes
 // whenever the landing is redeployed (a push to main, or a manual deploy).
 // Curated MDX entries in content/changelog take precedence for the same version.
-const RELEASES_REPO = "AgentWrapper/agent-orchestrator";
+const RELEASES_REPO = "Untrivial-ai/agent-orchestrator";
 // Only stable vMAJOR.MINOR.PATCH tags — skips nightlies, per-PR prereleases,
 // and package tags like @composio/ao@x.
 const STABLE_TAG = /^v\d+\.\d+\.\d+$/;

--- a/frontend/src/main/external-open.test.ts
+++ b/frontend/src/main/external-open.test.ts
@@ -3,9 +3,9 @@ import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./external-o
 
 describe("isAllowedAppExternalURL", () => {
 	it("allows web and mail handoff URLs from the app renderer", () => {
-		expect(isAllowedAppExternalURL("https://github.com/AgentWrapper/agent-orchestrator/issues/new")).toBe(true);
+		expect(isAllowedAppExternalURL("https://github.com/Untrivial-ai/agent-orchestrator/issues/new")).toBe(true);
 		expect(isAllowedAppExternalURL("http://localhost:5173/help")).toBe(true);
-		expect(isAllowedAppExternalURL("mailto:support@aoagents.dev?subject=AO%20feedback")).toBe(true);
+		expect(isAllowedAppExternalURL("mailto:prateek@untrivial.ai?subject=AO%20feedback")).toBe(true);
 	});
 
 	it("blocks local, privileged, and script schemes", () => {
@@ -17,9 +17,9 @@ describe("isAllowedAppExternalURL", () => {
 	it("opens allowed URLs through the native shell opener", async () => {
 		const openExternal = vi.fn().mockResolvedValue(undefined);
 
-		await openAllowedAppExternalURL("mailto:support@aoagents.dev?subject=AO%20feedback", { openExternal });
+		await openAllowedAppExternalURL("mailto:prateek@untrivial.ai?subject=AO%20feedback", { openExternal });
 
-		expect(openExternal).toHaveBeenCalledWith("mailto:support@aoagents.dev?subject=AO%20feedback");
+		expect(openExternal).toHaveBeenCalledWith("mailto:prateek@untrivial.ai?subject=AO%20feedback");
 	});
 
 	it("rejects unsupported URLs before reaching the shell opener", async () => {

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -290,7 +290,7 @@ describe("GlobalSettingsForm", () => {
 		expect(copied).not.toContain("## Type");
 		expect(copied).not.toContain("Generated locally by AO");
 		expect(openExternal).toHaveBeenCalledWith(
-			expect.stringContaining("https://github.com/AgentWrapper/agent-orchestrator/issues/new"),
+			expect.stringContaining("https://github.com/Untrivial-ai/agent-orchestrator/issues/new"),
 		);
 		expect(open).not.toHaveBeenCalled();
 		expect(screen.getByLabelText("Title")).toHaveValue("");
@@ -330,10 +330,10 @@ describe("GlobalSettingsForm", () => {
 
 		await waitFor(() => expect(writeText).toHaveBeenCalledTimes(2));
 		expect(writeText.mock.calls[0][0]).toContain("Daemon: unknown");
-		expect(writeText.mock.calls[1][0]).toContain("To: support@aoagents.dev");
+		expect(writeText.mock.calls[1][0]).toContain("To: prateek@untrivial.ai");
 		expect(writeText.mock.calls[1][0]).toContain("AO feedback");
 		expect(openExternal).toHaveBeenCalledWith("https://discord.com/invite/UZv7JjxbwG");
-		expect(openExternal).toHaveBeenCalledWith(expect.stringContaining("mailto:support@aoagents.dev"));
+		expect(openExternal).toHaveBeenCalledWith(expect.stringContaining("mailto:prateek@untrivial.ai"));
 		expect(open).not.toHaveBeenCalled();
 	});
 

--- a/frontend/src/renderer/lib/report-problem.test.ts
+++ b/frontend/src/renderer/lib/report-problem.test.ts
@@ -99,7 +99,7 @@ describe("report problem drafts", () => {
 		const draft = formatReportProblemDraft({ summary: "", details: "" }, diagnostics, "email");
 
 		expect(draft).toContain("AO feedback");
-		expect(draft).toContain("To: support@aoagents.dev");
+		expect(draft).toContain("To: prateek@untrivial.ai");
 		expect(draft).toContain("Not provided");
 		expect(draft).toContain("Safe diagnostics");
 		expect(draft).toContain("AO version: 1.2.3-test");
@@ -122,7 +122,7 @@ describe("report problem drafts", () => {
 
 	it("builds copy handoff destinations for GitHub, Discord, and support email", () => {
 		const github = new URL(reportProblemDestinationUrl(completeInput, diagnostics, "github")!);
-		expect(`${github.origin}${github.pathname}`).toBe("https://github.com/AgentWrapper/agent-orchestrator/issues/new");
+		expect(`${github.origin}${github.pathname}`).toBe("https://github.com/Untrivial-ai/agent-orchestrator/issues/new");
 		expect(github.searchParams.get("title")).toBe("Terminal keeps reconnecting after daemon restart");
 		expect(github.searchParams.get("body")).toContain("[redacted-local-path]");
 		expect(github.searchParams.get("body")).toContain("[redacted-local-url]");
@@ -133,7 +133,7 @@ describe("report problem drafts", () => {
 
 		const email = new URL(reportProblemDestinationUrl(completeInput, diagnostics, "email")!);
 		expect(email.protocol).toBe("mailto:");
-		expect(email.pathname).toBe("support@aoagents.dev");
+		expect(email.pathname).toBe("prateek@untrivial.ai");
 		expect(email.searchParams.get("subject")).toBe("AO feedback: Terminal keeps reconnecting after daemon restart");
 		expect(email.searchParams.get("body")).toContain("AO feedback");
 		expect(email.searchParams.get("body")).toContain("AO version: 1.2.3-test");

--- a/frontend/src/renderer/lib/report-problem.ts
+++ b/frontend/src/renderer/lib/report-problem.ts
@@ -22,8 +22,8 @@ const REDACTED_LOCAL_PATH = "[redacted-local-path]";
 const REDACTED_LOCAL_URL = "[redacted-local-url]";
 const REDACTED_SECRET = "[redacted-secret]";
 const DISCORD_INVITE_URL = "https://discord.com/invite/UZv7JjxbwG";
-const GITHUB_NEW_ISSUE_URL = "https://github.com/AgentWrapper/agent-orchestrator/issues/new";
-const SUPPORT_EMAIL = "support@aoagents.dev";
+const GITHUB_NEW_ISSUE_URL = "https://github.com/Untrivial-ai/agent-orchestrator/issues/new";
+const SUPPORT_EMAIL = "prateek@untrivial.ai";
 
 const LOCAL_URL_PATTERN =
 	/(?:\bfile:\/\/\/\S+|\bapp:\/\/renderer\/\S+|\bhttps?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?\S*)/gi;

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -34,6 +34,7 @@ describe("telemetry sanitizers", () => {
 		expect(config.persistence).toBe("memory");
 		expect(config.person_profiles).toBe("never");
 		expect(config.capture_performance).toBe(false);
+		expect(config.disable_session_recording).toBe(true);
 		expect(config.bootstrap).toEqual({
 			distinctID: "ins_stable-install-id",
 			isIdentifiedID: false,

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -473,6 +473,7 @@ export function buildPostHogConfig(distinctId: string): PostHogInitOptions {
 		capture_pageview: false,
 		capture_exceptions: false,
 		capture_performance: false,
+		disable_session_recording: true,
 		// AO owns the stable random installation ID. Memory-only SDK
 		// persistence prevents legacy identified state from replacing it after
 		// an upgrade; the AO-owned heartbeat and route reservations continue to


### PR DESCRIPTION
## Summary
- route public contact, founders, privacy, and desktop support email handoffs to prateek@untrivial.ai
- move current public GitHub references from AgentWrapper to Untrivial-ai across landing/docs/runtime support links
- remove the AO YouTube URL constant, social link, and JSON-LD sameAs entry because there is no YouTube channel right now
- add LinkedIn to the footer Community links
- render footer link columns as two columns on mobile, with Community below
- tighten the privacy page top spacing without adding guide-line, divider, or blog-scoped GridCross chrome
- make renderer PostHog session recording explicitly disabled and update privacy/README copy to match
- update tests that assert support email, GitHub handoff, and telemetry config

## PostHog verification
- Code: marketing PostHog sets disable_session_recording=true; renderer now also sets disable_session_recording=true
- PostHog MCP: system.session_recordings returned 0 undeleted recordings over both 30 days and 365 days, while events still show recent AO traffic

## Email scan notes
No production references remain for hello@aoagents.dev, support@aoagents.dev, or founders@aoagents.dev. Remaining non-Prateek email-like strings are fixtures/examples/package metadata or git SSH URLs.

## Validation
- npm run frontend:typecheck
- npm --prefix frontend run test -- src/renderer/lib/telemetry.test.ts src/main/external-open.test.ts src/renderer/lib/report-problem.test.ts src/renderer/components/GlobalSettingsForm.test.tsx
- npm --prefix frontend/src/landing run build
- verified http://127.0.0.1:3000/privacy/ returns 200, says the desktop app does not currently send PostHog session recordings, contains prateek@untrivial.ai, uses Untrivial-ai GitHub links, includes the LinkedIn footer URL, no longer contains the AO YouTube URL/text, and the unwanted guide/divider/GridCross lines are removed
- verified the mobile footer renders Product and Docs side by side, with Community below, at a 390px viewport