### PR TITLE
fix(browser-annotation): remove keyboard shortcut hint text from prompt

### DIFF
--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -198,8 +198,7 @@ describe("annotate preload", () => {
 		expect(fontMocks.add).toHaveBeenCalledTimes(2);
 		expect(form).toHaveAttribute("aria-label", "Annotate selection");
 		expect(root.querySelector(".prompt__meta")).toBeNull();
-		expect(root.querySelector(".prompt__shortcuts")?.textContent).toContain("⌘/Ctrl+EnterSend");
-		expect(root.querySelector(".prompt__shortcuts")?.textContent).toContain("EscCancel");
+		expect(root.querySelector(".prompt__shortcuts")).toBeNull();
 		expect(root.querySelector('[data-action="cancel"]')).toBeNull();
 		expect(primaryAction).toBeTruthy();
 		expect(primaryAction).toHaveAttribute("aria-label", "Send annotation");

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -348,39 +348,6 @@ function ensureOverlay(): ShadowRoot {
 			.prompt textarea::placeholder {
 				color: var(--ao-passive);
 			}
-			.prompt__shortcuts {
-				position: absolute;
-				left: 13px;
-				bottom: 10px;
-				display: flex;
-				align-items: center;
-				gap: 13px;
-				color: var(--ao-passive);
-				font-size: 10px;
-				line-height: 1;
-				pointer-events: none;
-			}
-			.prompt__shortcut {
-				display: inline-flex;
-				align-items: center;
-				gap: 4px;
-				white-space: nowrap;
-			}
-			.prompt__shortcut kbd {
-				display: inline-flex;
-				min-width: 18px;
-				height: 18px;
-				box-sizing: border-box;
-				align-items: center;
-				justify-content: center;
-				border: 1px solid color-mix(in oklch, var(--ao-border) 85%, transparent);
-				border-radius: 5px;
-				background: var(--ao-input);
-				color: color-mix(in oklch, var(--ao-foreground) 72%, transparent);
-				padding: 0 5px;
-				font: 9px/1 var(--ao-font-mono);
-				box-shadow: inset 0 -1px 0 color-mix(in oklch, var(--ao-border) 80%, transparent);
-			}
 			.prompt button[type="submit"] {
 				position: absolute;
 				right: 8px;
@@ -554,10 +521,6 @@ function openPrompt(
 	mount.innerHTML = `
 		<form class="prompt" aria-label="Annotate selection">
 			<textarea rows="1" aria-label="Annotation request" placeholder="Describe the change…"></textarea>
-			<div class="prompt__shortcuts" aria-hidden="true">
-				<span class="prompt__shortcut"><kbd>⌘/Ctrl</kbd><span>+</span><kbd>Enter</kbd><span>Send</span></span>
-				<span class="prompt__shortcut"><kbd>Esc</kbd><span>Cancel</span></span>
-			</div>
 			<button disabled type="submit" aria-label="Send annotation" title="Send (⌘/Ctrl + Enter)">
 				<svg viewBox="0 0 24 24" aria-hidden="true">
 					<path d="M12 19V5"></path>


### PR DESCRIPTION
## Summary
- Removes the "⌘/Ctrl + Enter Send | Esc Cancel" hint row from the browser annotation prompt overlay, plus its now-unused CSS.
- No functionality changes: the send button, its title attribute, and the Enter/Esc keybindings are all unchanged.

## Test plan
- [x] `npx vitest run src/annotate-preload.test.ts` (26 passed)