### PR TITLE
fix(lifecycle): make merge-conflict nudges reach needs-input sessions and re-fire after a conflict returns

### DIFF
--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -63,6 +63,7 @@ func startLifecycle(ctx context.Context, store *sqlite.Store, runtime ports.Runt
 		lifecycle.WithContainerReaper(dockerreap.New(), store),
 		lifecycle.WithActiveSteering(activeTurnSteering(agents)),
 		lifecycle.WithStartupSignalGate(startupSignalGatesInput(agents)),
+		lifecycle.WithUrgentNudgeGate(urgentNudgeWaitingInputSafe(agents)),
 	)
 	rp := reaper.New(lcm, store, runtime, reaper.Config{Logger: logger})
 	activityPoller := activityobserver.New(store, lcm, runtime, agents, activityobserver.Config{Logger: logger})
@@ -88,6 +89,27 @@ func startupSignalGatesInput(agents ports.AgentResolver) func(domain.AgentHarnes
 		}
 		signaler, ok := agent.(ports.StartupInputReadinessSignaler)
 		return ok && signaler.FirstSignalProvesInputReady()
+	}
+}
+
+// urgentNudgeWaitingInputSafe resolves whether an adapter reports a permission
+// dialog AS blocked (ports.BlockedActivitySignaler) rather than as
+// waiting_input. Only then is an urgent merge-conflict nudge safe to paste at a
+// waiting_input prompt — a harness like codex, which maps permission-request to
+// waiting_input and opts out of the signal, must not receive that unsolicited
+// write while it could be sitting on a masked decision. Unknown and opted-out
+// adapters answer false, so lifecycle withholds the urgent nudge there.
+func urgentNudgeWaitingInputSafe(agents ports.AgentResolver) func(domain.AgentHarness) bool {
+	return func(harness domain.AgentHarness) bool {
+		if agents == nil {
+			return false
+		}
+		agent, ok := agents.Agent(harness)
+		if !ok {
+			return false
+		}
+		signaler, ok := agent.(ports.BlockedActivitySignaler)
+		return ok && signaler.EmitsBlockedActivity()
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -610,6 +611,97 @@ func TestWiring_StartLifecycleThreadsMessengerIntoLCM(t *testing.T) {
 	}
 	if messenger.msgs[0].id != rec.ID {
 		t.Fatalf("nudge sent to %q, want %q", messenger.msgs[0].id, rec.ID)
+	}
+}
+
+// TestWiring_MergeConflictNudgeReArmsAfterConflictClears is the end-to-end
+// counterpart to the lifecycle unit tests for #4528, over the real sqlite store
+// the daemon runs on: it drives the SCM observer's entrypoint
+// (ApplySCMObservation) through the full mergeable → conflicting → mergeable →
+// conflicting cycle and asserts the second conflict notifies again. The
+// dedup signature is persisted in pr.last_nudge_signature, so a fake store
+// cannot prove the round trip actually survives the real column.
+func TestWiring_MergeConflictNudgeReArmsAfterConflictClears(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store, err := sqlitetest.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "p", Path: "/repo/p", RegisteredAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	rec, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: "p",
+		Kind:      domain.KindWorker,
+		Activity:  domain.Activity{State: domain.ActivityIdle, LastActivityAt: time.Now()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const prURL = "https://github.com/o/r/pull/1"
+	if err := store.WriteSCMObservation(ctx, domain.PullRequest{
+		URL:       prURL,
+		SessionID: rec.ID,
+		Number:    1,
+		UpdatedAt: time.Now(),
+	}, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatalf("persist PR before lifecycle: %v", err)
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	messenger := &captureMessenger{}
+	stack := startLifecycle(ctx, store, tmux.New(tmux.Options{}), messenger, nil, nil, nil, log)
+	t.Cleanup(stack.Stop)
+	t.Cleanup(cancel)
+
+	observe := func(state domain.Mergeability) {
+		t.Helper()
+		if err := stack.LCM.ApplySCMObservation(ctx, rec.ID, ports.SCMObservation{
+			Fetched:      true,
+			PR:           ports.SCMPRObservation{URL: prURL, Number: 1},
+			Mergeability: ports.SCMMergeabilityObservation{State: string(state), Conflict: state == domain.MergeConflicting},
+		}); err != nil {
+			t.Fatalf("ApplySCMObservation(%s): %v", state, err)
+		}
+	}
+
+	observe(domain.MergeMergeable)
+	observe(domain.MergeConflicting)
+	if len(messenger.msgs) != 1 {
+		t.Fatalf("first conflict should nudge once, got %d: %v", len(messenger.msgs), messenger.msgs)
+	}
+	observe(domain.MergeConflicting)
+	if len(messenger.msgs) != 1 {
+		t.Fatalf("an unchanged conflict must stay deduplicated, got %d: %v", len(messenger.msgs), messenger.msgs)
+	}
+	observe(domain.MergeMergeable)
+	observe(domain.MergeConflicting)
+	if len(messenger.msgs) != 2 {
+		t.Fatalf("a conflict returning after the PR went mergeable should nudge again, got %d: %v", len(messenger.msgs), messenger.msgs)
+	}
+	if messenger.msgs[1].id != rec.ID || !strings.Contains(messenger.msgs[1].msg, "merge conflicts") {
+		t.Fatalf("second nudge is not the merge-conflict nudge for this session: %+v", messenger.msgs[1])
+	}
+
+	// A daemon restart rebuilds the lifecycle manager with empty in-memory dedup
+	// maps, so only pr.last_nudge_signature carries the state forward. A bare
+	// lifecycle.New over the same store is that rebuild without the background
+	// observers a second startLifecycle would leave running. The still-unresolved
+	// conflict must stay quiet across that boundary.
+	restarted := &captureMessenger{}
+	restartedLCM := lifecycle.New(store, restarted)
+	if err := restartedLCM.ApplySCMObservation(ctx, rec.ID, ports.SCMObservation{
+		Fetched:      true,
+		PR:           ports.SCMPRObservation{URL: prURL, Number: 1},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeConflicting), Conflict: true},
+	}); err != nil {
+		t.Fatalf("ApplySCMObservation after restart: %v", err)
+	}
+	if len(restarted.msgs) != 0 {
+		t.Fatalf("restart replayed an already-delivered conflict nudge: %v", restarted.msgs)
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -192,6 +192,43 @@ func TestWiring_StartupSignalGateComesFromAdapters(t *testing.T) {
 	}
 }
 
+// TestWiring_UrgentNudgeGateComesFromAdapters asserts the urgent merge-conflict
+// nudge is fail-closed at a waiting_input prompt: it is only safe on a harness
+// that reports a permission dialog AS blocked (ports.BlockedActivitySignaler),
+// so a waiting_input prompt there is a genuine idle composer rather than a
+// masked permission decision. Codex, Droid, and the shared-hook harnesses all
+// fold permission prompts into waiting_input and must stay suppressed; only
+// blocked-signalling adapters (claude-code, kimchi) open the boundary.
+func TestWiring_UrgentNudgeGateComesFromAdapters(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	agents, err := buildAgentResolver(config.DefaultAgent, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	safe := urgentNudgeWaitingInputSafe(agents)
+
+	for _, harness := range []domain.AgentHarness{domain.HarnessClaudeCode, domain.HarnessKimchi} {
+		if !safe(harness) {
+			t.Errorf("harness %q reports permission dialogs as blocked; urgent nudge must be allowed at waiting_input", harness)
+		}
+	}
+	// Codex maps permission-request to waiting_input; Droid folds both permission
+	// decisions and idle notifications into waiting_input; Goose/Devin ride the
+	// shared name-only StandardDeriveActivityState with no blocked signal. All
+	// must keep urgent delivery suppressed at a waiting_input prompt.
+	for _, harness := range []domain.AgentHarness{
+		domain.HarnessCodex, domain.HarnessDroid, domain.HarnessGoose, domain.HarnessDevin,
+		"definitely-not-an-agent", "",
+	} {
+		if safe(harness) {
+			t.Errorf("harness %q cannot distinguish a masked permission prompt from an idle composer; urgent nudge must stay fail-closed", harness)
+		}
+	}
+	if urgentNudgeWaitingInputSafe(nil)(domain.HarnessClaudeCode) {
+		t.Error("a nil resolver must fail closed, not open the waiting_input boundary")
+	}
+}
+
 // TestWiring_StartSessionBuildsSessionService asserts the daemon's startSession
 // constructs a real controller-facing session service end to end (resolver +
 // gitworktree workspace + session manager over the shared store/LCM), which is

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -182,6 +182,20 @@ func WithStartupSignalGate(pred func(domain.AgentHarness) bool) Option {
 	}
 }
 
+// WithUrgentNudgeGate supplies the adapter capability predicate that decides
+// whether an urgent (merge-conflict) nudge may reach a session at a
+// waiting_input prompt: true only for harnesses that report a permission dialog
+// as blocked rather than as waiting_input. Without it the reducer treats every
+// waiting_input prompt as a possible masked decision and withholds the urgent
+// nudge until the session is active or idle.
+func WithUrgentNudgeGate(pred func(domain.AgentHarness) bool) Option {
+	return func(m *Manager) {
+		if pred != nil {
+			m.urgentNudgeWaitingInputSafe = pred
+		}
+	}
+}
+
 // Manager reduces runtime, activity, spawn, and termination observations into durable session facts.
 // It also owns agent nudges caused by PR observations, including merge-conflict, CI-failure, and review-feedback prompts.
 type Manager struct {
@@ -224,6 +238,12 @@ type Manager struct {
 	// unknown harness is only written to while idle.
 	steerActive             func(domain.AgentHarness) bool
 	startupSignalGatesInput func(domain.AgentHarness) bool
+	// urgentNudgeWaitingInputSafe reports whether a harness surfaces a permission
+	// dialog AS blocked (rather than as waiting_input), so an urgent merge-conflict
+	// nudge is safe to paste at a waiting_input prompt. Supplied by the agent
+	// adapter via WithUrgentNudgeGate; the default answers false, so an unknown
+	// harness never takes an urgent write while waiting_input.
+	urgentNudgeWaitingInputSafe func(domain.AgentHarness) bool
 }
 
 // New builds a Lifecycle Manager over the session store it writes and the messenger it uses for agent nudges.
@@ -234,14 +254,15 @@ func New(store sessionStore, messenger ports.AgentMessenger, opts ...Option) *Ma
 	// WithClock option may still override this in tests.
 	clock := func() time.Time { return time.Now().UTC() }
 	m := &Manager{
-		store:                   store,
-		window:                  defaultRecentActivityWindow,
-		clock:                   clock,
-		react:                   newReactionState(),
-		flights:                 map[domain.SessionID]*toolFlight{},
-		pendingLaunches:         map[domain.SessionID]pendingLaunch{},
-		steerActive:             func(domain.AgentHarness) bool { return false },
-		startupSignalGatesInput: func(domain.AgentHarness) bool { return false },
+		store:                       store,
+		window:                      defaultRecentActivityWindow,
+		clock:                       clock,
+		react:                       newReactionState(),
+		flights:                     map[domain.SessionID]*toolFlight{},
+		pendingLaunches:             map[domain.SessionID]pendingLaunch{},
+		steerActive:                 func(domain.AgentHarness) bool { return false },
+		startupSignalGatesInput:     func(domain.AgentHarness) bool { return false },
+		urgentNudgeWaitingInputSafe: func(domain.AgentHarness) bool { return false },
 	}
 	if messenger != nil {
 		m.guard = sessionguard.New(store, messenger, nil)

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -387,10 +387,10 @@ func (f *fakeMessenger) Send(_ context.Context, id domain.SessionID, msg string)
 	return nil
 }
 
-func newManager() (*Manager, *fakeStore, *fakeMessenger) {
+func newManager(opts ...Option) (*Manager, *fakeStore, *fakeMessenger) {
 	st := newFakeStore()
 	msg := &fakeMessenger{}
-	return New(st, msg), st, msg
+	return New(st, msg, opts...), st, msg
 }
 
 func working(id domain.SessionID) domain.SessionRecord {
@@ -2429,29 +2429,119 @@ func TestPRObservation_ExitedAgentIsNotNudged(t *testing.T) {
 	}
 }
 
+// TestPRObservation_ReArmClearsConflictWhileSessionExited is the regression
+// test for the delivery-gate finding: a definitively-cleared observation must
+// re-arm the merge-conflict dedup even when it arrives while the session is
+// exited. Exited sessions are still polled, so the sequence
+// conflicting -> exit -> mergeable -> restore -> conflicting must nudge on the
+// final conflict; a re-arm placed behind the dead-session return would skip the
+// clear and let the stale "conflicting" signature swallow the recurrence.
+func TestPRObservation_ReArmClearsConflictWhileSessionExited(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	conflicting := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}
+	mergeable := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeMergeable}
+
+	if err := m.ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("first conflict should nudge, got %v", msg.msgs)
+	}
+
+	// The agent exits, then the PR is observed mergeable while exited. No nudge
+	// is delivered (nowhere to write), but the re-arm bookkeeping must still run.
+	exited := working("mer-1")
+	exited.Activity.State = domain.ActivityExited
+	st.sessions["mer-1"] = exited
+	if err := m.ApplyPRObservation(ctx, "mer-1", mergeable); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("mergeable-while-exited must deliver nothing, got %v", msg.msgs)
+	}
+
+	// The agent is restored and the base advances into a fresh conflict. The
+	// re-arm during the exited window must let this recurrence nudge again.
+	st.sessions["mer-1"] = working("mer-1")
+	if err := m.ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 2 {
+		t.Fatalf("a conflict returning after a clear-while-exited must nudge again, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+}
+
+// TestPRObservation_ReArmClearsConflictSurvivesTerminatedRestore covers the
+// terminated variant of the same hazard: a terminated session is excluded from
+// polling, so the clear typically arrives on the first observation after
+// restore. The re-arm still runs ahead of the dead-session return, so even a
+// clear observed in the terminated window (before restore is reflected) drops
+// the stale signature and a later conflict nudges again.
+func TestPRObservation_ReArmClearsConflictSurvivesTerminatedRestore(t *testing.T) {
+	conflicting := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}
+	mergeable := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeMergeable}
+
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	if err := m.ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+		t.Fatal(err)
+	}
+
+	// Session terminates; a mergeable observation lands before restore. It must
+	// re-arm despite the terminated gate returning before any delivery.
+	terminated := working("mer-1")
+	terminated.IsTerminated = true
+	st.sessions["mer-1"] = terminated
+	if err := m.ApplyPRObservation(ctx, "mer-1", mergeable); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("mergeable-while-terminated must deliver nothing, got %v", msg.msgs)
+	}
+
+	// Restored, then a fresh conflict: the re-arm during the terminated window
+	// must let it nudge again rather than dedup against the stale signature.
+	st.sessions["mer-1"] = working("mer-1")
+	if err := m.ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 2 {
+		t.Fatalf("a conflict after a clear-while-terminated must nudge again, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+}
+
 // TestPRObservation_MergeConflictReachesNeedsInputSession is the regression
 // test for #2173: a session parked awaiting the human (waiting_input) must
 // still receive a merge-conflict nudge, because the human sitting at that
 // prompt may be exactly who needs to act (rebase it themselves, or redirect
 // the agent) — unlike CI-failure/review-feedback nudges, which only the agent
 // can act on and which correctly wait for it to resume (see the sibling test
-// below). A session blocked on a live permission dialog is a different,
-// narrower hazard (an unsolicited paste there risks answering the dialog) and
-// must still be refused.
+// below). Two states are still refused: a session blocked on a live permission
+// dialog, and a waiting_input session on a harness that cannot prove that
+// prompt is a genuine idle composer rather than a masked permission decision
+// (codex maps permission-request to waiting_input) — the harness-aware gate the
+// urgent route consults, so an unsolicited paste never answers a hidden dialog.
 func TestPRObservation_MergeConflictReachesNeedsInputSession(t *testing.T) {
+	const safeHarness = domain.AgentHarness("claude-code")
+	const ambiguousHarness = domain.AgentHarness("codex")
+	urgentGate := func(h domain.AgentHarness) bool { return h == safeHarness }
 	cases := []struct {
 		name      string
 		state     domain.ActivityState
+		harness   domain.AgentHarness
 		wantNudge bool
 	}{
-		{"waiting_input reaches the agent", domain.ActivityWaitingInput, true},
-		{"blocked stays suppressed", domain.ActivityBlocked, false},
+		{"waiting_input on a blocked-signalling harness reaches the agent", domain.ActivityWaitingInput, safeHarness, true},
+		{"waiting_input on an ambiguous harness stays suppressed", domain.ActivityWaitingInput, ambiguousHarness, false},
+		{"blocked stays suppressed", domain.ActivityBlocked, safeHarness, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m, st, msg := newManager()
+			m, st, msg := newManager(WithUrgentNudgeGate(urgentGate))
 			rec := working("mer-1")
 			rec.Activity.State = tc.state
+			rec.Harness = tc.harness
 			st.sessions["mer-1"] = rec
 
 			o := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -2325,6 +2325,70 @@ func TestPRObservation_ReArmSkipsStoreWriteWhenNothingArmed(t *testing.T) {
 	}
 }
 
+// TestPRObservation_ReArmRetriesAfterFailedPersist covers the failure ->
+// successful observation -> restart -> conflict path. The re-arm's in-memory
+// delete stands even when the durable write fails, so a naive implementation
+// would see nothing armed on the next mergeable observation, take the early
+// return, and never retry — leaving the stale "conflicting" signature on disk
+// to suppress the nudge after a restart, recreating #4528.
+func TestPRObservation_ReArmRetriesAfterFailedPersist(t *testing.T) {
+	conflicting := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}
+	mergeable := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeMergeable}
+
+	st := newFakeStore()
+	st.sessions["mer-1"] = working("mer-1")
+	m := New(st, &fakeMessenger{})
+	if err := m.ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+		t.Fatal(err)
+	}
+
+	st.signatureWriteErr = errors.New("db locked")
+	if err := m.ApplyPRObservation(ctx, "mer-1", mergeable); err == nil {
+		t.Fatal("a failed re-arm persist should surface to the observer")
+	}
+
+	// Persistence recovers. The next non-conflicting observation must retry the
+	// durable write rather than short-circuit on the now-empty in-memory maps.
+	st.signatureWriteErr = nil
+	if err := m.ApplyPRObservation(ctx, "mer-1", mergeable); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted := &fakeMessenger{}
+	if err := New(st, restarted).ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+		t.Fatal(err)
+	}
+	if len(restarted.msgs) != 1 {
+		t.Fatalf("a re-arm that retried its persist must survive a restart, got %v", restarted.msgs)
+	}
+}
+
+// TestPRObservation_ReArmStillNudgesInProcessAfterFailedPersist pins the other
+// half of the retry contract: the failed persist must not roll the in-memory
+// re-arm back, or a conflict returning before the write succeeds would be
+// deduplicated away inside the running daemon.
+func TestPRObservation_ReArmStillNudgesInProcessAfterFailedPersist(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	conflicting := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}
+	if err := m.ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+		t.Fatal(err)
+	}
+
+	st.signatureWriteErr = errors.New("db locked")
+	if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeMergeable}); err == nil {
+		t.Fatal("a failed re-arm persist should surface to the observer")
+	}
+	st.signatureWriteErr = nil
+
+	if err := m.ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 2 {
+		t.Fatalf("a conflict returning after a failed re-arm persist should still nudge, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+}
+
 // TestPRObservation_ReArmStoreFailureSurfacesWithoutLosingNudges checks the
 // deferred-error contract: a failed re-arm persist is reported, but only after
 // the independent CI nudge queued in the same observation has been sent.

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -2164,6 +2164,193 @@ func TestPRObservation_MergeConflictNudgesAgent(t *testing.T) {
 	}
 }
 
+// TestPRObservation_MergeConflictReArmsAfterConflictClears is the regression
+// test for #4528: AO notified on the first conflict but never again, because
+// the "merge-conflict:<url>" = "conflicting" signature sendOnce persists was
+// never cleared. A PR rebased clean and then made conflicting again by a
+// base-branch advance was silently swallowed as a duplicate.
+func TestPRObservation_MergeConflictReArmsAfterConflictClears(t *testing.T) {
+	// Every state that definitively rules a conflict out must re-arm; `blocked`
+	// is deliberately excluded because the observer synthesizes it from
+	// draft/CI/review facts even while provider mergeability is unknown.
+	for _, clear := range []domain.Mergeability{domain.MergeMergeable, domain.MergeUnstable} {
+		t.Run(string(clear), func(t *testing.T) {
+			m, st, msg := newManager()
+			st.sessions["mer-1"] = working("mer-1")
+			apply := func(state domain.Mergeability) {
+				t.Helper()
+				if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: state}); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			apply(clear)
+			apply(domain.MergeConflicting)
+			if len(msg.msgs) != 1 {
+				t.Fatalf("first conflict should nudge once, got %v", msg.msgs)
+			}
+			apply(clear)
+			apply(domain.MergeConflicting)
+			if len(msg.msgs) != 2 {
+				t.Fatalf("conflict returning after %s should nudge again, got %d nudges: %v", clear, len(msg.msgs), msg.msgs)
+			}
+		})
+	}
+}
+
+// TestPRObservation_ConsecutiveMergeConflictsStayDeduplicated pins the other
+// half of #4528: the re-arm must not weaken the dedup that stops an unchanged
+// conflict from re-nudging on every poll.
+func TestPRObservation_ConsecutiveMergeConflictsStayDeduplicated(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	for range 3 {
+		if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("identical consecutive conflicts should nudge once, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+}
+
+// TestPRObservation_UnknownMergeabilityDoesNotReArm keeps the re-arm off the
+// transient GitHub reports while it recomputes mergeability after a push or a
+// retarget. Treating unknown as "conflict resolved" would re-nudge on every
+// unknown → conflicting flap of a conflict that never went away.
+func TestPRObservation_UnknownMergeabilityDoesNotReArm(t *testing.T) {
+	for _, transient := range []domain.Mergeability{domain.MergeUnknown, domain.MergeBlocked, ""} {
+		t.Run(string(transient), func(t *testing.T) {
+			m, st, msg := newManager()
+			st.sessions["mer-1"] = working("mer-1")
+			for _, state := range []domain.Mergeability{domain.MergeConflicting, transient, domain.MergeConflicting} {
+				if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: state}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if len(msg.msgs) != 1 {
+				t.Fatalf("%q must not re-arm the conflict nudge, got %d nudges: %v", transient, len(msg.msgs), msg.msgs)
+			}
+		})
+	}
+}
+
+// TestPRObservation_MergeConflictDedupSurvivesRestart covers both persistence
+// directions of #4528 across a daemon restart, simulated by a fresh Manager
+// over the same store: an unchanged conflict must stay quiet, and a conflict
+// that cleared before the restart must be free to nudge again.
+func TestPRObservation_MergeConflictDedupSurvivesRestart(t *testing.T) {
+	conflicting := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}
+
+	t.Run("unchanged conflict stays deduplicated", func(t *testing.T) {
+		st := newFakeStore()
+		st.sessions["mer-1"] = working("mer-1")
+		first := New(st, &fakeMessenger{})
+		if err := first.ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+			t.Fatal(err)
+		}
+
+		restarted := &fakeMessenger{}
+		if err := New(st, restarted).ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+			t.Fatal(err)
+		}
+		if len(restarted.msgs) != 0 {
+			t.Fatalf("restart must not replay an already-sent conflict nudge, got %v", restarted.msgs)
+		}
+	})
+
+	t.Run("cleared conflict re-arms across restart", func(t *testing.T) {
+		st := newFakeStore()
+		st.sessions["mer-1"] = working("mer-1")
+		first := New(st, &fakeMessenger{})
+		if err := first.ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+			t.Fatal(err)
+		}
+		if err := first.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeMergeable}); err != nil {
+			t.Fatal(err)
+		}
+
+		restarted := &fakeMessenger{}
+		if err := New(st, restarted).ApplyPRObservation(ctx, "mer-1", conflicting); err != nil {
+			t.Fatal(err)
+		}
+		if len(restarted.msgs) != 1 {
+			t.Fatalf("a conflict returning after a restart should nudge, got %v", restarted.msgs)
+		}
+	})
+}
+
+// TestPRObservation_ReArmLeavesOtherDedupEntriesIntact guards the blast radius
+// of the re-arm: it must delete only this PR's merge-conflict key, so a
+// resolved conflict cannot replay the CI-failure nudge the same PR row holds.
+func TestPRObservation_ReArmLeavesOtherDedupEntriesIntact(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	o := ports.PRObservation{
+		Fetched:      true,
+		URL:          "pr1",
+		CI:           domain.CIFailing,
+		Checks:       []ports.PRCheckObservation{{Name: "build", CommitHash: "c1", Status: domain.PRCheckFailed, LogTail: "boom"}},
+		Mergeability: domain.MergeConflicting,
+	}
+	if err := m.ApplyPRObservation(ctx, "mer-1", o); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 2 {
+		t.Fatalf("want a CI and a merge-conflict nudge, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+
+	o.Mergeability = domain.MergeMergeable
+	if err := m.ApplyPRObservation(ctx, "mer-1", o); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 2 {
+		t.Fatalf("re-arming the conflict must not replay the unchanged CI nudge, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+}
+
+// TestPRObservation_ReArmSkipsStoreWriteWhenNothingArmed keeps a steadily
+// mergeable PR off the write path: the re-arm persists only when it actually
+// cleared an entry, so routine polls do not rewrite an unchanged payload.
+func TestPRObservation_ReArmSkipsStoreWriteWhenNothingArmed(t *testing.T) {
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	for range 2 {
+		if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeMergeable}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if st.signatureWrites != 0 {
+		t.Fatalf("mergeable polls with nothing armed wrote the signature payload %d times, want 0", st.signatureWrites)
+	}
+}
+
+// TestPRObservation_ReArmStoreFailureSurfacesWithoutLosingNudges checks the
+// deferred-error contract: a failed re-arm persist is reported, but only after
+// the independent CI nudge queued in the same observation has been sent.
+func TestPRObservation_ReArmStoreFailureSurfacesWithoutLosingNudges(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}); err != nil {
+		t.Fatal(err)
+	}
+
+	st.signatureWriteErr = errors.New("db locked")
+	err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{
+		Fetched:      true,
+		URL:          "pr1",
+		CI:           domain.CIFailing,
+		Checks:       []ports.PRCheckObservation{{Name: "build", CommitHash: "c1", Status: domain.PRCheckFailed, LogTail: "boom"}},
+		Mergeability: domain.MergeMergeable,
+	})
+	if err == nil {
+		t.Fatal("a failed re-arm persist should surface to the observer")
+	}
+	if len(msg.msgs) != 2 {
+		t.Fatalf("the CI nudge must still be sent before the deferred re-arm error, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+}
+
 func TestPRObservation_ExitedAgentIsNotNudged(t *testing.T) {
 	m, st, msg := newManager()
 	rec := working("mer-1")

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -2178,6 +2178,114 @@ func TestPRObservation_ExitedAgentIsNotNudged(t *testing.T) {
 	}
 }
 
+// TestPRObservation_MergeConflictReachesNeedsInputSession is the regression
+// test for #2173: a session parked awaiting the human (waiting_input) must
+// still receive a merge-conflict nudge, because the human sitting at that
+// prompt may be exactly who needs to act (rebase it themselves, or redirect
+// the agent) — unlike CI-failure/review-feedback nudges, which only the agent
+// can act on and which correctly wait for it to resume (see the sibling test
+// below). A session blocked on a live permission dialog is a different,
+// narrower hazard (an unsolicited paste there risks answering the dialog) and
+// must still be refused.
+func TestPRObservation_MergeConflictReachesNeedsInputSession(t *testing.T) {
+	cases := []struct {
+		name      string
+		state     domain.ActivityState
+		wantNudge bool
+	}{
+		{"waiting_input reaches the agent", domain.ActivityWaitingInput, true},
+		{"blocked stays suppressed", domain.ActivityBlocked, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, st, msg := newManager()
+			rec := working("mer-1")
+			rec.Activity.State = tc.state
+			st.sessions["mer-1"] = rec
+
+			o := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}
+			if err := m.ApplyPRObservation(ctx, "mer-1", o); err != nil {
+				t.Fatal(err)
+			}
+			gotNudge := len(msg.msgs) == 1
+			if gotNudge != tc.wantNudge {
+				t.Fatalf("nudge sent = %v (msgs=%v), want %v", gotNudge, msg.msgs, tc.wantNudge)
+			}
+			if gotNudge && !strings.Contains(msg.msgs[0], "merge conflicts") {
+				t.Fatalf("want merge-conflict nudge, got %q", msg.msgs[0])
+			}
+		})
+	}
+}
+
+// TestPRObservation_NeedsInputSessionStillWithholdsOtherNudges is the
+// regression guard: the needs-input gate must keep suppressing CI-failure and
+// review-feedback nudges exactly as before. Only the merge-conflict nudge
+// gets the carve-out in TestPRObservation_MergeConflictReachesNeedsInputSession.
+func TestPRObservation_NeedsInputSessionStillWithholdsOtherNudges(t *testing.T) {
+	for _, state := range []domain.ActivityState{domain.ActivityWaitingInput, domain.ActivityBlocked} {
+		t.Run(string(state), func(t *testing.T) {
+			m, st, msg := newManager()
+			rec := working("mer-1")
+			rec.Activity.State = state
+			st.sessions["mer-1"] = rec
+			st.comments["pr1"] = []domain.PullRequestComment{{ID: "1", Author: "alice", Body: "fix this", AutoInjectReview: true}}
+
+			o := ports.PRObservation{
+				Fetched: true,
+				URL:     "pr1",
+				CI:      domain.CIFailing,
+				Checks:  []ports.PRCheckObservation{{Name: "build", CommitHash: "c1", Status: domain.PRCheckFailed, LogTail: "boom"}},
+				Review:  domain.ReviewChangesRequest,
+			}
+			if err := m.ApplyPRObservation(ctx, "mer-1", o); err != nil {
+				t.Fatal(err)
+			}
+			if len(msg.msgs) != 0 {
+				t.Fatalf("needs-input session should not receive CI/review nudges, got %v", msg.msgs)
+			}
+		})
+	}
+}
+
+// TestPRObservation_DeadSessionGetsNoNudgesOfAnyKind sanity-checks that the
+// merge-conflict carve-out did not overreach: a genuinely dead session
+// (terminated, or its pane already exited to a shell) still gets nothing at
+// all, conflict included, since there is nowhere to deliver it.
+func TestPRObservation_DeadSessionGetsNoNudgesOfAnyKind(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*domain.SessionRecord)
+	}{
+		{"terminated", func(r *domain.SessionRecord) { r.IsTerminated = true }},
+		{"exited", func(r *domain.SessionRecord) { r.Activity.State = domain.ActivityExited }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, st, msg := newManager()
+			rec := working("mer-1")
+			tc.mut(&rec)
+			st.sessions["mer-1"] = rec
+			st.comments["pr1"] = []domain.PullRequestComment{{ID: "1", Author: "alice", Body: "fix this", AutoInjectReview: true}}
+
+			o := ports.PRObservation{
+				Fetched:      true,
+				URL:          "pr1",
+				CI:           domain.CIFailing,
+				Checks:       []ports.PRCheckObservation{{Name: "build", CommitHash: "c1", Status: domain.PRCheckFailed, LogTail: "boom"}},
+				Review:       domain.ReviewChangesRequest,
+				Mergeability: domain.MergeConflicting,
+			}
+			if err := m.ApplyPRObservation(ctx, "mer-1", o); err != nil {
+				t.Fatal(err)
+			}
+			if len(msg.msgs) != 0 {
+				t.Fatalf("%s session should receive no nudges at all, including for a conflict, got %v", tc.name, msg.msgs)
+			}
+		})
+	}
+}
+
 func TestPRObservation_NudgeIncludesPRIdentity(t *testing.T) {
 	m, st, msg := newManager()
 	st.sessions["mer-1"] = working("mer-1")
@@ -2648,7 +2756,7 @@ func TestLifecycleNudgeUsesLateBoundSessionInputLease(t *testing.T) {
 	m.SetSessionInputLease(fixedLifecycleInputLease(false))
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", Activity: domain.Activity{State: domain.ActivityIdle}}
 
-	outcome, err := m.sendOnce(ctx, "mer-1", "", "tracker-comment:1", "1", "review this", 0)
+	outcome, err := m.sendOnce(ctx, "mer-1", "", "tracker-comment:1", "1", "review this", 0, false)
 	if err != nil {
 		t.Fatalf("sendOnce: %v", err)
 	}
@@ -2682,7 +2790,7 @@ func TestLifecycleNudgeStartupGateUsesAdapterCapability(t *testing.T) {
 				Activity: domain.Activity{State: domain.ActivityIdle},
 			}
 
-			outcome, err := m.sendOnce(ctx, "mer-1", "", "tracker-comment:1", "1", "review this", 0)
+			outcome, err := m.sendOnce(ctx, "mer-1", "", "tracker-comment:1", "1", "review this", 0, false)
 			if err != nil {
 				t.Fatalf("sendOnce: %v", err)
 			}

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -283,7 +283,9 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	// defer the error past the send loop, still surfacing it so the observer logs
 	// and re-polls.
 	var blockedCheckErr error
-	if o.Mergeability == domain.MergeConflicting {
+	var rearmErr error
+	switch {
+	case o.Mergeability == domain.MergeConflicting:
 		// Only the bottom of a stack is eligible for the rebase nudge. A PR
 		// stacked on an open parent is expected to report conflicts against its
 		// parent branch until the parent merges and it retargets, so nudging the
@@ -298,8 +300,16 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			if o.URL != "" {
 				msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
 			}
-			nudges = append(nudges, pendingNudge{key: "merge-conflict:" + o.URL, sig: string(o.Mergeability), msg: msg, maxAttempts: 0, urgent: true})
+			nudges = append(nudges, pendingNudge{key: mergeConflictKey(o.URL), sig: string(o.Mergeability), msg: msg, maxAttempts: 0, urgent: true})
 		}
+	case mergeabilityClearsConflict(o.Mergeability):
+		// The conflict is definitively gone, so drop this PR's merge-conflict
+		// dedup entry (#4528). Without the re-arm the "conflicting" signature
+		// persists forever and the next real conflict — typically a base-branch
+		// advance after the agent rebased clean — is silently swallowed as a
+		// duplicate. Deferred like blockedCheckErr so a store failure here
+		// cannot discard the CI/review nudges already queued above.
+		rearmErr = m.rearmMergeConflict(ctx, o.URL)
 	}
 
 	for _, n := range nudges {
@@ -312,7 +322,10 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	if ciPolicyErr != nil {
 		return ciPolicyErr
 	}
-	return blockedCheckErr
+	if blockedCheckErr != nil {
+		return blockedCheckErr
+	}
+	return rearmErr
 }
 
 func (m *Manager) terminateCompletedSession(ctx context.Context, id domain.SessionID) error {
@@ -349,6 +362,66 @@ func (m *Manager) sessionComplete(ctx context.Context, id domain.SessionID) (boo
 		}
 	}
 	return merged, nil
+}
+
+// mergeConflictKey is the reaction-dedup key for a PR's merge-conflict nudge.
+// The send path and the re-arm path share it so the two cannot drift.
+func mergeConflictKey(prURL string) string { return "merge-conflict:" + prURL }
+
+// mergeabilityClearsConflict reports whether an observation positively
+// establishes that a PR is no longer conflicting, which is what re-arms its
+// merge-conflict nudge (#4528).
+//
+// Only states the provider actually computed count. `unknown` is the transient
+// GitHub reports while it recomputes mergeability after a push or a retarget;
+// re-arming on it would defeat the dedup entirely, since a conflict that never
+// went away flaps unknown → conflicting and would re-nudge on every poll.
+// `blocked` is excluded on the same grounds even though it is not literally a
+// conflict: the observer synthesizes it locally from draft / failing-CI /
+// changes-requested facts (see mergeabilityFromProviderFacts), so it is reported
+// even while provider mergeability is still unknown and cannot be read as proof
+// the conflict is gone. `mergeable` and `unstable` both require a computed
+// provider rollup that ruled conflicts out first, so both are definitive.
+func mergeabilityClearsConflict(state domain.Mergeability) bool {
+	return state == domain.MergeMergeable || state == domain.MergeUnstable
+}
+
+// rearmMergeConflict clears the merge-conflict dedup entry for prURL so a later
+// conflicting observation notifies again. sendOnce otherwise keeps the
+// "merge-conflict:<url>" = "conflicting" signature forever: a PR rebased clean
+// and then made conflicting again by a base-branch advance stayed silent, and
+// because the signature is persisted in pr.last_nudge_signature the suppression
+// survived daemon restarts (#4528).
+//
+// Only this PR's merge-conflict key is touched, so the CI and review-feedback
+// entries for the same PR keep their signatures and resolving a conflict cannot
+// replay unrelated nudges. The persisted payload is loaded first: after a
+// restart the in-memory maps are empty, and persisting from them alone would
+// erase every other key the PR row still holds.
+func (m *Manager) rearmMergeConflict(ctx context.Context, prURL string) error {
+	if m.guard == nil || prURL == "" {
+		return nil
+	}
+	m.react.mu.Lock()
+	defer m.react.mu.Unlock()
+
+	if !m.react.loaded[prURL] {
+		if err := m.loadPRSignaturesLocked(ctx, prURL); err != nil {
+			return err
+		}
+		m.react.loaded[prURL] = true
+	}
+	key := mergeConflictKey(prURL)
+	_, seen := m.react.seen[key]
+	_, attempted := m.react.attempts[key]
+	if !seen && !attempted {
+		// Nothing is armed, so skip the store write: a steadily mergeable PR
+		// must not re-persist an unchanged payload on every poll.
+		return nil
+	}
+	delete(m.react.seen, key)
+	delete(m.react.attempts, key)
+	return m.persistPRSignaturesLocked(ctx, prURL)
 }
 
 // prBlockedByOpenParent reports whether the PR at prURL is stacked on top of

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -110,10 +110,17 @@ type reactionState struct {
 	// seen/attempts during this process. Lazy: we only pay the DB read on the
 	// first reaction touching each PR after startup.
 	loaded map[string]bool
+	// pendingRearm tracks PR URLs whose merge-conflict re-arm has been applied
+	// in memory but whose durable write failed. The in-memory delete stands (a
+	// conflict returning in this process must still nudge), so without this the
+	// next re-arm would see nothing armed, take the early return, and never
+	// retry the store — leaving the stale "conflicting" signature on disk to
+	// suppress the nudge after a restart. Cleared once the write lands.
+	pendingRearm map[string]bool
 }
 
 func newReactionState() reactionState {
-	return reactionState{seen: map[string]string{}, attempts: map[string]int{}, loaded: map[string]bool{}}
+	return reactionState{seen: map[string]string{}, attempts: map[string]int{}, loaded: map[string]bool{}, pendingRearm: map[string]bool{}}
 }
 
 // reactionPayload is the JSON document persisted in pr.last_nudge_signature.
@@ -414,14 +421,26 @@ func (m *Manager) rearmMergeConflict(ctx context.Context, prURL string) error {
 	key := mergeConflictKey(prURL)
 	_, seen := m.react.seen[key]
 	_, attempted := m.react.attempts[key]
-	if !seen && !attempted {
-		// Nothing is armed, so skip the store write: a steadily mergeable PR
-		// must not re-persist an unchanged payload on every poll.
+	if !seen && !attempted && !m.react.pendingRearm[prURL] {
+		// Nothing is armed and no earlier re-arm is still owed a durable write,
+		// so skip the store write: a steadily mergeable PR must not re-persist
+		// an unchanged payload on every poll.
 		return nil
 	}
 	delete(m.react.seen, key)
 	delete(m.react.attempts, key)
-	return m.persistPRSignaturesLocked(ctx, prURL)
+	if err := m.persistPRSignaturesLocked(ctx, prURL); err != nil {
+		// The in-memory delete deliberately stands: a conflict returning later
+		// in this process must still nudge. But disk still holds the stale
+		// "conflicting" signature, which a restart would reload and use to
+		// suppress that nudge — the exact bug this re-arm exists to fix. Mark
+		// the PR so every later non-conflicting observation retries the write
+		// until it lands, instead of taking the early return above.
+		m.react.pendingRearm[prURL] = true
+		return err
+	}
+	delete(m.react.pendingRearm, prURL)
+	return nil
 }
 
 // prBlockedByOpenParent reports whether the PR at prURL is stacked on top of

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -182,10 +182,26 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	if err != nil || !ok {
 		return err
 	}
+	// Re-arm the merge-conflict dedup on a definitively-cleared observation
+	// BEFORE the dead-session delivery gate below. Re-arming is non-delivery
+	// bookkeeping — it only drops this PR's dedup entry in the store, it writes
+	// nothing to a pane — so it must run even for a session that has exited or is
+	// terminated. Otherwise conflicting -> agent exits -> mergeable -> agent
+	// restored -> conflicting keeps the durable "conflicting" signature and
+	// sendOnce swallows the recurrence: exited sessions are still polled, and a
+	// terminated session that is later restored resumes polling, so the cleared
+	// state must land regardless of current liveness. The error is deferred past
+	// the nudge send loop (returned as rearmErr) so a persist failure here cannot
+	// discard CI/review nudges an unstable PR still queues below.
+	var rearmErr error
+	if mergeabilityClearsConflict(o.Mergeability) {
+		rearmErr = m.rearmMergeConflict(ctx, o.URL)
+	}
 	// A genuinely dead session — terminated, or its pane already exited to a
-	// shell — has nowhere to deliver any nudge, merge-conflict included.
+	// shell — has nowhere to deliver any nudge, merge-conflict included, so
+	// return once the non-delivery re-arm above has run.
 	if rec.IsTerminated || rec.Activity.State == domain.ActivityExited {
-		return nil
+		return rearmErr
 	}
 	// cannotNudge's remaining condition, needs-input, defers CI-failure and
 	// review-feedback nudges until the agent is active again: both are
@@ -195,9 +211,11 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	// or redirect the agent), so the merge-conflict nudge below is deliberately
 	// exempted from this gate instead of loosening it for every nudge type. It
 	// still funnels through sendOnce's urgent path (sessionguard.NudgeUrgent),
-	// which continues to refuse a write while the session is blocked on a live
-	// permission dialog — only an idle needs-input prompt is safe to paste into
-	// unsolicited.
+	// which refuses while the session is blocked on a live permission dialog and
+	// while it sits at a waiting_input prompt on a harness that cannot prove that
+	// prompt is a genuine idle composer rather than a masked permission decision
+	// (the urgentNudgeWaitingInputSafe gate) — so only a provably-idle needs-input
+	// prompt is pasted into unsolicited.
 	needsInput := rec.Activity.State.NeedsInput()
 	// A single PR can trip several actionable conditions at once (failing CI,
 	// unresolved review comments, a merge conflict). Queue every applicable nudge
@@ -290,9 +308,7 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	// defer the error past the send loop, still surfacing it so the observer logs
 	// and re-polls.
 	var blockedCheckErr error
-	var rearmErr error
-	switch {
-	case o.Mergeability == domain.MergeConflicting:
+	if o.Mergeability == domain.MergeConflicting {
 		// Only the bottom of a stack is eligible for the rebase nudge. A PR
 		// stacked on an open parent is expected to report conflicts against its
 		// parent branch until the parent merges and it retargets, so nudging the
@@ -309,15 +325,11 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			}
 			nudges = append(nudges, pendingNudge{key: mergeConflictKey(o.URL), sig: string(o.Mergeability), msg: msg, maxAttempts: 0, urgent: true})
 		}
-	case mergeabilityClearsConflict(o.Mergeability):
-		// The conflict is definitively gone, so drop this PR's merge-conflict
-		// dedup entry (#4528). Without the re-arm the "conflicting" signature
-		// persists forever and the next real conflict — typically a base-branch
-		// advance after the agent rebased clean — is silently swallowed as a
-		// duplicate. Deferred like blockedCheckErr so a store failure here
-		// cannot discard the CI/review nudges already queued above.
-		rearmErr = m.rearmMergeConflict(ctx, o.URL)
 	}
+	// The definitively-cleared re-arm (#4528) runs above the dead-session gate,
+	// not here, so an exited/restored session still drops its stale "conflicting"
+	// signature; rearmErr is surfaced at the end of this function alongside the
+	// other deferred read errors.
 
 	for _, n := range nudges {
 		if _, err := m.sendOnce(ctx, id, o.URL, n.key, n.sig, n.msg, n.maxAttempts, n.urgent); err != nil {
@@ -980,9 +992,13 @@ func (m *Manager) sendOnce(ctx context.Context, id domain.SessionID, prURL, key,
 	if urgent {
 		// Merge-conflict nudges (the only urgent nudge today) must still reach
 		// a session idle at a needs-input prompt; NudgeUrgent keeps refusing
-		// only while a live permission dialog is on screen. See
-		// ApplyPRObservation's needsInput carve-out for the reasoning.
-		nudge = m.guard.NudgeUrgent
+		// while a live permission dialog is on screen — including the
+		// waiting_input prompts that harnesses without a blocked signal use to
+		// represent a masked permission decision (see the urgentNudgeGate
+		// predicate). See ApplyPRObservation's needsInput carve-out.
+		nudge = func(ctx context.Context, id domain.SessionID, msg string) (sessionguard.Outcome, error) {
+			return m.guard.NudgeUrgent(ctx, id, msg, m.urgentNudgeWaitingInputSafe)
+		}
 	}
 	outcome, err := nudge(ctx, id, msg)
 	if err != nil {

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -89,7 +89,7 @@ func (m *Manager) ApplyReviewBatch(ctx context.Context, workerID domain.SessionI
 	anchorPR := results[0].PRURL
 	key := "review-batch:" + anchorPR + ":" + batchID
 	sig := strings.Join(sigParts, "\x01")
-	outcome, err := m.sendOnce(ctx, workerID, anchorPR, key, sig, msg.String(), reviewMaxNudge)
+	outcome, err := m.sendOnce(ctx, workerID, anchorPR, key, sig, msg.String(), reviewMaxNudge, false)
 	if err != nil {
 		return ReviewDeliveryNoop, err
 	}
@@ -133,6 +133,12 @@ type pendingNudge struct {
 	sig         string
 	msg         string
 	maxAttempts int
+	// urgent routes the send through sessionguard.NudgeUrgent instead of
+	// Nudge: it still reaches a session idle at a needs-input prompt instead
+	// of being suppressed until the agent resumes. Reserved for the
+	// merge-conflict nudge (see ApplyPRObservation) — every other nudge type
+	// keeps the ordinary Nudge gate.
+	urgent bool
 }
 
 // ApplyPRObservation reacts to a fetched PR observation after the PR service has
@@ -169,18 +175,23 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	if err != nil || !ok {
 		return err
 	}
-	if cannotNudge(rec) {
+	// A genuinely dead session — terminated, or its pane already exited to a
+	// shell — has nowhere to deliver any nudge, merge-conflict included.
+	if rec.IsTerminated || rec.Activity.State == domain.ActivityExited {
 		return nil
 	}
-	reviews, err := m.store.ListPRReviews(ctx, o.URL)
-	if err != nil {
-		return fmt.Errorf("list persisted reviews for %s: %w", o.URL, err)
-	}
-	comments, err := m.store.ListPRComments(ctx, o.URL)
-	if err != nil {
-		return fmt.Errorf("list persisted comments for %s: %w", o.URL, err)
-	}
-	o.Comments = prCommentObservations(comments)
+	// cannotNudge's remaining condition, needs-input, defers CI-failure and
+	// review-feedback nudges until the agent is active again: both are
+	// actionable only by the agent, so re-surfacing them once it resumes loses
+	// nothing. A merge conflict is different — the human parked at the
+	// needs-input prompt may be exactly who needs to act (rebase it themselves,
+	// or redirect the agent), so the merge-conflict nudge below is deliberately
+	// exempted from this gate instead of loosening it for every nudge type. It
+	// still funnels through sendOnce's urgent path (sessionguard.NudgeUrgent),
+	// which continues to refuse a write while the session is blocked on a live
+	// permission dialog — only an idle needs-input prompt is safe to paste into
+	// unsolicited.
+	needsInput := rec.Activity.State.NeedsInput()
 	// A single PR can trip several actionable conditions at once (failing CI,
 	// unresolved review comments, a merge conflict). Queue every applicable nudge
 	// and send them together, so each surfaces independently instead of one
@@ -192,63 +203,75 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	var nudges []pendingNudge
 	var ciPolicyErr error
 
-	if o.CI == domain.CIFailing {
-		pr, ok, err := m.store.GetPR(ctx, o.URL)
-		switch {
-		case err != nil:
-			ciPolicyErr = fmt.Errorf("load CI injection policy for %s: %w", o.URL, err)
-		case !ok:
-			ciPolicyErr = fmt.Errorf("load CI injection policy for %s: PR not found", o.URL)
-		case pr.AutoInjectCI:
-			checks := failedPRChecks(o.Checks)
-			if len(checks) > 0 {
-				msg := formatCIFailureMessage(checks)
+	if !needsInput {
+		reviews, err := m.store.ListPRReviews(ctx, o.URL)
+		if err != nil {
+			return fmt.Errorf("list persisted reviews for %s: %w", o.URL, err)
+		}
+		comments, err := m.store.ListPRComments(ctx, o.URL)
+		if err != nil {
+			return fmt.Errorf("list persisted comments for %s: %w", o.URL, err)
+		}
+		o.Comments = prCommentObservations(comments)
+
+		if o.CI == domain.CIFailing {
+			pr, ok, err := m.store.GetPR(ctx, o.URL)
+			switch {
+			case err != nil:
+				ciPolicyErr = fmt.Errorf("load CI injection policy for %s: %w", o.URL, err)
+			case !ok:
+				ciPolicyErr = fmt.Errorf("load CI injection policy for %s: PR not found", o.URL)
+			case pr.AutoInjectCI:
+				checks := failedPRChecks(o.Checks)
+				if len(checks) > 0 {
+					msg := formatCIFailureMessage(checks)
+					if ident != "your PR" {
+						msg = strings.Replace(msg, "your PR", ident, 1)
+					}
+					if o.URL != "" {
+						msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
+					}
+					nudges = append(nudges, pendingNudge{key: "ci:" + o.URL, sig: ciFailureSignature(checks), msg: msg, maxAttempts: 0})
+				}
+			}
+		}
+
+		if hasUnresolvedComments(o.Comments) {
+			comments := unresolvedReviewComments(o.Comments)
+			for _, comment := range comments {
+				if !comment.AutoInjectReview {
+					continue
+				}
+				commentSlice := []ports.PRCommentObservation{comment}
+				msg := formatReviewCommentsMessage(commentSlice)
 				if ident != "your PR" {
 					msg = strings.Replace(msg, "your PR", ident, 1)
 				}
 				if o.URL != "" {
 					msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
 				}
-				nudges = append(nudges, pendingNudge{key: "ci:" + o.URL, sig: ciFailureSignature(checks), msg: msg, maxAttempts: 0})
+				sig := reviewCommentsSignature(commentSlice)
+				if sig == "" {
+					sig = string(o.Review)
+				}
+				nudges = append(nudges, pendingNudge{key: "comment:" + o.URL, sig: sig, msg: msg, maxAttempts: reviewMaxNudge})
 			}
 		}
-	}
 
-	if hasUnresolvedComments(o.Comments) {
-		comments := unresolvedReviewComments(o.Comments)
-		for _, comment := range comments {
-			if !comment.AutoInjectReview {
-				continue
+		if o.Review == domain.ReviewChangesRequest {
+			for _, review := range reviews {
+				if review.State != domain.ReviewChangesRequest || !review.AutoInjectReview {
+					continue
+				}
+				msg := formatReviewChangesRequestedMessage(review)
+				if ident != "your PR" {
+					msg = strings.Replace(msg, "your PR", ident, 1)
+				}
+				if o.URL != "" && review.URL == "" {
+					msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
+				}
+				nudges = append(nudges, pendingNudge{key: "review:" + o.URL + ":" + review.ID, sig: string(review.State), msg: msg, maxAttempts: reviewMaxNudge})
 			}
-			commentSlice := []ports.PRCommentObservation{comment}
-			msg := formatReviewCommentsMessage(commentSlice)
-			if ident != "your PR" {
-				msg = strings.Replace(msg, "your PR", ident, 1)
-			}
-			if o.URL != "" {
-				msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
-			}
-			sig := reviewCommentsSignature(commentSlice)
-			if sig == "" {
-				sig = string(o.Review)
-			}
-			nudges = append(nudges, pendingNudge{key: "comment:" + o.URL, sig: sig, msg: msg, maxAttempts: reviewMaxNudge})
-		}
-	}
-
-	if o.Review == domain.ReviewChangesRequest {
-		for _, review := range reviews {
-			if review.State != domain.ReviewChangesRequest || !review.AutoInjectReview {
-				continue
-			}
-			msg := formatReviewChangesRequestedMessage(review)
-			if ident != "your PR" {
-				msg = strings.Replace(msg, "your PR", ident, 1)
-			}
-			if o.URL != "" && review.URL == "" {
-				msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
-			}
-			nudges = append(nudges, pendingNudge{key: "review:" + o.URL + ":" + review.ID, sig: string(review.State), msg: msg, maxAttempts: reviewMaxNudge})
 		}
 	}
 
@@ -275,12 +298,12 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			if o.URL != "" {
 				msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
 			}
-			nudges = append(nudges, pendingNudge{key: "merge-conflict:" + o.URL, sig: string(o.Mergeability), msg: msg, maxAttempts: 0})
+			nudges = append(nudges, pendingNudge{key: "merge-conflict:" + o.URL, sig: string(o.Mergeability), msg: msg, maxAttempts: 0, urgent: true})
 		}
 	}
 
 	for _, n := range nudges {
-		if _, err := m.sendOnce(ctx, id, o.URL, n.key, n.sig, n.msg, n.maxAttempts); err != nil {
+		if _, err := m.sendOnce(ctx, id, o.URL, n.key, n.sig, n.msg, n.maxAttempts, n.urgent); err != nil {
 			return err
 		}
 	}
@@ -579,7 +602,7 @@ func (m *Manager) ApplyTrackerFacts(ctx context.Context, id domain.SessionID, o 
 			// the PR-row signature load/persist is skipped, so the dedup
 			// survives only for the lifetime of this Manager. Cross-restart
 			// persistence ships with #35.
-			_, err := m.sendOnce(ctx, id, "", "tracker-bot:"+o.Issue.URL, strings.Join(ids, ","), msg, 0)
+			_, err := m.sendOnce(ctx, id, "", "tracker-bot:"+o.Issue.URL, strings.Join(ids, ","), msg, 0, false)
 			return err
 		}
 	}
@@ -589,6 +612,13 @@ func (m *Manager) ApplyTrackerFacts(ctx context.Context, id domain.SessionID, o 
 // cannotNudge is the lifecycle entry guard for automated pane delivery. The
 // just-in-time sessionguard remains authoritative, but refusing exited agents
 // here avoids repeated dedup/store work for a pane that now contains a shell.
+//
+// ApplyPRObservation does NOT call this helper directly: it needs a narrower
+// carve-out so the merge-conflict nudge alone can bypass the needs-input
+// condition below (see its needsInput comment), so it inlines the
+// terminated/exited half of this check and evaluates needs-input separately.
+// Every other nudge path in this package (ApplyReviewBatch, ApplyTrackerFacts)
+// still gates on the full condition here, unchanged.
 func cannotNudge(rec domain.SessionRecord) bool {
 	return rec.IsTerminated || rec.Activity.State.NeedsInput() || rec.Activity.State == domain.ActivityExited
 }
@@ -824,7 +854,7 @@ const (
 	sendOnceSuppressed
 )
 
-func (m *Manager) sendOnce(ctx context.Context, id domain.SessionID, prURL, key, sig, msg string, maxAttempts int) (sendOnceOutcome, error) {
+func (m *Manager) sendOnce(ctx context.Context, id domain.SessionID, prURL, key, sig, msg string, maxAttempts int, urgent bool) (sendOnceOutcome, error) {
 	if m.guard == nil {
 		return sendOnceAccounted, nil
 	}
@@ -854,7 +884,15 @@ func (m *Manager) sendOnce(ctx context.Context, id domain.SessionID, prURL, key,
 	// suppresses (fail closed, nothing was written); a messenger failure means
 	// the write was attempted and stays accounted, matching the pre-guard
 	// behavior.
-	outcome, err := m.guard.Nudge(ctx, id, msg)
+	nudge := m.guard.Nudge
+	if urgent {
+		// Merge-conflict nudges (the only urgent nudge today) must still reach
+		// a session idle at a needs-input prompt; NudgeUrgent keeps refusing
+		// only while a live permission dialog is on screen. See
+		// ApplyPRObservation's needsInput carve-out for the reasoning.
+		nudge = m.guard.NudgeUrgent
+	}
+	outcome, err := nudge(ctx, id, msg)
 	if err != nil {
 		if outcome != sessionguard.Sent {
 			return sendOnceSuppressed, err

--- a/backend/internal/sessionguard/guard.go
+++ b/backend/internal/sessionguard/guard.go
@@ -285,12 +285,34 @@ func (g *Guard) Nudge(ctx context.Context, id domain.SessionID, msg string) (Out
 // reserved for alerts where a human parked at that prompt may be exactly who
 // needs to act (e.g. a merge conflict needing a rebase or a redirected agent),
 // unlike a routine reaction nudge that can simply wait for the agent to resume
-// on its own. It reuses refuseDeliver, the same policy real user messages take:
-// it still refuses while the session is blocked on a live permission decision
-// (an unsolicited write there risks answering the dialog rather than merely
-// being read late) and while a TUI session has not yet signalled startup.
-func (g *Guard) NudgeUrgent(ctx context.Context, id domain.SessionID, msg string) (Outcome, error) {
-	return g.send(ctx, id, msg, g.refuseDeliver)
+// on its own. It still refuses while a TUI session has not yet signalled
+// startup and while the session is blocked on a live permission decision (an
+// unsolicited paste+Enter there answers the dialog rather than merely being
+// read late).
+//
+// waiting_input is only safe on a harness that reports a permission dialog AS
+// blocked. Harnesses that instead surface an ambiguous permission state as
+// waiting_input (codex maps permission-request to waiting_input — see
+// ports.BlockedActivitySignaler) would have this unsolicited write land on that
+// hidden dialog. acceptsWaitingInput is the adapter-declared capability that a
+// waiting_input prompt is a genuine idle composer, not a masked decision; a nil
+// predicate is treated as "cannot distinguish", so an unknown harness never
+// takes an urgent write while waiting_input. This mirrors
+// CoordinationUnderMutation's waiting_input gating.
+func (g *Guard) NudgeUrgent(ctx context.Context, id domain.SessionID, msg string, acceptsWaitingInput func(domain.AgentHarness) bool) (Outcome, error) {
+	return g.send(ctx, id, msg, func(rec domain.SessionRecord) (Outcome, bool) {
+		if g.tuiAwaitingStartupInput(rec) {
+			return SuppressedStartupPending, true
+		}
+		switch rec.Activity.State {
+		case domain.ActivityBlocked:
+			return SuppressedAwaitingUser, true
+		case domain.ActivityWaitingInput:
+			return SuppressedAwaitingUser, acceptsWaitingInput == nil || !acceptsWaitingInput(rec.Harness)
+		default:
+			return SuppressedUnknown, false
+		}
+	})
 }
 
 // NudgeCoordination writes an AO-initiated coordination message under the full

--- a/backend/internal/sessionguard/guard.go
+++ b/backend/internal/sessionguard/guard.go
@@ -280,6 +280,19 @@ func (g *Guard) Nudge(ctx context.Context, id domain.SessionID, msg string) (Out
 	return g.send(ctx, id, msg, g.refuseNudge)
 }
 
+// NudgeUrgent writes an AO-initiated message that must reach the agent even
+// while the session sits idle at a needs-input prompt (waiting_input) —
+// reserved for alerts where a human parked at that prompt may be exactly who
+// needs to act (e.g. a merge conflict needing a rebase or a redirected agent),
+// unlike a routine reaction nudge that can simply wait for the agent to resume
+// on its own. It reuses refuseDeliver, the same policy real user messages take:
+// it still refuses while the session is blocked on a live permission decision
+// (an unsolicited write there risks answering the dialog rather than merely
+// being read late) and while a TUI session has not yet signalled startup.
+func (g *Guard) NudgeUrgent(ctx context.Context, id domain.SessionID, msg string) (Outcome, error) {
+	return g.send(ctx, id, msg, g.refuseDeliver)
+}
+
 // NudgeCoordination writes an AO-initiated coordination message under the full
 // delivery policy, re-evaluated here — at the write boundary — rather than from
 // a caller's earlier snapshot. It refuses whenever the session awaits the human,

--- a/backend/internal/sessionguard/guard_test.go
+++ b/backend/internal/sessionguard/guard_test.go
@@ -117,31 +117,38 @@ func TestGuard_OutcomeByState(t *testing.T) {
 
 // TestGuard_NudgeUrgentReachesNeedsInputButNotBlocked pins NudgeUrgent's
 // outcome table directly: it is the only nudge method that may write into a
-// session idle at a needs-input prompt, and it must still refuse every state
-// Deliver refuses — above all blocked, where a paste+Enter would answer a live
-// permission dialog on the user's behalf.
+// session idle at a needs-input prompt, and it must still refuse blocked (where
+// a paste+Enter would answer a live permission dialog on the user's behalf) and
+// a waiting_input prompt on a harness that cannot prove the prompt is a genuine
+// idle composer rather than a masked permission decision.
 func TestGuard_NudgeUrgentReachesNeedsInputButNotBlocked(t *testing.T) {
+	acceptsAll := func(domain.AgentHarness) bool { return true }
+	refusesAll := func(domain.AgentHarness) bool { return false }
 	cases := []struct {
-		name string
-		rec  domain.SessionRecord
-		ok   bool
-		want Outcome
+		name    string
+		rec     domain.SessionRecord
+		ok      bool
+		accepts func(domain.AgentHarness) bool
+		want    Outcome
 	}{
-		{"active", record(domain.ActivityActive, false), true, Sent},
-		{"idle", record(domain.ActivityIdle, false), true, Sent},
+		{"active", record(domain.ActivityActive, false), true, acceptsAll, Sent},
+		{"idle", record(domain.ActivityIdle, false), true, acceptsAll, Sent},
 		// The whole point of the method: unlike Nudge, an urgent nudge lands at
-		// an idle waiting_input prompt.
-		{"waiting_input", record(domain.ActivityWaitingInput, false), true, Sent},
-		{"blocked", record(domain.ActivityBlocked, false), true, SuppressedAwaitingUser},
-		{"exited", record(domain.ActivityExited, false), true, SuppressedExited},
-		{"terminated", record(domain.ActivityIdle, true), true, SuppressedTerminated},
-		{"missing", domain.SessionRecord{}, false, SuppressedNotFound},
+		// an idle waiting_input prompt — but only when the harness proves that
+		// prompt is a real composer, not an ambiguous permission state.
+		{"waiting_input capability-safe", record(domain.ActivityWaitingInput, false), true, acceptsAll, Sent},
+		{"waiting_input ambiguous suppressed", record(domain.ActivityWaitingInput, false), true, refusesAll, SuppressedAwaitingUser},
+		{"waiting_input nil predicate suppressed", record(domain.ActivityWaitingInput, false), true, nil, SuppressedAwaitingUser},
+		{"blocked", record(domain.ActivityBlocked, false), true, acceptsAll, SuppressedAwaitingUser},
+		{"exited", record(domain.ActivityExited, false), true, acceptsAll, SuppressedExited},
+		{"terminated", record(domain.ActivityIdle, true), true, acceptsAll, SuppressedTerminated},
+		{"missing", domain.SessionRecord{}, false, acceptsAll, SuppressedNotFound},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			msgr := &fakeMessenger{}
 			g := New(&fakeStore{rec: tc.rec, ok: tc.ok}, msgr, nil)
-			got, err := g.NudgeUrgent(context.Background(), "s1", "hello")
+			got, err := g.NudgeUrgent(context.Background(), "s1", "hello", tc.accepts)
 			if err != nil {
 				t.Fatalf("NudgeUrgent: %v", err)
 			}
@@ -169,7 +176,7 @@ func TestGuard_NudgeUrgentRespectsTUIStartupGate(t *testing.T) {
 	g := New(&fakeStore{rec: rec, ok: true}, msgr, nil)
 	g.SetStartupSignalGate(func(domain.AgentHarness) bool { return true })
 
-	got, err := g.NudgeUrgent(context.Background(), "s1", "rebase")
+	got, err := g.NudgeUrgent(context.Background(), "s1", "rebase", func(domain.AgentHarness) bool { return true })
 	if err != nil {
 		t.Fatalf("NudgeUrgent: %v", err)
 	}

--- a/backend/internal/sessionguard/guard_test.go
+++ b/backend/internal/sessionguard/guard_test.go
@@ -115,6 +115,72 @@ func TestGuard_OutcomeByState(t *testing.T) {
 	}
 }
 
+// TestGuard_NudgeUrgentReachesNeedsInputButNotBlocked pins NudgeUrgent's
+// outcome table directly: it is the only nudge method that may write into a
+// session idle at a needs-input prompt, and it must still refuse every state
+// Deliver refuses — above all blocked, where a paste+Enter would answer a live
+// permission dialog on the user's behalf.
+func TestGuard_NudgeUrgentReachesNeedsInputButNotBlocked(t *testing.T) {
+	cases := []struct {
+		name string
+		rec  domain.SessionRecord
+		ok   bool
+		want Outcome
+	}{
+		{"active", record(domain.ActivityActive, false), true, Sent},
+		{"idle", record(domain.ActivityIdle, false), true, Sent},
+		// The whole point of the method: unlike Nudge, an urgent nudge lands at
+		// an idle waiting_input prompt.
+		{"waiting_input", record(domain.ActivityWaitingInput, false), true, Sent},
+		{"blocked", record(domain.ActivityBlocked, false), true, SuppressedAwaitingUser},
+		{"exited", record(domain.ActivityExited, false), true, SuppressedExited},
+		{"terminated", record(domain.ActivityIdle, true), true, SuppressedTerminated},
+		{"missing", domain.SessionRecord{}, false, SuppressedNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgr := &fakeMessenger{}
+			g := New(&fakeStore{rec: tc.rec, ok: tc.ok}, msgr, nil)
+			got, err := g.NudgeUrgent(context.Background(), "s1", "hello")
+			if err != nil {
+				t.Fatalf("NudgeUrgent: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("outcome = %v, want %v", got, tc.want)
+			}
+			if wantSent := tc.want == Sent; (len(msgr.sent) == 1) != wantSent {
+				t.Fatalf("messenger sends = %d, want sent=%v", len(msgr.sent), wantSent)
+			}
+		})
+	}
+}
+
+// TestGuard_NudgeUrgentRespectsTUIStartupGate keeps the urgent carve-out from
+// widening past its one intended state: a TUI session that has not yet sent
+// its first hook may still be sitting on a pre-session dialog, so an urgent
+// nudge is refused there exactly as Deliver is.
+func TestGuard_NudgeUrgentRespectsTUIStartupGate(t *testing.T) {
+	msgr := &fakeMessenger{}
+	rec := domain.SessionRecord{
+		ID:       "s1",
+		Mode:     domain.SessionModeTUI,
+		Activity: domain.Activity{State: domain.ActivityWaitingInput},
+	}
+	g := New(&fakeStore{rec: rec, ok: true}, msgr, nil)
+	g.SetStartupSignalGate(func(domain.AgentHarness) bool { return true })
+
+	got, err := g.NudgeUrgent(context.Background(), "s1", "rebase")
+	if err != nil {
+		t.Fatalf("NudgeUrgent: %v", err)
+	}
+	if got != SuppressedStartupPending {
+		t.Fatalf("outcome = %v, want SuppressedStartupPending", got)
+	}
+	if len(msgr.sent) != 0 {
+		t.Fatalf("messenger sends = %d, want 0 before first hook", len(msgr.sent))
+	}
+}
+
 func TestGuard_TUIStartupPendingBlocksDeliver(t *testing.T) {
 	msgr := &fakeMessenger{}
 	rec := domain.SessionRecord{


### PR DESCRIPTION
This PR carries two related merge-conflict-nudge fixes. Both concern the same
`merge-conflict:<pr-url>` reaction in `backend/internal/lifecycle/reactions.go`,
and each one on its own still leaves the nudge silent in a common case.

Closes #4528. Addresses #2173 (the agent-nudge surfacing gap; the
notification-type and frontend-status gaps there are left for follow-up).

---

## 1. Merge-conflict nudges reach needs-input sessions

**Root cause.** `cannotNudge()` gates every reaction nudge on
`rec.Activity.State.NeedsInput()`, and `ApplyPRObservation` called it at the top
of the function — before the merge-conflict block that runs later in the same
function. A session parked at `waiting_input` (or `blocked`) whose PR went
`conflicting` produced no nudge, and since the reaction only starts its
`escalateAfter` timer on dispatch, no later escalation either. Completely
silent.

The pre-rewrite TypeScript implementation had the identical gap by a different
mechanism: `maybeDispatchMergeConflicts` gated on a status allowlist that
omitted the parked state, directly under a doc comment claiming it was
"dispatched independently of the session status." The same defect surviving two
separate implementations argues for a deliberate, named carve-out rather than
something that happens to fall out of the next refactor.

**Why this is a carve-out, not a general loosening.** CI-failure and
review-feedback nudges are actionable only by the agent, so deferring them until
it resumes loses nothing. A merge conflict is different: the human sitting at
that needs-input prompt may be exactly who needs to act (rebase it themselves,
or redirect the agent), so it should reach them immediately.

**The fix has two layers.**

- **`lifecycle/reactions.go`** — `ApplyPRObservation` now only short-circuits up
  front on `IsTerminated`/`ActivityExited` (a session with nowhere to deliver
  anything). It evaluates `needsInput` separately and uses it to gate just the
  CI-failure/unresolved-comment/review-changes-requested blocks, leaving the
  merge-conflict block unconditional. `cannotNudge()` itself is untouched, and
  every other nudge path (`ApplyReviewBatch`, `ApplyTrackerFacts`) still calls
  it exactly as before.
- **`sessionguard/guard.go`** — that alone is not sufficient. `sendOnce`
  delivers through `sessionguard.Guard.Nudge`, which independently refuses any
  write while `NeedsInput()` is true regardless of what the caller decided; it
  is the just-in-time re-check that closes the race between the reducer's
  snapshot and the actual pane write. Loosening the reducer's gate alone would
  have been a no-op. Added `Guard.NudgeUrgent`, which refuses while `Blocked` (a
  live permission dialog) and while a TUI session has not yet signalled startup,
  and — crucially — refuses at `waiting_input` unless the harness *positively
  proves* that prompt is a genuine idle composer rather than a masked permission
  decision (see the harness-aware gate below). The merge-conflict `pendingNudge`
  now carries an `urgent` flag routing it through `NudgeUrgent`; every other
  nudge type is unchanged.

## 2. Re-arm the nudge once a conflict clears (#4528)

**Root cause.** `sendOnce` persists the dedup entry
`"merge-conflict:<pr-url>" = "conflicting"` in `pr.last_nudge_signature`, and
nothing ever cleared it. Once the agent rebased a PR clean, a later base-branch
advance that made the same PR conflicting again produced the identical
key/signature and was swallowed as a duplicate. Because the signature is
durable, the suppression also survived daemon restarts. Confirmed live on
PR #4165 in the issue: durable mergeability `conflicting`, seen signature
`conflicting`, attempts `1`, and no second nudge.

**The fix.** `ApplyPRObservation` re-arms on the other edge of the transition: a
definitively non-conflicting observation drops that one PR's merge-conflict seen
signature and attempt count and persists the updated payload, so the next
conflicting observation notifies again.

What counts as definitive matters, and `mergeabilityClearsConflict` names it:

| state | re-arms? | why |
|---|---|---|
| `mergeable`, `unstable` | yes | both require a computed provider rollup that ruled conflicts out first |
| `unknown` (and the unset zero value) | no | the transient GitHub reports while recomputing after a push or retarget; re-arming here would defeat the dedup outright, since a conflict that never went away flaps `unknown → conflicting` and would re-nudge every poll |
| `blocked` | no | despite not literally being a conflict, the observer synthesizes it locally from draft / failing-CI / changes-requested facts (`mergeabilityFromProviderFacts`), so it is reported even while provider mergeability is still unknown — not proof the conflict is gone |

Excluding `blocked` has a known cost, and this PR demonstrated it on itself: AO
observed this PR as `conflicting` before it was rebased, and it is now
`blocked` (awaiting required review), so its merge-conflict dedup entry stays
armed rather than resetting. That is harmless here — there is no conflict, so
nothing should re-notify — but it means a *real* conflict appearing while a PR
is still `blocked` would be deduplicated against the stale `conflicting`
signature and stay silent until the PR reaches `mergeable`/`unstable` once.
Widening the re-arm to `blocked` would trade that for the flap-spam this issue
explicitly requires be prevented, so the narrower rule stands; flagging it as
the deliberate trade-off rather than an oversight.

The re-arm's durable write is retried until it lands. The in-memory delete
takes effect immediately (a conflict returning in-process must still nudge), so
a failed `UpdatePRLastNudgeSignature` would otherwise leave the next
observation seeing nothing armed, taking the early return, and never retrying —
leaving the stale `conflicting` signature on disk for a restart to reload.
`reactionState.pendingRearm` marks such PRs so every later non-conflicting
observation retries until the write succeeds. Rolling the in-memory delete back
instead would fix the restart case but deduplicate away a conflict that returns
before the write lands.

Blast radius is deliberately narrow. The re-arm deletes only this PR's
merge-conflict key, so the CI and review-feedback entries on the same PR row
keep their signatures and a resolved conflict cannot replay unrelated nudges. It
loads the persisted payload before mutating (after a restart the in-memory maps
are empty, and persisting from them alone would erase every other key the row
holds), skips the store write when nothing was armed so a steadily mergeable PR
does not rewrite an unchanged payload on every poll, and defers its error past
the send loop like `blockedCheckErr` so a store failure cannot discard the
CI/review nudges queued in the same observation.

## 3. Review follow-up: two boundary fixes

Two correctness boundaries surfaced in review, each fixed with its own coverage.

**Harness-aware urgent delivery.** `NudgeUrgent` originally reused
`refuseDeliver`, which refuses only on `Blocked` — so *every* `waiting_input`
session became writable. That is not equivalent to an idle composer for several
adapters: codex maps `permission-request` to `waiting_input`, Droid folds both
permission decisions and idle notifications into `waiting_input`, and the
shared-hook harnesses (`StandardDeriveActivityState`) do the same. An urgent
paste+Enter there could answer a live permission prompt. `NudgeUrgent` now takes
an `acceptsWaitingInput func(domain.AgentHarness) bool` predicate (mirroring
`CoordinationUnderMutation`'s existing gating) and is **fail-closed**: it refuses
`waiting_input` unless the predicate proves it safe, and a nil predicate refuses.
Lifecycle wires it via a new `WithUrgentNudgeGate` option, resolved in
`lifecycle_wiring.go` from `ports.BlockedActivitySignaler.EmitsBlockedActivity()`
— the exact contract for "reports permission dialogs as blocked rather than
waiting_input." Only claude-code and kimchi open the boundary; codex, Droid,
agy, prime-agent, and every shared-hook harness stay suppressed.

**Re-arm ahead of the dead-session return.** The `mergeabilityClearsConflict`
re-arm originally ran after `ApplyPRObservation`'s terminated/exited early
return. Because exited sessions are still polled (and a terminated session
resumes polling once restored), the sequence `conflicting → exit → mergeable →
restore → conflicting` kept the durable `conflicting` signature and the
recurrence was deduplicated away. Re-arming is non-delivery bookkeeping — it only
drops this PR's dedup entry in the store — so it now runs *before* the
dead-session gate, with its persist error still deferred past the nudge send
loop so a store failure cannot discard CI/review nudges an unstable PR queues.

## Test coverage

`internal/sessionguard/guard_test.go`

- `TestGuard_NudgeUrgentReachesNeedsInputButNotBlocked` — pins the new method's
  outcome table (sent at `active`/`idle` and at capability-safe `waiting_input`;
  suppressed at ambiguous/nil-predicate `waiting_input`, and at
  `blocked`/`exited`/`terminated`/missing).
- `TestGuard_NudgeUrgentRespectsTUIStartupGate` — the carve-out does not widen
  past its one intended state.

`internal/lifecycle/manager_test.go`

- `TestPRObservation_MergeConflictReachesNeedsInputSession` — a `waiting_input`
  session on a blocked-signalling harness now gets the nudge; the same state on
  an ambiguous harness (codex-like) and a `blocked` session still do not.
- `TestPRObservation_NeedsInputSessionStillWithholdsOtherNudges` — regression
  guard: a needs-input session still gets **no** CI-failure or review-feedback
  nudge.
- `TestPRObservation_DeadSessionGetsNoNudgesOfAnyKind` — a terminated or exited
  session still gets nothing at all, conflict included.
- `TestPRObservation_ReArmClearsConflictWhileSessionExited`,
  `TestPRObservation_ReArmClearsConflictSurvivesTerminatedRestore` — the
  re-arm runs ahead of the dead-session return, so `conflicting → exit/terminate
  → mergeable → restore → conflicting` nudges again instead of being swallowed.
- `TestPRObservation_MergeConflictReArmsAfterConflictClears` — the
  `mergeable → conflicting (notify) → mergeable (re-arm) → conflicting (notify
  again)` cycle, for both re-arming states.
- `TestPRObservation_ConsecutiveMergeConflictsStayDeduplicated` — identical
  consecutive conflicts still nudge exactly once.
- `TestPRObservation_UnknownMergeabilityDoesNotReArm` — `unknown`, `blocked` and
  the unset zero value do not re-arm.
- `TestPRObservation_MergeConflictDedupSurvivesRestart` — both directions across
  a fresh `Manager` over the same store: an unchanged conflict stays quiet, a
  cleared one is free to nudge again.
- `TestPRObservation_ReArmLeavesOtherDedupEntriesIntact`,
  `TestPRObservation_ReArmSkipsStoreWriteWhenNothingArmed`,
  `TestPRObservation_ReArmStoreFailureSurfacesWithoutLosingNudges` — blast
  radius, write-avoidance, and the deferred-error contract.
- `TestPRObservation_ReArmRetriesAfterFailedPersist` — failed persist →
  recovered observation → restart → conflict still nudges.
- `TestPRObservation_ReArmStillNudgesInProcessAfterFailedPersist` — a conflict
  returning before the retry lands is not deduplicated away in-process.

`internal/daemon/wiring_test.go`

- `TestWiring_MergeConflictNudgeReArmsAfterConflictClears` — the same cycle end
  to end through the observer's `ApplySCMObservation` entrypoint over the real
  sqlite store, plus the restart. A fake store cannot prove the
  `pr.last_nudge_signature` round trip actually survives the real column.
- `TestWiring_UrgentNudgeGateComesFromAdapters` — the urgent-nudge gate resolved
  against the real agent registry is fail-closed: claude-code/kimchi open the
  `waiting_input` boundary; codex, Droid, the shared-hook harnesses
  (goose/devin), an unknown harness, and a nil resolver stay suppressed.

## Verification

- Both new behaviors were confirmed to fail without the change: disabling the
  re-arm branch fails `MergeConflictReArmsAfterConflictClears` (both subtests),
  `MergeConflictDedupSurvivesRestart/cleared_conflict_re-arms_across_restart`,
  and the daemon integration test, while every dedup/regression test keeps
  passing.
- `gofmt -l .`, `go build ./...`, `go vet ./...` clean from `backend/`.
- `go test ./internal/lifecycle/... ./internal/sessionguard/... ./internal/observe/... ./internal/daemon/` — all pass.
- `go test -race ./internal/lifecycle/... ./internal/sessionguard/... ./internal/daemon/` — all pass.

## Rebase note

The original commit was rebased onto current `main`, which had moved under it:
the CI block now goes through the per-PR `AutoInjectCI` policy with a deferred
`ciPolicyErr`, the merge-conflict block gained the `prBlockedByOpenParent` stack
check with a deferred `blockedCheckErr`, and `sessionguard` factored its
policies into `refuseDeliver`/`refuseNudge`. Original authorship is preserved on
the first commit. `NudgeUrgent` initially reused `refuseDeliver`; review
follow-up (section 3) replaced that with an explicit harness-aware
`waiting_input` gate.

