### PR TITLE
fix: gate board actions on daemon status

### DIFF
--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -8,12 +8,19 @@ import type { ReactNode } from "react";
 // first-run states, mocking only the HTTP client, the router, and the native
 // folder picker: an empty daemon shows the import chooser (no column shells), a
 // fresh project shows the task invitation, and any session brings the columns back.
-const { getMock, navigateMock, chooseDirectoryMock, spawnOrchestratorMock } = vi.hoisted(() => ({
-	getMock: vi.fn(),
-	navigateMock: vi.fn(),
-	chooseDirectoryMock: vi.fn(),
-	spawnOrchestratorMock: vi.fn(),
-}));
+const { getMock, navigateMock, chooseDirectoryMock, spawnOrchestratorMock, boardActionsInPanelMock } = vi.hoisted(
+	() => ({
+		getMock: vi.fn(),
+		navigateMock: vi.fn(),
+		chooseDirectoryMock: vi.fn(),
+		spawnOrchestratorMock: vi.fn(),
+		// jsdom's default navigator reports no platform, so the real
+		// usesBoardActionsInPanel() (macOS-only) is false here already; this mock
+		// only exists so the daemon-gating test below can flip it on to exercise
+		// the in-panel header actions row the same way macOS does.
+		boardActionsInPanelMock: vi.fn(() => false),
+	}),
+);
 
 vi.mock("../../lib/spawn-orchestrator", () => ({
 	isChatPreflightError: (error: unknown) =>
@@ -30,6 +37,11 @@ vi.mock("../../lib/api-client", () => ({
 vi.mock("../../lib/bridge", () => ({
 	aoBridge: { app: { chooseDirectory: chooseDirectoryMock } },
 }));
+
+vi.mock("../../lib/platform", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../lib/platform")>();
+	return { ...actual, usesBoardActionsInPanel: () => boardActionsInPanelMock() };
+});
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@tanstack/react-router")>();
@@ -112,6 +124,7 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	createProjectMock.mockResolvedValue(undefined);
 	initializeProjectRepositoryMock.mockResolvedValue(undefined);
+	boardActionsInPanelMock.mockReturnValue(false);
 	useUiStore.setState({
 		orchestratorReplacementErrors: {},
 		orchestratorStartupErrors: {},
@@ -218,6 +231,53 @@ describe("global board first launch", () => {
 		expect(await screen.findByText("fix the bug")).toBeInTheDocument();
 		expect(screen.queryByTestId("daemon-startup-loader")).not.toBeInTheDocument();
 		expect(columnCount()).toBe(4);
+	});
+
+	it("disables New task and Spawn Orchestrator on a stale board once the daemon exits (#2242)", async () => {
+		// Same scenario as the previous test (daemon died, board stays mounted
+		// with its last-known sessions) but on the in-panel action layout, so the
+		// header's New task / Spawn Orchestrator buttons are on screen. Before the
+		// fix these stayed enabled and threw "AO daemon is not ready" as an
+		// unhandled rejection when clicked.
+		boardActionsInPanelMock.mockReturnValue(true);
+		respondWith([project], [workerSession]);
+		lastQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		lastShell = {
+			daemonStatus: { state: "ready" } as ShellContextValue["daemonStatus"],
+			workspaceStartupState: "ready",
+			createProject: createProjectMock,
+			initializeProjectRepository: initializeProjectRepositoryMock,
+		};
+		const { rerender } = render(
+			<QueryClientProvider client={lastQueryClient}>
+				<ShellProvider value={lastShell}>
+					<SessionsBoard projectId="proj-1" />
+				</ShellProvider>
+			</QueryClientProvider>,
+		);
+
+		await screen.findByText("fix the bug");
+		expect(screen.getByRole("button", { name: "New task" })).toBeEnabled();
+		expect(screen.getByRole("button", { name: "Spawn Orchestrator" })).toBeEnabled();
+
+		lastShell = {
+			...lastShell,
+			daemonStatus: { state: "stopped", code: "exited" } as ShellContextValue["daemonStatus"],
+		};
+		rerender(
+			<QueryClientProvider client={lastQueryClient}>
+				<ShellProvider value={lastShell}>
+					<SessionsBoard projectId="proj-1" />
+				</ShellProvider>
+			</QueryClientProvider>,
+		);
+
+		expect(screen.getByText("fix the bug")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "New task" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Spawn Orchestrator" })).toBeDisabled();
+
+		await userEvent.click(screen.getByRole("button", { name: "Spawn Orchestrator" }));
+		expect(spawnOrchestratorMock).not.toHaveBeenCalled();
 	});
 });
 

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -272,13 +272,18 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				</TopbarKillError>
 			)}
 			{visibleSpawnError && canCreateAsTui && !showProjectEmpty ? (
-				<TopbarButton disabled={isSpawning || isProjectRestarting} onClick={() => void openOrchestrator("tui")}>
+				<TopbarButton
+					disabled={isSpawning || isProjectRestarting || !isDaemonReady}
+					onClick={() => void openOrchestrator("tui")}
+				>
 					{t("newTask.createAsTui")}
 				</TopbarButton>
 			) : null}
 			<TopbarButton
 				aria-label={t("shell.newTask")}
-				disabled={isProjectRestarting}
+				// A dead daemon can't create a session; without this the button stays
+				// clickable after the board goes stale and the request just throws.
+				disabled={isProjectRestarting || !isDaemonReady}
 				onClick={() => projectId && requestNewTask(projectId)}
 				variant="accent"
 			>
@@ -291,7 +296,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						? t("shell.orchestratorWithActivity", { activity: orchestratorActivityLabel })
 						: t("shell.spawnOrchestrator")
 				}
-				disabled={isSpawning || isProjectRestarting}
+				disabled={isSpawning || isProjectRestarting || !isDaemonReady}
 				onClick={() => void openOrchestrator()}
 				variant="primary"
 			>


### PR DESCRIPTION
## What

Disable **New task** and **Spawn Orchestrator** on the project board (and the Terminal UI retry button shown after a failed spawn) while the daemon is not in the `ready` state.

## Why

When the Electron-managed daemon exits while the desktop app stays open, `SessionsBoard` deliberately keeps rendering the last-known project data instead of blanking the screen. That's correct, but the board's `New task` / `Spawn Orchestrator` header actions were gated only on `isSpawning` / `isProjectRestarting`, never on daemon readiness. So the stale board stayed fully interactive: clicking either action called `spawnOrchestrator` against an unreachable daemon API and threw `AO daemon is not ready`.

## How

- Verified the gap against current `main` first. `useDaemonStatus`/`shell-context` already expose `daemonStatus.state: "starting" | "ready" | "stopped" | "error"`, and `SessionsBoard` already derives `isDaemonReady = usesPreviewWorkspaceData || (shell ? shell.daemonStatus.state === "ready" : true)` for its own loading/startup screens - it just wasn't reused on the action buttons.
- On an unexpected daemon exit, Electron's main process sets `{ state: "stopped", code: "exited" }` (see `frontend/src/main.ts`). Because `code` is set, the board's `daemonHasFailed` flag is true, which keeps the normal board (not the startup loader) mounted with the header actions row - this is exactly the reported "stale board stays interactive" state, and it's what the new test reproduces.
- Added `!isDaemonReady` to the `disabled` condition on `New task`, `Spawn Orchestrator`, and the `Create as Terminal UI` retry button in `frontend/src/renderer/components/SessionsBoard.tsx`. No new UI: this reuses the app's existing native-`disabled` + `opacity-60` styling (`TopbarButton`), consistent with how the rest of the app already shows an unavailable action (e.g. `TerminalPane`'s `daemonReady` gating).
- I also checked the other half of the original report - `openOrchestrator` swallowing the daemon error as an unhandled rejection (`try/finally`, no `catch`). On current `main` this is already fixed: #2432 added a proper `catch` that sets `spawnError` and renders it via the existing `TopbarKillError` component (same pattern reused here for consistency). So that part of the issue no longer reproduces; this PR covers the remaining gap, the buttons staying enabled/clickable.
- `New task`'s own daemon-error handling (inside `TaskComposer`, opened via the dialog) was already solid - try/catch with an inline error message - so the only real gap for that action was the missing gate, which this PR fixes.

### Intentional scope note

`ShellTopbar.tsx` renders the same `New task` / `Spawn Orchestrator` pair for the Windows/Linux board layout and for session-detail routes, and has the identical missing-gate pattern (its own `openOrchestrator` already has a `catch`, so no unhandled rejection there either, just no daemon-ready gate). I scoped this PR to `SessionsBoard.tsx` per the issue's explicit repro (macOS board route) and code pointers, to keep the change surgical and reviewable as one fix. Flagging `ShellTopbar.tsx` here as a known follow-up rather than folding it into this PR silently.

## Testing

- `cd frontend && npx tsc --noEmit` - clean, no errors.
- Added a new test to `frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx`: renders a populated board with `daemonStatus: { state: "ready" }` (buttons enabled), then flips to `{ state: "stopped", code: "exited" }` (the exact status Electron sets on an unexpected exit) and asserts both buttons become disabled and that clicking no longer calls `spawnOrchestrator`. Confirmed this test actually catches the regression by temporarily reverting the `SessionsBoard.tsx` change and re-running it (fails as expected: buttons stay enabled).
- Ran the full targeted suite: `npx vitest run --config vite.renderer.config.ts src/renderer/__tests__/integration/board-empty-states.test.tsx src/renderer/components/SessionsBoard.test.tsx` - 54/54 passing.
- Ran the full frontend `vitest` suite as a broader safety net: 2043 passed / 6 failed / 2 skipped (plus the separate `src/landing` sub-package, 31 passed / 5 failed). All failures are pre-existing and unrelated to this change: the `src/landing` failures are a missing `node-html-markdown` dependency in that sub-package's own `package.json` (needs its own install, untouched by this PR), and the 6 `src/main/supervisor-link.test.ts` failures are `EACCES: permission denied` creating Unix-socket test fixtures under Windows `%TEMP%` in this sandbox - unrelated to anything touched here (`src/main/*` isn't part of this diff).
- **No live Electron verification.** I wasn't able to launch the real desktop app in this environment (no confirmed display for screenshot verification, and the sandbox showed heavy concurrent multi-agent activity sharing this checkout's git state, which made spinning up a dev Electron instance against shared `~/.ao` paths risky). Verification here is code review + typecheck + the tests above only - flagging this honestly rather than claiming a live-app check that wasn't actually done.

Addresses #2242.