### PR TITLE
feat(landing): add agent comparison pages

### DIFF
--- a/frontend/src/landing/content/compare/ao-vs-agentsmesh.mdx
+++ b/frontend/src/landing/content/compare/ao-vs-agentsmesh.mdx
@@ -1,0 +1,48 @@
+---
+title: "Agent Orchestrator vs AgentsMesh"
+description: "Compare AO and AgentsMesh for local agent orchestration, distributed runners, worktree isolation, and team workflows."
+date: "2026-08-01"
+lastUpdated: "2026-08-01"
+type: "1v1"
+competitors:
+  - "Agent Orchestrator"
+  - "AgentsMesh"
+keywords:
+  - "Agent Orchestrator vs AgentsMesh"
+  - "AgentsMesh alternative"
+  - "local coding agents"
+  - "distributed agent orchestration"
+---
+
+## Short answer
+
+Choose **Agent Orchestrator (AO)** when you want a lightweight, local-first desktop and CLI that orchestrates existing coding-agent tools without requiring a hosted control plane. Choose **AgentsMesh** when a team needs distributed runners, browser access, shared channels, and remote agent workstations.
+
+Both products support multiple coding agents and Git worktree isolation. [AgentsMesh documents a cloud control plane connected to self-hosted runners](https://agentsmesh.ai/docs); [AO keeps its daemon and application state local](https://aoagents.dev/docs/).
+
+## At a glance
+
+| Area | Agent Orchestrator | AgentsMesh |
+| --- | --- | --- |
+| Primary workflow | Local issue-to-PR agent supervision | Distributed team and AgentPod coordination |
+| Control plane | Local loopback daemon and desktop supervisor | Web control plane with runner and relay infrastructure |
+| Isolation | Local worktree or clone plugins | Sandboxed AgentPods with optional Git worktrees |
+| Collaboration | Tracker, SCM, notifier, and session plugins | Organizations, teams, channels, tickets, and pod bindings |
+| Feedback loop | CI and review events can wake the owning agent | Ticket and pod coordination through the platform |
+| Best fit | Individual developers and local-first project fleets | Teams operating agents across machines and cloud VMs |
+
+## Why choose Agent Orchestrator
+
+AO has a smaller operational footprint for developers who already have repositories and agent CLIs on their machine. It does not require an organization, hosted dashboard, relay cluster, or registered runner to start useful work. The desktop app supervises a loopback daemon, while `ao` provides the local automation boundary.
+
+AO is also purpose-built around the software-delivery loop: tracker issue, isolated session, branch, pull request, checks, review feedback, merge, and cleanup. That makes it a stronger fit when shipping reviewed code is the goal and distributed team infrastructure is unnecessary.
+
+## Frequently Asked Questions
+
+### Do AO and AgentsMesh both keep model credentials under user control?
+
+Yes. AO uses the credentials of installed agent CLIs directly, while AgentsMesh documents a bring-your-own-key model with encrypted credentials.
+
+### What is AO's main advantage over AgentsMesh?
+
+AO offers a simpler local-first path with no required hosted control plane and a focused issue-to-PR automation loop for existing developer machines.

--- a/frontend/src/landing/content/compare/ao-vs-conductor.mdx
+++ b/frontend/src/landing/content/compare/ao-vs-conductor.mdx
@@ -1,0 +1,48 @@
+---
+title: "Agent Orchestrator vs Conductor"
+description: "Compare AO and Conductor for running parallel coding agents in isolated Git worktrees."
+date: "2026-08-01"
+lastUpdated: "2026-08-01"
+type: "1v1"
+competitors:
+  - "Agent Orchestrator"
+  - "Conductor"
+keywords:
+  - "Agent Orchestrator vs Conductor"
+  - "Conductor alternative"
+  - "parallel coding agents"
+  - "Git worktree orchestration"
+---
+
+## Short answer
+
+Choose **Agent Orchestrator (AO)** when you want agents tracked from issue assignment through pull request, CI, review, and merge. Choose **Conductor** when you want a polished Mac workspace centered on starting local agent sessions, chatting, and reviewing their changes.
+
+Both products isolate work with Git worktrees. [Conductor documents a separate branch and working tree for each workspace](https://www.conductor.build/docs/concepts/parallel-agents); [AO tracks each isolated session until it becomes a pull request](https://aoagents.dev/docs/).
+
+## At a glance
+
+| Area | Agent Orchestrator | Conductor |
+| --- | --- | --- |
+| Primary workflow | Issue → agent → PR → CI/review loop → merge | Workspace → agent chat → diff/review |
+| Agent isolation | Worktree or clone workspace plugins | Git worktree per workspace |
+| Feedback automation | Routes CI failures and review comments back to the owning agent | Focused on interactive workspace and review flows |
+| Integrations | Replaceable tracker, SCM, runtime, workspace, notifier, and terminal plugins | Integrated desktop workflow |
+| Platforms | macOS, Windows, and Linux | Mac-focused desktop app |
+| API usage | Uses your installed agent CLIs and credentials directly | Uses configured agent credentials directly |
+
+## Why choose Agent Orchestrator
+
+AO treats the pull request lifecycle as part of orchestration, not as an activity after the agent stops. It derives session attention from durable agent, PR, CI, and review facts, then can wake the session that owns a branch when checks fail or reviewers request changes.
+
+That makes AO a stronger fit when you have a backlog of independent issues and want the system to keep work moving without manually copying feedback between GitHub and agent chats. Its plugin boundaries also let one workflow span different agent CLIs, trackers, SCM providers, runtimes, workspaces, terminals, and notification channels.
+
+## Frequently Asked Questions
+
+### Do AO and Conductor both prevent agents from editing the same checkout?
+
+Yes. Both use separate Git worktrees and branches so concurrently running agents do not share one working directory.
+
+### What is AO's main advantage over Conductor?
+
+AO's main advantage is lifecycle automation: tracker context, pull-request state, CI failures, and review feedback remain attached to the session that owns the work.

--- a/frontend/src/landing/content/compare/ao-vs-emdash.mdx
+++ b/frontend/src/landing/content/compare/ao-vs-emdash.mdx
@@ -1,0 +1,48 @@
+---
+title: "Agent Orchestrator vs Emdash"
+description: "Compare AO and Emdash for parallel coding agents, worktree isolation, task tracking, and review automation."
+date: "2026-08-01"
+lastUpdated: "2026-08-01"
+type: "1v1"
+competitors:
+  - "Agent Orchestrator"
+  - "Emdash"
+keywords:
+  - "Agent Orchestrator vs Emdash"
+  - "Emdash alternative"
+  - "parallel coding agents"
+  - "agent task orchestration"
+---
+
+## Short answer
+
+Choose **Agent Orchestrator (AO)** when you want a configurable orchestration layer that keeps tracker, agent, pull-request, CI, and review state connected. Choose **Emdash** when you want an agentic development environment with local and remote workspaces, previews, and environment provisioning.
+
+Both products create isolated branches and worktrees per task. [Emdash documents its task and worktree lifecycle](https://emdash.ai/docs/tasks); [AO documents an issue-to-merge workflow with automated CI and review loops](https://aoagents.dev/docs/).
+
+## At a glance
+
+| Area | Agent Orchestrator | Emdash |
+| --- | --- | --- |
+| Primary workflow | Tracker issue → session → PR lifecycle | Task → agent workspace → review and merge |
+| Isolation | Worktree or clone plugins | Worktree per task, with an opt-out |
+| External feedback | Reactions route CI failures and review comments to the owning session | PR checks and review tools in the development environment |
+| Remote execution | Runtime and workspace adapters | Remote SSH and provisioned environments |
+| Configuration | Per-project YAML and replaceable plugin slots | App-centered project and task configuration |
+| Platforms | macOS, Windows, and Linux | macOS, Windows, and Linux |
+
+## Why choose Agent Orchestrator
+
+AO is strongest when you want one operational model across projects and providers. Trackers, SCMs, agents, runtimes, workspaces, terminals, and notifiers are separate plugin slots, so teams can change one integration without replacing the whole orchestration workflow.
+
+AO also keeps attention on what happens after code generation. A failed check or requested change is associated with the correct branch and session, allowing the responsible agent to resume with the relevant feedback.
+
+## Frequently Asked Questions
+
+### Do AO and Emdash both support parallel worktrees?
+
+Yes. Both isolate concurrent tasks with separate Git branches and worktrees by default.
+
+### What is AO's main advantage over Emdash?
+
+AO provides a more explicitly modular orchestration boundary and centers durable tracker-to-PR automation, including automatic CI and review feedback routing.

--- a/frontend/src/landing/content/compare/ao-vs-superset.mdx
+++ b/frontend/src/landing/content/compare/ao-vs-superset.mdx
@@ -1,0 +1,48 @@
+---
+title: "Agent Orchestrator vs Superset"
+description: "Compare AO and Superset for managing parallel CLI coding agents across isolated Git worktrees."
+date: "2026-08-01"
+lastUpdated: "2026-08-01"
+type: "1v1"
+competitors:
+  - "Agent Orchestrator"
+  - "Superset"
+keywords:
+  - "Agent Orchestrator vs Superset"
+  - "Superset alternative"
+  - "parallel coding agents"
+  - "open source agent orchestration"
+---
+
+## Short answer
+
+Choose **Agent Orchestrator (AO)** when the unit of work is an issue that must reach a reviewed, passing pull request. Choose **Superset** when you want an open-source agent workspace with an integrated editor, terminal, browser, and diff experience.
+
+Both products run CLI agents in isolated worktrees. [Superset describes itself as an open-source AI coding platform](https://docs.superset.sh/overview); [AO is a local orchestration layer that tracks agents through PR completion](https://aoagents.dev/docs/).
+
+## At a glance
+
+| Area | Agent Orchestrator | Superset |
+| --- | --- | --- |
+| Primary workflow | Issue and PR lifecycle orchestration | Interactive coding-agent workspace |
+| Agent isolation | Worktree or clone workspace plugins | Git worktrees |
+| Review loop | CI and review feedback can return to the owning agent automatically | Built-in diff and commit workflow |
+| Extensibility | Plugin slots for agents, trackers, SCMs, runtimes, workspaces, notifiers, and terminals | CLI-agent integrations, MCP, and workspace tooling |
+| Interface | Desktop supervisor plus local `ao` CLI | Desktop workspace with editor, terminal, browser, and diffs |
+| Cost model | Free, open source, BYO agent credentials | Open source, BYO agent credentials |
+
+## Why choose Agent Orchestrator
+
+AO is stronger when supervising work matters more than editing inside the orchestrator. Sessions are connected to tracker items, branches, pull requests, checks, and reviews. Reactions can notify or re-engage the correct agent when external state changes.
+
+This creates a consistent issue-to-merge workflow even when projects use different agent CLIs or infrastructure. AO's thin desktop supervisor and local CLI sit above those tools rather than trying to become the code editor itself.
+
+## Frequently Asked Questions
+
+### Are AO and Superset both open source?
+
+Yes. Both are open-source desktop tools that use your own coding-agent access rather than proxying model calls.
+
+### What is AO's main advantage over Superset?
+
+AO focuses on durable issue, session, PR, CI, and review state, including automatic feedback routing after an agent opens a pull request.

--- a/frontend/src/landing/src/app/compare/[slug]/page.tsx
+++ b/frontend/src/landing/src/app/compare/[slug]/page.tsx
@@ -1,0 +1,95 @@
+import { COMPANY } from "@ao/shared/constants";
+import type { Metadata } from "next";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import { notFound } from "next/navigation";
+import remarkGfm from "remark-gfm";
+import {
+	ComparisonJsonLd,
+	FAQPageJsonLd,
+} from "@/components/JsonLd";
+import { docsMdxComponents } from "@/app/docs/components/mdx";
+import {
+	formatCompareDate,
+	getAllComparisonSlugs,
+	getComparisonPage,
+} from "@/lib/compare";
+import { extractComparisonFaqItems } from "@/lib/compare-utils";
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+	return getAllComparisonSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+	params,
+}: {
+	params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+	const { slug } = await params;
+	const page = getComparisonPage(slug);
+	if (!page) return { title: "Comparison not found" };
+
+	return {
+		title: page.title,
+		description: page.description,
+		keywords: page.keywords,
+		alternates: { canonical: page.url },
+		openGraph: {
+			title: page.title,
+			description: page.description,
+			url: page.url,
+			images: [page.image ?? "/og-image.png"],
+		},
+	};
+}
+
+export default async function ComparisonPage({
+	params,
+}: {
+	params: Promise<{ slug: string }>;
+}) {
+	const { slug } = await params;
+	const page = getComparisonPage(slug);
+	if (!page) notFound();
+
+	const url = `${COMPANY.MARKETING_URL}${page.url}`;
+	const faqItems = extractComparisonFaqItems(page.content);
+
+	return (
+		<main className="min-h-screen bg-background">
+			<ComparisonJsonLd
+				title={page.title}
+				description={page.description}
+				publishedTime={page.date}
+				modifiedTime={page.lastUpdated}
+				url={url}
+				image={page.image}
+				keywords={page.keywords}
+				articleSection="Comparisons"
+			/>
+			{faqItems.length > 0 && <FAQPageJsonLd items={faqItems} />}
+
+			<header className="mx-auto max-w-4xl px-6 pt-16 pb-10 md:pt-20">
+				<p className="text-sm text-muted-foreground">Comparison</p>
+				<h1 className="mt-4 text-balance text-3xl font-medium tracking-[-0.5px] text-foreground md:text-5xl">
+					{page.title}
+				</h1>
+				<p className="mt-4 max-w-3xl text-pretty text-lg text-muted-foreground">
+					{page.description}
+				</p>
+				<p className="mt-4 text-sm text-muted-foreground">
+					Updated {formatCompareDate(page.lastUpdated ?? page.date)}
+				</p>
+			</header>
+
+			<article className="prose prose-invert mx-auto max-w-4xl px-6 pb-20 text-foreground prose-headings:text-balance prose-headings:font-medium prose-headings:text-foreground prose-p:text-pretty prose-p:text-muted-foreground prose-li:text-muted-foreground prose-strong:text-foreground prose-a:text-foreground prose-a:underline prose-a:underline-offset-4 prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none prose-pre:border prose-pre:border-border prose-pre:bg-muted/35 prose-th:text-foreground prose-td:text-muted-foreground">
+				<MDXRemote
+					source={page.content}
+					components={docsMdxComponents}
+					options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
+				/>
+			</article>
+		</main>
+	);
+}

--- a/frontend/src/landing/src/app/llms-full.txt/route.ts
+++ b/frontend/src/landing/src/app/llms-full.txt/route.ts
@@ -1,5 +1,4 @@
 import { COMPANY } from "@ao/shared/constants";
-import { getBlogPosts } from "@/lib/blog";
 import { getComparisonPages } from "@/lib/compare";
 import {
 	buildDeveloperResourcesSection,
@@ -13,7 +12,6 @@ import { FAQ_ITEMS } from "../components/FAQSection/constants";
 export const dynamic = "force-static";
 
 export async function GET() {
-	const posts = getBlogPosts();
 	const comparisons = getComparisonPages();
 	const baseUrl = COMPANY.MARKETING_URL;
 
@@ -44,28 +42,6 @@ export async function GET() {
 					`URL: ${baseUrl}/compare/${page.slug}/`,
 					"",
 					stripMdxSyntax(page.content),
-					"",
-				]),
-			].join("\n"),
-		);
-	}
-
-	// Blog posts - full content
-	if (posts.length > 0) {
-		sections.push(
-			[
-				"---",
-				"",
-				"# Blog Posts",
-				"",
-				...posts.flatMap((post) => [
-					`## ${post.title}`,
-					"",
-					`URL: ${baseUrl}/blog/${post.slug}/`,
-					`Date: ${post.date}`,
-					`Author: ${post.author.name}`,
-					"",
-					stripMdxSyntax(post.content),
 					"",
 				]),
 			].join("\n"),

--- a/frontend/src/landing/src/components/JsonLd/JsonLd.tsx
+++ b/frontend/src/landing/src/components/JsonLd/JsonLd.tsx
@@ -3,6 +3,8 @@ import { COMPANY } from "@ao/shared/constants";
 const ORGANIZATION_ID = `${COMPANY.MARKETING_URL}/#organization`;
 const WEBSITE_ID = `${COMPANY.MARKETING_URL}/#website`;
 const SOFTWARE_ID = `${COMPANY.MARKETING_URL}/#software`;
+const PRODUCT_DESCRIPTION =
+	"Open-source desktop application and local CLI (ao) to run 10+ parallel AI coding agents in isolated Git worktrees without file conflicts or API proxying.";
 
 function serializeJsonLd(schema: unknown): string {
 	const json = JSON.stringify(schema);
@@ -42,7 +44,7 @@ export function OrganizationJsonLd() {
 		name: COMPANY.NAME,
 		url: COMPANY.MARKETING_URL,
 		logo: `${COMPANY.MARKETING_URL}/ao-logo.svg`,
-		description: "Run 10+ parallel coding agents on your machine",
+		description: PRODUCT_DESCRIPTION,
 		email: supportEmail,
 		contactPoint: {
 			"@type": "ContactPoint",
@@ -84,7 +86,7 @@ export function SoftwareApplicationJsonLd() {
 			price: "0",
 			priceCurrency: "USD",
 		},
-		description: "Run 10+ parallel coding agents on your machine",
+		description: PRODUCT_DESCRIPTION,
 		url: COMPANY.MARKETING_URL,
 	};
 
@@ -227,7 +229,7 @@ export function HomeWebPageJsonLd() {
 		"@type": "WebPage",
 		"@id": COMPANY.MARKETING_URL,
 		url: COMPANY.MARKETING_URL,
-		name: `${COMPANY.NAME}, Run 10+ parallel coding agents on your machine`,
+		name: `${COMPANY.NAME}, ${PRODUCT_DESCRIPTION}`,
 		isPartOf: {
 			"@type": "WebSite",
 			"@id": WEBSITE_ID,

--- a/frontend/src/landing/src/lib/llms.ts
+++ b/frontend/src/landing/src/lib/llms.ts
@@ -1,6 +1,5 @@
 import { COMPANY } from "@ao/shared/constants";
 import { FAQ_ITEMS } from "@/app/components/FAQSection/constants";
-import { getBlogPosts } from "./blog";
 import { getComparisonPages } from "./compare";
 import { getDocPage, getDocsNav, type DocsNavItem } from "./docs";
 
@@ -22,7 +21,7 @@ export function buildLlmsHeader(): string[] {
 	return [
 		`# ${COMPANY.NAME}`,
 		"",
-		"> Run 10+ parallel coding agents on your machine",
+		"> Open-source desktop application and local CLI (`ao`) to run 10+ parallel AI coding agents in isolated Git worktrees without file conflicts or API proxying.",
 		"",
 		`${COMPANY.NAME} is an open-source desktop application that lets developers run multiple AI coding agents in parallel, each in its own isolated Git worktree. It works with any CLI-based agent including Claude Code, OpenCode, and OpenAI Codex. Agents can work on different branches or features simultaneously without conflicts. ${COMPANY.NAME} is free, does not proxy API calls, and supports macOS, Windows, and Linux.`,
 	];
@@ -124,7 +123,6 @@ export function buildDocumentationSection(): string[] {
 }
 
 export function buildLlmsTxt(): string {
-	const posts = getBlogPosts();
 	const comparisons = getComparisonPages();
 	const baseUrl = COMPANY.MARKETING_URL;
 
@@ -136,10 +134,6 @@ export function buildLlmsTxt(): string {
 		...buildDeveloperResourcesSection({ includeDocumentationLinks: false }),
 		"",
 		...buildDocumentationSection(),
-		"",
-		"## Blog",
-		"",
-		...posts.map((post) => `- [${post.title}](${baseUrl}/blog/${post.slug}/)`),
 		"",
 		"## Comparisons",
 		"",


### PR DESCRIPTION
## Summary

- add static MDX comparison pages for Conductor, Superset, Emdash, and AgentsMesh
- render comparison metadata and FAQ structured data
- list comparisons in llms.txt and llms-full.txt while removing their embedded Blog sections
- update the AO product description across LLM output and JSON-LD
- run focused landing tests in the Pages workflow

## Validation

- npm test in frontend/src/landing - 8 tests passed
- npm exec tsc -- --noEmit in frontend/src/landing
- npm run frontend:typecheck
- production static export generated all four comparison routes in local verification