### PR TITLE
fix(session): enforce the 20-character display name cap on rename

### DIFF
--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/sync/singleflight"
 
@@ -17,6 +18,12 @@ import (
 	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 	"github.com/aoagents/agent-orchestrator/backend/internal/telemetrymeta"
 )
+
+// maxDisplayNameLen caps the user-facing session display name. Mirrors the
+// spawn path's limit (backend/internal/httpd/controllers/sessions.go and
+// backend/internal/cli/spawn.go) so rename cannot set a name spawn would have
+// rejected.
+const maxDisplayNameLen = 20
 
 // Store is the read-only persistence surface needed to assemble controller-facing session read models.
 type Store interface {
@@ -621,6 +628,9 @@ func (s *Service) Rename(ctx context.Context, id domain.SessionID, displayName s
 	displayName = strings.TrimSpace(displayName)
 	if displayName == "" {
 		return apierr.Invalid("DISPLAY_NAME_REQUIRED", "Display name is required", nil)
+	}
+	if utf8.RuneCountInString(displayName) > maxDisplayNameLen {
+		return apierr.Invalid("DISPLAY_NAME_TOO_LONG", "Display name must be 20 characters or fewer", nil)
 	}
 	renamed, err := s.store.RenameSession(ctx, id, displayName, time.Now().UTC())
 	if err != nil {

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -286,6 +286,25 @@ func TestSessionRenameUpdatesDisplayName(t *testing.T) {
 	}
 }
 
+// TestSessionRenameRejectsOverlongDisplayName asserts Rename caps the display
+// name at 20 characters, the same limit spawn enforces
+// (TestSessionsAPI_SpawnRejectsOverlongDisplayName in the controllers
+// package), so a name spawn would reject cannot be set via rename either.
+func TestSessionRenameRejectsOverlongDisplayName(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", DisplayName: "original"}
+
+	overlong := strings.Repeat("x", 21)
+	err := (&Service{store: st}).Rename(context.Background(), "mer-1", overlong)
+	var e *apierr.Error
+	if !errors.As(err, &e) || e.Kind != apierr.KindInvalid || e.Code != "DISPLAY_NAME_TOO_LONG" {
+		t.Fatalf("err = %v, want DISPLAY_NAME_TOO_LONG", err)
+	}
+	if got := st.sessions["mer-1"].DisplayName; got != "original" {
+		t.Fatalf("display name = %q, want unchanged (rename should have been rejected)", got)
+	}
+}
+
 func TestSessionPinAndUnpin(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}


### PR DESCRIPTION
## Root cause

Session display names are meant to be capped at 20 runes. Spawn enforces this (`utf8.RuneCountInString(displayName) > maxDisplayNameLen` -> `400 DISPLAY_NAME_TOO_LONG`) in `backend/internal/httpd/controllers/sessions.go` and `backend/internal/cli/spawn.go`. The rename path never got the same check: `Service.Rename` in `backend/internal/service/session/service.go` only trimmed the name and rejected empty strings. Since both `ao session rename` and `PATCH /api/v1/sessions/{id}` call through this same service method, an overlong name (21+ characters) was accepted and persisted verbatim by rename, even though spawning a session with that same name would be rejected.

## Fix

Added the identical length check to `Service.Rename`:

```go
if utf8.RuneCountInString(displayName) > maxDisplayNameLen {
	return apierr.Invalid("DISPLAY_NAME_TOO_LONG", "Display name must be 20 characters or fewer", nil)
}
```

`maxDisplayNameLen` is a new unexported constant local to the `session` service package (20), mirroring the same-named, same-valued constants already defined independently in the controllers and CLI packages and in the project service package -- there was no existing shared/exported constant to reuse across packages. The error code, message, and `apierr.Invalid` (400-class) construction match the spawn path exactly.

This fixes the cap at the single choke point all rename entry points funnel through (CLI `ao session rename` -> `PATCH /api/v1/sessions/{id}` -> `Service.Rename`), so both are covered by one change.

## Verification

- Added `TestSessionRenameRejectsOverlongDisplayName` in `backend/internal/service/session/service_test.go`, alongside the existing `TestSessionRenameUpdatesDisplayName`, asserting a 21-character rename is rejected with `DISPLAY_NAME_TOO_LONG` (`apierr.KindInvalid`) and that the stored display name is left unchanged.
- Confirmed the test actually exercises the bug: with the `service.go` change stashed out (test kept), the new test fails against the old code with `err = <nil>, want DISPLAY_NAME_TOO_LONG` -- i.e. the old code silently accepts the overlong rename. Restoring the fix makes it pass.
- `go build ./...` and `go vet ./...` from `backend/` are clean.
- Full test suite for every touched/related package passes: `go test -count=1 ./internal/service/session/... ./internal/httpd/controllers/... ./internal/cli/...`.
- Ran the full `go test ./...` suite as a sanity check. There are pre-existing failures on this Windows machine in `internal/service/agent`, `internal/service/project` (Windows path-separator mismatches in `TestManager_InitializeRepositoryRecovery`), and `internal/session_manager` (PATH/runtime-environment-dependent tests). I confirmed these are pre-existing and unrelated by reproducing the identical failures with this change stashed out; none of them touch session rename or display-name validation.

## Scope

Kept the change to the service layer only, since that is the single point every rename entry point shares. I did not add a duplicate client-side check to the CLI (`backend/internal/cli/session.go`) or the PATCH controller (`backend/internal/httpd/controllers/sessions.go`) -- the daemon's `DISPLAY_NAME_TOO_LONG` error now propagates through both unchanged. I also left the comment in `frontend/src/renderer/lib/rename-session.ts` ("The daemon enforces the same 20-character limit as the spawn `--name` flag") as-is: it was inaccurate before this fix and is accurate now that the daemon actually enforces it.

Addresses #2375.