### PR TITLE
feat: choose project default branch before initial orchestrator spawn

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/commands.go
+++ b/backend/internal/adapters/workspace/gitworktree/commands.go
@@ -129,16 +129,33 @@ func ignoredCountArgs(worktree string) []string {
 }
 
 func baseRefCandidates(branch, defaultBranch string) []string {
-	candidates := []string{"origin/" + branch}
-	if strings.Contains(defaultBranch, "/") {
-		// A qualified default ("upstream/main") is used verbatim; git's refname
-		// disambiguation already falls back to refs/heads/<defaultBranch>.
-		candidates = append(candidates, defaultBranch)
-	} else {
-		// The local head comes after origin/<defaultBranch> so remote-tracking
-		// still wins when present, but a remoteless repo can base new branches
-		// on its local default branch instead of failing BRANCH_NOT_FETCHED.
-		candidates = append(candidates, "origin/"+defaultBranch, "refs/heads/"+defaultBranch)
+	seen := make(map[string]struct{})
+	var candidates []string
+	add := func(ref string) {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			return
+		}
+		if _, ok := seen[ref]; !ok {
+			seen[ref] = struct{}{}
+			candidates = append(candidates, ref)
+		}
 	}
-	return append(candidates, branch)
+
+	add("origin/" + branch)
+	defaultBranch = strings.TrimSpace(defaultBranch)
+	if defaultBranch != "" {
+		if strings.HasPrefix(defaultBranch, "refs/") {
+			add(defaultBranch)
+		} else if strings.HasPrefix(defaultBranch, "origin/") {
+			add(defaultBranch)
+			add("refs/heads/" + strings.TrimPrefix(defaultBranch, "origin/"))
+		} else {
+			add("origin/" + defaultBranch)
+			add("refs/heads/" + defaultBranch)
+			add(defaultBranch)
+		}
+	}
+	add(branch)
+	return candidates
 }

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -53,15 +53,27 @@ func TestCommandArgs(t *testing.T) {
 
 func TestBaseRefCandidates(t *testing.T) {
 	got := baseRefCandidates("feature/test", "main")
-	want := []string{"origin/feature/test", "origin/main", "refs/heads/main", "feature/test"}
+	want := []string{"origin/feature/test", "origin/main", "refs/heads/main", "main", "feature/test"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("candidates = %#v, want %#v", got, want)
 	}
 
-	got = baseRefCandidates("feature/test", "upstream/main")
-	want = []string{"origin/feature/test", "upstream/main", "feature/test"}
+	got = baseRefCandidates("feature/test", "release/2026")
+	want = []string{"origin/feature/test", "origin/release/2026", "refs/heads/release/2026", "release/2026", "feature/test"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("qualified candidates = %#v, want %#v", got, want)
+		t.Fatalf("slash candidates = %#v, want %#v", got, want)
+	}
+
+	got = baseRefCandidates("feature/test", "upstream/main")
+	want = []string{"origin/feature/test", "origin/upstream/main", "refs/heads/upstream/main", "upstream/main", "feature/test"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("non-origin remote candidates = %#v, want %#v", got, want)
+	}
+
+	got = baseRefCandidates("feature/test", "origin/release/2026")
+	want = []string{"origin/feature/test", "origin/release/2026", "refs/heads/release/2026", "feature/test"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("origin slash candidates = %#v, want %#v", got, want)
 	}
 }
 
@@ -1041,6 +1053,92 @@ func TestAddWorktreeReportsBranchNotFetched(t *testing.T) {
 	_, err = ws.Create(context.Background(), ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/missing"})
 	if !errors.Is(err, ports.ErrWorkspaceBranchNotFetched) {
 		t.Fatalf("err = %v, want ports.ErrWorkspaceBranchNotFetched", err)
+	}
+}
+
+func TestCreateSpawnsWorktreeFromRemoteOnlySlashBranch(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "init", repo).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repo, "config", "user.email", "test@example.com").CombinedOutput(); err != nil {
+		t.Fatalf("git config user.email: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repo, "config", "user.name", "Test").CombinedOutput(); err != nil {
+		t.Fatalf("git config user.name: %v (%s)", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# demo"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repo, "add", ".").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repo, "commit", "-m", "init").CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repo, "update-ref", "refs/remotes/origin/release/2026", "HEAD").CombinedOutput(); err != nil {
+		t.Fatalf("git update-ref: %v (%s)", err, out)
+	}
+
+	ws, err := New(Options{ManagedRoot: root, DefaultBranch: "release/2026", RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	info, err := ws.Create(context.Background(), ports.WorkspaceConfig{
+		ProjectID: "proj",
+		SessionID: "sess-1",
+		Branch:    "ao/work",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if info.Path == "" {
+		t.Fatalf("workspace path is empty")
+	}
+}
+
+func TestCreateSpawnsWorktreeFromNonOriginRemoteQualifiedBranch(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "init", repo).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repo, "config", "user.email", "test@example.com").CombinedOutput(); err != nil {
+		t.Fatalf("git config user.email: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repo, "config", "user.name", "Test").CombinedOutput(); err != nil {
+		t.Fatalf("git config user.name: %v (%s)", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# demo"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repo, "add", ".").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repo, "commit", "-m", "init").CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repo, "update-ref", "refs/remotes/upstream/main", "HEAD").CombinedOutput(); err != nil {
+		t.Fatalf("git update-ref: %v (%s)", err, out)
+	}
+
+	ws, err := New(Options{ManagedRoot: root, DefaultBranch: "upstream/main", RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	info, err := ws.Create(context.Background(), ports.WorkspaceConfig{
+		ProjectID: "proj",
+		SessionID: "sess-1",
+		Branch:    "ao/work",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if info.Path == "" {
+		t.Fatalf("workspace path is empty")
 	}
 }
 

--- a/backend/internal/domain/projectconfig.go
+++ b/backend/internal/domain/projectconfig.go
@@ -139,6 +139,9 @@ func (c ProjectConfig) Validate() error {
 	if err := c.AgentConfig.Validate(); err != nil {
 		return err
 	}
+	if err := validateCanonicalBranchName("defaultBranch", c.DefaultBranch); err != nil {
+		return err
+	}
 	if err := validateNameComponent("sessionPrefix", c.SessionPrefix); err != nil {
 		return err
 	}
@@ -165,6 +168,23 @@ func (c ProjectConfig) Validate() error {
 	}
 	if err := c.TrackerIntake.Validate(); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateCanonicalBranchName(name, value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	if trimmed != value {
+		return fmt.Errorf("%s: must not have leading or trailing whitespace", name)
+	}
+	if strings.HasPrefix(value, "refs/") || strings.HasPrefix(value, "origin/") || value == "HEAD" {
+		return fmt.Errorf("%s: must be a canonical short branch name, not a qualified ref or HEAD", name)
+	}
+	if strings.ContainsAny(value, " \t\n\r~^:?*[\\]") || strings.Contains(value, "..") || strings.Contains(value, "@{") {
+		return fmt.Errorf("%s: contains invalid branch characters", name)
 	}
 	return nil
 }

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -930,6 +930,37 @@ paths:
       summary: Replace a project's per-project config
       tags:
       - projects
+  /api/v1/projects/discover-branches:
+    post:
+      operationId: discoverProjectBranches
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DiscoverBranchesRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BranchDiscoverResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+      summary: Discover repository branch choices and optionally refresh origin remote
+      tags:
+      - projects
   /api/v1/projects/initialize:
     post:
       operationId: initializeProjectRepository
@@ -2596,6 +2627,24 @@ components:
       - id
       - label
       type: object
+    BranchDiscoverResult:
+      properties:
+        branches:
+          items:
+            type: string
+          type: array
+        canRefreshOrigin:
+          type: boolean
+        defaultBranch:
+          type: string
+        hasOrigin:
+          type: boolean
+      required:
+      - defaultBranch
+      - branches
+      - hasOrigin
+      - canRefreshOrigin
+      type: object
     BrowserCommandRequest:
       properties:
         action:
@@ -2890,6 +2939,15 @@ components:
           $ref: '#/components/schemas/DevImportProjectsReport'
       required:
       - report
+      type: object
+    DiscoverBranchesRequest:
+      properties:
+        path:
+          type: string
+        refreshOrigin:
+          type: boolean
+      required:
+      - path
       type: object
     DomainActivity:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -259,6 +259,8 @@ var schemaNames = map[string]string{
 	"ProjectSetConfigInput":             "SetProjectConfigInput",
 	"ProjectUpdateSettingsInput":        "UpdateProjectSettingsInput",
 	"ProjectWorkspaceRepo":              "WorkspaceRepo",
+	"ProjectBranchDiscoverResult":       "BranchDiscoverResult",
+	"ControllersDiscoverBranchesRequest": "DiscoverBranchesRequest",
 	"SessionWorkspaceFileStatus":        "WorkspaceFileStatus",
 }
 
@@ -742,6 +744,16 @@ func projectOperations() []operation {
 				{http.StatusOK, projectsvc.InitializeRepositoryResult{}},
 				{http.StatusBadRequest, envelope.APIError{}},
 				{http.StatusConflict, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodPost, path: "/api/v1/projects/discover-branches", id: "discoverProjectBranches", tag: "projects",
+			summary: "Discover repository branch choices and optionally refresh origin remote",
+			reqBody: controllers.DiscoverBranchesRequest{},
+			resps: []respUnit{
+				{http.StatusOK, projectsvc.BranchDiscoverResult{}},
+				{http.StatusBadRequest, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},
 			},
 		}, {

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -43,6 +43,15 @@ type ProjectResponse struct {
 	Project projectsvc.Project `json:"project"`
 }
 
+// DiscoverBranchesRequest is the body of POST /api/v1/projects/discover-branches.
+type DiscoverBranchesRequest struct {
+	Path          string `json:"path"`
+	RefreshOrigin bool   `json:"refreshOrigin,omitempty"`
+}
+
+// DiscoverBranchesResponse is the body of POST /api/v1/projects/discover-branches.
+type DiscoverBranchesResponse = projectsvc.BranchDiscoverResult
+
 // GetProjectResponse is the { status, project } body of GET /projects/{id},
 // where project is oneOf Project|Degraded discriminated by status.
 type GetProjectResponse struct {

--- a/backend/internal/httpd/controllers/projects.go
+++ b/backend/internal/httpd/controllers/projects.go
@@ -27,6 +27,7 @@ func (c *ProjectsController) Register(r chi.Router) {
 	r.Get("/projects", c.list)
 	r.Post("/projects", c.add)
 	r.Post("/projects/initialize", c.initialize)
+	r.Post("/projects/discover-branches", c.discoverBranches)
 	r.Get("/projects/{id}", c.get)
 	r.Put("/projects/{id}", c.updateSettings)
 	r.Put("/projects/{id}/config", c.setConfig)
@@ -83,6 +84,35 @@ func (c *ProjectsController) initialize(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	envelope.WriteJSON(w, http.StatusOK, result)
+}
+
+func (c *ProjectsController) discoverBranches(w http.ResponseWriter, r *http.Request) {
+	if c.Mgr == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/projects/discover-branches")
+		return
+	}
+	var req DiscoverBranchesRequest
+	if err := decodeJSONStrict(r, &req); err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	discoverer, ok := c.Mgr.(projectsvc.BranchDiscoverer)
+	if !ok {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/projects/discover-branches")
+		return
+	}
+	var res projectsvc.BranchDiscoverResult
+	var err error
+	if req.RefreshOrigin {
+		res, err = discoverer.DiscoverBranchesAndRefreshOrigin(r.Context(), req.Path)
+	} else {
+		res, err = discoverer.DiscoverBranches(r.Context(), req.Path)
+	}
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, res)
 }
 func (c *ProjectsController) get(w http.ResponseWriter, r *http.Request) {
 	if c.Mgr == nil {

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -319,6 +319,42 @@ func TestProjectsAPI_InitializeRepository(t *testing.T) {
 	body, status, _ = doRequest(t, srv, "POST", "/api/v1/projects/initialize", `{"path":`+quote(committed)+`}`)
 	assertErrorCode(t, body, status, http.StatusConflict, "PROJECT_ALREADY_INITIALIZED")
 }
+
+func TestProjectsAPI_DiscoverBranches(t *testing.T) {
+	srv := newTestServer(t)
+
+	repo := gitRepo(t, "discover-repo")
+	if out, err := exec.Command("git", "-C", repo, "branch", "feature/login").CombinedOutput(); err != nil {
+		t.Fatalf("git branch: %v (%s)", err, out)
+	}
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/projects/discover-branches", `{"path":`+quote(repo)+`}`)
+	if status != http.StatusOK {
+		t.Fatalf("POST discover-branches = %d, want 200; body=%s", status, body)
+	}
+	var res struct {
+		DefaultBranch    string   `json:"defaultBranch"`
+		Branches         []string `json:"branches"`
+		HasOrigin        bool     `json:"hasOrigin"`
+		CanRefreshOrigin bool     `json:"canRefreshOrigin"`
+	}
+	mustJSON(t, []byte(body), &res)
+
+	if res.DefaultBranch != "main" {
+		t.Errorf("defaultBranch = %q, want main", res.DefaultBranch)
+	}
+	if res.HasOrigin || res.CanRefreshOrigin {
+		t.Errorf("hasOrigin/canRefreshOrigin = %v/%v, want false", res.HasOrigin, res.CanRefreshOrigin)
+	}
+	if len(res.Branches) != 2 || res.Branches[0] != "feature/login" || res.Branches[1] != "main" {
+		t.Errorf("branches = %v, want [feature/login, main]", res.Branches)
+	}
+
+	// Refreshing origin on repo with no origin returns 400 ORIGIN_NOT_CONFIGURED.
+	body, status, _ = doRequest(t, srv, "POST", "/api/v1/projects/discover-branches", `{"path":`+quote(repo)+`,"refreshOrigin":true}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "ORIGIN_NOT_CONFIGURED")
+}
+
 func TestProjectsAPI_Delete(t *testing.T) {
 
 	srv := newTestServer(t)

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -248,7 +249,14 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 	// `master` (or any non-`main` default) falls back to DefaultBranchName and
 	// every spawn fails BRANCH_NOT_FETCHED. Only persist when it diverges from
 	// the default, so the common `main` repo keeps an empty (NULL) config.
-	if row.Config.DefaultBranch == "" {
+	if row.Config.DefaultBranch != "" {
+		if !branchExists(ctx, path, row.Config.DefaultBranch) {
+			return Project{}, apierr.Invalid("INVALID_DEFAULT_BRANCH", fmt.Sprintf("Default branch %q does not exist in repository", row.Config.DefaultBranch), map[string]any{
+				"branch": row.Config.DefaultBranch,
+				"path":   path,
+			})
+		}
+	} else {
 		if branch := resolveDefaultBranch(path); branch != "" && branch != domain.DefaultBranchName {
 			row.Config.DefaultBranch = branch
 		}
@@ -672,6 +680,19 @@ func resolveDefaultBranch(path string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+func branchExists(ctx context.Context, repoPath, branch string) bool {
+	candidates := []string{
+		"refs/heads/" + branch,
+		"refs/remotes/origin/" + branch,
+	}
+	for _, ref := range candidates {
+		if _, err := aoprocess.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--verify", "--quiet", ref).Output(); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // Remove stops live project sessions, reclaims safe managed workspaces, then

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -47,6 +48,20 @@ type Manager interface {
 	// Remove unregisters a project, stopping its sessions and reclaiming
 	// managed workspaces.
 	Remove(ctx context.Context, id domain.ProjectID) (RemoveResult, error)
+}
+
+// BranchDiscoverResult carries branch discovery results for project creation.
+type BranchDiscoverResult struct {
+	DefaultBranch    string   `json:"defaultBranch"`
+	Branches         []string `json:"branches"`
+	HasOrigin        bool     `json:"hasOrigin"`
+	CanRefreshOrigin bool     `json:"canRefreshOrigin"`
+}
+
+// BranchDiscoverer contract for discovering and refreshing repository branches.
+type BranchDiscoverer interface {
+	DiscoverBranches(ctx context.Context, path string) (BranchDiscoverResult, error)
+	DiscoverBranchesAndRefreshOrigin(ctx context.Context, path string) (BranchDiscoverResult, error)
 }
 
 // SessionTeardowner is the narrow session-service surface project removal
@@ -693,6 +708,89 @@ func branchExists(ctx context.Context, repoPath, branch string) bool {
 		}
 	}
 	return false
+}
+
+// DiscoverBranches scans local and remote branches in the repository at path without performing any network fetch.
+func (m *Service) DiscoverBranches(ctx context.Context, repoPath string) (BranchDiscoverResult, error) {
+	path, err := normalizePath(repoPath)
+	if err != nil {
+		return BranchDiscoverResult{}, err
+	}
+	if !isGitRepo(path) {
+		return BranchDiscoverResult{}, apierr.Invalid("NOT_A_GIT_REPO", "Selected path is not a Git repository", map[string]any{"path": path})
+	}
+	return m.discoverBranchesInternal(ctx, path)
+}
+
+// DiscoverBranchesAndRefreshOrigin explicitly fetches `origin` remote, then discovers local and remote branches.
+func (m *Service) DiscoverBranchesAndRefreshOrigin(ctx context.Context, repoPath string) (BranchDiscoverResult, error) {
+	path, err := normalizePath(repoPath)
+	if err != nil {
+		return BranchDiscoverResult{}, err
+	}
+	if !isGitRepo(path) {
+		return BranchDiscoverResult{}, apierr.Invalid("NOT_A_GIT_REPO", "Selected path is not a Git repository", map[string]any{"path": path})
+	}
+	hasOrigin := resolveGitOriginURL(path) != ""
+	if !hasOrigin {
+		return BranchDiscoverResult{}, apierr.Invalid("ORIGIN_NOT_CONFIGURED", "Repository has no origin remote configured to refresh", map[string]any{"path": path})
+	}
+
+	if out, err := aoprocess.CommandContext(ctx, "git", "-C", path, "fetch", "origin").CombinedOutput(); err != nil {
+		return BranchDiscoverResult{}, apierr.Invalid("ORIGIN_FETCH_FAILED", fmt.Sprintf("Failed to fetch origin remote: %s", strings.TrimSpace(string(out))), map[string]any{
+			"path":  path,
+			"error": strings.TrimSpace(string(out)),
+		})
+	}
+
+	return m.discoverBranchesInternal(ctx, path)
+}
+
+func (m *Service) discoverBranchesInternal(ctx context.Context, path string) (BranchDiscoverResult, error) {
+	defaultBranch := resolveDefaultBranch(path)
+	if defaultBranch == "" {
+		defaultBranch = domain.DefaultBranchName
+	}
+	branchesSet := make(map[string]struct{})
+
+	if out, err := aoprocess.CommandContext(ctx, "git", "-C", path, "for-each-ref", "--format=%(refname:short)", "refs/heads").Output(); err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			if trimmed := strings.TrimSpace(line); trimmed != "" {
+				branchesSet[trimmed] = struct{}{}
+			}
+		}
+	}
+
+	if out, err := aoprocess.CommandContext(ctx, "git", "-C", path, "for-each-ref", "--format=%(refname:short)", "refs/remotes/origin").Output(); err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || trimmed == "origin" || trimmed == "origin/HEAD" {
+				continue
+			}
+			shortBranch := strings.TrimPrefix(trimmed, "origin/")
+			if shortBranch != "" && shortBranch != "HEAD" && shortBranch != "origin" {
+				branchesSet[shortBranch] = struct{}{}
+			}
+		}
+	}
+
+	if defaultBranch != "" && defaultBranch != "HEAD" {
+		branchesSet[defaultBranch] = struct{}{}
+	}
+
+	branches := make([]string, 0, len(branchesSet))
+	for b := range branchesSet {
+		branches = append(branches, b)
+	}
+	sort.Strings(branches)
+
+	hasOrigin := resolveGitOriginURL(path) != ""
+	return BranchDiscoverResult{
+		DefaultBranch:    defaultBranch,
+		Branches:         branches,
+		HasOrigin:        hasOrigin,
+		CanRefreshOrigin: hasOrigin,
+	}, nil
 }
 
 // Remove stops live project sessions, reclaims safe managed workspaces, then

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -553,6 +553,85 @@ func TestManager_AddPrefersOriginHeadNonMain(t *testing.T) {
 	}
 }
 
+func TestManager_DiscoverBranches(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+
+	t.Run("read-only discovery without origin", func(t *testing.T) {
+		repo := gitRepoOnBranch(t, "main")
+		if out, err := exec.Command("git", "-C", repo, "branch", "feature/local-1").CombinedOutput(); err != nil {
+			t.Fatalf("git branch: %v (%s)", err, out)
+		}
+
+		discoverer, ok := m.(project.BranchDiscoverer)
+		if !ok {
+			t.Fatal("Manager does not implement BranchDiscoverer")
+		}
+
+		res, err := discoverer.DiscoverBranches(ctx, repo)
+		if err != nil {
+			t.Fatalf("DiscoverBranches: %v", err)
+		}
+
+		if res.DefaultBranch != "main" {
+			t.Errorf("DefaultBranch = %q, want main", res.DefaultBranch)
+		}
+		if res.HasOrigin || res.CanRefreshOrigin {
+			t.Errorf("HasOrigin/CanRefreshOrigin = %v/%v, want false", res.HasOrigin, res.CanRefreshOrigin)
+		}
+		wantBranches := []string{"feature/local-1", "main"}
+		if len(res.Branches) != len(wantBranches) || res.Branches[0] != wantBranches[0] || res.Branches[1] != wantBranches[1] {
+			t.Errorf("Branches = %v, want %v", res.Branches, wantBranches)
+		}
+	})
+
+	t.Run("discovery with origin and remote branches", func(t *testing.T) {
+		repo := gitRepoWithOriginHead(t, "main", "dev")
+		if out, err := exec.Command("git", "-C", repo, "remote", "add", "origin", "https://example.com/repo.git").CombinedOutput(); err != nil {
+			t.Fatalf("git remote add: %v (%s)", err, out)
+		}
+		if out, err := exec.Command("git", "-C", repo, "update-ref", "refs/remotes/origin/release/v1", "HEAD").CombinedOutput(); err != nil {
+			t.Fatalf("git update-ref: %v (%s)", err, out)
+		}
+
+		discoverer := m.(project.BranchDiscoverer)
+		res, err := discoverer.DiscoverBranches(ctx, repo)
+		if err != nil {
+			t.Fatalf("DiscoverBranches: %v", err)
+		}
+
+		if !res.HasOrigin || !res.CanRefreshOrigin {
+			t.Errorf("HasOrigin/CanRefreshOrigin = %v/%v, want true", res.HasOrigin, res.CanRefreshOrigin)
+		}
+		wantBranches := []string{"dev", "main", "release/v1"}
+		if len(res.Branches) != len(wantBranches) {
+			t.Fatalf("Branches = %v, want %v", res.Branches, wantBranches)
+		}
+		for i, b := range wantBranches {
+			if res.Branches[i] != b {
+				t.Errorf("Branches[%d] = %q, want %q", i, res.Branches[i], b)
+			}
+		}
+	})
+
+	t.Run("refresh origin fails when no origin configured", func(t *testing.T) {
+		repo := gitRepo(t)
+		discoverer := m.(project.BranchDiscoverer)
+		_, err := discoverer.DiscoverBranchesAndRefreshOrigin(ctx, repo)
+		wantCode(t, err, "ORIGIN_NOT_CONFIGURED")
+	})
+
+	t.Run("refresh origin error on network/remote failure", func(t *testing.T) {
+		repo := gitRepo(t)
+		if out, err := exec.Command("git", "-C", repo, "remote", "add", "origin", "https://invalid.example.com/nonexistent.git").CombinedOutput(); err != nil {
+			t.Fatalf("git remote add: %v (%s)", err, out)
+		}
+		discoverer := m.(project.BranchDiscoverer)
+		_, err := discoverer.DiscoverBranchesAndRefreshOrigin(ctx, repo)
+		wantCode(t, err, "ORIGIN_FETCH_FAILED")
+	})
+}
+
 func TestManager_UpdateSettings(t *testing.T) {
 	ctx := context.Background()
 	m := newManager(t)

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -502,8 +502,8 @@ func TestManager_AddDetectsNonMainDefaultBranch(t *testing.T) {
 		t.Fatalf("Get DefaultBranch = %#v, want master", got.Project)
 	}
 
-	// An explicit config wins over detection.
-	mainRepo := gitRepoOnBranch(t, "trunk")
+	// An explicit config wins over detection when the branch exists in the repository.
+	mainRepo := gitRepoOnBranch(t, "release")
 	proj2, err := m.Add(ctx, project.AddInput{
 		Path:      mainRepo,
 		ProjectID: ptr("ao2"),
@@ -624,7 +624,7 @@ func TestManager_UpdateSettings(t *testing.T) {
 func TestManager_ListIncludesOnlySummarySafeProjectConfig(t *testing.T) {
 	ctx := context.Background()
 	m := newManager(t)
-	repo := gitRepo(t)
+	repo := gitRepoOnBranch(t, "develop")
 
 	cfg := domain.ProjectConfig{
 		DefaultBranch: "develop",
@@ -1435,3 +1435,64 @@ func TestManager_AddWorkspaceRejectsBareParent(t *testing.T) {
 	_, err := m.Add(ctx, project.AddInput{Path: bareParent, ProjectID: ptr("bare"), AsWorkspace: true})
 	wantCode(t, err, "WORKSPACE_PARENT_BARE")
 }
+
+func TestManager_AddValidatesExplicitDefaultBranch(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	repo := gitRepoOnBranch(t, "main")
+
+	// Create local branch "feature/demo" in repo.
+	if out, err := exec.Command("git", "-C", repo, "branch", "feature/demo").CombinedOutput(); err != nil {
+		t.Fatalf("git branch feature/demo: %v (%s)", err, out)
+	}
+
+	// 1. Valid existing branch succeeds and sets DefaultBranch.
+	proj, err := m.Add(ctx, project.AddInput{
+		Path:      repo,
+		ProjectID: ptr("p1"),
+		Config:    &domain.ProjectConfig{DefaultBranch: "feature/demo"},
+	})
+	if err != nil {
+		t.Fatalf("Add with existing branch feature/demo failed: %v", err)
+	}
+	if proj.DefaultBranch != "feature/demo" {
+		t.Fatalf("DefaultBranch = %q, want feature/demo", proj.DefaultBranch)
+	}
+
+	// 2. Non-existent branch is rejected with INVALID_DEFAULT_BRANCH and no project is stored.
+	repo2 := gitRepoOnBranch(t, "main")
+	_, err = m.Add(ctx, project.AddInput{
+		Path:      repo2,
+		ProjectID: ptr("p2"),
+		Config:    &domain.ProjectConfig{DefaultBranch: "nonexistent-branch"},
+	})
+	wantCode(t, err, "INVALID_DEFAULT_BRANCH")
+
+	list, err := m.List(ctx)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	for _, p := range list {
+		if p.ID == "p2" {
+			t.Fatalf("Project p2 was stored despite invalid default branch error")
+		}
+	}
+
+	// 4. Remote-only branch containing a slash (e.g., release/2026) validates and sets DefaultBranch.
+	repo3 := gitRepoOnBranch(t, "main")
+	if out, err := exec.Command("git", "-C", repo3, "update-ref", "refs/remotes/origin/release/2026", "HEAD").CombinedOutput(); err != nil {
+		t.Fatalf("git update-ref refs/remotes/origin/release/2026: %v (%s)", err, out)
+	}
+	proj3, err := m.Add(ctx, project.AddInput{
+		Path:      repo3,
+		ProjectID: ptr("p4"),
+		Config:    &domain.ProjectConfig{DefaultBranch: "release/2026"},
+	})
+	if err != nil {
+		t.Fatalf("Add with remote-only slash branch failed: %v", err)
+	}
+	if proj3.DefaultBranch != "release/2026" {
+		t.Fatalf("DefaultBranch = %q, want release/2026", proj3.DefaultBranch)
+	}
+}
+

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -366,6 +366,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/projects/discover-branches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Discover repository branch choices and optionally refresh origin remote */
+        post: operations["discoverProjectBranches"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/projects/initialize": {
         parameters: {
             query?: never;
@@ -883,6 +900,12 @@ export interface components {
             id: string;
             label: string;
         };
+        BranchDiscoverResult: {
+            branches: string[];
+            canRefreshOrigin: boolean;
+            defaultBranch: string;
+            hasOrigin: boolean;
+        };
         BrowserCommandRequest: {
             action: string;
             args?: {
@@ -989,6 +1012,10 @@ export interface components {
         };
         DevImportProjectsResponse: {
             report: components["schemas"]["DevImportProjectsReport"];
+        };
+        DiscoverBranchesRequest: {
+            path: string;
+            refreshOrigin?: boolean;
         };
         DomainActivity: {
             /** Format: date-time */
@@ -2786,6 +2813,48 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    discoverProjectBranches: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DiscoverBranchesRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BranchDiscoverResult"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/main/import-folder-scan.test.ts
+++ b/frontend/src/main/import-folder-scan.test.ts
@@ -63,10 +63,13 @@ describe("scanImportFolder", () => {
 		expect(scan.setupWarning).toContain("AO will initialize this folder as a separate repository.");
 	});
 
-	it("reports a true project repository root as importable", async () => {
+	it("reports a true project repository root as importable with discovered branches", async () => {
 		const root = await tempDir();
 		const repo = path.join(root, "repo");
 		await committedRepo(repo);
+		await git(["branch", "feature/login"], repo);
+		await git(["update-ref", "refs/remotes/origin/main", "HEAD"], repo);
+		await git(["update-ref", "refs/remotes/origin/dev", "HEAD"], repo);
 
 		const scan = await scanImportFolder(repo, "project");
 
@@ -76,6 +79,7 @@ describe("scanImportFolder", () => {
 				path: repo,
 				relativePath: ".",
 				branch: "main",
+				branches: ["dev", "feature/login", "main"],
 				hasRemote: true,
 				status: "ok",
 			}),

--- a/frontend/src/main/import-folder-scan.ts
+++ b/frontend/src/main/import-folder-scan.ts
@@ -11,6 +11,7 @@ export type GitRepoScanResult = {
 	path: string;
 	relativePath: string;
 	branch: string;
+	branches?: string[];
 	remote: string;
 	hasRemote: boolean;
 	status: "ok" | "error";
@@ -123,6 +124,57 @@ async function resolveDefaultBranch(repoPath: string, options: ScanOptions = {})
 	return "HEAD";
 }
 
+export async function resolveRepoBranches(
+	repoPath: string,
+	options: ScanOptions = {},
+): Promise<{ defaultBranch: string; branches: string[] }> {
+	const defaultBranch = await resolveDefaultBranch(repoPath, options);
+	const branchesSet = new Set<string>();
+
+	try {
+		const localOutput = await gitOutput(
+			repoPath,
+			["for-each-ref", "--format=%(refname:short)", "refs/heads"],
+			options,
+		);
+		if (localOutput) {
+			for (const line of localOutput.split("\n")) {
+				const trimmed = line.trim();
+				if (trimmed) branchesSet.add(trimmed);
+			}
+		}
+	} catch {
+		// Ignore git errors
+	}
+
+	try {
+		const remoteOutput = await gitOutput(
+			repoPath,
+			["for-each-ref", "--format=%(refname:short)", "refs/remotes/origin"],
+			options,
+		);
+		if (remoteOutput) {
+			for (const line of remoteOutput.split("\n")) {
+				const trimmed = line.trim();
+				if (!trimmed || trimmed === "origin/HEAD") continue;
+				const shortBranch = trimmed.replace(/^origin\//, "");
+				if (shortBranch && shortBranch !== "HEAD") {
+					branchesSet.add(shortBranch);
+				}
+			}
+		}
+	} catch {
+		// Ignore git errors
+	}
+
+	if (defaultBranch && defaultBranch !== "HEAD") {
+		branchesSet.add(defaultBranch);
+	}
+
+	const branches = Array.from(branchesSet).sort();
+	return { defaultBranch, branches };
+}
+
 async function scanGitRepo(
 	repoPath: string,
 	rootPath: string,
@@ -164,15 +216,16 @@ async function scanGitRepo(
 		return null;
 	}
 	if (!(await isGitRepo(repoPath, options))) return null;
-	const [branchResult, remoteResult, bareResult, headResult] = await Promise.allSettled([
-		resolveDefaultBranch(repoPath, options),
+	const [branchesResult, remoteResult, bareResult, headResult] = await Promise.allSettled([
+		resolveRepoBranches(repoPath, options),
 		gitOutput(repoPath, ["remote", "get-url", "origin"], options),
 		gitOutput(repoPath, ["rev-parse", "--is-bare-repository"], options),
 		gitOutput(repoPath, ["rev-parse", "--verify", "HEAD"], options),
 	]);
+	const branchInfo = branchesResult.status === "fulfilled" ? branchesResult.value : { defaultBranch: "HEAD", branches: [] };
 	const validationReason = scanRepoValidationReason(
 		name,
-		branchResult.status === "fulfilled" && branchResult.value ? branchResult.value : "HEAD",
+		branchInfo.defaultBranch,
 		remoteResult.status === "fulfilled" && remoteResult.value.length > 0,
 		bareResult.status === "fulfilled" && bareResult.value === "true",
 		headResult.status === "fulfilled",
@@ -181,7 +234,8 @@ async function scanGitRepo(
 		name,
 		path: repoPath,
 		relativePath,
-		branch: branchResult.status === "fulfilled" && branchResult.value ? branchResult.value : "HEAD",
+		branch: branchInfo.defaultBranch,
+		branches: branchInfo.branches,
 		remote: remoteResult.status === "fulfilled" ? remoteResult.value : "",
 		hasRemote: remoteResult.status === "fulfilled" && remoteResult.value.length > 0,
 		status: validationReason ? "error" : "ok",

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -37,6 +37,7 @@ export type ImportRepoScan = {
 	path: string;
 	relativePath: string;
 	branch: string;
+	branches?: string[];
 	remote: string;
 	hasRemote: boolean;
 	status?: "ok" | "error";

--- a/frontend/src/renderer/__tests__/_shell-create-project-config.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-create-project-config.test.tsx
@@ -27,4 +27,18 @@ describe("createProjectConfig", () => {
 			trackerIntake: { enabled: true, provider: "github", assignee: "octocat" },
 		});
 	});
+
+	it("includes defaultBranch in project config when specified", () => {
+		expect(
+			createProjectConfig({
+				workerAgent: "codex",
+				orchestratorAgent: "claude-code",
+				defaultBranch: "develop",
+			}),
+		).toEqual({
+			defaultBranch: "develop",
+			worker: { agent: "codex" },
+			orchestrator: { agent: "claude-code" },
+		});
+	});
 });

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
@@ -214,4 +214,55 @@ describe("CreateProjectAgentSheet", () => {
 
 		expect(screen.queryByLabelText("Default branch")).not.toBeInTheDocument();
 	});
+
+	it("renders Refresh branches button only when origin refresh is available, triggering onRefreshBranches on click", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		queryClient.setQueryData(agentsQueryKey, {
+			supported: [{ id: "claude-code", label: "claude-code" }],
+			installed: [{ id: "claude-code", label: "claude-code", authStatus: "authorized" }],
+			authorized: [{ id: "claude-code", label: "claude-code", authStatus: "authorized" }],
+		});
+		const onRefreshBranches = vi.fn();
+		const { rerender } = render(
+			<QueryClientProvider client={queryClient}>
+				<CreateProjectAgentSheet
+					defaultBranch="main"
+					branches={["main", "develop"]}
+					canRefreshOrigin={false}
+					onRefreshBranches={onRefreshBranches}
+					isCreating={false}
+					kind="single_repo"
+					onOpenChange={() => undefined}
+					onSubmit={vi.fn()}
+					open={true}
+					path="/repo/demo"
+				/>
+			</QueryClientProvider>,
+		);
+
+		expect(screen.queryByRole("button", { name: "Refresh branches" })).not.toBeInTheDocument();
+
+		rerender(
+			<QueryClientProvider client={queryClient}>
+				<CreateProjectAgentSheet
+					defaultBranch="main"
+					branches={["main", "develop"]}
+					canRefreshOrigin={true}
+					onRefreshBranches={onRefreshBranches}
+					isCreating={false}
+					kind="single_repo"
+					onOpenChange={() => undefined}
+					onSubmit={vi.fn()}
+					open={true}
+					path="/repo/demo"
+				/>
+			</QueryClientProvider>,
+		);
+
+		const refreshButton = screen.getByRole("button", { name: "Refresh branches" });
+		expect(refreshButton).toBeInTheDocument();
+
+		await userEvent.click(refreshButton);
+		expect(onRefreshBranches).toHaveBeenCalledTimes(1);
+	});
 });

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
@@ -155,6 +155,8 @@ describe("CreateProjectAgentSheet", () => {
 
 		const trigger = screen.getByLabelText("Default branch");
 		expect(trigger).toHaveTextContent("main");
+		const infoButton = screen.getByLabelText("What is the default branch?");
+		expect(infoButton).toBeInTheDocument();
 
 		await userEvent.click(trigger);
 		expect(await screen.findByPlaceholderText("Search branches...")).toBeInTheDocument();

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
@@ -129,4 +129,89 @@ describe("CreateProjectAgentSheet", () => {
 		expect(screen.queryByText("Repository")).not.toBeInTheDocument();
 		expect(screen.queryByText(/Reads credentials from/)).not.toBeInTheDocument();
 	});
+
+	it("renders Default branch selector preselected to inferred default for single_repo, allowing search and selection", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		queryClient.setQueryData(agentsQueryKey, {
+			supported: [{ id: "claude-code", label: "claude-code" }],
+			installed: [{ id: "claude-code", label: "claude-code", authStatus: "authorized" }],
+			authorized: [{ id: "claude-code", label: "claude-code", authStatus: "authorized" }],
+		});
+		const onSubmit = vi.fn().mockResolvedValue(undefined);
+		render(
+			<QueryClientProvider client={queryClient}>
+				<CreateProjectAgentSheet
+					defaultBranch="main"
+					branches={["main", "develop", "feature/auth"]}
+					isCreating={false}
+					kind="single_repo"
+					onOpenChange={() => undefined}
+					onSubmit={onSubmit}
+					open={true}
+					path="/repo/demo"
+				/>
+			</QueryClientProvider>,
+		);
+
+		const trigger = screen.getByLabelText("Default branch");
+		expect(trigger).toHaveTextContent("main");
+
+		await userEvent.click(trigger);
+		expect(await screen.findByPlaceholderText("Search branches...")).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "develop" })).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "feature/auth" })).toBeInTheDocument();
+
+		await userEvent.type(screen.getByPlaceholderText("Search branches..."), "dev");
+		expect(screen.getByRole("option", { name: "develop" })).toBeInTheDocument();
+		expect(screen.queryByRole("option", { name: "feature/auth" })).not.toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("option", { name: "develop" }));
+		expect(trigger).toHaveTextContent("develop");
+
+		await userEvent.click(screen.getByRole("button", { name: "Create and start" }));
+		await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				defaultBranch: "develop",
+			}),
+		);
+	});
+
+	it("hides Default branch selector for workspace projects or when repository setup is needed", () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const { rerender } = render(
+			<QueryClientProvider client={queryClient}>
+				<CreateProjectAgentSheet
+					defaultBranch="main"
+					branches={["main", "develop"]}
+					isCreating={false}
+					kind="workspace"
+					onOpenChange={() => undefined}
+					onSubmit={vi.fn()}
+					open={true}
+					path="/repo/demo"
+				/>
+			</QueryClientProvider>,
+		);
+
+		expect(screen.queryByLabelText("Default branch")).not.toBeInTheDocument();
+
+		rerender(
+			<QueryClientProvider client={queryClient}>
+				<CreateProjectAgentSheet
+					defaultBranch="main"
+					branches={["main", "develop"]}
+					isCreating={false}
+					kind="single_repo"
+					repositorySetupNeeded={true}
+					onOpenChange={() => undefined}
+					onSubmit={vi.fn()}
+					open={true}
+					path="/repo/demo"
+				/>
+			</QueryClientProvider>,
+		);
+
+		expect(screen.queryByLabelText("Default branch")).not.toBeInTheDocument();
+	});
 });

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as Dialog from "@radix-ui/react-dialog";
-import { TriangleAlert, X, type LucideIcon } from "lucide-react";
+import { Check, ChevronDown, GitBranch, Search, TriangleAlert, X, type LucideIcon } from "lucide-react";
 import { memo, useEffect, useState } from "react";
 import type { components } from "../../api/schema";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
@@ -15,6 +15,7 @@ import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
 import type { ProjectKind } from "../types/workspace";
 import { Button } from "./ui/button";
 import { Label } from "./ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 
 type TrackerIntakeConfig = components["schemas"]["TrackerIntakeConfig"];
@@ -25,6 +26,7 @@ export type CreateProjectAgentSelection = {
 	workerAgent: string;
 	orchestratorAgent: string;
 	trackerIntake?: TrackerIntakeConfig;
+	defaultBranch?: string;
 };
 
 const EMPTY_INTAKE: IntakeForm = { enabled: false, repo: "", assignee: "" };
@@ -34,6 +36,8 @@ const DEFAULT_AGENT_PRIORITY_RANK = new Map<string, number>(
 );
 
 type CreateProjectAgentSheetProps = {
+	defaultBranch?: string;
+	branches?: string[];
 	error?: string | null;
 	isCreating: boolean;
 	isInitializing?: boolean;
@@ -87,6 +91,8 @@ function projectSheetError(error: string): SheetError {
 }
 
 export function CreateProjectAgentSheet({
+	defaultBranch,
+	branches,
 	error,
 	isCreating,
 	isInitializing = false,
@@ -124,6 +130,7 @@ export function CreateProjectAgentSheet({
 		: agentsError;
 	const [workerAgent, setWorkerAgent] = useState("");
 	const [orchestratorAgent, setOrchestratorAgent] = useState("");
+	const [selectedBranch, setSelectedBranch] = useState(defaultBranch ?? "");
 	const [workerAgentTouched, setWorkerAgentTouched] = useState(false);
 	const [orchestratorAgentTouched, setOrchestratorAgentTouched] = useState(false);
 	const isBusy = isCreating || isInitializing;
@@ -140,14 +147,17 @@ export function CreateProjectAgentSheet({
 	}, [agentOptions, open, orchestratorAgentTouched, workerAgentTouched]);
 
 	useEffect(() => {
-		if (!open) {
+		if (open) {
+			setSelectedBranch(defaultBranch ?? "");
+		} else {
 			setWorkerAgent("");
 			setOrchestratorAgent("");
+			setSelectedBranch("");
 			setWorkerAgentTouched(false);
 			setOrchestratorAgentTouched(false);
 			setIntake(EMPTY_INTAKE);
 		}
-	}, [open, path]);
+	}, [defaultBranch, open, path]);
 
 	return (
 		<Dialog.Root open={open} onOpenChange={(next) => !isBusy && onOpenChange(next)}>
@@ -179,7 +189,12 @@ export function CreateProjectAgentSheet({
 						onSubmit={(event) => {
 							event.preventDefault();
 							if (!canSubmit) return;
-							void onSubmit({ workerAgent, orchestratorAgent, trackerIntake: buildIntake(intake) });
+							void onSubmit({
+								workerAgent,
+								orchestratorAgent,
+								trackerIntake: buildIntake(intake),
+								defaultBranch: selectedBranch || undefined,
+							});
 						}}
 					>
 						<div className="grid gap-4 sm:grid-cols-2">
@@ -218,6 +233,17 @@ export function CreateProjectAgentSheet({
 								}}
 							/>
 						</div>
+
+						{kind === "single_repo" && !repositorySetupNeeded && (
+							<SearchableBranchSelect
+								id="newProjectDefaultBranch"
+								label="Default branch"
+								value={selectedBranch || defaultBranch || "main"}
+								branches={branches && branches.length > 0 ? branches : [defaultBranch || "main"]}
+								onChange={setSelectedBranch}
+								disabled={isBusy}
+							/>
+						)}
 
 						{isLoadingAgents && (
 							<p className="text-xs leading-row text-[var(--color-text-agents-sheet-description)]">Loading agents...</p>
@@ -465,4 +491,99 @@ export function defaultAuthorizedAgent(authorizedAgents: AgentInfo[]): string {
 	const prioritized = DEFAULT_AGENT_PRIORITY.find((agent) => authorizedIds.has(agent));
 	if (prioritized) return prioritized;
 	return [...authorizedAgents].sort(agentLabelCompare)[0]?.id ?? "";
+}
+
+export function SearchableBranchSelect({
+	branches,
+	disabled = false,
+	id,
+	label,
+	onChange,
+	value,
+}: {
+	branches: string[];
+	disabled?: boolean;
+	id: string;
+	label: string;
+	onChange: (branch: string) => void;
+	value: string;
+}) {
+	const [open, setOpen] = useState(false);
+	const [search, setSearch] = useState("");
+
+	const filteredBranches = branches.filter((b) => b.toLowerCase().includes(search.toLowerCase().trim()));
+
+	return (
+		<div className="flex flex-col gap-1.5">
+			<Label htmlFor={id} className="agents-sheet-label text-xs font-medium text-muted-foreground">
+				{label}
+			</Label>
+			<Popover open={open} onOpenChange={setOpen}>
+				<PopoverTrigger asChild disabled={disabled}>
+					<button
+						type="button"
+						id={id}
+						aria-label={label}
+						className={cn(
+							"agents-sheet-control flex h-9 w-full items-center justify-between rounded-md border border-[var(--color-border-agents-sheet)] bg-[var(--color-bg-agents-sheet-control)] px-3 text-xs text-[var(--color-text-agents-sheet-title)] outline-none transition hover:bg-interactive-hover disabled:pointer-events-none disabled:opacity-50",
+						)}
+					>
+						<span className="flex items-center gap-2 truncate">
+							<GitBranch className="size-icon-sm shrink-0 opacity-70" aria-hidden="true" />
+							<span className="truncate">{value || "Select default branch"}</span>
+						</span>
+						<ChevronDown className="size-icon-sm shrink-0 opacity-70" aria-hidden="true" />
+					</button>
+				</PopoverTrigger>
+				<PopoverContent
+					side="bottom"
+					align="start"
+					sideOffset={4}
+					className="agents-sheet-menu z-overlay w-[var(--radix-popover-trigger-width)] max-h-select-menu-max overflow-hidden rounded-lg border border-[var(--color-border-agents-sheet)] bg-[var(--color-bg-agents-sheet)] p-2 shadow-md outline-none"
+				>
+					<div className="relative mb-2">
+						<Search className="pointer-events-none absolute left-2.5 top-1/2 size-icon-sm -translate-y-1/2 text-[var(--color-text-agents-sheet-description)]" />
+						<input
+							type="text"
+							className="w-full rounded-md border border-[var(--color-border-agents-sheet)] bg-[var(--color-bg-agents-sheet-control)] py-1.5 pl-8 pr-2.5 text-xs text-[var(--color-text-agents-sheet-title)] placeholder:text-[var(--color-text-agents-sheet-description)] focus:outline-none"
+							placeholder="Search branches..."
+							aria-label="Search branches"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+						/>
+					</div>
+					<div className="max-h-40 overflow-y-auto space-y-0.5" role="listbox" aria-label="Branch list">
+						{filteredBranches.length > 0 ? (
+							filteredBranches.map((branch) => (
+								<button
+									key={branch}
+									type="button"
+									role="option"
+									aria-selected={branch === value}
+									className={cn(
+										"flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-xs text-left transition",
+										branch === value
+											? "bg-[var(--color-bg-agents-sheet-control)] font-medium text-[var(--color-text-agents-sheet-title)]"
+											: "text-[var(--color-text-agents-sheet-description)] hover:bg-interactive-hover hover:text-[var(--color-text-agents-sheet-title)]",
+									)}
+									onClick={() => {
+										onChange(branch);
+										setOpen(false);
+										setSearch("");
+									}}
+								>
+									<span className="truncate">{branch}</span>
+									{branch === value && <Check className="size-icon-sm text-accent shrink-0" aria-hidden="true" />}
+								</button>
+							))
+						) : (
+							<p className="px-2.5 py-2 text-xs text-[var(--color-text-agents-sheet-description)]">
+								No matching branches
+							</p>
+						)}
+					</div>
+				</PopoverContent>
+			</Popover>
+		</div>
+	);
 }

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as Dialog from "@radix-ui/react-dialog";
-import { Check, ChevronDown, GitBranch, Search, TriangleAlert, X, type LucideIcon } from "lucide-react";
+import { Check, ChevronDown, GitBranch, RefreshCw, Search, TriangleAlert, X, type LucideIcon } from "lucide-react";
 import { memo, useEffect, useState } from "react";
 import type { components } from "../../api/schema";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
@@ -38,6 +38,9 @@ const DEFAULT_AGENT_PRIORITY_RANK = new Map<string, number>(
 type CreateProjectAgentSheetProps = {
 	defaultBranch?: string;
 	branches?: string[];
+	canRefreshOrigin?: boolean;
+	isRefreshingBranches?: boolean;
+	onRefreshBranches?: () => void;
 	error?: string | null;
 	isCreating: boolean;
 	isInitializing?: boolean;
@@ -93,6 +96,9 @@ function projectSheetError(error: string): SheetError {
 export function CreateProjectAgentSheet({
 	defaultBranch,
 	branches,
+	canRefreshOrigin = false,
+	isRefreshingBranches = false,
+	onRefreshBranches,
 	error,
 	isCreating,
 	isInitializing = false,
@@ -133,7 +139,7 @@ export function CreateProjectAgentSheet({
 	const [selectedBranch, setSelectedBranch] = useState(defaultBranch ?? "");
 	const [workerAgentTouched, setWorkerAgentTouched] = useState(false);
 	const [orchestratorAgentTouched, setOrchestratorAgentTouched] = useState(false);
-	const isBusy = isCreating || isInitializing;
+	const isBusy = isCreating || isInitializing || isRefreshingBranches;
 	const [intake, setIntake] = useState<IntakeForm>(EMPTY_INTAKE);
 	const intakeIncomplete = intakeNeedsRule(intake);
 	const canSubmit = workerAgent !== "" && orchestratorAgent !== "" && !intakeIncomplete && !isBusy && !isLoadingAgents;
@@ -242,6 +248,9 @@ export function CreateProjectAgentSheet({
 								branches={branches && branches.length > 0 ? branches : [defaultBranch || "main"]}
 								onChange={setSelectedBranch}
 								disabled={isBusy}
+								canRefreshOrigin={canRefreshOrigin}
+								isRefreshing={isRefreshingBranches}
+								onRefresh={onRefreshBranches}
 							/>
 						)}
 
@@ -495,17 +504,23 @@ export function defaultAuthorizedAgent(authorizedAgents: AgentInfo[]): string {
 
 export function SearchableBranchSelect({
 	branches,
+	canRefreshOrigin = false,
 	disabled = false,
 	id,
+	isRefreshing = false,
 	label,
 	onChange,
+	onRefresh,
 	value,
 }: {
 	branches: string[];
+	canRefreshOrigin?: boolean;
 	disabled?: boolean;
 	id: string;
+	isRefreshing?: boolean;
 	label: string;
 	onChange: (branch: string) => void;
+	onRefresh?: () => void;
 	value: string;
 }) {
 	const [open, setOpen] = useState(false);
@@ -515,9 +530,23 @@ export function SearchableBranchSelect({
 
 	return (
 		<div className="flex flex-col gap-1.5">
-			<Label htmlFor={id} className="agents-sheet-label text-xs font-medium text-muted-foreground">
-				{label}
-			</Label>
+			<div className="flex items-center justify-between">
+				<Label htmlFor={id} className="agents-sheet-label text-xs font-medium text-muted-foreground">
+					{label}
+				</Label>
+				{canRefreshOrigin && onRefresh && (
+					<button
+						type="button"
+						aria-label="Refresh branches"
+						disabled={disabled || isRefreshing}
+						onClick={onRefresh}
+						className="flex items-center gap-1 text-xs text-[var(--color-text-agents-sheet-description)] transition hover:text-[var(--color-text-agents-sheet-title)] disabled:pointer-events-none disabled:opacity-50"
+					>
+						<RefreshCw className={cn("size-3 shrink-0", isRefreshing && "animate-spin")} aria-hidden="true" />
+						<span>{isRefreshing ? "Refreshing..." : "Refresh branches"}</span>
+					</button>
+				)}
+			</div>
 			<Popover open={open} onOpenChange={setOpen}>
 				<PopoverTrigger asChild disabled={disabled}>
 					<button

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as Dialog from "@radix-ui/react-dialog";
-import { Check, ChevronDown, GitBranch, RefreshCw, Search, TriangleAlert, X, type LucideIcon } from "lucide-react";
+import { Check, ChevronDown, GitBranch, Info, RefreshCw, Search, TriangleAlert, X, type LucideIcon } from "lucide-react";
 import { memo, useEffect, useState } from "react";
 import type { components } from "../../api/schema";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
@@ -17,6 +17,7 @@ import { Button } from "./ui/button";
 import { Label } from "./ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 
 type TrackerIntakeConfig = components["schemas"]["TrackerIntakeConfig"];
 
@@ -531,9 +532,25 @@ export function SearchableBranchSelect({
 	return (
 		<div className="flex flex-col gap-1.5">
 			<div className="flex items-center justify-between">
-				<Label htmlFor={id} className="agents-sheet-label text-xs font-medium text-muted-foreground">
-					{label}
-				</Label>
+				<div className="flex items-center gap-1.5">
+					<Label htmlFor={id} className="agents-sheet-label text-xs font-medium text-muted-foreground">
+						{label}
+					</Label>
+					<TooltipProvider delayDuration={0}>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									className="grid size-icon-base place-items-center rounded-full text-muted-foreground hover:text-foreground focus-visible:outline-none"
+									aria-label="What is the default branch?"
+								>
+									<Info className="size-3.5" aria-hidden="true" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent>Used for the first orchestrator worktree and subsequent session worktrees.</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</div>
 				{canRefreshOrigin && onRefresh && (
 					<button
 						type="button"

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -78,6 +78,7 @@ export function CreateProjectFlow({
 					setFolderPickerOpen(true);
 					return;
 				}
+				setValidationScan(preflight.scan);
 				setRepositorySetup(preflight.setupCode);
 				setRepositorySetupWarning(preflight.setupWarning);
 			}
@@ -230,6 +231,8 @@ export function CreateProjectFlow({
 				</>
 			)}
 			<CreateProjectAgentSheet
+				defaultBranch={validationScan?.repos[0]?.branch}
+				branches={validationScan?.repos[0]?.branches}
 				error={error}
 				isCreating={isCreating}
 				isInitializing={isInitializing}

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -3,6 +3,7 @@ import { CheckCircle2, ChevronRight, Folder, FolderPlus, X, XCircle } from "luci
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { ImportFolderScan } from "../../preload";
 import { aoBridge } from "../lib/bridge";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { cn } from "../lib/utils";
 import type { ProjectKind } from "../types/workspace";
 import { CreateProjectAgentSheet, type CreateProjectAgentSelection } from "./CreateProjectAgentSheet";
@@ -46,11 +47,44 @@ export function CreateProjectFlow({
 	const [isChoosingPath, setIsChoosingPath] = useState(false);
 	const [isCreating, setIsCreating] = useState(false);
 	const [isInitializing, setIsInitializing] = useState(false);
+	const [isRefreshingBranches, setIsRefreshingBranches] = useState(false);
 	const [repositorySetup, setRepositorySetup] = useState<"NOT_A_GIT_REPO" | "PROJECT_UNBORN" | null>(null);
 	const [repositorySetupWarning, setRepositorySetupWarning] = useState<string | null>(null);
 
 	const hasModePicker = mode === "choose";
-	const isBusy = isChoosingPath || isCreating || isInitializing;
+	const isBusy = isChoosingPath || isCreating || isInitializing || isRefreshingBranches;
+
+	const handleRefreshBranches = async () => {
+		if (!selectedPath || isBusy) return;
+		setIsRefreshingBranches(true);
+		setError(null);
+		try {
+			const { data, error: apiErr } = await apiClient.POST("/api/v1/projects/discover-branches", {
+				body: { path: selectedPath, refreshOrigin: true },
+			});
+			if (apiErr) {
+				setError(apiErrorMessage(apiErr, "Failed to refresh origin branches"));
+				return;
+			}
+			if (data && validationScan) {
+				const updatedRepos = validationScan.repos.map((repo, idx) =>
+					idx === 0
+						? {
+								...repo,
+								branch: data.defaultBranch || repo.branch,
+								branches: data.branches || repo.branches,
+								hasRemote: data.hasOrigin,
+							}
+						: repo,
+				);
+				setValidationScan({ ...validationScan, repos: updatedRepos });
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to refresh origin branches");
+		} finally {
+			setIsRefreshingBranches(false);
+		}
+	};
 
 	const openFolderStep = (kind: ProjectKind) => {
 		// Keep the selector mounted behind the native picker. Closing it first
@@ -233,6 +267,9 @@ export function CreateProjectFlow({
 			<CreateProjectAgentSheet
 				defaultBranch={validationScan?.repos[0]?.branch}
 				branches={validationScan?.repos[0]?.branches}
+				canRefreshOrigin={validationScan?.repos[0]?.hasRemote ?? false}
+				isRefreshingBranches={isRefreshingBranches}
+				onRefreshBranches={handleRefreshBranches}
 				error={error}
 				isCreating={isCreating}
 				isInitializing={isInitializing}

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -217,6 +217,8 @@ describe("ProjectSettingsForm", () => {
 
 		expect(await screen.findByText("git@github.com:acme/project-one.git")).toBeInTheDocument();
 		expect(screen.getByLabelText("Default branch")).toHaveValue("develop");
+		const infoButton = screen.getByLabelText("About Default branch");
+		expect(infoButton).toBeInTheDocument();
 		expect(screen.getByLabelText("Session prefix")).toHaveValue("po");
 		expect(screen.getByLabelText("Model override")).toHaveValue("claude-opus-4-5");
 

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -263,6 +263,7 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 						id="defaultBranch"
 						value={form.defaultBranch}
 						placeholder="main"
+						tooltip="Changes affect new worktrees and do not migrate an existing Canonical Orchestrator Branch."
 						onChange={(value) => setForm((f) => ({ ...f, defaultBranch: value }))}
 					/>
 					<SettingsInputRow
@@ -436,6 +437,7 @@ function SettingsInputRow({
 	value,
 	onChange,
 	placeholder,
+	tooltip,
 }: {
 	icon?: LucideIcon;
 	label: string;
@@ -443,9 +445,10 @@ function SettingsInputRow({
 	value: string;
 	onChange: (value: string) => void;
 	placeholder?: string;
+	tooltip?: string;
 }) {
 	return (
-		<SettingsRow icon={icon} label={label}>
+		<SettingsRow icon={icon} label={label} tooltip={tooltip}>
 			<input
 				id={id}
 				aria-label={label}

--- a/frontend/src/renderer/components/settings/SettingsRow.tsx
+++ b/frontend/src/renderer/components/settings/SettingsRow.tsx
@@ -1,12 +1,29 @@
-import { ChevronRight, type LucideIcon } from "lucide-react";
+import { ChevronRight, Info, type LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "../../lib/utils";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
 
-function SettingsRowLabel({ icon: Icon, label }: { icon?: LucideIcon; label: string }) {
+function SettingsRowLabel({ icon: Icon, label, tooltip }: { icon?: LucideIcon; label: string; tooltip?: string }) {
 	return (
 		<div className="flex shrink-0 items-center gap-(--size-settings-row-icon-gap)">
 			{Icon ? <Icon className="size-icon-lg shrink-0 text-settings-muted" aria-hidden="true" /> : null}
 			<span className="whitespace-nowrap text-sm leading-5 text-settings-label">{label}</span>
+			{tooltip && (
+				<TooltipProvider delayDuration={0}>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								className="grid size-icon-base place-items-center rounded-full text-settings-muted hover:text-settings-label focus-visible:outline-none"
+								aria-label={`About ${label}`}
+							>
+								<Info className="size-3.5" aria-hidden="true" />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent>{tooltip}</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			)}
 		</div>
 	);
 }
@@ -15,17 +32,19 @@ function SettingsRowLabel({ icon: Icon, label }: { icon?: LucideIcon; label: str
 export function SettingsRow({
 	icon,
 	label,
+	tooltip,
 	children,
 	className,
 }: {
 	icon?: LucideIcon;
 	label: string;
+	tooltip?: string;
 	children: ReactNode;
 	className?: string;
 }) {
 	return (
 		<div className={cn("settings-row-bar", className)}>
-			<SettingsRowLabel icon={icon} label={label} />
+			<SettingsRowLabel icon={icon} label={label} tooltip={tooltip} />
 			<div className="flex min-w-0 flex-1 items-center justify-end">{children}</div>
 		</div>
 	);

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -62,10 +62,12 @@ type CreateProjectConfigInput = {
 	workerAgent: string;
 	orchestratorAgent: string;
 	trackerIntake?: components["schemas"]["TrackerIntakeConfig"];
+	defaultBranch?: string;
 };
 
 export function createProjectConfig(input: CreateProjectConfigInput): components["schemas"]["ProjectConfig"] {
 	return {
+		...(input.defaultBranch ? { defaultBranch: input.defaultBranch } : {}),
 		worker: { agent: input.workerAgent as components["schemas"]["RoleOverride"]["agent"] },
 		orchestrator: { agent: input.orchestratorAgent as components["schemas"]["RoleOverride"]["agent"] },
 		...(input.trackerIntake ? { trackerIntake: input.trackerIntake } : {}),
@@ -227,6 +229,7 @@ function ShellLayout() {
 			workerAgent: string;
 			orchestratorAgent: string;
 			trackerIntake?: components["schemas"]["TrackerIntakeConfig"];
+			defaultBranch?: string;
 			asWorkspace?: boolean;
 		}) => {
 			void addRendererExceptionStep("Project add requested", {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"frontend:typecheck": "npm --prefix frontend run typecheck",
 		"sqlc": "cd backend && go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate",
 		"api:spec": "cd backend && go generate ./internal/httpd/apispec/...",
-		"api:ts": "openapi-typescript backend/internal/httpd/apispec/openapi.yaml -o frontend/src/api/schema.ts",
+		"api:ts": "npx openapi-typescript@7.4.4 backend/internal/httpd/apispec/openapi.yaml -o frontend/src/api/schema.ts",
 		"api": "npm run api:spec && npm run api:ts"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## What

Adds default-branch selection to project creation and persists it before the first project orchestrator is created. The flow also supports explicitly refreshing the origin branch list and clarifies when a setting change affects new worktrees only.

## Why

An orchestrator can start immediately after project creation. Previously, users could only choose the project default branch later in Settings, after the canonical orchestrator worktree had already been created from main. No related upstream issue was supplied.

## How

Threads default-branch selection through project configuration before automatic startup, resolves local and origin branch forms consistently, and exposes a refresh path for branch discovery. The change remains scoped to initial creation; it intentionally does not migrate an existing canonical orchestrator branch when the setting is changed later.

## Testing

- cd backend && go test ./...
- cd frontend && npm run test -- --run src/renderer/components/CreateProjectAgentSheet.test.tsx
- npm run frontend:typecheck

## Checklist

- [x] Branched from main (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (go, frontend, etc.)