### PR TITLE
fix: keep current page when opening Settings modal

### DIFF
--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -116,6 +116,7 @@ beforeEach(() => {
 		orchestratorReplacementErrors: {},
 		orchestratorStartupErrors: {},
 		restartingProjectIds: new Set(),
+		settingsModal: null,
 	});
 });
 
@@ -271,10 +272,8 @@ describe("project board with no sessions", () => {
 		const [spawnButton] = screen.getAllByRole("button", { name: "Spawn Orchestrator" });
 		await userEvent.click(spawnButton);
 
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/settings",
-			params: { projectId: "proj-1" },
-		});
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-1" });
+		expect(navigateMock).not.toHaveBeenCalled();
 		expect(spawnOrchestratorMock).not.toHaveBeenCalled();
 	});
 

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -206,6 +206,7 @@ beforeEach(() => {
 			themePreference: "dark",
 			resolvedTheme: "dark",
 			restartingProjectIds: new Set(),
+			settingsModal: null,
 		});
 	});
 });
@@ -493,10 +494,8 @@ describe("CommandPalette actions", () => {
 		await screen.findByPlaceholderText(/search projects/i);
 		fireEvent.click(screen.getByText("Open orchestrator"));
 
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/settings",
-			params: { projectId: "proj-2" },
-		});
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-2" });
+		expect(navigateMock).not.toHaveBeenCalled();
 		expect(spawnMock).not.toHaveBeenCalled();
 		await waitFor(() => expect(paletteInput()).toBeNull());
 	});

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -186,13 +186,14 @@ export function CommandPalette() {
 		(target: NavigateTarget) => {
 			switch (target.to) {
 				case "/settings":
-					void navigate({ to: "/settings" });
+					// Modal — do not route to /settings (that legacy path redirects home).
+					useUiStore.getState().openGlobalSettings();
 					break;
 				case "/projects/$projectId":
 					void navigate({ to: target.to, params: target.params });
 					break;
 				case "/projects/$projectId/settings":
-					void navigate({ to: target.to, params: target.params });
+					useUiStore.getState().openProjectSettings(target.params.projectId);
 					break;
 				case "/projects/$projectId/sessions/$sessionId":
 					void navigate({ to: target.to, params: target.params });

--- a/frontend/src/renderer/components/RestoreUnavailableDialog.test.tsx
+++ b/frontend/src/renderer/components/RestoreUnavailableDialog.test.tsx
@@ -1,17 +1,13 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUiStore } from "../stores/ui-store";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { RestoreUnavailableDialog } from "./RestoreUnavailableDialog";
 
-const { navigateMock, spawnMock, workspaceQueryMock } = vi.hoisted(() => ({
-	navigateMock: vi.fn(),
+const { spawnMock, workspaceQueryMock } = vi.hoisted(() => ({
 	spawnMock: vi.fn(),
 	workspaceQueryMock: vi.fn(),
-}));
-
-vi.mock("@tanstack/react-router", () => ({
-	useNavigate: () => navigateMock,
 }));
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
@@ -44,6 +40,7 @@ const workspace: WorkspaceSummary = {
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	useUiStore.setState({ settingsModal: null });
 	workspaceQueryMock.mockReturnValue({ data: [workspace], isLoading: false });
 });
 
@@ -66,11 +63,8 @@ describe("RestoreUnavailableDialog", () => {
 
 		await userEvent.click(screen.getByRole("button", { name: "Configure orchestrator agent" }));
 
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/settings",
-			params: { projectId: "proj-1" },
-		});
 		expect(onOpenChange).toHaveBeenCalledWith(false);
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-1" });
 		expect(spawnMock).not.toHaveBeenCalled();
 		expect(onRecreated).not.toHaveBeenCalled();
 	});

--- a/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
+++ b/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
@@ -1,10 +1,10 @@
 import * as Dialog from "@radix-ui/react-dialog";
-import { useNavigate } from "@tanstack/react-router";
 import { Loader2, X } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
+import { useUiStore } from "../stores/ui-store";
 import { hasConfiguredOrchestratorAgent, isOrchestratorSession } from "../types/workspace";
 import type { WorkspaceSession } from "../types/workspace";
 import { Button } from "./ui/button";
@@ -24,7 +24,6 @@ type RestoreUnavailableDialogProps = {
 
 export function RestoreUnavailableDialog({ open, session, onOpenChange, onRecreated }: RestoreUnavailableDialogProps) {
 	const { t } = useTranslation();
-	const navigate = useNavigate();
 	const workspaceQuery = useWorkspaceQuery();
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | undefined>();
@@ -37,10 +36,7 @@ export function RestoreUnavailableDialog({ open, session, onOpenChange, onRecrea
 		if (checkingProject) return;
 		if (!hasOrchestratorAgent) {
 			onOpenChange(false);
-			void navigate({
-				to: "/projects/$projectId/settings",
-				params: { projectId: session.workspaceId },
-			});
+			useUiStore.getState().openProjectSettings(session.workspaceId);
 			return;
 		}
 		setBusy(true);

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -226,7 +226,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 		}
 		if (!hasConfiguredOrchestratorAgent(workspace)) {
 			if (workspace) {
-				void navigate({ to: "/projects/$projectId/settings", params: { projectId } });
+				useUiStore.getState().openProjectSettings(projectId);
 			}
 			return;
 		}

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -158,7 +158,7 @@ beforeEach(() => {
 	postMock.mockResolvedValue({ data: { ok: true, sessionId: "sess-1" }, error: undefined });
 	useWorkspaceQueryMock.mockReset();
 	useWorkspaceQueryMock.mockReturnValue({ data: [], isError: false, isLoading: false });
-	useUiStore.setState({ inspectorSessions: {} });
+	useUiStore.setState({ inspectorSessions: {}, settingsModal: null });
 });
 
 describe("ShellTopbar status pill", () => {
@@ -270,10 +270,8 @@ describe("ShellTopbar orchestrator actions", () => {
 
 		await userEvent.click(screen.getByRole("button", { name: "Open orchestrator" }));
 
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/settings",
-			params: { projectId: "proj-1" },
-		});
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-1" });
+		expect(navigateMock).not.toHaveBeenCalled();
 		expect(spawnMock).not.toHaveBeenCalled();
 	});
 

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -143,7 +143,7 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 		}
 		if (!hasConfiguredOrchestratorAgent(project)) {
 			if (project) {
-				void navigate({ to: "/projects/$projectId/settings", params: { projectId } });
+				useUiStore.getState().openProjectSettings(projectId);
 			}
 			return;
 		}

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -217,7 +217,7 @@ beforeEach(() => {
 	window.localStorage.clear();
 	document.documentElement.style.removeProperty("--ao-sidebar-w");
 	commandPaletteEnabled.current = true;
-	useUiStore.setState({ isCommandPaletteOpen: false });
+	useUiStore.setState({ isCommandPaletteOpen: false, settingsModal: null });
 	getMock.mockReset();
 	getMock.mockResolvedValue({
 		data: {
@@ -292,10 +292,8 @@ describe("Sidebar", () => {
 
 		await user.click(screen.getByRole("button", { name: "Spawn Project One orchestrator" }));
 
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/settings",
-			params: { projectId: "proj-1" },
-		});
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-1" });
+		expect(navigateMock).not.toHaveBeenCalled();
 		expect(spawnMock).not.toHaveBeenCalled();
 	});
 
@@ -902,7 +900,8 @@ describe("Sidebar", () => {
 		const user = userEvent.setup();
 		renderSidebar();
 		await user.click(screen.getAllByRole("button", { name: "Settings" })[0]);
-		expect(navigateMock).toHaveBeenCalledWith({ to: "/settings" });
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "global" });
+		expect(navigateMock).not.toHaveBeenCalled();
 	});
 
 	it("opens the command palette when Search is clicked", async () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -122,6 +122,8 @@ type SidebarProps = {
 // route params, and clicks navigate rather than mutate a store.
 function useSelection() {
 	const navigate = useNavigate();
+	const openGlobalSettings = useUiStore((state) => state.openGlobalSettings);
+	const openProjectSettings = useUiStore((state) => state.openProjectSettings);
 	const params = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
 	const pathname = useRouterState({ select: (state) => state.location.pathname });
 	return {
@@ -129,8 +131,10 @@ function useSelection() {
 		activeProjectId: params.projectId,
 		activeSessionId: params.sessionId,
 		goHome: () => void navigate({ to: "/" }),
-		goGlobalSettings: () => void navigate({ to: "/settings" }),
-		goSettings: (projectId: string) => void navigate({ to: "/projects/$projectId/settings", params: { projectId } }),
+		// Settings is a modal — open it in place so the current page (session
+		// terminal, board, etc.) stays underneath.
+		goGlobalSettings: () => openGlobalSettings(),
+		goSettings: (projectId: string) => openProjectSettings(projectId),
 		goProject: (projectId: string) => void navigate({ to: "/projects/$projectId", params: { projectId } }),
 		goSession: (projectId: string, sessionId: string) =>
 			void navigate({ to: "/projects/$projectId/sessions/$sessionId", params: { projectId, sessionId } }),

--- a/frontend/src/renderer/components/WindowTitlebar.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { PanelLeft } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -72,10 +71,9 @@ export function WindowTitlebar({
 }: {
 	onSidebarPreviewEnter?: React.PointerEventHandler<HTMLButtonElement>;
 }) {
-	const navigate = useNavigate();
 	const { t } = useTranslation();
 	const theme = useResolvedTheme();
-	const { isSidebarOpen, toggleSidebar } = useUiStore();
+	const { isSidebarOpen, toggleSidebar, openGlobalSettings } = useUiStore();
 	const [openMenu, setOpenMenu] = useState<MenuKey | null>(null);
 
 	// Electron draws the min/max/close overlay natively and can't read our CSS, so
@@ -120,7 +118,7 @@ export function WindowTitlebar({
 			</button>
 			<nav className="window-titlebar__menus">
 				<TopMenu id="file" label={t("titlebar.file")} openMenu={openMenu} setOpenMenu={setOpenMenu}>
-					<DropdownMenuItem onSelect={() => void navigate({ to: "/settings" })}>{t("shell.settings")}</DropdownMenuItem>
+					<DropdownMenuItem onSelect={() => openGlobalSettings()}>{t("shell.settings")}</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					<DropdownMenuItem onSelect={act("app.quit")}>
 						{t("titlebar.quit")}

--- a/frontend/src/renderer/routes/_shell.projects.$projectId_.settings.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId_.settings.tsx
@@ -1,31 +1,22 @@
-import { createFileRoute, useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { useUiStore } from "../stores/ui-store";
 
 export const Route = createFileRoute("/_shell/projects/$projectId_/settings")({
 	component: ProjectSettingsRoute,
 });
 
-// Deep-link shim: project settings is a modal. Prefer returning to the previous
-// page so opening settings from a session does not jump to the project board.
+// Deep-link shim: project settings is a modal. In-app openers call
+// openProjectSettings() directly; this route only handles cold loads.
 function ProjectSettingsRoute() {
 	const { projectId } = Route.useParams();
 	const navigate = useNavigate();
-	const router = useRouter();
-	const canGoBack = useCanGoBack();
 	const openProjectSettings = useUiStore((state) => state.openProjectSettings);
-	const didOpen = useRef(false);
 
 	useEffect(() => {
-		if (didOpen.current) return;
-		didOpen.current = true;
 		openProjectSettings(projectId);
-		if (canGoBack) {
-			router.history.back();
-		} else {
-			void navigate({ to: "/projects/$projectId", params: { projectId }, replace: true });
-		}
-	}, [canGoBack, navigate, openProjectSettings, projectId, router]);
+		void navigate({ to: "/projects/$projectId", params: { projectId }, replace: true });
+	}, [navigate, openProjectSettings, projectId]);
 
 	return null;
 }

--- a/frontend/src/renderer/routes/_shell.projects.$projectId_.settings.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId_.settings.tsx
@@ -1,20 +1,31 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { createFileRoute, useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
 import { useUiStore } from "../stores/ui-store";
 
 export const Route = createFileRoute("/_shell/projects/$projectId_/settings")({
 	component: ProjectSettingsRoute,
 });
 
+// Deep-link shim: project settings is a modal. Prefer returning to the previous
+// page so opening settings from a session does not jump to the project board.
 function ProjectSettingsRoute() {
 	const { projectId } = Route.useParams();
 	const navigate = useNavigate();
+	const router = useRouter();
+	const canGoBack = useCanGoBack();
 	const openProjectSettings = useUiStore((state) => state.openProjectSettings);
+	const didOpen = useRef(false);
 
 	useEffect(() => {
+		if (didOpen.current) return;
+		didOpen.current = true;
 		openProjectSettings(projectId);
-		void navigate({ to: "/projects/$projectId", params: { projectId }, replace: true });
-	}, [navigate, openProjectSettings, projectId]);
+		if (canGoBack) {
+			router.history.back();
+		} else {
+			void navigate({ to: "/projects/$projectId", params: { projectId }, replace: true });
+		}
+	}, [canGoBack, navigate, openProjectSettings, projectId, router]);
 
 	return null;
 }

--- a/frontend/src/renderer/routes/_shell.settings.tsx
+++ b/frontend/src/renderer/routes/_shell.settings.tsx
@@ -1,19 +1,30 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { createFileRoute, useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
 import { useUiStore } from "../stores/ui-store";
 
 export const Route = createFileRoute("/_shell/settings")({
 	component: LegacyGlobalSettingsRoute,
 });
 
+// Deep-link / bookmark shim: settings is a modal now. Open it, then leave this
+// route so the page underneath is whatever the user was on (not forced to "/").
 function LegacyGlobalSettingsRoute() {
 	const navigate = useNavigate();
+	const router = useRouter();
+	const canGoBack = useCanGoBack();
 	const openGlobalSettings = useUiStore((state) => state.openGlobalSettings);
+	const didOpen = useRef(false);
 
 	useEffect(() => {
+		if (didOpen.current) return;
+		didOpen.current = true;
 		openGlobalSettings();
-		void navigate({ to: "/", replace: true });
-	}, [navigate, openGlobalSettings]);
+		if (canGoBack) {
+			router.history.back();
+		} else {
+			void navigate({ to: "/", replace: true });
+		}
+	}, [canGoBack, navigate, openGlobalSettings, router]);
 
 	return null;
 }

--- a/frontend/src/renderer/routes/_shell.settings.tsx
+++ b/frontend/src/renderer/routes/_shell.settings.tsx
@@ -1,30 +1,21 @@
-import { createFileRoute, useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { useUiStore } from "../stores/ui-store";
 
 export const Route = createFileRoute("/_shell/settings")({
 	component: LegacyGlobalSettingsRoute,
 });
 
-// Deep-link / bookmark shim: settings is a modal now. Open it, then leave this
-// route so the page underneath is whatever the user was on (not forced to "/").
+// Deep-link / bookmark shim: settings is a modal now. In-app openers call
+// openGlobalSettings() directly; this route only handles cold loads of /settings.
 function LegacyGlobalSettingsRoute() {
 	const navigate = useNavigate();
-	const router = useRouter();
-	const canGoBack = useCanGoBack();
 	const openGlobalSettings = useUiStore((state) => state.openGlobalSettings);
-	const didOpen = useRef(false);
 
 	useEffect(() => {
-		if (didOpen.current) return;
-		didOpen.current = true;
 		openGlobalSettings();
-		if (canGoBack) {
-			router.history.back();
-		} else {
-			void navigate({ to: "/", replace: true });
-		}
-	}, [canGoBack, navigate, openGlobalSettings, router]);
+		void navigate({ to: "/", replace: true });
+	}, [navigate, openGlobalSettings]);
 
 	return null;
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -591,7 +591,10 @@ function ShellLayout() {
 		setActiveShellTerminal,
 	]);
 
-	useEffect(() => aoBridge.app.onOpenSettingsShortcut(() => void navigate({ to: "/settings" })), [navigate]);
+	useEffect(
+		() => aoBridge.app.onOpenSettingsShortcut(() => useUiStore.getState().openGlobalSettings()),
+		[],
+	);
 
 	useEffect(() => {
 		const disposePrevious = aoBridge.app.onPreviousSessionShortcut(() => navigateSession(-1));

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -167,6 +167,7 @@ vi.mock("../components/TitlebarNav", async () => {
 	};
 });
 vi.mock("../components/WindowTitlebar", () => ({ WindowTitlebar: () => null }));
+vi.mock("../components/SettingsDialog", () => ({ SettingsDialog: () => null }));
 vi.mock("../components/KeyboardShortcutsDialog", () => ({
 	KeyboardShortcutsDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="keyboard-shortcuts" /> : null),
 }));
@@ -291,6 +292,7 @@ beforeEach(() => {
 		isSidebarOpen: true,
 		newTaskRequest: null,
 		newShellTerminalNonce: 0,
+		settingsModal: null,
 	});
 });
 
@@ -564,7 +566,8 @@ describe("shell application shortcut subscriptions", () => {
 
 		act(() => shellMocks.state.openSettingsListener?.());
 
-		expect(shellMocks.navigate).toHaveBeenCalledWith({ to: "/settings" });
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "global" });
+		expect(shellMocks.navigate).not.toHaveBeenCalled();
 	});
 
 	it("moves to the next active session in the current project", async () => {


### PR DESCRIPTION
Fixes #3693

## Summary
- Open Settings via the UI-store modal in place (sidebar, Cmd+K, shortcuts, titlebar, and related project-settings entry points) instead of navigating to `/settings`
- Legacy `/settings` and project-settings routes still work as deep-link shims, but return with `history.back()` when possible instead of forcing Board

## Test plan
- [x] Unit tests for sidebar, command palette, shell shortcut, topbar, board empty states, restore dialog
- [ ] Open a session terminal → click sidebar Settings → confirm session stays behind the modal
- [ ] From that session, Cmd+K → Global settings → same
- [ ] Close settings → still on the same session
- [ ] Cold open `/settings` still lands on home with the modal open