### PR TITLE
fix: attribute worker sessions to the orchestrator that spawned them

### DIFF
--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -45,6 +45,12 @@ type spawnRequest struct {
 	Branch      string `json:"branch,omitempty"`
 	Prompt      string `json:"prompt,omitempty"`
 	DisplayName string `json:"displayName"`
+	// ParentOrchestratorID carries the caller's own AO_SESSION_ID so the daemon
+	// can attribute this spawn to its orchestrator when `ao spawn` runs from
+	// inside an orchestrator's own agent process. The daemon verifies the id
+	// actually names a live orchestrator session before recording it; it is
+	// empty (and ignored) for a plain user/CLI spawn run outside any session.
+	ParentOrchestratorID string `json:"parentOrchestratorId,omitempty"`
 }
 
 type spawnResult struct {
@@ -126,14 +132,15 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 				}
 			}
 			req := spawnRequest{
-				ProjectID:   opts.project,
-				IssueID:     opts.issue,
-				Kind:        opts.kind,
-				Harness:     opts.harness,
-				Mode:        opts.mode,
-				Branch:      opts.branch,
-				Prompt:      opts.prompt,
-				DisplayName: name,
+				ProjectID:            opts.project,
+				IssueID:              opts.issue,
+				Kind:                 opts.kind,
+				Harness:              opts.harness,
+				Mode:                 opts.mode,
+				Branch:               opts.branch,
+				Prompt:               opts.prompt,
+				DisplayName:          name,
+				ParentOrchestratorID: strings.TrimSpace(os.Getenv("AO_SESSION_ID")),
 			}
 			var res spawnResult
 			if err := ctx.postJSON(cmd.Context(), "sessions", req, &res); err != nil {

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -66,11 +66,19 @@ type SessionMetadata struct {
 // facts: identity, agent harness, activity_state, is_terminated, and operational
 // metadata. The user-facing Status is derived from these facts plus PR facts.
 type SessionRecord struct {
-	ID        SessionID    `json:"id"`
-	ProjectID ProjectID    `json:"projectId"`
-	IssueID   IssueID      `json:"issueId,omitempty"`
-	Kind      SessionKind  `json:"kind"`
-	Harness   AgentHarness `json:"harness,omitempty"`
+	ID        SessionID `json:"id"`
+	ProjectID ProjectID `json:"projectId"`
+	IssueID   IssueID   `json:"issueId,omitempty"`
+	// ParentOrchestratorID is the orchestrator session that spawned this
+	// session, captured at spawn time. It is set only when the spawn request
+	// came from an orchestrator's own agent process (identified via the
+	// caller's AO_SESSION_ID) that the session service verified was an active
+	// orchestrator session at spawn time; empty for sessions spawned directly
+	// by the user/CLI outside any orchestrator context, or spawned before this
+	// field existed. Immutable after creation: no UPDATE statement changes it.
+	ParentOrchestratorID SessionID    `json:"parentOrchestratorId,omitempty"`
+	Kind                 SessionKind  `json:"kind"`
+	Harness              AgentHarness `json:"harness,omitempty"`
 	// ReviewerHarness is this session's preferred reviewer. Empty delegates to
 	// the project configuration.
 	ReviewerHarness ReviewerHarness `json:"reviewerHarness,omitempty" enum:"claude-code,codex,copilot,cursor,kilocode,opencode,kiro,pi,qwen,agy,continue,goose,vibe,devin,droid,kimi,kimchi,muse,amp,aider,grok,crush,auggie,cline,autohand"`

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -4564,6 +4564,8 @@ components:
           - chat
           - tui
           type: string
+        parentOrchestratorId:
+          type: string
         pinnedAt:
           format: date-time
           type:
@@ -7012,6 +7014,8 @@ components:
           enum:
           - chat
           - tui
+          type: string
+        parentOrchestratorId:
           type: string
         projectId:
           type: string

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -172,6 +172,13 @@ type SpawnSessionRequest struct {
 	// `ao spawn --name` always sets it; other clients (e.g. the desktop new-task
 	// dialog) may omit it and fall back to the session id in the read model.
 	DisplayName string `json:"displayName,omitempty" maxLength:"20"`
+	// ParentOrchestratorID is the orchestrator session id that requested this
+	// spawn, when known. `ao spawn` sends the caller's AO_SESSION_ID here, which
+	// only names an orchestrator when the spawn was run from inside that
+	// orchestrator's own agent process. The daemon verifies this actually names
+	// a live orchestrator session before persisting it as the new session's
+	// parent; an absent, unknown, or non-orchestrator id is silently ignored.
+	ParentOrchestratorID domain.SessionID `json:"parentOrchestratorId,omitempty"`
 	// Attachments are files pasted or dropped into the task brief. Each carries
 	// its bytes as standard base64 (no data: URL prefix). The daemon writes them
 	// into the session worktree and appends path references to the prompt.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -239,7 +239,7 @@ func (c *SessionsController) spawn(w http.ResponseWriter, r *http.Request) {
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", attachErr.code, attachErr.message, nil)
 		return
 	}
-	sess, promptBytes, systemPromptBytes, err := c.Svc.Spawn(r.Context(), ports.SpawnConfig{ProjectID: in.ProjectID, IssueID: in.IssueID, Kind: in.Kind, Harness: in.Harness, Branch: in.Branch, RequestedMode: in.Mode, Prompt: in.Prompt, DisplayName: displayName, Attachments: attachments})
+	sess, promptBytes, systemPromptBytes, err := c.Svc.Spawn(r.Context(), ports.SpawnConfig{ProjectID: in.ProjectID, IssueID: in.IssueID, ParentOrchestratorID: in.ParentOrchestratorID, Kind: in.Kind, Harness: in.Harness, Branch: in.Branch, RequestedMode: in.Mode, Prompt: in.Prompt, DisplayName: displayName, Attachments: attachments})
 	if err != nil {
 		envelope.WriteError(w, r, err)
 		return

--- a/backend/internal/ports/session.go
+++ b/backend/internal/ports/session.go
@@ -21,6 +21,13 @@ type SpawnConfig struct {
 	Harness      domain.AgentHarness
 	Branch       string
 	Prompt       string
+	// ParentOrchestratorID is the caller-supplied orchestrator session id, sent
+	// when the spawn request came from an orchestrator's own agent process (via
+	// its AO_SESSION_ID). The session service verifies it names a real,
+	// currently known orchestrator session before persisting it onto the new
+	// session's ParentOrchestratorID; an absent, unknown, or non-orchestrator id
+	// is silently dropped rather than failing the spawn.
+	ParentOrchestratorID domain.SessionID
 	// AgentConfig overrides the resolved project/role agent config for this
 	// single spawn. Empty fields keep the project defaults.
 	AgentConfig AgentConfig

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -239,6 +239,7 @@ func (s *Service) spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.Session{}, 0, 0, fmt.Errorf("count sessions: %w", err)
 	}
 	cfg = s.withIssueContext(ctx, cfg, project)
+	cfg.ParentOrchestratorID = s.resolveParentOrchestratorID(ctx, cfg.ParentOrchestratorID)
 	rec, promptBytes, systemPromptBytes, err := s.manager.Spawn(ctx, cfg)
 	if err != nil {
 		s.emitSpawnFailed(cfg, err, s.now().Sub(start).Milliseconds())
@@ -253,6 +254,27 @@ func (s *Service) spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.Session{}, 0, 0, err
 	}
 	return sess, promptBytes, systemPromptBytes, nil
+}
+
+// resolveParentOrchestratorID verifies a caller-supplied parent-orchestrator
+// candidate before it can be persisted onto a spawned session's
+// ParentOrchestratorID. `ao spawn` sends the caller's AO_SESSION_ID, which is
+// only ever an orchestrator's id when the spawn request originated from that
+// orchestrator's own agent process (running `ao spawn` from inside its own
+// session) — see issue #1211's "no parent tracking" gap. A blank candidate, an
+// unknown session, or a session that is not an orchestrator all resolve to "",
+// so a worker spawned directly by the user/CLI never gets a parent attributed
+// to it.
+func (s *Service) resolveParentOrchestratorID(ctx context.Context, candidate domain.SessionID) domain.SessionID {
+	candidate = domain.SessionID(strings.TrimSpace(string(candidate)))
+	if candidate == "" || s.store == nil {
+		return ""
+	}
+	rec, ok, err := s.store.GetSession(ctx, candidate)
+	if err != nil || !ok || rec.Kind != domain.KindOrchestrator {
+		return ""
+	}
+	return candidate
 }
 
 // requireProject verifies the project is registered before any spawn write

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -1535,6 +1535,73 @@ func TestSpawnIssueContextSkipsUnresolvableIssueRef(t *testing.T) {
 	}
 }
 
+// TestSpawnParentOrchestratorIDAttribution is the service-layer half of the
+// #1211 fix: cfg.ParentOrchestratorID (the caller's AO_SESSION_ID, sent by
+// `ao spawn` when it runs from inside an orchestrator's own agent process)
+// must only reach the write path when it actually names a live orchestrator
+// session in the store — never for a worker's own AO_SESSION_ID, an unknown
+// id, or a plain user/CLI spawn that supplied none at all.
+func TestSpawnParentOrchestratorIDAttribution(t *testing.T) {
+	newSvc := func() (*Service, *fakeStore, *fakeCommander) {
+		st := newFakeStore()
+		st.projects["mer"] = domain.ProjectRecord{ID: "mer"}
+		fc := &fakeCommander{}
+		return &Service{manager: fc, store: st}, st, fc
+	}
+
+	t.Run("attributes the orchestrator that requested the spawn", func(t *testing.T) {
+		svc, st, fc := newSvc()
+		st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator}
+
+		if _, _, _, err := svc.Spawn(context.Background(), ports.SpawnConfig{
+			ProjectID: "mer", Kind: domain.KindWorker, ParentOrchestratorID: "mer-orch",
+		}); err != nil {
+			t.Fatalf("Spawn: %v", err)
+		}
+		if fc.spawnedCfg.ParentOrchestratorID != "mer-orch" {
+			t.Fatalf("spawnedCfg.ParentOrchestratorID = %q, want mer-orch", fc.spawnedCfg.ParentOrchestratorID)
+		}
+	})
+
+	t.Run("drops a candidate that is not an orchestrator session", func(t *testing.T) {
+		svc, st, fc := newSvc()
+		st.sessions["mer-worker"] = domain.SessionRecord{ID: "mer-worker", ProjectID: "mer", Kind: domain.KindWorker}
+
+		if _, _, _, err := svc.Spawn(context.Background(), ports.SpawnConfig{
+			ProjectID: "mer", Kind: domain.KindWorker, ParentOrchestratorID: "mer-worker",
+		}); err != nil {
+			t.Fatalf("Spawn: %v", err)
+		}
+		if fc.spawnedCfg.ParentOrchestratorID != "" {
+			t.Fatalf("spawnedCfg.ParentOrchestratorID = %q, want empty for a non-orchestrator candidate", fc.spawnedCfg.ParentOrchestratorID)
+		}
+	})
+
+	t.Run("drops an unknown candidate id", func(t *testing.T) {
+		svc, _, fc := newSvc()
+
+		if _, _, _, err := svc.Spawn(context.Background(), ports.SpawnConfig{
+			ProjectID: "mer", Kind: domain.KindWorker, ParentOrchestratorID: "ghost",
+		}); err != nil {
+			t.Fatalf("Spawn: %v", err)
+		}
+		if fc.spawnedCfg.ParentOrchestratorID != "" {
+			t.Fatalf("spawnedCfg.ParentOrchestratorID = %q, want empty for an unknown candidate", fc.spawnedCfg.ParentOrchestratorID)
+		}
+	})
+
+	t.Run("leaves it empty for a direct user/CLI spawn", func(t *testing.T) {
+		svc, _, fc := newSvc()
+
+		if _, _, _, err := svc.Spawn(context.Background(), ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+			t.Fatalf("Spawn: %v", err)
+		}
+		if fc.spawnedCfg.ParentOrchestratorID != "" {
+			t.Fatalf("spawnedCfg.ParentOrchestratorID = %q, want empty when the spawn request supplied none", fc.spawnedCfg.ParentOrchestratorID)
+		}
+	})
+}
+
 func TestSpawnFailedEmitsDuration(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer"}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2689,14 +2689,15 @@ func (m *Manager) cleanupRecords(ctx context.Context, project domain.ProjectID) 
 
 func seedRecord(cfg ports.SpawnConfig, now time.Time) domain.SessionRecord {
 	return domain.SessionRecord{
-		ProjectID:   cfg.ProjectID,
-		IssueID:     cfg.IssueID,
-		Kind:        cfg.Kind,
-		CreatedAt:   now,
-		UpdatedAt:   now,
-		Harness:     cfg.Harness,
-		DisplayName: cfg.DisplayName,
-		Activity:    domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
+		ProjectID:            cfg.ProjectID,
+		IssueID:              cfg.IssueID,
+		ParentOrchestratorID: cfg.ParentOrchestratorID,
+		Kind:                 cfg.Kind,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+		Harness:              cfg.Harness,
+		DisplayName:          cfg.DisplayName,
+		Activity:             domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
 		// Resolved before this point and persisted here. There is no UPDATE
 		// statement that can change it afterwards.
 		Mode:             domain.NormalizeSessionMode(cfg.RequestedMode),

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -328,6 +328,7 @@ type Session struct {
 	ControllerGeneration      string
 	BrowserCapabilityVerifier string
 	AutoInjectReview          bool
+	ParentOrchestratorID      domain.SessionID
 }
 
 type SessionCleanupFact struct {

--- a/backend/internal/storage/sqlite/gen/sessions.sql.go
+++ b/backend/internal/storage/sqlite/gen/sessions.sql.go
@@ -81,7 +81,7 @@ func (q *Queries) CommitSessionControllerEpoch(ctx context.Context, arg CommitSe
 }
 
 const getSession = `-- name: GetSession :one
-SELECT id, project_id, num, issue_id, kind, harness,
+SELECT id, project_id, num, issue_id, parent_orchestrator_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
     runtime_handle_id, agent_session_id, prompt,
     created_at, updated_at, display_name, first_signal_at, preview_url,
@@ -97,6 +97,7 @@ type GetSessionRow struct {
 	ProjectID                 domain.ProjectID
 	Num                       int64
 	IssueID                   domain.IssueID
+	ParentOrchestratorID      domain.SessionID
 	Kind                      domain.SessionKind
 	Harness                   domain.AgentHarness
 	ActivityState             domain.ActivityState
@@ -137,6 +138,7 @@ func (q *Queries) GetSession(ctx context.Context, id domain.SessionID) (GetSessi
 		&i.ProjectID,
 		&i.Num,
 		&i.IssueID,
+		&i.ParentOrchestratorID,
 		&i.Kind,
 		&i.Harness,
 		&i.ActivityState,
@@ -173,7 +175,7 @@ func (q *Queries) GetSession(ctx context.Context, id domain.SessionID) (GetSessi
 
 const insertSession = `-- name: InsertSession :exec
 INSERT INTO sessions (
-    id, project_id, num, issue_id, kind, harness, reviewer_harness, display_name,
+    id, project_id, num, issue_id, parent_orchestrator_id, kind, harness, reviewer_harness, display_name,
     activity_state, activity_last_at, first_signal_at, is_terminated,
     branch, workspace_path, workspace_repo_path, diff_base_sha, diff_base_ref, runtime_handle_id,
     runtime_launch_id, agent_session_id, prompt,
@@ -184,7 +186,7 @@ INSERT INTO sessions (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-    ?, ?, ?, ?
+    ?, ?, ?, ?, ?
 )
 `
 
@@ -193,6 +195,7 @@ type InsertSessionParams struct {
 	ProjectID                 domain.ProjectID
 	Num                       int64
 	IssueID                   domain.IssueID
+	ParentOrchestratorID      domain.SessionID
 	Kind                      domain.SessionKind
 	Harness                   domain.AgentHarness
 	ReviewerHarness           domain.ReviewerHarness
@@ -231,6 +234,7 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) er
 		arg.ProjectID,
 		arg.Num,
 		arg.IssueID,
+		arg.ParentOrchestratorID,
 		arg.Kind,
 		arg.Harness,
 		arg.ReviewerHarness,
@@ -266,7 +270,7 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) er
 }
 
 const listAllSessions = `-- name: ListAllSessions :many
-SELECT id, project_id, num, issue_id, kind, harness,
+SELECT id, project_id, num, issue_id, parent_orchestrator_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
     runtime_handle_id, agent_session_id, prompt,
     created_at, updated_at, display_name, first_signal_at, preview_url,
@@ -282,6 +286,7 @@ type ListAllSessionsRow struct {
 	ProjectID                 domain.ProjectID
 	Num                       int64
 	IssueID                   domain.IssueID
+	ParentOrchestratorID      domain.SessionID
 	Kind                      domain.SessionKind
 	Harness                   domain.AgentHarness
 	ActivityState             domain.ActivityState
@@ -328,6 +333,7 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]ListAllSessionsRow, er
 			&i.ProjectID,
 			&i.Num,
 			&i.IssueID,
+			&i.ParentOrchestratorID,
 			&i.Kind,
 			&i.Harness,
 			&i.ActivityState,
@@ -373,7 +379,7 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]ListAllSessionsRow, er
 }
 
 const listSessionsByProject = `-- name: ListSessionsByProject :many
-SELECT id, project_id, num, issue_id, kind, harness,
+SELECT id, project_id, num, issue_id, parent_orchestrator_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
     runtime_handle_id, agent_session_id, prompt,
     created_at, updated_at, display_name, first_signal_at, preview_url,
@@ -389,6 +395,7 @@ type ListSessionsByProjectRow struct {
 	ProjectID                 domain.ProjectID
 	Num                       int64
 	IssueID                   domain.IssueID
+	ParentOrchestratorID      domain.SessionID
 	Kind                      domain.SessionKind
 	Harness                   domain.AgentHarness
 	ActivityState             domain.ActivityState
@@ -435,6 +442,7 @@ func (q *Queries) ListSessionsByProject(ctx context.Context, projectID domain.Pr
 			&i.ProjectID,
 			&i.Num,
 			&i.IssueID,
+			&i.ParentOrchestratorID,
 			&i.Kind,
 			&i.Harness,
 			&i.ActivityState,

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -88,6 +88,7 @@ var shippedMigrations = map[int64]string{
 	82: "0082_allow_prime_agent_harness.sql",
 	83: "0083_reconcile_kimchi_prime_agent_harnesses.sql",
 	84: "0084_add_session_auto_inject_review.sql",
+	85: "0085_add_session_parent_orchestrator_id.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0085_add_session_parent_orchestrator_id.sql
+++ b/backend/internal/storage/sqlite/migrations/0085_add_session_parent_orchestrator_id.sql
@@ -1,0 +1,16 @@
+-- Persist which orchestrator session (if any) spawned a given session, so the
+-- desktop UI can link a worker's "Orchestrator" button to its actual parent
+-- instead of always guessing "the newest active orchestrator in the project"
+-- (issue #1211). Set once at spawn time by the session service; never updated
+-- afterwards, mirroring session_mode's immutable-after-spawn treatment below.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE sessions
+    ADD COLUMN parent_orchestrator_id TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE sessions DROP COLUMN parent_orchestrator_id;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/sessions.sql
+++ b/backend/internal/storage/sqlite/queries/sessions.sql
@@ -3,7 +3,7 @@ SELECT COALESCE(MAX(num), 0) + 1 AS next FROM sessions WHERE project_id = ?;
 
 -- name: InsertSession :exec
 INSERT INTO sessions (
-    id, project_id, num, issue_id, kind, harness, reviewer_harness, display_name,
+    id, project_id, num, issue_id, parent_orchestrator_id, kind, harness, reviewer_harness, display_name,
     activity_state, activity_last_at, first_signal_at, is_terminated,
     branch, workspace_path, workspace_repo_path, diff_base_sha, diff_base_ref, runtime_handle_id,
     runtime_launch_id, agent_session_id, prompt,
@@ -14,7 +14,7 @@ INSERT INTO sessions (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-    ?, ?, ?, ?
+    ?, ?, ?, ?, ?
 );
 
 -- name: UpdateSession :exec
@@ -55,7 +55,7 @@ SET session_mode = ?,
 WHERE id = ? AND session_mode = ? AND is_terminated = 0;
 
 -- name: GetSession :one
-SELECT id, project_id, num, issue_id, kind, harness,
+SELECT id, project_id, num, issue_id, parent_orchestrator_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
     runtime_handle_id, agent_session_id, prompt,
     created_at, updated_at, display_name, first_signal_at, preview_url,
@@ -66,7 +66,7 @@ SELECT id, project_id, num, issue_id, kind, harness,
 FROM sessions WHERE id = ?;
 
 -- name: ListSessionsByProject :many
-SELECT id, project_id, num, issue_id, kind, harness,
+SELECT id, project_id, num, issue_id, parent_orchestrator_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
     runtime_handle_id, agent_session_id, prompt,
     created_at, updated_at, display_name, first_signal_at, preview_url,
@@ -77,7 +77,7 @@ SELECT id, project_id, num, issue_id, kind, harness,
 FROM sessions WHERE project_id = ? ORDER BY num;
 
 -- name: ListAllSessions :many
-SELECT id, project_id, num, issue_id, kind, harness,
+SELECT id, project_id, num, issue_id, parent_orchestrator_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
     runtime_handle_id, agent_session_id, prompt,
     created_at, updated_at, display_name, first_signal_at, preview_url,

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -285,14 +285,15 @@ func mapListAllSessionsRows(rows []gen.ListAllSessionsRow) []domain.SessionRecor
 
 func rowToRecord(row gen.GetSessionRow) domain.SessionRecord {
 	return domain.SessionRecord{
-		ID:              row.ID,
-		ProjectID:       row.ProjectID,
-		IssueID:         row.IssueID,
-		Kind:            row.Kind,
-		Harness:         row.Harness,
-		ReviewerHarness: row.ReviewerHarness,
-		DisplayName:     row.DisplayName,
-		Mode:            domain.NormalizeSessionMode(row.SessionMode),
+		ID:                   row.ID,
+		ProjectID:            row.ProjectID,
+		IssueID:              row.IssueID,
+		ParentOrchestratorID: row.ParentOrchestratorID,
+		Kind:                 row.Kind,
+		Harness:              row.Harness,
+		ReviewerHarness:      row.ReviewerHarness,
+		DisplayName:          row.DisplayName,
+		Mode:                 domain.NormalizeSessionMode(row.SessionMode),
 		Activity: domain.Activity{
 			State:          row.ActivityState,
 			LastActivityAt: row.ActivityLastAt,
@@ -344,6 +345,7 @@ func recordToInsert(rec domain.SessionRecord, num int64) gen.InsertSessionParams
 		ProjectID:                 rec.ProjectID,
 		Num:                       num,
 		IssueID:                   rec.IssueID,
+		ParentOrchestratorID:      rec.ParentOrchestratorID,
 		Kind:                      rec.Kind,
 		Harness:                   rec.Harness,
 		ReviewerHarness:           rec.ReviewerHarness,

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -166,6 +166,72 @@ func TestSessionPersistsBrowserCapabilityVerifier(t *testing.T) {
 	}
 }
 
+// TestSessionPersistsParentOrchestratorID is the storage-layer half of the
+// #1211 fix: a worker session created with ParentOrchestratorID set must
+// persist and read back that id, a directly-spawned session must read back
+// empty, and an unrelated later UpdateSession must not touch the column
+// (mirrors session_mode's immutable-after-spawn treatment, added in the same
+// migration's Down/Up pair).
+func TestSessionPersistsParentOrchestratorID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+
+	orchestratorRec := sampleRecord("mer")
+	orchestratorRec.Kind = domain.KindOrchestrator
+	orchestrator, err := s.CreateSession(ctx, orchestratorRec)
+	if err != nil {
+		t.Fatalf("create orchestrator session: %v", err)
+	}
+
+	worker := sampleRecord("mer")
+	worker.ParentOrchestratorID = orchestrator.ID
+	created, err := s.CreateSession(ctx, worker)
+	if err != nil {
+		t.Fatalf("create worker session: %v", err)
+	}
+	if created.ParentOrchestratorID != orchestrator.ID {
+		t.Fatalf("created worker parentOrchestratorID = %q, want %q", created.ParentOrchestratorID, orchestrator.ID)
+	}
+
+	got, ok, err := s.GetSession(ctx, created.ID)
+	if err != nil || !ok {
+		t.Fatalf("get worker session: ok=%v err=%v", ok, err)
+	}
+	if got.ParentOrchestratorID != orchestrator.ID {
+		t.Fatalf("read-back worker parentOrchestratorID = %q, want %q", got.ParentOrchestratorID, orchestrator.ID)
+	}
+
+	// A directly-spawned session (no orchestrator parent) must not get one.
+	createdDirect, err := s.CreateSession(ctx, sampleRecord("mer"))
+	if err != nil {
+		t.Fatalf("create direct session: %v", err)
+	}
+	if createdDirect.ParentOrchestratorID != "" {
+		t.Fatalf("directly-spawned session parentOrchestratorID = %q, want empty", createdDirect.ParentOrchestratorID)
+	}
+	gotDirect, ok, err := s.GetSession(ctx, createdDirect.ID)
+	if err != nil || !ok {
+		t.Fatalf("get direct session: ok=%v err=%v", ok, err)
+	}
+	if gotDirect.ParentOrchestratorID != "" {
+		t.Fatalf("read-back direct session parentOrchestratorID = %q, want empty", gotDirect.ParentOrchestratorID)
+	}
+
+	// Immutable after creation: an unrelated UpdateSession must not clear it.
+	got.DisplayName = "renamed"
+	if err := s.UpdateSession(ctx, got); err != nil {
+		t.Fatalf("update worker session: %v", err)
+	}
+	afterUpdate, ok, err := s.GetSession(ctx, created.ID)
+	if err != nil || !ok {
+		t.Fatalf("get worker session after update: ok=%v err=%v", ok, err)
+	}
+	if afterUpdate.ParentOrchestratorID != orchestrator.ID {
+		t.Fatalf("parentOrchestratorID after unrelated update = %q, want %q", afterUpdate.ParentOrchestratorID, orchestrator.ID)
+	}
+}
+
 func TestProjectCRUDAndArchive(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/backend/sqlc.yaml
+++ b/backend/sqlc.yaml
@@ -100,6 +100,10 @@ sql:
             go_type:
               import: "github.com/aoagents/agent-orchestrator/backend/internal/domain"
               type: "IssueID"
+          - column: "sessions.parent_orchestrator_id"
+            go_type:
+              import: "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+              type: "SessionID"
           - column: "sessions.kind"
             go_type:
               import: "github.com/aoagents/agent-orchestrator/backend/internal/domain"

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1531,6 +1531,7 @@ export interface components {
             kind: string;
             /** @enum {string} */
             mode: "chat" | "tui";
+            parentOrchestratorId?: string;
             /** Format: date-time */
             pinnedAt?: null | string;
             /** Format: int64 */
@@ -2439,6 +2440,7 @@ export interface components {
             kind?: "worker" | "orchestrator";
             /** @enum {string} */
             mode?: "chat" | "tui";
+            parentOrchestratorId?: string;
             projectId: string;
             prompt?: string;
         };

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -6,9 +6,9 @@ import { useEffect, useState } from "react";
 import { animate, LayoutGroup, motion, useMotionValue, useReducedMotion } from "motion/react";
 import { NotificationCenter } from "./NotificationCenter";
 import {
-	findProjectOrchestrator,
 	hasConfiguredOrchestratorAgent,
 	isOrchestratorSession,
+	resolveSessionOrchestrator,
 	sessionIsActive,
 	type WorkspaceSession,
 } from "../types/workspace";
@@ -109,7 +109,10 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 	const isRootBoardRoute = !isSessionRoute && !isProjectBoardRoute;
 	const project = projectId ? all.find((workspace) => workspace.id === projectId) : undefined;
 	const projectLabel = project?.name ?? session?.workspaceName ?? (projectId ? "" : t("shell.board"));
-	const orchestrator = projectId ? findProjectOrchestrator(all, projectId) : undefined;
+	// Prefer this worker's recorded parent orchestrator over the project-wide
+	// recency heuristic: with 2+ concurrent orchestrators, the newest active one
+	// is not necessarily the one that spawned this session (issue #1211).
+	const orchestrator = projectId ? resolveSessionOrchestrator(all, projectId, session) : undefined;
 	const orchestratorActivityLabel = orchestrator ? getAgentActivityView(orchestrator.activity, t).label : undefined;
 	const isProjectRestarting = projectId ? restartingProjectIds.has(projectId) : false;
 

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -88,6 +88,7 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 						workspaceName: project.name,
 						title: session.displayName ?? session.issueId ?? session.id,
 						issueId: session.issueId,
+						parentOrchestratorId: session.parentOrchestratorId || undefined,
 						provider: toAgentProvider(session.harness),
 						reviewerHarness: toReviewerHarnessId(session.reviewerHarness),
 						kind: session.kind === "orchestrator" ? "orchestrator" : session.kind === "worker" ? "worker" : undefined,

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -5,6 +5,7 @@ import {
 	findProjectOrchestrator,
 	newestActiveOrchestrator,
 	orchestratorHealth,
+	resolveSessionOrchestrator,
 	sessionIsActive,
 	sessionNeedsAttention,
 	toAgentProvider,
@@ -189,6 +190,56 @@ describe("findProjectOrchestrator", () => {
 		});
 		expect(newestActiveOrchestrator([oldUpdate, newUpdate])).toBe(newUpdate);
 		expect(newestActiveOrchestrator([newUpdate, sameTimesHigherID])).toBe(sameTimesHigherID);
+	});
+});
+
+describe("resolveSessionOrchestrator", () => {
+	function workspaceWith(sessions: WorkspaceSession[]): WorkspaceSummary {
+		return { id: "skills", name: "skills", path: "/tmp/skills", sessions };
+	}
+
+	// Regression for #1211: with 2+ concurrent orchestrators, the newest active
+	// one is not necessarily the one that spawned a given worker. The button
+	// must follow the worker's recorded parent, not just "most recent."
+	it("prefers the worker's recorded parent over the newest active orchestrator", () => {
+		const older = sessionWith({ id: "skills-1", kind: "orchestrator", status: "working" });
+		const newer = sessionWith({ id: "skills-2", kind: "orchestrator", status: "working" });
+		const worker = sessionWith({ id: "skills-3", kind: "worker", status: "working", parentOrchestratorId: "skills-1" });
+		const workspaces = [workspaceWith([older, newer, worker])];
+
+		// The recency fallback alone would pick the newer orchestrator...
+		expect(findProjectOrchestrator(workspaces, "skills")).toBe(newer);
+		// ...but the worker actually belongs to the older one.
+		expect(resolveSessionOrchestrator(workspaces, "skills", worker)).toBe(older);
+	});
+
+	it("falls back to the recency heuristic when parentOrchestratorId is absent", () => {
+		const older = sessionWith({ id: "skills-1", kind: "orchestrator", status: "working" });
+		const newer = sessionWith({ id: "skills-2", kind: "orchestrator", status: "working" });
+		const worker = sessionWith({ id: "skills-3", kind: "worker", status: "working" });
+		const workspaces = [workspaceWith([older, newer, worker])];
+
+		expect(resolveSessionOrchestrator(workspaces, "skills", worker)).toBe(newer);
+	});
+
+	it("falls back to the recency heuristic when the recorded parent can't be found", () => {
+		const live = sessionWith({ id: "skills-2", kind: "orchestrator", status: "working" });
+		const worker = sessionWith({
+			id: "skills-3",
+			kind: "worker",
+			status: "working",
+			parentOrchestratorId: "skills-99",
+		});
+		const workspaces = [workspaceWith([live, worker])];
+
+		expect(resolveSessionOrchestrator(workspaces, "skills", worker)).toBe(live);
+	});
+
+	it("resolves without a session (e.g. board view) the same way findProjectOrchestrator does", () => {
+		const live = sessionWith({ id: "skills-2", kind: "orchestrator", status: "working" });
+		const workspaces = [workspaceWith([live])];
+
+		expect(resolveSessionOrchestrator(workspaces, "skills", undefined)).toBe(live);
 	});
 });
 

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -132,6 +132,16 @@ export type WorkspaceSession = {
 	title: string;
 	/** Raw issue/task identifier from the daemon. Intake ids are provider-prefixed. */
 	issueId?: string;
+	/**
+	 * The orchestrator session that spawned this session, when known. Set by the
+	 * daemon at spawn time only when the spawn request came from an
+	 * orchestrator's own agent process; absent for sessions spawned directly by
+	 * the user/CLI, or spawned before this field existed. Prefer this over
+	 * {@link findProjectOrchestrator}'s recency heuristic when resolving which
+	 * orchestrator a worker's "Orchestrator" button should link to — see
+	 * {@link resolveSessionOrchestrator}.
+	 */
+	parentOrchestratorId?: string;
 	provider: AgentProvider;
 	/** Reviewer selected for this session; absent means use the project default. */
 	reviewerHarness?: ReviewerHarnessId;
@@ -253,6 +263,31 @@ export function findProjectOrchestrator(
 ): WorkspaceSession | undefined {
 	const workspace = workspaces.find((w) => w.id === projectId);
 	return newestActiveOrchestrator(workspace?.sessions ?? []);
+}
+
+/**
+ * The orchestrator a worker session's "Orchestrator" button should link to.
+ * Prefers the session's recorded {@link WorkspaceSession.parentOrchestratorId}
+ * — the orchestrator that actually spawned it — resolved against the
+ * project's current session list. Falls back to
+ * {@link findProjectOrchestrator}'s recency heuristic when no parent is
+ * recorded (workers spawned before this field existed, or spawned directly
+ * without an orchestrator parent) or the recorded parent can no longer be
+ * found (e.g. cleaned up). This is what makes the button correct with 2+
+ * concurrent orchestrators in one project: the newest active orchestrator is
+ * not necessarily the one that spawned this particular worker.
+ */
+export function resolveSessionOrchestrator(
+	workspaces: WorkspaceSummary[],
+	projectId: string,
+	session?: WorkspaceSession,
+): WorkspaceSession | undefined {
+	if (session?.parentOrchestratorId) {
+		const workspace = workspaces.find((w) => w.id === projectId);
+		const parent = workspace?.sessions.find((s) => s.id === session.parentOrchestratorId);
+		if (parent) return parent;
+	}
+	return findProjectOrchestrator(workspaces, projectId);
 }
 
 export function newestActiveOrchestrator(sessions: WorkspaceSession[]): WorkspaceSession | undefined {


### PR DESCRIPTION
## Summary

Issue #1211 tracked two problems with the "Orchestrator" button on a worker session's page:

1. **Lexicographic-first fallback picking the wrong orchestrator** — already fixed on `main` (see the issue's own triage comment from 2026-07-28). `findProjectOrchestrator()` in `frontend/src/renderer/types/workspace.ts` sorts by recency, not lexicographically. **Not touched by this PR.**
2. **No parent tracking** — there was no `parentOrchestratorId` anywhere, so the button always fell back to "the newest active orchestrator in the project." That's usually right (the common case has exactly one orchestrator) but wrong whenever a project has 2+ concurrent orchestrators, since the newest-active one isn't necessarily the one that actually spawned a given worker. **This PR fixes that remaining gap.**

## What changed

- `backend/internal/domain/session.go` — `SessionRecord` gains `ParentOrchestratorID` (empty string means unset, matching the existing convention used for `IssueID` and other optional session identifiers).
- `backend/internal/ports/session.go` — `SpawnConfig` gains the same field, threaded from the HTTP request through the manager's `seedRecord`.
- `backend/internal/service/session/service.go` — `resolveParentOrchestratorID` verifies the caller-supplied id actually names a real, currently known **orchestrator** session before it is persisted. A worker's own id, an unknown id, or an absent one all resolve to empty, so a directly-spawned worker never gets a parent attributed to it.
- `backend/internal/cli/spawn.go` — `ao spawn` now sends the caller's own `AO_SESSION_ID` as `parentOrchestratorId`. This only names an orchestrator when `ao spawn` runs from inside an orchestrator's own agent process (its `AO_SESSION_ID` is its own session id); a spawn from a plain terminal has no `AO_SESSION_ID` at all, so nothing changes for direct spawns.
- `backend/internal/storage/sqlite/migrations/0085_add_session_parent_orchestrator_id.sql` — adds `sessions.parent_orchestrator_id` (`TEXT NOT NULL DEFAULT ''`), plus the matching `queries/sessions.sql` and regenerated `gen/` code (`npm run sqlc`). The column is immutable after spawn (excluded from `UpdateSession`'s SET clause), mirroring how `session_mode` is already treated.
- `frontend/src/renderer/types/workspace.ts` — new `resolveSessionOrchestrator()` prefers a session's `parentOrchestratorId` (resolved against the project's session list) and falls back to the existing `findProjectOrchestrator()` recency heuristic only when no parent is recorded, or the recorded parent can no longer be found. `findProjectOrchestrator()` itself is untouched.
- `frontend/src/renderer/components/ShellTopbar.tsx` — the "Orchestrator" button now resolves through `resolveSessionOrchestrator()`.
- `backend/internal/httpd/apispec/openapi.yaml` and `frontend/src/api/schema.ts` — regenerated via `npm run api` per the repo's API contract rule, committed together with the Go changes.

## Verification

- Backend: `go build ./...` and `go vet ./...` clean. New tests:
  - `TestSessionPersistsParentOrchestratorID` (`storage/sqlite/store`, real SQLite): a worker spawned with a parent id persists and reads it back; a directly-spawned session reads back empty; an unrelated `UpdateSession` call doesn't clear it.
  - `TestSpawnParentOrchestratorIDAttribution` (`service/session`): the service only forwards the candidate id to the write path when it resolves to a real orchestrator session in the store; it drops a non-orchestrator id, an unknown id, and an absent one.
  - Confirmed both **fail** against the pre-fix code (build failure for the missing field / empty read-back for the missing column) and **pass** with the fix restored, using a saved-and-reversed patch file (not `git stash`).
  - Full relevant suites pass: `domain`, `ports`, `service/session`, `httpd`, `httpd/controllers`, `httpd/apispec` (spec-drift test), `httpd/apispec/specgen`, `storage/sqlite` (migration ledger test), `storage/sqlite/store`, `cli`. Three pre-existing `session_manager` failures (Windows path-separator assertions) and one flaky `service/agent` catalog-staleness test reproduce identically on unmodified `main` and are unrelated to this change.
- Frontend: `npx tsc --noEmit` clean. New tests in `workspace.test.ts` (`resolveSessionOrchestrator`): prefers the recorded parent over the newest orchestrator, falls back to recency when `parentOrchestratorId` is absent, falls back when the recorded parent can't be found, and matches `findProjectOrchestrator` when no session is given — this is the actual regression the issue is about (2+ concurrent orchestrators, the worker's button must point at its real parent, not just "the newest one"). Confirmed fail/pass the same way as the backend. Full frontend suite passes except for pre-existing, unrelated failures (macOS packaging/signing tests, a landing-page script with an undeclared `node-html-markdown` dependency, and Electron main-process socket-reconnect timing) — none touch session/workspace/orchestrator code.

Addresses the remaining work in #1211.