### PR TITLE
fix: preserve successful delegated task spawns

### DIFF
--- a/backend/internal/httpd/auth_test.go
+++ b/backend/internal/httpd/auth_test.go
@@ -146,6 +146,7 @@ func TestPreviewFileSetsScopedCookie(t *testing.T) {
 	}
 	if c == nil {
 		t.Fatal("expected auth cookie on preview file response")
+		return
 	}
 	if c.Path != "/api/v1/sessions/abc/preview/files/" {
 		t.Errorf("cookie Path = %q, want /api/v1/sessions/abc/preview/files/", c.Path)
@@ -175,6 +176,7 @@ func TestPreviewCookieRefreshedAfterPasswordChange(t *testing.T) {
 	}
 	if c == nil {
 		t.Fatal("expected stale auth cookie to be refreshed")
+		return
 	}
 	if c.Value != "newpass12" {
 		t.Errorf("cookie Value = %q, want the current token newpass12", c.Value)

--- a/backend/internal/service/session/delegation.go
+++ b/backend/internal/service/session/delegation.go
@@ -3,11 +3,14 @@ package session
 import (
 	"context"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
+
+const delegatedTaskTitleLimit = 20
 
 // DelegateTaskInput describes a task AO should spawn as a worker session. Empty
 // RequestedAgent means the spawn uses the project's worker-agent default.
@@ -25,9 +28,9 @@ type DelegateTaskOutcome struct {
 	WorkerID       domain.SessionID
 }
 
-// DelegateTask spawns the worker directly, matching `ao spawn`, and leaves the
-// display name empty so the read model temporarily uses the worker id. If an
-// orchestrator is active, AO asks it to rename the worker from the task brief.
+// DelegateTask spawns the worker directly, matching `ao spawn`, with a
+// provisional display name derived from the task brief. If a running
+// orchestrator is available, AO best-effort asks it to refine that title.
 func (s *Service) DelegateTask(ctx context.Context, in DelegateTaskInput) (DelegateTaskOutcome, error) {
 	if _, err := s.requireProject(ctx, in.ProjectID); err != nil {
 		return DelegateTaskOutcome{}, err
@@ -44,6 +47,7 @@ func (s *Service) DelegateTask(ctx context.Context, in DelegateTaskInput) (Deleg
 		Kind:        domain.KindWorker,
 		Harness:     in.RequestedAgent,
 		Prompt:      in.Brief,
+		DisplayName: delegatedTaskDisplayName(in.Brief),
 		AgentConfig: ports.AgentConfig{Model: strings.TrimSpace(in.Model)},
 	})
 	if err != nil {
@@ -52,24 +56,37 @@ func (s *Service) DelegateTask(ctx context.Context, in DelegateTaskInput) (Deleg
 
 	out := DelegateTaskOutcome{WorkerID: worker.ID}
 	active := true
-	orchestrators, err := s.List(ctx, ListFilter{
+	// The worker spawn is the commit point. Discovering a title-refinement
+	// recipient after that point is deliberately best effort.
+	orchestrators, _ := s.List(ctx, ListFilter{
 		ProjectID:        in.ProjectID,
 		Active:           &active,
 		OrchestratorOnly: true,
 	})
-	if err != nil {
-		return out, err
+
+	running := orchestrators[:0]
+	for _, orchestrator := range orchestrators {
+		if orchestrator.Activity.State != domain.ActivityExited {
+			running = append(running, orchestrator)
+		}
 	}
-	if len(orchestrators) == 0 {
+	if len(running) == 0 {
 		return out, nil
 	}
 
-	orchestrator := newestSession(orchestrators)
-	out.OrchestratorID = orchestrator.ID
-	if err := s.manager.Send(ctx, orchestrator.ID, taskTitleDelegationMessage(worker.ID, in)); err != nil {
-		return out, err
+	orchestrator := newestSession(running)
+	if s.manager.Send(ctx, orchestrator.ID, taskTitleDelegationMessage(worker.ID, in)) == nil {
+		out.OrchestratorID = orchestrator.ID
 	}
 	return out, nil
+}
+
+func delegatedTaskDisplayName(brief string) string {
+	title := strings.Join(strings.Fields(brief), " ")
+	if utf8.RuneCountInString(title) <= delegatedTaskTitleLimit {
+		return title
+	}
+	return strings.TrimSpace(string([]rune(title)[:delegatedTaskTitleLimit]))
 }
 
 func taskTitleDelegationMessage(workerID domain.SessionID, in DelegateTaskInput) string {

--- a/backend/internal/service/session/delegation_test.go
+++ b/backend/internal/service/session/delegation_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -27,8 +28,9 @@ func TestDelegateTaskSpawnsWorkerThenRequestsTitleFromNewestActiveOrchestrator(t
 			now := time.Now().UTC()
 			st.sessions["orch-old"] = domain.SessionRecord{ID: "orch-old", ProjectID: "ao", Kind: domain.KindOrchestrator, CreatedAt: now.Add(-time.Minute)}
 			st.sessions["orch-new"] = domain.SessionRecord{ID: "orch-new", ProjectID: "ao", Kind: domain.KindOrchestrator, CreatedAt: now}
-			st.sessions["orch-dead"] = domain.SessionRecord{ID: "orch-dead", ProjectID: "ao", Kind: domain.KindOrchestrator, IsTerminated: true, CreatedAt: now.Add(time.Minute)}
-			st.sessions["worker"] = domain.SessionRecord{ID: "worker", ProjectID: "ao", Kind: domain.KindWorker, CreatedAt: now.Add(2 * time.Minute)}
+			st.sessions["orch-exited"] = domain.SessionRecord{ID: "orch-exited", ProjectID: "ao", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityExited}, CreatedAt: now.Add(time.Minute)}
+			st.sessions["orch-dead"] = domain.SessionRecord{ID: "orch-dead", ProjectID: "ao", Kind: domain.KindOrchestrator, IsTerminated: true, CreatedAt: now.Add(2 * time.Minute)}
+			st.sessions["worker"] = domain.SessionRecord{ID: "worker", ProjectID: "ao", Kind: domain.KindWorker, CreatedAt: now.Add(3 * time.Minute)}
 			cmd := &fakeCommander{}
 			svc := &Service{store: st, manager: cmd}
 
@@ -42,7 +44,7 @@ func TestDelegateTaskSpawnsWorkerThenRequestsTitleFromNewestActiveOrchestrator(t
 			if out.WorkerID != "mer-9" || out.OrchestratorID != "orch-new" {
 				t.Fatalf("out = %#v, want worker mer-9 and orchestrator orch-new", out)
 			}
-			if !cmd.spawned || cmd.spawnedCfg.ProjectID != "ao" || cmd.spawnedCfg.Kind != domain.KindWorker || cmd.spawnedCfg.Harness != tt.wantAgent || cmd.spawnedCfg.Prompt != brief || cmd.spawnedCfg.DisplayName != "" {
+			if !cmd.spawned || cmd.spawnedCfg.ProjectID != "ao" || cmd.spawnedCfg.Kind != domain.KindWorker || cmd.spawnedCfg.Harness != tt.wantAgent || cmd.spawnedCfg.Prompt != brief || cmd.spawnedCfg.DisplayName != "Fix the renderer wit" {
 				t.Fatalf("spawn cfg = %#v", cmd.spawnedCfg)
 			}
 			if cmd.spawnedCfg.AgentConfig.Model != strings.TrimSpace(tt.model) {
@@ -69,6 +71,24 @@ func TestDelegateTaskSpawnsWorkerThenRequestsTitleFromNewestActiveOrchestrator(t
 	}
 }
 
+func TestDelegatedTaskDisplayName(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		brief string
+		want  string
+	}{
+		{name: "short", brief: "  tell me a joke  ", want: "tell me a joke"},
+		{name: "whitespace", brief: "Fix the renderer\nwithout changing the API", want: "Fix the renderer wit"},
+		{name: "unicode rune limit", brief: "一二三四五六七八九十一二三四五六七八九十一", want: "一二三四五六七八九十一二三四五六七八九十"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := delegatedTaskDisplayName(tt.brief); got != tt.want {
+				t.Fatalf("delegatedTaskDisplayName(%q) = %q, want %q", tt.brief, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDelegateTaskDoesNotRequireActiveOrchestrator(t *testing.T) {
 	st := newFakeStore()
 	st.projects["ao"] = domain.ProjectRecord{ID: "ao"}
@@ -84,6 +104,24 @@ func TestDelegateTaskDoesNotRequireActiveOrchestrator(t *testing.T) {
 	}
 	if len(cmd.sent) != 0 {
 		t.Fatalf("sent = %#v, want none", cmd.sent)
+	}
+	if !cmd.spawned {
+		t.Fatal("worker was not spawned")
+	}
+}
+
+func TestDelegateTaskKeepsSpawnSuccessWhenTitleRequestFails(t *testing.T) {
+	st := newFakeStore()
+	st.projects["ao"] = domain.ProjectRecord{ID: "ao"}
+	st.sessions["orch"] = domain.SessionRecord{ID: "orch", ProjectID: "ao", Kind: domain.KindOrchestrator}
+	cmd := &fakeCommander{sendErr: errors.New("orchestrator exited")}
+
+	out, err := (&Service{store: st, manager: cmd}).DelegateTask(context.Background(), DelegateTaskInput{ProjectID: "ao", Brief: "Fix it"})
+	if err != nil {
+		t.Fatalf("DelegateTask: %v", err)
+	}
+	if out.WorkerID != "mer-9" || out.OrchestratorID != "" {
+		t.Fatalf("out = %#v, want spawned worker without title recipient", out)
 	}
 	if !cmd.spawned {
 		t.Fatal("worker was not spawned")


### PR DESCRIPTION
## Summary

- give delegated workers an immediate provisional display name derived from the task brief
- treat orchestrator discovery and title refinement as best effort after worker spawn commits
- skip exited orchestrators while retaining the guarded send for lifecycle races
- add regression coverage for exited targets, title derivation, and title-send failure

## Why

The delegate endpoint could spawn and start a worker, then select an exited-but-not-terminated orchestrator for the optional title request. Sessionguard correctly refused that write, but the service propagated the follow-up error and returned 500 even though the worker already existed. A retry could then create a duplicate worker.

This change makes worker spawn the success boundary. Title refinement can still improve the provisional title, but it cannot revoke a completed spawn.

## Testing

- cd backend && go test ./internal/service/session ./internal/httpd/controllers
- cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs
- native Electron dev verification with an exited, non-terminated orchestrator: delegate returned 202 and the worker appeared with its task-derived title

## Verification limitation

The repo-wide npm run lint gate was attempted but its Go test phase was not clean locally: internal/adapters/agent/fake TestFullLifecycleSpawnToTermination took about 6 seconds and failed its under-one-second speedup assertion. The package is unrelated to this diff; the touched package tests and golangci-lint pass.

No API contract or generated artifact changes are required.