### PR TITLE
fix(scm): condition commit check guard on all check runs, not just one

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -144,7 +144,7 @@ func (p *Provider) CommitChecksGuard(ctx context.Context, repo ports.SCMRepo, he
 		// Decode failure is unexpected but shouldn't block the whole repo poll.
 		// Return NotModified=false with no ETag so the observer falls back to the
 		// full GraphQL refresh path; DefaultPRMaxAge bounds staleness.
-		return ports.SCMGuardResult{}, nil
+		return ports.SCMGuardResult{}, nil //nolint:nilerr // decode failure falls back to the max-age refresh path
 	}
 	if page.TotalCount > len(page.CheckRuns) {
 		// The commit has more runs than one page fits; rely on a stable

--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -91,18 +91,130 @@ func (p *Provider) ListOpenPRsByRepo(ctx context.Context, repo ports.SCMRepo) ([
 	}
 }
 
-// CommitChecksGuard checks GitHub's per-commit check-runs ETag guard.
+// githubCheckRunsPageSize fetches the complete check-run set for a commit in a
+// single REST page when the commit has no more than this many runs. A commit
+// virtually never exceeds GitHub's 100-result cap, so one request carries the
+// whole representation and GitHub's ETag reflects every contributing run.
+const githubCheckRunsPageSize = 100
+
+// restCheckRunsPage is the GitHub list-check-runs response envelope.
+type restCheckRunsPage struct {
+	TotalCount int                  `json:"total_count"`
+	CheckRuns  []restCommitCheckRun `json:"check_runs"`
+}
+
+// restCommitCheckRun is the subset of a GitHub check-run we condition the
+// aggregate CI-state guard on.
+type restCommitCheckRun struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+// CommitChecksGuard checks GitHub's per-commit check-runs guard. It conditions
+// the fast CI-state guard on the complete check-run set rather than a single
+// item: GitHub's ETag for a per_page=1 response only reflects that one run, so
+// a different workflow finishing (or failing, or going pending) can leave the
+// returned item unchanged and GitHub answers 304 even though the aggregate CI
+// state AO displays has changed. Requesting the full page makes the guard
+// represent all runs that contribute to the state, and paginating plus
+// fingerprinting stays correct when a commit carries more than one page of
+// runs. DefaultPRMaxAge remains the safety backstop for PR metadata changes not
+// represented by check-state guards.
 func (p *Provider) CommitChecksGuard(ctx context.Context, repo ports.SCMRepo, headSHA, etag string) (ports.SCMGuardResult, error) {
 	if strings.TrimSpace(headSHA) == "" {
 		return ports.SCMGuardResult{}, fmt.Errorf("%w: empty head sha", ErrNotFound)
 	}
 	q := url.Values{}
-	q.Set("per_page", "1")
+	q.Set("per_page", strconv.Itoa(githubCheckRunsPageSize))
 	resp, err := p.client.doRESTWithETag(ctx, repoPath(repo.Owner, repo.Name, "commits", headSHA, "check-runs"), q, etag)
 	if err != nil {
 		return ports.SCMGuardResult{}, err
 	}
-	return ports.SCMGuardResult{ETag: firstNonEmptyHeader(resp.ETag, etag), NotModified: resp.NotModified}, nil
+	if resp.NotModified {
+		// GitHub confirmed the whole first page is unchanged, which covers every
+		// run for the overwhelmingly common single-page case.
+		return ports.SCMGuardResult{ETag: firstNonEmptyHeader(resp.ETag, etag), NotModified: true}, nil
+	}
+	page, err := decodeRestCheckRunsPage(resp.Body)
+	if err != nil {
+		return ports.SCMGuardResult{}, err
+	}
+	if page.TotalCount > len(page.CheckRuns) {
+		// The commit has more runs than one page fits; rely on a stable
+		// fingerprint over the complete set instead of a single page's ETag so a
+		// transition on a later page still invalidates the guard.
+		runs, err := p.fetchRemainingCommitCheckRuns(ctx, repo, headSHA, page)
+		if err != nil {
+			return ports.SCMGuardResult{}, err
+		}
+		fp := commitCheckRunsFingerprint(runs)
+		if etag == fp {
+			return ports.SCMGuardResult{ETag: fp, NotModified: true}, nil
+		}
+		return ports.SCMGuardResult{ETag: fp}, nil
+	}
+	// A single page carried the whole representation: GitHub's ETag is the
+	// correct validator, so any run transition yields a fresh ETag.
+	return ports.SCMGuardResult{ETag: firstNonEmptyHeader(resp.ETag, etag)}, nil
+}
+
+// decodeRestCheckRunsPage unmarshals a GitHub list-check-runs body.
+func decodeRestCheckRunsPage(body []byte) (restCheckRunsPage, error) {
+	var page restCheckRunsPage
+	if err := json.Unmarshal(body, &page); err != nil {
+		return restCheckRunsPage{}, fmt.Errorf("github scm: decode check runs: %w", err)
+	}
+	return page, nil
+}
+
+// fetchRemainingCommitCheckRuns gathers the check runs a commit carries beyond
+// the first page and returns every run across all pages.
+func (p *Provider) fetchRemainingCommitCheckRuns(ctx context.Context, repo ports.SCMRepo, headSHA string, page restCheckRunsPage) ([]restCommitCheckRun, error) {
+	runs := append([]restCommitCheckRun(nil), page.CheckRuns...)
+	for pageNum := 2; len(runs) < page.TotalCount; pageNum++ {
+		q := url.Values{}
+		q.Set("per_page", strconv.Itoa(githubCheckRunsPageSize))
+		q.Set("page", strconv.Itoa(pageNum))
+		resp, err := p.client.doREST(ctx, http.MethodGet, repoPath(repo.Owner, repo.Name, "commits", headSHA, "check-runs"), q, nil)
+		if err != nil {
+			return nil, err
+		}
+		next, err := decodeRestCheckRunsPage(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, next.CheckRuns...)
+		if len(next.CheckRuns) == 0 {
+			break
+		}
+	}
+	return runs, nil
+}
+
+// commitCheckRunsFingerprint is a stable hash of a commit's complete check-run
+// set, sorted so the order GitHub returns runs in cannot matter. It only hashes
+// the fields that determine the aggregate CI state (name, status, conclusion).
+func commitCheckRunsFingerprint(runs []restCommitCheckRun) string {
+	sort.Slice(runs, func(i, j int) bool {
+		if runs[i].Name != runs[j].Name {
+			return runs[i].Name < runs[j].Name
+		}
+		if runs[i].Status != runs[j].Status {
+			return runs[i].Status < runs[j].Status
+		}
+		return runs[i].Conclusion < runs[j].Conclusion
+	})
+	h := sha256.New()
+	for _, r := range runs {
+		_, _ = h.Write([]byte(r.Name))
+		h.Write([]byte{0})
+		_, _ = h.Write([]byte(r.Status))
+		h.Write([]byte{0})
+		_, _ = h.Write([]byte(r.Conclusion))
+		h.Write([]byte{0x1e})
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // FetchPullRequests fetches normalized PR/check metadata for up to 25 PR refs in

--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -35,6 +35,9 @@ const (
 	githubReviewThreadMaxPages = 2
 	// githubReviewSummaryLimit bounds submitted decisive reviews used for summary links.
 	githubReviewSummaryLimit = 20
+	// githubCheckRunsMaxPages bounds the pagination when fetching all check runs
+	// for a commit. This prevents unbounded pagination on malformed responses.
+	githubCheckRunsMaxPages = 10
 )
 
 // ParseRepository normalizes a GitHub remote/origin URL into a provider-neutral
@@ -138,7 +141,10 @@ func (p *Provider) CommitChecksGuard(ctx context.Context, repo ports.SCMRepo, he
 	}
 	page, err := decodeRestCheckRunsPage(resp.Body)
 	if err != nil {
-		return ports.SCMGuardResult{}, err
+		// Decode failure is unexpected but shouldn't block the whole repo poll.
+		// Return NotModified=false with no ETag so the observer falls back to the
+		// full GraphQL refresh path; DefaultPRMaxAge bounds staleness.
+		return ports.SCMGuardResult{}, nil
 	}
 	if page.TotalCount > len(page.CheckRuns) {
 		// The commit has more runs than one page fits; rely on a stable
@@ -172,7 +178,7 @@ func decodeRestCheckRunsPage(body []byte) (restCheckRunsPage, error) {
 // the first page and returns every run across all pages.
 func (p *Provider) fetchRemainingCommitCheckRuns(ctx context.Context, repo ports.SCMRepo, headSHA string, page restCheckRunsPage) ([]restCommitCheckRun, error) {
 	runs := append([]restCommitCheckRun(nil), page.CheckRuns...)
-	for pageNum := 2; len(runs) < page.TotalCount; pageNum++ {
+	for pageNum := 2; len(runs) < page.TotalCount && pageNum <= githubCheckRunsMaxPages; pageNum++ {
 		q := url.Values{}
 		q.Set("per_page", strconv.Itoa(githubCheckRunsPageSize))
 		q.Set("page", strconv.Itoa(pageNum))
@@ -196,25 +202,20 @@ func (p *Provider) fetchRemainingCommitCheckRuns(ctx context.Context, repo ports
 // set, sorted so the order GitHub returns runs in cannot matter. It only hashes
 // the fields that determine the aggregate CI state (name, status, conclusion).
 func commitCheckRunsFingerprint(runs []restCommitCheckRun) string {
-	sort.Slice(runs, func(i, j int) bool {
-		if runs[i].Name != runs[j].Name {
-			return runs[i].Name < runs[j].Name
-		}
-		if runs[i].Status != runs[j].Status {
-			return runs[i].Status < runs[j].Status
-		}
-		return runs[i].Conclusion < runs[j].Conclusion
-	})
-	h := sha256.New()
-	for _, r := range runs {
-		_, _ = h.Write([]byte(r.Name))
-		h.Write([]byte{0})
-		_, _ = h.Write([]byte(r.Status))
-		h.Write([]byte{0})
-		_, _ = h.Write([]byte(r.Conclusion))
-		h.Write([]byte{0x1e})
+	parts := make([]string, len(runs))
+	for i, r := range runs {
+		parts[i] = strings.Join([]string{r.Name, r.Status, r.Conclusion}, "\x00")
 	}
-	return hex.EncodeToString(h.Sum(nil))
+	return stableCheckFingerprint(parts)
+}
+
+// stableCheckFingerprint computes a stable SHA256 hash of a sorted string slice.
+// The slice is sorted, joined with "\x1e", then hashed. This shared logic is
+// used by both commitCheckRunsFingerprint and githubFailedFingerprint.
+func stableCheckFingerprint(parts []string) string {
+	sort.Strings(parts)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x1e")))
+	return hex.EncodeToString(sum[:])
 }
 
 // FetchPullRequests fetches normalized PR/check metadata for up to 25 PR refs in
@@ -572,13 +573,11 @@ func githubFailedFingerprint(head string, checks []ports.SCMCheckObservation) st
 	if len(checks) == 0 {
 		return ""
 	}
-	parts := make([]string, 0, len(checks))
-	for _, ch := range checks {
-		parts = append(parts, strings.Join([]string{head, ch.Name, ch.Status, ch.Conclusion, ch.URL, ch.ProviderID}, "\x00"))
+	parts := make([]string, len(checks))
+	for i, ch := range checks {
+		parts[i] = strings.Join([]string{head, ch.Name, ch.Status, ch.Conclusion, ch.URL, ch.ProviderID}, "\x00")
 	}
-	sort.Strings(parts)
-	sum := sha256.Sum256([]byte(strings.Join(parts, "\x1e")))
-	return hex.EncodeToString(sum[:])
+	return stableCheckFingerprint(parts)
 }
 
 func mergeabilityObservation(providerMergeable, providerMergeState, ci, review string, draft bool) ports.SCMMergeabilityObservation {

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -2,8 +2,10 @@ package github
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1510,5 +1512,185 @@ func TestFetchReviewThreadsFetchesOneOlderPageWhenOldestUnresolved(t *testing.T)
 	}
 	if len(review.Threads) != 2 || review.Threads[0].ID != "older" || review.Threads[1].ID != "latest-unresolved" {
 		t.Fatalf("threads order = %#v", review.Threads)
+	}
+}
+
+// installCheckRunsFake serves the per-commit check-runs endpoint exactly the way
+// GitHub does for ETag purposes: 304 when the representation GitHub would return
+// for the caller's per_page is unchanged, otherwise 200 with a fresh ETag. The
+// authoritative full run list is held behind mu so a test can pivot one run's
+// status between calls. This models the real GitHub contract, where the ETag
+// covers only the returned page (which is why the old per_page=1 bug existed).
+func installCheckRunsFake(t *testing.T, f *fakeGH, owner, repo, sha string, mu *sync.Mutex, runs *[]map[string]any) {
+	t.Helper()
+	path := repoPath(owner, repo, "commits", sha, "check-runs")
+	f.on(http.MethodGet, path, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		perPage := 100
+		if q := r.URL.Query().Get("per_page"); q != "" {
+			if n, err := strconv.Atoi(q); err == nil && n > 0 {
+				perPage = n
+			}
+		}
+		shown := *runs
+		if perPage < len(shown) {
+			shown = (*runs)[:perPage]
+		}
+		body, _ := json.Marshal(map[string]any{"total_count": len(*runs), "check_runs": shown})
+		sum := sha256.Sum256(body)
+		etag := fmt.Sprintf(`W/"%x"`, sum)
+		if r.Header.Get("If-None-Match") == etag {
+			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", etag)
+		_, _ = w.Write(body)
+	})
+}
+
+// TestCommitChecksGuard_OtherRunTransitionInvalidatesGuard is a regression test
+// for the "completed checks remain pending" bug: the guard used to condition on
+// per_page=1, so GitHub's ETag only covered the first returned run. When a
+// DIFFERENT workflow finished, the single-item representation was unchanged and
+// GitHub answered 304, leaving AO stuck on "Checks running" until the five-minute
+// forced refresh. The guard must now track the complete run set.
+func TestCommitChecksGuard_OtherRunTransitionInvalidatesGuard(t *testing.T) {
+	f := newFakeGH(t)
+	const owner, repo, sha = "octocat", "hello", "abc123"
+	var mu sync.Mutex
+	runs := []map[string]any{
+		{"id": 1, "name": "lint", "status": "completed", "conclusion": "success"},
+		{"id": 2, "name": "test", "status": "in_progress", "conclusion": ""},
+	}
+	installCheckRunsFake(t, f, owner, repo, sha, &mu, &runs)
+	p := newProviderForTest(t, f)
+	repoRef := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: owner, Name: repo, Repo: owner + "/" + repo}
+
+	// First poll: no cached ETag, must be a fresh fetch -> NotModified=false.
+	res, err := p.CommitChecksGuard(ctx(), repoRef, sha, "")
+	if err != nil {
+		t.Fatalf("first CommitChecksGuard: %v", err)
+	}
+	if res.NotModified {
+		t.Fatal("first poll reported NotModified with no cached ETag")
+	}
+	if res.ETag == "" {
+		t.Fatal("first poll returned an empty ETag")
+	}
+
+	// Second poll: representation unchanged -> 304 -> NotModified=true.
+	res, err = p.CommitChecksGuard(ctx(), repoRef, sha, res.ETag)
+	if err != nil {
+		t.Fatalf("unchanged CommitChecksGuard: %v", err)
+	}
+	if !res.NotModified {
+		t.Fatal("unchanged check-runs representation reported NotModified=false")
+	}
+
+	// Third poll: the FIRST returned run is stable, but a DIFFERENT run
+	// transitions in_progress -> completed. With the old per_page=1 guard this
+	// returned 304 and AO kept "Checks running". With the complete-representation
+	// guard the full body changed, so GitHub sends a fresh ETag -> NotModified=false.
+	mu.Lock()
+	runs = []map[string]any{
+		{"id": 1, "name": "lint", "status": "completed", "conclusion": "success"},
+		{"id": 2, "name": "test", "status": "completed", "conclusion": "success"},
+	}
+	mu.Unlock()
+	res, err = p.CommitChecksGuard(ctx(), repoRef, sha, res.ETag)
+	if err != nil {
+		t.Fatalf("transitioned CommitChecksGuard: %v", err)
+	}
+	if res.NotModified {
+		t.Fatal("guard stayed NotModified after a non-first run transitioned (per_page=1 regression)")
+	}
+}
+
+// TestCommitChecksGuard_PaginatedFingerprintInvalidatesLaterPageRun verifies the
+// paginated path: when a commit carries more than one page of check runs, the
+// guard fingerprints the complete set so a transition on a LATER page (invisible
+// to the first page's ETag) still invalidates the guard.
+func TestCommitChecksGuard_PaginatedFingerprintInvalidatesLaterPageRun(t *testing.T) {
+	f := newFakeGH(t)
+	const owner, repo, sha = "octocat", "hello", "abc123"
+	path := repoPath(owner, repo, "commits", sha, "check-runs")
+
+	var mu sync.Mutex
+	// 150 runs: page 1 holds runs 1..100, page 2 holds 101..150. The first-page
+	// ETag only reflects runs 1..100; the transition happens on a page-2 run.
+	page1 := make([]map[string]any, 0, githubCheckRunsPageSize)
+	for i := 1; i <= 100; i++ {
+		page1 = append(page1, map[string]any{"id": i, "name": fmt.Sprintf("job-%d", i), "status": "completed", "conclusion": "success"})
+	}
+	page2 := make([]map[string]any, 0, 50)
+	for i := 101; i <= 150; i++ {
+		status, conclusion := "completed", "success"
+		if i == 150 {
+			// The run whose transition the first page's ETag cannot see.
+			status, conclusion = "in_progress", ""
+		}
+		page2 = append(page2, map[string]any{"id": i, "name": fmt.Sprintf("job-%d", i), "status": status, "conclusion": conclusion})
+	}
+	state := &struct {
+		page1 []map[string]any
+		page2 []map[string]any
+	}{page1: page1, page2: page2}
+
+	f.on(http.MethodGet, path, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		pageNum := 1
+		if q := r.URL.Query().Get("page"); q != "" {
+			if n, err := strconv.Atoi(q); err == nil && n > 0 {
+				pageNum = n
+			}
+		}
+		var shown []map[string]any
+		switch pageNum {
+		case 1:
+			shown = state.page1
+		case 2:
+			shown = state.page2
+		}
+		body, _ := json.Marshal(map[string]any{"total_count": 150, "check_runs": shown})
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", fmt.Sprintf(`W/"%x"`, sha256.Sum256(body)))
+		_, _ = w.Write(body)
+	})
+	p := newProviderForTest(t, f)
+	repoRef := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: owner, Name: repo, Repo: owner + "/" + repo}
+
+	res, err := p.CommitChecksGuard(ctx(), repoRef, sha, "")
+	if err != nil {
+		t.Fatalf("first paginated guard: %v", err)
+	}
+	if res.NotModified {
+		t.Fatal("first paginated poll reported NotModified")
+	}
+	firstFingerprint := res.ETag
+
+	// Unchanged set -> NotModified=true.
+	res, err = p.CommitChecksGuard(ctx(), repoRef, sha, firstFingerprint)
+	if err != nil {
+		t.Fatalf("unchanged paginated guard: %v", err)
+	}
+	if !res.NotModified {
+		t.Fatal("unchanged page-2 content reported NotModified=false")
+	}
+
+	// Only a page-2 run transitions; page 1 (whose ETag page-1 callers would see)
+	// is untouched. The fingerprint over the whole set must change.
+	mu.Lock()
+	state.page2[49] = map[string]any{"id": 150, "name": "job-150", "status": "completed", "conclusion": "success"}
+	mu.Unlock()
+	res, err = p.CommitChecksGuard(ctx(), repoRef, sha, firstFingerprint)
+	if err != nil {
+		t.Fatalf("transitioned paginated guard: %v", err)
+	}
+	if res.NotModified {
+		t.Fatal("guard stayed NotModified after a page-2 run transitioned (fingerprint bug)")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #3601 — **completed checks can remain pending until forced refresh**.

`CommitChecksGuard` in `backend/internal/adapters/scm/github/observer_provider.go` requested the per-commit check-runs endpoint with `per_page=1` and used that single-item response's ETag as the fast check-state guard. When a PR carries multiple check runs, the one returned item can remain unchanged while a **different** workflow finishes, so GitHub answers `304 Not Modified` even though the aggregate CI state AO displays has changed. `selectRefreshCandidates` then skips the full GraphQL PR/check refresh, leaving the card on **Checks running** until the five-minute `DefaultPRMaxAge` backstop.

## Change

- Request the **complete** check-run representation (`per_page=100`, GitHub's cap) so the ETag covers every run that contributes to the aggregate CI state.
- When a commit carries more than one page of runs (`total_count > 100`), fall back to a stable fingerprint over the **full** run set (paginating), so a transition on a later page still invalidates the guard. Conditional-request savings are preserved: when nothing changed, the guard reports `NotModified` and the observer skips the GraphQL refresh.
- `DefaultPRMaxAge` remains as the safety backstop for PR metadata changes not represented by check-state guards.

## Tests

- `TestCommitChecksGuard_OtherRunTransitionInvalidatesGuard` — regression: first returned run stays stable while another run transitions `in_progress -> completed`; guard must report `NotModified=false`. (Verified this test fails against the old `per_page=1` logic.)
- `TestCommitChecksGuard_PaginatedFingerprintInvalidatesLaterPageRun` — a transition on a page-2 run invalidates the paginated fingerprint guard.
- Ran `go test ./internal/adapters/scm/github/... ./internal/observe/scm/...`, `go vet`, `gofmt`, and golangci-lint v2.12.2 — all clean.

Pre-existing failures in `internal/cli`, `internal/adapters/agent/fake`, and `internal/adapters/agent/kilocode` reproduce on clean upstream `main` and are unrelated to this change.

## Risks / Follow-ups

None known. The guard change only affects when the fast path forces a full refresh; it can only make CI transitions arrive sooner, never later.