### PR TITLE
fix(scm): guard all paginated check runs

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -134,9 +134,13 @@ func (p *Provider) CommitChecksGuard(ctx context.Context, repo ports.SCMRepo, he
 		previous.PageETags = make([]string, pageCount)
 		previous.PageETags[0] = resp.ETag
 	} else {
+		// total_count is present in every page representation, so page growth or
+		// shrinkage changes each stored page's ETag; all 304s imply a stable count.
 		pageCount = min(len(previous.PageETags), githubCheckRunsMaxPages)
 	}
 
+	// A missing page ETag is retained as an empty validator: that page is fetched
+	// unconditionally and keeps the guard changed, favoring freshness over 304 savings.
 	pageETags := make([]string, 0, pageCount)
 	changed := !composite
 	for page := 1; page <= pageCount; page++ {

--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -7,6 +7,7 @@ package github
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -21,7 +22,11 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-const scmBatchCheckContextLimit = 20
+const (
+	scmBatchCheckContextLimit = 20
+	githubCheckRunsPageSize   = 100
+	checkRunsGuardPrefix      = "ao-github-check-runs-v1:"
+)
 
 const (
 	// githubReviewThreadPageSize fetches the latest review window cheaply for
@@ -94,75 +99,80 @@ func (p *Provider) ListOpenPRsByRepo(ctx context.Context, repo ports.SCMRepo) ([
 	}
 }
 
-// githubCheckRunsPageSize fetches the complete check-run set for a commit in a
-// single REST page when the commit has no more than this many runs. A commit
-// virtually never exceeds GitHub's 100-result cap, so one request carries the
-// whole representation and GitHub's ETag reflects every contributing run.
-const githubCheckRunsPageSize = 100
-
 // restCheckRunsPage is the GitHub list-check-runs response envelope.
 type restCheckRunsPage struct {
-	TotalCount int                  `json:"total_count"`
-	CheckRuns  []restCommitCheckRun `json:"check_runs"`
+	TotalCount int `json:"total_count"`
 }
 
-// restCommitCheckRun is the subset of a GitHub check-run we condition the
-// aggregate CI-state guard on.
-type restCommitCheckRun struct {
-	Name       string `json:"name"`
-	Status     string `json:"status"`
-	Conclusion string `json:"conclusion"`
-}
-
-// CommitChecksGuard checks GitHub's per-commit check-runs guard. It conditions
-// the fast CI-state guard on the complete check-run set rather than a single
-// item: GitHub's ETag for a per_page=1 response only reflects that one run, so
-// a different workflow finishing (or failing, or going pending) can leave the
-// returned item unchanged and GitHub answers 304 even though the aggregate CI
-// state AO displays has changed. Requesting the full page makes the guard
-// represent all runs that contribute to the state, and paginating plus
-// fingerprinting stays correct when a commit carries more than one page of
-// runs. DefaultPRMaxAge remains the safety backstop for PR metadata changes not
-// represented by check-state guards.
+// CommitChecksGuard conditions the fast CI-state guard on every latest check
+// run. Single-page responses keep GitHub's ETag directly. Paginated responses
+// use an opaque token containing one ETag per page, so every unchanged page can
+// return a cheap 304 and a transition on any later page invalidates the guard.
 func (p *Provider) CommitChecksGuard(ctx context.Context, repo ports.SCMRepo, headSHA, etag string) (ports.SCMGuardResult, error) {
 	if strings.TrimSpace(headSHA) == "" {
 		return ports.SCMGuardResult{}, fmt.Errorf("%w: empty head sha", ErrNotFound)
 	}
-	q := url.Values{}
-	q.Set("per_page", strconv.Itoa(githubCheckRunsPageSize))
-	resp, err := p.client.doRESTWithETag(ctx, repoPath(repo.Owner, repo.Name, "commits", headSHA, "check-runs"), q, etag)
-	if err != nil {
-		return ports.SCMGuardResult{}, err
-	}
-	if resp.NotModified {
-		// GitHub confirmed the whole first page is unchanged, which covers every
-		// run for the overwhelmingly common single-page case.
-		return ports.SCMGuardResult{ETag: firstNonEmptyHeader(resp.ETag, etag), NotModified: true}, nil
-	}
-	page, err := decodeRestCheckRunsPage(resp.Body)
-	if err != nil {
-		// Decode failure is unexpected but shouldn't block the whole repo poll.
-		// Return NotModified=false with no ETag so the observer falls back to the
-		// full GraphQL refresh path; DefaultPRMaxAge bounds staleness.
-		return ports.SCMGuardResult{}, nil //nolint:nilerr // decode failure falls back to the max-age refresh path
-	}
-	if page.TotalCount > len(page.CheckRuns) {
-		// The commit has more runs than one page fits; rely on a stable
-		// fingerprint over the complete set instead of a single page's ETag so a
-		// transition on a later page still invalidates the guard.
-		runs, err := p.fetchRemainingCommitCheckRuns(ctx, repo, headSHA, page)
+	previous, composite := decodeCheckRunsGuard(etag)
+	path := repoPath(repo.Owner, repo.Name, "commits", headSHA, "check-runs")
+	var pageCount int
+	if !composite {
+		resp, err := p.fetchCommitChecksGuardPage(ctx, path, 1, etag)
 		if err != nil {
 			return ports.SCMGuardResult{}, err
 		}
-		fp := commitCheckRunsFingerprint(runs)
-		if etag == fp {
-			return ports.SCMGuardResult{ETag: fp, NotModified: true}, nil
+		if resp.NotModified {
+			return ports.SCMGuardResult{ETag: firstNonEmptyHeader(resp.ETag, etag), NotModified: true}, nil
 		}
-		return ports.SCMGuardResult{ETag: fp}, nil
+		page, err := decodeRestCheckRunsPage(resp.Body)
+		if err != nil {
+			return ports.SCMGuardResult{}, nil //nolint:nilerr // force the full refresh without failing the repo poll
+		}
+		pageCount = checkRunsPageCount(page.TotalCount)
+		if pageCount == 1 {
+			return ports.SCMGuardResult{ETag: firstNonEmptyHeader(resp.ETag, etag)}, nil
+		}
+		previous.PageETags = make([]string, pageCount)
+		previous.PageETags[0] = resp.ETag
+	} else {
+		pageCount = min(len(previous.PageETags), githubCheckRunsMaxPages)
 	}
-	// A single page carried the whole representation: GitHub's ETag is the
-	// correct validator, so any run transition yields a fresh ETag.
-	return ports.SCMGuardResult{ETag: firstNonEmptyHeader(resp.ETag, etag)}, nil
+
+	pageETags := make([]string, 0, pageCount)
+	changed := !composite
+	for page := 1; page <= pageCount; page++ {
+		previousETag := ""
+		if page <= len(previous.PageETags) {
+			previousETag = previous.PageETags[page-1]
+		}
+		if !composite && page == 1 {
+			pageETags = append(pageETags, previousETag)
+			continue
+		}
+		resp, err := p.fetchCommitChecksGuardPage(ctx, path, page, previousETag)
+		if err != nil {
+			return ports.SCMGuardResult{}, err
+		}
+		pageETags = append(pageETags, firstNonEmptyHeader(resp.ETag, previousETag))
+		if resp.NotModified {
+			continue
+		}
+
+		changed = true
+		pageBody, err := decodeRestCheckRunsPage(resp.Body)
+		if err != nil {
+			return ports.SCMGuardResult{}, nil //nolint:nilerr // force the full refresh without failing the repo poll
+		}
+		pageCount = checkRunsPageCount(pageBody.TotalCount)
+	}
+	if len(pageETags) > pageCount {
+		pageETags = pageETags[:pageCount]
+	}
+
+	guard, err := encodeCheckRunsGuard(checkRunsGuard{PageETags: pageETags})
+	if err != nil {
+		return ports.SCMGuardResult{}, err
+	}
+	return ports.SCMGuardResult{ETag: guard, NotModified: composite && !changed}, nil
 }
 
 // decodeRestCheckRunsPage unmarshals a GitHub list-check-runs body.
@@ -174,44 +184,50 @@ func decodeRestCheckRunsPage(body []byte) (restCheckRunsPage, error) {
 	return page, nil
 }
 
-// fetchRemainingCommitCheckRuns gathers the check runs a commit carries beyond
-// the first page and returns every run across all pages.
-func (p *Provider) fetchRemainingCommitCheckRuns(ctx context.Context, repo ports.SCMRepo, headSHA string, page restCheckRunsPage) ([]restCommitCheckRun, error) {
-	runs := append([]restCommitCheckRun(nil), page.CheckRuns...)
-	for pageNum := 2; len(runs) < page.TotalCount && pageNum <= githubCheckRunsMaxPages; pageNum++ {
-		q := url.Values{}
-		q.Set("per_page", strconv.Itoa(githubCheckRunsPageSize))
-		q.Set("page", strconv.Itoa(pageNum))
-		resp, err := p.client.doREST(ctx, http.MethodGet, repoPath(repo.Owner, repo.Name, "commits", headSHA, "check-runs"), q, nil)
-		if err != nil {
-			return nil, err
-		}
-		next, err := decodeRestCheckRunsPage(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-		runs = append(runs, next.CheckRuns...)
-		if len(next.CheckRuns) == 0 {
-			break
-		}
-	}
-	return runs, nil
+func (p *Provider) fetchCommitChecksGuardPage(ctx context.Context, path string, page int, etag string) (RESTResponse, error) {
+	q := url.Values{}
+	q.Set("filter", "latest")
+	q.Set("per_page", strconv.Itoa(githubCheckRunsPageSize))
+	q.Set("page", strconv.Itoa(page))
+	return p.client.doRESTWithETag(ctx, path, q, etag)
 }
 
-// commitCheckRunsFingerprint is a stable hash of a commit's complete check-run
-// set, sorted so the order GitHub returns runs in cannot matter. It only hashes
-// the fields that determine the aggregate CI state (name, status, conclusion).
-func commitCheckRunsFingerprint(runs []restCommitCheckRun) string {
-	parts := make([]string, len(runs))
-	for i, r := range runs {
-		parts[i] = strings.Join([]string{r.Name, r.Status, r.Conclusion}, "\x00")
+type checkRunsGuard struct {
+	PageETags []string `json:"page_etags"`
+}
+
+func checkRunsPageCount(totalCount int) int {
+	if totalCount <= 0 {
+		return 1
 	}
-	return stableCheckFingerprint(parts)
+	return min(1+(totalCount-1)/githubCheckRunsPageSize, githubCheckRunsMaxPages)
+}
+
+func encodeCheckRunsGuard(guard checkRunsGuard) (string, error) {
+	b, err := json.Marshal(guard)
+	if err != nil {
+		return "", fmt.Errorf("github scm: encode commit check-runs guard: %w", err)
+	}
+	return checkRunsGuardPrefix + base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func decodeCheckRunsGuard(value string) (checkRunsGuard, bool) {
+	encoded, ok := strings.CutPrefix(value, checkRunsGuardPrefix)
+	if !ok {
+		return checkRunsGuard{}, false
+	}
+	b, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return checkRunsGuard{}, false
+	}
+	var guard checkRunsGuard
+	if err := json.Unmarshal(b, &guard); err != nil || len(guard.PageETags) == 0 {
+		return checkRunsGuard{}, false
+	}
+	return guard, true
 }
 
 // stableCheckFingerprint computes a stable SHA256 hash of a sorted string slice.
-// The slice is sorted, joined with "\x1e", then hashed. This shared logic is
-// used by both commitCheckRunsFingerprint and githubFailedFingerprint.
 func stableCheckFingerprint(parts []string) string {
 	sort.Strings(parts)
 	sum := sha256.Sum256([]byte(strings.Join(parts, "\x1e")))

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1609,11 +1609,10 @@ func TestCommitChecksGuard_OtherRunTransitionInvalidatesGuard(t *testing.T) {
 	}
 }
 
-// TestCommitChecksGuard_PaginatedFingerprintInvalidatesLaterPageRun verifies the
-// paginated path: when a commit carries more than one page of check runs, the
-// guard fingerprints the complete set so a transition on a LATER page (invisible
-// to the first page's ETag) still invalidates the guard.
-func TestCommitChecksGuard_PaginatedFingerprintInvalidatesLaterPageRun(t *testing.T) {
+// TestCommitChecksGuard_PaginatedETagsInvalidateLaterPageRun verifies the
+// paginated path: every page is conditionally checked, so a transition on a
+// later page invalidates the composite guard while unchanged pages return 304.
+func TestCommitChecksGuard_PaginatedETagsInvalidateLaterPageRun(t *testing.T) {
 	f := newFakeGH(t)
 	const owner, repo, sha = "octocat", "hello", "abc123"
 	path := repoPath(owner, repo, "commits", sha, "check-runs")
@@ -1656,8 +1655,13 @@ func TestCommitChecksGuard_PaginatedFingerprintInvalidatesLaterPageRun(t *testin
 			shown = state.page2
 		}
 		body, _ := json.Marshal(map[string]any{"total_count": 150, "check_runs": shown})
+		etag := fmt.Sprintf(`W/"%x"`, sha256.Sum256(body))
+		w.Header().Set("ETag", etag)
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("ETag", fmt.Sprintf(`W/"%x"`, sha256.Sum256(body)))
 		_, _ = w.Write(body)
 	})
 	p := newProviderForTest(t, f)
@@ -1670,10 +1674,10 @@ func TestCommitChecksGuard_PaginatedFingerprintInvalidatesLaterPageRun(t *testin
 	if res.NotModified {
 		t.Fatal("first paginated poll reported NotModified")
 	}
-	firstFingerprint := res.ETag
+	firstGuard := res.ETag
 
 	// Unchanged set -> NotModified=true.
-	res, err = p.CommitChecksGuard(ctx(), repoRef, sha, firstFingerprint)
+	res, err = p.CommitChecksGuard(ctx(), repoRef, sha, firstGuard)
 	if err != nil {
 		t.Fatalf("unchanged paginated guard: %v", err)
 	}
@@ -1682,15 +1686,15 @@ func TestCommitChecksGuard_PaginatedFingerprintInvalidatesLaterPageRun(t *testin
 	}
 
 	// Only a page-2 run transitions; page 1 (whose ETag page-1 callers would see)
-	// is untouched. The fingerprint over the whole set must change.
+	// is untouched. The second page's validator must change.
 	mu.Lock()
 	state.page2[49] = map[string]any{"id": 150, "name": "job-150", "status": "completed", "conclusion": "success"}
 	mu.Unlock()
-	res, err = p.CommitChecksGuard(ctx(), repoRef, sha, firstFingerprint)
+	res, err = p.CommitChecksGuard(ctx(), repoRef, sha, firstGuard)
 	if err != nil {
 		t.Fatalf("transitioned paginated guard: %v", err)
 	}
 	if res.NotModified {
-		t.Fatal("guard stayed NotModified after a page-2 run transitioned (fingerprint bug)")
+		t.Fatal("guard stayed NotModified after a page-2 run transitioned")
 	}
 }

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -96,7 +96,8 @@ type Config struct {
 type ObserverCache struct {
 	// RepoPRListETag maps repository keys to the last open-PR-list ETag.
 	RepoPRListETag map[string]string
-	// CommitChecksETag maps repo+commit keys to the last check-runs ETag.
+	// CommitChecksETag maps repo+commit keys to the provider's opaque check-runs
+	// validator. GitHub combines one ETag per page in this token.
 	CommitChecksETag map[string]string
 	// LastReviewPollAt maps PR keys to the last review-thread fetch timestamp.
 	LastReviewPollAt map[string]time.Time

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -43,7 +43,8 @@ type SCMPRRef struct {
 // SCMGuardResult is an ETag-style cache guard result. NotModified maps to HTTP
 // 304 for providers that support it.
 type SCMGuardResult struct {
-	// ETag is the latest provider cache validator for this guard endpoint.
+	// ETag is the latest opaque provider cache validator for this guard. A
+	// provider may combine validators when the guarded representation is paged.
 	ETag string
 	// NotModified is true when the provider reported no change since the ETag.
 	NotModified bool


### PR DESCRIPTION
## Summary

- guard the complete latest check-run representation with one conditional ETag per 100-run page
- encode page validators in an opaque provider token so unchanged pages retain 304 savings
- use total_count to track page growth and shrinkage while preserving the five-minute max-age fallback
- cover a later-page check transition from pending to passing while the first page remains stable

## Tests

- cd backend && go test -race ./internal/adapters/scm/github ./internal/observe/scm
- cd backend && go build ./...
- cd backend && go test ./...

Fixes #3601