### PR TITLE
feat(agentstream): ABF-style sequenced agent stream over SSE

### DIFF
--- a/backend/internal/agentstream/acp_map.go
+++ b/backend/internal/agentstream/acp_map.go
@@ -1,0 +1,187 @@
+package agentstream
+
+import "fmt"
+
+// ACPSessionUpdate is a thin, Go-side view of stable ACP v1 session/update
+// notification payloads. It is deliberately SDK-free so adapters can map from
+// coder/acp-go-sdk (or test fixtures) without this package importing the SDK.
+//
+// sessionUpdate values follow the public ACP v1 schema:
+// agent_message_chunk, agent_thought_chunk, tool_call, tool_call_update,
+// plan, plan_update, plan_removed, and a few ignored lifecycle kinds.
+type ACPSessionUpdate struct {
+	// SessionUpdate is the ACP update kind (e.g. "agent_message_chunk").
+	SessionUpdate string `json:"sessionUpdate"`
+
+	// Message / thought chunks
+	Content   any    `json:"content,omitempty"`
+	MessageID string `json:"messageId,omitempty"`
+
+	// Tool call
+	ToolCallID string         `json:"toolCallId,omitempty"`
+	Title      string         `json:"title,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	Kind       string         `json:"kind,omitempty"`
+	Status     string         `json:"status,omitempty"`
+	RawInput   map[string]any `json:"rawInput,omitempty"`
+	RawOutput  any            `json:"rawOutput,omitempty"`
+
+	// Plan
+	PlanID  string `json:"planId,omitempty"`
+	Entries []any  `json:"entries,omitempty"`
+	Plan    *struct {
+		Type    string `json:"type,omitempty"`
+		PlanID  string `json:"planId,omitempty"`
+		Entries []any  `json:"entries,omitempty"`
+	} `json:"plan,omitempty"`
+}
+
+// MapACPSessionUpdate converts one ACP session/update into a BridgeEvent.
+// Returns ok=false for updates that have no stream representation (mode/config
+// noise, empty text chunks). Modeled on ABF AcpAdapter.handleSessionUpdate.
+func MapACPSessionUpdate(update ACPSessionUpdate) (BridgeEvent, bool) {
+	switch update.SessionUpdate {
+	case "agent_message_chunk":
+		text := textFromContent(update.Content)
+		if text == "" {
+			return BridgeEvent{}, false
+		}
+		return BridgeEvent{
+			Event:  "delta",
+			Text:   text,
+			ItemID: update.MessageID,
+		}, true
+
+	case "agent_thought_chunk":
+		text := textFromContent(update.Content)
+		if text == "" {
+			return BridgeEvent{}, false
+		}
+		return BridgeEvent{
+			Event:  "thinking",
+			Text:   text,
+			ItemID: update.MessageID,
+		}, true
+
+	case "tool_call":
+		name := firstNonEmpty(update.Title, update.Name, update.Kind, "tool")
+		return BridgeEvent{
+			Event:      "tool",
+			ToolCallID: update.ToolCallID,
+			Name:       name,
+			Input:      update.RawInput,
+			Output:     update.RawOutput,
+			ToolStatus: update.Status,
+			IsUpdate:   false,
+		}, true
+
+	case "tool_call_update":
+		name := firstNonEmpty(update.Title, update.Name, update.Kind, "tool")
+		return BridgeEvent{
+			Event:      "tool",
+			ToolCallID: update.ToolCallID,
+			Name:       name,
+			Input:      update.RawInput,
+			Output:     update.RawOutput,
+			ToolStatus: update.Status,
+			IsUpdate:   true,
+		}, true
+
+	case "plan":
+		return BridgeEvent{
+			Event:   "plan",
+			Entries: update.Entries,
+		}, true
+
+	case "plan_update":
+		be := BridgeEvent{Event: "plan"}
+		if update.Plan != nil {
+			be.PlanID = update.Plan.PlanID
+			if update.Plan.Type == "items" {
+				be.Entries = update.Plan.Entries
+			}
+			be.Data = map[string]any{"format": update.Plan.Type, "plan": update.Plan}
+		}
+		return be, true
+
+	case "plan_removed":
+		return BridgeEvent{
+			Event:  "plan",
+			PlanID: update.PlanID,
+			Data:   map[string]any{"operation": "removed"},
+		}, true
+
+	// Accepted from agents but have no product consumer on the stream.
+	case "usage_update", "current_mode_update", "config_option_update",
+		"session_info_update", "available_commands_update", "user_message_chunk":
+		return BridgeEvent{}, false
+
+	default:
+		return BridgeEvent{}, false
+	}
+}
+
+// MapACPStopReason maps an ACP prompt stopReason to a terminal bridge event.
+func MapACPStopReason(stopReason string) BridgeEvent {
+	if stopReason == "cancelled" {
+		return BridgeEvent{Event: "done", StopReason: "cancelled", Phase: "cancelled"}
+	}
+	return BridgeEvent{Event: "done", StopReason: stopReason}
+}
+
+// MapACPPermissionRequest maps a session/request_permission into a bridge event.
+func MapACPPermissionRequest(requestID, toolCallID, title string, options []map[string]any) BridgeEvent {
+	opts := make([]any, 0, len(options))
+	for _, o := range options {
+		opts = append(opts, o)
+	}
+	if title == "" {
+		title = "tool"
+	}
+	return BridgeEvent{
+		Event:      "permission",
+		RequestID:  requestID,
+		ToolCallID: toolCallID,
+		Name:       title,
+		Options:    opts,
+	}
+}
+
+// MapACPError maps a transport/adapter failure to a bridge error.
+func MapACPError(err error) BridgeEvent {
+	msg := "Unknown error"
+	if err != nil {
+		msg = err.Error()
+	}
+	return BridgeEvent{Event: "error", Error: msg}
+}
+
+func textFromContent(content any) string {
+	if content == nil {
+		return ""
+	}
+	switch c := content.(type) {
+	case string:
+		return c
+	case map[string]any:
+		if t, ok := c["type"].(string); ok && t == "text" {
+			if text, ok := c["text"].(string); ok {
+				return text
+			}
+		}
+		if text, ok := c["text"].(string); ok {
+			return text
+		}
+		return ""
+	default:
+		// Arrays of content blocks: take first text.
+		if arr, ok := content.([]any); ok {
+			for _, item := range arr {
+				if t := textFromContent(item); t != "" {
+					return t
+				}
+			}
+		}
+		return fmt.Sprint(c)
+	}
+}

--- a/backend/internal/agentstream/acp_map_test.go
+++ b/backend/internal/agentstream/acp_map_test.go
@@ -1,0 +1,93 @@
+package agentstream
+
+import "testing"
+
+func TestMapACPSessionUpdateMessageAndThought(t *testing.T) {
+	be, ok := MapACPSessionUpdate(ACPSessionUpdate{
+		SessionUpdate: "agent_message_chunk",
+		Content:       map[string]any{"type": "text", "text": "hello"},
+		MessageID:     "m1",
+	})
+	if !ok || be.Event != "delta" || be.Text != "hello" || be.ItemID != "m1" {
+		t.Fatalf("message chunk = %+v ok=%v", be, ok)
+	}
+
+	be, ok = MapACPSessionUpdate(ACPSessionUpdate{
+		SessionUpdate: "agent_thought_chunk",
+		Content:       map[string]any{"type": "text", "text": "hmm"},
+	})
+	if !ok || be.Event != "thinking" || be.Text != "hmm" {
+		t.Fatalf("thought chunk = %+v ok=%v", be, ok)
+	}
+}
+
+func TestMapACPSessionUpdateToolsAndPlan(t *testing.T) {
+	be, ok := MapACPSessionUpdate(ACPSessionUpdate{
+		SessionUpdate: "tool_call",
+		ToolCallID:    "tc1",
+		Title:         "Read",
+		RawInput:      map[string]any{"path": "x.go"},
+		Status:        "pending",
+	})
+	if !ok || be.Event != "tool" || be.IsUpdate || be.ToolCallID != "tc1" {
+		t.Fatalf("tool_call = %+v ok=%v", be, ok)
+	}
+
+	be, ok = MapACPSessionUpdate(ACPSessionUpdate{
+		SessionUpdate: "tool_call_update",
+		ToolCallID:    "tc1",
+		Title:         "Read",
+		Status:        "completed",
+		RawOutput:     "ok",
+	})
+	if !ok || !be.IsUpdate || be.ToolStatus != "completed" {
+		t.Fatalf("tool_call_update = %+v ok=%v", be, ok)
+	}
+
+	be, ok = MapACPSessionUpdate(ACPSessionUpdate{
+		SessionUpdate: "plan",
+		Entries: []any{
+			map[string]any{"content": "A", "status": "pending"},
+		},
+	})
+	if !ok || be.Event != "plan" || len(be.Entries) != 1 {
+		t.Fatalf("plan = %+v ok=%v", be, ok)
+	}
+
+	be, ok = MapACPSessionUpdate(ACPSessionUpdate{
+		SessionUpdate: "plan_removed",
+		PlanID:        "p1",
+	})
+	if !ok || be.Data["operation"] != "removed" {
+		t.Fatalf("plan_removed = %+v ok=%v", be, ok)
+	}
+}
+
+func TestMapACPSessionUpdateIgnoresNoise(t *testing.T) {
+	for _, kind := range []string{
+		"usage_update", "current_mode_update", "user_message_chunk", "unknown_thing",
+	} {
+		if _, ok := MapACPSessionUpdate(ACPSessionUpdate{SessionUpdate: kind}); ok {
+			t.Fatalf("%s should be ignored", kind)
+		}
+	}
+}
+
+func TestMapACPStopReasonAndError(t *testing.T) {
+	done := MapACPStopReason("end_turn")
+	if done.Event != "done" || done.StopReason != "end_turn" {
+		t.Fatalf("done = %+v", done)
+	}
+	cancel := MapACPStopReason("cancelled")
+	if cancel.Event != "done" || cancel.StopReason != "cancelled" {
+		t.Fatalf("cancel = %+v", cancel)
+	}
+	errEv := MapACPError(assertErr("boom"))
+	if errEv.Event != "error" || errEv.Error != "boom" {
+		t.Fatalf("error = %+v", errEv)
+	}
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/backend/internal/agentstream/hub.go
+++ b/backend/internal/agentstream/hub.go
@@ -1,0 +1,177 @@
+package agentstream
+
+import (
+	"sync"
+)
+
+const (
+	// DefaultReplayCapacity is how many recent events are kept per session for
+	// SSE reconnect (after=sequence).
+	DefaultReplayCapacity = 512
+	// DefaultSubscriberBuffer is the per-subscriber live channel size. When
+	// full, the hub drops the slowest subscriber rather than blocking producers.
+	DefaultSubscriberBuffer = 256
+)
+
+// Hub fans normalized stream events out to SSE subscribers and keeps a short
+// per-session replay ring for reconnect.
+//
+// Producers (ACP drivers, tests) call PublishBridge or Publish. Consumers
+// Subscribe with an optional after sequence.
+type Hub struct {
+	mu       sync.RWMutex
+	norm     *Normalizer
+	sessions map[string]*hubSession
+	capacity int
+	subBuf   int
+}
+
+type hubSession struct {
+	// ring holds the most recent events in sequence order (oldest first).
+	ring []Event
+	// subs maps subscriber id → channel
+	subs map[uint64]chan Event
+	next uint64
+}
+
+// NewHub constructs a stream hub with a dedicated normalizer.
+func NewHub() *Hub {
+	return &Hub{
+		norm:     NewNormalizer(),
+		sessions: make(map[string]*hubSession),
+		capacity: DefaultReplayCapacity,
+		subBuf:   DefaultSubscriberBuffer,
+	}
+}
+
+// Normalizer returns the hub's shared normalizer (for advanced producers).
+func (h *Hub) Normalizer() *Normalizer { return h.norm }
+
+// ConfigureSession sets the stream source advertised on subsequent events.
+func (h *Hub) ConfigureSession(sessionID string, source Source) {
+	h.norm.ConfigureSession(sessionID, source)
+}
+
+// ClearSession drops normalizer state, replay, and subscribers for a session.
+func (h *Hub) ClearSession(sessionID string) {
+	h.norm.ClearSession(sessionID)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if s, ok := h.sessions[sessionID]; ok {
+		for id, ch := range s.subs {
+			close(ch)
+			delete(s.subs, id)
+		}
+		delete(h.sessions, sessionID)
+	}
+}
+
+// PublishBridge normalizes a bridge event and fans it out. Returns the
+// sequenced event, or nil when the normalizer drops the input.
+func (h *Hub) PublishBridge(sessionID string, event BridgeEvent) *Event {
+	out := h.norm.Normalize(sessionID, event)
+	if out == nil {
+		return nil
+	}
+	h.publish(*out)
+	return out
+}
+
+// Publish fans out an already-sequenced event (tests / advanced producers).
+// Prefer PublishBridge so sequence ownership stays in the normalizer.
+func (h *Hub) Publish(event Event) {
+	h.publish(event)
+}
+
+// PublishACPSessionUpdate maps an ACP session/update and publishes it.
+// Returns the sequenced event when one was emitted.
+func (h *Hub) PublishACPSessionUpdate(sessionID string, update ACPSessionUpdate) *Event {
+	be, ok := MapACPSessionUpdate(update)
+	if !ok {
+		return nil
+	}
+	return h.PublishBridge(sessionID, be)
+}
+
+// Subscribe returns a live channel of events with sequence > after, plus a
+// snapshot of buffered events already past after. Call unsubscribe when done.
+func (h *Hub) Subscribe(sessionID string, after int64) (replay []Event, live <-chan Event, unsubscribe func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	s := h.ensureSessionLocked(sessionID)
+	replay = filterAfter(s.ring, after)
+
+	id := s.next
+	s.next++
+	ch := make(chan Event, h.subBuf)
+	s.subs[id] = ch
+
+	unsub := func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		ss, ok := h.sessions[sessionID]
+		if !ok {
+			return
+		}
+		if c, ok := ss.subs[id]; ok {
+			delete(ss.subs, id)
+			close(c)
+		}
+	}
+	return replay, ch, unsub
+}
+
+// Replay returns buffered events with sequence > after without subscribing.
+func (h *Hub) Replay(sessionID string, after int64) []Event {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	s, ok := h.sessions[sessionID]
+	if !ok {
+		return nil
+	}
+	return filterAfter(s.ring, after)
+}
+
+func (h *Hub) publish(event Event) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	s := h.ensureSessionLocked(event.SessionID)
+	s.ring = append(s.ring, event)
+	if len(s.ring) > h.capacity {
+		// Drop oldest.
+		s.ring = append([]Event(nil), s.ring[len(s.ring)-h.capacity:]...)
+	}
+	for id, ch := range s.subs {
+		select {
+		case ch <- event:
+		default:
+			// Slow subscriber: drop it rather than block the producer path.
+			close(ch)
+			delete(s.subs, id)
+		}
+	}
+}
+
+func (h *Hub) ensureSessionLocked(sessionID string) *hubSession {
+	s, ok := h.sessions[sessionID]
+	if !ok {
+		s = &hubSession{subs: make(map[uint64]chan Event)}
+		h.sessions[sessionID] = s
+	}
+	return s
+}
+
+func filterAfter(ring []Event, after int64) []Event {
+	if len(ring) == 0 {
+		return nil
+	}
+	out := make([]Event, 0, len(ring))
+	for _, e := range ring {
+		if e.Sequence > after {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/backend/internal/agentstream/hub_test.go
+++ b/backend/internal/agentstream/hub_test.go
@@ -1,0 +1,69 @@
+package agentstream
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHubPublishBridgeAndSubscribeReplay(t *testing.T) {
+	h := NewHub()
+	h.ConfigureSession("sess-1", Source{Kind: SourceKindNativeACPv1, Provider: "test"})
+
+	e1 := h.PublishBridge("sess-1", BridgeEvent{Event: "delta", Text: "a"})
+	e2 := h.PublishBridge("sess-1", BridgeEvent{Event: "delta", Text: "b"})
+	if e1 == nil || e2 == nil || e1.Sequence != 0 || e2.Sequence != 1 {
+		t.Fatalf("events = %+v %+v", e1, e2)
+	}
+
+	// Terminal flush
+	done := h.PublishBridge("sess-1", BridgeEvent{Event: "done", StopReason: "end_turn"})
+	if done == nil || !done.IsTerminal() {
+		t.Fatalf("done = %+v", done)
+	}
+
+	replay := h.Replay("sess-1", -1)
+	if len(replay) != 3 {
+		t.Fatalf("replay len = %d, want 3", len(replay))
+	}
+	after0 := h.Replay("sess-1", 0)
+	if len(after0) != 2 || after0[0].Sequence != 1 {
+		t.Fatalf("after0 = %+v", after0)
+	}
+
+	// Live subscribe after sequence 1 should get only done (seq 2) from replay
+	// plus future events.
+	snap, live, unsub := h.Subscribe("sess-1", 1)
+	defer unsub()
+	if len(snap) != 1 || snap[0].Type != TypeDone {
+		t.Fatalf("snap = %+v", snap)
+	}
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		h.PublishBridge("sess-1", BridgeEvent{Event: "status", Phase: "idle"})
+	}()
+
+	select {
+	case ev := <-live:
+		if ev.Type != TypeStatus || ev.StreamStatus != StatusIdle {
+			t.Fatalf("live = %+v", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for live event")
+	}
+}
+
+func TestHubPublishACPSessionUpdate(t *testing.T) {
+	h := NewHub()
+	h.ConfigureSession("s", Source{Kind: SourceKindNativeACPv1})
+	ev := h.PublishACPSessionUpdate("s", ACPSessionUpdate{
+		SessionUpdate: "agent_message_chunk",
+		Content:       map[string]any{"type": "text", "text": "via-acp"},
+	})
+	if ev == nil || ev.Type != TypeTextDelta || ev.Delta != "via-acp" {
+		t.Fatalf("ev = %+v", ev)
+	}
+	if h.PublishACPSessionUpdate("s", ACPSessionUpdate{SessionUpdate: "usage_update"}) != nil {
+		t.Fatal("usage_update should not publish")
+	}
+}

--- a/backend/internal/agentstream/normalizer.go
+++ b/backend/internal/agentstream/normalizer.go
@@ -1,0 +1,446 @@
+package agentstream
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// sessionStreamState tracks per-session sequencing and tool output diffs.
+type sessionStreamState struct {
+	sequence              int64
+	source                Source
+	toolOutputText        map[string]string
+	defaultTextItemID     string
+	defaultThinkingItemID string
+}
+
+// Normalizer converts BridgeEvent values into sequenced AgentStreamEvent
+// values. Sequence numbers are strictly increasing per session (0-based).
+//
+// Modeled on AllBeingsFuture electron/services/agent-stream-normalizer.ts.
+type Normalizer struct {
+	mu       sync.Mutex
+	sessions map[string]*sessionStreamState
+	// now is injectable for tests; defaults to time.Now.
+	now func() time.Time
+}
+
+// NewNormalizer builds an empty normalizer.
+func NewNormalizer() *Normalizer {
+	return &Normalizer{
+		sessions: make(map[string]*sessionStreamState),
+		now:      time.Now,
+	}
+}
+
+// ConfigureSession sets the stream source for a session. Creating a new
+// session resets sequence to start at 0 on the next event.
+func (n *Normalizer) ConfigureSession(sessionID string, source Source) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if existing, ok := n.sessions[sessionID]; ok {
+		existing.source = source
+		return
+	}
+	n.sessions[sessionID] = newSessionState(source)
+}
+
+// ClearSession drops sequencing state for a session.
+func (n *Normalizer) ClearSession(sessionID string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	delete(n.sessions, sessionID)
+}
+
+// Normalize maps one bridge event. Returns nil when the event should not be
+// streamed (empty deltas, permission outcomes, ignored status phases, etc.).
+// Terminal events (done/error/cancelled) clear tool-output tracking for the turn.
+func (n *Normalizer) Normalize(sessionID string, event BridgeEvent) *Event {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	state := n.ensureSessionLocked(sessionID)
+	sequence := state.sequence + 1
+	base := Event{
+		SessionID: sessionID,
+		Sequence:  sequence,
+		Timestamp: n.now().UTC(),
+		Source:    &Source{Kind: state.source.Kind, Provider: state.source.Provider},
+	}
+
+	var out *Event
+	switch event.Event {
+	case "delta":
+		delta := event.Text
+		if delta == "" {
+			return nil
+		}
+		itemID := event.ItemID
+		if itemID == "" {
+			itemID = state.defaultTextItemID
+		}
+		e := base
+		e.Type = TypeTextDelta
+		e.ItemID = itemID
+		e.Delta = delta
+		out = &e
+
+	case "thinking":
+		text := event.Text
+		if text == "" {
+			text = event.Thinking
+		}
+		if text == "" {
+			return nil
+		}
+		itemID := event.ItemID
+		if itemID == "" {
+			itemID = state.defaultThinkingItemID
+		}
+		e := base
+		e.Type = TypeThinkingUpdate
+		e.ItemID = itemID
+		e.Text = text
+		// Bridge adapters emit thinking chunks; the reducer appends by default.
+		e.Mode = string(ThinkingDelta)
+		out = &e
+
+	case "tool":
+		toolCallID := firstNonEmpty(event.ToolCallID, event.ToolName2, event.Name)
+		if toolCallID == "" {
+			toolCallID = fmt.Sprintf("tool-%d", sequence)
+		}
+		title := firstNonEmpty(event.Name, event.ToolName, event.ToolName2, "Tool")
+		if !event.IsUpdate {
+			e := base
+			e.Type = TypeToolCall
+			e.ToolCallID = toolCallID
+			e.Title = title
+			e.Name = firstNonEmpty(event.Name, event.ToolName, event.ToolName2)
+			e.Input = firstMap(event.Input, event.ToolInput, event.ToolInput2)
+			out = &e
+			break
+		}
+		status := mapToolStatus(firstNonEmpty(event.ToolStatus, event.Status))
+		fullText := formatOutputText(event.Output)
+		previous := state.toolOutputText[toolCallID]
+		var resultDelta string
+		if fullText != "" {
+			if len(fullText) >= len(previous) && fullText[:len(previous)] == previous {
+				resultDelta = fullText[len(previous):]
+			} else {
+				resultDelta = fullText
+			}
+			state.toolOutputText[toolCallID] = fullText
+		}
+		e := base
+		e.Type = TypeToolUpdate
+		e.ToolCallID = toolCallID
+		e.Status = status
+		e.Name = firstNonEmpty(event.Name, event.ToolName, event.ToolName2)
+		e.Title = title
+		e.Input = firstMap(event.Input, event.ToolInput, event.ToolInput2)
+		if resultDelta != "" {
+			e.ResultDelta = resultDelta
+			e.Output = &ToolOutput{Stream: "stdout", Text: resultDelta}
+		}
+		if status == ToolFailed {
+			errMsg := event.Error
+			if errMsg == "" {
+				errMsg = fullText
+			}
+			if errMsg == "" {
+				errMsg = "Tool failed"
+			}
+			e.Error = errMsg
+		}
+		out = &e
+
+	case "plan":
+		if event.Data != nil {
+			if op, _ := event.Data["operation"].(string); op == "removed" {
+				e := base
+				e.Type = TypePlan
+				e.Entries = []PlanEntry{}
+				out = &e
+				break
+			}
+		}
+		entries := normalizePlanEntries(event.Entries)
+		// Ignore plan lifecycle noise without displayable entries.
+		if len(entries) == 0 && event.PlanID == "" {
+			return nil
+		}
+		e := base
+		e.Type = TypePlan
+		if event.PlanID != "" {
+			e.PlanTitle = event.PlanID
+		}
+		e.Entries = entries
+		out = &e
+
+	case "permission":
+		// Only surface the initial request; outcomes stay internal to the adapter.
+		if event.Outcome != nil {
+			return nil
+		}
+		requestID := event.RequestID
+		options := normalizePermissionOptions(event.Options)
+		if requestID == "" || len(options) == 0 {
+			return nil
+		}
+		title := event.Name
+		if title == "" {
+			title = "Permission required"
+		}
+		e := base
+		e.Type = TypePermissionRequest
+		e.Request = &PermissionRequest{
+			RequestID:   requestID,
+			ToolCallID:  event.ToolCallID,
+			Title:       title,
+			Description: event.Description,
+			Options:     options,
+		}
+		out = &e
+
+	case "status":
+		switch event.Phase {
+		case "running":
+			e := base
+			e.Type = TypeStatus
+			e.StreamStatus = StatusRunning
+			e.Message = event.Detail
+			out = &e
+		case "idle":
+			e := base
+			e.Type = TypeStatus
+			e.StreamStatus = StatusIdle
+			e.Message = event.Detail
+			out = &e
+		case "waiting", "waiting_permission":
+			e := base
+			e.Type = TypeStatus
+			e.StreamStatus = StatusWaiting
+			e.Message = event.Detail
+			out = &e
+		case "starting":
+			e := base
+			e.Type = TypeStatus
+			e.StreamStatus = StatusStarting
+			e.Message = event.Detail
+			out = &e
+		default:
+			// ready and other non-UI phases are ignored
+			return nil
+		}
+
+	case "done":
+		if event.StopReason == "cancelled" || event.Phase == "cancelled" {
+			e := base
+			e.Type = TypeCancelled
+			reason := event.StopReason
+			if reason == "" {
+				reason = "cancelled"
+			}
+			e.Reason = reason
+			out = &e
+		} else {
+			e := base
+			e.Type = TypeDone
+			e.StopReason = event.StopReason
+			out = &e
+		}
+		state.toolOutputText = make(map[string]string)
+
+	case "error":
+		msg := event.Error
+		if msg == "" {
+			msg = event.Message
+		}
+		if msg == "" {
+			msg = "Unknown error"
+		}
+		e := base
+		e.Type = TypeError
+		e.Message = msg
+		out = &e
+		state.toolOutputText = make(map[string]string)
+
+	case "agent_task":
+		// Child-agent lifecycle is not part of the agent stream contract.
+		return nil
+	default:
+		return nil
+	}
+
+	if out == nil {
+		return nil
+	}
+	state.sequence = sequence
+	return out
+}
+
+func (n *Normalizer) ensureSessionLocked(sessionID string) *sessionStreamState {
+	state, ok := n.sessions[sessionID]
+	if !ok {
+		state = newSessionState(Source{Kind: SourceKindLegacyAdapter})
+		n.sessions[sessionID] = state
+	}
+	return state
+}
+
+func newSessionState(source Source) *sessionStreamState {
+	return &sessionStreamState{
+		sequence:              -1,
+		source:                source,
+		toolOutputText:        make(map[string]string),
+		defaultTextItemID:     "assistant-text",
+		defaultThinkingItemID: "assistant-thinking",
+	}
+}
+
+func mapPlanStatus(status any) PlanEntryStatus {
+	s, _ := status.(string)
+	switch s {
+	case "cancelled", "failed", "blocked":
+		return PlanBlocked
+	case "in_progress", "completed", "pending":
+		return PlanEntryStatus(s)
+	default:
+		return PlanPending
+	}
+}
+
+func mapToolStatus(status string) ToolUpdateStatus {
+	switch status {
+	case "pending", "completed", "failed":
+		return ToolUpdateStatus(status)
+	case "in_progress":
+		return ToolInProgress
+	default:
+		return ToolInProgress
+	}
+}
+
+func mapPermissionKind(kind any) (PermissionOptionKind, bool) {
+	s, ok := kind.(string)
+	if !ok {
+		return "", false
+	}
+	switch PermissionOptionKind(s) {
+	case PermissionAllowOnce, PermissionAllowAlways, PermissionRejectOnce, PermissionRejectAlways:
+		return PermissionOptionKind(s), true
+	default:
+		return "", false
+	}
+}
+
+func normalizePlanEntries(entries []any) []PlanEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]PlanEntry, 0, len(entries))
+	for i, entry := range entries {
+		record, _ := entry.(map[string]any)
+		if record == nil {
+			// json-decoded objects are map[string]any; tolerate structs via marshal.
+			if b, err := json.Marshal(entry); err == nil {
+				_ = json.Unmarshal(b, &record)
+			}
+		}
+		if record == nil {
+			record = map[string]any{}
+		}
+		content, _ := record["content"].(string)
+		if content == "" {
+			if t, ok := record["title"].(string); ok {
+				content = t
+			}
+		}
+		if content == "" {
+			content = fmt.Sprintf("Step %d", i+1)
+		}
+		id, _ := record["id"].(string)
+		if id == "" {
+			id = fmt.Sprintf("plan-entry-%d", i)
+		}
+		out = append(out, PlanEntry{
+			ID:     id,
+			Title:  content,
+			Status: mapPlanStatus(record["status"]),
+		})
+	}
+	return out
+}
+
+func normalizePermissionOptions(options []any) []PermissionOption {
+	if len(options) == 0 {
+		return nil
+	}
+	out := make([]PermissionOption, 0, len(options))
+	for _, option := range options {
+		record, _ := option.(map[string]any)
+		if record == nil {
+			if b, err := json.Marshal(option); err == nil {
+				_ = json.Unmarshal(b, &record)
+			}
+		}
+		if record == nil {
+			continue
+		}
+		optionID, _ := record["optionId"].(string)
+		label, _ := record["name"].(string)
+		if label == "" {
+			if l, ok := record["label"].(string); ok {
+				label = l
+			}
+		}
+		kind, ok := mapPermissionKind(record["kind"])
+		if optionID == "" || label == "" || !ok {
+			continue
+		}
+		out = append(out, PermissionOption{OptionID: optionID, Label: label, Kind: kind})
+	}
+	return out
+}
+
+func formatOutputText(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case float64, float32, int, int64, int32, bool:
+		return fmt.Sprint(v)
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprint(v)
+		}
+		return string(b)
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func firstMap(vals ...map[string]any) map[string]any {
+	for _, v := range vals {
+		if v != nil {
+			return v
+		}
+	}
+	return nil
+}

--- a/backend/internal/agentstream/normalizer_test.go
+++ b/backend/internal/agentstream/normalizer_test.go
@@ -1,0 +1,208 @@
+package agentstream
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests modeled on AllBeingsFuture electron/tests/agent-stream-normalizer.test.ts.
+
+func TestNormalizerMapsACPStyleBridgeEventsWithIncreasingSequences(t *testing.T) {
+	n := NewNormalizer()
+	fixed := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	n.now = func() time.Time { return fixed }
+	n.ConfigureSession("s1", Source{Kind: SourceKindNativeACPv1, Provider: "acp-agent"})
+
+	text := n.Normalize("s1", BridgeEvent{Event: "delta", Text: "hi", ItemID: "m1"})
+	if text == nil || text.Type != TypeTextDelta {
+		t.Fatalf("text = %+v, want text_delta", text)
+	}
+	if text.Sequence != 0 {
+		t.Fatalf("sequence = %d, want 0", text.Sequence)
+	}
+	if text.Delta != "hi" || text.ItemID != "m1" {
+		t.Fatalf("text fields = delta:%q itemId:%q", text.Delta, text.ItemID)
+	}
+	if text.Source == nil || text.Source.Kind != SourceKindNativeACPv1 {
+		t.Fatalf("source = %+v", text.Source)
+	}
+
+	thinking := n.Normalize("s1", BridgeEvent{Event: "thinking", Text: "hmm", ItemID: "t1"})
+	if thinking == nil || thinking.Type != TypeThinkingUpdate {
+		t.Fatalf("thinking = %+v", thinking)
+	}
+	if thinking.Sequence != 1 {
+		t.Fatalf("thinking sequence = %d, want 1", thinking.Sequence)
+	}
+	if thinking.Mode != string(ThinkingDelta) {
+		t.Fatalf("thinking mode = %q, want delta", thinking.Mode)
+	}
+
+	tool := n.Normalize("s1", BridgeEvent{
+		Event:      "tool",
+		ToolCallID: "tool-1",
+		Name:       "Read file",
+		Input:      map[string]any{"path": "a.ts"},
+		IsUpdate:   false,
+		ToolStatus: "pending",
+	})
+	if tool == nil || tool.Type != TypeToolCall {
+		t.Fatalf("tool = %+v", tool)
+	}
+	if tool.Sequence != 2 {
+		t.Fatalf("tool sequence = %d, want 2", tool.Sequence)
+	}
+
+	toolUpdate := n.Normalize("s1", BridgeEvent{
+		Event:      "tool",
+		ToolCallID: "tool-1",
+		Name:       "Read file",
+		IsUpdate:   true,
+		ToolStatus: "completed",
+		Output:     map[string]any{"bytes": 3},
+	})
+	if toolUpdate == nil || toolUpdate.Type != TypeToolUpdate {
+		t.Fatalf("toolUpdate = %+v", toolUpdate)
+	}
+	if toolUpdate.Sequence != 3 {
+		t.Fatalf("toolUpdate sequence = %d, want 3", toolUpdate.Sequence)
+	}
+	if toolUpdate.Status != ToolCompleted {
+		t.Fatalf("status = %q", toolUpdate.Status)
+	}
+	if toolUpdate.ResultDelta == "" || !contains(toolUpdate.ResultDelta, "bytes") {
+		t.Fatalf("resultDelta = %q, want bytes json", toolUpdate.ResultDelta)
+	}
+
+	plan := n.Normalize("s1", BridgeEvent{
+		Event: "plan",
+		Entries: []any{
+			map[string]any{"content": "Step A", "priority": "high", "status": "completed"},
+		},
+	})
+	if plan == nil || plan.Type != TypePlan {
+		t.Fatalf("plan = %+v", plan)
+	}
+	if len(plan.Entries) != 1 || plan.Entries[0].Title != "Step A" {
+		t.Fatalf("plan entries = %+v", plan.Entries)
+	}
+	if plan.Entries[0].ID != "plan-entry-0" || plan.Entries[0].Status != PlanCompleted {
+		t.Fatalf("plan entry = %+v", plan.Entries[0])
+	}
+
+	permission := n.Normalize("s1", BridgeEvent{
+		Event:      "permission",
+		RequestID:  "42",
+		Name:       "Inspect workspace",
+		ToolCallID: "tool-1",
+		Options: []any{
+			map[string]any{"optionId": "allow", "name": "Allow once", "kind": "allow_once"},
+			map[string]any{"optionId": "reject", "name": "Reject once", "kind": "reject_once"},
+		},
+	})
+	if permission == nil || permission.Type != TypePermissionRequest {
+		t.Fatalf("permission = %+v", permission)
+	}
+	if permission.Request == nil || permission.Request.RequestID != "42" {
+		t.Fatalf("request = %+v", permission.Request)
+	}
+	if len(permission.Request.Options) == 0 || permission.Request.Options[0].Label != "Allow once" {
+		t.Fatalf("options = %+v", permission.Request.Options)
+	}
+
+	// Permission outcomes are not streamed to the renderer.
+	if got := n.Normalize("s1", BridgeEvent{
+		Event:     "permission",
+		RequestID: "42",
+		Outcome:   map[string]any{"outcome": "selected", "optionId": "allow"},
+	}); got != nil {
+		t.Fatalf("permission outcome should be nil, got %+v", got)
+	}
+
+	done := n.Normalize("s1", BridgeEvent{Event: "done", StopReason: "end_turn"})
+	if done == nil || done.Type != TypeDone {
+		t.Fatalf("done = %+v", done)
+	}
+	if done.Sequence != 6 {
+		t.Fatalf("done sequence = %d, want 6", done.Sequence)
+	}
+	if !done.IsTerminal() {
+		t.Fatal("done should be terminal")
+	}
+
+	cancelled := n.Normalize("s1", BridgeEvent{Event: "done", StopReason: "cancelled"})
+	if cancelled == nil || cancelled.Type != TypeCancelled {
+		t.Fatalf("cancelled = %+v", cancelled)
+	}
+	if cancelled.Sequence != 7 {
+		t.Fatalf("cancelled sequence = %d, want 7", cancelled.Sequence)
+	}
+}
+
+func TestNormalizerIgnoresReadyStatusAndMapsRunningIdle(t *testing.T) {
+	n := NewNormalizer()
+	n.ConfigureSession("s2", Source{Kind: SourceKindLegacyAdapter, Provider: "claude"})
+	if got := n.Normalize("s2", BridgeEvent{Event: "status", Phase: "ready"}); got != nil {
+		t.Fatalf("ready status should be nil, got %+v", got)
+	}
+
+	running := n.Normalize("s2", BridgeEvent{Event: "status", Phase: "running"})
+	if running == nil || running.Type != TypeStatus || running.StreamStatus != StatusRunning {
+		t.Fatalf("running = %+v", running)
+	}
+
+	thinking := n.Normalize("s2", BridgeEvent{Event: "thinking", Text: "legacy"})
+	if thinking == nil || thinking.Type != TypeThinkingUpdate || thinking.Mode != string(ThinkingDelta) {
+		t.Fatalf("thinking = %+v", thinking)
+	}
+}
+
+func TestNormalizerDropsEmptyDeltasAndAgentTask(t *testing.T) {
+	n := NewNormalizer()
+	n.ConfigureSession("s3", Source{Kind: SourceKindNativeACPv1})
+	if got := n.Normalize("s3", BridgeEvent{Event: "delta", Text: ""}); got != nil {
+		t.Fatalf("empty delta should be nil, got %+v", got)
+	}
+	if got := n.Normalize("s3", BridgeEvent{Event: "agent_task"}); got != nil {
+		t.Fatalf("agent_task should be nil, got %+v", got)
+	}
+	// Sequence must not advance on dropped events.
+	next := n.Normalize("s3", BridgeEvent{Event: "delta", Text: "x"})
+	if next == nil || next.Sequence != 0 {
+		t.Fatalf("next sequence = %+v, want 0", next)
+	}
+}
+
+func TestNormalizerToolOutputDiffIsIncremental(t *testing.T) {
+	n := NewNormalizer()
+	n.ConfigureSession("s4", Source{Kind: SourceKindNativeACPv1})
+	_ = n.Normalize("s4", BridgeEvent{
+		Event: "tool", ToolCallID: "t", Name: "run", IsUpdate: false,
+	})
+	u1 := n.Normalize("s4", BridgeEvent{
+		Event: "tool", ToolCallID: "t", Name: "run", IsUpdate: true,
+		ToolStatus: "in_progress", Output: "hel",
+	})
+	if u1 == nil || u1.ResultDelta != "hel" {
+		t.Fatalf("u1 = %+v", u1)
+	}
+	u2 := n.Normalize("s4", BridgeEvent{
+		Event: "tool", ToolCallID: "t", Name: "run", IsUpdate: true,
+		ToolStatus: "completed", Output: "hello",
+	})
+	if u2 == nil || u2.ResultDelta != "lo" {
+		t.Fatalf("u2 resultDelta = %q, want lo", u2.ResultDelta)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		(func() bool {
+			for i := 0; i+len(sub) <= len(s); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		})())
+}

--- a/backend/internal/agentstream/types.go
+++ b/backend/internal/agentstream/types.go
@@ -1,0 +1,219 @@
+// Package agentstream defines the provider-neutral agent stream contract and
+// the normalizer that turns adapter-internal bridge events into sequenced
+// AgentStreamEvent values for HTTP/SSE clients.
+//
+// Semantics match AllBeingsFuture's AgentStreamEvent / StreamNormalizer
+// (stable ACP v1 product surface): text_delta, thinking_update, tool_call,
+// tool_update, plan, status, permission_request, done, error, cancelled.
+// The renderer must never speak ACP; it consumes only these events.
+package agentstream
+
+import "time"
+
+// Source identifies which adapter produced a stream event.
+type Source struct {
+	// Kind is "native-acp-v1" or "legacy-adapter".
+	Kind     string `json:"kind"`
+	Provider string `json:"provider,omitempty"`
+}
+
+// Known source kinds.
+const (
+	SourceKindNativeACPv1   = "native-acp-v1"
+	SourceKindLegacyAdapter = "legacy-adapter"
+)
+
+// PlanEntryStatus is one plan step state.
+type PlanEntryStatus string
+
+// Plan entry statuses.
+const (
+	PlanPending    PlanEntryStatus = "pending"
+	PlanInProgress PlanEntryStatus = "in_progress"
+	PlanCompleted  PlanEntryStatus = "completed"
+	PlanBlocked    PlanEntryStatus = "blocked"
+)
+
+// PlanEntry is one step in a plan.
+type PlanEntry struct {
+	ID     string          `json:"id"`
+	Title  string          `json:"title"`
+	Status PlanEntryStatus `json:"status"`
+}
+
+// PermissionOptionKind is a stable permission choice family.
+type PermissionOptionKind string
+
+// Permission option kinds.
+const (
+	PermissionAllowOnce    PermissionOptionKind = "allow_once"
+	PermissionAllowAlways  PermissionOptionKind = "allow_always"
+	PermissionRejectOnce   PermissionOptionKind = "reject_once"
+	PermissionRejectAlways PermissionOptionKind = "reject_always"
+)
+
+// PermissionOption is one choice offered for a permission request.
+type PermissionOption struct {
+	OptionID string               `json:"optionId"`
+	Label    string               `json:"label"`
+	Kind     PermissionOptionKind `json:"kind"`
+}
+
+// PermissionRequest is a structured permission prompt for the UI.
+type PermissionRequest struct {
+	RequestID   string             `json:"requestId"`
+	ToolCallID  string             `json:"toolCallId,omitempty"`
+	Title       string             `json:"title"`
+	Description string             `json:"description,omitempty"`
+	Options     []PermissionOption `json:"options"`
+}
+
+// EventType is the wire type of a stream event.
+type EventType string
+
+// Stream event types (ABF AgentStreamEvent).
+const (
+	TypeTextDelta         EventType = "text_delta"
+	TypeThinkingUpdate    EventType = "thinking_update"
+	TypeToolCall          EventType = "tool_call"
+	TypeToolUpdate        EventType = "tool_update"
+	TypePlan              EventType = "plan"
+	TypeStatus            EventType = "status"
+	TypePermissionRequest EventType = "permission_request"
+	TypeDone              EventType = "done"
+	TypeError             EventType = "error"
+	TypeCancelled         EventType = "cancelled"
+)
+
+// ToolUpdateStatus is a tool call lifecycle state.
+type ToolUpdateStatus string
+
+// Tool update statuses.
+const (
+	ToolPending    ToolUpdateStatus = "pending"
+	ToolInProgress ToolUpdateStatus = "in_progress"
+	ToolCompleted  ToolUpdateStatus = "completed"
+	ToolFailed     ToolUpdateStatus = "failed"
+)
+
+// StreamStatus is a coarse agent phase for the status event.
+type StreamStatus string
+
+// Stream status values.
+const (
+	StatusStarting StreamStatus = "starting"
+	StatusRunning  StreamStatus = "running"
+	StatusWaiting  StreamStatus = "waiting"
+	StatusIdle     StreamStatus = "idle"
+)
+
+// ThinkingMode controls how thinking text is applied.
+type ThinkingMode string
+
+// Thinking modes.
+const (
+	ThinkingDelta   ThinkingMode = "delta"
+	ThinkingReplace ThinkingMode = "replace"
+)
+
+// ToolOutput is optional structured tool result text.
+type ToolOutput struct {
+	Stream string `json:"stream"` // stdout | stderr
+	Text   string `json:"text"`
+}
+
+// Event is the provider-neutral stream event a client reduces.
+// Optional fields are populated according to Type.
+type Event struct {
+	Type      EventType `json:"type"`
+	SessionID string    `json:"sessionId"`
+	// Sequence is monotonic per session (0-based). Clients ignore duplicates
+	// and can reconnect with after=<last applied sequence>.
+	Sequence  int64     `json:"sequence"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	Source    *Source   `json:"source,omitempty"`
+
+	// text_delta / thinking_update
+	ItemID string `json:"itemId,omitempty"`
+	Delta  string `json:"delta,omitempty"`
+	Text   string `json:"text,omitempty"`
+	Mode   string `json:"mode,omitempty"` // delta | replace for thinking
+
+	// tool_call / tool_update
+	ToolCallID  string           `json:"toolCallId,omitempty"`
+	Name        string           `json:"name,omitempty"`
+	Title       string           `json:"title,omitempty"`
+	Input       map[string]any   `json:"input,omitempty"`
+	Status      ToolUpdateStatus `json:"status,omitempty"`
+	ResultDelta string           `json:"resultDelta,omitempty"`
+	Output      *ToolOutput      `json:"output,omitempty"`
+	Error       string           `json:"error,omitempty"`
+
+	// plan
+	PlanTitle string      `json:"planTitle,omitempty"`
+	Entries   []PlanEntry `json:"entries,omitempty"`
+
+	// status
+	StreamStatus StreamStatus `json:"streamStatus,omitempty"`
+	Message      string       `json:"message,omitempty"`
+
+	// permission_request
+	Request *PermissionRequest `json:"request,omitempty"`
+
+	// done / cancelled
+	StopReason string `json:"stopReason,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+// IsTerminal reports whether the event ends a turn (clients flush turn state).
+func (e Event) IsTerminal() bool {
+	switch e.Type {
+	case TypeDone, TypeError, TypeCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// BridgeEvent is the adapter-internal event shape (ABF BridgeEvent). Drivers
+// map ACP session/update (and legacy adapters) into this before normalization.
+type BridgeEvent struct {
+	Event string `json:"event"` // delta|done|error|tool|thinking|plan|permission|status|agent_task
+
+	Text    string `json:"text,omitempty"`
+	ItemID  string `json:"itemId,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Message string `json:"message,omitempty"`
+
+	// Thinking
+	Thinking string `json:"thinking,omitempty"`
+
+	// Tool
+	ToolCallID string         `json:"toolCallId,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	ToolName   string         `json:"toolName,omitempty"`
+	ToolName2  string         `json:"tool_name,omitempty"`
+	Input      map[string]any `json:"input,omitempty"`
+	ToolInput  map[string]any `json:"toolInput,omitempty"`
+	ToolInput2 map[string]any `json:"tool_input,omitempty"`
+	Output     any            `json:"output,omitempty"`
+	ToolStatus string         `json:"toolStatus,omitempty"`
+	Status     string         `json:"status,omitempty"`
+	IsUpdate   bool           `json:"isUpdate,omitempty"`
+
+	// Plan
+	PlanID  string         `json:"planId,omitempty"`
+	Entries []any          `json:"entries,omitempty"`
+	Data    map[string]any `json:"data,omitempty"`
+
+	// Permission
+	RequestID   string `json:"requestId,omitempty"`
+	Description string `json:"description,omitempty"`
+	Options     []any  `json:"options,omitempty"`
+	Outcome     any    `json:"outcome,omitempty"`
+
+	// Status / done
+	Phase      string `json:"phase,omitempty"`
+	Detail     string `json:"detail,omitempty"`
+	StopReason string `json:"stopReason,omitempty"`
+}

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/runtimeselect"
+	"github.com/aoagents/agent-orchestrator/backend/internal/agentstream"
 	"github.com/aoagents/agent-orchestrator/backend/internal/browserruntime"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemon/supervisor"
@@ -251,6 +252,10 @@ func Run() error {
 		go dispatcher.Run(ctx)
 	}
 
+	// Provider-neutral agent stream hub (ABF AgentStreamEvent semantics over SSE).
+	// ACP/chat drivers publish here; the renderer only consumes the SSE wire.
+	agentStreamHub := agentstream.NewHub()
+
 	srv, err := httpd.NewWithDeps(cfg, log, termMgr, httpd.APIDeps{
 		Projects:           projectSvc,
 		Agents:             agentSvc,
@@ -276,6 +281,7 @@ func Run() error {
 		Browser:             browserService,
 		PreviewServer:       managedPreview,
 		SessionCapabilities: browserAuthority,
+		AgentStream:         agentStreamHub,
 	})
 	if err != nil {
 		stop()

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -38,6 +38,9 @@ type APIDeps struct {
 	Browser             controllers.BrowserService
 	PreviewServer       controllers.ManagedPreviewServer
 	SessionCapabilities controllers.SessionCapabilityValidator
+	// AgentStream is nil until the daemon wires the hub; the SSE route then
+	// answers 501 rather than panicking.
+	AgentStream controllers.AgentStream
 }
 
 // API owns one controller per resource and is the single Register call the
@@ -55,6 +58,7 @@ type API struct {
 	shellTerms    *controllers.ShellTerminalsController
 	dev           *controllers.DevController
 	browser       *controllers.BrowserController
+	agentStream   *controllers.AgentStreamController
 	events        *EventsController
 }
 
@@ -84,6 +88,7 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 		shellTerms:    &controllers.ShellTerminalsController{Svc: deps.ShellTerminals},
 		dev:           &controllers.DevController{Import: deps.DevImport},
 		browser:       &controllers.BrowserController{Svc: deps.Browser},
+		agentStream:   &controllers.AgentStreamController{Stream: deps.AgentStream},
 		events:        &EventsController{Source: deps.CDC, Live: deps.Events},
 	}
 }
@@ -118,6 +123,7 @@ func (a *API) Register(root chi.Router) {
 		// Long-lived streams intentionally bypass the REST timeout middleware.
 		a.notifications.RegisterStream(r)
 		a.sessions.RegisterStreams(r)
+		a.agentStream.RegisterStreams(r)
 		a.events.Register(r)
 	})
 }

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -1364,6 +1364,56 @@ paths:
       summary: Report an agent activity-state signal for a session
       tags:
       - sessions
+  /api/v1/sessions/{sessionId}/agent-stream:
+    get:
+      operationId: streamSessionAgentEvents
+      parameters:
+      - description: Session identifier, e.g. project-1.
+        in: path
+        name: sessionId
+        required: true
+        schema:
+          description: Session identifier, e.g. project-1.
+          type: string
+      - description: Last applied agent-stream sequence. Events with sequence greater
+          than this are sent. Omit or -1 for the full buffer.
+        in: query
+        name: after
+        schema:
+          description: Last applied agent-stream sequence. Events with sequence greater
+            than this are sent. Omit or -1 for the full buffer.
+          type:
+          - "null"
+          - integer
+      responses:
+        "200":
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/AgentStreamEventResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Stream sequenced provider-neutral agent events for a session (ACP output
+        wire)
+      tags:
+      - sessions
   /api/v1/sessions/{sessionId}/kill:
     post:
       operationId: killSession
@@ -2711,6 +2761,170 @@ components:
       required:
       - id
       - label
+      type: object
+    AgentStreamEventResponse:
+      properties:
+        delta:
+          type: string
+        entries:
+          items:
+            $ref: '#/components/schemas/AgentStreamPlanEntryResponse'
+          type: array
+        error:
+          type: string
+        input:
+          additionalProperties: {}
+          type: object
+        itemId:
+          type: string
+        message:
+          type: string
+        mode:
+          enum:
+          - delta
+          - replace
+          type: string
+        name:
+          type: string
+        output:
+          $ref: '#/components/schemas/AgentStreamToolOutputResponse'
+        planTitle:
+          type: string
+        reason:
+          type: string
+        request:
+          $ref: '#/components/schemas/AgentStreamPermissionRequestResponse'
+        resultDelta:
+          type: string
+        sequence:
+          format: int64
+          type: integer
+        sessionId:
+          type: string
+        source:
+          $ref: '#/components/schemas/AgentStreamSourceResponse'
+        status:
+          enum:
+          - pending
+          - in_progress
+          - completed
+          - failed
+          type: string
+        stopReason:
+          type: string
+        streamStatus:
+          enum:
+          - starting
+          - running
+          - waiting
+          - idle
+          type: string
+        text:
+          type: string
+        timestamp:
+          format: date-time
+          type: string
+        title:
+          type: string
+        toolCallId:
+          type: string
+        type:
+          enum:
+          - text_delta
+          - thinking_update
+          - tool_call
+          - tool_update
+          - plan
+          - status
+          - permission_request
+          - done
+          - error
+          - cancelled
+          type: string
+      required:
+      - type
+      - sessionId
+      - sequence
+      type: object
+    AgentStreamPermissionOptionResponse:
+      properties:
+        kind:
+          enum:
+          - allow_once
+          - allow_always
+          - reject_once
+          - reject_always
+          type: string
+        label:
+          type: string
+        optionId:
+          type: string
+      required:
+      - optionId
+      - label
+      - kind
+      type: object
+    AgentStreamPermissionRequestResponse:
+      properties:
+        description:
+          type: string
+        options:
+          items:
+            $ref: '#/components/schemas/AgentStreamPermissionOptionResponse'
+          type: array
+        requestId:
+          type: string
+        title:
+          type: string
+        toolCallId:
+          type: string
+      required:
+      - requestId
+      - title
+      - options
+      type: object
+    AgentStreamPlanEntryResponse:
+      properties:
+        id:
+          type: string
+        status:
+          enum:
+          - pending
+          - in_progress
+          - completed
+          - blocked
+          type: string
+        title:
+          type: string
+      required:
+      - id
+      - title
+      - status
+      type: object
+    AgentStreamSourceResponse:
+      properties:
+        kind:
+          enum:
+          - native-acp-v1
+          - legacy-adapter
+          type: string
+        provider:
+          type: string
+      required:
+      - kind
+      type: object
+    AgentStreamToolOutputResponse:
+      properties:
+        stream:
+          enum:
+          - stdout
+          - stderr
+          type: string
+        text:
+          type: string
+      required:
+      - stream
+      - text
       type: object
     BrowserCommandRequest:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -177,6 +177,13 @@ var schemaNames = map[string]string{
 	"ControllersRestoreSessionResponse":           "RestoreSessionResponse",
 	"ControllersResumeAgentResponse":              "ResumeAgentResponse",
 	"ControllersCleanupSessionsResponse":          "CleanupSessionsResponse",
+	"ControllersAgentStreamAfterQuery":            "AgentStreamAfterQuery",
+	"ControllersAgentStreamEventResponse":         "AgentStreamEventResponse",
+	"ControllersAgentStreamSourceResponse":        "AgentStreamSourceResponse",
+	"ControllersAgentStreamToolOutputResponse":    "AgentStreamToolOutputResponse",
+	"ControllersAgentStreamPlanEntryResponse":     "AgentStreamPlanEntryResponse",
+	"ControllersAgentStreamPermissionOptionResponse": "AgentStreamPermissionOptionResponse",
+	"ControllersAgentStreamPermissionRequestResponse": "AgentStreamPermissionRequestResponse",
 	"ControllersCleanupSkippedSession":            "CleanupSkippedSession",
 	"ControllersWorkspaceFileQuery":               "WorkspaceFileQuery",
 	"ControllersListWorkspaceFilesResponse":       "ListWorkspaceFilesResponse",
@@ -950,6 +957,19 @@ func sessionOperations() []operation {
 			resps: []respUnit{
 				{http.StatusOK, ""},
 				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+			contentTypes: map[int]string{http.StatusOK: "text/event-stream"},
+		},
+		{
+			method: http.MethodGet, path: "/api/v1/sessions/{sessionId}/agent-stream", id: "streamSessionAgentEvents", tag: "sessions",
+			summary:    "Stream sequenced provider-neutral agent events for a session (ACP output wire)",
+			pathParams: []any{controllers.SessionIDParam{}, controllers.AgentStreamAfterQuery{}},
+			resps: []respUnit{
+				// SSE data frames are AgentStreamEventResponse JSON (event: agent_stream).
+				{http.StatusOK, controllers.AgentStreamEventResponse{}},
+				{http.StatusBadRequest, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},
 				{http.StatusNotImplemented, envelope.APIError{}},
 			},

--- a/backend/internal/httpd/controllers/agentstream.go
+++ b/backend/internal/httpd/controllers/agentstream.go
@@ -1,0 +1,128 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/agentstream"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+)
+
+// AgentStream is the per-session sequenced stream fan-out used by SSE clients.
+// Implemented by agentstream.Hub.
+type AgentStream interface {
+	Subscribe(sessionID string, after int64) (replay []agentstream.Event, live <-chan agentstream.Event, unsubscribe func())
+}
+
+// AgentStreamController serves GET /sessions/{sessionId}/agent-stream.
+//
+// Clients reduce provider-neutral AgentStreamEvent values. They never speak
+// ACP. Sequence is monotonic per session; reconnect with ?after=<last seq>
+// (or Last-Event-ID) to skip already-applied events.
+type AgentStreamController struct {
+	Stream AgentStream
+}
+
+// RegisterStreams mounts the long-lived agent stream SSE route outside the
+// REST request timeout group.
+func (c *AgentStreamController) RegisterStreams(r chi.Router) {
+	r.Get("/sessions/{sessionId}/agent-stream", c.stream)
+}
+
+func (c *AgentStreamController) stream(w http.ResponseWriter, r *http.Request) {
+	if c.Stream == nil {
+		apispec.NotImplemented(w, r, "GET", "/api/v1/sessions/{sessionId}/agent-stream")
+		return
+	}
+
+	after, err := parseAgentStreamAfter(r)
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_AFTER",
+			"after must be an integer (use -1 to replay from the start)", nil)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "SSE_UNSUPPORTED",
+			"Streaming is not supported by this server", nil)
+		return
+	}
+
+	id := sessionID(r)
+	replay, live, unsub := c.Stream.Subscribe(string(id), after)
+	defer unsub()
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream; charset=utf-8")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	for _, ev := range replay {
+		if err := writeAgentStreamSSE(w, flusher, ev); err != nil {
+			return
+		}
+	}
+
+	keepAlive := time.NewTicker(15 * time.Second)
+	defer keepAlive.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case ev, ok := <-live:
+			if !ok {
+				return
+			}
+			if err := writeAgentStreamSSE(w, flusher, ev); err != nil {
+				return
+			}
+		case <-keepAlive.C:
+			if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func parseAgentStreamAfter(r *http.Request) (int64, error) {
+	raw := r.URL.Query().Get("after")
+	if raw == "" {
+		raw = r.Header.Get("Last-Event-ID")
+	}
+	if raw == "" {
+		// Default: replay the whole in-memory buffer, then live events.
+		// Reconnect clients should pass after=<last applied sequence> (or
+		// Last-Event-ID) so already-reduced events are not re-applied.
+		return -1, nil
+	}
+	seq, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return seq, nil
+}
+
+func writeAgentStreamSSE(w http.ResponseWriter, flusher http.Flusher, ev agentstream.Event) error {
+	// Wire as AgentStreamEventResponse so OpenAPI/TS types stay aligned.
+	payload := AgentStreamEventFromDomain(ev)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "id: %d\nevent: agent_stream\ndata: %s\n\n", ev.Sequence, data); err != nil {
+		return err
+	}
+	flusher.Flush()
+	return nil
+}

--- a/backend/internal/httpd/controllers/agentstream_test.go
+++ b/backend/internal/httpd/controllers/agentstream_test.go
@@ -1,0 +1,182 @@
+package controllers_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/agentstream"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
+)
+
+func TestAgentStreamSSEReplaysAndLives(t *testing.T) {
+	hub := agentstream.NewHub()
+	hub.ConfigureSession("sess-1", agentstream.Source{
+		Kind: agentstream.SourceKindNativeACPv1, Provider: "test",
+	})
+	hub.PublishBridge("sess-1", agentstream.BridgeEvent{Event: "delta", Text: "hello"})
+	hub.PublishACPSessionUpdate("sess-1", agentstream.ACPSessionUpdate{
+		SessionUpdate: "agent_thought_chunk",
+		Content:       map[string]any{"type": "text", "text": "think"},
+	})
+
+	c := &controllers.AgentStreamController{Stream: hub}
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(api chi.Router) {
+		c.RegisterStreams(api)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/sess-1/agent-stream?after=-1", nil)
+	// Cancel after we have read the buffered frames so the handler exits.
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.ServeHTTP(rec, req)
+	}()
+
+	// Wait for headers + body.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if rec.Code != 0 && rec.Body.Len() > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q", ct)
+	}
+
+	// Publish a live event.
+	hub.PublishBridge("sess-1", agentstream.BridgeEvent{Event: "done", StopReason: "end_turn"})
+
+	// Wait until we see done in the body.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(rec.Body.String(), `"type":"done"`) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	events := parseAgentStreamSSE(t, rec.Body.String())
+	if len(events) < 3 {
+		t.Fatalf("events = %d, want >= 3; body=%s", len(events), rec.Body.String())
+	}
+	if events[0].Type != "text_delta" || events[0].Delta != "hello" {
+		t.Fatalf("first = %+v", events[0])
+	}
+	if events[0].Sequence != 0 {
+		t.Fatalf("first sequence = %d", events[0].Sequence)
+	}
+	if events[1].Type != "thinking_update" {
+		t.Fatalf("second = %+v", events[1])
+	}
+	foundDone := false
+	for _, e := range events {
+		if e.Type == "done" {
+			foundDone = true
+			if !e.IsTerminalLike() {
+				// not on DTO; check type only
+			}
+		}
+	}
+	if !foundDone {
+		t.Fatalf("missing done event in %v", events)
+	}
+}
+
+func TestAgentStreamNilReturns501(t *testing.T) {
+	c := &controllers.AgentStreamController{Stream: nil}
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(api chi.Router) {
+		c.RegisterStreams(api)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/x/agent-stream", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentStreamAfterSkipsApplied(t *testing.T) {
+	hub := agentstream.NewHub()
+	hub.ConfigureSession("s", agentstream.Source{Kind: agentstream.SourceKindNativeACPv1})
+	hub.PublishBridge("s", agentstream.BridgeEvent{Event: "delta", Text: "a"})
+	hub.PublishBridge("s", agentstream.BridgeEvent{Event: "delta", Text: "b"})
+
+	c := &controllers.AgentStreamController{Stream: hub}
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(api chi.Router) {
+		c.RegisterStreams(api)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/s/agent-stream?after=0", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.ServeHTTP(rec, req)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(rec.Body.String(), `"delta":"b"`) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	events := parseAgentStreamSSE(t, rec.Body.String())
+	if len(events) != 1 || events[0].Delta != "b" || events[0].Sequence != 1 {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+type streamFrame struct {
+	Type     string `json:"type"`
+	Delta    string `json:"delta"`
+	Sequence int64  `json:"sequence"`
+}
+
+func (f streamFrame) IsTerminalLike() bool {
+	return f.Type == "done" || f.Type == "error" || f.Type == "cancelled"
+}
+
+func parseAgentStreamSSE(t *testing.T, body string) []streamFrame {
+	t.Helper()
+	var out []streamFrame
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		raw := strings.TrimPrefix(line, "data: ")
+		var f streamFrame
+		if err := json.Unmarshal([]byte(raw), &f); err != nil {
+			t.Fatalf("unmarshal %q: %v", raw, err)
+		}
+		out = append(out, f)
+	}
+	return out
+}

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/agentstream"
 	"github.com/aoagents/agent-orchestrator/backend/internal/devimport"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/legacyimport"
@@ -865,4 +866,137 @@ type UnregisterPushDeviceResponse struct {
 // cannot change what another session in the project runs.
 type TriggerReviewRequest struct {
 	Harness domain.ReviewerHarness `json:"harness,omitempty" enum:"claude-code,codex,opencode"`
+}
+
+// AgentStreamAfterQuery is the optional resume cursor for the agent stream SSE.
+type AgentStreamAfterQuery struct {
+	// After is the last applied sequence; only events with sequence > after are
+	// replayed. Omit (or pass -1) to replay the whole in-memory buffer.
+	After *int64 `query:"after,omitempty" description:"Last applied agent-stream sequence. Events with sequence greater than this are sent. Omit or -1 for the full buffer."`
+}
+
+// AgentStreamEventResponse is the provider-neutral agent stream event payload
+// on GET /sessions/{sessionId}/agent-stream (SSE event name: agent_stream).
+// Semantics match ABF AgentStreamEvent; the renderer never speaks ACP.
+type AgentStreamEventResponse struct {
+	Type      string `json:"type" enum:"text_delta,thinking_update,tool_call,tool_update,plan,status,permission_request,done,error,cancelled"`
+	SessionID string `json:"sessionId"`
+	// Sequence is monotonic per session (0-based). Duplicate sequences are ignored.
+	Sequence  int64                      `json:"sequence"`
+	Timestamp time.Time                  `json:"timestamp,omitempty"`
+	Source    *AgentStreamSourceResponse `json:"source,omitempty"`
+
+	ItemID string `json:"itemId,omitempty"`
+	Delta  string `json:"delta,omitempty"`
+	Text   string `json:"text,omitempty"`
+	Mode   string `json:"mode,omitempty" enum:"delta,replace"`
+
+	ToolCallID  string                         `json:"toolCallId,omitempty"`
+	Name        string                         `json:"name,omitempty"`
+	Title       string                         `json:"title,omitempty"`
+	Input       map[string]any                 `json:"input,omitempty"`
+	Status      string                         `json:"status,omitempty" enum:"pending,in_progress,completed,failed"`
+	ResultDelta string                         `json:"resultDelta,omitempty"`
+	Output      *AgentStreamToolOutputResponse `json:"output,omitempty"`
+	Error       string                         `json:"error,omitempty"`
+
+	PlanTitle string                         `json:"planTitle,omitempty"`
+	Entries   []AgentStreamPlanEntryResponse `json:"entries,omitempty"`
+
+	StreamStatus string `json:"streamStatus,omitempty" enum:"starting,running,waiting,idle"`
+	Message      string `json:"message,omitempty"`
+
+	Request *AgentStreamPermissionRequestResponse `json:"request,omitempty"`
+
+	StopReason string `json:"stopReason,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+// AgentStreamSourceResponse identifies which adapter produced an event.
+type AgentStreamSourceResponse struct {
+	Kind     string `json:"kind" enum:"native-acp-v1,legacy-adapter"`
+	Provider string `json:"provider,omitempty"`
+}
+
+// AgentStreamToolOutputResponse is optional structured tool result text.
+type AgentStreamToolOutputResponse struct {
+	Stream string `json:"stream" enum:"stdout,stderr"`
+	Text   string `json:"text"`
+}
+
+// AgentStreamPlanEntryResponse is one plan step.
+type AgentStreamPlanEntryResponse struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Status string `json:"status" enum:"pending,in_progress,completed,blocked"`
+}
+
+// AgentStreamPermissionOptionResponse is one permission choice.
+type AgentStreamPermissionOptionResponse struct {
+	OptionID string `json:"optionId"`
+	Label    string `json:"label"`
+	Kind     string `json:"kind" enum:"allow_once,allow_always,reject_once,reject_always"`
+}
+
+// AgentStreamPermissionRequestResponse is a structured permission prompt.
+type AgentStreamPermissionRequestResponse struct {
+	RequestID   string                                `json:"requestId"`
+	ToolCallID  string                                `json:"toolCallId,omitempty"`
+	Title       string                                `json:"title"`
+	Description string                                `json:"description,omitempty"`
+	Options     []AgentStreamPermissionOptionResponse `json:"options"`
+}
+
+// AgentStreamEventFromDomain maps an internal stream event to the wire DTO.
+func AgentStreamEventFromDomain(ev agentstream.Event) AgentStreamEventResponse {
+	out := AgentStreamEventResponse{
+		Type:         string(ev.Type),
+		SessionID:    ev.SessionID,
+		Sequence:     ev.Sequence,
+		Timestamp:    ev.Timestamp,
+		ItemID:       ev.ItemID,
+		Delta:        ev.Delta,
+		Text:         ev.Text,
+		Mode:         ev.Mode,
+		ToolCallID:   ev.ToolCallID,
+		Name:         ev.Name,
+		Title:        ev.Title,
+		Input:        ev.Input,
+		Status:       string(ev.Status),
+		ResultDelta:  ev.ResultDelta,
+		Error:        ev.Error,
+		PlanTitle:    ev.PlanTitle,
+		StreamStatus: string(ev.StreamStatus),
+		Message:      ev.Message,
+		StopReason:   ev.StopReason,
+		Reason:       ev.Reason,
+	}
+	if ev.Source != nil {
+		out.Source = &AgentStreamSourceResponse{Kind: ev.Source.Kind, Provider: ev.Source.Provider}
+	}
+	if ev.Output != nil {
+		out.Output = &AgentStreamToolOutputResponse{Stream: ev.Output.Stream, Text: ev.Output.Text}
+	}
+	if len(ev.Entries) > 0 {
+		out.Entries = make([]AgentStreamPlanEntryResponse, len(ev.Entries))
+		for i, e := range ev.Entries {
+			out.Entries[i] = AgentStreamPlanEntryResponse{ID: e.ID, Title: e.Title, Status: string(e.Status)}
+		}
+	}
+	if ev.Request != nil {
+		opts := make([]AgentStreamPermissionOptionResponse, len(ev.Request.Options))
+		for i, o := range ev.Request.Options {
+			opts[i] = AgentStreamPermissionOptionResponse{
+				OptionID: o.OptionID, Label: o.Label, Kind: string(o.Kind),
+			}
+		}
+		out.Request = &AgentStreamPermissionRequestResponse{
+			RequestID:   ev.Request.RequestID,
+			ToolCallID:  ev.Request.ToolCallID,
+			Title:       ev.Request.Title,
+			Description: ev.Request.Description,
+			Options:     opts,
+		}
+	}
+	return out
 }

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -504,6 +504,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sessions/{sessionId}/agent-stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Stream sequenced provider-neutral agent events for a session (ACP output wire) */
+        get: operations["streamSessionAgentEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/sessions/{sessionId}/kill": {
         parameters: {
             query?: never;
@@ -916,6 +933,69 @@ export interface components {
             authStatus?: "authorized" | "unauthorized" | "unknown";
             id: string;
             label: string;
+        };
+        AgentStreamEventResponse: {
+            delta?: string;
+            entries?: components["schemas"]["AgentStreamPlanEntryResponse"][];
+            error?: string;
+            input?: {
+                [key: string]: unknown;
+            };
+            itemId?: string;
+            message?: string;
+            /** @enum {string} */
+            mode?: "delta" | "replace";
+            name?: string;
+            output?: components["schemas"]["AgentStreamToolOutputResponse"];
+            planTitle?: string;
+            reason?: string;
+            request?: components["schemas"]["AgentStreamPermissionRequestResponse"];
+            resultDelta?: string;
+            /** Format: int64 */
+            sequence: number;
+            sessionId: string;
+            source?: components["schemas"]["AgentStreamSourceResponse"];
+            /** @enum {string} */
+            status?: "pending" | "in_progress" | "completed" | "failed";
+            stopReason?: string;
+            /** @enum {string} */
+            streamStatus?: "starting" | "running" | "waiting" | "idle";
+            text?: string;
+            /** Format: date-time */
+            timestamp?: string;
+            title?: string;
+            toolCallId?: string;
+            /** @enum {string} */
+            type: "text_delta" | "thinking_update" | "tool_call" | "tool_update" | "plan" | "status" | "permission_request" | "done" | "error" | "cancelled";
+        };
+        AgentStreamPermissionOptionResponse: {
+            /** @enum {string} */
+            kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+            label: string;
+            optionId: string;
+        };
+        AgentStreamPermissionRequestResponse: {
+            description?: string;
+            options: components["schemas"]["AgentStreamPermissionOptionResponse"][];
+            requestId: string;
+            title: string;
+            toolCallId?: string;
+        };
+        AgentStreamPlanEntryResponse: {
+            id: string;
+            /** @enum {string} */
+            status: "pending" | "in_progress" | "completed" | "blocked";
+            title: string;
+        };
+        AgentStreamSourceResponse: {
+            /** @enum {string} */
+            kind: "native-acp-v1" | "legacy-adapter";
+            provider?: string;
+        };
+        AgentStreamToolOutputResponse: {
+            /** @enum {string} */
+            stream: "stdout" | "stderr";
+            text: string;
         };
         BrowserCommandRequest: {
             action: string;
@@ -3362,6 +3442,59 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    streamSessionAgentEvents: {
+        parameters: {
+            query?: {
+                /** @description Last applied agent-stream sequence. Events with sequence greater than this are sent. Omit or -1 for the full buffer. */
+                after?: null | number;
+            };
+            header?: never;
+            path: {
+                /** @description Session identifier, e.g. project-1. */
+                sessionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": components["schemas"]["AgentStreamEventResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Summary

Ports the **AllBeingsFuture ACP streaming output contract** into the AO daemon as a provider-neutral wire, without a full chat-stack port.

- **Canonical stream events** matching ABF `AgentStreamEvent` (`text_delta`, `thinking_update`, `tool_call`, `tool_update`, `plan`, `status`, `permission_request`, `done`, `error`, `cancelled`)
- **Normalizer** (`BridgeEvent` → sequenced events), modeled on ABF `agent-stream-normalizer` tests
- **ACP v1 mapper** for `session/update` chunks → bridge events (SDK-free; ready for `acp-go-sdk` producers)
- **Hub** with monotonic per-session sequence + short replay buffer
- **SSE path:** `GET /api/v1/sessions/{sessionId}/agent-stream?after=<seq>`
  - event name: `agent_stream`
  - `id:` = sequence
  - `data:` = `AgentStreamEventResponse` JSON
- Daemon wires `agentstream.NewHub()` into `APIDeps.AgentStream`
- OpenAPI + `frontend/src/api/schema.ts` regenerated

Intentionally **out of scope** (for follow-up workers): full fenzhi chat/service storage, multi-provider chat drivers, permission-respond HTTP, durable conversation projection.

## Frontend contract

1. Subscribe: `GET /api/v1/sessions/{sessionId}/agent-stream` (or `?after=-1` for full buffer; reconnect with `after=<lastSequence>` / `Last-Event-ID`)
2. Reduce only `AgentStreamEventResponse` types; never import ACP SDK
3. Terminal types (`done` / `error` / `cancelled`) flush the turn
4. Producers call hub `PublishBridge` / `PublishACPSessionUpdate` when ACP drivers land

## Tests

```bash
cd backend && go test ./internal/agentstream/ ./internal/httpd/controllers/ ./internal/httpd/...
```

All green locally.

## Test plan

- [x] Unit tests for normalizer (ABF-modeled sequences, tool diffs, permission drop, status map)
- [x] Unit tests for ACP session/update mapping
- [x] Hub subscribe/replay
- [x] SSE controller replay + live + after cursor + 501 when unwired
- [ ] Frontend consumes SSE and reduces events (next worker)
- [ ] ACP driver process publishes into hub (next backend worker)