### PR TITLE
Improve the delegation landing demo

### DIFF
--- a/frontend/src/landing/src/app/components/FeaturesSection/components/DelegationDemo/DelegationDemo.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/DelegationDemo/DelegationDemo.tsx
@@ -2,14 +2,14 @@
 
 import { domAnimation, LazyMotion, m } from "motion/react";
 import {
-	Bell,
+	BellRing,
 	ChevronDown,
 	ChevronLeft,
 	ChevronRight,
+	CircleAlert,
 	Folder,
 	LayoutGrid,
 	Maximize2,
-	Minus,
 	MoreVertical,
 	Network,
 	PanelLeft,
@@ -54,6 +54,8 @@ const TC = {
 	faint: APP.faint,
 } as const;
 
+const PROJECT_NAME = "solkit-ui";
+
 type Line = { id: string; node: ReactNode };
 type OrcLine = Line & { spawn?: string };
 
@@ -74,31 +76,19 @@ const ORC_LINES: OrcLine[] = [
 	{
 		id: "splash",
 		node: (
-			<div className="flex items-start gap-3" style={{ margin: "2px 0 8px" }}>
-				<span
-					style={{
-						width: 32,
-						height: 32,
-						borderRadius: 8,
-						background: "rgba(217,119,87,0.14)",
-						display: "grid",
-						placeItems: "center",
-						flex: "none",
-					}}
-				>
-					<img
-						src="/app-icons/coverage-claude-code.svg"
-						alt=""
-						style={{ width: 20, height: 20 }}
-						draggable={false}
-					/>
-				</span>
-				<div>
+			<div className="mb-2 flex items-start gap-2.5">
+				<img
+					src="/app-icons/agents/claude-code.svg"
+					alt=""
+					className="mt-0.5 size-5 shrink-0 object-contain"
+					draggable={false}
+				/>
+				<div className="min-w-0">
 					<div style={{ color: TC.fg, fontWeight: 700 }}>
 						Claude Code <span style={{ color: TC.mut, fontWeight: 400 }}>v2.1.204</span>
 					</div>
-					<div style={{ color: TC.mut }}>Opus 4.8 (1M context) with medium effort · Claude Team</div>
-					<div style={{ color: TC.faint }}>~/.ao/data/worktrees/ao/orchestrator/ao-orchestrator</div>
+					<div style={{ color: TC.mut }}>Opus 4.8 (1M context) · Claude Team</div>
+					<div className="truncate" style={{ color: TC.faint }}>~/ao/solkit-ui/orchestrator</div>
 				</div>
 			</div>
 		),
@@ -131,15 +121,6 @@ const ORC_LINES: OrcLine[] = [
 		),
 	},
 	{
-		id: "worker-claude",
-		node: (
-			<>
-				{"  "}
-				{s(TC.teal, "✓")} worker <b>Claude</b> · {s(TC.mut, "ao/ao-12/auth-callback")}
-			</>
-		),
-	},
-	{
 		id: "spawn-codex",
 		spawn: "codex",
 		node: (
@@ -150,46 +131,12 @@ const ORC_LINES: OrcLine[] = [
 		),
 	},
 	{
-		id: "worker-codex",
-		node: (
-			<>
-				{"  "}
-				{s(TC.teal, "✓")} worker <b>Codex</b> · {s(TC.mut, "ao/ao-12/auth-flow")}
-			</>
-		),
-	},
-	{
 		id: "spawn-cursor",
 		spawn: "cursor",
 		node: (
 			<>
 				{s(TC.blue, "➜")} {s(TC.mut, "ao")} spawn --name {s(TC.fg, '"setup guide"')} --prompt{" "}
 				{s(TC.mut, '"update the auth setup docs"')}
-			</>
-		),
-	},
-	{
-		id: "worker-cursor",
-		node: (
-			<>
-				{"  "}
-				{s(TC.teal, "✓")} worker <b>Cursor</b> · {s(TC.mut, "ao/ao-12/auth-docs")}
-			</>
-		),
-	},
-	{
-		id: "route",
-		node: (
-			<>
-				{s(TC.rev, "↻")} {s(TC.mut, 'ao send --session ao-12/auth-flow "rebase on the callback route"')}
-			</>
-		),
-	},
-	{
-		id: "escalate",
-		node: (
-			<>
-				{s(TC.amber, "▲")} {s(TC.mut, "ao/ao-12/auth-callback — needs a decision, escalated to you")}
 			</>
 		),
 	},
@@ -208,7 +155,14 @@ const WORKERS: Worker[] = [
 		lines: [
 			{ id: "c0", node: s(TC.mut, "Claude Code v2.1.204 · Opus 4.8 (1M context) · ~/ao/ao-12/auth-callback") },
 			{ id: "c1", node: <>{s(TC.blue, "❯")} build the GitHub OAuth callback route</> },
-			{ id: "c2", node: <>{s(TC.fg, "●")} reading {s(TC.mut, "src/auth/*.ts")}</> },
+			{
+				id: "c2",
+				node: (
+					<>
+						{s(TC.fg, "●")} reading {s(TC.mut, "src/auth/*.ts")}
+					</>
+				),
+			},
 			{
 				id: "c3",
 				node: (
@@ -245,7 +199,7 @@ const WORKERS: Worker[] = [
 		branch: "ao/ao-12/auth-flow",
 		statusLabel: "In review",
 		color: ST.review,
-		breathe: false,
+		breathe: true,
 		lines: [
 			{ id: "x0", node: s(TC.mut, "codex · ~/ao/ao-12/auth-flow") },
 			{ id: "x1", node: <>$ codex exec {s(TC.fg, '"add integration tests for the callback flow"')}</> },
@@ -284,11 +238,25 @@ const WORKERS: Worker[] = [
 		branch: "ao/ao-12/auth-docs",
 		statusLabel: "Input needed",
 		color: ST.needs,
-		breathe: false,
+		breathe: true,
 		lines: [
 			{ id: "u0", node: s(TC.mut, "cursor-agent · ~/ao/ao-12/auth-docs") },
-			{ id: "u1", node: <>{s(TC.fg, "●")} updating {s(TC.mut, "docs/auth/setup.md")}</> },
-			{ id: "u2", node: <>{s(TC.fg, "●")} added {s(TC.mut, '"Configure GitHub OAuth"')} section</> },
+			{
+				id: "u1",
+				node: (
+					<>
+						{s(TC.fg, "●")} updating {s(TC.mut, "docs/auth/setup.md")}
+					</>
+				),
+			},
+			{
+				id: "u2",
+				node: (
+					<>
+						{s(TC.fg, "●")} added {s(TC.mut, '"Configure GitHub OAuth"')} section
+					</>
+				),
+			},
 			{
 				id: "u3",
 				node: (
@@ -300,12 +268,53 @@ const WORKERS: Worker[] = [
 			{ id: "u4", node: s(TC.faint, "waiting for the orchestrator…") },
 		],
 	},
+	{
+		id: "login",
+		task: "Fix login redirect",
+		prov: "codex",
+		branch: "fix/auth-redirect",
+		statusLabel: "Idle",
+		color: ST.idle,
+		breathe: false,
+		lines: [
+			{ id: "l0", node: s(TC.mut, "codex · ~/solkit-ui/fix/auth-redirect") },
+			{ id: "l1", node: <>$ codex exec {s(TC.fg, '"fix the login redirect loop"')}</> },
+			{
+				id: "l2",
+				node: (
+					<>
+						{s(TC.fg, "●")} tracing {s(TC.mut, "middleware/auth.ts")}
+					</>
+				),
+			},
+			{ id: "l3", node: <>{s(TC.teal, "✓")} redirect preserves the requested destination</> },
+		],
+	},
+	{
+		id: "readme",
+		task: "Tidy readme",
+		prov: "claude-code",
+		branch: "docs/readme-cleanup",
+		statusLabel: "Idle",
+		color: ST.idle,
+		breathe: false,
+		lines: [
+			{ id: "r0", node: s(TC.mut, "Claude Code · ~/solkit-ui/docs/readme-cleanup") },
+			{ id: "r1", node: <>{s(TC.blue, "❯")} tighten the installation guide</> },
+			{
+				id: "r2",
+				node: (
+					<>
+						{s(TC.fg, "●")} editing {s(TC.mut, "README.md")} {s(TC.teal, "(+22 −14)")}
+					</>
+				),
+			},
+			{ id: "r3", node: <>$ markdownlint README.md {s(TC.teal, "✓ clean")}</> },
+		],
+	},
 ];
 
-const OTHER: { name: string; sessions: string[] }[] = [
-	{ name: "sandbox", sessions: ["fix login redirect", "tidy readme"] },
-	{ name: "scratch", sessions: [] },
-];
+const OTHER: { name: string; sessions: string[] }[] = [{ name: "sandbox", sessions: [] }];
 
 const byId = (id: string) => WORKERS.find((w) => w.id === id);
 
@@ -329,11 +338,45 @@ function Cursor() {
 	);
 }
 
-function IconBtn({ children }: { children: ReactNode }) {
+function ShellNav({
+	canGoForward,
+	onBack,
+	onForward,
+	onSidebar,
+}: {
+	canGoForward: boolean;
+	onBack: () => void;
+	onForward: () => void;
+	onSidebar: () => void;
+}) {
 	return (
-		<button type="button" className="grid size-6 place-items-center rounded-md hover:bg-white/5">
-			{children}
-		</button>
+		<div className="absolute left-2 top-1.5 z-20 flex items-center gap-1">
+			<button
+				type="button"
+				aria-label="Toggle sidebar"
+				onClick={onSidebar}
+				className="grid size-6 place-items-center rounded-md hover:bg-white/5"
+			>
+				<PanelLeft size={14} style={{ color: APP.mut }} />
+			</button>
+			<button
+				type="button"
+				aria-label="Go back"
+				onClick={onBack}
+				className="grid size-6 place-items-center rounded-md hover:bg-white/5"
+			>
+				<ChevronLeft size={14} style={{ color: APP.mut }} />
+			</button>
+			<button
+				type="button"
+				aria-label="Go forward"
+				disabled={!canGoForward}
+				onClick={onForward}
+				className="grid size-6 place-items-center rounded-md hover:bg-white/5 disabled:opacity-35"
+			>
+				<ChevronRight size={14} style={{ color: APP.mut }} />
+			</button>
+		</div>
 	);
 }
 
@@ -347,54 +390,77 @@ function StatusChip({ isOrc, worker }: { isOrc: boolean; worker?: Worker }) {
 	}
 	return (
 		<span style={chipStyle}>
-			<Dot color={worker?.color ?? ST.idle} breathe={worker?.breathe} size={7} />
+		<Dot color={worker?.color ?? ST.idle} breathe={worker?.breathe} size={7} />
 			{worker?.task}
 		</span>
 	);
 }
 
-function AppTopBar({ isOrc, worker, onKill }: { isOrc: boolean; worker?: Worker; onKill: () => void }) {
+function AppTopBar({
+	isOrc,
+	worker,
+	onKill,
+	onKanban,
+	onNotifications,
+	onOrchestrator,
+	onRunDemo,
+}: {
+	isOrc: boolean;
+	worker?: Worker;
+	onKill: () => void;
+	onKanban: () => void;
+	onNotifications: () => void;
+	onOrchestrator: () => void;
+	onRunDemo: () => void;
+}) {
 	return (
 		<div
-			className="flex h-[42px] items-center gap-2 px-2.5"
+			className="flex h-[40px] items-center gap-2 px-3"
 			style={{ borderBottom: `1px solid ${APP.line}`, background: APP.panel }}
 		>
-			<div className="mr-1 flex gap-[7px]" aria-hidden>
-				<span className="size-[11px] rounded-full" style={{ background: "#ff5f57" }} />
-				<span className="size-[11px] rounded-full" style={{ background: "#febc2e" }} />
-				<span className="size-[11px] rounded-full" style={{ background: "#28c840" }} />
-			</div>
-			<IconBtn>
-				<PanelLeft size={15} style={{ color: APP.mut }} />
-			</IconBtn>
-			<IconBtn>
-				<ChevronLeft size={15} style={{ color: APP.mut }} />
-			</IconBtn>
-			<IconBtn>
-				<ChevronRight size={15} style={{ color: APP.mut }} />
-			</IconBtn>
-			<div className="flex min-w-0 items-center gap-2" style={{ fontSize: 11, color: APP.mut }}>
-				<span style={{ color: APP.fg, fontWeight: 600 }}>demo</span>
-				<span style={{ color: APP.faint }}>·</span>
-				<StatusChip isOrc={isOrc} worker={worker} />
-			</div>
-			<div className="ml-auto flex items-center gap-[7px]">
-				{!isOrc && (
-					<button type="button" onClick={onKill} style={killBtnStyle}>
-						<Trash2 size={12} /> Kill
-					</button>
+			{isOrc ? (
+				<div className="hidden min-w-0 items-center gap-2 sm:flex" style={{ fontSize: 11, color: APP.mut }}>
+					<span className="max-w-[106px] truncate" style={{ color: APP.fg, fontWeight: 600 }}>
+						{PROJECT_NAME}
+					</span>
+					<span style={{ color: APP.faint }}>·</span>
+					<StatusChip isOrc worker={worker} />
+				</div>
+			) : (
+				<div className="flex min-w-0 items-center gap-2" style={{ color: APP.mut }}>
+					<StatusChip isOrc={false} worker={worker} />
+				</div>
+			)}
+			<div className="ml-auto flex shrink-0 items-center gap-[5px]">
+				{!isOrc ? (
+					<>
+						<button type="button" onClick={onKill} style={killBtnStyle}>
+							<Trash2 size={12} /> Kill
+						</button>
+						<button type="button" onClick={onOrchestrator} style={kanbanBtnStyle}>
+							<Network size={12} /> Orchestrator
+						</button>
+					</>
+				) : (
+					<>
+						<button type="button" aria-label="New task" onClick={onRunDemo} style={ghostBtnStyle}>
+							<Plus size={13} /> <span className="hidden sm:inline">New task</span>
+						</button>
+						<button type="button" aria-label="Kanban" onClick={onKanban} style={kanbanBtnStyle}>
+							<LayoutGrid size={13} /> <span className="hidden sm:inline">Kanban</span>
+						</button>
+					</>
 				)}
-				<button type="button" style={ghostBtnStyle}>
-					<Plus size={13} /> New task
-				</button>
-				<button type="button" style={kanbanBtnStyle}>
-					<LayoutGrid size={13} /> Kanban
-				</button>
-				<button type="button" className="relative grid size-6 place-items-center rounded-md">
-					<Bell size={15} style={{ color: APP.mut }} />
+				<button
+					type="button"
+					aria-label="Open notifications"
+					onClick={onNotifications}
+					className="relative grid size-6 place-items-center rounded-md hover:bg-white/5"
+				>
+					<BellRing size={15} fill="currentColor" style={{ color: APP.fg }} />
 					<span
-						className="absolute -right-1 -top-1 grid h-[14px] min-w-[14px] place-items-center rounded-full px-[3px] text-[8px] font-extrabold text-white"
-						style={{ background: APP.blue }}
+						className="absolute -right-1 -top-1 grid h-[14px] min-w-[14px] place-items-center rounded-full px-[3px] text-[8px] font-extrabold"
+						style={{ background: APP.fg, color: APP.bg }}
 					>
 						7
 					</span>
@@ -439,9 +505,6 @@ function SessionRow({ worker, active, onClick }: { worker: Worker; active: boole
 		<m.button
 			type="button"
 			onClick={onClick}
-			initial={{ opacity: 0, x: -6 }}
-			animate={{ opacity: 1, x: 0 }}
-			transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
 			className="flex items-center gap-2 rounded-md py-[5px] pl-[22px] pr-1.5 text-left text-[10.5px]"
 			style={{ color: active ? APP.fg : APP.mut, background: active ? APP.elev : "transparent" }}
 		>
@@ -452,7 +515,6 @@ function SessionRow({ worker, active, onClick }: { worker: Worker; active: boole
 }
 
 function AppSidebar({
-	isOrc,
 	active,
 	query,
 	setQuery,
@@ -461,7 +523,6 @@ function AppSidebar({
 	filtered,
 	onSelect,
 }: {
-	isOrc: boolean;
 	active: string;
 	query: string;
 	setQuery: (v: string) => void;
@@ -471,14 +532,13 @@ function AppSidebar({
 	onSelect: (id: string) => void;
 }) {
 	return (
-		<div
-			className="flex min-w-0 flex-col"
-			style={{ background: APP.panel, borderRight: `1px solid ${APP.line}` }}
-		>
+		<div className="flex min-w-0 flex-col" style={{ background: APP.panel }}>
 			<div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-2.5 scrollbar-hide">
 				<div className="flex flex-nowrap items-center gap-2 px-1 pb-3">
 					<img src="/ao-logo.svg" alt="" className="size-[18px] shrink-0" draggable={false} />
-					<b className="whitespace-nowrap text-[11px] font-bold tracking-[-0.2px]">Agent Orchestrator</b>
+					<b className="hidden whitespace-nowrap text-[11px] font-bold tracking-[-0.2px] sm:block">
+						Agent Orchestrator
+					</b>
 				</div>
 
 				<div
@@ -519,15 +579,20 @@ function AppSidebar({
 				)}
 
 				<div
-					className="flex items-center gap-1.5 px-1.5 pb-1 pt-2.5 text-[9px] font-bold tracking-[0.9px]"
+					className="flex items-center gap-1.5 px-1.5 pb-1 pt-2.5 text-[10px] font-semibold"
 					style={{ color: APP.faint }}
 				>
-					<span>PROJECTS</span>
+					<Folder size={12} />
+					<span>Projects</span>
+					<ChevronDown size={11} />
 					<Plus size={12} className="ml-auto" />
 				</div>
 
-				<ProjectRow selected={isOrc} onClick={() => onSelect("orc")}>
-					demo
+				<ProjectRow
+					selected={["orc", "claude", "codex", "cursor"].includes(active)}
+					onClick={() => onSelect("orc")}
+				>
+					{PROJECT_NAME}
 				</ProjectRow>
 
 				{filtered.map((id) => {
@@ -543,17 +608,23 @@ function AppSidebar({
 
 				{OTHER.map((p) => (
 					<div key={p.name}>
-						<ProjectRow>{p.name}</ProjectRow>
-						{p.sessions.map((t) => (
-							<div
-								key={t}
-								className="flex items-center gap-2 rounded-md py-[5px] pl-[22px] pr-1.5 text-[10.5px]"
-								style={{ color: APP.mut }}
-							>
-								<Dot color={ST.idle} />
-								<span className="min-w-0 flex-1 truncate">{t}</span>
-							</div>
-						))}
+						<ProjectRow
+							selected={p.sessions.includes(active)}
+							onClick={() => p.sessions[0] && onSelect(p.sessions[0])}
+						>
+							{p.name}
+						</ProjectRow>
+						{p.sessions.map((id) => {
+							const session = byId(id);
+							return session ? (
+								<SessionRow
+									key={id}
+									worker={session}
+									active={active === id}
+									onClick={() => onSelect(id)}
+								/>
+							) : null;
+						})}
 					</div>
 				))}
 			</div>
@@ -594,17 +665,19 @@ function AppTerminal({
 						worker?.task
 					)}
 				</span>
-				<span className="ml-auto flex items-center gap-2 text-[9.5px]" style={{ color: APP.faint }}>
-					<Minus size={12} />
-					<span>11px</span>
-					<Plus size={12} />
-					<Maximize2 size={12} className="ml-0.5" />
-				</span>
 			</div>
 			<div
-				className="min-h-0 flex-1 overflow-y-auto whitespace-pre-wrap px-3.5 py-3 font-mono leading-[1.66] scrollbar-hide"
+				className="relative min-h-0 flex-1 overflow-y-auto whitespace-pre-wrap px-3.5 py-3 font-mono leading-[1.66] scrollbar-hide"
 				style={{ background: APP.bg, fontSize: 10.5 }}
 			>
+				<div className="absolute right-2 top-1.5 z-10 flex items-center gap-1 font-mono text-[9.5px]" style={{ color: APP.faint }}>
+					<button type="button" className="grid size-5 place-items-center rounded hover:bg-white/5">−</button>
+					<span className="w-6 text-center">11px</span>
+					<button type="button" className="grid size-5 place-items-center rounded hover:bg-white/5">+</button>
+					<button type="button" className="ml-0.5 grid size-5 place-items-center rounded hover:bg-white/5" aria-label="Fullscreen terminal">
+						<Maximize2 size={12} />
+					</button>
+				</div>
 				{isOrc ? (
 					<>
 						{orcLines.map((l) => (
@@ -619,10 +692,16 @@ function AppTerminal({
 					</>
 				) : (
 					<>
-						{worker?.lines.map((l) => (
-							<div key={l.id} className="mb-px">
+						{worker?.lines.map((l, index) => (
+							<m.div
+								key={l.id}
+								className="mb-px"
+								initial={{ opacity: 0, y: 2 }}
+								animate={{ opacity: 1, y: 0 }}
+								transition={{ delay: index * 0.16, duration: 0.2 }}
+							>
 								{l.node}
-							</div>
+							</m.div>
 						))}
 						<div className="mb-px">
 							{worker?.color === ST.working ? <>{s(worker.color, "● ")}</> : null}
@@ -635,12 +714,96 @@ function AppTerminal({
 	);
 }
 
+function MiniBoard({ spawned, onSelect }: { spawned: string[]; onSelect: (id: string) => void }) {
+	const lanes = [
+		{ label: "Working", color: ST.working, id: "claude" },
+		{ label: "Needs you", color: ST.needs, id: "cursor" },
+		{ label: "In review", color: ST.review, id: "codex" },
+	];
+	return (
+		<div className="grid min-w-0 grid-cols-3" style={{ background: APP.bg }}>
+			{lanes.map((lane) => {
+				const worker = byId(lane.id);
+				return (
+					<div key={lane.id} className="border-r p-2 last:border-r-0" style={{ borderColor: APP.line }}>
+						<div
+							className="mb-2 flex items-center gap-1.5 text-[8.5px] font-semibold"
+							style={{ color: APP.mut }}
+						>
+							<Dot color={lane.color} size={6} />
+							{lane.label}
+						</div>
+						{worker && spawned.includes(lane.id) ? (
+							<button
+								type="button"
+								onClick={() => onSelect(lane.id)}
+								className="w-full rounded-md border p-2 text-left hover:bg-white/5"
+								style={{ borderColor: APP.line, background: APP.panel }}
+							>
+								<span className="block text-[9px] font-semibold">{worker.task}</span>
+								<span
+									className="mt-1 block truncate font-mono text-[7.5px]"
+									style={{ color: APP.faint }}
+								>
+									{worker.branch}
+								</span>
+							</button>
+						) : null}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function NotificationPreview({ onOpen }: { onOpen: () => void }) {
+	return (
+		<m.div
+			initial={{ opacity: 0, y: -4 }}
+			animate={{ opacity: 1, y: 0 }}
+			className="absolute right-2 top-10 z-20 w-[270px] overflow-hidden rounded-xl border text-left shadow-2xl"
+			style={{ background: APP.panel, borderColor: APP.line }}
+		>
+			<div className="border-b px-3.5 py-3" style={{ background: APP.elev, borderColor: APP.line }}>
+				<p className="text-[13px] font-semibold tracking-tight">Notifications</p>
+			</div>
+			<div className="flex items-center gap-1.5 px-3.5 pb-1 pt-2 text-[9px] font-medium uppercase tracking-wide" style={{ color: APP.faint }}>
+				Unseen
+				<span className="grid min-w-4 place-items-center rounded-full px-1 font-mono leading-4" style={{ background: APP.elev, color: APP.mut }}>
+					1
+				</span>
+			</div>
+			<button
+				type="button"
+				onClick={onOpen}
+				className="group grid w-full grid-cols-[26px_minmax(0,1fr)] gap-2.5 px-3.5 py-2.5 text-left hover:bg-white/5"
+			>
+				<span className="mt-0.5 grid size-[26px] place-items-center rounded-md" style={{ background: APP.elev, color: ST.needs }}>
+					<CircleAlert size={14} />
+				</span>
+				<span className="min-w-0">
+					<span className="flex min-w-0 items-start gap-2">
+						<span className="min-w-0 flex-1 text-[11px] font-medium leading-snug">Setup guide needs input</span>
+						<time className="shrink-0 font-mono text-[8px]" style={{ color: APP.faint }}>now</time>
+					</span>
+					<span className="mt-0.5 block text-[10px] leading-snug" style={{ color: APP.mut }}>
+						Choose whether the guide should document PKCE or the implicit flow.
+					</span>
+				</span>
+			</button>
+		</m.div>
+	);
+}
+
 export function DelegationDemo() {
 	const [spawned, setSpawned] = useState<string[]>(["orc"]);
-	const [orcCount, setOrcCount] = useState(0);
+	const [orcCount, setOrcCount] = useState(3);
 	const [active, setActive] = useState("orc");
 	const [query, setQuery] = useState("");
 	const [pinnedOpen, setPinnedOpen] = useState(false);
+	const [boardOpen, setBoardOpen] = useState(false);
+	const [notificationsOpen, setNotificationsOpen] = useState(false);
+	const [sidebarOpen, setSidebarOpen] = useState(true);
 	const startedRef = useRef(false);
 	const timerRef = useRef<number | undefined>(undefined);
 	const rootRef = useRef<HTMLDivElement>(null);
@@ -648,14 +811,13 @@ export function DelegationDemo() {
 	const start = useCallback(() => {
 		if (startedRef.current) return;
 		startedRef.current = true;
-		const reduce =
-			typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		const reduce = typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 		if (reduce) {
 			setSpawned(["orc", "claude", "codex", "cursor"]);
 			setOrcCount(ORC_LINES.length);
 			return;
 		}
-		let i = 0;
+		let i = 3;
 		const tick = () => {
 			i += 1;
 			const line = ORC_LINES[i - 1];
@@ -664,7 +826,30 @@ export function DelegationDemo() {
 				const id = line.spawn;
 				setSpawned((prev) => (prev.includes(id) ? prev : [...prev, id]));
 			}
-			if (i < ORC_LINES.length) timerRef.current = window.setTimeout(tick, 560);
+			if (i < ORC_LINES.length) {
+				timerRef.current = window.setTimeout(tick, 560);
+			} else {
+				const focusOrder = ["claude", "codex", "cursor"];
+				let focusIndex = 0;
+				const focusNext = () => {
+					if (focusIndex < focusOrder.length) {
+						setActive(focusOrder[focusIndex]);
+						setBoardOpen(false);
+						focusIndex += 1;
+						timerRef.current = window.setTimeout(focusNext, 1500);
+						return;
+					}
+					timerRef.current = window.setTimeout(() => {
+						setActive("orc");
+						setBoardOpen(false);
+						setSpawned(["orc"]);
+						setOrcCount(3);
+						i = 3;
+						timerRef.current = window.setTimeout(tick, 700);
+					}, 900);
+				};
+				timerRef.current = window.setTimeout(focusNext, 700);
+			}
 		};
 		tick();
 	}, []);
@@ -699,47 +884,96 @@ export function DelegationDemo() {
 			window.removeEventListener("resize", onVisible);
 			window.clearTimeout(t);
 			if (timerRef.current) window.clearTimeout(timerRef.current);
+			startedRef.current = false;
 		};
 	}, [start]);
 
 	const isOrc = active === "orc";
 	const worker = isOrc ? undefined : byId(active);
 	const needle = query.toLowerCase();
-	const filtered = spawned.filter(
-		(id) => id !== "orc" && (byId(id)?.task.toLowerCase().includes(needle) ?? false),
-	);
+	const filtered = spawned.filter((id) => id !== "orc" && (byId(id)?.task.toLowerCase().includes(needle) ?? false));
 
 	const killActive = () => {
 		if (isOrc) return;
 		setSpawned((prev) => prev.filter((id) => id !== active));
 		setActive("orc");
 	};
+	const selectSession = (id: string) => {
+		setActive(id);
+		setBoardOpen(false);
+	};
+	const restartDemo = () => {
+		if (timerRef.current) window.clearTimeout(timerRef.current);
+		startedRef.current = false;
+		setActive("orc");
+		setSpawned(["orc"]);
+		setOrcCount(3);
+		setBoardOpen(false);
+		timerRef.current = window.setTimeout(start, 120);
+	};
 
 	return (
 		<LazyMotion features={domAnimation}>
 			<div
 				ref={rootRef}
-				className="mx-auto w-full min-w-0 max-w-[620px] overflow-hidden rounded-xl border font-sans antialiased shadow-[0_28px_74px_-22px_rgba(0,0,0,0.86)]"
-				style={{ background: APP.bg, color: APP.fg, borderColor: APP.line, fontSize: 12 }}
+				className="relative mx-auto w-full min-w-0 max-w-[620px] overflow-hidden rounded-xl border font-sans antialiased shadow-[0_28px_74px_-22px_rgba(0,0,0,0.86)]"
+				style={{ background: APP.panel, color: APP.fg, borderColor: APP.line, fontSize: 12 }}
 			>
-				<AppTopBar isOrc={isOrc} worker={worker} onKill={killActive} />
-				<div className="grid" style={{ gridTemplateColumns: "180px 1fr", height: 344 }}>
-					<AppSidebar
-						isOrc={isOrc}
-						active={active}
-						query={query}
-						setQuery={setQuery}
-						pinnedOpen={pinnedOpen}
-						setPinnedOpen={setPinnedOpen}
-						filtered={filtered}
-						onSelect={setActive}
+				<ShellNav
+					canGoForward={spawned.length > 1}
+					onBack={() => selectSession("orc")}
+					onForward={() => selectSession(spawned.find((id) => id !== "orc") ?? "orc")}
+					onSidebar={() => setSidebarOpen((open) => !open)}
+				/>
+				{notificationsOpen ? (
+					<NotificationPreview
+						onOpen={() => {
+							selectSession("cursor");
+							setNotificationsOpen(false);
+						}}
 					/>
-					<AppTerminal
-						isOrc={isOrc}
-						orcLines={ORC_LINES.slice(0, orcCount)}
-						orcDone={orcCount >= ORC_LINES.length}
-						worker={worker}
-					/>
+				) : null}
+				<div
+					className={`grid ${sidebarOpen ? "grid-cols-[132px_minmax(0,1fr)] sm:grid-cols-[180px_minmax(0,1fr)]" : "grid-cols-1"}`}
+					style={{ height: 386 }}
+				>
+					{sidebarOpen ? (
+						<div className="flex min-h-0 pt-9">
+							<AppSidebar
+								active={active}
+								query={query}
+								setQuery={setQuery}
+								pinnedOpen={pinnedOpen}
+								setPinnedOpen={setPinnedOpen}
+								filtered={filtered}
+								onSelect={selectSession}
+							/>
+						</div>
+					) : null}
+					<div
+						className={`m-1 flex min-w-0 flex-col overflow-hidden rounded-lg border ${sidebarOpen ? "ml-0" : "ml-24"}`}
+						style={{ background: APP.bg, borderColor: APP.line }}
+					>
+						<AppTopBar
+							isOrc={isOrc}
+							worker={worker}
+							onKill={killActive}
+							onKanban={() => setBoardOpen(true)}
+							onNotifications={() => setNotificationsOpen((open) => !open)}
+							onOrchestrator={() => selectSession("orc")}
+							onRunDemo={restartDemo}
+						/>
+						{boardOpen ? (
+							<MiniBoard spawned={spawned} onSelect={selectSession} />
+						) : (
+							<AppTerminal
+								isOrc={isOrc}
+								orcLines={ORC_LINES.slice(0, orcCount)}
+								orcDone={orcCount >= ORC_LINES.length}
+								worker={worker}
+							/>
+						)}
+					</div>
 				</div>
 			</div>
 		</LazyMotion>
@@ -769,13 +1003,29 @@ const baseTopBtn: CSSProperties = {
 	borderRadius: 8,
 	fontSize: 11,
 	fontWeight: 650,
+	whiteSpace: "nowrap",
+	flexShrink: 0,
 	cursor: "pointer",
-	border: "1px solid transparent",
+	borderWidth: 1,
+	borderStyle: "solid",
+	borderColor: "transparent",
 	background: "transparent",
 	color: APP.fg,
 };
-const ghostBtnStyle: CSSProperties = { ...baseTopBtn, background: APP.elev, borderColor: APP.line };
-const kanbanBtnStyle: CSSProperties = { ...baseTopBtn, background: APP.blue, color: "#fff" };
+const ghostBtnStyle: CSSProperties = {
+	...baseTopBtn,
+	padding: "0 9px",
+	fontSize: 10.5,
+	background: APP.elev,
+	borderColor: APP.line,
+};
+const kanbanBtnStyle: CSSProperties = {
+	...baseTopBtn,
+	padding: "0 9px",
+	fontSize: 10.5,
+	background: APP.blue,
+	color: "#fff",
+};
 const killBtnStyle: CSSProperties = {
 	...baseTopBtn,
 	color: "color-mix(in srgb, #ee6a6a 82%, #fff)",

--- a/frontend/src/landing/src/app/components/FeaturesSection/components/DelegationDemo/DelegationDemo.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/DelegationDemo/DelegationDemo.tsx
@@ -316,6 +316,12 @@ const WORKERS: Worker[] = [
 
 const OTHER: { name: string; sessions: string[] }[] = [{ name: "sandbox", sessions: [] }];
 
+const MINI_BOARD_LANES = [
+	{ label: "Working", color: ST.working, id: "claude" },
+	{ label: "Needs you", color: ST.needs, id: "cursor" },
+	{ label: "In review", color: ST.review, id: "codex" },
+] as const;
+
 const byId = (id: string) => WORKERS.find((w) => w.id === id);
 
 function Dot({ color, breathe, size = 7 }: { color: string; breathe?: boolean; size?: number }) {
@@ -715,14 +721,9 @@ function AppTerminal({
 }
 
 function MiniBoard({ spawned, onSelect }: { spawned: string[]; onSelect: (id: string) => void }) {
-	const lanes = [
-		{ label: "Working", color: ST.working, id: "claude" },
-		{ label: "Needs you", color: ST.needs, id: "cursor" },
-		{ label: "In review", color: ST.review, id: "codex" },
-	];
 	return (
 		<div className="grid min-w-0 grid-cols-3" style={{ background: APP.bg }}>
-			{lanes.map((lane) => {
+			{MINI_BOARD_LANES.map((lane) => {
 				const worker = byId(lane.id);
 				return (
 					<div key={lane.id} className="border-r p-2 last:border-r-0" style={{ borderColor: APP.line }}>


### PR DESCRIPTION
Updates the delegation demo to match the desktop app and show an interactive orchestrator flow.

## Before

<img width="744" height="549" alt="image" src="https://github.com/user-attachments/assets/abe2039c-ca63-45bd-8f9b-7e7c4f378475" />

## After

<img width="658" height="488" alt="image" src="https://github.com/user-attachments/assets/f97cfef8-bcb9-44d7-9ff7-b63ba5e7be2e" />
