### PR TITLE
fix(frontend): optically align sidebar brand

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -938,7 +938,7 @@ describe("Sidebar", () => {
 
 		expect(document.querySelector('[data-slot="sidebar-brand-row"]')).toHaveClass("gap-2", "px-2.5");
 		expect(document.querySelector('[data-slot="sidebar-search-icon"]')).toHaveClass("size-5.5");
-		expect(screen.getByRole("button", { name: "Orchestrator board" }).querySelector("img")).not.toHaveClass(
+		expect(screen.getByRole("button", { name: "Orchestrator board" }).querySelector("img")).toHaveClass(
 			"-translate-y-[3px]",
 		);
 	});

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -285,7 +285,12 @@ export function Sidebar({
 								onClick={selection.goHome}
 								type="button"
 							>
-								<img src={aoLogo} alt="" aria-hidden="true" className="h-5.5 w-5.5 rounded-md object-cover" />
+								<img
+									src={aoLogo}
+									alt=""
+									aria-hidden="true"
+									className="h-5.5 w-5.5 -translate-y-[3px] rounded-md object-cover"
+								/>
 							</button>
 						</TooltipTrigger>
 						<TooltipContent side="right" hidden={state !== "collapsed"}>


### PR DESCRIPTION
## Summary

- restore the mascot's optical vertical correction in the fullscreen sidebar brand
- keep the wordmark and mascot visually aligned despite the asymmetric SVG artwork
- pin the correction in the sidebar component test

## Root cause

The fullscreen header cleanup removed the mascot's existing 3px optical lift. Flex/grid centering aligned the image element's bounding box, but the visible mascot artwork is bottom-heavy inside that box, so it appeared lower than the wordmark.

## Validation

- cd frontend && npm test -- --run src/renderer/components/Sidebar.test.tsx (53 passed)
- cd frontend && npm run typecheck
- loaded through the existing hot-reloading Electron dev app