### PR TITLE
fix(notifications): prioritize pull request context

### DIFF
--- a/backend/internal/notify/enrich.go
+++ b/backend/internal/notify/enrich.go
@@ -35,8 +35,11 @@ func titleForIntent(intent Intent) string {
 	case domain.NotificationNeedsInput:
 		return fmt.Sprintf("%s needs your input", sessionLabel(intent))
 	case domain.NotificationReadyToMerge:
-		if s := sessionLabel(intent); s != "session" {
-			return fmt.Sprintf("%s is ready to merge", s)
+		if title := strings.TrimSpace(intent.PRTitle); title != "" {
+			if label := prLabel(intent); label != "PR" {
+				return fmt.Sprintf("%s · %s", title, label)
+			}
+			return title
 		}
 		return fmt.Sprintf("%s is ready to merge", prLabel(intent))
 	case domain.NotificationPRMerged:
@@ -53,6 +56,9 @@ func bodyForIntent(intent Intent) string {
 	case domain.NotificationNeedsInput:
 		return "Your agent is waiting on you to continue."
 	case domain.NotificationReadyToMerge:
+		if session := sessionLabel(intent); session != "session" {
+			return fmt.Sprintf("%s is ready to merge. CI passed with no blocking review feedback.", session)
+		}
 		return "CI passed with no blocking review feedback."
 	case domain.NotificationPRMerged:
 		title := strings.TrimSpace(intent.PRTitle)

--- a/backend/internal/notify/enrich.go
+++ b/backend/internal/notify/enrich.go
@@ -57,7 +57,7 @@ func bodyForIntent(intent Intent) string {
 		return "Your agent is waiting on you to continue."
 	case domain.NotificationReadyToMerge:
 		if session := sessionLabel(intent); session != "session" {
-			return fmt.Sprintf("%s is ready to merge. CI passed with no blocking review feedback.", session)
+			return fmt.Sprintf("PR from session %s is ready to merge. CI passed with no blocking review feedback.", session)
 		}
 		return "CI passed with no blocking review feedback."
 	case domain.NotificationPRMerged:

--- a/backend/internal/notify/enrich_test.go
+++ b/backend/internal/notify/enrich_test.go
@@ -1,0 +1,53 @@
+package notify
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestEnrichReadyToMergePrioritizesPRContext(t *testing.T) {
+	t.Parallel()
+
+	rec, err := enrich(Intent{
+		Type:               domain.NotificationReadyToMerge,
+		SessionID:          "sess-1",
+		ProjectID:          "proj-1",
+		PRURL:              "https://github.com/acme/app/pull/67",
+		SessionDisplayName: "Checkout flow",
+		PRNumber:           67,
+		PRTitle:            "Fix checkout totals",
+		CreatedAt:          time.Date(2026, 8, 5, 4, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("enrich ready notification: %v", err)
+	}
+
+	if want := "Fix checkout totals · PR #67"; rec.Title != want {
+		t.Fatalf("title = %q, want %q", rec.Title, want)
+	}
+	if want := "Checkout flow is ready to merge. CI passed with no blocking review feedback."; rec.Body != want {
+		t.Fatalf("body = %q, want %q", rec.Body, want)
+	}
+}
+
+func TestEnrichReadyToMergeFallsBackWithoutPRTitle(t *testing.T) {
+	t.Parallel()
+
+	rec, err := enrich(Intent{
+		Type:      domain.NotificationReadyToMerge,
+		SessionID: "sess-1",
+		ProjectID: "proj-1",
+		PRURL:     "https://github.com/acme/app/pull/67",
+		PRNumber:  67,
+		CreatedAt: time.Date(2026, 8, 5, 4, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("enrich ready notification: %v", err)
+	}
+
+	if want := "PR #67 is ready to merge"; rec.Title != want {
+		t.Fatalf("title = %q, want %q", rec.Title, want)
+	}
+}

--- a/backend/internal/notify/enrich_test.go
+++ b/backend/internal/notify/enrich_test.go
@@ -27,7 +27,7 @@ func TestEnrichReadyToMergePrioritizesPRContext(t *testing.T) {
 	if want := "Fix checkout totals · PR #67"; rec.Title != want {
 		t.Fatalf("title = %q, want %q", rec.Title, want)
 	}
-	if want := "Checkout flow is ready to merge. CI passed with no blocking review feedback."; rec.Body != want {
+	if want := "PR from session Checkout flow is ready to merge. CI passed with no blocking review feedback."; rec.Body != want {
 		t.Fatalf("body = %q, want %q", rec.Body, want)
 	}
 }

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -491,7 +491,7 @@ describe("NotificationCenter", () => {
 		renderNotificationCenter();
 		await clickOpen();
 
-		await userEvent.click(screen.getByRole("link", { name: "Open PR #67 in browser" }));
+		await userEvent.click(screen.getByRole("link", { name: "Open PR #67" }));
 
 		expect(openExternal).toHaveBeenCalledWith("https://github.com/acme/app/pull/67");
 		expect(navigateMock).not.toHaveBeenCalled();

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { aoBridge } from "../lib/bridge";
 import type { NotificationDTO, NotificationListStatus } from "../lib/notifications";
 import { useUiStore } from "../stores/ui-store";
 import { NotificationCenter, NotificationRuntime } from "./NotificationCenter";
@@ -300,7 +301,7 @@ describe("NotificationCenter", () => {
 		expect(screen.queryByRole("button", { name: "Mark notification read" })).not.toBeInTheDocument();
 		expect(screen.getByText("Checkout flow needs input")).toBeInTheDocument();
 		expect(screen.getByText("Checkout flow needs input").className).toContain("font-medium");
-		expect(screen.getByText("Fix checkout totals · PR #67").className).toContain("font-medium");
+		expect(screen.getByLabelText("Fix checkout totals · PR #67").className).toContain("font-medium");
 		expect(screen.getByText("Docs sweep needs input").className).not.toContain("font-medium");
 	});
 
@@ -473,13 +474,11 @@ describe("NotificationCenter", () => {
 		});
 	});
 
-	// A PR row navigates to its owning session like any other row. The title is
-	// no longer a separate link, so clicking it never opens the PR in a browser.
-	it("opens the session from a PR row title without opening the PR in a browser", async () => {
+	it("opens the session from the non-link portion of a PR row title", async () => {
 		renderNotificationCenter();
 		await clickOpen();
 
-		await userEvent.click(screen.getByText("Fix checkout totals · PR #67"));
+		await userEvent.click(screen.getByLabelText("Fix checkout totals · PR #67"));
 		expect(window.open).not.toHaveBeenCalled();
 		expect(navigateMock).toHaveBeenCalledWith({
 			to: "/projects/$projectId/sessions/$sessionId",
@@ -487,11 +486,23 @@ describe("NotificationCenter", () => {
 		});
 	});
 
+	it("opens the linked PR number in the system browser without opening the session", async () => {
+		const openExternal = vi.spyOn(aoBridge.app, "openExternal").mockResolvedValue(undefined);
+		renderNotificationCenter();
+		await clickOpen();
+
+		await userEvent.click(screen.getByRole("link", { name: "Open PR #67 in browser" }));
+
+		expect(openExternal).toHaveBeenCalledWith("https://github.com/acme/app/pull/67");
+		expect(navigateMock).not.toHaveBeenCalled();
+		openExternal.mockRestore();
+	});
+
 	it("shows the PR title prominently and does not repeat the session name in metadata", async () => {
 		renderNotificationCenter();
 		await clickOpen();
 
-		const title = screen.getByText("Fix checkout totals · PR #67");
+		const title = screen.getByLabelText("Fix checkout totals · PR #67");
 		const row = title.closest('[role="listitem"]');
 		expect(row).not.toBeNull();
 		expect(row).toHaveTextContent("acme/app");
@@ -520,7 +531,7 @@ describe("NotificationCenter", () => {
 		renderNotificationCenter();
 		await clickOpen();
 
-		expect(screen.getByText("PR #67 is ready to merge")).toBeInTheDocument();
+		expect(screen.getByLabelText("PR #67 is ready to merge")).toBeInTheDocument();
 		expect(
 			screen.getByText(
 				"PR from session Checkout flow is ready to merge. CI passed with no blocking review feedback.",

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -35,7 +35,7 @@ const allNotifications: NotificationDTO[] = [
 		prUrl: "https://github.com/acme/app/pull/67",
 		type: "ready_to_merge",
 		title: "Fix checkout totals · PR #67",
-		body: "Checkout flow is ready to merge. CI passed with no blocking review feedback.",
+		body: "PR from session Checkout flow is ready to merge. CI passed with no blocking review feedback.",
 		status: "unread",
 		createdAt: "2026-07-21T11:00:00Z",
 		target: { kind: "pr", sessionId: "sess-2", prUrl: "https://github.com/acme/app/pull/67" },
@@ -496,6 +496,37 @@ describe("NotificationCenter", () => {
 		expect(row).not.toBeNull();
 		expect(row).toHaveTextContent("acme/app");
 		expect(row?.textContent?.match(/Checkout flow/g)).toHaveLength(1);
+	});
+
+	it("normalizes legacy ready notifications without rewriting stored history", async () => {
+		const legacyReady = {
+			...allNotifications[0],
+			title: "Checkout flow is ready to merge",
+			body: "CI passed with no blocking review feedback.",
+		};
+		notificationQueryMock.mockImplementation((status: NotificationListStatus) => ({
+			...notificationQueryResult(status),
+			data: {
+				pageParams: [""],
+				pages: [
+					{
+						notifications: [legacyReady],
+						unreadCount: 1,
+						unresolvedCount: 1,
+					},
+				],
+			},
+		}));
+		renderNotificationCenter();
+		await clickOpen();
+
+		expect(screen.getByText("PR #67 is ready to merge")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"PR from session Checkout flow is ready to merge. CI passed with no blocking review feedback.",
+			),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Checkout flow is ready to merge")).not.toBeInTheDocument();
 	});
 
 	it("opens the session with the keyboard from a focused row", async () => {

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -34,8 +34,8 @@ const allNotifications: NotificationDTO[] = [
 		projectId: "proj-1",
 		prUrl: "https://github.com/acme/app/pull/67",
 		type: "ready_to_merge",
-		title: "PR #67 is ready to merge",
-		body: "Checkout flow has no known blocking CI or review feedback.",
+		title: "Fix checkout totals · PR #67",
+		body: "Checkout flow is ready to merge. CI passed with no blocking review feedback.",
 		status: "unread",
 		createdAt: "2026-07-21T11:00:00Z",
 		target: { kind: "pr", sessionId: "sess-2", prUrl: "https://github.com/acme/app/pull/67" },
@@ -171,11 +171,12 @@ beforeEach(() => {
 		data: [
 			{
 				id: "proj-1",
+				name: "acme/app",
 				sessions: [
-					{ id: "sess-1", isTerminated: false, status: "needs_input" },
-					{ id: "sess-2", isTerminated: false, status: "ready_to_merge" },
-					{ id: "sess-4", isTerminated: false, status: "needs_input" },
-					{ id: "sess-dead", isTerminated: true, status: "terminated" },
+					{ id: "sess-1", isTerminated: false, status: "needs_input", title: "Checkout flow" },
+					{ id: "sess-2", isTerminated: false, status: "ready_to_merge", title: "Checkout flow" },
+					{ id: "sess-4", isTerminated: false, status: "needs_input", title: "Docs sweep" },
+					{ id: "sess-dead", isTerminated: true, status: "terminated", title: "Old PR" },
 				],
 			},
 		],
@@ -280,7 +281,7 @@ describe("NotificationCenter", () => {
 
 		const rows = panel.getAllByRole("listitem");
 		expect(rows.map((row) => row.textContent)).toEqual([
-			expect.stringContaining("PR #67 is ready to merge"),
+			expect.stringContaining("Fix checkout totals · PR #67"),
 			expect.stringContaining("Checkout flow needs input"),
 			expect.stringContaining("Docs sweep needs input"),
 			expect.stringContaining("PR #9 merged"),
@@ -299,7 +300,7 @@ describe("NotificationCenter", () => {
 		expect(screen.queryByRole("button", { name: "Mark notification read" })).not.toBeInTheDocument();
 		expect(screen.getByText("Checkout flow needs input")).toBeInTheDocument();
 		expect(screen.getByText("Checkout flow needs input").className).toContain("font-medium");
-		expect(screen.getByText("PR #67 is ready to merge").className).toContain("font-medium");
+		expect(screen.getByText("Fix checkout totals · PR #67").className).toContain("font-medium");
 		expect(screen.getByText("Docs sweep needs input").className).not.toContain("font-medium");
 	});
 
@@ -478,12 +479,23 @@ describe("NotificationCenter", () => {
 		renderNotificationCenter();
 		await clickOpen();
 
-		await userEvent.click(screen.getByText("PR #67 is ready to merge"));
+		await userEvent.click(screen.getByText("Fix checkout totals · PR #67"));
 		expect(window.open).not.toHaveBeenCalled();
 		expect(navigateMock).toHaveBeenCalledWith({
 			to: "/projects/$projectId/sessions/$sessionId",
 			params: { projectId: "proj-1", sessionId: "sess-2" },
 		});
+	});
+
+	it("shows the PR title prominently and does not repeat the session name in metadata", async () => {
+		renderNotificationCenter();
+		await clickOpen();
+
+		const title = screen.getByText("Fix checkout totals · PR #67");
+		const row = title.closest('[role="listitem"]');
+		expect(row).not.toBeNull();
+		expect(row).toHaveTextContent("acme/app");
+		expect(row?.textContent?.match(/Checkout flow/g)).toHaveLength(1);
 	});
 
 	it("opens the session with the keyboard from a focused row", async () => {

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -446,7 +446,8 @@ function NotificationItem({
 	const Icon = notificationIcon(notification.type);
 	const sessionId = notification.target.sessionId || notification.sessionId;
 	const canOpenSession = Boolean(sessionId) && sessionsReady && !terminated;
-	const showSessionMeta = Boolean(meta?.sessionName) && !notificationMentions(notification, meta?.sessionName ?? "");
+	const copy = notificationCopy(notification, meta?.sessionName);
+	const showSessionMeta = Boolean(meta?.sessionName) && !notificationMentions(copy, meta?.sessionName ?? "");
 	const openRow = () => {
 		if (canOpenSession) onOpenSession(notification);
 	};
@@ -489,12 +490,12 @@ function NotificationItem({
 								highlighted && "font-medium",
 							)}
 						>
-							{notification.title}
+							{copy.title}
 						</span>
 					</div>
-					{notification.body ? (
+					{copy.body ? (
 						<p className="mt-0.5 whitespace-pre-wrap break-words text-caption leading-snug text-muted-foreground">
-							{notification.body}
+							{copy.body}
 						</p>
 					) : null}
 					{meta && (meta.projectName || showSessionMeta) ? (
@@ -539,7 +540,38 @@ function NotificationItem({
 	);
 }
 
-function notificationMentions(notification: NotificationDTO, value: string): boolean {
+type NotificationCopy = Pick<NotificationDTO, "body" | "title">;
+
+function notificationCopy(notification: NotificationDTO, sessionName?: string): NotificationCopy {
+	if (notification.type !== "ready_to_merge") {
+		return { title: notification.title, body: notification.body };
+	}
+
+	const session = sessionName?.trim();
+	if (!session) {
+		return { title: notification.title, body: notification.body };
+	}
+
+	const legacySessionTitle = `${session} is ready to merge`;
+	const title =
+		notification.title.trim().toLocaleLowerCase() === legacySessionTitle.toLocaleLowerCase()
+			? readyNotificationFallbackTitle(notification)
+			: notification.title;
+
+	return {
+		title,
+		body: `PR from session ${session} is ready to merge. CI passed with no blocking review feedback.`,
+	};
+}
+
+function readyNotificationFallbackTitle(notification: NotificationDTO): string {
+	const titleNumber = notification.title.match(/\bPR\s*#(\d+)\b/i)?.[1];
+	const urlNumber = notification.prUrl.match(/\/pull\/(\d+)(?:\/|$)/)?.[1];
+	const number = titleNumber ?? urlNumber;
+	return number ? `PR #${number} is ready to merge` : "Pull request is ready to merge";
+}
+
+function notificationMentions(notification: NotificationCopy, value: string): boolean {
 	const needle = value.trim().toLocaleLowerCase();
 	if (!needle) return false;
 	return `${notification.title}\n${notification.body}`.toLocaleLowerCase().includes(needle);

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useParams } from "@tanstack/react-router";
 import {
+	ArrowUpRight,
 	Bell,
 	BellRing,
 	CheckCheck,
@@ -19,6 +20,7 @@ import { useMarkAllNotificationsReadMutation, useNotificationsQuery } from "../h
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { aoBridge } from "../lib/bridge";
+import { openLinkInSystemBrowser } from "../lib/external-link-policy";
 import { formatTimeCompact } from "../lib/format-time";
 import {
 	createNotificationsTransport,
@@ -447,6 +449,7 @@ function NotificationItem({
 	const sessionId = notification.target.sessionId || notification.sessionId;
 	const canOpenSession = Boolean(sessionId) && sessionsReady && !terminated;
 	const copy = notificationCopy(notification, meta?.sessionName);
+	const titleLink = notificationPRTitleLink(notification, copy.title);
 	const showSessionMeta = Boolean(meta?.sessionName) && !notificationMentions(copy, meta?.sessionName ?? "");
 	const openRow = () => {
 		if (canOpenSession) onOpenSession(notification);
@@ -485,12 +488,36 @@ function NotificationItem({
 					{/* Match the 26px icon band so the title centers with the left glyph. */}
 					<div className="flex min-h-notification-icon items-center">
 						<span
+							aria-label={copy.title}
 							className={cn(
 								"min-w-0 break-words text-control leading-snug text-foreground",
 								highlighted && "font-medium",
 							)}
 						>
-							{copy.title}
+							{titleLink ? (
+								<>
+									{titleLink.before}
+									<a
+										aria-label={`Open ${titleLink.label} in browser`}
+										className="inline-flex items-center gap-0.5 underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+										href={titleLink.url}
+										onClick={(event) => {
+											event.preventDefault();
+											event.stopPropagation();
+											void captureRendererEvent("ao.renderer.notification_opened", { target: "pr" });
+											void openLinkInSystemBrowser(titleLink.url);
+										}}
+										rel="noopener noreferrer"
+										target="_blank"
+									>
+										{titleLink.label}
+										<ArrowUpRight aria-hidden="true" className="size-icon-2xs shrink-0" strokeWidth={2} />
+									</a>
+									{titleLink.after}
+								</>
+							) : (
+								copy.title
+							)}
 						</span>
 					</div>
 					{copy.body ? (
@@ -541,6 +568,22 @@ function NotificationItem({
 }
 
 type NotificationCopy = Pick<NotificationDTO, "body" | "title">;
+
+function notificationPRTitleLink(
+	notification: NotificationDTO,
+	title: string,
+): { after: string; before: string; label: string; url: string } | null {
+	const url = notification.target.kind === "pr" ? notification.target.prUrl : notification.prUrl;
+	if (!url) return null;
+	const match = /\bPR\s*#\d+\b/i.exec(title);
+	if (!match || match.index === undefined) return null;
+	return {
+		before: title.slice(0, match.index),
+		label: match[0],
+		after: title.slice(match.index + match[0].length),
+		url,
+	};
+}
 
 function notificationCopy(notification: NotificationDTO, sessionName?: string): NotificationCopy {
 	if (notification.type !== "ready_to_merge") {

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -498,7 +498,7 @@ function NotificationItem({
 								<>
 									{titleLink.before}
 									<a
-										aria-label={`Open ${titleLink.label} in browser`}
+										aria-label={t("inspector.openPR", { number: titleLink.number })}
 										className="inline-flex items-center gap-0.5 underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
 										href={titleLink.url}
 										onClick={(event) => {
@@ -572,14 +572,15 @@ type NotificationCopy = Pick<NotificationDTO, "body" | "title">;
 function notificationPRTitleLink(
 	notification: NotificationDTO,
 	title: string,
-): { after: string; before: string; label: string; url: string } | null {
+): { after: string; before: string; label: string; number: string; url: string } | null {
 	const url = notification.target.kind === "pr" ? notification.target.prUrl : notification.prUrl;
 	if (!url) return null;
-	const match = /\bPR\s*#\d+\b/i.exec(title);
+	const match = /\bPR\s*#(\d+)\b/i.exec(title);
 	if (!match || match.index === undefined) return null;
 	return {
 		before: title.slice(0, match.index),
 		label: match[0],
+		number: match[1],
 		after: title.slice(match.index + match[0].length),
 		url,
 	};

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -446,6 +446,7 @@ function NotificationItem({
 	const Icon = notificationIcon(notification.type);
 	const sessionId = notification.target.sessionId || notification.sessionId;
 	const canOpenSession = Boolean(sessionId) && sessionsReady && !terminated;
+	const showSessionMeta = Boolean(meta?.sessionName) && !notificationMentions(notification, meta?.sessionName ?? "");
 	const openRow = () => {
 		if (canOpenSession) onOpenSession(notification);
 	};
@@ -496,11 +497,13 @@ function NotificationItem({
 							{notification.body}
 						</p>
 					) : null}
-					{meta ? (
+					{meta && (meta.projectName || showSessionMeta) ? (
 						<p className="mt-1 flex min-w-0 items-center gap-1.5 text-caption leading-none text-passive">
-							<span className="truncate font-medium text-muted-foreground">{meta.projectName}</span>
-							<span aria-hidden="true">·</span>
-							<span className="truncate">{meta.sessionName}</span>
+							{meta.projectName ? (
+								<span className="truncate font-medium text-muted-foreground">{meta.projectName}</span>
+							) : null}
+							{meta.projectName && showSessionMeta ? <span aria-hidden="true">·</span> : null}
+							{showSessionMeta ? <span className="truncate">{meta.sessionName}</span> : null}
 						</p>
 					) : null}
 				</div>
@@ -534,6 +537,12 @@ function NotificationItem({
 			</div>
 		</div>
 	);
+}
+
+function notificationMentions(notification: NotificationDTO, value: string): boolean {
+	const needle = value.trim().toLocaleLowerCase();
+	if (!needle) return false;
+	return `${notification.title}\n${notification.body}`.toLocaleLowerCase().includes(needle);
 }
 
 function notificationIcon(type: string) {


### PR DESCRIPTION
## Summary
- headline ready-to-merge notifications with the PR title and number
- move session readiness context into the body
- suppress repeated session names in notification metadata while preserving project context

## Tests
- go test ./internal/notify/...
- npm test -- --run src/renderer/components/NotificationCenter.test.tsx
- npm run typecheck (frontend)
- native Electron dev app launched against real AO data on the exact checkout

## Notes
- Stacked on #3596.
- The full backend suite currently has unrelated failures already present in the stacked base (CLI hook/project-resolution expectations and one workspace diff expectation).