### PR TITLE
fix: drop all-caps labels for sans tracking-tight

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -111,13 +111,14 @@ list of independent sessions. Grounded in the daemon
 
 System fonts only — no custom/Google fonts, zero font payload.
 
-- **UI / body / display:** `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+- **UI / body / display / labels:** `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
 Oxygen, Ubuntu, Cantarell, "Fira Sans", "Helvetica Neue", sans-serif` (San Francisco
   on macOS).
-- **Mono / terminal / code / eyebrow labels:** `Menlo, Monaco, Consolas,
-"Liberation Mono", "Courier New", monospace`.
-- **Eyebrow labels** (section titles, dialog titles, the rail "PROJECTS" header):
-  mono, **uppercase**, `letter-spacing: .12–.14em`, `--foreground-passive`.
+- **Mono / terminal / code only:** `Menlo, Monaco, Consolas,
+"Liberation Mono", "Courier New", monospace`. Never use mono for UI labels or buttons.
+- **Labels / section titles / buttons:** sans, **never all-caps**, `tracking-tight`
+  (`letter-spacing: -0.01em`), weight medium/semibold as needed. Do not apply
+  `text-transform: uppercase` or wide letter-spacing to chrome text.
 - **Scale:** 14px base UI / sidebar (`text-sm`, weight 400) · 12px secondary + labels
   (`text-xs`) · 13px code/mono/terminal · 11px tiny · 10px micro + badges · 9px sidebar
   badge label. Buttons are `font-normal` (400), not bold.
@@ -195,10 +196,10 @@ left rail stay name-only — no glyph.)
   1. **Orchestrator anchor** — pinned, single, visually distinct (blue 2px left bar,
      `--bg-2` fill, hub/`waypoints` icon, name "Orchestrator", a `5 agents · 2 need you`
      mono summary). This is ReverbCode's one addition over the reference. Default landing view.
-  2. `PROJECTS` eyebrow label + a `+`.
+  2. `Projects` section label + a `+`.
   3. Project rows (folder icon + name) with nested **worker rows beneath**. Each project
      row has a hover-revealed **`+`** that opens the New-worker modal pre-scoped to that
-     project (distinct from the `PROJECTS` header `+`, which registers a repo).
+     project (distinct from the `Projects` header `+`, which registers a repo).
   4. **Footer:** `Search ⌘K`, `Settings ⌘,`. (No Library.)
   5. **Account** row pinned at the very bottom.
 - **Worker rows are name-only.** Just the session name, truncated. Status, branch, diff,
@@ -234,7 +235,7 @@ mirrors the reference exactly. Launching from a project row pre-fills the Projec
 
 - Centered dialog, **12px radius**, `max-w` ~512px, `bg` canvas, `ring-1` at 10% fg,
   fade + zoom-95 enter.
-- **Header:** eyebrow mono-uppercase title `New worker` + `×` close.
+- **Header:** sans title `New worker` + `×` close.
 - **Body** (`gap` 15–16px): a **borderless large name field** (18px, auto-focus, slug
   rule "letters, numbers, hyphens") → **Project** selector → **Agent** selector
   (claude-code / codex / opencode / …) → a **"Based on"** bordered card with a segmented

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -649,7 +649,7 @@ function StaticPreview({ url }: { url: string }) {
 	return (
 		<div className="absolute inset-0 overflow-auto bg-preview text-preview-foreground">
 			<div className="border-b border-preview bg-surface px-4 py-3">
-				<div className="text-caption font-semibold uppercase tracking-wide-md text-preview-muted">AO Preview</div>
+				<div className="text-caption font-semibold tracking-tight text-preview-muted">AO Preview</div>
 				<div className="mt-1 truncate font-mono text-xs text-preview-link">{url}</div>
 			</div>
 			<div className="mx-auto max-w-preview-max px-5 py-6">
@@ -674,7 +674,7 @@ function StaticPreview({ url }: { url: string }) {
 							["Latency", "42 ms"],
 						].map(([label, value]) => (
 							<div key={label} className="rounded-md border border-preview-tile bg-preview-tile p-3">
-								<div className="text-caption font-medium uppercase tracking-wide text-preview-muted">{label}</div>
+								<div className="text-caption font-medium tracking-tight text-preview-muted">{label}</div>
 								<div className="mt-1 text-subtitle font-semibold text-preview-heading">{value}</div>
 							</div>
 						))}

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -545,7 +545,7 @@ function CreateProjectFolderDialog({
 
 								{error && (
 									<div className="rounded-lg border border-destructive/40 bg-destructive/10">
-										<div className="border-b border-destructive/30 px-4 py-3 font-mono text-[12px] font-semibold uppercase tracking-[0.12em] text-destructive">
+										<div className="border-b border-destructive/30 px-4 py-3 text-[12px] font-semibold tracking-tight text-destructive">
 											<span className="mr-2 inline-block size-2 rounded-full bg-destructive" aria-hidden="true" />
 											{isWorkspace ? t("createProject.importFailedWorkspace") : t("createProject.importFailedProject")}
 										</div>

--- a/frontend/src/renderer/components/KeyboardShortcutsDialog.tsx
+++ b/frontend/src/renderer/components/KeyboardShortcutsDialog.tsx
@@ -64,7 +64,7 @@ export function KeyboardShortcutsDialog({
 						if (shortcuts.length === 0) return null;
 						return (
 							<section className="border-b border-border py-4 last:border-b-0" key={shortcutCategoryLabel(category, t)}>
-								<h2 className="mb-2 font-mono text-micro font-semibold uppercase tracking-wide-lg text-passive">
+								<h2 className="mb-2 text-micro font-semibold tracking-tight text-passive">
 									{shortcutCategoryLabel(category, t)}
 								</h2>
 								<div className="flex flex-col">

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -355,9 +355,9 @@ function NotificationSectionError({
 
 function NotificationSectionHeading({ count, label }: { count: number; label: string }) {
 	return (
-		<div className="flex items-center gap-1.5 px-4 pb-1 pt-2 text-caption font-medium uppercase tracking-wide text-passive">
+		<div className="flex items-center gap-1.5 px-4 pb-1 pt-2 text-caption font-medium tracking-tight text-passive">
 			{label}
-			<span className="grid min-w-4 place-items-center rounded-full bg-surface px-1 font-mono text-[9px] normal-case leading-4 text-muted-foreground">
+			<span className="grid min-w-4 place-items-center rounded-full bg-surface px-1 font-mono text-[9px] leading-4 text-muted-foreground">
 				{count > 99 ? "99+" : count}
 			</span>
 		</div>

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -285,11 +285,11 @@ function Section({
 	title: string;
 }) {
 	// Boxed sections match the settings page row surface (bg + radius) with the
-	// uppercase muted kicker kept inside the card, as in the inspector refs.
+	// muted kicker kept inside the card, as in the inspector refs.
 	return (
 		<section className={cn("mb-2.5 last:mb-0", className)} data-testid="inspector-section">
 			<div className="overflow-hidden rounded-settings-row bg-settings-row px-3.5 py-3">
-				<div className="mb-2 flex items-center justify-between gap-2 text-2xs font-bold uppercase tracking-settings-section text-settings-muted">
+				<div className="mb-2 flex items-center justify-between gap-2 text-2xs font-medium tracking-tight text-settings-muted">
 					<span>{title}</span>
 					{action ?? null}
 				</div>

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -399,7 +399,7 @@ describe("SessionsBoard", () => {
 
 		expect(within(workSummary).getByText("Idle").querySelector("span")).toHaveClass("bg-status-idle");
 		expect(within(workSummary).getByText("Working").querySelector("span")).toHaveClass("bg-status-working");
-		expect(workSummary).toHaveClass("font-mono", "text-2xs", "uppercase");
+		expect(workSummary).toHaveClass("text-2xs", "tracking-tight");
 		expect(workSummary.parentElement).toHaveClass("h-12");
 		expect(workingRegion.firstElementChild).toHaveClass("py-2.5");
 		expect(within(workLane).getByLabelText("2 idle sessions")).toHaveTextContent("2");

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -395,7 +395,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 							>
 								<path d="m9 18 6-6-6-6" />
 							</svg>
-							<span className="font-mono text-2xs font-medium uppercase tracking-wide-sm">{t("shell.archive")}</span>
+							<span className="text-2xs font-medium tracking-tight">{t("shell.archive")}</span>
 							<span className="ml-1.5 font-mono text-micro text-passive">{archived.length}</span>
 						</button>
 					</div>
@@ -478,7 +478,7 @@ function ZoneColumn({
 						boxShadow: col.dotGlow ? `0 0 7px color-mix(in srgb, ${col.dot} 60%, transparent)` : undefined,
 					}}
 				/>
-				<span className={cn("font-mono text-2xs font-medium uppercase tracking-wide-sm", col.titleClassName)}>
+				<span className={cn("text-2xs font-medium tracking-tight", col.titleClassName)}>
 					{col.label}
 				</span>
 				<span className="ml-auto font-mono text-2xs leading-none text-passive">{sessions.length}</span>
@@ -648,7 +648,7 @@ function SplitLaneColumn({
 			<div className="flex h-12 shrink-0 items-center gap-2.5 px-4">
 				<div
 					aria-label={t("shell.laneSummaryAria", { primary: primaryTone.label, secondary: secondaryTone.label })}
-					className="flex min-w-0 items-center gap-2 font-mono text-2xs font-medium uppercase tracking-wide-sm"
+					className="flex min-w-0 items-center gap-2 text-2xs font-medium tracking-tight"
 					role="group"
 				>
 					<LaneStatusLabel tone={primaryTone} />
@@ -739,7 +739,7 @@ function SecondaryLaneSection({
 			role="region"
 		>
 			<div className="flex shrink-0 items-center gap-2.5 px-4 py-2.5">
-				<div className="font-mono text-2xs font-medium uppercase tracking-wide-sm">
+				<div className="text-2xs font-medium tracking-tight">
 					<LaneStatusLabel tone={tone} />
 				</div>
 				<span className="ml-auto font-mono text-2xs leading-none text-passive">{sessions.length}</span>

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -45,7 +45,7 @@ export function ShellTerminalsView() {
 	return (
 		<div className="flex h-full min-h-0 flex-col text-foreground">
 			<div className="flex h-inspector-tabs shrink-0 items-center gap-3 border-b border-border px-5">
-				<span className="shrink-0 font-mono text-caption font-semibold uppercase tracking-wide-lg text-muted-foreground">
+				<span className="shrink-0 text-caption font-semibold tracking-tight text-muted-foreground">
 					{t("workbench.terminals")}
 				</span>
 				<button

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -149,7 +149,7 @@ export function ShellTopbar() {
 							<span aria-hidden="true" className="text-xs leading-none text-passive">
 								·
 							</span>
-							<span className="inline-flex h-control-sm items-center gap-1 rounded-md border border-border bg-surface px-2 text-micro font-semibold leading-none tracking-wide-sm text-muted-foreground">
+							<span className="inline-flex h-control-sm items-center gap-1 rounded-md border border-border bg-surface px-2 text-micro font-semibold leading-none tracking-tight text-muted-foreground">
 								<OrchestratorIcon className="size-3 shrink-0" aria-hidden="true" />
 								{t("shell.orchestrator")}
 							</span>

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -490,7 +490,7 @@ function TerminalEndedStrip({ canRestore, error, isRestoring, onRestore, variant
 		<div className="shrink-0 border-b border-border bg-surface/80 px-4 py-2">
 			<div className="flex min-h-control-board items-center gap-3">
 				<div className="min-w-0 flex-1">
-					<div className="font-mono text-caption font-medium uppercase tracking-wide-md text-muted-foreground">
+					<div className="text-caption font-medium tracking-tight text-muted-foreground">
 						{t("terminal.ended")}
 					</div>
 					<div className="mt-0.5 truncate text-xs text-muted-foreground">{message}</div>

--- a/frontend/src/renderer/components/settings/SettingsSection.tsx
+++ b/frontend/src/renderer/components/settings/SettingsSection.tsx
@@ -20,7 +20,7 @@ export function SettingsSection({
 			data-testid={sectionId ? "settings-section" : undefined}
 			data-section={sectionId}
 		>
-			<h2 className="text-xs font-bold uppercase leading-4 tracking-settings-section text-settings-muted">{title}</h2>
+			<h2 className="text-xs font-medium leading-4 tracking-tight text-settings-muted">{title}</h2>
 			<div className="flex w-full flex-col gap-1.5">{children}</div>
 		</section>
 	);

--- a/frontend/src/renderer/components/ui/command.tsx
+++ b/frontend/src/renderer/components/ui/command.tsx
@@ -53,7 +53,7 @@ function CommandDialog({
 					<Dialog.Description className="sr-only">{description}</Dialog.Description>
 					<Command
 						className={cn(
-							"**:[[cmdk-group-heading]]:px-[var(--size-command-pad-x)] **:[[cmdk-group-heading]]:pt-2.5 **:[[cmdk-group-heading]]:pb-1 **:[[cmdk-group-heading]]:text-[11px] **:[[cmdk-group-heading]]:font-normal **:[[cmdk-group-heading]]:tracking-wide **:[[cmdk-group-heading]]:text-[var(--color-text-command-muted)] **:[[cmdk-group]]:px-0",
+							"**:[[cmdk-group-heading]]:px-[var(--size-command-pad-x)] **:[[cmdk-group-heading]]:pt-2.5 **:[[cmdk-group-heading]]:pb-1 **:[[cmdk-group-heading]]:text-[11px] **:[[cmdk-group-heading]]:font-normal **:[[cmdk-group-heading]]:tracking-tight **:[[cmdk-group-heading]]:text-[var(--color-text-command-muted)] **:[[cmdk-group]]:px-0",
 							commandClassName,
 						)}
 						{...restCommandProps}

--- a/frontend/src/renderer/components/ui/dropdown-menu.tsx
+++ b/frontend/src/renderer/components/ui/dropdown-menu.tsx
@@ -56,7 +56,7 @@ export function DropdownMenuLabel({
 	return (
 		<DropdownMenuPrimitive.Label
 			className={cn(
-				"px-2 py-1.5 text-micro tracking-wide text-passive",
+				"px-2 py-1.5 text-micro tracking-tight text-passive",
 				inset && "pl-8",
 				className,
 			)}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1646,7 +1646,7 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	font-size: 11px;
 	font-weight: 700;
 	color: #8bdc75;
-	text-transform: uppercase;
+	letter-spacing: var(--tracking-tight);
 }
 
 :root[data-theme="light"] .reviewer-terminal-header__role {
@@ -1690,15 +1690,13 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	margin-bottom: 11px;
 	font-size: 10.5px;
 	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.09em;
+	letter-spacing: var(--tracking-tight);
 	color: var(--fg-passive);
 }
 
 .inspector-section__link {
 	font-size: 11px;
 	font-weight: 500;
-	text-transform: none;
 	letter-spacing: 0;
 	color: var(--accent);
 }


### PR DESCRIPTION
## Summary
- Remove all-caps / mono eyebrow styling from board, settings, inspector, notifications, terminals, and related chrome
- Use sans + `tracking-tight` for labels and section titles
- Update `DESIGN.md` so typography guidance matches (no mono uppercase eyebrows)

## Test plan
- [ ] Board column headers / Archive / lane labels render title case, sans, tight tracking
- [ ] Settings and inspector section titles match
- [ ] Notification section headings, terminal ended banner, shortcuts dialog headings
- [ ] `SessionsBoard` unit tests pass