### PR TITLE
docs: ACP streaming output gap matrix (ABF vs Fenzhi vs main)

### DIFF
--- a/docs/plans/acp-abf-fenzhi-gap-matrix.md
+++ b/docs/plans/acp-abf-fenzhi-gap-matrix.md
@@ -1,274 +1,224 @@
-# ACP gap matrix: AllBeingsFuture vs Fenzhi AO design vs current main
+# ACP streaming output gap matrix (ABF vs Fenzhi vs current main)
 
-**Status:** docs gap analysis (no product code in this deliverable)  
-**Date:** 2026-08-04  
-**Audience:** backend and frontend implementers migrating Agent Client Protocol (ACP) into current `agent-orchestrator`  
-**Sources (read-only):**
+**Status:** docs gap analysis — **streaming output only** (not full product ACP: no package resolve, multi-provider product, MCP product, session lifecycle beyond stream effects)  
+**Date:** 2026-08-04 (scope correction)  
+**Audience:** backend + frontend implementers who must land **live agent stream output** in current `agent-orchestrator`  
+**File:** `docs/plans/acp-abf-fenzhi-gap-matrix.md`
 
-| Source | Path / refs | Role |
-| --- | --- | --- |
-| **ABF** | `/Users/zhongshengjieweilai/Desktop/AllBeingsFuture` — `docs/acp-architecture.md`, `frontend/docs/acp-renderer-streaming.md`, `electron/bridge/adapters/acp.ts`, `electron/bridge/acp-package-resolve.ts`, tests under `electron/tests/acp-*` | TypeScript Electron-main ACP client + renderer normalized stream contract |
-| **Fenzhi** | `/Users/zhongshengjieweilai/Desktop/fenzhi` — `backend/internal/ports/chat.go`, `backend/internal/adapters/chatdriver/acp/*`, provider bindings (`claudeacp`, `nativeacp`, `droidacp`, `opencodeacp`), `frontend/src/renderer/components/chat/*`, `frontend/acp-runtime` | Go daemon Chat driver over ACP + durable conversation UI |
-| **Current main** | this worktree (aligned with `origin/main` at analysis time) | Terminal/runtime session model only; **no ACP / Chat driver stack** |
+## Scope
 
-## Executive summary
+| In scope | Out of scope (do not block stream work) |
+| --- | --- |
+| Normalized stream event types | Full ACP product (auth, resume policy, packaging, multi-provider matrix) |
+| Envelope + sequence / ordering | Worktree, spawn, binary discovery |
+| StreamNormalizer (BridgeEvent → stream event) | Durable storage schema design (except how revision/sequence feeds live UI) |
+| text / thinking / tool / plan / permission / terminal events | Non-stream features (skills, compaction, models catalog) |
+| Batching, coalescing, replay safety | Experimental ACP v2 |
+| ABF Electron IPC vs AO HTTP/SSE transport | Terminal TUI byte streams |
 
-Current `agent-orchestrator` **main has no ACP surface**: no `ports.ChatDriver`, no `chatdriver/*`, no conversation domain projection for machine-protocol turns, no chat workspace UI, no packaged ACP runtime. Migrating ACP is a greenfield port against the **Fenzhi AO design** (daemon-owned Go transport + provider-neutral `ChatEvent`s), informed by **ABF** for stable v1 wire semantics, permission UX, package-resolve pitfalls, and stream-ordering rules.
+## Sources (read-only)
 
-**Architectural default for AO implementers:** follow **Fenzhi’s placement** (daemon Go adapter, not Electron-main process ownership). Use **ABF** as a clean-room checklist for stable ACP v1 mapping, IPC/stream sequencing discipline, and Electron packaging of JS wrappers. Do **not** paste ABF’s Electron `BridgeManager`/`agent:stream` path into AO’s renderer; AO already owns agent lifecycle in the loopback daemon.
-
-### Design tension to resolve early
-
-| Topic | ABF | Fenzhi | Recommendation for current AO |
-| --- | --- | --- | --- |
-| Process owner | Electron main | Daemon (Go) | **Daemon** (match AO architecture) |
-| SDK | `@agentclientprotocol/sdk` (TS) | `github.com/coder/acp-go-sdk` | **Go SDK in daemon**; keep renderer SDK-free |
-| Resume | `session/load` when `loadSession` | `session/resume` required | Prefer Fenzhi **resume**; optionally support **load** if product needs agents that only advertise `loadSession` |
-| Stream model | Monotonic `sequence` IPC `AgentStreamEvent` | `ChatEvent` channel → durable projection / HTTP+SSE | Prefer Fenzhi **domain events**; borrow ABF **monotonicity / append-only delta** rules for any live stream |
-| Client capabilities | Conservative `fs/terminal: false`; may advertise `plan` | No fs/terminal; elicitation + plan caps + extension meta | Match Fenzhi production honesty; gate experimental features |
+| Source | Streaming-relevant artifacts |
+| --- | --- |
+| **ABF** | `frontend/src/types/agentStreamTypes.ts`, `core/chat/agentStreamCore.ts`, `core/chat/agentStreamBatch.ts`, `hooks/agentStreamIpc.ts`, `docs/acp-architecture.md` §4, `frontend/docs/acp-renderer-streaming.md`, adapter emits internal `BridgeEvent` in `electron/bridge/adapters/acp.ts` |
+| **Fenzhi** | `backend/internal/ports/chat.go` (`ChatEvent` / kinds), ACP `SessionUpdate` → `ChatEvent` in `chatdriver/acp/client.go`, projector folds into conversation snapshot, frontend `useConversation` (ordered snapshot + poll; CDC SSE invalidates workspaces) |
+| **Current main** | Generic CDC SSE (`/api/v1/events`), notification stream, terminal mux WS — **no** agent stream event union, **no** StreamNormalizer, **no** chat conversation stream |
 
 ---
 
-## Capability matrix
+## 1. Architecture sketch
 
-Legend for **Current main**: `Missing` = not present; `Partial` = related substrate exists but not ACP/Chat; `Present` would mean shipped ACP/Chat behavior (none at analysis time).
+```text
+ABF path
+  ACP session/update  →  AcpAdapter BridgeEvent  →  [StreamNormalizer*]  →  AgentStreamEvent{sequence}
+       → Electron IPC `agent:stream`  →  parseAgentStreamEvent  →  batcher  →  reduceAgentStreamEvent
+  * StreamNormalizer is the documented integration seam; may still be incomplete vs runtime BridgeEvent
+
+Fenzhi path
+  ACP session/update  →  chatdriver maps to ports.ChatEvent  →  session_manager projects durable snapshot
+       → REST ConversationSnapshot (ordered by sequence/revision)
+       → UI polls snapshot (active 1s / idle 5s); optional future mux; board CDC SSE is separate
+
+Current main path
+  (missing agent stream)  — only session/workspace CDC SSE + terminal bytes
+```
+
+**Migration default for AO:** keep **daemon-owned** mapping (Fenzhi: ACP → `ChatEvent` → projection). Borrow **ABF’s** pure event union, monotonic sequence, append-only deltas, batch/coalesce, and reducer tests for any **live** path. Do **not** require Electron `agent:stream` IPC as the production transport.
+
+---
+
+## 2. Capability matrix (streaming only)
 
 | Capability | ABF | Fenzhi AO design | Current main | Action for implementers |
 | --- | --- | --- | --- | --- |
-| **Protocol version** | Stable ACP **v1** only (`protocolVersion: 1` / SDK `PROTOCOL_VERSION`); reject mismatch; forbid experimental v2 product paths | Negotiates via `acpsdk.ProtocolVersionNumber` on `Initialize`; incompatible → `ErrChatDriverIncompatible` | **Missing** | Pin one Go ACP SDK; assert negotiated version; CI ban experimental imports; document supported integer (v1). |
-| **Initialize** | `initialize` with clientInfo + conservative `clientCapabilities` (fs/terminal off; plan optional); store `agentCapabilities` / `agentInfo` | `Initialize` with `ClientInfo` name `agent-orchestrator`, `PlanCapabilities`, elicitation caps, Claude-bridge meta (`subagent-transcript`, `terminal_output`); no client fs/terminal | **Missing** | Implement handshake first; advertise only capabilities AO will actually serve; never grant daemon terminal/fs APIs to the agent via ACP client methods. |
-| **Session new** | `session/new` with absolute `cwd`, MCP servers, optional `additionalDirectories` | `session/new` after connect; absolute workspace; MCP + additional dirs gated by agent caps; optional `NewSessionMeta` / mode+config options | **Missing** | `ChatDriver.Start` → new session; require abs worktree; persist provider session id for resume. |
-| **Session load** | Prefer `session/load` when `loadSession` and `resumeSessionId` set | Not primary path; resume uses **ResumeSession** | **Missing** | Decide product path: implement **resume** as primary (Fenzhi); add **load** only if target agents lack resume. Never silently fall back to new session on failed resume. |
-| **Session resume** | Documented as optional later (`sessionCapabilities.resume`) | **Required**: Start/Resume fail if `SessionCapabilities.Resume == nil`; `Resume` reopens stored id without replaying AO transcript | **Missing** | Persist `ProviderConversationID`; resume after daemon restart; surface `ErrChatResumeFailed` to UI with recovery choices. |
-| **Prompt / turn** | One active `session/prompt` per adapter; content blocks (text + images always forwarded); system prompt injection once per process | Deferred turn: `SendTurn` prepares id, `StartDeferredTurn` after durable bind; `session/prompt` with message id; concurrent turn rejected | **Missing** | Backend: deferred binding to avoid race with projections; one in-flight turn; map stopReason → turn state. Frontend: composer send + busy/disable until terminal. |
-| **Cancel / interrupt** | UI Stop → `session/cancel` + cancel pending permissions + grace then kill | `Interrupt` → `session/cancel`; `ErrChatNoActiveTurn` if none; turn cancel context | **Missing** (terminal stop ≠ ACP cancel) | Wire stop control to ACP cancel; cancel parked permissions/elicitations; do not treat late stop as hard error. |
-| **Permissions / approvals** | `session/request_permission` → UI `permission_request`; respond via IPC; autoAccept policy; silent cancel is a known mismatch to fix | Park permission with AO-generated `requestId`; emit `approval.requested` with offered decisions; `ResolveRequest` validates offered option; timeout/cancel outcomes | **Missing** | Backend: park/resolve API (no auto-invented consent). Frontend: approval card from **offered** options only; dual-client race → `ErrChatRequestNotPending`. |
-| **Tool calls** | Map `tool_call` / `tool_call_update`; diff replacement content into append-only `resultDelta`; status pending/in_progress/completed/failed | Tool updates → activity started/completed + command/output deltas; nested agent metadata via parent tool id | **Missing** | Normalize tools into durable activities; append-only output deltas; preserve toolCallId stability. |
-| **Plans** | Full-replace plan events; map ACP `content`→title; synthesize ids; ACP statuses pending/in_progress/completed (`blocked` only for legacy) | `ChatEventPlanUpdated` / `domain.ConversationPlan` steps | **Missing** | Backend emit plan snapshots; frontend `TurnPlan`-style replace UI; do not invent ACP `blocked` on native path. |
-| **Thinking / reasoning** | `agent_thought_chunk` → `thinking_update` mode `delta` | `AgentThoughtChunk` → activity kind reasoning + `reasoning.delta` | **Missing** | Stream reasoning as first-class activity; never replace accumulation with empty settle. |
-| **MCP** | Normalize stdio/http/sse into session new/load; capability checks for http/sse | `normalizeMCPServers` with stdio/http/sse; fail if agent lacks transport; optional MCP server status events; reject ACP-tunneled MCP client methods | **Missing** | Pass session MCP configs at start/resume; gate on agent mcpCapabilities; secrets only to local process env/headers. |
-| **Package / binary resolve** | `acp-package-resolve`: asar vs asar.unpacked; bundled `claude-agent-acp` / `codex-acp`; host CLIs via PATH | Claude: packaged Node + `@agentclientprotocol/claude-agent-acp` under `frontend/acp-runtime`, `CLAUDE_CODE_EXECUTABLE` → user binary; native providers launch **plugin-resolved** binary only (no download) | **Partial** — agent plugins resolve TUI binaries; no ACP runtime pack | Port packaging story: ship adapter runtime for JS bridges; never substitute user CLIs; resolve spawnable paths outside asar. |
-| **Process cleanup** | Ordered destroy: cancel → optional `session/close` → close connection → SIGTERM → SIGKILL; drop maps | `Close`: cancel turn, fail pending permissions/inputs, best-effort `CloseSession`, stdin close + 3s wait + process-group kill; stderr drained to avoid deadlock | **Partial** — session/runtime reaper for TUI processes, not ACP conversations | Implement ACP-specific teardown; process groups (unix); no orphan node/agent on app quit; drain stderr. |
-| **Stream sequencing** | Per local session monotonic `sequence`; renderer drops `<= last`; append-only text/tool deltas; plan full replace; serialize emit | Event channel with buffer; slow consumer disconnected rather than blocking reader; durable projector folds deltas by item id | **Missing** for Chat; SSE/CDC exist for other domains | If live stream: guarantee order per conversation; append-only deltas; terminal events finalize turn. Prefer durable projection as source of truth (Fenzhi). |
-| **Multi-provider** | Profiles: native ACP + legacy Claude/Codex/Gemini/OpenCode/OpenAI adapters; `adapterType` selection | Shared `chatdriver/acp` + thin bindings: `claudeacp`, `opencodeacp`, `droidacp`, `nativeacp`; registry by harness; production floor caps | **Partial** — multi-harness TUI agents only | Reuse agent plugins for discovery/auth; one ACP transport; provider packages only launch/meta/mode mapping. Keep TUI path intact. |
-| **Tests** | Fake ACP agent; init/version/timeout/crash; stream map; permission cancel; cancel cooperative/uncooperative; package resolve; optional live smoke (Grok/Codex) | Extensive `driver_test.go`: deferred prompt, resume, elicitation, nested tools, usage/rate limits, config options, skills, steering; provider package tests | **Missing** for ACP | Port fake-agent tests to Go; production-floor capability tests; resume failure; permission matrix; process cleanup; no network in unit tests. |
+| **AgentStreamEvent / normalized event types** | Typed union: `text_delta`, `thinking_update`, `tool_call`, `tool_update`, `plan`, `status`, `permission_request`, `done`, `error`, `cancelled` | Provider-neutral `ChatEventKind`: `message.delta`, `reasoning.delta`, `activity.*`, `command.output.delta`, `turn.plan`, `approval.*`, `turn.started/completed`, `error`, `controller.state`, plus richer kinds | **Missing** | Define one AO wire shape (prefer Fenzhi kinds on REST/SSE **or** ABF union if a dedicated live stream is added). Keep renderer free of ACP SDK types. |
+| **Envelope** | `{ sessionId, sequence, timestamp?, source? }` on every event; `source.kind` = `native-acp-v1` \| `legacy-adapter` | Snapshot-centric: items carry provider turn/item ids + revisions; no IPC envelope | Session CDC envelopes only (not agent stream) | Live stream: require session/conversation id + monotonic seq. Snapshot path: ordered items + revision (Fenzhi). |
+| **Sequence** | Monotonic per **local** session, start 0, +1 per event; consumer ignores `sequence <= lastSequence` | Daemon snapshot “already ordered by sequence”; projector bumps revision per item on delta | No agent stream sequence | **P0:** allocate sequence (or durable revision) in daemon; document whether live clients drop stale seq; never reset mid-session without resetting consumer state. |
+| **StreamNormalizer** | Documented seam: internal `BridgeEvent` (`event: delta\|thinking\|tool\|…`) → `AgentStreamEvent` (`type: text_delta\|…`); field renames M6–M20 | Adapter **is** the normalizer: ACP → `ChatEvent` inside Go driver; no separate BridgeEvent SPI | **Missing** | Backend: map ACP `session/update` once at driver boundary. If dual paths exist, one normalizer module with unit tests per event kind. |
+| **text_delta** | Append-only `delta` + required `itemId`; never cumulative text in `delta` | `message.delta` with `Delta` + `ProviderItemID`; projector appends | **Missing** | Emit append-only chunks; stable item id (synthesize if ACP omits messageId). |
+| **thinking / reasoning** | `thinking_update` + `mode: 'delta'\|'replace'`; ACP uses delta | `activity.started` (reasoning) + `reasoning.delta` | **Missing** | Stream reasoning as first-class activity; delta append; do not replace accumulation with empty settle. |
+| **tool events** | Split `tool_call` vs `tool_update`; status pending/in_progress/completed/failed; `resultDelta` / `output.text` append-only; title required | `activity.started/completed` + `command.output.delta` / activity text; nested parent tool meta | **Missing** | Create then update; diff ACP replacement content before emitting deltas; stable `toolCallId`. |
+| **plan events** | Full **replace** snapshot: `{ title?, entries: {id,title,status}[] }`; synthesize ids; no native `blocked` from ACP v1 | `turn.plan` → `ConversationPlan` steps (pending/in_progress/completed) | **Missing** | Replace entire plan per event; map ACP `content`→title; synthesize stable entry ids. |
+| **permission stream events** | `permission_request` with options (`optionId`, `label`, `kind`); blocks UI until respond/cancel | `approval.requested` / `approval.resolved` with `RequestID` + offered decisions | **Missing** | Emit request on stream/snapshot; clear on resolve/cancel/terminal; requestId correlatable to Resolve API. |
+| **Terminal events** | `done` / `error` / `cancelled` finalize turn; flush partials; clear permission UI | `turn.completed` + turn state; `error`; controller ready/stopped | **Missing** | One clear terminal per turn; map `stopReason==cancelled` distinctly from success; cancel pending permissions in stream state. |
+| **status / controller** | App `status`: starting/running/waiting/idle (not ACP v2 state_change) | `controller.state`: connecting/ready/busy/recovering/stopped | Partial (session activity_state elsewhere) | Map lifecycle for stop button / waiting-on-permission UX without draft ACP v2. |
+| **Batching / coalescing** | `agentStreamBatch`: rAF + maxWait 48ms; batchable: text_delta, thinking delta (not replace), tool_update pending/in_progress; coalesce consecutive same-item deltas keeping **last** sequence | Projection absorbs high-frequency deltas; slow `Events()` consumer disconnected rather than blocking; UI polls snapshot | No agent stream batch | **Frontend:** port batcher if applying live events to React store. **Backend:** serialize emit per conversation; drop-behind policy for live subscribers. |
+| **Replay / reconnect** | Duplicate/old sequence ignored; optional ring buffer for resync; sequence lifetime of local session | REST snapshot is recovery; EventSource Last-Event-ID for CDC only | CDC Last-Event-ID exists for **workspace** events, not agent tokens | Prefer snapshot catch-up after reconnect; if live SSE for tokens is added, include seq + ignore stale; do not double-append text after REST resync. |
+| **IPC vs AO SSE transport** | Electron `webContents.send('agent:stream')` + invoke `agent:permission:respond`; renderer never speaks ACP | No agent:stream IPC; conversation REST + poll; generic `/api/v1/events` CDC for board; approvals via REST resolve | Same CDC/SSE + REST as Fenzhi substrate; **no** conversation stream API | **Do not** invent Electron IPC for stream in AO. Use daemon HTTP: either (A) snapshot poll/mux like Fenzhi or (B) dedicated conversation SSE with ABF-style sequenced events. Permission respond stays REST. |
+| **Legacy coexistence** | While normalized stream active, ignore `chat:update`/`chat:patch` for that session | Chat vs TUI modes separated; terminal bytes never Chat events | Terminal only | Keep terminal path separate from Chat stream; never parse TUI logs into stream events. |
+| **Tests to port** | See §5 | Driver maps SessionUpdate → ChatEvent; conversation e2e; frontend snapshot mapping | No stream tests | Port ABF reducer/batch/parser tests + Fenzhi map tests; golden fixtures per event type. |
 
 ---
 
-## Expanded notes by area
+## 3. Event type crosswalk (implementers)
 
-### 1. Protocol version and initialize
-
-**ABF** hard-fails when negotiated version ≠ stable v1 and documents capability honesty (do not advertise fs/terminal until implemented).
-
-**Fenzhi** maps auth-ish RPC failures (`-32000`) to `ErrChatAuthRequired` and other init failures to incompatible/unavailable.
-
-**Current main:** no initialize path.
-
-**Implementers:** land Go initialize + capability storage before any UI work; log agentInfo for support.
-
-### 2. Session new / load / resume
-
-| Operation | ABF | Fenzhi | Main |
+| Concern | ABF `AgentStreamEvent.type` | Fenzhi `ChatEventKind` | ACP v1 source (native) |
 | --- | --- | --- | --- |
-| new | yes | yes | no |
-| load | yes (resume path) | no (primary) | no |
-| resume | optional/future in docs | **required** | no |
-| close | best-effort on destroy | best-effort on `Close` | n/a |
+| Assistant text | `text_delta` | `message.delta` (+ `message.completed`) | `session/update` `agent_message_chunk` |
+| Thinking | `thinking_update` | `reasoning.delta` (+ activity started) | `agent_thought_chunk` |
+| Tool open | `tool_call` | `activity.started` | `tool_call` |
+| Tool progress/result | `tool_update` | `activity.completed` / `command.output.delta` / `activity.text` | `tool_call_update` |
+| Plan | `plan` | `turn.plan` | `plan` |
+| Permission | `permission_request` | `approval.requested` / `approval.resolved` | `session/request_permission` |
+| Lifecycle | `status` | `controller.state` / turn started | derived (not v2 state_change) |
+| Terminal OK | `done` | `turn.completed` (completed) | `session/prompt` stopReason ≠ cancelled |
+| Terminal cancel | `cancelled` | `turn.completed` (interrupted) | stopReason `cancelled` |
+| Terminal fail | `error` | `error` + failed turn | transport/prompt failure |
 
-**P0 product rule (from Fenzhi):** failed resume must not silently create a new provider conversation.
+**Field pitfalls (from ABF M-list, still load-bearing):**
 
-### 3. Prompt, cancel, concurrency
-
-Both designs enforce **one active prompt**. Fenzhi’s deferred start is important for AO’s durable turn rows and CDC/SSE consumers—port it when wiring session_manager.
-
-Cancel must:
-
-1. Notify `session/cancel`
-2. Resolve pending permissions/elicitations as cancelled
-3. Eventually emit a terminal turn state (interrupted/cancelled)
-4. Keep process alive when healthy (ABF cooperative cancel) unless destroy/shutdown
-
-### 4. Permissions
-
-ABF documents mismatches M2/M15/M16 (missing IPC broker, requestId, silent cancel). Fenzhi already parks approvals with explicit decision validation.
-
-**AO target:** Fenzhi-style API (`ResolveRequest`) exposed over daemon HTTP, not Electron-only IPC.
-
-### 5. Tool calls, plans, thinking
-
-Shared mapping rules (ABF table is the best wire checklist):
-
-- `agent_message_chunk` → message delta  
-- `agent_thought_chunk` → reasoning delta  
-- `tool_call` / `tool_call_update` → activities (diff replacement content)  
-- `plan` → full plan replace  
-- `usage_update` → usage side channel (do not require non-schema prompt usage)
-
-Fenzhi additionally maps nested subagent text, terminal output metadata, config option updates, available commands as skills, steering extension.
-
-### 6. MCP
-
-Both support stdio/http/sse shapes with capability checks. Neither should reintroduce MCP-over-ACP client tunnels without a security model.
-
-### 7. Package resolve and multi-provider
-
-| Provider style | ABF | Fenzhi |
+| Pitfall | Wrong | Right for stream |
 | --- | --- | --- |
-| Packaged JS ACP wrapper + host CLI | claude-agent-acp, codex-acp + asar unpack | Claude ACP runtime pack + `CLAUDE_CODE_EXECUTABLE` |
-| Native user binary speaking ACP | generic `acp` profile | `nativeacp` / droid / opencode |
-| Legacy non-ACP | separate adapters | keep TUI runtime path |
-
-Current main already has agent plugins for binary discovery—**reuse them** for ACP launch; do not invent a second install tree under Application Support (hard rule: state under `~/.ao` only).
-
-### 8. Stream sequencing vs durable conversation
-
-**ABF renderer contract** (`agentStreamTypes`): sequenced envelopes, ignore stale sequence, terminal `done|error|cancelled`.
-
-**Fenzhi frontend** (`components/chat/*`): conversation timeline, turn settings, plan, approvals, context meter, provider signals—driven by AO conversation APIs/events, not raw ACP.
-
-**Current main frontend:** sessions board + terminal; no chat workspace.
-
-For AO: implement **backend projection first**, then UI against domain snapshots/events (Fenzhi), while enforcing ABF’s **append-only / ordered delivery** invariants on the wire into the projector.
-
-### 9. Tests (minimum bar)
-
-Port/adapt:
-
-1. Initialize v1 success + version mismatch  
-2. Prompt streams text/thinking/tool/plan  
-3. Permission park/resolve/cancel/timeout  
-4. Cancel mid-turn; cancel mid-permission  
-5. Resume happy path + missing id + agent without resume  
-6. MCP unsupported transport fails clearly  
-7. Process exit: no hang on stderr flood; kill tree  
-8. Production floor: streaming + approvals + interrupt + resume  
-9. Provider binding unit tests (launch args/env only)
+| Text field | cumulative `text` as delta | append-only `delta` |
+| Thinking mode | omit mode | ACP → `delta`; legacy may `replace` |
+| itemId | optional | required / synthesized |
+| Tools | single `tool` + `isUpdate` | split create vs update |
+| Tool title | name only | always non-empty title |
+| Tool body | full rawOutput every update | diff → `resultDelta` / output text |
+| Plan entry | ACP `content`/`priority` | `id` + `title` + status |
+| Permission label | ACP `name` | UI `label` |
+| Permission id | missing | stable requestId for resolve |
+| Cancel terminal | `done` + stopReason cancelled only | distinct cancelled / interrupted |
+| sessionId on envelope | remote ACP id | **AO local** session/conversation id |
 
 ---
 
-## What current main already has (substrate, not ACP)
+## 4. IPC vs AO SSE (transport decision)
 
-Useful existing pieces **not** to reinvent:
+| Dimension | ABF IPC `agent:stream` | AO CDC SSE today | Fenzhi conversation live path | Recommendation for stream migration |
+| --- | --- | --- | --- | --- |
+| Carrier | Electron main → renderer | `EventSource` `/api/v1/events` | REST snapshot poll (+ planned mux) | Daemon HTTP; not Electron ACP |
+| Payload | Full `AgentStreamEvent` | Change-log style invalidation | Full ordered snapshot | **Tokens:** either sequenced live events or revisioned snapshot fields—not workspace-only invalidation |
+| Ordering | `sequence` on event | Last-Event-ID cursor | Server-ordered snapshot | Server is authority for order |
+| Reconnect | lastSequence drop | Last-Event-ID resume | Refetch snapshot | Snapshot catch-up mandatory |
+| Permissions | IPC invoke | n/a | REST resolve + snapshot | REST resolve |
+| High-frequency text | Client rAF batch | Low rate CDC | Poll absorbs | Batch on client **or** coalesce in projector |
+| Multi-client | Single Electron window | Multi-subscriber | Multi-client REST | Prefer Fenzhi multi-client model |
 
-- Daemon loopback HTTP, services, SQLite, CDC/SSE patterns  
-- Session lifecycle, worktrees, permission mode vocabulary on agent config  
-- Agent plugins / harness registry for TUI launch and auth probes  
-- Frontend Electron thin client + typed API client generation pipeline  
-
-Still **absent** relative to Fenzhi:
-
-- `ports/chat.go` and all Chat* types  
-- `adapters/chatdriver/**`  
-- Conversation domain / storage / HTTP controllers for turns  
-- Chat UI (`ChatWorkspace`, approvals, plans, reasoning)  
-- Packaged `acp-runtime` for JS bridges  
+**Anti-pattern:** emitting token deltas only as CDC “conversation.updated” without payload, then refetching huge snapshots every token without coalescing—too heavy. Prefer projector-side coalesce + throttled invalidate, or a dedicated conversation SSE channel with batched events.
 
 ---
 
-## Priority ranking for implementers
+## 5. Tests that must port
 
-### P0 — must land before any “Chat mode” claim
+### P0 stream tests (minimum bar)
 
-1. **Go ACP transport** in daemon: initialize, session new, prompt, cancel, close, process lifecycle  
-2. **`ports.ChatDriver` / `ChatConversation` / `ChatEvent`** boundary (provider DTOs never escape adapters)  
-3. **Permissions park/resolve** + production floor (streaming, approvals, interrupt, resume)  
-4. **Persist provider conversation id** + **resume without silent new-session**  
-5. **Durable turn projection** (or equivalent) so UI/API can read history after reconnect  
-6. **Fake-agent unit tests** for the above  
+| # | Test | Source to port from | Assert |
+| --- | --- | --- | --- |
+| T1 | Parser/validator rejects malformed envelope (missing sequence/sessionId/type) | ABF `agentStreamIpc.test.ts` | Invalid → drop |
+| T2 | Reducer ignores `sequence <= lastSequence` | ABF `agentStreamCore` tests | No double text |
+| T3 | `text_delta` appends by itemId | ABF core | Concat order correct |
+| T4 | `thinking_update` delta vs replace | ABF core | Replace not merged with delta incorrectly |
+| T5 | `tool_call` then `tool_update` with resultDelta | ABF + Fenzhi client map | Status + append body |
+| T6 | `plan` full replace | ABF + Fenzhi plan map | Entries replaced, not merged by accident |
+| T7 | `permission_request` then clear on terminal/resolve | ABF core | No stuck waiting_permission |
+| T8 | Terminal `done` / `error` / `cancelled` finalize | ABF core | Phase terminal; partials sealed |
+| T9 | Batch coalesce consecutive text/thinking/tool progressive | ABF `agentStreamBatch` tests | Coalesced sequence = last; reduce still idempotent |
+| T10 | ACP SessionUpdate → normalized events map | Fenzhi `driver_test` / ABF adapter tests | Golden ACP fixtures |
+| T11 | Cancel maps to cancelled/interrupted not success | Both | Terminal kind correct |
+| T12 | Reconnect: snapshot/resync does not re-append full history as new deltas | Design | Catch-up replaces or advances cursor |
 
-### P1 — product-complete first providers
+### Nice-to-have (P1)
 
-1. **Claude ACP binding** + packaged Node/runtime resolve (Fenzhi `acp-runtime` model)  
-2. **At least one native binary provider** (OpenCode or Droid pattern)  
-3. **MCP server injection** at session start/resume  
-4. **Plans + thinking + tool activities** end-to-end in UI  
-5. **Frontend chat workspace** consuming daemon APIs (not raw ACP)  
-6. **Process cleanup on session delete / daemon shutdown**  
-
-### P2 — parity / polish
-
-1. Elicitation / structured user input  
-2. Config options, skills, steering, usage/rate-limit banners  
-3. Nested subagent transcript hierarchy  
-4. Optional `session/load` for agents without resume  
-5. ABF-style package-resolve hardening for asar edge cases in desktop builds  
-6. Live smoke tests against real CLIs (gated, non-CI-default)  
-7. Normalized stream sequence numbers if a pure live-tail UI is added beside durable projection  
+- Slow consumer / full buffer disconnect (Fenzhi Events channel policy)  
+- Nested subagent activity text (Fenzhi)  
+- Fail-open silence using `lastEventAt` (ABF stream state)  
+- Parallel legacy + normalized path no double-append (ABF coexistence)
 
 ---
 
-## Backend vs frontend: what to implement first
+## 6. P0 stream gaps (current main) — ranked
 
-### Backend first (blocking)
+These are the **only** P0 items for **streaming output** migration:
 
-1. Port Fenzhi-shaped **`ports/chat.go`** contracts into current backend.  
-2. Implement **`chatdriver/acp`** (SDK connect, lifecycle, event map).  
-3. Wire **session manager / HTTP**: start, resume, send, interrupt, resolve approval, event stream or poll.  
-4. SQLite durability for conversations/turns/activities (follow Fenzhi domain vocabulary where it fits AO storage rules; **new migrations only**).  
-5. Register **one harness** (Claude ACP recommended) behind feature detection / probe.  
-6. Tests with **fake ACP agent** (no network).  
+| Rank | Gap | Why P0 | Owner |
+| --- | --- | --- | --- |
+| **S0** | No normalized agent stream event model on main | Nothing to render or project | Backend (+ FE types) |
+| **S1** | No ACP→normalized map (StreamNormalizer / driver SessionUpdate switch) | Wire never becomes UI facts | Backend |
+| **S2** | No monotonic sequence / revision for stream items | Replay and multi-client double-append | Backend |
+| **S3** | No append-only text/thinking/tool delta rules enforced | Garbled transcript | Backend + FE reducer |
+| **S4** | No plan replace + permission stream events | Incomplete turn UX | Backend + FE |
+| **S5** | No terminal event contract (done/error/cancelled) | Stuck streaming / wrong stop UX | Backend + FE |
+| **S6** | No live delivery path for conversation stream (poll/SSE/mux) beyond generic CDC | UI cannot see tokens | Backend transport + FE subscribe |
+| **S7** | No batch/coalesce strategy for high-frequency deltas | UI jank or SSE flood | FE batcher and/or BE projector |
+| **S8** | Missing unit tests T1–T12 | Regressions inevitable | Both |
 
-### Frontend second (unblocked by stable API)
+### Explicit non-P0 for this streaming slice
 
-1. Generate/open API types once controllers exist (`npm run api`).  
-2. **Chat workspace**: timeline, composer, stop, approval cards, plan panel, reasoning blocks.  
-3. Capability-gated controls (hide skills/config if not negotiated).  
-4. Resume failure UX (offer recover / new conversation—never silent).  
-5. Keep **terminal/TUI mode** working unchanged; chat is additive.  
-
-### Explicit non-goals for first migration slice
-
-- Electron-main ACP client (ABF layout) as the production owner  
-- Experimental ACP v2 / `state_change`  
-- Forcing every TUI harness onto ACP in one PR  
-- Remote HTTP/WebSocket ACP transport  
-- Auto-allow_always without user policy  
+Package resolve, multi-provider product matrix, MCP product config, session/load vs resume product policy, skills, elicitation, usage banners—track elsewhere; do not block S0–S8.
 
 ---
 
-## Suggested module map (target shape on current AO)
+## 7. Backend vs frontend — stream first
+
+### Backend first (blocks meaningful FE)
+
+1. Event vocabulary (`ChatEvent` **or** AO-native clone of ABF union) at the driver boundary.  
+2. ACP `session/update` mapping: text, thinking, tool, plan, permission, usage optional.  
+3. Sequence/revision allocation + serialized emit per conversation.  
+4. Terminal mapping from prompt result / cancel / process death.  
+5. Delivery: project into snapshot **and/or** push sequenced live events over HTTP SSE (not Electron IPC).  
+6. Tests T5, T6, T10, T11 + sequence monotonicity.
+
+### Frontend next
+
+1. Types for stream/snapshot items (generated from OpenAPI when possible).  
+2. Reducer or snapshot mapper: append deltas, replace plan, show permission, handle terminal.  
+3. Port ABF batcher if applying event lists to a store; else rely on snapshot throttle.  
+4. Subscribe path: poll active interval (Fenzhi) **or** conversation SSE; use CDC only as invalidate hint if payloads stay on REST.  
+5. Tests T1–T4, T7–T9, T12.
+
+### Transport choice (record decision in PR)
+
+| Option | Pros | Cons |
+| --- | --- | --- |
+| **A. Fenzhi snapshot poll** | Multi-client, simple reconnect, matches AO REST | Token latency = poll interval unless mux added |
+| **B. Sequenced conversation SSE** | Low latency; ABF sequence tests apply almost 1:1 | Need cursor, backpressure, coalescing |
+| **C. Hybrid** | Snapshot catch-up + SSE live tail | Most moving parts |
+
+**Suggested:** A for MVP stream correctness; add B/C when latency requires it. Either way enforce S2–S5.
+
+---
+
+## 8. Suggested module touchpoints (current AO)
 
 ```text
-backend/internal/ports/chat.go                 # ChatDriver contracts (from Fenzhi design)
-backend/internal/adapters/chatdriver/acp/      # shared ACP transport
-backend/internal/adapters/chatdriver/claudeacp/
-backend/internal/adapters/chatdriver/nativeacp/
-backend/internal/adapters/chatdriver/registry/
-backend/internal/service/…                     # conversation/session chat orchestration
-backend/internal/httpd/controllers/…           # REST + stream
-frontend/acp-runtime/                          # optional packaged JS bridges + Node
-frontend/src/renderer/components/chat/         # workspace UI
-docs/plans/acp-abf-fenzhi-gap-matrix.md        # this file
+backend/internal/ports/          # ChatEvent or stream event contracts
+backend/internal/adapters/…/acp  # SessionUpdate → events (normalizer)
+backend/internal/service/…       # project + sequence + optional SSE
+backend/internal/httpd/…         # conversation snapshot and/or stream route
+frontend/src/…                   # reducer/batcher or snapshot UI binding
+docs/plans/acp-abf-fenzhi-gap-matrix.md  # this streaming matrix
 ```
 
-ABF’s `StreamNormalizer` / `agent:stream` remains a **reference for event purity**, not a required Electron channel name in AO.
+ABF references only (do not copy Electron process ownership):
 
----
-
-## Source file index (for implementers)
-
-### AllBeingsFuture
-
-- `docs/acp-architecture.md` — system architecture, M1–M28 mismatches, test matrix  
-- `frontend/docs/acp-renderer-streaming.md` — renderer event union  
-- `electron/bridge/adapters/acp.ts` — runtime adapter  
-- `electron/bridge/acp-package-resolve.ts` — spawn path / asar  
-- `electron/tests/acp-adapter.test.ts`, `acp-package-resolve.test.ts`, `acp-builtin-smoke.test.ts`  
-- `frontend/src/types/agentStreamTypes.ts`, `frontend/src/core/chat/agentStreamCore.ts`  
-
-### Fenzhi
-
-- `backend/internal/ports/chat.go` — capabilities, events, driver interfaces  
-- `backend/internal/adapters/chatdriver/acp/{driver,client,conversation,process,session_setup}.go`  
-- `backend/internal/adapters/chatdriver/{claudeacp,nativeacp,droidacp,opencodeacp}/`  
-- `backend/internal/adapters/chatdriver/acp/driver_test.go`  
-- `frontend/src/renderer/components/chat/*`  
-- `frontend/acp-runtime/`, `frontend/scripts/build-acp-runtime.mjs`  
-
-### Current main
-
-- No ACP-equivalent packages at analysis time; start from Fenzhi ports + AO `docs/architecture.md` daemon boundaries.
+```text
+frontend/src/types/agentStreamTypes.ts
+frontend/src/core/chat/agentStreamCore.ts
+frontend/src/core/chat/agentStreamBatch.ts
+frontend/src/hooks/agentStreamIpc.ts
+```
 
 ---
 
@@ -276,8 +226,8 @@ ABF’s `StreamNormalizer` / `agent:stream` remains a **reference for event puri
 
 | Item | Value |
 | --- | --- |
-| Deliverable type | Docs only |
-| Protocol target | ACP stable v1 |
-| Preferred implementation lineage for AO | Fenzhi daemon Chat driver |
-| Preferred wire/UX checklist | ABF architecture + streaming contract |
-| Current main ACP status | Absent |
+| Scope | **ACP streaming output only** |
+| Preferred ownership | Daemon (Fenzhi) |
+| Preferred event purity / sequence / batch | ABF |
+| Preferred reconnect | Snapshot catch-up (Fenzhi) |
+| Current main stream status | Absent |

--- a/docs/plans/acp-abf-fenzhi-gap-matrix.md
+++ b/docs/plans/acp-abf-fenzhi-gap-matrix.md
@@ -1,0 +1,283 @@
+# ACP gap matrix: AllBeingsFuture vs Fenzhi AO design vs current main
+
+**Status:** docs gap analysis (no product code in this deliverable)  
+**Date:** 2026-08-04  
+**Audience:** backend and frontend implementers migrating Agent Client Protocol (ACP) into current `agent-orchestrator`  
+**Sources (read-only):**
+
+| Source | Path / refs | Role |
+| --- | --- | --- |
+| **ABF** | `/Users/zhongshengjieweilai/Desktop/AllBeingsFuture` — `docs/acp-architecture.md`, `frontend/docs/acp-renderer-streaming.md`, `electron/bridge/adapters/acp.ts`, `electron/bridge/acp-package-resolve.ts`, tests under `electron/tests/acp-*` | TypeScript Electron-main ACP client + renderer normalized stream contract |
+| **Fenzhi** | `/Users/zhongshengjieweilai/Desktop/fenzhi` — `backend/internal/ports/chat.go`, `backend/internal/adapters/chatdriver/acp/*`, provider bindings (`claudeacp`, `nativeacp`, `droidacp`, `opencodeacp`), `frontend/src/renderer/components/chat/*`, `frontend/acp-runtime` | Go daemon Chat driver over ACP + durable conversation UI |
+| **Current main** | this worktree (aligned with `origin/main` at analysis time) | Terminal/runtime session model only; **no ACP / Chat driver stack** |
+
+## Executive summary
+
+Current `agent-orchestrator` **main has no ACP surface**: no `ports.ChatDriver`, no `chatdriver/*`, no conversation domain projection for machine-protocol turns, no chat workspace UI, no packaged ACP runtime. Migrating ACP is a greenfield port against the **Fenzhi AO design** (daemon-owned Go transport + provider-neutral `ChatEvent`s), informed by **ABF** for stable v1 wire semantics, permission UX, package-resolve pitfalls, and stream-ordering rules.
+
+**Architectural default for AO implementers:** follow **Fenzhi’s placement** (daemon Go adapter, not Electron-main process ownership). Use **ABF** as a clean-room checklist for stable ACP v1 mapping, IPC/stream sequencing discipline, and Electron packaging of JS wrappers. Do **not** paste ABF’s Electron `BridgeManager`/`agent:stream` path into AO’s renderer; AO already owns agent lifecycle in the loopback daemon.
+
+### Design tension to resolve early
+
+| Topic | ABF | Fenzhi | Recommendation for current AO |
+| --- | --- | --- | --- |
+| Process owner | Electron main | Daemon (Go) | **Daemon** (match AO architecture) |
+| SDK | `@agentclientprotocol/sdk` (TS) | `github.com/coder/acp-go-sdk` | **Go SDK in daemon**; keep renderer SDK-free |
+| Resume | `session/load` when `loadSession` | `session/resume` required | Prefer Fenzhi **resume**; optionally support **load** if product needs agents that only advertise `loadSession` |
+| Stream model | Monotonic `sequence` IPC `AgentStreamEvent` | `ChatEvent` channel → durable projection / HTTP+SSE | Prefer Fenzhi **domain events**; borrow ABF **monotonicity / append-only delta** rules for any live stream |
+| Client capabilities | Conservative `fs/terminal: false`; may advertise `plan` | No fs/terminal; elicitation + plan caps + extension meta | Match Fenzhi production honesty; gate experimental features |
+
+---
+
+## Capability matrix
+
+Legend for **Current main**: `Missing` = not present; `Partial` = related substrate exists but not ACP/Chat; `Present` would mean shipped ACP/Chat behavior (none at analysis time).
+
+| Capability | ABF | Fenzhi AO design | Current main | Action for implementers |
+| --- | --- | --- | --- | --- |
+| **Protocol version** | Stable ACP **v1** only (`protocolVersion: 1` / SDK `PROTOCOL_VERSION`); reject mismatch; forbid experimental v2 product paths | Negotiates via `acpsdk.ProtocolVersionNumber` on `Initialize`; incompatible → `ErrChatDriverIncompatible` | **Missing** | Pin one Go ACP SDK; assert negotiated version; CI ban experimental imports; document supported integer (v1). |
+| **Initialize** | `initialize` with clientInfo + conservative `clientCapabilities` (fs/terminal off; plan optional); store `agentCapabilities` / `agentInfo` | `Initialize` with `ClientInfo` name `agent-orchestrator`, `PlanCapabilities`, elicitation caps, Claude-bridge meta (`subagent-transcript`, `terminal_output`); no client fs/terminal | **Missing** | Implement handshake first; advertise only capabilities AO will actually serve; never grant daemon terminal/fs APIs to the agent via ACP client methods. |
+| **Session new** | `session/new` with absolute `cwd`, MCP servers, optional `additionalDirectories` | `session/new` after connect; absolute workspace; MCP + additional dirs gated by agent caps; optional `NewSessionMeta` / mode+config options | **Missing** | `ChatDriver.Start` → new session; require abs worktree; persist provider session id for resume. |
+| **Session load** | Prefer `session/load` when `loadSession` and `resumeSessionId` set | Not primary path; resume uses **ResumeSession** | **Missing** | Decide product path: implement **resume** as primary (Fenzhi); add **load** only if target agents lack resume. Never silently fall back to new session on failed resume. |
+| **Session resume** | Documented as optional later (`sessionCapabilities.resume`) | **Required**: Start/Resume fail if `SessionCapabilities.Resume == nil`; `Resume` reopens stored id without replaying AO transcript | **Missing** | Persist `ProviderConversationID`; resume after daemon restart; surface `ErrChatResumeFailed` to UI with recovery choices. |
+| **Prompt / turn** | One active `session/prompt` per adapter; content blocks (text + images always forwarded); system prompt injection once per process | Deferred turn: `SendTurn` prepares id, `StartDeferredTurn` after durable bind; `session/prompt` with message id; concurrent turn rejected | **Missing** | Backend: deferred binding to avoid race with projections; one in-flight turn; map stopReason → turn state. Frontend: composer send + busy/disable until terminal. |
+| **Cancel / interrupt** | UI Stop → `session/cancel` + cancel pending permissions + grace then kill | `Interrupt` → `session/cancel`; `ErrChatNoActiveTurn` if none; turn cancel context | **Missing** (terminal stop ≠ ACP cancel) | Wire stop control to ACP cancel; cancel parked permissions/elicitations; do not treat late stop as hard error. |
+| **Permissions / approvals** | `session/request_permission` → UI `permission_request`; respond via IPC; autoAccept policy; silent cancel is a known mismatch to fix | Park permission with AO-generated `requestId`; emit `approval.requested` with offered decisions; `ResolveRequest` validates offered option; timeout/cancel outcomes | **Missing** | Backend: park/resolve API (no auto-invented consent). Frontend: approval card from **offered** options only; dual-client race → `ErrChatRequestNotPending`. |
+| **Tool calls** | Map `tool_call` / `tool_call_update`; diff replacement content into append-only `resultDelta`; status pending/in_progress/completed/failed | Tool updates → activity started/completed + command/output deltas; nested agent metadata via parent tool id | **Missing** | Normalize tools into durable activities; append-only output deltas; preserve toolCallId stability. |
+| **Plans** | Full-replace plan events; map ACP `content`→title; synthesize ids; ACP statuses pending/in_progress/completed (`blocked` only for legacy) | `ChatEventPlanUpdated` / `domain.ConversationPlan` steps | **Missing** | Backend emit plan snapshots; frontend `TurnPlan`-style replace UI; do not invent ACP `blocked` on native path. |
+| **Thinking / reasoning** | `agent_thought_chunk` → `thinking_update` mode `delta` | `AgentThoughtChunk` → activity kind reasoning + `reasoning.delta` | **Missing** | Stream reasoning as first-class activity; never replace accumulation with empty settle. |
+| **MCP** | Normalize stdio/http/sse into session new/load; capability checks for http/sse | `normalizeMCPServers` with stdio/http/sse; fail if agent lacks transport; optional MCP server status events; reject ACP-tunneled MCP client methods | **Missing** | Pass session MCP configs at start/resume; gate on agent mcpCapabilities; secrets only to local process env/headers. |
+| **Package / binary resolve** | `acp-package-resolve`: asar vs asar.unpacked; bundled `claude-agent-acp` / `codex-acp`; host CLIs via PATH | Claude: packaged Node + `@agentclientprotocol/claude-agent-acp` under `frontend/acp-runtime`, `CLAUDE_CODE_EXECUTABLE` → user binary; native providers launch **plugin-resolved** binary only (no download) | **Partial** — agent plugins resolve TUI binaries; no ACP runtime pack | Port packaging story: ship adapter runtime for JS bridges; never substitute user CLIs; resolve spawnable paths outside asar. |
+| **Process cleanup** | Ordered destroy: cancel → optional `session/close` → close connection → SIGTERM → SIGKILL; drop maps | `Close`: cancel turn, fail pending permissions/inputs, best-effort `CloseSession`, stdin close + 3s wait + process-group kill; stderr drained to avoid deadlock | **Partial** — session/runtime reaper for TUI processes, not ACP conversations | Implement ACP-specific teardown; process groups (unix); no orphan node/agent on app quit; drain stderr. |
+| **Stream sequencing** | Per local session monotonic `sequence`; renderer drops `<= last`; append-only text/tool deltas; plan full replace; serialize emit | Event channel with buffer; slow consumer disconnected rather than blocking reader; durable projector folds deltas by item id | **Missing** for Chat; SSE/CDC exist for other domains | If live stream: guarantee order per conversation; append-only deltas; terminal events finalize turn. Prefer durable projection as source of truth (Fenzhi). |
+| **Multi-provider** | Profiles: native ACP + legacy Claude/Codex/Gemini/OpenCode/OpenAI adapters; `adapterType` selection | Shared `chatdriver/acp` + thin bindings: `claudeacp`, `opencodeacp`, `droidacp`, `nativeacp`; registry by harness; production floor caps | **Partial** — multi-harness TUI agents only | Reuse agent plugins for discovery/auth; one ACP transport; provider packages only launch/meta/mode mapping. Keep TUI path intact. |
+| **Tests** | Fake ACP agent; init/version/timeout/crash; stream map; permission cancel; cancel cooperative/uncooperative; package resolve; optional live smoke (Grok/Codex) | Extensive `driver_test.go`: deferred prompt, resume, elicitation, nested tools, usage/rate limits, config options, skills, steering; provider package tests | **Missing** for ACP | Port fake-agent tests to Go; production-floor capability tests; resume failure; permission matrix; process cleanup; no network in unit tests. |
+
+---
+
+## Expanded notes by area
+
+### 1. Protocol version and initialize
+
+**ABF** hard-fails when negotiated version ≠ stable v1 and documents capability honesty (do not advertise fs/terminal until implemented).
+
+**Fenzhi** maps auth-ish RPC failures (`-32000`) to `ErrChatAuthRequired` and other init failures to incompatible/unavailable.
+
+**Current main:** no initialize path.
+
+**Implementers:** land Go initialize + capability storage before any UI work; log agentInfo for support.
+
+### 2. Session new / load / resume
+
+| Operation | ABF | Fenzhi | Main |
+| --- | --- | --- | --- |
+| new | yes | yes | no |
+| load | yes (resume path) | no (primary) | no |
+| resume | optional/future in docs | **required** | no |
+| close | best-effort on destroy | best-effort on `Close` | n/a |
+
+**P0 product rule (from Fenzhi):** failed resume must not silently create a new provider conversation.
+
+### 3. Prompt, cancel, concurrency
+
+Both designs enforce **one active prompt**. Fenzhi’s deferred start is important for AO’s durable turn rows and CDC/SSE consumers—port it when wiring session_manager.
+
+Cancel must:
+
+1. Notify `session/cancel`
+2. Resolve pending permissions/elicitations as cancelled
+3. Eventually emit a terminal turn state (interrupted/cancelled)
+4. Keep process alive when healthy (ABF cooperative cancel) unless destroy/shutdown
+
+### 4. Permissions
+
+ABF documents mismatches M2/M15/M16 (missing IPC broker, requestId, silent cancel). Fenzhi already parks approvals with explicit decision validation.
+
+**AO target:** Fenzhi-style API (`ResolveRequest`) exposed over daemon HTTP, not Electron-only IPC.
+
+### 5. Tool calls, plans, thinking
+
+Shared mapping rules (ABF table is the best wire checklist):
+
+- `agent_message_chunk` → message delta  
+- `agent_thought_chunk` → reasoning delta  
+- `tool_call` / `tool_call_update` → activities (diff replacement content)  
+- `plan` → full plan replace  
+- `usage_update` → usage side channel (do not require non-schema prompt usage)
+
+Fenzhi additionally maps nested subagent text, terminal output metadata, config option updates, available commands as skills, steering extension.
+
+### 6. MCP
+
+Both support stdio/http/sse shapes with capability checks. Neither should reintroduce MCP-over-ACP client tunnels without a security model.
+
+### 7. Package resolve and multi-provider
+
+| Provider style | ABF | Fenzhi |
+| --- | --- | --- |
+| Packaged JS ACP wrapper + host CLI | claude-agent-acp, codex-acp + asar unpack | Claude ACP runtime pack + `CLAUDE_CODE_EXECUTABLE` |
+| Native user binary speaking ACP | generic `acp` profile | `nativeacp` / droid / opencode |
+| Legacy non-ACP | separate adapters | keep TUI runtime path |
+
+Current main already has agent plugins for binary discovery—**reuse them** for ACP launch; do not invent a second install tree under Application Support (hard rule: state under `~/.ao` only).
+
+### 8. Stream sequencing vs durable conversation
+
+**ABF renderer contract** (`agentStreamTypes`): sequenced envelopes, ignore stale sequence, terminal `done|error|cancelled`.
+
+**Fenzhi frontend** (`components/chat/*`): conversation timeline, turn settings, plan, approvals, context meter, provider signals—driven by AO conversation APIs/events, not raw ACP.
+
+**Current main frontend:** sessions board + terminal; no chat workspace.
+
+For AO: implement **backend projection first**, then UI against domain snapshots/events (Fenzhi), while enforcing ABF’s **append-only / ordered delivery** invariants on the wire into the projector.
+
+### 9. Tests (minimum bar)
+
+Port/adapt:
+
+1. Initialize v1 success + version mismatch  
+2. Prompt streams text/thinking/tool/plan  
+3. Permission park/resolve/cancel/timeout  
+4. Cancel mid-turn; cancel mid-permission  
+5. Resume happy path + missing id + agent without resume  
+6. MCP unsupported transport fails clearly  
+7. Process exit: no hang on stderr flood; kill tree  
+8. Production floor: streaming + approvals + interrupt + resume  
+9. Provider binding unit tests (launch args/env only)
+
+---
+
+## What current main already has (substrate, not ACP)
+
+Useful existing pieces **not** to reinvent:
+
+- Daemon loopback HTTP, services, SQLite, CDC/SSE patterns  
+- Session lifecycle, worktrees, permission mode vocabulary on agent config  
+- Agent plugins / harness registry for TUI launch and auth probes  
+- Frontend Electron thin client + typed API client generation pipeline  
+
+Still **absent** relative to Fenzhi:
+
+- `ports/chat.go` and all Chat* types  
+- `adapters/chatdriver/**`  
+- Conversation domain / storage / HTTP controllers for turns  
+- Chat UI (`ChatWorkspace`, approvals, plans, reasoning)  
+- Packaged `acp-runtime` for JS bridges  
+
+---
+
+## Priority ranking for implementers
+
+### P0 — must land before any “Chat mode” claim
+
+1. **Go ACP transport** in daemon: initialize, session new, prompt, cancel, close, process lifecycle  
+2. **`ports.ChatDriver` / `ChatConversation` / `ChatEvent`** boundary (provider DTOs never escape adapters)  
+3. **Permissions park/resolve** + production floor (streaming, approvals, interrupt, resume)  
+4. **Persist provider conversation id** + **resume without silent new-session**  
+5. **Durable turn projection** (or equivalent) so UI/API can read history after reconnect  
+6. **Fake-agent unit tests** for the above  
+
+### P1 — product-complete first providers
+
+1. **Claude ACP binding** + packaged Node/runtime resolve (Fenzhi `acp-runtime` model)  
+2. **At least one native binary provider** (OpenCode or Droid pattern)  
+3. **MCP server injection** at session start/resume  
+4. **Plans + thinking + tool activities** end-to-end in UI  
+5. **Frontend chat workspace** consuming daemon APIs (not raw ACP)  
+6. **Process cleanup on session delete / daemon shutdown**  
+
+### P2 — parity / polish
+
+1. Elicitation / structured user input  
+2. Config options, skills, steering, usage/rate-limit banners  
+3. Nested subagent transcript hierarchy  
+4. Optional `session/load` for agents without resume  
+5. ABF-style package-resolve hardening for asar edge cases in desktop builds  
+6. Live smoke tests against real CLIs (gated, non-CI-default)  
+7. Normalized stream sequence numbers if a pure live-tail UI is added beside durable projection  
+
+---
+
+## Backend vs frontend: what to implement first
+
+### Backend first (blocking)
+
+1. Port Fenzhi-shaped **`ports/chat.go`** contracts into current backend.  
+2. Implement **`chatdriver/acp`** (SDK connect, lifecycle, event map).  
+3. Wire **session manager / HTTP**: start, resume, send, interrupt, resolve approval, event stream or poll.  
+4. SQLite durability for conversations/turns/activities (follow Fenzhi domain vocabulary where it fits AO storage rules; **new migrations only**).  
+5. Register **one harness** (Claude ACP recommended) behind feature detection / probe.  
+6. Tests with **fake ACP agent** (no network).  
+
+### Frontend second (unblocked by stable API)
+
+1. Generate/open API types once controllers exist (`npm run api`).  
+2. **Chat workspace**: timeline, composer, stop, approval cards, plan panel, reasoning blocks.  
+3. Capability-gated controls (hide skills/config if not negotiated).  
+4. Resume failure UX (offer recover / new conversation—never silent).  
+5. Keep **terminal/TUI mode** working unchanged; chat is additive.  
+
+### Explicit non-goals for first migration slice
+
+- Electron-main ACP client (ABF layout) as the production owner  
+- Experimental ACP v2 / `state_change`  
+- Forcing every TUI harness onto ACP in one PR  
+- Remote HTTP/WebSocket ACP transport  
+- Auto-allow_always without user policy  
+
+---
+
+## Suggested module map (target shape on current AO)
+
+```text
+backend/internal/ports/chat.go                 # ChatDriver contracts (from Fenzhi design)
+backend/internal/adapters/chatdriver/acp/      # shared ACP transport
+backend/internal/adapters/chatdriver/claudeacp/
+backend/internal/adapters/chatdriver/nativeacp/
+backend/internal/adapters/chatdriver/registry/
+backend/internal/service/…                     # conversation/session chat orchestration
+backend/internal/httpd/controllers/…           # REST + stream
+frontend/acp-runtime/                          # optional packaged JS bridges + Node
+frontend/src/renderer/components/chat/         # workspace UI
+docs/plans/acp-abf-fenzhi-gap-matrix.md        # this file
+```
+
+ABF’s `StreamNormalizer` / `agent:stream` remains a **reference for event purity**, not a required Electron channel name in AO.
+
+---
+
+## Source file index (for implementers)
+
+### AllBeingsFuture
+
+- `docs/acp-architecture.md` — system architecture, M1–M28 mismatches, test matrix  
+- `frontend/docs/acp-renderer-streaming.md` — renderer event union  
+- `electron/bridge/adapters/acp.ts` — runtime adapter  
+- `electron/bridge/acp-package-resolve.ts` — spawn path / asar  
+- `electron/tests/acp-adapter.test.ts`, `acp-package-resolve.test.ts`, `acp-builtin-smoke.test.ts`  
+- `frontend/src/types/agentStreamTypes.ts`, `frontend/src/core/chat/agentStreamCore.ts`  
+
+### Fenzhi
+
+- `backend/internal/ports/chat.go` — capabilities, events, driver interfaces  
+- `backend/internal/adapters/chatdriver/acp/{driver,client,conversation,process,session_setup}.go`  
+- `backend/internal/adapters/chatdriver/{claudeacp,nativeacp,droidacp,opencodeacp}/`  
+- `backend/internal/adapters/chatdriver/acp/driver_test.go`  
+- `frontend/src/renderer/components/chat/*`  
+- `frontend/acp-runtime/`, `frontend/scripts/build-acp-runtime.mjs`  
+
+### Current main
+
+- No ACP-equivalent packages at analysis time; start from Fenzhi ports + AO `docs/architecture.md` daemon boundaries.
+
+---
+
+## Document control
+
+| Item | Value |
+| --- | --- |
+| Deliverable type | Docs only |
+| Protocol target | ACP stable v1 |
+| Preferred implementation lineage for AO | Fenzhi daemon Chat driver |
+| Preferred wire/UX checklist | ABF architecture + streaming contract |
+| Current main ACP status | Absent |


### PR DESCRIPTION
## Summary

- Rescope `docs/plans/acp-abf-fenzhi-gap-matrix.md` to **ACP streaming output only** (not full product ACP).
- Matrix covers AgentStreamEvent types, sequence/envelope, StreamNormalizer, text/thinking/tool/plan/permission/terminal events, batching/replay, IPC vs AO SSE, and tests to port.
- Ranks **P0 stream gaps S0–S8** and recommends backend mapping first, then frontend reducer/subscribe; transport A snapshot poll MVP.

Docs only.

## Test plan

- [x] Narrowed against ABF stream types/core/batch/IPC docs and Fenzhi ChatEvent + useConversation delivery
- [x] Current main confirmed: CDC SSE exists, no agent stream
- [ ] Implementers use S0–S8 as stream migration checklist