### PR TITLE
fix(frontend): sync terminal colors with selected theme

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AttachableTerminal } from "../hooks/useTerminalSession";
+import { useUiStore } from "../stores/ui-store";
 import { XtermTerminal } from "./XtermTerminal";
 
 const state = vi.hoisted(() => ({
@@ -187,6 +188,42 @@ describe("XtermTerminal", () => {
 
 		expect(state.lastTerminal!.options.drawBoldTextInBrightColors).toBe(true);
 		expect(state.lastTerminal!.options.minimumContrastRatio).toBe(1);
+	});
+
+	it("updates the live terminal palette when the named color theme changes", () => {
+		const style = document.createElement("style");
+		style.textContent = `
+			:root {
+				--color-bg-terminal-opaque: #101317;
+				--color-text-terminal: #d7d7d2;
+				--color-working: #60a5fa;
+			}
+			:root[data-style-theme="github"] {
+				--background: #0d1117;
+				--foreground: #ccd3d8;
+				--primary: #58a6ff;
+			}
+		`;
+		document.head.appendChild(style);
+		delete document.documentElement.dataset.styleTheme;
+		useUiStore.setState({ themeStyle: "orchestrate" });
+
+		try {
+			render(<XtermTerminal theme="dark" />);
+			expect(state.lastTerminal!.options.theme).toMatchObject({ background: "#101317" });
+
+			act(() => useUiStore.getState().setThemeStyle("github"));
+
+			expect(state.lastTerminal!.options.theme).toMatchObject({
+				background: "#0d1117",
+				cursor: "#58a6ff",
+				foreground: "#ccd3d8",
+			});
+		} finally {
+			style.remove();
+			delete document.documentElement.dataset.styleTheme;
+			act(() => useUiStore.setState({ themeStyle: "orchestrate" }));
+		}
 	});
 
 	it("does not reserve width for the hidden terminal scrollbar", () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -35,9 +35,9 @@ import type {
 import { aoBridge } from "../lib/bridge";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
 import { openLinkInSystemBrowser } from "../lib/external-link-policy";
-import { applyDocumentTheme } from "../lib/theme";
+import { applyDocumentTheme, applyDocumentThemeStyle } from "../lib/theme";
 import { buildTerminalThemes } from "../lib/terminal-themes";
-import type { Theme } from "../stores/ui-store";
+import { useUiStore, type Theme } from "../stores/ui-store";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -260,6 +260,7 @@ function removeHiddenScrollbarReservation(term: Terminal): void {
 
 export function XtermTerminal(props: XtermTerminalProps) {
 	const { t } = useTranslation();
+	const themeStyle = useUiStore((state) => state.themeStyle);
 	const hostRef = useRef<HTMLDivElement | null>(null);
 	const termRef = useRef<Terminal | null>(null);
 	const fitRef = useRef<(() => void) | null>(null);
@@ -295,16 +296,17 @@ export function XtermTerminal(props: XtermTerminalProps) {
 	callbacksRef.current = props;
 
 	useEffect(() => {
+		// buildTerminalThemes() reads live CSS vars from :root. Parent shell effects
+		// run after child effects, so sync both independent theme axes here before
+		// reading. Retained terminals subscribe to themeStyle directly and update
+		// their live palette without being torn down or losing scrollback.
+		applyDocumentTheme(props.theme);
+		applyDocumentThemeStyle(themeStyle);
 		const term = termRef.current;
 		if (!term) return;
-		// buildTerminalThemes() reads live CSS vars from :root. Parent shell
-		// applies data-theme in its own effect, and child effects run first, so
-		// sync the document here before reading — otherwise the palette stays on
-		// the previous theme until remount.
-		applyDocumentTheme(props.theme);
 		const { dark, light } = buildTerminalThemes();
 		term.options.theme = props.theme === "dark" ? dark : light;
-	}, [props.theme]);
+	}, [props.theme, themeStyle]);
 
 	useEffect(() => {
 		const term = termRef.current;

--- a/frontend/src/renderer/lib/terminal-themes.ts
+++ b/frontend/src/renderer/lib/terminal-themes.ts
@@ -10,11 +10,16 @@ function cssVar(name: string): string {
 export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
 	// Opaque plate — xterm cells must not be translucent or the p-2 gutter and
 	// the glyph grid pick up different composites against app chrome.
-	const terminalBg = cssVar("--color-bg-terminal-opaque") || cssVar("--color-bg-terminal");
+	const namedThemeActive = typeof document !== "undefined" && Boolean(document.documentElement.dataset.styleTheme);
+	const terminalBg = namedThemeActive
+		? cssVar("--background")
+		: cssVar("--color-bg-terminal-opaque") || cssVar("--color-bg-terminal");
+	const terminalForeground = namedThemeActive ? cssVar("--foreground") : cssVar("--color-text-terminal");
+	const terminalCursor = namedThemeActive ? cssVar("--primary") : cssVar("--color-working");
 	const dark: ITheme = {
 		background: terminalBg,
-		foreground: cssVar("--color-text-terminal"),
-		cursor: cssVar("--color-working"),
+		foreground: terminalForeground,
+		cursor: terminalCursor,
 		cursorAccent: terminalBg,
 		selectionBackground: cssVar("--color-term-selection-dark"),
 		selectionInactiveBackground: cssVar("--color-term-selection-inactive"),
@@ -38,8 +43,8 @@ export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
 
 	const light: ITheme = {
 		background: terminalBg,
-		foreground: cssVar("--color-text-terminal"),
-		cursor: cssVar("--color-working"),
+		foreground: terminalForeground,
+		cursor: terminalCursor,
 		cursorAccent: terminalBg,
 		selectionBackground: cssVar("--color-term-selection-light"),
 		selectionInactiveBackground: cssVar("--color-term-selection-inactive-light"),

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -822,6 +822,17 @@
    Text chroma is capped so re-lighting cannot oversaturate a hue.
    ═══════════════════════════════════════════════════════════════ */
 
+/* A named palette owns the terminal's default plate and text as well as the
+   surrounding app chrome. ANSI slots stay independent because agent TUIs use
+   them semantically, but the formerly near-black terminal canvas now follows
+   each palette in both dark and light modes. */
+:root[data-style-theme] {
+	--color-bg-terminal-opaque: var(--background);
+	--color-bg-terminal: var(--background);
+	--color-text-terminal: var(--foreground);
+	--color-text-terminal-dim: var(--muted-foreground);
+}
+
 /* ── GitHub (Primer) ── */
 :root[data-style-theme="github"] {
 	/* Dark */


### PR DESCRIPTION
## Summary

- apply each named UI theme’s semantic background, foreground, and primary colors to live xterm terminals
- update retained terminal instances when either the color mode or named theme changes without losing scrollback
- preserve the existing ANSI palette while making the terminal canvas follow all named themes in light and dark modes

## Verification

- `npm test -- src/renderer/components/XtermTerminal.test.tsx` (48 passed)
- `npm run typecheck`
- manually verified in the Electron desktop app with Nord dark and Catppuccin dark/light themes

## Risk

- ANSI color slots intentionally remain terminal-specific for TUI readability; only the canvas, normal text, dim text, and cursor follow the selected application theme.