### PR TITLE
fix: add terminal topbar padding

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -201,12 +201,13 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.getByText("No session")).toBeInTheDocument();
 	});
 
-	it("uses the inspector tab height for the terminal header", () => {
+	it("uses the padded session topbar height for the terminal header", () => {
 		renderCenterPane({ session: worker });
 
 		const tablist = screen.getByRole("tablist", { name: "Open terminals" });
-		const header = tablist.closest(".h-inspector-tabs");
-		expect(header).toHaveClass("h-inspector-tabs");
+		const header = tablist.closest(".h-session-topbar");
+		expect(header).toHaveClass("h-session-topbar");
+		expect(screen.getByTestId("session-workspace-topbar")).toHaveClass("py-1");
 		expect(tablist.parentElement).toHaveClass("h-full");
 	});
 

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -187,13 +187,13 @@ export function CenterPane({
 
 	const terminalTopbar = (
 		<div
-			className="flex h-inspector-tabs w-full shrink-0 items-stretch bg-sidebar"
+			className="flex h-session-topbar w-full shrink-0 items-stretch bg-sidebar"
 			style={{
 				paddingLeft: isFullscreen ? 0 : terminalBounds.leftInset,
 				paddingRight: isFullscreen ? 0 : terminalBounds.rightInset,
 			}}
 		>
-			<div className="session-topbar-surface flex min-w-0 flex-1" data-testid="session-workspace-topbar">
+			<div className="session-topbar-surface flex min-w-0 flex-1 py-1" data-testid="session-workspace-topbar">
 				<div
 					className={cn(
 						"flex min-w-0 shrink items-center pr-1.5",

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -655,7 +655,7 @@ function ShellLayout() {
 				>
 					{routeParams.sessionId ? (
 						<SessionTopbarHost
-							className="relative z-chrome flex h-inspector-tabs w-full shrink-0 overflow-hidden bg-sidebar"
+							className="relative z-chrome flex h-session-topbar w-full shrink-0 overflow-hidden bg-sidebar"
 							data-testid="session-topbar-host"
 						/>
 					) : null}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -186,6 +186,7 @@
 	--spacing-control-board: var(--size-control-board);
 	--spacing-table-head: var(--size-table-head);
 	--spacing-inspector-tabs: var(--size-inspector-tabs);
+	--spacing-session-topbar: var(--size-session-topbar);
 	--spacing-browser-url: var(--size-browser-url);
 	--spacing-browser-min: var(--size-browser-min);
 	--spacing-dot-sm: var(--size-dot-sm);
@@ -495,10 +496,10 @@
 	--sidebar-chrome-offset: var(--size-traffic-light-clearance);
 }
 [data-topbar-offset="session"] {
-	--sidebar-chrome-offset: var(--size-inspector-tabs);
+	--sidebar-chrome-offset: var(--size-session-topbar);
 }
 .platform-windows [data-topbar-offset="session"] {
-	--sidebar-chrome-offset: calc(var(--size-window-titlebar) + var(--size-inspector-tabs));
+	--sidebar-chrome-offset: calc(var(--size-window-titlebar) + var(--size-session-topbar));
 }
 
 /* On macOS the titlebar controls stay fixed when the sidebar is off-canvas.

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -290,7 +290,7 @@ describe("shell workspace startup", () => {
 		const host = screen.getByTestId("session-topbar-host");
 		const sidebar = screen.getByTestId("sidebar");
 		expect(host.compareDocumentPosition(sidebar) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-		expect(host).toHaveClass("h-inspector-tabs");
+		expect(host).toHaveClass("h-session-topbar");
 		expect(sidebar).toHaveAttribute("data-topbar-offset", "session");
 		expect(document.querySelector(".center-panel-shell--session > .center-panel-surface")).toBeInTheDocument();
 	});

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -317,6 +317,7 @@
 	--size-settings-menu-width: 18rem; /* settings option menus — max width cap */
 	--size-settings-agent-menu-min-width: 20rem; /* agent harness picker — wider rows */
 	--size-notification-icon: 26px;
+	--size-session-topbar: calc(var(--size-inspector-tabs) + (2 * var(--space-1)));
 	/* DaemonFailureBanner floating toast (was w-[min(22rem,…)] / max-h-40). */
 	--size-daemon-failure-toast: 22rem;
 	--size-daemon-failure-details-max: 10rem;


### PR DESCRIPTION
## Summary

Adds vertical breathing room to the session terminal topbar so the terminal controls, session action buttons, and notification bell are not pressed against the topbar frame.

## Changes

- Added a dedicated `--size-session-topbar` token derived from the existing inspector tab height plus vertical padding.
- Applied the new topbar height to the session topbar host and renderer surface.
- Updated sidebar chrome offset calculations so session routes remain aligned with the taller topbar.
- Updated renderer tests that assert the session topbar sizing classes.

## Validation

- `npm --prefix frontend test -- CenterPane.test.tsx shell-new-session-shortcut.test.tsx`
- `npm run frontend:typecheck`
- `git diff --check`

## Risks

Low. This is scoped to session-route topbar sizing and padding; related offset tokens were updated with it to avoid layout overlap.

## Before
<img width="1320" height="845" alt="Screenshot 2026-08-04 at 4 51 52 PM" src="https://github.com/user-attachments/assets/1091ea03-1100-4ccb-a4d6-ce8a63e5f4cc" />

## After
<img width="1318" height="805" alt="Screenshot 2026-08-04 at 4 51 41 PM" src="https://github.com/user-attachments/assets/b22cc867-d05e-49b2-a907-c9730c5d84c3" />
