### PR TITLE
fix(send): delay Enter after large Codex paste bursts

### DIFF
--- a/backend/internal/adapters/runtime/conpty/client.go
+++ b/backend/internal/adapters/runtime/conpty/client.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"syscall"
 	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/inputdelay"
 )
 
 const (
@@ -60,12 +62,13 @@ func clientSendMessage(addr, message string) error {
 		}
 	}
 
-	// Brief pause before Enter (matches TS: Enter sent as a separate frame).
+	// Let large or multiline pastes settle before Enter. This widens the first
+	// Enter only, rather than sending a risky retry into a Codex decision prompt.
 	// Skipped for an empty message — an Enter-only nudge has no paste to let
 	// settle, and the pause would only widen the guard-read→Enter window
 	// (mirrors the tmux runtime's enterDelay contract).
-	if len(runes) > 0 {
-		time.Sleep(ptyInputEnterDelay)
+	if delay := inputdelay.ForMessage(message, ptyInputEnterDelay); delay > 0 {
+		time.Sleep(delay)
 	}
 	frame, err := EncodeMessage(MsgTerminalInput, []byte("\r"))
 	if err != nil {

--- a/backend/internal/adapters/runtime/inputdelay/inputdelay.go
+++ b/backend/internal/adapters/runtime/inputdelay/inputdelay.go
@@ -1,0 +1,40 @@
+// Package inputdelay computes the pre-Enter pause after terminal text input.
+package inputdelay
+
+import (
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	chunkRunes = 512
+	burstDelay = time.Second
+	burstStep  = 150 * time.Millisecond
+	maxDelay   = 2 * time.Second
+)
+
+// ForMessage returns the time to let a pasted message settle before Enter.
+// Empty messages are intentional Enter-only nudges and must remain immediate.
+// Multiline and chunked pastes need longer than the ordinary delay, but this
+// never retries Enter, so it cannot approve a prompt that was not submitted.
+func ForMessage(message string, configured time.Duration) time.Duration {
+	if message == "" {
+		return 0
+	}
+
+	runes := utf8.RuneCountInString(message)
+	if !strings.Contains(message, "\n") && runes <= chunkRunes {
+		return configured
+	}
+
+	chunks := (runes + chunkRunes - 1) / chunkRunes
+	delay := burstDelay + time.Duration(chunks-1)*burstStep
+	if delay > maxDelay {
+		delay = maxDelay
+	}
+	if configured > delay {
+		return configured
+	}
+	return delay
+}

--- a/backend/internal/adapters/runtime/inputdelay/inputdelay_test.go
+++ b/backend/internal/adapters/runtime/inputdelay/inputdelay_test.go
@@ -1,0 +1,31 @@
+package inputdelay
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestForMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		message    string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{"empty nudge", "", 300 * time.Millisecond, 0},
+		{"short line", "hello", 300 * time.Millisecond, 300 * time.Millisecond},
+		{"multiline", "hello\nworld", 300 * time.Millisecond, time.Second},
+		{"first chunk boundary", strings.Repeat("a", 512), 300 * time.Millisecond, 300 * time.Millisecond},
+		{"second chunk", strings.Repeat("a", 513), 300 * time.Millisecond, 1150 * time.Millisecond},
+		{"capped burst", strings.Repeat("a", 10_000), 300 * time.Millisecond, 2 * time.Second},
+		{"configured longer delay", "hello\nworld", 3 * time.Second, 3 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ForMessage(tt.message, tt.configured); got != tt.want {
+				t.Fatalf("ForMessage() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/inputdelay"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/ptyexec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -595,11 +596,11 @@ func (r *Runtime) SendMessage(ctx context.Context, handle ports.RuntimeHandle, m
 		// Errors reported by tmux after it accepts a chunk still return to the
 		// caller; they are not retried because AO cannot safely distinguish
 		// whether tmux applied the failed command.
-		if r.enterDelay > 0 {
+		if delay := inputdelay.ForMessage(message, r.enterDelay); delay > 0 {
 			select {
 			case <-enterCtx.Done():
 				return enterCtx.Err()
-			case <-time.After(r.enterDelay):
+			case <-time.After(delay):
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #3626.

This keeps Codex safe from a second, potentially destructive Enter while giving multiline and multi-frame terminal pastes longer to settle before their original Enter is sent.

- Short single-line messages retain the configured 300 ms delay.
- Multiline or more-than-512-rune messages use a 1 s delay plus 150 ms per extra chunk, capped at 2 s.
- Longer configured tmux delays are preserved.
- Empty Enter-only nudges remain immediate.
- Unix tmux and Windows ConPTY use the same policy.

Verification:
- `go test ./internal/adapters/runtime/inputdelay ./internal/adapters/runtime/conpty ./internal/adapters/runtime/tmux`
- `go test -race ./internal/adapters/runtime/inputdelay ./internal/adapters/runtime/conpty ./internal/adapters/runtime/tmux`
- `go build ./...`

`go test ./...` reached unrelated, pre-existing 3-second auth-probe timeouts in the Kilo Code and OpenCode adapter packages. The affected runtime packages passed.

