### PR TITLE
fix(desktop): enable Grok terminal wheel scrolling

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -233,12 +233,13 @@ describe("terminal restore", () => {
 });
 
 describe("providerScrollsByKeyboard", () => {
-	// opencode and its fork kilocode share a TUI that scrolls its own transcript
-	// by keyboard and ignores SGR wheel reports, so both must opt into the
+	// opencode, its fork kilocode, and grok use TUIs that scroll their own transcripts
+	// by keyboard and ignore SGR wheel reports, so all must opt into the
 	// PageUp/PageDown wheel routing (see XtermTerminal's paneScrollsByKeyboard).
-	it("is true for keyboard-scroll TUIs (opencode and its kilocode fork)", () => {
+	it("is true for keyboard-scroll TUIs", () => {
 		expect(providerScrollsByKeyboard("opencode")).toBe(true);
 		expect(providerScrollsByKeyboard("kilocode")).toBe(true);
+		expect(providerScrollsByKeyboard("grok")).toBe(true);
 	});
 
 	it("is false for mouse-report/native-scroll providers", () => {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -207,9 +207,9 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 // Agents whose full-screen TUI keeps its own transcript and scrolls it only by
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
 // PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard).
-// kilocode is a fork of opencode and shares its TUI surface, so it scrolls the
-// same way.
-const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode"]);
+// kilocode is a fork of opencode and shares its TUI surface; grok also uses a
+// full-screen keyboard-scroll TUI, so both scroll the same way.
+const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.
 export function providerScrollsByKeyboard(provider?: string): boolean {


### PR DESCRIPTION
## Summary
- classify Grok as a fullscreen keyboard-scroll TUI
- route Grok wheel and trackpad input through the existing PageUp/PageDown path
- cover Grok in the focused provider regression test

## Tests
- npm test -- TerminalPane.test.tsx
- npm run typecheck
- npm test

Fixes #3455