### PR TITLE
fix(ptyexec): bound Close wait after the SIGKILL fallback

### DIFF
--- a/backend/internal/adapters/runtime/ptyexec/spawn_unix.go
+++ b/backend/internal/adapters/runtime/ptyexec/spawn_unix.go
@@ -119,7 +119,11 @@ func (p *creackPTY) Close() error {
 			if p.cmd.Process != nil {
 				_ = p.cmd.Process.Kill()
 			}
-			<-done
+			// SIGKILL reaps a well-behaved process and done closes; a process
+			// wedged in uninterruptible kernel state survives it, so blocking
+			// on done here would hang daemon shutdown forever. waitForExit
+			// bounds the wait and Close releases the PTY master regardless.
+			waitForExit(done, killGrace)
 		}
 		p.closeErr = p.f.Close()
 	})

--- a/backend/internal/adapters/runtime/ptyexec/spawn_windows.go
+++ b/backend/internal/adapters/runtime/ptyexec/spawn_windows.go
@@ -85,7 +85,10 @@ func (p *conPTYProcess) Close() error {
 			if p.cmd.Process != nil {
 				_ = p.cmd.Process.Kill()
 			}
-			<-p.waitDone
+			// Mirror the Unix escape hatch: a process that survives Kill must
+			// not block Close (and daemon shutdown) forever. waitForExit
+			// bounds the wait and Close returns regardless.
+			waitForExit(p.waitDone, killGrace)
 		}
 	})
 	return nil

--- a/backend/internal/adapters/runtime/ptyexec/wait.go
+++ b/backend/internal/adapters/runtime/ptyexec/wait.go
@@ -1,0 +1,24 @@
+package ptyexec
+
+import "time"
+
+// killGrace bounds Close's final wait after the SIGKILL fallback. A process
+// wedged in an uninterruptible kernel state (D — e.g. blocked on a dead NFS
+// or FUSE mount in the workspace) cannot be reaped even by SIGKILL, and
+// cmd.Wait would block forever, stalling daemon shutdown (and session
+// teardown, which reaches the same Close via the Spawn ctx-cancellation
+// goroutine). After the grace, Close releases the PTY master and returns;
+// the Wait goroutine finishes whenever the kernel eventually reaps the
+// process.
+const killGrace = 2 * time.Second
+
+// waitForExit blocks until done is closed or grace elapses, whichever comes
+// first. It is Close's bounded tail: SIGKILL normally reaps the process
+// immediately and done closes; the timeout is the escape hatch for a wedged
+// process that cannot be killed.
+func waitForExit(done <-chan struct{}, grace time.Duration) {
+	select {
+	case <-done:
+	case <-time.After(grace):
+	}
+}

--- a/backend/internal/adapters/runtime/ptyexec/wait_test.go
+++ b/backend/internal/adapters/runtime/ptyexec/wait_test.go
@@ -1,0 +1,35 @@
+package ptyexec
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWaitForExitBoundsThePostKillWait guards the shutdown-hang escape hatch:
+// a process wedged in uninterruptible kernel state survives SIGKILL, and if
+// Close blocked on cmd.Wait it would stall daemon shutdown forever. waitForExit
+// is the bounded tail — it must return after grace even when done never closes.
+func TestWaitForExitBoundsThePostKillWait(t *testing.T) {
+	never := make(chan struct{})
+	start := time.Now()
+	waitForExit(never, 50*time.Millisecond)
+	elapsed := time.Since(start)
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("waitForExit returned after %v; expected it to wait out the grace", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("waitForExit blocked for %v; expected a bounded return after grace", elapsed)
+	}
+}
+
+// TestWaitForExitReturnsOnDone: when the process exits, done closes and
+// waitForExit returns without waiting out the grace.
+func TestWaitForExitReturnsOnDone(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	start := time.Now()
+	waitForExit(done, 5*time.Second)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("waitForExit took %v on a closed channel; expected an immediate return", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

`ptyexec.Spawn` opens a local PTY around a terminal attach client (`tmux attach-session` on Unix, ConPTY on Windows). Its `Close()` tears the attach process down as **SIGTERM → SIGKILL → `<-done`**, where `done` closes when `cmd.Wait()` returns.

That final `<-done` is **unbounded**. A process wedged in an uninterruptible kernel state (`D` — e.g. blocked on a dead NFS/FUSE mount in the workspace) survives **SIGKILL**, so `cmd.Wait()` never returns and `Close()` blocks forever. Because `Close()` runs on daemon shutdown and on session teardown (including via the `Spawn` ctx-cancellation goroutine), a single wedged attach terminal hangs the entire daemon shutdown indefinitely. The Windows `conPTYProcess.Close()` has the identical unbounded wait.

This matters in practice because the attach client here is `tmux attach`, which resolves its session in the workspace tree — exactly the kind of path a hung filesystem can wedge.

## Change

- Add a shared `killGrace` (2s) and a `waitForExit(done, grace)` helper that returns on `done` **or** after the grace.
- Unix `creackPTY.Close()` and Windows `conPTYProcess.Close()` now call `waitForExit(...)` after the SIGKILL fallback, then release the PTY master and return. The `cmd.Wait()` goroutine finishes whenever the kernel eventually reaps the process; `Close` stays idempotent via `closeOnce`.
- Add unit tests (`wait_test.go`) covering both the bounded-timeout escape hatch and the fast path when the process has already exited.

SIGTERM-first behavior is preserved: a cooperative attach client still detaches within `detachGrace` (250ms), and a TERM-ignoring process is still killed via SIGKILL — only the post-Kill wait is now bounded.

## Tests

- `go build ./...`, `go vet`
- `go test -race ./internal/adapters/runtime/... ./internal/terminal/...` — pass
- `go test ./...` — pass except four pre-existing `internal/cli` spawn tests that fail on a clean `main` checkout too (environment/daemon-404, unrelated to this change).

## Known risks / follow-ups

- Worst-case shutdown now adds up to ~2.25s per genuinely-wedged attach terminal instead of hanging forever (intentional tradeoff).