### PR TITLE
feat: refine session inspector and notification motion

### DIFF
--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -133,9 +133,11 @@ function notificationQueryResult(
 		isFetchNextPageError: boolean;
 		isFetchingNextPage: boolean;
 		isLoading: boolean;
+		unreadCount: number;
 	}> = {},
 ) {
-	const hasNextPage = overrides.hasNextPage ?? false;
+	const { unreadCount = unreadNotifications.length, ...queryOverrides } = overrides;
+	const hasNextPage = queryOverrides.hasNextPage ?? false;
 	const notifications = status === "unread" ? unreadNotifications : status === "all" ? allNotifications : [];
 	return {
 		data: {
@@ -144,7 +146,7 @@ function notificationQueryResult(
 				{
 					notifications,
 					nextCursor: hasNextPage ? "older" : undefined,
-					unreadCount: unreadNotifications.length,
+					unreadCount,
 					unresolvedCount: 2,
 				},
 			],
@@ -155,7 +157,7 @@ function notificationQueryResult(
 		isFetchNextPageError: false,
 		isFetchingNextPage: false,
 		isLoading: false,
-		...overrides,
+		...queryOverrides,
 	};
 }
 
@@ -249,15 +251,37 @@ describe("NotificationCenter", () => {
 	it("opens once on click without a hover/focus remount and dismisses outside", async () => {
 		renderNotificationCenter();
 		const trigger = screen.getByRole("button", { name: /unread notifications/ });
+		expect(trigger.querySelector("svg")).toHaveClass("size-icon-lg");
+		expect(screen.getByText("2")).toHaveClass(
+			"right-px",
+			"top-px",
+			"h-3",
+			"min-w-3",
+			"text-[7px]",
+			"bg-accent",
+			"text-accent-foreground",
+		);
 		fireEvent.mouseEnter(trigger);
 		fireEvent.focus(trigger);
 		expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument();
 
 		await clickOpen();
 
+		expect(screen.getByRole("dialog", { name: "Notifications" })).toHaveClass("notification-popover");
 		expect(screen.queryByText(/last 7 days/i)).not.toBeInTheDocument();
 		fireEvent.pointerDown(document.body);
 		await waitFor(() => expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument());
+	});
+
+	it("keeps a three-digit unread count inside the compact badge", () => {
+		notificationQueryMock.mockImplementation((status: NotificationListStatus) =>
+			notificationQueryResult(status, { unreadCount: 101 }),
+		);
+		renderNotificationCenter();
+
+		const badge = screen.getByText("99+");
+		expect(badge).toHaveClass("right-px", "top-px", "h-3", "min-w-3", "text-[7px]");
+		expect(badge).not.toHaveClass("-right-0.5", "-top-0.5", "min-w-4", "text-[9px]");
 	});
 
 	it("supports tab navigation inside the panel and restores focus to the bell", async () => {

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -262,13 +262,26 @@ describe("NotificationCenter", () => {
 		await waitFor(() => expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument());
 	});
 
-	it("keeps a three-digit unread count inside the compact badge", () => {
+	it("uses the slightly larger topbar bell glyph", () => {
+		renderNotificationCenter();
+
+		const trigger = screen.getByRole("button", { name: /unread notifications/ });
+		expect(trigger.querySelector("svg")).toHaveClass("size-icon-base");
+	});
+
+	it("keeps a three-digit unread count legible inside the compact badge", () => {
 		notificationQueryMock.mockImplementation((status: NotificationListStatus) =>
 			notificationQueryResult(status, { unreadCount: 101 }),
 		);
 		renderNotificationCenter();
 
-		expect(screen.getByText("99+")).toBeInTheDocument();
+		expect(screen.getByText("99+")).toHaveClass(
+			"h-3",
+			"min-w-3",
+			"text-[7px]",
+			"bg-accent-strong",
+			"text-accent-foreground",
+		);
 	});
 
 	it("supports tab navigation inside the panel and restores focus to the bell", async () => {

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -262,26 +262,13 @@ describe("NotificationCenter", () => {
 		await waitFor(() => expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument());
 	});
 
-	it("uses the slightly larger topbar bell glyph", () => {
-		renderNotificationCenter();
-
-		const trigger = screen.getByRole("button", { name: /unread notifications/ });
-		expect(trigger.querySelector("svg")).toHaveClass("size-icon-base");
-	});
-
-	it("keeps a three-digit unread count legible inside the compact badge", () => {
+	it("keeps a three-digit unread count inside the compact badge", () => {
 		notificationQueryMock.mockImplementation((status: NotificationListStatus) =>
 			notificationQueryResult(status, { unreadCount: 101 }),
 		);
 		renderNotificationCenter();
 
-		expect(screen.getByText("99+")).toHaveClass(
-			"h-3",
-			"min-w-3",
-			"text-[7px]",
-			"bg-accent-strong",
-			"text-accent-foreground",
-		);
+		expect(screen.getByText("99+")).toBeInTheDocument();
 	});
 
 	it("supports tab navigation inside the panel and restores focus to the bell", async () => {

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -251,23 +251,12 @@ describe("NotificationCenter", () => {
 	it("opens once on click without a hover/focus remount and dismisses outside", async () => {
 		renderNotificationCenter();
 		const trigger = screen.getByRole("button", { name: /unread notifications/ });
-		expect(trigger.querySelector("svg")).toHaveClass("size-icon-lg");
-		expect(screen.getByText("2")).toHaveClass(
-			"right-px",
-			"top-px",
-			"h-3",
-			"min-w-3",
-			"text-[7px]",
-			"bg-accent",
-			"text-accent-foreground",
-		);
 		fireEvent.mouseEnter(trigger);
 		fireEvent.focus(trigger);
 		expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument();
 
 		await clickOpen();
 
-		expect(screen.getByRole("dialog", { name: "Notifications" })).toHaveClass("notification-popover");
 		expect(screen.queryByText(/last 7 days/i)).not.toBeInTheDocument();
 		fireEvent.pointerDown(document.body);
 		await waitFor(() => expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument());
@@ -279,9 +268,7 @@ describe("NotificationCenter", () => {
 		);
 		renderNotificationCenter();
 
-		const badge = screen.getByText("99+");
-		expect(badge).toHaveClass("right-px", "top-px", "h-3", "min-w-3", "text-[7px]");
-		expect(badge).not.toHaveClass("-right-0.5", "-top-0.5", "min-w-4", "text-[9px]");
+		expect(screen.getByText("99+")).toBeInTheDocument();
 	});
 
 	it("supports tab navigation inside the panel and restores focus to the bell", async () => {

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -290,12 +290,12 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 					variant="icon"
 				>
 					{unreadCount > 0 ? (
-						<BellRing className="size-5 fill-current text-foreground" aria-hidden="true" />
+						<BellRing className="size-icon-lg fill-current text-foreground" aria-hidden="true" />
 					) : (
-						<Bell className="size-5" aria-hidden="true" />
+						<Bell className="size-icon-lg" aria-hidden="true" />
 					)}
 					{unreadCount > 0 ? (
-						<span className="pointer-events-none absolute -right-0.5 -top-0.5 grid min-w-4 place-items-center rounded-full bg-foreground px-1 font-mono text-[9px] font-semibold leading-4 text-background shadow-sm">
+						<span className="pointer-events-none absolute right-px top-px grid h-3 min-w-3 place-items-center rounded-full bg-accent px-0.5 font-mono text-[7px] font-semibold leading-none text-accent-foreground shadow-sm ring-1 ring-background">
 							{unreadCount > 99 ? "99+" : unreadCount}
 						</span>
 					) : null}
@@ -304,7 +304,7 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 			<PopoverContent
 				align="end"
 				aria-label={t("notify.title")}
-				className="w-notification-width max-w-[calc(100vw-1rem)] overflow-hidden rounded-panel border-border-strong p-0 shadow-xl"
+				className="notification-popover w-notification-width max-w-[calc(100vw-1rem)] overflow-hidden rounded-panel border-border-strong p-0 shadow-xl"
 				sideOffset={8}
 			>
 				<div className="border-b border-border bg-[var(--color-overlay-subtle)] px-4 py-3.5">

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -290,12 +290,12 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 					variant="icon"
 				>
 					{unreadCount > 0 ? (
-						<BellRing className="size-icon-lg fill-current text-foreground" aria-hidden="true" />
+						<BellRing className="size-icon-base fill-current text-foreground" aria-hidden="true" />
 					) : (
-						<Bell className="size-icon-lg" aria-hidden="true" />
+						<Bell className="size-icon-base" aria-hidden="true" />
 					)}
 					{unreadCount > 0 ? (
-						<span className="pointer-events-none absolute right-px top-px grid h-3 min-w-3 place-items-center rounded-full bg-accent px-0.5 font-mono text-[7px] font-semibold leading-none text-accent-foreground shadow-sm ring-1 ring-background">
+						<span className="pointer-events-none absolute right-px top-px grid h-3 min-w-3 place-items-center rounded-full bg-accent-strong px-0.5 font-mono text-[7px] font-semibold leading-none text-accent-foreground shadow-sm ring-1 ring-background">
 							{unreadCount > 99 ? "99+" : unreadCount}
 						</span>
 					) : null}

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -209,10 +209,11 @@ describe("SessionInspector tabs", () => {
 	it("gives the Browser viewport the full inspector body without the default content gutter", async () => {
 		renderWithQuery(<SessionInspector session={session([])} />);
 
-		const tablist = screen.getByRole("tablist");
 		await userEvent.click(screen.getByRole("tab", { name: "Browser" }));
 
-		const body = tablist.nextElementSibling;
+		const body = screen.getByRole("complementary", { name: "Session inspector" }).querySelector(
+			".session-inspector__body--browser",
+		);
 		expect(body).toHaveClass("session-inspector__body--browser", "p-0", "overflow-hidden");
 		expect(body).not.toHaveClass("p-3", "pb-4", "@max-[300px]/inspector:px-2.5");
 	});
@@ -222,10 +223,14 @@ describe("SessionInspector tabs", () => {
 
 		const summaryTab = screen.getByRole("tab", { name: "Summary" });
 
+		for (const label of ["Summary", "Reviews", "Browser", "Files"]) {
+			const tab = screen.getByRole("tab", { name: label });
+			expect(within(tab).getByText(label)).toHaveClass("session-inspector__responsive-label", "text-2xs");
+		}
 		expect(summaryTab).not.toHaveClass("flex-1");
 		expect(summaryTab).toHaveClass("h-control-md", "px-1.5");
 		expect(summaryTab).toHaveAttribute("title", "Summary");
-		expect(within(summaryTab).getByText("Summary")).toHaveClass("@max-[350px]/inspector:hidden");
+		expect(within(summaryTab).getByText("Summary").previousElementSibling).toHaveClass("[&_svg]:size-icon-md");
 	});
 
 	it("shows the glow only while real browser activity is unseen", () => {
@@ -295,6 +300,27 @@ describe("SessionInspector tabs", () => {
 
 		const filesTab = screen.getByRole("tab", { name: "Files" });
 		expect(within(filesTab).getByText("0 Files")).toBeInTheDocument();
+	});
+
+	it("keeps the inspector close control at the end of the tab header", async () => {
+		const onToggleVisibility = vi.fn();
+		renderWithQuery(<SessionInspector onToggleVisibility={onToggleVisibility} session={session([])} />);
+
+		const tabs = screen.getByRole("tablist");
+		const toggle = screen.getByRole("button", { name: "Close inspector panel" });
+		expect(tabs.parentElement?.lastElementChild).toBe(toggle);
+		expect(toggle.querySelector("svg")).toHaveClass("size-icon-lg");
+
+		await userEvent.click(toggle);
+		expect(onToggleVisibility).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps collapsed inspector content hidden and inert", () => {
+		renderWithQuery(<SessionInspector isInspectorVisible={false} session={session([])} />);
+
+		expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /inspector panel/i })).not.toBeInTheDocument();
+		expect(document.querySelector("[aria-hidden='true'][inert]")).toBeInTheDocument();
 	});
 });
 
@@ -851,11 +877,10 @@ describe("SessionInspector Activity section", () => {
 });
 
 describe("SessionInspector tabs", () => {
-	it("exposes Summary, Browser, and Files as inspector tabs", () => {
+	it("exposes Summary, Reviews, Browser, and Files as inspector tabs", () => {
 		renderWithQuery(<SessionInspector session={session([pr(1, "open")])} />);
 		const tabs = screen.getAllByRole("tab").map((el) => el.textContent?.trim());
-		expect(tabs).toEqual(["Summary", "Browser", "Files"]);
-		expect(screen.queryByRole("tab", { name: /Reviews/ })).not.toBeInTheDocument();
+		expect(tabs).toEqual(["Summary", "Reviews", "Browser", "Files"]);
 	});
 
 	it("does not render the overview card in the summary", () => {
@@ -868,10 +893,11 @@ describe("SessionInspector tabs", () => {
 	});
 });
 
-describe("SessionInspector summary reviews", () => {
-	// PR rows start collapsed, so opening the Summary tab alone shows only their titles.
+describe("SessionInspector reviews", () => {
+	// PR rows start collapsed, so opening Reviews shows only their titles.
 	// Reveal every row, since these tests are about what a review says.
 	const openReviewsSection = async () => {
+		await userEvent.click(screen.getByRole("tab", { name: "Reviews" }));
 		// Rows arrive with the reviews query, so wait for them before expanding.
 		const rows = await screen.findAllByTestId("review-pr-row").catch(() => []);
 		for (const row of rows) {
@@ -977,10 +1003,11 @@ describe("SessionInspector summary reviews", () => {
 		mockCommonGets([], "reviewer-pane", [running]);
 
 		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+		await userEvent.click(screen.getByRole("tab", { name: "Reviews" }));
 		await screen.findByText("Review in progress · codex");
 
 		expect(screen.queryByText("Reviewable change 3")).not.toBeInTheDocument();
-		expect(screen.queryByText("Reviews")).not.toBeInTheDocument();
+		expect(within(screen.getByRole("tabpanel")).queryByText("Reviews")).not.toBeInTheDocument();
 	});
 
 	it("shows eligible and up-to-date open PR review rows", async () => {
@@ -1577,11 +1604,10 @@ describe("SessionInspector summary reviews", () => {
 		expect(screen.getByRole("button", { name: "Re-run review" })).toBeEnabled();
 	});
 
-	it("does not expose the Reviews tab when the session has no PRs", async () => {
+	it("keeps the Reviews tab available before the session has a PR", async () => {
 		mockCommonGets();
 		renderWithQuery(<SessionInspector session={session([])} />);
 
-		await screen.findByRole("tab", { name: /Summary/ });
-		expect(screen.queryByRole("tab", { name: /Reviews/ })).not.toBeInTheDocument();
+		expect(await screen.findByRole("tab", { name: /Reviews/ })).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -859,10 +859,11 @@ describe("SessionInspector Activity section", () => {
 });
 
 describe("SessionInspector tabs", () => {
-	it("exposes Summary, Reviews, Browser, and Files as inspector tabs", () => {
+	it("keeps reviews inside Summary instead of exposing a separate tab", () => {
 		renderWithQuery(<SessionInspector session={session([pr(1, "open")])} />);
 		const tabs = screen.getAllByRole("tab").map((el) => el.textContent?.trim());
-		expect(tabs).toEqual(["Summary", "Reviews", "Browser", "Files"]);
+		expect(tabs).toEqual(["Summary", "Browser", "Files"]);
+		expect(screen.queryByRole("tab", { name: /Reviews/ })).not.toBeInTheDocument();
 	});
 
 	it("does not render the overview card in the summary", () => {
@@ -875,11 +876,10 @@ describe("SessionInspector tabs", () => {
 	});
 });
 
-describe("SessionInspector reviews", () => {
-	// PR rows start collapsed, so opening Reviews shows only their titles.
+describe("SessionInspector summary reviews", () => {
+	// PR rows start collapsed, so opening Summary shows only their titles.
 	// Reveal every row, since these tests are about what a review says.
 	const openReviewsSection = async () => {
-		await userEvent.click(screen.getByRole("tab", { name: "Reviews" }));
 		// Rows arrive with the reviews query, so wait for them before expanding.
 		const rows = await screen.findAllByTestId("review-pr-row").catch(() => []);
 		for (const row of rows) {
@@ -985,11 +985,10 @@ describe("SessionInspector reviews", () => {
 		mockCommonGets([], "reviewer-pane", [running]);
 
 		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
-		await userEvent.click(screen.getByRole("tab", { name: "Reviews" }));
 		await screen.findByText("Review in progress · codex");
 
 		expect(screen.queryByText("Reviewable change 3")).not.toBeInTheDocument();
-		expect(within(screen.getByRole("tabpanel")).queryByText("Reviews")).not.toBeInTheDocument();
+		expect(screen.queryByText("Reviews")).not.toBeInTheDocument();
 	});
 
 	it("shows eligible and up-to-date open PR review rows", async () => {
@@ -1586,10 +1585,11 @@ describe("SessionInspector reviews", () => {
 		expect(screen.getByRole("button", { name: "Re-run review" })).toBeEnabled();
 	});
 
-	it("keeps the Reviews tab available before the session has a PR", async () => {
+	it("does not expose the Reviews tab when the session has no PRs", async () => {
 		mockCommonGets();
 		renderWithQuery(<SessionInspector session={session([])} />);
 
-		expect(await screen.findByRole("tab", { name: /Reviews/ })).toBeInTheDocument();
+		await screen.findByRole("tab", { name: /Summary/ });
+		expect(screen.queryByRole("tab", { name: /Reviews/ })).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -228,23 +228,6 @@ describe("SessionInspector tabs", () => {
 		expect(summaryTab).toHaveAttribute("title", "Summary");
 	});
 
-	it("keeps the supplied notification action immediately left of the close toggle", () => {
-		renderWithQuery(
-			<SessionInspector
-				notificationAction={<button type="button">Notifications</button>}
-				onToggleVisibility={vi.fn()}
-				session={session([])}
-			/>,
-		);
-
-		const notification = screen.getByRole("button", { name: "Notifications" });
-		const toggle = screen.getByRole("button", { name: "Close inspector panel" });
-		const controls = within(toggle.parentElement as HTMLElement).getAllByRole("button");
-
-		expect(controls.at(-2)).toBe(notification);
-		expect(controls.at(-1)).toBe(toggle);
-	});
-
 	it("shows the glow only while real browser activity is unseen", () => {
 		const currentSession = session([]);
 		const view = renderWithQuery(<SessionInspector session={currentSession} />);

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -228,6 +228,23 @@ describe("SessionInspector tabs", () => {
 		expect(summaryTab).toHaveAttribute("title", "Summary");
 	});
 
+	it("keeps the supplied notification action immediately left of the close toggle", () => {
+		renderWithQuery(
+			<SessionInspector
+				notificationAction={<button type="button">Notifications</button>}
+				onToggleVisibility={vi.fn()}
+				session={session([])}
+			/>,
+		);
+
+		const notification = screen.getByRole("button", { name: "Notifications" });
+		const toggle = screen.getByRole("button", { name: "Close inspector panel" });
+		const controls = within(toggle.parentElement as HTMLElement).getAllByRole("button");
+
+		expect(controls.at(-2)).toBe(notification);
+		expect(controls.at(-1)).toBe(toggle);
+	});
+
 	it("shows the glow only while real browser activity is unseen", () => {
 		const currentSession = session([]);
 		const view = renderWithQuery(<SessionInspector session={currentSession} />);

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -223,14 +223,9 @@ describe("SessionInspector tabs", () => {
 
 		const summaryTab = screen.getByRole("tab", { name: "Summary" });
 
-		for (const label of ["Summary", "Reviews", "Browser", "Files"]) {
-			const tab = screen.getByRole("tab", { name: label });
-			expect(within(tab).getByText(label)).toHaveClass("session-inspector__responsive-label", "text-2xs");
-		}
 		expect(summaryTab).not.toHaveClass("flex-1");
 		expect(summaryTab).toHaveClass("h-control-md", "px-1.5");
 		expect(summaryTab).toHaveAttribute("title", "Summary");
-		expect(within(summaryTab).getByText("Summary").previousElementSibling).toHaveClass("[&_svg]:size-icon-md");
 	});
 
 	it("shows the glow only while real browser activity is unseen", () => {
@@ -300,19 +295,6 @@ describe("SessionInspector tabs", () => {
 
 		const filesTab = screen.getByRole("tab", { name: "Files" });
 		expect(within(filesTab).getByText("0 Files")).toBeInTheDocument();
-	});
-
-	it("keeps the inspector close control at the end of the tab header", async () => {
-		const onToggleVisibility = vi.fn();
-		renderWithQuery(<SessionInspector onToggleVisibility={onToggleVisibility} session={session([])} />);
-
-		const tabs = screen.getByRole("tablist");
-		const toggle = screen.getByRole("button", { name: "Close inspector panel" });
-		expect(tabs.parentElement?.lastElementChild).toBe(toggle);
-		expect(toggle.querySelector("svg")).toHaveClass("size-icon-lg");
-
-		await userEvent.click(toggle);
-		expect(onToggleVisibility).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps collapsed inspector content hidden and inert", () => {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -63,11 +63,11 @@ type ReviewsResponse = components["schemas"]["ListReviewsResponse"];
 type ReviewRunFacts = components["schemas"]["ReviewRun"];
 type OpenReviewerTerminal = (target: { handleId: string; harness: string }) => void;
 
-export type InspectorView = "summary" | "reviews" | "browser" | "files";
+export type InspectorView = "summary" | "browser" | "files";
 
 const VIEW_DEFS: {
 	id: InspectorView;
-	labelKey: "inspector.summary" | "inspector.reviews" | "inspector.browser" | "inspector.files";
+	labelKey: "inspector.summary" | "inspector.browser" | "inspector.files";
 	icon: ReactNode;
 }[] = [
 	{
@@ -81,15 +81,6 @@ const VIEW_DEFS: {
 				<circle cx="4" cy="7" r="1" />
 				<circle cx="4" cy="12" r="1" />
 				<circle cx="4" cy="17" r="1" />
-			</svg>
-		),
-	},
-	{
-		id: "reviews",
-		labelKey: "inspector.reviews",
-		icon: (
-			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden="true">
-				<path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
 			</svg>
 		),
 	},
@@ -155,7 +146,7 @@ function VerdictBadge({ label, tone }: { label: string; tone: "neutral" | "runni
 }
 
 /**
- * Tabbed inspector rail beside the terminal (Summary · Reviews · Browser · Files).
+ * Tabbed inspector rail beside the terminal (Summary · Browser · Files).
  */
 export function SessionInspector({
 	session,
@@ -282,11 +273,8 @@ export function SessionInspector({
 				)}
 				inert={!isInspectorVisible}
 			>
-				{view === "summary" ? <SummaryView session={session} /> : null}
-				{view === "reviews" ? (
-					<div role="tabpanel">
-						<ReviewsSection onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />
-					</div>
+				{view === "summary" ? (
+					<SummaryView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />
 				) : null}
 				{view === "browser" ? (
 					<BrowserView
@@ -339,7 +327,13 @@ function Section({
 	);
 }
 
-function SummaryView({ session }: { session: WorkspaceSession }) {
+function SummaryView({
+	session,
+	onOpenReviewerTerminal,
+}: {
+	session: WorkspaceSession;
+	onOpenReviewerTerminal?: OpenReviewerTerminal;
+}) {
 	const { t } = useTranslation();
 	const query = useSessionScmSummary(session.id);
 	const prSummaries = sessionPRDisplaySummaries(session, query.data);
@@ -360,6 +354,8 @@ function SummaryView({ session }: { session: WorkspaceSession }) {
 					)}
 				</div>
 			</Section>
+
+			{hasPRs ? <ReviewsSection onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : null}
 
 			{showCompletion ? <CompletionControls session={session} /> : null}
 

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -154,6 +154,7 @@ export function SessionInspector({
 	browserPoppedOut = false,
 	browserAnnotationQueue,
 	isInspectorVisible = true,
+	notificationAction,
 	onToggleBrowserPopOut,
 	onToggleVisibility,
 	onOpenFiles,
@@ -167,6 +168,7 @@ export function SessionInspector({
 	browserPoppedOut?: boolean;
 	browserAnnotationQueue?: BrowserAnnotationQueueModel;
 	isInspectorVisible?: boolean;
+	notificationAction?: ReactNode;
 	onToggleBrowserPopOut?: (next: boolean) => void;
 	onToggleVisibility?: () => void;
 	onOpenFiles?: () => void;
@@ -243,6 +245,7 @@ export function SessionInspector({
 						))}
 					</div>
 				) : null}
+				{isInspectorVisible ? notificationAction : null}
 				{isInspectorVisible ? (
 					<TopbarButton
 						aria-expanded="true"

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -17,6 +17,7 @@ import {
 	GitMerge,
 	Info,
 	MessageSquare,
+	PanelRightClose,
 	Play,
 	Trash2,
 	Loader2,
@@ -54,6 +55,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/t
 import { appI18n } from "../i18n";
 import type { MessageKey } from "../i18n";
 import { usesPreviewWorkspaceData as usePreviewData } from "../lib/preview-mode";
+import { TopbarButton } from "./TopbarButton";
 
 type ProjectConfig = components["schemas"]["ProjectConfig"];
 type PRReviewState = components["schemas"]["PRReviewState"];
@@ -61,9 +63,13 @@ type ReviewsResponse = components["schemas"]["ListReviewsResponse"];
 type ReviewRunFacts = components["schemas"]["ReviewRun"];
 type OpenReviewerTerminal = (target: { handleId: string; harness: string }) => void;
 
-export type InspectorView = "summary" | "browser" | "files";
+export type InspectorView = "summary" | "reviews" | "browser" | "files";
 
-const VIEW_DEFS: { id: InspectorView; labelKey: "inspector.summary" | "inspector.browser" | "inspector.files"; icon: ReactNode }[] = [
+const VIEW_DEFS: {
+	id: InspectorView;
+	labelKey: "inspector.summary" | "inspector.reviews" | "inspector.browser" | "inspector.files";
+	icon: ReactNode;
+}[] = [
 	{
 		id: "summary",
 		labelKey: "inspector.summary",
@@ -75,6 +81,15 @@ const VIEW_DEFS: { id: InspectorView; labelKey: "inspector.summary" | "inspector
 				<circle cx="4" cy="7" r="1" />
 				<circle cx="4" cy="12" r="1" />
 				<circle cx="4" cy="17" r="1" />
+			</svg>
+		),
+	},
+	{
+		id: "reviews",
+		labelKey: "inspector.reviews",
+		icon: (
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden="true">
+				<path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
 			</svg>
 		),
 	},
@@ -140,7 +155,7 @@ function VerdictBadge({ label, tone }: { label: string; tone: "neutral" | "runni
 }
 
 /**
- * Tabbed inspector rail beside the terminal (Summary · Browser · Files).
+ * Tabbed inspector rail beside the terminal (Summary · Reviews · Browser · Files).
  */
 export function SessionInspector({
 	session,
@@ -149,6 +164,7 @@ export function SessionInspector({
 	browserAnnotationQueue,
 	isInspectorVisible = true,
 	onToggleBrowserPopOut,
+	onToggleVisibility,
 	onOpenFiles,
 	filesView,
 	browserView,
@@ -161,6 +177,7 @@ export function SessionInspector({
 	browserAnnotationQueue?: BrowserAnnotationQueueModel;
 	isInspectorVisible?: boolean;
 	onToggleBrowserPopOut?: (next: boolean) => void;
+	onToggleVisibility?: () => void;
 	onOpenFiles?: () => void;
 	filesView?: ReactNode;
 	browserView?: BrowserViewModel;
@@ -196,47 +213,65 @@ export function SessionInspector({
 
 	return (
 		<aside className={inspectorShellClass} aria-label={t("inspector.aria")}>
-			<div className="flex h-inspector-tabs shrink-0 items-center gap-1 border-b border-border px-2.5" role="tablist">
-				{views.map((entry) => (
-					<button
-						aria-label={entry.label}
-						key={entry.id}
-						type="button"
-						role="tab"
-						aria-selected={view === entry.id}
-						className={cn(
-							"inline-flex h-control-md shrink-0 items-center justify-center gap-1.5 rounded-md px-1.5 text-sm-md font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
-							view === entry.id && "bg-interactive-active text-foreground",
-						)}
-						onClick={() => setView(entry.id)}
-						title={entry.label}
-					>
-						<span className="relative inline-flex shrink-0 [&_svg]:size-icon-md">
-							{entry.icon}
-							{entry.id === "browser" && browserUnseen ? (
-								<span
-									aria-hidden="true"
-									className="absolute -right-1 -top-1 inline-flex size-dot-sm"
-									data-testid="browser-unseen-indicator"
-								>
-									<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
-									<span className="relative inline-flex size-dot-sm rounded-full bg-primary ring-2 ring-background" />
+			<div className="session-inspector__topbar flex h-inspector-tabs shrink-0 items-center border-b border-border pl-2.5">
+				{isInspectorVisible ? (
+					<div className="flex min-w-0 flex-1 items-center gap-0.5" role="tablist">
+						{views.map((entry) => (
+							<button
+								aria-label={entry.label}
+								key={entry.id}
+								type="button"
+								role="tab"
+								aria-selected={view === entry.id}
+								className={cn(
+									"session-inspector__tab-button relative inline-flex h-control-md shrink-0 items-center justify-center rounded-md px-1.5 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
+									view === entry.id && "bg-interactive-active text-foreground",
+								)}
+								onClick={() => setView(entry.id)}
+								title={entry.label}
+							>
+								<span className="relative inline-flex shrink-0 [&_svg]:size-icon-md">
+									{entry.icon}
+									{entry.id === "browser" && browserUnseen ? (
+										<span
+											aria-hidden="true"
+											className="absolute right-0 top-0 inline-flex size-dot-sm"
+											data-testid="browser-unseen-indicator"
+										>
+											<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
+											<span className="relative inline-flex size-dot-sm rounded-full bg-primary ring-2 ring-background" />
+										</span>
+									) : null}
 								</span>
-							) : null}
-						</span>
-						<span className="truncate @max-[350px]/inspector:hidden">
-							{entry.id === "files" && filesChangedCount !== undefined
-								? t("files.tabCount", { count: filesChangedCount })
-								: entry.label}
-						</span>
-					</button>
-				))}
+								<span className="session-inspector__responsive-label whitespace-nowrap text-2xs">
+									{entry.id === "files" && filesChangedCount !== undefined
+										? t("files.tabCount", { count: filesChangedCount })
+										: entry.label}
+								</span>
+							</button>
+						))}
+					</div>
+				) : null}
+				{isInspectorVisible ? (
+					<TopbarButton
+						aria-expanded="true"
+						aria-label={t("shell.closeInspector")}
+						className="session-inspector__toggle ml-1.5 shrink-0"
+						onClick={onToggleVisibility}
+						title={t("shell.closeInspectorTitle")}
+						variant="icon"
+					>
+						<PanelRightClose className="size-icon-lg" aria-hidden="true" />
+					</TopbarButton>
+				) : null}
 			</div>
 
 			<div
+				aria-hidden={!isInspectorVisible}
 				className={cn(
 					inspectorBodyBaseClass,
 					view !== "browser" && view !== "files" && inspectorScrollableBodyClass,
+					!isInspectorVisible && "invisible pointer-events-none",
 					// Browser and Files own their viewport spacing. Keep their body
 					// padding out of the class list entirely so a shorthand `p-3`
 					// cannot win over `p-0` through generated utility ordering.
@@ -245,8 +280,14 @@ export function SessionInspector({
 						"session-inspector__body--browser p-0 overflow-hidden [&>[role=tabpanel]]:border-0 [&>[role=tabpanel]]:rounded-none",
 					view === "files" && "p-0 overflow-hidden [&>[role=tabpanel]]:h-full",
 				)}
+				inert={!isInspectorVisible}
 			>
-				{view === "summary" ? <SummaryView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : null}
+				{view === "summary" ? <SummaryView session={session} /> : null}
+				{view === "reviews" ? (
+					<div role="tabpanel">
+						<ReviewsSection onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />
+					</div>
+				) : null}
 				{view === "browser" ? (
 					<BrowserView
 						browserPoppedOut={browserPoppedOut}
@@ -298,13 +339,7 @@ function Section({
 	);
 }
 
-function SummaryView({
-	session,
-	onOpenReviewerTerminal,
-}: {
-	session: WorkspaceSession;
-	onOpenReviewerTerminal?: OpenReviewerTerminal;
-}) {
+function SummaryView({ session }: { session: WorkspaceSession }) {
 	const { t } = useTranslation();
 	const query = useSessionScmSummary(session.id);
 	const prSummaries = sessionPRDisplaySummaries(session, query.data);
@@ -325,8 +360,6 @@ function SummaryView({
 					)}
 				</div>
 			</Section>
-
-			{hasPRs ? <ReviewsSection onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : null}
 
 			{showCompletion ? <CompletionControls session={session} /> : null}
 

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -1163,6 +1163,18 @@ describe("SessionView", () => {
 		expect(document.querySelector(".files-popout-overlay")).not.toHaveClass("files-popout-overlay--mac-windowed");
 	});
 
+	it("opens a session on Summary even when an existing preview was previously selected", () => {
+		const worker = workerSession("sess-1");
+		worker.previewUrl = "http://localhost:5173/";
+		worker.previewRevision = 1;
+		act(() => useUiStore.getState().setInspectorView("sess-1", "browser"));
+
+		render(<SessionView sessionId="sess-1" />);
+
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+		expect(browserViewOptions.current).toMatchObject({ active: false });
+	});
+
 	it("opens the Browser tab for a new `ao preview` target without replacing the terminal", () => {
 		const worker = workerSession("sess-1");
 		const { rerender } = render(<SessionView sessionId="sess-1" />);
@@ -1196,7 +1208,7 @@ describe("SessionView", () => {
 		expect(handle.resize).toHaveBeenCalledWith("360px");
 	});
 
-	it("auto-opens first content, then glows for later preview work after the user leaves Browser", () => {
+	it("starts existing preview content on Summary, then glows for later preview work", () => {
 		const secondWorker = workerSession("sess-2");
 		secondWorker.previewUrl = "http://localhost:5173/";
 		secondWorker.previewRevision = 1;
@@ -1207,15 +1219,13 @@ describe("SessionView", () => {
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 
-		// The first content observed for this worker is immediately revealed.
+		// Existing content is the baseline for this visit and must not steal the
+		// default Summary tab.
 		rerender(<SessionView sessionId="sess-2" />);
-		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 		expect(browserUnseen("sess-2")).toBe(false);
 
-		// Once the user deliberately leaves Browser, later work must not steal
-		// the tab back. It marks Browser as unseen instead.
-		act(() => useUiStore.getState().setInspectorView("sess-2", "summary"));
-
+		// Later work must not steal the tab. It marks Browser as unseen instead.
 		secondWorker.previewRevision = 2;
 		rerender(<SessionView sessionId="sess-2" />);
 		expect(inspectorOpen("sess-2")).toBe(true);
@@ -1226,7 +1236,7 @@ describe("SessionView", () => {
 		expect(browserUnseen("sess-2")).toBe(false);
 	});
 
-	it("opens Browser when the first preview arrives with the async workspace response", () => {
+	it("keeps Summary when an existing preview arrives with the async workspace response", () => {
 		const secondWorker = workerSession("sess-2");
 		secondWorker.previewUrl = "http://localhost:5173/";
 		secondWorker.previewRevision = 1;
@@ -1241,7 +1251,7 @@ describe("SessionView", () => {
 
 		expect(inspectorOpen("sess-2")).toBe(true);
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
-		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 		const handle = panels.get("inspector")!.handle;
 		expect(handle.expand).not.toHaveBeenCalled();
 	});

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -817,17 +817,6 @@ describe("SessionView", () => {
 		expect(screen.getByTestId("panel-inspector")).toHaveClass("session-inspector-panel");
 	});
 
-	it("places the session topbar inside the terminal column so the inspector header shares the top row", () => {
-		render(<SessionView sessionId="sess-1" />);
-
-		const terminalPanel = screen.getByTestId("panel-terminal");
-		const inspectorPanel = screen.getByTestId("panel-inspector");
-		const host = within(terminalPanel).getByTestId("session-topbar-host");
-
-		expect(host).toHaveClass("h-inspector-tabs");
-		expect(inspectorPanel).not.toContainElement(host);
-	});
-
 	it("opens the Summary inspector alongside the terminal by default", () => {
 		render(<SessionView sessionId="sess-1" />);
 
@@ -1016,13 +1005,6 @@ describe("SessionView", () => {
 		expect(panelSizes("inspector")[0]).toBe("360px");
 	});
 
-	it("ignores the legacy percentage width and uses the uniform default", () => {
-		window.localStorage.setItem("ao.inspector.split", "40");
-		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
-		expect(panelSizes("inspector")[0]).toBe("360px");
-	});
-
 	// Regression: rrp only derives a panel's constraints one commit after it
 	// registers into a live group. Driving the imperative API in the commit
 	// where the inspector mounts (orchestrator → worker navigation; SessionView
@@ -1163,18 +1145,6 @@ describe("SessionView", () => {
 		expect(document.querySelector(".files-popout-overlay")).not.toHaveClass("files-popout-overlay--mac-windowed");
 	});
 
-	it("opens a session on Summary even when an existing preview was previously selected", () => {
-		const worker = workerSession("sess-1");
-		worker.previewUrl = "http://localhost:5173/";
-		worker.previewRevision = 1;
-		act(() => useUiStore.getState().setInspectorView("sess-1", "browser"));
-
-		render(<SessionView sessionId="sess-1" />);
-
-		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
-		expect(browserViewOptions.current).toMatchObject({ active: false });
-	});
-
 	it("opens the Browser tab for a new `ao preview` target without replacing the terminal", () => {
 		const worker = workerSession("sess-1");
 		const { rerender } = render(<SessionView sessionId="sess-1" />);
@@ -1234,26 +1204,6 @@ describe("SessionView", () => {
 
 		act(() => useUiStore.getState().setInspectorView("sess-2", "browser"));
 		expect(browserUnseen("sess-2")).toBe(false);
-	});
-
-	it("keeps Summary when an existing preview arrives with the async workspace response", () => {
-		const secondWorker = workerSession("sess-2");
-		secondWorker.previewUrl = "http://localhost:5173/";
-		secondWorker.previewRevision = 1;
-		workspaceQueryState.data = undefined;
-		workspaceQueryState.isLoading = true;
-
-		const { rerender } = render(<SessionView sessionId="sess-2" />);
-
-		workspaceQueryState.data = workspaces;
-		workspaceQueryState.isLoading = false;
-		rerender(<SessionView sessionId="sess-2" />);
-
-		expect(inspectorOpen("sess-2")).toBe(true);
-		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
-		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
-		const handle = panels.get("inspector")!.handle;
-		expect(handle.expand).not.toHaveBeenCalled();
 	});
 
 	it("glows for agent browser activity after the user leaves first content", () => {

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -277,14 +277,19 @@ vi.mock("./SessionInspector", () => ({
 		filesView,
 		onOpenFiles,
 		onToggleBrowserPopOut,
+		onToggleVisibility,
 		view,
 	}: {
 		filesView?: ReactNode;
 		onOpenFiles?: () => void;
 		onToggleBrowserPopOut?: () => void;
+		onToggleVisibility?: () => void;
 		view?: string;
 	}) => (
 		<div>
+			<button type="button" onClick={onToggleVisibility}>
+				close inspector
+			</button>
 			<button type="button" data-view={view} onClick={onToggleBrowserPopOut}>
 				pop browser
 			</button>
@@ -318,8 +323,21 @@ vi.mock("../hooks/useShellTerminals", () => ({
 // fake imperative handle per panel instead.
 vi.mock("./ui/resizable", () => ({
 	ResizablePanelGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-	ResizableHandle: ({ elementRef }: { elementRef?: Ref<HTMLDivElement | null> }) => (
+	ResizableHandle: ({
+		"aria-hidden": ariaHidden,
+		className,
+		disabled,
+		elementRef,
+	}: {
+		"aria-hidden"?: boolean;
+		className?: string;
+		disabled?: boolean;
+		elementRef?: Ref<HTMLDivElement | null>;
+	}) => (
 		<div
+			aria-hidden={ariaHidden}
+			className={className}
+			data-disabled={disabled ? "true" : undefined}
 			data-separator="inactive"
 			data-testid="resize-handle"
 			ref={(el) => {
@@ -784,24 +802,21 @@ describe("SessionView", () => {
 	// Regression: react-resizable-panels v4 treats bare numeric sizes as PIXELS
 	// (numbers were percentages in the older API the shadcn examples use).
 	// defaultSize={28}/maxSize={45} clamped the inspector rail to a 45px sliver.
-	// Every size must be an explicit percentage string.
-	it("sizes the terminal/inspector split in percentages, not pixels", () => {
+	// Every size must carry an explicit unit. The fixed 360px inspector width is
+	// the first width where every destination can show both icon and label.
+	it("gives the terminal and inspector constraints explicit, bounded units", () => {
 		render(<SessionView sessionId="sess-1" />);
 
-		for (const panelId of ["terminal", "inspector"]) {
-			const sizes = panelSizes(panelId);
-			expect(sizes.length).toBeGreaterThan(0);
-			for (const size of sizes) {
-				expect(size, `${panelId} size ${String(size)} must be a percentage string`).toMatch(/^\d+(\.\d+)?%$/);
-			}
-		}
+		expect(panelSizes("terminal")).toEqual(["72%", "50%"]);
+		expect(panelSizes("inspector")).toEqual(["360px", "360px", "50%"]);
+		expect(screen.getByTestId("panel-inspector")).toHaveClass("session-inspector-panel");
 	});
 
 	it("opens the Summary inspector alongside the terminal by default", () => {
 		render(<SessionView sessionId="sess-1" />);
 
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
-		expect(panelSizes("inspector")[0]).toBe("30%");
+		expect(panelSizes("inspector")[0]).toBe("360px");
 		// Open panels are non-collapsible so a drag clamps at minSize instead of
 		// snapping the rail away; only the closed panel is collapsible.
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("data-collapsible");
@@ -823,7 +838,7 @@ describe("SessionView", () => {
 	it("mounts the inspector open by default", () => {
 		render(<SessionView sessionId="sess-1" />);
 
-		expect(panelSizes("inspector")[0]).toMatch(/^[1-9]\d*(\.\d+)?%$/);
+		expect(panelSizes("inspector")[0]).toBe("360px");
 		const pane = screen.getByTestId("panel-inspector");
 		expect(pane).not.toHaveAttribute("inert");
 		expect(pane).toHaveAttribute("aria-hidden", "false");
@@ -838,6 +853,10 @@ describe("SessionView", () => {
 		const pane = screen.getByTestId("panel-inspector");
 		expect(pane).toHaveAttribute("inert");
 		expect(pane).toHaveAttribute("aria-hidden", "true");
+		const separator = screen.getByTestId("resize-handle");
+		expect(separator).toHaveAttribute("data-disabled", "true");
+		expect(separator).toHaveAttribute("aria-hidden", "true");
+		expect(separator).toHaveClass("w-0", "pointer-events-none", "after:hidden");
 		// Collapsed panels stay collapsible so the 0% size is a valid rrp state
 		// (and the separator can drag the rail back open).
 		expect(pane).toHaveAttribute("data-collapsible", "true");
@@ -880,7 +899,7 @@ describe("SessionView", () => {
 		// Opening resizes to the persisted split rather than expand(): the open
 		// panel re-registers as non-collapsible, and rrp's expand() no-ops on a
 		// non-collapsible panel.
-		expect(handle.resize).toHaveBeenCalledWith("30%");
+		expect(handle.resize).toHaveBeenCalledWith("360px");
 		expect(handle.collapse).not.toHaveBeenCalled();
 	});
 
@@ -895,11 +914,22 @@ describe("SessionView", () => {
 
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 		expect(inspectorOpen("sess-1")).toBe(true);
-		expect(handle.resize).toHaveBeenCalledWith("30%");
+		expect(handle.resize).toHaveBeenCalledWith("360px");
 
 		// Plain ⌘B belongs to the sidebar — the inspector must not react.
 		fireEvent.keyDown(window, { key: "b", metaKey: true });
 		expect(inspectorOpen("sess-1")).toBe(true);
+	});
+
+	it("wires the inspector header close control to the session panel state", () => {
+		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
+		render(<SessionView sessionId="sess-1" />);
+		const handle = panels.get("inspector")!.handle;
+
+		fireEvent.click(screen.getByRole("button", { name: "close inspector" }));
+
+		expect(inspectorOpen("sess-1")).toBe(false);
+		expect(handle.collapse).toHaveBeenCalledTimes(1);
 	});
 
 	it("persists drag resizes and never closes the store from a drag", () => {
@@ -912,14 +942,14 @@ describe("SessionView", () => {
 		// Dragging persists the width.
 		act(() => entry.onResize?.({ asPercentage: 31.5, inPixels: 400 }));
 		expect(inspectorOpen("sess-1")).toBe(true);
-		expect(window.localStorage.getItem("ao.inspector.split")).toBe("31.5");
+		expect(window.localStorage.getItem("ao.inspector.widthPx")).toBe("400");
 
 		// A drag can never auto-collapse the rail: even if a 0-size frame arrives
 		// mid-drag, the store stays open — collapse belongs to the explicit
 		// controls (topbar button / ⌘⇧B) only.
 		act(() => entry.onResize?.({ asPercentage: 0, inPixels: 0 }));
 		expect(inspectorOpen("sess-1")).toBe(true);
-		expect(window.localStorage.getItem("ao.inspector.split")).toBe("31.5");
+		expect(window.localStorage.getItem("ao.inspector.widthPx")).toBe("400");
 	});
 
 	it("reopens the store when a drag pulls the collapsed rail back open", () => {
@@ -931,7 +961,7 @@ describe("SessionView", () => {
 		act(() => entry.onResize?.({ asPercentage: 25, inPixels: 320 }));
 
 		expect(useUiStore.getState().inspectorSessions["sess-1"]).toMatchObject({ isOpen: true });
-		expect(window.localStorage.getItem("ao.inspector.split")).toBe("25");
+		expect(window.localStorage.getItem("ao.inspector.widthPx")).toBe("320");
 	});
 
 	// Regression: rrp v4 reports observed DOM sizes, so the flex-grow
@@ -953,14 +983,28 @@ describe("SessionView", () => {
 		act(() => useUiStore.getState().toggleInspector("sess-1"));
 		act(() => entry.onResize?.({ asPercentage: 12.4, inPixels: 160 }));
 		expect(inspectorOpen("sess-1")).toBe(false);
-		expect(window.localStorage.getItem("ao.inspector.split")).toBeNull();
+		expect(window.localStorage.getItem("ao.inspector.widthPx")).toBeNull();
 	});
 
-	it("restores the persisted split width", () => {
+	it("restores the persisted inspector width in pixels", () => {
+		window.localStorage.setItem("ao.inspector.widthPx", "400");
+		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
+		render(<SessionView sessionId="sess-1" />);
+		expect(panelSizes("inspector")[0]).toBe("400px");
+	});
+
+	it("clamps a persisted inspector width to the expanded minimum", () => {
+		window.localStorage.setItem("ao.inspector.widthPx", "240");
+		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
+		render(<SessionView sessionId="sess-1" />);
+		expect(panelSizes("inspector")[0]).toBe("360px");
+	});
+
+	it("ignores the legacy percentage width and uses the uniform default", () => {
 		window.localStorage.setItem("ao.inspector.split", "40");
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		render(<SessionView sessionId="sess-1" />);
-		expect(panelSizes("inspector")[0]).toBe("40%");
+		expect(panelSizes("inspector")[0]).toBe("360px");
 	});
 
 	// Regression: rrp only derives a panel's constraints one commit after it
@@ -978,7 +1022,9 @@ describe("SessionView", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		rerender(<SessionView sessionId="sess-1" />);
 
-		expect(panelSizes("inspector")[0]).toMatch(/^[1-9]\d*(\.\d+)?%$/);
+		expect(panelSizes("inspector")[0]).toBe("360px");
+		expect(screen.getByTestId("panel-inspector")).toHaveAttribute("aria-hidden", "false");
+		expect(document.querySelector(".session-inspector-motion")).toHaveAttribute("data-motion-state", "open");
 		const handle = panels.get("inspector")!.handle;
 		expect(handle.expand).not.toHaveBeenCalled();
 		expect(handle.collapse).not.toHaveBeenCalled();
@@ -1002,7 +1048,7 @@ describe("SessionView", () => {
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 
 		expect(inspectorOpen("sess-2")).toBe(true);
-		expect(handle.resize).toHaveBeenCalledWith("30%");
+		expect(handle.resize).toHaveBeenCalledWith("360px");
 	});
 
 	it("renders no inspector panel or handle for orchestrator sessions", () => {
@@ -1131,7 +1177,7 @@ describe("SessionView", () => {
 		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
 		expect(browserUnseen("sess-1")).toBe(false);
 		expect(browserViewOptions.current).toMatchObject({ active: true });
-		expect(handle.resize).toHaveBeenCalledWith("30%");
+		expect(handle.resize).toHaveBeenCalledWith("360px");
 	});
 
 	it("auto-opens first content, then glows for later preview work after the user leaves Browser", () => {
@@ -1141,7 +1187,7 @@ describe("SessionView", () => {
 
 		const { rerender } = render(<SessionView sessionId="sess-1" />);
 
-		expect(panelSizes("inspector")[0]).toBe("30%");
+		expect(panelSizes("inspector")[0]).toBe("360px");
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render as rtlRender, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { SessionView } from "./SessionView";
+import { SessionTopbarProvider } from "./SessionTopbarPortal";
 import { useUiStore } from "../stores/ui-store";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 
@@ -427,7 +428,11 @@ function render(ui: ReactNode) {
 	});
 	return {
 		...rtlRender(ui, {
-			wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>,
+			wrapper: ({ children }) => (
+				<QueryClientProvider client={client}>
+					<SessionTopbarProvider>{children}</SessionTopbarProvider>
+				</QueryClientProvider>
+			),
 		}),
 		client,
 	};
@@ -810,6 +815,17 @@ describe("SessionView", () => {
 		expect(panelSizes("terminal")).toEqual(["72%", "50%"]);
 		expect(panelSizes("inspector")).toEqual(["360px", "360px", "50%"]);
 		expect(screen.getByTestId("panel-inspector")).toHaveClass("session-inspector-panel");
+	});
+
+	it("places the session topbar inside the terminal column so the inspector header shares the top row", () => {
+		render(<SessionView sessionId="sess-1" />);
+
+		const terminalPanel = screen.getByTestId("panel-terminal");
+		const inspectorPanel = screen.getByTestId("panel-inspector");
+		const host = within(terminalPanel).getByTestId("session-topbar-host");
+
+		expect(host).toHaveClass("h-inspector-tabs");
+		expect(inspectorPanel).not.toContainElement(host);
 	});
 
 	it("opens the Summary inspector alongside the terminal by default", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
@@ -39,19 +39,24 @@ import { terminalTargetBelongsToSession, type TerminalTarget } from "../types/te
 import { matchesRendererShortcut } from "../stores/keybindings-store";
 import { useResolvedTheme, useUiStore, type InspectorView } from "../stores/ui-store";
 
-const INSPECTOR_MIN_PERCENT = 30;
-const INSPECTOR_MAX_PERCENT = 45;
-const inspectorSplitStorageKey = "ao.inspector.split";
+const INSPECTOR_DEFAULT_PX = 360;
+const INSPECTOR_DEFAULT_SIZE = `${INSPECTOR_DEFAULT_PX}px`;
+const INSPECTOR_MIN_PX = 360;
+const INSPECTOR_MIN_SIZE = `${INSPECTOR_MIN_PX}px`;
+const INSPECTOR_MAX_PERCENT = 50;
+const INSPECTOR_COLLAPSED_SIZE = "0%";
+const INSPECTOR_MOTION_MS = 240;
+const inspectorWidthStorageKey = "ao.inspector.widthPx";
 const shellTopbarHiddenByPlatform = hidesShellTopbar();
 
 type ReviewsResponse = components["schemas"]["ListReviewsResponse"];
 type ReviewerTerminalTarget = { handleId: string; harness: string };
 
-function initialSplitPercent(): number {
-	const raw = typeof window === "undefined" ? null : window.localStorage?.getItem(inspectorSplitStorageKey);
+function initialInspectorSize(): string {
+	const raw = typeof window === "undefined" ? null : window.localStorage?.getItem(inspectorWidthStorageKey);
 	const parsed = raw === null ? Number.NaN : Number(raw);
-	if (!Number.isFinite(parsed)) return INSPECTOR_MIN_PERCENT;
-	return Math.min(INSPECTOR_MAX_PERCENT, Math.max(INSPECTOR_MIN_PERCENT, parsed));
+	if (!Number.isFinite(parsed)) return INSPECTOR_DEFAULT_SIZE;
+	return `${Math.max(INSPECTOR_MIN_PX, Math.round(parsed))}px`;
 }
 
 function previewRevealKey(previewUrl?: string, previewRevision?: number): string {
@@ -92,9 +97,9 @@ type SessionViewProps = {
 // The panel is `collapsible` only while closed: rrp snaps a collapsible panel
 // to 0% when a drag crosses minSize, so an always-collapsible inspector let a
 // drag vanish the rail. While open the panel is non-collapsible and a drag
-// hard-stops at INSPECTOR_MIN_PERCENT; only the explicit controls collapse it.
+// hard-stops at INSPECTOR_MIN_SIZE; only the explicit controls collapse it.
 // Content keeps a stable min-width inside the clipped panel so nothing reflows
-// mid-animation; split width persists.
+// mid-animation; the persisted pixel width is clamped by the panel constraints.
 export function SessionView({ sessionId }: SessionViewProps) {
 	const { t } = useTranslation();
 	const workspaceQuery = useWorkspaceQuery();
@@ -111,6 +116,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const { daemonStatus } = useShell();
 	const inspectorRef = useRef<PanelImperativeHandle | null>(null);
 	const inspectorSeparatorRef = useRef<HTMLDivElement | null>(null);
+	const [inspectorMotionState, setInspectorMotionState] = useState<"closed" | "closing" | "open" | "opening">(
+		isInspectorOpen ? "open" : "closed",
+	);
 	const [terminalTarget, setTerminalTarget] = useState<TerminalTarget>({ kind: "worker" });
 	const [browserPopOutState, setBrowserPopOutState] = useState({ sessionId, poppedOut: false });
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
@@ -532,9 +540,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	if (!hasInspector) {
 		inspectorDefaultSizeRef.current = null;
 	} else if (inspectorDefaultSizeRef.current === null) {
-		inspectorDefaultSizeRef.current = isInspectorOpen ? `${initialSplitPercent()}%` : "0%";
+		inspectorDefaultSizeRef.current = isInspectorOpen ? initialInspectorSize() : INSPECTOR_COLLAPSED_SIZE;
 	}
-	const inspectorDefaultSize = inspectorDefaultSizeRef.current ?? "0%";
+	const inspectorDefaultSize = inspectorDefaultSizeRef.current ?? INSPECTOR_COLLAPSED_SIZE;
 
 	useEffect(() => {
 		if (!hasInspector) return;
@@ -547,26 +555,32 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [hasInspector, sessionId, toggleInspector]);
 
-	// Drive the collapsible panel from the store so the topbar button, ⌘⇧B, and
-	// drag-to-reopen all stay in sync. When the inspector panel mounts into
+	// Drive the collapsible panel from the store so the inspector controls and
+	// ⌘⇧B stay in sync. When the inspector panel mounts into
 	// the already-live group (orchestrator/loading → worker), rrp only derives
 	// the new panel's constraints in the next commit. This effect intentionally
 	// runs before the readiness effect below, so mount and StrictMode's effect
 	// replay remain imperative-free; later store changes can safely drive the
 	// registered panel.
 	const inspectorImperativeReadyRef = useRef(false);
+	useLayoutEffect(() => {
+		if (!hasInspector) {
+			setInspectorMotionState("closed");
+			return;
+		}
+		if (!inspectorImperativeReadyRef.current) {
+			setInspectorMotionState(isInspectorOpen ? "open" : "closed");
+		}
+	}, [hasInspector, isInspectorOpen]);
 	useEffect(() => {
 		if (!hasInspector || !inspectorImperativeReadyRef.current) return;
 		const panel = inspectorRef.current;
 		if (!panel) return;
 		if (isInspectorOpen) {
-			// resize(), not expand(): by the time this effect runs the panel has
-			// re-registered as non-collapsible (open panels refuse drag-collapse),
-			// and rrp's expand() no-ops on a non-collapsible panel. resize() also
-			// restores the persisted split regardless of what "most recent size"
-			// rrp remembers, which is 0 when the panel mounted collapsed.
-			panel.resize(`${initialSplitPercent()}%`);
-			return;
+			setInspectorMotionState("opening");
+			panel.resize(initialInspectorSize());
+			const frame = window.requestAnimationFrame(() => setInspectorMotionState("open"));
+			return () => window.cancelAnimationFrame(frame);
 		}
 		// Closing flips `collapsible` back on in this same commit, but rrp only
 		// re-derives the group's constraints in the follow-up commit its
@@ -574,9 +588,14 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		// open panel's non-collapsible constraints and no-ops. Repeat it on the
 		// next frame, when the fresh constraints have landed; collapse() is
 		// idempotent, so the double call is safe wherever the derivation lands.
+		setInspectorMotionState("closing");
 		panel.collapse();
 		const frame = window.requestAnimationFrame(() => panel.collapse());
-		return () => window.cancelAnimationFrame(frame);
+		const timer = window.setTimeout(() => setInspectorMotionState("closed"), INSPECTOR_MOTION_MS);
+		return () => {
+			window.clearTimeout(timer);
+			window.cancelAnimationFrame(frame);
+		};
 	}, [hasInspector, isInspectorOpen]);
 	useEffect(() => {
 		if (!hasInspector || !inspectorRef.current) {
@@ -589,8 +608,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		};
 	}, [hasInspector]);
 
-	// Persist drags and mirror a drag-reopen (dragging the separator of a
-	// collapsed inspector past the snap point) back into the store. Dragging an
+	// Persist drags while the inspector is open. Dragging an
 	// open inspector can never collapse it — the panel is non-collapsible while
 	// open, so rrp clamps the drag at minSize instead of snapping to 0%.
 	// Read the store imperatively to avoid a stale closure.
@@ -611,13 +629,14 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const handleInspectorResize = useCallback(
 		(size: PanelSize) => {
 			if (inspectorSeparatorRef.current?.getAttribute("data-separator") !== "active") return;
-			if (size.asPercentage <= 0) return;
-			window.localStorage?.setItem(inspectorSplitStorageKey, String(size.asPercentage));
+			if (size.inPixels <= 0) return;
+			window.localStorage?.setItem(inspectorWidthStorageKey, String(Math.round(size.inPixels)));
 			const currentOpen = useUiStore.getState().inspectorSessions[sessionId]?.isOpen ?? true;
 			if (!currentOpen) toggleInspector(sessionId);
 		},
 		[sessionId, toggleInspector],
 	);
+	const inspectorPanelVisible = inspectorMotionState !== "closed";
 
 	if (!session && !workspaceQuery.isLoading) {
 		return (
@@ -629,12 +648,22 @@ export function SessionView({ sessionId }: SessionViewProps) {
 
 	return (
 		<div className="relative flex h-full min-h-0 flex-col bg-background text-foreground" data-testid="session-detail">
-			<ResizablePanelGroup className="session-split min-h-0 flex-1" id="session-workspace" orientation="horizontal">
+			<ResizablePanelGroup
+				className="session-split min-h-0 flex-1"
+				id="session-workspace"
+				orientation="horizontal"
+				style={{ "--session-inspector-max-width": `${INSPECTOR_MAX_PERCENT}%` } as CSSProperties}
+			>
 				{/* react-resizable-panels v4: bare numbers are PIXELS; percentages must
             be strings. Numeric sizes here once clamped the inspector to 45px. */}
 				{/* RRP's inner panel defaults to overflow:auto. Nothing scrolls at pane level,
 				    so clip the chat rail's active marker instead of creating a horizontal scrollbar. */}
-				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%" style={{ overflow: "hidden" }}>
+				<ResizablePanel
+					defaultSize="72%"
+					id="terminal"
+					minSize={`${100 - INSPECTOR_MAX_PERCENT}%`}
+					style={{ overflow: "hidden" }}
+				>
 					<div className="relative h-full min-h-0">
 						{/* The committed mode owns the agent surface. Auxiliary shell and
 						    reviewer targets remain terminal surfaces in either mode. */}
@@ -680,24 +709,33 @@ export function SessionView({ sessionId }: SessionViewProps) {
 				{hasInspector ? (
 					<>
 						<ResizableHandle
-							className="w-1.75 cursor-col-resize touch-none bg-transparent after:w-px after:bg-border-strong hover:after:bg-border focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:after:bg-border data-[separator=active]:after:bg-border"
+							aria-hidden={!inspectorPanelVisible}
+							className={cn(
+								"w-1.75 cursor-col-resize touch-none bg-transparent transition-[width] duration-200 ease-out after:w-px after:bg-border-strong hover:after:bg-border focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:after:bg-border data-[separator=active]:after:bg-border",
+								!inspectorPanelVisible && "pointer-events-none w-0 after:hidden",
+							)}
+							disabled={!isInspectorOpen}
 							elementRef={inspectorSeparatorRef}
 						/>
 						<ResizablePanel
-							aria-hidden={!isInspectorOpen}
+							aria-hidden={!inspectorPanelVisible}
+							className="session-inspector-panel"
 							collapsible={!isInspectorOpen}
 							defaultSize={inspectorDefaultSize}
 							id="inspector"
 							inert={!isInspectorOpen}
 							maxSize={`${INSPECTOR_MAX_PERCENT}%`}
-							minSize={`${INSPECTOR_MIN_PERCENT}%`}
+							minSize={INSPECTOR_MIN_SIZE}
 							onResize={handleInspectorResize}
 							panelRef={inspectorRef}
 							style={{ overflow: "hidden" }}
 						>
-							{/* Stable content width while the panel animates (yyork pattern):
+							{/* Stable content width while the panel animates:
                   the pane clips instead of reflowing the inspector mid-collapse. */}
-							<div className="h-full min-w-inspector-min">
+							<div
+								className="session-inspector-motion h-full min-w-inspector-min"
+								data-motion-state={inspectorMotionState}
+							>
 								<SessionInspector
 									browserAnnotationQueue={browserAnnotationQueue}
 									browserPoppedOut={browserPoppedOut}
@@ -706,10 +744,11 @@ export function SessionView({ sessionId }: SessionViewProps) {
 											<SessionFilesView onToggleMaximized={handleToggleFilesPopOut} sessionId={session.id} />
 										) : null
 									}
-									isInspectorVisible={isInspectorOpen}
+									isInspectorVisible={inspectorPanelVisible}
 									onOpenFiles={handleOpenFiles}
 									onOpenReviewerTerminal={selectReviewerTerminal}
 									onToggleBrowserPopOut={handleToggleBrowserPopOut}
+									onToggleVisibility={() => toggleInspector(sessionId)}
 									onViewChange={(next: InspectorView) => setInspectorViewForSession(sessionId, next)}
 									view={inspectorView}
 									browserView={browserView}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -16,6 +16,7 @@ import {
 	SessionInterfaceTransitionNotice,
 } from "./SessionInterfaceSwitch";
 import { ShellTopbar } from "./ShellTopbar";
+import { SessionTopbarHost } from "./SessionTopbarPortal";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "./ui/resizable";
 import { useBrowserView } from "../hooks/useBrowserView";
 import {
@@ -664,46 +665,52 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					minSize={`${100 - INSPECTOR_MAX_PERCENT}%`}
 					style={{ overflow: "hidden" }}
 				>
-					<div className="relative h-full min-h-0">
-						{/* The committed mode owns the agent surface. Auxiliary shell and
-						    reviewer targets remain terminal surfaces in either mode. */}
-						{showChatSurface ? (
-							<SessionChatSurface
-								session={session}
-								headerActions={sessionHeaderActions}
-								controllerTransitioning={chatControllerTransitioning}
-								onOpenShell={addShellTerminal}
-								openingShell={openShellTerminal.isPending}
-								shellError={
-									openShellTerminal.error ? apiErrorMessage(openShellTerminal.error) : undefined
-								}
-							/>
-						) : (
-							<CenterPane
-								agentInputDisabled={
-									(interfaceSwitch.starting || activeInterfaceTransition) && session?.mode === "tui"
-								}
-								daemonReady={daemonStatus.state === "ready"}
-								onCloseShellTerminal={closeShellTerminalByHandle}
-								onNewShellTerminal={addShellTerminal}
-								onRenameShellTerminal={renameShellTerminalByHandle}
-								onSelectSessionTerminal={selectSessionTerminal}
-								onSelectReviewerTerminal={selectReviewerTerminal}
-								onSelectShellTerminal={selectShellTerminal}
-								reviewerTerminal={reviewerTerminal}
-								session={session}
-								shellTerminals={shellTerminals}
-								terminalTarget={routedTerminalTarget}
-								theme={theme}
-								topbarActions={sessionHeaderActions}
-							/>
-						)}
-						{interfaceSwitch.transition?.id !== dismissedTransitionID ? (
-							<SessionInterfaceTransitionNotice
-								transition={interfaceSwitch.transition}
-								onDismiss={() => setDismissedTransitionID(interfaceSwitch.transition?.id ?? "")}
-							/>
-						) : null}
+					<div className="relative flex h-full min-h-0 flex-col">
+						<SessionTopbarHost
+							className="relative z-chrome flex h-inspector-tabs w-full shrink-0 overflow-hidden"
+							data-testid="session-topbar-host"
+						/>
+						<div className="relative min-h-0 flex-1">
+							{/* The committed mode owns the agent surface. Auxiliary shell and
+							    reviewer targets remain terminal surfaces in either mode. */}
+							{showChatSurface ? (
+								<SessionChatSurface
+									session={session}
+									headerActions={sessionHeaderActions}
+									controllerTransitioning={chatControllerTransitioning}
+									onOpenShell={addShellTerminal}
+									openingShell={openShellTerminal.isPending}
+									shellError={
+										openShellTerminal.error ? apiErrorMessage(openShellTerminal.error) : undefined
+									}
+								/>
+							) : (
+								<CenterPane
+									agentInputDisabled={
+										(interfaceSwitch.starting || activeInterfaceTransition) && session?.mode === "tui"
+									}
+									daemonReady={daemonStatus.state === "ready"}
+									onCloseShellTerminal={closeShellTerminalByHandle}
+									onNewShellTerminal={addShellTerminal}
+									onRenameShellTerminal={renameShellTerminalByHandle}
+									onSelectSessionTerminal={selectSessionTerminal}
+									onSelectReviewerTerminal={selectReviewerTerminal}
+									onSelectShellTerminal={selectShellTerminal}
+									reviewerTerminal={reviewerTerminal}
+									session={session}
+									shellTerminals={shellTerminals}
+									terminalTarget={routedTerminalTarget}
+									theme={theme}
+									topbarActions={sessionHeaderActions}
+								/>
+							)}
+							{interfaceSwitch.transition?.id !== dismissedTransitionID ? (
+								<SessionInterfaceTransitionNotice
+									transition={interfaceSwitch.transition}
+									onDismiss={() => setDismissedTransitionID(interfaceSwitch.transition?.id ?? "")}
+								/>
+							) : null}
+						</div>
 					</div>
 				</ResizablePanel>
 				{hasInspector ? (

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -7,6 +7,7 @@ import type { components } from "../../api/schema";
 import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
 import { SessionChatSurface } from "./chat/SessionChatSurface";
+import { NotificationCenter } from "./NotificationCenter";
 import { SessionFilesView } from "./SessionFilesView";
 import { SessionInspector } from "./SessionInspector";
 import {
@@ -780,6 +781,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 										) : null
 									}
 									isInspectorVisible={inspectorPanelVisible}
+									notificationAction={isInspectorOpen ? <NotificationCenter /> : undefined}
 									onOpenFiles={handleOpenFiles}
 									onOpenReviewerTerminal={selectReviewerTerminal}
 									onToggleBrowserPopOut={handleToggleBrowserPopOut}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -117,6 +117,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const { daemonStatus } = useShell();
 	const inspectorRef = useRef<PanelImperativeHandle | null>(null);
 	const inspectorSeparatorRef = useRef<HTMLDivElement | null>(null);
+	const initializedInspectorSessionIdRef = useRef<string | null>(null);
 	const [inspectorMotionState, setInspectorMotionState] = useState<"closed" | "closing" | "open" | "opening">(
 		isInspectorOpen ? "open" : "closed",
 	);
@@ -393,6 +394,33 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// content here either — otherwise a merged/terminated session with an old
 	// preview auto-opens Browser onto a view the hook has already torn down.
 	const hasBrowserContent = !terminated && Boolean(previewUrl || browserUrl);
+
+	// Entering a session always starts on Summary. Treat browser content that
+	// already existed when the route resolved as the baseline for that visit;
+	// only preview work arriving afterward may reveal Browser automatically.
+	useLayoutEffect(() => {
+		if (!session || initializedInspectorSessionIdRef.current === sessionId) return;
+		initializedInspectorSessionIdRef.current = sessionId;
+		if (!hasInspector) return;
+		const current = useUiStore.getState().inspectorSessions[sessionId];
+		setInspectorViewForSession(sessionId, "summary");
+		if (current?.browserContentRevealed === undefined) {
+			setBrowserContentRevealed(sessionId, hasBrowserContent);
+		}
+		if (current?.previewKey === undefined) {
+			markInspectorPreviewSeen(sessionId, previewRevealKey(previewUrl, previewRevision));
+		}
+	}, [
+		hasBrowserContent,
+		hasInspector,
+		markInspectorPreviewSeen,
+		previewRevision,
+		previewUrl,
+		session,
+		sessionId,
+		setBrowserContentRevealed,
+		setInspectorViewForSession,
+	]);
 
 	useLayoutEffect(() => {
 		setTerminalTarget({ kind: "worker" });

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -304,18 +304,14 @@ describe("ShellTopbar orchestrator actions", () => {
 });
 
 describe("ShellTopbar inspector state", () => {
-	it("treats missing worker inspector state as open", async () => {
+	it("leaves closing to the inspector header while the worker rail is open", () => {
 		renderTopbarSessions([worker], "sess-1");
 
-		const toggle = screen.getByRole("button", { name: "Close inspector panel" });
-		expect(toggle).toHaveAttribute("aria-pressed", "true");
-
-		await userEvent.click(toggle);
-
-		expect(useUiStore.getState().inspectorSessions["sess-1"]).toEqual({ isOpen: false, view: "summary" });
+		expect(screen.queryByRole("button", { name: "Close inspector panel" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Open inspector panel" })).not.toBeInTheDocument();
 	});
 
-	it("routes aria-pressed to the current worker session", () => {
+	it("shows the reopen control only for the current collapsed worker", () => {
 		useUiStore.setState({
 			inspectorSessions: {
 				"sess-1": { isOpen: true, view: "summary" },
@@ -324,7 +320,8 @@ describe("ShellTopbar inspector state", () => {
 		});
 		const view = renderTopbarSessions([worker, secondWorker], "sess-1");
 
-		expect(screen.getByRole("button", { name: "Close inspector panel" })).toHaveAttribute("aria-pressed", "true");
+		expect(screen.queryByRole("button", { name: "Close inspector panel" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Open inspector panel" })).not.toBeInTheDocument();
 
 		paramsMock.sessionId = "sess-2";
 		view.rerenderTopbar();

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -340,6 +340,17 @@ describe("ShellTopbar inspector state", () => {
 		expect(controls.at(-1)).toBe(toggle);
 	});
 
+	it("leaves notifications to the inspector header while the inspector is open", () => {
+		useUiStore.setState({
+			inspectorSessions: {
+				"sess-1": { isOpen: true, view: "summary" },
+			},
+		});
+		renderTopbarSessions([worker], "sess-1");
+
+		expect(screen.queryByRole("button", { name: "Notifications" })).not.toBeInTheDocument();
+	});
+
 	it("toggles only the current worker session", async () => {
 		useUiStore.setState({
 			inspectorSessions: {

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -306,13 +306,6 @@ describe("ShellTopbar orchestrator actions", () => {
 });
 
 describe("ShellTopbar inspector state", () => {
-	it("leaves closing to the inspector header while the worker rail is open", () => {
-		renderTopbarSessions([worker], "sess-1");
-
-		expect(screen.queryByRole("button", { name: "Close inspector panel" })).not.toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: "Open inspector panel" })).not.toBeInTheDocument();
-	});
-
 	it("shows the reopen control only for the current collapsed worker", () => {
 		useUiStore.setState({
 			inspectorSessions: {

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -340,17 +340,6 @@ describe("ShellTopbar inspector state", () => {
 		expect(controls.at(-1)).toBe(toggle);
 	});
 
-	it("leaves notifications to the inspector header while the inspector is open", () => {
-		useUiStore.setState({
-			inspectorSessions: {
-				"sess-1": { isOpen: true, view: "summary" },
-			},
-		});
-		renderTopbarSessions([worker], "sess-1");
-
-		expect(screen.queryByRole("button", { name: "Notifications" })).not.toBeInTheDocument();
-	});
-
 	it("toggles only the current worker session", async () => {
 		useUiStore.setState({
 			inspectorSessions: {

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -49,7 +49,9 @@ vi.mock("../lib/telemetry", () => ({
 	captureRendererException: vi.fn(),
 }));
 vi.mock("./NewTaskDialog", () => ({ NewTaskDialog: () => null }));
-vi.mock("./NotificationCenter", () => ({ NotificationCenter: () => null }));
+vi.mock("./NotificationCenter", () => ({
+	NotificationCenter: () => <button aria-label="Notifications" type="button" />,
+}));
 
 const worker: WorkspaceSession = {
 	id: "sess-1",
@@ -327,6 +329,22 @@ describe("ShellTopbar inspector state", () => {
 		view.rerenderTopbar();
 
 		expect(screen.getByRole("button", { name: "Open inspector panel" })).toHaveAttribute("aria-pressed", "false");
+	});
+
+	it("keeps the collapsed inspector toggle at the far right after notifications", () => {
+		useUiStore.setState({
+			inspectorSessions: {
+				"sess-1": { isOpen: false, view: "summary" },
+			},
+		});
+		renderTopbarSessions([worker], "sess-1");
+
+		const toggle = screen.getByRole("button", { name: "Open inspector panel" });
+		const notification = screen.getByRole("button", { name: "Notifications" });
+		const controls = within(toggle.closest("header") as HTMLElement).getAllByRole("button");
+
+		expect(controls.indexOf(notification)).toBeLessThan(controls.indexOf(toggle));
+		expect(controls.at(-1)).toBe(toggle);
 	});
 
 	it("toggles only the current worker session", async () => {

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { GitBranch, PanelRightClose, PanelRightOpen, Plus, Trash2 } from "lucide-react";
+import { GitBranch, PanelRightOpen, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { animate, LayoutGroup, motion, useMotionValue, useReducedMotion } from "motion/react";
 import { NotificationCenter } from "./NotificationCenter";
@@ -323,23 +323,20 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 										: t("shell.orchestrator")}
 							</TopbarButton>
 						)}
-						{/* Inspector collapse (worker sessions only — orchestrators have no rail). */}
-						{!isOrchestrator && (
+						{/* The inspector header owns closing; the shell only restores a fully
+						    collapsed worker rail. Orchestrators have no inspector. */}
+						{!isOrchestrator && !isInspectorOpen ? (
 							<TopbarButton
-								aria-label={isInspectorOpen ? t("shell.closeInspector") : t("shell.openInspector")}
-								aria-pressed={isInspectorOpen}
+								aria-label={t("shell.openInspector")}
+								aria-pressed="false"
 								onClick={handleToggleInspector}
 								style={noDragStyle}
-								title={isInspectorOpen ? t("shell.closeInspectorTitle") : t("shell.openInspectorTitle")}
+								title={t("shell.openInspectorTitle")}
 								variant="icon"
 							>
-								{isInspectorOpen ? (
-									<PanelRightClose className="size-5" aria-hidden="true" />
-								) : (
-									<PanelRightOpen className="size-5" aria-hidden="true" />
-								)}
+								<PanelRightOpen className="size-icon-lg" aria-hidden="true" />
 							</TopbarButton>
-						)}
+						) : null}
 					</>
 				) : null}
 				{/* The bell always trails the actions row, on every platform. */}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -325,8 +325,10 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 						)}
 					</>
 				) : null}
-				{/* Notifications trail the primary actions but stay left of the inspector toggle. */}
-				<NotificationCenter style={noDragStyle} />
+				{/* The expanded inspector owns the notification action beside its close toggle. */}
+				{!(isSessionRoute && !isOrchestrator && isInspectorOpen) ? (
+					<NotificationCenter style={noDragStyle} />
+				) : null}
 				{/* The inspector header owns closing; the shell only restores a fully
 				    collapsed worker rail. Keep this final so it remains at the far right. */}
 				{isSessionRoute && !isOrchestrator && !isInspectorOpen ? (

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -323,24 +323,24 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 										: t("shell.orchestrator")}
 							</TopbarButton>
 						)}
-						{/* The inspector header owns closing; the shell only restores a fully
-						    collapsed worker rail. Orchestrators have no inspector. */}
-						{!isOrchestrator && !isInspectorOpen ? (
-							<TopbarButton
-								aria-label={t("shell.openInspector")}
-								aria-pressed="false"
-								onClick={handleToggleInspector}
-								style={noDragStyle}
-								title={t("shell.openInspectorTitle")}
-								variant="icon"
-							>
-								<PanelRightOpen className="size-icon-lg" aria-hidden="true" />
-							</TopbarButton>
-						) : null}
 					</>
 				) : null}
-				{/* The bell always trails the actions row, on every platform. */}
+				{/* Notifications trail the primary actions but stay left of the inspector toggle. */}
 				<NotificationCenter style={noDragStyle} />
+				{/* The inspector header owns closing; the shell only restores a fully
+				    collapsed worker rail. Keep this final so it remains at the far right. */}
+				{isSessionRoute && !isOrchestrator && !isInspectorOpen ? (
+					<TopbarButton
+						aria-label={t("shell.openInspector")}
+						aria-pressed="false"
+						onClick={handleToggleInspector}
+						style={noDragStyle}
+						title={t("shell.openInspectorTitle")}
+						variant="icon"
+					>
+						<PanelRightOpen className="size-icon-lg" aria-hidden="true" />
+					</TopbarButton>
+				) : null}
 			</div>
 		</motion.header>
 	</LayoutGroup>

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -11,7 +11,7 @@ import { SettingsDialog } from "../components/SettingsDialog";
 import { KeyboardShortcutsDialog } from "../components/KeyboardShortcutsDialog";
 import { KeyboardShortcutsSettingsDialog } from "../components/settings/KeyboardShortcutsSettingsDialog";
 import { ShellTopbar } from "../components/ShellTopbar";
-import { SessionTopbarHost, SessionTopbarProvider } from "../components/SessionTopbarPortal";
+import { SessionTopbarProvider } from "../components/SessionTopbarPortal";
 import { OrchestratorReplacementDialog } from "../components/OrchestratorReplacementDialog";
 import { Sidebar } from "../components/Sidebar";
 import { SidebarProvider } from "../components/ui/sidebar";
@@ -730,12 +730,6 @@ function ShellLayout() {
 								) : (
 							// Platform hides shell topbar: full-height panel; session mounts actions in-panel.
 							<CenterPanelShell className={routeParams.sessionId ? "center-panel-shell--session" : undefined}>
-								{routeParams.sessionId ? (
-									<SessionTopbarHost
-										className="relative z-chrome flex h-inspector-tabs w-full shrink-0 overflow-hidden"
-										data-testid="session-topbar-host"
-									/>
-								) : null}
 								<div className="flex min-h-0 flex-1 flex-col">
 									<Outlet />
 								</div>
@@ -743,12 +737,7 @@ function ShellLayout() {
 						)
 					) : framedAppTopbar ? (
 						<CenterPanelShell className={routeParams.sessionId ? "center-panel-shell--session" : undefined}>
-							{routeParams.sessionId ? (
-								<SessionTopbarHost
-									className="relative z-chrome flex h-inspector-tabs w-full shrink-0 overflow-hidden"
-									data-testid="session-topbar-host"
-								/>
-							) : (
+							{routeParams.sessionId ? null : (
 								<ShellTopbar />
 							)}
 							<div className="flex min-h-0 flex-1 flex-col">
@@ -757,12 +746,6 @@ function ShellLayout() {
 						</CenterPanelShell>
 					) : (
 						<CenterPanelShell className={routeParams.sessionId ? "center-panel-shell--session" : undefined}>
-							{routeParams.sessionId ? (
-								<SessionTopbarHost
-									className="relative z-chrome flex h-inspector-tabs w-full shrink-0 overflow-hidden"
-									data-testid="session-topbar-host"
-								/>
-							) : null}
 							<div className="flex min-h-0 flex-1 flex-col">
 								<Outlet />
 							</div>

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -27,7 +27,7 @@ export type SettingsModal =
 
 /** Worker detail view toggles — Changes (Git rail) is the default. */
 export type WorkbenchTab = "changes" | "files" | "terminal";
-export type InspectorView = "summary" | "browser" | "files";
+export type InspectorView = "summary" | "reviews" | "browser" | "files";
 
 export type InspectorSessionState = {
 	isOpen: boolean;

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -27,7 +27,7 @@ export type SettingsModal =
 
 /** Worker detail view toggles — Changes (Git rail) is the default. */
 export type WorkbenchTab = "changes" | "files" | "terminal";
-export type InspectorView = "summary" | "reviews" | "browser" | "files";
+export type InspectorView = "summary" | "browser" | "files";
 
 export type InspectorSessionState = {
 	isOpen: boolean;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2384,13 +2384,71 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	color: var(--fg);
 }
 
-/* Do not animate the inspector's flex-grow. The sibling is a live xterm WebGL
- * surface: interpolating this value makes ResizeObserver fit the terminal at
- * every intermediate width, reallocating the renderer and eventually causing
- * a PTY/SIGWINCH repaint. The inspector still opens and closes atomically, and
- * direct separator drags remain interactive. */
-.session-split #inspector[data-panel] {
+/* Match the left sidebar's spring-like reveal while keeping direct separator
+ * drags under the pointer. Both panels participate so neither edge snaps. */
+.session-split > [data-panel] {
+	transition: flex-grow 240ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.session-split > .session-inspector-panel[data-panel] {
+	max-width: var(--session-inspector-max-width, 50%);
+}
+
+.session-split:has([data-separator="active"]) > [data-panel] {
 	transition: none;
+}
+
+.session-inspector-motion {
+	opacity: 1;
+	transform: translateX(0);
+	transition:
+		opacity 150ms cubic-bezier(0.2, 0.8, 0.2, 1),
+		transform 150ms cubic-bezier(0.2, 0.8, 0.2, 1);
+	will-change: opacity, transform;
+}
+
+.session-inspector-motion[data-motion-state="opening"],
+.session-inspector-motion[data-motion-state="closing"],
+.session-inspector-motion[data-motion-state="closed"] {
+	opacity: 0;
+	transform: translateX(12px);
+}
+
+.session-inspector__topbar {
+	background: var(--bg);
+	color: var(--fg);
+	user-select: none;
+}
+
+.session-inspector__tab-button {
+	gap: 0;
+}
+
+.session-inspector__responsive-label {
+	max-width: 5.5rem;
+	margin-left: var(--space-1);
+	overflow: hidden;
+	opacity: 1;
+	transform: translateX(0);
+	transition:
+		max-width 170ms cubic-bezier(0.2, 0.8, 0.2, 1),
+		margin-left 170ms cubic-bezier(0.2, 0.8, 0.2, 1),
+		opacity 120ms ease-out,
+		transform 170ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@container inspector (max-width: 359px) {
+	.session-inspector__responsive-label {
+		max-width: 0;
+		margin-left: 0;
+		opacity: 0;
+		transform: translateX(-4px);
+	}
+}
+
+.session-inspector__toggle {
+	-webkit-app-region: no-drag;
+	margin-right: var(--space-2);
 }
 
 .inspector-section {
@@ -3360,9 +3418,45 @@ html[data-native-browser-composition="true"] .browser-popout-overlay {
 	animation: notification-row-in 180ms cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
 }
 
+@keyframes notification-popover-in {
+	from {
+		opacity: 0;
+		transform: translateY(-5px) scale(0.985);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}
+
+@keyframes notification-popover-out {
+	from {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+	to {
+		opacity: 0;
+		transform: translateY(-3px) scale(0.99);
+	}
+}
+
+.notification-popover[data-state="open"] {
+	animation: notification-popover-in 170ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.notification-popover[data-state="closed"] {
+	pointer-events: none;
+	animation: notification-popover-out 120ms ease-in both;
+}
+
 @media (prefers-reduced-motion: reduce) {
-	.notification-row-enter {
+	.notification-popover[data-state],
+	.notification-row-enter,
+	.session-inspector-motion,
+	.session-inspector__responsive-label,
+	.session-split > [data-panel] {
 		animation: none;
+		transition: none;
 	}
 }
 

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom/vitest";
+import * as jestDomMatchers from "@testing-library/jest-dom/matchers";
+import { expect } from "vitest";
 import "../i18n";
+
+// Vitest 4 can load the convenience entry against a different matcher
+// instance. Register the matchers on the active test runtime as well.
+expect.extend(jestDomMatchers);
 
 // Guard: src/main/** tests run in the Node.js environment (no DOM). vitest still
 // routes setupFiles here, so only install the DOM stubs when a DOM exists.

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -299,20 +299,16 @@ beforeEach(() => {
 });
 
 describe("shell workspace startup", () => {
-	it("places the topbar host inside the center panel surface on session routes", async () => {
+	it("leaves the session topbar row to the session split instead of reserving a full-width shell row", async () => {
 		shellMocks.state.routeParams = { sessionId: "sess-1" };
 		await renderShell();
 
-		const host = screen.getByTestId("session-topbar-host");
 		const sidebar = screen.getByTestId("sidebar");
-		// Host now lives inside center-panel-surface (after the sidebar in DOM order).
-		expect(host.compareDocumentPosition(sidebar) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
-		expect(host).toHaveClass("h-inspector-tabs");
-		// Sidebar uses the same topbar offset as non-session routes (no longer "session").
+		expect(screen.queryByTestId("session-topbar-host")).not.toBeInTheDocument();
+		// The route shell owns only the frame. SessionView places its topbar host
+		// inside the terminal panel so the inspector header can occupy this row too.
 		expect(sidebar).not.toHaveAttribute("data-topbar-offset", "session");
 		expect(document.querySelector(".center-panel-shell--session > .center-panel-surface")).toBeInTheDocument();
-		// Host must be a descendant of the session surface.
-		expect(document.querySelector(".center-panel-shell--session > .center-panel-surface")?.contains(host)).toBe(true);
 	});
 
 	it("forces a confirmed fetch and preserves a collapsed sidebar preference", async () => {


### PR DESCRIPTION
## What

Refines the session inspector/right sidebar and the notification surface as a focused extraction from the larger top-bar work.

- standardizes the inspector at a 360px default/minimum width with a 50% viewport maximum
- adds smooth open/close motion, a fully collapsed zero-width state, and responsive icon/label navigation
- introduces a dedicated Reviews tab and moves the close control into the inspector header
- keeps the top bar integration minimal by showing only the inspector reopen control when collapsed
- compacts the notification icon/count badge and animates the notification popover
- preserves inspector state when navigating from the orchestrator to a worker session

## Why

The previous top-bar branch mixed several independent UI concerns. This PR isolates the right sidebar plus the small notification polish so it can be reviewed and shipped independently without bringing in the center top bar, Kanban, orchestrator action, or terminal-tab restructuring.

## How

- persists inspector width in pixels under `ao.inspector.widthPx`, clamps it to the supported range, and intentionally ignores the older percentage split value
- drives the resizable panel from the per-session UI store while keeping inspector content mounted/inert during close motion
- uses container-responsive labels so narrow inspector widths show icons without abrupt layout changes
- adds reduced-motion fallbacks for both inspector and notification transitions
- restores Vitest's jest-dom matcher registration required by the current dependency versions

Intentional omissions: no Kanban layout changes, orchestrator/new-task button changes, center top-bar redesign, or terminal-tab work are included.

## Testing

- `cd frontend && npm test` — 162 files passed; 2,108 tests passed; 1 skipped
- `cd frontend && npm run typecheck`
- `cd frontend && npx vite build --config vite.renderer.config.ts`
- focused component suites — 193 tests passed across SessionInspector, SessionView, NotificationCenter, and ShellTopbar

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
