### PR TITLE
fix: sync xterm palette when toggling light/dark theme

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -32,6 +32,7 @@ import type { AttachableTerminal, TerminalUserInputSource } from "../hooks/useTe
 import { aoBridge } from "../lib/bridge";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
 import { openLinkInSystemBrowser } from "../lib/external-link-policy";
+import { applyDocumentTheme } from "../lib/theme";
 import { buildTerminalThemes } from "../lib/terminal-themes";
 import type { Theme } from "../stores/ui-store";
 import {
@@ -276,6 +277,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 	useEffect(() => {
 		const term = termRef.current;
 		if (!term) return;
+		// buildTerminalThemes() reads live CSS vars from :root. Parent shell
+		// applies data-theme in its own effect, and child effects run first, so
+		// sync the document here before reading — otherwise the palette stays on
+		// the previous theme until remount.
+		applyDocumentTheme(props.theme);
 		const { dark, light } = buildTerminalThemes();
 		term.options.theme = props.theme === "dark" ? dark : light;
 	}, [props.theme]);


### PR DESCRIPTION
## Summary
- Terminal stayed on the previous light/dark palette when toggling appearance until remount/navigation.
- Sync `data-theme` before reading CSS vars into the xterm theme so the palette updates immediately.

## Test plan
- [ ] Open a live session terminal
- [ ] Toggle light → dark and confirm terminal bg/fg update without leaving the session
- [ ] Toggle dark → light and confirm the same
- [ ] Remount/navigate away and back still looks correct

## Before 
<img width="1470" height="921" alt="image" src="https://github.com/user-attachments/assets/0b4d0b88-0705-4ce4-9899-3f30aba9e645" />
<img width="1467" height="924" alt="image" src="https://github.com/user-attachments/assets/8197cb34-84d6-41d7-928b-27c1f0c0f792" />

