### PR TITLE
feat(agent): add Muse model catalog

### DIFF
--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -75,6 +75,12 @@ func Base(agentID string) ports.AgentModelCatalog {
 			model("gpt-5.4-mini", "GPT-5.4 mini", false),
 			model("gpt-5.3-codex", "GPT-5.3-Codex", false),
 		)
+	case "muse":
+		return catalog(agentID, "official-catalog", true, now,
+			model("muse-spark", "Muse Spark", true),
+			model("muse-spark-1.1", "Muse Spark 1.1", false),
+			model("muse-spark-1.2", "Muse Spark 1.2", false),
+		)
 	case "amp":
 		c := catalog(agentID, "official-modes", false, now,
 			model("low", "Low", false),

--- a/backend/internal/adapters/agent/modelcatalog/catalog_test.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog_test.go
@@ -81,6 +81,7 @@ func TestBaseClassifiesStaticTextAndModeAgents(t *testing.T) {
 		{agent: "claude-code", mode: ports.ModelSelectionCatalog, count: 3},
 		{agent: "codex", mode: ports.ModelSelectionCatalog, count: 7},
 		{agent: "amp", mode: ports.ModelSelectionModeList, count: 4},
+		{agent: "muse", mode: ports.ModelSelectionCatalog, count: 3},
 		{agent: "aider", mode: ports.ModelSelectionCatalog},
 		{agent: "autohand", mode: ports.ModelSelectionCatalog},
 		{agent: "qwen", mode: ports.ModelSelectionText},
@@ -94,6 +95,22 @@ func TestBaseClassifiesStaticTextAndModeAgents(t *testing.T) {
 				t.Fatalf("Base(%q) = %#v", tc.agent, got)
 			}
 		})
+	}
+}
+
+func TestBaseMuseCatalogAllowsCustomModels(t *testing.T) {
+	got := Base("muse")
+	if got.SelectionMode != ports.ModelSelectionCatalog {
+		t.Fatalf("SelectionMode = %q, want catalog", got.SelectionMode)
+	}
+	if !got.AllowCustom {
+		t.Fatal("AllowCustom = false, want true")
+	}
+	if got.Source != "official-catalog" {
+		t.Fatalf("Source = %q, want official-catalog", got.Source)
+	}
+	if len(got.Models) != 3 || got.Models[0].ID != "muse-spark" || !got.Models[0].IsDefault {
+		t.Fatalf("models = %#v", got.Models)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a static Muse model catalog with muse-spark as the default
- keep Muse custom model entry enabled for future model IDs
- cover Muse catalog behavior in model catalog tests

## Tests
- go test -count=1 ./internal/adapters/agent/modelcatalog
- go test -count=1 ./internal/service/agent
- go test -count=1 ./internal/httpd/controllers

## Notes
- npm run lint was also run, but it failed in unrelated packages outside this change: backend/internal/adapters/agent/fake, kilocode, opencode, runtime/tmux, and backend/internal/cli.