### PR TITLE
feat(session-files): select code in the diff viewer, send to agent

### DIFF
--- a/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
+++ b/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
@@ -134,6 +134,38 @@ describe("DiffSelectionMenu", () => {
 		}
 	});
 
+	it("clears the pending sent auto-close timer and resets status when switching to Make changes", async () => {
+		vi.useFakeTimers();
+		try {
+			postMock.mockResolvedValue({ data: {} });
+			const onOpenChange = vi.fn();
+			renderMenu({ onOpenChange });
+
+			fireEvent.click(screen.getByRole("menuitem", { name: "Explain" }));
+
+			await act(async () => {
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+
+			expect(screen.getByText("Sent")).toBeInTheDocument();
+
+			fireEvent.click(screen.getByRole("menuitem", { name: "Make changes" }));
+
+			expect(screen.getByRole("textbox", { name: "Describe the change" })).toBeInTheDocument();
+			expect(screen.queryByText("Sent")).not.toBeInTheDocument();
+
+			act(() => {
+				vi.advanceTimersByTime(2_000);
+			});
+
+			expect(onOpenChange).not.toHaveBeenCalledWith(false);
+			expect(screen.getByRole("textbox", { name: "Describe the change" })).toBeInTheDocument();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("swaps to an input on Make changes and sends the typed instruction on Enter", async () => {
 		renderMenu();
 
@@ -182,6 +214,30 @@ describe("DiffSelectionMenu", () => {
 
 		expect(await screen.findByText("AO daemon is not ready.")).toBeInTheDocument();
 		expect(onOpenChange).not.toHaveBeenCalledWith(false);
+	});
+
+	it("shows an error status when the send promise rejects", async () => {
+		postMock.mockRejectedValue({ message: "Network unreachable." });
+		const onOpenChange = vi.fn();
+		renderMenu({ onOpenChange });
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Explain" }));
+
+		expect(await screen.findByText("Network unreachable.")).toBeInTheDocument();
+		expect(onOpenChange).not.toHaveBeenCalledWith(false);
+	});
+
+	it("clears the stale error text when switching to Make changes after a failed send", async () => {
+		postMock.mockResolvedValue({ error: { message: "AO daemon is not ready." } });
+		renderMenu();
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Explain" }));
+		expect(await screen.findByText("AO daemon is not ready.")).toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Make changes" }));
+
+		expect(screen.getByRole("textbox", { name: "Describe the change" })).toBeInTheDocument();
+		expect(screen.queryByText("AO daemon is not ready.")).not.toBeInTheDocument();
 	});
 
 	it("resets to the action list when reopened after a prior error", async () => {

--- a/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
+++ b/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
@@ -205,6 +205,42 @@ describe("DiffSelectionMenu", () => {
 		expect(onOpenChange).not.toHaveBeenCalledWith(false);
 	});
 
+	it("clears the pending sent auto-close timer and resets status when pressing Escape from the input", async () => {
+		vi.useFakeTimers();
+		try {
+			postMock.mockResolvedValue({ data: {} });
+			const onOpenChange = vi.fn();
+			renderMenu({ onOpenChange });
+
+			fireEvent.click(screen.getByRole("menuitem", { name: "Make changes" }));
+			const input = screen.getByRole("textbox", { name: "Describe the change" });
+
+			fireEvent.change(input, { target: { value: "Rename this to bar" } });
+			fireEvent.keyDown(input, { key: "Enter" });
+
+			await act(async () => {
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+
+			expect(screen.getByText("Sent")).toBeInTheDocument();
+
+			fireEvent.keyDown(input, { key: "Escape" });
+
+			expect(screen.getByRole("menuitem", { name: "Copy" })).toBeInTheDocument();
+			expect(screen.queryByRole("textbox", { name: "Describe the change" })).not.toBeInTheDocument();
+			expect(screen.queryByText("Sent")).not.toBeInTheDocument();
+
+			act(() => {
+				vi.advanceTimersByTime(2_000);
+			});
+
+			expect(onOpenChange).not.toHaveBeenCalledWith(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("shows an error status and does not auto-close when the send fails", async () => {
 		postMock.mockResolvedValue({ error: { message: "AO daemon is not ready." } });
 		const onOpenChange = vi.fn();
@@ -237,6 +273,22 @@ describe("DiffSelectionMenu", () => {
 		await userEvent.click(screen.getByRole("menuitem", { name: "Make changes" }));
 
 		expect(screen.getByRole("textbox", { name: "Describe the change" })).toBeInTheDocument();
+		expect(screen.queryByText("AO daemon is not ready.")).not.toBeInTheDocument();
+	});
+
+	it("clears the stale error text when pressing Escape from the input after a failed send", async () => {
+		postMock.mockResolvedValue({ error: { message: "AO daemon is not ready." } });
+		renderMenu();
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Make changes" }));
+		const input = await screen.findByRole("textbox", { name: "Describe the change" });
+		await userEvent.type(input, "Rename this to bar{Enter}");
+
+		expect(await screen.findByText("AO daemon is not ready.")).toBeInTheDocument();
+
+		await userEvent.keyboard("{Escape}");
+
+		expect(screen.getByRole("menuitem", { name: "Copy" })).toBeInTheDocument();
 		expect(screen.queryByText("AO daemon is not ready.")).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
+++ b/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
@@ -1,0 +1,216 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DiffSelectionMenu, type DiffSelectionMenuProps } from "./DiffSelectionMenu";
+import type { DiffSelectionLine } from "../../shared/diff-selection";
+
+const postMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { POST: postMock },
+	apiErrorMessage: (error: unknown, fallback = "Request failed") =>
+		typeof error === "object" && error !== null && "message" in error
+			? String((error as { message: unknown }).message)
+			: fallback,
+}));
+
+const writeTextMock = vi.hoisted(() => vi.fn());
+
+const SAMPLE_LINES: DiffSelectionLine[] = [
+	{ kind: "context", oldNo: 10, newNo: 10, text: "function foo() {" },
+	{ kind: "add", oldNo: null, newNo: 11, text: "  return 42;" },
+];
+
+function renderMenu(overrides: Partial<DiffSelectionMenuProps> = {}) {
+	const onOpenChange = overrides.onOpenChange ?? vi.fn();
+	const props: DiffSelectionMenuProps = {
+		sessionId: "sess-1",
+		filePath: "src/app.ts",
+		lines: SAMPLE_LINES,
+		selectedText: "  return 42;",
+		open: true,
+		position: { x: 10, y: 20 },
+		onOpenChange,
+		...overrides,
+	};
+	const view = render(<DiffSelectionMenu {...props} />);
+	return { onOpenChange, props, ...view };
+}
+
+describe("DiffSelectionMenu", () => {
+	beforeEach(() => {
+		postMock.mockReset();
+		postMock.mockResolvedValue({ data: {} });
+		writeTextMock.mockReset();
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: writeTextMock },
+		});
+	});
+
+	it("shows Copy, Explain, and Make changes when open", () => {
+		renderMenu();
+
+		expect(screen.getByRole("menuitem", { name: "Copy" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "Explain" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "Make changes" })).toBeInTheDocument();
+	});
+
+	it("disables Copy when there is no selected text", () => {
+		renderMenu({ selectedText: "" });
+
+		expect(screen.getByRole("menuitem", { name: "Copy" })).toHaveAttribute("data-disabled");
+	});
+
+	it("copies the selected text and closes the menu", async () => {
+		const { onOpenChange } = renderMenu();
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Copy" }));
+
+		expect(writeTextMock).toHaveBeenCalledWith("  return 42;");
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+		expect(postMock).not.toHaveBeenCalled();
+	});
+
+	it("sends the canned Explain instruction and shows a sending -> sent progression", async () => {
+		let resolvePost: (value: unknown) => void = () => undefined;
+		postMock.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolvePost = resolve;
+			}),
+		);
+		const onOpenChange = vi.fn();
+		renderMenu({ onOpenChange });
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Explain" }));
+
+		expect(await screen.findByText("Sending")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/send", {
+			params: { path: { sessionId: "sess-1" } },
+			body: { message: expect.stringContaining("Explain what these lines do and why.") },
+		});
+		const body = postMock.mock.calls[0][1].body as { message: string };
+		expect(body.message).toContain("File: src/app.ts");
+		expect(body.message).toContain("return 42;");
+
+		await act(async () => {
+			resolvePost({ data: {} });
+		});
+
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
+		expect(onOpenChange).not.toHaveBeenCalledWith(false);
+	});
+
+	it("auto-closes shortly after a successful send", async () => {
+		vi.useFakeTimers();
+		try {
+			let resolvePost: (value: unknown) => void = () => undefined;
+			postMock.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolvePost = resolve;
+				}),
+			);
+			const onOpenChange = vi.fn();
+			renderMenu({ onOpenChange });
+
+			fireEvent.click(screen.getByRole("menuitem", { name: "Explain" }));
+
+			await act(async () => {
+				resolvePost({ data: {} });
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+
+			expect(screen.getByText("Sent")).toBeInTheDocument();
+			expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+			act(() => {
+				vi.advanceTimersByTime(2_000);
+			});
+
+			expect(onOpenChange).toHaveBeenCalledWith(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("swaps to an input on Make changes and sends the typed instruction on Enter", async () => {
+		renderMenu();
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Make changes" }));
+		const input = await screen.findByRole("textbox", { name: "Describe the change" });
+		await userEvent.type(input, "Rename this to bar{Enter}");
+
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/send", {
+			params: { path: { sessionId: "sess-1" } },
+			body: { message: expect.stringContaining("Rename this to bar") },
+		});
+		const body = postMock.mock.calls[0][1].body as { message: string };
+		expect(body.message).not.toContain("Explain what these lines do and why.");
+	});
+
+	it("does not send on Enter with an empty or whitespace-only input", async () => {
+		renderMenu();
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Make changes" }));
+		const input = await screen.findByRole("textbox", { name: "Describe the change" });
+		await userEvent.type(input, "   {Enter}");
+
+		expect(postMock).not.toHaveBeenCalled();
+	});
+
+	it("returns to the action list on Escape from the input without closing the menu", async () => {
+		const { onOpenChange } = renderMenu();
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Make changes" }));
+		const input = await screen.findByRole("textbox", { name: "Describe the change" });
+		await userEvent.type(input, "partial text");
+		await userEvent.keyboard("{Escape}");
+
+		expect(screen.getByRole("menuitem", { name: "Copy" })).toBeInTheDocument();
+		expect(screen.queryByRole("textbox", { name: "Describe the change" })).not.toBeInTheDocument();
+		expect(onOpenChange).not.toHaveBeenCalledWith(false);
+	});
+
+	it("shows an error status and does not auto-close when the send fails", async () => {
+		postMock.mockResolvedValue({ error: { message: "AO daemon is not ready." } });
+		const onOpenChange = vi.fn();
+		renderMenu({ onOpenChange });
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Explain" }));
+
+		expect(await screen.findByText("AO daemon is not ready.")).toBeInTheDocument();
+		expect(onOpenChange).not.toHaveBeenCalledWith(false);
+	});
+
+	it("resets to the action list when reopened after a prior error", async () => {
+		postMock.mockResolvedValue({ error: { message: "AO daemon is not ready." } });
+		const onOpenChange = vi.fn();
+		const { rerender, props } = renderMenu({ onOpenChange });
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Explain" }));
+		expect(await screen.findByText("AO daemon is not ready.")).toBeInTheDocument();
+
+		rerender(<DiffSelectionMenu {...props} onOpenChange={onOpenChange} open={false} />);
+		rerender(<DiffSelectionMenu {...props} onOpenChange={onOpenChange} open />);
+
+		expect(screen.getByRole("menuitem", { name: "Copy" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "Explain" })).toBeInTheDocument();
+		expect(screen.queryByText("AO daemon is not ready.")).not.toBeInTheDocument();
+	});
+
+	it("resets to the action list when reopened after switching to input mode", async () => {
+		const onOpenChange = vi.fn();
+		const { rerender, props } = renderMenu({ onOpenChange });
+
+		await userEvent.click(screen.getByRole("menuitem", { name: "Make changes" }));
+		expect(await screen.findByRole("textbox", { name: "Describe the change" })).toBeInTheDocument();
+
+		rerender(<DiffSelectionMenu {...props} onOpenChange={onOpenChange} open={false} />);
+		rerender(<DiffSelectionMenu {...props} onOpenChange={onOpenChange} open />);
+
+		expect(screen.getByRole("menuitem", { name: "Make changes" })).toBeInTheDocument();
+		expect(screen.queryByRole("textbox", { name: "Describe the change" })).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/renderer/components/DiffSelectionMenu.tsx
+++ b/frontend/src/renderer/components/DiffSelectionMenu.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { formatDiffSelectionMessage, type DiffSelectionLine } from "../../shared/diff-selection";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { cn } from "../lib/utils";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+import { Input } from "./ui/input";
+
+export type DiffSelectionMenuProps = {
+	sessionId: string;
+	filePath: string;
+	/** Ordered lines from `frontend/src/shared/diff-selection.ts`. */
+	lines: DiffSelectionLine[];
+	/** Raw `window.getSelection().toString()` — used by Copy only. */
+	selectedText: string;
+	open: boolean;
+	/** Viewport coordinates for the fixed, cursor-positioned trigger. */
+	position: { x: number; y: number };
+	onOpenChange: (open: boolean) => void;
+};
+
+type Mode = "actions" | "input";
+type SendStatus = "idle" | "sending" | "sent" | "error";
+
+const EXPLAIN_INSTRUCTION = "Explain what these lines do and why.";
+// Mirrors BrowserPanel's ~2s "Sent" confirmation window before auto-close.
+const SENT_AUTO_CLOSE_MS = 2_000;
+
+export function DiffSelectionMenu({
+	sessionId,
+	filePath,
+	lines,
+	selectedText,
+	open,
+	position,
+	onOpenChange,
+}: DiffSelectionMenuProps) {
+	const [mode, setMode] = useState<Mode>("actions");
+	const [status, setStatus] = useState<SendStatus>("idle");
+	const [errorMessage, setErrorMessage] = useState("");
+	const [inputValue, setInputValue] = useState("");
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const sentTimerRef = useRef<number | null>(null);
+
+	const clearSentTimer = useCallback(() => {
+		if (sentTimerRef.current !== null) {
+			window.clearTimeout(sentTimerRef.current);
+			sentTimerRef.current = null;
+		}
+	}, []);
+
+	// One active selection at a time: a fresh open always starts at the action
+	// list, even if the previous open ended in the input state or an error.
+	// This effect's dependency is only `open`, so it fires on mount and on every
+	// false -> true transition, but not on unrelated re-renders while open.
+	useEffect(() => {
+		if (!open) return;
+		clearSentTimer();
+		setMode("actions");
+		setStatus("idle");
+		setErrorMessage("");
+		setInputValue("");
+	}, [open, clearSentTimer]);
+
+	useEffect(() => clearSentTimer, [clearSentTimer]);
+
+	useEffect(() => {
+		if (mode === "input") inputRef.current?.focus();
+	}, [mode]);
+
+	const send = useCallback(
+		async (instruction: string) => {
+			clearSentTimer();
+			setStatus("sending");
+			setErrorMessage("");
+			const message = formatDiffSelectionMessage({ instruction, filePath, lines });
+			try {
+				const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/send", {
+					params: { path: { sessionId } },
+					body: { message },
+				});
+				if (error) {
+					setStatus("error");
+					setErrorMessage(apiErrorMessage(error, "Unable to send message."));
+					return;
+				}
+				setStatus("sent");
+				sentTimerRef.current = window.setTimeout(() => {
+					sentTimerRef.current = null;
+					onOpenChange(false);
+				}, SENT_AUTO_CLOSE_MS);
+			} catch (thrown) {
+				setStatus("error");
+				setErrorMessage(apiErrorMessage(thrown, "Unable to send message."));
+			}
+		},
+		[clearSentTimer, filePath, lines, onOpenChange, sessionId],
+	);
+
+	const handleCopy = useCallback(() => {
+		void navigator.clipboard?.writeText(selectedText);
+		onOpenChange(false);
+	}, [onOpenChange, selectedText]);
+
+	const submitInput = useCallback(() => {
+		const trimmed = inputValue.trim();
+		if (!trimmed || status === "sending") return;
+		void send(trimmed);
+	}, [inputValue, send, status]);
+
+	const handleInputKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLInputElement>) => {
+			// Defensive: DropdownMenuContent has its own roving-focus/typeahead
+			// keyboard handling that a plain text input shouldn't feed into.
+			event.stopPropagation();
+			if (event.key === "Escape") {
+				// A step back to the action list, not a dismiss — must not let
+				// DropdownMenuContent's own Escape handling close the whole menu.
+				event.preventDefault();
+				setMode("actions");
+				return;
+			}
+			if (event.key === "Enter") {
+				event.preventDefault();
+				submitInput();
+			}
+		},
+		[submitInput],
+	);
+
+	const statusLabel =
+		status === "sending" ? "Sending" : status === "sent" ? "Sent" : status === "error" ? errorMessage : "";
+
+	return (
+		<DropdownMenu modal={false} open={open} onOpenChange={onOpenChange}>
+			<DropdownMenuTrigger asChild>
+				<button
+					aria-hidden="true"
+					style={{
+						border: 0,
+						height: 0,
+						left: position.x,
+						opacity: 0,
+						padding: 0,
+						pointerEvents: "none",
+						position: "fixed",
+						top: position.y,
+						width: 0,
+					}}
+					tabIndex={-1}
+					type="button"
+				/>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align="start"
+				className="min-w-56"
+				onCloseAutoFocus={(event) => event.preventDefault()}
+				// DismissableLayer listens for Escape on `document` in the capture
+				// phase, which runs before the input's own onKeyDown (a bubble-phase
+				// React handler) ever sees the event — so stopPropagation() there is
+				// too late to stop the auto-close. This prop fires synchronously
+				// inside that same capture-phase handler, before Radix checks
+				// `defaultPrevented`, so it's the only hook that can actually cancel
+				// the dismiss for input mode's "step back" behavior.
+				onEscapeKeyDown={(event) => {
+					if (mode !== "input") return;
+					event.preventDefault();
+					setMode("actions");
+				}}
+				side="right"
+				sideOffset={2}
+			>
+				{mode === "actions" ? (
+					<>
+						<DropdownMenuItem
+							disabled={selectedText.length === 0}
+							onSelect={(event) => {
+								event.preventDefault();
+								handleCopy();
+							}}
+						>
+							Copy
+						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem
+							disabled={status === "sending"}
+							onSelect={(event) => {
+								event.preventDefault();
+								void send(EXPLAIN_INSTRUCTION);
+							}}
+						>
+							Explain
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							disabled={status === "sending"}
+							onSelect={(event) => {
+								event.preventDefault();
+								setMode("input");
+							}}
+						>
+							Make changes
+						</DropdownMenuItem>
+					</>
+				) : (
+					<div className="p-1.5">
+						<Input
+							aria-label="Describe the change"
+							disabled={status === "sending"}
+							onChange={(event) => setInputValue(event.target.value)}
+							onKeyDown={handleInputKeyDown}
+							placeholder="Tell the agent what to change…"
+							ref={inputRef}
+							value={inputValue}
+						/>
+					</div>
+				)}
+				{statusLabel ? (
+					<div className={cn("px-2 py-1.5 text-caption", status === "error" ? "text-error" : "text-passive")}>
+						{statusLabel}
+					</div>
+				) : null}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/frontend/src/renderer/components/DiffSelectionMenu.tsx
+++ b/frontend/src/renderer/components/DiffSelectionMenu.tsx
@@ -181,6 +181,12 @@ export function DiffSelectionMenu({
 							disabled={selectedText.length === 0}
 							onSelect={(event) => {
 								event.preventDefault();
+								// Guards against a stale "sent" auto-close timer (armed by a
+								// prior Explain/Make changes send) firing after Copy has
+								// already closed the menu itself — see the same reset below.
+								clearSentTimer();
+								setStatus("idle");
+								setErrorMessage("");
 								handleCopy();
 							}}
 						>
@@ -200,6 +206,16 @@ export function DiffSelectionMenu({
 							disabled={status === "sending"}
 							onSelect={(event) => {
 								event.preventDefault();
+								// Unlike Explain/Enter-to-send, this path doesn't go through
+								// send(), so it must clear a still-armed "sent" auto-close
+								// timer (e.g. Explain succeeded, then the user immediately
+								// clicked Make changes) and reset the leftover status/error
+								// itself — otherwise the stale "Sent" label renders under the
+								// fresh input, and the old timer later closes the whole menu
+								// out from under the user's in-progress draft.
+								clearSentTimer();
+								setStatus("idle");
+								setErrorMessage("");
 								setMode("input");
 							}}
 						>

--- a/frontend/src/renderer/components/DiffSelectionMenu.tsx
+++ b/frontend/src/renderer/components/DiffSelectionMenu.tsx
@@ -54,6 +54,18 @@ export function DiffSelectionMenu({
 		}
 	}, []);
 
+	// Shared by every transition away from a prior send's outcome (Copy,
+	// Explain-then-Make-changes, and both Escape-from-input paths below): a
+	// still-armed "sent" auto-close timer or leftover status/error must never
+	// leak into the next action — otherwise a stale "Sent"/error label renders
+	// under the new state, and the old timer can later close the whole menu
+	// out from under the user with no action on their part.
+	const resetSendState = useCallback(() => {
+		clearSentTimer();
+		setStatus("idle");
+		setErrorMessage("");
+	}, [clearSentTimer]);
+
 	// One active selection at a time: a fresh open always starts at the action
 	// list, even if the previous open ended in the input state or an error.
 	// This effect's dependency is only `open`, so it fires on mount and on every
@@ -122,6 +134,7 @@ export function DiffSelectionMenu({
 				// A step back to the action list, not a dismiss — must not let
 				// DropdownMenuContent's own Escape handling close the whole menu.
 				event.preventDefault();
+				resetSendState();
 				setMode("actions");
 				return;
 			}
@@ -130,7 +143,7 @@ export function DiffSelectionMenu({
 				submitInput();
 			}
 		},
-		[submitInput],
+		[resetSendState, submitInput],
 	);
 
 	const statusLabel =
@@ -170,6 +183,7 @@ export function DiffSelectionMenu({
 				onEscapeKeyDown={(event) => {
 					if (mode !== "input") return;
 					event.preventDefault();
+					resetSendState();
 					setMode("actions");
 				}}
 				side="right"
@@ -183,10 +197,8 @@ export function DiffSelectionMenu({
 								event.preventDefault();
 								// Guards against a stale "sent" auto-close timer (armed by a
 								// prior Explain/Make changes send) firing after Copy has
-								// already closed the menu itself — see the same reset below.
-								clearSentTimer();
-								setStatus("idle");
-								setErrorMessage("");
+								// already closed the menu itself — see resetSendState above.
+								resetSendState();
 								handleCopy();
 							}}
 						>
@@ -213,9 +225,7 @@ export function DiffSelectionMenu({
 								// itself — otherwise the stale "Sent" label renders under the
 								// fresh input, and the old timer later closes the whole menu
 								// out from under the user's in-progress draft.
-								clearSentTimer();
-								setStatus("idle");
-								setErrorMessage("");
+								resetSendState();
 								setMode("input");
 							}}
 						>

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -1,15 +1,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionFilesView } from "./SessionFilesView";
 
-const { getMock } = vi.hoisted(() => ({ getMock: vi.fn() }));
+const { getMock, postMock } = vi.hoisted(() => ({ getMock: vi.fn(), postMock: vi.fn() }));
 
 vi.mock("../lib/api-client", () => ({
 	apiClient: {
 		GET: getMock,
+		POST: postMock,
 	},
 	apiErrorMessage: (error: unknown, fallback = "Request failed") => {
 		if (error instanceof Error) return error.message;
@@ -35,9 +36,75 @@ function diffLine(text: string) {
 		element != null && /whitespace-pre/.test(element.className) && element.textContent === text;
 }
 
+// Climbs from a DOM node down to the nearest text node, used to build real
+// Range boundaries for selection tests. `fromEnd` walks children in reverse so
+// callers can find the *last* text node of a subtree (for a Range end) as well
+// as the first (for a Range start) — needed because intra-line word highlights
+// nest the row's code text a level or two deeper than a plain row.
+function findTextNode(node: Node, fromEnd: boolean): Text | null {
+	if (node.nodeType === Node.TEXT_NODE) return node as Text;
+	const children = Array.from(node.childNodes);
+	const ordered = fromEnd ? children.reverse() : children;
+	for (const child of ordered) {
+		const found = findTextNode(child, fromEnd);
+		if (found) return found;
+	}
+	return null;
+}
+
+// Builds a real, non-collapsed browser Selection spanning the diff rows at
+// data-row-index `startIndex`..`endIndex` (inclusive) within `container`,
+// mirroring how a user would drag-select across rendered diff rows. jsdom
+// fires `selectionchange` asynchronously (matching real browsers), so this
+// also flushes that pending event before returning.
+async function selectAcrossRows(container: HTMLElement, startIndex: number, endIndex: number) {
+	const startRow = container.querySelector(`[data-row-index="${startIndex}"]`) as HTMLElement | null;
+	const endRow = container.querySelector(`[data-row-index="${endIndex}"]`) as HTMLElement | null;
+	if (!startRow || !endRow) throw new Error(`Expected diff rows at indices ${startIndex} and ${endIndex}`);
+	const startText = findTextNode(startRow.querySelector("span:last-child")!, false);
+	const endText = findTextNode(endRow.querySelector("span:last-child")!, true);
+	if (!startText || !endText) throw new Error("Expected a text node inside the selected diff rows");
+
+	const range = document.createRange();
+	range.setStart(startText, 0);
+	range.setEnd(endText, endText.textContent?.length ?? 0);
+	const selection = window.getSelection();
+	if (!selection) throw new Error("window.getSelection() unavailable");
+	selection.removeAllRanges();
+	selection.addRange(range);
+
+	await act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+
+	return { startRow, endRow };
+}
+
+const multiHunkDiff =
+	"diff --git a/src/App.tsx b/src/App.tsx\n" +
+	"index 111..222 100644\n" +
+	"--- a/src/App.tsx\n" +
+	"+++ b/src/App.tsx\n" +
+	"@@ -1,3 +1,3 @@\n" +
+	" line one\n" +
+	"-line two\n" +
+	"+line two changed\n" +
+	" line three\n" +
+	"@@ -10,3 +10,2 @@\n" +
+	" line ten\n" +
+	"-line eleven\n" +
+	" line twelve\n";
+
 describe("SessionFilesView", () => {
 	beforeEach(() => {
 		getMock.mockReset();
+		postMock.mockReset();
+		postMock.mockResolvedValue({ data: {} });
+		window.getSelection()?.removeAllRanges();
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: vi.fn() },
+		});
 		getMock.mockImplementation(async (path: string, options?: unknown) => {
 			if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
 				return {
@@ -100,6 +167,11 @@ describe("SessionFilesView", () => {
 			}
 			return { data: undefined };
 		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		window.getSelection()?.removeAllRanges();
 	});
 
 	it("loads the workspace files and requests detail for the selected file", async () => {
@@ -427,5 +499,183 @@ describe("SessionFilesView", () => {
 
 		await userEvent.click(await screen.findByRole("button", { name: "Close files" }));
 		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	describe("diff selection -> send to agent", () => {
+		it("removes the selectionchange listener when the diff view unmounts", async () => {
+			const { unmount } = renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+			await screen.findByText(diffLine("const value = 1;"));
+
+			const removeSpy = vi.spyOn(document, "removeEventListener");
+			unmount();
+
+			expect(removeSpy).toHaveBeenCalledWith("selectionchange", expect.any(Function));
+			removeSpy.mockRestore();
+		});
+
+		it("opens the custom menu for a real drag selection across diff rows and suppresses the native menu", async () => {
+			const { container } = renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+			await screen.findByText(diffLine("const value = 1;"));
+
+			const scrollPane = container.querySelector(".session-files-diff-scrollbar") as HTMLElement;
+			// Row 1 is the deleted line, row 2 is the added line — a selection
+			// dragged across both.
+			const { startRow } = await selectAcrossRows(scrollPane, 1, 2);
+
+			const notCanceled = fireEvent.contextMenu(startRow, { clientX: 12, clientY: 34 });
+
+			// fireEvent's return value is false when a handler called preventDefault —
+			// i.e. this is direct evidence the native context menu was suppressed.
+			expect(notCanceled).toBe(false);
+			expect(await screen.findByRole("menuitem", { name: "Copy" })).toBeInTheDocument();
+			expect(screen.getByRole("menuitem", { name: "Explain" })).toBeInTheDocument();
+			expect(screen.getByRole("menuitem", { name: "Make changes" })).toBeInTheDocument();
+		});
+
+		it("leaves the native context menu untouched when there is no active selection", async () => {
+			renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+			const contentSpan = await screen.findByText(diffLine("const value = 1;"));
+			window.getSelection()?.removeAllRanges();
+
+			const notCanceled = fireEvent.contextMenu(contentSpan, { clientX: 1, clientY: 1 });
+
+			expect(notCanceled).toBe(true);
+			expect(screen.queryByRole("menuitem", { name: "Copy" })).not.toBeInTheDocument();
+		});
+
+		it("maps a selection spanning multiple hunks and a pure-deletion line to the composed message", async () => {
+			getMock.mockImplementation(async (path: string) => {
+				if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
+					return {
+						data: {
+							sessionId: "sess-1",
+							truncated: false,
+							compareMode: "base",
+							files: [{ path: "src/App.tsx", status: "modified", additions: 1, deletions: 2, size: 120, binary: false }],
+						},
+					};
+				}
+				return {
+					data: {
+						sessionId: "sess-1",
+						path: "src/App.tsx",
+						status: "modified",
+						additions: 1,
+						deletions: 2,
+						size: 120,
+						binary: false,
+						deleted: false,
+						content: "",
+						contentTruncated: false,
+						diff: multiHunkDiff,
+						diffTruncated: false,
+					},
+				};
+			});
+
+			const { container } = renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+			await screen.findByText(diffLine("line twelve"));
+
+			const scrollPane = container.querySelector(".session-files-diff-scrollbar") as HTMLElement;
+			// Row 1 ("line one", first hunk) through row 8 ("line twelve", second
+			// hunk) — the range includes the hunk-band row (index 5) in between,
+			// and the pure-deletion row (index 7, no newNo).
+			const { startRow } = await selectAcrossRows(scrollPane, 1, 8);
+
+			const notCanceled = fireEvent.contextMenu(startRow, { clientX: 5, clientY: 6 });
+			expect(notCanceled).toBe(false);
+
+			await userEvent.click(await screen.findByRole("menuitem", { name: "Explain" }));
+
+			await waitFor(() => expect(postMock).toHaveBeenCalled());
+			const body = postMock.mock.calls[0][1].body as { message: string };
+			// Both hunks' real content lines made it into the message...
+			expect(body.message).toContain(" line one");
+			expect(body.message).toContain("- line two");
+			expect(body.message).toContain("+ line two changed");
+			expect(body.message).toContain(" line three");
+			expect(body.message).toContain(" line ten");
+			expect(body.message).toContain("- line eleven");
+			expect(body.message).toContain(" line twelve");
+			// ...but the intervening hunk-band row was dropped, not turned into a
+			// bogus "line".
+			expect(body.message).not.toContain("@@");
+			// The pure-deletion line correctly falls back to old-line numbering
+			// only where it has to; the overall range still prefers new numbers.
+			expect(body.message).toContain("Selected lines 1-11:");
+		});
+
+		it("pauses the file's polling refetch while a selection is active, and resumes once it clears", async () => {
+			// Load with real timers first — react-query's refetchInterval uses a
+			// genuine setInterval, and switching to fake timers here would leave
+			// the initial files-list/file-detail fetch chain (which goes through
+			// several renders) stuck with no way to drive it forward.
+			const { container } = renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+			await screen.findByText(diffLine("const value = 1;"));
+			const callsAfterLoad = getMock.mock.calls.length;
+			expect(callsAfterLoad).toBeGreaterThan(0);
+
+			// Now switch to fake timers so the 3500ms poll window itself is
+			// deterministic. Selecting flips `refetchInterval` from 3500 to
+			// `false`, so react-query tears down its interval; clearing the
+			// selection flips it back to 3500 and react-query schedules a fresh
+			// interval — using the (by-then) fake setInterval — for us to advance.
+			vi.useFakeTimers();
+
+			const scrollPane = container.querySelector(".session-files-diff-scrollbar") as HTMLElement;
+			const startRow = scrollPane.querySelector('[data-row-index="1"]') as HTMLElement;
+			const endRow = scrollPane.querySelector('[data-row-index="2"]') as HTMLElement;
+			const startText = findTextNode(startRow.querySelector("span:last-child")!, false)!;
+			const endText = findTextNode(endRow.querySelector("span:last-child")!, true)!;
+			const range = document.createRange();
+			range.setStart(startText, 0);
+			range.setEnd(endText, endText.textContent?.length ?? 0);
+			act(() => {
+				const selection = window.getSelection();
+				selection?.removeAllRanges();
+				selection?.addRange(range);
+				// Drive the listener directly instead of relying on jsdom's async,
+				// real-clock selectionchange dispatch, which fake timers don't control.
+				document.dispatchEvent(new Event("selectionchange"));
+			});
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(4_000);
+			});
+			expect(getMock).toHaveBeenCalledTimes(callsAfterLoad);
+
+			act(() => {
+				window.getSelection()?.removeAllRanges();
+				document.dispatchEvent(new Event("selectionchange"));
+			});
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(4_000);
+			});
+			expect(getMock.mock.calls.length).toBeGreaterThan(callsAfterLoad);
+		});
+
+		it("maps a single-side selection in split view to only that side's line", async () => {
+			renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+			await screen.findByText(diffLine("const value = 1;"));
+
+			await userEvent.click(screen.getByRole("button", { name: "Split diff view" }));
+
+			const oldSpan = await screen.findByText(diffLine("const value = 0;"));
+			const scrollPane = oldSpan.closest(".session-files-diff-scrollbar") as HTMLElement;
+			// Row 1 (the old/left side) on both ends — a selection confined to a
+			// single split-view column.
+			const { startRow } = await selectAcrossRows(scrollPane, 1, 1);
+
+			const notCanceled = fireEvent.contextMenu(startRow, { clientX: 3, clientY: 4 });
+			expect(notCanceled).toBe(false);
+
+			await userEvent.click(await screen.findByRole("menuitem", { name: "Explain" }));
+
+			await waitFor(() => expect(postMock).toHaveBeenCalled());
+			const body = postMock.mock.calls[0][1].body as { message: string };
+			expect(body.message).toContain("- const value = 0;");
+			expect(body.message).not.toContain("const value = 1;");
+		});
 	});
 });

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type KeyboardEvent,
+	type MouseEvent,
+	type ReactNode,
+} from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
 	Check,
@@ -22,9 +31,11 @@ import {
 	type WorkspaceFileSummary,
 } from "../hooks/useSessionWorkspaceFiles";
 import { cn } from "../lib/utils";
+import type { DiffSelectionLine } from "../../shared/diff-selection";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "./ui/accordion";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
+import { DiffSelectionMenu } from "./DiffSelectionMenu";
 import { Input } from "./ui/input";
 
 type WorkspaceFileDetail = components["schemas"]["WorkspaceFileResponse"] & {
@@ -310,10 +321,14 @@ function ReviewFileCard({
 	split: boolean;
 	wrap: boolean;
 }) {
+	// While the user has an active text selection (or the context menu it opens)
+	// in this file's diff, a background refetch would re-render the diff body
+	// out from under them and blow away the browser's native selection.
+	const [selectionOrMenuActive, setSelectionOrMenuActive] = useState(false);
 	const detailQuery = useQuery({
 		queryKey: ["session-workspace-file", sessionId, file.path],
 		enabled: expanded,
-		refetchInterval: expanded ? 3500 : false,
+		refetchInterval: expanded && !selectionOrMenuActive ? 3500 : false,
 		queryFn: () => loadWorkspaceFile(sessionId, file.path),
 	});
 
@@ -344,7 +359,14 @@ function ReviewFileCard({
 						</PanelMessage>
 					) : null}
 					{!detailQuery.isPending && !detailQuery.error && detailQuery.data ? (
-						<ReviewDiffBody detail={detailQuery.data} split={split && canSplitCompare(file.status)} wrap={wrap} />
+						<ReviewDiffBody
+							detail={detailQuery.data}
+							filePath={file.path}
+							onActiveSelectionChange={setSelectionOrMenuActive}
+							sessionId={sessionId}
+							split={split && canSplitCompare(file.status)}
+							wrap={wrap}
+						/>
 					) : null}
 				</AccordionContent>
 			</li>
@@ -416,7 +438,21 @@ async function loadWorkspaceFile(sessionId: string, path: string) {
 	return data;
 }
 
-function ReviewDiffBody({ detail, split, wrap }: { detail: WorkspaceFileDetail; split: boolean; wrap: boolean }) {
+function ReviewDiffBody({
+	detail,
+	filePath,
+	onActiveSelectionChange,
+	sessionId,
+	split,
+	wrap,
+}: {
+	detail: WorkspaceFileDetail;
+	filePath: string;
+	onActiveSelectionChange: (active: boolean) => void;
+	sessionId: string;
+	split: boolean;
+	wrap: boolean;
+}) {
 	if (detail.binary) {
 		return <PanelMessage>Binary file preview is not available.</PanelMessage>;
 	}
@@ -424,7 +460,17 @@ function ReviewDiffBody({ detail, split, wrap }: { detail: WorkspaceFileDetail; 
 	if (rows.length === 0) {
 		return <PanelMessage>{emptyDiffMessage(detail.compareMode)}</PanelMessage>;
 	}
-	return <DiffView rows={rows} split={split} truncated={detail.diffTruncated} wrap={wrap} />;
+	return (
+		<DiffView
+			filePath={filePath}
+			onActiveSelectionChange={onActiveSelectionChange}
+			rows={rows}
+			sessionId={sessionId}
+			split={split}
+			truncated={detail.diffTruncated}
+			wrap={wrap}
+		/>
+	);
 }
 
 type DiffRowKind = "context" | "add" | "del" | "hunk";
@@ -603,17 +649,116 @@ const diffMarkerGlyph: Record<Exclude<DiffRowKind, "hunk">, string> = {
 	context: " ",
 };
 
+// isSelectionActiveIn is the shared check used both by the live selectionchange
+// listener and the context-menu handler: a real (non-collapsed) selection whose
+// anchor lives inside this DiffView's scroll container.
+function isSelectionActiveIn(selection: Selection | null, container: HTMLElement | null): boolean {
+	if (!selection || !container || selection.isCollapsed) return false;
+	return selection.anchorNode !== null && container.contains(selection.anchorNode);
+}
+
+// closestDiffRowElement climbs from a Range boundary (which for a text
+// selection is almost always a text node, and text nodes have no `.closest`)
+// up to the nearest `[data-diff-row]` element, or null if the boundary isn't
+// inside a real diff row (e.g. it landed on a hunk band or an empty
+// split-view placeholder).
+function closestDiffRowElement(node: Node | null): Element | null {
+	if (!node) return null;
+	const element = node instanceof Element ? node : node.parentElement;
+	return element?.closest?.("[data-diff-row]") ?? null;
+}
+
+// toDiffSelectionLine maps a DiffRow to the shared DiffSelectionLine shape.
+// Hunk rows never carry data-row-index themselves, but a multi-hunk selection
+// range can still include one in the middle of the sliced rows[min..max] —
+// this drops it defensively rather than emitting a bogus "hunk" line.
+function toDiffSelectionLine(row: DiffRow): DiffSelectionLine | null {
+	if (row.kind === "hunk") return null;
+	return { kind: row.kind, oldNo: row.oldNo, newNo: row.newNo, text: row.text };
+}
+
+function isNotNull<T>(value: T | null): value is T {
+	return value !== null;
+}
+
+type DiffViewMenuState = {
+	open: boolean;
+	position: { x: number; y: number };
+	lines: DiffSelectionLine[];
+	selectedText: string;
+};
+
 function DiffView({
+	filePath,
+	onActiveSelectionChange,
 	rows,
+	sessionId,
 	split,
 	truncated,
 	wrap,
 }: {
+	filePath: string;
+	onActiveSelectionChange: (active: boolean) => void;
 	rows: DiffRow[];
+	sessionId: string;
 	split: boolean;
 	truncated?: boolean;
 	wrap: boolean;
 }) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [hasSelection, setHasSelection] = useState(false);
+	const [menuState, setMenuState] = useState<DiffViewMenuState | null>(null);
+
+	useEffect(() => {
+		const onSelectionChange = () => {
+			setHasSelection(isSelectionActiveIn(window.getSelection(), containerRef.current));
+		};
+		document.addEventListener("selectionchange", onSelectionChange);
+		return () => document.removeEventListener("selectionchange", onSelectionChange);
+	}, []);
+
+	const menuOpen = menuState?.open ?? false;
+	useEffect(() => {
+		onActiveSelectionChange(hasSelection || menuOpen);
+	}, [hasSelection, menuOpen, onActiveSelectionChange]);
+
+	const onContextMenu = useCallback(
+		(event: MouseEvent<HTMLDivElement>) => {
+			const container = containerRef.current;
+			const selection = window.getSelection();
+			if (!isSelectionActiveIn(selection, container) || !selection) return;
+
+			// Only past this point do we know we're overriding a real selection —
+			// the native context menu must stay untouched for a collapsed selection
+			// or one outside this container.
+			event.preventDefault();
+
+			const range = selection.getRangeAt(0);
+			const startRow = closestDiffRowElement(range.startContainer);
+			const endRow = closestDiffRowElement(range.endContainer);
+			if (!startRow || !endRow) return;
+
+			const startIndex = Number(startRow.getAttribute("data-row-index"));
+			const endIndex = Number(endRow.getAttribute("data-row-index"));
+			if (!Number.isFinite(startIndex) || !Number.isFinite(endIndex)) return;
+
+			const min = Math.min(startIndex, endIndex);
+			const max = Math.max(startIndex, endIndex);
+			const lines = rows
+				.slice(min, max + 1)
+				.map(toDiffSelectionLine)
+				.filter(isNotNull);
+
+			setMenuState({
+				open: true,
+				position: { x: event.clientX, y: event.clientY },
+				lines,
+				selectedText: selection.toString(),
+			});
+		},
+		[rows],
+	);
+
 	return (
 		<div className="flex min-h-[180px] max-h-[min(620px,calc(100vh-18rem))] flex-col">
 			{truncated ? (
@@ -621,7 +766,11 @@ function DiffView({
 					Diff preview truncated.
 				</div>
 			) : null}
-			<div className="session-files-diff-scrollbar min-h-0 flex-1 overflow-auto bg-terminal font-mono text-xs leading-row text-terminal-foreground">
+			<div
+				className="session-files-diff-scrollbar min-h-0 flex-1 overflow-auto bg-terminal font-mono text-xs leading-row text-terminal-foreground"
+				onContextMenu={onContextMenu}
+				ref={containerRef}
+			>
 				{split ? (
 					<SplitDiff rows={rows} />
 				) : (
@@ -630,7 +779,15 @@ function DiffView({
 							row.kind === "hunk" ? (
 								<HunkBand key={`h${index}`} row={row} />
 							) : (
-								<div className={cn("flex", diffRowTone[row.kind])} key={`r${index}`}>
+								<div
+									className={cn("flex", diffRowTone[row.kind])}
+									data-diff-row=""
+									data-kind={row.kind}
+									data-new-no={row.newNo ?? ""}
+									data-old-no={row.oldNo ?? ""}
+									data-row-index={index}
+									key={`r${index}`}
+								>
 									<span className="w-9 shrink-0 select-none border-r border-border/50 bg-terminal px-1.5 text-right text-passive/70 tabular-nums">
 										{row.newNo ?? row.oldNo ?? ""}
 									</span>
@@ -656,6 +813,15 @@ function DiffView({
 					</div>
 				)}
 			</div>
+			<DiffSelectionMenu
+				filePath={filePath}
+				lines={menuState?.lines ?? []}
+				onOpenChange={(open) => setMenuState((current) => (current ? { ...current, open } : current))}
+				open={menuOpen}
+				position={menuState?.position ?? { x: 0, y: 0 }}
+				selectedText={menuState?.selectedText ?? ""}
+				sessionId={sessionId}
+			/>
 		</div>
 	);
 }
@@ -669,34 +835,47 @@ function HunkBand({ row }: { row: DiffRow }) {
 	);
 }
 
-type SplitRow = { kind: "hunk"; row: DiffRow } | { kind: "pair"; left: DiffRow | null; right: DiffRow | null };
+type SplitRow =
+	| { kind: "hunk"; row: DiffRow }
+	| { kind: "pair"; left: DiffRow | null; leftIndex: number | null; right: DiffRow | null; rightIndex: number | null };
 
 // toSplitRows aligns the unified rows into left (old) / right (new) pairs: each
 // run of deletions lines up index-for-index with the additions that follow it,
-// context appears on both sides, and hunk headers span the full width.
+// context appears on both sides, and hunk headers span the full width. Each
+// side also carries its original index into the flat `rows` array (leftIndex /
+// rightIndex) so SplitSide can stamp the same data-row-index the unified view
+// uses, without SplitSide re-deriving it via `rows.indexOf`.
 function toSplitRows(rows: DiffRow[]): SplitRow[] {
 	const out: SplitRow[] = [];
-	let dels: DiffRow[] = [];
-	let adds: DiffRow[] = [];
+	let dels: Array<{ row: DiffRow; index: number }> = [];
+	let adds: Array<{ row: DiffRow; index: number }> = [];
 	const flush = () => {
 		const count = Math.max(dels.length, adds.length);
-		for (let i = 0; i < count; i += 1) out.push({ kind: "pair", left: dels[i] ?? null, right: adds[i] ?? null });
+		for (let i = 0; i < count; i += 1) {
+			out.push({
+				kind: "pair",
+				left: dels[i]?.row ?? null,
+				leftIndex: dels[i]?.index ?? null,
+				right: adds[i]?.row ?? null,
+				rightIndex: adds[i]?.index ?? null,
+			});
+		}
 		dels = [];
 		adds = [];
 	};
-	for (const row of rows) {
+	rows.forEach((row, index) => {
 		if (row.kind === "del") {
-			dels.push(row);
-			continue;
+			dels.push({ row, index });
+			return;
 		}
 		if (row.kind === "add") {
-			adds.push(row);
-			continue;
+			adds.push({ row, index });
+			return;
 		}
 		flush();
 		if (row.kind === "hunk") out.push({ kind: "hunk", row });
-		else out.push({ kind: "pair", left: row, right: row });
-	}
+		else out.push({ kind: "pair", left: row, leftIndex: index, right: row, rightIndex: index });
+	});
 	flush();
 	return out;
 }
@@ -709,8 +888,8 @@ function SplitDiff({ rows }: { rows: DiffRow[] }) {
 					<HunkBand key={`sh${index}`} row={splitRow.row} />
 				) : (
 					<div className="grid grid-cols-2 divide-x divide-border/40" key={`sp${index}`}>
-						<SplitSide row={splitRow.left} side="old" />
-						<SplitSide row={splitRow.right} side="new" />
+						<SplitSide row={splitRow.left} rowIndex={splitRow.leftIndex} side="old" />
+						<SplitSide row={splitRow.right} rowIndex={splitRow.rightIndex} side="new" />
 					</div>
 				),
 			)}
@@ -718,12 +897,19 @@ function SplitDiff({ rows }: { rows: DiffRow[] }) {
 	);
 }
 
-function SplitSide({ row, side }: { row: DiffRow | null; side: "old" | "new" }) {
-	if (!row) return <div className="bg-surface-faint/20" aria-hidden="true" />;
+function SplitSide({ row, rowIndex, side }: { row: DiffRow | null; rowIndex: number | null; side: "old" | "new" }) {
+	if (!row || rowIndex === null) return <div className="bg-surface-faint/20" aria-hidden="true" />;
 	const lineNo = side === "old" ? row.oldNo : row.newNo;
 	const tone = row.kind === "hunk" ? "" : diffRowTone[row.kind];
 	return (
-		<div className={cn("flex min-w-0", tone)}>
+		<div
+			className={cn("flex min-w-0", tone)}
+			data-diff-row=""
+			data-kind={row.kind}
+			data-new-no={row.newNo ?? ""}
+			data-old-no={row.oldNo ?? ""}
+			data-row-index={rowIndex}
+		>
 			<span className="w-9 shrink-0 select-none border-r border-border/50 bg-terminal px-1.5 text-right text-passive/70 tabular-nums">
 				{lineNo ?? ""}
 			</span>

--- a/frontend/src/shared/diff-selection.test.ts
+++ b/frontend/src/shared/diff-selection.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import {
+	MAX_DIFF_SELECTION_MESSAGE_LENGTH,
+	formatDiffSelectionMessage,
+	type DiffSelectionPayload,
+} from "./diff-selection";
+
+describe("formatDiffSelectionMessage", () => {
+	it("formats a simple selection of context, add, and del lines with line range", () => {
+		const payload: DiffSelectionPayload = {
+			instruction: "Explain this change",
+			filePath: "src/app.ts",
+			lines: [
+				{ kind: "context", oldNo: 10, newNo: 10, text: "export function greet(name: string) {" },
+				{ kind: "add", oldNo: null, newNo: 11, text: "return `Hello, ${name}!`;" },
+				{ kind: "del", oldNo: 12, newNo: null, text: "console.log(name);" },
+				{ kind: "context", oldNo: 13, newNo: 12, text: "}" },
+			],
+		};
+
+		const message = formatDiffSelectionMessage(payload);
+
+		expect(message).toContain("Explain this change");
+		expect(message).toContain("src/app.ts");
+		expect(message).toContain("lines 10-12");
+		expect(message).toContain(" export function greet(name: string) {");
+		expect(message).toContain("+ return `Hello, ${name}!`;");
+		expect(message).toContain("- console.log(name);");
+		expect(message).toContain(" }");
+	});
+
+	it("derives line range from new numbers when available", () => {
+		const payload: DiffSelectionPayload = {
+			instruction: "Make changes",
+			filePath: "test.js",
+			lines: [
+				{ kind: "add", oldNo: null, newNo: 5, text: "new line 1" },
+				{ kind: "add", oldNo: null, newNo: 6, text: "new line 2" },
+				{ kind: "add", oldNo: null, newNo: 7, text: "new line 3" },
+			],
+		};
+
+		const message = formatDiffSelectionMessage(payload);
+
+		expect(message).toContain("lines 5-7");
+	});
+
+	it("falls back to old numbers for pure-deletion selections with no newNo", () => {
+		const payload: DiffSelectionPayload = {
+			instruction: "Review these deletions",
+			filePath: "src/old.ts",
+			lines: [
+				{ kind: "del", oldNo: 20, newNo: null, text: "remove this" },
+				{ kind: "del", oldNo: 21, newNo: null, text: "and this too" },
+				{ kind: "del", oldNo: 22, newNo: null, text: "and this" },
+			],
+		};
+
+		const message = formatDiffSelectionMessage(payload);
+
+		expect(message).toContain("lines 20-22");
+	});
+
+	it("prefers new-line numbering when mixed add/del/context lines are present", () => {
+		const payload: DiffSelectionPayload = {
+			instruction: "Explain",
+			filePath: "mixed.js",
+			lines: [
+				{ kind: "del", oldNo: 5, newNo: null, text: "old line" },
+				{ kind: "add", oldNo: null, newNo: 5, text: "new line" },
+				{ kind: "context", oldNo: 6, newNo: 6, text: "context" },
+			],
+		};
+
+		const message = formatDiffSelectionMessage(payload);
+
+		// Should use new numbers (5-6) since at least one line has a newNo
+		expect(message).toContain("lines 5-6");
+	});
+
+	it("includes diff markers (space for context, + for add, - for del)", () => {
+		const payload: DiffSelectionPayload = {
+			instruction: "Review",
+			filePath: "file.ts",
+			lines: [
+				{ kind: "context", oldNo: 1, newNo: 1, text: "unchanged line" },
+				{ kind: "add", oldNo: null, newNo: 2, text: "added line" },
+				{ kind: "del", oldNo: 3, newNo: null, text: "deleted line" },
+			],
+		};
+
+		const message = formatDiffSelectionMessage(payload);
+
+		// Check that diff markers are preserved
+		expect(message).toContain(" unchanged line");
+		expect(message).toContain("+ added line");
+		expect(message).toContain("- deleted line");
+	});
+
+	it("reflects both canned and user-typed instructions verbatim", () => {
+		const cannedPayload: DiffSelectionPayload = {
+			instruction: "Explain this change",
+			filePath: "file.ts",
+			lines: [{ kind: "context", oldNo: 1, newNo: 1, text: "line" }],
+		};
+
+		const cannedMessage = formatDiffSelectionMessage(cannedPayload);
+		expect(cannedMessage).toContain("Explain this change");
+
+		const userPayload: DiffSelectionPayload = {
+			instruction: "This is my custom instruction to fix the bug",
+			filePath: "file.ts",
+			lines: [{ kind: "context", oldNo: 1, newNo: 1, text: "line" }],
+		};
+
+		const userMessage = formatDiffSelectionMessage(userPayload);
+		expect(userMessage).toContain("This is my custom instruction to fix the bug");
+	});
+
+	it("keeps the total message below the length cap", () => {
+		const longText = "x".repeat(500);
+		const payload: DiffSelectionPayload = {
+			instruction: "Make changes: " + "a".repeat(200),
+			filePath: "very/long/file/path/that/is/quite/long.ts",
+			lines: Array.from({ length: 100 }, (_, i) => ({
+				kind: "add" as const,
+				oldNo: null,
+				newNo: i + 1,
+				text: longText,
+			})),
+		};
+
+		const message = formatDiffSelectionMessage(payload);
+
+		expect(message.length).toBeLessThanOrEqual(MAX_DIFF_SELECTION_MESSAGE_LENGTH);
+		expect(message).toContain("[truncated]");
+	});
+
+	it("handles a single line selection", () => {
+		const payload: DiffSelectionPayload = {
+			instruction: "Explain",
+			filePath: "single.ts",
+			lines: [{ kind: "add", oldNo: null, newNo: 42, text: "console.log('test');" }],
+		};
+
+		const message = formatDiffSelectionMessage(payload);
+
+		expect(message).toContain("lines 42-42");
+		expect(message).toContain("+ console.log('test');");
+	});
+
+	it("handles empty text lines", () => {
+		const payload: DiffSelectionPayload = {
+			instruction: "Review",
+			filePath: "blank.ts",
+			lines: [
+				{ kind: "context", oldNo: 1, newNo: 1, text: "function test() {" },
+				{ kind: "add", oldNo: null, newNo: 2, text: "" },
+				{ kind: "context", oldNo: 2, newNo: 3, text: "}" },
+			],
+		};
+
+		const message = formatDiffSelectionMessage(payload);
+
+		// Empty line should still have the marker
+		expect(message).toContain("+");
+	});
+
+	it("preserves instruction and file path for truncated messages", () => {
+		const longText = "x".repeat(2000);
+		const payload: DiffSelectionPayload = {
+			instruction: "Critical instruction",
+			filePath: "src/critical.ts",
+			lines: Array.from({ length: 50 }, (_, i) => ({
+				kind: "add" as const,
+				oldNo: null,
+				newNo: i + 1,
+				text: longText,
+			})),
+		};
+
+		const message = formatDiffSelectionMessage(payload);
+
+		expect(message).toContain("Critical instruction");
+		expect(message).toContain("src/critical.ts");
+		expect(message).toContain("[truncated]");
+	});
+});

--- a/frontend/src/shared/diff-selection.ts
+++ b/frontend/src/shared/diff-selection.ts
@@ -1,0 +1,103 @@
+export const MAX_DIFF_SELECTION_MESSAGE_LENGTH = 8192;
+
+const MAX_INSTRUCTION_LENGTH = 1000;
+const MAX_FILEPATH_LENGTH = 500;
+const MAX_LINE_TEXT_LENGTH = 1000;
+
+export type DiffSelectionLineKind = "context" | "add" | "del";
+
+export type DiffSelectionLine = {
+	kind: DiffSelectionLineKind;
+	oldNo: number | null;
+	newNo: number | null;
+	text: string;
+};
+
+export type DiffSelectionPayload = {
+	instruction: string;
+	filePath: string;
+	lines: DiffSelectionLine[];
+};
+
+export function formatDiffSelectionMessage(payload: DiffSelectionPayload): string {
+	const instruction = compactText(payload.instruction, MAX_INSTRUCTION_LENGTH) || "(empty)";
+	const filePath = compactText(payload.filePath, MAX_FILEPATH_LENGTH);
+	const lineRange = deriveLineRange(payload.lines);
+
+	const formattedLines = payload.lines.map((line) => {
+		const marker = getMarkerForKind(line.kind);
+		const text = truncateLineText(line.text, MAX_LINE_TEXT_LENGTH);
+		// Marker is either a space (context), '+' (add), or '-' (del).
+		// For readability in message format, add a space after + and - markers to match context format.
+		const separator = marker === " " ? "" : " ";
+		return `${marker}${separator}${text}`;
+	});
+
+	const lines = [
+		"The user selected lines in the diff viewer and asked for a change.",
+		"",
+		"Instruction:",
+		instruction,
+		"",
+		`File: ${filePath}`,
+		`Selected ${lineRange}:`,
+		"",
+		...formattedLines,
+	];
+
+	return limitMessage(lines.join("\n"), MAX_DIFF_SELECTION_MESSAGE_LENGTH);
+}
+
+function deriveLineRange(lines: DiffSelectionLine[]): string {
+	if (lines.length === 0) return "lines (empty selection)";
+
+	const firstLine = lines[0];
+	const lastLine = lines[lines.length - 1];
+
+	// Determine if we have any new numbers
+	const hasAnyNewNo = lines.some((line) => line.newNo !== null);
+
+	if (hasAnyNewNo) {
+		// Prefer new-line range when any line has a new number
+		const startNo = firstLine.newNo ?? firstLine.oldNo ?? "?";
+		const endNo = lastLine.newNo ?? lastLine.oldNo ?? "?";
+		return `lines ${startNo}-${endNo}`;
+	} else {
+		// Fall back to old-line range (for pure deletions)
+		const startNo = firstLine.oldNo ?? "?";
+		const endNo = lastLine.oldNo ?? "?";
+		return `lines ${startNo}-${endNo}`;
+	}
+}
+
+function getMarkerForKind(kind: DiffSelectionLineKind): string {
+	switch (kind) {
+		case "add":
+			return "+";
+		case "del":
+			return "-";
+		case "context":
+			return " ";
+	}
+}
+
+function compactText(value: string, maxLength: number): string {
+	const compact = value.replace(/\s+/g, " ").trim();
+	if (compact.length <= maxLength) return compact;
+	const suffix = " [truncated]";
+	return `${compact.slice(0, Math.max(0, maxLength - suffix.length)).trimEnd()}${suffix}`;
+}
+
+function truncateLineText(value: string, maxLength: number): string {
+	// Preserve whitespace in diff lines (meaningful indentation, etc.)
+	// Only truncate if line exceeds maxLength.
+	if (value.length <= maxLength) return value;
+	const suffix = "[truncated]";
+	return `${value.slice(0, Math.max(0, maxLength - suffix.length))}${suffix}`;
+}
+
+function limitMessage(message: string, maxLength: number): string {
+	if (message.length <= maxLength) return message;
+	const suffix = "\n[truncated]";
+	return `${message.slice(0, Math.max(0, maxLength - suffix.length)).trimEnd()}${suffix}`;
+}


### PR DESCRIPTION
## Summary
- Select a range of lines in a session's diff viewer (unified or split), right-click, and either **Explain** or **Make changes** — sends a composed message to the agent via the existing `/send` endpoint, reusing the same mechanism the browser-panel "annotate page" flow already proves out.
- **Copy** is also available from the same menu, since intercepting the native context menu loses the browser's default Copy item.
- Diff polling pauses while a selection or the menu is active, so a background refetch can't clear the user's selection mid-action.

Stacked on #3466 (targets that branch, not `main`) since it depends on the toolbar/accordion rewrite there.

## Changes
- `frontend/src/shared/diff-selection.ts` — pure message formatter (mirrors `browser-annotations.ts`)
- `frontend/src/renderer/components/DiffSelectionMenu.tsx` — cursor-positioned Copy/Explain/Make-changes menu (mirrors `XtermTerminal.tsx`'s context-menu pattern)
- `frontend/src/renderer/components/SessionFilesView.tsx` — wires real text selection to the menu via `data-row-index` row attributes, and pauses the file card's polling refetch while a selection/menu is active

## Test plan
- [x] `diff-selection.test.ts`, `DiffSelectionMenu.test.tsx`, `SessionFilesView.test.tsx` — 50/50 passing
- [x] `tsc --noEmit` clean
- [x] Full renderer suite run — only pre-existing, unrelated failures (macOS packaging tests, a Windows socket-timing test, a landing-docs script missing an optional `cheerio` dep), confirmed unrelated via `git stash`
- [ ] Manual: drag-select in a running session (unified + split), right-click, Explain/Make changes/Copy, confirm the agent receives the right file/lines and the diff auto-refreshes after an edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)