### PR TITLE
fix(frontend): keep ACP extraction on output volume

### DIFF
--- a/frontend/scripts/build-acp-runtime-helpers.mjs
+++ b/frontend/scripts/build-acp-runtime-helpers.mjs
@@ -1,9 +1,16 @@
-import { rmSync, unlinkSync } from "node:fs";
+import { mkdtempSync, rmSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 const ROOT_BUILD_TOOLS = ["corepack", "corepack.cmd", "npm", "npm.cmd", "npx", "npx.cmd"];
 const BIN_BUILD_TOOLS = ["corepack", "npm", "npx"];
 const BUILD_ONLY_CONTENT = ["include", "lib", "node_modules", "share", "CHANGELOG.md", "README.md"];
+
+export function createWorkDirectory(outputRoot) {
+	// Windows runners commonly keep the checkout on D: and the OS temp directory
+	// on C:. Keep extraction beside its destination so the final rename remains
+	// an atomic, same-filesystem operation on every platform.
+	return mkdtempSync(join(outputRoot, ".node-download-"));
+}
 
 export function npmInvocation(
 	args,

--- a/frontend/scripts/build-acp-runtime-helpers.test.mjs
+++ b/frontend/scripts/build-acp-runtime-helpers.test.mjs
@@ -1,9 +1,9 @@
 // @vitest-environment node
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { npmInvocation, pruneNodeDistribution } from "./build-acp-runtime-helpers.mjs";
+import { createWorkDirectory, npmInvocation, pruneNodeDistribution } from "./build-acp-runtime-helpers.mjs";
 
 const temporaryDirectories = [];
 
@@ -11,6 +11,16 @@ afterEach(() => {
 	for (const directory of temporaryDirectories.splice(0)) {
 		rmSync(directory, { recursive: true, force: true });
 	}
+});
+
+describe("createWorkDirectory", () => {
+	it("places extraction on the output filesystem", () => {
+		const outputRoot = temporaryDirectory();
+		const workDirectory = createWorkDirectory(outputRoot);
+
+		expect(dirname(workDirectory)).toBe(outputRoot);
+		expect(existsSync(workDirectory)).toBe(true);
+	});
 });
 
 describe("npmInvocation", () => {

--- a/frontend/scripts/build-acp-runtime.mjs
+++ b/frontend/scripts/build-acp-runtime.mjs
@@ -3,17 +3,15 @@ import {
 	cpSync,
 	existsSync,
 	mkdirSync,
-	mkdtempSync,
 	readFileSync,
 	renameSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
-import { npmInvocation, pruneNodeDistribution } from "./build-acp-runtime-helpers.mjs";
+import { createWorkDirectory, npmInvocation, pruneNodeDistribution } from "./build-acp-runtime-helpers.mjs";
 
 const NODE_VERSION = "22.23.2";
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
@@ -83,7 +81,7 @@ for (const name of nativeClaudePackages) {
 	rmSync(join(anthropicDir, name), { recursive: true, force: true });
 }
 
-const workDir = mkdtempSync(join(tmpdir(), "ao-acp-runtime-"));
+const workDir = createWorkDirectory(outDir);
 try {
 	const [sums, archive] = await Promise.all([
 		download(`${baseURL}/SHASUMS256.txt`),


### PR DESCRIPTION
## Summary

- create the ACP Node extraction directory inside `resources/acp-runtime` instead of the OS temp directory
- keep extraction and the final `renameSync` destination on the same filesystem
- add regression coverage that asserts the work directory is a child of the output root

## Context

This follows #3660. That fix worked: the next artifact run completed Linux packaging and Windows passed the nested `npm ci`. Windows then exposed the next platform boundary:

```text
EXDEV: cross-device link not permitted, rename
'C:\Users\...\Temp\ao-acp-runtime-...\node-v22.23.2-win-x64'
-> 'D:\a\agent-orchestrator\...\resources\acp-runtime\node'
```

GitHub's Windows runner keeps `%TEMP%` on `C:` and the checkout on `D:`, while `renameSync` only works within one filesystem. Failed job: https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/31109355905/job/92642776628

## Verification

- `npx vitest run scripts/build-acp-runtime-helpers.test.mjs --config vite.renderer.config.ts` (6 tests)
- `npm run build:acp-runtime`
- verified Node 22.23.2 and no leftover `.node-download-*` directory
- `npm run typecheck`
- `npm run typecheck:e2e`
- `npm run make` (unsigned local macOS zip and DMG)

A signed publish was intentionally not run; release publishing remains with the designated conductor.
