### PR TITLE
feat(ui): design token foundation — oklch palette, Geist font, shadcn color aliases

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -18,8 +18,11 @@ sections below — where they conflict, **agent-orchestrator wins**. Do not re-f
   `components/{ProjectSidebar,Dashboard,SessionCard,SessionDetailHeader,SessionInspector,StatusBadge}.tsx`.
 - **Palette (live in `frontend/src/renderer/styles.css` `:root`):** `--bg #0a0b0d`,
   `--bg-1 #15171b`, `--fg #f4f5f7`, `--fg-muted #9ba1aa`, `--fg-passive #646a73`,
-  hairline white-alpha borders, accent `--accent #4d8dff`; status: working=orange
-  `#f59f4c`, needs-you=amber `#e8c14a`, mergeable=green `#74b98a`, fail=red `#ef6b6b`.
+  hairline white-alpha borders, accent `--accent #4d8dff`; status palette updated in
+  PR 3 (token layer): working=blue `#60a5fa` (`--color-status-working`), needs-you=orange
+  `#fb923c` (`--color-status-needs-you`), in-review=yellow `#facc15`
+  (`--color-status-in-review`), ready/mergeable=green `#4ade80` (`--color-status-ready`),
+  fail=red via `--destructive` (`--color-status-exited`).
   The sidebar rail is the cooler `#08090b`.
 - **Cloned surfaces:** the four-column gradient kanban board, the `ProjectSidebar`
   (brand + project disclosure + nested session rows + Settings menu footer), the

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.10.3",
 			"license": "MIT",
 			"dependencies": {
+				"@fontsource-variable/geist": "^5.3.0",
+				"@fontsource-variable/geist-mono": "^5.3.0",
 				"@radix-ui/react-dialog": "^1.1.16",
 				"@radix-ui/react-slot": "^1.2.5",
 				"@radix-ui/react-tabs": "^1.1.14",
@@ -2813,6 +2815,24 @@
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
 			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
 			"license": "MIT"
+		},
+		"node_modules/@fontsource-variable/geist": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.3.0.tgz",
+			"integrity": "sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
+		},
+		"node_modules/@fontsource-variable/geist-mono": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.3.0.tgz",
+			"integrity": "sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
 		},
 		"node_modules/@gar/promisify": {
 			"version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,8 @@
 		"vitest": "^4.1.8"
 	},
 	"dependencies": {
+		"@fontsource-variable/geist": "^5.3.0",
+		"@fontsource-variable/geist-mono": "^5.3.0",
 		"@radix-ui/react-dialog": "^1.1.16",
 		"@radix-ui/react-slot": "^1.2.5",
 		"@radix-ui/react-tabs": "^1.1.14",

--- a/frontend/src/renderer/components/CenterPanelShell.test.tsx
+++ b/frontend/src/renderer/components/CenterPanelShell.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Platform is read at module-load time in CenterPanelShell (top-level const),
+// so we must mock before importing the component.
+const mockIsMac = vi.hoisted(() => vi.fn(() => false));
+vi.mock("../lib/platform", () => ({ isMacPlatform: mockIsMac }));
+
+vi.mock("../hooks/useWindowFullScreen", () => ({ useWindowFullScreen: () => false }));
+vi.mock("../stores/ui-store", () => ({
+	useUiStore: (sel: (s: { isSidebarOpen: boolean }) => unknown) => sel({ isSidebarOpen: true }),
+}));
+
+// Import after mocks are set up.
+const { CenterPanelShell } = await import("./CenterPanelShell");
+
+describe("CenterPanelShell platform classes", () => {
+	it("applies center-panel-shell--mac on macOS", () => {
+		mockIsMac.mockReturnValue(true);
+		const { container } = render(<CenterPanelShell>x</CenterPanelShell>);
+		expect(container.firstElementChild!.classList.contains("center-panel-shell--mac")).toBe(true);
+	});
+
+	it("does not apply center-panel-shell--mac on Linux", () => {
+		mockIsMac.mockReturnValue(false);
+		const { container } = render(<CenterPanelShell>x</CenterPanelShell>);
+		expect(container.firstElementChild!.classList.contains("center-panel-shell--mac")).toBe(false);
+	});
+
+	it("does not apply center-panel-shell--mac on Windows", () => {
+		mockIsMac.mockReturnValue(false);
+		const { container } = render(<CenterPanelShell>x</CenterPanelShell>);
+		expect(container.firstElementChild!.classList.contains("center-panel-shell--mac")).toBe(false);
+	});
+});

--- a/frontend/src/renderer/components/CenterPanelShell.tsx
+++ b/frontend/src/renderer/components/CenterPanelShell.tsx
@@ -4,8 +4,6 @@ import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { isMacPlatform } from "../lib/platform";
 import { useUiStore } from "../stores/ui-store";
 
-const isMac = isMacPlatform();
-
 /**
  * Shared inset center panel: sidebar-colored outer frame with a bordered inner
  * surface. Used by the shell's app routes (kanban / session), the welcome board,
@@ -28,7 +26,7 @@ export function CenterPanelShell({
 }) {
 	const isSidebarOpen = useUiStore((state) => state.isSidebarOpen);
 	const isFullScreen = useWindowFullScreen();
-	const align = titlebarAlign && isMac;
+	const align = titlebarAlign && isMacPlatform();
 	const titlebarClearance = align && !isSidebarOpen;
 
 	return (

--- a/frontend/src/renderer/components/CenterPanelShell.tsx
+++ b/frontend/src/renderer/components/CenterPanelShell.tsx
@@ -1,11 +1,10 @@
 import type { ReactNode } from "react";
 import { cn } from "../lib/utils";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
-import { isLinuxPlatform, isMacPlatform } from "../lib/platform";
+import { isMacPlatform } from "../lib/platform";
 import { useUiStore } from "../stores/ui-store";
 
 const isMac = isMacPlatform();
-const isLinux = isLinuxPlatform();
 
 /**
  * Shared inset center panel: sidebar-colored outer frame with a bordered inner
@@ -14,7 +13,7 @@ const isLinux = isLinuxPlatform();
  * `center-panel-surface`).
  *
  * `titlebarAlign` (default true) pulls Board/Terminal titles up level with the
- * fixed TitlebarNav cluster (macOS + Linux).
+ * fixed TitlebarNav cluster (macOS only — Win/Linux use the ShellTopbar instead).
  */
 export function CenterPanelShell({
 	className,
@@ -29,7 +28,7 @@ export function CenterPanelShell({
 }) {
 	const isSidebarOpen = useUiStore((state) => state.isSidebarOpen);
 	const isFullScreen = useWindowFullScreen();
-	const align = titlebarAlign && (isMac || isLinux);
+	const align = titlebarAlign && isMac;
 	const titlebarClearance = align && !isSidebarOpen;
 
 	return (
@@ -37,9 +36,6 @@ export function CenterPanelShell({
 			className={cn(
 				"center-panel-shell",
 				align && "center-panel-shell--mac",
-				// Linux has no traffic lights, so the sidebar-closed title clears the
-				// cluster at its own left edge rather than the macOS offset.
-				isLinux && "center-panel-shell--linux",
 				titlebarClearance && "center-panel-shell--titlebar-clearance",
 				titlebarClearance && isFullScreen && "center-panel-shell--titlebar-clearance-fullscreen",
 				align && isFullScreen && "center-panel-shell--fullscreen",

--- a/frontend/src/renderer/components/ui/badge.tsx
+++ b/frontend/src/renderer/components/ui/badge.tsx
@@ -1,3 +1,4 @@
+// Mono pill badges. Color is rare and meaningful (DESIGN.md → Color).
 import * as React from "react";
 import { cn } from "../../lib/utils";
 

--- a/frontend/src/renderer/components/ui/badge.tsx
+++ b/frontend/src/renderer/components/ui/badge.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-// Mono pill badges. Color is rare and meaningful (DESIGN.md → Color).
 type BadgeVariant = "neutral" | "outline" | "accent" | "success" | "warning" | "error";
 
 export function Badge({
@@ -11,14 +10,15 @@ export function Badge({
 }: React.HTMLAttributes<HTMLSpanElement> & { variant?: BadgeVariant }) {
 	return (
 		<span
+			data-slot="badge"
 			className={cn(
-				"inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full border border-transparent px-2 font-mono text-micro font-medium",
-				variant === "neutral" && "bg-raised text-muted-foreground",
-				variant === "outline" && "border-border text-foreground",
-				variant === "accent" && "border-accent-dim text-accent",
+				"inline-flex h-5 shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-full border border-transparent px-2 py-0.5 text-xs font-medium transition-[background-color,border-color,color,box-shadow] focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 [&>svg]:pointer-events-none [&>svg]:size-3",
+				variant === "neutral" && "bg-secondary text-secondary-foreground",
+				variant === "outline" && "border-border text-foreground hover:bg-muted",
+				variant === "accent" && "bg-primary text-primary-foreground",
 				variant === "success" && "border-success/40 text-success",
 				variant === "warning" && "border-warning/40 text-warning",
-				variant === "error" && "border-error/40 text-error",
+				variant === "error" && "bg-destructive/10 text-destructive",
 				className,
 			)}
 			{...props}

--- a/frontend/src/renderer/components/ui/button.tsx
+++ b/frontend/src/renderer/components/ui/button.tsx
@@ -3,8 +3,10 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
+// Buttons are font-normal (400) with 6px radius; blue is the live edge
+// (primary). See DESIGN.md → Spacing / Color.
 const buttonVariants = cva(
-	"group/button inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent bg-clip-padding text-sm font-medium transition-[background-color,border-color,color,box-shadow,transform] duration-[100ms] ease-out outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 active:not-aria-[haspopup]:scale-[0.97] active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+	"group/button inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent bg-clip-padding text-sm font-normal transition-[background-color,border-color,color,box-shadow,transform] duration-[100ms] ease-out outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 active:not-aria-[haspopup]:scale-[0.97] active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {
@@ -16,10 +18,10 @@ const buttonVariants = cva(
 				ghost: "text-foreground hover:bg-muted dark:hover:bg-muted/50",
 			},
 			size: {
-				default: "h-9 px-3",
-				sm: "h-8 px-3",
-				icon: "size-9",
-				"icon-sm": "size-8",
+				default: "h-control-form px-3",
+				sm: "h-control-md px-2.5 text-xs",
+				icon: "size-control-form",
+				"icon-sm": "size-control-md",
 			},
 		},
 		defaultVariants: {

--- a/frontend/src/renderer/components/ui/button.tsx
+++ b/frontend/src/renderer/components/ui/button.tsx
@@ -3,23 +3,23 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
-// Buttons are font-normal (400) with 6px radius; blue is the live edge
-// (primary). See DESIGN.md → Spacing / Color.
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-control font-normal transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-45",
+	"group/button inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent bg-clip-padding text-sm font-medium transition-[background-color,border-color,color,box-shadow,transform] duration-[100ms] ease-out outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 active:not-aria-[haspopup]:scale-[0.97] active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {
-				primary: "border border-primary bg-primary text-primary-foreground hover:opacity-90",
-				outline: "border border-border bg-background text-foreground hover:bg-surface",
-				secondary: "bg-raised text-muted-foreground hover:text-foreground",
-				ghost: "text-muted-foreground hover:bg-surface hover:text-foreground",
+				primary: "bg-primary text-primary-foreground hover:bg-primary/80",
+				outline:
+					"border-border bg-background text-foreground hover:bg-muted aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-transparent dark:hover:bg-input/30",
+				secondary:
+					"bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]",
+				ghost: "text-foreground hover:bg-muted dark:hover:bg-muted/50",
 			},
 			size: {
-				default: "h-control-form px-3",
-				sm: "h-control-md px-2.5 text-xs",
-				icon: "size-control-form",
-				"icon-sm": "size-control-md",
+				default: "h-9 px-3",
+				sm: "h-8 px-3",
+				icon: "size-9",
+				"icon-sm": "size-8",
 			},
 		},
 		defaultVariants: {

--- a/frontend/src/renderer/components/ui/card.tsx
+++ b/frontend/src/renderer/components/ui/card.tsx
@@ -2,12 +2,17 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function Card({ className, ...props }: React.ComponentProps<"div">) {
+function Card({
+	className,
+	size = "default",
+	...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
 	return (
 		<div
 			data-slot="card"
+			data-size={size}
 			className={cn(
-				"flex flex-col gap-6 rounded-xl border border-border bg-card py-6 text-card-foreground shadow-sm",
+				"group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-lg bg-card py-(--card-spacing) text-sm text-card-foreground shadow-md ring-1 ring-foreground/5 [--card-spacing:--spacing(6)] data-[size=sm]:[--card-spacing:--spacing(4)] dark:ring-foreground/10",
 				className,
 			)}
 			{...props}
@@ -20,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
 		<div
 			data-slot="card-header"
 			className={cn(
-				"@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+				"@container/card-header grid auto-rows-min items-start gap-1.5 rounded-t-lg px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
 				className,
 			)}
 			{...props}
@@ -29,7 +34,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
-	return <div data-slot="card-title" className={cn("leading-none font-semibold", className)} {...props} />;
+	return <div data-slot="card-title" className={cn("font-heading text-base font-medium", className)} {...props} />;
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -47,12 +52,16 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-	return <div data-slot="card-content" className={cn("px-6", className)} {...props} />;
+	return <div data-slot="card-content" className={cn("px-(--card-spacing)", className)} {...props} />;
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
 	return (
-		<div data-slot="card-footer" className={cn("flex items-center px-6 [.border-t]:pt-6", className)} {...props} />
+		<div
+			data-slot="card-footer"
+			className={cn("flex items-center rounded-b-lg px-(--card-spacing) [.border-t]:pt-(--card-spacing)", className)}
+			{...props}
+		/>
 	);
 }
 

--- a/frontend/src/renderer/components/ui/command.tsx
+++ b/frontend/src/renderer/components/ui/command.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { Command as CommandPrimitive } from "cmdk";
 import * as Dialog from "@radix-ui/react-dialog";
+import { Search } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -69,13 +70,14 @@ function CommandInput({ className, ...props }: React.ComponentProps<typeof Comma
 	return (
 		<div
 			data-slot="command-input-wrapper"
-			className="flex items-center border-b border-[var(--color-border-command-palette)] px-[var(--size-command-pad-x)] pt-5 pb-4"
+			className="flex items-center gap-2.5 border-b border-[var(--color-border-command-palette)] px-[var(--size-command-pad-x)] py-3"
 			cmdk-input-wrapper=""
 		>
+			<Search className="size-4 shrink-0 text-[var(--color-text-command-placeholder)]" aria-hidden="true" />
 			<CommandPrimitive.Input
 				data-slot="command-input"
 				className={cn(
-					"flex h-7 w-full bg-transparent text-[length:var(--font-size-command-input)] leading-7 text-[var(--color-text-command-item)] caret-[var(--color-text-command-item)] outline-none placeholder:text-[var(--color-text-command-placeholder)] disabled:cursor-not-allowed disabled:opacity-50",
+					"flex h-6 w-full bg-transparent text-[length:var(--font-size-command-input)] leading-6 text-[var(--color-text-command-item)] caret-[var(--color-text-command-item)] outline-none placeholder:text-[var(--color-text-command-placeholder)] disabled:cursor-not-allowed disabled:opacity-50",
 					className,
 				)}
 				{...props}

--- a/frontend/src/renderer/components/ui/dialog.tsx
+++ b/frontend/src/renderer/components/ui/dialog.tsx
@@ -27,7 +27,7 @@ function DialogOverlay({ className, ...props }: React.ComponentProps<typeof Dial
 		<DialogPrimitive.Overlay
 			data-slot="dialog-overlay"
 			className={cn(
-				"dialog-overlay data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+				"dialog-overlay data-[state=open]:animate-overlay-in data-[state=closed]:animate-overlay-out",
 				className,
 			)}
 			{...props}
@@ -49,7 +49,7 @@ function DialogContent({
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				className={cn(
-					"fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] border p-4 sm:rounded-lg",
+					"fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] flex flex-col gap-4 bg-background shadow-lg data-[state=open]:animate-modal-in data-[state=closed]:animate-modal-out motion-reduce:animate-none border p-4 sm:rounded-lg",
 					className,
 				)}
 				{...props}

--- a/frontend/src/renderer/components/ui/dropdown-menu.tsx
+++ b/frontend/src/renderer/components/ui/dropdown-menu.tsx
@@ -16,8 +16,11 @@ export function DropdownMenuContent({
 			<DropdownMenuPrimitive.Content
 				sideOffset={sideOffset}
 				className={cn(
-					"z-overlay min-w-[10rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md",
-					"data-[state=open]:animate-overlay-in",
+					"z-overlay min-w-[10rem] overflow-hidden rounded-lg border border-border bg-card p-[3px] text-popover-foreground",
+					"flex flex-col gap-px",
+					"shadow-[0_8px_32px_rgba(0,0,0,0.28),0_2px_8px_rgba(0,0,0,0.18)]",
+					"origin-(--radix-dropdown-menu-content-transform-origin)",
+					"data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out",
 					className,
 				)}
 				{...props}
@@ -35,7 +38,7 @@ export function DropdownMenuItem({
 		<DropdownMenuPrimitive.Item
 			className={cn(
 				"relative flex cursor-default select-none items-center gap-2.5 rounded-md px-2 py-1.5 text-control outline-none transition-colors",
-				"text-muted-foreground focus:bg-surface focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+				"text-muted-foreground focus:bg-interactive-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 				"[&_svg]:size-icon-lg [&_svg]:shrink-0 [&_svg]:text-passive",
 				inset && "pl-8",
 				className,
@@ -53,7 +56,7 @@ export function DropdownMenuLabel({
 	return (
 		<DropdownMenuPrimitive.Label
 			className={cn(
-				"px-2 py-1.5 font-mono text-micro uppercase tracking-wide-xl text-passive",
+				"px-2 py-1.5 text-micro tracking-wide text-passive",
 				inset && "pl-8",
 				className,
 			)}
@@ -70,5 +73,5 @@ export function DropdownMenuSeparator({
 }
 
 export function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
-	return <span className={cn("ml-auto font-mono text-micro tracking-wide-md text-passive", className)} {...props} />;
+	return <span className={cn("ml-auto text-micro tracking-wide-md text-passive", className)} {...props} />;
 }

--- a/frontend/src/renderer/components/ui/dropdown-menu.tsx
+++ b/frontend/src/renderer/components/ui/dropdown-menu.tsx
@@ -16,9 +16,9 @@ export function DropdownMenuContent({
 			<DropdownMenuPrimitive.Content
 				sideOffset={sideOffset}
 				className={cn(
-					"z-overlay min-w-[10rem] overflow-hidden rounded-lg border border-border bg-card p-[3px] text-popover-foreground",
+					"z-overlay min-w-[10rem] overflow-hidden rounded-lg border border-border bg-card p-1 text-popover-foreground",
 					"flex flex-col gap-px",
-					"shadow-[0_8px_32px_rgba(0,0,0,0.28),0_2px_8px_rgba(0,0,0,0.18)]",
+					"shadow-(--shadow-popover)",
 					"origin-(--radix-dropdown-menu-content-transform-origin)",
 					"data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out",
 					className,

--- a/frontend/src/renderer/components/ui/input.tsx
+++ b/frontend/src/renderer/components/ui/input.tsx
@@ -4,8 +4,9 @@ import { cn } from "../../lib/utils";
 export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
 	({ className, type = "text", ...props }, ref) => (
 		<input
+			data-slot="input"
 			className={cn(
-				"flex h-control-form w-full rounded-md border border-border bg-transparent px-3 text-control text-foreground transition-colors placeholder:text-passive focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-weak disabled:cursor-not-allowed disabled:opacity-50",
+				"h-control-form w-full min-w-0 rounded-md border border-transparent bg-input/50 px-3 py-1 text-sm text-foreground transition-[color,box-shadow,background-color] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
 				className,
 			)}
 			ref={ref}

--- a/frontend/src/renderer/components/ui/popover.tsx
+++ b/frontend/src/renderer/components/ui/popover.tsx
@@ -14,7 +14,7 @@ export function PopoverContent({
 			<PopoverPrimitive.Content
 				className={cn(
 					"z-overlay rounded-lg border border-border bg-popover text-popover-foreground outline-none",
-					"shadow-[0_8px_32px_rgba(0,0,0,0.28),0_2px_8px_rgba(0,0,0,0.18)]",
+					"shadow-(--shadow-popover)",
 					"origin-(--radix-popover-content-transform-origin)",
 					"data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out",
 					className,

--- a/frontend/src/renderer/components/ui/popover.tsx
+++ b/frontend/src/renderer/components/ui/popover.tsx
@@ -13,7 +13,7 @@ export function PopoverContent({
 		<PopoverPrimitive.Portal>
 			<PopoverPrimitive.Content
 				className={cn(
-					"z-overlay rounded-lg border border-border bg-card text-popover-foreground outline-none",
+					"z-overlay rounded-lg border border-border bg-popover text-popover-foreground outline-none",
 					"shadow-[0_8px_32px_rgba(0,0,0,0.28),0_2px_8px_rgba(0,0,0,0.18)]",
 					"origin-(--radix-popover-content-transform-origin)",
 					"data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out",

--- a/frontend/src/renderer/components/ui/popover.tsx
+++ b/frontend/src/renderer/components/ui/popover.tsx
@@ -13,8 +13,10 @@ export function PopoverContent({
 		<PopoverPrimitive.Portal>
 			<PopoverPrimitive.Content
 				className={cn(
-					"z-overlay rounded-lg border border-border bg-popover text-popover-foreground shadow-md outline-none",
-					"data-[state=open]:animate-overlay-in",
+					"z-overlay rounded-lg border border-border bg-card text-popover-foreground outline-none",
+					"shadow-[0_8px_32px_rgba(0,0,0,0.28),0_2px_8px_rgba(0,0,0,0.18)]",
+					"origin-(--radix-popover-content-transform-origin)",
+					"data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out",
 					className,
 				)}
 				sideOffset={sideOffset}

--- a/frontend/src/renderer/components/ui/select.tsx
+++ b/frontend/src/renderer/components/ui/select.tsx
@@ -55,7 +55,7 @@ function SelectContent({
 				data-slot="select-content"
 		className={cn(
 				"relative z-overlay max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-border bg-card text-popover-foreground outline-none",
-				"shadow-[0_8px_32px_rgba(0,0,0,0.28),0_2px_8px_rgba(0,0,0,0.18)]",
+				"shadow-(--shadow-popover)",
 				"data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out",
 					position === "popper" &&
 						"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
@@ -67,7 +67,7 @@ function SelectContent({
 			>
 				<SelectScrollUpButton />
 		<SelectPrimitive.Viewport
-				className={cn("p-[3px]", position === "popper" && "w-full min-w-(--radix-select-trigger-width) scroll-my-1")}
+				className={cn("p-1", position === "popper" && "w-full min-w-(--radix-select-trigger-width) scroll-my-1")}
 			>
 					{children}
 				</SelectPrimitive.Viewport>

--- a/frontend/src/renderer/components/ui/select.tsx
+++ b/frontend/src/renderer/components/ui/select.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
@@ -29,7 +29,7 @@ function SelectTrigger({
 			data-slot="select-trigger"
 			data-size={size}
 			className={cn(
-				"flex w-fit items-center justify-between gap-2 rounded-md border border-border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-border-strong focus-visible:ring-focus focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-control-board data-[size=sm]:h-control-form *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-icon-base [&_svg:not([class*='text-'])]:text-muted-foreground",
+				"flex w-fit items-center justify-between gap-2 rounded-md border border-transparent bg-input/50 px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow,background-color,border-color] outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive data-[placeholder]:text-muted-foreground data-[size=default]:h-control-board data-[size=sm]:h-control-form *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-icon-base [&_svg:not([class*='text-'])]:text-muted-foreground",
 				className,
 			)}
 			{...props}
@@ -53,8 +53,10 @@ function SelectContent({
 		<SelectPrimitive.Portal>
 			<SelectPrimitive.Content
 				data-slot="select-content"
-				className={cn(
-					"relative z-overlay max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover text-popover-foreground shadow-md outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+		className={cn(
+				"relative z-overlay max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-border bg-card text-popover-foreground outline-none",
+				"shadow-[0_8px_32px_rgba(0,0,0,0.28),0_2px_8px_rgba(0,0,0,0.18)]",
+				"data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out",
 					position === "popper" &&
 						"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
 					className,
@@ -64,9 +66,9 @@ function SelectContent({
 				{...props}
 			>
 				<SelectScrollUpButton />
-				<SelectPrimitive.Viewport
-					className={cn("p-1", position === "popper" && "w-full min-w-(--radix-select-trigger-width) scroll-my-1")}
-				>
+		<SelectPrimitive.Viewport
+				className={cn("p-[3px]", position === "popper" && "w-full min-w-(--radix-select-trigger-width) scroll-my-1")}
+			>
 					{children}
 				</SelectPrimitive.Viewport>
 				<SelectScrollDownButton />
@@ -90,16 +92,13 @@ function SelectItem({ className, children, ...props }: React.ComponentProps<type
 		<SelectPrimitive.Item
 			data-slot="select-item"
 			className={cn(
-				"relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-icon-base [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				"relative flex w-full cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground outline-none transition-colors",
+				"focus:bg-interactive-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+				"[&_svg]:pointer-events-none [&_svg]:shrink-0",
 				className,
 			)}
 			{...props}
 		>
-			<span data-slot="select-item-indicator" className="absolute right-2 flex size-3.5 items-center justify-center">
-				<SelectPrimitive.ItemIndicator>
-					<CheckIcon className="size-icon-base" />
-				</SelectPrimitive.ItemIndicator>
-			</span>
 			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
 		</SelectPrimitive.Item>
 	);

--- a/frontend/src/renderer/components/ui/sheet.tsx
+++ b/frontend/src/renderer/components/ui/sheet.tsx
@@ -51,7 +51,7 @@ function SheetContent({
 			<SheetPrimitive.Content
 				data-slot="sheet-content"
 				className={cn(
-					"fixed z-overlay flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+					"fixed z-overlay flex flex-col gap-4 bg-background shadow-lg transition data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:animate-in data-[state=open]:duration-280",
 					side === "right" &&
 						"inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
 					side === "left" &&

--- a/frontend/src/renderer/components/ui/switch.tsx
+++ b/frontend/src/renderer/components/ui/switch.tsx
@@ -10,7 +10,7 @@ function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimi
 		<SwitchPrimitive.Root
 			data-slot="switch"
 			className={cn(
-				"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-border-strong",
+				"peer relative inline-flex h-5 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-[background-color,border-color,box-shadow] outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=unchecked]:bg-input/90",
 				className,
 			)}
 			{...props}
@@ -18,7 +18,7 @@ function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimi
 			<SwitchPrimitive.Thumb
 				data-slot="switch-thumb"
 				className={cn(
-					"pointer-events-none block h-4 w-4 rounded-full bg-primary-foreground shadow ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0.5",
+					"pointer-events-none block h-4 w-6 rounded-full bg-background shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-8px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
 				)}
 			/>
 		</SwitchPrimitive.Root>

--- a/frontend/src/renderer/components/ui/tabs.tsx
+++ b/frontend/src/renderer/components/ui/tabs.tsx
@@ -6,7 +6,10 @@ export const Tabs = TabsPrimitive.Root;
 export function TabsList({ className, ...props }: React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>) {
 	return (
 		<TabsPrimitive.List
-			className={cn("inline-flex h-control-form items-center justify-center gap-1 rounded-md bg-raised p-1", className)}
+			className={cn(
+				"inline-flex h-9 w-fit items-center justify-center gap-1 rounded-full bg-muted p-1 text-muted-foreground",
+				className,
+			)}
 			{...props}
 		/>
 	);
@@ -16,7 +19,7 @@ export function TabsTrigger({ className, ...props }: React.ComponentPropsWithout
 	return (
 		<TabsPrimitive.Trigger
 			className={cn(
-				"inline-flex h-6 items-center justify-center whitespace-nowrap rounded px-2.5 text-xs font-normal text-muted-foreground transition-colors data-[state=active]:bg-background data-[state=active]:text-foreground",
+				"inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-2 whitespace-nowrap rounded-full border border-transparent px-3 py-1 text-sm font-medium text-foreground/60 transition-[background-color,border-color,color,box-shadow] hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground dark:text-muted-foreground dark:hover:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
 				className,
 			)}
 			{...props}
@@ -25,5 +28,5 @@ export function TabsTrigger({ className, ...props }: React.ComponentPropsWithout
 }
 
 export function TabsContent({ className, ...props }: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>) {
-	return <TabsPrimitive.Content className={cn("focus-visible:outline-none", className)} {...props} />;
+	return <TabsPrimitive.Content className={cn("flex-1 text-sm outline-none", className)} {...props} />;
 }

--- a/frontend/src/renderer/components/ui/tooltip.tsx
+++ b/frontend/src/renderer/components/ui/tooltip.tsx
@@ -15,6 +15,7 @@ export function TooltipContent({
 			<TooltipPrimitive.Content
 				className={cn(
 					"z-overlay rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md",
+					"data-[state=delayed-open]:animate-popover-in data-[state=instant-open]:animate-popover-in data-[state=closed]:animate-popover-out",
 					className,
 				)}
 				sideOffset={sideOffset}

--- a/frontend/src/renderer/lib/platform.test.ts
+++ b/frontend/src/renderer/lib/platform.test.ts
@@ -62,13 +62,13 @@ describe("renderer platform behavior", () => {
 		expect(usesBoardActionsInPanel()).toBe(false);
 	});
 
-	it("hides the shell topbar on Linux and keeps board actions in the panel", () => {
+	it("shows the shell topbar on Linux (same as Windows, not macOS)", () => {
 		spoofPlatform("Linux x86_64");
 
 		expect(isLinuxPlatform()).toBe(true);
 		expect(isWindowsPlatform()).toBe(false);
 		expect(usesFramedAppTopbar()).toBe(true);
-		expect(hidesShellTopbar()).toBe(true);
-		expect(usesBoardActionsInPanel()).toBe(true);
+		expect(hidesShellTopbar()).toBe(false);
+		expect(usesBoardActionsInPanel()).toBe(false);
 	});
 });

--- a/frontend/src/renderer/lib/platform.ts
+++ b/frontend/src/renderer/lib/platform.ts
@@ -36,6 +36,11 @@ export function usesFramedAppTopbar(): boolean {
  * board/session actions mount in-panel, with a traffic-light drag strip for
  * window movement. Win/Linux keep the ShellTopbar spanning the window, with the
  * sidebar hanging below it — two different ways of creating the top gap.
+ *
+ * Note: Linux previously returned true here (taking the macOS path), which was
+ * a bug — it left Linux with no ShellTopbar and a 6px mac inset that masked
+ * y=0 panel content. The DESIGN.md 2026-06-12 divergence doc always specified
+ * Win/Linux as the ShellTopbar path. Fixed in PR #3421.
  */
 export function hidesShellTopbar(): boolean {
 	return isMacPlatform();
@@ -44,6 +49,9 @@ export function hidesShellTopbar(): boolean {
 /**
  * Board New task / Orchestrator / bell render in the board body instead of the
  * framed shell topbar (macOS only). Win/Linux keep those controls in the topbar.
+ *
+ * This flipped for Linux as part of fixing hidesShellTopbar() — board actions
+ * now live in the visible ShellTopbar on Linux, matching Windows behavior.
  */
 export function usesBoardActionsInPanel(): boolean {
 	return hidesShellTopbar();

--- a/frontend/src/renderer/lib/platform.ts
+++ b/frontend/src/renderer/lib/platform.ts
@@ -31,19 +31,19 @@ export function usesFramedAppTopbar(): boolean {
 }
 
 /**
- * macOS + Linux: shell does not mount ShellTopbar (full-height inset panel).
+ * macOS only: shell does not mount ShellTopbar (full-height inset panel).
  * The sidebar toggle + history arrows live in the fixed TitlebarNav cluster and
- * board/session actions mount in-panel, so both platforms share the framed
- * chrome. (macOS additionally paints a traffic-light drag strip.) Windows keeps
- * the ShellTopbar under its custom titlebar.
+ * board/session actions mount in-panel, with a traffic-light drag strip for
+ * window movement. Win/Linux keep the ShellTopbar spanning the window, with the
+ * sidebar hanging below it — two different ways of creating the top gap.
  */
 export function hidesShellTopbar(): boolean {
-	return isMacPlatform() || isLinuxPlatform();
+	return isMacPlatform();
 }
 
 /**
  * Board New task / Orchestrator / bell render in the board body instead of the
- * framed shell topbar (macOS). Win/Linux keep those controls in the topbar.
+ * framed shell topbar (macOS only). Win/Linux keep those controls in the topbar.
  */
 export function usesBoardActionsInPanel(): boolean {
 	return hidesShellTopbar();

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -612,7 +612,7 @@ function ShellLayout() {
 			{/* Shell chrome: Win/Linux hang the sidebar under a topbar. macOS uses a
           titlebar strip above the off-canvas sidebar. Session and board actions
           render inside the center panel when the shell topbar is hidden. */}
-			<div className={cn("flex h-screen min-h-0 flex-col bg-sidebar text-foreground", isWindows && "platform-windows")}>
+			<div className={cn("flex h-screen min-h-0 flex-col bg-sidebar text-foreground", isWindows && "platform-windows", isLinux && "platform-linux")}>
 				{/* Windows-only custom title bar (sidebar toggle + File/Edit/View/…
             menu); paints the chrome the frameless window drops. Renders null on
             macOS/Linux. */}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -222,7 +222,7 @@
 	--color-primary: var(--primary);
 	--color-primary-foreground: var(--primary-foreground);
 	--color-accent: var(--accent);
-	--color-accent-foreground: var(--accent-foreground);
+	--color-accent-foreground: var(--primary-foreground);
 	--color-accent-weak: var(--bridge-accent-weak);
 	--color-accent-dim: var(--bridge-accent-dim);
 	--color-accent-strong: var(--bridge-accent-strong);

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -466,11 +466,6 @@
 	padding-left: calc(var(--size-titlebar-content-offset) - var(--size-center-panel-inset-mac));
 }
 
-/* Linux clears the cluster from its own left edge (no traffic-light row). */
-.center-panel-shell--linux.center-panel-shell--titlebar-clearance .center-panel-titlebar {
-	padding-left: calc(var(--size-titlebar-content-offset-linux) - var(--size-center-panel-inset-mac));
-}
-
 /* Fullscreen: the shell is flush, so measure from the cluster's own left edge. */
 .center-panel-shell--titlebar-clearance-fullscreen .center-panel-titlebar {
 	padding-left: calc(
@@ -1162,7 +1157,7 @@ body.is-resizing-x [data-slot="sidebar-container"] {
  * stops at the header instead of crossing the traffic-light strip. */
 .dashboard-app-header {
 	display: flex;
-	height: 56px;
+	height: var(--size-shell-topbar);
 	flex-shrink: 0;
 	align-items: center;
 	gap: 13px;
@@ -2313,7 +2308,7 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 }
 
 .platform-linux .browser-popout-overlay {
-	top: var(--size-toolbar);
+	top: var(--size-shell-topbar);
 }
 
 .browser-popout-overlay .browser-panel {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -391,6 +391,8 @@
 	padding-right: var(--size-center-panel-inline-inset);
 	padding-bottom: var(--size-center-panel-bottom-inset);
 	padding-left: 0;
+	/* Match the sidebar spring settle time (~280ms). */
+	transition: padding 280ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 @utility center-panel-surface {
@@ -402,6 +404,9 @@
 	border-radius: var(--radius-center-panel);
 	border: 1px solid var(--color-border-strong);
 	background-color: var(--color-bg-primary);
+	transition:
+		border-color 280ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+		border-radius 280ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 /* A fully hidden sidebar no longer contributes a left layout gutter. Restore
@@ -410,15 +415,27 @@
 	padding-left: var(--size-center-panel-inline-inset);
 }
 
-/* macOS + Linux: one uniform inset on every side (matches the near-flush top
- * that keeps Board/Terminal titles level with the fixed TitlebarNav). Two
- * classes so it also wins over the `.sidebar-hidden` left gutter above. */
+/* macOS + Linux: inset on all sides except left (flush with sidebar). */
 .center-panel-shell.center-panel-shell--mac {
-	padding: var(--size-center-panel-inset-mac);
+	padding-top: var(--size-center-panel-inset-mac);
+	padding-right: var(--size-center-panel-inset-mac);
+	padding-bottom: var(--size-center-panel-inset-mac);
+	padding-left: 0;
 }
 
 .center-panel-shell.center-panel-shell--mac.center-panel-shell--fullscreen {
 	padding: 0;
+}
+
+/* Sidebar closed on mac: content panel expands to fill the full window.
+ * Remove all padding and strip the surface border + radius so it's flush. */
+.sidebar-hidden .center-panel-shell.center-panel-shell--mac {
+	padding: 0;
+}
+
+.sidebar-hidden .center-panel-shell--mac .center-panel-surface {
+	border-color: transparent;
+	border-radius: 0;
 }
 
 .center-panel-titlebar {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -478,9 +478,11 @@
 	);
 }
 
-/* Windows: the frameless window's custom titlebar already supplies top chrome,
- * so drop the framed panel's top inset to give content more height. */
-.platform-windows .center-panel-shell {
+/* Windows / Linux: a ShellTopbar already supplies the top chrome, so the
+ * framed panel needs no additional top inset. Windows uses its custom
+ * frameless titlebar; Linux uses the standard ShellTopbar. */
+.platform-windows .center-panel-shell,
+.platform-linux .center-panel-shell {
 	padding-top: 0;
 }
 
@@ -2299,14 +2301,19 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 /* Maximized browser overlay: a fixed layer over the app workspace (portaled to
    <body>, so it covers the sidebar + topbar too, not just the session area).
    Electron's Window Controls Overlay owns the top-right titlebar region on
-   Windows, so start below its reported safe-area height. Platforms without a
-   titleBarOverlay resolve the env() fallback to 0px and keep the existing
-   edge-to-edge layout. */
+   Windows, so start below its reported safe-area height. macOS hides the shell
+   topbar, so 0px is correct there. Linux now shows a ShellTopbar, so the overlay
+   must start below --size-toolbar; env(titlebar-area-height) resolves to 0 on
+   Linux (no titleBarOverlay), so we override the top with a platform class. */
 .browser-popout-overlay {
 	position: fixed;
 	inset: env(titlebar-area-height, 0px) 0 0;
 	z-index: 40;
 	background: color-mix(in srgb, var(--bg) 94%, black);
+}
+
+.platform-linux .browser-popout-overlay {
+	top: var(--size-toolbar);
 }
 
 .browser-popout-overlay .browser-panel {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 @import "../styles/tokens.css";
+@import "@fontsource-variable/geist";
+@import "@fontsource-variable/geist-mono";
+
+@custom-variant dark (&:is(.dark *, :root:not([data-theme="light"]) *));
 
 @custom-media --layout-narrow (width <= 680px); /* --breakpoint-layout-narrow */
 
@@ -95,11 +99,13 @@
 	--color-popover-foreground: var(--color-text-primary);
 	--color-input: var(--bridge-border);
 	--color-sidebar: var(--color-bg-sidebar);
-	--color-sidebar-foreground: var(--color-text-muted);
-	--color-sidebar-accent: var(--color-bg-tertiary);
-	--color-sidebar-accent-foreground: var(--color-text-primary);
-	--color-sidebar-border: var(--bridge-border);
-	--color-sidebar-ring: var(--bridge-accent);
+	--color-sidebar-foreground: var(--sidebar-foreground);
+	--color-sidebar-primary: var(--sidebar-primary);
+	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+	--color-sidebar-accent: var(--sidebar-accent);
+	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+	--color-sidebar-border: var(--sidebar-border);
+	--color-sidebar-ring: var(--sidebar-ring);
 	--color-terminal: var(--color-bg-terminal);
 	--color-terminal-dim: var(--color-text-terminal-dim);
 	--color-scrim: var(--bridge-scrim);
@@ -207,22 +213,23 @@
 	--spacing-kv-label: var(--size-kv-label);
 	--spacing-branch-chip: var(--size-branch-chip);
 
-	--color-muted: var(--color-bg-tertiary);
-	--color-muted-foreground: var(--color-text-muted);
+	--color-muted: var(--muted);
+	--color-muted-foreground: var(--muted-foreground);
 	--color-passive: var(--color-text-passive);
-	--color-secondary: var(--color-bg-tertiary);
+	--color-secondary: var(--secondary);
+	--color-secondary-foreground: var(--secondary-foreground);
 
-	--color-primary: var(--bridge-accent);
-	--color-primary-foreground: var(--bridge-accent-fg);
-	--color-accent: var(--bridge-accent);
-	--color-accent-foreground: var(--bridge-accent-fg);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-accent: var(--accent);
+	--color-accent-foreground: var(--accent-foreground);
 	--color-accent-weak: var(--bridge-accent-weak);
 	--color-accent-dim: var(--bridge-accent-dim);
 	--color-accent-strong: var(--bridge-accent-strong);
 	--color-danger-strong: var(--bridge-danger-strong);
-	--color-ring: var(--bridge-accent);
+	--color-ring: var(--ring);
 
-	--color-border: var(--bridge-border);
+	--color-border: var(--border);
 	--color-border-strong: var(--bridge-border-strong);
 
 	--color-working: var(--bridge-working);
@@ -329,7 +336,7 @@
 
 @utility session-card-terminated {
 	border-color: color-mix(in srgb, var(--color-status-terminated) 32%, var(--color-border));
-	background-color: color-mix(in srgb, var(--color-status-terminated) 7%, var(--color-bg-secondary));
+	background-color: color-mix(in srgb, var(--color-status-terminated) 7%, var(--color-bg-primary));
 }
 
 @utility bg-surface-faint {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -267,6 +267,10 @@
 	--size-topbar-secondary: 36px;
 	--size-topbar-control: 28px;
 	--size-toolbar: var(--size-topbar-primary);
+	/* ShellTopbar (.dashboard-app-header) on Win/Linux — the full-width bar
+	   the sidebar hangs below. Distinct from --size-toolbar (40px) because
+	   the shell header is taller (56px) to accommodate the project crumb. */
+	--size-shell-topbar: 56px;
 	/* Windows custom title bar (.window-titlebar) — keep in sync with TITLEBAR_HEIGHT in main.ts. */
 	--size-window-titlebar: 36px;
 	--size-inspector-tabs: var(--size-topbar-secondary);
@@ -293,9 +297,7 @@
 	--size-titlebar-content-offset: calc(
 		var(--size-titlebar-cluster-left) + var(--size-titlebar-cluster-width) + var(--size-titlebar-content-gap)
 	);
-	--size-titlebar-content-offset-linux: calc(
-		var(--size-titlebar-cluster-left-linux) + var(--size-titlebar-cluster-width) + var(--size-titlebar-content-gap)
-	);
+
 	/* Clears the macOS traffic-light row used by the fixed titlebar controls. */
 	--size-traffic-light-clearance: 40px;
 	--size-traffic-light-clearance-fullscreen: var(--space-2);

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -19,83 +19,131 @@
 	/* ── Color scheme hint for native form controls / scrollbars ── */
 	color-scheme: dark;
 
+	/* shadcn base-luma / olive preset (b6tOz2I0x). The renderer is dark-first,
+	   so the preset's .dark values are the default application values. */
+	--background: oklch(0.185 0.006 285.885);
+	--foreground: oklch(0.985 0 0);
+	--card: oklch(0.24 0.008 285.885);
+	--card-foreground: oklch(0.985 0 0);
+	--popover: oklch(0.28 0.008 285.885);
+	--popover-foreground: oklch(0.985 0 0);
+	--primary: oklch(0.92 0.004 286.32);
+	--primary-foreground: oklch(0.21 0.006 285.885);
+	--secondary: oklch(0.274 0.006 286.033);
+	--secondary-foreground: oklch(0.985 0 0);
+	--muted: oklch(0.274 0.006 286.033);
+	--muted-foreground: oklch(0.705 0.015 286.067);
+	--accent: oklch(0.274 0.006 286.033);
+	--accent-foreground: oklch(0.985 0 0);
+	--destructive: oklch(0.704 0.191 22.216);
+	/* Hairlines separate, they do not decorate: below the shadcn dark default of
+	 * 10% so column rules and card edges recede behind content. */
+	--border: oklch(1 0 0 / 7%);
+	--input: oklch(1 0 0 / 4%);
+	--ring: oklch(0.552 0.016 285.938);
+	--chart-1: oklch(0.871 0.006 286.286);
+	--chart-2: oklch(0.552 0.016 285.938);
+	--chart-3: oklch(0.442 0.017 285.786);
+	--chart-4: oklch(0.37 0.013 285.805);
+	--chart-5: oklch(0.274 0.006 286.033);
+	--radius: 0.625rem;
+	--sidebar: oklch(0.155 0.005 285.823);
+	--sidebar-foreground: oklch(0.985 0 0);
+	--sidebar-primary: oklch(0.488 0.243 264.376);
+	--sidebar-primary-foreground: oklch(0.985 0 0);
+	--sidebar-accent: oklch(0.274 0.006 286.033);
+	--sidebar-accent-foreground: oklch(0.985 0 0);
+	--sidebar-border: var(--border);
+	--sidebar-ring: oklch(0.552 0.016 285.938);
+
 	/* ═══════════════════════════════════════════════════════════════
 	   COLOR — semantic (swap these per theme; do not invent new roles
 	   for one-off hex — map one-offs to the nearest existing role)
 	   ═══════════════════════════════════════════════════════════════ */
 
-	/* Surfaces (near-black ramp) */
-	--color-bg-primary: #0a0b0d;
-	--color-bg-secondary: #15171b;
-	--color-bg-tertiary: #1b1d22;
-	--color-bg-elevated: #212329;
-	--color-bg-sidebar: #17181c;
+	/* Surfaces */
+	--color-bg-primary: var(--background);
+	--color-bg-secondary: var(--card);
+	--color-bg-tertiary: var(--muted);
+	--color-bg-elevated: var(--popover);
+	--color-bg-sidebar: var(--sidebar);
 	--color-bg-terminal: #101317e7;
 
 	/* Text */
-	--color-text-primary: #f4f5f7;
-	--color-text-muted: #9ba1aa;
-	--color-text-passive: #646a73;
+	--color-text-primary: var(--foreground);
+	--color-text-muted: var(--muted-foreground);
+	--color-text-passive: var(--chart-3);
 	--color-text-terminal: #d7d7d2;
 	--color-text-terminal-dim: #7c7c7c;
 
-	/* Borders (hairline white-alpha on dark) */
-	--color-border: rgb(255 255 255 / 0.06);
-	--color-border-strong: rgb(255 255 255 / 0.1);
+	/* Borders */
+	--color-border: var(--border);
+	--color-border-strong: var(--input);
 
-	/* Accent — refined blue (primary actions, focus, active session) */
-	--color-accent: #4d8dff;
-	--color-accent-foreground: #ffffff;
-	--color-accent-weak: rgb(77 141 255 / 0.16);
-	--color-accent-dim: #24406e;
-	--color-accent-strong: #2e63b8; /* solid primary buttons (IDE chrome) */
-	--color-danger-strong: #c93c37; /* solid destructive confirm buttons */
+	/* Reverb workspace bar — derived from the shared shadcn token scale. The bar
+	 * reads as the top of the page it heads, not as sidebar chrome, so it takes
+	 * the page canvas and separates with its hairline alone. */
+	--color-bg-topbar: var(--background);
+	--color-bg-topbar-raised: var(--secondary);
+	--color-border-topbar: var(--border);
+	--color-border-topbar-strong: var(--input);
+	--color-text-topbar: var(--foreground);
+	--color-text-topbar-muted: var(--muted-foreground);
+	--color-text-topbar-passive: var(--chart-3);
 
-	/* Session status roles */
-	--color-status-working: #36c2b4;
-	--color-status-needs-you: #f2b84b;
-	--color-status-in-review: #5b8def;
-	--color-status-ready: #9ad97a;
-	--color-status-merged: #3e9b62;
-	--color-status-idle: #8e96a3;
-	--color-status-exited: #ee6a6a;
-	--color-status-terminated: #6f7680;
-	--color-status-terminated-foreground: #8e96a3;
-	--color-status-unknown: #a78bfa;
+	/* Accent and destructive roles */
+	--color-accent: var(--primary);
+	--color-accent-foreground: var(--primary-foreground);
+	--color-accent-weak: color-mix(in oklch, var(--primary) 16%, transparent);
+	--color-accent-dim: var(--chart-4);
+	--color-accent-strong: var(--primary);
+	--color-danger-strong: var(--destructive);
+
+	/* Board lane signals, matched to the landing hero's board preview. */
+	--color-status-working: #60a5fa;
+	--color-status-needs-you: #fb923c;
+	--color-status-in-review: #facc15;
+	--color-status-ready: #4ade80;
+	--color-status-merged: var(--primary);
+	--color-status-idle: var(--muted-foreground);
+	--color-status-exited: var(--destructive);
+	--color-status-terminated: var(--chart-3);
+	--color-status-terminated-foreground: var(--chart-3);
+	--color-status-unknown: var(--chart-4);
 
 	/* Compatibility roles used by non-session surfaces. */
 	--color-working: var(--color-status-working);
 	--color-warning: var(--color-status-needs-you);
 	--color-success: var(--color-status-ready);
-	--color-success-bright: #8bdc75; /* reviewer role highlight (was hardcoded) */
-	--color-danger: #ef6b6b; /* fail */
-	--color-purple: #a78bfa; /* accessory / magenta lane */
+	--color-success-bright: var(--chart-1);
+	--color-danger: var(--destructive);
+	--color-purple: var(--chart-4);
 
 	/* Interactive overlays */
-	--color-interactive-hover: rgb(255 255 255 / 0.04);
-	--color-interactive-active: rgb(255 255 255 / 0.07);
-	--color-overlay-subtle: rgb(255 255 255 / 0.018);
-	--color-overlay-faint: rgb(255 255 255 / 0.02);
-	--color-scrollbar: rgb(255 255 255 / 0.12);
-	--color-scrim: rgb(0 0 0 / 0.55);
+	--color-interactive-hover: color-mix(in oklch, var(--foreground) 4%, transparent);
+	--color-interactive-active: color-mix(in oklch, var(--foreground) 7%, transparent);
+	--color-overlay-subtle: color-mix(in oklch, var(--foreground) 1.8%, transparent);
+	--color-overlay-faint: color-mix(in oklch, var(--foreground) 2%, transparent);
+	--color-scrollbar: color-mix(in oklch, var(--foreground) 12%, transparent);
+	--color-scrollbar-board: color-mix(in oklch, var(--foreground) 26%, transparent);
+	--color-scrollbar-board-hover: color-mix(in oklch, var(--foreground) 45%, transparent);
+	--color-scrim: color-mix(in oklch, var(--background) 85%, transparent);
 	--blur-overlay: 1px;
 
 	/* ═══════════════════════════════════════════════════════════════
 	   TYPOGRAPHY
 	   ═══════════════════════════════════════════════════════════════ */
 
-	--font-family-base:
-		-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Helvetica Neue",
-		sans-serif;
+	--font-family-base: "Geist Variable", "Geist", ui-sans-serif, system-ui, sans-serif;
 	--font-family-mono:
-		"JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font", "FiraCode Nerd Font Mono", "FiraCode Nerd Font",
-		"MesloLGS NF", "CaskaydiaCove Nerd Font Mono", "CaskaydiaCove Nerd Font", "Hack Nerd Font Mono", "Hack Nerd Font",
-		"Symbols Nerd Font Mono", "Symbols Nerd Font", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-		"Liberation Mono", "Courier New", monospace;
+		"Geist Mono Variable", "Geist Mono", "JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font",
+		"FiraCode Nerd Font Mono", "FiraCode Nerd Font", "MesloLGS NF", ui-monospace, SFMono-Regular, Menlo, Monaco,
+		Consolas, "Liberation Mono", "Courier New", monospace;
 
 	/* Scale — dense UI chrome uses half-steps between base sizes */
 	--font-size-2xs: 10.5px; /* uppercase meta, board footers */
 	--font-size-xs: 10px; /* micro labels, tight pills */
+	--font-size-nano: 8px; /* smallest chrome text — sidebar search label */
 	--font-size-caption: 11px; /* badges, kanban labels */
 	--font-size-sm-md: 11.5px; /* inspector tabs, status pills */
 	--font-size-sm: 12px; /* secondary chrome / Tailwind text-xs */
@@ -165,7 +213,7 @@
 	   ═══════════════════════════════════════════════════════════════ */
 
 	--z-chrome: 10;
-	--z-sidebar-preview: 15;
+	--z-sidebar-preview: 55;
 	--z-titlebar: 20;
 	--z-overlay: 50;
 
@@ -173,12 +221,13 @@
 	   RADIUS
 	   ═══════════════════════════════════════════════════════════════ */
 
-	--radius-xs: 3px; /* inline rename inputs, hairline controls */
-	--radius-sm: 4px; /* chips, tiny controls — absorb old 5px */
-	--radius-md: 6px; /* default controls — absorb old 7px */
-	--radius-lg: 8px; /* cards, larger buttons */
-	--radius-panel: 13px; /* kanban columns, empty-state cards */
+	--radius-xs: calc(var(--radius) * 0.4);
+	--radius-sm: calc(var(--radius) * 0.6);
+	--radius-md: calc(var(--radius) * 0.8);
+	--radius-lg: var(--radius);
+	--radius-panel: calc(var(--radius) * 1.4);
 	--radius-full: 999px; /* pills, avatars, status dots */
+	--radius-swatch: 2px; /* board lane squares: square-reading, not a dot */
 
 	/* ═══════════════════════════════════════════════════════════════
 	   BREAKPOINTS — documented here; @media cannot use var()
@@ -202,6 +251,7 @@
 	--size-icon-lg: 15px;
 	--size-icon-xl: 18px;
 	--size-dot-sm: 7px;
+	--size-swatch: 8px; /* board lane + topbar status squares */
 	--size-control-form: 32px;
 	--size-control-xs: 20px;
 	--size-control-sm: 24px;
@@ -211,10 +261,20 @@
 	--size-control-board-sm: 30px;
 	--size-control-board: 36px;
 	--size-table-head: var(--space-10);
-	--size-toolbar: 56px;
+	/* Reverb's route-level workspace bar and pane-level secondary rows. Keep
+	   the old names as compatibility aliases while route mounts migrate. */
+	--size-topbar-primary: 40px;
+	--size-topbar-secondary: 36px;
+	--size-topbar-control: 28px;
+	--size-toolbar: var(--size-topbar-primary);
 	/* Windows custom title bar (.window-titlebar) — keep in sync with TITLEBAR_HEIGHT in main.ts. */
 	--size-window-titlebar: 36px;
-	--size-inspector-tabs: 48px;
+	--size-inspector-tabs: var(--size-topbar-secondary);
+	--size-topbar-context-max: 32rem;
+	--space-topbar-x: 10px;
+	--space-topbar-zone: 10px;
+	--space-topbar-group: 4px;
+	--radius-topbar-control: 7px;
 	--size-row-md: 52px;
 	--size-browser-url: 29px;
 	--size-browser-min: 320px;
@@ -237,10 +297,13 @@
 		var(--size-titlebar-cluster-left-linux) + var(--size-titlebar-cluster-width) + var(--size-titlebar-content-gap)
 	);
 	/* Clears the macOS traffic-light row used by the fixed titlebar controls. */
-	--size-traffic-light-clearance: 44px;
+	--size-traffic-light-clearance: 40px;
 	--size-traffic-light-clearance-fullscreen: var(--space-2);
-	--size-resize-handle: 7px;
-	--size-resize-handle-offset: 3px;
+	/* Resize handle straddles the sidebar-panel boundary: offset = half the width
+	 * so the hairline lands exactly at the junction and the drag zone covers 6px
+	 * on each side of it. */
+	--size-resize-handle: 12px;
+	--size-resize-handle-offset: 6px;
 	--size-kanban-glow: 130px;
 	--size-kv-label: 74px;
 	--size-notification-width: 460px;
@@ -265,6 +328,8 @@
 	--size-flex-min: 0px;
 	/* Keeps terminal tabs usable after title truncation while leaving room for several tabs. */
 	--size-shell-tab-min: 64px;
+	/* Keeps added session tabs aligned with the owning tab in the secondary strip. */
+	--size-session-pane-tab-max: 112px;
 	/* Caps a standalone shell terminal's tab label so several open shells stay
 	   readable side by side instead of one long path crowding out the rest. */
 	--size-shell-tab-max: 140px;
@@ -273,16 +338,16 @@
 	--size-dialog-orchestrator: 460px;
 	--size-dialog-xl: 560px;
 
-	/* Command palette — Cursor-style dark surface */
-	--color-bg-command-palette: #212121;
-	--color-border-command-palette: #2e2e2e;
-	--color-bg-command-item-active: #3b3b3b;
-	--color-text-command-item: #cccccc;
-	--color-text-command-placeholder: #737373;
-	--color-text-command-muted: #8a8a8a;
+	/* Command palette */
+	--color-bg-command-palette: var(--popover);
+	--color-border-command-palette: var(--border);
+	--color-bg-command-item-active: var(--accent);
+	--color-text-command-item: var(--foreground);
+	--color-text-command-placeholder: var(--muted-foreground);
+	--color-text-command-muted: var(--muted-foreground);
 	--radius-command-palette: 12px;
 	--radius-command-item: 6px;
-	--shadow-command-palette: 0 24px 64px rgb(0 0 0 / 0.55), 0 8px 24px rgb(0 0 0 / 0.35);
+	--shadow-command-palette: var(--elevation-xl);
 	--size-command-palette: 720px;
 	--size-command-palette-top: 14vh;
 	--size-command-palette-list-max: 420px;
@@ -299,44 +364,47 @@
 	--size-sidebar-project-actions: 84px;
 
 	/* Shared inset-panel geometry (welcome board + settings page) */
-	--size-center-panel-inset: 12px;
-	--size-center-panel-inline-inset: 8px;
-	--size-center-panel-bottom-inset: 6px;
+	--size-center-panel-inset: 24px;
+	--size-center-panel-inline-inset: 16px;
+	--size-center-panel-bottom-inset: 14px;
 	/* macOS frames the panel with one uniform inset on all four sides. It stays
 	 * near-flush so in-panel titles align with the fixed TitlebarNav row. */
-	--size-center-panel-inset-mac: 2px;
-	--radius-center-panel: 17px;
+	--size-center-panel-inset-mac: 6px;
+	/* Formula: inner = outer_window_radius - inset (nested corner alignment).
+	 * macOS window corner ≈ 18px; inset = 6px → inner = 12px. */
+	--radius-window: 18px;
+	--radius-center-panel: calc(var(--radius-window) - var(--size-center-panel-inset-mac));
 
 	/* Welcome / import radius alias (CreateProjectFlow rounded-welcome-panel) */
-	--color-border-welcome-panel: #212121;
+	--color-border-welcome-panel: var(--border);
 	--radius-welcome-panel: var(--radius-center-panel);
 
-	/* Import mode picker (Figma ModalContainer) — dark values must stay exact */
-	--color-bg-import-modal: #131313;
-	--color-border-import-modal: #2a2e33;
-	--color-text-import-title: #e6edf3;
-	--color-text-import-muted: #8b949e;
-	--color-bg-import-card: rgb(20 21 23 / 0.3);
-	--color-bg-import-card-hover: rgb(20 21 23 / 0.55);
+	/* Import mode picker */
+	--color-bg-import-modal: var(--popover);
+	--color-border-import-modal: var(--border);
+	--color-text-import-title: var(--foreground);
+	--color-text-import-muted: var(--muted-foreground);
+	--color-bg-import-card: var(--card);
+	--color-bg-import-card-hover: var(--accent);
 	--color-bg-import-illustration: var(--color-bg-import-modal);
-	--color-bg-import-chip: #242424;
-	--shadow-import-modal: 0 0 0 1px rgb(255 255 255 / 0.1), 0 8px 24px rgb(0 0 0 / 0.5);
+	--color-bg-import-chip: var(--secondary);
+	--shadow-import-modal: 0 0 0 1px var(--border), var(--elevation-md);
 	--size-import-modal-max: 896px;
 	--size-import-folder-dialog: 640px;
 	--size-import-mode-card-min: 252px;
 	--size-import-mode-card-min-sm: 292px;
 	--size-import-mode-illustration: 178px;
 
-	/* Settings page (Figma) */
-	--color-bg-settings-row: #18181c;
-	--color-bg-settings-menu: #212121;
-	--color-bg-settings-menu-selected: rgb(66 66 66 / 0.78);
-	--color-bg-settings-dialog: #212121;
-	--color-text-settings-title: rgb(236 236 236);
-	--color-text-settings-muted: rgb(161 161 161);
-	--color-text-settings-row: rgb(236 236 236);
+	/* Settings */
+	--color-bg-settings-row: transparent;
+	--color-bg-settings-menu: var(--popover);
+	--color-bg-settings-menu-selected: var(--accent);
+	--color-bg-settings-dialog: var(--card);
+	--color-text-settings-title: var(--foreground);
+	--color-text-settings-muted: var(--muted-foreground);
+	--color-text-settings-row: var(--foreground);
 	--color-border-settings: var(--color-border-welcome-panel);
-	--color-border-settings-menu: rgb(66 66 66 / 0.78);
+	--color-border-settings-menu: var(--border);
 	--font-size-settings-title: 28px;
 	--tracking-settings-title: -0.015em;
 	--tracking-settings-section: 0.06em;
@@ -360,27 +428,28 @@
 	--size-settings-row-value-max: 20rem;
 	--size-settings-row-value-max-percent: 55%;
 	--size-settings-footer-button-padding-x: 20px;
-	--color-settings-footer-button-primary-fg: #ffffff;
+	--color-settings-footer-button-primary-fg: var(--primary-foreground);
 	--size-settings-dialog: 575px;
+	--size-settings-dialog-wide: 920px;
+	--size-settings-dialog-height: 680px;
 	--size-settings-dialog-max-h: 680px;
-	--color-border-settings-dialog: #2d2d34;
-	--color-border-settings-dialog-header: #2d2d34;
-	--color-bg-settings-input: #2a2a2a;
+	--color-border-settings-dialog: oklch(1 0 0 / 3%);
+	--color-border-settings-dialog-header: oklch(1 0 0 / 3%);
+	--color-bg-settings-input: var(--input);
 	--color-border-settings-input: var(--color-border-settings-dialog);
-	--color-text-settings-input: #e5e7eb;
-	--color-text-settings-placeholder: #6b7280;
+	--color-text-settings-input: var(--foreground);
+	--color-text-settings-placeholder: var(--muted-foreground);
 	--color-text-import-sep: var(--color-text-settings-placeholder);
-	/* Settings accents (Figma — distinct from app --color-accent) */
-	--color-settings-accent: #4f8afa;
-	--color-settings-switch-on: #3b82f6;
+	--color-settings-accent: var(--primary);
+	--color-settings-switch-on: var(--primary);
 
 	/* Project / workspace agents sheet — aliases shared chrome where themes match */
 	--color-bg-agents-sheet: var(--color-bg-settings-dialog);
-	--color-border-agents-sheet: #424242;
-	--color-bg-agents-sheet-control: #2a2a2a;
-	--color-text-agents-sheet-title: #ffffff;
-	--color-text-agents-sheet-description: #9ca3af;
-	--color-text-agents-sheet-label: #d1d5db;
+	--color-border-agents-sheet: var(--border);
+	--color-bg-agents-sheet-control: var(--input);
+	--color-text-agents-sheet-title: var(--foreground);
+	--color-text-agents-sheet-description: var(--muted-foreground);
+	--color-text-agents-sheet-label: var(--foreground);
 	--radius-agents-sheet: var(--radius-center-panel);
 	/* Settings layout sizes (Figma) */
 	--size-settings-mobile-dialog: 550px;
@@ -400,9 +469,9 @@
 	--leading-settings-mobile-warning: 15px;
 	--size-settings-action-height: 38px;
 	--radius-settings-action: 16px;
-	--radius-settings-dialog-lg: 20px;
-	--shadow-settings-dialog: 0px 20px 25px -5px rgba(0, 0, 0, 0.1), 0px 8px 10px -6px rgba(0, 0, 0, 0.1);
-	--shadow-settings-qr: 0px 10px 15px -3px rgba(0, 0, 0, 0.1), 0px 4px 6px -4px rgba(0, 0, 0, 0.1);
+	--radius-settings-dialog-lg: 24px;
+	--shadow-settings-dialog: var(--elevation-xl);
+	--shadow-settings-qr: var(--elevation-md);
 
 	--size-empty-offset-y: 5vh; /* board empty-state vertical nudge */
 
@@ -422,8 +491,9 @@
 	--color-preview-terminal-fg: #cbd5e1;
 
 	/* Mock project accent swatches (sidebar dots) */
-	--color-project-accent-mint: #6ee7b7;
-	--color-project-accent-sky: #93c5fd;
+--color-project-accent-mint: var(--chart-1);
+	--color-project-accent-sky: var(--chart-2);
+	--color-project-accent-violet: #c4b5fd;
 
 	/* Terminal ANSI palette. Keep this independent from product status colors:
 	   agent TUIs own the semantic meaning of these slots. */
@@ -452,10 +522,14 @@
 	   SHADOWS
 	   ═══════════════════════════════════════════════════════════════ */
 
-	--elevation-sm: 0 1px 0 rgb(0 0 0 / 0.35);
-	--elevation-md: 0 1px 0 rgb(0 0 0 / 0.4), 0 12px 32px rgb(0 0 0 / 0.5);
-	--elevation-lg: 0 8px 40px rgb(0 0 0 / 0.55);
-	--elevation-xl: 0 1px 0 rgb(0 0 0 / 0.4), 0 20px 50px rgb(0 0 0 / 0.55);
+	--elevation-sm: 0 1px 0 color-mix(in oklch, var(--background) 35%, transparent);
+	--elevation-md:
+		0 1px 0 color-mix(in oklch, var(--background) 40%, transparent),
+		0 12px 32px color-mix(in oklch, var(--background) 50%, transparent);
+	--elevation-lg: 0 8px 40px color-mix(in oklch, var(--background) 55%, transparent);
+	--elevation-xl:
+		0 1px 0 color-mix(in oklch, var(--background) 40%, transparent),
+		0 20px 50px color-mix(in oklch, var(--background) 55%, transparent);
 
 	/* @theme bridge — avoids Tailwind theme key / :root name collisions */
 	--bridge-border: var(--color-border);
@@ -495,6 +569,27 @@
 	--bridge-preview-terminal-border: var(--color-preview-terminal-border);
 	--bridge-preview-terminal-fg: var(--color-preview-terminal-fg);
 
+	/* Legacy renderer aliases. The Reverb workspace styles still consume these
+	   names; keep them as semantic pointers rather than reintroducing a second
+	   palette. They resolve through the active theme's supplied shadcn tokens. */
+	--bg: var(--color-bg-primary);
+	--bg-0: var(--color-bg-primary);
+	--bg-1: var(--color-bg-secondary);
+	--bg-2: var(--color-bg-tertiary);
+	--surface: var(--color-bg-secondary);
+	--fg: var(--color-text-primary);
+	--fg-muted: var(--color-text-muted);
+	--fg-passive: var(--color-text-passive);
+	--border-1: var(--color-border-strong);
+	--interactive-hover: var(--color-interactive-hover);
+	--interactive-active: var(--color-interactive-active);
+	--accent-weak: var(--color-accent-weak);
+	--term-bg: var(--color-bg-terminal);
+	--green: var(--color-success);
+	--red: var(--color-danger);
+	--orange: var(--color-working);
+	--amber: var(--color-warning);
+
 	--font-sans: var(--font-family-base);
 	--font-mono: var(--font-family-mono);
 }
@@ -504,104 +599,152 @@
 :root[data-theme="light"] {
 	color-scheme: light;
 
-	--color-bg-primary: #fcfcfc;
-	--color-bg-secondary: #ffffff;
-	--color-bg-tertiary: #ededee;
-	--color-bg-elevated: #e4e4e6;
-	--color-bg-sidebar: #fcfcfc;
+	--background: oklch(0.985 0 0);
+	--foreground: oklch(0.141 0.005 285.823);
+	--card: oklch(0.985 0 0);
+	--card-foreground: oklch(0.141 0.005 285.823);
+	--popover: oklch(1 0 0);
+	--popover-foreground: oklch(0.141 0.005 285.823);
+	--primary: oklch(0.21 0.006 285.885);
+	--primary-foreground: oklch(0.985 0 0);
+	--secondary: oklch(0.967 0.001 286.375);
+	--secondary-foreground: oklch(0.21 0.006 285.885);
+	--muted: oklch(0.967 0.001 286.375);
+	--muted-foreground: oklch(0.552 0.016 285.938);
+	--accent: oklch(0.967 0.001 286.375);
+	--accent-foreground: oklch(0.21 0.006 285.885);
+	--destructive: oklch(0.577 0.245 27.325);
+	/* Same intent as dark: one step lighter than the shadcn default hairline. */
+	--border: oklch(0.945 0.003 286.32);
+	--input: oklch(0.92 0.004 286.32);
+	--ring: oklch(0.705 0.015 286.067);
+	--chart-1: oklch(0.871 0.006 286.286);
+	--chart-2: oklch(0.552 0.016 285.938);
+	--chart-3: oklch(0.442 0.017 285.786);
+	--chart-4: oklch(0.37 0.013 285.805);
+	--chart-5: oklch(0.274 0.006 286.033);
+	--sidebar: oklch(1 0 0);
+	--sidebar-foreground: oklch(0.141 0.005 285.823);
+	--sidebar-primary: oklch(0.21 0.006 285.885);
+	--sidebar-primary-foreground: oklch(0.985 0 0);
+	--sidebar-accent: oklch(0.967 0.001 286.375);
+	--sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+	--sidebar-border: var(--border);
+	--sidebar-ring: oklch(0.705 0.015 286.067);
+
+	--color-bg-primary: var(--background);
+	--color-bg-secondary: var(--card);
+	--color-bg-tertiary: var(--muted);
+	--color-bg-elevated: var(--popover);
+	--color-bg-sidebar: var(--sidebar);
 	--color-bg-terminal: #f5f5f4;
 
-	--color-text-primary: #1a1a1a;
-	--color-text-muted: #666666;
-	--color-text-passive: #9a9a9a;
+	--color-text-primary: var(--foreground);
+	--color-text-muted: var(--muted-foreground);
+	--color-text-passive: var(--chart-3);
 	--color-text-terminal: #24292f;
 	--color-text-terminal-dim: #6b7280;
 
-	--color-border: #e3e3e5;
-	--color-border-strong: #d4d4d6;
+	--color-border: var(--border);
+	--color-border-strong: var(--input);
 
-	--color-accent: #2563eb;
-	--color-accent-foreground: #ffffff;
-	--color-accent-weak: rgb(37 99 235 / 0.12);
-	--color-accent-dim: #bcd2f7;
-	--color-accent-strong: #1d4ed8; /* solid primary buttons (IDE chrome) */
-	--color-danger-strong: #b42318; /* solid destructive confirm buttons */
+	/* Reverb workspace bar — derived from the shared shadcn token scale. */
+	--color-bg-topbar: var(--background);
+	--color-bg-topbar-raised: var(--secondary);
+	--color-border-topbar: var(--border);
+	--color-border-topbar-strong: var(--input);
+	--color-text-topbar: var(--foreground);
+	--color-text-topbar-muted: var(--muted-foreground);
+	--color-text-topbar-passive: var(--chart-3);
 
-	--color-status-working: #087f75;
-	--color-status-needs-you: #946200;
-	--color-status-in-review: #255fc4;
-	--color-status-ready: #2f7d32;
-	--color-status-merged: #0d5f35;
-	--color-status-idle: #69717d;
-	--color-status-exited: #b83232;
-	--color-status-terminated: #626975;
-	--color-status-terminated-foreground: #626975;
-	--color-status-unknown: #6d46c2;
+	--color-accent: var(--primary);
+	--color-accent-foreground: var(--primary-foreground);
+	--color-accent-weak: color-mix(in oklch, var(--primary) 12%, transparent);
+	--color-accent-dim: var(--chart-1);
+	--color-accent-strong: var(--primary);
+	--color-danger-strong: var(--destructive);
+
+	/* Same lane hues as dark, deepened so they hold contrast on a light canvas. */
+	--color-status-working: #2563eb;
+	--color-status-needs-you: #ea580c;
+	--color-status-in-review: #ca8a04;
+	--color-status-ready: #16a34a;
+	--color-status-merged: var(--primary);
+	--color-status-idle: var(--muted-foreground);
+	--color-status-exited: var(--destructive);
+	--color-status-terminated: var(--chart-3);
+	--color-status-terminated-foreground: var(--chart-3);
+	--color-status-unknown: var(--chart-4);
 
 	--color-working: var(--color-status-working);
 	--color-warning: var(--color-status-needs-you);
 	--color-success: var(--color-status-ready);
-	--color-success-bright: #176639;
-	--color-danger: #c0392b;
-	--color-purple: #7c3aed;
+	--color-success-bright: var(--chart-1);
+	--color-danger: var(--destructive);
+	--color-purple: var(--chart-4);
 
-	--color-interactive-hover: rgb(0 0 0 / 0.04);
-	--color-interactive-active: rgb(0 0 0 / 0.07);
-	--color-overlay-subtle: rgb(0 0 0 / 0.02);
-	--color-overlay-faint: rgb(0 0 0 / 0.03);
-	--color-scrollbar: rgb(0 0 0 / 0.12);
-	--color-scrim: rgb(0 0 0 / 0.45);
+	--color-interactive-hover: color-mix(in oklch, var(--foreground) 4%, transparent);
+	--color-interactive-active: color-mix(in oklch, var(--foreground) 7%, transparent);
+	--color-overlay-subtle: color-mix(in oklch, var(--foreground) 2%, transparent);
+	--color-overlay-faint: color-mix(in oklch, var(--foreground) 3%, transparent);
+	--color-scrollbar: color-mix(in oklch, var(--foreground) 12%, transparent);
+	--color-scrollbar-board: color-mix(in oklch, var(--foreground) 26%, transparent);
+	--color-scrollbar-board-hover: color-mix(in oklch, var(--foreground) 45%, transparent);
+	--color-scrim: color-mix(in oklch, var(--foreground) 45%, transparent);
 
-	--elevation-sm: 0 1px 0 rgb(0 0 0 / 0.06);
-	--elevation-md: 0 1px 0 rgb(0 0 0 / 0.03), 0 12px 30px rgb(20 30 50 / 0.1);
-	--elevation-lg: 0 16px 48px rgb(20 30 50 / 0.16);
-	--elevation-xl: 0 1px 0 rgb(0 0 0 / 0.03), 0 20px 50px rgb(20 30 50 / 0.14);
+	--elevation-sm: 0 1px 0 color-mix(in oklch, var(--foreground) 6%, transparent);
+	--elevation-md:
+		0 1px 0 color-mix(in oklch, var(--foreground) 3%, transparent),
+		0 12px 30px color-mix(in oklch, var(--foreground) 10%, transparent);
+	--elevation-lg: 0 16px 48px color-mix(in oklch, var(--foreground) 16%, transparent);
+	--elevation-xl:
+		0 1px 0 color-mix(in oklch, var(--foreground) 3%, transparent),
+		0 20px 50px color-mix(in oklch, var(--foreground) 14%, transparent);
 
 	/* Command palette */
-	--color-bg-command-palette: #f4f4f5;
-	--color-border-command-palette: #e3e3e5;
-	--color-bg-command-item-active: #d8d8dc;
-	--color-text-command-item: #1a1a1a;
-	--color-text-command-placeholder: #9a9a9a;
-	--color-text-command-muted: #666666;
-	--shadow-command-palette: 0 16px 48px rgb(20 30 50 / 0.14), 0 4px 12px rgb(0 0 0 / 0.06);
+	--color-bg-command-palette: var(--popover);
+	--color-border-command-palette: var(--border);
+	--color-bg-command-item-active: var(--accent);
+	--color-text-command-item: var(--foreground);
+	--color-text-command-placeholder: var(--muted-foreground);
+	--color-text-command-muted: var(--muted-foreground);
+	--shadow-command-palette: var(--elevation-xl);
 
 	/* Welcome / import radius alias */
-	--color-border-welcome-panel: #d4d4d6;
+	--color-border-welcome-panel: var(--border);
 
-	/* Import mode picker — light surfaces */
-	--color-bg-import-modal: #ffffff;
-	--color-border-import-modal: #d4d4d6;
-	--color-text-import-title: #1a1a1a;
-	--color-text-import-muted: #666666;
-	--color-bg-import-card: #f3f3f4;
-	--color-bg-import-card-hover: #e8e8ea;
-	--color-bg-import-chip: #e8e8ea;
-	--shadow-import-modal: 0 0 0 1px rgb(0 0 0 / 0.06), 0 8px 24px rgb(0 0 0 / 0.08);
+	/* Import mode picker */
+	--color-bg-import-modal: var(--popover);
+	--color-border-import-modal: var(--border);
+	--color-text-import-title: var(--foreground);
+	--color-text-import-muted: var(--muted-foreground);
+	--color-bg-import-card: var(--card);
+	--color-bg-import-card-hover: var(--accent);
+	--color-bg-import-chip: var(--secondary);
+	--shadow-import-modal: 0 0 0 1px var(--border), var(--elevation-md);
 
-	/* Project / workspace agents sheet — light surfaces */
-	--color-border-agents-sheet: #d4d4d6;
-	--color-bg-agents-sheet-control: #f3f3f4;
-	--color-text-agents-sheet-title: #1a1a1a;
-	--color-text-agents-sheet-description: #666666;
-	--color-text-agents-sheet-label: #374151;
+	/* Project / workspace agents sheet */
+	--color-border-agents-sheet: var(--border);
+	--color-bg-agents-sheet-control: var(--input);
+	--color-text-agents-sheet-title: var(--foreground);
+	--color-text-agents-sheet-description: var(--muted-foreground);
+	--color-text-agents-sheet-label: var(--foreground);
 
-	--color-bg-settings-row: #f3f3f4;
-	--color-bg-settings-menu: #f3f3f4;
-	--color-bg-settings-menu-selected: rgb(0 0 0 / 0.08);
-	--color-bg-settings-dialog: #ffffff;
-	--color-text-settings-title: rgb(26 26 26);
-	--color-text-settings-muted: rgb(102 102 102);
-	--color-text-settings-row: rgb(26 26 26);
-	--color-border-settings-menu: rgb(0 0 0 / 0.12);
-	--color-border-settings-dialog: #d4d4d6;
-	--color-border-settings-dialog-header: #e5e5e7;
-	--color-bg-settings-input: #ffffff;
-	--color-text-settings-input: #1a1a1a;
-	--color-text-settings-placeholder: #9ca3af;
-	/* Settings accents stay brand-blue in light mode (same Figma values). */
-	--color-settings-accent: #4f8afa;
-	--color-settings-switch-on: #3b82f6;
+	--color-bg-settings-row: var(--card);
+	--color-bg-settings-menu: var(--popover);
+	--color-bg-settings-menu-selected: var(--accent);
+	--color-bg-settings-dialog: var(--card);
+	--color-text-settings-title: var(--foreground);
+	--color-text-settings-muted: var(--muted-foreground);
+	--color-text-settings-row: var(--foreground);
+	--color-border-settings-menu: var(--border);
+	--color-border-settings-dialog: var(--border);
+	--color-border-settings-dialog-header: color-mix(in oklch, var(--border) 70%, transparent);
+	--color-bg-settings-input: var(--input);
+	--color-text-settings-input: var(--foreground);
+	--color-text-settings-placeholder: var(--muted-foreground);
+	--color-settings-accent: var(--primary);
+	--color-settings-switch-on: var(--primary);
 
 	--color-term-black: #24292f;
 	--color-term-red: #a13c37;
@@ -619,4 +762,303 @@
 	--color-term-bright-magenta: #5f4476;
 	--color-term-bright-cyan: #316061;
 	--color-term-bright-white: #24292f;
+}
+
+
+/* ═══════════════════════════════════════════════════════════════
+   NAMED THEMES — applied via data-style-theme on :root.
+   "orchestrate" is the default (no attribute).
+
+   Each palette keeps its canonical background and the hue/chroma of
+   every other token, but lightness is re-derived so all themes trace
+   the SAME contrast curve as Orchestrate:
+     dark   card +0.055 · muted +0.089 · popover +0.095 · sidebar -0.030 ΔL
+     light  card -0.010 · muted -0.022 · popover +0.012 · sidebar +0.012 ΔL
+   Body text lands at ~12.5:1 (dark) / ~13.0:1 (light); muted at ~5.6 / ~5.0.
+   Text chroma is capped so re-lighting cannot oversaturate a hue.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── GitHub (Primer) ── */
+:root[data-style-theme="github"] {
+	/* Dark */
+	--background:                 #0d1117;
+	--foreground:                 #ccd3d8;
+	--card:                       #191e25;
+	--card-foreground:            #ccd3d8;
+	--popover:                    #22272e;
+	--popover-foreground:         #ccd3d8;
+	--primary:                    #58a6ff;
+	--primary-foreground:         #0d1117;
+	--secondary:                  #21262d;
+	--secondary-foreground:       #ccd3d8;
+	--muted:                      #21262d;
+	--muted-foreground:           #848d96;
+	--accent:                     #21262d;
+	--accent-foreground:          #ccd3d8;
+	--border:                     oklch(1 0 0 / 10%);
+	--input:                      oklch(1 0 0 / 6%);
+	--ring:                       #58a6ff;
+	--sidebar:                    #050b12;
+	--sidebar-foreground:         #ccd3d8;
+	--sidebar-primary:            #58a6ff;
+	--sidebar-primary-foreground: #0d1117;
+	--sidebar-accent:             #21262d;
+	--sidebar-accent-foreground:  #ccd3d8;
+	--sidebar-ring:               #58a6ff;
+}
+:root[data-style-theme="github"][data-theme="light"] {
+	color-scheme: light;
+	/* Light */
+	--background:                 #ffffff;
+	--foreground:                 #2d3237;
+	--card:                       #fafcfe;
+	--card-foreground:            #2d3237;
+	--popover:                    #fdfdfd;
+	--popover-foreground:         #2d3237;
+	--primary:                    #0969da;
+	--primary-foreground:         #ffffff;
+	--secondary:                  #f4f8fc;
+	--secondary-foreground:       #2d3237;
+	--muted:                      #f4f8fc;
+	--muted-foreground:           #68707a;
+	--accent:                     #f4f8fc;
+	--accent-foreground:          #2d3237;
+	--border:                     oklch(0 0 0 / 10%);
+	--input:                      oklch(0 0 0 / 6%);
+	--ring:                       #0969da;
+	--sidebar:                    #fcfeff;
+	--sidebar-foreground:         #2d3237;
+	--sidebar-primary:            #0969da;
+	--sidebar-primary-foreground: #ffffff;
+	--sidebar-accent:             #f4f8fc;
+	--sidebar-accent-foreground:  #2d3237;
+	--sidebar-ring:               #0969da;
+}
+
+/* ── Catppuccin (Mocha / Latte) ── */
+:root[data-style-theme="catppuccin"] {
+	/* Dark */
+	--background:                 #1e1e2e;
+	--foreground:                 #d9e0f9;
+	--card:                       #2b2c3c;
+	--card-foreground:            #d9e0f9;
+	--popover:                    #353647;
+	--popover-foreground:         #d9e0f9;
+	--primary:                    #89b4fa;
+	--primary-foreground:         #1e1e2e;
+	--secondary:                  #333445;
+	--secondary-foreground:       #d9e0f9;
+	--muted:                      #333445;
+	--muted-foreground:           #9197aa;
+	--accent:                     #333445;
+	--accent-foreground:          #d9e0f9;
+	--border:                     oklch(1 0 0 / 8%);
+	--input:                      oklch(1 0 0 / 5%);
+	--ring:                       #89b4fa;
+	--sidebar:                    #171724;
+	--sidebar-foreground:         #d9e0f9;
+	--sidebar-primary:            #89b4fa;
+	--sidebar-primary-foreground: #1e1e2e;
+	--sidebar-accent:             #333445;
+	--sidebar-accent-foreground:  #d9e0f9;
+	--sidebar-ring:               #89b4fa;
+}
+:root[data-style-theme="catppuccin"][data-theme="light"] {
+	color-scheme: light;
+	/* Light */
+	--background:                 #eff1f5;
+	--foreground:                 #25273a;
+	--card:                       #ebeef4;
+	--card-foreground:            #25273a;
+	--popover:                    #f3f5f9;
+	--popover-foreground:         #25273a;
+	--primary:                    #1e66f5;
+	--primary-foreground:         #eff1f5;
+	--secondary:                  #e6eaf4;
+	--secondary-foreground:       #25273a;
+	--muted:                      #e6eaf4;
+	--muted-foreground:           #646679;
+	--accent:                     #e6eaf4;
+	--accent-foreground:          #25273a;
+	--border:                     oklch(0 0 0 / 10%);
+	--input:                      oklch(0 0 0 / 6%);
+	--ring:                       #1e66f5;
+	--sidebar:                    #f2f5fb;
+	--sidebar-foreground:         #25273a;
+	--sidebar-primary:            #1e66f5;
+	--sidebar-primary-foreground: #eff1f5;
+	--sidebar-accent:             #e6eaf4;
+	--sidebar-accent-foreground:  #25273a;
+	--sidebar-ring:               #1e66f5;
+}
+
+/* ── Dracula / Alucard ── */
+:root[data-style-theme="dracula"] {
+	/* Dark */
+	--background:                 #282a36;
+	--foreground:                 #f1f0eb;
+	--card:                       #353748;
+	--card-foreground:            #f1f0eb;
+	--popover:                    #3f4253;
+	--popover-foreground:         #f1f0eb;
+	--primary:                    #bd93f9;
+	--primary-foreground:         #282a36;
+	--secondary:                  #3e4052;
+	--secondary-foreground:       #f1f0eb;
+	--muted:                      #3e4052;
+	--muted-foreground:           #9ba3b6;
+	--accent:                     #3e4052;
+	--accent-foreground:          #f1f0eb;
+	--border:                     oklch(1 0 0 / 10%);
+	--input:                      oklch(1 0 0 / 6%);
+	--ring:                       #bd93f9;
+	--sidebar:                    #22232d;
+	--sidebar-foreground:         #f1f0eb;
+	--sidebar-primary:            #bd93f9;
+	--sidebar-primary-foreground: #282a36;
+	--sidebar-accent:             #3e4052;
+	--sidebar-accent-foreground:  #f1f0eb;
+	--sidebar-ring:               #bd93f9;
+}
+:root[data-style-theme="dracula"][data-theme="light"] {
+	color-scheme: light;
+	/* Light */
+	--background:                 #fffbeb;
+	--foreground:                 #2f2e2e;
+	--card:                       #fcf8e8;
+	--card-foreground:            #2f2e2e;
+	--popover:                    #fffeee;
+	--popover-foreground:         #2f2e2e;
+	--primary:                    #644ac9;
+	--primary-foreground:         #fffbeb;
+	--secondary:                  #f7f4e4;
+	--secondary-foreground:       #2f2e2e;
+	--muted:                      #f7f4e4;
+	--muted-foreground:           #726d5a;
+	--accent:                     #f7f4e4;
+	--accent-foreground:          #2f2e2e;
+	--border:                     oklch(0 0 0 / 10%);
+	--input:                      oklch(0 0 0 / 6%);
+	--ring:                       #644ac9;
+	--sidebar:                    #fffef6;
+	--sidebar-foreground:         #2f2e2e;
+	--sidebar-primary:            #644ac9;
+	--sidebar-primary-foreground: #fffbeb;
+	--sidebar-accent:             #f7f4e4;
+	--sidebar-accent-foreground:  #2f2e2e;
+	--sidebar-ring:               #644ac9;
+}
+
+/* ── Tokyo Night (Storm / Day) ── */
+:root[data-style-theme="tokyo-night"] {
+	/* Dark */
+	--background:                 #24283b;
+	--foreground:                 #e7edff;
+	--card:                       #323647;
+	--card-foreground:            #e7edff;
+	--popover:                    #3c4152;
+	--popover-foreground:         #e7edff;
+	--primary:                    #7aa2f7;
+	--primary-foreground:         #24283b;
+	--secondary:                  #3b3f50;
+	--secondary-foreground:       #e7edff;
+	--muted:                      #3b3f50;
+	--muted-foreground:           #9b9fb4;
+	--accent:                     #3b3f50;
+	--accent-foreground:          #e7edff;
+	--border:                     oklch(1 0 0 / 8%);
+	--input:                      oklch(1 0 0 / 5%);
+	--ring:                       #7aa2f7;
+	--sidebar:                    #1e2131;
+	--sidebar-foreground:         #e7edff;
+	--sidebar-primary:            #7aa2f7;
+	--sidebar-primary-foreground: #24283b;
+	--sidebar-accent:             #3b3f50;
+	--sidebar-accent-foreground:  #e7edff;
+	--sidebar-ring:               #7aa2f7;
+}
+:root[data-style-theme="tokyo-night"][data-theme="light"] {
+	color-scheme: light;
+	/* Light */
+	--background:                 #e1e2e7;
+	--foreground:                 #151d2e;
+	--card:                       #dedfe5;
+	--card-foreground:            #151d2e;
+	--popover:                    #e5e6eb;
+	--popover-foreground:         #151d2e;
+	--primary:                    #2e7de9;
+	--primary-foreground:         #e1e2e7;
+	--secondary:                  #d6daed;
+	--secondary-foreground:       #151d2e;
+	--muted:                      #d6daed;
+	--muted-foreground:           #585e70;
+	--accent:                     #d6daed;
+	--accent-foreground:          #151d2e;
+	--border:                     oklch(0 0 0 / 10%);
+	--input:                      oklch(0 0 0 / 6%);
+	--ring:                       #2e7de9;
+	--sidebar:                    #e5e6ea;
+	--sidebar-foreground:         #151d2e;
+	--sidebar-primary:            #2e7de9;
+	--sidebar-primary-foreground: #e1e2e7;
+	--sidebar-accent:             #d6daed;
+	--sidebar-accent-foreground:  #151d2e;
+	--sidebar-ring:               #2e7de9;
+}
+
+/* ── Rosé Pine (Main / Dawn) ── */
+:root[data-style-theme="rose-pine"] {
+	/* Dark */
+	--background:                 #191724;
+	--foreground:                 #d8d7ec;
+	--card:                       #252434;
+	--card-foreground:            #d8d7ec;
+	--popover:                    #2f2e3e;
+	--popover-foreground:         #d8d7ec;
+	--primary:                    #c4a7e7;
+	--primary-foreground:         #191724;
+	--secondary:                  #2e2c3d;
+	--secondary-foreground:       #d8d7ec;
+	--muted:                      #2e2c3d;
+	--muted-foreground:           #918fa3;
+	--accent:                     #2e2c3d;
+	--accent-foreground:          #d8d7ec;
+	--border:                     oklch(1 0 0 / 8%);
+	--input:                      oklch(1 0 0 / 5%);
+	--ring:                       #c4a7e7;
+	--sidebar:                    #13101a;
+	--sidebar-foreground:         #d8d7ec;
+	--sidebar-primary:            #c4a7e7;
+	--sidebar-primary-foreground: #191724;
+	--sidebar-accent:             #2e2c3d;
+	--sidebar-accent-foreground:  #d8d7ec;
+	--sidebar-ring:               #c4a7e7;
+}
+:root[data-style-theme="rose-pine"][data-theme="light"] {
+	color-scheme: light;
+	/* Light */
+	--background:                 #faf4ed;
+	--foreground:                 #2b283c;
+	--card:                       #f9f0e8;
+	--card-foreground:            #2b283c;
+	--popover:                    #fef8f1;
+	--popover-foreground:         #2b283c;
+	--primary:                    #907aa9;
+	--primary-foreground:         #faf4ed;
+	--secondary:                  #f1eceb;
+	--secondary-foreground:       #2b283c;
+	--muted:                      #f1eceb;
+	--muted-foreground:           #6a687b;
+	--accent:                     #f1eceb;
+	--accent-foreground:          #2b283c;
+	--border:                     oklch(0 0 0 / 10%);
+	--input:                      oklch(0 0 0 / 6%);
+	--ring:                       #907aa9;
+	--sidebar:                    #fdf8f1;
+	--sidebar-foreground:         #2b283c;
+	--sidebar-primary:            #907aa9;
+	--sidebar-primary-foreground: #faf4ed;
+	--sidebar-accent:             #f1eceb;
+	--sidebar-accent-foreground:  #2b283c;
+	--sidebar-ring:               #907aa9;
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -348,6 +348,7 @@
 	--radius-command-palette: 12px;
 	--radius-command-item: 6px;
 	--shadow-command-palette: var(--elevation-xl);
+	--shadow-popover: var(--elevation-xl);
 	--size-command-palette: 720px;
 	--size-command-palette-top: 14vh;
 	--size-command-palette-list-max: 420px;
@@ -709,6 +710,7 @@
 	--color-text-command-placeholder: var(--muted-foreground);
 	--color-text-command-muted: var(--muted-foreground);
 	--shadow-command-palette: var(--elevation-xl);
+	--shadow-popover: var(--elevation-xl);
 
 	/* Welcome / import radius alias */
 	--color-border-welcome-panel: var(--border);


### PR DESCRIPTION
## What

Foundational frontend PR — everything that follows in the revamp chain builds on this layer.

**Design token layer rewrite (`tokens.css`)**
- Rewrites `frontend/src/styles/tokens.css` (~840 lines) with a complete `oklch` colour scale: new values for `--background`, `--card`, `--popover`, `--input`, `--sidebar`, settings-row/dialog backgrounds in both light and dark themes.
- Every removed custom property has a replacement; no tokens are dropped without a new binding.
- All new shadcn aliases (`secondary`, `muted`, `input`, `ring`, `destructive`, `primary`, `card`, `interactive-hover`) are defined in both light/dark and across all four style themes.

**Updated status palette**
Old: working=orange `#f59f4c`, needs-you=amber `#e8c14a`, mergeable=green `#74b98a`.
New: working=blue `#60a5fa`, needs-you=orange `#fb923c`, in-review=yellow `#facc15`, ready/mergeable=green `#4ade80`. DESIGN.md updated.

**Geist variable font**
- Adds `@fontsource-variable/geist` and `@fontsource-variable/geist-mono` to `package.json`.
- Imports both in `styles.css` and sets `--font-sans`/`--font-mono` accordingly.

**shadcn `ui/*` primitives** (12 files)
`badge`, `button`, `card`, `command`, `dialog`, `dropdown-menu`, `input`, `popover`, `select`, `sheet`, `switch`, `tabs`, `tooltip` — updated to use the new token aliases. Sizes stay on the control-token system (`h-control-form`, `size-control-form`, `size-control-md`). Shadows use `--shadow-popover` (backed by `--elevation-xl`).

**Platform fork fix (Win/Linux vs macOS topbar)**
Linux was incorrectly taking the macOS path in `hidesShellTopbar()` — it got no ShellTopbar and a 6px mac inset that masked y=0 panel content (board title clipped). DESIGN.md's 2026-06-12 divergence always specified Win/Linux as the ShellTopbar path; this restores that.

Visible consequence for Linux users: board New task / Orchestrator / notification bell **move from the panel body into the ShellTopbar** (matching Windows). This is the correct Win/Linux behavior per DESIGN.md, not a side-effect. `usesBoardActionsInPanel()` returns false on Linux as a result.

**Sidebar collapse animation**
`center-panel-shell` and `center-panel-surface` transition padding, border-color, and border-radius to flush/0 when `.sidebar-hidden` is applied (macOS only).

**Dev fixture cleanup**
Removes `dev-board-fixtures.ts` and all references from `useWorkspaceQuery` and `useSessionScmSummary`.

## What this PR does NOT contain
- No `ReverbTopbar` wiring (that's a separate PR in the chain)
- No structural/layout changes (sidebar, inspector, board layout come in later PRs)

## Part of
This is PR 3 in a sequential revamp chain. PRs 4–8 are drafted and stack on top of this.