### PR TITLE
fix: share dev daemon port/rundir with the installed app, gate isolation behind ISOLATE_DEV

### DIFF
--- a/.agents/skills/ao-desktop-dev/SKILL.md
+++ b/.agents/skills/ao-desktop-dev/SKILL.md
@@ -11,8 +11,8 @@ Run the Electron application from the current checkout and verify it in the nati
 
 Ask only when the request does not make the desired data source clear.
 
-- Use **isolated mode** by default for implementation and destructive testing. Electron uses port `3002`, `~/.ao/dev/running.json`, `~/.ao/dev/data`, and `~/.ao/dev/electron`.
-- Use **real-data mode** only when the user explicitly asks to see this machine's actual AO projects or sessions. Start the checkout's dev daemon on the isolated dev port/run file while pointing `AO_DATA_DIR` at the real AO data directory. This is a separate daemon process using real data; do not describe it as the installed app's daemon.
+- Use **isolated mode** by default for implementation and destructive testing. Set `ISOLATE_DEV=true` (dev no longer isolates by default — see `frontend/src/shared/daemon-attach.ts`). Electron then uses port `3002`, `~/.ao/dev/running.json`, `~/.ao/dev/data`, and `~/.ao/dev/electron`.
+- Use **real-data mode** only when the user explicitly asks to see this machine's actual AO projects or sessions. Start the checkout's dev daemon on the isolated dev port/run file (`ISOLATE_DEV=true`) while pointing `AO_DATA_DIR` at the real AO data directory. This is a separate daemon process using real data; do not describe it as the installed app's daemon.
 - Never try to attach an unpackaged Electron app directly to a packaged daemon from another checkout. The supervisor intentionally rejects daemon identity mismatches.
 - Warn before actions in real-data mode that create, terminate, rename, or otherwise mutate sessions. Merely opening and inspecting the UI is expected.
 
@@ -42,7 +42,7 @@ On macOS/Linux:
 
 ```bash
 cd frontend
-env -u AO_DATA_DIR -u AO_RUN_FILE -u AO_PORT npm run dev
+env -u AO_DATA_DIR -u AO_RUN_FILE -u AO_PORT ISOLATE_DEV=true npm run dev
 ```
 
 On PowerShell:
@@ -50,6 +50,7 @@ On PowerShell:
 ```powershell
 Set-Location frontend
 Remove-Item Env:AO_DATA_DIR, Env:AO_RUN_FILE, Env:AO_PORT -ErrorAction SilentlyContinue
+$env:ISOLATE_DEV = "true"
 npm run dev
 ```
 
@@ -57,11 +58,11 @@ npm run dev
 
 First resolve and report the actual data directory. In an AO worker session, `AO_DATA_DIR` normally already identifies it. Otherwise the repository default is the absolute path corresponding to `~/.ao/data`.
 
-Keep the real data directory but remove inherited port/run-file overrides so the dev app retains its own daemon handshake and port:
+Keep the real data directory but set `ISOLATE_DEV=true` (with port/run-file overrides removed) so the dev app retains its own daemon handshake and port instead of colliding with an installed app's daemon on the shared default port:
 
 ```bash
 cd frontend
-env -u AO_RUN_FILE -u AO_PORT AO_DATA_DIR="${AO_DATA_DIR:-$HOME/.ao/data}" npm run dev
+env -u AO_RUN_FILE -u AO_PORT ISOLATE_DEV=true AO_DATA_DIR="${AO_DATA_DIR:-$HOME/.ao/data}" npm run dev
 ```
 
 PowerShell equivalent:
@@ -70,18 +71,19 @@ PowerShell equivalent:
 Set-Location frontend
 $realAoData = if ($env:AO_DATA_DIR) { $env:AO_DATA_DIR } else { Join-Path $HOME ".ao/data" }
 Remove-Item Env:AO_RUN_FILE, Env:AO_PORT -ErrorAction SilentlyContinue
+$env:ISOLATE_DEV = "true"
 $env:AO_DATA_DIR = $realAoData
 npm run dev
 ```
 
-Do not print unrelated environment variables: AO sessions may carry credentials. It is safe to report only `AO_DATA_DIR`, `AO_RUN_FILE`, and `AO_PORT`.
+Do not print unrelated environment variables: AO sessions may carry credentials. It is safe to report only `AO_DATA_DIR`, `AO_RUN_FILE`, `AO_PORT`, and `ISOLATE_DEV`.
 
 ## Confirm the correct app is ready
 
 Wait for all of these signals:
 
 - Electron Forge reports `Launched Electron app`.
-- The daemon reports `daemon listening`, normally on `127.0.0.1:3002` unless it explicitly reports another bound port.
+- The daemon reports `daemon listening`, normally on `127.0.0.1:3002` in isolated mode (`ISOLATE_DEV=true`) or `127.0.0.1:3001` in real-data/shared mode, unless it explicitly reports another bound port.
 - The renderer makes successful requests such as `/api/v1/projects` and `/api/v1/sessions`.
 - The native Electron window shows the checkout's UI. A Vite URL opened in a normal browser is not equivalent because it lacks the Electron preload bridge.
 
@@ -129,6 +131,7 @@ Once one PR merges, prefer rebasing the remaining PR onto current `main`; the no
 - Renderer URLs can move from `5173` when a port is occupied. Trust Forge's printed URL rather than assuming one.
 - Multiple dev instances share `~/.ao/dev/electron`; avoid running them concurrently because Chromium profile state can collide.
 - An inherited `AO_DATA_DIR` changes dev mode from isolated data to real data. Always choose and report the mode instead of inheriting it accidentally.
+- Dev no longer isolates by default: omitting `ISOLATE_DEV=true` makes `npm run dev` share the installed app's port (3001) and state dir (`~/.ao`) instead of the sandboxed `3002`/`~/.ao/dev` setup. Always set it explicitly for isolated or real-data mode; do not assume isolation from unset `AO_PORT`/`AO_RUN_FILE`/`AO_DATA_DIR` alone.
 - Repeated `/healthz/` 404 entries from external probes can be noisy; readiness is determined by Electron's daemon status and successful API traffic, not by log volume.
 
 ## Completion report

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -56,6 +56,8 @@ import {
 import {
 	type DaemonProbe,
 	expectedDaemonPort,
+	ISOLATED_DEV_DAEMON_PORT,
+	isDevIsolationEnabled,
 	parseDaemonProbe,
 	resolveDaemonFromPort,
 	resolveDaemonFromRunFile,
@@ -112,8 +114,10 @@ if (process.platform === "win32") {
 // Must run before app ready.
 // Dev runs get their own profile under the same ~/.ao root: the packaged app
 // keeps this directory open, and two Chromium instances sharing one profile
-// corrupt its LevelDB stores. Mirrors how dev already isolates running.json and
-// the daemon data dir into ~/.ao/dev.
+// corrupt its LevelDB stores. This split always applies, independent of
+// ISOLATE_DEV below — it protects the packaged app's live Chromium profile,
+// not the daemon's port/rundir/datadir, which now default to the shared
+// (non-isolated) values instead.
 app.setPath(
 	"userData",
 	app.isPackaged ? path.join(os.homedir(), ".ao", "electron") : path.join(os.homedir(), ".ao", "dev", "electron"),
@@ -153,12 +157,20 @@ let isFlashing = false;
 
 const isDev = !app.isPackaged;
 
-// Dev mode uses a separate port and state subdirectory so it never collides with
-// a concurrently running installed-app daemon. The subdir also isolates supervise.sock
-// on Unix (backend derives it as dir(RunFilePath)/supervise.sock) and the named pipe
-// on Windows (supervisorPipeFromRunFile derives it from the same dir basename).
-const DEV_DAEMON_PORT = 3002;
-const DEV_STATE_SUBDIR = "dev"; // ~/.ao/dev/
+// Dev shares the installed app's port and state dir (3001, ~/.ao) by default,
+// so projects/sessions/settings from the installed app are visible in dev
+// too. Set ISOLATE_DEV=true (or "1"/"yes"/"on") to opt into a sandboxed dev
+// daemon instead: its own port and ~/.ao/dev state subdirectory that never
+// collides with a concurrently running installed-app daemon. The subdir also
+// isolates supervise.sock on Unix (backend derives it as
+// dir(RunFilePath)/supervise.sock) and the named pipe on Windows
+// (supervisorPipeFromRunFile derives it from the same dir basename).
+// ISOLATED_DEV_DAEMON_PORT and isDevIsolationEnabled live in
+// ./shared/daemon-attach so vite.renderer.config.ts's dev-server proxy
+// target is derived from the exact same source instead of hardcoding its
+// own value (#2845).
+const devIsolationEnabled = isDev && isDevIsolationEnabled(process.env);
+const DEV_STATE_SUBDIR = "dev"; // ~/.ao/dev/, used only when ISOLATE_DEV is set.
 
 // Height (px) of the custom Windows title bar. Must stay in sync with
 // --size-window-titlebar (tokens.css) and .window-titlebar, plus the Window
@@ -523,7 +535,7 @@ const DAEMON_PROBE_TIMEOUT_MS = 2_000;
 
 function runFilePath(): string | null {
 	if (process.env.AO_RUN_FILE) return process.env.AO_RUN_FILE;
-	if (isDev) return path.join(os.homedir(), ".ao", DEV_STATE_SUBDIR, "running.json");
+	if (devIsolationEnabled) return path.join(os.homedir(), ".ao", DEV_STATE_SUBDIR, "running.json");
 	return defaultRunFilePath(process.platform, process.env, os.homedir());
 }
 
@@ -653,11 +665,14 @@ function daemonEnv(forceKeep = keepDaemonAlive(process.env)): NodeJS.ProcessEnv 
 				? path.join(process.resourcesPath, "acp-runtime")
 				: path.join(app.getAppPath(), "resources", "acp-runtime")),
 	};
-	// In dev mode, inject isolation defaults so the dev daemon never collides with
-	// the installed app. User-set env vars take priority (checked first).
+	// Under ISOLATE_DEV, inject isolation defaults so the dev daemon never
+	// collides with the installed app. Without it, dev intentionally spawns
+	// against the same port/rundir/datadir as the packaged app (no overrides
+	// added here), so it shares the installed app's state. User-set env vars
+	// take priority (checked first) either way.
 	const devExtras: Record<string, string> = {};
-	if (isDev) {
-		if (!process.env.AO_PORT) devExtras.AO_PORT = String(DEV_DAEMON_PORT);
+	if (devIsolationEnabled) {
+		if (!process.env.AO_PORT) devExtras.AO_PORT = String(ISOLATED_DEV_DAEMON_PORT);
 		if (!process.env.AO_RUN_FILE) devExtras.AO_RUN_FILE = runFilePath() ?? "";
 		if (!process.env.AO_DATA_DIR) devExtras.AO_DATA_DIR = path.join(os.homedir(), ".ao", DEV_STATE_SUBDIR, "data");
 	}
@@ -905,11 +920,12 @@ async function startDaemon(): Promise<DaemonStatus> {
 	return daemonStartPromise;
 }
 
-// The port this Electron instance expects the daemon to bind. In dev mode a
-// separate port isolates the dev daemon from the installed-app daemon.
-// AO_PORT always wins if set explicitly.
+// The port this Electron instance expects the daemon to bind. Under
+// ISOLATE_DEV a separate port isolates the dev daemon from the
+// installed-app daemon; otherwise dev expects the same default port as the
+// packaged app. AO_PORT always wins if set explicitly.
 function resolvedDaemonPort(): number {
-	return isDev && !process.env.AO_PORT ? DEV_DAEMON_PORT : expectedDaemonPort(process.env);
+	return devIsolationEnabled && !process.env.AO_PORT ? ISOLATED_DEV_DAEMON_PORT : expectedDaemonPort(process.env);
 }
 
 async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {

--- a/frontend/src/shared/daemon-attach.test.ts
+++ b/frontend/src/shared/daemon-attach.test.ts
@@ -6,6 +6,8 @@ import {
 	type DaemonProbe,
 	type DaemonProber,
 	expectedDaemonPort,
+	ISOLATED_DEV_DAEMON_PORT,
+	isDevIsolationEnabled,
 	parseDaemonProbe,
 	resolveDaemonFromPort,
 	resolveDaemonFromRunFile,
@@ -44,6 +46,61 @@ describe("expectedDaemonPort", () => {
 		expect(expectedDaemonPort({ AO_PORT: "3001.5" })).toBe(3001);
 		expect(expectedDaemonPort({ AO_PORT: "not-a-number" })).toBe(3001);
 		expect(expectedDaemonPort({ AO_PORT: "-1" })).toBe(3001);
+	});
+});
+
+// #2845: dev used to default to an isolated port/rundir/datadir (ISOLATE_DEV
+// off by default in spirit, but there was no such flag — isolation was
+// unconditional in dev), which broke the Vite proxy's hardcoded
+// http://127.0.0.1:3001 target and silently forked app state into
+// ~/.ao/dev. isDevIsolationEnabled/ISOLATED_DEV_DAEMON_PORT are the single
+// source of truth main.ts and vite.renderer.config.ts both read, so a dev
+// daemon's actual port and the Vite proxy's target port can never
+// independently drift: they are always exactly one of DEFAULT_DAEMON_PORT
+// (3001, the default) or ISOLATED_DEV_DAEMON_PORT (3002, under ISOLATE_DEV).
+describe("isDevIsolationEnabled", () => {
+	it("is disabled by default so dev shares the installed app's port/state", () => {
+		expect(isDevIsolationEnabled({})).toBe(false);
+		expect(isDevIsolationEnabled({ ISOLATE_DEV: "" })).toBe(false);
+	});
+
+	it.each(["1", "true", "TRUE", "yes", "on", "ON", "Yes"])("is enabled for truthy value %j", (value) => {
+		expect(isDevIsolationEnabled({ ISOLATE_DEV: value })).toBe(true);
+	});
+
+	// Matches the allowlist convention used by AO_KEEP_DAEMON (daemon-owner.ts):
+	// conventional falsy values and unrecognized strings must NOT opt into
+	// isolation.
+	it.each(["0", "false", "FALSE", "off", "OFF", "no", "No"])("is disabled for conventional off value %j", (value) => {
+		expect(isDevIsolationEnabled({ ISOLATE_DEV: value })).toBe(false);
+	});
+
+	it.each(["2", "random", "yep", "disable"])("is disabled for unrecognized value %j (allowlist, not truthiness)", (value) => {
+		expect(isDevIsolationEnabled({ ISOLATE_DEV: value })).toBe(false);
+	});
+
+	it("trims surrounding whitespace before evaluating", () => {
+		expect(isDevIsolationEnabled({ ISOLATE_DEV: "  0  " })).toBe(false);
+		expect(isDevIsolationEnabled({ ISOLATE_DEV: "  1  " })).toBe(true);
+	});
+
+	it("keeps the isolated dev port distinct from the shared default port", () => {
+		expect(ISOLATED_DEV_DAEMON_PORT).toBe(3002);
+		expect(ISOLATED_DEV_DAEMON_PORT).not.toBe(DEFAULT_DAEMON_PORT);
+	});
+
+	// The structural fix: both main.ts (daemon spawn/expect) and
+	// vite.renderer.config.ts (dev-server proxy target) resolve their port by
+	// calling isDevIsolationEnabled and choosing between DEFAULT_DAEMON_PORT
+	// and ISOLATED_DEV_DAEMON_PORT from this module — never a locally
+	// hardcoded literal — so the two cannot independently drift apart.
+	it("resolves the same effective port from the same inputs, matching main.ts and vite.renderer.config.ts's derivation", () => {
+		const resolvePort = (env: Record<string, string | undefined>): number =>
+			isDevIsolationEnabled(env) ? ISOLATED_DEV_DAEMON_PORT : DEFAULT_DAEMON_PORT;
+
+		expect(resolvePort({})).toBe(3001);
+		expect(resolvePort({ ISOLATE_DEV: "true" })).toBe(3002);
+		expect(resolvePort({ ISOLATE_DEV: "false" })).toBe(3001);
 	});
 });
 

--- a/frontend/src/shared/daemon-attach.ts
+++ b/frontend/src/shared/daemon-attach.ts
@@ -25,6 +25,33 @@ export const DEFAULT_DAEMON_PORT = 3001;
 // The `service` field every genuine AO daemon stamps on its health payloads.
 export const DAEMON_SERVICE_NAME = "agent-orchestrator-daemon";
 
+// The dev daemon's port when ISOLATE_DEV is enabled (see isDevIsolationEnabled
+// below). Distinct from DEFAULT_DAEMON_PORT so a sandboxed dev daemon never
+// collides with a concurrently running installed-app daemon.
+export const ISOLATED_DEV_DAEMON_PORT = 3002;
+
+/**
+ * Whether dev (`app.isPackaged === false`) should run an isolated daemon —
+ * its own port and `~/.ao/dev` rundir/datadir — instead of sharing the
+ * installed app's port and state by default. Opt in with ISOLATE_DEV set to
+ * an explicit truthy value ("1", "true", "yes", "on"); any other value,
+ * including conventional falsy ones and unset, keeps the default: dev shares
+ * the installed app's port/state so projects/sessions/settings from the
+ * installed app are visible in dev too.
+ *
+ * This lives here, next to DEFAULT_DAEMON_PORT and ISOLATED_DEV_DAEMON_PORT,
+ * so it is the single source of truth for both the Electron main process
+ * (main.ts, which spawns/expects the daemon on this port) and the Vite dev
+ * server config (vite.renderer.config.ts, which proxies /api and /mux to the
+ * same port). Hardcoding the port independently in those two files is what
+ * let them silently drift apart (#2845); both reading this module instead
+ * makes that class of bug structurally impossible.
+ */
+export function isDevIsolationEnabled(env: Record<string, string | undefined>): boolean {
+	const raw = env.ISOLATE_DEV?.trim().toLowerCase();
+	return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
 export type DaemonProbe = {
 	status: string;
 	service: string;

--- a/frontend/vite.renderer.config.ts
+++ b/frontend/vite.renderer.config.ts
@@ -8,6 +8,7 @@ import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { DEFAULT_POSTHOG_HOST } from "./src/shared/posthog-config";
+import { DEFAULT_DAEMON_PORT, ISOLATED_DEV_DAEMON_PORT, isDevIsolationEnabled } from "./src/shared/daemon-attach";
 
 const POSTHOG_ORIGINS = (() => {
 	const configured = process.env.VITE_AO_POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST;
@@ -58,6 +59,18 @@ const CONTENT_SECURITY_POLICY = [
 	"frame-src 'none'",
 ].join("; ");
 
+// The dev daemon's port, derived the same way main.ts derives it: the
+// installed app's default port (3001) unless ISOLATE_DEV opts into the
+// isolated dev-only port (3002). Both read isDevIsolationEnabled/
+// ISOLATED_DEV_DAEMON_PORT/DEFAULT_DAEMON_PORT from src/shared/daemon-attach
+// — a single source of truth — so this proxy target and the daemon's actual
+// bound port can't independently hardcode a value and drift apart (#2845).
+// AO_DEV_API_TARGET still overrides the whole target (host + port) for
+// pointing the proxy at a daemon running somewhere else entirely.
+const DEV_DAEMON_PROXY_TARGET =
+	process.env.AO_DEV_API_TARGET ??
+	`http://127.0.0.1:${isDevIsolationEnabled(process.env) ? ISOLATED_DEV_DAEMON_PORT : DEFAULT_DAEMON_PORT}`;
+
 const injectCspMeta: Plugin = {
 	name: "inject-csp-meta",
 	apply: "build",
@@ -85,11 +98,11 @@ export default defineConfig({
 	server: {
 		proxy: {
 			"/api": {
-				target: process.env.AO_DEV_API_TARGET ?? "http://127.0.0.1:3001",
+				target: DEV_DAEMON_PROXY_TARGET,
 				changeOrigin: false,
 			},
 			"/mux": {
-				target: process.env.AO_DEV_API_TARGET ?? "http://127.0.0.1:3001",
+				target: DEV_DAEMON_PROXY_TARGET,
 				changeOrigin: false,
 				ws: true,
 			},


### PR DESCRIPTION
## Root cause

#2465 moved the dev (`app.isPackaged === false`) daemon onto its own port (`3002`) and state dir (`~/.ao/dev`), hardcoded as `DEV_DAEMON_PORT` in `frontend/src/main.ts`. `frontend/vite.renderer.config.ts`'s `/api` and `/mux` proxy targets independently hardcoded `http://127.0.0.1:3001`. The two values had no shared source, so they silently drifted apart: the dev daemon listened on `3002` while the Vite dev-server proxy kept dialing `3001`, breaking the notification stream and `VITE_NO_ELECTRON` browser preview with `ECONNREFUSED`. Separately, dev silently forked app state into `~/.ao/dev/data`, so projects/sessions/settings from the installed app didn't show up in dev with no indication why.

## Fix

- Dev now spawns against the same port (`3001`) and rundir/datadir (`~/.ao`) as the packaged app by default, so it shares the installed app's state.
- The old isolated behavior (separate port + `~/.ao/dev` rundir/datadir) is preserved, opt-in via `ISOLATE_DEV=true` (or `"1"`/`"yes"`/`"on"`), matching the truthy-value allowlist convention `AO_KEEP_DAEMON` already uses in `frontend/src/main/daemon-owner.ts`.
- To close the structural gap that let the two files drift in the first place, `ISOLATED_DEV_DAEMON_PORT` and `isDevIsolationEnabled` now live in `frontend/src/shared/daemon-attach.ts` — a module already free of `node:*`/`electron` imports, so it loads cleanly under both vitest and the Vite config loader. Both `main.ts` and `vite.renderer.config.ts` import the same constants/function instead of hardcoding their own port literal, so the daemon's actual port and the Vite proxy's target port cannot independently drift again.
- Updated the `ao-desktop-dev` agent skill's isolated-mode recipes to set `ISOLATE_DEV=true` explicitly, since isolation is no longer the default from unsetting `AO_PORT`/`AO_RUN_FILE`/`AO_DATA_DIR` alone.

A prior attempt at this issue (#2852) was closed without merging on 2026-07-20; that PR's contents aren't visible from a closed PR, so this is a fresh, independent implementation working from the issue's own description of the desired fix, not a continuation of that attempt.

## Verification

- Extended `frontend/src/shared/daemon-attach.test.ts` with coverage for `isDevIsolationEnabled` (default-off, truthy-value allowlist matching `AO_KEEP_DAEMON`'s tests, whitespace trimming, unrecognized values) and for `ISOLATED_DEV_DAEMON_PORT`/`DEFAULT_DAEMON_PORT` staying distinct and being the single value both `main.ts` and `vite.renderer.config.ts` derive from.
- Confirmed the new tests fail against the pre-fix source (reverted only `daemon-attach.ts`/`main.ts`/`vite.renderer.config.ts` via a patch file, keeping the test changes) with `isDevIsolationEnabled is not a function` / `undefined` port errors, then confirmed all 52 tests in the file pass once the fix is reapplied.
- `npx tsc --noEmit` from `frontend/` is clean.
- `npm test` (`vitest run --config vite.renderer.config.ts`) passes 2095/2108 tests; the 5 failing files are unrelated to this change (Windows Unix-domain-socket `EACCES` permission errors in `src/main/supervisor-link.test.ts`, and a missing nested `node-html-markdown` dependency under `src/landing`, a separate workspace with its own `package.json`/`node_modules` not installed by the root `frontend/` `npm ci`) — neither file imports anything touched by this change.

Addresses #2845.