### PR TITLE
fix: sanitize project IDs derived from folder names with dots/special chars

### DIFF
--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -834,8 +834,16 @@ func defaultProjectID(path string) domain.ProjectID {
 	id := strings.ToLower(filepath.Base(path))
 	id = strings.TrimSpace(id)
 	id = strings.ReplaceAll(id, " ", "-")
+	id = nonAlphanumeric.ReplaceAllString(id, "-")
+	// Trim leading/trailing hyphens/underscores that could violate validation
+	id = strings.Trim(id, "-_")
+	if id == "" {
+		id = "project"
+	}
 	return domain.ProjectID(id)
 }
+
+var nonAlphanumeric = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 
 var projectIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 


### PR DESCRIPTION
## Summary

When a user runs `ao start` in a directory like `llama.cpp`, the derived project ID would fail validation with:

```
Error: [
  {
    "validation": "regex",
    "code": "invalid_string",
    "message": "Project ID must match [a-zA-Z0-9_-]+ (no dots, slashes, or special characters)",
    "path": [
      "projects",
      "llama.cpp"
    ]
  }
]
```

## Changes

- Modified `defaultProjectID` in `backend/internal/service/project/service.go` to:
  1. Replace non-alphanumeric characters (except `_` and `-`) with hyphens
  2. Trim leading/trailing hyphens/underscores that could violate validation
  3. Fall back to "project" for edge cases (e.g., folders with only special chars)

## Test Cases

| Input | Output | Valid |
|-------|--------|-------|
| `llama.cpp` | `llama-cpp` | ✓ |
| `my-project` | `my-project` | ✓ |
| `test@domain` | `test-domain` | ✓ |
| `special!@#$chars` | `special-chars` | ✓ |
| `.config` | `config` | ✓ |
| `@myproject` | `myproject` | ✓ |
| `---test---` | `test` | ✓ |
| `...` | `project` | ✓ |

## Testing

- All existing tests pass: `go test ./internal/service/project/... -race`
- Build passes: `go build ./...`

Fixes #1877