### PR TITLE
feat(mobile): push-to-talk voice dictation

### DIFF
--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -55,8 +55,14 @@
 				"expo-camera",
 				{
 					"cameraPermission": "Allow AO to scan the pairing QR code.",
-					"microphonePermission": false,
 					"recordAudioAndroid": false
+				}
+			],
+			[
+				"expo-speech-recognition",
+				{
+					"microphonePermission": "Allow AO to use the microphone so you can dictate prompts to an agent.",
+					"speechRecognitionPermission": "Allow AO to transcribe your speech into prompts for an agent."
 				}
 			],
 			[

--- a/packages/mobile/app/session/[id].tsx
+++ b/packages/mobile/app/session/[id].tsx
@@ -22,6 +22,7 @@ import {
 	type SendTarget,
 } from "../../lib/session/sendRoute";
 import { useApp } from "../../lib/store";
+import { useVoiceInput } from "../../lib/voice/useVoiceInput";
 import { useTheme, useThemedStyles, useThemeState } from "../../lib/ThemeProvider";
 
 const FONT_SIZE = 12;
@@ -844,6 +845,37 @@ export default function TerminalScreen() {
 		}
 	}, [msg, sendTarget, cfg, id, projectId, status]);
 
+	// Push-to-talk dictation, captured on the PHONE rather than by the harness.
+	//
+	// Driving a harness's own voice mode from here (Claude Code's /voice) looks
+	// easy — the key row already sends arbitrary bytes to the PTY — but it records
+	// through the *daemon host's* microphone, which is a machine the user is not
+	// sitting at. It would also only ever work for the harnesses that ship a voice
+	// mode at all.
+	//
+	// Capturing here inverts both: the transcript is just text, so it leaves
+	// through sendPrompt like anything typed, and every harness gets it for free.
+	const voice = useVoiceInput({
+		onTranscript: useCallback((text: string) => {
+			// Land in the composer as an editable draft rather than sending. This
+			// text reaches an agent with tool access and speech-to-text mishears code
+			// vocabulary often enough that silent submission isn't acceptable.
+			//
+			// The composer is always mounted now, so there is nothing to open — and
+			// nothing focuses the field either, which would pop the keyboard over the
+			// terminal mid-phrase.
+			// Append, so several held phrases build one prompt (the same way holding
+			// the key again appends in Claude Code's own dictation).
+			setMsg((m) => (m ? `${m} ${text}` : text));
+			haptics.success();
+		}, []),
+	});
+
+	// Recognition failures surface in the existing banner rather than new UI.
+	useEffect(() => {
+		if (voice.error) setBanner(voice.error);
+	}, [voice.error]);
+
 	// Toggle the in-app browser. The poll above keeps `preview` current, so a tap
 	// just shows/hides the overlay. A bare README (the detector's markdown fallback)
 	// reports "no preview yet" instead of surfacing an unbuilt repo doc.
@@ -1124,6 +1156,27 @@ export default function TerminalScreen() {
 			{/* The input dock. One container, one bottom inset, fixed slots — every
 			    control sits in the same place in every state the screen can reach. */}
 			<View style={[styles.dock, { paddingBottom: bottomPad }]}>
+				{/* Live dictation readout. Deliberately not inside the field: the
+				    partial transcript changes on every syllable, and rewriting the
+				    input under the user's caret is hostile. */}
+				{(voice.state === "starting" || voice.state === "recording" || voice.state === "transcribing") && (
+					<View style={[styles.voiceStrip, voice.state === "starting" && styles.voiceStripWarmup]}>
+						<Feather name="mic" size={13} color={voice.state === "starting" ? t.textTertiary : t.blue} />
+						<Text style={styles.voiceText} numberOfLines={2}>
+							{voice.partial ||
+								(voice.state === "starting"
+									? // The mic is not capturing yet. Saying "Listening" here would
+										// invite speech that gets dropped during warm-up.
+										"Keep holding..."
+									: voice.state === "transcribing"
+										? "Transcribing..."
+										: voice.mode === "latched"
+											? "Recording hands-free - tap the mic to finish"
+											: "Speak now - release to insert")}
+						</Text>
+					</View>
+				)}
+
 				<KeyRow onKey={sendKey} />
 
 				<Composer
@@ -1133,6 +1186,7 @@ export default function TerminalScreen() {
 					sending={sending}
 					target={sendTarget}
 					onTargetChange={setSendTarget}
+					voice={voice}
 					keyboardVisible={kbVisible}
 					onDismissKeyboard={Keyboard.dismiss}
 				/>
@@ -1279,4 +1333,22 @@ const makeStyles = (t: Theme) =>
 		marginTop: 10,
 	},
 	restoreCtaText: { color: t.onAccent, fontSize: 15, fontWeight: "700" },
+	// Accent-blue like the rest of the chrome. Red is reserved for the mic button
+	// alone: one small saturated element reads as "recording", a whole red panel
+	// reads as an error. It sits at the top of the dock, so it divides itself from
+	// the keys below rather than redrawing the dock's own top border.
+	voiceStrip: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 8,
+		paddingHorizontal: 12,
+		paddingVertical: 7,
+		backgroundColor: t.tintBlue,
+		borderBottomWidth: 1,
+		borderBottomColor: t.blue,
+	},
+	// Muted while the mic warms up, so "ready to speak" is a visible state change
+	// and not just a wording difference.
+	voiceStripWarmup: { backgroundColor: t.bgElevated, borderBottomColor: t.borderDefault },
+	voiceText: { flex: 1, color: t.textPrimary, fontSize: 13 },
 });

--- a/packages/mobile/lib/session/Composer.tsx
+++ b/packages/mobile/lib/session/Composer.tsx
@@ -1,5 +1,7 @@
 import { Feather } from "@expo/vector-icons";
 import { Pressable, StyleSheet, TextInput, View } from "react-native";
+import { MicKey } from "../voice/MicKey";
+import type { VoiceMode, VoiceState } from "../voice/types";
 import { useTheme, useThemedStyles, useThemeState } from "../ThemeProvider";
 import type { Theme } from "../theme";
 import type { SendTarget } from "./sendRoute";
@@ -15,6 +17,7 @@ export function Composer({
 	sending,
 	target,
 	onTargetChange,
+	voice,
 	keyboardVisible,
 	onDismissKeyboard,
 }: {
@@ -24,6 +27,7 @@ export function Composer({
 	sending: boolean;
 	target: SendTarget;
 	onTargetChange: (target: SendTarget) => void;
+	voice: { state: VoiceState; mode: VoiceMode; pressIn(): void; pressOut(): void };
 	keyboardVisible: boolean;
 	onDismissKeyboard: () => void;
 }) {
@@ -79,6 +83,8 @@ export function Composer({
 					</Pressable>
 				) : null}
 			</View>
+
+			<MicKey state={voice.state} mode={voice.mode} onPressIn={voice.pressIn} onPressOut={voice.pressOut} />
 
 			<Pressable
 				accessibilityRole="button"
@@ -137,8 +143,8 @@ const makeStyles = (t: Theme) =>
 		borderRadius: 8,
 	},
 	routeToggleActive: { backgroundColor: t.tintBlue },
-	// Rounded square rather than a circle, so it matches the radius of the field
-	// beside it instead of being the only circle in the dock.
+	// Rounded square at the same radius as the mic, so the two read as a pair and
+	// match the field beside them rather than being the only circles in the dock.
 	send: {
 		width: CONTROL_SIZE,
 		height: CONTROL_SIZE,

--- a/packages/mobile/lib/voice/MicKey.tsx
+++ b/packages/mobile/lib/voice/MicKey.tsx
@@ -1,0 +1,143 @@
+import { Feather } from "@expo/vector-icons";
+import { useEffect, useRef } from "react";
+import { Animated, Pressable, StyleSheet, View } from "react-native";
+import type { Theme } from "../theme";
+import { haptics } from "../haptics";
+import type { VoiceMode, VoiceState } from "./types";
+import { useTheme, useThemedStyles } from "../ThemeProvider";
+
+// The dictation control, with two gestures:
+//
+//   hold        - push-to-talk. Cheapest audio session, fastest to capture,
+//                 built-in mic. For short phrases where warm-up dominates.
+//   double-tap  - latch on, hands-free, Bluetooth-capable. Tap once more to
+//                 finish. For long prompts where warm-up stops mattering.
+//
+// Sized to the send button and sitting beside it: dictation is a primary way to
+// talk to an agent from a phone, and as one more outlined grey pill in the key
+// row it was indistinguishable from `zoom-out`.
+//
+// Tonal rather than solid, though. Two identical solid-blue buttons side by side
+// have no hierarchy — the eye can't tell which one commits. Mic is tinted, send
+// is filled; the mic only goes solid (red) while it is actually recording, which
+// is the one moment it should outrank everything on screen.
+//
+// Rounded square, not a circle: the field is radius 11 and the keys radius 7, so
+// two circles were the only round things in the dock.
+
+/** Matches the send button so the two controls are the same size. */
+export const MIC_SIZE = 40;
+const MIC_RADIUS = 12;
+
+export function MicKey({
+	state,
+	mode,
+	onPressIn,
+	onPressOut,
+}: {
+	state: VoiceState;
+	mode: VoiceMode;
+	onPressIn(): void;
+	onPressOut(): void;
+}) {
+	const t = useTheme();
+	const styles = useThemedStyles(makeStyles);
+	const live = state === "recording" || state === "starting";
+	const latched = live && mode === "latched";
+	const denied = state === "denied";
+	// Rendered even with no recogniser on the device. Returning null here used to
+	// remove the control from the row entirely, reflowing everything beside it.
+	const unavailable = state === "unavailable";
+	const disabled = unavailable || denied;
+
+	// A breathing ring behind the circle while the mic is open — the same
+	// Animated loop `Dot` uses, rather than a new animation dependency.
+	const pulse = useRef(new Animated.Value(0)).current;
+	useEffect(() => {
+		if (!live) {
+			pulse.setValue(0);
+			return;
+		}
+		const loop = Animated.loop(
+			Animated.sequence([
+				Animated.timing(pulse, { toValue: 1, duration: 900, useNativeDriver: true }),
+				Animated.timing(pulse, { toValue: 0, duration: 900, useNativeDriver: true }),
+			]),
+		);
+		loop.start();
+		return () => loop.stop();
+	}, [live, pulse]);
+
+	const fill = live ? t.red : denied ? t.tintRed : unavailable ? t.bgElevated : t.tintBlue;
+	const ink = live ? t.textPrimary : denied ? t.red : unavailable ? t.textFaint : t.blue;
+
+	return (
+		<View style={styles.slot}>
+			{live ? (
+				<Animated.View
+					pointerEvents="none"
+					style={[
+						styles.ring,
+						{
+							opacity: pulse.interpolate({ inputRange: [0, 1], outputRange: [0.45, 0] }),
+							transform: [{ scale: pulse.interpolate({ inputRange: [0, 1], outputRange: [1, 1.45] }) }],
+						},
+					]}
+				/>
+			) : null}
+			<Pressable
+				accessibilityRole="button"
+				accessibilityLabel={
+					unavailable
+						? "Dictation unavailable on this device"
+						: latched
+							? "Stop dictating"
+							: "Hold to dictate, or double-tap for hands-free"
+				}
+				accessibilityState={{ busy: live, disabled }}
+				disabled={disabled}
+				style={({ pressed }) => [
+					styles.mic,
+					{ backgroundColor: fill },
+					latched && styles.latched,
+					unavailable && styles.unavailable,
+					pressed && !disabled && { opacity: 0.85 },
+				]}
+				onPressIn={() => {
+					haptics.tap();
+					onPressIn();
+				}}
+				onPressOut={onPressOut}
+				// A finger sliding off still ends a held phrase — otherwise the mic
+				// would stay open with no obvious way to close it. Latched mode is
+				// unaffected: it ignores the finger by design.
+				onTouchCancel={onPressOut}
+			>
+				<Feather name={denied || unavailable ? "mic-off" : "mic"} size={18} color={ink} />
+			</Pressable>
+		</View>
+	);
+}
+
+const makeStyles = (t: Theme) =>
+	StyleSheet.create({
+	slot: { width: MIC_SIZE, height: MIC_SIZE, alignItems: "center", justifyContent: "center" },
+	mic: {
+		width: MIC_SIZE,
+		height: MIC_SIZE,
+		borderRadius: MIC_RADIUS,
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	ring: {
+		position: "absolute",
+		width: MIC_SIZE,
+		height: MIC_SIZE,
+		borderRadius: MIC_RADIUS,
+		backgroundColor: t.red,
+	},
+	// Latched holds the mic open with no finger on it, so it gets an outline the
+	// held state doesn't — this is the state that must never be missed.
+	latched: { borderWidth: 2, borderColor: t.textPrimary },
+	unavailable: { borderWidth: 1, borderColor: t.borderSubtle, opacity: 0.5 },
+});

--- a/packages/mobile/lib/voice/deviceProvider.test.ts
+++ b/packages/mobile/lib/voice/deviceProvider.test.ts
@@ -1,0 +1,546 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A fake of the native module that lets a test drive the recogniser's event
+// stream by hand. The provider's whole job is turning that ragged stream — several
+// finals, a trailing `end`, errors that are really just silence — into exactly one
+// outcome, so the events are what we need control over.
+const listeners = new Map<string, ((e: unknown) => void)[]>();
+const started: unknown[] = [];
+const calls = { start: 0, stop: 0, abort: 0 };
+let recognitionAvailable = true;
+let permissionGranted = true;
+// Counts native permission round-trips, which sit in front of the microphone start.
+let permissionChecks = 0;
+let supportedLocales = ["en-US", "en-GB", "en-IN"];
+// iOS and Android segment differently, so the provider branches on platform.
+let platformOS = "android";
+
+vi.mock("react-native", () => ({
+	Platform: {
+		get OS() {
+			return platformOS;
+		},
+	},
+}));
+
+function emit(event: string, payload?: unknown) {
+	for (const l of [...(listeners.get(event) ?? [])]) l(payload);
+}
+
+vi.mock("expo-speech-recognition", () => ({
+	AVAudioSessionCategory: { record: "record", playAndRecord: "playAndRecord" },
+	AVAudioSessionCategoryOptions: { allowBluetooth: "allowBluetooth", defaultToSpeaker: "defaultToSpeaker" },
+	AVAudioSessionMode: { default: "default", measurement: "measurement" },
+	ExpoSpeechRecognitionModule: {
+		addListener(event: string, cb: (e: unknown) => void) {
+			const list = listeners.get(event) ?? [];
+			list.push(cb);
+			listeners.set(event, list);
+			return {
+				remove() {
+					listeners.set(event, (listeners.get(event) ?? []).filter((x) => x !== cb));
+				},
+			};
+		},
+		start(options: unknown) {
+			calls.start++;
+			started.push(options);
+		},
+		stop() {
+			calls.stop++;
+		},
+		abort() {
+			calls.abort++;
+		},
+		isRecognitionAvailable: () => recognitionAvailable,
+		getSupportedLocales: async () => ({ locales: supportedLocales, installedLocales: [] }),
+		getPermissionsAsync: async () => {
+			permissionChecks++;
+			return { granted: permissionGranted };
+		},
+		requestPermissionsAsync: async () => {
+			permissionChecks++;
+			return { granted: permissionGranted };
+		},
+	},
+}));
+
+const { createDeviceVoiceProvider } = await import("./deviceProvider");
+
+function harness() {
+	const onReady = vi.fn();
+	const onPartial = vi.fn();
+	const onFinal = vi.fn();
+	const onError = vi.fn();
+	return { cb: { onReady, onPartial, onFinal, onError }, onReady, onPartial, onFinal, onError };
+}
+
+const result = (transcript: string, isFinal: boolean) => ({
+	isFinal,
+	results: [{ transcript, confidence: 1, segments: [] }],
+});
+
+beforeEach(() => {
+	listeners.clear();
+	started.length = 0;
+	calls.start = 0;
+	calls.stop = 0;
+	calls.abort = 0;
+	recognitionAvailable = true;
+	permissionGranted = true;
+	permissionChecks = 0;
+	supportedLocales = ["en-US", "en-GB", "en-IN"];
+	platformOS = "android";
+});
+
+describe("availability and permission", () => {
+	it("reports unavailable when the device has no recogniser", () => {
+		recognitionAvailable = false;
+		expect(createDeviceVoiceProvider().available()).toBe(false);
+	});
+
+	it("reports a declined permission rather than throwing", async () => {
+		permissionGranted = false;
+		await expect(createDeviceVoiceProvider().requestPermission()).resolves.toBe(false);
+	});
+
+	it("does not re-ask the OS once permission is granted", async () => {
+		const p = createDeviceVoiceProvider();
+		await p.requestPermission();
+		await p.requestPermission();
+		await p.requestPermission();
+
+		// This call sits directly in front of the microphone starting. Repeating the
+		// native round-trip on every press delays recording enough to swallow the
+		// first words of a short phrase.
+		expect(permissionChecks).toBe(1);
+	});
+});
+
+describe("warm-up", () => {
+	it("signals readiness only when the recogniser actually starts capturing", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		// start() has returned, but the microphone is still warming up. Telling the
+		// user to speak now would lose the first words of the phrase.
+		expect(h.onReady).not.toHaveBeenCalled();
+
+		emit("start");
+		expect(h.onReady).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not signal readiness for a session already abandoned", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		p.abort();
+		emit("start");
+
+		expect(h.onReady).not.toHaveBeenCalled();
+	});
+});
+
+describe("transcript delivery", () => {
+	it("streams partials and delivers one final transcript", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("result", result("add a test", false));
+		emit("result", result("add a test for pairing", false));
+		expect(h.onPartial).toHaveBeenCalledTimes(2);
+		expect(h.onPartial).toHaveBeenLastCalledWith("add a test for pairing");
+
+		emit("result", result("add a test for pairing.", true));
+		emit("end");
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("add a test for pairing.");
+	});
+
+	it("delivers the transcript exactly once even when `end` repeats", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("result", result("ship it", true));
+		emit("end");
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("ship it");
+	});
+
+	it("does not end the recording on a final result — the user may still be talking", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		// A pause closes a segment in continuous mode. That is a segment boundary,
+		// not the end of the recording; the finger is still on the key.
+		emit("result", result("open the pull request", true));
+		expect(h.onFinal).not.toHaveBeenCalled();
+
+		emit("result", result("and rerun the tests", true));
+		emit("end");
+
+		// Both segments, in order. Settling on the first would have silently dropped
+		// everything said after the pause.
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("open the pull request and rerun the tests");
+	});
+
+	it("keeps banked segments while a later segment is still forming", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("result", result("fix the parser", true));
+		emit("result", result("then", false));
+		// The live readout must show everything heard so far, not just the segment
+		// currently being recognised.
+		expect(h.onPartial).toHaveBeenLastCalledWith("fix the parser then");
+
+		emit("result", result("then commit", false));
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("fix the parser then commit");
+	});
+
+	it("keeps earlier speech when Android rolls over to a new segment with no final", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		// Android's onPartialResults just emits whatever the recogniser currently
+		// has. After a pause it restarts from scratch with no isFinal in between,
+		// so an unrelated partial is the only signal that a segment ended.
+		emit("result", result("add a test", false));
+		emit("result", result("add a test for the pairing flow", false));
+		// ...user pauses, then keeps talking. Fresh partial, unrelated text.
+		emit("result", result("then run", false));
+		emit("result", result("then run the linter", false));
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith(
+			"add a test for the pairing flow then run the linter",
+		);
+	});
+
+	it("banks the previous segment when Android announces a new utterance", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		// onBeginningOfSpeech is the authoritative boundary: a new utterance is
+		// starting, so whatever is held as a partial belongs to the previous one.
+		emit("speechstart");
+		emit("result", result("add tests", false));
+		// Pause, then more speech. This is the case the text heuristic gets wrong —
+		// same opening word AND longer — so it only works because of speechstart.
+		emit("speechstart");
+		emit("result", result("add documentation for the API", false));
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("add tests add documentation for the API");
+	});
+
+	it("does not bank on speechstart on iOS, where partials are cumulative", async () => {
+		platformOS = "ios";
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		// iOS runs one recognition task and restates everything each time, so
+		// banking on speechstart would duplicate rather than segment.
+		emit("result", result("add test", false));
+		emit("speechstart");
+		emit("result", result("add test add documentation", false));
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("add test add documentation");
+	});
+
+	// Regression: a long iOS dictation snowballed into
+	// "How the How's the system system turning How is the system turning?".
+	// iOS emits `isFinal` results periodically through one continuous task, and
+	// each one restates the WHOLE recording. Banking them the way Android's
+	// segments are banked re-added the entire phrase on every final.
+	it("does not duplicate when iOS emits a cumulative final mid-recording", async () => {
+		platformOS = "ios";
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("result", result("how is the system", false));
+		// iOS finalises the task so far, restating everything — not a new segment.
+		emit("result", result("how is the system turning", true));
+		// ...and carries straight on, still cumulative.
+		emit("result", result("how is the system turning right now", false));
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("how is the system turning right now");
+	});
+
+	it("does not duplicate across several cumulative iOS finals", async () => {
+		platformOS = "ios";
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("result", result("open the", true));
+		emit("result", result("open the pull request", true));
+		emit("result", result("open the pull request and merge it", true));
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("open the pull request and merge it");
+	});
+
+	it("keeps the live readout cumulative-but-not-doubled on iOS", async () => {
+		platformOS = "ios";
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("result", result("ship the", false));
+		emit("result", result("ship the release", true));
+		// The strip must not read "ship the release ship the release".
+		expect(h.onPartial).toHaveBeenLastCalledWith("ship the release");
+	});
+
+	// iOS caps how long one recognition task may run. When it restarts, the new
+	// task's results begin from scratch — that IS a real boundary, and dropping
+	// it would lose everything said before the restart.
+	it("preserves earlier speech across an iOS recognition-task restart", async () => {
+		platformOS = "ios";
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("result", result("first half of the sentence", false));
+		emit("result", result("first half of the sentence complete", true));
+		// New task: unrelated opening, starts short.
+		emit("result", result("second", false));
+		emit("result", result("second half now", false));
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("first half of the sentence complete second half now");
+	});
+
+	it("does not treat an in-place revision as a new segment", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		// Recognisers rewrite words they already emitted as confidence improves.
+		// Those revisions share an opening and must NOT be banked as separate
+		// segments, or the transcript doubles up.
+		emit("result", result("add a test", false));
+		emit("result", result("add a test for pairing", false));
+		emit("result", result("add attest for pairing flow", false));
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("add attest for pairing flow");
+	});
+
+	it("does not duplicate a segment that ends with a final result", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		// The final supersedes the partial it grew from; banking both would repeat it.
+		emit("result", result("open the", false));
+		emit("result", result("open the pull request", false));
+		emit("result", result("open the pull request", true));
+		emit("result", result("then merge it", false));
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("open the pull request then merge it");
+	});
+
+	it("keeps the words already heard when the session ends without a final result", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("result", result("run the tests", false));
+		// A silence timeout ends the session with no isFinal result. The user said
+		// something; dropping it would be the worst outcome.
+		emit("end");
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("run the tests");
+		expect(h.onError).not.toHaveBeenCalled();
+	});
+
+	it("reports an empty transcript rather than an error when nothing was said", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		// A stray press: the recogniser reports "no-speech", which is expected, not
+		// a fault. The caller distinguishes it by the empty string.
+		emit("error", { error: "no-speech", message: "No speech detected" });
+
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("");
+		expect(h.onError).not.toHaveBeenCalled();
+	});
+
+	it("trims the transcript", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+		emit("result", result("  hello world  ", true));
+		emit("end");
+		expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("hello world");
+	});
+});
+
+describe("failures", () => {
+	it("surfaces a readable message for a real error", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("error", { error: "not-allowed", message: "denied" });
+
+		expect(h.onError).toHaveBeenCalledTimes(1);
+		expect(h.onError.mock.calls[0][0]).toMatch(/permission was denied/i);
+		expect(h.onFinal).not.toHaveBeenCalled();
+	});
+
+	it("does not emit a transcript after an error", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		emit("error", { error: "audio-capture", message: "mic failed" });
+		// Listeners are gone, so a late event from the native side is inert.
+		emit("result", result("too late", true));
+		emit("end");
+
+		expect(h.onFinal).not.toHaveBeenCalled();
+		expect(h.onError).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("lifecycle", () => {
+	it("aborting delivers nothing and drops its listeners", async () => {
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		p.abort();
+		expect(calls.abort).toBe(1);
+
+		// The native side emits "aborted" in response; it must not reach the caller
+		// that already walked away.
+		emit("error", { error: "aborted", message: "aborted" });
+		emit("end");
+
+		expect(h.onFinal).not.toHaveBeenCalled();
+		expect(h.onError).not.toHaveBeenCalled();
+	});
+
+	it("does not leave the previous recording's listeners attached on restart", async () => {
+		const p = createDeviceVoiceProvider();
+		const first = harness();
+		const second = harness();
+
+		await p.start(first.cb);
+		await p.start(second.cb);
+
+		emit("result", result("second phrase", true));
+		emit("end");
+
+		expect(first.onFinal).not.toHaveBeenCalled();
+		expect(second.onFinal).toHaveBeenCalledExactlyOnceWith("second phrase");
+	});
+
+	it("reports a synchronous start failure through onError", async () => {
+		const mod = await import("expo-speech-recognition");
+		const spy = vi
+			.spyOn(mod.ExpoSpeechRecognitionModule, "start")
+			.mockImplementationOnce(() => {
+				throw new Error("mic busy");
+			});
+
+		const p = createDeviceVoiceProvider();
+		const h = harness();
+		await p.start(h.cb);
+
+		expect(h.onError).toHaveBeenCalledExactlyOnceWith("mic busy");
+		spy.mockRestore();
+	});
+
+	it("delivers the transcript even if the recogniser never emits `end` after stop", async () => {
+		vi.useFakeTimers();
+		try {
+			const p = createDeviceVoiceProvider();
+			const h = harness();
+			await p.start(h.cb);
+
+			emit("result", result("deploy to staging", false));
+			p.stop();
+			// The recogniser dies silently: no `end`, no final result. Without the
+			// watchdog the words would be stranded and the UI stuck recording.
+			expect(h.onFinal).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(5000);
+			expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("deploy to staging");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not double-deliver when `end` arrives after stop", async () => {
+		vi.useFakeTimers();
+		try {
+			const p = createDeviceVoiceProvider();
+			const h = harness();
+			await p.start(h.cb);
+
+			emit("result", result("run the linter", false));
+			p.stop();
+			emit("end");
+			vi.advanceTimersByTime(5000);
+
+			expect(h.onFinal).toHaveBeenCalledExactlyOnceWith("run the linter");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("requests push-to-talk options tuned for prompts", async () => {
+		const p = createDeviceVoiceProvider();
+		await p.start(harness().cb);
+
+		const opts = started[0] as Record<string, unknown>;
+		// Continuous: the finger decides when the phrase ends, not a silence timer.
+		expect(opts.continuous).toBe(true);
+		expect(opts.interimResults).toBe(true);
+		expect(opts.addsPunctuation).toBe(true);
+		expect(opts.contextualStrings).toContain("git");
+	});
+
+	it("uses the cheapest audio session for push-to-talk", async () => {
+		const p = createDeviceVoiceProvider();
+		await p.start(harness().cb);
+
+		// The library's default (playAndRecord + measurement + allowBluetooth) costs
+		// roughly a second to activate, largely on Bluetooth route negotiation and an
+		// output path dictation never uses. Intolerable before a short phrase.
+		const opts = started[0] as { iosCategory?: Record<string, unknown> };
+		expect(opts.iosCategory?.category).toBe("record");
+		expect(opts.iosCategory?.categoryOptions).toEqual([]);
+	});
+
+	it("buys the Bluetooth-capable audio session for latched dictation", async () => {
+		const p = createDeviceVoiceProvider();
+		await p.start(harness().cb, { mode: "latched" });
+
+		// Here the warm-up is amortised over a long prompt, so it is worth paying for
+		// a session that can route through a headset mic.
+		const opts = started[0] as { iosCategory?: Record<string, unknown> };
+		expect(opts.iosCategory?.category).toBe("playAndRecord");
+		expect(opts.iosCategory?.categoryOptions).toContain("allowBluetooth");
+	});
+});

--- a/packages/mobile/lib/voice/deviceProvider.ts
+++ b/packages/mobile/lib/voice/deviceProvider.ts
@@ -1,0 +1,422 @@
+import {
+	AVAudioSessionCategory,
+	AVAudioSessionCategoryOptions,
+	AVAudioSessionMode,
+	ExpoSpeechRecognitionModule,
+} from "expo-speech-recognition";
+import { Platform } from "react-native";
+import type { VoiceCallbacks, VoiceMode, VoiceProvider } from "./types";
+
+// On-device speech recognition: iOS SFSpeechRecognizer, Android SpeechRecognizer.
+// Chosen over a cloud recogniser because it is free, private, needs no API key
+// and carries no per-minute cost — dictation is the kind of thing people leave
+// on, and a metered one would be quietly expensive.
+
+// Bias the recogniser toward words that show up constantly in agent prompts and
+// would otherwise come back mangled ("get" for "git", "MPM" for "npm"). iOS maps
+// this to SFSpeechRecognitionRequest.contextualStrings, Android to
+// EXTRA_BIASING_STRINGS. Same trick Claude Code applies to its own dictation.
+const CODING_VOCABULARY = [
+	"git",
+	"npm",
+	"repo",
+	"commit",
+	"rebase",
+	"branch",
+	"merge",
+	"PR",
+	"diff",
+	"refactor",
+	"TypeScript",
+	"JavaScript",
+	"Go",
+	"React",
+	"Expo",
+	"JSON",
+	"API",
+	"CLI",
+	"daemon",
+	"worktree",
+	"regex",
+	"localhost",
+	"stack trace",
+	"lint",
+	"typecheck",
+];
+
+// How long stop() waits for the recogniser's `end` event before delivering the
+// transcript anyway. Generous: `end` normally arrives in well under a second, and
+// firing early would cut off a final result still in flight.
+const STOP_GRACE_MS = 4000;
+
+// Recognition accuracy drops sharply when the locale doesn't match the speaker's
+// accent - "en-US" applied to an en-IN or en-GB speaker mishears steadily rather
+// than failing outright, which reads as "it just transcribes the wrong words".
+// So resolve the device's own locale against what the recogniser actually
+// supports, and fall back to the same language in another region before giving up
+// on en-US.
+let resolvedLang: string | null = null;
+
+const normalizeLocale = (s: string) => s.replace(/_/g, "-").toLowerCase();
+
+async function resolveLang(): Promise<string> {
+	if (resolvedLang) return resolvedLang;
+
+	let device = "en-US";
+	try {
+		device = Intl.DateTimeFormat().resolvedOptions().locale || "en-US";
+	} catch {
+		// No Intl (unexpected on Hermes) - keep the default.
+	}
+
+	try {
+		const { locales } = await ExpoSpeechRecognitionModule.getSupportedLocales({});
+		const want = normalizeLocale(device);
+		const exact = locales.find((l) => normalizeLocale(l) === want);
+		if (exact) return (resolvedLang = exact);
+
+		// e.g. device is en-IN but only en-GB is installed - still far closer than en-US.
+		const language = want.split("-")[0];
+		const sameLanguage = locales.find((l) => normalizeLocale(l).split("-")[0] === language);
+		if (sameLanguage) return (resolvedLang = sameLanguage);
+	} catch {
+		// Locale enumeration is best-effort; en-US is the safe fallback.
+	}
+
+	return (resolvedLang = "en-US");
+}
+
+// LAST-RESORT segment detection, for a recognition service that emits neither a
+// final result nor `speechstart` at a boundary. The real boundaries come from
+// those two events; this only catches a partial that has obviously rolled over
+// without one.
+//
+// Within a segment, successive partials restate the whole segment: they grow, and
+// revise words in place ("add a test" -> "add a test for" -> "add attest for").
+// They therefore keep sharing an opening. A partial that shares none belongs to a
+// new segment, so the previous one is finished and must be banked.
+function isSameSegment(prev: string, next: string): boolean {
+	if (!prev.trim()) return true;
+	const a = prev.trim().toLowerCase();
+	const b = next.trim().toLowerCase();
+	// Plain growth, or a revision that shortened the text.
+	if (b.startsWith(a) || a.startsWith(b)) return true;
+	// A revision can rewrite words the recogniser already emitted ("a test" ->
+	// "attest"), so a character prefix is too brittle. But it still opens on the
+	// same word and does not get shorter. A new segment after a pause starts fresh
+	// and short, so this separates them without being fooled by re-transcription.
+	const firstWord = (s: string) => s.slice(0, s.indexOf(" ") === -1 ? s.length : s.indexOf(" "));
+	return firstWord(a) === firstWord(b) && b.length >= a.length;
+}
+
+// A "no speech" error is what you get from a mis-tap or a silent room. It is the
+// expected outcome of a stray press, not a fault worth showing a banner for.
+const SILENT_ERRORS = new Set(["no-speech", "aborted", "speech-timeout"]);
+
+const ERROR_MESSAGES: Record<string, string> = {
+	"not-allowed": "Microphone or speech permission was denied. Enable it in Settings to dictate.",
+	"service-not-allowed": "Speech recognition is unavailable on this device.",
+	"language-not-supported": "Speech recognition is not available for this language.",
+	network: "Speech recognition needs a network connection and could not reach it.",
+	"audio-capture": "Could not capture audio from the microphone.",
+	interrupted: "Recording was interrupted.",
+	busy: "The speech recogniser is busy. Try again in a moment.",
+};
+
+// Process-wide singleton. The provider caches the permission grant, and the
+// native module caches the SFSpeechRecognizer across starts — both of which are
+// wasted if a new provider appears every time a terminal screen mounts. Recording
+// state lives inside one provider, and only one recording can run at a time
+// anyway, so sharing is safe.
+let shared: VoiceProvider | null = null;
+
+export function getDeviceVoiceProvider(): VoiceProvider {
+	shared ??= createDeviceVoiceProvider();
+	return shared;
+}
+
+export function createDeviceVoiceProvider(): VoiceProvider {
+	// Kick locale resolution off now rather than on the first press: warm-up is
+	// already the sore point, and this must not add to it. If it hasn't finished by
+	// the time the user speaks, start() falls back to en-US for that one phrase.
+	void resolveLang();
+
+	// Everything about one recording lives in a single object, so ending a
+	// recording is "drop the session" rather than "reset five variables". A stale
+	// event that somehow outlives its subscriptions finds `session` null and is
+	// ignored, and there is no window where half the state has been cleared.
+	type Session = {
+		cb: VoiceCallbacks;
+		subscriptions: { remove(): void }[];
+		// Continuous recognition is SEGMENTED on Android: each pause closes a segment
+		// with its own `isFinal` result, and the next segment starts from scratch
+		// rather than restating what came before. So finished segments must be kept
+		// and joined - treating any single result as "the transcript" silently drops
+		// everything the user said after their first pause.
+		finalized: string[];
+		// The in-flight segment, replaced as it firms up (partials restate the whole
+		// current segment, they are not deltas).
+		partial: string;
+		// Set by stop(); fires only if `end` never arrives. See stop().
+		settleTimer?: ReturnType<typeof setTimeout>;
+	};
+	let session: Session | null = null;
+	// Sticky once granted. Permission can only be revoked from Settings, which
+	// restarts the app, so caching it for the process lifetime is safe.
+	let granted = false;
+
+	// Everything heard so far: completed segments plus the one in progress.
+	function transcriptOf(s: Session): string {
+		return [...s.finalized, s.partial].filter(Boolean).join(" ").trim();
+	}
+
+	function close(): VoiceCallbacks | null {
+		if (!session) return null;
+		const { cb, subscriptions, settleTimer } = session;
+		session = null;
+		if (settleTimer) clearTimeout(settleTimer);
+		for (const sub of subscriptions) sub.remove();
+		return cb;
+	}
+
+	// Ends the recording exactly once. Driven by `end` — documented as always the
+	// last event, including after errors — rather than by a final result, because
+	// in continuous mode a final result means "segment done", not "recording done".
+	// Always reports through onFinal; an empty string is a legitimate result
+	// meaning "nothing was said", which the caller treats as a no-op, not an error.
+	function settle() {
+		if (!session) return;
+		const text = transcriptOf(session);
+		const cb = close();
+		cb?.onFinal(text);
+	}
+
+	function fail(message: string) {
+		const cb = close();
+		cb?.onError(message);
+	}
+
+	// Drop listeners before aborting so the resulting "aborted" error event can't
+	// settle a session the caller has already walked away from.
+	function abortSession() {
+		close();
+		try {
+			ExpoSpeechRecognitionModule.abort();
+		} catch {
+			// Nothing was running.
+		}
+	}
+
+	return {
+		id: "device",
+
+		language() {
+			return resolvedLang;
+		},
+
+		available() {
+			try {
+				return ExpoSpeechRecognitionModule.isRecognitionAvailable();
+			} catch {
+				// Module missing entirely (e.g. a build that skipped prebuild).
+				return false;
+			}
+		},
+
+		async requestPermission() {
+			// Every press goes through here, and this sits directly in front of the
+			// microphone starting — so once permission is known to be granted, skip the
+			// native round-trip entirely. Re-asking each time delayed the start of
+			// recording enough to swallow the first words of a short phrase.
+			if (granted) return true;
+			try {
+				const existing = await ExpoSpeechRecognitionModule.getPermissionsAsync();
+				if (existing.granted) {
+					granted = true;
+					return true;
+				}
+				const res = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
+				granted = res.granted;
+				return res.granted;
+			} catch {
+				return false;
+			}
+		},
+
+		async start(cb, opts) {
+			const longForm = opts?.mode === "latched";
+			// A previous recording that never settled must not leak its listeners.
+			// When there is no live session the native side is already stopped (every
+			// settle path follows a native end/error), so don't abort for nothing.
+			if (session) abortSession();
+			const current: Session = { cb, subscriptions: [], finalized: [], partial: "" };
+			session = current;
+
+			current.subscriptions.push(
+				ExpoSpeechRecognitionModule.addListener("result", (e) => {
+					if (session !== current) return;
+					const transcript = e.results?.[0]?.transcript ?? "";
+
+					// iOS is ONE cumulative stream, not a sequence of segments. A single
+					// recognition task runs over the whole recording and every result —
+					// `isFinal` ones included — restates everything said so far. Banking
+					// those the way Android's segments are banked appends the entire
+					// phrase again on each final, and then the next cumulative partial
+					// adds it a third time, which is why a long dictation snowballed into
+					// "How the How's the system system turning How is the system turning?".
+					//
+					// So iOS keeps its whole stream in `partial` and never banks on a
+					// final. The one case that does bank is a task restart (iOS caps how
+					// long a single recognition task may run): its first result starts
+					// from scratch and shares no opening with what came before, so the
+					// finished task has to be preserved or the earlier speech is lost.
+					if (Platform.OS === "ios") {
+						if (!isSameSegment(current.partial, transcript) && current.partial.trim()) {
+							current.finalized.push(current.partial.trim());
+						}
+						current.partial = transcript;
+						cb.onPartial(transcriptOf(current));
+						return;
+					}
+
+					if (e.isFinal) {
+						// A closed segment, NOT the end of the recording. Bank it and wait —
+						// the user is still holding the key and may keep talking. The final
+						// supersedes the partial it was built from, so the partial is
+						// dropped rather than banked alongside it.
+						if (transcript.trim()) current.finalized.push(transcript.trim());
+						current.partial = "";
+					} else {
+						// Normally `speechstart` has already banked the previous segment by
+						// now. This only fires if the service announced no boundary at all.
+						if (!isSameSegment(current.partial, transcript) && current.partial.trim()) {
+							current.finalized.push(current.partial.trim());
+						}
+						current.partial = transcript;
+					}
+					cb.onPartial(transcriptOf(current));
+				}),
+			);
+
+			current.subscriptions.push(
+				// The authoritative segment boundary on Android, and the reason its
+				// transcripts can now match iOS's.
+				//
+				// iOS runs ONE recognition task over the whole stream, so each result
+				// restates everything said so far - pauses included. Android's
+				// SpeechRecognizer is built for a single utterance, so it emits a
+				// sequence of independent chunks that have to be stitched.
+				// `onBeginningOfSpeech` fires at the start of each new utterance, so
+				// anything still held as a partial belongs to the previous one.
+				//
+				// iOS is excluded deliberately: it fires `speechstart` once after a
+				// result, and its partials are cumulative, so banking there would
+				// duplicate the text rather than segment it.
+				ExpoSpeechRecognitionModule.addListener("speechstart", () => {
+					if (session !== current || Platform.OS !== "android") return;
+					if (current.partial.trim()) {
+						current.finalized.push(current.partial.trim());
+						current.partial = "";
+					}
+				}),
+			);
+
+			current.subscriptions.push(
+				ExpoSpeechRecognitionModule.addListener("start", () => {
+					// The recogniser is live. Until this fires the microphone is still
+					// warming up and speech is dropped on the floor, so this is the only
+					// honest moment to prompt the user to talk.
+					if (session === current) cb.onReady();
+				}),
+			);
+
+			current.subscriptions.push(
+				ExpoSpeechRecognitionModule.addListener("error", (e) => {
+					if (session !== current) return;
+					// Silence, a stray tap, or a deliberate abort is not a fault. Settle
+					// normally so anything already transcribed survives.
+					if (SILENT_ERRORS.has(e.error)) settle();
+					else fail(ERROR_MESSAGES[e.error] ?? e.message ?? "Speech recognition failed.");
+				}),
+			);
+
+			current.subscriptions.push(
+				ExpoSpeechRecognitionModule.addListener("end", () => {
+					// `end` is the only reliable "the recording is over" signal: it is
+					// documented as always the last event dispatched, including after an
+					// error, and unlike a final result it never also means "segment
+					// boundary". This is what settles a normal recording.
+					if (session === current) settle();
+				}),
+			);
+
+			try {
+				ExpoSpeechRecognitionModule.start({
+					// Synchronous read of the pre-resolved value - awaiting here would add
+					// to the warm-up the user is already waiting through.
+					lang: resolvedLang ?? "en-US",
+					interimResults: true,
+					// Push-to-talk: the user's finger decides when the phrase ends, not a
+					// silence timer. Unsupported on Android 12 and below, where it falls
+					// back to auto-stop — still correct, just less forgiving of a pause.
+					continuous: true,
+					addsPunctuation: true,
+					contextualStrings: CODING_VOCABULARY,
+					// The audio session is the warm-up: measured at ~1.1s, dominated by
+					// Bluetooth HFP route negotiation and configuring an output path.
+					// That cost is intolerable before a three-second phrase and irrelevant
+					// before a sixty-second one, so the two modes buy different sessions.
+					// It cannot be changed mid-recording - iOS would need a teardown and
+					// re-activation - which is why the mode is fixed at start.
+					iosCategory: longForm
+						? {
+								// Hands-free dictation: worth the slower activation to let a
+								// Bluetooth headset mic carry a long prompt.
+								category: AVAudioSessionCategory.playAndRecord,
+								categoryOptions: [
+									AVAudioSessionCategoryOptions.allowBluetooth,
+									AVAudioSessionCategoryOptions.defaultToSpeaker,
+								],
+								mode: AVAudioSessionMode.measurement,
+							}
+						: {
+								// Push-to-talk: cheapest session that can capture. Built-in mic
+								// only, no route negotiation, no output path.
+								category: AVAudioSessionCategory.record,
+								categoryOptions: [],
+								mode: AVAudioSessionMode.default,
+							},
+					androidIntentOptions: {
+						// Thinking mid-sentence is normal when dictating a prompt. Android's
+						// default silence timeout is short enough to end the session while
+						// the user is still holding the key, so widen it and let the finger
+						// decide instead.
+						EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS: 10000,
+						EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS: 10000,
+					},
+				});
+			} catch (e) {
+				fail(e instanceof Error ? e.message : "Could not start the microphone.");
+			}
+		},
+
+		stop() {
+			const current = session;
+			try {
+				ExpoSpeechRecognitionModule.stop();
+			} catch {
+				// Already stopped; the `end` listener settles us.
+			}
+			if (!current) return;
+			// Watchdog. `end` normally lands within a few hundred ms of stop() and is
+			// what delivers the transcript. If the recogniser dies without emitting it
+			// the UI would sit in "recording" forever with the words stranded — the
+			// "it recorded but nothing happened" failure. Settle with what we heard.
+			current.settleTimer = setTimeout(() => {
+				if (session === current) settle();
+			}, STOP_GRACE_MS);
+		},
+
+		abort: abortSession,
+	};
+}

--- a/packages/mobile/lib/voice/types.ts
+++ b/packages/mobile/lib/voice/types.ts
@@ -1,0 +1,60 @@
+// The seam between the mic UI and whatever actually turns speech into text.
+//
+// Only an on-device recogniser ships today (see `deviceProvider.ts`), but the
+// interface is deliberately shaped so a cloud provider — Wispr Flow, Deepgram —
+// is an additive file rather than a rewrite. The mic is always the phone's and
+// never the harness's — see the note in `app/session/[id].tsx` for why.
+
+export type VoiceState =
+	| "idle"
+	| "starting"
+	| "recording"
+	// Audio captured, text not back yet. Unreachable for the on-device provider
+	// (which streams), but present from day one so a later batch/cloud provider —
+	// which does have a gap between release and text — needs no UI change.
+	| "transcribing"
+	| "denied"
+	| "unavailable";
+
+/**
+ * How a recording was started, which decides the audio session it gets.
+ *
+ * `push` — hold the key. Optimised for the shortest possible time-to-capture,
+ * because a ~1s warm-up is intolerable before a three-second phrase. Uses the
+ * bare `record` category: built-in mic, no Bluetooth route negotiation.
+ *
+ * `latched` — double-tap, hands-free until tapped again. Here the warm-up is
+ * amortised over a long dictation and stops mattering, so this one pays for the
+ * richer session that can route through a Bluetooth headset.
+ */
+export type VoiceMode = "push" | "latched";
+
+export type VoiceCallbacks = {
+	/**
+	 * The microphone is actually capturing. Fired after a warm-up that can run to
+	 * several hundred milliseconds, so it — not the return of `start()` — is the
+	 * moment the UI may tell the user to speak. Anything said before this is lost.
+	 */
+	onReady(): void;
+	/** Live, not-yet-final text. A batch provider simply never calls this. */
+	onPartial(text: string): void;
+	/** The finished transcript. Called at most once per `start`. */
+	onFinal(text: string): void;
+	/** Human-readable failure. The provider is back to idle once this fires. */
+	onError(message: string): void;
+};
+
+export interface VoiceProvider {
+	readonly id: "device" | "cloud";
+	/** False when this device/build can't transcribe at all — the mic key hides. */
+	available(): boolean;
+	/** Resolved recognition locale, or null before it has been determined. */
+	language(): string | null;
+	/** Prompts on first call. Resolves false if the user declined. */
+	requestPermission(): Promise<boolean>;
+	start(cb: VoiceCallbacks, opts?: { mode?: VoiceMode }): Promise<void>;
+	/** Finish and emit a final result. */
+	stop(): void;
+	/** Discard — no final result. Used on unmount/blur. */
+	abort(): void;
+}

--- a/packages/mobile/lib/voice/useVoiceInput.ts
+++ b/packages/mobile/lib/voice/useVoiceInput.ts
@@ -1,0 +1,267 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AppState } from "react-native";
+import { haptics } from "../haptics";
+import { getDeviceVoiceProvider } from "./deviceProvider";
+import type { VoiceMode, VoiceProvider, VoiceState } from "./types";
+
+// Dictation, decoupled from any screen. Owns permission, the recording
+// lifecycle, the live partial transcript, and the gesture that distinguishes a
+// hold from a double-tap; knows nothing about terminals, sessions, or how the
+// text is eventually sent.
+
+// A press shorter than this was a tap, not a hold.
+const TAP_MS = 250;
+// How long after a tap a second tap still counts as a double-tap.
+const DOUBLE_TAP_MS = 300;
+// Breathing room between aborting the tap's recording and starting the latched
+// one, so the native recogniser isn't still tearing down and reporting "busy".
+// Only ever paid on the double-tap path, which is not latency-sensitive.
+const RESTART_DELAY_MS = 120;
+
+export type UseVoiceInput = {
+	state: VoiceState;
+	/** Which gesture started the current recording. */
+	mode: VoiceMode;
+	/** Live text while recording. Empty otherwise. */
+	partial: string;
+	/** Last failure, or null. Cleared on the next recording. */
+	error: string | null;
+	/** Finger down on the mic key. */
+	pressIn(): void;
+	/** Finger up off the mic key. */
+	pressOut(): void;
+};
+
+export function useVoiceInput({
+	onTranscript,
+	provider,
+}: {
+	onTranscript: (text: string) => void;
+	/** Injectable for tests; defaults to the on-device recogniser. */
+	provider?: VoiceProvider;
+}): UseVoiceInput {
+	const device = useMemo(() => provider ?? getDeviceVoiceProvider(), [provider]);
+
+	const [state, setState] = useState<VoiceState>("idle");
+	const [mode, setMode] = useState<VoiceMode>("push");
+	const [partial, setPartial] = useState("");
+	const [error, setError] = useState<string | null>(null);
+
+	// Gesture bookkeeping. All refs: these are read and written inside touch
+	// handlers and timers that resolve far faster than React re-renders.
+	const modeRef = useRef<VoiceMode>("push");
+	const pressStartRef = useRef(0);
+	// Non-null while a tap is waiting to see if it becomes a double-tap.
+	const tapWindowRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const restartRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	// True for the single press that switched us into latched mode, so its own
+	// release doesn't immediately stop the recording it just started.
+	const startedLatchedRef = useRef(false);
+
+	// The ref is the authoritative phase, not a mirror of `state`. Press-in →
+	// permission dialog → press-out all resolve faster than React re-renders, so
+	// reading `state` inside those callbacks would see stale values. Always change
+	// phase through `setPhase` so the two never diverge.
+	const stateRef = useRef<VoiceState>("idle");
+	const setPhase = useCallback((next: VoiceState) => {
+		stateRef.current = next;
+		setState(next);
+	}, []);
+	const onTranscriptRef = useRef(onTranscript);
+	onTranscriptRef.current = onTranscript;
+	// Guards against a permission dialog resolving after the component unmounted.
+	const mountedRef = useRef(true);
+
+	// Availability is a device fact, not a permission — check it once so the mic
+	// key can hide entirely rather than failing on press.
+	useEffect(() => {
+		if (!device.available()) setPhase("unavailable");
+	}, [device, setPhase]);
+
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+			// Never leave the microphone open behind a closed screen. This is the
+			// guarantee that a latched recording cannot outlive the terminal screen.
+			if (tapWindowRef.current) clearTimeout(tapWindowRef.current);
+			if (restartRef.current) clearTimeout(restartRef.current);
+			modeRef.current = "push";
+			device.abort();
+		};
+	}, [device]);
+
+	// Backgrounding the app must also close the mic: iOS will interrupt the audio
+	// session anyway, and leaving the UI stuck in `recording` is worse than
+	// dropping a phrase the user walked away from.
+	useEffect(() => {
+		const sub = AppState.addEventListener("change", (next) => {
+			if (next === "active") return;
+			if (stateRef.current !== "recording" && stateRef.current !== "starting") return;
+			device.abort();
+			modeRef.current = "push";
+			setMode("push");
+			setPartial("");
+			setPhase("idle");
+		});
+		return () => sub.remove();
+	}, [device, setPhase]);
+
+	const beginRecording = useCallback(
+		(mode: VoiceMode) => {
+		const current = stateRef.current;
+		if (current === "unavailable" || current === "starting" || current === "recording") return;
+
+		modeRef.current = mode;
+		setMode(mode);
+		setError(null);
+		setPartial("");
+		setPhase("starting");
+
+		// Warm-up is the whole complaint ("keep holding..." lasting too long), and it
+		// splits into two very different costs: our own permission round-trip, and
+		// the native recogniser + audio-session startup. Timing them separately is
+		// the only way to know which one to attack.
+		const t0 = Date.now();
+		let tPermission = 0;
+
+		void (async () => {
+			// Asked lazily on first use, so users who never touch the mic never see
+			// a permission dialog.
+			const granted = await device.requestPermission();
+			tPermission = Date.now() - t0;
+			if (!mountedRef.current) return;
+			if (!granted) {
+				setPhase("denied");
+				setError("Microphone access is off. Enable it in Settings to dictate.");
+				return;
+			}
+
+			// The finger may have lifted while the dialog was up — don't start a
+			// recording nobody is holding.
+			if (stateRef.current !== "starting") return;
+
+			await device.start(
+				{
+				onReady: () => {
+					if (__DEV__) {
+						const total = Date.now() - t0;
+						console.log(
+							`[voice] warm-up ${total}ms (permission ${tPermission}ms, recogniser ${total - tPermission}ms) lang=${device.language() ?? "pending"}`,
+						);
+					}
+					if (!mountedRef.current) return;
+					// Only now is the microphone actually capturing. A short buzz is the
+					// cue to start talking - the user is looking at the terminal, not at
+					// the key, so a visual-only change would be missed.
+					if (stateRef.current === "starting") {
+						setPhase("recording");
+						haptics.select();
+					}
+				},
+				onPartial: (text) => {
+					if (!mountedRef.current) return;
+					setPartial(text);
+				},
+				onFinal: (text) => {
+					modeRef.current = "push";
+					if (!mountedRef.current) return;
+					setMode("push");
+					setPartial("");
+					setPhase("idle");
+					// An empty transcript means silence or a stray tap: a no-op, not an
+					// error, and nothing should reach the composer.
+					if (text) onTranscriptRef.current(text);
+				},
+				onError: (message) => {
+					modeRef.current = "push";
+					if (!mountedRef.current) return;
+					setMode("push");
+					setPartial("");
+					setPhase("idle");
+					setError(message);
+				},
+				},
+				{ mode },
+			);
+
+			// Deliberately does NOT move to "recording" here. start() returning only
+			// means the recogniser was asked to start; the mic is still warming up and
+			// speech is dropped until the `onReady` callback above fires. Claiming
+			// "Listening" at this point is what made short holds lose their first
+			// words - the UI invited the user to talk before anything was capturing.
+		})();
+		},
+		[device, setPhase],
+	);
+
+	// Ends whatever is running, keeping the transcript.
+	const finish = useCallback(() => {
+		const current = stateRef.current;
+		if (current === "starting") {
+			// Released before the recogniser was live — nothing to finalise.
+			device.abort();
+			setPhase("idle");
+			setPartial("");
+			return;
+		}
+		if (current !== "recording") return;
+		// Stays in `recording` until the provider settles, so the UI doesn't flash
+		// idle while the final result is still in flight.
+		device.stop();
+	}, [device, setPhase]);
+
+	const pressIn = useCallback(() => {
+		// While latched the key is a stop button — the finger is not holding
+		// anything, so a press means "I'm done talking".
+		if (modeRef.current === "latched" && stateRef.current !== "idle") {
+			startedLatchedRef.current = false;
+			finish();
+			return;
+		}
+
+		// Second tap of a double-tap: go hands-free. This is the only path that gets
+		// the Bluetooth-capable audio session, because the session is fixed at start
+		// and cannot be upgraded mid-recording.
+		if (tapWindowRef.current) {
+			clearTimeout(tapWindowRef.current);
+			tapWindowRef.current = null;
+			startedLatchedRef.current = true;
+			haptics.tap();
+			// The tap's own recording was aborted a moment ago; give the native
+			// recogniser time to finish tearing down before asking it to start again.
+			restartRef.current = setTimeout(() => beginRecording("latched"), RESTART_DELAY_MS);
+			return;
+		}
+
+		// Ordinary press. Start immediately and decide what it *was* on release —
+		// waiting to disambiguate would add to a warm-up that is already the sore
+		// point, and the overwhelming majority of presses are holds.
+		startedLatchedRef.current = false;
+		pressStartRef.current = Date.now();
+		beginRecording("push");
+	}, [beginRecording, finish]);
+
+	const pressOut = useCallback(() => {
+		// The press that armed latched mode; releasing it must not stop anything.
+		if (startedLatchedRef.current) return;
+		// Latched recording ignores the finger entirely.
+		if (modeRef.current === "latched") return;
+
+		if (Date.now() - pressStartRef.current < TAP_MS) {
+			// A tap, not a hold. Throw away the sliver of audio and wait to see
+			// whether a second tap follows.
+			device.abort();
+			setPhase("idle");
+			setPartial("");
+			tapWindowRef.current = setTimeout(() => {
+				tapWindowRef.current = null;
+			}, DOUBLE_TAP_MS);
+			return;
+		}
+
+		finish();
+	}, [device, finish, setPhase]);
+
+	return { state, mode, partial, error, pressIn, pressOut };
+}

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -22,6 +22,7 @@
         "expo-notifications": "~0.32.17",
         "expo-router": "6.0.24",
         "expo-secure-store": "~15.0.8",
+        "expo-speech-recognition": "~3.1.3",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -5834,6 +5835,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-speech-recognition": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-3.1.3.tgz",
+      "integrity": "sha512-vluXqggfY2AJcazYITvnV6YSE2rVe5SId5TpdjMC/m6JPUgHCOODrcHJtAQF6OUYl4f2T7oZSceGw6fJCC86Xw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -27,6 +27,7 @@
 		"expo-notifications": "~0.32.17",
 		"expo-router": "6.0.24",
 		"expo-secure-store": "~15.0.8",
+		"expo-speech-recognition": "~3.1.3",
 		"expo-status-bar": "~3.0.9",
 		"react": "19.1.0",
 		"react-native": "0.81.5",


### PR DESCRIPTION
> **Depends on #3399 — draft until that merges.**
>
> This branch is built on `feat/mobile-theming-and-shell`, but a PR base must live in the upstream repo, so this targets `main` and currently shows #3399's commits too. **Only the last two commits are new here.** The moment #3399 merges, this diff collapses to just those two on its own and I will mark it ready.
>
> Just the voice work: https://github.com/Prasad-D-Ware/agent-orchestrator/compare/feat/mobile-theming-and-shell...feat/mobile-voice-dictation

Adds push-to-talk dictation to the session composer: hold the mic to speak, release to insert, or swipe up to latch it hands-free.

Typing prompts on a phone keyboard is the slowest part of driving a session from one, and it is the reason a phone session tends to become read-only in practice.

## The mic is the phone's, never the harness's

The obvious-looking implementation is to drive the harness's own voice mode — Claude Code exposes `/voice`, and the key row already sends arbitrary bytes to the PTY, so it is trivially deliverable.

It does not work, and the reason generalises. The harness records through the **daemon host's** microphone: the machine running the agent, which is not the machine the user is holding. It would also only ever work for the harnesses that ship a voice mode at all.

Capturing on the phone inverts both. The transcript is just text, so it leaves through the same `sendPrompt` path as anything typed, and every harness gets dictation for free.

## Choices worth flagging in review

- **On-device recognition** (iOS `SFSpeechRecognizer`, Android `SpeechRecognizer`) rather than cloud: free, private, no API key, no per-minute cost. Dictation is the kind of feature people leave on, and a metered recogniser would be quietly expensive. The provider interface is shaped so a cloud backend is an additive file, not a rewrite.
- **The transcript lands as an editable draft, not a send.** This text reaches an agent with tool access, and speech-to-text mishears code vocabulary often enough that silent submission is not acceptable. Phrases append, so several held bursts build one prompt.
- **The recogniser is biased toward agent vocabulary** — otherwise "git" comes back "get" and "npm" comes back "MPM". `contextualStrings` on iOS, `EXTRA_BIASING_STRINGS` on Android.
- **The live partial sits above the dock, not in the field.** It changes on every syllable, and rewriting text under the user's caret is hostile.
- **Warm-up says "Keep holding...", not "Listening".** The mic is not capturing yet, and the latter invites speech that gets dropped.

## Permissions

`expo-camera`'s `microphonePermission: false` is dropped, since the app now genuinely wants the microphone. The usage descriptions live on the `expo-speech-recognition` plugin, covering both microphone and speech recognition.

## Testing

- `npm run typecheck` — clean
- `npm test` — 19 files, 268 tests passing (31 new, covering the provider's permission, lifecycle and mode handling)
