### PR TITLE
fix(topbar): remove resting border on Kill button

### DIFF
--- a/frontend/src/renderer/components/TopbarButton.tsx
+++ b/frontend/src/renderer/components/TopbarButton.tsx
@@ -11,7 +11,7 @@ const topbarButtonVariants = cva(
 				accent:
 					"h-control-lg gap-1.5 rounded-md border border-border px-3.5 text-sm font-semibold leading-none bg-raised text-muted-foreground hover:bg-surface hover:text-foreground",
 				icon: "grid size-control-lg place-items-center rounded-md text-muted-foreground hover:bg-interactive-hover hover:text-foreground",
-				kill: "h-control-lg gap-1.5 rounded-md border border-border bg-transparent px-3.5 text-sm font-semibold leading-none text-error/80 hover:border-error/50 hover:bg-error/10 hover:text-error",
+				kill: "h-control-lg gap-1.5 rounded-md border border-transparent bg-transparent px-3.5 text-sm font-semibold leading-none text-error/80 hover:border-error/50 hover:bg-error/10 hover:text-error",
 				killConfirm:
 					"h-control-lg gap-1.5 rounded-md border border-error/40 bg-error/10 px-3 text-control font-semibold leading-none text-error hover:bg-error/16",
 				killCancel:


### PR DESCRIPTION
## What

Removes the faint resting border on the topbar Kill button that appeared as an unwanted faded line to the left of the button.

## Why

The `kill` variant in `TopbarButton.tsx` used `border-border`, which in dark mode renders at `oklch(1 0 0 / 7%)` — a near-invisible but still noticeable outline. With `bg-transparent` on the button, the left edge of this outline read as a stray vertical divider rather than a complete rectangle border.

## Change

`border-border` → `border-transparent` on the `kill` variant. The border keeps its 1px width so there is zero layout shift when `hover:border-error/50` activates on hover.

| Before | After |
|--------|-------|
| Faint outline visible at rest | Clean — no border until hover |

## Test

- `tsc --noEmit` ✅
- `ShellTopbar.test.tsx` — 27/27 passed ✅