### PR TITLE
fix: disable text selection on marketing pages

### DIFF
--- a/frontend/src/landing/src/app/globals.css
+++ b/frontend/src/landing/src/app/globals.css
@@ -7,6 +7,20 @@
 
 @source "../../packages/ui/src/**/*.{ts,tsx}";
 
+/* Match the desktop app: marketing chrome is not selectable. */
+body {
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+input,
+textarea,
+[contenteditable="true"],
+.prose {
+	-webkit-user-select: text;
+	user-select: text;
+}
+
 /*
  * Blog code blocks - force dark theme
  * Note: !important is required to override Shiki's inline styles


### PR DESCRIPTION
## Summary
- Set `user-select: none` on the landing page `body` to match the desktop app
- Keep selection enabled for inputs and `.prose` (docs/blog copy)

## Test plan
- [ ] Open the homepage and try selecting header, hero, and feature copy — selection should not appear
- [ ] Confirm feature demos / app mockups are not selectable
- [ ] Confirm waitlist/download form inputs are still selectable
- [ ] Confirm docs/blog body text and code blocks remain selectable

## Before
<img width="1103" height="661" alt="image" src="https://github.com/user-attachments/assets/db8168e6-598c-4955-a4d8-e6ca1e2a859d" />
