### PR TITLE
fix(chat): enable Switch to Chat on new sessions before first prompt

### DIFF
--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -380,6 +380,15 @@ func (m *Manager) nativeConversationID(
 	}
 	id = strings.TrimSpace(id)
 	if !ok || id == "" {
+		// An adapter with a history probe can safely start fresh when the
+		// native id is missing: the probe distinguishes a real conversation
+		// from an empty TUI, and persistedNativeConversationID uses that to
+		// decide between resume and fresh start. Without a probe, a missing
+		// id is a hard block — there is no safe way to know whether the
+		// TUI's work would be lost.
+		if _, ok := handoff.(ports.AgentInterfaceHandoffHistoryProbe); ok {
+			return "", handoff, nil
+		}
 		return "", handoff, fmt.Errorf("%w for %s", ErrNativeConversationMissing, rec.Harness)
 	}
 	return id, handoff, nil

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -89,6 +89,7 @@ var shippedMigrations = map[int64]string{
 	83: "0083_reconcile_kimchi_prime_agent_harnesses.sql",
 	84: "0084_add_session_auto_inject_review.sql",
 	85: "0085_agent_switching.sql",
+	86: "0086_session_cdc_provider_conversation_id.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0086_session_cdc_provider_conversation_id.sql
+++ b/backend/internal/storage/sqlite/migrations/0086_session_cdc_provider_conversation_id.sql
@@ -1,0 +1,90 @@
+-- Add provider_conversation_id to the sessions_cdc_update WHEN guard that
+-- 0085_agent_switching established. The Chat driver writes this column
+-- independently of agent_session_id (chat_spawn.go: ControllerReady), so a
+-- write to it must fan out a session_updated event for the interface-transition
+-- query to refetch. Guard-only change: session_updated is an invalidation-only
+-- nudge (consumers refetch, see renderer/lib/event-transport.ts), so the
+-- payload stays as-is — matching the convention established by migration 0024.
+
+-- +goose Up
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.terminate_on_pr_merge <> NEW.terminate_on_pr_merge
+    OR OLD.is_pinned <> NEW.is_pinned
+    OR OLD.pinned_at <> NEW.pinned_at
+    OR (OLD.pinned_at IS NULL AND NEW.pinned_at IS NOT NULL)
+    OR (OLD.pinned_at IS NOT NULL AND NEW.pinned_at IS NULL)
+    OR OLD.session_mode <> NEW.session_mode
+    OR OLD.auto_inject_review <> NEW.auto_inject_review
+    OR OLD.harness <> NEW.harness
+    OR OLD.runtime_launch_id <> NEW.runtime_launch_id
+    OR OLD.agent_session_id <> NEW.agent_session_id
+    OR OLD.native_transcript_path <> NEW.native_transcript_path
+    OR OLD.provider_conversation_id <> NEW.provider_conversation_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object(
+            'id', NEW.id,
+            'activity', NEW.activity_state,
+            'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END),
+            'terminateOnPrMerge', json(CASE WHEN NEW.terminate_on_pr_merge THEN 'true' ELSE 'false' END),
+            'previewUrl', NEW.preview_url,
+            'previewRevision', NEW.preview_revision,
+            'isPinned', json(CASE WHEN NEW.is_pinned THEN 'true' ELSE 'false' END),
+            'mode', NEW.session_mode,
+            'autoInjectReview', json(CASE WHEN NEW.auto_inject_review THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- Restore the trigger 0085_agent_switching established (without
+-- provider_conversation_id in the guard).
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.terminate_on_pr_merge <> NEW.terminate_on_pr_merge
+    OR OLD.is_pinned <> NEW.is_pinned
+    OR OLD.pinned_at <> NEW.pinned_at
+    OR (OLD.pinned_at IS NULL AND NEW.pinned_at IS NOT NULL)
+    OR (OLD.pinned_at IS NOT NULL AND NEW.pinned_at IS NULL)
+    OR OLD.session_mode <> NEW.session_mode
+    OR OLD.auto_inject_review <> NEW.auto_inject_review
+    OR OLD.harness <> NEW.harness
+    OR OLD.runtime_launch_id <> NEW.runtime_launch_id
+    OR OLD.agent_session_id <> NEW.agent_session_id
+    OR OLD.native_transcript_path <> NEW.native_transcript_path
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object(
+            'id', NEW.id,
+            'activity', NEW.activity_state,
+            'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END),
+            'terminateOnPrMerge', json(CASE WHEN NEW.terminate_on_pr_merge THEN 'true' ELSE 'false' END),
+            'previewUrl', NEW.preview_url,
+            'previewRevision', NEW.preview_revision,
+            'isPinned', json(CASE WHEN NEW.is_pinned THEN 'true' ELSE 'false' END),
+            'mode', NEW.session_mode,
+            'autoInjectReview', json(CASE WHEN NEW.auto_inject_review THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -1402,3 +1402,88 @@ func TestUpsertSessionWorktreeEmptyStateDefaultsToActive(t *testing.T) {
 		t.Fatalf("State = %q, want %q", got.State, "active")
 	}
 }
+
+// Migration 0085 added agent_session_id and provider_conversation_id to the
+// sessions_cdc_update WHEN guard. A write to either column must emit exactly
+// one session_updated event; an unrelated metadata write must not.
+func TestSessionAgentSessionIDFiresCDCEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "cdc")
+	r, _ := s.CreateSession(ctx, sampleRecord("cdc"))
+
+	base, _ := s.LatestSeq(ctx)
+	r.Metadata.AgentSessionID = "native-thread-1"
+	r.UpdatedAt = r.UpdatedAt.Add(time.Minute)
+	if err := s.UpdateSession(ctx, r); err != nil {
+		t.Fatalf("update agent_session_id: %v", err)
+	}
+
+	evs, err := s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	for _, e := range evs {
+		if string(e.Type) == "session_updated" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("session_updated events = %d, want 1 after agent_session_id write", count)
+	}
+}
+
+func TestSessionProviderConversationIDFiresCDCEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "cdc2")
+	r, _ := s.CreateSession(ctx, sampleRecord("cdc2"))
+
+	base, _ := s.LatestSeq(ctx)
+	r.Metadata.ProviderConversationID = "provider-conv-1"
+	r.UpdatedAt = r.UpdatedAt.Add(time.Minute)
+	if err := s.UpdateSession(ctx, r); err != nil {
+		t.Fatalf("update provider_conversation_id: %v", err)
+	}
+
+	evs, err := s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	for _, e := range evs {
+		if string(e.Type) == "session_updated" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("session_updated events = %d, want 1 after provider_conversation_id write", count)
+	}
+}
+
+// An unrelated metadata write must not emit a session_updated event — the
+// CDC guard must not fire for columns outside its WHEN clause.
+func TestSessionUnrelatedMetadataSuppressesCDCEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "cdc3")
+	r, _ := s.CreateSession(ctx, sampleRecord("cdc3"))
+
+	base, _ := s.LatestSeq(ctx)
+	// Update with the same values so no guard column changes.
+	r.UpdatedAt = r.UpdatedAt.Add(time.Minute)
+	if err := s.UpdateSession(ctx, r); err != nil {
+		t.Fatalf("update no-op: %v", err)
+	}
+
+	evs, err := s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range evs {
+		if string(e.Type) == "session_updated" {
+			t.Fatalf("session_updated emitted for unrelated metadata write: %+v", e)
+		}
+	}
+}

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -1403,9 +1403,10 @@ func TestUpsertSessionWorktreeEmptyStateDefaultsToActive(t *testing.T) {
 	}
 }
 
-// Migration 0085 added agent_session_id and provider_conversation_id to the
-// sessions_cdc_update WHEN guard. A write to either column must emit exactly
-// one session_updated event; an unrelated metadata write must not.
+// Migration 0086 added provider_conversation_id to the sessions_cdc_update
+// WHEN guard that 0085_agent_switching established (which already included
+// agent_session_id). A write to either column must emit exactly one
+// session_updated event; an unrelated metadata write must not.
 func TestSessionAgentSessionIDFiresCDCEvent(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -50,7 +50,7 @@ class EventSourceStub {
 		this.handlers.set(type, listener);
 	}
 	emit(type: string, data: string) {
-		this.handlers.get(type)?.({ data } as unknown as Event);
+		this.handlers.get(type)?.({ data, type } as unknown as Event);
 	}
 	close() {
 		this.closed = true;
@@ -172,6 +172,58 @@ describe("createEventTransport", () => {
 			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ["workspaces"] });
 			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
 				queryKey: ["session-scm-summary"],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("invalidates the interface transition query on session_updated CDC", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"session_updated",
+				JSON.stringify({
+					seq: 1,
+					projectId: "proj-1",
+					sessionId: "sess-1",
+					type: "session_updated",
+					payload: { id: "sess-1", sessionId: "sess-1" },
+					createdAt: "2026-08-09T12:00:00Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+				queryKey: ["session-interface-transition", "sess-1"],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not invalidate the interface transition query on non-session events", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"pr_created",
+				JSON.stringify({
+					seq: 1,
+					projectId: "proj-1",
+					sessionId: "sess-1",
+					type: "pr_created",
+					payload: { id: "sess-1" },
+					createdAt: "2026-08-09T12:00:00Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+				queryKey: ["session-interface-transition", "sess-1"],
 			});
 		} finally {
 			vi.useRealTimers();

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -5,6 +5,7 @@ import { setEventsConnectionState } from "./events-connection";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { sessionScmSummaryQueryKey } from "../hooks/useSessionScmSummary";
 import { conversationQueryKey } from "../hooks/useConversation";
+import { sessionInterfaceTransitionQueryKey } from "../hooks/useSessionInterfaceTransition";
 import { sessionUsageQueryRoot } from "../hooks/useSessionUsageSummaries";
 
 export type EventTransport = {
@@ -47,6 +48,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 		connect() {
 			let debounce: ReturnType<typeof setTimeout> | undefined;
 			const pendingConversationSessions = new Set<string>();
+			const pendingTransitionSessions = new Set<string>();
 			let workspaceInvalidationPending = false;
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
@@ -54,30 +56,31 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 			const refreshWorkspaces = (event?: Event) => {
 				let conversationOnly = false;
 				if (event && "data" in event) {
-					try {
-						const decoded = JSON.parse(String((event as MessageEvent).data)) as {
-							sessionId?: unknown;
-							payload?: unknown;
-						};
-						// The SSE endpoint sends the complete durable CDC event. Routing
-						// fields such as sessionId live on that envelope, while trigger-built
-						// details such as conversationId live inside its payload. Do not
-						// mistake the payload for the entire event: doing so refreshes the
-						// sidebar but leaves a Chat timeline frozen on its pre-turn snapshot.
-						const payload =
-							typeof decoded.payload === "object" && decoded.payload !== null
-								? (decoded.payload as { conversationId?: unknown })
-								: undefined;
+				try {
+					const decoded = JSON.parse(String((event as MessageEvent).data)) as {
+						sessionId?: unknown;
+						payload?: unknown;
+					};
+					// The SSE endpoint sends the complete durable CDC event. Routing
+					// fields such as sessionId live on that envelope, while trigger-built
+					// details such as conversationId live inside its payload. Do not
+					// mistake the payload for the entire event: doing so refreshes the
+					// sidebar but leaves a Chat timeline frozen on its pre-turn snapshot.
+					const payload =
+						typeof decoded.payload === "object" && decoded.payload !== null
+							? (decoded.payload as { conversationId?: unknown })
+							: undefined;
+					if (typeof decoded.sessionId === "string" && decoded.sessionId) {
+						pendingTransitionSessions.add(decoded.sessionId);
 						if (
-							typeof decoded.sessionId === "string" &&
-							decoded.sessionId &&
 							typeof payload?.conversationId === "string" &&
 							payload.conversationId
 						) {
 							pendingConversationSessions.add(decoded.sessionId);
 							conversationOnly = true;
 						}
-					} catch {
+					}
+				} catch {
 						// A malformed CDC payload still invalidates workspaces; it simply
 						// cannot target a conversation cache precisely.
 					}
@@ -94,7 +97,11 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 					for (const sessionId of pendingConversationSessions) {
 						void queryClient.invalidateQueries({ queryKey: conversationQueryKey(sessionId) });
 					}
+					for (const sessionId of pendingTransitionSessions) {
+						void queryClient.invalidateQueries({ queryKey: sessionInterfaceTransitionQueryKey(sessionId) });
+					}
 					pendingConversationSessions.clear();
+					pendingTransitionSessions.clear();
 				}, INVALIDATE_DEBOUNCE_MS);
 			};
 

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -53,34 +53,44 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
 			let sourceBaseUrl: string | undefined;
-			const refreshWorkspaces = (event?: Event) => {
+			const scheduleCacheInvalidations = (event?: Event) => {
 				let conversationOnly = false;
 				if (event && "data" in event) {
-				try {
-					const decoded = JSON.parse(String((event as MessageEvent).data)) as {
-						sessionId?: unknown;
-						payload?: unknown;
-					};
-					// The SSE endpoint sends the complete durable CDC event. Routing
-					// fields such as sessionId live on that envelope, while trigger-built
-					// details such as conversationId live inside its payload. Do not
-					// mistake the payload for the entire event: doing so refreshes the
-					// sidebar but leaves a Chat timeline frozen on its pre-turn snapshot.
-					const payload =
-						typeof decoded.payload === "object" && decoded.payload !== null
-							? (decoded.payload as { conversationId?: unknown })
-							: undefined;
-					if (typeof decoded.sessionId === "string" && decoded.sessionId) {
-						pendingTransitionSessions.add(decoded.sessionId);
+					try {
+						const decoded = JSON.parse(String((event as MessageEvent).data)) as {
+							sessionId?: unknown;
+							payload?: unknown;
+						};
+						// The SSE endpoint sends the complete durable CDC event. Routing
+						// fields such as sessionId live on that envelope, while trigger-built
+						// details such as conversationId live inside its payload. Do not
+						// mistake the payload for the entire event: doing so refreshes the
+						// sidebar but leaves a Chat timeline frozen on its pre-turn snapshot.
+						const payload =
+							typeof decoded.payload === "object" && decoded.payload !== null
+								? (decoded.payload as { conversationId?: unknown })
+								: undefined;
 						if (
+							typeof decoded.sessionId === "string" &&
+							decoded.sessionId &&
 							typeof payload?.conversationId === "string" &&
 							payload.conversationId
 						) {
 							pendingConversationSessions.add(decoded.sessionId);
 							conversationOnly = true;
 						}
-					}
-				} catch {
+						// Transition invalidation is gated on session_updated: only a
+						// session row change (agent_session_id or provider_conversation_id
+						// landing) means the "Switch to Chat" readiness may have flipped.
+						// PR/check/review events do not affect interface readiness.
+						if (
+							typeof decoded.sessionId === "string" &&
+							decoded.sessionId &&
+							(event as MessageEvent).type === "session_updated"
+						) {
+							pendingTransitionSessions.add(decoded.sessionId);
+						}
+					} catch {
 						// A malformed CDC payload still invalidates workspaces; it simply
 						// cannot target a conversation cache precisely.
 					}
@@ -135,7 +145,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 					source.onopen = () => {
 						setEventsConnectionState("connected");
 						// Events emitted during the gap were lost; refetch once on (re)open.
-						refreshWorkspaces();
+						scheduleCacheInvalidations();
 					};
 					source.onerror = () => {
 						// While readyState is CONNECTING the browser retries on its own;
@@ -144,9 +154,9 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 						setEventsConnectionState("disconnected");
 						if (source?.readyState === EVENTSOURCE_CLOSED) scheduleRetry();
 					};
-					source.onmessage = refreshWorkspaces; // unnamed events, if any
+					source.onmessage = scheduleCacheInvalidations; // unnamed events, if any
 					for (const type of CDC_EVENT_TYPES) {
-						source.addEventListener(type, refreshWorkspaces);
+						source.addEventListener(type, scheduleCacheInvalidations);
 					}
 					// EventSource auto-reconnects and resumes via Last-Event-ID while
 					// CONNECTING; scheduleRetry only covers the terminal CLOSED state.
@@ -157,7 +167,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 
 			const removeDaemonListener = aoBridge.daemon.onStatus(() => {
 				connectSource();
-				refreshWorkspaces();
+				scheduleCacheInvalidations();
 			});
 			// Rebind when the daemon comes back on a different port, independent of
 			// status-event ordering.


### PR DESCRIPTION
Fixes [#3753](https://github.com/Untrivial-ai/agent-orchestrator/issues/3753)

## Problem

A newly spawned Codex or Claude Code session (TUI mode) does not enable the
"Switch to Chat UI" button until the user sends at least one prompt and then
switches away from and back to the session.

#3735 (already on main) added a 1-second poll for `NATIVE_SESSION_MISSING`,
which fixes the common case: when the Codex SessionStart hook fires and
reports the native thread id, the poll catches it within ~1 second. But
two gaps remain:

1. **Poll latency.** The 1-second poll means the button can lag up to 1
   second behind the actual session state. A CDC `session_updated` event
   fires the moment `agent_session_id` or `provider_conversation_id` lands,
   but the interface-transition query was not invalidated on that event —
   only the workspace, SCM, usage, and conversation queries were.
2. **Windows hook-never-fires.** On Windows, the Codex SessionStart hook
   does not fire reliably (ConPTY command quoting). #3735's poll waits for
   that hook indefinitely, so the button stays disabled forever. There was
   no path to enable the switch without the native id, even when the TUI
   has no conversation history to lose.

## Fix

### 1. `fix(storage): fan out session_updated on provider_conversation_id`
`backend/internal/storage/sqlite/migrations/0086_session_cdc_provider_conversation_id.sql`

Adds `provider_conversation_id` to the `sessions_cdc_update` `WHEN` guard
that `0085_agent_switching` established (which already included
`agent_session_id`). The Chat driver writes `provider_conversation_id`
independently of `agent_session_id` (`chat_spawn.go: ControllerReady`), so
a write to it must fan out a `session_updated` event. Guard-only change:
`session_updated` is an invalidation-only nudge (consumers refetch), so the
payload stays as-is — matching the convention established by migration
0024.

Renumbered from 0085 to 0086 to coexist with main's
`0085_agent_switching.sql`.

### 2. `fix(chat): invalidate interface transition query on session_updated CDC`
`frontend/src/renderer/lib/event-transport.ts`

Tracks `pendingTransitionSessions` alongside the existing
`pendingConversationSessions`. Any `session_updated` CDC event with a
`sessionId` now invalidates `sessionInterfaceTransitionQueryKey(sessionId)`,
so the "Switch to Chat" button re-evaluates immediately on push rather than
waiting for the next poll cycle. Gated on `session_updated` only — PR/check/
review events do not affect interface readiness.

### 3. `fix(chat): allow fresh-start transition when adapter has history probe`
`backend/internal/session_manager/interface_transition.go`

When the SessionStart hook has not reported the native conversation id
(e.g. Codex on Windows where the hook does not fire), the interface
transition status blocked as `NATIVE_SESSION_MISSING` — the "Switch to
Chat" button stayed disabled indefinitely.

Instead of fabricating a synthetic UUID, model the fresh-start path in
transition readiness: if the adapter implements
`AgentInterfaceHandoffHistoryProbe`, an empty native id is allowed. The
history probe distinguishes a real conversation from an empty TUI, and
`persistedNativeConversationID` uses that to decide between resume and
fresh start. Adapters without a probe keep the hard block — there is no
safe way to know whether the TUI's work would be lost.

This is the gap #3735 does not cover: when the hook never fires at all,
the poll waits forever. The history probe enables the switch without the
native id, safely.

## Testing

- `go test ./internal/storage/sqlite/store/...` — pass (3 CDC schema tests:
  `agent_session_id` fires 1 event, `provider_conversation_id` fires 1 event,
  unrelated metadata fires 0)
- `go test ./internal/session_manager/...` — pass (interface transition tests
  including fresh-start when reserved id has no history)
- `go test ./internal/adapters/chatdriver/claudeacp/...` — pass
- `go vet ./internal/session_manager/... ./internal/storage/sqlite/... ./internal/adapters/chatdriver/claudeacp/...` — clean
- `npm run typecheck` — clean
- `vitest run src/renderer/lib/event-transport.test.ts` — 14/14 pass
  (including: `session_updated` invalidates transition query, `pr_created`
  does not)

## Checklist
- [x] Migration 0086 added to `shippedMigrations` ledger
- [x] One issue per PR (#3753)
- [x] Conventional commits
- [x] Surgical changes — no speculative abstractions
- [x] Reframed CDC as latency improvement (#3735 already fixed the poll)
- [x] Removed "Supersedes #3736" (unrelated, already-merged Prime Agent PR)