### PR TITLE
fix: restore model menu scrolling

### DIFF
--- a/frontend/e2e/model-menu-scroll.spec.ts
+++ b/frontend/e2e/model-menu-scroll.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+import { installFakeAgent } from "./support/fake-bridge";
+
+const projectId = "model-scroll-proj";
+const models = Array.from({ length: 30 }, (_, index) => ({
+	id: `opencode-go/model-${index + 1}`,
+	label: `opencode-go/model-${index + 1}`,
+	provider: "opencode-go",
+	isDefault: index === 0,
+}));
+
+test("renderer: hidden model-menu scrollbar keeps wheel scrolling functional @T0", async ({ page }) => {
+	await installFakeAgent(page, { projectId, projectName: projectId });
+	await page.route("http://127.0.0.1:8080/api/v1/**", async (route) => {
+		const request = route.request();
+		const pathname = new URL(request.url()).pathname;
+		if (pathname === "/api/v1/agents" || pathname === "/api/v1/agents/refresh") {
+			await route.fulfill({
+				json: {
+					supported: [{ id: "opencode", label: "OpenCode" }],
+					installed: [{ id: "opencode", label: "OpenCode", authStatus: "authorized" }],
+					authorized: [{ id: "opencode", label: "OpenCode", authStatus: "authorized" }],
+				},
+			});
+			return;
+		}
+		if (pathname === `/api/v1/projects/${projectId}`) {
+			await route.fulfill({
+				json: {
+					status: "ok",
+					project: {
+						id: projectId,
+						agent: "opencode",
+						config: { worker: { agent: "opencode" } },
+					},
+				},
+			});
+			return;
+		}
+		if (pathname === "/api/v1/agents/opencode/models") {
+			await route.fulfill({
+				json: {
+					agent: "opencode",
+					selectionMode: "catalog",
+					models,
+					allowCustom: true,
+					refreshRecommended: false,
+				},
+			});
+			return;
+		}
+		await route.fulfill({ json: { status: "ok" } });
+	});
+
+	await page.goto(`/#/projects/${projectId}`);
+	await page.getByRole("button", { name: "New task" }).first().click();
+	const dialog = page.getByRole("dialog", { name: "New task" });
+	await expect(dialog).toBeVisible();
+	await dialog.getByRole("button", { name: "Model" }).click();
+
+	const scroller = page.locator(".model-menu-scroll");
+	await expect(scroller).toBeVisible();
+	const geometry = await scroller.evaluate((element) => ({
+		clientHeight: element.clientHeight,
+		scrollHeight: element.scrollHeight,
+	}));
+	expect(geometry.scrollHeight).toBeGreaterThan(geometry.clientHeight);
+	await scroller.hover();
+	await page.mouse.wheel(0, 400);
+
+	await expect.poll(() => scroller.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+});

--- a/frontend/src/renderer/components/settings/AgentModelCombobox.tsx
+++ b/frontend/src/renderer/components/settings/AgentModelCombobox.tsx
@@ -176,10 +176,13 @@ export function AgentModelCombobox({
 					</div>
 				)}
 
-				<div className="relative min-h-0 flex-1 overflow-hidden">
+				{/* The menu has a max-height rather than a definite height, so h-full lets
+				    this list grow behind the clipped shell. A zero-min grid track makes the
+				    list consume the available space and retain its content as scroll overflow. */}
+				<div className="relative grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)] overflow-hidden">
 					<div
 						ref={scrollRef}
-						className="model-menu-scroll h-full min-h-0 overflow-y-auto overscroll-contain"
+						className="model-menu-scroll min-h-0 overflow-y-auto overscroll-contain"
 						onScroll={updateScrollCue}
 					>
 						{normalizedSearch === "" && (
@@ -208,13 +211,13 @@ export function AgentModelCombobox({
 														</span>
 													)}
 												</div>
-												{shouldShowModelID(item, visibleModels, normalizedSearch) && (
-													<p className="truncate text-xs text-settings-muted">{item.id}</p>
-												)}
-											</div>
-											{group.kind !== "provider" && item.provider !== "Other" && (
-												<span className="shrink-0 text-xs text-settings-muted">{item.provider}</span>
+											{shouldShowModelID(item, visibleModels, normalizedSearch) && (
+												<p className="truncate text-xs text-settings-muted">{item.id}</p>
 											)}
+										</div>
+										{group.kind !== "provider" && item.provider !== "Other" && (
+											<span className="shrink-0 text-xs text-settings-muted">{item.provider}</span>
+										)}
 										</div>
 									</DropdownMenuItem>
 								))}

--- a/frontend/src/renderer/components/settings/AgentModelCombobox.tsx
+++ b/frontend/src/renderer/components/settings/AgentModelCombobox.tsx
@@ -176,9 +176,6 @@ export function AgentModelCombobox({
 					</div>
 				)}
 
-				{/* The menu has a max-height rather than a definite height, so h-full lets
-				    this list grow behind the clipped shell. A zero-min grid track makes the
-				    list consume the available space and retain its content as scroll overflow. */}
 				<div className="relative grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)] overflow-hidden">
 					<div
 						ref={scrollRef}


### PR DESCRIPTION
## Summary
- restore mouse-wheel and trackpad scrolling in long model catalogs
- keep the scrollbar and gutter visually hidden
- add a Chromium regression test that verifies real scroll geometry and wheel movement

## Root cause
The list used percentage height beneath a max-height-only flex parent. It expanded to the full catalog height, then the parent clipped it, leaving no scrollable overflow. A zero-min grid track now constrains the list to the available menu space.

## Verification
- frontend typecheck
- E2E typecheck
- 154 Vitest files / 2,021 tests
- 21 renderer-smoke Playwright tests
- focused wheel-scroll test repeated three times
- native Electron verification with the real OpenCode catalog and real AO data