### PR TITLE
fix: detect authenticated Kimi installs

### DIFF
--- a/backend/internal/adapters/agent/kimi/auth.go
+++ b/backend/internal/adapters/agent/kimi/auth.go
@@ -2,6 +2,7 @@ package kimi
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -46,7 +47,10 @@ func kimiLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	if !ok {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	return kimiConfigAuthStatus(filepath.Join(home, "config.toml"))
+	if status, ok, err := kimiConfigAuthStatus(filepath.Join(home, "config.toml")); err != nil || ok {
+		return status, ok, err
+	}
+	return kimiCredentialsAuthStatus(filepath.Join(home, "credentials", "kimi-code.json"))
 }
 
 func kimiCodeHome() (string, bool) {
@@ -83,6 +87,32 @@ func kimiConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 				return ports.AgentAuthStatusAuthorized, true, nil
 			}
 		}
+	}
+	return ports.AgentAuthStatusUnauthorized, true, nil
+}
+
+func kimiCredentialsAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+
+	var credentials struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(data, &credentials); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if strings.TrimSpace(credentials.AccessToken) != "" ||
+		strings.TrimSpace(credentials.RefreshToken) != "" {
+		return ports.AgentAuthStatusAuthorized, true, nil
 	}
 	return ports.AgentAuthStatusUnauthorized, true, nil
 }

--- a/backend/internal/adapters/agent/kimi/auth.go
+++ b/backend/internal/adapters/agent/kimi/auth.go
@@ -47,10 +47,18 @@ func kimiLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	if !ok {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	if status, ok, err := kimiConfigAuthStatus(filepath.Join(home, "config.toml")); err != nil || ok {
-		return status, ok, err
+	configStatus, configOK, err := kimiConfigAuthStatus(filepath.Join(home, "config.toml"))
+	if err != nil || configStatus == ports.AgentAuthStatusAuthorized {
+		return configStatus, configOK, err
 	}
-	return kimiCredentialsAuthStatus(filepath.Join(home, "credentials", "kimi-code.json"))
+	credentialsStatus, credentialsOK, err := kimiCredentialsAuthStatus(filepath.Join(home, "credentials", "kimi-code.json"))
+	if err != nil || credentialsOK {
+		return credentialsStatus, credentialsOK, err
+	}
+	if configOK {
+		return configStatus, configOK, nil
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
 }
 
 func kimiCodeHome() (string, bool) {

--- a/backend/internal/adapters/agent/kimi/auth_test.go
+++ b/backend/internal/adapters/agent/kimi/auth_test.go
@@ -42,6 +42,26 @@ base_url = "https://api.z.ai/api/coding/paas/v4"
 	}
 }
 
+func TestKimiLocalAuthStatusUsesKimiCredentials(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+	credentialsDir := filepath.Join(home, "credentials")
+	if err := os.MkdirAll(credentialsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(credentialsDir, "kimi-code.json"), []byte(`{"access_token":"token"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := kimiLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestKimiConfigAuthStatusAuthorizedWithProviderAPIKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(path, []byte(`
@@ -70,6 +90,36 @@ api_key = ""
 	}
 
 	status, ok, err := kimiConfigAuthStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusUnauthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	}
+}
+
+func TestKimiCredentialsAuthStatusAuthorizedWithRefreshToken(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kimi-code.json")
+	if err := os.WriteFile(path, []byte(`{"refresh_token":"token"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := kimiCredentialsAuthStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestKimiCredentialsAuthStatusUnauthorizedWithEmptyTokens(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kimi-code.json")
+	if err := os.WriteFile(path, []byte(`{"access_token":"","refresh_token":"","token_type":"bearer"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := kimiCredentialsAuthStatus(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/adapters/agent/kimi/auth_test.go
+++ b/backend/internal/adapters/agent/kimi/auth_test.go
@@ -62,6 +62,34 @@ func TestKimiLocalAuthStatusUsesKimiCredentials(t *testing.T) {
 	}
 }
 
+func TestKimiLocalAuthStatusCredentialsOverrideEmptyConfigAPIKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[providers.zai-coding-plan]
+api_key = ""
+[providers.moonshot]
+api_key = ""
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	credentialsDir := filepath.Join(home, "credentials")
+	if err := os.MkdirAll(credentialsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(credentialsDir, "kimi-code.json"), []byte(`{"access_token":"token"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := kimiLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestKimiConfigAuthStatusAuthorizedWithProviderAPIKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(path, []byte(`

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -222,7 +222,7 @@ var kimiBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"kimi"},
 	WinNames:      []string{"kimi.cmd", "kimi.exe", "kimi"},
 	UnixPaths:     []string{"/usr/local/bin/kimi", "/opt/homebrew/bin/kimi"},
-	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("kimi", []string{".cargo", "bin", "kimi"}),
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("kimi", []string{".kimi-code", "bin", "kimi"}, []string{".cargo", "bin", "kimi"}),
 	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "kimi.cmd"}},

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -32,6 +32,16 @@ func TestManifest(t *testing.T) {
 	}
 }
 
+func TestKimiBinarySpecIncludesSelfManagedInstallPath(t *testing.T) {
+	want := []string{".kimi-code", "bin", "kimi"}
+	for _, path := range kimiBinarySpec.UnixHomePaths {
+		if reflect.DeepEqual(path, want) {
+			return
+		}
+	}
+	t.Fatalf("UnixHomePaths = %#v, want %v", kimiBinarySpec.UnixHomePaths, want)
+}
+
 func TestGetConfigSpecAdvertisesModelField(t *testing.T) {
 	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
 	if err != nil {


### PR DESCRIPTION
## Summary
- add Kimi self-managed install path (`~/.kimi-code/bin/kimi`) to binary discovery
- recognize Kimi OAuth credential files (`~/.kimi-code/credentials/kimi-code.json`) as authorized when they contain an access or refresh token
- prefer valid credential tokens over empty `config.toml` `api_key` placeholders
- add focused tests for Kimi binary discovery and credential auth classification

## Issue
Kimi was already present in the agents dropdown, but authenticated local installs were still shown as `Needs auth`. The frontend was rendering the daemon catalog correctly; the bad state came from the Kimi adapter's readiness probe.

The local Kimi install shape can be:
- binary at `~/.kimi-code/bin/kimi`
- `config.toml` containing empty `api_key = ""` placeholders
- real OAuth auth stored in `~/.kimi-code/credentials/kimi-code.json`

The adapter did not search the self-managed binary path, and its first OAuth credential support still stopped too early when it saw empty `api_key` values in `config.toml`, classifying the install as unauthorized before checking the credential JSON.
## Before 
<img width="590" height="526" alt="Screenshot 2026-08-05 at 3 17 58 PM" src="https://github.com/user-attachments/assets/07916fae-93fb-47f3-afe3-4a5c63da1a24" />

## After
<img width="588" height="521" alt="Screenshot 2026-08-05 at 3 11 39 PM" src="https://github.com/user-attachments/assets/82fa0216-fd6d-4415-a1ec-674bcd8217c6" />

## Fix
The Kimi adapter now checks `~/.kimi-code/bin/kimi` during binary resolution. For auth, it treats a non-empty config API key as authorized, then checks `credentials/kimi-code.json` for an access or refresh token, and only falls back to the empty config-key unauthorized result when no credential token exists.

With that, the daemon can classify this local Kimi install as installed/authorized, and the existing agents dropdown can show it as available instead of `Needs auth`.

## Tests
- `go test ./internal/adapters/agent/kimi ./internal/service/agent`
- `go test ./internal/adapters/agent/registry ./internal/httpd/controllers -run 'Test.*Agent|TestEveryHarnessReportsAuthStatus|TestHarnessed'`\n- `git diff --check`\n\n## Risks\nLow. The change is scoped to Kimi catalog readiness probes and does not alter launch or restore command behavior.