### PR TITLE
feat(telemetry): uniform client tag on desktop and CLI events

### DIFF
--- a/backend/internal/adapters/telemetry/posthog.go
+++ b/backend/internal/adapters/telemetry/posthog.go
@@ -326,6 +326,10 @@ func (s *PostHogSink) properties(ev ports.TelemetryEvent) map[string]any {
 		"source":                   ev.Source,
 		"level":                    string(ev.Level),
 		"telemetry_schema_version": remoteTelemetrySchemaVersion,
+		// Classifies this install as the CLI/daemon on every event, matching the
+		// desktop renderer (client="desktop") and mobile (client="mobile"), so a
+		// shared event like ao.app.active splits by one property across surfaces.
+		"client": "cli",
 		// The distinct ID is a random install ID with no person data behind it,
 		// so skip PostHog person-profile processing: identified events bill at
 		// several times the anonymous rate and the profiles would hold nothing.

--- a/backend/internal/adapters/telemetry/tenure_test.go
+++ b/backend/internal/adapters/telemetry/tenure_test.go
@@ -177,6 +177,11 @@ func TestPostHogSinkStampsDefaultAgentAndTenure(t *testing.T) {
 	if got["tenure"] != string(TenureFirstDay) {
 		t.Errorf("tenure = %v, want d0", got["tenure"])
 	}
+	// The classifier: every daemon/CLI event must carry client="cli" so a
+	// shared event like ao.app.active splits by client across desktop/mobile/cli.
+	if got["client"] != "cli" {
+		t.Errorf("client = %v, want cli", got["client"])
+	}
 	for _, key := range []string{"install_age_days", "active_days"} {
 		if _, ok := got[key]; !ok {
 			t.Errorf("%s missing from the payload", key)

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -520,6 +520,11 @@ describe("daily active heartbeat", () => {
 		expect(versionChannelFrom("unknown")).toBe("unknown");
 	});
 
+	it("classifies the desktop app with client=desktop on every event", () => {
+		const ctx = buildTelemetryContext("0.11.3", "darwin", "stable");
+		expect(ctx.client).toBe("desktop");
+	});
+
 	it("carries intent and reality as separate context properties", () => {
 		const ctx = buildTelemetryContext("0.11.3", "darwin", "nightly");
 		// opted into nightly, still running a stable binary: the gap is the signal.

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -121,6 +121,11 @@ export function buildTelemetryContext(
 ): TelemetryProperties {
 	const version = appVersion.trim() || "unknown";
 	return {
+		// Classifies this install as the desktop app across every event, so a
+		// shared event like ao.app.active splits cleanly by `client` alongside
+		// the mobile app (client="mobile") and the CLI (client="cli"), rather
+		// than by inferring from the platform value set.
+		client: "desktop",
 		app_version: version,
 		ao_version: version,
 		platform,


### PR DESCRIPTION
Adds `client` to the two surfaces that lacked it: `"desktop"` in the renderer context and `"cli"` in the Go sink's base properties. Mobile already sends `"mobile"` / `"mobile-web"`.

## Why this is a separate PR
This change was written against #3547 but pushed to that branch after #3547 had already merged, so the commit was stranded on the branch and never reached main. This PR lands it cleanly off current main.

## What it fixes
A shared event like `ao.app.active` could previously be split into phone vs laptop only by inferring from the platform value set (ios/android vs darwin/win32/linux), which breaks the day a new platform or a web desktop build appears. Now every surface carries one `client` property, so the split is a single filter across `desktop / cli / mobile / mobile-web`.

The tag rides in the context layer, ahead of the per-event allowlist (same as `app_version`), so it is automatic on every event and cannot be dropped by the sanitizer.

## Verification
Wire-asserted on both sides: the Go stamps test decodes the request body and asserts `client="cli"`; the renderer context test asserts `client="desktop"`. Both were confirmed to fail when the tag is removed. Downloads are out of scope (they live in the app stores and GitHub, not PostHog); this classifies active usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)