### PR TITLE
fix terminal theme timing

### DIFF
--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { CommandPalette } from "../components/CommandPalette";
 import { CenterPanelShell } from "../components/CenterPanelShell";
 import { DaemonFailureBanner } from "../components/DaemonFailureBanner";
@@ -372,7 +372,7 @@ function ShellLayout() {
 		[navigate, queryClient, setOrchestratorReplacementError, setProjectRestarting],
 	);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		applyDocumentTheme(resolvedTheme);
 	}, [resolvedTheme]);
 


### PR DESCRIPTION
## What changed
- Moved shell theme application from `useEffect` to `useLayoutEffect` so the document theme is applied before terminal descendants read CSS variables.

## Why
- The terminal theme was one render behind because xterm-derived theme values were computed after the DOM theme class/data attribute update.

## Impact
- Terminal colors now track the active app theme without the stale-frame mismatch described in issue 3398.

## Validation
- `cd frontend && npm run typecheck`
- `cd frontend && npm test -- --run src/renderer/components/XtermTerminal.test.tsx`

Fixes #3398
