### PR TITLE
chore(release): stop generating dead Linux .blockmap sidecars

### DIFF
--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -177,9 +177,11 @@ convincing false failure) and runs `codesign --verify --deep --strict`,
 
 Expected assets: versioned installers for every platform
 (`Agent.Orchestrator-darwin-{arm64,x64}-X.Y.Z.zip`, `Agent.Orchestrator.Setup.X.Y.Z.exe`,
-`Agent.Orchestrator-X.Y.Z.AppImage`, deb, rpm) plus `.blockmap` sidecars for
-Windows and Linux only (macOS ships none by policy since #3151, so mac clients
-always take the full-download path), the version-free aliases `ao start` fetches
+`Agent.Orchestrator-X.Y.Z.AppImage`, deb, rpm) plus a `.blockmap` sidecar for
+the Windows installer only (macOS ships none by policy since #3151, so mac
+clients always take the full-download path; Linux sidecars were retired in
+#3288 because `AppImageUpdater` never fetched one), the version-free aliases
+`ao start` fetches
 (`agent-orchestrator-darwin-arm64.zip`, `agent-orchestrator-darwin-x64.zip`,
 `agent-orchestrator-win32-x64.exe`, `agent-orchestrator-linux-x64.AppImage`,
 and the deb/rpm published under versioned names), and the electron-updater

--- a/frontend/scripts/blockmap.mjs
+++ b/frontend/scripts/blockmap.mjs
@@ -13,17 +13,19 @@ const { buildBlockMap } = require("app-builder-lib/out/targets/blockmap/blockmap
 // file's base64 sha512 + byte size, exactly as electron-updater reads them from
 // the feed yml. We deliberately do NOT surface blockMapSize.
 //
-// What omitting blockMapSize actually does, per platform (verified against the
-// published electron-updater@6.8.9 tarball, #3288 workstream 3):
-//   win:   selects the sidecar differential path in NsisUpdater, via
-//          AppUpdater.differentialDownloadInstaller. Sidecars are load-bearing.
-//   linux: does NOT select a sidecar path. AppImageUpdater has no sidecar path
-//          at all; it uses FileWithEmbeddedBlockMapDifferentialDownloader,
-//          reading the blockmap from the AppImage tail and requiring
-//          blockMapSize. Without it, linux differential updates are off
-//          entirely and the sidecars we write for linux are read by nobody.
-//   mac:   never calls writeBlockmap (see feed.mjs's hashFile), so MacUpdater
-//          always takes the full zip download (#3034, #3151, #3267 decision 4).
+// Only the windows installer is passed here; feed.mjs uses hashFile for every
+// other platform. Why, per platform (verified against the published
+// electron-updater@6.8.9 tarball, #3288 workstream 3):
+//   win:   omitting blockMapSize selects the sidecar differential path in
+//          NsisUpdater, via AppUpdater.differentialDownloadInstaller. Sidecars
+//          are load-bearing.
+//   linux: AppImageUpdater has no sidecar path at all; it uses
+//          FileWithEmbeddedBlockMapDifferentialDownloader, reading the blockmap
+//          from the AppImage tail and requiring blockMapSize. With that absent,
+//          linux differential updates are off entirely and a sidecar would be
+//          read by nobody, so none is generated (#3288 workstream 3).
+//   mac:   no sidecar either, so MacUpdater always takes the full zip download
+//          (#3034, #3151, #3267 decision 4).
 export async function writeBlockmap(filePath) {
 	const { sha512, size } = await buildBlockMap(filePath, "gzip", `${filePath}.blockmap`);
 	return { sha512, size };

--- a/frontend/scripts/blockmap.test.mjs
+++ b/frontend/scripts/blockmap.test.mjs
@@ -7,6 +7,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 
+// Smoke test for the pinned app-builder-lib internal import. Since #3288
+// workstream 3 the only caller is the windows installer branch of
+// feed.mjs's generateFeeds; mac and linux take hashFile instead.
 describe("writeBlockmap", () => {
 	it("writes a gzip sidecar and returns the file's base64 sha512 + size", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "bm-"));

--- a/frontend/scripts/feed.mjs
+++ b/frontend/scripts/feed.mjs
@@ -1,5 +1,6 @@
 // Generates electron-updater feed metadata (latest*.yml / nightly*.yml) plus
-// gzip sidecar blockmaps for a release's versioned installers. Dependency-free
+// gzip sidecar blockmaps for the Windows installer, the only artifact whose
+// updater actually fetches one (see generateFeeds). Dependency-free
 // ESM (mirrors nightly-version.mjs) so CI runs `node scripts/feed.mjs` directly
 // and vitest unit-tests the pure functions. The only non-stdlib reach is the
 // blockmap wrapper (Task 1).
@@ -51,9 +52,8 @@ export function feedFilename(channel, platform) {
 //          `fileSize - (blockMapSize + 4)` and therefore hard-requires
 //          blockMapSize in the yml. With it absent, linux differential updates
 //          cannot run at all and every client falls back to a full download.
-//          The linux .blockmap sidecars we publish are consumed by nothing (see
-//          the note in generateFeeds).
-//   mac:   no sidecar is generated at all (see hashFile), so MacUpdater always
+//          No linux sidecar is generated, since nothing would read it.
+//   mac:   no sidecar is generated either (see hashFile), so MacUpdater always
 //          takes the full-download path. Settled permanent baseline, #3151/#3267.
 //
 // When important is true, emits `important: true` after releaseDate so the
@@ -72,17 +72,18 @@ export function buildYml(version, files, releaseDate, important = false) {
 	return lines.join("\n") + "\n";
 }
 
-// generateFeeds writes the yml + sidecar blockmaps for every platform present in
-// dir. version may carry +build metadata (nightly); strip it for the yml.
-// mac zips skip the blockmap sidecar entirely (see hashFile); see #3034/#3151.
+// generateFeeds writes the yml for every platform present in dir, plus a
+// .blockmap sidecar for the windows installer only. version may carry +build
+// metadata (nightly); strip it for the yml.
 //
-// The linux sidecars this still writes are dead weight: AppImageUpdater reads
-// its blockmap from the AppImage tail, never from a sidecar, and needs a
-// blockMapSize we never emit (see buildYml). Generation is kept deliberately
-// rather than dropped, because the release publish guard lives in a separate
-// private pipeline that currently asserts on the linux sidecar filenames;
-// dropping the files here would red that guard out of band. Removing both
-// together is tracked as its own decision on #3288 workstream 3.
+// Windows is the only platform whose updater fetches a sidecar
+// (AppUpdater.differentialDownloadInstaller, reached from NsisUpdater). mac
+// skips it by policy so MacUpdater always takes the full download (#3034,
+// #3151, #3267 decision 4); linux never had a reader at all, since
+// AppImageUpdater takes its blockmap from the AppImage tail and needs a
+// blockMapSize buildYml does not emit. Linux generation was retired in #3288
+// workstream 3; the private publish guard treats linux sidecars as optional,
+// so their absence is not a publish failure.
 export async function generateFeeds(dir, rawVersion, channel, releaseDate, important = false) {
 	const version = rawVersion.split("+")[0];
 	const sel = selectInstallers(readdirSync(dir), version);
@@ -96,7 +97,7 @@ export async function generateFeeds(dir, rawVersion, channel, releaseDate, impor
 		const files = [];
 		for (const name of names) {
 			const { sha512, size } =
-				platform === "mac" ? hashFile(join(dir, name)) : await writeBlockmap(join(dir, name));
+				platform === "win" ? await writeBlockmap(join(dir, name)) : hashFile(join(dir, name));
 			files.push({ url: name, sha512, size });
 		}
 		writeFileSync(join(dir, feedFilename(channel, platform)), buildYml(version, files, releaseDate, important));
@@ -118,9 +119,11 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 }
 
 // hashFile computes the same {sha512, size} shape writeBlockmap returns, but
-// without writing a .blockmap sidecar file. Used for mac zips specifically:
-// Squirrel.Mac's ShipIt install step runs `ditto` against the extracted update
-// cache and fails on a corrupt one, which is the #3034 failure signature.
+// without writing a .blockmap sidecar file. Used for every platform except
+// windows. For linux the reason is simply that nothing reads the sidecar (see
+// generateFeeds). For mac it is a deliberate fix: Squirrel.Mac's ShipIt install
+// step runs `ditto` against the extracted update cache and fails on a corrupt
+// one, which is the #3034 failure signature.
 //
 // The original zip-format theory (that ShipIt failed because
 // @electron-forge/maker-zip's output lacked the AppleDouble "._*" entries

--- a/frontend/scripts/feed.test.mjs
+++ b/frontend/scripts/feed.test.mjs
@@ -167,17 +167,20 @@ describe("hashFile", () => {
 	});
 });
 
-// Regression coverage for #3034: mac zips must never produce a .blockmap
-// sidecar, since Squirrel.Mac's ShipIt `ditto` install step fails against
-// the AppleDouble-less format @electron-forge/maker-zip produces, and a
-// sidecar-driven differential update against it is the likely corruption
-// path. win/linux keep the existing blockmap sidecar behavior unchanged.
-describe("generateFeeds mac blockmap exclusion (#3034)", () => {
+// Windows is the only platform whose updater fetches a .blockmap sidecar.
+//   mac   is regression coverage for #3034: Squirrel.Mac's ShipIt `ditto`
+//         install step fails against a corrupt update cache, and a
+//         sidecar-driven differential update is the corruption path (#3151,
+//         #3267 decision 4).
+//   linux never had a reader: AppImageUpdater takes its blockmap from the
+//         AppImage tail and needs a blockMapSize feed.mjs does not emit, so a
+//         sidecar fed nothing. Generation retired in #3288 workstream 3.
+describe("generateFeeds blockmap sidecars are windows-only", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it("does not call writeBlockmap or write a .blockmap sidecar for mac zips", async () => {
+	it("does not call writeBlockmap or write a .blockmap sidecar for mac zips (#3034)", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "feed-test-"));
 		const macZip = "Agent.Orchestrator-darwin-arm64-0.10.4.zip";
 		writeFileSync(join(dir, macZip), "fake mac zip");
@@ -194,7 +197,30 @@ describe("generateFeeds mac blockmap exclusion (#3034)", () => {
 		rmSync(dir, { recursive: true, force: true });
 	});
 
-	it("still calls writeBlockmap for win and linux installers", async () => {
+	it("does not call writeBlockmap or write a .blockmap sidecar for linux AppImages (#3288)", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "feed-test-"));
+		const linuxAppImage = "Agent.Orchestrator-0.10.4.AppImage";
+		writeFileSync(join(dir, linuxAppImage), "fake linux installer");
+
+		await generateFeeds(dir, "0.10.4", "nightly", "2026-06-27T12:00:00.000Z");
+
+		expect(writeBlockmap).not.toHaveBeenCalled();
+		expect(existsSync(join(dir, `${linuxAppImage}.blockmap`))).toBe(false);
+
+		// The feed still lists the AppImage with a real hash; only the dead
+		// sidecar is gone, and blockMapSize stays absent so AppImageUpdater
+		// keeps falling back to a full download rather than erroring.
+		const yml = readFileSync(join(dir, "nightly-linux.yml"), "utf8");
+		expect(yml).not.toContain("blockMapSize");
+		expect(yml).toContain(`url: ${linuxAppImage}`);
+		expect(yml).toContain(
+			`sha512: ${createHash("sha512").update(Buffer.from("fake linux installer")).digest("base64")}`,
+		);
+
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("still calls writeBlockmap for the win installer", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "feed-test-"));
 		const winExe = "Agent.Orchestrator.Setup.0.10.4.exe";
 		const linuxAppImage = "Agent.Orchestrator-0.10.4.AppImage";
@@ -203,9 +229,8 @@ describe("generateFeeds mac blockmap exclusion (#3034)", () => {
 
 		await generateFeeds(dir, "0.10.4", "nightly", "2026-06-27T12:00:00.000Z");
 
-		expect(writeBlockmap).toHaveBeenCalledTimes(2);
+		expect(writeBlockmap).toHaveBeenCalledTimes(1);
 		expect(writeBlockmap).toHaveBeenCalledWith(join(dir, winExe));
-		expect(writeBlockmap).toHaveBeenCalledWith(join(dir, linuxAppImage));
 
 		rmSync(dir, { recursive: true, force: true });
 	});


### PR DESCRIPTION
Closes part of #3288 (workstream 3, the "consider dropping linux sidecar generation entirely" follow-up).

## Why

`AppImageUpdater` never fetches a `.blockmap` sidecar. Its differential path uses `FileWithEmbeddedBlockMapDifferentialDownloader`, which reads the blockmap from the AppImage's own tail at `fileSize - (blockMapSize + 4)` and therefore hard-requires `blockMapSize` in the feed yml. `feed.mjs` deliberately never emits `blockMapSize`.

Net: Linux differential updates were already off (clients fall back to a full download), and every Linux `.blockmap` we published was read by nobody. `feed.mjs` has said so in a comment since #3288 landed; this deletes the generation to match.

## The blocker is gone, verified

The only reason generation was kept is recorded in that comment: the private release pipeline's publish guard asserted on the Linux sidecar filenames, so dropping the files here would have redded a guard out of band.

That hardcoded list no longer exists. The guard is now feed-derived and its sidecar policy is:

```
win:   required   (NsisUpdater does fetch them, via AppUpdater.differentialDownloadInstaller)
mac:   forbidden  (policy, #3151, for #3034)
linux: ignored    ("so that the public repo dropping the dead generation
                    does not fail a publish here")
```

It is the only blockmap check wired into the private pipeline; no hardcoded filename list remains anywhere in those workflows. So this change is a publish no-op there.

## What changed

- `frontend/scripts/feed.mjs`: the sidecar branch flips from "everything except mac" to "win only". One line.
- `frontend/scripts/feed.test.mjs`: the `#3034` mac-exclusion block becomes a windows-only block. Adds a Linux case asserting no `writeBlockmap` call, no sidecar on disk, and that `latest-linux.yml` still carries the AppImage's real sha512 with `blockMapSize` still absent (so AppImageUpdater keeps falling back to a full download rather than erroring). The win case now asserts exactly one call.
- `frontend/scripts/blockmap.test.mjs`: notes that the pinned `app-builder-lib` import now has one caller.
- Stale comments corrected in `feed.mjs` (header, `buildYml`, `generateFeeds`, `hashFile`) and `blockmap.mjs`, plus the one line in `frontend/docs/desktop-release.md` that listed sidecars as "Windows and Linux only".

Both release workflows collect sidecars with `shopt -s nullglob` globs (`.github/workflows/frontend-release.yml:407`, `feature-release.yml:468`), so fewer files needs no workflow change.

## Not touched

- **Windows sidecars are load-bearing.** `NsisUpdater` genuinely fetches `<installer>.blockmap`; a missing one silently degrades every Windows user to a full download. Unchanged.
- **macOS keeps shipping none**, per #3151 / #3267 decision 4. Unchanged; its regression test still asserts it.

## Tests

`frontend/scripts` suite, 88 passed:

```
 ✓ scripts/feed.test.mjs > generateFeeds blockmap sidecars are windows-only > does not call writeBlockmap or write a .blockmap sidecar for mac zips (#3034) 1ms
 ✓ scripts/feed.test.mjs > generateFeeds blockmap sidecars are windows-only > does not call writeBlockmap or write a .blockmap sidecar for linux AppImages (#3288) 1ms
 ✓ scripts/feed.test.mjs > generateFeeds blockmap sidecars are windows-only > still calls writeBlockmap for the win installer 1ms
 ✓ scripts/blockmap.test.mjs > writeBlockmap > writes a gzip sidecar and returns the file's base64 sha512 + size 23ms

 Test Files  8 passed (8)
      Tests  88 passed (88)
   Duration  568ms
```

(`npx vitest run --dir scripts`. Running the wider `scripts/` pattern also sweeps in `src/landing/scripts/generate-markdown-twins.test.mjs`, which fails on a missing `cheerio`; that dep lives in the separate `frontend/src/landing/package.json` and needs its own `npm ci`. Unrelated to this change and outside `frontend/scripts/`.)