### PR TITLE
fix(agent): mark continue harness as signal-capable

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -34,6 +34,7 @@ var Derivers = map[string]DeriveFunc{
 	// deriver; the rest share the name-only StandardDeriveActivityState.
 	"claude-code": claudecode.DeriveActivityState,
 	"grok":        claudecode.DeriveActivityState,
+	"continue":    claudecode.DeriveActivityState,
 	"muse":        muse.DeriveActivityState,
 	"codex":       codex.DeriveActivityState,
 	"droid":       droid.DeriveActivityState,

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -22,7 +22,7 @@ func TestDeriverTokensAreKnownHarnesses(t *testing.T) {
 }
 
 func TestSupportsHarness(t *testing.T) {
-	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessMuse, domain.HarnessOpenCode, domain.HarnessKimi, domain.HarnessVibe, domain.HarnessPrimeAgent} {
+	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessContinue, domain.HarnessMuse, domain.HarnessOpenCode, domain.HarnessKimi, domain.HarnessVibe, domain.HarnessPrimeAgent} {
 		if !SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = false, want true", h)
 		}
@@ -102,6 +102,33 @@ func TestGrokDerivesClaudeCompatibleActivity(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("Derive(grok, %q) = %q, want %q", tt.event, got, tt.want)
+			}
+		})
+	}
+}
+
+// Continue delegates GetAgentHooks to the claude-code plugin, so its deriver
+// must be claudecode.DeriveActivityState (same as grok's) and behave
+// identically.
+func TestContinueDerivesClaudeCompatibleActivity(t *testing.T) {
+	tests := []struct {
+		name    string
+		event   string
+		payload string
+		want    domain.ActivityState
+	}{
+		{"permission request", "permission-request", `{}`, domain.ActivityBlocked},
+		{"idle notification", "notification", `{"notification_type":"idle_prompt"}`, domain.ActivityIdle},
+		{"session end", "session-end", `{}`, domain.ActivityExited},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := Derive("continue", tt.event, []byte(tt.payload))
+			if !ok {
+				t.Fatalf("Derive(continue, %q) ok=false, want true", tt.event)
+			}
+			if got != tt.want {
+				t.Fatalf("Derive(continue, %q) = %q, want %q", tt.event, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Context

Issue #2402 originally reported three harnesses (`grok`, `devin`, `continue`) missing from the `Derivers` map in `backend/internal/adapters/agent/activitydispatch/dispatch.go`, which backs `SupportsHarness()`. That function distinguishes `no_signal` (broken hook pipeline, should alarm) from `idle` (harness has no hook pipeline at all, silence is expected) during session status derivation.

By the time I picked this up, `grok` and `devin` had already been fixed on `main` (both are present in `Derivers` today). Only `continue` was still missing. This PR completes the issue by adding the third harness, following the exact pattern already used for the other two.

## Root cause

`backend/internal/adapters/agent/continueagent/continueagent.go`'s `GetAgentHooks` delegates directly to `(&claudecode.Plugin{}).GetAgentHooks(...)`, installing the same `ao hooks claude-code <evt>` callbacks as the claude-code adapter itself (confirmed by reading `claudecode/hooks.go`, which defines `claudeHookCommandPrefix = "ao hooks claude-code "`). So a `continue` session has a fully working, live claude-code-shaped activity pipeline.

However, `"continue"` was never a key in `Derivers`, so `SupportsHarness("continue")` returned `false` even though the harness genuinely has hook coverage. That made status derivation treat prolonged continue-session silence as expected `idle` instead of `no_signal`, hiding real broken-hook cases.

Note this is different from `grok`'s current adapter (`backend/internal/adapters/agent/grok/grok.go`), which has since grown its own dedicated hook installer emitting `ao hooks grok <evt>` (its own token, `grokHookCommandPrefix = "ao hooks grok "`). `continue` still purely delegates to claudecode's installer, so it needs `claudecode.DeriveActivityState` specifically -- the same deriver function grok's `Derivers` entry uses -- not the generic `activitystate.StandardDeriveActivityState` used for harnesses like `devin` whose hook path differs.

## Fix

Added one entry to `Derivers` in `dispatch.go`, in the same bucket as the other claude-code-shaped adapters:

```go
"continue":    claudecode.DeriveActivityState,
```

## Tests

- Extended the existing `TestSupportsHarness` table in `dispatch_test.go` to assert `SupportsHarness(domain.HarnessContinue)` is `true`.
- Added `TestContinueDerivesClaudeCompatibleActivity`, mirroring the existing `TestGrokDerivesClaudeCompatibleActivity`, to prove `Derive("continue", ...)` actually resolves through `claudecode.DeriveActivityState` for permission-request / notification / session-end events.

## Verification

- Stash-based fail-then-pass: `git stash push -- dispatch.go` (keeping the new/extended tests), ran `go test ./internal/adapters/agent/activitydispatch/...` and confirmed both `TestSupportsHarness` and `TestContinueDerivesClaudeCompatibleActivity` fail against the pre-fix code (`SupportsHarness("continue") = false`, `Derive(continue, ...) ok=false`). Then `git stash pop` and confirmed both pass.
- `cd backend && go build ./...` -- clean.
- `cd backend && go vet ./...` -- clean.
- `cd backend && go test ./internal/adapters/agent/...` -- all packages pass except two pre-existing, unrelated failures in this environment (`fake` package: Windows `sh.exe` path resolution; `modelcatalog`: picks up a real local `~/.claude` config default). I confirmed both fail identically with the fix stashed out, so they are pre-existing local-environment issues, not caused by this change.
- Branch is rebased onto current upstream `main` (past the recent Kimchi and Prime Agent harness additions, which also touch `dispatch.go`/`dispatch_test.go` -- merged with no functional conflicts).

Addresses #2402.