### PR TITLE
fix: hide fake agent harness from selectable lists

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -6,11 +6,15 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
-// Every deriver key must be a known harness name: SupportsHarness equates the
-// two, so a token that drifts from its harness constant would silently report
-// the harness as hook-less.
+// Every deriver key must be a known harness name except fake, whose deriver is
+// retained for test fixtures and historical callbacks even though the harness is
+// no longer user-selectable. SupportsHarness equates tokens and harnesses, so any
+// other drift would silently report a hooked harness as hook-less.
 func TestDeriverTokensAreKnownHarnesses(t *testing.T) {
 	for token := range Derivers {
+		if token == string(domain.HarnessFake) {
+			continue
+		}
 		if !domain.AgentHarness(token).IsKnown() {
 			t.Errorf("deriver token %q is not a known AgentHarness", token)
 		}

--- a/backend/internal/adapters/agent/fake/fake_test.go
+++ b/backend/internal/adapters/agent/fake/fake_test.go
@@ -22,8 +22,8 @@ func TestManifestReportsFakeHarness(t *testing.T) {
 	if domain.AgentHarness(m.ID) != domain.HarnessFake {
 		t.Fatalf("manifest id %q does not match domain.HarnessFake %q", m.ID, domain.HarnessFake)
 	}
-	if !domain.HarnessFake.IsKnown() {
-		t.Fatal("domain.HarnessFake is not registered as a known harness")
+	if domain.HarnessFake.IsKnown() {
+		t.Fatal("domain.HarnessFake must not be registered as a user-selectable harness")
 	}
 	found := false
 	for _, c := range m.Capabilities {

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/devin"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/fake"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/goose"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/grok"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kilocode"
@@ -64,7 +63,6 @@ func Constructors() []adapters.Adapter {
 		vibe.New(),
 		pi.New(),
 		autohand.New(),
-		fake.New(),
 	}
 }
 

--- a/backend/internal/adapters/agent/registry/registry_test.go
+++ b/backend/internal/adapters/agent/registry/registry_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -71,6 +72,14 @@ func TestEveryHarnessReportsAuthStatus(t *testing.T) {
 		}
 		if _, ok := ha.Agent.(ports.AgentAuthChecker); !ok {
 			t.Errorf("%s does not implement ports.AgentAuthChecker", ha.Harness)
+		}
+	}
+}
+
+func TestHarnessedExcludesFakeHarness(t *testing.T) {
+	for _, ha := range Harnessed() {
+		if ha.Harness == domain.HarnessFake {
+			t.Fatal("fake harness must not be returned as a shipped selectable agent")
 		}
 	}
 }

--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -167,7 +167,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 		return pflag.NormalizedName(name)
 	})
 	f.StringVar(&opts.project, "project", "", "Project id to spawn the session in (default: AO_PROJECT_ID, current registered repo, or Scratch when it is the only project)")
-	f.StringVar(&opts.harness, "harness", "", "Agent harness / --agent: claude-code, codex, aider, opencode, grok, droid, amp, agy, crush, cursor, qwen, copilot, goose, auggie, continue, devin, cline, kimi, kiro, kilocode, vibe, pi, autohand, fake (default: project worker.agent; orchestrator spawns default to project orchestrator.agent; required if the project has none)")
+	f.StringVar(&opts.harness, "harness", "", "Agent harness / --agent: claude-code, codex, aider, opencode, grok, droid, amp, agy, crush, cursor, qwen, copilot, goose, auggie, continue, devin, cline, kimi, kiro, kilocode, vibe, pi, autohand (default: project worker.agent; orchestrator spawns default to project orchestrator.agent; required if the project has none)")
 	f.StringVar(&opts.kind, "kind", "", "Session role: worker or orchestrator (default: worker)")
 	f.StringVar(&opts.branch, "branch", "", "Branch for git project sessions (default: ao/<session-id>/root; unsupported for Scratch)")
 	f.StringVar(&opts.prompt, "prompt", "", "Initial prompt for the agent")

--- a/backend/internal/domain/harness.go
+++ b/backend/internal/domain/harness.go
@@ -28,8 +28,8 @@ const (
 	HarnessVibe       AgentHarness = "vibe"
 	HarnessPi         AgentHarness = "pi"
 	HarnessAutohand   AgentHarness = "autohand"
-	// HarnessFake is a deterministic, LLM-free harness used by e2e tests to
-	// drive the session lifecycle on a scripted timeline (no network, no tokens).
+	// HarnessFake is retained for existing test fixtures and historical session
+	// rows, but is not user-selectable.
 	HarnessFake AgentHarness = "fake"
 )
 
@@ -40,7 +40,7 @@ var AllHarnesses = []AgentHarness{
 	HarnessDroid, HarnessAmp, HarnessAgy, HarnessCrush, HarnessCursor, HarnessQwen,
 	HarnessCopilot, HarnessGoose, HarnessAuggie, HarnessContinue, HarnessDevin,
 	HarnessCline, HarnessKimi, HarnessKiro, HarnessKilocode, HarnessVibe, HarnessPi,
-	HarnessAutohand, HarnessFake,
+	HarnessAutohand,
 }
 
 // IsKnown reports whether h is one of the supported harnesses.

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -4191,7 +4191,6 @@ components:
           - vibe
           - pi
           - autohand
-          - fake
           type: string
         issueId:
           type: string

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -155,7 +155,7 @@ type SpawnSessionRequest struct {
 	ProjectID domain.ProjectID    `json:"projectId"`
 	IssueID   domain.IssueID      `json:"issueId,omitempty"`
 	Kind      domain.SessionKind  `json:"kind,omitempty" enum:"worker,orchestrator"`
-	Harness   domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand,fake"`
+	Harness   domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand"`
 	Branch    string              `json:"branch,omitempty"`
 	Prompt    string              `json:"prompt,omitempty" maxLength:"4096"`
 	// DisplayName is the sidebar label for the session, capped at 20 characters.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1492,7 +1492,7 @@ export interface components {
             branch?: string;
             displayName?: string;
             /** @enum {string} */
-            harness?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand" | "fake";
+            harness?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand";
             issueId?: string;
             /** @enum {string} */
             kind?: "worker" | "orchestrator";

--- a/frontend/src/renderer/components/NewTaskDialog.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.tsx
@@ -10,12 +10,12 @@ import { RequiredAgentField } from "./CreateProjectAgentSheet";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { captureRendererEvent } from "../lib/telemetry";
-import type { AgentProvider } from "../types/workspace";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { useImageAttachments } from "../hooks/useImageAttachments";
 import { cn } from "../lib/utils";
 
 type Project = components["schemas"]["Project"];
+type SpawnHarness = components["schemas"]["SpawnSessionRequest"]["harness"];
 
 type NewTaskDialogProps = {
 	open: boolean;
@@ -112,7 +112,7 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 			const body: components["schemas"]["SpawnSessionRequest"] = {
 				projectId,
 				kind: "worker",
-				harness: agentTouched && agent ? (agent as AgentProvider) : undefined,
+				harness: agentTouched && agent ? (agent as SpawnHarness) : undefined,
 				issueId: cleanTitle,
 				prompt: cleanPrompt,
 			};

--- a/frontend/src/renderer/lib/agent-options.ts
+++ b/frontend/src/renderer/lib/agent-options.ts
@@ -22,5 +22,4 @@ export const AGENT_OPTIONS = [
 	"vibe",
 	"pi",
 	"autohand",
-	"fake",
 ] as const;


### PR DESCRIPTION
## Summary
- remove the fake harness from shipped/selectable agent inventory
- remove fake from spawn help, API enum, generated frontend schema, and frontend fallback agent options
- keep the fake harness constant/package for historical rows and direct test fixtures
- add a registry regression test that prevents fake from appearing as a selectable shipped agent

## Tests
- go test ./internal/adapters/agent/registry ./internal/domain ./internal/service/agent ./internal/httpd/apispec/... ./internal/httpd/controllers
- go test ./internal/cli -run 'TestSpawnCommand_(RequiresName|RejectsOverlongName|RejectsInvalidKind|ScratchRejectsGitOnlyFlags|RejectsUnsupportedAgentWithoutProbing)'\n- npx openapi-typescript@7.4.4 backend/internal/httpd/apispec/openapi.yaml -o frontend/src/api/schema.ts\n\n## Notes\n- npm run frontend:typecheck could not run in this worktree because tsc is not installed.\n- Full go test ./internal/cli still has unrelated environment-sensitive failures around hook LaunchID/browser error expectations.