### PR TITLE
fix(session): let PR status win over sticky waiting_input/blocked

### DIFF
--- a/backend/internal/service/session/status.go
+++ b/backend/internal/service/session/status.go
@@ -38,6 +38,15 @@ func deriveStatus(rec domain.SessionRecord, prs []domain.PRFacts, now time.Time,
 	case domain.ActivityExited:
 		return domain.StatusExited
 	case domain.ActivityWaitingInput, domain.ActivityBlocked:
+		// PR facts are a newer, more actionable signal than a sticky
+		// waiting_input/blocked activity state: once a worker has raised a
+		// PR, its pipeline status (pr_open, ci_failed, review_pending, ...)
+		// is more useful than a stale "needs input" pinned from the last
+		// hook callback. Only fall back to needs_input when there is no
+		// open (or merged) PR to derive a status from.
+		if scmStatus := deriveSCMStatus(prs); scmStatus != "" {
+			return scmStatus
+		}
 		return domain.StatusNeedsInput
 	}
 

--- a/backend/internal/service/session/status_test.go
+++ b/backend/internal/service/session/status_test.go
@@ -48,8 +48,22 @@ func TestServiceDerivesStatusFromSessionFactsAndPR(t *testing.T) {
 	}{
 		{"terminated", statusRec(domain.ActivityExited, true), nil, false, domain.StatusTerminated},
 		{"merged-pr", statusRec(domain.ActivityIdle, true), statusPR(domain.PRFacts{Merged: true}), false, domain.StatusMerged},
-		{"needs-input", statusRec(domain.ActivityWaitingInput, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusNeedsInput},
-		{"needs-input-blocked", statusRec(domain.ActivityBlocked, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusNeedsInput},
+		// Termination outranks activity state entirely, unaffected by the
+		// waiting_input/PR precedence fix below: a terminated session with a
+		// waiting_input activity signal still reports merged, exactly as an
+		// idle terminated session does.
+		{"terminated-waiting-input-merged-pr-still-merged", statusRec(domain.ActivityWaitingInput, true), statusPR(domain.PRFacts{Merged: true}), false, domain.StatusMerged},
+		// waiting_input with no PR to derive a status from still falls back to needs_input.
+		{"needs-input", statusRec(domain.ActivityWaitingInput, false), nil, false, domain.StatusNeedsInput},
+		// waiting_input with an owned PR now surfaces the PR's pipeline status
+		// instead of masking it behind needs_input.
+		{"waiting-input-pr-derived-ci-failed", statusRec(domain.ActivityWaitingInput, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusCIFailed},
+		// blocked with no PR to derive a status from still falls back to needs_input.
+		{"needs-input-blocked", statusRec(domain.ActivityBlocked, false), nil, false, domain.StatusNeedsInput},
+		// blocked with an owned PR now surfaces the PR's pipeline status
+		// instead of masking it behind needs_input (same fix as waiting_input,
+		// since both share the same activity-precedence case).
+		{"blocked-pr-derived-ci-failed", statusRec(domain.ActivityBlocked, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusCIFailed},
 		{"exited", statusRec(domain.ActivityExited, false), statusPR(domain.PRFacts{Mergeability: domain.MergeMergeable}), false, domain.StatusExited},
 		{"ci-failed", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusCIFailed},
 		{"draft", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{Draft: true}), false, domain.StatusDraft},
@@ -112,8 +126,16 @@ func TestDeriveStatusActivityPrecedence(t *testing.T) {
 		{"exited-without-pr", domain.ActivityExited, nil, domain.StatusExited},
 		{"exited-with-open-pr", domain.ActivityExited, statusPR(domain.PRFacts{}), domain.StatusExited},
 		{"exited-with-merged-pr", domain.ActivityExited, statusPR(domain.PRFacts{Merged: true}), domain.StatusExited},
-		{"waiting-with-pr", domain.ActivityWaitingInput, statusPR(domain.PRFacts{Mergeability: domain.MergeMergeable}), domain.StatusNeedsInput},
-		{"blocked-with-pr", domain.ActivityBlocked, statusPR(domain.PRFacts{Mergeability: domain.MergeMergeable}), domain.StatusNeedsInput},
+		// waiting_input/blocked defer to the PR's pipeline status when there is
+		// one to derive; they only fall back to needs_input when there isn't.
+		{"waiting-with-pr", domain.ActivityWaitingInput, statusPR(domain.PRFacts{Mergeability: domain.MergeMergeable}), domain.StatusMergeable},
+		{"blocked-with-pr", domain.ActivityBlocked, statusPR(domain.PRFacts{Mergeability: domain.MergeMergeable}), domain.StatusMergeable},
+		{"waiting-without-pr", domain.ActivityWaitingInput, nil, domain.StatusNeedsInput},
+		{"blocked-without-pr", domain.ActivityBlocked, nil, domain.StatusNeedsInput},
+		{"waiting-with-open-pr", domain.ActivityWaitingInput, statusPR(domain.PRFacts{}), domain.StatusPROpen},
+		{"waiting-with-ci-failing-pr", domain.ActivityWaitingInput, statusPR(domain.PRFacts{CI: domain.CIFailing}), domain.StatusCIFailed},
+		{"blocked-with-open-pr", domain.ActivityBlocked, statusPR(domain.PRFacts{}), domain.StatusPROpen},
+		{"blocked-with-ci-failing-pr", domain.ActivityBlocked, statusPR(domain.PRFacts{CI: domain.CIFailing}), domain.StatusCIFailed},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Root cause

`deriveStatus` in `backend/internal/service/session/status.go` returns `StatusNeedsInput` for `ActivityWaitingInput`/`ActivityBlocked` before ever consulting PR facts (`deriveSCMStatus`, which is only reached further down the function). `waiting_input` is a sticky, very common activity state (e.g. it is set after a Claude Code hook fires once the agent's turn ends), so once a worker session hits it, the session's displayed status stays pinned at `needs_input` even after the worker opens a PR whose own pipeline status (`pr_open`, `ci_failed`, `review_pending`, `changes_requested`, `approved`, `mergeable`) is a much more actionable signal for the user.

## Fix

Reordered the `ActivityWaitingInput`/`ActivityBlocked` case so it consults `deriveSCMStatus(prs)` first and only falls back to `StatusNeedsInput` when there is no open (or merged) PR to derive a status from. This is a surgical, three-line reorder inside the existing switch case; no other branch of `deriveStatus` was touched.

Terminated-session precedence is unaffected: the `rec.IsTerminated` check still short-circuits at the very top of the function, before the activity switch is ever reached, so `terminated + merged PR => merged` (and `terminated => terminated` with no PR) behaves exactly as before regardless of the last activity signal.

`ActivityBlocked` was given the same treatment as `ActivityWaitingInput` since the issue is silent on `Blocked` specifically, but both share the same `case` in the switch (grouped together already), and the same masking bug applies equally to both.

## Tests changed/added (`backend/internal/service/session/status_test.go`)

- Changed `needs-input` / `needs-input-blocked` (previously asserted `waiting_input`/`blocked` + a CI-failing PR => `needs_input`, which codified the bug) to use no PR at all, so they now correctly assert the genuine no-PR needs_input case.
- Added `waiting-input-pr-derived-ci-failed` / `blocked-pr-derived-ci-failed`: `waiting_input`/`blocked` + CI-failing PR => `ci_failed`.
- Added `terminated-waiting-input-merged-pr-still-merged`: a terminated session with a `waiting_input` activity signal and a merged PR still reports `merged`, confirming terminated precedence is unaffected by this fix.
- In `TestDeriveStatusActivityPrecedence`, updated `waiting-with-pr` / `blocked-with-pr` (mergeable PR) to expect `mergeable` instead of the old `needs_input`, and added `waiting-without-pr`, `blocked-without-pr` (no PR => `needs_input`), `waiting-with-open-pr`, `blocked-with-open-pr` (plain open PR => `pr_open`), and `waiting-with-ci-failing-pr`, `blocked-with-ci-failing-pr` (=> `ci_failed`), covering exactly the cases the issue calls out.

## Verification

- Proved the new/changed tests actually catch the bug: reverse-applied just the `status.go` fix (via a saved patch, keeping the updated tests in place), reran the affected tests, and confirmed every new/changed case failed with `got "needs_input" want "..."` against the old code. Reapplied the fix and confirmed all of them pass.
- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./internal/service/session/...` passes in full, including every pre-existing test in the package (no regressions) plus all new/updated cases.
- Branch is up to date with `upstream/main` (0 commits behind at time of opening this PR), so no rebase was needed.

Addresses #2174.