### PR TITLE
fix: cancel OpenCode reviews without interrupt

### DIFF
--- a/backend/internal/adapters/reviewer/opencode/opencode.go
+++ b/backend/internal/adapters/reviewer/opencode/opencode.go
@@ -99,7 +99,12 @@ func (r *Reviewer) ReviewMessage(_ context.Context, inv ports.ReviewInvocation) 
 }
 
 // ReviewCancel stops the active OpenCode reviewer turn while preserving the
-// terminal pane for inspection.
+// terminal pane for inspection. OpenCode can treat Ctrl-C as a TUI exit in
+// common states, so cancellation is an in-band steering message instead of an
+// interrupt.
 func (r *Reviewer) ReviewCancel(context.Context) (ports.ReviewCancelSpec, error) {
-	return ports.ReviewCancelSpec{Mode: ports.ReviewCancelInterrupt, Interrupts: 2}, nil
+	return ports.ReviewCancelSpec{
+		Mode:    ports.ReviewCancelMessage,
+		Message: "Stop the current review task immediately. Do not submit or post any review result for that cancelled task. Wait for AO to send the next review task.",
+	}, nil
 }

--- a/backend/internal/adapters/reviewer/opencode/opencode_test.go
+++ b/backend/internal/adapters/reviewer/opencode/opencode_test.go
@@ -226,6 +226,24 @@ func TestReviewMessageReturnsTaskPrompt(t *testing.T) {
 	}
 }
 
+func TestReviewCancelUsesMessageMode(t *testing.T) {
+	spec, err := (&Reviewer{}).ReviewCancel(context.Background())
+	if err != nil {
+		t.Fatalf("ReviewCancel: %v", err)
+	}
+	if spec.Mode != ports.ReviewCancelMessage {
+		t.Fatalf("cancel mode = %q, want %q", spec.Mode, ports.ReviewCancelMessage)
+	}
+	if spec.Interrupts != 0 {
+		t.Fatalf("interrupts = %d, want 0", spec.Interrupts)
+	}
+	for _, want := range []string{"Stop the current review task", "Do not submit", "Wait for AO"} {
+		if !strings.Contains(spec.Message, want) {
+			t.Fatalf("cancel message %q missing %q", spec.Message, want)
+		}
+	}
+}
+
 func reviewerConfigBashPolicy(t *testing.T) map[string]string {
 	t.Helper()
 	configText, err := buildReviewerConfig("")

--- a/backend/internal/adapters/reviewer/registry_test.go
+++ b/backend/internal/adapters/reviewer/registry_test.go
@@ -26,10 +26,20 @@ func TestRegistryMatchesDomainVocabulary(t *testing.T) {
 			t.Errorf("reviewer harness %q does not implement cancellation", h)
 		} else if spec, err := canceller.ReviewCancel(context.Background()); err != nil {
 			t.Errorf("reviewer harness %q cancel spec: %v", h, err)
-		} else if spec.Mode != ports.ReviewCancelInterrupt {
-			t.Errorf("reviewer harness %q cancel mode = %q, want %q", h, spec.Mode, ports.ReviewCancelInterrupt)
-		} else if spec.Interrupts != 2 {
-			t.Errorf("reviewer harness %q cancel interrupts = %d, want 2", h, spec.Interrupts)
+		} else if h == domain.ReviewerOpenCode {
+			if spec.Mode != ports.ReviewCancelMessage {
+				t.Errorf("reviewer harness %q cancel mode = %q, want %q", h, spec.Mode, ports.ReviewCancelMessage)
+			}
+			if spec.Message == "" {
+				t.Errorf("reviewer harness %q cancel message is empty", h)
+			}
+		} else {
+			if spec.Mode != ports.ReviewCancelInterrupt {
+				t.Errorf("reviewer harness %q cancel mode = %q, want %q", h, spec.Mode, ports.ReviewCancelInterrupt)
+			}
+			if spec.Interrupts != 2 {
+				t.Errorf("reviewer harness %q cancel interrupts = %d, want 2", h, spec.Interrupts)
+			}
 		}
 		registered[h] = true
 	}

--- a/backend/internal/ports/reviewer.go
+++ b/backend/internal/ports/reviewer.go
@@ -28,6 +28,10 @@ const (
 	// ReviewCancelInterrupt sends the terminal interrupt key sequence to the
 	// reviewer process while preserving the terminal pane.
 	ReviewCancelInterrupt ReviewCancelMode = "interrupt"
+	// ReviewCancelMessage sends an in-band message to the reviewer process. Use
+	// this for harnesses where Ctrl-C exits the TUI instead of cancelling only
+	// the active turn.
+	ReviewCancelMessage ReviewCancelMode = "message"
 )
 
 // ReviewCancelSpec is the adapter-selected cancellation behavior for a running
@@ -35,6 +39,7 @@ const (
 type ReviewCancelSpec struct {
 	Mode       ReviewCancelMode
 	Interrupts int
+	Message    string
 }
 
 // ReviewerCanceller is implemented by reviewer adapters that explicitly define

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -277,6 +277,12 @@ func (l *agentLauncher) Cancel(ctx context.Context, handleID string, harness dom
 		return fmt.Errorf("reviewer cancel: %w", err)
 	}
 	switch spec.Mode {
+	case ports.ReviewCancelMessage:
+		message := strings.TrimSpace(spec.Message)
+		if message == "" {
+			return fmt.Errorf("reviewer adapter %q returned empty cancel message", harness)
+		}
+		return l.runtime.SendMessage(ctx, ports.RuntimeHandle{ID: handleID}, message)
 	case ports.ReviewCancelInterrupt:
 		interrupts := spec.Interrupts
 		if interrupts <= 0 {

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -43,6 +43,7 @@ type fakeCancellableReviewer struct {
 	cancelErr  error
 	mode       ports.ReviewCancelMode
 	interrupts int
+	message    string
 }
 
 func (f *fakeCancellableReviewer) ReviewCancel(context.Context) (ports.ReviewCancelSpec, error) {
@@ -54,7 +55,7 @@ func (f *fakeCancellableReviewer) ReviewCancel(context.Context) (ports.ReviewCan
 	if mode == "" {
 		mode = ports.ReviewCancelInterrupt
 	}
-	return ports.ReviewCancelSpec{Mode: mode, Interrupts: f.interrupts}, nil
+	return ports.ReviewCancelSpec{Mode: mode, Interrupts: f.interrupts, Message: f.message}, nil
 }
 
 type fakeReviewerForPreflight struct {
@@ -303,6 +304,28 @@ func TestLauncherCancelUsesReviewerCancelMode(t *testing.T) {
 	}
 	if rt.interrupts != 2 {
 		t.Fatalf("interrupt count = %d, want 2", rt.interrupts)
+	}
+}
+
+func TestLauncherCancelMessageSendsMessageWithoutInterrupt(t *testing.T) {
+	reviewer := &fakeCancellableReviewer{
+		mode:    ports.ReviewCancelMessage,
+		message: "stop this review and wait",
+	}
+	rt := &fakeRuntime{}
+	l := newTestLauncher(t, reviewer, rt)
+
+	if err := l.Cancel(context.Background(), "review-mer-1", domain.ReviewerOpenCode); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if !reviewer.cancelled {
+		t.Fatal("expected reviewer cancel hook to run")
+	}
+	if rt.sentTo != "review-mer-1" || rt.sentMsg != reviewer.message {
+		t.Fatalf("sent to %q msg %q, want review-mer-1 %q", rt.sentTo, rt.sentMsg, reviewer.message)
+	}
+	if rt.interrupts != 0 {
+		t.Fatalf("interrupt count = %d, want 0", rt.interrupts)
 	}
 }
 


### PR DESCRIPTION
Closes #3517

## Summary
- adds a reviewer cancel message mode alongside terminal interrupts
- wires reviewer cancellation messages through the existing reviewer pane SendMessage path
- switches OpenCode reviewer cancellation to an in-band stop instruction so Ctrl-C does not exit the TUI
- adds launcher, registry, and OpenCode adapter tests for message-based cancellation

## Tests
- `cd backend && go test ./internal/review ./internal/adapters/reviewer/... ./internal/ports`
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs ./internal/review ./internal/adapters/reviewer/... ./internal/ports`

## Notes
- `npm run lint` currently fails before golangci-lint in unrelated existing tests: kilocode/opencode auth timeout tests, CLI hook launch-id expectations, and spawn/project context tests. The touched backend packages pass separately.