### PR TITLE
fix: drop Terminal label and flush session tabs left

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -65,7 +65,7 @@ describe("CenterPane toolbar session label", () => {
 	it("uses the inspector tab height for the terminal header", () => {
 		render(<CenterPane session={worker} theme="dark" daemonReady />);
 
-		const header = screen.getByText("Terminal").parentElement?.parentElement;
+		const header = screen.getByRole("button", { name: worker.title }).closest(".h-inspector-tabs");
 		expect(header).toHaveClass("h-inspector-tabs");
 	});
 
@@ -86,7 +86,7 @@ describe("CenterPane toolbar session label", () => {
 
 		// The display controls float over the terminal body, not the tab bar,
 		// so tabs and controls can never overlap.
-		const tabBarRow = screen.getByText("Terminal").closest("div")?.parentElement;
+		const tabBarRow = screen.getByRole("button", { name: worker.title }).closest(".h-inspector-tabs");
 		expect(tabBarRow).not.toBeNull();
 		expect(tabBarRow?.contains(screen.getByRole("button", { name: /fullscreen/i }))).toBe(false);
 	});

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -123,16 +123,13 @@ export function CenterPane({
 			className="terminal-pane-frame flex h-full min-h-0 min-w-flex-min flex-col"
 			onWheelCapture={handleWheelZoom}
 		>
-			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border px-5">
-				<div className="flex min-w-flex-min flex-1 items-center gap-3">
-					<span className="shrink-0 font-mono text-caption font-semibold uppercase tracking-wide-lg text-muted-foreground">
-						{t("workbench.terminal")}
-					</span>
+			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border px-2">
+				<div className="flex min-w-flex-min flex-1 items-center">
 					<button
 						aria-label={t("terminal.scrollTabsLeft")}
 						className={cn(
-							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none disabled:opacity-0",
-							!tabsOverflow.canScrollLeft && "invisible",
+							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none",
+							!tabsOverflow.canScrollLeft && "w-0 min-w-0 overflow-hidden p-0 opacity-0",
 						)}
 						disabled={!tabsOverflow.canScrollLeft}
 						onClick={() => tabsOverflow.scrollByDirection(-1)}
@@ -170,8 +167,8 @@ export function CenterPane({
 					<button
 						aria-label={t("terminal.scrollTabsRight")}
 						className={cn(
-							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none disabled:opacity-0",
-							!tabsOverflow.canScrollRight && "invisible",
+							"inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none",
+							!tabsOverflow.canScrollRight && "w-0 min-w-0 overflow-hidden p-0 opacity-0",
 						)}
 						disabled={!tabsOverflow.canScrollRight}
 						onClick={() => tabsOverflow.scrollByDirection(1)}


### PR DESCRIPTION
## Summary
- Remove the uppercase `Terminal` label from the session pane tab strip.
- Tighten bar padding and collapse hidden scroll chevrons so they no longer reserve empty space before the session tab.

## Test plan
- [ ] Open a session and confirm the tab strip no longer shows `TERMINAL`.
- [ ] Confirm the session tab (e.g. session name pill) sits near the left edge with no large empty gap.
- [ ] With many shell tabs, confirm left/right scroll chevrons still appear and work when the strip overflows.
- [ ] Confirm New terminal and font/fullscreen controls still work.

## Before 
<img width="776" height="495" alt="image" src="https://github.com/user-attachments/assets/435831fe-09a8-4b61-8d9c-62abbef21842" />

## After
<img width="857" height="547" alt="image" src="https://github.com/user-attachments/assets/6f5df842-1eb2-4127-a5c2-548fb0bbd8c1" />
