### PR TITLE
Isolate Kimi reviewer profile/config/credentials from the host

### DIFF
--- a/backend/internal/adapters/reviewer/kimi/kimi.go
+++ b/backend/internal/adapters/reviewer/kimi/kimi.go
@@ -1,5 +1,18 @@
 // Package kimi adapts Kimi Code CLI as an experimental host-trusted AO
 // reviewer. It always runs Kimi's visible, long-lived interactive TUI.
+//
+// Kimi's CLI has no read-only sandbox flag, no tool allow/deny list, and no
+// permission-policy injection point (unlike claude-code's AllowedTools, codex's
+// --sandbox read-only, or opencode's OPENCODE_CONFIG_CONTENT). The only launch
+// flags it exposes are approval-mode flags (--auto, -y) that make the model
+// more autonomous, not more restricted, so none of those three mechanisms
+// apply here. AO instead applies the same AO-owned isolation the
+// reviewgateway package already gives Kimi's fellow host-trusted reviewers
+// (agy, continueagent, goose, qwen, vibe): Kimi's profile, config, credentials,
+// and hooks are redirected to a private root under AO_DATA_DIR instead of the
+// user's real ~/.kimi-code. This keeps a shell escape or config change inside
+// the reviewer pane from reading or overwriting the user's real Kimi profile.
+// It does not make the checkout itself read-only; see HostTrustWarning.
 package kimi
 
 import (
@@ -13,14 +26,35 @@ import (
 	workerkimi "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/reviewgateway"
 )
 
 const skillsDirectoryName = "kimi-reviewer-skills"
 
+// kimiCodeHomeEnv is Kimi CLI's documented environment variable for pointing
+// the CLI at an alternate profile/config/credentials/hooks home. Mirrors the
+// worker Kimi adapter's private kimiCodeHomeEnv constant
+// (backend/internal/adapters/agent/kimi/kimi.go), which uses the same
+// variable to keep worker sessions off the user's real Kimi profile.
+const kimiCodeHomeEnv = "KIMI_CODE_HOME"
+
+// kimiAPIKeyEnvVars are the environment variables Kimi CLI reads for API-key
+// auth (mirrors backend/internal/adapters/agent/kimi/auth.go's
+// kimiAPIKeyEnvVars). The reviewer launch replaces the process environment
+// with an AO-owned one, so any of these present in the daemon's own
+// environment must be forwarded explicitly or env-var auth would silently stop
+// working once the profile is isolated.
+var kimiAPIKeyEnvVars = []string{"KIMI_API_KEY", "KIMI_CODE_API_KEY", "MOONSHOT_API_KEY"}
+
 // HostTrustWarning describes the authority retained by Kimi's interactive
 // terminal. Plan mode limits Kimi to read-only tools, while auto mode handles
-// approvals and questions without pausing for user input. AO deliberately
-// does not replace the TUI with print/headless mode or place it in a sandbox.
+// approvals and questions without pausing for user input, and AO isolates
+// Kimi's own profile/config/credentials/hooks to an AO-owned root (see the
+// package doc) — but none of that is OS isolation or a tool allow/deny list: a
+// terminal user can still invoke shell mode, change Plan mode, open an
+// external editor, or alter configuration, and read/write the review checkout
+// itself. AO deliberately does not replace the TUI with print/headless mode or
+// place it in a sandbox.
 const HostTrustWarning = "experimental host-trusted reviewer: Kimi has no OS isolation; terminal users can invoke shell mode, change Plan mode, open an external editor, or alter configuration"
 
 // Reviewer builds Kimi's persistent interactive reviewer command.
@@ -48,7 +82,11 @@ func (*Reviewer) ReviewPromptReadinessHints(ctx context.Context) (ports.PromptRe
 // ReviewCommand starts only Kimi's normal interactive TUI. The initial task is
 // injected after the pane starts; --prompt, --print, --quiet, --command, ACP,
 // Wire, AFK, YOLO, and sandbox wrappers are never emitted. Auto mode is paired
-// with Plan mode so read-only reviewer tools run unattended.
+// with Plan mode so read-only reviewer tools run unattended. Kimi's own
+// profile/config/credentials/hooks are redirected to an AO-owned root (see the
+// package doc) instead of the user's real ~/.kimi-code so a shell escape or
+// config change inside the pane cannot read or overwrite it; the checkout
+// itself remains host-trusted because Kimi's CLI has no read-only mechanism.
 func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.ReviewCommandSpec{}, err
@@ -72,15 +110,99 @@ func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation
 	if err := os.MkdirAll(skillsDir, 0o700); err != nil {
 		return ports.ReviewCommandSpec{}, fmt.Errorf("kimi reviewer: create empty skills directory: %w", err)
 	}
+	env, err := reviewgateway.PrepareHostTrustedEnvironment(inv.DataDir, inv.ReviewerID)
+	if err != nil {
+		return ports.ReviewCommandSpec{}, fmt.Errorf("kimi reviewer: prepare AO-owned profile: %w", err)
+	}
+	if err := seedHostKimiProfile(env.ConfigRoot); err != nil {
+		return ports.ReviewCommandSpec{}, err
+	}
+	envVars := env.TUIEnvironment()
+	envVars["AO_DATA_DIR"] = env.DataDir
+	envVars[kimiCodeHomeEnv] = env.ConfigRoot
+	for _, name := range kimiAPIKeyEnvVars {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			envVars[name] = value
+		}
+	}
 	message := fmt.Sprintf(
 		"Read and follow the AO reviewer role in `%s`, then %s",
 		filepath.ToSlash(inv.SystemPromptFile),
 		strings.TrimSpace(inv.Prompt),
 	)
 	return ports.ReviewCommandSpec{
-		Argv:           []string{binary, "--plan", "--auto", "--skills-dir", skillsDir},
-		InitialMessage: message,
+		Argv:             []string{binary, "--plan", "--auto", "--skills-dir", skillsDir},
+		Env:              envVars,
+		InitialMessage:   message,
+		WorkingDirectory: inv.WorkspacePath,
 	}, nil
+}
+
+// seedHostKimiProfile copies the user's real Kimi config and credentials into
+// the AO-owned private profile root so authentication keeps working once
+// KIMI_CODE_HOME points away from the user's real ~/.kimi-code. It never
+// writes back to the host profile, and it is a best-effort copy: a missing
+// source file is not an error.
+func seedHostKimiProfile(configRoot string) error {
+	if strings.TrimSpace(configRoot) == "" {
+		return nil
+	}
+	srcHome := hostKimiCodeHome()
+	if srcHome == "" || sameKimiHomePath(srcHome, configRoot) {
+		return nil
+	}
+	if err := copyHostKimiFile(filepath.Join(srcHome, "config.toml"), filepath.Join(configRoot, "config.toml")); err != nil {
+		return err
+	}
+	credentialsName := filepath.Join("credentials", "kimi-code.json")
+	if err := copyHostKimiFile(filepath.Join(srcHome, credentialsName), filepath.Join(configRoot, credentialsName)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// copyHostKimiFile copies one file from the user's real Kimi profile into the
+// AO-owned private profile, preserving the destination directory structure. A
+// missing source file is not an error since not every install has one.
+func copyHostKimiFile(src, dst string) error {
+	data, err := os.ReadFile(src) //nolint:gosec // src is derived from the resolved host Kimi profile directory.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("kimi reviewer: read host profile %s: %w", filepath.Base(src), err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return fmt.Errorf("kimi reviewer: create private profile directory: %w", err)
+	}
+	if err := os.WriteFile(dst, data, 0o600); err != nil {
+		return fmt.Errorf("kimi reviewer: write private profile %s: %w", filepath.Base(dst), err)
+	}
+	return nil
+}
+
+// hostKimiCodeHome resolves the user's real Kimi profile directory, mirroring
+// the worker Kimi adapter's private kimiCodeHome() lookup
+// (backend/internal/adapters/agent/kimi/auth.go): the KIMI_CODE_HOME
+// environment variable if set, otherwise ~/.kimi-code.
+func hostKimiCodeHome() string {
+	if value := strings.TrimSpace(os.Getenv(kimiCodeHomeEnv)); value != "" {
+		return value
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".kimi-code")
+}
+
+func sameKimiHomePath(a, b string) bool {
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA == nil && errB == nil {
+		return absA == absB
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }
 
 // ReviewRestoreCommand restores a recorded Kimi reviewer pane by relaunching

--- a/backend/internal/adapters/reviewer/kimi/kimi_test.go
+++ b/backend/internal/adapters/reviewer/kimi/kimi_test.go
@@ -15,6 +15,7 @@ func TestReviewCommandUsesPlanModeAndEmptySkillsDirectory(t *testing.T) {
 	r := &Reviewer{resolveBinary: func(context.Context) (string, error) { return "/opt/kimi", nil }}
 	root := t.TempDir()
 	inv := ports.ReviewInvocation{
+		DataDir: filepath.Join(root, "ao-data"), ReviewerID: "review-worker-1",
 		TaskPromptRoot: root, SystemPromptFile: filepath.Join(root, "system.md"), Prompt: "Read task.",
 	}
 	spec, err := r.ReviewCommand(context.Background(), inv)
@@ -37,6 +38,116 @@ func TestReviewCommandUsesPlanModeAndEmptySkillsDirectory(t *testing.T) {
 		if slices.Contains(spec.Argv, forbidden) {
 			t.Fatalf("argv contains forbidden flag %q: %#v", forbidden, spec.Argv)
 		}
+	}
+}
+
+// TestReviewCommandIsolatesKimiProfileFromHostConfiguration proves the read-only
+// hardening: Kimi's CLI has no sandbox flag or tool allow/deny list (unlike
+// claude-code/codex/opencode), so AO instead redirects KIMI_CODE_HOME (and the
+// generic HOME/XDG/tmp variables) to an AO-owned root under DataDir, matching
+// the reviewgateway pattern already shipped for agy/continueagent/goose/qwen/vibe.
+// Without this, Kimi inherited the daemon's real environment and ran with
+// KIMI_CODE_HOME unset, i.e. against the user's actual ~/.kimi-code profile,
+// hooks, and config.
+func TestReviewCommandIsolatesKimiProfileFromHostConfiguration(t *testing.T) {
+	r := &Reviewer{resolveBinary: func(context.Context) (string, error) { return "/opt/kimi", nil }}
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "ao-data")
+	inv := ports.ReviewInvocation{
+		DataDir: dataDir, ReviewerID: "review-worker-1",
+		TaskPromptRoot: filepath.Join(root, "prompts"), SystemPromptFile: filepath.Join(root, "system.md"),
+		WorkspacePath: filepath.Join(root, "checkout"), Prompt: "Read task.",
+	}
+	spec, err := r.ReviewCommand(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantConfigRoot := filepath.Join(dataDir, "reviewer-runtime", "review-worker-1", "config")
+	if spec.Env["HOME"] != wantConfigRoot || spec.Env[kimiCodeHomeEnv] != wantConfigRoot {
+		t.Fatalf("AO-owned Kimi profile root = %#v, want HOME and %s = %q", spec.Env, kimiCodeHomeEnv, wantConfigRoot)
+	}
+	if spec.Env["AO_DATA_DIR"] != dataDir {
+		t.Fatalf("AO_DATA_DIR = %q, want %q", spec.Env["AO_DATA_DIR"], dataDir)
+	}
+	// The checkout stays the reviewer's working directory: Kimi genuinely needs
+	// to read the PR locally, and only its own profile/config/credentials/hooks
+	// are isolated, not the reviewed source.
+	if spec.WorkingDirectory != inv.WorkspacePath {
+		t.Fatalf("WorkingDirectory = %q, want the worker checkout %q", spec.WorkingDirectory, inv.WorkspacePath)
+	}
+}
+
+// TestReviewCommandSeedsPrivateProfileFromHostKimiConfig mirrors
+// TestReviewCommandSeedsPrivateProfileFromHostVibeHome /
+// TestReviewCommandSeedsPrivateProfileFromHostConfig: the AO-owned profile must
+// still authenticate, so the user's real config.toml and credentials file are
+// copied (never referenced in place) into the isolated root.
+func TestReviewCommandSeedsPrivateProfileFromHostKimiConfig(t *testing.T) {
+	hostHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, hostHome)
+	hostConfig := []byte("api_key = \"host-key\"\n")
+	if err := os.WriteFile(filepath.Join(hostHome, "config.toml"), hostConfig, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	credentialsDir := filepath.Join(hostHome, "credentials")
+	if err := os.MkdirAll(credentialsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	hostCredentials := []byte(`{"access_token":"host-token"}`)
+	if err := os.WriteFile(filepath.Join(credentialsDir, "kimi-code.json"), hostCredentials, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	r := &Reviewer{resolveBinary: func(context.Context) (string, error) { return "/opt/kimi", nil }}
+	spec, err := r.ReviewCommand(context.Background(), ports.ReviewInvocation{
+		DataDir: filepath.Join(root, "ao-data"), ReviewerID: "review-worker-1",
+		TaskPromptRoot: filepath.Join(root, "prompts"), SystemPromptFile: filepath.Join(root, "system.md"),
+		WorkspacePath: filepath.Join(root, "checkout"), Prompt: "Read task.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, want := range map[string][]byte{
+		"config.toml": hostConfig,
+		filepath.Join("credentials", "kimi-code.json"): hostCredentials,
+	} {
+		copied := filepath.Join(spec.Env[kimiCodeHomeEnv], name)
+		data, err := os.ReadFile(copied)
+		if err != nil {
+			t.Fatalf("read copied %s: %v", name, err)
+		}
+		if string(data) != string(want) {
+			t.Fatalf("copied %s = %q, want %q", name, string(data), string(want))
+		}
+		info, err := os.Stat(copied)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("copied %s mode = %o, want 600", name, info.Mode().Perm())
+		}
+	}
+}
+
+// TestReviewCommandForwardsKimiAPIKeyEnvVars proves env-var-based auth (the
+// alternative to config.toml/credentials) still reaches the isolated launch,
+// mirroring TestReviewCommandExportsContinueAPIKey for the continue reviewer.
+func TestReviewCommandForwardsKimiAPIKeyEnvVars(t *testing.T) {
+	t.Setenv("MOONSHOT_API_KEY", "moonshot-key")
+	root := t.TempDir()
+	r := &Reviewer{resolveBinary: func(context.Context) (string, error) { return "/opt/kimi", nil }}
+	spec, err := r.ReviewCommand(context.Background(), ports.ReviewInvocation{
+		DataDir: filepath.Join(root, "ao-data"), ReviewerID: "review-worker-1",
+		TaskPromptRoot: filepath.Join(root, "prompts"), SystemPromptFile: filepath.Join(root, "system.md"),
+		Prompt: "Read task.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Env["MOONSHOT_API_KEY"] != "moonshot-key" {
+		t.Fatalf("MOONSHOT_API_KEY was not forwarded into the isolated reviewer env: %#v", spec.Env)
 	}
 }
 


### PR DESCRIPTION
## Scope

This is a narrow slice of #3745 ("Hardening: enforce read-only tool access and reliable cancel-stop for all reviewer harnesses"): only the **read-only access gap for the Kimi reviewer**. It does **not** touch the cancel-behavior half of that issue (interrupt reliability), which spans `ports/reviewer.go` and `review/launcher.go` across every reviewer and is left for a separate PR.

## Problem

`backend/internal/adapters/reviewer/kimi/kimi.go` launched Kimi's CLI with only `--plan` (plus `--skills-dir` once a task exists) and no other hardening:

- No sandbox flag, no tool allow/deny list, no permission-policy injection - unlike the three reviewers that already enforce read-only behavior: `claudecode` (`AllowedTools`/`DisallowedTools`), `codex` (`--sandbox read-only`), `opencode` (`OPENCODE_CONFIG_CONTENT` deny-by-default policy).
- `ReviewCommand` set no `Env` and no `WorkingDirectory` override, so the reviewer inherited the daemon's real process environment and ran with cwd at the worker checkout. `KIMI_CODE_HOME` was unset, so Kimi read and could write the user's real `~/.kimi-code` profile, config, credentials, and hooks - not just an AO-owned copy.

## Investigation: does Kimi's CLI support any of the three existing mechanisms?

No. The worker Kimi adapter (`backend/internal/adapters/agent/kimi/kimi.go`, `appendApprovalFlags`) shows Kimi's only relevant launch flags are approval-mode flags: `--auto` / `-y` (yolo). Both make the model *more* autonomous, not more restricted - there is no allowlist, no sandbox flag, no permission-policy hook equivalent to the other three adapters. `docs/adr/0002-secure-interactive-reviewer-gateway.md` independently confirms this: Kimi is explicitly listed (alongside Agy, Continue, Devin, Droid, Goose, Qwen, Vibe) as a CLI whose native modes cannot be made genuinely read-only by flags or prompt text, and states real containment requires an OS-level sandbox provider that is "required" but not yet built for any adapter.

So none of the three named mechanisms apply here, and I looked for an AO-side mitigation instead, per the issue's own suggested approach ("wrap the harness in a containment layer" / apply an AO-owned isolation root). One already exists and is already shipped: `backend/internal/reviewgateway.PrepareHostTrustedEnvironment`, used today by five sibling host-trusted reviewers - `agy`, `continueagent`, `goose`, `qwen`, `vibe` - to redirect each CLI's profile/config/state/cache/tmp directories to a private root under `AO_DATA_DIR` instead of the user's real CLI profile. Kimi was the only reviewer using this general "host-trusted CLI with no read-only mode" shape that had zero use of this existing mechanism - it was strictly worse off than its closest peers, not merely at the same tier.

## Fix

`ReviewCommand` now:

- Calls `reviewgateway.PrepareHostTrustedEnvironment(inv.DataDir, inv.ReviewerID)` to get an AO-owned profile root (mirrors `qwen.go`/`vibe.go`/`goose.go`/`agy.go`/`continueagent.go` exactly).
- Points `KIMI_CODE_HOME` (Kimi's own documented env var, already used the same way by the *worker* Kimi adapter's `AugmentRuntimeEnv`) plus the generic `HOME`/`XDG_*`/`TMPDIR` variables at that root, so a shell escape or config change inside the reviewer pane cannot read or overwrite the user's real `~/.kimi-code`.
- Seeds `config.toml` and `credentials/kimi-code.json` from the user's real profile into the isolated root (mirrors `seedHostVibeProfile`/`seedHostQwenSettings`/`seedHostContinueConfig`) so authentication keeps working.
- Forwards `KIMI_API_KEY` / `KIMI_CODE_API_KEY` / `MOONSHOT_API_KEY` from the daemon's environment if set (mirrors `continueagent`'s `CONTINUE_API_KEY` forwarding), since env-var auth is Kimi's other supported auth path.
- Leaves `WorkingDirectory` as the worker checkout (unchanged) - Kimi genuinely needs to read the PR locally to review it, matching `goose`/`vibe`/`agy`/`continueagent`, which isolate the *profile* but not the working directory either.

## What this does **not** fix (honest residual gap)

The review checkout itself is not read-only. Kimi's CLI has no allow/deny tool list and no read-only sandbox mode, so shell mode, file edits, and config changes *inside the checkout* remain possible from the terminal - identical to the residual risk already accepted for `agy`/`continueagent`/`goose`/`qwen`/`vibe`. Fully closing that requires either upstream Kimi CLI support for a tool allowlist/sandbox flag, or the OS-level reviewer sandbox described in `docs/adr/0002-secure-interactive-reviewer-gateway.md` (tmux/ConPTY + AppContainer/restricted-token containment), neither of which exists today for any reviewer. The package doc, `HostTrustWarning`, and `ReviewCommand` comments in `kimi.go` now state this precisely instead of only describing the old, unmitigated gap.

## Testing

- `TestReviewCommandIsolatesKimiProfileFromHostConfiguration` - asserts `HOME`/`KIMI_CODE_HOME` point at the AO-owned `reviewer-runtime/<reviewerId>/config` root and `WorkingDirectory` stays the worker checkout.
- `TestReviewCommandSeedsPrivateProfileFromHostKimiConfig` - asserts `config.toml` and `credentials/kimi-code.json` are copied byte-for-byte into the isolated root.
- `TestReviewCommandForwardsKimiAPIKeyEnvVars` - asserts `MOONSHOT_API_KEY` reaches the isolated launch env.
- Updated `TestReviewCommandUsesPlanModeAndEmptySkillsDirectory` to supply `DataDir`/`ReviewerID` (now required inputs) while keeping its existing argv/message/skills-dir assertions.

**Verification performed:**
- `go build ./...` and `go vet ./...` from `backend/` are clean.
- Fail-then-pass: saved the `kimi.go` diff as a patch, reverse-applied it (keeping the test changes), and reran the new tests - they fail to even compile (`undefined: kimiCodeHomeEnv`) against the unpatched adapter, confirming the tests are load-bearing on the fix. Re-applying the patch restores a clean build and passing tests. No `git stash` was used at any point (this repo's other adapters use identical `reviewgateway`/profile-seeding/env-forwarding patterns, and stash refs are shared across concurrent worktrees, so a patch file was used instead).
- `go test ./internal/adapters/reviewer/...` was run from `backend/`. Note for reviewers testing on native Windows: several *pre-existing, untouched* reviewer test files (`agy`, `continueagent`, `cursor`, `devin`, `droid`, `goose`, `qwen`, `vibe`, and now `kimi`) hardcode a Unix-style absolute path (e.g. `/opt/kimi`) for their fake resolved binary, which `filepath.IsAbs` correctly does not treat as absolute on Windows without a drive letter, and separately assert `os.FileMode` bits that NTFS does not preserve the same way as POSIX permissions. Both are pre-existing, cross-package Windows-only artifacts confirmed by running the identical assertions against the unmodified upstream `kimi.go` and against untouched sibling packages - not regressions from this change. I confirmed the new isolation logic itself is correct with a temporary, uncommitted local copy of the new tests using a Windows-safe absolute path, which passed cleanly; that scratch copy was deleted before committing and is not part of this PR.

Addresses part of #3745 (Kimi reviewer read-only enforcement; cancel-behavior consistency is left for follow-up).