### PR TITLE
fix(browser): stop re-asserting preview URL on session switch-back

### DIFF
--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useBrowserView, type BrowserNavState } from "./useBrowserView";
+import { resetConsumedPreviewTriggersForTest, useBrowserView, type BrowserNavState } from "./useBrowserView";
 
 type Listener = (state: BrowserNavState) => void;
 type TabsListener = (state: import("../../main/browser-view-host").BrowserTabsState) => void;
@@ -116,6 +116,7 @@ describe("useBrowserView", () => {
 		vi.restoreAllMocks();
 		setFullscreenElement(null);
 		document.body.replaceChildren();
+		resetConsumedPreviewTriggersForTest();
 	});
 
 	it("ensures a scoped browser view and reports the measured slot bounds", async () => {
@@ -781,6 +782,144 @@ describe("useBrowserView", () => {
 			expect(bridge.navigate).toHaveBeenCalledWith({ viewId: "42:sess-1", url: "file:///tmp/preview/index.html" }),
 		);
 		expect(bridge.navigate).toHaveBeenCalledTimes(3);
+	});
+
+	it("keeps the user's manual navigation on session switch-back and only re-navigates on a new preview", async () => {
+		// Regression for #3536: the native view survives a session switch in the
+		// main process with the user's last URL (e.g. google.com), but the preview
+		// effect used to re-fire on remount and navigate it back to previewUrl.
+		const bridge = setupBridge();
+		const { result, rerender } = renderHook(
+			({ sessionId, previewUrl, previewRevision }) =>
+				useBrowserView({ sessionId, active: true, poppedOut: false, previewUrl, previewRevision }),
+			{
+				initialProps: {
+					sessionId: "sess-1",
+					previewUrl: "http://localhost:5217/" as string | undefined,
+					previewRevision: 1 as number | undefined,
+				},
+			},
+		);
+		await waitFor(() =>
+			expect(bridge.navigate).toHaveBeenCalledWith({ viewId: "42:sess-1", url: "http://localhost:5217/" }),
+		);
+		expect(bridge.navigate).toHaveBeenCalledTimes(1);
+
+		// The user browses elsewhere; the main-process view now holds google.com.
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "https://www.google.com/",
+				title: "Google",
+				canGoBack: true,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+
+		// Switch to another session, then back.
+		rerender({ sessionId: "sess-2", previewUrl: undefined, previewRevision: undefined });
+		await waitFor(() => expect(result.current.viewId).toBe("42:sess-2"));
+		rerender({ sessionId: "sess-1", previewUrl: "http://localhost:5217/", previewRevision: 1 });
+		await waitFor(() => expect(result.current.viewId).toBe("42:sess-1"));
+
+		// The already-consumed preview must not be re-asserted: the view keeps
+		// whatever the user navigated to.
+		expect(bridge.navigate).toHaveBeenCalledTimes(1);
+		expect(bridge.clear).not.toHaveBeenCalled();
+
+		// A genuine new `ao preview` (revision bump) still takes over.
+		rerender({ sessionId: "sess-1", previewUrl: "http://localhost:5217/", previewRevision: 2 });
+		await waitFor(() => expect(bridge.navigate).toHaveBeenCalledTimes(2));
+		expect(bridge.navigate).toHaveBeenLastCalledWith({ viewId: "42:sess-1", url: "http://localhost:5217/" });
+	});
+
+	it("does not re-navigate to the preview when the hook fully remounts for the same session", async () => {
+		// SessionView may unmount entirely on a session switch; the consumed
+		// trigger must outlive the hook instance, not just a prop change.
+		const bridge = setupBridge();
+		const first = renderHook(() =>
+			useBrowserView({
+				sessionId: "sess-1",
+				active: true,
+				poppedOut: false,
+				previewUrl: "http://localhost:5217/",
+				previewRevision: 1,
+			}),
+		);
+		await waitFor(() => expect(bridge.navigate).toHaveBeenCalledTimes(1));
+		first.unmount();
+
+		const second = renderHook(() =>
+			useBrowserView({
+				sessionId: "sess-1",
+				active: true,
+				poppedOut: false,
+				previewUrl: "http://localhost:5217/",
+				previewRevision: 1,
+			}),
+		);
+		await waitFor(() => expect(second.result.current.viewId).toBe("42:sess-1"));
+		expect(bridge.navigate).toHaveBeenCalledTimes(1);
+		second.unmount();
+	});
+
+	it("re-applies the preview after termination frees the consumed trigger for a reused session ID", async () => {
+		const bridge = setupBridge();
+		const first = renderHook(
+			({ terminated }) =>
+				useBrowserView({
+					sessionId: "sess-1",
+					active: true,
+					poppedOut: false,
+					terminated,
+					previewUrl: "http://localhost:5217/",
+					previewRevision: 1,
+				}),
+			{ initialProps: { terminated: false } },
+		);
+		await waitFor(() => expect(bridge.navigate).toHaveBeenCalledTimes(1));
+		first.rerender({ terminated: true });
+		await waitFor(() => expect(bridge.destroy).toHaveBeenCalledWith("42:sess-1"));
+		first.unmount();
+
+		// A fresh worker reusing the session ID gets its own preview navigation.
+		const second = renderHook(() =>
+			useBrowserView({
+				sessionId: "sess-1",
+				active: true,
+				poppedOut: false,
+				previewUrl: "http://localhost:5217/",
+				previewRevision: 1,
+			}),
+		);
+		await waitFor(() => expect(bridge.navigate).toHaveBeenCalledTimes(2));
+		second.unmount();
+	});
+
+	it("re-applies the preview on remount without a native browser, whose view state does not survive", async () => {
+		// In web/mock mode navState is component-local, so remounting with an
+		// already-consumed trigger must still restore the static preview.
+		const original = window.ao;
+		window.ao = undefined;
+		try {
+			const props = {
+				sessionId: "sess-1",
+				active: true,
+				poppedOut: false,
+				previewUrl: "http://localhost:5217/",
+				previewRevision: 1,
+			};
+			const first = renderHook(() => useBrowserView(props));
+			await waitFor(() => expect(first.result.current.navState.url).toBe("http://localhost:5217/"));
+			first.unmount();
+
+			const second = renderHook(() => useBrowserView(props));
+			await waitFor(() => expect(second.result.current.navState.url).toBe("http://localhost:5217/"));
+			second.unmount();
+		} finally {
+			window.ao = original;
+		}
 	});
 
 	it("navigates each worker to its own target when sessions share a revision number", async () => {

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -80,6 +80,19 @@ const EMPTY_TABS_STATE: BrowserTabsState = {
 	tabs: [],
 };
 
+type PreviewTrigger = { revision: number | null; target: string };
+
+// Last preview trigger consumed per session, outliving the hook instance. The
+// native view survives session switches in the main process — with whatever URL
+// the user last navigated to — so the consumed trigger must survive too:
+// keeping it only in a component ref made every remount (session switch-back)
+// re-assert previewUrl and clobber manual navigation (#3536).
+const consumedPreviewTriggers = new Map<string, PreviewTrigger>();
+
+export function resetConsumedPreviewTriggersForTest(): void {
+	consumedPreviewTriggers.clear();
+}
+
 const HIDDEN_RECT: BrowserRect = { x: 0, y: 0, width: 0, height: 0 };
 const VISUAL_TRANSITION_DURATION_MS = 240;
 const VISUAL_TRANSITION_CAPTURE_TIMEOUT_MS = 120;
@@ -305,10 +318,15 @@ export function useBrowserView({
 
 	useEffect(() => {
 		let disposed = false;
-		// Preview revisions are scoped to a session. Reset the trigger before
-		// ensuring a different worker so equal revision numbers cannot suppress
-		// that worker's own target.
-		previewTriggerRef.current = null;
+		// Preview revisions are scoped to a session, so never carry the trigger
+		// over from a previously shown worker: equal revision numbers must not
+		// suppress this worker's own target. With a native browser, seed from the
+		// per-session consumed map instead of null — the main-process view kept
+		// the user's last URL across the switch, and re-consuming an already-seen
+		// trigger would navigate it back to previewUrl. Without a native browser
+		// the view state died with the previous mount, so re-applying the preview
+		// is what restores it.
+		previewTriggerRef.current = hasNativeBrowser ? (consumedPreviewTriggers.get(sessionId) ?? null) : null;
 		setTabsState(EMPTY_TABS_STATE);
 		setTabNotice("");
 		setAgentBrowserActive(false);
@@ -650,13 +668,15 @@ export function useBrowserView({
 		const previous = previewTriggerRef.current;
 		if (previous?.revision === revision && previous.target === target) return;
 		if (revision !== null && previous?.revision === revision) return;
-		previewTriggerRef.current = { revision, target };
+		const consumed: PreviewTrigger = { revision, target };
+		previewTriggerRef.current = consumed;
+		if (hasNativeBrowser) consumedPreviewTriggers.set(sessionId, consumed);
 		if (target) {
 			void navigate(target);
 		} else if ((revision !== null && revision > 0) || previous?.target) {
 			void clear();
 		}
-	}, [clear, navigate, previewRevision, previewUrl, terminated, viewId]);
+	}, [clear, hasNativeBrowser, navigate, previewRevision, previewUrl, sessionId, terminated, viewId]);
 
 	const destroy = useCallback(() => {
 		const id = viewIdRef.current;
@@ -684,8 +704,11 @@ export function useBrowserView({
 	// explicit preview-reset operation.
 	useEffect(() => {
 		if (!terminated || !viewId) return;
+		// The browser target is gone for good; if the session ID is ever reused,
+		// a stale consumed trigger must not suppress the new worker's preview.
+		consumedPreviewTriggers.delete(sessionId);
 		destroy();
-	}, [destroy, terminated, viewId]);
+	}, [destroy, sessionId, terminated, viewId]);
 
 	return {
 		viewId,


### PR DESCRIPTION
Fixes #3536.

## Problem

In a session with an active `ao preview` URL, the in-app browser panel discarded the user's manual navigation on every session switch-back: browse to google.com, switch sessions, return → the panel silently re-navigated to the preview URL.

## Root cause

The preview-navigation effect in `useBrowserView.ts` dedups `ao preview` triggers via a component-local ref (`previewTriggerRef`). On a session switch the browser view remounts with a fresh `viewId` (in the effect's dep array) and the ref resets, so the already-consumed `(revision, target)` was consumed again. Meanwhile the main process (`ensureSession`) keeps the session's native view alive across switches with the user's last URL — so the re-fired effect navigated that surviving view back to `previewUrl`.

## Fix

Persist the last consumed preview trigger per session in a module-level map that outlives the hook instance, and seed the dedup ref from it on mount when a native browser is present. Auto-navigation now fires only on a genuine revision/target change (a real new `ao preview`), never merely because the view remounted.

- A fresh `ao preview` (revision bump) still takes over the panel, including with the same URL.
- Termination still destroys the view, and drops the session's consumed trigger so a reused session ID is not suppressed.
- The non-native (web/mock) fallback keeps its old remount behavior: its view state genuinely dies with the component, so re-applying the preview is what restores it.
- Cross-session revision-collision behavior is preserved (the map is keyed by session ID).

## Tests

- New: manual navigation survives switch-away/switch-back (prop-change and full-remount variants) and a subsequent revision bump still navigates; termination frees the consumed trigger for a reused session ID; non-native remount still restores the preview.
- Full frontend suite: 110 files / 1458 tests pass; `npm run typecheck` clean.

## Manual verification (real desktop app)

Reproduced the maintainer's exact steps in the dev Electron app against an isolated daemon, driving the UI over CDP and asserting the native `WebContentsView` target URLs:

1. Session with `ao preview http://127.0.0.1:5217/` → Browser panel auto-loads it (revision 1).
2. Typed `https://www.google.com/` in the panel URL bar → native view on google.com.
3. Switched to another session and back → native view **still on google.com** (previously snapped back to `:5217`); URL bar shows google.com.
4. Re-ran `ao preview http://127.0.0.1:5217/` (revision 2) → panel navigates back to the preview.
5. Repeated navigate/switch/return after revision 2 → google.com preserved again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)