### PR TITLE
fix: recover Codex interface switch readiness

### DIFF
--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -117,7 +117,9 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	appendHideRateLimitNudgeFlag(&cmd)
 	appendHookTrustBypassFlag(&cmd)
 	appendApprovalFlags(&cmd, cfg.Permissions)
-	appendSessionHookFlags(&cmd)
+	if err := appendSessionHookFlags(&cmd); err != nil {
+		return nil, err
+	}
 	appendTerminalCompatibilityFlags(&cmd)
 	appendWorkspaceTrustFlag(&cmd, cfg.WorkspacePath)
 	appendModelFlag(&cmd, cfg.Config)
@@ -159,7 +161,9 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	appendHideRateLimitNudgeFlag(&cmd)
 	appendHookTrustBypassFlag(&cmd)
 	appendApprovalFlags(&cmd, cfg.Permissions)
-	appendSessionHookFlags(&cmd)
+	if err := appendSessionHookFlags(&cmd); err != nil {
+		return nil, false, err
+	}
 	appendTerminalCompatibilityFlags(&cmd)
 	appendWorkspaceTrustFlag(&cmd, cfg.Session.WorkspacePath)
 	appendModelFlag(&cmd, cfg.Config)
@@ -450,7 +454,12 @@ func DoctorLaunchProbes() [][]string {
 	overrideProbe := []string{"features", "list"}
 	appendNoUpdateCheckFlag(&overrideProbe)
 	appendHideRateLimitNudgeFlag(&overrideProbe)
-	appendSessionHookFlags(&overrideProbe)
+	if err := appendSessionHookFlags(&overrideProbe); err != nil {
+		// The probe only asks Codex to parse the hook config; a bare fallback
+		// keeps that diagnostic available if the current executable cannot be
+		// resolved, while real session launches fail closed above.
+		appendSessionHookFlagsForExecutable(&overrideProbe, "ao")
+	}
 	appendWorkspaceTrustFlag(&overrideProbe, os.TempDir())
 	return [][]string{flagProbe, overrideProbe}
 }

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -9,6 +9,7 @@ package codex
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
@@ -66,6 +69,7 @@ var _ ports.Agent = (*Plugin)(nil)
 var _ ports.ActiveTurnSteerer = (*Plugin)(nil)
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
 var _ ports.AgentInterfaceHandoff = (*Plugin)(nil)
+var _ ports.AgentInterfaceHandoffHistoryProbe = (*Plugin)(nil)
 var _ ports.TerminalActivityDetector = (*Plugin)(nil)
 
 // Manifest returns the adapter's static self-description.
@@ -196,6 +200,87 @@ func (p *Plugin) NativeConversationID(
 	}
 	id := strings.TrimSpace(session.Metadata[ports.MetadataKeyAgentSessionID])
 	return id, id != "", nil
+}
+
+// NativeConversationExists distinguishes a Codex thread UUID from a thread
+// that app-server can actually resume. Codex returns the UUID from thread/start
+// before the first user message materializes a rollout; thread/resume rejects
+// that reserved-only UUID with "no rollout found for thread id".
+//
+// Active rollouts live below CODEX_HOME/sessions. Archived rollouts are
+// deliberately excluded because Codex also rejects them from thread/resume.
+// We only establish that a non-empty rollout exists; Codex remains responsible
+// for parsing its own provider state.
+func (p *Plugin) NativeConversationExists(
+	ctx context.Context,
+	_ ports.SessionRef,
+	nativeConversationID string,
+	env map[string]string,
+) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	id, valid := canonicalCodexThreadID(nativeConversationID)
+	if !valid {
+		return false, nil
+	}
+	codexHome := strings.TrimSpace(env["CODEX_HOME"])
+	if codexHome == "" {
+		codexHome = strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	}
+	if codexHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return false, fmt.Errorf("codex: resolve rollout root: %w", err)
+		}
+		codexHome = filepath.Join(home, ".codex")
+	}
+
+	found := false
+	sessionsDir := filepath.Join(codexHome, "sessions")
+	err := filepath.WalkDir(sessionsDir, func(_ string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() || !codexRolloutNameMatches(entry.Name(), id) {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() && info.Size() > 0 {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("codex: inspect rollout root %s: %w", sessionsDir, err)
+	}
+	return found, nil
+}
+
+func canonicalCodexThreadID(value string) (string, bool) {
+	parsed, err := uuid.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return "", false
+	}
+	return parsed.String(), true
+}
+
+func codexRolloutNameMatches(name, nativeConversationID string) bool {
+	if !strings.HasPrefix(name, "rollout-") {
+		return false
+	}
+	suffix := "-" + nativeConversationID + ".jsonl"
+	return strings.HasSuffix(name, suffix) || strings.HasSuffix(name, suffix+".zst")
 }
 
 // AuthStatus checks Codex's local login state without making a model call.

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -35,6 +35,67 @@ func TestNativeConversationIDRequiresCapturedCodexThreadForTUI(t *testing.T) {
 	}
 }
 
+func TestNativeConversationExistsRequiresActivePersistedCodexRollout(t *testing.T) {
+	p := &Plugin{}
+	id := "019fc430-1234-7abc-8def-0123456789ab"
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", t.TempDir())
+	env := map[string]string{"CODEX_HOME": codexHome}
+
+	exists, err := p.NativeConversationExists(context.Background(), ports.SessionRef{}, id, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("reserved Codex thread without a rollout reported as persisted")
+	}
+
+	activeDir := filepath.Join(codexHome, "sessions", "2026", "08", "08")
+	if err := os.MkdirAll(activeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rollout := filepath.Join(activeDir, "rollout-2026-08-08T10-00-00-"+id+".jsonl")
+	if err := os.WriteFile(rollout, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exists, err = p.NativeConversationExists(context.Background(), ports.SessionRef{}, id, env)
+	if err != nil || exists {
+		t.Fatalf("empty rollout: exists=%v err=%v", exists, err)
+	}
+	if err := os.WriteFile(rollout, []byte("{\"type\":\"session_meta\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exists, err = p.NativeConversationExists(context.Background(), ports.SessionRef{}, id, env)
+	if err != nil || !exists {
+		t.Fatalf("active rollout: exists=%v err=%v", exists, err)
+	}
+
+	if err := os.Remove(rollout); err != nil {
+		t.Fatal(err)
+	}
+	archivedDir := filepath.Join(codexHome, "archived_sessions")
+	if err := os.MkdirAll(archivedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	archived := filepath.Join(archivedDir, "rollout-2026-08-08T10-00-00-"+id+".jsonl")
+	if err := os.WriteFile(archived, []byte("{\"type\":\"session_meta\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exists, err = p.NativeConversationExists(context.Background(), ports.SessionRef{}, id, env)
+	if err != nil || exists {
+		t.Fatalf("archived rollout: exists=%v err=%v", exists, err)
+	}
+
+	compressed := rollout + ".zst"
+	if err := os.WriteFile(compressed, []byte("compressed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exists, err = p.NativeConversationExists(context.Background(), ports.SessionRef{}, id, env)
+	if err != nil || !exists {
+		t.Fatalf("compressed active rollout: exists=%v err=%v", exists, err)
+	}
+}
+
 // canonicalTempDir returns a t.TempDir() with symlinks resolved so the
 // workspace trust flag collapses to a single predictable entry (macOS TempDir
 // lives under a /var -> /private/var symlink).

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -114,13 +114,31 @@ func canonicalTempDir(t *testing.T) string {
 
 // sessionHookFlags mirrors the `-c` hook config appendSessionHookFlags emits,
 // asserted literally so accidental format drift fails loudly: Codex parses
-// these values as TOML.
-func sessionHookFlags() []string {
+// these values as TOML. The absolute AO executable is load-bearing because
+// Codex invokes hooks through a login shell, which may replace PATH.
+func sessionHookFlags(t *testing.T) []string {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(executable) {
+		executable, err = filepath.Abs(executable)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if runtime.GOOS == "windows" {
+		executable = `"` + executable + `"`
+	} else {
+		executable = `'` + strings.ReplaceAll(executable, `'`, `'"'"'`) + `'`
+	}
+	prefix := executable + " hooks codex "
 	return []string{
-		"-c", `hooks.SessionStart=[{hooks=[{type="command",command="ao hooks codex session-start",timeout=5}]}]`,
-		"-c", `hooks.UserPromptSubmit=[{hooks=[{type="command",command="ao hooks codex user-prompt-submit",timeout=5}]}]`,
-		"-c", `hooks.PermissionRequest=[{hooks=[{type="command",command="ao hooks codex permission-request",timeout=5}]}]`,
-		"-c", `hooks.Stop=[{hooks=[{type="command",command="ao hooks codex stop",timeout=5}]}]`,
+		"-c", `hooks.SessionStart=[{hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"session-start") + `,timeout=5}]}]`,
+		"-c", `hooks.UserPromptSubmit=[{hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"user-prompt-submit") + `,timeout=5}]}]`,
+		"-c", `hooks.PermissionRequest=[{hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"permission-request") + `,timeout=5}]}]`,
+		"-c", `hooks.Stop=[{hooks=[{type="command",command=` + codexTOMLBasicString(prefix+"stop") + `,timeout=5}]}]`,
 	}
 }
 
@@ -153,7 +171,7 @@ func TestGetLaunchCommandBuildsCrossPlatformArgv(t *testing.T) {
 		"--dangerously-bypass-hook-trust",
 		"--dangerously-bypass-approvals-and-sandbox",
 	}
-	want = append(want, sessionHookFlags()...)
+	want = append(want, sessionHookFlags(t)...)
 	if runtime.GOOS == "windows" {
 		want = append(want, "--no-alt-screen")
 	}
@@ -179,7 +197,7 @@ func TestGetLaunchCommandWithoutWorkspaceOmitsTrustFlag(t *testing.T) {
 			t.Fatalf("command %#v contains a projects trust flag without a workspace", cmd)
 		}
 	}
-	if !containsSubsequence(cmd, sessionHookFlags()) {
+	if !containsSubsequence(cmd, sessionHookFlags(t)) {
 		t.Fatalf("command %#v missing session hook flags", cmd)
 	}
 }
@@ -624,7 +642,7 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 		"--ask-for-approval", "on-request",
 		"-c", `approvals_reviewer="auto_review"`,
 	}
-	want = append(want, sessionHookFlags()...)
+	want = append(want, sessionHookFlags(t)...)
 	if runtime.GOOS == "windows" {
 		want = append(want, "--no-alt-screen")
 	}

--- a/backend/internal/adapters/agent/codex/hooks.go
+++ b/backend/internal/adapters/agent/codex/hooks.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
@@ -74,13 +75,39 @@ var codexManagedHooks = []codexHookSpec{
 }
 
 // appendSessionHookFlags adds AO's activity hooks to the argv as `-c`
-// session-flag config, one flag per managed event.
-func appendSessionHookFlags(cmd *[]string) {
+// session-flag config, one flag per managed event. Codex executes command
+// hooks through a login shell, which may replace PATH, so every hook invokes
+// this exact AO executable instead of relying on a bare `ao` lookup.
+func appendSessionHookFlags(cmd *[]string) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve AO hook executable: %w", err)
+	}
+	if !filepath.IsAbs(executable) {
+		executable, err = filepath.Abs(executable)
+		if err != nil {
+			return fmt.Errorf("make AO hook executable absolute: %w", err)
+		}
+	}
+	appendSessionHookFlagsForExecutable(cmd, executable)
+	return nil
+}
+
+func appendSessionHookFlagsForExecutable(cmd *[]string, executable string) {
+	prefix := shellQuoteHookExecutable(executable) + " hooks codex "
 	for _, spec := range codexManagedHooks {
+		action := strings.TrimPrefix(spec.Command, codexHookCommandPrefix)
 		flag := fmt.Sprintf(`hooks.%s=[{hooks=[{type="command",command=%s,timeout=%d}]}]`,
-			spec.Event, codexTOMLBasicString(spec.Command), codexHookTimeout)
+			spec.Event, codexTOMLBasicString(prefix+action), codexHookTimeout)
 		*cmd = append(*cmd, "-c", flag)
 	}
+}
+
+func shellQuoteHookExecutable(executable string) string {
+	if runtime.GOOS == "windows" {
+		return `"` + executable + `"`
+	}
+	return `'` + strings.ReplaceAll(executable, `'`, `'"'"'`) + `'`
 }
 
 // appendWorkspaceTrustFlag marks the session's worktree as a trusted Codex

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	codexagent "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -770,6 +773,70 @@ func TestInterfaceTransitionTUIToChatStartsFreshWhenReservedIDHasNoHistory(t *te
 	}
 	if got := fmt.Sprint(*log); got != "[stop:tui:runtime-1 start:chat]" {
 		t.Fatalf("controller order = %s", got)
+	}
+}
+
+func TestInterfaceTransitionTUIToChatStartsFreshWhenCodexRolloutIsMissing(t *testing.T) {
+	manager, store, _, chat, _ := newTransitionManager(t, domain.SessionModeTUI)
+	t.Setenv("CODEX_HOME", t.TempDir())
+	manager.agents = singleAgent{agent: codexagent.New()}
+	rec := store.sessions["session-1"]
+	rec.Harness = domain.HarnessCodex
+	rec.Metadata.AgentSessionID = "019fc430-1234-7abc-8def-0123456789ab"
+	store.sessions["session-1"] = rec
+
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("phase = %s, error = %s", settled.Phase, settled.ErrorDetail)
+	}
+	if settled.NativeConversationID != "" {
+		t.Fatalf("native conversation = %q, want fresh sentinel", settled.NativeConversationID)
+	}
+	if chat.start.ProviderConversationID != "" {
+		t.Fatalf("Chat resumed missing Codex rollout %q, want a fresh conversation",
+			chat.start.ProviderConversationID)
+	}
+}
+
+func TestInterfaceTransitionTUIToChatReusesPersistedCodexRollout(t *testing.T) {
+	manager, store, _, chat, _ := newTransitionManager(t, domain.SessionModeTUI)
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	manager.agents = singleAgent{agent: codexagent.New()}
+	id := "019fc430-1234-7abc-8def-0123456789ab"
+	rec := store.sessions["session-1"]
+	rec.Harness = domain.HarnessCodex
+	rec.Metadata.AgentSessionID = id
+	store.sessions["session-1"] = rec
+	rolloutDir := filepath.Join(codexHome, "sessions", "2026", "08", "08")
+	if err := os.MkdirAll(rolloutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rollout := filepath.Join(rolloutDir, "rollout-2026-08-08T10-00-00-"+id+".jsonl")
+	if err := os.WriteFile(rollout, []byte("{\"type\":\"session_meta\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("phase = %s, error = %s", settled.Phase, settled.ErrorDetail)
+	}
+	if settled.NativeConversationID != id {
+		t.Fatalf("native conversation = %q, want %q", settled.NativeConversationID, id)
+	}
+	if chat.start.ProviderConversationID != id {
+		t.Fatalf("Chat resumed %q, want persisted Codex rollout %q",
+			chat.start.ProviderConversationID, id)
 	}
 }
 

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getMock } = vi.hoisted(() => ({ getMock: vi.fn() }));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { GET: getMock, POST: vi.fn(), DELETE: vi.fn() },
+	apiErrorMessage: () => "request failed",
+	hasTrustedApiBaseUrl: () => true,
+}));
+
+import { useSessionInterfaceTransition } from "./useSessionInterfaceTransition";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+	getMock.mockReset();
+});
+
+describe("interface switch readiness", () => {
+	it("rechecks a missing native session until the switch becomes supported", async () => {
+		getMock
+			.mockResolvedValueOnce({
+				data: {
+					supported: false,
+					targetMode: "chat",
+					reasonCode: "NATIVE_SESSION_MISSING",
+					reason: "no native conversation found for codex",
+				},
+				error: undefined,
+			})
+			.mockResolvedValue({
+				data: { supported: true, targetMode: "chat" },
+				error: undefined,
+			});
+
+		const { result } = renderHook(() => useSessionInterfaceTransition("session-1"), {
+			wrapper,
+		});
+
+		await waitFor(() => expect(result.current.status?.supported).toBe(false));
+		await waitFor(() => expect(result.current.status?.supported).toBe(true), {
+			timeout: 2_500,
+		});
+		expect(getMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not poll a permanently unsupported interface handoff", async () => {
+		getMock.mockResolvedValue({
+			data: {
+				supported: false,
+				targetMode: "chat",
+				reasonCode: "INTERFACE_HANDOFF_UNSUPPORTED",
+				reason: "cursor has not declared compatible TUI and Chat identities",
+			},
+			error: undefined,
+		});
+
+		const { result } = renderHook(() => useSessionInterfaceTransition("session-1"), {
+			wrapper,
+		});
+
+		await waitFor(() => expect(result.current.status?.supported).toBe(false));
+		await new Promise((resolve) => setTimeout(resolve, 1_100));
+		expect(getMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
@@ -27,6 +27,8 @@ const cancellablePhases = new Set<SessionInterfaceTransition["phase"]>([
 	"draining",
 ]);
 
+const nativeSessionReadinessPoll = 1_000;
+
 export function interfaceTransitionIsActive(transition?: SessionInterfaceTransition): boolean {
 	return Boolean(transition && activePhases.has(transition.phase));
 }
@@ -60,8 +62,18 @@ export function useSessionInterfaceTransition(sessionId: string | undefined) {
 			if (error) throw error;
 			return data as SessionInterfaceTransitionStatus;
 		},
-		refetchInterval: (state) =>
-			interfaceTransitionIsActive(state.state.data?.transition) ? 250 : false,
+		refetchInterval: (state) => {
+			const status = state.state.data;
+			if (interfaceTransitionIsActive(status?.transition)) return 250;
+			// Codex reports its native thread id from an asynchronous SessionStart
+			// hook. The first status request can therefore race that hook and return
+			// NATIVE_SESSION_MISSING. Recheck only this transient readiness state so
+			// a supported switch enables without polling permanently unsupported
+			// harnesses or ordinary idle sessions.
+			return status?.reasonCode === "NATIVE_SESSION_MISSING"
+				? nativeSessionReadinessPoll
+				: false;
+		},
 		retry: 1,
 	});
 


### PR DESCRIPTION
## Summary

- invoke Codex lifecycle hooks with the running AO executable's absolute, shell-quoted path, so Codex's login shell cannot redirect callbacks to a stale or foreign `ao`
- recheck only the transient `NATIVE_SESSION_MISSING` interface status, allowing **Switch to chat UI** to enable as soon as a successful `SessionStart` hook records the thread id
- implement Codex's native-history probe so a reserved UUID with no active rollout starts fresh instead of issuing a doomed `thread/resume`

## RCA

Three independent gaps produced two similar-looking symptoms:

1. **The native id never arrives for some users.** Codex runs command hooks through the user's login shell. AO previously emitted bare `ao hooks codex ...` commands and only prepended the daemon directory to the child process's inherited `PATH`. A login-shell startup file can replace or reorder that `PATH`; the hook then invokes another AO installation (or no AO), exits, and never records the native Codex thread id. This depends on each user's shell setup, which explains why only some users reproduce it indefinitely.
2. **The renderer can cache an early missing-id response.** Even when the hook succeeds, the initial interface-status request can race the asynchronous `SessionStart` callback. The query returned `NATIVE_SESSION_MISSING`, but idle status queries did not refetch, leaving the button stale until some unrelated remount/refetch.
3. **A UUID is not necessarily resumable history.** Codex app-server can reserve and return a thread UUID before the first user turn writes an active rollout. AO treated every non-empty Codex UUID as resumable, passed an unmaterialized id to `thread/resume`, and surfaced `no rollout found for thread id ...`.

## Why the earlier fixes did not cover this

- #170 prepended AO's daemon directory to the spawned session `PATH`. That helps ordinary child-process lookup, but it does not survive a login shell that reconstructs `PATH` before running a hook.
- #3711 recovers a stopped Chat controller. It does not make a missing Codex rollout resumable and therefore cannot fix `no rollout found`.
- #3719 prevents a stale-idle transition drain from hanging. It is a separate transition-lifecycle failure.
- #3717 changes frontend chat links/text selection and is unrelated.

## Reproduction and evidence

### Real desktop reproduction on `main`

1. Launch the actual AO Electron app against an isolated data directory.
2. Start a Codex 0.147 TUI session and send `Reply with only OK`.
3. Observe Codex return `OK`, while **Switch to chat UI** remains disabled and Activity shows **No Signal**.
4. In the reproduced shell, `zsh -lc 'command -v ao'` resolves a stale package-manager shim; invoking it exits 1 because its old module target no longer exists. Therefore the `SessionStart` callback never reaches this daemon.
5. To isolate the second bug, record the valid native id directly. The daemon then reports `{supported:true,targetMode:"chat"}`, but the already-mounted UI remains disabled because it never refetches the earlier `NATIVE_SESSION_MISSING` result.

### Real desktop verification on this branch

1. Start the same Codex flow from the fixed app.
2. Inspect the live launch command: every Codex hook contains the absolute daemon executable and the isolated daemon run-file environment.
3. Send the same prompt. The real `SessionStart` callback records the native id, the button becomes enabled, and Activity becomes **Idle**.
4. Click **Switch to chat UI**. The transition completes and Chat UI displays the original `Reply with only OK` prompt and `OK` response. The reverse **Switch to terminal UI** control is enabled.

### Automated regression evidence

- Before the absolute-path implementation, the launch/restore command tests failed because the generated hook command still contained bare `ao hooks ...`; after the change, the same tests pass with the current AO executable embedded.
- The renderer regression test starts at `NATIVE_SESSION_MISSING`, advances the mocked daemon to `supported: true`, and proves the hook refetches exactly once. A second test proves permanently unsupported harnesses are not polled.
- Session-manager tests prove a missing Codex rollout uses the fresh-conversation sentinel, while a non-empty active `.jsonl` rollout preserves the native id.
- Adapter tests additionally cover missing, zero-byte, archived, active, and compressed active rollout files.

## Change-by-change necessity

| Change | Required? | Reason |
|---|---:|---|
| Absolute, shell-quoted AO hook executable | Yes | Fixes the indefinite, user-specific failure where no native id is ever recorded. Quoting is required for packaged paths such as `Agent Orchestrator.app`. |
| Error propagation from launch/restore | Yes | A session launched without working tracking hooks recreates the same unrecoverable disabled state. Failing the launch is safer and diagnosable. |
| Targeted one-second `NATIVE_SESSION_MISSING` poll | Yes | Absolute hooks can still finish after the first HTTP read; polling closes that legitimate async race. It stops immediately when ready and never runs for permanently unsupported harnesses. |
| Codex active-rollout probe | Yes | Prevents `thread/resume` from receiving an id that Codex has reserved but cannot resume. |
| Missing/zero-byte/archived vs active/compressed tests | Yes | These are the exact provider states that decide whether continuity is safe. |
| Frontend permanent-unsupported test | Yes | Guards the UX/performance boundary: Cursor and other unsupported harnesses must not begin background polling. |

No API, schema, storage, or UI-component change is needed.

## Validation

- `go test ./internal/adapters/agent/codex ./internal/session_manager -count=1`
- `go test ./...` (via the repository lint command)
- focused `golangci-lint` for the changed backend packages: `0 issues`
- `npm test -- --run src/renderer/hooks/useSessionInterfaceTransition.test.tsx`
- `npm run typecheck`
- `npm run package` (production Electron bundles and macOS package)
- actual AO Electron + Codex 0.147 TUI-to-Chat handoff against isolated data

The repository-wide linter process also scanned stale sibling worktrees on this machine and reported pre-existing/generated findings from those other paths. The changed packages themselves lint clean, and CI remains the clean-checkout authority.
