### PR TITLE
fix(scm): let UNSTABLE win over ci_failing in provider-facts mergeability

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -599,6 +599,17 @@ func mergeabilityObservation(providerMergeable, providerMergeState, ci, review s
 		out.State = string(domain.MergeBlocked)
 		addBlocker("blocked_by_provider")
 	}
+	// UNSTABLE must be checked before the draft/CI/review blockers below:
+	// doc.go's priority order puts rule (3) mergeStateStatus == UNSTABLE
+	// ahead of rule (5) changes_requested and rule (6) CI == failing, and
+	// state can only hold one value, so this never masks the BLOCKED check
+	// above. UNSTABLE means GitHub still considers the PR mergeable despite
+	// a failing/pending NON-required check; a required-check failure
+	// surfaces as BLOCKED via mergeStateStatus, not via ci == CIFailing.
+	if state == "UNSTABLE" {
+		out.State = string(domain.MergeUnstable)
+		return out
+	}
 	if draft {
 		out.State = string(domain.MergeBlocked)
 		addBlocker("draft")
@@ -616,10 +627,6 @@ func mergeabilityObservation(providerMergeable, providerMergeState, ci, review s
 		addBlocker("review_required")
 	}
 	if out.State == string(domain.MergeBlocked) {
-		return out
-	}
-	if state == "UNSTABLE" {
-		out.State = string(domain.MergeUnstable)
 		return out
 	}
 	if mergeable == "MERGEABLE" && (state == "CLEAN" || state == "HAS_HOOKS" || state == "") &&

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1283,6 +1283,23 @@ func TestSCMMergeabilityBlocksReviewRequiredAndDraft(t *testing.T) {
 	}
 }
 
+// TestSCMMergeabilityObservationUnstableBeatsCIFailing is the repro from
+// issue #2401: a PR whose provider mergeStateStatus is UNSTABLE (GitHub
+// still considers it mergeable despite a failing/pending non-required
+// check) must surface as MergeUnstable even though its CI rollup is
+// CIFailing. Per doc.go's documented priority order, rule (3) UNSTABLE
+// wins over rule (6) CI == failing — mirroring mergeabilityFromGraphQL,
+// which switches on state before ever consulting CI.
+func TestSCMMergeabilityObservationUnstableBeatsCIFailing(t *testing.T) {
+	got := mergeabilityObservation("MERGEABLE", "UNSTABLE", string(domain.CIFailing), string(domain.ReviewApproved), false)
+	if got.State != string(domain.MergeUnstable) {
+		t.Fatalf("mergeability = %+v, want unstable (UNSTABLE must win over ci_failing per doc.go priority order)", got)
+	}
+	if contains(got.Blockers, "ci_failing") {
+		t.Fatalf("blockers = %v, unstable PR should not carry a ci_failing blocker", got.Blockers)
+	}
+}
+
 func TestFetchPullRequestsDoesNotFallbackWhenContextPageComplete(t *testing.T) {
 	fake := newFakeGH(t)
 	fx := basePRFixture()

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -1323,6 +1323,17 @@ func mergeabilityFromProviderFacts(providerMergeable, providerMergeState, ci, re
 		out.State = string(domain.MergeBlocked)
 		addBlocker("blocked_by_provider")
 	}
+	// UNSTABLE must be checked before the draft/CI/review blockers below:
+	// doc.go's priority order puts rule (3) mergeStateStatus == UNSTABLE
+	// ahead of rule (5) changes_requested and rule (6) CI == failing, and
+	// state can only hold one value, so this never masks the BLOCKED check
+	// above. UNSTABLE means GitHub still considers the PR mergeable despite
+	// a failing/pending NON-required check; a required-check failure
+	// surfaces as BLOCKED via mergeStateStatus, not via ci == CIFailing.
+	if state == "UNSTABLE" {
+		out.State = string(domain.MergeUnstable)
+		return out
+	}
 	if draft {
 		out.State = string(domain.MergeBlocked)
 		addBlocker("draft")
@@ -1340,10 +1351,6 @@ func mergeabilityFromProviderFacts(providerMergeable, providerMergeState, ci, re
 		addBlocker("review_required")
 	}
 	if out.State == string(domain.MergeBlocked) {
-		return out
-	}
-	if state == "UNSTABLE" {
-		out.State = string(domain.MergeUnstable)
 		return out
 	}
 	if mergeable == "MERGEABLE" && (state == "CLEAN" || state == "HAS_HOOKS" || state == "") &&

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -1602,3 +1602,24 @@ func TestDiscoverSubjects_NonGitPathDoesNotBackfill(t *testing.T) {
 		t.Fatalf("RepoOriginURL = %q, want empty (no persist on failed backfill)", got)
 	}
 }
+
+// TestMergeabilityFromProviderFactsUnstableBeatsCIFailing is the repro from
+// issue #2401: a PR whose provider mergeStateStatus is UNSTABLE (GitHub
+// still considers it mergeable despite a failing/pending non-required
+// check) must surface as MergeUnstable even though its CI rollup is
+// CIFailing. Per doc.go's documented priority order (backend/internal/adapters/scm/github/doc.go),
+// rule (3) UNSTABLE wins over rule (6) CI == failing — mirroring
+// mergeabilityFromGraphQL, which switches on state before ever consulting
+// CI. This path was previously untested, which is how the two functions
+// diverged from the documented order.
+func TestMergeabilityFromProviderFactsUnstableBeatsCIFailing(t *testing.T) {
+	got := mergeabilityFromProviderFacts("MERGEABLE", "UNSTABLE", string(domain.CIFailing), string(domain.ReviewApproved), false)
+	if got.State != string(domain.MergeUnstable) {
+		t.Fatalf("mergeability = %+v, want unstable (UNSTABLE must win over ci_failing per doc.go priority order)", got)
+	}
+	for _, b := range got.Blockers {
+		if b == "ci_failing" {
+			t.Fatalf("blockers = %v, unstable PR should not carry a ci_failing blocker", got.Blockers)
+		}
+	}
+}


### PR DESCRIPTION
### Root cause

`backend/internal/adapters/scm/github/doc.go` documents the Mergeability priority order as "first rule that matches wins":

```
(2) mergeStateStatus == BLOCKED         -> MergeBlocked
(3) mergeStateStatus == UNSTABLE        -> MergeUnstable
...
(5) reviewDecision == changes_requested -> MergeBlocked
(6) CI == failing                       -> MergeBlocked
```

So rule (3) UNSTABLE must win over rule (5)/(6). Two byte-identical functions did not follow that order:

- `mergeabilityObservation` in `backend/internal/adapters/scm/github/observer_provider.go`
- `mergeabilityFromProviderFacts` in `backend/internal/observe/scm/observer.go`

Both checked `draft` / `ci == CIFailing` / `review == changes_requested`, set `MergeBlocked`, and returned as soon as `out.State == MergeBlocked` -- before ever reaching the `state == "UNSTABLE"` branch that followed. Since a genuinely UNSTABLE PR's overall CI status rollup is typically `FAILURE` (mapping to `ci = CIFailing`), the `UNSTABLE` branch was effectively dead code for the common case: a PR GitHub itself considers mergeable (failing/pending *non-required* check) got persisted as `Mergeability = blocked` with blocker `ci_failing` instead of `Mergeability = unstable`.

The sibling `mergeabilityFromGraphQL` in `backend/internal/adapters/scm/github/provider.go` is the correct reference: it switches on `state` first and returns `MergeUnstable` for the `UNSTABLE` case before ever consulting CI, matching `doc.go`. There's also an existing integration test (`TestObserve_MergeabilityStates`, same file) with a load-bearing case explicitly distinguishing "ci failing forces blocked even when mergeStateStatus is CLEAN" from the separate "unstable via merge_state_status=UNSTABLE" case -- confirming CI-forces-blocked is meant to apply only when the provider hasn't already told us the check is non-required (UNSTABLE), which the two buggy functions did not respect.

### Fix

Moved the `state == "UNSTABLE"` check above the `draft` / `ci == CIFailing` / `review` blocking checks in both functions, immediately after the `state == "BLOCKED"` check, so it returns before those blockers can run. `state` is a single string value, so `BLOCKED` and `UNSTABLE` are mutually exclusive within one call -- reordering does not change behavior for the `BLOCKED` case (it still falls through to accumulate any additional blockers exactly as before). Kept both functions byte-identical (aside from name), as the codebase comment describes them.

### Tests

Added one regression test to each function's suite (state=UNSTABLE, ci=failing -> the exact repro combination), verifying `MergeUnstable` with no `ci_failing` blocker:

- `TestSCMMergeabilityObservationUnstableBeatsCIFailing` in `backend/internal/adapters/scm/github/provider_test.go`
- `TestMergeabilityFromProviderFactsUnstableBeatsCIFailing` in `backend/internal/observe/scm/observer_test.go`

Neither function previously had a test covering this combination (`mergeabilityFromProviderFacts` had no direct unit test at all), which is how the divergence from `doc.go` slipped in.

### Verification

- Stashed the two production-code changes (kept the new tests) and reran the new tests: both **failed** against the prior code, reproducing the bug (`State:blocked Blockers:[ci_failing]` instead of `unstable`).
- Popped the stash and reran: both **pass**.
- `cd backend && go build ./...` -- clean.
- `cd backend && go vet ./...` -- clean.
- `go test ./internal/adapters/scm/github/...` -- all pass (full package suite, including the pre-existing `TestObserve_MergeabilityStates` and `TestSCMMergeabilityBlocksReviewRequiredAndDraft`).
- `go test ./internal/observe/scm/...` -- all pass (full package suite).

Honesty notes:
- Could not run `go test -race` on the touched packages: this environment has `CGO_ENABLED=0` and no `gcc` on `PATH`, so `-race` fails to build (`cgo: C compiler "gcc" not found`) rather than failing due to the change itself.
- A full `go test ./...` from `backend/` shows pre-existing failures in `internal/session_manager` (Windows path-separator expectations, e.g. `/ao/bin` vs `\ao\bin`, and a PATH-construction test) that are unrelated to this change -- that package is untouched by this diff and those tests fail identically on `main`.

Addresses #2401.