### PR TITLE
fix: shorten download CTA copy

### DIFF
--- a/frontend/src/landing/src/app/components/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/src/landing/src/app/components/DownloadButton/DownloadButton.test.tsx
@@ -14,7 +14,7 @@ describe("DownloadButton", () => {
     const icons = link.find("[data-download-icon]");
 
     expect(link.attr("href")).toBe("/download");
-    expect(link.find("[data-download-label]").text()).toBe("Download AO");
+    expect(link.find("[data-download-label]").text()).toBe("Download");
     expect(icons).toHaveLength(2);
     expect(icons.eq(0).hasClass("md:hidden")).toBe(true);
     expect(icons.eq(1).hasClass("hidden")).toBe(true);

--- a/frontend/src/landing/src/app/components/DownloadButton/DownloadButton.tsx
+++ b/frontend/src/landing/src/app/components/DownloadButton/DownloadButton.tsx
@@ -138,7 +138,7 @@ export function DownloadButton({
       <span data-download-icon className="hidden md:inline-flex">
         <PlatformIcon platform={downloadPlatform} />
       </span>
-      <span data-download-label>Download AO</span>
+      <span data-download-label>Download</span>
     </Link>
   );
 }


### PR DESCRIPTION
## What changed

- Shorten the global landing CTA label from `Download AO` to `Download`.
- Update the focused component assertion to match.

## Why

The platform icon already provides contextual identity, so the shorter generic label is cleaner while preserving the existing responsive platform behavior.

## Impact

Only the visible CTA copy changes. The `/download` destination, responsive mobile/desktop icons, platform detection, and download flows are unchanged.

## Validation

- `npx vitest run --config vite.renderer.config.ts src/landing/src/app/components/DownloadButton/DownloadButton.test.tsx`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `npm run build`
