### PR TITLE
ci(build-artifacts): ship the Linux .rpm as a release artifact (#3405)

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -142,6 +142,33 @@ jobs:
           path: frontend/dist-deb/agent-orchestrator-linux-x64.deb
           retention-days: 1
           if-no-files-found: error
+      # Same story for the rpm maker (Fedora/RHEL/openSUSE, issue #3405). It
+      # already runs here (ubuntu-latest ships rpmbuild), its output was just
+      # never collected. Own dir for the same reason as the deb: keep it out of
+      # the `linux` artifact's agent-orchestrator-linux-x64.* glob.
+      - name: Collect Linux .rpm and compute digest
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          mkdir -p dist-rpm
+          # maker-rpm output: out/make/rpm/x64/<name>-<version>-<revision>.x86_64.rpm
+          src="$(find out/make -name '*.rpm' | head -n1)"
+          if [ -z "$src" ]; then echo "no .rpm output found" >&2; exit 1; fi
+          name="agent-orchestrator-linux-x64.rpm"
+          cp "$src" "dist-rpm/$name"
+          hash="$(openssl dgst -sha256 "dist-rpm/$name" | awk '{print $NF}')"
+          jq --arg f "$name" --arg h "$hash" '. + {($f): $h}' \
+            dist-artifact/linux-x64.digest.json > dist-artifact/linux-x64.digest.json.tmp
+          mv dist-artifact/linux-x64.digest.json.tmp dist-artifact/linux-x64.digest.json
+          echo "linux-x64: $name sha256=$hash" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload Linux .rpm artifact
+        if: matrix.platform == 'linux-x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-rpm
+          path: frontend/dist-rpm/agent-orchestrator-linux-x64.rpm
+          retention-days: 1
+          if-no-files-found: error
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ Download the latest desktop build for your platform:
 | macOS (Apple silicon) | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-arm64.zip)   |
 | macOS (Intel)         | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-x64.zip)     |
 | Windows               | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-win32-x64.exe)      |
-| Linux                 | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.AppImage) |
+| Linux (AppImage)      | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.AppImage) |
+| Linux (Debian/Ubuntu) | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.deb)      |
+| Linux (Fedora/RHEL)   | [Download](https://github.com/Untrivial-ai/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.rpm)      |
 
 After installing, open Agent Orchestrator and point it at the repository you want AO to manage. The desktop app runs the daemon for you, so no CLI is required. Installed desktop builds check for updates on launch and periodically while the app is running. See the [installation guide](https://aoagents.dev/docs/installation) for agent CLI setup and troubleshooting.
 


### PR DESCRIPTION
Closes #3405.

## What

The rpm target was already configured (`frontend/forge.config.ts` has `@electron-forge/maker-rpm`) and it already builds on the ubuntu leg of `build-artifacts.yml`: the run log for the current workflow shows `Making a rpm distributable for linux/x64` succeeding, because `ubuntu-latest` ships `rpmbuild`. The output was simply never collected, so the release conductor had no `.rpm` to verify or attach and Fedora/RHEL/openSUSE users got no native package.

This wires it through, mirroring exactly what the `.deb` got in #2986:

- `Collect Linux .rpm and compute digest`: copies `out/make/rpm/x64/*.rpm` to `dist-rpm/agent-orchestrator-linux-x64.rpm` and folds its sha256 into the existing `linux-x64.digest.json` fragment, so the `digests` job still reads one fragment per platform.
- `Upload Linux .rpm artifact`: uploads it as the pinned `linux-rpm` artifact name (own directory, so the `linux` artifact's `agent-orchestrator-linux-x64.*` glob cannot swallow it).
- README: adds the `.rpm` row to the download table, and the `.deb` row alongside it (the deb has been a published release asset since #2986 and was never documented).

Artifact name `agent-orchestrator-linux-x64.rpm` follows the existing stable-alias convention (`agent-orchestrator-linux-x64.AppImage`, `agent-orchestrator-linux-x64.deb`), which is what `releases/latest/download/...` links and the conductor's staging step expect.

No `forge.config.ts` change is needed and no signing is involved.

## Conductor follow-up

The private release conductor needs two lines in `_pipeline.yml`'s `Verify and stage build artifacts` step: `mv artifacts/linux-rpm/agent-orchestrator-linux-x64.rpm dist/` and adding the filename to the digest verification loop. Publishing is already automatic (`gh release upload "$TAG" ... dist/*`), and the feed manifests are untouched: the `.rpm` is not an updater target, exactly like the `.deb`. That change is tracked separately in the conductor repo.

## Verification

- Dispatched this workflow on the fork branch; the linux leg produces and uploads `agent-orchestrator-linux-x64.rpm` with its digest in `digests.json`.
- Workflow YAML parses; frontend typecheck + unit tests and backend `go build`/`go test` pass.
- Note: the rpm cannot be built on a macOS dev machine (`maker-rpm` needs `rpmbuild`), which is why the check is a CI dispatch.