### PR TITLE
fix(session): resolve PR fallback compare base to merge-base

### DIFF
--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -584,6 +584,51 @@ func TestWorkspaceFilesPRFallbackPrefersDefaultTargetPR(t *testing.T) {
 	}
 }
 
+func TestWorkspaceFilesPRFallbackUsesMergeBaseWhenTargetBranchAdvances(t *testing.T) {
+	repo := newWorkspaceRepo(t)
+	runGit(t, repo, "branch", "-M", "main")
+	forkBase := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+	runGit(t, repo, "switch", "-c", "ao/work")
+	writeWorkspaceFile(t, repo, "worker.go", "package main\n")
+	runGit(t, repo, "add", "worker.go")
+	runGit(t, repo, "commit", "-m", "worker change")
+	runGit(t, repo, "switch", "main")
+	writeWorkspaceFile(t, repo, "mainonly.go", "package main\n")
+	runGit(t, repo, "add", "mainonly.go")
+	runGit(t, repo, "commit", "-m", "main advanced independently")
+	prBaseSHA := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+	runGit(t, repo, "switch", "ao/work")
+
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: domain.ProjectConfig{DefaultBranch: "main"}}
+	st.sessions["ao-1"] = domain.SessionRecord{
+		ID:        "ao-1",
+		ProjectID: "mer",
+		Metadata:  domain.SessionMetadata{WorkspacePath: repo},
+	}
+	st.prs["ao-1"] = []domain.PullRequest{
+		{URL: "pr", SessionID: "ao-1", Number: 1, TargetBranch: "main", BaseSHA: prBaseSHA, UpdatedAt: time.Unix(100, 0)},
+	}
+
+	files, err := (&Service{store: st}).ListWorkspaceFiles(context.Background(), "ao-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if files.CompareBaseSHA != forkBase || files.CompareBaseRef != "main" {
+		t.Fatalf("compare base = sha:%q ref:%q, want merge base %s main", files.CompareBaseSHA, files.CompareBaseRef, forkBase)
+	}
+	byPath := map[string]WorkspaceFileSummary{}
+	for _, file := range files.Files {
+		byPath[file.Path] = file
+	}
+	if byPath["worker.go"].Status != WorkspaceFileAdded {
+		t.Fatalf("worker.go = %#v, want added", byPath["worker.go"])
+	}
+	if got, ok := byPath["mainonly.go"]; ok {
+		t.Fatalf("mainonly.go = %#v, want excluded once compare resolves to the merge base instead of the advanced target tip", got)
+	}
+}
+
 func TestWorkspaceFilesReportCommittedDeletionsAgainstRecordedBase(t *testing.T) {
 	repo := newWorkspaceRepo(t)
 	base := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -278,6 +278,14 @@ func resolveWorkspaceCompare(ctx context.Context, root, recordedSHA, recordedRef
 	if pr, ok := selectWorkspaceComparePR(prs, defaultBranch); ok {
 		baseSHA := strings.TrimSpace(pr.BaseSHA)
 		if gitCommitExists(ctx, root, baseSHA) {
+			// pr.BaseSHA is the target branch's current tip, not the commit the
+			// session forked from. If the target branch has advanced since, diff
+			// straight against it would also surface every base-only change
+			// (reversed) as if the session had touched it. Compare against the
+			// merge base instead so only the session's own changes show up.
+			if merged, ok := gitMergeBase(ctx, root, baseSHA); ok {
+				baseSHA = merged
+			}
 			return workspaceCompareTarget{BaseSHA: baseSHA, BaseRef: strings.TrimSpace(pr.TargetBranch), Mode: WorkspaceCompareBase}
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes #3203: the Files tab could report far more changed files than a PR actually has (e.g. 2 files on GitHub vs. 36 in AO).
- Root cause: the PR fallback in `resolveWorkspaceCompare` used the provider's current `pr.BaseSHA` (the target branch's live tip) directly, instead of the merge-base of `HEAD` and that SHA. When the target branch advances after a session forks and no diff base is recorded, the raw-SHA diff also picks up every base-only change in reverse, alongside the session's own edits.
- Fix: resolve `git merge-base HEAD pr.BaseSHA` and use that as `CompareBaseSHA`, keeping the PR's target branch as `CompareBaseRef`. File status, numstat, and per-file diff/patch all read from the same `workspaceCompareTarget`, so this single change fixes all three surfaces.

## Test plan
- [x] Added `TestWorkspaceFilesPRFallbackUsesMergeBaseWhenTargetBranchAdvances`, which reproduces the reported scenario (target branch advances independently after the session forks, no recorded diff base) and asserts base-only files are excluded and only the session's own file shows as added.
- [x] `go test ./internal/service/session/...` — pass, including the existing `TestWorkspaceFilesPRFallbackPrefersDefaultTargetPR` (unaffected).
- [x] `go build ./...` and `go vet ./...` — clean.
- [x] `go test ./...` — same 3 pre-existing failures reproduce identically on `main` without this change (Windows PATH-separator formatting in `session_manager`, fsnotify timing in `workspacewatch`); unrelated to this fix.