### PR TITLE
fix(cli): merge set-config by default instead of silent full replace

### DIFF
--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -95,22 +95,34 @@ type trackerIntakeConfig struct {
 	Assignee string `json:"assignee,omitempty"`
 }
 
+// reviewerConfig mirrors domain.ReviewerConfig.
+type reviewerConfig struct {
+	Harness string `json:"harness,omitempty"`
+}
+
+// containerReapConfig mirrors domain.ContainerReapConfig.
+type containerReapConfig struct {
+	Disabled bool `json:"disabled,omitempty"`
+}
+
 // projectConfig mirrors the daemon's typed domain.ProjectConfig for the CLI
 // client. The CLI sets common fields via flags and the whole object via
 // --config-json.
 type projectConfig struct {
-	DefaultBranch     string              `json:"defaultBranch,omitempty"`
-	SessionPrefix     string              `json:"sessionPrefix,omitempty"`
-	Env               map[string]string   `json:"env,omitempty"`
-	Symlinks          []string            `json:"symlinks,omitempty"`
-	PostCreate        []string            `json:"postCreate,omitempty"`
-	AgentRules        string              `json:"agentRules,omitempty"`
-	AgentRulesFile    string              `json:"agentRulesFile,omitempty"`
-	OrchestratorRules string              `json:"orchestratorRules,omitempty"`
-	AgentConfig       agentConfig         `json:"agentConfig,omitempty"`
-	Worker            roleOverride        `json:"worker,omitempty"`
-	Orchestrator      roleOverride        `json:"orchestrator,omitempty"`
-	TrackerIntake     trackerIntakeConfig `json:"trackerIntake,omitempty"`
+	DefaultBranch     string               `json:"defaultBranch,omitempty"`
+	SessionPrefix     string               `json:"sessionPrefix,omitempty"`
+	Env               map[string]string    `json:"env,omitempty"`
+	Symlinks          []string             `json:"symlinks,omitempty"`
+	PostCreate        []string             `json:"postCreate,omitempty"`
+	AgentRules        string               `json:"agentRules,omitempty"`
+	AgentRulesFile    string               `json:"agentRulesFile,omitempty"`
+	OrchestratorRules string               `json:"orchestratorRules,omitempty"`
+	AgentConfig       agentConfig          `json:"agentConfig,omitempty"`
+	Worker            roleOverride         `json:"worker,omitempty"`
+	Orchestrator      roleOverride         `json:"orchestrator,omitempty"`
+	Reviewers         []reviewerConfig     `json:"reviewers,omitempty"`
+	TrackerIntake     trackerIntakeConfig  `json:"trackerIntake,omitempty"`
+	ContainerReap     containerReapConfig  `json:"containerReap,omitempty"`
 }
 
 // setConfigRequest mirrors the daemon's SetConfigInput body for
@@ -302,8 +314,9 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 			if !opts.replace && !opts.clear {
 				var existing projectGetResult
 				if err := ctx.getJSON(cmd.Context(), "projects/"+url.PathEscape(id), &existing); err != nil {
-					current = projectConfig{}
-				} else if existing.Project.Config != nil {
+					return fmt.Errorf("cannot merge: fetch current config for %s: %w", id, err)
+				}
+				if existing.Project.Config != nil {
 					current = *existing.Project.Config
 				}
 			}
@@ -388,7 +401,12 @@ func buildProjectConfig(opts projectSetConfigOptions, current projectConfig, fla
 		if err != nil {
 			return projectConfig{}, err
 		}
-		cfg.Env = env
+		if cfg.Env == nil {
+			cfg.Env = make(map[string]string)
+		}
+		for k, v := range env {
+			cfg.Env[k] = v
+		}
 	}
 	if flags.Changed("symlink") {
 		cfg.Symlinks = opts.symlink
@@ -417,12 +435,21 @@ func buildProjectConfig(opts projectSetConfigOptions, current projectConfig, fla
 	if flags.Changed("orchestrator-agent") {
 		cfg.Orchestrator.Agent = opts.orchestratorAgent
 	}
+	if flags.Changed("tracker-intake") {
+		cfg.TrackerIntake.Enabled = opts.trackerIntake
+	}
+	if flags.Changed("tracker-repo") {
+		cfg.TrackerIntake.Repo = opts.trackerRepo
+		if opts.trackerRepo != "" && cfg.TrackerIntake.Provider == "" {
+			cfg.TrackerIntake.Provider = "github"
+		}
+	}
+	if flags.Changed("tracker-assignee") {
+		cfg.TrackerIntake.Assignee = opts.trackerAssignee
+	}
 	if flags.Changed("tracker-intake") || flags.Changed("tracker-repo") || flags.Changed("tracker-assignee") {
-		cfg.TrackerIntake = trackerIntakeConfig{
-			Enabled:  opts.trackerIntake,
-			Provider: trackerProviderForFlags(opts),
-			Repo:     opts.trackerRepo,
-			Assignee: opts.trackerAssignee,
+		if cfg.TrackerIntake.Provider == "" && (opts.trackerIntake || opts.trackerRepo != "" || opts.trackerAssignee != "") {
+			cfg.TrackerIntake.Provider = "github"
 		}
 	}
 
@@ -443,7 +470,12 @@ func mergeProjectConfig(current, overlay projectConfig) projectConfig {
 		out.SessionPrefix = overlay.SessionPrefix
 	}
 	if len(overlay.Env) > 0 {
-		out.Env = overlay.Env
+		if out.Env == nil {
+			out.Env = make(map[string]string)
+		}
+		for k, v := range overlay.Env {
+			out.Env[k] = v
+		}
 	}
 	if len(overlay.Symlinks) > 0 {
 		out.Symlinks = overlay.Symlinks
@@ -494,16 +526,26 @@ func mergeProjectConfig(current, overlay projectConfig) projectConfig {
 		out.Orchestrator.AgentConfig.Permissions = overlay.Orchestrator.AgentConfig.Permissions
 	}
 	if overlay.TrackerIntake.Enabled || overlay.TrackerIntake.Repo != "" || overlay.TrackerIntake.Assignee != "" {
-		out.TrackerIntake = overlay.TrackerIntake
+		if overlay.TrackerIntake.Enabled {
+			out.TrackerIntake.Enabled = true
+		}
+		if overlay.TrackerIntake.Provider != "" {
+			out.TrackerIntake.Provider = overlay.TrackerIntake.Provider
+		}
+		if overlay.TrackerIntake.Repo != "" {
+			out.TrackerIntake.Repo = overlay.TrackerIntake.Repo
+		}
+		if overlay.TrackerIntake.Assignee != "" {
+			out.TrackerIntake.Assignee = overlay.TrackerIntake.Assignee
+		}
+	}
+	if len(overlay.Reviewers) > 0 {
+		out.Reviewers = overlay.Reviewers
+	}
+	if overlay.ContainerReap.Disabled {
+		out.ContainerReap.Disabled = true
 	}
 	return out
-}
-
-func trackerProviderForFlags(opts projectSetConfigOptions) string {
-	if opts.trackerIntake || opts.trackerRepo != "" || opts.trackerAssignee != "" {
-		return "github"
-	}
-	return ""
 }
 
 // parseEnvPairs turns repeated KEY=VALUE flags into a map.

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -87,9 +87,10 @@ type roleOverride struct {
 	AgentConfig agentConfig `json:"agentConfig,omitempty"`
 }
 
-// trackerIntakeConfig mirrors domain.TrackerIntakeConfig.
+// trackerIntakeConfig mirrors domain.TrackerIntakeConfig. Enabled is a pointer
+// so that --config-json merge can distinguish "false" from "field absent".
 type trackerIntakeConfig struct {
-	Enabled  bool   `json:"enabled,omitempty"`
+	Enabled  *bool  `json:"enabled,omitempty"`
 	Provider string `json:"provider,omitempty"`
 	Repo     string `json:"repo,omitempty"`
 	Assignee string `json:"assignee,omitempty"`
@@ -100,29 +101,30 @@ type reviewerConfig struct {
 	Harness string `json:"harness,omitempty"`
 }
 
-// containerReapConfig mirrors domain.ContainerReapConfig.
+// containerReapConfig mirrors domain.ContainerReapConfig. Disabled is a
+// pointer so that --config-json merge can distinguish "false" from "absent".
 type containerReapConfig struct {
-	Disabled bool `json:"disabled,omitempty"`
+	Disabled *bool `json:"disabled,omitempty"`
 }
 
 // projectConfig mirrors the daemon's typed domain.ProjectConfig for the CLI
 // client. The CLI sets common fields via flags and the whole object via
 // --config-json.
 type projectConfig struct {
-	DefaultBranch     string               `json:"defaultBranch,omitempty"`
-	SessionPrefix     string               `json:"sessionPrefix,omitempty"`
-	Env               map[string]string    `json:"env,omitempty"`
-	Symlinks          []string             `json:"symlinks,omitempty"`
-	PostCreate        []string             `json:"postCreate,omitempty"`
-	AgentRules        string               `json:"agentRules,omitempty"`
-	AgentRulesFile    string               `json:"agentRulesFile,omitempty"`
-	OrchestratorRules string               `json:"orchestratorRules,omitempty"`
-	AgentConfig       agentConfig          `json:"agentConfig,omitempty"`
-	Worker            roleOverride         `json:"worker,omitempty"`
-	Orchestrator      roleOverride         `json:"orchestrator,omitempty"`
-	Reviewers         []reviewerConfig     `json:"reviewers,omitempty"`
-	TrackerIntake     trackerIntakeConfig  `json:"trackerIntake,omitempty"`
-	ContainerReap     containerReapConfig  `json:"containerReap,omitempty"`
+	DefaultBranch     string              `json:"defaultBranch,omitempty"`
+	SessionPrefix     string              `json:"sessionPrefix,omitempty"`
+	Env               map[string]string   `json:"env,omitempty"`
+	Symlinks          []string            `json:"symlinks,omitempty"`
+	PostCreate        []string            `json:"postCreate,omitempty"`
+	AgentRules        string              `json:"agentRules,omitempty"`
+	AgentRulesFile    string              `json:"agentRulesFile,omitempty"`
+	OrchestratorRules string              `json:"orchestratorRules,omitempty"`
+	AgentConfig       agentConfig         `json:"agentConfig,omitempty"`
+	Worker            roleOverride        `json:"worker,omitempty"`
+	Orchestrator      roleOverride        `json:"orchestrator,omitempty"`
+	Reviewers         []reviewerConfig    `json:"reviewers,omitempty"`
+	TrackerIntake     trackerIntakeConfig `json:"trackerIntake,omitempty"`
+	ContainerReap     containerReapConfig `json:"containerReap,omitempty"`
 }
 
 // setConfigRequest mirrors the daemon's SetConfigInput body for
@@ -436,7 +438,8 @@ func buildProjectConfig(opts projectSetConfigOptions, current projectConfig, fla
 		cfg.Orchestrator.Agent = opts.orchestratorAgent
 	}
 	if flags.Changed("tracker-intake") {
-		cfg.TrackerIntake.Enabled = opts.trackerIntake
+		v := opts.trackerIntake
+		cfg.TrackerIntake.Enabled = &v
 	}
 	if flags.Changed("tracker-repo") {
 		cfg.TrackerIntake.Repo = opts.trackerRepo
@@ -525,25 +528,23 @@ func mergeProjectConfig(current, overlay projectConfig) projectConfig {
 	if overlay.Orchestrator.AgentConfig.Permissions != "" {
 		out.Orchestrator.AgentConfig.Permissions = overlay.Orchestrator.AgentConfig.Permissions
 	}
-	if overlay.TrackerIntake.Enabled || overlay.TrackerIntake.Repo != "" || overlay.TrackerIntake.Assignee != "" {
-		if overlay.TrackerIntake.Enabled {
-			out.TrackerIntake.Enabled = true
-		}
-		if overlay.TrackerIntake.Provider != "" {
-			out.TrackerIntake.Provider = overlay.TrackerIntake.Provider
-		}
-		if overlay.TrackerIntake.Repo != "" {
-			out.TrackerIntake.Repo = overlay.TrackerIntake.Repo
-		}
-		if overlay.TrackerIntake.Assignee != "" {
-			out.TrackerIntake.Assignee = overlay.TrackerIntake.Assignee
-		}
+	if overlay.TrackerIntake.Enabled != nil {
+		out.TrackerIntake.Enabled = overlay.TrackerIntake.Enabled
+	}
+	if overlay.TrackerIntake.Provider != "" {
+		out.TrackerIntake.Provider = overlay.TrackerIntake.Provider
+	}
+	if overlay.TrackerIntake.Repo != "" {
+		out.TrackerIntake.Repo = overlay.TrackerIntake.Repo
+	}
+	if overlay.TrackerIntake.Assignee != "" {
+		out.TrackerIntake.Assignee = overlay.TrackerIntake.Assignee
 	}
 	if len(overlay.Reviewers) > 0 {
 		out.Reviewers = overlay.Reviewers
 	}
-	if overlay.ContainerReap.Disabled {
-		out.ContainerReap.Disabled = true
+	if overlay.ContainerReap.Disabled != nil {
+		out.ContainerReap.Disabled = overlay.ContainerReap.Disabled
 	}
 	return out
 }

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -12,6 +12,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type projectAddOptions struct {
@@ -136,6 +137,7 @@ type projectSetConfigOptions struct {
 	trackerAssignee   string
 	configJSON        string
 	clear             bool
+	replace           bool
 	json              bool
 }
 
@@ -276,12 +278,14 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 	var opts projectSetConfigOptions
 	cmd := &cobra.Command{
 		Use:   "set-config <id>",
-		Short: "Set the per-project config",
-		Long: "Replace a project's per-project config (branch, session prefix, env, " +
-			"symlinks, post-create, rules, agent model/permissions, role overrides, tracker intake). The config " +
-			"is resolved when a session spawns.\n\n" +
-			"Set fields via flags, pass the whole object with --config-json, or --clear " +
-			"to remove all config.",
+		Short: "Update the per-project config",
+		Long: "Update a project's per-project config (branch, session prefix, env, " +
+			"symlinks, post-create, rules, agent model/permissions, role overrides, tracker intake). " +
+			"By default, unspecified fields keep their current values (merge). " +
+			"Use --replace to overwrite the entire config (old behavior). " +
+			"The config is resolved when a session spawns.\n\n" +
+			"Set fields via flags, pass a partial or whole object with --config-json, " +
+			"or --clear to remove all config.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
 				return usageError{err}
@@ -293,7 +297,18 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id := strings.TrimSpace(args[0])
-			config, err := buildProjectConfig(opts)
+
+			var current projectConfig
+			if !opts.replace && !opts.clear {
+				var existing projectGetResult
+				if err := ctx.getJSON(cmd.Context(), "projects/"+url.PathEscape(id), &existing); err != nil {
+					current = projectConfig{}
+				} else if existing.Project.Config != nil {
+					current = *existing.Project.Config
+				}
+			}
+
+			config, err := buildProjectConfig(opts, current, cmd.Flags())
 			if err != nil {
 				return err
 			}
@@ -327,19 +342,23 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 	f.StringVar(&opts.trackerAssignee, "tracker-assignee", "", "GitHub issue assignee required for intake eligibility")
 	f.StringVar(&opts.configJSON, "config-json", "", "Full config as a JSON object (overrides field flags)")
 	f.BoolVar(&opts.clear, "clear", false, "Clear all config")
+	f.BoolVar(&opts.replace, "replace", false, "Replace the entire config instead of merging (old behavior)")
 	f.BoolVar(&opts.json, "json", false, "Output the updated project as JSON")
 	return cmd
 }
 
 // buildProjectConfig turns the set-config flags into the typed config sent to
-// the daemon. --clear empties the config; --config-json supplies the whole
-// object; otherwise the field flags form the config. The daemon validates the
-// values.
-func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
+// the daemon. --clear empties the config; --replace with --config-json supplies
+// the whole object; --config-json alone deep-merges into current; otherwise the
+// field flags merge into current (only changed flags overwrite). The daemon
+// validates the values.
+func buildProjectConfig(opts projectSetConfigOptions, current projectConfig, flags *pflag.FlagSet) (projectConfig, error) {
 	if opts.clear {
 		return projectConfig{}, nil
 	}
-	if opts.configJSON != "" {
+
+	// --replace + --config-json: full replace, no merge.
+	if opts.replace && opts.configJSON != "" {
 		var cfg projectConfig
 		if err := json.Unmarshal([]byte(opts.configJSON), &cfg); err != nil {
 			return projectConfig{}, usageError{fmt.Errorf("--config-json is not a valid JSON object: %w", err)}
@@ -347,33 +366,137 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 		return cfg, nil
 	}
 
-	env, err := parseEnvPairs(opts.env)
-	if err != nil {
-		return projectConfig{}, err
+	// --config-json without --replace: deep-merge into current.
+	if opts.configJSON != "" {
+		var cfg projectConfig
+		if err := json.Unmarshal([]byte(opts.configJSON), &cfg); err != nil {
+			return projectConfig{}, usageError{fmt.Errorf("--config-json is not a valid JSON object: %w", err)}
+		}
+		return mergeProjectConfig(current, cfg), nil
 	}
-	cfg := projectConfig{
-		DefaultBranch:     opts.defaultBranch,
-		SessionPrefix:     opts.sessionPrefix,
-		Env:               env,
-		Symlinks:          opts.symlink,
-		PostCreate:        opts.postCreate,
-		AgentRules:        opts.agentRules,
-		AgentRulesFile:    opts.agentRulesFile,
-		OrchestratorRules: opts.orchestratorRules,
-		AgentConfig:       agentConfig{Model: opts.model, Permissions: opts.permission},
-		Worker:            roleOverride{Agent: opts.workerAgent},
-		Orchestrator:      roleOverride{Agent: opts.orchestratorAgent},
-		TrackerIntake: trackerIntakeConfig{
+
+	// Field-flag merge: start from current, overlay only changed flags.
+	cfg := current
+	if flags.Changed("default-branch") {
+		cfg.DefaultBranch = opts.defaultBranch
+	}
+	if flags.Changed("session-prefix") {
+		cfg.SessionPrefix = opts.sessionPrefix
+	}
+	if flags.Changed("env") {
+		env, err := parseEnvPairs(opts.env)
+		if err != nil {
+			return projectConfig{}, err
+		}
+		cfg.Env = env
+	}
+	if flags.Changed("symlink") {
+		cfg.Symlinks = opts.symlink
+	}
+	if flags.Changed("post-create") {
+		cfg.PostCreate = opts.postCreate
+	}
+	if flags.Changed("agent-rules") {
+		cfg.AgentRules = opts.agentRules
+	}
+	if flags.Changed("agent-rules-file") {
+		cfg.AgentRulesFile = opts.agentRulesFile
+	}
+	if flags.Changed("orchestrator-rules") {
+		cfg.OrchestratorRules = opts.orchestratorRules
+	}
+	if flags.Changed("model") {
+		cfg.AgentConfig.Model = opts.model
+	}
+	if flags.Changed("permission") {
+		cfg.AgentConfig.Permissions = opts.permission
+	}
+	if flags.Changed("worker-agent") {
+		cfg.Worker.Agent = opts.workerAgent
+	}
+	if flags.Changed("orchestrator-agent") {
+		cfg.Orchestrator.Agent = opts.orchestratorAgent
+	}
+	if flags.Changed("tracker-intake") || flags.Changed("tracker-repo") || flags.Changed("tracker-assignee") {
+		cfg.TrackerIntake = trackerIntakeConfig{
 			Enabled:  opts.trackerIntake,
 			Provider: trackerProviderForFlags(opts),
 			Repo:     opts.trackerRepo,
 			Assignee: opts.trackerAssignee,
-		},
+		}
 	}
+
 	if reflect.DeepEqual(cfg, projectConfig{}) {
 		return projectConfig{}, usageError{errors.New("usage: provide at least one config flag, --config-json, or --clear")}
 	}
 	return cfg, nil
+}
+
+// mergeProjectConfig deep-merges overlay into current. Non-zero fields in
+// overlay win; zero-value fields preserve the existing value.
+func mergeProjectConfig(current, overlay projectConfig) projectConfig {
+	out := current
+	if overlay.DefaultBranch != "" {
+		out.DefaultBranch = overlay.DefaultBranch
+	}
+	if overlay.SessionPrefix != "" {
+		out.SessionPrefix = overlay.SessionPrefix
+	}
+	if len(overlay.Env) > 0 {
+		out.Env = overlay.Env
+	}
+	if len(overlay.Symlinks) > 0 {
+		out.Symlinks = overlay.Symlinks
+	}
+	if len(overlay.PostCreate) > 0 {
+		out.PostCreate = overlay.PostCreate
+	}
+	if overlay.AgentRules != "" {
+		out.AgentRules = overlay.AgentRules
+	}
+	if overlay.AgentRulesFile != "" {
+		out.AgentRulesFile = overlay.AgentRulesFile
+	}
+	if overlay.OrchestratorRules != "" {
+		out.OrchestratorRules = overlay.OrchestratorRules
+	}
+	if overlay.AgentConfig.Model != "" {
+		out.AgentConfig.Model = overlay.AgentConfig.Model
+	}
+	if overlay.AgentConfig.Mode != "" {
+		out.AgentConfig.Mode = overlay.AgentConfig.Mode
+	}
+	if overlay.AgentConfig.Permissions != "" {
+		out.AgentConfig.Permissions = overlay.AgentConfig.Permissions
+	}
+	if overlay.Worker.Agent != "" {
+		out.Worker.Agent = overlay.Worker.Agent
+	}
+	if overlay.Worker.AgentConfig.Model != "" {
+		out.Worker.AgentConfig.Model = overlay.Worker.AgentConfig.Model
+	}
+	if overlay.Worker.AgentConfig.Mode != "" {
+		out.Worker.AgentConfig.Mode = overlay.Worker.AgentConfig.Mode
+	}
+	if overlay.Worker.AgentConfig.Permissions != "" {
+		out.Worker.AgentConfig.Permissions = overlay.Worker.AgentConfig.Permissions
+	}
+	if overlay.Orchestrator.Agent != "" {
+		out.Orchestrator.Agent = overlay.Orchestrator.Agent
+	}
+	if overlay.Orchestrator.AgentConfig.Model != "" {
+		out.Orchestrator.AgentConfig.Model = overlay.Orchestrator.AgentConfig.Model
+	}
+	if overlay.Orchestrator.AgentConfig.Mode != "" {
+		out.Orchestrator.AgentConfig.Mode = overlay.Orchestrator.AgentConfig.Mode
+	}
+	if overlay.Orchestrator.AgentConfig.Permissions != "" {
+		out.Orchestrator.AgentConfig.Permissions = overlay.Orchestrator.AgentConfig.Permissions
+	}
+	if overlay.TrackerIntake.Enabled || overlay.TrackerIntake.Repo != "" || overlay.TrackerIntake.Assignee != "" {
+		out.TrackerIntake = overlay.TrackerIntake
+	}
+	return out
 }
 
 func trackerProviderForFlags(opts projectSetConfigOptions) string {

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -89,7 +89,7 @@ func TestProjectSetConfig_TrackerIntakeFlags(t *testing.T) {
 	if err := json.Unmarshal(capture.body, &got); err != nil {
 		t.Fatalf("decode request: %v\nbody=%s", err, capture.body)
 	}
-	if !got.Config.TrackerIntake.Enabled || got.Config.TrackerIntake.Provider != "github" || got.Config.TrackerIntake.Repo != "acme/demo" || got.Config.TrackerIntake.Assignee != "alice" {
+	if got.Config.TrackerIntake.Enabled == nil || !*got.Config.TrackerIntake.Enabled || got.Config.TrackerIntake.Provider != "github" || got.Config.TrackerIntake.Repo != "acme/demo" || got.Config.TrackerIntake.Assignee != "alice" {
 		t.Fatalf("tracker intake request = %#v", got.Config.TrackerIntake)
 	}
 }
@@ -109,7 +109,7 @@ func TestProjectSetConfig_TrackerIntakeJSON(t *testing.T) {
 	if err := json.Unmarshal(capture.body, &got); err != nil {
 		t.Fatalf("decode request: %v\nbody=%s", err, capture.body)
 	}
-	if !got.Config.TrackerIntake.Enabled || got.Config.TrackerIntake.Provider != "github" || got.Config.TrackerIntake.Assignee != "alice" {
+	if got.Config.TrackerIntake.Enabled == nil || !*got.Config.TrackerIntake.Enabled || got.Config.TrackerIntake.Provider != "github" || got.Config.TrackerIntake.Assignee != "alice" {
 		t.Fatalf("tracker intake request = %#v", got.Config.TrackerIntake)
 	}
 	if got.Config.Worker.Agent != "amp" || got.Config.Worker.AgentConfig.Mode != "ultra" {
@@ -142,7 +142,7 @@ func TestBuildProjectConfigTrackerIntakeFlags(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.TrackerIntake.Enabled || got.TrackerIntake.Provider != "github" || got.TrackerIntake.Repo != "acme/demo" || got.TrackerIntake.Assignee != "alice" {
+	if got.TrackerIntake.Enabled == nil || !*got.TrackerIntake.Enabled || got.TrackerIntake.Provider != "github" || got.TrackerIntake.Repo != "acme/demo" || got.TrackerIntake.Assignee != "alice" {
 		t.Fatalf("tracker intake config = %#v", got.TrackerIntake)
 	}
 }
@@ -457,7 +457,7 @@ func TestProjectSetConfig_MergePreservesReviewersAndContainerReap(t *testing.T) 
 	if len(got.Config.Reviewers) != 1 || got.Config.Reviewers[0].Harness != "codex" {
 		t.Fatalf("reviewers = %#v, want [{harness:codex}] preserved", got.Config.Reviewers)
 	}
-	if !got.Config.ContainerReap.Disabled {
+	if got.Config.ContainerReap.Disabled == nil || !*got.Config.ContainerReap.Disabled {
 		t.Fatalf("containerReap = %#v, want {disabled:true} preserved", got.Config.ContainerReap)
 	}
 	if got.Config.Env["SOME_VAR"] != "hello" {
@@ -485,7 +485,7 @@ func TestProjectSetConfig_TrackerFlagOverlaysOnlyChangedField(t *testing.T) {
 	if got.Config.TrackerIntake.Assignee != "bob" {
 		t.Fatalf("assignee = %q, want bob", got.Config.TrackerIntake.Assignee)
 	}
-	if !got.Config.TrackerIntake.Enabled {
+	if got.Config.TrackerIntake.Enabled == nil || !*got.Config.TrackerIntake.Enabled {
 		t.Fatalf("enabled = false, want true preserved from existing")
 	}
 	if got.Config.TrackerIntake.Repo != "acme/demo" {
@@ -493,6 +493,72 @@ func TestProjectSetConfig_TrackerFlagOverlaysOnlyChangedField(t *testing.T) {
 	}
 	if got.Config.TrackerIntake.Provider != "github" {
 		t.Fatalf("provider = %q, want github preserved from existing", got.Config.TrackerIntake.Provider)
+	}
+}
+
+// TestProjectSetConfig_ConfigJSONCanDisableTrackerIntake verifies that
+// --config-json merge can set trackerIntake.enabled to false. Before the
+// pointer fix, a false value was indistinguishable from "field absent"
+// after JSON unmarshaling, so the merge silently kept the existing true
+// value — the disable was a no-op.
+func TestProjectSetConfig_ConfigJSONCanDisableTrackerIntake(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"trackerIntake":{"enabled":true,"provider":"github","repo":"acme/demo","assignee":"alice"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--config-json", `{"trackerIntake":{"enabled":false}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.TrackerIntake.Enabled == nil {
+		t.Fatalf("enabled = nil, want pointer to false")
+	}
+	if *got.Config.TrackerIntake.Enabled {
+		t.Fatalf("enabled = true, want false (merge should honor explicit false)")
+	}
+	if got.Config.TrackerIntake.Provider != "github" || got.Config.TrackerIntake.Repo != "acme/demo" || got.Config.TrackerIntake.Assignee != "alice" {
+		t.Fatalf("other tracker fields = %#v, want preserved from existing", got.Config.TrackerIntake)
+	}
+}
+
+// TestProjectSetConfig_ConfigJSONCanReenableContainerReap verifies that
+// --config-json merge can set containerReap.disabled to false. Before the
+// pointer fix, a false value was indistinguishable from "field absent",
+// so once disabled the merge path could never re-enable reaping — the
+// user had to fall back to --replace or --clear.
+func TestProjectSetConfig_ConfigJSONCanReenableContainerReap(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"containerReap":{"disabled":true},"env":{"FOO":"bar"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--config-json", `{"containerReap":{"disabled":false}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.ContainerReap.Disabled == nil {
+		t.Fatalf("disabled = nil, want pointer to false")
+	}
+	if *got.Config.ContainerReap.Disabled {
+		t.Fatalf("disabled = true, want false (merge should honor explicit false)")
+	}
+	if got.Config.Env["FOO"] != "bar" {
+		t.Fatalf("env = %#v, want FOO=bar preserved from existing", got.Config.Env)
 	}
 }
 
@@ -609,7 +675,6 @@ func TestProjectSetConfig_ReplaceEnvWholeMap(t *testing.T) {
 		t.Fatalf("env[EXISTING] = %q, want absent (--replace replaces whole map)", got.Config.Env["EXISTING"])
 	}
 }
-
 
 func TestProjectRemove_RequiresID(t *testing.T) {
 	setConfigEnv(t)

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -434,6 +434,183 @@ func TestProjectSetConfig_ClearStillWipes(t *testing.T) {
 	}
 }
 
+func TestProjectSetConfig_MergePreservesReviewersAndContainerReap(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"reviewers":[{"harness":"codex"}],"containerReap":{"disabled":true},"env":{"SOME_VAR":"hello"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--model", "claude-opus-4-5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.AgentConfig.Model != "claude-opus-4-5" {
+		t.Fatalf("model = %q, want claude-opus-4-5", got.Config.AgentConfig.Model)
+	}
+	if len(got.Config.Reviewers) != 1 || got.Config.Reviewers[0].Harness != "codex" {
+		t.Fatalf("reviewers = %#v, want [{harness:codex}] preserved", got.Config.Reviewers)
+	}
+	if !got.Config.ContainerReap.Disabled {
+		t.Fatalf("containerReap = %#v, want {disabled:true} preserved", got.Config.ContainerReap)
+	}
+	if got.Config.Env["SOME_VAR"] != "hello" {
+		t.Fatalf("env = %#v, want SOME_VAR=hello preserved", got.Config.Env)
+	}
+}
+
+func TestProjectSetConfig_TrackerFlagOverlaysOnlyChangedField(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"trackerIntake":{"enabled":true,"provider":"github","repo":"acme/demo","assignee":"alice"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--tracker-assignee", "bob")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.TrackerIntake.Assignee != "bob" {
+		t.Fatalf("assignee = %q, want bob", got.Config.TrackerIntake.Assignee)
+	}
+	if !got.Config.TrackerIntake.Enabled {
+		t.Fatalf("enabled = false, want true preserved from existing")
+	}
+	if got.Config.TrackerIntake.Repo != "acme/demo" {
+		t.Fatalf("repo = %q, want acme/demo preserved from existing", got.Config.TrackerIntake.Repo)
+	}
+	if got.Config.TrackerIntake.Provider != "github" {
+		t.Fatalf("provider = %q, want github preserved from existing", got.Config.TrackerIntake.Provider)
+	}
+}
+
+func TestProjectSetConfig_GETFailurePreventsPUT(t *testing.T) {
+	cfg := setConfigEnv(t)
+	capture := &projectCapture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture.method = r.Method
+		capture.path = r.URL.Path
+		data, _ := io.ReadAll(r.Body)
+		capture.body = data
+		if !strings.HasPrefix(r.URL.Path, "/api/v1/projects") {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":"internal server error"}`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"project":{"id":"demo"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--model", "claude-opus-4-5")
+	if err == nil {
+		t.Fatal("expected error from GET failure, got nil")
+	}
+	if capture.method == http.MethodPut {
+		t.Fatalf("PUT was issued despite GET failure — fail-open must not allow data loss")
+	}
+}
+
+func TestProjectSetConfig_EnvMergesByKey(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"env":{"EXISTING":"kept","OTHER":"also"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--env", "NEW=val")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.Env["NEW"] != "val" {
+		t.Fatalf("env[NEW] = %q, want val", got.Config.Env["NEW"])
+	}
+	if got.Config.Env["EXISTING"] != "kept" {
+		t.Fatalf("env[EXISTING] = %q, want kept (merge by key, not wholesale replace)", got.Config.Env["EXISTING"])
+	}
+	if got.Config.Env["OTHER"] != "also" {
+		t.Fatalf("env[OTHER] = %q, want also preserved", got.Config.Env["OTHER"])
+	}
+}
+
+func TestProjectSetConfig_ConfigJSONEnvMergesByKey(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"env":{"EXISTING":"kept"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo",
+		"--config-json", `{"env":{"NEW":"val"}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.Env["NEW"] != "val" {
+		t.Fatalf("env[NEW] = %q, want val", got.Config.Env["NEW"])
+	}
+	if got.Config.Env["EXISTING"] != "kept" {
+		t.Fatalf("env[EXISTING] = %q, want kept (deep merge by key)", got.Config.Env["EXISTING"])
+	}
+}
+
+func TestProjectSetConfig_ReplaceEnvWholeMap(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"env":{"EXISTING":"kept"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo",
+		"--config-json", `{"env":{"NEW":"val"}}`, "--replace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.Env["NEW"] != "val" {
+		t.Fatalf("env[NEW] = %q, want val", got.Config.Env["NEW"])
+	}
+	if _, exists := got.Config.Env["EXISTING"]; exists {
+		t.Fatalf("env[EXISTING] = %q, want absent (--replace replaces whole map)", got.Config.Env["EXISTING"])
+	}
+}
+
+
 func TestProjectRemove_RequiresID(t *testing.T) {
 	setConfigEnv(t)
 	_, _, err := executeCLI(t, Deps{}, "project", "rm")

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -5,8 +5,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 type projectCapture struct {
@@ -33,6 +36,36 @@ func projectServer(t *testing.T, status int, respBody string) (*httptest.Server,
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		_, _ = io.WriteString(w, respBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, capture
+}
+
+// projectSetConfigServer returns a mock daemon that serves different bodies
+// for GET (returning existing config) and PUT (returning the update result).
+// The PUT request body is captured for assertion.
+func projectSetConfigServer(t *testing.T, getBody, putBody string) (*httptest.Server, *projectCapture) {
+	t.Helper()
+	capture := &projectCapture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture.method = r.Method
+		capture.path = r.URL.Path
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		capture.body = data
+		if !strings.HasPrefix(r.URL.Path, "/api/v1/projects") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			_, _ = io.WriteString(w, getBody)
+		} else {
+			_, _ = io.WriteString(w, putBody)
+		}
 	}))
 	t.Cleanup(srv.Close)
 	return srv, capture
@@ -85,11 +118,27 @@ func TestProjectSetConfig_TrackerIntakeJSON(t *testing.T) {
 }
 
 func TestBuildProjectConfigTrackerIntakeFlags(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	var trackerIntake bool
+	var trackerRepo, trackerAssignee string
+	flags.BoolVar(&trackerIntake, "tracker-intake", false, "")
+	flags.StringVar(&trackerRepo, "tracker-repo", "", "")
+	flags.StringVar(&trackerAssignee, "tracker-assignee", "", "")
+	if err := flags.Set("tracker-intake", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := flags.Set("tracker-repo", "acme/demo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := flags.Set("tracker-assignee", "alice"); err != nil {
+		t.Fatal(err)
+	}
+
 	got, err := buildProjectConfig(projectSetConfigOptions{
 		trackerIntake:   true,
 		trackerRepo:     "acme/demo",
 		trackerAssignee: "alice",
-	})
+	}, projectConfig{}, flags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,6 +312,125 @@ func TestProjectSetConfig_RulesFlags(t *testing.T) {
 	}
 	if !strings.Contains(out, "updated config for project demo") {
 		t.Fatalf("output missing update message:\n%s", out)
+	}
+}
+
+func TestProjectSetConfig_MergePreservesUnspecifiedFields(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"env":{"SOME_VAR":"hello"},"worker":{"agent":"amp"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--model", "claude-opus-4-5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPut || capture.path != "/api/v1/projects/demo/config" {
+		t.Fatalf("request = %s %s, want PUT /api/v1/projects/demo/config", capture.method, capture.path)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.AgentConfig.Model != "claude-opus-4-5" {
+		t.Fatalf("model = %q, want claude-opus-4-5", got.Config.AgentConfig.Model)
+	}
+	if got.Config.Env["SOME_VAR"] != "hello" {
+		t.Fatalf("env = %#v, want SOME_VAR=hello preserved", got.Config.Env)
+	}
+	if got.Config.Worker.Agent != "amp" {
+		t.Fatalf("worker = %#v, want amp preserved", got.Config.Worker)
+	}
+}
+
+func TestProjectSetConfig_ReplaceDiscardsUnspecifiedFields(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"env":{"SOME_VAR":"hello"},"worker":{"agent":"amp"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--model", "claude-opus-4-5", "--replace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPut || capture.path != "/api/v1/projects/demo/config" {
+		t.Fatalf("request = %s %s, want PUT /api/v1/projects/demo/config", capture.method, capture.path)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.AgentConfig.Model != "claude-opus-4-5" {
+		t.Fatalf("model = %q, want claude-opus-4-5", got.Config.AgentConfig.Model)
+	}
+	if len(got.Config.Env) > 0 {
+		t.Fatalf("env = %#v, want empty (replace mode)", got.Config.Env)
+	}
+	if got.Config.Worker.Agent != "" {
+		t.Fatalf("worker = %#v, want empty (replace mode)", got.Config.Worker)
+	}
+}
+
+func TestProjectSetConfig_ConfigJSONMergesIntoExisting(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"env":{"SOME_VAR":"hello"},"worker":{"agent":"amp"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo",
+		"--config-json", `{"agentConfig":{"model":"claude-opus-4-5"}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPut || capture.path != "/api/v1/projects/demo/config" {
+		t.Fatalf("request = %s %s, want PUT /api/v1/projects/demo/config", capture.method, capture.path)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.AgentConfig.Model != "claude-opus-4-5" {
+		t.Fatalf("model = %q, want claude-opus-4-5", got.Config.AgentConfig.Model)
+	}
+	if got.Config.Env["SOME_VAR"] != "hello" {
+		t.Fatalf("env = %#v, want SOME_VAR=hello preserved by merge", got.Config.Env)
+	}
+	if got.Config.Worker.Agent != "amp" {
+		t.Fatalf("worker = %#v, want amp preserved by merge", got.Config.Worker)
+	}
+}
+
+func TestProjectSetConfig_ClearStillWipes(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectSetConfigServer(t,
+		`{"status":"ok","project":{"id":"demo","config":{"env":{"SOME_VAR":"hello"},"worker":{"agent":"amp"}}}}`,
+		`{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--clear")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPut || capture.path != "/api/v1/projects/demo/config" {
+		t.Fatalf("request = %s %s, want PUT /api/v1/projects/demo/config", capture.method, capture.path)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if !reflect.DeepEqual(got.Config, projectConfig{}) {
+		t.Fatalf("config = %#v, want empty (clear mode)", got.Config)
 	}
 }
 


### PR DESCRIPTION
Fixes [#3714](https://github.com/Untrivial-ai/agent-orchestrator/issues/3714)

## Summary
- `ao project set-config` did a full replace — any field not supplied was silently wiped to its zero value, with no warning. A routine one-setting change (e.g. updating the model) would drop unrelated settings like env vars, worker config, and setup commands.
- `buildProjectConfig` now starts from the current config fetched via GET and overlays only flags the user explicitly passed (using cobra's `Changed()` check).
- `--config-json` deep-merges into the existing config instead of replacing it wholesale.
- A new `--replace` flag opts into the old full-replace behavior for users who want it. `--clear` still wipes everything.
- Help text updated: "Set" → "Update", mentions merge-by-default and `--replace`.

## Tests
- `cd backend && go test ./internal/cli/... -run TestProjectSetConfig -v` (7 passed)
- `cd backend && go test ./internal/cli/... -run TestBuildProjectConfig -v` (1 passed)
- `cd backend && go test ./internal/cli/...` (full CLI suite passed)
- `cd backend && go vet ./internal/cli/...`

## Manual verification
Verified against a local daemon: setting `--env FOO=bar` then later `--model claude-opus-4-5` preserves `FOO=bar` (was silently wiped before). `--replace` restores old behavior. `--config-json` with a partial object merges into existing config. `--clear` still wipes everything.
<img width="1861" height="512" alt="Screenshot 2026-08-08 165908" src="https://github.com/user-attachments/assets/bd50dbc2-89a7-410b-9419-4a77b3a88b2a" />
<img width="1790" height="430" alt="Screenshot 2026-08-08 165614" src="https://github.com/user-attachments/assets/0207a431-6210-48cc-9587-67b9196d33ce" />
