### PR TITLE
fix(desktop): guard quitAndInstallUpdate against macOS translocation/read-only bundles

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -1231,3 +1231,130 @@ describe("returnToHome", () => {
     expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled();
   });
 });
+
+// #3527: on macOS, Squirrel.Mac cannot replace a translocated or otherwise
+// read-only .app bundle, so quitAndInstall() used to silently no-op with no
+// restart and no error. These cover the guard added in front of it.
+describe("macOS translocation/writability guard", () => {
+  const installedExecPath =
+    "/Applications/Agent Orchestrator.app/Contents/MacOS/Agent Orchestrator";
+  const translocatedExecPath =
+    "/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/AppTranslocation/1234-5678-ABCD/d/Agent Orchestrator.app/Contents/MacOS/Agent Orchestrator";
+
+  describe("isTranslocatedPath", () => {
+    it("flags a path running out of the App Translocation mirror", async () => {
+      const { module } = await importAutoUpdater();
+      expect(module.isTranslocatedPath(translocatedExecPath)).toBe(true);
+    });
+
+    it("does not flag a normal /Applications install path", async () => {
+      const { module } = await importAutoUpdater();
+      expect(module.isTranslocatedPath(installedExecPath)).toBe(false);
+    });
+  });
+
+  describe("resolveMacBundleRoot", () => {
+    it("walks up from Contents/MacOS/<exe> to the .app bundle root", async () => {
+      const { module } = await importAutoUpdater();
+      expect(module.resolveMacBundleRoot(installedExecPath)).toBe(
+        "/Applications/Agent Orchestrator.app",
+      );
+    });
+
+    it("resolves the .app root even from inside the translocation mirror", async () => {
+      const { module } = await importAutoUpdater();
+      expect(module.resolveMacBundleRoot(translocatedExecPath)).toBe(
+        "/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/AppTranslocation/1234-5678-ABCD/d/Agent Orchestrator.app",
+      );
+    });
+  });
+
+  describe("isBundleWritable", () => {
+    it("is true when the access check does not throw", async () => {
+      const { module } = await importAutoUpdater();
+      expect(
+        module.isBundleWritable(
+          "/Applications/Agent Orchestrator.app",
+          () => undefined,
+        ),
+      ).toBe(true);
+    });
+
+    it("is false when the access check throws (read-only volume/permission)", async () => {
+      const { module } = await importAutoUpdater();
+      expect(
+        module.isBundleWritable(
+          "/Volumes/ReadOnlyDMG/Agent Orchestrator.app",
+          () => {
+            throw new Error("EACCES: permission denied");
+          },
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("quitAndInstallUpdate", () => {
+    it("installs normally on macOS when the bundle is a real, writable install", async () => {
+      const { module, autoUpdater, dialog } = await importAutoUpdater();
+
+      module.quitAndInstallUpdate(true, installedExecPath, () => undefined);
+
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+      expect(dialog.showMessageBox).not.toHaveBeenCalled();
+    });
+
+    it("blocks and shows a dialog instead of installing when translocated", async () => {
+      const { module, autoUpdater, dialog } = await importAutoUpdater();
+
+      module.quitAndInstallUpdate(
+        true,
+        translocatedExecPath,
+        () => undefined, // bundle would actually be writable here; translocation alone must block
+      );
+
+      expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+      expect(dialog.showMessageBox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "warning",
+          buttons: ["OK"],
+          message: expect.stringMatching(/install/i),
+          detail: expect.stringMatching(/Applications/),
+        }),
+      );
+    });
+
+    it("blocks and shows a dialog instead of installing when the bundle is not writable", async () => {
+      const { module, autoUpdater, dialog } = await importAutoUpdater();
+
+      module.quitAndInstallUpdate(true, installedExecPath, () => {
+        throw new Error("EACCES: permission denied");
+      });
+
+      expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+      expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op guard on non-darwin platforms even for a translocated-looking, non-writable path", async () => {
+      const { module, autoUpdater, dialog } = await importAutoUpdater();
+
+      module.quitAndInstallUpdate(false, translocatedExecPath, () => {
+        throw new Error("EACCES: permission denied");
+      });
+
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+      expect(dialog.showMessageBox).not.toHaveBeenCalled();
+    });
+
+    it("does nothing at all in dev (unpackaged), before the platform guard even runs", async () => {
+      const { module, autoUpdater, dialog } = await importAutoUpdater(
+        undefined,
+        { isPackaged: false },
+      );
+
+      module.quitAndInstallUpdate(true, translocatedExecPath, () => undefined);
+
+      expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+      expect(dialog.showMessageBox).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1,6 +1,6 @@
 import { autoUpdater } from "electron-updater";
 import { app, BrowserWindow, dialog } from "electron";
-import { existsSync } from "node:fs";
+import { accessSync, constants, existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -774,10 +774,96 @@ export async function downloadUpdateNow(requestId?: string): Promise<void> {
   }
 }
 
+// --- macOS App Translocation / read-only bundle guard ---------------------
+// Squirrel.Mac (electron-updater's macOS install backend) replaces the running
+// .app bundle in place, so it needs write access to the bundle's real,
+// installed location. Two situations break that silently: the app running
+// translocated (macOS "App Translocation" runs an unmoved, freshly-downloaded
+// .app from a randomized read-only mirror under
+// /private/var/folders/.../AppTranslocation/<uuid>/d/ instead of its real
+// path) or a bundle that is otherwise non-writable (read-only volume, missing
+// permission bit). In either case quitAndInstall() silently no-ops: no
+// restart, no error, no feedback (#3527). quitAndInstallUpdate() below checks
+// both before installing.
+//
+// Kept as small, pure functions that take the path as a parameter instead of
+// reading process.execPath internally, so they're unit-testable with
+// fabricated path strings without a real macOS bundle -- the same
+// dependency-injection convention keybinding-settings.ts's
+// coerceKeybindingOverrides(raw, isMac) and daemon-launch.ts's
+// resolveDaemonLaunch(...) already use in this directory.
+
+/** True when execPath is running out of macOS's App Translocation mirror. */
+export function isTranslocatedPath(execPath: string): boolean {
+  return execPath.includes("/AppTranslocation/");
+}
+
+// Walk up from the executable to the enclosing `.app` bundle root:
+// .../Agent Orchestrator.app/Contents/MacOS/<exe> -> .../Agent Orchestrator.app.
+// Same three-level walk as resolveBundlePath() in main.ts, for the same
+// reason (app.getAppPath() would return the app.asar path inside the bundle,
+// not the bundle directory itself) -- but done via "/"-delimited string
+// splitting rather than node:path, since macOS bundle paths are always POSIX
+// and path.resolve/path.join follow the *host* OS's separator rules, which
+// would make this non-deterministic under test on a non-POSIX host. Same
+// reasoning as daemon-launch.ts's joinPath in this repo.
+export function resolveMacBundleRoot(execPath: string): string {
+  const segments = execPath.split("/");
+  return segments.slice(0, Math.max(segments.length - 3, 0)).join("/");
+}
+
+// True unless the bundle root cannot be written to (read-only volume, missing
+// permission bit) -- the other way Squirrel.Mac silently fails besides
+// translocation. checkAccess is injected (defaulting to a real fs.accessSync
+// check) so tests can fabricate both outcomes without a real filesystem.
+export function isBundleWritable(
+  bundleRoot: string,
+  checkAccess: (targetPath: string) => void = (p) =>
+    accessSync(p, constants.W_OK),
+): boolean {
+  try {
+    checkAccess(bundleRoot);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // quitAndInstallUpdate installs a downloaded update and relaunches. isSilent
 // false keeps the installer UI on Windows; isForceRunAfter relaunches the app.
-export function quitAndInstallUpdate(): void {
+//
+// On macOS specifically, guard against the silent-no-op cases above: if the
+// bundle is translocated or otherwise non-writable, show an actionable dialog
+// instead of calling quitAndInstall(). The staged update and update settings
+// are left untouched (nothing here writes state), so the install can simply
+// be retried once the user has moved the app to /Applications and relaunched.
+//
+// isMac/execPath/checkAccess default to the real process so the existing call
+// site (main.ts's "updates:install" IPC handler, invoked with no arguments)
+// behaves exactly as before; tests override them to exercise the guard
+// without a real macOS bundle.
+export function quitAndInstallUpdate(
+  isMac: boolean = process.platform === "darwin",
+  execPath: string = process.execPath,
+  checkAccess?: (targetPath: string) => void,
+): void {
   if (!app.isPackaged) return;
+  if (isMac) {
+    const bundleRoot = resolveMacBundleRoot(execPath);
+    if (
+      isTranslocatedPath(execPath) ||
+      !isBundleWritable(bundleRoot, checkAccess)
+    ) {
+      void dialog.showMessageBox({
+        type: "warning",
+        buttons: ["OK"],
+        message: "Can't install this update yet",
+        detail:
+          "Agent Orchestrator is running from a read-only location -- this usually means it launched straight from a DMG or Downloads without being moved to Applications. Move Agent Orchestrator.app to your Applications folder, relaunch it, and Restart to update again.",
+      });
+      return;
+    }
+  }
   autoUpdater.quitAndInstall(false, true);
 }
 


### PR DESCRIPTION
## Problem

On macOS, when Agent Orchestrator runs under App Translocation (launched straight from Downloads or a mounted DMG without being moved to `/Applications`), the app bundle lives at a randomized **read-only** path (`/private/var/folders/.../AppTranslocation/<uuid>/d/Agent Orchestrator.app`). An update still checks, downloads, and stages fine, and the sidebar shows "Restart to update", but clicking it does nothing: Squirrel.Mac (electron-updater's macOS install backend) cannot replace a read-only bundle, so `autoUpdater.quitAndInstall()` silently no-ops. No restart, no error, no guidance.

`quitAndInstallUpdate()` in `frontend/src/main/auto-updater.ts` had no translocation/writability check at all before calling `quitAndInstall()`.

## Fix

Added a macOS-only guard in front of `autoUpdater.quitAndInstall()`:

- `isTranslocatedPath(execPath)` — true when the executable path contains `/AppTranslocation/`.
- `resolveMacBundleRoot(execPath)` — walks up from `.../Agent Orchestrator.app/Contents/MacOS/<exe>` to the enclosing `.app` bundle root (same three-level walk as `resolveBundlePath()` already does in `main.ts`, implemented via `/`-delimited string splitting rather than `node:path` so it's deterministic under test regardless of the host OS running the test suite, matching `daemon-launch.ts`'s `joinPath` reasoning in this repo).
- `isBundleWritable(bundleRoot, checkAccess?)` — true unless a `fs.accessSync(path, fs.constants.W_OK)` check throws (read-only volume, missing permission bit); `checkAccess` is injected so it's testable without touching a real filesystem.

If either check fires, `quitAndInstallUpdate()` shows an actionable `dialog.showMessageBox` (the same dialog mechanism already used elsewhere in this file, e.g. `ensureUpdatePrefs`) telling the user to move the app to `/Applications` and relaunch, then returns without calling `quitAndInstall()`. Nothing in the guard touches update-settings or the staged-update state, so the install can simply be retried after the user moves the app.

All three detection functions take their inputs as parameters instead of reading `process.execPath`/`process.platform` internally, and `quitAndInstallUpdate()` itself takes `isMac`/`execPath`/`checkAccess` overrides that default to the real process — the same dependency-injection-via-default-parameter convention `keybinding-settings.ts`'s `coerceKeybindingOverrides(raw, isMac)` already uses in this directory. This is what makes the guard unit-testable with fabricated path strings and a mocked fs check, no real macOS bundle required.

## Verification

**Important disclosure: I do not have access to a macOS environment.** I could not run the packaged Electron app, reproduce a real translocated bundle, or see the actual dialog render. Everything below was verified through code review, TypeScript typechecking, and unit tests with mocked/fabricated inputs — not a live macOS run. This should be treated as unverified against real macOS behavior until someone with mac hardware confirms the dialog UX and real-world translocation detection.

What I did verify:

- Read `frontend/src/main/auto-updater.ts` in full and confirmed `quitAndInstallUpdate()` was exactly as bare as described (no guard of any kind) before this change.
- Traced the call site: `main.ts`'s `ipcMain.handle("updates:install", () => { quitAndInstallUpdate(); })` — the new optional parameters default to the real process, so this call site's behavior is unchanged when both checks pass.
- Confirmed the staged-update/escalation tracking (`stagedVersion`, `stagedAtMs`, etc.) and `update-settings` persistence are untouched by the guard — nothing is cleared or invalidated when it fires.
- Added unit tests to `frontend/src/main/auto-updater.test.ts` (11 new cases, using the existing `importAutoUpdater()` electron-mocking harness already in that file) covering:
  - A translocated path string correctly detected as translocated, and a normal `/Applications/Agent Orchestrator.app/...` path correctly not flagged.
  - `resolveMacBundleRoot` correctly walking up to the `.app` root from both a normal install path and a translocation-mirror path.
  - A mocked non-writable access check correctly failing `isBundleWritable`, and a mocked writable one correctly passing.
  - `quitAndInstallUpdate` calling through to `autoUpdater.quitAndInstall(false, true)` when the bundle is a normal writable install, and calling `dialog.showMessageBox` instead (with an `/Applications`-mentioning, install-guidance message) and *not* calling `quitAndInstall` when translocated or non-writable.
  - The guard being a no-op on non-darwin platforms even for a translocated-looking, non-writable path (still calls `quitAndInstall` as before).
  - No-op in dev (unpackaged) before the platform check even runs, matching existing behavior.
- Proved the tests actually exercise the fix using a patch-file diff/reverse-apply (not `git stash`, to avoid colliding with other concurrent work in shared worktrees of this repo): reversed just the `auto-updater.ts` change while keeping the new tests, confirmed 8 of the 11 new tests fail against the unpatched code (`module.isTranslocatedPath is not a function`, and `quitAndInstall` being called when it shouldn't be), then reapplied the fix and confirmed all 47 tests in the file pass.
- `npx tsc --noEmit` from `frontend/` — clean, no errors.
- `npx vitest run --config vite.renderer.config.ts src/main/auto-updater.test.ts` — 47/47 passed.
- `npx vitest run --config vite.renderer.config.ts src/main` (broader regression check) — 284 passed, 2 skipped, 4 failed. The 4 failures are all in `supervisor-link.test.ts` (`EACCES: permission denied` creating a Unix-domain-socket file under the Windows temp dir) — a pre-existing Windows-sandbox limitation unrelated to this change; I did not touch `supervisor-link.ts` or its test, and `auto-updater.test.ts` was unaffected in the same run.

Given the lack of a real macOS test environment, I'd appreciate a reviewer with mac hardware confirming: the dialog actually renders with sensible copy, `isTranslocatedPath`/`resolveMacBundleRoot` correctly handle a real translocated bundle's path shape, and `fs.accessSync` behaves as expected against an actual read-only-mounted or translocated bundle directory.

Addresses #3527.
