### PR TITLE
fix: tighten settings option menu width

### DIFF
--- a/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
+++ b/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
@@ -67,7 +67,7 @@ export function SettingsOptionMenu<T extends string>({
 			<DropdownMenuContent
 				align={menuAlign}
 				className={cn(
-					"settings-menu-surface overflow-y-auto! overflow-x-hidden! max-h-select-menu-max! rounded-(--radius-settings-panel) border-settings-menu bg-settings-menu",
+					"settings-menu-surface min-w-[length:var(--size-settings-menu-min-width)] overflow-y-auto! overflow-x-hidden! max-h-select-menu-max! rounded-(--radius-settings-panel) border-settings-menu bg-settings-menu",
 					menuClassName,
 				)}
 			>

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -600,7 +600,8 @@ button.settings-row-bar {
 
 @utility settings-menu-surface {
 	display: flex;
-	width: min(var(--size-settings-menu-width), calc(100vw - 2rem));
+	width: max-content;
+	max-width: min(var(--size-settings-menu-width), calc(100vw - 2rem));
 	min-width: var(--size-settings-menu-min-width);
 	max-height: var(--size-select-menu-max);
 	flex-direction: column;
@@ -616,6 +617,7 @@ button.settings-row-bar {
 }
 
 @utility settings-agent-menu-surface {
+	width: var(--size-settings-agent-menu-min-width);
 	min-width: var(--size-settings-agent-menu-min-width);
 	padding: var(--space-3);
 	gap: var(--space-2);

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -314,8 +314,8 @@
 	--size-notification-width: 460px;
 	--size-notification-max-height: 420px;
 	--size-select-menu-max: 320px; /* agent/select dropdown scroll cap (was max-h-80) */
-	--size-settings-menu-width: 18rem; /* settings option menus — max width cap */
-	--size-settings-agent-menu-min-width: 20rem; /* agent harness picker — wider rows */
+	--size-settings-menu-width: 20rem; /* settings option menus — matches agent picker box width */
+	--size-settings-agent-menu-min-width: 20rem; /* agent harness picker — fixed width for status columns */
 	--size-notification-icon: 26px;
 	--size-session-topbar: calc(var(--size-inspector-tabs) + (2 * var(--space-1)));
 	/* DaemonFailureBanner floating toast (was w-[min(22rem,…)] / max-h-40). */
@@ -431,7 +431,7 @@
 	--size-settings-section-inner-gap: 12px;
 	--size-settings-row-padding: 16px;
 	--size-settings-row-icon-gap: 12px;
-	--size-settings-menu-min-width: 11rem;
+	--size-settings-menu-min-width: 9rem;
 	--size-settings-inline-input-min: 3.5rem;
 	--size-settings-inline-input-max: 12rem;
 	--size-settings-inline-input-max-percent: 42%;


### PR DESCRIPTION
## Summary
- Simple settings menus (theme, language, auto-updates, release channel) hug their content instead of forcing an 18rem box.
- Project agent pickers keep a fixed 20rem width so status columns still lay out correctly.
- Lower the simple-menu min-width floor and cap growth with the existing max-width token.

## Test plan
- [ ] Settings → General: open Theme and Language menus — width follows longest label, no large empty side gap
- [ ] Settings → Updates: open Enabled/Disabled and Stable/Nightly — same tighter sizing
- [ ] Project → Agents: open Default worker / orchestrator agent pickers — still ~20rem with status labels aligned
- [ ] Confirm short menus (Theme, Enabled) are not oversized; long labels (Português (Brasil), Nightly) are not clipped

## Before
<img width="504" height="289" alt="image" src="https://github.com/user-attachments/assets/2ebb8236-9726-472f-89cc-2c139650a309" />
<img width="366" height="489" alt="image" src="https://github.com/user-attachments/assets/3ee18b0a-36a9-4c4e-8683-7c2670e14c13" />
<img width="633" height="301" alt="image" src="https://github.com/user-attachments/assets/096bf51f-db01-4bdf-83f3-054ed0f92d30" />
<img width="485" height="203" alt="image" src="https://github.com/user-attachments/assets/94137618-161f-4fd9-b589-6621a1cc200f" />

## After
<img width="265" height="234" alt="image" src="https://github.com/user-attachments/assets/4e2a00ba-7f08-478c-9887-10d8086187af" />
<img width="301" height="388" alt="image" src="https://github.com/user-attachments/assets/43479191-631e-4837-85e6-9f5f9426a053" />
<img width="278" height="196" alt="image" src="https://github.com/user-attachments/assets/f343861b-9c44-4f86-a0d7-d810e862c390" />
<img width="234" height="150" alt="image" src="https://github.com/user-attachments/assets/4404b7c0-2934-484a-8245-f38569f07b66" />
