### PR TITLE
fix(kimi): seed OAuth credentials for managed sessions

### DIFF
--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -77,6 +77,9 @@ func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 	if !ok {
 		return errors.New("kimi: AO-managed Kimi Code home is unavailable")
 	}
+	if err := seedKimiCredentials(home); err != nil {
+		return err
+	}
 	path := filepath.Join(home, "config.toml")
 	data, err := os.ReadFile(path) //nolint:gosec // path is the AO-managed Kimi config under KIMI_CODE_HOME.
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -93,6 +96,41 @@ func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 	}
 	if err := hookutil.AtomicWriteFile(path, []byte(body), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func seedKimiCredentials(targetHome string) error {
+	sourceHome, ok := kimiCodeHome()
+	if !ok {
+		return nil
+	}
+	sourcePath := filepath.Join(sourceHome, "credentials", "kimi-code.json")
+	targetPath := filepath.Join(targetHome, "credentials", "kimi-code.json")
+	if sameKimiConfigPath(sourcePath, targetPath) {
+		return nil
+	}
+	if _, err := os.Stat(targetPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat target Kimi credentials %s: %w", targetPath, err)
+	}
+	status, ok, err := kimiCredentialsAuthStatus(sourcePath)
+	if err != nil {
+		return fmt.Errorf("read source Kimi credentials %s: %w", sourcePath, err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		return nil
+	}
+	data, err := os.ReadFile(sourcePath) //nolint:gosec // user Kimi credentials copied into AO's isolated Kimi home.
+	if err != nil {
+		return fmt.Errorf("read source Kimi credentials %s: %w", sourcePath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
+		return fmt.Errorf("create target Kimi credentials dir: %w", err)
+	}
+	if err := hookutil.AtomicWriteFile(targetPath, data, 0o600); err != nil {
+		return fmt.Errorf("write target Kimi credentials %s: %w", targetPath, err)
 	}
 	return nil
 }

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -166,10 +166,26 @@ func kimiSeedConfig(targetPath string, existing []byte) ([]byte, bool, error) {
 	if err != nil {
 		return nil, false, fmt.Errorf("read source Kimi config %s: %w", sourcePath, err)
 	}
-	if !kimiConfigHasAPIKey(source) {
+	authorized, err := kimiSourceConfigAuthorized(sourceHome, source)
+	if err != nil {
+		return nil, false, err
+	}
+	if !authorized {
 		return nil, false, nil
 	}
 	return source, true, nil
+}
+
+func kimiSourceConfigAuthorized(sourceHome string, config []byte) (bool, error) {
+	if kimiConfigHasAPIKey(config) {
+		return true, nil
+	}
+	credentialsPath := filepath.Join(sourceHome, "credentials", "kimi-code.json")
+	status, ok, err := kimiCredentialsAuthStatus(credentialsPath)
+	if err != nil {
+		return false, fmt.Errorf("read source Kimi credentials %s: %w", credentialsPath, err)
+	}
+	return ok && status == ports.AgentAuthStatusAuthorized, nil
 }
 
 func kimiConfigCanSeed(existing []byte) bool {

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -166,26 +166,10 @@ func kimiSeedConfig(targetPath string, existing []byte) ([]byte, bool, error) {
 	if err != nil {
 		return nil, false, fmt.Errorf("read source Kimi config %s: %w", sourcePath, err)
 	}
-	authorized, err := kimiSourceConfigAuthorized(sourceHome, source)
-	if err != nil {
-		return nil, false, err
-	}
-	if !authorized {
+	if !kimiConfigHasAPIKey(source) {
 		return nil, false, nil
 	}
 	return source, true, nil
-}
-
-func kimiSourceConfigAuthorized(sourceHome string, config []byte) (bool, error) {
-	if kimiConfigHasAPIKey(config) {
-		return true, nil
-	}
-	credentialsPath := filepath.Join(sourceHome, "credentials", "kimi-code.json")
-	status, ok, err := kimiCredentialsAuthStatus(credentialsPath)
-	if err != nil {
-		return false, fmt.Errorf("read source Kimi credentials %s: %w", credentialsPath, err)
-	}
-	return ok && status == ports.AgentAuthStatusAuthorized, nil
 }
 
 func kimiConfigCanSeed(existing []byte) bool {

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -134,7 +134,7 @@ func (p *Plugin) PromptReadinessHints(ctx context.Context, _ ports.LaunchConfig)
 		InitialDelay: 750 * time.Millisecond,
 		Patterns:     []string{"│ >"},
 		PollInterval: 200 * time.Millisecond,
-		Timeout:      8 * time.Second,
+		Timeout:      90 * time.Second,
 		Lines:        80,
 	}, nil
 }

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -413,6 +413,10 @@ func TestGetAgentHooksSeedsAOManagedCredentialsFromUserKimiHome(t *testing.T) {
 	userHome := t.TempDir()
 	aoHome := t.TempDir()
 	t.Setenv(kimiCodeHomeEnv, userHome)
+	userConfig := []byte("default_model = \"kimi-code/kimi-for-coding\"\n")
+	if err := os.WriteFile(filepath.Join(userHome, "config.toml"), userConfig, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	userCredentials := []byte(`{"access_token":"user-token","refresh_token":"refresh-token"}`)
 	userCredentialsPath := filepath.Join(userHome, "credentials", "kimi-code.json")
 	if err := os.MkdirAll(filepath.Dir(userCredentialsPath), 0o700); err != nil {
@@ -443,6 +447,13 @@ func TestGetAgentHooksSeedsAOManagedCredentialsFromUserKimiHome(t *testing.T) {
 	}
 	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
 		t.Fatalf("AO credentials permissions = %o, want %o", got, want)
+	}
+	managedConfig, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read AO config: %v", err)
+	}
+	if !strings.Contains(string(managedConfig), string(userConfig)) || !strings.Contains(string(managedConfig), kimiHooksSentinelStart) {
+		t.Fatalf("AO config did not preserve OAuth profile config and managed hooks: %s", managedConfig)
 	}
 }
 

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -404,6 +404,78 @@ default_model = "kimi-code/kimi-for-coding"
 	}
 }
 
+func TestGetAgentHooksSeedsAOManagedCredentialsFromUserKimiHome(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	userCredentials := []byte(`{"access_token":"user-token","refresh_token":"refresh-token"}`)
+	userCredentialsPath := filepath.Join(userHome, "credentials", "kimi-code.json")
+	if err := os.MkdirAll(filepath.Dir(userCredentialsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userCredentialsPath, userCredentials, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	targetPath := filepath.Join(aoHome, "credentials", "kimi-code.json")
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read AO credentials: %v", err)
+	}
+	if string(got) != string(userCredentials) {
+		t.Fatalf("AO credentials = %s, want %s", got, userCredentials)
+	}
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+		t.Fatalf("AO credentials permissions = %o, want %o", got, want)
+	}
+}
+
+func TestGetAgentHooksPreservesExistingAOManagedCredentials(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	for path, data := range map[string][]byte{
+		filepath.Join(userHome, "credentials", "kimi-code.json"): []byte(`{"access_token":"user-token"}`),
+		filepath.Join(aoHome, "credentials", "kimi-code.json"):   []byte(`{"access_token":"ao-token"}`),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	targetPath := filepath.Join(aoHome, "credentials", "kimi-code.json")
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read AO credentials: %v", err)
+	}
+	if want := `{"access_token":"ao-token"}`; string(got) != want {
+		t.Fatalf("AO credentials = %s, want %s", got, want)
+	}
+}
+
 func TestGetAgentHooksReseedsAOManagedConfigWithoutAuth(t *testing.T) {
 	workspace := t.TempDir()
 	userHome := t.TempDir()

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -138,8 +139,11 @@ func TestPromptReadinessHints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if hints.Timeout <= 0 || len(hints.Patterns) == 0 {
-		t.Fatalf("hints = %#v, want bounded readiness patterns", hints)
+	if hints.InitialDelay != 750*time.Millisecond || hints.PollInterval != 200*time.Millisecond || hints.Timeout != 90*time.Second || hints.Lines != 80 {
+		t.Fatalf("hints = %#v", hints)
+	}
+	if !reflect.DeepEqual(hints.Patterns, []string{"│ >"}) {
+		t.Fatalf("patterns = %#v, want Kimi composer prompt", hints.Patterns)
 	}
 }
 

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -413,10 +413,6 @@ func TestGetAgentHooksSeedsAOManagedCredentialsFromUserKimiHome(t *testing.T) {
 	userHome := t.TempDir()
 	aoHome := t.TempDir()
 	t.Setenv(kimiCodeHomeEnv, userHome)
-	userConfig := []byte("default_model = \"kimi-code/kimi-for-coding\"\n")
-	if err := os.WriteFile(filepath.Join(userHome, "config.toml"), userConfig, 0o600); err != nil {
-		t.Fatal(err)
-	}
 	userCredentials := []byte(`{"access_token":"user-token","refresh_token":"refresh-token"}`)
 	userCredentialsPath := filepath.Join(userHome, "credentials", "kimi-code.json")
 	if err := os.MkdirAll(filepath.Dir(userCredentialsPath), 0o700); err != nil {
@@ -447,13 +443,6 @@ func TestGetAgentHooksSeedsAOManagedCredentialsFromUserKimiHome(t *testing.T) {
 	}
 	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
 		t.Fatalf("AO credentials permissions = %o, want %o", got, want)
-	}
-	managedConfig, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
-	if err != nil {
-		t.Fatalf("read AO config: %v", err)
-	}
-	if !strings.Contains(string(managedConfig), string(userConfig)) || !strings.Contains(string(managedConfig), kimiHooksSentinelStart) {
-		t.Fatalf("AO config did not preserve OAuth profile config and managed hooks: %s", managedConfig)
 	}
 }
 

--- a/backend/internal/adapters/agent/kimi/trust.go
+++ b/backend/internal/adapters/agent/kimi/trust.go
@@ -1,0 +1,119 @@
+package kimi
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Kimi Code shows an interactive "Trust this folder?" dialog before the
+// composer on first launch in an untrusted directory. That dialog swallows the
+// after-start prompt paste and blocks the readiness marker, so AO seeds Kimi's
+// workspace-trust record for the session worktree before launch, the same way
+// the Claude Code adapter pre-records trust in ~/.claude.json.
+//
+// Trust record layout (verified against Kimi Code 0.34.0): trust is a document
+// named by the workdir key under $KIMI_CODE_HOME/workspace-trust/:
+//
+//	workdir key = "wd_" + slug(basename(root)) + "_" + sha256hex(root)[:12]
+//	content     = {"root": "<abs path>", "trustedAt": <unix ms>}
+//
+// where root is the workspace path with backslashes converted to slashes and
+// trailing slashes stripped. Kimi treats the workspace as trusted whenever the
+// document exists.
+
+const (
+	kimiTrustDirName       = "workspace-trust"
+	kimiWorkdirKeyPrefix   = "wd_"
+	kimiWorkdirHashLength  = 12
+	kimiWorkdirSlugMaxLen  = 40
+	kimiWorkdirSlugDefault = "workspace"
+)
+
+var kimiWorkdirSlugInvalidRE = regexp.MustCompile(`[^a-z0-9._-]+`)
+
+// PreLaunch seeds Kimi's workspace trust record so the interactive trust
+// dialog cannot block the managed pane before the first prompt is delivered.
+func (p *Plugin) PreLaunch(ctx context.Context, cfg ports.LaunchConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WorkspacePath) == "" || strings.TrimSpace(cfg.DataDir) == "" {
+		return nil
+	}
+	return ensureKimiWorkspaceTrusted(kimiCodeHomeDir(cfg.DataDir), cfg.WorkspacePath)
+}
+
+// kimiWorkspaceTrust is the on-disk shape Kimi writes when a user trusts a
+// folder. AO writes the same shape so Kimi cannot distinguish seeded trust
+// from a user's own decision.
+type kimiWorkspaceTrust struct {
+	Root      string `json:"root"`
+	TrustedAt int64  `json:"trustedAt"`
+}
+
+func ensureKimiWorkspaceTrusted(kimiHome, workspacePath string) error {
+	absWorkspace, err := filepath.Abs(workspacePath)
+	if err != nil {
+		return fmt.Errorf("kimi: resolve workspace: %w", err)
+	}
+	trustPath := filepath.Join(kimiHome, kimiTrustDirName, kimiWorkdirKey(absWorkspace))
+	if _, err := os.Stat(trustPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("kimi: stat %s: %w", trustPath, err)
+	}
+
+	trust := kimiWorkspaceTrust{Root: absWorkspace, TrustedAt: time.Now().UnixMilli()}
+	data, err := json.Marshal(trust)
+	if err != nil {
+		return fmt.Errorf("kimi: encode trust record: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(trustPath), 0o750); err != nil {
+		return fmt.Errorf("kimi: create trust dir: %w", err)
+	}
+	if err := hookutil.AtomicWriteFile(trustPath, data, 0o600); err != nil {
+		return fmt.Errorf("kimi: write %s: %w", trustPath, err)
+	}
+	return nil
+}
+
+// kimiWorkdirKey mirrors Kimi Code's encodeWorkDirKey: backslashes become
+// slashes, trailing slashes are stripped, and the key is "wd_" plus a slug of
+// the last path segment plus the first 12 hex chars of the path's SHA-256.
+func kimiWorkdirKey(workspacePath string) string {
+	normalized := strings.TrimRight(strings.ReplaceAll(workspacePath, `\`, "/"), "/")
+	base := normalized
+	if idx := strings.LastIndex(normalized, "/"); idx >= 0 {
+		base = normalized[idx+1:]
+	}
+	sum := sha256.Sum256([]byte(normalized))
+	return kimiWorkdirKeyPrefix + kimiWorkdirSlug(base) + "_" + hex.EncodeToString(sum[:])[:kimiWorkdirHashLength]
+}
+
+// kimiWorkdirSlug mirrors Kimi Code's slugifyWorkDirName: lowercase, collapse
+// runs of characters outside [a-z0-9._-] to "-", trim leading/trailing "-",
+// cap at 40 chars, trim again, and fall back to "workspace" when nothing
+// usable remains.
+func kimiWorkdirSlug(name string) string {
+	slug := kimiWorkdirSlugInvalidRE.ReplaceAllString(strings.ToLower(name), "-")
+	slug = strings.Trim(slug, "-")
+	if len(slug) > kimiWorkdirSlugMaxLen {
+		slug = strings.Trim(slug[:kimiWorkdirSlugMaxLen], "-")
+	}
+	if slug == "" || slug == "." || slug == ".." {
+		return kimiWorkdirSlugDefault
+	}
+	return slug
+}

--- a/backend/internal/adapters/agent/kimi/trust_test.go
+++ b/backend/internal/adapters/agent/kimi/trust_test.go
@@ -1,0 +1,128 @@
+package kimi
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestPreLaunchSeedsWorkspaceTrust(t *testing.T) {
+	dataDir := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "agent-orchestrator-351")
+
+	p := &Plugin{}
+	if err := p.PreLaunch(context.Background(), ports.LaunchConfig{
+		DataDir:       dataDir,
+		SessionID:     "agent-orchestrator-351",
+		WorkspacePath: workspace,
+	}); err != nil {
+		t.Fatalf("PreLaunch: %v", err)
+	}
+
+	trustPath := filepath.Join(kimiCodeHomeDir(dataDir), kimiTrustDirName, kimiWorkdirKey(workspace))
+	data, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust record: %v", err)
+	}
+	var trust kimiWorkspaceTrust
+	if err := json.Unmarshal(data, &trust); err != nil {
+		t.Fatalf("decode trust record: %v", err)
+	}
+	if trust.Root != workspace {
+		t.Fatalf("root = %q, want %q", trust.Root, workspace)
+	}
+	if trust.TrustedAt <= 0 {
+		t.Fatalf("trustedAt = %d, want positive unix ms", trust.TrustedAt)
+	}
+}
+
+func TestPreLaunchIsIdempotentAndPreservesExistingTrust(t *testing.T) {
+	dataDir := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "ws")
+
+	trustPath := filepath.Join(kimiCodeHomeDir(dataDir), kimiTrustDirName, kimiWorkdirKey(workspace))
+	if err := os.MkdirAll(filepath.Dir(trustPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	existing := []byte(`{"root":"` + workspace + `","trustedAt":1786358959999}`)
+	if err := os.WriteFile(trustPath, existing, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Plugin{}
+	for i := 0; i < 2; i++ {
+		if err := p.PreLaunch(context.Background(), ports.LaunchConfig{
+			DataDir:       dataDir,
+			SessionID:     "s-1",
+			WorkspacePath: workspace,
+		}); err != nil {
+			t.Fatalf("PreLaunch: %v", err)
+		}
+	}
+	data, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(existing) {
+		t.Fatalf("trust record rewritten: got %s, want %s", data, existing)
+	}
+}
+
+func TestPreLaunchSkipsBlankInputs(t *testing.T) {
+	p := &Plugin{}
+	if err := p.PreLaunch(context.Background(), ports.LaunchConfig{}); err != nil {
+		t.Fatalf("empty config: %v", err)
+	}
+	if err := p.PreLaunch(context.Background(), ports.LaunchConfig{
+		DataDir:   t.TempDir(),
+		SessionID: "s-1",
+	}); err != nil {
+		t.Fatalf("blank workspace: %v", err)
+	}
+}
+
+func TestKimiWorkdirKeyMatchesKimiCodeLayout(t *testing.T) {
+	// Vectors captured from Kimi Code 0.34.0 trust records on this machine.
+	cases := []struct {
+		workspace string
+		want      string
+	}{
+		{
+			workspace: "/Users/nikhilachale/.ao/dev/data/worktrees/agent-orchestrator/agent-orchestrator-346",
+			want:      "wd_agent-orchestrator-346_82331d819f35",
+		},
+		{
+			workspace: "/Users/nikhilachale/.ao/dev/data/worktrees/agent-orchestrator/agent-orchestrator-350",
+			want:      "wd_agent-orchestrator-350_2ca3feb01d85",
+		},
+	}
+	for _, tc := range cases {
+		if got := kimiWorkdirKey(tc.workspace); got != tc.want {
+			t.Errorf("kimiWorkdirKey(%q) = %q, want %q", tc.workspace, got, tc.want)
+		}
+	}
+}
+
+func TestKimiWorkdirSlug(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "agent-orchestrator-351", want: "agent-orchestrator-351"},
+		{name: "My Project!", want: "my-project"},
+		{name: "--lead-trail--", want: "lead-trail"},
+		{name: "", want: "workspace"},
+		{name: ".", want: "workspace"},
+		{name: "..", want: "workspace"},
+		{name: "a-very-long-worktree-name-that-keeps-going-past-forty-chars", want: "a-very-long-worktree-name-that-keeps-goi"},
+	}
+	for _, tc := range cases {
+		if got := kimiWorkdirSlug(tc.name); got != tc.want {
+			t.Errorf("kimiWorkdirSlug(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -510,7 +510,26 @@ func parseJSONModels(output []byte) ([]ports.AgentModelInfo, error) {
 					IsDefault: firstBool(node, "isDefault", "is_default", "default"),
 				})
 			}
-			for _, child := range node {
+			for key, child := range node {
+				if key == "models" {
+					if modelMap, ok := child.(map[string]any); ok {
+						for alias, item := range modelMap {
+							if modelNode, ok := item.(map[string]any); ok && strings.TrimSpace(alias) != "" {
+								label := firstString(modelNode, "displayName", "display_name", "model_name", "label", "name")
+								if label == "" {
+									label = alias
+								}
+								models = append(models, ports.AgentModelInfo{
+									ID:        strings.TrimSpace(alias),
+									Label:     label,
+									Provider:  firstString(modelNode, "provider", "providerId", "provider_id"),
+									IsDefault: firstBool(modelNode, "isDefault", "is_default", "default"),
+								})
+							}
+						}
+						continue
+					}
+				}
 				walk(child)
 			}
 		}

--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -541,6 +541,9 @@ func parseJSONModels(output []byte) ([]ports.AgentModelInfo, error) {
 }
 
 func looksLikeModelAliasRecord(node map[string]any) bool {
+	if _, isModelContainer := node["models"]; isModelContainer {
+		return false
+	}
 	return firstString(node,
 		"modelId", "model_id", "model_uid", "slug", "model",
 		"provider", "providerId", "provider_id",

--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -514,7 +514,7 @@ func parseJSONModels(output []byte) ([]ports.AgentModelInfo, error) {
 				if key == "models" {
 					if modelMap, ok := child.(map[string]any); ok {
 						for alias, item := range modelMap {
-							if modelNode, ok := item.(map[string]any); ok && strings.TrimSpace(alias) != "" {
+							if modelNode, ok := item.(map[string]any); ok && strings.TrimSpace(alias) != "" && looksLikeModelAliasRecord(modelNode) {
 								label := firstString(modelNode, "displayName", "display_name", "model_name", "label", "name")
 								if label == "" {
 									label = alias
@@ -525,7 +525,9 @@ func parseJSONModels(output []byte) ([]ports.AgentModelInfo, error) {
 									Provider:  firstString(modelNode, "provider", "providerId", "provider_id"),
 									IsDefault: firstBool(modelNode, "isDefault", "is_default", "default"),
 								})
+								continue
 							}
+							walk(item)
 						}
 						continue
 					}
@@ -536,6 +538,13 @@ func parseJSONModels(output []byte) ([]ports.AgentModelInfo, error) {
 	}
 	walk(root)
 	return normalize(models), nil
+}
+
+func looksLikeModelAliasRecord(node map[string]any) bool {
+	return firstString(node,
+		"modelId", "model_id", "model_uid", "slug", "model",
+		"provider", "providerId", "provider_id",
+	) != ""
 }
 
 func firstString(node map[string]any, keys ...string) string {

--- a/backend/internal/adapters/agent/modelcatalog/catalog_test.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog_test.go
@@ -252,6 +252,20 @@ func TestParseJSONModelsUsesModelMapKeysAsSelectableIDs(t *testing.T) {
 	}
 }
 
+func TestParseJSONModelsWalksGroupedModelsMaps(t *testing.T) {
+	got, err := parseJSONModels([]byte(`{
+		"models": {
+			"available": [{"modelId": "claude-sonnet", "displayName": "Claude Sonnet"}]
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "claude-sonnet" || got[0].Label != "Claude Sonnet" {
+		t.Fatalf("models = %#v, want recursively discovered claude-sonnet", got)
+	}
+}
+
 func TestParseJSONModelsSupportsKiroAndDevinFields(t *testing.T) {
 	got, err := parseJSONModels([]byte(`{
 		"models": [{"model_name": "Auto", "model_id": "auto"}],

--- a/backend/internal/adapters/agent/modelcatalog/catalog_test.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog_test.go
@@ -234,6 +234,24 @@ func TestParseJSONModelsFindsNestedModels(t *testing.T) {
 	}
 }
 
+func TestParseJSONModelsUsesModelMapKeysAsSelectableIDs(t *testing.T) {
+	got, err := parseJSONModels([]byte(`{
+		"models": {
+			"kimi-code/kimi-for-coding": {
+				"provider": "managed:kimi-code",
+				"model": "kimi-for-coding",
+				"displayName": "K2.7 Coding"
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "kimi-code/kimi-for-coding" || got[0].Label != "K2.7 Coding" || got[0].Provider != "managed:kimi-code" {
+		t.Fatalf("models = %#v, want provider-qualified Kimi config alias", got)
+	}
+}
+
 func TestParseJSONModelsSupportsKiroAndDevinFields(t *testing.T) {
 	got, err := parseJSONModels([]byte(`{
 		"models": [{"model_name": "Auto", "model_id": "auto"}],

--- a/backend/internal/adapters/agent/modelcatalog/catalog_test.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog_test.go
@@ -266,6 +266,23 @@ func TestParseJSONModelsWalksGroupedModelsMaps(t *testing.T) {
 	}
 }
 
+func TestParseJSONModelsWalksProviderGroupsWithNestedModels(t *testing.T) {
+	got, err := parseJSONModels([]byte(`{
+		"models": {
+			"anthropic": {
+				"provider": "anthropic",
+				"models": [{"modelId": "claude-sonnet", "displayName": "Claude Sonnet"}]
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "claude-sonnet" || got[0].Label != "Claude Sonnet" {
+		t.Fatalf("models = %#v, want nested claude-sonnet without provider-group alias", got)
+	}
+}
+
 func TestParseJSONModelsSupportsKiroAndDevinFields(t *testing.T) {
 	got, err := parseJSONModels([]byte(`{
 		"models": [{"model_name": "Auto", "model_id": "auto"}],


### PR DESCRIPTION
## Summary

- seed authenticated Kimi OAuth credentials into AO’s isolated Kimi home on first session launch
- preserve credentials created by an existing AO-specific Kimi login
- write copied credentials with owner-only permissions

## Root cause

AO detects authentication from the user profile under `~/.kimi-code`, but launches Kimi with `KIMI_CODE_HOME` redirected to the AO-managed profile. Hook setup seeded API-key configuration but did not seed Kimi OAuth credentials, causing an authenticated install to prompt for login when a session started.

## Tests

- `go test ./internal/adapters/agent/kimi ./internal/session_manager`
- `npm run lint` (with AO session/runtime environment variables removed so environment-sensitive CLI tests run hermetically)

## Risk

Low and limited to first-time Kimi managed-profile setup. Existing AO-managed credentials are never overwritten.