### PR TITLE
fix: keep sidebar expand toggle above hover peek

### DIFF
--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -70,6 +70,7 @@ export function TitlebarNav({
 	return (
 		<div
 			className={`fixed ${topClass} ${leftClass} z-titlebar flex h-traffic-light-clearance items-center gap-1`}
+			data-slot="titlebar-nav"
 			style={noDragStyle}
 		>
 			<TitlebarButton

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -458,6 +458,12 @@ function ShellLayout() {
 		const handlePointerMove = (event: PointerEvent) => {
 			const target = event.target instanceof Element ? event.target : null;
 			const isInSidebarPortal = Boolean(target?.closest('[role="dialog"], [role="listbox"], [role="menu"]'));
+			// TitlebarNav / WindowTitlebar sit above the peek in z-order; keep the
+			// preview open while the pointer is on those controls so hover→click
+			// to pin still works.
+			const isInTitlebarChrome = Boolean(
+				target?.closest("[data-slot='titlebar-nav'], .window-titlebar"),
+			);
 			const sidebar = document.querySelector<HTMLElement>('[data-slot="sidebar-container"]');
 			const bounds = sidebar?.getBoundingClientRect();
 			const isInSidebar = Boolean(
@@ -468,7 +474,7 @@ function ShellLayout() {
 				event.clientY <= bounds.bottom,
 			);
 
-			if (isInSidebar || isInSidebarPortal) {
+			if (isInSidebar || isInSidebarPortal || isInTitlebarChrome) {
 				cancelSidebarPeekClose();
 				return;
 			}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1361,6 +1361,8 @@ body.is-resizing-x [data-slot="sidebar-container"] {
  * The whole strip is the window-drag region; interactive children opt out with
  * -webkit-app-region: no-drag. */
 .window-titlebar {
+	position: relative;
+	z-index: var(--z-titlebar);
 	display: flex;
 	height: var(--size-window-titlebar);
 	flex-shrink: 0;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -210,10 +210,13 @@
 
 	/* ═══════════════════════════════════════════════════════════════
 	   Z-INDEX — stacking layers
+	   chrome < sidebar-preview < titlebar < overlay
+	   Preview peeks paint behind the titlebar cluster so the expand
+	   toggle stays clickable while the overlay is open.
 	   ═══════════════════════════════════════════════════════════════ */
 
 	--z-chrome: 10;
-	--z-sidebar-preview: 55;
+	--z-sidebar-preview: 15;
 	--z-titlebar: 20;
 	--z-overlay: 50;
 


### PR DESCRIPTION
## Summary
- Lower `--z-sidebar-preview` below `--z-titlebar` so hover peeks no longer cover the expand/collapse toggle
- Stack the Windows titlebar above peeks
- Treat titlebar chrome as a keep-open zone while peeking so hover→click to pin still works

## Test plan
- [ ] Collapse the sidebar
- [ ] Hover the expand button — peek opens and the button stays visible/clickable
- [ ] Click the expand button while peeking — sidebar pins open
- [ ] Move pointer away from peek/titlebar — peek closes
- [ ] On Windows, confirm the titlebar toggle stays usable during peek

## Before
<img width="344" height="918" alt="image" src="https://github.com/user-attachments/assets/d737f3f1-b47d-4331-8143-505edfa4df0a" />


## After
<img width="373" height="943" alt="image" src="https://github.com/user-attachments/assets/74523942-f488-4a55-896d-cc64f20dfe66" />
