### PR TITLE
fix(frontend): use product app name across OS menus

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -70,7 +70,7 @@ import { keepDaemonAlive, shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { shouldSignalAttention, shouldToast } from "./main/notification-signals";
-import { buildWindowsAppMenuTemplate } from "./main/menu";
+import { APP_NAME, buildAppMenuTemplate } from "./main/menu";
 import { ancestorRepositorySetupWarning, scanImportFolder } from "./main/import-folder-scan";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
@@ -90,7 +90,7 @@ process.stdout.on("error", ignoreStdStreamError);
 process.stderr.on("error", ignoreStdStreamError);
 
 // Must run before app ready so the About panel and default-menu role labels use it.
-app.setName("Agent Orchestrator");
+app.setName(APP_NAME);
 
 // Windows shows native toasts only when the app declares an AppUserModelID that
 // matches its installer shortcut (the NSIS maker's appId). Without it,
@@ -268,8 +268,8 @@ function appendDaemonOutput(text: string): void {
 // bar stays out of sight, but the roles keep their accelerators alive (Reload,
 // DevTools, zoom, full screen, edit commands) and each acts on the *focused*
 // webContents — including a BrowserView panel — matching native menu behaviour.
-function buildWindowsAppMenu(): Menu {
-	return Menu.buildFromTemplate(buildWindowsAppMenuTemplate());
+function buildAppMenu(): Menu {
+	return Menu.buildFromTemplate(buildAppMenuTemplate(process.platform));
 }
 
 function createWindow(): void {
@@ -280,7 +280,7 @@ function createWindow(): void {
 		height: 860,
 		minWidth: 960,
 		minHeight: 640,
-		title: "Agent Orchestrator",
+		title: APP_NAME,
 		icon: windowIconPath(),
 		backgroundColor: "#0f1014",
 		// Windows goes frameless with a Window Controls Overlay: Electron still draws
@@ -309,13 +309,17 @@ function createWindow(): void {
 		},
 	});
 
+	// Install our own native menu on every OS so dev and packaged builds use the
+	// product name instead of Electron's default app identity. On Windows this
+	// stays hidden below; only its native accelerators are used.
+	Menu.setApplicationMenu(buildAppMenu());
+
 	// On Windows the app paints its own title bar (WindowTitlebar), so the native
 	// menu bar is hidden (autoHideMenuBar above). The role-based menu is still
 	// installed so its accelerators keep working and act on the focused pane;
 	// setMenuBarVisibility(false) keeps the strip itself out of view. macOS/Linux
 	// keep their native menus.
 	if (process.platform === "win32") {
-		Menu.setApplicationMenu(buildWindowsAppMenu());
 		mainWindow.setMenuBarVisibility(false);
 	}
 

--- a/frontend/src/main/menu.test.ts
+++ b/frontend/src/main/menu.test.ts
@@ -1,20 +1,49 @@
 import { describe, expect, it } from "vitest";
-import { buildWindowsAppMenuTemplate } from "./menu";
+import { APP_NAME, buildAppMenuTemplate } from "./menu";
 
-type MenuItem = ReturnType<typeof buildWindowsAppMenuTemplate>[number];
+type MenuItem = ReturnType<typeof buildAppMenuTemplate>[number];
 type SubmenuItem = NonNullable<Extract<MenuItem["submenu"], readonly unknown[]>>[number];
 
-function viewSubmenu(): readonly SubmenuItem[] {
-	const viewMenu = buildWindowsAppMenuTemplate().find((item) => item.label === "View");
+function appSubmenu(platform: NodeJS.Platform): readonly SubmenuItem[] {
+	const appMenu = buildAppMenuTemplate(platform)[0];
+	if (!appMenu || !Array.isArray(appMenu.submenu)) {
+		throw new Error("App menu not found");
+	}
+	return appMenu.submenu;
+}
+
+function viewSubmenu(platform: NodeJS.Platform = "linux"): readonly SubmenuItem[] {
+	const viewMenu = buildAppMenuTemplate(platform).find((item) => item.label === "View");
 	if (!viewMenu || !Array.isArray(viewMenu.submenu)) {
 		throw new Error("View menu not found");
 	}
 	return viewMenu.submenu;
 }
 
-describe("buildWindowsAppMenuTemplate", () => {
-	it("registers both plus key forms for zoom in", () => {
-		const zoomInItems = viewSubmenu().filter((item) => item.role === "zoomIn");
+describe("buildAppMenuTemplate", () => {
+	it.each(["darwin", "linux", "win32"] as const)("uses Agent Orchestrator as the app menu label on %s", (platform) => {
+		const appMenu = buildAppMenuTemplate(platform)[0];
+
+		expect(appMenu.label).toBe(APP_NAME);
+		expect(appSubmenu(platform)).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ label: `About ${APP_NAME}`, role: "about" }),
+				expect.objectContaining({ label: `Quit ${APP_NAME}`, role: "quit" }),
+			]),
+		);
+	});
+
+	it("keeps macOS app menu roles", () => {
+		expect(appSubmenu("darwin")).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ label: `Hide ${APP_NAME}`, role: "hide" }),
+				expect.objectContaining({ role: "services" }),
+			]),
+		);
+	});
+
+	it("registers both Windows plus key forms for zoom in", () => {
+		const zoomInItems = viewSubmenu("win32").filter((item) => item.role === "zoomIn");
 
 		expect(zoomInItems).toEqual(
 			expect.arrayContaining([
@@ -24,7 +53,7 @@ describe("buildWindowsAppMenuTemplate", () => {
 		);
 	});
 
-	it("keeps the direct minus accelerator for zoom out", () => {
-		expect(viewSubmenu()).toContainEqual(expect.objectContaining({ accelerator: "Ctrl+-", role: "zoomOut" }));
+	it("keeps the direct Windows minus accelerator for zoom out", () => {
+		expect(viewSubmenu("win32")).toContainEqual(expect.objectContaining({ accelerator: "Ctrl+-", role: "zoomOut" }));
 	});
 });

--- a/frontend/src/main/menu.ts
+++ b/frontend/src/main/menu.ts
@@ -1,7 +1,43 @@
 import type { MenuItemConstructorOptions } from "electron";
 
-export function buildWindowsAppMenuTemplate(): MenuItemConstructorOptions[] {
+export const APP_NAME = "Agent Orchestrator";
+
+function buildAppSubmenu(platform: NodeJS.Platform): MenuItemConstructorOptions[] {
+	if (platform === "darwin") {
+		return [
+			{ label: `About ${APP_NAME}`, role: "about" },
+			{ type: "separator" },
+			{ role: "services" },
+			{ type: "separator" },
+			{ label: `Hide ${APP_NAME}`, role: "hide" },
+			{ role: "hideOthers" },
+			{ role: "unhide" },
+			{ type: "separator" },
+			{ label: `Quit ${APP_NAME}`, role: "quit" },
+		];
+	}
+
 	return [
+		{ label: `About ${APP_NAME}`, role: "about" },
+		{ type: "separator" },
+		{ label: `Quit ${APP_NAME}`, role: "quit" },
+	];
+}
+
+export function buildAppMenuTemplate(platform: NodeJS.Platform): MenuItemConstructorOptions[] {
+	const zoomInItems: MenuItemConstructorOptions[] =
+		platform === "win32"
+			? [
+					{ accelerator: "Ctrl+=", role: "zoomIn" },
+					{ accelerator: "Ctrl+Plus", acceleratorWorksWhenHidden: true, role: "zoomIn", visible: false },
+				]
+			: [{ role: "zoomIn" }];
+
+	const template: MenuItemConstructorOptions[] = [
+		{
+			label: APP_NAME,
+			submenu: buildAppSubmenu(platform),
+		},
 		{
 			label: "Edit",
 			submenu: [
@@ -11,7 +47,14 @@ export function buildWindowsAppMenuTemplate(): MenuItemConstructorOptions[] {
 				{ role: "cut" },
 				{ role: "copy" },
 				{ role: "paste" },
+				{ role: "pasteAndMatchStyle" },
+				{ role: "delete" },
 				{ role: "selectAll" },
+				{ type: "separator" },
+				{
+					label: "Speech",
+					submenu: [{ role: "startSpeaking" }, { role: "stopSpeaking" }],
+				},
 			],
 		},
 		{
@@ -21,16 +64,29 @@ export function buildWindowsAppMenuTemplate(): MenuItemConstructorOptions[] {
 				{ role: "toggleDevTools" },
 				{ type: "separator" },
 				{ role: "resetZoom" },
-				{ accelerator: "Ctrl+=", role: "zoomIn" },
-				{ accelerator: "Ctrl+Plus", acceleratorWorksWhenHidden: true, role: "zoomIn", visible: false },
-				{ accelerator: "Ctrl+-", role: "zoomOut" },
+				...zoomInItems,
+				{ role: "zoomOut" },
 				{ type: "separator" },
 				{ role: "togglefullscreen" },
 			],
 		},
 		{
 			label: "Window",
-			submenu: [{ role: "minimize" }, { role: "close" }],
+			submenu: [{ role: "close" }, { role: "minimize" }, { role: "zoom" }, { type: "separator" }, { role: "front" }],
+		},
+		{
+			label: "Help",
+			submenu: [],
 		},
 	];
+
+	if (platform === "win32") {
+		const viewMenu = template.find((item) => item.label === "View");
+		if (viewMenu && Array.isArray(viewMenu.submenu)) {
+			const zoomOutItem = viewMenu.submenu.find((item) => item.role === "zoomOut");
+			if (zoomOutItem) zoomOutItem.accelerator = "Ctrl+-";
+		}
+	}
+
+	return template;
 }


### PR DESCRIPTION
## Summary
- add a shared `APP_NAME` constant for the Electron main process
- install a platform-aware native application menu on macOS, Linux, and Windows so the app identity reads `Agent Orchestrator` instead of Electron defaults
- keep Windows menu accelerators while hiding the native menu bar as before

## Validation
- `cd frontend && npm run typecheck`
- `cd frontend && npx vitest run --config vitest.config.ts src/main/menu.test.ts`