### PR TITLE
fix: align Settings and Archive hairlines

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -63,13 +63,12 @@ import { useUiStore } from "../stores/ui-store"
 import { ConfirmDialog } from "./ConfirmDialog";
 import { CreateProjectFlow, type CreateProjectInput } from "./CreateProjectFlow";
 import { ResizeHandle } from "./ResizeHandle";
-import { isLinuxPlatform, isMacPlatform } from "../lib/platform";
+import { isMacPlatform } from "../lib/platform";
 
-// macOS + Linux paint framed chrome: the fixed TitlebarNav cluster carries the
+// macOS paints framed chrome: the fixed TitlebarNav cluster carries the
 // sidebar toggle + history arrows above this surface. Windows hangs the sidebar
 // under its custom titlebar.
 const isMac = isMacPlatform();
-const isLinux = isLinuxPlatform();
 const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
 // Shared styling for the per-project hover action buttons (dashboard,
@@ -369,14 +368,14 @@ export function Sidebar({
 			{/* Footer — Settings opens the global settings page directly.
 			    Top hairline matches the board Archive `border-t border-border-strong`.
 			    Row height matches Archive (`h-row-md`). Bottom margin is the shell
-			    inset minus 1px so the hairline meets Archive (the +1 surface-border
-			    compensation overshoots on mac/linux). */}
+			    inset plus the center-panel surface's 1px border so the hairline
+			    meets Archive (Archive sits inside that bordered surface). */}
 			<SidebarFooter
 				className={cn(
 					"relative mt-auto gap-0 overflow-hidden border-t border-border-strong px-2 pb-0 pt-0 transition-[padding] duration-200 ease-linear group-data-[collapsible=icon]:min-h-16 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:border-t-0 group-data-[collapsible=icon]:px-1.5 group-data-[collapsible=icon]:pb-0 group-data-[collapsible=icon]:pt-1.5",
-					isMac || isLinux
-						? "mb-[calc(var(--size-center-panel-inset-mac)-1px)]"
-						: "mb-[calc(var(--size-center-panel-bottom-inset)-1px)]",
+					isMac
+						? "mb-[calc(var(--size-center-panel-inset-mac)+1px)]"
+						: "mb-[calc(var(--size-center-panel-bottom-inset)+1px)]",
 				)}
 			>
 				{/* Always-present daemon status mirror for the smoke suite: no visible

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -415,7 +415,7 @@
 	padding-left: var(--size-center-panel-inline-inset);
 }
 
-/* macOS + Linux: inset on all sides except left (flush with sidebar). */
+/* macOS: inset on all sides except left (flush with sidebar). */
 .center-panel-shell.center-panel-shell--mac {
 	padding-top: var(--size-center-panel-inset-mac);
 	padding-right: var(--size-center-panel-inset-mac);


### PR DESCRIPTION
## Summary
- Raise the sidebar Settings footer margin by the center-panel surface’s 1px border (`inset + 1px`) so its hairline lines up with Archive
- Use the Mac inset on macOS and the shared bottom inset on Windows/Linux (stop treating Linux like Mac for this margin)
- Correct the `.center-panel-shell--mac` comment to macOS-only

## Test plan
- [ ] macOS: board with archived sessions — Settings and Archive top borders form one continuous line
- [ ] Expand/collapse Archive — Settings hairline stays aligned when collapsed
- [ ] Windows/Linux (or platform mock): same alignment against the larger bottom inset
- [ ] Collapsed sidebar icon rail: Settings control still usable; no layout jump at the footer

## Before
<img width="413" height="163" alt="image" src="https://github.com/user-attachments/assets/3afbe89b-2bef-44b4-9070-cdf9a81f67f0" />

## After
<img width="540" height="163" alt="image" src="https://github.com/user-attachments/assets/abf624f2-a460-455d-a524-788e9ff6cdd2" />
