### PR TITLE
fix: keep terminal p-2 gutter on #101317e7

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -399,9 +399,9 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 					}
 				/>
 			)}
-			{/* p-2 insets xterm from the pane edges. terminal-surface keeps the
-			    gutter on #101317e7 (opaque plate underneath) so it does not
-			    blend against app chrome. Overlays cover the full padding box. */}
+			{/* p-2 insets xterm from the pane edges. Surface + xterm chrome use
+			    the opaque #101317 plate so the gutter never fringes against app
+			    chrome. Overlays cover the full padding box. */}
 			<div className="relative min-h-0 flex-1 p-2">
 				<XtermTerminal
 					ariaLabel={terminalTarget?.kind === "shell" ? t("terminal.shellAria") : t("terminal.sessionAria")}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -358,7 +358,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 
 	if (initFailed) {
 		return (
-			<div className="grid h-full place-items-center bg-terminal p-4 font-mono text-xs text-muted-foreground">
+			<div className="terminal-surface grid h-full place-items-center p-4 font-mono text-xs text-muted-foreground">
 				{t("terminal.initFailed")}
 			</div>
 		);
@@ -387,7 +387,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 		: t("terminal.noSessionSelected");
 
 	return (
-		<div className="flex h-full min-h-0 flex-col bg-terminal" data-testid="session-terminal">
+		<div className="terminal-surface flex h-full min-h-0 flex-col" data-testid="session-terminal">
 			{showEndedState && (
 				<TerminalEndedStrip
 					canRestore={canRestoreSession}
@@ -399,10 +399,9 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 					}
 				/>
 			)}
-			{/* p-2 keeps the xterm content off the pane edges; the host fills the
-			    remaining content box, so FitAddon still measures it correctly and
-			    the absolute overlays (empty state, banner) keep covering the
-			    full padding box. */}
+			{/* p-2 insets xterm from the pane edges. terminal-surface keeps the
+			    gutter on #101317e7 (opaque plate underneath) so it does not
+			    blend against app chrome. Overlays cover the full padding box. */}
 			<div className="relative min-h-0 flex-1 p-2">
 				<XtermTerminal
 					ariaLabel={terminalTarget?.kind === "shell" ? t("terminal.shellAria") : t("terminal.sessionAria")}
@@ -414,7 +413,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 					theme={theme}
 				/>
 				{showEmptyState && (
-					<div className="absolute inset-0 grid place-items-center bg-terminal font-mono text-control">
+					<div className="terminal-surface absolute inset-0 grid place-items-center font-mono text-control">
 						<div className="text-center">
 							<div className="text-terminal">{emptyStateTitle}</div>
 							<div className="mt-2 text-terminal-dim">{emptyStateMessage}</div>
@@ -460,7 +459,7 @@ function ReplayCover() {
 		// live the whole time, so clicks, selection and wheel must pass through
 		// rather than being swallowed for the length of the gate.
 		<div
-			className="pointer-events-none absolute inset-0 grid place-items-center bg-terminal"
+			className="terminal-surface pointer-events-none absolute inset-0 grid place-items-center"
 			data-testid="terminal-replay-cover"
 		>
 			{showLabel && <div className="font-mono text-caption text-terminal-dim">{t("terminal.loadingOutput")}</div>}

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -780,7 +780,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				ref={hostRef}
 				aria-label={props.ariaLabel}
 				className={props.className}
-				style={{ height: "100%", overflow: "hidden", width: "100%" }}
+				style={{
+					backgroundColor: "var(--color-bg-terminal-opaque)",
+					height: "100%",
+					overflow: "hidden",
+					width: "100%",
+				}}
 			/>
 			<DropdownMenu modal={false} open={contextMenu.open} onOpenChange={setContextMenuOpen}>
 				<DropdownMenuTrigger asChild>

--- a/frontend/src/renderer/lib/terminal-themes.ts
+++ b/frontend/src/renderer/lib/terminal-themes.ts
@@ -8,11 +8,14 @@ function cssVar(name: string): string {
 
 /** xterm palettes harmonized to tokens.css (--color-term-* / semantic colors). */
 export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
+	// Opaque plate — xterm cells must not be translucent or the p-2 gutter and
+	// the glyph grid pick up different composites against app chrome.
+	const terminalBg = cssVar("--color-bg-terminal-opaque") || cssVar("--color-bg-terminal");
 	const dark: ITheme = {
-		background: cssVar("--color-bg-terminal"),
+		background: terminalBg,
 		foreground: cssVar("--color-text-terminal"),
 		cursor: cssVar("--color-working"),
-		cursorAccent: cssVar("--color-bg-terminal"),
+		cursorAccent: terminalBg,
 		selectionBackground: cssVar("--color-term-selection-dark"),
 		selectionInactiveBackground: cssVar("--color-term-selection-inactive"),
 		black: cssVar("--color-term-black"),
@@ -34,10 +37,10 @@ export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
 	};
 
 	const light: ITheme = {
-		background: cssVar("--color-bg-terminal"),
+		background: terminalBg,
 		foreground: cssVar("--color-text-terminal"),
 		cursor: cssVar("--color-working"),
-		cursorAccent: cssVar("--color-bg-terminal"),
+		cursorAccent: terminalBg,
 		selectionBackground: cssVar("--color-term-selection-light"),
 		selectionInactiveBackground: cssVar("--color-term-selection-inactive-light"),
 		black: cssVar("--color-term-black"),

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1083,11 +1083,18 @@ textarea,
 	background: var(--color-bg-primary);
 }
 
-/* Opaque plate + translucent token. Without the plate, #101317e7 composites
-   against panel chrome and the p-2 gutter reads as a different color. */
+/* Paint the pane with the opaque RGB of --color-bg-terminal only. The e7 alpha
+   on the token composites against app chrome and left a #111316 fringe in the
+   p-2 gutter / FitAddon leftover strips. */
 .terminal-surface {
 	background-color: var(--color-bg-terminal-opaque);
-	background-image: linear-gradient(var(--color-bg-terminal), var(--color-bg-terminal));
+}
+
+.terminal-surface .xterm,
+.terminal-surface .xterm-viewport,
+.terminal-surface .xterm-screen,
+.terminal-surface .xterm-helpers {
+	background-color: var(--color-bg-terminal-opaque) !important;
 }
 
 @keyframes status-pulse {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -107,6 +107,7 @@
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-terminal: var(--color-bg-terminal);
+	--color-terminal-opaque: var(--color-bg-terminal-opaque);
 	--color-terminal-dim: var(--color-text-terminal-dim);
 	--color-scrim: var(--bridge-scrim);
 
@@ -1080,6 +1081,13 @@ textarea,
 
 .terminal-pane-frame:fullscreen {
 	background: var(--color-bg-primary);
+}
+
+/* Opaque plate + translucent token. Without the plate, #101317e7 composites
+   against panel chrome and the p-2 gutter reads as a different color. */
+.terminal-surface {
+	background-color: var(--color-bg-terminal-opaque);
+	background-image: linear-gradient(var(--color-bg-terminal), var(--color-bg-terminal));
 }
 
 @keyframes status-pulse {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -67,6 +67,9 @@
 	--color-bg-tertiary: var(--muted);
 	--color-bg-elevated: var(--popover);
 	--color-bg-sidebar: var(--sidebar);
+	/* Opaque plate under the translucent fill — stops the p-2 gutter blending
+	   against app chrome into a different picked color (e.g. #111316). */
+	--color-bg-terminal-opaque: #101317;
 	--color-bg-terminal: #101317e7;
 
 	/* Text */
@@ -648,6 +651,7 @@
 	--color-bg-tertiary: var(--muted);
 	--color-bg-elevated: var(--popover);
 	--color-bg-sidebar: var(--sidebar);
+	--color-bg-terminal-opaque: #f5f5f4;
 	--color-bg-terminal: #f5f5f4;
 
 	--color-text-primary: var(--foreground);

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -67,8 +67,8 @@
 	--color-bg-tertiary: var(--muted);
 	--color-bg-elevated: var(--popover);
 	--color-bg-sidebar: var(--sidebar);
-	/* Opaque plate under the translucent fill — stops the p-2 gutter blending
-	   against app chrome into a different picked color (e.g. #111316). */
+	/* Token keeps the historical #101317e7 value; painted surfaces use the
+	   opaque plate so the p-2 gutter cannot composite into #111316. */
 	--color-bg-terminal-opaque: #101317;
 	--color-bg-terminal: #101317e7;
 


### PR DESCRIPTION
## Summary
- Keep the terminal `p-2` inset and `--color-bg-terminal: #101317e7`
- Add an opaque `#101317` plate under the translucent fill so the gutter no longer blends against app chrome into a different color (e.g. `#111316`)
- Point xterm’s theme background at the opaque token so cell grid and gutter stay aligned

## Test plan
- [ ] Open a session terminal and confirm the `p-2` inset is still present
- [ ] Color-pick the padding gutter — it should match the terminal fill (`#101317`), not a blended chrome color
- [ ] Empty / loading / ended terminal states use the same surface
- [ ] Spot-check light theme terminal background

## Before 
<img width="982" height="950" alt="image" src="https://github.com/user-attachments/assets/eac726c7-fae2-4537-8d50-0e246998499f" />


##After
<img width="981" height="939" alt="image" src="https://github.com/user-attachments/assets/229176ae-7fd0-466c-8feb-636aa03ea6e3" />
