### PR TITLE
docs(ci): correct the stale "release workflows are paused" claim in mac-update-e2e

### DIFF
--- a/.github/workflows/mac-update-e2e.yml
+++ b/.github/workflows/mac-update-e2e.yml
@@ -31,8 +31,12 @@ name: macOS update e2e
 #
 # Deliberately NOT wired into any release workflow, and not to be wired in as
 # part of this file's current shape:
-#   - The release workflows are paused, and un-pausing them is a separate
-#     decision that does not belong to this change.
+#   - NOT because the release pipeline is paused. It is not: the release repo's
+#     workflows are active, nightly runs green daily, and stable ships
+#     regularly. An earlier version of this comment claimed they were paused;
+#     that was true when written and is not true now. The reasons this stays
+#     unwired are the cost argument below and the monitoring-not-a-gate
+#     argument above, neither of which a live pipeline changes.
 #   - macOS runner minutes are materially more expensive than Linux, and this
 #     project ships nightlies frequently. #3288 recommends concentrating spend on
 #     promotion to the STABLE channel specifically (the exact transition that


### PR DESCRIPTION
The header comment in `.github/workflows/mac-update-e2e.yml` listed "The release workflows are paused, and un-pausing them is a separate decision" as a reason the job is not wired into a release workflow. That was true when written and is no longer true, so it actively misleads anyone reading the file to decide what to do with this job.

Verified before editing:

- `gh api repos/Untrivial-ai/ao-releases/actions/workflows` reports all five workflows (`pipeline`, `lint`, `nightly`, `preview`, `stable`) in state `active`.
- `nightly` ran green on 2026-08-02 ([run 30752790310](https://github.com/Untrivial-ai/ao-releases/actions/runs/30752790310)) and runs green daily.
- `stable` ran green on 2026-07-30 ([run 30575514766](https://github.com/Untrivial-ai/ao-releases/actions/runs/30575514766)), shipping v0.11.2.

Only the paused claim is stale, and only it changed. The cost argument and the "this is monitoring, not a promotion gate" argument both still stand and are still the actual reasons this job is `workflow_dispatch`/`workflow_call` only, so both are left intact. The replacement bullet records that the pipeline is live specifically so the stale claim does not get reintroduced.

Comment-only, no behaviour change.

Refs #3288