### PR TITLE
fix(session-manager): include install hint in tmux prerequisite error

### DIFF
--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -3316,9 +3316,23 @@ func (m *Manager) validateRuntimePrerequisites() error {
 		return nil
 	}
 	if path, err := m.lookPath("tmux"); err != nil || path == "" {
-		return fmt.Errorf("%w: tmux required on macOS/Linux but not in PATH", ports.ErrRuntimePrerequisite)
+		return fmt.Errorf("%w: tmux required on macOS/Linux but not in PATH — install it: %s", ports.ErrRuntimePrerequisite, tmuxInstallHint(runtime.GOOS))
 	}
 	return nil
+}
+
+// tmuxInstallHint returns the package-manager command to install tmux on the
+// current platform. Included in the prerequisite-missing error so users get an
+// actionable instruction instead of a bare "not in PATH" message.
+func tmuxInstallHint(goos string) string {
+	switch goos {
+	case "darwin":
+		return "brew install tmux"
+	case "linux":
+		return "sudo apt install tmux  # Debian/Ubuntu — or: dnf install tmux (Fedora) / pacman -S tmux (Arch)"
+	default:
+		return "install tmux via your package manager"
+	}
 }
 
 func (m *Manager) superviseAgentProcess(agent ports.Agent, id domain.SessionID, env map[string]string, argv []string) ([]string, string, error) {


### PR DESCRIPTION
Fixes #3434

## Summary

When tmux is not installed and a user tries to spawn a session, the error message previously gave no guidance on how to fix it:

```
runtime: prerequisite missing: tmux required on macOS/Linux but not in PATH
```

Now includes a platform-specific install command:

```
runtime: prerequisite missing: tmux required on macOS/Linux but not in PATH — install it: brew install tmux
```

Added a `tmuxInstallHint(goos string)` helper that returns the correct package-manager command per platform:
- **macOS:** `brew install tmux`
- **Linux:** `sudo apt install tmux` (with dnf/pacman alternatives noted)
- **Other:** generic fallback

## Scope

This PR addresses **Layer 1** (actionable error message) from issue #3434. Layers 2 (proactive startup check) and 3 (frontend error UX) are left for follow-up since they require broader changes.

## Test

```bash
cd backend && go build ./... && go test ./internal/session_manager/ ./internal/service/session/ -count=1
```

Existing test at `manager_test.go` verifies the error still wraps `ports.ErrRuntimePrerequisite` and contains "tmux required" — both still pass with the enhanced message.
