### PR TITLE
feat(landing): add mobile TestFlight download flow

### DIFF
--- a/frontend/src/landing/src/app/components/DownloadButton/DownloadButton.tsx
+++ b/frontend/src/landing/src/app/components/DownloadButton/DownloadButton.tsx
@@ -65,7 +65,7 @@ function getDownloadPlatform(platform: Platform): DownloadPlatform {
   return "apple";
 }
 
-function MonitorIcon() {
+function MobileIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -78,8 +78,8 @@ function MonitorIcon() {
       className="size-4 shrink-0"
       aria-hidden="true"
     >
-      <rect x="2" y="3" width="20" height="14" rx="2" />
-      <path d="M8 21h8M12 17v4" />
+      <rect x="5" y="2" width="14" height="20" rx="2" />
+      <path d="M12 18h.01" />
     </svg>
   );
 }
@@ -103,17 +103,13 @@ export function DownloadButton({
 }: DownloadButtonProps) {
   const { platform } = usePlatform();
   const downloadPlatform = getDownloadPlatform(platform);
-  // AO is a desktop app, so a phone can't run any build — point mobile visitors
-  // at the desktop download with a label that sets that expectation.
   const isMobile = platform === Platform.Mobile;
   const sizeClasses =
     size === "sm"
       ? "h-8 px-3 text-sm"
       : "px-3 sm:px-6 py-2 sm:py-3 text-sm sm:text-base";
   const label = isMobile
-    ? size === "sm"
-      ? "Get for desktop"
-      : "Get AO for desktop"
+    ? "Download AO Mobile"
     : getLabel(size, downloadPlatform);
 
   const buttonClasses = `bg-foreground text-background ${sizeClasses} rounded-2xl tracking-[-0.5px] font-semibold hover:opacity-90 transition-opacity flex items-center gap-2 whitespace-nowrap shrink-0 ${className}`;
@@ -124,7 +120,7 @@ export function DownloadButton({
       className={buttonClasses}
       onClick={() => track("download_clicked")}
     >
-      {isMobile ? <MonitorIcon /> : <PlatformIcon platform={downloadPlatform} />}
+      {isMobile ? <MobileIcon /> : <PlatformIcon platform={downloadPlatform} />}
       {label}
     </Link>
   );

--- a/frontend/src/landing/src/app/download/MobileAppCTA.tsx
+++ b/frontend/src/landing/src/app/download/MobileAppCTA.tsx
@@ -26,6 +26,12 @@ export function MobileAppCTA() {
     );
   }, []);
 
+  // mobileOS is null until usePlatform's effect runs, so the first render here
+  // always matches TestFlightDialog - same as everywhere else - then swaps to
+  // the button + sheet below once iOS is detected. That's a full component
+  // swap (dialog -> sheet), not a text change; it merely looks seamless
+  // because TRIGGER_CLASS here and the trigger className in TestFlightDialog
+  // are byte-identical. Keep the two in sync or the swap will visibly jump.
   // Android and desktop both keep the original QR dialog. Android additionally
   // sees the untouched "Android coming soon" chip beside it.
   if (mobileOS !== "ios") return <TestFlightDialog />;

--- a/frontend/src/landing/src/app/download/MobileAppCTA.tsx
+++ b/frontend/src/landing/src/app/download/MobileAppCTA.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FaApple } from "react-icons/fa";
+import { track } from "@/lib/analytics";
+import { isIPadOS, usePlatform } from "../hooks/useOS";
+import { TestFlightDialog } from "./TestFlightDialog";
+import { TestFlightMobileSheet } from "./TestFlightMobileSheet";
+
+const TRIGGER_CLASS =
+  "inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-3xl bg-foreground px-3 py-2 text-sm font-semibold tracking-[-0.5px] text-background transition-opacity hover:opacity-85 sm:px-6 sm:py-3 sm:text-base";
+
+// Picks the install flow by device. A QR is the right answer on desktop - its
+// job is to move the invite onto a phone - and exactly the wrong answer on the
+// phone itself, which is what confused visitors before this split existed.
+export function MobileAppCTA() {
+  const { mobileOS } = usePlatform();
+  const [open, setOpen] = useState(false);
+  const [deviceName, setDeviceName] = useState<"iPhone" | "iPad">("iPhone");
+
+  useEffect(() => {
+    setDeviceName(
+      isIPadOS(navigator.userAgent, navigator.maxTouchPoints)
+        ? "iPad"
+        : "iPhone",
+    );
+  }, []);
+
+  // Android and desktop both keep the original QR dialog. Android additionally
+  // sees the untouched "Android coming soon" chip beside it.
+  if (mobileOS !== "ios") return <TestFlightDialog />;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          track("testflight_sheet_opened");
+          setOpen(true);
+        }}
+        className={TRIGGER_CLASS}
+      >
+        <FaApple className="size-4 shrink-0" aria-hidden="true" />
+        Install on this {deviceName}
+      </button>
+
+      <TestFlightMobileSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        deviceName={deviceName}
+      />
+    </>
+  );
+}

--- a/frontend/src/landing/src/app/download/TestFlightMobileSheet.tsx
+++ b/frontend/src/landing/src/app/download/TestFlightMobileSheet.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { TESTFLIGHT_APP_URL, TESTFLIGHT_URL } from "@ao/shared/constants";
+import { AnimatePresence, motion } from "motion/react";
+import { ExternalLink, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { track } from "@/lib/analytics";
+
+// Tapping step 1 navigates away to the App Store. Safari may restore the page
+// from bfcache (state intact) or reload it (state lost) - and on a reload the
+// visitor would come back to a gate they already cleared, which is the exact
+// frustration this sheet exists to remove. So the cleared gate is persisted.
+const STORAGE_KEY = "ao.testflight.hasApp";
+
+function readHasTestFlight(): boolean {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    // Private mode or blocked storage: fall back to in-memory gating.
+    return false;
+  }
+}
+
+function rememberHasTestFlight(): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, "true");
+  } catch {
+    // Non-fatal - the gate still works for this page view.
+  }
+}
+
+const ACTION_BASE =
+  "flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold transition-opacity";
+
+interface TestFlightMobileSheetProps {
+  open: boolean;
+  onClose: () => void;
+  deviceName: "iPhone" | "iPad";
+}
+
+// The phone counterpart to TestFlightDialog. It carries no QR: the visitor is
+// holding the target device, so the invite has to be tappable, not scannable.
+// Step 2 stays inert until step 1 is taken because TestFlight betas are
+// meaningless without Apple's TestFlight app, and nothing in the old dialog
+// stopped a visitor tapping the invite first.
+export function TestFlightMobileSheet({
+  open,
+  onClose,
+  deviceName,
+}: TestFlightMobileSheetProps) {
+  const [hasTestFlight, setHasTestFlight] = useState(false);
+
+  // Read after mount so the server render and the first client render agree.
+  useEffect(() => {
+    if (open && readHasTestFlight()) setHasTestFlight(true);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    // The page behind a sheet must not scroll under it.
+    const { overflow } = document.body.style;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = overflow;
+    };
+  }, [open, onClose]);
+
+  const unlock = useCallback(() => {
+    setHasTestFlight(true);
+    rememberHasTestFlight();
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {open ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center">
+          <motion.button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            className="absolute inset-0 cursor-default bg-black/70 backdrop-blur-sm outline-none"
+          />
+
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="testflight-sheet-title"
+            initial={{ y: "100%" }}
+            animate={{ y: 0 }}
+            exit={{ y: "100%" }}
+            transition={{ type: "spring", duration: 0.36, bounce: 0.08 }}
+            className="relative w-full max-w-md rounded-t-2xl border border-border bg-card px-5 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] shadow-[0_-24px_60px_-20px_rgba(0,0,0,0.8)]"
+          >
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="absolute right-4 top-4 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+            >
+              <X className="size-4" aria-hidden="true" />
+            </button>
+
+            <h2
+              id="testflight-sheet-title"
+              className="pr-8 text-xl font-semibold text-foreground"
+            >
+              Get AO on this {deviceName}
+            </h2>
+            <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
+              Two taps, about a minute. The beta is free while it lasts.
+            </p>
+
+            <ol className="mt-6 space-y-6">
+              <li>
+                <div className="flex gap-3">
+                  <span
+                    aria-hidden="true"
+                    className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-xs font-bold text-background"
+                  >
+                    1
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-foreground">
+                      Install TestFlight
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                      Apple&apos;s free app for betas. Come back here once it
+                      finishes installing.
+                    </p>
+                  </div>
+                </div>
+                <a
+                  href={TESTFLIGHT_APP_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() => {
+                    track("testflight_app_store_clicked");
+                    unlock();
+                  }}
+                  className={`${ACTION_BASE} mt-3 bg-foreground text-background hover:opacity-85`}
+                >
+                  Get TestFlight
+                  <ExternalLink className="size-3.5" aria-hidden="true" />
+                </a>
+              </li>
+
+              <li>
+                <div className="flex gap-3">
+                  <span
+                    aria-hidden="true"
+                    className={`mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+                      hasTestFlight
+                        ? "bg-foreground text-background"
+                        : "bg-foreground/25 text-background"
+                    }`}
+                  >
+                    2
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-foreground">
+                      Open the AO invite
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                      TestFlight opens on the AO beta. Tap Accept, then Install.
+                    </p>
+                  </div>
+                </div>
+
+                {hasTestFlight ? (
+                  <a
+                    href={TESTFLIGHT_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={() => track("testflight_invite_clicked")}
+                    className={`${ACTION_BASE} mt-3 bg-foreground text-background hover:opacity-85`}
+                  >
+                    Open invite
+                    <ExternalLink className="size-3.5" aria-hidden="true" />
+                  </a>
+                ) : (
+                  <>
+                    {/* A disabled button, not a dimmed anchor: the invite must
+                        be genuinely unactivatable, not merely discouraged. */}
+                    <button
+                      type="button"
+                      disabled
+                      aria-disabled="true"
+                      className={`${ACTION_BASE} mt-3 cursor-not-allowed bg-foreground/25 text-background`}
+                    >
+                      Open invite
+                      <ExternalLink className="size-3.5" aria-hidden="true" />
+                    </button>
+                    <p className="mt-2 text-center text-xs text-muted-foreground">
+                      Install TestFlight first
+                    </p>
+                  </>
+                )}
+              </li>
+            </ol>
+
+            {hasTestFlight ? null : (
+              <button
+                type="button"
+                onClick={() => {
+                  track("testflight_already_installed");
+                  unlock();
+                }}
+                className="mt-6 w-full py-2 text-sm font-semibold text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+              >
+                I already have TestFlight
+              </button>
+            )}
+          </motion.div>
+        </div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/landing/src/app/download/TestFlightMobileSheet.tsx
+++ b/frontend/src/landing/src/app/download/TestFlightMobileSheet.tsx
@@ -6,13 +6,14 @@ import { ExternalLink, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { track } from "@/lib/analytics";
 
-// Tapping step 1 navigates away to the App Store. Safari may restore the page
-// from bfcache (state intact) or reload it (state lost) - and on a reload the
-// visitor would come back to a gate they already cleared, which is the exact
-// frustration this sheet exists to remove. So the cleared gate is persisted.
+// Once a visitor clears the gate, it should stay cleared - on a return visit
+// or a manual reload, not just for the rest of this page view. Re-showing a
+// gate they already cleared is the exact frustration this sheet exists to
+// remove. So the cleared gate is persisted.
 const STORAGE_KEY = "ao.testflight.hasApp";
 
 function readHasTestFlight(): boolean {
+  if (typeof window === "undefined") return false;
   try {
     return window.localStorage.getItem(STORAGE_KEY) === "true";
   } catch {
@@ -48,12 +49,7 @@ export function TestFlightMobileSheet({
   onClose,
   deviceName,
 }: TestFlightMobileSheetProps) {
-  const [hasTestFlight, setHasTestFlight] = useState(false);
-
-  // Read after mount so the server render and the first client render agree.
-  useEffect(() => {
-    if (open && readHasTestFlight()) setHasTestFlight(true);
-  }, [open]);
+  const [hasTestFlight, setHasTestFlight] = useState(() => readHasTestFlight());
 
   useEffect(() => {
     if (!open) return;
@@ -104,6 +100,7 @@ export function TestFlightMobileSheet({
               type="button"
               onClick={onClose}
               aria-label="Close"
+              autoFocus
               className="absolute right-4 top-4 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
             >
               <X className="size-4" aria-hidden="true" />

--- a/frontend/src/landing/src/app/download/TestFlightMobileSheet.tsx
+++ b/frontend/src/landing/src/app/download/TestFlightMobileSheet.tsx
@@ -2,37 +2,9 @@
 
 import { TESTFLIGHT_APP_URL, TESTFLIGHT_URL } from "@ao/shared/constants";
 import { AnimatePresence, motion } from "motion/react";
-import { Check, ExternalLink, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { ExternalLink, X } from "lucide-react";
+import { useEffect } from "react";
 import { track } from "@/lib/analytics";
-
-// Once a visitor clears the gate, it should stay cleared - on a return visit
-// or a manual reload, not just for the rest of this page view. Re-showing a
-// gate they already cleared is the exact frustration this sheet exists to
-// remove. So the cleared gate is persisted.
-const STORAGE_KEY = "ao.testflight.hasApp";
-
-function readHasTestFlight(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(STORAGE_KEY) === "true";
-  } catch {
-    // Private mode or blocked storage: fall back to in-memory gating.
-    return false;
-  }
-}
-
-// Writes both ways: the toggle is reversible, so a visitor who taps it by
-// mistake can put the gate back rather than being stuck with a step 2 that
-// sends them nowhere.
-function rememberHasTestFlight(value: boolean): void {
-  try {
-    if (value) window.localStorage.setItem(STORAGE_KEY, "true");
-    else window.localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    // Non-fatal - the gate still works for this page view.
-  }
-}
 
 const ACTION_BASE =
   "flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3.5 text-sm font-semibold transition-opacity";
@@ -44,17 +16,12 @@ interface TestFlightMobileSheetProps {
 }
 
 // The phone counterpart to TestFlightDialog. It carries no QR: the visitor is
-// holding the target device, so the invite has to be tappable, not scannable.
-// Step 2 stays inert until step 1 is taken because TestFlight betas are
-// meaningless without Apple's TestFlight app, and nothing in the old dialog
-// stopped a visitor tapping the invite first.
+// holding the target device, so both TestFlight actions are directly tappable.
 export function TestFlightMobileSheet({
   open,
   onClose,
   deviceName,
 }: TestFlightMobileSheetProps) {
-  const [hasTestFlight, setHasTestFlight] = useState(() => readHasTestFlight());
-
   useEffect(() => {
     if (!open) return;
     const onKey = (event: KeyboardEvent) => {
@@ -69,25 +36,6 @@ export function TestFlightMobileSheet({
       document.body.style.overflow = overflow;
     };
   }, [open, onClose]);
-
-  const unlock = useCallback(() => {
-    setHasTestFlight(true);
-    rememberHasTestFlight(true);
-  }, []);
-
-  // The toggle is the one control that must never disappear: someone who
-  // already has TestFlight needs the fast path visible on arrival, not hidden
-  // behind having first tapped the step they don't need.
-  const toggleHasTestFlight = useCallback(() => {
-    setHasTestFlight((previous) => {
-      const next = !previous;
-      track(
-        next ? "testflight_already_installed" : "testflight_gate_restored",
-      );
-      rememberHasTestFlight(next);
-      return next;
-    });
-  }, []);
 
   return (
     <AnimatePresence>
@@ -146,17 +94,9 @@ export function TestFlightMobileSheet({
                     1
                   </span>
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-baseline justify-between gap-3">
-                      <p className="text-sm font-semibold text-foreground">
-                        Install TestFlight
-                      </p>
-                      {hasTestFlight ? (
-                        <span className="flex shrink-0 items-center gap-1 text-xs font-semibold text-foreground">
-                          <Check className="size-3.5" aria-hidden="true" />
-                          Ready
-                        </span>
-                      ) : null}
-                    </div>
+                    <p className="text-sm font-semibold text-foreground">
+                      Install TestFlight
+                    </p>
                     <p className="mt-1 text-sm leading-6 text-muted-foreground">
                       Apple&apos;s free app for betas. Come back here once it
                       finishes installing.
@@ -167,46 +107,19 @@ export function TestFlightMobileSheet({
                   href={TESTFLIGHT_APP_URL}
                   target="_blank"
                   rel="noreferrer"
-                  onClick={() => {
-                    track("testflight_app_store_clicked");
-                    unlock();
-                  }}
+                  onClick={() => track("testflight_app_store_clicked")}
                   className={`${ACTION_BASE} mt-3 bg-foreground text-background hover:opacity-85`}
                 >
                   Get TestFlight
                   <ExternalLink className="size-3.5" aria-hidden="true" />
                 </a>
-
-                <button
-                  type="button"
-                  role="checkbox"
-                  aria-checked={hasTestFlight}
-                  onClick={toggleHasTestFlight}
-                  className="mt-2.5 flex w-full items-center justify-center gap-2 py-2 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <span
-                    aria-hidden="true"
-                    className={`flex size-4 shrink-0 items-center justify-center rounded border transition-colors ${
-                      hasTestFlight
-                        ? "border-foreground bg-foreground text-background"
-                        : "border-muted-foreground"
-                    }`}
-                  >
-                    {hasTestFlight ? <Check className="size-3" /> : null}
-                  </span>
-                  I already have TestFlight
-                </button>
               </li>
 
               <li>
                 <div className="flex gap-3">
                   <span
                     aria-hidden="true"
-                    className={`mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
-                      hasTestFlight
-                        ? "bg-foreground text-background"
-                        : "bg-foreground/25 text-background"
-                    }`}
+                    className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-xs font-bold text-background"
                   >
                     2
                   </span>
@@ -220,35 +133,16 @@ export function TestFlightMobileSheet({
                   </div>
                 </div>
 
-                {hasTestFlight ? (
-                  <a
-                    href={TESTFLIGHT_URL}
-                    target="_blank"
-                    rel="noreferrer"
-                    onClick={() => track("testflight_invite_clicked")}
-                    className={`${ACTION_BASE} mt-3 bg-foreground text-background hover:opacity-85`}
-                  >
-                    Open invite
-                    <ExternalLink className="size-3.5" aria-hidden="true" />
-                  </a>
-                ) : (
-                  <>
-                    {/* A disabled button, not a dimmed anchor: the invite must
-                        be genuinely unactivatable, not merely discouraged. */}
-                    <button
-                      type="button"
-                      disabled
-                      aria-disabled="true"
-                      className={`${ACTION_BASE} mt-3 cursor-not-allowed bg-foreground/25 text-background`}
-                    >
-                      Open invite
-                      <ExternalLink className="size-3.5" aria-hidden="true" />
-                    </button>
-                    <p className="mt-2 text-center text-xs text-muted-foreground">
-                      Install TestFlight first
-                    </p>
-                  </>
-                )}
+                <a
+                  href={TESTFLIGHT_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() => track("testflight_invite_clicked")}
+                  className={`${ACTION_BASE} mt-3 bg-foreground text-background hover:opacity-85`}
+                >
+                  Open invite
+                  <ExternalLink className="size-3.5" aria-hidden="true" />
+                </a>
               </li>
             </ol>
           </motion.div>

--- a/frontend/src/landing/src/app/download/TestFlightMobileSheet.tsx
+++ b/frontend/src/landing/src/app/download/TestFlightMobileSheet.tsx
@@ -2,7 +2,7 @@
 
 import { TESTFLIGHT_APP_URL, TESTFLIGHT_URL } from "@ao/shared/constants";
 import { AnimatePresence, motion } from "motion/react";
-import { ExternalLink, X } from "lucide-react";
+import { Check, ExternalLink, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { track } from "@/lib/analytics";
 
@@ -22,9 +22,13 @@ function readHasTestFlight(): boolean {
   }
 }
 
-function rememberHasTestFlight(): void {
+// Writes both ways: the toggle is reversible, so a visitor who taps it by
+// mistake can put the gate back rather than being stuck with a step 2 that
+// sends them nowhere.
+function rememberHasTestFlight(value: boolean): void {
   try {
-    window.localStorage.setItem(STORAGE_KEY, "true");
+    if (value) window.localStorage.setItem(STORAGE_KEY, "true");
+    else window.localStorage.removeItem(STORAGE_KEY);
   } catch {
     // Non-fatal - the gate still works for this page view.
   }
@@ -68,7 +72,21 @@ export function TestFlightMobileSheet({
 
   const unlock = useCallback(() => {
     setHasTestFlight(true);
-    rememberHasTestFlight();
+    rememberHasTestFlight(true);
+  }, []);
+
+  // The toggle is the one control that must never disappear: someone who
+  // already has TestFlight needs the fast path visible on arrival, not hidden
+  // behind having first tapped the step they don't need.
+  const toggleHasTestFlight = useCallback(() => {
+    setHasTestFlight((previous) => {
+      const next = !previous;
+      track(
+        next ? "testflight_already_installed" : "testflight_gate_restored",
+      );
+      rememberHasTestFlight(next);
+      return next;
+    });
   }, []);
 
   return (
@@ -94,7 +112,9 @@ export function TestFlightMobileSheet({
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
             transition={{ type: "spring", duration: 0.36, bounce: 0.08 }}
-            className="relative w-full max-w-md rounded-t-2xl border border-border bg-card px-5 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] shadow-[0_-24px_60px_-20px_rgba(0,0,0,0.8)]"
+            // max-h + scroll so a short screen (an SE, or landscape) can still
+            // reach the last control instead of having it clipped off-screen.
+            className="relative max-h-[90dvh] w-full max-w-md overflow-y-auto rounded-t-2xl border border-border bg-card px-5 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] shadow-[0_-24px_60px_-20px_rgba(0,0,0,0.8)]"
           >
             <button
               type="button"
@@ -125,10 +145,18 @@ export function TestFlightMobileSheet({
                   >
                     1
                   </span>
-                  <div className="min-w-0">
-                    <p className="text-sm font-semibold text-foreground">
-                      Install TestFlight
-                    </p>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline justify-between gap-3">
+                      <p className="text-sm font-semibold text-foreground">
+                        Install TestFlight
+                      </p>
+                      {hasTestFlight ? (
+                        <span className="flex shrink-0 items-center gap-1 text-xs font-semibold text-foreground">
+                          <Check className="size-3.5" aria-hidden="true" />
+                          Ready
+                        </span>
+                      ) : null}
+                    </div>
                     <p className="mt-1 text-sm leading-6 text-muted-foreground">
                       Apple&apos;s free app for betas. Come back here once it
                       finishes installing.
@@ -148,6 +176,26 @@ export function TestFlightMobileSheet({
                   Get TestFlight
                   <ExternalLink className="size-3.5" aria-hidden="true" />
                 </a>
+
+                <button
+                  type="button"
+                  role="checkbox"
+                  aria-checked={hasTestFlight}
+                  onClick={toggleHasTestFlight}
+                  className="mt-2.5 flex w-full items-center justify-center gap-2 py-2 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <span
+                    aria-hidden="true"
+                    className={`flex size-4 shrink-0 items-center justify-center rounded border transition-colors ${
+                      hasTestFlight
+                        ? "border-foreground bg-foreground text-background"
+                        : "border-muted-foreground"
+                    }`}
+                  >
+                    {hasTestFlight ? <Check className="size-3" /> : null}
+                  </span>
+                  I already have TestFlight
+                </button>
               </li>
 
               <li>
@@ -203,19 +251,6 @@ export function TestFlightMobileSheet({
                 )}
               </li>
             </ol>
-
-            {hasTestFlight ? null : (
-              <button
-                type="button"
-                onClick={() => {
-                  track("testflight_already_installed");
-                  unlock();
-                }}
-                className="mt-6 w-full py-2 text-sm font-semibold text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
-              >
-                I already have TestFlight
-              </button>
-            )}
           </motion.div>
         </div>
       ) : null}

--- a/frontend/src/landing/src/app/download/page.tsx
+++ b/frontend/src/landing/src/app/download/page.tsx
@@ -9,7 +9,7 @@ import { Download } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import { FaAndroid, FaApple, FaLinux, FaWindows } from "react-icons/fa";
-import { TestFlightDialog } from "./TestFlightDialog";
+import { MobileAppCTA } from "./MobileAppCTA";
 import { PlatformDownloadButton } from "./PlatformDownloadButton";
 import { DesktopAppPreview, PhoneAppPreview } from "./StaticAppPreviews";
 
@@ -221,7 +221,7 @@ export default async function DownloadPage() {
                   anywhere.
                 </p>
                 <div className="mt-6 flex flex-wrap items-center gap-3">
-                  <TestFlightDialog />
+                  <MobileAppCTA />
                   <span className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-3xl border border-border px-3 py-2 text-sm font-semibold tracking-[-0.5px] text-muted-foreground sm:px-6 sm:py-3 sm:text-base">
                     <FaAndroid className="size-4 shrink-0" aria-hidden="true" />
                     Android coming soon

--- a/frontend/src/landing/src/app/download/page.tsx
+++ b/frontend/src/landing/src/app/download/page.tsx
@@ -172,7 +172,7 @@ export default async function DownloadPage() {
           </div>
 
           <div className="grid gap-6 md:grid-cols-2">
-            <article className="flex h-full flex-col rounded-2xl bg-card p-4 sm:p-5">
+            <article className="order-2 flex h-full flex-col rounded-2xl bg-card p-4 sm:p-5 md:order-1">
               <div className="relative mb-5 h-80 overflow-hidden rounded-xl sm:h-[360px]">
                 <Image
                   src="/optimized/feature3.webp"
@@ -200,7 +200,7 @@ export default async function DownloadPage() {
               </div>
             </article>
 
-            <article className="flex h-full flex-col rounded-2xl bg-card p-4 sm:p-5">
+            <article className="order-1 flex h-full flex-col rounded-2xl bg-card p-4 sm:p-5 md:order-2">
               <div className="relative mb-5 h-80 overflow-hidden rounded-xl sm:h-[360px]">
                 <Image
                   src="/optimized/feature.webp"

--- a/frontend/src/landing/src/app/hooks/useOS/index.ts
+++ b/frontend/src/landing/src/app/hooks/useOS/index.ts
@@ -1,5 +1,7 @@
 export {
+	isIPadOS,
 	isMacPlatform,
+	type MobileOS,
 	Platform,
 	type PlatformInfo,
 	usePlatform,

--- a/frontend/src/landing/src/app/hooks/useOS/useOS.ts
+++ b/frontend/src/landing/src/app/hooks/useOS/useOS.ts
@@ -11,8 +11,11 @@ export const Platform = {
 
 export type Platform = (typeof Platform)[keyof typeof Platform];
 
+export type MobileOS = "ios" | "android" | null;
+
 export interface PlatformInfo {
 	platform: Platform;
+	mobileOS: MobileOS;
 }
 
 function detectMacArch():
@@ -42,30 +45,51 @@ function detectMacArch():
 	}
 }
 
+// Modern iPadOS reports a desktop "Macintosh" user agent for compat, so the
+// only signal that separates an iPad from a Mac is that it reports touch
+// points. This is used for the device noun in copy, and to route iPads to the
+// touch flow rather than a QR they have no second device to scan.
+export function isIPadOS(userAgent: string, maxTouchPoints: number): boolean {
+	if (/ipad/i.test(userAgent)) return true;
+	return /macintosh|mac os x/i.test(userAgent) && maxTouchPoints > 1;
+}
+
+function detectMobileOS(userAgent: string, maxTouchPoints: number): MobileOS {
+	if (/iphone|ipod/i.test(userAgent) || isIPadOS(userAgent, maxTouchPoints)) {
+		return "ios";
+	}
+	if (/android/i.test(userAgent)) return "android";
+	return null;
+}
+
 function detectPlatform(): PlatformInfo {
 	if (typeof navigator === "undefined") {
-		return { platform: Platform.Unknown };
+		return { platform: Platform.Unknown, mobileOS: null };
 	}
 
 	const userAgent = navigator.userAgent;
+	const mobileOS = detectMobileOS(userAgent, navigator.maxTouchPoints);
 
 	if (/android|iphone|ipad|ipod|mobile|tablet/i.test(userAgent)) {
-		return { platform: Platform.Mobile };
+		return { platform: Platform.Mobile, mobileOS };
 	}
 
 	if (/mac os x|macintosh/i.test(userAgent)) {
-		return { platform: detectMacArch() };
+		return { platform: detectMacArch(), mobileOS };
 	}
 	if (/windows/i.test(userAgent)) {
-		return { platform: Platform.Windows };
+		return { platform: Platform.Windows, mobileOS };
 	}
 	if (/linux|x11/i.test(userAgent)) {
-		return { platform: Platform.Linux };
+		return { platform: Platform.Linux, mobileOS };
 	}
-	return { platform: Platform.Unknown };
+	return { platform: Platform.Unknown, mobileOS };
 }
 
-const DEFAULT_PLATFORM: PlatformInfo = { platform: Platform.Unknown };
+const DEFAULT_PLATFORM: PlatformInfo = {
+	platform: Platform.Unknown,
+	mobileOS: null,
+};
 
 export function usePlatform(): PlatformInfo {
 	const [platform, setPlatform] = useState<PlatformInfo>(DEFAULT_PLATFORM);

--- a/frontend/src/landing/src/app/hooks/useOS/useOS.ts
+++ b/frontend/src/landing/src/app/hooks/useOS/useOS.ts
@@ -49,9 +49,15 @@ function detectMacArch():
 // only signal that separates an iPad from a Mac is that it reports touch
 // points. This is used for the device noun in copy, and to route iPads to the
 // touch flow rather than a QR they have no second device to scan.
+//
+// Match "macintosh" only, never "mac os x": every iPhone UA contains the
+// substring "like Mac OS X" ("iPhone; CPU iPhone OS 17_5 like Mac OS X"), so
+// matching that phrase labels every iPhone an iPad. The explicit iPhone/iPod
+// exclusion keeps that true even if a future UA adds "Macintosh".
 export function isIPadOS(userAgent: string, maxTouchPoints: number): boolean {
 	if (/ipad/i.test(userAgent)) return true;
-	return /macintosh|mac os x/i.test(userAgent) && maxTouchPoints > 1;
+	if (/iphone|ipod/i.test(userAgent)) return false;
+	return /macintosh/i.test(userAgent) && maxTouchPoints > 1;
 }
 
 function detectMobileOS(userAgent: string, maxTouchPoints: number): MobileOS {

--- a/frontend/src/landing/src/app/hooks/useOS/useOS.ts
+++ b/frontend/src/landing/src/app/hooks/useOS/useOS.ts
@@ -68,15 +68,13 @@ function detectMobileOS(userAgent: string, maxTouchPoints: number): MobileOS {
 	return null;
 }
 
-function detectPlatform(): PlatformInfo {
-	if (typeof navigator === "undefined") {
-		return { platform: Platform.Unknown, mobileOS: null };
-	}
+export function detectPlatformInfo(
+	userAgent: string,
+	maxTouchPoints: number,
+): PlatformInfo {
+	const mobileOS = detectMobileOS(userAgent, maxTouchPoints);
 
-	const userAgent = navigator.userAgent;
-	const mobileOS = detectMobileOS(userAgent, navigator.maxTouchPoints);
-
-	if (/android|iphone|ipad|ipod|mobile|tablet/i.test(userAgent)) {
+	if (mobileOS !== null || /mobile|tablet/i.test(userAgent)) {
 		return { platform: Platform.Mobile, mobileOS };
 	}
 
@@ -90,6 +88,13 @@ function detectPlatform(): PlatformInfo {
 		return { platform: Platform.Linux, mobileOS };
 	}
 	return { platform: Platform.Unknown, mobileOS };
+}
+
+function detectPlatform(): PlatformInfo {
+	if (typeof navigator === "undefined") {
+		return { platform: Platform.Unknown, mobileOS: null };
+	}
+	return detectPlatformInfo(navigator.userAgent, navigator.maxTouchPoints);
 }
 
 const DEFAULT_PLATFORM: PlatformInfo = {

--- a/frontend/src/renderer/lib/landing-useOS.test.ts
+++ b/frontend/src/renderer/lib/landing-useOS.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import {
+	detectPlatformInfo,
+	Platform,
+} from "../../landing/src/app/hooks/useOS/useOS";
+
+describe("detectPlatformInfo", () => {
+	test.each([
+		{
+			name: "modern iPad",
+			userAgent:
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 Version/17.5 Mobile/15E148 Safari/604.1",
+			maxTouchPoints: 5,
+			mobileOS: "ios",
+		},
+		{
+			name: "legacy iPad",
+			userAgent:
+				"Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148",
+			maxTouchPoints: 5,
+			mobileOS: "ios",
+		},
+		{
+			name: "iPhone",
+			userAgent:
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148",
+			maxTouchPoints: 5,
+			mobileOS: "ios",
+		},
+		{
+			name: "Android",
+			userAgent:
+				"Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 Chrome/131.0 Mobile Safari/537.36",
+			maxTouchPoints: 5,
+			mobileOS: "android",
+		},
+	] as const)("classifies $name as mobile", ({ userAgent, maxTouchPoints, mobileOS }) => {
+		expect(detectPlatformInfo(userAgent, maxTouchPoints)).toEqual({
+			platform: Platform.Mobile,
+			mobileOS,
+		});
+	});
+
+	test("does not classify a real Mac as mobile", () => {
+		const result = detectPlatformInfo(
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.5 Safari/605.1.15",
+			0,
+		);
+
+		expect(result.platform).not.toBe(Platform.Mobile);
+		expect(result.mobileOS).toBeNull();
+	});
+});


### PR DESCRIPTION
## What

- Detect iOS and Android separately on the landing site, including desktop-mode iPadOS.
- Send iPhone and iPad visitors to a QR-free TestFlight bottom sheet while preserving the desktop QR flow.
- Make both **Get TestFlight** and **Open invite** available immediately, without a prerequisite checkbox or persisted gate.
- Show the mobile-app card first on small screens.
- Label the header action **Download AO Mobile** with a phone icon on mobile devices.

## Why

The existing download experience was desktop-oriented even when visited from a phone. Mobile visitors were shown desktop copy and a QR-based flow despite already holding the target device. The first mobile implementation also gated the invite behind redundant TestFlight state, adding friction for visitors who already had the app.

## How

- Extend `usePlatform` with `mobileOS` while keeping the existing desktop platform contract.
- Treat detected iOS and Android devices as `Platform.Mobile` before matching desktop-style user agents.
- Route only iOS visitors to `TestFlightMobileSheet`; desktop and Android retain the existing `TestFlightDialog` behavior.
- Keep both TestFlight destinations as ordinary external links with the existing analytics events.
- Add regression coverage for modern and legacy iPads, iPhone, Android, and real Mac user agents.

Intentional omission: Android remains marked as coming soon and continues to use the existing non-iOS path.

## Testing

- `cd frontend && npm test` — 149 files, 1,970 tests passed.
- `cd frontend && npm run typecheck`
- `cd frontend/src/landing && npm exec tsc -- --noEmit`
- `cd frontend/src/landing && npm run build`
- Verified the `/download/` flow from an iPhone on the local network with both TestFlight actions enabled immediately.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
