### PR TITLE
fix: open board from project name without double-click

### DIFF
--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -239,12 +239,26 @@ describe("ShellTopbar orchestrator actions", () => {
 		if (!pulses) expect(indicator).not.toHaveClass("animate-status-pulse");
 	});
 
-	it("marks Kanban as the primary action on orchestrator sessions", () => {
+	it("opens the board from the project name on orchestrator sessions", async () => {
+		renderTopbar(orchestrator, true);
+
+		expect(screen.queryByText("Kanban")).not.toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: "Open Kanban" }));
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId",
+			params: { projectId: "proj-1" },
+		});
+	});
+
+	it("opens the board from the project-name crumb on the full orchestrator topbar", async () => {
 		renderTopbar(orchestrator);
 
-		expect(screen.getByRole("button", { name: "Open Kanban" })).toHaveClass("bg-accent-strong");
 		expect(screen.getByRole("button", { name: "New task" })).toHaveClass("bg-raised");
-		expect(screen.getByRole("button", { name: "New task" })).not.toHaveClass("bg-accent-strong");
+		await userEvent.click(screen.getByRole("button", { name: "Open Kanban" }));
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId",
+			params: { projectId: "proj-1" },
+		});
 	});
 
 	it("opens project settings instead of spawning when no orchestrator agent is configured", async () => {

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { GitBranch, LayoutDashboard, PanelRightClose, PanelRightOpen, Plus, Trash2 } from "lucide-react";
+import { GitBranch, PanelRightClose, PanelRightOpen, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { animate, LayoutGroup, motion, useMotionValue, useReducedMotion } from "motion/react";
 import { NotificationCenter } from "./NotificationCenter";
@@ -26,6 +26,7 @@ import { OrchestratorIcon } from "./icons";
 import { OrchestratorActivityIndicator } from "./OrchestratorActivityIndicator";
 import { getAgentActivityView } from "../lib/session-presentation";
 import { isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
+import { cn } from "../lib/utils";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { StatusPill } from "./StatusPill";
 import { TopbarButton, TopbarKillError, topbarHeaderClass, topbarProjectLabelClass } from "./TopbarButton";
@@ -42,10 +43,11 @@ const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperti
 // / inspector stay available. The variant is derived from the route, not props:
 // a sessionId in the URL swaps the lead to the session identity (orchestrator
 // crumb + mode badge, or worker branch + status pill) and the actions to
-// board/orchestrator + inspector controls (orchestrators open the Kanban board;
-// workers open their orchestrator); otherwise it's the dashboard crumb plus the
-// Orchestrator launcher when a project is in scope. Embedded mode contributes
-// only session actions to the terminal bar; other routes retain this full bar.
+// board/orchestrator + inspector controls (orchestrators open the board via the
+// project-name control; workers open their orchestrator); otherwise it's the
+// dashboard crumb plus the Orchestrator launcher when a project is in scope.
+// Embedded mode contributes session actions to the terminal bar — and for
+// orchestrators, the clickable project name that replaces the old Kanban button.
 // Pixel equivalents of the CSS custom properties used for titlebar clearance.
 // --size-titlebar-cluster-left (72) + --size-titlebar-cluster-width (3×28+2×4=92)
 // + --size-titlebar-content-gap (12) = 176; minus --size-center-panel-inset-mac (6) = 170.
@@ -180,14 +182,7 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 				{isSessionRoute && isOrchestrator ? (
 					<div className="inline-flex min-w-0 items-center gap-2">
 						<div className="inline-flex min-w-0 items-center gap-1.5">
-							<motion.span
-								layoutId="topbar-project-label"
-								layout="position"
-								className={topbarProjectLabelClass}
-								transition={{ type: "spring", stiffness: 400, damping: 40 }}
-							>
-								{projectLabel}
-							</motion.span>
+							<ProjectBoardLabelButton label={projectLabel} onOpen={openBoard} style={noDragStyle} />
 								<span aria-hidden="true" className="text-xs leading-none text-passive">
 									·
 								</span>
@@ -270,6 +265,16 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 					<>
 						{isOrchestrator ? (
 							<>
+								{/* Session routes mount this topbar embedded — the lead crumb
+								    above is hidden — so the project name must live here too. */}
+								{embedded ? (
+									<ProjectBoardLabelButton
+										className="mr-1"
+										label={projectLabel}
+										onOpen={openBoard}
+										style={noDragStyle}
+									/>
+								) : null}
 								<ProjectTerminationFeedback projectId={projectId} />
 								<TopbarButton
 									aria-label={t("shell.newTask")}
@@ -280,10 +285,6 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 								>
 									<Plus className="size-icon-lg" aria-hidden="true" />
 									{t("shell.newTask")}
-								</TopbarButton>
-								<TopbarButton aria-label={t("shell.openKanban")} onClick={openBoard} style={noDragStyle} variant="primary">
-									<LayoutDashboard className="size-icon-lg" aria-hidden="true" />
-									{t("shell.kanban")}
 								</TopbarButton>
 							</>
 						) : null}
@@ -346,6 +347,41 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 			</div>
 		</motion.header>
 	</LayoutGroup>
+	);
+}
+
+const projectBoardLabelTransition = { type: "spring" as const, stiffness: 400, damping: 40 };
+
+/** Project name → board. Outer `<button>` owns the click so Motion's shared-layout spring cannot swallow the first pointer event (#3682). */
+function ProjectBoardLabelButton({
+	label,
+	onOpen,
+	style,
+	className,
+}: {
+	label: string;
+	onOpen: () => void;
+	style?: React.CSSProperties;
+	className?: string;
+}) {
+	const { t } = useTranslation();
+	return (
+		<button
+			aria-label={t("shell.openKanban")}
+			className={cn("min-w-0 rounded-sm text-left hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring", className)}
+			onClick={onOpen}
+			style={style}
+			type="button"
+		>
+			<motion.span
+				layoutId="topbar-project-label"
+				layout="position"
+				className={topbarProjectLabelClass}
+				transition={projectBoardLabelTransition}
+			>
+				{label}
+			</motion.span>
+		</button>
 	);
 }
 

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -487,6 +487,32 @@ describe("Sidebar", () => {
 		expect(screen.getByText("Project One").closest("button")).toHaveAttribute("aria-expanded", "false");
 	});
 
+	it("expands a collapsed project when opening its orchestrator", async () => {
+		const user = userEvent.setup();
+		const orchestrator: WorkspaceSession = {
+			...session,
+			id: "proj-1-orc",
+			title: "Orchestrator",
+			kind: "orchestrator",
+		};
+		renderSidebar({
+			workspaces: [{ ...workspace, sessions: [orchestrator, session] }],
+		});
+
+		await user.click(screen.getByRole("button", { name: "Toggle Project One sessions" }));
+		expect(screen.queryByLabelText("Open fix login")).not.toBeInTheDocument();
+		expect(screen.getByText("Project One").closest("button")).toHaveAttribute("aria-expanded", "false");
+
+		await user.click(screen.getByRole("button", { name: "Open Project One orchestrator" }));
+
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj-1", sessionId: "proj-1-orc" },
+		});
+		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();
+		expect(screen.getByText("Project One").closest("button")).toHaveAttribute("aria-expanded", "true");
+	});
+
 	it("defaults worker and orchestrator agents when creating a project", async () => {
 		const user = userEvent.setup();
 		const onCreateProject = vi.fn().mockResolvedValue(undefined) as CreateProjectHandler;

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -447,6 +447,46 @@ describe("Sidebar", () => {
 		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-1" } });
 	});
 
+	it("returns to the project board from an orchestrator session without collapsing", async () => {
+		const user = userEvent.setup();
+		const orchestrator: WorkspaceSession = {
+			...session,
+			id: "proj-1-orc",
+			title: "Orchestrator",
+			kind: "orchestrator",
+		};
+		mockParams.projectId = "proj-1";
+		mockParams.sessionId = "proj-1-orc";
+		renderSidebar({
+			workspaces: [{ ...workspace, sessions: [orchestrator, session] }],
+		});
+
+		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();
+
+		await user.click(screen.getByText("Project One"));
+
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-1" } });
+		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();
+		expect(screen.getByText("Project One").closest("button")).toHaveAttribute("aria-expanded", "true");
+	});
+
+	it("collapses an expanded project when its board is already active", async () => {
+		const user = userEvent.setup();
+		mockParams.projectId = "proj-1";
+		mockParams.sessionId = undefined;
+		renderSidebar({
+			workspaces: [{ ...workspace, sessions: [session] }],
+		});
+
+		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();
+
+		await user.click(screen.getByText("Project One"));
+
+		expect(navigateMock).not.toHaveBeenCalled();
+		expect(screen.queryByLabelText("Open fix login")).not.toBeInTheDocument();
+		expect(screen.getByText("Project One").closest("button")).toHaveAttribute("aria-expanded", "false");
+	});
+
 	it("defaults worker and orchestrator agents when creating a project", async () => {
 		const user = userEvent.setup();
 		const onCreateProject = vi.fn().mockResolvedValue(undefined) as CreateProjectHandler;

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -558,8 +558,11 @@ function ProjectItem({
 
 	// Mirrors ShellTopbar's launcher: attach to the running orchestrator, or
 	// spawn one via the daemon and follow it once the workspace refetches.
+	// Expand a collapsed project so opening the orchestrator also reveals its
+	// session list — otherwise the tree stays shut while you're inside it.
 	const openOrchestrator = async () => {
 		if (isProjectRestarting) return;
+		if (!expanded) onToggle();
 		if (orchestrator) {
 			selection.goSession(workspace.id, orchestrator.id);
 			return;

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -580,11 +580,15 @@ function ProjectItem({
 		}
 	};
 
+	// Expanded + already on the project board → collapse. Expanded + on a
+	// session (orchestrator or worker) → board. Collapsed → expand + board.
+	// Do not treat orchestratorActive like the board: the project row is the
+	// one-click path back from the orchestrator button.
 	const onProjectClick = () => {
 		if (!expanded) {
 			onToggle();
 			selection.goProject(workspace.id);
-		} else if (projectActive) {
+		} else if (dashboardActive) {
 			onToggle();
 		} else {
 			selection.goProject(workspace.id);


### PR DESCRIPTION
Fixes #3682

## Summary
- Make the orchestrator project name a stable button around the Motion label so the shared `layoutId` spring cannot swallow the first click
- Remove the redundant Kanban button; project name is the board control
- Keep that control visible when the topbar is embedded on session routes

## Test plan
- [ ] Open an orchestrator session → click the project name once → lands on the kanban board
- [ ] Confirm the old Kanban button is gone
- [ ] Worker sessions still show Kill / Orchestrator / inspector as before
- [ ] `npx vitest run src/renderer/components/ShellTopbar.test.tsx`