### PR TITLE
fix(frontend): only confirm busy interface switches in chatUI

### DIFF
--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -541,37 +541,78 @@ describe("SessionView", () => {
 		expect(screen.getByText("chat surface")).toBeInTheDocument();
 	});
 
-	it("opens the switch policy dialog from TUI instead of auto-starting", () => {
+	it.each([
+		["Terminal UI worker", "sess-1", "tui", "chat", "Switch to chat UI"],
+		["Terminal UI orchestrator", "sess-orch", "tui", "chat", "Switch to chat UI"],
+		["Chat worker", "sess-1", "chat", "tui", "Switch to terminal UI"],
+		["Chat orchestrator", "sess-orch", "chat", "tui", "Switch to terminal UI"],
+	] as const)("switches an idle %s directly with drain", (_label, sessionId, mode, targetMode, buttonName) => {
+		interfaceTransitionState.status = { supported: true, targetMode };
+		const session = workerSession(sessionId);
+		session.mode = mode;
+		session.status = "idle";
+		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
+
+		render(<SessionView sessionId={sessionId} />);
+
+		fireEvent.click(screen.getByRole("button", { name: buttonName }));
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		expect(interfaceTransitionMock.start).toHaveBeenCalledWith({ targetMode, policy: "drain" });
+	});
+
+	it("keeps the policy dialog closed when an idle direct switch fails", async () => {
 		interfaceTransitionState.status = { supported: true, targetMode: "chat" };
 		const session = workerSession("sess-1");
 		session.status = "idle";
 		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
+		interfaceTransitionMock.start.mockRejectedValueOnce(new Error("switch failed"));
+
+		render(<SessionView sessionId="sess-1" />);
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Switch to chat UI" }));
+		});
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it.each([
+		["working status", "sess-1", "tui", "chat", "Switch to chat UI", "working", "idle"],
+		["needs-input status", "sess-orch", "tui", "chat", "Switch to chat UI", "needs_input", "idle"],
+		["active activity", "sess-1", "chat", "tui", "Switch to terminal UI", "idle", "active"],
+		["waiting-input activity", "sess-orch", "chat", "tui", "Switch to terminal UI", "idle", "waiting_input"],
+		["blocked activity", "sess-1", "tui", "chat", "Switch to chat UI", "idle", "blocked"],
+	] as const)("opens the switch policy dialog for %s", (_label, sessionId, mode, targetMode, buttonName, status, activityState) => {
+		interfaceTransitionState.status = { supported: true, targetMode };
+		const session = workerSession(sessionId);
+		session.mode = mode;
+		session.status = status;
+		session.activity = { state: activityState, lastActivityAt: "2026-08-06T00:00:00Z" };
+
+		render(<SessionView sessionId={sessionId} />);
+
+		fireEvent.click(screen.getByRole("button", { name: buttonName }));
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(interfaceTransitionMock.start).not.toHaveBeenCalled();
+	});
+
+	it("checks only the selected session when deciding whether to show the policy dialog", () => {
+		interfaceTransitionState.status = { supported: true, targetMode: "chat" };
+		const selected = workerSession("sess-1");
+		selected.status = "idle";
+		selected.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
+		const other = workerSession("sess-2");
+		other.status = "working";
+		other.activity = { state: "active", lastActivityAt: "2026-08-06T00:00:00Z" };
 
 		render(<SessionView sessionId="sess-1" />);
 
 		fireEvent.click(screen.getByRole("button", { name: "Switch to chat UI" }));
 
-		expect(screen.getByRole("dialog")).toHaveTextContent("Switch to Chat UI?");
-		expect(screen.getByRole("button", { name: /Finish work, then switch/ })).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: /Stop now and switch/ })).toBeInTheDocument();
-		expect(interfaceTransitionMock.start).not.toHaveBeenCalled();
-	});
-
-	it("opens the switch policy dialog from Chat instead of auto-starting", () => {
-		interfaceTransitionState.status = { supported: true, targetMode: "tui" };
-		const session = workerSession("sess-1");
-		session.mode = "chat";
-		session.status = "idle";
-		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
-
-		render(<SessionView sessionId="sess-1" />);
-
-		fireEvent.click(screen.getByRole("button", { name: "Switch to terminal UI" }));
-
-		expect(screen.getByRole("dialog")).toHaveTextContent("Switch to Terminal UI?");
-		expect(screen.getByRole("button", { name: /Finish work, then switch/ })).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: /Stop now and switch/ })).toBeInTheDocument();
-		expect(interfaceTransitionMock.start).not.toHaveBeenCalled();
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		expect(interfaceTransitionMock.start).toHaveBeenCalledWith({ targetMode: "chat", policy: "drain" });
 	});
 
 	it("walks backward through auxiliary terminals before returning to the permanent terminal", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -247,6 +247,14 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const interfaceTarget =
 		(activeInterfaceTransition ? interfaceSwitch.transition?.targetMode : interfaceSwitch.status?.targetMode) ??
 		(session?.mode === "chat" ? "tui" : "chat");
+	const interfaceBusy = Boolean(
+		session &&
+		(session.status === "working" ||
+			session.status === "needs_input" ||
+			session.activity?.state === "active" ||
+			session.activity?.state === "waiting_input" ||
+			session.activity?.state === "blocked"),
+	);
 	const interfaceWaitingForInput = Boolean(
 		session &&
 		(session.status === "needs_input" ||
@@ -259,17 +267,20 @@ export function SessionView({ sessionId }: SessionViewProps) {
 				await interfaceSwitch.start({ targetMode: interfaceTarget, policy });
 				setInterfaceSwitchDialogOpen(false);
 			} catch {
-				// The mutation owns the typed error. Keep the dialog open so it is
-				// visible instead of also producing an unhandled rejection.
-				setInterfaceSwitchDialogOpen(true);
+				// The mutation owns the typed error. A policy dialog that was already
+				// open stays open; a direct idle switch must not open one on failure.
 			}
 		},
 		[interfaceSwitch, interfaceTarget],
 	);
 	const requestInterfaceSwitch = useCallback(() => {
 		interfaceSwitch.resetStartError();
+		if (!interfaceBusy) {
+			void beginInterfaceSwitch("drain");
+			return;
+		}
 		setInterfaceSwitchDialogOpen(true);
-	}, [interfaceSwitch]);
+	}, [beginInterfaceSwitch, interfaceBusy, interfaceSwitch]);
 	const showInterfaceSwitchAction = Boolean(
 		interfaceSwitch.status || interfaceSwitch.isLoading || interfaceSwitch.statusError,
 	);


### PR DESCRIPTION
## What

Switch idle worker and orchestrator sessions directly between Chat UI and Terminal UI, while retaining the switch-policy dialog for sessions that are actively working or waiting for input.

## Why

The interface-switch action always opened a policy dialog, even when the selected session had no running work. The confirmation is only relevant when switching could interrupt or wait on an active task.

## How

- Derive busy state from the selected session only.
- Treat working, needs-input, active, waiting-input, and blocked states as busy.
- Start idle switches immediately with the drain policy in either direction.
- Keep the policy dialog closed if an idle direct-switch request fails.
- Cover workers and orchestrators, both switch directions, each busy signal, and isolation from other busy sessions.

## Testing

- `cd frontend && npm run typecheck`
- `cd frontend && npx vitest run --config vite.renderer.config.ts src/renderer/components/SessionView.test.tsx` (43 tests passed)
- `git diff --check`

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant frontend checks pass