### PR TITLE
fix(frontend): remove extra terminal edge spacing

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -222,11 +222,11 @@ function activeXterm(): HTMLElement {
 }
 
 describe("TerminalPane empty states", () => {
-	it("uses the full top and right extent for the terminal grid", () => {
+	it("uses the full top, right, and bottom extent for the terminal grid", () => {
 		const view = renderPane({ ...worker, terminalHandleId: "term-1" });
 		try {
-			expect(screen.getByTestId("xterm").parentElement).toHaveClass("pb-2", "pl-2");
-			expect(screen.getByTestId("xterm").parentElement).not.toHaveClass("pt-2", "pr-2", "p-2");
+			expect(screen.getByTestId("xterm").parentElement).toHaveClass("pl-2");
+			expect(screen.getByTestId("xterm").parentElement).not.toHaveClass("pt-2", "pr-2", "pb-2", "p-2");
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -222,6 +222,16 @@ function activeXterm(): HTMLElement {
 }
 
 describe("TerminalPane empty states", () => {
+	it("uses the full top and right extent for the terminal grid", () => {
+		const view = renderPane({ ...worker, terminalHandleId: "term-1" });
+		try {
+			expect(screen.getByTestId("xterm").parentElement).toHaveClass("pb-2", "pl-2");
+			expect(screen.getByTestId("xterm").parentElement).not.toHaveClass("pt-2", "pr-2", "p-2");
+		} finally {
+			view.restore();
+		}
+	});
+
 	it("shows a no-selection message when no session is selected", () => {
 		const view = renderPane();
 		try {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -1076,11 +1076,11 @@ function AttachedTerminal({
 					}
 				/>
 			)}
-			{/* Keep a small gutter where terminal output starts and along the bottom,
-			    but let xterm use the full top/right extent. The host fills the remaining
+			{/* Keep a small gutter where terminal output starts, but let xterm use the
+			    full top/right/bottom extent. The host fills the remaining
 			    content box, so FitAddon still measures it correctly and the absolute
 			    overlays (empty state, banner) keep covering the full padding box. */}
-			<div className="relative min-h-0 flex-1 pb-2 pl-2">
+			<div className="relative min-h-0 flex-1 pl-2">
 				<XtermTerminal
 					ariaLabel={terminalTarget?.kind === "shell" ? t("terminal.shellAria") : t("terminal.sessionAria")}
 					fontSize={fontSize}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -1076,10 +1076,11 @@ function AttachedTerminal({
 					}
 				/>
 			)}
-			{/* p-2 insets xterm from the pane edges. Surface + xterm chrome use
-			    the opaque #101317 plate so the gutter never fringes against app
-			    chrome. Overlays cover the full padding box. */}
-			<div className="relative min-h-0 flex-1 p-2">
+			{/* Keep a small gutter where terminal output starts and along the bottom,
+			    but let xterm use the full top/right extent. The host fills the remaining
+			    content box, so FitAddon still measures it correctly and the absolute
+			    overlays (empty state, banner) keep covering the full padding box. */}
+			<div className="relative min-h-0 flex-1 pb-2 pl-2">
 				<XtermTerminal
 					ariaLabel={terminalTarget?.kind === "shell" ? t("terminal.shellAria") : t("terminal.sessionAria")}
 					fontSize={fontSize}

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -23,6 +23,7 @@ const state = vi.hoisted(() => ({
 		selectionListeners: Set<() => void>;
 		_core: {
 			element: { classList: { add: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> } };
+			viewport: { scrollBarWidth: number };
 			_selectionService: {
 				enable: ReturnType<typeof vi.fn>;
 				shouldForceSelection: (event: MouseEvent) => boolean;
@@ -52,6 +53,7 @@ vi.mock("@xterm/xterm", () => ({
 		selectionListeners = new Set<() => void>();
 		_core = {
 			element: { classList: { add: vi.fn(), remove: vi.fn() } },
+			viewport: { scrollBarWidth: 15 },
 			_selectionService: {
 				enable: vi.fn(),
 				shouldForceSelection: () => false,
@@ -185,6 +187,12 @@ describe("XtermTerminal", () => {
 
 		expect(state.lastTerminal!.options.drawBoldTextInBrightColors).toBe(true);
 		expect(state.lastTerminal!.options.minimumContrastRatio).toBe(1);
+	});
+
+	it("does not reserve width for the hidden terminal scrollbar", () => {
+		render(<XtermTerminal theme="dark" />);
+
+		expect(state.lastTerminal!._core.viewport.scrollBarWidth).toBe(0);
 	});
 
 	it("copies selected terminal text on the terminal copy shortcut", () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -183,6 +183,9 @@ function terminalHasFocus(host: HTMLElement): boolean {
 type XtermInternal = Terminal & {
 	_core?: {
 		element?: HTMLElement;
+		viewport?: {
+			scrollBarWidth: number;
+		};
 		_selectionService?: {
 			enable: () => void;
 			shouldForceSelection: (event: MouseEvent) => boolean;
@@ -248,6 +251,11 @@ function forceSelectionMode(term: Terminal): void {
 	selectionService.shouldForceSelection = () => true;
 	selectionService.enable();
 	element.classList.remove("enable-mouse-events");
+}
+
+function removeHiddenScrollbarReservation(term: Terminal): void {
+	const viewport = (term as XtermInternal)._core?.viewport;
+	if (viewport) viewport.scrollBarWidth = 0;
 }
 
 export function XtermTerminal(props: XtermTerminalProps) {
@@ -363,7 +371,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				// rely on the terminal's scrollback (codex, a plain shell). Keep it > 0
 				// so that history survives to be scrolled locally (see the wheel
 				// handler's normal-buffer branch). The scrollbar itself is hidden in
-				// CSS so FitAddon's ~14px reservation doesn't shift the grid.
+				// CSS; its matching FitAddon reservation is removed after open() below.
 				scrollback: 5000,
 				theme: props.theme === "dark" ? dark : light,
 			});
@@ -395,6 +403,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		if (import.meta.env.DEV) {
 			(host as DevXtermHost).__aoXtermForTest = term;
 		}
+		// xterm reserves a 15px fallback for macOS overlay scrollbars even when CSS
+		// hides the scrollbar entirely. FitAddon subtracts that private value from
+		// every width proposal, leaving a conspicuous empty strip on the right. The
+		// viewport still scrolls normally without the invisible reservation.
+		removeHiddenScrollbarReservation(term);
 		loadRenderer(term);
 		term.options.macOptionClickForcesSelection = true;
 		forceSelectionMode(term);


### PR DESCRIPTION
## Summary
- keep only the terminal's left content gutter and let xterm use the full top, right, and bottom extent
- remove xterm's hidden 15px macOS overlay-scrollbar reservation from FitAddon width calculations
- add layout and scrollbar-reservation regression coverage

## Tests
- `cd frontend && npm test -- --run src/renderer/components/XtermTerminal.test.tsx src/renderer/components/TerminalPane.test.tsx`
- `cd frontend && npm run typecheck`

## Notes
- The scrollbar-width adjustment uses the same guarded xterm private viewport API that FitAddon already depends on.
- tmux multi-view sizing behavior (`window-size largest`) is intentionally unchanged.
