### PR TITLE
fix(agent-claude-code): refuse to overwrite zero-byte ~/.claude.json

### DIFF
--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -601,7 +601,8 @@ func claudeConfigPath() (string, error) {
 // only projects[workspacePath].hasTrustDialogAccepted = true (preserving the
 // rest of the entry and every other project), and writes back via a
 // temp-file + atomic rename. If the path is already trusted, it makes no
-// write at all. A missing config file is treated as an empty one.
+// write at all. A missing config file is treated as an empty one; a
+// zero-byte or corrupt config file is refused rather than overwritten.
 // claudeTrustMu serializes ensureWorkspaceTrusted within the process. Concurrent
 // spawns to different workspaces otherwise read the same ~/.claude.json snapshot
 // and the last rename drops the other's trust entry.
@@ -615,10 +616,16 @@ func ensureWorkspaceTrusted(configPath, workspacePath string) error {
 	data, err := os.ReadFile(configPath)
 	switch {
 	case err == nil:
-		if len(data) > 0 {
-			if err := json.Unmarshal(data, &root); err != nil {
-				return fmt.Errorf("claude-code: parse %s: %w", configPath, err)
-			}
+		if len(bytes.TrimSpace(data)) == 0 {
+			// A zero-byte read means we may have caught some other writer
+			// mid-truncate. Treat it like a corrupt file, not a missing
+			// one: refuse to write rather than silently replacing the
+			// user's real config (oauthAccount, projects history, etc.)
+			// with one containing only the trust entry.
+			return fmt.Errorf("claude-code: %s is empty; refusing to overwrite", configPath)
+		}
+		if err := json.Unmarshal(data, &root); err != nil {
+			return fmt.Errorf("claude-code: parse %s: %w", configPath, err)
 		}
 	case os.IsNotExist(err):
 		// Treat as empty config; we'll create it.

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -745,6 +745,29 @@ func TestEnsureWorkspaceTrustedCreatesMissingConfig(t *testing.T) {
 	}
 }
 
+func TestEnsureWorkspaceTrustedRefusesZeroByteConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".claude.json")
+	// Simulate catching some other writer mid-truncate: the file exists
+	// but reads back as zero bytes.
+	if err := os.WriteFile(cfgPath, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ensureWorkspaceTrusted(cfgPath, "/some/worktree")
+	if err == nil {
+		t.Fatal("expected error for zero-byte config, got nil")
+	}
+
+	data, readErr := os.ReadFile(cfgPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(data) != 0 {
+		t.Fatalf("zero-byte config must not be overwritten; got %d bytes: %s", len(data), data)
+	}
+}
+
 func readJSON(t *testing.T, path string) map[string]any {
 	t.Helper()
 	data, err := os.ReadFile(path)


### PR DESCRIPTION
## Root cause

`ensureWorkspaceTrusted` in `backend/internal/adapters/agent/claudecode/claudecode.go` reads `~/.claude.json` before adding a trust-dialog entry. The switch on the read result had three cases: read succeeded, file missing, or read failed. The success case guarded the `json.Unmarshal` call with `len(data) > 0`, so a zero-byte read fell through with `root` left as `map[string]any{}` — exactly the same state as a genuinely missing file. The function then wrote a brand-new config containing only `projects[workspacePath].hasTrustDialogAccepted = true` and atomically renamed it over the real `~/.claude.json`, destroying `oauthAccount`, `userID`, and every `projects` entry.

This was the one input that produced a destructive write. A missing file is a deliberate, commented "create new" case. A corrupt file makes `json.Unmarshal` fail and the function returns an error without writing anything. A zero-byte read — e.g. catching some other writer (Claude Code itself, or a concurrent AO session) mid-truncate — had no equivalent guard.

## Fix

Treat zero-byte (and whitespace-only) content the same as corrupt content: return an error and refuse to write, instead of silently treating it as an empty-but-valid config.

```go
case err == nil:
	if len(bytes.TrimSpace(data)) == 0 {
		return fmt.Errorf("claude-code: %s is empty; refusing to overwrite", configPath)
	}
	if err := json.Unmarshal(data, &root); err != nil {
		return fmt.Errorf("claude-code: parse %s: %w", configPath, err)
	}
```

`bytes` was already imported in this file, so no new dependency. Also updated the function's doc comment to state the zero-byte/corrupt behavior explicitly.

## Test

Added `TestEnsureWorkspaceTrustedRefusesZeroByteConfig` in `claudecode_test.go`, matching the structure of the existing missing-config and already-trusted tests: it writes a zero-byte `.claude.json`, calls `ensureWorkspaceTrusted`, asserts an error is returned, and asserts the file is still zero bytes afterward (nothing was written).

## Verification

- `git stash` on just the source fix (keeping the new test) confirmed the new test fails against the old code: `ensureWorkspaceTrusted` returned `nil` instead of an error, i.e. it silently wrote over the empty file. `git stash pop` restored the fix and the test passes.
- The existing `TestEnsureWorkspaceTrustedCreatesEntry`, `TestEnsureWorkspaceTrustedIsIdempotentAndNoWriteWhenAlreadyTrusted`, and `TestEnsureWorkspaceTrustedCreatesMissingConfig` tests still pass unchanged — no regression on the missing-file or already-trusted paths.
- `cd backend && go build ./...` and `go vet ./...` are clean.
- `cd backend && go test ./internal/adapters/agent/claudecode/...` passes in full.
- `cd backend && go test ./...` was also run for the wider backend. Two pre-existing failures showed up (`TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH`, `TestSpawn_DoesNotAddNodeRuntimeForNativeBinary` in `internal/session_manager`, and a timing-sensitive `TestBeginInputDrainReturnsTheLastAcceptedWriteBarrier` in `internal/terminal`). I confirmed these are unrelated to this change and not introduced by it: stashing my diff back out and re-running them against unmodified `main` reproduces the same `session_manager` failures (a Windows-path-separator/node-version assumption baked into that test, unrelated to this package) and the terminal test passed cleanly across repeated baseline runs, consistent with a pre-existing flake.

Addresses #3746.
