### PR TITLE
fix(daemon): enforce exclusive data-dir ownership

### DIFF
--- a/.agents/skills/ao-desktop-dev/SKILL.md
+++ b/.agents/skills/ao-desktop-dev/SKILL.md
@@ -12,7 +12,7 @@ Run the Electron application from the current checkout and verify it in the nati
 Ask only when the request does not make the desired data source clear.
 
 - Use **isolated mode** by default for implementation and destructive testing. Electron uses port `3002`, `~/.ao/dev/running.json`, `~/.ao/dev/data`, and `~/.ao/dev/electron`.
-- Use **real-data mode** only when the user explicitly asks to see this machine's actual AO projects or sessions. Start the checkout's dev daemon on the isolated dev port/run file while pointing `AO_DATA_DIR` at the real AO data directory. This is a separate daemon process using real data; do not describe it as the installed app's daemon.
+- Use **real-data mode** only when the user explicitly asks to see this machine's actual AO projects or sessions. The real data directory has one daemon owner: stop that owner before starting the checkout's daemon, and never run both against it. A newer checkout may migrate the database, so prefer isolated mode for backend or migration testing.
 - Never try to attach an unpackaged Electron app directly to a packaged daemon from another checkout. The supervisor intentionally rejects daemon identity mismatches.
 - Warn before actions in real-data mode that create, terminate, rename, or otherwise mutate sessions. Merely opening and inspecting the UI is expected.
 
@@ -57,7 +57,9 @@ npm run dev
 
 First resolve and report the actual data directory. In an AO worker session, `AO_DATA_DIR` normally already identifies it. Otherwise the repository default is the absolute path corresponding to `~/.ao/data`.
 
-Keep the real data directory but remove inherited port/run-file overrides so the dev app retains its own daemon handshake and port:
+Check its normal run file and health endpoint for a live owner. If one exists, report that stopping it will interrupt its desktop connection and active work, then obtain the user's authorization to stop that exact daemon. Proceed only after its process and listener are gone.
+
+With exclusive ownership established, keep the real data directory but remove inherited port/run-file overrides so the dev app uses its own daemon handshake and port:
 
 ```bash
 cd frontend
@@ -73,6 +75,8 @@ Remove-Item Env:AO_RUN_FILE, Env:AO_PORT -ErrorAction SilentlyContinue
 $env:AO_DATA_DIR = $realAoData
 npm run dev
 ```
+
+If startup reports that the data directory is already in use, keep the owner running and switch to isolated mode unless the user authorizes stopping it. Changing only the port or run file cannot create a second owner.
 
 Do not print unrelated environment variables: AO sessions may carry credentials. It is safe to report only `AO_DATA_DIR`, `AO_RUN_FILE`, and `AO_PORT`.
 
@@ -129,6 +133,7 @@ Once one PR merges, prefer rebasing the remaining PR onto current `main`; the no
 - Renderer URLs can move from `5173` when a port is occupied. Trust Forge's printed URL rather than assuming one.
 - Multiple dev instances share `~/.ao/dev/electron`; avoid running them concurrently because Chromium profile state can collide.
 - An inherited `AO_DATA_DIR` changes dev mode from isolated data to real data. Always choose and report the mode instead of inheriting it accidentally.
+- A different `AO_PORT` or `AO_RUN_FILE` does not isolate SQLite. Every concurrent daemon needs a different `AO_DATA_DIR`.
 - Repeated `/healthz/` 404 entries from external probes can be noisy; readiness is determined by Electron's daemon status and successful API traffic, not by log volume.
 
 ## Completion report

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/browserruntime"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemon/supervisor"
+	"github.com/aoagents/agent-orchestrator/backend/internal/datadirlock"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
@@ -64,6 +65,17 @@ func Run() error {
 	ignoreBrokenPipeSignal()
 
 	log := newLogger()
+
+	// Acquire durable mutation authority before opening the store or running any
+	// reconciliation. Without this process-lifetime lease, concurrent starts can
+	// both pass the run-file probe, bind different ports, and mutate the same DB.
+	dataLease, err := datadirlock.Acquire(cfg.DataDir)
+	if err != nil {
+		return fmt.Errorf("acquire data-dir ownership: %w", err)
+	}
+	defer func() { _ = dataLease.Close() }()
+	log.Info("data-dir ownership acquired", "lock", dataLease.Path(), "pid", dataLease.PID())
+
 	var browserRuntimeToken string
 	if os.Getenv(browserruntime.RuntimeTokenStdinEnv) == "1" {
 		browserRuntimeToken, err = browserruntime.ReadRuntimeToken(os.Stdin)
@@ -88,6 +100,8 @@ func Run() error {
 	// PID for unrelated processes. So a "live" PID is verified against an actual
 	// /healthz probe; a run-file left by a crashed/hard-killed/reused-PID
 	// predecessor is treated as stale and overwritten when the new server starts.
+	// The data-dir lease above is authoritative; this retains stale-run-file
+	// cleanup for the lease holder.
 	if live, err := runfile.CheckStale(cfg.RunFilePath); err != nil {
 		return fmt.Errorf("inspect run-file: %w", err)
 	} else if live != nil && runFileOwnerServing(&http.Client{Timeout: staleProbeTimeout}, config.LoopbackHost, live) {

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -92,10 +92,16 @@ func Run() error {
 	// PID for unrelated processes. So a "live" PID is verified against an actual
 	// /healthz probe; a run-file left by a crashed/hard-killed/reused-PID
 	// predecessor is treated as stale and overwritten when the new server starts.
+	ownershipClient := &http.Client{Timeout: staleProbeTimeout}
 	if live, err := runfile.CheckStale(cfg.RunFilePath); err != nil {
 		return fmt.Errorf("inspect run-file: %w", err)
-	} else if live != nil && runFileOwnerServing(&http.Client{Timeout: staleProbeTimeout}, config.LoopbackHost, live) {
+	} else if live != nil && runFileOwnerServing(ownershipClient, config.LoopbackHost, live) {
 		return fmt.Errorf("daemon already running (pid %d, port %d); refusing to start", live.PID, live.Port)
+	}
+	if live, err := conventionalDataDirOwner(ownershipClient, config.LoopbackHost, cfg.DataDir, cfg.RunFilePath); err != nil {
+		return fmt.Errorf("inspect data-dir owner run-file: %w", err)
+	} else if live != nil {
+		return fmt.Errorf("data directory %q is already in use by daemon pid %d on port %d; stop it or choose a different AO_DATA_DIR", cfg.DataDir, live.PID, live.Port)
 	}
 
 	// Acquire durable mutation authority after the normal same-run-file diagnostic

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -5,6 +5,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -67,17 +68,6 @@ func Run() error {
 	ignoreBrokenPipeSignal()
 
 	log := newLogger()
-
-	// Acquire durable mutation authority before opening the store or running any
-	// reconciliation. Without this process-lifetime lease, concurrent starts can
-	// both pass the run-file probe, bind different ports, and mutate the same DB.
-	dataLease, err := datadirlock.Acquire(cfg.DataDir)
-	if err != nil {
-		return fmt.Errorf("acquire data-dir ownership: %w", err)
-	}
-	defer func() { _ = dataLease.Close() }()
-	log.Info("data-dir ownership acquired", "lock", dataLease.Path(), "pid", dataLease.PID())
-
 	var browserRuntimeToken string
 	if os.Getenv(browserruntime.RuntimeTokenStdinEnv) == "1" {
 		browserRuntimeToken, err = browserruntime.ReadRuntimeToken(os.Stdin)
@@ -102,13 +92,25 @@ func Run() error {
 	// PID for unrelated processes. So a "live" PID is verified against an actual
 	// /healthz probe; a run-file left by a crashed/hard-killed/reused-PID
 	// predecessor is treated as stale and overwritten when the new server starts.
-	// The data-dir lease above is authoritative; this retains stale-run-file
-	// cleanup for the lease holder.
 	if live, err := runfile.CheckStale(cfg.RunFilePath); err != nil {
 		return fmt.Errorf("inspect run-file: %w", err)
 	} else if live != nil && runFileOwnerServing(&http.Client{Timeout: staleProbeTimeout}, config.LoopbackHost, live) {
 		return fmt.Errorf("daemon already running (pid %d, port %d); refusing to start", live.PID, live.Port)
 	}
+
+	// Acquire durable mutation authority after the normal same-run-file diagnostic
+	// but before opening or migrating SQLite. Concurrent starts can both pass the
+	// run-file probe when they use different run files; this data-dir-scoped lease
+	// is the authoritative ownership gate in that case.
+	dataLease, err := datadirlock.Acquire(cfg.DataDir)
+	if err != nil {
+		if !errors.Is(err, datadirlock.ErrLocked) {
+			return fmt.Errorf("acquire data-dir ownership: %w", err)
+		}
+		return fmt.Errorf("data directory %q is already in use; stop its daemon or choose a different AO_DATA_DIR: %w", cfg.DataDir, err)
+	}
+	defer func() { _ = dataLease.Close() }()
+	log.Info("data-dir ownership acquired", "lock", dataLease.Path(), "pid", dataLease.PID())
 
 	// Open the durable store and bring up the CDC substrate: DB triggers capture
 	// changes into change_log, the poller tails it, and the broadcaster fans

--- a/backend/internal/daemon/stale.go
+++ b/backend/internal/daemon/stale.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemonmeta"
@@ -13,6 +14,25 @@ import (
 // staleProbeTimeout bounds the startup ownership probe so a run-file pointing at
 // an unreachable port cannot stall daemon startup.
 const staleProbeTimeout = 2 * time.Second
+
+// conventionalDataDirOwner checks the running.json that older AO releases
+// place beside their data/ directory. Those releases predate daemon.lock, so
+// probing this conventional handshake closes the upgrade window where a new
+// daemon uses a different run file but points at an older live daemon's data.
+func conventionalDataDirOwner(client *http.Client, host, dataDir, configuredRunFile string) (*runfile.Info, error) {
+	ownerRunFile := filepath.Join(filepath.Dir(filepath.Clean(dataDir)), "running.json")
+	if filepath.Clean(ownerRunFile) == filepath.Clean(configuredRunFile) {
+		return nil, nil
+	}
+	live, err := runfile.CheckStale(ownerRunFile)
+	if err != nil {
+		return nil, err
+	}
+	if live == nil || !runFileOwnerServing(client, host, live) {
+		return nil, nil
+	}
+	return live, nil
+}
 
 // runFileOwnerServing reports whether an AO daemon matching info is actually
 // serving on the recorded loopback port.

--- a/backend/internal/daemon/stale_test.go
+++ b/backend/internal/daemon/stale_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -112,5 +114,36 @@ func TestRunFileOwnerServingNilOrZeroPort(t *testing.T) {
 	}
 	if runFileOwnerServing(client, "127.0.0.1", &runfile.Info{PID: 1, Port: 0}) {
 		t.Error("runFileOwnerServing(port 0) = true, want false")
+	}
+}
+
+func TestConventionalDataDirOwnerFindsPreLockDaemon(t *testing.T) {
+	pid := os.Getpid()
+	srv := httptest.NewServer(healthzBody(daemonmeta.ServiceName, pid))
+	defer srv.Close()
+	host, port := hostPort(t, srv.URL)
+
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	ownerRunFile := filepath.Join(root, "running.json")
+	configuredRunFile := filepath.Join(root, "dev", "running.json")
+	if err := runfile.Write(ownerRunFile, runfile.Info{PID: pid, Port: port}); err != nil {
+		t.Fatalf("write owner run-file: %v", err)
+	}
+
+	got, err := conventionalDataDirOwner(srv.Client(), host, dataDir, configuredRunFile)
+	if err != nil {
+		t.Fatalf("conventionalDataDirOwner: %v", err)
+	}
+	if got == nil || got.PID != pid || got.Port != port {
+		t.Fatalf("owner = %+v, want pid %d port %d", got, pid, port)
+	}
+
+	got, err = conventionalDataDirOwner(srv.Client(), host, dataDir, ownerRunFile)
+	if err != nil {
+		t.Fatalf("same configured run-file: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("same configured run-file owner = %+v, want nil (already checked by caller)", got)
 	}
 }

--- a/backend/internal/datadirlock/lock.go
+++ b/backend/internal/datadirlock/lock.go
@@ -1,0 +1,115 @@
+// Package datadirlock provides a daemon-lifetime exclusive ownership lease
+// keyed to AO_DATA_DIR. Only one process may hold the lease; it must be
+// acquired before opening the SQLite store or reconciling sessions so two
+// concurrent starts cannot both mutate the same durable state.
+package datadirlock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// LockFileName is the lease file under the data directory.
+const LockFileName = "daemon.lock"
+
+// ErrLocked means another live process holds the data-dir lease.
+var ErrLocked = errors.New("datadirlock: data directory already owned by another daemon")
+
+// Lease is an exclusive, process-lifetime lock on a data directory.
+// Close releases the lease. The process must keep the Lease alive for the
+// entire daemon lifetime (do not close early).
+type Lease struct {
+	file *os.File
+	path string
+	pid  int
+}
+
+// Path returns the absolute path of the lock file.
+func (l *Lease) Path() string {
+	if l == nil {
+		return ""
+	}
+	return l.path
+}
+
+// PID returns the process ID written into the lock file (this process).
+func (l *Lease) PID() int {
+	if l == nil {
+		return 0
+	}
+	return l.pid
+}
+
+// Close releases the exclusive lease. Safe to call on a nil Lease.
+func (l *Lease) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	err := unlockAndClose(l.file)
+	l.file = nil
+	return err
+}
+
+// Acquire takes an exclusive non-blocking lease on dataDir.
+// On success the caller owns durable mutation rights for that directory until
+// Close. On failure with ErrLocked, another process already owns the dir.
+//
+// dataDir is created if missing (0o750). The lock file is best-effort annotated
+// with this process's PID for operator debugging; the OS lock is authoritative.
+func Acquire(dataDir string) (*Lease, error) {
+	dataDir = strings.TrimSpace(dataDir)
+	if dataDir == "" {
+		return nil, fmt.Errorf("datadirlock: empty data directory")
+	}
+	abs, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("datadirlock: abs %q: %w", dataDir, err)
+	}
+	if err := os.MkdirAll(abs, 0o750); err != nil {
+		return nil, fmt.Errorf("datadirlock: mkdir %q: %w", abs, err)
+	}
+	path := filepath.Join(abs, LockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // lock file under AO data dir
+	if err != nil {
+		return nil, fmt.Errorf("datadirlock: open %q: %w", path, err)
+	}
+	if err := tryLock(f); err != nil {
+		_ = f.Close()
+		if errors.Is(err, ErrLocked) {
+			// Surface the peer PID when readable (best-effort).
+			if peer, readErr := readPeerPID(path); readErr == nil && peer > 0 {
+				return nil, fmt.Errorf("%w (path %s, peer pid %d)", ErrLocked, path, peer)
+			}
+			return nil, fmt.Errorf("%w (path %s)", ErrLocked, path)
+		}
+		return nil, fmt.Errorf("datadirlock: lock %q: %w", path, err)
+	}
+	pid := os.Getpid()
+	// Truncate and write PID for operators; lock is already held.
+	if err := f.Truncate(0); err == nil {
+		_, _ = f.Seek(0, 0)
+		_, _ = f.WriteString(strconv.Itoa(pid) + "\n")
+		_ = f.Sync()
+	}
+	return &Lease{file: f, path: path, pid: pid}, nil
+}
+
+func readPeerPID(path string) (int, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	s := strings.TrimSpace(string(raw))
+	if s == "" {
+		return 0, fmt.Errorf("empty")
+	}
+	// First line only.
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	return strconv.Atoi(strings.TrimSpace(s))
+}

--- a/backend/internal/datadirlock/lock_test.go
+++ b/backend/internal/datadirlock/lock_test.go
@@ -1,0 +1,194 @@
+package datadirlock_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/datadirlock"
+)
+
+func TestAcquireExclusive(t *testing.T) {
+	dir := t.TempDir()
+	first, err := datadirlock.Acquire(dir)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer func() { _ = first.Close() }()
+
+	second, err := datadirlock.Acquire(dir)
+	if !errors.Is(err, datadirlock.ErrLocked) {
+		t.Fatalf("second acquire err=%v, want ErrLocked", err)
+	}
+	if second != nil {
+		t.Fatal("second lease must be nil")
+	}
+
+	if err := first.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	third, err := datadirlock.Acquire(dir)
+	if err != nil {
+		t.Fatalf("re-acquire after close: %v", err)
+	}
+	if err := third.Close(); err != nil {
+		t.Fatalf("close re-acquired lease: %v", err)
+	}
+}
+
+func TestAcquireConcurrentOnlyOneSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	const contenders = 16
+	var wins atomic.Int32
+	var wg sync.WaitGroup
+	leases := make(chan *datadirlock.Lease, contenders)
+	wg.Add(contenders)
+	for range contenders {
+		go func() {
+			defer wg.Done()
+			lease, err := datadirlock.Acquire(dir)
+			if err == nil {
+				wins.Add(1)
+				leases <- lease
+				return
+			}
+			if !errors.Is(err, datadirlock.ErrLocked) {
+				t.Errorf("unexpected err: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	close(leases)
+	if wins.Load() != 1 {
+		t.Fatalf("winners=%d, want 1", wins.Load())
+	}
+	for lease := range leases {
+		if err := lease.Close(); err != nil {
+			t.Errorf("close lease: %v", err)
+		}
+	}
+}
+
+// TestConcurrentSubprocessOneReachesReconcileMarker proves that when two real
+// processes contend for one data dir, exactly one reaches the durable-mutation
+// marker after acquiring the lease (mirrors boot: lease -> reconcile).
+func TestConcurrentSubprocessOneReachesReconcileMarker(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "reconciled.pids")
+	loserResult := filepath.Join(dir, "contender.error")
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	startChild := func() *exec.Cmd {
+		cmd := exec.Command(exe, "-test.run=TestHelperProcessAcquireAndReconcile", "-test.v")
+		cmd.Env = append(os.Environ(),
+			"DATADIRLOCK_HELPER=1",
+			"DATADIRLOCK_DIR="+dir,
+			"DATADIRLOCK_MARKER="+marker,
+			"DATADIRLOCK_LOSER_RESULT="+loserResult,
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd
+	}
+	first, second := startChild(), startChild()
+	if err := first.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Start(); err != nil {
+		_ = first.Process.Kill()
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 2)
+	go func() { done <- first.Wait() }()
+	go func() { done <- second.Wait() }()
+	var exitErrs int
+	for range 2 {
+		select {
+		case err := <-done:
+			if err != nil {
+				exitErrs++
+			}
+		case <-time.After(10 * time.Second):
+			_ = first.Process.Kill()
+			_ = second.Process.Kill()
+			t.Fatal("timeout waiting for helper children")
+		}
+	}
+	if exitErrs != 1 {
+		t.Fatalf("non-zero exits=%d, want 1 (one locked, one owner)", exitErrs)
+	}
+	loserErr, err := os.ReadFile(loserResult)
+	if err != nil {
+		t.Fatalf("read losing contender result: %v", err)
+	}
+	if !strings.Contains(string(loserErr), datadirlock.ErrLocked.Error()) {
+		t.Fatalf("losing contender err=%q, want ErrLocked", loserErr)
+	}
+	raw, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	lines := 0
+	for _, b := range raw {
+		if b == '\n' {
+			lines++
+		}
+	}
+	if lines != 1 {
+		t.Fatalf("marker lines=%d content=%q, want exactly one pid line", lines, raw)
+	}
+	if _, err := strconv.Atoi(string(raw[:len(raw)-1])); err != nil {
+		t.Fatalf("marker pid parse: %v (%q)", err, raw)
+	}
+}
+
+// TestHelperProcessAcquireAndReconcile is the subprocess body for
+// TestConcurrentSubprocessOneReachesReconcileMarker, not a standalone test.
+func TestHelperProcessAcquireAndReconcile(t *testing.T) {
+	if os.Getenv("DATADIRLOCK_HELPER") != "1" {
+		t.Skip("helper process")
+	}
+	dir := os.Getenv("DATADIRLOCK_DIR")
+	marker := os.Getenv("DATADIRLOCK_MARKER")
+	loserResult := os.Getenv("DATADIRLOCK_LOSER_RESULT")
+	lease, err := datadirlock.Acquire(dir)
+	if err != nil {
+		_ = os.WriteFile(loserResult, []byte(err.Error()), 0o600)
+		os.Exit(1)
+	}
+	f, err := os.OpenFile(marker, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		_ = lease.Close()
+		os.Exit(2)
+	}
+	if _, err := f.WriteString(strconv.Itoa(os.Getpid()) + "\n"); err != nil {
+		_ = f.Close()
+		_ = lease.Close()
+		os.Exit(2)
+	}
+	_ = f.Close()
+	// Keep the lease until the peer records its failed acquisition. This avoids
+	// relying on scheduler timing while still exercising two real processes.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(loserResult); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) || time.Now().After(deadline) {
+			_ = lease.Close()
+			os.Exit(2)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_ = lease.Close()
+	os.Exit(0)
+}

--- a/backend/internal/datadirlock/lock_unix.go
+++ b/backend/internal/datadirlock/lock_unix.go
@@ -1,0 +1,25 @@
+//go:build unix
+
+package datadirlock
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func tryLock(f *os.File) error {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return ErrLocked
+	}
+	return err
+}
+
+func unlockAndClose(f *os.File) error {
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return f.Close()
+}

--- a/backend/internal/datadirlock/lock_windows.go
+++ b/backend/internal/datadirlock/lock_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package datadirlock
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func tryLock(f *os.File) error {
+	// Lock the first byte of the file exclusively, non-blocking.
+	var ol windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&ol,
+	)
+	if err == nil {
+		return nil
+	}
+	if err == windows.ERROR_LOCK_VIOLATION || err == windows.ERROR_IO_PENDING {
+		return ErrLocked
+	}
+	return err
+}
+
+func unlockAndClose(f *os.File) error {
+	var ol windows.Overlapped
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &ol)
+	return f.Close()
+}

--- a/backend/internal/httpd/server.go
+++ b/backend/internal/httpd/server.go
@@ -35,12 +35,12 @@ type Server struct {
 // which case the /mux terminal surface is not mounted.
 //
 // If the configured port is already held, it falls back to an OS-assigned
-// ephemeral port rather than failing. A genuine peer AO daemon is ruled out
-// upstream (the running.json + /healthz check in daemon.Run), so a conflict here
-// means a non-AO process owns the port; exiting would only leave the desktop
-// supervisor stuck on "daemon not ready". The actual bound port is logged
-// ("daemon listening") and written to running.json, both of which the supervisor
-// reads, so the fallback propagates to the renderer with no UI changes.
+// ephemeral port rather than failing. Port binding does not grant mutation
+// authority over AO_DATA_DIR: daemon.Run acquires an exclusive data-dir lease
+// before opening the store or reconciling. A second AO process exits before it
+// reaches this bind, so the lease holder may safely use the fallback when a
+// non-AO process owns the configured port. The actual bound port is logged and
+// written to running.json, which propagates it to the renderer.
 func NewWithDeps(cfg config.Config, log *slog.Logger, termMgr *terminal.Manager, deps APIDeps) (*Server, error) {
 	log = loggerOrDefault(log)
 	ln, err := net.Listen("tcp", cfg.Addr())
@@ -48,12 +48,12 @@ func NewWithDeps(cfg config.Config, log *slog.Logger, termMgr *terminal.Manager,
 		if !isAddrInUse(err) {
 			return nil, fmt.Errorf("bind %s: %w", cfg.Addr(), err)
 		}
-		// Configured port is taken by a non-AO process: retry on an ephemeral port.
+		// The lease holder may retry on an ephemeral port when this port is taken.
 		fallback, ferr := net.Listen("tcp", net.JoinHostPort(cfg.Host, "0"))
 		if ferr != nil {
 			return nil, fmt.Errorf("bind %s (in use) and ephemeral fallback: %w", cfg.Addr(), ferr)
 		}
-		log.Warn("configured port in use; bound an ephemeral port instead",
+		log.Warn("configured port in use; bound an ephemeral port instead (data-dir lease already held)",
 			"configured", cfg.Addr(), "bound", fallback.Addr().String())
 		ln = fallback
 	}


### PR DESCRIPTION
## Summary

- acquire one OS-backed, process-lifetime lease per `AO_DATA_DIR` before SQLite is opened or migrated
- reject a second daemon using the same data directory even when its port and run file differ
- keep the existing same-run-file diagnostic and make data-dir conflicts actionable
- correct the desktop development workflow so real data is never shared by concurrent daemons

## Why

Ports and run files identify a daemon; they do not isolate SQLite. Two local AO versions using one `AO_DATA_DIR` can both pass their run-file checks, then a newer version can migrate the database while the older daemon is still running. The older process subsequently executes SQL against a schema it no longer understands.

With this change, parallel checkouts remain supported by giving each daemon a different `AO_DATA_DIR`. A second owner of the same directory fails before storage opens, so it cannot migrate or reconcile shared state.

Fixes #3716
Fixes #3805

## Implementation

- add a small cross-platform `internal/datadirlock` package
- use non-blocking `flock` on Unix and `LockFileEx` on Windows
- store the owning PID for diagnostics while treating the OS lock as authoritative
- hold the lease for the full daemon lifetime and release it on shutdown
- probe the conventional sibling `running.json` so a current build also rejects a data directory still owned by a live pre-lock AO release

This is schema-free and does not change the API.

## Validation

- `go test -p 1 ./...`
- `go test ./internal/datadirlock ./internal/daemon ./internal/httpd/...`
- `go test -race ./internal/daemon ./internal/datadirlock`
- `go build ./...`
- `go vet ./...`
- golangci-lint v2.12.2 with an isolated cache: 0 issues
- Linux amd64 and Windows amd64 `datadirlock` cross-compilation
- live two-daemon check with one temporary data directory and different ports/run files: second daemon rejected before creating its run file; acquisition succeeded after the first stopped
- native Electron verification with two simultaneous isolated instances and a third shared-data rejection; screenshots are in the PR comment
- mixed-version verification: a current daemon rejected data owned by an `origin/main` pre-lock daemon, which remained healthy
- AO desktop development skill validation
- `git diff --check`

The highly parallel `npm run lint` test phase hit existing timing flakes in the fake, kilocode, and opencode adapter packages. All three passed on their focused serial rerun, and the full serial backend suite above passed.
