### PR TITLE
fix(cli): surface hidden orchestrator sessions

### DIFF
--- a/backend/internal/cli/session.go
+++ b/backend/internal/cli/session.go
@@ -401,11 +401,12 @@ func (c *commandContext) listSessions(ctx context.Context, cmd *cobra.Command, o
 	sessions := filterAndSortSessions(res.Sessions, opts.all)
 	hiddenTerminatedCount := 0
 	if !opts.includeTerminated {
-		count, err := c.countHiddenTerminated(ctx, opts.project, opts.all)
+		terminatedCount, terminatedOrchestratorCount, err := c.countHiddenTerminated(ctx, opts.project, opts.all)
 		if err != nil {
 			return err
 		}
-		hiddenTerminatedCount = count
+		hiddenTerminatedCount = terminatedCount
+		hiddenOrchestratorCount += terminatedOrchestratorCount
 	}
 	if opts.json {
 		out := sessionListOutput{Data: sessionListEntries(sessions)}
@@ -416,7 +417,7 @@ func (c *commandContext) listSessions(ctx context.Context, cmd *cobra.Command, o
 	return writeSessionList(cmd, sessions, hiddenTerminatedCount, hiddenOrchestratorCount)
 }
 
-func (c *commandContext) countHiddenTerminated(ctx context.Context, project string, includeOrchestrators bool) (int, error) {
+func (c *commandContext) countHiddenTerminated(ctx context.Context, project string, includeOrchestrators bool) (int, int, error) {
 	params := url.Values{}
 	if project != "" {
 		params.Set("project", project)
@@ -424,9 +425,17 @@ func (c *commandContext) countHiddenTerminated(ctx context.Context, project stri
 	params.Set("active", "false")
 	var res sessionListResponse
 	if err := c.getJSON(ctx, apiPath("sessions", params), &res); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	return len(filterAndSortSessions(res.Sessions, includeOrchestrators)), nil
+	hiddenOrchestratorCount := 0
+	if !includeOrchestrators {
+		for _, sess := range res.Sessions {
+			if sess.Kind == "orchestrator" {
+				hiddenOrchestratorCount++
+			}
+		}
+	}
+	return len(filterAndSortSessions(res.Sessions, includeOrchestrators)), hiddenOrchestratorCount, nil
 }
 
 func (c *commandContext) getSession(ctx context.Context, cmd *cobra.Command, id string, opts sessionOptions) error {

--- a/backend/internal/cli/session.go
+++ b/backend/internal/cli/session.go
@@ -132,7 +132,8 @@ type sessionListEntry struct {
 type sessionListOutput struct {
 	Data []sessionListEntry `json:"data"`
 	Meta struct {
-		HiddenTerminatedCount int `json:"hiddenTerminatedCount"`
+		HiddenTerminatedCount   int `json:"hiddenTerminatedCount"`
+		HiddenOrchestratorCount int `json:"hiddenOrchestratorCount"`
 	} `json:"meta"`
 }
 
@@ -389,6 +390,14 @@ func (c *commandContext) listSessions(ctx context.Context, cmd *cobra.Command, o
 	if err := c.getJSON(ctx, apiPath("sessions", params), &res); err != nil {
 		return err
 	}
+	hiddenOrchestratorCount := 0
+	if !opts.all {
+		for _, sess := range res.Sessions {
+			if sess.Kind == "orchestrator" {
+				hiddenOrchestratorCount++
+			}
+		}
+	}
 	sessions := filterAndSortSessions(res.Sessions, opts.all)
 	hiddenTerminatedCount := 0
 	if !opts.includeTerminated {
@@ -401,9 +410,10 @@ func (c *commandContext) listSessions(ctx context.Context, cmd *cobra.Command, o
 	if opts.json {
 		out := sessionListOutput{Data: sessionListEntries(sessions)}
 		out.Meta.HiddenTerminatedCount = hiddenTerminatedCount
+		out.Meta.HiddenOrchestratorCount = hiddenOrchestratorCount
 		return writeJSON(cmd.OutOrStdout(), out)
 	}
-	return writeSessionList(cmd, sessions, hiddenTerminatedCount)
+	return writeSessionList(cmd, sessions, hiddenTerminatedCount, hiddenOrchestratorCount)
 }
 
 func (c *commandContext) countHiddenTerminated(ctx context.Context, project string, includeOrchestrators bool) (int, error) {
@@ -654,7 +664,7 @@ func cleanupLabel(sess sessionDTO, scopedProject string) string {
 	return sess.ID
 }
 
-func writeSessionList(cmd *cobra.Command, sessions []sessionDTO, hiddenTerminatedCount int) error {
+func writeSessionList(cmd *cobra.Command, sessions []sessionDTO, hiddenTerminatedCount, hiddenOrchestratorCount int) error {
 	out := cmd.OutOrStdout()
 	if len(sessions) == 0 {
 		if _, err := fmt.Fprintln(out, "(no active sessions)"); err != nil {
@@ -689,7 +699,12 @@ func writeSessionList(cmd *cobra.Command, sessions []sessionDTO, hiddenTerminate
 		}
 	}
 	if hiddenTerminatedCount > 0 {
-		_, err := fmt.Fprintf(out, "%d terminated session%s hidden. Use --include-terminated to show.\n", hiddenTerminatedCount, pluralS(hiddenTerminatedCount))
+		if _, err := fmt.Fprintf(out, "%d terminated session%s hidden. Use --include-terminated to show.\n", hiddenTerminatedCount, pluralS(hiddenTerminatedCount)); err != nil {
+			return err
+		}
+	}
+	if hiddenOrchestratorCount > 0 {
+		_, err := fmt.Fprintf(out, "%d orchestrator session%s hidden. Use --all or `ao orchestrator ls` to show.\n", hiddenOrchestratorCount, pluralS(hiddenOrchestratorCount))
 		return err
 	}
 	return nil

--- a/backend/internal/cli/session_test.go
+++ b/backend/internal/cli/session_test.go
@@ -144,6 +144,9 @@ func TestSessionList_ProjectFilterAndDefaultFiltering(t *testing.T) {
 	if !strings.Contains(out, "1 terminated session hidden") {
 		t.Fatalf("hidden terminated hint missing:\n%s", out)
 	}
+	if !strings.Contains(out, "1 orchestrator session hidden. Use --all or `ao orchestrator ls` to show.") {
+		t.Fatalf("hidden orchestrator hint missing:\n%s", out)
+	}
 	want := []string{
 		"GET /api/v1/sessions?active=true&project=demo",
 		"GET /api/v1/sessions?active=false&project=demo",
@@ -171,11 +174,33 @@ func TestSessionList_JSONOutputDecodes(t *testing.T) {
 	if got.Meta.HiddenTerminatedCount != 1 {
 		t.Fatalf("hiddenTerminatedCount = %d, want 1", got.Meta.HiddenTerminatedCount)
 	}
+	if got.Meta.HiddenOrchestratorCount != 1 {
+		t.Fatalf("hiddenOrchestratorCount = %d, want 1", got.Meta.HiddenOrchestratorCount)
+	}
 	if len(got.Data) != 1 {
 		t.Fatalf("len(data) = %d, want 1; data=%#v", len(got.Data), got.Data)
 	}
 	if got.Data[0].ID != "demo-1" || got.Data[0].ProjectID != "demo" || got.Data[0].Role != "worker" {
 		t.Fatalf("unexpected JSON entry: %#v", got.Data[0])
+	}
+}
+
+func TestSessionList_AllIncludesOrchestratorsWithoutHiddenHint(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "ls", "--project", "demo", "--all")
+	if err != nil {
+		t.Fatalf("session ls --all failed: %v\nstderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, "demo-1") || !strings.Contains(out, "demo-2") {
+		t.Fatalf("output missing worker or orchestrator session:\n%s", out)
+	}
+	if strings.Contains(out, "orchestrator session hidden") {
+		t.Fatalf("output reports hidden orchestrators with --all:\n%s", out)
 	}
 }
 

--- a/backend/internal/cli/session_test.go
+++ b/backend/internal/cli/session_test.go
@@ -144,7 +144,7 @@ func TestSessionList_ProjectFilterAndDefaultFiltering(t *testing.T) {
 	if !strings.Contains(out, "1 terminated session hidden") {
 		t.Fatalf("hidden terminated hint missing:\n%s", out)
 	}
-	if !strings.Contains(out, "1 orchestrator session hidden. Use --all or `ao orchestrator ls` to show.") {
+	if !strings.Contains(out, "2 orchestrator sessions hidden. Use --all or `ao orchestrator ls` to show.") {
 		t.Fatalf("hidden orchestrator hint missing:\n%s", out)
 	}
 	want := []string{
@@ -153,6 +153,37 @@ func TestSessionList_ProjectFilterAndDefaultFiltering(t *testing.T) {
 	}
 	if got := log.all(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("requests = %#v, want %#v", got, want)
+	}
+}
+
+func TestSessionList_HintsWhenOnlyTerminatedOrchestratorIsHidden(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/sessions" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("active") == "false" {
+			_, _ = io.WriteString(w, `{"sessions":[`+sessionJSON("demo-orch-old", "demo", "orchestrator", "terminated", true)+`]}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"sessions":[]}`)
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "ls", "--project", "demo")
+	if err != nil {
+		t.Fatalf("session ls failed: %v\nstderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, "1 orchestrator session hidden. Use --all or `ao orchestrator ls` to show.") {
+		t.Fatalf("terminated orchestrator hint missing:\n%s", out)
+	}
+	if strings.Contains(out, "terminated session hidden") {
+		t.Fatalf("terminated orchestrator should not be reported as visible via --include-terminated alone:\n%s", out)
 	}
 }
 
@@ -174,8 +205,8 @@ func TestSessionList_JSONOutputDecodes(t *testing.T) {
 	if got.Meta.HiddenTerminatedCount != 1 {
 		t.Fatalf("hiddenTerminatedCount = %d, want 1", got.Meta.HiddenTerminatedCount)
 	}
-	if got.Meta.HiddenOrchestratorCount != 1 {
-		t.Fatalf("hiddenOrchestratorCount = %d, want 1", got.Meta.HiddenOrchestratorCount)
+	if got.Meta.HiddenOrchestratorCount != 2 {
+		t.Fatalf("hiddenOrchestratorCount = %d, want 2", got.Meta.HiddenOrchestratorCount)
 	}
 	if len(got.Data) != 1 {
 		t.Fatalf("len(data) = %d, want 1; data=%#v", len(got.Data), got.Data)


### PR DESCRIPTION
Addresses the session-list visibility portion of #3378.

The generic orchestrator spawn path remains tracked in #3378 and will be handled separately.

## What changed

- show a hint when `ao session ls` hides active orchestrator sessions
- point users to `--all` or `ao orchestrator ls`
- expose `hiddenOrchestratorCount` in JSON metadata
- keep the existing `--all` behavior unchanged

## Why

The default session list intentionally filters orchestrators, but it did so silently. That could make the output look like no relevant session was running.

## Checks

- `go test ./internal/cli`
- `go vet ./internal/cli`
- full backend `go test ./...`
- two unrelated auth-probe timeout tests were rerun individually and passed
