### PR TITLE
fix(chat): honor Codex configured effort default

### DIFF
--- a/backend/internal/adapters/chatdriver/codexappserver/conversation.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conversation.go
@@ -47,6 +47,8 @@ type conversation struct {
 
 	threadID string
 	events   chan ports.ChatEvent
+	// Effective defaults returned when Codex opened or resumed this thread.
+	threadModel, threadEffort string
 
 	mu      sync.Mutex
 	pending map[string]*parkedRequest
@@ -114,8 +116,10 @@ func newConversation(proc *process, log *slog.Logger) *conversation {
 // start records the opened thread and begins translating notifications. It is
 // called once, after the thread is open, so no event is emitted for a
 // conversation the caller does not yet have a handle to.
-func (c *conversation) start(threadID string) {
+func (c *conversation) start(threadID, model, effort string) {
 	c.threadID = threadID
+	c.threadModel = model
+	c.threadEffort = effort
 	go c.pump()
 }
 
@@ -340,6 +344,13 @@ func (c *conversation) ListModels(ctx context.Context) ([]ports.ChatModel, error
 			Efforts:       efforts,
 			DefaultEffort: entry.DefaultEff,
 		})
+	}
+	// Thread settings include the user's config; model/list only has generic defaults.
+	for i := range models {
+		if models[i].ID == c.threadModel && c.threadEffort != "" {
+			models[i].DefaultEffort = c.threadEffort
+			break
+		}
 	}
 	return models, nil
 }

--- a/backend/internal/adapters/chatdriver/codexappserver/driver.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver.go
@@ -262,6 +262,8 @@ func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.Ch
 		Thread struct {
 			ID string `json:"id"`
 		} `json:"thread"`
+		Model           string `json:"model"`
+		ReasoningEffort string `json:"reasoningEffort"`
 	}
 	openCtx, cancel := context.WithTimeout(ctx, handshakeTimeout)
 	defer cancel()
@@ -274,7 +276,7 @@ func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.Ch
 		return nil, errors.New("thread/start returned no thread id")
 	}
 
-	conv.start(resp.Thread.ID)
+	conv.start(resp.Thread.ID, resp.Model, resp.ReasoningEffort)
 	return conv, nil
 }
 
@@ -308,7 +310,11 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 	}
 	resumeCtx, cancel := context.WithTimeout(ctx, handshakeTimeout)
 	defer cancel()
-	err = conv.conn.request(resumeCtx, "thread/resume", params, nil)
+	var resp struct {
+		Model           string `json:"model"`
+		ReasoningEffort string `json:"reasoningEffort"`
+	}
+	err = conv.conn.request(resumeCtx, "thread/resume", params, &resp)
 	if err != nil {
 		_ = conv.Close()
 		// Deliberately not falling back to thread/start: silently opening a new
@@ -316,7 +322,7 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 		return nil, fmt.Errorf("%w: %w", ports.ErrChatResumeFailed, err)
 	}
 
-	conv.start(cfg.ProviderConversationID)
+	conv.start(cfg.ProviderConversationID, resp.Model, resp.ReasoningEffort)
 	return conv, nil
 }
 

--- a/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
@@ -791,14 +791,15 @@ func TestNoTurnSettingsSendsNoSettingsFields(t *testing.T) {
 	}
 }
 
-// The catalog is the provider's. Hidden models are dropped because the provider
-// marks them hidden when the account should not be offered them, and offering one
-// anyway is a choice that then fails.
-func TestListModelsDropsHiddenAndKeepsProviderOrder(t *testing.T) {
+// The catalog is the provider's. Hidden models are dropped because offering one
+// would fail, while the opened thread's effort is more specific than the generic
+// model default returned by model/list.
+func TestListModelsKeepsCatalogAndUsesThreadEffort(t *testing.T) {
 	d, srv := newTestDriver(t)
 	// Scripted before Start: the server goroutine reads this map, so writing it
 	// afterwards would race the connection it is already serving.
-	srv.reply("model/list", `{"data":[{"id":"a","displayName":"Model A","description":"first","isDefault":true,"hidden":false,"defaultReasoningEffort":"medium","supportedReasoningEfforts":[{"reasoningEffort":"low"},{"reasoningEffort":"high"}]},{"id":"secret","displayName":"Hidden","isDefault":false,"hidden":true,"defaultReasoningEffort":"low","supportedReasoningEfforts":[]},{"id":"b","displayName":"Model B","isDefault":false,"hidden":false,"defaultReasoningEffort":"low","supportedReasoningEfforts":[]}]}`)
+	srv.reply("thread/start", `{"thread":{"id":"thread-1"},"model":"a","reasoningEffort":"xhigh","cwd":"/tmp/ws"}`)
+	srv.reply("model/list", `{"data":[{"id":"a","displayName":"Model A","description":"first","isDefault":true,"hidden":false,"defaultReasoningEffort":"medium","supportedReasoningEfforts":[{"reasoningEffort":"low"},{"reasoningEffort":"xhigh"}]},{"id":"secret","displayName":"Hidden","isDefault":false,"hidden":true,"defaultReasoningEffort":"low","supportedReasoningEfforts":[]},{"id":"b","displayName":"Model B","isDefault":false,"hidden":false,"defaultReasoningEffort":"low","supportedReasoningEfforts":[]}]}`)
 
 	conv, err := d.Start(context.Background(), ports.ChatStartConfig{WorkspacePath: "/tmp/ws"})
 	if err != nil {
@@ -824,11 +825,11 @@ func TestListModelsDropsHiddenAndKeepsProviderOrder(t *testing.T) {
 	if !models[0].Default {
 		t.Error("the provider's default was not carried through")
 	}
-	if got := models[0].Efforts; len(got) != 2 || got[0] != "low" || got[1] != "high" {
-		t.Errorf("efforts = %v, want [low high]", got)
+	if got := models[0].Efforts; len(got) != 2 || got[0] != "low" || got[1] != "xhigh" {
+		t.Errorf("efforts = %v, want [low xhigh]", got)
 	}
-	if models[0].DefaultEffort != "medium" {
-		t.Errorf("default effort = %q, want medium", models[0].DefaultEffort)
+	if models[0].DefaultEffort != "xhigh" {
+		t.Errorf("default effort = %q, want the thread's xhigh", models[0].DefaultEffort)
 	}
 }
 


### PR DESCRIPTION
## Summary
- capture the effective model and reasoning effort returned when a Codex chat thread starts or resumes
- use that thread-specific effort for the matching model instead of the generic model catalog fallback
- keep the fix inside the Codex adapter without changing frontend, API, storage, or provider-neutral interfaces

## Why
Codex model/list reports the model-wide default effort (low), while thread/start and thread/resume report the effective value after applying the user configuration (for example, xhigh). AO discarded the latter, so Chat advertised low even when the thread opened at xhigh.

## Tests
- go test ./internal/adapters/chatdriver/codexappserver
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs
- Electron development build launched locally

## Risk
Low. The catalog remains unchanged except for DefaultEffort on the exact model Codex reports for the live thread. If Codex omits either value or the model is absent, existing behavior is preserved.