### PR TITLE
fix(frontend): avoid xterm viewport disposal race

### DIFF
--- a/frontend/e2e/terminal-viewport-retention.spec.ts
+++ b/frontend/e2e/terminal-viewport-retention.spec.ts
@@ -42,6 +42,7 @@ const handleC = `${sessionC.id}/terminal_0`;
 const handleD = `${sessionD.id}/terminal_0`;
 const handleE = `${sessionE.id}/terminal_0`;
 const handleF = `${sessionF.id}/terminal_0`;
+const replacementHandleA = `${sessionA.id}/terminal_replacement`;
 const orchestratorHandle = "fake-proj-orchestrator/terminal_0";
 
 const longReplay = [
@@ -189,6 +190,7 @@ async function installHarness(page: Page): Promise<void> {
 		[handleD]: "D short replay",
 		[handleE]: "E short replay",
 		[handleF]: "F short replay",
+		[replacementHandleA]: "A replacement replay",
 		[orchestratorHandle]: "Orchestrator ready",
 	});
 	await page.goto(`/#/projects/fake-proj/sessions/${sessionA.id}`);
@@ -197,6 +199,23 @@ async function installHarness(page: Page): Promise<void> {
 }
 
 test.describe("retained terminal viewport", () => {
+	test("replaces an active session handle without an uncaught xterm viewport error", async ({ page }) => {
+		const pageErrors: string[] = [];
+		page.on("pageerror", (error) => pageErrors.push(error.stack ?? error.message));
+		await installHarness(page);
+
+		await page.evaluate(
+			({ sessionId, handleId }) => window.__aoFakeAgent!.setTerminalHandle(sessionId, handleId),
+			{ sessionId: sessionA.id, handleId: replacementHandleA },
+		);
+		await expect(
+			page.locator(`[data-terminal-cache-key^="session:${sessionA.id}:worker|handle:${replacementHandleA}"]`),
+		).toHaveAttribute("data-terminal-activation-phase", "visible");
+
+		await page.waitForTimeout(250);
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("retains the first of six live sessions with zero reopen and reveals its latest output", async ({
 		page,
 	}) => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -902,12 +902,20 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			clearSuppressNativePaste();
 			keyInput.dispose();
 			userInputListeners.clear();
-			try {
-				term.dispose();
-			} catch {
-				// Some renderer addons can throw during dispose in certain GPU
-				// environments; the terminal is being torn down regardless.
-			}
+			// xterm 5.5 schedules Viewport.syncScrollArea with a zero-delay timer
+			// during open(). Disposing in this same task clears RenderService's
+			// renderer first, so that pending callback throws while reading its
+			// dimensions. Handle replacement can hit exactly that window. Queue our
+			// disposal behind xterm's callback; all AO listeners and attachments are
+			// already detached above, so the terminal is inert during this one tick.
+			window.setTimeout(() => {
+				try {
+					term.dispose();
+				} catch {
+					// Some renderer addons can throw during dispose in certain GPU
+					// environments; the terminal is being torn down regardless.
+				}
+			}, 0);
 		};
 	}, []);
 


### PR DESCRIPTION
## What

Avoid an xterm viewport race when AO replaces the active terminal handle for a retained session.

## Why

AO currently disposes the old xterm instance synchronously. xterm may still have queued viewport work for that instance, so the later callback reaches a disposed terminal and throws in the renderer.

Fixes #3803.

## How

- Detach AO listeners and the transport synchronously so the old handle immediately loses routing and input ownership.
- Defer only the old terminal object's final `dispose()` call to the next macrotask.
- Add a focused real-xterm Playwright regression for exact active-handle replacement.

## Testing

- `npm run typecheck`
- `npm run typecheck:e2e`
- `npm test -- src/renderer/components/XtermTerminal.test.tsx` (49/49)
- Focused Playwright handle-replacement regression (1/1)
- `git diff --check`

## Checklist

- [x] Branched from `main`
- [x] One focused change linked to its issue
- [x] Tests added for the user-visible failure
- [x] Relevant frontend and E2E checks pass
