### PR TITLE
fix(workspace): stop leaking a descriptor per watched file on macOS

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aymanbagabas/go-pty v0.2.3
 	github.com/coder/websocket v1.8.14
 	github.com/creack/pty v1.1.24
-	github.com/fsnotify/fsnotify v1.9.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/google/uuid v1.6.0
 	github.com/pressly/goose/v3 v3.27.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -15,8 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
 github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/backend/internal/workspacewatch/descriptors_test.go
+++ b/backend/internal/workspacewatch/descriptors_test.go
@@ -1,0 +1,84 @@
+package workspacewatch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// openDescriptors counts this process's open file descriptors. Readdirnames
+// avoids stat'ing each entry, which trips over descriptors closed mid-scan.
+func openDescriptors(t *testing.T) (int, bool) {
+	t.Helper()
+	dir, err := os.Open("/dev/fd")
+	if err != nil {
+		return 0, false
+	}
+	defer func() { _ = dir.Close() }()
+	names, err := dir.Readdirnames(-1)
+	if err != nil {
+		return 0, false
+	}
+	return len(names), true
+}
+
+// TestWatchReleasesDescriptorsOnCancel pins the descriptor accounting of a
+// cancelled watch. The kqueue backend keeps one descriptor per watched file, so
+// a workspace watcher that does not release them on teardown costs roughly two
+// thousand descriptors per stream against a 61,440 per-process cap on macOS:
+// a handful of workspace views wedge the whole daemon, and every later
+// operation that needs a descriptor (spawning git, opening the next watcher)
+// fails with a bare 500. fsnotify v1.9.0 leaked exactly this way, because
+// kqueue.Close marked the watcher closed before its removal loop ran, which
+// made every removal a no-op.
+func TestWatchReleasesDescriptorsOnCancel(t *testing.T) {
+	baseline, ok := openDescriptors(t)
+	if !ok {
+		t.Skip("descriptor counting is unavailable on this platform")
+	}
+
+	root := t.TempDir()
+	for d := range 20 {
+		dir := filepath.Join(root, fmt.Sprintf("dir-%02d", d))
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("create dir: %v", err)
+		}
+		for f := range 20 {
+			name := filepath.Join(dir, fmt.Sprintf("file-%02d.txt", f))
+			if err := os.WriteFile(name, []byte("x"), 0o600); err != nil {
+				t.Fatalf("create file: %v", err)
+			}
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	changes, err := Watch(ctx, root)
+	if err != nil {
+		t.Fatalf("watch: %v", err)
+	}
+
+	watching, _ := openDescriptors(t)
+	if watching <= baseline {
+		t.Fatalf("watching descriptors = %d, want more than the %d baseline", watching, baseline)
+	}
+
+	cancel()
+	for range changes { //nolint:revive // drain until the watcher closes the channel
+	}
+
+	// Teardown is asynchronous; poll rather than sleep a fixed interval.
+	deadline := time.Now().Add(10 * time.Second)
+	var after int
+	for time.Now().Before(deadline) {
+		after, _ = openDescriptors(t)
+		if after <= baseline {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("descriptors after cancel = %d, want at most the %d baseline (leaked %d of the %d opened)",
+		after, baseline, after-baseline, watching-baseline)
+}


### PR DESCRIPTION
## What

Bumps `fsnotify` from v1.9.0 to v1.10.1 and adds a regression test for the file descriptors held by a workspace watcher.

## Why

The kqueue backend keeps one file descriptor per watched file, so a single `/api/v1/sessions/{id}/workspace/events` stream costs roughly 1,950 descriptors on an AO checkout. fsnotify v1.9.0 never releases them:

```go
func (w *kqueue) Close() error {
	if w.shared.close() { return nil }       // closes w.done, so isClosed() is now true
	pathsToRemove := w.watches.listPaths(false)
	for _, name := range pathsToRemove {
		w.Remove(name)                       // every call...
	}
	unix.Close(w.closepipe[1])
}

func (w *kqueue) remove(name string, unwatchFiles bool) error {
	if w.isClosed() { return nil }           // ...returns here
	...
	unix.Close(info.wd)                      // never runs
```

`Close` marks the watcher closed before running its own removal loop, and `remove` bails out early on a closed watcher, so the loop that releases the descriptors is dead code.

macOS caps a process at 61,440 descriptors (`kern.maxfilesperproc`), which is about 30 workspace streams. Once the daemon is at the cap, pooled database reads still succeed while anything needing a new descriptor fails, so the user-visible symptom is `GET /workspace/files` and `GET /workspace/events` returning a bare 500 on a daemon whose `/healthz` and `/api/v1/sessions` are green. Only restarting the app clears it.

Measured on a wedged daemon, one worktree held 31,951 descriptors across only 2,126 distinct paths: 16 leaked watcher trees for a single session.

## Isolating it

```
raw fsnotify: add 342 dirs -> 1,925 fds -> Close()      leaked 1,916
workspacewatch.Watch + context cancel                   leaked 1,944
raw fsnotify, Remove() each path BEFORE Close()         leaked 0
```

The third line rules out AO's teardown: `workspacewatch` cancels correctly, the descriptors simply are not returned unless removal runs before `Close`.

Upstream tracked this as fsnotify#732 and fixed it in fsnotify#740 ("kqueue: drop watches directly in Close() instead of going through remove()"), released in v1.10.1 on 2026-05-04. The dependency was added at v1.9.0 in #3492 on 2026-08-03, three months after the fix shipped, and was not previously in `go.sum`, so nothing in the module graph required that version.

## Test

`TestWatchReleasesDescriptorsOnCancel` builds a 400-file tree, watches it, cancels, and asserts descriptors return to baseline. It pins the accounting rather than the version string:

- on v1.9.0: `FAIL ... leaked 421 of 424 opened`
- on v1.10.1: passes

`workspacewatch` is the only importer of fsnotify. `go build ./...`, the `workspacewatch` and `httpd` suites, and `golangci-lint` on the package are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
