### PR TITLE
fix(browser): preserve cancel frames after delivered writes

### DIFF
--- a/backend/internal/browserruntime/broker.go
+++ b/backend/internal/browserruntime/broker.go
@@ -290,8 +290,10 @@ func (b *Broker) write(ctx context.Context, conn net.Conn, msg wireMessage) erro
 	if err := conn.SetWriteDeadline(deadline); err != nil {
 		return err
 	}
+	interruptDone := make(chan struct{})
 	stop := context.AfterFunc(ctx, func() {
 		_ = conn.SetWriteDeadline(time.Now())
+		close(interruptDone)
 	})
 	frame, err := json.Marshal(msg)
 	if err == nil && len(frame)+1 > maxRuntimeFrameBytes {
@@ -309,8 +311,17 @@ func (b *Broker) write(ctx context.Context, conn net.Conn, msg wireMessage) erro
 			frame = frame[written:]
 		}
 	}
-	stop()
+	writeComplete := err == nil && len(frame) == 0
+	if !stop() {
+		<-interruptDone
+	}
 	_ = conn.SetWriteDeadline(time.Time{})
+	// Once the complete frame reached the runtime, let Execute observe a
+	// simultaneous cancellation and send the matching cancel frame. Returning
+	// ctx.Err here would make the delivered command impossible to cancel.
+	if writeComplete {
+		return nil
+	}
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}

--- a/backend/internal/browserruntime/broker_test.go
+++ b/backend/internal/browserruntime/broker_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -200,41 +201,41 @@ func TestBrokerRejectsInvalidRuntimeToken(t *testing.T) {
 
 func TestBrokerCancellationSendsCancelFrame(t *testing.T) {
 	broker := New(nil)
-	ctx, stop := context.WithCancel(context.Background())
-	defer stop()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	go func() { _ = broker.Serve(ctx, ln) }()
-	conn, err := net.Dial("tcp", ln.Addr().String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = conn.Close() }()
-	enc, dec := json.NewEncoder(conn), json.NewDecoder(conn)
-	_ = enc.Encode(wireMessage{Type: "hello", Version: ProtocolVersion})
-	waitConnected(t, broker)
+	brokerConn, runtimeConn := net.Pipe()
+	pausedConn := newPauseAfterFirstWriteConn(brokerConn)
+	t.Cleanup(func() {
+		pausedConn.release()
+		_ = brokerConn.Close()
+		_ = runtimeConn.Close()
+	})
+	broker.mu.Lock()
+	broker.conn = pausedConn
+	broker.connectedAt = time.Now().UTC()
+	broker.mu.Unlock()
+	dec := json.NewDecoder(runtimeConn)
 
 	requestCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	errCh := make(chan error, 1)
 	go func() {
 		_, err := broker.Execute(requestCtx, "session-1", "wait", nil)
 		errCh <- err
 	}()
 	var command wireMessage
-	_ = conn.SetReadDeadline(time.Now().Add(browserRuntimeTestTimeout()))
+	_ = runtimeConn.SetReadDeadline(time.Now().Add(browserRuntimeTestTimeout()))
 	if err := dec.Decode(&command); err != nil {
 		t.Fatal(err)
 	}
+	<-pausedConn.firstWriteDone
 	waitPendingRequest(t, broker, command.RequestID)
 	cancel()
+	pausedConn.release()
 	var cancelMessage wireMessage
-	_ = conn.SetReadDeadline(time.Now().Add(browserRuntimeTestTimeout()))
+	_ = runtimeConn.SetReadDeadline(time.Now().Add(browserRuntimeTestTimeout()))
 	if err := dec.Decode(&cancelMessage); err != nil {
 		t.Fatal(err)
 	}
-	_ = conn.SetReadDeadline(time.Time{})
+	_ = runtimeConn.SetReadDeadline(time.Time{})
 	if cancelMessage.Type != "cancel" || cancelMessage.RequestID != command.RequestID {
 		t.Fatalf("cancel message = %#v, command = %#v", cancelMessage, command)
 	}
@@ -246,6 +247,35 @@ func TestBrokerCancellationSendsCancelFrame(t *testing.T) {
 	case <-time.After(browserRuntimeTestTimeout()):
 		t.Fatal("Execute did not return after request cancellation")
 	}
+}
+
+type pauseAfterFirstWriteConn struct {
+	net.Conn
+	firstWriteDone chan struct{}
+	releaseWrite   chan struct{}
+	pauseOnce      sync.Once
+	releaseOnce    sync.Once
+}
+
+func newPauseAfterFirstWriteConn(conn net.Conn) *pauseAfterFirstWriteConn {
+	return &pauseAfterFirstWriteConn{
+		Conn:           conn,
+		firstWriteDone: make(chan struct{}),
+		releaseWrite:   make(chan struct{}),
+	}
+}
+
+func (c *pauseAfterFirstWriteConn) Write(frame []byte) (int, error) {
+	written, err := c.Conn.Write(frame)
+	c.pauseOnce.Do(func() {
+		close(c.firstWriteDone)
+		<-c.releaseWrite
+	})
+	return written, err
+}
+
+func (c *pauseAfterFirstWriteConn) release() {
+	c.releaseOnce.Do(func() { close(c.releaseWrite) })
 }
 
 func TestBrokerWriteObservesContext(t *testing.T) {


### PR DESCRIPTION
Fixes #3732

## Summary

- preserve a successful browser-runtime write when request cancellation arrives after the complete command frame has been delivered
- wait for an already-started write-deadline interrupt before clearing the connection deadline
- make the cancel-frame regression deterministic by pausing immediately after the fake runtime receives the command bytes

## Root cause

`Broker.write` checked `ctx.Err()` after writing the complete command frame. If cancellation landed between delivery and the write returning, `Execute` treated the command as unsent and exited through its write-error path without emitting a cancel frame. The runtime could keep executing the browser command, and `TestBrokerCancellationSendsCancelFrame` intermittently timed out.

[PR #3727](https://github.com/Untrivial-ai/agent-orchestrator/pull/3727) did not introduce the bug; its [`main` Go run](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/31251765230) exposed the pre-existing race from the browser bridge.

## Test

```bash
cd backend
go test -race ./internal/browserruntime -run '^TestBrokerCancellationSendsCancelFrame$' -count=1000
go test -race ./internal/browserruntime -count=100
go build ./...
go vet ./...
go test -race -p 4 -count=1 ./...
cd ..
GOFLAGS=-p=4 npm run lint
```

## Risk

Low. The change is limited to the daemon's serialized browser-runtime write path. Incomplete writes retain the existing context/error behavior; only fully delivered frames are treated as successful so `Execute` can send their correlated cancellation.
