### PR TITLE
fix(tmux): unset ambient color env vars and pin pane interpreter to POSIX sh

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -252,10 +252,16 @@ func New(opts Options) *Runtime {
 	if timeout == 0 {
 		timeout = defaultTimeout
 	}
+	// The pane runs `<shell> -c <launchCmd>`, and buildLaunchCommand emits POSIX
+	// shell syntax (`export KEY=value`, `unset KEY`, `cd <dir> || exit`). A
+	// user's $SHELL may be a non-POSIX shell (fish does not support `export
+	// KEY=value` or `unset`), which would make the pane fail to parse the launch
+	// command and exit immediately, killing the tmux session before the
+	// liveness probe. So the pane interpreter is always a POSIX shell; the
+	// user's interactive shell is still honoured for the keep-alive via
+	// `exec "${SHELL:-/bin/sh}" -i` inside the launch command (tmux copies
+	// $SHELL into the session env).
 	shellPath := opts.Shell
-	if shellPath == "" {
-		shellPath = getenv("SHELL")
-	}
 	if shellPath == "" {
 		shellPath = "/bin/sh"
 	}
@@ -986,6 +992,15 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
+// ambientColorSuppressors are variables that make agent TUIs drop color. A
+// daemon started from a coding agent or CI terminal inherits them for that
+// context's captured output, and they must not follow into an interactive
+// session. tmux widens the blast radius: a pane inherits the tmux SERVER's
+// environment, frozen from whatever first started the server, so scrubbing the
+// daemon's own environment is not enough. A project can still opt out of color
+// by setting any of these explicitly in its configured environment.
+var ambientColorSuppressors = []string{"CI", "COLOR", "FORCE_COLOR", "NO_COLOR"}
+
 // buildLaunchCommand builds the shell command string passed to `sh -c`. It
 // exports env vars, then runs argv, then execs a keep-alive interactive shell
 // so the tmux session survives the agent exiting.
@@ -1002,12 +1017,13 @@ func buildLaunchCommand(cfg ports.RuntimeConfig) string {
 	b.WriteString("cd ")
 	b.WriteString(shellQuote(cfg.WorkspacePath))
 	b.WriteString(" || exit; ")
-	if _, configured := cfg.Env["NO_COLOR"]; !configured {
-		// The daemon may be launched from another agent or CI environment that
-		// sets NO_COLOR for its own captured output. Do not leak that ambient
-		// preference into an interactive terminal session. A project can still
-		// opt out of color explicitly through its configured environment.
-		b.WriteString("unset NO_COLOR; ")
+	for _, key := range ambientColorSuppressors {
+		if _, configured := cfg.Env[key]; configured {
+			continue
+		}
+		b.WriteString("unset ")
+		b.WriteString(key)
+		b.WriteString("; ")
 	}
 	for _, key := range sortedKeys(cfg.Env) {
 		if key == "PATH" || key == "COLORTERM" {

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -237,8 +237,10 @@ func stableRunDir() string {
 }
 
 // New builds a tmux Runtime, filling unset Options with defaults: binary "tmux"
-// (resolved via exec.LookPath), shell from $SHELL (else /bin/sh), and the
-// default timeout and output chunk size.
+// (resolved via exec.LookPath), pane interpreter /bin/sh (always POSIX —
+// $SHELL is used only by the keep-alive `exec "${SHELL:-/bin/sh}" -i` so the
+// user's interactive shell is preserved without exposing buildLaunchCommand's
+// export/unset syntax to non-POSIX shells), and the default timeout and chunk size.
 func New(opts Options) *Runtime {
 	binary := opts.Binary
 	if binary == "" {

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -50,7 +50,7 @@ var getenv = os.Getenv
 // New), so the zero value is usable.
 type Options struct {
 	Binary     string        // default "tmux" (resolved via exec.LookPath)
-	Shell      string        // default $SHELL else /bin/sh
+	Shell      string        // POSIX sh for the pane interpreter (the keep-alive exec still uses $SHELL); see New
 	Timeout    time.Duration // default 5s
 	ChunkSize  int           // default 16*1024
 	EnterDelay time.Duration // pause after pasting a non-empty message before pressing Enter; default defaultEnterDelay. Conpty already does this (ptyInputEnterDelay); tmux lacked it, so a large multiline paste could absorb the trailing Enter and leave the prompt unsubmitted (issue #2342).
@@ -992,14 +992,28 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// ambientColorSuppressors are variables that make agent TUIs drop color. A
-// daemon started from a coding agent or CI terminal inherits them for that
-// context's captured output, and they must not follow into an interactive
-// session. tmux widens the blast radius: a pane inherits the tmux SERVER's
+// ambientEnvSuppressors lists environment variables that should not leak from
+// the daemon's launch context into interactive pane sessions. tmux widens the
+// blast radius beyond the daemon process: a pane inherits the tmux SERVER's
 // environment, frozen from whatever first started the server, so scrubbing the
-// daemon's own environment is not enough. A project can still opt out of color
-// by setting any of these explicitly in its configured environment.
-var ambientColorSuppressors = []string{"CI", "COLOR", "FORCE_COLOR", "NO_COLOR"}
+// daemon's own environment is not enough. A project can still opt in to any of
+// these by setting them explicitly in its configured environment.
+//
+// Color-output variables (NO_COLOR, COLOR, FORCE_COLOR): tools respect these to
+// suppress or force colour. Inside a real pty they should not be inherited from
+// a CI/agent context that may have disabled colour for piped output.
+// FORCE_COLOR enables colour (value 1/2/3 = colour depth); only 0 or absence
+// suppresses it. Unsetting it drops the force-on signal — low risk in a pty
+// since COLORTERM=truecolor is exported separately, but the comment above
+// reflects the accurate direction.
+// COLOR is not a NO_COLOR-family standard; it is included defensively for tools
+// that happen to read it.
+//
+// CI: not a colour variable. CI=true changes npm/yarn/pnpm install strictness,
+// Jest/Vitest watch mode, Playwright, Husky, Next.js build output, and most
+// CLI progress bars. An interactive pane should behave as a developer workstation,
+// not a CI runner, so we unset it here. ao itself does not read CI.
+var ambientEnvSuppressors = []string{"CI", "COLOR", "FORCE_COLOR", "NO_COLOR"}
 
 // buildLaunchCommand builds the shell command string passed to `sh -c`. It
 // exports env vars, then runs argv, then execs a keep-alive interactive shell
@@ -1017,7 +1031,7 @@ func buildLaunchCommand(cfg ports.RuntimeConfig) string {
 	b.WriteString("cd ")
 	b.WriteString(shellQuote(cfg.WorkspacePath))
 	b.WriteString(" || exit; ")
-	for _, key := range ambientColorSuppressors {
+	for _, key := range ambientEnvSuppressors {
 		if _, configured := cfg.Env[key]; configured {
 			continue
 		}

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -98,11 +98,16 @@ func TestNewDefaultsToPortableShell(t *testing.T) {
 	}
 }
 
-func TestNewPicksUpShellFromEnv(t *testing.T) {
-	t.Setenv("SHELL", "/bin/zsh")
+func TestNewIgnoresNonPosixShellEnv(t *testing.T) {
+	// The pane interpreter must be POSIX regardless of $SHELL: buildLaunchCommand
+	// emits `export KEY=value` / `unset`, which fish and other non-POSIX shells
+	// reject, killing the pane before the liveness probe. A non-POSIX $SHELL
+	// (fish) must NOT become the pane shell; the user's shell is still honoured
+	// for the keep-alive via `exec "${SHELL:-/bin/sh}" -i` in the launch command.
+	t.Setenv("SHELL", "/opt/homebrew/bin/fish")
 	r := New(Options{})
-	if got := r.shell; got != "/bin/zsh" {
-		t.Fatalf("shell = %q, want /bin/zsh", got)
+	if got := r.shell; got != "/bin/sh" {
+		t.Fatalf("shell = %q, want /bin/sh (POSIX, ignoring non-POSIX $SHELL)", got)
 	}
 }
 
@@ -404,21 +409,42 @@ func TestCreateLaunchCommandExportsEnvVars(t *testing.T) {
 	}
 }
 
-func TestBuildLaunchCommandPreservesExplicitNoColor(t *testing.T) {
+// A daemon launched from a coding agent or CI terminal inherits that context's
+// color-off variables, and a tmux pane inherits them again from the tmux server
+// even when the daemon's own environment is clean. Unsetting only NO_COLOR left
+// CI and COLOR to reach the agent, which rendered its TUI with no color at all.
+func TestBuildLaunchCommandUnsetsAmbientColorSuppressors(t *testing.T) {
 	launchCmd := buildLaunchCommand(ports.RuntimeConfig{
 		WorkspacePath: "/tmp/ws",
 		Argv:          []string{"myagent"},
-		Env:           map[string]string{"NO_COLOR": "1"},
 	})
 
-	if !strings.Contains(launchCmd, "export NO_COLOR='1';") {
-		t.Fatalf("launch command does not preserve configured NO_COLOR: %q", launchCmd)
+	for _, key := range []string{"CI", "COLOR", "FORCE_COLOR", "NO_COLOR"} {
+		if !strings.Contains(launchCmd, "unset "+key+";") {
+			t.Fatalf("launch command does not unset ambient %s: %q", key, launchCmd)
+		}
 	}
-	if strings.Contains(launchCmd, "unset NO_COLOR;") {
-		t.Fatalf("launch command unsets configured NO_COLOR: %q", launchCmd)
-	}
-	if !strings.Contains(launchCmd, "export COLORTERM='truecolor';") {
-		t.Fatalf("launch command does not advertise true color: %q", launchCmd)
+}
+
+func TestBuildLaunchCommandPreservesExplicitColorSuppressors(t *testing.T) {
+	for _, key := range []string{"CI", "COLOR", "FORCE_COLOR", "NO_COLOR"} {
+		t.Run(key, func(t *testing.T) {
+			launchCmd := buildLaunchCommand(ports.RuntimeConfig{
+				WorkspacePath: "/tmp/ws",
+				Argv:          []string{"myagent"},
+				Env:           map[string]string{key: "1"},
+			})
+
+			if !strings.Contains(launchCmd, "export "+key+"='1';") {
+				t.Fatalf("launch command does not preserve configured %s: %q", key, launchCmd)
+			}
+			if strings.Contains(launchCmd, "unset "+key+";") {
+				t.Fatalf("launch command unsets configured %s: %q", key, launchCmd)
+			}
+			if !strings.Contains(launchCmd, "export COLORTERM='truecolor';") {
+				t.Fatalf("launch command does not advertise true color: %q", launchCmd)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

Two focused backend fixes in the tmux adapter — no frontend changes.

**1. Unset ambient color/CI env vars in every pane**

Introduces `ambientColorSuppressors` (`CI`, `COLOR`, `FORCE_COLOR`, `NO_COLOR`). These are unset inside the pane launch command so agent TUIs (Claude, etc.) render colors correctly even when the daemon was started from a CI or coding-agent terminal that had them set. Previously only `NO_COLOR` was cleared.

**2. Pin pane interpreter to POSIX sh**

The `buildLaunchCommand` output uses POSIX syntax (`export`, `unset`, `cd || exit`). If the user's `$SHELL` is fish or nushell that syntax fails to parse and the session exits before the liveness probe fires. The fix pins the interpreter to `/bin/sh`; the user's interactive shell is still used for the keep-alive via `exec "${SHELL:-/bin/sh}" -i` at the end of the launch command.
