### PR TITLE
Rebuild the feedback loop demo to mirror the session view

### DIFF
--- a/frontend/src/landing/src/app/components/FeaturesSection/components/FeedbackLoopDemo/FeedbackLoopDemo.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/FeedbackLoopDemo/FeedbackLoopDemo.tsx
@@ -1,239 +1,351 @@
 "use client";
 
-import { AnimatePresence, motion } from "motion/react";
-import {
-	Check,
-	CircleAlert,
-	GitPullRequest,
-	MessageSquare,
-	RotateCw,
-	Terminal,
-} from "lucide-react";
-import { useEffect, useState } from "react";
-import {
-	FeaturePreviewShell,
-	StatusDot,
-	previewStatus,
-} from "../FeaturePreviewShell";
+import { motion } from "motion/react";
+import { GeistMono } from "geist/font/mono";
+import { ArrowUpRight, Files, Globe, GitPullRequest } from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+import { featurePreviewTokens, StatusDot } from "../FeaturePreviewShell";
 
-const states = [
-	{
-		label: "CI failed",
-		color: previewStatus.error,
-		event: "test / web",
-		detail: "AuthCallback › rejects expired state",
-		terminal: [
-			"observer  check failure received from PR #2481",
-			"route     sending failure to owning Claude session",
-			"agent     opening test/auth-callback.test.ts",
-		],
-	},
-	{
-		label: "Agent fixing",
-		color: previewStatus.working,
-		event: "Failure routed",
-		detail: "Claude resumed with CI logs attached",
-		terminal: [
-			"read      callback handler and failing assertion",
-			"edit      preserve state expiry before token exchange",
-			"test      auth callback suite · 12 passed",
-		],
-	},
-	{
-		label: "Checks passed",
-		color: previewStatus.success,
-		event: "10 / 10 checks",
-		detail: "New commit pushed to feat/github-auth",
-		terminal: [
-			"commit    fix(auth): reject expired callback state",
-			"push      feat/github-auth",
-			"observer  all required checks passed",
-		],
-	},
-	{
-		label: "Approved",
-		color: previewStatus.accent,
-		event: "Review resolved",
-		detail: "Ready to merge",
-		terminal: [
-			"review    comment thread resolved",
-			"review    approval received from codex",
-			"queue     PR #2481 is ready to merge",
-		],
-	},
+const tone = {
+  working: "#60a5fa",
+  success: "#4ade80",
+  danger: "oklch(0.704 0.191 22.216)",
+  foreground: "var(--preview-foreground)",
+  muted: "var(--preview-muted-foreground)",
+} as const;
+
+const phases = [
+  {
+    label: "CI failed",
+    status: "Needs attention",
+    color: tone.danger,
+    check: "test / web",
+    checkDetail: "AuthCallback rejects expired state",
+    lines: [
+      { kind: "system", text: "GitHub feedback routed from PR #2481" },
+      { kind: "error", text: "test / web failed: expected 401, received 500" },
+      { kind: "muted", text: "Failure logs attached. Resuming session…" },
+    ],
+  },
+  {
+    label: "Working",
+    status: "Agent fixing",
+    color: tone.working,
+    check: "test / web",
+    checkDetail: "Re-running after the next push",
+    lines: [
+      { kind: "prompt", text: "The expiry check runs after token exchange." },
+      { kind: "action", text: "reading  src/auth/callback.ts" },
+      { kind: "action", text: "editing  validate state before exchange" },
+    ],
+  },
+  {
+    label: "Working",
+    status: "Verifying fix",
+    color: tone.working,
+    check: "Checks running",
+    checkDetail: "Commit 91f8c2a pushed to feat/github-auth",
+    lines: [
+      { kind: "command", text: "npm test -- auth/callback" },
+      { kind: "success", text: "12 tests passed" },
+      { kind: "command", text: "git push origin feat/github-auth" },
+    ],
+  },
+  {
+    label: "In review",
+    status: "Checks passed",
+    color: tone.success,
+    check: "10 / 10 checks",
+    checkDetail: "Required checks passed",
+    lines: [
+      { kind: "success", text: "test / web" },
+      { kind: "success", text: "typecheck" },
+      { kind: "system", text: "PR #2481 returned to review" },
+    ],
+  },
 ] as const;
 
+type Phase = (typeof phases)[number];
+type TerminalLine = Phase["lines"][number];
+
 export function FeedbackLoopDemo() {
-	const [active, setActive] = useState(0);
+  const [active, setActive] = useState(0);
 
-	useEffect(() => {
-		const interval = window.setInterval(
-			() => setActive((current) => (current + 1) % states.length),
-			2300,
-		);
-		return () => window.clearInterval(interval);
-	}, []);
+  useEffect(() => {
+    const interval = window.setInterval(
+      () => setActive((value) => (value + 1) % phases.length),
+      2500,
+    );
+    return () => window.clearInterval(interval);
+  }, []);
 
-	const state = states[active];
+  const phase = phases[active];
 
-	return (
-		<FeaturePreviewShell
-			title="Session · Ship GitHub sign-in"
-			trailing={
-				<div className="flex items-center gap-1.5 text-[9px]" style={{ color: state.color }}>
-					<StatusDot color={state.color} pulse={active === 1} />
-					{state.label}
-				</div>
-			}
-		>
-			<div className="grid h-[318px] grid-cols-1 sm:grid-cols-[190px_minmax(0,1fr)]">
-				<aside className="hidden border-r border-[var(--preview-border)] bg-[var(--preview-card)]/35 p-3 sm:block">
-					<div className="flex items-center gap-2">
-						<img
-							src="/app-icons/coverage-claude-code.svg"
-							alt=""
-							className="size-4"
-							draggable="false"
-						/>
-						<div className="min-w-0">
-							<div className="truncate text-[10px] font-semibold">
-								Claude worker
-							</div>
-							<div className="truncate font-mono text-[9px] text-[var(--preview-muted-foreground)]">
-								feat/github-auth
-							</div>
-						</div>
-					</div>
+  return (
+    <div
+      className="mx-auto w-full min-w-0 max-w-[620px] overflow-hidden rounded-xl border border-[var(--preview-border)] bg-[var(--preview-background)] font-sans text-[var(--preview-foreground)] antialiased shadow-[0_28px_74px_-22px_rgba(0,0,0,0.86)]"
+      style={featurePreviewTokens}
+    >
+      <div className="grid h-[330px] min-w-0 grid-cols-1 grid-rows-[minmax(0,1fr)_42px] sm:h-[370px] sm:grid-cols-[minmax(0,1fr)_208px] sm:grid-rows-1">
+        <AgentPane active={active} phase={phase} />
+        <Inspector active={active} phase={phase} onSelect={setActive} />
+        <MobileActivity active={active} onSelect={setActive} />
+      </div>
+    </div>
+  );
+}
 
-					<div className="mt-4 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--preview-muted-foreground)]">
-						PR #2481
-					</div>
-					<div className="mt-2 space-y-1.5">
-						{states.map((item, index) => {
-							const complete = index < active;
-							const isActive = index === active;
-							return (
-								<button
-									type="button"
-									key={item.label}
-									onClick={() => setActive(index)}
-									className={`relative flex w-full items-start gap-2 rounded-md border px-2 py-2 text-left outline-none transition-colors ${
-										isActive
-											? "border-[var(--preview-ring)] bg-[var(--preview-muted)]"
-											: "border-transparent hover:bg-[var(--preview-muted)]/60"
-									} focus-visible:ring-2 focus-visible:ring-[var(--preview-ring)]`}
-								>
-									<div className="mt-0.5">
-										{complete ? (
-											<Check className="size-3 text-[#74b98a]" />
-										) : index === 0 ? (
-											<CircleAlert
-												className="size-3"
-												style={{ color: isActive ? item.color : "#737373" }}
-											/>
-										) : index === 3 ? (
-											<MessageSquare
-												className="size-3"
-												style={{ color: isActive ? item.color : "#737373" }}
-											/>
-										) : (
-											<StatusDot
-												color={isActive ? item.color : "#737373"}
-												pulse={isActive}
-											/>
-										)}
-									</div>
-									<div className="min-w-0">
-										<div className="truncate text-[9px] font-medium">
-											{item.event}
-										</div>
-										<div className="mt-0.5 truncate text-[9px] text-[var(--preview-muted-foreground)]">
-											{item.label}
-										</div>
-									</div>
-								</button>
-							);
-						})}
-					</div>
-				</aside>
+function AgentPane({ active, phase }: { active: number; phase: Phase }) {
+  return (
+    <main className="flex min-h-0 min-w-0 flex-col overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col bg-[#101317]">
+        <motion.div
+          key={active}
+          initial={{ opacity: 0, y: 5 }}
+          animate={{ opacity: 1, y: 0 }}
+          className={`${GeistMono.className} space-y-2.5 p-4 text-[12px] leading-5 text-[#d7d7d2]`}
+        >
+          {phase.lines.map((line, index) => (
+            <motion.div
+              key={line.text}
+              initial={{ opacity: 0, x: -3 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: index * 0.12 }}
+              className="flex items-start gap-2.5"
+            >
+              <span
+                className="w-3 shrink-0 text-center font-semibold"
+                style={{ color: lineColor(line) }}
+              >
+                {linePrefix(line)}
+              </span>
+              <span
+                className="min-w-0 break-words"
+                style={{ color: lineColor(line) }}
+              >
+                {line.text}
+              </span>
+            </motion.div>
+          ))}
+          {active === 1 ? (
+            <div className="flex items-center gap-2 text-[#7c7c7c]">
+              <span className="size-2 animate-spin rounded-full border border-current border-t-transparent" />
+              working…
+            </div>
+          ) : null}
+        </motion.div>
+      </div>
+    </main>
+  );
+}
 
-				<section className="flex min-w-0 flex-col p-3 sm:p-3.5">
-					<div className="flex items-start justify-between gap-3 rounded-lg border border-[var(--preview-border)] bg-[var(--preview-card)] p-3">
-						<div className="min-w-0">
-							<div className="flex items-center gap-2 text-[10px] font-semibold">
-								<GitPullRequest className="size-3.5" />
-								<span className="truncate">{state.event}</span>
-							</div>
-							<p className="mt-1.5 truncate text-[9px] text-[var(--preview-muted-foreground)]">
-								{state.detail}
-							</p>
-						</div>
-						<motion.div
-							key={state.label}
-							initial={{ opacity: 0, scale: 0.9 }}
-							animate={{ opacity: 1, scale: 1 }}
-							className="shrink-0 rounded px-1.5 py-1 font-mono text-[9px]"
-							style={{
-								backgroundColor: `color-mix(in srgb, ${state.color} 16%, transparent)`,
-								color: state.color,
-							}}
-						>
-							{state.label}
-						</motion.div>
-					</div>
+function Inspector({
+  active,
+  phase,
+  onSelect,
+}: {
+  active: number;
+  phase: Phase;
+  onSelect: (value: number) => void;
+}) {
+  return (
+    <aside className="hidden min-w-0 overflow-hidden border-l border-[var(--preview-border)] bg-[var(--preview-card)]/25 sm:block">
+      <div className="flex h-11 items-center gap-1 border-b border-[var(--preview-border)] px-2.5">
+        <InspectorTab active label="Summary">
+          <SummaryIcon />
+        </InspectorTab>
+        <InspectorTab label="Browser">
+          <Globe className="size-3.5" />
+        </InspectorTab>
+        <InspectorTab label="Files">
+          <Files className="size-3.5" />
+        </InspectorTab>
+      </div>
+      <div className="space-y-2.5 p-2.5">
+        <section>
+          <div className="rounded-lg bg-[var(--preview-card)] px-3.5 py-3">
+            <div className="mb-2 text-[10.5px] font-bold uppercase tracking-[0.08em] text-[var(--preview-muted-foreground)]">
+              Pull request
+            </div>
+            <div className="rounded-lg border border-[var(--preview-border)] bg-[var(--preview-background)]/45 px-2.5 py-2">
+              <div className="flex items-center gap-2 text-[11.5px] font-semibold">
+                <GitPullRequest className="size-3.5" />
+                PR #2481
+                <span className="ml-auto inline-flex items-center gap-0.5 text-[10.5px] text-blue-400">
+                  Open <ArrowUpRight className="size-3" />
+                </span>
+              </div>
+              <div className="mt-2.5 border-t border-[var(--preview-border)] pt-2.5">
+                <div
+                  className="flex items-center gap-1.5 text-[10.5px] font-medium"
+                  style={{ color: phase.color }}
+                >
+                  <StatusDot color={phase.color} pulse={active === 2} />
+                  {phase.check}
+                </div>
+                <div className="mt-1.5 text-[10px] leading-[1.45] text-[var(--preview-muted-foreground)]">
+                  {phase.checkDetail}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
 
-					<div className="mt-3 min-h-0 flex-1 overflow-hidden rounded-lg border border-[var(--preview-border)] bg-black/20">
-						<div className="flex h-8 items-center gap-2 border-b border-[var(--preview-border)] px-3 text-[9px] text-[var(--preview-muted-foreground)]">
-							<Terminal className="size-3" />
-							Agent output
-							<RotateCw
-								className={`ml-auto size-3 ${active === 1 ? "animate-spin" : ""}`}
-							/>
-						</div>
-						<AnimatePresence mode="wait" initial={false}>
-							<motion.div
-								key={active}
-								initial={{ opacity: 0, y: 6 }}
-								animate={{ opacity: 1, y: 0 }}
-								exit={{ opacity: 0, y: -4 }}
-								transition={{ duration: 0.22 }}
-								className="space-y-3 p-3 font-mono text-[9px] leading-4"
-							>
-								{state.terminal.map((line, index) => {
-									const [command, ...rest] = line.split(/\s+/);
-									return (
-										<motion.div
-											key={line}
-											initial={{ opacity: 0, x: -4 }}
-											animate={{ opacity: 1, x: 0 }}
-											transition={{ delay: index * 0.11 }}
-											className="flex gap-3"
-										>
-											<span className="w-12 shrink-0 text-[#7eaaff]">
-												{command}
-											</span>
-											<span className="text-[var(--preview-muted-foreground)]">
-												{rest.join(" ")}
-											</span>
-										</motion.div>
-									);
-								})}
-								{active < 3 ? (
-									<div className="flex items-center gap-2 text-[var(--preview-muted-foreground)]/65">
-										<span className="size-2 animate-spin rounded-full border border-current border-t-transparent" />
-										watching GitHub…
-									</div>
-								) : (
-									<div className="flex items-center gap-2 text-[#74b98a]">
-										<Check className="size-3" />
-										feedback loop complete
-									</div>
-								)}
-							</motion.div>
-						</AnimatePresence>
-					</div>
-				</section>
-			</div>
-		</FeaturePreviewShell>
-	);
+        <section>
+          <div className="rounded-lg bg-[var(--preview-card)] px-3.5 py-3">
+            <div className="mb-2 text-[10.5px] font-bold uppercase tracking-[0.08em] text-[var(--preview-muted-foreground)]">
+              Activity
+            </div>
+            <div className="space-y-0">
+              {phases.map((item, index) => (
+                <button
+                  type="button"
+                  key={item.status}
+                  onClick={() => onSelect(index)}
+                  className="relative flex w-full items-start gap-2.5 pb-2.5 text-left last:pb-0"
+                >
+                  {index < phases.length - 1 ? (
+                    <span className="absolute left-[3px] top-2 h-[calc(100%-4px)] w-px bg-[var(--preview-border)]" />
+                  ) : null}
+                  <span
+                    className="relative mt-1 size-2 shrink-0 rounded-full"
+                    style={{
+                      background:
+                        index <= active
+                          ? item.color
+                          : "var(--preview-muted-foreground)",
+                    }}
+                  />
+                  <span className="min-w-0">
+                    <span
+                      className="block text-[10.5px] font-medium"
+                      style={{
+                        color: index === active ? item.color : tone.muted,
+                      }}
+                    >
+                      {item.status}
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
+    </aside>
+  );
+}
+
+function InspectorTab({
+  active = false,
+  children,
+  label,
+}: {
+  active?: boolean;
+  children: ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      className={`grid size-7 place-items-center rounded-md ${
+        active
+          ? "bg-[var(--preview-muted)] text-[var(--preview-foreground)]"
+          : "text-[var(--preview-muted-foreground)]"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SummaryIcon() {
+  return (
+    <svg
+      className="size-3.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      aria-hidden="true"
+    >
+      <line x1="8" y1="7" x2="20" y2="7" />
+      <line x1="8" y1="12" x2="20" y2="12" />
+      <line x1="8" y1="17" x2="16" y2="17" />
+      <circle cx="4" cy="7" r="1" />
+      <circle cx="4" cy="12" r="1" />
+      <circle cx="4" cy="17" r="1" />
+    </svg>
+  );
+}
+
+function MobileActivity({
+  active,
+  onSelect,
+}: {
+  active: number;
+  onSelect: (value: number) => void;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 border-t border-[var(--preview-border)] bg-[var(--preview-card)]/35 px-3 sm:hidden">
+      <span className="shrink-0 text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--preview-muted-foreground)]">
+        Activity
+      </span>
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-1.5">
+        {phases.map((item, index) => (
+          <button
+            type="button"
+            key={item.status}
+            onClick={() => onSelect(index)}
+            aria-label={item.status}
+            className="grid size-6 shrink-0 place-items-center rounded-md"
+          >
+            <span
+              className="size-2 rounded-full"
+              style={{ background: index <= active ? item.color : tone.muted }}
+            />
+          </button>
+        ))}
+      </div>
+      <span
+        className="min-w-0 max-w-[94px] truncate text-[10.5px] font-medium"
+        style={{ color: phases[active].color }}
+      >
+        {phases[active].status}
+      </span>
+    </div>
+  );
+}
+
+function lineColor(line: TerminalLine): string {
+  switch (line.kind) {
+    case "error":
+      return tone.danger;
+    case "success":
+      return tone.success;
+    case "action":
+      return tone.working;
+    case "muted":
+      return tone.muted;
+    default:
+      return tone.foreground;
+  }
+}
+
+function linePrefix(line: TerminalLine): string {
+  switch (line.kind) {
+    case "error":
+      return "×";
+    case "success":
+      return "✓";
+    case "action":
+      return "●";
+    case "prompt":
+      return "❯";
+    case "command":
+      return "$";
+    default:
+      return "";
+  }
 }

--- a/frontend/src/landing/src/app/components/FeaturesSection/components/FeedbackLoopDemo/FeedbackLoopDemo.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/FeedbackLoopDemo/FeedbackLoopDemo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "motion/react";
+import { domAnimation, LazyMotion, m } from "motion/react";
 import { GeistMono } from "geist/font/mono";
 import {
 	ArrowUpDown,
@@ -136,14 +136,14 @@ const phases: Phase[] = [
 
 type LineTone = "fg" | "dim" | "error" | "success" | "working";
 
-type Line = { phase: number; marker?: string; indent?: number; tone: LineTone; text: string; blank?: boolean };
+type Line = { id: string; phase: number; marker?: string; indent?: number; tone: LineTone; text: string; blank?: boolean };
 
 /**
  * One accumulating transcript, the way a real pane behaves — the terminal keeps
  * its scrollback and tails the newest line, it does not swap screens between
  * states. Phase -1 is the scrollback this session had before CI spoke up.
  */
-const transcript: Line[] = [
+const transcriptLines: Omit<Line, "id">[] = [
 	{ phase: -1, marker: "❯", tone: "fg", text: "Add GitHub OAuth callback handling." },
 	{ phase: -1, blank: true, tone: "dim", text: "" },
 	{ phase: -1, marker: "⏺", tone: "fg", text: "Search(pattern: \"oauth\", path: \"src\")" },
@@ -188,6 +188,10 @@ const transcript: Line[] = [
 	{ phase: 3, indent: 1, tone: "success", text: "✓ test / web   ✓ typecheck   ✓ lint" },
 	{ phase: 3, marker: "·", tone: "working", text: "PR #2481 is approved and mergeable" },
 ];
+
+/** Stable per-line keys: the source array never reorders, so index-derived
+ *  ids are stamped once here rather than recomputed at render. */
+const transcript: Line[] = transcriptLines.map((line, index) => ({ ...line, id: `line-${index}` }));
 
 const lineToneColor: Record<LineTone, string> = {
 	fg: "var(--preview-terminal-fg)",
@@ -239,7 +243,7 @@ function SessionTopbar({ phase }: { phase: Phase }) {
 			<div className="flex min-w-0 flex-1 items-stretch">
 				<div className="flex min-w-0 flex-1 items-center">
 					{/* The tab list takes the free space, so "new terminal" trails it. */}
-					<div className="flex min-w-0 flex-1 self-stretch items-center" role="tablist">
+					<div aria-label="Terminal tabs" className="flex min-w-0 flex-1 self-stretch items-center" role="tablist">
 						{/* The permanent session tab — the only one branded by the harness. */}
 						<span className="relative inline-flex min-w-0 shrink-0 self-stretch items-center gap-1.5 border-r border-[var(--preview-border)] bg-[var(--preview-overlay)] px-2.5 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-[var(--preview-terminal)]">
 							<img
@@ -366,34 +370,36 @@ function TerminalPane({ active }: { active: number }) {
 
 	return (
 		<main className="flex min-h-0 min-w-0 flex-1 flex-col justify-end overflow-hidden bg-[var(--preview-terminal)] px-3 py-2.5">
-			<div className={`${GeistMono.className} text-[10px] leading-[1.35] text-[var(--preview-terminal-fg)]`}>
-				{visible.map((line, index) => (
-					<motion.div
-						key={`${line.phase}-${index}`}
-						initial={line.phase === active ? { opacity: 0 } : false}
-						animate={{ opacity: 1 }}
-						transition={{ duration: 0.18 }}
-						className="flex min-w-0 items-start gap-1.5"
-						style={{ color: lineToneColor[line.tone] }}
-					>
-						{line.blank ? (
-							<span aria-hidden="true">&nbsp;</span>
-						) : (
-							<>
-								<span className="w-[7px] shrink-0" style={{ marginLeft: (line.indent ?? 0) * 7 }}>
-									{line.marker ?? ""}
-								</span>
-								<span className="min-w-0 whitespace-pre-wrap break-words">
-									{line.text}
-									{index === lastIndex && (active === 1 || active === 2) ? (
-										<span className="ml-0.5 inline-block h-[9px] w-[5px] translate-y-[1px] animate-pulse bg-[var(--preview-terminal-fg)]" />
-									) : null}
-								</span>
-							</>
-						)}
-					</motion.div>
-				))}
-			</div>
+			<LazyMotion features={domAnimation}>
+				<div className={`${GeistMono.className} text-[10px] leading-[1.35] text-[var(--preview-terminal-fg)]`}>
+					{visible.map((line, index) => (
+						<m.div
+							key={line.id}
+							initial={line.phase === active ? { opacity: 0 } : false}
+							animate={{ opacity: 1 }}
+							transition={{ duration: 0.18 }}
+							className="flex min-w-0 items-start gap-1.5"
+							style={{ color: lineToneColor[line.tone] }}
+						>
+							{line.blank ? (
+								<span aria-hidden="true">&nbsp;</span>
+							) : (
+								<>
+									<span className="w-[7px] shrink-0" style={{ marginLeft: (line.indent ?? 0) * 7 }}>
+										{line.marker ?? ""}
+									</span>
+									<span className="min-w-0 whitespace-pre-wrap break-words">
+										{line.text}
+										{index === lastIndex && (active === 1 || active === 2) ? (
+											<span className="ml-0.5 inline-block h-[9px] w-[5px] translate-y-[1px] animate-pulse bg-[var(--preview-terminal-fg)]" />
+										) : null}
+									</span>
+								</>
+							)}
+						</m.div>
+					))}
+				</div>
+			</LazyMotion>
 		</main>
 	);
 }
@@ -407,6 +413,7 @@ function Inspector({ phase }: { phase: Phase }) {
 			className="hidden w-[232px] shrink-0 flex-col overflow-hidden border-l border-[var(--preview-border)] sm:flex"
 		>
 			<div
+				aria-label="Inspector views"
 				className="flex h-[30px] shrink-0 items-center gap-1 border-b border-[var(--preview-border)] px-2.5"
 				role="tablist"
 			>
@@ -532,8 +539,9 @@ function PRSummaryCard({ phase }: { phase: Phase }) {
  * chronological order, each event stamped with formatTimeCompact().
  */
 function ActivityTimeline({ phase }: { phase: Phase }) {
-	const events: { tone: "now" | "neutral"; node: ReactNode; ts: string | null }[] = [
+	const events: { id: string; tone: "now" | "neutral"; node: ReactNode; ts: string | null }[] = [
 		{
+			id: "current",
 			tone: "now",
 			node: (
 				<span className="inline-flex flex-wrap items-center gap-1">
@@ -546,6 +554,7 @@ function ActivityTimeline({ phase }: { phase: Phase }) {
 			ts: null,
 		},
 		{
+			id: "opened",
 			tone: "neutral",
 			node: (
 				<span className="inline-flex min-w-0 items-center gap-0.5 text-[var(--preview-foreground)]">
@@ -560,7 +569,7 @@ function ActivityTimeline({ phase }: { phase: Phase }) {
 	return (
 		<div className="relative pl-4">
 			{events.map((event, index) => (
-				<div key={index} className="relative pb-2.5 last:pb-0">
+				<div key={event.id} className="relative pb-2.5 last:pb-0">
 					{index < events.length - 1 ? (
 						<span
 							aria-hidden="true"

--- a/frontend/src/landing/src/app/components/FeaturesSection/components/FeedbackLoopDemo/FeedbackLoopDemo.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/FeedbackLoopDemo/FeedbackLoopDemo.tsx
@@ -2,350 +2,635 @@
 
 import { motion } from "motion/react";
 import { GeistMono } from "geist/font/mono";
-import { ArrowUpRight, Files, Globe, GitPullRequest } from "lucide-react";
-import { useEffect, useState, type ReactNode } from "react";
-import { featurePreviewTokens, StatusDot } from "../FeaturePreviewShell";
+import {
+	ArrowUpDown,
+	ArrowUpRight,
+	Bell,
+	Files,
+	GitPullRequest,
+	Maximize2,
+	Minus,
+	PanelRightClose,
+	Plus,
+	Trash2,
+} from "lucide-react";
+import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import { featurePreviewTokens } from "../FeaturePreviewShell";
 
-const tone = {
-  working: "#60a5fa",
-  success: "#4ade80",
-  danger: "oklch(0.704 0.191 22.216)",
-  foreground: "var(--preview-foreground)",
-  muted: "var(--preview-muted-foreground)",
+/*
+ * A miniature of the real AO session view: terminal pane + inspector rail.
+ * Every surface here is the renderer's own, transcribed from
+ *   frontend/src/renderer/components/CenterPane.tsx       (session topbar, agent tab)
+ *   frontend/src/renderer/components/SessionInspector.tsx (tabs, sections, PR card, timeline)
+ *   frontend/src/renderer/components/PRSummaryDisplay.tsx (PR meta + CI/Merge/Review parts)
+ *   frontend/src/renderer/components/StatusPill.tsx       (timeline pills)
+ * Copy comes from frontend/src/renderer/i18n/en.json, colors from
+ * frontend/src/styles/tokens.css. Type is scaled ~0.82x so the whole session
+ * view fits the preview card, the way the sibling feature demos do.
+ */
+
+/** Extra renderer tokens the shared preview set does not carry. */
+const sessionPreviewTokens = {
+	...featurePreviewTokens,
+	"--preview-sidebar": "oklch(0.155 0.005 285.823)", // --sidebar
+	"--preview-overlay": "oklch(0.28 0.008 285.885)", // --popover / bg-overlay
+	"--preview-passive": "oklch(0.442 0.017 285.786)", // --chart-3 / text-passive
+	"--preview-link": "oklch(0.92 0.004 286.32)", // --color-accent -> --primary
+	"--preview-input": "oklch(1 0 0 / 4%)", // --color-bg-settings-input
+	"--preview-input-border": "oklch(1 0 0 / 3%)", // --color-border-settings-input
+	"--preview-interactive-active": "color-mix(in oklch, oklch(0.985 0 0) 7%, transparent)",
+	"--preview-terminal": "#101317e7", // --color-bg-terminal
+	"--preview-terminal-fg": "#d7d7d2", // --color-text-terminal
+	"--preview-terminal-dim": "#7c7c7c", // --color-text-terminal-dim
+} as CSSProperties;
+
+/** --color-status-* from tokens.css, plus the tones the PR parts map onto. */
+const status = {
+	working: "#60a5fa",
+	needsYou: "#fb923c",
+	ready: "#4ade80",
+	idle: "oklch(0.705 0.015 286.067)",
+	exited: "oklch(0.704 0.191 22.216)",
 } as const;
 
-const phases = [
-  {
-    label: "CI failed",
-    status: "Needs attention",
-    color: tone.danger,
-    check: "test / web",
-    checkDetail: "AuthCallback rejects expired state",
-    lines: [
-      { kind: "system", text: "GitHub feedback routed from PR #2481" },
-      { kind: "error", text: "test / web failed: expected 401, received 500" },
-      { kind: "muted", text: "Failure logs attached. Resuming session…" },
-    ],
-  },
-  {
-    label: "Working",
-    status: "Agent fixing",
-    color: tone.working,
-    check: "test / web",
-    checkDetail: "Re-running after the next push",
-    lines: [
-      { kind: "prompt", text: "The expiry check runs after token exchange." },
-      { kind: "action", text: "reading  src/auth/callback.ts" },
-      { kind: "action", text: "editing  validate state before exchange" },
-    ],
-  },
-  {
-    label: "Working",
-    status: "Verifying fix",
-    color: tone.working,
-    check: "Checks running",
-    checkDetail: "Commit 91f8c2a pushed to feat/github-auth",
-    lines: [
-      { kind: "command", text: "npm test -- auth/callback" },
-      { kind: "success", text: "12 tests passed" },
-      { kind: "command", text: "git push origin feat/github-auth" },
-    ],
-  },
-  {
-    label: "In review",
-    status: "Checks passed",
-    color: tone.success,
-    check: "10 / 10 checks",
-    checkDetail: "Required checks passed",
-    lines: [
-      { kind: "success", text: "test / web" },
-      { kind: "success", text: "typecheck" },
-      { kind: "system", text: "PR #2481 returned to review" },
-    ],
-  },
-] as const;
+type PartTone = "neutral" | "passive" | "success" | "warning" | "error";
 
-type Phase = (typeof phases)[number];
-type TerminalLine = Phase["lines"][number];
+/** PRSummaryDisplay's toneClass, resolved against the preview tokens. */
+const partToneColor: Record<PartTone, string> = {
+	neutral: "var(--preview-muted-foreground)",
+	passive: "var(--preview-passive)",
+	success: status.ready,
+	warning: status.needsYou,
+	error: status.exited,
+};
+
+type Pill = { label: string; tone: string; breathe: boolean };
+type Part = { label: string; status: string; tone: PartTone; summary?: string; link?: string };
+
+type Phase = {
+	/** getAgentActivityView(): drives the agent tab's dot and the timeline pill. */
+	activity: Pill;
+	/** getSessionTimelinePillView(): the SCM pills beside it. */
+	scm: Pill[];
+	parts: Part[];
+	diff: { files: number; additions: number; deletions: number };
+	openedAgo: string;
+};
+
+const activityPills = {
+	idle: { label: "Idle", tone: status.idle, breathe: false },
+	working: { label: "Working", tone: status.working, breathe: true },
+} as const;
+
+const ciFailed: Pill = { label: "CI Failed", tone: status.exited, breathe: false };
+
+const phases: Phase[] = [
+	{
+		// GitHub reported a failing check and an unresolved review; the agent is idle.
+		activity: activityPills.idle,
+		scm: [ciFailed],
+		parts: [
+			{ label: "CI", status: "Failing", tone: "error", link: "test / web" },
+			{ label: "Merge", status: "Blocked", tone: "warning" },
+			{ label: "Review", status: "Changes requested", tone: "warning", link: "prateek" },
+		],
+		diff: { files: 3, additions: 41, deletions: 12 },
+		openedAgo: "18m ago",
+	},
+	{
+		// AO routed the failure back into the session that owns the branch.
+		activity: activityPills.working,
+		scm: [ciFailed],
+		parts: [
+			{ label: "CI", status: "Failing", tone: "error", link: "test / web" },
+			{ label: "Merge", status: "Blocked", tone: "warning" },
+			{ label: "Review", status: "Changes requested", tone: "warning", link: "prateek" },
+		],
+		diff: { files: 3, additions: 41, deletions: 12 },
+		openedAgo: "21m ago",
+	},
+	{
+		// Fix pushed — GitHub is re-running the required checks.
+		activity: activityPills.working,
+		scm: [],
+		parts: [
+			{ label: "CI", status: "Pending", tone: "neutral" },
+			{ label: "Merge", status: "Checking", tone: "passive" },
+			{ label: "Review", status: "Changes requested", tone: "warning", link: "prateek" },
+		],
+		diff: { files: 4, additions: 47, deletions: 14 },
+		openedAgo: "24m ago",
+	},
+	{
+		activity: activityPills.idle,
+		scm: [],
+		parts: [
+			{ label: "CI", status: "Passing", tone: "success" },
+			{ label: "Merge", status: "Mergeable", tone: "success" },
+			{ label: "Review", status: "Approved", tone: "success" },
+		],
+		diff: { files: 4, additions: 47, deletions: 14 },
+		openedAgo: "26m ago",
+	},
+];
+
+type LineTone = "fg" | "dim" | "error" | "success" | "working";
+
+type Line = { phase: number; marker?: string; indent?: number; tone: LineTone; text: string; blank?: boolean };
+
+/**
+ * One accumulating transcript, the way a real pane behaves — the terminal keeps
+ * its scrollback and tails the newest line, it does not swap screens between
+ * states. Phase -1 is the scrollback this session had before CI spoke up.
+ */
+const transcript: Line[] = [
+	{ phase: -1, marker: "❯", tone: "fg", text: "Add GitHub OAuth callback handling." },
+	{ phase: -1, blank: true, tone: "dim", text: "" },
+	{ phase: -1, marker: "⏺", tone: "fg", text: "Search(pattern: \"oauth\", path: \"src\")" },
+	{ phase: -1, marker: "⎿", tone: "dim", text: "Found 4 files" },
+	{ phase: -1, marker: "⏺", tone: "fg", text: "Read(src/auth/session.ts)" },
+	{ phase: -1, marker: "⎿", tone: "dim", text: "Read 54 lines" },
+	{ phase: -1, marker: "⏺", tone: "fg", text: "Read(src/auth/index.ts)" },
+	{ phase: -1, marker: "⎿", tone: "dim", text: "Read 88 lines" },
+	{ phase: -1, marker: "⏺", tone: "fg", text: "Write(src/auth/callback.ts)" },
+	{ phase: -1, marker: "⎿", tone: "dim", text: "Wrote 96 lines" },
+	{ phase: -1, marker: "⏺", tone: "fg", text: "Write(src/auth/callback.test.ts)" },
+	{ phase: -1, marker: "⎿", tone: "dim", text: "Wrote 61 lines" },
+	{ phase: -1, marker: "⏺", tone: "fg", text: "Bash(npm test -- auth)" },
+	{ phase: -1, marker: "⎿", tone: "success", text: "Tests  11 passed (11)" },
+	{ phase: -1, marker: "⏺", tone: "fg", text: "Bash(git push origin feat/github-auth)" },
+	{ phase: -1, marker: "⎿", tone: "dim", text: "4c1d0ab pushed to feat/github-auth" },
+	{ phase: -1, marker: "⏺", tone: "fg", text: "Bash(gh pr create --fill)" },
+	{ phase: -1, marker: "⎿", tone: "dim", text: ".../agent-orchestrator/pull/2481" },
+	{ phase: -1, marker: "⏺", tone: "fg", text: "Opened PR #2481. Watching checks." },
+
+	{ phase: 0, blank: true, tone: "dim", text: "" },
+	{ phase: 0, marker: "·", tone: "working", text: "AO routed GitHub feedback here" },
+	{ phase: 0, indent: 1, tone: "dim", text: 'PR #2481 · check "test / web" failed' },
+	{ phase: 0, indent: 1, tone: "error", text: "FAIL  src/auth/callback.test.ts" },
+	{ phase: 0, indent: 2, tone: "dim", text: "● rejects an expired state param" },
+	{ phase: 0, indent: 3, tone: "dim", text: "expected 401, received 500" },
+
+	{ phase: 1, blank: true, tone: "dim", text: "" },
+	{ phase: 1, marker: "⏺", tone: "fg", text: "Read(src/auth/callback.ts)" },
+	{ phase: 1, marker: "⎿", tone: "dim", text: "Read 143 lines" },
+	{ phase: 1, marker: "⏺", tone: "fg", text: "The expiry check runs after the exchange." },
+	{ phase: 1, marker: "⏺", tone: "fg", text: "Update(src/auth/callback.ts)" },
+	{ phase: 1, marker: "⎿", tone: "dim", text: "Updated with 6 additions and 2 removals" },
+
+	{ phase: 2, marker: "⏺", tone: "fg", text: "Bash(npm test -- auth/callback)" },
+	{ phase: 2, marker: "⎿", tone: "success", text: "Tests  12 passed (12)" },
+	{ phase: 2, marker: "⏺", tone: "fg", text: "Bash(git push origin feat/github-auth)" },
+	{ phase: 2, marker: "⎿", tone: "dim", text: "91f8c2a pushed to feat/github-auth" },
+
+	{ phase: 3, blank: true, tone: "dim", text: "" },
+	{ phase: 3, marker: "·", tone: "working", text: "Checks re-ran on 91f8c2a" },
+	{ phase: 3, indent: 1, tone: "success", text: "✓ test / web   ✓ typecheck   ✓ lint" },
+	{ phase: 3, marker: "·", tone: "working", text: "PR #2481 is approved and mergeable" },
+];
+
+const lineToneColor: Record<LineTone, string> = {
+	fg: "var(--preview-terminal-fg)",
+	dim: "var(--preview-terminal-dim)",
+	error: status.exited,
+	success: status.ready,
+	working: status.working,
+};
 
 export function FeedbackLoopDemo() {
-  const [active, setActive] = useState(0);
+	const [active, setActive] = useState(0);
 
-  useEffect(() => {
-    const interval = window.setInterval(
-      () => setActive((value) => (value + 1) % phases.length),
-      2500,
-    );
-    return () => window.clearInterval(interval);
-  }, []);
+	useEffect(() => {
+		const interval = window.setInterval(() => setActive((value) => (value + 1) % phases.length), 3400);
+		return () => window.clearInterval(interval);
+	}, []);
 
-  const phase = phases[active];
+	const phase = phases[active] as Phase;
 
-  return (
-    <div
-      className="mx-auto w-full min-w-0 max-w-[620px] overflow-hidden rounded-xl border border-[var(--preview-border)] bg-[var(--preview-background)] font-sans text-[var(--preview-foreground)] antialiased shadow-[0_28px_74px_-22px_rgba(0,0,0,0.86)]"
-      style={featurePreviewTokens}
-    >
-      <div className="grid h-[330px] min-w-0 grid-cols-1 grid-rows-[minmax(0,1fr)_42px] sm:h-[370px] sm:grid-cols-[minmax(0,1fr)_208px] sm:grid-rows-1">
-        <AgentPane active={active} phase={phase} />
-        <Inspector active={active} phase={phase} onSelect={setActive} />
-        <MobileActivity active={active} onSelect={setActive} />
-      </div>
-    </div>
-  );
+	return (
+		<div
+			className="mx-auto w-full min-w-0 max-w-[620px] overflow-hidden rounded-xl border border-[var(--preview-border)] bg-[var(--preview-background)] font-sans text-[var(--preview-foreground)] antialiased shadow-[0_28px_74px_-22px_rgba(0,0,0,0.86)]"
+			style={sessionPreviewTokens}
+		>
+			<div className="flex h-[330px] min-w-0 flex-col sm:h-[370px]">
+				<SessionTopbar phase={phase} />
+				<div className="flex min-h-0 min-w-0 flex-1">
+					<TerminalPane active={active} />
+					{/* The rail's own edge is the split, so the topbar divider above it
+					    and this hairline read as one unbroken rule. */}
+					<Inspector phase={phase} />
+				</div>
+			</div>
+		</div>
+	);
 }
 
-function AgentPane({ active, phase }: { active: number; phase: Phase }) {
-  return (
-    <main className="flex min-h-0 min-w-0 flex-col overflow-hidden">
-      <div className="flex min-h-0 flex-1 flex-col bg-[#101317]">
-        <motion.div
-          key={active}
-          initial={{ opacity: 0, y: 5 }}
-          animate={{ opacity: 1, y: 0 }}
-          className={`${GeistMono.className} space-y-2.5 p-4 text-[12px] leading-5 text-[#d7d7d2]`}
-        >
-          {phase.lines.map((line, index) => (
-            <motion.div
-              key={line.text}
-              initial={{ opacity: 0, x: -3 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: index * 0.12 }}
-              className="flex items-start gap-2.5"
-            >
-              <span
-                className="w-3 shrink-0 text-center font-semibold"
-                style={{ color: lineColor(line) }}
-              >
-                {linePrefix(line)}
-              </span>
-              <span
-                className="min-w-0 break-words"
-                style={{ color: lineColor(line) }}
-              >
-                {line.text}
-              </span>
-            </motion.div>
-          ))}
-          {active === 1 ? (
-            <div className="flex items-center gap-2 text-[#7c7c7c]">
-              <span className="size-2 animate-spin rounded-full border border-current border-t-transparent" />
-              working…
-            </div>
-          ) : null}
-        </motion.div>
-      </div>
-    </main>
-  );
+/* ── Session topbar (CenterPane.tsx) ─────────────────────────────────────── */
+
+function SessionTopbar({ phase }: { phase: Phase }) {
+	// Flush to the card edge. The app insets this surface against the sidebar and
+	// the native titlebar; there is no window chrome here to inset it from, so the
+	// inset would only read as a stray gap.
+	return (
+		<div className="flex h-9 w-full shrink-0 items-stretch overflow-hidden border-b border-[var(--preview-border)] bg-[var(--preview-background)]">
+			{/* Terminal region — exactly as wide as the pane below it, so the font
+			    and fullscreen controls stop at the split instead of crossing it.
+			    No vertical inset: the tab meets the card edge and the terminal. */}
+			<div className="flex min-w-0 flex-1 items-stretch">
+				<div className="flex min-w-0 flex-1 items-center">
+					{/* The tab list takes the free space, so "new terminal" trails it. */}
+					<div className="flex min-w-0 flex-1 self-stretch items-center" role="tablist">
+						{/* The permanent session tab — the only one branded by the harness. */}
+						<span className="relative inline-flex min-w-0 shrink-0 self-stretch items-center gap-1.5 border-r border-[var(--preview-border)] bg-[var(--preview-overlay)] px-2.5 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-[var(--preview-terminal)]">
+							<img
+								src="/app-icons/coverage-claude-code.svg"
+								alt=""
+								aria-hidden="true"
+								className="size-[13px] shrink-0 object-contain"
+								draggable={false}
+							/>
+							<span className="inline-flex items-center gap-1.5 text-[10.5px] font-medium leading-none text-[var(--preview-foreground)]">
+								<span className="truncate">github-auth</span>
+								<span
+									className={`size-[5px] shrink-0 rounded-full ${phase.activity.breathe ? "animate-pulse" : ""}`}
+									style={{ background: phase.activity.tone }}
+								/>
+							</span>
+						</span>
+					</div>
+					<button
+						type="button"
+						aria-label="New terminal"
+						className="grid size-[21px] shrink-0 place-items-center rounded-[5px] border border-[var(--preview-border)] text-[var(--preview-muted-foreground)]"
+					>
+						<Plus aria-hidden="true" className="size-3" />
+					</button>
+				</div>
+				<div className="ml-1.5 mr-1.5 flex shrink-0 items-center gap-0.5 border-l border-[var(--preview-border)] pl-1.5">
+					<TerminalControl label="Decrease font size">
+						<Minus aria-hidden="true" className="size-[11px]" />
+					</TerminalControl>
+					<span className="w-7 text-center font-mono text-[8px] tabular-nums text-[var(--preview-muted-foreground)]">
+						12px
+					</span>
+					<TerminalControl label="Increase font size">
+						<Plus aria-hidden="true" className="size-[11px]" />
+					</TerminalControl>
+					<span aria-hidden="true" className="mx-0.5 h-3 w-px bg-[var(--preview-border)]" />
+					<TerminalControl label="Fullscreen">
+						<Maximize2 aria-hidden="true" className="size-3" />
+					</TerminalControl>
+				</div>
+			</div>
+			{/* Session action region (ShellTopbar embedded). Pinned to the rail's
+			    width so its left edge continues the split hairline below. */}
+			<div className="hidden w-[232px] shrink-0 items-center justify-end gap-1 border-l border-[var(--preview-border)] px-1.5 sm:flex">
+				<button
+					type="button"
+					aria-label="Kill session"
+					className="inline-flex h-[26px] shrink-0 items-center gap-1 rounded-[6px] border border-[var(--preview-border)] bg-transparent px-1.5 text-[10px] font-semibold leading-none"
+					style={{ color: `color-mix(in srgb, ${status.exited} 80%, transparent)` }}
+				>
+					<Trash2 aria-hidden="true" className="size-3 shrink-0" />
+					Kill
+				</button>
+				<button
+					type="button"
+					aria-label="Open orchestrator"
+					className="inline-flex h-[26px] min-w-0 shrink items-center gap-1 rounded-[6px] bg-[var(--preview-primary)] px-1.5 text-[10px] font-semibold leading-none text-[var(--preview-primary-foreground)]"
+				>
+					<OrchestratorIcon />
+					<span className="truncate">Orchestrator</span>
+				</button>
+				<button
+					type="button"
+					aria-label="Close inspector panel"
+					title="Close inspector · ⌘⇧B"
+					className="grid size-[24px] shrink-0 place-items-center rounded-[6px] text-[var(--preview-muted-foreground)]"
+				>
+					<PanelRightClose aria-hidden="true" className="size-4" />
+				</button>
+				<span
+					aria-label="Notifications"
+					className="grid size-[24px] shrink-0 place-items-center rounded-[6px] text-[var(--preview-muted-foreground)]"
+				>
+					<Bell aria-hidden="true" className="size-4" />
+				</span>
+			</div>
+		</div>
+	);
 }
 
-function Inspector({
-  active,
-  phase,
-  onSelect,
-}: {
-  active: number;
-  phase: Phase;
-  onSelect: (value: number) => void;
-}) {
-  return (
-    <aside className="hidden min-w-0 overflow-hidden border-l border-[var(--preview-border)] bg-[var(--preview-card)]/25 sm:block">
-      <div className="flex h-11 items-center gap-1 border-b border-[var(--preview-border)] px-2.5">
-        <InspectorTab active label="Summary">
-          <SummaryIcon />
-        </InspectorTab>
-        <InspectorTab label="Browser">
-          <Globe className="size-3.5" />
-        </InspectorTab>
-        <InspectorTab label="Files">
-          <Files className="size-3.5" />
-        </InspectorTab>
-      </div>
-      <div className="space-y-2.5 p-2.5">
-        <section>
-          <div className="rounded-lg bg-[var(--preview-card)] px-3.5 py-3">
-            <div className="mb-2 text-[10.5px] font-bold uppercase tracking-[0.08em] text-[var(--preview-muted-foreground)]">
-              Pull request
-            </div>
-            <div className="rounded-lg border border-[var(--preview-border)] bg-[var(--preview-background)]/45 px-2.5 py-2">
-              <div className="flex items-center gap-2 text-[11.5px] font-semibold">
-                <GitPullRequest className="size-3.5" />
-                PR #2481
-                <span className="ml-auto inline-flex items-center gap-0.5 text-[10.5px] text-blue-400">
-                  Open <ArrowUpRight className="size-3" />
-                </span>
-              </div>
-              <div className="mt-2.5 border-t border-[var(--preview-border)] pt-2.5">
-                <div
-                  className="flex items-center gap-1.5 text-[10.5px] font-medium"
-                  style={{ color: phase.color }}
-                >
-                  <StatusDot color={phase.color} pulse={active === 2} />
-                  {phase.check}
-                </div>
-                <div className="mt-1.5 text-[10px] leading-[1.45] text-[var(--preview-muted-foreground)]">
-                  {phase.checkDetail}
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section>
-          <div className="rounded-lg bg-[var(--preview-card)] px-3.5 py-3">
-            <div className="mb-2 text-[10.5px] font-bold uppercase tracking-[0.08em] text-[var(--preview-muted-foreground)]">
-              Activity
-            </div>
-            <div className="space-y-0">
-              {phases.map((item, index) => (
-                <button
-                  type="button"
-                  key={item.status}
-                  onClick={() => onSelect(index)}
-                  className="relative flex w-full items-start gap-2.5 pb-2.5 text-left last:pb-0"
-                >
-                  {index < phases.length - 1 ? (
-                    <span className="absolute left-[3px] top-2 h-[calc(100%-4px)] w-px bg-[var(--preview-border)]" />
-                  ) : null}
-                  <span
-                    className="relative mt-1 size-2 shrink-0 rounded-full"
-                    style={{
-                      background:
-                        index <= active
-                          ? item.color
-                          : "var(--preview-muted-foreground)",
-                    }}
-                  />
-                  <span className="min-w-0">
-                    <span
-                      className="block text-[10.5px] font-medium"
-                      style={{
-                        color: index === active ? item.color : tone.muted,
-                      }}
-                    >
-                      {item.status}
-                    </span>
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
-        </section>
-      </div>
-    </aside>
-  );
+function TerminalControl({ children, label }: { children: ReactNode; label: string }) {
+	return (
+		<button
+			type="button"
+			aria-label={label}
+			className="grid size-5 shrink-0 place-items-center rounded-[5px] text-[var(--preview-muted-foreground)]"
+		>
+			{children}
+		</button>
+	);
 }
 
-function InspectorTab({
-  active = false,
-  children,
-  label,
-}: {
-  active?: boolean;
-  children: ReactNode;
-  label: string;
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      className={`grid size-7 place-items-center rounded-md ${
-        active
-          ? "bg-[var(--preview-muted)] text-[var(--preview-foreground)]"
-          : "text-[var(--preview-muted-foreground)]"
-      }`}
-    >
-      {children}
-    </button>
-  );
+/** OrchestratorIcon from frontend/src/renderer/components/icons.tsx. */
+function OrchestratorIcon() {
+	return (
+		<svg
+			className="size-3 shrink-0"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<circle cx="12" cy="4" r="2" />
+			<circle cx="5" cy="20" r="2" />
+			<circle cx="12" cy="20" r="2" />
+			<circle cx="19" cy="20" r="2" />
+			<path d="M12 6v12" />
+			<path d="M5 11h14" />
+			<path d="M5 11v7" />
+			<path d="M19 11v7" />
+		</svg>
+	);
 }
+
+/* ── Terminal pane ───────────────────────────────────────────────────────── */
+
+function TerminalPane({ active }: { active: number }) {
+	const visible = transcript.filter((line) => line.phase <= active);
+	const lastIndex = visible.length - 1;
+
+	return (
+		<main className="flex min-h-0 min-w-0 flex-1 flex-col justify-end overflow-hidden bg-[var(--preview-terminal)] px-3 py-2.5">
+			<div className={`${GeistMono.className} text-[10px] leading-[1.35] text-[var(--preview-terminal-fg)]`}>
+				{visible.map((line, index) => (
+					<motion.div
+						key={`${line.phase}-${index}`}
+						initial={line.phase === active ? { opacity: 0 } : false}
+						animate={{ opacity: 1 }}
+						transition={{ duration: 0.18 }}
+						className="flex min-w-0 items-start gap-1.5"
+						style={{ color: lineToneColor[line.tone] }}
+					>
+						{line.blank ? (
+							<span aria-hidden="true">&nbsp;</span>
+						) : (
+							<>
+								<span className="w-[7px] shrink-0" style={{ marginLeft: (line.indent ?? 0) * 7 }}>
+									{line.marker ?? ""}
+								</span>
+								<span className="min-w-0 whitespace-pre-wrap break-words">
+									{line.text}
+									{index === lastIndex && (active === 1 || active === 2) ? (
+										<span className="ml-0.5 inline-block h-[9px] w-[5px] translate-y-[1px] animate-pulse bg-[var(--preview-terminal-fg)]" />
+									) : null}
+								</span>
+							</>
+						)}
+					</motion.div>
+				))}
+			</div>
+		</main>
+	);
+}
+
+/* ── Inspector rail (SessionInspector.tsx) ───────────────────────────────── */
+
+function Inspector({ phase }: { phase: Phase }) {
+	return (
+		<aside
+			aria-label="Session inspector"
+			className="hidden w-[232px] shrink-0 flex-col overflow-hidden border-l border-[var(--preview-border)] sm:flex"
+		>
+			<div
+				className="flex h-[30px] shrink-0 items-center gap-1 border-b border-[var(--preview-border)] px-2.5"
+				role="tablist"
+			>
+				{/* Under 350px the rail drops its tab labels and shows icons alone. */}
+				<InspectorTab active label="Summary">
+					<SummaryIcon />
+				</InspectorTab>
+				<InspectorTab label="Browser">
+					<BrowserIcon />
+				</InspectorTab>
+				<InspectorTab label={`${phase.diff.files} Files`}>
+					<Files aria-hidden="true" className="size-3" />
+				</InspectorTab>
+			</div>
+
+			<div className="min-h-0 flex-1 overflow-hidden px-2 pb-3 pt-2">
+				<Section title="Pull request">
+					<PRSummaryCard phase={phase} />
+				</Section>
+				<Section title="Activity">
+					<ActivityTimeline phase={phase} />
+				</Section>
+			</div>
+		</aside>
+	);
+}
+
+function InspectorTab({ active = false, children, label }: { active?: boolean; children: ReactNode; label: string }) {
+	return (
+		<button
+			type="button"
+			role="tab"
+			aria-selected={active}
+			aria-label={label}
+			title={label}
+			className={`inline-flex size-6 shrink-0 items-center justify-center rounded-md ${
+				active
+					? "bg-[var(--preview-interactive-active)] text-[var(--preview-foreground)]"
+					: "text-[var(--preview-passive)]"
+			}`}
+		>
+			{children}
+		</button>
+	);
+}
+
+function Section({ children, title }: { children: ReactNode; title: string }) {
+	// bg-settings-row is transparent in the dark theme; the box is padding alone.
+	return (
+		<section className="mb-1 last:mb-0">
+			<div className="overflow-hidden rounded-[13px] px-3 py-2">
+				<div className="mb-1.5 text-[8.5px] font-bold uppercase tracking-[0.06em] text-[var(--preview-muted-foreground)]">
+					{title}
+				</div>
+				{children}
+			</div>
+		</section>
+	);
+}
+
+function PRSummaryCard({ phase }: { phase: Phase }) {
+	return (
+		<div className="rounded-lg border border-[var(--preview-input-border)] bg-[var(--preview-input)] px-2 py-1.5">
+			<div className="flex items-center gap-1.5">
+				<GitPullRequest aria-hidden="true" className="size-3 shrink-0 text-[var(--preview-muted-foreground)]" />
+				<span className="text-[10.5px] font-medium text-[var(--preview-foreground)]">PR #2481</span>
+				<span
+					className="inline-flex h-[15px] shrink-0 items-center rounded-full border px-1.5 text-[7.5px] font-medium leading-none"
+					style={{
+						color: status.ready,
+						borderColor: `color-mix(in srgb, ${status.ready} 40%, transparent)`,
+						background: `color-mix(in srgb, ${status.ready} 10%, transparent)`,
+					}}
+				>
+					open
+				</span>
+				<span className="ml-auto inline-flex shrink-0 items-center gap-0.5 text-[9px] font-medium text-[var(--preview-link)]">
+					Open
+					<ArrowUpRight aria-hidden="true" className="size-2.5 shrink-0" strokeWidth={2} />
+				</span>
+			</div>
+			<div className="mt-1 truncate text-[10px] font-medium leading-snug text-[var(--preview-foreground)]">
+				Reject expired OAuth state
+			</div>
+			<div className="mt-1 min-w-0 font-mono text-[8.5px] leading-[1.4]">
+				<div className="truncate text-[var(--preview-passive)]">feat/github-auth -&gt; main</div>
+				<div className="flex min-w-0 flex-wrap items-center gap-x-1 text-[var(--preview-muted-foreground)]">
+					<span className="inline-flex items-center gap-0.5" style={{ color: status.needsYou }}>
+						<ArrowUpDown aria-hidden="true" className="h-2 w-2 shrink-0" strokeWidth={2.2} />
+						{phase.diff.files} files
+					</span>
+					<span className="text-[var(--preview-passive)]">·</span>
+					<span style={{ color: status.ready }}>+{phase.diff.additions}</span>
+					<span className="text-[var(--preview-passive)]">·</span>
+					<span style={{ color: status.exited }}>-{phase.diff.deletions}</span>
+				</div>
+			</div>
+			<div className="mt-1.5 flex flex-col gap-0.5 font-mono text-[8.5px] leading-[1.4]">
+				{phase.parts.map((part) => (
+					<div key={part.label} className="flex min-w-0 flex-col">
+						<div className="min-w-0 truncate">
+							<span className="text-[var(--preview-passive)]">{part.label}</span>{" "}
+							<span className="font-medium" style={{ color: partToneColor[part.tone] }}>
+								{part.status}
+							</span>
+							{part.summary ? <span className="text-[var(--preview-passive)]"> · {part.summary}</span> : null}
+						</div>
+						{part.link ? (
+							<span className="inline-flex min-w-0 max-w-full items-center gap-0.5 text-[var(--preview-link)]">
+								<span className="truncate">{part.link}</span>
+								<ArrowUpRight aria-hidden="true" className="size-2 shrink-0" strokeWidth={2} />
+							</span>
+						) : null}
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+/**
+ * ActivityTimeline: the live reading sits on top, then history in reverse
+ * chronological order, each event stamped with formatTimeCompact().
+ */
+function ActivityTimeline({ phase }: { phase: Phase }) {
+	const events: { tone: "now" | "neutral"; node: ReactNode; ts: string | null }[] = [
+		{
+			tone: "now",
+			node: (
+				<span className="inline-flex flex-wrap items-center gap-1">
+					<StatusPill {...phase.activity} />
+					{phase.scm.map((pill) => (
+						<StatusPill key={pill.label} {...pill} />
+					))}
+				</span>
+			),
+			ts: null,
+		},
+		{
+			tone: "neutral",
+			node: (
+				<span className="inline-flex min-w-0 items-center gap-0.5 text-[var(--preview-foreground)]">
+					Opened&nbsp;<b className="font-semibold">PR #2481</b>
+					<ArrowUpRight aria-hidden="true" className="size-2.5 shrink-0" strokeWidth={2} />
+				</span>
+			),
+			ts: phase.openedAgo,
+		},
+	];
+
+	return (
+		<div className="relative pl-4">
+			{events.map((event, index) => (
+				<div key={index} className="relative pb-2.5 last:pb-0">
+					{index < events.length - 1 ? (
+						<span
+							aria-hidden="true"
+							className={`absolute -bottom-[7px] -left-[11px] w-px bg-[var(--preview-border)] ${
+								event.tone === "now" ? "top-1/2" : "top-[8px]"
+							}`}
+						/>
+					) : null}
+					<div className="relative flex min-h-[8px] items-center">
+						<span
+							aria-hidden="true"
+							className={`absolute -left-[14px] size-[7px] rounded-full ${
+								event.tone === "now" ? "top-1/2 -translate-y-1/2" : "top-[4px]"
+							}`}
+							style={{
+								background: event.tone === "now" ? status.working : "var(--preview-passive)",
+								boxShadow:
+									event.tone === "now"
+										? `0 0 0 2.5px var(--preview-background), 0 0 6px ${status.working}`
+										: "0 0 0 2.5px var(--preview-background)",
+							}}
+						/>
+						<div className="min-w-0 text-[9.5px] leading-normal">{event.node}</div>
+					</div>
+					{event.ts ? (
+						<div className="mt-0.5 font-mono text-[8px] text-[var(--preview-passive)]">{event.ts}</div>
+					) : null}
+				</div>
+			))}
+		</div>
+	);
+}
+
+function StatusPill({ label, tone, breathe }: Pill) {
+	return (
+		<span
+			className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-[6px] px-1.5 py-[3px] text-[9px] font-semibold"
+			style={{
+				color: tone,
+				background: `color-mix(in srgb, ${tone} 7%, transparent)`,
+				boxShadow: `inset 0 0 0 1px color-mix(in srgb, ${tone} 25%, transparent)`,
+			}}
+		>
+			<span className={`size-[5px] rounded-full ${breathe ? "animate-pulse" : ""}`} style={{ background: tone }} />
+			{label}
+		</span>
+	);
+}
+
+/* Inspector tab icons — traced from VIEW_DEFS in SessionInspector.tsx. */
 
 function SummaryIcon() {
-  return (
-    <svg
-      className="size-3.5"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.7"
-      aria-hidden="true"
-    >
-      <line x1="8" y1="7" x2="20" y2="7" />
-      <line x1="8" y1="12" x2="20" y2="12" />
-      <line x1="8" y1="17" x2="16" y2="17" />
-      <circle cx="4" cy="7" r="1" />
-      <circle cx="4" cy="12" r="1" />
-      <circle cx="4" cy="17" r="1" />
-    </svg>
-  );
+	return (
+		<svg className="size-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden="true">
+			<line x1="8" y1="7" x2="20" y2="7" />
+			<line x1="8" y1="12" x2="20" y2="12" />
+			<line x1="8" y1="17" x2="16" y2="17" />
+			<circle cx="4" cy="7" r="1" />
+			<circle cx="4" cy="12" r="1" />
+			<circle cx="4" cy="17" r="1" />
+		</svg>
+	);
 }
 
-function MobileActivity({
-  active,
-  onSelect,
-}: {
-  active: number;
-  onSelect: (value: number) => void;
-}) {
-  return (
-    <div className="flex min-w-0 items-center gap-2 border-t border-[var(--preview-border)] bg-[var(--preview-card)]/35 px-3 sm:hidden">
-      <span className="shrink-0 text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--preview-muted-foreground)]">
-        Activity
-      </span>
-      <div className="flex min-w-0 flex-1 items-center justify-end gap-1.5">
-        {phases.map((item, index) => (
-          <button
-            type="button"
-            key={item.status}
-            onClick={() => onSelect(index)}
-            aria-label={item.status}
-            className="grid size-6 shrink-0 place-items-center rounded-md"
-          >
-            <span
-              className="size-2 rounded-full"
-              style={{ background: index <= active ? item.color : tone.muted }}
-            />
-          </button>
-        ))}
-      </div>
-      <span
-        className="min-w-0 max-w-[94px] truncate text-[10.5px] font-medium"
-        style={{ color: phases[active].color }}
-      >
-        {phases[active].status}
-      </span>
-    </div>
-  );
-}
-
-function lineColor(line: TerminalLine): string {
-  switch (line.kind) {
-    case "error":
-      return tone.danger;
-    case "success":
-      return tone.success;
-    case "action":
-      return tone.working;
-    case "muted":
-      return tone.muted;
-    default:
-      return tone.foreground;
-  }
-}
-
-function linePrefix(line: TerminalLine): string {
-  switch (line.kind) {
-    case "error":
-      return "×";
-    case "success":
-      return "✓";
-    case "action":
-      return "●";
-    case "prompt":
-      return "❯";
-    case "command":
-      return "$";
-    default:
-      return "";
-  }
+function BrowserIcon() {
+	return (
+		<svg className="size-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden="true">
+			<circle cx="12" cy="12" r="9" />
+			<line x1="3" y1="12" x2="21" y2="12" />
+			<path d="M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18" />
+		</svg>
+	);
 }


### PR DESCRIPTION
The Feedback Loop demo on the landing page did not look much like the app. It was a browser-chrome shell around a stylized four-state list, so it read as an illustration rather than a screenshot of AO.

This rebuilds it as a miniature of the real session view, with the surfaces transcribed from the renderer.

<img width="1391" height="489" alt="image" src="https://github.com/user-attachments/assets/b452b3a3-a752-4e8e-926f-28f04eac4d0e" />

## Checks

Verified with headless screenshots at 1440 and 390 across all four phases: no overflow in the topbar, terminal, rail or card, and the topbar divider aligns exactly with the terminal/rail split so the line is unbroken. Typecheck passes. One file changed.