### PR TITLE
Fix maximized window layout

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -385,7 +385,6 @@ async function createWindowInternal(): Promise<void> {
 	syncNativeWindowBackground();
 	const shellWebContents = getShellWebContents();
 	if (!shellWebContents) throw new Error("AO shell WebContents was not created");
-	mainWindow.on("resize", composition.resize);
 
 	// On Windows the app paints its own title bar (WindowTitlebar), so the native
 	// menu bar is hidden (autoHideMenuBar above). The role-based menu is still

--- a/frontend/src/main/window-composition.test.ts
+++ b/frontend/src/main/window-composition.test.ts
@@ -3,8 +3,10 @@ import { createWindowComposition } from "./window-composition";
 
 function setup() {
 	let bounds = { x: 0, y: 0, width: 900, height: 640 };
+	let boundsChanged: (() => void) | undefined;
 	const addChildView = vi.fn();
 	const removeChildView = vi.fn();
+	const removeListener = vi.fn();
 	const close = vi.fn();
 	const view = {
 		webContents: { close },
@@ -13,10 +15,16 @@ function setup() {
 		setVisible: vi.fn(),
 	};
 	const mainWindow = {
-		contentView: { addChildView, removeChildView },
-		getContentBounds: () => bounds,
+		contentView: {
+			addChildView,
+			getBounds: () => bounds,
+			on: vi.fn((event: string, listener: () => void) => {
+				if (event === "bounds-changed") boundsChanged = listener;
+			}),
+			removeChildView,
+			removeListener,
+		},
 		isDestroyed: () => false,
-		on: vi.fn(),
 	};
 	function FakeWebContentsView() {
 		return view;
@@ -26,7 +34,20 @@ function setup() {
 		WebContentsView: FakeWebContentsView as never,
 		preload: "/preload.js",
 	});
-	return { addChildView, bounds: () => bounds, close, composition, mainWindow, removeChildView, view };
+	return {
+		addChildView,
+		bounds: () => bounds,
+		close,
+		composition,
+		emitBoundsChanged: () => boundsChanged?.(),
+		mainWindow,
+		removeChildView,
+		removeListener,
+		setBounds: (next: typeof bounds) => {
+			bounds = next;
+		},
+		view,
+	};
 }
 
 describe("createWindowComposition", () => {
@@ -44,14 +65,16 @@ describe("createWindowComposition", () => {
 	});
 
 	it("resizes and disposes the explicit shell without recreating it", () => {
-		const { bounds, close, composition, removeChildView, view } = setup();
+		const { bounds, close, composition, emitBoundsChanged, removeChildView, removeListener, setBounds, view } = setup();
 
 		(view.setBounds as ReturnType<typeof vi.fn>).mockClear();
-		composition.resize();
-		expect(view.setBounds).toHaveBeenCalledWith({ x: 0, y: 0, width: 900, height: 640 });
-		expect(bounds()).toEqual({ x: 0, y: 0, width: 900, height: 640 });
+		setBounds({ x: 0, y: 0, width: 1920, height: 1080 });
+		emitBoundsChanged();
+		expect(view.setBounds).toHaveBeenCalledWith({ x: 0, y: 0, width: 1920, height: 1080 });
+		expect(bounds()).toEqual({ x: 0, y: 0, width: 1920, height: 1080 });
 
 		composition.dispose();
+		expect(removeListener).toHaveBeenCalledWith("bounds-changed", composition.resize);
 		expect(removeChildView).toHaveBeenCalledWith(view);
 		expect(close).toHaveBeenCalledOnce();
 	});

--- a/frontend/src/main/window-composition.ts
+++ b/frontend/src/main/window-composition.ts
@@ -1,6 +1,6 @@
-import type { BaseWindow, WebContents, WebContentsView, Rectangle } from "electron";
+import type { BaseWindow, WebContents, WebContentsView } from "electron";
 
-type MainWindowHost = Pick<BaseWindow, "contentView" | "getContentBounds" | "on" | "isDestroyed">;
+type MainWindowHost = Pick<BaseWindow, "contentView" | "isDestroyed">;
 
 export type WebContentsViewConstructor = new (options: {
 	webPreferences: Electron.WebPreferences;
@@ -42,10 +42,11 @@ export function createWindowComposition(options: {
 	let overlayOpen = false;
 	const resize = (): void => {
 		if (options.mainWindow.isDestroyed?.()) return;
-		const bounds = options.mainWindow.getContentBounds() as Rectangle;
+		const bounds = options.mainWindow.contentView.getBounds();
 		shellView.setBounds({ x: 0, y: 0, width: bounds.width, height: bounds.height });
 		shellView.setVisible(true);
 	};
+	options.mainWindow.contentView.on("bounds-changed", resize);
 
 	const setOverlayOpen = (open: boolean): void => {
 		if (overlayOpen === open) return;
@@ -67,6 +68,7 @@ export function createWindowComposition(options: {
 		setOverlayOpen,
 		resize,
 		dispose: () => {
+			options.mainWindow.contentView.removeListener("bounds-changed", resize);
 			try {
 				options.mainWindow.contentView.removeChildView(shellView);
 			} catch {


### PR DESCRIPTION
## Summary

Resize the Electron shell from the native content view so maximized windows fill the full screen.

## Before

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/d6e52243-59f3-4529-8319-0ef9305f85bb" />

## After

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/152e2341-0a2e-4d5e-bf29-316045e4fbef" />
## Validation

- `npx vitest run src/main/window-composition.test.ts`
- `npm run typecheck`
