### PR TITLE
fix(frontend): strip macOS nested-radius from Windows/Linux center panel

### DIFF
--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -530,19 +530,21 @@
 	);
 }
 
-/* Windows / Linux: a ShellTopbar already supplies the top chrome, so the
- * framed panel needs no additional top inset. Windows uses its custom
- * frameless titlebar; Linux uses the standard ShellTopbar. */
+/* Windows / Linux: rectangular frameless window. There is no rounded macOS
+ * window to inset into, so flush the framed panel on every side — top is
+ * already covered by the custom titlebar / ShellTopbar, and the left is flush
+ * to the sidebar globally (padding-left: 0). Zero the remaining right/bottom
+ * insets so the panel fills the full window width instead of floating with a
+ * gap on the right and bottom. */
 .platform-windows .center-panel-shell,
 .platform-linux .center-panel-shell {
 	padding-top: 0;
+	padding-right: 0;
+	padding-bottom: 0;
 }
 
-/* Windows/Linux: rectangular frameless window — the macOS nested-radius
- * formula (window_radius − inset) only makes sense inside a rounded macOS
- * window. Strip it so the framed panel has sharp corners, consistent with the
- * flush left edge (padding-left: 0). Without this the right/bottom corners
- * curve away from the window edge while the left stays square. */
+/* macOS nested-radius formula (window_radius − inset) only makes sense inside
+ * a rounded macOS window. Strip it so the framed panel has sharp corners. */
 .platform-windows .center-panel-surface,
 .platform-linux .center-panel-surface {
 	border-radius: 0;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -538,6 +538,16 @@
 	padding-top: 0;
 }
 
+/* Windows/Linux: rectangular frameless window — the macOS nested-radius
+ * formula (window_radius − inset) only makes sense inside a rounded macOS
+ * window. Strip it so the framed panel has sharp corners, consistent with the
+ * flush left edge (padding-left: 0). Without this the right/bottom corners
+ * curve away from the window edge while the left stays square. */
+.platform-windows .center-panel-surface,
+.platform-linux .center-panel-surface {
+	border-radius: 0;
+}
+
 @utility settings-row-bar {
 	display: flex;
 	height: var(--size-settings-row);


### PR DESCRIPTION
## Problem

On Windows/Linux, the right side of the app shows curved/rounded corner radii while the left side (flush with the sidebar) stays square — reported by @phylsolver in bug-triage.

## Root cause

`center-panel-surface` uses `border-radius: var(--radius-center-panel)` (= **12px**), derived from a **macOS-specific formula**:

```
inner_radius = window_radius (18px) − inset (6px) = 12px
```

This nested-radius curve only makes sense **inside a rounded macOS window**. On Windows/Linux the frameless window is **rectangular**, and the shell has **asymmetric padding**:

| Edge | Padding | Curve visible? |
|------|---------|----------------|
| Left | `0` (flush to sidebar) | hidden |
| Top  | `0` (overridden by #3083) | hidden |
| Right | `16px` | **visible** |
| Bottom | `14px` | **visible** |

So the rounded corners only show on the right/bottom, making the panel look like a floating rounded card while the left stays square.

PR #3083 (*"flush Windows center panel"*) already dropped the **top** inset on Windows but never stripped the **radius**. This finishes that job.

## Fix

Set `border-radius: 0` on `.platform-windows` / `.platform-linux` `center-panel-surface` so the framed panel has sharp corners, consistent with the flush left edge. macOS is untouched — it keeps the nested-radius curve inside its rounded window.

## Testing

- [x] CSS-only change, no logic/TS affected
- [x] macOS path (`center-panel-shell--mac`) untouched — no regression
- [ ] Manual: verify Windows/Linux center panel now has square corners on right/bottom