### PR TITLE
fix(frontend): restore rounded center-panel corners on Windows/Linux

### DIFF
--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1767,7 +1767,6 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	align-items: center;
 	gap: 8px;
 	padding: 0 10px;
-	border-bottom: 1px solid var(--border);
 	/* Matches the shell chrome (bg-sidebar) and the Window Controls Overlay
 	   color pushed in WindowTitlebar/main.ts, so the native min/max/close
 	   strip blends into the bar instead of reading as a separate box. */

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -556,14 +556,24 @@
 	);
 }
 
-/* Windows / Linux: a ShellTopbar already supplies the top chrome, so the
- * framed panel needs no additional top inset. Windows uses its custom
- * frameless titlebar; Linux uses the standard ShellTopbar. The right/bottom
- * insets and the shared --radius-center-panel rounding are kept so the panel
- * matches the macOS framed look. */
+/* Windows / Linux: rectangular frameless window. There is no rounded macOS
+ * window to inset into, so flush the framed panel on every side — top is
+ * already covered by the custom titlebar / ShellTopbar, and the left is flush
+ * to the sidebar globally (padding-left: 0). Zero the remaining right/bottom
+ * insets so the panel fills the full window width instead of floating with a
+ * gap on the right and bottom. */
 .platform-windows .center-panel-shell,
 .platform-linux .center-panel-shell {
 	padding-top: 0;
+	padding-right: 0;
+	padding-bottom: 0;
+}
+
+/* macOS nested-radius formula (window_radius − inset) only makes sense inside
+ * a rounded macOS window. Strip it so the framed panel has sharp corners. */
+.platform-windows .center-panel-surface,
+.platform-linux .center-panel-surface {
+	border-radius: 0;
 }
 
 @utility settings-row-bar {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -556,24 +556,14 @@
 	);
 }
 
-/* Windows / Linux: rectangular frameless window. There is no rounded macOS
- * window to inset into, so flush the framed panel on every side — top is
- * already covered by the custom titlebar / ShellTopbar, and the left is flush
- * to the sidebar globally (padding-left: 0). Zero the remaining right/bottom
- * insets so the panel fills the full window width instead of floating with a
- * gap on the right and bottom. */
+/* Windows / Linux: a ShellTopbar already supplies the top chrome, so the
+ * framed panel needs no additional top inset. Windows uses its custom
+ * frameless titlebar; Linux uses the standard ShellTopbar. The right/bottom
+ * insets and the shared --radius-center-panel rounding are kept so the panel
+ * matches the macOS framed look. */
 .platform-windows .center-panel-shell,
 .platform-linux .center-panel-shell {
 	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-/* macOS nested-radius formula (window_radius − inset) only makes sense inside
- * a rounded macOS window. Strip it so the framed panel has sharp corners. */
-.platform-windows .center-panel-surface,
-.platform-linux .center-panel-surface {
-	border-radius: 0;
 }
 
 @utility settings-row-bar {


### PR DESCRIPTION
## Problem

PR #3615 stripped `border-radius` and zeroed the right and bottom insets on Windows and Linux. That made the center panel fill the window edge to edge with sharp corners, instead of using the framed rounded look that macOS has.

## Change

Restore the shared `--radius-center-panel` rounding and the right and bottom insets on Windows and Linux so the center panel matches the macOS framed look across platforms.

The `padding-top: 0` behavior from #3083 is kept. The custom frameless titlebar and ShellTopbar already provide the top chrome, so a top inset is not needed.

This PR also intentionally removes the Windows titlebar bottom separator. With the rounded framed panel restored, that divider created an extra visual line between the titlebar and the app chrome.

Single-file change: `frontend/src/renderer/styles.css`.

Key CSS changes:

- Remove Windows and Linux overrides that zeroed right and bottom padding on `.center-panel-shell`.
- Remove Windows and Linux overrides that forced `.center-panel-surface` to `border-radius: 0`.
- Remove the `.window-titlebar` bottom border so the top chrome reads as one surface.

## Screenshots

Before:
<img width=1647 height=886 alt=image src=https://github.com/user-attachments/assets/18132fd5-6122-47c0-b077-fbf783c479c6 />

After:
<img width=1647 height=888 alt=image src=https://github.com/user-attachments/assets/f8cd4cd6-f861-4213-89c5-03bfb1425894 />

## Verification

- `npx vitest run --config vite.renderer.config.ts src/renderer/components/CenterPanelShell.test.tsx src/renderer/test/shell-new-session-shortcut.test.tsx` passed, 23/23 tests
- `npm run typecheck` passed