### PR TITLE
fix(frontend): prevent chat pane horizontal overflow

### DIFF
--- a/frontend/e2e/chat-scroll-overflow.spec.ts
+++ b/frontend/e2e/chat-scroll-overflow.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+import { installFakeAgent } from "./support/fake-bridge";
+
+const sessionId = "chat-scroll";
+const now = "2026-08-08T08:00:00Z";
+
+const turns = Array.from({ length: 3 }, (_, index) => ({
+	id: `turn-${index}`,
+	state: "completed",
+	requestedAt: now,
+	startedAt: now,
+	completedAt: now,
+}));
+
+const messages = turns.flatMap((turn, index) => [
+	{
+		kind: "message",
+		id: `user-${index}`,
+		turnId: turn.id,
+		sequence: index * 2 + 1,
+		revision: 0,
+		role: "user",
+		origin: "human",
+		text: `Investigate the chat scroll marker for turn ${index + 1}.`,
+		streaming: false,
+		createdAt: now,
+	},
+	{
+		kind: "message",
+		id: `assistant-${index}`,
+		turnId: turn.id,
+		sequence: index * 2 + 2,
+		revision: 0,
+		role: "assistant",
+		origin: "provider",
+		text: "The conversation needs enough durable history to make its minimap interactive. ".repeat(4),
+		streaming: false,
+		createdAt: now,
+	},
+]);
+
+test("chat minimap does not make the session pane scroll horizontally", async ({ page }) => {
+	await installFakeAgent(page, {
+		workers: [{ id: sessionId, title: "Debug chat scroll", mode: "chat" }],
+	});
+
+	await page.route(`**/api/v1/sessions/${sessionId}/**`, async (route) => {
+		const path = new URL(route.request().url()).pathname;
+		if (path.endsWith("/conversation")) {
+			await route.fulfill({
+				json: {
+					conversationId: "conversation-chat-scroll",
+					sessionId,
+					harness: "codex",
+					mode: "chat",
+					controller: "ready",
+					latestSequence: messages.length,
+					oldestSequence: 1,
+					hasMoreBefore: false,
+					turns,
+					messages,
+					activities: [],
+					settings: {},
+				},
+			});
+			return;
+		}
+		if (path.endsWith("/conversation/models")) {
+			await route.fulfill({ json: { models: [], selected: {} } });
+			return;
+		}
+		if (path.endsWith("/conversation/skills")) {
+			await route.fulfill({ json: { skills: [] } });
+			return;
+		}
+		if (path.endsWith("/workspace/files")) {
+			await route.fulfill({ json: { files: [], truncated: false } });
+			return;
+		}
+		if (path.endsWith("/interface-transition")) {
+			await route.fulfill({ json: { supported: true, targetMode: "tui" } });
+			return;
+		}
+		await route.fulfill({ status: 404, json: { error: { code: "NOT_FOUND", message: "not found" } } });
+	});
+
+	await page.goto(`/#/projects/fake-proj/sessions/${sessionId}`);
+	await expect(page.getByRole("log", { name: "Conversation" })).toBeVisible();
+
+	const marker = page.locator("[data-chat-scroll-marker]").first();
+	await expect(marker).toBeVisible();
+	await marker.hover();
+	const activeMarker = marker.locator(".chat-scroll-marker");
+	await expect(activeMarker).toHaveClass(/chat-scroll-marker-active/);
+	await expect.poll(() => activeMarker.evaluate((node) => node.getBoundingClientRect().width))
+		.toBeGreaterThan(27.5);
+
+	const pane = await page.locator("#terminal > div").evaluate((node) => ({
+		overflow: node.scrollWidth - node.clientWidth,
+		overflowX: getComputedStyle(node).overflowX,
+	}));
+	// Keep the assertion red-capable: the marker still crosses the pane edge, but
+	// the pane must clip that visual flourish instead of offering a native scrollbar.
+	expect(pane.overflow).toBeGreaterThan(0);
+	expect(pane.overflowX).toBe("hidden");
+});

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -213,6 +213,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 export type FakeWorker = {
 	id: string;
 	title: string;
+	mode?: "chat" | "tui";
 	provider?: string;
 	branch?: string;
 	status?: string;
@@ -287,6 +288,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				title: w.title,
 				provider: w.provider ?? "codex",
 				kind: "worker",
+				mode: w.mode ?? "tui",
 				branch: w.branch ?? `session/${w.id}`,
 				status: w.status ?? "working",
 				createdAt: nowIso,

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -572,7 +572,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			<ResizablePanelGroup className="session-split min-h-0 flex-1" id="session-workspace" orientation="horizontal">
 				{/* react-resizable-panels v4: bare numbers are PIXELS; percentages must
             be strings. Numeric sizes here once clamped the inspector to 45px. */}
-				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%">
+				{/* RRP's inner panel defaults to overflow:auto. Nothing scrolls at pane level,
+				    so clip the chat rail's active marker instead of creating a horizontal scrollbar. */}
+				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%" style={{ overflow: "hidden" }}>
 					<div className="relative h-full min-h-0">
 						{/* The committed mode owns the agent surface. Auxiliary shell and
 						    reviewer targets remain terminal surfaces in either mode. */}


### PR DESCRIPTION
## Summary

- clip the resizable session pane's inner overflow so the animated Chat minimap marker cannot create a native horizontal scrollbar
- add a Playwright regression that keeps the original 2px protrusion in the fixture while asserting the pane clips it
- allow fake E2E workers to opt into their committed Chat mode

## Root cause

react-resizable-panels v4 gives the inner panel wrapper overflow: auto. Hovering a Chat minimap entry expands its active marker to 28px, which crosses the pane edge by 2px. That raises the wrapper's scrollWidth and paints the horizontal scrollbar shown in the report.

The session pane itself has no scrolling responsibility, so it now clips overflow while the transcript remains the vertical scroll owner.

## Verification

- cd frontend && npm run typecheck
- cd frontend && npm run typecheck:e2e
- cd frontend && npm run test -- src/renderer/components/chat/ChatWorkspace.test.tsx src/renderer/components/chat/ChatMarkdown.test.tsx — 40 tests passed
- cd frontend && npx playwright test e2e/chat-scroll-overflow.spec.ts --repeat-each=3 — 3 runs passed
- verified in the real Electron desktop app on macOS using the normal ~/.ao/dev data/profile
