### PR TITLE
fix(frontend): align terminal tabs with topbar edge

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -206,13 +206,15 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.getByText("No session")).toBeInTheDocument();
 	});
 
-	it("uses the padded session topbar height for the terminal header", () => {
+	it("bottom-aligns compact terminal tabs inside the taller session topbar", () => {
 		renderCenterPane({ session: worker });
 
 		const tablist = screen.getByRole("tablist", { name: "Open terminals" });
 		const header = tablist.closest(".h-session-topbar");
 		expect(header).toHaveClass("h-session-topbar");
-		expect(screen.getByTestId("session-workspace-topbar")).toHaveClass("py-1");
+		expect(screen.getByTestId("session-workspace-topbar")).not.toHaveClass("py-1");
+		expect(tablist).toHaveClass("h-inspector-tabs", "self-end");
+		expect(tablist).not.toHaveClass("self-stretch");
 		expect(tablist.parentElement).toHaveClass("h-full");
 	});
 

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -206,15 +206,15 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.getByText("No session")).toBeInTheDocument();
 	});
 
-	it("bottom-aligns compact terminal tabs inside the taller session topbar", () => {
+	it("positions the framed terminal topbar below its outer breathing room", () => {
 		renderCenterPane({ session: worker });
 
 		const tablist = screen.getByRole("tablist", { name: "Open terminals" });
 		const header = tablist.closest(".h-session-topbar");
-		expect(header).toHaveClass("h-session-topbar");
+		expect(header).toHaveClass("h-session-topbar", "pt-1");
 		expect(screen.getByTestId("session-workspace-topbar")).not.toHaveClass("py-1");
-		expect(tablist).toHaveClass("h-inspector-tabs", "self-end");
-		expect(tablist).not.toHaveClass("self-stretch");
+		expect(tablist).toHaveClass("self-stretch");
+		expect(tablist).not.toHaveClass("mt-0.5", "h-inspector-tabs", "self-end");
 		expect(tablist.parentElement).toHaveClass("h-full");
 	});
 
@@ -233,7 +233,9 @@ describe("CenterPane toolbar session label", () => {
 		expect(terminalRegion).toContainElement(screen.getByRole("button", { name: "New terminal" }));
 		expect(terminalRegion).toContainElement(screen.getByRole("toolbar", { name: "Terminal display controls" }));
 		expect(terminalRegion).not.toContainElement(screen.getByTestId("session-action-region"));
-		expect(screen.getByTestId("session-action-region")).toContainElement(
+		const actionRegion = screen.getByTestId("session-action-region");
+		expect(actionRegion).not.toHaveClass("border-l");
+		expect(actionRegion).toContainElement(
 			screen.getByRole("button", { name: "Session action" }),
 		);
 	});

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -193,7 +193,7 @@ export function CenterPane({
 				paddingRight: isFullscreen ? 0 : terminalBounds.rightInset,
 			}}
 		>
-			<div className="session-topbar-surface flex min-w-0 flex-1 py-1" data-testid="session-workspace-topbar">
+			<div className="session-topbar-surface flex min-w-0 flex-1" data-testid="session-workspace-topbar">
 				<div
 					className={cn(
 						"flex min-w-0 shrink items-center pr-1.5",
@@ -221,7 +221,7 @@ export function CenterPane({
 						<div
 							ref={tabsOverflow.ref}
 							aria-label={t("terminal.tabsAria")}
-							className="scrollbar-none flex min-w-flex-min flex-1 self-stretch items-center overflow-x-auto"
+							className="scrollbar-none flex h-inspector-tabs min-w-flex-min flex-1 self-end items-center overflow-x-auto"
 							onKeyDown={handleTerminalTabListKeyDown}
 							role="tablist"
 						>

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -187,7 +187,7 @@ export function CenterPane({
 
 	const terminalTopbar = (
 		<div
-			className="flex h-session-topbar w-full shrink-0 items-stretch bg-sidebar"
+			className="flex h-session-topbar w-full shrink-0 items-stretch bg-sidebar pt-1"
 			style={{
 				paddingLeft: isFullscreen ? 0 : terminalBounds.leftInset,
 				paddingRight: isFullscreen ? 0 : terminalBounds.rightInset,
@@ -221,7 +221,7 @@ export function CenterPane({
 						<div
 							ref={tabsOverflow.ref}
 							aria-label={t("terminal.tabsAria")}
-							className="scrollbar-none flex h-inspector-tabs min-w-flex-min flex-1 self-end items-center overflow-x-auto"
+							className="scrollbar-none flex min-w-flex-min flex-1 self-stretch items-center overflow-x-auto"
 							onKeyDown={handleTerminalTabListKeyDown}
 							role="tablist"
 						>
@@ -318,7 +318,7 @@ export function CenterPane({
 				</div>
 				{isFullscreen ? null : (
 					<div
-						className="ml-auto flex shrink-0 items-center border-l border-border/70 px-3"
+						className="ml-auto flex shrink-0 items-center px-3"
 						data-testid="session-action-region"
 					>
 						{topbarActions}


### PR DESCRIPTION
## Summary

- keep the taller session topbar introduced by PR #3556 so terminal controls and session actions retain vertical breathing room
- remove padding from the shared topbar surface so connected tabs no longer float above the terminal divider
- restore the compact terminal-tab height and bottom-align the tab strip

## Root cause

PR #3556 applied vertical padding to the shared surface containing both centered controls and bottom-connected tabs. Since the tabs stretch within that padded surface, their active underline ended above the actual topbar edge and produced a detached double-divider treatment.

## Verification

- npm test -- src/renderer/components/CenterPane.test.tsx
- npm run typecheck
- hot-reloaded and exercised in the real-data Electron dev app