### PR TITLE
fix(frontend): repair ACP runtime packaging

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       # The daemon is compiled by build-daemon.mjs during premake, so the Go

--- a/.github/workflows/desktop-testing.yml
+++ b/.github/workflows/desktop-testing.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       # The daemon is compiled by build-daemon.mjs during premake, so the Go

--- a/.github/workflows/feature-release.yml
+++ b/.github/workflows/feature-release.yml
@@ -247,7 +247,7 @@ jobs:
       - uses: actions/setup-node@v4
         if: steps.gate.outputs.skip != 'true'
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -322,7 +322,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       # The daemon is compiled by build-daemon.mjs during prepackage/premake, so
@@ -188,7 +188,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - uses: actions/setup-go@v5

--- a/.github/workflows/testing-build.yml
+++ b/.github/workflows/testing-build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - uses: actions/setup-go@v5

--- a/frontend/scripts/build-acp-runtime-helpers.mjs
+++ b/frontend/scripts/build-acp-runtime-helpers.mjs
@@ -1,0 +1,54 @@
+import { rmSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT_BUILD_TOOLS = ["corepack", "corepack.cmd", "npm", "npm.cmd", "npx", "npx.cmd"];
+const BIN_BUILD_TOOLS = ["corepack", "npm", "npx"];
+const BUILD_ONLY_CONTENT = ["include", "lib", "node_modules", "share", "CHANGELOG.md", "README.md"];
+
+export function npmInvocation(
+	args,
+	{
+		platform = process.platform,
+		execPath = process.execPath,
+		npmExecPath = process.env.npm_execpath,
+		commandInterpreter = process.env.ComSpec,
+	} = {},
+) {
+	// npm exposes the JavaScript entry point of the npm instance running this
+	// package script. Invoking it with Node avoids the npm.cmd shell boundary on
+	// Windows and keeps the nested install on the same npm version as the build.
+	if (npmExecPath) {
+		return { command: execPath, args: [npmExecPath, ...args] };
+	}
+	if (platform === "win32") {
+		return {
+			command: commandInterpreter || "cmd.exe",
+			args: ["/d", "/s", "/c", "npm.cmd", ...args],
+		};
+	}
+	return { command: "npm", args };
+}
+
+export function pruneNodeDistribution(nodeRoot) {
+	// The Unix archives expose npm/corepack as bin/ symlinks into lib/. Remove
+	// the entry points before their targets so packagers never see dangling
+	// links. Windows keeps the launchers at the archive root instead.
+	for (const name of BIN_BUILD_TOOLS) {
+		removeFile(join(nodeRoot, "bin", name));
+	}
+	for (const name of ROOT_BUILD_TOOLS) {
+		removeFile(join(nodeRoot, name));
+	}
+	for (const name of BUILD_ONLY_CONTENT) {
+		rmSync(join(nodeRoot, name), { recursive: true, force: true });
+	}
+}
+
+function removeFile(path) {
+	try {
+		// unlink removes a symlink itself even when its target is already absent.
+		unlinkSync(path);
+	} catch (error) {
+		if (error?.code !== "ENOENT") throw error;
+	}
+}

--- a/frontend/scripts/build-acp-runtime-helpers.test.mjs
+++ b/frontend/scripts/build-acp-runtime-helpers.test.mjs
@@ -1,0 +1,91 @@
+// @vitest-environment node
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { npmInvocation, pruneNodeDistribution } from "./build-acp-runtime-helpers.mjs";
+
+const temporaryDirectories = [];
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("npmInvocation", () => {
+	it("runs the parent npm CLI through Node on Windows", () => {
+		expect(
+			npmInvocation(["ci", "--omit=dev"], {
+				platform: "win32",
+				execPath: "C:\\node\\node.exe",
+				npmExecPath: "C:\\node\\node_modules\\npm\\bin\\npm-cli.js",
+				commandInterpreter: "C:\\Windows\\System32\\cmd.exe",
+			}),
+		).toEqual({
+			command: "C:\\node\\node.exe",
+			args: ["C:\\node\\node_modules\\npm\\bin\\npm-cli.js", "ci", "--omit=dev"],
+		});
+	});
+
+	it("falls back to cmd.exe for a directly invoked Windows build script", () => {
+		expect(
+			npmInvocation(["ci"], {
+				platform: "win32",
+				npmExecPath: null,
+				commandInterpreter: "C:\\Windows\\System32\\cmd.exe",
+			}),
+		).toEqual({
+			command: "C:\\Windows\\System32\\cmd.exe",
+			args: ["/d", "/s", "/c", "npm.cmd", "ci"],
+		});
+	});
+
+	it("invokes npm directly on Unix when no parent npm CLI is available", () => {
+		expect(npmInvocation(["ci"], { platform: "linux", npmExecPath: null })).toEqual({
+			command: "npm",
+			args: ["ci"],
+		});
+	});
+});
+
+describe("pruneNodeDistribution", () => {
+	it("removes Unix package-manager links before deleting their targets", () => {
+		const nodeRoot = temporaryDirectory();
+		const bin = join(nodeRoot, "bin");
+		const npmBin = join(nodeRoot, "lib", "node_modules", "npm", "bin");
+		mkdirSync(bin, { recursive: true });
+		mkdirSync(npmBin, { recursive: true });
+		writeFileSync(join(bin, "node"), "node");
+		writeFileSync(join(npmBin, "npm-cli.js"), "npm");
+		writeFileSync(join(npmBin, "npx-cli.js"), "npx");
+		symlinkSync("../lib/node_modules/npm/bin/npm-cli.js", join(bin, "npm"));
+		symlinkSync("../lib/node_modules/npm/bin/npx-cli.js", join(bin, "npx"));
+		symlinkSync("../lib/node_modules/corepack/dist/corepack.js", join(bin, "corepack"));
+
+		pruneNodeDistribution(nodeRoot);
+
+		expect(readdirSync(bin)).toEqual(["node"]);
+		expect(existsSync(join(nodeRoot, "lib"))).toBe(false);
+	});
+
+	it("removes package-manager files and modules from a Windows distribution", () => {
+		const nodeRoot = temporaryDirectory();
+		writeFileSync(join(nodeRoot, "node.exe"), "node");
+		writeFileSync(join(nodeRoot, "LICENSE"), "license");
+		for (const name of ["corepack", "corepack.cmd", "npm", "npm.cmd", "npx", "npx.cmd"]) {
+			writeFileSync(join(nodeRoot, name), name);
+		}
+		mkdirSync(join(nodeRoot, "node_modules", "npm"), { recursive: true });
+
+		pruneNodeDistribution(nodeRoot);
+
+		expect(readdirSync(nodeRoot).sort()).toEqual(["LICENSE", "node.exe"]);
+	});
+});
+
+function temporaryDirectory() {
+	const directory = mkdtempSync(join(tmpdir(), "ao-acp-runtime-test-"));
+	temporaryDirectories.push(directory);
+	return directory;
+}

--- a/frontend/scripts/build-acp-runtime.mjs
+++ b/frontend/scripts/build-acp-runtime.mjs
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { npmInvocation, pruneNodeDistribution } from "./build-acp-runtime-helpers.mjs";
 
 const NODE_VERSION = "22.23.2";
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
@@ -35,6 +36,7 @@ const baseURL = `https://nodejs.org/dist/v${NODE_VERSION}`;
 const buildSignature = createHash("sha256")
 	.update(readFileSync(join(sourceDir, "package-lock.json")))
 	.update(readFileSync(fileURLToPath(import.meta.url)))
+	.update(readFileSync(join(scriptsDir, "build-acp-runtime-helpers.mjs")))
 	.update(`node=${NODE_VERSION};platform=${platform};arch=${arch}`)
 	.digest("hex");
 const markerPath = join(outDir, ".ao-acp-runtime.json");
@@ -59,7 +61,8 @@ mkdirSync(outDir, { recursive: true });
 cpSync(join(sourceDir, "package.json"), join(outDir, "package.json"));
 cpSync(join(sourceDir, "package-lock.json"), join(outDir, "package-lock.json"));
 
-run("npm", ["ci", "--omit=dev", "--omit=optional", "--ignore-scripts"], { cwd: outDir });
+const npm = npmInvocation(["ci", "--omit=dev", "--omit=optional", "--ignore-scripts"]);
+run(npm.command, npm.args, { cwd: outDir });
 
 // The Claude Agent SDK declares platform-native Claude executables as optional
 // dependencies. --omit=optional excludes them; this removal is defense-in-depth.
@@ -112,9 +115,7 @@ try {
 	renameSync(extracted, nodeOut);
 	// Only the runtime executable is needed; npm, headers, docs, and corepack are
 	// build/development tools and would add roughly 80 MB to every desktop update.
-	for (const name of ["include", "lib", "share", "CHANGELOG.md", "README.md"]) {
-		rmSync(join(nodeOut, name), { recursive: true, force: true });
-	}
+	pruneNodeDistribution(nodeOut);
 } finally {
 	rmSync(workDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

- invoke the nested ACP runtime `npm ci` through the parent npm CLI, avoiding the Windows `npm.cmd` shell boundary
- remove npm, npx, and corepack entry points before pruning their targets so Linux packagers never encounter dangling symlinks
- prune the Windows Node distribution consistently, run desktop packaging jobs on Node 22, and add cross-platform regression coverage

## Context

The unsigned artifact build at https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/31106840992 failed in two places:

- Windows stopped with `spawnSync npm ENOENT`
- Linux's deb maker stopped while statting the dangling `resources/acp-runtime/node/bin/npx` link

The macOS legs passed because their makers did not follow that dangling link during packaging.

## Verification

- `npx vitest run scripts/build-acp-runtime-helpers.test.mjs --config vite.renderer.config.ts` under Node 22.23.2
- `npm run build:acp-runtime`
- `npm run typecheck`
- `npm run typecheck:e2e`
- `npm test` (148 files, 1,953 tests)
- `npm run make` (unsigned local macOS zip and DMG)
- verified the packaged Node resource contains only `LICENSE` and `bin/node`, with no dangling symlinks

A signed publish was intentionally not run; release publishing remains with the designated conductor.
