### PR TITLE
fix(runtime): distinguish absent tmux servers

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -490,13 +490,11 @@ func (r *Runtime) paneSessionIDs(ctx context.Context, id string) []int {
 
 // IsAlive reports whether the handle's session still exists via `tmux
 // has-session`. Exit 0 means alive. A non-zero exit with output naming this
-// session as missing is a definitive false, nil. A server-level failure ("no
-// server running", "error connecting") wraps ports.ErrRuntimeUnavailable: the
-// probe learned nothing about this session — the agent process may well still
-// be running as an orphan of the dead server — so it must never be read as
-// per-session death (issue #3475). Any other non-zero exit is a plain probe
-// error so callers (the reaper feeding the LCM) treat it as a failed probe
-// and never kill a session on a transient error.
+// session as missing is a definitive false, nil. A server-level absence wraps
+// ports.ErrRuntimeServerAbsent; other reachability failures wrap
+// ports.ErrRuntimeUnavailable. Both remain errors so each caller must
+// explicitly decide whether authoritative server absence is safe to consume.
+// Any other non-zero exit is a plain probe error.
 func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error) {
 	id, err := handleID(handle)
 	if err != nil {
@@ -508,6 +506,10 @@ func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool
 		if errors.As(err, &exitErr) {
 			if sessionMissingOutput(string(out)) {
 				return false, nil
+			}
+			if serverAbsentOutput(string(out)) {
+				return false, fmt.Errorf("tmux runtime: probe session %s: %w: %s",
+					id, ports.ErrRuntimeServerAbsent, strings.TrimSpace(string(out)))
 			}
 			if serverUnreachableOutput(string(out)) {
 				return false, fmt.Errorf("tmux runtime: probe session %s: %w: %s",
@@ -958,13 +960,21 @@ func sessionMissingOutput(out string) bool {
 		strings.Contains(s, "session not found")
 }
 
-// serverUnreachableOutput reports whether a non-zero tmux exit means the
-// server itself could not be reached, which is inconclusive for any single
-// session's liveness.
-func serverUnreachableOutput(out string) bool {
+// serverAbsentOutput reports tmux diagnostics that prove the server does not
+// exist. tmux versions use both spellings below for the same missing Unix
+// socket. ENOENT is authoritative even if a new server races to start later:
+// the old server's panes cannot survive its exit.
+func serverAbsentOutput(out string) bool {
 	s := strings.ToLower(out)
 	return strings.Contains(s, "no server running") ||
-		strings.Contains(s, "error connecting")
+		(strings.Contains(s, "error connecting") && strings.Contains(s, "no such file or directory"))
+}
+
+// serverUnreachableOutput reports a non-zero tmux exit that failed to reach
+// the server without proving absence, such as a permission failure.
+func serverUnreachableOutput(out string) bool {
+	s := strings.ToLower(out)
+	return strings.Contains(s, "error connecting")
 }
 
 // killSessionMissingOutput reports whether a non-zero `tmux kill-session`
@@ -972,7 +982,7 @@ func serverUnreachableOutput(out string) bool {
 // missing server also means there is nothing left to kill, so it shares the
 // server-level patterns that liveness probing must not use.
 func killSessionMissingOutput(out string) bool {
-	return sessionMissingOutput(out) || serverUnreachableOutput(out)
+	return sessionMissingOutput(out) || serverAbsentOutput(out) || serverUnreachableOutput(out)
 }
 
 // -- text helpers --

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -868,33 +868,51 @@ func TestIsAliveReturnsFalseNilOnCantFindSession(t *testing.T) {
 	}
 }
 
-// A server-level failure says nothing about one session: the whole server is
-// gone (or unreachable), and the agent may still be alive as an orphan. It
-// must surface as ports.ErrRuntimeUnavailable — an inconclusive probe — never
-// as a definitive "this session is dead" (issue #3475: reading it as death
-// archived every session on the board in one pass).
-func TestIsAliveReportsNoServerAsRuntimeUnavailable(t *testing.T) {
+func TestIsAliveReportsNoServerAsTypedServerAbsence(t *testing.T) {
 	r, fr := newTestRuntime(0)
 	fr.outputs = [][]byte{[]byte("no server running on /tmp/tmux-1000/default")}
 	fr.err = &exec.ExitError{}
 
 	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if !errors.Is(err, ports.ErrRuntimeServerAbsent) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeServerAbsent", err)
+	}
 	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
-		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+		t.Fatalf("IsAlive err = %v, want parent ports.ErrRuntimeUnavailable", err)
 	}
 	if alive {
 		t.Fatal("alive = true, want false")
 	}
 }
 
-func TestIsAliveReportsErrorConnectingAsRuntimeUnavailable(t *testing.T) {
+func TestIsAliveReportsMissingSocketAsTypedServerAbsence(t *testing.T) {
 	r, fr := newTestRuntime(0)
 	fr.outputs = [][]byte{[]byte("error connecting to /tmp/tmux-1000/default (No such file or directory)")}
 	fr.err = &exec.ExitError{}
 
 	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if !errors.Is(err, ports.ErrRuntimeServerAbsent) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeServerAbsent", err)
+	}
+	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
+		t.Fatalf("IsAlive err = %v, want parent ports.ErrRuntimeUnavailable", err)
+	}
+	if alive {
+		t.Fatal("alive = true, want false")
+	}
+}
+
+func TestIsAliveReportsPermissionFailureAsRuntimeUnavailable(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	fr.outputs = [][]byte{[]byte("error connecting to /tmp/tmux-1000/default (Permission denied)")}
+	fr.err = &exec.ExitError{}
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
 	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
 		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+	}
+	if errors.Is(err, ports.ErrRuntimeServerAbsent) {
+		t.Fatalf("IsAlive err = %v, permission failure must remain inconclusive", err)
 	}
 	if alive {
 		t.Fatal("alive = true, want false")

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -300,13 +300,20 @@ var (
 	// with no message (issue #2775).
 	ErrRuntimeWorkspaceCwdMismatch = errors.New("runtime: session working directory mismatch")
 	// ErrRuntimeUnavailable reports that a liveness probe could not reach the
-	// runtime infrastructure at all (e.g. tmux "no server running" or "error
-	// connecting"). It says nothing about any individual session, so callers
-	// must treat it as an inconclusive probe, never as per-session death
-	// (issue #3475: reading a server-level outage as N session deaths archived
-	// every session on the board). Adapters wrap this sentinel via fmt.Errorf
-	// so callers can match it with errors.Is.
+	// runtime infrastructure and learned nothing authoritative about the target
+	// session. Callers must treat it as an inconclusive probe, never as
+	// per-session death. Adapters wrap this sentinel via fmt.Errorf so callers can
+	// match it with errors.Is (issue #3475).
 	ErrRuntimeUnavailable = errors.New("runtime: infrastructure unavailable")
+	// ErrRuntimeServerAbsent is the authoritative subset of
+	// ErrRuntimeUnavailable where the adapter proved that the runtime server does
+	// not exist. It wraps ErrRuntimeUnavailable so callers that do not explicitly
+	// opt into the distinction remain fail-closed.
+	//
+	// For tmux, an absent server proves its panes are gone. Recovery and cleanup
+	// paths may use that fact, while steady-state board probes still see an error
+	// and cannot convert one server outage into N independent session deaths.
+	ErrRuntimeServerAbsent = fmt.Errorf("%w: server absent", ErrRuntimeUnavailable)
 )
 
 // WorkspaceConfig is the spec for creating or restoring a session's workspace.

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1751,12 +1751,11 @@ func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation strin
 func (m *Manager) restartRuntime(ctx context.Context, handle ports.RuntimeHandle, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
 	alive, err := m.runtime.IsAlive(ctx, handle)
 	if err != nil {
-		if !errors.Is(err, ports.ErrRuntimeUnavailable) {
+		if !errors.Is(err, ports.ErrRuntimeServerAbsent) {
 			return ports.RuntimeHandle{}, fmt.Errorf("probe existing runtime: %w", err)
 		}
-		// The runtime infrastructure itself is gone (e.g. the tmux server was
-		// killed). Restore/restart is exactly the recovery path for that
-		// outage, so proceed as "no existing runtime" and create a fresh one.
+		// A pane cannot survive an absent tmux server. Restore/restart may create
+		// a replacement without launching beside the old runtime.
 		alive = false
 	}
 	if alive {
@@ -1921,9 +1920,9 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 			alive, err := m.runtime.IsAlive(ctx, handle)
 			switch {
 			case err == nil:
-			case errors.Is(err, ports.ErrRuntimeUnavailable):
-				// Normal after a machine reboot: the runtime is conclusively gone,
-				// so preserve work and create the restore marker below.
+			case errors.Is(err, ports.ErrRuntimeServerAbsent):
+				// Normal after a machine reboot: the server is authoritatively
+				// absent, so preserve work and create the restore marker below.
 				alive = false
 			default:
 				// A failed probe is not proof of death: leave the session as-is.
@@ -1957,7 +1956,7 @@ func (m *Manager) reconcileReap(ctx context.Context, rec domain.SessionRecord) e
 	}
 	alive, err := m.runtime.IsAlive(ctx, handle)
 	if err != nil {
-		if errors.Is(err, ports.ErrRuntimeUnavailable) {
+		if errors.Is(err, ports.ErrRuntimeServerAbsent) {
 			return nil // no server means no leaked session to reap
 		}
 		return fmt.Errorf("reconcile reap %s: probe: %w", rec.ID, err)

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1321,6 +1321,38 @@ func TestResumeAgent_FallsBackToRuntimeRecreateWithoutRestartCapability(t *testi
 	}
 }
 
+func TestRestartRuntime_ServerAbsentCreatesReplacement(t *testing.T) {
+	rt := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{
+		aliveErr: fmt.Errorf("tmux socket absent: %w", ports.ErrRuntimeServerAbsent),
+	}}
+	m := New(Deps{Runtime: rt})
+
+	handle, err := m.restartRuntime(context.Background(), ports.RuntimeHandle{ID: "old"}, ports.RuntimeConfig{SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("restartRuntime: %v", err)
+	}
+	if handle.ID != "h1" || rt.created != 1 || rt.restarted != 0 || rt.destroyed != 0 {
+		t.Fatalf("replacement = %+v create/restart/destroy=%d/%d/%d, want h1 and 1/0/0",
+			handle, rt.created, rt.restarted, rt.destroyed)
+	}
+}
+
+func TestRestartRuntime_UnavailableProbeFailsClosed(t *testing.T) {
+	rt := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{
+		aliveErr: fmt.Errorf("tmux permission failure: %w", ports.ErrRuntimeUnavailable),
+	}}
+	m := New(Deps{Runtime: rt})
+
+	_, err := m.restartRuntime(context.Background(), ports.RuntimeHandle{ID: "old"}, ports.RuntimeConfig{SessionID: "s1"})
+	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
+		t.Fatalf("restartRuntime error = %v, want ErrRuntimeUnavailable", err)
+	}
+	if rt.created != 0 || rt.restarted != 0 || rt.destroyed != 0 {
+		t.Fatalf("inconclusive probe touched runtime: create/restart/destroy=%d/%d/%d",
+			rt.created, rt.restarted, rt.destroyed)
+	}
+}
+
 func TestResumeAgent_RequiresLiveExitedSession(t *testing.T) {
 	runtime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
 	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
@@ -6319,6 +6351,32 @@ func TestReconcileLive_ProbeErrorIsNotDeath(t *testing.T) {
 	}
 }
 
+func TestReconcileLive_UnavailableProbeIsNotDeath(t *testing.T) {
+	st := newFakeStore()
+	rt := &fakeRuntime{aliveErr: fmt.Errorf("tmux permission failure: %w", ports.ErrRuntimeUnavailable)}
+	ws := &fakeWorkspace{}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: lcm,
+		LookPath: func(string) (string, error) { return "/bin/true", nil },
+	})
+	rec := domain.SessionRecord{
+		ID: "s3", ProjectID: "p1",
+		Metadata: domain.SessionMetadata{
+			Branch: "ao/s3/root", WorkspacePath: "/wt/s3", RuntimeHandleID: "s3",
+		},
+	}
+
+	if err := m.reconcileLive(context.Background(), rec); !errors.Is(err, ports.ErrRuntimeUnavailable) {
+		t.Fatalf("reconcileLive error = %v, want ErrRuntimeUnavailable", err)
+	}
+	if ws.stashCalls != 0 || lcm.terminated["s3"] != 0 || rt.destroyed != 0 {
+		t.Fatalf("inconclusive probe mutated state: stash=%d term=%d destroy=%d",
+			ws.stashCalls, lcm.terminated["s3"], rt.destroyed)
+	}
+}
+
 func TestReconcileLive_ScratchDeadRuntimeTerminatesWithoutWorkspaceTeardown(t *testing.T) {
 	st := newFakeStore()
 	st.projects["scratch"] = domain.ProjectRecord{ID: "scratch", Kind: domain.ProjectKindScratch, Config: testRoleAgents()}
@@ -6481,6 +6539,38 @@ func TestReconcileReap_TerminatedAndDeadTmuxLeftAlone(t *testing.T) {
 	}
 	if err := m.reconcileReap(context.Background(), rec); err != nil {
 		t.Fatalf("reconcileReap: %v", err)
+	}
+	if rt.destroyed != 0 {
+		t.Fatalf("Destroy calls = %d, want 0", rt.destroyed)
+	}
+}
+
+func TestReconcileReap_ServerAbsentNeedsNoDestroy(t *testing.T) {
+	rt := &fakeRuntime{aliveErr: fmt.Errorf("tmux socket absent: %w", ports.ErrRuntimeServerAbsent)}
+	m := New(Deps{Runtime: rt})
+	rec := domain.SessionRecord{
+		ID: "t3", IsTerminated: true,
+		Metadata: domain.SessionMetadata{RuntimeHandleID: "t3"},
+	}
+
+	if err := m.reconcileReap(context.Background(), rec); err != nil {
+		t.Fatalf("reconcileReap: %v", err)
+	}
+	if rt.destroyed != 0 {
+		t.Fatalf("Destroy calls = %d, want 0", rt.destroyed)
+	}
+}
+
+func TestReconcileReap_UnavailableProbeDoesNotClaimAbsence(t *testing.T) {
+	rt := &fakeRuntime{aliveErr: fmt.Errorf("tmux permission failure: %w", ports.ErrRuntimeUnavailable)}
+	m := New(Deps{Runtime: rt})
+	rec := domain.SessionRecord{
+		ID: "t4", IsTerminated: true,
+		Metadata: domain.SessionMetadata{RuntimeHandleID: "t4"},
+	}
+
+	if err := m.reconcileReap(context.Background(), rec); !errors.Is(err, ports.ErrRuntimeUnavailable) {
+		t.Fatalf("reconcileReap error = %v, want ErrRuntimeUnavailable", err)
 	}
 	if rt.destroyed != 0 {
 		t.Fatalf("Destroy calls = %d, want 0", rt.destroyed)


### PR DESCRIPTION
## What

This is a small follow-up to #3475 for the way tmux 3.7b reports a missing server socket.

The change introduces a narrower `ErrRuntimeServerAbsent` result while keeping it underneath `ErrRuntimeUnavailable`. Recovery code can use the narrower result when the old tmux server is definitely gone; callers that do not opt in continue to behave conservatively.

## Why

Fixes #3800.

On the affected macOS machine, tmux returned:

```text
error connecting to <TMUX_SOCKET> (No such file or directory)
```

AO currently groups that with other connection failures, including `Permission denied`. That is safe for normal liveness observation, but a stricter boot reaper cannot distinguish a genuinely absent server from an ambiguous infrastructure problem and therefore refuses to start.

The protection added by #3475 is intentional and important: a server-level failure must not make the board conclude that every session independently died. This PR keeps that behavior. It only gives recovery and cleanup paths a more precise answer when the socket is actually absent.

### Redacted observed daemon log

Usernames, home-directory paths, project/session names, timestamps, PIDs, and token-adjacent context have been replaced or omitted.

```text
time=<TIMESTAMP> level=INFO msg="data-dir ownership acquired" lock=<AO_DATA_DIR>/daemon.lock pid=<DAEMON_PID>

time=<TIMESTAMP> level=ERROR msg="reconcile: live pass failed, skipping" sessionID=<ACTIVE_SESSION> error="reconcile <ACTIVE_SESSION>: probe: tmux runtime: probe session <ACTIVE_SESSION>: runtime: infrastructure unavailable: error connecting to <TMUX_SOCKET> (No such file or directory)"

time=<TIMESTAMP> level=ERROR msg="reconcile: reap pass left boot unsafe" sessionID=<TERMINATED_SESSION_1> error="session: unsafe to serve: terminated runtime reap unresolved: session <TERMINATED_SESSION_1> probe: tmux runtime: probe session <TERMINATED_SESSION_1>: runtime: infrastructure unavailable: error connecting to <TMUX_SOCKET> (No such file or directory)"

reconcile sessions on boot: session: unsafe to serve: terminated runtime reap unresolved: session <TERMINATED_SESSION_1> probe: tmux runtime: probe session <TERMINATED_SESSION_1>: runtime: infrastructure unavailable: error connecting to <TMUX_SOCKET> (No such file or directory)
```

## How

- `no server running ...` and `error connecting ... (No such file or directory)` map to `ErrRuntimeServerAbsent`.
- The new error wraps `ErrRuntimeUnavailable`, so existing fail-closed callers remain conservative.
- Restart and boot reconciliation explicitly handle the narrower absence result.
- `error connecting ... (Permission denied)` and unrecognized failures remain inconclusive.
- Teardown remains idempotent for all of tmux's missing-server messages.

One deliberate boundary: this does not treat every `error connecting` result as absence. That would weaken the safety behavior from #3475.

If maintainers would prefer the subtype to live at a different boundary, or want the change limited to the adapter first, I am happy to revise it.

## Testing

Validated locally:

```text
cd backend && go build ./...
cd backend && go test -p 1 ./...
cd backend && go vet ./...
cd backend && go test ./internal/adapters/runtime/tmux ./internal/session_manager
```

The exact ENOENT stderr was reproduced on macOS arm64 with tmux 3.7b. The installed app was recovered using a temporary empty tmux session; it was not replaced with the PR build.

## Notes for reviewers

- The exact startup refusal was reproduced on integration commit `619bed7cb`, which already has stricter fail-closed boot reconciliation.
- Upstream `main` shares the ambiguous adapter classification but currently handles `ErrRuntimeUnavailable` more permissively, so it may not reproduce the identical startup refusal without the stricter reconciliation path.
- The PR is intentionally focused on the shared classification contract.

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added/updated for the observed behavior
- [ ] Relevant upstream CI checks pass (pending)
