### PR TITLE
fix: polish import mode picker illustration styling

### DIFF
--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -419,18 +419,15 @@ function ProjectModeButton({
 					)}
 				>
 					{isWorkspace ? (
-						<span className="flex h-(--size-import-mode-illustration) w-full max-w-[240px] flex-col items-start gap-3 rounded-lg border border-dashed border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-illustration)] p-4">
+						<span className="flex h-(--size-import-mode-illustration) w-full max-w-[240px] flex-col items-start gap-3 rounded-lg border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-illustration)] p-4">
 							<span className="flex items-center gap-2 text-[14px] leading-5 text-[var(--color-text-import-muted)]">
 								<Folder className="size-[14px] shrink-0" aria-hidden="true" />
 								my-workspace/
 							</span>
 							<span className="flex w-full flex-col items-start gap-2">
 								{["web-app", "api-server", "shared-libs"].map((repo) => (
-									<span
-										key={repo}
-										className="flex w-full items-center rounded bg-[var(--color-bg-import-chip)] px-3 py-2"
-									>
-										<span className="mr-2 size-2 shrink-0 rounded-full bg-accent" aria-hidden="true" />
+									<span key={repo} className="flex w-full items-center px-3 py-2">
+										<span className="mr-2 size-2 shrink-0 rounded-full bg-accent-strong" aria-hidden="true" />
 										<span className="text-[12px] font-bold leading-4 text-[var(--color-text-import-title)]">
 											{repo}
 										</span>
@@ -440,9 +437,9 @@ function ProjectModeButton({
 						</span>
 					) : (
 						<span className="flex h-[50px] w-fit items-center rounded-lg border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-chip)] px-4 py-3">
-							<span className="mr-2 size-2 shrink-0 rounded-full bg-accent" aria-hidden="true" />
+							<span className="mr-2 size-2 shrink-0 rounded-full bg-accent-strong" aria-hidden="true" />
 							<span className="text-[14px] font-bold leading-5 text-[var(--color-text-import-title)]">web-app</span>
-							<span className="px-1 text-[16px] leading-6 text-[var(--color-text-import-sep)]" aria-hidden="true">
+							<span className="px-1 text-[16px] leading-6 text-[var(--color-text-import-muted)]" aria-hidden="true">
 								·
 							</span>
 							<span className="text-[14px] font-normal leading-5 text-[var(--color-text-import-muted)]">main</span>

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -391,13 +391,13 @@
 	--radius-welcome-panel: var(--radius-center-panel);
 
 	/* Import mode picker */
-	--color-bg-import-modal: var(--popover);
+	--color-bg-import-modal: var(--card);
 	--color-border-import-modal: var(--border);
 	--color-text-import-title: var(--foreground);
 	--color-text-import-muted: var(--muted-foreground);
-	--color-bg-import-card: var(--card);
+	--color-bg-import-card: var(--popover);
 	--color-bg-import-card-hover: var(--accent);
-	--color-bg-import-illustration: var(--color-bg-import-modal);
+	--color-bg-import-illustration: var(--color-bg-import-chip);
 	--color-bg-import-chip: var(--secondary);
 	--shadow-import-modal: 0 0 0 1px var(--border), var(--elevation-md);
 	--size-import-modal-max: 896px;
@@ -450,7 +450,7 @@
 	--color-border-settings-input: var(--color-border-settings-dialog);
 	--color-text-settings-input: var(--foreground);
 	--color-text-settings-placeholder: var(--muted-foreground);
-	--color-text-import-sep: var(--color-text-settings-placeholder);
+	--color-text-import-sep: var(--color-text-import-muted);
 	--color-settings-accent: var(--primary);
 	--color-settings-switch-on: var(--primary);
 
@@ -732,6 +732,7 @@
 	--color-text-import-muted: var(--muted-foreground);
 	--color-bg-import-card: var(--card);
 	--color-bg-import-card-hover: var(--accent);
+	--color-bg-import-illustration: var(--color-bg-import-chip);
 	--color-bg-import-chip: var(--secondary);
 	--shadow-import-modal: 0 0 0 1px var(--border), var(--elevation-md);
 


### PR DESCRIPTION
## Summary
- Align workspace and project preview chrome (shared chip bg + solid border; drop dashed outline).
- Remove nested repo-row chip fills so list items sit on the preview surface.
- Use `accent-strong` dots and muted separator text so markers stay readable on dark surfaces.
- Retune import modal/card tokens and keep illustration tied to the chip surface token.

## Test plan
- [ ] Open Import to Agent Orchestrator
- [ ] Workspace preview: solid border, same bg as project pill, no dashed outline, no nested gray row chips
- [ ] Dots on workspace repos + project pill are clearly visible
- [ ] Project pill `·` separator is readable
- [ ] Hover/click Workspace and Project still works; folder flow unchanged
- [ ] Spot-check light theme import dialog surfaces

## Before
<img width="1022" height="607" alt="image" src="https://github.com/user-attachments/assets/ed1c6899-dbc1-4cab-89c3-3c5da7a8892a" />

## After
<img width="1028" height="644" alt="image" src="https://github.com/user-attachments/assets/2149e3cf-6a0b-450f-bee6-75a1460992ed" />
