### PR TITLE
fix: deliver Grok prompts after TUI startup

### DIFF
--- a/backend/internal/adapters/agent/grok/grok.go
+++ b/backend/internal/adapters/agent/grok/grok.go
@@ -5,10 +5,13 @@
 // hooks into .claude/settings.local.json with Grok-specific AO hook commands.
 // Grok will pick them up via its compat layer.
 //
-// Launch uses a positional prompt for the initial task (in-command delivery).
+// Launch starts Grok's interactive TUI without a prompt. AO delivers the
+// initial task through the terminal after the TUI is ready because Grok's
+// `-p`/`--single` mode is headless and bare positional arguments are parsed as
+// subcommands.
 // AO's standing instructions are appended with `--rules` so Grok's built-in
 // coding-agent system prompt is preserved. Permission handling uses
-// `--permission-mode`. We also pass `--no-auto-update` for headless/scripted use
+// `--permission-mode`. We also pass `--no-auto-update` for AO-managed sessions
 // (parity with Codex no-update).
 // Restore prefers the hook-captured native session id via `-r <id>`.
 //
@@ -22,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
@@ -105,8 +109,10 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
-// GetLaunchCommand builds `grok --no-auto-update [--permission-mode <mode>] [-- prompt]`.
-// Prompt is delivered positionally so Grok starts an interactive coding session.
+// GetLaunchCommand builds `grok --no-auto-update [--permission-mode <mode>]`
+// and leaves the prompt for AO's after-start terminal delivery. Grok's
+// `-p`/`--single` flag runs one headless turn and exits, while a bare prompt is
+// parsed as a subcommand by current Grok versions.
 //
 // Uses --permission-mode (acceptEdits / auto / bypassPermissions) to match
 // `grok -h` output. Default omits the flag so Grok uses its config.
@@ -127,11 +133,32 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		cmd = append(cmd, "--rules", systemPrompt)
 	}
 
-	if cfg.Prompt != "" {
-		cmd = append(cmd, "--", cfg.Prompt)
-	}
-
 	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that AO should inject prompted Grok tasks
+// into the interactive terminal after startup.
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, _ ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryAfterStart, nil
+}
+
+// PromptReadinessHints waits for Grok's interactive UI before AO injects the
+// worker's first task. Timeout falls back to delivery so a changed startup
+// banner cannot permanently block spawning.
+func (p *Plugin) PromptReadinessHints(ctx context.Context, _ ports.LaunchConfig) (ports.PromptReadinessHints, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.PromptReadinessHints{}, err
+	}
+	return ports.PromptReadinessHints{
+		InitialDelay: 750 * time.Millisecond,
+		Patterns:     []string{"Grok Build"},
+		PollInterval: 200 * time.Millisecond,
+		Timeout:      8 * time.Second,
+		Lines:        80,
+	}, nil
 }
 
 // GetAgentHooks installs Claude Code-shaped hooks because Grok Build has a

--- a/backend/internal/adapters/agent/grok/grok_test.go
+++ b/backend/internal/adapters/agent/grok/grok_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hooksjson"
@@ -48,8 +49,21 @@ func TestGetPromptDeliveryStrategy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if s != ports.PromptDeliveryInCommand {
-		t.Fatalf("strategy = %q, want in_command", s)
+	if s != ports.PromptDeliveryAfterStart {
+		t.Fatalf("strategy = %q, want after_start", s)
+	}
+}
+
+func TestPromptReadinessHints(t *testing.T) {
+	hints, err := (&Plugin{}).PromptReadinessHints(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if hints.InitialDelay != 750*time.Millisecond || hints.PollInterval != 200*time.Millisecond || hints.Timeout != 8*time.Second || hints.Lines != 80 {
+		t.Fatalf("hints = %#v", hints)
+	}
+	if !reflect.DeepEqual(hints.Patterns, []string{"Grok Build"}) {
+		t.Fatalf("patterns = %#v, want Grok Build", hints.Patterns)
 	}
 }
 
@@ -63,7 +77,7 @@ func TestGetLaunchCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	wantPrefix := []string{"grok", "--no-auto-update", "--permission-mode", "bypassPermissions", "--rules", "ao standing instructions", "--", "do the thing"}
+	wantPrefix := []string{"grok", "--no-auto-update", "--permission-mode", "bypassPermissions", "--rules", "ao standing instructions"}
 	if !reflect.DeepEqual(cmd, wantPrefix) {
 		t.Fatalf("cmd = %#v, want prefix %#v", cmd, wantPrefix)
 	}
@@ -81,7 +95,7 @@ func TestGetLaunchCommandDefaultPerms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := []string{"grok", "--no-auto-update", "--", "fix it"}
+	want := []string{"grok", "--no-auto-update"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
@@ -100,7 +114,7 @@ func TestGetLaunchCommandAcceptEdits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := []string{"grok", "--no-auto-update", "--permission-mode", "acceptEdits", "--", "refactor auth"}
+	want := []string{"grok", "--no-auto-update", "--permission-mode", "acceptEdits"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
@@ -116,14 +130,14 @@ func TestGetLaunchCommandAuto(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := []string{"grok", "--no-auto-update", "--permission-mode", "auto", "--", "ship it"}
+	want := []string{"grok", "--no-auto-update", "--permission-mode", "auto"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
 	assertNoPromptFlag(t, cmd)
 }
 
-func TestGetLaunchCommandTerminatesFlagsBeforeLeadingDashPrompt(t *testing.T) {
+func TestGetLaunchCommandDoesNotPassLeadingDashPromptAsSubcommand(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "grok"}
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		Prompt: "-add a health check",
@@ -131,7 +145,7 @@ func TestGetLaunchCommandTerminatesFlagsBeforeLeadingDashPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := []string{"grok", "--no-auto-update", "--", "-add a health check"}
+	want := []string{"grok", "--no-auto-update"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
@@ -161,7 +175,7 @@ func TestGetLaunchCommandSystemPromptFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := []string{"grok", "--no-auto-update", "--rules", "file standing instructions", "--", "fix it"}
+	want := []string{"grok", "--no-auto-update", "--rules", "file standing instructions"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION
## Summary

- start Grok without passing the task as a positional subcommand
- deliver the initial task through the interactive TUI after its Grok Build readiness marker appears
- preserve permission-mode mapping, appended AO rules, Grok hook wiring, and native session restore arguments
- update adapter tests to lock the current Grok CLI invocation shape

Closes #3532

## Investigation

The installed Grok Build 0.2.22 CLI uses the root grammar grok [OPTIONS] [COMMAND]. Bare prompt text is therefore parsed as an unknown subcommand. The -p/--single flag is supported, but it runs headlessly for one turn and exits, which is not a usable AO interactive worker lifecycle.

The adapter originally used -p. PR #2518 switched to a positional prompt to retain the TUI, but that positional form is incompatible with the current CLI. The supported interactive path is to launch the TUI without a task and submit the task through the terminal after startup, matching AO interactive adapters such as Kimi.

## Tests

- cd backend && go build ./...
- cd backend && go test ./internal/adapters/agent/grok
- cd backend && go test ./internal/adapters/agent/...
- cd backend && go vet ./internal/adapters/agent/grok
- cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs
- live Grok 0.2.22 PTY probe: launched the same promptless TUI argv, submitted a test task through the terminal, received AO_GROK_PROMPT_OK, and observed session-start/user-prompt-submit/stop hooks

npm run lint reaches one unrelated existing backend test failure: internal/service/session.TestWorkspaceFilesIncludeWorkspaceProjectChildRepoDiffs receives compare ref main where the test expects empty. Running inside the live AO worker environment also requires removing AO runtime variables to keep CLI tests isolated.

## Risks

- The readiness marker depends on the Grok Build footer text. AO has an 8-second timeout and falls back to prompt delivery if the banner changes.
- Restore remains unchanged and continues to use the hook-captured native session ID.