### PR TITLE
feat(mobile): per-name rate cap on mobile telemetry events

### DIFF
--- a/packages/mobile/lib/telemetry/rateLimit.test.ts
+++ b/packages/mobile/lib/telemetry/rateLimit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+	checkRateLimit,
+	EVENTS_PER_NAME_PER_DAY,
+	EVENTS_PER_NAME_PER_MINUTE,
+	type RateLimitState,
+} from "./rateLimit";
+
+const T0 = Date.parse("2026-08-07T10:00:00Z");
+
+function run(count: number, startState: RateLimitState = {}, name = "ao.v2.mobile_app.feature_used", now = T0) {
+	let state = startState;
+	const results: boolean[] = [];
+	for (let i = 0; i < count; i++) {
+		const r = checkRateLimit(state, name, now);
+		state = r.state;
+		results.push(r.allowed);
+	}
+	return { state, results };
+}
+
+describe("checkRateLimit", () => {
+	it("allows up to the per-minute cap, then denies within the same minute", () => {
+		const { results } = run(EVENTS_PER_NAME_PER_MINUTE + 3);
+		expect(results.slice(0, EVENTS_PER_NAME_PER_MINUTE).every(Boolean)).toBe(true);
+		expect(results.slice(EVENTS_PER_NAME_PER_MINUTE).every((x) => x === false)).toBe(true);
+	});
+
+	it("reopens the minute window after 60s", () => {
+		const first = run(EVENTS_PER_NAME_PER_MINUTE);
+		const later = checkRateLimit(first.state, "ao.v2.mobile_app.feature_used", T0 + 61_000);
+		expect(later.allowed).toBe(true);
+	});
+
+	// The real backstop: a runaway that paces itself under the minute cap still
+	// cannot exceed the daily ceiling.
+	it("enforces the daily ceiling across many minute windows", () => {
+		let state: RateLimitState = {};
+		let allowed = 0;
+		// One event every 30s for a full day's worth of attempts.
+		for (let i = 0; i < EVENTS_PER_NAME_PER_DAY + 50; i++) {
+			const r = checkRateLimit(state, "ao.v2.mobile_app.connected", T0 + i * 30_000);
+			state = r.state;
+			if (r.allowed) allowed++;
+		}
+		expect(allowed).toBe(EVENTS_PER_NAME_PER_DAY);
+	});
+
+	it("resets the daily counter on a new UTC day", () => {
+		let state: RateLimitState = {};
+		for (let i = 0; i < EVENTS_PER_NAME_PER_DAY; i++) {
+			state = checkRateLimit(state, "ao.v2.app.active", T0 + i * 1000).state;
+		}
+		const capped = checkRateLimit(state, "ao.v2.app.active", T0 + 5000);
+		expect(capped.allowed).toBe(false);
+		const nextDay = checkRateLimit(capped.state, "ao.v2.app.active", Date.parse("2026-08-08T00:01:00Z"));
+		expect(nextDay.allowed).toBe(true);
+	});
+
+	it("caps each event name independently", () => {
+		let state: RateLimitState = {};
+		for (let i = 0; i < EVENTS_PER_NAME_PER_MINUTE; i++) {
+			state = checkRateLimit(state, "a", T0).state;
+		}
+		expect(checkRateLimit(state, "a", T0).allowed).toBe(false);
+		expect(checkRateLimit(state, "b", T0).allowed).toBe(true);
+	});
+});

--- a/packages/mobile/lib/telemetry/rateLimit.test.ts
+++ b/packages/mobile/lib/telemetry/rateLimit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	checkRateLimit,
+	mergeRateState,
 	EVENTS_PER_NAME_PER_DAY,
 	EVENTS_PER_NAME_PER_MINUTE,
 	type RateLimitState,
@@ -64,5 +65,28 @@ describe("checkRateLimit", () => {
 		}
 		expect(checkRateLimit(state, "a", T0).allowed).toBe(false);
 		expect(checkRateLimit(state, "b", T0).allowed).toBe(true);
+	});
+});
+
+describe("mergeRateState (restart persistence)", () => {
+	const DAY = "2026-08-07";
+	// The race this exists for: an event advanced in memory before the persisted
+	// state loaded. The higher persisted day count must survive, or a restart
+	// resets the ceiling.
+	it("keeps the higher day count for the same day, so a restart cannot reset it", () => {
+		const persisted = { "ao.v2.mobile_app.connected": { minuteStart: 0, minuteCount: 0, day: DAY, dayCount: 199 } };
+		const current = { "ao.v2.mobile_app.connected": { minuteStart: 1, minuteCount: 1, day: DAY, dayCount: 1 } };
+		expect(mergeRateState(persisted, current)["ao.v2.mobile_app.connected"].dayCount).toBe(199);
+	});
+
+	it("drops a persisted entry from an older day", () => {
+		const persisted = { x: { minuteStart: 0, minuteCount: 0, day: "2026-08-06", dayCount: 200 } };
+		const current = { x: { minuteStart: 0, minuteCount: 1, day: DAY, dayCount: 1 } };
+		expect(mergeRateState(persisted, current).x.dayCount).toBe(1);
+	});
+
+	it("carries a persisted name the current session hasn't touched", () => {
+		const persisted = { y: { minuteStart: 0, minuteCount: 0, day: DAY, dayCount: 42 } };
+		expect(mergeRateState(persisted, {}).y.dayCount).toBe(42);
 	});
 });

--- a/packages/mobile/lib/telemetry/rateLimit.ts
+++ b/packages/mobile/lib/telemetry/rateLimit.ts
@@ -64,3 +64,30 @@ export function checkRateLimit(
 	};
 	return { allowed: true, state: next };
 }
+
+/**
+ * Merges persisted state into in-memory state at launch, preserving the daily
+ * ceiling across a restart. The naive spread ({...persisted, ...current}) lets a
+ * count that advanced in the race before the async load resolved overwrite the
+ * higher persisted count, which would reset the ceiling a restart is meant to
+ * carry over. For the same UTC day this takes the max of both; a persisted entry
+ * from an older day is dropped, since its counts no longer apply.
+ */
+export function mergeRateState(persisted: RateLimitState, current: RateLimitState): RateLimitState {
+	const out: RateLimitState = { ...persisted };
+	for (const name of Object.keys(current)) {
+		const cur = current[name];
+		const prev = out[name];
+		if (!prev || prev.day !== cur.day) {
+			out[name] = cur;
+			continue;
+		}
+		out[name] = {
+			day: cur.day,
+			dayCount: Math.max(prev.dayCount, cur.dayCount),
+			minuteStart: Math.max(prev.minuteStart, cur.minuteStart),
+			minuteCount: Math.max(prev.minuteCount, cur.minuteCount),
+		};
+	}
+	return out;
+}

--- a/packages/mobile/lib/telemetry/rateLimit.ts
+++ b/packages/mobile/lib/telemetry/rateLimit.ts
@@ -1,0 +1,66 @@
+// Per-event-name rate cap for the mobile client, mirroring the desktop sink's
+// bounds (backend/internal/adapters/telemetry/ratelimit.go): at most 5 events
+// per name per rolling minute, 200 per name per UTC day. The daily ceiling is
+// the real backstop against a runaway loop or a caller wired into a poll tick;
+// the minute cap smooths a short burst.
+//
+// Pure and testable: the decision is a function of the stored state and the
+// current time. runtime.ts holds the state in memory (seeded from AsyncStorage
+// so a crash-restart loop cannot reset the daily ceiling) and persists it.
+
+export const EVENTS_PER_NAME_PER_MINUTE = 5;
+export const EVENTS_PER_NAME_PER_DAY = 200;
+
+type NameWindow = {
+	minuteStart: number; // epoch ms of the current minute window
+	minuteCount: number;
+	day: string; // UTC date "YYYY-MM-DD"
+	dayCount: number;
+};
+
+export type RateLimitState = Record<string, NameWindow>;
+
+function utcDay(nowMs: number): string {
+	return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+/**
+ * Decides whether an event of `name` may be sent now, and returns the state to
+ * store back. `allowed: false` means the cap was hit; the state still advances
+ * so the window bookkeeping stays correct.
+ *
+ * Windows reset lazily on read: a minute older than 60s starts fresh, and a new
+ * UTC day zeroes the day counter. So an idle app never carries stale counts.
+ */
+export function checkRateLimit(
+	state: RateLimitState,
+	name: string,
+	nowMs: number,
+	limits: { perMinute: number; perDay: number } = {
+		perMinute: EVENTS_PER_NAME_PER_MINUTE,
+		perDay: EVENTS_PER_NAME_PER_DAY,
+	},
+): { allowed: boolean; state: RateLimitState } {
+	const prev = state[name];
+	const day = utcDay(nowMs);
+
+	const minuteStart = prev && nowMs - prev.minuteStart < 60_000 ? prev.minuteStart : nowMs;
+	const minuteCount = minuteStart === prev?.minuteStart ? prev.minuteCount : 0;
+	const dayCount = prev && prev.day === day ? prev.dayCount : 0;
+
+	// Deny without mutating the counts further: once at the cap, extra attempts
+	// in the same window neither send nor inflate the stored count past the cap.
+	if (minuteCount >= limits.perMinute || dayCount >= limits.perDay) {
+		const next: RateLimitState = {
+			...state,
+			[name]: { minuteStart, minuteCount, day, dayCount },
+		};
+		return { allowed: false, state: next };
+	}
+
+	const next: RateLimitState = {
+		...state,
+		[name]: { minuteStart, minuteCount: minuteCount + 1, day, dayCount: dayCount + 1 },
+	};
+	return { allowed: true, state: next };
+}

--- a/packages/mobile/lib/telemetry/runtime.ts
+++ b/packages/mobile/lib/telemetry/runtime.ts
@@ -12,7 +12,7 @@ import {
 	MOBILE_TELEMETRY_DISABLED,
 } from "./config";
 import { MOBILE_EVENTS } from "./events";
-import { checkRateLimit, type RateLimitState } from "./rateLimit";
+import { checkRateLimit, mergeRateState, type RateLimitState } from "./rateLimit";
 import { createMobileTelemetry, type MobileTelemetry } from "./telemetry";
 
 // The one file that touches the SDK and the native runtime. Everything else in
@@ -46,9 +46,9 @@ function loadRateState(): void {
 	void AsyncStorage.getItem(RATE_STORAGE_KEY).then((raw) => {
 		if (!raw) return;
 		try {
-			// Current in-memory counts win over persisted, in case events fired
-			// before the async read resolved.
-			rateState = { ...(JSON.parse(raw) as RateLimitState), ...rateState };
+			// Take the max per name so a count that advanced in the race before
+			// this read resolved cannot lower the persisted daily ceiling.
+			rateState = mergeRateState(JSON.parse(raw) as RateLimitState, rateState);
 		} catch {
 			/* ignore corrupt state; start fresh */
 		}

--- a/packages/mobile/lib/telemetry/runtime.ts
+++ b/packages/mobile/lib/telemetry/runtime.ts
@@ -12,6 +12,7 @@ import {
 	MOBILE_TELEMETRY_DISABLED,
 } from "./config";
 import { MOBILE_EVENTS } from "./events";
+import { checkRateLimit, type RateLimitState } from "./rateLimit";
 import { createMobileTelemetry, type MobileTelemetry } from "./telemetry";
 
 // The one file that touches the SDK and the native runtime. Everything else in
@@ -33,6 +34,36 @@ let telemetry: MobileTelemetry | null = null;
  * Idempotent: repeated calls return the same instance, so mounting the init
  * component more than once cannot create a second client.
  */
+const RATE_STORAGE_KEY = "ao.telemetry.rateLimit";
+let rateState: RateLimitState = {};
+let rateStateLoaded = false;
+
+// Seed the per-name counters from storage once, so a crash-restart loop cannot
+// reset the daily ceiling. Best-effort: a read failure just starts from empty.
+function loadRateState(): void {
+	if (rateStateLoaded) return;
+	rateStateLoaded = true;
+	void AsyncStorage.getItem(RATE_STORAGE_KEY).then((raw) => {
+		if (!raw) return;
+		try {
+			// Current in-memory counts win over persisted, in case events fired
+			// before the async read resolved.
+			rateState = { ...(JSON.parse(raw) as RateLimitState), ...rateState };
+		} catch {
+			/* ignore corrupt state; start fresh */
+		}
+	});
+}
+
+// Sync predicate for the facade: advances the in-memory window and persists it
+// fire-and-forget. Returns false once a name is over its minute or day cap.
+function allowEvent(name: string): boolean {
+	const { allowed, state } = checkRateLimit(rateState, name, Date.now());
+	rateState = state;
+	void AsyncStorage.setItem(RATE_STORAGE_KEY, JSON.stringify(state)).catch(() => {});
+	return allowed;
+}
+
 export function initMobileTelemetry(): MobileTelemetry | null {
 	if (telemetry) return telemetry;
 	// Dev gate: a dev client (npm start / Expo Go) must never send to the
@@ -61,7 +92,11 @@ export function initMobileTelemetry(): MobileTelemetry | null {
 		appVersion: version,
 	});
 
-	telemetry = createMobileTelemetry(client, context, MOBILE_DISABLED_EVENTS);
+	loadRateState();
+	telemetry = createMobileTelemetry(client, context, {
+		disabledEvents: MOBILE_DISABLED_EVENTS,
+		allow: allowEvent,
+	});
 	return telemetry;
 }
 

--- a/packages/mobile/lib/telemetry/telemetry.test.ts
+++ b/packages/mobile/lib/telemetry/telemetry.test.ts
@@ -63,10 +63,19 @@ describe("createMobileTelemetry", () => {
 
 	it("drops an event named in the build-time kill switch", () => {
 		const { client, captures } = fakeClient();
-		const t = createMobileTelemetry(client, {}, [MOBILE_EVENTS.connected]);
+		const t = createMobileTelemetry(client, {}, { disabledEvents: [MOBILE_EVENTS.connected] });
 		t.capture(MOBILE_EVENTS.connected, { trigger: "launch" });
 		t.capture(MOBILE_EVENTS.paired, { method: "qr" });
 		expect(captures.map((c) => c.event)).toEqual([MOBILE_EVENTS.paired]);
+	});
+
+	it("drops an event the rate limiter rejects", () => {
+		const { client, captures } = fakeClient();
+		let calls = 0;
+		const t = createMobileTelemetry(client, {}, { allow: () => (++calls <= 1) });
+		t.capture(MOBILE_EVENTS.paired, { method: "qr" }); // 1st: allowed
+		t.capture(MOBILE_EVENTS.paired, { method: "qr" }); // 2nd: rate-limited
+		expect(captures).toHaveLength(1);
 	});
 
 	it("emits the daily active heartbeat once per UTC day", async () => {

--- a/packages/mobile/lib/telemetry/telemetry.ts
+++ b/packages/mobile/lib/telemetry/telemetry.ts
@@ -21,15 +21,26 @@ export type MobileTelemetry = {
 	active(storage?: ActiveStorage, now?: Date): Promise<void>;
 };
 
+export type MobileTelemetryOptions = {
+	disabledEvents?: readonly string[];
+	/**
+	 * Returns false to drop an event that has hit the per-name rate cap. Sync so
+	 * capture() stays non-blocking; runtime.ts backs it with an in-memory,
+	 * persisted limiter. Omitted in tests that are not exercising the cap.
+	 */
+	allow?: (event: string) => boolean;
+};
+
 export function createMobileTelemetry(
 	client: MobileTelemetryClient,
 	context: Record<string, unknown>,
-	disabledEvents: readonly string[] = [],
+	options: MobileTelemetryOptions = {},
 ): MobileTelemetry {
 	// Context rides as super-properties, so every event is tagged with
 	// client/platform/version without the call sites repeating it.
 	void client.register(context);
-	const denied = new Set(disabledEvents);
+	const denied = new Set(options.disabledEvents ?? []);
+	const allow = options.allow ?? (() => true);
 
 	const capture = (event: MobileEventName, properties?: Record<string, unknown>): void => {
 		// Fail closed on the event name: an event not in the allowlist is never
@@ -37,6 +48,9 @@ export function createMobileTelemetry(
 		if (!(event in MOBILE_ALLOWLIST)) return;
 		// Build-time kill switch, mirroring the desktop denylist.
 		if (denied.has(event)) return;
+		// Per-name rate cap: the runaway backstop. Checked last so a legitimate
+		// event is only dropped when the name is genuinely over its window.
+		if (!allow(event)) return;
 		client.capture(event, {
 			...sanitizeMobileProperties(event, properties),
 			// Anonymous rate, belt-and-braces with personProfiles:"never" at init.


### PR DESCRIPTION
Stacked on #3661. The client-side rate cap, the remaining part of the runtime.ts review blocker, split into its own PR as requested.

Mirrors the desktop sink's bounds: **5 events per name per rolling minute, 200 per name per UTC day.** The daily ceiling is the real backstop, even a loop that paces itself under the minute cap (like the `connected`-per-poll bug fixed in #3661) can't exceed 200/name/day.

`checkRateLimit` is a pure function of state + time, fully unit-tested and mutation-checked. `runtime.ts` holds the state in memory and persists it to AsyncStorage, seeded at launch so a crash-restart loop can't reset the daily ceiling. The facade applies it as a sync predicate after the allowlist and kill-switch checks.

Base is `ao/ao-25/mobile-telemetry` (#3661), merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)