### PR TITLE
feat(browser-panel): surface dev-server URLs detected in terminal output

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserPanel, BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { useBrowserView, type BrowserNavState } from "../hooks/useBrowserView";
+import { useUiStore } from "../stores/ui-store";
 import type { WorkspaceSession } from "../types/workspace";
 import type { BrowserAnnotationCancelPayload, BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
 
@@ -176,6 +177,7 @@ describe("BrowserPanel", () => {
 			canGoForward: false,
 			isLoading: false,
 		};
+		useUiStore.setState({ detectedUrlsBySession: {} });
 	});
 
 	it("navigates to the entered URL on submit", async () => {
@@ -373,6 +375,30 @@ describe("BrowserPanel", () => {
 		expect(await screen.findByRole("menu")).not.toHaveAttribute("data-ao-browser-native-overlay");
 		expect(screen.getByText("First app").closest('[role="menuitem"]')).toHaveClass("cursor-pointer");
 		expect(screen.getByRole("menuitem", { name: "Close tab First app" })).toHaveClass("cursor-pointer");
+	});
+
+	it("hides the detected-URLs menu when nothing has been detected", () => {
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		expect(screen.queryByRole("button", { name: /detected urls/i })).not.toBeInTheDocument();
+	});
+
+	it("lists detected URLs and navigates to the one the user picks", async () => {
+		useUiStore.getState().addDetectedUrl("sess-1", "http://localhost:3000/");
+		useUiStore.getState().addDetectedUrl("sess-1", "http://localhost:4173/");
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		await userEvent.click(screen.getByRole("button", { name: "Detected URLs (2)" }));
+		await userEvent.click(screen.getByRole("menuitem", { name: "http://localhost:4173/" }));
+
+		expect(hookState.navigate).toHaveBeenCalledWith("http://localhost:4173/");
+	});
+
+	it("scopes the detected-URLs menu to the current session", () => {
+		useUiStore.getState().addDetectedUrl("other-session", "http://localhost:9999/");
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		expect(screen.queryByRole("button", { name: /detected urls/i })).not.toBeInTheDocument();
 	});
 
 	it("disables annotation mode when no page is loaded", () => {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -15,6 +15,7 @@ import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { useBrowserView, type BrowserViewModel } from "../hooks/useBrowserView";
 import { formatBrowserAnnotationMessage, type BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
 import type { WorkspaceSession } from "../types/workspace";
+import { DetectedUrlsMenu } from "./DetectedUrlsMenu";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import {
@@ -218,6 +219,7 @@ export function BrowserPanel({ session, active, poppedOut, onTogglePopOut }: Bro
 }
 
 export function BrowserPanelView({
+	session,
 	poppedOut,
 	onTogglePopOut,
 	browserView,
@@ -442,6 +444,7 @@ export function BrowserPanelView({
 						{agentStatusLabel}
 					</span>
 				) : null}
+				<DetectedUrlsMenu onNavigate={(url) => void navigate(url)} sessionId={session.id} />
 					<div className="browser-panel__url-wrap relative min-w-0 flex-1">
 						<Globe2
 							aria-hidden="true"

--- a/frontend/src/renderer/components/DetectedUrlsMenu.tsx
+++ b/frontend/src/renderer/components/DetectedUrlsMenu.tsx
@@ -1,0 +1,54 @@
+import { Link2 } from "lucide-react";
+import { useUiStore } from "../stores/ui-store";
+import { Button } from "./ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+
+const EMPTY_URLS: string[] = [];
+
+type DetectedUrlsMenuProps = {
+	sessionId: string;
+	onNavigate: (url: string) => void;
+};
+
+// Popover off the Browser toolbar listing URLs the terminal has passively
+// printed (e.g. a dev-server address) so the user can jump to one without
+// retyping it. Hidden entirely once nothing has been detected yet.
+export function DetectedUrlsMenu({ sessionId, onNavigate }: DetectedUrlsMenuProps) {
+	const urls = useUiStore((state) => state.detectedUrlsBySession[sessionId] ?? EMPTY_URLS);
+
+	if (urls.length === 0) return null;
+
+	return (
+		<DropdownMenu modal={false}>
+			<DropdownMenuTrigger asChild>
+				<Button
+					aria-label={`Detected URLs (${urls.length})`}
+					size="icon-sm"
+					title="URLs detected in this session's terminal"
+					type="button"
+					variant="ghost"
+				>
+					<Link2 aria-hidden="true" className="size-icon-base" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-72" sideOffset={8}>
+				<DropdownMenuLabel>Detected URLs</DropdownMenuLabel>
+				{urls.map((url) => (
+					<DropdownMenuItem
+						className="cursor-pointer py-2 font-mono text-xs"
+						key={url}
+						onSelect={() => onNavigate(url)}
+					>
+						<span className="block min-w-0 truncate">{url}</span>
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession } from "../types/workspace";
+import { useUiStore } from "../stores/ui-store";
 import { TerminalPane, providerScrollsByKeyboard } from "./TerminalPane";
 
 const { postMock, terminalError, terminalState, replaySettled } = vi.hoisted(() => ({
@@ -12,6 +13,7 @@ const { postMock, terminalError, terminalState, replaySettled } = vi.hoisted(() 
 	replaySettled: { value: true },
 }));
 let terminalLinkHandler: ((uri: string) => void) | undefined;
+let terminalOutputHandler: ((text: string) => void) | undefined;
 
 vi.mock("../lib/api-client", () => ({
 	apiClient: { POST: (...args: unknown[]) => postMock(...args) },
@@ -26,12 +28,15 @@ vi.mock("./XtermTerminal", () => ({
 }));
 
 vi.mock("../hooks/useTerminalSession", () => ({
-	useTerminalSession: () => ({
-		attach: vi.fn(),
-		state: terminalState.value,
-		error: terminalError.value,
-		replaySettled: replaySettled.value,
-	}),
+	useTerminalSession: (_session: unknown, options: { onOutput?: (text: string) => void }) => {
+		terminalOutputHandler = options?.onOutput;
+		return {
+			attach: vi.fn(),
+			state: terminalState.value,
+			error: terminalError.value,
+			replaySettled: replaySettled.value,
+		};
+	},
 }));
 
 const worker = {
@@ -61,6 +66,8 @@ beforeEach(() => {
 	terminalState.value = "idle";
 	replaySettled.value = true;
 	terminalLinkHandler = undefined;
+	terminalOutputHandler = undefined;
+	useUiStore.setState({ detectedUrlsBySession: {} });
 });
 
 function renderPane(session?: WorkspaceSession) {
@@ -366,6 +373,39 @@ describe("terminal link preview", () => {
 			expect(invalidate).not.toHaveBeenCalled();
 		} finally {
 			warning.mockRestore();
+			view.restore();
+		}
+	});
+});
+
+describe("passive URL detection", () => {
+	it("retains a URL printed in a worker's terminal output", () => {
+		const view = renderPane(worker);
+		try {
+			expect(terminalOutputHandler).toBeTypeOf("function");
+			act(() => terminalOutputHandler?.("Local: http://localhost:5173/\n"));
+
+			expect(useUiStore.getState().detectedUrlsBySession["sess-1"]).toEqual(["http://localhost:5173/"]);
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("does not retain URLs without a selected session", () => {
+		const view = renderPane();
+		try {
+			expect(terminalOutputHandler).toBeUndefined();
+			expect(useUiStore.getState().detectedUrlsBySession).toEqual({});
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("does not watch output for orchestrator terminals", () => {
+		const view = renderPane(orchestrator);
+		try {
+			expect(terminalOutputHandler).toBeUndefined();
+		} finally {
 			view.restore();
 		}
 	});

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -248,8 +248,9 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 			const sessionId = session?.id;
 			if (!sessionId) return;
 			if (!urlWatcherRef.current) {
-				urlWatcherRef.current = createUrlWatcher(() => {
+				urlWatcherRef.current = createUrlWatcher((url) => {
 					const store = useUiStore.getState();
+					store.addDetectedUrl(sessionId, url);
 					const current = store.inspectorSessions[sessionId];
 					const viewingBrowser = (current?.isOpen ?? true) && (current?.view ?? "summary") === "browser";
 					if (!viewingBrowser) store.setBrowserUnseen(sessionId, true);

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -1,4 +1,52 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUiStore } from "./ui-store";
+
+describe("ui-store detectedUrlsBySession", () => {
+	beforeEach(() => {
+		useUiStore.setState({ detectedUrlsBySession: {} });
+	});
+
+	it("retains a URL detected for a session", () => {
+		useUiStore.getState().addDetectedUrl("sess-1", "http://localhost:5173/");
+		expect(useUiStore.getState().detectedUrlsBySession["sess-1"]).toEqual(["http://localhost:5173/"]);
+	});
+
+	it("keeps sessions' URL lists independent", () => {
+		useUiStore.getState().addDetectedUrl("sess-1", "http://localhost:5173/");
+		useUiStore.getState().addDetectedUrl("sess-2", "http://localhost:4173/");
+		expect(useUiStore.getState().detectedUrlsBySession["sess-1"]).toEqual(["http://localhost:5173/"]);
+		expect(useUiStore.getState().detectedUrlsBySession["sess-2"]).toEqual(["http://localhost:4173/"]);
+	});
+
+	it("orders the most recently detected URL first", () => {
+		useUiStore.getState().addDetectedUrl("sess-1", "http://localhost:3000/");
+		useUiStore.getState().addDetectedUrl("sess-1", "http://localhost:4000/");
+		expect(useUiStore.getState().detectedUrlsBySession["sess-1"]).toEqual([
+			"http://localhost:4000/",
+			"http://localhost:3000/",
+		]);
+	});
+
+	it("moves a repeated URL back to the front instead of duplicating it", () => {
+		useUiStore.getState().addDetectedUrl("sess-1", "http://localhost:3000/");
+		useUiStore.getState().addDetectedUrl("sess-1", "http://localhost:4000/");
+		useUiStore.getState().addDetectedUrl("sess-1", "http://localhost:3000/");
+		expect(useUiStore.getState().detectedUrlsBySession["sess-1"]).toEqual([
+			"http://localhost:3000/",
+			"http://localhost:4000/",
+		]);
+	});
+
+	it("caps the retained list at 20 URLs per session, dropping the oldest", () => {
+		for (let i = 0; i < 25; i++) {
+			useUiStore.getState().addDetectedUrl("sess-1", `http://localhost:3000/${i}`);
+		}
+		const urls = useUiStore.getState().detectedUrlsBySession["sess-1"];
+		expect(urls).toHaveLength(20);
+		expect(urls[0]).toBe("http://localhost:3000/24");
+		expect(urls.at(-1)).toBe("http://localhost:3000/5");
+	});
+});
 
 // developerMode initializes from localStorage at module load, so each case resets
 // modules and re-imports to exercise the real initialization path.

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -67,6 +67,10 @@ type UiState = {
 	// session. Surfaces outside the session subtree (the notification runtime)
 	// need that distinction, and SessionView's own target is local state.
 	visibleTerminalKindBySession: Record<string, TerminalTarget["kind"]>;
+	// URLs passively detected in a worker's terminal output (e.g. a dev-server
+	// address a command printed), most recent first. Purely a convenience list
+	// for the Browser tab's "detected URLs" menu — detection never navigates.
+	detectedUrlsBySession: Record<string, string[]>;
 	setWorkbenchTab: (tab: WorkbenchTab) => void;
 	setThemePreference: (theme: ThemePreference) => void;
 	setDeveloperMode: (enabled: boolean) => void;
@@ -88,10 +92,14 @@ type UiState = {
 	setActiveShellTerminal: (handleId: string | null) => void;
 	setVisibleTerminalKind: (sessionId: string, kind: TerminalTarget["kind"]) => void;
 	clearVisibleTerminalKind: (sessionId: string) => void;
+	addDetectedUrl: (sessionId: string, url: string) => void;
 };
 
 const sidebarStorageKey = "ao.sidebar.open";
 const developerModeStorageKey = "ao.developerMode";
+// Much lower than detect-urls.ts's internal SEEN_MAX (512) — that cap bounds an
+// internal dedupe set, this one bounds a user-facing list in a toolbar menu.
+const DETECTED_URLS_MAX = 20;
 
 function getLocalStorage() {
 	if (typeof window === "undefined" || !window.localStorage) return null;
@@ -128,6 +136,7 @@ export const useUiStore = create<UiState>((set) => ({
 	newShellTerminalNonce: 0,
 	activeShellTerminalHandleId: null,
 	visibleTerminalKindBySession: {},
+	detectedUrlsBySession: {},
 	setWorkbenchTab: (workbenchTab) => set({ workbenchTab }),
 	setThemePreference: (themePreference) => {
 		getLocalStorage()?.setItem(themeStorageKey, themePreference);
@@ -250,6 +259,12 @@ export const useUiStore = create<UiState>((set) => ({
 			const visibleTerminalKindBySession = { ...state.visibleTerminalKindBySession };
 			delete visibleTerminalKindBySession[sessionId];
 			return { visibleTerminalKindBySession };
+		}),
+	addDetectedUrl: (sessionId, url) =>
+		set((state) => {
+			const current = state.detectedUrlsBySession[sessionId] ?? [];
+			const next = [url, ...current.filter((existing) => existing !== url)].slice(0, DETECTED_URLS_MAX);
+			return { detectedUrlsBySession: { ...state.detectedUrlsBySession, [sessionId]: next } };
 		}),
 }));
 


### PR DESCRIPTION
## Summary
- Retain URLs passively detected in a worker's terminal output (e.g. a dev-server address) per session instead of discarding them after the "unseen" badge fires — deduped, most-recent-first, capped at 20.
- New `DetectedUrlsMenu` toolbar popover on the Browser panel (mirrors the existing tabs-menu pattern) listing detected URLs; clicking one navigates. Hidden entirely when nothing's been detected.

## Test plan
- [x] `vitest run` — full frontend suite (only pre-existing, environment-specific failures remain: Windows Unix-socket `EACCES` in `supervisor-link.test.ts`, missing optional `cheerio` dep in landing doc-gen tests, macOS-only DMG packaging test)
- [x] `tsc --noEmit` clean
- [x] New unit tests: `ui-store.test.ts` (dedupe/cap/ordering), `TerminalPane.test.tsx` (wiring), `BrowserPanel.test.tsx` (menu render/hide/navigate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)