### PR TITLE
fix(codex): preserve Windows PATH precedence during binary resolution

### DIFF
--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -231,13 +231,25 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 			}
 		}
 
-		for _, name := range []string{"codex.cmd", "codex", "codex.exe"} {
-			path, err := exec.LookPath(name)
-			if err == nil && path != "" {
-				if isWindowsAppsCodexExecutable(path) {
-					continue
+		resolveWindowsCandidate := func(candidate string) (string, bool) {
+			path, err := exec.LookPath(candidate)
+			if err != nil || path == "" {
+				return "", false
+			}
+			if isWindowsAppsCodexExecutable(path) {
+				return "", false
+			}
+			return resolveNativeWindowsCodex(path), true
+		}
+
+		for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+			if dir == "" {
+				continue
+			}
+			for _, name := range []string{"codex.exe", "codex", "codex.cmd"} {
+				if path, ok := resolveWindowsCandidate(filepath.Join(dir, name)); ok {
+					return path, nil
 				}
-				return resolveNativeWindowsCodex(path), nil
 			}
 			if err := ctx.Err(); err != nil {
 				return "", err

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -203,6 +203,43 @@ func TestResolveCodexBinaryPrefersNPMOverWindowsAppsExecutable(t *testing.T) {
 	}
 }
 
+func TestResolveCodexBinaryPrefersEarlierPathExeOverLaterCmd(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows resolver only")
+	}
+
+	root := t.TempDir()
+	firstDir := filepath.Join(root, "first")
+	secondDir := filepath.Join(root, "second")
+	if err := os.MkdirAll(firstDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(secondDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(firstDir, "codex.exe")
+	if err := os.WriteFile(want, []byte("native codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shim := filepath.Join(secondDir, "codex.cmd")
+	if err := os.WriteFile(shim, []byte("@echo off\r\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("APPDATA", "")
+	t.Setenv("PATH", strings.Join([]string{firstDir, secondDir}, string(os.PathListSeparator)))
+	t.Setenv("USERPROFILE", filepath.Join(root, "profile"))
+
+	got, err := ResolveCodexBinary(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveCodexBinary: %v", err)
+	}
+	if got != want {
+		t.Fatalf("ResolveCodexBinary = %q, want %q", got, want)
+	}
+}
+
 func TestGetLaunchCommandMapsApprovalModes(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## What

Fix Windows Codex binary resolution so PATH directory order is preserved when both `codex.exe` and `codex.cmd` exist.

## Why

Addresses #3409.

The previous implementation searched by filename across the entire PATH (`codex.cmd`, `codex`, then `codex.exe`), allowing a later `codex.cmd` shim to be selected before an earlier native `codex.exe`.

## How

- Replace the Windows filename-first PATH search with a directory-first PATH scan.
- Check `codex.exe`, `codex`, then `codex.cmd` within each PATH directory.
- Continue using `resolveNativeWindowsCodex()` so a shim is upgraded to a nearby native executable when available.
- Preserve existing WindowsApps filtering.
- Add a regression test covering an earlier PATH `codex.exe` and a later PATH `codex.cmd`.

## Testing

Validated locally with:

```bash
cd backend
go test ./internal/adapters/agent/codex
```

## Checklist

- [x] One focused change
- [x] Added a regression test
- [x] Local tests pass