### PR TITLE
feat(themes): add themes

### DIFF
--- a/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -1,12 +1,24 @@
 import { Languages, Monitor, Moon, Palette, Smartphone, Sun } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import type { ThemePreference } from "../../lib/theme";
+import type { ThemePreference, ThemeStyle } from "../../lib/theme";
 import type { AppLocale } from "../../i18n";
 import { useLocaleStore } from "../../stores/locale-store";
 import { useUiStore } from "../../stores/ui-store";
 import { SettingsOptionMenu, type SettingsOption } from "./SettingsOptionMenu";
 import { SettingsLinkRow, SettingsRow } from "./SettingsRow";
 import { SettingsSection } from "./SettingsSection";
+
+const COLOR_THEME_OPTIONS = [
+	{ value: "orchestrate", label: "Orchestrate" },
+	{ value: "github", label: "GitHub" },
+	{ value: "catppuccin", label: "Catppuccin" },
+	{ value: "dracula", label: "Dracula" },
+	{ value: "tokyo-night", label: "Tokyo Night" },
+	{ value: "rose-pine", label: "Rosé Pine" },
+	{ value: "nord", label: "Nord" },
+	{ value: "gruvbox", label: "Gruvbox" },
+	{ value: "solarized", label: "Solarized" },
+] satisfies SettingsOption<ThemeStyle>[];
 
 export function GeneralSettingsSection({
 	onConnectMobile,
@@ -18,6 +30,8 @@ export function GeneralSettingsSection({
 	const { t } = useTranslation();
 	const themePreference = useUiStore((state) => state.themePreference);
 	const setThemePreference = useUiStore((state) => state.setThemePreference);
+	const themeStyle = useUiStore((state) => state.themeStyle);
+	const setThemeStyle = useUiStore((state) => state.setThemeStyle);
 	const locale = useLocaleStore((state) => state.locale);
 	const setLocale = useLocaleStore((state) => state.setLocale);
 	const localeSaving = useLocaleStore((state) => state.saving);
@@ -46,7 +60,15 @@ export function GeneralSettingsSection({
 
 	return (
 		<SettingsSection title={t("settings.general")} titleHidden={titleHidden}>
-			<SettingsRow icon={Palette} label={t("settings.theme")}>
+			<SettingsRow icon={Palette} label={t("settings.colorTheme")}>
+				<SettingsOptionMenu
+					aria-label={t("settings.colorTheme")}
+					value={themeStyle}
+					options={COLOR_THEME_OPTIONS}
+					onChange={setThemeStyle}
+				/>
+			</SettingsRow>
+			<SettingsRow icon={Moon} label={t("settings.theme")}>
 				<SettingsOptionMenu
 					aria-label={t("settings.theme")}
 					value={themePreference}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -507,6 +507,7 @@
 	"settings.project.workspaceRepos": "Workspace-Repos",
 	"settings.project.worktrees": "Worktrees",
 	"settings.reportProblem": "Problem melden",
+	"settings.colorTheme": "Farbthema",
 	"settings.theme": "Design",
 	"settings.theme.dark": "Dunkel",
 	"settings.theme.light": "Hell",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -495,6 +495,7 @@
 	"settings.project.workflow": "Workflow",
 	"settings.project.intake": "Intake",
 	"settings.reportProblem": "Report a problem",
+	"settings.colorTheme": "Color Theme",
 	"settings.theme": "Theme",
 	"settings.theme.dark": "Dark",
 	"settings.theme.light": "Light",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -516,6 +516,7 @@
 	"settings.project.workspaceRepos": "Repos del espacio de trabajo",
 	"settings.project.worktrees": "Worktrees",
 	"settings.reportProblem": "Informar de un problema",
+	"settings.colorTheme": "Tema de color",
 	"settings.theme": "Tema",
 	"settings.theme.dark": "Oscuro",
 	"settings.theme.light": "Claro",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -516,6 +516,7 @@
 	"settings.project.workspaceRepos": "Dépôts de l'espace de travail",
 	"settings.project.worktrees": "Worktrees",
 	"settings.reportProblem": "Signaler un problème",
+	"settings.colorTheme": "Thème de couleur",
 	"settings.theme": "Thème",
 	"settings.theme.dark": "Sombre",
 	"settings.theme.light": "Clair",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -507,6 +507,7 @@
 	"settings.project.workspaceRepos": "ワークスペースのリポジトリ",
 	"settings.project.worktrees": "ワークツリー",
 	"settings.reportProblem": "問題を報告",
+	"settings.colorTheme": "カラーテーマ",
 	"settings.theme": "テーマ",
 	"settings.theme.dark": "ダーク",
 	"settings.theme.light": "ライト",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -507,6 +507,7 @@
 	"settings.project.workspaceRepos": "워크스페이스 저장소",
 	"settings.project.worktrees": "워크트리",
 	"settings.reportProblem": "문제 보고",
+	"settings.colorTheme": "색상 테마",
 	"settings.theme": "테마",
 	"settings.theme.dark": "다크",
 	"settings.theme.light": "라이트",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -516,6 +516,7 @@
 	"settings.project.workspaceRepos": "Repos do workspace",
 	"settings.project.worktrees": "Worktrees",
 	"settings.reportProblem": "Relatar um problema",
+	"settings.colorTheme": "Tema de cor",
 	"settings.theme": "Tema",
 	"settings.theme.dark": "Escuro",
 	"settings.theme.light": "Claro",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -491,6 +491,7 @@
 	"settings.project.workflow": "工作流",
 	"settings.project.intake": "任务接收",
 	"settings.reportProblem": "报告问题",
+	"settings.colorTheme": "颜色主题",
 	"settings.theme": "主题",
 	"settings.theme.dark": "深色",
 	"settings.theme.light": "浅色",

--- a/frontend/src/renderer/lib/apply-initial-theme.ts
+++ b/frontend/src/renderer/lib/apply-initial-theme.ts
@@ -1,5 +1,6 @@
-import { applyDocumentTheme, resolveTheme } from "./theme";
+import { applyDocumentTheme, applyDocumentThemeStyle, readStoredThemeStyle, resolveTheme } from "./theme";
 
-// Runs as the first main.tsx import, before styles.css, so data-theme is set
-// before token CSS paints (avoids a light/dark flash on load).
+// Runs as the first main.tsx import, before styles.css, so data-theme and
+// data-style-theme are set before token CSS paints (avoids a flash on load).
 applyDocumentTheme(resolveTheme());
+applyDocumentThemeStyle(readStoredThemeStyle());

--- a/frontend/src/renderer/lib/theme.ts
+++ b/frontend/src/renderer/lib/theme.ts
@@ -1,7 +1,16 @@
 export type Theme = "light" | "dark";
 export type ThemePreference = Theme | "system";
 
-export type ThemeStyle = "orchestrate" | "github" | "catppuccin" | "dracula" | "tokyo-night" | "rose-pine";
+export type ThemeStyle =
+	| "orchestrate"
+	| "github"
+	| "catppuccin"
+	| "dracula"
+	| "tokyo-night"
+	| "rose-pine"
+	| "nord"
+	| "gruvbox"
+	| "solarized";
 
 export const themeStorageKey = "ao.theme";
 export const themeStyleStorageKey = "ao.theme-style";
@@ -41,7 +50,10 @@ export function readStoredThemeStyle(): ThemeStyle {
 			stored === "catppuccin" ||
 			stored === "dracula" ||
 			stored === "tokyo-night" ||
-			stored === "rose-pine"
+			stored === "rose-pine" ||
+			stored === "nord" ||
+			stored === "gruvbox" ||
+			stored === "solarized"
 		) {
 			return stored;
 		}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -29,7 +29,7 @@ import { addRendererExceptionStep, captureRendererEvent, captureRendererExceptio
 import { ShellProvider } from "../lib/shell-context";
 import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { captureOrchestratorReplacementFailure } from "../lib/orchestrator-replacement-telemetry";
-import { applyDocumentTheme } from "../lib/theme";
+import { applyDocumentTheme, applyDocumentThemeStyle } from "../lib/theme";
 import { aoBridge } from "../lib/bridge";
 import { handleModifierLinkClick } from "../lib/external-link-policy";
 import { cn } from "../lib/utils";
@@ -95,7 +95,7 @@ function ShellLayout() {
 	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
 	const workspaceStartupBaselineRef = useRef(0);
 	const agentCatalogPortRef = useRef<number | undefined>(undefined);
-	const { themePreference, resolvedTheme, isSidebarOpen, toggleSidebar } = useUiStore();
+	const { themePreference, resolvedTheme, themeStyle, isSidebarOpen, toggleSidebar } = useUiStore();
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const requestCreateProject = useUiStore((state) => state.requestCreateProject);
@@ -378,6 +378,10 @@ function ShellLayout() {
 	useEffect(() => {
 		applyDocumentTheme(resolvedTheme);
 	}, [resolvedTheme]);
+
+	useEffect(() => {
+		applyDocumentThemeStyle(themeStyle);
+	}, [themeStyle]);
 
 	// A daemon port is not enough to render a trustworthy empty state: the
 	// route loader may have cached [] before Electron reported the port. Fetch

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -2,15 +2,18 @@ import { create } from "zustand";
 import type { TerminalTarget } from "../types/terminal";
 import {
 	readStoredThemePreference,
+	readStoredThemeStyle,
 	resolveTheme,
 	systemTheme,
 	themeStorageKey,
+	themeStyleStorageKey,
 	type Theme,
 	type ThemePreference,
+	type ThemeStyle,
 } from "../lib/theme";
 
-export type { Theme, ThemePreference } from "../lib/theme";
-export { readStoredThemePreference, resolveTheme } from "../lib/theme";
+export type { Theme, ThemePreference, ThemeStyle } from "../lib/theme";
+export { readStoredThemePreference, readStoredThemeStyle, resolveTheme } from "../lib/theme";
 
 export type SettingsModal =
 	| { scope: "global" }
@@ -53,6 +56,8 @@ type UiState = {
 	themePreference: ThemePreference;
 	/** Resolved light/dark for React consumers; may track OS while preference is system. */
 	resolvedTheme: Theme;
+	/** Named color style theme (e.g. "catppuccin", "nord") — independent of light/dark mode. */
+	themeStyle: ThemeStyle;
 	/** When true, developer-only surfaces (e.g. Feature Releases) are revealed. Default off. */
 	developerMode: boolean;
 	restartingProjectIds: ReadonlySet<string>;
@@ -86,6 +91,7 @@ type UiState = {
 	devSettings: DevSettings;
 	setWorkbenchTab: (tab: WorkbenchTab) => void;
 	setThemePreference: (theme: ThemePreference) => void;
+	setThemeStyle: (style: ThemeStyle) => void;
 	openGlobalSettings: () => void;
 	openProjectSettings: (projectId: string) => void;
 	closeSettings: () => void;
@@ -148,6 +154,7 @@ function inspectorState(sessions: Record<string, InspectorSessionState>, session
 }
 
 const initialThemePreference = readStoredThemePreference();
+const initialThemeStyle = readStoredThemeStyle();
 
 export const useUiStore = create<UiState>((set) => ({
 	workbenchTab: "changes",
@@ -157,6 +164,7 @@ export const useUiStore = create<UiState>((set) => ({
 	settingsModal: null,
 	themePreference: initialThemePreference,
 	resolvedTheme: resolveTheme(initialThemePreference),
+	themeStyle: initialThemeStyle,
 	developerMode: initialDeveloperMode(),
 	restartingProjectIds: new Set<string>(),
 	orchestratorReplacementErrors: {},
@@ -171,6 +179,10 @@ export const useUiStore = create<UiState>((set) => ({
 	setThemePreference: (themePreference) => {
 		getLocalStorage()?.setItem(themeStorageKey, themePreference);
 		set({ themePreference, resolvedTheme: resolveTheme(themePreference) });
+	},
+	setThemeStyle: (themeStyle) => {
+		getLocalStorage()?.setItem(themeStyleStorageKey, themeStyle);
+		set({ themeStyle });
 	},
 	openGlobalSettings: () => set({ settingsModal: { scope: "global" } }),
 	openProjectSettings: (projectId) => set({ settingsModal: { scope: "project", projectId } }),

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1074,3 +1074,174 @@
 	--sidebar-accent-foreground:  #2b283c;
 	--sidebar-ring:               #907aa9;
 }
+
+/* ── Nord ── */
+:root[data-style-theme="nord"] {
+	/* Dark */
+	--background:                 #2e3440;
+	--foreground:                 #d8dee9;
+	--card:                       #3b4252;
+	--card-foreground:            #d8dee9;
+	--popover:                    #434c5e;
+	--popover-foreground:         #d8dee9;
+	--primary:                    #88c0d0;
+	--primary-foreground:         #2e3440;
+	--secondary:                  #3b4252;
+	--secondary-foreground:       #d8dee9;
+	--muted:                      #3b4252;
+	--muted-foreground:           #8894a3;
+	--accent:                     #3b4252;
+	--accent-foreground:          #d8dee9;
+	--border:                     oklch(1 0 0 / 8%);
+	--input:                      oklch(1 0 0 / 5%);
+	--ring:                       #88c0d0;
+	--sidebar:                    #252b37;
+	--sidebar-foreground:         #d8dee9;
+	--sidebar-primary:            #88c0d0;
+	--sidebar-primary-foreground: #2e3440;
+	--sidebar-accent:             #3b4252;
+	--sidebar-accent-foreground:  #d8dee9;
+	--sidebar-ring:               #88c0d0;
+}
+:root[data-style-theme="nord"][data-theme="light"] {
+	color-scheme: light;
+	/* Light */
+	--background:                 #eceff4;
+	--foreground:                 #2e3440;
+	--card:                       #e5e9f0;
+	--card-foreground:            #2e3440;
+	--popover:                    #eef0f4;
+	--popover-foreground:         #2e3440;
+	--primary:                    #5e81ac;
+	--primary-foreground:         #eceff4;
+	--secondary:                  #e0e5ee;
+	--secondary-foreground:       #2e3440;
+	--muted:                      #e0e5ee;
+	--muted-foreground:           #5a6474;
+	--accent:                     #e0e5ee;
+	--accent-foreground:          #2e3440;
+	--border:                     oklch(0 0 0 / 10%);
+	--input:                      oklch(0 0 0 / 6%);
+	--ring:                       #5e81ac;
+	--sidebar:                    #f2f5f9;
+	--sidebar-foreground:         #2e3440;
+	--sidebar-primary:            #5e81ac;
+	--sidebar-primary-foreground: #eceff4;
+	--sidebar-accent:             #e0e5ee;
+	--sidebar-accent-foreground:  #2e3440;
+	--sidebar-ring:               #5e81ac;
+}
+
+/* ── Gruvbox ── */
+:root[data-style-theme="gruvbox"] {
+	/* Dark */
+	--background:                 #282828;
+	--foreground:                 #ebdbb2;
+	--card:                       #3c3836;
+	--card-foreground:            #ebdbb2;
+	--popover:                    #45403d;
+	--popover-foreground:         #ebdbb2;
+	--primary:                    #fabd2f;
+	--primary-foreground:         #282828;
+	--secondary:                  #3c3836;
+	--secondary-foreground:       #ebdbb2;
+	--muted:                      #3c3836;
+	--muted-foreground:           #928374;
+	--accent:                     #3c3836;
+	--accent-foreground:          #ebdbb2;
+	--border:                     oklch(1 0 0 / 8%);
+	--input:                      oklch(1 0 0 / 5%);
+	--ring:                       #d79921;
+	--sidebar:                    #1d2021;
+	--sidebar-foreground:         #ebdbb2;
+	--sidebar-primary:            #d79921;
+	--sidebar-primary-foreground: #282828;
+	--sidebar-accent:             #3c3836;
+	--sidebar-accent-foreground:  #ebdbb2;
+	--sidebar-ring:               #d79921;
+}
+:root[data-style-theme="gruvbox"][data-theme="light"] {
+	color-scheme: light;
+	/* Light */
+	--background:                 #fbf1c7;
+	--foreground:                 #3c3836;
+	--card:                       #f2e5bc;
+	--card-foreground:            #3c3836;
+	--popover:                    #f5eacc;
+	--popover-foreground:         #3c3836;
+	--primary:                    #b57614;
+	--primary-foreground:         #fbf1c7;
+	--secondary:                  #ebdbb2;
+	--secondary-foreground:       #3c3836;
+	--muted:                      #ebdbb2;
+	--muted-foreground:           #7c6f64;
+	--accent:                     #ebdbb2;
+	--accent-foreground:          #3c3836;
+	--border:                     oklch(0 0 0 / 10%);
+	--input:                      oklch(0 0 0 / 6%);
+	--ring:                       #b57614;
+	--sidebar:                    #f9f0cb;
+	--sidebar-foreground:         #3c3836;
+	--sidebar-primary:            #b57614;
+	--sidebar-primary-foreground: #fbf1c7;
+	--sidebar-accent:             #ebdbb2;
+	--sidebar-accent-foreground:  #3c3836;
+	--sidebar-ring:               #b57614;
+}
+
+/* ── Solarized ── */
+:root[data-style-theme="solarized"] {
+	/* Dark */
+	--background:                 #002b36;
+	--foreground:                 #839496;
+	--card:                       #073642;
+	--card-foreground:            #93a1a1;
+	--popover:                    #0d404d;
+	--popover-foreground:         #93a1a1;
+	--primary:                    #268bd2;
+	--primary-foreground:         #002b36;
+	--secondary:                  #073642;
+	--secondary-foreground:       #93a1a1;
+	--muted:                      #073642;
+	--muted-foreground:           #657b83;
+	--accent:                     #073642;
+	--accent-foreground:          #93a1a1;
+	--border:                     oklch(1 0 0 / 8%);
+	--input:                      oklch(1 0 0 / 5%);
+	--ring:                       #268bd2;
+	--sidebar:                    #001f28;
+	--sidebar-foreground:         #93a1a1;
+	--sidebar-primary:            #268bd2;
+	--sidebar-primary-foreground: #002b36;
+	--sidebar-accent:             #073642;
+	--sidebar-accent-foreground:  #93a1a1;
+	--sidebar-ring:               #268bd2;
+}
+:root[data-style-theme="solarized"][data-theme="light"] {
+	color-scheme: light;
+	/* Light */
+	--background:                 #fdf6e3;
+	--foreground:                 #586e75;
+	--card:                       #f5edd8;
+	--card-foreground:            #657b83;
+	--popover:                    #f9f2e7;
+	--popover-foreground:         #657b83;
+	--primary:                    #268bd2;
+	--primary-foreground:         #fdf6e3;
+	--secondary:                  #eee8d5;
+	--secondary-foreground:       #657b83;
+	--muted:                      #eee8d5;
+	--muted-foreground:           #93a1a1;
+	--accent:                     #eee8d5;
+	--accent-foreground:          #657b83;
+	--border:                     oklch(0 0 0 / 10%);
+	--input:                      oklch(0 0 0 / 6%);
+	--ring:                       #268bd2;
+	--sidebar:                    #fef8ec;
+	--sidebar-foreground:         #657b83;
+	--sidebar-primary:            #268bd2;
+	--sidebar-primary-foreground: #fdf6e3;
+	--sidebar-accent:             #eee8d5;
+	--sidebar-accent-foreground:  #657b83;
+	--sidebar-ring:               #268bd2;
+}


### PR DESCRIPTION
Adds a Color Theme picker to Settings. Choose from 9 themes - Orchestrate (default), GitHub, Catppuccin, Dracula, Tokyo Night, Rosé Pine, Nord, Gruvbox, and Solarized. 
Your selection persists across reloads.

<img width="983" height="768" alt="image" src="https://github.com/user-attachments/assets/1355c31d-dc60-46c7-a082-420b72c5dec1" />
