### PR TITLE
feat(models): surface Claude Code's configured model, and invalidate the catalog cache on config change

### DIFF
--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -132,6 +133,9 @@ func (Discoverer) Manual(agentID string) ports.AgentModelCatalog { return Manual
 // Discover executes model catalog discovery for an agent binary.
 func Discover(ctx context.Context, agentID, binary, workingDir string, env map[string]string) (ports.AgentModelCatalog, error) {
 	base := Base(agentID)
+	if agentID == "claude-code" {
+		return withClaudeCodeDefault(base, workingDir, env), nil
+	}
 	spec, ok := commandSpecs[agentID]
 	if !ok {
 		return base, nil
@@ -158,6 +162,88 @@ func Discover(ctx context.Context, agentID, binary, workingDir string, env map[s
 	base.Source = "cli"
 	base.FetchedAt = time.Now().UTC()
 	return base, nil
+}
+
+// claudeCodeSettingsReadLimit bounds how much of a settings file AO parses. The
+// documented files are small; a pathological one must not stall discovery.
+const claudeCodeSettingsReadLimit = 1 << 20
+
+// withClaudeCodeDefault flags the model Claude Code will actually run with.
+// Claude Code exposes no non-interactive command that reports its resolved
+// model, but the value it resolves is readable: AO passes no --model, so the
+// choice comes from ANTHROPIC_MODEL or the "model" key in the settings files,
+// nearest scope first. When none of them set a model the CLI picks internally
+// and AO must not guess, so the catalog keeps no default and the picker keeps
+// showing "Agent default".
+func withClaudeCodeDefault(base ports.AgentModelCatalog, workingDir string, env map[string]string) ports.AgentModelCatalog {
+	resolved := claudeCodeResolvedModel(workingDir, env)
+	if resolved == "" {
+		return base
+	}
+	models := make([]ports.AgentModelInfo, len(base.Models))
+	copy(models, base.Models)
+	base.Models = models
+	for i := range base.Models {
+		if strings.EqualFold(base.Models[i].ID, resolved) {
+			base.Models[i].IsDefault = true
+			return base
+		}
+	}
+	// A configured model that is not one of the published aliases (an explicit
+	// snapshot id, or an alias variant such as "opus[1m]") still has to be
+	// selectable, otherwise the picker would show a default it cannot round-trip.
+	base.Models = append(base.Models, model(resolved, resolved, true))
+	return base
+}
+
+// claudeCodeResolvedModel returns the configured Claude Code model, or "" when
+// no scope sets one. Order mirrors Claude Code's own precedence, narrowed to the
+// sources AO can read without running the CLI.
+func claudeCodeResolvedModel(workingDir string, env map[string]string) string {
+	if fromEnv := strings.TrimSpace(env["ANTHROPIC_MODEL"]); fromEnv != "" {
+		return fromEnv
+	}
+	if fromEnv := strings.TrimSpace(os.Getenv("ANTHROPIC_MODEL")); fromEnv != "" {
+		return fromEnv
+	}
+	var candidates []string
+	if dir := strings.TrimSpace(workingDir); dir != "" {
+		candidates = append(candidates,
+			filepath.Join(dir, ".claude", "settings.local.json"),
+			filepath.Join(dir, ".claude", "settings.json"),
+		)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, ".claude", "settings.json"))
+	}
+	for _, candidate := range candidates {
+		if configured := claudeCodeSettingsModel(candidate); configured != "" {
+			return configured
+		}
+	}
+	return ""
+}
+
+// claudeCodeSettingsModel reads one settings file's "model". An unreadable or
+// malformed file is not an error worth surfacing: the picker degrades to no
+// default, exactly as if the key were absent.
+func claudeCodeSettingsModel(path string) string {
+	file, err := os.Open(path) //nolint:gosec // path is derived from the project dir and the user's home
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = file.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(file, claudeCodeSettingsReadLimit))
+	if err != nil {
+		return ""
+	}
+	var settings struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(settings.Model)
 }
 
 func hasDiscoverySource(agentID string) bool {

--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -122,9 +122,12 @@ func (Discoverer) Discover(ctx context.Context, request ports.AgentModelDiscover
 	return Discover(ctx, request.AgentID, request.Binary, request.WorkingDir, request.Env)
 }
 
-// BinaryVersion returns a stable fingerprint for the installed agent binary.
-func (Discoverer) BinaryVersion(ctx context.Context, binary string) string {
-	return BinaryVersion(ctx, binary)
+// CatalogFingerprint returns a stable fingerprint of the discovery inputs: the
+// installed agent binary plus the configuration this adapter reads to build the
+// catalog. Folding configuration in is what lets a settings edit invalidate a
+// cached catalog, since the binary alone does not change when settings do.
+func (Discoverer) CatalogFingerprint(ctx context.Context, request ports.AgentModelDiscoveryRequest) string {
+	return CatalogFingerprint(ctx, request.AgentID, request.Binary, request.WorkingDir, request.Env)
 }
 
 // Manual returns the manual-entry fallback catalog for an agent.
@@ -318,6 +321,34 @@ func BinaryVersion(ctx context.Context, binary string) string {
 	_, _ = hash.Write([]byte{0})
 	_, _ = hash.Write([]byte(strconv.FormatInt(info.ModTime().UnixNano(), 10)))
 	return fmt.Sprintf("%x", hash.Sum(nil)[:8])
+}
+
+// CatalogFingerprint hashes every discovery input for an agent: the resolved
+// executable, plus the configuration values the adapter reads. A cached catalog
+// stays valid only while this is unchanged, so configuration AO reads during
+// discovery must be represented here or an edit would never take effect.
+func CatalogFingerprint(ctx context.Context, agentID, binary, workingDir string, env map[string]string) string {
+	binaryVersion := BinaryVersion(ctx, binary)
+	config := discoveryConfigInputs(agentID, workingDir, env)
+	if config == "" {
+		// Keep the executable-only fingerprint byte-identical to what earlier
+		// daemons wrote, so upgrading does not invalidate every cached catalog.
+		return binaryVersion
+	}
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(binaryVersion))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(config))
+	return fmt.Sprintf("%x", hash.Sum(nil)[:8])
+}
+
+// discoveryConfigInputs returns the configuration an agent's discovery consults,
+// or "" when the catalog depends on the binary alone.
+func discoveryConfigInputs(agentID, workingDir string, env map[string]string) string {
+	if agentID != "claude-code" {
+		return ""
+	}
+	return "model=" + claudeCodeResolvedModel(workingDir, env)
 }
 
 func catalog(agentID, source string, allowCustom bool, at time.Time, models ...ports.AgentModelInfo) ports.AgentModelCatalog {

--- a/backend/internal/adapters/agent/modelcatalog/catalog_test.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog_test.go
@@ -3,6 +3,8 @@ package modelcatalog
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -196,5 +198,132 @@ func TestParseJSONModelsSupportsKiroAndDevinFields(t *testing.T) {
 	}
 	if len(want) != 0 {
 		t.Fatalf("models = %#v, missing %#v", got, want)
+	}
+}
+
+func writeClaudeSettings(t *testing.T, dir, model string) {
+	t.Helper()
+	settingsDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "{}"
+	if model != "" {
+		body = `{"model": "` + model + `"}`
+	}
+	if err := os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func claudeDefaultID(catalog ports.AgentModelCatalog) string {
+	for _, item := range catalog.Models {
+		if item.IsDefault {
+			return item.ID
+		}
+	}
+	return ""
+}
+
+func TestClaudeCodeDiscoveryFlagsTheConfiguredAliasAsDefault(t *testing.T) {
+	t.Setenv("ANTHROPIC_MODEL", "")
+	dir := t.TempDir()
+	writeClaudeSettings(t, dir, "opus")
+
+	got, err := Discover(context.Background(), "claude-code", "", dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id := claudeDefaultID(got); id != "opus" {
+		t.Fatalf("default = %q, want opus (models %#v)", id, got.Models)
+	}
+	if len(got.Models) != 3 {
+		t.Fatalf("models = %#v, want the three published aliases", got.Models)
+	}
+}
+
+func TestClaudeCodeDiscoveryAddsAConfiguredModelOutsideTheAliases(t *testing.T) {
+	t.Setenv("ANTHROPIC_MODEL", "")
+	dir := t.TempDir()
+	writeClaudeSettings(t, dir, "opus[1m]")
+
+	got, err := Discover(context.Background(), "claude-code", "", dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Without the appended entry the picker would name a default it cannot select.
+	if id := claudeDefaultID(got); id != "opus[1m]" {
+		t.Fatalf("default = %q, want opus[1m] (models %#v)", id, got.Models)
+	}
+	if len(got.Models) != 4 {
+		t.Fatalf("models = %#v, want the aliases plus the configured model", got.Models)
+	}
+}
+
+func TestClaudeCodeDiscoveryPrefersNearerScopesAndProjectEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_MODEL", "")
+	dir := t.TempDir()
+	writeClaudeSettings(t, dir, "haiku")
+	local := filepath.Join(dir, ".claude", "settings.local.json")
+	if err := os.WriteFile(local, []byte(`{"model": "sonnet"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Discover(context.Background(), "claude-code", "", dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id := claudeDefaultID(got); id != "sonnet" {
+		t.Fatalf("default = %q, want the local settings model", id)
+	}
+
+	// The project's own environment outranks every settings file.
+	got, err = Discover(context.Background(), "claude-code", "", dir, map[string]string{"ANTHROPIC_MODEL": "haiku"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id := claudeDefaultID(got); id != "haiku" {
+		t.Fatalf("default = %q, want the project env model", id)
+	}
+}
+
+func TestClaudeCodeDiscoveryKeepsNoDefaultWhenNothingConfigured(t *testing.T) {
+	t.Setenv("ANTHROPIC_MODEL", "")
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+	writeClaudeSettings(t, dir, "")
+
+	got, err := Discover(context.Background(), "claude-code", "", dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// AO passes no --model, so the CLI decides. Guessing here would assert a
+	// default AO cannot verify.
+	if id := claudeDefaultID(got); id != "" {
+		t.Fatalf("default = %q, want none", id)
+	}
+	if len(got.Models) != 3 {
+		t.Fatalf("models = %#v, want the three published aliases", got.Models)
+	}
+}
+
+func TestClaudeCodeDiscoveryIgnoresMalformedSettings(t *testing.T) {
+	t.Setenv("ANTHROPIC_MODEL", "")
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+	settingsDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte(`{"model": `), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Discover(context.Background(), "claude-code", "", dir, nil)
+	if err != nil {
+		t.Fatalf("malformed settings must not fail discovery: %v", err)
+	}
+	if id := claudeDefaultID(got); id != "" {
+		t.Fatalf("default = %q, want none", id)
 	}
 }

--- a/backend/internal/adapters/agent/modelcatalog/catalog_test.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog_test.go
@@ -327,3 +327,52 @@ func TestClaudeCodeDiscoveryIgnoresMalformedSettings(t *testing.T) {
 		t.Fatalf("default = %q, want none", id)
 	}
 }
+
+func TestCatalogFingerprintTracksTheConfiguredClaudeCodeModel(t *testing.T) {
+	t.Setenv("ANTHROPIC_MODEL", "")
+	dir := t.TempDir()
+	writeClaudeSettings(t, dir, "opus")
+
+	first := CatalogFingerprint(context.Background(), "claude-code", "", dir, nil)
+	if first == "" {
+		t.Fatal("fingerprint is empty for a configured model")
+	}
+
+	// A settings edit changes the catalog, so it has to change the fingerprint —
+	// otherwise the cached catalog stays authoritative forever.
+	writeClaudeSettings(t, dir, "haiku")
+	second := CatalogFingerprint(context.Background(), "claude-code", "", dir, nil)
+	if second == first {
+		t.Fatalf("fingerprint unchanged (%q) after the configured model changed", second)
+	}
+
+	writeClaudeSettings(t, dir, "opus")
+	if again := CatalogFingerprint(context.Background(), "claude-code", "", dir, nil); again != first {
+		t.Fatalf("fingerprint = %q, want %q for identical inputs", again, first)
+	}
+}
+
+func TestCatalogFingerprintKeepsTheExecutableOnlyValueForConfiglessAgents(t *testing.T) {
+	dir := t.TempDir()
+	writeClaudeSettings(t, dir, "opus")
+	// codex reads no configuration, so its fingerprint must stay byte-identical
+	// to the executable fingerprint earlier daemons cached under.
+	got := CatalogFingerprint(context.Background(), "codex", "codex", dir, nil)
+	if want := BinaryVersion(context.Background(), "codex"); got != want {
+		t.Fatalf("fingerprint = %q, want the executable fingerprint %q", got, want)
+	}
+}
+
+func TestCatalogFingerprintDistinguishesConfiguredFromUnconfigured(t *testing.T) {
+	t.Setenv("ANTHROPIC_MODEL", "")
+	t.Setenv("HOME", t.TempDir())
+	unset := t.TempDir()
+	writeClaudeSettings(t, unset, "")
+	configured := t.TempDir()
+	writeClaudeSettings(t, configured, "opus")
+
+	if CatalogFingerprint(context.Background(), "claude-code", "", unset, nil) ==
+		CatalogFingerprint(context.Background(), "claude-code", "", configured, nil) {
+		t.Fatal("configuring a model must change the fingerprint")
+	}
+}

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -137,11 +137,16 @@ type AgentModelDiscoveryRequest struct {
 	Env        map[string]string
 }
 
-// AgentModelDiscoverer isolates CLI execution and executable fingerprinting
-// from the core agent service.
+// AgentModelDiscoverer isolates CLI execution and discovery-input
+// fingerprinting from the core agent service.
 type AgentModelDiscoverer interface {
 	Discover(ctx context.Context, request AgentModelDiscoveryRequest) (AgentModelCatalog, error)
-	BinaryVersion(ctx context.Context, binary string) string
+	// CatalogFingerprint summarizes every input a discovery run would read: the
+	// resolved executable plus any configuration the adapter consults. The
+	// service compares it against the cached catalog's fingerprint, so it must
+	// change whenever the catalog those inputs produce would change, and it must
+	// stay cheap enough to compute before deciding to skip discovery.
+	CatalogFingerprint(ctx context.Context, request AgentModelDiscoveryRequest) string
 	Manual(agentID string) AgentModelCatalog
 }
 

--- a/backend/internal/service/agent/catalog_test.go
+++ b/backend/internal/service/agent/catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -66,11 +67,13 @@ type fakeProjectLookup struct {
 }
 
 type fakeModelDiscoverer struct {
-	version       string
-	catalog       ports.AgentModelCatalog
-	err           error
-	discoverCalls atomic.Int32
-	lastRequest   ports.AgentModelDiscoveryRequest
+	version                string
+	catalog                ports.AgentModelCatalog
+	err                    error
+	discoverCalls          atomic.Int32
+	lastRequest            ports.AgentModelDiscoveryRequest
+	fingerprintRequests    atomic.Int32
+	lastFingerprintRequest atomic.Pointer[ports.AgentModelDiscoveryRequest]
 }
 
 func (f *fakeModelDiscoverer) Discover(_ context.Context, request ports.AgentModelDiscoveryRequest) (ports.AgentModelCatalog, error) {
@@ -89,7 +92,11 @@ func (f *fakeModelDiscoverer) Discover(_ context.Context, request ports.AgentMod
 	return catalog, f.err
 }
 
-func (f *fakeModelDiscoverer) BinaryVersion(context.Context, string) string { return f.version }
+func (f *fakeModelDiscoverer) CatalogFingerprint(_ context.Context, request ports.AgentModelDiscoveryRequest) string {
+	f.fingerprintRequests.Add(1)
+	f.lastFingerprintRequest.Store(&request)
+	return f.version
+}
 
 func (f *fakeModelDiscoverer) Manual(agentID string) ports.AgentModelCatalog {
 	return ports.AgentModelCatalog{
@@ -806,5 +813,40 @@ func harnessAuthAgent(id, label string, status ports.AgentAuthStatus, err error)
 			Name: label,
 		},
 		Agent: fakeAuthAgent{fakeAgent: fakeAgent{}, status: status, authErr: err},
+	}
+}
+
+func TestModelsFingerprintsTheSameInputsDiscoveryReads(t *testing.T) {
+	projects := &fakeProjectLookup{records: map[string]domain.ProjectRecord{
+		"proj-1": {
+			ID:     "proj-1",
+			Path:   "/work/project",
+			Config: domain.ProjectConfig{Env: map[string]string{"ANTHROPIC_MODEL": "opus"}},
+		},
+	}}
+	discoverer := &fakeModelDiscoverer{version: "v1", catalog: ports.AgentModelCatalog{
+		SelectionMode: ports.ModelSelectionCatalog,
+		Models:        []ports.AgentModelInfo{{ID: "opus"}},
+		Source:        "official-aliases",
+	}}
+	svc := newService([]agentregistry.HarnessAgent{
+		harnessAgent("claude-code", "Claude Code", nil),
+	}, &fakeModelCache{}, projects, discoverer)
+
+	if _, err := svc.Models(context.Background(), "claude-code", "proj-1", false); err != nil {
+		t.Fatal(err)
+	}
+	// The cache decision runs before discovery, so it must be able to see the
+	// configuration discovery would read. Fingerprinting a narrower input than
+	// Discover consumes is what let a settings edit go unnoticed.
+	fingerprinted := discoverer.lastFingerprintRequest.Load()
+	if fingerprinted == nil {
+		t.Fatal("catalog fingerprint was never requested")
+	}
+	if !reflect.DeepEqual(*fingerprinted, discoverer.lastRequest) {
+		t.Fatalf("fingerprint request = %#v, want the discovery request %#v", *fingerprinted, discoverer.lastRequest)
+	}
+	if fingerprinted.WorkingDir != "/work/project" || fingerprinted.Env["ANTHROPIC_MODEL"] != "opus" {
+		t.Fatalf("fingerprint request = %#v, want the project working dir and env", *fingerprinted)
 	}
 }

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -308,15 +308,18 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 			binary = resolved
 		}
 	}
-	version := s.discoverer.BinaryVersion(ctx, binary)
+	request := ports.AgentModelDiscoveryRequest{
+		AgentID: agentID, Binary: binary, WorkingDir: discovery.workingDir, Env: discovery.env,
+	}
+	// Fingerprints the same inputs the discovery run would read, so a change to
+	// either the executable or the configuration behind it invalidates the cache.
+	version := s.discoverer.CatalogFingerprint(ctx, request)
 	if hasCached && mode != modelLoadRefresh && cached.BinaryVersion == version {
 		cached.Catalog.RefreshRecommended = false
 		return cached.Catalog, nil
 	}
 
-	discovered, discoverErr := s.discoverer.Discover(ctx, ports.AgentModelDiscoveryRequest{
-		AgentID: agentID, Binary: binary, WorkingDir: discovery.workingDir, Env: discovery.env,
-	})
+	discovered, discoverErr := s.discoverer.Discover(ctx, request)
 	discovered.BinaryVersion = version
 	discovered.ValidatedAt = time.Now().UTC()
 	discovered.RefreshRecommended = false


### PR DESCRIPTION
Stacked on #3653 — targets `ao/agent-orchestrator-1-46/new-task-default-agent`, review/merge that one first.

## Summary

#3653 makes the New task modal preselect the model an agent will actually use. Codex fills in, Claude Code does not: `modelcatalog.Base` flags none of `sonnet`/`opus`/`haiku` as default, so there is nothing to preselect and the field falls back to `Agent default`.

Two commits:

**1. Surface the configured model.** Claude Code exposes no non-interactive command that reports a resolved model — but the value it resolves is readable. AO passes no `--model`, so the choice comes from `ANTHROPIC_MODEL` or the `model` key in the settings files. Discovery now reads that value and flags it, nearest scope first:

1. the project's configured env (`ANTHROPIC_MODEL`)
2. process `ANTHROPIC_MODEL`
3. `<project>/.claude/settings.local.json`
4. `<project>/.claude/settings.json`
5. `~/.claude/settings.json`

A configured model outside the three published aliases (an explicit snapshot id, or a variant such as `opus[1m]`) is appended to the catalog, otherwise the picker would name a default it cannot round-trip. **When no scope sets a model, the catalog keeps no default** — the CLI decides, and asserting a guess would be a claim AO cannot verify.

**2. Make the cache honor it.** The cached catalog was keyed on the agent executable alone, so a settings edit could never invalidate it — the stale catalog stayed authoritative until the binary changed or the user pressed "Refresh models". The discoverer's `BinaryVersion(ctx, binary)` becomes `CatalogFingerprint(ctx, request)` over the same request `Discover` receives, so the cache decision — which by design runs *before* discovery — can see the configuration discovery would read. Agents that consult no configuration still return the bare executable fingerprint, so upgrading does not invalidate every cached catalog. This matches what `AgentModelCatalog.BinaryVersion` already documented itself as: "the legacy wire name for AO's non-sensitive executable **and configuration** metadata fingerprint."

## Tests

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test ./internal/adapters/... ./internal/service/... ./internal/httpd/...` passes.
- modelcatalog: configured alias flagged; out-of-alias value appended and flagged; local settings beat project settings and project env beats both; nothing configured leaves no default; malformed settings degrade to no default instead of failing discovery; fingerprint changes when the configured model changes and returns to its prior value for identical inputs; config-less agents keep the byte-identical executable fingerprint.
- service: the fingerprint request is deep-equal to the discovery request, carrying the project working dir and env — the invariant whose absence caused the staleness.
- **Verified live** against a dev daemon, without touching Refresh models:

  | step | fingerprint | default |
  |---|---|---|
  | baseline (`~/.claude/settings.json`) | `7a1bd55a1cf77e24` | `opus[1m]` |
  | wrote `<project>/.claude/settings.json` = haiku | `fa61532e84d9aa62` | `haiku` |
  | removed it again | `7a1bd55a1cf77e24` | `opus[1m]` |

Pre-existing, unrelated: `adapters/agent/kilocode`, `adapters/agent/opencode`, `adapters/agent/fake`, and `internal/cli` fail on this machine (CLI tests reach the live local daemon; two timing/probe tests). Same failures on a clean tree.

## Risks / follow-ups

- `CatalogFingerprint` replaces `BinaryVersion` on the `AgentModelDiscoverer` port. One production implementation and one test fake; no wire or storage change (the persisted column keeps its legacy name).
- Reading `~/.claude/settings.json` is a new (read-only, size-bounded) filesystem touch on claude-code discovery, now also on the cache-check path. Only the `model` key is parsed; nothing is logged.
- Enterprise-managed policy settings, which outrank user settings in Claude Code's own precedence, are not consulted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)