### PR TITLE
feat: auto-grow chat composer

### DIFF
--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -29,6 +29,33 @@ const textFile = (name = "notes.txt") => new File(["hello"], name, { type: "text
 /* ---- the keyboard contract the composer already had ---------------------- */
 
 describe("send keys", () => {
+	it("grows with the draft, then scrolls after the seven-line cap", () => {
+		const { field } = renderComposer();
+		let scrollHeight = 112;
+		Object.defineProperty(field, "scrollHeight", {
+			configurable: true,
+			get: () => scrollHeight,
+		});
+		// JSDOM does not resolve Tailwind's generated max-height, so mirror the
+		// max-h-40 value inline while exercising the browser measurement path.
+		field.style.maxHeight = "160px";
+
+		fireEvent.change(field, { target: { value: "A prompt that wraps to a few lines" } });
+		expect(field.style.height).toBe("112px");
+		expect(field.style.overflowY).toBe("hidden");
+
+		scrollHeight = 240;
+		fireEvent.change(field, { target: { value: "A much longer prompt that exceeds seven lines" } });
+		expect(field.style.height).toBe("160px");
+		expect(field.style.overflowY).toBe("auto");
+
+		scrollHeight = 72;
+		fireEvent.change(field, { target: { value: "Short again" } });
+		expect(field.style.height).toBe("72px");
+		expect(field.style.overflowY).toBe("hidden");
+		expect(field).toHaveClass("chat-composer-scrollbar", "max-h-40");
+	});
+
 	it("separates secondary message tools from the primary send action", () => {
 		render(
 			<ChatComposer

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -75,6 +75,27 @@ function withAttachmentReferences(text: string, paths: string[]): string {
 		.join("\n")}`;
 }
 
+/**
+ * Match the field to its content until CSS's seven-line cap takes over.
+ *
+ * Resetting first is what lets a deleted draft shrink as well as grow. The cap
+ * remains in CSS so typography and spacing stay the source of truth; this helper
+ * only decides when the textarea needs its own scroll surface.
+ */
+function resizeTextareaToContent(node: HTMLTextAreaElement) {
+	node.style.height = "0px";
+	node.style.overflowY = "hidden";
+
+	const contentHeight = node.scrollHeight;
+	const maxHeight = Number.parseFloat(window.getComputedStyle(node).maxHeight);
+	const cappedHeight = Number.isFinite(maxHeight)
+		? Math.min(contentHeight, maxHeight)
+		: contentHeight;
+
+	node.style.height = `${cappedHeight}px`;
+	node.style.overflowY = contentHeight > cappedHeight ? "auto" : "hidden";
+}
+
 export function ChatComposer({
 	onSend,
 	busy,
@@ -153,6 +174,9 @@ export function ChatComposer({
 	const pendingCaret = useRef<number | null>(null);
 	const stagedDelivery = useRef<{ signature: string; paths: string[] } | null>(null);
 	const menuId = useId();
+	const resizeTextarea = useCallback(() => {
+		if (textarea.current) resizeTextareaToContent(textarea.current);
+	}, []);
 
 	const fileAttachments = useFileAttachments();
 	const canAttach = Boolean(onStageAttachments);
@@ -197,6 +221,25 @@ export function ChatComposer({
 		setText(next);
 		setCaret(nextCaret);
 	}, []);
+
+	useLayoutEffect(() => {
+		resizeTextarea();
+	}, [resizeTextarea, text]);
+
+	useEffect(() => {
+		const node = textarea.current;
+		if (!node || typeof ResizeObserver === "undefined") return;
+
+		let width = node.clientWidth;
+		const observer = new ResizeObserver(([entry]) => {
+			const nextWidth = entry?.contentRect.width ?? width;
+			if (nextWidth === width) return;
+			width = nextWidth;
+			resizeTextarea();
+		});
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, [resizeTextarea]);
 
 	useLayoutEffect(() => {
 		const target = pendingCaret.current;
@@ -459,7 +502,7 @@ export function ChatComposer({
 									? "Ask the agent…  /  for skills, @ for files"
 									: "Ask the agent…  @ for files"
 				}
-				className="max-h-48 min-h-[3.25rem] w-full resize-none bg-transparent px-1.5 py-1.5 text-sm leading-relaxed text-foreground outline-none placeholder:text-passive disabled:opacity-50"
+				className="chat-composer-scrollbar max-h-40 min-h-[3.25rem] w-full resize-none overflow-y-hidden overscroll-contain bg-transparent px-1.5 py-1.5 text-sm leading-relaxed text-foreground outline-none placeholder:text-passive disabled:opacity-50"
 			/>
 
 			{attachmentError ? (

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -75,27 +75,6 @@ function withAttachmentReferences(text: string, paths: string[]): string {
 		.join("\n")}`;
 }
 
-/**
- * Match the field to its content until CSS's seven-line cap takes over.
- *
- * Resetting first is what lets a deleted draft shrink as well as grow. The cap
- * remains in CSS so typography and spacing stay the source of truth; this helper
- * only decides when the textarea needs its own scroll surface.
- */
-function resizeTextareaToContent(node: HTMLTextAreaElement) {
-	node.style.height = "0px";
-	node.style.overflowY = "hidden";
-
-	const contentHeight = node.scrollHeight;
-	const maxHeight = Number.parseFloat(window.getComputedStyle(node).maxHeight);
-	const cappedHeight = Number.isFinite(maxHeight)
-		? Math.min(contentHeight, maxHeight)
-		: contentHeight;
-
-	node.style.height = `${cappedHeight}px`;
-	node.style.overflowY = contentHeight > cappedHeight ? "auto" : "hidden";
-}
-
 export function ChatComposer({
 	onSend,
 	busy,
@@ -174,8 +153,22 @@ export function ChatComposer({
 	const pendingCaret = useRef<number | null>(null);
 	const stagedDelivery = useRef<{ signature: string; paths: string[] } | null>(null);
 	const menuId = useId();
+	/** Match the field to its content until CSS's seven-line cap takes over. */
 	const resizeTextarea = useCallback(() => {
-		if (textarea.current) resizeTextareaToContent(textarea.current);
+		const node = textarea.current;
+		if (!node) return;
+		// Reset first so deleting a draft shrinks the field as well as growing it.
+		node.style.height = "0px";
+		node.style.overflowY = "hidden";
+
+		const contentHeight = node.scrollHeight;
+		const maxHeight = Number.parseFloat(window.getComputedStyle(node).maxHeight);
+		const cappedHeight = Number.isFinite(maxHeight)
+			? Math.min(contentHeight, maxHeight)
+			: contentHeight;
+
+		node.style.height = `${cappedHeight}px`;
+		node.style.overflowY = contentHeight > cappedHeight ? "auto" : "hidden";
 	}, []);
 
 	const fileAttachments = useFileAttachments();

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1596,6 +1596,41 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	box-shadow: var(--elevation-md);
 }
 
+/* The draft grows to seven lines before it becomes its own scroll surface. A
+   narrow inset thumb keeps long prompts legible without the platform scrollbar
+   competing with the composer controls. */
+.chat-composer-scrollbar {
+	scrollbar-width: thin;
+	scrollbar-color: var(--color-scrollbar-board) transparent;
+}
+
+.chat-composer-scrollbar::-webkit-scrollbar {
+	width: 8px;
+}
+
+.chat-composer-scrollbar::-webkit-scrollbar-button {
+	display: none;
+	width: 0;
+	height: 0;
+}
+
+.chat-composer-scrollbar::-webkit-scrollbar-track,
+.chat-composer-scrollbar::-webkit-scrollbar-corner {
+	background: transparent;
+}
+
+.chat-composer-scrollbar::-webkit-scrollbar-thumb {
+	border: 2px solid transparent;
+	border-radius: var(--radius-full);
+	background: var(--color-scrollbar-board);
+	background-clip: content-box;
+}
+
+.chat-composer-scrollbar::-webkit-scrollbar-thumb:hover {
+	background: var(--color-scrollbar-board-hover);
+	background-clip: content-box;
+}
+
 .cursor-chat-human-message {
 	background: color-mix(in srgb, var(--color-bg-elevated) 72%, var(--color-bg-secondary));
 	border-color: color-mix(in srgb, var(--color-border-strong) 85%, transparent);


### PR DESCRIPTION
## Summary

- Grow the chat draft from its compact minimum through seven visible lines, then enable internal scrolling.
- Shrink the textarea when content is removed and remeasure when the composer width changes.
- Replace the native scrollbar appearance with a slim, theme-aware rounded thumb.

## Testing

- npm test -- ChatComposer.test.tsx (36 passed)
- npm run typecheck
- Browser interaction check: 6 lines = 138px/hidden overflow, 7 lines = 159px/hidden overflow, 8 lines = 160px/auto overflow
- GitHub CI: Frontend test, renderer-smoke, and gitleaks passed

## Review

- Standards review found one one-off helper; the resize logic was inlined into its shared callback in dce632d09.
- Follow-up standards review found no remaining violations or code smells.
- Spec review found no missing behavior, incorrect behavior, or material scope creep.

## Known limitations

- Native Electron was not launched because another checkout owned the shared dev profile; the exact component was verified in an isolated browser preview.