### PR TITLE
feat: add multi-agent token usage observability

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -300,7 +300,7 @@ func Run() error {
 		usageCollector *usagesvc.Collector
 		usagePipeline  *usagepipeline.Pipeline
 	)
-	if roots, rootsErr := usagesvc.DefaultSourceRoots(ctx); rootsErr != nil {
+	if roots, rootsErr := usagesvc.DefaultSourceRoots(ctx, cfg.DataDir); rootsErr != nil {
 		log.Warn("usage collection disabled", "err", rootsErr)
 	} else {
 		usageCollector = usagesvc.NewCollector(store, roots, func(reconcile bool) {
@@ -318,6 +318,10 @@ func Run() error {
 			roots.ClaudeProjects,
 			roots.CodexSessions,
 			roots.CodexArchived,
+			roots.CopilotSessions,
+			roots.KimiHome,
+			roots.PiSessions,
+			roots.QwenUsage,
 		}, usagepipeline.CoordinatorConfig{
 			Logger:     log,
 			Initialize: usageCollector.BackfillActive,

--- a/backend/internal/domain/usage.go
+++ b/backend/internal/domain/usage.go
@@ -12,9 +12,13 @@ type UsageSourceKind string
 
 // UsageSourceKind values identify certified native usage artifact shapes.
 const (
-	UsageSourceClaudeMain     UsageSourceKind = "claude_main"
-	UsageSourceClaudeSubagent UsageSourceKind = "claude_subagent"
-	UsageSourceCodexRollout   UsageSourceKind = "codex_rollout"
+	UsageSourceClaudeMain      UsageSourceKind = "claude_main"
+	UsageSourceClaudeSubagent  UsageSourceKind = "claude_subagent"
+	UsageSourceCodexRollout    UsageSourceKind = "codex_rollout"
+	UsageSourceCopilotShutdown UsageSourceKind = "copilot_shutdown"
+	UsageSourceKimiWire        UsageSourceKind = "kimi_wire"
+	UsageSourcePiSession       UsageSourceKind = "pi_session"
+	UsageSourceQwenMonthly     UsageSourceKind = "qwen_monthly"
 )
 
 // UsageBindingState tracks the root native-session binding lifecycle.
@@ -117,6 +121,16 @@ type UsageTokenMetrics struct {
 	CacheWriteTokens    int64
 	OutputTokens        int64
 	ReasoningTokens     *int64
+}
+
+// UsageMetricCoverage describes which optional token buckets a harness's
+// certified native source can report. It is derived at read time so a source
+// that lacks a metric is not presented as a reported zero.
+type UsageMetricCoverage struct {
+	UncachedInput bool
+	CacheRead     bool
+	CacheWrite    bool
+	Reasoning     bool
 }
 
 // ModelUsageEvent is one append-only normalized usage fact.

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6899,6 +6899,8 @@ components:
       type: object
     ProjectSummary:
       properties:
+        config:
+          $ref: '#/components/schemas/ProjectConfig'
         id:
           type: string
         kind:

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6899,8 +6899,6 @@ components:
       type: object
     ProjectSummary:
       properties:
-        config:
-          $ref: '#/components/schemas/ProjectConfig'
         id:
           type: string
         kind:

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -531,10 +531,15 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	// rule, while their tracking side effects still land. Untagged signals
 	// (old CLIs, adapters without tool identity) pass through untouched —
 	// last-writer-wins, exactly as before.
-	metadataChanged := (s.AgentSessionID != "" && rec.Metadata.AgentSessionID != s.AgentSessionID) ||
+	nativeSessionChanged := s.AgentSessionID != "" && rec.Metadata.AgentSessionID != s.AgentSessionID
+	metadataChanged := nativeSessionChanged ||
 		(s.LatestUserPrompt != "" && rec.Metadata.LatestUserPrompt != s.LatestUserPrompt) ||
 		(s.LatestAssistantUpdate != "" && rec.Metadata.LatestAssistantUpdate != s.LatestAssistantUpdate) ||
 		(s.TranscriptPath != "" && rec.Metadata.NativeTranscriptPath != s.TranscriptPath)
+	var usageReactivator sessionUsageReactivator
+	if nativeSessionChanged {
+		usageReactivator = m.usageReactivator
+	}
 	if s.Valid {
 		s = m.applyToolPrecedenceLocked(id, rec.Activity.State, s)
 	}
@@ -547,6 +552,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		rec.UpdatedAt = now
 		_, err := m.store.UpdateSessionFromActivitySignal(ctx, rec)
 		m.mu.Unlock()
+		if err == nil {
+			reactivateSessionUsage(ctx, id, rec.Metadata.RuntimeLaunchID, usageReactivator)
+		}
 		return err
 	}
 	if metadataChanged {
@@ -573,6 +581,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 			}
 			if !applied {
 				return nil
+			}
+			if nativeSessionChanged {
+				reactivateSessionUsage(ctx, id, rec.Metadata.RuntimeLaunchID, usageReactivator)
 			}
 			return m.acknowledgeAgentSwitchTarget(ctx, id, s, now)
 		}
@@ -618,6 +629,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	resolutions := needsInputResolutions(rec, next, now)
 	waitingEvents := m.waitingInputEvents(next, prevState, prevAt, now)
 	m.mu.Unlock()
+	if nativeSessionChanged {
+		reactivateSessionUsage(ctx, id, next.Metadata.RuntimeLaunchID, usageReactivator)
+	}
 	if err := m.acknowledgeAgentSwitchTarget(ctx, id, s, now); err != nil {
 		return err
 	}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -1432,6 +1432,27 @@ func TestMarkSpawnedReactivatesUsageAfterLifecycleTransition(t *testing.T) {
 	}
 }
 
+func TestApplyActivitySignalNativeSessionIDReactivatesUsageDiscovery(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	rec.Metadata.RuntimeLaunchID = "launch-1"
+	st.sessions[rec.ID] = rec
+	usage := &fakeUsageLifecycle{fakeUsageFinalizer: fakeUsageFinalizer{store: st}}
+	m.SetUsageFinalizer(usage)
+
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		AgentSessionID: "pi-native-1",
+		LaunchID:       "launch-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if usage.reactivateCalls != 1 || usage.reactivateID != rec.ID ||
+		usage.reactivateLaunch != "launch-1" || !usage.sawLive {
+		t.Fatalf("usage discovery = calls:%d id:%q launch:%q live:%v",
+			usage.reactivateCalls, usage.reactivateID, usage.reactivateLaunch, usage.sawLive)
+	}
+}
+
 func TestMarkTerminatedFinalizesUsageBeforeLifecycleTransition(t *testing.T) {
 	m, st, _ := newManager()
 	rec := working("mer-1")

--- a/backend/internal/observe/usage/copilot_parser_test.go
+++ b/backend/internal/observe/usage/copilot_parser_test.go
@@ -63,6 +63,30 @@ func TestParseCopilotTracksModelsIndependently(t *testing.T) {
 	}
 }
 
+func TestParseCopilotAssistantMessageOutputTokens(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	records := []jsonlRecord{
+		{Data: []byte(`{"type":"assistant.message","id":"message-1","data":{"model":"gpt-5-mini","outputTokens":944}}`)},
+		{Data: []byte(`{"type":"assistant.message","id":"message-2","data":{"model":"gpt-5-mini","outputTokens":17}}`)},
+	}
+	result := parseRecords(source, records, 200, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("events = %+v, want one usage event per assistant message", result.Events)
+	}
+	if got := result.Events[0].Tokens; got.InputTokens != 0 || got.OutputTokens != 944 || got.ReasoningTokens != nil {
+		t.Fatalf("first tokens = %+v", got)
+	}
+	if got := result.Events[1].Tokens; got.InputTokens != 0 || got.OutputTokens != 17 || got.ReasoningTokens != nil {
+		t.Fatalf("second tokens = %+v", got)
+	}
+	if result.Events[0].SourceEventKey == "" || result.Events[0].SourceEventKey == result.Events[1].SourceEventKey {
+		t.Fatalf("event keys = %q/%q", result.Events[0].SourceEventKey, result.Events[1].SourceEventKey)
+	}
+}
+
 // TestParseCopilotCounterRegressionResetsBaseline catches negative usage deltas
 // after Copilot starts a new cumulative epoch.
 func TestParseCopilotCounterRegressionResetsBaseline(t *testing.T) {

--- a/backend/internal/observe/usage/copilot_parser_test.go
+++ b/backend/internal/observe/usage/copilot_parser_test.go
@@ -102,6 +102,28 @@ func TestParseCopilotPrefersShutdownRollupOverAssistantMessages(t *testing.T) {
 	}
 }
 
+func TestParseCopilotLaterShutdownSuppressesAlreadyParsedAssistantMessage(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	first := parseRecords(source, []jsonlRecord{
+		{Offset: 0, Data: []byte(`{"type":"assistant.message","id":"message-1","data":{"model":"gpt-5-mini","outputTokens":17}}`)},
+	}, 100, time.Unix(1700000000, 0).UTC())
+	if first.err != nil || len(first.Events) != 1 {
+		t.Fatalf("first result = %+v", first)
+	}
+
+	source.Source.ParserStateJSON = first.Cursor.ParserStateJSON
+	second := parseRecords(source, []jsonlRecord{
+		{Offset: 100, Data: copilotShutdownLine("gpt-5-mini", 100, 60, 10, 17, 5)},
+	}, 200, time.Unix(1700000001, 0).UTC())
+	if second.err != nil || len(second.Events) != 1 {
+		t.Fatalf("second result = %+v", second)
+	}
+	if got := second.Events[0].Tokens; got.InputTokens != 100 || got.OutputTokens != 0 ||
+		got.ReasoningTokens == nil || *got.ReasoningTokens != 0 {
+		t.Fatalf("shutdown delta tokens = %+v", got)
+	}
+}
+
 // TestParseCopilotCounterRegressionResetsBaseline catches negative usage deltas
 // after Copilot starts a new cumulative epoch.
 func TestParseCopilotCounterRegressionResetsBaseline(t *testing.T) {

--- a/backend/internal/observe/usage/copilot_parser_test.go
+++ b/backend/internal/observe/usage/copilot_parser_test.go
@@ -1,0 +1,97 @@
+package usage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// TestParseCopilotCumulativeShutdownDeltas catches counting repeated shutdown
+// summaries twice or treating inclusive input as ordinary input.
+func TestParseCopilotCumulativeShutdownDeltas(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	records := []jsonlRecord{
+		{Offset: 0, Data: copilotShutdownLine("claude-haiku-4.5", 111529, 86021, 25483, 901, 251)},
+		{Offset: 100, Data: copilotShutdownLine("claude-haiku-4.5", 111529, 86021, 25483, 901, 251)},
+		{Offset: 200, Data: copilotShutdownLine("claude-haiku-4.5", 120000, 90000, 26000, 950, 275)},
+	}
+
+	result := parseRecords(source, records, 300, now)
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("events = %d, want initial total and one positive delta", len(result.Events))
+	}
+	first := result.Events[0]
+	if first.ModelID != "claude-haiku-4.5" {
+		t.Fatalf("model = %q", first.ModelID)
+	}
+	if got := first.Tokens; got.InputTokens != 111529 || got.UncachedInputTokens != 25 ||
+		got.CacheReadTokens != 86021 || got.CacheWriteTokens != 25483 ||
+		got.OutputTokens != 901 || got.ReasoningTokens == nil || *got.ReasoningTokens != 251 {
+		t.Fatalf("first tokens = %+v", got)
+	}
+	if got := result.Events[1].Tokens; got.InputTokens != 8471 || got.UncachedInputTokens != 3975 ||
+		got.CacheReadTokens != 3979 || got.CacheWriteTokens != 517 ||
+		got.OutputTokens != 49 || got.ReasoningTokens == nil || *got.ReasoningTokens != 24 {
+		t.Fatalf("delta tokens = %+v", got)
+	}
+	if first.SourceEventKey == "" || first.SourceEventKey == result.Events[1].SourceEventKey {
+		t.Fatalf("event keys = %q/%q", first.SourceEventKey, result.Events[1].SourceEventKey)
+	}
+}
+
+// TestParseCopilotTracksModelsIndependently catches one model switch replacing
+// the baseline for another model in the same native session.
+func TestParseCopilotTracksModelsIndependently(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	record := jsonlRecord{Data: []byte(`{"type":"session.shutdown","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":100,"outputTokens":20,"cacheReadTokens":60,"cacheWriteTokens":10,"reasoningTokens":5}},"claude-haiku-4.5":{"usage":{"inputTokens":40,"outputTokens":8,"cacheReadTokens":20,"cacheWriteTokens":5,"reasoningTokens":2}}}}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("events = %+v, want one event per model", result.Events)
+	}
+	state := parserStateFromResult(t, result, domain.UsageSourceCopilotShutdown)
+	if len(state.Copilot.Models) != 2 || state.Copilot.Models["gpt-5-mini"].InputTokens != 100 {
+		t.Fatalf("state = %+v", state.Copilot)
+	}
+}
+
+// TestParseCopilotCounterRegressionResetsBaseline catches negative usage deltas
+// after Copilot starts a new cumulative epoch.
+func TestParseCopilotCounterRegressionResetsBaseline(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	first := parseRecords(source, []jsonlRecord{{Data: copilotShutdownLine("gpt-5-mini", 100, 60, 10, 20, 5)}}, 100, time.Unix(1700000000, 0).UTC())
+	if first.err != nil || len(first.Events) != 1 {
+		t.Fatalf("first parse = %+v", first)
+	}
+	source.Source.ParserStateJSON = first.Cursor.ParserStateJSON
+	reset := parseRecords(source, []jsonlRecord{{Data: copilotShutdownLine("gpt-5-mini", 10, 5, 0, 2, 1)}}, 200, time.Unix(1700000001, 0).UTC())
+	if reset.err != nil {
+		t.Fatal(reset.err)
+	}
+	if len(reset.Events) != 0 || reset.Cursor.AnomalyCount != 1 ||
+		reset.Cursor.LastErrorCode != domain.UsageErrorNonMonotonicCumulativeUsage {
+		t.Fatalf("reset result = %+v", reset)
+	}
+	state := parserStateFromResult(t, reset, domain.UsageSourceCopilotShutdown)
+	if state.Copilot.Models["gpt-5-mini"].InputTokens != 10 {
+		t.Fatalf("reset state = %+v", state.Copilot)
+	}
+}
+
+func copilotShutdownLine(model string, input, cacheRead, cacheWrite, output, reasoning int64) []byte {
+	return []byte(`{"type":"session.shutdown","data":{"modelMetrics":{"` + model + `":{"usage":{"inputTokens":` +
+		intString(input) + `,"outputTokens":` + intString(output) + `,"cacheReadTokens":` + intString(cacheRead) +
+		`,"cacheWriteTokens":` + intString(cacheWrite) + `,"reasoningTokens":` + intString(reasoning) + `}}}}}`)
+}
+
+func intString(value int64) string {
+	return fmt.Sprintf("%d", value)
+}

--- a/backend/internal/observe/usage/copilot_parser_test.go
+++ b/backend/internal/observe/usage/copilot_parser_test.go
@@ -87,6 +87,21 @@ func TestParseCopilotAssistantMessageOutputTokens(t *testing.T) {
 	}
 }
 
+func TestParseCopilotPrefersShutdownRollupOverAssistantMessages(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	records := []jsonlRecord{
+		{Data: []byte(`{"type":"assistant.message","id":"message-1","data":{"model":"gpt-5-mini","outputTokens":17}}`)},
+		{Data: copilotShutdownLine("gpt-5-mini", 100, 60, 10, 17, 5)},
+	}
+	result := parseRecords(source, records, 200, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := result.Events[0].Tokens; got.InputTokens != 100 || got.OutputTokens != 17 || got.ReasoningTokens == nil || *got.ReasoningTokens != 5 {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
 // TestParseCopilotCounterRegressionResetsBaseline catches negative usage deltas
 // after Copilot starts a new cumulative epoch.
 func TestParseCopilotCounterRegressionResetsBaseline(t *testing.T) {

--- a/backend/internal/observe/usage/kimi_parser_test.go
+++ b/backend/internal/observe/usage/kimi_parser_test.go
@@ -33,6 +33,25 @@ func TestParseKimiUsageRecord(t *testing.T) {
 	}
 }
 
+func TestParseKimiUsageRecordWithNumericTime(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	record := jsonlRecord{Offset: 100, Data: []byte(`{"time":1797038183476.96,"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":6697,"output":39,"inputCacheRead":19200,"inputCacheCreation":0},"usageScope":"turn"}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %+v, want one usage record", result.Events)
+	}
+	if got := result.Events[0].Tokens; got.InputTokens != 25897 || got.UncachedInputTokens != 6697 ||
+		got.CacheReadTokens != 19200 || got.CacheWriteTokens != 0 || got.OutputTokens != 39 {
+		t.Fatalf("tokens = %+v", got)
+	}
+	if result.Events[0].SourceEventKey == "" {
+		t.Fatalf("event key is empty")
+	}
+}
+
 func TestParseKimiUsageRecordHasReplayStableKey(t *testing.T) {
 	source := usageSource(domain.UsageSourceKimiWire)
 	record := jsonlRecord{Offset: 100, Data: []byte(`{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":1,"inputCacheRead":2,"inputCacheCreation":3,"output":4}}`)}

--- a/backend/internal/observe/usage/kimi_parser_test.go
+++ b/backend/internal/observe/usage/kimi_parser_test.go
@@ -1,0 +1,59 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// TestParseKimiUsageRecord catches omitting cache buckets from Kimi's ordinary
+// input field or counting unrelated wire records as usage.
+func TestParseKimiUsageRecord(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	records := []jsonlRecord{
+		{Offset: 0, Data: []byte(`{"id":"message-1","time":"2026-08-09T09:59:00Z","type":"message.create","message":{}}`)},
+		{Offset: 100, Data: []byte(`{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":13,"inputCacheRead":21,"inputCacheCreation":8,"output":5},"usageScope":"turn"}`)},
+	}
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %+v, want one usage record", result.Events)
+	}
+	event := result.Events[0]
+	if event.ModelID != "kimi-for-coding" || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	if got := event.Tokens; got.InputTokens != 42 || got.UncachedInputTokens != 13 ||
+		got.CacheReadTokens != 21 || got.CacheWriteTokens != 8 || got.OutputTokens != 5 ||
+		got.ReasoningTokens != nil {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseKimiUsageRecordHasReplayStableKey(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	record := jsonlRecord{Offset: 100, Data: []byte(`{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":1,"inputCacheRead":2,"inputCacheCreation":3,"output":4}}`)}
+	first := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000000, 0).UTC())
+	second := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000001, 0).UTC())
+	if first.err != nil || second.err != nil || len(first.Events) != 1 || len(second.Events) != 1 {
+		t.Fatalf("first=%+v second=%+v", first, second)
+	}
+	if first.Events[0].SourceEventKey != second.Events[0].SourceEventKey {
+		t.Fatalf("keys = %q/%q", first.Events[0].SourceEventKey, second.Events[0].SourceEventKey)
+	}
+}
+
+func TestParseKimiRejectsNegativeUsage(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	record := jsonlRecord{Data: []byte(`{"id":"usage-bad","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":-1,"inputCacheRead":0,"inputCacheCreation":0,"output":1}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 || result.Cursor.LastErrorCode != domain.UsageErrorMalformedJSONL {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -43,6 +43,8 @@ func parseRecordsWithState(
 	case domain.UsageSourceCodexRollout:
 		parseCodex(source, records, state.Codex, &result)
 		result.pendingCodexSpawnCalls = len(state.Codex.PendingSpawnCallIDs)
+	case domain.UsageSourceCopilotShutdown:
+		parseCopilot(source, records, state.Copilot, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -89,6 +91,7 @@ type parserStateEnvelope struct {
 	Integrity  *parserIntegrityStateV1 `json:"integrity,omitempty"`
 	Claude     *claudeParserStateV1    `json:"claude,omitempty"`
 	Codex      *codexParserStateV1     `json:"codex,omitempty"`
+	Copilot    *copilotParserStateV1   `json:"copilot,omitempty"`
 }
 
 type parserIntegrityStateV1 struct {
@@ -123,6 +126,18 @@ type codexParserStateV1 struct {
 	DirectParentID      string           `json:"direct_parent_id,omitempty"`
 	PendingSpawnCallIDs []string         `json:"pending_spawn_call_ids"`
 	DiscoveredChildIDs  []string         `json:"discovered_child_ids"`
+}
+
+type copilotTokenVector struct {
+	InputTokens      int64 `json:"input_tokens"`
+	CacheReadTokens  int64 `json:"cache_read_tokens"`
+	CacheWriteTokens int64 `json:"cache_write_tokens"`
+	OutputTokens     int64 `json:"output_tokens"`
+	ReasoningTokens  int64 `json:"reasoning_tokens"`
+}
+
+type copilotParserStateV1 struct {
+	Models map[string]copilotTokenVector `json:"models"`
 }
 
 func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, error) {
@@ -166,12 +181,12 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 	}
 	switch source.Kind {
 	case domain.UsageSourceClaudeMain, domain.UsageSourceClaudeSubagent:
-		if state.Claude == nil || state.Codex != nil {
+		if state.Claude == nil || state.Codex != nil || state.Copilot != nil {
 			return nil, errors.New("claude state has invalid parser payload")
 		}
 		state.Claude.LegacyProvider = ""
 	case domain.UsageSourceCodexRollout:
-		if state.Codex == nil || state.Claude != nil {
+		if state.Codex == nil || state.Claude != nil || state.Copilot != nil {
 			return nil, errors.New("codex state has invalid parser payload")
 		}
 		if state.Codex.PendingSpawnCallIDs == nil {
@@ -186,6 +201,18 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 		}
 		if err := validateCodexDirectParent(source, state.Codex); err != nil {
 			return nil, err
+		}
+	case domain.UsageSourceCopilotShutdown:
+		if state.Copilot == nil || state.Claude != nil || state.Codex != nil {
+			return nil, errors.New("copilot state has invalid parser payload")
+		}
+		if state.Copilot.Models == nil {
+			state.Copilot.Models = make(map[string]copilotTokenVector)
+		}
+		for model, total := range state.Copilot.Models {
+			if firstNonEmpty(model) == "" || !validCopilotTotal(total) {
+				return nil, errors.New("copilot state has invalid model baseline")
+			}
 		}
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", source.Kind)
@@ -206,6 +233,8 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 			PendingSpawnCallIDs: []string{},
 			DiscoveredChildIDs:  []string{},
 		}
+	case domain.UsageSourceCopilotShutdown:
+		state.Copilot = &copilotParserStateV1{Models: make(map[string]copilotTokenVector)}
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", kind)
 	}

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -45,6 +45,12 @@ func parseRecordsWithState(
 		result.pendingCodexSpawnCalls = len(state.Codex.PendingSpawnCallIDs)
 	case domain.UsageSourceCopilotShutdown:
 		parseCopilot(source, records, state.Copilot, &result)
+	case domain.UsageSourceKimiWire:
+		parseKimi(source, records, &result)
+	case domain.UsageSourcePiSession:
+		parsePi(source, records, &result)
+	case domain.UsageSourceQwenMonthly:
+		parseQwen(source, records, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -214,6 +220,10 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 				return nil, errors.New("copilot state has invalid model baseline")
 			}
 		}
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession, domain.UsageSourceQwenMonthly:
+		if state.Claude != nil || state.Codex != nil || state.Copilot != nil {
+			return nil, errors.New("append-only state has invalid parser payload")
+		}
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", source.Kind)
 	}
@@ -235,6 +245,9 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 		}
 	case domain.UsageSourceCopilotShutdown:
 		state.Copilot = &copilotParserStateV1{Models: make(map[string]copilotTokenVector)}
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession, domain.UsageSourceQwenMonthly:
+		// Append-only sources derive replay-stable event keys from native record IDs
+		// and do not need a provider-specific parser baseline.
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", kind)
 	}

--- a/backend/internal/observe/usage/parser_copilot.go
+++ b/backend/internal/observe/usage/parser_copilot.go
@@ -1,0 +1,125 @@
+package usage
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type copilotTranscriptRecord struct {
+	Type string `json:"type"`
+	Data struct {
+		ModelMetrics map[string]struct {
+			Usage *struct {
+				InputTokens      int64 `json:"inputTokens"`
+				OutputTokens     int64 `json:"outputTokens"`
+				CacheReadTokens  int64 `json:"cacheReadTokens"`
+				CacheWriteTokens int64 `json:"cacheWriteTokens"`
+				ReasoningTokens  int64 `json:"reasoningTokens"`
+			} `json:"usage"`
+		} `json:"modelMetrics"`
+	} `json:"data"`
+}
+
+func parseCopilot(
+	source domain.UsageSourceContext,
+	records []jsonlRecord,
+	state *copilotParserStateV1,
+	result *parseResult,
+) {
+	for _, record := range records {
+		var native copilotTranscriptRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "session.shutdown" {
+			continue
+		}
+		for nativeModel, metrics := range native.Data.ModelMetrics {
+			model := firstNonEmpty(nativeModel)
+			if model == "" || metrics.Usage == nil {
+				recordMalformed(result)
+				continue
+			}
+			usage := metrics.Usage
+			total := copilotTokenVector{
+				InputTokens:      usage.InputTokens,
+				CacheReadTokens:  usage.CacheReadTokens,
+				CacheWriteTokens: usage.CacheWriteTokens,
+				OutputTokens:     usage.OutputTokens,
+				ReasoningTokens:  usage.ReasoningTokens,
+			}
+			if !validCopilotTotal(total) {
+				recordMalformed(result)
+				continue
+			}
+			baseline := state.Models[model]
+			if copilotCounterRegressed(total, baseline) {
+				state.Models[model] = total
+				result.Cursor.AnomalyCount++
+				result.Cursor.LastErrorCode = domain.UsageErrorNonMonotonicCumulativeUsage
+				continue
+			}
+			delta := subtractCopilotTotal(total, baseline)
+			state.Models[model] = total
+			if delta.InputTokens == 0 && delta.OutputTokens == 0 && delta.CacheWriteTokens == 0 {
+				continue
+			}
+			uncached := delta.InputTokens - delta.CacheReadTokens - delta.CacheWriteTokens
+			tokens := domain.UsageTokenMetrics{
+				InputTokens:         delta.InputTokens,
+				UncachedInputTokens: uncached,
+				CacheReadTokens:     delta.CacheReadTokens,
+				CacheWriteTokens:    delta.CacheWriteTokens,
+				OutputTokens:        delta.OutputTokens,
+				ReasoningTokens:     int64Ptr(delta.ReasoningTokens),
+			}
+			if !validTokenMetrics(tokens) {
+				recordMalformed(result)
+				continue
+			}
+			result.Events = append(result.Events, domain.ModelUsageEvent{
+				ModelID: model,
+				Tokens:  tokens,
+				SourceEventKey: stableSourceEventKey(
+					"copilot",
+					source.NativeRootID,
+					model,
+					strconv.FormatInt(total.InputTokens, 10),
+					strconv.FormatInt(total.CacheReadTokens, 10),
+					strconv.FormatInt(total.CacheWriteTokens, 10),
+					strconv.FormatInt(total.OutputTokens, 10),
+					strconv.FormatInt(total.ReasoningTokens, 10),
+				),
+			})
+		}
+	}
+}
+
+func validCopilotTotal(total copilotTokenVector) bool {
+	return total.InputTokens >= 0 && total.CacheReadTokens >= 0 && total.CacheWriteTokens >= 0 &&
+		total.OutputTokens >= 0 && total.ReasoningTokens >= 0 &&
+		total.CacheReadTokens <= total.InputTokens &&
+		total.CacheWriteTokens <= total.InputTokens-total.CacheReadTokens &&
+		total.ReasoningTokens <= total.OutputTokens
+}
+
+func copilotCounterRegressed(total, baseline copilotTokenVector) bool {
+	return total.InputTokens < baseline.InputTokens ||
+		total.CacheReadTokens < baseline.CacheReadTokens ||
+		total.CacheWriteTokens < baseline.CacheWriteTokens ||
+		total.OutputTokens < baseline.OutputTokens ||
+		total.ReasoningTokens < baseline.ReasoningTokens
+}
+
+func subtractCopilotTotal(total, baseline copilotTokenVector) copilotTokenVector {
+	return copilotTokenVector{
+		InputTokens:      total.InputTokens - baseline.InputTokens,
+		CacheReadTokens:  total.CacheReadTokens - baseline.CacheReadTokens,
+		CacheWriteTokens: total.CacheWriteTokens - baseline.CacheWriteTokens,
+		OutputTokens:     total.OutputTokens - baseline.OutputTokens,
+		ReasoningTokens:  total.ReasoningTokens - baseline.ReasoningTokens,
+	}
+}

--- a/backend/internal/observe/usage/parser_copilot.go
+++ b/backend/internal/observe/usage/parser_copilot.go
@@ -8,9 +8,14 @@ import (
 )
 
 type copilotTranscriptRecord struct {
+	ID   string `json:"id"`
 	Type string `json:"type"`
 	Data struct {
-		ModelMetrics map[string]struct {
+		Model           string `json:"model"`
+		InputTokens     int64  `json:"inputTokens"`
+		OutputTokens    int64  `json:"outputTokens"`
+		ReasoningTokens *int64 `json:"reasoningTokens"`
+		ModelMetrics    map[string]struct {
 			Usage *struct {
 				InputTokens      int64 `json:"inputTokens"`
 				OutputTokens     int64 `json:"outputTokens"`
@@ -34,67 +39,118 @@ func parseCopilot(
 			recordMalformed(result)
 			continue
 		}
-		if native.Type != "session.shutdown" {
+		switch native.Type {
+		case "assistant.message":
+			appendCopilotAssistantMessageUsage(source, record, native, result)
+		case "session.shutdown":
+			parseCopilotShutdownUsage(source, native, state, result)
+		default:
 			continue
 		}
-		for nativeModel, metrics := range native.Data.ModelMetrics {
-			model := firstNonEmpty(nativeModel)
-			if model == "" || metrics.Usage == nil {
-				recordMalformed(result)
-				continue
-			}
-			usage := metrics.Usage
-			total := copilotTokenVector{
-				InputTokens:      usage.InputTokens,
-				CacheReadTokens:  usage.CacheReadTokens,
-				CacheWriteTokens: usage.CacheWriteTokens,
-				OutputTokens:     usage.OutputTokens,
-				ReasoningTokens:  usage.ReasoningTokens,
-			}
-			if !validCopilotTotal(total) {
-				recordMalformed(result)
-				continue
-			}
-			baseline := state.Models[model]
-			if copilotCounterRegressed(total, baseline) {
-				state.Models[model] = total
-				result.Cursor.AnomalyCount++
-				result.Cursor.LastErrorCode = domain.UsageErrorNonMonotonicCumulativeUsage
-				continue
-			}
-			delta := subtractCopilotTotal(total, baseline)
-			state.Models[model] = total
-			if delta.InputTokens == 0 && delta.OutputTokens == 0 && delta.CacheWriteTokens == 0 {
-				continue
-			}
-			uncached := delta.InputTokens - delta.CacheReadTokens - delta.CacheWriteTokens
-			tokens := domain.UsageTokenMetrics{
-				InputTokens:         delta.InputTokens,
-				UncachedInputTokens: uncached,
-				CacheReadTokens:     delta.CacheReadTokens,
-				CacheWriteTokens:    delta.CacheWriteTokens,
-				OutputTokens:        delta.OutputTokens,
-				ReasoningTokens:     int64Ptr(delta.ReasoningTokens),
-			}
-			if !validTokenMetrics(tokens) {
-				recordMalformed(result)
-				continue
-			}
-			result.Events = append(result.Events, domain.ModelUsageEvent{
-				ModelID: model,
-				Tokens:  tokens,
-				SourceEventKey: stableSourceEventKey(
-					"copilot",
-					source.NativeRootID,
-					model,
-					strconv.FormatInt(total.InputTokens, 10),
-					strconv.FormatInt(total.CacheReadTokens, 10),
-					strconv.FormatInt(total.CacheWriteTokens, 10),
-					strconv.FormatInt(total.OutputTokens, 10),
-					strconv.FormatInt(total.ReasoningTokens, 10),
-				),
-			})
+	}
+}
+
+func appendCopilotAssistantMessageUsage(
+	source domain.UsageSourceContext,
+	record jsonlRecord,
+	native copilotTranscriptRecord,
+	result *parseResult,
+) {
+	model := firstNonEmpty(native.Data.Model)
+	if model == "" || native.Data.InputTokens < 0 || native.Data.OutputTokens < 0 ||
+		(native.Data.ReasoningTokens != nil && (*native.Data.ReasoningTokens < 0 || *native.Data.ReasoningTokens > native.Data.OutputTokens)) {
+		recordMalformed(result)
+		return
+	}
+	if native.Data.InputTokens == 0 && native.Data.OutputTokens == 0 {
+		return
+	}
+	tokens := domain.UsageTokenMetrics{
+		InputTokens:         native.Data.InputTokens,
+		UncachedInputTokens: native.Data.InputTokens,
+		OutputTokens:        native.Data.OutputTokens,
+		ReasoningTokens:     native.Data.ReasoningTokens,
+	}
+	if !validTokenMetrics(tokens) {
+		recordMalformed(result)
+		return
+	}
+	identity := firstNonEmpty(native.ID, strconv.FormatInt(record.Offset, 10))
+	result.Events = append(result.Events, domain.ModelUsageEvent{
+		ModelID: model,
+		Tokens:  tokens,
+		SourceEventKey: stableSourceEventKey(
+			"copilot-message",
+			source.NativeRootID,
+			model,
+			identity,
+		),
+	})
+}
+
+func parseCopilotShutdownUsage(
+	source domain.UsageSourceContext,
+	native copilotTranscriptRecord,
+	state *copilotParserStateV1,
+	result *parseResult,
+) {
+	for nativeModel, metrics := range native.Data.ModelMetrics {
+		model := firstNonEmpty(nativeModel)
+		if model == "" || metrics.Usage == nil {
+			recordMalformed(result)
+			continue
 		}
+		usage := metrics.Usage
+		total := copilotTokenVector{
+			InputTokens:      usage.InputTokens,
+			CacheReadTokens:  usage.CacheReadTokens,
+			CacheWriteTokens: usage.CacheWriteTokens,
+			OutputTokens:     usage.OutputTokens,
+			ReasoningTokens:  usage.ReasoningTokens,
+		}
+		if !validCopilotTotal(total) {
+			recordMalformed(result)
+			continue
+		}
+		baseline := state.Models[model]
+		if copilotCounterRegressed(total, baseline) {
+			state.Models[model] = total
+			result.Cursor.AnomalyCount++
+			result.Cursor.LastErrorCode = domain.UsageErrorNonMonotonicCumulativeUsage
+			continue
+		}
+		delta := subtractCopilotTotal(total, baseline)
+		state.Models[model] = total
+		if delta.InputTokens == 0 && delta.OutputTokens == 0 && delta.CacheWriteTokens == 0 {
+			continue
+		}
+		uncached := delta.InputTokens - delta.CacheReadTokens - delta.CacheWriteTokens
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         delta.InputTokens,
+			UncachedInputTokens: uncached,
+			CacheReadTokens:     delta.CacheReadTokens,
+			CacheWriteTokens:    delta.CacheWriteTokens,
+			OutputTokens:        delta.OutputTokens,
+			ReasoningTokens:     int64Ptr(delta.ReasoningTokens),
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"copilot",
+				source.NativeRootID,
+				model,
+				strconv.FormatInt(total.InputTokens, 10),
+				strconv.FormatInt(total.CacheReadTokens, 10),
+				strconv.FormatInt(total.CacheWriteTokens, 10),
+				strconv.FormatInt(total.OutputTokens, 10),
+				strconv.FormatInt(total.ReasoningTokens, 10),
+			),
+		})
 	}
 }
 

--- a/backend/internal/observe/usage/parser_copilot.go
+++ b/backend/internal/observe/usage/parser_copilot.go
@@ -50,7 +50,7 @@ func parseCopilot(
 		switch native.Type {
 		case "assistant.message":
 			if !hasShutdown {
-				appendCopilotAssistantMessageUsage(source, record, native, result)
+				appendCopilotAssistantMessageUsage(source, record, native, state, result)
 			}
 		case "session.shutdown":
 			parseCopilotShutdownUsage(source, native, state, result)
@@ -64,6 +64,7 @@ func appendCopilotAssistantMessageUsage(
 	source domain.UsageSourceContext,
 	record jsonlRecord,
 	native copilotTranscriptRecord,
+	state *copilotParserStateV1,
 	result *parseResult,
 ) {
 	model := firstNonEmpty(native.Data.Model)
@@ -85,6 +86,13 @@ func appendCopilotAssistantMessageUsage(
 		recordMalformed(result)
 		return
 	}
+	baseline := state.Models[model]
+	baseline.InputTokens += native.Data.InputTokens
+	baseline.OutputTokens += native.Data.OutputTokens
+	if native.Data.ReasoningTokens != nil {
+		baseline.ReasoningTokens += *native.Data.ReasoningTokens
+	}
+	state.Models[model] = baseline
 	identity := firstNonEmpty(native.ID, strconv.FormatInt(record.Offset, 10))
 	result.Events = append(result.Events, domain.ModelUsageEvent{
 		ModelID: model,
@@ -130,6 +138,9 @@ func parseCopilotShutdownUsage(
 			continue
 		}
 		delta := subtractCopilotTotal(total, baseline)
+		if delta.ReasoningTokens > delta.OutputTokens {
+			delta.ReasoningTokens = delta.OutputTokens
+		}
 		state.Models[model] = total
 		if delta.InputTokens == 0 && delta.OutputTokens == 0 && delta.CacheWriteTokens == 0 {
 			continue

--- a/backend/internal/observe/usage/parser_copilot.go
+++ b/backend/internal/observe/usage/parser_copilot.go
@@ -33,6 +33,14 @@ func parseCopilot(
 	state *copilotParserStateV1,
 	result *parseResult,
 ) {
+	hasShutdown := false
+	for _, record := range records {
+		var native copilotTranscriptRecord
+		if json.Unmarshal(record.Data, &native) == nil && native.Type == "session.shutdown" {
+			hasShutdown = true
+			break
+		}
+	}
 	for _, record := range records {
 		var native copilotTranscriptRecord
 		if err := json.Unmarshal(record.Data, &native); err != nil {
@@ -41,7 +49,9 @@ func parseCopilot(
 		}
 		switch native.Type {
 		case "assistant.message":
-			appendCopilotAssistantMessageUsage(source, record, native, result)
+			if !hasShutdown {
+				appendCopilotAssistantMessageUsage(source, record, native, result)
+			}
 		case "session.shutdown":
 			parseCopilotShutdownUsage(source, native, state, result)
 		default:

--- a/backend/internal/observe/usage/parser_kimi.go
+++ b/backend/internal/observe/usage/parser_kimi.go
@@ -8,10 +8,10 @@ import (
 )
 
 type kimiWireRecord struct {
-	ID    string `json:"id"`
-	Time  string `json:"time"`
-	Type  string `json:"type"`
-	Model string `json:"model"`
+	ID    string          `json:"id"`
+	Time  json.RawMessage `json:"time"`
+	Type  string          `json:"type"`
+	Model string          `json:"model"`
 	Usage *struct {
 		InputOther         int64 `json:"inputOther"`
 		InputCacheRead     int64 `json:"inputCacheRead"`
@@ -52,7 +52,7 @@ func parseKimi(source domain.UsageSourceContext, records []jsonlRecord, result *
 			recordMalformed(result)
 			continue
 		}
-		identity := firstNonEmpty(native.ID, native.Time, strconv.FormatInt(record.Offset, 10))
+		identity := firstNonEmpty(native.ID, kimiRecordTimeIdentity(native.Time), strconv.FormatInt(record.Offset, 10))
 		result.Events = append(result.Events, domain.ModelUsageEvent{
 			ModelID: model,
 			Tokens:  tokens,
@@ -65,4 +65,19 @@ func parseKimi(source domain.UsageSourceContext, records []jsonlRecord, result *
 			),
 		})
 	}
+}
+
+func kimiRecordTimeIdentity(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String()
+	}
+	return ""
 }

--- a/backend/internal/observe/usage/parser_kimi.go
+++ b/backend/internal/observe/usage/parser_kimi.go
@@ -1,0 +1,68 @@
+package usage
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type kimiWireRecord struct {
+	ID    string `json:"id"`
+	Time  string `json:"time"`
+	Type  string `json:"type"`
+	Model string `json:"model"`
+	Usage *struct {
+		InputOther         int64 `json:"inputOther"`
+		InputCacheRead     int64 `json:"inputCacheRead"`
+		InputCacheCreation int64 `json:"inputCacheCreation"`
+		Output             int64 `json:"output"`
+	} `json:"usage"`
+}
+
+func parseKimi(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	for _, record := range records {
+		var native kimiWireRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "usage.record" {
+			continue
+		}
+		model := firstNonEmpty(native.Model)
+		if model == "" || native.Usage == nil {
+			recordMalformed(result)
+			continue
+		}
+		usage := native.Usage
+		input, ok := sumNonNegative(usage.InputOther, usage.InputCacheRead, usage.InputCacheCreation)
+		if !ok || usage.Output < 0 {
+			recordMalformed(result)
+			continue
+		}
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         input,
+			UncachedInputTokens: usage.InputOther,
+			CacheReadTokens:     usage.InputCacheRead,
+			CacheWriteTokens:    usage.InputCacheCreation,
+			OutputTokens:        usage.Output,
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		identity := firstNonEmpty(native.ID, native.Time, strconv.FormatInt(record.Offset, 10))
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"kimi",
+				source.NativeRootID,
+				source.Source.SubagentID,
+				identity,
+				model,
+			),
+		})
+	}
+}

--- a/backend/internal/observe/usage/parser_pi.go
+++ b/backend/internal/observe/usage/parser_pi.go
@@ -1,0 +1,77 @@
+package usage
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type piSessionRecord struct {
+	Type    string `json:"type"`
+	ID      string `json:"id"`
+	Message *struct {
+		Role     string `json:"role"`
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+		Usage    *struct {
+			Input      int64 `json:"input"`
+			Output     int64 `json:"output"`
+			CacheRead  int64 `json:"cacheRead"`
+			CacheWrite int64 `json:"cacheWrite"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+func parsePi(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	for _, record := range records {
+		var native piSessionRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "message" || native.Message == nil || native.Message.Role != "assistant" {
+			continue
+		}
+		message := native.Message
+		model := firstNonEmpty(message.Model)
+		if model == "" || message.Usage == nil {
+			recordMalformed(result)
+			continue
+		}
+		provider := firstNonEmpty(message.Provider)
+		if provider != "" {
+			model = provider + "/" + model
+		}
+		usage := message.Usage
+		input, ok := sumNonNegative(usage.Input, usage.CacheRead, usage.CacheWrite)
+		if !ok || usage.Output < 0 {
+			recordMalformed(result)
+			continue
+		}
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         input,
+			UncachedInputTokens: usage.Input,
+			CacheReadTokens:     usage.CacheRead,
+			CacheWriteTokens:    usage.CacheWrite,
+			OutputTokens:        usage.Output,
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		identity := firstNonEmpty(native.ID, strconv.FormatInt(record.Offset, 10))
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"pi",
+				source.NativeRootID,
+				identity,
+				strings.TrimSpace(message.Provider),
+				strings.TrimSpace(message.Model),
+			),
+		})
+	}
+}

--- a/backend/internal/observe/usage/parser_qwen.go
+++ b/backend/internal/observe/usage/parser_qwen.go
@@ -34,9 +34,9 @@ func parseQwen(source domain.UsageSourceContext, records []jsonlRecord, result *
 		if native.SchemaVersion != 1 || model == "" || identity == "" ||
 			native.InputTokens < 0 || native.OutputTokens < 0 || native.CachedTokens < 0 ||
 			native.ThoughtsTokens < 0 ||
-			native.CachedTokens > native.InputTokens || native.ThoughtsTokens > native.OutputTokens ||
+			native.CachedTokens > native.InputTokens ||
 			native.TotalTokens != nil && (*native.TotalTokens < 0 ||
-				*native.TotalTokens != native.InputTokens+native.OutputTokens) {
+				*native.TotalTokens != native.InputTokens+native.OutputTokens+native.ThoughtsTokens) {
 			recordMalformed(result)
 			continue
 		}

--- a/backend/internal/observe/usage/parser_qwen.go
+++ b/backend/internal/observe/usage/parser_qwen.go
@@ -44,7 +44,7 @@ func parseQwen(source domain.UsageSourceContext, records []jsonlRecord, result *
 			InputTokens:         native.InputTokens,
 			UncachedInputTokens: native.InputTokens - native.CachedTokens,
 			CacheReadTokens:     native.CachedTokens,
-			OutputTokens:        native.OutputTokens,
+			OutputTokens:        native.OutputTokens + native.ThoughtsTokens,
 			ReasoningTokens:     int64Ptr(native.ThoughtsTokens),
 		}
 		if !validTokenMetrics(tokens) {

--- a/backend/internal/observe/usage/parser_qwen.go
+++ b/backend/internal/observe/usage/parser_qwen.go
@@ -1,0 +1,65 @@
+package usage
+
+import (
+	"encoding/json"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type qwenUsageRecord struct {
+	SchemaVersion  int    `json:"schemaVersion"`
+	ID             string `json:"id"`
+	Timestamp      string `json:"timestamp"`
+	SessionID      string `json:"sessionId"`
+	Model          string `json:"model"`
+	InputTokens    int64  `json:"inputTokens"`
+	OutputTokens   int64  `json:"outputTokens"`
+	CachedTokens   int64  `json:"cachedTokens"`
+	ThoughtsTokens int64  `json:"thoughtsTokens"`
+	TotalTokens    *int64 `json:"totalTokens"`
+}
+
+func parseQwen(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	for _, record := range records {
+		var native qwenUsageRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.SessionID != source.NativeRootID {
+			continue
+		}
+		model := firstNonEmpty(native.Model)
+		identity := firstNonEmpty(native.ID)
+		if native.SchemaVersion != 1 || model == "" || identity == "" ||
+			native.InputTokens < 0 || native.OutputTokens < 0 || native.CachedTokens < 0 ||
+			native.ThoughtsTokens < 0 ||
+			native.CachedTokens > native.InputTokens || native.ThoughtsTokens > native.OutputTokens ||
+			native.TotalTokens != nil && (*native.TotalTokens < 0 ||
+				*native.TotalTokens != native.InputTokens+native.OutputTokens) {
+			recordMalformed(result)
+			continue
+		}
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         native.InputTokens,
+			UncachedInputTokens: native.InputTokens - native.CachedTokens,
+			CacheReadTokens:     native.CachedTokens,
+			OutputTokens:        native.OutputTokens,
+			ReasoningTokens:     int64Ptr(native.ThoughtsTokens),
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"qwen",
+				source.NativeRootID,
+				identity,
+				model,
+			),
+		})
+	}
+}

--- a/backend/internal/observe/usage/pi_parser_test.go
+++ b/backend/internal/observe/usage/pi_parser_test.go
@@ -1,0 +1,38 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestParsePiAssistantUsage(t *testing.T) {
+	source := usageSource(domain.UsageSourcePiSession)
+	records := []jsonlRecord{
+		{Data: []byte(`{"type":"session","id":"pi-session","cwd":"/repo","version":3}`)},
+		{Offset: 100, Data: []byte(`{"type":"message","id":"msg-1","message":{"role":"assistant","provider":"zai-glm","model":"glm-4.5","usage":{"input":11,"output":7,"cacheRead":5,"cacheWrite":3,"totalTokens":26,"cost":{"total":99}}}}`)},
+		{Offset: 200, Data: []byte(`{"type":"message","id":"msg-2","message":{"role":"user","usage":{"input":100}}}`)},
+	}
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.Events[0]
+	if event.ModelID != "zai-glm/glm-4.5" || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	if got := event.Tokens; got.InputTokens != 19 || got.UncachedInputTokens != 11 ||
+		got.CacheReadTokens != 5 || got.CacheWriteTokens != 3 || got.OutputTokens != 7 || got.ReasoningTokens != nil {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParsePiRejectsInvalidUsage(t *testing.T) {
+	source := usageSource(domain.UsageSourcePiSession)
+	record := jsonlRecord{Data: []byte(`{"type":"message","id":"bad","message":{"role":"assistant","model":"m","usage":{"input":-1,"output":1}}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/backend/internal/observe/usage/qwen_parser_test.go
+++ b/backend/internal/observe/usage/qwen_parser_test.go
@@ -12,7 +12,7 @@ func TestParseQwenUsageForBoundSession(t *testing.T) {
 	source.NativeRootID = "qwen-session"
 	records := []jsonlRecord{
 		{Data: []byte(`{"schemaVersion":1,"id":"other","sessionId":"another","model":"qwen3","inputTokens":999,"outputTokens":999,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":1998}`)},
-		{Offset: 100, Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"qwen-session","model":"qwen3-coder","inputTokens":30,"outputTokens":12,"cachedTokens":9,"thoughtsTokens":4,"totalTokens":42}`)},
+		{Offset: 100, Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"qwen-session","model":"qwen3-coder","inputTokens":30,"outputTokens":12,"cachedTokens":9,"thoughtsTokens":4,"totalTokens":46}`)},
 	}
 	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
 	if result.err != nil || len(result.Events) != 1 {

--- a/backend/internal/observe/usage/qwen_parser_test.go
+++ b/backend/internal/observe/usage/qwen_parser_test.go
@@ -1,0 +1,60 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestParseQwenUsageForBoundSession(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "qwen-session"
+	records := []jsonlRecord{
+		{Data: []byte(`{"schemaVersion":1,"id":"other","sessionId":"another","model":"qwen3","inputTokens":999,"outputTokens":999,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":1998}`)},
+		{Offset: 100, Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"qwen-session","model":"qwen3-coder","inputTokens":30,"outputTokens":12,"cachedTokens":9,"thoughtsTokens":4,"totalTokens":42}`)},
+	}
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.Events[0]
+	if event.ModelID != "qwen3-coder" || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	if got := event.Tokens; got.InputTokens != 30 || got.UncachedInputTokens != 21 ||
+		got.CacheReadTokens != 9 || got.CacheWriteTokens != 0 || got.OutputTokens != 12 ||
+		got.ReasoningTokens == nil || *got.ReasoningTokens != 4 {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseQwenRejectsInconsistentTotals(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"bad","sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":4,"thoughtsTokens":0,"totalTokens":5}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestParseQwenAllowsOmittedTotalTokens(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"native-root","source":"managed-auto-memory-extractor","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":0}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestParseQwenRequiresNativeRecordID(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":0,"totalTokens":5}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/backend/internal/observe/usage/qwen_parser_test.go
+++ b/backend/internal/observe/usage/qwen_parser_test.go
@@ -23,8 +23,21 @@ func TestParseQwenUsageForBoundSession(t *testing.T) {
 		t.Fatalf("event = %+v", event)
 	}
 	if got := event.Tokens; got.InputTokens != 30 || got.UncachedInputTokens != 21 ||
-		got.CacheReadTokens != 9 || got.CacheWriteTokens != 0 || got.OutputTokens != 12 ||
+		got.CacheReadTokens != 9 || got.CacheWriteTokens != 0 || got.OutputTokens != 16 ||
 		got.ReasoningTokens == nil || *got.ReasoningTokens != 4 {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseQwenNormalizesThoughtsIntoOutputTokens(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":4,"totalTokens":9}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := result.Events[0].Tokens; got.OutputTokens != 6 || got.ReasoningTokens == nil || *got.ReasoningTokens != 4 {
 		t.Fatalf("tokens = %+v", got)
 	}
 }

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -11,3 +11,19 @@ func SupportedHarness(h domain.AgentHarness) bool {
 		return false
 	}
 }
+
+// MetricCoverage reports the optional token buckets present in each certified
+// native format. Source support is enabled separately by SupportedHarness so a
+// parser can be developed without exposing an incomplete collection pipeline.
+func MetricCoverage(h domain.AgentHarness) domain.UsageMetricCoverage {
+	switch h {
+	case domain.HarnessClaudeCode, domain.HarnessKimi, domain.HarnessPi:
+		return domain.UsageMetricCoverage{UncachedInput: true, CacheRead: true, CacheWrite: true}
+	case domain.HarnessCodex, domain.HarnessCopilot:
+		return domain.UsageMetricCoverage{UncachedInput: true, CacheRead: true, CacheWrite: true, Reasoning: true}
+	case domain.HarnessQwen:
+		return domain.UsageMetricCoverage{UncachedInput: true, CacheRead: true, Reasoning: true}
+	default:
+		return domain.UsageMetricCoverage{}
+	}
+}

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,8 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot,
+		domain.HarnessKimi, domain.HarnessPi, domain.HarnessQwen:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -630,6 +630,10 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	var errs []error
+	if err := c.backfillPiPaths(ctx); err != nil {
+		errs = append(errs, err)
+	}
 	if limit == 0 {
 		limit = defaultDiscoveryLimit
 	}
@@ -638,7 +642,6 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 		return err
 	}
 	now := c.now().UTC()
-	var errs []error
 	for _, binding := range bindings {
 		if err := c.reconcileBinding(ctx, binding, now); err != nil {
 			errs = append(errs, err)

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -57,14 +57,18 @@ type HookSignal struct {
 // SourceRoots are the provider-owned directories from which AO may read usage
 // transcripts.
 type SourceRoots struct {
-	ClaudeProjects string
-	CodexSessions  string
-	CodexArchived  string
+	ClaudeProjects  string
+	CodexSessions   string
+	CodexArchived   string
+	CopilotSessions string
+	KimiHome        string
+	PiSessions      string
+	QwenUsage       string
 }
 
-// DefaultSourceRoots resolves the native Claude Code and Codex transcript
-// directories for the current user.
-func DefaultSourceRoots(ctx context.Context) (SourceRoots, error) {
+// DefaultSourceRoots resolves the native transcript and usage directories for
+// the current user. dataDir is AO's already-resolved durable data directory.
+func DefaultSourceRoots(ctx context.Context, dataDir string) (SourceRoots, error) {
 	if err := ctx.Err(); err != nil {
 		return SourceRoots{}, err
 	}
@@ -76,10 +80,21 @@ func DefaultSourceRoots(ctx context.Context) (SourceRoots, error) {
 	if codexHome == "" {
 		codexHome = filepath.Join(home, ".codex")
 	}
+	piHome := strings.TrimSpace(os.Getenv("PI_CODING_AGENT_DIR"))
+	if piHome == "" {
+		piHome = filepath.Join(home, ".pi", "agent")
+	}
+	if strings.TrimSpace(dataDir) == "" {
+		dataDir = filepath.Join(home, ".ao", "data")
+	}
 	return SourceRoots{
-		ClaudeProjects: filepath.Join(home, ".claude", "projects"),
-		CodexSessions:  filepath.Join(codexHome, "sessions"),
-		CodexArchived:  filepath.Join(codexHome, "archived_sessions"),
+		ClaudeProjects:  filepath.Join(home, ".claude", "projects"),
+		CodexSessions:   filepath.Join(codexHome, "sessions"),
+		CodexArchived:   filepath.Join(codexHome, "archived_sessions"),
+		CopilotSessions: filepath.Join(home, ".copilot", "session-state"),
+		KimiHome:        filepath.Join(dataDir, "kimi"),
+		PiSessions:      filepath.Join(piHome, "sessions"),
+		QwenUsage:       filepath.Join(home, ".qwen", "usage"),
 	}, nil
 }
 
@@ -331,9 +346,9 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 	}
 
 	if mainArtifact != nil {
-		kind := domain.UsageSourceClaudeMain
-		if session.Harness == domain.HarnessCodex {
-			kind = domain.UsageSourceCodexRollout
+		kind, supported := sourceKindForHarness(session.Harness)
+		if !supported {
+			return nil
 		}
 		changed, err := c.registerHookSource(
 			ctx,
@@ -552,9 +567,9 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 		return nil
 	}
 
-	kind := domain.UsageSourceClaudeMain
-	if session.Harness == domain.HarnessCodex {
-		kind = domain.UsageSourceCodexRollout
+	kind, supported := sourceKindForHarness(session.Harness)
+	if !supported {
+		return nil
 	}
 	if _, err := c.registerSource(ctx, binding, kind, nativeID, "", path, now, false); err != nil {
 		return err
@@ -801,9 +816,9 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 		targetState = domain.UsageBindingActive
 	}
 
-	kind := domain.UsageSourceClaudeMain
-	if binding.Harness == domain.HarnessCodex {
-		kind = domain.UsageSourceCodexRollout
+	kind, supported := sourceKindForHarness(binding.Harness)
+	if !supported {
+		return nil
 	}
 	if _, err := c.registerSource(ctx, binding, kind, binding.NativeRootID, "", path, now, false); err != nil {
 		return err
@@ -1651,6 +1666,14 @@ func (c *Collector) allowedRoots(harness domain.AgentHarness) []string {
 		return []string{c.roots.ClaudeProjects}
 	case domain.HarnessCodex:
 		return []string{c.roots.CodexSessions, c.roots.CodexArchived}
+	case domain.HarnessCopilot:
+		return []string{c.roots.CopilotSessions}
+	case domain.HarnessKimi:
+		return []string{c.roots.KimiHome}
+	case domain.HarnessPi:
+		return []string{c.roots.PiSessions}
+	case domain.HarnessQwen:
+		return []string{c.roots.QwenUsage}
 	default:
 		return nil
 	}

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -1810,8 +1810,7 @@ func validateSourceAttribution(
 		}
 		if binding.Harness != domain.HarnessKimi || nativeSessionID != binding.NativeRootID ||
 			filepath.Base(resolved) != "wire.jsonl" || filepath.Base(agentsDir) != "agents" ||
-			filepath.Base(sessionDir) != binding.NativeRootID ||
-			filepath.Base(filepath.Dir(sessionDir)) != "sessions" || subagentID != wantSubagent {
+			filepath.Base(sessionDir) != binding.NativeRootID || subagentID != wantSubagent {
 			return rejected()
 		}
 	case domain.UsageSourcePiSession:
@@ -1847,14 +1846,13 @@ func (c *Collector) validateSourceAttribution(
 	if kind != domain.UsageSourceKimiWire {
 		return nil
 	}
-	expectedSessionDir, err := filepath.EvalSymlinks(filepath.Join(
-		c.roots.KimiHome, "sessions", binding.NativeRootID,
-	))
+	expectedRoot, err := filepath.EvalSymlinks(filepath.Join(c.roots.KimiHome, "sessions"))
 	if err != nil {
 		return errors.New(domain.UsageErrorArtifactPathRejected)
 	}
 	actualSessionDir := filepath.Dir(filepath.Dir(filepath.Dir(resolved)))
-	if filepath.Clean(actualSessionDir) != filepath.Clean(expectedSessionDir) {
+	rel, err := filepath.Rel(expectedRoot, actualSessionDir)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return errors.New(domain.UsageErrorArtifactPathRejected)
 	}
 	return nil

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -265,7 +265,7 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 		}
 	}
 	if signal.NativeSessionID != "" && mainPath == "" &&
-		(session.Harness == domain.HarnessCodex || finalizing && !existsForDiscovery) {
+		(session.Harness != domain.HarnessClaudeCode || finalizing && !existsForDiscovery) {
 		mainPath, err = c.discoverPath(ctx, session.Harness, signal.NativeSessionID)
 		if err != nil {
 			return err
@@ -578,8 +578,10 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
-		return err
+	} else if session.Harness == domain.HarnessCodex {
+		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
 	}
 	if state == domain.UsageBindingFinalizing {
 		return c.settleFinalizingBinding(ctx, binding.ID, now)
@@ -827,8 +829,10 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
-		return err
+	} else if binding.Harness == domain.HarnessCodex {
+		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
 	}
 	lastErrorCode := ""
 	if binding.Harness == domain.HarnessCodex &&
@@ -1654,6 +1658,12 @@ func validateSourceAttribution(
 			filepath.Base(resolved) != "agent-"+subagentID+".jsonl" {
 			return rejected()
 		}
+	case domain.UsageSourceCopilotShutdown:
+		if binding.Harness != domain.HarnessCopilot || nativeSessionID != binding.NativeRootID ||
+			filepath.Base(filepath.Dir(resolved)) != binding.NativeRootID ||
+			filepath.Base(resolved) != "events.jsonl" {
+			return rejected()
+		}
 	default:
 		return rejected()
 	}
@@ -1721,6 +1731,8 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		patterns = []string{filepath.Join(c.roots.ClaudeProjects, "*", nativeID+".jsonl")}
 	case domain.HarnessCodex:
 		return c.discoverCodexPath(ctx, nativeID, "")
+	case domain.HarnessCopilot:
+		patterns = []string{filepath.Join(c.roots.CopilotSessions, nativeID, "events.jsonl")}
 	}
 	type candidate struct {
 		path string

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -517,12 +517,9 @@ func (c *Collector) BackfillActive(ctx context.Context) error {
 }
 
 func (c *Collector) backfillPiPaths(ctx context.Context) error {
-	paths, err := filepath.Glob(filepath.Join(c.roots.PiSessions, "*", "*.jsonl"))
+	paths, err := newestPiPaths(ctx, c.roots.PiSessions, 256)
 	if err != nil {
 		return err
-	}
-	if len(paths) > 256 {
-		paths = paths[len(paths)-256:]
 	}
 	var errs []error
 	for _, path := range paths {
@@ -605,15 +602,16 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 	if _, err := c.registerSource(ctx, binding, kind, nativeID, "", path, now, false); err != nil {
 		return err
 	}
-	if session.Harness == domain.HarnessClaudeCode {
+	switch session.Harness {
+	case domain.HarnessClaudeCode:
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if session.Harness == domain.HarnessCodex {
+	case domain.HarnessCodex:
 		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
 			return err
 		}
-	} else if session.Harness == domain.HarnessKimi {
+	case domain.HarnessKimi:
 		if err := c.registerDiscoveredKimiAgents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
@@ -661,7 +659,7 @@ func (c *Collector) ReconcilePath(ctx context.Context, path string) error {
 
 	resolved, _, _, err := c.validateSourcePath(ctx, domain.HarnessCodex, path)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // Watch notifications may be for another provider's path.
 	}
 	meta, ok := readCodexSessionMeta(resolved)
 	if !ok || len(meta.NativeSessionID) > maxUsageMetadataBytes ||
@@ -715,7 +713,7 @@ func (c *Collector) ReconcilePath(ctx context.Context, path string) error {
 func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
 	resolved, _, _, err := c.validateSourcePath(ctx, domain.HarnessPi, path)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // Watch notifications may be for another provider's path.
 	}
 	meta, ok := readPiSessionMeta(resolved)
 	if !ok {
@@ -723,7 +721,7 @@ func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
 	}
 	workspace, err := filepath.EvalSymlinks(filepath.Clean(meta.CWD))
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // Ignore stale or malformed provider session metadata.
 	}
 	sessions, err := c.store.ListAllSessions(ctx)
 	if err != nil {
@@ -918,15 +916,16 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 	if _, err := c.registerSource(ctx, binding, kind, binding.NativeRootID, "", path, now, false); err != nil {
 		return err
 	}
-	if binding.Harness == domain.HarnessClaudeCode {
+	switch binding.Harness {
+	case domain.HarnessClaudeCode:
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if binding.Harness == domain.HarnessCodex {
+	case domain.HarnessCodex:
 		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
 			return err
 		}
-	} else if binding.Harness == domain.HarnessKimi {
+	case domain.HarnessKimi:
 		if err := c.registerDiscoveredKimiAgents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
@@ -1153,7 +1152,7 @@ func (c *Collector) registerHookSource(
 	if kind == domain.UsageSourceCodexRollout && subagentID != "" {
 		expectedParentID = binding.NativeRootID
 	}
-	if err := validateSourceAttribution(
+	if err := c.validateSourceAttribution(
 		binding,
 		kind,
 		nativeSessionID,
@@ -1198,7 +1197,7 @@ func (c *Collector) registerSourceWithExpectedParent(
 	if err != nil {
 		return false, err
 	}
-	if err := validateSourceAttribution(
+	if err := c.validateSourceAttribution(
 		binding,
 		kind,
 		nativeSessionID,
@@ -1244,7 +1243,7 @@ func (c *Collector) registerSourceWithInventory(
 	if err != nil {
 		return false, err
 	}
-	if err := validateSourceAttribution(
+	if err := c.validateSourceAttribution(
 		binding,
 		kind,
 		nativeSessionID,
@@ -1808,7 +1807,8 @@ func validateSourceAttribution(
 		}
 		if binding.Harness != domain.HarnessKimi || nativeSessionID != binding.NativeRootID ||
 			filepath.Base(resolved) != "wire.jsonl" || filepath.Base(agentsDir) != "agents" ||
-			filepath.Base(sessionDir) != binding.NativeRootID || subagentID != wantSubagent {
+			filepath.Base(sessionDir) != binding.NativeRootID ||
+			filepath.Base(filepath.Dir(sessionDir)) != "sessions" || subagentID != wantSubagent {
 			return rejected()
 		}
 	case domain.UsageSourcePiSession:
@@ -1824,6 +1824,35 @@ func validateSourceAttribution(
 		}
 	default:
 		return rejected()
+	}
+	return nil
+}
+
+func (c *Collector) validateSourceAttribution(
+	binding domain.UsageBindingRecord,
+	kind domain.UsageSourceKind,
+	nativeSessionID string,
+	subagentID string,
+	resolved string,
+	expectedParentID string,
+) error {
+	if err := validateSourceAttribution(
+		binding, kind, nativeSessionID, subagentID, resolved, expectedParentID,
+	); err != nil {
+		return err
+	}
+	if kind != domain.UsageSourceKimiWire {
+		return nil
+	}
+	expectedSessionDir, err := filepath.EvalSymlinks(filepath.Join(
+		c.roots.KimiHome, "sessions", binding.NativeRootID,
+	))
+	if err != nil {
+		return errors.New(domain.UsageErrorArtifactPathRejected)
+	}
+	actualSessionDir := filepath.Dir(filepath.Dir(filepath.Dir(resolved)))
+	if filepath.Clean(actualSessionDir) != filepath.Clean(expectedSessionDir) {
+		return errors.New(domain.UsageErrorArtifactPathRejected)
 	}
 	return nil
 }
@@ -1944,10 +1973,13 @@ func (c *Collector) discoverKimiPath(ctx context.Context, nativeID string) (stri
 	if err != nil {
 		return "", err
 	}
-	defer index.Close()
+	defer func() { _ = index.Close() }()
 
 	var latest kimiIndexRecord
-	scanner := bufio.NewScanner(io.LimitReader(index, 8<<20))
+	// Replay the full append-only index so the last record for this session
+	// wins even after the file grows. Memory remains bounded by the scanner's
+	// per-record cap; provider index size does not become an allocation.
+	scanner := bufio.NewScanner(index)
 	scanner.Buffer(make([]byte, 4096), 64<<10)
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
@@ -1989,7 +2021,7 @@ func readPiSessionMeta(path string) (piSessionMeta, bool) {
 	if err != nil {
 		return piSessionMeta{}, false
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	reader := bufio.NewReader(io.LimitReader(file, 64<<10))
 	line, err := reader.ReadBytes('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
@@ -2004,22 +2036,53 @@ func readPiSessionMeta(path string) (piSessionMeta, bool) {
 }
 
 func (c *Collector) discoverPiPath(ctx context.Context, nativeID string) (string, error) {
-	paths, err := filepath.Glob(filepath.Join(c.roots.PiSessions, "*", "*.jsonl"))
+	paths, err := newestPiPaths(ctx, c.roots.PiSessions, 256)
 	if err != nil {
 		return "", err
 	}
-	if len(paths) > 256 {
-		paths = paths[len(paths)-256:]
-	}
-	for index := len(paths) - 1; index >= 0; index-- {
+	for _, path := range paths {
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
-		if meta, ok := readPiSessionMeta(paths[index]); ok && meta.ID == nativeID {
-			return paths[index], nil
+		if meta, ok := readPiSessionMeta(path); ok && meta.ID == nativeID {
+			return path, nil
 		}
 	}
 	return "", nil
+}
+
+func newestPiPaths(ctx context.Context, root string, limit int) ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(root, "*", "*.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	type candidate struct {
+		path string
+		mod  time.Time
+	}
+	candidates := make([]candidate, 0, len(paths))
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() {
+			candidates = append(candidates, candidate{path: path, mod: info.ModTime()})
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].mod.Equal(candidates[j].mod) {
+			return candidates[i].path > candidates[j].path
+		}
+		return candidates[i].mod.After(candidates[j].mod)
+	})
+	if limit > 0 && len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	result := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, candidate.path)
+	}
+	return result, nil
 }
 
 func qwenUsageFilename(name string) bool {

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -365,6 +365,11 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 			return err
 		}
 		inventoryChanged = inventoryChanged || changed
+		if session.Harness == domain.HarnessKimi {
+			if err := c.registerDiscoveredKimiAgents(ctx, binding, mainArtifact.path, now, false); err != nil {
+				return err
+			}
+		}
 		sourceErrorCode := ""
 		if c.codexDiscoveryStillPending(ctx, signal.Event, signal.TranscriptPath, mainPath) {
 			sourceErrorCode = domain.UsageErrorSourceDiscoveryPending
@@ -495,10 +500,36 @@ func (c *Collector) BackfillActive(ctx context.Context) error {
 			continue
 		}
 		nativeID := boundedUsageMetadata(session.Metadata.AgentSessionID)
+		if nativeID == "" && session.Harness == domain.HarnessPi {
+			if err := c.backfillPiPaths(ctx); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
 		if nativeID == "" || !nativeUsageIDPattern.MatchString(nativeID) {
 			continue
 		}
 		if err := c.backfillSession(ctx, session, nativeID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *Collector) backfillPiPaths(ctx context.Context) error {
+	paths, err := filepath.Glob(filepath.Join(c.roots.PiSessions, "*", "*.jsonl"))
+	if err != nil {
+		return err
+	}
+	if len(paths) > 256 {
+		paths = paths[len(paths)-256:]
+	}
+	var errs []error
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := c.reconcilePiPath(ctx, path); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -582,6 +613,10 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
 			return err
 		}
+	} else if session.Harness == domain.HarnessKimi {
+		if err := c.registerDiscoveredKimiAgents(ctx, binding, path, now, false); err != nil {
+			return err
+		}
 	}
 	if state == domain.UsageBindingFinalizing {
 		return c.settleFinalizingBinding(ctx, binding.ID, now)
@@ -614,11 +649,15 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 	return errors.Join(errs...)
 }
 
-// ReconcilePath uses Codex rollout metadata to validate replacements and reach
-// newly-created child bindings independently of the bounded discovery queue.
+// ReconcilePath uses provider metadata to validate sources that appear outside
+// the bounded discovery queue. Codex supplies thread ancestry; Pi supplies a
+// session header whose cwd can be correlated to one live AO worktree.
 func (c *Collector) ReconcilePath(ctx context.Context, path string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if pathWithinRoot(ctx, path, c.roots.PiSessions) {
+		return c.reconcilePiPath(ctx, path)
+	}
 
 	resolved, _, _, err := c.validateSourcePath(ctx, domain.HarnessCodex, path)
 	if err != nil {
@@ -671,6 +710,60 @@ func (c *Collector) ReconcilePath(ctx context.Context, path string) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
+	resolved, _, _, err := c.validateSourcePath(ctx, domain.HarnessPi, path)
+	if err != nil {
+		return nil
+	}
+	meta, ok := readPiSessionMeta(resolved)
+	if !ok {
+		return nil
+	}
+	workspace, err := filepath.EvalSymlinks(filepath.Clean(meta.CWD))
+	if err != nil {
+		return nil
+	}
+	sessions, err := c.store.ListAllSessions(ctx)
+	if err != nil {
+		return err
+	}
+	matches := make([]domain.SessionRecord, 0, 1)
+	for _, session := range sessions {
+		if session.Harness != domain.HarnessPi || session.IsTerminated ||
+			session.Activity.State == domain.ActivityExited || session.Metadata.WorkspacePath == "" {
+			continue
+		}
+		candidate, err := filepath.EvalSymlinks(filepath.Clean(session.Metadata.WorkspacePath))
+		if err == nil && candidate == workspace {
+			matches = append(matches, session)
+		}
+	}
+	if len(matches) != 1 {
+		return nil
+	}
+	now := c.now().UTC()
+	binding, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
+		SessionID:    matches[0].ID,
+		Harness:      domain.HarnessPi,
+		NativeRootID: meta.ID,
+		State:        domain.UsageBindingActive,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		return err
+	}
+	changed, err := c.registerSource(
+		ctx, binding, domain.UsageSourcePiSession, meta.ID, "", resolved, now, false,
+	)
+	if err != nil {
+		return err
+	}
+	if changed {
+		c.notifySourceInventory(false)
+	}
+	return nil
 }
 
 func (c *Collector) reconcileRetiredCodexClaims(
@@ -831,6 +924,10 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 		}
 	} else if binding.Harness == domain.HarnessCodex {
 		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
+	} else if binding.Harness == domain.HarnessKimi {
+		if err := c.registerDiscoveredKimiAgents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
 	}
@@ -1378,6 +1475,42 @@ func discoverClaudeSubagentPaths(ctx context.Context, mainPath string) ([]string
 	return result, nil
 }
 
+func (c *Collector) registerDiscoveredKimiAgents(
+	ctx context.Context,
+	binding domain.UsageBindingRecord,
+	mainPath string,
+	now time.Time,
+	reactivateExisting bool,
+) error {
+	sessionDir := filepath.Dir(filepath.Dir(filepath.Dir(mainPath)))
+	paths, err := filepath.Glob(filepath.Join(sessionDir, "agents", "*", "wire.jsonl"))
+	if err != nil {
+		return err
+	}
+	sort.Strings(paths)
+	var errs []error
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		agentID := boundedUsageMetadata(filepath.Base(filepath.Dir(path)))
+		if agentID == "" || !nativeUsageIDPattern.MatchString(agentID) {
+			continue
+		}
+		subagentID := agentID
+		if agentID == "main" {
+			subagentID = ""
+		}
+		if _, err := c.registerSource(
+			ctx, binding, domain.UsageSourceKimiWire, binding.NativeRootID,
+			subagentID, path, now, reactivateExisting,
+		); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func (c *Collector) registerDiscoveredCodexChildren(
 	ctx context.Context,
 	binding domain.UsageBindingRecord,
@@ -1664,6 +1797,31 @@ func validateSourceAttribution(
 			filepath.Base(resolved) != "events.jsonl" {
 			return rejected()
 		}
+	case domain.UsageSourceKimiWire:
+		agentDir := filepath.Dir(resolved)
+		agentsDir := filepath.Dir(agentDir)
+		sessionDir := filepath.Dir(agentsDir)
+		agentID := filepath.Base(agentDir)
+		wantSubagent := agentID
+		if agentID == "main" {
+			wantSubagent = ""
+		}
+		if binding.Harness != domain.HarnessKimi || nativeSessionID != binding.NativeRootID ||
+			filepath.Base(resolved) != "wire.jsonl" || filepath.Base(agentsDir) != "agents" ||
+			filepath.Base(sessionDir) != binding.NativeRootID || subagentID != wantSubagent {
+			return rejected()
+		}
+	case domain.UsageSourcePiSession:
+		meta, ok := readPiSessionMeta(resolved)
+		if binding.Harness != domain.HarnessPi || nativeSessionID != binding.NativeRootID ||
+			subagentID != "" || !ok || meta.ID != nativeSessionID {
+			return rejected()
+		}
+	case domain.UsageSourceQwenMonthly:
+		if binding.Harness != domain.HarnessQwen || nativeSessionID != binding.NativeRootID ||
+			subagentID != "" || !qwenUsageFilename(filepath.Base(resolved)) {
+			return rejected()
+		}
 	default:
 		return rejected()
 	}
@@ -1733,6 +1891,12 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		return c.discoverCodexPath(ctx, nativeID, "")
 	case domain.HarnessCopilot:
 		patterns = []string{filepath.Join(c.roots.CopilotSessions, nativeID, "events.jsonl")}
+	case domain.HarnessKimi:
+		return c.discoverKimiPath(ctx, nativeID)
+	case domain.HarnessPi:
+		return c.discoverPiPath(ctx, nativeID)
+	case domain.HarnessQwen:
+		return c.discoverQwenPath(ctx)
 	}
 	type candidate struct {
 		path string
@@ -1764,6 +1928,136 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		return "", nil
 	}
 	return matches[0].path, nil
+}
+
+type kimiIndexRecord struct {
+	SessionID  string `json:"sessionId"`
+	SessionDir string `json:"sessionDir"`
+	Deleted    bool   `json:"deleted"`
+}
+
+func (c *Collector) discoverKimiPath(ctx context.Context, nativeID string) (string, error) {
+	index, err := os.Open(filepath.Join(c.roots.KimiHome, "session_index.jsonl"))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	defer index.Close()
+
+	var latest kimiIndexRecord
+	scanner := bufio.NewScanner(io.LimitReader(index, 8<<20))
+	scanner.Buffer(make([]byte, 4096), 64<<10)
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		var record kimiIndexRecord
+		if json.Unmarshal(scanner.Bytes(), &record) == nil && record.SessionID == nativeID {
+			latest = record
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if latest.Deleted || latest.SessionID == "" || !filepath.IsAbs(latest.SessionDir) ||
+		filepath.Base(filepath.Clean(latest.SessionDir)) != nativeID ||
+		!pathWithinRoot(ctx, latest.SessionDir, filepath.Join(c.roots.KimiHome, "sessions")) {
+		return "", nil
+	}
+	main := filepath.Join(latest.SessionDir, "agents", "main", "wire.jsonl")
+	if info, err := os.Stat(main); err == nil && info.Mode().IsRegular() {
+		return main, nil
+	}
+	paths, err := filepath.Glob(filepath.Join(latest.SessionDir, "agents", "*", "wire.jsonl"))
+	if err != nil || len(paths) == 0 {
+		return "", err
+	}
+	sort.Strings(paths)
+	return paths[0], nil
+}
+
+type piSessionMeta struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	CWD  string `json:"cwd"`
+}
+
+func readPiSessionMeta(path string) (piSessionMeta, bool) {
+	file, err := os.Open(path)
+	if err != nil {
+		return piSessionMeta{}, false
+	}
+	defer file.Close()
+	reader := bufio.NewReader(io.LimitReader(file, 64<<10))
+	line, err := reader.ReadBytes('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return piSessionMeta{}, false
+	}
+	var meta piSessionMeta
+	if json.Unmarshal(bytes.TrimSpace(line), &meta) != nil || meta.Type != "session" ||
+		!nativeUsageIDPattern.MatchString(meta.ID) || !filepath.IsAbs(meta.CWD) {
+		return piSessionMeta{}, false
+	}
+	return meta, true
+}
+
+func (c *Collector) discoverPiPath(ctx context.Context, nativeID string) (string, error) {
+	paths, err := filepath.Glob(filepath.Join(c.roots.PiSessions, "*", "*.jsonl"))
+	if err != nil {
+		return "", err
+	}
+	if len(paths) > 256 {
+		paths = paths[len(paths)-256:]
+	}
+	for index := len(paths) - 1; index >= 0; index-- {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if meta, ok := readPiSessionMeta(paths[index]); ok && meta.ID == nativeID {
+			return paths[index], nil
+		}
+	}
+	return "", nil
+}
+
+func qwenUsageFilename(name string) bool {
+	if !strings.HasPrefix(name, "token-usage-") || !strings.HasSuffix(name, ".jsonl") {
+		return false
+	}
+	month := strings.TrimSuffix(strings.TrimPrefix(name, "token-usage-"), ".jsonl")
+	if len(month) != 7 || month[4] != '-' {
+		return false
+	}
+	_, err := time.Parse("2006-01", month)
+	return err == nil
+}
+
+func (c *Collector) discoverQwenPath(ctx context.Context) (string, error) {
+	paths, err := filepath.Glob(filepath.Join(c.roots.QwenUsage, "token-usage-*.jsonl"))
+	if err != nil {
+		return "", err
+	}
+	valid := paths[:0]
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if !qwenUsageFilename(filepath.Base(path)) {
+			continue
+		}
+		if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() {
+			valid = append(valid, path)
+		}
+	}
+	sort.Slice(valid, func(i, j int) bool {
+		return filepath.Base(valid[i]) > filepath.Base(valid[j])
+	})
+	if len(valid) == 0 {
+		return "", nil
+	}
+	return valid[0], nil
 }
 
 func (c *Collector) discoverCodexPath(ctx context.Context, nativeID, parentID string) (string, error) {

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -231,6 +231,10 @@ func (c *Collector) ReactivateSession(
 		if err := c.backfillSession(ctx, session, nativeID); err != nil {
 			return err
 		}
+	} else if session.Harness == domain.HarnessPi {
+		if err := c.backfillPiPaths(ctx); err != nil {
+			return err
+		}
 	} else {
 		return nil
 	}

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1718,6 +1719,34 @@ func TestCollectorDiscoversCopilotShutdownSource(t *testing.T) {
 	}
 }
 
+func TestCollectorRetriesCopilotSourceCreatedAfterSessionStart(t *testing.T) {
+	const nativeID = "11111111-1111-4111-8111-111111111111"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCopilot, nativeID, false)
+	root := filepath.Join(t.TempDir(), "session-state")
+	collector := NewCollector(store, SourceRoots{CopilotSessions: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessCopilot, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	pending, err := store.HasPendingUsageDiscovery(context.Background())
+	if err != nil || !pending {
+		t.Fatalf("pending=%v err=%v, want durable discovery retry", pending, err)
+	}
+	path := filepath.Join(root, nativeID, "events.jsonl")
+	writeUsageFixture(t, path, `{"type":"session.shutdown","data":{"modelMetrics":{}}}`+"\n")
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
 func TestCollectorRejectsCopilotSourceForDifferentNativeSession(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "session-state")
 	path := filepath.Join(root, "other-native", "events.jsonl")
@@ -1799,6 +1828,39 @@ func TestCollectorKimiIndexRejectsDeletedAndEscapingSessions(t *testing.T) {
 	}
 }
 
+func TestCollectorKimiIndexReplaysRecordsBeyondEightMiB(t *testing.T) {
+	const nativeID = "kimi-late-session"
+	home := t.TempDir()
+	sessionDir := filepath.Join(home, "sessions", nativeID)
+	wire := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
+	writeUsageFixture(t, wire, "{}\n")
+	fillerLine := []byte(`{"sessionId":"unrelated","deleted":true}` + "\n")
+	filler := bytes.Repeat(fillerLine, (8<<20)/len(fillerLine)+1)
+	late := []byte(fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n", nativeID, sessionDir))
+	writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"), string(append(filler, late...)))
+	collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+
+	path, err := collector.discoverPath(context.Background(), domain.HarnessKimi, nativeID)
+	mustNoError(t, err)
+	if path != wire {
+		t.Fatalf("discovered %q, want late-index wire %q", path, wire)
+	}
+}
+
+func TestCollectorRejectsKimiWireOutsideCanonicalSessionsDirectory(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	home := t.TempDir()
+	path := filepath.Join(home, "attacker", "sessions", nativeID, "agents", "main", "wire.jsonl")
+	writeUsageFixture(t, path, "{}\n")
+	binding := domain.UsageBindingRecord{Harness: domain.HarnessKimi, NativeRootID: nativeID}
+	collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+	if err := collector.validateSourceAttribution(
+		binding, domain.UsageSourceKimiWire, nativeID, "", canonicalUsagePath(t, path), "",
+	); err == nil {
+		t.Fatal("accepted Kimi wire outside <KimiHome>/sessions/<native-id>")
+	}
+}
+
 func TestCollectorDiscoversPiSessionByHeaderID(t *testing.T) {
 	const nativeID = "pi-session-1"
 	store := collectorTestStore(t)
@@ -1818,6 +1880,28 @@ func TestCollectorDiscoversPiSessionByHeaderID(t *testing.T) {
 	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
 	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourcePiSession {
 		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorPiDiscoveryCapsNewestFilesByModificationTime(t *testing.T) {
+	const nativeID = "pi-newest-session"
+	root := t.TempDir()
+	newest := filepath.Join(root, "a-project", "000-newest.jsonl")
+	writeUsageFixture(t, newest, `{"type":"session","id":"`+nativeID+`","cwd":"/repo","version":3}`+"\n")
+	old := time.Now().Add(-time.Hour)
+	for index := 0; index < 256; index++ {
+		path := filepath.Join(root, fmt.Sprintf("z-project-%03d", index), "old.jsonl")
+		writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"old-%03d","cwd":"/repo","version":3}`+"\n", index))
+		mustNoError(t, os.Chtimes(path, old, old))
+	}
+	newTime := time.Now().Add(time.Hour)
+	mustNoError(t, os.Chtimes(newest, newTime, newTime))
+	collector := NewCollector(collectorTestStore(t), SourceRoots{PiSessions: root}, nil)
+
+	path, err := collector.discoverPath(context.Background(), domain.HarnessPi, nativeID)
+	mustNoError(t, err)
+	if path != newest {
+		t.Fatalf("discovered %q, want newest %q", path, newest)
 	}
 }
 
@@ -1896,6 +1980,35 @@ func TestCollectorBackfillFindsPiSessionWithoutCapturedNativeID(t *testing.T) {
 	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
 	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-existing" {
 		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
+func TestCollectorBindsPiWhenLifecycleCapturesNativeSessionID(t *testing.T) {
+	const nativeID = "pi-captured"
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session.Metadata.WorkspacePath = workspace
+	session.Metadata.RuntimeLaunchID = "launch-1"
+	mustNoError(t, store.UpdateSession(context.Background(), session))
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "captured.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":%q,"cwd":%q,"version":3}`+"\n", nativeID, workspace))
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+	manager := lifecycle.New(store, nil)
+	manager.SetUsageFinalizer(collector)
+
+	mustNoError(t, manager.ApplyActivitySignal(context.Background(), session.ID, ports.ActivitySignal{
+		AgentSessionID: nativeID,
+		LaunchID:       "launch-1",
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != nativeID {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("sources=%+v err=%v", sources, err)
 	}
 }
 

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1688,6 +1688,45 @@ func TestValidateSourcePathAcceptsOnlyMatchingProviderRoot(t *testing.T) {
 	}
 }
 
+// TestCollectorDiscoversCopilotShutdownSource catches accepting the native
+// Copilot hook ID without binding its per-session events file.
+func TestCollectorDiscoversCopilotShutdownSource(t *testing.T) {
+	const nativeID = "11111111-1111-4111-8111-111111111111"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCopilot, nativeID, false)
+	root := filepath.Join(t.TempDir(), "session-state")
+	path := filepath.Join(root, nativeID, "events.jsonl")
+	writeUsageFixture(t, path, `{"type":"session.shutdown","data":{"modelMetrics":{}}}`+"\n")
+	collector := NewCollector(store, SourceRoots{CopilotSessions: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness:         domain.HarnessCopilot,
+		Event:           "session-start",
+		NativeSessionID: nativeID,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings = %+v, err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 {
+		t.Fatalf("sources = %+v, err=%v", sources, err)
+	}
+	if sources[0].Kind != domain.UsageSourceCopilotShutdown || sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("source = %+v", sources[0])
+	}
+}
+
+func TestCollectorRejectsCopilotSourceForDifferentNativeSession(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "session-state")
+	path := filepath.Join(root, "other-native", "events.jsonl")
+	writeUsageFixture(t, path, "{}\n")
+	binding := domain.UsageBindingRecord{Harness: domain.HarnessCopilot, NativeRootID: "bound-native"}
+	if err := validateSourceAttribution(binding, domain.UsageSourceCopilotShutdown, "bound-native", "", canonicalUsagePath(t, path), ""); err == nil {
+		t.Fatal("accepted Copilot events file from a different native session")
+	}
+}
+
 func differentHarness(harness domain.AgentHarness) domain.AgentHarness {
 	if harness == domain.HarnessCopilot {
 		return domain.HarnessKimi

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -1632,6 +1633,66 @@ func TestDiscoverCodexPathRequiresConfiguredRoots(t *testing.T) {
 	if got != "" {
 		t.Fatalf("unconfigured Codex roots discovered %q", got)
 	}
+}
+
+// TestDefaultSourceRootsIncludesFileBackedAgents catches launching the daemon
+// without watching a provider's actual durable usage directory.
+func TestDefaultSourceRootsIncludesFileBackedAgents(t *testing.T) {
+	home := t.TempDir()
+	dataDir := filepath.Join(home, ".ao", "data")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+
+	got, err := DefaultSourceRoots(context.Background(), dataDir)
+	mustNoError(t, err)
+	want := SourceRoots{
+		ClaudeProjects:  filepath.Join(home, ".claude", "projects"),
+		CodexSessions:   filepath.Join(home, ".codex", "sessions"),
+		CodexArchived:   filepath.Join(home, ".codex", "archived_sessions"),
+		CopilotSessions: filepath.Join(home, ".copilot", "session-state"),
+		KimiHome:        filepath.Join(dataDir, "kimi"),
+		PiSessions:      filepath.Join(home, ".pi", "agent", "sessions"),
+		QwenUsage:       filepath.Join(home, ".qwen", "usage"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("roots = %+v, want %+v", got, want)
+	}
+}
+
+func TestValidateSourcePathAcceptsOnlyMatchingProviderRoot(t *testing.T) {
+	root := t.TempDir()
+	files := map[domain.AgentHarness]string{
+		domain.HarnessCopilot: filepath.Join(root, "copilot", "native", "events.jsonl"),
+		domain.HarnessKimi:    filepath.Join(root, "kimi", "sessions", "native", "agents", "main", "wire.jsonl"),
+		domain.HarnessPi:      filepath.Join(root, "pi", "worktree", "session.jsonl"),
+		domain.HarnessQwen:    filepath.Join(root, "qwen", "token-usage-2026-08.jsonl"),
+	}
+	for _, path := range files {
+		writeUsageFixture(t, path, "{}\n")
+	}
+	collector := NewCollector(collectorTestStore(t), SourceRoots{
+		CopilotSessions: filepath.Join(root, "copilot"),
+		KimiHome:        filepath.Join(root, "kimi"),
+		PiSessions:      filepath.Join(root, "pi"),
+		QwenUsage:       filepath.Join(root, "qwen"),
+	}, nil)
+
+	for harness, path := range files {
+		if _, _, _, err := collector.validateSourcePath(context.Background(), harness, path); err != nil {
+			t.Errorf("validate %s path: %v", harness, err)
+		}
+		if _, _, _, err := collector.validateSourcePath(context.Background(), harness, files[differentHarness(harness)]); err == nil {
+			t.Errorf("%s accepted another provider's root", harness)
+		}
+	}
+}
+
+func differentHarness(harness domain.AgentHarness) domain.AgentHarness {
+	if harness == domain.HarnessCopilot {
+		return domain.HarnessKimi
+	}
+	return domain.HarnessCopilot
 }
 
 func TestDiscoverClaudePathRejectsGlobMetadata(t *testing.T) {

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -2001,6 +2001,65 @@ func TestCollectorReconcileFindsPiSessionWithoutCapturedNativeID(t *testing.T) {
 	}
 }
 
+func TestCollectorMarkSpawnedFindsExistingPiSessionWithoutCapturedNativeID(t *testing.T) {
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "existing.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-existing","cwd":%q,"version":3}`+"\n", workspace))
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+	manager := lifecycle.New(store, nil)
+	manager.SetUsageFinalizer(collector)
+
+	mustNoError(t, manager.MarkSpawned(context.Background(), session.ID, domain.SessionMetadata{
+		RuntimeLaunchID: "launch-1",
+		WorkspacePath:   workspace,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-existing" {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorMarkSpawnedRetriesPiSessionCreatedLater(t *testing.T) {
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	root := t.TempDir()
+	wakes := 0
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, func(reconcile bool) {
+		if reconcile {
+			wakes++
+		}
+	})
+	manager := lifecycle.New(store, nil)
+	manager.SetUsageFinalizer(collector)
+
+	mustNoError(t, manager.MarkSpawned(context.Background(), session.ID, domain.SessionMetadata{
+		RuntimeLaunchID: "launch-1",
+		WorkspacePath:   workspace,
+	}))
+	if wakes != 1 {
+		t.Fatalf("reconcile wakes = %d, want 1", wakes)
+	}
+	if bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID); err != nil || len(bindings) != 0 {
+		t.Fatalf("early bindings=%+v err=%v", bindings, err)
+	}
+
+	path := filepath.Join(root, "project", "late.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-late","cwd":%q,"version":3}`+"\n", workspace))
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-late" {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
 func TestCollectorBindsPiWhenLifecycleCapturesNativeSessionID(t *testing.T) {
 	const nativeID = "pi-captured"
 	store := collectorTestStore(t)

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1724,6 +1725,242 @@ func TestCollectorRejectsCopilotSourceForDifferentNativeSession(t *testing.T) {
 	binding := domain.UsageBindingRecord{Harness: domain.HarnessCopilot, NativeRootID: "bound-native"}
 	if err := validateSourceAttribution(binding, domain.UsageSourceCopilotShutdown, "bound-native", "", canonicalUsagePath(t, path), ""); err == nil {
 		t.Fatal("accepted Copilot events file from a different native session")
+	}
+}
+
+func TestCollectorDiscoversKimiWireSourcesFromSessionIndex(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessKimi, nativeID, false)
+	home := t.TempDir()
+	sessionDir := filepath.Join(home, "sessions", nativeID)
+	mainPath := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
+	childPath := filepath.Join(sessionDir, "agents", "researcher", "wire.jsonl")
+	writeUsageFixture(t, mainPath, "{}\n")
+	writeUsageFixture(t, childPath, "{}\n")
+	writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"),
+		fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q,"workDir":"/repo"}`+"\n", nativeID, sessionDir))
+	collector := NewCollector(store, SourceRoots{KimiHome: home}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessKimi, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+	gotSubagents := []string{sources[0].SubagentID, sources[1].SubagentID}
+	slices.Sort(gotSubagents)
+	if !reflect.DeepEqual(gotSubagents, []string{"", "researcher"}) {
+		t.Fatalf("subagent IDs = %v", gotSubagents)
+	}
+}
+
+func TestCollectorKimiIndexRejectsDeletedAndEscapingSessions(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	tests := []struct {
+		name    string
+		records func(home string) string
+	}{
+		{
+			name: "last record deletes session",
+			records: func(home string) string {
+				dir := filepath.Join(home, "sessions", nativeID)
+				return fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n"+`{"sessionId":%q,"deleted":true}`+"\n", nativeID, dir, nativeID)
+			},
+		},
+		{
+			name: "session directory escapes root",
+			records: func(home string) string {
+				dir := filepath.Join(filepath.Dir(home), nativeID)
+				return fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n", nativeID, dir)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			escapingDir := filepath.Join(filepath.Dir(home), nativeID)
+			t.Cleanup(func() { _ = os.RemoveAll(escapingDir) })
+			writeUsageFixture(t, filepath.Join(home, "sessions", nativeID, "agents", "main", "wire.jsonl"), "{}\n")
+			writeUsageFixture(t, filepath.Join(escapingDir, "agents", "main", "wire.jsonl"), "{}\n")
+			writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"), tc.records(home))
+			collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+			path, err := collector.discoverPath(context.Background(), domain.HarnessKimi, nativeID)
+			mustNoError(t, err)
+			if path != "" {
+				t.Fatalf("discovered rejected session path %q", path)
+			}
+		})
+	}
+}
+
+func TestCollectorDiscoversPiSessionByHeaderID(t *testing.T) {
+	const nativeID = "pi-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessPi, nativeID, false)
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "2026-08-09_"+nativeID+".jsonl")
+	writeUsageFixture(t, path, `{"type":"session","id":"`+nativeID+`","cwd":"/repo","version":3}`+"\n")
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessPi, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if len(bindings) != 1 {
+		t.Fatalf("bindings = %+v", bindings)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourcePiSession {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorReconcilePiPathMatchesExactlyOneLivePiWorkspace(t *testing.T) {
+	const nativeID = "pi-session-from-header"
+	store := collectorTestStore(t)
+	matchingWorkspace := t.TempDir()
+	otherWorkspace := t.TempDir()
+	matching := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	matching.Metadata.WorkspacePath = matchingWorkspace
+	mustNoError(t, store.UpdateSession(context.Background(), matching))
+	other := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	other.Metadata.WorkspacePath = otherWorkspace
+	mustNoError(t, store.UpdateSession(context.Background(), other))
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "session.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":%q,"cwd":%q,"version":3}`+"\n", nativeID, matchingWorkspace))
+
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+	mustNoError(t, collector.ReconcilePath(context.Background(), path))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), matching.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != nativeID {
+		t.Fatalf("matching bindings=%+v err=%v", bindings, err)
+	}
+	otherBindings, err := store.ListUsageBindingsForSession(context.Background(), other.ID)
+	if err != nil || len(otherBindings) != 0 {
+		t.Fatalf("other bindings=%+v err=%v", otherBindings, err)
+	}
+}
+
+func TestCollectorReconcilePiPathIgnoresAmbiguousOrNonPiWorkspace(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		harnesses []domain.AgentHarness
+	}{
+		{name: "ambiguous", harnesses: []domain.AgentHarness{domain.HarnessPi, domain.HarnessPi}},
+		{name: "non-pi", harnesses: []domain.AgentHarness{domain.HarnessQwen}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := collectorTestStore(t)
+			workspace := t.TempDir()
+			var sessions []domain.SessionRecord
+			for _, harness := range tc.harnesses {
+				session := collectorTestSession(t, store, harness, "", false)
+				session.Metadata.WorkspacePath = workspace
+				mustNoError(t, store.UpdateSession(context.Background(), session))
+				sessions = append(sessions, session)
+			}
+			root := t.TempDir()
+			path := filepath.Join(root, "project", "session.jsonl")
+			writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-native","cwd":%q,"version":3}`+"\n", workspace))
+			collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+			mustNoError(t, collector.ReconcilePath(context.Background(), path))
+			for _, session := range sessions {
+				bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+				if err != nil || len(bindings) != 0 {
+					t.Fatalf("session %s bindings=%+v err=%v", session.ID, bindings, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCollectorBackfillFindsPiSessionWithoutCapturedNativeID(t *testing.T) {
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session.Metadata.WorkspacePath = workspace
+	mustNoError(t, store.UpdateSession(context.Background(), session))
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "existing.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-existing","cwd":%q,"version":3}`+"\n", workspace))
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+
+	mustNoError(t, collector.BackfillActive(context.Background()))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-existing" {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
+func TestCollectorDiscoversQwenSharedMonthlyUsage(t *testing.T) {
+	const nativeID = "qwen-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessQwen, nativeID, false)
+	root := t.TempDir()
+	path := filepath.Join(root, "token-usage-2026-08.jsonl")
+	writeUsageFixture(t, path, `{"schemaVersion":1,"id":"turn-1","sessionId":"`+nativeID+`","model":"qwen3","inputTokens":1,"outputTokens":1,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":2}`+"\n")
+	collector := NewCollector(store, SourceRoots{QwenUsage: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessQwen, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if len(bindings) != 1 {
+		t.Fatalf("bindings = %+v", bindings)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourceQwenMonthly {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorQwenRegistersNewestMonthAndLaterRollover(t *testing.T) {
+	const nativeID = "qwen-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessQwen, nativeID, false)
+	root := t.TempDir()
+	june := filepath.Join(root, "token-usage-2026-06.jsonl")
+	july := filepath.Join(root, "token-usage-2026-07.jsonl")
+	writeUsageFixture(t, june, "{}\n")
+	writeUsageFixture(t, july, "{}\n")
+	future := time.Now().Add(24 * time.Hour)
+	mustNoError(t, os.Chtimes(june, future, future))
+	collector := NewCollector(store, SourceRoots{QwenUsage: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessQwen, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, july) {
+		t.Fatalf("initial sources=%+v err=%v", sources, err)
+	}
+
+	august := filepath.Join(root, "token-usage-2026-08.jsonl")
+	writeUsageFixture(t, august, "{}\n")
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+	sources, err = store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("rollover sources=%+v err=%v", sources, err)
+	}
+	gotPaths := []string{sources[0].ArtifactPath, sources[1].ArtifactPath}
+	slices.Sort(gotPaths)
+	wantPaths := []string{canonicalUsagePath(t, july), canonicalUsagePath(t, august)}
+	slices.Sort(wantPaths)
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("paths=%v want=%v", gotPaths, wantPaths)
+	}
+	for _, source := range sources {
+		if source.State != domain.UsageSourceActive && source.State != domain.UsageSourcePending {
+			t.Fatalf("source state=%s, want active or newly pending", source.State)
+		}
 	}
 }
 

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1983,6 +1983,24 @@ func TestCollectorBackfillFindsPiSessionWithoutCapturedNativeID(t *testing.T) {
 	}
 }
 
+func TestCollectorReconcileFindsPiSessionWithoutCapturedNativeID(t *testing.T) {
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session.Metadata.WorkspacePath = workspace
+	mustNoError(t, store.UpdateSession(context.Background(), session))
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "existing.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-existing","cwd":%q,"version":3}`+"\n", workspace))
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-existing" {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
 func TestCollectorBindsPiWhenLifecycleCapturesNativeSessionID(t *testing.T) {
 	const nativeID = "pi-captured"
 	store := collectorTestStore(t)

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1762,7 +1762,7 @@ func TestCollectorDiscoversKimiWireSourcesFromSessionIndex(t *testing.T) {
 	store := collectorTestStore(t)
 	session := collectorTestSession(t, store, domain.HarnessKimi, nativeID, false)
 	home := t.TempDir()
-	sessionDir := filepath.Join(home, "sessions", nativeID)
+	sessionDir := filepath.Join(home, "sessions", "wd_agent-orchestrator-379_1f71c05c08c2", nativeID)
 	mainPath := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
 	childPath := filepath.Join(sessionDir, "agents", "researcher", "wire.jsonl")
 	writeUsageFixture(t, mainPath, "{}\n")

--- a/backend/internal/service/usage/source_profile.go
+++ b/backend/internal/service/usage/source_profile.go
@@ -1,0 +1,24 @@
+package usage
+
+import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
+// sourceKindForHarness returns the root usage artifact shape for a harness.
+// Claude and Codex may register additional child sources after the root.
+func sourceKindForHarness(h domain.AgentHarness) (domain.UsageSourceKind, bool) {
+	switch h {
+	case domain.HarnessClaudeCode:
+		return domain.UsageSourceClaudeMain, true
+	case domain.HarnessCodex:
+		return domain.UsageSourceCodexRollout, true
+	case domain.HarnessCopilot:
+		return domain.UsageSourceCopilotShutdown, true
+	case domain.HarnessKimi:
+		return domain.UsageSourceKimiWire, true
+	case domain.HarnessPi:
+		return domain.UsageSourcePiSession, true
+	case domain.HarnessQwen:
+		return domain.UsageSourceQwenMonthly, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/service/usage/summary.go
+++ b/backend/internal/service/usage/summary.go
@@ -55,8 +55,11 @@ func (r *SummaryReader) Get(ctx context.Context, sessionID domain.SessionID) (do
 }
 
 func usageTotals(models []domain.UsageModelAggregate) domain.UsageMetricTotals {
+	if len(models) == 0 {
+		return domain.UsageMetricTotals{}
+	}
 	var input, uncached, cacheRead, cacheWrite, output, reasoning, reasoningEvents int64
-	var uncachedAvailable, cacheReadAvailable, cacheWriteAvailable, reasoningAvailable bool
+	uncachedAvailable, cacheReadAvailable, cacheWriteAvailable, reasoningAvailable := true, true, true, true
 	for _, model := range models {
 		coverage := MetricCoverage(model.Harness)
 		input += model.Tokens.InputTokens
@@ -64,17 +67,14 @@ func usageTotals(models []domain.UsageModelAggregate) domain.UsageMetricTotals {
 		cacheRead += model.Tokens.CacheReadTokens
 		cacheWrite += model.Tokens.CacheWriteTokens
 		output += model.Tokens.OutputTokens
-		uncachedAvailable = uncachedAvailable || coverage.UncachedInput
-		cacheReadAvailable = cacheReadAvailable || coverage.CacheRead
-		cacheWriteAvailable = cacheWriteAvailable || coverage.CacheWrite
-		reasoningAvailable = reasoningAvailable || coverage.Reasoning
+		uncachedAvailable = uncachedAvailable && coverage.UncachedInput
+		cacheReadAvailable = cacheReadAvailable && coverage.CacheRead
+		cacheWriteAvailable = cacheWriteAvailable && coverage.CacheWrite
+		reasoningAvailable = reasoningAvailable && coverage.Reasoning
 		if model.Tokens.ReasoningTokens != nil {
 			reasoning += *model.Tokens.ReasoningTokens
 		}
 		reasoningEvents += model.ReasoningEventCount
-	}
-	if len(models) == 0 {
-		return domain.UsageMetricTotals{}
 	}
 	totals := domain.UsageMetricTotals{
 		InputTokens: &input, OutputTokens: &output,

--- a/backend/internal/service/usage/summary.go
+++ b/backend/internal/service/usage/summary.go
@@ -56,12 +56,18 @@ func (r *SummaryReader) Get(ctx context.Context, sessionID domain.SessionID) (do
 
 func usageTotals(models []domain.UsageModelAggregate) domain.UsageMetricTotals {
 	var input, uncached, cacheRead, cacheWrite, output, reasoning, reasoningEvents int64
+	var uncachedAvailable, cacheReadAvailable, cacheWriteAvailable, reasoningAvailable bool
 	for _, model := range models {
+		coverage := MetricCoverage(model.Harness)
 		input += model.Tokens.InputTokens
 		uncached += model.Tokens.UncachedInputTokens
 		cacheRead += model.Tokens.CacheReadTokens
 		cacheWrite += model.Tokens.CacheWriteTokens
 		output += model.Tokens.OutputTokens
+		uncachedAvailable = uncachedAvailable || coverage.UncachedInput
+		cacheReadAvailable = cacheReadAvailable || coverage.CacheRead
+		cacheWriteAvailable = cacheWriteAvailable || coverage.CacheWrite
+		reasoningAvailable = reasoningAvailable || coverage.Reasoning
 		if model.Tokens.ReasoningTokens != nil {
 			reasoning += *model.Tokens.ReasoningTokens
 		}
@@ -71,10 +77,18 @@ func usageTotals(models []domain.UsageModelAggregate) domain.UsageMetricTotals {
 		return domain.UsageMetricTotals{}
 	}
 	totals := domain.UsageMetricTotals{
-		InputTokens: &input, UncachedInputTokens: &uncached, CacheReadTokens: &cacheRead,
-		CacheWriteTokens: &cacheWrite, OutputTokens: &output,
+		InputTokens: &input, OutputTokens: &output,
 	}
-	if reasoningEvents > 0 {
+	if uncachedAvailable {
+		totals.UncachedInputTokens = &uncached
+	}
+	if cacheReadAvailable {
+		totals.CacheReadTokens = &cacheRead
+	}
+	if cacheWriteAvailable {
+		totals.CacheWriteTokens = &cacheWrite
+	}
+	if reasoningAvailable && reasoningEvents > 0 {
 		totals.ReasoningTokens = &reasoning
 	}
 	return totals

--- a/backend/internal/service/usage/summary_test.go
+++ b/backend/internal/service/usage/summary_test.go
@@ -76,7 +76,7 @@ func TestSummaryReaderGetAggregatesModelsAndIntegrity(t *testing.T) {
 	}
 	if got.Totals.InputTokens == nil || *got.Totals.InputTokens != 1100 ||
 		got.Totals.OutputTokens == nil || *got.Totals.OutputTokens != 225 ||
-		got.Totals.ReasoningTokens == nil || *got.Totals.ReasoningTokens != 40 {
+		got.Totals.ReasoningTokens != nil {
 		t.Fatalf("totals = %+v", got.Totals)
 	}
 	if len(got.Harnesses) != 2 || got.Harnesses[0].Models[0].ModelID != "gpt-5.6" {
@@ -127,6 +127,9 @@ func TestSummaryReaderGetAppliesHarnessMetricCoverage(t *testing.T) {
 	mustNoError(t, err)
 	if len(got.Harnesses) != 2 {
 		t.Fatalf("harnesses = %+v", got.Harnesses)
+	}
+	if got.Totals.CacheWriteTokens != nil || got.Totals.ReasoningTokens != nil {
+		t.Fatalf("mixed-harness totals expose partial metrics = %+v", got.Totals)
 	}
 	qwen := got.Harnesses[0].Totals
 	if qwen.CacheWriteTokens != nil {

--- a/backend/internal/service/usage/summary_test.go
+++ b/backend/internal/service/usage/summary_test.go
@@ -95,3 +95,51 @@ func TestSummaryReaderGetReturnsUnavailableMetricsWithoutEvents(t *testing.T) {
 		t.Fatalf("empty usage = %+v", got)
 	}
 }
+
+// TestSummaryReaderGetAppliesHarnessMetricCoverage catches treating a metric
+// the native source never reports as a real zero. Native zeroes for supported
+// metrics must remain distinguishable from unavailable metrics.
+func TestSummaryReaderGetAppliesHarnessMetricCoverage(t *testing.T) {
+	zero := int64(0)
+	store := &usageSummaryStoreStub{
+		found:   true,
+		session: domain.SessionRecord{ID: "coverage", Harness: domain.HarnessQwen},
+		models: []domain.UsageModelAggregate{
+			{
+				Harness: domain.HarnessQwen, ModelID: "qwen3-coder",
+				Tokens: domain.UsageTokenMetrics{
+					InputTokens: 10, UncachedInputTokens: 4, CacheReadTokens: 6,
+					OutputTokens: 2, ReasoningTokens: &zero,
+				},
+				ReasoningEventCount: 1,
+			},
+			{
+				Harness: domain.HarnessKimi, ModelID: "kimi-for-coding",
+				Tokens: domain.UsageTokenMetrics{
+					InputTokens: 8, UncachedInputTokens: 3, CacheReadTokens: 4,
+					CacheWriteTokens: 1, OutputTokens: 2,
+				},
+			},
+		},
+	}
+
+	got, err := NewSummaryReader(store).Get(context.Background(), "coverage")
+	mustNoError(t, err)
+	if len(got.Harnesses) != 2 {
+		t.Fatalf("harnesses = %+v", got.Harnesses)
+	}
+	qwen := got.Harnesses[0].Totals
+	if qwen.CacheWriteTokens != nil {
+		t.Fatalf("qwen cache write = %v, want unavailable", *qwen.CacheWriteTokens)
+	}
+	if qwen.ReasoningTokens == nil || *qwen.ReasoningTokens != 0 {
+		t.Fatalf("qwen reasoning = %v, want reported zero", qwen.ReasoningTokens)
+	}
+	kimi := got.Harnesses[1].Totals
+	if kimi.CacheWriteTokens == nil || *kimi.CacheWriteTokens != 1 {
+		t.Fatalf("kimi cache write = %v, want 1", kimi.CacheWriteTokens)
+	}
+	if kimi.ReasoningTokens != nil {
+		t.Fatalf("kimi reasoning = %v, want unavailable", *kimi.ReasoningTokens)
+	}
+}

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -5734,6 +5734,40 @@ func TestRetireForReplacementRuntimeDestroyFailureBlocksWorkspaceRelease(t *test
 	}
 }
 
+func TestRetireForReplacementForceDestroyFailureLeavesSessionActive(t *testing.T) {
+	m, st, rt, ws := newLifecycleManager()
+	ws.forceDestroyErr = errors.New("worktree still registered")
+	ws.stashRef = "refs/ao/preserved/mer-orch"
+	st.sessions["mer-orch"] = domain.SessionRecord{
+		ID:        "mer-orch",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-orch", Branch: "ao/mer-orchestrator", RuntimeHandleID: "orch-handle"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-orch"] = []domain.SessionWorktreeRecord{{
+		SessionID:    "mer-orch",
+		RepoName:     domain.RootWorkspaceRepoName,
+		Branch:       "ao/mer-orchestrator",
+		WorktreePath: "/ws/mer-orch",
+		PreservedRef: "refs/ao/preserved/old",
+	}}
+
+	err := m.RetireForReplacement(ctx, "mer-orch")
+	if err == nil || !strings.Contains(err.Error(), "force destroy") {
+		t.Fatalf("RetireForReplacement err = %v, want force destroy failure", err)
+	}
+	if st.sessions["mer-orch"].IsTerminated {
+		t.Fatal("session must remain active so retry can retire it again")
+	}
+	if rt.destroyed != 1 {
+		t.Fatalf("runtime destroyed = %d, want 1 before workspace release", rt.destroyed)
+	}
+	if ws.stashCalls != 1 {
+		t.Fatalf("stash calls = %d, want 1", ws.stashCalls)
+	}
+}
+
 // TestSaveAndTeardownAll_CleanWorktreeWritesEmptyRef verifies that a clean
 // worktree (StashUncommitted returns "") still writes a worktree row (with
 // empty preserved_ref). The row's presence is the shutdown-saved marker.

--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -931,6 +931,253 @@ func reconcileSchema(db *sql.DB) error {
 	if err := reconcileHarnessConstraint(db); err != nil {
 		return err
 	}
+	if err := reconcileUsageSchema(db); err != nil {
+		return err
+	}
+	return nil
+}
+
+func reconcileUsageSchema(db *sql.DB) error {
+	var usageBindings int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'usage_bindings'`,
+	).Scan(&usageBindings); err != nil {
+		return fmt.Errorf("schema verification: inspect usage_bindings table: %w", err)
+	}
+	if usageBindings == 0 {
+		return nil
+	}
+
+	checks := []struct {
+		kind string
+		name string
+	}{
+		{kind: "table", name: "usage_sources"},
+		{kind: "table", name: "model_usage_events"},
+		{kind: "view", name: "usage_codex_source_discovery"},
+		{kind: "view", name: "usage_codex_pending_children"},
+		{kind: "view", name: "usage_session_integrity"},
+	}
+	needsRepair := false
+	for _, check := range checks {
+		var count int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master WHERE type = ? AND name = ?`, check.kind, check.name,
+		).Scan(&count); err != nil {
+			return fmt.Errorf("schema verification: inspect %s %s: %w", check.kind, check.name, err)
+		}
+		if count == 0 {
+			needsRepair = true
+			break
+		}
+	}
+	if !needsRepair {
+		var parserState int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('usage_sources') WHERE name = 'parser_state_json'`,
+		).Scan(&parserState); err != nil {
+			return fmt.Errorf("schema verification: inspect usage_sources.parser_state_json: %w", err)
+		}
+		needsRepair = parserState == 0
+	}
+	if !needsRepair {
+		return nil
+	}
+
+	var parserState int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('usage_sources') WHERE name = 'parser_state_json'`,
+	).Scan(&parserState); err != nil {
+		return fmt.Errorf("schema verification: inspect usage_sources.parser_state_json before repair: %w", err)
+	}
+	parserStateExpr := `'{}'`
+	if parserState > 0 {
+		parserStateExpr = "parser_state_json"
+	}
+
+	_, err := db.Exec(fmt.Sprintf(`
+PRAGMA foreign_keys=OFF;
+BEGIN IMMEDIATE;
+
+DROP VIEW IF EXISTS usage_session_integrity;
+DROP VIEW IF EXISTS usage_codex_pending_children;
+DROP VIEW IF EXISTS usage_codex_source_discovery;
+DROP TRIGGER IF EXISTS model_usage_events_cdc_insert;
+DROP TRIGGER IF EXISTS usage_sources_cdc_update;
+DROP TRIGGER IF EXISTS usage_sources_cdc_insert;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
+
+CREATE TABLE usage_bindings_next (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')),
+    native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id   TEXT NOT NULL DEFAULT '',
+    state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code    TEXT NOT NULL DEFAULT '',
+    updated_at         TIMESTAMP NOT NULL,
+    UNIQUE (session_id, harness, native_root_id)
+);
+
+CREATE TABLE usage_sources_next (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind                TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout', 'copilot_shutdown', 'kimi_wire', 'pi_session', 'qwen_monthly')),
+    native_session_id   TEXT NOT NULL DEFAULT '',
+    subagent_id         TEXT NOT NULL DEFAULT '',
+    artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity       TEXT NOT NULL DEFAULT '',
+    generation          INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset         INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    parser_state_json   TEXT NOT NULL DEFAULT '{}',
+    state               TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count       INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count       INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at       TIMESTAMP,
+    last_error_code     TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+
+CREATE TABLE model_usage_events_next (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id              INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    usage_source_id         INTEGER NOT NULL REFERENCES usage_sources (id) ON DELETE CASCADE,
+    model_id                TEXT NOT NULL CHECK (trim(model_id) <> ''),
+    input_tokens            INTEGER NOT NULL CHECK (input_tokens >= 0),
+    uncached_input_tokens   INTEGER NOT NULL CHECK (uncached_input_tokens >= 0 AND uncached_input_tokens <= input_tokens),
+    cache_read_tokens       INTEGER NOT NULL CHECK (cache_read_tokens >= 0 AND cache_read_tokens <= input_tokens),
+    cache_write_tokens      INTEGER NOT NULL CHECK (cache_write_tokens >= 0 AND cache_write_tokens <= input_tokens),
+    output_tokens           INTEGER NOT NULL CHECK (output_tokens >= 0),
+    reasoning_tokens        INTEGER CHECK (reasoning_tokens IS NULL OR (reasoning_tokens >= 0 AND reasoning_tokens <= output_tokens)),
+    source_event_key        TEXT NOT NULL CHECK (trim(source_event_key) <> ''),
+    UNIQUE (binding_id, source_event_key)
+);
+
+INSERT INTO usage_bindings_next
+SELECT id, session_id, harness, native_root_id, initial_model_id, state,
+       last_error_code, updated_at
+FROM usage_bindings;
+
+INSERT INTO usage_sources_next
+SELECT id, binding_id, kind, native_session_id, subagent_id, artifact_path,
+       file_identity, generation, byte_offset, %s,
+       state, failure_count, anomaly_count, next_retry_at, last_error_code, updated_at
+FROM usage_sources;
+
+INSERT INTO model_usage_events_next
+SELECT id, binding_id, usage_source_id, model_id, input_tokens,
+       uncached_input_tokens, cache_read_tokens, cache_write_tokens,
+       output_tokens, reasoning_tokens, source_event_key
+FROM model_usage_events;
+
+DROP TABLE model_usage_events;
+DROP TABLE usage_sources;
+DROP TABLE usage_bindings;
+ALTER TABLE usage_bindings_next RENAME TO usage_bindings;
+ALTER TABLE usage_sources_next RENAME TO usage_sources;
+ALTER TABLE model_usage_events_next RENAME TO model_usage_events;
+
+CREATE INDEX IF NOT EXISTS idx_usage_bindings_session_state ON usage_bindings (session_id, state);
+CREATE INDEX IF NOT EXISTS idx_usage_sources_state_retry ON usage_sources (state, next_retry_at);
+CREATE INDEX IF NOT EXISTS idx_usage_sources_binding_kind ON usage_sources (binding_id, kind);
+CREATE INDEX IF NOT EXISTS idx_usage_sources_codex_native_latest
+    ON usage_sources (kind, native_session_id, binding_id, generation DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_binding_model ON model_usage_events (binding_id, model_id);
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_usage_source ON model_usage_events (usage_source_id);
+
+CREATE VIEW usage_codex_source_discovery AS
+SELECT source_id, binding_id, native_session_id,
+    CASE WHEN child_ids_json IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM json_each(child_ids_json) WHERE type <> 'text'
+    ) THEN child_ids_json ELSE '[]' END AS discovered_child_ids_json,
+    CASE WHEN child_ids_json IS NOT NULL AND EXISTS (
+        SELECT 1 FROM json_each(child_ids_json) WHERE type <> 'text'
+    ) THEN 1 ELSE 0 END AS has_mixed_child_types
+FROM (
+    SELECT id AS source_id, binding_id, native_session_id,
+        CASE WHEN json_valid(parser_state_json)
+          AND json_type(parser_state_json, '$') = 'object'
+          AND json_type(parser_state_json, '$.version') = 'integer'
+          AND json_extract(parser_state_json, '$.version') = 1
+          AND json_type(parser_state_json, '$.source_kind') = 'text'
+          AND json_extract(parser_state_json, '$.source_kind') = 'codex_rollout'
+          AND json_type(parser_state_json, '$.codex') = 'object'
+          AND json_type(parser_state_json, '$.codex.discovered_child_ids') = 'array'
+        THEN json_extract(parser_state_json, '$.codex.discovered_child_ids') END AS child_ids_json
+    FROM usage_sources WHERE kind = 'codex_rollout'
+);
+
+CREATE VIEW usage_codex_pending_children AS
+SELECT spawning.binding_id, CAST(discovered.value AS TEXT) AS native_session_id
+FROM usage_codex_source_discovery spawning
+JOIN json_each(spawning.discovered_child_ids_json) discovered
+WHERE discovered.type = 'text'
+  AND length(discovered.value) = 36
+  AND substr(discovered.value, 9, 1) = '-'
+  AND substr(discovered.value, 14, 1) = '-'
+  AND substr(discovered.value, 19, 1) = '-'
+  AND substr(discovered.value, 24, 1) = '-'
+  AND lower(discovered.value) = discovered.value
+  AND length(replace(discovered.value, '-', '')) = 32
+  AND replace(discovered.value, '-', '') NOT GLOB '*[^0-9a-f]*'
+  AND spawning.source_id = (
+      SELECT latest.id FROM usage_sources latest
+      WHERE latest.binding_id = spawning.binding_id
+        AND latest.kind = 'codex_rollout'
+        AND latest.native_session_id = spawning.native_session_id
+      ORDER BY latest.generation DESC, latest.id DESC LIMIT 1
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM usage_sources registered
+      WHERE registered.binding_id = spawning.binding_id
+        AND registered.kind = 'codex_rollout'
+        AND registered.native_session_id = CAST(discovered.value AS TEXT)
+  );
+
+CREATE VIEW usage_session_integrity AS
+SELECT ub.session_id,
+    CAST(MAX(CASE
+        WHEN ub.state = 'partial'
+          OR ub.last_error_code NOT IN ('', 'source_discovery_pending', 'artifact_missing', 'source_read_failed')
+          OR (us.last_error_code <> 'artifact_replaced' AND (
+              us.anomaly_count > 0
+              OR us.last_error_code NOT IN ('', 'source_discovery_pending', 'artifact_missing', 'source_read_failed')
+          ))
+        THEN 1 ELSE 0
+    END) AS INTEGER) AS incomplete
+FROM usage_bindings ub
+LEFT JOIN usage_sources us ON us.binding_id = ub.id
+GROUP BY ub.session_id;
+
+CREATE TRIGGER usage_bindings_cdc_insert AFTER INSERT ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+CREATE TRIGGER usage_bindings_cdc_update AFTER UPDATE ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+CREATE TRIGGER usage_sources_cdc_update AFTER UPDATE ON usage_sources
+WHEN OLD.anomaly_count IS NOT NEW.anomaly_count
+  OR OLD.last_error_code IS NOT NEW.last_error_code
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, ub.session_id, 'session_updated', json_object('id', ub.session_id), NEW.updated_at
+    FROM usage_bindings ub JOIN sessions s ON s.id = ub.session_id WHERE ub.id = NEW.binding_id;
+END;
+
+COMMIT;
+PRAGMA foreign_keys=ON;
+`, parserStateExpr))
+	if err != nil {
+		_, _ = db.Exec(`ROLLBACK`)
+		_, _ = db.Exec(`PRAGMA foreign_keys=ON`)
+		return fmt.Errorf("schema repair: rebuild usage schema: %w", err)
+	}
 	return nil
 }
 

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -377,7 +377,7 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex')
+      AND ub.harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')
       AND (
           ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
@@ -730,13 +730,13 @@ SELECT ub.id, ub.session_id, ub.harness, ub.native_root_id, ub.initial_model_id,
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex', 'kimi', 'pi', 'qwen')
+  AND ub.harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness IN ('claude-code', 'kimi', 'pi', 'qwen')
+      ub.harness IN ('claude-code', 'copilot', 'kimi', 'pi', 'qwen')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -730,13 +730,13 @@ SELECT ub.id, ub.session_id, ub.harness, ub.native_root_id, ub.initial_model_id,
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.harness IN ('claude-code', 'codex', 'kimi', 'pi', 'qwen')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness = 'claude-code'
+      ub.harness IN ('claude-code', 'kimi', 'pi', 'qwen')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -98,6 +98,7 @@ var shippedMigrations = map[int64]string{
 	92: "0092_pr_reviews_target_sha.sql",
 	93: "0093_review_run_trigger_source.sql",
 	94: "0094_agent_switch_recovery.sql",
+	95: "0095_multi_agent_usage.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_multi_agent_usage_test.go
+++ b/backend/internal/storage/sqlite/migrate_multi_agent_usage_test.go
@@ -1,0 +1,98 @@
+package sqlite
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// TestMultiAgentUsageMigrationAcceptsCertifiedSourceValues catches a migration
+// that reports success without actually widening the usage CHECK constraints.
+// The production change that makes this fail is dropping any certified harness
+// or source kind from the rebuilt schema.
+func TestMultiAgentUsageMigrationAcceptsCertifiedSourceValues(t *testing.T) {
+	db := openMigratedTestDB(t)
+	now := time.Unix(100, 0).UTC()
+	if _, err := db.Exec(`
+INSERT INTO projects (id, path, registered_at, config)
+VALUES ('usage-project', '/repo/usage-project', ?, '{}');
+`, now); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+
+	tests := []struct {
+		harness domain.AgentHarness
+		kind    domain.UsageSourceKind
+	}{
+		{domain.HarnessCopilot, domain.UsageSourceCopilotShutdown},
+		{domain.HarnessKimi, domain.UsageSourceKimiWire},
+		{domain.HarnessPi, domain.UsageSourcePiSession},
+		{domain.HarnessQwen, domain.UsageSourceQwenMonthly},
+	}
+	for index, test := range tests {
+		sessionID := "usage-session-" + string(rune('a'+index))
+		if _, err := db.Exec(`
+INSERT INTO sessions (id, project_id, num, harness, activity_last_at, created_at, updated_at)
+VALUES (?, 'usage-project', ?, ?, ?, ?, ?)
+`, sessionID, index+1, test.harness, now, now, now); err != nil {
+			t.Fatalf("insert %s session: %v", test.harness, err)
+		}
+		result, err := db.Exec(`
+INSERT INTO usage_bindings
+    (session_id, harness, native_root_id, state, updated_at)
+VALUES (?, ?, ?, 'active', ?)
+`, sessionID, test.harness, "native-"+sessionID, now)
+		if err != nil {
+			t.Fatalf("insert %s binding: %v", test.harness, err)
+		}
+		bindingID, err := result.LastInsertId()
+		if err != nil {
+			t.Fatalf("read %s binding id: %v", test.harness, err)
+		}
+		if _, err := db.Exec(`
+INSERT INTO usage_sources
+    (binding_id, kind, native_session_id, artifact_path, state, updated_at)
+VALUES (?, ?, ?, ?, 'active', ?)
+`, bindingID, test.kind, "native-"+sessionID, "/tmp/"+sessionID+".jsonl", now); err != nil {
+			t.Fatalf("insert %s source %s: %v", test.harness, test.kind, err)
+		}
+	}
+}
+
+func TestMultiAgentUsageMigrationRejectsUnknownValues(t *testing.T) {
+	db := openMigratedTestDB(t)
+	now := time.Unix(100, 0).UTC()
+	if _, err := db.Exec(`
+INSERT INTO projects (id, path, registered_at, config)
+VALUES ('usage-project', '/repo/usage-project', ?, '{}');
+INSERT INTO sessions (id, project_id, num, harness, activity_last_at, created_at, updated_at)
+VALUES ('usage-session', 'usage-project', 1, 'codex', ?, ?, ?);
+INSERT INTO usage_bindings
+    (session_id, harness, native_root_id, state, updated_at)
+VALUES ('usage-session', 'codex', 'native-session', 'active', ?);
+`, now, now, now, now, now); err != nil {
+		t.Fatalf("seed usage binding: %v", err)
+	}
+
+	assertCheckFailure(t, db, `
+INSERT INTO usage_bindings
+    (session_id, harness, native_root_id, state, updated_at)
+VALUES ('usage-session', 'unknown-agent', 'unknown-native', 'active', ?)
+`, now)
+	assertCheckFailure(t, db, `
+INSERT INTO usage_sources
+    (binding_id, kind, native_session_id, artifact_path, state, updated_at)
+VALUES (1, 'unknown_source', 'native-session', '/tmp/unknown.jsonl', 'active', ?)
+`, now)
+}
+
+func assertCheckFailure(t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	_, err := db.Exec(query, args...)
+	if err == nil || !strings.Contains(err.Error(), "CHECK constraint failed") {
+		t.Fatalf("error = %v, want CHECK constraint failure", err)
+	}
+}

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -135,6 +135,124 @@ VALUES (1, 1, 1, 'gpt-test', 120, 100, 20, 0, 30, 'event-1');
 	}
 }
 
+func TestMigrateRepairsAppliedButStaleUsageSchema(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 43)
+
+	if _, err := db.Exec(`
+CREATE TABLE usage_bindings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex')),
+    native_root_id TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id TEXT NOT NULL DEFAULT '',
+    source_cli_version TEXT NOT NULL DEFAULT '',
+    state TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code TEXT NOT NULL DEFAULT '',
+    first_seen_at TIMESTAMP NOT NULL,
+    last_seen_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    UNIQUE (session_id, harness, native_root_id)
+);
+CREATE TABLE usage_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout')),
+    native_session_id TEXT NOT NULL DEFAULT '',
+    subagent_id TEXT NOT NULL DEFAULT '',
+    artifact_path TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity TEXT NOT NULL DEFAULT '',
+    generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    baseline_input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_input_tokens >= 0),
+    baseline_cached_input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_cached_input_tokens >= 0),
+    baseline_cache_write_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_cache_write_tokens >= 0),
+    baseline_output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_output_tokens >= 0),
+    baseline_reasoning_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_reasoning_tokens >= 0),
+    current_model_id TEXT NOT NULL DEFAULT '',
+    current_provider TEXT NOT NULL DEFAULT '',
+    parser_version TEXT NOT NULL CHECK (trim(parser_version) <> ''),
+    state TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at TIMESTAMP,
+    last_error_code TEXT NOT NULL DEFAULT '',
+    last_observed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+CREATE TABLE model_usage_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    usage_source_id INTEGER NOT NULL REFERENCES usage_sources (id) ON DELETE CASCADE,
+    model_id TEXT NOT NULL CHECK (trim(model_id) <> ''),
+    input_tokens INTEGER NOT NULL CHECK (input_tokens >= 0),
+    uncached_input_tokens INTEGER NOT NULL CHECK (uncached_input_tokens >= 0 AND uncached_input_tokens <= input_tokens),
+    cache_read_tokens INTEGER NOT NULL CHECK (cache_read_tokens >= 0 AND cache_read_tokens <= input_tokens),
+    cache_write_tokens INTEGER NOT NULL CHECK (cache_write_tokens >= 0 AND cache_write_tokens <= input_tokens),
+    output_tokens INTEGER NOT NULL CHECK (output_tokens >= 0),
+    reasoning_tokens INTEGER CHECK (reasoning_tokens IS NULL OR (reasoning_tokens >= 0 AND reasoning_tokens <= output_tokens)),
+    source_event_key TEXT NOT NULL CHECK (trim(source_event_key) <> ''),
+    UNIQUE (binding_id, source_event_key)
+);
+INSERT INTO projects (id, path, registered_at, config)
+VALUES ('agent-orchestrator', '/repo/agent-orchestrator', '2026-08-01T00:00:00Z', '{}');
+INSERT INTO sessions (id, project_id, num, harness, activity_last_at, created_at, updated_at)
+VALUES ('agent-orchestrator-1', 'agent-orchestrator', 1, 'codex', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z');
+INSERT INTO usage_bindings
+    (id, session_id, harness, native_root_id, state, first_seen_at, last_seen_at, updated_at)
+VALUES (1, 'agent-orchestrator-1', 'codex', 'native-1', 'active', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z');
+INSERT INTO usage_sources
+    (id, binding_id, kind, native_session_id, artifact_path, parser_version, state, created_at, updated_at)
+VALUES (1, 1, 'codex_rollout', 'native-1', '/tmp/rollout.jsonl', 'legacy', 'active', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z');
+INSERT INTO model_usage_events
+    (id, binding_id, usage_source_id, model_id, input_tokens, uncached_input_tokens,
+     cache_read_tokens, cache_write_tokens, output_tokens, source_event_key)
+VALUES (1, 1, 1, 'gpt-test', 120, 100, 20, 0, 30, 'event-1');
+`); err != nil {
+		t.Fatalf("seed stale usage schema: %v", err)
+	}
+	for version := 44; version <= 52; version++ {
+		if _, err := db.Exec(
+			`INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, 1)`, version,
+		); err != nil {
+			t.Fatalf("seed migration %d: %v", version, err)
+		}
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate stale applied usage schema: %v", err)
+	}
+	for table, wantColumns := range expectedUsageTableColumns {
+		if got := tableColumns(t, db, table); !reflect.DeepEqual(got, wantColumns) {
+			t.Errorf("%s columns = %v, want %v", table, got, wantColumns)
+		}
+	}
+	for _, view := range []string{"usage_codex_source_discovery", "usage_codex_pending_children", "usage_session_integrity"} {
+		var viewCount int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master WHERE type = 'view' AND name = ?`, view,
+		).Scan(&viewCount); err != nil || viewCount != 1 {
+			t.Fatalf("%s view count = %d, err = %v", view, viewCount, err)
+		}
+	}
+	if _, err := db.Exec(`
+INSERT INTO usage_bindings
+    (session_id, harness, native_root_id, state, updated_at)
+VALUES ('agent-orchestrator-1', 'copilot', 'copilot-native-1', 'active', '2026-08-01T00:00:00Z');
+INSERT INTO usage_sources
+    (binding_id, kind, artifact_path, state, updated_at)
+VALUES ((SELECT id FROM usage_bindings WHERE harness = 'copilot'), 'copilot_shutdown', '/tmp/copilot.jsonl', 'active', '2026-08-01T00:00:00Z');
+`); err != nil {
+		t.Fatalf("insert copilot usage after repair: %v", err)
+	}
+}
+
 func openMigratedTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)

--- a/backend/internal/storage/sqlite/migrations/0095_multi_agent_usage.sql
+++ b/backend/internal/storage/sqlite/migrations/0095_multi_agent_usage.sql
@@ -1,0 +1,57 @@
+-- Widen the token-usage source constraints for the file-backed agent
+-- collectors. The tables otherwise remain byte-for-byte compatible, so follow
+-- the repository's established writable_schema pattern for CHECK-only changes
+-- instead of rebuilding append-only usage rows and their foreign keys.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (harness IN (''claude-code'', ''codex''))',
+    'CHECK (harness IN (''claude-code'', ''codex'', ''copilot'', ''kimi'', ''pi'', ''qwen''))'
+)
+WHERE type = 'table' AND name = 'usage_bindings';
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (kind IN (''claude_main'', ''claude_subagent'', ''codex_rollout''))',
+    'CHECK (kind IN (''claude_main'', ''claude_subagent'', ''codex_rollout'', ''copilot_shutdown'', ''kimi_wire'', ''pi_session'', ''qwen_monthly''))'
+)
+WHERE type = 'table' AND name = 'usage_sources';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (harness IN (''claude-code'', ''codex'', ''copilot'', ''kimi'', ''pi'', ''qwen''))',
+    'CHECK (harness IN (''claude-code'', ''codex''))'
+)
+WHERE type = 'table' AND name = 'usage_bindings';
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (kind IN (''claude_main'', ''claude_subagent'', ''codex_rollout'', ''copilot_shutdown'', ''kimi_wire'', ''pi_session'', ''qwen_monthly''))',
+    'CHECK (kind IN (''claude_main'', ''claude_subagent'', ''codex_rollout''))'
+)
+WHERE type = 'table' AND name = 'usage_sources';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -107,7 +107,7 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex')
+      AND ub.harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')
       AND (
           ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
@@ -157,13 +157,13 @@ SELECT ub.*
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex', 'kimi', 'pi', 'qwen')
+  AND ub.harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness IN ('claude-code', 'kimi', 'pi', 'qwen')
+      ub.harness IN ('claude-code', 'copilot', 'kimi', 'pi', 'qwen')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -157,13 +157,13 @@ SELECT ub.*
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.harness IN ('claude-code', 'codex', 'kimi', 'pi', 'qwen')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness = 'claude-code'
+      ub.harness IN ('claude-code', 'kimi', 'pi', 'qwen')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'

--- a/docs/superpowers/plans/2026-08-09-file-backed-token-usage.md
+++ b/docs/superpowers/plans/2026-08-09-file-backed-token-usage.md
@@ -1,0 +1,493 @@
+# File-Backed Multi-Agent Token Usage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add reliable terminal-session token usage collection for GitHub Copilot, Kimi Code, Pi, and Qwen Code through AO's existing append-only usage pipeline.
+
+**Architecture:** Add provider source kinds and a new SQLite compatibility migration, then extend the existing collector with small provider profiles for roots, artifact attribution, and discovery. Provider parsers normalize native JSONL records into the current `ModelUsageEvent` vector; the existing ingestor, durable cursors, idempotency keys, aggregation service, API, and CDC remain authoritative.
+
+**Tech Stack:** Go 1.x, SQLite/goose, sqlc-generated storage, Electron/React/TypeScript, Go table tests and integration tests.
+
+## Global Constraints
+
+- This plan covers file-backed TUI sources only: Copilot, Kimi, Pi, and Qwen.
+- Grok OTEL is a separate plan because it introduces a loopback protocol receiver.
+- Droid remains unsupported; never ingest `summaryTokens` as model usage.
+- Do not add prices, currencies, cost estimates, billing APIs, or credit tracking.
+- Do not modify migration `0052_model_usage.sql`; add migration `0084_multi_agent_usage.sql`.
+- Preserve the loopback/LAN listener boundary and keep all AO-owned state under `AO_DATA_DIR`.
+- Total tokens remain inclusive input plus inclusive output; never add cache or reasoning subsets twice.
+- Do not hand-edit generated sqlc code.
+
+---
+
+### Task 1: Expand durable usage source contracts
+
+**Files:**
+- Create: `backend/internal/storage/sqlite/migrations/0084_multi_agent_usage.sql`
+- Create: `backend/internal/storage/sqlite/migrate_multi_agent_usage_test.go`
+- Modify: `backend/internal/domain/usage.go`
+- Modify: `backend/internal/service/usage/capabilities.go`
+- Test: `backend/internal/service/usage/summary_test.go`
+
+**Interfaces:**
+- Produces source constants `UsageSourceCopilotShutdown`, `UsageSourceKimiWire`, `UsageSourcePiSession`, and `UsageSourceQwenMonthly`.
+- Produces `MetricCoverage(h domain.AgentHarness) domain.UsageMetricCoverage` and extends `SupportedHarness` only as each complete provider task lands.
+- Preserves all existing columns, foreign keys, unique keys, indexes, and CDC triggers.
+
+- [ ] **Step 1: Write a failing migration test**
+
+Create a fresh store, insert one binding/source for each new harness/kind pair,
+and assert that unknown harness and source-kind strings fail their respective
+CHECK constraints. Provider pairing remains enforced by collector attribution,
+because `usage_sources` references its binding and SQLite CHECK constraints
+cannot query the parent row. The expected valid pairs are:
+
+```go
+tests := []struct {
+    harness domain.AgentHarness
+    kind    domain.UsageSourceKind
+}{
+    {domain.HarnessCopilot, domain.UsageSourceCopilotShutdown},
+    {domain.HarnessKimi, domain.UsageSourceKimiWire},
+    {domain.HarnessPi, domain.UsageSourcePiSession},
+    {domain.HarnessQwen, domain.UsageSourceQwenMonthly},
+}
+```
+
+- [ ] **Step 2: Run the migration test and verify RED**
+
+Run: `cd backend && go test ./internal/storage/sqlite -run TestMultiAgentUsageMigration -count=1`
+
+Expected: compilation failure for missing source constants or SQLite CHECK failure for the new harnesses.
+
+- [ ] **Step 3: Add source constants and migration**
+
+Add these exact values:
+
+```go
+UsageSourceCopilotShutdown UsageSourceKind = "copilot_shutdown"
+UsageSourceKimiWire       UsageSourceKind = "kimi_wire"
+UsageSourcePiSession      UsageSourceKind = "pi_session"
+UsageSourceQwenMonthly    UsageSourceKind = "qwen_monthly"
+```
+
+Migration 0084 must rebuild `usage_bindings`, `usage_sources`, and
+`model_usage_events` in one foreign-key-safe transaction, copy existing rows,
+restore indexes/triggers, and expand only the harness/source CHECK lists. Use
+the table-rebuild shape established in migration 0052.
+
+- [ ] **Step 4: Run storage tests and verify GREEN**
+
+Run: `cd backend && go test ./internal/storage/sqlite -run 'TestMultiAgentUsageMigration|TestMigrations' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Add failing summary coverage tests**
+
+Assert that Qwen cache write and Claude/Kimi/Pi reasoning are nil while native
+zeroes for supported metrics remain pointers to zero. Assert Copilot and Qwen
+reasoning remain available.
+
+- [ ] **Step 6: Implement the harness metric capability matrix**
+
+Add a small domain value:
+
+```go
+type UsageMetricCoverage struct {
+    UncachedInput bool
+    CacheRead     bool
+    CacheWrite    bool
+    Reasoning     bool
+}
+```
+
+Apply coverage in `summary.go` after aggregation; do not add nullable database
+columns. Existing Claude and Codex summary behavior must stay unchanged.
+
+- [ ] **Step 7: Run usage summary tests and commit**
+
+Run: `cd backend && go test ./internal/service/usage ./internal/storage/sqlite -count=1`
+
+Commit: `feat: expand token usage source contracts`
+
+---
+
+### Task 2: Generalize source profiles and hook metadata
+
+**Files:**
+- Create: `backend/internal/service/usage/source_profile.go`
+- Modify: `backend/internal/service/usage/collector.go`
+- Modify: `backend/internal/service/usage/collector_test.go`
+- Modify: `backend/internal/cli/hooks.go`
+- Modify: `backend/internal/cli/hooks_test.go`
+- Modify: `backend/internal/daemon/daemon.go`
+
+**Interfaces:**
+- Produces `sourceKindForHarness(domain.AgentHarness) (domain.UsageSourceKind, bool)`.
+- Extends `SourceRoots` with `CopilotSessions`, `KimiHome`, `PiSessions`, and `QwenUsage`.
+- Keeps Codex-only reconciliation and subagent logic behind explicit harness checks.
+
+- [ ] **Step 1: Write failing profile and root tests**
+
+Assert exact default roots:
+
+```text
+~/.copilot/session-state
+$AO_DATA_DIR/kimi
+$PI_CODING_AGENT_DIR/sessions or ~/.pi/agent/sessions
+~/.qwen/usage
+```
+
+Assert every source path outside its provider root is rejected.
+
+- [ ] **Step 2: Run collector tests and verify RED**
+
+Run: `cd backend && go test ./internal/service/usage -run 'TestDefaultSourceRoots|TestValidateSourcePath' -count=1`
+
+Expected: missing fields/profile behavior.
+
+- [ ] **Step 3: Implement source profiles**
+
+Move repeated Claude/Codex source-kind selection into
+`sourceKindForHarness`. Extend `allowedRoots`, `discoverPath`, hook registration,
+backfill, and reconciliation through this helper while preserving the special
+Claude subagent and Codex child branches.
+
+- [ ] **Step 4: Add failing hook metadata tests**
+
+For Copilot, Kimi, and Qwen session-start payloads, assert `hookUsageMetadata`
+returns bounded harness/native ID/model/path metadata. Pi remains hookless.
+
+- [ ] **Step 5: Generalize hook usage metadata**
+
+Allow certified hook-capable harnesses through `hookUsageMetadata`; reuse
+`hookAgentSessionID` rather than adding provider-specific duplicate ID parsing.
+Do not forward arbitrary payload content.
+
+- [ ] **Step 6: Wire all file roots into the daemon watcher**
+
+Pass the new roots to `NewPipeline`. Empty/nonexistent roots must remain safe;
+the watcher already handles root availability and retries.
+
+- [ ] **Step 7: Run focused tests and commit**
+
+Run: `cd backend && go test ./internal/cli ./internal/service/usage ./internal/observe/usage ./internal/daemon -count=1`
+
+Commit: `refactor: add token usage source profiles`
+
+---
+
+### Task 3: Add GitHub Copilot cumulative usage
+
+**Files:**
+- Create: `backend/internal/observe/usage/copilot_parser_test.go`
+- Modify: `backend/internal/observe/usage/parser.go`
+- Modify: `backend/internal/service/usage/collector_test.go`
+- Modify: `backend/internal/service/usage/capabilities.go`
+
+**Interfaces:**
+- Parser state: `Copilot *copilotParserStateV1` with `Models map[string]copilotTokenVector`.
+- Source artifact: `<CopilotSessions>/<native-id>/events.jsonl`.
+- Source event key includes native root ID, model ID, and the cumulative vector.
+
+- [ ] **Step 1: Write failing parser tests**
+
+Use a sanitized shutdown record:
+
+```json
+{"type":"session.shutdown","data":{"modelMetrics":{"claude-haiku-4.5":{"usage":{"inputTokens":111529,"outputTokens":901,"cacheReadTokens":86021,"cacheWriteTokens":25483,"reasoningTokens":251}}}}}
+```
+
+Assert full first emission, no emission for an identical repeated summary,
+positive deltas for a later summary, independent baselines per model, and
+baseline reset plus anomaly for a regression.
+
+- [ ] **Step 2: Run the parser test and verify RED**
+
+Run: `cd backend && go test ./internal/observe/usage -run TestParseCopilot -count=1`
+
+Expected: unsupported source format.
+
+- [ ] **Step 3: Implement Copilot state and parser**
+
+Normalize:
+
+```text
+input = inputTokens
+uncached = inputTokens - cacheReadTokens - cacheWriteTokens
+cache_read = cacheReadTokens
+cache_write = cacheWriteTokens
+output = outputTokens
+reasoning = reasoningTokens
+```
+
+Reject negative fields and vectors where cache subsets exceed input or
+reasoning exceeds output.
+
+- [ ] **Step 4: Add failing Copilot discovery test**
+
+Create `<root>/<uuid>/events.jsonl`, record a Copilot hook containing the UUID,
+and assert one `copilot_shutdown` source is registered. Also assert a sibling
+UUID cannot be attributed to the binding.
+
+- [ ] **Step 5: Implement discovery/attribution and enable Copilot**
+
+Add the exact path rule and only then include `HarnessCopilot` in
+`SupportedHarness`.
+
+- [ ] **Step 6: Run provider and integration tests and commit**
+
+Run: `cd backend && go test ./internal/observe/usage ./internal/service/usage ./internal/storage/sqlite -count=1`
+
+Commit: `feat: collect Copilot token usage`
+
+---
+
+### Task 4: Add Kimi root and subagent usage
+
+**Files:**
+- Create: `backend/internal/observe/usage/kimi_parser_test.go`
+- Modify: `backend/internal/observe/usage/parser.go`
+- Modify: `backend/internal/service/usage/collector.go`
+- Modify: `backend/internal/service/usage/collector_test.go`
+- Modify: `backend/internal/service/usage/capabilities.go`
+
+**Interfaces:**
+- Kimi index: `<KimiHome>/session_index.jsonl` records containing `sessionId`, `sessionDir`, and `workDir`.
+- Kimi sources: `<sessionDir>/agents/*/wire.jsonl`.
+- Parser state uses the append-only source cursor; no token baseline is required.
+
+- [ ] **Step 1: Write failing Kimi parser tests**
+
+Use this sanitized native record:
+
+```json
+{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":13,"inputCacheRead":21,"inputCacheCreation":8,"output":5},"usageScope":"turn"}
+```
+
+Assert inclusive input 42, uncached 13, read 21, write 8, output 5, reasoning
+nil, replay-stable event keys, and rejection of negative fields.
+
+- [ ] **Step 2: Run the parser test and verify RED**
+
+Run: `cd backend && go test ./internal/observe/usage -run TestParseKimi -count=1`
+
+Expected: unsupported source format.
+
+- [ ] **Step 3: Implement Kimi parsing**
+
+Add an append-only parser payload to the state envelope and normalize each
+`usage.record`. Ignore unrelated wire records.
+
+- [ ] **Step 4: Write failing Kimi discovery tests**
+
+Build a session index with a valid entry under `<KimiHome>/sessions`, create
+`agents/main/wire.jsonl` and `agents/agent-1/wire.jsonl`, and assert both become
+sources with distinct `SubagentID` values. Assert deleted index entries and
+session directories escaping the sessions root are rejected.
+
+- [ ] **Step 5: Implement Kimi index replay and source registration**
+
+Replay the append-only index so the last record for a session wins. Validate
+that `sessionDir` is absolute, below `<KimiHome>/sessions`, and has the native
+session ID as its basename. Register every regular `agents/*/wire.jsonl` file.
+
+- [ ] **Step 6: Enable Kimi, run tests, and commit**
+
+Run: `cd backend && go test ./internal/observe/usage ./internal/service/usage -count=1`
+
+Commit: `feat: collect Kimi token usage`
+
+---
+
+### Task 5: Add Pi worktree-correlated usage
+
+**Files:**
+- Create: `backend/internal/observe/usage/pi_parser_test.go`
+- Modify: `backend/internal/observe/usage/parser.go`
+- Modify: `backend/internal/service/usage/collector.go`
+- Modify: `backend/internal/service/usage/collector_test.go`
+- Modify: `backend/internal/service/usage/capabilities.go`
+
+**Interfaces:**
+- Pi header shape: `{"type":"session","id":"<uuid>","cwd":"<absolute-worktree>",...}`.
+- Pi message shape: `{"type":"message","id":"<id>","message":{"role":"assistant","provider":"...","model":"...","usage":{...}}}`.
+- `ReconcilePath` may establish a Pi binding by matching the canonical header cwd to one live AO Pi session workspace.
+
+- [ ] **Step 1: Write failing Pi parser tests**
+
+Use a session header plus assistant record with `input`, `cacheRead`,
+`cacheWrite`, `output`, and nested `cost`. Assert cost is ignored and tokens are
+normalized as inclusive input `input + cacheRead + cacheWrite`. Ignore user and
+tool-result messages.
+
+- [ ] **Step 2: Run the parser test and verify RED**
+
+Run: `cd backend && go test ./internal/observe/usage -run TestParsePi -count=1`
+
+Expected: unsupported source format.
+
+- [ ] **Step 3: Implement Pi parsing**
+
+Use message ID for the stable key, falling back to offset only when absent.
+Use `provider/model` only as the exact model ID when the provider prefix is
+needed to avoid ambiguity.
+
+- [ ] **Step 4: Write failing Pi attribution tests**
+
+Create two live Pi AO sessions with different worktrees and one Pi artifact.
+Assert only the matching canonical cwd receives a binding/source. Assert an
+ambiguous duplicate-worktree match and a non-Pi session are ignored.
+
+- [ ] **Step 5: Implement Pi path reconciliation**
+
+Extend `ReconcilePath` to validate Pi files, read only the bounded first JSONL
+record, match cwd to a live Pi session, and create/register the native binding.
+Do not import terminated historical sessions.
+
+- [ ] **Step 6: Enable Pi, run tests, and commit**
+
+Run: `cd backend && go test ./internal/observe/usage ./internal/service/usage -count=1`
+
+Commit: `feat: collect Pi token usage`
+
+---
+
+### Task 6: Add Qwen shared monthly usage
+
+**Files:**
+- Create: `backend/internal/observe/usage/qwen_parser_test.go`
+- Modify: `backend/internal/observe/usage/parser.go`
+- Modify: `backend/internal/service/usage/collector.go`
+- Modify: `backend/internal/service/usage/collector_test.go`
+- Modify: `backend/internal/service/usage/capabilities.go`
+
+**Interfaces:**
+- Qwen source: `<QwenUsage>/token-usage-YYYY-MM.jsonl`.
+- Parser filters every record by `sessionId == source.NativeRootID`.
+- Source event key uses the native record `id` and session ID.
+
+- [ ] **Step 1: Write failing Qwen parser tests**
+
+Use records for two session IDs and sources `main` and
+`managed-auto-memory-extractor`. Assert only the bound session is counted, all
+of its source categories are included, input is inclusive, cached is a subset,
+and thoughts is a subset of output.
+
+- [ ] **Step 2: Run the parser test and verify RED**
+
+Run: `cd backend && go test ./internal/observe/usage -run TestParseQwen -count=1`
+
+Expected: unsupported source format.
+
+- [ ] **Step 3: Implement Qwen parsing**
+
+Require `schemaVersion == 1`, a non-empty ID/model/session ID, non-negative
+values, `cachedTokens <= inputTokens`, `thoughtsTokens <= outputTokens`, and
+`totalTokens == inputTokens + outputTokens` when total is present.
+
+- [ ] **Step 4: Write failing monthly discovery tests**
+
+Create two monthly files and a hook-captured Qwen session ID. Assert the latest
+file is registered initially and a later reconciliation registers the next
+month without retiring or replaying the prior generation.
+
+- [ ] **Step 5: Implement Qwen discovery and enable Qwen**
+
+Discover bounded `token-usage-*.jsonl` candidates sorted by month/name and
+mtime. Shared-log attribution is enforced by the parser rather than filename.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run: `cd backend && go test ./internal/observe/usage ./internal/service/usage -count=1`
+
+Commit: `feat: collect Qwen token usage`
+
+---
+
+### Task 7: Verify API and frontend token presentation
+
+**Files:**
+- Modify: `backend/internal/httpd/controllers/usage_test.go` if existing response fixtures require new harness rows
+- Modify: `frontend/src/renderer/components/SessionInspector.tsx`
+- Modify: `frontend/src/renderer/components/SessionInspector.test.tsx`
+- Modify: `frontend/src/renderer/hooks/useSessionUsage.ts` only if the Developer Mode gate lives there
+
+**Interfaces:**
+- Existing `GET /api/v1/sessions/{sessionId}/usage` wire shape remains unchanged.
+- Detailed metrics use nullable values to render unavailable source metrics as an em dash.
+- Droid receives no fabricated event or total.
+
+- [ ] **Step 1: Add failing HTTP/API aggregation tests**
+
+Insert events for each new harness and assert exact harness/model rows and
+canonical totals. Assert no schema change is needed.
+
+- [ ] **Step 2: Run controller tests and verify RED**
+
+Run: `cd backend && go test ./internal/httpd/controllers -run Usage -count=1`
+
+- [ ] **Step 3: Make only compatibility fixes required by the tests**
+
+Do not regenerate OpenAPI unless a response DTO actually changes. If it does,
+edit the controller source and spec generator, run `npm run api`, and commit
+both generated artifacts together.
+
+- [ ] **Step 4: Add failing frontend tests**
+
+Assert new harness labels/models render through the existing usage component,
+unavailable cache-write/reasoning metrics render `—`, and the cost placeholder
+remains unpopulated. Assert Droid has no fake zero-token row.
+
+- [ ] **Step 5: Expose certified token usage**
+
+Remove the Developer Mode fetch/display gate only if the backend integration
+tests for all four providers are green. Keep the existing loading/error and
+incomplete-data behavior.
+
+- [ ] **Step 6: Run frontend tests and commit**
+
+Run: `cd frontend && npm test -- SessionInspector.test.tsx`
+
+Run: `cd frontend && npm run typecheck`
+
+Commit: `feat: expose multi-agent token usage`
+
+---
+
+### Task 8: Final integration verification
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-09-file-backed-token-usage.md` only to check completed boxes
+
+**Interfaces:**
+- Produces a clean, reviewable branch with no generated drift or local artifacts.
+
+- [ ] **Step 1: Run focused backend verification**
+
+Run: `cd backend && go test ./internal/observe/usage ./internal/service/usage ./internal/storage/sqlite ./internal/httpd/controllers -count=1`
+
+- [ ] **Step 2: Run broader backend verification**
+
+Run: `cd backend && go test ./...`
+
+- [ ] **Step 3: Run repository checks**
+
+Run: `npm run frontend:typecheck`
+
+Run: `npm run lint`
+
+- [ ] **Step 4: Check generated and workspace state**
+
+Run: `git diff --check`
+
+Run: `git status --short`
+
+Expected: only intentional tracked changes; no local data, generated drift,
+credentials, or build output.
+
+- [ ] **Step 5: Commit final test/doc adjustments**
+
+Commit only if verification required an intentional tracked change:
+`test: verify multi-agent token usage`

--- a/docs/superpowers/specs/2026-08-09-token-usage-observability-design.md
+++ b/docs/superpowers/specs/2026-08-09-token-usage-observability-design.md
@@ -1,0 +1,311 @@
+# Multi-Agent Token Usage Observability Design
+
+## Goal
+
+Extend AO's existing append-only token usage pipeline from Claude Code and
+Codex to GitHub Copilot, Grok, Kimi Code, Pi, and Qwen Code without adding
+monetary cost calculation. Droid remains explicitly unsupported until its TUI
+exposes reliable session-level token events.
+
+## Scope
+
+This work covers terminal-UI sessions supervised by AO. Existing Chat-mode
+conversation usage remains independent and unchanged.
+
+The user-facing token vocabulary remains:
+
+- inclusive input tokens;
+- uncached input tokens;
+- cache-read tokens;
+- cache-write tokens;
+- inclusive output tokens; and
+- reasoning tokens when the native source reports them separately.
+
+Missing native metrics remain distinguishable from a reported zero wherever
+the aggregate API already supports availability metadata. Total tokens remain
+`input_tokens + output_tokens`; cache and reasoning subsets are never added a
+second time.
+
+Monetary prices, billing APIs, currencies, credit balances, and cost estimates
+are out of scope. The existing frontend cost placeholder and the optional
+Chat-provider cost field are not connected to this work.
+
+## Approaches Considered
+
+### 1. Provider adapters feeding the existing pipeline (selected)
+
+Each certified native artifact gets a source kind, parser, discovery strategy,
+and parser state. All adapters emit the existing `ModelUsageEvent` token vector
+into the current durable cursor, idempotency, aggregation, and integrity
+machinery.
+
+This preserves the rewrite architecture and keeps provider-specific semantics
+at the ingestion boundary. It also permits cumulative sources such as Copilot
+and append-only per-turn sources such as Kimi to share storage safely.
+
+### 2. One generic configurable JSON parser
+
+A data-driven field mapping could reduce parser code, but it cannot naturally
+express cumulative baselines, duplicate shutdown summaries, nested subagent
+files, monthly shared logs, or Grok's OTEL transport. It would move complexity
+into an implicit configuration language and make source-format validation less
+clear.
+
+### 3. Independent collector and storage path per provider
+
+Separate pipelines would isolate providers but duplicate cursor handling,
+rotation detection, retry behavior, event idempotency, integrity state, API
+aggregation, and frontend invalidation. This conflicts with AO's existing
+usage boundary and would be harder to keep consistent.
+
+## Architecture
+
+The existing usage pipeline stays authoritative:
+
+1. AO binds an AO session to a native agent session identifier.
+2. A provider adapter registers one or more validated source artifacts.
+3. The watcher schedules changed sources.
+4. The ingestor reads bounded chunks from durable byte offsets.
+5. A provider parser normalizes native records into append-only
+   `ModelUsageEvent` values.
+6. SQLite deduplicates events by stable source event key.
+7. Existing service summaries and API responses aggregate the canonical token
+   vector by harness and model.
+
+Provider differences are represented explicitly rather than inferred in a
+generic parser. File-based sources use the existing watcher. Grok uses a small
+opt-in OTLP receiver that binds only to `127.0.0.1`; it feeds the same
+normalization/storage boundary and is never attached to the mobile LAN router.
+The receiver writes validated, content-free API-usage envelopes to an AO-owned
+per-session JSONL spool under `AO_DATA_DIR`; the normal watcher, durable cursor,
+and parser then ingest that spool instead of creating a second write path.
+
+The database receives a new migration that rebuilds the usage tables with the
+additional harness and source-kind checks. Already-merged migration 0052 is not
+modified. Generated sqlc code is regenerated only if source queries change.
+
+## Provider Sources and Normalization
+
+### Claude Code
+
+No source-discovery change. Preserve the current completed-message and
+subagent behavior:
+
+```text
+input = input_tokens + cache_read_input_tokens + cache_creation_input_tokens
+uncached = input_tokens
+cache_read = cache_read_input_tokens
+cache_write = cache_creation_input_tokens
+output = output_tokens
+reasoning = unavailable
+```
+
+The cache-write TTL split is not required for token-only observability.
+
+### Codex
+
+No source-discovery change. Preserve cumulative-counter delta processing:
+
+```text
+input = delta(input_tokens)
+uncached = input - cache_read - cache_write
+cache_read = delta(cached_input_tokens)
+cache_write = delta(cache_write_input_tokens)
+output = delta(output_tokens)
+reasoning = delta(reasoning_output_tokens)
+```
+
+### GitHub Copilot
+
+Use the hook-captured native UUID to register
+`~/.copilot/session-state/<uuid>/events.jsonl`. Parse cumulative per-model
+`session.shutdown.data.modelMetrics` summaries. Maintain the last vector per
+model in parser state so repeated shutdown records produce no duplicate usage
+and increased summaries emit only their delta.
+
+```text
+input = usage.inputTokens
+uncached = input - cacheReadTokens - cacheWriteTokens
+cache_read = usage.cacheReadTokens
+cache_write = usage.cacheWriteTokens
+output = usage.outputTokens
+reasoning = usage.reasoningTokens
+```
+
+Invalid non-monotonic per-model counters reset that model's baseline, increment
+the source anomaly count, and emit no negative delta.
+
+### Kimi Code
+
+Use Kimi's AO-managed home and hook-captured native session ID to discover the
+session directory. Register every `agents/*/wire.jsonl` source so root and
+subagent usage are included. Parse append-only `usage.record` values.
+
+```text
+input = inputOther + inputCacheRead + inputCacheCreation
+uncached = inputOther
+cache_read = inputCacheRead
+cache_write = inputCacheCreation
+output = output
+reasoning = unavailable
+```
+
+The agent directory identity participates in the stable event key.
+
+### Pi
+
+Pi has no native lifecycle hook suitable for source binding. Discover session
+JSONL files from Pi's session directory by matching the durable session header
+`cwd` to AO's unique registered worktree, then bind the header session ID.
+Parse assistant-message usage values.
+
+```text
+input = input + cacheRead + cacheWrite
+uncached = input
+cache_read = cacheRead
+cache_write = cacheWrite
+output = output
+reasoning = unavailable
+```
+
+Any native monetary fields are ignored.
+
+### Qwen Code
+
+Use the hook-captured `session_id` and register the active monthly
+`~/.qwen/usage/token-usage-YYYY-MM.jsonl` file. Because that file contains
+multiple sessions, the parser accepts only records matching the binding's
+native session ID. The collector registers a new monthly file when the session
+crosses a month boundary.
+
+```text
+input = inputTokens
+uncached = inputTokens - cachedTokens
+cache_read = cachedTokens
+cache_write = unavailable
+output = outputTokens
+reasoning = thoughtsTokens
+```
+
+All records for the session are counted, including managed helper sources,
+because they consume model tokens on behalf of that session.
+
+### Grok
+
+Enable only for AO-launched Grok sessions after explicit user opt-in. AO sets
+Grok's external telemetry variables to an AO-owned loopback OTLP endpoint and
+does not request prompt or tool content. Parse `grok_code.api_request` events
+and correlate their `session.id` to the hook-captured native session ID.
+
+```text
+input = input_tokens
+uncached = input_tokens - cache_read_tokens
+cache_read = cache_read_tokens
+cache_write = unavailable
+output = output_tokens
+reasoning = reasoning_tokens
+```
+
+The receiver rejects non-loopback traffic, unknown schema versions, records
+without a matching active AO binding, and oversized payloads.
+
+### Droid
+
+Droid's current TUI transcript summary count is not ingested. It is a context
+summary size rather than reliable cumulative request usage. AO reports usage
+as unavailable for Droid. A later design may consume documented Droid Exec or
+verified OTEL token events once they can be correlated to the same native TUI
+session.
+
+## Source Discovery and Hook Metadata
+
+The hook command currently forwards usage-specific metadata only for Claude
+Code and Codex. It will be generalized to accept bounded native session IDs,
+model IDs, and transcript paths for every certified hook-capable harness while
+retaining per-provider validation.
+
+Provider-owned source roots are added to `SourceRoots`. Every registered file
+must remain under its declared provider root, be a regular file, and pass the
+existing identity and replacement checks. Shared files, such as Qwen's monthly
+log, still get one logical source per AO binding; parser filtering prevents
+cross-session attribution.
+
+## Storage and Compatibility
+
+A new migration rebuilds `usage_bindings` and `usage_sources` to admit:
+
+- harnesses `copilot`, `grok`, `kimi`, `pi`, and `qwen` using their existing
+  canonical `AgentHarness` strings; and
+- source kinds for Copilot shutdown summaries, Grok OTEL API requests, Kimi
+  wire logs, Pi sessions, and Qwen monthly usage logs.
+
+The `model_usage_events` token columns and API DTOs remain unchanged. When a
+source does not expose a metric, a harness/source capability matrix makes the
+corresponding aggregate API pointer nil rather than presenting an unavailable
+metric as a reported zero. Native zeroes remain zero. The event table continues
+to use zero for unavailable non-null token columns internally; availability is
+derived at service read time from the certified source semantics. Reasoning
+continues to use its existing nullable event column.
+
+Existing Claude and Codex bindings, cursors, events, and aggregate results must
+survive the migration unchanged.
+
+## Error Handling and Integrity
+
+- Malformed or negative usage records increment the existing anomaly count and
+  do not emit an event.
+- Cumulative counter regressions establish a new baseline without emitting a
+  negative delta.
+- A shared-log record for another session is ignored, not treated as malformed.
+- Duplicate native event identifiers or repeated cumulative summaries are
+  idempotent.
+- Missing or rotated files use the existing retry and source-generation paths.
+- Unsupported source formats retain the existing safe error code and mark the
+  session aggregate incomplete.
+- A provider is added to `SupportedHarness` only when binding, discovery,
+  parsing, replay, and aggregation tests pass.
+
+## Frontend Behavior
+
+The existing token summary and detailed metric components remain the rendering
+surface. Once a harness is certified, its session/model rows appear through the
+same API response as Claude and Codex.
+
+The token usage section may be made generally visible once all backend sources
+in this branch are certified. Unsupported Droid sessions show an explicit
+usage-unavailable state rather than a fabricated zero. The cost placeholder is
+not implemented or populated by this work.
+
+## Testing Strategy
+
+Every provider is developed test-first with sanitized golden records matching
+the inspected native format. Tests cover:
+
+- canonical field normalization;
+- missing optional fields and zero values;
+- malformed and negative values;
+- stable event-key replay;
+- cumulative duplicate and reset behavior where applicable;
+- session filtering for shared logs;
+- subagent attribution where applicable;
+- source discovery and provider-root path rejection;
+- finalization and restart from durable cursors;
+- SQLite migration preservation and new CHECK constraints;
+- aggregate API compatibility; and
+- frontend rendering for supported and unavailable harnesses.
+
+Focused package tests run after each red-green cycle. Final verification uses
+the backend usage, storage, and HTTP tests plus frontend typecheck and relevant
+component tests.
+
+## Delivery
+
+Work remains on `feat/token-usage-observability`. Commits are kept reviewable:
+schema/framework first, then one provider per commit, Grok transport separately,
+and frontend exposure last. No release, publish, or pull request is part of this
+implementation unless separately requested.
+
+Because Grok introduces a loopback protocol receiver while the other additions
+are file adapters, implementation is split into two independently reviewable
+plans on the same branch: file-backed providers first, then Grok OTEL. Each plan
+must leave AO in a working, testable state.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2364,7 +2364,6 @@ export interface components {
             project: components["schemas"]["Project"];
         };
         ProjectSummary: {
-            config?: components["schemas"]["ProjectConfig"];
             id: string;
             /** @enum {string} */
             kind: "single_repo" | "workspace" | "scratch";

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2364,6 +2364,7 @@ export interface components {
             project: components["schemas"]["Project"];
         };
         ProjectSummary: {
+            config?: components["schemas"]["ProjectConfig"];
             id: string;
             /** @enum {string} */
             kind: "single_repo" | "workspace" | "scratch";

--- a/skills/agent-role-smoke/SKILL.md
+++ b/skills/agent-role-smoke/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: agent-role-smoke
+description: Run AO agent role smoke tests for orchestrator and worker behavior across installed or selected agent harnesses. Use when validating that Agent Orchestrator can launch agents as orchestrators/workers, that role-specific system prompts are being generated and delivered, and that agents respond correctly to simple UI-edit tasks.
+---
+
+# Agent Role Smoke
+
+Use this skill to validate AO agent harnesses in both roles:
+
+- **orchestrator**: launches with orchestrator standing instructions and delegates implementation to a worker.
+- **worker**: launches with worker standing instructions and performs the assigned edit in its own workspace.
+
+Do not ask agents to print or reveal their exact system prompt. AO deliberately includes a standing-instruction confidentiality guard. Verify prompt delivery through role behavior and AO-generated prompt artifacts instead.
+
+## Quick Start
+
+Start the AO dev app first:
+
+```bash
+cd frontend
+npm run dev
+```
+
+This starts both the daemon and Electron supervisor. Once the app is running, start testing the selected orchestrator or worker behavior directly. Do not run API generation, lint, typecheck, or broad checks by default; assume those are fine unless the user explicitly asks for them or the dev app/manual test exposes a problem.
+
+From the repo root, in another terminal:
+
+```bash
+node skills/agent-role-smoke/scripts/agent-role-smoke.mjs
+```
+
+Common focused runs:
+
+```bash
+node skills/agent-role-smoke/scripts/agent-role-smoke.mjs --agent codex --role worker
+node skills/agent-role-smoke/scripts/agent-role-smoke.mjs --agent codex --role orchestrator
+node skills/agent-role-smoke/scripts/agent-role-smoke.mjs --agents codex,claude-code --role both
+node skills/agent-role-smoke/scripts/agent-role-smoke.mjs --all-supported
+```
+
+By default the script tests installed/authorized harnesses from `ao agent ls --refresh --json`. Pass `--all-supported` only when you intentionally want missing binaries or unauthenticated harnesses recorded as failures.
+
+The script configures the disposable test project with `permissions: "bypass-permissions"` by default for both worker and orchestrator roles. This keeps role smoke tests from stalling on native prompts such as "trust this folder" or command approval dialogs. Use `--manual-permissions --keep` when you intentionally want to inspect and answer native permission prompts in the AO session terminal.
+
+During worker and orchestrator live-behavior waits, the script watches the session's tmux pane. If pane output does not change for 7 seconds, it sends one `Enter` to the attached tmux pane and then waits for another 7 seconds of unchanged output before sending another. This is a generic fallback for permission, confirmation, or continue prompts that do not match the visible prompt heuristics.
+
+Before sending an orchestrator task, the script verifies the orchestrator tmux pane exists, has produced output, and is not sitting on a visible blocking prompt. If a startup or delegation poll shows a permission/approval prompt, the script sends one best-effort `Enter` to the orchestrator pane before continuing. For Cursor runs, it also pre-trusts the predictable orchestrator workspace under `~/.cursor/projects` and answers the Cursor workspace-trust screen with `a` if it still appears.
+
+The orchestrator task includes a unique `AO_ROLE_SMOKE_TASK ...` marker. After `ao send`, the script captures the orchestrator pane and confirms either the marker appears or a new collapsed pasted-text block appears in CLIs that hide pasted content. If neither delivery signal appears, it checks for a visible blocking prompt, sends one `Enter` if needed, and retries the message send before testing whether the orchestrator actually delegates to a worker.
+
+Before creating a new test project, the script removes stale `role-smoke-*` projects and sessions. This prevents an old smoke-test orchestrator, especially one running a different harness, from being reused or confusing a new run. Pass `--no-preflight-clean` only when investigating a preserved smoke fixture.
+
+## Preconditions
+
+1. Start the AO dev app from `frontend/` with `npm run dev`.
+2. Wait for the daemon and Electron supervisor to be running.
+3. Begin testing the given orchestrator. Do not add separate preflight checks unless something fails or the user asks for deeper validation.
+
+## What the Script Does
+
+- Creates a disposable git fixture with a small UI file.
+- Registers the fixture as an AO project.
+- For each selected harness:
+  - configures the project role override for worker and/or orchestrator, including test-friendly permission bypass unless `--manual-permissions` is set.
+  - preflights old `role-smoke-*` sessions and removes stale test orchestrators before starting the new orchestrator.
+  - spawns a worker with `ao spawn --harness` for worker tests.
+  - spawns an orchestrator through `POST /api/v1/orchestrators` for orchestrator tests.
+  - verifies the orchestrator is usable, sends a concrete UI-edit task, and confirms the task marker reached the orchestrator pane.
+  - checks generated prompt files under the AO data dir.
+  - checks session role/harness metadata and fixture worktree diffs.
+
+## Pass Criteria
+
+- **Worker pass**: session launches with the requested harness, AO generated a non-empty system prompt artifact, and the worker changes the fixture's `src/App.jsx` so the New Task button is green or the notification icon is red.
+- **Orchestrator pass**: session launches with the requested harness, AO generated a non-empty orchestrator prompt artifact, and the orchestrator creates or redirects a worker instead of editing its own workspace.
+- **Skip**: harness is not installed or is explicitly unauthorized in the AO agent catalog.
+
+The orchestrator task prompt pins the exact `--ao-bin` value and project id. This prevents the orchestrator from trying `ao start`, opening Electron, or delegating through a different AO binary than the smoke harness is using.
+
+If a live harness cannot make model calls because auth/quota/model setup is incomplete, treat that as an environment failure for the harness, not proof that AO role prompting is broken.
+
+## Useful Flags
+
+```bash
+--agent <id>              Test one harness.
+--agents <a,b,c>          Test a comma-separated harness list.
+--role worker|orchestrator|both
+--all-supported           Try every AO-supported harness.
+--ao-bin <path>           Use a specific ao binary instead of PATH.
+--timeout-ms <ms>         Poll timeout for live behavior checks.
+--permission-mode <mode>  Permission mode for test sessions; defaults to bypass-permissions.
+--manual-permissions      Do not set AO permissions; answer native prompts manually.
+--no-preflight-clean      Keep old role-smoke-* projects/sessions before this run.
+--stop-ao-after           Run `ao stop` after the smoke test finishes.
+--stop-electron-after     Best-effort stop of local AO/Electron desktop processes after the test.
+--keep                    Keep sessions, project registration, and fixture dir.
+--verbose                 Print command/API details while running.
+```
+
+Use `--keep` when investigating a failure so the AO sessions and fixture worktrees remain available for inspection.

--- a/skills/agent-role-smoke/scripts/agent-role-smoke.mjs
+++ b/skills/agent-role-smoke/scripts/agent-role-smoke.mjs
@@ -1,0 +1,861 @@
+#!/usr/bin/env node
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { homedir, platform, tmpdir } from "node:os";
+import path from "node:path";
+
+const DEFAULT_TIMEOUT_MS = 180_000;
+const POLL_MS = 5_000;
+const ROLE_BOTH = "both";
+const DEFAULT_ORCHESTRATOR_SEND_DELAY_MS = 8_000;
+const DEFAULT_PERMISSION_MODE = "bypass-permissions";
+const CURSOR_TRUST_READY_TIMEOUT_MS = 60_000;
+const ORCHESTRATOR_READY_TIMEOUT_MS = 60_000;
+const ORCHESTRATOR_DELIVERY_TIMEOUT_MS = 60_000;
+const IDLE_ENTER_MS = 7_000;
+const IDLE_POLL_MS = 1_000;
+const PERMISSION_MODES = new Set(["default", "accept-edits", "auto", "bypass-permissions"]);
+
+main().catch((err) => {
+  console.error(`agent-role-smoke: ${err.message}`);
+  if (err.cause?.stdout || err.cause?.stderr) {
+    if (err.cause.stdout) console.error(err.cause.stdout);
+    if (err.cause.stderr) console.error(err.cause.stderr);
+  }
+  process.exitCode = 1;
+});
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    return;
+  }
+
+  try {
+    const status = runAOJSON(opts, ["status", "--json"]);
+    if (status.state !== "ready") {
+      throw new Error(`AO daemon is ${status.state}; start AO before running this smoke test`);
+    }
+    if (!status.port) {
+      throw new Error("AO status did not report a daemon port");
+    }
+
+    const harnesses = discoverHarnesses(opts);
+    if (harnesses.length === 0) {
+      throw new Error("No harnesses selected. Use --agent, --agents, or check `ao agent ls --refresh --json`.");
+    }
+    if (opts.preflightClean) {
+      cleanupStaleSmokeState(opts, harnesses);
+    }
+
+    const fixture = createFixture();
+    const projectID = `role-smoke-${Date.now().toString(36)}`;
+    const createdSessions = new Set();
+    const results = [];
+
+    try {
+      runAO(opts, ["project", "add", "--path", fixture.root, "--id", projectID, "--name", "AO Role Smoke"]);
+
+      for (const harness of harnesses) {
+        if (opts.role === "worker" || opts.role === ROLE_BOTH) {
+          results.push(await runWorkerSmoke(opts, status, fixture, projectID, harness, createdSessions));
+        }
+        if (opts.role === "orchestrator" || opts.role === ROLE_BOTH) {
+          results.push(await runOrchestratorSmoke(opts, status, fixture, projectID, harness, createdSessions));
+        }
+      }
+    } finally {
+      if (!opts.keep) {
+        for (const id of [...createdSessions].reverse()) {
+          try {
+            runAO(opts, ["session", "kill", id]);
+          } catch {
+            // Best-effort cleanup. The summary already records test failures.
+          }
+        }
+        try {
+          runAO(opts, ["project", "rm", projectID, "--yes"]);
+        } catch {
+          // Project cleanup is best-effort because active worktrees can block removal.
+        }
+        try {
+          rmSync(fixture.root, { recursive: true, force: true });
+        } catch {
+          // Temp fixture cleanup is best-effort.
+        }
+      }
+    }
+
+    printSummary(results, opts.keep ? fixture.root : "");
+    if (results.some((r) => r.status === "fail")) {
+      process.exitCode = 1;
+    }
+  } finally {
+    teardownAO(opts);
+  }
+}
+
+async function runWorkerSmoke(opts, status, fixture, projectID, harness, createdSessions) {
+  const result = { harness, role: "worker", status: "fail", detail: "" };
+  try {
+    setProjectConfig(opts, projectID, {
+      agentRules: "AO role smoke worker rule: complete only the assigned fixture edit and report the changed file.",
+      agentConfig: permissionAgentConfig(opts),
+      worker: { agent: harness, agentConfig: permissionAgentConfig(opts) },
+    });
+
+    const spawnText = runAO(opts, [
+      "spawn",
+      "--project",
+      projectID,
+      "--harness",
+      harness,
+      "--name",
+      shortName(`worker-${harness}`),
+      "--prompt",
+      workerTaskPrompt(),
+      "--skip-agent-check",
+    ]);
+    const sessionID = parseSpawnedSessionID(spawnText);
+    createdSessions.add(sessionID);
+
+    await waitForSession(opts, projectID, sessionID, DEFAULT_TIMEOUT_MS);
+    const session = await getSession(status.port, sessionID, opts);
+    assertSession(session, harness, "worker");
+    assertSystemPrompt(status.dataDir, sessionID, "AO Worker Role");
+
+    const workspace = await waitForWorkspace(fixture.root, session.branch, opts.timeoutMs);
+    const changed = await waitForFixtureChange(workspace, opts.timeoutMs, opts, sessionID);
+    if (!changed) {
+      throw new Error(`worker ${sessionID} did not produce the expected fixture edit before timeout`);
+    }
+
+    result.status = "pass";
+    result.detail = `${sessionID} changed fixture in ${workspace}`;
+  } catch (err) {
+    result.detail = err.message;
+  }
+  return result;
+}
+
+async function runOrchestratorSmoke(opts, status, fixture, projectID, harness, createdSessions) {
+  const result = { harness, role: "orchestrator", status: "fail", detail: "" };
+  try {
+    setProjectConfig(opts, projectID, {
+      orchestratorRules: "AO role smoke orchestrator rule: delegate implementation to a worker; do not edit files in the orchestrator workspace.",
+      agentConfig: permissionAgentConfig(opts),
+      worker: { agent: harness, agentConfig: permissionAgentConfig(opts) },
+      orchestrator: { agent: harness, agentConfig: permissionAgentConfig(opts) },
+    });
+
+    const before = listSessions(opts, projectID, true).map((s) => s.id);
+    if (harness === "cursor") {
+      pretrustCursorWorkspace(opts, predictedOrchestratorWorkspace(status.dataDir, projectID));
+    }
+    const body = await apiJSON(status.port, "POST", "/orchestrators", { projectId: projectID, clean: true }, opts);
+    const sessionID = body.orchestrator?.id;
+    if (!sessionID) {
+      throw new Error("orchestrator spawn response did not include orchestrator.id");
+    }
+    createdSessions.add(sessionID);
+
+    await waitForSession(opts, projectID, sessionID, DEFAULT_TIMEOUT_MS);
+    const session = await getSession(status.port, sessionID, opts);
+    assertSession(session, harness, "orchestrator");
+    assertSystemPrompt(status.dataDir, sessionID, "AO Orchestrator Role");
+
+    if (opts.orchestratorSendDelayMs > 0) {
+      await sleep(opts.orchestratorSendDelayMs);
+    }
+    await preparePostStartSend(opts, harness, sessionID);
+    const taskPrompt = orchestratorTaskPrompt(opts, projectID, harness);
+    await sendTaskToOrchestrator(opts, sessionID, taskPrompt, orchestratorTaskMarker(projectID, harness));
+
+    const afterWorker = await waitForNewWorker(opts, projectID, before, opts.timeoutMs, sessionID);
+    createdSessions.add(afterWorker.id);
+
+    const orchestratorWorkspace = await waitForWorkspace(fixture.root, session.branch, opts.timeoutMs);
+    const orchestratorDiff = gitOutput(["-C", orchestratorWorkspace, "status", "--porcelain"]);
+    if (orchestratorDiff.trim() !== "") {
+      throw new Error(`orchestrator ${sessionID} modified its own workspace:\n${orchestratorDiff}`);
+    }
+
+    result.status = "pass";
+    result.detail = `${sessionID} delegated to worker ${afterWorker.id}`;
+  } catch (err) {
+    result.detail = err.message;
+  }
+  return result;
+}
+
+function parseArgs(args) {
+  const opts = {
+    aoBin: process.env.AO_BIN || "ao",
+    agent: "",
+    agents: "",
+    allSupported: false,
+    role: ROLE_BOTH,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    orchestratorSendDelayMs: DEFAULT_ORCHESTRATOR_SEND_DELAY_MS,
+    permissionMode: DEFAULT_PERMISSION_MODE,
+    manualPermissions: false,
+    preflightClean: true,
+    stopAOAfter: false,
+    stopElectronAfter: false,
+    keep: false,
+    verbose: false,
+    help: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        opts.help = true;
+        break;
+      case "--ao-bin":
+        opts.aoBin = requireValue(args, ++i, arg);
+        break;
+      case "--agent":
+        opts.agent = requireValue(args, ++i, arg);
+        break;
+      case "--agents":
+        opts.agents = requireValue(args, ++i, arg);
+        break;
+      case "--role":
+        opts.role = requireValue(args, ++i, arg);
+        if (!["worker", "orchestrator", ROLE_BOTH].includes(opts.role)) {
+          throw new Error("--role must be worker, orchestrator, or both");
+        }
+        break;
+      case "--timeout-ms":
+        opts.timeoutMs = Number(requireValue(args, ++i, arg));
+        if (!Number.isFinite(opts.timeoutMs) || opts.timeoutMs <= 0) {
+          throw new Error("--timeout-ms must be a positive number");
+        }
+        break;
+      case "--orchestrator-send-delay-ms":
+        opts.orchestratorSendDelayMs = Number(requireValue(args, ++i, arg));
+        if (!Number.isFinite(opts.orchestratorSendDelayMs) || opts.orchestratorSendDelayMs < 0) {
+          throw new Error("--orchestrator-send-delay-ms must be zero or a positive number");
+        }
+        break;
+      case "--permission-mode":
+        opts.permissionMode = requireValue(args, ++i, arg);
+        if (!PERMISSION_MODES.has(opts.permissionMode)) {
+          throw new Error("--permission-mode must be default, accept-edits, auto, or bypass-permissions");
+        }
+        break;
+      case "--manual-permissions":
+        opts.manualPermissions = true;
+        break;
+      case "--no-preflight-clean":
+        opts.preflightClean = false;
+        break;
+      case "--stop-ao-after":
+        opts.stopAOAfter = true;
+        break;
+      case "--stop-electron-after":
+        opts.stopElectronAfter = true;
+        break;
+      case "--all-supported":
+        opts.allSupported = true;
+        break;
+      case "--keep":
+        opts.keep = true;
+        break;
+      case "--verbose":
+        opts.verbose = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (opts.agent && opts.agents) {
+    throw new Error("use either --agent or --agents, not both");
+  }
+  return opts;
+}
+
+function printHelp() {
+  console.log(`Usage: node skills/agent-role-smoke/scripts/agent-role-smoke.mjs [options]
+
+Options:
+  --agent <id>              Test one harness
+  --agents <a,b,c>          Test a comma-separated harness list
+  --role <role>             worker, orchestrator, or both (default: both)
+  --all-supported           Attempt every supported harness
+  --ao-bin <path>           Use a specific ao binary (default: AO_BIN or ao)
+  --timeout-ms <ms>         Poll timeout for live checks (default: ${DEFAULT_TIMEOUT_MS})
+  --orchestrator-send-delay-ms <ms>
+                            Delay before sending to a fresh orchestrator (default: ${DEFAULT_ORCHESTRATOR_SEND_DELAY_MS})
+  --permission-mode <mode>  AO permission mode for test sessions (default: ${DEFAULT_PERMISSION_MODE})
+                            One of default, accept-edits, auto, bypass-permissions
+  --manual-permissions      Do not set AO permissions in project config; answer native prompts manually
+  --no-preflight-clean      Do not remove stale role-smoke-* projects/sessions before testing
+  --stop-ao-after           Run \`ao stop\` after the smoke test finishes
+  --stop-electron-after     Best-effort stop of local AO/Electron desktop processes after the test
+  --keep                    Keep sessions, AO project, and fixture dir
+  --verbose                 Print command/API details
+  -h, --help                Show this help
+`);
+}
+
+function requireValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function discoverHarnesses(opts) {
+  if (opts.agent) return [opts.agent.trim()].filter(Boolean);
+  if (opts.agents) {
+    return opts.agents.split(",").map((v) => v.trim()).filter(Boolean);
+  }
+
+  const inv = runAOJSON(opts, ["agent", "ls", "--refresh", "--json"]);
+  const source = opts.allSupported ? inv.supported : selectRunnableAgents(inv);
+  return [...new Set(source.map((info) => info.id).filter(Boolean))];
+}
+
+function selectRunnableAgents(inv) {
+  const authorized = inv.authorized || [];
+  if (authorized.length > 0) return authorized;
+  return (inv.installed || []).filter((info) => info.authStatus !== "unauthorized");
+}
+
+function cleanupStaleSmokeState(opts, targetHarnesses) {
+  const target = new Set(targetHarnesses);
+  const sessions = listSessions(opts, "", true);
+  const staleSessions = sessions.filter((s) => String(s.projectId || "").startsWith("role-smoke-") && !s.isTerminated);
+  for (const session of staleSessions.reverse()) {
+    if (session.role === "orchestrator" && session.harness && !target.has(session.harness)) {
+      logVerbose(opts, `stale smoke orchestrator ${session.id} uses ${session.harness}; replacing for ${targetHarnesses.join(",")}`);
+    } else {
+      logVerbose(opts, `removing stale smoke session ${session.id}`);
+    }
+    try {
+      runAO(opts, ["session", "kill", session.id]);
+    } catch (err) {
+      logVerbose(opts, `could not kill stale smoke session ${session.id}: ${err.message}`);
+    }
+  }
+
+  const projects = listProjects(opts).filter((p) => String(p.id || "").startsWith("role-smoke-"));
+  for (const project of projects) {
+    try {
+      runAO(opts, ["project", "rm", project.id, "--yes"]);
+    } catch (err) {
+      logVerbose(opts, `could not remove stale smoke project ${project.id}: ${err.message}`);
+    }
+  }
+}
+
+function listProjects(opts) {
+  const out = runAOJSON(opts, ["project", "ls", "--json"]);
+  return out.projects || out.data || [];
+}
+
+function createFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "ao-agent-role-smoke-"));
+  const src = path.join(root, "src");
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({ scripts: { test: "node -e \"console.log('fixture ok')\"" } }, null, 2) + "\n");
+  mkdirSync(src, { recursive: true });
+  writeFileSync(
+    path.join(src, "App.jsx"),
+    `export function App() {
+  return (
+    <main>
+      <button className="new-task" style={{ backgroundColor: "blue" }}>New Task</button>
+      <span className="notification-icon" style={{ color: "gray" }}>!</span>
+    </main>
+  );
+}
+`,
+  );
+  gitOutput(["-C", root, "init"]);
+  gitOutput(["-C", root, "add", "."]);
+  gitOutput(["-C", root, "-c", "user.name=AO Smoke", "-c", "user.email=ao-smoke@example.invalid", "commit", "-m", "initial fixture"]);
+  return { root };
+}
+
+function setProjectConfig(opts, projectID, config) {
+  runAO(opts, ["project", "set-config", projectID, "--config-json", JSON.stringify(config)]);
+}
+
+function permissionAgentConfig(opts) {
+  if (opts.manualPermissions) return {};
+  return { permissions: opts.permissionMode };
+}
+
+function workerTaskPrompt() {
+  return `Change the New Task button color to green in src/App.jsx. If that is not straightforward, change the notification icon color to red instead. Keep the change minimal and report the file changed.`;
+}
+
+function orchestratorTaskPrompt(opts, projectID, harness) {
+  const marker = orchestratorTaskMarker(projectID, harness);
+  return `${marker}
+
+Please get this fixture UI change done: change the New Task button color to green in src/App.jsx, or change the notification icon color to red.
+
+You are testing the ${harness} orchestrator role for AO project ${projectID}.
+The AO daemon is already running. Do not run \`ao start\`, do not open Electron, and do not use a different AO binary.
+Use this exact AO command shape if you need to delegate:
+
+\`${opts.aoBin} spawn --project ${projectID} --harness ${harness} --name ui-green-btn --prompt "Change the New Task button color to green in src/App.jsx. If that is not straightforward, change the notification icon color to red instead. Keep the change minimal and report the file changed." --skip-agent-check\`
+
+Delegate the implementation to a worker session and do not edit files in your own orchestrator workspace.`;
+}
+
+function orchestratorTaskMarker(projectID, harness) {
+  return `AO_ROLE_SMOKE_TASK ${projectID} ${harness}`;
+}
+
+function runAO(opts, args) {
+  if (opts.verbose) console.error(`$ ${opts.aoBin} ${args.join(" ")}`);
+  const res = spawnSync(opts.aoBin, args, { encoding: "utf8" });
+  if (res.status !== 0) {
+    const err = new Error(`ao ${args.join(" ")} failed with exit ${res.status}`);
+    err.cause = { stdout: res.stdout, stderr: res.stderr };
+    throw err;
+  }
+  return res.stdout;
+}
+
+function teardownAO(opts) {
+  if (opts.stopAOAfter) {
+    try {
+      runAO(opts, ["stop"]);
+    } catch (err) {
+      logVerbose(opts, `ao stop failed: ${err.message}`);
+    }
+  }
+  if (opts.stopElectronAfter) {
+    stopElectron(opts);
+  }
+}
+
+function stopElectron(opts) {
+  if (platform() === "win32") {
+    spawnSync("taskkill", ["/IM", "Agent Orchestrator.exe", "/F"], { encoding: "utf8" });
+    return;
+  }
+  const patterns = [
+    "Agent Orchestrator",
+    "Electron.*agent-orchestrator",
+    "electron-forge.*agent-orchestrator",
+  ];
+  for (const pattern of patterns) {
+    const res = spawnSync("pkill", ["-f", pattern], { encoding: "utf8" });
+    if (opts.verbose && res.status === 0) {
+      console.error(`stopped Electron process matching ${pattern}`);
+    }
+  }
+}
+
+function logVerbose(opts, message) {
+  if (opts.verbose) console.error(`agent-role-smoke: ${message}`);
+}
+
+function runAOJSON(opts, args) {
+  const out = runAO(opts, args);
+  try {
+    return JSON.parse(out);
+  } catch (err) {
+    throw new Error(`ao ${args.join(" ")} did not return JSON: ${err.message}`);
+  }
+}
+
+async function apiJSON(port, method, apiPath, body, opts) {
+  const url = `http://127.0.0.1:${port}/api/v1${apiPath}`;
+  if (opts.verbose) console.error(`${method} ${url}`);
+  const res = await fetch(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let parsed = {};
+  if (text.trim()) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { raw: text };
+    }
+  }
+  if (!res.ok) {
+    throw new Error(`${method} ${apiPath} failed with HTTP ${res.status}: ${text}`);
+  }
+  return parsed;
+}
+
+function parseSpawnedSessionID(output) {
+  const match = output.match(/spawned session\s+(\S+)/);
+  if (!match) {
+    throw new Error(`could not parse spawned session id from:\n${output}`);
+  }
+  return match[1];
+}
+
+function listSessions(opts, projectID, includeOrchestrators = false) {
+  const args = ["session", "ls", "--include-terminated", "--json"];
+  if (projectID) args.splice(2, 0, "--project", projectID);
+  if (includeOrchestrators) args.splice(2, 0, "--all");
+  return runAOJSON(opts, args).data || [];
+}
+
+async function waitForSession(opts, projectID, sessionID, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const sessions = listSessions(opts, projectID, true);
+    const found = sessions.find((s) => s.id === sessionID);
+    if (found) return found;
+    await sleep(POLL_MS);
+  }
+  throw new Error(`session ${sessionID} did not appear before timeout`);
+}
+
+async function getSession(port, sessionID, opts) {
+  const body = await apiJSON(port, "GET", `/sessions/${encodeURIComponent(sessionID)}`, undefined, opts);
+  if (!body.session) {
+    throw new Error(`GET session ${sessionID} did not include session`);
+  }
+  return body.session;
+}
+
+async function waitForNewWorker(opts, projectID, beforeIDs, timeoutMs, sessionID = "") {
+  const before = new Set(beforeIDs);
+  const deadline = Date.now() + timeoutMs;
+  let sentEnter = false;
+  const idleEnter = createIdleEnterTracker(opts, sessionID, "orchestrator delegation poll");
+  while (Date.now() < deadline) {
+    const sessions = listSessions(opts, projectID, true);
+    const found = sessions.find((s) => s.role === "worker" && !before.has(s.id));
+    if (found) return found;
+    if (sessionID) {
+      idleEnter(captureTmuxPane(opts, sessionID, 180));
+    }
+    if (!sentEnter && acknowledgeVisibleBlockingPrompt(opts, sessionID, "orchestrator delegation poll")) {
+      sentEnter = true;
+    }
+    await sleep(IDLE_POLL_MS);
+  }
+  throw new Error("orchestrator did not create or redirect a new worker before timeout");
+}
+
+function assertSession(session, harness, role) {
+  const actualRole = session.role || session.kind;
+  if (actualRole !== role) {
+    throw new Error(`session ${session.id} role = ${actualRole}, want ${role}`);
+  }
+  if (session.harness !== harness) {
+    throw new Error(`session ${session.id} harness = ${session.harness}, want ${harness}`);
+  }
+}
+
+function assertSystemPrompt(dataDir, sessionID, expectedMarker) {
+  const file = path.join(dataDir, "prompts", sessionID, "system.md");
+  if (!existsSync(file)) {
+    throw new Error(`missing system prompt artifact: ${file}`);
+  }
+  const body = readFileSync(file, "utf8");
+  if (!body.trim()) {
+    throw new Error(`system prompt artifact is empty: ${file}`);
+  }
+  if (!body.includes(expectedMarker)) {
+    throw new Error(`system prompt artifact ${file} does not include ${expectedMarker}`);
+  }
+}
+
+async function waitForWorkspace(repoRoot, branch, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const worktree = findWorktreeByBranch(repoRoot, branch);
+    if (worktree) return worktree;
+    await sleep(1_000);
+  }
+  throw new Error(`could not find worktree for branch ${branch}`);
+}
+
+function findWorktreeByBranch(repoRoot, branch) {
+  if (!branch) return "";
+  const out = gitOutput(["-C", repoRoot, "worktree", "list", "--porcelain"]);
+  const entries = out.split(/\n\n+/);
+  for (const entry of entries) {
+    const lines = entry.split("\n");
+    const worktree = lines.find((line) => line.startsWith("worktree "))?.slice("worktree ".length);
+    const foundBranch = lines.find((line) => line.startsWith("branch "))?.slice("branch refs/heads/".length);
+    if (worktree && foundBranch === branch) {
+      return worktree;
+    }
+  }
+  return "";
+}
+
+async function waitForFixtureChange(workspace, timeoutMs, opts, sessionID = "") {
+  const deadline = Date.now() + timeoutMs;
+  let sentEnter = false;
+  const idleEnter = createIdleEnterTracker(opts, sessionID, "fixture-change poll");
+  while (Date.now() < deadline) {
+    const file = path.join(workspace, "src", "App.jsx");
+    if (existsSync(file)) {
+      const body = readFileSync(file, "utf8").toLowerCase();
+      const changed = body.includes("green") || body.includes("#008000") || body.includes("rgb(0, 128, 0)") || body.includes("red") || body.includes("#ff0000");
+      const dirty = gitOutput(["-C", workspace, "status", "--porcelain"]).trim() !== "";
+      if (changed && dirty) return true;
+    }
+    if (sessionID) {
+      idleEnter(captureTmuxPane(opts, sessionID, 180));
+    }
+    if (!sentEnter && acknowledgeVisibleBlockingPrompt(opts, sessionID, "fixture-change poll")) {
+      sentEnter = true;
+    }
+    await sleep(IDLE_POLL_MS);
+  }
+  return false;
+}
+
+function sendEnterToTmux(opts, sessionID, reason) {
+  sendKeysToTmux(opts, sessionID, ["Enter"], reason);
+}
+
+function sendKeysToTmux(opts, sessionID, keys, reason) {
+  if (!sessionID) return;
+  const target = `${sessionID}:0.0`;
+  const res = spawnSync("tmux", ["send-keys", "-t", target, ...keys], { encoding: "utf8" });
+  if (res.status === 0) {
+    logVerbose(opts, `sent ${keys.join(" ")} to tmux pane ${target} during ${reason}`);
+    return;
+  }
+  logVerbose(opts, `could not send ${keys.join(" ")} to tmux pane ${target}: ${res.stderr || res.stdout || `exit ${res.status}`}`);
+}
+
+async function preparePostStartSend(opts, harness, sessionID) {
+  await waitForOrchestratorPane(opts, sessionID, ORCHESTRATOR_READY_TIMEOUT_MS);
+  await clearStartupBlockingPrompt(opts, harness, sessionID, ORCHESTRATOR_READY_TIMEOUT_MS);
+  const ready = await waitForOrchestratorPromptReady(opts, harness, sessionID, ORCHESTRATOR_READY_TIMEOUT_MS);
+  if (!ready) {
+    throw new Error(`orchestrator ${sessionID} did not reach a usable prompt before task injection`);
+  }
+}
+
+async function waitForOrchestratorPane(opts, sessionID, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  const idleEnter = createIdleEnterTracker(opts, sessionID, "orchestrator pane startup");
+  while (Date.now() < deadline) {
+    const output = captureTmuxPane(opts, sessionID, 120);
+    if (output.trim()) return output;
+    idleEnter(output);
+    await sleep(1_000);
+  }
+  throw new Error(`orchestrator ${sessionID} tmux pane did not produce output before timeout`);
+}
+
+async function clearStartupBlockingPrompt(opts, harness, sessionID, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let answered = false;
+  const idleEnter = createIdleEnterTracker(opts, sessionID, "startup prompt clear");
+  while (Date.now() < deadline) {
+    const output = captureTmuxPane(opts, sessionID, 140);
+    if (harness === "cursor" && cursorWorkspaceTrustVisible(output)) {
+      sendKeysToTmux(opts, sessionID, ["a"], "cursor workspace trust prompt before send");
+      await sleep(1_000);
+      continue;
+    }
+    if (visibleBlockingPrompt(output) && !answered) {
+      sendEnterToTmux(opts, sessionID, "startup blocking prompt before send");
+      answered = true;
+      await sleep(1_000);
+      continue;
+    }
+    idleEnter(output);
+    return;
+  }
+}
+
+async function waitForOrchestratorPromptReady(opts, harness, sessionID, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  const idleEnter = createIdleEnterTracker(opts, sessionID, "orchestrator prompt readiness");
+  while (Date.now() < deadline) {
+    const output = captureTmuxPane(opts, sessionID, 140);
+    if (orchestratorPromptReady(output, harness)) return true;
+    idleEnter(output);
+    await sleep(1_000);
+  }
+  return false;
+}
+
+function orchestratorPromptReady(output, harness) {
+  if (!output.trim()) return false;
+  if (harness === "cursor" && cursorWorkspaceTrustVisible(output)) return false;
+  if (visibleBlockingPrompt(output)) return false;
+  return true;
+}
+
+async function sendTaskToOrchestrator(opts, sessionID, message, marker) {
+  const deadline = Date.now() + ORCHESTRATOR_DELIVERY_TIMEOUT_MS;
+  let attempts = 0;
+  let acknowledged = false;
+  let lastError = "";
+  while (Date.now() < deadline && attempts < 3) {
+    attempts += 1;
+    const beforeOutput = captureTmuxPane(opts, sessionID, 180);
+    try {
+      runAO(opts, ["send", "--session", sessionID, "--message", message]);
+    } catch (err) {
+      lastError = err.message;
+      if (!sendFailedOnDecision(err)) throw err;
+      acknowledgeVisibleBlockingPrompt(opts, sessionID, `send attempt ${attempts} blocked by decision prompt`);
+      await sleep(2_000);
+      continue;
+    }
+
+    if (await waitForTaskDeliveryEvidence(opts, sessionID, marker, beforeOutput, 10_000)) return;
+
+    if (!acknowledged) {
+      acknowledgeVisibleBlockingPrompt(opts, sessionID, "task delivery verification");
+      acknowledged = true;
+      await sleep(2_000);
+      continue;
+    }
+  }
+  const pane = captureTmuxPane(opts, sessionID, 160);
+  const extra = lastError ? ` Last send error: ${lastError}.` : "";
+  throw new Error(`task message marker ${marker} did not appear in orchestrator ${sessionID} pane after send.${extra}\nRecent pane output:\n${pane}`);
+}
+
+async function waitForTaskDeliveryEvidence(opts, sessionID, marker, beforeOutput, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  const beforePastes = pastedTextCount(beforeOutput);
+  const idleEnter = createIdleEnterTracker(opts, sessionID, "task delivery evidence");
+  while (Date.now() < deadline) {
+    const output = captureTmuxPane(opts, sessionID, 180);
+    if (output.includes(marker)) return true;
+    if (pastedTextCount(output) > beforePastes) return true;
+    idleEnter(output);
+    await sleep(1_000);
+  }
+  return false;
+}
+
+function pastedTextCount(output) {
+  return (output.match(/\[Pasted text #\d+/g) || []).length;
+}
+
+function acknowledgeVisibleBlockingPrompt(opts, sessionID, reason) {
+  if (!sessionID) return false;
+  const output = captureTmuxPane(opts, sessionID, 140);
+  if (!visibleBlockingPrompt(output)) return false;
+  sendEnterToTmux(opts, sessionID, reason);
+  return true;
+}
+
+function createIdleEnterTracker(opts, sessionID, reason) {
+  let lastOutput = null;
+  let lastChangedAt = Date.now();
+  let lastEnterAt = 0;
+  return (output) => {
+    if (!sessionID) return;
+    const now = Date.now();
+    if (lastOutput === null || output !== lastOutput) {
+      lastOutput = output;
+      lastChangedAt = now;
+      return;
+    }
+    if (now - lastChangedAt < IDLE_ENTER_MS || now - lastEnterAt < IDLE_ENTER_MS) {
+      return;
+    }
+    sendEnterToTmux(opts, sessionID, `${reason}; no tmux output change for ${IDLE_ENTER_MS / 1_000}s`);
+    lastEnterAt = now;
+    lastChangedAt = now;
+  };
+}
+
+function captureTmuxPane(opts, sessionID, lines) {
+  const target = `${sessionID}:0.0`;
+  const res = spawnSync("tmux", ["capture-pane", "-t", target, "-p", "-S", `-${lines}`], { encoding: "utf8" });
+  if (res.status === 0) return res.stdout;
+  logVerbose(opts, `could not capture tmux pane ${target}: ${res.stderr || res.stdout || `exit ${res.status}`}`);
+  return "";
+}
+
+function cursorWorkspaceTrustVisible(output) {
+  return output.includes("Workspace Trust Required") || output.includes("Trusting workspace");
+}
+
+function visibleBlockingPrompt(output) {
+  if (!output) return false;
+  const normalized = output.toLowerCase();
+  return (
+    normalized.includes("waiting for approval") ||
+    normalized.includes("run this command?") ||
+    normalized.includes("allow this command") ||
+    normalized.includes("approve") ||
+    normalized.includes("permission required") ||
+    normalized.includes("permission denied") ||
+    normalized.includes("permission prompt") ||
+    normalized.includes("do you want to proceed") ||
+    normalized.includes("press enter") ||
+    normalized.includes("hit enter") ||
+    /\[(y|yes)\/(n|no)\]/i.test(output) ||
+    /\((y|yes)\)/i.test(output)
+  );
+}
+
+function sendFailedOnDecision(err) {
+  const text = `${err.message || ""}\n${err.cause?.stdout || ""}\n${err.cause?.stderr || ""}`;
+  return text.includes("SESSION_AWAITING_DECISION") || text.toLowerCase().includes("awaiting decision");
+}
+
+function predictedOrchestratorWorkspace(dataDir, projectID) {
+  const prefix = String(projectID).slice(0, 12);
+  return path.join(dataDir, "worktrees", String(projectID), "orchestrator", `${prefix}-orchestrator`);
+}
+
+function pretrustCursorWorkspace(opts, workspacePath) {
+  const dir = path.join(homedir(), ".cursor", "projects", cursorProjectKey(workspacePath));
+  mkdirSync(dir, { recursive: true });
+  const trustPath = path.join(dir, ".workspace-trusted");
+  writeFileSync(
+    trustPath,
+    JSON.stringify({ trustedAt: new Date().toISOString(), workspacePath }, null, 2) + "\n",
+    { mode: 0o644 },
+  );
+  const repoPath = path.join(dir, "repo.json");
+  if (!existsSync(repoPath)) {
+    writeFileSync(repoPath, JSON.stringify({ id: randomUUID() }, null, 2) + "\n", { mode: 0o644 });
+  }
+  logVerbose(opts, `pretrusted Cursor workspace ${workspacePath}`);
+}
+
+function cursorProjectKey(workspacePath) {
+  return path.resolve(workspacePath).replace(/^[\\/]+/, "").replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function gitOutput(args) {
+  return execFileSync("git", args, { encoding: "utf8" });
+}
+
+function shortName(name) {
+  return name.replace(/[^a-z0-9-]/gi, "-").slice(0, 20);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function printSummary(results, keptFixture) {
+  console.log("\nAgent role smoke summary");
+  for (const result of results) {
+    const icon = result.status === "pass" ? "PASS" : "FAIL";
+    console.log(`${icon} ${result.harness} ${result.role}: ${result.detail}`);
+  }
+  if (keptFixture) {
+    const exists = existsSync(keptFixture) && statSync(keptFixture).isDirectory();
+    if (exists) console.log(`Kept fixture: ${keptFixture}`);
+  }
+}


### PR DESCRIPTION
## What

Add file-backed token usage observability for Copilot, Kimi, Pi, and Qwen alongside the existing Codex and Claude support.

- Parse each provider's native token metrics into the existing usage model.
- Discover, validate, and reconcile provider-owned usage artifacts durably.
- Preserve per-metric availability when aggregating mixed harnesses.
- Keep token usage visible only when Developer Mode is enabled.

## Why

AO already exposes token usage for Codex and Claude, but sessions using other supported agents could not report reliable input, cache, output, and reasoning totals. This extends the same collector and summary pipeline without introducing a separate accounting path.

## How

- Add source profiles and parsers for Copilot shutdown metrics, Kimi wire events, Pi session events, and Qwen monthly usage.
- Extend the existing usage binding/source constraints through migration 0085.
- Fence source attribution to the expected provider root and native session.
- Retry artifacts that appear after session startup and reactivate Pi discovery when its native session ID is persisted.
- Treat a mixed-harness aggregate metric as available only when every contributor reports it.

Intentional omissions:

- Cost and pricing status are not included.
- Grok requires an OTEL ingestion path and remains a follow-up.
- Droid provides only a summary, which is insufficient for reliable token totals.

## Testing

- `npm run lint`
- `npm run frontend:typecheck`
- `cd backend && go test ./internal/storage/sqlite -run 'Test(MigrationVersionLedger|MultiAgentUsageMigration)' -count=1`

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
