### PR TITLE
fix: snap theme switches with View Transitions

### DIFF
--- a/frontend/src/renderer/lib/theme.test.ts
+++ b/frontend/src/renderer/lib/theme.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	applyDocumentTheme,
+	applyDocumentThemeStyle,
+	runThemeTransition,
+} from "./theme";
+
+describe("runThemeTransition", () => {
+	afterEach(() => {
+		Reflect.deleteProperty(document, "startViewTransition");
+		delete document.documentElement.dataset.theme;
+		delete document.documentElement.dataset.styleTheme;
+		document.documentElement.style.colorScheme = "";
+	});
+
+	it("runs the update immediately when View Transitions are unavailable", () => {
+		Reflect.deleteProperty(document, "startViewTransition");
+		const update = vi.fn(() => {
+			applyDocumentTheme("light");
+		});
+
+		runThemeTransition(update);
+
+		expect(update).toHaveBeenCalledOnce();
+		expect(document.documentElement.dataset.theme).toBe("light");
+		expect(document.documentElement.style.colorScheme).toBe("light");
+	});
+
+	it("wraps the update in startViewTransition when available", () => {
+		const startViewTransition = vi.fn((callback: () => void) => {
+			callback();
+			return {
+				finished: Promise.resolve(),
+				ready: Promise.resolve(),
+				updateCallbackDone: Promise.resolve(),
+				skipTransition: () => undefined,
+			};
+		});
+		Object.defineProperty(document, "startViewTransition", {
+			configurable: true,
+			writable: true,
+			value: startViewTransition,
+		});
+		const update = vi.fn(() => {
+			applyDocumentThemeStyle("github");
+		});
+
+		runThemeTransition(update);
+
+		expect(startViewTransition).toHaveBeenCalledOnce();
+		expect(update).toHaveBeenCalledOnce();
+		expect(document.documentElement.dataset.styleTheme).toBe("github");
+	});
+});
+
+describe("applyDocumentThemeStyle", () => {
+	afterEach(() => {
+		delete document.documentElement.dataset.styleTheme;
+	});
+
+	it("clears data-style-theme for orchestrate", () => {
+		document.documentElement.dataset.styleTheme = "nord";
+		applyDocumentThemeStyle("orchestrate");
+		expect(document.documentElement.dataset.styleTheme).toBeUndefined();
+	});
+});

--- a/frontend/src/renderer/lib/theme.ts
+++ b/frontend/src/renderer/lib/theme.ts
@@ -77,3 +77,17 @@ export function applyDocumentThemeStyle(style: ThemeStyle): void {
 		document.documentElement.dataset.styleTheme = style;
 	}
 }
+
+/**
+ * Apply a theme DOM update under a View Transition so per-element
+ * `transition-colors` / background tweens are hidden behind a snapshot.
+ * Default VT crossfade is disabled in CSS — this is an instant cut.
+ * Falls back to a plain update when the API is unavailable.
+ */
+export function runThemeTransition(update: () => void): void {
+	if (typeof document === "undefined" || typeof document.startViewTransition !== "function") {
+		update();
+		return;
+	}
+	document.startViewTransition(update);
+}

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -1,9 +1,12 @@
 import { create } from "zustand";
 import type { TerminalTarget } from "../types/terminal";
 import {
+	applyDocumentTheme,
+	applyDocumentThemeStyle,
 	readStoredThemePreference,
 	readStoredThemeStyle,
 	resolveTheme,
+	runThemeTransition,
 	systemTheme,
 	themeStorageKey,
 	themeStyleStorageKey,
@@ -156,7 +159,7 @@ function inspectorState(sessions: Record<string, InspectorSessionState>, session
 const initialThemePreference = readStoredThemePreference();
 const initialThemeStyle = readStoredThemeStyle();
 
-export const useUiStore = create<UiState>((set) => ({
+export const useUiStore = create<UiState>((set, get) => ({
 	workbenchTab: "changes",
 	isSidebarOpen: initialSidebarOpen(),
 	inspectorSessions: {},
@@ -177,12 +180,21 @@ export const useUiStore = create<UiState>((set) => ({
 	devSettings: initialDevSettings(),
 	setWorkbenchTab: (workbenchTab) => set({ workbenchTab }),
 	setThemePreference: (themePreference) => {
-		getLocalStorage()?.setItem(themeStorageKey, themePreference);
-		set({ themePreference, resolvedTheme: resolveTheme(themePreference) });
+		if (get().themePreference === themePreference) return;
+		runThemeTransition(() => {
+			const resolvedTheme = resolveTheme(themePreference);
+			getLocalStorage()?.setItem(themeStorageKey, themePreference);
+			applyDocumentTheme(resolvedTheme);
+			set({ themePreference, resolvedTheme });
+		});
 	},
 	setThemeStyle: (themeStyle) => {
-		getLocalStorage()?.setItem(themeStyleStorageKey, themeStyle);
-		set({ themeStyle });
+		if (get().themeStyle === themeStyle) return;
+		runThemeTransition(() => {
+			getLocalStorage()?.setItem(themeStyleStorageKey, themeStyle);
+			applyDocumentThemeStyle(themeStyle);
+			set({ themeStyle });
+		});
 	},
 	openGlobalSettings: () => set({ settingsModal: { scope: "global" } }),
 	openProjectSettings: (projectId) => set({ settingsModal: { scope: "project", projectId } }),
@@ -195,12 +207,16 @@ export const useUiStore = create<UiState>((set) => ({
 		getLocalStorage()?.setItem(developerModeStorageKey, String(developerMode));
 		set({ developerMode });
 	},
-	syncSystemTheme: () =>
-		set((state) => {
-			if (state.themePreference !== "system") return state;
-			const next = systemTheme();
-			return next === state.resolvedTheme ? state : { resolvedTheme: next };
-		}),
+	syncSystemTheme: () => {
+		const { themePreference, resolvedTheme } = get();
+		if (themePreference !== "system") return;
+		const next = systemTheme();
+		if (next === resolvedTheme) return;
+		runThemeTransition(() => {
+			applyDocumentTheme(next);
+			set({ resolvedTheme: next });
+		});
+	},
 	toggleSidebar: () =>
 		set((state) => {
 			const isSidebarOpen = !state.isSidebarOpen;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -13,6 +13,17 @@
  * (:root[data-theme="light"]). apply-initial-theme runs before CSS load; the
  * Zustand theme toggle updates data-theme on <html>.
  */
+
+/*
+ * Theme switches run under document.startViewTransition so per-element
+ * color/background transitions are hidden behind a snapshot. Kill the
+ * default root crossfade — we want an instant cut, not an animation.
+ */
+::view-transition-old(root),
+::view-transition-new(root) {
+	animation: none;
+	mix-blend-mode: normal;
+}
 @theme inline {
 	--font-sans: var(--font-family-base);
 	--font-mono: var(--font-family-mono);


### PR DESCRIPTION
## Summary
- Wrap Color Theme, light/dark, and system theme updates in `document.startViewTransition` so CSS variable changes are covered by a screen snapshot
- Disable the default root crossfade so the swap is instant (no wipe/fade)
- Apply `data-theme` / `data-style-theme` inside the transition callback; keep shell effects as an idempotent safety net

## Test plan
- [ ] Switch Color Theme in Settings — UI snaps, no color fade on sidebar/board/cards
- [ ] Switch Theme (light / dark / system) — same instant cut
- [ ] Toggle theme from the command palette
- [ ] With Theme = System, change OS appearance — snap without fade
- [ ] `npx vitest run src/renderer/lib/theme.test.ts`
- [ ] `npm run frontend:typecheck`