### PR TITLE
fix: stop the session Files diff viewer from freezing on large diffs

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/swaggest/jsonschema-go v0.3.79
 	github.com/swaggest/openapi-go v0.2.61
 	github.com/yuin/goldmark v1.8.2
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.51.0
@@ -34,7 +35,6 @@ require (
 	github.com/u-root/u-root v0.16.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	modernc.org/libc v1.72.3 // indirect

--- a/backend/internal/cli/dto_drift_e2e_test.go
+++ b/backend/internal/cli/dto_drift_e2e_test.go
@@ -148,6 +148,8 @@ func (f *fakeSessionService) StageAttachments(context.Context, domain.SessionID,
 	return nil, nil
 }
 
+func (f *fakeSessionService) InvalidateWorkspaceCache(domain.SessionID) {}
+
 type fakeAgentCatalog struct{}
 
 var _ controllers.AgentCatalog = (*fakeAgentCatalog)(nil)

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -87,6 +87,7 @@ type SessionService interface {
 	WorkspaceWatchPaths(ctx context.Context, id domain.SessionID) ([]string, error)
 	ListWorkspaceFiles(ctx context.Context, id domain.SessionID) (sessionsvc.WorkspaceFiles, error)
 	GetWorkspaceFile(ctx context.Context, id domain.SessionID, path string) (sessionsvc.WorkspaceFileDetail, error)
+	InvalidateWorkspaceCache(id domain.SessionID)
 	Pin(ctx context.Context, id domain.SessionID) (domain.Session, error)
 	Unpin(ctx context.Context, id domain.SessionID) (domain.Session, error)
 }
@@ -557,6 +558,7 @@ func (c *SessionsController) streamWorkspaceChanges(w http.ResponseWriter, r *ht
 			if !ok {
 				return
 			}
+			c.Svc.InvalidateWorkspaceCache(sessionID(r))
 			if _, err := fmt.Fprint(w, "event: workspace_changed\ndata: {}\n\n"); err != nil {
 				return
 			}

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -406,6 +406,8 @@ func (f *fakeSessionService) GetWorkspaceFile(_ context.Context, id domain.Sessi
 	return sessionsvc.WorkspaceFileDetail{SessionID: id, Path: path}, nil
 }
 
+func (f *fakeSessionService) InvalidateWorkspaceCache(_ domain.SessionID) {}
+
 func newSessionTestServer(t *testing.T, svc *fakeSessionService) *httptest.Server {
 	return newSessionTestServerWithPreview(t, svc, nil)
 }

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -8,12 +8,13 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 	"github.com/aoagents/agent-orchestrator/backend/internal/telemetrymeta"
-	"golang.org/x/sync/singleflight"
 )
 
 // Store is the read-only persistence surface needed to assemble controller-facing session read models.

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 	"github.com/aoagents/agent-orchestrator/backend/internal/telemetrymeta"
+	"golang.org/x/sync/singleflight"
 )
 
 // Store is the read-only persistence surface needed to assemble controller-facing session read models.
@@ -142,6 +143,12 @@ type Service struct {
 	telemetry           ports.EventSink
 	orchestratorLocksMu sync.Mutex
 	orchestratorLocks   map[domain.ProjectID]*sync.Mutex
+	workspaceCache      *workspaceCache
+	// workspaceGroup coalesces concurrent cache-miss compare/status lookups
+	// for the same (session, root): "Expand All" on many files fires that
+	// many GetWorkspaceFile calls at once, and without this each one would
+	// independently spawn its own git subprocesses for identical work.
+	workspaceGroup singleflight.Group
 	// signalCapable reports whether a harness has a hook pipeline that can
 	// deliver activity signals at all. Only capable harnesses are eligible for
 	// the no_signal downgrade: a hook-less harness staying silent forever is
@@ -183,6 +190,7 @@ func NewWithDeps(d Deps) *Service {
 	if s.clock == nil {
 		s.clock = time.Now
 	}
+	s.workspaceCache = newWorkspaceCache(workspaceCacheTTL, s.clock)
 	return s
 }
 

--- a/backend/internal/service/session/workspace_cache.go
+++ b/backend/internal/service/session/workspace_cache.go
@@ -1,0 +1,97 @@
+package session
+
+import (
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// workspaceCacheTTL bridges the short window between a session's workspace
+// file list loading and the user immediately expanding a file, so the
+// expansion doesn't redundantly re-resolve the compare base and re-run the
+// same git status/diff/numstat calls the list request just made. It is not
+// the primary correctness mechanism for freshness — the filesystem watcher
+// that powers the workspace SSE stream invalidates entries the instant a
+// real change is observed (see Service.InvalidateWorkspaceCache). The TTL
+// only matters as a backstop for the brief window before that watcher
+// connects.
+const workspaceCacheTTL = 3 * time.Second
+
+type workspaceCacheKey struct {
+	session domain.SessionID
+	root    string
+}
+
+// String gives workspaceCacheKey a stable identity for use as a
+// singleflight.Group key. NUL can't appear in a session ID or filesystem
+// path, so it's a safe separator against collisions between the two fields.
+func (k workspaceCacheKey) String() string {
+	return string(k.session) + "\x00" + k.root
+}
+
+type workspaceCacheEntry struct {
+	at      time.Time
+	compare workspaceCompareTarget
+	changes workspaceChangeSet
+}
+
+type workspaceCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	now     func() time.Time
+	entries map[workspaceCacheKey]workspaceCacheEntry
+}
+
+func newWorkspaceCache(ttl time.Duration, now func() time.Time) *workspaceCache {
+	if now == nil {
+		now = time.Now
+	}
+	return &workspaceCache{ttl: ttl, now: now, entries: make(map[workspaceCacheKey]workspaceCacheEntry)}
+}
+
+// get, set, and invalidateSession are nil-receiver-safe: a *Service built via
+// a bare struct literal (common in this package's tests) leaves
+// workspaceCache nil, and a nil cache should behave as permanently empty
+// rather than panicking or requiring every construction site to remember
+// initialization — the same nil-safe idiom Go gives nil maps and slices.
+func (c *workspaceCache) get(key workspaceCacheKey) (workspaceCacheEntry, bool) {
+	if c == nil {
+		return workspaceCacheEntry{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return workspaceCacheEntry{}, false
+	}
+	if c.now().Sub(entry.at) > c.ttl {
+		delete(c.entries, key)
+		return workspaceCacheEntry{}, false
+	}
+	return entry, true
+}
+
+func (c *workspaceCache) set(key workspaceCacheKey, entry workspaceCacheEntry) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = entry
+}
+
+// invalidateSession purges every cached entry for a session, across every
+// worktree root it spans (workspace projects can span several repos).
+func (c *workspaceCache) invalidateSession(id domain.SessionID) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.entries {
+		if key.session == id {
+			delete(c.entries, key)
+		}
+	}
+}

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -14,10 +14,11 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -561,7 +562,7 @@ func (s *Service) workspaceFileSummariesCached(
 	return files, truncated, compare, nil
 }
 
-func buildWorkspaceFileSummaries(root, prefix string, excludePrefixes []string, paths []string, changes workspaceChangeSet) []WorkspaceFileSummary {
+func buildWorkspaceFileSummaries(root, prefix string, excludePrefixes, paths []string, changes workspaceChangeSet) []WorkspaceFileSummary {
 	files := make([]WorkspaceFileSummary, 0, len(paths))
 	for _, rel := range paths {
 		if workspacePathExcluded(rel, excludePrefixes) {
@@ -621,7 +622,10 @@ func (s *Service) resolveWorkspaceChanges(
 	if err != nil {
 		return workspaceCompareTarget{}, workspaceChangeSet{}, err
 	}
-	entry := v.(workspaceCacheEntry)
+	entry, ok := v.(workspaceCacheEntry)
+	if !ok {
+		return workspaceCompareTarget{}, workspaceChangeSet{}, fmt.Errorf("resolveWorkspaceChanges: unexpected singleflight result type %T", v)
+	}
 	return entry.compare, entry.changes, nil
 }
 
@@ -952,18 +956,9 @@ func resolvedScratchPath(filePath string) (string, bool) {
 	return resolved, err == nil
 }
 
-func workspaceGitFiles(ctx context.Context, root string, extraPaths map[string]struct{}) ([]string, bool, error) {
-	parts, err := gitLsFilesParts(ctx, root)
-	if err != nil {
-		return nil, false, err
-	}
-	paths, truncated := mergeWorkspaceFilePaths(parts, extraPaths)
-	return paths, truncated, nil
-}
-
-// gitLsFilesParts runs the one git subprocess `workspaceGitFiles` needs, kept
-// separate from the (pure, no I/O) merge step so callers can run it
-// concurrently with other independent git calls (see workspaceFileSummaries).
+// gitLsFilesParts runs the `git ls-files` subprocess, kept separate from the
+// (pure, no I/O) merge step in mergeWorkspaceFilePaths so callers can run it
+// concurrently with other independent git calls (see workspaceFileSummariesCached).
 func gitLsFilesParts(ctx context.Context, root string) ([]string, error) {
 	out, err := gitWorkspaceOutput(ctx, root, "ls-files", "-z", "-co", "--exclude-standard")
 	if err != nil {

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -123,6 +124,14 @@ func (s *Service) WorkspaceWatchPaths(ctx context.Context, id domain.SessionID) 
 	return paths, nil
 }
 
+// InvalidateWorkspaceCache purges cached compare-base and git-status data for
+// a session. Called from the workspace SSE stream the instant its filesystem
+// watcher observes a real change, so a list/detail request racing a fresh
+// git mutation never returns stale cached state.
+func (s *Service) InvalidateWorkspaceCache(id domain.SessionID) {
+	s.workspaceCache.invalidateSession(id)
+}
+
 // ListWorkspaceFiles returns all tracked and untracked, non-ignored files in a
 // session worktree, annotated with their current git status against the
 // session's recorded base when available.
@@ -153,8 +162,10 @@ func (s *Service) ListWorkspaceFiles(ctx context.Context, id domain.SessionID) (
 	if err != nil {
 		return WorkspaceFiles{}, err
 	}
-	compare := resolveWorkspaceCompare(ctx, rec.Metadata.WorkspacePath, rec.Metadata.DiffBaseSHA, rec.Metadata.DiffBaseRef, defaultBranchForProject(project, projectOK), prs)
-	files, truncated, err := workspaceFileSummaries(ctx, rec.Metadata.WorkspacePath, "", nil, compare)
+	resolve := func(rctx context.Context) workspaceCompareTarget {
+		return resolveWorkspaceCompare(rctx, rec.Metadata.WorkspacePath, rec.Metadata.DiffBaseSHA, rec.Metadata.DiffBaseRef, defaultBranchForProject(project, projectOK), prs)
+	}
+	files, truncated, compare, err := s.workspaceFileSummariesCached(ctx, id, rec.Metadata.WorkspacePath, "", nil, resolve)
 	if err != nil {
 		return WorkspaceFiles{}, err
 	}
@@ -198,8 +209,14 @@ func (s *Service) GetWorkspaceFile(ctx context.Context, id domain.SessionID, raw
 	if err != nil {
 		return WorkspaceFileDetail{}, err
 	}
-	compare := resolveWorkspaceCompare(ctx, rec.Metadata.WorkspacePath, rec.Metadata.DiffBaseSHA, rec.Metadata.DiffBaseRef, defaultBranchForProject(project, projectOK), prs)
-	return workspaceFileDetail(ctx, id, rec.Metadata.WorkspacePath, "", rel, compare)
+	resolve := func(rctx context.Context) workspaceCompareTarget {
+		return resolveWorkspaceCompare(rctx, rec.Metadata.WorkspacePath, rec.Metadata.DiffBaseSHA, rec.Metadata.DiffBaseRef, defaultBranchForProject(project, projectOK), prs)
+	}
+	compare, changes, err := s.resolveWorkspaceChanges(ctx, id, rec.Metadata.WorkspacePath, resolve)
+	if err != nil {
+		return WorkspaceFileDetail{}, err
+	}
+	return workspaceFileDetail(ctx, id, rec.Metadata.WorkspacePath, "", rel, compare, changes)
 }
 
 func (s *Service) sessionWorkspaceRecord(ctx context.Context, id domain.SessionID) (domain.SessionRecord, error) {
@@ -413,8 +430,10 @@ func (s *Service) listWorkspaceProjectFiles(ctx context.Context, rec domain.Sess
 		if err != nil {
 			return WorkspaceFiles{}, err
 		}
-		compare := resolveWorkspaceCompare(ctx, rec.Metadata.WorkspacePath, rec.Metadata.DiffBaseSHA, rec.Metadata.DiffBaseRef, defaultBranchForProject(project, true), prs)
-		files, truncated, err := workspaceFileSummaries(ctx, rec.Metadata.WorkspacePath, "", nil, compare)
+		resolve := func(rctx context.Context) workspaceCompareTarget {
+			return resolveWorkspaceCompare(rctx, rec.Metadata.WorkspacePath, rec.Metadata.DiffBaseSHA, rec.Metadata.DiffBaseRef, defaultBranchForProject(project, true), prs)
+		}
+		files, truncated, compare, err := s.workspaceFileSummariesCached(ctx, rec.ID, rec.Metadata.WorkspacePath, "", nil, resolve)
 		if err != nil {
 			return WorkspaceFiles{}, err
 		}
@@ -440,12 +459,14 @@ func (s *Service) listWorkspaceProjectFiles(ctx context.Context, rec domain.Sess
 		if prefix == "" {
 			exclude = childPrefixes
 		}
-		compare := resolveWorkspaceProjectCompare(ctx, row.WorktreePath, row.BaseSHA, defaultBranch)
-		compares = append(compares, compare)
-		repoFiles, repoTruncated, err := workspaceFileSummaries(ctx, row.WorktreePath, prefix, exclude, compare)
+		resolve := func(rctx context.Context) workspaceCompareTarget {
+			return resolveWorkspaceProjectCompare(rctx, row.WorktreePath, row.BaseSHA, defaultBranch)
+		}
+		repoFiles, repoTruncated, compare, err := s.workspaceFileSummariesCached(ctx, rec.ID, row.WorktreePath, prefix, exclude, resolve)
 		if err != nil {
 			return WorkspaceFiles{}, err
 		}
+		compares = append(compares, compare)
 		files, truncated = appendWorkspaceFilesWithCap(files, repoFiles, truncated)
 		truncated = truncated || repoTruncated
 	}
@@ -471,15 +492,28 @@ func (s *Service) getWorkspaceProjectFile(ctx context.Context, rec domain.Sessio
 		if err != nil {
 			return WorkspaceFileDetail{}, err
 		}
-		compare := resolveWorkspaceCompare(ctx, rec.Metadata.WorkspacePath, rec.Metadata.DiffBaseSHA, rec.Metadata.DiffBaseRef, defaultBranchForProject(project, true), prs)
-		return workspaceFileDetail(ctx, rec.ID, rec.Metadata.WorkspacePath, "", rel, compare)
+		resolve := func(rctx context.Context) workspaceCompareTarget {
+			return resolveWorkspaceCompare(rctx, rec.Metadata.WorkspacePath, rec.Metadata.DiffBaseSHA, rec.Metadata.DiffBaseRef, defaultBranchForProject(project, true), prs)
+		}
+		compare, changes, err := s.resolveWorkspaceChanges(ctx, rec.ID, rec.Metadata.WorkspacePath, resolve)
+		if err != nil {
+			return WorkspaceFileDetail{}, err
+		}
+		return workspaceFileDetail(ctx, rec.ID, rec.Metadata.WorkspacePath, "", rel, compare, changes)
 	}
 	row, prefix, repoRel, ok := workspaceProjectFileTarget(rec.Metadata.WorkspacePath, rows, rel)
 	if !ok {
 		return WorkspaceFileDetail{}, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
 	}
-	compare := resolveWorkspaceProjectCompare(ctx, row.WorktreePath, row.BaseSHA, defaultBranchForProject(project, true))
-	return workspaceFileDetail(ctx, rec.ID, row.WorktreePath, prefix, repoRel, compare)
+	defaultBranch := defaultBranchForProject(project, true)
+	resolve := func(rctx context.Context) workspaceCompareTarget {
+		return resolveWorkspaceProjectCompare(rctx, row.WorktreePath, row.BaseSHA, defaultBranch)
+	}
+	compare, changes, err := s.resolveWorkspaceChanges(ctx, rec.ID, row.WorktreePath, resolve)
+	if err != nil {
+		return WorkspaceFileDetail{}, err
+	}
+	return workspaceFileDetail(ctx, rec.ID, row.WorktreePath, prefix, repoRel, compare, changes)
 }
 
 func appendWorkspaceFilesWithCap(files, repoFiles []WorkspaceFileSummary, truncated bool) ([]WorkspaceFileSummary, bool) {
@@ -497,15 +531,37 @@ func appendWorkspaceFilesWithCap(files, repoFiles []WorkspaceFileSummary, trunca
 	return append(files, repoFiles...), truncated
 }
 
-func workspaceFileSummaries(ctx context.Context, root, prefix string, excludePrefixes []string, compare workspaceCompareTarget) ([]WorkspaceFileSummary, bool, error) {
-	changes, err := workspaceChangeMaps(ctx, root, compare.gitBase())
-	if err != nil {
-		return nil, false, err
+// workspaceFileSummariesCached resolves the changed-file list for one
+// worktree root, reusing a cached compare+status result when a recent
+// ListWorkspaceFiles/GetWorkspaceFile call for the same session/root already
+// computed it (see workspaceCache). On a cache miss it resolves the compare
+// base, computes git status/diff/numstat, and lists working-tree files
+// concurrently, since none of those git calls depend on each other.
+func (s *Service) workspaceFileSummariesCached(
+	ctx context.Context, id domain.SessionID, root, prefix string, excludePrefixes []string,
+	resolve func(ctx context.Context) workspaceCompareTarget,
+) ([]WorkspaceFileSummary, bool, workspaceCompareTarget, error) {
+	var compare workspaceCompareTarget
+	var changes workspaceChangeSet
+	var lsParts []string
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() (err error) {
+		compare, changes, err = s.resolveWorkspaceChanges(gctx, id, root, resolve)
+		return err
+	})
+	g.Go(func() (err error) {
+		lsParts, err = gitLsFilesParts(gctx, root)
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		return nil, false, workspaceCompareTarget{}, err
 	}
-	paths, truncated, err := workspaceGitFiles(ctx, root, changes.changedPaths())
-	if err != nil {
-		return nil, false, err
-	}
+	paths, truncated := mergeWorkspaceFilePaths(lsParts, changes.changedPaths())
+	files := buildWorkspaceFileSummaries(root, prefix, excludePrefixes, paths, changes)
+	return files, truncated, compare, nil
+}
+
+func buildWorkspaceFileSummaries(root, prefix string, excludePrefixes []string, paths []string, changes workspaceChangeSet) []WorkspaceFileSummary {
 	files := make([]WorkspaceFileSummary, 0, len(paths))
 	for _, rel := range paths {
 		if workspacePathExcluded(rel, excludePrefixes) {
@@ -527,14 +583,49 @@ func workspaceFileSummaries(ctx context.Context, root, prefix string, excludePre
 			Binary:       binary,
 		})
 	}
-	return files, truncated, nil
+	return files
 }
 
-func workspaceFileDetail(ctx context.Context, id domain.SessionID, root, prefix, rel string, compare workspaceCompareTarget) (WorkspaceFileDetail, error) {
-	changes, err := workspaceChangeMaps(ctx, root, compare.gitBase())
-	if err != nil {
-		return WorkspaceFileDetail{}, err
+// resolveWorkspaceChanges resolves the compare base and git status/diff maps
+// for one worktree root, reusing a cached result from a recent list/detail
+// call for the same session/root instead of re-running resolve+
+// workspaceChangeMaps from scratch. On a cache miss, concurrent callers for
+// the same (session, root) — e.g. "Expand All" firing GetWorkspaceFile for
+// every changed file in the same instant — share a single in-flight
+// resolve+workspaceChangeMaps call via singleflight instead of each spawning
+// its own redundant set of git subprocesses.
+func (s *Service) resolveWorkspaceChanges(
+	ctx context.Context, id domain.SessionID, root string,
+	resolve func(ctx context.Context) workspaceCompareTarget,
+) (workspaceCompareTarget, workspaceChangeSet, error) {
+	key := workspaceCacheKey{session: id, root: root}
+	if cached, ok := s.workspaceCache.get(key); ok {
+		return cached.compare, cached.changes, nil
 	}
+	v, err, _ := s.workspaceGroup.Do(key.String(), func() (any, error) {
+		// A concurrent caller may have already populated the cache while this
+		// call was queued behind the singleflight lock — re-check before
+		// doing the work again.
+		if cached, ok := s.workspaceCache.get(key); ok {
+			return cached, nil
+		}
+		compare := resolve(ctx)
+		changes, err := workspaceChangeMaps(ctx, root, compare.gitBase())
+		if err != nil {
+			return nil, err
+		}
+		entry := workspaceCacheEntry{at: s.now(), compare: compare, changes: changes}
+		s.workspaceCache.set(key, entry)
+		return entry, nil
+	})
+	if err != nil {
+		return workspaceCompareTarget{}, workspaceChangeSet{}, err
+	}
+	entry := v.(workspaceCacheEntry)
+	return entry.compare, entry.changes, nil
+}
+
+func workspaceFileDetail(ctx context.Context, id domain.SessionID, root, prefix, rel string, compare workspaceCompareTarget, changes workspaceChangeSet) (WorkspaceFileDetail, error) {
 	status := changes.statuses[rel]
 	if status == "" {
 		status = WorkspaceFileUnmodified
@@ -569,7 +660,8 @@ func workspaceFileDetail(ctx context.Context, id domain.SessionID, root, prefix,
 			detail.Content = content
 		}
 	}
-	diff, truncated, err := workspaceFileDiff(ctx, root, compare.gitBase(), rel, status, previousPath, detail.Content, detail.Binary)
+	_, untracked := changes.untracked[rel]
+	diff, truncated, err := workspaceFileDiff(ctx, root, compare.gitBase(), rel, status, previousPath, detail.Content, detail.Binary, untracked)
 	if err != nil {
 		return WorkspaceFileDetail{}, err
 	}
@@ -861,11 +953,26 @@ func resolvedScratchPath(filePath string) (string, bool) {
 }
 
 func workspaceGitFiles(ctx context.Context, root string, extraPaths map[string]struct{}) ([]string, bool, error) {
-	out, err := gitWorkspaceOutput(ctx, root, "ls-files", "-z", "-co", "--exclude-standard")
+	parts, err := gitLsFilesParts(ctx, root)
 	if err != nil {
 		return nil, false, err
 	}
-	parts := splitNUL(out)
+	paths, truncated := mergeWorkspaceFilePaths(parts, extraPaths)
+	return paths, truncated, nil
+}
+
+// gitLsFilesParts runs the one git subprocess `workspaceGitFiles` needs, kept
+// separate from the (pure, no I/O) merge step so callers can run it
+// concurrently with other independent git calls (see workspaceFileSummaries).
+func gitLsFilesParts(ctx context.Context, root string) ([]string, error) {
+	out, err := gitWorkspaceOutput(ctx, root, "ls-files", "-z", "-co", "--exclude-standard")
+	if err != nil {
+		return nil, err
+	}
+	return splitNUL(out), nil
+}
+
+func mergeWorkspaceFilePaths(parts []string, extraPaths map[string]struct{}) ([]string, bool) {
 	paths := make([]string, 0, len(parts))
 	seen := map[string]struct{}{}
 	truncated := false
@@ -895,13 +1002,18 @@ func workspaceGitFiles(ctx context.Context, root string, extraPaths map[string]s
 	for _, part := range parts {
 		addPath(part)
 	}
-	return paths, truncated, nil
+	return paths, truncated
 }
 
 type workspaceChangeSet struct {
 	statuses map[string]WorkspaceFileStatus
 	counts   map[string][2]int
 	previous map[string]string
+	// untracked holds paths git diff's machinery doesn't know about relative
+	// to base (status "??" from `git status`, absent from `git diff
+	// --name-status`) — computed once here so workspaceFileDiff can tell
+	// whether to synthesize a diff without its own extra git spawn.
+	untracked map[string]struct{}
 }
 
 func (c workspaceChangeSet) changedPaths() map[string]struct{} {
@@ -916,16 +1028,25 @@ func (c workspaceChangeSet) changedPaths() map[string]struct{} {
 }
 
 func workspaceChangeMaps(ctx context.Context, root, base string) (workspaceChangeSet, error) {
-	diffStatuses, diffPrevious, err := workspaceDiffStatuses(ctx, root, base)
-	if err != nil {
-		return workspaceChangeSet{}, err
-	}
-	statusStatuses, statusPrevious, err := workspaceStatuses(ctx, root)
-	if err != nil {
-		return workspaceChangeSet{}, err
-	}
-	counts, err := workspaceNumstat(ctx, root, base)
-	if err != nil {
+	var (
+		diffStatuses, statusStatuses map[string]WorkspaceFileStatus
+		diffPrevious, statusPrevious map[string]string
+		counts                       map[string][2]int
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() (err error) {
+		diffStatuses, diffPrevious, err = workspaceDiffStatuses(gctx, root, base)
+		return err
+	})
+	g.Go(func() (err error) {
+		statusStatuses, statusPrevious, err = workspaceStatuses(gctx, root)
+		return err
+	})
+	g.Go(func() (err error) {
+		counts, err = workspaceNumstat(gctx, root, base)
+		return err
+	})
+	if err := g.Wait(); err != nil {
 		return workspaceChangeSet{}, err
 	}
 	statuses := map[string]WorkspaceFileStatus{}
@@ -948,10 +1069,21 @@ func workspaceChangeMaps(ctx context.Context, root, base string) (workspaceChang
 		}
 		previous[rel] = prev
 	}
+	untracked := map[string]struct{}{}
 	for rel, status := range statuses {
 		if status != WorkspaceFileAdded {
 			continue
 		}
+		// diffStatuses (git diff --name-status against base) is the correct
+		// "does git diff machinery know this path" signal — unlike counts
+		// (git diff --numstat), which deliberately omits binary files
+		// ("-\t-\tpath") even when they ARE tracked relative to base, so
+		// counts membership alone would misclassify a tracked binary Added
+		// file as untracked.
+		if _, ok := diffStatuses[rel]; ok {
+			continue
+		}
+		untracked[rel] = struct{}{}
 		if _, ok := counts[rel]; ok {
 			continue
 		}
@@ -960,7 +1092,7 @@ func workspaceChangeMaps(ctx context.Context, root, base string) (workspaceChang
 			counts[rel] = [2]int{additions, 0}
 		}
 	}
-	return workspaceChangeSet{statuses: statuses, counts: counts, previous: previous}, nil
+	return workspaceChangeSet{statuses: statuses, counts: counts, previous: previous, untracked: untracked}, nil
 }
 
 func workspaceStatuses(ctx context.Context, root string) (map[string]WorkspaceFileStatus, map[string]string, error) {
@@ -1129,11 +1261,11 @@ func workspaceFileSizeAndBinary(root, rel string, status WorkspaceFileStatus) (i
 	return info.Size(), binary
 }
 
-func workspaceFileDiff(ctx context.Context, root, base, rel string, status WorkspaceFileStatus, previousPath, content string, binary bool) (string, bool, error) {
+func workspaceFileDiff(ctx context.Context, root, base, rel string, status WorkspaceFileStatus, previousPath, content string, binary, untracked bool) (string, bool, error) {
 	if status == WorkspaceFileUnmodified {
 		return "", false, nil
 	}
-	if status == WorkspaceFileAdded && !gitTracked(ctx, root, rel) {
+	if status == WorkspaceFileAdded && untracked {
 		if binary {
 			return "", false, nil
 		}
@@ -1152,11 +1284,6 @@ func workspaceFileDiff(ctx context.Context, root, base, rel string, status Works
 	}
 	truncatedDiff, truncated := truncateUTF8(out, maxWorkspaceDiffBytes)
 	return truncatedDiff, truncated, nil
-}
-
-func gitTracked(ctx context.Context, root, rel string) bool {
-	_, err := gitWorkspaceOutput(ctx, root, "ls-files", "--error-unmatch", "--", rel)
-	return err == nil
 }
 
 func syntheticAddedFileDiff(rel, content string) string {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
 				"@radix-ui/react-tooltip": "^1.2.9",
 				"@tanstack/react-query": "^5.101.0",
 				"@tanstack/react-router": "^1.170.15",
+				"@tanstack/react-virtual": "^3.14.9",
 				"@xterm/addon-canvas": "^0.7.0",
 				"@xterm/addon-fit": "^0.10.0",
 				"@xterm/addon-search": "^0.15.0",
@@ -6127,6 +6128,23 @@
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
+		"node_modules/@tanstack/react-virtual": {
+			"version": "3.14.9",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+			"integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/virtual-core": "3.17.7"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/@tanstack/router-core": {
 			"version": "1.171.13",
 			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.13.tgz",
@@ -6247,6 +6265,16 @@
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
 			"integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/virtual-core": {
+			"version": "3.17.7",
+			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+			"integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
 		"@radix-ui/react-tooltip": "^1.2.9",
 		"@tanstack/react-query": "^5.101.0",
 		"@tanstack/react-router": "^1.170.15",
+		"@tanstack/react-virtual": "^3.14.9",
 		"@xterm/addon-canvas": "^0.7.0",
 		"@xterm/addon-fit": "^0.10.0",
 		"@xterm/addon-search": "^0.15.0",

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -769,4 +769,153 @@ describe("SessionFilesView", () => {
 			expect(body.message).not.toContain("const value = 1;");
 		});
 	});
+
+	describe("large diff virtualization", () => {
+		// jsdom has no real layout engine — getBoundingClientRect/clientHeight
+		// are 0 for every element by default, which would make the virtualizer
+		// see a zero-height viewport and render nothing. Mock a realistic
+		// viewport so its visible-range math has something real to work with;
+		// scrollTop is a plain settable property in jsdom, so simulating scroll
+		// (set scrollTop, fire "scroll") drives the virtualizer for real.
+		const VIEWPORT_HEIGHT = 600;
+
+		beforeEach(() => {
+			vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+				top: 0,
+				left: 0,
+				right: 800,
+				bottom: VIEWPORT_HEIGHT,
+				width: 800,
+				height: VIEWPORT_HEIGHT,
+				x: 0,
+				y: 0,
+				toJSON() {
+					return this;
+				},
+			});
+			vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(VIEWPORT_HEIGHT);
+			vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(VIEWPORT_HEIGHT);
+			vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(800);
+		});
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		function bigModifiedDiff(lineCount: number) {
+			const hunkLines: string[] = [`@@ -1,${lineCount} +1,${lineCount} @@`];
+			for (let i = 0; i < lineCount; i += 1) {
+				hunkLines.push(`-old line ${i} with some content to diff against`);
+				hunkLines.push(`+new line ${i} with some different content entirely`);
+			}
+			return "diff --git a/big.txt b/big.txt\nindex 111..222 100644\n--- a/big.txt\n+++ b/big.txt\n" + hunkLines.join("\n") + "\n";
+		}
+
+		function mockBigFile(diff: string, lineCount: number) {
+			getMock.mockImplementation(async (path: string, options?: unknown) => {
+				if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
+					return {
+						data: {
+							sessionId: "sess-1",
+							truncated: false,
+							files: [
+								{ path: "big.txt", status: "modified", additions: lineCount, deletions: lineCount, size: 20000, binary: false },
+							],
+						},
+					};
+				}
+				if (path === "/api/v1/sessions/{sessionId}/workspace/file") {
+					const query = options as { params?: { query?: { path?: string } } };
+					return {
+						data: {
+							sessionId: "sess-1",
+							path: query.params?.query?.path ?? "big.txt",
+							status: "modified",
+							additions: lineCount,
+							deletions: lineCount,
+							size: 20000,
+							binary: false,
+							deleted: false,
+							content: "irrelevant",
+							contentTruncated: false,
+							diff,
+							diffTruncated: false,
+							compareBaseSha: "base-sha",
+							compareBaseRef: "main",
+							compareMode: "base",
+						},
+					};
+				}
+				return { data: undefined };
+			});
+		}
+
+		it("opens a large diff without hanging, mounting far fewer DOM rows than the diff has", async () => {
+			const lineCount = 400;
+			mockBigFile(bigModifiedDiff(lineCount), lineCount);
+
+			renderWithQuery(<SessionFilesView sessionId="sess-1" />);
+			await userEvent.click(await screen.findByRole("button", { name: "Expand big.txt" }));
+
+			await waitFor(() =>
+				expect(screen.getByText(diffLine("new line 0 with some different content entirely"))).toBeInTheDocument(),
+			);
+
+			const mountedRows = document.querySelectorAll("[data-diff-row]").length;
+			// lineCount*2 (del+add) + 1 hunk row is the fully-unvirtualized count;
+			// a real viewport-sized window plus overscan should be a small
+			// fraction of that.
+			expect(mountedRows).toBeGreaterThan(0);
+			expect(mountedRows).toBeLessThan(lineCount);
+
+			// Never reaches the last line without scrolling — proves it's actually
+			// windowed, not just slow to reveal everything.
+			expect(screen.queryByText(diffLine(`new line ${lineCount - 1} with some different content entirely`))).not.toBeInTheDocument();
+		});
+
+		it("loads more rows as the shared scroll container scrolls", async () => {
+			const lineCount = 400;
+			mockBigFile(bigModifiedDiff(lineCount), lineCount);
+
+			renderWithQuery(<SessionFilesView sessionId="sess-1" />);
+			await userEvent.click(await screen.findByRole("button", { name: "Expand big.txt" }));
+			await waitFor(() =>
+				expect(screen.getByText(diffLine("new line 0 with some different content entirely"))).toBeInTheDocument(),
+			);
+
+			const scrollRoot = document.querySelector<HTMLElement>("[data-files-scroll-root]");
+			expect(scrollRoot).not.toBeNull();
+			// jsdom doesn't clamp scrollTop against a real scrollHeight, so an
+			// oversized value reliably lands on the last rows regardless of the
+			// virtualizer's exact estimated-vs-measured row height math.
+			scrollRoot!.scrollTop = 999_999;
+			fireEvent.scroll(scrollRoot!);
+
+			await waitFor(() =>
+				expect(
+					screen.queryByText(diffLine(`new line ${lineCount - 1} with some different content entirely`)),
+				).toBeInTheDocument(),
+			);
+		});
+
+		// jsdom has no real Worker implementation, so this exercises
+		// useParsedDiff's exact "worker unavailable" fallback path — the same
+		// path a CSP-blocked or otherwise-broken worker would take in a real
+		// browser. A diff this size (well over the 50,000-char worker
+		// threshold) would otherwise never resolve if that fallback were
+		// broken.
+		it("still renders a diff large enough to route through the parser worker path", async () => {
+			const lineCount = 700;
+			const diff = bigModifiedDiff(lineCount);
+			expect(diff.length).toBeGreaterThan(50_000);
+			mockBigFile(diff, lineCount);
+
+			renderWithQuery(<SessionFilesView sessionId="sess-1" />);
+			await userEvent.click(await screen.findByRole("button", { name: "Expand big.txt" }));
+
+			await waitFor(() =>
+				expect(screen.getByText(diffLine("new line 0 with some different content entirely"))).toBeInTheDocument(),
+			);
+		});
+	});
 });

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -1,4 +1,5 @@
 import {
+	memo,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -7,8 +8,10 @@ import {
 	type KeyboardEvent,
 	type MouseEvent,
 	type ReactNode,
+	type RefObject,
 } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import {
@@ -34,7 +37,9 @@ import {
 	type WorkspaceCompareMode,
 	type WorkspaceFileSummary,
 } from "../hooks/useSessionWorkspaceFiles";
+import { useParsedDiff } from "../hooks/useParsedDiff";
 import { cn } from "../lib/utils";
+import type { DiffRow, DiffRowKind, DiffSegment } from "../lib/diff-parser";
 import type { DiffSelectionLine } from "../../shared/diff-selection";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "./ui/accordion";
 import { subscribeWorkspaceFileChanges } from "../lib/workspace-file-events";
@@ -556,10 +561,13 @@ function ReviewDiffBody({
 	wrap: boolean;
 }) {
 	const { t } = useTranslation();
+	const { rows, pending } = useParsedDiff(detail.diff);
 	if (detail.binary) {
 		return <PanelMessage compact>{t("files.binaryUnavailable")}</PanelMessage>;
 	}
-	const rows = parseUnifiedDiff(detail.diff);
+	if (pending) {
+		return <PanelMessage compact>{t("files.loadingDiff")}</PanelMessage>;
+	}
 	if (rows.length === 0) {
 		return <PanelMessage compact>{emptyDiffMessage(detail.compareMode, t)}</PanelMessage>;
 	}
@@ -577,170 +585,6 @@ function ReviewDiffBody({
 			wrap={wrap}
 		/>
 	);
-}
-
-type DiffRowKind = "context" | "add" | "del" | "hunk";
-
-type DiffSegment = { text: string; changed: boolean };
-
-type DiffRow = {
-	kind: DiffRowKind;
-	oldNo: number | null;
-	newNo: number | null;
-	text: string;
-	// hunk rows only: the enclosing function/section context after the @@ range.
-	section?: string;
-	// add/del rows only: intra-line word-level highlight of what changed.
-	segments?: DiffSegment[];
-};
-
-// Git file-header lines carry no reviewable content, so they are hidden — the
-// panel reads like a diff instead of a raw `git diff` dump. Matched by prefix
-// after line endings are normalized, so it behaves the same on every OS.
-const gitHeaderPrefixes = [
-	"diff --git ",
-	"index ",
-	"old mode ",
-	"new mode ",
-	"new file mode ",
-	"deleted file mode ",
-	"similarity index ",
-	"dissimilarity index ",
-	"rename from ",
-	"rename to ",
-	"copy from ",
-	"copy to ",
-	"--- ",
-	"+++ ",
-];
-
-const hunkHeaderPattern = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
-
-// parseUnifiedDiff turns a raw `git diff` string into typed rows with real
-// per-side line numbers. Line endings are normalized first (Windows \r\n and
-// classic-Mac \r as well as Unix \n) so numbering and marker detection are
-// identical across operating systems.
-function parseUnifiedDiff(raw: string): DiffRow[] {
-	if (!raw) return [];
-	const lines = raw.replace(/\r\n?/g, "\n").split("\n");
-	if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
-	const rows: DiffRow[] = [];
-	let oldNo = 0;
-	let newNo = 0;
-	let inHunk = false;
-	for (const line of lines) {
-		if (gitHeaderPrefixes.some((prefix) => line.startsWith(prefix))) continue;
-		if (line.startsWith("@@")) {
-			const hunk = hunkHeaderPattern.exec(line);
-			oldNo = hunk ? Number(hunk[1]) : 1;
-			newNo = hunk ? Number(hunk[2]) : 1;
-			inHunk = true;
-			const sectionStart = line.indexOf("@@", 2);
-			const range = sectionStart >= 0 ? line.slice(0, sectionStart + 2) : line;
-			const section = sectionStart >= 0 ? line.slice(sectionStart + 2).trim() : "";
-			rows.push({ kind: "hunk", oldNo: null, newNo: null, text: range, section: section || undefined });
-			continue;
-		}
-		if (!inHunk) continue;
-		if (line.startsWith("\\")) continue; // "\ No newline at end of file"
-		const marker = line[0];
-		const text = line.slice(1);
-		if (marker === "+") {
-			rows.push({ kind: "add", oldNo: null, newNo, text });
-			newNo += 1;
-		} else if (marker === "-") {
-			rows.push({ kind: "del", oldNo, newNo: null, text });
-			oldNo += 1;
-		} else {
-			rows.push({ kind: "context", oldNo, newNo, text });
-			oldNo += 1;
-			newNo += 1;
-		}
-	}
-	annotateIntraLine(rows);
-	return rows;
-}
-
-// Longest line length still worth an intra-line (word-level) diff. The LCS is
-// O(tokens^2), so very long lines are left as whole-line highlights.
-const maxIntraLineChars = 400;
-
-// annotateIntraLine pairs each run of deleted lines with the equal-length run of
-// added lines that immediately follows it (a line-for-line replacement) and
-// marks the exact tokens that changed within each pair, so the UI can highlight
-// what actually changed instead of tinting the whole line.
-function annotateIntraLine(rows: DiffRow[]): void {
-	let i = 0;
-	while (i < rows.length) {
-		if (rows[i].kind !== "del") {
-			i += 1;
-			continue;
-		}
-		let delEnd = i;
-		while (delEnd < rows.length && rows[delEnd].kind === "del") delEnd += 1;
-		let addEnd = delEnd;
-		while (addEnd < rows.length && rows[addEnd].kind === "add") addEnd += 1;
-		const dels = delEnd - i;
-		const adds = addEnd - delEnd;
-		if (dels > 0 && dels === adds) {
-			for (let k = 0; k < dels; k += 1) {
-				const del = rows[i + k];
-				const add = rows[delEnd + k];
-				if (del.text.length > maxIntraLineChars || add.text.length > maxIntraLineChars) continue;
-				const { oldSegments, newSegments } = intraLineSegments(del.text, add.text);
-				del.segments = oldSegments;
-				add.segments = newSegments;
-			}
-		}
-		i = addEnd > i ? addEnd : i + 1;
-	}
-}
-
-function tokenizeLine(value: string): string[] {
-	return value.match(/\s+|[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g) ?? [];
-}
-
-function pushSegment(segments: DiffSegment[], text: string, changed: boolean): void {
-	const last = segments[segments.length - 1];
-	if (last && last.changed === changed) last.text += text;
-	else segments.push({ text, changed });
-}
-
-// intraLineSegments token-diffs two lines via LCS and returns the tokens that
-// only exist on one side marked as changed.
-function intraLineSegments(
-	oldText: string,
-	newText: string,
-): { oldSegments: DiffSegment[]; newSegments: DiffSegment[] } {
-	const a = tokenizeLine(oldText);
-	const b = tokenizeLine(newText);
-	const lcs: number[][] = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
-	for (let x = a.length - 1; x >= 0; x -= 1) {
-		for (let y = b.length - 1; y >= 0; y -= 1) {
-			lcs[x][y] = a[x] === b[y] ? lcs[x + 1][y + 1] + 1 : Math.max(lcs[x + 1][y], lcs[x][y + 1]);
-		}
-	}
-	const oldSegments: DiffSegment[] = [];
-	const newSegments: DiffSegment[] = [];
-	let x = 0;
-	let y = 0;
-	while (x < a.length && y < b.length) {
-		if (a[x] === b[y]) {
-			pushSegment(oldSegments, a[x], false);
-			pushSegment(newSegments, b[y], false);
-			x += 1;
-			y += 1;
-		} else if (lcs[x + 1][y] >= lcs[x][y + 1]) {
-			pushSegment(oldSegments, a[x], true);
-			x += 1;
-		} else {
-			pushSegment(newSegments, b[y], true);
-			y += 1;
-		}
-	}
-	while (x < a.length) pushSegment(oldSegments, a[x++], true);
-	while (y < b.length) pushSegment(newSegments, b[y++], true);
-	return { oldSegments, newSegments };
 }
 
 const diffRowTone: Record<Exclude<DiffRowKind, "hunk">, string> = {
@@ -794,6 +638,85 @@ type DiffViewMenuState = {
 	selectedText: string;
 };
 
+// SessionFilesView has no per-file scroll box — the Files panel is one
+// continuous list, and an expanded file's rows scroll as part of that same
+// shared container (`[data-files-scroll-root]`). Below the threshold every
+// row just renders directly, unchanged from before (the vast majority of
+// diffs never pay for any of this). Above it, only the rows actually
+// scrolled into view are mounted, via @tanstack/react-virtual attached to
+// that SHARED scroll container rather than a container of this file's own —
+// `scrollMargin` is this file's row-list's offset from the top of the shared
+// scrollable content, since the virtualizer needs that to know which of its
+// rows fall inside the current viewport. That offset shifts whenever
+// anything above this file changes height (another file expanding or
+// collapsing, or gaining/losing its own virtualized rows), so it's
+// re-measured via a ResizeObserver on the full file list rather than once.
+// Rows wrap (`whitespace-pre-wrap`) and the panel's available width varies a
+// lot — full window width when the Files view is maximized, much narrower
+// when docked alongside the terminal — so a long line can be one row of
+// height in the maximized view and several wrapped rows tall when docked.
+// ESTIMATED_ROW_HEIGHT is only the initial guess for a row that hasn't
+// rendered yet; `measureElement` corrects it to the row's real height once
+// mounted, which is what keeps rows from overlapping when they wrap.
+const ROW_VIRTUALIZE_THRESHOLD = 150;
+const ESTIMATED_ROW_HEIGHT = 20;
+
+function useSharedScrollRowVirtualizer(
+	scrollContainerRef: RefObject<HTMLElement | null>,
+	count: number,
+	enabled: boolean,
+) {
+	const listRef = useRef<HTMLDivElement>(null);
+	const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+	const [scrollMargin, setScrollMargin] = useState(0);
+
+	useEffect(() => {
+		if (!enabled) return;
+		setScrollElement(scrollContainerRef.current?.closest<HTMLElement>("[data-files-scroll-root]") ?? null);
+	}, [enabled, scrollContainerRef]);
+
+	// A regular effect, not useLayoutEffect: "Expand All" mounts many DiffView
+	// instances in the same commit, and React runs every layout effect from
+	// that commit synchronously, before the browser is allowed to paint
+	// anything. A read (getBoundingClientRect) here forces a synchronous
+	// layout — N of those back to back, all before first paint, is exactly
+	// what made "Expand All" stall. A plain effect still measures almost
+	// immediately (one frame later at worst), which is an imperceptible
+	// one-time cost for something that self-corrects, in exchange for never
+	// blocking paint on how many files just got expanded at once.
+	useEffect(() => {
+		if (!enabled || !scrollElement || !listRef.current) return;
+		const measure = () => {
+			if (!listRef.current) return;
+			const listRect = listRef.current.getBoundingClientRect();
+			const scrollRect = scrollElement.getBoundingClientRect();
+			setScrollMargin(listRect.top - scrollRect.top + scrollElement.scrollTop);
+		};
+		measure();
+		const resizeTarget = scrollElement.querySelector<HTMLElement>(".session-files-review-list") ?? scrollElement;
+		const observer = new ResizeObserver(measure);
+		observer.observe(resizeTarget);
+		return () => observer.disconnect();
+	}, [enabled, scrollElement]);
+
+	const virtualizer = useVirtualizer({
+		count,
+		getScrollElement: () => (enabled ? scrollElement : null),
+		estimateSize: () => ESTIMATED_ROW_HEIGHT,
+		// Every row outside the viewport that overscan pulls in is a row that
+		// still has to pay full first-time cost (render + a real DOM
+		// measurement, see useSharedScrollRowVirtualizer's comment above) the
+		// first time it's scrolled into range. A smaller buffer means fewer
+		// never-before-seen rows get force-measured on each scroll jump,
+		// trading a slightly higher chance of a one-frame blank edge during
+		// very fast scrolling for less of that first-pass cost on big files.
+		overscan: 8,
+		scrollMargin,
+	});
+
+	return { listRef, virtualizer };
+}
+
 function DiffView({
 	annotation,
 	filePath,
@@ -821,6 +744,8 @@ function DiffView({
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [hasSelection, setHasSelection] = useState(false);
 	const [menuState, setMenuState] = useState<DiffViewMenuState | null>(null);
+	const shouldVirtualize = !split && rows.length > ROW_VIRTUALIZE_THRESHOLD;
+	const { listRef, virtualizer } = useSharedScrollRowVirtualizer(containerRef, rows.length, shouldVirtualize);
 
 	useEffect(() => {
 		const onSelectionChange = () => {
@@ -885,53 +810,55 @@ function DiffView({
 				ref={containerRef}
 			>
 				{split ? (
-					<SplitDiff annotation={annotation} path={path} previousPath={previousPath} rows={rows} />
+					<SplitDiff annotation={annotation} path={path} previousPath={previousPath} rows={rows} t={t} />
+				) : shouldVirtualize ? (
+					<div
+						className={cn("relative", !wrap && "min-w-max")}
+						ref={listRef}
+						style={{ height: virtualizer.getTotalSize() }}
+					>
+						{virtualizer.getVirtualItems().map((virtualRow) => {
+							const row = rows[virtualRow.index];
+							return (
+								<div
+									data-index={virtualRow.index}
+									key={virtualRow.index}
+									ref={virtualizer.measureElement}
+									style={{
+										position: "absolute",
+										top: 0,
+										left: 0,
+										width: "100%",
+										transform: `translateY(${virtualRow.start - virtualizer.options.scrollMargin}px)`,
+									}}
+								>
+									<DiffRowContent
+										annotation={annotation}
+										index={virtualRow.index}
+										path={path}
+										previousPath={previousPath}
+										row={row}
+										t={t}
+										wrap={wrap}
+									/>
+								</div>
+							);
+						})}
+					</div>
 				) : (
 					<div className={cn(!wrap && "min-w-max")}>
-						{rows.map((row, index) =>
-							row.kind === "hunk" ? (
-								<HunkBand key={`h${index}`} row={row} />
-							) : (
-								<div key={`r${index}`}>
-									<div
-										className={cn("group/line relative flex", diffRowTone[row.kind])}
-										data-diff-row=""
-										data-kind={row.kind}
-										data-new-no={row.newNo ?? ""}
-										data-old-no={row.oldNo ?? ""}
-										data-row-index={index}
-									>
-										<LineFeedbackButton
-											active={isAnnotationRow(annotation.target, path, index)}
-											onClick={() => annotation.begin(lineAnnotationTarget(path, previousPath, row, index))}
-											target={lineAnnotationTarget(path, previousPath, row, index)}
-										/>
-										<span className="w-9 shrink-0 select-none border-r border-border/50 bg-terminal px-1.5 text-right text-passive/70 tabular-nums">
-											{row.newNo ?? row.oldNo ?? ""}
-										</span>
-										<span
-											className={cn(
-												"w-4 shrink-0 select-none text-center",
-												row.kind === "add" && "text-success",
-												row.kind === "del" && "text-error",
-											)}
-										>
-											{diffMarkerGlyph[row.kind]}
-										</span>
-										<span className={cn("pr-3", wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre")}>
-											{row.segments ? (
-												<DiffLineSegments add={row.kind === "add"} segments={row.segments} />
-											) : (
-												row.text || " "
-											)}
-										</span>
-									</div>
-									{isAnnotationRow(annotation.target, path, index) ? (
-										<FileAnnotationComposer annotation={annotation} />
-									) : null}
-								</div>
-							),
-						)}
+						{rows.map((row, index) => (
+							<DiffRowContent
+								annotation={annotation}
+								index={index}
+								key={index}
+								path={path}
+								previousPath={previousPath}
+								row={row}
+								t={t}
+								wrap={wrap}
+							/>
+						))}
 					</div>
 				)}
 			</div>
@@ -948,14 +875,90 @@ function DiffView({
 	);
 }
 
-function HunkBand({ row }: { row: DiffRow }) {
+const HunkBand = memo(function HunkBand({ row }: { row: DiffRow }) {
 	return (
 		<div className="flex select-none items-baseline gap-2 bg-surface-faint px-2.5 py-0.75 text-passive">
 			<span className="shrink-0 text-passive/70">{row.text}</span>
 			{row.section ? <span className="min-w-0 truncate text-passive/90">{row.section}</span> : null}
 		</div>
 	);
+});
+
+type DiffRowContentProps = {
+	annotation: FileAnnotationModel;
+	index: number;
+	path: string;
+	previousPath?: string;
+	row: DiffRow;
+	t: TFunction;
+	wrap: boolean;
+};
+
+// One unified-view diff row, shared between the plain (non-virtualized) and
+// virtualized render paths so they can't drift apart from each other.
+function DiffRowContentInner({ annotation, index, path, previousPath, row, t, wrap }: DiffRowContentProps) {
+	if (row.kind === "hunk") return <HunkBand row={row} />;
+	return (
+		<div>
+			<div
+				className={cn("group/line relative flex", diffRowTone[row.kind])}
+				data-diff-row=""
+				data-kind={row.kind}
+				data-new-no={row.newNo ?? ""}
+				data-old-no={row.oldNo ?? ""}
+				data-row-index={index}
+			>
+				<LineFeedbackButton
+					active={isAnnotationRow(annotation.target, path, index)}
+					onClick={() => annotation.begin(lineAnnotationTarget(path, previousPath, row, index))}
+					t={t}
+					target={lineAnnotationTarget(path, previousPath, row, index)}
+				/>
+				<span className="w-9 shrink-0 select-none border-r border-border/50 bg-terminal px-1.5 text-right text-passive/70 tabular-nums">
+					{row.newNo ?? row.oldNo ?? ""}
+				</span>
+				<span
+					className={cn(
+						"w-4 shrink-0 select-none text-center",
+						row.kind === "add" && "text-success",
+						row.kind === "del" && "text-error",
+					)}
+				>
+					{diffMarkerGlyph[row.kind]}
+				</span>
+				<span className={cn("pr-3", wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre")}>
+					{row.segments ? <DiffLineSegments add={row.kind === "add"} segments={row.segments} /> : row.text || " "}
+				</span>
+			</div>
+			{isAnnotationRow(annotation.target, path, index) ? <FileAnnotationComposer annotation={annotation} /> : null}
+		</div>
+	);
 }
+
+// `annotation` is a fresh object on every SessionFilesView render (its draft
+// text, send status, etc. all live there), so a plain memo would never skip
+// a re-render — every row would see a "changed" prop on every keystroke
+// anywhere in the panel, on top of every scroll tick. Only a row that IS or
+// WAS the active annotation target actually needs to re-render when
+// `annotation` changes; every other row only cares about `row`/`index`/
+// `path`/`previousPath`/`wrap`, which are stable across scroll-driven
+// re-renders. This is what actually lets scrolling skip re-running the
+// i18next calls, cn() calls, and nested Button for rows that are already
+// mounted and unchanged.
+const DiffRowContent = memo(DiffRowContentInner, (prev, next) => {
+	if (
+		prev.row !== next.row ||
+		prev.index !== next.index ||
+		prev.path !== next.path ||
+		prev.previousPath !== next.previousPath ||
+		prev.wrap !== next.wrap
+	) {
+		return false;
+	}
+	const prevActive = isAnnotationRow(prev.annotation.target, prev.path, prev.index);
+	const nextActive = isAnnotationRow(next.annotation.target, next.path, next.index);
+	return !prevActive && !nextActive;
+});
 
 type SplitRow =
 	| { kind: "hunk"; row: DiffRow }
@@ -1007,15 +1010,18 @@ function SplitDiff({
 	path,
 	previousPath,
 	rows,
+	t,
 }: {
 	annotation: FileAnnotationModel;
 	path: string;
 	previousPath?: string;
 	rows: DiffRow[];
+	t: TFunction;
 }) {
+	const splitRows = useMemo(() => toSplitRows(rows), [rows]);
 	return (
 		<div>
-			{toSplitRows(rows).map((splitRow, index) =>
+			{splitRows.map((splitRow, index) =>
 				splitRow.kind === "hunk" ? (
 					<HunkBand key={`sh${index}`} row={splitRow.row} />
 				) : (
@@ -1028,6 +1034,7 @@ function SplitDiff({
 								row={splitRow.left}
 								rowIndex={splitRow.leftIndex}
 								side="old"
+								t={t}
 							/>
 							<SplitSide
 								annotation={annotation}
@@ -1036,6 +1043,7 @@ function SplitDiff({
 								row={splitRow.right}
 								rowIndex={splitRow.rightIndex}
 								side="new"
+								t={t}
 							/>
 						</div>
 						{(splitRow.leftIndex !== null && isAnnotationRow(annotation.target, path, splitRow.leftIndex)) ||
@@ -1056,6 +1064,7 @@ function SplitSide({
 	row,
 	rowIndex,
 	side,
+	t,
 }: {
 	annotation: FileAnnotationModel;
 	path: string;
@@ -1063,6 +1072,7 @@ function SplitSide({
 	row: DiffRow | null;
 	rowIndex: number | null;
 	side: "old" | "new";
+	t: TFunction;
 }) {
 	if (!row || rowIndex === null) return <div className="bg-surface-faint/20" aria-hidden="true" />;
 	const lineNo = side === "old" ? row.oldNo : row.newNo;
@@ -1081,6 +1091,7 @@ function SplitSide({
 				<LineFeedbackButton
 					active={isAnnotationRow(annotation.target, path, rowIndex)}
 					onClick={() => annotation.begin(target)}
+					t={t}
 					target={target}
 				/>
 			) : null}
@@ -1118,16 +1129,22 @@ function isAnnotationRow(target: ActiveFileAnnotationTarget | null, path: string
 	return target?.path === path && target.side !== "file" && target.rowIndex === rowIndex;
 }
 
+// `t` comes from the caller (which already holds one useTranslation()
+// subscription) rather than calling useTranslation() here: this button is
+// invisible until hover on every diff row, and a virtualized file can mount
+// dozens of them per scroll tick — a separate i18n context subscription per
+// row added up on large files.
 function LineFeedbackButton({
 	active,
 	onClick,
+	t,
 	target,
 }: {
 	active: boolean;
 	onClick: () => void;
+	t: TFunction;
 	target: ActiveFileAnnotationTarget;
 }) {
-	const { t } = useTranslation();
 	if (active) return null;
 	const side = t(target.side === "old" ? "files.oldSide" : "files.newSide");
 	const label = t("files.addLineFeedback", { file: target.path, line: target.line, side });

--- a/frontend/src/renderer/hooks/useParsedDiff.ts
+++ b/frontend/src/renderer/hooks/useParsedDiff.ts
@@ -1,0 +1,101 @@
+import { useEffect, useMemo, useState } from "react";
+import { parseUnifiedDiff, type DiffRow } from "../lib/diff-parser";
+import DiffParserWorker from "../workers/diff-parser.worker?worker";
+import type { DiffParserRequest, DiffParserResponse } from "../workers/diff-parser.worker";
+
+// Below this, parsing synchronously on the render thread is already
+// effectively instant (a few ms at most) — routing through a worker would
+// only add message-passing latency for no benefit. Above it, parsing (in
+// particular the intra-line LCS highlighting) can take long enough to be
+// felt as a hitch, so it moves off the render thread entirely instead.
+const WORKER_DIFF_THRESHOLD_CHARS = 50_000;
+
+let sharedWorker: Worker | null = null;
+let sharedWorkerFailed = false;
+let nextRequestId = 0;
+const pendingRequests = new Map<number, { resolve: (rows: DiffRow[]) => void; reject: (error: Error) => void }>();
+
+// One worker instance shared across every open diff, not one per file: this
+// parser is cheap (no syntax highlighting, unlike e.g. @pierre/diffs), so a
+// single worker keeps up, and it avoids paying worker-startup cost on every
+// file open.
+function getSharedWorker(): Worker | null {
+	if (sharedWorkerFailed || typeof Worker === "undefined") return null;
+	if (sharedWorker) return sharedWorker;
+	try {
+		const worker = new DiffParserWorker();
+		worker.addEventListener("message", (event: MessageEvent<DiffParserResponse>) => {
+			const entry = pendingRequests.get(event.data.id);
+			if (!entry) return;
+			pendingRequests.delete(event.data.id);
+			if (event.data.ok) entry.resolve(event.data.rows);
+			else entry.reject(new Error(event.data.error));
+		});
+		worker.addEventListener("error", () => {
+			// A worker-level error (e.g. the script failed to load) doesn't carry a
+			// request id — fail everything in flight so callers fall back to
+			// parsing synchronously instead of hanging forever, and stop trying to
+			// use this worker going forward.
+			sharedWorkerFailed = true;
+			for (const [id, entry] of pendingRequests) {
+				entry.reject(new Error("diff parser worker failed"));
+				pendingRequests.delete(id);
+			}
+		});
+		sharedWorker = worker;
+	} catch {
+		sharedWorkerFailed = true;
+	}
+	return sharedWorker;
+}
+
+function parseInWorker(diff: string): Promise<DiffRow[]> {
+	const worker = getSharedWorker();
+	if (!worker) return Promise.reject(new Error("diff parser worker unavailable"));
+	return new Promise((resolve, reject) => {
+		const id = nextRequestId++;
+		pendingRequests.set(id, { resolve, reject });
+		const request: DiffParserRequest = { id, diff };
+		worker.postMessage(request);
+	});
+}
+
+export type ParsedDiffResult = {
+	rows: DiffRow[];
+	// True only while a large diff's worker parse is still in flight. Small
+	// diffs are never pending — they resolve synchronously on the same
+	// render, so callers can tell "still parsing" apart from "genuinely no
+	// changes" (rows.length === 0) without an extra render's delay.
+	pending: boolean;
+};
+
+// Parses `diff` into rows. Small diffs resolve synchronously on the very
+// first render, byte-for-byte the same behavior as calling parseUnifiedDiff
+// directly (this is the common case — the vast majority of diffs never pay
+// for anything below this line). Large diffs parse in a background worker so
+// the render thread never blocks on them; if the worker is unavailable or
+// fails (jsdom in tests, a CSP that blocks it, etc.), parsing falls back to
+// the same synchronous path rather than the diff silently never appearing.
+export function useParsedDiff(diff: string): ParsedDiffResult {
+	const isSmall = diff.length < WORKER_DIFF_THRESHOLD_CHARS;
+	const syncRows = useMemo(() => (isSmall ? parseUnifiedDiff(diff) : null), [diff, isSmall]);
+	const [asyncResult, setAsyncResult] = useState<{ diff: string; rows: DiffRow[] } | null>(null);
+
+	useEffect(() => {
+		if (isSmall) return;
+		let cancelled = false;
+		parseInWorker(diff)
+			.catch(() => parseUnifiedDiff(diff))
+			.then((rows) => {
+				if (cancelled) return;
+				setAsyncResult({ diff, rows });
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [diff, isSmall]);
+
+	if (isSmall) return { rows: syncRows ?? [], pending: false };
+	if (asyncResult?.diff === diff) return { rows: asyncResult.rows, pending: false };
+	return { rows: [], pending: true };
+}

--- a/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
+++ b/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
@@ -28,7 +28,11 @@ export function sessionWorkspaceFilesQueryOptions(sessionId: string, errorMessag
 	return {
 		queryKey: sessionWorkspaceFilesQueryKey(sessionId),
 		queryFn: () => fetchSessionWorkspaceFiles(sessionId, errorMessage),
-		refetchInterval: 3500,
+		// SSE (subscribeWorkspaceFileChanges) already invalidates this query
+		// immediately on real filesystem changes and on reconnect, triggering
+		// an instant refetch regardless of this interval. Polling is only a
+		// safety net for missed/dropped SSE events, so it can stay slow.
+		refetchInterval: 30_000,
 	};
 }
 

--- a/frontend/src/renderer/lib/diff-parser.ts
+++ b/frontend/src/renderer/lib/diff-parser.ts
@@ -1,0 +1,165 @@
+// Pure diff-parsing logic shared between the main thread (small diffs, where
+// a worker round-trip would cost more than it saves) and the diff-parser Web
+// Worker (large diffs, where this keeps the parse + intra-line LCS off the
+// render thread entirely). No DOM, no React — safe to run in either context.
+
+export type DiffRowKind = "context" | "add" | "del" | "hunk";
+
+export type DiffSegment = { text: string; changed: boolean };
+
+export type DiffRow = {
+	kind: DiffRowKind;
+	oldNo: number | null;
+	newNo: number | null;
+	text: string;
+	// hunk rows only: the enclosing function/section context after the @@ range.
+	section?: string;
+	// add/del rows only: intra-line word-level highlight of what changed.
+	segments?: DiffSegment[];
+};
+
+// Git file-header lines carry no reviewable content, so they are hidden — the
+// panel reads like a diff instead of a raw `git diff` dump. Matched by prefix
+// after line endings are normalized, so it behaves the same on every OS.
+const gitHeaderPrefixes = [
+	"diff --git ",
+	"index ",
+	"old mode ",
+	"new mode ",
+	"new file mode ",
+	"deleted file mode ",
+	"similarity index ",
+	"dissimilarity index ",
+	"rename from ",
+	"rename to ",
+	"copy from ",
+	"copy to ",
+	"--- ",
+	"+++ ",
+];
+
+const hunkHeaderPattern = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+// parseUnifiedDiff turns a raw `git diff` string into typed rows with real
+// per-side line numbers. Line endings are normalized first (Windows \r\n and
+// classic-Mac \r as well as Unix \n) so numbering and marker detection are
+// identical across operating systems.
+export function parseUnifiedDiff(raw: string): DiffRow[] {
+	if (!raw) return [];
+	const lines = raw.replace(/\r\n?/g, "\n").split("\n");
+	if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+	const rows: DiffRow[] = [];
+	let oldNo = 0;
+	let newNo = 0;
+	let inHunk = false;
+	for (const line of lines) {
+		if (gitHeaderPrefixes.some((prefix) => line.startsWith(prefix))) continue;
+		if (line.startsWith("@@")) {
+			const hunk = hunkHeaderPattern.exec(line);
+			oldNo = hunk ? Number(hunk[1]) : 1;
+			newNo = hunk ? Number(hunk[2]) : 1;
+			inHunk = true;
+			const sectionStart = line.indexOf("@@", 2);
+			const range = sectionStart >= 0 ? line.slice(0, sectionStart + 2) : line;
+			const section = sectionStart >= 0 ? line.slice(sectionStart + 2).trim() : "";
+			rows.push({ kind: "hunk", oldNo: null, newNo: null, text: range, section: section || undefined });
+			continue;
+		}
+		if (!inHunk) continue;
+		if (line.startsWith("\\")) continue; // "\ No newline at end of file"
+		const marker = line[0];
+		const text = line.slice(1);
+		if (marker === "+") {
+			rows.push({ kind: "add", oldNo: null, newNo, text });
+			newNo += 1;
+		} else if (marker === "-") {
+			rows.push({ kind: "del", oldNo, newNo: null, text });
+			oldNo += 1;
+		} else {
+			rows.push({ kind: "context", oldNo, newNo, text });
+			oldNo += 1;
+			newNo += 1;
+		}
+	}
+	annotateIntraLine(rows);
+	return rows;
+}
+
+// Longest line length still worth an intra-line (word-level) diff. The LCS is
+// O(tokens^2), so very long lines are left as whole-line highlights.
+const maxIntraLineChars = 400;
+
+// annotateIntraLine pairs each run of deleted lines with the equal-length run of
+// added lines that immediately follows it (a line-for-line replacement) and
+// marks the exact tokens that changed within each pair, so the UI can highlight
+// what actually changed instead of tinting the whole line.
+function annotateIntraLine(rows: DiffRow[]): void {
+	let i = 0;
+	while (i < rows.length) {
+		if (rows[i].kind !== "del") {
+			i += 1;
+			continue;
+		}
+		let delEnd = i;
+		while (delEnd < rows.length && rows[delEnd].kind === "del") delEnd += 1;
+		let addEnd = delEnd;
+		while (addEnd < rows.length && rows[addEnd].kind === "add") addEnd += 1;
+		const dels = delEnd - i;
+		const adds = addEnd - delEnd;
+		if (dels > 0 && dels === adds) {
+			for (let k = 0; k < dels; k += 1) {
+				const del = rows[i + k];
+				const add = rows[delEnd + k];
+				if (del.text.length > maxIntraLineChars || add.text.length > maxIntraLineChars) continue;
+				const { oldSegments, newSegments } = intraLineSegments(del.text, add.text);
+				del.segments = oldSegments;
+				add.segments = newSegments;
+			}
+		}
+		i = addEnd > i ? addEnd : i + 1;
+	}
+}
+
+function tokenizeLine(value: string): string[] {
+	return value.match(/\s+|[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g) ?? [];
+}
+
+function pushSegment(segments: DiffSegment[], text: string, changed: boolean): void {
+	const last = segments[segments.length - 1];
+	if (last && last.changed === changed) last.text += text;
+	else segments.push({ text, changed });
+}
+
+// intraLineSegments token-diffs two lines via LCS and returns the tokens that
+// only exist on one side marked as changed.
+function intraLineSegments(oldText: string, newText: string): { oldSegments: DiffSegment[]; newSegments: DiffSegment[] } {
+	const a = tokenizeLine(oldText);
+	const b = tokenizeLine(newText);
+	const lcs: number[][] = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
+	for (let x = a.length - 1; x >= 0; x -= 1) {
+		for (let y = b.length - 1; y >= 0; y -= 1) {
+			lcs[x][y] = a[x] === b[y] ? lcs[x + 1][y + 1] + 1 : Math.max(lcs[x + 1][y], lcs[x][y + 1]);
+		}
+	}
+	const oldSegments: DiffSegment[] = [];
+	const newSegments: DiffSegment[] = [];
+	let x = 0;
+	let y = 0;
+	while (x < a.length && y < b.length) {
+		if (a[x] === b[y]) {
+			pushSegment(oldSegments, a[x], false);
+			pushSegment(newSegments, b[y], false);
+			x += 1;
+			y += 1;
+		} else if (lcs[x + 1][y] >= lcs[x][y + 1]) {
+			pushSegment(oldSegments, a[x], true);
+			x += 1;
+		} else {
+			pushSegment(newSegments, b[y], true);
+			y += 1;
+		}
+	}
+	while (x < a.length) pushSegment(oldSegments, a[x++], true);
+	while (y < b.length) pushSegment(newSegments, b[y++], true);
+	return { oldSegments, newSegments };
+}

--- a/frontend/src/renderer/workers/diff-parser.worker.ts
+++ b/frontend/src/renderer/workers/diff-parser.worker.ts
@@ -1,0 +1,37 @@
+// Runs parseUnifiedDiff (parsing + the intra-line LCS highlighting) off the
+// render thread for large diffs. See useParsedDiff, which only routes here
+// above a size threshold — small diffs stay on the main thread since a
+// worker round-trip costs more than the parse itself for those.
+//
+// The project's tsconfig only loads the "DOM" lib (no "WebWorker"), since
+// this is the one file in the renderer that runs in a worker context rather
+// than a window — adding "WebWorker" globally would mix incompatible global
+// types (self/postMessage disagree between the two libs) across every other
+// file. Casting the worker's global scope through `Worker` sidesteps that
+// without touching the shared tsconfig.
+import { parseUnifiedDiff, type DiffRow } from "../lib/diff-parser";
+
+export type DiffParserRequest = {
+	id: number;
+	diff: string;
+};
+
+export type DiffParserResponse = { id: number; ok: true; rows: DiffRow[] } | { id: number; ok: false; error: string };
+
+const worker = self as unknown as Worker;
+
+worker.addEventListener("message", (event: MessageEvent<DiffParserRequest>) => {
+	const { id, diff } = event.data;
+	try {
+		const rows = parseUnifiedDiff(diff);
+		const response: DiffParserResponse = { id, ok: true, rows };
+		worker.postMessage(response);
+	} catch (error) {
+		const response: DiffParserResponse = {
+			id,
+			ok: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+		worker.postMessage(response);
+	}
+});


### PR DESCRIPTION
## Summary

Opening or scrolling a large file's diff in the session Files panel could block the render thread and spawn redundant git subprocesses per request, making the whole app feel unresponsive. This fixes it end to end, backend and frontend.

**Backend (workspace file/diff serving):**
- Parallelize the independent git subprocess calls in `workspaceChangeMaps`/`workspaceFileSummaries` instead of running them sequentially.
- Add a short-TTL cache for resolved compare/status data (`workspace_cache.go`), invalidated by the workspace filesystem watcher's SSE stream on real changes, so expanding a file right after the list loads doesn't redundantly recompute it.
- Coalesce concurrent cache-miss lookups for the same session/root via `singleflight`, so "Expand All" firing many `GetWorkspaceFile` calls at once shares one computation instead of each spawning its own git calls.
- Fix a misclassification where tracked binary Added files were treated as untracked (`git diff --numstat` omits binary files even when tracked, which isn't the same as being untracked), which produced an incorrect synthetic diff instead of the real one.

**Frontend (`SessionFilesView`):**
- Virtualize the diff row list against the shared scroll container (`@tanstack/react-virtual`) so only rows actually scrolled into view mount, with dynamic per-row measurement for correct heights under line-wrapping at any panel width (docked vs. maximized).
- Memoize per-row rendering and thread the i18n `t` function down instead of every row independently subscribing to the translation context.
- Move diff parsing (`parseUnifiedDiff` + the intra-line LCS highlighting) into a Web Worker for large diffs, with a synchronous fallback if the worker is unavailable; small diffs keep parsing synchronously with no behavior change.
- Reduce the workspace files list's polling interval now that the SSE stream already invalidates it on real changes, cutting redundant backend load.

## Test plan

- [x] `go build ./...` and `go test ./internal/service/session/... ./internal/httpd/controllers/... ./internal/cli/...` — all pass
- [x] `tsc --noEmit` — clean
- [x] `SessionFilesView.test.tsx` (31 tests, including new coverage for row virtualization and the diff-parser worker fallback path) — all pass
- [x] Production `vite build` — confirms the diff-parser worker bundles correctly as its own same-origin chunk, compatible with the existing CSP
- [ ] Manual verification in the packaged Electron app on a real large diff (recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)