### PR TITLE
fix: make jump-to-latest button opaque

### DIFF
--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -219,6 +219,14 @@ describe("ChatWorkspace timeline", () => {
 		stubGeometry(log, { scrollHeight: 4000, clientHeight: 800, scrollTop: 100 });
 		log.dispatchEvent(new Event("scroll"));
 		const jump = await screen.findByRole("button", { name: /jump to latest/i });
+		expect(jump).toHaveClass(
+			"bg-raised",
+			"dark:bg-raised",
+			"hover:bg-surface",
+			"dark:hover:bg-surface",
+		);
+		expect(jump).not.toHaveClass("dark:bg-transparent");
+		expect(jump).not.toHaveClass("dark:hover:bg-input/30");
 
 		// Taking the jump re-arms following, so the control retires itself.
 		await user.click(jump);

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1229,7 +1229,7 @@ function Timeline({
 					size="sm"
 					variant="outline"
 					onClick={() => setPinned(true)}
-					className="absolute bottom-3 left-1/2 -translate-x-1/2 gap-1.5 bg-raised shadow-sm"
+					className="absolute bottom-3 left-1/2 -translate-x-1/2 gap-1.5 bg-raised shadow-sm hover:bg-surface dark:bg-raised dark:hover:bg-surface"
 				>
 					<ArrowDown aria-hidden="true" className="size-3.5" />
 					Jump to latest


### PR DESCRIPTION
## Summary

- keep the chat Jump to latest control opaque in dark mode
- use an opaque surface color for its hover state
- add regression coverage for the inherited outline-button classes

## Screenshot

![Jump to latest button with an opaque dark background](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/afa89f5b01b0ebedf00a20ff3cbf0d901d92d121/jump-to-latest-opaque.png)

## Tests

- npm test -- --run src/renderer/components/chat/ChatWorkspace.test.tsx
- npm run typecheck

## Risks

- Low: scoped to the floating chat control styling and its test