### PR TITLE
fix(release): stop baking the pre-rename AgentWrapper org into release config

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -78,6 +78,11 @@ jobs:
           node -e "const v=process.env.BUILD_VERSION.split('+')[0]; const fs=require('fs'); const p=require('./package.json'); p.version=v; fs.writeFileSync('./package.json', JSON.stringify(p,null,'\t')+'\n');"
       - name: Build (unsigned, no publish)
         shell: bash
+        env:
+          # forge.config.ts bakes app-update.yml's owner/repo from this at make
+          # time even though this workflow never publishes; unset, it falls back
+          # to forge.config.ts's production default (#3523).
+          AO_RELEASE_REPO: ${{ github.repository }}
         run: npm run make
       - name: Collect artifact and compute digest
         shell: bash

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -6,8 +6,9 @@ import MakerAppImage from "./makers/maker-appimage";
 import { writeFileSync } from "node:fs";
 
 // Default GitHub release target (production). aoagents was the temporary rewrite
-// home; releases land on AgentWrapper (spec §1.1).
-const DEFAULT_RELEASE_REPO = "AgentWrapper/agent-orchestrator";
+// home; releases land on Untrivial-ai, the org this repo now lives under
+// (formerly AgentWrapper) (spec §1.1).
+const DEFAULT_RELEASE_REPO = "Untrivial-ai/agent-orchestrator";
 
 // The packaged binary name (no extension). Single source of truth: the packager
 // names the exe/ELF from this, and the NSIS + deb makers must point their
@@ -192,7 +193,7 @@ const config: ForgeConfig = {
 			// to the production target. The dev/test loop sets
 			// AO_RELEASE_REPO=harshitsinghbhandari/agent-orchestrator (spec §1.1, §8).
 			// Note: aoagents/agent-orchestrator was the temporary rewrite home and is
-			// intentionally NOT the default; releases land on AgentWrapper.
+			// intentionally NOT the default; releases land on Untrivial-ai.
 			config: {
 				repository: parseReleaseRepo(process.env.AO_RELEASE_REPO),
 				prerelease: process.env.AO_RELEASE_PRERELEASE === "true",

--- a/frontend/src/main/feature-builds.ts
+++ b/frontend/src/main/feature-builds.ts
@@ -7,12 +7,12 @@ const GITHUB_API = "https://api.github.com";
 
 // Default when the baked app-update.yml cannot be read (dev, or a malformed
 // bundle). Matches forge.config.ts DEFAULT_RELEASE_REPO.
-const DEFAULT_REPO = { owner: "AgentWrapper", repo: "agent-orchestrator" } as const;
+const DEFAULT_REPO = { owner: "Untrivial-ai", repo: "agent-orchestrator" } as const;
 
 // Resolve the GitHub repo the app updates from by reading the same bundled
 // app-update.yml that electron-updater uses. Both are baked from AO_RELEASE_REPO
 // at build time, so this keeps the feature list and the updater on the SAME repo
-// (a fork build lists that fork's feature releases, not AgentWrapper's). The
+// (a fork build lists that fork's feature releases, not Untrivial-ai's). The
 // list and the updater must never diverge, or the picker would offer builds
 // the updater cannot install.
 let cachedRepo: { owner: string; repo: string } | undefined;


### PR DESCRIPTION
## What

`DEFAULT_RELEASE_REPO` in `frontend/forge.config.ts` and `DEFAULT_REPO` in `frontend/src/main/feature-builds.ts` still hardcoded `AgentWrapper/agent-orchestrator` -- the org this repo was renamed away from. Any build path that doesn't set `AO_RELEASE_REPO` explicitly bakes the stale owner into the shipped `app-update.yml`, including `build-artifacts.yml`'s dispatchable unsigned build, which never sets it at all.

Today auto-update only keeps working because GitHub's org-rename redirect (`AgentWrapper` -> `Untrivial-ai`) happens to still resolve. That redirect breaks permanently the moment the still-existing `AgentWrapper` account creates any repo named `agent-orchestrator`, at which point every fleet install baked with the stale owner loses auto-update for good.

## Fix

- `frontend/forge.config.ts`: `DEFAULT_RELEASE_REPO` -> `Untrivial-ai/agent-orchestrator`.
- `frontend/src/main/feature-builds.ts`: `DEFAULT_REPO` -> `{ owner: "Untrivial-ai", ... }` (kept in sync with the forge default per its own comment).
- `.github/workflows/build-artifacts.yml`: set `AO_RELEASE_REPO: ${{ github.repository }}` on the make step, matching the pattern `frontend-release.yml` already uses, so forks and dispatched builds bake their own owner instead of falling through to the production default at all.

## Scope note

This addresses the part of #3523 that lives in this repo. The issue also calls out the external `ao-releases` conductor and a macOS update-e2e regression guard; I don't have access to that conductor repo and don't have a macOS environment to build/verify an e2e guard, so I left both out rather than guess. Happy to take a pass at the e2e guard if someone can point me at how `mac-update-e2e.yml` is normally exercised.

## Testing

- `npx tsc --noEmit` over the frontend: clean (after `npm ci` to pick up the current lockfile).
- `npx vitest run src/main/feature-builds.test.ts src/main/auto-updater.test.ts`: 61/61 passing, no regressions.
- `.github/workflows/build-artifacts.yml` parsed with `js-yaml` to confirm the edited step is still valid YAML.
- Grepped the touched files for any remaining `AgentWrapper` reference; only the intentional historical note in the `forge.config.ts` comment remains.

I don't have a way to actually run the Electron packaging step or a macOS/Linux release build in this environment, so I wasn't able to verify the baked `app-update.yml` output end-to-end -- the fix is a straightforward default-value substitution plus an explicit env var mirroring an existing working pattern, but flagging that gap for reviewers.