### PR TITLE
fix(scm): keep merge-terminated session namespaces eligible for late-PR attribution

### DIFF
--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -470,6 +470,15 @@ func (o *Observer) checkCredentials(ctx context.Context) (bool, error) {
 // session may own several PRs, so each open tracked PR becomes its own subject.
 // Terminal PRs stay eligible only for an opted-in live session, allowing an
 // unacknowledged teardown failure to be delivered again on a later poll.
+//
+// Merge-terminated sessions (TerminateOnPRMerge) are an exception to the
+// termination cutoff: they stay eligible for branch-prefix discovery of new
+// PRs (#2879). When a session's first PR merges, lifecycle can mark it
+// terminated (and tear down its worker) before a follow-up PR the worker had
+// already pushed is observed. If the session's namespace stops being scanned
+// at that instant, that follow-up PR is never attributed, enriched, or
+// surfaced. Keeping only the branch prefix alive lets the observer claim such
+// a late PR; its already-tracked PRs are not refreshed (see below).
 func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, []sessionRepo, error) {
 	sessions, err := o.store.ListAllSessions(ctx)
 	if err != nil {
@@ -481,7 +490,7 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 	out := map[string]*subject{}
 	var sessionRepos []sessionRepo
 	for _, sess := range sessions {
-		if sess.IsTerminated {
+		if sess.IsTerminated && !sess.TerminateOnPRMerge {
 			continue
 		}
 		branch := strings.TrimSpace(sess.Metadata.Branch)
@@ -529,6 +538,12 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 		}
 		if len(repos) == 0 {
 			o.logger.Debug("scm observer: project has no supported SCM origins", "project", proj.ID)
+			continue
+		}
+		// A terminated session contributes its branch namespace for late-PR
+		// attribution only (#2879); its already-tracked PRs are not refreshed
+		// here, so a dead session never keeps the poll hot.
+		if sess.IsTerminated {
 			continue
 		}
 		prs, err := o.store.ListPRsBySession(ctx, sess.ID)
@@ -764,6 +779,9 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 			sr, ok := matchSession(eligible, pr.SourceBranch)
 			if !ok {
 				continue
+			}
+			if sr.session.IsTerminated {
+				o.logger.Info("scm observer: attributed post-termination PR to session", "session", sr.session.ID, "pr", firstNonEmpty(pr.URL, pr.HTMLURL), "branch", pr.SourceBranch)
 			}
 			known := domain.PullRequest{
 				URL:          firstNonEmpty(pr.URL, pr.HTMLURL),

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -731,6 +731,101 @@ func TestMatchSession_PrefersExactBranchOverNamespaceMatch(t *testing.T) {
 	}
 }
 
+// A merge-terminated session (TerminateOnPRMerge) must stay eligible for
+// branch-prefix discovery so a follow-up PR the worker pushed around the
+// merge/termination instant is still attributed and enriched instead of
+// vanishing from the board (#2879).
+func TestPoll_AttributesPostTerminationPRForMergeTerminatedSession(t *testing.T) {
+	store := testStoreWithSession()
+	store.sessions[0].Metadata.Branch = "ao/p-1/root"
+	store.sessions[0].IsTerminated = true
+	store.sessions[0].TerminateOnPRMerge = true
+	prObs := testObs(1)
+	prObs.PR.SourceBranch = "ao/p-1/fix"
+	prObs.PR.TargetBranch = "main"
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
+		openPRs: map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {
+			{URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "ao/p-1/fix", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha1"},
+		}},
+		observations: map[string]ports.SCMObservation{prKey(testRepo, 1): prObs},
+	}
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.writes) == 0 {
+		t.Fatal("expected post-termination PR write")
+	}
+	if got := store.writes[0].pr.SessionID; got != "p-1" {
+		t.Fatalf("attributed session id = %q, want p-1", got)
+	}
+	if got := store.writes[0].pr.SourceBranch; got != "ao/p-1/fix" {
+		t.Fatalf("source branch = %q, want ao/p-1/fix", got)
+	}
+	fetched := map[int]bool{}
+	for _, batch := range provider.fetchBatches {
+		for _, ref := range batch {
+			fetched[ref.Number] = true
+		}
+	}
+	if !fetched[1] {
+		t.Fatalf("post-termination PR was not refreshed, fetched %#v", fetched)
+	}
+	if len(lc.observed) != 1 {
+		t.Fatalf("lifecycle observations = %d, want 1", len(lc.observed))
+	}
+}
+
+// A session terminated deliberately (not via TerminateOnPRMerge) keeps the
+// pre-existing cutoff: its namespace is not scanned, so no PR row is created.
+func TestPoll_DoesNotAttributePostTerminationPRForManualTermination(t *testing.T) {
+	store := testStoreWithSession()
+	store.sessions[0].Metadata.Branch = "ao/p-1/root"
+	store.sessions[0].IsTerminated = true
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
+		openPRs: map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {
+			{URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "ao/p-1/fix", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha1"},
+		}},
+	}
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.writes) != 0 {
+		t.Fatalf("expected no PR writes for manually terminated session, got %#v", store.writes)
+	}
+	if len(lc.observed) != 0 {
+		t.Fatalf("expected no lifecycle observations for manually terminated session, got %d", len(lc.observed))
+	}
+}
+
+// A merge-terminated session does not yield refresh subjects for its
+// already-tracked PRs, only late-PR discovery. An open PR it already owned
+// before termination is not re-fetched.
+func TestDiscoverSubjects_MergeTerminatedSessionSkipsTrackedPRSubjects(t *testing.T) {
+	store := testStoreWithSession()
+	store.sessions[0].Metadata.Branch = "ao/p-1/root"
+	store.sessions[0].IsTerminated = true
+	store.sessions[0].TerminateOnPRMerge = true
+	store.prs["p-1"] = []domain.PullRequest{{URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "ao/p-1/fix", SessionID: "p-1"}}
+	provider := &fakeProvider{}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+	subjects, sessionRepos, err := obs.discoverSubjects(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subjects) != 0 {
+		t.Fatalf("merge-terminated session must not yield refresh subjects, got %d", len(subjects))
+	}
+	if len(sessionRepos) == 0 {
+		t.Fatal("merge-terminated session must stay eligible for late-PR discovery")
+	}
+}
+
 func TestPoll_DiscoversWorkspaceChildRepoPR(t *testing.T) {
 	store := testStoreWithSession()
 	store.sessions[0].Metadata.Branch = "ao/p-1/root"


### PR DESCRIPTION
## Problem (#2879)

When a session's first PR merges and there are no other open PRs, lifecycle terminates the session. The SCM observer skips terminated sessions entirely, so any follow-up PR the worker pushed around the merge/termination instant is never attributed, enriched, or surfaced on the board.

## Fix

Merge-terminated sessions (`TerminateOnPRMerge`) now stay eligible for **branch-prefix discovery of new PRs** while their already-tracked PRs remain skipped:

- The session's branch namespace is still scanned so `discoverNewPRs` can attribute a previously-unknown PR whose source branch matches.
- The attributed PR row is persisted and enriched (CI checks, review facts).
- Lifecycle nudges stay inert for the terminated session (`cannotNudge` returns true), so no re-termination loop or phantom notifications.
- Manually terminated sessions (without `TerminateOnPRMerge`) keep the pre-existing cutoff — their namespace is not scanned.

Cost is bounded because repo scans are guarded by ETags; a merged-terminated session whose repo is already scanned by a live session costs nothing, otherwise it's a conditional 304 request.

## Changes

- **`backend/internal/observe/scm/observer.go`**
  - `discoverSubjects`: merge-terminated sessions contribute `sessionRepo` entries for late-PR discovery but skip their tracked-PR subjects loop (no refreshes).
  - `discoverNewPRs`: log info when attributing a post-termination PR so it's observable.
- **`backend/internal/observe/scm/observer_test.go`**
  - `TestPoll_AttributesPostTerminationPRForMergeTerminatedSession`: verifies late PR is discovered, persisted, refreshed, and lifecycle-received.
  - `TestPoll_DoesNotAttributePostTerminationPRForManualTermination`: verifies manually killed sessions keep the pre-existing cutoff.
  - `TestDiscoverSubjects_MergeTerminatedSessionSkipsTrackedPRSubjects`: verifies no refresh subjects for already-tracked PRs.

`go test ./internal/observe/scm/` green; `golangci-lint v2.12.2` clean for the package.