### PR TITLE
fix(frontend): sort activity timeline chronologically by timestamp

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -845,6 +845,21 @@ describe("SessionInspector Activity section", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2026-06-15T12:00:00Z"));
 
+		const summaries = [
+			prSummary(42, "draft", {
+				createdAt: "2026-06-15T10:30:00Z",
+				stateChangedAt: "2026-06-15T10:30:00Z",
+			}),
+			prSummary(41, "open", {
+				createdAt: "2026-06-15T11:00:00Z",
+				stateChangedAt: "2026-06-15T11:00:00Z",
+			}),
+			prSummary(40, "merged", {
+				createdAt: "2026-06-15T09:30:00Z",
+				stateChangedAt: "2026-06-15T11:30:00Z",
+			}),
+		];
+
 		renderWithQuery(
 			<SessionInspector
 				session={session([pr(42, "draft"), pr(41, "open"), pr(40, "merged")], {
@@ -854,6 +869,8 @@ describe("SessionInspector Activity section", () => {
 					activity: { state: "idle", lastActivityAt: "2026-06-15T10:00:00Z" },
 				})}
 			/>,
+			undefined,
+			(client) => client.setQueryData(sessionScmSummaryQueryKey("sess-1"), summaries),
 		);
 
 		const section = screen.getByText("Activity").closest("[data-testid='inspector-section']") as HTMLElement;
@@ -862,11 +879,11 @@ describe("SessionInspector Activity section", () => {
 		);
 		expect(rows).toEqual([
 			"Idle",
-			"Done",
-			"Merged PR #40",
-			"Opened PR #40",
-			"Opened PR #41",
-			"Draft PR #42",
+			"Done30m ago",
+			"Merged PR #4030m ago",
+			"Opened PR #411h ago",
+			"Draft PR #421h ago",
+			"Opened PR #402h ago",
 			"Created workspace3h ago",
 		]);
 
@@ -875,6 +892,51 @@ describe("SessionInspector Activity section", () => {
 		expect(
 			within(eventRows[eventRows.length - 1] as HTMLElement).queryByTestId("inspector-timeline-connector"),
 		).not.toBeInTheDocument();
+	});
+
+	it("sorts activity events chronologically across multiple PRs (regression)", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-15T12:00:00Z"));
+
+		// Reproduces the reported bug: two PRs opened at different times must
+		// appear in reverse-chronological order, not in PR-number order.
+		// PR #3683 opened 53m ago should appear ABOVE PR #3647 opened 1d ago.
+		const summaries = [
+			prSummary(3647, "merged", {
+				createdAt: "2026-06-14T12:00:00Z",
+				stateChangedAt: "2026-06-14T18:00:00Z",
+			}),
+			prSummary(3683, "open", {
+				createdAt: "2026-06-15T11:07:00Z",
+				stateChangedAt: "2026-06-15T11:07:00Z",
+			}),
+		];
+
+		renderWithQuery(
+			<SessionInspector
+				session={session([pr(3647, "merged"), pr(3683, "open")], {
+					createdAt: "2026-06-14T10:00:00Z",
+					updatedAt: "2026-06-15T11:07:00Z",
+					activity: { state: "active", lastActivityAt: "2026-06-15T11:50:00Z" },
+				})}
+			/>,
+			undefined,
+			(client) => client.setQueryData(sessionScmSummaryQueryKey("sess-1"), summaries),
+		);
+
+		const section = screen.getByText("Activity").closest("[data-testid='inspector-section']") as HTMLElement;
+		const rows = Array.from(section.querySelectorAll("[data-testid='inspector-timeline-event']"), (row) =>
+			row.textContent?.replace(/\s+/g, " ").trim(),
+		);
+
+		// Newest first: Working > Opened #3683 (53m) > Merged #3647 (18h) > Opened #3647 (1d) > Created workspace
+		expect(rows).toEqual([
+			"Working",
+			"Opened PR #368353m ago",
+			"Merged PR #364718h ago",
+			"Opened PR #36471d ago",
+			"Created workspace1d ago",
+		]);
 	});
 });
 

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -915,18 +915,28 @@ const timelineNodeTone: Record<TimelineTone, string> = {
 };
 
 function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: WorkspaceSession }) {
-	const history: {
+	type HistoryEntry = {
 		tone: TimelineTone;
 		node: ReactNode;
 		ts: string | null;
+		/** Epoch ms for chronological sorting. */
+		sortTs: number;
+		/** Push order — descending tiebreaker so same-timestamp events keep
+		 *  reverse-category order (Done > Merged > Opened > Draft > Created). */
+		seq: number;
 		markerTone?: string;
 		markerBreathe?: boolean;
-	}[] = [];
+	};
+
+	const history: HistoryEntry[] = [];
+	let seq = 0;
 
 	history.push({
 		tone: "neutral",
 		node: <>{appI18n.t("inspector.timeline.createdWorkspace")}</>,
 		ts: formatTimeCompact(session.createdAt ?? session.updatedAt),
+		sortTs: parseTimestamp(session.createdAt ?? session.updatedAt),
+		seq: seq++,
 	});
 
 	for (const pr of prs.filter((pr) => pr.state === "draft")) {
@@ -934,6 +944,8 @@ function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: 
 			tone: "neutral",
 			node: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.draft")} />,
 			ts: prStateTime(pr),
+			sortTs: parseTimestamp(pr.stateChangedAt ?? pr.updatedAt),
+			seq: seq++,
 		});
 	}
 
@@ -942,6 +954,8 @@ function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: 
 			tone: "neutral",
 			node: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.opened")} />,
 			ts: prCreatedTime(pr),
+			sortTs: parseTimestamp(pr.createdAt ?? pr.updatedAt),
+			seq: seq++,
 		});
 	}
 
@@ -950,6 +964,8 @@ function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: 
 			tone: "good",
 			node: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.merged")} />,
 			ts: prStateTime(pr),
+			sortTs: parseTimestamp(pr.stateChangedAt ?? pr.updatedAt),
+			seq: seq++,
 		});
 	}
 
@@ -958,11 +974,18 @@ function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: 
 			tone: "good",
 			node: <>{appI18n.t("inspector.timeline.done")}</>,
 			ts: latestMergedTime(prs),
+			sortTs: latestMergedTimeMs(prs),
+			seq: seq++,
 		});
 	}
 
+	// Sort historical events in reverse-chronological order (newest first).
+	// Tie-breaking by descending seq keeps the semantic grouping when timestamps
+	// are equal or missing: Done > Merged > Opened > Draft > Created workspace.
+	const sortedHistory = [...history].sort((a, b) => b.sortTs - a.sortTs || b.seq - a.seq);
+
 	// Current activity is a live reading, not a historical event. Keep it above
-	// the optional reverse-chronological history and do not imply that its last
+	// the reverse-chronological history and do not imply that its last
 	// hook time is when the state transition occurred.
 	const activityView = getAgentActivityView(session.activity);
 	const current = {
@@ -994,7 +1017,7 @@ function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: 
 		markerTone: string;
 		markerBreathe: boolean;
 	};
-	const events = [current, ...history.reverse()];
+	const events = [current, ...sortedHistory];
 
 	return (
 		<div className="relative pl-5">
@@ -1054,17 +1077,26 @@ function prCreatedTime(pr: SessionPRSummary): string | null {
 	return pr.createdAt ? formatTimeCompact(pr.createdAt) : null;
 }
 
+/** Parse an ISO timestamp to epoch milliseconds, returning 0 on failure/absence. */
+function parseTimestamp(value?: string | null): number {
+	if (!value) return 0;
+	const ms = Date.parse(value);
+	return Number.isFinite(ms) ? ms : 0;
+}
+
 function latestMergedTime(prs: SessionPRSummary[]): string | null {
-	let latest: { timestamp: string; milliseconds: number } | undefined;
+	const ms = latestMergedTimeMs(prs);
+	return ms > 0 ? formatTimeCompact(new Date(ms).toISOString()) : null;
+}
+
+function latestMergedTimeMs(prs: SessionPRSummary[]): number {
+	let latest = 0;
 	for (const pr of prs) {
-		if (pr.state !== "merged" || !pr.stateChangedAt) continue;
-		const milliseconds = Date.parse(pr.stateChangedAt);
-		if (!Number.isFinite(milliseconds)) continue;
-		if (!latest || milliseconds > latest.milliseconds) {
-			latest = { timestamp: pr.stateChangedAt, milliseconds };
-		}
+		if (pr.state !== "merged") continue;
+		const ms = parseTimestamp(pr.stateChangedAt ?? pr.updatedAt);
+		if (ms > latest) latest = ms;
 	}
-	return latest ? formatTimeCompact(latest.timestamp) : null;
+	return latest;
 }
 
 type ScmTimelineState = "ci_failed" | "changes_requested" | "conflict";


### PR DESCRIPTION
Fixes #3698

## Summary

The `ActivityTimeline` component in `SessionInspector.tsx` built its history array by pushing events in **category groups** (Created → Drafts → Opened → Merged → Done), then called `.reverse()`. This flipped the category order but did **not** sort by timestamp — so a recently-opened PR (e.g. 53m ago) could appear below an older PR (e.g. 1d ago) when both were in the "opened" group.

**Fix:** Replace `history.reverse()` with a proper reverse-chronological sort:
```typescript
const sortedHistory = [...history].sort((a, b) => b.sortTs - a.sortTs || b.seq - a.seq);
```

Each history entry now carries:
- `sortTs` — epoch ms parsed from `createdAt`/`stateChangedAt`/`updatedAt`
- `seq` — push order, used as a descending tiebreaker when timestamps are equal or missing (preserves the semantic grouping: Done > Merged > Opened > Draft > Created)

## Root Cause

`SessionInspector.tsx:997` — `const events = [current, ...history.reverse()];`

The `.reverse()` call only reversed array push order, not chronological order. Within a category group (e.g. two "opened" PRs), events stayed in PR-number order regardless of their actual timestamps.

## Test

- Updated existing ordering test to use realistic SCM summary timestamps (the original used artificial equal timestamps that masked the bug)
- Added regression test reproducing the exact reported scenario: PR #3683 (53m ago) vs PR #3647 (1d ago)

```
cd frontend && npx vitest run src/renderer/components/SessionInspector.test.tsx
```

All 76 tests pass.
