### PR TITLE
fix(workspace): seed preserve temp index from HEAD before add -A

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/commands.go
+++ b/backend/internal/adapters/workspace/gitworktree/commands.go
@@ -71,6 +71,19 @@ func worktreeListPorcelainArgs(repo string) []string {
 	return []string{"-C", repo, "worktree", "list", "--porcelain"}
 }
 
+// readTreeHeadArgs seeds a temp index from HEAD so git's "a tracked path
+// bypasses .gitignore" rule (which keys off what is IN THE INDEX, not what is
+// in HEAD) has something to key off before the subsequent `git add -A` runs
+// against the same temp index. Without this, a fresh/empty temp index makes
+// git treat a file that is committed in HEAD but also matches .gitignore as
+// untracked+ignored, so `add -A` silently skips it. GIT_INDEX_FILE must be set
+// in the command's environment before calling. Fails with exit 128 and
+// "fatal: Not a valid object name HEAD" on an unborn HEAD (no commits yet);
+// callers must tolerate that specific failure and leave the temp index empty.
+func readTreeHeadArgs(worktree string) []string {
+	return []string{"-C", worktree, "read-tree", "HEAD"}
+}
+
 // addAllTempIndexArgs stages all tracked and non-ignored untracked files into a
 // temp index file without touching the real index or the working tree.
 // GIT_INDEX_FILE must be set in the command's environment before calling.

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -414,6 +414,32 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 	// Deferred remove is a best-effort cleanup in case git leaves the file.
 	defer func() { _ = os.Remove(tmpIdxPath) }()
 
+	// Seed the temp index from HEAD before staging. git's "an already-tracked
+	// path bypasses .gitignore" rule keys off what is IN THE INDEX, not what
+	// is in HEAD, and the temp index above starts absent (empty). Without this
+	// seed step, a file that is committed in HEAD but ALSO matches a
+	// .gitignore pattern looks, from this empty index's perspective, exactly
+	// like a genuinely untracked ignored file, so the `git add -A` below would
+	// silently skip it (no -f). The preserve tree would then omit the file;
+	// since the preserve commit's parent is HEAD (which still has the file),
+	// the diff would read as a deletion, and ApplyPreserved would faithfully
+	// replay that deletion on restore, destroying the uncommitted edit. `git
+	// read-tree HEAD` makes git aware of what HEAD actually tracks, so the
+	// subsequent add -A correctly stages a tracked+ignored edit as modified
+	// while still skipping genuinely untracked ignored files.
+	//
+	// An unborn HEAD (a brand new repo with no commits yet) has nothing to
+	// seed from: `git read-tree HEAD` fails with exit 128 and "fatal: Not a
+	// valid object name HEAD" (verified against git 2.54). That specific
+	// failure is expected and tolerated — the temp index simply stays empty,
+	// exactly as it behaved before this seed step existed. Any other
+	// read-tree failure is a real problem and is surfaced normally.
+	readTreeCmd := exec.CommandContext(ctx, w.binary, readTreeHeadArgs(path)...)
+	readTreeCmd.Env = append(os.Environ(), "GIT_INDEX_FILE="+tmpIdxPath)
+	if out, err := readTreeCmd.CombinedOutput(); err != nil && !isUnbornHeadReadTreeError(string(out)) {
+		return "", commandError{args: append([]string{w.binary}, readTreeHeadArgs(path)...), output: string(out), err: err}
+	}
+
 	// Stage all tracked and non-ignored untracked files into the temp index.
 	// GIT_INDEX_FILE overrides the index so the real index is never touched.
 	addCmd := exec.CommandContext(ctx, w.binary, addAllTempIndexArgs(path)...)
@@ -471,6 +497,18 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 
 func isNotGitRepositoryError(err error) bool {
 	return strings.Contains(err.Error(), "not a git repository")
+}
+
+// isUnbornHeadReadTreeError reports whether a "git read-tree HEAD" failure is
+// only the unborn-HEAD case: a repo with no commits yet has no HEAD for
+// read-tree to seed the temp index from. Verified against git 2.54: that case
+// fails with exactly this message at exit 128. Text matching mirrors the
+// existing isNotGitRepositoryError / isMissingRegisteredWorktreeError /
+// isLockedWorktreeRemoveError helpers in this file. Matching only this exact
+// message keeps every other read-tree failure (corruption, permissions, etc.)
+// from being silently swallowed.
+func isUnbornHeadReadTreeError(output string) bool {
+	return strings.Contains(output, "Not a valid object name HEAD")
 }
 
 // countIgnoredPaths returns the number of entries listed by

--- a/backend/internal/adapters/workspace/gitworktree/workspace_preserve_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_preserve_test.go
@@ -218,6 +218,126 @@ func TestWorkspaceIntegrationApplyPreservedConflict(t *testing.T) {
 	}
 }
 
+// TestWorkspaceIntegrationStashApplyPreservesTrackedIgnoredEdit is a
+// regression test for the data-loss bug where an uncommitted edit to a file
+// that is tracked in HEAD but ALSO matches a .gitignore pattern (a real
+// pattern: commit a config once, then gitignore it so local edits never get
+// pushed) was silently dropped by StashUncommitted and then deleted on
+// restore by ApplyPreserved.
+//
+// Root cause: StashUncommitted stages the preserve tree through a temp index
+// file that starts absent/empty. git's "an already-tracked path bypasses
+// .gitignore" rule keys off what is IN THE INDEX, not what is in HEAD, so
+// against an empty index `git add -A` cannot tell a tracked-but-ignored file
+// apart from a genuinely untracked-and-ignored one, and silently skips both
+// (no -f passed). The preserve tree then omits the tracked file; since the
+// preserve commit's parent is HEAD (which still has the file), the diff reads
+// as a deletion, and ApplyPreserved's cherry-pick faithfully replays that
+// deletion on restore.
+//
+// This test also covers the negative case in the same run: a genuinely
+// untracked file that matches .gitignore (never committed) must still be
+// excluded from the preserve/restore round trip. That is the main regression
+// risk of seeding the temp index from HEAD — it must not start capturing real
+// ignored junk (build output, node_modules, etc).
+func TestWorkspaceIntegrationStashApplyPreservesTrackedIgnoredEdit(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	root := filepath.Join(tmp, "managed")
+	ws, err := New(Options{Binary: git, ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	cfg := ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess-tracked-ignored", Branch: "feature/tracked-ignored"}
+
+	info, err := ws.Create(ctx, cfg)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Commit config.yaml (tracked in HEAD), THEN add it to .gitignore and
+	// commit that too, so it stays tracked while also matching an ignore
+	// pattern going forward — the exact real-world shape the issue describes.
+	configPath := filepath.Join(info.Path, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("original\n"), 0o644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	runGit(t, git, info.Path, "add", "config.yaml")
+	runGit(t, git, info.Path, "commit", "-m", "add config.yaml")
+
+	if err := os.WriteFile(filepath.Join(info.Path, ".gitignore"), []byte("config.yaml\nbuild/\n"), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+	runGit(t, git, info.Path, "add", ".gitignore")
+	runGit(t, git, info.Path, "commit", "-m", "gitignore config.yaml and build/")
+
+	// Uncommitted edit to the tracked-but-now-ignored file: this is the edit
+	// that must survive preserve/restore.
+	if err := os.WriteFile(configPath, []byte("edited by agent\n"), 0o644); err != nil {
+		t.Fatalf("edit config.yaml: %v", err)
+	}
+
+	// Negative case: a genuinely untracked file that matches .gitignore (never
+	// committed). It must be excluded from the round trip, same as before
+	// this fix — seeding the temp index from HEAD must not start capturing
+	// real ignored junk.
+	buildDir := filepath.Join(info.Path, "build")
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		t.Fatalf("mkdir build: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(buildDir, "output.log"), []byte("junk\n"), 0o644); err != nil {
+		t.Fatalf("write build/output.log: %v", err)
+	}
+
+	// StashUncommitted: must return a non-empty ref (there is real work to
+	// preserve: the config.yaml edit).
+	ref, err := ws.StashUncommitted(ctx, info)
+	if err != nil {
+		t.Fatalf("StashUncommitted: %v", err)
+	}
+	if ref == "" {
+		t.Fatal("StashUncommitted returned empty ref, want a preserve ref for the tracked-ignored edit")
+	}
+
+	// ForceDestroy: simulate session close.
+	if err := ws.ForceDestroy(ctx, info); err != nil {
+		t.Fatalf("ForceDestroy: %v", err)
+	}
+	if _, err := os.Stat(info.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree path still exists after ForceDestroy")
+	}
+
+	// Restore: simulate re-open / re-attach.
+	restored, err := ws.Restore(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	// ApplyPreserved: replay the captured state.
+	if err := ws.ApplyPreserved(ctx, restored, ref); err != nil {
+		t.Fatalf("ApplyPreserved: %v", err)
+	}
+
+	// The tracked-but-ignored file must still exist AND carry the edited
+	// content — not the original, and not deleted. This is the core assertion
+	// for the data-loss bug: before the fix, config.yaml did not exist here.
+	restoredConfig := filepath.Join(restored.Path, "config.yaml")
+	configBytes, err := os.ReadFile(restoredConfig)
+	if err != nil {
+		t.Fatalf("config.yaml missing after apply (data loss): %v", err)
+	}
+	if string(configBytes) != "edited by agent\n" {
+		t.Fatalf("config.yaml content = %q, want %q (edit lost or reverted to original)", string(configBytes), "edited by agent\n")
+	}
+
+	// Negative case: the genuinely untracked, ignored file must NOT reappear.
+	if _, err := os.Stat(filepath.Join(restored.Path, "build", "output.log")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("build/output.log exists after apply but must not (it was untracked and .gitignore-d)")
+	}
+}
+
 // TestWorkspaceIntegrationStashCleanWorktree proves that StashUncommitted on a
 // clean worktree returns an empty ref and no error (nothing to preserve).
 func TestWorkspaceIntegrationStashCleanWorktree(t *testing.T) {


### PR DESCRIPTION
## Bug

This is a real data-loss bug. `StashUncommitted` in `backend/internal/adapters/workspace/gitworktree/workspace.go` builds the session's preserve commit by staging into a temp index file pointed at by `GIT_INDEX_FILE`, and that temp index deliberately starts absent/empty (git treats a nonexistent `GIT_INDEX_FILE` path as an empty index). It then runs `git add -A` against that empty index (no `-f`) to capture uncommitted work.

git's rule that an already-tracked path bypasses `.gitignore` keys off what is **in the index**, not what is in HEAD. Because the temp index starts empty, git has no record that anything is tracked. A file that IS committed in HEAD but ALSO matches a `.gitignore` pattern — a common, non-exotic pattern: commit a config/template once, then gitignore it so local edits never get pushed — is therefore indistinguishable from a genuinely untracked ignored file, and `git add -A` silently skips it.

The resulting preserve tree omits that file. Since the preserve commit's parent is HEAD (which still has the file), the diff between HEAD and the preserve tree reads as a **deletion** of the file. When the session reopens, `ApplyPreserved` cherry-picks that preserve commit onto the restored worktree and faithfully applies the delete — destroying the user's uncommitted edit.

## Fix

Seed the temp index from HEAD with `git read-tree HEAD` (same `GIT_INDEX_FILE` override) immediately before `git add -A`, so git is aware of what HEAD actually tracks:

- A tracked-but-gitignored file with uncommitted edits is now correctly staged as modified (`M`), not skipped.
- A genuinely untracked, gitignored file (build output, `node_modules`, etc.) is still correctly skipped by `git add -A`, since no `-f` is passed — this does not regress.
- An unborn HEAD (a brand new repo with no commits yet) has nothing to seed from: `git read-tree HEAD` fails with exit 128 and "fatal: Not a valid object name HEAD" (verified against real git). That specific failure is tolerated and the temp index is left empty, exactly as it behaved before this change. Any other `read-tree` failure is surfaced normally and is not swallowed.

The pre-existing comment in `StashUncommitted` explaining why the temp index file must not be pre-created is unaffected — this change only adds a `read-tree` call against the same not-pre-created path, after git has already started treating it as an empty index and before `add -A` runs against it.

## Verification

- Manually reproduced the bug against real git first, independent of this codebase: committed `config.yaml`, gitignored it, edited it uncommitted. `git add -A` against an empty temp index produced `D config.yaml` in `git diff --name-status HEAD <preserve-tree>`. Seeding with `git read-tree HEAD` first produced `M config.yaml` instead, while a genuinely untracked+ignored file stayed excluded from the diff in both cases.
- Added `TestWorkspaceIntegrationStashApplyPreservesTrackedIgnoredEdit` to `workspace_preserve_test.go`, mirroring this package's existing real-git integration test style (temp dirs, real `git` binary, no mocking). It: commits `config.yaml`, commits a `.gitignore` listing it, edits it uncommitted, runs the full `StashUncommitted` -> `ForceDestroy` -> `Restore` -> `ApplyPreserved` round trip, and asserts `config.yaml` exists afterward with the edited content (not the original, not deleted).
- Same test also covers the negative case in one run: a genuinely untracked file matching `.gitignore` (`build/output.log`, never committed) is asserted to stay excluded from the round trip. This is the main regression risk of seeding from HEAD, and it passes — confirmed not regressed.
- Proved the fix actually matters: stashed only the fix (`commands.go`/`workspace.go`), kept the new test, ran it against the old code — it FAILED with "config.yaml missing after apply (data loss)", reproducing the bug exactly as described. Popped the stash, reran — it PASSED.
- `go build ./...` and `go vet ./...` from `backend/` are clean.
- Full `gitworktree` package test suite passes, including the pre-existing `TestWorkspaceIntegrationStashApplyRoundTrip`, which already asserts a genuinely-ignored file (`secret.txt`) stays excluded — no regression there either.
- Ran the full `backend` test suite (`go test ./...`). Three unrelated failures in `internal/session_manager` (`TestSpawn_DefaultsBranchUnderDevNamespaceForDevDataDir`, `TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH`, `TestSpawn_DoesNotAddNodeRuntimeForNativeBinary`) are pre-existing on unmodified `main` in this environment (confirmed by stashing this change entirely and re-running them) and are unrelated to this change — they look like Windows path-separator / local node-version environment assumptions, not something this diff touches.

I did not add a dedicated unborn-HEAD test case: the existing test fixtures in this file all set up a repo with an initial commit via `setupOriginClone`, and adding a from-scratch no-commit fixture felt like a bigger addition than this fix warrants. I manually traced the code path instead (confirmed the exact git error text and exit code against real git, shown above) and I'm confident in it, but flagging honestly that it isn't covered by an automated test in this PR.

Addresses #2451.