### PR TITLE
fix(desktop): keep notification bell trailing the actions row on the board

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -250,7 +250,6 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 
 	const actions = projectId ? (
 		<>
-			{boardOwnsNotificationCenter ? <NotificationCenter /> : null}
 			{visibleSpawnError && !showProjectEmpty && (
 				<TopbarKillError className="max-w-content-max truncate" title={visibleSpawnError}>
 					{visibleSpawnError}
@@ -281,6 +280,9 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 							? "Orchestrator"
 							: "Spawn Orchestrator"}
 			</TopbarButton>
+			{/* The bell trails the actions row here too, matching ShellTopbar, so it
+			    stays put when navigating between board and session views. */}
+			{boardOwnsNotificationCenter ? <NotificationCenter /> : null}
 		</>
 	) : boardOwnsNotificationCenter ? (
 		<NotificationCenter />
@@ -295,7 +297,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			    chooser was review feedback on #2432. */}
 			{!showWelcome && !showStartup && boardActionsInPanel && (boardLabel || actions) ? (
 				<div
-					className="center-panel-titlebar flex h-toolbar shrink-0 items-center gap-2 border-b border-border-strong pr-4.5"
+					className="center-panel-titlebar flex h-toolbar shrink-0 items-center gap-2 border-b border-border-strong pr-4"
 					style={dragStyle}
 				>
 					{boardLabel ? <span className={topbarProjectLabelClass}>{boardLabel}</span> : null}

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -280,8 +280,6 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 							? "Orchestrator"
 							: "Spawn Orchestrator"}
 			</TopbarButton>
-			{/* The bell trails the actions row here too, matching ShellTopbar, so it
-			    stays put when navigating between board and session views. */}
 			{boardOwnsNotificationCenter ? <NotificationCenter /> : null}
 		</>
 	) : boardOwnsNotificationCenter ? (


### PR DESCRIPTION
small fix :)

- The kanban board's in-panel title row rendered the notification bell **first** in its actions fragment, while `ShellTopbar` (worker session view) always trails it — so the bell jumped sides when navigating between the two views.
- The board row also used `pr-4.5` (18px) vs the topbar's `pr-4` (16px), shifting the bell's right edge by 2px.
- Fix: move `<NotificationCenter />` to the end of the board's actions fragment and align the row's right padding with `topbarHeaderClass`.

<img width="1380" height="913" alt="image" src="https://github.com/user-attachments/assets/4f93253a-a79d-4b75-b4fd-f3c2d93e713f" />
<img width="1349" height="909" alt="image" src="https://github.com/user-attachments/assets/bdc8f981-4cf7-4342-ae3c-477ac64dceb2" />
