### PR TITLE
fix(session): prevent stale-idle interface drain hangs

### DIFF
--- a/backend/internal/adapters/agent/codex/terminal_activity_test.go
+++ b/backend/internal/adapters/agent/codex/terminal_activity_test.go
@@ -20,15 +20,6 @@ func TestDetectTerminalActivity(t *testing.T) {
 			ok:     true,
 		},
 		{
-			// tmux capture-pane omits styling, so the detector cannot distinguish
-			// this draft from the placeholder above. Draft text remains terminal-local
-			// and is outside the interface handoff's quiescence decision.
-			name:   "typed but unsubmitted composer",
-			output: "› keep this draft\n\ngpt-5.6-sol low · ~/project\n",
-			want:   domain.ActivityIdle,
-			ok:     true,
-		},
-		{
 			name:   "working composer",
 			output: "• Working (2m 10s • esc to interrupt)\n› Add tests\n\ngpt-5.6-sol low · ~/project\n",
 		},

--- a/backend/internal/adapters/agent/codex/terminal_activity_test.go
+++ b/backend/internal/adapters/agent/codex/terminal_activity_test.go
@@ -20,6 +20,15 @@ func TestDetectTerminalActivity(t *testing.T) {
 			ok:     true,
 		},
 		{
+			// tmux capture-pane omits styling, so the detector cannot distinguish
+			// this draft from the placeholder above. Draft text remains terminal-local
+			// and is outside the interface handoff's quiescence decision.
+			name:   "typed but unsubmitted composer",
+			output: "› keep this draft\n\ngpt-5.6-sol low · ~/project\n",
+			want:   domain.ActivityIdle,
+			ok:     true,
+		},
+		{
 			name:   "working composer",
 			output: "• Working (2m 10s • esc to interrupt)\n› Add tests\n\ngpt-5.6-sol low · ~/project\n",
 		},

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -12,18 +12,19 @@ import (
 )
 
 const (
-	interfaceTransitionPoll              = 150 * time.Millisecond
-	interfaceTransitionIdleSettle        = 750 * time.Millisecond
-	interfaceTransitionIdleSampleMinimum = 3
-	interfaceTransitionStaleIdleLimit    = 5 * time.Second
-	interfaceTransitionOutputReadLimit   = 2 * time.Second
-	interfaceTransitionOutputLines       = 40
-	interfaceInterruptSettle             = 2 * time.Second
-	interfaceTransitionStopLimit         = 15 * time.Second
-	interfaceTransitionStepLimit         = 45 * time.Second
-	interfaceDeliveryRetry               = 2 * time.Second
-	interfaceDeliveryIdlePoll            = 30 * time.Second
+	interfaceTransitionPoll             = 150 * time.Millisecond
+	interfaceTransitionIdleSettle       = 750 * time.Millisecond
+	interfaceTransitionStaleIdleSamples = 3
+	interfaceTransitionStaleIdleLimit   = 5 * time.Second
+	interfaceTransitionOutputLines      = 40
+	interfaceInterruptSettle            = 2 * time.Second
+	interfaceTransitionStopLimit        = 15 * time.Second
+	interfaceTransitionStepLimit        = 45 * time.Second
+	interfaceDeliveryRetry              = 2 * time.Second
+	interfaceDeliveryIdlePoll           = 30 * time.Second
 )
+
+var errDrainQuiescenceUnverified = errors.New("AO could not verify that the terminal was idle after the latest input. The source interface was left untouched; retry after the terminal settles")
 
 // interfaceTransitionStore is optional so the existing narrow Manager Store
 // port and its many focused fakes do not grow methods unrelated to their tests.
@@ -292,9 +293,8 @@ func (m *Manager) runInterfaceTransition(
 	}
 	if err := m.prepareSourceHandoff(ctx, rec, transition.Policy, lastTerminalInputAt); err != nil {
 		code := "SOURCE_QUIESCE_FAILED"
-		if errors.Is(err, ErrDrainQuiescenceUnverified) {
+		if errors.Is(err, errDrainQuiescenceUnverified) {
 			code = "DRAIN_QUIESCENCE_UNVERIFIED"
-			err = errors.New("AO could not verify that the terminal was idle after the latest input. The source interface was left untouched; retry Finish work or choose Stop now")
 		}
 		fail(code, err)
 		return
@@ -551,28 +551,24 @@ func (m *Manager) prepareSourceHandoff(
 		now := time.Now()
 		idleProven := tuiIdleAfterInput(current, lastTerminalInputAt)
 		staleIdle := current.Activity.State == domain.ActivityIdle && !idleProven
+		probeCtx := ctx
+		var cancelProbe context.CancelFunc
 		if staleIdle {
 			if staleIdleSince.IsZero() {
 				staleIdleSince = now
 			}
+			probeCtx, cancelProbe = context.WithDeadline(ctx, staleIdleSince.Add(m.interfaceTransition.staleIdleLimit))
 			// A screen can still show the idle composer briefly after Enter was
 			// accepted. Give the last input a full settle window before treating
 			// adapter markers as evidence, then require repeated samples below.
-			if detector != nil && terminalInputQuiet(lastTerminalInputAt, now, m.interfaceTransition.idleSettle) {
-				readLimit := m.interfaceTransition.outputReadLimit
-				remaining := m.interfaceTransition.staleIdleLimit - now.Sub(staleIdleSince)
-				if remaining < readLimit {
-					readLimit = remaining
-				}
-				if readLimit > 0 {
-					outputCtx, cancel := context.WithTimeout(ctx, readLimit)
-					output, outputErr := m.runtime.GetOutput(outputCtx, handle, m.interfaceTransition.outputLines)
-					cancel()
-					now = time.Now()
-					if outputErr == nil {
-						state, authoritative := detector.DetectTerminalActivity(output)
-						idleProven = authoritative && state == domain.ActivityIdle
-					}
+			inputQuiet := lastTerminalInputAt.IsZero() ||
+				!now.Before(lastTerminalInputAt.Add(m.interfaceTransition.idleSettle))
+			if detector != nil && inputQuiet {
+				output, outputErr := m.runtime.GetOutput(probeCtx, handle, interfaceTransitionOutputLines)
+				now = time.Now()
+				if outputErr == nil {
+					state, authoritative := detector.DetectTerminalActivity(output)
+					idleProven = authoritative && state == domain.ActivityIdle
 				}
 			}
 		} else {
@@ -585,14 +581,20 @@ func (m *Manager) prepareSourceHandoff(
 			if idleSince.IsZero() {
 				idleSince = now
 			} else if now.Sub(idleSince) >= m.interfaceTransition.idleSettle &&
-				idleSamples >= m.interfaceTransition.idleSampleMinimum {
+				(!staleIdle || idleSamples >= interfaceTransitionStaleIdleSamples) {
+				if cancelProbe != nil {
+					cancelProbe()
+				}
 				return nil
 			}
 		} else {
 			idleSince = time.Time{}
 			idleSamples = 0
 		}
-		alive, probeErr := m.runtime.IsAlive(ctx, handle)
+		alive, probeErr := m.runtime.IsAlive(probeCtx, handle)
+		if cancelProbe != nil {
+			cancelProbe()
+		}
 		if probeErr == nil && !alive {
 			return nil
 		}
@@ -601,7 +603,7 @@ func (m *Manager) prepareSourceHandoff(
 		// unknown captures. Partial terminal redraws may alternate between idle
 		// and ambiguous forever; neither outcome is enough to stop the source.
 		if staleIdle && now.Sub(staleIdleSince) >= m.interfaceTransition.staleIdleLimit {
-			return ErrDrainQuiescenceUnverified
+			return errDrainQuiescenceUnverified
 		}
 		select {
 		case <-ctx.Done():
@@ -609,10 +611,6 @@ func (m *Manager) prepareSourceHandoff(
 		case <-ticker.C:
 		}
 	}
-}
-
-func terminalInputQuiet(lastInputAt, now time.Time, settle time.Duration) bool {
-	return lastInputAt.IsZero() || !now.Before(lastInputAt.Add(settle))
 }
 
 // tuiIdleAfterInput proves that the idle fact was written after every terminal

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -12,13 +12,17 @@ import (
 )
 
 const (
-	interfaceTransitionPoll       = 150 * time.Millisecond
-	interfaceTransitionIdleSettle = 750 * time.Millisecond
-	interfaceInterruptSettle      = 2 * time.Second
-	interfaceTransitionStopLimit  = 15 * time.Second
-	interfaceTransitionStepLimit  = 45 * time.Second
-	interfaceDeliveryRetry        = 2 * time.Second
-	interfaceDeliveryIdlePoll     = 30 * time.Second
+	interfaceTransitionPoll              = 150 * time.Millisecond
+	interfaceTransitionIdleSettle        = 750 * time.Millisecond
+	interfaceTransitionIdleSampleMinimum = 3
+	interfaceTransitionStaleIdleLimit    = 5 * time.Second
+	interfaceTransitionOutputReadLimit   = 2 * time.Second
+	interfaceTransitionOutputLines       = 40
+	interfaceInterruptSettle             = 2 * time.Second
+	interfaceTransitionStopLimit         = 15 * time.Second
+	interfaceTransitionStepLimit         = 45 * time.Second
+	interfaceDeliveryRetry               = 2 * time.Second
+	interfaceDeliveryIdlePoll            = 30 * time.Second
 )
 
 // interfaceTransitionStore is optional so the existing narrow Manager Store
@@ -287,7 +291,12 @@ func (m *Manager) runInterfaceTransition(
 		return
 	}
 	if err := m.prepareSourceHandoff(ctx, rec, transition.Policy, lastTerminalInputAt); err != nil {
-		fail("SOURCE_QUIESCE_FAILED", err)
+		code := "SOURCE_QUIESCE_FAILED"
+		if errors.Is(err, ErrDrainQuiescenceUnverified) {
+			code = "DRAIN_QUIESCENCE_UNVERIFIED"
+			err = errors.New("AO could not verify that the terminal was idle after the latest input. The source interface was left untouched; retry Finish work or choose Stop now")
+		}
+		fail(code, err)
 		return
 	}
 	sourcePrepared = true
@@ -519,9 +528,15 @@ func (m *Manager) prepareSourceHandoff(
 		}
 	}
 
-	ticker := time.NewTicker(interfaceTransitionPoll)
+	var detector ports.TerminalActivityDetector
+	if agent, ok := m.agents.Agent(rec.Harness); ok {
+		detector, _ = agent.(ports.TerminalActivityDetector)
+	}
+	ticker := time.NewTicker(m.interfaceTransition.pollInterval)
 	defer ticker.Stop()
 	idleSince := time.Time{}
+	idleSamples := 0
+	staleIdleSince := time.Time{}
 	for {
 		current, ok, err := m.store.GetSession(ctx, rec.ID)
 		if err != nil {
@@ -533,18 +548,60 @@ func (m *Manager) prepareSourceHandoff(
 		if current.Activity.State == domain.ActivityExited {
 			return nil
 		}
-		if tuiIdleAfterInput(current, lastTerminalInputAt) {
+		now := time.Now()
+		idleProven := tuiIdleAfterInput(current, lastTerminalInputAt)
+		staleIdle := current.Activity.State == domain.ActivityIdle && !idleProven
+		if staleIdle {
+			if staleIdleSince.IsZero() {
+				staleIdleSince = now
+			}
+			// A screen can still show the idle composer briefly after Enter was
+			// accepted. Give the last input a full settle window before treating
+			// adapter markers as evidence, then require repeated samples below.
+			if detector != nil && terminalInputQuiet(lastTerminalInputAt, now, m.interfaceTransition.idleSettle) {
+				readLimit := m.interfaceTransition.outputReadLimit
+				remaining := m.interfaceTransition.staleIdleLimit - now.Sub(staleIdleSince)
+				if remaining < readLimit {
+					readLimit = remaining
+				}
+				if readLimit > 0 {
+					outputCtx, cancel := context.WithTimeout(ctx, readLimit)
+					output, outputErr := m.runtime.GetOutput(outputCtx, handle, m.interfaceTransition.outputLines)
+					cancel()
+					now = time.Now()
+					if outputErr == nil {
+						state, authoritative := detector.DetectTerminalActivity(output)
+						idleProven = authoritative && state == domain.ActivityIdle
+					}
+				}
+			}
+		} else {
+			// A reported active turn or user-paced decision is allowed to wait
+			// without a deadline. A real state change resets prior ambiguity.
+			staleIdleSince = time.Time{}
+		}
+		if idleProven {
+			idleSamples++
 			if idleSince.IsZero() {
-				idleSince = time.Now()
-			} else if time.Since(idleSince) >= interfaceTransitionIdleSettle {
+				idleSince = now
+			} else if now.Sub(idleSince) >= m.interfaceTransition.idleSettle &&
+				idleSamples >= m.interfaceTransition.idleSampleMinimum {
 				return nil
 			}
 		} else {
 			idleSince = time.Time{}
+			idleSamples = 0
 		}
 		alive, probeErr := m.runtime.IsAlive(ctx, handle)
 		if probeErr == nil && !alive {
 			return nil
+		}
+		now = time.Now()
+		// Bound the whole contradictory stale-idle regime, not just consecutive
+		// unknown captures. Partial terminal redraws may alternate between idle
+		// and ambiguous forever; neither outcome is enough to stop the source.
+		if staleIdle && now.Sub(staleIdleSince) >= m.interfaceTransition.staleIdleLimit {
+			return ErrDrainQuiescenceUnverified
 		}
 		select {
 		case <-ctx.Done():
@@ -552,6 +609,10 @@ func (m *Manager) prepareSourceHandoff(
 		case <-ticker.C:
 		}
 	}
+}
+
+func terminalInputQuiet(lastInputAt, now time.Time, settle time.Duration) bool {
+	return lastInputAt.IsZero() || !now.Before(lastInputAt.Add(settle))
 }
 
 // tuiIdleAfterInput proves that the idle fact was written after every terminal

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -184,12 +183,15 @@ func (transitionAgent) NativeConversationID(_ context.Context, session ports.Ses
 type transitionDetectorAgent struct{ transitionAgent }
 
 func (transitionDetectorAgent) DetectTerminalActivity(output string) (domain.ActivityState, bool) {
-	return codex.New().DetectTerminalActivity(output)
+	if output == "idle" {
+		return domain.ActivityIdle, true
+	}
+	return "", false
 }
 
 const (
-	codexIdleDraftOutput = "› keep this draft\n\ngpt-5.6-sol low · ~/project\n"
-	codexWorkingOutput   = "• Working (1s • esc to interrupt)\n› keep this draft\n\ngpt-5.6-sol low · ~/project\n"
+	idleTerminalOutput      = "idle"
+	ambiguousTerminalOutput = "ambiguous"
 )
 
 type emptyTransitionAgent struct{ transitionAgent }
@@ -200,15 +202,24 @@ func (emptyTransitionAgent) NativeConversationExists(context.Context, ports.Sess
 
 type transitionRuntime struct {
 	*fakeRuntime
-	log             *[]string
-	stopErrors      []error
-	outputForCall   func(int) string
-	outputCallTimes []time.Time
+	log                        *[]string
+	stopErrors                 []error
+	outputForCall              func(int) string
+	outputCallTimes            []time.Time
+	blockAliveUntilContextDone bool
 }
 
 func (r *transitionRuntime) Interrupt(_ context.Context, handle ports.RuntimeHandle) error {
 	*r.log = append(*r.log, "interrupt:tui:"+handle.ID)
 	return nil
+}
+
+func (r *transitionRuntime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error) {
+	if r.blockAliveUntilContextDone {
+		<-ctx.Done()
+		return false, ctx.Err()
+	}
+	return r.fakeRuntime.IsAlive(ctx, handle)
 }
 
 func (r *transitionRuntime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error {
@@ -234,9 +245,6 @@ func (r *transitionRuntime) GetOutput(ctx context.Context, handle ports.RuntimeH
 		return r.fakeRuntime.GetOutput(ctx, handle, lines)
 	}
 	r.outputCalls++
-	if r.outputErr != nil {
-		return "", r.outputErr
-	}
 	return r.outputForCall(r.outputCalls), nil
 }
 
@@ -326,20 +334,6 @@ func TestTUIIdleAfterInputRequiresANewerIdleFact(t *testing.T) {
 	}
 }
 
-func TestTerminalInputQuietRequiresAFullSettleWindow(t *testing.T) {
-	inputAt := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
-	settle := 750 * time.Millisecond
-	if terminalInputQuiet(inputAt, inputAt.Add(settle-time.Nanosecond), settle) {
-		t.Fatal("terminal input was treated as settled before the quiet window elapsed")
-	}
-	if !terminalInputQuiet(inputAt, inputAt.Add(settle), settle) {
-		t.Fatal("terminal input was not treated as settled at the quiet-window boundary")
-	}
-	if !terminalInputQuiet(time.Time{}, inputAt, settle) {
-		t.Fatal("an empty input barrier should not delay terminal activity proof")
-	}
-}
-
 func newTransitionManager(t *testing.T, mode domain.SessionMode) (*Manager, *transitionStore, *transitionRuntime, *transitionChat, *[]string) {
 	t.Helper()
 	store := newTransitionStore()
@@ -378,24 +372,9 @@ func newTransitionManager(t *testing.T, mode domain.SessionMode) (*Manager, *tra
 
 func useFastInterfaceTransitionTimings(manager *Manager) {
 	manager.interfaceTransition = interfaceTransitionConfig{
-		pollInterval:      time.Millisecond,
-		idleSettle:        5 * time.Millisecond,
-		idleSampleMinimum: 3,
-		staleIdleLimit:    60 * time.Millisecond,
-		outputReadLimit:   10 * time.Millisecond,
-		outputLines:       40,
-	}
-}
-
-func TestNewConfiguresInterfaceTransitionProof(t *testing.T) {
-	manager, _, _, _, _ := newTransitionManager(t, domain.SessionModeTUI)
-	if manager.interfaceTransition.pollInterval <= 0 ||
-		manager.interfaceTransition.idleSettle <= 0 ||
-		manager.interfaceTransition.idleSampleMinimum < 2 ||
-		manager.interfaceTransition.staleIdleLimit <= manager.interfaceTransition.idleSettle ||
-		manager.interfaceTransition.outputReadLimit <= 0 ||
-		manager.interfaceTransition.outputLines <= 0 {
-		t.Fatalf("invalid interface transition proof config: %+v", manager.interfaceTransition)
+		pollInterval:   time.Millisecond,
+		idleSettle:     5 * time.Millisecond,
+		staleIdleLimit: 60 * time.Millisecond,
 	}
 }
 
@@ -450,7 +429,7 @@ func TestInterfaceTransitionTUIToChatDrainsAVisibleIdleComposerAfterNonSubmittin
 	rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now.Add(-time.Minute)}
 	store.sessions["session-1"] = rec
 	runtime.aliveByHandle = map[string]bool{"runtime-1": true}
-	runtime.outputs = []string{codexIdleDraftOutput}
+	runtime.outputs = []string{idleTerminalOutput}
 	manager.SetTerminalInputGate(&transitionInputGate{
 		acquired:    make(chan string, 1),
 		released:    make(chan string, 1),
@@ -466,9 +445,9 @@ func TestInterfaceTransitionTUIToChatDrainsAVisibleIdleComposerAfterNonSubmittin
 	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
 		t.Fatalf("phase = %s, error = %s", settled.Phase, settled.ErrorDetail)
 	}
-	if runtime.outputCalls < manager.interfaceTransition.idleSampleMinimum {
+	if runtime.outputCalls < interfaceTransitionStaleIdleSamples {
 		t.Fatalf("terminal output calls = %d, want at least %d consecutive idle samples",
-			runtime.outputCalls, manager.interfaceTransition.idleSampleMinimum)
+			runtime.outputCalls, interfaceTransitionStaleIdleSamples)
 	}
 	if firstCapture := runtime.outputCallTimes[0]; firstCapture.Before(now.Add(manager.interfaceTransition.idleSettle)) {
 		t.Fatalf("first terminal capture at %s, before input settled at %s",
@@ -507,29 +486,32 @@ func TestInterfaceTransitionTUIToChatUsesANewerIdleFactWithoutReadingTerminalOut
 
 func TestInterfaceTransitionTUIToChatFailsClosedWhenStaleIdleCannotBeVerified(t *testing.T) {
 	tests := []struct {
-		name          string
-		agent         ports.Agent
-		outputs       []string
-		outputForCall func(int) string
-		outputErr     error
-		aliveErr      error
-		wantCaptures  bool
+		name                       string
+		agent                      ports.Agent
+		outputs                    []string
+		outputForCall              func(int) string
+		blockAliveUntilContextDone bool
+		wantCaptures               bool
 	}{
 		{name: "detector unavailable", agent: transitionAgent{}},
-		{name: "detector ambiguous", agent: transitionDetectorAgent{}, outputs: []string{codexWorkingOutput}, wantCaptures: true},
+		{name: "detector ambiguous", agent: transitionDetectorAgent{}, outputs: []string{ambiguousTerminalOutput}, wantCaptures: true},
 		{
 			name:  "idle and ambiguous captures keep alternating",
 			agent: transitionDetectorAgent{},
 			outputForCall: func(call int) string {
 				if call%2 == 1 {
-					return codexIdleDraftOutput
+					return idleTerminalOutput
 				}
-				return codexWorkingOutput
+				return ambiguousTerminalOutput
 			},
 			wantCaptures: true,
 		},
-		{name: "terminal output unavailable", agent: transitionDetectorAgent{}, outputErr: errors.New("capture failed"), wantCaptures: true},
-		{name: "runtime liveness unknown", agent: transitionDetectorAgent{}, outputs: []string{codexWorkingOutput}, aliveErr: errors.New("probe failed"), wantCaptures: true},
+		{
+			name:                       "liveness probe reaches proof deadline",
+			agent:                      transitionDetectorAgent{},
+			outputs:                    []string{ambiguousTerminalOutput},
+			blockAliveUntilContextDone: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -541,10 +523,9 @@ func TestInterfaceTransitionTUIToChatFailsClosedWhenStaleIdleCannotBeVerified(t 
 			rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now.Add(-time.Minute)}
 			store.sessions["session-1"] = rec
 			runtime.aliveByHandle = map[string]bool{"runtime-1": true}
-			runtime.aliveErr = tt.aliveErr
 			runtime.outputs = tt.outputs
 			runtime.outputForCall = tt.outputForCall
-			runtime.outputErr = tt.outputErr
+			runtime.blockAliveUntilContextDone = tt.blockAliveUntilContextDone
 			gate := &transitionInputGate{
 				acquired:    make(chan string, 1),
 				released:    make(chan string, 1),

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -180,6 +181,17 @@ func (transitionAgent) NativeConversationID(_ context.Context, session ports.Ses
 	return id, id != "", nil
 }
 
+type transitionDetectorAgent struct{ transitionAgent }
+
+func (transitionDetectorAgent) DetectTerminalActivity(output string) (domain.ActivityState, bool) {
+	return codex.New().DetectTerminalActivity(output)
+}
+
+const (
+	codexIdleDraftOutput = "› keep this draft\n\ngpt-5.6-sol low · ~/project\n"
+	codexWorkingOutput   = "• Working (1s • esc to interrupt)\n› keep this draft\n\ngpt-5.6-sol low · ~/project\n"
+)
+
 type emptyTransitionAgent struct{ transitionAgent }
 
 func (emptyTransitionAgent) NativeConversationExists(context.Context, ports.SessionRef, string, map[string]string) (bool, error) {
@@ -188,8 +200,10 @@ func (emptyTransitionAgent) NativeConversationExists(context.Context, ports.Sess
 
 type transitionRuntime struct {
 	*fakeRuntime
-	log        *[]string
-	stopErrors []error
+	log             *[]string
+	stopErrors      []error
+	outputForCall   func(int) string
+	outputCallTimes []time.Time
 }
 
 func (r *transitionRuntime) Interrupt(_ context.Context, handle ports.RuntimeHandle) error {
@@ -212,6 +226,18 @@ func (r *transitionRuntime) Destroy(ctx context.Context, handle ports.RuntimeHan
 func (r *transitionRuntime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
 	*r.log = append(*r.log, "start:tui")
 	return r.fakeRuntime.Create(ctx, cfg)
+}
+
+func (r *transitionRuntime) GetOutput(ctx context.Context, handle ports.RuntimeHandle, lines int) (string, error) {
+	r.outputCallTimes = append(r.outputCallTimes, time.Now())
+	if r.outputForCall == nil {
+		return r.fakeRuntime.GetOutput(ctx, handle, lines)
+	}
+	r.outputCalls++
+	if r.outputErr != nil {
+		return "", r.outputErr
+	}
+	return r.outputForCall(r.outputCalls), nil
 }
 
 type transitionChat struct {
@@ -300,6 +326,20 @@ func TestTUIIdleAfterInputRequiresANewerIdleFact(t *testing.T) {
 	}
 }
 
+func TestTerminalInputQuietRequiresAFullSettleWindow(t *testing.T) {
+	inputAt := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	settle := 750 * time.Millisecond
+	if terminalInputQuiet(inputAt, inputAt.Add(settle-time.Nanosecond), settle) {
+		t.Fatal("terminal input was treated as settled before the quiet window elapsed")
+	}
+	if !terminalInputQuiet(inputAt, inputAt.Add(settle), settle) {
+		t.Fatal("terminal input was not treated as settled at the quiet-window boundary")
+	}
+	if !terminalInputQuiet(time.Time{}, inputAt, settle) {
+		t.Fatal("an empty input barrier should not delay terminal activity proof")
+	}
+}
+
 func newTransitionManager(t *testing.T, mode domain.SessionMode) (*Manager, *transitionStore, *transitionRuntime, *transitionChat, *[]string) {
 	t.Helper()
 	store := newTransitionStore()
@@ -334,6 +374,29 @@ func newTransitionManager(t *testing.T, mode domain.SessionMode) (*Manager, *tra
 		NewLaunchID: func() string { counter++; return fmt.Sprintf("generation-%d", counter) },
 	})
 	return manager, store, runtime, chat, log
+}
+
+func useFastInterfaceTransitionTimings(manager *Manager) {
+	manager.interfaceTransition = interfaceTransitionConfig{
+		pollInterval:      time.Millisecond,
+		idleSettle:        5 * time.Millisecond,
+		idleSampleMinimum: 3,
+		staleIdleLimit:    60 * time.Millisecond,
+		outputReadLimit:   10 * time.Millisecond,
+		outputLines:       40,
+	}
+}
+
+func TestNewConfiguresInterfaceTransitionProof(t *testing.T) {
+	manager, _, _, _, _ := newTransitionManager(t, domain.SessionModeTUI)
+	if manager.interfaceTransition.pollInterval <= 0 ||
+		manager.interfaceTransition.idleSettle <= 0 ||
+		manager.interfaceTransition.idleSampleMinimum < 2 ||
+		manager.interfaceTransition.staleIdleLimit <= manager.interfaceTransition.idleSettle ||
+		manager.interfaceTransition.outputReadLimit <= 0 ||
+		manager.interfaceTransition.outputLines <= 0 {
+		t.Fatalf("invalid interface transition proof config: %+v", manager.interfaceTransition)
+	}
 }
 
 func awaitTransition(t *testing.T, store *transitionStore, id string) domain.SessionInterfaceTransition {
@@ -375,6 +438,232 @@ func TestInterfaceTransitionTUIToChatStopsBeforeStartingAndReusesNativeConversat
 	}
 	if got := fmt.Sprint(*log); got != "[stop:tui:runtime-1 start:chat]" {
 		t.Fatalf("controller order = %s", got)
+	}
+}
+
+func TestInterfaceTransitionTUIToChatDrainsAVisibleIdleComposerAfterNonSubmittingInput(t *testing.T) {
+	manager, store, runtime, _, _ := newTransitionManager(t, domain.SessionModeTUI)
+	useFastInterfaceTransitionTimings(manager)
+	manager.agents = singleAgent{agent: transitionDetectorAgent{}}
+	now := time.Now()
+	rec := store.sessions["session-1"]
+	rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now.Add(-time.Minute)}
+	store.sessions["session-1"] = rec
+	runtime.aliveByHandle = map[string]bool{"runtime-1": true}
+	runtime.outputs = []string{codexIdleDraftOutput}
+	manager.SetTerminalInputGate(&transitionInputGate{
+		acquired:    make(chan string, 1),
+		released:    make(chan string, 1),
+		lastInputAt: now,
+	})
+
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("phase = %s, error = %s", settled.Phase, settled.ErrorDetail)
+	}
+	if runtime.outputCalls < manager.interfaceTransition.idleSampleMinimum {
+		t.Fatalf("terminal output calls = %d, want at least %d consecutive idle samples",
+			runtime.outputCalls, manager.interfaceTransition.idleSampleMinimum)
+	}
+	if firstCapture := runtime.outputCallTimes[0]; firstCapture.Before(now.Add(manager.interfaceTransition.idleSettle)) {
+		t.Fatalf("first terminal capture at %s, before input settled at %s",
+			firstCapture, now.Add(manager.interfaceTransition.idleSettle))
+	}
+}
+
+func TestInterfaceTransitionTUIToChatUsesANewerIdleFactWithoutReadingTerminalOutput(t *testing.T) {
+	manager, store, runtime, _, _ := newTransitionManager(t, domain.SessionModeTUI)
+	useFastInterfaceTransitionTimings(manager)
+	manager.agents = singleAgent{agent: transitionDetectorAgent{}}
+	now := time.Now()
+	rec := store.sessions["session-1"]
+	rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}
+	store.sessions["session-1"] = rec
+	runtime.aliveByHandle = map[string]bool{"runtime-1": true}
+	manager.SetTerminalInputGate(&transitionInputGate{
+		acquired:    make(chan string, 1),
+		released:    make(chan string, 1),
+		lastInputAt: now,
+	})
+
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("phase = %s, error = %s", settled.Phase, settled.ErrorDetail)
+	}
+	if runtime.outputCalls != 0 {
+		t.Fatalf("terminal output calls = %d, want timestamp proof to avoid capture", runtime.outputCalls)
+	}
+}
+
+func TestInterfaceTransitionTUIToChatFailsClosedWhenStaleIdleCannotBeVerified(t *testing.T) {
+	tests := []struct {
+		name          string
+		agent         ports.Agent
+		outputs       []string
+		outputForCall func(int) string
+		outputErr     error
+		aliveErr      error
+		wantCaptures  bool
+	}{
+		{name: "detector unavailable", agent: transitionAgent{}},
+		{name: "detector ambiguous", agent: transitionDetectorAgent{}, outputs: []string{codexWorkingOutput}, wantCaptures: true},
+		{
+			name:  "idle and ambiguous captures keep alternating",
+			agent: transitionDetectorAgent{},
+			outputForCall: func(call int) string {
+				if call%2 == 1 {
+					return codexIdleDraftOutput
+				}
+				return codexWorkingOutput
+			},
+			wantCaptures: true,
+		},
+		{name: "terminal output unavailable", agent: transitionDetectorAgent{}, outputErr: errors.New("capture failed"), wantCaptures: true},
+		{name: "runtime liveness unknown", agent: transitionDetectorAgent{}, outputs: []string{codexWorkingOutput}, aliveErr: errors.New("probe failed"), wantCaptures: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager, store, runtime, _, _ := newTransitionManager(t, domain.SessionModeTUI)
+			useFastInterfaceTransitionTimings(manager)
+			manager.agents = singleAgent{agent: tt.agent}
+			now := time.Now()
+			rec := store.sessions["session-1"]
+			rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now.Add(-time.Minute)}
+			store.sessions["session-1"] = rec
+			runtime.aliveByHandle = map[string]bool{"runtime-1": true}
+			runtime.aliveErr = tt.aliveErr
+			runtime.outputs = tt.outputs
+			runtime.outputForCall = tt.outputForCall
+			runtime.outputErr = tt.outputErr
+			gate := &transitionInputGate{
+				acquired:    make(chan string, 1),
+				released:    make(chan string, 1),
+				lastInputAt: now,
+			}
+			manager.SetTerminalInputGate(gate)
+
+			transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+				domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+			if err != nil {
+				t.Fatal(err)
+			}
+			settled := awaitTransition(t, store, transition.ID)
+			if settled.Phase != domain.SessionInterfaceTransitionFailed || settled.ErrorCode != "DRAIN_QUIESCENCE_UNVERIFIED" {
+				t.Fatalf("transition = %+v, want failed DRAIN_QUIESCENCE_UNVERIFIED", settled)
+			}
+			if !strings.Contains(settled.ErrorDetail, "source interface was left untouched") ||
+				strings.Contains(settled.ErrorDetail, "session:") {
+				t.Fatalf("error detail = %q, want actionable user-facing source-preservation text", settled.ErrorDetail)
+			}
+			if runtime.destroyed != 0 {
+				t.Fatalf("source runtime destroyed %d times after unverified drain", runtime.destroyed)
+			}
+			if tt.wantCaptures && runtime.outputCalls == 0 {
+				t.Fatal("terminal detector was not consulted")
+			}
+			select {
+			case <-gate.released:
+			case <-time.After(time.Second):
+				t.Fatal("terminal input gate remained closed after drain failure")
+			}
+		})
+	}
+}
+
+func TestInterfaceTransitionTUIToChatAcceptsConfirmedRuntimeExitDuringStaleIdle(t *testing.T) {
+	manager, store, runtime, _, _ := newTransitionManager(t, domain.SessionModeTUI)
+	useFastInterfaceTransitionTimings(manager)
+	now := time.Now()
+	rec := store.sessions["session-1"]
+	rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now.Add(-time.Minute)}
+	store.sessions["session-1"] = rec
+	runtime.aliveByHandle = map[string]bool{"runtime-1": false}
+	manager.SetTerminalInputGate(&transitionInputGate{
+		acquired:    make(chan string, 1),
+		released:    make(chan string, 1),
+		lastInputAt: now,
+	})
+
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("transition = %+v, want confirmed runtime exit to complete the handoff", settled)
+	}
+	if runtime.outputCalls != 0 {
+		t.Fatalf("terminal output calls = %d, want confirmed exit before the proof window", runtime.outputCalls)
+	}
+}
+
+func TestInterfaceTransitionTUIToChatDoesNotTimeOutActiveWorkOrDecisions(t *testing.T) {
+	for _, state := range []domain.ActivityState{
+		domain.ActivityActive,
+		domain.ActivityWaitingInput,
+		domain.ActivityBlocked,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			manager, store, runtime, _, _ := newTransitionManager(t, domain.SessionModeTUI)
+			useFastInterfaceTransitionTimings(manager)
+			rec := store.sessions["session-1"]
+			rec.Activity = domain.Activity{State: state, LastActivityAt: time.Now().Add(-time.Hour)}
+			store.sessions["session-1"] = rec
+			runtime.aliveByHandle = map[string]bool{"runtime-1": true}
+			gate := &transitionInputGate{
+				acquired:    make(chan string, 1),
+				released:    make(chan string, 1),
+				lastInputAt: time.Now(),
+			}
+			manager.SetTerminalInputGate(gate)
+
+			transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+				domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+			if err != nil {
+				t.Fatal(err)
+			}
+			deadline := time.Now().Add(time.Second)
+			for time.Now().Before(deadline) {
+				current, _, readErr := store.GetSessionInterfaceTransition(context.Background(), transition.ID)
+				if readErr != nil {
+					t.Fatal(readErr)
+				}
+				if current.Phase == domain.SessionInterfaceTransitionDraining {
+					break
+				}
+				time.Sleep(time.Millisecond)
+			}
+			time.Sleep(2 * manager.interfaceTransition.staleIdleLimit)
+			current, _, err := store.GetSessionInterfaceTransition(context.Background(), transition.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if current.Phase != domain.SessionInterfaceTransitionDraining {
+				t.Fatalf("phase = %s, want draining while source is %s", current.Phase, state)
+			}
+			if err := manager.CancelInterfaceTransition(context.Background(), "session-1"); err != nil {
+				t.Fatal(err)
+			}
+			if runtime.destroyed != 0 {
+				t.Fatalf("source runtime destroyed %d times while cancelling %s drain", runtime.destroyed, state)
+			}
+			select {
+			case <-gate.released:
+			case <-time.After(time.Second):
+				t.Fatal("terminal input gate remained closed after cancellation")
+			}
+		})
 	}
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -73,10 +73,6 @@ var (
 	// ErrInterfaceTransitionNotCancellable protects the no-overlap invariant once
 	// the source controller is already stopping or stopped.
 	ErrInterfaceTransitionNotCancellable = errors.New("session: interface transition can no longer be cancelled")
-	// ErrDrainQuiescenceUnverified means the source still reports idle, but AO
-	// could not prove that terminal input accepted after that idle fact finished
-	// processing. The handoff does not stop the source controller on this path.
-	ErrDrainQuiescenceUnverified = errors.New("session: terminal quiescence could not be verified")
 	// ErrResumeInProgress prevents concurrent resume requests from replacing the
 	// same runtime twice.
 	ErrResumeInProgress = errors.New("session: agent resume already in progress")
@@ -427,12 +423,9 @@ type sendConfirmConfig struct {
 // making the contradictory stale-idle proof window short and testable. Only an
 // idle row older than accepted PTY input consumes staleIdleLimit.
 type interfaceTransitionConfig struct {
-	pollInterval      time.Duration
-	idleSettle        time.Duration
-	idleSampleMinimum int
-	staleIdleLimit    time.Duration
-	outputReadLimit   time.Duration
-	outputLines       int
+	pollInterval   time.Duration
+	idleSettle     time.Duration
+	staleIdleLimit time.Duration
 }
 
 // Production sendConfirm bounds: 3 Enters total (1 from Send + 2 re-sends),
@@ -508,12 +501,9 @@ func New(d Deps) *Manager {
 			maxAttempts:     sendConfirmMaxAttempts,
 		},
 		interfaceTransition: interfaceTransitionConfig{
-			pollInterval:      interfaceTransitionPoll,
-			idleSettle:        interfaceTransitionIdleSettle,
-			idleSampleMinimum: interfaceTransitionIdleSampleMinimum,
-			staleIdleLimit:    interfaceTransitionStaleIdleLimit,
-			outputReadLimit:   interfaceTransitionOutputReadLimit,
-			outputLines:       interfaceTransitionOutputLines,
+			pollInterval:   interfaceTransitionPoll,
+			idleSettle:     interfaceTransitionIdleSettle,
+			staleIdleLimit: interfaceTransitionStaleIdleLimit,
 		},
 		logger: d.Logger,
 	}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -73,6 +73,10 @@ var (
 	// ErrInterfaceTransitionNotCancellable protects the no-overlap invariant once
 	// the source controller is already stopping or stopped.
 	ErrInterfaceTransitionNotCancellable = errors.New("session: interface transition can no longer be cancelled")
+	// ErrDrainQuiescenceUnverified means the source still reports idle, but AO
+	// could not prove that terminal input accepted after that idle fact finished
+	// processing. The handoff does not stop the source controller on this path.
+	ErrDrainQuiescenceUnverified = errors.New("session: terminal quiescence could not be verified")
 	// ErrResumeInProgress prevents concurrent resume requests from replacing the
 	// same runtime twice.
 	ErrResumeInProgress = errors.New("session: agent resume already in progress")
@@ -275,7 +279,10 @@ type Manager struct {
 	// actually became active (the agent accepted the prompt). New fills in the
 	// sendConfirm* defaults; tests in this package shrink the timings directly.
 	sendConfirm sendConfirmConfig
-	logger      *slog.Logger
+	// interfaceTransition bounds only contradictory stale-idle proof. Turns and
+	// user-paced waits reported through the activity boundary remain unbounded.
+	interfaceTransition interfaceTransitionConfig
+	logger              *slog.Logger
 
 	// shellTerminalsMu guards shellTerminals: it is late-bound (see
 	// ShellTerminalCloser) after Manager already exists, so a setter mutates it
@@ -416,6 +423,18 @@ type sendConfirmConfig struct {
 	maxAttempts int
 }
 
+// interfaceTransitionConfig keeps reported human-paced work unbounded while
+// making the contradictory stale-idle proof window short and testable. Only an
+// idle row older than accepted PTY input consumes staleIdleLimit.
+type interfaceTransitionConfig struct {
+	pollInterval      time.Duration
+	idleSettle        time.Duration
+	idleSampleMinimum int
+	staleIdleLimit    time.Duration
+	outputReadLimit   time.Duration
+	outputLines       int
+}
+
 // Production sendConfirm bounds: 3 Enters total (1 from Send + 2 re-sends),
 // each given 2s to flip the session active, polled every 300ms.
 const (
@@ -487,6 +506,14 @@ func New(d Deps) *Manager {
 			pollInterval:    sendConfirmPollInterval,
 			attemptDeadline: sendConfirmAttemptDeadline,
 			maxAttempts:     sendConfirmMaxAttempts,
+		},
+		interfaceTransition: interfaceTransitionConfig{
+			pollInterval:      interfaceTransitionPoll,
+			idleSettle:        interfaceTransitionIdleSettle,
+			idleSampleMinimum: interfaceTransitionIdleSampleMinimum,
+			staleIdleLimit:    interfaceTransitionStaleIdleLimit,
+			outputReadLimit:   interfaceTransitionOutputReadLimit,
+			outputLines:       interfaceTransitionOutputLines,
 		},
 		logger: d.Logger,
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -369,6 +369,15 @@ There is no provider-neutral way to migrate a currently executing tool call or a
 detached background process, and AO does not synthesize terminal screen output
 into structured Chat history.
 
+For TUI drains, AO gates new terminal input before checking quiescence. It accepts
+either an idle fact newer than the last accepted input or an adapter-confirmed
+idle terminal held across the settle window. If newer input contradicts a stale
+idle fact and terminal state cannot be verified, the transition fails after a
+short proof window without stopping the source controller. Activity reported as
+active work or a user-paced decision has no such deadline; an unverified stale
+idle row fails closed instead of guessing which state is on screen. Unsubmitted
+composer text is interface-local and must be submitted or copied before switching.
+
 ### Observation Flow
 
 ```mermaid

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -371,12 +371,9 @@ into structured Chat history.
 
 For TUI drains, AO gates new terminal input before checking quiescence. It accepts
 either an idle fact newer than the last accepted input or an adapter-confirmed
-idle terminal held across the settle window. If newer input contradicts a stale
-idle fact and terminal state cannot be verified, the transition fails after a
-short proof window without stopping the source controller. Activity reported as
-active work or a user-paced decision has no such deadline; an unverified stale
-idle row fails closed instead of guessing which state is on screen. Unsubmitted
-composer text is interface-local and must be submitted or copied before switching.
+idle terminal held across the settle window. A contradictory stale-idle fact has
+a bounded proof window and fails without stopping the source; activity reported
+as active work or a user-paced decision remains unbounded.
 
 ### Observation Flow
 


### PR DESCRIPTION
## What

Prevent TUI-to-Chat drain transitions from waiting forever when accepted terminal input is newer than the last durable idle fact.

## Why

The input gate correctly rejects that stale idle row because buffered PTY input might still submit work. Non-submitting Codex input produces no newer hook, however, so the transition previously had no safe proof path and no bound.

Fixes #3718.

## How

- preserve the existing fresh-idle path
- for contradictory stale idle, wait for input to settle and require three consecutive adapter-confirmed idle samples
- give terminal capture and runtime liveness checks one cumulative five-second proof deadline
- fail with `DRAIN_QUIESCENCE_UNVERIFIED` while releasing the input gate and leaving the source controller untouched
- keep Active, WaitingInput, and Blocked drains unbounded and cancellable

The detector stays behind the existing port with a package-local test fake. The only configurable values are the three timings tests need to shorten. There are no frontend, API, storage, or adapter behavior changes.

Intentional omission: this PR adds no confirmation dialog or unsent-draft warning; draft policy is unchanged.

## Testing

- `npm run lint` — all Go tests pass; golangci-lint reports 0 issues
- `cd backend && go test -race ./internal/session_manager ./internal/adapters/agent/codex -count=1`
- `cd backend && go test ./internal/session_manager -run "TestInterfaceTransitionTUIToChat|TestTUIIdleAfterInput" -count=10`
- `git diff --check`
- GitHub CI — 8/8 checks pass, including `go test -race ./...`

## Checklist

- [x] Branched from `main`
- [x] One focused change; links #3718
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for the user-visible behavior and safety boundaries
- [x] Current CI rerun passes