### PR TITLE
docs(landing): link full LLM resources

### DIFF
--- a/frontend/src/landing/src/app/llms-full.txt/route.ts
+++ b/frontend/src/landing/src/app/llms-full.txt/route.ts
@@ -14,6 +14,7 @@ export const dynamic = "force-static";
 export async function GET() {
 	const comparisons = getComparisonPages();
 	const baseUrl = COMPANY.MARKETING_URL;
+	const docsUrl = COMPANY.DOCS_URL;
 
 	const sections: string[] = [];
 
@@ -25,6 +26,18 @@ export async function GET() {
 			...buildWhenToUseSection(),
 			"",
 			...buildDeveloperResourcesSection(),
+		].join("\n"),
+	);
+
+	sections.push(
+		[
+			"---",
+			"",
+			"# Documentation",
+			"",
+			`- **[Documentation overview](${docsUrl}/index.html.md)**`,
+			`- **[Quickstart guide](${docsUrl}/quickstart/index.html.md)**`,
+			`- **[Command-line interface (CLI) reference](${docsUrl}/cli/index.html.md)**`,
 		].join("\n"),
 	);
 

--- a/frontend/src/landing/src/lib/llms.ts
+++ b/frontend/src/landing/src/lib/llms.ts
@@ -132,6 +132,7 @@ export function buildLlmsTxt(): string {
 		...buildWhenToUseSection({ referenceDocumentationSection: true }),
 		"",
 		...buildDeveloperResourcesSection({ includeDocumentationLinks: false }),
+		`- [Full LLM context](${baseUrl}/llms-full.txt): combined AO overview, developer resources, comparisons, and FAQ`,
 		"",
 		...buildDocumentationSection(),
 		"",


### PR DESCRIPTION
## Summary

- add full-content Markdown-twin links for the documentation overview, Quickstart, and CLI to llms-full.txt
- link llms-full.txt from the Developer resources section in llms.txt
- keep documentation content in its generated Markdown twins instead of duplicating it

## Validation

- focused LLM-link assertions
- npm exec tsc -- --noEmit in frontend/src/landing
- independent code review: ready to merge, no Critical or Important findings

Closes #3439