### PR TITLE
fix(ci): reuse migrated SQLite test fixtures

### DIFF
--- a/backend/internal/cdc/cdc_test.go
+++ b/backend/internal/cdc/cdc_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 func newStore(t *testing.T) *sqlite.Store {
 	t.Helper()
-	s, err := sqlite.Open(t.TempDir())
+	s, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/daemon/telemetry_wiring_test.go
+++ b/backend/internal/daemon/telemetry_wiring_test.go
@@ -11,7 +11,7 @@ import (
 	telemetryadapter "github.com/aoagents/agent-orchestrator/backend/internal/adapters/telemetry"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
-	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 func TestNewTelemetrySink_DefaultsToNoopWhenDisabled(t *testing.T) {
@@ -30,7 +30,7 @@ func TestNewTelemetrySink_MetricsOnlyDoesNotEnableEvents(t *testing.T) {
 
 func TestNewTelemetrySink_UsesLocalSQLiteWhenEnabled(t *testing.T) {
 	dataDir := t.TempDir()
-	store, err := sqlite.Open(dataDir)
+	store, err := sqlitetest.Open(dataDir)
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestNewTelemetrySink_UsesLocalSQLiteWhenEnabled(t *testing.T) {
 
 func TestNewTelemetrySink_FanoutIncludesPostHogWhenConfigured(t *testing.T) {
 	dataDir := t.TempDir()
-	store, err := sqlite.Open(dataDir)
+	store, err := sqlitetest.Open(dataDir)
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
 	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
-	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 // TestWiring_WriteFlowsToBroadcaster exercises the real boot path end to end:
@@ -30,7 +30,7 @@ import (
 // broadcaster, through the same cdc.Source implementation the daemon uses.
 func TestWiring_WriteFlowsToBroadcaster(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +171,7 @@ func TestWiring_ActiveTurnSteeringComesFromAdapters(t *testing.T) {
 // gitworktree workspace + session manager over the shared store/LCM), which is
 // what gets mounted at httpd APIDeps.Sessions.
 func TestWiring_StartSessionBuildsSessionService(t *testing.T) {
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestWiring_StartSessionBuildsSessionService(t *testing.T) {
 
 func TestWiring_StartSessionSpawnsScratchWithoutGitRepo(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +284,7 @@ func TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "")
 
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken(t *testing.T) {
 
 func TestWiring_SeedScratchProjectOnBootUsesDataDir(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +347,7 @@ func TestWiring_SeedScratchProjectOnBootUsesDataDir(t *testing.T) {
 // intake after daemon boot was silently never picked up until a restart. The
 // loop must always start; Poll is what decides whether there's work to do.
 func TestStartTrackerIntake_RunsEvenWithoutEnabledProjects(t *testing.T) {
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +410,7 @@ func (c *captureRuntimeSender) SendMessage(_ context.Context, handle ports.Runti
 // TestWiring_SessionMessengerSendsToRuntimePane asserts the daemon wires ao
 // send to the live runtime pane and resolves the handle from the shared store.
 func TestWiring_SessionMessengerSendsToRuntimePane(t *testing.T) {
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -443,7 +443,7 @@ func TestWiring_SessionMessengerSendsToRuntimePane(t *testing.T) {
 }
 
 func TestWiring_SessionMessengerWrapsLookupErrors(t *testing.T) {
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -457,7 +457,7 @@ func TestWiring_SessionMessengerWrapsLookupErrors(t *testing.T) {
 }
 
 func TestWiring_SessionMessengerRequiresRuntimeHandle(t *testing.T) {
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -482,7 +482,7 @@ func TestWiring_SessionMessengerRequiresRuntimeHandle(t *testing.T) {
 }
 
 func TestWiring_SessionMessengerRejectsTerminatedSession(t *testing.T) {
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ func TestWiring_StartLifecycleThreadsMessengerIntoLCM(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Cancel must run BEFORE Stop so the reaper goroutine's ctx.Done() fires;
 	// Stop is a no-op otherwise. Cleanup is LIFO, so register Stop first.
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -581,7 +581,7 @@ func TestWiring_StartLifecycleThreadsMessengerIntoLCM(t *testing.T) {
 // resolver turns a registered project into its on-disk repo path (so spawns
 // materialise a worktree), and fails loudly for an unregistered project.
 func TestProjectRepoResolver_ResolvesRegisteredProject(t *testing.T) {
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/devimport/importer_test.go
+++ b/backend/internal/devimport/importer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 func TestRunImportsIntoEmptyTarget(t *testing.T) {
@@ -369,7 +370,7 @@ func TestRunCopiesWorkspaceChildRepos(t *testing.T) {
 
 func newStore(t *testing.T) *sqlite.Store {
 	t.Helper()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -31,7 +31,7 @@ import (
 
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 // emptyGetManager returns a GetResult that sets neither Project nor Degraded —
@@ -80,7 +80,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 
 	if err != nil {
 

--- a/backend/internal/integration/lifecycle_sqlite_test.go
+++ b/backend/internal/integration/lifecycle_sqlite_test.go
@@ -13,6 +13,7 @@ import (
 	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
 	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 type stubRuntime struct {
@@ -128,7 +129,7 @@ type stack struct {
 func newStack(t *testing.T) *stack {
 	t.Helper()
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/integration/scm_observer_test.go
+++ b/backend/internal/integration/scm_observer_test.go
@@ -24,6 +24,7 @@ import (
 	scmobserve "github.com/aoagents/agent-orchestrator/backend/internal/observe/scm"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 var scmTestRepo = ports.SCMRepo{
@@ -180,7 +181,7 @@ func newSCMFixture(t *testing.T, branch string) *scmFixture {
 	t.Helper()
 	ctx := context.Background()
 
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("sqlite.Open: %v", err)
 	}

--- a/backend/internal/observe/activity/observer_integration_test.go
+++ b/backend/internal/observe/activity/observer_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
-	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 func TestObserverIntegrationReconcilesRealTmuxOutputIntoSQLite(t *testing.T) {
@@ -40,7 +40,7 @@ func TestObserverIntegrationReconcilesRealTmuxOutputIntoSQLite(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			store, err := sqlite.Open(t.TempDir())
+			store, err := sqlitetest.Open(t.TempDir())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/backend/internal/observe/usage/test_helpers_test.go
+++ b/backend/internal/observe/usage/test_helpers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 func parseRecords(source domain.UsageSourceContext, records []jsonlRecord, nextOffset int64, now time.Time) parseResult {
@@ -37,7 +38,7 @@ func seedUsageTestSession(
 	now time.Time,
 ) (*sqlite.Store, domain.SessionRecord) {
 	t.Helper()
-	store, err := sqlite.Open(dataDir)
+	store, err := sqlitetest.Open(dataDir)
 	mustNoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 	ctx := context.Background()

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	chatsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/chat"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/store"
 )
 
@@ -29,11 +30,7 @@ const (
 func openStore(t *testing.T) *sqlite.Store {
 	t.Helper()
 	dir := t.TempDir()
-	st, err := sqlite.Open(dir)
-	if err != nil {
-		t.Fatalf("open store: %v", err)
-	}
-	t.Cleanup(func() { _ = st.Close() })
+	st := sqlitetest.MustOpenAt(t, dir)
 
 	ctx := context.Background()
 	if err := st.UpsertProject(ctx, domain.ProjectRecord{

--- a/backend/internal/service/devimport/service_test.go
+++ b/backend/internal/service/devimport/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 func TestRunProjectsDryRunWritesNothing(t *testing.T) {
@@ -112,7 +113,7 @@ func TestRunProjectsRejectsSymlinkedSameSourceAndTarget(t *testing.T) {
 
 func openStore(t *testing.T, dataDir string) *sqlite.Store {
 	t.Helper()
-	store, err := sqlite.Open(dataDir)
+	store, err := sqlitetest.Open(dataDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -15,15 +15,15 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/service/project"
-	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
-// newManager builds a Manager over a real, throwaway sqlite store (pure-Go
-// driver, migrations run on Open) — no in-memory store.
+// newManager builds a Manager over a real, isolated sqlite store cloned from a
+// current migrated template — no in-memory store.
 func newManager(t *testing.T) project.Manager {
 	t.Helper()
 	t.Setenv("GIT_CEILING_DIRECTORIES", os.TempDir())
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestManager_AddListGetRemove(t *testing.T) {
 
 func TestManager_AddEmitsProjectAndFirstProjectTelemetry(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestManager_AddEmitsProjectAndFirstProjectTelemetry(t *testing.T) {
 
 func TestManager_AddDoesNotRepeatFirstProjectTelemetry(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestManager_AddDoesNotRepeatFirstProjectTelemetry(t *testing.T) {
 
 func TestManager_EnsureDefaultScratchProjectSeedsFreshRegistry(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestManager_EnsureDefaultScratchProjectSeedsFreshRegistry(t *testing.T) {
 
 func TestManager_EnsureDefaultScratchProjectDoesNotReseedWithActiveProject(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -299,7 +299,7 @@ func TestManager_EnsureDefaultScratchProjectDoesNotReseedWithActiveProject(t *te
 
 func TestManager_EnsureDefaultScratchProjectReseedsAfterArchivedScratchLeavesNoActiveProjects(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -335,7 +335,7 @@ func TestManager_EnsureDefaultScratchProjectReseedsAfterArchivedScratchLeavesNoA
 
 func TestManager_SetConfigRejectsScratchGitOnlyFields(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestManager_SetConfigRejectsScratchGitOnlyFields(t *testing.T) {
 
 func TestManager_RemoveTeardownsBeforeArchive(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestManager_RemoveTeardownsBeforeArchive(t *testing.T) {
 
 func TestManager_RemoveDoesNotArchiveWhenTeardownFails(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
@@ -454,7 +454,7 @@ func TestManager_DefaultsWhenUnconfigured(t *testing.T) {
 
 func TestManager_GetUsesConfiguredDefaultHarness(t *testing.T) {
 	ctx := context.Background()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}

--- a/backend/internal/service/usage/collector_budget_test.go
+++ b/backend/internal/service/usage/collector_budget_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 const (
@@ -296,7 +297,7 @@ func TestCollectorCodexBudgetFinalizationWaitsThenPersistsPartialAcrossRestart(t
 func testCollectorCodexBudgetFinalizationWaitsThenPersistsPartialAcrossRestart(t *testing.T, hookEvent string) {
 	ctx := context.Background()
 	dataDir := t.TempDir()
-	store, err := sqlite.Open(dataDir)
+	store, err := sqlitetest.Open(dataDir)
 	mustNoError(t, err)
 	root := t.TempDir()
 	now := time.Unix(1700000000, 0).UTC()

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 func TestCollectorRegistersFinalizesAndReactivatesSource(t *testing.T) {
@@ -1706,7 +1707,7 @@ func TestSourceIdentityDoesNotChangeAsFirstRecordIsWritten(t *testing.T) {
 
 func collectorTestStore(t *testing.T) *sqlite.Store {
 	t.Helper()
-	store, err := sqlite.Open(t.TempDir())
+	store, err := sqlitetest.Open(t.TempDir())
 	mustNoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 	if err := store.UpsertProject(context.Background(), domain.ProjectRecord{

--- a/backend/internal/storage/sqlite/sqlitetest/sqlitetest.go
+++ b/backend/internal/storage/sqlite/sqlitetest/sqlitetest.go
@@ -1,0 +1,111 @@
+// Package sqlitetest provides isolated, fully migrated SQLite stores for tests.
+package sqlitetest
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+var databaseTemplate struct {
+	sync.Once
+	data []byte
+	err  error
+}
+
+// Open returns a store cloned from a database migrated once for the current
+// test binary. dataDir may contain unrelated fixture files, but it must not
+// already contain ao.db. Tests that exercise migration behavior should continue
+// to call sqlite.Open directly with an empty directory.
+func Open(dataDir string) (*sqlite.Store, error) {
+	template, err := templateDatabase()
+	if err != nil {
+		return nil, fmt.Errorf("build migrated template: %w", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create data dir: %w", err)
+	}
+	dbPath := filepath.Join(dataDir, "ao.db")
+	if err := writeExclusive(dbPath, template); err != nil {
+		return nil, fmt.Errorf("clone migrated template: %w", err)
+	}
+
+	store, err := sqlite.Open(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("open cloned store: %w", err)
+	}
+	return store, nil
+}
+
+// MustOpen returns an isolated store and registers its cleanup with t.
+func MustOpen(t testing.TB) *sqlite.Store {
+	t.Helper()
+	return MustOpenAt(t, t.TempDir())
+}
+
+// MustOpenAt is MustOpen for callers that also use dataDir for other fixtures.
+func MustOpenAt(t testing.TB, dataDir string) *sqlite.Store {
+	t.Helper()
+
+	store, err := Open(dataDir)
+	if err != nil {
+		t.Fatalf("open cloned SQLite test store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close cloned SQLite test store: %v", err)
+		}
+	})
+	return store
+}
+
+func templateDatabase() ([]byte, error) {
+	databaseTemplate.Do(func() {
+		databaseTemplate.data, databaseTemplate.err = buildTemplateDatabase()
+	})
+	return databaseTemplate.data, databaseTemplate.err
+}
+
+func buildTemplateDatabase() ([]byte, error) {
+	dataDir, err := os.MkdirTemp("", "ao-sqlite-test-template-")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dataDir) }()
+
+	store, err := sqlite.Open(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("migrate template: %w", err)
+	}
+	if err := store.Close(); err != nil {
+		return nil, fmt.Errorf("close template: %w", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dataDir, "ao.db"))
+	if err != nil {
+		return nil, fmt.Errorf("read template: %w", err)
+	}
+	return data, nil
+}
+
+func writeExclusive(path string, data []byte) (err error) {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+	written, err := file.Write(data)
+	if err == nil && written != len(data) {
+		err = io.ErrShortWrite
+	}
+	return err
+}

--- a/backend/internal/storage/sqlite/sqlitetest/sqlitetest_test.go
+++ b/backend/internal/storage/sqlite/sqlitetest/sqlitetest_test.go
@@ -1,0 +1,43 @@
+package sqlitetest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
+)
+
+func TestOpenReturnsCurrentIsolatedStores(t *testing.T) {
+	first := sqlitetest.MustOpen(t)
+	if err := first.UpsertProject(context.Background(), domain.ProjectRecord{
+		ID:           "first",
+		Path:         "/tmp/first",
+		RegisteredAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed first store: %v", err)
+	}
+
+	second := sqlitetest.MustOpen(t)
+	if _, found, err := second.GetProject(context.Background(), "first"); err != nil {
+		t.Fatalf("read second store: %v", err)
+	} else if found {
+		t.Fatal("second store inherited rows from first store")
+	}
+}
+
+func TestOpenRefusesToReplaceExistingDatabase(t *testing.T) {
+	dataDir := t.TempDir()
+	store, err := sqlitetest.Open(dataDir)
+	if err != nil {
+		t.Fatalf("open first store: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close first store: %v", err)
+	}
+
+	if _, err := sqlitetest.Open(dataDir); err == nil {
+		t.Fatal("second open replaced an existing database")
+	}
+}

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -12,16 +12,12 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
 
 func newTestStore(t *testing.T) *sqlite.Store {
 	t.Helper()
-	s, err := sqlite.Open(t.TempDir())
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	t.Cleanup(func() { _ = s.Close() })
-	return s
+	return sqlitetest.MustOpen(t)
 }
 
 func seedProject(t *testing.T, s *sqlite.Store, id string) {


### PR DESCRIPTION
## Summary

- build a fully migrated SQLite template once per test binary and clone it for each isolated fixture
- route non-migration store, chat, usage, project, daemon, and integration tests through the shared helper
- keep migration tests and the persistence/reopen test on the real `sqlite.Open` path
- refuse to overwrite an existing `ao.db` and cover both fixture isolation and overwrite safety

## Why

`go test -race ./...` was replaying all 60 migrations for nearly every real-database test. The store package reached Go's 10-minute package timeout, while the chat package was taking 7-10 minutes and competing for the same runner CPU.

No tests are removed. The change preserves a separate on-disk database per test while avoiding repeated migration DDL.

Local before/after measurements:

| Suite | Before | After |
| --- | ---: | ---: |
| SQLite store, `-race` | 523.5s | 24.3s |
| Chat, `-race` | 416-572s in CI | 24.2s |
| Full `go test -race -count=1 ./...` | 14-19m in CI | 2m06s locally |

## Validation

- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- golangci-lint v2.12.2: 0 issues
- all affected packages pass with and without `-race`
- full race run completed in 2m06s; one unrelated existing OpenCode auth test with a fixed 3s deadline failed under full local concurrency and passed immediately in isolation
