### PR TITLE
fix: resolve three safe issue fixes

### DIFF
--- a/backend/internal/adapters/agent/goose/goose.go
+++ b/backend/internal/adapters/agent/goose/goose.go
@@ -135,7 +135,7 @@ func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, _ ports.LaunchCo
 
 // GetRestoreCommand rebuilds the argv that continues an existing Goose session:
 //
-//	[env GOOSE_MODE=<mode>] goose run --system <text> --resume --session-id <agentSessionId>
+//	[env GOOSE_MODE=<mode>] goose run --system <text> -t "" --resume --session-id <agentSessionId>
 //
 // ok is false when the hook-derived native session id has not landed yet, so
 // callers can fall back to fresh launch behavior. AO deliberately uses run
@@ -165,7 +165,9 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		cmd = append(cmd, "--system", systemPrompt)
 	}
 	appendModelFlag(&cmd, cfg.Config)
-	cmd = append(cmd, "--resume", "--session-id", agentSessionID)
+	// Goose requires one of --instructions, --text, or --recipe even when
+	// resuming. Empty text preserves the interactive, non-replaying behavior.
+	cmd = append(cmd, "-t", "", "--resume", "--session-id", agentSessionID)
 	return cmd, true, nil
 }
 

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -440,12 +440,12 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 	}
 	want := []string{
 		"env", "GOOSE_MODE=auto",
-		"goose", "run", "--system", "restore inline wins", "--resume", "--session-id", "20260720_1",
+		"goose", "run", "--system", "restore inline wins", "-t", "", "--resume", "--session-id", "20260720_1",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
 	}
-	if contains(cmd, "-t") || contains(cmd, "restore original task") {
+	if contains(cmd, "restore original task") {
 		t.Fatalf("restore command %#v unexpectedly replays the original task", cmd)
 	}
 }

--- a/frontend/src/landing/src/app/docs/components/DocsToc.tsx
+++ b/frontend/src/landing/src/app/docs/components/DocsToc.tsx
@@ -15,6 +15,11 @@ export function DocsToc({ toc }: { toc: TocItem[] }) {
         // Last heading whose top has scrolled past the header band is the active one.
         if (el && el.getBoundingClientRect().top <= 120) current = id;
       }
+      // The last heading may never reach the threshold when the document
+      // cannot scroll any further. At the bottom, it is the active section.
+      if (window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
+        current = ids.at(-1) ?? current;
+      }
       setActive(current);
     };
     update();

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -877,12 +877,12 @@ describe("SessionInspector Activity section", () => {
 		);
 		expect(rows).toEqual([
 			"Idle",
-			"Done",
+			"Created workspace3h ago",
 			"Merged PR #40",
+			"Draft PR #42",
+			"Done",
 			"Opened PR #40",
 			"Opened PR #41",
-			"Draft PR #42",
-			"Created workspace3h ago",
 		]);
 
 		const eventRows = section.querySelectorAll("[data-testid='inspector-timeline-event']");

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -921,45 +921,53 @@ function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: 
 		tone: TimelineTone;
 		node: ReactNode;
 		ts: string | null;
+		sortTs: number;
+		seq?: number;
 		markerTone?: string;
 		markerBreathe?: boolean;
 	}[] = [];
 
-	history.push({
+	const addHistory = (event: (typeof history)[number]) => history.push({ ...event, seq: history.length });
+	addHistory({
 		tone: "neutral",
 		node: <>{appI18n.t("inspector.timeline.createdWorkspace")}</>,
 		ts: formatTimeCompact(session.createdAt ?? session.updatedAt),
+		sortTs: Date.parse(session.createdAt ?? session.updatedAt ?? "") || 0,
 	});
 
 	for (const pr of prs.filter((pr) => pr.state === "draft")) {
-		history.push({
+		addHistory({
 			tone: "neutral",
 			node: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.draft")} />,
 			ts: prStateTime(pr),
+			sortTs: Date.parse(pr.stateChangedAt ?? pr.updatedAt ?? pr.createdAt ?? "") || 0,
 		});
 	}
 
 	for (const pr of prs.filter((pr) => pr.state !== "draft")) {
-		history.push({
+		addHistory({
 			tone: "neutral",
 			node: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.opened")} />,
 			ts: prCreatedTime(pr),
+			sortTs: Date.parse(pr.createdAt ?? "") || 0,
 		});
 	}
 
 	for (const pr of prs.filter((pr) => pr.state === "merged")) {
-		history.push({
+		addHistory({
 			tone: "good",
 			node: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.merged")} />,
 			ts: prStateTime(pr),
+			sortTs: Date.parse(pr.stateChangedAt ?? pr.updatedAt ?? "") || 0,
 		});
 	}
 
 	if (session.status === "merged") {
-		history.push({
+		addHistory({
 			tone: "good",
 			node: <>{appI18n.t("inspector.timeline.done")}</>,
 			ts: latestMergedTime(prs),
+			sortTs: latestMergedMilliseconds(prs),
 		});
 	}
 
@@ -996,7 +1004,7 @@ function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: 
 		markerTone: string;
 		markerBreathe: boolean;
 	};
-	const events = [current, ...history.reverse()];
+	const events = [current, ...[...history].sort((a, b) => b.sortTs - a.sortTs || (b.seq ?? 0) - (a.seq ?? 0))];
 
 	return (
 		<div className="relative pl-5">
@@ -1057,6 +1065,16 @@ function prCreatedTime(pr: SessionPRSummary): string | null {
 }
 
 function latestMergedTime(prs: SessionPRSummary[]): string | null {
+	const latest = latestMergedTimestamp(prs);
+	return latest ? formatTimeCompact(latest) : null;
+}
+
+function latestMergedMilliseconds(prs: SessionPRSummary[]): number {
+	const timestamp = latestMergedTimestamp(prs);
+	return timestamp ? Date.parse(timestamp) : 0;
+}
+
+function latestMergedTimestamp(prs: SessionPRSummary[]): string | null {
 	let latest: { timestamp: string; milliseconds: number } | undefined;
 	for (const pr of prs) {
 		if (pr.state !== "merged" || !pr.stateChangedAt) continue;
@@ -1066,7 +1084,7 @@ function latestMergedTime(prs: SessionPRSummary[]): string | null {
 			latest = { timestamp: pr.stateChangedAt, milliseconds };
 		}
 	}
-	return latest ? formatTimeCompact(latest.timestamp) : null;
+	return latest?.timestamp ?? null;
 }
 
 type ScmTimelineState = "ci_failed" | "changes_requested" | "conflict";


### PR DESCRIPTION
This PR contains three independently verified, low-risk fixes:

- Fix Goose restore commands for Goose 1.45+ by supplying the required empty `-t` argument. Fixes #3581.
- Sort Session Inspector activity history by event timestamp instead of category insertion order. Fixes #3698.
- Activate the final Docs TOC heading when the page reaches its scroll limit. Fixes #3486.

Verification:
- `go test ./internal/adapters/agent/goose`
- `npm test -- --run src/renderer/components/SessionInspector.test.tsx`
- `npm run typecheck`

