### PR TITLE
fix(opencode): detect agent exit via AO's process supervisor

### DIFF
--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -72,6 +72,14 @@ func New() *Plugin {
 	return &Plugin{}
 }
 
+// ExitDetectionMode opts opencode into AO's process supervisor. opencode's
+// launch command ends in an interactive keep-alive shell, so the tmux pane
+// outlives the agent process and runtime liveness alone reports a dead worker
+// as alive forever (#2089). Mirrors the codex adapter.
+func (p *Plugin) ExitDetectionMode() ports.AgentExitDetectionMode {
+	return ports.AgentExitDetectionSupervisor
+}
+
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
 var _ ports.AgentAuthChecker = (*Plugin)(nil)

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -937,3 +937,10 @@ func contains(values []string, needle string) bool {
 	}
 	return false
 }
+
+func TestExitDetectionUsesAOProcessSupervisor(t *testing.T) {
+	plugin := &Plugin{}
+	if got := plugin.ExitDetectionMode(); got != ports.AgentExitDetectionSupervisor {
+		t.Fatalf("exit detection mode = %q, want %q", got, ports.AgentExitDetectionSupervisor)
+	}
+}


### PR DESCRIPTION
## Problem

The `opencode` adapter does not implement `ports.AgentExitDetector`, so it falls back to runtime-only liveness.

AO launches every seat as:

```
bash -c '<agent> ...; exec "${SHELL:-/bin/sh}" -i'
```

The trailing interactive shell is deliberate — it keeps the pane usable after the agent finishes. But it means the tmux pane **outlives the agent process**, so `tmux has-session` keeps answering "alive" long after `opencode` has exited or been killed.

Consequences observed on a worker seat whose agent was killed:

- the reaper never observes a dead worker, so the session is never marked terminated;
- `session restore` then refuses the session as not-restorable, because AO still believes it is alive;
- the seat is effectively unrecoverable without manual intervention.

Fixes #2089.

## Fix

Opt `opencode` into `AgentExitDetectionSupervisor`, exactly as the `codex` adapter already does (`adapters/agent/codex/codex.go`). The launch argv is then wrapped in `ao agent-process supervise`, which reports the real process exit back to the daemon, and `RuntimeLaunchID` is populated so the workload-death signal is no longer fenced off.

This is the mechanism AO already ships; the adapter simply was not opted in.

## Verification

Built from this branch and run as an isolated daemon (separate port, data dir, run file and `TMUX_TMPDIR`), against a scratch git repo:

1. Spawned an `opencode` worker seat; confirmed it did real work in its worktree.
2. `kill -9` on the `opencode` process.
3. **Before the patch:** session stayed `running` indefinitely; the tmux pane was still alive, and `has-session` still reported alive.
4. **After the patch:** session moved to `exited` within a few seconds of the kill, while the pane remained (as intended).
5. The seat could then be recovered in place via `POST /sessions/{id}/activity {"state":"exited"}` followed by `POST /sessions/{id}/resume-agent`, and the resumed agent wrote a new file into the preserved worktree — so the session became genuinely restorable, not merely relabelled.

`go test ./internal/adapters/agent/opencode/...` passes, including the added case.

## Notes

- No behaviour change for any other adapter.
- One incidental finding while testing, reported separately rather than folded in here: `respawnPaneArgs` targets `<session>:0.0` unconditionally, so on a machine with `base-index 1` / `pane-base-index 1` in `~/.tmux.conf` the pane is `1.1`, and `resume-agent` fails with `can't find window: 0`. That is independent of this fix and needs its own change (a tmux target that does not assume index 0, e.g. `{start}.{top-left}`); happy to open a separate PR for it.
