### PR TITLE
fix(terminal): log shell-terminal open failures instead of failing si…

### DIFF
--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -100,6 +100,11 @@ export function useOpenShellTerminal() {
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
 		},
+		// Without this, a failed open (worktree gone, no shell resolvable, daemon
+		// busy) leaves the "+" button looking like it silently did nothing.
+		onError: (error) => {
+			console.error("Failed to open shell terminal:", error);
+		},
 	});
 }
 


### PR DESCRIPTION
…lently

Clicking the tab strip's + button gives no feedback if opening the shell fails (worktree gone, no shell resolvable, daemon busy) - the mutation had no onError handler, so a real failure looked identical to nothing having happened. Logging the error at least surfaces the cause in DevTools.

## What

Brief description of the change.

## Why

Problem this solves / issue it closes (e.g. `Fixes #123`).

## How

Key implementation decisions, trade-offs, or areas reviewers should focus on.
Call out intentional omissions (especially vs older TypeScript behavior) when relevant.

## Testing

How you validated this locally (commands, scenarios, screenshots if UI).

## Checklist

- [ ] Branched from `main` (or continuing an existing PR branch)
- [ ] One focused change; links the related issue when applicable
- [ ] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [ ] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
