### PR TITLE
fix: restore full-width See it in action video

### DIFF
--- a/frontend/src/landing/src/app/components/VideoSection/VideoSection.tsx
+++ b/frontend/src/landing/src/app/components/VideoSection/VideoSection.tsx
@@ -35,40 +35,40 @@ export function VideoSection() {
 					<p className="mt-3 text-base text-muted-foreground">
 						Watch AO run a fleet of agents end to end on a single repo, from task to merged PR.
 					</p>
+				</div>
 
-					<div className="relative mx-auto mt-12 w-full">
-						<div
-							data-testid="video-frame"
-							className="relative aspect-video overflow-hidden bg-black"
-						>
-							{playing ? (
-								<iframe
-									src={`https://player.mux.com/${MUX_PLAYBACK_ID}?autoplay=true&metadata-video-title=${ENCODED_VIDEO_TITLE}&video-title=${ENCODED_VIDEO_TITLE}`}
-									allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture"
-									allowFullScreen
-									className="absolute inset-0 h-full w-full border-none"
-									title={VIDEO_TITLE}
+				<div className="relative mx-auto mt-12 w-full">
+					<div
+						data-testid="video-frame"
+						className="relative aspect-video overflow-hidden bg-black"
+					>
+						{playing ? (
+							<iframe
+								src={`https://player.mux.com/${MUX_PLAYBACK_ID}?autoplay=true&metadata-video-title=${ENCODED_VIDEO_TITLE}&video-title=${ENCODED_VIDEO_TITLE}`}
+								allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture"
+								allowFullScreen
+								className="absolute inset-0 h-full w-full border-none"
+								title={VIDEO_TITLE}
+							/>
+						) : (
+							<button
+								type="button"
+								onClick={() => setPlaying(true)}
+								aria-label={`Play video: ${VIDEO_TITLE}`}
+								className="group absolute inset-0 cursor-pointer"
+							>
+								<Image
+									src="/mux-video-preview.jpg"
+									alt="Still from the Agent Orchestrator demo video"
+									fill
+									sizes="(min-width: 1280px) 1280px, 100vw"
+									className="object-cover"
 								/>
-							) : (
-								<button
-									type="button"
-									onClick={() => setPlaying(true)}
-									aria-label={`Play video: ${VIDEO_TITLE}`}
-									className="group absolute inset-0 cursor-pointer"
-								>
-									<Image
-										src="/mux-video-preview.jpg"
-										alt="Still from the Agent Orchestrator demo video"
-										fill
-										sizes="(min-width: 1280px) 1280px, 100vw"
-										className="object-cover"
-									/>
-									<span className="absolute inset-0 grid place-items-center">
-										<PlayIcon className="h-14 w-14 translate-x-[3px] text-white transition-transform duration-200 group-hover:scale-110 sm:h-16 sm:w-16" />
-									</span>
-								</button>
-							)}
-						</div>
+								<span className="absolute inset-0 grid place-items-center">
+									<PlayIcon className="h-14 w-14 translate-x-[3px] text-white transition-transform duration-200 group-hover:scale-110 sm:h-16 sm:w-16" />
+								</span>
+							</button>
+						)}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Restore the "See it in action" layout so heading/copy stay in `max-w-3xl` and the video is a sibling under `max-w-7xl` again.
- Fixes the left-shifted player introduced when #3279 dropped the closing `</div>` and #3440 closed the narrow wrapper around the video as it was not matching the whole website theme

## Test plan
- [ ] Open the landing page `/#see-it`
- [ ] Confirm the video spans the full content width (not a narrow left column)
- [ ] Confirm heading + description remain left-aligned above the player
- [ ] Click play and confirm the Mux iframe still loads