### PR TITLE
fix(session): tolerate legacy/corrupt local state during project teardown

### DIFF
--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -415,6 +415,37 @@ func TestManager_RemoveDoesNotArchiveWhenTeardownFails(t *testing.T) {
 	}
 }
 
+// TestManager_RemoveSurfacesProjectRemoveBlockedConflict verifies the typed
+// PROJECT_REMOVE_BLOCKED conflict that TeardownProject returns for a
+// genuinely-blocking dirty worktree (issue #2598, fix points 2/4) survives
+// Remove()'s pass-through unchanged, and that the project stays registered
+// rather than being silently archived out from under preserved work.
+func TestManager_RemoveSurfacesProjectRemoveBlockedConflict(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlitetest.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	blocked := apierr.Conflict("PROJECT_REMOVE_BLOCKED", "Project has sessions with uncommitted worktree changes", map[string]any{
+		"blockedSessions": []map[string]string{{"sessionId": "ao-1", "workspacePath": "/managed/ao/ao-1"}},
+	})
+	m := project.NewWithDeps(project.Deps{Store: store, Sessions: &fakeProjectTeardowner{err: blocked}})
+
+	if _, err := m.Add(ctx, project.AddInput{Path: gitRepo(t), ProjectID: ptr("ao")}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	_, err = m.Remove(ctx, "ao")
+	wantCode(t, err, "PROJECT_REMOVE_BLOCKED")
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) || apiErr.Kind != apierr.KindConflict {
+		t.Fatalf("Remove err = %v, want a KindConflict *apierr.Error", err)
+	}
+	if got, err := m.Get(ctx, "ao"); err != nil || got.Project == nil || got.Project.ID != "ao" {
+		t.Fatalf("project after blocked remove = %#v, %v; want still active", got, err)
+	}
+}
+
 func TestManager_DefaultsWhenUnconfigured(t *testing.T) {
 	ctx := context.Background()
 	m := newManager(t)

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -733,24 +733,92 @@ func (s *Service) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 	return out, nil
 }
 
+// preservedWorktree names one session whose worktree Kill genuinely had to
+// preserve (uncommitted changes) rather than destroy, during project teardown.
+type preservedWorktree struct {
+	SessionID     domain.SessionID
+	WorkspacePath string
+}
+
 // TeardownProject stops every live session in a project, then asks the session
-// manager to reclaim terminal workspaces. Dirty worktrees are preserved by Kill
-// and Cleanup; callers only see hard teardown failures.
+// manager to reclaim terminal workspaces. It must tolerate legacy or
+// inconsistent local AO state: a stale runtime handle, a missing or non-git
+// worktree, a prunable git worktree registration, an already-removed
+// filesystem path, or any other teardown failure that Kill/Cleanup did not
+// already fold into a dirty-worktree preservation should never by itself block
+// unregistering the project. Every non-terminated session's Kill outcome is
+// collected instead of short-circuiting on the first raw error: unrecognized
+// failures are logged with their original cause (for daemon-side diagnosis)
+// and otherwise ignored, while the one case that truly must preserve user
+// work — Kill declining to force-delete a dirty worktree (freed=false, err=nil,
+// see ports.ErrWorkspaceDirty) — is aggregated across every affected session
+// and surfaced as a structured PROJECT_REMOVE_BLOCKED conflict instead of
+// silently archiving the project out from under still-preserved work.
 func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID) error {
 	recs, err := s.listRecords(ctx, project)
 	if err != nil {
 		return err
 	}
+	var preserved []preservedWorktree
 	for _, rec := range recs {
 		if rec.IsTerminated {
 			continue
 		}
-		if _, err := s.Kill(ctx, rec.ID); err != nil {
-			return err
+		freed, killErr := s.Kill(ctx, rec.ID)
+		if killErr != nil {
+			s.warnTeardown("teardown project: session kill failed; continuing", project, rec.ID, killErr)
+			continue
+		}
+		if !freed {
+			preserved = append(preserved, preservedWorktree{SessionID: rec.ID, WorkspacePath: rec.Metadata.WorkspacePath})
 		}
 	}
-	_, err = s.Cleanup(ctx, project)
-	return err
+	if _, err := s.Cleanup(ctx, project); err != nil {
+		if len(preserved) == 0 {
+			return err
+		}
+		// Cleanup already treats per-session workspace teardown trouble as
+		// best-effort (see manager.Cleanup/cleanupOne); a hard error here only
+		// comes from listing terminated records, a real infra failure. Keep the
+		// cause in the logs but let the actionable PROJECT_REMOVE_BLOCKED
+		// conflict below take priority on the wire over a generic one.
+		s.warnTeardown("teardown project: cleanup failed; continuing", project, "", err)
+	}
+	if len(preserved) > 0 {
+		return projectRemoveBlockedError(preserved)
+	}
+	return nil
+}
+
+// warnTeardown logs a non-fatal project-teardown failure with its original
+// cause. The raw cause never leaves the daemon: it is intentionally not part
+// of any returned apierr, so a legacy/corrupt local state failure never leaks
+// internal filesystem detail onto the wire while still being diagnosable from
+// server-side logs.
+func (s *Service) warnTeardown(msg string, project domain.ProjectID, sessionID domain.SessionID, err error) {
+	if s.logger == nil {
+		return
+	}
+	s.logger.Warn(msg, "projectID", project, "sessionID", sessionID, "error", err)
+}
+
+// projectRemoveBlockedError reports that project removal cannot proceed
+// because one or more sessions have dirty, uncommitted worktrees that Kill
+// preserved instead of force-deleting. Details name every blocking session and
+// its preserved path so the caller has a concrete recovery action: resolve
+// (commit, discard, or let the session finish) each session's uncommitted
+// changes, then retry removal.
+func projectRemoveBlockedError(preserved []preservedWorktree) error {
+	sessions := make([]map[string]string, 0, len(preserved))
+	for _, p := range preserved {
+		sessions = append(sessions, map[string]string{
+			"sessionId":     string(p.SessionID),
+			"workspacePath": p.WorkspacePath,
+		})
+	}
+	return apierr.Conflict("PROJECT_REMOVE_BLOCKED",
+		"Project has sessions with uncommitted worktree changes that AO preserved instead of deleting. Resolve or discard those changes (or let the session finish), then retry removal.",
+		map[string]any{"blockedSessions": sessions})
 }
 
 // List returns sessions as enriched display models after applying API filters.

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -1153,6 +1153,8 @@ type fakeCommander struct {
 	sentMessages    []string
 	cleanupProjects []domain.ProjectID
 	killErr         error
+	killErrs        map[domain.SessionID]error
+	killNotFreed    map[domain.SessionID]bool
 	retireErr       error
 	sendErr         error
 	sendFunc        func(domain.SessionID, string) error
@@ -1199,10 +1201,20 @@ func (f *fakeCommander) ResumeAgentWithMode(_ context.Context, id domain.Session
 	return f.restoreResult, nil
 }
 func (f *fakeCommander) Kill(_ context.Context, id domain.SessionID) (bool, error) {
+	if f.killErrs != nil {
+		if err, ok := f.killErrs[id]; ok {
+			return false, err
+		}
+	}
 	if f.killErr != nil {
 		return false, f.killErr
 	}
 	f.killed = append(f.killed, id)
+	if f.killNotFreed != nil && f.killNotFreed[id] {
+		// Mirrors manager.Kill preserving a dirty worktree: it still tears the
+		// session down (nil error) but declines to force-delete the workspace.
+		return false, nil
+	}
 	return true, nil
 }
 func (f *fakeCommander) RetireForReplacement(_ context.Context, id domain.SessionID) error {
@@ -1284,19 +1296,85 @@ func TestTeardownProjectKillsActiveSessionsThenCleansProject(t *testing.T) {
 	}
 }
 
-func TestTeardownProjectStopsOnKillError(t *testing.T) {
+// TestTeardownProjectToleratesUnrecognizedKillFailure covers regression
+// scenario (c) from issue #2598: a non-dirty teardown failure from the
+// workspace/runtime adapter that isn't in toAPIError's sentinel allowlist
+// (a plain, unwrapped error — the shape a stale runtime handle or a Windows
+// sharing-violation on os.RemoveAll would surface as). Project removal must
+// not abort or surface a raw 500 for it: the failure is logged and the
+// project's teardown otherwise proceeds and succeeds, aggregating across every
+// session instead of stopping on the first raw error (fix point 3).
+func TestTeardownProjectToleratesUnrecognizedKillFailure(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}
+	st.sessions["mer-2"] = domain.SessionRecord{ID: "mer-2", ProjectID: "mer"}
 	boom := errors.New("boom")
-	fc := &fakeCommander{killErr: boom}
+	fc := &fakeCommander{killErrs: map[domain.SessionID]error{"mer-1": boom}}
+	svc := &Service{manager: fc, store: st}
+
+	if err := svc.TeardownProject(context.Background(), "mer"); err != nil {
+		t.Fatalf("TeardownProject err = %v, want nil (unrecognized kill failures must be tolerated)", err)
+	}
+	if len(fc.killed) != 1 || fc.killed[0] != "mer-2" {
+		t.Fatalf("killed = %#v, want mer-2 killed despite mer-1's failure", fc.killed)
+	}
+	if len(fc.cleanupProjects) != 1 || fc.cleanupProjects[0] != "mer" {
+		t.Fatalf("cleanup projects = %#v, want [mer] to still run after a tolerated kill failure", fc.cleanupProjects)
+	}
+}
+
+// TestTeardownProjectToleratesStaleWorktreeRegistration covers regression
+// scenario (b): a stale/prunable/non-git worktree registration, the shape
+// gitworktree.Workspace.Destroy returns wrapped around ports.ErrWorkspaceStale
+// when an AO-managed workspace path no longer points at a registered git
+// worktree. That must not block project removal either (fix point 1).
+func TestTeardownProjectToleratesStaleWorktreeRegistration(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}
+	staleErr := fmt.Errorf("gitworktree: stale worktree %q: %w", "/tmp/rc-main", ports.ErrWorkspaceStale)
+	fc := &fakeCommander{killErrs: map[domain.SessionID]error{"mer-1": staleErr}}
+	svc := &Service{manager: fc, store: st}
+
+	if err := svc.TeardownProject(context.Background(), "mer"); err != nil {
+		t.Fatalf("TeardownProject err = %v, want nil (stale worktree registration must be tolerated)", err)
+	}
+	if len(fc.cleanupProjects) != 1 || fc.cleanupProjects[0] != "mer" {
+		t.Fatalf("cleanup projects = %#v, want [mer] to still run after a tolerated stale-worktree failure", fc.cleanupProjects)
+	}
+}
+
+// TestTeardownProjectBlocksOnDirtyPreservedWorktree covers regression scenario
+// (a): a live session whose worktree Kill genuinely had to preserve rather
+// than force-delete (ports.ErrWorkspaceDirty surfaces from Kill as
+// freed=false, err=nil). That is the one case that truly must block removal
+// (fix points 2, 4, 6): TeardownProject must thread the freed=false signal
+// through and return a structured PROJECT_REMOVE_BLOCKED conflict — naming the
+// blocking session — instead of silently archiving the project out from under
+// preserved user work.
+func TestTeardownProjectBlocksOnDirtyPreservedWorktree(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/managed/mer/mer-1"},
+	}
+	fc := &fakeCommander{killNotFreed: map[domain.SessionID]bool{"mer-1": true}}
 	svc := &Service{manager: fc, store: st}
 
 	err := svc.TeardownProject(context.Background(), "mer")
-	if !errors.Is(err, boom) {
-		t.Fatalf("TeardownProject err = %v, want boom", err)
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("TeardownProject err = %v, want *apierr.Error", err)
 	}
-	if len(fc.cleanupProjects) != 0 {
-		t.Fatalf("cleanup projects = %#v, want none after kill failure", fc.cleanupProjects)
+	if apiErr.Kind != apierr.KindConflict {
+		t.Fatalf("kind = %v, want KindConflict (409)", apiErr.Kind)
+	}
+	if apiErr.Code != "PROJECT_REMOVE_BLOCKED" {
+		t.Fatalf("code = %q, want PROJECT_REMOVE_BLOCKED", apiErr.Code)
+	}
+	blocked, ok := apiErr.Details["blockedSessions"].([]map[string]string)
+	if !ok || len(blocked) != 1 || blocked[0]["sessionId"] != "mer-1" || blocked[0]["workspacePath"] != "/managed/mer/mer-1" {
+		t.Fatalf("details[blockedSessions] = %#v, want [{sessionId: mer-1, workspacePath: /managed/mer/mer-1}]", apiErr.Details["blockedSessions"])
 	}
 }
 


### PR DESCRIPTION
## Root cause

Project deletion (`DELETE /api/v1/projects/{id}`) goes through `project.Service.Remove` -> `session.Service.TeardownProject` -> `session.Service.Kill` per live session -> `session_manager.Manager.Kill`.

`TeardownProject` looped every non-terminated session and returned on the **first** raw error from `Kill`, and separately ignored `Kill`'s `freed` boolean entirely. `Manager.Kill` already special-cases a dirty, uncommitted worktree (`ports.ErrWorkspaceDirty`) by preserving it and returning `freed=false, err=nil` — a benign outcome. But **any other** teardown failure (a stale runtime handle, a missing or non-git worktree path, a prunable git worktree registration left behind by `git worktree prune`, an already-removed filesystem path, or a Windows sharing-violation on `os.RemoveAll` right after a runtime process is killed) comes back as a raw, unwrapped Go error. `toAPIError` only recognizes a small set of named sentinels; anything else passes through unchanged, and `envelope.WriteError` collapses any non-`*apierr.Error` into an opaque `500 INTERNAL_ERROR`. The project stays registered with no recovery path shown to the user.

Full trace and two independent reproductions (idle project, and a project with an actively-running session on Windows) are in #2598 and its comment.

## Fix

All changes are in `backend/internal/service/session/service.go`, scoped to `TeardownProject`:

1. **Tolerate legacy/corrupt local state (issue fix point 1).** `TeardownProject` no longer short-circuits on a session's `Kill` error. Every non-terminated session gets a `Kill` attempt; an error from any one of them is logged server-side with its original cause and otherwise ignored, so it cannot by itself block unregistering the project.
3. **Aggregate outcomes instead of first-error-wins (fix point 3).** The Kill loop now runs to completion across every session before `TeardownProject` decides success/failure/conflict, instead of aborting immediately.
2 & 6. **Typed `PROJECT_REMOVE_BLOCKED` conflict + thread `freed` through (fix points 2 and 6).** `Kill`'s previously-discarded `freed=false` result (dirty worktree genuinely preserved, not force-deleted) is now collected across every affected session. If any exist after the loop, `TeardownProject` returns a new `apierr.Conflict("PROJECT_REMOVE_BLOCKED", ...)` with structured `details.blockedSessions` (`sessionId` + `workspacePath` per entry) instead of silently succeeding or 500ing.
4. **409, not 500, for the genuinely-blocking case (fix point 4) — design choice.** The issue leaves "block with 409" vs "archive and preserve" as an explicit implementer choice. I chose **block with 409**: a project with only stale/legacy/corrupt teardown failures (no real user data at risk) now unregisters successfully, but a project with a live, dirty, unpreserved-by-normal-means worktree blocks removal with the new structured error rather than silently archiving the project while the worktree becomes orphaned and undiscoverable (the project entry that would have pointed back at it is gone). This matches `AGENTS.md`'s existing hard rule ("do not force-delete dirty registered worktrees") in spirit — removal of the *registration* stays blocked, not just the worktree deletion — and keeps the recovery path concrete (resolve/commit/discard the session's changes, or let it finish, then retry).
5. **Keep the raw cause in logs only (fix point 5).** Every tolerated failure is logged via `slog` (`s.logger.Warn`, guarded for nil in tests) with the real underlying error; the wire response is always either success or the structured conflict — never a raw 500 sourced from this path.
7. **Regression coverage (fix point 7).** Added to `backend/internal/service/session/service_test.go`, extending the existing `fakeCommander` with per-session `Kill` overrides (`killErrs`, `killNotFreed`) following the existing fake-injection pattern in that file:
   - `TestTeardownProjectBlocksOnDirtyPreservedWorktree` — scenario (a): a live dirty session worktree — asserts a `*apierr.Error` with `Kind == KindConflict` and `Code == "PROJECT_REMOVE_BLOCKED"`, with `details.blockedSessions` naming the session and its path.
   - `TestTeardownProjectToleratesStaleWorktreeRegistration` — scenario (b): a stale/prunable worktree registration, using an error wrapped around `ports.ErrWorkspaceStale` (the sentinel `gitworktree.Workspace.Destroy` actually returns for this shape) — asserts `TeardownProject` succeeds and `Cleanup` still runs.
   - `TestTeardownProjectToleratesUnrecognizedKillFailure` (repurposed from the old `TestTeardownProjectStopsOnKillError`, which asserted the buggy first-error-wins behavior) — scenario (c): a plain, unwrapped error not in `toAPIError`'s sentinel allowlist — asserts `TeardownProject` succeeds, the other session still gets killed, and `Cleanup` still runs.
   
   Also added `TestManager_RemoveSurfacesProjectRemoveBlockedConflict` in `backend/internal/service/project/service_test.go`, verifying the typed conflict survives `project.Service.Remove`'s pass-through unchanged and the project stays registered (not silently archived) when blocked.

### Not implemented

No DTO/OpenAPI changes: `APIError.Details` (`backend/internal/httpd/envelope/envelope.go`) is already a generic `map[string]any` on every endpoint's error schema, so the new code/details surface on the wire with no spec regeneration needed. No frontend changes: `frontend/src/renderer/routes/_shell.tsx`'s `removeProject` already renders whatever structured `message`/`code` the API returns generically, so this fix alone turns today's opaque "Internal server error (INTERNAL_ERROR)" into the real, actionable cause without any renderer changes.

## Verification

- Patch-based fail-then-pass (no `git stash`, to avoid colliding with other concurrent worktrees on this shared clone): isolated the `service.go` implementation diff into a patch file, reverse-applied it while keeping the new tests, confirmed all three new regression tests fail against the unpatched code (`TeardownProjectToleratesUnrecognizedKillFailure` and `TeardownProjectToleratesStaleWorktreeRegistration` propagate the raw error instead of tolerating it; `TeardownProjectBlocksOnDirtyPreservedWorktree` returns `nil` instead of the typed conflict), then re-applied the patch and confirmed all three pass.
- `cd backend && go build ./...` and `go vet ./...`: clean.
- Full test suite for every touched package: `go test ./internal/service/session/...` (all pass), `go test ./internal/service/project/...` (all pass except one pre-existing, unrelated Windows path-separator failure in `TestManager_InitializeRepositoryRecovery`, confirmed to already fail identically on a pristine `upstream/main` checkout with no code changes at all), `go test ./internal/httpd/...` (all pass, covers the envelope/controller error-mapping boundary).
- `go test -race` was not runnable in this sandbox (`CGO_ENABLED=0`, no `gcc` on PATH) — unrelated to this change, an environment limitation.

Addresses #2598.