### PR TITLE
fix: replace native number spinners with +/- steppers in dev settings

### DIFF
--- a/frontend/src/renderer/components/settings/DevSettingsSection.tsx
+++ b/frontend/src/renderer/components/settings/DevSettingsSection.tsx
@@ -63,6 +63,7 @@ type NumberStepperProps = {
 };
 
 function NumberStepper({ "aria-label": ariaLabel, max, min, onChange, step = 1, value }: NumberStepperProps) {
+	const { t } = useTranslation();
 	const clamp = (next: number) => Math.max(min, Math.min(max, next));
 	const [draft, setDraft] = useState(String(value));
 
@@ -80,7 +81,7 @@ function NumberStepper({ "aria-label": ariaLabel, max, min, onChange, step = 1, 
 	return (
 		<div className="flex items-center gap-1.5">
 			<StepperButton
-				aria-label={`Decrease ${ariaLabel}`}
+				aria-label={t("settings.dev.decreaseAria", { label: ariaLabel })}
 				disabled={value <= min}
 				onClick={() => onChange(clamp(value - step))}
 			>
@@ -113,7 +114,7 @@ function NumberStepper({ "aria-label": ariaLabel, max, min, onChange, step = 1, 
 				)}
 			/>
 			<StepperButton
-				aria-label={`Increase ${ariaLabel}`}
+				aria-label={t("settings.dev.increaseAria", { label: ariaLabel })}
 				disabled={value >= max}
 				onClick={() => onChange(clamp(value + step))}
 			>

--- a/frontend/src/renderer/components/settings/DevSettingsSection.tsx
+++ b/frontend/src/renderer/components/settings/DevSettingsSection.tsx
@@ -1,8 +1,10 @@
-import { Beaker, Dice5, PaintBucket } from "lucide-react";
+import { Beaker, Dice5, Minus, PaintBucket, Plus } from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useUiStore } from "../../stores/ui-store";
 import { IS_DEV } from "../../lib/is-dev";
-import { Input } from "../ui/input";
+import { cn } from "../../lib/utils";
 import { SettingsRow } from "./SettingsRow";
 import { SettingsSection } from "./SettingsSection";
 
@@ -17,36 +19,22 @@ export function DevSettingsSection({ titleHidden }: { titleHidden?: boolean }) {
 	return (
 		<SettingsSection title={t("settings.dev.title")} sectionId="dev-settings" titleHidden={titleHidden}>
 			<SettingsRow icon={Dice5} label={t("settings.dev.fixtureSessionsLabel")}>
-				<Input
-					type="number"
-					min={0}
-					max={20}
-					value={devSettings.fixtureCount}
-					onChange={(e) =>
-						setDevSettings({
-							...devSettings,
-							fixtureCount: Math.max(0, Math.min(20, Number(e.target.value) || 0)),
-						})
-					}
+				<NumberStepper
 					aria-label={t("settings.dev.fixtureCountAria")}
-					className="w-20 text-right tabular-nums"
+					max={20}
+					min={0}
+					value={devSettings.fixtureCount}
+					onChange={(fixtureCount) => setDevSettings({ ...devSettings, fixtureCount })}
 				/>
 			</SettingsRow>
 			<SettingsRow icon={PaintBucket} label={t("settings.dev.activitySpreadLabel")}>
-				<Input
-					type="number"
-					min={5}
+				<NumberStepper
+					aria-label={t("settings.dev.activitySpreadAria")}
 					max={480}
+					min={5}
 					step={5}
 					value={devSettings.randomSpreadMinutes}
-					onChange={(e) =>
-						setDevSettings({
-							...devSettings,
-							randomSpreadMinutes: Math.max(5, Math.min(480, Number(e.target.value) || 5)),
-						})
-					}
-					aria-label={t("settings.dev.activitySpreadAria")}
-					className="w-20 text-right tabular-nums"
+					onChange={(randomSpreadMinutes) => setDevSettings({ ...devSettings, randomSpreadMinutes })}
 				/>
 			</SettingsRow>
 			<SettingsRow icon={Beaker} label={t("settings.dev.resetDefaultsLabel")}>
@@ -62,5 +50,105 @@ export function DevSettingsSection({ titleHidden }: { titleHidden?: boolean }) {
 				</button>
 			</SettingsRow>
 		</SettingsSection>
+	);
+}
+
+type NumberStepperProps = {
+	"aria-label": string;
+	max: number;
+	min: number;
+	onChange: (value: number) => void;
+	step?: number;
+	value: number;
+};
+
+function NumberStepper({ "aria-label": ariaLabel, max, min, onChange, step = 1, value }: NumberStepperProps) {
+	const clamp = (next: number) => Math.max(min, Math.min(max, next));
+	const [draft, setDraft] = useState(String(value));
+
+	useEffect(() => {
+		setDraft(String(value));
+	}, [value]);
+
+	const commit = (raw: string) => {
+		const next = Number(raw);
+		const clamped = Number.isNaN(next) ? min : clamp(next);
+		onChange(clamped);
+		setDraft(String(clamped));
+	};
+
+	return (
+		<div className="flex items-center gap-1.5">
+			<StepperButton
+				aria-label={`Decrease ${ariaLabel}`}
+				disabled={value <= min}
+				onClick={() => onChange(clamp(value - step))}
+			>
+				<Minus className="size-3.5" aria-hidden="true" strokeWidth={2.25} />
+			</StepperButton>
+			<input
+				type="number"
+				aria-label={ariaLabel}
+				min={min}
+				max={max}
+				step={step}
+				value={draft}
+				onChange={(event) => {
+					const raw = event.target.value;
+					setDraft(raw);
+					if (raw === "" || raw === "-") return;
+					const next = Number(raw);
+					if (!Number.isNaN(next)) onChange(clamp(next));
+				}}
+				onBlur={() => commit(draft)}
+				onKeyDown={(event) => {
+					if (event.key === "Enter") {
+						event.currentTarget.blur();
+					}
+				}}
+				className={cn(
+					"h-7 w-12 rounded-md border-0 bg-transparent px-1 text-center text-sm tabular-nums text-settings-label outline-none",
+					"focus-visible:shadow-[0_0_0_2px_var(--bridge-accent-weak)]",
+					"[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+				)}
+			/>
+			<StepperButton
+				aria-label={`Increase ${ariaLabel}`}
+				disabled={value >= max}
+				onClick={() => onChange(clamp(value + step))}
+			>
+				<Plus className="size-3.5" aria-hidden="true" strokeWidth={2.25} />
+			</StepperButton>
+		</div>
+	);
+}
+
+function StepperButton({
+	"aria-label": ariaLabel,
+	children,
+	disabled,
+	onClick,
+}: {
+	"aria-label": string;
+	children: ReactNode;
+	disabled?: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			aria-label={ariaLabel}
+			disabled={disabled}
+			onClick={onClick}
+			className={cn(
+				"inline-flex size-7 shrink-0 items-center justify-center rounded-full",
+				"bg-(--color-bg-settings-input) text-settings-muted",
+				"transition-colors hover:text-settings-label",
+				"focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--bridge-accent-weak)]",
+				"disabled:pointer-events-none disabled:opacity-40",
+			)}
+		>
+			{children}
+		</button>
 	);
 }

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -931,6 +931,8 @@
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
 	"settings.dev.resetReload": "Reset & Reload",
+	"settings.dev.decreaseAria": "Decrease {{label}}",
+	"settings.dev.increaseAria": "Increase {{label}}",
 	"shell.pinSession": "Pin session",
 	"shell.unpinSession": "Unpin session"
 }

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -847,6 +847,8 @@
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
 	"settings.dev.resetReload": "Reset & Reload",
+	"settings.dev.decreaseAria": "Decrease {{label}}",
+	"settings.dev.increaseAria": "Increase {{label}}",
 	"files.close": "Close files",
 	"files.closeSearch": "Close search",
 	"files.copyPath": "Copy path for {{path}}",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -946,6 +946,8 @@
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
 	"settings.dev.resetReload": "Reset & Reload",
+	"settings.dev.decreaseAria": "Decrease {{label}}",
+	"settings.dev.increaseAria": "Increase {{label}}",
 	"shell.pinSession": "Pin session",
 	"shell.unpinSession": "Unpin session"
 }

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -946,6 +946,8 @@
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
 	"settings.dev.resetReload": "Reset & Reload",
+	"settings.dev.decreaseAria": "Decrease {{label}}",
+	"settings.dev.increaseAria": "Increase {{label}}",
 	"shell.pinSession": "Pin session",
 	"shell.unpinSession": "Unpin session"
 }

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -931,6 +931,8 @@
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
 	"settings.dev.resetReload": "Reset & Reload",
+	"settings.dev.decreaseAria": "Decrease {{label}}",
+	"settings.dev.increaseAria": "Increase {{label}}",
 	"shell.pinSession": "Pin session",
 	"shell.unpinSession": "Unpin session"
 }

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -931,6 +931,8 @@
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
 	"settings.dev.resetReload": "Reset & Reload",
+	"settings.dev.decreaseAria": "Decrease {{label}}",
+	"settings.dev.increaseAria": "Increase {{label}}",
 	"shell.pinSession": "Pin session",
 	"shell.unpinSession": "Unpin session"
 }

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -946,6 +946,8 @@
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
 	"settings.dev.resetReload": "Reset & Reload",
+	"settings.dev.decreaseAria": "Decrease {{label}}",
+	"settings.dev.increaseAria": "Increase {{label}}",
 	"shell.pinSession": "Pin session",
 	"shell.unpinSession": "Unpin session"
 }

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -914,5 +914,7 @@
 	"settings.dev.activitySpreadLabel": "活动分布（分钟）",
 	"settings.dev.activitySpreadAria": "活动分布（分钟）",
 	"settings.dev.resetDefaultsLabel": "重置默认值",
-	"settings.dev.resetReload": "重置并重新加载"
+	"settings.dev.resetReload": "重置并重新加载",
+	"settings.dev.decreaseAria": "减少{{label}}",
+	"settings.dev.increaseAria": "增加{{label}}"
 }


### PR DESCRIPTION
## Summary
- Replace native up/down spinner arrows on Fixture count / Activity spread with circular − / + steppers.
- Keep the center field editable so values can still be typed.
- Hide browser spinner chrome; clamp to min/max on commit.

## Test plan
- [ ] Open Settings → Developer (dev build)
- [ ] Use − / + on both rows; values update and disable at min/max
- [ ] Type a value directly, blur/Enter; it clamps correctly
- [ ] Clear the field briefly while typing without it snapping mid-edit
- [ ] Reset & Reload still restores defaults

## Before
<img width="720" height="164" alt="image" src="https://github.com/user-attachments/assets/693a353d-1567-4459-98d6-b3a390182933" />


## After
<img width="697" height="174" alt="image" src="https://github.com/user-attachments/assets/949feda9-0de9-4700-821b-20e82e84b9bf" />
