### PR TITLE
fix: don't gate PR-outcome notifications behind session restore

### DIFF
--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -70,7 +70,9 @@ const allNotifications: NotificationDTO[] = [
 		sessionId: "sess-dead",
 		projectId: "proj-1",
 		prUrl: "",
-		type: "pr_merged",
+		// needs_input: an agent is genuinely paused waiting on this session, so a
+		// terminated backing session should still require restore before opening.
+		type: "needs_input",
 		title: "PR #9 merged",
 		body: "The agent session has ended.",
 		status: "read",
@@ -566,6 +568,53 @@ describe("NotificationCenter", () => {
 
 		await userEvent.click(screen.getByRole("button", { name: "Restore session" }));
 		await waitFor(() => expect(restoreSessionMock).toHaveBeenCalledWith("sess-dead"));
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj-1", sessionId: "sess-dead" },
+		});
+	});
+
+	// A PR outcome describes work that already finished — there's no paused
+	// agent to resume, so a terminated session behind one should stay directly
+	// viewable instead of gated behind restore.
+	it("opens a terminated session directly for a PR-outcome notification, with no restore option", async () => {
+		notificationQueryMock.mockImplementation((status: NotificationListStatus) =>
+			status === "all"
+				? {
+						...notificationQueryResult(status),
+						data: {
+							pageParams: [""],
+							pages: [
+								{
+									notifications: [
+										{
+											id: "ntf_dead_pr",
+											sessionId: "sess-dead",
+											projectId: "proj-1",
+											prUrl: "https://github.com/acme/app/pull/9",
+											type: "pr_merged",
+											title: "PR #9 merged",
+											body: "The agent session has ended.",
+											status: "read",
+											createdAt: "2026-07-19T09:00:00Z",
+											target: { kind: "session", sessionId: "sess-dead" },
+										},
+									],
+									unreadCount: 0,
+									unresolvedCount: 0,
+								},
+							],
+						},
+					}
+				: notificationQueryResult(status),
+		);
+		renderNotificationCenter();
+		await clickOpen();
+
+		expect(screen.queryByRole("button", { name: "Restore session" })).not.toBeInTheDocument();
+
+		await userEvent.click(screen.getByText("The agent session has ended."));
+		expect(restoreSessionMock).not.toHaveBeenCalled();
 		expect(navigateMock).toHaveBeenCalledWith({
 			to: "/projects/$projectId/sessions/$sessionId",
 			params: { projectId: "proj-1", sessionId: "sess-dead" },

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -360,6 +360,12 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 						{notifications.map((notification) => {
 							const sessionId = notification.target.sessionId || notification.sessionId;
 							const terminated = Boolean(sessionId) && terminatedIds.has(sessionId);
+							// Restoring only makes sense when an agent is actually paused waiting
+							// on input. PR outcomes (ready_to_merge, pr_merged, pr_closed_unmerged)
+							// describe work that already finished — there is nothing to resume, so
+							// a terminated session behind one of these should stay viewable, not
+							// gated behind a restore action.
+							const offerRestore = terminated && notification.type === "needs_input";
 							return (
 								<NotificationItem
 									highlighted={highlightedIds.has(notification.id) || notification.status === "unread"}
@@ -372,6 +378,7 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 									restoreDisabled={restoringSessionId !== undefined}
 									sessionsReady={sessionsReady}
 									terminated={terminated}
+									offerRestore={offerRestore}
 								/>
 							);
 						})}
@@ -419,14 +426,18 @@ function NotificationEmpty({ icon: Icon, message }: { icon: typeof Bell; message
 }
 
 /**
- * The whole row is the click target for live sessions. Terminated sessions are
- * not navigable — restore is the only session action. PR titles stay a real
+ * The whole row is the click target for live sessions. A terminated session
+ * behind a `needs_input` notification is not navigable — restore is the only
+ * action, since there is a paused agent to resume. PR-outcome notifications
+ * (`offerRestore` false) describe finished work, so a terminated session stays
+ * viewable there instead of being gated behind restore. PR titles stay a real
  * link so a PR row can open the PR without a separate icon button.
  */
 function NotificationItem({
 	highlighted,
 	meta,
 	notification,
+	offerRestore,
 	onOpenSession,
 	onRestore,
 	restoring,
@@ -437,6 +448,7 @@ function NotificationItem({
 	highlighted: boolean;
 	meta?: { projectName: string; sessionName: string };
 	notification: NotificationDTO;
+	offerRestore: boolean;
 	onOpenSession: (notification: NotificationDTO) => void;
 	onRestore: () => void;
 	restoring: boolean;
@@ -447,7 +459,7 @@ function NotificationItem({
 	const { t } = useTranslation();
 	const Icon = notificationIcon(notification.type);
 	const sessionId = notification.target.sessionId || notification.sessionId;
-	const canOpenSession = Boolean(sessionId) && sessionsReady && !terminated;
+	const canOpenSession = Boolean(sessionId) && sessionsReady && (!terminated || !offerRestore);
 	const copy = notificationCopy(notification, meta?.sessionName);
 	const titleLink = notificationPRTitleLink(notification, copy.title);
 	const showSessionMeta = Boolean(meta?.sessionName) && !notificationMentions(copy, meta?.sessionName ?? "");
@@ -540,7 +552,7 @@ function NotificationItem({
 					<time className="shrink-0 font-mono text-[9px] leading-none text-passive" dateTime={notification.createdAt}>
 						{formatTimeCompact(notification.createdAt)}
 					</time>
-					{terminated && sessionId ? (
+					{offerRestore && sessionId ? (
 						<Tooltip delayDuration={0}>
 							<TooltipTrigger asChild>
 								<button


### PR DESCRIPTION
## Summary
- `ready_to_merge`, `pr_merged`, and `pr_closed_unmerged` notifications describe work that already finished, so a terminated session behind one of them has nothing to resume. These types no longer show the restore action and their row navigates directly to the (terminated) session instead of being blocked.
- Only `needs_input` notifications keep the restore-first behavior, since there's an actual paused agent to resume there.

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npx vitest run src/renderer/components/NotificationCenter.test.tsx` (26/26 pass, includes a new test for the PR-outcome no-restore path)
- [x] `cd frontend && npm run test` (full suite: 1541/1546 pass; the 5 failures are in `generate-markdown-twins.test.mjs`, a pre-existing environment issue — missing `cheerio` in `node_modules` — reproduced identically on `main` before this change)