### PR TITLE
fix(web): give the terminal keyboard focus when a session/handle attaches

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -17,6 +17,7 @@ import {
 
 const {
 	attachMock,
+	focusMock,
 	getMock,
 	postMock,
 	prepareForActivationMock,
@@ -29,6 +30,7 @@ const {
 } = vi.hoisted(
 	() => ({
 		attachMock: vi.fn(() => vi.fn()),
+		focusMock: vi.fn(),
 		getMock: vi.fn(async (_path: string, _options: unknown) => ({ data: undefined })),
 		postMock: vi.fn(),
 		prepareForActivationMock: vi.fn(async (): Promise<void> => undefined),
@@ -69,6 +71,7 @@ vi.mock("./XtermTerminal", () => ({
 			props.onReady?.({
 				cols: 80,
 				rows: 24,
+				focus: focusMock,
 				write: vi.fn((_data, done) => done?.()),
 				writeln: vi.fn(),
 				showLatestOutput: vi.fn(),
@@ -129,6 +132,7 @@ beforeEach(() => {
 	terminalLinkHandler = undefined;
 	terminalSessionOptions.length = 0;
 	attachMock.mockClear();
+	focusMock.mockClear();
 	prepareForActivationMock.mockReset();
 	prepareForActivationMock.mockResolvedValue(undefined);
 	xtermMounts.value = 0;
@@ -263,6 +267,44 @@ describe("TerminalPane empty states", () => {
 				),
 			).toBeInTheDocument();
 			expect(screen.queryByText(/worker terminal/i)).not.toBeInTheDocument();
+		} finally {
+			view.restore();
+		}
+	});
+});
+
+// Terminal keyboard focus (issue #2434): opening a session/agent view must
+// hand the terminal keyboard focus so the user can type immediately, but the
+// empty-state pane (no session/handle attached yet) must never have focus
+// stolen onto it.
+describe("TerminalPane terminal focus", () => {
+	it("focuses the terminal once a session handle is attached", async () => {
+		const view = renderPane({ ...worker, terminalHandleId: "term-1" });
+		try {
+			await waitFor(() => expect(attachMock).toHaveBeenCalled());
+			expect(focusMock).toHaveBeenCalled();
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("does not steal focus onto the empty-state pane when no session is selected", async () => {
+		const view = renderPane();
+		try {
+			expect(screen.getByText("No session selected. Pick a worker to attach its terminal.")).toBeInTheDocument();
+			await waitFor(() => expect(attachMock).toHaveBeenCalled());
+			expect(focusMock).not.toHaveBeenCalled();
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("does not focus while a session is starting but has no terminal handle yet", async () => {
+		const view = renderPane(worker);
+		try {
+			expect(screen.getByText("Starting session")).toBeInTheDocument();
+			await waitFor(() => expect(attachMock).toHaveBeenCalled());
+			expect(focusMock).not.toHaveBeenCalled();
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -971,6 +971,11 @@ function AttachedTerminal({
 		void terminal.prepareForActivation().then(() => {
 			if (!current) return;
 			detach = attach(terminal);
+			// Focus the terminal the moment a session/handle is actually attached,
+			// so the user can type immediately without an extra click. Gated on
+			// handleId (not just `terminal`) so the empty-state pane — no session
+			// selected — never has focus stolen onto it.
+			if (handleId) terminal.focus();
 		});
 		return () => {
 			current = false;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -859,6 +859,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			get rows() {
 				return term.rows;
 			},
+			focus: focusTerminal,
 			// Forward xterm's write callback: it fires once THIS chunk has been
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -106,6 +106,7 @@ function createFakeTerminal(): FakeTerminal {
 	const terminal: FakeTerminal = {
 		cols: 80,
 		rows: 24,
+		focus: () => undefined,
 		autoCompleteWrites: true,
 		lines: [],
 		pendingWriteCallbacks: [],

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -29,6 +29,8 @@ export type TerminalUserInputSource = "keyboard" | "paste" | "composition" | "sh
 export type AttachableTerminal = {
 	cols: number;
 	rows: number;
+	/** Give the underlying xterm.js instance keyboard focus. */
+	focus: () => void;
 	/**
 	 * `done` fires once this exact chunk has been parsed into the buffer (xterm's
 	 * own write callback). The attachment uses it to reveal the pane at the


### PR DESCRIPTION
## Root cause

Opening a session/agent terminal (from the Kanban board, an orchestrator session, or switching tabs) never gave the underlying xterm.js instance keyboard focus, so typing did nothing until the user manually clicked inside the terminal pane first.

- `frontend/src/renderer/components/XtermTerminal.tsx` owns the real `Terminal` instance (`term`) from `@xterm/xterm`, which has a built-in `term.focus()` method, but nothing in this file ever called it.
- The handle object it exposes outward, `AttachableTerminal` (`frontend/src/renderer/hooks/useTerminalSession.ts`), had no `focus` method, so callers had no way to request it.
- `frontend/src/renderer/components/TerminalPane.tsx`'s `AttachedTerminal` has an existing effect that attaches the terminal to its PTY handle once `prepareForActivation()` resolves — a reliable "just opened" moment on every session/tab switch — but it did nothing focus-related.

## Fix

Split by mechanism (capability) vs. policy (when to use it), same as the surrounding code's existing separation of concerns:

1. `XtermTerminal.tsx`: the handle now exposes `focus`, wired to the existing `focusTerminal` helper (already used by the context-menu's copy/paste/selectAll/clear actions to restore focus after using the menu) rather than a bare `term.focus()` call, so the same try/catch around a torn-down terminal or unavailable hidden textarea applies here too.
2. `useTerminalSession.ts`: the `AttachableTerminal` type gains the matching `focus: () => void` field.
3. `TerminalPane.tsx`: `AttachedTerminal`'s existing attach effect calls `terminal.focus()` right after `attach(terminal)`, gated on `handleId` being present. This keeps the empty-state pane (no session selected, `showEmptyState = !handleId`) from ever having focus stolen onto it, since that gate is exactly the one already governing the empty-state UI.

## Verification

- `npx tsc --noEmit` from `frontend/` is clean (ran `npm ci` first since `node_modules` wasn't present in the worktree).
- Existing unit tests cover this seam: `TerminalPane.test.tsx` and `useTerminalSession.test.tsx` both construct a fake `AttachableTerminal`/xterm mock that now had to gain a `focus` field to satisfy the updated type — fixed both fakes.
- Added three focused tests to `TerminalPane.test.tsx` (`describe("TerminalPane terminal focus")`):
  - focuses the terminal once a session handle is attached,
  - does NOT focus when no session is selected (empty state),
  - does NOT focus while a session is starting but has no terminal handle yet.
  I verified these tests are meaningful (not vacuously true) by temporarily reverting the `TerminalPane.tsx` change and confirming the positive test fails without the fix, then re-applied the fix.
- Full suite for the three touched files: `TerminalPane.test.tsx`, `useTerminalSession.test.tsx`, `XtermTerminal.test.tsx` — 134 tests passed (had to pass `--pool=threads` to vitest; the default forked-process pool times out in this sandboxed environment, unrelated to the change).
- I do not have a way to launch the real Electron desktop app in this environment (no GUI, and the repo's `ao-desktop-dev` dev skill isn't available in this session), so I was not able to do a live click-free-typing check in the actual app. Verification here is code review + typecheck + unit tests only — flagging this honestly per repo convention for intentional verification gaps.

Addresses #2434.