### PR TITLE
Fix: resolve git binary via PATH with install-location fallback (Windows spawn git ENOENT)

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/git_binary.go
+++ b/backend/internal/adapters/workspace/gitworktree/git_binary.go
@@ -1,0 +1,115 @@
+package gitworktree
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// ErrGitBinaryNotFound is returned when the default "git" binary cannot be
+// located on PATH or in any well-known Git install location. Naming the
+// problem here means callers see "git executable not found" instead of a raw,
+// confusing os/exec ENOENT.
+var ErrGitBinaryNotFound = errors.New("gitworktree: git executable not found")
+
+// gitPathLookup abstracts exec.LookPath so tests can force a PATH miss
+// without mutating the process's real PATH.
+type gitPathLookup func(name string) (string, error)
+
+// gitPathExists abstracts checking whether a fallback candidate path names a
+// usable file, so fallback-location tests don't depend on a real Git install
+// living at that path on the machine running the tests. It mirrors the
+// commandRunner field above: an injectable seam over an OS call so tests
+// don't have to hit the real filesystem/environment to exercise this path.
+type gitPathExists func(path string) bool
+
+// resolveGitBinary finds the git executable New should use when the caller
+// does not supply an explicit Options.Binary override: PATH first (so the
+// common case, where git is reachable, behaves exactly as before), then a
+// platform's well-known Git install locations if PATH lookup fails.
+//
+// This mirrors the pre-rewrite TypeScript getGitExecutable() helper
+// (@aoagents/ao-core, since removed with the rest of that package) that this
+// Go port dropped when the codebase was rewritten: search PATH, fall back to
+// common install locations, and produce a clear error naming the real problem
+// if nothing is found. Go's os/exec resolves a bare "git" against PATH lazily
+// at spawn time with no such fallback, so a process launched with a degraded
+// PATH (e.g. a GUI app on Windows that doesn't inherit a shell profile) fails
+// every git invocation with a bare ENOENT until this resolves once up front.
+//
+// The result is resolved once, in New, and stored on the Workspace as
+// w.binary, which every command in this package already reuses for its whole
+// lifetime — that per-instance reuse is the caching the TS helper did
+// explicitly with its own memoized cache.
+func resolveGitBinary(lookPath gitPathLookup, exists gitPathExists) (string, error) {
+	if path, err := lookPath(defaultGitBinary); err == nil && path != "" {
+		return path, nil
+	}
+	candidates := gitFallbackCandidates()
+	for _, candidate := range candidates {
+		if candidate != "" && exists(candidate) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"%w: not on PATH and not found in %d well-known install location(s); install Git and ensure it is on PATH, or pass an explicit binary path",
+		ErrGitBinaryNotFound, len(candidates),
+	)
+}
+
+// gitFallbackCandidates lists common Git install locations to probe, in
+// order, for the current OS. A base directory that is unavailable (e.g. an
+// unset Windows env var) simply contributes no candidates rather than
+// erroring, so resolveGitBinary always has a well-defined (possibly empty)
+// list to walk.
+func gitFallbackCandidates() []string {
+	switch runtime.GOOS {
+	case "windows":
+		return windowsGitCandidates(os.Getenv("ProgramFiles"), os.Getenv("ProgramFiles(x86)"), os.Getenv("LocalAppData"))
+	case "darwin":
+		return []string{
+			"/opt/homebrew/bin/git", // Homebrew on Apple Silicon
+			"/usr/local/bin/git",    // Homebrew on Intel, and the pre-Homebrew default prefix
+			"/usr/bin/git",          // Xcode Command Line Tools
+		}
+	default:
+		return []string{
+			"/usr/bin/git",       // standard distro package location
+			"/usr/local/bin/git", // locally-built or manually-installed git
+			"/bin/git",
+		}
+	}
+}
+
+// windowsGitCandidates returns the well-known locations Git for Windows
+// installs to: the official 64- and 32-bit installer's Program Files paths,
+// and the per-user installer's location under %LocalAppData%\Programs. Each
+// base is passed in explicitly (rather than read here) so this stays a pure,
+// directly testable function; gitFallbackCandidates supplies the real
+// environment values. A blank base (the env var was unset) contributes no
+// candidates.
+func windowsGitCandidates(programFiles, programFilesX86, localAppData string) []string {
+	var out []string
+	for _, base := range []string{programFiles, programFilesX86} {
+		if base == "" {
+			continue
+		}
+		out = append(out,
+			filepath.Join(base, "Git", "cmd", "git.exe"),
+			filepath.Join(base, "Git", "bin", "git.exe"),
+		)
+	}
+	if localAppData != "" {
+		out = append(out, filepath.Join(localAppData, "Programs", "Git", "cmd", "git.exe"))
+	}
+	return out
+}
+
+// isRegularFile reports whether path names an existing, non-directory file.
+// It is the real gitPathExists New uses outside tests.
+func isRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/backend/internal/adapters/workspace/gitworktree/git_binary_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/git_binary_test.go
@@ -1,0 +1,174 @@
+package gitworktree
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestResolveGitBinaryPrefersPath confirms the common case is unchanged:
+// when git is genuinely resolvable via PATH, resolveGitBinary returns that
+// path directly and never consults the fallback candidate list.
+func TestResolveGitBinaryPrefersPath(t *testing.T) {
+	want := filepath.Join("fake", "path", "to", "git")
+	lookPath := func(name string) (string, error) {
+		if name != defaultGitBinary {
+			t.Fatalf("lookPath called with %q, want %q", name, defaultGitBinary)
+		}
+		return want, nil
+	}
+	exists := func(path string) bool {
+		t.Fatalf("fallback exists(%q) should not be consulted when PATH lookup succeeds", path)
+		return false
+	}
+
+	got, err := resolveGitBinary(lookPath, exists)
+	if err != nil {
+		t.Fatalf("resolveGitBinary: %v", err)
+	}
+	if got != want {
+		t.Fatalf("resolveGitBinary() = %q, want %q", got, want)
+	}
+}
+
+// TestResolveGitBinaryFallsBackWhenPathMisses is the regression test for
+// issue #1777: a PATH lookup failure (the ENOENT trigger — a degraded PATH
+// that doesn't include git's directory) must not be fatal as long as git
+// lives in one of this platform's well-known install locations. lookPath is
+// mocked to fail exactly like a real PATH miss; exists is mocked so only the
+// platform's last candidate "exists", proving earlier misses are walked past
+// rather than the first candidate being blindly trusted.
+func TestResolveGitBinaryFallsBackWhenPathMisses(t *testing.T) {
+	candidates := gitFallbackCandidates()
+	if len(candidates) == 0 {
+		t.Skipf("no known fallback candidates for GOOS %q", runtime.GOOS)
+	}
+	want := candidates[len(candidates)-1]
+
+	lookPath := func(string) (string, error) { return "", exec.ErrNotFound }
+	exists := func(path string) bool { return path == want }
+
+	got, err := resolveGitBinary(lookPath, exists)
+	if err != nil {
+		t.Fatalf("resolveGitBinary: %v", err)
+	}
+	if got != want {
+		t.Fatalf("resolveGitBinary() = %q, want %q", got, want)
+	}
+}
+
+// TestResolveGitBinaryNotFoundNamesTheProblem confirms that when neither PATH
+// nor any fallback location has git, the error clearly names the real
+// problem (git missing) instead of leaking a bare, confusing ENOENT.
+func TestResolveGitBinaryNotFoundNamesTheProblem(t *testing.T) {
+	lookPath := func(string) (string, error) { return "", exec.ErrNotFound }
+	exists := func(string) bool { return false }
+
+	_, err := resolveGitBinary(lookPath, exists)
+	if !errors.Is(err, ErrGitBinaryNotFound) {
+		t.Fatalf("resolveGitBinary() err = %v, want ErrGitBinaryNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "git executable not found") {
+		t.Fatalf("resolveGitBinary() err = %q, want a message naming the missing git executable", err.Error())
+	}
+}
+
+// TestWindowsGitCandidatesOrderAndContent locks in the well-known Windows
+// install locations and their order: both Program Files bases before the
+// per-user LocalAppData install, cmd before bin within each base (matching
+// how Git for Windows itself orders PATH entries).
+func TestWindowsGitCandidatesOrderAndContent(t *testing.T) {
+	got := windowsGitCandidates(`C:\Program Files`, `C:\Program Files (x86)`, `C:\Users\tester\AppData\Local`)
+	want := []string{
+		filepath.Join(`C:\Program Files`, "Git", "cmd", "git.exe"),
+		filepath.Join(`C:\Program Files`, "Git", "bin", "git.exe"),
+		filepath.Join(`C:\Program Files (x86)`, "Git", "cmd", "git.exe"),
+		filepath.Join(`C:\Program Files (x86)`, "Git", "bin", "git.exe"),
+		filepath.Join(`C:\Users\tester\AppData\Local`, "Programs", "Git", "cmd", "git.exe"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("windowsGitCandidates() = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestWindowsGitCandidatesSkipsUnsetBases confirms an unavailable base (an
+// unset env var, surfaced as "") contributes no candidates instead of
+// producing a malformed path.
+func TestWindowsGitCandidatesSkipsUnsetBases(t *testing.T) {
+	if got := windowsGitCandidates("", "", ""); len(got) != 0 {
+		t.Fatalf("windowsGitCandidates(\"\",\"\",\"\") = %#v, want empty", got)
+	}
+	got := windowsGitCandidates("", "", `C:\Users\tester\AppData\Local`)
+	want := []string{filepath.Join(`C:\Users\tester\AppData\Local`, "Programs", "Git", "cmd", "git.exe")}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("windowsGitCandidates with only localAppData set = %#v, want %#v", got, want)
+	}
+}
+
+// TestNewResolvesDefaultBinaryFromPATH confirms New's real wiring (not just
+// resolveGitBinary in isolation) still resolves git via PATH in the ordinary
+// case, where git is genuinely on PATH — true throughout this repo's own
+// dev/CI environment.
+func TestNewResolvesDefaultBinaryFromPATH(t *testing.T) {
+	requireGit(t)
+	resolved, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("exec.LookPath(git): %v", err)
+	}
+
+	ws, err := New(Options{ManagedRoot: t.TempDir(), RepoResolver: StaticRepoResolver{"proj": "unused"}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if ws.binary != resolved {
+		t.Fatalf("ws.binary = %q, want %q", ws.binary, resolved)
+	}
+}
+
+// TestNewHonorsExplicitBinaryOverride confirms Options.Binary remains an
+// escape hatch that bypasses resolution entirely — load-bearing for tests
+// and callers that already know the exact binary to use.
+func TestNewHonorsExplicitBinaryOverride(t *testing.T) {
+	ws, err := New(Options{
+		Binary:       "custom-git-that-is-not-on-path",
+		ManagedRoot:  t.TempDir(),
+		RepoResolver: StaticRepoResolver{"proj": "unused"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if ws.binary != "custom-git-that-is-not-on-path" {
+		t.Fatalf("ws.binary = %q, want explicit override preserved verbatim", ws.binary)
+	}
+}
+
+// TestNewSurfacesClearErrorWhenGitUnresolvable drives New's real resolution
+// path (exec.LookPath + isRegularFile) end to end into a total miss, by
+// forcing PATH and every Windows fallback base to directories that do not
+// contain git. This is the scenario the original bug report describes: a
+// process whose inherited PATH does not include git's directory. Windows-only
+// because the fallback candidates on darwin/linux are fixed absolute system
+// paths (not env-driven) that this test cannot safely redirect away from a
+// real install on a CI machine that has one.
+func TestNewSurfacesClearErrorWhenGitUnresolvable(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("fallback candidates on this GOOS are fixed system paths, not env-driven")
+	}
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("ProgramFiles", t.TempDir())
+	t.Setenv("ProgramFiles(x86)", t.TempDir())
+	t.Setenv("LocalAppData", t.TempDir())
+
+	_, err := New(Options{ManagedRoot: t.TempDir(), RepoResolver: StaticRepoResolver{"proj": "unused"}})
+	if !errors.Is(err, ErrGitBinaryNotFound) {
+		t.Fatalf("New() err = %v, want ErrGitBinaryNotFound", err)
+	}
+}

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -16,6 +16,12 @@ import (
 )
 
 const (
+	// defaultGitBinary is the PATH name New looks up via resolveGitBinary when
+	// Options.Binary is not set. It is never used as a bare, unresolved
+	// argv[0]: New always resolves it (or a fallback install location) to a
+	// concrete path first, so every exec in this package still spawns
+	// correctly even when the process's inherited PATH does not include git's
+	// directory (see git_binary.go).
 	defaultGitBinary = "git"
 	// defaultBranch is the base branch used when neither the per-project config
 	// nor the adapter options name one. It shares domain's single source of truth.
@@ -94,7 +100,11 @@ var _ ports.WorkspaceProject = (*Workspace)(nil)
 func New(opts Options) (*Workspace, error) {
 	binary := opts.Binary
 	if binary == "" {
-		binary = defaultGitBinary
+		resolved, err := resolveGitBinary(exec.LookPath, isRegularFile)
+		if err != nil {
+			return nil, err
+		}
+		binary = resolved
 	}
 	branch := opts.DefaultBranch
 	if branch == "" {


### PR DESCRIPTION
## Problem

`gitworktree.New` defaults `opts.Binary` to the bare string `"git"` whenever a caller does not set an explicit `Binary` override. The daemon's own wiring (`backend/internal/daemon/lifecycle_wiring.go`, the `gitworktree.New(gitworktree.Options{...})` call site) does not set `Binary:`, so production always takes this default. That bare string is passed straight into `os/exec` at every git invocation in the package (`w.run(ctx, w.binary, ...)`), relying on the process's inherited PATH to resolve it lazily at spawn time, with no fallback.

On a Windows process whose inherited PATH does not include git's directory (a real, documented scenario for GUI-launched apps with a degraded PATH), every git call fails with a raw `ENOENT` instead of a clear "git not found" error.

## This is a reintroduced regression

This exact defect was already fixed once, pre-rewrite, in the now-deleted `@aoagents/ao-core` TypeScript package via `getGitExecutable()` (PR #1776): search PATH first, fall back to common Git install locations per OS, cache the result, and produce a clear error if nothing is found. That fix did not carry over when this repository was rewritten in Go, so the same bug is present again in the current code.

## Fix

Added `resolveGitBinary` in a new `backend/internal/adapters/workspace/gitworktree/git_binary.go`:

- Searches PATH via `exec.LookPath` first, so the common case (git reachable on PATH) is completely unchanged.
- Falls back, in order, to Git's well-known install locations if PATH lookup fails: Windows (`%ProgramFiles%/Git/cmd` and `/bin`, `%ProgramFiles(x86)%/Git/cmd` and `/bin`, `%LocalAppData%/Programs/Git/cmd`), macOS (Homebrew Apple Silicon/Intel paths, Xcode Command Line Tools), and Linux (standard system paths).
- Returns a clear `ErrGitBinaryNotFound`-wrapped error naming the actual problem (git missing / unreachable) instead of a raw `ENOENT` if nothing resolves.

`New` now calls this once at construction (only when `opts.Binary == ""`) and stores the resolved absolute path on the `Workspace`, so every command in the package reuses one resolved binary for its whole lifetime -- the same caching effect the old TS helper achieved explicitly. `opts.Binary` remains an unconditional override that bypasses resolution entirely, so existing callers/tests that already pass an explicit binary path are unaffected.

The PATH-lookup and fallback-existence checks are both injected (`gitPathLookup`/`gitPathExists`), following the same DI pattern this file already uses for `commandRunner`, so the fallback branch is unit-testable without depending on the real PATH or a real Git install at any specific location on the test machine.

I looked at `binaryutil.ResolveBinary` (`backend/internal/adapters/agent/binaryutil`), which already implements a similar PATH-then-fallback-locations pattern for agent CLIs, before writing this. I did not reuse it directly for two reasons: its `WinBase` candidate model only covers `%APPDATA%`/`%LOCALAPPDATA%`/home-relative paths and has no way to express `%ProgramFiles%`, which is where Git for Windows actually installs by default, so it would not have covered the primary real-world fallback case; and its not-found error wraps `ports.ErrAgentBinaryNotFound` ("agent: binary not found on PATH"), which is pattern-matched elsewhere in the codebase specifically to mean an AI agent CLI is missing -- reusing it for git would produce a misleading message and risk being caught by that agent-specific handling. The resolver added here mirrors `binaryutil`'s overall shape (PATH first, then ordered platform candidates) without those two mismatches.

## Verification

- Confirmed the bug against current code by reading `workspace.go`'s `New()`/`defaultGitBinary` and the `lifecycle_wiring.go` call site (no `Binary:` override), and confirming `aoprocess.CommandContext` is a thin `exec.CommandContext` wrapper with no PATH fallback of its own.
- Added tests in `git_binary_test.go` covering: PATH-preferred resolution (and that the fallback checker is never even consulted when PATH succeeds), fallback-location resolution when PATH lookup is mocked to fail, a clear not-found error naming the problem, the Windows candidate list's order/content and its skipping of unset env bases, `New()`'s end-to-end PATH resolution (git is genuinely on PATH in this environment), the `opts.Binary` override escape hatch, and (Windows-only) `New()`'s end-to-end total-miss error path with PATH and every Windows fallback base env var pointed at empty directories.
- Proved the fix matters via a patch-based fail/pass cycle (not `git stash`): reverse-applied the implementation patch (removing `git_binary.go` and the `New()` wiring change) while keeping the new test file, confirmed `go test` failed to even build (`undefined: resolveGitBinary`, `undefined: ErrGitBinaryNotFound`, etc. -- i.e. there is no fallback to fail into on the old code), then reapplied the patch and confirmed every new test passes.
- `go build ./...` and `go vet ./...` are clean from `backend`.
- Full `gitworktree` package test suite passes, including the pre-existing real-git integration tests (`TestWorkspaceIntegrationCreateRestoreDestroy` and friends, which shell out to actual git) -- confirming normal git worktree operations still work end-to-end with the resolver in the loop.

Addresses #1777.