### PR TITLE
fix: surface Codex native input waits

### DIFF
--- a/backend/internal/adapters/agent/codex/activity.go
+++ b/backend/internal/adapters/agent/codex/activity.go
@@ -6,17 +6,20 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // bool is false when the event carries no activity signal.
 //
 // event is the AO hook sub-command name installed in codexManagedHooks
-// ("user-prompt-submit", "permission-request", "stop", ...), not the native
-// Codex event name. Codex currently has no SessionEnd/Notification equivalent
-// in the adapter, so runtime exit still falls back to the reaper.
+// ("user-prompt-submit", "pre-tool-use", "post-tool-use", ...), not the
+// native Codex event name. Codex currently has no SessionEnd/Notification
+// equivalent in the adapter, so runtime exit still falls back to the reaper.
 func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
 	switch event {
 	case "user-prompt-submit":
 		return domain.ActivityActive, true
+	case "pre-tool-use":
+		return domain.ActivityBlocked, true
+	case "post-tool-use":
+		return domain.ActivityActive, true
 	case "permission-request":
-		// waiting_input, not blocked: codex installs no pre/post-tool-use
-		// hooks, so a blocked state could never be cleared before the turn
-		// ends. waiting_input still suppresses automated nudges.
+		// Permission prompts remain waiting_input. ActivityBlocked is reserved
+		// for the paired native request_user_input lifecycle above.
 		return domain.ActivityWaitingInput, true
 	case "stop":
 		return domain.ActivityIdle, true

--- a/backend/internal/adapters/agent/codex/activity_test.go
+++ b/backend/internal/adapters/agent/codex/activity_test.go
@@ -6,6 +6,12 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
+func TestEmitsBlockedActivity(t *testing.T) {
+	if New().EmitsBlockedActivity() {
+		t.Fatal("Codex must remain ineligible for automated Enter confirmation")
+	}
+}
+
 func TestDeriveActivityState(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -13,9 +19,11 @@ func TestDeriveActivityState(t *testing.T) {
 		want   domain.ActivityState
 		wantOK bool
 	}{
-		{"user prompt -> active", "user-prompt-submit", domain.ActivityActive, true},
+		{"user prompt clears stale wait -> active", "user-prompt-submit", domain.ActivityActive, true},
+		{"request user input start -> blocked", "pre-tool-use", domain.ActivityBlocked, true},
+		{"request user input completion -> active", "post-tool-use", domain.ActivityActive, true},
 		{"permission request -> waiting_input", "permission-request", domain.ActivityWaitingInput, true},
-		{"stop -> idle", "stop", domain.ActivityIdle, true},
+		{"turn stop clears interrupted wait -> idle", "stop", domain.ActivityIdle, true},
 		{"session start -> no signal", "session-start", "", false},
 		{"unknown event -> no signal", "frobnicate", "", false},
 	}

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -45,11 +45,11 @@ func New() *Plugin {
 // launch. See ports.SubmitActivitySignaler.
 func (p *Plugin) EmitsSubmitActivity() bool { return true }
 
-// EmitsBlockedActivity is false: codex reports permission prompts as
-// waiting_input — it installs no post-tool-use hook, so a blocked state could
-// never be cleared mid-turn. confirmActive must not nudge it (an Enter could
-// answer a pending decision it cannot report as blocked). See
-// ports.BlockedActivitySignaler.
+// EmitsBlockedActivity remains false because Codex permission-request hooks
+// still map to waiting_input rather than a correlatable blocked tool flight.
+// The request_user_input hooks make that native wait observable and clearable,
+// but do not make automated Enter confirmation safe for every Codex prompt.
+// See ports.BlockedActivitySignaler.
 func (p *Plugin) EmitsBlockedActivity() bool { return false }
 
 // ExitDetectionMode opts Codex into AO's process supervisor. Codex hooks
@@ -115,6 +115,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	cmd = []string{binary}
 	appendNoUpdateCheckFlag(&cmd)
 	appendHideRateLimitNudgeFlag(&cmd)
+	appendDefaultModeRequestUserInputFlag(&cmd)
 	appendHookTrustBypassFlag(&cmd)
 	appendApprovalFlags(&cmd, cfg.Permissions)
 	if err := appendSessionHookFlags(&cmd); err != nil {
@@ -159,6 +160,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	cmd = append(cmd, binary, "resume")
 	appendNoUpdateCheckFlag(&cmd)
 	appendHideRateLimitNudgeFlag(&cmd)
+	appendDefaultModeRequestUserInputFlag(&cmd)
 	appendHookTrustBypassFlag(&cmd)
 	appendApprovalFlags(&cmd, cfg.Permissions)
 	if err := appendSessionHookFlags(&cmd); err != nil {
@@ -454,6 +456,7 @@ func DoctorLaunchProbes() [][]string {
 	overrideProbe := []string{"features", "list"}
 	appendNoUpdateCheckFlag(&overrideProbe)
 	appendHideRateLimitNudgeFlag(&overrideProbe)
+	appendDefaultModeRequestUserInputFlag(&overrideProbe)
 	if err := appendSessionHookFlags(&overrideProbe); err != nil {
 		// The probe only asks Codex to parse the hook config; a bare fallback
 		// keeps that diagnostic available if the current executable cannot be
@@ -474,6 +477,10 @@ func appendHideRateLimitNudgeFlag(cmd *[]string) {
 	// In a headless AO pane that dialog hangs the session invisibly and
 	// swallows the auto-submitted spawn prompt, so suppress it.
 	*cmd = append(*cmd, "-c", "notice.hide_rate_limit_model_nudge=true")
+}
+
+func appendDefaultModeRequestUserInputFlag(cmd *[]string) {
+	*cmd = append(*cmd, "-c", "features.default_mode_request_user_input=true")
 }
 
 func appendHookTrustBypassFlag(cmd *[]string) {

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -138,6 +139,8 @@ func sessionHookFlags(t *testing.T) []string {
 		"-c", `hooks.SessionStart=[{hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"session-start") + `,timeout=5}]}]`,
 		"-c", `hooks.UserPromptSubmit=[{hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"user-prompt-submit") + `,timeout=5}]}]`,
 		"-c", `hooks.PermissionRequest=[{hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"permission-request") + `,timeout=5}]}]`,
+		"-c", `hooks.PreToolUse=[{matcher="^request_user_input$",hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"pre-tool-use") + `,timeout=5}]}]`,
+		"-c", `hooks.PostToolUse=[{matcher="^request_user_input$",hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"post-tool-use") + `,timeout=5}]}]`,
 		"-c", `hooks.Stop=[{hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"stop") + `,timeout=5}]}]`,
 	}
 }
@@ -168,6 +171,7 @@ func TestGetLaunchCommandBuildsCrossPlatformArgv(t *testing.T) {
 		"codex",
 		"-c", "check_for_update_on_startup=false",
 		"-c", "notice.hide_rate_limit_model_nudge=true",
+		"-c", "features.default_mode_request_user_input=true",
 		"--dangerously-bypass-hook-trust",
 		"--dangerously-bypass-approvals-and-sandbox",
 	}
@@ -638,6 +642,7 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 		"resume",
 		"-c", "check_for_update_on_startup=false",
 		"-c", "notice.hide_rate_limit_model_nudge=true",
+		"-c", "features.default_mode_request_user_input=true",
 		"--dangerously-bypass-hook-trust",
 		"--ask-for-approval", "on-request",
 		"-c", `approvals_reviewer="auto_review"`,
@@ -816,12 +821,47 @@ func TestDoctorLaunchProbesMirrorLaunchFlags(t *testing.T) {
 	}
 	joined := strings.Join(override, " ")
 	for _, want := range []string{
-		"hooks.SessionStart=", "hooks.UserPromptSubmit=", "hooks.PermissionRequest=", "hooks.Stop=",
+		"features.default_mode_request_user_input=true",
+		"hooks.SessionStart=", "hooks.UserPromptSubmit=", "hooks.PermissionRequest=",
+		"hooks.PreToolUse=", "hooks.PostToolUse=", "hooks.Stop=",
 		"notice.hide_rate_limit_model_nudge=true",
 		`projects={`,
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("override probe missing %q in %s", want, joined)
+		}
+	}
+}
+
+func TestRequestUserInputHooksUseExactMatcher(t *testing.T) {
+	wantCommands := map[string]string{
+		"PreToolUse":  codexHookCommandPrefix + "pre-tool-use",
+		"PostToolUse": codexHookCommandPrefix + "post-tool-use",
+	}
+	for event, wantCommand := range wantCommands {
+		var matcher string
+		var command string
+		for _, spec := range codexManagedHooks {
+			if spec.Event == event {
+				matcher = spec.Matcher
+				command = spec.Command
+				break
+			}
+		}
+		if matcher != `^request_user_input$` {
+			t.Fatalf("%s matcher = %q, want exact request_user_input matcher", event, matcher)
+		}
+		for _, tool := range []string{"request_user_input", "shell", "mcp__request_user_input", "request_user_input_extra"} {
+			matched, err := regexp.MatchString(matcher, tool)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if matched != (tool == "request_user_input") {
+				t.Fatalf("%s matcher against %q = %v", event, tool, matched)
+			}
+		}
+		if command != wantCommand {
+			t.Fatalf("%s command = %q, want lifecycle event %q", event, command, wantCommand)
 		}
 	}
 }

--- a/backend/internal/adapters/agent/codex/hooks.go
+++ b/backend/internal/adapters/agent/codex/hooks.go
@@ -61,6 +61,7 @@ type codexHookEntry struct {
 // codexHookSpec describes one hook AO delivers via launch-command config.
 type codexHookSpec struct {
 	Event   string
+	Matcher string
 	Command string
 }
 
@@ -71,6 +72,8 @@ var codexManagedHooks = []codexHookSpec{
 	{Event: "SessionStart", Command: codexHookCommandPrefix + "session-start"},
 	{Event: "UserPromptSubmit", Command: codexHookCommandPrefix + "user-prompt-submit"},
 	{Event: "PermissionRequest", Command: codexHookCommandPrefix + "permission-request"},
+	{Event: "PreToolUse", Matcher: `^request_user_input$`, Command: codexHookCommandPrefix + "pre-tool-use"},
+	{Event: "PostToolUse", Matcher: `^request_user_input$`, Command: codexHookCommandPrefix + "post-tool-use"},
 	{Event: "Stop", Command: codexHookCommandPrefix + "stop"},
 }
 
@@ -97,8 +100,12 @@ func appendSessionHookFlagsForExecutable(cmd *[]string, executable string) {
 	prefix := shellQuoteHookExecutable(executable) + " hooks codex "
 	for _, spec := range codexManagedHooks {
 		action := strings.TrimPrefix(spec.Command, codexHookCommandPrefix)
-		flag := fmt.Sprintf(`hooks.%s=[{hooks=[{type="command",command=%s,timeout=%d}]}]`,
-			spec.Event, codexTOMLBasicString(prefix+action), codexHookTimeout)
+		matcher := ""
+		if spec.Matcher != "" {
+			matcher = "matcher=" + codexTOMLBasicString(spec.Matcher) + ","
+		}
+		flag := fmt.Sprintf(`hooks.%s=[{%shooks=[{type="command",command=%s,timeout=%d}]}]`,
+			spec.Event, matcher, codexTOMLBasicString(prefix+action), codexHookTimeout)
 		*cmd = append(*cmd, "-c", flag)
 	}
 }

--- a/backend/internal/lifecycle/toolflight_test.go
+++ b/backend/internal/lifecycle/toolflight_test.go
@@ -36,6 +36,21 @@ func stateOf(st *fakeStore, id domain.SessionID) domain.ActivityState {
 	return st.sessions[id].Activity.State
 }
 
+func TestToolPrecedence_CodexRequestUserInputPrePostClearsBlocked(t *testing.T) {
+	m, st, _ := newManager()
+	seedSignaled(st, "mer-1", domain.ActivityActive)
+
+	mustApply(t, m, "mer-1", sig(domain.ActivityBlocked, "pre-tool-use", "request_user_input", "toolu_input"))
+	if got := stateOf(st, "mer-1"); got != domain.ActivityBlocked {
+		t.Fatalf("state while request_user_input is pending = %q, want blocked", got)
+	}
+
+	mustApply(t, m, "mer-1", sig(domain.ActivityActive, "post-tool-use", "request_user_input", "toolu_input"))
+	if got := stateOf(st, "mer-1"); got != domain.ActivityActive {
+		t.Fatalf("state after request_user_input completion = %q, want active", got)
+	}
+}
+
 // blockOnDialog drives a session into blocked through the real signal path:
 // the blocking tool's pre-tool-use, then permission-request naming that tool.
 func blockOnDialog(t *testing.T, m *Manager, st *fakeStore, id domain.SessionID, toolName, toolUseID string) {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/scratch"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -6490,6 +6491,25 @@ func TestSend_SkipsConfirmForSubmitOnlyHarness(t *testing.T) {
 	}
 	if len(msg.msgs) != 1 {
 		t.Fatalf("Send calls = %d, want 1 (submit-only harness must not be nudged)", len(msg.msgs))
+	}
+}
+
+func TestSend_SkipsConfirmForCodexAdapter(t *testing.T) {
+	// Codex reports request_user_input as a blocked tool flight, but its
+	// separate permission-request hook remains waiting_input. The real adapter
+	// must therefore stay out of Enter-only confirmation so a delayed submit
+	// signal can never cause AO to answer a permission dialog.
+	st := newFakeStore()
+	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: domain.HarnessCodex,
+		Activity: domain.Activity{State: domain.ActivityIdle}}
+	msg := &fakeMessenger{}
+	m := newSendTestManager(t, codex.New(), msg, st)
+
+	if err := m.Send(context.Background(), "s1", "do the thing"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("Send calls = %d, want 1 (Codex adapter must not be nudged)", len(msg.msgs))
 	}
 }
 


### PR DESCRIPTION
## Summary

- enable Codex's native Default-mode `request_user_input` feature for AO launch, restore, and Doctor probes
- install exact `request_user_input` PreToolUse/PostToolUse hooks so lifecycle derives `blocked` while unanswered and clears to `active`, with existing Stop/UserPromptSubmit boundaries preserved
- keep Codex ineligible for automated Enter confirmation because its separate permission hook is not safely correlated; cover the real adapter and sticky tool-flight reducer with regressions

Tracks https://github.com/SharonTal/shamAI/issues/64 (approved PLAN 64-P1). The durable tracker remains open for human verification.

## Verification

- `go test ./internal/adapters/agent/codex ./internal/adapters/agent/activitydispatch ./internal/lifecycle ./internal/session_manager ./internal/service/session/...`
- `go test -race ./internal/adapters/agent/codex ./internal/lifecycle ./internal/session_manager ./internal/service/session/...`
- environment-isolated `npm run lint` (`go test ./...` plus golangci-lint v2.12.2): 0 issues
- Codex CLI 0.146 Doctor launch-flag canary: accepted feature/hook/trust overrides
- isolated real Electron/dev-daemon acceptance on port 3002: fresh and restored native prompts both reached `blocked`/`needs_input`, guarded send returned `SESSION_AWAITING_DECISION`, native answer emitted PostToolUse `active`, and Stop returned `idle`; production AO daemon/data were not stopped or mutated

## Fresh-context review gate

All four bounded, independent read-only reviews exited 0 with `NO FINDINGS` after the nudge-safety remediation:

- scope/acceptance: `codex-cli-0.146.0-ephemeral-43f46787-577d-4e21-a0bc-92398f5445d4`
- adapter architecture/hook ownership: `codex-cli-0.146.0-ephemeral-04f167c3-0df0-4920-bcd1-a5f4335b3f21`
- correctness/state clearing/guarded-send/data integrity: `codex-cli-0.146.0-ephemeral-e9f53431-0146-49d7-9ca9-bbabb50c2781`
- supported Codex CLI compatibility/live evidence: `codex-cli-0.146.0-ephemeral-ef968f49-d71c-466f-a604-8e36170b1142`

## Scope

No API/schema, frontend, manual status override, ShamAI file, or unrelated harness behavior changes.