### PR TITLE
fix(terminal): proportional history-safe wheel scroll

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -235,7 +235,7 @@ describe("terminal restore", () => {
 describe("providerScrollsByKeyboard", () => {
 	// opencode and its fork kilocode share a TUI that scrolls its own transcript
 	// by keyboard and ignores SGR wheel reports, so both must opt into the
-	// PageUp/PageDown wheel routing (see XtermTerminal's paneScrollsByKeyboard).
+	// keyboard wheel routing (see XtermTerminal's paneScrollsByKeyboard).
 	// Grok is the same class of full-screen agent TUI.
 	it("is true for keyboard-scroll TUIs (opencode, kilocode, grok)", () => {
 		expect(providerScrollsByKeyboard("opencode")).toBe(true);

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession } from "../types/workspace";
-import { TerminalPane, providerScrollsByKeyboard } from "./TerminalPane";
+import { TerminalPane, keyboardScrollProfileFor, providerScrollsByKeyboard } from "./TerminalPane";
 
 const { postMock, terminalError, terminalState, replaySettled } = vi.hoisted(() => ({
 	postMock: vi.fn(),
@@ -250,6 +250,20 @@ describe("providerScrollsByKeyboard", () => {
 
 	it("is false when the provider is unknown", () => {
 		expect(providerScrollsByKeyboard(undefined)).toBe(false);
+	});
+});
+
+describe("keyboardScrollProfileFor", () => {
+	it("maps keyboard-scroll providers to line-scroll profiles", () => {
+		expect(keyboardScrollProfileFor("grok")).toBe("grok");
+		expect(keyboardScrollProfileFor("opencode")).toBe("opencode");
+		expect(keyboardScrollProfileFor("kilocode")).toBe("kilocode");
+	});
+
+	it("is false for providers that use SGR or local scrollback", () => {
+		expect(keyboardScrollProfileFor("codex")).toBe(false);
+		expect(keyboardScrollProfileFor("claude-code")).toBe(false);
+		expect(keyboardScrollProfileFor(undefined)).toBe(false);
 	});
 });
 

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -236,9 +236,11 @@ describe("providerScrollsByKeyboard", () => {
 	// opencode and its fork kilocode share a TUI that scrolls its own transcript
 	// by keyboard and ignores SGR wheel reports, so both must opt into the
 	// PageUp/PageDown wheel routing (see XtermTerminal's paneScrollsByKeyboard).
-	it("is true for keyboard-scroll TUIs (opencode and its kilocode fork)", () => {
+	// Grok is the same class of full-screen agent TUI.
+	it("is true for keyboard-scroll TUIs (opencode, kilocode, grok)", () => {
 		expect(providerScrollsByKeyboard("opencode")).toBe(true);
 		expect(providerScrollsByKeyboard("kilocode")).toBe(true);
+		expect(providerScrollsByKeyboard("grok")).toBe(true);
 	});
 
 	it("is false for mouse-report/native-scroll providers", () => {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -208,8 +208,10 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
 // PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard).
 // kilocode is a fork of opencode and shares its TUI surface, so it scrolls the
-// same way.
-const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode"]);
+// same way. Grok is the same class of alt-buffer agent TUI: wheel/SGR does not
+// move its conversation history, but PageUp/PageDown does (and on Windows the
+// ConPTY path has no mux copy-mode fallback either).
+const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.
 export function providerScrollsByKeyboard(provider?: string): boolean {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -206,11 +206,12 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 
 // Agents whose full-screen TUI keeps its own transcript and scrolls it only by
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
-// proportional arrow keys for these (see XtermTerminal's paneScrollsByKeyboard).
-// kilocode is a fork of opencode and shares its TUI surface, so it scrolls the
-// same way. Grok is the same class of alt-buffer agent TUI: wheel/SGR does not
-// move its conversation history, but ↑/↓ and PageUp/PageDown do (and on Windows
-// the ConPTY path has no mux copy-mode fallback either).
+// PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard) — not
+// bare ArrowUp/ArrowDown, which Grok and similar chat TUIs bind to input-history
+// recall. kilocode is a fork of opencode and shares its TUI surface. Grok is the
+// same class of alt-buffer agent TUI: wheel/SGR does not move its conversation
+// transcript, but PageUp/PageDown do (and on Windows the ConPTY path has no mux
+// copy-mode fallback either).
 const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -206,17 +206,27 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 
 // Agents whose full-screen TUI keeps its own transcript and scrolls it only by
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
-// PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard) — not
+// history-safe provider keys (see XtermTerminal's paneScrollsByKeyboard) — not
 // bare ArrowUp/ArrowDown, which Grok and similar chat TUIs bind to input-history
 // recall. kilocode is a fork of opencode and shares its TUI surface. Grok is the
 // same class of alt-buffer agent TUI: wheel/SGR does not move its conversation
-// transcript, but PageUp/PageDown do (and on Windows the ConPTY path has no mux
-// copy-mode fallback either).
+// transcript under AO/ConPTY, so we synthesize its documented line-scroll keys
+// (and OpenCode's) instead of one full PageUp/PageDown per notch.
 const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.
 export function providerScrollsByKeyboard(provider?: string): boolean {
 	return provider ? KEYBOARD_SCROLL_PROVIDERS.has(provider) : false;
+}
+
+/** Profile string for XtermTerminal.paneScrollsByKeyboard, or false. */
+export function keyboardScrollProfileFor(
+	provider?: string,
+): false | "grok" | "opencode" | "kilocode" {
+	if (!provider || !KEYBOARD_SCROLL_PROVIDERS.has(provider)) return false;
+	if (provider === "grok") return "grok";
+	if (provider === "kilocode") return "kilocode";
+	return "opencode";
 }
 
 function bannerText(state: TerminalSessionState, t: TFunction, error?: string): string | undefined {
@@ -413,7 +423,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 					onError={handleInitError}
 					onLinkOpen={handleLinkOpen}
 					onReady={handleReady}
-					paneScrollsByKeyboard={providerScrollsByKeyboard(provider)}
+					paneScrollsByKeyboard={keyboardScrollProfileFor(provider)}
 					theme={theme}
 				/>
 				{showEmptyState && (

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -206,11 +206,11 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 
 // Agents whose full-screen TUI keeps its own transcript and scrolls it only by
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
-// PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard).
+// proportional arrow keys for these (see XtermTerminal's paneScrollsByKeyboard).
 // kilocode is a fork of opencode and shares its TUI surface, so it scrolls the
 // same way. Grok is the same class of alt-buffer agent TUI: wheel/SGR does not
-// move its conversation history, but PageUp/PageDown does (and on Windows the
-// ConPTY path has no mux copy-mode fallback either).
+// move its conversation history, but ↑/↓ and PageUp/PageDown do (and on Windows
+// the ConPTY path has no mux copy-mode fallback either).
 const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -700,40 +700,44 @@ describe("XtermTerminal", () => {
 		expect(onInput).not.toHaveBeenCalled();
 	});
 
-	it("falls back to proportional arrow keys for alt-buffer panes with mouse tracking off", () => {
+	it("falls back to PageUp/PageDown for alt-buffer panes with mouse tracking off", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		state.lastTerminal!.modes.mouseTrackingMode = "none";
 		// Alt buffer: no local scrollback to move, and no keyboard-scroll hint, so
-		// one arrow key per scrolled line is the free-scroll fallback.
+		// page keys scroll the app transcript (not arrows — those recall history).
 		state.lastTerminal!.buffer.active.type = "alternate";
 
-		// rowHeight = 16.2px; -50px => 3 lines up; +20px => 1 line down.
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
+		// Must not look like input-history navigation (ArrowUp/ArrowDown).
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 	});
 
-	it("sends proportional arrow keys on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
+	it("sends PageUp/PageDown on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
 		setNavigatorPlatform("Win32");
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Full-screen agent TUIs (Grok/orchestrator session transcript) enable mouse
 		// tracking on the alternate screen. Unix can fall back to tmux copy-mode;
-		// Windows ConPTY cannot, so wheel becomes line-scroll arrow keys (not a
-		// single PageUp per notch — that felt like fixed full-screen jumps).
+		// Windows ConPTY cannot, so wheel must become page keys — not ArrowUp/
+		// ArrowDown, which Grok binds to prompt input-history recall.
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 		state.lastTerminal!.buffer.active.type = "alternate";
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 	});
 
 	it("still sends SGR on Windows for normal-buffer mouse-tracking panes", () => {
@@ -760,23 +764,28 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
 	});
 
-	it("sends proportional arrow keys for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
+	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Linux (beforeEach) + mouse tracking on: without the paneScrollsByKeyboard
-		// hint this would send SGR reports; the hint forces line-scroll arrows for
-		// agents whose TUI ignores wheel (opencode, kilocode, grok).
+		// hint this would send SGR reports; the hint forces page keys for agents
+		// whose TUI ignores wheel (opencode, kilocode, grok). Must not emit bare
+		// ArrowUp/ArrowDown — Grok treats those as input-history recall.
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 
-		// -50px => 3 ArrowUp; magnitude tracks wheel delta (free scroll).
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 
-		// Small roll moves one line; large line-mode flick moves many.
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
+
+		// Line-mode notches still map to a single page key (direction only).
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 1, deltaMode: 1 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -5, deltaMode: 1 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(5), "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 	});
 
 	it("routes web links to the AO browser and does not open the system browser", () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -700,38 +700,40 @@ describe("XtermTerminal", () => {
 		expect(onInput).not.toHaveBeenCalled();
 	});
 
-	it("falls back to PageUp/PageDown for alt-buffer panes with mouse tracking off", () => {
+	it("falls back to proportional arrow keys for alt-buffer panes with mouse tracking off", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		state.lastTerminal!.modes.mouseTrackingMode = "none";
-		// Alt buffer: no local scrollback to move, and no keyboard-scroll hint, so a
-		// page key per notch is the best fallback.
+		// Alt buffer: no local scrollback to move, and no keyboard-scroll hint, so
+		// one arrow key per scrolled line is the free-scroll fallback.
 		state.lastTerminal!.buffer.active.type = "alternate";
 
+		// rowHeight = 16.2px; -50px => 3 lines up; +20px => 1 line down.
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
 		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
 	});
 
-	it("sends PageUp/PageDown on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
+	it("sends proportional arrow keys on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
 		setNavigatorPlatform("Win32");
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Full-screen agent TUIs (Grok/orchestrator session transcript) enable mouse
 		// tracking on the alternate screen. Unix can fall back to tmux copy-mode;
-		// Windows ConPTY cannot, so wheel must become page keys.
+		// Windows ConPTY cannot, so wheel becomes line-scroll arrow keys (not a
+		// single PageUp per notch — that felt like fixed full-screen jumps).
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 		state.lastTerminal!.buffer.active.type = "alternate";
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
 		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
 	});
 
 	it("still sends SGR on Windows for normal-buffer mouse-tracking panes", () => {
@@ -758,16 +760,23 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
 	});
 
-	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
+	it("sends proportional arrow keys for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Linux (beforeEach) + mouse tracking on: without the paneScrollsByKeyboard
-		// hint this would send SGR reports; the hint forces page keys for agents
-		// whose TUI ignores wheel (opencode, kilocode, grok).
+		// hint this would send SGR reports; the hint forces line-scroll arrows for
+		// agents whose TUI ignores wheel (opencode, kilocode, grok).
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 
+		// -50px => 3 ArrowUp; magnitude tracks wheel delta (free scroll).
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(3), "wheel");
+
+		// Small roll moves one line; large line-mode flick moves many.
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: 1, deltaMode: 1 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[B", "wheel");
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: -5, deltaMode: 1 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[A".repeat(5), "wheel");
 	});
 
 	it("routes web links to the AO browser and does not open the system browser", () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -716,24 +716,54 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
 	});
 
-	it("sends SGR reports on Windows when the pane tracks the mouse (conpty delivers them to the app)", () => {
+	it("sends PageUp/PageDown on Windows for alt-buffer mouse-tracking panes (no tmux under conpty)", () => {
 		setNavigatorPlatform("Win32");
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
-		// A mouse-tracking pane gets SGR reports on every platform; on Windows conpty
-		// forwards them straight to the app. Keyboard-scroll panes (opencode) opt out
-		// via the paneScrollsByKeyboard hint, tested separately.
+		// Full-screen agent TUIs (Grok/orchestrator session transcript) enable mouse
+		// tracking on the alternate screen. Unix can fall back to tmux copy-mode;
+		// Windows ConPTY cannot, so wheel must become page keys.
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
+		state.lastTerminal!.buffer.active.type = "alternate";
+
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
+
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
+	});
+
+	it("still sends SGR on Windows for normal-buffer mouse-tracking panes", () => {
+		setNavigatorPlatform("Win32");
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+		// Normal buffer + mouse tracking is uncommon; keep SGR so we do not force
+		// page keys onto a shell that expects mouse reports.
+		state.lastTerminal!.modes.mouseTrackingMode = "any";
+		state.lastTerminal!.buffer.active.type = "normal";
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
 	});
 
-	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode on macOS/Linux)", () => {
+	it("sends SGR on non-Windows when the pane tracks the mouse (tmux/mux path)", () => {
+		setNavigatorPlatform("Linux x86_64");
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+		state.lastTerminal!.modes.mouseTrackingMode = "any";
+		state.lastTerminal!.buffer.active.type = "alternate";
+
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
+	});
+
+	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Linux (beforeEach) + mouse tracking on: without the paneScrollsByKeyboard
-		// hint this would send SGR reports; the hint forces page keys.
+		// hint this would send SGR reports; the hint forces page keys for agents
+		// whose TUI ignores wheel (opencode, kilocode, grok).
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -723,10 +723,9 @@ describe("XtermTerminal", () => {
 		setNavigatorPlatform("Win32");
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
-		// Full-screen agent TUIs (Grok/orchestrator session transcript) enable mouse
-		// tracking on the alternate screen. Unix can fall back to tmux copy-mode;
-		// Windows ConPTY cannot, so wheel must become page keys — not ArrowUp/
-		// ArrowDown, which Grok binds to prompt input-history recall.
+		// Full-screen agent TUIs enable mouse tracking on the alternate screen.
+		// Unix can fall back to tmux copy-mode; Windows ConPTY cannot, so wheel
+		// becomes page keys — not ArrowUp/ArrowDown (prompt history recall).
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 		state.lastTerminal!.buffer.active.type = "alternate";
 
@@ -764,28 +763,75 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
 	});
 
-	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode/grok on macOS/Linux)", () => {
+	it("sends proportional Grok line-scroll keys (Ctrl+K/J) for grok keyboard-scroll panes", () => {
 		const onInput = vi.fn();
-		render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
-		// Linux (beforeEach) + mouse tracking on: without the paneScrollsByKeyboard
-		// hint this would send SGR reports; the hint forces page keys for agents
-		// whose TUI ignores wheel (opencode, kilocode, grok). Must not emit bare
-		// ArrowUp/ArrowDown — Grok treats those as input-history recall.
+		render(
+			<XtermTerminal theme="dark" paneScrollsByKeyboard="grok" onReady={(terminal) => terminal.onUserInput(onInput)} />,
+		);
+		// Linux (beforeEach) + mouse tracking on: without the hint this would send
+		// SGR; grok profile uses Ctrl+K/J line keys (Grok docs), not PageUp and not
+		// bare ArrowUp/ArrowDown (prompt history).
 		state.lastTerminal!.modes.mouseTrackingMode = "any";
 
+		// rowHeight = 16.2px; -50px => 3 lines up => 3× Ctrl+K.
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x0b".repeat(3), "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[5~|\x1b\[6~/);
+
+		// +20px => 1 line down => Ctrl+J (LF), not Enter CR and not ArrowDown.
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\n", "wheel");
+		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B|\r/);
+
+		// Line-mode: magnitude is honored (5 notches up => 5× Ctrl+K).
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: -5, deltaMode: 1 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x0b".repeat(5), "wheel");
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: 1, deltaMode: 1 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\n", "wheel");
+	});
+
+	it("sends proportional OpenCode line-scroll keys for opencode/kilocode keyboard-scroll panes", () => {
+		const lineUp = "\x1b[27;7;121~"; // Ctrl+Alt+Y
+		const lineDown = "\x1b[27;7;101~"; // Ctrl+Alt+E
+
+		for (const profile of ["opencode", "kilocode"] as const) {
+			const onInput = vi.fn();
+			const view = render(
+				<XtermTerminal
+					theme="dark"
+					paneScrollsByKeyboard={profile}
+					onReady={(terminal) => terminal.onUserInput(onInput)}
+				/>,
+			);
+			state.lastTerminal!.modes.mouseTrackingMode = "any";
+
+			// -50px => 3 lines up — finer than always-one-page-regardless-of-delta.
+			expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
+			expect(onInput).toHaveBeenLastCalledWith(lineUp.repeat(3), "wheel");
+			expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
+			expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[5~|\x1b\[6~/);
+
+			expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
+			expect(onInput).toHaveBeenLastCalledWith(lineDown, "wheel");
+			view.unmount();
+		}
+	});
+
+	it("uses a single PageUp/PageDown when paneScrollsByKeyboard is the coarse page profile", () => {
+		const onInput = vi.fn();
+		render(
+			<XtermTerminal theme="dark" paneScrollsByKeyboard="page" onReady={(terminal) => terminal.onUserInput(onInput)} />,
+		);
+		state.lastTerminal!.modes.mouseTrackingMode = "any";
+
+		// Direction only — full page already jumps far; do not multiply by |lines|.
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
 
-		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
-		expect(onInput.mock.calls.at(-1)?.[0]).not.toMatch(/\x1b\[A|\x1b\[B/);
-
-		// Line-mode notches still map to a single page key (direction only).
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: 1, deltaMode: 1 } as WheelEvent)).toBe(false);
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
-		expect(state.lastTerminal!.wheelHandler!({ deltaY: -5, deltaMode: 1 } as WheelEvent)).toBe(false);
-		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 	});
 
 	it("routes web links to the AO browser and does not open the system browser", () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -660,10 +660,17 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				term.scrollLines(lines);
 				return false;
 			}
-			// Mouse tracking on: the pane (tmux/zellij copy-mode, or any app that
-			// tracks the mouse) acts on SGR wheel reports. On Windows conpty this
-			// reaches the app directly; under a mux it drives copy-mode.
+			// Mouse tracking on: under a mux (tmux with `mouse on`), SGR wheel
+			// reports drive copy-mode or the app. On Windows ConPTY there is no
+			// mux copy-mode safety net — synthetic SGR often no-ops for full-screen
+			// agent TUIs (orchestrator/claude/grok conversation history), while
+			// PageUp/PageDown reliably scroll their transcripts. Prefer page keys
+			// for alt-buffer panes on Windows; keep SGR elsewhere.
 			if (term.modes.mouseTrackingMode !== "none") {
+				if (isWindowsPlatform() && term.buffer.active.type === "alternate") {
+					emitUserInput(pageKeyReport(lines), "wheel");
+					return false;
+				}
 				const button = lines < 0 ? SGR_WHEEL_UP : SGR_WHEEL_DOWN;
 				emitUserInput(sgrWheelReport(button, Math.abs(lines)), "wheel");
 				return false;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -48,15 +48,21 @@ export type XtermTerminalProps = {
 	fontSize?: number;
 	theme: Theme;
 	/**
-	 * The pane app scrolls its transcript by keyboard (PageUp/PageDown) rather
-	 * than acting on SGR wheel reports — e.g. opencode, which enables mouse
-	 * tracking but never scrolls on wheel reports. Routes the wheel to page keys
-	 * on every platform (see the wheel handler), fixing it under a mux too.
+	 * The pane app scrolls its transcript by keyboard rather than SGR wheel
+	 * reports (opencode/kilocode/grok enable mouse tracking but ignore wheel).
+	 * Routes the wheel to history-safe keys on every platform (see the wheel
+	 * handler), fixing it under a mux too.
 	 *
-	 * Do not use bare ArrowUp/ArrowDown for this path: chat TUIs (Grok and
-	 * similar) bind those keys to input-history recall, not viewport scroll.
+	 * Profiles pick provider line-scroll bindings so small rolls move a little
+	 * and large flicks move farther — not one full PageUp/PageDown per notch.
+	 * Do not use bare ArrowUp/ArrowDown: chat TUIs (Grok and similar) bind
+	 * those to prompt input-history recall, not viewport scroll.
+	 *
+	 * - `"grok"` — Ctrl+K / Ctrl+J (Grok line scroll; LF ≠ Enter CR)
+	 * - `"opencode"` / `"kilocode"` — Ctrl+Alt+Y / Ctrl+Alt+E (OpenCode defaults)
+	 * - `true` / `"page"` — PageUp / PageDown (coarse universal fallback)
 	 */
-	paneScrollsByKeyboard?: boolean;
+	paneScrollsByKeyboard?: boolean | "grok" | "opencode" | "kilocode" | "page";
 	/** Terminal construction failed; the owner decides how to surface it. */
 	onError?: (error: unknown) => void;
 	/** Called after a terminal hyperlink is opened in the OS browser. */
@@ -218,20 +224,56 @@ function sgrWheelReport(button: number, count: number): string {
 	return `\x1b[<${button};1;1M`.repeat(count);
 }
 
-// PageUp (CSI 5~) / PageDown (CSI 6~) for pane apps that scroll their transcript
-// by keyboard rather than mouse reports. One page key per wheel event: a page
-// already scrolls a full screen, so scaling by line count would over-scroll.
+// History-safe keyboard scroll encodings for agent TUIs that ignore SGR wheel.
 //
-// Bare ArrowUp/ArrowDown must not be used here. Grok (and many chat CLI TUIs)
-// bind those keys to prompt input-history recall — wheel → ArrowUp re-injects
-// previously sent messages into the input box. PageUp/PageDown scroll the
-// conversation transcript without touching history.
+// Evaluated options (Grok docs + OpenCode keybinds):
+// - Bare ArrowUp/Down: NO — Grok binds them to prompt history recall.
+// - SGR wheel: these agents ignore reports under AO/ConPTY.
+// - PageUp/PageDown: works (incl. Grok with prompt focused) but one key =
+//   one full viewport → every notch jumps a page (the user report).
+// - Grok Ctrl+K/J: official *line* scroll; Ctrl+J is LF (\n), distinct from
+//   Enter CR (\r), so it does not submit the prompt.
+// - OpenCode Ctrl+Alt+Y/E: official messages_line_up/down defaults.
+// - Grok Ctrl+U/D half-page: coarser than line; Ctrl+D is also quit/EOF risk.
+//
+// Prefer provider line keys when known; fall back to page keys for generic
+// alt-buffer paths. Cap repeats so a huge flick cannot flood the PTY.
 const PAGE_UP = "\x1b[5~";
 const PAGE_DOWN = "\x1b[6~";
+// Grok: scroll one line without changing selection (scrollback nav docs).
+const GROK_LINE_UP = "\x0b"; // Ctrl+K
+const GROK_LINE_DOWN = "\n"; // Ctrl+J (LF, not Enter)
+// OpenCode modifyOtherKeys form: CSI 27 ; 7 ; code ~  (7 = ctrl+alt).
+const OPENCODE_LINE_UP = "\x1b[27;7;121~"; // Ctrl+Alt+Y
+const OPENCODE_LINE_DOWN = "\x1b[27;7;101~"; // Ctrl+Alt+E
+const KEYBOARD_SCROLL_MAX_STEPS = 12;
 
-function keyboardScrollReport(lines: number): string {
+export type KeyboardScrollProfile = "grok" | "opencode" | "page";
+
+function resolveKeyboardScrollProfile(
+	value: boolean | "grok" | "opencode" | "kilocode" | "page" | undefined,
+): KeyboardScrollProfile | null {
+	if (!value) return null;
+	if (value === "grok") return "grok";
+	if (value === "opencode" || value === "kilocode") return "opencode";
+	return "page";
+}
+
+/** @internal Exported for unit tests. */
+export function keyboardScrollReport(lines: number, profile: KeyboardScrollProfile = "page"): string {
 	if (lines === 0) return "";
-	return lines < 0 ? PAGE_UP : PAGE_DOWN;
+	// Page keys already move a full viewport — emit one per event (direction
+	// only). Used for generic alt-buffer fallbacks without a provider line map.
+	if (profile === "page") {
+		return lines < 0 ? PAGE_UP : PAGE_DOWN;
+	}
+	// Provider line profiles: one history-safe line key per scrolled line so
+	// small rolls move a little and large flicks move farther.
+	const steps = Math.min(Math.abs(lines), KEYBOARD_SCROLL_MAX_STEPS);
+	if (profile === "grok") {
+		return (lines < 0 ? GROK_LINE_UP : GROK_LINE_DOWN).repeat(steps);
+	}
+	return (lines < 0 ? OPENCODE_LINE_UP : OPENCODE_LINE_DOWN).repeat(steps);
 }
 
 function forceSelectionMode(term: Terminal): void {
@@ -655,11 +697,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			if (lines === 0) return false;
 			// A full-screen TUI that keeps its own transcript and scrolls it only by
 			// keyboard (opencode/grok) ignores wheel/mouse reports on every platform;
-			// route its wheel to PageUp/PageDown (not arrows — those recall prompt
-			// history in chat TUIs). Kept first so those agents are unaffected by
+			// route its wheel to provider line keys when known (proportional, history-
+			// safe — not bare arrows). Kept first so those agents are unaffected by
 			// the buffer-aware paths below.
-			if (callbacksRef.current.paneScrollsByKeyboard) {
-				emitUserInput(keyboardScrollReport(lines), "wheel");
+			const keyboardProfile = resolveKeyboardScrollProfile(callbacksRef.current.paneScrollsByKeyboard);
+			if (keyboardProfile) {
+				emitUserInput(keyboardScrollReport(lines, keyboardProfile), "wheel");
 				return false;
 			}
 			// A normal-buffer pane with mouse tracking off (codex, a plain shell)
@@ -674,11 +717,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// reports drive copy-mode or the app. On Windows ConPTY there is no
 			// mux copy-mode safety net — synthetic SGR often no-ops for full-screen
 			// agent TUIs (orchestrator/claude/grok conversation history), while
-			// PageUp/PageDown reliably scroll their transcripts. Prefer page keys
-			// for alt-buffer panes on Windows; keep SGR elsewhere.
+			// page keys reliably scroll their transcripts. Prefer page keys for
+			// alt-buffer panes on Windows; keep SGR elsewhere.
 			if (term.modes.mouseTrackingMode !== "none") {
 				if (isWindowsPlatform() && term.buffer.active.type === "alternate") {
-					emitUserInput(keyboardScrollReport(lines), "wheel");
+					emitUserInput(keyboardScrollReport(lines, "page"), "wheel");
 					return false;
 				}
 				const button = lines < 0 ? SGR_WHEEL_UP : SGR_WHEEL_DOWN;
@@ -687,7 +730,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			}
 			// Alt-buffer pane with mouse tracking off and no keyboard-scroll hint:
 			// no scrollback to move locally, so fall back to page keys (not arrows).
-			emitUserInput(keyboardScrollReport(lines), "wheel");
+			emitUserInput(keyboardScrollReport(lines, "page"), "wheel");
 			return false;
 		});
 		const pasteInput = (event: ClipboardEvent) => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -48,10 +48,10 @@ export type XtermTerminalProps = {
 	fontSize?: number;
 	theme: Theme;
 	/**
-	 * The pane app scrolls its transcript by keyboard (PageUp/PageDown) rather
-	 * than acting on SGR wheel reports — e.g. opencode, which enables mouse
-	 * tracking but never scrolls on wheel reports. Routes the wheel to page keys
-	 * on every platform (see the wheel handler), fixing it under a mux too.
+	 * The pane app scrolls its transcript by keyboard rather than acting on SGR
+	 * wheel reports — e.g. opencode, which enables mouse tracking but never
+	 * scrolls on wheel reports. Routes the wheel to proportional arrow keys
+	 * (see the wheel handler), fixing it under a mux too.
 	 */
 	paneScrollsByKeyboard?: boolean;
 	/** Terminal construction failed; the owner decides how to surface it. */
@@ -215,14 +215,18 @@ function sgrWheelReport(button: number, count: number): string {
 	return `\x1b[<${button};1;1M`.repeat(count);
 }
 
-// PageUp (CSI 5~) / PageDown (CSI 6~) for pane apps that scroll their transcript
-// by keyboard rather than mouse reports. One page key per wheel notch: a page
-// already scrolls a full screen, so scaling by line count would over-scroll.
-const PAGE_UP = "\x1b[5~";
-const PAGE_DOWN = "\x1b[6~";
+// ArrowUp (CSI A) / ArrowDown (CSI B) for pane apps that scroll their transcript
+// by keyboard rather than mouse reports. One arrow key per scrolled line so the
+// wheel feels free/proportional: small rolls move a little, large flicks move
+// farther, and the user can stop mid-history. (A single PageUp/PageDown per
+// event ignored |lines| and felt like fixed full-screen jumps.)
+const ARROW_UP = "\x1b[A";
+const ARROW_DOWN = "\x1b[B";
 
-function pageKeyReport(lines: number): string {
-	return lines < 0 ? PAGE_UP : PAGE_DOWN;
+function keyboardScrollReport(lines: number): string {
+	const count = Math.abs(lines);
+	if (count === 0) return "";
+	return (lines < 0 ? ARROW_UP : ARROW_DOWN).repeat(count);
 }
 
 function forceSelectionMode(term: Terminal): void {
@@ -645,11 +649,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			}
 			if (lines === 0) return false;
 			// A full-screen TUI that keeps its own transcript and scrolls it only by
-			// keyboard (opencode) ignores wheel/mouse reports on every platform; route
-			// its wheel to page keys. Kept first so opencode is unaffected by the
-			// buffer-aware paths below.
+			// keyboard (opencode/grok) ignores wheel/mouse reports on every platform;
+			// route its wheel to proportional arrow keys. Kept first so those agents
+			// are unaffected by the buffer-aware paths below.
 			if (callbacksRef.current.paneScrollsByKeyboard) {
-				emitUserInput(pageKeyReport(lines), "wheel");
+				emitUserInput(keyboardScrollReport(lines), "wheel");
 				return false;
 			}
 			// A normal-buffer pane with mouse tracking off (codex, a plain shell)
@@ -664,11 +668,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// reports drive copy-mode or the app. On Windows ConPTY there is no
 			// mux copy-mode safety net — synthetic SGR often no-ops for full-screen
 			// agent TUIs (orchestrator/claude/grok conversation history), while
-			// PageUp/PageDown reliably scroll their transcripts. Prefer page keys
-			// for alt-buffer panes on Windows; keep SGR elsewhere.
+			// arrow keys scroll their transcripts line-by-line. Prefer proportional
+			// keyboard scroll for alt-buffer panes on Windows; keep SGR elsewhere.
 			if (term.modes.mouseTrackingMode !== "none") {
 				if (isWindowsPlatform() && term.buffer.active.type === "alternate") {
-					emitUserInput(pageKeyReport(lines), "wheel");
+					emitUserInput(keyboardScrollReport(lines), "wheel");
 					return false;
 				}
 				const button = lines < 0 ? SGR_WHEEL_UP : SGR_WHEEL_DOWN;
@@ -676,8 +680,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				return false;
 			}
 			// Alt-buffer pane with mouse tracking off and no keyboard-scroll hint:
-			// no scrollback to move locally, so fall back to page keys.
-			emitUserInput(pageKeyReport(lines), "wheel");
+			// no scrollback to move locally, so fall back to proportional arrow keys.
+			emitUserInput(keyboardScrollReport(lines), "wheel");
 			return false;
 		});
 		const pasteInput = (event: ClipboardEvent) => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -48,10 +48,13 @@ export type XtermTerminalProps = {
 	fontSize?: number;
 	theme: Theme;
 	/**
-	 * The pane app scrolls its transcript by keyboard rather than acting on SGR
-	 * wheel reports — e.g. opencode, which enables mouse tracking but never
-	 * scrolls on wheel reports. Routes the wheel to proportional arrow keys
-	 * (see the wheel handler), fixing it under a mux too.
+	 * The pane app scrolls its transcript by keyboard (PageUp/PageDown) rather
+	 * than acting on SGR wheel reports — e.g. opencode, which enables mouse
+	 * tracking but never scrolls on wheel reports. Routes the wheel to page keys
+	 * on every platform (see the wheel handler), fixing it under a mux too.
+	 *
+	 * Do not use bare ArrowUp/ArrowDown for this path: chat TUIs (Grok and
+	 * similar) bind those keys to input-history recall, not viewport scroll.
 	 */
 	paneScrollsByKeyboard?: boolean;
 	/** Terminal construction failed; the owner decides how to surface it. */
@@ -215,18 +218,20 @@ function sgrWheelReport(button: number, count: number): string {
 	return `\x1b[<${button};1;1M`.repeat(count);
 }
 
-// ArrowUp (CSI A) / ArrowDown (CSI B) for pane apps that scroll their transcript
-// by keyboard rather than mouse reports. One arrow key per scrolled line so the
-// wheel feels free/proportional: small rolls move a little, large flicks move
-// farther, and the user can stop mid-history. (A single PageUp/PageDown per
-// event ignored |lines| and felt like fixed full-screen jumps.)
-const ARROW_UP = "\x1b[A";
-const ARROW_DOWN = "\x1b[B";
+// PageUp (CSI 5~) / PageDown (CSI 6~) for pane apps that scroll their transcript
+// by keyboard rather than mouse reports. One page key per wheel event: a page
+// already scrolls a full screen, so scaling by line count would over-scroll.
+//
+// Bare ArrowUp/ArrowDown must not be used here. Grok (and many chat CLI TUIs)
+// bind those keys to prompt input-history recall — wheel → ArrowUp re-injects
+// previously sent messages into the input box. PageUp/PageDown scroll the
+// conversation transcript without touching history.
+const PAGE_UP = "\x1b[5~";
+const PAGE_DOWN = "\x1b[6~";
 
 function keyboardScrollReport(lines: number): string {
-	const count = Math.abs(lines);
-	if (count === 0) return "";
-	return (lines < 0 ? ARROW_UP : ARROW_DOWN).repeat(count);
+	if (lines === 0) return "";
+	return lines < 0 ? PAGE_UP : PAGE_DOWN;
 }
 
 function forceSelectionMode(term: Terminal): void {
@@ -650,8 +655,9 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			if (lines === 0) return false;
 			// A full-screen TUI that keeps its own transcript and scrolls it only by
 			// keyboard (opencode/grok) ignores wheel/mouse reports on every platform;
-			// route its wheel to proportional arrow keys. Kept first so those agents
-			// are unaffected by the buffer-aware paths below.
+			// route its wheel to PageUp/PageDown (not arrows — those recall prompt
+			// history in chat TUIs). Kept first so those agents are unaffected by
+			// the buffer-aware paths below.
 			if (callbacksRef.current.paneScrollsByKeyboard) {
 				emitUserInput(keyboardScrollReport(lines), "wheel");
 				return false;
@@ -668,8 +674,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// reports drive copy-mode or the app. On Windows ConPTY there is no
 			// mux copy-mode safety net — synthetic SGR often no-ops for full-screen
 			// agent TUIs (orchestrator/claude/grok conversation history), while
-			// arrow keys scroll their transcripts line-by-line. Prefer proportional
-			// keyboard scroll for alt-buffer panes on Windows; keep SGR elsewhere.
+			// PageUp/PageDown reliably scroll their transcripts. Prefer page keys
+			// for alt-buffer panes on Windows; keep SGR elsewhere.
 			if (term.modes.mouseTrackingMode !== "none") {
 				if (isWindowsPlatform() && term.buffer.active.type === "alternate") {
 					emitUserInput(keyboardScrollReport(lines), "wheel");
@@ -680,7 +686,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				return false;
 			}
 			// Alt-buffer pane with mouse tracking off and no keyboard-scroll hint:
-			// no scrollback to move locally, so fall back to proportional arrow keys.
+			// no scrollback to move locally, so fall back to page keys (not arrows).
 			emitUserInput(keyboardScrollReport(lines), "wheel");
 			return false;
 		});


### PR DESCRIPTION
## Summary

Smoother follow-up to **#3540** for keyboard-scroll agent panes (especially **Grok on Windows**).

#3540 made history scroll work with PageUp/PageDown (history-safe; no bare ArrowUp/ArrowDown). That baseline is correct, but every wheel notch still jumps a full page because `keyboardScrollReport()` ignored `|lines|`.

This PR restores a **proportional / 丝滑** wheel feel while remaining **history-safe**.

### Key choice

| Option | Result |
|--------|--------|
| Bare ArrowUp/Down | **Rejected** — Grok binds these to prompt input-history recall |
| SGR wheel | Ignored by these agents under AO/ConPTY |
| PageUp/PageDown only (#3540) | Works, but one key = one full viewport → jumpy |
| **Grok Ctrl+K / Ctrl+J** | **Chosen for grok** — documented line scroll; Ctrl+J is LF (`\n`), distinct from Enter CR (`\r`) |
| **OpenCode Ctrl+Alt+Y / Ctrl+Alt+E** | **Chosen for opencode/kilocode** — default `messages_line_up/down` |
| Generic alt-buffer fallback | Still one PageUp/PageDown per event (direction only) |

### Behavior

- **grok**: one Ctrl+K/J per scrolled line (small rolls move a little, large flicks farther)
- **opencode / kilocode**: one Ctrl+Alt+Y/E per line
- Unchanged: Ctrl/Cmd+wheel zoom, normal-buffer `term.scrollLines`, Unix mux SGR path

### Relationship to #3540

- Branch is **#3540 tip + this proportional commit** (same files: `XtermTerminal` / `TerminalPane`).
- This PR **supersedes / improves** #3540 for wheel feel while keeping the history-safe design.
- Suggested review order: review #3540 first as the baseline, then this; **or** review/merge this alone and close #3540 as fully replaced.
- Do **not** merge both as independent stacks without reconciling — they touch the same paths.

## Test plan

- [x] `npm test -- src/renderer/components/XtermTerminal.test.tsx src/renderer/components/TerminalPane.test.tsx` (78 passed on source branch)
- [x] Manual: Grok on Windows — wheel moves transcript gradually, does **not** recall prompt history
- [x] Manual: opencode/kilocode still scroll transcript via wheel

## Notes

- Frontend-only
- Fork tracking PR: https://github.com/AllBeingsFuture/agent-orchestrator/pull/2