### PR TITLE
fix(frontend): improve merged PR chip contrast

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -299,7 +299,7 @@ describe("SessionInspector PR section", () => {
 		expect(prSection("Pull request").getByText("open")).toHaveClass("text-[9px]", "leading-none");
 	});
 
-	it("keeps a legible state chip after a pull request merges", () => {
+	it("uses the state chip as the single merged-state indicator", () => {
 		renderWithQuery(<SessionInspector session={session([pr(7, "merged")], { status: "merged" })} />);
 
 		const card = prSection("Pull request").getByText("PR #7").closest("article") as HTMLElement;
@@ -308,7 +308,7 @@ describe("SessionInspector PR section", () => {
 			"bg-overlay",
 			"text-success",
 		);
-		expect(within(card).getByText("Pull request merged")).toBeInTheDocument();
+		expect(within(card).queryByText("Pull request merged")).not.toBeInTheDocument();
 	});
 
 	it("shows the empty state when there are no PRs", () => {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -304,8 +304,8 @@ describe("SessionInspector PR section", () => {
 
 		const card = prSection("Pull request").getByText("PR #7").closest("article") as HTMLElement;
 		expect(within(card).getByText("merged", { exact: true })).toHaveClass(
-			"border-success/40",
-			"bg-success/10",
+			"border-border-strong",
+			"bg-overlay",
 			"text-success",
 		);
 		expect(within(card).getByText("Pull request merged")).toBeInTheDocument();

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -299,11 +299,15 @@ describe("SessionInspector PR section", () => {
 		expect(prSection("Pull request").getByText("open")).toHaveClass("text-[9px]", "leading-none");
 	});
 
-	it("omits the redundant state chip after a pull request merges", () => {
+	it("keeps a legible state chip after a pull request merges", () => {
 		renderWithQuery(<SessionInspector session={session([pr(7, "merged")], { status: "merged" })} />);
 
 		const card = prSection("Pull request").getByText("PR #7").closest("article") as HTMLElement;
-		expect(within(card).queryByText("merged", { exact: true })).not.toBeInTheDocument();
+		expect(within(card).getByText("merged", { exact: true })).toHaveClass(
+			"border-success/40",
+			"bg-success/10",
+			"text-success",
+		);
 		expect(within(card).getByText("Pull request merged")).toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -299,6 +299,14 @@ describe("SessionInspector PR section", () => {
 		expect(prSection("Pull request").getByText("open")).toHaveClass("text-[9px]", "leading-none");
 	});
 
+	it("omits the redundant state chip after a pull request merges", () => {
+		renderWithQuery(<SessionInspector session={session([pr(7, "merged")], { status: "merged" })} />);
+
+		const card = prSection("Pull request").getByText("PR #7").closest("article") as HTMLElement;
+		expect(within(card).queryByText("merged", { exact: true })).not.toBeInTheDocument();
+		expect(within(card).getByText("Pull request merged")).toBeInTheDocument();
+	});
+
 	it("shows the empty state when there are no PRs", () => {
 		renderWithQuery(<SessionInspector session={session([])} />);
 		expect(screen.getByText("No pull request opened yet.")).toBeInTheDocument();

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -514,12 +514,14 @@ function PRSummaryCard({ pr }: { pr: SessionPRSummary }) {
 					<span>PR #{pr.number}</span>
 					<ArrowUpRight aria-hidden="true" className="size-icon-2xs shrink-0" strokeWidth={2} />
 				</a>
-				<Badge
-					variant="outline"
-					className={cn("h-5 px-1.5 text-[9px] leading-none font-medium", prStateTone[pr.state])}
-				>
-					{t(prStateLabelKeys[pr.state])}
-				</Badge>
+				{pr.state !== "merged" ? (
+					<Badge
+						variant="outline"
+						className={cn("h-5 px-1.5 text-[9px] leading-none font-medium", prStateTone[pr.state])}
+					>
+						{t(prStateLabelKeys[pr.state])}
+					</Badge>
+				) : null}
 			</div>
 			<PRSummaryMeta className="mt-1.5" pr={pr} />
 			<PRCardStatusSummary className="mt-2" pr={pr} />

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -522,7 +522,7 @@ function PRSummaryCard({ pr }: { pr: SessionPRSummary }) {
 				</Badge>
 			</div>
 			<PRSummaryMeta className="mt-1.5" pr={pr} />
-			<PRCardStatusSummary className="mt-2" pr={pr} />
+			{pr.state !== "merged" ? <PRCardStatusSummary className="mt-2" pr={pr} /> : null}
 		</article>
 	);
 }

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -88,7 +88,7 @@ const usePreviewData = import.meta.env.VITE_NO_ELECTRON === "1";
 const prStateTone: Record<SessionPRSummary["state"], string> = {
 	open: "border-border-strong bg-overlay text-muted-foreground",
 	draft: "border-status-in-review/35 bg-status-in-review/10 text-status-in-review",
-	merged: "border-success/40 bg-success/10 text-success",
+	merged: "border-border-strong bg-overlay text-success",
 	closed: "border-error/40 bg-error/10 text-error",
 };
 

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -88,7 +88,7 @@ const usePreviewData = import.meta.env.VITE_NO_ELECTRON === "1";
 const prStateTone: Record<SessionPRSummary["state"], string> = {
 	open: "border-border-strong bg-overlay text-muted-foreground",
 	draft: "border-status-in-review/35 bg-status-in-review/10 text-status-in-review",
-	merged: "border-accent/40 bg-accent-weak text-accent",
+	merged: "border-success/40 bg-success/10 text-success",
 	closed: "border-error/40 bg-error/10 text-error",
 };
 
@@ -514,14 +514,12 @@ function PRSummaryCard({ pr }: { pr: SessionPRSummary }) {
 					<span>PR #{pr.number}</span>
 					<ArrowUpRight aria-hidden="true" className="size-icon-2xs shrink-0" strokeWidth={2} />
 				</a>
-				{pr.state !== "merged" ? (
-					<Badge
-						variant="outline"
-						className={cn("h-5 px-1.5 text-[9px] leading-none font-medium", prStateTone[pr.state])}
-					>
-						{t(prStateLabelKeys[pr.state])}
-					</Badge>
-				) : null}
+				<Badge
+					variant="outline"
+					className={cn("h-5 px-1.5 text-[9px] leading-none font-medium", prStateTone[pr.state])}
+				>
+					{t(prStateLabelKeys[pr.state])}
+				</Badge>
 			</div>
 			<PRSummaryMeta className="mt-1.5" pr={pr} />
 			<PRCardStatusSummary className="mt-2" pr={pr} />


### PR DESCRIPTION
Summary:
- keep the merged-state badge beside the PR number for consistency with open, draft, and closed PRs
- use a neutral chip surface with green text for legible but restrained merged emphasis
- remove the repetitive pull-request-merged status row so completed cards stay compact

Verification:
- npm test -- --run src/renderer/components/SessionInspector.test.tsx
- npm run typecheck
- rendered against real AO data in the Electron dev app