### PR TITLE
feat(agent): add Oh My Pi (omp) agent adapter

### DIFF
--- a/backend/internal/adapters/agent/omp/auth.go
+++ b/backend/internal/adapters/agent/omp/auth.go
@@ -1,0 +1,133 @@
+package omp
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+
+	_ "modernc.org/sqlite" // register sqlite driver for the OMP agent.db credential probe
+)
+
+var _ ports.AgentAuthChecker = (*Plugin)(nil)
+
+// ompAPIKeyEnvVars mirrors the provider API-key env vars OMP itself resolves
+// credentials from (see environment-variables.md); any one present is a fast,
+// definite "authorized" signal without touching agent.db.
+var ompAPIKeyEnvVars = []string{
+	"ANTHROPIC_API_KEY",
+	"OPENAI_API_KEY",
+	"GEMINI_API_KEY",
+	"GOOGLE_API_KEY",
+	"OPENROUTER_API_KEY",
+	"XAI_API_KEY",
+	"DEEPSEEK_API_KEY",
+	"GROQ_API_KEY",
+	"MISTRAL_API_KEY",
+	"CEREBRAS_API_KEY",
+	"FIREWORKS_API_KEY",
+	"TOGETHER_API_KEY",
+}
+
+// AuthStatus checks whether OMP has at least one enabled credential, without
+// making a model call. It checks provider API-key env vars first, then the
+// local agent.db credential store (multi-provider, multi-credential; see
+// session.md/porting-from-pi-mono.md), falling back to a generic CLI probe.
+func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
+	binary, err := p.ompBinary(ctx)
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	}
+
+	for _, name := range ompAPIKeyEnvVars {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return ports.AgentAuthStatusAuthorized, nil
+		}
+	}
+
+	if status, ok, err := ompDBAuthStatus(ctx); err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	} else if ok {
+		return status, nil
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	return authprobe.CLIStatus(probeCtx, binary, [][]string{{"auth-broker", "status"}})
+}
+
+// ompConfigDir returns OMP's agent directory: PI_CODING_AGENT_DIR verbatim
+// when set (full override, default profile only), else
+// $HOME/<PI_CONFIG_DIR or .omp>/agent.
+func ompConfigDir() (string, bool) {
+	if dir := strings.TrimSpace(os.Getenv("PI_CODING_AGENT_DIR")); dir != "" {
+		return dir, true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", false
+	}
+	root := strings.TrimSpace(os.Getenv("PI_CONFIG_DIR"))
+	if root == "" {
+		root = ".omp"
+	}
+	return filepath.Join(home, root, "agent"), true
+}
+
+// ompDBAuthStatus opens agent.db read-only and reports whether at least one
+// credential row has no disabled_cause. A missing file/table (older or
+// relocated OMP install) is reported as "not determined" (ok=false) rather
+// than unauthorized, so callers fall back to the generic CLI probe instead of
+// asserting a negative from an absent database.
+func ompDBAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	configDir, ok := ompConfigDir()
+	if !ok {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	dbPath := filepath.Join(configDir, "agent.db")
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return ports.AgentAuthStatusUnknown, false, nil
+	} else if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+
+	db, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro&_pragma=busy_timeout(1000)")
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	var enabledCount int
+	err = db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM auth_credentials WHERE disabled_cause IS NULL`,
+	).Scan(&enabledCount)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table") {
+			return ports.AgentAuthStatusUnknown, false, nil
+		}
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if enabledCount > 0 {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
+
+	var totalCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM auth_credentials`).Scan(&totalCount); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if totalCount > 0 {
+		// Rows exist but every one is disabled (all disabled_cause set).
+		return ports.AgentAuthStatusUnauthorized, true, nil
+	}
+	return ports.AgentAuthStatusUnauthorized, true, nil
+}

--- a/backend/internal/adapters/agent/omp/auth_test.go
+++ b/backend/internal/adapters/agent/omp/auth_test.go
@@ -1,0 +1,150 @@
+package omp
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestOMPDBAuthStatusAuthorizedWithEnabledCredential(t *testing.T) {
+	dbPath := writeAuthCredentialsDB(t, []authCredentialRow{
+		{provider: "anthropic", disabledCause: ""},
+	})
+	t.Setenv("PI_CODING_AGENT_DIR", filepath.Dir(dbPath))
+
+	status, ok, err := ompDBAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestOMPDBAuthStatusUnauthorizedWhenAllDisabled(t *testing.T) {
+	dbPath := writeAuthCredentialsDB(t, []authCredentialRow{
+		{provider: "anthropic", disabledCause: "revoked"},
+	})
+	t.Setenv("PI_CODING_AGENT_DIR", filepath.Dir(dbPath))
+
+	status, ok, err := ompDBAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusUnauthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	}
+}
+
+func TestOMPDBAuthStatusUnauthorizedWhenEmpty(t *testing.T) {
+	dbPath := writeAuthCredentialsDB(t, nil)
+	t.Setenv("PI_CODING_AGENT_DIR", filepath.Dir(dbPath))
+
+	status, ok, err := ompDBAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusUnauthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	}
+}
+
+func TestOMPDBAuthStatusUnknownWhenMissing(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
+
+	status, ok, err := ompDBAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestOMPDBAuthStatusUnknownWhenSchemaUnrecognized(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "agent.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE some_other_table (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PI_CODING_AGENT_DIR", dir)
+
+	status, ok, err := ompDBAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false) on schema mismatch", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestAuthStatusEnvVarFastPath(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+
+	p := &Plugin{resolvedBinary: "omp"}
+	status, err := p.AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+type authCredentialRow struct {
+	provider      string
+	disabledCause string
+}
+
+// writeAuthCredentialsDB creates an agent.db-shaped sqlite file matching the
+// real OMP auth_credentials schema and returns its path.
+func writeAuthCredentialsDB(t *testing.T, rows []authCredentialRow) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "agent.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	if _, err := db.Exec(`
+		CREATE TABLE auth_credentials (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			provider TEXT NOT NULL,
+			credential_type TEXT NOT NULL,
+			data TEXT NOT NULL,
+			disabled_cause TEXT DEFAULT NULL,
+			identity_key TEXT DEFAULT NULL,
+			created_at INTEGER NOT NULL DEFAULT 0,
+			updated_at INTEGER NOT NULL DEFAULT 0
+		)
+	`); err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		var disabledCause any
+		if row.disabledCause != "" {
+			disabledCause = row.disabledCause
+		}
+		if _, err := db.Exec(
+			`INSERT INTO auth_credentials (provider, credential_type, data, disabled_cause) VALUES (?, ?, ?, ?)`,
+			row.provider, "api_key", `{"key":"test"}`, disabledCause,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dbPath
+}

--- a/backend/internal/adapters/agent/omp/install.go
+++ b/backend/internal/adapters/agent/omp/install.go
@@ -1,0 +1,8 @@
+package omp
+
+import "context"
+
+// ResolveBinary resolves the executable path for the plugin.
+func (p *Plugin) ResolveBinary(ctx context.Context) (string, error) {
+	return p.ompBinary(ctx)
+}

--- a/backend/internal/adapters/agent/omp/omp.go
+++ b/backend/internal/adapters/agent/omp/omp.go
@@ -1,0 +1,238 @@
+// Package omp implements the Oh My Pi agent adapter: launching new
+// interactive OMP sessions, resuming sessions by native session id, and
+// mapping AO's permission modes onto OMP's approval-mode flags.
+//
+// Oh My Pi ("@oh-my-pi/pi-coding-agent", binary "omp") is a terminal coding
+// harness distinct from the "pi" adapter already shipped by AO ("pi",
+// "@earendil-works/pi-coding-agent") — OMP is a downstream fork/successor of
+// that CLI, but the binaries, flags, and session-storage layout have diverged
+// enough that OMP needs its own adapter rather than reusing pi's. AO runs OMP
+// interactively in the session terminal pane. The initial prompt is delivered
+// in-command as a trailing positional message; like pi, OMP's argument parser
+// treats a leading "-" on that positional as a flag, so AO relies on prompts
+// not beginning with "-".
+//
+// System prompts: OMP's `--append-system-prompt` flag documents that it
+// accepts either literal text or file contents. AO reads SystemPromptFile
+// itself and inlines the text (matching the pi/codex adapters) instead of
+// relying on OMP's own file-vs-text detection, so a read failure aborts the
+// launch instead of silently passing a path OMP may not resolve.
+//
+// Permissions: OMP sessions run headlessly inside AO's terminal pane, so a
+// mode that leaves `exec`-tier tools prompting would hang forever with nobody
+// to click approve (see the identical rationale in the codex adapter). OMP's
+// `tools.approvalMode` has three tiers (`always-ask`, `write`, `yolo`) plus a
+// `--auto-approve` flag that force-overrides to yolo regardless of project
+// config:
+//   - default / auto  -> `--approval-mode yolo` (headless-safe; matches OMP's
+//     own schema default)
+//   - accept-edits     -> `--approval-mode write` (auto-approves read+write,
+//     still prompts exec — same semantics as Claude Code's acceptEdits)
+//   - bypass-permissions -> `--auto-approve` (forces yolo, overriding any
+//     project-level approvalMode)
+//
+// Restore: OMP persists sessions under
+// ~/.omp/agent/sessions/<scope>-<project>-<hash>/<timestamp>_<id>.jsonl and
+// resumes by id with `-r/--resume <id>` (accepts an id prefix). GetRestoreCommand
+// builds that command whenever ports.MetadataKeyAgentSessionID is already
+// present in session metadata, but nothing in this adapter populates that key:
+// like the pi adapter it mirrors, OMP has no native hook config file AO can
+// install (see Hooks below), so no mechanism currently writes the native
+// session id back into AO's metadata. In practice GetRestoreCommand's ok=false
+// branch is the one that fires today, and AO falls back to a fresh launch.
+// Restore becomes reachable once an OMP-specific mechanism (e.g. a `--hook`
+// extension that reports the session id back to AO, or a session-file scan
+// keyed on cwd) is added to populate that metadata key — tracked as follow-up
+// work, not invented here to avoid claiming a capability that isn't wired.
+//
+// Hooks: OMP's lifecycle-extensibility surface is in-process TypeScript
+// extensions (`--hook`/`-e`), not a config file AO can merge into, so hook
+// installation is intentionally a no-op (same tradeoff pi documents). This is
+// also why restore (above) and SessionInfo (title/summary) are unavailable
+// today: both depend on a hook reporting back to AO.
+//
+// AuthStatus: OMP stores credentials in a multi-provider sqlite `agent.db`
+// (table `auth_credentials`, one row per provider credential with a nullable
+// `disabled_cause`) rather than a single auth.json/env var. AuthStatus checks
+// common provider API-key env vars, then reads agent.db directly, falling back
+// to a generic CLI probe. The schema is an internal implementation detail, not
+// a public contract: a future OMP release can rename it without notice, so the
+// read fails soft (unknown, not a wrong answer) on any schema mismatch.
+package omp
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const adapterID = "omp"
+
+// Plugin is the Oh My Pi agent adapter. It is safe for concurrent use; the
+// binary path is resolved once and cached under binaryMu.
+type Plugin struct {
+	agentbase.Base
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register OMP adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description.
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          adapterID,
+		Name:        "Oh My Pi",
+		Description: "Run Oh My Pi (omp) worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports the per-project agent config keys OMP understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	return agentbase.ModelConfigSpec(ctx, "Model override passed to `omp --model` (fuzzy match, e.g. \"opus\" or \"gpt-5.2\").")
+}
+
+// GetLaunchCommand builds the argv to start a new interactive OMP session:
+//
+//	omp [--append-system-prompt <system prompt>] [--model <model>] [--approval-mode <mode> | --auto-approve] [<prompt>]
+//
+// The prompt is delivered in-command as a trailing positional message. OMP
+// does not honor a `--` options terminator, so the prompt must not begin with
+// "-".
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
+	binary, err := p.ompBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = []string{binary}
+	if err := appendSystemPromptFlag(&cmd, cfg.SystemPrompt, cfg.SystemPromptFile); err != nil {
+		return nil, err
+	}
+	agentbase.AppendModelFlag(&cmd, cfg.Config, "--model")
+	appendApprovalFlags(&cmd, cfg.Permissions)
+	if cfg.Prompt != "" {
+		cmd = append(cmd, cfg.Prompt)
+	}
+	return cmd, nil
+}
+
+// GetRestoreCommand rebuilds the argv that continues an existing OMP session
+// when a native session id is already present in metadata. OMP resumes by id
+// with `--resume <id>` (id prefixes accepted). ok=false when that id is
+// absent, which is the current path in practice — see the package doc for why
+// nothing populates it yet.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	agentSessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	if agentSessionID == "" {
+		return nil, false, nil
+	}
+
+	binary, err := p.ompBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	cmd = []string{binary}
+	if err := appendSystemPromptFlag(&cmd, cfg.SystemPrompt, cfg.SystemPromptFile); err != nil {
+		return nil, false, err
+	}
+	agentbase.AppendModelFlag(&cmd, cfg.Config, "--model")
+	appendApprovalFlags(&cmd, cfg.Permissions)
+	cmd = append(cmd, "--resume", agentSessionID)
+	return cmd, true, nil
+}
+
+// appendSystemPromptFlag reads SystemPromptFile itself (rather than passing
+// the path straight through) so a read failure aborts the launch instead of
+// silently handing OMP an unresolved path.
+func appendSystemPromptFlag(cmd *[]string, systemPrompt, systemPromptFile string) error {
+	switch {
+	case systemPrompt != "":
+		*cmd = append(*cmd, "--append-system-prompt", systemPrompt)
+	case systemPromptFile != "":
+		data, err := os.ReadFile(systemPromptFile) //nolint:gosec // path is AO-owned launch config
+		if err != nil {
+			return err
+		}
+		*cmd = append(*cmd, "--append-system-prompt", string(data))
+	}
+	return nil
+}
+
+// appendApprovalFlags maps AO's permission modes onto OMP's approval-mode
+// flags. OMP sessions run headlessly, so every mode resolves to a flag that
+// cannot leave a tool call stalled on an unattended approval prompt:
+//   - default / auto      -> --approval-mode yolo (auto-approves read, write,
+//     and exec tools; matches OMP's own schema default)
+//   - accept-edits         -> --approval-mode write (auto-approves read/write,
+//     still prompts exec)
+//   - bypass-permissions   -> --auto-approve (forces yolo, overriding project
+//     config)
+func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
+	switch ports.NormalizePermissionMode(permissions) {
+	case ports.PermissionModeAcceptEdits:
+		*cmd = append(*cmd, "--approval-mode", "write")
+	case ports.PermissionModeBypassPermissions:
+		*cmd = append(*cmd, "--auto-approve")
+	case ports.PermissionModeDefault, ports.PermissionModeAuto:
+		*cmd = append(*cmd, "--approval-mode", "yolo")
+	}
+}
+
+var ompBinarySpec = binaryutil.BinarySpec{
+	Label:     "omp",
+	Names:     []string{"omp"},
+	WinNames:  []string{"omp.cmd", "omp.exe", "omp"},
+	UnixPaths: []string{"/usr/local/bin/omp", "/opt/homebrew/bin/omp"},
+	UnixHomePaths: [][]string{
+		{".bun", "bin", "omp"},
+		{".local", "bin", "omp"},
+	},
+	WinPaths: []binaryutil.WinPath{
+		{Base: binaryutil.WinLocalAppData, Parts: []string{"bun", "bin", "omp.exe"}},
+		{Base: binaryutil.WinHome, Parts: []string{".bun", "bin", "omp.exe"}},
+	},
+}
+
+// ResolveOMPBinary finds the `omp` binary, searching PATH then common install
+// locations (OMP ships via Bun, so ~/.bun/bin is checked ahead of generic
+// fallbacks). It returns a wrapped ports.ErrAgentBinaryNotFound when OMP is
+// absent.
+func ResolveOMPBinary(ctx context.Context) (string, error) {
+	return binaryutil.ResolveBinary(ctx, ompBinarySpec)
+}
+
+func (p *Plugin) ompBinary(ctx context.Context) (string, error) {
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+
+	binary, err := ResolveOMPBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}

--- a/backend/internal/adapters/agent/omp/omp_test.go
+++ b/backend/internal/adapters/agent/omp/omp_test.go
@@ -1,0 +1,304 @@
+package omp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifest(t *testing.T) {
+	m := (&Plugin{}).Manifest()
+	if m.ID != "omp" {
+		t.Fatalf("ID = %q, want omp", m.ID)
+	}
+	if m.Name != "Oh My Pi" {
+		t.Fatalf("Name = %q, want Oh My Pi", m.Name)
+	}
+	hasAgent := false
+	for _, c := range m.Capabilities {
+		if c == adapters.CapabilityAgent {
+			hasAgent = true
+		}
+	}
+	if !hasAgent {
+		t.Fatal("missing CapabilityAgent")
+	}
+}
+
+func TestGetConfigSpecReportsModelField(t *testing.T) {
+	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `omp --model` (fuzzy match, e.g. \"opus\" or \"gpt-5.2\").",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
+	}
+}
+
+func TestGetPromptDeliveryStrategy(t *testing.T) {
+	s, err := (&Plugin{}).GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s != ports.PromptDeliveryInCommand {
+		t.Fatalf("strategy = %q, want %q", s, ports.PromptDeliveryInCommand)
+	}
+}
+
+func TestGetLaunchCommandWorkerWithPromptDefaultsToYolo(t *testing.T) {
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Kind:   domain.KindWorker,
+		Prompt: "add a health check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"omp", "--approval-mode", "yolo", "add a health check"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModelBeforePrompt(t *testing.T) {
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config:       ports.AgentConfig{Model: "  openai/gpt-5.2  "},
+		SystemPrompt: "follow repo rules",
+		Prompt:       "add a health check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"omp",
+		"--append-system-prompt", "follow repo rules",
+		"--model", "openai/gpt-5.2",
+		"--approval-mode", "yolo",
+		"add a health check",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"omp", "--approval-mode", "yolo"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandApprovalModeMapping(t *testing.T) {
+	cases := []struct {
+		mode ports.PermissionMode
+		want []string
+	}{
+		{ports.PermissionModeDefault, []string{"omp", "--approval-mode", "yolo"}},
+		{"", []string{"omp", "--approval-mode", "yolo"}},
+		{ports.PermissionModeAuto, []string{"omp", "--approval-mode", "yolo"}},
+		{ports.PermissionModeAcceptEdits, []string{"omp", "--approval-mode", "write"}},
+		{ports.PermissionModeBypassPermissions, []string{"omp", "--auto-approve"}},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.mode), func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "omp"}
+			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{Permissions: tc.mode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cmd, tc.want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetLaunchCommandPrefersInlineSystemPrompt(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "system.md")
+	if err := os.WriteFile(file, []byte("file contents win"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPromptFile: file,
+		SystemPrompt:     "inline wins",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"omp", "--append-system-prompt", "inline wins", "--approval-mode", "yolo"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandReadsSystemPromptFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "system.md")
+	if err := os.WriteFile(file, []byte("file contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPromptFile: file,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"omp", "--append-system-prompt", "file contents", "--approval-mode", "yolo"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandSystemPromptFileReadError(t *testing.T) {
+	p := &Plugin{resolvedBinary: "omp"}
+	_, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPromptFile: filepath.Join(t.TempDir(), "missing.md"),
+	})
+	if err == nil {
+		t.Fatal("expected error for unreadable system-prompt file, got nil")
+	}
+}
+
+func TestGetRestoreCommand(t *testing.T) {
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		SystemPrompt:     "restore inline wins",
+		SystemPromptFile: filepath.Join(t.TempDir(), "missing.md"),
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "019e950e-52e0-7411-961b-d380ca7e610f"},
+		},
+		Permissions: ports.PermissionModeBypassPermissions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+
+	want := []string{
+		"omp",
+		"--append-system-prompt", "restore inline wins",
+		"--auto-approve",
+		"--resume", "019e950e-52e0-7411-961b-d380ca7e610f",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModelBeforeSession(t *testing.T) {
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "opus"},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "019e950e-52e0-7411-961b-d380ca7e610f"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+
+	want := []string{"omp", "--model", "opus", "--approval-mode", "yolo", "--resume", "019e950e-52e0-7411-961b-d380ca7e610f"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandNoID(t *testing.T) {
+	p := &Plugin{resolvedBinary: "omp"}
+	_, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{Metadata: map[string]string{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("ok=true with no agentSessionId, want false")
+	}
+}
+
+func TestGetAgentHooksNoOp(t *testing.T) {
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: t.TempDir()}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v, want nil", err)
+	}
+}
+
+func TestSessionInfoNoOp(t *testing.T) {
+	info, ok, err := (&Plugin{}).SessionInfo(context.Background(), ports.SessionRef{
+		Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "019e950e-52e0-7411-961b-d380ca7e610f"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("ok=true with info %#v, want no-op false", info)
+	}
+	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("info = %#v, want zero", info)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := (&Plugin{}).GetConfigSpec(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetConfigSpec err = %v, want context.Canceled", err)
+	}
+	if _, err := (&Plugin{}).GetPromptDeliveryStrategy(ctx, ports.LaunchConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetPromptDeliveryStrategy err = %v, want context.Canceled", err)
+	}
+	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).GetRestoreCommand(ctx, ports.RestoreConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetRestoreCommand err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).SessionInfo(ctx, ports.SessionRef{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SessionInfo err = %v, want context.Canceled", err)
+	}
+}
+
+func TestResolveOMPBinaryContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ResolveOMPBinary(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ResolveOMPBinary err = %v, want context.Canceled", err)
+	}
+}

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kilocode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kiro"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/omp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/pi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/qwen"
@@ -62,6 +63,7 @@ func Constructors() []adapters.Adapter {
 		kilocode.New(),
 		vibe.New(),
 		pi.New(),
+		omp.New(),
 		autohand.New(),
 	}
 }

--- a/backend/internal/domain/harness.go
+++ b/backend/internal/domain/harness.go
@@ -27,6 +27,7 @@ const (
 	HarnessKilocode   AgentHarness = "kilocode"
 	HarnessVibe       AgentHarness = "vibe"
 	HarnessPi         AgentHarness = "pi"
+	HarnessOMP        AgentHarness = "omp"
 	HarnessAutohand   AgentHarness = "autohand"
 	// HarnessFake is retained for existing test fixtures and historical session
 	// rows, but is not user-selectable.
@@ -40,7 +41,7 @@ var AllHarnesses = []AgentHarness{
 	HarnessDroid, HarnessAmp, HarnessAgy, HarnessCrush, HarnessCursor, HarnessQwen,
 	HarnessCopilot, HarnessGoose, HarnessAuggie, HarnessContinue, HarnessDevin,
 	HarnessCline, HarnessKimi, HarnessKiro, HarnessKilocode, HarnessVibe, HarnessPi,
-	HarnessAutohand,
+	HarnessOMP, HarnessAutohand,
 }
 
 // IsKnown reports whether h is one of the supported harnesses.


### PR DESCRIPTION
## What

Adds a new agent harness for **Oh My Pi** (binary `omp`), a terminal coding CLI built on the same lineage as the already-shipped `pi` adapter (`@earendil-works/pi-coding-agent`) but distinct from it (`@oh-my-pi/pi-coding-agent`) — diverged flags, approval semantics, credential storage, and session layout, so it gets its own adapter (`backend/internal/adapters/agent/omp`) rather than reusing `pi`'s.

## Adapter behavior

- **Launch/restore argv**: `--model`, `--append-system-prompt` (reads `SystemPromptFile` itself so a read failure aborts the launch), `--resume <id>` — same shape as the `pi` adapter.
- **Permissions**: OMP sessions run unattended in an AO terminal pane, so every `ports.PermissionMode` maps to a flag that can't leave a tool call stuck on an approval prompt (same rationale as the `codex` adapter):
  - default / auto → `--approval-mode yolo` (also OMP's own schema default)
  - accept-edits → `--approval-mode write`
  - bypass-permissions → `--auto-approve` (forces yolo, overriding project config)
- **Binary resolution**: PATH, then `~/.bun/bin/omp` (OMP ships via Bun, not npm).
- **AuthStatus**: provider API-key env vars first, then a read-only probe of OMP's `agent.db` (`auth_credentials` table — confirmed against a live local install), then a generic CLI fallback. The sqlite read is defensive: any schema mismatch (an internal implementation detail, not a public contract) fails soft to `unknown` rather than a wrong answer.

## Known limitation

`GetRestoreCommand`'s `ok=true` path isn't reachable yet: nothing currently populates `ports.MetadataKeyAgentSessionID` for OMP sessions, because OMP has no native hook-config file AO can install into (same gap the `pi` adapter has today — pi doesn't override `SessionInfo` either). Fresh launch is what runs in practice. Wiring an OMP-side reporting mechanism (a `--hook` extension, or a session-file scan keyed on cwd) is left as follow-up rather than invented here; documented in the package doc comment.

## Changes

- `backend/internal/adapters/agent/omp/{omp,install,auth}.go` (+ tests)
- `backend/internal/domain/harness.go`: adds `HarnessOMP = "omp"`
- `backend/internal/adapters/agent/registry/registry.go`: wires `omp.New()` into `Constructors()`

## Verification

```
go build ./...   # clean
go vet ./...      # clean
go test ./...     # all pass, including the pre-existing registry-level
                   # contract tests (TestEveryHarnessReportsAuthStatus,
                   # TestEveryProductionHarnessReportsModelOrModeConfig,
                   # TestGetAgentHooksFootprintIsGitignored)
gofmt -l          # clean on touched files
```

No project-wide lint/format tooling was run beyond `gofmt`/`go vet` (Go toolchain only available locally, no Node/frontend changes needed since this is backend-only).

## Process note

CONTRIBUTING.md asks non-trivial changes to start on Discord/an issue first — I don't have an existing thread for this. Happy to open an issue and link back, or split/adjust this PR based on maintainer feedback. Filed directly because a user of AO asked for the harness support and I had working, tested code in hand.