### PR TITLE
fix: notify orchestrator when worker turn completes (idle)

### DIFF
--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -122,11 +122,23 @@ type Manager struct {
 	// This coordination is intentionally memory-only: a daemon crash leaves the
 	// durable session exited, so the user can safely retry the resume.
 	pendingLaunches map[domain.SessionID]pendingLaunch
+	// pendingWorkerIdle queues worker turn-completion messages when the project's
+	// orchestrator is mid-turn and cannot safely receive a coordination write.
+	// Flushed when the orchestrator next becomes idle. Memory-only: a daemon
+	// restart drops the queue (the orchestrator can still observe worker state
+	// via the board / `ao session` and workers can still `ao send`).
+	pendingWorkerIdle map[domain.ProjectID][]pendingWorkerIdle
 	// steerActive reports whether a harness can safely receive a write during an
 	// active turn (input steers the run) rather than only while idle. Supplied by
 	// the agent adapter via WithActiveSteering; the default answers false, so an
 	// unknown harness is only written to while idle.
 	steerActive func(domain.AgentHarness) bool
+}
+
+// pendingWorkerIdle is one deferred worker-turn-completion coordination message.
+type pendingWorkerIdle struct {
+	workerID domain.SessionID
+	msg      string
 }
 
 // New builds a Lifecycle Manager over the session store it writes and the messenger it uses for agent nudges.
@@ -137,13 +149,14 @@ func New(store sessionStore, messenger ports.AgentMessenger, opts ...Option) *Ma
 	// WithClock option may still override this in tests.
 	clock := func() time.Time { return time.Now().UTC() }
 	m := &Manager{
-		store:           store,
-		window:          defaultRecentActivityWindow,
-		clock:           clock,
-		react:           newReactionState(),
-		flights:         map[domain.SessionID]*toolFlight{},
-		pendingLaunches: map[domain.SessionID]pendingLaunch{},
-		steerActive:     func(domain.AgentHarness) bool { return false },
+		store:             store,
+		window:            defaultRecentActivityWindow,
+		clock:             clock,
+		react:             newReactionState(),
+		flights:           map[domain.SessionID]*toolFlight{},
+		pendingLaunches:   map[domain.SessionID]pendingLaunch{},
+		pendingWorkerIdle: map[domain.ProjectID][]pendingWorkerIdle{},
+		steerActive:       func(domain.AgentHarness) bool { return false },
 	}
 	if messenger != nil {
 		m.guard = sessionguard.New(store, messenger, nil)
@@ -429,13 +442,48 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	// that pinged them has nothing left to resolve.
 	resolutions := needsInputResolutions(rec, next, now)
 	waitingEvents := m.waitingInputEvents(next, prevState, prevAt, now)
+	// Capture the transition facts the dispatcher needs before releasing the
+	// reducer lock: side-effect deliveries re-read the store and must not run
+	// under m.mu (they take the guard's own session read + messenger I/O).
+	workerTurnComplete := isWorkerTurnComplete(prevState, next)
+	orchBecameIdle := isOrchestratorBecameIdle(prevState, next)
 	m.mu.Unlock()
 	for _, ev := range waitingEvents {
 		m.emitTelemetry(ctx, ev)
 	}
 	m.emitNotification(ctx, intent)
 	m.resolveNotifications(ctx, resolutions...)
+	// Worker turn completion → parent orchestrator coordination message. Runs
+	// after the activity write so the board already shows idle when the
+	// orchestrator looks; failures are best-effort (logged inside).
+	if workerTurnComplete {
+		m.dispatchWorkerIdle(ctx, next)
+	}
+	// An orchestrator that just became idle may now accept messages that were
+	// deferred while it was mid-turn.
+	if orchBecameIdle {
+		m.flushPendingWorkerIdle(ctx, next)
+	}
 	return nil
+}
+
+// isWorkerTurnComplete reports a worker finishing an agent turn: active → idle.
+// waiting_input → idle is not a completion (the worker was already paused for
+// input). Other transitions never notify the orchestrator.
+func isWorkerTurnComplete(prev domain.ActivityState, next domain.SessionRecord) bool {
+	return next.Kind == domain.KindWorker &&
+		!next.IsTerminated &&
+		prev == domain.ActivityActive &&
+		next.Activity.State == domain.ActivityIdle
+}
+
+// isOrchestratorBecameIdle reports an orchestrator entering idle so deferred
+// worker-completion messages can be delivered.
+func isOrchestratorBecameIdle(prev domain.ActivityState, next domain.SessionRecord) bool {
+	return next.Kind == domain.KindOrchestrator &&
+		!next.IsTerminated &&
+		prev != domain.ActivityIdle &&
+		next.Activity.State == domain.ActivityIdle
 }
 
 // toolFlight tracks one session's in-flight tool executions and the pending

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -2043,7 +2043,7 @@ func TestSCMObservation_ReadyToMergeSuppressedWhileWaitingInput(t *testing.T) {
 	}
 }
 
-func TestActivity_WorkerIdleDoesNotNudgeOrchestrator(t *testing.T) {
+func TestActivity_WorkerIdleNudgesOrchestrator(t *testing.T) {
 	m, st, msg := newManager()
 	now := time.Now()
 	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
@@ -2055,8 +2055,14 @@ func TestActivity_WorkerIdleDoesNotNudgeOrchestrator(t *testing.T) {
 	if got := st.sessions["mer-8"].Activity.State; got != domain.ActivityIdle {
 		t.Fatalf("worker activity = %q, want idle", got)
 	}
-	if len(msg.msgs) != 0 {
-		t.Fatalf("orchestrator nudges = %d, want 0", len(msg.msgs))
+	if len(msg.msgs) != 1 {
+		t.Fatalf("orchestrator nudges = %d, want 1: %v", len(msg.msgs), msg.msgs)
+	}
+	if msg.ids[0] != "mer-orch" {
+		t.Fatalf("nudge target = %q, want mer-orch", msg.ids[0])
+	}
+	if !strings.Contains(msg.msgs[0], "mer-8") || !strings.Contains(msg.msgs[0], "husky-setup") || !strings.Contains(msg.msgs[0], "idle") {
+		t.Fatalf("worker-idle nudge missing identity: %q", msg.msgs[0])
 	}
 }
 
@@ -2108,13 +2114,40 @@ func TestActivity_WorkerIdleOrchestratorActiveDefersNoNudge(t *testing.T) {
 	m, st, msg := newManager()
 	now := time.Now()
 	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
-	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, DisplayName: "husky-setup", Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
 
 	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle}); err != nil {
 		t.Fatal(err)
 	}
 	if len(msg.msgs) != 0 {
 		t.Fatalf("nudged a busy orchestrator: %d, want 0", len(msg.msgs))
+	}
+
+	// When the orchestrator later becomes idle, the deferred completion lands.
+	if err := m.ApplyActivitySignal(ctx, "mer-orch", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("deferred worker-idle nudges = %d, want 1: %v", len(msg.msgs), msg.msgs)
+	}
+	if msg.ids[0] != "mer-orch" {
+		t.Fatalf("deferred nudge target = %q, want mer-orch", msg.ids[0])
+	}
+	if !strings.Contains(msg.msgs[0], "mer-8") {
+		t.Fatalf("deferred nudge missing worker id: %q", msg.msgs[0])
+	}
+}
+
+func TestActivity_WorkerIdleNoOrchestratorIsNoop(t *testing.T) {
+	m, st, msg := newManager()
+	now := time.Now()
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
+
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 0 {
+		t.Fatalf("nudges without orchestrator = %d, want 0", len(msg.msgs))
 	}
 }
 

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -580,6 +580,144 @@ func cannotNudge(rec domain.SessionRecord) bool {
 	return rec.IsTerminated || rec.Activity.State.NeedsInput() || rec.Activity.State == domain.ActivityExited
 }
 
+// dispatchWorkerIdle notifies the project's live orchestrator that a worker
+// finished a turn (activity active → idle). Delivery uses NudgeCoordination so
+// a blocked/busy orchestrator is not interrupted; when the orchestrator is
+// mid-turn the message is queued and flushed on its next idle transition.
+//
+// This is the path that closes the "worker finished, orchestrator gets silence"
+// coordination gap: workers are still free to `ao send` richer status, but the
+// orchestrator must learn of turn completion even when they do not.
+func (m *Manager) dispatchWorkerIdle(ctx context.Context, worker domain.SessionRecord) {
+	if m.guard == nil {
+		return
+	}
+	orchID, ok, err := m.resolveLiveOrchestrator(ctx, worker.ProjectID)
+	if err != nil {
+		slog.Default().Warn("lifecycle: resolve orchestrator for worker idle", "worker", worker.ID, "err", err)
+		return
+	}
+	if !ok {
+		return
+	}
+	msg := workerIdleMessage(worker)
+	outcome, err := m.guard.NudgeCoordination(ctx, orchID, msg, m.steerActive)
+	if err != nil {
+		slog.Default().Warn("lifecycle: worker-idle orchestrator nudge failed",
+			"worker", worker.ID, "orchestrator", orchID, "err", err)
+		return
+	}
+	switch outcome {
+	case sessionguard.Sent:
+		// Drop any previously deferred message for this worker: the live send
+		// supersedes a stale queued copy from an earlier busy attempt.
+		m.dropPendingWorkerIdle(worker.ProjectID, worker.ID)
+	case sessionguard.SuppressedBusy:
+		m.queuePendingWorkerIdle(worker.ProjectID, pendingWorkerIdle{workerID: worker.ID, msg: msg})
+	default:
+		// blocked / terminated / exited / not found: drop. A blocked
+		// orchestrator must not receive automated Enter; the operator can
+		// re-check the board once they unblock it.
+	}
+}
+
+// flushPendingWorkerIdle delivers any worker-idle messages queued while the
+// orchestrator was mid-turn. Called when the orchestrator itself becomes idle.
+func (m *Manager) flushPendingWorkerIdle(ctx context.Context, orch domain.SessionRecord) {
+	if m.guard == nil {
+		return
+	}
+	pending := m.takePendingWorkerIdle(orch.ProjectID)
+	if len(pending) == 0 {
+		return
+	}
+	for i, item := range pending {
+		outcome, err := m.guard.NudgeCoordination(ctx, orch.ID, item.msg, m.steerActive)
+		if err != nil {
+			slog.Default().Warn("lifecycle: deferred worker-idle nudge failed",
+				"worker", item.workerID, "orchestrator", orch.ID, "err", err)
+			// Messenger failure is unlikely to recover mid-flush; drop the rest
+			// rather than re-spamming on every subsequent idle.
+			return
+		}
+		if outcome == sessionguard.SuppressedBusy {
+			// Orchestrator went busy again mid-flush; re-queue this item and
+			// everything still pending so a later idle can retry.
+			for _, p := range pending[i:] {
+				m.queuePendingWorkerIdle(orch.ProjectID, p)
+			}
+			return
+		}
+		// Sent, or suppressed for blocked/terminated/not-found: drop this item
+		// and continue best-effort with the rest.
+	}
+}
+
+func (m *Manager) resolveLiveOrchestrator(ctx context.Context, project domain.ProjectID) (domain.SessionID, bool, error) {
+	recs, err := m.store.ListSessions(ctx, project)
+	if err != nil {
+		return "", false, err
+	}
+	for _, rec := range recs {
+		if rec.Kind == domain.KindOrchestrator && !rec.IsTerminated {
+			return rec.ID, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func workerIdleMessage(worker domain.SessionRecord) string {
+	name := strings.TrimSpace(worker.DisplayName)
+	if name == "" {
+		return fmt.Sprintf("[AO] Worker %s finished its turn and is now idle.", worker.ID)
+	}
+	return fmt.Sprintf("[AO] Worker %s (%s) finished its turn and is now idle.", worker.ID, name)
+}
+
+func (m *Manager) queuePendingWorkerIdle(project domain.ProjectID, item pendingWorkerIdle) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.pendingWorkerIdle == nil {
+		m.pendingWorkerIdle = map[domain.ProjectID][]pendingWorkerIdle{}
+	}
+	// One pending entry per worker: a later idle supersedes an earlier one.
+	out := m.pendingWorkerIdle[project][:0]
+	for _, p := range m.pendingWorkerIdle[project] {
+		if p.workerID != item.workerID {
+			out = append(out, p)
+		}
+	}
+	m.pendingWorkerIdle[project] = append(out, item)
+}
+
+func (m *Manager) dropPendingWorkerIdle(project domain.ProjectID, workerID domain.SessionID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	pending := m.pendingWorkerIdle[project]
+	if len(pending) == 0 {
+		return
+	}
+	out := pending[:0]
+	for _, p := range pending {
+		if p.workerID != workerID {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		delete(m.pendingWorkerIdle, project)
+		return
+	}
+	m.pendingWorkerIdle[project] = out
+}
+
+func (m *Manager) takePendingWorkerIdle(project domain.ProjectID) []pendingWorkerIdle {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	pending := m.pendingWorkerIdle[project]
+	delete(m.pendingWorkerIdle, project)
+	return pending
+}
+
 func isTerminalTrackerState(state domain.NormalizedIssueState) bool {
 	return state == domain.IssueDone || state == domain.IssueCancelled
 }


### PR DESCRIPTION
## Summary
Wire the missing lifecycle dispatcher so a worker **active → idle** transition notifies the project''s live orchestrator.

### Problem
Scaffolding already existed (`ListSessions` for resolve-at-delivery, `NudgeCoordination` for busy/blocked policy), but `ApplyActivitySignal` never called it. Parents saw silence after workers finished turns — especially visible on Windows where operators rely on that signal rather than only manual `ao send`.

### Fix
- Dispatch on worker **active → idle**; skip `waiting_input → idle` and non-workers
- Deliver via `NudgeCoordination` (idle now; queue when orchestrator is busy; drop when blocked)
- Flush deferred completions when the orchestrator next becomes idle
- Regression tests for happy path, deferral, blocked, and no-orchestrator

## User-visible impact
Orchestrators receive a coordination nudge when a worker finishes a turn, so multi-agent workflows resume without manual messaging.

## Test plan
- [x] `go test ./internal/lifecycle/` (pass)
- [x] Manual multi-session: worker completes turn → orchestrator receives idle notification

## Notes
- Cherry-picked onto `Untrivial-ai/main` from fork.
- Single-commit, single-topic PR.