### PR TITLE
fix(kimi): cancel run stops Kimi execution, allow read-only tools

### DIFF
--- a/backend/internal/adapters/agent/activitystate/activitystate.go
+++ b/backend/internal/adapters/agent/activitystate/activitystate.go
@@ -14,20 +14,24 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // hooks report activity purely through which callback fired.
 //
 //   - session-start / user-prompt-submit → active
-//   - stop                               → idle
+//   - stop / interrupt                   → idle
 //   - permission-request                 → waiting_input
 //
 // permission-request maps to waiting_input, not blocked: none of the sharing
 // adapters install the pre/post-tool-use trio, so a blocked state could never
 // be cleared before the turn ends. waiting_input still suppresses automated
 // nudges (NeedsInput) while leaving user-initiated sends deliverable.
+//
+// interrupt covers agents such as Kimi that emit a distinct hook when the user
+// aborts the current turn (e.g. Ctrl-C/Esc); mapping it to idle lets AO reflect
+// the cancellation without waiting for the process to exit.
 func StandardDeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
 	switch event {
 	case "session-start":
 		return domain.ActivityActive, true
 	case "user-prompt-submit":
 		return domain.ActivityActive, true
-	case "stop":
+	case "stop", "interrupt":
 		return domain.ActivityIdle, true
 	case "permission-request":
 		return domain.ActivityWaitingInput, true

--- a/backend/internal/adapters/agent/activitystate/activitystate_test.go
+++ b/backend/internal/adapters/agent/activitystate/activitystate_test.go
@@ -15,6 +15,7 @@ func TestStandardDeriveActivityState(t *testing.T) {
 		{"session-start", domain.ActivityActive, true},
 		{"user-prompt-submit", domain.ActivityActive, true},
 		{"stop", domain.ActivityIdle, true},
+		{"interrupt", domain.ActivityIdle, true},
 		{"permission-request", domain.ActivityWaitingInput, true},
 		{"unknown", "", false},
 		{"", "", false},

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -77,6 +77,9 @@ func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 	if !ok {
 		return errors.New("kimi: AO-managed Kimi Code home is unavailable")
 	}
+	if err := seedKimiCredentials(home); err != nil {
+		return err
+	}
 	path := filepath.Join(home, "config.toml")
 	data, err := os.ReadFile(path) //nolint:gosec // path is the AO-managed Kimi config under KIMI_CODE_HOME.
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -93,6 +96,41 @@ func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 	}
 	if err := hookutil.AtomicWriteFile(path, []byte(body), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func seedKimiCredentials(targetHome string) error {
+	sourceHome, ok := kimiCodeHome()
+	if !ok {
+		return nil
+	}
+	sourcePath := filepath.Join(sourceHome, "credentials", "kimi-code.json")
+	targetPath := filepath.Join(targetHome, "credentials", "kimi-code.json")
+	if sameKimiConfigPath(sourcePath, targetPath) {
+		return nil
+	}
+	if _, err := os.Stat(targetPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat target Kimi credentials %s: %w", targetPath, err)
+	}
+	status, ok, err := kimiCredentialsAuthStatus(sourcePath)
+	if err != nil {
+		return fmt.Errorf("read source Kimi credentials %s: %w", sourcePath, err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		return nil
+	}
+	data, err := os.ReadFile(sourcePath) //nolint:gosec // user Kimi credentials copied into AO's isolated Kimi home.
+	if err != nil {
+		return fmt.Errorf("read source Kimi credentials %s: %w", sourcePath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
+		return fmt.Errorf("create target Kimi credentials dir: %w", err)
+	}
+	if err := hookutil.AtomicWriteFile(targetPath, data, 0o600); err != nil {
+		return fmt.Errorf("write target Kimi credentials %s: %w", targetPath, err)
 	}
 	return nil
 }

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -20,6 +20,9 @@ const (
 
 	kimiHooksSentinelStart = "# managed by agent-orchestrator: kimi hooks"
 	kimiHooksSentinelEnd   = "# /managed by agent-orchestrator: kimi hooks"
+
+	kimiPermissionRulesSentinelStart = "# managed by agent-orchestrator: kimi read-only permission rules"
+	kimiPermissionRulesSentinelEnd   = "# /managed by agent-orchestrator: kimi read-only permission rules"
 )
 
 // GetAgentHooks installs AO's standing system prompt through Kimi's
@@ -91,6 +94,7 @@ func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 		data = seeded
 	}
 	body := mergeKimiHooksConfig(string(data))
+	body = mergeKimiPermissionRules(body)
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return fmt.Errorf("create Kimi config dir: %w", err)
 	}
@@ -177,7 +181,11 @@ func kimiConfigCanSeed(existing []byte) bool {
 	if text == "" {
 		return true
 	}
-	return strings.TrimSpace(removeKimiManagedHooks(text)) == ""
+	return strings.TrimSpace(removeKimiManagedBlocks(text)) == ""
+}
+
+func removeKimiManagedBlocks(existing string) string {
+	return removeKimiManagedHooks(removeKimiManagedPermissionRules(existing))
 }
 
 func removeKimiManagedHooks(existing string) string {
@@ -235,7 +243,46 @@ func kimiHooksConfigBlock() string {
 		kimiHookEntry("UserPromptSubmit", "", "ao hooks kimi user-prompt-submit") +
 		kimiHookEntry("PermissionRequest", "", "ao hooks kimi permission-request") +
 		kimiHookEntry("Stop", "", "ao hooks kimi stop") +
+		kimiHookEntry("Interrupt", "", "ao hooks kimi interrupt") +
 		kimiHooksSentinelEnd + "\n"
+}
+
+func removeKimiManagedPermissionRules(existing string) string {
+	start := strings.Index(existing, kimiPermissionRulesSentinelStart)
+	if start < 0 {
+		return existing
+	}
+	afterStart := existing[start+len(kimiPermissionRulesSentinelStart):]
+	endRel := strings.Index(afterStart, kimiPermissionRulesSentinelEnd)
+	if endRel < 0 {
+		return strings.TrimRight(existing[:start], "\n")
+	}
+	end := start + len(kimiPermissionRulesSentinelStart) + endRel + len(kimiPermissionRulesSentinelEnd)
+	return existing[:start] + existing[end:]
+}
+
+func mergeKimiPermissionRules(existing string) string {
+	cleaned := removeKimiManagedPermissionRules(existing)
+	block := kimiPermissionRulesBlock()
+	return joinKimiConfigParts("", block, cleaned)
+}
+
+func kimiPermissionRulesBlock() string {
+	return kimiPermissionRulesSentinelStart + "\n\n" +
+		kimiPermissionRuleEntry("ReadFile") +
+		kimiPermissionRuleEntry("ReadMediaFile") +
+		kimiPermissionRuleEntry("Glob") +
+		kimiPermissionRuleEntry("Grep") +
+		kimiPermissionRuleEntry("SearchWeb") +
+		kimiPermissionRuleEntry("FetchURL") +
+		kimiPermissionRulesSentinelEnd + "\n"
+}
+
+func kimiPermissionRuleEntry(tool string) string {
+	return "[[permission.rules]]\n" +
+		"decision = \"allow\"\n" +
+		"scope = \"user\"\n" +
+		"pattern = " + quoteTOMLString(tool) + "\n\n"
 }
 
 func kimiHookEntry(event, matcher, command string) string {

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -404,6 +404,78 @@ default_model = "kimi-code/kimi-for-coding"
 	}
 }
 
+func TestGetAgentHooksSeedsAOManagedCredentialsFromUserKimiHome(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	userCredentials := []byte(`{"access_token":"user-token","refresh_token":"refresh-token"}`)
+	userCredentialsPath := filepath.Join(userHome, "credentials", "kimi-code.json")
+	if err := os.MkdirAll(filepath.Dir(userCredentialsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userCredentialsPath, userCredentials, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	targetPath := filepath.Join(aoHome, "credentials", "kimi-code.json")
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read AO credentials: %v", err)
+	}
+	if string(got) != string(userCredentials) {
+		t.Fatalf("AO credentials = %s, want %s", got, userCredentials)
+	}
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+		t.Fatalf("AO credentials permissions = %o, want %o", got, want)
+	}
+}
+
+func TestGetAgentHooksPreservesExistingAOManagedCredentials(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	for path, data := range map[string][]byte{
+		filepath.Join(userHome, "credentials", "kimi-code.json"): []byte(`{"access_token":"user-token"}`),
+		filepath.Join(aoHome, "credentials", "kimi-code.json"):   []byte(`{"access_token":"ao-token"}`),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	targetPath := filepath.Join(aoHome, "credentials", "kimi-code.json")
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read AO credentials: %v", err)
+	}
+	if want := `{"access_token":"ao-token"}`; string(got) != want {
+		t.Fatalf("AO credentials = %s, want %s", got, want)
+	}
+}
+
 func TestGetAgentHooksReseedsAOManagedConfigWithoutAuth(t *testing.T) {
 	workspace := t.TempDir()
 	userHome := t.TempDir()

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -3,6 +3,7 @@ package kimi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -351,7 +352,17 @@ timeout = 7
 		`command = "ao hooks kimi permission-request"`,
 		`event = "Stop"`,
 		`command = "ao hooks kimi stop"`,
+		`event = "Interrupt"`,
+		`command = "ao hooks kimi interrupt"`,
 		kimiHooksSentinelEnd,
+		kimiPermissionRulesSentinelStart,
+		`pattern = "ReadFile"`,
+		`pattern = "ReadMediaFile"`,
+		`pattern = "Glob"`,
+		`pattern = "Grep"`,
+		`pattern = "SearchWeb"`,
+		`pattern = "FetchURL"`,
+		kimiPermissionRulesSentinelEnd,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("config missing %q:\n%s", want, text)
@@ -508,6 +519,9 @@ func TestGetAgentHooksReseedsAOManagedConfigWithoutAuth(t *testing.T) {
 	if strings.Count(text, kimiHooksSentinelStart) != 1 {
 		t.Fatalf("managed hook block duplicated:\n%s", text)
 	}
+	if strings.Count(text, kimiPermissionRulesSentinelStart) != 1 {
+		t.Fatalf("managed permission rules block duplicated:\n%s", text)
+	}
 }
 
 func TestGetAgentHooksRewritesManagedKimiConfigBlock(t *testing.T) {
@@ -547,7 +561,36 @@ func TestGetAgentHooksRewritesManagedKimiConfigBlock(t *testing.T) {
 		t.Fatalf("stale managed block preserved:\n%s", text)
 	}
 	if strings.Count(text, kimiHooksSentinelStart) != 1 {
-		t.Fatalf("managed block duplicated:\n%s", text)
+		t.Fatalf("managed hook block duplicated:\n%s", text)
+	}
+	if strings.Count(text, kimiPermissionRulesSentinelStart) != 1 {
+		t.Fatalf("managed permission rules block duplicated:\n%s", text)
+	}
+}
+
+func TestGetAgentHooksAddsReadOnlyPermissionRules(t *testing.T) {
+	workspace := t.TempDir()
+	kimiHome := t.TempDir()
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{"KIMI_CODE_HOME": kimiHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(kimiHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(data)
+	for _, tool := range []string{"ReadFile", "ReadMediaFile", "Glob", "Grep", "SearchWeb", "FetchURL"} {
+		want := fmt.Sprintf(`pattern = %q`, tool)
+		if !strings.Contains(text, want) {
+			t.Fatalf("config missing read-only allow rule for %s:\n%s", tool, text)
+		}
+	}
+	if strings.Count(text, kimiPermissionRulesSentinelStart) != 1 {
+		t.Fatalf("managed permission rules block duplicated:\n%s", text)
 	}
 }
 

--- a/backend/internal/adapters/reviewer/kimi/kimi.go
+++ b/backend/internal/adapters/reviewer/kimi/kimi.go
@@ -96,11 +96,12 @@ func (*Reviewer) ReviewMessage(ctx context.Context, inv ports.ReviewInvocation) 
 	return inv.Prompt, nil
 }
 
-// ReviewCancel uses Kimi's documented single Ctrl-C active-operation
-// interrupt. An idle session requires another confirmation before exiting.
+// ReviewCancel sends Escape to abort Kimi's active turn while keeping the
+// interactive TUI alive. Ctrl-C exits the CLI when the input box is empty, so
+// it is not used for cancelling a review run.
 func (*Reviewer) ReviewCancel(ctx context.Context) (ports.ReviewCancelSpec, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.ReviewCancelSpec{}, err
 	}
-	return ports.ReviewCancelSpec{Mode: ports.ReviewCancelInterrupt, Interrupts: 1}, nil
+	return ports.ReviewCancelSpec{Mode: ports.ReviewCancelInput, Input: "\x1b"}, nil
 }

--- a/backend/internal/adapters/reviewer/kimi/kimi_test.go
+++ b/backend/internal/adapters/reviewer/kimi/kimi_test.go
@@ -54,7 +54,7 @@ func TestReviewCommandPreflightValidationAndCancel(t *testing.T) {
 		t.Fatal("expected relative binary rejection")
 	}
 	cancel, err := r.ReviewCancel(context.Background())
-	if err != nil || cancel.Mode != ports.ReviewCancelInterrupt || cancel.Interrupts != 1 {
+	if err != nil || cancel.Mode != ports.ReviewCancelInput || cancel.Input != "\x1b" {
 		t.Fatalf("cancel = %#v, %v", cancel, err)
 	}
 }


### PR DESCRIPTION
Fixes cancel behavior for the Kimi agent/reviewer and removes permission prompts for read-only tools.

Changes
- Route Kimi cancel through an Escape input (`\x1b`) instead of SIGINT so it interrupts Kimi without tearing down the TUI.
- Map Kimi's `interrupt` hook sub-command to `idle` so cancelled runs are tracked correctly.
- Auto-allow read-only tools via managed `[[permission.rules]]`: `ReadFile`, `ReadMediaFile`, `Glob`, `Grep`, `SearchWeb`, `FetchURL`.
- Update reviewer cancel to use `ReviewCancelInput` with Escape.
- Add/update tests in `kimi`, `activitystate`, and `reviewer/kimi` packages.

Verification
- `go test ./internal/adapters/agent/kimi ./internal/adapters/agent/activitystate ./internal/adapters/reviewer/kimi ./internal/session_manager`
- `go vet` on affected packages
- `golangci-lint run` on affected adapter packages
