### PR TITLE
feat(harness): add Muse Code agent support

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -31,6 +31,7 @@ var Derivers = map[string]DeriveFunc{
 	// deriver; the rest share the name-only StandardDeriveActivityState.
 	"claude-code": claudecode.DeriveActivityState,
 	"grok":        claudecode.DeriveActivityState,
+	"muse":        claudecode.DeriveActivityState,
 	"codex":       codex.DeriveActivityState,
 	"droid":       droid.DeriveActivityState,
 	"agy":         agy.DeriveActivityState,

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -22,7 +22,7 @@ func TestDeriverTokensAreKnownHarnesses(t *testing.T) {
 }
 
 func TestSupportsHarness(t *testing.T) {
-	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessOpenCode, domain.HarnessKimi, domain.HarnessVibe} {
+	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessMuse, domain.HarnessOpenCode, domain.HarnessKimi, domain.HarnessVibe} {
 		if !SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = false, want true", h)
 		}
@@ -33,6 +33,30 @@ func TestSupportsHarness(t *testing.T) {
 		if SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = true, want false", h)
 		}
+	}
+}
+
+func TestMuseDerivesManagedHookActivity(t *testing.T) {
+	tests := []struct {
+		event string
+		want  domain.ActivityState
+	}{
+		{"user-prompt-submit", domain.ActivityActive},
+		{"pre-tool-use", domain.ActivityActive},
+		{"permission-request", domain.ActivityBlocked},
+		{"post-tool-use", domain.ActivityActive},
+		{"stop", domain.ActivityIdle},
+	}
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			got, ok := Derive("muse", tt.event, []byte(`{}`))
+			if !ok || got != tt.want {
+				t.Fatalf("Derive(muse, %q) = (%q, %v), want (%q, true)", tt.event, got, ok, tt.want)
+			}
+		})
+	}
+	if got, ok := Derive("muse", "session-start", []byte(`{}`)); ok {
+		t.Fatalf("Derive(muse, session-start) = (%q, true), want metadata-only", got)
 	}
 }
 

--- a/backend/internal/adapters/agent/muse/auth.go
+++ b/backend/internal/adapters/agent/muse/auth.go
@@ -2,6 +2,7 @@ package muse
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,9 +12,9 @@ import (
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
-// AuthStatus reports whether Muse can see a configured provider credential.
-// Muse also supports unauthenticated local Ollama endpoints, so an absent key is
-// unknown rather than unauthorized.
+// AuthStatus reports whether the official Meta provider has a local API key or
+// OAuth login. Credential values are only tested for non-emptiness and are
+// never returned or logged.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
 	if _, err := p.ResolveBinary(ctx); err != nil {
 		return ports.AgentAuthStatusUnknown, err
@@ -24,61 +25,40 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	return ports.AgentAuthStatusUnknown, nil
 }
 
-// These are Muse's built-in provider variables plus the variables its model
-// picker documents for supported OpenAI-compatible providers.
-var museAPIKeyEnvVars = []string{
-	"OPENAI_API_KEY",
-	"GEMINI_API_KEY",
-	"GOOGLE_API_KEY",
-	"ANTHROPIC_API_KEY",
-	"CEREBRAS_API_KEY",
-	"SYN_API_KEY",
-	"AZURE_OPENAI_API_KEY",
-	"OPENROUTER_API_KEY",
-	"ZAI_API_KEY",
-	"ARK_API_KEY",
-	"GROQ_API_KEY",
-	"MISTRAL_API_KEY",
-	"COHERE_API_KEY",
-	"DEEPSEEK_API_KEY",
-	"TOGETHER_API_KEY",
-	"FIREWORKS_API_KEY",
-	"XAI_API_KEY",
-	"PERPLEXITY_API_KEY",
-	"HUGGINGFACE_API_KEY",
-}
+const museAPIKeyEnvVar = "META_API_KEY"
 
 func museLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	for _, name := range museAPIKeyEnvVars {
-		if strings.TrimSpace(os.Getenv(name)) != "" {
-			return ports.AgentAuthStatusAuthorized, true, nil
-		}
+	if strings.TrimSpace(os.Getenv(museAPIKeyEnvVar)) != "" {
+		return ports.AgentAuthStatusAuthorized, true, nil
 	}
 
-	path, ok := museConfigPath()
+	path, ok := museAuthPath()
 	if !ok {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	return museConfigAuthStatus(path)
+	return museAuthJSONStatus(path)
 }
 
-// museConfigPath mirrors Muse's path selection: an explicitly configured XDG
-// config root wins, otherwise all state defaults to ~/.muse.
-func museConfigPath() (string, bool) {
+// museAuthPath mirrors the official launcher: MUSE_AUTH_PATH wins, then the
+// XDG config root, then ~/.config/muse/auth.json.
+func museAuthPath() (string, bool) {
+	if path := strings.TrimSpace(os.Getenv("MUSE_AUTH_PATH")); path != "" {
+		return path, true
+	}
 	if root := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); root != "" {
-		return filepath.Join(root, "muse", "muse.cfg"), true
+		return filepath.Join(root, "muse", "auth.json"), true
 	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return "", false
 	}
-	return filepath.Join(home, ".muse", "muse.cfg"), true
+	return filepath.Join(home, ".config", "muse", "auth.json"), true
 }
 
-func museConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
+func museAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // user-selected Muse config path
 	if os.IsNotExist(err) {
 		return ports.AgentAuthStatusUnknown, false, nil
@@ -87,26 +67,33 @@ func museConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 
-	knownKeys := make(map[string]struct{}, len(museAPIKeyEnvVars))
-	for _, name := range museAPIKeyEnvVars {
-		knownKeys[name] = struct{}{}
+	if strings.TrimSpace(string(data)) == "" {
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
-			continue
-		}
-		key, value, found := strings.Cut(line, "=")
-		if !found {
-			continue
-		}
-		if _, ok := knownKeys[strings.ToUpper(strings.TrimSpace(key))]; !ok {
-			continue
-		}
-		value = strings.Trim(strings.TrimSpace(strings.SplitN(value, "#", 2)[0]), `"'`)
-		if value != "" {
+	var auth struct {
+		Providers struct {
+			Meta struct {
+				Mechanism   string `json:"mechanism"`
+				AccessToken string `json:"access_token"`
+				APIKey      string `json:"api_key"`
+			} `json:"meta"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal(data, &auth); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	meta := auth.Providers.Meta
+	switch strings.ToLower(strings.TrimSpace(meta.Mechanism)) {
+	case "oauth":
+		if strings.TrimSpace(meta.AccessToken) != "" {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
+		return ports.AgentAuthStatusUnauthorized, true, nil
+	case "api_key", "api-key", "apikey":
+		if strings.TrimSpace(meta.APIKey) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+		return ports.AgentAuthStatusUnauthorized, true, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/muse/auth.go
+++ b/backend/internal/adapters/agent/muse/auth.go
@@ -25,7 +25,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	return ports.AgentAuthStatusUnknown, nil
 }
 
-const museAPIKeyEnvVar = "META_API_KEY"
+const museAPIKeyEnvVar = "META_API_KEY" //nolint:gosec // environment variable name, not a credential
 
 func museLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
 	if err := ctx.Err(); err != nil {

--- a/backend/internal/adapters/agent/muse/auth.go
+++ b/backend/internal/adapters/agent/muse/auth.go
@@ -1,0 +1,112 @@
+package muse
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+var _ ports.AgentAuthChecker = (*Plugin)(nil)
+
+// AuthStatus reports whether Muse can see a configured provider credential.
+// Muse also supports unauthenticated local Ollama endpoints, so an absent key is
+// unknown rather than unauthorized.
+func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
+	if _, err := p.ResolveBinary(ctx); err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	}
+	if status, ok, err := museLocalAuthStatus(ctx); err != nil || ok {
+		return status, err
+	}
+	return ports.AgentAuthStatusUnknown, nil
+}
+
+// These are Muse's built-in provider variables plus the variables its model
+// picker documents for supported OpenAI-compatible providers.
+var museAPIKeyEnvVars = []string{
+	"OPENAI_API_KEY",
+	"GEMINI_API_KEY",
+	"GOOGLE_API_KEY",
+	"ANTHROPIC_API_KEY",
+	"CEREBRAS_API_KEY",
+	"SYN_API_KEY",
+	"AZURE_OPENAI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"ZAI_API_KEY",
+	"ARK_API_KEY",
+	"GROQ_API_KEY",
+	"MISTRAL_API_KEY",
+	"COHERE_API_KEY",
+	"DEEPSEEK_API_KEY",
+	"TOGETHER_API_KEY",
+	"FIREWORKS_API_KEY",
+	"XAI_API_KEY",
+	"PERPLEXITY_API_KEY",
+	"HUGGINGFACE_API_KEY",
+}
+
+func museLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	for _, name := range museAPIKeyEnvVars {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+	}
+
+	path, ok := museConfigPath()
+	if !ok {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	return museConfigAuthStatus(path)
+}
+
+// museConfigPath mirrors Muse's path selection: an explicitly configured XDG
+// config root wins, otherwise all state defaults to ~/.muse.
+func museConfigPath() (string, bool) {
+	if root := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); root != "" {
+		return filepath.Join(root, "muse", "muse.cfg"), true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", false
+	}
+	return filepath.Join(home, ".muse", "muse.cfg"), true
+}
+
+func museConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // user-selected Muse config path
+	if os.IsNotExist(err) {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+
+	knownKeys := make(map[string]struct{}, len(museAPIKeyEnvVars))
+	for _, name := range museAPIKeyEnvVars {
+		knownKeys[name] = struct{}{}
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		if _, ok := knownKeys[strings.ToUpper(strings.TrimSpace(key))]; !ok {
+			continue
+		}
+		value = strings.Trim(strings.TrimSpace(strings.SplitN(value, "#", 2)[0]), `"'`)
+		if value != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
+}

--- a/backend/internal/adapters/agent/muse/auth_test.go
+++ b/backend/internal/adapters/agent/muse/auth_test.go
@@ -1,0 +1,112 @@
+package muse
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestMuseLocalAuthStatusAuthorizedWithProviderEnv(t *testing.T) {
+	clearMuseAuthEnv(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	status, ok, err := museLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestMuseLocalAuthStatusUsesXDGConfig(t *testing.T) {
+	clearMuseAuthEnv(t)
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	dir := filepath.Join(root, "muse")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "muse.cfg"), []byte("[muse]\nopenai_api_key = sk-config\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := museLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestMuseConfigAuthStatusFindsAnyConfiguredProvider(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "muse.cfg")
+	if err := os.WriteFile(path, []byte("[muse]\nopenai_api_key = \nanthropic_api_key = 'configured' # comment\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, ok, err := museConfigAuthStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestMuseConfigAuthStatusUnknownWithoutCredential(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "muse.cfg")
+	if err := os.WriteFile(path, []byte("[muse]\nagent_name = muse\nowner_name = user\nopenai_api_key = \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, ok, err := museConfigAuthStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestMuseLocalAuthStatusUnknownWhenMissing(t *testing.T) {
+	clearMuseAuthEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	status, ok, err := museLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestAuthStatusUsesLocalCredentialProbe(t *testing.T) {
+	clearMuseAuthEnv(t)
+	t.Setenv("OPENROUTER_API_KEY", "configured")
+	status, err := (&Plugin{resolvedBinary: "muse"}).AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestMuseLocalAuthStatusHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	status, ok, err := museLocalAuthStatus(ctx)
+	if !errors.Is(err, context.Canceled) || ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v, %v), want (unknown, false, context.Canceled)", status, ok, err)
+	}
+}
+
+func clearMuseAuthEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range museAPIKeyEnvVars {
+		t.Setenv(name, "")
+	}
+}

--- a/backend/internal/adapters/agent/muse/auth_test.go
+++ b/backend/internal/adapters/agent/muse/auth_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestMuseLocalAuthStatusAuthorizedWithProviderEnv(t *testing.T) {
+func TestMuseLocalAuthStatusAuthorizedWithMetaAPIKey(t *testing.T) {
 	clearMuseAuthEnv(t)
-	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv(museAPIKeyEnvVar, "test-api-key")
 	status, ok, err := museLocalAuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -22,17 +22,12 @@ func TestMuseLocalAuthStatusAuthorizedWithProviderEnv(t *testing.T) {
 	}
 }
 
-func TestMuseLocalAuthStatusUsesXDGConfig(t *testing.T) {
+func TestMuseLocalAuthStatusUsesXDGMetaOAuth(t *testing.T) {
 	clearMuseAuthEnv(t)
 	root := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", root)
-	dir := filepath.Join(root, "muse")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "muse.cfg"), []byte("[muse]\nopenai_api_key = sk-config\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	path := filepath.Join(root, "muse", "auth.json")
+	writeMuseAuthFixture(t, path, `{"schema_version":1,"providers":{"meta":{"mechanism":"oauth","access_token":"fixture-access-token"}}}`)
 
 	status, ok, err := museLocalAuthStatus(context.Background())
 	if err != nil {
@@ -43,31 +38,58 @@ func TestMuseLocalAuthStatusUsesXDGConfig(t *testing.T) {
 	}
 }
 
-func TestMuseConfigAuthStatusFindsAnyConfiguredProvider(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "muse.cfg")
-	if err := os.WriteFile(path, []byte("[muse]\nopenai_api_key = \nanthropic_api_key = 'configured' # comment\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	status, ok, err := museConfigAuthStatus(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+func TestMuseLocalAuthStatusHonorsExplicitAuthPath(t *testing.T) {
+	clearMuseAuthEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	t.Setenv("MUSE_AUTH_PATH", path)
+	writeMuseAuthFixture(t, path, `{"providers":{"meta":{"mechanism":"oauth","access_token":"fixture-access-token"}}}`)
+
+	status, ok, err := museLocalAuthStatus(context.Background())
+	if err != nil || !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v, %v), want (authorized, true, nil)", status, ok, err)
 	}
 }
 
-func TestMuseConfigAuthStatusUnknownWithoutCredential(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "muse.cfg")
-	if err := os.WriteFile(path, []byte("[muse]\nagent_name = muse\nowner_name = user\nopenai_api_key = \n"), 0o600); err != nil {
+func TestMuseAuthJSONStatusOAuthRequiresAccessToken(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	writeMuseAuthFixture(t, path, `{"providers":{"meta":{"mechanism":"oauth","access_token":""}}}`)
+	status, ok, err := museAuthJSONStatus(path)
+	if err != nil {
 		t.Fatal(err)
 	}
-	status, ok, err := museConfigAuthStatus(path)
+	if !ok || status != ports.AgentAuthStatusUnauthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	}
+}
+
+func TestMuseAuthJSONStatusSupportsStoredMetaAPIKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	writeMuseAuthFixture(t, path, `{"providers":{"meta":{"mechanism":"api_key","api_key":"fixture-api-key"}}}`)
+	status, ok, err := museAuthJSONStatus(path)
+	if err != nil || !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v, %v), want (authorized, true, nil)", status, ok, err)
+	}
+}
+
+func TestMuseAuthJSONStatusUnknownWithoutMetaCredential(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	writeMuseAuthFixture(t, path, `{"schema_version":1,"providers":{}}`)
+	status, ok, err := museAuthJSONStatus(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ok || status != ports.AgentAuthStatusUnknown {
 		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestMuseAuthJSONStatusRejectsMalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	writeMuseAuthFixture(t, path, `{not-json`)
+	status, ok, err := museAuthJSONStatus(path)
+	if err == nil || ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v, %v), want (unknown, false, error)", status, ok, err)
 	}
 }
 
@@ -85,7 +107,7 @@ func TestMuseLocalAuthStatusUnknownWhenMissing(t *testing.T) {
 
 func TestAuthStatusUsesLocalCredentialProbe(t *testing.T) {
 	clearMuseAuthEnv(t)
-	t.Setenv("OPENROUTER_API_KEY", "configured")
+	t.Setenv(museAPIKeyEnvVar, "configured")
 	status, err := (&Plugin{resolvedBinary: "muse"}).AuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -104,9 +126,19 @@ func TestMuseLocalAuthStatusHonorsCancellation(t *testing.T) {
 	}
 }
 
+func writeMuseAuthFixture(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func clearMuseAuthEnv(t *testing.T) {
 	t.Helper()
-	for _, name := range museAPIKeyEnvVars {
-		t.Setenv(name, "")
-	}
+	t.Setenv(museAPIKeyEnvVar, "")
+	t.Setenv("MUSE_AUTH_PATH", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
 }

--- a/backend/internal/adapters/agent/muse/hooks.go
+++ b/backend/internal/adapters/agent/muse/hooks.go
@@ -2,54 +2,25 @@ package muse
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-const (
-	museInstructionsFileName = "AGENTS.md"
-	museInstructionsSentinel = "<!-- managed by agent-orchestrator: muse system prompt -->"
-	museInstructionsEnd      = "<!-- /managed by agent-orchestrator: muse system prompt -->"
-)
-
-// GetAgentHooks installs AO's standing prompt through Muse's documented
-// workspace-root AGENTS.md. Muse's external hook support does not currently
-// emit every lifecycle event AO needs, so this adapter intentionally installs
-// instructions only and relies on AO's generic process supervision.
-func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if strings.TrimSpace(cfg.WorkspacePath) == "" {
-		return errors.New("muse.GetAgentHooks: WorkspacePath is required")
-	}
-	systemPrompt, err := museSystemPromptText(cfg.SystemPrompt, cfg.SystemPromptFile)
-	if err != nil {
-		return fmt.Errorf("muse.GetAgentHooks: %w", err)
-	}
-	if systemPrompt == "" {
-		return nil
-	}
-
-	path := museInstructionsPath(cfg.WorkspacePath)
-	existing, err := os.ReadFile(path) //nolint:gosec // path is inside the session workspace
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("muse.GetAgentHooks: read %s: %w", path, err)
-	}
-	if err := hookutil.AtomicWriteFile(path, []byte(mergeMuseInstructionFile(string(existing), systemPrompt)), 0o600); err != nil {
-		return fmt.Errorf("muse.GetAgentHooks: write %s: %w", path, err)
-	}
-	return nil
+// GetAgentHooks deliberately does not install workspace files. Muse receives
+// AO's standing prompt from the process-local environment assembled by
+// GetLaunchCommand, leaving tracked and untracked project state untouched.
+func (p *Plugin) GetAgentHooks(ctx context.Context, _ ports.WorkspaceHookConfig) error {
+	return ctx.Err()
 }
 
-func museInstructionsPath(workspacePath string) string {
-	return filepath.Join(workspacePath, museInstructionsFileName)
+// CleanupWorkspace is intentionally a no-op because prompt injection is
+// process-local. Keeping the lifecycle hook explicit makes launch rollback and
+// teardown safe even when the workspace has an existing AGENTS.md.
+func (p *Plugin) CleanupWorkspace(ctx context.Context, _ ports.WorkspaceHookConfig) error {
+	return ctx.Err()
 }
 
 func museSystemPromptText(inline, file string) (string, error) {
@@ -64,43 +35,4 @@ func museSystemPromptText(inline, file string) (string, error) {
 		return "", fmt.Errorf("read system prompt file: %w", err)
 	}
 	return strings.TrimRight(string(data), "\n"), nil
-}
-
-func museInstructionFile(systemPrompt string) string {
-	return museInstructionsSentinel + "\n\n" +
-		"# Agent Orchestrator Session Instructions\n\n" +
-		strings.TrimRight(systemPrompt, "\n") + "\n\n" +
-		museInstructionsEnd + "\n"
-}
-
-func mergeMuseInstructionFile(existing, systemPrompt string) string {
-	block := museInstructionFile(systemPrompt)
-	start := strings.Index(existing, museInstructionsSentinel)
-	if start < 0 {
-		return joinMuseInstructionParts(existing, block, "")
-	}
-
-	afterStart := existing[start+len(museInstructionsSentinel):]
-	endRel := strings.Index(afterStart, museInstructionsEnd)
-	if endRel < 0 {
-		return joinMuseInstructionParts(existing[:start], block, "")
-	}
-	end := start + len(museInstructionsSentinel) + endRel + len(museInstructionsEnd)
-	return joinMuseInstructionParts(existing[:start], block, existing[end:])
-}
-
-func joinMuseInstructionParts(prefix, block, suffix string) string {
-	var b strings.Builder
-	prefix = strings.TrimRight(prefix, "\n")
-	if prefix != "" {
-		b.WriteString(prefix)
-		b.WriteString("\n\n")
-	}
-	b.WriteString(block)
-	suffix = strings.TrimLeft(suffix, "\n")
-	if suffix != "" {
-		b.WriteString("\n")
-		b.WriteString(suffix)
-	}
-	return b.String()
 }

--- a/backend/internal/adapters/agent/muse/hooks.go
+++ b/backend/internal/adapters/agent/muse/hooks.go
@@ -1,0 +1,113 @@
+package muse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	museInstructionsDirName  = ".muse"
+	museInstructionsFileName = "AGENTS.md"
+	museInstructionsSentinel = "<!-- managed by agent-orchestrator: muse system prompt -->"
+	museInstructionsEnd      = "<!-- /managed by agent-orchestrator: muse system prompt -->"
+)
+
+// GetAgentHooks installs AO's standing prompt through Muse's documented
+// project instruction file. Muse's external hook support does not currently
+// emit every lifecycle event AO needs, so this adapter intentionally installs
+// instructions only and relies on AO's generic process supervision.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WorkspacePath) == "" {
+		return errors.New("muse.GetAgentHooks: WorkspacePath is required")
+	}
+	systemPrompt, err := museSystemPromptText(cfg.SystemPrompt, cfg.SystemPromptFile)
+	if err != nil {
+		return fmt.Errorf("muse.GetAgentHooks: %w", err)
+	}
+	if systemPrompt == "" {
+		return nil
+	}
+
+	path := museInstructionsPath(cfg.WorkspacePath)
+	existing, err := os.ReadFile(path) //nolint:gosec // path is inside the session workspace
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("muse.GetAgentHooks: read %s: %w", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("muse.GetAgentHooks: create instruction dir: %w", err)
+	}
+	if err := hookutil.AtomicWriteFile(path, []byte(mergeMuseInstructionFile(string(existing), systemPrompt)), 0o600); err != nil {
+		return fmt.Errorf("muse.GetAgentHooks: write %s: %w", path, err)
+	}
+	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(path), museInstructionsFileName); err != nil {
+		return fmt.Errorf("muse.GetAgentHooks: gitignore: %w", err)
+	}
+	return nil
+}
+
+func museInstructionsPath(workspacePath string) string {
+	return filepath.Join(workspacePath, museInstructionsDirName, museInstructionsFileName)
+}
+
+func museSystemPromptText(inline, file string) (string, error) {
+	if strings.TrimSpace(inline) != "" {
+		return strings.TrimRight(inline, "\n"), nil
+	}
+	if strings.TrimSpace(file) == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(file) //nolint:gosec // path is AO-owned launch config
+	if err != nil {
+		return "", fmt.Errorf("read system prompt file: %w", err)
+	}
+	return strings.TrimRight(string(data), "\n"), nil
+}
+
+func museInstructionFile(systemPrompt string) string {
+	return museInstructionsSentinel + "\n\n" +
+		"# Agent Orchestrator Session Instructions\n\n" +
+		strings.TrimRight(systemPrompt, "\n") + "\n\n" +
+		museInstructionsEnd + "\n"
+}
+
+func mergeMuseInstructionFile(existing, systemPrompt string) string {
+	block := museInstructionFile(systemPrompt)
+	start := strings.Index(existing, museInstructionsSentinel)
+	if start < 0 {
+		return joinMuseInstructionParts(existing, block, "")
+	}
+
+	afterStart := existing[start+len(museInstructionsSentinel):]
+	endRel := strings.Index(afterStart, museInstructionsEnd)
+	if endRel < 0 {
+		return joinMuseInstructionParts(existing[:start], block, "")
+	}
+	end := start + len(museInstructionsSentinel) + endRel + len(museInstructionsEnd)
+	return joinMuseInstructionParts(existing[:start], block, existing[end:])
+}
+
+func joinMuseInstructionParts(prefix, block, suffix string) string {
+	var b strings.Builder
+	prefix = strings.TrimRight(prefix, "\n")
+	if prefix != "" {
+		b.WriteString(prefix)
+		b.WriteString("\n\n")
+	}
+	b.WriteString(block)
+	suffix = strings.TrimLeft(suffix, "\n")
+	if suffix != "" {
+		b.WriteString("\n")
+		b.WriteString(suffix)
+	}
+	return b.String()
+}

--- a/backend/internal/adapters/agent/muse/hooks.go
+++ b/backend/internal/adapters/agent/muse/hooks.go
@@ -13,14 +13,13 @@ import (
 )
 
 const (
-	museInstructionsDirName  = ".muse"
 	museInstructionsFileName = "AGENTS.md"
 	museInstructionsSentinel = "<!-- managed by agent-orchestrator: muse system prompt -->"
 	museInstructionsEnd      = "<!-- /managed by agent-orchestrator: muse system prompt -->"
 )
 
 // GetAgentHooks installs AO's standing prompt through Muse's documented
-// project instruction file. Muse's external hook support does not currently
+// workspace-root AGENTS.md. Muse's external hook support does not currently
 // emit every lifecycle event AO needs, so this adapter intentionally installs
 // instructions only and relies on AO's generic process supervision.
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
@@ -43,20 +42,14 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("muse.GetAgentHooks: read %s: %w", path, err)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return fmt.Errorf("muse.GetAgentHooks: create instruction dir: %w", err)
-	}
 	if err := hookutil.AtomicWriteFile(path, []byte(mergeMuseInstructionFile(string(existing), systemPrompt)), 0o600); err != nil {
 		return fmt.Errorf("muse.GetAgentHooks: write %s: %w", path, err)
-	}
-	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(path), museInstructionsFileName); err != nil {
-		return fmt.Errorf("muse.GetAgentHooks: gitignore: %w", err)
 	}
 	return nil
 }
 
 func museInstructionsPath(workspacePath string) string {
-	return filepath.Join(workspacePath, museInstructionsDirName, museInstructionsFileName)
+	return filepath.Join(workspacePath, museInstructionsFileName)
 }
 
 func museSystemPromptText(inline, file string) (string, error) {

--- a/backend/internal/adapters/agent/muse/hooks.go
+++ b/backend/internal/adapters/agent/muse/hooks.go
@@ -25,12 +25,14 @@ type museHooksFile struct {
 }
 
 func museManagedHooks(cfg ports.WorkspaceHookConfig) map[string][]hooksjson.MatcherGroup {
+	// Muse runs background subagents after the main turn has stopped. Their
+	// tool hooks share this managed configuration but do not emit a matching
+	// Stop, so installing PreToolUse/PostToolUse can incorrectly reactivate an
+	// otherwise idle AO session. Track the top-level turn lifecycle instead.
 	return map[string][]hooksjson.MatcherGroup{
 		"SessionStart":      {museHookGroup(cfg, "session-start")},
 		"UserPromptSubmit":  {museHookGroup(cfg, "user-prompt-submit")},
-		"PreToolUse":        {museHookGroup(cfg, "pre-tool-use")},
 		"PermissionRequest": {museHookGroup(cfg, "permission-request")},
-		"PostToolUse":       {museHookGroup(cfg, "post-tool-use")},
 		"Stop":              {museHookGroup(cfg, "stop")},
 	}
 }

--- a/backend/internal/adapters/agent/muse/hooks.go
+++ b/backend/internal/adapters/agent/muse/hooks.go
@@ -2,25 +2,97 @@ package muse
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hooksjson"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-// GetAgentHooks deliberately does not install workspace files. Muse receives
-// AO's standing prompt from the process-local environment assembled by
-// GetLaunchCommand, leaving tracked and untracked project state untouched.
-func (p *Plugin) GetAgentHooks(ctx context.Context, _ ports.WorkspaceHookConfig) error {
-	return ctx.Err()
+const (
+	museManagedHooksEnvVar = "TBH_MANAGED_HOOKS_PATH"
+	museHookCommandPrefix  = "ao hooks muse "
+)
+
+var museManagedHooks = map[string][]hooksjson.MatcherGroup{
+	"SessionStart":      {museHookGroup("session-start")},
+	"UserPromptSubmit":  {museHookGroup("user-prompt-submit")},
+	"PreToolUse":        {museHookGroup("pre-tool-use")},
+	"PermissionRequest": {museHookGroup("permission-request")},
+	"PostToolUse":       {museHookGroup("post-tool-use")},
+	"Stop":              {museHookGroup("stop")},
 }
 
-// CleanupWorkspace is intentionally a no-op because prompt injection is
-// process-local. Keeping the lifecycle hook explicit makes launch rollback and
-// teardown safe even when the workspace has an existing AGENTS.md.
-func (p *Plugin) CleanupWorkspace(ctx context.Context, _ ports.WorkspaceHookConfig) error {
-	return ctx.Err()
+type museHooksFile struct {
+	Hooks map[string][]hooksjson.MatcherGroup `json:"hooks"`
+}
+
+func museHookGroup(event string) hooksjson.MatcherGroup {
+	return hooksjson.MatcherGroup{Hooks: []hooksjson.HookEntry{{
+		Type:    "command",
+		Command: museHookCommandPrefix + event,
+		Timeout: 5,
+	}}}
+}
+
+// GetAgentHooks writes Muse's managed-hook configuration under AO's data
+// directory. Muse receives its path through a process-local environment
+// variable, so this does not create or modify any file in the project.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path, err := museManagedHooksPath(cfg.DataDir, cfg.SessionID)
+	if err != nil {
+		return fmt.Errorf("muse.GetAgentHooks: %w", err)
+	}
+	data, err := json.MarshalIndent(museHooksFile{Hooks: museManagedHooks}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("muse.GetAgentHooks: marshal hooks: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("muse.GetAgentHooks: create hooks directory: %w", err)
+	}
+	if err := hookutil.AtomicWriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("muse.GetAgentHooks: write hooks: %w", err)
+	}
+	return nil
+}
+
+// CleanupWorkspace removes the AO-owned managed-hook file. The method name is
+// part of the shared agent lifecycle; Muse's project workspace stays untouched.
+func (p *Plugin) CleanupWorkspace(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path, err := museManagedHooksPath(cfg.DataDir, cfg.SessionID)
+	if err != nil {
+		return fmt.Errorf("muse.CleanupWorkspace: %w", err)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("muse.CleanupWorkspace: remove hooks: %w", err)
+	}
+	return nil
+}
+
+func museManagedHooksPath(dataDir, sessionID string) (string, error) {
+	dataDir = strings.TrimSpace(dataDir)
+	if dataDir == "" {
+		return "", errors.New("DataDir is required")
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return "", errors.New("SessionID is required")
+	}
+	if sessionID == "." || filepath.Base(sessionID) != sessionID {
+		return "", errors.New("SessionID must be a single path component")
+	}
+	return filepath.Join(dataDir, "agent-hooks", adapterID, sessionID+".json"), nil
 }
 
 func museSystemPromptText(inline, file string) (string, error) {

--- a/backend/internal/adapters/agent/muse/hooks.go
+++ b/backend/internal/adapters/agent/muse/hooks.go
@@ -17,27 +17,48 @@ import (
 const (
 	museManagedHooksEnvVar = "TBH_MANAGED_HOOKS_PATH"
 	museHookCommandPrefix  = "ao hooks muse "
+	aoRunFileEnvVar        = "AO_RUN_FILE"
 )
-
-var museManagedHooks = map[string][]hooksjson.MatcherGroup{
-	"SessionStart":      {museHookGroup("session-start")},
-	"UserPromptSubmit":  {museHookGroup("user-prompt-submit")},
-	"PreToolUse":        {museHookGroup("pre-tool-use")},
-	"PermissionRequest": {museHookGroup("permission-request")},
-	"PostToolUse":       {museHookGroup("post-tool-use")},
-	"Stop":              {museHookGroup("stop")},
-}
 
 type museHooksFile struct {
 	Hooks map[string][]hooksjson.MatcherGroup `json:"hooks"`
 }
 
-func museHookGroup(event string) hooksjson.MatcherGroup {
+func museManagedHooks(cfg ports.WorkspaceHookConfig) map[string][]hooksjson.MatcherGroup {
+	return map[string][]hooksjson.MatcherGroup{
+		"SessionStart":      {museHookGroup(cfg, "session-start")},
+		"UserPromptSubmit":  {museHookGroup(cfg, "user-prompt-submit")},
+		"PreToolUse":        {museHookGroup(cfg, "pre-tool-use")},
+		"PermissionRequest": {museHookGroup(cfg, "permission-request")},
+		"PostToolUse":       {museHookGroup(cfg, "post-tool-use")},
+		"Stop":              {museHookGroup(cfg, "stop")},
+	}
+}
+
+func museHookGroup(cfg ports.WorkspaceHookConfig, event string) hooksjson.MatcherGroup {
 	return hooksjson.MatcherGroup{Hooks: []hooksjson.HookEntry{{
 		Type:    "command",
-		Command: museHookCommandPrefix + event,
+		Command: museHookCommand(cfg, event),
 		Timeout: 5,
 	}}}
+}
+
+// Muse sanitizes AO_* variables from hook subprocesses. Put the non-sensitive
+// callback route directly in AO's per-session hook command so the callback can
+// identify its AO session and, in dev mode, the exact daemon that launched it.
+func museHookCommand(cfg ports.WorkspaceHookConfig, event string) string {
+	assignments := []string{
+		"AO_SESSION_ID=" + museShellQuote(strings.TrimSpace(cfg.SessionID)),
+		"AO_DATA_DIR=" + museShellQuote(strings.TrimSpace(cfg.DataDir)),
+	}
+	if runFile := strings.TrimSpace(os.Getenv(aoRunFileEnvVar)); runFile != "" {
+		assignments = append(assignments, aoRunFileEnvVar+"="+museShellQuote(runFile))
+	}
+	return "env " + strings.Join(assignments, " ") + " " + museHookCommandPrefix + event
+}
+
+func museShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 // GetAgentHooks writes Muse's managed-hook configuration under AO's data
@@ -51,7 +72,7 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err != nil {
 		return fmt.Errorf("muse.GetAgentHooks: %w", err)
 	}
-	data, err := json.MarshalIndent(museHooksFile{Hooks: museManagedHooks}, "", "  ")
+	data, err := json.MarshalIndent(museHooksFile{Hooks: museManagedHooks(cfg)}, "", "  ")
 	if err != nil {
 		return fmt.Errorf("muse.GetAgentHooks: marshal hooks: %w", err)
 	}

--- a/backend/internal/adapters/agent/muse/install.go
+++ b/backend/internal/adapters/agent/muse/install.go
@@ -1,0 +1,8 @@
+package muse
+
+import "context"
+
+// ResolveBinary resolves the executable path for the plugin.
+func (p *Plugin) ResolveBinary(ctx context.Context) (string, error) {
+	return p.museBinary(ctx)
+}

--- a/backend/internal/adapters/agent/muse/muse.go
+++ b/backend/internal/adapters/agent/muse/muse.go
@@ -1,0 +1,120 @@
+// Package muse implements the Muse Code CLI agent adapter.
+//
+// Muse is distributed as the Python package "code-muse" and installs the
+// executable "muse". AO launches `muse --interactive` and supplies an initial
+// task as a positional command after `--`. Muse's `-p/--prompt` mode is not
+// used because it executes one prompt and exits instead of keeping the
+// interactive prompt-toolkit session attached to AO's terminal.
+//
+// Muse has no permission-mode launch flags; its approval behavior is configured
+// through yolo_mode in muse.cfg. It reads project instructions from
+// .muse/AGENTS.md, which GetAgentHooks uses for AO's standing instructions.
+package muse
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const adapterID = "muse"
+
+// Plugin is the Muse Code CLI agent adapter. It is safe for concurrent use;
+// the binary path is resolved once and cached under binaryMu.
+type Plugin struct {
+	agentbase.Base
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register Muse adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description.
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          adapterID,
+		Name:        "Muse Code",
+		Description: "Run Muse Code CLI worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports Muse's optional model override.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	return agentbase.ModelConfigSpec(ctx, "Model override passed to `muse --model`.")
+}
+
+// GetLaunchCommand builds the argv for a persistent interactive Muse session:
+//
+//	muse --interactive [--model <model>] [-- <prompt>]
+//
+// A prompt is positional, not passed through -p/--prompt, because that flag is
+// Muse's single-prompt mode and exits after the response. The `--` terminator
+// keeps prompts beginning with a dash from being parsed as Muse flags.
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) ([]string, error) {
+	binary, err := p.museBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := []string{binary, "--interactive"}
+	agentbase.AppendModelFlag(&cmd, cfg.Config, "--model")
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "--", cfg.Prompt)
+	}
+	return cmd, nil
+}
+
+var museBinarySpec = binaryutil.BinarySpec{
+	Label:    "muse",
+	Names:    []string{"muse"},
+	WinNames: []string{"muse.exe", "muse.cmd", "muse"},
+	UnixPaths: []string{
+		"/usr/local/bin/muse",
+		"/opt/homebrew/bin/muse",
+	},
+	UnixHomePaths: [][]string{
+		{".local", "bin", "muse"}, // uv tool, pipx, and common pip user installs
+		{".pyenv", "shims", "muse"},
+		{"Library", "Python", "3.14", "bin", "muse"},
+	},
+	WinPaths: []binaryutil.WinPath{
+		{Base: binaryutil.WinLocalAppData, Parts: []string{"Programs", "Python", "Python314", "Scripts", "muse.exe"}},
+		{Base: binaryutil.WinAppData, Parts: []string{"Python", "Python314", "Scripts", "muse.exe"}},
+		{Base: binaryutil.WinHome, Parts: []string{".local", "bin", "muse.exe"}},
+	},
+}
+
+// ResolveMuseBinary finds the `muse` executable installed by the code-muse
+// package, searching PATH and common UV/pip/Python user install locations.
+func ResolveMuseBinary(ctx context.Context) (string, error) {
+	return binaryutil.ResolveBinary(ctx, museBinarySpec)
+}
+
+func (p *Plugin) museBinary(ctx context.Context) (string, error) {
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+	binary, err := ResolveMuseBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}

--- a/backend/internal/adapters/agent/muse/muse.go
+++ b/backend/internal/adapters/agent/muse/muse.go
@@ -5,8 +5,8 @@
 // it opens the interactive TUI, and an optional positional prompt starts the
 // first turn without leaving that TUI.
 //
-// Muse reads trusted project instructions from the workspace-root AGENTS.md,
-// which GetAgentHooks uses for AO's standing instructions.
+// AO's standing instructions are passed through Muse's process-local system
+// prompt environment, so launching a session never modifies project files.
 package muse
 
 import (
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -24,6 +26,11 @@ import (
 )
 
 const adapterID = "muse"
+
+// Muse's own launcher forwards this process-local override to the runtime.
+// Unlike AGENTS.md, it applies only to this process and cannot dirty the
+// project. The installed Meta binary contract is covered by the launch tests.
+const museSystemPromptEnvVar = "TBH_EVAL_APPEND_SYSTEM_PROMPT"
 
 // Plugin is the Muse Code CLI agent adapter. It is safe for concurrent use;
 // the binary path is resolved once and cached under binaryMu.
@@ -61,7 +68,7 @@ func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 
 // GetLaunchCommand builds the argv for a persistent interactive Muse session:
 //
-//	muse --trust-workspace [--approval-mode never|--yolo] [--model <model>] [prompt]
+//	[env TBH_EVAL_APPEND_SYSTEM_PROMPT=<instructions>] muse --trust-workspace [--approval-mode never|--yolo] [--model <model>] [prompt]
 //
 // The prompt is the CLI's documented optional positional argument. `muse exec`
 // is deliberately not used because it is headless and exits after one turn.
@@ -70,8 +77,16 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	if err != nil {
 		return nil, err
 	}
+	systemPrompt, err := museSystemPromptText(cfg.SystemPrompt, cfg.SystemPromptFile)
+	if err != nil {
+		return nil, fmt.Errorf("muse.GetLaunchCommand: %w", err)
+	}
 
-	cmd := []string{binary, "--trust-workspace"}
+	cmd := make([]string, 0, 9)
+	if systemPrompt != "" {
+		cmd = append(cmd, "env", museSystemPromptEnvVar+"="+systemPrompt)
+	}
+	cmd = append(cmd, binary, "--trust-workspace")
 	appendApprovalFlags(&cmd, cfg.Permissions)
 	agentbase.AppendModelFlag(&cmd, cfg.Config, "--model")
 	if cfg.Prompt != "" {
@@ -106,20 +121,61 @@ var museBinarySpec = binaryutil.BinarySpec{
 // command name is shared by unrelated tools, so a version-signature check keeps
 // those shims from being reported as an installed AO harness.
 func ResolveMuseBinary(ctx context.Context) (string, error) {
-	binary, err := binaryutil.ResolveBinary(ctx, museBinarySpec)
+	return resolveMuseBinary(ctx, museBinarySpec)
+}
+
+func resolveMuseBinary(ctx context.Context, spec binaryutil.BinarySpec) (string, error) {
+	first, err := binaryutil.ResolveBinary(ctx, spec)
 	if err != nil {
 		return "", err
 	}
+
+	candidates := append([]string{first}, museCanonicalBinaryCandidates(spec)...)
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		if isOfficialMuseBinary(ctx, candidate) {
+			return candidate, nil
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("%s: %w", spec.Label, ports.ErrAgentBinaryNotFound)
+}
+
+func isOfficialMuseBinary(ctx context.Context, binary string) bool {
 	cmd := exec.CommandContext(ctx, binary, "--version")
 	cmd.Env = append(os.Environ(), "MUSE_NO_AUTO_UPDATE=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("muse: verify official Meta Muse Code CLI at %s: %w", binary, err)
+		return false
 	}
-	if !strings.HasPrefix(strings.TrimSpace(string(out)), "Muse Code ") {
-		return "", fmt.Errorf("muse: %s is not the official Meta Muse Code CLI: %w", binary, ports.ErrAgentBinaryNotFound)
+	return strings.HasPrefix(strings.TrimSpace(string(out)), "Muse Code ")
+}
+
+func museCanonicalBinaryCandidates(spec binaryutil.BinarySpec) []string {
+	if runtime.GOOS == "windows" {
+		return nil
 	}
-	return binary, nil
+	candidates := append([]string(nil), spec.UnixPaths...)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return candidates
+	}
+	for _, parts := range spec.UnixHomePaths {
+		candidates = append(candidates, filepath.Join(append([]string{home}, parts...)...))
+	}
+	return candidates
 }
 
 func (p *Plugin) museBinary(ctx context.Context) (string, error) {

--- a/backend/internal/adapters/agent/muse/muse.go
+++ b/backend/internal/adapters/agent/muse/muse.go
@@ -1,18 +1,20 @@
 // Package muse implements the Muse Code CLI agent adapter.
 //
-// Muse is distributed as the Python package "code-muse" and installs the
-// executable "muse". AO launches `muse --interactive` and supplies an initial
-// task as a positional command after `--`. Muse's `-p/--prompt` mode is not
-// used because it executes one prompt and exits instead of keeping the
-// interactive prompt-toolkit session attached to AO's terminal.
+// Muse Code is Meta's terminal coding agent, installed from
+// https://dev.meta.ai/install.sh as the executable "muse". With no subcommand
+// it opens the interactive TUI, and an optional positional prompt starts the
+// first turn without leaving that TUI.
 //
-// Muse has no permission-mode launch flags; its approval behavior is configured
-// through yolo_mode in muse.cfg. It reads project instructions from
-// .muse/AGENTS.md, which GetAgentHooks uses for AO's standing instructions.
+// Muse reads trusted project instructions from the workspace-root AGENTS.md,
+// which GetAgentHooks uses for AO's standing instructions.
 package muse
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 	"sync"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
@@ -59,23 +61,32 @@ func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 
 // GetLaunchCommand builds the argv for a persistent interactive Muse session:
 //
-//	muse --interactive [--model <model>] [-- <prompt>]
+//	muse --trust-workspace [--approval-mode never|--yolo] [--model <model>] [prompt]
 //
-// A prompt is positional, not passed through -p/--prompt, because that flag is
-// Muse's single-prompt mode and exits after the response. The `--` terminator
-// keeps prompts beginning with a dash from being parsed as Muse flags.
+// The prompt is the CLI's documented optional positional argument. `muse exec`
+// is deliberately not used because it is headless and exits after one turn.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) ([]string, error) {
 	binary, err := p.museBinary(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd := []string{binary, "--interactive"}
+	cmd := []string{binary, "--trust-workspace"}
+	appendApprovalFlags(&cmd, cfg.Permissions)
 	agentbase.AppendModelFlag(&cmd, cfg.Config, "--model")
 	if cfg.Prompt != "" {
-		cmd = append(cmd, "--", cfg.Prompt)
+		cmd = append(cmd, cfg.Prompt)
 	}
 	return cmd, nil
+}
+
+func appendApprovalFlags(cmd *[]string, mode ports.PermissionMode) {
+	switch mode {
+	case ports.PermissionModeAcceptEdits, ports.PermissionModeAuto:
+		*cmd = append(*cmd, "--approval-mode", "never")
+	case ports.PermissionModeBypassPermissions:
+		*cmd = append(*cmd, "--yolo")
+	}
 }
 
 var museBinarySpec = binaryutil.BinarySpec{
@@ -87,21 +98,28 @@ var museBinarySpec = binaryutil.BinarySpec{
 		"/opt/homebrew/bin/muse",
 	},
 	UnixHomePaths: [][]string{
-		{".local", "bin", "muse"}, // uv tool, pipx, and common pip user installs
-		{".pyenv", "shims", "muse"},
-		{"Library", "Python", "3.14", "bin", "muse"},
-	},
-	WinPaths: []binaryutil.WinPath{
-		{Base: binaryutil.WinLocalAppData, Parts: []string{"Programs", "Python", "Python314", "Scripts", "muse.exe"}},
-		{Base: binaryutil.WinAppData, Parts: []string{"Python", "Python314", "Scripts", "muse.exe"}},
-		{Base: binaryutil.WinHome, Parts: []string{".local", "bin", "muse.exe"}},
+		{".local", "bin", "muse"}, // official Meta installer default
 	},
 }
 
-// ResolveMuseBinary finds the `muse` executable installed by the code-muse
-// package, searching PATH and common UV/pip/Python user install locations.
+// ResolveMuseBinary finds the official Meta Muse Code launcher. The `muse`
+// command name is shared by unrelated tools, so a version-signature check keeps
+// those shims from being reported as an installed AO harness.
 func ResolveMuseBinary(ctx context.Context) (string, error) {
-	return binaryutil.ResolveBinary(ctx, museBinarySpec)
+	binary, err := binaryutil.ResolveBinary(ctx, museBinarySpec)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.CommandContext(ctx, binary, "--version")
+	cmd.Env = append(os.Environ(), "MUSE_NO_AUTO_UPDATE=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("muse: verify official Meta Muse Code CLI at %s: %w", binary, err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(string(out)), "Muse Code ") {
+		return "", fmt.Errorf("muse: %s is not the official Meta Muse Code CLI: %w", binary, ports.ErrAgentBinaryNotFound)
+	}
+	return binary, nil
 }
 
 func (p *Plugin) museBinary(ctx context.Context) (string, error) {

--- a/backend/internal/adapters/agent/muse/muse.go
+++ b/backend/internal/adapters/agent/muse/muse.go
@@ -28,8 +28,6 @@ import (
 
 const adapterID = "muse"
 
-const aoRunFileEnvVar = "AO_RUN_FILE"
-
 // Muse's own launcher forwards this process-local override to the runtime.
 // Unlike AGENTS.md, it applies only to this process and cannot dirty the
 // project. The installed Meta binary contract is covered by the launch tests.
@@ -96,13 +94,6 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 			return nil, fmt.Errorf("muse.GetLaunchCommand: %w", pathErr)
 		}
 		env = append(env, museManagedHooksEnvVar+"="+hooksPath)
-		// A dev Electron daemon can use real AO data while publishing its
-		// endpoint through a separate run file. Propagate that explicit route
-		// so Muse's hook subprocesses report to the daemon that launched the
-		// session, not another installed AO daemon sharing the same data.
-		if runFile := strings.TrimSpace(os.Getenv(aoRunFileEnvVar)); runFile != "" {
-			env = append(env, aoRunFileEnvVar+"="+runFile)
-		}
 	}
 	if len(env) > 0 {
 		cmd = append(cmd, "env")

--- a/backend/internal/adapters/agent/muse/muse.go
+++ b/backend/internal/adapters/agent/muse/muse.go
@@ -5,8 +5,9 @@
 // it opens the interactive TUI, and an optional positional prompt starts the
 // first turn without leaving that TUI.
 //
-// AO's standing instructions are passed through Muse's process-local system
-// prompt environment, so launching a session never modifies project files.
+// AO's standing instructions and activity hooks are passed through Muse's
+// process-local environment, so launching a session never modifies project
+// files.
 package muse
 
 import (
@@ -68,7 +69,7 @@ func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 
 // GetLaunchCommand builds the argv for a persistent interactive Muse session:
 //
-//	[env TBH_EVAL_APPEND_SYSTEM_PROMPT=<instructions>] muse --trust-workspace [--approval-mode never|--yolo] [--model <model>] [prompt]
+//	[env TBH_EVAL_APPEND_SYSTEM_PROMPT=<instructions> TBH_MANAGED_HOOKS_PATH=<path>] muse --trust-workspace [--approval-mode never|--yolo] [--model <model>] [prompt]
 //
 // The prompt is the CLI's documented optional positional argument. `muse exec`
 // is deliberately not used because it is headless and exits after one turn.
@@ -82,9 +83,21 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		return nil, fmt.Errorf("muse.GetLaunchCommand: %w", err)
 	}
 
-	cmd := make([]string, 0, 9)
+	cmd := make([]string, 0, 11)
+	env := make([]string, 0, 2)
 	if systemPrompt != "" {
-		cmd = append(cmd, "env", museSystemPromptEnvVar+"="+systemPrompt)
+		env = append(env, museSystemPromptEnvVar+"="+systemPrompt)
+	}
+	if cfg.DataDir != "" || cfg.SessionID != "" {
+		hooksPath, pathErr := museManagedHooksPath(cfg.DataDir, cfg.SessionID)
+		if pathErr != nil {
+			return nil, fmt.Errorf("muse.GetLaunchCommand: %w", pathErr)
+		}
+		env = append(env, museManagedHooksEnvVar+"="+hooksPath)
+	}
+	if len(env) > 0 {
+		cmd = append(cmd, "env")
+		cmd = append(cmd, env...)
 	}
 	cmd = append(cmd, binary, "--trust-workspace")
 	appendApprovalFlags(&cmd, cfg.Permissions)

--- a/backend/internal/adapters/agent/muse/muse.go
+++ b/backend/internal/adapters/agent/muse/muse.go
@@ -28,6 +28,8 @@ import (
 
 const adapterID = "muse"
 
+const aoRunFileEnvVar = "AO_RUN_FILE"
+
 // Muse's own launcher forwards this process-local override to the runtime.
 // Unlike AGENTS.md, it applies only to this process and cannot dirty the
 // project. The installed Meta binary contract is covered by the launch tests.
@@ -94,6 +96,13 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 			return nil, fmt.Errorf("muse.GetLaunchCommand: %w", pathErr)
 		}
 		env = append(env, museManagedHooksEnvVar+"="+hooksPath)
+		// A dev Electron daemon can use real AO data while publishing its
+		// endpoint through a separate run file. Propagate that explicit route
+		// so Muse's hook subprocesses report to the daemon that launched the
+		// session, not another installed AO daemon sharing the same data.
+		if runFile := strings.TrimSpace(os.Getenv(aoRunFileEnvVar)); runFile != "" {
+			env = append(env, aoRunFileEnvVar+"="+runFile)
+		}
 	}
 	if len(env) > 0 {
 		cmd = append(cmd, "env")

--- a/backend/internal/adapters/agent/muse/muse_test.go
+++ b/backend/internal/adapters/agent/muse/muse_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -102,6 +103,50 @@ func TestGetLaunchCommandAppendsModelBeforePrompt(t *testing.T) {
 	}
 }
 
+func TestGetLaunchCommandInjectsSystemPromptWithoutProjectFiles(t *testing.T) {
+	p := &Plugin{resolvedBinary: "muse"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPrompt: "follow AO rules\n",
+		Prompt:       "fix it",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"env", museSystemPromptEnvVar + "=follow AO rules",
+		"muse", "--trust-workspace", "fix it",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandReadsSystemPromptFile(t *testing.T) {
+	promptFile := filepath.Join(t.TempDir(), "system.md")
+	if err := os.WriteFile(promptFile, []byte("file rules\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := &Plugin{resolvedBinary: "muse"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{SystemPromptFile: promptFile})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"env", museSystemPromptEnvVar + "=file rules", "muse", "--trust-workspace"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandMissingSystemPromptFileErrors(t *testing.T) {
+	p := &Plugin{resolvedBinary: "muse"}
+	_, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPromptFile: filepath.Join(t.TempDir(), "missing.md"),
+	})
+	if err == nil {
+		t.Fatal("GetLaunchCommand succeeded with a missing system prompt file")
+	}
+}
+
 func TestGetLaunchCommandMapsOfficialPermissionFlags(t *testing.T) {
 	tests := []struct {
 		name string
@@ -117,8 +162,7 @@ func TestGetLaunchCommandMapsOfficialPermissionFlags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Plugin{resolvedBinary: "muse"}
 			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
-				Permissions:  tt.mode,
-				SystemPrompt: "AO rules",
+				Permissions: tt.mode,
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -140,86 +184,50 @@ func TestGetPromptDeliveryStrategy(t *testing.T) {
 	}
 }
 
-func TestGetAgentHooksInstallsSystemPromptInstructions(t *testing.T) {
+func TestWorkspaceHooksLeaveTrackedAgentsMDUnchanged(t *testing.T) {
 	workspace := t.TempDir()
-	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
-		WorkspacePath: workspace,
-		SystemPrompt:  "follow AO rules\n",
-	}); err != nil {
+	runGit(t, workspace, "init")
+	runGit(t, workspace, "config", "user.name", "AO Test")
+	runGit(t, workspace, "config", "user.email", "ao@example.invalid")
+	path := filepath.Join(workspace, "AGENTS.md")
+	want := []byte("project-owned instructions\n")
+	if err := os.WriteFile(path, want, 0o600); err != nil {
 		t.Fatal(err)
 	}
+	runGit(t, workspace, "add", "AGENTS.md")
+	runGit(t, workspace, "commit", "-m", "add project instructions")
 
-	data, err := os.ReadFile(museInstructionsPath(workspace))
+	p := &Plugin{}
+	cfg := ports.WorkspaceHookConfig{WorkspacePath: workspace, SystemPrompt: "AO-only instructions"}
+	if err := p.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.CleanupWorkspace(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	text := string(data)
-	for _, want := range []string{museInstructionsSentinel, "# Agent Orchestrator Session Instructions", "follow AO rules", museInstructionsEnd} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("instructions missing %q:\n%s", want, text)
-		}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AGENTS.md = %q, want unchanged %q", got, want)
 	}
-	if filepath.Base(museInstructionsPath(workspace)) != "AGENTS.md" || filepath.Dir(museInstructionsPath(workspace)) != workspace {
-		t.Fatalf("instructions path = %s, want workspace-root AGENTS.md", museInstructionsPath(workspace))
+	if status := runGit(t, workspace, "status", "--porcelain"); status != "" {
+		t.Fatalf("workspace became dirty:\n%s", status)
 	}
 }
 
-func TestGetAgentHooksReadsSystemPromptFile(t *testing.T) {
+func TestWorkspaceHooksDoNotCreateAgentsMD(t *testing.T) {
 	workspace := t.TempDir()
-	promptFile := filepath.Join(t.TempDir(), "system.md")
-	if err := os.WriteFile(promptFile, []byte("file rules\n"), 0o600); err != nil {
+	p := &Plugin{}
+	cfg := ports.WorkspaceHookConfig{WorkspacePath: workspace, SystemPrompt: "AO-only instructions"}
+	if err := p.GetAgentHooks(context.Background(), cfg); err != nil {
 		t.Fatal(err)
 	}
-	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
-		WorkspacePath:    workspace,
-		SystemPromptFile: promptFile,
-	}); err != nil {
+	if err := p.CleanupWorkspace(context.Background(), cfg); err != nil {
 		t.Fatal(err)
 	}
-	data, err := os.ReadFile(museInstructionsPath(workspace))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(data), "file rules") {
-		t.Fatalf("instructions missing file rules:\n%s", data)
-	}
-}
-
-func TestGetAgentHooksPreservesAndRewritesUserInstructions(t *testing.T) {
-	workspace := t.TempDir()
-	path := museInstructionsPath(workspace)
-	existing := "before\n\n" + museInstructionFile("old rules") + "\nafter\n"
-	if err := os.WriteFile(path, []byte(existing), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
-		WorkspacePath: workspace,
-		SystemPrompt:  "new rules",
-	}); err != nil {
-		t.Fatal(err)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	text := string(data)
-	for _, want := range []string{"before", "after", "new rules"} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("instructions missing %q:\n%s", want, text)
-		}
-	}
-	if strings.Contains(text, "old rules") || strings.Count(text, museInstructionsSentinel) != 1 {
-		t.Fatalf("managed instructions not rewritten cleanly:\n%s", text)
-	}
-}
-
-func TestGetAgentHooksNoPromptIsNoOp(t *testing.T) {
-	workspace := t.TempDir()
-	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(filepath.Join(workspace, museInstructionsFileName)); !errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(filepath.Join(workspace, "AGENTS.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("AGENTS.md stat err = %v, want not exist", err)
 	}
 }
@@ -234,9 +242,38 @@ func TestResolveMuseBinaryRejectsUnrelatedMuseCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", dir)
-	_, err := ResolveMuseBinary(context.Background())
+	_, err := resolveMuseBinary(context.Background(), binaryutil.BinarySpec{
+		Label: "muse",
+		Names: []string{"muse"},
+	})
 	if !errors.Is(err, ports.ErrAgentBinaryNotFound) {
 		t.Fatalf("err = %v, want ErrAgentBinaryNotFound", err)
+	}
+}
+
+func TestResolveMuseBinaryContinuesAfterPathCollision(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	pathDir := t.TempDir()
+	shadow := filepath.Join(pathDir, "muse")
+	if err := os.WriteFile(shadow, []byte("#!/bin/sh\necho 'unrelated muse 1.0'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	officialDir := t.TempDir()
+	official := filepath.Join(officialDir, "muse")
+	if err := os.WriteFile(official, []byte("#!/bin/sh\necho 'Muse Code 0.1.0 (0.1.0-R708.1)'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", pathDir)
+
+	got, err := resolveMuseBinary(context.Background(), binaryutil.BinarySpec{
+		Label:     "muse",
+		Names:     []string{"muse"},
+		UnixPaths: []string{official},
+	})
+	if err != nil || got != official {
+		t.Fatalf("resolveMuseBinary = (%q, %v), want (%q, nil)", got, err, official)
 	}
 }
 
@@ -282,6 +319,9 @@ func TestContextCancellation(t *testing.T) {
 	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
 	}
+	if err := (&Plugin{}).CleanupWorkspace(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("CleanupWorkspace err = %v, want context.Canceled", err)
+	}
 	if _, _, err := (&Plugin{}).GetRestoreCommand(ctx, ports.RestoreConfig{}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetRestoreCommand err = %v, want context.Canceled", err)
 	}
@@ -291,4 +331,15 @@ func TestContextCancellation(t *testing.T) {
 	if _, err := ResolveMuseBinary(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("ResolveMuseBinary err = %v, want context.Canceled", err)
 	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
 }

--- a/backend/internal/adapters/agent/muse/muse_test.go
+++ b/backend/internal/adapters/agent/muse/muse_test.go
@@ -1,0 +1,264 @@
+package muse
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifest(t *testing.T) {
+	m := (&Plugin{}).Manifest()
+	if m.ID != "muse" || m.Name != "Muse Code" {
+		t.Fatalf("manifest = %#v, want muse/Muse Code", m)
+	}
+	for _, capability := range m.Capabilities {
+		if capability == adapters.CapabilityAgent {
+			return
+		}
+	}
+	t.Fatal("manifest missing CapabilityAgent")
+}
+
+func TestMuseBinarySpecIncludesUVToolInstallPath(t *testing.T) {
+	want := []string{".local", "bin", "muse"}
+	for _, path := range museBinarySpec.UnixHomePaths {
+		if reflect.DeepEqual(path, want) {
+			return
+		}
+	}
+	t.Fatalf("UnixHomePaths = %#v, want %v", museBinarySpec.UnixHomePaths, want)
+}
+
+func TestGetConfigSpecAdvertisesModelField(t *testing.T) {
+	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(spec.Fields) != 1 || spec.Fields[0].Key != "model" || spec.Fields[0].Type != ports.ConfigFieldString {
+		t.Fatalf("fields = %#v, want model/string", spec.Fields)
+	}
+}
+
+func TestGetLaunchCommandStartsInteractiveSession(t *testing.T) {
+	p := &Plugin{resolvedBinary: "muse"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"muse", "--interactive"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandDeliversPromptPositionally(t *testing.T) {
+	tests := []struct {
+		name   string
+		prompt string
+	}{
+		{name: "ordinary", prompt: "fix the tests"},
+		{name: "leading dash", prompt: "-add a health check"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "muse"}
+			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{Prompt: tt.prompt})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := []string{"muse", "--interactive", "--", tt.prompt}
+			if !reflect.DeepEqual(cmd, want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, want)
+			}
+			for _, arg := range cmd {
+				if arg == "-p" || arg == "--prompt" {
+					t.Fatalf("cmd = %#v unexpectedly uses Muse's single-prompt mode", cmd)
+				}
+			}
+		})
+	}
+}
+
+func TestGetLaunchCommandAppendsModelBeforePrompt(t *testing.T) {
+	p := &Plugin{resolvedBinary: "muse"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "anthropic:claude-sonnet-4"},
+		Prompt: "fix it",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"muse", "--interactive", "--model", "anthropic:claude-sonnet-4", "--", "fix it"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandIgnoresPermissionAndSystemPromptArgs(t *testing.T) {
+	for _, mode := range []ports.PermissionMode{
+		ports.PermissionModeDefault,
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions,
+	} {
+		t.Run(string(mode), func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "muse"}
+			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+				Permissions:  mode,
+				SystemPrompt: "AO rules",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := []string{"muse", "--interactive"}
+			if !reflect.DeepEqual(cmd, want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, want)
+			}
+		})
+	}
+}
+
+func TestGetPromptDeliveryStrategy(t *testing.T) {
+	strategy, err := (&Plugin{}).GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strategy != ports.PromptDeliveryInCommand {
+		t.Fatalf("strategy = %q, want %q", strategy, ports.PromptDeliveryInCommand)
+	}
+}
+
+func TestGetAgentHooksInstallsSystemPromptInstructions(t *testing.T) {
+	workspace := t.TempDir()
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		SystemPrompt:  "follow AO rules\n",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(museInstructionsPath(workspace))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, want := range []string{museInstructionsSentinel, "# Agent Orchestrator Session Instructions", "follow AO rules", museInstructionsEnd} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("instructions missing %q:\n%s", want, text)
+		}
+	}
+	gitignore, err := os.ReadFile(filepath.Join(workspace, museInstructionsDirName, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(gitignore), "/AGENTS.md\n") {
+		t.Fatalf("gitignore does not ignore AGENTS.md:\n%s", gitignore)
+	}
+}
+
+func TestGetAgentHooksReadsSystemPromptFile(t *testing.T) {
+	workspace := t.TempDir()
+	promptFile := filepath.Join(t.TempDir(), "system.md")
+	if err := os.WriteFile(promptFile, []byte("file rules\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath:    workspace,
+		SystemPromptFile: promptFile,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(museInstructionsPath(workspace))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "file rules") {
+		t.Fatalf("instructions missing file rules:\n%s", data)
+	}
+}
+
+func TestGetAgentHooksPreservesAndRewritesUserInstructions(t *testing.T) {
+	workspace := t.TempDir()
+	path := museInstructionsPath(workspace)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	existing := "before\n\n" + museInstructionFile("old rules") + "\nafter\n"
+	if err := os.WriteFile(path, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		SystemPrompt:  "new rules",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, want := range []string{"before", "after", "new rules"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("instructions missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "old rules") || strings.Count(text, museInstructionsSentinel) != 1 {
+		t.Fatalf("managed instructions not rewritten cleanly:\n%s", text)
+	}
+}
+
+func TestGetAgentHooksNoPromptIsNoOp(t *testing.T) {
+	workspace := t.TempDir()
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, museInstructionsDirName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf(".muse stat err = %v, want not exist", err)
+	}
+}
+
+func TestRestoreAndSessionInfoAreNoOps(t *testing.T) {
+	p := &Plugin{}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "session-id"}},
+	})
+	if err != nil || ok || cmd != nil {
+		t.Fatalf("restore = (%#v, %v, %v), want (nil, false, nil)", cmd, ok, err)
+	}
+	info, ok, err := p.SessionInfo(context.Background(), ports.SessionRef{})
+	if err != nil || ok || !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("session info = (%#v, %v, %v), want zero/false/nil", info, ok, err)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := (&Plugin{}).GetConfigSpec(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetConfigSpec err = %v, want context.Canceled", err)
+	}
+	if _, err := (&Plugin{}).GetPromptDeliveryStrategy(ctx, ports.LaunchConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetPromptDeliveryStrategy err = %v, want context.Canceled", err)
+	}
+	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).GetRestoreCommand(ctx, ports.RestoreConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetRestoreCommand err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).SessionInfo(ctx, ports.SessionRef{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SessionInfo err = %v, want context.Canceled", err)
+	}
+	if _, err := ResolveMuseBinary(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ResolveMuseBinary err = %v, want context.Canceled", err)
+	}
+}

--- a/backend/internal/adapters/agent/muse/muse_test.go
+++ b/backend/internal/adapters/agent/muse/muse_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestManifest(t *testing.T) {
 	t.Fatal("manifest missing CapabilityAgent")
 }
 
-func TestMuseBinarySpecIncludesUVToolInstallPath(t *testing.T) {
+func TestMuseBinarySpecIncludesOfficialInstallerPath(t *testing.T) {
 	want := []string{".local", "bin", "muse"}
 	for _, path := range museBinarySpec.UnixHomePaths {
 		if reflect.DeepEqual(path, want) {
@@ -52,7 +53,7 @@ func TestGetLaunchCommandStartsInteractiveSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"muse", "--interactive"}
+	want := []string{"muse", "--trust-workspace"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
@@ -64,7 +65,7 @@ func TestGetLaunchCommandDeliversPromptPositionally(t *testing.T) {
 		prompt string
 	}{
 		{name: "ordinary", prompt: "fix the tests"},
-		{name: "leading dash", prompt: "-add a health check"},
+		{name: "multiline", prompt: "fix the tests\nthen report"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,13 +74,13 @@ func TestGetLaunchCommandDeliversPromptPositionally(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := []string{"muse", "--interactive", "--", tt.prompt}
+			want := []string{"muse", "--trust-workspace", tt.prompt}
 			if !reflect.DeepEqual(cmd, want) {
 				t.Fatalf("cmd = %#v, want %#v", cmd, want)
 			}
 			for _, arg := range cmd {
-				if arg == "-p" || arg == "--prompt" {
-					t.Fatalf("cmd = %#v unexpectedly uses Muse's single-prompt mode", cmd)
+				if arg == "exec" {
+					t.Fatalf("cmd = %#v unexpectedly uses Muse's headless mode", cmd)
 				}
 			}
 		})
@@ -89,37 +90,41 @@ func TestGetLaunchCommandDeliversPromptPositionally(t *testing.T) {
 func TestGetLaunchCommandAppendsModelBeforePrompt(t *testing.T) {
 	p := &Plugin{resolvedBinary: "muse"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
-		Config: ports.AgentConfig{Model: "anthropic:claude-sonnet-4"},
+		Config: ports.AgentConfig{Model: "muse-spark"},
 		Prompt: "fix it",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"muse", "--interactive", "--model", "anthropic:claude-sonnet-4", "--", "fix it"}
+	want := []string{"muse", "--trust-workspace", "--model", "muse-spark", "fix it"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
 }
 
-func TestGetLaunchCommandIgnoresPermissionAndSystemPromptArgs(t *testing.T) {
-	for _, mode := range []ports.PermissionMode{
-		ports.PermissionModeDefault,
-		ports.PermissionModeAcceptEdits,
-		ports.PermissionModeAuto,
-		ports.PermissionModeBypassPermissions,
-	} {
-		t.Run(string(mode), func(t *testing.T) {
+func TestGetLaunchCommandMapsOfficialPermissionFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		mode ports.PermissionMode
+		want []string
+	}{
+		{"default", ports.PermissionModeDefault, []string{"muse", "--trust-workspace"}},
+		{"accept edits", ports.PermissionModeAcceptEdits, []string{"muse", "--trust-workspace", "--approval-mode", "never"}},
+		{"auto", ports.PermissionModeAuto, []string{"muse", "--trust-workspace", "--approval-mode", "never"}},
+		{"bypass", ports.PermissionModeBypassPermissions, []string{"muse", "--trust-workspace", "--yolo"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			p := &Plugin{resolvedBinary: "muse"}
 			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
-				Permissions:  mode,
+				Permissions:  tt.mode,
 				SystemPrompt: "AO rules",
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := []string{"muse", "--interactive"}
-			if !reflect.DeepEqual(cmd, want) {
-				t.Fatalf("cmd = %#v, want %#v", cmd, want)
+			if !reflect.DeepEqual(cmd, tt.want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, tt.want)
 			}
 		})
 	}
@@ -154,12 +159,8 @@ func TestGetAgentHooksInstallsSystemPromptInstructions(t *testing.T) {
 			t.Fatalf("instructions missing %q:\n%s", want, text)
 		}
 	}
-	gitignore, err := os.ReadFile(filepath.Join(workspace, museInstructionsDirName, ".gitignore"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(gitignore), "/AGENTS.md\n") {
-		t.Fatalf("gitignore does not ignore AGENTS.md:\n%s", gitignore)
+	if filepath.Base(museInstructionsPath(workspace)) != "AGENTS.md" || filepath.Dir(museInstructionsPath(workspace)) != workspace {
+		t.Fatalf("instructions path = %s, want workspace-root AGENTS.md", museInstructionsPath(workspace))
 	}
 }
 
@@ -187,9 +188,6 @@ func TestGetAgentHooksReadsSystemPromptFile(t *testing.T) {
 func TestGetAgentHooksPreservesAndRewritesUserInstructions(t *testing.T) {
 	workspace := t.TempDir()
 	path := museInstructionsPath(workspace)
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		t.Fatal(err)
-	}
 	existing := "before\n\n" + museInstructionFile("old rules") + "\nafter\n"
 	if err := os.WriteFile(path, []byte(existing), 0o600); err != nil {
 		t.Fatal(err)
@@ -221,8 +219,40 @@ func TestGetAgentHooksNoPromptIsNoOp(t *testing.T) {
 	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(workspace, museInstructionsDirName)); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf(".muse stat err = %v, want not exist", err)
+	if _, err := os.Stat(filepath.Join(workspace, museInstructionsFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("AGENTS.md stat err = %v, want not exist", err)
+	}
+}
+
+func TestResolveMuseBinaryRejectsUnrelatedMuseCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "muse")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho 'unrelated muse 1.0'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	_, err := ResolveMuseBinary(context.Background())
+	if !errors.Is(err, ports.ErrAgentBinaryNotFound) {
+		t.Fatalf("err = %v, want ErrAgentBinaryNotFound", err)
+	}
+}
+
+func TestResolveMuseBinaryAcceptsOfficialVersionSignature(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "muse")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho 'Muse Code 0.1.0 (0.1.0-R708.1)'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	got, err := ResolveMuseBinary(context.Background())
+	if err != nil || got != path {
+		t.Fatalf("ResolveMuseBinary = (%q, %v), want (%q, nil)", got, err, path)
 	}
 }
 

--- a/backend/internal/adapters/agent/muse/muse_test.go
+++ b/backend/internal/adapters/agent/muse/muse_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
@@ -123,7 +124,6 @@ func TestGetLaunchCommandInjectsSystemPromptWithoutProjectFiles(t *testing.T) {
 }
 
 func TestGetLaunchCommandInjectsManagedHooksPath(t *testing.T) {
-	t.Setenv(aoRunFileEnvVar, "")
 	dataDir := t.TempDir()
 	p := &Plugin{resolvedBinary: "muse"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
@@ -148,7 +148,6 @@ func TestGetLaunchCommandInjectsManagedHooksPath(t *testing.T) {
 }
 
 func TestGetLaunchCommandCombinesSystemPromptAndManagedHooksEnvironment(t *testing.T) {
-	t.Setenv(aoRunFileEnvVar, "")
 	dataDir := t.TempDir()
 	p := &Plugin{resolvedBinary: "muse"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
@@ -167,33 +166,6 @@ func TestGetLaunchCommandCombinesSystemPromptAndManagedHooksEnvironment(t *testi
 		"env",
 		museSystemPromptEnvVar + "=follow AO rules",
 		museManagedHooksEnvVar + "=" + hooksPath,
-		"muse", "--trust-workspace",
-	}
-	if !reflect.DeepEqual(cmd, want) {
-		t.Fatalf("cmd = %#v, want %#v", cmd, want)
-	}
-}
-
-func TestGetLaunchCommandRoutesHooksToExplicitDaemonRunFile(t *testing.T) {
-	dataDir := t.TempDir()
-	runFile := filepath.Join(t.TempDir(), "running.json")
-	t.Setenv(aoRunFileEnvVar, runFile)
-	p := &Plugin{resolvedBinary: "muse"}
-	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
-		DataDir:   dataDir,
-		SessionID: "sess-1",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	hooksPath, err := museManagedHooksPath(dataDir, "sess-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{
-		"env",
-		museManagedHooksEnvVar + "=" + hooksPath,
-		aoRunFileEnvVar + "=" + runFile,
 		"muse", "--trust-workspace",
 	}
 	if !reflect.DeepEqual(cmd, want) {
@@ -265,6 +237,7 @@ func TestGetPromptDeliveryStrategy(t *testing.T) {
 }
 
 func TestWorkspaceHooksLeaveTrackedAgentsMDUnchanged(t *testing.T) {
+	t.Setenv(aoRunFileEnvVar, "")
 	workspace := t.TempDir()
 	runGit(t, workspace, "init")
 	runGit(t, workspace, "config", "user.name", "AO Test")
@@ -313,6 +286,7 @@ func TestWorkspaceHooksLeaveTrackedAgentsMDUnchanged(t *testing.T) {
 }
 
 func TestWorkspaceHooksDoNotCreateAgentsMD(t *testing.T) {
+	t.Setenv(aoRunFileEnvVar, "")
 	workspace := t.TempDir()
 	p := &Plugin{}
 	dataDir := t.TempDir()
@@ -339,6 +313,34 @@ func TestWorkspaceHooksDoNotCreateAgentsMD(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(workspace, "AGENTS.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("AGENTS.md stat err = %v, want not exist", err)
+	}
+}
+
+func TestManagedHookCommandsRestoreSanitizedAORoute(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "data dir")
+	runFile := filepath.Join(t.TempDir(), "dev's running.json")
+	t.Setenv(aoRunFileEnvVar, runFile)
+	cfg := ports.WorkspaceHookConfig{DataDir: dataDir, SessionID: "sess-1"}
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	path, err := museManagedHooksPath(dataDir, cfg.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned path
+	if err != nil {
+		t.Fatal(err)
+	}
+	var file museHooksFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatal(err)
+	}
+	command := file.Hooks["UserPromptSubmit"][0].Hooks[0].Command
+	want := "env AO_SESSION_ID='sess-1' AO_DATA_DIR=" + museShellQuote(dataDir) +
+		" AO_RUN_FILE=" + museShellQuote(runFile) + " ao hooks muse user-prompt-submit"
+	if command != want {
+		t.Fatalf("command = %q, want %q", command, want)
 	}
 }
 
@@ -379,7 +381,7 @@ func assertMuseManagedHooks(t *testing.T, path string) {
 			t.Fatalf("hooks[%q] = %#v, want one command", nativeEvent, groups)
 		}
 		hook := groups[0].Hooks[0]
-		if hook.Type != "command" || hook.Command != museHookCommandPrefix+aoEvent {
+		if hook.Type != "command" || !strings.HasSuffix(hook.Command, " "+museHookCommandPrefix+aoEvent) {
 			t.Fatalf("hooks[%q] = %#v, want AO %q command", nativeEvent, hook, aoEvent)
 		}
 	}

--- a/backend/internal/adapters/agent/muse/muse_test.go
+++ b/backend/internal/adapters/agent/muse/muse_test.go
@@ -370,9 +370,7 @@ func assertMuseManagedHooks(t *testing.T, path string) {
 	want := map[string]string{
 		"SessionStart":      "session-start",
 		"UserPromptSubmit":  "user-prompt-submit",
-		"PreToolUse":        "pre-tool-use",
 		"PermissionRequest": "permission-request",
-		"PostToolUse":       "post-tool-use",
 		"Stop":              "stop",
 	}
 	for nativeEvent, aoEvent := range want {

--- a/backend/internal/adapters/agent/muse/muse_test.go
+++ b/backend/internal/adapters/agent/muse/muse_test.go
@@ -123,6 +123,7 @@ func TestGetLaunchCommandInjectsSystemPromptWithoutProjectFiles(t *testing.T) {
 }
 
 func TestGetLaunchCommandInjectsManagedHooksPath(t *testing.T) {
+	t.Setenv(aoRunFileEnvVar, "")
 	dataDir := t.TempDir()
 	p := &Plugin{resolvedBinary: "muse"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
@@ -147,6 +148,7 @@ func TestGetLaunchCommandInjectsManagedHooksPath(t *testing.T) {
 }
 
 func TestGetLaunchCommandCombinesSystemPromptAndManagedHooksEnvironment(t *testing.T) {
+	t.Setenv(aoRunFileEnvVar, "")
 	dataDir := t.TempDir()
 	p := &Plugin{resolvedBinary: "muse"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
@@ -165,6 +167,33 @@ func TestGetLaunchCommandCombinesSystemPromptAndManagedHooksEnvironment(t *testi
 		"env",
 		museSystemPromptEnvVar + "=follow AO rules",
 		museManagedHooksEnvVar + "=" + hooksPath,
+		"muse", "--trust-workspace",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandRoutesHooksToExplicitDaemonRunFile(t *testing.T) {
+	dataDir := t.TempDir()
+	runFile := filepath.Join(t.TempDir(), "running.json")
+	t.Setenv(aoRunFileEnvVar, runFile)
+	p := &Plugin{resolvedBinary: "muse"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		DataDir:   dataDir,
+		SessionID: "sess-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hooksPath, err := museManagedHooksPath(dataDir, "sess-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"env",
+		museManagedHooksEnvVar + "=" + hooksPath,
+		aoRunFileEnvVar + "=" + runFile,
 		"muse", "--trust-workspace",
 	}
 	if !reflect.DeepEqual(cmd, want) {

--- a/backend/internal/adapters/agent/muse/muse_test.go
+++ b/backend/internal/adapters/agent/muse/muse_test.go
@@ -2,6 +2,7 @@ package muse
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -121,6 +122,56 @@ func TestGetLaunchCommandInjectsSystemPromptWithoutProjectFiles(t *testing.T) {
 	}
 }
 
+func TestGetLaunchCommandInjectsManagedHooksPath(t *testing.T) {
+	dataDir := t.TempDir()
+	p := &Plugin{resolvedBinary: "muse"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		DataDir:   dataDir,
+		SessionID: "agent-orchestrator-96",
+		Prompt:    "fix it",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hooksPath, err := museManagedHooksPath(dataDir, "agent-orchestrator-96")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"env", museManagedHooksEnvVar + "=" + hooksPath,
+		"muse", "--trust-workspace", "fix it",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandCombinesSystemPromptAndManagedHooksEnvironment(t *testing.T) {
+	dataDir := t.TempDir()
+	p := &Plugin{resolvedBinary: "muse"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		DataDir:      dataDir,
+		SessionID:    "sess-1",
+		SystemPrompt: "follow AO rules",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hooksPath, err := museManagedHooksPath(dataDir, "sess-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"env",
+		museSystemPromptEnvVar + "=follow AO rules",
+		museManagedHooksEnvVar + "=" + hooksPath,
+		"muse", "--trust-workspace",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
 func TestGetLaunchCommandReadsSystemPromptFile(t *testing.T) {
 	promptFile := filepath.Join(t.TempDir(), "system.md")
 	if err := os.WriteFile(promptFile, []byte("file rules\n"), 0o600); err != nil {
@@ -198,12 +249,27 @@ func TestWorkspaceHooksLeaveTrackedAgentsMDUnchanged(t *testing.T) {
 	runGit(t, workspace, "commit", "-m", "add project instructions")
 
 	p := &Plugin{}
-	cfg := ports.WorkspaceHookConfig{WorkspacePath: workspace, SystemPrompt: "AO-only instructions"}
+	dataDir := t.TempDir()
+	cfg := ports.WorkspaceHookConfig{
+		DataDir: dataDir, SessionID: "sess-tracked",
+		WorkspacePath: workspace, SystemPrompt: "AO-only instructions",
+	}
 	if err := p.GetAgentHooks(context.Background(), cfg); err != nil {
 		t.Fatal(err)
 	}
+	hooksPath, err := museManagedHooksPath(dataDir, cfg.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMuseManagedHooks(t, hooksPath)
+	if status := runGit(t, workspace, "status", "--porcelain"); status != "" {
+		t.Fatalf("workspace became dirty before cleanup:\n%s", status)
+	}
 	if err := p.CleanupWorkspace(context.Background(), cfg); err != nil {
 		t.Fatal(err)
+	}
+	if _, err := os.Stat(hooksPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("managed hooks stat after cleanup = %v, want not exist", err)
 	}
 	got, err := os.ReadFile(path)
 	if err != nil {
@@ -220,15 +286,73 @@ func TestWorkspaceHooksLeaveTrackedAgentsMDUnchanged(t *testing.T) {
 func TestWorkspaceHooksDoNotCreateAgentsMD(t *testing.T) {
 	workspace := t.TempDir()
 	p := &Plugin{}
-	cfg := ports.WorkspaceHookConfig{WorkspacePath: workspace, SystemPrompt: "AO-only instructions"}
+	dataDir := t.TempDir()
+	cfg := ports.WorkspaceHookConfig{
+		DataDir: dataDir, SessionID: "sess-absent",
+		WorkspacePath: workspace, SystemPrompt: "AO-only instructions",
+	}
 	if err := p.GetAgentHooks(context.Background(), cfg); err != nil {
 		t.Fatal(err)
+	}
+	hooksPath, err := museManagedHooksPath(dataDir, cfg.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMuseManagedHooks(t, hooksPath)
+	if _, err := os.Stat(filepath.Join(workspace, "AGENTS.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("AGENTS.md stat before cleanup = %v, want not exist", err)
 	}
 	if err := p.CleanupWorkspace(context.Background(), cfg); err != nil {
 		t.Fatal(err)
 	}
+	if err := p.CleanupWorkspace(context.Background(), cfg); err != nil {
+		t.Fatalf("second cleanup: %v", err)
+	}
 	if _, err := os.Stat(filepath.Join(workspace, "AGENTS.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("AGENTS.md stat err = %v, want not exist", err)
+	}
+}
+
+func TestManagedHooksRequireAOOwnedPathInputs(t *testing.T) {
+	p := &Plugin{resolvedBinary: "muse"}
+	for _, cfg := range []ports.WorkspaceHookConfig{
+		{},
+		{DataDir: t.TempDir()},
+		{DataDir: t.TempDir(), SessionID: "../escape"},
+	} {
+		if err := p.GetAgentHooks(context.Background(), cfg); err == nil {
+			t.Fatalf("GetAgentHooks(%+v) succeeded, want error", cfg)
+		}
+	}
+}
+
+func assertMuseManagedHooks(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned path
+	if err != nil {
+		t.Fatal(err)
+	}
+	var file museHooksFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatalf("decode managed hooks: %v", err)
+	}
+	want := map[string]string{
+		"SessionStart":      "session-start",
+		"UserPromptSubmit":  "user-prompt-submit",
+		"PreToolUse":        "pre-tool-use",
+		"PermissionRequest": "permission-request",
+		"PostToolUse":       "post-tool-use",
+		"Stop":              "stop",
+	}
+	for nativeEvent, aoEvent := range want {
+		groups := file.Hooks[nativeEvent]
+		if len(groups) != 1 || len(groups[0].Hooks) != 1 {
+			t.Fatalf("hooks[%q] = %#v, want one command", nativeEvent, groups)
+		}
+		hook := groups[0].Hooks[0]
+		if hook.Type != "command" || hook.Command != museHookCommandPrefix+aoEvent {
+			t.Fatalf("hooks[%q] = %#v, want AO %q command", nativeEvent, hook, aoEvent)
+		}
 	}
 }
 

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kilocode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kiro"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/muse"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/pi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/qwen"
@@ -48,6 +49,7 @@ func Constructors() []adapters.Adapter {
 		qwen.New(),
 		copilot.New(),
 		kimi.New(),
+		muse.New(),
 		droid.New(),
 		amp.New(),
 		agy.New(),

--- a/backend/internal/cli/doctor.go
+++ b/backend/internal/cli/doctor.go
@@ -62,6 +62,7 @@ type harnessProbe struct {
 var doctorHarnesses = []harnessProbe{
 	{Name: "claude-code", BinaryName: "claude", VersionArg: "--version"},
 	{Name: "codex", BinaryName: "codex", VersionArg: "--version"},
+	{Name: "muse", BinaryName: "muse", VersionArg: "--version"},
 }
 
 func newDoctorCommand(ctx *commandContext) *cobra.Command {

--- a/backend/internal/cli/doctor.go
+++ b/backend/internal/cli/doctor.go
@@ -54,15 +54,16 @@ const (
 )
 
 type harnessProbe struct {
-	Name       string
-	BinaryName string
-	VersionArg string
+	Name                  string
+	BinaryName            string
+	VersionArg            string
+	ExpectedVersionPrefix string
 }
 
 var doctorHarnesses = []harnessProbe{
 	{Name: "claude-code", BinaryName: "claude", VersionArg: "--version"},
 	{Name: "codex", BinaryName: "codex", VersionArg: "--version"},
-	{Name: "muse", BinaryName: "muse", VersionArg: "--version"},
+	{Name: "muse", BinaryName: "muse", VersionArg: "--version", ExpectedVersionPrefix: "Muse Code "},
 }
 
 func newDoctorCommand(ctx *commandContext) *cobra.Command {
@@ -388,6 +389,12 @@ func (c *commandContext) checkHarness(ctx context.Context, harness harnessProbe)
 	version := firstOutputLine(out)
 	if version == "" {
 		version = "version output was empty"
+	}
+	if harness.ExpectedVersionPrefix != "" && !strings.HasPrefix(version, harness.ExpectedVersionPrefix) {
+		return doctorCheck{
+			Level: doctorWarn, Section: doctorSectionAgents, Name: harness.Name,
+			Message: fmt.Sprintf("%s resolves to %s, but its version output %q does not identify the expected CLI (%q prefix)", harness.BinaryName, path, version, harness.ExpectedVersionPrefix),
+		}
 	}
 	return doctorCheck{Level: doctorPass, Section: doctorSectionAgents, Name: harness.Name, Message: fmt.Sprintf("%s resolves to %s (%s)", harness.BinaryName, path, version)}
 }

--- a/backend/internal/cli/doctor_test.go
+++ b/backend/internal/cli/doctor_test.go
@@ -120,12 +120,13 @@ func TestDoctorChecksHarnessVersions(t *testing.T) {
 		"git":    "/bin/git",
 		"claude": "/bin/claude",
 		"codex":  "/bin/codex",
+		"muse":   "/bin/muse",
 	}
 	c := doctorContext(t, cmdPath, func(_ context.Context, name string, args ...string) ([]byte, error) {
 		switch name {
 		case "/bin/git":
 			return []byte("git version 2.43.0\n"), nil
-		case "/bin/claude", "/bin/codex":
+		case "/bin/claude", "/bin/codex", "/bin/muse":
 			if len(args) == 1 && args[0] == "--version" {
 				return []byte(strings.TrimPrefix(name, "/bin/") + " 1.2.3\n"), nil
 			}
@@ -142,7 +143,7 @@ func TestDoctorChecksHarnessVersions(t *testing.T) {
 	})
 
 	checks := c.runDoctor(context.Background())
-	for _, name := range []string{"claude-code", "codex"} {
+	for _, name := range []string{"claude-code", "codex", "muse"} {
 		check := findDoctorCheck(t, checks, name)
 		if check.Level != doctorPass || !strings.Contains(check.Message, "resolves to") {
 			t.Fatalf("%s check = %+v, want PASS with path/version", name, check)
@@ -302,7 +303,7 @@ func TestDoctorTextOutputIsGrouped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("doctor failed: %v\nstderr=%s\nstdout=%s", err, errOut, out)
 	}
-	for _, want := range []string{"Core:\nPASS config:", "Tools:\nPASS git:", "Agent harnesses:\nWARN claude-code:", "WARN codex:", "GitHub:\nWARN github-token:"} {
+	for _, want := range []string{"Core:\nPASS config:", "Tools:\nPASS git:", "Agent harnesses:\nWARN claude-code:", "WARN codex:", "WARN muse:", "GitHub:\nWARN github-token:"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, out)
 		}

--- a/backend/internal/cli/doctor_test.go
+++ b/backend/internal/cli/doctor_test.go
@@ -128,6 +128,9 @@ func TestDoctorChecksHarnessVersions(t *testing.T) {
 			return []byte("git version 2.43.0\n"), nil
 		case "/bin/claude", "/bin/codex", "/bin/muse":
 			if len(args) == 1 && args[0] == "--version" {
+				if name == "/bin/muse" {
+					return []byte("Muse Code 0.1.0 (0.1.0-R708.1)\n"), nil
+				}
 				return []byte(strings.TrimPrefix(name, "/bin/") + " 1.2.3\n"), nil
 			}
 			// The codex launch-flag canary probes the same binary.
@@ -148,6 +151,21 @@ func TestDoctorChecksHarnessVersions(t *testing.T) {
 		if check.Level != doctorPass || !strings.Contains(check.Message, "resolves to") {
 			t.Fatalf("%s check = %+v, want PASS with path/version", name, check)
 		}
+	}
+}
+
+func TestDoctorRejectsUnrelatedMuseBinary(t *testing.T) {
+	setConfigEnv(t)
+	c := doctorContext(t, map[string]string{"git": "/bin/git", "muse": "/bin/muse"}, func(_ context.Context, name string, _ ...string) ([]byte, error) {
+		if name == "/bin/git" {
+			return []byte("git version 2.43.0\n"), nil
+		}
+		return []byte("unrelated muse 1.0\n"), nil
+	})
+
+	check := findDoctorCheck(t, c.runDoctor(context.Background()), "muse")
+	if check.Level != doctorWarn || !strings.Contains(check.Message, "does not identify the expected CLI") {
+		t.Fatalf("muse check = %+v, want WARN for unrelated binary", check)
 	}
 }
 

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -433,27 +433,54 @@ func TestHooks_ClaudeCodeBlankSessionIDIsIgnored(t *testing.T) {
 	}
 }
 
-func TestHooks_GrokSessionStartReportsAgentSessionID(t *testing.T) {
+func TestHooks_ClaudeCompatibleSessionStartReportsAgentSessionID(t *testing.T) {
+	for _, agent := range []string{"grok", "muse"} {
+		t.Run(agent, func(t *testing.T) {
+			t.Setenv("AO_SESSION_ID", "ao-7")
+			cfg := setConfigEnv(t)
+			srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+			writeRunFileFor(t, cfg, srv)
+
+			_, _, err := executeCLI(t, Deps{
+				In:           strings.NewReader(`{"session_id":"` + agent + `-native-1"}`),
+				ProcessAlive: func(int) bool { return true },
+			}, "hooks", agent, "session-start")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if capture.hits != 1 {
+				t.Fatalf("daemon calls = %d, want 1", capture.hits)
+			}
+			var req setActivityAPIRequest
+			if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+				t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+			}
+			want := setActivityAPIRequest{Event: "session-start", AgentSessionID: agent + "-native-1"}
+			if req != want {
+				t.Fatalf("body = %+v, want %+v", req, want)
+			}
+		})
+	}
+}
+
+func TestHooks_MuseUserPromptReportsActive(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	cfg := setConfigEnv(t)
 	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
 	writeRunFileFor(t, cfg, srv)
 
 	_, _, err := executeCLI(t, Deps{
-		In:           strings.NewReader(`{"session_id":"grok-native-1"}`),
+		In:           strings.NewReader(`{"session_id":"muse-native-1"}`),
 		ProcessAlive: func(int) bool { return true },
-	}, "hooks", "grok", "session-start")
+	}, "hooks", "muse", "user-prompt-submit")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if capture.hits != 1 {
-		t.Fatalf("daemon calls = %d, want 1", capture.hits)
 	}
 	var req setActivityAPIRequest
 	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
 		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
 	}
-	want := setActivityAPIRequest{Event: "session-start", AgentSessionID: "grok-native-1"}
+	want := setActivityAPIRequest{State: "active", Event: "user-prompt-submit", AgentSessionID: "muse-native-1"}
 	if req != want {
 		t.Fatalf("body = %+v, want %+v", req, want)
 	}

--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -175,7 +175,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 		return pflag.NormalizedName(name)
 	})
 	f.StringVar(&opts.project, "project", "", "Project id to spawn the session in (default: AO_PROJECT_ID, current registered repo, or Scratch when it is the only project)")
-	f.StringVar(&opts.harness, "harness", "", "Agent harness / --agent: claude-code, codex, aider, opencode, grok, droid, amp, agy, crush, cursor, qwen, copilot, goose, auggie, continue, devin, cline, kimi, kiro, kilocode, vibe, pi, autohand (default: project worker.agent; orchestrator spawns default to project orchestrator.agent; required if the project has none)")
+	f.StringVar(&opts.harness, "harness", "", "Agent harness / --agent: claude-code, codex, aider, opencode, grok, droid, amp, agy, crush, cursor, qwen, copilot, goose, auggie, continue, devin, cline, kimi, muse, kiro, kilocode, vibe, pi, autohand (default: project worker.agent; orchestrator spawns default to project orchestrator.agent; required if the project has none)")
 	f.StringVar(&opts.kind, "kind", "", "Session role: worker or orchestrator (default: worker)")
 	f.StringVar(&opts.mode, "mode", "", "Initial session interface: chat (structured agent connection) or tui (the agent's native terminal). Omitted uses the daemon default; compatible sessions can switch later.")
 	f.StringVar(&opts.branch, "branch", "", "Branch for git project sessions (default: ao/<session-id>/root; unsupported for Scratch)")

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -102,6 +102,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 		{domain.HarnessQwen, "qwen"},
 		{domain.HarnessCopilot, "copilot"},
 		{domain.HarnessKimi, "kimi"},
+		{domain.HarnessMuse, "muse"},
 		{domain.HarnessDroid, "droid"},
 		{domain.HarnessAmp, "amp"},
 		{domain.HarnessAgy, "agy"},

--- a/backend/internal/domain/harness.go
+++ b/backend/internal/domain/harness.go
@@ -23,6 +23,7 @@ const (
 	HarnessDevin      AgentHarness = "devin"
 	HarnessCline      AgentHarness = "cline"
 	HarnessKimi       AgentHarness = "kimi"
+	HarnessMuse       AgentHarness = "muse"
 	HarnessKiro       AgentHarness = "kiro"
 	HarnessKilocode   AgentHarness = "kilocode"
 	HarnessVibe       AgentHarness = "vibe"
@@ -39,7 +40,7 @@ var AllHarnesses = []AgentHarness{
 	HarnessClaudeCode, HarnessCodex, HarnessAider, HarnessOpenCode, HarnessGrok,
 	HarnessDroid, HarnessAmp, HarnessAgy, HarnessCrush, HarnessCursor, HarnessQwen,
 	HarnessCopilot, HarnessGoose, HarnessAuggie, HarnessContinue, HarnessDevin,
-	HarnessCline, HarnessKimi, HarnessKiro, HarnessKilocode, HarnessVibe, HarnessPi,
+	HarnessCline, HarnessKimi, HarnessMuse, HarnessKiro, HarnessKilocode, HarnessVibe, HarnessPi,
 	HarnessAutohand,
 }
 

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -5017,6 +5017,7 @@ components:
           - devin
           - cline
           - kimi
+          - muse
           - kiro
           - kilocode
           - vibe
@@ -6606,6 +6607,7 @@ components:
           - devin
           - cline
           - kimi
+          - muse
           - kiro
           - kilocode
           - vibe

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -157,7 +157,7 @@ type SpawnSessionRequest struct {
 	ProjectID domain.ProjectID    `json:"projectId"`
 	IssueID   domain.IssueID      `json:"issueId,omitempty"`
 	Kind      domain.SessionKind  `json:"kind,omitempty" enum:"worker,orchestrator"`
-	Harness   domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand"`
+	Harness   domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,muse,kiro,kilocode,vibe,pi,autohand"`
 	Branch    string              `json:"branch,omitempty"`
 	// Mode picks the conversation controller: chat talks to the agent over a
 	// structured connection, tui opens the agent's native terminal interface.
@@ -478,7 +478,7 @@ type SendSessionMessageResponse struct {
 type DelegateTaskRequest struct {
 	ProjectID domain.ProjectID    `json:"projectId"`
 	Brief     string              `json:"brief" maxLength:"4096"`
-	Agent     domain.AgentHarness `json:"agent,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand,fake"`
+	Agent     domain.AgentHarness `json:"agent,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,muse,kiro,kilocode,vibe,pi,autohand,fake"`
 	Model     string              `json:"model,omitempty" maxLength:"256"`
 	// Mode is omitted for the daemon-owned default. The UI sends tui only when
 	// the user explicitly accepts the fallback after Chat preflight fails.

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -64,6 +64,7 @@ var shippedMigrations = map[int64]string{
 	44: "0044_backfill_review_run_batch_id.sql",
 	47: "0047_agent_model_catalog.sql",
 	52: "0052_model_usage.sql",
+	53: "0053_allow_muse_harness.sql",
 	66: "0066_chat_session_mode.sql",
 	67: "0067_app_settings.sql",
 	68: "0068_conversation_turn_settings.sql",

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -208,6 +208,7 @@ func TestMigrateAllowsEveryShippedHarness(t *testing.T) {
 		domain.HarnessDevin,
 		domain.HarnessCline,
 		domain.HarnessKimi,
+		domain.HarnessMuse,
 		domain.HarnessKiro,
 		domain.HarnessKilocode,
 		domain.HarnessVibe,

--- a/backend/internal/storage/sqlite/migrations/0053_allow_muse_harness.sql
+++ b/backend/internal/storage/sqlite/migrations/0053_allow_muse_harness.sql
@@ -1,0 +1,38 @@
+-- Widen sessions.harness to allow the Muse Code CLI adapter. SQLite cannot
+-- ALTER an existing CHECK, so update the stored CREATE TABLE text and force a
+-- schema reparse, following the established harness migrations.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (harness IN ('''', ''claude-code'', ''codex'', ''aider'', ''opencode'', ''grok'', ''droid'', ''amp'', ''agy'', ''crush'', ''cursor'', ''qwen'', ''copilot'', ''goose'', ''auggie'', ''continue'', ''devin'', ''cline'', ''kimi'', ''kiro'', ''kilocode'', ''vibe'', ''pi'', ''autohand'', ''fake''))',
+    'CHECK (harness IN ('''', ''claude-code'', ''codex'', ''aider'', ''opencode'', ''grok'', ''droid'', ''amp'', ''agy'', ''crush'', ''cursor'', ''qwen'', ''copilot'', ''goose'', ''auggie'', ''continue'', ''devin'', ''cline'', ''kimi'', ''muse'', ''kiro'', ''kilocode'', ''vibe'', ''pi'', ''autohand'', ''fake''))'
+)
+WHERE type = 'table' AND name = 'sessions';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (harness IN ('''', ''claude-code'', ''codex'', ''aider'', ''opencode'', ''grok'', ''droid'', ''amp'', ''agy'', ''crush'', ''cursor'', ''qwen'', ''copilot'', ''goose'', ''auggie'', ''continue'', ''devin'', ''cline'', ''kimi'', ''muse'', ''kiro'', ''kilocode'', ''vibe'', ''pi'', ''autohand'', ''fake''))',
+    'CHECK (harness IN ('''', ''claude-code'', ''codex'', ''aider'', ''opencode'', ''grok'', ''droid'', ''amp'', ''agy'', ''crush'', ''cursor'', ''qwen'', ''copilot'', ''goose'', ''auggie'', ''continue'', ''devin'', ''cline'', ''kimi'', ''kiro'', ''kilocode'', ''vibe'', ''pi'', ''autohand'', ''fake''))'
+)
+WHERE type = 'table' AND name = 'sessions';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -69,7 +69,7 @@ surface (`npm run sqlc`, `npm run api`).
 - Terminal mux over WebSocket (`/mux`): per-client `tmux attach` PTY on
   Darwin/Linux; conpty loopback pty-host on Windows.
 - Lifecycle reducer plus reaper (`internal/observe/reaper`).
-- Agent adapter platform under `internal/adapters/agent/` (23 adapters) with a
+- Agent adapter platform under `internal/adapters/agent/` (24 adapters) with a
   registry and `ao hooks` activity dispatch.
 - OpenAPI spec generated from Go DTOs; frontend TS types generated from it and
   drift-checked in CI.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1690,7 +1690,7 @@ export interface components {
         };
         DelegateTaskRequest: {
             /** @enum {string} */
-            agent?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand" | "fake";
+            agent?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "muse" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand" | "fake";
             brief: string;
             /** @enum {string} */
             mode?: "tui" | "chat";
@@ -2304,7 +2304,7 @@ export interface components {
             branch?: string;
             displayName?: string;
             /** @enum {string} */
-            harness?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand";
+            harness?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "muse" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand";
             issueId?: string;
             /** @enum {string} */
             kind?: "worker" | "orchestrator";

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -622,6 +622,7 @@ describe("providerScrollsByKeyboard", () => {
 		expect(providerScrollsByKeyboard("opencode")).toBe(true);
 		expect(providerScrollsByKeyboard("kilocode")).toBe(true);
 		expect(providerScrollsByKeyboard("grok")).toBe(true);
+		expect(providerScrollsByKeyboard("muse")).toBe(true);
 	});
 
 	it("is false for mouse-report/native-scroll providers", () => {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -836,9 +836,9 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 // Agents whose full-screen TUI keeps its own transcript and scrolls it only by
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
 // PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard).
-// kilocode is a fork of opencode and shares its TUI surface; grok also uses a
-// full-screen keyboard-scroll TUI, so both scroll the same way.
-const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
+// kilocode is a fork of opencode and shares its TUI surface; grok and Muse Code
+// also use full-screen keyboard-scroll TUIs, so they scroll the same way.
+const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok", "muse"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.
 export function providerScrollsByKeyboard(provider?: string): boolean {

--- a/frontend/src/renderer/lib/agent-options.ts
+++ b/frontend/src/renderer/lib/agent-options.ts
@@ -17,6 +17,7 @@ export const AGENT_OPTIONS = [
 	"devin",
 	"cline",
 	"kimi",
+	"muse",
 	"kiro",
 	"kilocode",
 	"vibe",

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -259,6 +259,7 @@ describe("orchestratorHealth", () => {
 describe("toAgentProvider", () => {
 	it("passes through a known provider", () => {
 		expect(toAgentProvider("opencode")).toBe("opencode");
+		expect(toAgentProvider("muse")).toBe("muse");
 	});
 
 	it("defaults unknown and undefined providers to codex", () => {

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -80,6 +80,7 @@ export type AgentProvider =
 	| "devin"
 	| "cline"
 	| "kimi"
+	| "muse"
 	| "kiro"
 	| "kilocode"
 	| "vibe"
@@ -369,6 +370,7 @@ export function toAgentProvider(provider?: string): AgentProvider {
 		case "devin":
 		case "cline":
 		case "kimi":
+		case "muse":
 		case "kiro":
 		case "kilocode":
 		case "vibe":


### PR DESCRIPTION
## Summary

- add an AO harness for the official Meta Muse Code CLI (`muse`), installed with `curl -fsSL https://dev.meta.ai/install.sh | sh`
- launch the persistent TUI as `muse --trust-workspace [options] [prompt]`, with model and AO permission-mode mapping, workspace-root `AGENTS.md` instructions, and keyboard-based transcript scrolling
- detect only the official CLI by its `Muse Code ...` version signature, and detect Meta auth from `META_API_KEY` or OAuth/API-key state in `MUSE_AUTH_PATH`, `$XDG_CONFIG_HOME/muse/auth.json`, or `~/.config/muse/auth.json`
- register `muse` in the daemon catalog, CLI harness help and doctor checks, frontend picker/types, API schemas, and SQLite harness constraint

## Launch and prompt verification

Verified against the official locally installed Meta launcher and binary, Muse Code `0.1.0 (0.1.0-R708.1)`:

- `muse --help` confirms that no subcommand opens the interactive TUI and an optional positional `PROMPT` starts the session; `muse exec` is the separate headless mode
- `muse init --dry-run` confirms Muse reads workspace-root `AGENTS.md`; a live probe confirmed project rules are skipped unless `--trust-workspace` is supplied
- a detached real TUI session launched with the maintainer's Meta OAuth login, received `Reply with exactly META_MUSE_AO_OK and do not use tools.` as its positional initial prompt, rendered `META_MUSE_AO_OK`, and remained at the interactive prompt
- the PR's real-data Electron daemon resolved the official `~/.local/bin/muse` launcher and returned Muse in both `installed` and `authorized` with `authStatus: authorized`, using `~/.config/muse/auth.json` without logging credential values
- Muse uses a full-screen transcript with keyboard scrolling, so the frontend routes wheel input to PageUp/PageDown for this provider

## Tests

- `cd backend && env -i HOME="$HOME" PATH="$PATH" TMPDIR="${TMPDIR:-/tmp}" go test ./...`
- `cd backend && go test ./internal/adapters/agent/muse ./internal/service/agent`
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs ./internal/adapters/agent/muse/...`
- `cd frontend && npm run typecheck`
