### PR TITLE
fix(muse): resume native sessions deterministically

### DIFF
--- a/backend/internal/adapters/agent/muse/muse.go
+++ b/backend/internal/adapters/agent/muse/muse.go
@@ -109,6 +109,64 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	return cmd, nil
 }
 
+// GetRestoreCommand builds the argv to resume an existing Muse session:
+//
+//	[env TBH_EVAL_APPEND_DEVELOPER_PROMPT=<instructions> TBH_MANAGED_HOOKS_PATH=<path>] muse --trust-workspace [--approval-mode never|--yolo] [--model <model>] resume <agentSessionId>
+//
+// ok is false when Muse has not emitted its native session id through AO hooks.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+
+	agentSessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	if agentSessionID == "" {
+		return nil, false, nil
+	}
+
+	binary, err := p.museBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	systemPrompt, err := museSystemPromptText(cfg.SystemPrompt, cfg.SystemPromptFile)
+	if err != nil {
+		return nil, false, fmt.Errorf("muse.GetRestoreCommand: %w", err)
+	}
+
+	cmd = make([]string, 0, 12)
+	env := make([]string, 0, 2)
+	if systemPrompt != "" {
+		env = append(env, museDeveloperPromptEnvVar+"="+systemPrompt)
+	}
+	if cfg.DataDir != "" || cfg.Session.ID != "" {
+		hooksPath, pathErr := museManagedHooksPath(cfg.DataDir, cfg.Session.ID)
+		if pathErr != nil {
+			return nil, false, fmt.Errorf("muse.GetRestoreCommand: %w", pathErr)
+		}
+		env = append(env, museManagedHooksEnvVar+"="+hooksPath)
+	}
+	if len(env) > 0 {
+		cmd = append(cmd, "env")
+		cmd = append(cmd, env...)
+	}
+
+	cmd = append(cmd, binary, "--trust-workspace")
+	appendApprovalFlags(&cmd, cfg.Permissions)
+	agentbase.AppendModelFlag(&cmd, cfg.Config, "--model")
+	cmd = append(cmd, "resume", agentSessionID)
+	return cmd, true, nil
+}
+
+// SessionInfo surfaces Muse hook-derived metadata.
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	info, ok := agentbase.StandardSessionInfo(session)
+	return info, ok, nil
+}
+
 func appendApprovalFlags(cmd *[]string, mode ports.PermissionMode) {
 	switch mode {
 	case ports.PermissionModeAcceptEdits, ports.PermissionModeAuto:

--- a/backend/internal/adapters/agent/muse/muse_test.go
+++ b/backend/internal/adapters/agent/muse/muse_test.go
@@ -446,17 +446,112 @@ func TestResolveMuseBinaryAcceptsOfficialVersionSignature(t *testing.T) {
 	}
 }
 
-func TestRestoreAndSessionInfoAreNoOps(t *testing.T) {
-	p := &Plugin{}
+func TestGetRestoreCommandUsesMuseNativeSessionID(t *testing.T) {
+	p := &Plugin{resolvedBinary: "muse"}
 	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
-		Session: ports.SessionRef{Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "session-id"}},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "muse-native-1"},
+		},
 	})
-	if err != nil || ok || cmd != nil {
-		t.Fatalf("restore = (%#v, %v, %v), want (nil, false, nil)", cmd, ok, err)
+	if err != nil {
+		t.Fatal(err)
 	}
-	info, ok, err := p.SessionInfo(context.Background(), ports.SessionRef{})
-	if err != nil || ok || !reflect.DeepEqual(info, ports.SessionInfo{}) {
-		t.Fatalf("session info = (%#v, %v, %v), want zero/false/nil", info, ok, err)
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{"muse", "--trust-workspace", "resume", "muse-native-1"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandPreservesModel(t *testing.T) {
+	p := &Plugin{resolvedBinary: "muse"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "muse-spark"},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "muse-native-1"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{"muse", "--trust-workspace", "--model", "muse-spark", "resume", "muse-native-1"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandInjectsPromptAndManagedHooksEnvironment(t *testing.T) {
+	dataDir := t.TempDir()
+	p := &Plugin{resolvedBinary: "muse"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		DataDir:      dataDir,
+		SystemPrompt: "follow AO rules\n",
+		Session: ports.SessionRef{
+			ID:       "agent-orchestrator-96",
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "muse-native-1"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	hooksPath, err := museManagedHooksPath(dataDir, "agent-orchestrator-96")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"env",
+		museDeveloperPromptEnvVar + "=follow AO rules",
+		museManagedHooksEnvVar + "=" + hooksPath,
+		"muse", "--trust-workspace", "resume", "muse-native-1",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandRequiresAgentSessionID(t *testing.T) {
+	tests := []struct {
+		name    string
+		session ports.SessionRef
+	}{
+		{"missing metadata", ports.SessionRef{}},
+		{"missing agent session metadata", ports.SessionRef{Metadata: map[string]string{}}},
+		{"blank agent session metadata", ports.SessionRef{Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "   "}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "muse"}
+			cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{Session: tt.session})
+			if err != nil || ok || cmd != nil {
+				t.Fatalf("restore = (%#v, %v, %v), want (nil, false, nil)", cmd, ok, err)
+			}
+		})
+	}
+}
+
+func TestSessionInfoReturnsAgentSessionID(t *testing.T) {
+	info, ok, err := (&Plugin{}).SessionInfo(context.Background(), ports.SessionRef{
+		Metadata: map[string]string{
+			ports.MetadataKeyAgentSessionID: "muse-native-1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := ports.SessionInfo{AgentSessionID: "muse-native-1"}
+	if !reflect.DeepEqual(info, want) {
+		t.Fatalf("info = %#v, want %#v", info, want)
 	}
 }
 


### PR DESCRIPTION
## What

Use Muse's documented native resume command for AO restores: `muse resume <session-uuid>`.

## Why

`muse resume --last` is nondeterministic when a workspace has multiple Muse sessions. AO already captures Muse's native session id through hooks, so restore should target that id directly.

## How

- Adds Muse `GetRestoreCommand` using stored `agentSessionId` metadata.
- Reapplies developer prompt, managed hooks env, permissions, and model config during restore.
- Adds `SessionInfo` support via standard hook metadata.
- Replaces the no-op restore/session-info test with deterministic resume coverage.

## Testing

- `go test ./internal/adapters/agent/muse`
- `go test ./internal/cli`
- `go test ./internal/session_manager`
- `npm run lint`

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched