### PR TITLE
Remove the Files copy path button

### DIFF
--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -180,7 +180,6 @@ describe("SessionFilesView", () => {
 		await screen.findByRole("button", { name: "Collapse src/App.tsx" });
 		expect(screen.queryByRole("button", { name: /README\.md/ })).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Download src/App.tsx" })).not.toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Copy path for src/App.tsx" })).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Diff layout" })).not.toBeInTheDocument();
 		expect(screen.queryByText("Stacked")).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Refresh files" })).not.toBeInTheDocument();

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -12,13 +12,11 @@ import { useQuery } from "@tanstack/react-query";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import {
-	Check,
 	ChevronDown,
 	ChevronRight,
 	ChevronsDownUp,
 	ChevronsUpDown,
 	Columns2,
-	Copy,
 	Maximize2,
 	Minimize2,
 	Search,
@@ -334,7 +332,6 @@ function ReviewFileCard({
 					className="gap-2 px-3 py-1.5"
 					data-file-toggle=""
 					headerClassName="min-h-10 hover:bg-interactive-hover/50 data-[state=open]:bg-interactive-active/45"
-					trailing={<CopyPathButton path={file.path} />}
 				>
 					{expanded ? (
 						<ChevronDown className="size-icon-sm shrink-0 text-passive" aria-hidden="true" />
@@ -365,31 +362,6 @@ function ReviewFileCard({
 				</AccordionContent>
 			</li>
 		</AccordionItem>
-	);
-}
-
-function CopyPathButton({ path }: { path: string }) {
-	const { t } = useTranslation();
-	const [copied, setCopied] = useState(false);
-	return (
-		<Button
-			aria-label={copied ? t("files.pathCopied") : t("files.copyPath", { path })}
-			className="mr-1.5 shrink-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/row:opacity-100"
-			onClick={() => {
-				void navigator.clipboard?.writeText(path);
-				setCopied(true);
-				setTimeout(() => setCopied(false), 1200);
-			}}
-			size="icon-sm"
-			type="button"
-			variant="ghost"
-		>
-			{copied ? (
-				<Check className="size-icon-sm text-success" aria-hidden="true" />
-			) : (
-				<Copy className="size-icon-sm" aria-hidden="true" />
-			)}
-		</Button>
 	);
 }
 

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -810,8 +810,6 @@
 	"files.expandFile": "Expand {{file}}",
 	"files.loadingDiff": "Loading diff...",
 	"files.error.loadFile": "Unable to load this file.",
-	"files.pathCopied": "Path copied",
-	"files.copyPath": "Copy path for {{path}}",
 	"files.noChangesHead": "No changes against HEAD.",
 	"files.noChangesBase": "No changes against base.",
 	"files.noneChanged": "No changed files found.",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -810,8 +810,6 @@
 	"files.expandFile": "展开 {{file}}",
 	"files.loadingDiff": "正在加载差异...",
 	"files.error.loadFile": "无法加载此文件。",
-	"files.pathCopied": "路径已复制",
-	"files.copyPath": "复制 {{path}} 的路径",
 	"files.noChangesHead": "与 HEAD 相比没有更改。",
 	"files.noChangesBase": "与基准相比没有更改。",
 	"files.noneChanged": "未找到已更改的文件。",


### PR DESCRIPTION
## Summary
- remove the copy-path button from file rows
- remove its unused translations and test assertion

## Tests
- `npm run frontend:typecheck`
- `npm --prefix frontend test -- --run src/renderer/components/SessionFilesView.test.tsx src/renderer/i18n/renderer-coverage.test.ts`