### PR TITLE
Revamping browser annotation and adding multi-element select on shift toggle 

### DIFF
--- a/frontend/e2e/resize-clamp.spec.ts
+++ b/frontend/e2e/resize-clamp.spec.ts
@@ -59,7 +59,7 @@ test("inspector drag stops at minSize instead of collapsing; buttons still toggl
 	const y = separatorBox.y + separatorBox.height / 2;
 
 	// Drag the separator all the way to the right edge: the rail must clamp at
-	// its 22% minSize, not snap away.
+	// its 30% minSize, not snap away.
 	await dragPointer(
 		page,
 		{ x: separatorBox.x + separatorBox.width / 2, y },
@@ -69,7 +69,7 @@ test("inspector drag stops at minSize instead of collapsing; buttons still toggl
 	await expect(inspector).toBeVisible();
 	const inspectorBox = await inspector.boundingBox();
 	if (!inspectorBox) throw new Error("inspector hidden after drag");
-	expect(inspectorBox.width / groupBox.width).toBeGreaterThan(0.2);
+	expect(inspectorBox.width / groupBox.width).toBeGreaterThan(0.28);
 
 	// The explicit control still collapses…
 	await page.getByRole("button", { name: "Close inspector panel" }).click();

--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -187,8 +187,11 @@ describe("annotate preload", () => {
 		expect(fontMocks.families).toContain("Geist Mono Variable");
 		expect(fontMocks.add).toHaveBeenCalledTimes(2);
 		expect(promptMeta).not.toBeNull();
-		expect(promptMeta!.textContent).toContain("Ctrl + Enter to send");
-		expect(promptMeta!.textContent).toContain("Esc to cancel");
+		expect(promptMeta).toHaveAttribute("aria-label", "Command or Control plus Enter to send. Escape to cancel.");
+		expect(Array.from(promptMeta!.querySelectorAll("kbd"), (key) => key.textContent)).toEqual([
+			"⌘/Ctrl + Enter",
+			"Esc",
+		]);
 		expect(root.querySelector('[data-action="cancel"]')).toBeNull();
 		expect(primaryAction).toBeTruthy();
 		expect(primaryAction?.disabled).toBe(true);
@@ -213,5 +216,31 @@ describe("annotate preload", () => {
 
 		expect(electronMocks.send).toHaveBeenCalledWith("browser:annotation:cancel", { reason: "escape" });
 		expect(document.querySelector("[data-ao-annotation-root]")).toBeNull();
+	});
+
+	it("reflows and repositions an open prompt when the browser viewport narrows", () => {
+		const originalWidth = window.innerWidth;
+		const originalVisualViewport = window.visualViewport;
+		const first = elementWithBounds("first", { left: 700, top: 24, width: 120, height: 40 });
+
+		dispatchPageEvent(first, "click");
+		const root = overlayRoot();
+		const textarea = root.querySelector<HTMLTextAreaElement>("textarea")!;
+		const form = root.querySelector<HTMLFormElement>("form")!;
+		textarea.value = "Keep this feedback while resizing.";
+
+		Object.defineProperty(window, "innerWidth", { configurable: true, value: 520 });
+		Object.defineProperty(window, "visualViewport", {
+			configurable: true,
+			value: { width: 320, height: window.innerHeight },
+		});
+		window.dispatchEvent(new Event("resize"));
+
+		expect(form.style.width).toBe("292px");
+		expect(form.style.left).toBe("14px");
+		expect(textarea.value).toBe("Keep this feedback while resizing.");
+
+		Object.defineProperty(window, "innerWidth", { configurable: true, value: originalWidth });
+		Object.defineProperty(window, "visualViewport", { configurable: true, value: originalVisualViewport });
 	});
 });

--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -193,7 +193,9 @@ describe("annotate preload", () => {
 		expect(textarea).not.toBeNull();
 		expect(textarea).toHaveAttribute("rows", "1");
 		expect(textarea).toHaveAttribute("placeholder", "Describe the change…");
-		expect(root.querySelector("style")?.textContent).toContain("max-height: 104px");
+		expect(root.querySelector("style")?.textContent).toContain(
+			"max-height: var(--ao-prompt-textarea-max-height, 350px)",
+		);
 
 		textarea!.value = "Make this button easier to notice.";
 		textarea!.dispatchEvent(
@@ -204,6 +206,48 @@ describe("annotate preload", () => {
 			"browser:annotation:submit",
 			expect.objectContaining({ instruction: "Make this button easier to notice." }),
 		);
+	});
+
+	it("grows long comments to a viewport-aware limit with invisible scrolling", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+		dispatchPageEvent(first, "click");
+
+		const root = overlayRoot();
+		const form = root.querySelector<HTMLFormElement>("form")!;
+		const textarea = root.querySelector<HTMLTextAreaElement>("textarea")!;
+		Object.defineProperty(textarea, "scrollHeight", { configurable: true, value: 900 });
+		textarea.value = "A very long annotation";
+		textarea.dispatchEvent(new Event("input", { bubbles: true }));
+
+		expect(form).toHaveClass("prompt--expanded");
+		expect(textarea.style.height).toBe("312px");
+		expect(textarea.style.overflowY).toBe("auto");
+		expect(form.style.getPropertyValue("--ao-prompt-textarea-max-height")).toBe("312px");
+		expect(root.querySelector("style")?.textContent).toContain("padding: 6px 9px");
+		expect(root.querySelector("style")?.textContent).toContain("padding-bottom: 43px");
+		expect(root.querySelector("style")?.textContent).toContain(".prompt--expanded::after");
+		expect(root.querySelector("style")?.textContent).toContain("scrollbar-width: none");
+		expect(root.querySelector("style")?.textContent).toContain("textarea::-webkit-scrollbar");
+	});
+
+	it("uses the room above for a selected element near the viewport bottom", () => {
+		const originalHeight = window.innerHeight;
+		Object.defineProperty(window, "innerHeight", { configurable: true, value: 500 });
+		const first = elementWithBounds("first", { left: 12, top: 420, width: 120, height: 40 });
+		dispatchPageEvent(first, "click");
+
+		const root = overlayRoot();
+		const form = root.querySelector<HTMLFormElement>("form")!;
+		const textarea = root.querySelector<HTMLTextAreaElement>("textarea")!;
+		Object.defineProperty(textarea, "scrollHeight", { configurable: true, value: 900 });
+		textarea.value = "A very long annotation";
+		textarea.dispatchEvent(new Event("input", { bubbles: true }));
+
+		expect(form).toHaveClass("prompt--expanded");
+		expect(textarea.style.height).toBe("312px");
+		expect(Number.parseFloat(form.style.top)).toBeLessThan(420);
+
+		Object.defineProperty(window, "innerHeight", { configurable: true, value: originalHeight });
 	});
 
 	it("keeps prompt controls active for escape", () => {

--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -196,6 +196,7 @@ describe("annotate preload", () => {
 		expect(primaryAction).toBeTruthy();
 		expect(primaryAction?.disabled).toBe(true);
 		expect(textarea).not.toBeNull();
+		expect(root.querySelector("style")?.textContent).toContain("@media (max-width: 420px)");
 
 		textarea!.value = "Make this button easier to notice.";
 		textarea!.dispatchEvent(

--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -174,15 +174,13 @@ describe("annotate preload", () => {
 		dispatchPageEvent(first, "click");
 
 		const root = overlayRoot();
-		const header = root.querySelector<HTMLElement>(".prompt__header");
 		const promptMeta = root.querySelector(".prompt__meta");
 		const textarea = root.querySelector<HTMLTextAreaElement>("textarea");
 		const primaryAction = Array.from(root.querySelectorAll<HTMLButtonElement>("button")).find(
-			(button) => button.textContent?.trim() === "Send feedback" && button.type === "submit",
+			(button) => button.textContent?.trim() === "Send" && button.type === "submit",
 		);
 
-		expect(header?.textContent).toBe("Annotate on selected components");
-		expect(header?.title).toBe("button#first");
+		expect(root.querySelector(".prompt__header")).toBeNull();
 		expect(fontMocks.families).toContain("Geist Variable");
 		expect(fontMocks.families).toContain("Geist Mono Variable");
 		expect(fontMocks.add).toHaveBeenCalledTimes(2);

--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -168,33 +168,32 @@ describe("annotate preload", () => {
 		expect(payload.context.selector).toBe("button#first");
 	});
 
-	it("renders the refined prompt affordances and submits from the primary action", () => {
+	it("renders a compact auto-growing prompt and submits from the embedded action", () => {
 		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
 
 		dispatchPageEvent(first, "click");
 
 		const root = overlayRoot();
-		const promptMeta = root.querySelector(".prompt__meta");
+		const form = root.querySelector<HTMLFormElement>("form");
 		const textarea = root.querySelector<HTMLTextAreaElement>("textarea");
-		const primaryAction = Array.from(root.querySelectorAll<HTMLButtonElement>("button")).find(
-			(button) => button.textContent?.trim() === "Send" && button.type === "submit",
-		);
+		const primaryAction = root.querySelector<HTMLButtonElement>('button[type="submit"]');
 
 		expect(root.querySelector(".prompt__header")).toBeNull();
 		expect(fontMocks.families).toContain("Geist Variable");
 		expect(fontMocks.families).toContain("Geist Mono Variable");
 		expect(fontMocks.add).toHaveBeenCalledTimes(2);
-		expect(promptMeta).not.toBeNull();
-		expect(promptMeta).toHaveAttribute("aria-label", "Command or Control plus Enter to send. Escape to cancel.");
-		expect(Array.from(promptMeta!.querySelectorAll("kbd"), (key) => key.textContent)).toEqual([
-			"⌘/Ctrl + Enter",
-			"Esc",
-		]);
+		expect(form).toHaveAttribute("aria-label", "Annotate selection");
+		expect(root.querySelector(".prompt__meta")).toBeNull();
+		expect(root.querySelector(".prompt__footer")).toBeNull();
 		expect(root.querySelector('[data-action="cancel"]')).toBeNull();
 		expect(primaryAction).toBeTruthy();
+		expect(primaryAction).toHaveAttribute("aria-label", "Send annotation");
+		expect(primaryAction).toHaveAttribute("title", "Send (⌘/Ctrl + Enter)");
 		expect(primaryAction?.disabled).toBe(true);
 		expect(textarea).not.toBeNull();
-		expect(root.querySelector("style")?.textContent).toContain("@media (max-width: 420px)");
+		expect(textarea).toHaveAttribute("rows", "1");
+		expect(textarea).toHaveAttribute("placeholder", "Describe the change…");
+		expect(root.querySelector("style")?.textContent).toContain("max-height: 104px");
 
 		textarea!.value = "Make this button easier to notice.";
 		textarea!.dispatchEvent(

--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -99,6 +99,18 @@ function highlightStyle(): CSSStyleDeclaration {
 	return highlight.style;
 }
 
+function shiftKeyDown(repeat = false): void {
+	document.dispatchEvent(new KeyboardEvent("keydown", { key: "Shift", bubbles: true, cancelable: true, repeat }));
+}
+
+function selectionBoxes(): HTMLDivElement[] {
+	return Array.from(overlayRoot().querySelectorAll<HTMLDivElement>(".selections .highlight--selected"));
+}
+
+function promptForm(): HTMLFormElement | null {
+	return overlayRoot().querySelector<HTMLFormElement>("form");
+}
+
 function submitPrompt(instruction: string): BrowserAnnotationPageSubmitPayload {
 	const root = overlayRoot();
 	const textarea = root.querySelector<HTMLTextAreaElement>("textarea");
@@ -165,7 +177,9 @@ describe("annotate preload", () => {
 		const payload = submitPrompt("Make this button blue.");
 
 		expect(payload.instruction).toBe("Make this button blue.");
-		expect(payload.context.selector).toBe("button#first");
+		expect(payload.selection.kind).toBe("element");
+		if (payload.selection.kind !== "element") throw new Error("expected an element selection");
+		expect(payload.selection.context.selector).toBe("button#first");
 	});
 
 	it("renders a compact auto-growing prompt and submits from the embedded action", () => {
@@ -284,5 +298,66 @@ describe("annotate preload", () => {
 
 		Object.defineProperty(window, "innerWidth", { configurable: true, value: originalWidth });
 		Object.defineProperty(window, "visualViewport", { configurable: true, value: originalVisualViewport });
+	});
+
+	it("accumulates a multi-selection on Shift and toggles a re-clicked element back out", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+		const second = elementWithBounds("second", { left: 240, top: 160, width: 80, height: 30 });
+
+		shiftKeyDown();
+		dispatchPageEvent(first, "click");
+		dispatchPageEvent(second, "click");
+		expect(selectionBoxes()).toHaveLength(2);
+
+		dispatchPageEvent(first, "click");
+		expect(selectionBoxes()).toHaveLength(1);
+		expect(selectionBoxes()[0].style.left).toBe("240px");
+		expect(promptForm()).toBeNull();
+	});
+
+	it("opens the prompt with every selected element when Shift is pressed again", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+		const second = elementWithBounds("second", { left: 240, top: 160, width: 80, height: 30 });
+
+		shiftKeyDown();
+		dispatchPageEvent(first, "click");
+		dispatchPageEvent(second, "click");
+		shiftKeyDown();
+
+		const payload = submitPrompt("Align these two.");
+
+		expect(payload.selection.kind).toBe("elements");
+		if (payload.selection.kind !== "elements") throw new Error("expected an elements selection");
+		expect(payload.selection.contexts.map((context) => context.selector)).toEqual(["button#first", "button#second"]);
+	});
+
+	it("does not open the prompt when Shift is pressed again with nothing selected", () => {
+		shiftKeyDown();
+		shiftKeyDown();
+
+		expect(promptForm()).toBeNull();
+		expect(electronMocks.send).not.toHaveBeenCalledWith("browser:annotation:submit", expect.anything());
+	});
+
+	it("ignores a held-down Shift key repeat so multi-select mode does not toggle off early", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+
+		shiftKeyDown();
+		shiftKeyDown(true);
+		dispatchPageEvent(first, "click");
+
+		expect(selectionBoxes()).toHaveLength(1);
+		expect(promptForm()).toBeNull();
+	});
+
+	it("cancels an in-progress multi-selection on Escape", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+
+		shiftKeyDown();
+		dispatchPageEvent(first, "click");
+		document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+
+		expect(electronMocks.send).toHaveBeenCalledWith("browser:annotation:cancel", { reason: "escape" });
+		expect(document.querySelector("[data-ao-annotation-root]")).toBeNull();
 	});
 });

--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -19,6 +19,31 @@ vi.mock("electron", () => ({
 	},
 }));
 
+// jsdom implements neither FontFace nor document.fonts; stub both so
+// registerFonts() runs for real instead of short-circuiting on the
+// "not supported" guard, so tests exercise the actual loading path.
+const fontMocks = vi.hoisted(() => ({
+	families: [] as string[],
+	add: vi.fn(),
+}));
+
+class MockFontFace {
+	family: string;
+	constructor(family: string) {
+		this.family = family;
+		fontMocks.families.push(family);
+	}
+	load(): Promise<MockFontFace> {
+		return Promise.resolve(this);
+	}
+}
+
+vi.stubGlobal("FontFace", MockFontFace);
+Object.defineProperty(document, "fonts", {
+	configurable: true,
+	value: { add: fontMocks.add },
+});
+
 await import("./annotate-preload");
 
 type Bounds = {
@@ -90,6 +115,8 @@ describe("annotate preload", () => {
 	beforeEach(() => {
 		document.body.innerHTML = "";
 		electronMocks.send.mockClear();
+		fontMocks.add.mockClear();
+		fontMocks.families.length = 0;
 		setAnnotationMode(true);
 	});
 
@@ -141,17 +168,46 @@ describe("annotate preload", () => {
 		expect(payload.context.selector).toBe("button#first");
 	});
 
-	it("keeps prompt controls active for cancel and escape", () => {
+	it("renders the refined prompt affordances and submits from the primary action", () => {
 		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
 
 		dispatchPageEvent(first, "click");
-		overlayRoot().querySelector<HTMLButtonElement>('[data-action="cancel"]')?.click();
 
-		expect(electronMocks.send).toHaveBeenCalledWith("browser:annotation:cancel", { reason: "cancel" });
-		expect(document.querySelector("[data-ao-annotation-root]")).toBeNull();
+		const root = overlayRoot();
+		const header = root.querySelector<HTMLElement>(".prompt__header");
+		const promptMeta = root.querySelector(".prompt__meta");
+		const textarea = root.querySelector<HTMLTextAreaElement>("textarea");
+		const primaryAction = Array.from(root.querySelectorAll<HTMLButtonElement>("button")).find(
+			(button) => button.textContent?.trim() === "Send feedback" && button.type === "submit",
+		);
 
-		electronMocks.send.mockClear();
-		setAnnotationMode(true);
+		expect(header?.textContent).toBe("Annotate on selected components");
+		expect(header?.title).toBe("button#first");
+		expect(fontMocks.families).toContain("Geist Variable");
+		expect(fontMocks.families).toContain("Geist Mono Variable");
+		expect(fontMocks.add).toHaveBeenCalledTimes(2);
+		expect(promptMeta).not.toBeNull();
+		expect(promptMeta!.textContent).toContain("Ctrl + Enter to send");
+		expect(promptMeta!.textContent).toContain("Esc to cancel");
+		expect(root.querySelector('[data-action="cancel"]')).toBeNull();
+		expect(primaryAction).toBeTruthy();
+		expect(primaryAction?.disabled).toBe(true);
+		expect(textarea).not.toBeNull();
+
+		textarea!.value = "Make this button easier to notice.";
+		textarea!.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true, bubbles: true, cancelable: true }),
+		);
+
+		expect(electronMocks.send).toHaveBeenCalledWith(
+			"browser:annotation:submit",
+			expect.objectContaining({ instruction: "Make this button easier to notice." }),
+		);
+	});
+
+	it("keeps prompt controls active for escape", () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+
 		dispatchPageEvent(first, "click");
 		document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
 

--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -198,7 +198,8 @@ describe("annotate preload", () => {
 		expect(fontMocks.add).toHaveBeenCalledTimes(2);
 		expect(form).toHaveAttribute("aria-label", "Annotate selection");
 		expect(root.querySelector(".prompt__meta")).toBeNull();
-		expect(root.querySelector(".prompt__footer")).toBeNull();
+		expect(root.querySelector(".prompt__shortcuts")?.textContent).toContain("⌘/Ctrl+EnterSend");
+		expect(root.querySelector(".prompt__shortcuts")?.textContent).toContain("EscCancel");
 		expect(root.querySelector('[data-action="cancel"]')).toBeNull();
 		expect(primaryAction).toBeTruthy();
 		expect(primaryAction).toHaveAttribute("aria-label", "Send annotation");
@@ -238,8 +239,8 @@ describe("annotate preload", () => {
 		expect(textarea.style.overflowY).toBe("auto");
 		expect(form.style.getPropertyValue("--ao-prompt-textarea-max-height")).toBe("312px");
 		expect(root.querySelector("style")?.textContent).toContain("padding: 6px 9px");
-		expect(root.querySelector("style")?.textContent).toContain("padding-bottom: 43px");
-		expect(root.querySelector("style")?.textContent).toContain(".prompt--expanded::after");
+		expect(root.querySelector("style")?.textContent).toContain("padding: 5px 5px 43px");
+		expect(root.querySelector("style")?.textContent).toContain(".prompt::after");
 		expect(root.querySelector("style")?.textContent).toContain("scrollbar-width: none");
 		expect(root.querySelector("style")?.textContent).toContain("textarea::-webkit-scrollbar");
 	});

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -7,11 +7,14 @@ import {
 	type BrowserAnnotationContext,
 	type BrowserAnnotationPageSubmitPayload,
 } from "./shared/browser-annotations";
-import { promptPositionForRect } from "./shared/browser-annotation-overlay";
+import { promptPositionForRect, type AnnotationRectLike } from "./shared/browser-annotation-overlay";
 
 let enabled = false;
 let selectedElement: Element | null = null;
 let selectedContext: BrowserAnnotationContext | null = null;
+let multiSelectActive = false;
+let multiSelectElements: Element[] = [];
+let multiSelectContexts: BrowserAnnotationContext[] | null = null;
 let host: HTMLDivElement | null = null;
 let shadow: ShadowRoot | null = null;
 let viewportResizeObserver: ResizeObserver | null = null;
@@ -39,6 +42,9 @@ function setEnabled(next: boolean, cancelReason: BrowserAnnotationCancelReason):
 	enabled = next;
 	selectedElement = null;
 	selectedContext = null;
+	multiSelectActive = false;
+	multiSelectElements = [];
+	multiSelectContexts = null;
 	if (hintFadeTimer) clearTimeout(hintFadeTimer);
 	if (enabled) {
 		ensureOverlay();
@@ -80,7 +86,7 @@ function removeListeners(): void {
 }
 
 function handlePointerMove(event: PointerEvent): void {
-	if (!enabled || selectedContext || isOverlayEvent(event)) return;
+	if (!enabled || selectedContext || multiSelectContexts || isOverlayEvent(event)) return;
 	const target = annotationTarget(event.target);
 	if (!target || target === selectedElement) return;
 	selectedElement = target;
@@ -90,7 +96,7 @@ function handlePointerMove(event: PointerEvent): void {
 
 function handleClick(event: MouseEvent): void {
 	if (!enabled || isOverlayEvent(event)) return;
-	if (selectedContext) {
+	if (selectedContext || multiSelectContexts) {
 		event.preventDefault();
 		event.stopPropagation();
 		event.stopImmediatePropagation();
@@ -101,23 +107,83 @@ function handleClick(event: MouseEvent): void {
 	event.preventDefault();
 	event.stopPropagation();
 	event.stopImmediatePropagation();
+	if (multiSelectActive) {
+		toggleMultiSelectElement(target);
+		return;
+	}
 	selectedElement = target;
 	selectedContext = createBrowserAnnotationContext(target);
 	renderPrompt(target, selectedContext);
 }
 
 function handleKeyDown(event: KeyboardEvent): void {
-	if (!enabled || event.key !== "Escape") return;
+	if (!enabled) return;
+	if (event.key === "Escape") {
+		event.preventDefault();
+		event.stopPropagation();
+		event.stopImmediatePropagation();
+		setEnabled(false, "escape");
+		return;
+	}
+	if (event.key !== "Shift" || event.repeat || selectedContext || multiSelectContexts) return;
 	event.preventDefault();
 	event.stopPropagation();
 	event.stopImmediatePropagation();
-	setEnabled(false, "escape");
+	if (multiSelectActive) {
+		finishMultiSelect();
+	} else {
+		startMultiSelect();
+	}
+}
+
+function startMultiSelect(): void {
+	multiSelectActive = true;
+	multiSelectElements = [];
+	hideHoverHighlight();
+	renderMultiSelections();
+	renderHint();
+}
+
+function finishMultiSelect(): void {
+	multiSelectActive = false;
+	hideHoverHighlight();
+	if (multiSelectElements.length === 0) {
+		renderHint();
+		return;
+	}
+	multiSelectContexts = multiSelectElements.map(createBrowserAnnotationContext);
+	renderMultiPrompt(multiSelectElements, multiSelectContexts);
+}
+
+function toggleMultiSelectElement(target: Element): void {
+	const index = multiSelectElements.indexOf(target);
+	if (index === -1) {
+		multiSelectElements.push(target);
+	} else {
+		multiSelectElements.splice(index, 1);
+	}
+	renderMultiSelections();
+	renderHint();
+}
+
+function hideHoverHighlight(): void {
+	selectedElement = null;
+	const highlight = ensureOverlay().querySelector<HTMLDivElement>(".highlight");
+	if (highlight) highlight.hidden = true;
+}
+
+function currentPromptRect(): AnnotationRectLike | null {
+	if (multiSelectContexts && multiSelectElements.length > 0) return unionRect(multiSelectElements);
+	if (selectedContext && selectedElement) return selectedElement.getBoundingClientRect();
+	return null;
 }
 
 function refreshHighlight(): void {
-	if (!enabled || !selectedElement) return;
-	renderHighlight(selectedElement, Boolean(selectedContext));
-	if (selectedContext) repositionPrompt(selectedElement);
+	if (!enabled) return;
+	if (selectedElement) renderHighlight(selectedElement, Boolean(selectedContext));
+	if (multiSelectElements.length > 0) renderMultiSelections();
+	const rect = currentPromptRect();
+	if (rect) repositionPrompt(rect);
 }
 
 function annotationTarget(target: EventTarget | null): Element | null {
@@ -211,6 +277,13 @@ function ensureOverlay(): ShadowRoot {
 					height 120ms ease,
 					border-color 120ms ease,
 					background 120ms ease;
+			}
+			.highlight--selected {
+				border-color: #74b98a;
+				background: rgba(116, 185, 138, 0.14);
+				box-shadow:
+					0 0 0 1px rgba(255, 255, 255, 0.20),
+					0 12px 36px rgba(0, 0, 0, 0.24);
 			}
 			.prompt {
 				position: fixed;
@@ -365,6 +438,7 @@ function ensureOverlay(): ShadowRoot {
 			}
 			</style>
 		<div class="highlight" hidden></div>
+		<div class="selections"></div>
 		<div class="mount"></div>
 	`;
 	return shadow;
@@ -374,7 +448,7 @@ function renderHint(): void {
 	const root = ensureOverlay();
 	const mount = root.querySelector<HTMLDivElement>(".mount");
 	if (!mount) return;
-	mount.innerHTML = `<div class="hint">Click an element to annotate. Press Esc to cancel.</div>`;
+	mount.innerHTML = `<div class="hint">${hintText()}</div>`;
 
 	if (hintFadeTimer) clearTimeout(hintFadeTimer);
 	hintFadeTimer = setTimeout(() => {
@@ -384,6 +458,17 @@ function renderHint(): void {
 		}
 		hintFadeTimer = null;
 	}, 3000);
+}
+
+function hintText(): string {
+	if (!multiSelectActive) {
+		return "Click an element to annotate, or press Shift to select multiple. Press Esc to cancel.";
+	}
+	if (multiSelectElements.length === 0) {
+		return "Click elements to select them. Press Shift again to finish.";
+	}
+	const count = multiSelectElements.length;
+	return `${count} element${count === 1 ? "" : "s"} selected. Click more, or press Shift to finish.`;
 }
 
 function renderHighlight(element: Element, locked: boolean): void {
@@ -399,8 +484,43 @@ function renderHighlight(element: Element, locked: boolean): void {
 	highlight.style.borderColor = locked ? "#74b98a" : "#4d8dff";
 }
 
+function renderMultiSelections(): void {
+	const root = ensureOverlay();
+	const container = root.querySelector<HTMLDivElement>(".selections");
+	if (!container) return;
+	container.innerHTML = "";
+	for (const element of multiSelectElements) {
+		const rect = element.getBoundingClientRect();
+		const box = document.createElement("div");
+		box.className = "highlight highlight--selected";
+		box.style.left = `${Math.max(0, rect.left)}px`;
+		box.style.top = `${Math.max(0, rect.top)}px`;
+		box.style.width = `${Math.max(0, rect.width)}px`;
+		box.style.height = `${Math.max(0, rect.height)}px`;
+		container.appendChild(box);
+	}
+}
+
 function renderPrompt(element: Element, context: BrowserAnnotationContext): void {
 	renderHighlight(element, true);
+	openPrompt(element.getBoundingClientRect(), (instruction) => ({
+		instruction,
+		selection: { kind: "element", context },
+	}));
+}
+
+function renderMultiPrompt(elements: Element[], contexts: BrowserAnnotationContext[]): void {
+	renderMultiSelections();
+	openPrompt(unionRect(elements), (instruction) => ({
+		instruction,
+		selection: { kind: "elements", contexts },
+	}));
+}
+
+function openPrompt(
+	rect: AnnotationRectLike,
+	buildPayload: (instruction: string) => BrowserAnnotationPageSubmitPayload,
+): void {
 	const root = ensureOverlay();
 	const mount = root.querySelector<HTMLDivElement>(".mount");
 	if (!mount) return;
@@ -416,12 +536,13 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 		</form>
 	`;
 	const form = mount.querySelector<HTMLFormElement>("form")!;
-	repositionPrompt(element);
+	repositionPrompt(rect);
 	const textarea = form.querySelector<HTMLTextAreaElement>("textarea")!;
 	const submitButton = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
 	const updateSubmitState = (): void => {
 		submitButton.disabled = textarea.value.trim().length === 0;
-		repositionPrompt(element);
+		const current = currentPromptRect();
+		if (current) repositionPrompt(current);
 	};
 	const submitAnnotation = (): boolean => {
 		const instruction = textarea.value.trim();
@@ -429,8 +550,7 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 			textarea.focus();
 			return false;
 		}
-		const payload: BrowserAnnotationPageSubmitPayload = { instruction, context };
-		ipcRenderer.send("browser:annotation:submit", payload);
+		ipcRenderer.send("browser:annotation:submit", buildPayload(instruction));
 		setEnabled(false, "disabled");
 		return true;
 	};
@@ -462,9 +582,8 @@ function currentViewport(): { width: number; height: number } {
 	};
 }
 
-function setPromptHeightLimit(form: HTMLFormElement, element: Element, chromeHeight: number): number {
+function setPromptHeightLimit(form: HTMLFormElement, rect: AnnotationRectLike, chromeHeight: number): number {
 	const viewportHeight = currentViewport().height;
-	const rect = element.getBoundingClientRect();
 	const spaceAbove = rect.top - PROMPT_GAP - PROMPT_GUTTER;
 	const spaceBelow = viewportHeight - PROMPT_GUTTER - rect.bottom - PROMPT_GAP;
 	const availablePromptHeight = Math.max(spaceAbove, spaceBelow);
@@ -477,7 +596,7 @@ function setPromptHeightLimit(form: HTMLFormElement, element: Element, chromeHei
 	return textareaMaxHeight;
 }
 
-function repositionPrompt(element: Element): void {
+function repositionPrompt(rect: AnnotationRectLike): void {
 	const form = shadow?.querySelector<HTMLFormElement>(".prompt");
 	if (!form) return;
 	const { width: viewportWidth, height: viewportHeight } = currentViewport();
@@ -489,13 +608,13 @@ function repositionPrompt(element: Element): void {
 		const expanded = textarea.scrollHeight > TEXTAREA_MIN_HEIGHT;
 		form.classList.toggle("prompt--expanded", expanded);
 		const chromeHeight = expanded ? PROMPT_EXPANDED_CHROME_HEIGHT : PROMPT_COMPACT_CHROME_HEIGHT;
-		const textareaMaxHeight = setPromptHeightLimit(form, element, chromeHeight);
+		const textareaMaxHeight = setPromptHeightLimit(form, rect, chromeHeight);
 		const height = Math.min(textareaMaxHeight, Math.max(TEXTAREA_MIN_HEIGHT, textarea.scrollHeight));
 		textarea.style.height = `${height}px`;
 		textarea.style.overflowY = textarea.scrollHeight > textareaMaxHeight ? "auto" : "hidden";
 	}
 	const measuredHeight = form.getBoundingClientRect().height;
-	const { left, top } = promptPosition(element.getBoundingClientRect(), promptWidth, measuredHeight || 44, {
+	const { left, top } = promptPosition(rect, promptWidth, measuredHeight || 44, {
 		width: viewportWidth,
 		height: viewportHeight,
 	});
@@ -504,7 +623,7 @@ function repositionPrompt(element: Element): void {
 }
 
 function promptPosition(
-	rect: DOMRect,
+	rect: AnnotationRectLike,
 	promptWidth: number,
 	promptHeight: number,
 	viewport = { width: window.innerWidth, height: window.innerHeight },
@@ -517,6 +636,15 @@ function promptPosition(
 		gutter: PROMPT_GUTTER,
 		gap: PROMPT_GAP,
 	});
+}
+
+function unionRect(elements: Element[]): AnnotationRectLike {
+	const rects = elements.map((element) => element.getBoundingClientRect());
+	return {
+		left: Math.min(...rects.map((rect) => rect.left)),
+		top: Math.min(...rects.map((rect) => rect.top)),
+		bottom: Math.max(...rects.map((rect) => rect.bottom)),
+	};
 }
 
 function cleanupOverlay(): void {

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -23,7 +23,7 @@ let hintFadeTimer: NodeJS.Timeout | null = null;
 const PROMPT_GUTTER = 14;
 const PROMPT_GAP = 10;
 const PROMPT_MAX_HEIGHT = 360;
-const PROMPT_COMPACT_CHROME_HEIGHT = 10;
+const PROMPT_COMPACT_CHROME_HEIGHT = 48;
 const PROMPT_EXPANDED_CHROME_HEIGHT = 48;
 const TEXTAREA_MIN_HEIGHT = 32;
 
@@ -294,7 +294,7 @@ function ensureOverlay(): ShadowRoot {
 				background: var(--ao-surface);
 				color: var(--ao-foreground);
 				box-shadow: 0 10px 30px rgba(0, 0, 0, 0.38);
-				padding: 5px;
+				padding: 5px 5px 43px;
 				font: 13px/1.5 var(--ao-font-sans);
 				font-weight: 400;
 				pointer-events: auto;
@@ -332,13 +332,7 @@ function ensureOverlay(): ShadowRoot {
 				scrollbar-width: none;
 				-ms-overflow-style: none;
 			}
-			.prompt:not(.prompt--expanded) textarea {
-				padding-right: 40px;
-			}
-			.prompt--expanded {
-				padding-bottom: 43px;
-			}
-			.prompt--expanded::after {
+			.prompt::after {
 				content: "";
 				position: absolute;
 				left: 0;
@@ -353,6 +347,39 @@ function ensureOverlay(): ShadowRoot {
 			}
 			.prompt textarea::placeholder {
 				color: var(--ao-passive);
+			}
+			.prompt__shortcuts {
+				position: absolute;
+				left: 13px;
+				bottom: 10px;
+				display: flex;
+				align-items: center;
+				gap: 13px;
+				color: var(--ao-passive);
+				font-size: 10px;
+				line-height: 1;
+				pointer-events: none;
+			}
+			.prompt__shortcut {
+				display: inline-flex;
+				align-items: center;
+				gap: 4px;
+				white-space: nowrap;
+			}
+			.prompt__shortcut kbd {
+				display: inline-flex;
+				min-width: 18px;
+				height: 18px;
+				box-sizing: border-box;
+				align-items: center;
+				justify-content: center;
+				border: 1px solid color-mix(in oklch, var(--ao-border) 85%, transparent);
+				border-radius: 5px;
+				background: var(--ao-input);
+				color: color-mix(in oklch, var(--ao-foreground) 72%, transparent);
+				padding: 0 5px;
+				font: 9px/1 var(--ao-font-mono);
+				box-shadow: inset 0 -1px 0 color-mix(in oklch, var(--ao-border) 80%, transparent);
 			}
 			.prompt button[type="submit"] {
 				position: absolute;
@@ -527,6 +554,10 @@ function openPrompt(
 	mount.innerHTML = `
 		<form class="prompt" aria-label="Annotate selection">
 			<textarea rows="1" aria-label="Annotation request" placeholder="Describe the change…"></textarea>
+			<div class="prompt__shortcuts" aria-hidden="true">
+				<span class="prompt__shortcut"><kbd>⌘/Ctrl</kbd><span>+</span><kbd>Enter</kbd><span>Send</span></span>
+				<span class="prompt__shortcut"><kbd>Esc</kbd><span>Cancel</span></span>
+			</div>
 			<button disabled type="submit" aria-label="Send annotation" title="Send (⌘/Ctrl + Enter)">
 				<svg viewBox="0 0 24 24" aria-hidden="true">
 					<path d="M12 19V5"></path>

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -16,6 +16,13 @@ let host: HTMLDivElement | null = null;
 let shadow: ShadowRoot | null = null;
 let viewportResizeObserver: ResizeObserver | null = null;
 
+const PROMPT_GUTTER = 14;
+const PROMPT_GAP = 10;
+const PROMPT_MAX_HEIGHT = 360;
+const PROMPT_COMPACT_CHROME_HEIGHT = 10;
+const PROMPT_EXPANDED_CHROME_HEIGHT = 48;
+const TEXTAREA_MIN_HEIGHT = 32;
+
 ipcRenderer.on("browser:annotation:setMode", (_event, input: { enabled?: boolean }) => {
 	setEnabled(Boolean(input?.enabled), "disabled");
 });
@@ -232,7 +239,7 @@ function ensureOverlay(): ShadowRoot {
 				width: 100%;
 				height: 32px;
 				min-height: 32px;
-				max-height: 104px;
+				max-height: var(--ao-prompt-textarea-max-height, 350px);
 				box-sizing: border-box;
 				resize: none;
 				border: 0;
@@ -240,13 +247,34 @@ function ensureOverlay(): ShadowRoot {
 				background: transparent;
 				color: var(--ao-foreground);
 				caret-color: var(--ao-foreground);
-				padding: 6px 40px 6px 9px;
+				padding: 6px 9px;
 				font-family: var(--ao-font-sans);
 				font-size: var(--ao-text-xs);
 				line-height: 20px;
 				font-weight: 400;
 				outline: none;
 				overflow-y: hidden;
+				scrollbar-width: none;
+				-ms-overflow-style: none;
+			}
+			.prompt:not(.prompt--expanded) textarea {
+				padding-right: 40px;
+			}
+			.prompt--expanded {
+				padding-bottom: 43px;
+			}
+			.prompt--expanded::after {
+				content: "";
+				position: absolute;
+				left: 0;
+				right: 0;
+				bottom: 42px;
+				height: 1px;
+				background: color-mix(in oklch, var(--ao-border) 85%, transparent);
+				pointer-events: none;
+			}
+			.prompt textarea::-webkit-scrollbar {
+				display: none;
 			}
 			.prompt textarea::placeholder {
 				color: var(--ao-passive);
@@ -369,16 +397,9 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 	repositionPrompt(element);
 	const textarea = form.querySelector<HTMLTextAreaElement>("textarea")!;
 	const submitButton = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
-	const resizeTextarea = (): void => {
-		textarea.style.height = "0px";
-		const height = Math.min(104, Math.max(32, textarea.scrollHeight));
-		textarea.style.height = `${height}px`;
-		textarea.style.overflowY = textarea.scrollHeight > 104 ? "auto" : "hidden";
-		repositionPrompt(element);
-	};
 	const updateSubmitState = (): void => {
 		submitButton.disabled = textarea.value.trim().length === 0;
-		resizeTextarea();
+		repositionPrompt(element);
 	};
 	const submitAnnotation = (): boolean => {
 		const instruction = textarea.value.trim();
@@ -408,17 +429,49 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 	setTimeout(() => textarea.focus(), 0);
 }
 
-function repositionPrompt(element: Element): void {
-	const form = shadow?.querySelector<HTMLFormElement>(".prompt");
-	if (!form) return;
+function currentViewport(): { width: number; height: number } {
 	const documentWidth = document.documentElement.clientWidth;
 	const documentHeight = document.documentElement.clientHeight;
 	const layoutWidth = Math.min(window.innerWidth, documentWidth > 0 ? documentWidth : window.innerWidth);
 	const layoutHeight = Math.min(window.innerHeight, documentHeight > 0 ? documentHeight : window.innerHeight);
-	const viewportWidth = Math.min(layoutWidth, window.visualViewport?.width ?? layoutWidth);
-	const viewportHeight = Math.min(layoutHeight, window.visualViewport?.height ?? layoutHeight);
+	return {
+		width: Math.min(layoutWidth, window.visualViewport?.width ?? layoutWidth),
+		height: Math.min(layoutHeight, window.visualViewport?.height ?? layoutHeight),
+	};
+}
+
+function setPromptHeightLimit(form: HTMLFormElement, element: Element, chromeHeight: number): number {
+	const viewportHeight = currentViewport().height;
+	const rect = element.getBoundingClientRect();
+	const spaceAbove = rect.top - PROMPT_GAP - PROMPT_GUTTER;
+	const spaceBelow = viewportHeight - PROMPT_GUTTER - rect.bottom - PROMPT_GAP;
+	const availablePromptHeight = Math.max(spaceAbove, spaceBelow);
+	const promptMaxHeight = Math.max(
+		TEXTAREA_MIN_HEIGHT + chromeHeight,
+		Math.min(PROMPT_MAX_HEIGHT, availablePromptHeight),
+	);
+	const textareaMaxHeight = promptMaxHeight - chromeHeight;
+	form.style.setProperty("--ao-prompt-textarea-max-height", `${textareaMaxHeight}px`);
+	return textareaMaxHeight;
+}
+
+function repositionPrompt(element: Element): void {
+	const form = shadow?.querySelector<HTMLFormElement>(".prompt");
+	if (!form) return;
+	const { width: viewportWidth, height: viewportHeight } = currentViewport();
 	const promptWidth = Math.max(0, Math.min(360, viewportWidth - 28));
 	form.style.width = `${promptWidth}px`;
+	const textarea = form.querySelector<HTMLTextAreaElement>("textarea");
+	if (textarea) {
+		textarea.style.height = "0px";
+		const expanded = textarea.scrollHeight > TEXTAREA_MIN_HEIGHT;
+		form.classList.toggle("prompt--expanded", expanded);
+		const chromeHeight = expanded ? PROMPT_EXPANDED_CHROME_HEIGHT : PROMPT_COMPACT_CHROME_HEIGHT;
+		const textareaMaxHeight = setPromptHeightLimit(form, element, chromeHeight);
+		const height = Math.min(textareaMaxHeight, Math.max(TEXTAREA_MIN_HEIGHT, textarea.scrollHeight));
+		textarea.style.height = `${height}px`;
+		textarea.style.overflowY = textarea.scrollHeight > textareaMaxHeight ? "auto" : "hidden";
+	}
 	const measuredHeight = form.getBoundingClientRect().height;
 	const { left, top } = promptPosition(element.getBoundingClientRect(), promptWidth, measuredHeight || 44, {
 		width: viewportWidth,
@@ -439,8 +492,8 @@ function promptPosition(
 		height: viewport.height,
 		promptWidth,
 		promptHeight,
-		gutter: 14,
-		gap: 10,
+		gutter: PROMPT_GUTTER,
+		gap: PROMPT_GAP,
 	});
 }
 

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -15,6 +15,7 @@ let selectedElement: Element | null = null;
 let selectedContext: BrowserAnnotationContext | null = null;
 let host: HTMLDivElement | null = null;
 let shadow: ShadowRoot | null = null;
+let viewportResizeObserver: ResizeObserver | null = null;
 
 ipcRenderer.on("browser:annotation:setMode", (_event, input: { enabled?: boolean }) => {
 	setEnabled(Boolean(input?.enabled), "disabled");
@@ -49,6 +50,12 @@ function installListeners(): void {
 	document.addEventListener("keydown", handleKeyDown, true);
 	window.addEventListener("scroll", refreshHighlight, true);
 	window.addEventListener("resize", refreshHighlight, true);
+	window.visualViewport?.addEventListener("resize", refreshHighlight);
+	window.visualViewport?.addEventListener("scroll", refreshHighlight);
+	if (typeof ResizeObserver !== "undefined") {
+		viewportResizeObserver = new ResizeObserver(refreshHighlight);
+		viewportResizeObserver.observe(document.documentElement);
+	}
 }
 
 function removeListeners(): void {
@@ -58,6 +65,10 @@ function removeListeners(): void {
 	document.removeEventListener("keydown", handleKeyDown, true);
 	window.removeEventListener("scroll", refreshHighlight, true);
 	window.removeEventListener("resize", refreshHighlight, true);
+	window.visualViewport?.removeEventListener("resize", refreshHighlight);
+	window.visualViewport?.removeEventListener("scroll", refreshHighlight);
+	viewportResizeObserver?.disconnect();
+	viewportResizeObserver = null;
 }
 
 function handlePointerMove(event: PointerEvent): void {
@@ -98,6 +109,7 @@ function handleKeyDown(event: KeyboardEvent): void {
 function refreshHighlight(): void {
 	if (!enabled || !selectedElement) return;
 	renderHighlight(selectedElement, Boolean(selectedContext));
+	if (selectedContext) repositionPrompt(selectedElement);
 }
 
 function annotationTarget(target: EventTarget | null): Element | null {
@@ -259,17 +271,51 @@ function ensureOverlay(): ShadowRoot {
 				margin-top: 8px;
 			}
 			.prompt__meta {
+				display: flex;
 				flex: 1 1 auto;
+				height: var(--ao-control-md);
+				align-items: center;
+				gap: 6px;
 				margin-right: auto;
 				min-width: 0;
-				overflow: hidden;
 				color: var(--ao-passive);
 				font-family: var(--ao-font-sans);
 				font-size: var(--ao-text-xs);
 				line-height: 1.5;
 				font-weight: 400;
+			}
+			.prompt__shortcut {
+				display: inline-flex;
+				height: 100%;
+				align-items: center;
+				gap: 4px;
 				white-space: nowrap;
-				text-overflow: ellipsis;
+			}
+			.prompt__shortcut > span {
+				display: inline-flex;
+				height: 18px;
+				align-items: center;
+				line-height: 1;
+			}
+			.prompt__shortcut + .prompt__shortcut::before {
+				content: "·";
+				color: color-mix(in oklch, var(--ao-passive) 55%, transparent);
+				line-height: 1;
+			}
+			.prompt__shortcut kbd {
+				display: inline-flex;
+				min-height: 18px;
+				align-items: center;
+				justify-content: center;
+				border: 1px solid color-mix(in oklch, var(--ao-passive) 35%, transparent);
+				border-radius: 4px;
+				background: color-mix(in oklch, var(--ao-muted) 55%, transparent);
+				padding: 0 5px;
+				color: color-mix(in oklch, var(--ao-foreground) 78%, transparent);
+				font-family: var(--ao-font-mono);
+				font-size: 10px;
+				line-height: 1;
+				box-shadow: inset 0 -1px 0 color-mix(in oklch, var(--ao-passive) 20%, transparent);
 			}
 			.actions {
 				display: flex;
@@ -374,9 +420,6 @@ function ensureOverlay(): ShadowRoot {
 				.prompt__meta {
 					order: 2;
 					margin-right: 0;
-					overflow: visible;
-					white-space: normal;
-					text-overflow: clip;
 				}
 			}
 			</style>
@@ -411,14 +454,15 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 	const root = ensureOverlay();
 	const mount = root.querySelector<HTMLDivElement>(".mount");
 	if (!mount) return;
-	const rect = element.getBoundingClientRect();
-	const { left, top } = promptPosition(rect);
 	mount.innerHTML = `
-		<form class="prompt" style="left: ${left}px; top: ${top}px;">
+		<form class="prompt">
 			<div class="prompt__header">Annotate on selected components</div>
 			<textarea aria-label="Annotation request" placeholder="Describe to agent what you want to change..."></textarea>
 			<div class="prompt__footer">
-				<div class="prompt__meta">⌘/Ctrl + Enter to send · Esc to cancel</div>
+				<div class="prompt__meta" aria-label="Command or Control plus Enter to send. Escape to cancel.">
+					<span class="prompt__shortcut"><kbd>⌘/Ctrl + Enter</kbd><span>Send</span></span>
+					<span class="prompt__shortcut"><kbd>Esc</kbd><span>Cancel</span></span>
+				</div>
 				<div class="actions">
 					<button disabled type="submit">
 						<svg viewBox="0 0 24 24" aria-hidden="true">
@@ -432,6 +476,7 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 		</form>
 	`;
 	const form = mount.querySelector<HTMLFormElement>("form")!;
+	repositionPrompt(element);
 	const header = form.querySelector<HTMLDivElement>(".prompt__header")!;
 	header.title = elementSummary(context);
 	const textarea = form.querySelector<HTMLTextAreaElement>("textarea")!;
@@ -467,12 +512,37 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 	setTimeout(() => textarea.focus(), 0);
 }
 
-function promptPosition(rect: DOMRect): { left: number; top: number } {
+function repositionPrompt(element: Element): void {
+	const form = shadow?.querySelector<HTMLFormElement>(".prompt");
+	if (!form) return;
+	const documentWidth = document.documentElement.clientWidth;
+	const documentHeight = document.documentElement.clientHeight;
+	const layoutWidth = Math.min(window.innerWidth, documentWidth > 0 ? documentWidth : window.innerWidth);
+	const layoutHeight = Math.min(window.innerHeight, documentHeight > 0 ? documentHeight : window.innerHeight);
+	const viewportWidth = Math.min(layoutWidth, window.visualViewport?.width ?? layoutWidth);
+	const viewportHeight = Math.min(layoutHeight, window.visualViewport?.height ?? layoutHeight);
+	const promptWidth = Math.max(0, Math.min(440, viewportWidth - 28));
+	form.style.width = `${promptWidth}px`;
+	const measuredHeight = form.getBoundingClientRect().height;
+	const { left, top } = promptPosition(element.getBoundingClientRect(), promptWidth, measuredHeight || 178, {
+		width: viewportWidth,
+		height: viewportHeight,
+	});
+	form.style.left = `${left}px`;
+	form.style.top = `${top}px`;
+}
+
+function promptPosition(
+	rect: DOMRect,
+	promptWidth: number,
+	promptHeight: number,
+	viewport = { width: window.innerWidth, height: window.innerHeight },
+): { left: number; top: number } {
 	return promptPositionForRect(rect, {
-		width: window.innerWidth,
-		height: window.innerHeight,
-		promptWidth: Math.min(440, window.innerWidth - 28),
-		promptHeight: 178,
+		width: viewport.width,
+		height: viewport.height,
+		promptWidth,
+		promptHeight,
 		gutter: 14,
 		gap: 10,
 	});

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -15,6 +15,7 @@ let selectedContext: BrowserAnnotationContext | null = null;
 let host: HTMLDivElement | null = null;
 let shadow: ShadowRoot | null = null;
 let viewportResizeObserver: ResizeObserver | null = null;
+let hintFadeTimer: NodeJS.Timeout | null = null;
 
 const PROMPT_GUTTER = 14;
 const PROMPT_GAP = 10;
@@ -38,6 +39,7 @@ function setEnabled(next: boolean, cancelReason: BrowserAnnotationCancelReason):
 	enabled = next;
 	selectedElement = null;
 	selectedContext = null;
+	if (hintFadeTimer) clearTimeout(hintFadeTimer);
 	if (enabled) {
 		ensureOverlay();
 		installListeners();
@@ -326,6 +328,7 @@ function ensureOverlay(): ShadowRoot {
 				position: fixed;
 				left: 12px;
 				bottom: 12px;
+				max-width: calc(100vw - 36px);
 				border-radius: 6px;
 				background: #15171b;
 				color: #c9d1d9;
@@ -334,10 +337,20 @@ function ensureOverlay(): ShadowRoot {
 				box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 				pointer-events: none;
 				animation: prompt-in 140ms ease-out;
+				word-wrap: break-word;
+				overflow-wrap: break-word;
+				white-space: normal;
+			}
+			.hint-fade-out {
+				animation: hint-fade-out 300ms ease-in forwards !important;
 			}
 			@keyframes prompt-in {
 				from { opacity: 0; transform: translateY(4px) scale(0.985); }
 				to { opacity: 1; transform: translateY(0) scale(1); }
+			}
+			@keyframes hint-fade-out {
+				from { opacity: 1; }
+				to { opacity: 0; }
 			}
 			@media (prefers-reduced-motion: reduce) {
 				.highlight,
@@ -362,6 +375,15 @@ function renderHint(): void {
 	const mount = root.querySelector<HTMLDivElement>(".mount");
 	if (!mount) return;
 	mount.innerHTML = `<div class="hint">Click an element to annotate. Press Esc to cancel.</div>`;
+
+	if (hintFadeTimer) clearTimeout(hintFadeTimer);
+	hintFadeTimer = setTimeout(() => {
+		const hintElement = root.querySelector<HTMLDivElement>(".hint");
+		if (hintElement) {
+			hintElement.classList.add("hint-fade-out");
+		}
+		hintFadeTimer = null;
+	}, 3000);
 }
 
 function renderHighlight(element: Element, locked: boolean): void {

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -205,161 +205,89 @@ function ensureOverlay(): ShadowRoot {
 			}
 			.prompt {
 				position: fixed;
-				width: min(440px, calc(100vw - 28px));
+				width: min(360px, calc(100vw - 28px));
 				box-sizing: border-box;
-				border: 1px solid color-mix(in oklch, var(--ao-border) 70%, transparent);
-				border-radius: var(--ao-radius-md);
+				border: 1px solid color-mix(in oklch, var(--ao-border) 85%, transparent);
+				border-radius: 12px;
 				background: var(--ao-surface);
 				color: var(--ao-foreground);
-				box-shadow: 0 18px 52px rgba(0, 0, 0, 0.48);
-				padding: 8px 12px;
+				box-shadow: 0 10px 30px rgba(0, 0, 0, 0.38);
+				padding: 5px;
 				font: 13px/1.5 var(--ao-font-sans);
 				font-weight: 400;
 				pointer-events: auto;
 				animation: prompt-in 140ms ease-out;
+				transition:
+					border-color 120ms ease,
+					box-shadow 120ms ease;
+			}
+			.prompt:focus-within {
+				border-color: color-mix(in oklch, var(--ao-ring) 80%, transparent);
+				box-shadow:
+					0 0 0 3px color-mix(in oklch, var(--ao-ring) 24%, transparent),
+					0 10px 30px rgba(0, 0, 0, 0.38);
 			}
 			.prompt textarea {
 				display: block;
 				width: 100%;
-				min-height: 80px;
+				height: 32px;
+				min-height: 32px;
+				max-height: 104px;
 				box-sizing: border-box;
-				resize: vertical;
-				border: 1px solid var(--ao-input);
-				border-radius: 6px;
-				background: var(--ao-background);
+				resize: none;
+				border: 0;
+				border-radius: 8px;
+				background: transparent;
 				color: var(--ao-foreground);
 				caret-color: var(--ao-foreground);
-				padding: 8px 10px;
+				padding: 6px 40px 6px 9px;
 				font-family: var(--ao-font-sans);
 				font-size: var(--ao-text-xs);
-				line-height: 1.5;
+				line-height: 20px;
 				font-weight: 400;
 				outline: none;
-				transition:
-					border-color 120ms ease,
-					box-shadow 120ms ease,
-					background 120ms ease;
+				overflow-y: hidden;
 			}
 			.prompt textarea::placeholder {
 				color: var(--ao-passive);
 			}
-			.prompt textarea:focus,
-			.prompt textarea:focus-visible {
-				border-color: var(--ao-ring);
-				box-shadow: 0 0 0 3px color-mix(in oklch, var(--ao-ring) 30%, transparent);
-			}
-			.prompt__footer {
-				display: flex;
-				align-items: center;
-				justify-content: flex-end;
-				flex-wrap: nowrap;
-				gap: 6px;
-				margin-top: 8px;
-			}
-			.prompt__meta {
-				display: flex;
-				flex: 1 1 auto;
-				height: var(--ao-control-md);
-				align-items: center;
-				gap: 6px;
-				margin-right: auto;
-				min-width: 0;
-				color: var(--ao-passive);
-				font-family: var(--ao-font-sans);
-				font-size: var(--ao-text-xs);
-				line-height: 1.5;
-				font-weight: 400;
-			}
-			.prompt__shortcut {
+			.prompt button[type="submit"] {
+				position: absolute;
+				right: 8px;
+				bottom: 7px;
 				display: inline-flex;
-				height: 100%;
-				align-items: center;
-				gap: 4px;
-				white-space: nowrap;
-			}
-			.prompt__shortcut > span {
-				display: inline-flex;
-				height: 18px;
-				align-items: center;
-				line-height: 1;
-			}
-			.prompt__shortcut + .prompt__shortcut::before {
-				content: "·";
-				color: color-mix(in oklch, var(--ao-passive) 55%, transparent);
-				line-height: 1;
-			}
-			.prompt__shortcut kbd {
-				display: inline-flex;
-				min-height: 18px;
+				width: 28px;
+				height: 28px;
 				align-items: center;
 				justify-content: center;
-				border: 1px solid color-mix(in oklch, var(--ao-passive) 35%, transparent);
-				border-radius: 4px;
-				background: color-mix(in oklch, var(--ao-muted) 55%, transparent);
-				padding: 0 5px;
-				color: color-mix(in oklch, var(--ao-foreground) 78%, transparent);
-				font-family: var(--ao-font-mono);
-				font-size: 10px;
-				line-height: 1;
-				box-shadow: inset 0 -1px 0 color-mix(in oklch, var(--ao-passive) 20%, transparent);
-			}
-			.actions {
-				display: flex;
-				flex: 0 0 auto;
-				align-items: center;
-				justify-content: flex-end;
-				gap: 6px;
-				margin: 0;
-			}
-			.actions button {
-				display: inline-flex;
-				flex-shrink: 0;
-				height: var(--ao-control-md);
-				align-items: center;
-				justify-content: center;
-				gap: 6px;
-				border-radius: 6px;
+				border-radius: 999px;
 				border: 1px solid transparent;
-				background: transparent;
-				color: var(--ao-foreground);
-				padding: 0 10px;
-				font-family: var(--ao-font-sans);
-				font-size: var(--ao-text-xs);
-				line-height: 1;
-				font-weight: 400;
-				white-space: nowrap;
+				background: var(--ao-primary);
+				color: var(--ao-primary-foreground);
+				padding: 0;
 				transition:
 					background 120ms ease,
-					border-color 120ms ease,
+					opacity 120ms ease,
 					transform 120ms ease;
 			}
-			.actions button:hover {
-				background: color-mix(in oklch, var(--ao-muted) 50%, transparent);
+			.prompt button[type="submit"]:hover {
+				background: color-mix(in oklch, var(--ao-primary) 82%, transparent);
 			}
-			.actions button:active {
+			.prompt button[type="submit"]:active {
 				transform: translateY(1px);
 			}
-			.actions button:focus-visible {
+			.prompt button[type="submit"]:focus-visible {
 				outline: none;
 				border-color: var(--ao-ring);
 				box-shadow: 0 0 0 3px color-mix(in oklch, var(--ao-ring) 30%, transparent);
 			}
-			.actions button:disabled {
-				opacity: 0.5;
+			.prompt button[type="submit"]:disabled {
+				opacity: 0.32;
 				pointer-events: none;
 			}
-			.actions button[type="submit"] {
-				background: var(--ao-primary);
-				color: var(--ao-primary-foreground);
-			}
-			.actions button[type="submit"]:hover {
-				background: color-mix(in oklch, var(--ao-primary) 80%, transparent);
-				color: var(--ao-primary-foreground);
-			}
-			.actions svg {
+			.prompt button[type="submit"] svg {
 				width: var(--ao-icon-sm);
 				height: var(--ao-icon-sm);
-				flex-shrink: 0;
 				stroke: currentColor;
 				stroke-width: 2;
 				stroke-linecap: round;
@@ -385,28 +313,13 @@ function ensureOverlay(): ShadowRoot {
 			}
 			@media (prefers-reduced-motion: reduce) {
 				.highlight,
-				.prompt textarea,
-				.actions button {
+				.prompt,
+				.prompt button[type="submit"] {
 					transition: none;
 				}
 				.prompt,
 				.hint {
 					animation: none;
-				}
-			}
-			@media (max-width: 420px) {
-				.prompt__footer {
-					align-items: stretch;
-					flex-direction: column;
-				}
-				.actions {
-					order: 1;
-					align-self: flex-end;
-				}
-				.prompt__meta {
-					order: 2;
-					width: 100%;
-					margin-right: 0;
 				}
 			}
 			</style>
@@ -442,32 +355,30 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 	const mount = root.querySelector<HTMLDivElement>(".mount");
 	if (!mount) return;
 	mount.innerHTML = `
-		<form class="prompt">
-			
-			<textarea aria-label="Annotation request" placeholder="Describe to agent what you want to change..."></textarea>
-			<div class="prompt__footer">
-				<div class="prompt__meta" aria-label="Command or Control plus Enter to send. Escape to cancel.">
-					<span class="prompt__shortcut"><kbd>⌘/Ctrl + Enter</kbd><span>Send</span></span>
-					<span class="prompt__shortcut"><kbd>Esc</kbd><span>Cancel</span></span>
-				</div>
-				<div class="actions">
-					<button disabled type="submit">
-						<svg viewBox="0 0 24 24" aria-hidden="true">
-							<path d="m22 2-7 20-4-9-9-4Z"></path>
-							<path d="M22 2 11 13"></path>
-						</svg>
-						<span>Send</span>
-					</button>
-				</div>
-			</div>
+		<form class="prompt" aria-label="Annotate selection">
+			<textarea rows="1" aria-label="Annotation request" placeholder="Describe the change…"></textarea>
+			<button disabled type="submit" aria-label="Send annotation" title="Send (⌘/Ctrl + Enter)">
+				<svg viewBox="0 0 24 24" aria-hidden="true">
+					<path d="M12 19V5"></path>
+					<path d="m5 12 7-7 7 7"></path>
+				</svg>
+			</button>
 		</form>
 	`;
 	const form = mount.querySelector<HTMLFormElement>("form")!;
 	repositionPrompt(element);
 	const textarea = form.querySelector<HTMLTextAreaElement>("textarea")!;
 	const submitButton = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
+	const resizeTextarea = (): void => {
+		textarea.style.height = "0px";
+		const height = Math.min(104, Math.max(32, textarea.scrollHeight));
+		textarea.style.height = `${height}px`;
+		textarea.style.overflowY = textarea.scrollHeight > 104 ? "auto" : "hidden";
+		repositionPrompt(element);
+	};
 	const updateSubmitState = (): void => {
 		submitButton.disabled = textarea.value.trim().length === 0;
+		resizeTextarea();
 	};
 	const submitAnnotation = (): boolean => {
 		const instruction = textarea.value.trim();
@@ -506,10 +417,10 @@ function repositionPrompt(element: Element): void {
 	const layoutHeight = Math.min(window.innerHeight, documentHeight > 0 ? documentHeight : window.innerHeight);
 	const viewportWidth = Math.min(layoutWidth, window.visualViewport?.width ?? layoutWidth);
 	const viewportHeight = Math.min(layoutHeight, window.visualViewport?.height ?? layoutHeight);
-	const promptWidth = Math.max(0, Math.min(440, viewportWidth - 28));
+	const promptWidth = Math.max(0, Math.min(360, viewportWidth - 28));
 	form.style.width = `${promptWidth}px`;
 	const measuredHeight = form.getBoundingClientRect().height;
-	const { left, top } = promptPosition(element.getBoundingClientRect(), promptWidth, measuredHeight || 178, {
+	const { left, top } = promptPosition(element.getBoundingClientRect(), promptWidth, measuredHeight || 44, {
 		width: viewportWidth,
 		height: viewportHeight,
 	});

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -457,7 +457,7 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 	if (!mount) return;
 	mount.innerHTML = `
 		<form class="prompt">
-			<div class="prompt__header">Annotate on selected components</div>
+			
 			<textarea aria-label="Annotation request" placeholder="Describe to agent what you want to change..."></textarea>
 			<div class="prompt__footer">
 				<div class="prompt__meta" aria-label="Command or Control plus Enter to send. Escape to cancel.">
@@ -470,7 +470,7 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 							<path d="m22 2-7 20-4-9-9-4Z"></path>
 							<path d="M22 2 11 13"></path>
 						</svg>
-						<span>Send feedback</span>
+						<span>Send</span>
 					</button>
 				</div>
 			</div>

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -1,6 +1,9 @@
 import { ipcRenderer } from "electron";
+import geistLatinWoff2 from "@fontsource-variable/geist/files/geist-latin-wght-normal.woff2?inline";
+import geistMonoLatinWoff2 from "@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2?inline";
 import {
 	createBrowserAnnotationContext,
+	elementSummary,
 	type BrowserAnnotationCancelReason,
 	type BrowserAnnotationContext,
 	type BrowserAnnotationPageSubmitPayload,
@@ -107,6 +110,37 @@ function annotationTarget(target: EventTarget | null): Element | null {
 	return element;
 }
 
+// Registered as FontFace objects from decoded bytes rather than an @font-face
+// `src: url(data:...)` rule: the annotated page's own CSP (font-src) can block
+// that url() fetch, silently falling the overlay back to a system font. A
+// FontFace built from an in-memory buffer does no fetch, so it is not subject
+// to the page's CSP and always loads.
+function decodeBase64Font(dataUri: string): ArrayBuffer {
+	const base64 = dataUri.slice(dataUri.indexOf(",") + 1);
+	const binary = atob(base64);
+	const buffer = new ArrayBuffer(binary.length);
+	const bytes = new Uint8Array(buffer);
+	for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+	return buffer;
+}
+
+function registerFonts(root: ShadowRoot): void {
+	if (typeof FontFace === "undefined") return;
+	const fontSet = (root as ShadowRoot & { fonts?: FontFaceSet }).fonts ?? document.fonts;
+	const sans = new FontFace("Geist Variable", decodeBase64Font(geistLatinWoff2), {
+		weight: "100 900",
+		style: "normal",
+	});
+	const mono = new FontFace("Geist Mono Variable", decodeBase64Font(geistMonoLatinWoff2), {
+		weight: "100 900",
+		style: "normal",
+	});
+	fontSet.add(sans);
+	fontSet.add(mono);
+	void sans.load();
+	void mono.load();
+}
+
 function ensureOverlay(): ShadowRoot {
 	if (shadow && host?.isConnected) return shadow;
 	host = document.createElement("div");
@@ -117,9 +151,28 @@ function ensureOverlay(): ShadowRoot {
 	host.style.pointerEvents = "none";
 	(document.documentElement ?? document.body).appendChild(host);
 	shadow = host.attachShadow({ mode: "open" });
+	registerFonts(shadow);
 	shadow.innerHTML = `
 		<style>
-			:host { all: initial; }
+			:host {
+				all: initial;
+				--ao-background: oklch(0.185 0.006 285.885);
+				--ao-foreground: oklch(0.985 0 0);
+				--ao-surface: oklch(0.24 0.008 285.885);
+				--ao-muted: oklch(0.274 0.006 286.033);
+				--ao-border: oklch(1 0 0 / 7%);
+				--ao-input: oklch(1 0 0 / 4%);
+				--ao-ring: oklch(0.552 0.016 285.938);
+				--ao-passive: oklch(0.442 0.017 285.786);
+				--ao-primary: oklch(0.92 0.004 286.32);
+				--ao-primary-foreground: oklch(0.21 0.006 285.885);
+				--ao-font-sans: "Geist Variable", "Geist", ui-sans-serif, system-ui, sans-serif;
+				--ao-font-mono: "Geist Mono Variable", "Geist Mono", "JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font", "FiraCode Nerd Font Mono", "FiraCode Nerd Font", "MesloLGS NF", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+				--ao-text-xs: 12px;
+				--ao-control-md: 28px;
+				--ao-icon-sm: 13px;
+				--ao-radius-md: 8px;
+			}
 			.highlight {
 				position: fixed;
 				box-sizing: border-box;
@@ -141,76 +194,145 @@ function ensureOverlay(): ShadowRoot {
 			}
 			.prompt {
 				position: fixed;
-				width: min(380px, calc(100vw - 24px));
+				width: min(440px, calc(100vw - 28px));
 				box-sizing: border-box;
-				border: 1px solid rgba(255, 255, 255, 0.14);
-				border-radius: 8px;
-				background: rgba(18, 20, 24, 0.98);
-				color: #f4f5f7;
-				box-shadow:
-					0 0 0 1px rgba(255, 255, 255, 0.06),
-					0 18px 52px rgba(0, 0, 0, 0.48);
-				padding: 12px;
-				font: 13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+				border: 1px solid color-mix(in oklch, var(--ao-border) 70%, transparent);
+				border-radius: var(--ao-radius-md);
+				background: var(--ao-surface);
+				color: var(--ao-foreground);
+				box-shadow: 0 18px 52px rgba(0, 0, 0, 0.48);
+				padding: 8px 12px;
+				font: 13px/1.5 var(--ao-font-sans);
+				font-weight: 400;
 				pointer-events: auto;
 				animation: prompt-in 140ms ease-out;
 			}
 			.prompt__header {
-				margin-bottom: 9px;
-				color: rgba(244, 245, 247, 0.82);
-				font-size: 12px;
-				font-weight: 650;
+				display: block;
+				min-width: 0;
+				margin: 0 0 6px;
+				overflow: hidden;
+				color: var(--ao-passive);
+				font-family: var(--ao-font-sans);
+				font-size: var(--ao-text-xs);
+				line-height: 1.5;
+				font-weight: 400;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 			.prompt textarea {
+				display: block;
 				width: 100%;
-				min-height: 102px;
+				min-height: 80px;
 				box-sizing: border-box;
 				resize: vertical;
-				border: 1px solid rgba(255, 255, 255, 0.12);
+				border: 1px solid var(--ao-input);
 				border-radius: 6px;
-				background: rgba(7, 8, 10, 0.92);
-				color: #f4f5f7;
-				padding: 9px 10px;
-				font: inherit;
+				background: var(--ao-background);
+				color: var(--ao-foreground);
+				caret-color: var(--ao-foreground);
+				padding: 8px 10px;
+				font-family: var(--ao-font-sans);
+				font-size: var(--ao-text-xs);
+				line-height: 1.5;
+				font-weight: 400;
 				outline: none;
 				transition:
 					border-color 120ms ease,
 					box-shadow 120ms ease,
 					background 120ms ease;
 			}
-			.prompt textarea:focus {
-				border-color: #4d8dff;
-				box-shadow: 0 0 0 3px rgba(77, 141, 255, 0.16);
+			.prompt textarea::placeholder {
+				color: var(--ao-passive);
+			}
+			.prompt textarea:focus,
+			.prompt textarea:focus-visible {
+				border-color: var(--ao-ring);
+				box-shadow: 0 0 0 3px color-mix(in oklch, var(--ao-ring) 30%, transparent);
+			}
+			.prompt__footer {
+				display: flex;
+				align-items: center;
+				justify-content: flex-end;
+				flex-wrap: nowrap;
+				gap: 6px;
+				margin-top: 8px;
+			}
+			.prompt__meta {
+				flex: 1 1 auto;
+				margin-right: auto;
+				min-width: 0;
+				overflow: hidden;
+				color: var(--ao-passive);
+				font-family: var(--ao-font-sans);
+				font-size: var(--ao-text-xs);
+				line-height: 1.5;
+				font-weight: 400;
+				white-space: nowrap;
+				text-overflow: ellipsis;
 			}
 			.actions {
 				display: flex;
+				flex: 0 0 auto;
+				align-items: center;
 				justify-content: flex-end;
-				gap: 8px;
-				margin-top: 8px;
+				gap: 6px;
+				margin: 0;
 			}
 			.actions button {
-				height: 30px;
+				display: inline-flex;
+				flex-shrink: 0;
+				height: var(--ao-control-md);
+				align-items: center;
+				justify-content: center;
+				gap: 6px;
 				border-radius: 6px;
-				border: 1px solid rgba(255, 255, 255, 0.12);
-				background: #1b1d22;
-				color: #f4f5f7;
+				border: 1px solid transparent;
+				background: transparent;
+				color: var(--ao-foreground);
 				padding: 0 10px;
-				font: inherit;
+				font-family: var(--ao-font-sans);
+				font-size: var(--ao-text-xs);
+				line-height: 1;
+				font-weight: 400;
+				white-space: nowrap;
 				transition:
 					background 120ms ease,
 					border-color 120ms ease,
 					transform 120ms ease;
 			}
 			.actions button:hover {
-				background: #242830;
+				background: color-mix(in oklch, var(--ao-muted) 50%, transparent);
 			}
 			.actions button:active {
 				transform: translateY(1px);
 			}
+			.actions button:focus-visible {
+				outline: none;
+				border-color: var(--ao-ring);
+				box-shadow: 0 0 0 3px color-mix(in oklch, var(--ao-ring) 30%, transparent);
+			}
+			.actions button:disabled {
+				opacity: 0.5;
+				pointer-events: none;
+			}
 			.actions button[type="submit"] {
-				border-color: #4d8dff;
-				background: #4d8dff;
-				color: #fff;
+				background: var(--ao-primary);
+				color: var(--ao-primary-foreground);
+			}
+			.actions button[type="submit"]:hover {
+				background: color-mix(in oklch, var(--ao-primary) 80%, transparent);
+				color: var(--ao-primary-foreground);
+			}
+			.actions svg {
+				width: var(--ao-icon-sm);
+				height: var(--ao-icon-sm);
+				flex-shrink: 0;
+				stroke: currentColor;
+				stroke-width: 2;
+				stroke-linecap: round;
+				stroke-linejoin: round;
+				fill: none;
 			}
 			.hint {
 				position: fixed;
@@ -218,9 +340,9 @@ function ensureOverlay(): ShadowRoot {
 				bottom: 12px;
 				border-radius: 6px;
 				background: #15171b;
-				color: #f4f5f7;
+				color: #c9d1d9;
 				padding: 7px 9px;
-				font: 12px/1.3 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+				font: 12px/1.3 var(--ao-font-sans);
 				box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 				pointer-events: none;
 				animation: prompt-in 140ms ease-out;
@@ -240,7 +362,24 @@ function ensureOverlay(): ShadowRoot {
 					animation: none;
 				}
 			}
-		</style>
+			@media (max-width: 360px) {
+				.prompt__footer {
+					align-items: stretch;
+					flex-direction: column;
+				}
+				.actions {
+					order: 1;
+					width: 100%;
+				}
+				.prompt__meta {
+					order: 2;
+					margin-right: 0;
+					overflow: visible;
+					white-space: normal;
+					text-overflow: clip;
+				}
+			}
+			</style>
 		<div class="highlight" hidden></div>
 		<div class="mount"></div>
 	`;
@@ -276,29 +415,54 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 	const { left, top } = promptPosition(rect);
 	mount.innerHTML = `
 		<form class="prompt" style="left: ${left}px; top: ${top}px;">
-			<div class="prompt__header">Annotate selection</div>
-			<textarea aria-label="Annotation request" placeholder="Describe what to change"></textarea>
-			<div class="actions">
-				<button type="button" data-action="cancel">Cancel</button>
-				<button type="submit">Send</button>
+			<div class="prompt__header">Annotate on selected components</div>
+			<textarea aria-label="Annotation request" placeholder="Describe to agent what you want to change..."></textarea>
+			<div class="prompt__footer">
+				<div class="prompt__meta">⌘/Ctrl + Enter to send · Esc to cancel</div>
+				<div class="actions">
+					<button disabled type="submit">
+						<svg viewBox="0 0 24 24" aria-hidden="true">
+							<path d="m22 2-7 20-4-9-9-4Z"></path>
+							<path d="M22 2 11 13"></path>
+						</svg>
+						<span>Send feedback</span>
+					</button>
+				</div>
 			</div>
 		</form>
 	`;
 	const form = mount.querySelector<HTMLFormElement>("form")!;
+	const header = form.querySelector<HTMLDivElement>(".prompt__header")!;
+	header.title = elementSummary(context);
 	const textarea = form.querySelector<HTMLTextAreaElement>("textarea")!;
-	form.addEventListener("submit", (event) => {
-		event.preventDefault();
+	const submitButton = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
+	const updateSubmitState = (): void => {
+		submitButton.disabled = textarea.value.trim().length === 0;
+	};
+	const submitAnnotation = (): boolean => {
 		const instruction = textarea.value.trim();
 		if (!instruction) {
 			textarea.focus();
-			return;
+			return false;
 		}
 		const payload: BrowserAnnotationPageSubmitPayload = { instruction, context };
 		ipcRenderer.send("browser:annotation:submit", payload);
 		setEnabled(false, "disabled");
+		return true;
+	};
+	form.addEventListener("submit", (event) => {
+		event.preventDefault();
+		submitAnnotation();
 	});
-	form.querySelector<HTMLButtonElement>('[data-action="cancel"]')?.addEventListener("click", () => {
-		setEnabled(false, "cancel");
+	textarea.addEventListener("input", updateSubmitState);
+	textarea.addEventListener("keydown", (event) => {
+		if (event.key === "Escape") {
+			event.preventDefault();
+			setEnabled(false, "escape");
+		} else if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+			event.preventDefault();
+			submitAnnotation();
+		}
 	});
 	setTimeout(() => textarea.focus(), 0);
 }
@@ -307,10 +471,10 @@ function promptPosition(rect: DOMRect): { left: number; top: number } {
 	return promptPositionForRect(rect, {
 		width: window.innerWidth,
 		height: window.innerHeight,
-		promptWidth: Math.min(380, window.innerWidth - 24),
-		promptHeight: 180,
-		gutter: 12,
-		gap: 8,
+		promptWidth: Math.min(440, window.innerWidth - 28),
+		promptHeight: 178,
+		gutter: 14,
+		gap: 10,
 	});
 }
 

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -3,7 +3,6 @@ import geistLatinWoff2 from "@fontsource-variable/geist/files/geist-latin-wght-n
 import geistMonoLatinWoff2 from "@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2?inline";
 import {
 	createBrowserAnnotationContext,
-	elementSummary,
 	type BrowserAnnotationCancelReason,
 	type BrowserAnnotationContext,
 	type BrowserAnnotationPageSubmitPayload,
@@ -218,19 +217,6 @@ function ensureOverlay(): ShadowRoot {
 				font-weight: 400;
 				pointer-events: auto;
 				animation: prompt-in 140ms ease-out;
-			}
-			.prompt__header {
-				display: block;
-				min-width: 0;
-				margin: 0 0 6px;
-				overflow: hidden;
-				color: var(--ao-passive);
-				font-family: var(--ao-font-sans);
-				font-size: var(--ao-text-xs);
-				line-height: 1.5;
-				font-weight: 400;
-				text-overflow: ellipsis;
-				white-space: nowrap;
 			}
 			.prompt textarea {
 				display: block;
@@ -478,8 +464,6 @@ function renderPrompt(element: Element, context: BrowserAnnotationContext): void
 	`;
 	const form = mount.querySelector<HTMLFormElement>("form")!;
 	repositionPrompt(element);
-	const header = form.querySelector<HTMLDivElement>(".prompt__header")!;
-	header.title = elementSummary(context);
 	const textarea = form.querySelector<HTMLTextAreaElement>("textarea")!;
 	const submitButton = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
 	const updateSubmitState = (): void => {

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -408,17 +408,18 @@ function ensureOverlay(): ShadowRoot {
 					animation: none;
 				}
 			}
-			@media (max-width: 360px) {
+			@media (max-width: 420px) {
 				.prompt__footer {
 					align-items: stretch;
 					flex-direction: column;
 				}
 				.actions {
 					order: 1;
-					width: 100%;
+					align-self: flex-end;
 				}
 				.prompt__meta {
 					order: 2;
+					width: 100%;
 					margin-right: 0;
 				}
 			}

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -560,6 +560,7 @@ function openPrompt(
 	});
 	textarea.addEventListener("input", updateSubmitState);
 	textarea.addEventListener("keydown", (event) => {
+		event.stopPropagation();
 		if (event.key === "Escape") {
 			event.preventDefault();
 			setEnabled(false, "escape");

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -62,6 +62,7 @@ function setupHost() {
 		on: (event: string, listener: (...args: never[]) => void) => {
 			webContentsListeners.set(event, listener);
 		},
+		focus: vi.fn(),
 		reload: vi.fn(),
 		send: vi.fn(),
 		setWindowOpenHandler: () => undefined,
@@ -1267,19 +1268,43 @@ describe("browser annotation IPC", () => {
 		expect(webContents.send).not.toHaveBeenCalledWith("browser:annotation:setMode", { enabled: true });
 	});
 
-	it("forwards preview annotation submissions to the renderer-owned view", async () => {
+	it("focuses the preview webContents when annotation mode is enabled, so a keypress reaches it without a prior click", async () => {
+		const { invoke, webContents } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+
+		expect(webContents.focus).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not steal focus when annotation mode is turned off", async () => {
+		const { invoke, webContents } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+		webContents.focus.mockClear();
+
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: false });
+
+		expect(webContents.focus).not.toHaveBeenCalled();
+	});
+
+	it("forwards a single-element preview annotation submission to the renderer-owned view", async () => {
 		const { invoke, send, sent } = setupHost();
 		await invoke("browser:ensure", "sess-1");
 
 		send("browser:annotation:submit", 99, {
 			instruction: "Make this button blue.",
-			context: {
-				url: "http://localhost:5173/",
-				tag: "button",
-				classes: [],
-				selector: "button",
-				rect: { x: 0, y: 0, width: 80, height: 30 },
-				computedStyle: {},
+			selection: {
+				kind: "element",
+				context: {
+					url: "http://localhost:5173/",
+					tag: "button",
+					classes: [],
+					selector: "button",
+					rect: { x: 0, y: 0, width: 80, height: 30 },
+					nearbyText: [],
+					computedStyle: {},
+				},
 			},
 		});
 
@@ -1288,9 +1313,112 @@ describe("browser annotation IPC", () => {
 			payload: expect.objectContaining({
 				viewId: "1:sess-1",
 				instruction: "Make this button blue.",
-				context: expect.objectContaining({ selector: "button" }),
+				selection: expect.objectContaining({
+					kind: "element",
+					context: expect.objectContaining({ selector: "button" }),
+				}),
 			}),
 		});
+	});
+
+	it("forwards a multi-element preview annotation submission to the renderer-owned view", async () => {
+		const { invoke, send, sent } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		send("browser:annotation:submit", 99, {
+			instruction: "Align these two.",
+			selection: {
+				kind: "elements",
+				contexts: [
+					{
+						url: "http://localhost:5173/",
+						tag: "button",
+						classes: [],
+						selector: "button#a",
+						rect: { x: 0, y: 0, width: 80, height: 30 },
+						nearbyText: [],
+						computedStyle: {},
+					},
+					{
+						url: "http://localhost:5173/",
+						tag: "button",
+						classes: [],
+						selector: "button#b",
+						rect: { x: 100, y: 0, width: 80, height: 30 },
+						nearbyText: [],
+						computedStyle: {},
+					},
+				],
+			},
+		});
+
+		expect(sent).toContainEqual({
+			channel: "browser:annotation:submitted",
+			payload: expect.objectContaining({
+				viewId: "1:sess-1",
+				instruction: "Align these two.",
+				selection: expect.objectContaining({
+					kind: "elements",
+					contexts: [
+						expect.objectContaining({ selector: "button#a" }),
+						expect.objectContaining({ selector: "button#b" }),
+					],
+				}),
+			}),
+		});
+	});
+
+	it("ignores a malformed annotation selection instead of forwarding it", async () => {
+		const { invoke, send, sent } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		send("browser:annotation:submit", 99, {
+			instruction: "Make this button blue.",
+			selection: { kind: "elements", contexts: [] },
+		});
+
+		expect(sent.some((entry) => entry.channel === "browser:annotation:submitted")).toBe(false);
+	});
+
+	it("ignores a single-element selection whose context is missing required fields", async () => {
+		const { invoke, send, sent } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		send("browser:annotation:submit", 99, {
+			instruction: "Make this button blue.",
+			selection: {
+				kind: "element",
+				context: { tag: "button" },
+			},
+		});
+
+		expect(sent.some((entry) => entry.channel === "browser:annotation:submitted")).toBe(false);
+	});
+
+	it("ignores a multi-element selection containing a malformed context entry", async () => {
+		const { invoke, send, sent } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		send("browser:annotation:submit", 99, {
+			instruction: "Align these two.",
+			selection: {
+				kind: "elements",
+				contexts: [
+					{
+						url: "http://localhost/",
+						tag: "button",
+						classes: [],
+						selector: "button",
+						rect: { x: 0, y: 0, width: 1, height: 1 },
+						nearbyText: [],
+						computedStyle: {},
+					},
+					null,
+				],
+			},
+		});
+
+		expect(sent.some((entry) => entry.channel === "browser:annotation:submitted")).toBe(false);
 	});
 
 	it("ignores preview annotation events after the view is destroyed", async () => {

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -11,13 +11,61 @@ import type {
 import { randomUUID } from "node:crypto";
 import type {
 	BrowserAnnotationCancelPayload,
+	BrowserAnnotationContext,
 	BrowserAnnotationModeInput,
 	BrowserAnnotationPageCancelPayload,
 	BrowserAnnotationPageSubmitPayload,
+	BrowserAnnotationSelection,
 	BrowserAnnotationSubmitPayload,
 } from "../shared/browser-annotations";
 import { attachAppShortcuts } from "./app-shortcuts";
 import type { KeybindingOverrides } from "../shared/shortcuts";
+
+function isValidAnnotationContext(value: unknown): value is BrowserAnnotationContext {
+	if (typeof value !== "object" || value === null) return false;
+	const context = value as {
+		url?: unknown;
+		tag?: unknown;
+		classes?: unknown;
+		selector?: unknown;
+		rect?: unknown;
+		nearbyText?: unknown;
+		computedStyle?: unknown;
+	};
+	if (typeof context.url !== "string") return false;
+	if (typeof context.tag !== "string") return false;
+	if (!Array.isArray(context.classes)) return false;
+	if (typeof context.selector !== "string") return false;
+	if (typeof context.rect !== "object" || context.rect === null) return false;
+	const rect = context.rect as { x?: unknown; y?: unknown; width?: unknown; height?: unknown };
+	if (
+		typeof rect.x !== "number" ||
+		typeof rect.y !== "number" ||
+		typeof rect.width !== "number" ||
+		typeof rect.height !== "number"
+	) {
+		return false;
+	}
+	if (!Array.isArray(context.nearbyText)) return false;
+	if (typeof context.computedStyle !== "object" || context.computedStyle === null) return false;
+	return true;
+}
+
+function isValidAnnotationSelection(value: unknown): value is BrowserAnnotationSelection {
+	if (typeof value !== "object" || value === null) return false;
+	const selection = value as { kind?: unknown; context?: unknown; contexts?: unknown };
+	if (selection.kind === "element") {
+		return isValidAnnotationContext(selection.context);
+	}
+	if (selection.kind === "elements") {
+		return (
+			Array.isArray(selection.contexts) &&
+			selection.contexts.length > 0 &&
+			selection.contexts.every(isValidAnnotationContext)
+		);
+	}
+	return false;
+}
 
 export type BrowserRect = Pick<Rectangle, "x" | "y" | "width" | "height">;
 
@@ -81,6 +129,7 @@ type BrowserWebContents = Pick<
 	| "capturePage"
 	| "clearHistory"
 	| "debugger"
+	| "focus"
 	| "mainFrame"
 	| "getTitle"
 	| "getURL"
@@ -686,6 +735,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		const entry = activeEntry(session);
 		entry.annotationEnabled = input.enabled;
 		entry.view.webContents.send("browser:annotation:setMode", { enabled: input.enabled });
+		if (input.enabled) entry.view.webContents.focus();
 	};
 
 	const forwardAnnotationSubmit = (
@@ -699,8 +749,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			!entry ||
 			!payload ||
 			typeof payload.instruction !== "string" ||
-			typeof payload.context !== "object" ||
-			payload.context === null
+			!isValidAnnotationSelection(payload.selection)
 		) {
 			return;
 		}
@@ -708,7 +757,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		const forwarded: BrowserAnnotationSubmitPayload = {
 			viewId,
 			instruction: payload.instruction,
-			context: payload.context,
+			selection: payload.selection,
 		};
 		options.mainWindow.webContents.send("browser:annotation:submitted", forwarded);
 	};

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserPanel, BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { useBrowserView, type BrowserNavState } from "../hooks/useBrowserView";
 import type { WorkspaceSession } from "../types/workspace";
-import type { BrowserAnnotationCancelPayload, BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
+import type {
+	BrowserAnnotationCancelPayload,
+	BrowserAnnotationContext,
+	BrowserAnnotationSubmitPayload,
+} from "../../shared/browser-annotations";
 
 const postMock = vi.hoisted(() => vi.fn());
 
@@ -83,18 +87,25 @@ const session: WorkspaceSession = {
 	prs: [],
 };
 
-function annotationPayload(instruction: string): BrowserAnnotationSubmitPayload {
+type ElementAnnotationPayload = BrowserAnnotationSubmitPayload & {
+	selection: { kind: "element"; context: BrowserAnnotationContext };
+};
+
+function annotationPayload(instruction: string): ElementAnnotationPayload {
 	return {
 		viewId: "42:sess-1",
 		instruction,
-		context: {
-			url: "http://localhost:5173/",
-			tag: "button",
-			classes: [],
-			selector: "button",
-			rect: { x: 0, y: 0, width: 80, height: 30 },
-			nearbyText: [],
-			computedStyle: {},
+		selection: {
+			kind: "element",
+			context: {
+				url: "http://localhost:5173/",
+				tag: "button",
+				classes: [],
+				selector: "button",
+				rect: { x: 0, y: 0, width: 80, height: 30 },
+				nearbyText: [],
+				computedStyle: {},
+			},
 		},
 	};
 }
@@ -408,17 +419,20 @@ describe("BrowserPanel", () => {
 				listener({
 					viewId: "42:sess-1",
 					instruction: "Make this button blue.",
-					context: {
-						url: "http://localhost:5173/",
-						title: "Preview",
-						tag: "button",
-						id: "save",
-						classes: ["primary"],
-						selector: "button#save",
-						rect: { x: 16, y: 24, width: 140, height: 36 },
-						visibleText: "Save changes",
-						nearbyText: ["Profile settings"],
-						computedStyle: {},
+					selection: {
+						kind: "element",
+						context: {
+							url: "http://localhost:5173/",
+							title: "Preview",
+							tag: "button",
+							id: "save",
+							classes: ["primary"],
+							selector: "button#save",
+							rect: { x: 16, y: 24, width: 140, height: 36 },
+							visibleText: "Save changes",
+							nearbyText: ["Profile settings"],
+							computedStyle: {},
+						},
 					},
 				}),
 			);
@@ -554,17 +568,20 @@ describe("BrowserPanel", () => {
 		const { rerender } = render(
 			<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />,
 		);
-		const payload = {
+		const payload: BrowserAnnotationSubmitPayload = {
 			viewId: "42:sess-1",
 			instruction: "Make this button yellow.",
-			context: {
-				url: "http://localhost:5173/",
-				tag: "button",
-				classes: [],
-				selector: "button",
-				rect: { x: 0, y: 0, width: 80, height: 30 },
-				nearbyText: [],
-				computedStyle: {},
+			selection: {
+				kind: "element",
+				context: {
+					url: "http://localhost:5173/",
+					tag: "button",
+					classes: [],
+					selector: "button",
+					rect: { x: 0, y: 0, width: 80, height: 30 },
+					nearbyText: [],
+					computedStyle: {},
+				},
 			},
 		};
 
@@ -613,14 +630,17 @@ describe("BrowserPanel", () => {
 				listener({
 					viewId: "42:sess-1",
 					instruction: "Move this card higher.",
-					context: {
-						url: "http://localhost:5173/",
-						tag: "section",
-						classes: [],
-						selector: "section",
-						rect: { x: 0, y: 0, width: 320, height: 180 },
-						nearbyText: [],
-						computedStyle: {},
+					selection: {
+						kind: "element",
+						context: {
+							url: "http://localhost:5173/",
+							tag: "section",
+							classes: [],
+							selector: "section",
+							rect: { x: 0, y: 0, width: 320, height: 180 },
+							nearbyText: [],
+							computedStyle: {},
+						},
 					},
 				}),
 			);
@@ -673,14 +693,17 @@ describe("BrowserPanel", () => {
 				listener({
 					viewId: "42:sess-1",
 					instruction: "Make this button blue.",
-					context: {
-						url: "http://localhost:5173/",
-						tag: "button",
-						classes: [],
-						selector: "button",
-						rect: { x: 0, y: 0, width: 80, height: 30 },
-						nearbyText: [],
-						computedStyle: {},
+					selection: {
+						kind: "element",
+						context: {
+							url: "http://localhost:5173/",
+							tag: "button",
+							classes: [],
+							selector: "button",
+							rect: { x: 0, y: 0, width: 80, height: 30 },
+							nearbyText: [],
+							computedStyle: {},
+						},
 					},
 				}),
 			);
@@ -701,9 +724,9 @@ describe("BrowserPanel", () => {
 			annotationSubmitListeners.forEach((listener) =>
 				listener({
 					...payload,
-					context: {
-						...payload.context,
-						selector: "button#save",
+					selection: {
+						kind: "element",
+						context: { ...payload.selection.context, selector: "button#save" },
 					},
 				}),
 			);

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -448,7 +448,7 @@ describe("SessionView", () => {
 		render(<SessionView sessionId="sess-1" />);
 
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
-		expect(panelSizes("inspector")[0]).toBe("28%");
+		expect(panelSizes("inspector")[0]).toBe("30%");
 		// Open panels are non-collapsible so a drag clamps at minSize instead of
 		// snapping the rail away; only the closed panel is collapsible.
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("data-collapsible");
@@ -527,7 +527,7 @@ describe("SessionView", () => {
 		// Opening resizes to the persisted split rather than expand(): the open
 		// panel re-registers as non-collapsible, and rrp's expand() no-ops on a
 		// non-collapsible panel.
-		expect(handle.resize).toHaveBeenCalledWith("28%");
+		expect(handle.resize).toHaveBeenCalledWith("30%");
 		expect(handle.collapse).not.toHaveBeenCalled();
 	});
 
@@ -542,7 +542,7 @@ describe("SessionView", () => {
 
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 		expect(inspectorOpen("sess-1")).toBe(true);
-		expect(handle.resize).toHaveBeenCalledWith("28%");
+		expect(handle.resize).toHaveBeenCalledWith("30%");
 
 		// Plain ⌘B belongs to the sidebar — the inspector must not react.
 		fireEvent.keyDown(window, { key: "b", metaKey: true });
@@ -649,7 +649,7 @@ describe("SessionView", () => {
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 
 		expect(inspectorOpen("sess-2")).toBe(true);
-		expect(handle.resize).toHaveBeenCalledWith("28%");
+		expect(handle.resize).toHaveBeenCalledWith("30%");
 	});
 
 	it("renders no inspector panel or handle for orchestrator sessions", () => {
@@ -788,7 +788,7 @@ describe("SessionView", () => {
 
 		const { rerender } = render(<SessionView sessionId="sess-1" />);
 
-		expect(panelSizes("inspector")[0]).toBe("28%");
+		expect(panelSizes("inspector")[0]).toBe("30%");
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -25,7 +25,7 @@ import { isOrchestratorSession, sessionIsActive } from "../types/workspace";
 import type { TerminalTarget } from "../types/terminal";
 import { matchesRendererShortcut } from "../stores/keybindings-store";
 
-const INSPECTOR_MIN_PERCENT = 22;
+const INSPECTOR_MIN_PERCENT = 30;
 const INSPECTOR_MAX_PERCENT = 45;
 const inspectorSplitStorageKey = "ao.inspector.split";
 const shellTopbarHiddenByPlatform = hidesShellTopbar();
@@ -33,7 +33,7 @@ const shellTopbarHiddenByPlatform = hidesShellTopbar();
 function initialSplitPercent(): number {
 	const raw = typeof window === "undefined" ? null : window.localStorage?.getItem(inspectorSplitStorageKey);
 	const parsed = raw === null ? Number.NaN : Number(raw);
-	if (!Number.isFinite(parsed)) return 28;
+	if (!Number.isFinite(parsed)) return INSPECTOR_MIN_PERCENT;
 	return Math.min(INSPECTOR_MAX_PERCENT, Math.max(INSPECTOR_MIN_PERCENT, parsed));
 }
 

--- a/frontend/src/shared/browser-annotations.test.ts
+++ b/frontend/src/shared/browser-annotations.test.ts
@@ -72,26 +72,29 @@ describe("formatBrowserAnnotationMessage", () => {
 		const message = formatBrowserAnnotationMessage({
 			viewId: "42:sess-1",
 			instruction: "Make the save button blue and larger.",
-			context: {
-				url: "http://localhost:5173/settings",
-				title: "Settings",
-				tag: "button",
-				id: "save",
-				classes: ["primary"],
-				selector: "button#save",
-				rect: { x: 16, y: 24, width: 140, height: 36 },
-				visibleText: "Save changes",
-				ariaLabel: "Save profile",
-				nearbyText: ["Profile settings"],
-				computedStyle: {
-					display: "inline-flex",
-					position: "static",
-					color: "rgb(255, 255, 255)",
-					backgroundColor: "rgb(0, 0, 0)",
-					fontSize: "14px",
-					fontWeight: "600",
-					padding: "8px 12px",
-					margin: "0px",
+			selection: {
+				kind: "element",
+				context: {
+					url: "http://localhost:5173/settings",
+					title: "Settings",
+					tag: "button",
+					id: "save",
+					classes: ["primary"],
+					selector: "button#save",
+					rect: { x: 16, y: 24, width: 140, height: 36 },
+					visibleText: "Save changes",
+					ariaLabel: "Save profile",
+					nearbyText: ["Profile settings"],
+					computedStyle: {
+						display: "inline-flex",
+						position: "static",
+						color: "rgb(255, 255, 255)",
+						backgroundColor: "rgb(0, 0, 0)",
+						fontSize: "14px",
+						fontWeight: "600",
+						padding: "8px 12px",
+						margin: "0px",
+					},
 				},
 			},
 		});
@@ -108,20 +111,77 @@ describe("formatBrowserAnnotationMessage", () => {
 		const message = formatBrowserAnnotationMessage({
 			viewId: "42:sess-1",
 			instruction: "Change this. ".repeat(800),
-			context: {
-				url: "http://localhost:5173/",
-				title: "Preview",
-				tag: "div",
-				classes: [],
-				selector: "body > div:nth-of-type(1)",
-				rect: { x: 0, y: 0, width: 100, height: 100 },
-				visibleText: "Long visible text ".repeat(500),
-				nearbyText: ["Nearby copy ".repeat(500)],
-				computedStyle: {},
+			selection: {
+				kind: "element",
+				context: {
+					url: "http://localhost:5173/",
+					title: "Preview",
+					tag: "div",
+					classes: [],
+					selector: "body > div:nth-of-type(1)",
+					rect: { x: 0, y: 0, width: 100, height: 100 },
+					visibleText: "Long visible text ".repeat(500),
+					nearbyText: ["Nearby copy ".repeat(500)],
+					computedStyle: {},
+				},
 			},
 		});
 
 		expect(message.length).toBeLessThanOrEqual(MAX_BROWSER_ANNOTATION_MESSAGE_LENGTH);
 		expect(message).toContain("[truncated]");
+	});
+
+	it("lists every element for a multi-element selection", () => {
+		const elementContext = (overrides: Record<string, unknown>) => ({
+			url: "http://localhost:5173/",
+			tag: "button",
+			classes: [],
+			selector: "button",
+			rect: { x: 10, y: 20, width: 80, height: 30 },
+			nearbyText: [],
+			computedStyle: {},
+			...overrides,
+		});
+		const message = formatBrowserAnnotationMessage({
+			viewId: "1:sess-1",
+			instruction: "Align these two buttons.",
+			selection: {
+				kind: "elements",
+				contexts: [
+					elementContext({ id: "save", selector: "button#save" }),
+					elementContext({ id: "cancel", selector: "button#cancel" }),
+				],
+			},
+		});
+
+		expect(message).toContain("The user selected 2 elements in the AO browser preview and asked for a change.");
+		expect(message).toContain("Selected elements (2) at http://localhost:5173/:");
+		expect(message).toContain("1. button#save (selector: button#save, bounds: x=10, y=20, width=80, height=30)");
+		expect(message).toContain("2. button#cancel (selector: button#cancel, bounds: x=10, y=20, width=80, height=30)");
+	});
+
+	it("pluralizes correctly for a single-element multi-selection", () => {
+		const message = formatBrowserAnnotationMessage({
+			viewId: "1:sess-1",
+			instruction: "Fix this element.",
+			selection: {
+				kind: "elements",
+				contexts: [
+					{
+						url: "http://localhost:5173/",
+						tag: "button",
+						classes: [],
+						selector: "button#fix-me",
+						rect: { x: 10, y: 20, width: 80, height: 30 },
+						nearbyText: [],
+						computedStyle: {},
+					},
+				],
+			},
+		});
+
+		expect(message).toContain("The user selected 1 element in the AO browser preview and asked for a change.");
+		expect(message).toContain("Selected element (1) at http://localhost:5173/:");
+		expect(message).not.toContain("1 elements");
 	});
 });

--- a/frontend/src/shared/browser-annotations.ts
+++ b/frontend/src/shared/browser-annotations.ts
@@ -44,9 +44,13 @@ export type BrowserAnnotationModeInput = {
 	enabled: boolean;
 };
 
+export type BrowserAnnotationSelection =
+	| { kind: "element"; context: BrowserAnnotationContext }
+	| { kind: "elements"; contexts: BrowserAnnotationContext[] };
+
 export type BrowserAnnotationPageSubmitPayload = {
 	instruction: string;
-	context: BrowserAnnotationContext;
+	selection: BrowserAnnotationSelection;
 };
 
 export type BrowserAnnotationSubmitPayload = BrowserAnnotationPageSubmitPayload & {
@@ -106,13 +110,31 @@ export function createBrowserAnnotationContext(element: Element): BrowserAnnotat
 }
 
 export function formatBrowserAnnotationMessage(payload: BrowserAnnotationSubmitPayload): string {
-	const context = payload.context;
+	const selection = payload.selection;
 	const lines = [
-		"The user selected an element in the AO browser preview and asked for a change.",
+		selection.kind === "element"
+			? "The user selected an element in the AO browser preview and asked for a change."
+			: `The user selected ${selection.contexts.length} element${selection.contexts.length === 1 ? "" : "s"} in the AO browser preview and asked for a change.`,
 		"",
 		"Change request:",
 		compactText(payload.instruction, MAX_INSTRUCTION_LENGTH) || "(empty)",
 		"",
+		...(selection.kind === "element"
+			? elementSelectionLines(selection.context)
+			: elementsSelectionLines(selection.contexts)),
+		"",
+		"Execution constraints:",
+		"- Make the smallest source change that satisfies the request.",
+		"- Do not start, restart, or background a dev server.",
+		"- Do not run watch-mode or long-running commands.",
+		"- If verification is needed, use a finite command only; otherwise rely on the existing preview watcher or dev-server refresh.",
+	];
+
+	return limitMessage(lines.join("\n"), MAX_BROWSER_ANNOTATION_MESSAGE_LENGTH);
+}
+
+function elementSelectionLines(context: BrowserAnnotationContext): string[] {
+	return [
 		"Selected element context:",
 		`- URL: ${context.url || "(unknown)"}`,
 		context.title ? `- Title: ${compactText(context.title, 160)}` : null,
@@ -129,15 +151,17 @@ export function formatBrowserAnnotationMessage(payload: BrowserAnnotationSubmitP
 		Object.keys(context.computedStyle).length > 0
 			? `- Computed style: ${compactText(JSON.stringify(context.computedStyle), 700)}`
 			: null,
-		"",
-		"Execution constraints:",
-		"- Make the smallest source change that satisfies the request.",
-		"- Do not start, restart, or background a dev server.",
-		"- Do not run watch-mode or long-running commands.",
-		"- If verification is needed, use a finite command only; otherwise rely on the existing preview watcher or dev-server refresh.",
 	].filter((line): line is string => line !== null);
+}
 
-	return limitMessage(lines.join("\n"), MAX_BROWSER_ANNOTATION_MESSAGE_LENGTH);
+function elementsSelectionLines(contexts: BrowserAnnotationContext[]): string[] {
+	const url = contexts.find((context) => context.url)?.url || "(unknown)";
+	const items = contexts.map((context, index) => {
+		const bounds = `x=${context.rect.x}, y=${context.rect.y}, width=${context.rect.width}, height=${context.rect.height}`;
+		const text = context.visibleText ? ` — ${compactText(context.visibleText, 160)}` : "";
+		return `${index + 1}. ${elementSummary(context)} (selector: ${context.selector}, bounds: ${bounds})${text}`;
+	});
+	return [`Selected element${contexts.length === 1 ? "" : "s"} (${contexts.length}) at ${url}:`, ...items];
 }
 
 function elementSummary(context: BrowserAnnotationContext): string {

--- a/frontend/src/shared/browser-annotations.ts
+++ b/frontend/src/shared/browser-annotations.ts
@@ -140,7 +140,7 @@ export function formatBrowserAnnotationMessage(payload: BrowserAnnotationSubmitP
 	return limitMessage(lines.join("\n"), MAX_BROWSER_ANNOTATION_MESSAGE_LENGTH);
 }
 
-export function elementSummary(context: BrowserAnnotationContext): string {
+function elementSummary(context: BrowserAnnotationContext): string {
 	const id = context.id ? `#${context.id}` : "";
 	const classes = context.classes.length > 0 ? `.${context.classes.join(".")}` : "";
 	return `${context.tag}${id}${classes}`;

--- a/frontend/src/shared/browser-annotations.ts
+++ b/frontend/src/shared/browser-annotations.ts
@@ -140,7 +140,7 @@ export function formatBrowserAnnotationMessage(payload: BrowserAnnotationSubmitP
 	return limitMessage(lines.join("\n"), MAX_BROWSER_ANNOTATION_MESSAGE_LENGTH);
 }
 
-function elementSummary(context: BrowserAnnotationContext): string {
+export function elementSummary(context: BrowserAnnotationContext): string {
 	const id = context.id ? `#${context.id}` : "";
 	const classes = context.classes.length > 0 ? `.${context.classes.join(".")}` : "";
 	return `${context.tag}${id}${classes}`;


### PR DESCRIPTION
## Summary
- Restyles the "Annotate selection" popup in the browser preview panel to match the file diff viewer's inline feedback composer: same surface/border/ring tokens, unified 12px type scale, primary submit button that's disabled until text is entered, and the same `⌘/Ctrl + Enter to send · Esc to cancel` convention.
- Drops the redundant Cancel button (Esc already dismisses the popup) and shows a plain "Annotate on selected components" label instead of a raw element selector.
- Fixes buttons wrapping to two lines when the AO window is narrowed, by making the footer's action row shrink-proof and reflowing the hint below it (instead of above) on very narrow widths.
- Fixes the Geist font not actually rendering in the popup: it was loaded via an `@font-face src: url(data:...)` rule, which the *annotated page's own* CSP (`font-src`) can silently block, falling back to the OS system font. Switched to registering the font as a `FontFace` built from decoded bytes on the shadow root's own `FontFaceSet` — no network fetch, so it isn't subject to the page's CSP.

<img width="447" height="168" alt="image" src="https://github.com/user-attachments/assets/ddb5d02f-cb92-415d-b190-f035c1ecb71b" />



## Test plan
- [x] `npx vitest run --config vite.renderer.config.ts annotate-preload` — 5/5 passing, including new coverage asserting the `FontFace` registration path actually runs with "Geist Variable"/"Geist Mono Variable"
- [x] `npx tsc --noEmit` — clean
- [x] Manual check in the desktop app: open a project's browser preview, enter annotate mode, select an element, confirm the popup matches the diff viewer's feedback box styling and the font renders as Geist

