### PR TITLE
fix(chat): reconcile turn-state desync when Stop turn fails with CHAT_NO_ACTIVE_TURN

### DIFF
--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -33,6 +33,7 @@ type Store interface {
 	CreateConversation(ctx context.Context, id string, scope domain.ConversationScope, project domain.ProjectID, session domain.SessionID, now time.Time) (domain.ConversationRecord, error)
 	ConversationForSession(ctx context.Context, session domain.SessionID) (domain.ConversationRecord, error)
 	ClaimChatControllerGeneration(ctx context.Context, session domain.SessionID, generation string, now time.Time) error
+	GetRunningTurn(ctx context.Context, conversationID string) (id, providerTurnID string, ok bool, err error)
 
 	AdoptProviderTurn(ctx context.Context, conversationID string, session domain.SessionID, generation, turnID, providerTurnID string, now time.Time) error
 	AppendImportedUserMessage(ctx context.Context, conversationID, providerTurnID string, msg domain.ConversationMessage, now time.Time) error
@@ -1036,7 +1037,24 @@ const turnAckWait = 3 * time.Second
 func (c *Controller) Interrupt(ctx context.Context) error {
 	turn, ok := c.awaitAcknowledgedTurn(ctx)
 	if !ok {
-		return ErrNoActiveTurn
+		// Memory says nothing is running, but check SQLite — a prior
+		// SettleTurn failure may have left a turn in 'running' state
+		// while the in-memory pendingTurnID was already cleared.
+		_, providerTurnID, running, err := c.store.GetRunningTurn(ctx, c.conversation.ID)
+		if err != nil {
+			return fmt.Errorf("check running turn: %w", err)
+		}
+		if !running {
+			return ErrNoActiveTurn
+		}
+		// The turn is stale from the controller's perspective — the provider
+		// already emitted a completion event that failed to project. Settle
+		// it as interrupted so the UI unblocks, matching the user's intent.
+		if err := c.store.SettleTurn(ctx, c.conversation.ID, providerTurnID,
+			domain.TurnStateInterrupted, "reconciled by interrupt (stale running turn)", c.now()); err != nil {
+			return fmt.Errorf("reconcile stale running turn: %w", err)
+		}
+		return nil
 	}
 
 	c.mu.Lock()
@@ -1308,6 +1326,18 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 			}, now)
 
 	case ports.ChatEventTurnCompleted:
+		message := ""
+		if event.Err != nil {
+			message = event.Err.Error()
+		}
+		state := event.TurnState
+		if state == "" {
+			state = domain.TurnStateFailed
+		}
+		if err := c.store.SettleTurn(
+			ctx, c.conversation.ID, event.ProviderTurnID, state, message, now); err != nil {
+			return err
+		}
 		c.mu.Lock()
 		if c.pendingTurnID == event.ProviderTurnID {
 			c.pendingTurnID = ""
@@ -1317,19 +1347,6 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 		}
 		c.state = ports.ChatControllerReady
 		c.mu.Unlock()
-		message := ""
-		if event.Err != nil {
-			message = event.Err.Error()
-		}
-		state := event.TurnState
-		if state == "" {
-			// A completion with no status is not evidence of success.
-			state = domain.TurnStateFailed
-		}
-		if err := c.store.SettleTurn(
-			ctx, c.conversation.ID, event.ProviderTurnID, state, message, now); err != nil {
-			return err
-		}
 		return nil
 
 	case ports.ChatEventMessageDelta:

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -1034,27 +1034,48 @@ const turnAckWait = 3 * time.Second
 // the next message instead of stopping would be the opposite of what the button
 // says. The cutoff is recorded before the provider call, so a completion that
 // races back cannot drain the queue the interrupt was about to cancel.
+//
+// Two recovery paths exist for when memory and SQLite disagree:
+//
+//   - The provider says ErrChatNoActiveTurn for a turn memory still tracks. A
+//     prior tx.Commit failure rolled back the SettleTurn write while memory was
+//     already cleared (before the fix that moved clearing to afterProject), or
+//     the turn completed between awaitAcknowledgedTurn and the provider call.
+//     reconcileDurableTurn settles the durable row, clears memory, cancels the
+//     queue, and reports idle — the full Interrupt contract without a second
+//     provider send.
+//   - Memory says nothing is running but SQLite has a turn in 'running'. This
+//     is the dispatch race: BindTurnToProvider wrote 'running' before
+//     pendingTurnID was set, and Stop arrived in that window. Taking sendMu
+//     before the disk fallback ensures dispatch() has finished (and set
+//     pendingTurnID) before we decide to reconcile — if dispatch completed
+//     while we waited, the normal interrupt path runs instead. The durable
+//     turn is reconciled only if memory is still empty after the lock.
 func (c *Controller) Interrupt(ctx context.Context) error {
 	turn, ok := c.awaitAcknowledgedTurn(ctx)
 	if !ok {
-		// Memory says nothing is running, but check SQLite — a prior
-		// SettleTurn failure may have left a turn in 'running' state
-		// while the in-memory pendingTurnID was already cleared.
-		_, providerTurnID, running, err := c.store.GetRunningTurn(ctx, c.conversation.ID)
-		if err != nil {
-			return fmt.Errorf("check running turn: %w", err)
+		// Take sendMu so dispatch() cannot be mid-flight. If dispatch was
+		// running, it finishes first, sets pendingTurnID, and we go through
+		// the normal interrupt path instead of the disk fallback.
+		c.sendMu.Lock()
+		defer c.sendMu.Unlock()
+
+		c.mu.Lock()
+		pending := c.pendingTurnID
+		c.mu.Unlock()
+		if pending != "" {
+			// dispatch finished while we waited — interrupt normally.
+			turn = pending
+		} else {
+			_, providerTurnID, running, err := c.store.GetRunningTurn(ctx, c.conversation.ID)
+			if err != nil {
+				return fmt.Errorf("check running turn: %w", err)
+			}
+			if !running {
+				return ErrNoActiveTurn
+			}
+			return c.reconcileDurableTurn(ctx, providerTurnID)
 		}
-		if !running {
-			return ErrNoActiveTurn
-		}
-		// The turn is stale from the controller's perspective — the provider
-		// already emitted a completion event that failed to project. Settle
-		// it as interrupted so the UI unblocks, matching the user's intent.
-		if err := c.store.SettleTurn(ctx, c.conversation.ID, providerTurnID,
-			domain.TurnStateInterrupted, "reconciled by interrupt (stale running turn)", c.now()); err != nil {
-			return fmt.Errorf("reconcile stale running turn: %w", err)
-		}
-		return nil
 	}
 
 	c.mu.Lock()
@@ -1062,16 +1083,60 @@ func (c *Controller) Interrupt(ctx context.Context) error {
 	c.mu.Unlock()
 
 	if err := c.conv.Interrupt(ctx, turn); err != nil {
+		if errors.Is(err, ports.ErrChatNoActiveTurn) {
+			// The provider already finished this turn, but AO's memory and/or
+			// SQLite may still show it as running. Reconcile the durable state
+			// and cancel the queue rather than surfacing a bare ErrNoActiveTurn
+			// that leaves the user stuck on "Working".
+			c.mu.Lock()
+			c.cancelQueuedAt = time.Time{}
+			c.mu.Unlock()
+			return c.reconcileDurableTurn(ctx, turn)
+		}
 		// The interrupt did not happen, so the queue it was going to cancel is
 		// still the user's to send.
 		c.mu.Lock()
 		c.cancelQueuedAt = time.Time{}
 		c.mu.Unlock()
-		if errors.Is(err, ports.ErrChatNoActiveTurn) {
-			return ErrNoActiveTurn
-		}
 		return fmt.Errorf("interrupt turn %s: %w", turn, err)
 	}
+	return nil
+}
+
+// reconcileDurableTurn settles a turn that the controller can no longer cancel
+// through the normal path but SQLite still considers running. It attempts a
+// best-effort provider interrupt, settles the durable row as interrupted, clears
+// in-memory turn state, cancels queued turns, and reports idle — the full
+// Interrupt contract in one place so both recovery paths (ErrChatNoActiveTurn
+// from the provider and the dispatch-race disk fallback) share the same
+// behavior.
+func (c *Controller) reconcileDurableTurn(ctx context.Context, providerTurnID string) error {
+	if err := c.conv.Interrupt(ctx, providerTurnID); err != nil {
+		if !errors.Is(err, ports.ErrChatNoActiveTurn) {
+			c.log.Warn("provider interrupt during reconciliation failed",
+				"session", c.sessionID, "turn", providerTurnID, "error", err)
+		}
+	}
+
+	if err := c.store.SettleTurn(ctx, c.conversation.ID, providerTurnID,
+		domain.TurnStateInterrupted, "reconciled by interrupt", c.now()); err != nil {
+		return fmt.Errorf("reconcile durable turn: %w", err)
+	}
+
+	now := c.now()
+	c.mu.Lock()
+	c.cancelQueuedAt = now
+	c.pendingTurnID = ""
+	c.ackedTurnID = ""
+	c.state = ports.ChatControllerReady
+	c.mu.Unlock()
+
+	if err := c.store.CancelQueuedTurns(ctx, c.conversation.ID, now, now); err != nil {
+		c.log.Error("failed to cancel queued turns during reconciliation",
+			"session", c.sessionID, "error", err)
+	}
+
+	c.reportActivity(ctx, domain.ActivityIdle, "chat.interrupt.reconciled", now)
 	return nil
 }
 
@@ -1212,6 +1277,8 @@ func (c *Controller) project() {
 	}
 
 	c.mu.Lock()
+	c.pendingTurnID = ""
+	c.ackedTurnID = ""
 	c.state = ports.ChatControllerStopped
 	c.mu.Unlock()
 
@@ -1338,15 +1405,6 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 			ctx, c.conversation.ID, event.ProviderTurnID, state, message, now); err != nil {
 			return err
 		}
-		c.mu.Lock()
-		if c.pendingTurnID == event.ProviderTurnID {
-			c.pendingTurnID = ""
-		}
-		if c.ackedTurnID == event.ProviderTurnID {
-			c.ackedTurnID = ""
-		}
-		c.state = ports.ChatControllerReady
-		c.mu.Unlock()
 		return nil
 
 	case ports.ChatEventMessageDelta:
@@ -1677,6 +1735,19 @@ func (c *Controller) afterProject(ctx context.Context, event ports.ChatEvent) {
 	case ports.ChatEventTurnStarted:
 		c.reportActivity(ctx, domain.ActivityActive, "chat.turn.started", now)
 	case ports.ChatEventTurnCompleted:
+		// In-memory state is cleared after the SQLite transaction commits, not
+		// inside it. A commit failure that rolls back the SettleTurn write must
+		// not leave memory thinking the turn is done — that split-brain is what
+		// made Stop return CHAT_NO_ACTIVE_TURN while the UI showed "Working".
+		c.mu.Lock()
+		if c.pendingTurnID == event.ProviderTurnID {
+			c.pendingTurnID = ""
+		}
+		if c.ackedTurnID == event.ProviderTurnID {
+			c.ackedTurnID = ""
+		}
+		c.state = ports.ChatControllerReady
+		c.mu.Unlock()
 		c.reportActivity(ctx, domain.ActivityIdle, "chat.turn.completed", now)
 		// The settled turn is committed before another queued turn can dispatch.
 		c.drain(ctx)

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -251,6 +251,38 @@ func (r *recordingActivity) snapshot() []ports.ActivitySignal {
 	return append([]ports.ActivitySignal(nil), r.signals...)
 }
 
+func hasActivitySignal(signals []ports.ActivitySignal, state domain.ActivityState, event string) bool {
+	for _, s := range signals {
+		if s.State == state && s.Event == event {
+			return true
+		}
+	}
+	return false
+}
+
+// awaitSnapshot polls until pred holds, for tests that build their own service
+// rather than using the harness.
+func awaitSnapshotFromStore(t *testing.T, st *sqlite.Store, conversationID string,
+	pred func(store.ConversationSnapshot) bool) store.ConversationSnapshot {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last store.ConversationSnapshot
+	for time.Now().Before(deadline) {
+		snapshot, err := st.LoadConversationSnapshot(context.Background(), conversationID)
+		if err != nil {
+			t.Fatalf("load snapshot: %v", err)
+		}
+		last = snapshot
+		if pred(snapshot) {
+			return snapshot
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("snapshot never satisfied the condition; last had %d messages, %d activities, %d turns",
+		len(last.Messages), len(last.Activities), len(last.Turns))
+	return last
+}
+
 func productionCaps() ports.ChatCapabilities {
 	return ports.ChatCapabilities{
 		ports.ChatCapabilityStreaming: true,
@@ -1539,10 +1571,10 @@ func TestInterruptWaitsForTheProviderToAcknowledgeTheTurn(t *testing.T) {
 	}
 }
 
-// A provider that refuses because the turn is genuinely gone must reach the client
-// as the same typed "nothing to interrupt" answer AO produces itself — not as a
-// protocol error that renders as an internal failure.
-func TestProviderRefusalBecomesTheTypedNoActiveTurnError(t *testing.T) {
+// A provider that refuses because the turn is genuinely gone must reconcile the
+// durable turn as interrupted instead of surfacing a bare ErrNoActiveTurn that
+// leaves the user stuck on "Working". The queue behind it is cancelled too.
+func TestProviderRefusalReconcilesTheTurnAsInterrupted(t *testing.T) {
 	conv := newInterruptRecorder() // never marks anything active
 	h := newHarnessWithConversation(t, conv)
 	ctx := context.Background()
@@ -1550,10 +1582,29 @@ func TestProviderRefusalBecomesTheTypedNoActiveTurnError(t *testing.T) {
 	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{Text: "go", ClientMessageID: "c1"}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
 
-	err := h.svc.Interrupt(ctx, testSession)
-	if !errorsIs(err, chatsvc.ErrNoActiveTurn) {
-		t.Fatalf("err = %v, want ErrNoActiveTurn", err)
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateInterrupted
+	})
+	if snapshot.Turns[0].State != domain.TurnStateInterrupted {
+		t.Fatalf("turn state = %q, want %q", snapshot.Turns[0].State, domain.TurnStateInterrupted)
+	}
+
+	if got := conv.attemptCount(); got != 2 {
+		t.Errorf("provider interrupt attempts = %d, want 2 (initial + reconciliation)", got)
+	}
+
+	// Reconciliation must report idle so the session lifecycle reflects the stop.
+	if !hasActivitySignal(h.activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
+		t.Errorf("no idle activity signal emitted after reconciliation; signals = %v",
+			h.activity.snapshot())
 	}
 }
 
@@ -2043,5 +2094,259 @@ func TestInterruptReturnsNoActiveTurnWhenNoRunningTurnAnywhere(t *testing.T) {
 	err := h.svc.Interrupt(ctx, testSession)
 	if !errorsIs(err, chatsvc.ErrNoActiveTurn) {
 		t.Fatalf("err = %v, want ErrNoActiveTurn", err)
+	}
+}
+
+// When the provider refuses to cancel a turn that SQLite still shows as running,
+// the reconciliation must also cancel any turns queued behind it. Stop is the
+// user's brake — a brake that releases the next message would be the opposite.
+func TestProviderRefusalReconciliationCancelsQueuedTurns(t *testing.T) {
+	conv := newInterruptRecorder() // never marks anything active
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "running", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send running: %v", err)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "queued", ClientMessageID: "c2",
+	}); err != nil {
+		t.Fatalf("Send queued: %v", err)
+	}
+
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		states := turnStateByText(t, s)
+		return states["running"].Terminal() && states["queued"].Terminal()
+	})
+	states := turnStateByText(t, snapshot)
+	if states["queued"] != domain.TurnStateInterrupted {
+		t.Errorf("queued turn = %q; want %q (cancelled, not dispatched)",
+			states["queued"], domain.TurnStateInterrupted)
+	}
+	if got := h.conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; reconciliation must not release the queue", got)
+	}
+}
+
+// The dispatch race: BindTurnToProvider writes state='running' to SQLite before
+// pendingTurnID is set in memory. If Stop arrives in that window, memory says
+// nothing is running, so Interrupt falls through to the disk fallback and must
+// reconcile the turn. This test simulates that race by creating a running turn
+// directly in the store and calling Interrupt with empty memory.
+func TestInterruptReconcilesDispatchRaceTurn(t *testing.T) {
+	conv := newInterruptRecorder() // refuses all interrupts
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	// Simulate the race window: a turn is running in SQLite (BindTurnToProvider
+	// already wrote 'running') but the controller never set pendingTurnID.
+	const providerTurnID = "race-turn"
+	if err := h.st.AdoptProviderTurn(ctx, h.ctrl.ConversationID(), testSession,
+		h.ctrl.Generation(), "race-turn-id", providerTurnID, h.now()); err != nil {
+		t.Fatalf("AdoptProviderTurn: %v", err)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateInterrupted
+	})
+
+	if got := conv.attemptCount(); got != 1 {
+		t.Errorf("provider interrupt attempts = %d, want 1 (best-effort cancel during reconciliation)", got)
+	}
+
+	// Reconciliation must report idle so the session lifecycle reflects the stop.
+	if !hasActivitySignal(h.activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
+		t.Errorf("no idle activity signal emitted after reconciliation; signals = %v",
+			h.activity.snapshot())
+	}
+}
+
+// Memory state (pendingTurnID, ackedTurnID, controller state) must be cleared
+// after the SQLite transaction commits, not inside it. A turn that completes
+// normally must leave the controller ready for the next send without a stale
+// pendingTurnID lingering.
+func TestTurnCompletionClearsMemoryAfterCommit(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "hello", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	h.conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	// Complete the turn. afterProject runs after the commit and clears memory.
+	h.conv.emit(ports.ChatEvent{
+		Kind:           ports.ChatEventTurnCompleted,
+		ProviderTurnID: "provider-turn-1",
+		TurnState:      domain.TurnStateCompleted,
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateCompleted
+	})
+
+	// The controller must not be busy — a subsequent send must succeed,
+	// proving pendingTurnID was cleared in afterProject after the commit.
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "next", ClientMessageID: "c2",
+	}); err != nil {
+		t.Fatalf("Send after completion: %v", err)
+	}
+}
+
+// failingProjectStore wraps a real store and injects a failure into
+// ProjectProviderEvent when the method matches a target event kind. This
+// simulates a tx.Commit failure without needing to corrupt SQLite.
+type failingProjectStore struct {
+	chatsvc.Store
+	failMethod string
+}
+
+func (s *failingProjectStore) ProjectProviderEvent(
+	ctx context.Context, conversationID string, session domain.SessionID,
+	generation, providerEventID, method, payloadJSON string, now time.Time,
+	project func(context.Context) error,
+) (bool, error) {
+	if method == s.failMethod {
+		return false, errors.New("injected projection failure")
+	}
+	return s.Store.ProjectProviderEvent(ctx, conversationID, session, generation,
+		providerEventID, method, payloadJSON, now, project)
+}
+
+// The exact #3749 scenario: SettleTurn fails inside the projection transaction
+// (pendingTurnID stays set because afterProject never runs), then Interrupt
+// calls the provider which returns ErrChatNoActiveTurn (the turn already
+// completed on the provider side). reconcileDurableTurn must settle the
+// durable row as interrupted, cancel the queue, clear memory, and report idle
+// — the full Interrupt contract without a second successful provider send.
+func TestProjectionFailureAndProviderRefusalReconcilesDurableTurn(t *testing.T) {
+	conv := newInterruptRecorder() // never marks anything active → always refuses
+	st := openStore(t)
+
+	var counterMu sync.Mutex
+	counter := 0
+	newID := func() string {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+		counter++
+		return fmt.Sprintf("id-%03d", counter)
+	}
+
+	// Fail projection for turn/completed so afterProject never runs and
+	// pendingTurnID stays set — simulating the tx.Commit failure.
+	failingStore := &failingProjectStore{
+		Store:      st,
+		failMethod: string(ports.ChatEventTurnCompleted),
+	}
+	activity := &recordingActivity{}
+	clock := time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)
+	svc := chatsvc.New(chatsvc.Options{
+		Store:    failingStore,
+		Sessions: st,
+		Drivers:  fakeRegistry{driver: fakeDriver{conv: conv}},
+		Activity: activity,
+		Log:      slog.New(slog.DiscardHandler),
+		NewID:    newID,
+		Now:      func() time.Time { return clock },
+	})
+
+	ctrl, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID:     testSession,
+		ProjectID:     testProject,
+		Harness:       domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+
+	ctx := context.Background()
+
+	// Send the running turn.
+	if _, err := svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "running", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send running: %v", err)
+	}
+	conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+
+	// Wait for the turn to be running on disk.
+	awaitSnapshotFromStore(t, st, ctrl.ConversationID(), func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	// Queue a second prompt behind the running turn.
+	if _, err := svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "queued", ClientMessageID: "c2",
+	}); err != nil {
+		t.Fatalf("Send queued: %v", err)
+	}
+
+	// Emit turn completion — projection fails (simulating tx.Commit failure),
+	// so afterProject never runs and pendingTurnID stays set.
+	conv.emit(ports.ChatEvent{
+		Kind:           ports.ChatEventTurnCompleted,
+		ProviderTurnID: "provider-turn-1",
+		TurnState:      domain.TurnStateCompleted,
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	// Now press Stop. pendingTurnID is still set (projection failed), so
+	// awaitAcknowledgedTurn returns ok=true. The provider refuses with
+	// ErrChatNoActiveTurn. reconcileDurableTurn must settle the durable row,
+	// cancel the queue, and report idle.
+	if err := svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	// The running turn must be interrupted on disk.
+	snapshot := awaitSnapshotFromStore(t, st, ctrl.ConversationID(), func(s store.ConversationSnapshot) bool {
+		if len(s.Turns) < 2 {
+			return false
+		}
+		states := turnStateByText(t, s)
+		return states["running"].Terminal() && states["queued"].Terminal()
+	})
+	states := turnStateByText(t, snapshot)
+	if states["running"] != domain.TurnStateInterrupted {
+		t.Errorf("running turn = %q, want %q", states["running"], domain.TurnStateInterrupted)
+	}
+	if states["queued"] != domain.TurnStateInterrupted {
+		t.Errorf("queued turn = %q, want %q (cancelled, not dispatched)",
+			states["queued"], domain.TurnStateInterrupted)
+	}
+
+	// No extra provider send beyond the initial dispatch + interrupt attempts.
+	if got := conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; reconciliation must not release the queue", got)
+	}
+
+	// An idle signal must be emitted.
+	if !hasActivitySignal(activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
+		t.Errorf("no idle activity signal emitted after reconciliation; signals = %v",
+			activity.snapshot())
 	}
 }

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -2001,3 +2001,47 @@ func TestProviderStartedTurnIsAdoptedSoItsItemsCorrelate(t *testing.T) {
 		}
 	}
 }
+
+// A SettleTurn failure during ChatEventTurnCompleted projection leaves SQLite
+// with state='running' while the in-memory pendingTurnID is already cleared.
+// The user sees "Working" (SQLite) but "Stop turn" returns CHAT_NO_ACTIVE_TURN
+// (memory). Interrupt must reconcile by settling the stale running turn as
+// interrupted instead of refusing.
+func TestInterruptReconcilesStaleRunningTurnOnDisk(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	// Simulate the desync: create a running turn directly in the store,
+	// bypassing the controller so its pendingTurnID stays empty.
+	const providerTurnID = "stale-running-turn"
+	if err := h.st.AdoptProviderTurn(ctx, h.ctrl.ConversationID(), testSession,
+		"stale-generation", "stale-turn-id", providerTurnID, h.now()); err != nil {
+		t.Fatalf("AdoptProviderTurn: %v", err)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	// Interrupt should recover the stale turn, not return ErrNoActiveTurn.
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	// The turn must now be interrupted on disk so the UI unblocks.
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateInterrupted
+	})
+}
+
+// When memory is empty AND SQLite has no running turn, Interrupt must still
+// return ErrNoActiveTurn — the disk fallback must not produce a false positive.
+func TestInterruptReturnsNoActiveTurnWhenNoRunningTurnAnywhere(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	// No message sent, no turn in flight: nothing to interrupt.
+	err := h.svc.Interrupt(ctx, testSession)
+	if !errorsIs(err, chatsvc.ErrNoActiveTurn) {
+		t.Fatalf("err = %v, want ErrNoActiveTurn", err)
+	}
+}

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -389,6 +389,25 @@ func (q *Queries) FailRolledBackConversationApprovals(ctx context.Context, arg F
 	return err
 }
 
+const getRunningTurnForConversation = `-- name: GetRunningTurnForConversation :one
+SELECT id, provider_turn_id FROM conversation_turns
+WHERE conversation_id = ? AND state = 'running'
+ORDER BY started_at DESC
+LIMIT 1
+`
+
+type GetRunningTurnForConversationRow struct {
+	ID             string
+	ProviderTurnID string
+}
+
+func (q *Queries) GetRunningTurnForConversation(ctx context.Context, conversationID string) (GetRunningTurnForConversationRow, error) {
+	row := q.db.QueryRowContext(ctx, getRunningTurnForConversation, conversationID)
+	var i GetRunningTurnForConversationRow
+	err := row.Scan(&i.ID, &i.ProviderTurnID)
+	return i, err
+}
+
 const insertConversation = `-- name: InsertConversation :exec
 
 INSERT INTO conversations (id, scope, project_id, session_id, current_session_id, latest_sequence, created_at, updated_at)

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -208,7 +208,11 @@ SET state = 'failed',
     error_message = 'controller ended before the turn completed',
     completed_at = ?
 WHERE handled_by_session_id = ? AND state IN ('queued', 'running');
-
+-- name: GetRunningTurnForConversation :one
+SELECT id, provider_turn_id FROM conversation_turns
+WHERE conversation_id = ? AND state = 'running'
+ORDER BY started_at DESC
+LIMIT 1;
 -- Overwrite the turn's changed-file summary. The provider re-sends the whole diff
 -- on every update, so the latest payload is the complete answer and there is
 -- nothing to merge with what was there before.

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -383,6 +383,20 @@ func (s *Store) SettleOrphanedTurns(ctx context.Context, session domain.SessionI
 	return nil
 }
 
+// GetRunningTurn returns the most recent running turn for a conversation, if any.
+// Used by Interrupt() to recover from a desync where in-memory state lost track
+// of a turn that SQLite still shows as running.
+func (s *Store) GetRunningTurn(ctx context.Context, conversationID string) (id, providerTurnID string, ok bool, err error) {
+	row, err := s.conversationReader(ctx).GetRunningTurnForConversation(ctx, conversationID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, fmt.Errorf("get running turn for %s: %w", conversationID, err)
+	}
+	return row.ID, row.ProviderTurnID, true, nil
+}
+
 // SetConversationSettings records the provider choices for the next turn.
 //
 // An empty field is stored as NULL rather than as an empty string, so "the user

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -214,6 +214,9 @@ export function useConversationCommands(sessionId: string | undefined) {
 			if (error) throw error;
 		},
 		onSuccess: invalidate,
+		onError: () => {
+			invalidate();
+		},
 	});
 
 	const resume = useMutation({

--- a/packages/mobile/lib/chat/useConversation.ts
+++ b/packages/mobile/lib/chat/useConversation.ts
@@ -235,7 +235,12 @@ export function useMobileConversation(
 	}, [refresh]);
 
 	const runAction = useCallback(
-		async <T,>(kind: ConversationAction, action: () => Promise<T>, resetHistoricalPages = false): Promise<T> => {
+		async <T,>(
+			kind: ConversationAction,
+			action: () => Promise<T>,
+			resetHistoricalPages = false,
+			onError?: () => void,
+		): Promise<T> => {
 			setPendingActions((old) => old.includes(kind) ? old : [...old, kind]);
 			setActionError(undefined);
 			setActionErrors((old) => ({ ...old, [kind]: undefined }));
@@ -250,6 +255,7 @@ export function useMobileConversation(
 				setActionError(message);
 				setActionErrors((old) => ({ ...old, [kind]: message }));
 				setActionCodes((old) => ({ ...old, [kind]: conversationErrorCode(cause) }));
+				if (onError) onError();
 				throw new Error(message);
 			} finally {
 				setPendingActions((old) => old.filter((candidate) => candidate !== kind));
@@ -324,7 +330,12 @@ export function useMobileConversation(
 		retrySend,
 		discardSend: (id) => setPendingSends((old) => old.filter((item) => item.id !== id)),
 		steer: (text) => runAction("steer", () => requireConfig(cfg, (c) => steerConversation(c, sessionId, text, clientMessageId()))),
-		interrupt: () => runAction("interrupt", () => requireConfig(cfg, (c) => interruptConversation(c, sessionId))),
+		interrupt: () => runAction(
+			"interrupt",
+			() => requireConfig(cfg, (c) => interruptConversation(c, sessionId)),
+			false,
+			() => { void refresh(); },
+		),
 		resolveApproval: (requestId, decisionId) =>
 			runAction("approval", () => requireConfig(cfg, (c) => resolveApproval(c, sessionId, requestId, decisionId))),
 		resolveInput: (requestId, action, content) =>


### PR DESCRIPTION
Fixes [[#3749](https://github.com/Untrivial-ai/agent-orchestrator/issues/3749) — "Stop turn" fails with `CHAT_NO_ACTIVE_TURN` while the UI shows a running turn.

The chat controller kept two sources of truth for "is a turn running?" — an in-memory `pendingTurnID` and a durable SQLite `conversation_turns.state = 'running'` row. They could diverge when `SettleTurn` failed inside the `ProjectProviderEvent` transaction: the rollback discarded the SQLite update but the in-memory mutation had already run, leaving the UI showing "Working" with no way to stop it.

## Root Cause
`Controller.apply()` for `ChatEventTurnCompleted` mutated `pendingTurnID = ""` in memory *before* calling `SettleTurn()`, which runs inside a SQLite transaction. If `SettleTurn` failed, the transaction rolled back (SQLite retained `state = 'running'`) but the in-memory `pendingTurnID` was already cleared — not rolled back because it's a Go variable, not SQL. This desync meant `Interrupt()` found nothing to cancel while the UI read SQLite and showed "Working".

## Fix
1. **Reorder `apply()`** — durable write before memory mutation. If `SettleTurn` fails, memory stays intact so `Interrupt()` still works. (`controller.go`)
2. **Disk fallback in `Interrupt()`** — if memory says nothing is running, check SQLite for a stale `running` turn and settle it as `interrupted`. Mirrors the existing `SettleOrphanedTurns` reconciliation pattern. (`controller.go` + `conversation_store.go` + `conversations.sql`)
3. **Frontend resilience** — `onError` handler on the `interrupt` mutation invalidates the conversation query so the UI refetches and unblocks. (`useConversation.ts`)

## Manual Testing

### Test 1: Normal "Stop turn" still works (regression check)
1. Start the daemon: `go run ./cmd/ao daemon`
2. Start the desktop app: `cd frontend && npm run dev`
3. Open a chat session (codex, Chat mode)
4. Send a slow prompt:
   > Write a comprehensive test suite for a banking application in Go. Include tests for account creation, deposits, withdrawals, transfers, overdrafts, concurrency with goroutines, transaction rollback, audit logging, and edge cases. Cover both unit and integration tests.
5. While it shows "Working Xs", click "Stop turn"
6. **Result:** Turn stops, status shows "Stopped" — no regression

<img width="1038" height="700" alt="Screenshot 2026-08-09 114347" src="https://github.com/user-attachments/assets/95e709ed-ac3c-4ba9-9d71-b2f5d8c4de31" />


### Test 2: Stale "Working" bar recovers after daemon restart (the bug)
1. Start the daemon standalone: `go run ./cmd/ao daemon`
2. Start the desktop app: `cd frontend && npm run dev`
3. Open a chat session (codex, Chat mode)
4. Send the same slow prompt
5. While it shows "Working Xs", **kill the daemon** (Ctrl+C in the terminal)
6. The UI keeps showing "Working" (stale SQLite state — turn still `running` on disk)
7. **Restart the daemon:** `go run ./cmd/ao daemon`
8. Click "Stop turn"
9. **Before the fix:** Error `there is no turn in flight to interrupt (CHAT_NO_ACTIVE_TURN)`, UI stays stuck on "Working" indefinitely
10. **After the fix:** Turn settles as interrupted, UI unblocks

<img width="996" height="647" alt="Screenshot 2026-08-09 120414" src="https://github.com/user-attachments/assets/32d419a2-1bc5-4f6a-9990-f3ac6f819f37" />

## Automated Tests
- `TestInterruptReconcilesStaleRunningTurnOnDisk` — a turn left `running` on disk while the controller has no `pendingTurnID` is settled as `interrupted` by `Interrupt()`, unblocking the UI.
- `TestInterruptReturnsNoActiveTurnWhenNoRunningTurnAnywhere` — the disk fallback does not produce false positives when memory and SQLite agree there is nothing to stop.
- `go test ./internal/service/chat/...` — 79/79 pass (77 existing + 2 new)
- `go vet ./...` — clean
- `npm run typecheck` — clean