### PR TITLE
fix(terminal): Grok/Windows history scroll with PageUp/PageDown wheel

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -235,7 +235,7 @@ describe("terminal restore", () => {
 describe("providerScrollsByKeyboard", () => {
 	// opencode and its fork kilocode share a TUI that scrolls its own transcript
 	// by keyboard and ignores SGR wheel reports, so both must opt into the
-	// PageUp/PageDown wheel routing (see XtermTerminal's paneScrollsByKeyboard).
+	// keyboard wheel routing (see XtermTerminal's paneScrollsByKeyboard).
 	// Grok is the same class of full-screen agent TUI.
 	it("is true for keyboard-scroll TUIs (opencode, kilocode, grok)", () => {
 		expect(providerScrollsByKeyboard("opencode")).toBe(true);

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -236,9 +236,11 @@ describe("providerScrollsByKeyboard", () => {
 	// opencode and its fork kilocode share a TUI that scrolls its own transcript
 	// by keyboard and ignores SGR wheel reports, so both must opt into the
 	// PageUp/PageDown wheel routing (see XtermTerminal's paneScrollsByKeyboard).
-	it("is true for keyboard-scroll TUIs (opencode and its kilocode fork)", () => {
+	// Grok is the same class of full-screen agent TUI.
+	it("is true for keyboard-scroll TUIs (opencode, kilocode, grok)", () => {
 		expect(providerScrollsByKeyboard("opencode")).toBe(true);
 		expect(providerScrollsByKeyboard("kilocode")).toBe(true);
+		expect(providerScrollsByKeyboard("grok")).toBe(true);
 	});
 
 	it("is false for mouse-report/native-scroll providers", () => {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -208,8 +208,10 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
 // PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard).
 // kilocode is a fork of opencode and shares its TUI surface, so it scrolls the
-// same way.
-const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode"]);
+// same way. Grok is the same class of alt-buffer agent TUI: wheel/SGR does not
+// move its conversation history, but PageUp/PageDown does (and on Windows the
+// ConPTY path has no mux copy-mode fallback either).
+const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.
 export function providerScrollsByKeyboard(provider?: string): boolean {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -206,11 +206,12 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 
 // Agents whose full-screen TUI keeps its own transcript and scrolls it only by
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
-// proportional arrow keys for these (see XtermTerminal's paneScrollsByKeyboard).
-// kilocode is a fork of opencode and shares its TUI surface, so it scrolls the
-// same way. Grok is the same class of alt-buffer agent TUI: wheel/SGR does not
-// move its conversation history, but ↑/↓ and PageUp/PageDown do (and on Windows
-// the ConPTY path has no mux copy-mode fallback either).
+// PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard) — not
+// bare ArrowUp/ArrowDown, which Grok and similar chat TUIs bind to input-history
+// recall. kilocode is a fork of opencode and shares its TUI surface. Grok is the
+// same class of alt-buffer agent TUI: wheel/SGR does not move its conversation
+// transcript, but PageUp/PageDown do (and on Windows the ConPTY path has no mux
+// copy-mode fallback either).
 const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -206,11 +206,11 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 
 // Agents whose full-screen TUI keeps its own transcript and scrolls it only by
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
-// PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard).
+// proportional arrow keys for these (see XtermTerminal's paneScrollsByKeyboard).
 // kilocode is a fork of opencode and shares its TUI surface, so it scrolls the
 // same way. Grok is the same class of alt-buffer agent TUI: wheel/SGR does not
-// move its conversation history, but PageUp/PageDown does (and on Windows the
-// ConPTY path has no mux copy-mode fallback either).
+// move its conversation history, but ↑/↓ and PageUp/PageDown do (and on Windows
+// the ConPTY path has no mux copy-mode fallback either).
 const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -700,40 +700,44 @@ describe("XtermTerminal", () => {
 		expect(onInput).not.toHaveBeenCalled();
 	});
 
-	it("falls back to proportional arrow keys for alt-buffer panes with mouse tracking off", () => {
+	it("falls back to PageUp/PageDown for alt-buffer panes with mouse tracking off", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		state.lastTerminal!.modes.mouseTrackingMode = "none";
 		// Alt buffer: no local scrollback to move, and no keyboard-scroll hint, so
-		// one arrow key per scrolled line is the free-scroll fallback.
+		// page keys scroll the app transcript (not arrows — those recall history).
 		state.lastTerminal!.buffer.active.type = "alternate";
 
-		// rowHeight = 16.2px; -50px => 3 lines up; +20px => 1 line down.
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
+		// Must not look like input-history navigation (ArrowUp/ArrowDown).
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 	});
 
-	it("sends proportional arrow keys on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
+	it("sends PageUp/PageDown on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
 		setNavigatorPlatform("Win32");
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Full-screen agent TUIs (Grok/orchestrator session transcript) enable mouse
 		// tracking on the alternate screen. Unix can fall back to tmux copy-mode;
-		// Windows ConPTY cannot, so wheel becomes line-scroll arrow keys (not a
-		// single PageUp per notch — that felt like fixed full-screen jumps).
+		// Windows ConPTY cannot, so wheel must become page keys — not ArrowUp/
+		// ArrowDown, which Grok binds to prompt input-history recall.
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 		state.lastTerminal!.buffer.active.type = "alternate";
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 	});
 
 	it("still sends SGR on Windows for normal-buffer mouse-tracking panes", () => {
@@ -760,23 +764,28 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
 	});
 
-	it("sends proportional arrow keys for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
+	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Linux (beforeEach) + mouse tracking on: without the paneScrollsByKeyboard
-		// hint this would send SGR reports; the hint forces line-scroll arrows for
-		// agents whose TUI ignores wheel (opencode, kilocode, grok).
+		// hint this would send SGR reports; the hint forces page keys for agents
+		// whose TUI ignores wheel (opencode, kilocode, grok). Must not emit bare
+		// ArrowUp/ArrowDown — Grok treats those as input-history recall.
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 
-		// -50px => 3 ArrowUp; magnitude tracks wheel delta (free scroll).
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 
-		// Small roll moves one line; large line-mode flick moves many.
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
+
+		// Line-mode notches still map to a single page key (direction only).
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 1, deltaMode: 1 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -5, deltaMode: 1 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(5), "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 	});
 
 	it("routes web links to the AO browser and does not open the system browser", () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -700,38 +700,40 @@ describe("XtermTerminal", () => {
 		expect(onInput).not.toHaveBeenCalled();
 	});
 
-	it("falls back to PageUp/PageDown for alt-buffer panes with mouse tracking off", () => {
+	it("falls back to proportional arrow keys for alt-buffer panes with mouse tracking off", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		state.lastTerminal!.modes.mouseTrackingMode = "none";
-		// Alt buffer: no local scrollback to move, and no keyboard-scroll hint, so a
-		// page key per notch is the best fallback.
+		// Alt buffer: no local scrollback to move, and no keyboard-scroll hint, so
+		// one arrow key per scrolled line is the free-scroll fallback.
 		state.lastTerminal!.buffer.active.type = "alternate";
 
+		// rowHeight = 16.2px; -50px => 3 lines up; +20px => 1 line down.
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
 		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
 	});
 
-	it("sends PageUp/PageDown on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
+	it("sends proportional arrow keys on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
 		setNavigatorPlatform("Win32");
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Full-screen agent TUIs (Grok/orchestrator session transcript) enable mouse
 		// tracking on the alternate screen. Unix can fall back to tmux copy-mode;
-		// Windows ConPTY cannot, so wheel must become page keys.
+		// Windows ConPTY cannot, so wheel becomes line-scroll arrow keys (not a
+		// single PageUp per notch — that felt like fixed full-screen jumps).
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 		state.lastTerminal!.buffer.active.type = "alternate";
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
 		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
 	});
 
 	it("still sends SGR on Windows for normal-buffer mouse-tracking panes", () => {
@@ -758,16 +760,23 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
 	});
 
-	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
+	it("sends proportional arrow keys for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Linux (beforeEach) + mouse tracking on: without the paneScrollsByKeyboard
-		// hint this would send SGR reports; the hint forces page keys for agents
-		// whose TUI ignores wheel (opencode, kilocode, grok).
+		// hint this would send SGR reports; the hint forces line-scroll arrows for
+		// agents whose TUI ignores wheel (opencode, kilocode, grok).
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 
+		// -50px => 3 ArrowUp; magnitude tracks wheel delta (free scroll).
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
+
+		// Small roll moves one line; large line-mode flick moves many.
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: 1, deltaMode: 1 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: -5, deltaMode: 1 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(5), "wheel");
 	});
 
 	it("routes web links to the AO browser and does not open the system browser", () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -716,24 +716,54 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
 	});
 
-	it("sends SGR reports on Windows when the pane tracks the mouse (conpty delivers them to the app)", () => {
+	it("sends PageUp/PageDown on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
 		setNavigatorPlatform("Win32");
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
-		// A mouse-tracking pane gets SGR reports on every platform; on Windows conpty
-		// forwards them straight to the app. Keyboard-scroll panes (opencode) opt out
-		// via the paneScrollsByKeyboard hint, tested separately.
+		// Full-screen agent TUIs (Grok/orchestrator session transcript) enable mouse
+		// tracking on the alternate screen. Unix can fall back to tmux copy-mode;
+		// Windows ConPTY cannot, so wheel must become page keys.
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
+		state.lastTerminal!.buffer.active.type = "alternate";
+
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
+
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+	});
+
+	it("still sends SGR on Windows for normal-buffer mouse-tracking panes", () => {
+		setNavigatorPlatform("Win32");
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+		// Normal buffer + mouse tracking is uncommon; keep SGR so we do not force
+		// page keys onto a shell that expects mouse reports.
+		state.lastTerminal!.modes.mouseTrackingMode = "any";
+		state.lastTerminal!.buffer.active.type = "normal";
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
 	});
 
-	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode on macOS/Linux)", () => {
+	it("sends SGR on non-Windows when the pane tracks the mouse (tmux/mux path)", () => {
+		setNavigatorPlatform("Linux x86_64");
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+		state.lastTerminal!.modes.mouseTrackingMode = "any";
+		state.lastTerminal!.buffer.active.type = "alternate";
+
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
+	});
+
+	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Linux (beforeEach) + mouse tracking on: without the paneScrollsByKeyboard
-		// hint this would send SGR reports; the hint forces page keys.
+		// hint this would send SGR reports; the hint forces page keys for agents
+		// whose TUI ignores wheel (opencode, kilocode, grok).
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -660,10 +660,17 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				term.scrollLines(lines);
 				return false;
 			}
-			// Mouse tracking on: the pane (tmux/zellij copy-mode, or any app that
-			// tracks the mouse) acts on SGR wheel reports. On Windows conpty this
-			// reaches the app directly; under a mux it drives copy-mode.
+			// Mouse tracking on: under a mux (tmux with `mouse on`), SGR wheel
+			// reports drive copy-mode or the app. On Windows ConPTY there is no
+			// mux copy-mode safety net — synthetic SGR often no-ops for full-screen
+			// agent TUIs (orchestrator/claude/grok conversation history), while
+			// PageUp/PageDown reliably scroll their transcripts. Prefer page keys
+			// for alt-buffer panes on Windows; keep SGR elsewhere.
 			if (term.modes.mouseTrackingMode !== "none") {
+				if (isWindowsPlatform() && term.buffer.active.type === "alternate") {
+					emitUserInput(pageKeyReport(lines), "wheel");
+					return false;
+				}
 				const button = lines < 0 ? SGR_WHEEL_UP : SGR_WHEEL_DOWN;
 				emitUserInput(sgrWheelReport(button, Math.abs(lines)), "wheel");
 				return false;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -48,10 +48,10 @@ export type XtermTerminalProps = {
 	fontSize?: number;
 	theme: Theme;
 	/**
-	 * The pane app scrolls its transcript by keyboard (PageUp/PageDown) rather
-	 * than acting on SGR wheel reports — e.g. opencode, which enables mouse
-	 * tracking but never scrolls on wheel reports. Routes the wheel to page keys
-	 * on every platform (see the wheel handler), fixing it under a mux too.
+	 * The pane app scrolls its transcript by keyboard rather than acting on SGR
+	 * wheel reports — e.g. opencode, which enables mouse tracking but never
+	 * scrolls on wheel reports. Routes the wheel to proportional arrow keys
+	 * (see the wheel handler), fixing it under a mux too.
 	 */
 	paneScrollsByKeyboard?: boolean;
 	/** Terminal construction failed; the owner decides how to surface it. */
@@ -215,14 +215,18 @@ function sgrWheelReport(button: number, count: number): string {
 	return `\x1b[<${button};1;1M`.repeat(count);
 }
 
-// PageUp (CSI 5~) / PageDown (CSI 6~) for pane apps that scroll their transcript
-// by keyboard rather than mouse reports. One page key per wheel notch: a page
-// already scrolls a full screen, so scaling by line count would over-scroll.
-const PAGE_UP = "\x1b[5~";
-const PAGE_DOWN = "\x1b[6~";
+// ArrowUp (CSI A) / ArrowDown (CSI B) for pane apps that scroll their transcript
+// by keyboard rather than mouse reports. One arrow key per scrolled line so the
+// wheel feels free/proportional: small rolls move a little, large flicks move
+// farther, and the user can stop mid-history. (A single PageUp/PageDown per
+// event ignored |lines| and felt like fixed full-screen jumps.)
+const ARROW_UP = "\x1b[A";
+const ARROW_DOWN = "\x1b[B";
 
-function pageKeyReport(lines: number): string {
-	return lines < 0 ? PAGE_UP : PAGE_DOWN;
+function keyboardScrollReport(lines: number): string {
+	const count = Math.abs(lines);
+	if (count === 0) return "";
+	return (lines < 0 ? ARROW_UP : ARROW_DOWN).repeat(count);
 }
 
 function forceSelectionMode(term: Terminal): void {
@@ -645,11 +649,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			}
 			if (lines === 0) return false;
 			// A full-screen TUI that keeps its own transcript and scrolls it only by
-			// keyboard (opencode) ignores wheel/mouse reports on every platform; route
-			// its wheel to page keys. Kept first so opencode is unaffected by the
-			// buffer-aware paths below.
+			// keyboard (opencode/grok) ignores wheel/mouse reports on every platform;
+			// route its wheel to proportional arrow keys. Kept first so those agents
+			// are unaffected by the buffer-aware paths below.
 			if (callbacksRef.current.paneScrollsByKeyboard) {
-				emitUserInput(pageKeyReport(lines), "wheel");
+				emitUserInput(keyboardScrollReport(lines), "wheel");
 				return false;
 			}
 			// A normal-buffer pane with mouse tracking off (codex, a plain shell)
@@ -664,11 +668,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// reports drive copy-mode or the app. On Windows ConPTY there is no
 			// mux copy-mode safety net — synthetic SGR often no-ops for full-screen
 			// agent TUIs (orchestrator/claude/grok conversation history), while
-			// PageUp/PageDown reliably scroll their transcripts. Prefer page keys
-			// for alt-buffer panes on Windows; keep SGR elsewhere.
+			// arrow keys scroll their transcripts line-by-line. Prefer proportional
+			// keyboard scroll for alt-buffer panes on Windows; keep SGR elsewhere.
 			if (term.modes.mouseTrackingMode !== "none") {
 				if (isWindowsPlatform() && term.buffer.active.type === "alternate") {
-					emitUserInput(pageKeyReport(lines), "wheel");
+					emitUserInput(keyboardScrollReport(lines), "wheel");
 					return false;
 				}
 				const button = lines < 0 ? SGR_WHEEL_UP : SGR_WHEEL_DOWN;
@@ -676,8 +680,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				return false;
 			}
 			// Alt-buffer pane with mouse tracking off and no keyboard-scroll hint:
-			// no scrollback to move locally, so fall back to page keys.
-			emitUserInput(pageKeyReport(lines), "wheel");
+			// no scrollback to move locally, so fall back to proportional arrow keys.
+			emitUserInput(keyboardScrollReport(lines), "wheel");
 			return false;
 		});
 		const pasteInput = (event: ClipboardEvent) => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -48,10 +48,13 @@ export type XtermTerminalProps = {
 	fontSize?: number;
 	theme: Theme;
 	/**
-	 * The pane app scrolls its transcript by keyboard rather than acting on SGR
-	 * wheel reports — e.g. opencode, which enables mouse tracking but never
-	 * scrolls on wheel reports. Routes the wheel to proportional arrow keys
-	 * (see the wheel handler), fixing it under a mux too.
+	 * The pane app scrolls its transcript by keyboard (PageUp/PageDown) rather
+	 * than acting on SGR wheel reports — e.g. opencode, which enables mouse
+	 * tracking but never scrolls on wheel reports. Routes the wheel to page keys
+	 * on every platform (see the wheel handler), fixing it under a mux too.
+	 *
+	 * Do not use bare ArrowUp/ArrowDown for this path: chat TUIs (Grok and
+	 * similar) bind those keys to input-history recall, not viewport scroll.
 	 */
 	paneScrollsByKeyboard?: boolean;
 	/** Terminal construction failed; the owner decides how to surface it. */
@@ -215,18 +218,20 @@ function sgrWheelReport(button: number, count: number): string {
 	return `\x1b[<${button};1;1M`.repeat(count);
 }
 
-// ArrowUp (CSI A) / ArrowDown (CSI B) for pane apps that scroll their transcript
-// by keyboard rather than mouse reports. One arrow key per scrolled line so the
-// wheel feels free/proportional: small rolls move a little, large flicks move
-// farther, and the user can stop mid-history. (A single PageUp/PageDown per
-// event ignored |lines| and felt like fixed full-screen jumps.)
-const ARROW_UP = "\x1b[A";
-const ARROW_DOWN = "\x1b[B";
+// PageUp (CSI 5~) / PageDown (CSI 6~) for pane apps that scroll their transcript
+// by keyboard rather than mouse reports. One page key per wheel event: a page
+// already scrolls a full screen, so scaling by line count would over-scroll.
+//
+// Bare ArrowUp/ArrowDown must not be used here. Grok (and many chat CLI TUIs)
+// bind those keys to prompt input-history recall — wheel → ArrowUp re-injects
+// previously sent messages into the input box. PageUp/PageDown scroll the
+// conversation transcript without touching history.
+const PAGE_UP = "\x1b[5~";
+const PAGE_DOWN = "\x1b[6~";
 
 function keyboardScrollReport(lines: number): string {
-	const count = Math.abs(lines);
-	if (count === 0) return "";
-	return (lines < 0 ? ARROW_UP : ARROW_DOWN).repeat(count);
+	if (lines === 0) return "";
+	return lines < 0 ? PAGE_UP : PAGE_DOWN;
 }
 
 function forceSelectionMode(term: Terminal): void {
@@ -650,8 +655,9 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			if (lines === 0) return false;
 			// A full-screen TUI that keeps its own transcript and scrolls it only by
 			// keyboard (opencode/grok) ignores wheel/mouse reports on every platform;
-			// route its wheel to proportional arrow keys. Kept first so those agents
-			// are unaffected by the buffer-aware paths below.
+			// route its wheel to PageUp/PageDown (not arrows — those recall prompt
+			// history in chat TUIs). Kept first so those agents are unaffected by
+			// the buffer-aware paths below.
 			if (callbacksRef.current.paneScrollsByKeyboard) {
 				emitUserInput(keyboardScrollReport(lines), "wheel");
 				return false;
@@ -668,8 +674,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// reports drive copy-mode or the app. On Windows ConPTY there is no
 			// mux copy-mode safety net — synthetic SGR often no-ops for full-screen
 			// agent TUIs (orchestrator/claude/grok conversation history), while
-			// arrow keys scroll their transcripts line-by-line. Prefer proportional
-			// keyboard scroll for alt-buffer panes on Windows; keep SGR elsewhere.
+			// PageUp/PageDown reliably scroll their transcripts. Prefer page keys
+			// for alt-buffer panes on Windows; keep SGR elsewhere.
 			if (term.modes.mouseTrackingMode !== "none") {
 				if (isWindowsPlatform() && term.buffer.active.type === "alternate") {
 					emitUserInput(keyboardScrollReport(lines), "wheel");
@@ -680,7 +686,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				return false;
 			}
 			// Alt-buffer pane with mouse tracking off and no keyboard-scroll hint:
-			// no scrollback to move locally, so fall back to proportional arrow keys.
+			// no scrollback to move locally, so fall back to page keys (not arrows).
 			emitUserInput(keyboardScrollReport(lines), "wheel");
 			return false;
 		});


### PR DESCRIPTION
## Summary
Fixes Grok (and similar full-screen chat TUIs) history scrolling on Windows under ConPTY, with free proportional mouse-wheel scroll that does **not** hijack shell input history.

### Problem
Windows ConPTY has no tmux copy-mode fallback. Full-screen agent TUIs enable mouse tracking on the alt buffer, so wheel events were sent as SGR reports that often no-op. An intermediate attempt used ArrowUp/ArrowDown for free scroll, which made Grok recall prompt input history instead of scrolling the transcript.

### Fix (final behavior)
1. Route Windows alt-buffer / keyboard-scroll-provider wheels to **PageUp/PageDown** (not arrows).
2. Mark Grok as a keyboard-scroll provider so conversation history scrolls (alongside opencode/kilocode).
3. Free proportional mouse-wheel scroll for normal terminal content, with PageUp/PageDown for history-safe keyboard-scroll paths.

### Commits (oldest → newest)
- `fix(terminal): scroll Grok history on Windows with PageUp/PageDown`
- `fix(terminal): free proportional mouse-wheel scroll` (earlier arrows approach)
- `fix(terminal): use PageUp/PageDown for wheel, not arrows` (corrects the arrow regression)

Both intermediate and final commits are included so review can see the intentional correction; behavior of the tip is PageUp/PageDown-only for history-sensitive paths.

## User-visible impact
- Mouse wheel scrolls Grok/Windows agent history instead of no-op or prompt-history recall.
- Proportional free scroll still works where appropriate; zoom/SGR paths unchanged.

## Test plan
- [ ] Unit: `XtermTerminal.test.tsx` / `TerminalPane.test.tsx` (no frontend `node_modules` in this worktree; run CI or local frontend tests)
- [ ] Manual Windows desktop: open Grok session, wheel through history, confirm no ArrowUp prompt recall
- [ ] Manual: non-Grok shell free wheel still scrolls buffer

## Notes
- Cherry-picked onto `Untrivial-ai/main` from fork tip (excluding the fork-only merge commit).
- Topic-split PR; independent of backup/i18n/lifecycle work.