### PR TITLE
feat(landing): add 0.12.0 and 0.12.1 changelog entries, stamp version 0.12.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "agent-orchestrator",
-	"version": "0.12.1",
+	"version": "0.12.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "agent-orchestrator",
-			"version": "0.12.1",
+			"version": "0.12.6",
 			"license": "MIT",
 			"dependencies": {
 				"@aoagents/product-ui": "file:../packages/product-ui",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "agent-orchestrator",
-	"version": "0.10.3",
+	"version": "0.12.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "agent-orchestrator",
-			"version": "0.10.3",
+			"version": "0.12.1",
 			"license": "MIT",
 			"dependencies": {
 				"@aoagents/product-ui": "file:../packages/product-ui",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "agent-orchestrator",
 	"productName": "Agent Orchestrator",
-	"version": "0.12.1",
+	"version": "0.12.6",
 	"private": true,
 	"description": "Electron + TypeScript frontend for the agent-orchestrator rewrite",
 	"author": "Agent Orchestrator",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "agent-orchestrator",
 	"productName": "Agent Orchestrator",
-	"version": "0.10.3",
+	"version": "0.12.1",
 	"private": true,
 	"description": "Electron + TypeScript frontend for the agent-orchestrator rewrite",
 	"author": "Agent Orchestrator",

--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
@@ -5,6 +5,8 @@ date: "2026-08-05T06:52:44Z"
 ---
 
 > Covers everything since **v0.11.2**.
+>
+> **macOS users should go straight to [0.12.1](/changelog/agent-orchestrator-0-12-1).** This build leaks file descriptors and breaks the Files view and task creation after a few hours of use.
 
 0.11.0 was about the foundation holding weight. 0.12.0 is what got built on it: the app now speaks eight languages, the sidebar and settings work the way you would expect them to, and a class of failure that could wipe every session off your board is gone.
 

--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Agent Orchestrator 0.12.0"
 description: "80 commits since 0.11.2. The desktop app now speaks eight languages, sits on a new color palette, and lets you pin sessions and pick a reviewer per session. The mobile app got theming and hold-to-talk dictation. Containers a session started get cleaned up when it dies."
-date: "2026-08-05"
+date: "2026-08-05T06:52:44Z"
 ---
 
 > Covers everything since **v0.11.2**.

--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
@@ -6,7 +6,7 @@ date: "2026-08-05T06:52:44Z"
 
 > Covers everything since **v0.11.2**.
 >
-> **macOS users should go straight to [0.12.1](/changelog/agent-orchestrator-0-12-1).** This build leaks file descriptors and breaks the Files view and task creation after a few hours of use.
+> **macOS users should go straight to [0.12.1](/changelog/agent-orchestrator-0-12-1) or later.** This build leaks file descriptors and breaks the Files view and task creation after a few hours of use.
 
 0.11.0 was about the foundation holding weight. 0.12.0 is what got built on it: the app now speaks eight languages, the sidebar and settings work the way you would expect them to, and a class of failure that could wipe every session off your board is gone.
 

--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
@@ -1,0 +1,97 @@
+---
+title: "Agent Orchestrator 0.12.0"
+description: "80 commits since 0.11.2. The desktop app now speaks eight languages, sits on a new color palette, and lets you pin sessions and pick a reviewer per session. The mobile app got theming and hold-to-talk dictation. Containers a session started get cleaned up when it dies."
+date: "2026-08-05"
+---
+
+> Covers everything since **v0.11.2**.
+
+0.11.0 was about the foundation holding weight. 0.12.0 is what got built on it: the app now speaks eight languages, the sidebar and settings work the way you would expect them to, and a class of failure that could wipe every session off your board is gone.
+
+80 commits from 22 authors, 26 features and 44 fixes, no breaking changes.
+
+---
+
+## Highlights
+
+### The app speaks eight languages
+
+The desktop app has a real localization layer now, built on i18next, with the language picked under **Settings > General** and remembered in `~/.ao/ui-settings.json`. Simplified Chinese landed first and covers the shell chrome, sidebar, board, settings, dialogs, inspector tabs, command palette and terminal copy. Japanese, Korean, Spanish, French, German and Brazilian Portuguese followed, along with READMEs in each. English stays the default and the fallback, so an untranslated string shows English rather than a key. (#3465, #3541)
+
+### Mobile: themes, native sheets, and hold-to-talk
+
+The mobile app is no longer dark-only. It ships light and dark palettes plus a "system" preference that keeps following the OS instead of latching onto whatever it read at launch, with the app shell rebuilt on native sheets and the session board splitting on terminated runtime rather than finished status.
+
+It also has **push-to-talk dictation**. Hold the mic key in the composer to speak, release to insert, or swipe up to latch it hands-free. Recognition runs on-device (iOS `SFSpeechRecognizer`, Android `SpeechRecognizer`), so there is no API key and no per-minute cost, and it is biased toward the vocabulary that agent prompts are full of, so you get "git" and "npm" instead of "get" and "MPM". The transcript lands in the composer as an editable draft rather than sending, because speech-to-text mishears code often enough that silent submission is not safe. Held bursts append, so several presses build one prompt.
+
+Plus a Liquid Glass app icon matching the desktop build, and a fix for the default LAN port, which pointed at the loopback-only daemon port instead of the mobile bridge on 3011, so a fresh install could not connect without hand-editing it. (#3399, #3400, #3304, #3494)
+
+### A new color foundation
+
+The renderer moved onto an oklch design token palette with Geist as the UI font and shadcn color aliases mapped onto it, replacing hardcoded values across the component library. Session status now has one consistent palette everywhere it appears: working is blue, needs-you is orange, in-review is yellow, ready is green. (#3421)
+
+### Pin the sessions you keep coming back to
+
+Sessions can be pinned to a **Pinned** section at the top of the sidebar, persisted server-side so the pin survives a restart. The sidebar itself became collapsible: Pinned and Projects each fold away, and a click on a project's folder icon expands or collapses it without switching to it first. (#3511, #3310)
+
+### Pick the reviewer per session
+
+The reviewer agent used to be a single project-wide setting. You can now pick one for an individual session, and running that pass will not change what any other session in the project uses. The Reviews tab also lists every recorded pass for the session instead of only the current and previous run for a PR, so you can compare what two different reviewers said. A declined review, when the daemon reuses an existing pass rather than running a new one, no longer reports itself as a success. (#3477)
+
+### Settings opens as a modal
+
+Settings and project settings open over the board instead of navigating away from it, with a sidebar for General, Updates, Developer and Help. Escape or a click outside closes it, and you land back where you were. (#3497)
+
+### Notifications you can act on
+
+When a session needs you and the window is not focused, the macOS dock bounces, the Windows taskbar flashes until you come back, and the badge count of unread notifications stays in sync on macOS, Windows and Linux.
+
+Inside the panel, whole rows are click targets rather than just the title text, and the manual Unread/All tabs and mark-as-read are gone. Notifications now track two independent things: whether you have seen it (cleared when you open the panel) and whether the underlying issue is still open (written only by lifecycle). A notification you already read stays listed while the thing it reported is unresolved, and closes itself when the session leaves the needs-input state, terminates, or the PR merges or closes. Transitions that happened while the daemon was down are re-checked at startup. (#2534, #3296, #3495, #3558)
+
+### Command palette actions and a menu bar tray
+
+Cmd/Ctrl+K now carries session actions, not just navigation, and the task composer behind New Task was extracted so the palette can spawn work with the same UI. macOS also gets an attention tray icon in the menu bar for sessions waiting on you. (#3531)
+
+### Containers a session started get cleaned up
+
+Docker containers a session launched are removed when that session reaches a terminal state, including when it crashes or is SIGKILLed rather than only when you kill it explicitly. Label a container `ao.session=$AO_SESSION_ID` to have it reaped, or `ao.spare=true` for shared infrastructure that should outlive the session. Docker calls are bounded by a timeout, and a project that fails to load fails closed rather than reaping. (#3153)
+
+### Files and diffs
+
+The Files panel replaced its toggled search button and file-count label with an always-visible search input, dropped the refresh button (the list already polls), and rebuilt the list as an accordion with a live file count on the tab. The diff viewer streams workspace changes as they happen, has a clearer layout toggle and inline per-file feedback, and expands properly in the maximized view. Workspace diffs are also base-aware now, so a child session diffs against the branch it actually came from instead of a fixed base. (#3466, #3503, #3492, #3369, #3214)
+
+---
+
+## Reliability
+
+**One outage no longer wipes your board.** This was the big one (#3475). Three separate bugs could archive every session at once. Preview teardown group-killed a bare PID without re-verifying it still belonged to the process it launched, and a recycled PID number took out an unrelated process family; because a tmux server is its own group leader, one stale group kill destroyed every session. A tmux "no server running" probe was read as per-session death when it says nothing about any individual session, so a server hiccup archived the board. And a burned migration returned 500s that the board treated as absent sessions. Liveness probes now report inconclusive instead of dead, the reaper refuses to conclude a pass where most of the board probes dead simultaneously, and the migration ledger repairs itself on histories that were already burned. (#3491, #3598)
+
+**Orchestrators.** Duplicate active orchestrators can no longer be created for the same project, `ao session ls` surfaces hidden orchestrator sessions and counts hidden terminated ones instead of quietly dropping them, and the automated orchestrator re-engagement messages were reverted after they proved noisier than useful. (#3397, #3393, #3394)
+
+**Agents.** Droid forwards role-specific model config through its settings file, written under the data dir rather than a temp directory. Grok prompts are delivered after its TUI finishes starting instead of into a terminal that is not listening yet, and its terminal scrolls with the wheel. The internal fake test harness no longer shows up in agent pickers. (#3156, #3534, #3533, #3518)
+
+**Browser.** Annotation selection is locked while a prompt is in flight so a click cannot retarget it mid-send, native views no longer paint over the app when hidden, URL editing works in the maximized browser on macOS, the element selector badge is out of the annotation dialog, and switching away from a session and back no longer re-asserts a preview URL you had already navigated away from. (#3232, #3295, #3488, #3464, #3538, #3370)
+
+**Desktop.** The auto-updater logs 404s on missing release manifests instead of raising a dialog telling you to check an auth token you do not have. Sidebar and inspector drags clamp at their minimum width rather than snapping shut. The daemon ignores SIGPIPE on closed output. PR and Completion sections in the inspector stay hidden when there is nothing in them, and duplicate PR summaries are deduped. Alongside those, a pass of chrome fixes: titlebar nav aligned to the macOS traffic lights, terminal tab bar polish, settings and archive hairlines, terminal topbar padding, and text selection disabled on app chrome and marketing pages. (#3012, #3478, #3193, #3325, #3250, #3505, #3480, #3507, #3556, #3508, #3520)
+
+---
+
+## Under the hood
+
+Telemetry gained a runtime kill switch: `AO_TELEMETRY_DISABLED_EVENTS` silences named streams (with `*` prefix matching) without shipping a release, and silenced streams still land in local SQLite so they stay debuggable. Daemon events are stamped with a version, update events are recorded, PostHog controls were hardened, and autocapture is asserted off in tests. CI now emits a Linux `.rpm` alongside the `.deb`.
+
+On the site: docs are published as Markdown twins with the full hierarchy exposed in `llms.txt`, agent comparison pages were added, the hero board, delegation demo and mobile mockup were rebuilt to match what the desktop app actually looks like, and the iOS beta CTA went live. Duplicate Organization structured data was removed and content signals now apply to allowed crawlers. (#3401, #3388, #3406, #3395, #3363, #3438, #3344, #3430, #3496, #3428, #3429, #3500, #3521, #3522, #3144, #3367, #3365, #3389)
+
+---
+
+## Upgrading
+
+GitHub Releases and Homebrew are the supported install paths. Existing installs update in place. If a previous update left your migration ledger in a broken state, 0.12.0 repairs it on start rather than failing the boot.
+
+---
+
+## Contributors
+
+22 authors landed work in this range. Thanks to Just_Anniee, prateek, ronish, VenkataSakethDakuri, Vaibhaav Tiwari, Prasad Ware, Pulkit Saraf, Khushi Diwan, Harshit Singh Bhandari, Tamish Mhatre, Maaz, Hardik Sharma, Anmol, AllBeingsFuture, Aditi, vanshx999, i-trytoohard, achal, Yash Maheshwari, Keshav Varshney, AshutoshIIT1234 and Apoorv Singh.
+
+**Full changelog:** https://github.com/Untrivial-ai/agent-orchestrator/compare/v0.11.2...v0.12.0

--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-12-1.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-12-1.mdx
@@ -1,12 +1,14 @@
 ---
 title: "Agent Orchestrator 0.12.1"
-description: "28 commits on the same day as 0.12.0. Nine color themes including Nord, Gruvbox and Solarized, per-agent model selection with a real catalog, new tasks that can go through the project orchestrator, and a merge button for a PR that is ready."
+description: "Nine color themes including Nord, Gruvbox and Solarized, per-agent model selection with a real catalog, new tasks that can go through the project orchestrator, and a merge button for a PR that is ready. Also fixes a macOS file descriptor leak from 0.12.0."
 date: "2026-08-05T18:28:27Z"
 ---
 
 > Covers everything since **v0.12.0**.
+>
+> **On macOS, update and then reboot.** 0.12.0 leaked file descriptors, and relaunching the app is not always enough to stop the old daemon binary from serving. See [the postmortem](https://github.com/Untrivial-ai/agent-orchestrator/discussions/3646).
 
-A same-day follow-up to 0.12.0. Most of it is finishing work that 0.12.0 started: the token palette now has themes on top of it, the sidebar it redesigned has animation, and the reviews and browser surfaces it reworked got their rough edges taken off. Two larger pieces landed alongside: per-agent model selection and orchestrator task delegation.
+A same-day follow-up to 0.12.0. Most of it is finishing work that 0.12.0 started: the token palette now has themes on top of it, the sidebar it redesigned has animation, and the reviews and browser surfaces it reworked got their rough edges taken off. Two larger pieces landed alongside, per-agent model selection and orchestrator task delegation, and the macOS descriptor leak that prompted the release is fixed.
 
 28 commits, 6 features and 17 fixes, no breaking changes.
 
@@ -46,7 +48,7 @@ Project lists animate open and closed, the sidebar itself opens and closes on a 
 
 ## Fixes
 
-**Resource leaks.** The workspace file watcher leaked a file descriptor per watched file on macOS, so a long-lived session watching a large tree would climb toward the process limit. (#3624)
+**The macOS descriptor leak.** On 0.12.0, the live Files view leaked file descriptors on macOS and never released them, so after a few hours of use the Files view came up blank and creating a task started failing with a 500. The cause was fsnotify v1.9.0's kqueue backend; 0.12.1 bumps it and adds a regression test on descriptor counts after teardown. Linux and Windows were never affected. [Postmortem](https://github.com/Untrivial-ai/agent-orchestrator/discussions/3646). (#3624)
 
 **Terminals.** A terminal keeps its viewport across navigation instead of resetting scroll position when you come back, and shows the latest output on return. (#3371)
 
@@ -66,6 +68,8 @@ Project lists animate open and closed, the sidebar itself opens and closes on a 
 
 ## Upgrading
 
-GitHub Releases and Homebrew are the supported install paths. Existing installs update in place, and there is nothing to do by hand coming from 0.12.0.
+GitHub Releases and Homebrew are the supported install paths. Existing installs update in place.
+
+On macOS, reboot after updating. When a daemon is already running and was not started by the app, the app attaches to it instead of owning it, so quitting and reopening leaves the old binary serving requests. Rebooting is the reliable way to be sure you are actually on 0.12.1. That attach behavior is being tracked as its own issue.
 
 **Full changelog:** https://github.com/Untrivial-ai/agent-orchestrator/compare/v0.12.0...v0.12.1

--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-12-1.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-12-1.mdx
@@ -1,0 +1,71 @@
+---
+title: "Agent Orchestrator 0.12.1"
+description: "28 commits on the same day as 0.12.0. Nine color themes including Nord, Gruvbox and Solarized, per-agent model selection with a real catalog, new tasks that can go through the project orchestrator, and a merge button for a PR that is ready."
+date: "2026-08-05T18:28:27Z"
+---
+
+> Covers everything since **v0.12.0**.
+
+A same-day follow-up to 0.12.0. Most of it is finishing work that 0.12.0 started: the token palette now has themes on top of it, the sidebar it redesigned has animation, and the reviews and browser surfaces it reworked got their rough edges taken off. Two larger pieces landed alongside: per-agent model selection and orchestrator task delegation.
+
+28 commits, 6 features and 17 fixes, no breaking changes.
+
+---
+
+## Highlights
+
+### Nine color themes
+
+0.12.0 shipped the oklch token foundation. This turns it into something you can pick from: a **Color Theme** row above the light/dark Mode row in Settings > General, listing nine themes. Nord, Gruvbox and Solarized are new, each with dark and light variants built on the same contrast curve as the existing ones. The theme-style plumbing had been declared but never actually wired to anything, so the stored choice is now applied at startup instead of being ignored.
+
+Switching a theme also stopped looking broken. The swap happens under a View Transitions snapshot so colors change in one cut rather than every element tweening its own background at its own pace, and the terminal palette now syncs on the toggle instead of showing stale colors until the next remount. (#3585, #3620, #3587)
+
+### Model selection that knows what the agent supports
+
+Model configuration went from a text field you had to get right to a real picker. Each agent's models are discovered from its own config files and cached in a local catalog, then offered in a searchable combobox in project settings, per agent. The catalog is served cache-first and revalidated in the background, with indexed search so a large model list stays responsive. (#3386)
+
+### Hand a new task to the project orchestrator
+
+New Task can now delegate to the project's orchestrator session instead of always spawning a worker directly, so a task can be routed and broken down by the orchestrator that already has the project's context. The dialog's fields were simplified around the choice. (#3443)
+
+### Merge a PR that is ready, from the app
+
+The session inspector gained a merge action for a PR in the ready state, going through a guarded merge path rather than a raw merge call, and it now says why a merge is blocked instead of just refusing. The merged status chip also has enough contrast to read. (#3599, #3589)
+
+### Browser annotations, rebuilt
+
+The annotate overlay was rebuilt on the same tokens and copy conventions as the diff viewer's inline feedback box, and it can select multiple elements by holding shift. Annotations reflow when the embedded viewport changes rather than stranding a prompt off-screen, and the inspector no longer shrinks to an unusable clipped width.
+
+The overlay's font also renders correctly now. It used to load Geist through an `@font-face` `src: url(data:...)` rule, which the annotated page's own content security policy could silently block, quietly falling back to the OS font. It is registered as a `FontFace` on the shadow root instead, which fetches nothing and so is not subject to the page's policy. (#3549)
+
+### The sidebar moves
+
+Project lists animate open and closed, the sidebar itself opens and closes on a spring, and the topbar's project label animates with it. Project rows have a right-click context menu, session rows have a kill button, and the redesign respects the OS reduced-motion setting rather than animating regardless. (#3490)
+
+---
+
+## Fixes
+
+**Resource leaks.** The workspace file watcher leaked a file descriptor per watched file on macOS, so a long-lived session watching a large tree would climb toward the process limit. (#3624)
+
+**Terminals.** A terminal keeps its viewport across navigation instead of resetting scroll position when you come back, and shows the latest output on return. (#3371)
+
+**Browser.** Switching tabs could leave the previous tab's content on screen, because the native overlay was not explicitly torn down on selection. Overlay cleanup is explicit now, with a test covering repeated activation of the same tab. (#3579)
+
+**Agents.** Kimi installs that are authenticated through credential tokens rather than an API key are detected as authenticated, instead of being reported as needing setup. (#3603)
+
+**Storage.** The 0044 review-batch backfill was missing from the shipped-migrations ledger, the gap that the 0.12.0 repair work exists to prevent. (#3611)
+
+**Reviews.** Review summaries render only when a summary is actually present, so an empty pass no longer leaves a blank block, and the review controls row lays out its actions inline. An obsolete review result reducer was removed. (#3608, #3559)
+
+**Chrome.** Dev settings use circular minus and plus steppers instead of native number spinners, which behaved differently on every platform. Alongside that: terminal tabs flush to the topbar edge, pinned session rows aligned, the terminal gutter preserved, modal footer buttons unified with equal edge padding, the session page topbar fixed, the import mode picker illustration restyled, and the report problem button on the primary footer style. (#3588, #3590, #3592, #3586, #3584, #3560, #3583, #3578)
+
+**Landing.** The feedback loop demo was rebuilt to mirror the session view and its chrome matched to it, the Feature 4 project mockup improved, and the trusted-agents marquee widened so its heading stays on one line. (#3605, #3616, #3561, #3457)
+
+---
+
+## Upgrading
+
+GitHub Releases and Homebrew are the supported install paths. Existing installs update in place, and there is nothing to do by hand coming from 0.12.0.
+
+**Full changelog:** https://github.com/Untrivial-ai/agent-orchestrator/compare/v0.12.0...v0.12.1


### PR DESCRIPTION
Adds curated changelog entries for stable **v0.12.0** and **v0.12.1**, and stamps the desktop app version to match what shipped.

Same shape as the 0.11.0 entry from #3140: MDX in `content/changelog/`, which takes precedence over the auto-populated GitHub Release body for the same version.

## 0.12.0 (`v0.11.2..v0.12.0`, 80 commits, 26 feat, 44 fix, 22 authors)

- i18next foundation with Simplified Chinese, then ja/ko/es/fr/de/pt-BR plus translated READMEs (#3465, #3541)
- Mobile light/dark theming, native sheets, rebuilt app shell, push-to-talk dictation, Liquid Glass icon (#3399, #3400, #3304, #3494)
- oklch design token palette, Geist font, shadcn color aliases, unified status colors (#3421)
- Session pinning and collapsible sidebar sections (#3511, #3310)
- Per-session reviewer choice with every recorded pass in one view (#3477)
- Settings as a modal (#3497)
- Notification dock bounce, taskbar flash, badge count, clickable rows, auto-resolution (#2534, #3296, #3495, #3558)
- Command palette session actions and macOS attention tray (#3531)
- Docker container reaping on terminal session state (#3153)
- Files panel accordion and the streamlined, base-aware diff viewer (#3466, #3503, #3492, #3369, #3214)
- Reliability leads with the board-wiping class of failure from #3475 (#3491, #3598)

## 0.12.1 (`v0.12.0..v0.12.1`, 28 commits, 6 feat, 17 fix)

- Nine color themes with Nord, Gruvbox and Solarized, plus the theme-style wiring that had been declared but never applied (#3585, #3620, #3587)
- Adapter-aware model selection with a discovered, cached per-agent catalog (#3386)
- New tasks can be delegated through the project orchestrator (#3443)
- Merge a ready PR from the inspector, with merge blockers explained (#3599, #3589)
- Browser annotation rebuilt, shift to multi-select, and the CSP-blocked font fixed (#3549)
- Sidebar animations, project context menu, reduced-motion respected (#3490)
- The macOS file descriptor leak that prompted the release: the live Files view leaked descriptors and never released them, so the Files view went blank and task creation 500'd after a few hours (fsnotify v1.9.0 kqueue, [postmortem](https://github.com/Untrivial-ai/agent-orchestrator/discussions/3646)) (#3624)
- Terminal viewport retained across navigation (#3371), wrong tab content after switching (#3579), authenticated Kimi detection (#3603), the missing 0044 shipped-migrations entry (#3611)

### Why only 0.12.0 and 0.12.1 get curated MDX

`src/lib/changelog.ts` pulls every stable `vMAJOR.MINOR.PATCH` release from GitHub at build time and renders its release body, with curated MDX winning for the same version. 0.12.2 through 0.12.6 already list that way, so they need no file here. Only 0.12.0 and 0.12.1 were missing usable bodies.

## Version stamp

`frontend/package.json` has been stuck at `0.10.3` since #2637, through v0.11.0, v0.11.1, v0.11.2 and all of the 0.12.x line. It is now `0.12.6`, which is the current latest release (published 2026-08-16).

This matters beyond cosmetics: `frontend-release.yml` derives the release tag it publishes to from this field rather than from the git tag (`tag="v$(node -p "require('./package.json').version")"`), so a `workflow_dispatch` run against the repo as it stands would target `v0.10.3`. The real release path sets the version itself, so shipped assets are named correctly; this brings the checked-in value back in line with them.

The lockfile's root `version` is updated alongside so the two stay in sync. #2637 changed `package.json` alone and let them drift.

## Dates

Both entries carry the release publish timestamp from the GitHub API rather than a bare date (`2026-08-05T06:52:44Z` and `2026-08-05T18:28:27Z`). Both shipped the same day, and the list sorts on that value, so a bare date would have rendered 0.12.1 below 0.12.0.

## Verification

Entry contents were cross-checked against the real ranges rather than taken on trust. Every PR number cited in the 0.12.1 entry (28 of 28) appears in `git log v0.12.0..v0.12.1`; in the 0.12.0 entry, 66 of the 67 numbers appear in `git log v0.11.2..v0.12.0`, and the one that does not, #3475, is cited as the tracking issue for the board-wipe outage, not as a PR.

`npm ci && npm run build` in `frontend/src/landing` passes on the rebased branch, with `NODE_ENV` unset:

```
✓ Generating static pages using 7 workers (89/89) in 3.7s
> node scripts/generate-markdown-twins.mjs
Generated 46 documentation Markdown twins
```

The static export prerenders `agent-orchestrator-0-12-0.html` and `agent-orchestrator-0-12-1.html`, and there is no `v0-12-0.html` or `v0-12-1.html` alongside them, so the dedupe against the GitHub Release body holds. On `/changelog` the order is 0.12.6, 0.12.5, 0.12.4, 0.12.3, 0.12.2, 0.12.1, 0.12.0, 0.11.2, so the new entries slot in correctly.

No em dashes or en dashes in either entry, checked against the rendered HTML (0 matches in both files).

## macOS note

Both entries carry the leak note. 0.12.1 spells out the reboot step, since an attached daemon keeps serving the old binary across an app update. The 0.12.0 entry points macOS readers at 0.12.1 or later, since every 0.12.x patch since then carries the fix.
