### PR TITLE
feat(frontend): ABF agent-stream reducers + minimal ACP stream UX

### DIFF
--- a/frontend/docs/acp-renderer-streaming.md
+++ b/frontend/docs/acp-renderer-streaming.md
@@ -1,0 +1,92 @@
+# ACP Renderer Streaming Contract (Agent Orchestrator)
+
+## Scope and compatibility
+
+This renderer slice targets the stable Agent Client Protocol (ACP) wire protocol version `1` **on the daemon side only**. The Electron renderer:
+
+- does **not** depend on `@agentclientprotocol/sdk`
+- does **not** speak raw ACP JSON-RPC
+- consumes **normalized** `AgentStreamEvent` envelopes over daemon HTTP/SSE
+
+Source of truth for TypeScript shapes:
+
+- `frontend/src/renderer/types/agentStreamTypes.ts`
+- `frontend/src/renderer/types/streamMessages.ts` (reducer output rows)
+- pure reduce/batch: `frontend/src/renderer/lib/agent-stream/`
+
+Semantics are adapted from AllBeingsFuture’s `acp-renderer-streaming.md` and `agentStreamCore` / `agentStreamBatch`.
+
+## Backend → renderer
+
+Provisional SSE route (not yet on `main` OpenAPI):
+
+```http
+GET /api/v1/sessions/{sessionId}/agent-stream
+```
+
+Recommended frame:
+
+```text
+event: agent_stream
+data: {"type":"text_delta","sessionId":"...","sequence":1,"itemId":"...","delta":"..."}
+```
+
+Default `message` events with the same JSON body are also accepted.
+
+Envelope requirements:
+
+| Field | Rule |
+| --- | --- |
+| `sessionId` | string; if omitted on the wire, the transport fills from the path |
+| `sequence` | required, non-negative, strictly increasing per session |
+| `timestamp` | optional ISO string |
+| `source` | optional `{ kind: 'native-acp-v1' \| 'legacy-adapter', provider? }` |
+
+Event types (see `AgentStreamEvent`):
+
+- `text_delta` — append-only assistant text (`delta` is a fragment, never the full buffer)
+- `thinking_update` — `mode: 'delta' \| 'replace'`
+- `tool_call` / `tool_update` — tool lifecycle; progressive `resultDelta` / `output` are append-only
+- `plan` — full plan replacement
+- `status` — `starting` \| `running` \| `waiting` \| `idle`
+- `permission_request` — options with `optionId`, `label`, `kind`
+- `done` / `error` / `cancelled` — terminal for the current turn
+
+The reducer ignores `sequence <= lastSequence` so retransmission is safe.
+
+## Renderer → backend
+
+Permission choice (provisional):
+
+```http
+POST /api/v1/sessions/{sessionId}/agent-stream/permissions/{requestId}
+Content-Type: application/json
+
+{ "optionId": "allow_once" }
+```
+
+Implemented in `respondToAgentPermission`. A non-2xx response leaves the permission UI open and surfaces the error.
+
+Cancellation continues through existing session stop / interrupt APIs once wired; the stream state enters `cancelling` via `requestAgentStreamCancellation` optimistically.
+
+## Batching
+
+High-frequency events (`text_delta`, progressive `thinking_update`, in-progress `tool_update`) are coalesced per animation frame (`createAgentStreamBatcher`) so React does not re-render on every token. Terminal events flush immediately.
+
+## UI surface
+
+Minimal AO-styled components (not a wholesale ABF ConversationView port):
+
+- `AgentStreamTimeline` — text / thinking / tool cards
+- `AgentActivityPanel` — plan + permission
+- `AgentStreamSurface` — header + timeline + activity
+- `useAgentStream` — batcher + optional SSE + permission POST
+
+## Backend status
+
+As of this frontend PR, the provisional routes above are **not** present on `main` OpenAPI. The pure reducer, batcher, parser, and UI work offline via `pushEvents`. Live SSE stays `connection: unavailable` until the daemon implements the contract.
+
+## Clean-room / dependency note
+
+- No `@agentclientprotocol/sdk` in the renderer
+- No Electron IPC `agent:stream` / `agent:permission:respond` channels (ABF); AO uses loopback daemon HTTP/SSE

--- a/frontend/src/renderer/components/agent-stream/AgentActivityPanel.tsx
+++ b/frontend/src/renderer/components/agent-stream/AgentActivityPanel.tsx
@@ -1,0 +1,162 @@
+/**
+ * Live plan + permission surface for an active agent stream.
+ * AO design tokens (hairline borders, muted text, accent for allow actions).
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { Check, Circle, LoaderCircle, ShieldAlert, XCircle } from "lucide-react";
+import { isAgentStreamActive } from "../../lib/agent-stream";
+import type { AgentPermissionOption, AgentSessionStreamState } from "../../types/agentStreamTypes";
+import { cn } from "../../lib/utils";
+
+interface Props {
+	stream?: AgentSessionStreamState;
+	onPermissionResponse: (requestId: string, optionId: string) => Promise<void>;
+}
+
+function PlanStatusIcon({ status }: { status: string }) {
+	if (status === "completed") {
+		return <Check className="size-3.5 text-status-ready" aria-hidden="true" />;
+	}
+	if (status === "in_progress") {
+		return <LoaderCircle className="size-3.5 animate-spin text-status-working" aria-hidden="true" />;
+	}
+	if (status === "blocked") {
+		return <XCircle className="size-3.5 text-destructive" aria-hidden="true" />;
+	}
+	return <Circle className="size-3 text-muted-foreground" aria-hidden="true" />;
+}
+
+function optionClass(option: AgentPermissionOption): string {
+	if (option.kind.startsWith("reject")) {
+		return "border-border bg-transparent text-foreground hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive";
+	}
+	return "border-accent/30 bg-accent/10 text-foreground hover:border-accent/50 hover:bg-accent/15";
+}
+
+export function AgentActivityPanel({ stream, onPermissionResponse }: Props) {
+	const [submittingOptionId, setSubmittingOptionId] = useState<string | null>(null);
+	const [responseError, setResponseError] = useState("");
+	const firstOptionRef = useRef<HTMLButtonElement | null>(null);
+	const permission = stream?.permission;
+
+	useEffect(() => {
+		setSubmittingOptionId(null);
+		setResponseError("");
+		if (!permission) return;
+		requestAnimationFrame(() => firstOptionRef.current?.focus({ preventScroll: true }));
+	}, [permission?.requestId]);
+
+	const respond = async (option: AgentPermissionOption) => {
+		if (!permission || submittingOptionId) return;
+		setSubmittingOptionId(option.optionId);
+		setResponseError("");
+		try {
+			await onPermissionResponse(permission.requestId, option.optionId);
+		} catch (err) {
+			setResponseError(err instanceof Error ? err.message : String(err));
+			setSubmittingOptionId(null);
+		}
+	};
+
+	const planEntries = stream?.plan?.entries ?? [];
+	const planAllDone = planEntries.length > 0 && planEntries.every((entry) => entry.status === "completed");
+	const showStatus = Boolean(stream?.statusMessage) && isAgentStreamActive(stream);
+	const showPlan = planEntries.length > 0 && isAgentStreamActive(stream) && !planAllDone;
+	if (!permission && !showStatus && !showPlan) return null;
+
+	return (
+		<div className="space-y-2" data-testid="agent-activity-panel">
+			{(showStatus || showPlan) && (
+				<section
+					className="rounded-lg border border-border bg-muted/30 px-3 py-2.5"
+					aria-label="Agent progress"
+				>
+					{showStatus ? (
+						<div className="flex items-center gap-2 text-xs text-muted-foreground" role="status" aria-live="polite">
+							{stream?.phase === "running" ? (
+								<LoaderCircle className="size-3.5 animate-spin text-status-working" aria-hidden="true" />
+							) : null}
+							<span>{stream?.statusMessage}</span>
+						</div>
+					) : null}
+					{showPlan ? (
+						<div className={showStatus ? "mt-2 border-t border-border pt-2" : undefined}>
+							{stream?.plan?.title ? (
+								<p className="mb-1.5 text-xs font-medium text-foreground">{stream.plan.title}</p>
+							) : null}
+							<ol className="space-y-1">
+								{stream?.plan?.entries.map((entry) => (
+									<li key={entry.id} className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+										<span className="flex size-4 shrink-0 items-center justify-center">
+											<PlanStatusIcon status={entry.status} />
+										</span>
+										<span className={entry.status === "completed" ? "text-passive line-through" : undefined}>
+											{entry.title}
+										</span>
+									</li>
+								))}
+							</ol>
+						</div>
+					) : null}
+				</section>
+			)}
+
+			{permission ? (
+				<section
+					className="rounded-lg border border-status-needs-you/30 bg-status-needs-you/5 px-4 py-3"
+					role="alertdialog"
+					aria-labelledby={`permission-title-${permission.requestId}`}
+					aria-describedby={
+						permission.description ? `permission-description-${permission.requestId}` : undefined
+					}
+				>
+					<div className="flex items-start gap-3">
+						<ShieldAlert className="mt-0.5 size-4 shrink-0 text-status-needs-you" aria-hidden="true" />
+						<div className="min-w-0 flex-1">
+							<h3
+								id={`permission-title-${permission.requestId}`}
+								className="text-sm font-medium text-foreground"
+							>
+								{permission.title}
+							</h3>
+							{permission.description ? (
+								<p
+									id={`permission-description-${permission.requestId}`}
+									className="mt-1 whitespace-pre-wrap break-words text-xs leading-5 text-muted-foreground"
+								>
+									{permission.description}
+								</p>
+							) : null}
+							<div className="mt-3 flex flex-wrap gap-2">
+								{permission.options.map((option, index) => (
+									<button
+										key={option.optionId}
+										ref={index === 0 ? firstOptionRef : undefined}
+										type="button"
+										disabled={submittingOptionId !== null}
+										onClick={() => void respond(option)}
+										className={cn(
+											"min-h-9 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-wait disabled:opacity-50",
+											optionClass(option),
+										)}
+									>
+										{submittingOptionId === option.optionId ? (
+											<LoaderCircle className="mr-1.5 inline size-3 animate-spin" aria-hidden="true" />
+										) : null}
+										{option.label}
+									</button>
+								))}
+							</div>
+							{responseError ? (
+								<p className="mt-2 text-xs text-destructive" role="alert">
+									{responseError}
+								</p>
+							) : null}
+						</div>
+					</div>
+				</section>
+			) : null}
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/agent-stream/AgentStreamSurface.test.tsx
+++ b/frontend/src/renderer/components/agent-stream/AgentStreamSurface.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AgentStreamSurface } from "./AgentStreamSurface";
+import { AgentStreamTimeline, groupStreamMessages } from "./AgentStreamTimeline";
+import { createAgentSessionStreamState } from "../../lib/agent-stream";
+import type { UseAgentStreamResult } from "../../hooks/useAgentStream";
+import type { StreamMessage } from "../../types/streamMessages";
+
+function mockAgentStream(partial: Partial<UseAgentStreamResult> = {}): UseAgentStreamResult {
+	return {
+		messages: [],
+		stream: createAgentSessionStreamState(),
+		streaming: false,
+		error: "",
+		connection: "idle",
+		pushEvents: vi.fn(),
+		respondToPermission: vi.fn().mockResolvedValue(undefined),
+		requestCancel: vi.fn(),
+		reset: vi.fn(),
+		...partial,
+	};
+}
+
+describe("groupStreamMessages", () => {
+	it("pairs tool_use with tool_result", () => {
+		const messages: StreamMessage[] = [
+			{ role: "assistant", content: "hi", partial: false },
+			{ role: "tool_use", content: "Read", toolUseId: "t1", toolName: "Read", partial: true },
+			{ role: "tool_result", content: "ok", toolUseId: "t1", toolResult: "ok", partial: false },
+		];
+		const items = groupStreamMessages(messages);
+		expect(items).toHaveLength(2);
+		expect(items[0].kind).toBe("text");
+		expect(items[1].kind).toBe("tool");
+		if (items[1].kind === "tool") {
+			expect(items[1].call?.toolUseId).toBe("t1");
+			expect(items[1].result?.toolResult).toBe("ok");
+		}
+	});
+});
+
+describe("AgentStreamTimeline", () => {
+	it("renders assistant text and thinking", () => {
+		render(
+			<AgentStreamTimeline
+				messages={[
+					{ role: "thinking", content: "plan", isThinking: true, partial: true },
+					{ role: "assistant", content: "Hello", partial: true },
+				]}
+				streaming
+			/>,
+		);
+		expect(screen.getByTestId("stream-thinking")).toHaveTextContent("plan");
+		expect(screen.getByTestId("stream-assistant")).toHaveTextContent("Hello");
+	});
+
+	it("renders tool card status", () => {
+		render(
+			<AgentStreamTimeline
+				messages={[
+					{
+						role: "tool_use",
+						content: "shell",
+						toolUseId: "t1",
+						toolName: "Bash",
+						toolStatus: "completed",
+						partial: false,
+					},
+					{
+						role: "tool_result",
+						content: "done",
+						toolUseId: "t1",
+						toolResult: "done",
+						partial: false,
+					},
+				]}
+			/>,
+		);
+		expect(screen.getByTestId("stream-tool")).toHaveAttribute("data-tool-status", "completed");
+		fireEvent.click(screen.getByRole("button", { name: /Bash/i }));
+		expect(screen.getByText("done")).toBeTruthy();
+	});
+});
+
+describe("AgentStreamSurface", () => {
+	it("shows permission panel and forwards option clicks", async () => {
+		const respondToPermission = vi.fn().mockResolvedValue(undefined);
+		const stream = {
+			...createAgentSessionStreamState(),
+			phase: "waiting_permission" as const,
+			permission: {
+				requestId: "req-1",
+				title: "Allow shell?",
+				options: [{ optionId: "allow", label: "Allow once", kind: "allow_once" as const }],
+			},
+		};
+		render(
+			<AgentStreamSurface
+				agentStream={mockAgentStream({
+					stream,
+					streaming: true,
+					respondToPermission,
+				})}
+			/>,
+		);
+		expect(screen.getByTestId("agent-activity-panel")).toBeTruthy();
+		fireEvent.click(screen.getByRole("button", { name: "Allow once" }));
+		expect(respondToPermission).toHaveBeenCalledWith("req-1", "allow");
+	});
+
+	it("renders stop while streaming", () => {
+		const requestCancel = vi.fn();
+		render(
+			<AgentStreamSurface
+				agentStream={mockAgentStream({
+					streaming: true,
+					stream: { phase: "running", lastSequence: 1 },
+					requestCancel,
+				})}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+		expect(requestCancel).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/renderer/components/agent-stream/AgentStreamSurface.tsx
+++ b/frontend/src/renderer/components/agent-stream/AgentStreamSurface.tsx
@@ -1,0 +1,72 @@
+/**
+ * Minimal container that wires timeline + activity panel to useAgentStream.
+ * Not a full chat product surface — enough to render live ACP stream UX.
+ */
+
+import { LoaderCircle } from "lucide-react";
+import { AgentActivityPanel } from "./AgentActivityPanel";
+import { AgentStreamTimeline } from "./AgentStreamTimeline";
+import type { UseAgentStreamResult } from "../../hooks/useAgentStream";
+import { cn } from "../../lib/utils";
+
+export interface AgentStreamSurfaceProps {
+	agentStream: UseAgentStreamResult;
+	className?: string;
+	/** Optional header label */
+	title?: string;
+}
+
+export function AgentStreamSurface({ agentStream, className, title = "Agent stream" }: AgentStreamSurfaceProps) {
+	const { messages, stream, streaming, error, connection, respondToPermission, requestCancel } = agentStream;
+
+	return (
+		<section
+			aria-label={title}
+			className={cn("flex h-full min-h-0 flex-col bg-background", className)}
+			data-testid="agent-stream-surface"
+			data-connection={connection}
+		>
+			<header className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-4 py-2">
+				<div className="flex items-center gap-2 text-xs text-muted-foreground">
+					{streaming ? (
+						<LoaderCircle className="size-3.5 animate-spin text-status-working" aria-hidden="true" />
+					) : null}
+					<span className="font-medium text-foreground">{title}</span>
+					<span className="text-passive">·</span>
+					<span className="capitalize">{stream.phase}</span>
+					{connection !== "idle" && connection !== "open" ? (
+						<>
+							<span className="text-passive">·</span>
+							<span>{connection}</span>
+						</>
+					) : null}
+				</div>
+				{streaming ? (
+					<button
+						type="button"
+						className="rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground hover:bg-interactive-hover disabled:opacity-50"
+						onClick={requestCancel}
+						disabled={stream.phase === "cancelling"}
+					>
+						{stream.phase === "cancelling" ? "Cancelling…" : "Stop"}
+					</button>
+				) : null}
+			</header>
+
+			<div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+				<AgentStreamTimeline messages={messages} streaming={streaming} />
+			</div>
+
+			{(stream.permission || stream.plan || stream.statusMessage || error) && (
+				<div className="shrink-0 space-y-2 border-t border-border px-4 py-3">
+					{error ? (
+						<p className="text-xs text-destructive" role="alert">
+							{error}
+						</p>
+					) : null}
+					<AgentActivityPanel stream={stream} onPermissionResponse={respondToPermission} />
+				</div>
+			)}
+		</section>
+	);
+}

--- a/frontend/src/renderer/components/agent-stream/AgentStreamTimeline.tsx
+++ b/frontend/src/renderer/components/agent-stream/AgentStreamTimeline.tsx
@@ -1,0 +1,207 @@
+/**
+ * Renders reduced StreamMessage rows: assistant text, thinking, tools.
+ * AO chrome only — not a clone of ABF ConversationView layout.
+ */
+
+import { ChevronDown, ChevronRight, LoaderCircle, Wrench } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { StreamMessage } from "../../types/streamMessages";
+import { cn } from "../../lib/utils";
+
+export interface AgentStreamTimelineProps {
+	messages: StreamMessage[];
+	streaming?: boolean;
+	className?: string;
+}
+
+type TimelineItem =
+	| { kind: "text"; message: StreamMessage; key: string }
+	| { kind: "thinking"; message: StreamMessage; key: string }
+	| { kind: "tool"; call?: StreamMessage; result?: StreamMessage; key: string }
+	| { kind: "other"; message: StreamMessage; key: string };
+
+function messageKey(message: StreamMessage, index: number): string {
+	return message.id || message.streamItemId || message.toolUseId || message.toolCallId || `msg-${index}`;
+}
+
+function toolId(message: StreamMessage): string | undefined {
+	return message.toolUseId || message.toolCallId;
+}
+
+/** Pair tool_use with following tool_result by id; keep narrative order. */
+export function groupStreamMessages(messages: StreamMessage[]): TimelineItem[] {
+	const items: TimelineItem[] = [];
+	const pendingTools = new Map<string, number>();
+
+	messages.forEach((message, index) => {
+		const key = messageKey(message, index);
+		if (message.role === "thinking" || message.isThinking) {
+			items.push({ kind: "thinking", message, key });
+			return;
+		}
+		if (message.role === "assistant" || message.role === "user") {
+			items.push({ kind: "text", message, key });
+			return;
+		}
+		if (message.role === "tool_use") {
+			const id = toolId(message);
+			items.push({ kind: "tool", call: message, key });
+			if (id) pendingTools.set(id, items.length - 1);
+			return;
+		}
+		if (message.role === "tool_result") {
+			const id = toolId(message);
+			const slot = id !== undefined ? pendingTools.get(id) : undefined;
+			if (slot !== undefined) {
+				const existing = items[slot];
+				if (existing.kind === "tool") {
+					items[slot] = { ...existing, result: message };
+					pendingTools.delete(id!);
+					return;
+				}
+			}
+			items.push({ kind: "tool", result: message, key });
+			return;
+		}
+		items.push({ kind: "other", message, key });
+	});
+
+	return items;
+}
+
+function ThinkingBubble({ message }: { message: StreamMessage }) {
+	const live = Boolean(message.partial);
+	return (
+		<div
+			className="rounded-lg border border-border bg-muted/20 px-3 py-2 text-xs text-muted-foreground"
+			data-testid="stream-thinking"
+		>
+			<div className="mb-1 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-passive">
+				{live ? <LoaderCircle className="size-3 animate-spin" aria-hidden="true" /> : null}
+				Thinking
+			</div>
+			<pre className="whitespace-pre-wrap break-words font-sans text-xs leading-relaxed text-muted-foreground">
+				{message.content || (live ? "…" : "")}
+			</pre>
+		</div>
+	);
+}
+
+function TextBubble({ message }: { message: StreamMessage }) {
+	const isUser = message.role === "user";
+	return (
+		<div
+			className={cn(
+				"rounded-lg border px-3.5 py-2.5 text-sm leading-relaxed",
+				isUser
+					? "ml-8 border-border bg-muted/40 text-foreground"
+					: "mr-4 border-border bg-background text-foreground",
+			)}
+			data-testid={isUser ? "stream-user" : "stream-assistant"}
+			data-partial={message.partial ? "true" : undefined}
+		>
+			<div className="whitespace-pre-wrap break-words">
+				{message.content}
+				{message.partial ? (
+					<span className="ml-0.5 inline-block h-3 w-1.5 animate-pulse bg-accent align-middle" aria-hidden="true" />
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+function ToolCard({ call, result }: { call?: StreamMessage; result?: StreamMessage }) {
+	const [open, setOpen] = useState(false);
+	const name = result?.toolName || call?.toolName || call?.content || "Tool";
+	const status = call?.toolStatus || (result ? (result.isError ? "failed" : "completed") : "pending");
+	const live = Boolean(call?.partial || result?.partial || call?.isDelta || result?.isDelta);
+	const output = result?.toolResult || result?.content || "";
+	const input = call?.toolInput ?? result?.toolInput;
+
+	return (
+		<div
+			className="overflow-hidden rounded-lg border border-border bg-muted/15"
+			data-testid="stream-tool"
+			data-tool-status={status}
+		>
+			<button
+				type="button"
+				className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-foreground hover:bg-interactive-hover"
+				onClick={() => setOpen((v) => !v)}
+				aria-expanded={open}
+			>
+				{open ? (
+					<ChevronDown className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+				) : (
+					<ChevronRight className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+				)}
+				<Wrench className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+				<span className="min-w-0 flex-1 truncate font-medium">{name}</span>
+				{live ? (
+					<LoaderCircle className="size-3.5 animate-spin text-status-working" aria-hidden="true" />
+				) : (
+					<span
+						className={cn(
+							"text-[10px] uppercase tracking-wide",
+							status === "failed" ? "text-destructive" : "text-passive",
+						)}
+					>
+						{status}
+					</span>
+				)}
+			</button>
+			{open ? (
+				<div className="space-y-2 border-t border-border px-3 py-2 font-mono text-[11px] text-muted-foreground">
+					{input && Object.keys(input).length > 0 ? (
+						<pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded bg-background/60 p-2">
+							{JSON.stringify(input, null, 2)}
+						</pre>
+					) : null}
+					{output ? (
+						<pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-background/60 p-2">
+							{output}
+						</pre>
+					) : live ? (
+						<p className="text-passive">Running…</p>
+					) : null}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+export function AgentStreamTimeline({ messages, streaming, className }: AgentStreamTimelineProps) {
+	const items = useMemo(() => groupStreamMessages(messages), [messages]);
+
+	if (items.length === 0) {
+		return (
+			<div
+				className={cn("flex h-full items-center justify-center text-xs text-muted-foreground", className)}
+				data-testid="stream-timeline-empty"
+			>
+				{streaming ? "Waiting for agent output…" : "No stream messages yet."}
+			</div>
+		);
+	}
+
+	return (
+		<div className={cn("flex flex-col gap-2.5", className)} data-testid="stream-timeline" data-streaming={streaming ? "true" : undefined}>
+			{items.map((item) => {
+				if (item.kind === "thinking") {
+					return <ThinkingBubble key={item.key} message={item.message} />;
+				}
+				if (item.kind === "text") {
+					return <TextBubble key={item.key} message={item.message} />;
+				}
+				if (item.kind === "tool") {
+					return <ToolCard key={item.key} call={item.call} result={item.result} />;
+				}
+				return (
+					<div key={item.key} className="text-xs text-muted-foreground" data-testid="stream-other">
+						{item.message.content}
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/frontend/src/renderer/hooks/useAgentStream.ts
+++ b/frontend/src/renderer/hooks/useAgentStream.ts
@@ -1,0 +1,177 @@
+/**
+ * Live agent-stream state for one session.
+ *
+ * Applies batched, sequenced AgentStreamEvent values through the pure reducer.
+ * Transport is optional: when the daemon SSE route is unavailable the hook still
+ * exposes `pushEvents` for tests and for a future composition with snapshot poll.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	createAgentSessionStreamState,
+	createAgentStreamBatcher,
+	isAgentStreamActive,
+	reduceAgentStreamEvent,
+	requestAgentStreamCancellation,
+	resolveAgentStreamPermission,
+	connectAgentStream,
+	respondToAgentPermission,
+	type AgentStreamTransport,
+} from "../lib/agent-stream";
+import type {
+	AgentPermissionResponse,
+	AgentSessionStreamState,
+	AgentStreamEvent,
+} from "../types/agentStreamTypes";
+import type { StreamMessage } from "../types/streamMessages";
+import { getApiBaseUrl, hasTrustedApiBaseUrl } from "../lib/api-client";
+
+export type AgentStreamConnectionState = "idle" | "connecting" | "open" | "disconnected" | "unavailable";
+
+export interface UseAgentStreamOptions {
+	sessionId: string | undefined;
+	/** When false, do not open SSE (fixture / unit-test mode). Default true. */
+	connect?: boolean;
+	/** Seed messages (e.g. from a durable snapshot). */
+	initialMessages?: StreamMessage[];
+	/** Inject permission responder (tests). */
+	respondPermission?: (response: AgentPermissionResponse) => Promise<void>;
+}
+
+export interface UseAgentStreamResult {
+	messages: StreamMessage[];
+	stream: AgentSessionStreamState;
+	streaming: boolean;
+	error: string;
+	connection: AgentStreamConnectionState;
+	/** Apply one or more already-parsed events (bypasses SSE). */
+	pushEvents: (events: AgentStreamEvent[]) => void;
+	respondToPermission: (requestId: string, optionId: string) => Promise<void>;
+	requestCancel: () => void;
+	/** Reset timeline + stream state (new turn / session switch). */
+	reset: (messages?: StreamMessage[]) => void;
+}
+
+export function useAgentStream(options: UseAgentStreamOptions): UseAgentStreamResult {
+	const { sessionId, connect = true, initialMessages = [], respondPermission } = options;
+	const [messages, setMessages] = useState<StreamMessage[]>(initialMessages);
+	const [stream, setStream] = useState<AgentSessionStreamState>(createAgentSessionStreamState);
+	const [error, setError] = useState("");
+	const [connection, setConnection] = useState<AgentStreamConnectionState>("idle");
+
+	const messagesRef = useRef(messages);
+	const streamRef = useRef(stream);
+	messagesRef.current = messages;
+	streamRef.current = stream;
+
+	const applyEvents = useCallback((events: AgentStreamEvent[]) => {
+		let nextMessages = messagesRef.current;
+		let nextStream = streamRef.current;
+		let nextError = "";
+		for (const event of events) {
+			const reduced = reduceAgentStreamEvent(nextMessages, nextStream, event);
+			if (reduced.ignored) continue;
+			nextMessages = reduced.messages;
+			nextStream = reduced.stream;
+			if (reduced.error) nextError = reduced.error;
+		}
+		messagesRef.current = nextMessages;
+		streamRef.current = nextStream;
+		setMessages(nextMessages);
+		setStream(nextStream);
+		if (nextError) setError(nextError);
+	}, []);
+
+	const batcherRef = useRef<ReturnType<typeof createAgentStreamBatcher> | null>(null);
+	if (!batcherRef.current) {
+		batcherRef.current = createAgentStreamBatcher({
+			onFlush: (_sessionId, events) => applyEvents(events),
+		});
+	}
+
+	const pushEvents = useCallback((events: AgentStreamEvent[]) => {
+		const batcher = batcherRef.current;
+		if (!batcher) return;
+		for (const event of events) batcher.push(event);
+	}, []);
+
+	// SSE transport when session is set and connect is requested.
+	useEffect(() => {
+		if (!sessionId || !connect) {
+			setConnection(sessionId ? "idle" : "idle");
+			return;
+		}
+		if (!hasTrustedApiBaseUrl()) {
+			setConnection("unavailable");
+			return;
+		}
+
+		let transport: AgentStreamTransport | null = null;
+		transport = connectAgentStream({
+			sessionId,
+			baseUrl: getApiBaseUrl(),
+			onEvent: (event) => batcherRef.current?.push(event),
+			onConnectionChange: (state) => {
+				setConnection(state === "open" ? "open" : state === "connecting" ? "connecting" : "disconnected");
+			},
+		});
+		if (!transport) {
+			setConnection("unavailable");
+			return;
+		}
+
+		return () => {
+			transport?.dispose();
+			batcherRef.current?.flush(sessionId);
+		};
+	}, [sessionId, connect]);
+
+	useEffect(() => {
+		return () => {
+			batcherRef.current?.dispose();
+			batcherRef.current = null;
+		};
+	}, []);
+
+	const respondToPermission = useCallback(
+		async (requestId: string, optionId: string) => {
+			if (!sessionId) throw new Error("No session");
+			const payload: AgentPermissionResponse = { sessionId, requestId, optionId };
+			if (respondPermission) {
+				await respondPermission(payload);
+			} else {
+				await respondToAgentPermission(payload, fetch, getApiBaseUrl());
+			}
+			const next = resolveAgentStreamPermission(streamRef.current, requestId);
+			streamRef.current = next;
+			setStream(next);
+		},
+		[sessionId, respondPermission],
+	);
+
+	const requestCancel = useCallback(() => {
+		const next = requestAgentStreamCancellation(streamRef.current);
+		streamRef.current = next;
+		setStream(next);
+	}, []);
+
+	const reset = useCallback((seed: StreamMessage[] = []) => {
+		messagesRef.current = seed;
+		streamRef.current = createAgentSessionStreamState();
+		setMessages(seed);
+		setStream(streamRef.current);
+		setError("");
+	}, []);
+
+	return {
+		messages,
+		stream,
+		streaming: isAgentStreamActive(stream),
+		error,
+		connection,
+		pushEvents,
+		respondToPermission,
+		requestCancel,
+		reset,
+	};
+}

--- a/frontend/src/renderer/lib/agent-stream/agentStreamBatch.test.ts
+++ b/frontend/src/renderer/lib/agent-stream/agentStreamBatch.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStreamEvent } from "../../types/agentStreamTypes"
+import {
+  coalesceAgentStreamEvents,
+  createAgentStreamBatcher,
+  isBatchableAgentStreamEvent,
+} from "./agentStreamBatch"
+
+function textDelta(
+  sessionId: string,
+  sequence: number,
+  itemId: string,
+  delta: string,
+): AgentStreamEvent {
+  return { type: 'text_delta', sessionId, sequence, itemId, delta }
+}
+
+function thinkingDelta(
+  sessionId: string,
+  sequence: number,
+  itemId: string,
+  text: string,
+  mode?: 'delta' | 'replace',
+): AgentStreamEvent {
+  return { type: 'thinking_update', sessionId, sequence, itemId, text, mode }
+}
+
+function toolCall(sessionId: string, sequence: number): AgentStreamEvent {
+  return {
+    type: 'tool_call',
+    sessionId,
+    sequence,
+    toolCallId: 'tool-1',
+    title: 'Read',
+  }
+}
+
+function toolUpdate(
+  sessionId: string,
+  sequence: number,
+  status: 'pending' | 'in_progress' | 'completed' | 'failed',
+  resultDelta?: string,
+  toolCallId = 'tool-1',
+): AgentStreamEvent {
+  return {
+    type: 'tool_update',
+    sessionId,
+    sequence,
+    toolCallId,
+    status,
+    resultDelta,
+  }
+}
+
+function done(sessionId: string, sequence: number): AgentStreamEvent {
+  return { type: 'done', sessionId, sequence }
+}
+
+describe('isBatchableAgentStreamEvent', () => {
+  it('batches text_delta and thinking delta/default', () => {
+    expect(isBatchableAgentStreamEvent(textDelta('s', 1, 'i', 'a'))).toBe(true)
+    expect(isBatchableAgentStreamEvent(thinkingDelta('s', 1, 'i', 'a'))).toBe(true)
+    expect(isBatchableAgentStreamEvent(thinkingDelta('s', 1, 'i', 'a', 'delta'))).toBe(true)
+  })
+
+  it('batches progressive tool_update but not terminal tool/done/thinking replace', () => {
+    expect(isBatchableAgentStreamEvent(toolUpdate('s', 1, 'pending'))).toBe(true)
+    expect(isBatchableAgentStreamEvent(toolUpdate('s', 1, 'in_progress', 'tick'))).toBe(true)
+    expect(isBatchableAgentStreamEvent(toolUpdate('s', 1, 'completed', 'done'))).toBe(false)
+    expect(isBatchableAgentStreamEvent(toolUpdate('s', 1, 'failed', 'err'))).toBe(false)
+    expect(isBatchableAgentStreamEvent(toolCall('s', 1))).toBe(false)
+    expect(isBatchableAgentStreamEvent(done('s', 1))).toBe(false)
+    expect(isBatchableAgentStreamEvent(thinkingDelta('s', 1, 'i', 'full', 'replace'))).toBe(false)
+  })
+})
+
+describe('coalesceAgentStreamEvents', () => {
+  it('merges consecutive same itemId text_delta and keeps last sequence', () => {
+    const coalesced = coalesceAgentStreamEvents([
+      textDelta('s1', 1, 'reply-1', 'Hello '),
+      textDelta('s1', 2, 'reply-1', 'world'),
+      textDelta('s1', 3, 'reply-1', '!'),
+    ])
+    expect(coalesced).toEqual([
+      textDelta('s1', 3, 'reply-1', 'Hello world!'),
+    ])
+  })
+
+  it('does not merge non-increasing sequences so reduce can ignore replays', () => {
+    const coalesced = coalesceAgentStreamEvents([
+      textDelta('s1', 1, 'reply-1', 'Hello '),
+      textDelta('s1', 2, 'reply-1', 'world'),
+      textDelta('s1', 2, 'reply-1', 'world'),
+    ])
+    expect(coalesced).toEqual([
+      textDelta('s1', 2, 'reply-1', 'Hello world'),
+      textDelta('s1', 2, 'reply-1', 'world'),
+    ])
+  })
+
+  it('does not merge different itemIds or non-consecutive deltas', () => {
+    const tool = toolCall('s1', 2)
+    const coalesced = coalesceAgentStreamEvents([
+      textDelta('s1', 1, 'a', 'A'),
+      tool,
+      textDelta('s1', 3, 'a', 'B'),
+      textDelta('s1', 4, 'b', 'C'),
+    ])
+    expect(coalesced).toEqual([
+      textDelta('s1', 1, 'a', 'A'),
+      tool,
+      textDelta('s1', 3, 'a', 'B'),
+      textDelta('s1', 4, 'b', 'C'),
+    ])
+  })
+
+  it('merges consecutive thinking deltas', () => {
+    const coalesced = coalesceAgentStreamEvents([
+      thinkingDelta('s1', 1, 't1', 'think '),
+      thinkingDelta('s1', 2, 't1', 'more', 'delta'),
+    ])
+    expect(coalesced).toEqual([
+      thinkingDelta('s1', 2, 't1', 'think more', 'delta'),
+    ])
+  })
+
+  it('merges consecutive progressive tool_update resultDeltas', () => {
+    const coalesced = coalesceAgentStreamEvents([
+      toolUpdate('s1', 1, 'in_progress', 'Hello '),
+      toolUpdate('s1', 2, 'in_progress', 'world'),
+      toolUpdate('s1', 3, 'in_progress', '!'),
+    ])
+    expect(coalesced).toEqual([
+      toolUpdate('s1', 3, 'in_progress', 'Hello world!'),
+    ])
+  })
+
+  it('does not merge tool_update across different toolCallIds or terminal status', () => {
+    const coalesced = coalesceAgentStreamEvents([
+      toolUpdate('s1', 1, 'in_progress', 'a', 'tool-a'),
+      toolUpdate('s1', 2, 'in_progress', 'b', 'tool-b'),
+      toolUpdate('s1', 3, 'in_progress', 'c', 'tool-b'),
+      toolUpdate('s1', 4, 'completed', 'done', 'tool-b'),
+    ])
+    expect(coalesced).toEqual([
+      toolUpdate('s1', 1, 'in_progress', 'a', 'tool-a'),
+      toolUpdate('s1', 3, 'in_progress', 'bc', 'tool-b'),
+      toolUpdate('s1', 4, 'completed', 'done', 'tool-b'),
+    ])
+  })
+})
+
+describe('createAgentStreamBatcher', () => {
+  let scheduled: Array<() => void> = []
+  let onFlush: ReturnType<typeof vi.fn<(sessionId: string, events: AgentStreamEvent[]) => void>>
+
+  afterEach(() => {
+    scheduled = []
+    vi.useRealTimers()
+  })
+
+  function createTestBatcher(overrides?: { maxWaitMs?: number }) {
+    onFlush = vi.fn<(sessionId: string, events: AgentStreamEvent[]) => void>()
+    scheduled = []
+    return createAgentStreamBatcher({
+      onFlush,
+      // Disable max-wait by default so existing tests control flush via schedule only.
+      maxWaitMs: 0,
+      schedule: (flush) => {
+        scheduled.push(flush)
+        return scheduled.length - 1
+      },
+      cancelSchedule: (handle) => {
+        const idx = handle as number
+        scheduled[idx] = () => {}
+      },
+      ...overrides,
+    })
+  }
+
+  it('does not flush text_delta until schedule runs; coalesces on flush', () => {
+    const batcher = createTestBatcher()
+    batcher.push(textDelta('s1', 1, 'reply-1', 'Hello '))
+    batcher.push(textDelta('s1', 2, 'reply-1', 'world'))
+
+    expect(onFlush).not.toHaveBeenCalled()
+    expect(scheduled).toHaveLength(1)
+
+    scheduled[0]()
+
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith('s1', [
+      textDelta('s1', 2, 'reply-1', 'Hello world'),
+    ])
+    batcher.dispose()
+  })
+
+  it('flushes immediately on tool_call including prior pending deltas', () => {
+    const batcher = createTestBatcher()
+    batcher.push(textDelta('s1', 1, 'reply-1', 'Hi'))
+    expect(onFlush).not.toHaveBeenCalled()
+
+    batcher.push(toolCall('s1', 2))
+
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith('s1', [
+      textDelta('s1', 1, 'reply-1', 'Hi'),
+      toolCall('s1', 2),
+    ])
+    // cancelled the pending schedule
+    scheduled[0]()
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    batcher.dispose()
+  })
+
+  it('batches progressive tool_update until schedule; completed flushes immediately', () => {
+    const batcher = createTestBatcher()
+    batcher.push(toolUpdate('s1', 1, 'in_progress', 'tick '))
+    batcher.push(toolUpdate('s1', 2, 'in_progress', 'tock'))
+    expect(onFlush).not.toHaveBeenCalled()
+    expect(scheduled).toHaveLength(1)
+
+    scheduled[0]()
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith('s1', [
+      toolUpdate('s1', 2, 'in_progress', 'tick tock'),
+    ])
+
+    batcher.push(toolUpdate('s1', 3, 'in_progress', 'more'))
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    batcher.push(toolUpdate('s1', 4, 'completed', 'done'))
+    expect(onFlush).toHaveBeenCalledTimes(2)
+    expect(onFlush.mock.calls[1][1]).toEqual([
+      toolUpdate('s1', 3, 'in_progress', 'more'),
+      toolUpdate('s1', 4, 'completed', 'done'),
+    ])
+    batcher.dispose()
+  })
+
+  it('flushes immediately on done', () => {
+    const batcher = createTestBatcher()
+    batcher.push(textDelta('s1', 1, 'reply-1', 'x'))
+    batcher.push(done('s1', 2))
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush.mock.calls[0][1]).toEqual([
+      textDelta('s1', 1, 'reply-1', 'x'),
+      done('s1', 2),
+    ])
+    batcher.dispose()
+  })
+
+  it('flushes immediately on thinking mode replace', () => {
+    const batcher = createTestBatcher()
+    batcher.push(thinkingDelta('s1', 1, 't1', 'partial'))
+    expect(onFlush).not.toHaveBeenCalled()
+    batcher.push(thinkingDelta('s1', 2, 't1', 'full', 'replace'))
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush.mock.calls[0][1]).toEqual([
+      thinkingDelta('s1', 1, 't1', 'partial'),
+      thinkingDelta('s1', 2, 't1', 'full', 'replace'),
+    ])
+    batcher.dispose()
+  })
+
+  it('keeps independent queues per session', () => {
+    const batcher = createTestBatcher()
+    batcher.push(textDelta('s1', 1, 'a', 'A'))
+    batcher.push(textDelta('s2', 1, 'b', 'B'))
+    expect(scheduled).toHaveLength(2)
+    expect(onFlush).not.toHaveBeenCalled()
+
+    scheduled[0]()
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith('s1', [textDelta('s1', 1, 'a', 'A')])
+
+    scheduled[1]()
+    expect(onFlush).toHaveBeenCalledTimes(2)
+    expect(onFlush).toHaveBeenLastCalledWith('s2', [textDelta('s2', 1, 'b', 'B')])
+    batcher.dispose()
+  })
+
+  it('flush(sessionId) drains one session; flush() drains all', () => {
+    const batcher = createTestBatcher()
+    batcher.push(textDelta('s1', 1, 'a', 'A'))
+    batcher.push(textDelta('s2', 1, 'b', 'B'))
+
+    batcher.flush('s1')
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith('s1', [textDelta('s1', 1, 'a', 'A')])
+
+    batcher.flush()
+    expect(onFlush).toHaveBeenCalledTimes(2)
+    expect(onFlush).toHaveBeenLastCalledWith('s2', [textDelta('s2', 1, 'b', 'B')])
+    batcher.dispose()
+  })
+
+  it('dispose drops pending without calling onFlush', () => {
+    const batcher = createTestBatcher()
+    batcher.push(textDelta('s1', 1, 'a', 'A'))
+    batcher.dispose()
+    scheduled[0]()
+    expect(onFlush).not.toHaveBeenCalled()
+    batcher.push(textDelta('s1', 2, 'a', 'B'))
+    expect(onFlush).not.toHaveBeenCalled()
+  })
+
+  it('flushes via maxWait when frame schedule is delayed (rAF starved)', () => {
+    vi.useFakeTimers()
+    const batcher = createTestBatcher({ maxWaitMs: 40 })
+    batcher.push(textDelta('s1', 1, 'reply-1', 'Hello '))
+    batcher.push(textDelta('s1', 2, 'reply-1', 'world'))
+
+    expect(onFlush).not.toHaveBeenCalled()
+    expect(scheduled).toHaveLength(1)
+
+    // Simulate Electron background: rAF never fires, max-wait wins
+    vi.advanceTimersByTime(39)
+    expect(onFlush).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith('s1', [
+      textDelta('s1', 2, 'reply-1', 'Hello world'),
+    ])
+
+    // Late rAF must be a no-op (cancelled when max-wait flushed)
+    scheduled[0]()
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    batcher.dispose()
+  })
+
+  it('cancel on schedule flush also clears maxWait so timer does not double-flush', () => {
+    vi.useFakeTimers()
+    const batcher = createTestBatcher({ maxWaitMs: 40 })
+    batcher.push(textDelta('s1', 1, 'reply-1', 'Hi'))
+
+    // Frame schedule wins first
+    scheduled[0]()
+    expect(onFlush).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(100)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    batcher.dispose()
+  })
+})

--- a/frontend/src/renderer/lib/agent-stream/agentStreamBatch.ts
+++ b/frontend/src/renderer/lib/agent-stream/agentStreamBatch.ts
@@ -1,0 +1,257 @@
+import type { AgentStreamEvent } from "../../types/agentStreamTypes"
+
+export type AgentStreamBatchScheduleHandle = unknown
+
+export type AgentStreamBatchSchedule = (
+  flush: () => void,
+) => AgentStreamBatchScheduleHandle
+
+export type AgentStreamBatchCancelSchedule = (
+  handle: AgentStreamBatchScheduleHandle,
+) => void
+
+export interface AgentStreamBatcherOptions {
+  onFlush: (sessionId: string, events: AgentStreamEvent[]) => void
+  schedule?: AgentStreamBatchSchedule
+  cancelSchedule?: AgentStreamBatchCancelSchedule
+  /**
+   * Max wait before flush if the frame schedule is delayed (e.g. Electron
+   * background rAF throttle). Whichever fires first (schedule vs timer) flushes.
+   * Default 48ms. Set to 0 or negative to disable.
+   */
+  maxWaitMs?: number
+}
+
+export interface AgentStreamBatcher {
+  push(event: AgentStreamEvent): void
+  flush(sessionId?: string): void
+  dispose(): void
+}
+
+/** Default max-wait so text_delta still lands when rAF is starved. */
+export const AGENT_STREAM_BATCH_MAX_WAIT_MS = 48
+
+interface SessionScheduleEntry {
+  scheduleHandle: AgentStreamBatchScheduleHandle
+  maxWaitId?: ReturnType<typeof setTimeout>
+}
+
+/**
+ * Events that can wait for the next animation frame before reducing into the store.
+ *
+ * ~1 store update per display frame is intentional: further coalescing would add
+ * visible latency without a smoother UI (paint already caps at display refresh).
+ * Terminal tool/status events still flush immediately via push().
+ */
+export function isBatchableAgentStreamEvent(event: AgentStreamEvent): boolean {
+  if (event.type === 'text_delta') return true
+  if (event.type === 'thinking_update') {
+    // replace must land immediately so partial thinking is not merged incorrectly
+    return event.mode !== 'replace'
+  }
+  // Progressive tool output is high-frequency (stdout ticks); completed/failed must land now.
+  if (event.type === 'tool_update') {
+    return event.status === 'pending' || event.status === 'in_progress'
+  }
+  return false
+}
+
+function mergeToolUpdateOutput(
+  prev: Extract<AgentStreamEvent, { type: 'tool_update' }>,
+  next: Extract<AgentStreamEvent, { type: 'tool_update' }>,
+): Extract<AgentStreamEvent, { type: 'tool_update' }>['output'] | undefined {
+  if (!prev.output && !next.output) return undefined
+  if (!prev.output) return next.output
+  if (!next.output) return prev.output
+  // Different streams: prefer the later chunk so reduce keeps stream identity.
+  if (prev.output.stream !== next.output.stream) return next.output
+  return {
+    stream: next.output.stream,
+    text: `${prev.output.text || ''}${next.output.text || ''}`,
+  }
+}
+
+/**
+ * Merge consecutive same-session+itemId text/thinking deltas, and progressive tool_update.
+ * lastSequence contract: coalesced event.sequence is the last real event's sequence.
+ * Only merges strictly increasing sequences so replay/duplicate events stay separate
+ * for reduceAgentStreamEvent to ignore.
+ */
+export function coalesceAgentStreamEvents(events: AgentStreamEvent[]): AgentStreamEvent[] {
+  if (events.length <= 1) return events
+
+  const out: AgentStreamEvent[] = []
+  for (const event of events) {
+    const prev = out[out.length - 1]
+    if (
+      prev
+      && prev.type === 'text_delta'
+      && event.type === 'text_delta'
+      && prev.sessionId === event.sessionId
+      && prev.itemId === event.itemId
+      && event.sequence > prev.sequence
+    ) {
+      out[out.length - 1] = {
+        ...event,
+        delta: `${prev.delta}${event.delta}`,
+      }
+      continue
+    }
+    if (
+      prev
+      && prev.type === 'thinking_update'
+      && event.type === 'thinking_update'
+      && prev.sessionId === event.sessionId
+      && prev.itemId === event.itemId
+      && prev.mode !== 'replace'
+      && event.mode !== 'replace'
+      && event.sequence > prev.sequence
+    ) {
+      out[out.length - 1] = {
+        ...event,
+        text: `${prev.text}${event.text}`,
+      }
+      continue
+    }
+    if (
+      prev
+      && prev.type === 'tool_update'
+      && event.type === 'tool_update'
+      && prev.sessionId === event.sessionId
+      && prev.toolCallId === event.toolCallId
+      && event.sequence > prev.sequence
+      && isBatchableAgentStreamEvent(prev)
+      && isBatchableAgentStreamEvent(event)
+    ) {
+      const mergedResultDelta = `${prev.resultDelta || ''}${event.resultDelta || ''}`
+      const mergedOutput = mergeToolUpdateOutput(prev, event)
+      out[out.length - 1] = {
+        ...event,
+        // Later event wins status/name/title/input/error; append progressive payloads.
+        resultDelta: mergedResultDelta || undefined,
+        output: mergedOutput,
+      }
+      continue
+    }
+    out.push(event)
+  }
+  return out
+}
+
+function defaultSchedule(flush: () => void): AgentStreamBatchScheduleHandle {
+  if (typeof requestAnimationFrame === 'function') {
+    return { kind: 'raf' as const, id: requestAnimationFrame(flush) }
+  }
+  if (typeof queueMicrotask === 'function') {
+    const token = { cancelled: false }
+    queueMicrotask(() => {
+      if (!token.cancelled) flush()
+    })
+    return { kind: 'micro' as const, token }
+  }
+  return { kind: 'timeout' as const, id: setTimeout(flush, 0) }
+}
+
+function defaultCancelSchedule(handle: AgentStreamBatchScheduleHandle): void {
+  if (!handle || typeof handle !== 'object') return
+  const h = handle as { kind?: string; id?: number | ReturnType<typeof setTimeout>; token?: { cancelled: boolean } }
+  if (h.kind === 'raf' && typeof h.id === 'number' && typeof cancelAnimationFrame === 'function') {
+    cancelAnimationFrame(h.id)
+    return
+  }
+  if (h.kind === 'micro' && h.token) {
+    h.token.cancelled = true
+    return
+  }
+  if (h.kind === 'timeout' && h.id !== undefined) {
+    clearTimeout(h.id as ReturnType<typeof setTimeout>)
+  }
+}
+
+export function createAgentStreamBatcher(options: AgentStreamBatcherOptions): AgentStreamBatcher {
+  const schedule = options.schedule ?? defaultSchedule
+  const cancelSchedule = options.cancelSchedule ?? defaultCancelSchedule
+  const maxWaitMs = options.maxWaitMs ?? AGENT_STREAM_BATCH_MAX_WAIT_MS
+  const pending = new Map<string, AgentStreamEvent[]>()
+  const scheduled = new Map<string, SessionScheduleEntry>()
+  let disposed = false
+
+  const clearSchedule = (sessionId: string) => {
+    const entry = scheduled.get(sessionId)
+    if (entry === undefined) return
+    scheduled.delete(sessionId)
+    cancelSchedule(entry.scheduleHandle)
+    if (entry.maxWaitId !== undefined) {
+      clearTimeout(entry.maxWaitId)
+    }
+  }
+
+  const flushSession = (sessionId: string) => {
+    clearSchedule(sessionId)
+    const events = pending.get(sessionId)
+    if (!events || events.length === 0) {
+      pending.delete(sessionId)
+      return
+    }
+    pending.delete(sessionId)
+    const coalesced = coalesceAgentStreamEvents(events)
+    options.onFlush(sessionId, coalesced)
+  }
+
+  const armSchedule = (sessionId: string) => {
+    if (scheduled.has(sessionId)) return
+
+    const run = () => {
+      if (disposed) return
+      // clearSchedule inside flushSession cancels the peer (rAF or max-wait)
+      flushSession(sessionId)
+    }
+
+    const scheduleHandle = schedule(run)
+    let maxWaitId: ReturnType<typeof setTimeout> | undefined
+    if (maxWaitMs > 0) {
+      maxWaitId = setTimeout(run, maxWaitMs)
+    }
+    scheduled.set(sessionId, { scheduleHandle, maxWaitId })
+  }
+
+  return {
+    push(event: AgentStreamEvent) {
+      if (disposed) return
+      const sessionId = event.sessionId
+      const queue = pending.get(sessionId)
+      if (queue) {
+        queue.push(event)
+      } else {
+        pending.set(sessionId, [event])
+      }
+
+      if (!isBatchableAgentStreamEvent(event)) {
+        flushSession(sessionId)
+        return
+      }
+
+      armSchedule(sessionId)
+    },
+
+    flush(sessionId?: string) {
+      if (disposed) return
+      if (sessionId !== undefined) {
+        flushSession(sessionId)
+        return
+      }
+      for (const id of [...pending.keys()]) {
+        flushSession(id)
+      }
+    },
+
+    dispose() {
+      if (disposed) return
+      disposed = true
+      for (const id of [...scheduled.keys()]) {
+        clearSchedule(id)
+      }
+      pending.clear()
+    },
+  }
+}

--- a/frontend/src/renderer/lib/agent-stream/agentStreamCore.test.ts
+++ b/frontend/src/renderer/lib/agent-stream/agentStreamCore.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it } from "vitest";
+import type { StreamMessage } from "../../types/streamMessages";
+import {
+  AGENT_STREAM_SILENCE_MS,
+  annotateLivePartialFlags,
+  convergeAgentStreamOnLegacyEnd,
+  createAgentSessionStreamState,
+  isAgentStreamActive,
+  reduceAgentStreamEvent,
+  shouldPreferAgentStream,
+} from "./agentStreamCore"
+
+describe('agentStreamCore', () => {
+  it('appends text deltas once and ignores replayed sequence numbers', () => {
+    const first = reduceAgentStreamEvent([], undefined, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 1, itemId: 'reply-1', delta: 'Hello ',
+    })
+    const second = reduceAgentStreamEvent(first.messages, first.stream, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 2, itemId: 'reply-1', delta: 'world',
+    })
+    const replay = reduceAgentStreamEvent(second.messages, second.stream, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 2, itemId: 'reply-1', delta: 'world',
+    })
+
+    expect(second.messages).toHaveLength(1)
+    expect(second.messages[0].content).toBe('Hello world')
+    expect(replay.ignored).toBe(true)
+    expect(replay.messages).toBe(second.messages)
+    expect(typeof second.stream.lastEventAt).toBe('number')
+    expect(shouldPreferAgentStream(second.stream)).toBe(true)
+  })
+
+  it('stamps lastEventAt and fails open after silence timeout', () => {
+    const applied = reduceAgentStreamEvent([], undefined, {
+      type: 'text_delta',
+      sessionId: 'session-1',
+      sequence: 1,
+      itemId: 'reply-1',
+      delta: 'hi',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    })
+    expect(applied.stream.lastEventAt).toBe(Date.parse('2026-01-01T00:00:00.000Z'))
+    expect(isAgentStreamActive(applied.stream)).toBe(true)
+    expect(shouldPreferAgentStream(applied.stream, applied.stream.lastEventAt! + 1000)).toBe(true)
+    expect(shouldPreferAgentStream(
+      applied.stream,
+      applied.stream.lastEventAt! + AGENT_STREAM_SILENCE_MS,
+    )).toBe(false)
+
+    // Missing lastEventAt still prefers an active stream (safe default).
+    expect(shouldPreferAgentStream({ phase: 'running', lastSequence: 1 })).toBe(true)
+    expect(convergeAgentStreamOnLegacyEnd(applied.stream)).toEqual(expect.objectContaining({
+      phase: 'done',
+      permission: undefined,
+      plan: undefined,
+      statusMessage: undefined,
+    }))
+    expect(convergeAgentStreamOnLegacyEnd({ phase: 'done', lastSequence: 1 })).toBeUndefined()
+  })
+
+  it('opens a new assistant bubble after a turn is finalized (multi-turn)', () => {
+    const first = reduceAgentStreamEvent([], undefined, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 1, itemId: 'reply-1', delta: '回复1',
+    })
+    const done = reduceAgentStreamEvent(first.messages, first.stream, {
+      type: 'done', sessionId: 'session-1', sequence: 2, stopReason: 'end_turn',
+    })
+    expect(done.messages).toHaveLength(1)
+    expect(done.messages[0]).toEqual(expect.objectContaining({
+      role: 'assistant', content: '回复1', partial: false,
+    }))
+
+    // Later work in the same session must not reopen the finalized bubble.
+    const third = reduceAgentStreamEvent(done.messages, done.stream, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 3, itemId: 'reply-3', delta: '回复3',
+    })
+    expect(third.messages).toHaveLength(2)
+    expect(third.messages[0]).toEqual(expect.objectContaining({
+      role: 'assistant', content: '回复1', partial: false,
+    }))
+    expect(third.messages[1]).toEqual(expect.objectContaining({
+      role: 'assistant', content: '回复3', partial: true,
+    }))
+  })
+
+  it('does not reopen a finalized assistant bubble even when itemId matches', () => {
+    const first = reduceAgentStreamEvent([], undefined, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 1, itemId: 'same-item', delta: '第一段',
+    })
+    const done = reduceAgentStreamEvent(first.messages, first.stream, {
+      type: 'done', sessionId: 'session-1', sequence: 2, stopReason: 'end_turn',
+    })
+    const again = reduceAgentStreamEvent(done.messages, done.stream, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 3, itemId: 'same-item', delta: '第二段',
+    })
+
+    expect(again.messages).toHaveLength(2)
+    expect(again.messages[0].content).toBe('第一段')
+    expect(again.messages[1].content).toBe('第二段')
+  })
+
+  it('opens a new assistant bubble after tools even when itemId is reused', () => {
+    // Providers often keep one default text itemId for the whole turn.
+    const first = reduceAgentStreamEvent([], undefined, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 1, itemId: 'assistant-text',
+      delta: '先查工具组折叠逻辑。',
+    })
+    const tool = reduceAgentStreamEvent(first.messages, first.stream, {
+      type: 'tool_call', sessionId: 'session-1', sequence: 2,
+      toolCallId: 'tool-1', title: 'grep', name: 'Grep',
+    })
+    const second = reduceAgentStreamEvent(tool.messages, tool.stream, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 3, itemId: 'assistant-text',
+      delta: '根因是默认折叠，正在改为自动展开。',
+    })
+
+    const assistants = second.messages.filter(message => message.role === 'assistant')
+    expect(assistants).toHaveLength(2)
+    expect(assistants[0]).toEqual(expect.objectContaining({
+      content: '先查工具组折叠逻辑。',
+      partial: false,
+    }))
+    expect(assistants[1]).toEqual(expect.objectContaining({
+      content: '根因是默认折叠，正在改为自动展开。',
+      partial: true,
+    }))
+    // Tool sits between the two reply bubbles.
+    expect(second.messages.map(message => message.role)).toEqual([
+      'assistant', 'tool_use', 'assistant',
+    ])
+  })
+
+  it('does not grow an earlier partial bubble when tools sit after it', () => {
+    const first = reduceAgentStreamEvent([], undefined, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 1, itemId: 'assistant-text', delta: '回复A',
+    })
+    // Simulate a tool message already after the open bubble without sealing
+    // via tool_call (defensive: trailing-only merge must still hold).
+    const withTool = {
+      messages: [
+        ...first.messages,
+        {
+          role: 'tool_use',
+          content: 'shell',
+          partial: false,
+          toolUseId: 'tool-x',
+          toolName: 'Bash',
+        } as StreamMessage,
+      ],
+      stream: first.stream,
+    }
+    const second = reduceAgentStreamEvent(withTool.messages, withTool.stream, {
+      type: 'text_delta', sessionId: 'session-1', sequence: 2, itemId: 'assistant-text', delta: '回复B',
+    })
+
+    expect(second.messages.filter(message => message.role === 'assistant')).toHaveLength(2)
+    expect(second.messages[0].content).toBe('回复A')
+    expect(second.messages[2].content).toBe('回复B')
+  })
+
+  it('supports replace-style thinking updates without duplicating text', () => {
+    const first = reduceAgentStreamEvent([], undefined, {
+      type: 'thinking_update', sessionId: 'session-1', sequence: 1, itemId: 'thought-1', text: 'Checking', mode: 'replace',
+    })
+    const second = reduceAgentStreamEvent(first.messages, first.stream, {
+      type: 'thinking_update', sessionId: 'session-1', sequence: 2, itemId: 'thought-1', text: 'Checking files', mode: 'replace',
+    })
+
+    expect(second.messages).toHaveLength(1)
+    expect(second.messages[0]).toEqual(expect.objectContaining({
+      role: 'thinking', content: 'Checking files', isThinking: true, partial: true,
+    }))
+  })
+
+  it('correlates tool output with its call and finalizes the lifecycle', () => {
+    const call = reduceAgentStreamEvent([], undefined, {
+      type: 'tool_call', sessionId: 'session-1', sequence: 1,
+      toolCallId: 'tool-1', title: 'Run tests', name: 'shell', input: { command: 'npm test' },
+    })
+    expect(call.messages[0]).toEqual(expect.objectContaining({
+      role: 'tool_use', toolUseId: 'tool-1', toolStatus: 'pending', partial: true, isDelta: true,
+    }))
+    const output = reduceAgentStreamEvent(call.messages, call.stream, {
+      type: 'tool_update', sessionId: 'session-1', sequence: 2,
+      toolCallId: 'tool-1', status: 'in_progress', output: { stream: 'stdout', text: 'PASS\n' },
+    })
+    expect(output.messages[0]).toEqual(expect.objectContaining({
+      role: 'tool_use', toolStatus: 'in_progress', partial: true, isDelta: true,
+    }))
+    const complete = reduceAgentStreamEvent(output.messages, output.stream, {
+      type: 'tool_update', sessionId: 'session-1', sequence: 3,
+      toolCallId: 'tool-1', status: 'completed', resultDelta: 'Done',
+    })
+
+    expect(complete.messages).toHaveLength(2)
+    expect(complete.messages[0]).toEqual(expect.objectContaining({
+      role: 'tool_use', toolUseId: 'tool-1', toolStatus: 'completed', partial: false, isDelta: false,
+    }))
+    expect(complete.messages[1]).toEqual(expect.objectContaining({
+      role: 'tool_result', toolUseId: 'tool-1', toolResult: 'PASS\nDone', isDelta: false, partial: false,
+    }))
+  })
+
+  it('tool_update completed sets toolStatus=completed and partial=false on tool_use and tool_result', () => {
+    const complete = reduceAgentStreamEvent([], undefined, {
+      type: 'tool_update',
+      sessionId: 'session-1',
+      sequence: 1,
+      toolCallId: 'mcp-wait-1',
+      name: 'wait_agent_idle',
+      status: 'completed',
+      resultDelta: 'idle',
+    })
+
+    expect(complete.messages).toHaveLength(2)
+    expect(complete.messages[0]).toEqual(expect.objectContaining({
+      role: 'tool_use',
+      toolUseId: 'mcp-wait-1',
+      toolName: 'wait_agent_idle',
+      toolStatus: 'completed',
+      partial: false,
+    }))
+    expect(complete.messages[1]).toEqual(expect.objectContaining({
+      role: 'tool_result',
+      toolUseId: 'mcp-wait-1',
+      toolResult: 'idle',
+      partial: false,
+      isDelta: false,
+      isError: false,
+    }))
+  })
+
+  it('tool_update failed sets toolStatus=failed and clears partial on both rows', () => {
+    const failed = reduceAgentStreamEvent([], undefined, {
+      type: 'tool_update',
+      sessionId: 'session-1',
+      sequence: 1,
+      toolCallId: 'tool-fail',
+      name: 'Bash',
+      status: 'failed',
+      error: 'timeout',
+    })
+
+    expect(failed.messages[0]).toEqual(expect.objectContaining({
+      role: 'tool_use',
+      toolStatus: 'failed',
+      partial: false,
+    }))
+    expect(failed.messages[1]).toEqual(expect.objectContaining({
+      role: 'tool_result',
+      partial: false,
+      isDelta: false,
+      isError: true,
+      toolResult: 'timeout',
+    }))
+  })
+
+  it('flushes partial messages and pending tools on terminal errors', () => {
+    const messages = [
+      { role: 'assistant', content: 'Partial reply', partial: true } as StreamMessage,
+      { role: 'tool_use', content: '', partial: true, toolUseId: 'tool-1', toolName: 'shell' } as StreamMessage,
+    ]
+    const terminal = reduceAgentStreamEvent(messages, createAgentSessionStreamState(), {
+      type: 'error', sessionId: 'session-1', sequence: 4, message: 'Agent disconnected',
+    })
+
+    expect(terminal.streaming).toBe(false)
+    expect(terminal.error).toBe('Agent disconnected')
+    expect(terminal.stream.phase).toBe('error')
+    expect(terminal.messages[0]).toEqual(expect.objectContaining({ partial: false }))
+    expect(terminal.messages[2]).toEqual(expect.objectContaining({
+      role: 'tool_result', toolUseId: 'tool-1', isError: true, toolResult: 'Agent disconnected',
+    }))
+  })
+
+  it('replaces plan and status state, then clears pending permission on completion', () => {
+    const plan = reduceAgentStreamEvent([], undefined, {
+      type: 'plan', sessionId: 'session-1', sequence: 1, title: 'Implementation',
+      entries: [{ id: 'step-1', title: 'Inspect files', status: 'in_progress' }],
+    })
+    const status = reduceAgentStreamEvent(plan.messages, plan.stream, {
+      type: 'status', sessionId: 'session-1', sequence: 2, status: 'running', message: 'Inspecting files',
+    })
+    const permission = reduceAgentStreamEvent(status.messages, status.stream, {
+      type: 'permission_request', sessionId: 'session-1', sequence: 3,
+      request: {
+        requestId: 'permission-1',
+        title: 'Allow edit?',
+        options: [{ optionId: 'allow', label: 'Allow once', kind: 'allow_once' }],
+      },
+    })
+    const done = reduceAgentStreamEvent(permission.messages, permission.stream, {
+      type: 'done', sessionId: 'session-1', sequence: 4, stopReason: 'end_turn',
+    })
+
+    expect(status.stream.plan?.entries[0]?.title).toBe('Inspect files')
+    expect(status.stream.statusMessage).toBe('Inspecting files')
+    expect(permission.stream.phase).toBe('waiting_permission')
+    expect(done.stream).toEqual(expect.objectContaining({
+      phase: 'done',
+      permission: undefined,
+      statusMessage: undefined,
+      plan: undefined,
+      terminalReason: 'end_turn',
+    }))
+    expect(done.streaming).toBe(false)
+  })
+
+  it('clears plan on error, cancelled, and status idle so the activity panel closes', () => {
+    const withPlan = reduceAgentStreamEvent([], undefined, {
+      type: 'plan', sessionId: 'session-1', sequence: 1,
+      entries: [{ id: 'step-1', title: 'Inspect files', status: 'completed' }],
+    })
+
+    const errored = reduceAgentStreamEvent(withPlan.messages, withPlan.stream, {
+      type: 'error', sessionId: 'session-1', sequence: 2, message: 'boom',
+    })
+    expect(errored.stream.plan).toBeUndefined()
+
+    const cancelled = reduceAgentStreamEvent(withPlan.messages, withPlan.stream, {
+      type: 'cancelled', sessionId: 'session-1', sequence: 2, reason: 'user',
+    })
+    expect(cancelled.stream.plan).toBeUndefined()
+
+    const idle = reduceAgentStreamEvent(withPlan.messages, withPlan.stream, {
+      type: 'status', sessionId: 'session-1', sequence: 2, status: 'idle',
+    })
+    expect(idle.stream.plan).toBeUndefined()
+    expect(idle.stream.statusMessage).toBeUndefined()
+    expect(idle.stream.phase).toBe('idle')
+  })
+
+  it('matches legacy toolCallId rows on tool_update so stream output keeps flowing after fail-open', () => {
+    // Silence fail-open may replace stream messages with process.ts rows that
+    // only carry toolCallId (no toolUseId / partial).
+    const legacyMessages = [
+      {
+        role: 'tool_use',
+        content: '',
+        toolCallId: 'call-legacy',
+        toolName: 'Bash',
+        toolInput: { command: 'sleep 1' },
+      } as StreamMessage,
+    ]
+    const updated = reduceAgentStreamEvent(legacyMessages, {
+      phase: 'running',
+      lastSequence: 0,
+      lastEventAt: Date.now(),
+    }, {
+      type: 'tool_update',
+      sessionId: 'session-1',
+      sequence: 1,
+      toolCallId: 'call-legacy',
+      status: 'in_progress',
+      resultDelta: 'tick\n',
+    })
+
+    expect(updated.messages).toHaveLength(2)
+    expect(updated.messages[0]).toEqual(expect.objectContaining({
+      role: 'tool_use',
+      toolUseId: 'call-legacy',
+      toolStatus: 'in_progress',
+      partial: true,
+    }))
+    expect(updated.messages[1]).toEqual(expect.objectContaining({
+      role: 'tool_result',
+      toolUseId: 'call-legacy',
+      toolResult: 'tick\n',
+      partial: true,
+      isDelta: true,
+    }))
+  })
+
+  it('merges text_delta into a trailing partial assistant that lacks streamItemId', () => {
+    const legacyPartial = [
+      {
+        role: 'assistant',
+        content: 'legacy head ',
+        partial: true,
+      } as StreamMessage,
+    ]
+    const next = reduceAgentStreamEvent(legacyPartial, {
+      phase: 'running',
+      lastSequence: 0,
+      lastEventAt: Date.now(),
+    }, {
+      type: 'text_delta',
+      sessionId: 'session-1',
+      sequence: 1,
+      itemId: 'assistant-text',
+      delta: 'stream tail',
+    })
+
+    expect(next.messages).toHaveLength(1)
+    expect(next.messages[0]).toEqual(expect.objectContaining({
+      role: 'assistant',
+      content: 'legacy head stream tail',
+      partial: true,
+      streamItemId: 'assistant-text',
+    }))
+  })
+
+  it('annotateLivePartialFlags re-stamps open tools and trailing narrative while streaming', () => {
+    const messages = [
+      { role: 'thinking', content: 'done thought', partial: false, isThinking: true } as StreamMessage,
+      {
+        role: 'tool_use',
+        content: '',
+        toolCallId: 't1',
+        toolName: 'Grep',
+        partial: false,
+      } as StreamMessage,
+      { role: 'assistant', content: 'reply so far', partial: false } as StreamMessage,
+    ]
+
+    const annotated = annotateLivePartialFlags(messages, true)
+    expect(annotated[1]).toEqual(expect.objectContaining({
+      role: 'tool_use',
+      partial: true,
+      toolUseId: 't1',
+    }))
+    expect(annotated[2]).toEqual(expect.objectContaining({
+      role: 'assistant',
+      content: 'reply so far',
+      partial: true,
+    }))
+    // Earlier sealed thinking stays sealed.
+    expect(annotated[0]).toEqual(expect.objectContaining({
+      role: 'thinking',
+      partial: false,
+    }))
+
+    expect(annotateLivePartialFlags(messages, false)).toBe(messages)
+  })
+})

--- a/frontend/src/renderer/lib/agent-stream/agentStreamCore.ts
+++ b/frontend/src/renderer/lib/agent-stream/agentStreamCore.ts
@@ -1,0 +1,532 @@
+import type {
+	AgentSessionStreamState,
+	AgentStreamEvent,
+	AgentStreamPhase,
+} from "../../types/agentStreamTypes";
+import type { StreamMessage } from "../../types/streamMessages";
+
+function toolIdOf(message: StreamMessage): string | undefined {
+	return message.toolUseId || message.toolCallId;
+}
+
+function matchesToolCall(message: StreamMessage, toolCallId: string): boolean {
+	return toolIdOf(message) === toolCallId;
+}
+
+export interface AgentStreamReduction {
+	messages: StreamMessage[];
+	stream: AgentSessionStreamState;
+	streaming: boolean;
+	error: string;
+	ignored: boolean;
+}
+
+const ACTIVE_PHASES = new Set<AgentStreamPhase>(['running', 'waiting_permission', 'cancelling'])
+
+/** How long agent:stream may stay silent before legacy chat:update/patch/poll may resume. */
+export const AGENT_STREAM_SILENCE_MS = 12_000
+
+export function createAgentSessionStreamState(): AgentSessionStreamState {
+  return { phase: 'idle', lastSequence: -1 }
+}
+
+export function isAgentStreamActive(stream: AgentSessionStreamState | undefined): boolean {
+  return Boolean(stream && ACTIVE_PHASES.has(stream.phase))
+}
+
+/**
+ * Prefer the normalized agent:stream path only while it is active and not silent.
+ * After silence timeout, legacy chat paths fail open so a lost done/event cannot freeze the UI.
+ */
+export function shouldPreferAgentStream(
+  stream: AgentSessionStreamState | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (!isAgentStreamActive(stream)) return false
+  const lastEventAt = stream!.lastEventAt
+  // No timestamp yet (e.g. manually seeded active state) — keep preferring stream.
+  if (lastEventAt == null) return true
+  return now - lastEventAt < AGENT_STREAM_SILENCE_MS
+}
+
+/**
+ * Converge a stuck active stream when legacy backend reports the turn has ended.
+ * Returns undefined when there is nothing to change.
+ */
+export function convergeAgentStreamOnLegacyEnd(
+  stream: AgentSessionStreamState | undefined,
+): AgentSessionStreamState | undefined {
+  if (!stream || !isAgentStreamActive(stream)) return undefined
+  return {
+    ...stream,
+    phase: 'done',
+    permission: undefined,
+    statusMessage: undefined,
+    plan: undefined,
+  }
+}
+
+function timestampOf(event: AgentStreamEvent): string {
+  return event.timestamp || new Date().toISOString()
+}
+
+function activate(stream: AgentSessionStreamState): AgentSessionStreamState {
+  if (stream.phase === 'cancelling') return stream
+  if (ACTIVE_PHASES.has(stream.phase)) return { ...stream, phase: 'running', terminalReason: undefined }
+  return {
+    ...stream,
+    phase: 'running',
+    statusMessage: undefined,
+    plan: undefined,
+    permission: undefined,
+    terminalReason: undefined,
+  }
+}
+
+function patchMessage(
+  messages: StreamMessage[],
+  predicate: (message: StreamMessage) => boolean,
+  update: (message: StreamMessage) => StreamMessage,
+): { messages: StreamMessage[]; found: boolean } {
+  const index = messages.findIndex(message => predicate(message as StreamMessage))
+  if (index < 0) return { messages, found: false }
+  const next = messages.slice()
+  next[index] = update(next[index] as StreamMessage) as StreamMessage
+  return { messages: next, found: true }
+}
+
+/**
+ * Close open narrative bubbles (assistant / thinking) before a tool or a new
+ * reply segment starts. Providers often reuse one default text itemId for the
+ * whole turn; without sealing, later text would keep growing the first bubble.
+ */
+function sealOpenNarrativeMessages(messages: StreamMessage[]): StreamMessage[] {
+  let changed = false
+  const next = messages.map(message => {
+    const streamMessage = message as StreamMessage
+    const isNarrative = streamMessage.role === 'assistant'
+      || streamMessage.role === 'thinking'
+      || Boolean(streamMessage.isThinking)
+    if (!isNarrative || !streamMessage.partial) return message
+    changed = true
+    return { ...streamMessage, partial: false } as StreamMessage
+  })
+  return changed ? next : messages
+}
+
+function appendTextDelta(messages: StreamMessage[], event: Extract<AgentStreamEvent, { type: 'text_delta' }>) {
+  // Only extend the *trailing* open assistant bubble with the same stream item.
+  // Never reopen an earlier partial bubble after tools / other messages have
+  // been appended — that is what forces multi-round replies into one box.
+  //
+  // Legacy fail-open snapshots often omit streamItemId/sourceItemId while still
+  // marking the last assistant partial=true. Merge into that trailing bubble so
+  // post-silence agent:stream deltas keep growing the live reply instead of
+  // spawning a frozen second box with only the latest fragment.
+  const last = messages[messages.length - 1] as StreamMessage | undefined
+  const lastItemId = last?.streamItemId || last?.sourceItemId
+  const canMergeTrailing = Boolean(
+    last?.role === 'assistant'
+    && last.partial === true
+    && (lastItemId == null || lastItemId === event.itemId),
+  )
+  if (canMergeTrailing && last) {
+    const next = messages.slice()
+    next[next.length - 1] = {
+      ...last,
+      content: `${last.content || ''}${event.delta}`,
+      partial: true,
+      streamItemId: last.streamItemId || event.itemId,
+    } as StreamMessage
+    return next
+  }
+
+  return [...messages, {
+    role: 'assistant',
+    content: event.delta,
+    partial: true,
+    id: `${event.itemId}-${event.sequence}`,
+    streamItemId: event.itemId,
+    timestamp: timestampOf(event),
+  } as StreamMessage]
+}
+
+function updateThinking(messages: StreamMessage[], event: Extract<AgentStreamEvent, { type: 'thinking_update' }>) {
+  // Same trailing-only rule as text: a thinking block closed by tools must not
+  // absorb later thought chunks into the earlier bubble.
+  const last = messages[messages.length - 1] as StreamMessage | undefined
+  const lastItemId = last?.streamItemId || last?.sourceItemId
+  const canMergeTrailing = Boolean(
+    last
+    && Boolean(last.isThinking)
+    && last.partial === true
+    && (lastItemId == null || lastItemId === event.itemId),
+  )
+  if (canMergeTrailing && last) {
+    const next = messages.slice()
+    next[next.length - 1] = {
+      ...last,
+      content: event.mode === 'replace' ? event.text : `${last.content || ''}${event.text}`,
+      partial: true,
+      streamItemId: last.streamItemId || event.itemId,
+    } as StreamMessage
+    return next
+  }
+
+  return [...messages, {
+    role: 'thinking',
+    content: event.text,
+    partial: true,
+    isThinking: true,
+    id: `${event.itemId}-${event.sequence}`,
+    streamItemId: event.itemId,
+    timestamp: timestampOf(event),
+  } as StreamMessage]
+}
+
+function upsertToolCall(messages: StreamMessage[], event: Extract<AgentStreamEvent, { type: 'tool_call' }>) {
+  const patched = patchMessage(
+    messages,
+    message => message.role === 'tool_use' && matchesToolCall(message, event.toolCallId),
+    message => {
+      const terminal = message.toolStatus === 'completed' || message.toolStatus === 'failed'
+      return {
+        ...message,
+        toolName: event.name || message.toolName || event.title,
+        toolInput: event.input || message.toolInput,
+        content: event.title || message.content,
+        // Normalize legacy toolCallId rows so later stream updates keep matching.
+        toolUseId: message.toolUseId || event.toolCallId,
+        toolCallId: message.toolCallId || event.toolCallId,
+        // tool_call has no status field; keep existing terminal status, else pending.
+        toolStatus: terminal ? message.toolStatus : (message.toolStatus || 'pending'),
+        partial: !terminal,
+        isDelta: !terminal,
+      }
+    },
+  )
+  if (patched.found) return patched.messages
+  // New tool boundary: seal any live narrative so the next text_delta opens a new bubble.
+  const sealed = sealOpenNarrativeMessages(messages)
+  return [...sealed, {
+    role: 'tool_use',
+    content: event.title || '',
+    partial: true,
+    isDelta: true,
+    id: `tool-${event.toolCallId}`,
+    toolUseId: event.toolCallId,
+    toolCallId: event.toolCallId,
+    toolName: event.name || event.title,
+    toolInput: event.input || {},
+    toolStatus: 'pending',
+    timestamp: timestampOf(event),
+  } as StreamMessage]
+}
+
+function ensureToolCall(messages: StreamMessage[], event: Extract<AgentStreamEvent, { type: 'tool_update' }>) {
+  const exists = messages.some(message => (
+    (message as StreamMessage).role === 'tool_use'
+    && matchesToolCall(message as StreamMessage, event.toolCallId)
+  ))
+  if (exists) return messages
+  const terminal = event.status === 'completed' || event.status === 'failed'
+  const sealed = sealOpenNarrativeMessages(messages)
+  return [...sealed, {
+    role: 'tool_use',
+    content: event.title || '',
+    partial: !terminal,
+    // Keep isDelta in lockstep with partial so tool UI (groups/cards) treats
+    // in-flight tool_use as live, not settled "已发起".
+    isDelta: !terminal,
+    id: `tool-${event.toolCallId}`,
+    toolUseId: event.toolCallId,
+    toolCallId: event.toolCallId,
+    toolName: event.name || 'Tool',
+    toolInput: event.input || {},
+    toolStatus: event.status,
+    timestamp: timestampOf(event),
+  } as StreamMessage]
+}
+
+function updateTool(messages: StreamMessage[], event: Extract<AgentStreamEvent, { type: 'tool_update' }>) {
+  let next = ensureToolCall(messages, event)
+  const terminal = event.status === 'completed' || event.status === 'failed'
+  const callPatch = patchMessage(
+    next,
+    message => message.role === 'tool_use' && matchesToolCall(message, event.toolCallId),
+    message => ({
+      ...message,
+      toolName: event.name || message.toolName,
+      toolInput: event.input || message.toolInput,
+      content: event.title || message.content,
+      toolUseId: message.toolUseId || event.toolCallId,
+      toolCallId: message.toolCallId || event.toolCallId,
+      // ConversationView / tool groups key off toolStatus (not only partial).
+      toolStatus: event.status,
+      partial: !terminal,
+      isDelta: !terminal,
+    }),
+  )
+  next = callPatch.messages
+
+  const outputText = event.resultDelta || event.output?.text || (event.status === 'failed' ? event.error || '' : '')
+  const resultPatch = patchMessage(
+    next,
+    message => message.role === 'tool_result' && matchesToolCall(message, event.toolCallId),
+    message => ({
+      ...message,
+      toolName: event.name || message.toolName,
+      toolInput: event.input || message.toolInput,
+      content: `${message.content || ''}${outputText}`,
+      toolResult: `${message.toolResult || ''}${outputText}`,
+      toolOutputs: event.output
+        ? [...(message.toolOutputs || []), event.output]
+        : message.toolOutputs,
+      toolUseId: message.toolUseId || event.toolCallId,
+      isDelta: !terminal,
+      partial: !terminal,
+      isError: event.status === 'failed',
+    }),
+  )
+  if (resultPatch.found) return resultPatch.messages
+
+  return [...next, {
+    role: 'tool_result',
+    content: outputText,
+    partial: !terminal,
+    id: `tool-result-${event.toolCallId}`,
+    toolUseId: event.toolCallId,
+    toolCallId: event.toolCallId,
+    toolName: event.name,
+    toolInput: event.input,
+    toolResult: outputText,
+    toolOutputs: event.output ? [event.output] : undefined,
+    isDelta: !terminal,
+    isError: event.status === 'failed',
+    timestamp: timestampOf(event),
+  } as StreamMessage]
+}
+
+function finalizeMessages(messages: StreamMessage[], error?: string): StreamMessage[] {
+  const resultIds = new Set(messages
+    .filter(message => message.role === 'tool_result')
+    .map(message => toolIdOf(message as StreamMessage))
+    .filter((id): id is string => Boolean(id)))
+  const finalized = messages.map(message => {
+    const streamMessage = message as StreamMessage
+    if (!streamMessage.partial && !streamMessage.isDelta) return message
+    return {
+      ...streamMessage,
+      partial: false,
+      isDelta: streamMessage.role === 'tool_result' ? false : streamMessage.isDelta,
+      isError: error && streamMessage.role === 'tool_result' ? true : streamMessage.isError,
+    } as StreamMessage
+  })
+
+  for (const message of messages) {
+    const tool = message as StreamMessage
+    const toolId = toolIdOf(tool)
+    if (tool.role !== 'tool_use' || !toolId || resultIds.has(toolId)) continue
+    finalized.push({
+      role: 'tool_result',
+      content: error || '',
+      partial: false,
+      id: `tool-result-${toolId}`,
+      toolUseId: toolId,
+      toolCallId: tool.toolCallId || toolId,
+      toolName: tool.toolName,
+      toolResult: error || '',
+      isDelta: false,
+      isError: Boolean(error),
+      timestamp: tool.timestamp || new Date().toISOString(),
+    } as StreamMessage)
+  }
+  return finalized
+}
+
+/**
+ * After silence fail-open applies a legacy chat snapshot mid-turn, re-stamp
+ * live partial flags so the UI does not freeze as "执行了 / 思考完成" while the
+ * turn is still streaming. Safe no-op when streaming is false.
+ */
+export function annotateLivePartialFlags(
+  messages: StreamMessage[],
+  streaming: boolean,
+): StreamMessage[] {
+  if (!streaming || messages.length === 0) return messages
+
+  const completedToolIds = new Set(
+    messages
+      .filter(message => {
+        const m = message as StreamMessage
+        return m.role === 'tool_result' && !m.partial && !m.isDelta
+      })
+      .map(message => toolIdOf(message as StreamMessage))
+      .filter((id): id is string => Boolean(id)),
+  )
+
+  let changed = false
+  const next = messages.map((message, index) => {
+    const m = message as StreamMessage
+    if (m.role === 'tool_use') {
+      const id = toolIdOf(m)
+      const terminalStatus = m.toolStatus === 'completed' || m.toolStatus === 'failed'
+      const open = !terminalStatus && (!id || !completedToolIds.has(id))
+      if (open && !m.partial) {
+        changed = true
+        return {
+          ...m,
+          partial: true,
+          toolUseId: m.toolUseId || m.toolCallId,
+        } as StreamMessage
+      }
+      if (open && !m.toolUseId && m.toolCallId) {
+        changed = true
+        return { ...m, toolUseId: m.toolCallId } as StreamMessage
+      }
+      return message
+    }
+
+    // Keep the trailing narrative bubble live while the turn is still open so
+    // subsequent agent:stream deltas can merge instead of forking a new box.
+    if (index === messages.length - 1) {
+      const isNarrative = m.role === 'assistant'
+        || m.role === 'thinking'
+        || Boolean(m.isThinking)
+      if (isNarrative && !m.partial) {
+        changed = true
+        return { ...m, partial: true } as StreamMessage
+      }
+    }
+    return message
+  })
+
+  return changed ? next : messages
+}
+
+export function reduceAgentStreamEvent(
+  messages: StreamMessage[],
+  currentStream: AgentSessionStreamState | undefined,
+  event: AgentStreamEvent,
+): AgentStreamReduction {
+  const current = currentStream || createAgentSessionStreamState()
+  if (!Number.isSafeInteger(event.sequence) || event.sequence <= current.lastSequence) {
+    return {
+      messages,
+      stream: current,
+      streaming: isAgentStreamActive(current),
+      error: current.phase === 'error' ? current.terminalReason || '' : '',
+      ignored: true,
+    }
+  }
+
+  let nextMessages = messages
+  const eventAt = event.timestamp ? Date.parse(event.timestamp) : NaN
+  const lastEventAt = Number.isFinite(eventAt) ? eventAt : Date.now()
+  // Explicit type: lastEventAt is optional on AgentSessionStreamState; without annotation,
+  // the local object is inferred with required lastEventAt and breaks activate() reassignment.
+  let stream: AgentSessionStreamState = { ...current, lastSequence: event.sequence, lastEventAt }
+  let error = ''
+
+  switch (event.type) {
+    case 'text_delta':
+      nextMessages = appendTextDelta(messages, event)
+      stream = activate(stream)
+      break
+    case 'thinking_update':
+      nextMessages = updateThinking(messages, event)
+      stream = activate(stream)
+      break
+    case 'tool_call':
+      nextMessages = upsertToolCall(messages, event)
+      stream = activate(stream)
+      break
+    case 'tool_update':
+      nextMessages = updateTool(messages, event)
+      stream = activate(stream)
+      break
+    case 'plan':
+      stream = { ...activate(stream), plan: { title: event.title, entries: event.entries } }
+      break
+    case 'status':
+      stream = {
+        ...stream,
+        phase: event.status === 'idle' ? 'idle' : event.status === 'waiting' ? 'waiting_permission' : 'running',
+        statusMessage: event.message,
+        terminalReason: undefined,
+      }
+      if (event.status === 'idle') {
+        // Idle ends the turn — drop live progress UI (plan/status) so the bottom panel closes.
+        nextMessages = finalizeMessages(messages)
+        stream = { ...stream, plan: undefined, statusMessage: undefined }
+      }
+      break
+    case 'permission_request':
+      stream = {
+        ...stream,
+        phase: 'waiting_permission',
+        permission: event.request,
+        statusMessage: undefined,
+        terminalReason: undefined,
+      }
+      break
+    case 'done':
+      nextMessages = finalizeMessages(messages)
+      stream = {
+        ...stream,
+        phase: 'done',
+        permission: undefined,
+        statusMessage: undefined,
+        plan: undefined,
+        terminalReason: event.stopReason,
+      }
+      break
+    case 'error':
+      nextMessages = finalizeMessages(messages, event.message)
+      stream = {
+        ...stream,
+        phase: 'error',
+        permission: undefined,
+        statusMessage: undefined,
+        plan: undefined,
+        terminalReason: event.message,
+      }
+      error = event.message
+      break
+    case 'cancelled':
+      nextMessages = finalizeMessages(messages)
+      stream = {
+        ...stream,
+        phase: 'cancelled',
+        permission: undefined,
+        statusMessage: undefined,
+        plan: undefined,
+        terminalReason: event.reason,
+      }
+      break
+  }
+
+  // activate() / branch spreads must not drop the stamp from a successful apply.
+  stream = { ...stream, lastEventAt }
+
+  return {
+    messages: nextMessages,
+    stream,
+    streaming: isAgentStreamActive(stream),
+    error,
+    ignored: false,
+  }
+}
+
+export function requestAgentStreamCancellation(stream: AgentSessionStreamState | undefined) {
+  return { ...(stream || createAgentSessionStreamState()), phase: 'cancelling' as const, statusMessage: undefined }
+}
+
+export function resolveAgentStreamPermission(
+  stream: AgentSessionStreamState | undefined,
+  requestId: string,
+) {
+  const current = stream || createAgentSessionStreamState()
+  if (current.permission?.requestId !== requestId) return current
+  return { ...current, permission: undefined, phase: 'running' as const }
+}

--- a/frontend/src/renderer/lib/agent-stream/agentStreamParse.test.ts
+++ b/frontend/src/renderer/lib/agent-stream/agentStreamParse.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	parseAgentStreamEvent,
+	respondToAgentPermission,
+} from "./agentStreamParse";
+
+describe("parseAgentStreamEvent", () => {
+	it("accepts normalized events without provider-specific fields", () => {
+		expect(
+			parseAgentStreamEvent({
+				type: "tool_call",
+				sessionId: "session-1",
+				sequence: 3,
+				toolCallId: "call-1",
+				title: "Read configuration",
+				source: { kind: "native-acp-v1" },
+			}),
+		).toEqual(expect.objectContaining({ type: "tool_call", toolCallId: "call-1" }));
+	});
+
+	it("rejects malformed permission prompts and unsupported events", () => {
+		expect(
+			parseAgentStreamEvent({
+				type: "permission_request",
+				sessionId: "session-1",
+				sequence: 4,
+				request: { requestId: "request-1", title: "Approve?", options: [] },
+			}),
+		).toBeNull();
+		expect(
+			parseAgentStreamEvent({ type: "codex_output", sessionId: "session-1", sequence: 5 }),
+		).toBeNull();
+	});
+});
+
+describe("respondToAgentPermission", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("POSTs optionId to the provisional daemon route", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({}),
+		});
+		await respondToAgentPermission(
+			{ sessionId: "session-1", requestId: "request-1", optionId: "allow-once" },
+			fetchImpl as unknown as typeof fetch,
+			"http://127.0.0.1:3001",
+		);
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"http://127.0.0.1:3001/api/v1/sessions/session-1/agent-stream/permissions/request-1",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ optionId: "allow-once" }),
+			}),
+		);
+	});
+
+	it("throws when the daemon rejects the choice", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 404,
+			statusText: "Not Found",
+			json: async () => ({ error: { message: "route not implemented" } }),
+		});
+		await expect(
+			respondToAgentPermission(
+				{ sessionId: "s", requestId: "r", optionId: "allow" },
+				fetchImpl as unknown as typeof fetch,
+				"http://127.0.0.1:3001",
+			),
+		).rejects.toThrow(/route not implemented/);
+	});
+});

--- a/frontend/src/renderer/lib/agent-stream/agentStreamParse.ts
+++ b/frontend/src/renderer/lib/agent-stream/agentStreamParse.ts
@@ -1,0 +1,134 @@
+/**
+ * Parse and validate normalized agent-stream envelopes from the daemon.
+ *
+ * The renderer never speaks raw ACP. Events arrive as JSON (SSE `data:` frames
+ * or HTTP poll payloads) and must match AgentStreamEvent before reduce.
+ */
+
+import type { AgentPermissionResponse, AgentStreamEvent } from "../../types/agentStreamTypes";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseAgentStreamEvent(value: unknown): AgentStreamEvent | null {
+	if (
+		!isRecord(value) ||
+		typeof value.sessionId !== "string" ||
+		!Number.isSafeInteger(value.sequence) ||
+		Number(value.sequence) < 0
+	) {
+		return null;
+	}
+	if (typeof value.type !== "string") return null;
+
+	switch (value.type) {
+		case "text_delta":
+			return typeof value.itemId === "string" && typeof value.delta === "string"
+				? (value as unknown as AgentStreamEvent)
+				: null;
+		case "thinking_update":
+			return typeof value.itemId === "string" &&
+				typeof value.text === "string" &&
+				(value.mode === undefined || value.mode === "delta" || value.mode === "replace")
+				? (value as unknown as AgentStreamEvent)
+				: null;
+		case "tool_call":
+			return typeof value.toolCallId === "string" && typeof value.title === "string"
+				? (value as unknown as AgentStreamEvent)
+				: null;
+		case "tool_update":
+			return typeof value.toolCallId === "string" &&
+				["pending", "in_progress", "completed", "failed"].includes(String(value.status))
+				? (value as unknown as AgentStreamEvent)
+				: null;
+		case "plan":
+			return Array.isArray(value.entries) &&
+				value.entries.every(
+					(entry) =>
+						isRecord(entry) &&
+						typeof entry.id === "string" &&
+						typeof entry.title === "string" &&
+						["pending", "in_progress", "completed", "blocked"].includes(String(entry.status)),
+				)
+				? (value as unknown as AgentStreamEvent)
+				: null;
+		case "status":
+			return ["starting", "running", "waiting", "idle"].includes(String(value.status))
+				? (value as unknown as AgentStreamEvent)
+				: null;
+		case "permission_request":
+			return isRecord(value.request) &&
+				typeof value.request.requestId === "string" &&
+				typeof value.request.title === "string" &&
+				Array.isArray(value.request.options) &&
+				value.request.options.length > 0 &&
+				value.request.options.every(
+					(option) =>
+						isRecord(option) &&
+						typeof option.optionId === "string" &&
+						typeof option.label === "string" &&
+						["allow_once", "allow_always", "reject_once", "reject_always"].includes(
+							String(option.kind),
+						),
+				)
+				? (value as unknown as AgentStreamEvent)
+				: null;
+		case "done":
+		case "cancelled":
+			return value as unknown as AgentStreamEvent;
+		case "error":
+			return typeof value.message === "string" ? (value as unknown as AgentStreamEvent) : null;
+		default:
+			return null;
+	}
+}
+
+/**
+ * Provisional daemon route for permission responses.
+ * Backend must implement this (or supersede with OpenAPI) before live ACP chat.
+ *
+ * POST /api/v1/sessions/{sessionId}/agent-stream/permissions/{requestId}
+ * body: { optionId: string }
+ */
+export const AGENT_STREAM_PERMISSION_PATH =
+	"/api/v1/sessions/{sessionId}/agent-stream/permissions/{requestId}" as const;
+
+/**
+ * Provisional SSE path for sequenced agent-stream events.
+ * GET /api/v1/sessions/{sessionId}/agent-stream
+ * event: agent_stream
+ * data: AgentStreamEvent JSON
+ */
+export const AGENT_STREAM_SSE_PATH = "/api/v1/sessions/{sessionId}/agent-stream" as const;
+
+export type PermissionRespondFn = (response: AgentPermissionResponse) => Promise<void>;
+
+/**
+ * Default permission responder via daemon HTTP.
+ * Throws a clear error when the route is unavailable so the UI can keep the prompt open.
+ */
+export async function respondToAgentPermission(
+	response: AgentPermissionResponse,
+	fetchImpl: typeof fetch = fetch,
+	baseUrl?: string,
+): Promise<void> {
+	const root = (baseUrl ?? "").replace(/\/+$/, "");
+	const path = `/api/v1/sessions/${encodeURIComponent(response.sessionId)}/agent-stream/permissions/${encodeURIComponent(response.requestId)}`;
+	const url = root ? `${root}${path}` : path;
+	const res = await fetchImpl(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", Accept: "application/json" },
+		body: JSON.stringify({ optionId: response.optionId }),
+	});
+	if (!res.ok) {
+		let detail = res.statusText;
+		try {
+			const body = (await res.json()) as { error?: { message?: string }; message?: string };
+			detail = body.error?.message ?? body.message ?? detail;
+		} catch {
+			// ignore JSON parse failures
+		}
+		throw new Error(detail || `Permission response failed (${res.status})`);
+	}
+}

--- a/frontend/src/renderer/lib/agent-stream/agentStreamTransport.test.ts
+++ b/frontend/src/renderer/lib/agent-stream/agentStreamTransport.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	AGENT_STREAM_EVENT_NAME,
+	connectAgentStream,
+	parseAgentStreamSseData,
+} from "./agentStreamTransport";
+
+class EventSourceStub {
+	static instances: EventSourceStub[] = [];
+	url: string;
+	onopen: ((ev: Event) => void) | null = null;
+	onerror: ((ev: Event) => void) | null = null;
+	onmessage: ((ev: MessageEvent) => void) | null = null;
+	private listeners = new Map<string, Set<(ev: MessageEvent) => void>>();
+	readyState = 0;
+	closed = false;
+
+	constructor(url: string) {
+		this.url = url;
+		EventSourceStub.instances.push(this);
+		queueMicrotask(() => {
+			this.readyState = 1;
+			this.onopen?.(new Event("open"));
+		});
+	}
+
+	addEventListener(type: string, listener: EventListener) {
+		const set = this.listeners.get(type) ?? new Set();
+		set.add(listener as (ev: MessageEvent) => void);
+		this.listeners.set(type, set);
+	}
+
+	close() {
+		this.closed = true;
+		this.readyState = 2;
+	}
+
+	emit(type: string, data: string) {
+		const ev = { data } as MessageEvent;
+		if (type === "message") this.onmessage?.(ev);
+		for (const listener of this.listeners.get(type) ?? []) listener(ev);
+	}
+}
+
+describe("parseAgentStreamSseData", () => {
+	it("parses JSON and fills missing sessionId", () => {
+		const event = parseAgentStreamSseData(
+			JSON.stringify({ type: "text_delta", sequence: 1, itemId: "a", delta: "hi" }),
+			"session-1",
+		);
+		expect(event).toEqual(
+			expect.objectContaining({ type: "text_delta", sessionId: "session-1", delta: "hi" }),
+		);
+	});
+
+	it("returns null for garbage", () => {
+		expect(parseAgentStreamSseData("not-json", "s")).toBeNull();
+	});
+});
+
+describe("connectAgentStream", () => {
+	it("subscribes to agent_stream frames and forwards parsed events", async () => {
+		EventSourceStub.instances = [];
+		const onEvent = vi.fn();
+		const transport = connectAgentStream({
+			sessionId: "session-1",
+			baseUrl: "http://127.0.0.1:3001",
+			EventSourceImpl: EventSourceStub as unknown as typeof EventSource,
+			retryMs: 0,
+			onEvent,
+		});
+		expect(transport).not.toBeNull();
+		expect(EventSourceStub.instances[0].url).toBe(
+			"http://127.0.0.1:3001/api/v1/sessions/session-1/agent-stream",
+		);
+
+		EventSourceStub.instances[0].emit(
+			AGENT_STREAM_EVENT_NAME,
+			JSON.stringify({
+				type: "text_delta",
+				sessionId: "session-1",
+				sequence: 1,
+				itemId: "r1",
+				delta: "Hello",
+			}),
+		);
+		expect(onEvent).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "text_delta", delta: "Hello" }),
+		);
+
+		transport?.dispose();
+		expect(EventSourceStub.instances[0].closed).toBe(true);
+	});
+});

--- a/frontend/src/renderer/lib/agent-stream/agentStreamTransport.ts
+++ b/frontend/src/renderer/lib/agent-stream/agentStreamTransport.ts
@@ -1,0 +1,167 @@
+/**
+ * SSE transport for normalized agent-stream events.
+ *
+ * Mirrors AO's workspace-file-events / CDC EventSource patterns: reconnect on
+ * CLOSED, ignore malformed frames, never depend on ACP SDK.
+ *
+ * Backend contract (not yet on main OpenAPI — see docs/acp-renderer-streaming.md):
+ *   GET {baseUrl}/api/v1/sessions/{sessionId}/agent-stream
+ *   Named event: agent_stream (or default message) with JSON AgentStreamEvent body.
+ */
+
+import { getApiBaseUrl, hasTrustedApiBaseUrl } from "../api-client";
+import type { AgentStreamEvent } from "../../types/agentStreamTypes";
+import { parseAgentStreamEvent } from "./agentStreamParse";
+
+const SSE_RETRY_MS = 5_000;
+const EVENTSOURCE_CLOSED = 2;
+export const AGENT_STREAM_EVENT_NAME = "agent_stream";
+
+export type AgentStreamTransportHandlers = {
+	onEvent: (event: AgentStreamEvent) => void;
+	onConnectionChange?: (state: "connecting" | "open" | "disconnected") => void;
+	onParseError?: (raw: string, error: unknown) => void;
+};
+
+export type AgentStreamTransport = {
+	/** Close the stream and cancel reconnects. */
+	dispose: () => void;
+};
+
+export type AgentStreamTransportOptions = AgentStreamTransportHandlers & {
+	sessionId: string;
+	/** Override base URL (tests). Defaults to trusted API base. */
+	baseUrl?: string;
+	/** Inject EventSource for tests. */
+	EventSourceImpl?: typeof EventSource;
+	/** Disable auto-reconnect (tests). */
+	retryMs?: number;
+};
+
+function buildStreamUrl(baseUrl: string, sessionId: string): string {
+	return `${baseUrl.replace(/\/+$/, "")}/api/v1/sessions/${encodeURIComponent(sessionId)}/agent-stream`;
+}
+
+function handleMessageData(
+	raw: string,
+	handlers: AgentStreamTransportHandlers,
+	sessionId: string,
+): void {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw) as unknown;
+	} catch (error) {
+		handlers.onParseError?.(raw, error);
+		return;
+	}
+	// Allow envelopes that omit sessionId by filling from the subscription.
+	if (typeof parsed === "object" && parsed !== null) {
+		const record = parsed as { sessionId?: unknown };
+		if (typeof record.sessionId !== "string" || record.sessionId.length === 0) {
+			record.sessionId = sessionId;
+		}
+	}
+	const event = parseAgentStreamEvent(parsed);
+	if (!event) {
+		handlers.onParseError?.(raw, new Error("invalid agent stream event"));
+		return;
+	}
+	// Drop frames for other sessions if the daemon multiplexes (defensive).
+	if (event.sessionId !== sessionId) return;
+	handlers.onEvent(event);
+}
+
+/**
+ * Open a sequenced agent-stream SSE subscription for one session.
+ * Returns null when EventSource is unavailable or the API base is untrusted
+ * (no daemon yet) — callers should treat that as transport not ready.
+ */
+export function connectAgentStream(options: AgentStreamTransportOptions): AgentStreamTransport | null {
+	const EventSourceImpl = options.EventSourceImpl ?? globalThis.EventSource;
+	if (typeof EventSourceImpl === "undefined") return null;
+
+	const baseUrl = options.baseUrl ?? (hasTrustedApiBaseUrl() ? getApiBaseUrl() : "");
+	if (!baseUrl) {
+		options.onConnectionChange?.("disconnected");
+		return null;
+	}
+
+	const retryMs = options.retryMs ?? SSE_RETRY_MS;
+	let disposed = false;
+	let source: EventSource | undefined;
+	let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const clearRetry = () => {
+		if (retryTimer !== undefined) {
+			clearTimeout(retryTimer);
+			retryTimer = undefined;
+		}
+	};
+
+	const attach = (es: EventSource) => {
+		es.onopen = () => {
+			if (!disposed) options.onConnectionChange?.("open");
+		};
+		es.onerror = () => {
+			if (disposed) return;
+			options.onConnectionChange?.("disconnected");
+			if (es.readyState === EVENTSOURCE_CLOSED) {
+				es.close();
+				if (source === es) source = undefined;
+				scheduleRetry();
+			}
+		};
+		const onData = (ev: MessageEvent<string>) => {
+			if (disposed || typeof ev.data !== "string") return;
+			handleMessageData(ev.data, options, options.sessionId);
+		};
+		// Named event preferred; also listen to default message for simpler servers.
+		es.addEventListener(AGENT_STREAM_EVENT_NAME, onData as EventListener);
+		es.onmessage = onData;
+	};
+
+	const scheduleRetry = () => {
+		if (disposed || retryMs <= 0 || retryTimer !== undefined) return;
+		retryTimer = setTimeout(() => {
+			retryTimer = undefined;
+			connect();
+		}, retryMs);
+	};
+
+	const connect = () => {
+		if (disposed) return;
+		clearRetry();
+		source?.close();
+		options.onConnectionChange?.("connecting");
+		const es = new EventSourceImpl(buildStreamUrl(baseUrl, options.sessionId));
+		source = es;
+		attach(es);
+	};
+
+	connect();
+
+	return {
+		dispose() {
+			disposed = true;
+			clearRetry();
+			source?.close();
+			source = undefined;
+			options.onConnectionChange?.("disconnected");
+		},
+	};
+}
+
+/** Pure helper for tests: parse one SSE data payload. */
+export function parseAgentStreamSseData(raw: string, sessionId: string): AgentStreamEvent | null {
+	const handlers: { event?: AgentStreamEvent } = {};
+	handleMessageData(
+		raw,
+		{
+			onEvent: (event) => {
+				handlers.event = event;
+			},
+		},
+		sessionId,
+	);
+	return handlers.event ?? null;
+}

--- a/frontend/src/renderer/lib/agent-stream/index.ts
+++ b/frontend/src/renderer/lib/agent-stream/index.ts
@@ -1,0 +1,4 @@
+export * from "./agentStreamCore";
+export * from "./agentStreamBatch";
+export * from "./agentStreamParse";
+export * from "./agentStreamTransport";

--- a/frontend/src/renderer/types/agentStreamTypes.ts
+++ b/frontend/src/renderer/types/agentStreamTypes.ts
@@ -1,0 +1,127 @@
+export type AgentStreamSource =
+  | { kind: 'native-acp-v1'; provider?: string }
+  | { kind: 'legacy-adapter'; provider?: string }
+
+export type AgentStreamPhase =
+  | 'idle'
+  | 'running'
+  | 'waiting_permission'
+  | 'cancelling'
+  | 'done'
+  | 'error'
+  | 'cancelled'
+
+export type AgentPlanEntryStatus = 'pending' | 'in_progress' | 'completed' | 'blocked'
+
+export interface AgentPlanEntry {
+  id: string
+  title: string
+  status: AgentPlanEntryStatus
+}
+
+export interface AgentPlan {
+  title?: string
+  entries: AgentPlanEntry[]
+}
+
+export type AgentPermissionOptionKind =
+  | 'allow_once'
+  | 'allow_always'
+  | 'reject_once'
+  | 'reject_always'
+
+export interface AgentPermissionOption {
+  optionId: string
+  label: string
+  kind: AgentPermissionOptionKind
+}
+
+export interface AgentPermissionRequest {
+  requestId: string
+  toolCallId?: string
+  title: string
+  description?: string
+  options: AgentPermissionOption[]
+}
+
+interface AgentStreamEventBase {
+  sessionId: string
+  /** Monotonic within a session. Replayed or duplicate sequence numbers are ignored. */
+  sequence: number
+  timestamp?: string
+  source?: AgentStreamSource
+}
+
+export type AgentStreamEvent =
+  | (AgentStreamEventBase & {
+      type: 'text_delta'
+      itemId: string
+      delta: string
+    })
+  | (AgentStreamEventBase & {
+      type: 'thinking_update'
+      itemId: string
+      text: string
+      mode?: 'delta' | 'replace'
+    })
+  | (AgentStreamEventBase & {
+      type: 'tool_call'
+      toolCallId: string
+      name?: string
+      title: string
+      input?: Record<string, unknown>
+    })
+  | (AgentStreamEventBase & {
+      type: 'tool_update'
+      toolCallId: string
+      status: 'pending' | 'in_progress' | 'completed' | 'failed'
+      name?: string
+      title?: string
+      input?: Record<string, unknown>
+      resultDelta?: string
+      output?: { stream: 'stdout' | 'stderr'; text: string }
+      error?: string
+    })
+  | (AgentStreamEventBase & {
+      type: 'plan'
+      title?: string
+      entries: AgentPlanEntry[]
+    })
+  | (AgentStreamEventBase & {
+      type: 'status'
+      status: 'starting' | 'running' | 'waiting' | 'idle'
+      message?: string
+    })
+  | (AgentStreamEventBase & {
+      type: 'permission_request'
+      request: AgentPermissionRequest
+    })
+  | (AgentStreamEventBase & {
+      type: 'done'
+      stopReason?: string
+    })
+  | (AgentStreamEventBase & {
+      type: 'error'
+      message: string
+    })
+  | (AgentStreamEventBase & {
+      type: 'cancelled'
+      reason?: string
+    })
+
+export interface AgentSessionStreamState {
+  phase: AgentStreamPhase
+  lastSequence: number
+  /** Epoch ms of the last successfully applied agent:stream event. Used for fail-open silence. */
+  lastEventAt?: number
+  statusMessage?: string
+  plan?: AgentPlan
+  permission?: AgentPermissionRequest
+  terminalReason?: string
+}
+
+export interface AgentPermissionResponse {
+  sessionId: string
+  requestId: string
+  optionId: string
+}

--- a/frontend/src/renderer/types/streamMessages.ts
+++ b/frontend/src/renderer/types/streamMessages.ts
@@ -1,0 +1,42 @@
+/**
+ * Normalized chat timeline rows produced by the agent-stream reducer.
+ *
+ * Independent of any provider SDK and of the durable conversation snapshot
+ * model. The reducer only needs these fields; the renderer maps them to AO UI.
+ */
+
+export type StreamMessageRole =
+	| "user"
+	| "assistant"
+	| "thinking"
+	| "tool_use"
+	| "tool_result"
+	| "system"
+	| "error";
+
+export interface StreamToolOutput {
+	stream: "stdout" | "stderr";
+	text: string;
+}
+
+export interface StreamMessage {
+	role: StreamMessageRole;
+	content: string;
+	id?: string;
+	timestamp?: string;
+	toolName?: string;
+	toolInput?: Record<string, unknown>;
+	toolResult?: string;
+	toolOutputs?: StreamToolOutput[];
+	toolUseId?: string;
+	/** Legacy process path id; treated as an alias of toolUseId for stream reduce. */
+	toolCallId?: string;
+	toolStatus?: string;
+	isDelta?: boolean;
+	isError?: boolean;
+	isThinking?: boolean;
+	streamItemId?: string;
+	/** Legacy process path item id for assistant bubbles. */
+	sourceItemId?: string;
+	partial?: boolean;
+}


### PR DESCRIPTION
## Summary

Ports the **AllBeingsFuture agent-stream consumer core** into AO’s renderer for ACP streaming output UX, without importing `@agentclientprotocol/sdk` or speaking raw ACP.

- **Types:** `AgentStreamEvent` envelopes + `StreamMessage` reducer rows
- **Pure core:** `reduceAgentStreamEvent`, batch/coalesce, sequence ignore, silence fail-open helpers
- **Transport:** SSE client for provisional `GET /api/v1/sessions/{id}/agent-stream` + HTTP permission POST
- **UI (minimal, AO design tokens):** timeline (text / thinking / tools), plan + permission panel, surface shell
- **Hook:** `useAgentStream` (batcher + optional SSE + `pushEvents` for offline/tests)
- **Docs:** `frontend/docs/acp-renderer-streaming.md`

Does **not** port full fenzhi `ChatWorkspace` (out of corrected scope). SessionView / settings left untouched until backend stream API lands.

## Backend dependencies (BLOCKED for live wiring)

Provisional routes not on `main` OpenAPI yet:

1. `GET /api/v1/sessions/{sessionId}/agent-stream` — SSE, `event: agent_stream`, JSON `AgentStreamEvent`
2. `POST /api/v1/sessions/{sessionId}/agent-stream/permissions/{requestId}` — body `{ optionId }`

Until those exist, `connection` stays `unavailable`; UI works via `pushEvents`.

## Tests

```bash
cd frontend && npx tsc --noEmit
npx vitest run --config vite.renderer.config.ts \
  src/renderer/lib/agent-stream \
  src/renderer/components/agent-stream
```

**Results:** typecheck clean; **46** tests passed.

## Next actions for orchestrator

1. Backend worker: implement agent-stream SSE + permission resolve (and OpenAPI regen)
2. Frontend follow-up: mount `AgentStreamSurface` on chat-mode sessions when `session.mode === "chat"` / ACP harness ready
3. Optional: map durable conversation snapshot → seed `StreamMessage[]` for reconnect