### PR TITLE
docs: remove tmux — ABF ACP process cutover plan

### DIFF
--- a/docs/plans/abf-no-tmux-acp-cutover.md
+++ b/docs/plans/abf-no-tmux-acp-cutover.md
@@ -1,0 +1,459 @@
+# Plan: Remove tmux — ABF-style ACP process cutover
+
+**Status:** planning (docs only) — hard pivot 2026-08-04  
+**Human decision:** Fully remove **tmux** from agent-orchestrator; agents are **child processes** (ACP v1 stdio / HTTP), not interactive CLIs in tmux panes.  
+**Architecture source of truth:** Desktop AllBeingsFuture (`/Users/zhongshengjieweilai/Desktop/AllBeingsFuture`)  
+**AO design fit:** Chat/protocol in the **daemon** (fenzhi-style ports); renderer consumes sequenced stream events only — never ACP SDK, never raw PTY for the agent pane.
+
+**Supersedes** the streaming-only framing in `docs/plans/acp-migration-from-abf-fenzhi.md` as the active product cutover goal. Streaming remains a **subsystem** of this plan (Phase 1), not the whole program.
+
+---
+
+## 1. Goal and non-goals
+
+### 1.1 Goal
+
+Replace AO’s agent execution model:
+
+```text
+TODAY
+  spawn → worktree → runtime (tmux|conpty) → agent CLI in PTY
+       → ao send = send-keys → /mux xterm attach → “alive” ≈ tmux session alive
+
+TARGET (ABF-like)
+  spawn → worktree (keep)
+       → start ACP (or HTTP) child process via Process/Chat runtime
+       → stream AgentStreamEvent over daemon SSE/WS
+       → Chat / stream UI primary (not xterm agent pane)
+       → send = protocol prompt (not keystrokes)
+       → alive ≈ supervised child process / controller health (not tmux)
+```
+
+**Delete / stop using for agent sessions:**
+
+- `backend/internal/adapters/runtime/tmux/**`
+- Agent attach via terminal mux that assumes a tmux/conpty **agent** session
+- `ao doctor` hard-dep on `tmux` for the agent path
+- Lifecycle/reaper logic that treats “tmux session alive” as “agent alive” for ACP sessions
+- `ao send` as `tmux send-keys` / ConPTY keystroke injection for agents
+
+**Platform completeness:** Windows is not “tmux-only cleanup.” Replace the **conpty agent path** the same way (child process + stream), not only Darwin/Linux tmux.
+
+### 1.2 Non-goals (this cutover)
+
+- Cloning ABF Electron UI, missions, stickers, or proprietary chrome wholesale  
+- Keeping dual agent modes forever (TUI-in-tmux + ACP) as a product end state — dual-run is a **migration bridge** only  
+- Shipping every provider binding on day one (phased: stream + one producer, then expand)  
+- Remote ACP over network (stdio local / HTTP API local-or-configured only)
+
+### 1.3 Shell terminals (human: 全量去掉 tmux)
+
+Human direction: **remove the tmux package entirely.** User shell tabs must not reintroduce tmux.
+
+| Option | When |
+| --- | --- |
+| **A. Plain PTY shell runtime** (recommended if shell tabs stay) | New thin adapter: spawn user shell in a PTY (unix `pty`, Windows ConPTY **only for interactive shell**, not agent CLIs); shellterm service retargeted |
+| **B. Defer shell tabs** | Hide/disable shellterm until a non-tmux PTY lands; agent cutover unblocked |
+
+**Do not** leave shellterm wired to `runtimeselect` → tmux after Phase 4.
+
+---
+
+## 2. ABF process architecture (source of truth)
+
+```text
+Renderer
+  agentStreamCore / batch / UI
+        ▲  agent:stream (IPC in ABF)
+ProcessService
+  start / stop / send / stream / permissions / multi-agent
+        │
+BridgeManager ── ProviderAdapter
+        │              ├─ AcpAdapter: child_process.spawn + ACP v1 NDJSON stdio
+        │              └─ OpenAI (HTTP) etc.
+        ▼
+StreamNormalizer → sequenced AgentStreamEvent
+```
+
+Key ABF properties AO must match:
+
+| Property | ABF | AO today | Target |
+| --- | --- | --- | --- |
+| Agent isolation | worktree / cwd on child | git worktree + tmux session | **worktree only** (+ process cwd) |
+| Control plane | ProcessService + Bridge | session_manager + Runtime | Process/Chat runtime in daemon |
+| User input | `sendMessage` → adapter protocol | `Send` → send-keys | protocol `session/prompt` (or HTTP) |
+| Output | normalized stream events | PTY bytes → xterm | `AgentStreamEvent` SSE/WS |
+| Stop | cancel turn / destroy process | interrupt keystroke / kill tmux | `session/cancel` + process teardown |
+| Liveness | child process / adapter | tmux has-session / pane | process PID / controller state |
+| Multi-agent | parent/child ProcessService | orchestrator + worker sessions | keep AO session graph; drop tmux per worker |
+| tmux | **none** | required on Darwin/Linux | **none** |
+
+Reference files (read-only):
+
+- `electron/services/process.ts` — ProcessService  
+- `electron/bridge/bridge.ts` — BridgeManager  
+- `electron/bridge/adapters/acp.ts` — spawn + ACP  
+- `electron/services/agent-stream-normalizer.ts` — sequence + map  
+- `frontend/src/types/agentStreamTypes.ts` — wire events  
+- `docs/acp-architecture.md`, `frontend/docs/acp-renderer-streaming.md`
+
+---
+
+## 3. AO today — tmux / runtime blast radius
+
+### 3.1 Core agent path
+
+| Area | Role of tmux/conpty |
+| --- | --- |
+| `adapters/runtime/tmux/**` | Create session, send-keys, capture-pane, attach, IsAlive |
+| `adapters/runtime/conpty/**` | Windows agent PTY host (same Runtime interface) |
+| `adapters/runtime/runtimeselect` | `tmux` on unix, `conpty` on Windows |
+| `session_manager.Manager` | Spawn/restore: `runtime.Create`; Send: `SendMessage`; kill: `Destroy`; prerequisites: **tmux on PATH** |
+| `lifecycle` + `observe/reaper` | RuntimeFacts: session alive vs workload dead (tmux pane vs process) |
+| `terminal` + `httpd` terminal mux | Attach Stream → xterm agent pane |
+| `cli/doctor.go` | `tmux` version check (warn/fail) on non-Windows |
+| Agent plugins | Build **argv** for CLI launch into runtime shell |
+
+### 3.2 Secondary users of Runtime (must retarget)
+
+| Area | Today | After cutover |
+| --- | --- | --- |
+| `service/shellterm` | Same Runtime as agents (tmux/conpty) | Plain PTY shell adapter **or** deferred |
+| `review/launcher` | May use runtime patterns | Review agent via ACP process or explicit non-tmux path |
+| Tests / fakes | `fakeRuntime`, tmux string fixtures | Process runtime fakes |
+
+### 3.3 What to keep
+
+- Git worktree workspace adapter (`adapters/workspace/gitworktree`)  
+- Session/project domain, SQLite session rows, CDC for session facts  
+- Orchestrator/worker session model, hooks, SCM, PR, notifications  
+- Loopback daemon HTTP, thin CLI  
+- `~/.ao` state rules  
+
+---
+
+## 4. Target architecture (AO-shaped)
+
+```text
+CLI / Desktop
+    │  loopback HTTP
+    ▼
+Daemon
+  session_manager.Spawn
+      │  1) workspace.Create (worktree) — UNCHANGED
+      │  2) processRuntime.Start(session) — NEW (ACP/HTTP child)
+      │  3) streamHub.Configure(session)
+      ▼
+  Chat/Process controller (ABF ProcessService role)
+      │  SendTurn / Interrupt / ResolvePermission / Destroy
+      ▼
+  adapters: acp | http-provider | (later bindings)
+      │  stdio NDJSON or HTTP
+      ▼
+  StreamNormalizer → AgentStreamEvent
+      │
+      ├─▶ SSE GET /api/v1/sessions/{id}/agent-stream
+      └─▶ (optional later) durable conversation projector
+
+Lifecycle / reaper
+  Agent alive := process/controller health + launch id
+  NOT tmux has-session
+
+Frontend
+  Stream timeline primary
+  Agent xterm pane hidden/removed
+  Optional: user shell tab via plain PTY (no tmux)
+```
+
+### 4.1 Port split (do not overload Runtime)
+
+| Port | Responsibility |
+| --- | --- |
+| `Workspace` | worktree create/destroy/restore (keep) |
+| **`AgentProcess` / Chat driver** (new or fenzhi `ChatDriver`) | Start/resume/stop child; prompt; cancel; events |
+| `StreamHub` | Per-session sequence, fan-out SSE |
+| `ShellPTY` (optional, separate) | User shell only — **never** used for agent CLIs |
+| ~~`Runtime` tmux/conpty for agents~~ | **Delete** after cutover |
+
+Fenzhi reference (boundary only): Chat is separate from terminal keystroke ports; provider DTOs stay in adapters; production floor for mutating agents = streaming + approvals + interrupt + resume.
+
+### 4.2 Wire: AgentStreamEvent (ABF)
+
+Keep ABF stream union as daemon→UI JSON (see prior streaming plan). Transport: **session SSE** (preferred) or WS. Sequence monotonic per session; append-only deltas; plan replace; permission out-of-band POST.
+
+### 4.3 Send / interrupt / kill / restore
+
+| Operation | Today | Target |
+| --- | --- | --- |
+| Send | `tmux send-keys` / conpty write | `session/prompt` or provider HTTP chat |
+| Interrupt | C-c keystroke | `session/cancel` + cancel pending permissions |
+| Kill session | destroy tmux + worktree policy | stop process → close ACP → worktree policy unchanged |
+| Restore / daemon restart | reattach tmux if alive | **resume** provider conversation or fail loud (`resume failed`); re-spawn child; no tmux reattach |
+| Liveness | runtime session exists | child PID / controller state / negotiated session id |
+
+### 4.4 Windows
+
+| Today | Target |
+| --- | --- |
+| `conpty` Runtime hosts agent CLI | Same ACP/HTTP **child process** model as unix (pipes, not agent ConPTY) |
+| doctor “conpty built-in” as agent prereq | doctor checks process runtime / provider binary, not tmux, not agent-conpty |
+| ConPTY may remain **only** for optional user shell PTY | Not for agent path |
+
+---
+
+## 5. Phased PR breakdown
+
+### Phase 0 — Docs (this file)
+
+- Land cutover plan; mark older ACP plan as superseded for product goal.  
+- **Exit:** team agrees no-tmux end state + process architecture.
+
+### Phase 1 — ACP process runtime + stream pipeline (replace agent launch core)
+
+**Build:**
+
+1. Internal process runtime: spawn supervised child (stdio), env, cwd=worktree, kill tree on destroy.  
+2. ACP v1 client (prefer Go `acp-go-sdk` in daemon; ABF TS is reference only).  
+3. StreamNormalizer + StreamHub + SSE `GET /api/v1/sessions/{id}/agent-stream`.  
+4. Fake ACP agent + unit tests (handshake, prompt, tools, permission, cancel).  
+5. Feature flag / session flag `execution=acp` (or force all new spawns once ready).
+
+**Still allowed temporarily:** old tmux path for unflagged sessions (bridge only).
+
+**Success:** spawn ACP fake → sequenced events on SSE; no tmux binary used on that path.
+
+### Phase 2 — Session spawn / send / kill / restore without tmux
+
+**Change `session_manager` (and services):**
+
+| API | Behavior |
+| --- | --- |
+| Spawn | worktree + `AgentProcess.Start`; store process/provider conversation id; **no** `runtime.Create` for agents |
+| Send | protocol send; reject keystroke path for ACP sessions |
+| Interrupt / stop turn | process cancel |
+| Kill / cleanup | process Destroy + existing worktree rules |
+| Restore / RestoreAll | resume or recreate process; remove tmux restart/relaunch branches for agents |
+| validateRuntimePrerequisites | remove tmux LookPath for agent spawn |
+
+**Lifecycle / reaper:**
+
+- Stop treating “runtime session alive + workload dead” as the primary agent model for ACP.  
+- Agent death = process exit / controller stopped (with existing “failed probe ≠ dead” caution).  
+- Drop or rewrite reaper paths that inspect tmux panes / supervised process **inside** tmux.
+
+**CLI:** `ao send`, `ao session kill`, restore paths updated; docs strings that mention tmux send-keys fixed.
+
+**Success:** end-to-end agent session on Darwin/Linux/Windows CI matrix **without** `tmux` installed (agent path).
+
+### Phase 3 — Frontend: stream UI primary; hide agent terminal
+
+1. Port ABF pure stream modules (types, reduce, batch, parse) + tests.  
+2. EventSource (or WS) client → timeline UI in session workbench.  
+3. Permission resolve POST; stop/interrupt control.  
+4. **Hide/remove agent xterm pane** for ACP sessions (no `/mux` attach to agent handle).  
+5. New Task / session UX assumes chat stream, not “open terminal to type at CLI”.  
+6. Optional: keep xterm **only** for user shell tabs if Phase 4A ships plain PTY.
+
+**Success:** primary agent interaction is stream UI; no dependency on agent mux for happy path.
+
+### Phase 4 — Remove tmux adapter + doctor + docs + tests
+
+**Delete / purge:**
+
+- `backend/internal/adapters/runtime/tmux/**`  
+- `runtimeselect` tmux branch (and agent conpty path — see Phase 5)  
+- doctor `tmux` check and tests  
+- session_manager tmux prerequisite + comments  
+- integration tests that require real tmux for agents  
+- architecture/STATUS/stack/cli docs that mandate tmux for agents  
+- prompt text telling agents not to write to tmux (replace with AO send / protocol wording)
+
+**Shell:** implement plain PTY shell **or** disable shellterm; **must not** call deleted tmux package.
+
+**Gate:**
+
+```bash
+# Agent path must be clean. Allow only migration notes under docs/plans/ or changelog.
+rg -n 'tmux' backend --glob '*.go'
+# Expect: zero hits in adapters/runtime, session_manager agent path, doctor, lifecycle agent probes
+# Residual comments in historical docs/plans only if explicitly retained
+```
+
+**Success criteria (human):**
+
+- [ ] `rg tmux backend` zero for agent path (or only historical docs/migration notes)  
+- [ ] Spawn agent works with **ACP stream only**  
+- [ ] No `tmux` binary required for `ao doctor` agent path  
+
+### Phase 5 — Windows: replace conpty **agent** path the same way
+
+Do not treat “deleted tmux” as done on macOS only.
+
+1. Stop using `adapters/runtime/conpty` for **agent** Create/Send/Attach.  
+2. Same `AgentProcess` + ACP/HTTP + SSE on Windows.  
+3. doctor: remove agent-conpty-as-session-runtime framing; check Node/provider as needed.  
+4. Delete or shrink conpty package to **shell-only** PTY host, or delete if shell deferred.  
+5. CI job without tmux; Windows job without agent conpty dependency.
+
+**Success:** Windows agent spawn/stream/kill green; no tmux; no agent-conpty.
+
+### Suggested sequencing
+
+```text
+P0 docs
+  └─▶ P1 process + stream (+ flag)
+        └─▶ P2 session_manager / lifecycle / send / restore
+              ├─▶ P3 frontend stream UI (// after stream SSE stable)
+              └─▶ P5 windows in parallel with P2/P3 once process runtime is OS-agnostic
+                    └─▶ P4 delete tmux + doctor + docs (when flag default ON and P5 agent path done)
+```
+
+P4 is last: no deletion until agent path default is ACP and shell strategy is decided.
+
+---
+
+## 6. File-level change map
+
+### 6.1 Add (primary)
+
+| Area | Suggested location |
+| --- | --- |
+| Process/ACP runtime | `backend/internal/adapters/agentproc/` or `chatdriver/acp/` (fenzhi-style) |
+| Stream normalizer + hub | `backend/internal/agentstream/` |
+| SSE controller | `backend/internal/httpd/` + OpenAPI |
+| Frontend stream core | `frontend/src/renderer/lib/agent-stream/` |
+| Stream timeline UI | `frontend/src/renderer/components/...` (minimal chat surface) |
+| Shell PTY (if kept) | `backend/internal/adapters/runtime/shellpty/` — **not** named tmux |
+
+### 6.2 Rewrite
+
+| File / package | Change |
+| --- | --- |
+| `session_manager/manager.go` | Spawn/Send/Kill/Restore without agent Runtime |
+| `lifecycle/*`, `observe/reaper/*` | Process-based facts |
+| `daemon/*` wiring | Wire process runtime + stream hub; unwire agent tmux |
+| `cli/doctor.go` | Drop tmux agent check |
+| `cli/send.go` + HTTP send | Protocol send |
+| `ports/outbound.go` | Deprecate agent Runtime; add process ports |
+| Frontend session terminal | Hide agent mux; show stream |
+| `docs/architecture.md`, `STATUS.md`, `stack.md`, `cli/README.md` | No tmux requirement |
+
+### 6.3 Delete (end state)
+
+| Path |
+| --- |
+| `backend/internal/adapters/runtime/tmux/**` |
+| Agent-only usage of `conpty` (package shrink or delete) |
+| `runtimeselect` as agent backend selector (replace or delete) |
+| Tests that shell out to `tmux` for agent e2e |
+
+### 6.4 From ABF (logic, not Electron)
+
+| Concept | Port into |
+| --- | --- |
+| ProcessService lifecycle | session_manager + process service |
+| AcpAdapter spawn/map | Go ACP adapter |
+| StreamNormalizer | Go + TS reduce (UI) |
+| AgentStreamEvent | SSE JSON + frontend types |
+| Permission broker | HTTP resolve + parked requests |
+
+### 6.5 From fenzhi (optional accelerator)
+
+If available: `ports/chat.go`, `chatdriver/acp`, `service/chat`, conversation durability — **after** process+stream work, not as a blocker for deleting tmux. Prefer process+stream cutover over waiting for full Chat product parity.
+
+---
+
+## 7. Migration / dual-run strategy
+
+1. **Flag** `AO_AGENT_EXECUTION=acp|tui` or per-session mode (default tui → default acp → remove tui).  
+2. New sessions: ACP once Phase 2 is default.  
+3. Existing live tmux sessions: support until daemon restart, then restore via ACP resume or mark interrupted — **no** forever dual stack.  
+4. P4 deletion only when: default ACP, Windows green, shell non-tmux, CI without tmux package.
+
+---
+
+## 8. Risks
+
+1. **Providers without good ACP** — interim: HTTP adapter (ABF openai-style) or single CLI wrapper that speaks ACP; avoid resurrecting tmux.  
+2. **Loss of “reattach to live CLI”** — intentional; resume is protocol resume, not pane attach.  
+3. **Shellterm coupling** — shell still on tmux blocks P4; decide PTY vs defer early.  
+4. **Reaper false positives/negatives** — rewrite probes carefully; failed probe ≠ dead (existing AO rule).  
+5. **Windows process job control** — kill process trees correctly without ConPTY agent host.  
+6. **Orchestrator agents expecting TUI** — standing prompts / hooks must say protocol send, not terminal.  
+7. **Large session_manager blast radius** — surgical flags first; avoid big-bang rewrite without tests.  
+8. **Review launcher / secondary runtimes** — hunt all `runtime.Create` call sites before deleting tmux.
+
+---
+
+## 9. Success criteria (checklist)
+
+### Product
+
+- [ ] Spawn agent creates worktree + ACP/HTTP child only (no tmux session).  
+- [ ] Send delivers protocol turns; stream UI shows text/tools/plan/permissions.  
+- [ ] Interrupt/cancel does not use send-keys C-c.  
+- [ ] Kill/teardown does not call tmux kill-session.  
+- [ ] Restore works without tmux reattach.  
+- [ ] Agent terminal pane not required for agent work.  
+- [ ] Windows agents use the same process model (not leftover agent-conpty).
+
+### Engineering gates
+
+- [ ] `rg -n tmux backend --glob '*.go'` clean for agent path (no adapter, no doctor, no spawn prereq).  
+- [ ] `ao doctor` does not require `tmux` binary for agent health.  
+- [ ] CI agent e2e runs in environment **without** tmux installed.  
+- [ ] Frontend has no ACP SDK; stream over loopback HTTP only.
+
+---
+
+## 10. Recommended worker spawn order
+
+1. **Docs** — this plan (P0).  
+2. **Backend process + stream** (P1) — OS-agnostic child + normalizer + SSE + fake ACP.  
+3. **Backend session_manager cutover** (P2) — spawn/send/kill/restore + lifecycle/reaper.  
+4. **Frontend stream UI** (P3) — parallel once SSE contract frozen.  
+5. **Windows agent process parity** (P5) — parallel with P2/P3.  
+6. **Shell strategy** — plain PTY or disable shellterm (before P4).  
+7. **Delete tmux + doctor + docs** (P4) — last.
+
+Avoid concurrent edits to `session_manager/manager.go` and `adapters/runtime/tmux` deletion until P2 flag is default.
+
+---
+
+## 11. Explicit next actions for implementers
+
+1. Inventory every `runtime.Create` / `SendMessage` / `Attach` / `IsAlive` call site; tag agent vs shell vs review.  
+2. Implement **AgentProcess** + fake ACP + SSE (P1) behind flag; prove no tmux on that path.  
+3. Switch spawn/send for flagged sessions; add lifecycle process facts.  
+4. Land frontend stream reduce + minimal timeline; hide agent xterm when `execution=acp`.  
+5. Decide shell: plain PTY package vs feature-off.  
+6. Flip default to ACP; run CI without tmux.  
+7. Delete `adapters/runtime/tmux`, doctor checks, docs; shrink conpty to shell-only or delete.  
+8. Update `docs/architecture.md` / `STATUS.md` to describe process agents.
+
+---
+
+## 12. Open decisions
+
+| Decision | Options | Recommendation |
+| --- | --- | --- |
+| Dual-run duration | Flag one release vs hard cut | Flag until P2+P3 green, then default ACP within same epic |
+| Shell tabs | Plain PTY vs defer | Plain PTY if shell is product-critical; else defer to unblock P4 |
+| First real producer | Fake only → Claude ACP → Codex app-server | Fake for P1; one real provider before default flip |
+| Durable chat DB | Stream-only vs fenzhi conversations | Stream-only sufficient to delete tmux; durability can follow |
+| `ao send` semantics | Always protocol | Yes for all agents post-cutover |
+
+---
+
+## 13. Related docs
+
+| Doc | Role |
+| --- | --- |
+| `docs/plans/abf-no-tmux-acp-cutover.md` | **This plan — active cutover** |
+| `docs/plans/acp-migration-from-abf-fenzhi.md` | Streaming subsystem detail; superseded as overall goal |
+| ABF `docs/acp-architecture.md` | Process + stream contracts |
+| fenzhi `ports/chat.go` + `chatdriver/acp` | Optional Go implementation reference |
+
+---
+
+*Plan only. Implementation must follow `AGENTS.md` (loopback daemon, thin CLI, no renderer protocol logic, `~/.ao` only).*

--- a/docs/plans/acp-migration-from-abf-fenzhi.md
+++ b/docs/plans/acp-migration-from-abf-fenzhi.md
@@ -1,0 +1,462 @@
+# ACP Migration Plan: AllBeingsFuture concepts → AO main (fenzhi architecture)
+
+**Status:** planning deliverable (docs only)  
+**Date:** 2026-08-04  
+**Target branch base:** current `main` (no Chat API / no `chatdriver` today)  
+**Authoritative design reference:** Desktop `fenzhi` (`/Users/zhongshengjieweilai/Desktop/fenzhi`)  
+**Capability / product-reference source:** Desktop `AllBeingsFuture` (`/Users/zhongshengjieweilai/Desktop/AllBeingsFuture`)  
+
+This plan is intentionally **implementation-free**. It tells implementer workers what to port, in what order, and what not to copy.
+
+---
+
+## 1. Executive summary
+
+| Source | Role in this migration |
+| --- | --- |
+| **fenzhi** | **Primary port target.** Go daemon owns ACP lifecycle, domain conversation model, Chat service/controller, HTTP API, SQLite durability, CDC updates, and desktop chat UI. SDK: `github.com/coder/acp-go-sdk`. |
+| **AllBeingsFuture (ABF)** | **Capability and contract reference.** Normalized streaming UX concepts, permission mediation, package-resolve heuristics, test matrices, and docs about ACP v1 mapping. **Do not** lift ABF’s Electron-main ACP transport into AO product. |
+| **AO main today** | TUI/terminal agent sessions only. No `ports.Chat*`, no `chatdriver`, no conversation tables, no conversation HTTP routes, no chat renderer surface. |
+
+**Design decision (settled):** Prefer **fenzhi’s Go backend ACP stack** over porting ABF’s TypeScript Electron ACP adapter as-is. Map ABF product capabilities into AO ports/events; keep daemon protocol logic out of the Electron renderer.
+
+---
+
+## 2. Architecture mapping table
+
+Status key for **main today**:
+
+- **absent** — not present on main  
+- **partial** — related surface exists but Chat/ACP is missing  
+- **present (fenzhi only)** — exists fully in fenzhi; copy path is known  
+
+| ABF component | AO (fenzhi) component | Status on main | Migration action |
+| --- | --- | --- | --- |
+| Electron main `@agentclientprotocol/sdk` + `electron/bridge/adapters/acp.ts` | `backend/internal/adapters/chatdriver/acp/*` + `github.com/coder/acp-go-sdk` | **absent** | Port fenzhi ACP package; do not port Node SDK into product daemon |
+| `electron/bridge/acp-package-resolve.ts` | Provider binding probe/launch (`claudeacp`, `nativeacp`, …) + existing agent plugins’ `ResolveBinary` | **partial** (agent plugins exist; no Chat binding) | Port fenzhi bindings; optionally reuse ABF **heuristics** only if a binding needs path discovery AO plugins lack |
+| `BridgeManager` + adapter registry | `chatdriver/registry` + daemon wiring of `ChatDriverRegistry` | **absent** | Port registry + wire in `daemon` |
+| `BridgeEvent` (adapter-internal) | `ports.ChatEvent` + domain activity/message projection | **absent** | Port fenzhi port + projector; ABF BridgeEvent is conceptual only |
+| `StreamNormalizer` → sequenced `AgentStreamEvent` | Chat **controller** projects provider events → durable rows; clients get snapshot + CDC (not IPC stream of raw deltas) | **absent** | Port fenzhi service/controller + storage; do **not** reintroduce ABF IPC sequence protocol as product wire format |
+| `agent:stream` IPC envelope (`sessionId`, `sequence`, …) | Loopback HTTP conversation snapshot + SQLite CDC change_log (existing AO pattern) | **partial** (CDC exists; no conversation entities) | Extend CDC/triggers for conversation tables; frontend consumes daemon API |
+| `agent:permission:respond` IPC | `POST .../conversation/approvals/{requestId}/resolve` | **absent** | Port HTTP + service path |
+| `ProcessService.StopProcess` cancel | `POST .../conversation/interrupt` + driver `session/cancel` | **partial** (session kill exists; not Chat interrupt) | Port Chat interrupt; keep session terminate separate |
+| Renderer `agentStreamCore` / `agentStreamTypes.ts` | `frontend/.../components/chat/*` + `hooks/useConversation.ts` + domain-aligned TS types from OpenAPI | **absent** | Port fenzhi chat UI; map ABF UX ideas (permission card, plan, tool status) into fenzhi components—not ABF CSS/layout wholesale |
+| Legacy CLI parsers (`electron/parser/*`) | **Out of Chat path.** AO TUI mode already uses terminal adapters | **present** (TUI) | Non-goal for Chat; TUI remains default session mode |
+| ABF provider profiles (`acp`, `claude-sdk`, `codex-appserver`, …) | Harness + `SessionMode` (`tui` \| `chat`) + driver registry | **partial** (harnesses exist; no mode column) | Add `SessionMode`; Chat drivers for selected harnesses |
+| ABF SQLite chat messages in Electron | `conversations` / `conversation_turns` / `messages` / `activities` (+ later migrations) | **absent** | Port fenzhi migrations (re-numbered after main head) |
+| ABF clean-room ACP v1 docs | This plan + optional `docs/` architecture note after ship | **absent** | Keep product docs AO-native; cite public ACP schema only |
+
+### 2.1 Layer ownership (target AO)
+
+```text
+Renderer (Electron)
+  SessionChatSurface · ChatComposer · approvals/plans/tools UI
+  useConversation → HTTP + CDC
+  NEVER imports acp-go-sdk / Node ACP SDK / provider wire DTOs
+        │  loopback HTTP (127.0.0.1, unauthenticated)
+        ▼
+Daemon (Go)
+  httpd/controllers/conversations*.go
+  service/chat (Service + Controller)
+  ports.ChatDriver / ChatConversation / ChatEvent
+  adapters/chatdriver/{acp,claudeacp,nativeacp,droidacp,opencodeacp,codexappserver,registry}
+  storage/sqlite conversation* + CDC triggers
+        │  stdio NDJSON JSON-RPC (or Codex app-server)
+        ▼
+Provider process (user-installed CLI / packaged bridge only where fenzhi already does)
+```
+
+Hard rules from `AGENTS.md` remain binding: loopback unauthenticated; CLI thin HTTP client; no daemon protocol in renderer; `~/.ao` only for app state.
+
+---
+
+## 3. Capability gap analysis
+
+### 3.1 ABF capability → fenzhi coverage
+
+| Capability | ABF | fenzhi design | Gap vs main | Notes for AO port |
+| --- | --- | --- | --- | --- |
+| Stable ACP v1 stdio client | Yes (TS SDK) | Yes (Go SDK `acp-go-sdk` v0.13.5 in fenzhi) | Main missing | Pin SDK version in `backend/go.mod` when porting |
+| `initialize` / protocolVersion gate | Yes | Yes | Main missing | Reject non-v1; no experimental v2 |
+| `session/new` + resume (`session/load` or resume capability) | Yes | Yes (resume required for production floor) | Main missing | Production floor: streaming + approvals + interrupt + resume |
+| Prompt turn + streaming text | Yes | `message.delta` / `message.completed` | Main missing | Durable message rows + in-place delta mutation |
+| Thinking / reasoning | Yes (`thinking_update`) | `reasoning.delta` + `ActivityKindReasoning` | Main missing | Hideable reasoning |
+| Tool calls | Yes | activities (`command`, `mcp_tool`, …) | Main missing | Prefer typed activities over free-form tool blobs |
+| Plans | Yes | `turn.plan` + plan activity | Main missing | Full snapshot replace semantics (ABF + fenzhi agree) |
+| Permissions / approvals | Yes | `approval.requested` / resolve API | Main missing | Provider-offered decision options only (`ErrChatDecisionNotOffered`) |
+| Cancel in-flight turn | Yes | interrupt | Main missing | Map late stop → `ErrChatNoActiveTurn` (ordinary, not 500) |
+| Legacy + native dual path | Yes (explicit) | Chat vs TUI session modes | TUI only on main | Keep TUI default; Chat opt-in per session |
+| Sequenced live stream IPC | Yes | **Different:** durable sequence + CDC | Main has CDC only | Do not clone ABF IPC sequence as API; follow fenzhi |
+| Compaction | Weak / optional | First-class capability + API | Main missing | Later phase OK |
+| Steer mid-turn | No (ABF) | `ChatSteerer` + API | Main missing | Codex-first; optional for ACP agents |
+| Config options / models / skills | Partial status messages in ABF docs | First-class list/set APIs | Main missing | Phase after core chat |
+| Usage / rate limits / diffs / MCP reload | Partial | Full port surfaces in fenzhi | Main missing | Phase after core chat |
+| Nested agents / elicitation / images | Partial product | Capabilities modeled in ports | Main missing | Capability-gated; do not block MVP |
+| Package resolve for packaged ACP adapters | Yes (Node) | `frontend/acp-runtime` + `claudeacp` runtime resolve | Main missing | Port fenzhi packaging, not ABF resolve wholesale |
+| Fake ACP agent tests | Yes (`fixtures/fake-acp-agent.ts`) | Go unit tests + e2e chat suite | Main missing | Prefer fenzhi Go tests; ABF fixture ideas only |
+
+### 3.2 What ABF has that fenzhi already covers (port fenzhi, not ABF code)
+
+- Provider-neutral streaming UX (text, thinking, tools, plan, permissions, terminal turn states).
+- Permission request/response mediation with cancel-on-stop.
+- Native ACP process lifecycle (init → session → prompt → cancel → teardown).
+- MCP server injection into session setup (stdio/http/sse negotiation).
+- Separation of renderer from ACP SDK.
+
+### 3.3 What ABF has that is still product/design work on top of fenzhi
+
+- ABF-specific supervisor/child mission product model (out of scope for Chat MVP).
+- ABF proprietary conversation UI (layout, stickers, virtualization details)—**do not wholesale copy**.
+- ABF package-resolve edge cases for multi-layout Electron packaging—audit against AO forge packaging only if Claude ACP runtime packaging fails.
+- ABF dual “legacy adapter still emits BridgeEvent” path—AO already has TUI mode; no need for a second legacy chat normalizer in process.
+
+### 3.4 What fenzhi has that ABF does not (bring intentionally)
+
+- Separate **Chat port** from Agent/Runtime (no keystroke “send”).
+- Durable conversation model (messages ≠ activities; conversation-scoped immutable sequence).
+- Production capability floor for mutating workspace Chat sessions.
+- Steer, compaction, rollback, fork, rename, config options, skills, MCP reload, usage/rate limits as first-class optional interfaces.
+- Codex **app-server** driver (`codexappserver`) as a non-ACP machine protocol beside ACP.
+- Full HTTP OpenAPI surface under `/api/v1/sessions/{sessionId}/conversation/*`.
+- Backend e2e suite (`backend/e2e/chat_*.go`).
+
+---
+
+## 4. Main baseline (facts to preserve)
+
+As of this plan’s research against the worktree’s then-current main lineage:
+
+| Area | Main state |
+| --- | --- |
+| `backend/internal/ports/` | No `chat.go` / `chat_steer.go` |
+| `backend/internal/adapters/chatdriver/` | **Does not exist** |
+| `backend/internal/service/chat/` | **Does not exist** |
+| `backend/internal/domain/conversation.go` / `sessionmode.go` | **Do not exist** |
+| SQLite migrations | Head around `0042_review_run_unique_per_harness.sql` (no conversation migrations) |
+| HTTP DTOs / OpenAPI | No conversation operations |
+| Frontend | No `renderer/components/chat/` |
+| Agent plugins | TUI launch/auth already exist for many harnesses (reuse for Chat probe/launch) |
+| CDC | Present for sessions etc.; extend for conversation tables via triggers |
+
+fenzhi conversation migrations start at `0041_chat_session_mode.sql` through `0051_...`. On main they must be **re-numbered** after the live head (never edit already-merged migrations).
+
+---
+
+## 5. File-level port list
+
+### 5.1 Primary port from fenzhi (authoritative)
+
+Port in dependency order. Paths are relative to repo root; source tree is fenzhi.
+
+#### Phase A — domain + ports (no process I/O)
+
+| fenzhi path | Notes |
+| --- | --- |
+| `backend/internal/domain/sessionmode.go` (+ test) | `tui` / `chat`; default `tui` |
+| `backend/internal/domain/conversation.go` | Durable model + plan types |
+| `backend/internal/ports/chat.go` | ChatDriver, events, capabilities, errors |
+| `backend/internal/ports/chat_steer.go` | Optional steerer |
+
+#### Phase B — storage
+
+| fenzhi path | Notes |
+| --- | --- |
+| `backend/internal/storage/sqlite/migrations/0041_chat_session_mode.sql` … `0051_*.sql` | Re-number as `00NN+` on main |
+| `backend/internal/storage/sqlite/queries/conversations.sql` (+ session column queries) | sqlc source |
+| `backend/internal/storage/sqlite/store/conversation_store.go` (+ history store tests) | |
+| Generated `gen/*` via `npm run sqlc` only | Do not hand-edit gen |
+
+#### Phase C — chatdriver adapters
+
+| fenzhi path | Notes |
+| --- | --- |
+| `backend/internal/adapters/chatdriver/acp/*.go` | Lifecycle + mapping; owns ACP |
+| `backend/internal/adapters/chatdriver/registry/*` | |
+| `backend/internal/adapters/chatdriver/claudeacp/*` | Claude via packaged ACP runtime + `CLAUDE_CODE_EXECUTABLE` |
+| `backend/internal/adapters/chatdriver/nativeacp/*` | Shared native binding helper |
+| `backend/internal/adapters/chatdriver/droidacp/*` | |
+| `backend/internal/adapters/chatdriver/opencodeacp/*` | |
+| `backend/internal/adapters/chatdriver/codexappserver/*` | Non-ACP; keep as parallel driver |
+
+#### Phase D — service + session manager hooks
+
+| fenzhi path | Notes |
+| --- | --- |
+| `backend/internal/service/chat/*` | Service, controller, history, steer, skills |
+| `backend/internal/session_manager/chat_spawn.go` (+ tests, attachments) | Spawn path for Chat mode |
+| Session status derivation updates that treat Chat activity | e.g. fenzhi `service/session/status.go` Chat exemption patterns |
+| Daemon wiring of registry + chat service | Follow fenzhi `daemon` patterns |
+
+#### Phase E — HTTP + OpenAPI + CLI (if any)
+
+| fenzhi path | Notes |
+| --- | --- |
+| `backend/internal/httpd/controllers/conversations*.go` (+ tests) | |
+| `backend/internal/httpd/controllers/dto.go` conversation DTOs | |
+| `backend/internal/httpd/apispec/specgen/build.go` operations | Then `npm run api` |
+| CLI only if fenzhi exposes chat commands still desired | Thin HTTP; mirror DTOs; table tests |
+
+#### Phase F — frontend
+
+| fenzhi path | Notes |
+| --- | --- |
+| `frontend/src/renderer/components/chat/**` | AO design system / DESIGN.md |
+| `frontend/src/renderer/hooks/useConversation.ts` (+ test) | |
+| `frontend/src/renderer/types/conversation.ts` | Prefer OpenAPI-generated types where possible |
+| Session surface integration (mode toggle / chat panel entry) | Surgical; do not restyle board |
+| `frontend/acp-runtime/**` + `frontend/scripts/build-acp-runtime.mjs` | Packaged Claude ACP adapter runtime only |
+
+#### Phase G — tests & packaging
+
+| fenzhi path | Notes |
+| --- | --- |
+| `backend/e2e/chat_*.go` + `harness_test.go` | Bring after API stable |
+| Unit tests colocated with adapters/service | Port with code |
+| `backend/go.mod` / `go.sum` | Add `github.com/coder/acp-go-sdk` |
+
+### 5.2 Selective concepts from ABF (not wholesale file ports)
+
+Use as **requirements and test ideas**, re-implement inside fenzhi shapes:
+
+| ABF path | Extract | Re-home in AO |
+| --- | --- | --- |
+| `docs/acp-architecture.md` | Lifecycle diagram, security notes, capability honesty (no fs/terminal client caps until implemented) | This plan + future `docs/` architecture section |
+| `frontend/docs/acp-renderer-streaming.md` | Event semantics (append-only deltas, plan replace, terminal events) | Verify fenzhi projector + UI match; do not invent ABF IPC on daemon |
+| `electron/bridge/adapters/acp.ts` | Mapping table ACP v1 → UI concepts; permission cancel-on-destroy; MCP capability assert | Cross-check `chatdriver/acp/client.go` + conversation mapping |
+| `electron/bridge/types.ts` | BridgeEvent kind inventory for gap checklist | Already covered by `ports.ChatEventKind` |
+| `frontend/src/types/agentStreamTypes.ts` | Product UX event set | Ensure fenzhi UI covers parity items needed for MVP |
+| `electron/bridge/acp-package-resolve.ts` | Candidate node_modules roots / unpack heuristics | Only if AO desktop packaging of `acp-runtime` needs it |
+| `electron/tests/acp-*.ts` | Cases: handshake fail, permission respond, cancel, package resolve | Port as Go tests / e2e assertions |
+| `electron/services/agent-stream-normalizer.ts` | Diff tool_call_update replacement content into deltas | Confirm fenzhi activity projection does equivalent |
+
+**Explicit non-ports from ABF:** `electron/parser/*` legacy log parsers for Chat; proprietary mission/team UI; stickers; ABF Zustand stores; ABF IPC channel names.
+
+---
+
+## 6. Phased PR breakdown
+
+Keep **one concern per PR**. Conventional commits. Each PR should leave main green.
+
+### PR-0 — Docs (this document)
+
+- **Scope:** `docs/plans/acp-migration-from-abf-fenzhi.md` only  
+- **Exit:** Team agrees architecture (fenzhi primary, ABF concepts only)
+
+### PR-1 — Backend core: domain, ports, schema foundation
+
+- Add `SessionMode`, conversation domain types, `ports.Chat*`  
+- Migration(s) for: `sessions.mode`, `provider_conversation_id`, core `conversations` / turns / messages / activities tables + CDC triggers  
+- Store interfaces + sqlc  
+- **No** live provider process required  
+- **Tests:** domain pure tests; store tests with sqlite  
+- **Success:** can create Chat-mode session row + empty conversation snapshot in tests
+
+### PR-2 — Chat service/controller (fake driver)
+
+- `service/chat` with in-memory/fake `ChatDriver`  
+- Project events to durable rows; approvals; interrupt  
+- Session manager spawn hook for Chat (still fake driver)  
+- **Tests:** controller unit tests from fenzhi (trimmed)  
+- **Success:** send message → deltas persist → interrupt → approval resolve against fake
+
+### PR-3 — Provider-neutral ACP driver + registry
+
+- Port `chatdriver/acp` + registry  
+- Wire daemon  
+- Fake ACP agent or recorded pipes in unit tests  
+- **Success:** ACP handshake + turn + permission + cancel against fake process
+
+### PR-4 — Provider bindings (split if needed)
+
+Recommended sub-order:
+
+1. **codexappserver** (often highest product value; non-ACP) **or** **claudeacp** (ACP + packaged runtime)—product owner picks first ship harness  
+2. `nativeacp` + `opencodeacp` + `droidacp`  
+3. Packaging: `frontend/acp-runtime` for Claude bridge  
+
+Each binding reuses existing agent plugin `ResolveBinary` / `AuthStatus`.
+
+**Success per binding:** `Probe` works; Start/Resume/SendTurn/Interrupt/approvals green in unit or gated live tests.
+
+### PR-5 — HTTP API + OpenAPI + typed client
+
+- Controllers + DTOs  
+- `npm run api` → commit `openapi.yaml` + `frontend/src/api/schema.ts`  
+- Map port errors to stable API error codes  
+- Optional thin CLI conversation commands if product wants them  
+- **Tests:** httptest controller tests; api drift tests  
+
+### PR-6 — Frontend chat surface
+
+- Port fenzhi chat components + `useConversation`  
+- Session inspector / workbench entry for Chat mode  
+- Approvals, plans, tools, interrupt, composer  
+- Follow `DESIGN.md` / agent-orchestrator look; no ABF skin  
+- **Tests:** component tests; smoke e2e if feasible  
+
+### PR-7 — Hardening: advanced capabilities + e2e
+
+- Compaction, steer, models/config options, skills, usage, diffs, MCP reload as prioritized  
+- Port fenzhi `backend/e2e/chat_*.go`  
+- Docs: architecture note + STATUS.md  
+
+### Suggested dependency graph
+
+```text
+PR-0 docs
+  └─▶ PR-1 domain/schema
+        └─▶ PR-2 service (fake)
+              ├─▶ PR-3 acp core
+              │     └─▶ PR-4 bindings (+ packaging)
+              └─▶ PR-5 HTTP/OpenAPI ──▶ PR-6 frontend
+                                        └─▶ PR-7 e2e/advanced
+```
+
+PR-3 and PR-5 can partially parallelize after PR-2 if API contracts are frozen from fenzhi DTOs early—prefer freezing OpenAPI from fenzhi shapes in PR-5 only after service methods stabilize.
+
+---
+
+## 7. Event / API contract mapping (ABF stream → AO Chat)
+
+Implementers should treat the **right-hand column** as product truth.
+
+| ABF `AgentStreamEvent` | AO `ports.ChatEvent` / domain | HTTP / UI effect |
+| --- | --- | --- |
+| `text_delta` | `message.delta` | Mutate assistant message in place |
+| `thinking_update` | `reasoning.delta` / reasoning activity | Collapsible reasoning |
+| `tool_call` / `tool_update` | `activity.started` / `activity.completed` (+ command output deltas) | Tool/command cards |
+| `plan` | `turn.plan` | Replace plan UI |
+| `permission_request` | `approval.requested` | Approval card; resolve via POST |
+| `status` | `controller.state` + turn state | Banners / busy |
+| `done` / `cancelled` / `error` | `turn.completed` + `TurnState*` / `error` | Finalize turn |
+| IPC `sequence` | Conversation `sequence` on rows + CDC | Client applies by sequence; no ABF IPC |
+
+---
+
+## 8. Risks
+
+1. **Schema renumbering / migration collision** — fenzhi `0041+` collides with main’s non-chat migrations; must resequence and retest empty + upgrade DBs.  
+2. **SDK version skew** — `acp-go-sdk` vs ABF Node SDK vs provider agents; negotiate only stable v1; pin and test handshake failures.  
+3. **Resume semantics** — silent new conversation after daemon restart is forbidden (`ErrChatResumeFailed`); UI must force recovery choice.  
+4. **Dual mode confusion** — Chat vs TUI on same harness; mode immutable per session; status derivation and “send” paths must not cross.  
+5. **Packaging Claude ACP runtime** — Node bridge packaging (`acp-runtime`) can break desktop updates if not integrated into forge build.  
+6. **Permission consent bugs** — inventing decision options or auto-allow-always without policy is a security defect.  
+7. **Scope creep from ABF UI** — copying ABF conversation chrome violates AO design system and delays ship.  
+8. **Codex app-server vs ACP** — two machine protocols; keep separate packages; do not force Codex through ACP if fenzhi uses app-server.  
+9. **CDC lag / projector races** — deferred turn start (fenzhi `ChatDeferredTurnStarter`) must be preserved to avoid event loss.  
+10. **Live provider flakiness** — gate live tests; keep fake/unit coverage as merge gate.
+
+---
+
+## 9. Non-goals
+
+- Porting ABF Electron-main ACP TypeScript stack as AO’s product transport.  
+- Putting ACP SDK or provider wire parsing in the renderer.  
+- Adopting experimental ACP v2 / remote HTTP-WS ACP in the first ship.  
+- Replacing TUI mode or forcing all harnesses to Chat.  
+- Wholesale ABF UI, mission/team/sticker product surfaces.  
+- Auto-accept permissions by default.  
+- Advertising client `fs` / `terminal` ACP capabilities until AO implements them safely (fenzhi deliberately refuses).  
+- Editing already-merged SQLite migrations.  
+- npm-as-primary distribution changes.  
+- Implementing the full stack in the planning session (this PR).
+
+---
+
+## 10. Success criteria
+
+### MVP (after PR-1…PR-6 for at least one harness)
+
+- [ ] Session can be created with `mode=chat` for a supported harness; default remains `tui`.  
+- [ ] Daemon owns provider process; renderer only uses loopback HTTP + CDC.  
+- [ ] User can send a message, see streaming assistant text, tools/activities, and plans.  
+- [ ] User can resolve a permission request with only provider-offered options.  
+- [ ] User can interrupt a turn; late interrupt is a soft error, not a crash.  
+- [ ] Daemon restart resumes provider conversation or surfaces resume failure—never silent empty thread.  
+- [ ] Production floor capabilities enforced before workspace-mutating Chat.  
+- [ ] OpenAPI + `schema.ts` committed and drift-clean.  
+- [ ] `go test` for touched packages and relevant e2e/unit gates green.  
+- [ ] No ACP protocol logic in Electron renderer; no `~/Library/Application Support` state.
+
+### Full fenzhi parity (PR-7+)
+
+- [ ] Codex app-server + Claude ACP + at least one native ACP harness.  
+- [ ] Steer/compaction/config options/skills/usage as capability-gated UI.  
+- [ ] Backend e2e chat suite ported and running in CI where feasible.
+
+---
+
+## 11. Recommended worker spawn order
+
+1. **Backend domain/schema worker** — PR-1  
+2. **Backend chat service worker** — PR-2 (depends on 1)  
+3. **Backend ACP driver worker** — PR-3 (depends on 2)  
+4. **Backend provider binding worker(s)** — PR-4 (depends on 3; can fan out per harness)  
+5. **Backend HTTP/OpenAPI worker** — PR-5 (depends on 2; ideally after 3 method freeze)  
+6. **Frontend chat UI worker** — PR-6 (depends on 5)  
+7. **E2E/hardening worker** — PR-7 (depends on 4+6)
+
+Do **not** start frontend before OpenAPI exists. Do **not** start provider live tests before fake-driver controller is green.
+
+---
+
+## 12. Explicit next actions for implementer workers
+
+1. Confirm product **first ship harness** (Claude ACP vs Codex app-server).  
+2. Diff fenzhi vs main for session spawn/status/daemon wiring and list exact merge conflicts expected (main has moved past some fenzhi bases).  
+3. Land PR-1 with renumbered migrations; run `npm run sqlc`.  
+4. Port `ports/chat.go` verbatim in spirit (keep comments that encode rules).  
+5. Introduce fake driver before real ACP process code.  
+6. Port `chatdriver/acp` with `acp-go-sdk`; refuse client fs/terminal caps.  
+7. Wire registry in daemon; keep loopback bind unchanged.  
+8. Generate API; only then port fenzhi chat UI.  
+9. Add packaging for `acp-runtime` if Claude is first ship.  
+10. Track STATUS.md once MVP merges.
+
+---
+
+## 13. Reference inventory (read-only sources)
+
+### fenzhi
+
+- `backend/internal/ports/chat.go`, `chat_steer.go`  
+- `backend/internal/adapters/chatdriver/**`  
+- `backend/internal/service/chat/**`  
+- `backend/internal/domain/conversation.go`, `sessionmode.go`  
+- `backend/internal/httpd/controllers/conversations*.go`  
+- `backend/internal/storage/sqlite/migrations/0041_chat_session_mode.sql` … `0051_*`  
+- `frontend/src/renderer/components/chat/**`, `hooks/useConversation.ts`  
+- `frontend/acp-runtime/package.json`  
+- `backend/e2e/chat_*.go`  
+- `backend/go.mod` → `github.com/coder/acp-go-sdk`
+
+### AllBeingsFuture
+
+- `docs/acp-architecture.md`  
+- `frontend/docs/acp-renderer-streaming.md`  
+- `electron/bridge/adapters/acp.ts`  
+- `electron/bridge/acp-package-resolve.ts`  
+- `electron/bridge/types.ts`  
+- `frontend/src/types/agentStreamTypes.ts`  
+- `electron/tests/acp-*.ts`
+
+### Public ACP
+
+- Stable schema: https://github.com/agentclientprotocol/agent-client-protocol (`schema/v1`)  
+- Go SDK: `github.com/coder/acp-go-sdk`  
+- Do not use experimental v2 product paths
+
+---
+
+## 14. Open decisions (need product/orchestrator input)
+
+| Decision | Options | Recommendation |
+| --- | --- | --- |
+| First Chat harness | Claude ACP / Codex app-server / OpenCode native | Codex if app-server stability is known in fenzhi; else Claude if desktop packaging ready |
+| Default mode for new sessions | Always `tui` / opt-in Chat / harness-default | Keep **default `tui`** (fenzhi) |
+| CLI conversation commands | HTTP-only first / add `ao chat` subset | HTTP-only first; CLI later if needed |
+| How much of fenzhi advanced capabilities in MVP | Core stream+approve+interrupt+resume only / full parity | **Core first**; advanced in PR-7 |
+
+---
+
+*End of plan. Implementation must follow `AGENTS.md` hard rules and keep changes surgical per PR.*

--- a/docs/plans/acp-migration-from-abf-fenzhi.md
+++ b/docs/plans/acp-migration-from-abf-fenzhi.md
@@ -1,462 +1,438 @@
-# ACP Migration Plan: AllBeingsFuture concepts → AO main (fenzhi architecture)
+# Plan: Migrate ABF ACP **streaming output** into Agent Orchestrator
 
-**Status:** planning deliverable (docs only)  
-**Date:** 2026-08-04  
-**Target branch base:** current `main` (no Chat API / no `chatdriver` today)  
-**Authoritative design reference:** Desktop `fenzhi` (`/Users/zhongshengjieweilai/Desktop/fenzhi`)  
-**Capability / product-reference source:** Desktop `AllBeingsFuture` (`/Users/zhongshengjieweilai/Desktop/AllBeingsFuture`)  
-
-This plan is intentionally **implementation-free**. It tells implementer workers what to port, in what order, and what not to copy.
+**Status:** planning (docs only) — scope corrected 2026-08-04  
+**Primary goal:** Bring AllBeingsFuture’s **normalized ACP stream pipeline** (events + sequence + consumer reduce) into this repo — **not** a full Chat product, provider matrix, or packaging port.  
+**Source of truth (streaming):** Desktop `AllBeingsFuture`  
+**Design fit (boundaries only):** Desktop `fenzhi` — Chat/protocol events stay in the daemon; renderer never imports ACP SDKs.  
+**Target base:** current AO `main` (no Chat API / no stream surface today).
 
 ---
 
-## 1. Executive summary
+## 0. Scope correction (authoritative)
 
-| Source | Role in this migration |
+| In scope | Out of scope |
 | --- | --- |
-| **fenzhi** | **Primary port target.** Go daemon owns ACP lifecycle, domain conversation model, Chat service/controller, HTTP API, SQLite durability, CDC updates, and desktop chat UI. SDK: `github.com/coder/acp-go-sdk`. |
-| **AllBeingsFuture (ABF)** | **Capability and contract reference.** Normalized streaming UX concepts, permission mediation, package-resolve heuristics, test matrices, and docs about ACP v1 mapping. **Do not** lift ABF’s Electron-main ACP transport into AO product. |
-| **AO main today** | TUI/terminal agent sessions only. No `ports.Chat*`, no `chatdriver`, no conversation tables, no conversation HTTP routes, no chat renderer surface. |
+| Normalized stream **event types** and envelope (`sequence`, `sessionId`, source) | Full fenzhi chat product (compaction, steer, skills, config options, models, MCP reload, packaging) |
+| **Backend normalizer**: provider/adapter events → sequenced stream events | Porting ABF Electron-main ACP TypeScript as the product transport |
+| **Emission path** to the renderer over AO daemon HTTP (SSE or dedicated stream) | Full provider matrix (Claude/Codex/Droid/OpenCode bindings, `acp-runtime` packaging) |
+| **Frontend reducer** + minimal timeline that renders the stream | Wholesale ABF conversation UI, missions, stickers, virtualization product chrome |
+| Unit tests for normalizer + reducer parity with ABF | Replacing TUI sessions; remote ACP transports; experimental ACP v2 |
 
-**Design decision (settled):** Prefer **fenzhi’s Go backend ACP stack** over porting ABF’s TypeScript Electron ACP adapter as-is. Map ABF product capabilities into AO ports/events; keep daemon protocol logic out of the Electron renderer.
+**One-sentence product slice:**  
+*An AO session can push ACP-shaped activity as sequenced `AgentStreamEvent`s from the daemon; the desktop renderer reduces them into a live timeline (text, thinking, tools, plan, permission, terminal states) without speaking ACP itself.*
 
 ---
 
-## 2. Architecture mapping table
-
-Status key for **main today**:
-
-- **absent** — not present on main  
-- **partial** — related surface exists but Chat/ACP is missing  
-- **present (fenzhi only)** — exists fully in fenzhi; copy path is known  
-
-| ABF component | AO (fenzhi) component | Status on main | Migration action |
-| --- | --- | --- | --- |
-| Electron main `@agentclientprotocol/sdk` + `electron/bridge/adapters/acp.ts` | `backend/internal/adapters/chatdriver/acp/*` + `github.com/coder/acp-go-sdk` | **absent** | Port fenzhi ACP package; do not port Node SDK into product daemon |
-| `electron/bridge/acp-package-resolve.ts` | Provider binding probe/launch (`claudeacp`, `nativeacp`, …) + existing agent plugins’ `ResolveBinary` | **partial** (agent plugins exist; no Chat binding) | Port fenzhi bindings; optionally reuse ABF **heuristics** only if a binding needs path discovery AO plugins lack |
-| `BridgeManager` + adapter registry | `chatdriver/registry` + daemon wiring of `ChatDriverRegistry` | **absent** | Port registry + wire in `daemon` |
-| `BridgeEvent` (adapter-internal) | `ports.ChatEvent` + domain activity/message projection | **absent** | Port fenzhi port + projector; ABF BridgeEvent is conceptual only |
-| `StreamNormalizer` → sequenced `AgentStreamEvent` | Chat **controller** projects provider events → durable rows; clients get snapshot + CDC (not IPC stream of raw deltas) | **absent** | Port fenzhi service/controller + storage; do **not** reintroduce ABF IPC sequence protocol as product wire format |
-| `agent:stream` IPC envelope (`sessionId`, `sequence`, …) | Loopback HTTP conversation snapshot + SQLite CDC change_log (existing AO pattern) | **partial** (CDC exists; no conversation entities) | Extend CDC/triggers for conversation tables; frontend consumes daemon API |
-| `agent:permission:respond` IPC | `POST .../conversation/approvals/{requestId}/resolve` | **absent** | Port HTTP + service path |
-| `ProcessService.StopProcess` cancel | `POST .../conversation/interrupt` + driver `session/cancel` | **partial** (session kill exists; not Chat interrupt) | Port Chat interrupt; keep session terminate separate |
-| Renderer `agentStreamCore` / `agentStreamTypes.ts` | `frontend/.../components/chat/*` + `hooks/useConversation.ts` + domain-aligned TS types from OpenAPI | **absent** | Port fenzhi chat UI; map ABF UX ideas (permission card, plan, tool status) into fenzhi components—not ABF CSS/layout wholesale |
-| Legacy CLI parsers (`electron/parser/*`) | **Out of Chat path.** AO TUI mode already uses terminal adapters | **present** (TUI) | Non-goal for Chat; TUI remains default session mode |
-| ABF provider profiles (`acp`, `claude-sdk`, `codex-appserver`, …) | Harness + `SessionMode` (`tui` \| `chat`) + driver registry | **partial** (harnesses exist; no mode column) | Add `SessionMode`; Chat drivers for selected harnesses |
-| ABF SQLite chat messages in Electron | `conversations` / `conversation_turns` / `messages` / `activities` (+ later migrations) | **absent** | Port fenzhi migrations (re-numbered after main head) |
-| ABF clean-room ACP v1 docs | This plan + optional `docs/` architecture note after ship | **absent** | Keep product docs AO-native; cite public ACP schema only |
-
-### 2.1 Layer ownership (target AO)
+## 1. ABF streaming pipeline (what we are migrating)
 
 ```text
-Renderer (Electron)
-  SessionChatSurface · ChatComposer · approvals/plans/tools UI
-  useConversation → HTTP + CDC
-  NEVER imports acp-go-sdk / Node ACP SDK / provider wire DTOs
-        │  loopback HTTP (127.0.0.1, unauthenticated)
+Provider adapter (ACP or legacy)
+        │  BridgeEvent  (adapter-internal, not wire to UI)
         ▼
-Daemon (Go)
-  httpd/controllers/conversations*.go
-  service/chat (Service + Controller)
-  ports.ChatDriver / ChatConversation / ChatEvent
-  adapters/chatdriver/{acp,claudeacp,nativeacp,droidacp,opencodeacp,codexappserver,registry}
-  storage/sqlite conversation* + CDC triggers
-        │  stdio NDJSON JSON-RPC (or Codex app-server)
+AgentStreamNormalizer  (sequence++, map kinds, tool output diff)
+        │  AgentStreamEvent  (provider-neutral, sequenced)
         ▼
-Provider process (user-installed CLI / packaged bridge only where fenzhi already does)
+IPC agent:stream  ──▶  parseAgentStreamEvent
+        │
+        ▼
+AgentStreamBatcher  (rAF coalesce text/thinking/tool progress)
+        │
+        ▼
+reduceAgentStreamEvent  (pure)  ──▶  messages + AgentSessionStreamState
+        │
+        ▼
+Conversation / activity UI
 ```
 
-Hard rules from `AGENTS.md` remain binding: loopback unauthenticated; CLI thin HTTP client; no daemon protocol in renderer; `~/.ao` only for app state.
+### Canonical source files (ABF)
+
+| Layer | Path |
+| --- | --- |
+| Architecture | `docs/acp-architecture.md` (StreamNormalizer, envelope, mapping) |
+| Renderer contract | `frontend/docs/acp-renderer-streaming.md` |
+| Wire types | `frontend/src/types/agentStreamTypes.ts` |
+| Normalizer | `electron/services/agent-stream-normalizer.ts` (+ `electron/tests/agent-stream-normalizer.test.ts`) |
+| Main-side types twin | `electron/services/agent-stream-types.ts` (keep in sync with frontend types) |
+| Pure reducer | `frontend/src/core/chat/agentStreamCore.ts` (+ tests) |
+| Coalesce/batch | `frontend/src/core/chat/agentStreamBatch.ts` (+ tests) |
+| Parse/IPC respond | `frontend/src/hooks/agentStreamIpc.ts` |
+| Producer only | `electron/bridge/adapters/acp.ts` → emits `BridgeEvent`; normalizer is the seam |
+
+### Load-bearing ABF rules (must preserve semantics)
+
+1. **`sequence`**: per local `sessionId`, start at `0`, strictly increasing for every emitted stream event; consumer ignores `sequence <= lastSequence` (replay-safe).  
+2. **Append-only deltas**: `text_delta.delta`, `tool_update.resultDelta` / `output.text` never carry cumulative text.  
+3. **Plan = full replace** snapshot each event.  
+4. **Thinking**: ACP chunks as `mode: 'delta'`; legacy may `replace` (reducer supports both).  
+5. **Tool updates**: ACP replacement content is **diffed** against previous full text before emitting `resultDelta`.  
+6. **Terminal events**: `done` | `error` | `cancelled` finalize partial bubbles, clear permission UI, end the turn stream.  
+7. **Permission**: surface only request (not outcome) as `permission_request`; respond out-of-band with `{ sessionId, requestId, optionId }`.  
+8. **Silence fail-open** (ABF product): after ~12s without stream events while “active”, legacy paths may resume — in AO this becomes “prefer stream while active, then fall back to snapshot/CDC” if both exist.  
+9. **No ACP SDK in renderer.**
 
 ---
 
-## 3. Capability gap analysis
+## 2. Event type map: ABF → AO wire
 
-### 3.1 ABF capability → fenzhi coverage
+### 2.1 Recommended AO product wire (streaming MVP)
 
-| Capability | ABF | fenzhi design | Gap vs main | Notes for AO port |
-| --- | --- | --- | --- | --- |
-| Stable ACP v1 stdio client | Yes (TS SDK) | Yes (Go SDK `acp-go-sdk` v0.13.5 in fenzhi) | Main missing | Pin SDK version in `backend/go.mod` when porting |
-| `initialize` / protocolVersion gate | Yes | Yes | Main missing | Reject non-v1; no experimental v2 |
-| `session/new` + resume (`session/load` or resume capability) | Yes | Yes (resume required for production floor) | Main missing | Production floor: streaming + approvals + interrupt + resume |
-| Prompt turn + streaming text | Yes | `message.delta` / `message.completed` | Main missing | Durable message rows + in-place delta mutation |
-| Thinking / reasoning | Yes (`thinking_update`) | `reasoning.delta` + `ActivityKindReasoning` | Main missing | Hideable reasoning |
-| Tool calls | Yes | activities (`command`, `mcp_tool`, …) | Main missing | Prefer typed activities over free-form tool blobs |
-| Plans | Yes | `turn.plan` + plan activity | Main missing | Full snapshot replace semantics (ABF + fenzhi agree) |
-| Permissions / approvals | Yes | `approval.requested` / resolve API | Main missing | Provider-offered decision options only (`ErrChatDecisionNotOffered`) |
-| Cancel in-flight turn | Yes | interrupt | Main missing | Map late stop → `ErrChatNoActiveTurn` (ordinary, not 500) |
-| Legacy + native dual path | Yes (explicit) | Chat vs TUI session modes | TUI only on main | Keep TUI default; Chat opt-in per session |
-| Sequenced live stream IPC | Yes | **Different:** durable sequence + CDC | Main has CDC only | Do not clone ABF IPC sequence as API; follow fenzhi |
-| Compaction | Weak / optional | First-class capability + API | Main missing | Later phase OK |
-| Steer mid-turn | No (ABF) | `ChatSteerer` + API | Main missing | Codex-first; optional for ACP agents |
-| Config options / models / skills | Partial status messages in ABF docs | First-class list/set APIs | Main missing | Phase after core chat |
-| Usage / rate limits / diffs / MCP reload | Partial | Full port surfaces in fenzhi | Main missing | Phase after core chat |
-| Nested agents / elicitation / images | Partial product | Capabilities modeled in ports | Main missing | Capability-gated; do not block MVP |
-| Package resolve for packaged ACP adapters | Yes (Node) | `frontend/acp-runtime` + `claudeacp` runtime resolve | Main missing | Port fenzhi packaging, not ABF resolve wholesale |
-| Fake ACP agent tests | Yes (`fixtures/fake-acp-agent.ts`) | Go unit tests + e2e chat suite | Main missing | Prefer fenzhi Go tests; ABF fixture ideas only |
+**Keep the ABF `AgentStreamEvent` discriminated union as the cross-process contract**, with one transport change:
 
-### 3.2 What ABF has that fenzhi already covers (port fenzhi, not ABF code)
-
-- Provider-neutral streaming UX (text, thinking, tools, plan, permissions, terminal turn states).
-- Permission request/response mediation with cancel-on-stop.
-- Native ACP process lifecycle (init → session → prompt → cancel → teardown).
-- MCP server injection into session setup (stdio/http/sse negotiation).
-- Separation of renderer from ACP SDK.
-
-### 3.3 What ABF has that is still product/design work on top of fenzhi
-
-- ABF-specific supervisor/child mission product model (out of scope for Chat MVP).
-- ABF proprietary conversation UI (layout, stickers, virtualization details)—**do not wholesale copy**.
-- ABF package-resolve edge cases for multi-layout Electron packaging—audit against AO forge packaging only if Claude ACP runtime packaging fails.
-- ABF dual “legacy adapter still emits BridgeEvent” path—AO already has TUI mode; no need for a second legacy chat normalizer in process.
-
-### 3.4 What fenzhi has that ABF does not (bring intentionally)
-
-- Separate **Chat port** from Agent/Runtime (no keystroke “send”).
-- Durable conversation model (messages ≠ activities; conversation-scoped immutable sequence).
-- Production capability floor for mutating workspace Chat sessions.
-- Steer, compaction, rollback, fork, rename, config options, skills, MCP reload, usage/rate limits as first-class optional interfaces.
-- Codex **app-server** driver (`codexappserver`) as a non-ACP machine protocol beside ACP.
-- Full HTTP OpenAPI surface under `/api/v1/sessions/{sessionId}/conversation/*`.
-- Backend e2e suite (`backend/e2e/chat_*.go`).
-
----
-
-## 4. Main baseline (facts to preserve)
-
-As of this plan’s research against the worktree’s then-current main lineage:
-
-| Area | Main state |
+| ABF transport | AO transport (target) |
 | --- | --- |
-| `backend/internal/ports/` | No `chat.go` / `chat_steer.go` |
-| `backend/internal/adapters/chatdriver/` | **Does not exist** |
-| `backend/internal/service/chat/` | **Does not exist** |
-| `backend/internal/domain/conversation.go` / `sessionmode.go` | **Do not exist** |
-| SQLite migrations | Head around `0042_review_run_unique_per_harness.sql` (no conversation migrations) |
-| HTTP DTOs / OpenAPI | No conversation operations |
-| Frontend | No `renderer/components/chat/` |
-| Agent plugins | TUI launch/auth already exist for many harnesses (reuse for Chat probe/launch) |
-| CDC | Present for sessions etc.; extend for conversation tables via triggers |
+| Electron IPC `agent:stream` push | Daemon **SSE** (preferred) or WebSocket on loopback HTTP |
+| `agent:permission:respond` invoke | `POST` on a session-scoped approval route (minimal) |
+| Envelope fields on every event | Same: `sessionId`, `sequence`, optional `timestamp`, optional `source` |
 
-fenzhi conversation migrations start at `0041_chat_session_mode.sql` through `0051_...`. On main they must be **re-numbered** after the live head (never edit already-merged migrations).
+**Do not** invent a second parallel event vocabulary in the renderer. Backend may use an internal adapter event type (ABF `BridgeEvent` or fenzhi `ports.ChatEvent`), but the **daemon→UI stream frame** should be ABF-compatible `AgentStreamEvent` JSON so the reducer ports almost verbatim.
 
----
+Optional later: a thin alias layer if AO OpenAPI wants `camelCase` DTO names — keep field-level parity with ABF types.
 
-## 5. File-level port list
+### 2.2 `AgentStreamEvent` union (AO wire — copy semantics)
 
-### 5.1 Primary port from fenzhi (authoritative)
-
-Port in dependency order. Paths are relative to repo root; source tree is fenzhi.
-
-#### Phase A — domain + ports (no process I/O)
-
-| fenzhi path | Notes |
-| --- | --- |
-| `backend/internal/domain/sessionmode.go` (+ test) | `tui` / `chat`; default `tui` |
-| `backend/internal/domain/conversation.go` | Durable model + plan types |
-| `backend/internal/ports/chat.go` | ChatDriver, events, capabilities, errors |
-| `backend/internal/ports/chat_steer.go` | Optional steerer |
-
-#### Phase B — storage
-
-| fenzhi path | Notes |
-| --- | --- |
-| `backend/internal/storage/sqlite/migrations/0041_chat_session_mode.sql` … `0051_*.sql` | Re-number as `00NN+` on main |
-| `backend/internal/storage/sqlite/queries/conversations.sql` (+ session column queries) | sqlc source |
-| `backend/internal/storage/sqlite/store/conversation_store.go` (+ history store tests) | |
-| Generated `gen/*` via `npm run sqlc` only | Do not hand-edit gen |
-
-#### Phase C — chatdriver adapters
-
-| fenzhi path | Notes |
-| --- | --- |
-| `backend/internal/adapters/chatdriver/acp/*.go` | Lifecycle + mapping; owns ACP |
-| `backend/internal/adapters/chatdriver/registry/*` | |
-| `backend/internal/adapters/chatdriver/claudeacp/*` | Claude via packaged ACP runtime + `CLAUDE_CODE_EXECUTABLE` |
-| `backend/internal/adapters/chatdriver/nativeacp/*` | Shared native binding helper |
-| `backend/internal/adapters/chatdriver/droidacp/*` | |
-| `backend/internal/adapters/chatdriver/opencodeacp/*` | |
-| `backend/internal/adapters/chatdriver/codexappserver/*` | Non-ACP; keep as parallel driver |
-
-#### Phase D — service + session manager hooks
-
-| fenzhi path | Notes |
-| --- | --- |
-| `backend/internal/service/chat/*` | Service, controller, history, steer, skills |
-| `backend/internal/session_manager/chat_spawn.go` (+ tests, attachments) | Spawn path for Chat mode |
-| Session status derivation updates that treat Chat activity | e.g. fenzhi `service/session/status.go` Chat exemption patterns |
-| Daemon wiring of registry + chat service | Follow fenzhi `daemon` patterns |
-
-#### Phase E — HTTP + OpenAPI + CLI (if any)
-
-| fenzhi path | Notes |
-| --- | --- |
-| `backend/internal/httpd/controllers/conversations*.go` (+ tests) | |
-| `backend/internal/httpd/controllers/dto.go` conversation DTOs | |
-| `backend/internal/httpd/apispec/specgen/build.go` operations | Then `npm run api` |
-| CLI only if fenzhi exposes chat commands still desired | Thin HTTP; mirror DTOs; table tests |
-
-#### Phase F — frontend
-
-| fenzhi path | Notes |
-| --- | --- |
-| `frontend/src/renderer/components/chat/**` | AO design system / DESIGN.md |
-| `frontend/src/renderer/hooks/useConversation.ts` (+ test) | |
-| `frontend/src/renderer/types/conversation.ts` | Prefer OpenAPI-generated types where possible |
-| Session surface integration (mode toggle / chat panel entry) | Surgical; do not restyle board |
-| `frontend/acp-runtime/**` + `frontend/scripts/build-acp-runtime.mjs` | Packaged Claude ACP adapter runtime only |
-
-#### Phase G — tests & packaging
-
-| fenzhi path | Notes |
-| --- | --- |
-| `backend/e2e/chat_*.go` + `harness_test.go` | Bring after API stable |
-| Unit tests colocated with adapters/service | Port with code |
-| `backend/go.mod` / `go.sum` | Add `github.com/coder/acp-go-sdk` |
-
-### 5.2 Selective concepts from ABF (not wholesale file ports)
-
-Use as **requirements and test ideas**, re-implement inside fenzhi shapes:
-
-| ABF path | Extract | Re-home in AO |
+| `type` | Payload | Semantics |
 | --- | --- | --- |
-| `docs/acp-architecture.md` | Lifecycle diagram, security notes, capability honesty (no fs/terminal client caps until implemented) | This plan + future `docs/` architecture section |
-| `frontend/docs/acp-renderer-streaming.md` | Event semantics (append-only deltas, plan replace, terminal events) | Verify fenzhi projector + UI match; do not invent ABF IPC on daemon |
-| `electron/bridge/adapters/acp.ts` | Mapping table ACP v1 → UI concepts; permission cancel-on-destroy; MCP capability assert | Cross-check `chatdriver/acp/client.go` + conversation mapping |
-| `electron/bridge/types.ts` | BridgeEvent kind inventory for gap checklist | Already covered by `ports.ChatEventKind` |
-| `frontend/src/types/agentStreamTypes.ts` | Product UX event set | Ensure fenzhi UI covers parity items needed for MVP |
-| `electron/bridge/acp-package-resolve.ts` | Candidate node_modules roots / unpack heuristics | Only if AO desktop packaging of `acp-runtime` needs it |
-| `electron/tests/acp-*.ts` | Cases: handshake fail, permission respond, cancel, package resolve | Port as Go tests / e2e assertions |
-| `electron/services/agent-stream-normalizer.ts` | Diff tool_call_update replacement content into deltas | Confirm fenzhi activity projection does equivalent |
+| `text_delta` | `itemId`, `delta` | Append-only assistant text |
+| `thinking_update` | `itemId`, `text`, `mode?: 'delta' \| 'replace'` | Reasoning stream |
+| `tool_call` | `toolCallId`, `title`, `name?`, `input?` | Tool creation |
+| `tool_update` | `toolCallId`, `status`, optional fields, `resultDelta?`, `output?`, `error?` | Progress/result; deltas append-only |
+| `plan` | `title?`, `entries[]` | Full plan replace |
+| `status` | `status: starting \| running \| waiting \| idle`, `message?` | App lifecycle (not ACP v2) |
+| `permission_request` | `request: { requestId, toolCallId?, title, description?, options[] }` | Blocks until resolve/cancel |
+| `done` | `stopReason?` | Terminal success |
+| `error` | `message` | Terminal failure |
+| `cancelled` | `reason?` | Terminal cancel |
 
-**Explicit non-ports from ABF:** `electron/parser/*` legacy log parsers for Chat; proprietary mission/team UI; stickers; ABF Zustand stores; ABF IPC channel names.
+Envelope on every event:
+
+```ts
+{ sessionId: string; sequence: number; timestamp?: string;
+  source?: { kind: 'native-acp-v1' | 'legacy-adapter'; provider?: string } }
+```
+
+### 2.3 Internal producer map (BridgeEvent / ACP → stream)
+
+From ABF normalizer (`AgentStreamNormalizer.normalize`):
+
+| Input (`BridgeEvent.event`) | Output stream `type` | Notes |
+| --- | --- | --- |
+| `delta` + text | `text_delta` | empty text → drop |
+| `thinking` | `thinking_update` `mode: 'delta'` | |
+| `tool` `!isUpdate` | `tool_call` | |
+| `tool` `isUpdate` | `tool_update` | diff output → `resultDelta` |
+| `plan` | `plan` | empty remove → `entries: []` |
+| `permission` without outcome | `permission_request` | outcomes dropped |
+| `status` phase | `status` | ignore non-UI phases (e.g. `ready`) |
+| `done` / cancel stopReason | `done` or `cancelled` | clear tool output cache |
+| `error` | `error` | clear tool output cache |
+| `agent_task` | *(drop)* | out of stream MVP |
+
+### 2.4 Optional mapping through fenzhi `ports.ChatEvent` (if Chat stack lands later)
+
+Use only as an **adapter-internal** intermediate. Streaming MVP does **not** require durable conversation tables.
+
+| ABF stream | fenzhi `ChatEventKind` (internal) |
+| --- | --- |
+| `text_delta` | `message.delta` |
+| `thinking_update` | `reasoning.delta` |
+| `tool_call` / `tool_update` | `activity.started` / `activity.completed` (+ `command.output.delta`) |
+| `plan` | `turn.plan` |
+| `permission_request` | `approval.requested` |
+| `status` | `controller.state` / turn lifecycle |
+| `done` / `cancelled` / `error` | `turn.completed` + `TurnState*` / `error` |
+
+If both exist: **normalizer emits AgentStreamEvent for live UI**; durable projector may separately consume ChatEvents. Do not force the renderer to reduce ChatEvent kinds.
+
+### 2.5 ACP v1 notification → BridgeEvent (producer side, reference)
+
+From ABF docs (implement in Go or TS adapter behind the normalizer):
+
+| ACP v1 | Bridge / stream |
+| --- | --- |
+| `agent_message_chunk` text | `delta` → `text_delta` |
+| `agent_thought_chunk` text | `thinking` → `thinking_update` delta |
+| `tool_call` | `tool` create → `tool_call` |
+| `tool_call_update` | `tool` update → `tool_update` (diff content) |
+| `plan` | `plan` → `plan` |
+| `session/request_permission` | `permission` → `permission_request` |
+| prompt `stopReason` | `done` / `cancelled` |
+| transport failure | `error` |
 
 ---
 
-## 6. Phased PR breakdown
+## 3. Backend: normalizer + emission path
 
-Keep **one concern per PR**. Conventional commits. Each PR should leave main green.
-
-### PR-0 — Docs (this document)
-
-- **Scope:** `docs/plans/acp-migration-from-abf-fenzhi.md` only  
-- **Exit:** Team agrees architecture (fenzhi primary, ABF concepts only)
-
-### PR-1 — Backend core: domain, ports, schema foundation
-
-- Add `SessionMode`, conversation domain types, `ports.Chat*`  
-- Migration(s) for: `sessions.mode`, `provider_conversation_id`, core `conversations` / turns / messages / activities tables + CDC triggers  
-- Store interfaces + sqlc  
-- **No** live provider process required  
-- **Tests:** domain pure tests; store tests with sqlite  
-- **Success:** can create Chat-mode session row + empty conversation snapshot in tests
-
-### PR-2 — Chat service/controller (fake driver)
-
-- `service/chat` with in-memory/fake `ChatDriver`  
-- Project events to durable rows; approvals; interrupt  
-- Session manager spawn hook for Chat (still fake driver)  
-- **Tests:** controller unit tests from fenzhi (trimmed)  
-- **Success:** send message → deltas persist → interrupt → approval resolve against fake
-
-### PR-3 — Provider-neutral ACP driver + registry
-
-- Port `chatdriver/acp` + registry  
-- Wire daemon  
-- Fake ACP agent or recorded pipes in unit tests  
-- **Success:** ACP handshake + turn + permission + cancel against fake process
-
-### PR-4 — Provider bindings (split if needed)
-
-Recommended sub-order:
-
-1. **codexappserver** (often highest product value; non-ACP) **or** **claudeacp** (ACP + packaged runtime)—product owner picks first ship harness  
-2. `nativeacp` + `opencodeacp` + `droidacp`  
-3. Packaging: `frontend/acp-runtime` for Claude bridge  
-
-Each binding reuses existing agent plugin `ResolveBinary` / `AuthStatus`.
-
-**Success per binding:** `Probe` works; Start/Resume/SendTurn/Interrupt/approvals green in unit or gated live tests.
-
-### PR-5 — HTTP API + OpenAPI + typed client
-
-- Controllers + DTOs  
-- `npm run api` → commit `openapi.yaml` + `frontend/src/api/schema.ts`  
-- Map port errors to stable API error codes  
-- Optional thin CLI conversation commands if product wants them  
-- **Tests:** httptest controller tests; api drift tests  
-
-### PR-6 — Frontend chat surface
-
-- Port fenzhi chat components + `useConversation`  
-- Session inspector / workbench entry for Chat mode  
-- Approvals, plans, tools, interrupt, composer  
-- Follow `DESIGN.md` / agent-orchestrator look; no ABF skin  
-- **Tests:** component tests; smoke e2e if feasible  
-
-### PR-7 — Hardening: advanced capabilities + e2e
-
-- Compaction, steer, models/config options, skills, usage, diffs, MCP reload as prioritized  
-- Port fenzhi `backend/e2e/chat_*.go`  
-- Docs: architecture note + STATUS.md  
-
-### Suggested dependency graph
+### 3.1 Placement in AO
 
 ```text
-PR-0 docs
-  └─▶ PR-1 domain/schema
-        └─▶ PR-2 service (fake)
-              ├─▶ PR-3 acp core
-              │     └─▶ PR-4 bindings (+ packaging)
-              └─▶ PR-5 HTTP/OpenAPI ──▶ PR-6 frontend
-                                        └─▶ PR-7 e2e/advanced
+[optional] ACP process adapter (later PR / sibling)
+        │  internal events (Bridge-like or ChatEvent)
+        ▼
+backend normalizer (NEW)  — sequence allocator per sessionId
+        │  AgentStreamEvent JSON
+        ▼
+session stream hub (NEW)  — fan-out, optional ring buffer for reconnect
+        │
+        ▼
+httpd SSE  GET /api/v1/sessions/{sessionId}/agent-stream
+        │  (loopback 127.0.0.1, unauthenticated — existing AO rule)
+        ▼
+renderer EventSource → parse → batch → reduce → timeline
 ```
 
-PR-3 and PR-5 can partially parallelize after PR-2 if API contracts are frozen from fenzhi DTOs early—prefer freezing OpenAPI from fenzhi shapes in PR-5 only after service methods stabilize.
+**Boundary rules (fenzhi-aligned):**
+
+- Normalizer + sequence + permission correlation live in the **daemon**, not Electron main, not renderer.  
+- Renderer does not import `acp-go-sdk` or Node ACP SDK.  
+- CLI stays a thin HTTP client if any stream debug command is added later.
+
+### 3.2 Why not only existing `/api/v1/events` CDC?
+
+Main already has CDC SSE (`GET /api/v1/events`) for **durable row changes** (`session_updated`, PR facts, …). High-frequency token deltas do **not** belong as one SQLite change_log row per token:
+
+| Approach | Fit for streaming MVP |
+| --- | --- |
+| **Dedicated agent-stream SSE** (recommended) | Matches ABF push semantics; sequence owned by stream hub; no DB write per delta |
+| CDC after durable projection | Good for **final** message/activity rows once Chat storage exists; too slow/heavy for live typing |
+| Terminal websocket mux | Wrong abstraction (bytes/PTY), not typed agent events |
+
+**MVP recommendation:** new session-scoped SSE for live `AgentStreamEvent`. Optionally later, CDC invalidates a conversation snapshot after terminal turn.
+
+### 3.3 Backend components to add (minimal)
+
+| Component | Responsibility |
+| --- | --- |
+| `AgentStreamEvent` DTO (Go) | Mirror ABF JSON field names |
+| `StreamNormalizer` | Port ABF normalizer logic (sequence, tool diff, kind map) |
+| `StreamHub` | Per-session subscribers, last-N ring buffer, configure source kind |
+| `EventsController` route or new controller | `GET .../agent-stream?afterSequence=` |
+| Permission resolve handler | Minimal POST; completes parked permission in producer |
+| Fake producer (tests / demo) | Inject synthetic Bridge-like events without real ACP |
+
+### 3.4 Sequence + reconnect
+
+- Server allocates sequence; clients send `afterSequence` (or SSE `Last-Event-ID` if framed that way).  
+- Replay from ring buffer only (`sequence > after`); never re-send cumulative text.  
+- On hub clear/session destroy: clients reset `lastSequence` or receive a stream-reset control event (pick one policy in implementation; prefer explicit `status: idle` + client reset on session change).
+
+### 3.5 What **not** to build in streaming PRs
+
+- Full `chatdriver` provider matrix, `acp-runtime` packaging, conversation SQLite schema, steer/compaction/skills APIs.  
+Those may land in **other** migrations; streaming must demo with a **fake producer** or a single thin ACP fake process.
 
 ---
 
-## 7. Event / API contract mapping (ABF stream → AO Chat)
+## 4. Frontend: reducer + timeline
 
-Implementers should treat the **right-hand column** as product truth.
+### 4.1 Port as pure modules (high fidelity)
 
-| ABF `AgentStreamEvent` | AO `ports.ChatEvent` / domain | HTTP / UI effect |
+| ABF module | AO target (suggested) | Notes |
 | --- | --- | --- |
-| `text_delta` | `message.delta` | Mutate assistant message in place |
-| `thinking_update` | `reasoning.delta` / reasoning activity | Collapsible reasoning |
-| `tool_call` / `tool_update` | `activity.started` / `activity.completed` (+ command output deltas) | Tool/command cards |
-| `plan` | `turn.plan` | Replace plan UI |
-| `permission_request` | `approval.requested` | Approval card; resolve via POST |
-| `status` | `controller.state` + turn state | Banners / busy |
-| `done` / `cancelled` / `error` | `turn.completed` + `TurnState*` / `error` | Finalize turn |
-| IPC `sequence` | Conversation `sequence` on rows + CDC | Client applies by sequence; no ABF IPC |
+| `agentStreamTypes.ts` | `frontend/src/renderer/lib/agent-stream/types.ts` (or `shared/`) | Source of truth types |
+| `agentStreamCore.ts` | `.../agent-stream/reduce.ts` | Pure reduce; **port tests** |
+| `agentStreamBatch.ts` | `.../agent-stream/batch.ts` | Coalesce text/thinking/tool progress |
+| `agentStreamIpc.ts` parse | `.../agent-stream/parse.ts` | Drop Electron invoke; keep parse |
+| Permission respond | thin API client POST | No `window.electronAPI` |
+| Stream subscribe | `EventSource` helper (pattern from `event-transport.ts` / workspace events) | |
+
+### 4.2 Reducer contract (must keep)
+
+From ABF `reduceAgentStreamEvent` behavior (tests are the spec):
+
+- Ignore `sequence <= lastSequence`.  
+- Stamp `lastEventAt`; silence timeout fail-open helpers.  
+- Append text into partial assistant bubble by `itemId`; open **new** bubble after tools / after terminal even if itemId reuses.  
+- Thinking delta vs replace.  
+- Tool call + update correlation (`toolCallId`); progressive stdout merge.  
+- Plan replace; clear plan on terminal/idle.  
+- Permission set/clear on terminal.  
+- Phase machine: `idle → running → waiting_permission → cancelling → done|error|cancelled`.
+
+### 4.3 Minimal timeline UI (demo-only chrome)
+
+Only enough surface to **prove the stream**:
+
+- Scrollable list of reduced messages (assistant text, thinking collapsed, tool cards).  
+- Plan panel when `stream.plan` set.  
+- Permission buttons when `stream.permission` set.  
+- Status/phase indicator + Stop (calls interrupt/cancel stub).  
+
+Use existing AO shadcn / DESIGN.md primitives. **Do not** port ABF ConversationView layout, stickers, or virtualization product work unless a stream demo is blocked without them.
+
+### 4.4 Integration point
+
+- Session inspector or a dedicated “Agent stream” panel when a session is selected.  
+- Hook: `useAgentStream(sessionId)` → EventSource + batcher + reduce into local React state (or a small store).  
+- No dependency on Chat-mode session flag for MVP if fake producer is session-scoped for any session id used in tests.
 
 ---
 
-## 8. Risks
+## 5. Phased PRs (streaming only)
 
-1. **Schema renumbering / migration collision** — fenzhi `0041+` collides with main’s non-chat migrations; must resequence and retest empty + upgrade DBs.  
-2. **SDK version skew** — `acp-go-sdk` vs ABF Node SDK vs provider agents; negotiate only stable v1; pin and test handshake failures.  
-3. **Resume semantics** — silent new conversation after daemon restart is forbidden (`ErrChatResumeFailed`); UI must force recovery choice.  
-4. **Dual mode confusion** — Chat vs TUI on same harness; mode immutable per session; status derivation and “send” paths must not cross.  
-5. **Packaging Claude ACP runtime** — Node bridge packaging (`acp-runtime`) can break desktop updates if not integrated into forge build.  
-6. **Permission consent bugs** — inventing decision options or auto-allow-always without policy is a security defect.  
-7. **Scope creep from ABF UI** — copying ABF conversation chrome violates AO design system and delays ship.  
-8. **Codex app-server vs ACP** — two machine protocols; keep separate packages; do not force Codex through ACP if fenzhi uses app-server.  
-9. **CDC lag / projector races** — deferred turn start (fenzhi `ChatDeferredTurnStarter`) must be preserved to avoid event loss.  
-10. **Live provider flakiness** — gate live tests; keep fake/unit coverage as merge gate.
+Keep PRs small; conventional commits; one concern each.
 
----
+### PR-S0 — Docs (this plan)
 
-## 9. Non-goals
+- Rewrite plan around streaming-only goal.  
+- **Exit:** team aligned on wire = ABF `AgentStreamEvent` over daemon SSE.
 
-- Porting ABF Electron-main ACP TypeScript stack as AO’s product transport.  
-- Putting ACP SDK or provider wire parsing in the renderer.  
-- Adopting experimental ACP v2 / remote HTTP-WS ACP in the first ship.  
-- Replacing TUI mode or forcing all harnesses to Chat.  
-- Wholesale ABF UI, mission/team/sticker product surfaces.  
-- Auto-accept permissions by default.  
-- Advertising client `fs` / `terminal` ACP capabilities until AO implements them safely (fenzhi deliberately refuses).  
-- Editing already-merged SQLite migrations.  
-- npm-as-primary distribution changes.  
-- Implementing the full stack in the planning session (this PR).
+### PR-S1 — Shared stream types + pure reducer/batcher (frontend-first OK)
 
----
+- Port `AgentStreamEvent` types, `parseAgentStreamEvent`, `reduceAgentStreamEvent`, batch/coalesce.  
+- Port ABF unit tests (vitest) with AO paths.  
+- **No** UI chrome beyond optional story/fixture if needed for tests.  
+- **Success:** tests green for sequence ignore, text append, tools, plan, permission clear, terminal flush.
 
-## 10. Success criteria
+### PR-S2 — Backend normalizer + hub + SSE
 
-### MVP (after PR-1…PR-6 for at least one harness)
+- Go DTO + normalizer ported from ABF rules (table-driven tests).  
+- In-memory hub + `GET /api/v1/sessions/{sessionId}/agent-stream`.  
+- Fake producer endpoint or test-only inject for e2e (e.g. internal test helper, or `POST .../agent-stream/fixtures` behind build tag / debug).  
+- **Success:** curl/EventSource receives strictly increasing sequences; tool diff correct; permission event shape valid.
 
-- [ ] Session can be created with `mode=chat` for a supported harness; default remains `tui`.  
-- [ ] Daemon owns provider process; renderer only uses loopback HTTP + CDC.  
-- [ ] User can send a message, see streaming assistant text, tools/activities, and plans.  
-- [ ] User can resolve a permission request with only provider-offered options.  
-- [ ] User can interrupt a turn; late interrupt is a soft error, not a crash.  
-- [ ] Daemon restart resumes provider conversation or surfaces resume failure—never silent empty thread.  
-- [ ] Production floor capabilities enforced before workspace-mutating Chat.  
-- [ ] OpenAPI + `schema.ts` committed and drift-clean.  
-- [ ] `go test` for touched packages and relevant e2e/unit gates green.  
-- [ ] No ACP protocol logic in Electron renderer; no `~/Library/Application Support` state.
+### PR-S3 — Frontend wire-up + minimal timeline
 
-### Full fenzhi parity (PR-7+)
+- EventSource client + batcher + reduce into UI.  
+- Permission POST + cancel/stop stub.  
+- Session panel demo.  
+- **Success:** running fake producer updates timeline live; replay afterSequence works; no ACP SDK in renderer.
 
-- [ ] Codex app-server + Claude ACP + at least one native ACP harness.  
-- [ ] Steer/compaction/config options/skills/usage as capability-gated UI.  
-- [ ] Backend e2e chat suite ported and running in CI where feasible.
+### PR-S4 — Thin real producer (optional, still not full product)
+
+- Single path that feeds the normalizer from a real or fake ACP stdio process **or** from fenzhi-style ChatEvent bridge if Chat lands.  
+- Still **not** multi-provider packaging.  
+- **Success:** one end-to-end native-acp-v1 source kind in `source` field.
+
+### Dependency graph
+
+```text
+PR-S0 docs
+  ├─▶ PR-S1 frontend pure stream modules + tests
+  └─▶ PR-S2 backend normalizer + SSE
+        └─▶ PR-S3 UI wire-up (needs S1 + S2)
+              └─▶ PR-S4 optional real producer
+```
+
+S1 and S2 can parallelize after S0.
 
 ---
 
-## 11. Recommended worker spawn order
+## 6. File-level port list (streaming)
 
-1. **Backend domain/schema worker** — PR-1  
-2. **Backend chat service worker** — PR-2 (depends on 1)  
-3. **Backend ACP driver worker** — PR-3 (depends on 2)  
-4. **Backend provider binding worker(s)** — PR-4 (depends on 3; can fan out per harness)  
-5. **Backend HTTP/OpenAPI worker** — PR-5 (depends on 2; ideally after 3 method freeze)  
-6. **Frontend chat UI worker** — PR-6 (depends on 5)  
-7. **E2E/hardening worker** — PR-7 (depends on 4+6)
+### From ABF (primary for stream logic)
 
-Do **not** start frontend before OpenAPI exists. Do **not** start provider live tests before fake-driver controller is green.
+| Source | Action |
+| --- | --- |
+| `frontend/src/types/agentStreamTypes.ts` | Port types |
+| `frontend/src/core/chat/agentStreamCore.ts` + tests | Port pure reduce |
+| `frontend/src/core/chat/agentStreamBatch.ts` + tests | Port batch/coalesce |
+| `frontend/src/hooks/agentStreamIpc.ts` | Port **parse** only; rehome permission to HTTP |
+| `electron/services/agent-stream-normalizer.ts` + tests | Reimplement in **Go** (or shared test vectors) |
+| `electron/services/agent-stream-types.ts` | Ensure parity with frontend types |
+| `frontend/docs/acp-renderer-streaming.md` | Condense into this plan / short AO stream doc later |
+| `docs/acp-architecture.md` §§4–5 | Mapping + permission rules |
+| `electron/bridge/types.ts` | Internal producer event shape reference |
+| `electron/bridge/adapters/acp.ts` | Producer mapping reference only |
 
----
+### From fenzhi (boundary / emission reference only)
 
-## 12. Explicit next actions for implementer workers
+| Source | Use |
+| --- | --- |
+| `backend/internal/ports/chat.go` event kinds | Optional internal intermediate; not required for MVP wire |
+| `service/chat` controller event loop | Pattern for serializing per-session emit |
+| Chat UI components | **Not** required; steal patterns only if timeline needs a card |
+| Full chatdriver / migrations / OpenAPI conversation surface | **Non-goal** for this plan |
 
-1. Confirm product **first ship harness** (Claude ACP vs Codex app-server).  
-2. Diff fenzhi vs main for session spawn/status/daemon wiring and list exact merge conflicts expected (main has moved past some fenzhi bases).  
-3. Land PR-1 with renumbered migrations; run `npm run sqlc`.  
-4. Port `ports/chat.go` verbatim in spirit (keep comments that encode rules).  
-5. Introduce fake driver before real ACP process code.  
-6. Port `chatdriver/acp` with `acp-go-sdk`; refuse client fs/terminal caps.  
-7. Wire registry in daemon; keep loopback bind unchanged.  
-8. Generate API; only then port fenzhi chat UI.  
-9. Add packaging for `acp-runtime` if Claude is first ship.  
-10. Track STATUS.md once MVP merges.
+### Main AO reuse
 
----
-
-## 13. Reference inventory (read-only sources)
-
-### fenzhi
-
-- `backend/internal/ports/chat.go`, `chat_steer.go`  
-- `backend/internal/adapters/chatdriver/**`  
-- `backend/internal/service/chat/**`  
-- `backend/internal/domain/conversation.go`, `sessionmode.go`  
-- `backend/internal/httpd/controllers/conversations*.go`  
-- `backend/internal/storage/sqlite/migrations/0041_chat_session_mode.sql` … `0051_*`  
-- `frontend/src/renderer/components/chat/**`, `hooks/useConversation.ts`  
-- `frontend/acp-runtime/package.json`  
-- `backend/e2e/chat_*.go`  
-- `backend/go.mod` → `github.com/coder/acp-go-sdk`
-
-### AllBeingsFuture
-
-- `docs/acp-architecture.md`  
-- `frontend/docs/acp-renderer-streaming.md`  
-- `electron/bridge/adapters/acp.ts`  
-- `electron/bridge/acp-package-resolve.ts`  
-- `electron/bridge/types.ts`  
-- `frontend/src/types/agentStreamTypes.ts`  
-- `electron/tests/acp-*.ts`
-
-### Public ACP
-
-- Stable schema: https://github.com/agentclientprotocol/agent-client-protocol (`schema/v1`)  
-- Go SDK: `github.com/coder/acp-go-sdk`  
-- Do not use experimental v2 product paths
+| Existing | Use |
+| --- | --- |
+| `frontend/src/renderer/lib/event-transport.ts` | EventSource reconnect patterns |
+| `backend/internal/httpd/events.go` | SSE write helpers / style |
+| Loopback daemon + typed API client generation | If stream route is OpenAPI-registered |
 
 ---
 
-## 14. Open decisions (need product/orchestrator input)
+## 7. Risks
+
+1. **Confusing stream SSE with CDC** — token spam must not hit `change_log`.  
+2. **Sequence policy on reconnect** — wrong reset causes blank or duplicated text.  
+3. **Tool output diff bugs** — replacement vs delta mismatches explode UI.  
+4. **Permission correlation** — requestId must match parked RPC; invalid optionId must not consume request.  
+5. **Scope creep** — full Chat stack / multi-provider packaging derails the stream demo.  
+6. **Dual state** — if snapshot polling is added later, enforce ABF “prefer stream while active” rules.  
+7. **Batching latency** — preserve ABF immediate flush for terminal/permission/plan; only batch high-frequency deltas.
+
+---
+
+## 8. Non-goals (explicit)
+
+- Full Chat session mode, conversation SQLite schema, OpenAPI conversation CRUD.  
+- Multi-provider Chat drivers (`claudeacp`, `codexappserver`, …) and desktop `acp-runtime` packaging.  
+- Porting ABF Electron ACP adapter as AO’s runtime.  
+- ACP SDK or provider parsing in the renderer.  
+- Experimental ACP v2 / remote HTTP ACP.  
+- ABF proprietary conversation chrome (missions, stickers, full virtualization product).  
+- Replacing TUI terminal sessions.  
+- Steer, compaction, skills, model pickers, MCP reload UIs — unless a stream event cannot be demoed without a stub control.
+
+---
+
+## 9. Success criteria (streaming MVP)
+
+- [ ] Documented map ABF stream types ↔ AO SSE JSON is implemented 1:1 for the union above.  
+- [ ] Backend allocates monotonic `sequence` per session; clients drop duplicates/replays.  
+- [ ] Normalizer tool output is append-only `resultDelta` (diffed).  
+- [ ] Frontend pure reducer + batcher tests ported and green.  
+- [ ] Minimal timeline shows text, thinking, tools, plan, permission, and terminal states from a fake producer.  
+- [ ] Permission resolve round-trip works over HTTP.  
+- [ ] Renderer has zero ACP SDK dependency.  
+- [ ] Loopback-only daemon path; no new authenticated network listener.
+
+---
+
+## 10. Recommended worker spawn order
+
+1. **Docs** — this plan (S0).  
+2. **Frontend stream core** — types + reduce + batch + tests (S1).  
+3. **Backend stream** — normalizer + hub + SSE + tests (S2).  
+4. **Frontend integration** — EventSource + minimal timeline + permission POST (S3).  
+5. **Optional producer** — thin ACP or fixture feeder (S4).
+
+Avoid parallel edits to the same files: S1 owns `frontend/.../agent-stream/*`; S2 owns `backend/.../agentstream/*` (or similar); S3 only wires them.
+
+---
+
+## 11. Explicit next actions for implementers
+
+1. Freeze wire JSON: commit ABF-compatible `AgentStreamEvent` TypeScript + matching Go struct tags.  
+2. Land **PR-S1** with ABF reducer/batcher tests as the behavioral spec.  
+3. Land **PR-S2** with table tests for normalizer (text, thinking, tool diff, plan, permission drop-on-outcome, terminal).  
+4. Add SSE route + ring buffer; document `afterSequence` query.  
+5. Wire **PR-S3** demo panel; use fake producer only until S4.  
+6. Do **not** start packaging/provider matrix under this plan’s PRs.
+
+---
+
+## 12. Open decisions (streaming-specific)
 
 | Decision | Options | Recommendation |
 | --- | --- | --- |
-| First Chat harness | Claude ACP / Codex app-server / OpenCode native | Codex if app-server stability is known in fenzhi; else Claude if desktop packaging ready |
-| Default mode for new sessions | Always `tui` / opt-in Chat / harness-default | Keep **default `tui`** (fenzhi) |
-| CLI conversation commands | HTTP-only first / add `ao chat` subset | HTTP-only first; CLI later if needed |
-| How much of fenzhi advanced capabilities in MVP | Core stream+approve+interrupt+resume only / full parity | **Core first**; advanced in PR-7 |
+| Live transport | Session SSE vs WS vs reuse CDC | **Session SSE** |
+| SSE event name | `agent_stream` vs unnamed `message` | Named `agent_stream` + JSON body |
+| Fake producer | Debug HTTP inject vs test-only | Debug inject behind non-prod or explicit flag for demo |
+| Where types live | `renderer/lib` vs `shared` | `shared` if main process ever needs parse; else renderer + Go DTO |
+| Permission route | New minimal path vs wait for Chat approvals API | Minimal `POST .../agent-stream/permissions/{requestId}/resolve` for MVP |
 
 ---
 
-*End of plan. Implementation must follow `AGENTS.md` hard rules and keep changes surgical per PR.*
+## 13. Relationship to earlier “full Chat stack” thinking
+
+An earlier draft of this file planned a wholesale fenzhi Chat/ACP product port. That is **superseded** for the active migration goal:
+
+- **Streaming output path** (this document) ships first and stands alone.  
+- Full Chat durability/drivers/OpenAPI may still use fenzhi later; they must **consume or bridge into** this stream contract rather than invent a second live UI event language.
+
+---
+
+*Implementation must follow `AGENTS.md` hard rules. Plan-only session: no stream stack code in the docs PR beyond this file.*

--- a/docs/plans/acp-migration-from-abf-fenzhi.md
+++ b/docs/plans/acp-migration-from-abf-fenzhi.md
@@ -1,7 +1,12 @@
 # Plan: Migrate ABF ACP **streaming output** into Agent Orchestrator
 
-**Status:** planning (docs only) — scope corrected 2026-08-04  
-**Primary goal:** Bring AllBeingsFuture’s **normalized ACP stream pipeline** (events + sequence + consumer reduce) into this repo — **not** a full Chat product, provider matrix, or packaging port.  
+> **Superseded as the active product goal (2026-08-04).**  
+> Human hard pivot: **fully remove tmux** and run agents as ACP/HTTP child processes.  
+> Active cutover plan: [`abf-no-tmux-acp-cutover.md`](./abf-no-tmux-acp-cutover.md).  
+> This document remains useful as **Phase 1 subsystem detail** (AgentStreamEvent, normalizer, reducer).
+
+**Status:** planning (docs only) — streaming subsystem; overall goal moved to no-tmux cutover  
+**Primary goal (historical):** Bring AllBeingsFuture’s **normalized ACP stream pipeline** (events + sequence + consumer reduce) into this repo — **not** a full Chat product, provider matrix, or packaging port.  
 **Source of truth (streaming):** Desktop `AllBeingsFuture`  
 **Design fit (boundaries only):** Desktop `fenzhi` — Chat/protocol events stay in the daemon; renderer never imports ACP SDKs.  
 **Target base:** current AO `main` (no Chat API / no stream surface today).


### PR DESCRIPTION
## Summary

Hard pivot (human): **fully remove tmux** from agent-orchestrator. Agents become ABF-style **child processes** (ACP v1 stdio / HTTP), not interactive CLIs in tmux/conpty.

### Docs

- **Active plan:** `docs/plans/abf-no-tmux-acp-cutover.md`
  - Target architecture: worktree + ACP process + AgentStreamEvent SSE + Chat UI
  - Phases: (1) process+stream (2) spawn/send/kill/restore (3) frontend stream primary (4) delete tmux/doctor/docs (5) Windows agent-conpty parity
  - Success: no tmux for agent path; doctor does not require tmux; spawn works with ACP stream only
- **Superseded framing:** `docs/plans/acp-migration-from-abf-fenzhi.md` kept as streaming subsystem detail

## Scope

Docs only — no implementation.

## Tests

None (markdown).