### PR TITLE
fix(desktop): clamp sidebar and inspector drags at min width instead of auto-collapsing

### DIFF
--- a/frontend/e2e/inspector-toggle.spec.ts
+++ b/frontend/e2e/inspector-toggle.spec.ts
@@ -9,9 +9,8 @@ import { expect, test } from "@playwright/test";
 // profiles to collapsed. Only real separator drags may write back; this needs
 // the real rrp + CSS pipeline, which the mocked unit tests can't exercise.
 test("topbar button collapses and reopens the inspector rail", async ({ page }) => {
-	await page.goto("/");
-	await page.getByRole("button", { name: "Open refactor-mux" }).click();
-	await expect(page).toHaveURL(/sessions\/refactor-mux/);
+	// A worker session from the dev:web mock dataset (lib/mock-data.ts).
+	await page.goto("/#/projects/ao-demo/sessions/demo-working");
 
 	// Fresh profile: the rail must mount open, not get toggled shut by
 	// mount-time layout events.

--- a/frontend/e2e/resize-clamp.spec.ts
+++ b/frontend/e2e/resize-clamp.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Dragging a panel edge must clamp at the panel's minimum width — never
+// auto-collapse. Both rails had drag-to-collapse behavior: the sidebar's
+// useResizable fired onCollapse the moment a drag crossed the min, and the
+// inspector's always-`collapsible` rrp panel snapped to 0% past minSize.
+// Collapse belongs to the explicit controls only (⌘B / topbar buttons). The
+// clamp lives in the real drag pipelines (pointer events + rrp + CSS), which
+// the mocked unit tests can't exercise end-to-end.
+
+async function dragPointer(page: Page, from: { x: number; y: number }, to: { x: number; y: number }) {
+	await page.mouse.move(from.x, from.y);
+	await page.mouse.down();
+	// Multiple steps so rrp/useResizable see a realistic pointermove stream.
+	await page.mouse.move(to.x, to.y, { steps: 8 });
+	await page.mouse.up();
+}
+
+test("sidebar drag stops at its minimum width instead of collapsing", async ({ page }) => {
+	await page.goto("/");
+
+	const sidebar = page.locator('[data-slot="sidebar"]');
+	await expect(sidebar).toHaveAttribute("data-state", "expanded");
+
+	const handle = page.getByTestId("resize-handle");
+	const box = await handle.boundingBox();
+	if (!box) throw new Error("sidebar resize handle not visible");
+
+	// Drag far past the 200px floor, all the way to the window edge.
+	await dragPointer(
+		page,
+		{ x: box.x + box.width / 2, y: box.y + box.height / 2 },
+		{ x: 0, y: box.y + box.height / 2 },
+	);
+
+	await expect(sidebar).toHaveAttribute("data-state", "expanded");
+	const width = await page.evaluate(() =>
+		document.documentElement.style.getPropertyValue("--ao-sidebar-w"),
+	);
+	expect(width).toBe("200px");
+
+	// The explicit toggle still collapses (and the drag-clamped width persisted).
+	await page.keyboard.press("ControlOrMeta+b");
+	await expect(sidebar).toHaveAttribute("data-state", "collapsed");
+	expect(await page.evaluate(() => window.localStorage.getItem("ao-sidebar-w"))).toBe("200");
+});
+
+test("inspector drag stops at minSize instead of collapsing; buttons still toggle", async ({ page }) => {
+	// A worker session from the dev:web mock dataset (lib/mock-data.ts).
+	await page.goto("/#/projects/ao-demo/sessions/demo-working");
+
+	const inspector = page.locator("#inspector");
+	await expect(inspector).toBeVisible();
+
+	const separator = page.locator('[data-slot="resizable-handle"]');
+	const separatorBox = await separator.boundingBox();
+	const groupBox = await page.locator("#session-workspace").boundingBox();
+	if (!separatorBox || !groupBox) throw new Error("session split not visible");
+	const y = separatorBox.y + separatorBox.height / 2;
+
+	// Drag the separator all the way to the right edge: the rail must clamp at
+	// its 22% minSize, not snap away.
+	await dragPointer(
+		page,
+		{ x: separatorBox.x + separatorBox.width / 2, y },
+		{ x: groupBox.x + groupBox.width - 2, y },
+	);
+
+	await expect(inspector).toBeVisible();
+	const inspectorBox = await inspector.boundingBox();
+	if (!inspectorBox) throw new Error("inspector hidden after drag");
+	expect(inspectorBox.width / groupBox.width).toBeGreaterThan(0.2);
+
+	// The explicit control still collapses…
+	await page.getByRole("button", { name: "Close inspector panel" }).click();
+	await expect(inspector).toBeHidden();
+
+	// …and dragging the collapsed rail's separator back out reopens it.
+	const collapsedSeparatorBox = await separator.boundingBox();
+	if (!collapsedSeparatorBox) throw new Error("separator not visible while collapsed");
+	await dragPointer(
+		page,
+		{ x: collapsedSeparatorBox.x + collapsedSeparatorBox.width / 2, y },
+		{ x: groupBox.x + groupBox.width * 0.7, y },
+	);
+	await expect(inspector).toBeVisible();
+
+	// Reopened rail must again refuse to drag-collapse.
+	const reopenedSeparatorBox = await separator.boundingBox();
+	if (!reopenedSeparatorBox) throw new Error("separator not visible after reopen");
+	await dragPointer(
+		page,
+		{ x: reopenedSeparatorBox.x + reopenedSeparatorBox.width / 2, y },
+		{ x: groupBox.x + groupBox.width - 2, y },
+	);
+	await expect(inspector).toBeVisible();
+});

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -437,7 +437,9 @@ describe("SessionView", () => {
 
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		expect(panelSizes("inspector")[0]).toBe("28%");
-		expect(screen.getByTestId("panel-inspector")).toHaveAttribute("data-collapsible", "true");
+		// Open panels are non-collapsible so a drag clamps at minSize instead of
+		// snapping the rail away; only the closed panel is collapsible.
+		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("data-collapsible");
 		expect(screen.getByTestId("resize-handle")).toBeInTheDocument();
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
@@ -471,6 +473,9 @@ describe("SessionView", () => {
 		const pane = screen.getByTestId("panel-inspector");
 		expect(pane).toHaveAttribute("inert");
 		expect(pane).toHaveAttribute("aria-hidden", "true");
+		// Collapsed panels stay collapsible so the 0% size is a valid rrp state
+		// (and the separator can drag the rail back open).
+		expect(pane).toHaveAttribute("data-collapsible", "true");
 		expect(panels.get("inspector")!.handle.collapse).not.toHaveBeenCalled();
 	});
 
@@ -501,13 +506,16 @@ describe("SessionView", () => {
 		);
 		const handle = panels.get("inspector")!.handle;
 
-		expect(handle.expand).not.toHaveBeenCalled();
+		expect(handle.resize).not.toHaveBeenCalled();
 		expect(handle.collapse).not.toHaveBeenCalled();
 
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 
 		expect(inspectorOpen("sess-1")).toBe(true);
-		expect(handle.expand).toHaveBeenCalledTimes(1);
+		// Opening resizes to the persisted split rather than expand(): the open
+		// panel re-registers as non-collapsible, and rrp's expand() no-ops on a
+		// non-collapsible panel.
+		expect(handle.resize).toHaveBeenCalledWith("28%");
 		expect(handle.collapse).not.toHaveBeenCalled();
 	});
 
@@ -522,38 +530,43 @@ describe("SessionView", () => {
 
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 		expect(inspectorOpen("sess-1")).toBe(true);
-		expect(handle.expand).toHaveBeenCalled();
+		expect(handle.resize).toHaveBeenCalledWith("28%");
 
 		// Plain ⌘B belongs to the sidebar — the inspector must not react.
 		fireEvent.keyDown(window, { key: "b", metaKey: true });
 		expect(inspectorOpen("sess-1")).toBe(true);
 	});
 
-	it("syncs drag resizes back into the store and persists the split", () => {
+	it("persists drag resizes and never closes the store from a drag", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		render(<SessionView sessionId="sess-1" />);
 		const entry = panels.get("inspector")!;
 		// rrp marks the separator active for the duration of a pointer drag.
 		screen.getByTestId("resize-handle").setAttribute("data-separator", "active");
 
-		// Dragging past minSize collapses the panel → store follows.
-		act(() => entry.onResize?.({ asPercentage: 0, inPixels: 0 }));
-		expect(inspectorOpen("sess-1")).toBe(false);
-
-		// Dragging it back open reopens + persists the width.
+		// Dragging persists the width.
 		act(() => entry.onResize?.({ asPercentage: 31.5, inPixels: 400 }));
+		expect(inspectorOpen("sess-1")).toBe(true);
+		expect(window.localStorage.getItem("ao.inspector.split")).toBe("31.5");
+
+		// A drag can never auto-collapse the rail: even if a 0-size frame arrives
+		// mid-drag, the store stays open — collapse belongs to the explicit
+		// controls (topbar button / ⌘⇧B) only.
+		act(() => entry.onResize?.({ asPercentage: 0, inPixels: 0 }));
 		expect(inspectorOpen("sess-1")).toBe(true);
 		expect(window.localStorage.getItem("ao.inspector.split")).toBe("31.5");
 	});
 
-	it("persists a drag collapse from the default-open inspector state", () => {
+	it("reopens the store when a drag pulls the collapsed rail back open", () => {
+		act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
 		render(<SessionView sessionId="sess-1" />);
 		const entry = panels.get("inspector")!;
 		screen.getByTestId("resize-handle").setAttribute("data-separator", "active");
 
-		act(() => entry.onResize?.({ asPercentage: 0, inPixels: 0 }));
+		act(() => entry.onResize?.({ asPercentage: 25, inPixels: 320 }));
 
-		expect(useUiStore.getState().inspectorSessions["sess-1"]).toMatchObject({ isOpen: false, view: "summary" });
+		expect(useUiStore.getState().inspectorSessions["sess-1"]).toMatchObject({ isOpen: true });
+		expect(window.localStorage.getItem("ao.inspector.split")).toBe("25");
 	});
 
 	// Regression: rrp v4 reports observed DOM sizes, so the flex-grow
@@ -624,7 +637,7 @@ describe("SessionView", () => {
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 
 		expect(inspectorOpen("sess-2")).toBe(true);
-		expect(handle.expand).toHaveBeenCalledTimes(1);
+		expect(handle.resize).toHaveBeenCalledWith("28%");
 	});
 
 	it("renders no inspector panel or handle for orchestrator sessions", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -54,10 +54,14 @@ type SessionViewProps = {
 // each session gets a clean xterm/mux binding.
 //
 // The split is shadcn's resizable (react-resizable-panels v4) with a fully
-// collapsible inspector: the panel is `collapsible` and driven to 0% via the
-// imperative API from the ui-store (topbar button / ⌘⇧B), animated by the
-// flex-grow transition in styles.css. Content keeps a stable min-width inside
-// the clipped panel so nothing reflows mid-animation; split width persists.
+// collapsible inspector driven to 0% via the imperative API from the ui-store
+// (topbar button / ⌘⇧B), animated by the flex-grow transition in styles.css.
+// The panel is `collapsible` only while closed: rrp snaps a collapsible panel
+// to 0% when a drag crosses minSize, so an always-collapsible inspector let a
+// drag vanish the rail. While open the panel is non-collapsible and a drag
+// hard-stops at INSPECTOR_MIN_PERCENT; only the explicit controls collapse it.
+// Content keeps a stable min-width inside the clipped panel so nothing reflows
+// mid-animation; split width persists.
 export function SessionView({ sessionId }: SessionViewProps) {
 	const { t } = useTranslation();
 	const workspaceQuery = useWorkspaceQuery();
@@ -271,7 +275,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// Computed when the inspector panel mounts and frozen while it stays
 	// mounted: rrp re-registers the panel (a layout effect keyed on defaultSize,
 	// among others) whenever this prop's identity changes, and the imperative
-	// collapse()/expand() below can race that re-registration within the same
+	// collapse()/resize() below can race that re-registration within the same
 	// commit — rrp then throws "Panel constraints not found for Panel
 	// inspector", which unwinds the whole route to the router's CatchBoundary
 	// (the toggle button looks dead and the session view is torn down).
@@ -300,7 +304,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	}, [hasInspector, sessionId, toggleInspector]);
 
 	// Drive the collapsible panel from the store so the topbar button, ⌘⇧B, and
-	// drag-to-collapse all stay in sync. When the inspector panel mounts into
+	// drag-to-reopen all stay in sync. When the inspector panel mounts into
 	// the already-live group (orchestrator/loading → worker), rrp only derives
 	// the new panel's constraints in the next commit. This effect intentionally
 	// runs before the readiness effect below, so mount and StrictMode's effect
@@ -312,13 +316,23 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		const panel = inspectorRef.current;
 		if (!panel) return;
 		if (isInspectorOpen) {
-			panel.expand();
-			// expand() restores the "most recent" size, which is 0 when the panel
-			// mounted collapsed — fall back to the persisted split.
-			if (panel.getSize().asPercentage === 0) panel.resize(`${initialSplitPercent()}%`);
-		} else {
-			panel.collapse();
+			// resize(), not expand(): by the time this effect runs the panel has
+			// re-registered as non-collapsible (open panels refuse drag-collapse),
+			// and rrp's expand() no-ops on a non-collapsible panel. resize() also
+			// restores the persisted split regardless of what "most recent size"
+			// rrp remembers, which is 0 when the panel mounted collapsed.
+			panel.resize(`${initialSplitPercent()}%`);
+			return;
 		}
+		// Closing flips `collapsible` back on in this same commit, but rrp only
+		// re-derives the group's constraints in the follow-up commit its
+		// registration effect schedules — so this first collapse() still sees the
+		// open panel's non-collapsible constraints and no-ops. Repeat it on the
+		// next frame, when the fresh constraints have landed; collapse() is
+		// idempotent, so the double call is safe wherever the derivation lands.
+		panel.collapse();
+		const frame = window.requestAnimationFrame(() => panel.collapse());
+		return () => window.cancelAnimationFrame(frame);
 	}, [hasInspector, isInspectorOpen]);
 	useEffect(() => {
 		if (!hasInspector || !inspectorRef.current) {
@@ -331,11 +345,14 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		};
 	}, [hasInspector]);
 
-	// Persist drags and mirror collapse state (dragging past minSize collapses)
-	// back into the store. Read the store imperatively to avoid a stale closure.
+	// Persist drags and mirror a drag-reopen (dragging the separator of a
+	// collapsed inspector past the snap point) back into the store. Dragging an
+	// open inspector can never collapse it — the panel is non-collapsible while
+	// open, so rrp clamps the drag at minSize instead of snapping to 0%.
+	// Read the store imperatively to avoid a stale closure.
 	// Gated on an actively dragged separator: rrp v4 derives sizes from the
 	// observed DOM layout, so the flex-grow transition that animates
-	// expand()/collapse() (styles.css) fires onResize with transient
+	// resize()/collapse() (styles.css) fires onResize with transient
 	// mid-animation sizes too. Writing those back turned the imperative
 	// collapse into a feedback loop — a mid-collapse size read as "dragged
 	// back open", re-toggled the store, and the panel bounced back (the
@@ -346,17 +363,14 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// Also wrapped in useCallback: rrp v4's panel registration useLayoutEffect
 	// includes onResize in its dep array, so an unstable reference would
 	// de-register/re-register the inspector panel on every render and race
-	// with the expand()/collapse() effect above.
+	// with the resize()/collapse() effect above.
 	const handleInspectorResize = useCallback(
 		(size: PanelSize) => {
 			if (inspectorSeparatorRef.current?.getAttribute("data-separator") !== "active") return;
+			if (size.asPercentage <= 0) return;
+			window.localStorage?.setItem(inspectorSplitStorageKey, String(size.asPercentage));
 			const currentOpen = useUiStore.getState().inspectorSessions[sessionId]?.isOpen ?? true;
-			if (size.asPercentage > 0) {
-				window.localStorage?.setItem(inspectorSplitStorageKey, String(size.asPercentage));
-				if (!currentOpen) toggleInspector(sessionId);
-			} else if (currentOpen) {
-				toggleInspector(sessionId);
-			}
+			if (!currentOpen) toggleInspector(sessionId);
 		},
 		[sessionId, toggleInspector],
 	);
@@ -398,7 +412,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 						/>
 						<ResizablePanel
 							aria-hidden={!isInspectorOpen}
-							collapsible
+							collapsible={!isInspectorOpen}
 							defaultSize={inspectorDefaultSize}
 							id="inspector"
 							inert={!isInspectorOpen}

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -3,12 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	Sidebar,
-	SIDEBAR_COLLAPSE_THRESHOLD,
-	SIDEBAR_DEFAULT_WIDTH,
-	SIDEBAR_MIN_WIDTH,
-} from "./Sidebar";
+import { Sidebar, SIDEBAR_DEFAULT_WIDTH, SIDEBAR_MIN_WIDTH } from "./Sidebar";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { agentsQueryKey } from "../hooks/useAgentsQuery";
 import { useUiStore } from "../stores/ui-store";
@@ -252,8 +247,8 @@ describe("Sidebar", () => {
 	it("keeps only the collapsed Settings control keyboard-accessible while collapsed", async () => {
 		renderSidebar();
 
-		fireEvent.pointerDown(screen.getByTestId("resize-handle"), { clientX: SIDEBAR_DEFAULT_WIDTH });
-		fireEvent.pointerMove(window, { clientX: SIDEBAR_COLLAPSE_THRESHOLD - 1 });
+		// Collapse via the explicit shortcut — dragging can no longer collapse.
+		fireEvent.keyDown(window, { key: "b", metaKey: true });
 
 		await waitFor(() => {
 			expect(document.querySelector('[data-slot="sidebar"][data-state="collapsed"]')).toBeInTheDocument();
@@ -980,7 +975,7 @@ describe("Sidebar", () => {
 		expect(projectRow).toHaveClass("pr-sidebar-project-actions");
 	});
 
-	it("snaps to the real collapsed rail when dragged past the resize collapse threshold", async () => {
+	it("clamps a drag at the minimum width instead of collapsing", async () => {
 		renderSidebar();
 
 		const resizeHandle = screen.getByTestId("resize-handle");
@@ -988,16 +983,25 @@ describe("Sidebar", () => {
 
 		expect(document.querySelector('[data-slot="sidebar"][data-state="expanded"]')).toBeInTheDocument();
 
+		// Drag far past the minimum: the width stops at the floor and the sidebar
+		// stays expanded — only the explicit toggle collapses it.
 		fireEvent.pointerDown(resizeHandle, { clientX: SIDEBAR_DEFAULT_WIDTH });
-		fireEvent.pointerMove(window, { clientX: SIDEBAR_COLLAPSE_THRESHOLD - 1 });
+		fireEvent.pointerMove(window, { clientX: 0 });
+		fireEvent.pointerUp(window);
 
+		expect(document.querySelector('[data-slot="sidebar"][data-state="expanded"]')).toBeInTheDocument();
+		expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${SIDEBAR_MIN_WIDTH}px`);
+		expect(window.localStorage.getItem("ao-sidebar-w")).toBe(String(SIDEBAR_MIN_WIDTH));
+		expect(document.body).not.toHaveClass("is-resizing-x");
+	});
+
+	it("expands from the collapsed rail by dragging and persists the width", async () => {
+		renderSidebar();
+
+		fireEvent.keyDown(window, { key: "b", metaKey: true });
 		await waitFor(() => {
 			expect(document.querySelector('[data-slot="sidebar"][data-state="collapsed"]')).toBeInTheDocument();
 		});
-		expect(document.cookie).toContain("sidebar_state=false");
-		expect(window.localStorage.getItem("ao-sidebar-w")).toBe(String(SIDEBAR_DEFAULT_WIDTH));
-		expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${SIDEBAR_DEFAULT_WIDTH}px`);
-		expect(document.body).not.toHaveClass("is-resizing-x");
 
 		const expandRail = document.querySelector('[data-sidebar="rail"]');
 		if (!(expandRail instanceof HTMLElement)) throw new Error("Sidebar rail not found");
@@ -1012,38 +1016,6 @@ describe("Sidebar", () => {
 		});
 		expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${expandedWidth}px`);
 		expect(window.localStorage.getItem("ao-sidebar-w")).toBe(String(expandedWidth));
-	});
-
-	it("discards a queued narrow resize frame when collapsing", async () => {
-		let queuedFrame: FrameRequestCallback | undefined;
-		const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-			queuedFrame = callback;
-			return 1;
-		});
-		const cancelAnimationFrameSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
-
-		try {
-			renderSidebar();
-
-			const resizeHandle = screen.getByTestId("resize-handle");
-
-			fireEvent.pointerDown(resizeHandle, { clientX: SIDEBAR_DEFAULT_WIDTH });
-			fireEvent.pointerMove(window, { clientX: SIDEBAR_MIN_WIDTH + 5 });
-			fireEvent.pointerMove(window, { clientX: SIDEBAR_COLLAPSE_THRESHOLD - 1 });
-
-			await waitFor(() => {
-				expect(document.querySelector('[data-slot="sidebar"][data-state="collapsed"]')).toBeInTheDocument();
-			});
-			expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1);
-			expect(window.localStorage.getItem("ao-sidebar-w")).toBe(String(SIDEBAR_DEFAULT_WIDTH));
-			expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${SIDEBAR_DEFAULT_WIDTH}px`);
-
-			queuedFrame?.(performance.now());
-			expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${SIDEBAR_DEFAULT_WIDTH}px`);
-		} finally {
-			requestAnimationFrameSpy.mockRestore();
-			cancelAnimationFrameSpy.mockRestore();
-		}
 	});
 
 	it("animates active sidebar dots using their PR context color", () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -92,7 +92,6 @@ const MAX_DISPLAY_NAME_LEN = 20;
 export const SIDEBAR_DEFAULT_WIDTH = 240;
 export const SIDEBAR_MIN_WIDTH = 200;
 export const SIDEBAR_MAX_WIDTH = 420;
-export const SIDEBAR_COLLAPSE_THRESHOLD = SIDEBAR_MIN_WIDTH;
 
 type SidebarProps = {
 	/** Hide the sidebar's right edge stroke on the welcome board inset chrome. */
@@ -206,7 +205,9 @@ export function Sidebar({
 
 	// agent-orchestrator's sidebar resize: drag the right edge (200-420px,
 	// persisted), double-click to reset to 240px. Drives --ao-sidebar-w on :root,
-	// which the provider forwards into shadcn's --sidebar-width.
+	// which the provider forwards into shadcn's --sidebar-width. Dragging clamps
+	// at SIDEBAR_MIN_WIDTH — collapsing stays on the explicit toggle (⌘B /
+	// titlebar button), never on a drag.
 	const {
 		onPointerDown: onResizePointerDown,
 		onCollapsedPointerDown: onCollapsedResizePointerDown,
@@ -218,8 +219,6 @@ export function Sidebar({
 		min: SIDEBAR_MIN_WIDTH,
 		max: SIDEBAR_MAX_WIDTH,
 		edge: "right",
-		collapseBelow: SIDEBAR_COLLAPSE_THRESHOLD,
-		onCollapse: () => setOpen(false),
 		onExpand: () => setOpen(true),
 	});
 

--- a/frontend/src/renderer/hooks/useResizable.ts
+++ b/frontend/src/renderer/hooks/useResizable.ts
@@ -14,10 +14,6 @@ interface UseResizableOptions {
 	 * handle) grows with leftward drag.
 	 */
 	edge: "left" | "right";
-	/** Optional raw drag width below which the owner should collapse. */
-	collapseBelow?: number;
-	/** Called once when a drag crosses collapseBelow. */
-	onCollapse?: () => void;
 	/** Called once when a collapsed rail drag should reopen the owner. */
 	onExpand?: () => void;
 	/** Pointer movement needed before a collapsed rail drag expands. */
@@ -37,8 +33,6 @@ export function useResizable({
 	min,
 	max,
 	edge,
-	collapseBelow,
-	onCollapse,
 	onExpand,
 	expandDragThreshold = 8,
 }: UseResizableOptions) {
@@ -79,14 +73,6 @@ export function useResizable({
 		if (pending !== null) apply(pending);
 	}, [apply]);
 
-	const discardPending = useCallback(() => {
-		if (frameRef.current !== null) {
-			window.cancelAnimationFrame(frameRef.current);
-			frameRef.current = null;
-		}
-		pendingWidthRef.current = null;
-	}, []);
-
 	// Restore persisted width on mount.
 	useEffect(() => {
 		const saved = Number(window.localStorage.getItem(storageKey));
@@ -103,7 +89,6 @@ export function useResizable({
 			const startX = event.clientX;
 			const startWidth = widthRef.current;
 			const sign = edge === "right" ? 1 : -1;
-			let collapsed = false;
 			document.body.classList.add("is-resizing-x");
 
 			const onUp = () => {
@@ -111,26 +96,17 @@ export function useResizable({
 				window.removeEventListener("pointerup", onUp);
 				flushPending();
 				document.body.classList.remove("is-resizing-x");
-				if (!collapsed) window.localStorage.setItem(storageKey, String(widthRef.current));
+				window.localStorage.setItem(storageKey, String(widthRef.current));
 			};
+			// Dragging never collapses the panel: `apply` clamps at `min`, so the
+			// drag simply stops at the floor. Collapse stays on explicit controls.
 			const onMove = (e: PointerEvent) => {
-				const nextWidth = startWidth + sign * (e.clientX - startX);
-				if (collapseBelow !== undefined && onCollapse && nextWidth <= collapseBelow) {
-					collapsed = true;
-					const preservedWidth = Math.min(max, Math.max(min, startWidth));
-					discardPending();
-					apply(preservedWidth);
-					window.localStorage.setItem(storageKey, String(preservedWidth));
-					onUp();
-					onCollapse();
-					return;
-				}
-				applyOnFrame(nextWidth);
+				applyOnFrame(startWidth + sign * (e.clientX - startX));
 			};
 			window.addEventListener("pointermove", onMove);
 			window.addEventListener("pointerup", onUp);
 		},
-		[apply, applyOnFrame, collapseBelow, discardPending, edge, flushPending, max, min, onCollapse, storageKey],
+		[applyOnFrame, edge, flushPending, storageKey],
 	);
 
 	const onCollapsedPointerDown = useCallback(


### PR DESCRIPTION
## Summary

Dragging the left sidebar or the right inspector rail narrower used to shrink the panel past a usable width and then auto-collapse it entirely. Both drags now hard-stop at a minimum-width floor; collapsing remains available only through the explicit controls (⌘B / titlebar toggle for the sidebar, topbar button / ⌘⇧B for the inspector).

### Root causes

- **Sidebar** — `useResizable` had a `collapseBelow` threshold set to `SIDEBAR_MIN_WIDTH` (200px), so the instant a drag crossed the min it fired `onCollapse` and hid the panel.
- **Inspector** — the react-resizable-panels v4 panel was always `collapsible`, and rrp snaps a collapsible panel to 0% once a drag passes halfway below `minSize` (22%).

### Fix

- `useResizable` drops the `collapseBelow`/`onCollapse` drag path; the existing `min` clamp in `apply()` is the floor (200px, the same clamp convention as #1385). Persistence and the collapsed-rail drag-to-expand are unchanged; the drag-clamped width now also persists on pointer-up.
- The inspector panel is `collapsible` only while closed, so an open-panel drag clamps at the existing 22% `minSize`. Opening drives `resize()` to the persisted split (rrp's `expand()` no-ops on a non-collapsible panel); closing repeats `collapse()` on the next animation frame because rrp only derives the re-registered collapsible constraints one commit after the prop flips (a same-commit `collapse()` no-ops against the stale non-collapsible constraints).
- Drag-to-reopen of the collapsed inspector via its separator still works and is covered by e2e.

### Tests

- Unit: `Sidebar.test.tsx` / `SessionView.test.tsx` updated — drags assert the clamp (and never close the store); explicit toggles still collapse/reopen.
- E2E (new `e2e/resize-clamp.spec.ts`, real pointer drags over the real rrp + CSS pipeline): sidebar drag to the window edge stays expanded at 200px and persists; inspector drag to the group edge clamps at its 22% floor, the topbar button still collapses it, and the collapsed rail drags back open.
- Repaired `e2e/inspector-toggle.spec.ts`, which referenced the stale `refactor-mux` mock fixture (dataset is now `ao-demo`/`demo-working`) and could not run.

Verified visually against `dev:web` by dragging both rails to their extremes (screenshots checked): each stops at its floor instead of disappearing, and the explicit collapse controls still work.

`npm test` (renderer suite), `npm run typecheck`, `npm run typecheck:e2e`, and the `@T0|@P0` renderer smoke suite pass. The only failing file is the pre-existing, unrelated `src/landing/scripts/generate-markdown-twins.test.mjs` (fails identically on a clean tree in this environment).

Related: #1385 (min/max width clamp convention for the web project sidebar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)