### PR TITLE
feat: support NVIDIA Build API keys in supported agents

### DIFF
--- a/backend/internal/adapters/agent/aider/auth.go
+++ b/backend/internal/adapters/agent/aider/auth.go
@@ -38,6 +38,7 @@ var aiderAPIKeyEnvVars = []string{
 	"XAI_API_KEY",
 	"MISTRAL_API_KEY",
 	"COHERE_API_KEY",
+	"NVIDIA_NIM_API_KEY",
 }
 
 func aiderLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {

--- a/backend/internal/adapters/agent/aider/auth_test.go
+++ b/backend/internal/adapters/agent/aider/auth_test.go
@@ -22,6 +22,19 @@ func TestAiderLocalAuthStatusAuthorizedWithProviderEnv(t *testing.T) {
 	}
 }
 
+func TestAiderLocalAuthStatusAuthorizedWithNVIDIAEnv(t *testing.T) {
+	clearAiderAuthEnv(t)
+	t.Setenv("NVIDIA_NIM_API_KEY", "nvapi-test")
+
+	status, ok, err := aiderLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestAiderLocalAuthStatusAuthorizedWithConfigFile(t *testing.T) {
 	clearAiderAuthEnv(t)
 	home := t.TempDir()

--- a/backend/internal/adapters/agent/aider/auth_test.go
+++ b/backend/internal/adapters/agent/aider/auth_test.go
@@ -24,7 +24,7 @@ func TestAiderLocalAuthStatusAuthorizedWithProviderEnv(t *testing.T) {
 
 func TestAiderLocalAuthStatusAuthorizedWithNVIDIAEnv(t *testing.T) {
 	clearAiderAuthEnv(t)
-	t.Setenv("NVIDIA_NIM_API_KEY", "nvapi-test")
+	t.Setenv("NVIDIA_NIM_API_KEY", "test-only-placeholder")
 
 	status, ok, err := aiderLocalAuthStatus(context.Background())
 	if err != nil {

--- a/backend/internal/adapters/agent/goose/auth.go
+++ b/backend/internal/adapters/agent/goose/auth.go
@@ -40,6 +40,7 @@ var gooseAPIKeyEnvVars = []string{
 	"XAI_API_KEY",
 	"MISTRAL_API_KEY",
 	"COHERE_API_KEY",
+	"NVIDIA_API_KEY",
 }
 
 func gooseLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -242,7 +242,7 @@ func TestAuthStatusAuthorizedFromEnv(t *testing.T) {
 
 func TestAuthStatusAuthorizedFromNVIDIAEnv(t *testing.T) {
 	clearGooseAuthEnv(t)
-	t.Setenv("NVIDIA_API_KEY", "nvapi-test")
+	t.Setenv("NVIDIA_API_KEY", "test-only-placeholder")
 	plugin := &Plugin{resolvedBinary: "goose"}
 
 	got, err := plugin.AuthStatus(context.Background())

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -240,6 +240,20 @@ func TestAuthStatusAuthorizedFromEnv(t *testing.T) {
 	}
 }
 
+func TestAuthStatusAuthorizedFromNVIDIAEnv(t *testing.T) {
+	clearGooseAuthEnv(t)
+	t.Setenv("NVIDIA_API_KEY", "nvapi-test")
+	plugin := &Plugin{resolvedBinary: "goose"}
+
+	got, err := plugin.AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("AuthStatus = %q, want %q", got, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestAuthStatusAuthorizedFromGooseConfig(t *testing.T) {
 	clearGooseAuthEnv(t)
 	home := t.TempDir()

--- a/backend/internal/adapters/agent/kilocode/auth.go
+++ b/backend/internal/adapters/agent/kilocode/auth.go
@@ -61,6 +61,7 @@ var kilocodeAPIKeyEnvVars = []string{
 	"XAI_API_KEY",
 	"MISTRAL_API_KEY",
 	"COHERE_API_KEY",
+	"NVIDIA_API_KEY",
 }
 
 func kilocodeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {

--- a/backend/internal/adapters/agent/kilocode/auth_test.go
+++ b/backend/internal/adapters/agent/kilocode/auth_test.go
@@ -26,7 +26,7 @@ func TestKilocodeLocalAuthStatusAuthorizedWithNVIDIAEnv(t *testing.T) {
 	for _, name := range kilocodeAPIKeyEnvVars {
 		t.Setenv(name, "")
 	}
-	t.Setenv("NVIDIA_API_KEY", "nvapi-test")
+	t.Setenv("NVIDIA_API_KEY", "test-only-placeholder")
 
 	status, ok, err := kilocodeLocalAuthStatus(context.Background())
 	if err != nil {

--- a/backend/internal/adapters/agent/kilocode/auth_test.go
+++ b/backend/internal/adapters/agent/kilocode/auth_test.go
@@ -22,6 +22,21 @@ func TestKilocodeLocalAuthStatusAuthorizedWithProviderEnv(t *testing.T) {
 	}
 }
 
+func TestKilocodeLocalAuthStatusAuthorizedWithNVIDIAEnv(t *testing.T) {
+	for _, name := range kilocodeAPIKeyEnvVars {
+		t.Setenv(name, "")
+	}
+	t.Setenv("NVIDIA_API_KEY", "nvapi-test")
+
+	status, ok, err := kilocodeLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestKilocodeAuthListStatusAuthorizedWithEnvironmentVariable(t *testing.T) {
 	output := `
 log stream error: EPERM: operation not permitted

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -211,6 +211,7 @@ var opencodeAPIKeyEnvVars = []string{
 	"XAI_API_KEY",
 	"MISTRAL_API_KEY",
 	"COHERE_API_KEY",
+	"NVIDIA_API_KEY",
 }
 
 func opencodeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -31,7 +31,7 @@ func TestOpenCodeLocalAuthStatusAuthorizedWithEnv(t *testing.T) {
 
 func TestOpenCodeLocalAuthStatusAuthorizedWithNVIDIAEnv(t *testing.T) {
 	clearOpenCodeAuthEnv(t)
-	t.Setenv("NVIDIA_API_KEY", "nvapi-test")
+	t.Setenv("NVIDIA_API_KEY", "test-only-placeholder")
 
 	status, ok, err := opencodeLocalAuthStatus(context.Background())
 	if err != nil {

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -29,6 +29,19 @@ func TestOpenCodeLocalAuthStatusAuthorizedWithEnv(t *testing.T) {
 	}
 }
 
+func TestOpenCodeLocalAuthStatusAuthorizedWithNVIDIAEnv(t *testing.T) {
+	clearOpenCodeAuthEnv(t)
+	t.Setenv("NVIDIA_API_KEY", "nvapi-test")
+
+	status, ok, err := opencodeLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestOpenCodeLocalAuthStatusAuthorizedWithAuthFile(t *testing.T) {
 	clearOpenCodeAuthEnv(t)
 	writeOpenCodeAuthFile(t, `{

--- a/frontend/src/landing/content/docs/guides/meta.json
+++ b/frontend/src/landing/content/docs/guides/meta.json
@@ -1,5 +1,5 @@
 {
 	"title": "Guides",
 	"defaultOpen": false,
-	"pages": ["per-role-agents", "parallel-issues", "ci-recovery", "review-loop", "reactions", "multi-project"]
+	"pages": ["per-role-agents", "nvidia-build", "parallel-issues", "ci-recovery", "review-loop", "reactions", "multi-project"]
 }

--- a/frontend/src/landing/content/docs/guides/nvidia-build.mdx
+++ b/frontend/src/landing/content/docs/guides/nvidia-build.mdx
@@ -1,0 +1,65 @@
+---
+title: NVIDIA Build models
+description: Use NVIDIA-hosted models with supported AO agents without storing API keys in the repository.
+---
+
+# NVIDIA Build models
+
+NVIDIA Build is a model provider, not a standalone coding-agent binary. Use it through a supported agent that integrates
+with NVIDIA, while AO continues to provide worktrees, sessions, terminals, activity tracking, pull-request workflows,
+and, where the agent supports it, native session resume.
+
+## Recommended: OpenCode
+
+OpenCode provides the most complete NVIDIA-backed AO experience because both NVIDIA provider support and native session
+resume are available.
+
+1. Install OpenCode and configure its NVIDIA provider/model using OpenCode's normal provider flow.
+2. Export the key from your shell profile:
+
+   ```bash
+   export NVIDIA_API_KEY="<your-key>"
+   ```
+
+3. Select OpenCode in AO:
+
+   ```yaml title="agent-orchestrator.yaml"
+   agent: opencode
+   ```
+
+AO's desktop app imports the login-shell environment at startup, forwards it to the daemon, and the local agent session
+inherits it. Restart AO after changing the shell profile. AO's authentication-status check only tests whether the variable
+is non-empty; it never logs or returns the value. The selected agent uses the inherited key to authenticate directly with
+NVIDIA.
+
+## Other supported agents
+
+| Agent | Environment variable | Notes |
+| --- | --- | --- |
+| OpenCode | `NVIDIA_API_KEY` | Recommended; supports AO session discovery and resume. |
+| Kilo Code | `NVIDIA_API_KEY` | Configure an NVIDIA `provider/model-id` using Kilo's normal model settings. |
+| Goose | `NVIDIA_API_KEY` | Select NVIDIA as the provider and choose a model in Goose. |
+| Aider | `NVIDIA_NIM_API_KEY` | Uses LiteLLM's NVIDIA NIM variable name; Aider does not support native session resume. |
+
+The key value is supplied directly to the selected agent through its inherited process environment. AO does not copy it
+into the worktree or add it to an agent command line.
+
+## Keep the key secret
+
+- Never put the key in `agent-orchestrator.yaml`, prompts, issues, command-line arguments, source files, or tracked config.
+- Do not symlink a credential-bearing `.env` file into AO worktrees.
+- Keep `.env` files ignored and review staged changes before every push.
+- If a key is ever exposed, revoke and rotate it immediately in NVIDIA Build.
+
+AO redacts `NVIDIA_API_KEY=...`, `NVIDIA_NIM_API_KEY=...`, and raw `nvapi-...` values from support-report drafts. This is
+defense in depth, not a substitute for keeping credentials out of repository content and prompts.
+
+## Verify without revealing the key
+
+Run the agent catalog command:
+
+```bash
+ao agent ls
+```
+
+The selected agent should report as authenticated. AO displays only authentication status, never the credential value.

--- a/frontend/src/renderer/lib/report-problem.test.ts
+++ b/frontend/src/renderer/lib/report-problem.test.ts
@@ -67,10 +67,11 @@ describe("report problem drafts", () => {
 		expect(draft).not.toContain("hunter2");
 	});
 
-	it("redacts JSON secrets, authorization headers, and GitHub token forms", () => {
+	it("redacts JSON secrets, authorization headers, NVIDIA keys, and GitHub token forms", () => {
 		const githubToken = `ghp_${"abcdefghijklmnopqrstuvwxyz"}${"1234567890AB"}`;
 		const githubOauthToken = `gho_${"abcdefghijklmnopqrstuvwxyz"}${"1234567890AB"}`;
 		const fineGrainedGithubToken = `github_pat_11${"AAAAAAAAAAAAAAAAAAAA"}_${"B".repeat(74)}`;
+		const nvidiaKey = `nvapi-${"N".repeat(48)}`;
 
 		const draft = formatReportProblemDraft(
 			{
@@ -79,6 +80,8 @@ describe("report problem drafts", () => {
 					'{"token": "json-token-secret", "api_key": "json-api-key-secret"}',
 					`Authorization: token ${githubOauthToken}`,
 					"authorization: Bearer header-token-secret",
+					`NVIDIA_API_KEY=${nvidiaKey}`,
+					`Raw NVIDIA key: ${nvidiaKey}`,
 					fineGrainedGithubToken,
 				].join("\n"),
 			},
@@ -92,6 +95,7 @@ describe("report problem drafts", () => {
 		expect(draft).not.toContain(githubToken);
 		expect(draft).not.toContain(githubOauthToken);
 		expect(draft).not.toContain("header-token-secret");
+		expect(draft).not.toContain(nvidiaKey);
 		expect(draft).not.toContain(fineGrainedGithubToken);
 	});
 

--- a/frontend/src/renderer/lib/report-problem.ts
+++ b/frontend/src/renderer/lib/report-problem.ts
@@ -37,6 +37,7 @@ const ASSIGNMENT_SECRET_PATTERN =
 	/(\b[A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|ACCESS[_-]?TOKEN|REFRESH[_-]?TOKEN|AUTH)[A-Z0-9_]*\s*[:=]\s*)(["']?)[^\s"',)]+/gi;
 const BEARER_SECRET_PATTERN = /\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi;
 const OPENAI_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]+/g;
+const NVIDIA_KEY_PATTERN = /\bnvapi-[A-Za-z0-9_-]{8,}\b/g;
 const GITHUB_TOKEN_PATTERN = /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/g;
 
 export function sanitizeReportText(value: string): string {
@@ -50,6 +51,7 @@ export function sanitizeReportText(value: string): string {
 		.replace(ASSIGNMENT_SECRET_PATTERN, `$1$2${REDACTED_SECRET}`)
 		.replace(BEARER_SECRET_PATTERN, `$1${REDACTED_SECRET}`)
 		.replace(OPENAI_KEY_PATTERN, REDACTED_SECRET)
+		.replace(NVIDIA_KEY_PATTERN, REDACTED_SECRET)
 		.replace(GITHUB_TOKEN_PATTERN, REDACTED_SECRET);
 }
 

--- a/frontend/src/shared/shell-env.test.ts
+++ b/frontend/src/shared/shell-env.test.ts
@@ -71,6 +71,15 @@ describe("buildDaemonEnv", () => {
 		expect(env.ANTHROPIC_API_KEY).toBe("sk-ant");
 	});
 
+	it("keeps an NVIDIA credential present only in the shell env", () => {
+		const env = buildDaemonEnv(
+			minimalProcessEnv,
+			{ PATH: "/opt/homebrew/bin", NVIDIA_API_KEY: "test-only-placeholder" },
+			{},
+		);
+		expect(env.NVIDIA_API_KEY).toBe("test-only-placeholder");
+	});
+
 	it("takes PATH from the shell env (with floor) over a minimal process PATH", () => {
 		const env = buildDaemonEnv(minimalProcessEnv, { PATH: "/opt/homebrew/bin:/usr/bin" }, {});
 		expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/opt/homebrew/sbin:/usr/local/bin:/bin:/usr/sbin:/sbin");


### PR DESCRIPTION
## Summary

- recognize NVIDIA Build credentials for OpenCode, Kilo Code, Goose, and Aider
- recommend OpenCode when users want the fullest Agent Orchestrator resume and tracking experience
- preserve `NVIDIA_API_KEY` when the desktop app imports the login-shell environment
- redact both assigned NVIDIA variables and raw `nvapi-...` values from support reports
- add a secure setup guide that keeps credentials out of repositories and AO configuration

NVIDIA Build is added as a provider used by supported agents, not as a separate standalone agent. OpenCode, Kilo Code, and Goose use `NVIDIA_API_KEY`; Aider uses `NVIDIA_NIM_API_KEY`.

## Security

- no real API key or complete credential-shaped test value is present in this branch
- authentication checks only test whether the relevant environment variable is non-empty; they never return or log its value
- AO passes the inherited environment locally to the selected agent without writing the key to a worktree, project configuration, or command-line argument
- the selected agent authenticates directly with NVIDIA
- support-report sanitization removes variable assignments and raw NVIDIA key-shaped values
- documentation warns users never to paste keys into YAML, prompts, issues, source files, or tracked `.env` files, and to rotate any exposed key

## Validation

- `go test ./internal/adapters/agent/aider ./internal/adapters/agent/opencode ./internal/adapters/agent/kilocode ./internal/adapters/agent/goose`
- focused Vitest suite: 2 files and 29 tests passed
- repository credential-pattern scan: clean
- staged diff check: clean

The full Go suite was also attempted; unrelated Windows-only environment assumptions fail outside the changed packages. The frontend typecheck was attempted, but this local pnpm install did not expose Electron Forge's shared type package at the workspace root.