### PR TITLE
fix(cursor): stop activity state sticking on "Input Needed" all turn

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agy"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/fake"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
@@ -37,7 +38,7 @@ var Derivers = map[string]DeriveFunc{
 	"opencode":    opencode.DeriveActivityState,
 	"goose":       activitystate.StandardDeriveActivityState,
 	"devin":       activitystate.StandardDeriveActivityState,
-	"cursor":      activitystate.StandardDeriveActivityState,
+	"cursor":      cursor.DeriveActivityState,
 	"qwen":        activitystate.StandardDeriveActivityState,
 	"copilot":     activitystate.StandardDeriveActivityState,
 	"kimi":        activitystate.StandardDeriveActivityState,

--- a/backend/internal/adapters/agent/cursor/activity.go
+++ b/backend/internal/adapters/agent/cursor/activity.go
@@ -1,0 +1,32 @@
+package cursor
+
+import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
+// DeriveActivityState maps a Cursor hook event onto an AO activity state.
+//
+// event is the AO hook sub-command name installed in cursorManagedHooks
+// ("user-prompt-submit", "pre-tool-use", ...), NOT the native Cursor event
+// name.
+//
+// cursor-agent is always launched with --trust, so beforeShellExecution/
+// beforeMCPExecution (and their after* counterparts) never pause for a real
+// permission decision — they fire on every auto-approved tool call. They are
+// therefore treated like claude-code's PreToolUse/PostToolUse trio (active),
+// not like a permission dialog. Unlike claude-code, Cursor exposes no
+// separate hook that fires only for a genuine blocking dialog, so a cursor
+// session never enters waiting_input/blocked: there is no signal AO could use
+// to know one is happening.
+func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+	switch event {
+	case "session-start":
+		return domain.ActivityActive, true
+	case "user-prompt-submit":
+		return domain.ActivityActive, true
+	case "pre-tool-use", "post-tool-use":
+		return domain.ActivityActive, true
+	case "stop":
+		return domain.ActivityIdle, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/adapters/agent/cursor/hooks.go
+++ b/backend/internal/adapters/agent/cursor/hooks.go
@@ -57,12 +57,23 @@ type cursorHookSpec struct {
 // cursorManagedHooks is the source of truth for the hooks AO installs. The
 // native-event → AO-subcommand contract is FIXED: the orchestrator's CLI hook
 // dispatch and activity.go agree on the sub-command names.
+//
+// The before*/after* pairs are dispatched as pre-tool-use/post-tool-use, the
+// same tokens claude-code uses for its own tool-use trio — NOT as
+// permission-request. cursor-agent is always launched with --trust
+// (cursor.go's GetLaunchCommand/GetRestoreCommand), so these hooks never
+// actually pause for a real permission decision; they fire on every
+// auto-approved tool call. Mapping them to permission-request's
+// waiting_input, with no paired after-hook to demote it, is what left the
+// activity badge stuck on "Input Needed" for the whole turn. See DeriveActivityState.
 var cursorManagedHooks = []cursorHookSpec{
 	{Event: "sessionStart", Command: cursorHookCommandPrefix + "session-start"},
 	{Event: "beforeSubmitPrompt", Command: cursorHookCommandPrefix + "user-prompt-submit"},
 	{Event: "stop", Command: cursorHookCommandPrefix + "stop"},
-	{Event: "beforeShellExecution", Command: cursorHookCommandPrefix + "permission-request"},
-	{Event: "beforeMCPExecution", Command: cursorHookCommandPrefix + "permission-request"},
+	{Event: "beforeShellExecution", Command: cursorHookCommandPrefix + "pre-tool-use"},
+	{Event: "afterShellExecution", Command: cursorHookCommandPrefix + "post-tool-use"},
+	{Event: "beforeMCPExecution", Command: cursorHookCommandPrefix + "pre-tool-use"},
+	{Event: "afterMCPExecution", Command: cursorHookCommandPrefix + "post-tool-use"},
 }
 
 // GetAgentHooks installs AO's Cursor hooks into the worktree-local


### PR DESCRIPTION
## Summary

Fixes #3306.

Cursor's `beforeShellExecution`/`beforeMCPExecution` hooks were dispatched to AO as `permission-request`, which the shared `activitystate.StandardDeriveActivityState` maps to `waiting_input` (a sticky state). No `afterShellExecution`/`afterMCPExecution` hook was installed to demote it back, and no fallback terminal-activity detection exists for cursor (unlike codex). So once the first tool call flipped the badge to "Input Needed", nothing cleared it until the turn's `stop` hook — even while the agent was visibly editing files and running commands for the rest of the turn.

The `permission-request` mapping was also the wrong model to begin with: AO always launches `cursor-agent` with `--trust` (`cursor.go`'s `GetLaunchCommand`/`GetRestoreCommand`), so these hooks never represent a real blocking permission decision — they fire on every auto-approved tool call. They're functionally equivalent to claude-code's `PreToolUse`/`PostToolUse` trio, not to a permission dialog.

## Change

Rather than reusing `permission-request` and bolting on the same `toolFlight`/`blockedCandidate` correlation machinery `manager.go` uses to safely clear claude-code's sticky `blocked` state, this follows the simpler half of the existing pattern:

- **`cursor/hooks.go`**: `beforeShellExecution`/`beforeMCPExecution` now dispatch as `pre-tool-use` (was `permission-request`). Their previously-unregistered `afterShellExecution`/`afterMCPExecution` counterparts are now installed too, dispatching as `post-tool-use` — the same sub-command names claude-code uses for its own tool-use trio.
- **`cursor/activity.go`** (new): cursor gets its own `DeriveActivityState`, replacing the shared `activitystate.StandardDeriveActivityState`. `pre-tool-use`/`post-tool-use` both map to `active` (matching how claude-code's trio maps to `active`, not `waiting_input`/`blocked`). `session-start`/`user-prompt-submit` → `active`, `stop` → `idle`.
- **`activitydispatch/dispatch.go`**: registers `cursor.DeriveActivityState` for the `"cursor"` token.

Because cursor's tool-use signals now always resolve to `active`, the session never enters a sticky state in the first place — so the existing precedence guard in `manager.go` (`isToolUseEvent`, `applyToolPrecedenceLocked`) doesn't need to change, and no per-tool correlation tracking is needed for cursor.

**Trade-off**: cursor sessions can no longer show "Input Needed" at all, since Cursor exposes no separate hook that fires only for a genuine blocking dialog (unlike claude-code's distinct `PermissionRequest` event). Given `--trust` means that indicator was never trustworthy to begin with (same "many-to-one collapse" already flagged in `copilot/hooks.go`), this seemed like the honest trade rather than leaving a misleading sticky state in place.

The forum-sourced caveat in #3306 (that `beforeMCPExecution`/`afterMCPExecution` may not fire for the `cursor-agent` CLI) is left as an open follow-up — registering them is harmless dead weight if unconfirmed, consistent with the issue's own suggested fix.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` passes (all packages, including `cursor`, `activitydispatch`, `lifecycle`)
- [ ] Manual repro from #3306: start a Cursor session, hit "Input Needed", send a follow-up, confirm the badge reflects "active" through subsequent tool calls instead of sticking

🤖 Generated with [Claude Code](https://claude.com/claude-code)