### PR TITLE
fix: use primary footer styles on report problem button

### DIFF
--- a/frontend/src/renderer/components/settings/ReportProblemDialog.test.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemDialog.test.tsx
@@ -33,5 +33,7 @@ describe("ReportProblemDialog", () => {
 		fireEvent.change(summaryInput, { target: { value: "Test Summary" } });
 		fireEvent.change(detailsInput, { target: { value: "Test Details" } });
 		expect(submitButton).toBeEnabled();
+		expect(submitButton).toHaveClass("settings-footer-button", "settings-footer-button-primary");
+		expect(submitButton.className).not.toMatch(/\btext-white\b/);
 	});
 });

--- a/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
@@ -243,11 +243,11 @@ export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogP
 					</DialogClose>
 					<button
 						type="button"
-						className="settings-footer-button border-transparent bg-settings-accent text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+						className="settings-footer-button settings-footer-button-primary"
 						disabled={!canSubmit}
 						onClick={() => {
 							if (!canSubmit) return;
-							void copyDraft()
+							void copyDraft();
 						}}
 					>
 						{destination.action}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -741,13 +741,12 @@ button.settings-row-bar {
 	transition-property: opacity;
 	transition-duration: var(--duration-normal);
 
-	&:hover {
+	&:hover:not(:disabled) {
 		opacity: 0.9;
 	}
 
 	&:disabled {
 		cursor: not-allowed;
-		opacity: 0.5;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Switch Report a problem primary action to `settings-footer-button-primary` (same tokens as Save changes) so text uses `--primary-foreground` instead of hardcoded white.
- Drop disabled `opacity: 0.5` on primary footer buttons so the white primary bg stays white instead of washing out to gray.
- Assert the report dialog primary button uses the design-system classes.

Fixes #3577

## Test plan
- [ ] Open Settings → Report a problem (dark mode)
- [ ] Confirm "Copy & Create …" matches Save changes: light primary bg + dark text, readable when disabled
- [ ] Fill title + details → button enables and submit still works
- [ ] Confirm Cancel still looks correct beside it

## Before
<img width="736" height="593" alt="image" src="https://github.com/user-attachments/assets/61f0e3aa-e9d1-484a-8704-7063784ed76b" />

## After
<img width="774" height="585" alt="image" src="https://github.com/user-attachments/assets/564b72ab-e536-4491-a150-f335bfe49da1" />
