### PR TITLE
fix: align Chat recovery with TUI lifecycle

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -231,9 +231,10 @@ func Run() error {
 		Drivers: chatDrivers,
 		// The LCM satisfies ActivityRecorder directly: a chat turn is a pure
 		// lifecycle reduction, same as a hook signal from a terminal session.
-		Activity: lcStack.LCM,
-		Log:      log,
-		NewID:    uuid.NewString,
+		Activity:          lcStack.LCM,
+		Log:               log,
+		NewID:             uuid.NewString,
+		BackgroundContext: ctx,
 	})
 
 	sessionSvc, reviewSvc, sessMgr, err := startSession(ctx, cfg, runtimeAdapter, store, lcStack.LCM, messenger, telemetrySink, agents, managedPreview, browserBroker, browserAuthority, chatLauncher{svc: chatSvc}, settingsSvc, log)

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -441,17 +442,20 @@ func (c chatLauncher) StartChat(ctx context.Context, cfg sessionmanager.ChatStar
 		SystemPrompt:           cfg.SystemPrompt,
 		AdditionalDirectories:  cfg.AdditionalDirectories,
 		ProviderConversationID: cfg.ProviderConversationID,
-		ControllerReady: func(out chatsvc.StartResult) error {
+		ControllerReady: func(readyCtx context.Context, out chatsvc.StartResult) error {
 			if cfg.ControllerReady == nil {
 				return nil
 			}
-			return cfg.ControllerReady(sessionmanager.ChatStarted{
+			return cfg.ControllerReady(readyCtx, sessionmanager.ChatStarted{
 				ProviderConversationID: out.ProviderConversationID,
 				ControllerGeneration:   out.ControllerGeneration,
 			})
 		},
 	})
 	if err != nil {
+		if errors.Is(err, chatsvc.ErrControllerAlreadyLive) {
+			return sessionmanager.ChatStarted{}, sessionmanager.ErrAgentNotExited
+		}
 		return sessionmanager.ChatStarted{}, err
 	}
 	return sessionmanager.ChatStarted{
@@ -478,6 +482,10 @@ func (c chatLauncher) RelayChatTurnWithID(
 
 func (c chatLauncher) HasLiveChatController(id domain.SessionID) bool {
 	return c.svc.HasLiveChatController(id)
+}
+
+func (c chatLauncher) OwnsChatController(id domain.SessionID) bool {
+	return c.svc.OwnsChatController(id)
 }
 
 // PrepareChatHandoff closes Chat intake and waits for the controller to become

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -546,12 +546,12 @@ func isToolUseEvent(event string) bool {
 	return event == "pre-tool-use" || event == "post-tool-use" || event == "post-tool-use-failure"
 }
 
-// isTurnBoundaryEvent reports the events that reliably mean the pending
-// dialog is gone: a prompt cannot be submitted while a dialog holds the
-// composer, and a turn cannot end (or the session exit) with one on screen.
-func isTurnBoundaryEvent(event string) bool {
-	return event == "user-prompt-submit" || event == "stop" || event == "session-end" ||
-		event == "process-exited" || event == "chat.controller.stopped"
+// isTurnBoundarySignal reports signals that reliably mean the pending dialog is
+// gone. Exited is authoritative regardless of whether TUI's process supervisor,
+// Chat's controller stream, or another controller reported it.
+func isTurnBoundarySignal(s ports.ActivitySignal) bool {
+	return s.State == domain.ActivityExited || s.Event == "user-prompt-submit" ||
+		s.Event == "stop" || s.Event == "session-end" || s.Event == "process-exited"
 }
 
 // applyToolPrecedenceLocked folds an event-tagged activity signal through the
@@ -632,7 +632,7 @@ func (m *Manager) applyToolPrecedenceLocked(id domain.SessionID, cur domain.Acti
 		// Paused on a decision: only a turn boundary or the correlated post
 		// may change the state.
 		switch {
-		case isTurnBoundaryEvent(s.Event):
+		case isTurnBoundarySignal(s):
 			delete(m.flights, id)
 			return s
 		case (s.Event == "post-tool-use" || s.Event == "post-tool-use-failure") &&
@@ -656,7 +656,7 @@ func (m *Manager) applyToolPrecedenceLocked(id domain.SessionID, cur domain.Acti
 		return suppressed
 
 	default:
-		if isTurnBoundaryEvent(s.Event) {
+		if isTurnBoundarySignal(s) {
 			delete(m.flights, id)
 		}
 		return s

--- a/backend/internal/lifecycle/toolflight_test.go
+++ b/backend/internal/lifecycle/toolflight_test.go
@@ -106,7 +106,9 @@ func TestToolPrecedence_TurnBoundariesClearBlocked(t *testing.T) {
 		{"user-prompt-submit", sig(domain.ActivityActive, "user-prompt-submit", "", ""), domain.ActivityActive},
 		{"stop", sig(domain.ActivityIdle, "stop", "", ""), domain.ActivityIdle},
 		{"session-end", sig(domain.ActivityExited, "session-end", "", ""), domain.ActivityExited},
+		{"tui-process-exited", sig(domain.ActivityExited, "process-exited", "", ""), domain.ActivityExited},
 		{"chat-controller-stopped", sig(domain.ActivityExited, "chat.controller.stopped", "", ""), domain.ActivityExited},
+		{"other-controller-exited", sig(domain.ActivityExited, "controller.transport.closed", "", ""), domain.ActivityExited},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -167,6 +167,12 @@ type Controller struct {
 	stopped  chan struct{}
 	once     sync.Once
 	closeErr error
+	// activated gates live projection until Session Manager has durably committed
+	// this generation. It is Chat's equivalent of TUI lifecycle's pending-launch
+	// gate: the provider may exist first, but its signals cannot race MarkSpawned.
+	activated           chan struct{}
+	activateOnce        sync.Once
+	activationCommitted bool
 }
 
 // ErrNoActiveTurn reports an interrupt with nothing to cancel.
@@ -198,10 +204,11 @@ func newController(
 		log:          log,
 		newID:        newID,
 		now:          now,
-		state:        ports.ChatControllerReady,
+		state:        ports.ChatControllerConnecting,
 		settings:     conversation.Settings,
 		mcpServers:   map[string]domain.ConversationMCPServer{},
 		stopped:      make(chan struct{}),
+		activated:    make(chan struct{}),
 	}
 	// Seeded from the durable row so a reconnect merges onto what is already known
 	// rather than starting from blank and reporting a conversation as having no
@@ -227,9 +234,62 @@ func newController(
 // start begins live provider consumption after any durable native history has
 // been imported. Keeping construction and consumption separate prevents a resume
 // notification from racing ahead of the older turns it follows.
-func (c *Controller) start() {
-	go c.project()
-	go c.readRateLimits()
+func (c *Controller) start(ctx context.Context) {
+	go func() {
+		<-c.activated
+		if c.committedAfterActivation() {
+			c.project()
+			return
+		}
+		c.discardUncommittedEvents(ctx)
+	}()
+	go func() {
+		<-c.activated
+		if c.committedAfterActivation() {
+			c.readRateLimits()
+		}
+	}()
+}
+
+// releaseStart releases the projector after Session Manager either committed or
+// rejected this controller generation. Rejected generations drain provider
+// transport only; they never project transcript or lifecycle facts.
+func (c *Controller) releaseStart(committed bool) {
+	c.activateOnce.Do(func() {
+		c.mu.Lock()
+		c.activationCommitted = committed
+		if committed && c.state == ports.ChatControllerConnecting {
+			c.state = ports.ChatControllerReady
+		}
+		c.mu.Unlock()
+		close(c.activated)
+	})
+}
+
+func (c *Controller) committedAfterActivation() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.activationCommitted
+}
+
+func (c *Controller) discardUncommittedEvents(ctx context.Context) {
+	defer func() {
+		c.mu.Lock()
+		c.state = ports.ChatControllerStopped
+		c.mu.Unlock()
+		close(c.stopped)
+	}()
+	events := c.conv.Events()
+	for {
+		select {
+		case _, ok := <-events:
+			if !ok {
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // importNativeHistory projects the settled provider thread before live event
@@ -1155,6 +1215,10 @@ func (c *Controller) Close(ctx context.Context) error {
 	c.once.Do(func() {
 		c.closeErr = c.conv.Close()
 	})
+	// A launch can fail before activation. Closing the provider first and then
+	// releasing projection lets the goroutine observe the closed stream and
+	// finish cleanup without projecting pre-commit provider traffic.
+	c.releaseStart(false)
 	select {
 	case <-c.stopped:
 		return c.closeErr

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -104,6 +105,20 @@ type stuckConversation struct {
 }
 
 func (s *stuckConversation) Close() error { return s.closeErr }
+
+type claimFailStore struct {
+	chatsvc.Store
+	err error
+}
+
+func (s claimFailStore) ClaimChatControllerGeneration(
+	context.Context,
+	domain.SessionID,
+	string,
+	time.Time,
+) error {
+	return s.err
+}
 
 func (f *deferredConversation) StartDeferredTurn(providerTurnID string) error {
 	return f.start(providerTurnID)
@@ -996,9 +1011,20 @@ func TestControllerReadyRunsBeforeStreamProjection(t *testing.T) {
 	controller, err := svc.Start(context.Background(), chatsvc.StartConfig{
 		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
 		WorkspacePath: t.TempDir(),
-		ControllerReady: func(started chatsvc.StartResult) error {
+		ControllerReady: func(_ context.Context, started chatsvc.StartResult) error {
 			if signals := activity.snapshot(); len(signals) != 0 {
 				t.Fatalf("provider events projected before controller-ready commit: %+v", signals)
+			}
+			if !svc.HasLiveChatController(testSession) {
+				t.Fatal("controller ownership was not published before lifecycle commit")
+			}
+			if _, controllerErr := svc.Controller(testSession); !errors.Is(controllerErr, chatsvc.ErrControllerStarting) {
+				t.Fatalf("pre-commit controller error = %v, want ErrControllerStarting", controllerErr)
+			}
+			if _, sendErr := svc.Send(context.Background(), testSession, ports.ChatUserMessage{
+				Text: "must wait for commit",
+			}); !errors.Is(sendErr, chatsvc.ErrControllerStarting) {
+				t.Fatalf("pre-commit Send error = %v, want ErrControllerStarting", sendErr)
 			}
 			if started.ProviderConversationID == "" || started.ControllerGeneration == "" {
 				t.Fatalf("controller-ready result = %+v", started)
@@ -1020,6 +1046,119 @@ func TestControllerReadyRunsBeforeStreamProjection(t *testing.T) {
 		}
 	}
 	t.Fatalf("stream closure was not projected after controller-ready: %+v", activity.snapshot())
+}
+
+func TestStartRejectsAnAlreadyLiveController(t *testing.T) {
+	st := openStore(t)
+	first := newFakeConversation()
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers: fakeRegistry{driver: fakeDriver{conv: first}},
+		Log:     slog.New(slog.DiscardHandler),
+		NewID:   func() string { return "already-live-id" },
+	})
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+	cfg := chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	}
+	if _, err := svc.Start(context.Background(), cfg); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if _, err := svc.Start(context.Background(), cfg); !errors.Is(err, chatsvc.ErrControllerAlreadyLive) {
+		t.Fatalf("second Start error = %v, want ErrControllerAlreadyLive", err)
+	}
+}
+
+func TestControllerCommitFailureKeepsUnstoppedOwnershipVisible(t *testing.T) {
+	st := openStore(t)
+	base := newFakeConversation()
+	base.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnStarted, ProviderTurnID: "uncommitted-provider-turn",
+	})
+	stuck := &stuckConversation{fakeConversation: base, closeErr: errors.New("close failed")}
+	activity := &recordingActivity{}
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers:  fakeRegistry{driver: fakeDriver{conv: stuck}},
+		Activity: activity,
+		Log:      slog.New(slog.DiscardHandler),
+		NewID:    func() string { return "failed-commit-id" },
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	_, err := svc.Start(ctx, chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+		ControllerReady: func(context.Context, chatsvc.StartResult) error {
+			return errors.New("mark spawned failed")
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "mark spawned failed") ||
+		!strings.Contains(err.Error(), "close failed") {
+		t.Fatalf("Start error = %v, want commit and close failures", err)
+	}
+	if !svc.HasLiveChatController(testSession) {
+		t.Fatal("failed close hid controller ownership and made workspace teardown unsafe")
+	}
+	if !svc.OwnsChatController(testSession) {
+		t.Fatal("failed close released registry ownership before the stream ended")
+	}
+
+	base.closeOnce.Do(func() { close(base.events) })
+	deadline := time.Now().Add(time.Second)
+	for svc.OwnsChatController(testSession) && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if svc.OwnsChatController(testSession) {
+		t.Fatal("controller ownership remained after its stream finally closed")
+	}
+	if signals := activity.snapshot(); len(signals) != 0 {
+		t.Fatalf("uncommitted provider events reached lifecycle projection: %+v", signals)
+	}
+}
+
+func TestGenerationClaimFailureKeepsUnstoppedOwnershipVisible(t *testing.T) {
+	st := openStore(t)
+	base := newFakeConversation()
+	stuck := &stuckConversation{fakeConversation: base, closeErr: errors.New("close failed")}
+	claimErr := errors.New("claim generation failed")
+	svc := chatsvc.New(chatsvc.Options{
+		Store:    claimFailStore{Store: st, err: claimErr},
+		Sessions: st,
+		Drivers:  fakeRegistry{driver: fakeDriver{conv: stuck}},
+		Log:      slog.New(slog.DiscardHandler),
+		NewID:    func() string { return "failed-claim-id" },
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	_, err := svc.Start(ctx, chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	})
+	if !errors.Is(err, claimErr) || !strings.Contains(err.Error(), "close failed") {
+		t.Fatalf("Start error = %v, want claim and close failures", err)
+	}
+	if !svc.OwnsChatController(testSession) {
+		t.Fatal("post-provider claim failure hid controller ownership")
+	}
+	if _, secondErr := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	}); !errors.Is(secondErr, chatsvc.ErrControllerAlreadyLive) {
+		t.Fatalf("retry error = %v, want ErrControllerAlreadyLive", secondErr)
+	}
+
+	base.closeOnce.Do(func() { close(base.events) })
+	deadline := time.Now().Add(time.Second)
+	for svc.OwnsChatController(testSession) && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if svc.OwnsChatController(testSession) {
+		t.Fatal("failed-claim controller ownership remained after stream closure")
+	}
 }
 
 // Dispatch reads the persisted mode. A TUI session must be refused even if a
@@ -1333,6 +1472,9 @@ func TestStartWaitsForStoppedControllerCleanupBeforeRelaunch(t *testing.T) {
 	}
 	if svc.HasLiveChatController(testSession) {
 		t.Fatal("stopped controller reported live")
+	}
+	if !svc.OwnsChatController(testSession) {
+		t.Fatal("stopped state released ownership before the provider stream ended")
 	}
 
 	replacementWorkspace := t.TempDir()

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -18,6 +18,16 @@ import (
 // or its controller may have stopped, and the client needs to tell those apart.
 var ErrNoController = errors.New("no live chat controller for session")
 
+// ErrControllerAlreadyLive reports a second launch request while this daemon
+// still owns the session's controller. Recovery must never turn that into a
+// successful no-op because Session Manager needs to preserve one-writer errors.
+var ErrControllerAlreadyLive = errors.New("chat controller is already live")
+
+// ErrControllerStarting reports a command that arrived before Session Manager
+// committed the controller generation. It retains ErrNoController's API mapping
+// while allowing lifecycle coordination to distinguish a launch in progress.
+var ErrControllerStarting = fmt.Errorf("%w: controller is starting", ErrNoController)
+
 // ErrNotChatMode reports a Chat command against a session whose committed
 // controller is currently TUI. An explicit interface transition may change that
 // fact later, but callers must route from the persisted mode they read now.
@@ -41,6 +51,9 @@ type Service struct {
 	log        *slog.Logger
 	newID      IDFactory
 	now        Clock
+	// backgroundContext is canceled with the daemon, not with the HTTP request
+	// that happened to launch a controller.
+	backgroundContext context.Context
 
 	mu          sync.RWMutex
 	controllers map[domain.SessionID]*Controller
@@ -77,6 +90,9 @@ type Options struct {
 	Log      *slog.Logger
 	NewID    IDFactory
 	Now      Clock
+	// BackgroundContext owns controller cleanup that must outlive the launch
+	// request. It defaults to context.Background for focused tests.
+	BackgroundContext context.Context
 }
 
 // New builds a Chat service.
@@ -89,18 +105,23 @@ func New(opts Options) *Service {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
+	backgroundContext := opts.BackgroundContext
+	if backgroundContext == nil {
+		backgroundContext = context.Background()
+	}
 	return &Service{
-		store:       opts.Store,
-		reader:      opts.Reader,
-		pageReader:  opts.PageReader,
-		sessions:    opts.Sessions,
-		drivers:     opts.Drivers,
-		activity:    opts.Activity,
-		log:         log,
-		newID:       opts.NewID,
-		now:         now,
-		controllers: make(map[domain.SessionID]*Controller),
-		gates:       make(map[domain.SessionID]controllerGate),
+		store:             opts.Store,
+		reader:            opts.Reader,
+		pageReader:        opts.PageReader,
+		sessions:          opts.Sessions,
+		drivers:           opts.Drivers,
+		activity:          opts.Activity,
+		log:               log,
+		newID:             opts.NewID,
+		now:               now,
+		backgroundContext: backgroundContext,
+		controllers:       make(map[domain.SessionID]*Controller),
+		gates:             make(map[domain.SessionID]controllerGate),
 	}
 }
 
@@ -135,7 +156,7 @@ type StartConfig struct {
 	// consumption starts. A controller that exits immediately must report after
 	// the launch has been marked live, so its exited signal cannot be overwritten
 	// by a later launch-completion write.
-	ControllerReady func(StartResult) error
+	ControllerReady func(context.Context, StartResult) error
 }
 
 func controllerStartResult(controller *Controller) StartResult {
@@ -143,16 +164,6 @@ func controllerStartResult(controller *Controller) StartResult {
 		ProviderConversationID: controller.ProviderConversationID(),
 		ControllerGeneration:   controller.Generation(),
 	}
-}
-
-func notifyControllerReady(cfg StartConfig, controller *Controller) error {
-	if cfg.ControllerReady == nil {
-		return nil
-	}
-	if err := cfg.ControllerReady(controllerStartResult(controller)); err != nil {
-		return fmt.Errorf("commit chat controller: %w", err)
-	}
-	return nil
 }
 
 // settleOrphanedWork closes out anything a previous controller left behind.
@@ -192,7 +203,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	s.mu.RUnlock()
 	if existing != nil {
 		if existing.State() != ports.ChatControllerStopped {
-			return existing, nil
+			return nil, ErrControllerAlreadyLive
 		}
 		// A stopped event can reach the UI before the projector finishes its final
 		// durable cleanup and the registry goroutine releases the entry. Never hand
@@ -263,13 +274,39 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 		return nil, err
 	}
 
+	// Publish ownership immediately after the provider exists. Every later step
+	// is fallible; retaining this connecting controller is how a failed close
+	// prevents retry or workspace teardown from creating a second writer.
+	generation := s.newID()
+	controller := newController(
+		cfg.SessionID, conversation, generation, conv, s.store, s.activity, s.log, s.newID, s.now)
+	s.mu.Lock()
+	s.controllers[cfg.SessionID] = controller
+	controller.start(s.backgroundContext)
+	s.mu.Unlock()
+
+	// Drop the registry entry only when the provider stream really ends.
+	go func() {
+		controller.Wait()
+		s.mu.Lock()
+		if current, ok := s.controllers[cfg.SessionID]; ok && current == controller {
+			delete(s.controllers, cfg.SessionID)
+		}
+		s.mu.Unlock()
+	}()
+	abortUncommitted := func(startErr error) error {
+		if closeErr := controller.Close(ctx); closeErr != nil {
+			return errors.Join(startErr,
+				fmt.Errorf("close uncommitted chat controller: %w", closeErr))
+		}
+		return startErr
+	}
+
 	// Claim the durable fence before the controller starts consuming events. An
 	// older controller's projection transaction compares its generation with this
 	// session row and becomes a no-op after this point.
-	generation := s.newID()
 	if err := s.store.ClaimChatControllerGeneration(ctx, cfg.SessionID, generation, s.now()); err != nil {
-		_ = conv.Close()
-		return nil, fmt.Errorf("claim chat controller: %w", err)
+		return nil, abortUncommitted(fmt.Errorf("claim chat controller: %w", err))
 	}
 
 	// Whatever the previous controller left in flight is not this controller's, and
@@ -289,8 +326,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 			"reason": "native conversation was unavailable",
 		})
 		if marshalErr != nil {
-			_ = conv.Close()
-			return nil, fmt.Errorf("encode fresh context boundary: %w", marshalErr)
+			return nil, abortUncommitted(fmt.Errorf("encode fresh context boundary: %w", marshalErr))
 		}
 		if boundaryErr := s.store.UpsertActivity(ctx, conversation.ID, "", domain.ConversationActivity{
 			ID:             s.newID(),
@@ -300,15 +336,10 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 			Detail:         detail,
 			ProviderItemID: "ao-context-reset:" + string(cfg.SessionID),
 		}, s.now()); boundaryErr != nil {
-			_ = conv.Close()
-			return nil, fmt.Errorf("record fresh context boundary: %w", boundaryErr)
+			return nil, abortUncommitted(fmt.Errorf("record fresh context boundary: %w", boundaryErr))
 		}
 	}
 
-	// A fresh generation per launch, so events from the controller this one
-	// replaced can be told apart from the current one's.
-	controller := newController(
-		cfg.SessionID, conversation, generation, conv, s.store, s.activity, s.log, s.newID, s.now)
 	if cfg.ProviderConversationID != "" {
 		// The provider's native thread is the continuity authority across TUI and
 		// Chat. Import it before the live projector starts so the first notification
@@ -323,60 +354,63 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 		if s.reader != nil {
 			existing, err = s.reader.LoadConversationSnapshot(ctx, conversation.ID)
 			if err != nil {
-				_ = conv.Close()
-				return nil, fmt.Errorf("load conversation before native history import: %w", err)
+				return nil, abortUncommitted(fmt.Errorf("load conversation before native history import: %w", err))
 			}
 		}
 		if err := controller.importNativeHistory(
 			ctx, existing.Turns, existing.Messages, existing.Activities,
 		); err != nil {
-			_ = conv.Close()
-			return nil, err
+			return nil, abortUncommitted(err)
 		}
 	}
-	if err := notifyControllerReady(cfg, controller); err != nil {
-		_ = conv.Close()
-		return nil, err
-	}
-	s.mu.Lock()
-	s.controllers[cfg.SessionID] = controller
-	controller.start()
-	s.mu.Unlock()
 
-	// Drop the registry entry when the provider stream ends, so a later command
-	// reports ErrNoController instead of writing into a dead controller.
-	go func() {
-		controller.Wait()
-		s.mu.Lock()
-		if current, ok := s.controllers[cfg.SessionID]; ok && current == controller {
-			delete(s.controllers, cfg.SessionID)
+	if cfg.ControllerReady != nil {
+		if err := cfg.ControllerReady(ctx, controllerStartResult(controller)); err != nil {
+			commitErr := fmt.Errorf("commit chat controller: %w", err)
+			return nil, abortUncommitted(commitErr)
 		}
-		s.mu.Unlock()
-	}()
+	}
+	controller.releaseStart(true)
 
 	return controller, nil
 }
 
 // Controller returns a session's live controller.
 func (s *Service) Controller(sessionID domain.SessionID) (*Controller, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	controller, ok := s.controllers[sessionID]
-	if !ok {
+	controller := s.ownedController(sessionID)
+	if controller == nil {
 		return nil, ErrNoController
+	}
+	state := controller.State()
+	if state == ports.ChatControllerStopped {
+		return nil, ErrNoController
+	}
+	if state == ports.ChatControllerConnecting {
+		return nil, ErrControllerStarting
 	}
 	return controller, nil
 }
 
-// HasLiveChatController reports whether the service owns a controller that can
-// still process provider events. A stopped controller can remain in the registry
-// briefly while its final cleanup lands; Start waits for that cleanup before
-// replacing it rather than treating the dead entry as a successful resume.
-func (s *Service) HasLiveChatController(sessionID domain.SessionID) bool {
+func (s *Service) ownedController(sessionID domain.SessionID) *Controller {
 	s.mu.RLock()
-	controller := s.controllers[sessionID]
-	s.mu.RUnlock()
+	defer s.mu.RUnlock()
+	return s.controllers[sessionID]
+}
+
+// HasLiveChatController reports whether the service owns a starting or active
+// controller whose state has not reached stopped. A stopped controller can
+// remain in the registry briefly while final cleanup lands; Start waits for that
+// cleanup before replacing it rather than returning the dead entry.
+func (s *Service) HasLiveChatController(sessionID domain.SessionID) bool {
+	controller := s.ownedController(sessionID)
 	return controller != nil && controller.State() != ports.ChatControllerStopped
+}
+
+// OwnsChatController reports registry ownership, including a stopped controller
+// whose provider stream or final cleanup has not completed. Workspace teardown
+// requires this stronger fact; reported state alone is not proof the owner left.
+func (s *Service) OwnsChatController(sessionID domain.SessionID) bool {
+	return s.ownedController(sessionID) != nil
 }
 
 // requireChatSession reads the persisted mode and refuses anything that is not a
@@ -468,6 +502,9 @@ func (s *Service) PrepareChatHandoff(
 	policy domain.SessionInterfaceTransitionPolicy,
 ) error {
 	controller, err := s.Controller(id)
+	if errors.Is(err, ErrControllerStarting) {
+		return err
+	}
 	if errors.Is(err, ErrNoController) {
 		// A dead/missing source controller is already quiescent. Session Manager
 		// can safely stop (a no-op) and resume the native conversation in TUI,
@@ -626,7 +663,7 @@ func (s *Service) Snapshot(ctx context.Context, id domain.SessionID) (Snapshot, 
 
 	state := ports.ChatControllerStopped
 	var caps ports.ChatCapabilities
-	if controller, err := s.Controller(id); err == nil {
+	if controller := s.ownedController(id); controller != nil {
 		state = controller.State()
 		caps = controller.Capabilities()
 	}
@@ -676,7 +713,7 @@ func (s *Service) SnapshotPage(ctx context.Context, id domain.SessionID, beforeS
 	}
 	state := ports.ChatControllerStopped
 	var caps ports.ChatCapabilities
-	if controller, err := s.Controller(id); err == nil {
+	if controller := s.ownedController(id); controller != nil {
 		state = controller.State()
 		caps = controller.Capabilities()
 	}
@@ -776,7 +813,7 @@ type StartRequest struct {
 	ProviderConversationID string
 	// ControllerReady runs after the provider and generation exist but before
 	// live event projection starts.
-	ControllerReady func(StartResult) error
+	ControllerReady func(context.Context, StartResult) error
 }
 
 // StartResult is the durable outcome of a launch.

--- a/backend/internal/session_manager/chat_spawn.go
+++ b/backend/internal/session_manager/chat_spawn.go
@@ -2,6 +2,7 @@ package sessionmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -47,6 +48,9 @@ type ChatLauncher interface {
 	// for the session. Resume uses this to distinguish a stale durable activity
 	// state left by an older daemon from a genuinely live controller.
 	HasLiveChatController(id domain.SessionID) bool
+	// OwnsChatController includes a stopped controller whose event stream has not
+	// finished. Rollback must preserve its workspace until ownership is released.
+	OwnsChatController(id domain.SessionID) bool
 	// StopChat releases a session's controller.
 	StopChat(ctx context.Context, id domain.SessionID) error
 }
@@ -74,7 +78,7 @@ type ChatStart struct {
 	// ControllerReady commits the durable controller facts before the provider
 	// event stream is consumed. This prevents an immediate exit from racing a
 	// later MarkSpawned write back to idle.
-	ControllerReady func(ChatStarted) error
+	ControllerReady func(context.Context, ChatStarted) error
 }
 
 // ChatStarted is the durable result of a launch.
@@ -118,7 +122,7 @@ func (m *Manager) launchChatController(ctx context.Context, in chatSpawn) (domai
 
 	var (
 		controllerCommitted bool
-		completionErr       error
+		markSpawnedErr      error
 	)
 	_, err := m.chat.StartChat(ctx, ChatStart{
 		SessionID:             id,
@@ -132,7 +136,7 @@ func (m *Manager) launchChatController(ctx context.Context, in chatSpawn) (domai
 		Permissions:           agentConfig.Permissions,
 		SystemPrompt:          in.systemPrompt,
 		AdditionalDirectories: workspaceProjectDirectories(in.workspace.Path, in.workspaceProject),
-		ControllerReady: func(started ChatStarted) error {
+		ControllerReady: func(readyCtx context.Context, started ChatStarted) error {
 			metadata := domain.SessionMetadata{
 				Branch:            in.workspace.Branch,
 				WorkspacePath:     in.workspace.Path,
@@ -146,20 +150,26 @@ func (m *Manager) launchChatController(ctx context.Context, in chatSpawn) (domai
 				ProviderConversationID: started.ProviderConversationID,
 				ControllerGeneration:   started.ControllerGeneration,
 			}
-			completionErr = m.lcm.MarkSpawned(ctx, id, metadata)
-			controllerCommitted = completionErr == nil
-			return completionErr
+			markSpawnedErr = m.lcm.MarkSpawned(readyCtx, id, metadata)
+			controllerCommitted = markSpawnedErr == nil
+			return markSpawnedErr
 		},
 	})
 	if err != nil {
-		if completionErr != nil || controllerCommitted {
-			m.stopChatBestEffort(ctx, id)
-			m.rollbackPreparedSpawnWorkspace(ctx, in.record, in.workspace, in.workspaceProject, true)
+		// Provider startup has fallible work before ControllerReady (generation
+		// claim, context-boundary persistence, native-history import). Consult
+		// actual ownership as well as callback state: a close timeout in any of
+		// those steps must preserve the workspace for the remaining controller.
+		if markSpawnedErr != nil || controllerCommitted || m.chat.OwnsChatController(id) {
+			controllerStopped, stopErr := m.stopChatAndConfirm(ctx, id)
+			m.rollbackChatSpawnWorkspace(ctx, in, controllerStopped)
 			m.markSpawnFailedTerminated(ctx, id)
-			if completionErr != nil {
-				return domain.SessionRecord{}, fmt.Errorf("spawn %s: completed: %w", id, completionErr)
+			if markSpawnedErr != nil {
+				return domain.SessionRecord{}, fmt.Errorf("spawn %s: completed: %w", id,
+					errors.Join(markSpawnedErr, stopErr))
 			}
-			return domain.SessionRecord{}, fmt.Errorf("spawn %s: chat controller: %w", id, err)
+			return domain.SessionRecord{}, fmt.Errorf("spawn %s: chat controller: %w", id,
+				errors.Join(err, stopErr))
 		}
 		// No controller exists, so nothing provider-side needs closing. The
 		// runtime was never touched, hence runtimeDestroyed=false.
@@ -172,26 +182,41 @@ func (m *Manager) launchChatController(ctx context.Context, in chatSpawn) (domai
 	// provider either accepts the turn or reports why.
 	if in.prompt != "" {
 		if _, err := m.chat.StartChatTurn(ctx, id, in.prompt); err != nil {
-			m.stopChatBestEffort(ctx, id)
-			m.rollbackPreparedSpawnWorkspace(ctx, in.record, in.workspace, in.workspaceProject, true)
+			controllerStopped, stopErr := m.stopChatAndConfirm(ctx, id)
+			m.rollbackChatSpawnWorkspace(ctx, in, controllerStopped)
 			m.markSpawnFailedTerminated(ctx, id)
-			return domain.SessionRecord{}, fmt.Errorf("spawn %s: deliver prompt: %w", id, err)
+			return domain.SessionRecord{}, fmt.Errorf("spawn %s: deliver prompt: %w", id,
+				errors.Join(err, stopErr))
 		}
 	}
 
 	return m.getRecord(ctx, id)
 }
 
-// stopChatBestEffort closes a controller during rollback. A failure here is
-// logged rather than returned: the spawn is already failing, and the caller's
-// error is the one worth surfacing.
-func (m *Manager) stopChatBestEffort(ctx context.Context, id domain.SessionID) {
+// stopChatAndConfirm reports whether the controller released registry ownership.
+// Reported stopped state alone is insufficient: its stream may still be holding
+// the workspace while final cleanup runs.
+func (m *Manager) stopChatAndConfirm(ctx context.Context, id domain.SessionID) (bool, error) {
 	if m.chat == nil {
+		return true, nil
+	}
+	err := m.chat.StopChat(ctx, id)
+	stopped := !m.chat.OwnsChatController(id)
+	if !stopped && err == nil {
+		err = errors.New("chat controller remained live after close")
+	}
+	if err != nil {
+		m.logger.Warn("close chat controller", "sessionID", id, "error", err)
+	}
+	return stopped, err
+}
+
+func (m *Manager) rollbackChatSpawnWorkspace(ctx context.Context, in chatSpawn, controllerStopped bool) {
+	if !controllerStopped {
+		m.preserveFailedSpawnWorkspace(ctx, in.record.ID, in.workspace, false)
 		return
 	}
-	if err := m.chat.StopChat(ctx, id); err != nil {
-		m.logger.Warn("spawn rollback: close chat controller", "sessionID", id, "error", err)
-	}
+	m.rollbackPreparedSpawnWorkspace(ctx, in.record, in.workspace, in.workspaceProject, true)
 }
 
 // sendChat routes an outbound message into a chat session's conversation.
@@ -218,6 +243,9 @@ func (m *Manager) sendChat(ctx context.Context, id domain.SessionID, message, cl
 	}
 	if rec.IsTerminated {
 		return true, fmt.Errorf("send %s: %w", id, ErrTerminated)
+	}
+	if rec.Activity.State == domain.ActivityExited {
+		return true, fmt.Errorf("send %s: %w", id, ErrAgentExited)
 	}
 	var relayErr error
 	if clientMessageID != "" {
@@ -286,7 +314,7 @@ func (m *Manager) resumeChatController(
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("%s %s: workspace roots: %w", operation, rec.ID, err)
 	}
-	var completionErr error
+	var markSpawnedErr error
 	_, err = m.chat.StartChat(ctx, ChatStart{
 		SessionID:             rec.ID,
 		ProjectID:             rec.ProjectID,
@@ -301,7 +329,7 @@ func (m *Manager) resumeChatController(
 		AdditionalDirectories: additionalDirectories,
 		// The handle that makes this a resume rather than a new conversation.
 		ProviderConversationID: rec.Metadata.ProviderConversationID,
-		ControllerReady: func(started ChatStarted) error {
+		ControllerReady: func(readyCtx context.Context, started ChatStarted) error {
 			metadata := rec.Metadata
 			metadata.WorkspacePath = ws.Path
 			metadata.WorkspaceRepoPath = ws.RepoPath
@@ -313,14 +341,15 @@ func (m *Manager) resumeChatController(
 			// controller this one replaced carry the old one and are rejected.
 			metadata.ControllerGeneration = started.ControllerGeneration
 
-			completionErr = m.lcm.MarkSpawned(ctx, rec.ID, metadata)
-			return completionErr
+			markSpawnedErr = m.lcm.MarkSpawned(readyCtx, rec.ID, metadata)
+			return markSpawnedErr
 		},
 	})
 	if err != nil {
-		if completionErr != nil {
-			m.stopChatBestEffort(ctx, rec.ID)
-			return RestoreResult{}, fmt.Errorf("%s %s: completed: %w", operation, rec.ID, completionErr)
+		if markSpawnedErr != nil {
+			_, stopErr := m.stopChatAndConfirm(ctx, rec.ID)
+			return RestoreResult{}, fmt.Errorf("%s %s: completed: %w", operation, rec.ID,
+				errors.Join(markSpawnedErr, stopErr))
 		}
 		return RestoreResult{}, fmt.Errorf("%s %s: resume chat: %w", operation, rec.ID, err)
 	}

--- a/backend/internal/session_manager/chat_spawn_test.go
+++ b/backend/internal/session_manager/chat_spawn_test.go
@@ -40,6 +40,7 @@ type recordingLauncher struct {
 	preflightErr error
 	startErr     error
 	turnErr      error
+	stopErr      error
 	live         bool
 	afterReady   func()
 
@@ -57,7 +58,7 @@ func (l *recordingLauncher) PreflightChat(_ context.Context, harness domain.Agen
 	return l.preflightErr
 }
 
-func (l *recordingLauncher) StartChat(_ context.Context, cfg ChatStart) (ChatStarted, error) {
+func (l *recordingLauncher) StartChat(ctx context.Context, cfg ChatStart) (ChatStarted, error) {
 	l.started = append(l.started, cfg)
 	if l.startErr != nil {
 		return ChatStarted{}, l.startErr
@@ -67,7 +68,7 @@ func (l *recordingLauncher) StartChat(_ context.Context, cfg ChatStart) (ChatSta
 		ControllerGeneration:   "gen-1",
 	}
 	if cfg.ControllerReady != nil {
-		if err := cfg.ControllerReady(started); err != nil {
+		if err := cfg.ControllerReady(ctx, started); err != nil {
 			return ChatStarted{}, err
 		}
 	}
@@ -95,10 +96,14 @@ func (l *recordingLauncher) RelayChatTurnWithID(_ context.Context, _ domain.Sess
 func (l *recordingLauncher) StopChat(_ context.Context, id domain.SessionID) error { //nolint:unparam
 
 	l.stopped = append(l.stopped, id)
-	return nil
+	return l.stopErr
 }
 
 func (l *recordingLauncher) HasLiveChatController(domain.SessionID) bool {
+	return l.live
+}
+
+func (l *recordingLauncher) OwnsChatController(domain.SessionID) bool {
 	return l.live
 }
 
@@ -138,6 +143,37 @@ func TestResumeExitedChatSessionDoesNotRequireTerminalRuntimeHandle(t *testing.T
 	}
 	if result.Session.Activity.State != domain.ActivityIdle {
 		t.Fatalf("resumed activity = %q, want idle", result.Session.Activity.State)
+	}
+}
+
+func TestResumeChatStartFailureLeavesSessionExitedLikeTUI(t *testing.T) {
+	launcher := &recordingLauncher{startErr: errors.New("app-server exited")}
+	mgr, store, runtime := newChatManager(launcher)
+	seedChatResumeSession(store, domain.ActivityExited)
+	before := store.sessions["mer-1"]
+
+	if _, err := mgr.ResumeAgentWithMode(context.Background(), "mer-1"); err == nil {
+		t.Fatal("expected failed controller start to fail resume")
+	}
+	if got := store.sessions["mer-1"]; got != before {
+		t.Fatalf("failed Chat resume changed durable session: got %+v, want %+v", got, before)
+	}
+	if runtime.created != 0 || runtime.destroyed != 0 {
+		t.Fatalf("failed Chat resume touched terminal runtime: created=%d destroyed=%d",
+			runtime.created, runtime.destroyed)
+	}
+}
+
+func TestSendRejectsExitedChatWhileReplacementIsStarting(t *testing.T) {
+	launcher := &recordingLauncher{live: true}
+	mgr, store, _ := newChatManager(launcher)
+	seedChatResumeSession(store, domain.ActivityExited)
+
+	if err := mgr.Send(context.Background(), "mer-1", "do not deliver yet"); !errors.Is(err, ErrAgentExited) {
+		t.Fatalf("Send error = %v, want ErrAgentExited", err)
+	}
+	if len(launcher.relayed) != 0 {
+		t.Fatalf("exited Chat session relayed messages before commit: %v", launcher.relayed)
 	}
 }
 
@@ -244,6 +280,22 @@ func TestRestoreChatSessionRequiresProviderConversation(t *testing.T) {
 	}
 	if len(launcher.started) != 0 {
 		t.Fatalf("missing provider handle started %d controllers", len(launcher.started))
+	}
+}
+
+func TestRestoreChatSessionRejectsLiveControllerLikeTUI(t *testing.T) {
+	launcher := &recordingLauncher{live: true}
+	mgr, store, _ := newChatManager(launcher)
+	seedChatResumeSession(store, domain.ActivityExited)
+	rec := store.sessions["mer-1"]
+	rec.IsTerminated = true
+	store.sessions["mer-1"] = rec
+
+	if _, err := mgr.RestoreWithMode(context.Background(), "mer-1"); !errors.Is(err, ErrNotRestorable) {
+		t.Fatalf("RestoreWithMode error = %v, want ErrNotRestorable", err)
+	}
+	if len(launcher.started) != 0 {
+		t.Fatalf("live controller restore started %d replacement controllers", len(launcher.started))
 	}
 }
 
@@ -418,6 +470,67 @@ func TestChatSpawnRollsBackWhenControllerFailsToStart(t *testing.T) {
 	}
 }
 
+func TestChatSpawnPreservesWorkspaceWhenControllerCannotStop(t *testing.T) {
+	launcher := &recordingLauncher{
+		turnErr: errors.New("initial turn failed"),
+		stopErr: errors.New("controller close timed out"),
+		live:    true,
+	}
+	mgr, store, _ := newChatManager(launcher)
+
+	_, _, _, err := mgr.Spawn(context.Background(), ports.SpawnConfig{
+		ProjectID:     chatTestProject,
+		Kind:          domain.KindWorker,
+		Harness:       domain.HarnessCodex,
+		Prompt:        "do the thing",
+		RequestedMode: domain.SessionModeChat,
+	})
+	if err == nil || !errors.Is(err, launcher.stopErr) {
+		t.Fatalf("Spawn error = %v, want controller close failure", err)
+	}
+	workspace := mgr.workspace.(*fakeWorkspace)
+	if workspace.destroyed != 0 {
+		t.Fatalf("live controller's workspace was destroyed %d times", workspace.destroyed)
+	}
+	sessions, listErr := store.ListAllSessions(context.Background())
+	if listErr != nil || len(sessions) != 1 {
+		t.Fatalf("sessions after failed spawn = %+v, err=%v", sessions, listErr)
+	}
+	if !sessions[0].IsTerminated || sessions[0].Metadata.WorkspacePath == "" {
+		t.Fatalf("failed spawn did not preserve recoverable workspace facts: %+v", sessions[0])
+	}
+}
+
+func TestChatSpawnPreservesWorkspaceWhenPreCommitControllerCannotStop(t *testing.T) {
+	launcher := &recordingLauncher{
+		startErr: errors.New("generation claim failed"),
+		stopErr:  errors.New("controller close timed out"),
+		live:     true,
+	}
+	mgr, store, _ := newChatManager(launcher)
+
+	_, _, _, err := mgr.Spawn(context.Background(), ports.SpawnConfig{
+		ProjectID:     chatTestProject,
+		Kind:          domain.KindWorker,
+		Harness:       domain.HarnessCodex,
+		RequestedMode: domain.SessionModeChat,
+	})
+	if err == nil || !errors.Is(err, launcher.startErr) || !errors.Is(err, launcher.stopErr) {
+		t.Fatalf("Spawn error = %v, want start and controller close failures", err)
+	}
+	workspace := mgr.workspace.(*fakeWorkspace)
+	if workspace.destroyed != 0 {
+		t.Fatalf("pre-commit controller's workspace was destroyed %d times", workspace.destroyed)
+	}
+	sessions, listErr := store.ListAllSessions(context.Background())
+	if listErr != nil || len(sessions) != 1 {
+		t.Fatalf("sessions after failed spawn = %+v, err=%v", sessions, listErr)
+	}
+	if !sessions[0].IsTerminated || sessions[0].Metadata.WorkspacePath == "" {
+		t.Fatalf("failed pre-commit spawn did not preserve workspace facts: %+v", sessions[0])
+	}
+}
+
 // Kill must close the controller, not tear down a runtime the session never had.
 // A chat controller owns an app-server child process, so skipping this leaks it.
 func TestKillClosesTheChatControllerAndTouchesNoRuntime(t *testing.T) {
@@ -443,6 +556,35 @@ func TestKillClosesTheChatControllerAndTouchesNoRuntime(t *testing.T) {
 	}
 	if runtime.destroyed != 0 {
 		t.Errorf("kill destroyed %d runtimes for a session that never had one", runtime.destroyed)
+	}
+}
+
+func TestKillChatCloseFailureLeavesSessionAndWorkspaceLiveLikeTUI(t *testing.T) {
+	launcher := &recordingLauncher{
+		stopErr: errors.New("controller close timed out"),
+		live:    true,
+	}
+	mgr, store, _ := newChatManager(launcher)
+	ctx := context.Background()
+
+	rec, _, _, err := mgr.Spawn(ctx, ports.SpawnConfig{
+		ProjectID:     chatTestProject,
+		Kind:          domain.KindWorker,
+		Harness:       domain.HarnessCodex,
+		RequestedMode: domain.SessionModeChat,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if _, err := mgr.Kill(ctx, rec.ID); !errors.Is(err, launcher.stopErr) {
+		t.Fatalf("Kill error = %v, want controller close failure", err)
+	}
+	if got := store.sessions[rec.ID]; got.IsTerminated {
+		t.Fatalf("failed controller close terminated session: %+v", got)
+	}
+	workspace := mgr.workspace.(*fakeWorkspace)
+	if workspace.destroyed != 0 {
+		t.Fatalf("failed controller close destroyed workspace %d times", workspace.destroyed)
 	}
 }
 

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -275,12 +275,12 @@ func (c *transitionChat) PreflightChat(ctx context.Context, _ domain.AgentHarnes
 	}
 	return c.preflightErr
 }
-func (c *transitionChat) StartChat(_ context.Context, cfg ChatStart) (ChatStarted, error) {
+func (c *transitionChat) StartChat(ctx context.Context, cfg ChatStart) (ChatStarted, error) {
 	c.start = cfg
 	*c.log = append(*c.log, "start:chat")
 	started := ChatStarted{ProviderConversationID: cfg.ProviderConversationID, ControllerGeneration: "chat-generation"}
 	if cfg.ControllerReady != nil {
-		if err := cfg.ControllerReady(started); err != nil {
+		if err := cfg.ControllerReady(ctx, started); err != nil {
 			return ChatStarted{}, err
 		}
 	}
@@ -300,6 +300,7 @@ func (c *transitionChat) RelayChatTurnWithID(_ context.Context, _ domain.Session
 	return "", nil
 }
 func (*transitionChat) HasLiveChatController(domain.SessionID) bool { return false }
+func (*transitionChat) OwnsChatController(domain.SessionID) bool    { return false }
 func (c *transitionChat) StopChat(_ context.Context, _ domain.SessionID) error {
 	*c.log = append(*c.log, "stop:chat")
 	return nil

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1126,7 +1126,9 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	// process, and closing it also settles any turn left in flight so a later
 	// read does not show work that is no longer running.
 	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
-		m.stopChatBestEffort(ctx, id)
+		if _, err := m.stopChatAndConfirm(ctx, id); err != nil {
+			return false, fmt.Errorf("kill %s: chat controller: %w", id, err)
+		}
 	} else if handle.ID != "" {
 		if err := m.runtime.Destroy(ctx, handle); err != nil {
 			return false, fmt.Errorf("kill %s: runtime: %w", id, err)
@@ -1366,6 +1368,13 @@ func (m *Manager) RestoreWithMode(ctx context.Context, id domain.SessionID) (Res
 		return RestoreResult{}, fmt.Errorf("restore %s: %w", id, ErrNotFound)
 	}
 	if !rec.IsTerminated {
+		return RestoreResult{}, fmt.Errorf("restore %s: %w", id, ErrNotRestorable)
+	}
+	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat &&
+		m.chat != nil && m.chat.OwnsChatController(id) {
+		// Match TUI restore's one-controller invariant. A terminated durable row
+		// is not enough to prove a Chat controller is gone while this daemon still
+		// owns one, so never turn restore into a second writer.
 		return RestoreResult{}, fmt.Errorf("restore %s: %w", id, ErrNotRestorable)
 	}
 	meta := rec.Metadata


### PR DESCRIPTION
## What

- make Chat controller startup follow TUI's prepare/start/commit/release ordering
- publish connecting-controller ownership before any fallible post-provider work, while gating provider event projection until `MarkSpawned` commits the generation
- distinguish controller liveness from registry ownership so stopped or failed-to-close controllers still prevent duplicate recovery and workspace teardown
- treat every authoritative `ActivityExited` signal as a lifecycle turn boundary, independent of whether TUI or Chat reported it
- align Chat kill, restore, resume, and failed-spawn cleanup with TUI's one-controller and workspace-safety rules

Follow-up to #3711. Fixes parity and rollback gaps found while comparing that recovery path directly with TUI lifecycle behavior. Relates to #3710.

## TUI parity

| Lifecycle invariant | TUI | Chat after this change |
| --- | --- | --- |
| One controller owns the session | runtime handle and launch generation | controller registry owner and controller generation |
| Signals cannot beat durable launch commit | pending-launch gate | connecting controller plus activation gate |
| Durable launch completion | `MarkSpawned` records runtime metadata | `ControllerReady` calls the same `MarkSpawned` with provider metadata |
| Authoritative death signal | process supervisor/reaper emits `ActivityExited` | provider event-stream closure emits `ActivityExited` |
| Failed stop protects workspace | runtime destroy must succeed before teardown | registry ownership must be released before teardown |
| Duplicate recovery is rejected | live runtime/generation guard | live or cleanup-owning controller guard |

The mechanisms remain adapter-specific: TUI has a terminal runtime and reaper; Chat has a provider process, conversation ID, controller registry, and event stream. The durable lifecycle ordering and safety invariants are now shared.

## Behavior covered

- a provider event emitted immediately at startup cannot overwrite or precede `MarkSpawned`
- commands cannot reach a connecting, uncommitted controller
- an uncommitted generation's buffered provider events are discarded
- a generation-claim or lifecycle-commit failure retains ownership if provider close times out
- a second start/restore cannot create another provider writer while ownership remains
- failed spawn or kill cannot destroy a workspace still owned by a provider
- stream closure clears blocked state through generic exited semantics
- stale pre-#3711 Chat rows remain recoverable when no controller owner exists

## Testing

- `GOFLAGS=-p=1 npm run lint` — pass, 0 issues
- `cd backend && go build ./...` — pass
- `cd backend && go test -race -p 1 ./internal/service/chat ./internal/lifecycle ./internal/session_manager ./internal/daemon` — pass
- `git diff --check origin/main...HEAD` — pass

## Checklist

- [x] Based on current `main`
- [x] Focused follow-up to #3711
- [x] Regression tests cover lifecycle ordering, duplicate ownership, failed cleanup, and workspace preservation
- [x] No frontend or API contract changes
