### PR TITLE
Fix URL editing in macOS maximized browser view

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -188,6 +188,17 @@ describe("BrowserPanel", () => {
 		expect(hookState.navigate).toHaveBeenCalledWith("localhost:5173");
 	});
 
+	it("keeps the URL input editable while the browser is maximized", async () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut session={session} />);
+		const input = screen.getByRole("textbox", { name: /browser url/i });
+
+		await userEvent.clear(input);
+		await userEvent.type(input, "http://localhost:4173/");
+
+		expect(input).toHaveValue("http://localhost:4173/");
+	});
+
 	it("threads the session preview URL into the browser view (which drives navigation)", () => {
 		render(
 			<BrowserPanel

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -7,9 +7,20 @@ import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 
 const navigateMock = vi.hoisted(() => vi.fn());
 const openShellTerminalMock = vi.hoisted(() => vi.fn());
+const nativeFullScreenMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,
+}));
+
+vi.mock("../lib/platform", () => ({
+	// Exercise the macOS shell layout without changing the existing Ctrl-based
+	// shortcut assertions in this suite.
+	hidesShellTopbar: () => true,
+	isMacPlatform: () => false,
+}));
+vi.mock("../hooks/useWindowFullScreen", () => ({
+	useWindowFullScreen: () => nativeFullScreenMock(),
 }));
 
 type FakePanelHandle = {
@@ -321,6 +332,7 @@ function inspectorButton(): HTMLElement {
 
 describe("SessionView", () => {
 	beforeEach(() => {
+		nativeFullScreenMock.mockReturnValue(false);
 		window.localStorage.clear();
 		for (const session of workspaces.flatMap((workspace) => workspace.sessions)) {
 			delete session.previewUrl;
@@ -660,12 +672,23 @@ describe("SessionView", () => {
 
 		// The maximized overlay appears; the terminal stays mounted behind it.
 		expect(screen.getByRole("button", { name: "browser center" })).toBeInTheDocument();
+		expect(document.querySelector(".browser-popout-overlay")).toHaveClass("browser-popout-overlay--mac-windowed");
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 
 		fireEvent.click(screen.getByRole("button", { name: "browser center" }));
 		expect(screen.queryByRole("button", { name: "browser center" })).not.toBeInTheDocument();
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		expect(browserDestroy).not.toHaveBeenCalled();
+	});
+
+	it("does not reserve the traffic-light band during native macOS fullscreen", () => {
+		nativeFullScreenMock.mockReturnValue(true);
+		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "pop browser" }));
+
+		expect(document.querySelector(".browser-popout-overlay")).not.toHaveClass("browser-popout-overlay--mac-windowed");
 	});
 
 	it("does not carry popped-out browser visibility into the next session", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -18,7 +18,9 @@ import {
 	useShellTerminals,
 } from "../hooks/useShellTerminals";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
+import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { hidesShellTopbar } from "../lib/platform";
+import { cn } from "../lib/utils";
 import { isOrchestratorSession, sessionIsActive } from "../types/workspace";
 import type { TerminalTarget } from "../types/terminal";
 import { matchesRendererShortcut } from "../stores/keybindings-store";
@@ -80,6 +82,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const [terminalTarget, setTerminalTarget] = useState<TerminalTarget>({ kind: "worker" });
 	const [browserPoppedOut, setBrowserPoppedOut] = useState(false);
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
+	const isNativeFullScreen = useWindowFullScreen();
 
 	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
 
@@ -473,7 +476,12 @@ export function SessionView({ sessionId }: SessionViewProps) {
           and fills the window below any native titlebar overlay. */}
 			{browserPoppedOut && session
 				? createPortal(
-						<div className="browser-popout-overlay">
+						<div
+							className={cn(
+								"browser-popout-overlay",
+								shellTopbarHiddenByPlatform && !isNativeFullScreen && "browser-popout-overlay--mac-windowed",
+							)}
+						>
 							<BrowserPanelView
 								active
 								annotationQueue={browserAnnotationQueue}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2305,6 +2305,22 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	inset: env(titlebar-area-height, 0px) 0 0;
 	z-index: 40;
 	background: color-mix(in srgb, var(--bg) 94%, black);
+	/* The macOS shell has a separate traffic-light drag strip. Keep the
+	   maximized browser surface interactive even if those regions overlap while
+	   the window is transitioning between layouts. */
+	-webkit-app-region: no-drag;
+}
+
+/* macOS keeps the native traffic lights visible while the window is not in
+   native fullscreen. The maximized browser is portaled to <body>, so reserve
+   that band here instead of allowing its toolbar to render beneath the lights. */
+.browser-popout-overlay--mac-windowed {
+	top: var(--size-traffic-light-clearance);
+}
+
+.browser-popout-overlay .browser-panel__toolbar,
+.browser-popout-overlay .browser-panel__toolbar * {
+	-webkit-app-region: no-drag;
 }
 
 .platform-linux .browser-popout-overlay {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2297,9 +2297,11 @@ body.is-resizing-x [data-slot="sidebar-container"] {
    <body>, so it covers the sidebar + topbar too, not just the session area).
    Electron's Window Controls Overlay owns the top-right titlebar region on
    Windows, so start below its reported safe-area height. macOS hides the shell
-   topbar, so 0px is correct there. Linux now shows a ShellTopbar, so the overlay
-   must start below --size-toolbar; env(titlebar-area-height) resolves to 0 on
-   Linux (no titleBarOverlay), so we override the top with a platform class. */
+   topbar; windowed mode reserves the native traffic-light band below, while
+   native fullscreen keeps a 0px top inset. Linux now shows a ShellTopbar, so
+   the overlay must start below --size-toolbar; env(titlebar-area-height)
+   resolves to 0 on Linux (no titleBarOverlay), so we override the top with a
+   platform class. */
 .browser-popout-overlay {
 	position: fixed;
 	inset: env(titlebar-area-height, 0px) 0 0;


### PR DESCRIPTION
## What

Keep the browser URL field selectable and editable when the browser panel is maximized on macOS.

## Why

The macOS shell uses a hidden native titlebar with a traffic-light drag region. The maximized browser is portaled to `document.body` and originally rendered from `y=0`, allowing its URL toolbar to overlap that native drag region. Electron treated pointer input there as window dragging instead of delivering it to the URL input.

Windows is unaffected because its Window Controls Overlay safe area is already applied.

## How

- Reserve the existing 40px macOS titlebar band in windowed mode.
- Mark the maximized browser surface and toolbar controls as `-webkit-app-region: no-drag`.
- Skip the inset during native macOS fullscreen, where traffic lights are hidden.
- Add regression tests for URL editing and fullscreen/windowed overlay behavior.

## Files affected

- `frontend/src/renderer/components/SessionView.tsx`
- `frontend/src/renderer/styles.css`
- `frontend/src/renderer/components/BrowserPanel.test.tsx`
- `frontend/src/renderer/components/SessionView.test.tsx`

## Testing

- `npm test -- --run src/renderer/components/SessionView.test.tsx src/renderer/components/BrowserPanel.test.tsx` — 55 tests passed.
- `npm run typecheck` — passed.
- Manual testing on macOS remains pending; automated regression tests and typecheck pass.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Tests added/updated for user-visible behavior
- [x] Follows repository conventions
- [x] Relevant CI checks pass