### PR TITLE
fix(release): bake Untrivial-ai as update feed owner and guard against drift

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -78,7 +78,31 @@ jobs:
           node -e "const v=process.env.BUILD_VERSION.split('+')[0]; const fs=require('fs'); const p=require('./package.json'); p.version=v; fs.writeFileSync('./package.json', JSON.stringify(p,null,'\t')+'\n');"
       - name: Build (unsigned, no publish)
         shell: bash
+        env:
+          # Bake the update feed's owner/repo from the repo this build runs in.
+          # Without this, forge.config.ts falls back to DEFAULT_RELEASE_REPO,
+          # which went stale across the AgentWrapper -> Untrivial-ai transfer and
+          # left every published build pointing its updater at the old owner,
+          # alive only through GitHub's rename redirect (#3523).
+          AO_RELEASE_REPO: ${{ github.repository }}
         run: npm run make
+      - name: Verify baked update feed repo
+        # app-update.yml is what electron-updater reads at runtime to build the
+        # feed URL; forge's prePackage hook writes it to the working dir and
+        # ships it via extraResource. If the baked owner/repo ever diverges from
+        # the repo publishing the release (org rename, fork misconfig), fail the
+        # build here instead of stranding installed clients on a redirect
+        # GitHub may some day stop honoring (#3523).
+        shell: bash
+        run: |
+          set -euo pipefail
+          owner="$(sed -n 's/^owner:[[:space:]]*//p' app-update.yml)"
+          repo="$(sed -n 's/^repo:[[:space:]]*//p' app-update.yml)"
+          echo "baked feed: $owner/$repo (expected $GITHUB_REPOSITORY)"
+          if [ "$owner/$repo" != "$GITHUB_REPOSITORY" ]; then
+            echo "::error::app-update.yml bakes $owner/$repo but this build publishes from $GITHUB_REPOSITORY" >&2
+            exit 1
+          fi
       - name: Collect artifact and compute digest
         shell: bash
         env:

--- a/.github/workflows/mac-update-e2e.yml
+++ b/.github/workflows/mac-update-e2e.yml
@@ -164,6 +164,26 @@ jobs:
         if: always()
         run: frontend/scripts/verify-mac-artifact.sh "/Applications/Agent Orchestrator.app"
 
+      - name: Verify the updated app's baked update feed
+        # The update above already proved the REAL published feed resolves (the
+        # app follows GitHub's actual redirect chain to fetch the manifest and
+        # asset). This step closes the remaining gap from #3523: the freshly
+        # installed version N must bake an app-update.yml whose owner/repo is
+        # the repo the release was published from. A stale baked owner (as after
+        # the AgentWrapper -> Untrivial-ai transfer) keeps working only through
+        # GitHub's rename redirect, so nothing else fails until that redirect
+        # dies — this assertion turns the drift into a red run instead.
+        run: |
+          set -euo pipefail
+          yml="/Applications/Agent Orchestrator.app/Contents/Resources/app-update.yml"
+          owner="$(sed -n 's/^owner:[[:space:]]*//p' "$yml")"
+          repo="$(sed -n 's/^repo:[[:space:]]*//p' "$yml")"
+          echo "updated app bakes feed: $owner/$repo (expected $GITHUB_REPOSITORY)"
+          if [ "$owner/$repo" != "$GITHUB_REPOSITORY" ]; then
+            echo "::error::updated app bakes $owner/$repo but releases publish from $GITHUB_REPOSITORY" >&2
+            exit 1
+          fi
+
       - name: Report runner cost
         if: always()
         env:

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -5,9 +5,13 @@ import MakerDMG, { sealDmg, verifyDmg } from "./makers/maker-dmg";
 import MakerAppImage from "./makers/maker-appimage";
 import { writeFileSync } from "node:fs";
 
-// Default GitHub release target (production). aoagents was the temporary rewrite
-// home; releases land on AgentWrapper (spec §1.1).
-const DEFAULT_RELEASE_REPO = "AgentWrapper/agent-orchestrator";
+// Default GitHub release target (production). Releases land on Untrivial-ai
+// (the org the repo was transferred to in July 2026; AgentWrapper and aoagents
+// are prior homes). Builds cut by CI must NOT rely on this fallback: the
+// workflows set AO_RELEASE_REPO to the repo they run in, and build-artifacts.yml
+// asserts the baked app-update.yml matches it, so a future org/repo rename
+// fails the build instead of stranding the fleet on a redirect (#3523).
+const DEFAULT_RELEASE_REPO = "Untrivial-ai/agent-orchestrator";
 
 // The packaged binary name (no extension). Single source of truth: the packager
 // names the exe/ELF from this, and the NSIS + deb makers must point their
@@ -183,8 +187,9 @@ const config: ForgeConfig = {
 			// fork without a source edit. AO_RELEASE_REPO is "owner/repo"; it defaults
 			// to the production target. The dev/test loop sets
 			// AO_RELEASE_REPO=harshitsinghbhandari/agent-orchestrator (spec §1.1, §8).
-			// Note: aoagents/agent-orchestrator was the temporary rewrite home and is
-			// intentionally NOT the default; releases land on AgentWrapper.
+			// Note: aoagents/agent-orchestrator and AgentWrapper/agent-orchestrator
+			// are prior homes and intentionally NOT the default; releases land on
+			// Untrivial-ai.
 			config: {
 				repository: parseReleaseRepo(process.env.AO_RELEASE_REPO),
 				prerelease: process.env.AO_RELEASE_PRERELEASE === "true",

--- a/frontend/src/main/feature-builds.ts
+++ b/frontend/src/main/feature-builds.ts
@@ -7,12 +7,12 @@ const GITHUB_API = "https://api.github.com";
 
 // Default when the baked app-update.yml cannot be read (dev, or a malformed
 // bundle). Matches forge.config.ts DEFAULT_RELEASE_REPO.
-const DEFAULT_REPO = { owner: "AgentWrapper", repo: "agent-orchestrator" } as const;
+const DEFAULT_REPO = { owner: "Untrivial-ai", repo: "agent-orchestrator" } as const;
 
 // Resolve the GitHub repo the app updates from by reading the same bundled
 // app-update.yml that electron-updater uses. Both are baked from AO_RELEASE_REPO
 // at build time, so this keeps the feature list and the updater on the SAME repo
-// (a fork build lists that fork's feature releases, not AgentWrapper's). The
+// (a fork build lists that fork's feature releases, not Untrivial-ai's). The
 // list and the updater must never diverge, or the picker would offer builds
 // the updater cannot install.
 let cachedRepo: { owner: string; repo: string } | undefined;


### PR DESCRIPTION
## Summary

Fixes the latent owner-baking fragility from #3523: every published build bakes `owner: AgentWrapper` into `app-update.yml` because the dispatched `build-artifacts.yml` build never sets `AO_RELEASE_REPO`, so `forge.config.ts` falls back to the stale `DEFAULT_RELEASE_REPO`. Installed clients currently update only via GitHub's rename redirect — a single point of failure that dies permanently if the still-existing `AgentWrapper` user account ever creates a repo named `agent-orchestrator`.

**Stage 1 finding (see #3523 discussion):** the reported `net::ERR_FAILED` is NOT caused by the redirect chain. Reproduced with (a) a harness on the exact installed versions (Electron 33.4.11 + electron-updater 6.8.9) and (b) the actual installed AgentWrapper-baked binary under an isolated `HOME`: both check AND download successfully through the 301→302 chain. The error is instance-specific (wedged Chromium network stack in a long-running process; separate hardening ticket). No mass reinstall is needed — the fleet self-heals via a normal nightly once this and the ao-releases PR land.

## Changes

- `frontend/forge.config.ts`: `DEFAULT_RELEASE_REPO` → `Untrivial-ai/agent-orchestrator`
- `.github/workflows/build-artifacts.yml`: set `AO_RELEASE_REPO: ${{ github.repository }}` on the make step (root fix — this is the build the release conductor dispatches), and assert the baked `app-update.yml` owner/repo matches `github.repository` so a future org/repo rename fails the build, not the fleet
- `frontend/src/main/feature-builds.ts`: `DEFAULT_REPO` fallback → `Untrivial-ai`
- `.github/workflows/mac-update-e2e.yml`: after the real-feed update completes (which already exercises GitHub's actual redirect chain), assert the freshly installed app bakes an owner/repo matching the publishing repo

## Companion PR

Untrivial-ai/ao-releases#25 — repoints the release conductor's hardcoded `AgentWrapper/agent-orchestrator` references to `Untrivial-ai`.

## Tests

- `vitest run src/main/feature-builds.test.ts src/main/auto-updater.test.ts` — 61/61 pass (Node 20)
- `tsc --noEmit` — clean
- Verified live: a fresh electron-updater client against the `Untrivial-ai` feed resolves `nightly-mac.yml` in a single 302 (no 301 hop) and downloads the asset

## Risks / follow-ups

- Draft until the maintainer confirms keeping releases on `Untrivial-ai/agent-orchestrator` (vs a dedicated releases repo, which would require a dual-publish bridge — old clients' baked URLs redirect owner only, not repo name)
- After merge: cut a nightly and verify the bundle's `app-update.yml` reads `owner: Untrivial-ai` (the new build-artifacts assertion now enforces this)

Refs #3523

🤖 Generated with [Claude Code](https://claude.com/claude-code)
