### PR TITLE
chore(mobile): stamp app version 1.1.0

### DIFF
--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -2,7 +2,7 @@
 	"expo": {
 		"name": "AO",
 		"slug": "ao-mobile",
-		"version": "1.0.0",
+		"version": "1.1.0",
 		"orientation": "portrait",
 		"icon": "./assets/icon.png",
 		"userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- bump the Expo mobile app version from 1.0.0 to 1.1.0 for the next TestFlight / Android closed-testing build
- leave package.json unchanged because the store-facing app version lives in app.json

## Validation
- cd packages/mobile && npm run test
- cd packages/mobile && npm run typecheck