### PR TITLE
feat(landing): generate Markdown twins for docs

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -28,9 +28,14 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: |
+            frontend/package-lock.json
+            frontend/src/landing/package-lock.json
 
       - run: npm ci
+
+      - name: Install landing dependencies
+        run: npm ci --prefix src/landing
 
       - name: Typecheck project
         run: npm run typecheck

--- a/frontend/src/landing/package-lock.json
+++ b/frontend/src/landing/package-lock.json
@@ -49,15 +49,12 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@types/three": "^0.181.0",
+        "cheerio": "1.2.0",
+        "node-html-markdown": "2.0.0",
         "tailwindcss": "4.2.2",
         "three": "^0.181.2",
         "typescript": "6.0.3"
       }
-    },
-    "../site-theme": {
-      "name": "@ao/site-theme",
-      "version": "0.1.0",
-      "extraneous": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2855,6 +2852,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -3326,6 +3387,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.8",
       "license": "MIT",
@@ -3430,6 +3498,50 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "license": "MIT",
@@ -3503,6 +3615,36 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "dev": true,
@@ -3570,6 +3712,65 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "license": "BSD-2-Clause",
@@ -3584,6 +3785,20 @@
       "version": "1.5.396",
       "license": "ISC"
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.24.3",
       "license": "MIT",
@@ -3593,6 +3808,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -4042,6 +4270,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "license": "MIT",
@@ -4058,6 +4296,39 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "license": "MIT",
@@ -4067,6 +4338,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/import-in-the-middle": {
@@ -5746,11 +6030,48 @@
         }
       }
     },
+    "node_modules/node-html-markdown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-2.0.0.tgz",
+      "integrity": "sha512-DqUC3GGP7pwSYxS93SwHoP+qCw78xcMP6C6H2DuC8rPD2AweJRjBzQb5SdXpKtDlqAQ7hVotJcfhgU7hU5Gthw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-html-parser": "^6.1.13"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.51",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/oniguruma-parser": {
@@ -5812,6 +6133,59 @@
     "node_modules/parse-entities/node_modules/@types/unist": {
       "version": "2.0.11",
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -6273,6 +6647,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "license": "MIT"
@@ -6605,6 +6986,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "license": "MIT"
@@ -6844,6 +7235,30 @@
       "peer": true,
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {

--- a/frontend/src/landing/package.json
+++ b/frontend/src/landing/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "node scripts/generate-markdown-twins.mjs",
     "start": "next start"
   },
   "workspaces": [
@@ -52,6 +53,8 @@
     "@types/three": "^0.181.0",
     "tailwindcss": "4.2.2",
     "three": "^0.181.2",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "cheerio": "1.2.0",
+    "node-html-markdown": "2.0.0"
   }
 }

--- a/frontend/src/landing/scripts/generate-markdown-twins.mjs
+++ b/frontend/src/landing/scripts/generate-markdown-twins.mjs
@@ -21,7 +21,16 @@ for (const htmlFile of htmlFiles) {
   const $ = load(await readFile(htmlFile, "utf8"));
   const title = $("[data-doc-title]").first().text().trim();
   const description = $("[data-doc-description]").first().text().trim();
-  const article = $("[data-doc-content]").first().html();
+  const content = $("[data-doc-content]").first();
+
+  content.find("[data-doc-tab-list]").remove();
+  content.find("[data-doc-tab-panel]").each((_, panel) => {
+    const label = $(panel).attr("data-doc-tab-label");
+    if (label) $(panel).prepend($("<p>").append($("<strong>").text(label)));
+    $(panel).removeAttr("hidden");
+  });
+
+  const article = content.html();
 
   if (!title || !description || !article) throw new Error(`Missing documentation content in ${htmlFile}`);
 

--- a/frontend/src/landing/scripts/generate-markdown-twins.mjs
+++ b/frontend/src/landing/scripts/generate-markdown-twins.mjs
@@ -1,0 +1,22 @@
+import { glob, readFile, writeFile } from "node:fs/promises";
+import { load } from "cheerio";
+import { NodeHtmlMarkdown } from "node-html-markdown";
+
+const htmlFiles = [];
+for await (const file of glob("out/docs/**/index.html")) htmlFiles.push(file);
+
+if (htmlFiles.length === 0) throw new Error("No documentation HTML files found");
+
+for (const htmlFile of htmlFiles) {
+  const $ = load(await readFile(htmlFile, "utf8"));
+  const title = $("[data-doc-title]").first().text().trim();
+  const description = $("[data-doc-description]").first().text().trim();
+  const article = $("[data-doc-content]").first().html();
+
+  if (!title || !description || !article) throw new Error(`Missing documentation content in ${htmlFile}`);
+
+  const body = NodeHtmlMarkdown.translate(article);
+  await writeFile(`${htmlFile}.md`, `# ${title}\n\n${description}\n\n${body}\n`, "utf8");
+}
+
+console.log(`Generated ${htmlFiles.length} documentation Markdown twins`);

--- a/frontend/src/landing/scripts/generate-markdown-twins.mjs
+++ b/frontend/src/landing/scripts/generate-markdown-twins.mjs
@@ -1,9 +1,19 @@
-import { glob, readFile, writeFile } from "node:fs/promises";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { load } from "cheerio";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 
-const htmlFiles = [];
-for await (const file of glob("out/docs/**/index.html")) htmlFiles.push(file);
+async function findIndexHtmlFiles(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await findIndexHtmlFiles(entryPath)));
+    else if (entry.name === "index.html") files.push(entryPath);
+  }
+  return files;
+}
+
+const htmlFiles = await findIndexHtmlFiles("out/docs");
 
 if (htmlFiles.length === 0) throw new Error("No documentation HTML files found");
 

--- a/frontend/src/landing/scripts/generate-markdown-twins.test.mjs
+++ b/frontend/src/landing/scripts/generate-markdown-twins.test.mjs
@@ -1,16 +1,22 @@
-import assert from "node:assert/strict";
+// @vitest-environment node
+import { afterEach, expect, test } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const generatorPath = fileURLToPath(new URL("./generate-markdown-twins.mjs", import.meta.url));
+const workspaces = new Set();
 
-async function createWorkspace(t) {
+afterEach(async () => {
+  await Promise.all([...workspaces].map((workspace) => rm(workspace, { recursive: true, force: true })));
+  workspaces.clear();
+});
+
+async function createWorkspace() {
   const workspace = await mkdtemp(path.join(tmpdir(), "ao-markdown-twins-"));
-  t.after(() => rm(workspace, { recursive: true, force: true }));
+  workspaces.add(workspace);
   await mkdir(path.join(workspace, "out", "docs"), { recursive: true });
   return workspace;
 }
@@ -27,8 +33,8 @@ function runGenerator(workspace) {
   return spawnSync(process.execPath, [generatorPath], { cwd: workspace, encoding: "utf8" });
 }
 
-test("generates Markdown with every tab panel and without tab controls", async (t) => {
-  const workspace = await createWorkspace(t);
+test("generates Markdown with every tab panel and without tab controls", async () => {
+  const workspace = await createWorkspace();
   const htmlPath = await writeDoc(
     workspace,
     "installation",
@@ -49,49 +55,44 @@ test("generates Markdown with every tab panel and without tab controls", async (
 
   const result = runGenerator(workspace);
 
-  assert.equal(result.status, 0, result.stderr || result.error?.message);
+  expect(result.error).toBeUndefined();
+  expect(result.status).toBe(0);
   const markdown = await readFile(`${htmlPath}.md`, "utf8");
-  assert.match(markdown, /^# Installation\n\nInstall AO on your platform\./);
-  assert.match(markdown, /\*\*Claude Code\*\*[\s\S]*Run Claude Code\./);
-  assert.match(markdown, /\*\*Codex\*\*[\s\S]*Run Codex\./);
-  assert.doesNotMatch(markdown, /Tab controls only/);
+  expect(markdown).toMatch(/^# Installation\n\nInstall AO on your platform\./);
+  expect(markdown).toMatch(/\*\*Claude Code\*\*[\s\S]*Run Claude Code\./);
+  expect(markdown).toMatch(/\*\*Codex\*\*[\s\S]*Run Codex\./);
+  expect(markdown).not.toMatch(/Tab controls only/);
 });
 
-test("rejects documentation with missing required content", async (t) => {
-  const cases = [
-    {
-      name: "title",
-      html: '<p data-doc-description>Description</p><article data-doc-content><p>Body</p></article>',
-    },
-    {
-      name: "description",
-      html: '<h1 data-doc-title>Title</h1><article data-doc-content><p>Body</p></article>',
-    },
-    {
-      name: "article",
-      html: '<h1 data-doc-title>Title</h1><p data-doc-description>Description</p>',
-    },
-  ];
-
-  for (const fixture of cases) {
-    await t.test(`missing ${fixture.name}`, async (t) => {
-      const workspace = await createWorkspace(t);
-      const htmlPath = await writeDoc(workspace, fixture.name, fixture.html);
-
-      const result = runGenerator(workspace);
-
-      assert.notEqual(result.status, 0);
-      assert.match(`${result.stdout}\n${result.stderr}`, /Missing documentation content/);
-      await assert.rejects(readFile(`${htmlPath}.md`, "utf8"), { code: "ENOENT" });
-    });
-  }
-});
-
-test("rejects an empty documentation tree", async (t) => {
-  const workspace = await createWorkspace(t);
+test.each([
+  {
+    name: "title",
+    html: '<p data-doc-description>Description</p><article data-doc-content><p>Body</p></article>',
+  },
+  {
+    name: "description",
+    html: '<h1 data-doc-title>Title</h1><article data-doc-content><p>Body</p></article>',
+  },
+  {
+    name: "article",
+    html: '<h1 data-doc-title>Title</h1><p data-doc-description>Description</p>',
+  },
+])("rejects documentation with missing $name", async ({ name, html }) => {
+  const workspace = await createWorkspace();
+  const htmlPath = await writeDoc(workspace, name, html);
 
   const result = runGenerator(workspace);
 
-  assert.notEqual(result.status, 0);
-  assert.match(`${result.stdout}\n${result.stderr}`, /No documentation HTML files found/);
+  expect(result.status).not.toBe(0);
+  expect(`${result.stdout}\n${result.stderr}`).toMatch(/Missing documentation content/);
+  await expect(readFile(`${htmlPath}.md`, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+test("rejects an empty documentation tree", async () => {
+  const workspace = await createWorkspace();
+
+  const result = runGenerator(workspace);
+
+  expect(result.status).not.toBe(0);
+  expect(`${result.stdout}\n${result.stderr}`).toMatch(/No documentation HTML files found/);
 });

--- a/frontend/src/landing/scripts/generate-markdown-twins.test.mjs
+++ b/frontend/src/landing/scripts/generate-markdown-twins.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const generatorPath = fileURLToPath(new URL("./generate-markdown-twins.mjs", import.meta.url));
+
+async function createWorkspace(t) {
+  const workspace = await mkdtemp(path.join(tmpdir(), "ao-markdown-twins-"));
+  t.after(() => rm(workspace, { recursive: true, force: true }));
+  await mkdir(path.join(workspace, "out", "docs"), { recursive: true });
+  return workspace;
+}
+
+async function writeDoc(workspace, slug, html) {
+  const directory = path.join(workspace, "out", "docs", slug);
+  await mkdir(directory, { recursive: true });
+  const htmlPath = path.join(directory, "index.html");
+  await writeFile(htmlPath, html, "utf8");
+  return htmlPath;
+}
+
+function runGenerator(workspace) {
+  return spawnSync(process.execPath, [generatorPath], { cwd: workspace, encoding: "utf8" });
+}
+
+test("generates Markdown with every tab panel and without tab controls", async (t) => {
+  const workspace = await createWorkspace(t);
+  const htmlPath = await writeDoc(
+    workspace,
+    "installation",
+    `
+      <h1 data-doc-title>Installation</h1>
+      <p data-doc-description>Install AO on your platform.</p>
+      <article data-doc-content>
+        <div data-doc-tab-list><button>Tab controls only</button></div>
+        <section data-doc-tab-panel data-doc-tab-label="Claude Code">
+          <p>Run Claude Code.</p>
+        </section>
+        <section data-doc-tab-panel data-doc-tab-label="Codex" hidden>
+          <p>Run Codex.</p>
+        </section>
+      </article>
+    `,
+  );
+
+  const result = runGenerator(workspace);
+
+  assert.equal(result.status, 0, result.stderr || result.error?.message);
+  const markdown = await readFile(`${htmlPath}.md`, "utf8");
+  assert.match(markdown, /^# Installation\n\nInstall AO on your platform\./);
+  assert.match(markdown, /\*\*Claude Code\*\*[\s\S]*Run Claude Code\./);
+  assert.match(markdown, /\*\*Codex\*\*[\s\S]*Run Codex\./);
+  assert.doesNotMatch(markdown, /Tab controls only/);
+});
+
+test("rejects documentation with missing required content", async (t) => {
+  const cases = [
+    {
+      name: "title",
+      html: '<p data-doc-description>Description</p><article data-doc-content><p>Body</p></article>',
+    },
+    {
+      name: "description",
+      html: '<h1 data-doc-title>Title</h1><article data-doc-content><p>Body</p></article>',
+    },
+    {
+      name: "article",
+      html: '<h1 data-doc-title>Title</h1><p data-doc-description>Description</p>',
+    },
+  ];
+
+  for (const fixture of cases) {
+    await t.test(`missing ${fixture.name}`, async (t) => {
+      const workspace = await createWorkspace(t);
+      const htmlPath = await writeDoc(workspace, fixture.name, fixture.html);
+
+      const result = runGenerator(workspace);
+
+      assert.notEqual(result.status, 0);
+      assert.match(`${result.stdout}\n${result.stderr}`, /Missing documentation content/);
+      await assert.rejects(readFile(`${htmlPath}.md`, "utf8"), { code: "ENOENT" });
+    });
+  }
+});
+
+test("rejects an empty documentation tree", async (t) => {
+  const workspace = await createWorkspace(t);
+
+  const result = runGenerator(workspace);
+
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}\n${result.stderr}`, /No documentation HTML files found/);
+});

--- a/frontend/src/landing/src/app/docs/[[...slug]]/page.tsx
+++ b/frontend/src/landing/src/app/docs/[[...slug]]/page.tsx
@@ -46,13 +46,18 @@ export default async function DocsPage({ params }: { params: Promise<{ slug?: st
         <div className="mx-auto max-w-7xl px-6 xl:pl-[18rem] 2xl:pl-[19rem]">
           <div className="max-w-3xl pt-16 pb-10 md:pt-20 md:pb-12">
             <p className="text-sm text-muted-foreground">Documentation</p>
-            <h1 className="mt-4 text-balance text-3xl font-medium tracking-[-0.5px] text-foreground md:text-4xl">
+            <h1
+              data-doc-title
+              className="mt-4 text-balance text-3xl font-medium tracking-[-0.5px] text-foreground md:text-4xl"
+            >
               {doc.title}
             </h1>
             {doc.description ? (
-              <p className="mt-3 max-w-2xl text-pretty text-muted-foreground">{doc.description}</p>
+              <p data-doc-description className="mt-3 max-w-2xl text-pretty text-muted-foreground">
+                {doc.description}
+              </p>
             ) : (
-              <p className="mt-3 max-w-2xl text-pretty text-muted-foreground">
+              <p data-doc-description className="mt-3 max-w-2xl text-pretty text-muted-foreground">
                 Product docs for running, extending, and operating Agent Orchestrator.
               </p>
             )}
@@ -68,7 +73,10 @@ export default async function DocsPage({ params }: { params: Promise<{ slug?: st
         </aside>
 
         <div className="flex gap-10">
-          <article className="prose prose-invert min-w-0 max-w-3xl flex-1 pt-10 pb-4 text-foreground prose-headings:text-balance prose-headings:font-medium prose-headings:tracking-[-0.5px] prose-headings:text-foreground prose-h1:mt-0 prose-h1:text-3xl prose-h1:mb-2 prose-h2:mt-10 prose-h2:text-2xl prose-h2:pb-0 prose-h3:mt-7 prose-h3:text-xl prose-p:text-pretty prose-p:text-muted-foreground prose-p:leading-relaxed prose-li:text-muted-foreground prose-ul:text-muted-foreground prose-ol:text-muted-foreground prose-blockquote:text-muted-foreground prose-strong:text-foreground prose-a:text-foreground prose-a:decoration-border prose-a:underline prose-a:underline-offset-4 hover:prose-a:text-foreground prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none prose-pre:border prose-pre:border-border prose-pre:bg-muted/35 prose-hr:my-8 prose-hr:border-border prose-th:text-foreground prose-td:text-muted-foreground">
+          <article
+            data-doc-content
+            className="prose prose-invert min-w-0 max-w-3xl flex-1 pt-10 pb-4 text-foreground prose-headings:text-balance prose-headings:font-medium prose-headings:tracking-[-0.5px] prose-headings:text-foreground prose-h1:mt-0 prose-h1:text-3xl prose-h1:mb-2 prose-h2:mt-10 prose-h2:text-2xl prose-h2:pb-0 prose-h3:mt-7 prose-h3:text-xl prose-p:text-pretty prose-p:text-muted-foreground prose-p:leading-relaxed prose-li:text-muted-foreground prose-ul:text-muted-foreground prose-ol:text-muted-foreground prose-blockquote:text-muted-foreground prose-strong:text-foreground prose-a:text-foreground prose-a:decoration-border prose-a:underline prose-a:underline-offset-4 hover:prose-a:text-foreground prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none prose-pre:border prose-pre:border-border prose-pre:bg-muted/35 prose-hr:my-8 prose-hr:border-border prose-th:text-foreground prose-td:text-muted-foreground"
+          >
             <MDXRemote
               source={doc.content}
               components={docsMdxComponents}

--- a/frontend/src/landing/src/app/docs/components/DocsTabs.tsx
+++ b/frontend/src/landing/src/app/docs/components/DocsTabs.tsx
@@ -18,7 +18,7 @@ export function Tabs({ items, children }: { items?: string[]; children: ReactNod
 
   return (
     <div className="my-6 overflow-hidden rounded-xl border border-border bg-muted/25">
-      <div className="flex flex-wrap gap-1 border-b border-border bg-background p-1.5">
+      <div data-doc-tab-list className="flex flex-wrap gap-1 border-b border-border bg-background p-1.5">
         {labels.map((label, i) => (
           <button
             key={label}
@@ -35,7 +35,11 @@ export function Tabs({ items, children }: { items?: string[]; children: ReactNod
         ))}
       </div>
       <div className="prose prose-invert max-w-none px-4 py-4 prose-p:my-2 prose-pre:my-2">
-        {tabs[active]?.props.children}
+        {tabs.map((tab, i) => (
+          <section key={labels[i]} data-doc-tab-panel data-doc-tab-label={labels[i]} hidden={i !== active}>
+            {tab.props.children}
+          </section>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/landing/src/lib/llms.ts
+++ b/frontend/src/landing/src/lib/llms.ts
@@ -85,7 +85,7 @@ function renderDocumentationItem(item: DocsNavItem, depth: number): string[] {
 
 	const page = item.url ? getDocPage(docSlugFromUrl(item.url)) : undefined;
 	const href = item.url
-		? `${COMPANY.MARKETING_URL}${item.url.endsWith("/") ? item.url : `${item.url}/`}`
+		? `${COMPANY.MARKETING_URL}${item.url.replace(/\/+$/, "")}/index.html.md`
 		: undefined;
 	const link = href ? `[${item.title}](${href})` : item.title;
 	const label = item.items && item.items.length > 0 ? `**${link}**` : link;
@@ -107,7 +107,7 @@ export function buildDocumentationSection(): string[] {
 	const lines = [
 		"## Documentation",
 		"",
-		`- **[Documentation overview](${COMPANY.DOCS_URL}/)**${overviewDescription}`,
+		`- **[Documentation overview](${COMPANY.DOCS_URL}/index.html.md)**${overviewDescription}`,
 	];
 
 	for (const item of getDocsNav()) {


### PR DESCRIPTION
## Summary

- mark rendered documentation titles, descriptions, and article bodies with stable extraction attributes
- generate an `index.html.md` twin for every exported documentation page during `postbuild`
- extract only documentation content with Cheerio and convert it with `node-html-markdown`
- fail the build when no documentation HTML is available or required content is missing

## Why

The documentation is authored as MDX and statically rendered to HTML. Generating Markdown twins from that final HTML reuses the existing React/MDX component rendering while excluding navigation and other page chrome.

## Validation

- `npm ci --dry-run --ignore-scripts`
- `npm run build`
- production export generated 55 documentation HTML pages and 55 Markdown twins, with zero missing twins
- `git diff --check`