### PR TITLE
fix: disable text selection on app chrome

### DIFF
--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -842,6 +842,8 @@ body {
 	font-size: var(--font-size-md);
 	line-height: var(--line-height-normal);
 	-webkit-font-smoothing: antialiased;
+	-webkit-user-select: none;
+	user-select: none;
 }
 
 button,
@@ -849,6 +851,13 @@ input,
 textarea,
 select {
 	font: inherit;
+}
+
+input,
+textarea,
+[contenteditable="true"] {
+	-webkit-user-select: text;
+	user-select: text;
 }
 
 :is(


### PR DESCRIPTION
## Summary
- Set `user-select: none` on the renderer `body` so sidebar/board chrome text isn't accidentally selectable
- Re-enable selection on `input`, `textarea`, and `[contenteditable="true"]` so form fields still work

## Test plan
- [ ] Drag across sidebar project names / board column headers — no blue selection highlight
- [ ] Type and select text in settings inputs / textareas — selection still works
- [ ] Confirm terminal / contenteditable areas still allow selection where expected

## Before
<img width="593" height="394" alt="image" src="https://github.com/user-attachments/assets/1790ea6c-7dc7-4b3e-b55c-138bd06774ca" />
