### PR TITLE
fix: keep pinned sessions under Projects in hero mockup

### DIFF
--- a/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.tsx
+++ b/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.tsx
@@ -1298,8 +1298,9 @@ function SidebarSessionRow({
 
 function Sidebar({ cards }: { cards: PreviewCard[] }) {
 	const activeCards = cards.filter((card) => !card.merging);
+	// Pin is a shortcut: pinned sessions also stay under their project.
 	const pinnedCards = activeCards.filter(isPinnedSidebarCard);
-	const projectCards = activeCards.filter((card) => !isPinnedSidebarCard(card));
+	const projectCards = activeCards;
 	return (
 		<aside
 			aria-hidden="true"


### PR DESCRIPTION
## Summary
- Landing hero sidebar was treating pin as exclusive: pinned cards were filtered out of Projects.
- Projects now lists all active sessions; Pinned still shows the pin shortcut set.

## Test plan
- [ ] Open the landing hero mockup and confirm Pinned has review/ready/pending/merge cards
- [ ] Confirm those same sessions also appear under Projects → agent-orchestrator
- [ ] Confirm non-pinned working sessions still appear only under Projects