### PR TITLE
fix: reject spawn for closed/cancelled tracker issues

### DIFF
--- a/backend/internal/domain/tracker.go
+++ b/backend/internal/domain/tracker.go
@@ -32,6 +32,12 @@ const (
 	IssueCancelled  NormalizedIssueState = "cancelled"
 )
 
+// IsTerminal reports whether the issue's work is finished (done or cancelled)
+// and no further session should be spawned against it.
+func (s NormalizedIssueState) IsTerminal() bool {
+	return s == IssueDone || s == IssueCancelled
+}
+
 // Issue is the minimum projection every tracker can produce. Provider-specific
 // metadata stays inside provider-specific code paths.
 type Issue struct {

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -540,7 +540,7 @@ func cannotNudge(rec domain.SessionRecord) bool {
 }
 
 func isTerminalTrackerState(state domain.NormalizedIssueState) bool {
-	return state == domain.IssueDone || state == domain.IssueCancelled
+	return state.IsTerminal()
 }
 
 func newBotCommentContent(comments []ports.TrackerCommentObservation) ([]string, []string) {

--- a/backend/internal/service/session/issue_context.go
+++ b/backend/internal/service/session/issue_context.go
@@ -27,6 +27,7 @@ func (s *Service) withIssueContext(ctx context.Context, cfg ports.SpawnConfig, p
 	}
 	issue, err := s.tracker.Get(ctx, id)
 	if err != nil {
+		//nolint:nilerr // tracker fetch failure falls back to spawn with no issue context (TestSpawnIssueContextFetchFailureFallsBack)
 		return cfg, nil
 	}
 	if issue.State.IsTerminal() {

--- a/backend/internal/service/session/issue_context.go
+++ b/backend/internal/service/session/issue_context.go
@@ -8,30 +8,34 @@ import (
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 const issueContextBodyLimit = 12000
 
-func (s *Service) withIssueContext(ctx context.Context, cfg ports.SpawnConfig, project domain.ProjectRecord) ports.SpawnConfig {
+func (s *Service) withIssueContext(ctx context.Context, cfg ports.SpawnConfig, project domain.ProjectRecord) (ports.SpawnConfig, error) {
 	if cfg.IssueContext != "" || cfg.IssueID == "" || s.tracker == nil {
-		return cfg
+		return cfg, nil
 	}
 	if cfg.Kind != "" && cfg.Kind != domain.KindWorker {
-		return cfg
+		return cfg, nil
 	}
 	id, ok := s.trackerIDForIssue(project, cfg.IssueID)
 	if !ok {
-		return cfg
+		return cfg, nil
 	}
 	issue, err := s.tracker.Get(ctx, id)
 	if err != nil {
-		return cfg
+		return cfg, nil
+	}
+	if issue.State.IsTerminal() {
+		return cfg, apierr.Conflict("ISSUE_CLOSED", fmt.Sprintf("Issue %s is closed. Cannot spawn a session for a closed/cancelled issue.", id.Native), nil)
 	}
 	if issueContext := formatIssueContext(issue); issueContext != "" {
 		cfg.IssueContext = issueContext
 	}
-	return cfg
+	return cfg, nil
 }
 
 func (s *Service) trackerIDForIssue(project domain.ProjectRecord, issueID domain.IssueID) (domain.TrackerID, bool) {

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -237,7 +237,10 @@ func (s *Service) spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	if err != nil {
 		return domain.Session{}, 0, 0, fmt.Errorf("count sessions: %w", err)
 	}
-	cfg = s.withIssueContext(ctx, cfg, project)
+	cfg, err = s.withIssueContext(ctx, cfg, project)
+	if err != nil {
+		return domain.Session{}, 0, 0, err
+	}
 	rec, promptBytes, systemPromptBytes, err := s.manager.Spawn(ctx, cfg)
 	if err != nil {
 		s.emitSpawnFailed(cfg, err, s.now().Sub(start).Milliseconds())

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -1505,6 +1505,66 @@ func TestSpawnIssueContextSkipsUnresolvableIssueRef(t *testing.T) {
 	}
 }
 
+func TestSpawnRejectsTerminalIssueState(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", RepoOriginURL: "https://github.com/acme/repo"}
+	fc := &fakeCommander{}
+
+	for _, tc := range []struct {
+		name  string
+		state domain.NormalizedIssueState
+	}{
+		{name: "done", state: domain.IssueDone},
+		{name: "cancelled", state: domain.IssueCancelled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := &fakeTracker{issue: domain.Issue{
+				ID:    domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/repo#123"},
+				Title: "Closed work item",
+				State: tc.state,
+			}}
+			svc := NewWithDeps(Deps{Manager: fc, Store: st, Tracker: tracker})
+
+			_, _, _, err := svc.Spawn(context.Background(), ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, IssueID: "123"})
+			if err == nil {
+				t.Fatalf("Spawn: expected error for %s issue, got nil", tc.state)
+			}
+			apiErr := &apierr.Error{}
+			if !errors.As(err, &apiErr) || apiErr.Code != "ISSUE_CLOSED" {
+				t.Fatalf("error = %v, want apierr ISSUE_CLOSED", err)
+			}
+			if !strings.Contains(err.Error(), "closed/cancelled issue") {
+				t.Fatalf("error message = %q, want closed/cancelled issue hint", err.Error())
+			}
+			if fc.spawned {
+				t.Fatalf("manager.Spawn called for %s issue; no session should be created", tc.state)
+			}
+			if len(tracker.ids) != 1 || tracker.ids[0].Native != "acme/repo#123" {
+				t.Fatalf("tracker ids = %+v, want exactly acme/repo#123", tracker.ids)
+			}
+		})
+	}
+}
+
+func TestSpawnAllowsInProgressIssueState(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", RepoOriginURL: "https://github.com/acme/repo"}
+	fc := &fakeCommander{}
+	tracker := &fakeTracker{issue: domain.Issue{
+		ID:    domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/repo#42"},
+		Title: "Work in progress",
+		State: domain.IssueInProgress,
+	}}
+	svc := NewWithDeps(Deps{Manager: fc, Store: st, Tracker: tracker})
+
+	if _, _, _, err := svc.Spawn(context.Background(), ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, IssueID: "42"}); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if !fc.spawned {
+		t.Fatalf("manager.Spawn not called for in_progress issue")
+	}
+}
+
 func TestSpawnFailedEmitsDuration(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer"}


### PR DESCRIPTION
## Summary

Running `ao spawn <issue-number>` on a **closed or cancelled issue** proceeds through the entire spawn pipeline — session ID reservation, worktree creation, tmux pane, and agent launch — without ever checking whether the issue is still open. This spawns a full session on already-resolved work.

## Changes

- **Gate the spawn on issue state** inside `withIssueContext` (`backend/internal/service/session/issue_context.go`), the single funnel for CLI, HTTP and dashboard spawns. When the fetched issue is in a terminal state (`done` or `cancelled`), return `apierr.Conflict` `ISSUE_CLOSED` before any session/worktree/tmux is created.
- **Factor the terminal-state predicate** onto `domain.NormalizedIssueState.IsTerminal()` so `lifecycle` and the session service share one source of truth instead of a duplicated inline check.
- **`Service.Spawn`/spawn** propagate the error instead of proceeding to `manager.Spawn`.

`in_progress` and `review` issues still spawn normally (matches `isTerminalTrackerState` in `backend/internal/lifecycle/reactions.go`).

## Test coverage

- `TestSpawnRejectsTerminalIssueState`: done and cancelled issues return `ISSUE_CLOSED` and never reach `manager.Spawn`.
- `TestSpawnAllowsInProgressIssueState`: an in-progress issue still spawns.

## Verification

- `cd backend && go build ./...`
- `go test ./internal/service/session/... ./internal/domain/... ./internal/lifecycle/...` — pass
- `go vet ./internal/service/session/... ./internal/domain/... ./internal/lifecycle/...` — clean

Fixes #2063