### PR TITLE
fix(storage): heal incomplete chat schema so packaged daemon can start

### DIFF
--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -130,6 +130,13 @@ func migrate(db *sql.DB) error {
 	if err := goose.SetDialect("sqlite3"); err != nil {
 		return fmt.Errorf("set goose dialect: %w", err)
 	}
+	// Recover install/upgrade databases that claim Chat migration 0041+ in
+	// goose_db_version but are missing the base conversation objects. Without
+	// this, 0043 fails with "no such table: conversations" and the packaged
+	// desktop daemon never binds its loopback port.
+	if err := healIncompleteChatBaseSchema(db); err != nil {
+		return fmt.Errorf("heal incomplete chat schema: %w", err)
+	}
 	// Builds can advance a database past a migration that is added or
 	// renumbered later (notably across fast-moving Nightly releases). Apply
 	// those embedded migrations instead of permanently wedging daemon startup

--- a/backend/internal/storage/sqlite/heal_chat_schema.go
+++ b/backend/internal/storage/sqlite/heal_chat_schema.go
@@ -1,0 +1,292 @@
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// healIncompleteChatBaseSchema repairs databases where goose recorded migration
+// 0041 (or later) as applied, but the Chat base objects are missing.
+//
+// That state was observed on upgrade: goose_db_version had 41/42 applied and
+// app_settings existed, yet sessions lacked session_mode and the conversations
+// tables were absent. The next migration (0043) then fails with
+// "no such table: conversations" and the install-build daemon cannot start.
+//
+// The heal is a no-op when 0041 has not been claimed yet (goose still owns a
+// normal Up of 0041) or when the base objects are already present.
+func healIncompleteChatBaseSchema(db *sql.DB) error {
+	claimed, err := chatBaseSchemaClaimed(db)
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return nil
+	}
+
+	if err := ensureSessionChatColumns(db); err != nil {
+		return err
+	}
+	if err := ensureConversationBaseTables(db); err != nil {
+		return err
+	}
+	return ensureConversationBaseTriggers(db)
+}
+
+func chatBaseSchemaClaimed(db *sql.DB) (bool, error) {
+	var n int
+	// goose_db_version may not exist on a brand-new file; treat that as unclaimed.
+	err := db.QueryRow(`
+SELECT COUNT(*) FROM sqlite_master
+WHERE type = 'table' AND name = 'goose_db_version'
+`).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("check goose_db_version: %w", err)
+	}
+	if n == 0 {
+		return false, nil
+	}
+	// Only heal when 0041 itself is recorded as applied. A later version alone
+	// (AllowMissing histories) still needs goose to run the real 0041 file.
+	err = db.QueryRow(`
+SELECT COUNT(*) FROM goose_db_version
+WHERE is_applied = 1 AND version_id = 41
+`).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("query chat migration claim: %w", err)
+	}
+	return n > 0, nil
+}
+
+func tableExists(db *sql.DB, name string) (bool, error) {
+	var n int
+	err := db.QueryRow(`
+SELECT COUNT(*) FROM sqlite_master
+WHERE type = 'table' AND name = ?
+`, name).Scan(&n)
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func columnExists(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query(fmt.Sprintf(`PRAGMA table_info(%s)`, table))
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+func ensureSessionChatColumns(db *sql.DB) error {
+	for _, col := range []struct {
+		name string
+		ddl  string
+	}{
+		{"session_mode", `ALTER TABLE sessions ADD COLUMN session_mode TEXT NOT NULL DEFAULT 'tui'`},
+		{"provider_conversation_id", `ALTER TABLE sessions ADD COLUMN provider_conversation_id TEXT NOT NULL DEFAULT ''`},
+		{"controller_generation", `ALTER TABLE sessions ADD COLUMN controller_generation TEXT NOT NULL DEFAULT ''`},
+	} {
+		ok, err := columnExists(db, "sessions", col.name)
+		if err != nil {
+			return fmt.Errorf("check sessions.%s: %w", col.name, err)
+		}
+		if ok {
+			continue
+		}
+		if _, err := db.Exec(col.ddl); err != nil {
+			return fmt.Errorf("heal sessions.%s: %w", col.name, err)
+		}
+	}
+	return nil
+}
+
+func ensureConversationBaseTables(db *sql.DB) error {
+	// CREATE TABLE IF NOT EXISTS keeps a partial heal from erroring if one of the
+	// conversation tables already exists while another is missing.
+	const ddl = `
+CREATE TABLE IF NOT EXISTS conversations (
+    id              TEXT PRIMARY KEY,
+    scope           TEXT NOT NULL CHECK (scope IN ('session', 'project')),
+    project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    session_id      TEXT REFERENCES sessions(id) ON DELETE CASCADE,
+    latest_sequence INTEGER NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP NOT NULL,
+    updated_at      TIMESTAMP NOT NULL,
+    CHECK ((scope = 'session' AND session_id IS NOT NULL)
+        OR (scope = 'project' AND session_id IS NULL))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_session ON conversations(session_id)
+    WHERE session_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_project_scope ON conversations(project_id)
+    WHERE scope = 'project';
+
+CREATE TABLE IF NOT EXISTS conversation_turns (
+    id                     TEXT PRIMARY KEY,
+    conversation_id        TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    handled_by_session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    provider_turn_id       TEXT NOT NULL DEFAULT '',
+    controller_generation  TEXT NOT NULL DEFAULT '',
+    state                  TEXT NOT NULL CHECK (state IN ('queued', 'running', 'completed', 'interrupted', 'failed')),
+    error_message          TEXT NOT NULL DEFAULT '',
+    requested_at           TIMESTAMP NOT NULL,
+    started_at             TIMESTAMP,
+    completed_at           TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_conversation_turns_conversation ON conversation_turns(conversation_id, requested_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_turns_provider ON conversation_turns(conversation_id, provider_turn_id)
+    WHERE provider_turn_id <> '';
+
+CREATE TABLE IF NOT EXISTS conversation_messages (
+    id                TEXT PRIMARY KEY,
+    conversation_id   TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    turn_id           TEXT REFERENCES conversation_turns(id) ON DELETE SET NULL,
+    sequence          INTEGER NOT NULL,
+    revision          INTEGER NOT NULL DEFAULT 0,
+    role              TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+    origin            TEXT NOT NULL CHECK (origin IN ('human', 'automation', 'daemon', 'provider')),
+    text              TEXT NOT NULL DEFAULT '',
+    streaming          INTEGER NOT NULL DEFAULT 0,
+    provider_item_id  TEXT NOT NULL DEFAULT '',
+    client_message_id TEXT NOT NULL DEFAULT '',
+    created_at        TIMESTAMP NOT NULL,
+    updated_at        TIMESTAMP NOT NULL,
+    UNIQUE (conversation_id, sequence)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_messages_provider_item
+    ON conversation_messages(conversation_id, provider_item_id)
+    WHERE provider_item_id <> '';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_messages_client_id
+    ON conversation_messages(conversation_id, client_message_id)
+    WHERE client_message_id <> '';
+CREATE INDEX IF NOT EXISTS idx_conversation_messages_order
+    ON conversation_messages(conversation_id, sequence);
+
+CREATE TABLE IF NOT EXISTS conversation_activities (
+    id                TEXT PRIMARY KEY,
+    conversation_id   TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    turn_id           TEXT REFERENCES conversation_turns(id) ON DELETE SET NULL,
+    sequence          INTEGER NOT NULL,
+    revision          INTEGER NOT NULL DEFAULT 0,
+    kind              TEXT NOT NULL CHECK (kind IN ('command', 'file_change', 'plan', 'reasoning', 'approval', 'usage', 'error', 'system')),
+    status            TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed', 'pending', 'resolved')),
+    summary           TEXT NOT NULL DEFAULT '',
+    detail_json       TEXT NOT NULL DEFAULT '',
+    request_id        TEXT NOT NULL DEFAULT '',
+    provider_item_id  TEXT NOT NULL DEFAULT '',
+    created_at        TIMESTAMP NOT NULL,
+    updated_at        TIMESTAMP NOT NULL,
+    UNIQUE (conversation_id, sequence)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_activities_provider_item
+    ON conversation_activities(conversation_id, provider_item_id)
+    WHERE provider_item_id <> '';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_activities_request
+    ON conversation_activities(conversation_id, request_id)
+    WHERE request_id <> '';
+CREATE INDEX IF NOT EXISTS idx_conversation_activities_order
+    ON conversation_activities(conversation_id, sequence);
+CREATE INDEX IF NOT EXISTS idx_conversation_activities_pending
+    ON conversation_activities(conversation_id, kind, status);
+
+CREATE TABLE IF NOT EXISTS conversation_provider_events (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id    TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    session_id         TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    provider_event_id  TEXT NOT NULL DEFAULT '',
+    method             TEXT NOT NULL,
+    payload_json       TEXT NOT NULL,
+    received_at        TIMESTAMP NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_provider_events_dedupe
+    ON conversation_provider_events(conversation_id, provider_event_id)
+    WHERE provider_event_id <> '';
+CREATE INDEX IF NOT EXISTS idx_conversation_provider_events_replay
+    ON conversation_provider_events(conversation_id, id);
+`
+	if _, err := db.Exec(ddl); err != nil {
+		return fmt.Errorf("heal conversation base tables: %w", err)
+	}
+	return nil
+}
+
+func ensureConversationBaseTriggers(db *sql.DB) error {
+	// Recreate only when missing so a healthy database is not rewritten on every boot.
+	for _, name := range []string{
+		"conversation_messages_cdc_insert",
+		"conversation_activities_cdc_insert",
+		"conversation_turns_cdc_update",
+	} {
+		var n int
+		if err := db.QueryRow(`
+SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name = ?
+`, name).Scan(&n); err != nil {
+			return fmt.Errorf("check trigger %s: %w", name, err)
+		}
+		if n > 0 {
+			continue
+		}
+		var ddl string
+		switch name {
+		case "conversation_messages_cdc_insert":
+			ddl = `
+CREATE TRIGGER conversation_messages_cdc_insert
+AFTER INSERT ON conversation_messages
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, s.id, 'session_updated',
+           json_object('id', s.id, 'activity', s.activity_state,
+                       'isTerminated', json(CASE WHEN s.is_terminated THEN 'true' ELSE 'false' END)),
+           NEW.updated_at
+    FROM conversations c
+    JOIN sessions s ON s.id = c.session_id
+    WHERE c.id = NEW.conversation_id;
+END;`
+		case "conversation_activities_cdc_insert":
+			ddl = `
+CREATE TRIGGER conversation_activities_cdc_insert
+AFTER INSERT ON conversation_activities
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, s.id, 'session_updated',
+           json_object('id', s.id, 'activity', s.activity_state,
+                       'isTerminated', json(CASE WHEN s.is_terminated THEN 'true' ELSE 'false' END)),
+           NEW.updated_at
+    FROM conversations c
+    JOIN sessions s ON s.id = c.session_id
+    WHERE c.id = NEW.conversation_id;
+END;`
+		case "conversation_turns_cdc_update":
+			ddl = `
+CREATE TRIGGER conversation_turns_cdc_update
+AFTER UPDATE ON conversation_turns
+WHEN OLD.state <> NEW.state
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, s.id, 'session_updated',
+           json_object('id', s.id, 'activity', s.activity_state,
+                       'isTerminated', json(CASE WHEN s.is_terminated THEN 'true' ELSE 'false' END)),
+           COALESCE(NEW.completed_at, NEW.started_at, NEW.requested_at)
+    FROM sessions s
+    WHERE s.id = NEW.handled_by_session_id;
+END;`
+		}
+		if _, err := db.Exec(ddl); err != nil {
+			return fmt.Errorf("heal trigger %s: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/backend/internal/storage/sqlite/heal_chat_schema_test.go
+++ b/backend/internal/storage/sqlite/heal_chat_schema_test.go
@@ -1,0 +1,125 @@
+package sqlite
+
+import (
+	"testing"
+	"time"
+)
+
+// Mirrors the production failure that blocked packaged-app startup: goose has
+// already recorded 0041/0042, app_settings exists, but conversation tables and
+// session chat columns were never created. migrate() must heal that hole and
+// then finish later chat migrations.
+func TestMigrateHealsClaimedButMissingChatBaseSchema(t *testing.T) {
+	db := openTestDB(t)
+	upTo(t, db, 40)
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO projects (id, path, display_name, registered_at)
+		VALUES ('p1', '/tmp/p1', 'proj', ?)`, now); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO sessions (id, project_id, num, kind, activity_state, activity_last_at, is_terminated, created_at, updated_at)
+		VALUES ('ao-1', 'p1', 1, 'worker', 'idle', ?, 0, ?, ?)`, now, now, now); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	// Claim 0041/0042 the way a damaged install history did: version rows and
+	// 0042's table without any 0041 objects.
+	if _, err := db.Exec(`INSERT INTO goose_db_version (version_id, is_applied, tstamp) VALUES (41, 1, ?)`, now); err != nil {
+		t.Fatalf("claim 41: %v", err)
+	}
+	if _, err := db.Exec(`
+CREATE TABLE app_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    default_session_mode TEXT NOT NULL DEFAULT 'tui'
+        CHECK (default_session_mode IN ('chat', 'tui')),
+    updated_at TIMESTAMP NOT NULL
+)`); err != nil {
+		t.Fatalf("create app_settings: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO app_settings (id, default_session_mode, updated_at) VALUES (1, 'tui', ?)`, now); err != nil {
+		t.Fatalf("seed app_settings: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO goose_db_version (version_id, is_applied, tstamp) VALUES (42, 1, ?)`, now); err != nil {
+		t.Fatalf("claim 42: %v", err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate damaged chat history: %v", err)
+	}
+
+	for _, table := range []string{
+		"conversations",
+		"conversation_turns",
+		"conversation_messages",
+		"conversation_activities",
+		"conversation_provider_events",
+	} {
+		ok, err := tableExists(db, table)
+		if err != nil {
+			t.Fatalf("tableExists %s: %v", table, err)
+		}
+		if !ok {
+			t.Fatalf("expected table %s after heal", table)
+		}
+	}
+
+	for _, col := range []string{"session_mode", "provider_conversation_id", "controller_generation"} {
+		ok, err := columnExists(db, "sessions", col)
+		if err != nil {
+			t.Fatalf("columnExists sessions.%s: %v", col, err)
+		}
+		if !ok {
+			t.Fatalf("expected sessions.%s after heal", col)
+		}
+	}
+
+	var mode string
+	if err := db.QueryRow(`SELECT session_mode FROM sessions WHERE id = 'ao-1'`).Scan(&mode); err != nil {
+		t.Fatalf("read backfilled session_mode: %v", err)
+	}
+	if mode != "tui" {
+		t.Fatalf("healed session_mode = %q, want tui", mode)
+	}
+
+	// Later additive chat migrations must be able to run after the heal.
+	ok, err := columnExists(db, "conversations", "model")
+	if err != nil {
+		t.Fatalf("columnExists conversations.model: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected conversations.model from 0043 after heal+migrate")
+	}
+
+	// Idempotent: a second migrate must not fail on the healed schema.
+	if err := migrate(db); err != nil {
+		t.Fatalf("repeat migrate after heal: %v", err)
+	}
+}
+
+// A clean database that has never claimed 0041 must still rely on goose, not
+// the heal path, for creating Chat objects.
+func TestMigrateDoesNotHealBeforeChatMigrationClaimed(t *testing.T) {
+	db := openTestDB(t)
+	upTo(t, db, 40)
+
+	ok, err := tableExists(db, "conversations")
+	if err != nil {
+		t.Fatalf("tableExists: %v", err)
+	}
+	if ok {
+		t.Fatal("conversations should not exist before 0041")
+	}
+
+	// Heal alone must no-op when goose has not claimed chat migrations.
+	if err := healIncompleteChatBaseSchema(db); err != nil {
+		t.Fatalf("heal before claim: %v", err)
+	}
+	ok, err = tableExists(db, "conversations")
+	if err != nil {
+		t.Fatalf("tableExists after no-op heal: %v", err)
+	}
+	if ok {
+		t.Fatal("heal created conversations before 0041 was claimed")
+	}
+}


### PR DESCRIPTION
## Summary
- On packaged install/upgrade, some local `ao.db` files had goose migration **0041** marked applied without creating `conversations` (or `sessions.session_mode` columns).
- The next migration **0043** then failed with `no such table: conversations`, so the install-build daemon never listened on `127.0.0.1:3001` and the app looked broken.
- Before `goose.Up`, detect that incomplete claim and recreate the 0041 base objects (tables/indexes/triggers + session columns) so later chat migrations can finish.

## Test plan
- [x] `go test ./internal/storage/sqlite/ -count=1`
- [x] Regression test seeds claimed 0041/0042 without conversation tables; migrate heals and applies 0043+.
- [x] Local packaged app start against a previously broken `~/.ao/data/ao.db` reaches daemon port 3001 after heal.