### PR TITLE
fix(frontend): increase merged status contrast

### DIFF
--- a/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
@@ -236,7 +236,7 @@ describe("PR hydration for a normal project (#251)", () => {
 		expect(screen.getByLabelText("#281 merged")).toBeInTheDocument();
 		expect(screen.getByLabelText("#282 closed")).toBeInTheDocument();
 		expect(screen.getByText("draft")).toBeInTheDocument();
-		expect(screen.getByText("merged")).toHaveClass("text-accent");
+		expect(screen.getByText("merged")).toHaveClass("text-status-merged");
 		expect(screen.getByText("closed")).toHaveClass("text-error");
 		expect(screen.queryByText("review pending")).not.toBeInTheDocument();
 		expect(screen.queryByText("CI")).not.toBeInTheDocument();

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -696,6 +696,7 @@ describe("SessionsBoard", () => {
 		expect(screen.getByText("github:INT-17")).toBeInTheDocument();
 		const prStatus = screen.getByLabelText("#42 merged");
 		expect(prStatus).toHaveTextContent("PR#42merged");
+		expect(within(prStatus).getByText("merged")).toHaveClass("text-status-merged");
 		const openPrStatus = screen.getByLabelText("#41 open");
 		expect(openPrStatus.parentElement).toBe(prStatus.parentElement);
 		expect(prStatus.parentElement).toHaveClass("flex-wrap");

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -1083,7 +1083,7 @@ function groupPRsByLifecycle(prs: SessionPRSummary[]): BoardPRGroup[] {
 
 function prLifecycleStatus(pr: SessionPRSummary): BoardPRLifecycleStatus {
 	if (pr.state === "draft") return { label: "draft", className: "text-passive" };
-	if (pr.state === "merged") return { label: "merged", className: "text-accent" };
+	if (pr.state === "merged") return { label: "merged", className: "text-status-merged" };
 	if (pr.state === "closed") return { label: "closed", className: "text-error" };
 	return { label: "open", className: "text-success" };
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -104,7 +104,7 @@
 	--color-status-needs-you: #fb923c;
 	--color-status-in-review: #facc15;
 	--color-status-ready: #4ade80;
-	--color-status-merged: var(--primary);
+	--color-status-merged: var(--color-status-ready);
 	--color-status-idle: var(--muted-foreground);
 	--color-status-exited: var(--destructive);
 	--color-status-terminated: var(--chart-3);
@@ -682,7 +682,7 @@
 	--color-status-needs-you: #ea580c;
 	--color-status-in-review: #ca8a04;
 	--color-status-ready: #16a34a;
-	--color-status-merged: var(--primary);
+	--color-status-merged: var(--color-status-ready);
 	--color-status-idle: var(--muted-foreground);
 	--color-status-exited: var(--destructive);
 	--color-status-terminated: var(--chart-3);


### PR DESCRIPTION
## Summary
- map merged session status to the shared success/merge color in dark and light themes
- use the same semantic merged token for inline PR lifecycle labels
- keep live and archived cards visually consistent

## Tests
- `cd frontend && npm test -- --run src/renderer/components/SessionsBoard.test.tsx`
- `cd frontend && npm run typecheck`

## Visual verification
- hot-reloaded in the session-owned Electron dev app against the current AO data/daemon state