### PR TITLE
fix(sqlite): ledger 0043 and repair is_pinned on burned migration histories

### DIFF
--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -191,6 +191,43 @@ var schemaRepairs = []struct {
         AND status NOT IN ('failed', 'cancelled')
         AND (status = 'running' OR verdict NOT IN ('', 'changes_requested'))`,
 		}},
+	// 0043_add_session_pinned.sql. The trigger replay hangs off pinned_at, the
+	// second of the two columns: it references both, and SQLite resolves a
+	// trigger body at CREATE time, so it cannot run until both exist.
+	{table: "sessions", column: "is_pinned",
+		addDDL: `ALTER TABLE sessions ADD COLUMN is_pinned BOOLEAN NOT NULL DEFAULT 0`},
+	{table: "sessions", column: "pinned_at",
+		addDDL: `ALTER TABLE sessions ADD COLUMN pinned_at DATETIME`,
+		postAdd: []string{
+			`DROP TRIGGER IF EXISTS sessions_cdc_update`,
+			`CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.terminate_on_pr_merge <> NEW.terminate_on_pr_merge
+    OR OLD.is_pinned <> NEW.is_pinned
+    OR OLD.pinned_at <> NEW.pinned_at
+    OR (OLD.pinned_at IS NULL AND NEW.pinned_at IS NOT NULL)
+    OR (OLD.pinned_at IS NOT NULL AND NEW.pinned_at IS NULL)
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object(
+            'id', NEW.id,
+            'activity', NEW.activity_state,
+            'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END),
+            'terminateOnPrMerge', json(CASE WHEN NEW.terminate_on_pr_merge THEN 'true' ELSE 'false' END),
+            'previewUrl', NEW.preview_url,
+            'previewRevision', NEW.preview_revision,
+            'isPinned', json(CASE WHEN NEW.is_pinned THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END`,
+		}},
 }
 
 // reconcileSchema verifies that the columns in schemaRepairs physically exist

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -60,6 +60,7 @@ var shippedMigrations = map[int64]string{
 	40: "0040_add_session_diff_base.sql",
 	41: "0041_notification_resolution.sql",
 	42: "0042_review_run_unique_per_harness.sql",
+	43: "0043_add_session_pinned.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they


### PR DESCRIPTION
## Why

`main` is red on Go / build-test at 3d782c2 ([run](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/30976687994)):

```
--- FAIL: TestMigrationVersionLedger
    migration "0043_add_session_pinned.sql" (version 43) is not in the shippedMigrations ledger
--- FAIL: TestSessionListSucceedsOnBurnedMigrationHistory
    insert session mer-1: SQL logic error: table sessions has no column named is_pinned (1)
```

Two PRs, each green on its own base, neither re-run against the other:

- #3511 (merged 2026-08-04 22:09Z) added `0043_add_session_pinned.sql`.
- #3491 (merged 2026-08-05 04:58Z) added the append-only ledger and `schemaRepairs`, both stopping at 42 because the branch predates #3511.

The second failure is not ledger bookkeeping, it is the defect the guard exists to catch. The #3475/#3476 field profiles have `goose_db_version` recording versions 40 through 51 from a foreign build, so goose skips 0043 there entirely. `gen/sessions.sql.go` selects and writes `is_pinned` and `pinned_at` in create, list, get, and update, so on those installs session pinning ships as an opaque 500 on the session list while `/healthz` stays green.

## What

- Append `43: "0043_add_session_pinned.sql"` to `shippedMigrations`.
- Add `sessions.is_pinned` and `sessions.pinned_at` to `schemaRepairs`, and replay 0043's CDC trigger in `postAdd` so pin changes still broadcast on a repaired database.

The trigger replay hangs off `pinned_at`, the second column, because SQLite resolves a trigger body at `CREATE TRIGGER` time and the body references both columns. Hanging it off `is_pinned` would fail with `no such column: NEW.pinned_at`. `postAdd` runs only when the column was just added, so healthy databases are untouched.

## Verification

```
go test ./internal/storage/sqlite/ -run 'TestMigrationVersionLedger|TestSessionListSucceedsOnBurnedMigrationHistory'   ok
go test ./internal/storage/...                                                                                        ok, 88 tests, 3 packages
gofmt -l internal/storage/sqlite/                                                                                     clean
golangci-lint run ./internal/storage/...                                                                              0 issues
```

## Risks and follow-ups

- No schema change and no new migration, so nothing new to burn.
- The repair path is exercised by `TestSessionListSucceedsOnBurnedMigrationHistory`, which seeds versions 40 to 51 as applied and now creates and lists a session successfully.
- Worth considering separately: nothing forces a PR that touches `migrations/` to be re-tested against current `main` before merge, which is exactly how this landed.

Blocks the nightly. Conductor run [30976937971](https://github.com/Untrivial-ai/ao-releases/actions/runs/30976937971) was cancelled at the wait step before any publish, so no release was cut from the broken SHA.