### PR TITLE
fix: gate review rows until verdict

### DIFF
--- a/frontend/e2e/reviews-tab.spec.ts
+++ b/frontend/e2e/reviews-tab.spec.ts
@@ -55,13 +55,13 @@ test("the Reviews tab renders the reviewer panel for a session that owns PRs", a
 
 	await inspector.getByRole("tab", { name: "Reviews" }).click();
 
-	// The reviewer card surfaces the harness, its approved verdict, and both
-	// actions — never the empty state, since this session owns a PR.
+	// The reviewer card surfaces the harness, its approved verdict, and the rerun
+	// action — never the empty state, since this session owns a PR.
 	await expect(inspector.getByText("No pull request opened yet.")).toHaveCount(0);
 	await expect(inspector.getByText("codex")).toBeVisible();
 	await expect(inspector.getByText("Approved")).toBeVisible();
 	await expect(inspector.getByRole("button", { name: "Re-run review" })).toBeVisible();
-	await expect(inspector.getByRole("button", { name: "Open terminal" })).toBeVisible();
+	await expect(inspector.getByRole("button", { name: "Open terminal" })).toHaveCount(0);
 });
 
 test("the Reviews tab shows the empty state for a session with no PRs", async ({ page }) => {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1267,6 +1267,20 @@ describe("SessionInspector summary reviews", () => {
 		expect(screen.getByText("Changes requested")).toBeInTheDocument();
 	});
 
+	it("hides agent review PR rows while a triggered review is still running without a verdict", async () => {
+		const running = {
+			...reviewState(3, "running", "sha-1"),
+			latestRun: { ...approvedReview, id: "run-live", harness: "codex", status: "running", verdict: "" },
+		};
+		mockCommonGets([], "reviewer-pane", [running]);
+
+		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+		await screen.findByText("Review in progress · codex");
+
+		expect(screen.queryByText("Reviewable change 3")).not.toBeInTheDocument();
+		expect(screen.queryByText("Reviews")).not.toBeInTheDocument();
+	});
+
 	it("shows eligible and up-to-date open PR review rows", async () => {
 		mockCommonGets([approvedReview], "reviewer-pane", [
 			reviewState(3, "needs_review", "abc123"),
@@ -1288,6 +1302,7 @@ describe("SessionInspector summary reviews", () => {
 		expect(screen.queryByText("Reviewable change 5")).not.toBeInTheDocument();
 		expect(screen.getAllByText("Approved")).not.toHaveLength(0);
 		expect(screen.getByRole("button", { name: "Re-run review" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Open terminal" })).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Run" })).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Re-run" })).not.toBeInTheDocument();
 	});

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -14,7 +14,6 @@ import {
 	GitMerge,
 	Info,
 	Play,
-	Terminal,
 	Trash2,
 	Loader2,
 	X,
@@ -1253,29 +1252,28 @@ function ReviewsSection({
 		<div>
 			{/* Running a review is an action; reading them is a list. The action stays
 			    on top, then one list carrying both sources keyed by PR. */}
-				<ReviewPanel
-					config={projectConfigQuery.data}
-					error={reviewsQuery.error ?? triggerReview.error ?? cancelReview.error ?? killReview.error ?? saveReviewer.error}
+			<ReviewPanel
+				config={projectConfigQuery.data}
+				error={reviewsQuery.error ?? triggerReview.error ?? cancelReview.error ?? killReview.error ?? saveReviewer.error}
 				isLoading={reviewsQuery.isLoading}
 				isCancelling={cancelReview.isPending}
 				isKilling={killReview.isPending}
 				isSwitchingReviewer={saveReviewer.isPending}
 				isTriggering={triggerReview.isPending}
-				onOpenTerminal={onOpenReviewerTerminal}
 				onCancel={() => cancelReview.mutate()}
 				onKill={() => killReview.mutate()}
 				onTrigger={() => triggerReview.mutate()}
 				reviewerHandleId={reviewsQuery.data?.reviewerHandleId ?? ""}
 				reviewStates={reviewStates}
-					notice={reviewNotice}
-					agentCatalog={agentsQuery.data}
-					reviewerOverride={reviewerOverride}
-					onReviewerOverrideChange={(next) => {
-						setReviewerOverride(next);
-						saveReviewer.mutate(next);
-					}}
-					session={session}
-				/>
+				notice={reviewNotice}
+				agentCatalog={agentsQuery.data}
+				reviewerOverride={reviewerOverride}
+				onReviewerOverrideChange={(next) => {
+					setReviewerOverride(next);
+					saveReviewer.mutate(next);
+				}}
+				session={session}
+			/>
 			<MergedReviewsSection
 				githubPRs={githubReviews}
 				isLoading={scmSummary.isLoading}
@@ -1635,7 +1633,6 @@ function ReviewPanel({
 	onTrigger,
 	onCancel,
 	onKill,
-	onOpenTerminal,
 }: {
 	session: WorkspaceSession;
 	config?: ProjectConfig;
@@ -1654,7 +1651,6 @@ function ReviewPanel({
 	onTrigger: () => void;
 	onCancel: () => void;
 	onKill: () => void;
-	onOpenTerminal?: OpenReviewerTerminal;
 }) {
 	const { t } = useTranslation();
 	if (sortedPRs(session).length === 0) {
@@ -1677,15 +1673,10 @@ function ReviewPanel({
 	const latest = runningRun ?? newestRun;
 	const harness = latest?.harness || config?.reviewers?.[0]?.harness || "claude-code";
 	const projectDefaultLabel = t("newTask.projectDefault");
-	const terminalEnabled = Boolean(reviewerHandleId && onOpenTerminal);
 	const hasReviewerSession = reviewerHandleId.trim() !== "";
 	const reviewRunning = openReviewStates.some((reviewState) => reviewState.status === "running");
 	const reviewHasRun = reviewRunning || Boolean(latest);
 	const runAction = reviewSessionRunAction(openReviewStates, isTriggering);
-	const openReviewerTerminal = () => {
-		if (!terminalEnabled) return;
-		onOpenTerminal?.({ handleId: reviewerHandleId, harness });
-	};
 	const runDisabled =
 		isTriggering ||
 		isKilling ||
@@ -1778,27 +1769,12 @@ function ReviewPanel({
 									<Trash2 aria-hidden="true" />
 								</Button>
 							) : null}
-							{reviewHasRun ? (
-								<Button
-									aria-label={t("inspector.openTerminal")}
-									className="shrink-0 gap-1.5 [&_svg]:size-icon-sm"
-									disabled={!terminalEnabled}
-									onClick={openReviewerTerminal}
-									size="sm"
-									title={t("inspector.openTerminal")}
-									type="button"
-									variant="ghost"
-								>
-									<Terminal aria-hidden="true" />
-									<span className="review-run-action-label">{t("inspector.openTerminal")}</span>
-								</Button>
-							) : null}
 						</div>
 					</div>
-					</div>
+				</div>
 				{reviewRunning ? (
 					<div className="mt-3 flex items-center gap-2 border-t border-border pt-3">
-							<Loader2 aria-hidden="true" className="size-icon-sm shrink-0 animate-spin text-muted-foreground" />
+						<Loader2 aria-hidden="true" className="size-icon-sm shrink-0 animate-spin text-muted-foreground" />
 						<span className="min-w-0 flex-1 truncate text-2xs font-medium text-muted-foreground">
 							{isCancelling ? t("inspector.review.cancelling") : `Review in progress · ${harness}`}
 						</span>
@@ -2055,13 +2031,24 @@ function runsByPRFrom(openReviewStates: PRReviewState[], runs: ReviewRunFacts[])
 	return byPR;
 }
 
-/** The PRs AO has actually reviewed, or been asked to. */
+function reviewRunHasOutcome(run: ReviewRunFacts | undefined): boolean {
+	return Boolean(
+		run &&
+			(run.verdict?.trim() ||
+				run.status === "complete" ||
+				run.status === "delivered" ||
+				run.status === "failed" ||
+				run.status === "cancelled"),
+	);
+}
+
+/** The PRs AO has an agent review outcome for. */
 function triggeredReviewStatesFrom(openReviewStates: PRReviewState[], runs: ReviewRunFacts[]): PRReviewState[] {
 	return openReviewStates.filter(
 		(reviewState) =>
-			Boolean(reviewState.latestRun) ||
-			Boolean(reviewState.previousRun) ||
-			runs.some((run) => run.prUrl === reviewState.prUrl) ||
+			reviewRunHasOutcome(reviewState.latestRun) ||
+			reviewRunHasOutcome(reviewState.previousRun) ||
+			runs.some((run) => run.prUrl === reviewState.prUrl && reviewRunHasOutcome(run)) ||
 			reviewState.status === "up_to_date" ||
 			reviewState.status === "changes_requested",
 	);


### PR DESCRIPTION
## Summary
- Hide agent review PR rows while a triggered review is still running without a verdict/outcome
- Remove the Open terminal button from the Run review controls
- Update renderer and e2e expectations for the changed review panel behavior

## Tests
- git diff --check
- Not run: npm --prefix frontend test -- SessionInspector.test.tsx (local node_modules missing; vitest not found)
- Not run: npm run frontend:typecheck (local node_modules missing; tsc not found)

## Risks / follow-ups
- CI should run the frontend test/typecheck jobs in an environment with dependencies installed.