### PR TITLE
fix: recover Chat sessions after controller stops

### DIFF
--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -467,6 +467,10 @@ func (c chatLauncher) RelayChatTurnWithID(
 	return c.svc.RelayChatTurnWithID(ctx, id, text, clientMessageID)
 }
 
+func (c chatLauncher) HasLiveChatController(id domain.SessionID) bool {
+	return c.svc.HasLiveChatController(id)
+}
+
 // PrepareChatHandoff closes Chat intake and waits for the controller to become
 // quiescent before Session Manager stops it. These methods intentionally live
 // on the wiring adapter: Session Manager's handoff capability is optional, but

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -441,6 +441,15 @@ func (c chatLauncher) StartChat(ctx context.Context, cfg sessionmanager.ChatStar
 		SystemPrompt:           cfg.SystemPrompt,
 		AdditionalDirectories:  cfg.AdditionalDirectories,
 		ProviderConversationID: cfg.ProviderConversationID,
+		ControllerReady: func(out chatsvc.StartResult) error {
+			if cfg.ControllerReady == nil {
+				return nil
+			}
+			return cfg.ControllerReady(sessionmanager.ChatStarted{
+				ProviderConversationID: out.ProviderConversationID,
+				ControllerGeneration:   out.ControllerGeneration,
+			})
+		},
 	})
 	if err != nil {
 		return sessionmanager.ChatStarted{}, err

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -550,7 +550,8 @@ func isToolUseEvent(event string) bool {
 // dialog is gone: a prompt cannot be submitted while a dialog holds the
 // composer, and a turn cannot end (or the session exit) with one on screen.
 func isTurnBoundaryEvent(event string) bool {
-	return event == "user-prompt-submit" || event == "stop" || event == "session-end" || event == "process-exited"
+	return event == "user-prompt-submit" || event == "stop" || event == "session-end" ||
+		event == "process-exited" || event == "chat.controller.stopped"
 }
 
 // applyToolPrecedenceLocked folds an event-tagged activity signal through the

--- a/backend/internal/lifecycle/toolflight_test.go
+++ b/backend/internal/lifecycle/toolflight_test.go
@@ -106,6 +106,7 @@ func TestToolPrecedence_TurnBoundariesClearBlocked(t *testing.T) {
 		{"user-prompt-submit", sig(domain.ActivityActive, "user-prompt-submit", "", ""), domain.ActivityActive},
 		{"stop", sig(domain.ActivityIdle, "stop", "", ""), domain.ActivityIdle},
 		{"session-end", sig(domain.ActivityExited, "session-end", "", ""), domain.ActivityExited},
+		{"chat-controller-stopped", sig(domain.ActivityExited, "chat.controller.stopped", "", ""), domain.ActivityExited},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -1207,6 +1207,12 @@ func (c *Controller) project() {
 	// was blocking is gone. Both are closed out honestly rather than left looking
 	// live forever.
 	now := c.now()
+	// The provider stream ending is the one universal stop signal. Some drivers
+	// emit an explicit controller-state event first, but a process crash or lost
+	// transport cannot. Report the same lifecycle boundary here so the session
+	// does not remain durably active, idle, or blocked after its controller died.
+	// ControllerGeneration fences this write from a replacement controller.
+	c.reportActivity(ctx, domain.ActivityExited, "chat.controller.stopped", now)
 	if err := c.store.SettleOrphanedTurns(ctx, c.sessionID, now); err != nil {
 		c.log.Error("failed to settle orphaned turns", "session", c.sessionID, "error", err)
 	}

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -977,6 +977,51 @@ func TestControllerStreamClosureReportsSessionExited(t *testing.T) {
 	t.Fatalf("controller stream ended without an exited lifecycle signal: %+v", h.activity.snapshot())
 }
 
+func TestControllerReadyRunsBeforeStreamProjection(t *testing.T) {
+	st := openStore(t)
+	conv := newFakeConversation()
+	if err := conv.Close(); err != nil {
+		t.Fatalf("close provider stream: %v", err)
+	}
+	activity := &recordingActivity{}
+	ready := false
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers:  fakeRegistry{driver: fakeDriver{conv: conv}},
+		Activity: activity,
+		Log:      slog.New(slog.DiscardHandler),
+		NewID:    func() string { return "controller-ready-id" },
+	})
+
+	controller, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+		ControllerReady: func(started chatsvc.StartResult) error {
+			if signals := activity.snapshot(); len(signals) != 0 {
+				t.Fatalf("provider events projected before controller-ready commit: %+v", signals)
+			}
+			if started.ProviderConversationID == "" || started.ControllerGeneration == "" {
+				t.Fatalf("controller-ready result = %+v", started)
+			}
+			ready = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	controller.Wait()
+	if !ready {
+		t.Fatal("controller-ready callback was not called")
+	}
+	for _, signal := range activity.snapshot() {
+		if signal.State == domain.ActivityExited && signal.Event == "chat.controller.stopped" {
+			return
+		}
+	}
+	t.Fatalf("stream closure was not projected after controller-ready: %+v", activity.snapshot())
+}
+
 // Dispatch reads the persisted mode. A TUI session must be refused even if a
 // controller somehow exists, because the mode is the authority.
 func TestSendRefusedForTUISession(t *testing.T) {

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -181,6 +181,32 @@ type fakeDriver struct {
 	resumeCfg *ports.ChatResumeConfig
 }
 
+type sequenceDriver struct {
+	mu            sync.Mutex
+	conversations []ports.ChatConversation
+}
+
+func (d *sequenceDriver) Harness() domain.AgentHarness { return domain.HarnessCodex }
+func (d *sequenceDriver) Probe(context.Context) (ports.ChatCapabilities, error) {
+	return productionCaps(), nil
+}
+func (d *sequenceDriver) next() (ports.ChatConversation, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.conversations) == 0 {
+		return nil, errors.New("no conversation queued")
+	}
+	conversation := d.conversations[0]
+	d.conversations = d.conversations[1:]
+	return conversation, nil
+}
+func (d *sequenceDriver) Start(context.Context, ports.ChatStartConfig) (ports.ChatConversation, error) {
+	return d.next()
+}
+func (d *sequenceDriver) Resume(context.Context, ports.ChatResumeConfig) (ports.ChatConversation, error) {
+	return d.next()
+}
+
 func (d fakeDriver) Harness() domain.AgentHarness { return domain.HarnessCodex }
 func (d fakeDriver) Probe(context.Context) (ports.ChatCapabilities, error) {
 	return productionCaps(), nil
@@ -202,6 +228,28 @@ type fakeRegistry struct{ driver ports.ChatDriver }
 
 func (r fakeRegistry) Driver(domain.AgentHarness) (ports.ChatDriver, error) { return r.driver, nil }
 func (r fakeRegistry) SupportsChat(domain.AgentHarness) bool                { return true }
+
+type recordingActivity struct {
+	mu      sync.Mutex
+	signals []ports.ActivitySignal
+}
+
+func (r *recordingActivity) ApplyActivitySignal(
+	_ context.Context,
+	_ domain.SessionID,
+	signal ports.ActivitySignal,
+) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.signals = append(r.signals, signal)
+	return nil
+}
+
+func (r *recordingActivity) snapshot() []ports.ActivitySignal {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]ports.ActivitySignal(nil), r.signals...)
+}
 
 func productionCaps() ports.ChatCapabilities {
 	return ports.ChatCapabilities{
@@ -507,10 +555,11 @@ func TestFreshProjectControllerRecordsNativeContextBoundary(t *testing.T) {
 /* ---- harness ----------------------------------------------------------- */
 
 type harness struct {
-	svc  *chatsvc.Service
-	st   *sqlite.Store
-	conv *fakeConversation
-	ctrl *chatsvc.Controller
+	svc      *chatsvc.Service
+	st       *sqlite.Store
+	conv     *fakeConversation
+	ctrl     *chatsvc.Controller
+	activity *recordingActivity
 
 	clockMu sync.Mutex
 	clock   time.Time
@@ -549,7 +598,12 @@ func newHarnessWithConversation(t *testing.T, conv ports.ChatConversation) *harn
 	} else if recorder, ok := conv.(*historyRecorder); ok {
 		base = recorder.fakeConversation
 	}
-	h := &harness{st: st, conv: base, clock: time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)}
+	h := &harness{
+		st:       st,
+		conv:     base,
+		activity: &recordingActivity{},
+		clock:    time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC),
+	}
 
 	// Guarded because the id factory is called from both the projection goroutine and
 	// whichever goroutine a test drives commands from, and an unsynchronized counter
@@ -562,6 +616,7 @@ func newHarnessWithConversation(t *testing.T, conv ports.ChatConversation) *harn
 		Store:    st,
 		Sessions: st,
 		Drivers:  fakeRegistry{driver: fakeDriver{conv: conv}},
+		Activity: h.activity,
 		Log:      slog.New(slog.DiscardHandler),
 		NewID: func() string {
 			counterMu.Lock()
@@ -904,6 +959,24 @@ func TestControllerDeathSettlesInFlightWork(t *testing.T) {
 	}
 }
 
+func TestControllerStreamClosureReportsSessionExited(t *testing.T) {
+	h := newHarness(t)
+
+	// A provider can disappear without emitting a final controller-state event.
+	// Closing the stream is still authoritative proof that this controller ended.
+	if err := h.conv.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	h.ctrl.Wait()
+
+	for _, signal := range h.activity.snapshot() {
+		if signal.State == domain.ActivityExited && signal.Event == "chat.controller.stopped" {
+			return
+		}
+	}
+	t.Fatalf("controller stream ended without an exited lifecycle signal: %+v", h.activity.snapshot())
+}
+
 // Dispatch reads the persisted mode. A TUI session must be refused even if a
 // controller somehow exists, because the mode is the authority.
 func TestSendRefusedForTUISession(t *testing.T) {
@@ -1157,16 +1230,91 @@ func TestServiceStopRetainsControllerUntilItsEventStreamActuallyEnds(t *testing.
 	if _, err := h.svc.Controller(testSession); err != nil {
 		t.Fatalf("controller was forgotten while its stream was still live: %v", err)
 	}
+	if !h.svc.HasLiveChatController(testSession) {
+		t.Fatal("live-controller guard cleared before the provider stream ended")
+	}
 
 	base.closeOnce.Do(func() { close(base.events) })
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		if _, err := h.svc.Controller(testSession); errors.Is(err, chatsvc.ErrNoController) {
+			if h.svc.HasLiveChatController(testSession) {
+				t.Fatal("live-controller guard remained set after registry release")
+			}
 			return
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal("controller registry did not release the stopped stream")
+}
+
+func TestStartWaitsForStoppedControllerCleanupBeforeRelaunch(t *testing.T) {
+	st := openStore(t)
+	first := newFakeConversation()
+	second := newFakeConversation()
+	driver := &sequenceDriver{conversations: []ports.ChatConversation{first, second}}
+	var idMu sync.Mutex
+	nextID := 0
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers: fakeRegistry{driver: driver},
+		Log:     slog.New(slog.DiscardHandler),
+		NewID: func() string {
+			idMu.Lock()
+			defer idMu.Unlock()
+			nextID++
+			return fmt.Sprintf("relaunch-id-%d", nextID)
+		},
+	})
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+
+	firstController, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	first.emit(ports.ChatEvent{
+		Kind:            ports.ChatEventControllerState,
+		ControllerState: ports.ChatControllerStopped,
+	})
+	deadline := time.Now().Add(time.Second)
+	for firstController.State() != ports.ChatControllerStopped && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := firstController.State(); got != ports.ChatControllerStopped {
+		t.Fatalf("first controller state = %q, want stopped", got)
+	}
+	if svc.HasLiveChatController(testSession) {
+		t.Fatal("stopped controller reported live")
+	}
+
+	replacementWorkspace := t.TempDir()
+	waitCtx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	controller, err := svc.Start(waitCtx, chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: replacementWorkspace, ProviderConversationID: "thread-1",
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start while stopped controller was cleaning up = controller=%p err=%v, want deadline", controller, err)
+	}
+
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first conversation: %v", err)
+	}
+	firstController.Wait()
+	replacement, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: replacementWorkspace, ProviderConversationID: "thread-1",
+	})
+	if err != nil {
+		t.Fatalf("relaunch: %v", err)
+	}
+	if replacement == firstController {
+		t.Fatal("relaunch returned the stopped controller")
+	}
 }
 
 // The cancellation belongs to the moment stop was pressed. A message typed after

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -131,6 +131,28 @@ type StartConfig struct {
 	MCPServers            []ports.ChatMCPServerConfig
 	// ProviderConversationID resumes an existing provider conversation when set.
 	ProviderConversationID string
+	// ControllerReady commits the controller's durable generation before event
+	// consumption starts. A controller that exits immediately must report after
+	// the launch has been marked live, so its exited signal cannot be overwritten
+	// by a later launch-completion write.
+	ControllerReady func(StartResult) error
+}
+
+func controllerStartResult(controller *Controller) StartResult {
+	return StartResult{
+		ProviderConversationID: controller.ProviderConversationID(),
+		ControllerGeneration:   controller.Generation(),
+	}
+}
+
+func notifyControllerReady(cfg StartConfig, controller *Controller) error {
+	if cfg.ControllerReady == nil {
+		return nil
+	}
+	if err := cfg.ControllerReady(controllerStartResult(controller)); err != nil {
+		return fmt.Errorf("commit chat controller: %w", err)
+	}
+	return nil
 }
 
 // settleOrphanedWork closes out anything a previous controller left behind.
@@ -311,6 +333,10 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 			_ = conv.Close()
 			return nil, err
 		}
+	}
+	if err := notifyControllerReady(cfg, controller); err != nil {
+		_ = conv.Close()
+		return nil, err
 	}
 	s.mu.Lock()
 	s.controllers[cfg.SessionID] = controller
@@ -728,10 +754,7 @@ func (s *Service) StartChat(ctx context.Context, cfg StartRequest) (StartResult,
 	if err != nil {
 		return StartResult{}, err
 	}
-	return StartResult{
-		ProviderConversationID: controller.ProviderConversationID(),
-		ControllerGeneration:   controller.Generation(),
-	}, nil
+	return controllerStartResult(controller), nil
 }
 
 // StartRequest mirrors session_manager.ChatStart. Duplicated rather than
@@ -751,6 +774,9 @@ type StartRequest struct {
 	MCPServers            []ports.ChatMCPServerConfig
 	// ProviderConversationID resumes a stored conversation. Empty starts fresh.
 	ProviderConversationID string
+	// ControllerReady runs after the provider and generation exist but before
+	// live event projection starts.
+	ControllerReady func(StartResult) error
 }
 
 // StartResult is the durable outcome of a launch.

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -166,11 +166,27 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	defer gate.unlock()
 
 	s.mu.RLock()
-	if existing, ok := s.controllers[cfg.SessionID]; ok {
-		s.mu.RUnlock()
-		return existing, nil
-	}
+	existing := s.controllers[cfg.SessionID]
 	s.mu.RUnlock()
+	if existing != nil {
+		if existing.State() != ports.ChatControllerStopped {
+			return existing, nil
+		}
+		// A stopped event can reach the UI before the projector finishes its final
+		// durable cleanup and the registry goroutine releases the entry. Never hand
+		// that dead controller back as a successful resume. Wait for its stream to
+		// finish, then remove only that generation before opening the replacement.
+		select {
+		case <-existing.stopped:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		s.mu.Lock()
+		if current := s.controllers[cfg.SessionID]; current == existing {
+			delete(s.controllers, cfg.SessionID)
+		}
+		s.mu.Unlock()
+	}
 
 	driver, err := s.drivers.Driver(cfg.Harness)
 	if err != nil {
@@ -324,6 +340,17 @@ func (s *Service) Controller(sessionID domain.SessionID) (*Controller, error) {
 		return nil, ErrNoController
 	}
 	return controller, nil
+}
+
+// HasLiveChatController reports whether the service owns a controller that can
+// still process provider events. A stopped controller can remain in the registry
+// briefly while its final cleanup lands; Start waits for that cleanup before
+// replacing it rather than treating the dead entry as a successful resume.
+func (s *Service) HasLiveChatController(sessionID domain.SessionID) bool {
+	s.mu.RLock()
+	controller := s.controllers[sessionID]
+	s.mu.RUnlock()
+	return controller != nil && controller.State() != ports.ChatControllerStopped
 }
 
 // requireChatSession reads the persisted mode and refuses anything that is not a

--- a/backend/internal/session_manager/chat_spawn.go
+++ b/backend/internal/session_manager/chat_spawn.go
@@ -28,7 +28,8 @@ type ChatLauncher interface {
 	// nothing.
 	PreflightChat(ctx context.Context, harness domain.AgentHarness) error
 	// StartChat launches the controller and returns the provider conversation
-	// handle to persist for resume.
+	// handle to persist for resume. Implementations must call ControllerReady
+	// after the provider and generation exist but before consuming live events.
 	StartChat(ctx context.Context, cfg ChatStart) (ChatStarted, error)
 	// StartChatTurn delivers the initial prompt as a normal turn. There is no
 	// paste-and-Enter equivalent in chat mode: the provider either accepts the
@@ -70,6 +71,10 @@ type ChatStart struct {
 	// ProviderConversationID resumes a stored conversation instead of opening a
 	// new one. Empty means start fresh.
 	ProviderConversationID string
+	// ControllerReady commits the durable controller facts before the provider
+	// event stream is consumed. This prevents an immediate exit from racing a
+	// later MarkSpawned write back to idle.
+	ControllerReady func(ChatStarted) error
 }
 
 // ChatStarted is the durable result of a launch.
@@ -105,8 +110,17 @@ func (m *Manager) launchChatController(ctx context.Context, in chatSpawn) (domai
 	// provider passes its environment through to the shell commands it runs, so
 	// this is what makes `ao` resolvable to the agent.
 	env := m.runtimeEnv(id, in.cfg.ProjectID, in.cfg.IssueID, in.project.Config.Env)
+	var diffBaseSHA, diffBaseRef string
+	if in.projectKind == domain.ProjectKindSingleRepo {
+		diffBaseSHA, diffBaseRef = resolveSpawnDiffBase(
+			ctx, in.workspace.Path, in.project.Config.WithDefaults().DefaultBranch)
+	}
 
-	started, err := m.chat.StartChat(ctx, ChatStart{
+	var (
+		controllerCommitted bool
+		completionErr       error
+	)
+	_, err := m.chat.StartChat(ctx, ChatStart{
 		SessionID:             id,
 		ProjectID:             in.cfg.ProjectID,
 		Kind:                  in.cfg.Kind,
@@ -118,35 +132,39 @@ func (m *Manager) launchChatController(ctx context.Context, in chatSpawn) (domai
 		Permissions:           agentConfig.Permissions,
 		SystemPrompt:          in.systemPrompt,
 		AdditionalDirectories: workspaceProjectDirectories(in.workspace.Path, in.workspaceProject),
+		ControllerReady: func(started ChatStarted) error {
+			metadata := domain.SessionMetadata{
+				Branch:            in.workspace.Branch,
+				WorkspacePath:     in.workspace.Path,
+				WorkspaceRepoPath: in.workspace.RepoPath,
+				Prompt:            in.prompt,
+				DiffBaseSHA:       diffBaseSHA,
+				DiffBaseRef:       diffBaseRef,
+				// No RuntimeHandleID or RuntimeLaunchID: a chat session has no
+				// agent pane. Leaving them empty keeps the reaper from probing for
+				// a terminal that was never created.
+				ProviderConversationID: started.ProviderConversationID,
+				ControllerGeneration:   started.ControllerGeneration,
+			}
+			completionErr = m.lcm.MarkSpawned(ctx, id, metadata)
+			controllerCommitted = completionErr == nil
+			return completionErr
+		},
 	})
 	if err != nil {
+		if completionErr != nil || controllerCommitted {
+			m.stopChatBestEffort(ctx, id)
+			m.rollbackPreparedSpawnWorkspace(ctx, in.record, in.workspace, in.workspaceProject, true)
+			m.markSpawnFailedTerminated(ctx, id)
+			if completionErr != nil {
+				return domain.SessionRecord{}, fmt.Errorf("spawn %s: completed: %w", id, completionErr)
+			}
+			return domain.SessionRecord{}, fmt.Errorf("spawn %s: chat controller: %w", id, err)
+		}
 		// No controller exists, so nothing provider-side needs closing. The
 		// runtime was never touched, hence runtimeDestroyed=false.
 		m.rollbackSeedSpawnWorkspace(ctx, in.record, in.workspace, in.workspaceProject, false)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: chat controller: %w", id, err)
-	}
-
-	metadata := domain.SessionMetadata{
-		Branch:            in.workspace.Branch,
-		WorkspacePath:     in.workspace.Path,
-		WorkspaceRepoPath: in.workspace.RepoPath,
-		Prompt:            in.prompt,
-		// No RuntimeHandleID or RuntimeLaunchID: a chat session has no agent pane.
-		// Leaving them empty is what keeps the reaper from probing for a terminal
-		// that was never created.
-		ProviderConversationID: started.ProviderConversationID,
-		ControllerGeneration:   started.ControllerGeneration,
-	}
-	if in.projectKind == domain.ProjectKindSingleRepo {
-		metadata.DiffBaseSHA, metadata.DiffBaseRef = resolveSpawnDiffBase(
-			ctx, in.workspace.Path, in.project.Config.WithDefaults().DefaultBranch)
-	}
-
-	if err := m.lcm.MarkSpawned(ctx, id, metadata); err != nil {
-		m.stopChatBestEffort(ctx, id)
-		m.rollbackPreparedSpawnWorkspace(ctx, in.record, in.workspace, in.workspaceProject, true)
-		m.markSpawnFailedTerminated(ctx, id)
-		return domain.SessionRecord{}, fmt.Errorf("spawn %s: completed: %w", id, err)
 	}
 
 	// The initial prompt is a normal turn through the controller. There is no
@@ -268,7 +286,8 @@ func (m *Manager) resumeChatController(
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("%s %s: workspace roots: %w", operation, rec.ID, err)
 	}
-	started, err := m.chat.StartChat(ctx, ChatStart{
+	var completionErr error
+	_, err = m.chat.StartChat(ctx, ChatStart{
 		SessionID:             rec.ID,
 		ProjectID:             rec.ProjectID,
 		Kind:                  rec.Kind,
@@ -282,25 +301,28 @@ func (m *Manager) resumeChatController(
 		AdditionalDirectories: additionalDirectories,
 		// The handle that makes this a resume rather than a new conversation.
 		ProviderConversationID: rec.Metadata.ProviderConversationID,
+		ControllerReady: func(started ChatStarted) error {
+			metadata := rec.Metadata
+			metadata.WorkspacePath = ws.Path
+			metadata.WorkspaceRepoPath = ws.RepoPath
+			if ws.Branch != "" {
+				metadata.Branch = ws.Branch
+			}
+			metadata.ProviderConversationID = started.ProviderConversationID
+			// A fresh generation per launch: events still arriving from the
+			// controller this one replaced carry the old one and are rejected.
+			metadata.ControllerGeneration = started.ControllerGeneration
+
+			completionErr = m.lcm.MarkSpawned(ctx, rec.ID, metadata)
+			return completionErr
+		},
 	})
 	if err != nil {
+		if completionErr != nil {
+			m.stopChatBestEffort(ctx, rec.ID)
+			return RestoreResult{}, fmt.Errorf("%s %s: completed: %w", operation, rec.ID, completionErr)
+		}
 		return RestoreResult{}, fmt.Errorf("%s %s: resume chat: %w", operation, rec.ID, err)
-	}
-
-	metadata := rec.Metadata
-	metadata.WorkspacePath = ws.Path
-	metadata.WorkspaceRepoPath = ws.RepoPath
-	if ws.Branch != "" {
-		metadata.Branch = ws.Branch
-	}
-	metadata.ProviderConversationID = started.ProviderConversationID
-	// A fresh generation per launch: events still arriving from the controller
-	// this one replaced carry the old one and are rejected.
-	metadata.ControllerGeneration = started.ControllerGeneration
-
-	if err := m.lcm.MarkSpawned(ctx, rec.ID, metadata); err != nil {
-		m.stopChatBestEffort(ctx, rec.ID)
-		return RestoreResult{}, fmt.Errorf("%s %s: completed: %w", operation, rec.ID, err)
 	}
 
 	restored, err := m.getRecord(ctx, rec.ID)

--- a/backend/internal/session_manager/chat_spawn.go
+++ b/backend/internal/session_manager/chat_spawn.go
@@ -42,6 +42,10 @@ type ChatLauncher interface {
 	// the key through to ChatUserMessage so retry after an uncertain outbox
 	// acknowledgement cannot create a second provider turn.
 	RelayChatTurnWithID(ctx context.Context, id domain.SessionID, text, clientMessageID string) (string, error)
+	// HasLiveChatController reports whether the daemon still owns a controller
+	// for the session. Resume uses this to distinguish a stale durable activity
+	// state left by an older daemon from a genuinely live controller.
+	HasLiveChatController(id domain.SessionID) bool
 	// StopChat releases a session's controller.
 	StopChat(ctx context.Context, id domain.SessionID) error
 }

--- a/backend/internal/session_manager/chat_spawn_test.go
+++ b/backend/internal/session_manager/chat_spawn_test.go
@@ -41,6 +41,7 @@ type recordingLauncher struct {
 	startErr     error
 	turnErr      error
 	live         bool
+	afterReady   func()
 
 	preflighted []domain.AgentHarness
 	started     []ChatStart
@@ -61,10 +62,19 @@ func (l *recordingLauncher) StartChat(_ context.Context, cfg ChatStart) (ChatSta
 	if l.startErr != nil {
 		return ChatStarted{}, l.startErr
 	}
-	return ChatStarted{
+	started := ChatStarted{
 		ProviderConversationID: "thread-1",
 		ControllerGeneration:   "gen-1",
-	}, nil
+	}
+	if cfg.ControllerReady != nil {
+		if err := cfg.ControllerReady(started); err != nil {
+			return ChatStarted{}, err
+		}
+	}
+	if l.afterReady != nil {
+		l.afterReady()
+	}
+	return started, nil
 }
 
 func (l *recordingLauncher) StartChatTurn(_ context.Context, _ domain.SessionID, text string) (string, error) {
@@ -131,6 +141,25 @@ func TestResumeExitedChatSessionDoesNotRequireTerminalRuntimeHandle(t *testing.T
 	}
 }
 
+func TestResumeChatKeepsExitReportedBeforeStartReturns(t *testing.T) {
+	launcher := &recordingLauncher{}
+	mgr, store, _ := newChatManager(launcher)
+	seedChatResumeSession(store, domain.ActivityExited)
+	launcher.afterReady = func() {
+		rec := store.sessions["mer-1"]
+		rec.Activity = domain.Activity{State: domain.ActivityExited}
+		store.sessions["mer-1"] = rec
+	}
+
+	result, err := mgr.ResumeAgentWithMode(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("ResumeAgentWithMode: %v", err)
+	}
+	if result.Session.Activity.State != domain.ActivityExited {
+		t.Fatalf("activity after immediate controller exit = %q, want exited", result.Session.Activity.State)
+	}
+}
+
 func TestResumeStaleChatSessionWhenNoControllerIsLive(t *testing.T) {
 	launcher := &recordingLauncher{}
 	mgr, store, _ := newChatManager(launcher)
@@ -145,15 +174,76 @@ func TestResumeStaleChatSessionWhenNoControllerIsLive(t *testing.T) {
 }
 
 func TestResumeChatSessionRejectsLiveController(t *testing.T) {
-	launcher := &recordingLauncher{live: true}
-	mgr, store, _ := newChatManager(launcher)
-	seedChatResumeSession(store, domain.ActivityIdle)
+	for _, state := range []domain.ActivityState{domain.ActivityIdle, domain.ActivityExited} {
+		t.Run(string(state), func(t *testing.T) {
+			launcher := &recordingLauncher{live: true}
+			mgr, store, _ := newChatManager(launcher)
+			seedChatResumeSession(store, state)
 
-	if _, err := mgr.ResumeAgentWithMode(context.Background(), "mer-1"); !errors.Is(err, ErrAgentNotExited) {
-		t.Fatalf("ResumeAgentWithMode error = %v, want ErrAgentNotExited", err)
+			if _, err := mgr.ResumeAgentWithMode(context.Background(), "mer-1"); !errors.Is(err, ErrAgentNotExited) {
+				t.Fatalf("ResumeAgentWithMode error = %v, want ErrAgentNotExited", err)
+			}
+			if len(launcher.started) != 0 {
+				t.Fatalf("duplicate resume started %d controllers", len(launcher.started))
+			}
+		})
+	}
+}
+
+func TestResumeBranchlessScratchChatSession(t *testing.T) {
+	launcher := &recordingLauncher{}
+	mgr, store, _ := newChatManager(launcher)
+	store.projects["scratch"] = domain.ProjectRecord{
+		ID: "scratch", Kind: domain.ProjectKindScratch, Config: testRoleAgents(),
+	}
+	store.sessions["scratch-1"] = domain.SessionRecord{
+		ID: "scratch-1", ProjectID: "scratch", Kind: domain.KindWorker,
+		Harness: domain.HarnessCodex, Mode: domain.SessionModeChat,
+		Activity: domain.Activity{State: domain.ActivityExited},
+		Metadata: domain.SessionMetadata{
+			WorkspacePath:          "/ws/scratch-1",
+			ProviderConversationID: "thread-existing",
+		},
+	}
+
+	if _, err := mgr.ResumeAgentWithMode(context.Background(), "scratch-1"); err != nil {
+		t.Fatalf("ResumeAgentWithMode: %v", err)
+	}
+	if len(launcher.started) != 1 {
+		t.Fatalf("started %d chat controllers, want 1", len(launcher.started))
+	}
+}
+
+func TestResumeChatSessionRequiresProviderConversation(t *testing.T) {
+	launcher := &recordingLauncher{}
+	mgr, store, _ := newChatManager(launcher)
+	seedChatResumeSession(store, domain.ActivityExited)
+	rec := store.sessions["mer-1"]
+	rec.Metadata.ProviderConversationID = ""
+	store.sessions["mer-1"] = rec
+
+	if _, err := mgr.ResumeAgentWithMode(context.Background(), "mer-1"); !errors.Is(err, ErrIncompleteHandle) {
+		t.Fatalf("ResumeAgentWithMode error = %v, want ErrIncompleteHandle", err)
 	}
 	if len(launcher.started) != 0 {
-		t.Fatalf("duplicate resume started %d controllers", len(launcher.started))
+		t.Fatalf("missing provider handle started %d controllers", len(launcher.started))
+	}
+}
+
+func TestRestoreChatSessionRequiresProviderConversation(t *testing.T) {
+	launcher := &recordingLauncher{}
+	mgr, store, _ := newChatManager(launcher)
+	seedChatResumeSession(store, domain.ActivityExited)
+	rec := store.sessions["mer-1"]
+	rec.IsTerminated = true
+	rec.Metadata.ProviderConversationID = ""
+	store.sessions["mer-1"] = rec
+
+	if _, err := mgr.RestoreWithMode(context.Background(), "mer-1"); !errors.Is(err, ErrIncompleteHandle) {
+		t.Fatalf("RestoreWithMode error = %v, want ErrIncompleteHandle", err)
+	}
+	if len(launcher.started) != 0 {
+		t.Fatalf("missing provider handle started %d controllers", len(launcher.started))
 	}
 }
 

--- a/backend/internal/session_manager/chat_spawn_test.go
+++ b/backend/internal/session_manager/chat_spawn_test.go
@@ -40,6 +40,7 @@ type recordingLauncher struct {
 	preflightErr error
 	startErr     error
 	turnErr      error
+	live         bool
 
 	preflighted []domain.AgentHarness
 	started     []ChatStart
@@ -85,6 +86,75 @@ func (l *recordingLauncher) StopChat(_ context.Context, id domain.SessionID) err
 
 	l.stopped = append(l.stopped, id)
 	return nil
+}
+
+func (l *recordingLauncher) HasLiveChatController(domain.SessionID) bool {
+	return l.live
+}
+
+func seedChatResumeSession(store *fakeStore, state domain.ActivityState) {
+	store.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: chatTestProject,
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessCodex,
+		Mode:      domain.SessionModeChat,
+		Activity:  domain.Activity{State: state},
+		Metadata: domain.SessionMetadata{
+			WorkspacePath:          "/ws/mer-1",
+			Branch:                 "ao/mer-1",
+			ProviderConversationID: "thread-existing",
+		},
+	}
+}
+
+func TestResumeExitedChatSessionDoesNotRequireTerminalRuntimeHandle(t *testing.T) {
+	launcher := &recordingLauncher{}
+	mgr, store, runtime := newChatManager(launcher)
+	seedChatResumeSession(store, domain.ActivityExited)
+
+	result, err := mgr.ResumeAgentWithMode(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("ResumeAgentWithMode: %v", err)
+	}
+	if len(launcher.started) != 1 {
+		t.Fatalf("started %d chat controllers, want 1", len(launcher.started))
+	}
+	if got := launcher.started[0].ProviderConversationID; got != "thread-existing" {
+		t.Fatalf("provider conversation id = %q, want thread-existing", got)
+	}
+	if runtime.created != 0 || runtime.destroyed != 0 {
+		t.Fatalf("chat resume touched terminal runtime: created=%d destroyed=%d", runtime.created, runtime.destroyed)
+	}
+	if result.Session.Activity.State != domain.ActivityIdle {
+		t.Fatalf("resumed activity = %q, want idle", result.Session.Activity.State)
+	}
+}
+
+func TestResumeStaleChatSessionWhenNoControllerIsLive(t *testing.T) {
+	launcher := &recordingLauncher{}
+	mgr, store, _ := newChatManager(launcher)
+	seedChatResumeSession(store, domain.ActivityIdle)
+
+	if _, err := mgr.ResumeAgentWithMode(context.Background(), "mer-1"); err != nil {
+		t.Fatalf("ResumeAgentWithMode: %v", err)
+	}
+	if len(launcher.started) != 1 {
+		t.Fatalf("started %d chat controllers, want 1", len(launcher.started))
+	}
+}
+
+func TestResumeChatSessionRejectsLiveController(t *testing.T) {
+	launcher := &recordingLauncher{live: true}
+	mgr, store, _ := newChatManager(launcher)
+	seedChatResumeSession(store, domain.ActivityIdle)
+
+	if _, err := mgr.ResumeAgentWithMode(context.Background(), "mer-1"); !errors.Is(err, ErrAgentNotExited) {
+		t.Fatalf("ResumeAgentWithMode error = %v, want ErrAgentNotExited", err)
+	}
+	if len(launcher.started) != 0 {
+		t.Fatalf("duplicate resume started %d controllers", len(launcher.started))
+	}
 }
 
 // An unsupported chat request must be refused before anything durable exists: no

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -244,7 +244,13 @@ func (c *transitionChat) PreflightChat(ctx context.Context, _ domain.AgentHarnes
 func (c *transitionChat) StartChat(_ context.Context, cfg ChatStart) (ChatStarted, error) {
 	c.start = cfg
 	*c.log = append(*c.log, "start:chat")
-	return ChatStarted{ProviderConversationID: cfg.ProviderConversationID, ControllerGeneration: "chat-generation"}, nil
+	started := ChatStarted{ProviderConversationID: cfg.ProviderConversationID, ControllerGeneration: "chat-generation"}
+	if cfg.ControllerReady != nil {
+		if err := cfg.ControllerReady(started); err != nil {
+			return ChatStarted{}, err
+		}
+	}
+	return started, nil
 }
 func (*transitionChat) StartChatTurn(context.Context, domain.SessionID, string) (string, error) {
 	return "", nil

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -259,6 +259,7 @@ func (c *transitionChat) RelayChatTurnWithID(_ context.Context, _ domain.Session
 	c.relayIDs = append(c.relayIDs, clientMessageID)
 	return "", nil
 }
+func (*transitionChat) HasLiveChatController(domain.SessionID) bool { return false }
 func (c *transitionChat) StopChat(_ context.Context, _ domain.SessionID) error {
 	*c.log = append(*c.log, "stop:chat")
 	return nil

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1415,25 +1415,28 @@ func (m *Manager) ResumeAgentWithMode(ctx context.Context, id domain.SessionID) 
 		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrTerminated)
 	}
 	mode := domain.NormalizeSessionMode(rec.Mode)
+	if mode == domain.SessionModeChat && m.chat != nil && m.chat.HasLiveChatController(id) {
+		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrAgentNotExited)
+	}
 	if rec.Activity.State != domain.ActivityExited {
 		// Builds before the controller-stop lifecycle fix can leave a Chat row
 		// idle, active, or blocked even though no controller survived. The live
 		// registry is authoritative for whether a duplicate Chat controller could
 		// be created, so recover only when it confirms there is none. TUI keeps its
 		// existing durable-exited precondition.
-		if mode != domain.SessionModeChat || m.chat == nil || m.chat.HasLiveChatController(id) {
+		if mode != domain.SessionModeChat || m.chat == nil {
 			return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrAgentNotExited)
 		}
 	}
-	meta := rec.Metadata
-	if meta.WorkspacePath == "" || meta.Branch == "" ||
-		(mode != domain.SessionModeChat && meta.RuntimeHandleID == "") {
-		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrIncompleteHandle)
-	}
-
 	project, err := m.loadProject(ctx, rec.ProjectID)
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, err)
+	}
+	meta := rec.Metadata
+	if meta.WorkspacePath == "" ||
+		(meta.Branch == "" && project.Kind.WithDefault() != domain.ProjectKindScratch) ||
+		(mode != domain.SessionModeChat && meta.RuntimeHandleID == "") {
+		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrIncompleteHandle)
 	}
 	ws := ports.WorkspaceInfo{
 		Path:      meta.WorkspacePath,
@@ -1483,6 +1486,8 @@ func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation strin
 	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
 		if forceFresh {
 			rec.Metadata.ProviderConversationID = ""
+		} else if strings.TrimSpace(rec.Metadata.ProviderConversationID) == "" {
+			return RestoreResult{}, fmt.Errorf("%s %s: %w", operation, rec.ID, ErrIncompleteHandle)
 		}
 		return m.resumeChatController(ctx, operation, rec, project, ws)
 	}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1414,11 +1414,20 @@ func (m *Manager) ResumeAgentWithMode(ctx context.Context, id domain.SessionID) 
 	if rec.IsTerminated {
 		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrTerminated)
 	}
+	mode := domain.NormalizeSessionMode(rec.Mode)
 	if rec.Activity.State != domain.ActivityExited {
-		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrAgentNotExited)
+		// Builds before the controller-stop lifecycle fix can leave a Chat row
+		// idle, active, or blocked even though no controller survived. The live
+		// registry is authoritative for whether a duplicate Chat controller could
+		// be created, so recover only when it confirms there is none. TUI keeps its
+		// existing durable-exited precondition.
+		if mode != domain.SessionModeChat || m.chat == nil || m.chat.HasLiveChatController(id) {
+			return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrAgentNotExited)
+		}
 	}
 	meta := rec.Metadata
-	if meta.WorkspacePath == "" || meta.Branch == "" || meta.RuntimeHandleID == "" {
+	if meta.WorkspacePath == "" || meta.Branch == "" ||
+		(mode != domain.SessionModeChat && meta.RuntimeHandleID == "") {
 		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrIncompleteHandle)
 	}
 
@@ -1431,6 +1440,9 @@ func (m *Manager) ResumeAgentWithMode(ctx context.Context, id domain.SessionID) 
 		Branch:    meta.Branch,
 		SessionID: rec.ID,
 		ProjectID: rec.ProjectID,
+	}
+	if mode == domain.SessionModeChat {
+		return m.relaunchSession(ctx, "resume agent", rec, project, ws, nil)
 	}
 	handle := ports.RuntimeHandle{ID: meta.RuntimeHandleID}
 	return m.relaunchSession(ctx, "resume agent", rec, project, ws, &handle)


### PR DESCRIPTION
## What

- report Chat lifecycle `exited` whenever the provider event stream ends, including abrupt disconnects without a final controller-state event
- allow `chat.controller.stopped` to clear sticky `blocked` activity
- make agent resume mode-aware so Chat sessions relaunch their provider conversation without a terminal runtime handle
- recover stale pre-fix Chat activity only when no live controller exists, and wait for a stopped controller's final cleanup before replacement

## Why

The desktop can correctly show **The agent controller stopped** while **Resume agent** fails with `AGENT_NOT_EXITED`. Some sessions remain durably idle/active/blocked after their Chat controller dies; sessions that do reach exited then fail the TUI-only runtime-handle precondition.

Fixes #3710.

## How

The controller's provider-stream closure now emits the same generation-fenced lifecycle signal as an explicit stopped event. Lifecycle treats that event as a turn boundary so a dead controller cannot remain blocked.

Session Manager keeps TUI resume semantics unchanged. For Chat, the in-memory controller registry prevents duplicate recovery of a live controller and permits stale durable rows to recover when no controller remains. The Chat service distinguishes a stopped registry entry from a usable controller and waits for its projector cleanup before launching the replacement generation.

No frontend or API contract changes are required; the existing recovery action works once daemon state and resume semantics agree.

## Testing

- `GOFLAGS=-p=1 npm run lint`
- `cd backend && go build ./...`
- `cd backend && go test -race -p 1 ./internal/service/chat ./internal/lifecycle ./internal/session_manager`
- focused regressions for raw stream closure, blocked-to-exited transition, stale/live controller guards, runtime-handle-free Chat resume, and stopped-controller relaunch ordering

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
