### PR TITLE
fix(session): keep terminated status when an open PR remains

### DIFF
--- a/backend/internal/service/session/status.go
+++ b/backend/internal/service/session/status.go
@@ -26,7 +26,7 @@ const noSignalGrace = 90 * time.Second
 // until the parent does. Merged/closed PRs only matter once no open PR remains.
 func deriveStatus(rec domain.SessionRecord, prs []domain.PRFacts, now time.Time, signalCapable bool) domain.SessionStatus {
 	if rec.IsTerminated {
-		if anyMerged(prs) {
+		if len(openPRs(prs)) == 0 && anyMerged(prs) {
 			return domain.StatusMerged
 		}
 		return domain.StatusTerminated

--- a/backend/internal/service/session/status_test.go
+++ b/backend/internal/service/session/status_test.go
@@ -48,6 +48,23 @@ func TestServiceDerivesStatusFromSessionFactsAndPR(t *testing.T) {
 	}{
 		{"terminated", statusRec(domain.ActivityExited, true), nil, false, domain.StatusTerminated},
 		{"merged-pr", statusRec(domain.ActivityIdle, true), statusPR(domain.PRFacts{Merged: true}), false, domain.StatusMerged},
+		// A terminated session whose only PR is merged still reports merged: no
+		// open PR remains, so the merged short-circuit applies as before.
+		{"terminated-only-pr-merged", statusRec(domain.ActivityExited, true), statusPR(domain.PRFacts{Merged: true}), false, domain.StatusMerged},
+		// A terminated session that still owns an open PR (e.g. a stack where only
+		// the bottom PR merged) did not complete: the merged short-circuit must not
+		// fire while an open PR remains, matching the invariant that merged only
+		// wins once no open PR is left.
+		{
+			"terminated-with-open-pr-stays-terminated",
+			statusRec(domain.ActivityExited, true),
+			[]domain.PRFacts{{URL: "a", Merged: true}, {URL: "b", SourceBranch: "ao/b", TargetBranch: "main"}},
+			false,
+			domain.StatusTerminated,
+		},
+		// A terminated session with no PRs at all stays terminated (sanity: the
+		// no-PR case must not regress).
+		{"terminated-no-prs", statusRec(domain.ActivityExited, true), nil, false, domain.StatusTerminated},
 		{"needs-input", statusRec(domain.ActivityWaitingInput, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusNeedsInput},
 		{"needs-input-blocked", statusRec(domain.ActivityBlocked, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusNeedsInput},
 		{"exited", statusRec(domain.ActivityExited, false), statusPR(domain.PRFacts{Mergeability: domain.MergeMergeable}), false, domain.StatusExited},


### PR DESCRIPTION
### Root cause

`deriveStatus` in `backend/internal/service/session/status.go` has a terminated branch that reports `StatusMerged` whenever *any* of the session's PRs is merged:

```go
if rec.IsTerminated {
    if anyMerged(prs) {
        return domain.StatusMerged
    }
    return domain.StatusTerminated
}
```

The function's own doc comment states the invariant: "Merged/closed PRs only matter once no open PR remains." The non-terminated branch already enforces this correctly (via `deriveSCMStatus`, which computes `open := openPRs(prs)` and only falls back to `anyMerged` once `len(open) == 0`). The terminated branch skips that gate, so the two branches disagree.

Concretely: a session owning a stacked PR pair (PR A merges, PR B is still open) that gets killed while B is open reports as cleanly `merged`, hiding the abandoned open PR B from the dashboard. The same happens with two independent PRs where one merges and the session is killed with the other still open.

### Fix

Gate the terminated branch's merged short-circuit on there being no open PR remaining, mirroring the non-terminated branch:

```go
if rec.IsTerminated {
    if len(openPRs(prs)) == 0 && anyMerged(prs) {
        return domain.StatusMerged
    }
    return domain.StatusTerminated
}
```

Existing behavior is preserved: a terminated session whose only PR is merged still reports `merged`. Only the `merged + open` combination changes, from `merged` to `terminated`.

### Tests

Added three cases to `TestServiceDerivesStatusFromSessionFactsAndPR` in `status_test.go`:

- `terminated-only-pr-merged`: terminated, single merged PR, no open PR -> `StatusMerged` (regression guard on existing behavior).
- `terminated-with-open-pr-stays-terminated`: terminated, one merged PR plus one still-open PR (the stacked-PR repro) -> `StatusTerminated`, not `StatusMerged`.
- `terminated-no-prs`: terminated, no PRs at all -> `StatusTerminated` (sanity, must not regress).

### Verification

- Confirmed the bug against current `main`: reverted just the one-line fix (via a standalone patch, reapplied after) and reran the new test case, which failed with `got "merged" want "terminated"`; the other new cases still passed. Reapplied the fix and reran: all pass.
- `cd backend && go build ./...` and `go vet ./...`: clean.
- `cd backend && go test ./internal/service/session/...`: all tests pass, including the full existing suite (no regressions).
- `cd backend && go test ./...`: only unrelated, pre-existing failures in `internal/session_manager` (Windows path-separator/PATH-construction test expectations), confirmed to fail identically with the fix reverted, so unrelated to this change.

Addresses #2390.