### PR TITLE
fix(claudeacp): resolve Windows .cmd shim to .exe for Chat spawn

### DIFF
--- a/backend/internal/adapters/chatdriver/claudeacp/driver.go
+++ b/backend/internal/adapters/chatdriver/claudeacp/driver.go
@@ -73,6 +73,7 @@ func New(plugin claudePlugin, log *slog.Logger) ports.ChatDriver {
 			if err != nil {
 				return acpdriver.Launch{}, fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
 			}
+			claudeBinary = resolveClaudeExe(ctx, claudeBinary)
 			env := make(map[string]string, len(cfg.Env)+1)
 			for key, value := range cfg.Env {
 				env[key] = value
@@ -199,6 +200,57 @@ func requireFile(path, label string) error {
 		return fmt.Errorf("%s at %s is a directory", label, path)
 	}
 	return nil
+}
+
+// resolveClaudeExe resolves a Windows npm .cmd shim to the .exe it delegates
+// to. Node child_process.spawn cannot execute .cmd files, so the ACP runtime
+// needs the real executable path. Without it, Windows users cannot switch to
+// Chat at all — the CDC and readiness work in the companion branch would be
+// unusable on Windows until this lands.
+func resolveClaudeExe(ctx context.Context, binary string) string {
+	if err := ctx.Err(); err != nil {
+		return binary
+	}
+	if runtime.GOOS != "windows" || !strings.HasSuffix(strings.ToLower(binary), ".cmd") {
+		return binary
+	}
+	exe := binary[:len(binary)-4] + ".exe"
+	if info, err := os.Stat(exe); err == nil && !info.IsDir() {
+		return exe
+	}
+	data, err := os.ReadFile(binary)
+	if err != nil {
+		return binary
+	}
+	dir := filepath.Dir(binary)
+	for _, line := range strings.Split(string(data), "\n") {
+		if err := ctx.Err(); err != nil {
+			return binary
+		}
+		line = strings.TrimSpace(line)
+		if !strings.Contains(line, ".exe") {
+			continue
+		}
+		start := strings.Index(line, `"`)
+		if start < 0 {
+			continue
+		}
+		rest := line[start+1:]
+		end := strings.Index(rest, `"`)
+		if end < 0 {
+			continue
+		}
+		quoted := rest[:end]
+		quoted = strings.ReplaceAll(quoted, `%dp0%`, dir)
+		quoted = filepath.Clean(quoted)
+		if !strings.HasSuffix(strings.ToLower(quoted), ".exe") {
+			continue
+		}
+		if info, err := os.Stat(quoted); err == nil && !info.IsDir() {
+			return quoted
+		}
+	}
+	return binary
 }
 
 func requireNodeVersion(ctx context.Context, node string) error {

--- a/backend/internal/adapters/chatdriver/claudeacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/claudeacp/driver_test.go
@@ -3,7 +3,9 @@ package claudeacp
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
@@ -58,5 +60,132 @@ func TestRuntimeCommandOverride(t *testing.T) {
 	}
 	if launch.command != executable || len(launch.args) != 0 {
 		t.Fatalf("runtime = %#v", launch)
+	}
+}
+
+// writeCmd writes a .cmd shim file in a temp dir and returns its path.
+func writeCmd(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// resolveClaudeExe is Windows-gated (runtime.GOOS != "windows" → pass-through).
+// Tests that depend on the .cmd branch still run on all platforms: the GOOS
+// check inside resolveClaudeExe returns the input unchanged on non-Windows,
+// which is the correct pass-through behavior. Windows-only branches (sibling
+// .exe, quoted %dp0%) are exercised when the test binary runs on Windows; on
+// other platforms the same cases assert the pass-through, so the suite stays
+// green everywhere while covering the Windows paths when run there.
+
+func TestResolveClaudeExePassThroughNonCmd(t *testing.T) {
+	ctx := context.Background()
+	if got := resolveClaudeExe(ctx, "/usr/local/bin/claude"); got != "/usr/local/bin/claude" {
+		t.Errorf("non-.cmd path = %q, want pass-through", got)
+	}
+	if got := resolveClaudeExe(ctx, ""); got != "" {
+		t.Errorf("empty path = %q, want pass-through", got)
+	}
+}
+
+func TestResolveClaudeExeCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// Even a .cmd path returns immediately when ctx is already cancelled.
+	cmd := writeCmd(t, "claude.cmd", "@echo off\n")
+	if got := resolveClaudeExe(ctx, cmd); got != cmd {
+		t.Errorf("cancelled ctx = %q, want %q (pass-through)", got, cmd)
+	}
+}
+
+func TestResolveClaudeExeMissingFile(t *testing.T) {
+	ctx := context.Background()
+	// A .cmd path that does not exist on disk returns the original path.
+	missing := filepath.Join(t.TempDir(), "nonexistent.cmd")
+	if got := resolveClaudeExe(ctx, missing); got != missing {
+		t.Errorf("missing .cmd = %q, want %q (pass-through)", got, missing)
+	}
+}
+
+func TestResolveClaudeExeSiblingExe(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("sibling .exe resolution is Windows-gated")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	cmdPath := filepath.Join(dir, "claude.cmd")
+	if err := os.WriteFile(cmdPath, []byte("@echo off"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exePath := filepath.Join(dir, "claude.exe")
+	if err := os.WriteFile(exePath, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveClaudeExe(ctx, cmdPath); got != exePath {
+		t.Errorf("sibling .exe = %q, want %q", got, exePath)
+	}
+}
+
+func TestResolveClaudeExeQuotedDp0Target(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("dp0 expansion is Windows-gated")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	// Simulate an npm .cmd shim that delegates to a nested .exe.
+	targetExe := filepath.Join(dir, "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe")
+	if err := os.MkdirAll(filepath.Dir(targetExe), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetExe, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmdContent := "@echo off\n" +
+		"\"%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe\" %*\n"
+	cmdPath := filepath.Join(dir, "claude.cmd")
+	if err := os.WriteFile(cmdPath, []byte(cmdContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveClaudeExe(ctx, cmdPath)
+	want, _ := filepath.Abs(targetExe)
+	if got != want {
+		t.Errorf("quoted %%dp0%% target = %q, want %q", got, want)
+	}
+}
+
+func TestResolveClaudeExeMalformedCmd(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("malformed .cmd fallback is Windows-gated")
+	}
+	ctx := context.Background()
+	// A .cmd with no valid .exe reference falls through to the original path.
+	cmdPath := writeCmd(t, "claude.cmd", "@echo off\nrem no exe here\n")
+	if got := resolveClaudeExe(ctx, cmdPath); got != cmdPath {
+		t.Errorf("malformed .cmd = %q, want %q (pass-through)", got, cmdPath)
+	}
+}
+
+func TestResolveClaudeExeUnreadableCmd(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("unreadable .cmd fallback is Windows-gated")
+	}
+	ctx := context.Background()
+	// A .cmd file that exists but cannot be read falls through to the original.
+	cmdPath := writeCmd(t, "claude.cmd", "@echo off\n")
+	// Remove read permission. On Windows this may not block os.ReadFile for
+	// the owner, so the assertion tolerates either outcome: if the file is
+	// still readable, resolveClaudeExe parses it and may find no .exe →
+	// pass-through; if unreadable, it returns the original path. Either way
+	// the result must be the original cmd path (no sibling .exe exists).
+	if err := os.Chmod(cmdPath, 0o000); err != nil {
+		t.Skipf("chmod unsupported: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cmdPath, 0o644) })
+	if got := resolveClaudeExe(ctx, cmdPath); got != cmdPath {
+		t.Errorf("unreadable .cmd = %q, want %q (pass-through)", got, cmdPath)
 	}
 }

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -380,6 +380,15 @@ func (m *Manager) nativeConversationID(
 	}
 	id = strings.TrimSpace(id)
 	if !ok || id == "" {
+		// An adapter with a history probe can safely start fresh when the
+		// native id is missing: the probe distinguishes a real conversation
+		// from an empty TUI, and persistedNativeConversationID uses that to
+		// decide between resume and fresh start. Without a probe, a missing
+		// id is a hard block — there is no safe way to know whether the
+		// TUI's work would be lost.
+		if _, ok := handoff.(ports.AgentInterfaceHandoffHistoryProbe); ok {
+			return "", handoff, nil
+		}
 		return "", handoff, fmt.Errorf("%w for %s", ErrNativeConversationMissing, rec.Harness)
 	}
 	return id, handoff, nil

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -89,6 +89,7 @@ var shippedMigrations = map[int64]string{
 	83: "0083_reconcile_kimchi_prime_agent_harnesses.sql",
 	84: "0084_add_session_auto_inject_review.sql",
 	85: "0085_agent_switching.sql",
+	86: "0086_session_cdc_provider_conversation_id.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0086_session_cdc_provider_conversation_id.sql
+++ b/backend/internal/storage/sqlite/migrations/0086_session_cdc_provider_conversation_id.sql
@@ -1,0 +1,90 @@
+-- Add provider_conversation_id to the sessions_cdc_update WHEN guard that
+-- 0085_agent_switching established. The Chat driver writes this column
+-- independently of agent_session_id (chat_spawn.go: ControllerReady), so a
+-- write to it must fan out a session_updated event for the interface-transition
+-- query to refetch. Guard-only change: session_updated is an invalidation-only
+-- nudge (consumers refetch, see renderer/lib/event-transport.ts), so the
+-- payload stays as-is — matching the convention established by migration 0024.
+
+-- +goose Up
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.terminate_on_pr_merge <> NEW.terminate_on_pr_merge
+    OR OLD.is_pinned <> NEW.is_pinned
+    OR OLD.pinned_at <> NEW.pinned_at
+    OR (OLD.pinned_at IS NULL AND NEW.pinned_at IS NOT NULL)
+    OR (OLD.pinned_at IS NOT NULL AND NEW.pinned_at IS NULL)
+    OR OLD.session_mode <> NEW.session_mode
+    OR OLD.auto_inject_review <> NEW.auto_inject_review
+    OR OLD.harness <> NEW.harness
+    OR OLD.runtime_launch_id <> NEW.runtime_launch_id
+    OR OLD.agent_session_id <> NEW.agent_session_id
+    OR OLD.native_transcript_path <> NEW.native_transcript_path
+    OR OLD.provider_conversation_id <> NEW.provider_conversation_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object(
+            'id', NEW.id,
+            'activity', NEW.activity_state,
+            'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END),
+            'terminateOnPrMerge', json(CASE WHEN NEW.terminate_on_pr_merge THEN 'true' ELSE 'false' END),
+            'previewUrl', NEW.preview_url,
+            'previewRevision', NEW.preview_revision,
+            'isPinned', json(CASE WHEN NEW.is_pinned THEN 'true' ELSE 'false' END),
+            'mode', NEW.session_mode,
+            'autoInjectReview', json(CASE WHEN NEW.auto_inject_review THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- Restore the trigger 0085_agent_switching established (without
+-- provider_conversation_id in the guard).
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.terminate_on_pr_merge <> NEW.terminate_on_pr_merge
+    OR OLD.is_pinned <> NEW.is_pinned
+    OR OLD.pinned_at <> NEW.pinned_at
+    OR (OLD.pinned_at IS NULL AND NEW.pinned_at IS NOT NULL)
+    OR (OLD.pinned_at IS NOT NULL AND NEW.pinned_at IS NULL)
+    OR OLD.session_mode <> NEW.session_mode
+    OR OLD.auto_inject_review <> NEW.auto_inject_review
+    OR OLD.harness <> NEW.harness
+    OR OLD.runtime_launch_id <> NEW.runtime_launch_id
+    OR OLD.agent_session_id <> NEW.agent_session_id
+    OR OLD.native_transcript_path <> NEW.native_transcript_path
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object(
+            'id', NEW.id,
+            'activity', NEW.activity_state,
+            'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END),
+            'terminateOnPrMerge', json(CASE WHEN NEW.terminate_on_pr_merge THEN 'true' ELSE 'false' END),
+            'previewUrl', NEW.preview_url,
+            'previewRevision', NEW.preview_revision,
+            'isPinned', json(CASE WHEN NEW.is_pinned THEN 'true' ELSE 'false' END),
+            'mode', NEW.session_mode,
+            'autoInjectReview', json(CASE WHEN NEW.auto_inject_review THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -1402,3 +1402,88 @@ func TestUpsertSessionWorktreeEmptyStateDefaultsToActive(t *testing.T) {
 		t.Fatalf("State = %q, want %q", got.State, "active")
 	}
 }
+
+// Migration 0085 added agent_session_id and provider_conversation_id to the
+// sessions_cdc_update WHEN guard. A write to either column must emit exactly
+// one session_updated event; an unrelated metadata write must not.
+func TestSessionAgentSessionIDFiresCDCEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "cdc")
+	r, _ := s.CreateSession(ctx, sampleRecord("cdc"))
+
+	base, _ := s.LatestSeq(ctx)
+	r.Metadata.AgentSessionID = "native-thread-1"
+	r.UpdatedAt = r.UpdatedAt.Add(time.Minute)
+	if err := s.UpdateSession(ctx, r); err != nil {
+		t.Fatalf("update agent_session_id: %v", err)
+	}
+
+	evs, err := s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	for _, e := range evs {
+		if string(e.Type) == "session_updated" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("session_updated events = %d, want 1 after agent_session_id write", count)
+	}
+}
+
+func TestSessionProviderConversationIDFiresCDCEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "cdc2")
+	r, _ := s.CreateSession(ctx, sampleRecord("cdc2"))
+
+	base, _ := s.LatestSeq(ctx)
+	r.Metadata.ProviderConversationID = "provider-conv-1"
+	r.UpdatedAt = r.UpdatedAt.Add(time.Minute)
+	if err := s.UpdateSession(ctx, r); err != nil {
+		t.Fatalf("update provider_conversation_id: %v", err)
+	}
+
+	evs, err := s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	for _, e := range evs {
+		if string(e.Type) == "session_updated" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("session_updated events = %d, want 1 after provider_conversation_id write", count)
+	}
+}
+
+// An unrelated metadata write must not emit a session_updated event — the
+// CDC guard must not fire for columns outside its WHEN clause.
+func TestSessionUnrelatedMetadataSuppressesCDCEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "cdc3")
+	r, _ := s.CreateSession(ctx, sampleRecord("cdc3"))
+
+	base, _ := s.LatestSeq(ctx)
+	// Update with the same values so no guard column changes.
+	r.UpdatedAt = r.UpdatedAt.Add(time.Minute)
+	if err := s.UpdateSession(ctx, r); err != nil {
+		t.Fatalf("update no-op: %v", err)
+	}
+
+	evs, err := s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range evs {
+		if string(e.Type) == "session_updated" {
+			t.Fatalf("session_updated emitted for unrelated metadata write: %+v", e)
+		}
+	}
+}

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -1403,9 +1403,10 @@ func TestUpsertSessionWorktreeEmptyStateDefaultsToActive(t *testing.T) {
 	}
 }
 
-// Migration 0085 added agent_session_id and provider_conversation_id to the
-// sessions_cdc_update WHEN guard. A write to either column must emit exactly
-// one session_updated event; an unrelated metadata write must not.
+// Migration 0086 added provider_conversation_id to the sessions_cdc_update
+// WHEN guard that 0085_agent_switching established (which already included
+// agent_session_id). A write to either column must emit exactly one
+// session_updated event; an unrelated metadata write must not.
 func TestSessionAgentSessionIDFiresCDCEvent(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -50,7 +50,7 @@ class EventSourceStub {
 		this.handlers.set(type, listener);
 	}
 	emit(type: string, data: string) {
-		this.handlers.get(type)?.({ data } as unknown as Event);
+		this.handlers.get(type)?.({ data, type } as unknown as Event);
 	}
 	close() {
 		this.closed = true;
@@ -172,6 +172,58 @@ describe("createEventTransport", () => {
 			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ["workspaces"] });
 			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
 				queryKey: ["session-scm-summary"],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("invalidates the interface transition query on session_updated CDC", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"session_updated",
+				JSON.stringify({
+					seq: 1,
+					projectId: "proj-1",
+					sessionId: "sess-1",
+					type: "session_updated",
+					payload: { id: "sess-1", sessionId: "sess-1" },
+					createdAt: "2026-08-09T12:00:00Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+				queryKey: ["session-interface-transition", "sess-1"],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not invalidate the interface transition query on non-session events", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"pr_created",
+				JSON.stringify({
+					seq: 1,
+					projectId: "proj-1",
+					sessionId: "sess-1",
+					type: "pr_created",
+					payload: { id: "sess-1" },
+					createdAt: "2026-08-09T12:00:00Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+				queryKey: ["session-interface-transition", "sess-1"],
 			});
 		} finally {
 			vi.useRealTimers();

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -5,6 +5,7 @@ import { setEventsConnectionState } from "./events-connection";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { sessionScmSummaryQueryKey } from "../hooks/useSessionScmSummary";
 import { conversationQueryKey } from "../hooks/useConversation";
+import { sessionInterfaceTransitionQueryKey } from "../hooks/useSessionInterfaceTransition";
 import { sessionUsageQueryRoot } from "../hooks/useSessionUsageSummaries";
 
 export type EventTransport = {
@@ -47,6 +48,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 		connect() {
 			let debounce: ReturnType<typeof setTimeout> | undefined;
 			const pendingConversationSessions = new Set<string>();
+			const pendingTransitionSessions = new Set<string>();
 			let workspaceInvalidationPending = false;
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
@@ -54,30 +56,31 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 			const refreshWorkspaces = (event?: Event) => {
 				let conversationOnly = false;
 				if (event && "data" in event) {
-					try {
-						const decoded = JSON.parse(String((event as MessageEvent).data)) as {
-							sessionId?: unknown;
-							payload?: unknown;
-						};
-						// The SSE endpoint sends the complete durable CDC event. Routing
-						// fields such as sessionId live on that envelope, while trigger-built
-						// details such as conversationId live inside its payload. Do not
-						// mistake the payload for the entire event: doing so refreshes the
-						// sidebar but leaves a Chat timeline frozen on its pre-turn snapshot.
-						const payload =
-							typeof decoded.payload === "object" && decoded.payload !== null
-								? (decoded.payload as { conversationId?: unknown })
-								: undefined;
+				try {
+					const decoded = JSON.parse(String((event as MessageEvent).data)) as {
+						sessionId?: unknown;
+						payload?: unknown;
+					};
+					// The SSE endpoint sends the complete durable CDC event. Routing
+					// fields such as sessionId live on that envelope, while trigger-built
+					// details such as conversationId live inside its payload. Do not
+					// mistake the payload for the entire event: doing so refreshes the
+					// sidebar but leaves a Chat timeline frozen on its pre-turn snapshot.
+					const payload =
+						typeof decoded.payload === "object" && decoded.payload !== null
+							? (decoded.payload as { conversationId?: unknown })
+							: undefined;
+					if (typeof decoded.sessionId === "string" && decoded.sessionId) {
+						pendingTransitionSessions.add(decoded.sessionId);
 						if (
-							typeof decoded.sessionId === "string" &&
-							decoded.sessionId &&
 							typeof payload?.conversationId === "string" &&
 							payload.conversationId
 						) {
 							pendingConversationSessions.add(decoded.sessionId);
 							conversationOnly = true;
 						}
-					} catch {
+					}
+				} catch {
 						// A malformed CDC payload still invalidates workspaces; it simply
 						// cannot target a conversation cache precisely.
 					}
@@ -94,7 +97,11 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 					for (const sessionId of pendingConversationSessions) {
 						void queryClient.invalidateQueries({ queryKey: conversationQueryKey(sessionId) });
 					}
+					for (const sessionId of pendingTransitionSessions) {
+						void queryClient.invalidateQueries({ queryKey: sessionInterfaceTransitionQueryKey(sessionId) });
+					}
 					pendingConversationSessions.clear();
+					pendingTransitionSessions.clear();
 				}, INVALIDATE_DEBOUNCE_MS);
 			};
 

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -53,34 +53,44 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
 			let sourceBaseUrl: string | undefined;
-			const refreshWorkspaces = (event?: Event) => {
+			const scheduleCacheInvalidations = (event?: Event) => {
 				let conversationOnly = false;
 				if (event && "data" in event) {
-				try {
-					const decoded = JSON.parse(String((event as MessageEvent).data)) as {
-						sessionId?: unknown;
-						payload?: unknown;
-					};
-					// The SSE endpoint sends the complete durable CDC event. Routing
-					// fields such as sessionId live on that envelope, while trigger-built
-					// details such as conversationId live inside its payload. Do not
-					// mistake the payload for the entire event: doing so refreshes the
-					// sidebar but leaves a Chat timeline frozen on its pre-turn snapshot.
-					const payload =
-						typeof decoded.payload === "object" && decoded.payload !== null
-							? (decoded.payload as { conversationId?: unknown })
-							: undefined;
-					if (typeof decoded.sessionId === "string" && decoded.sessionId) {
-						pendingTransitionSessions.add(decoded.sessionId);
+					try {
+						const decoded = JSON.parse(String((event as MessageEvent).data)) as {
+							sessionId?: unknown;
+							payload?: unknown;
+						};
+						// The SSE endpoint sends the complete durable CDC event. Routing
+						// fields such as sessionId live on that envelope, while trigger-built
+						// details such as conversationId live inside its payload. Do not
+						// mistake the payload for the entire event: doing so refreshes the
+						// sidebar but leaves a Chat timeline frozen on its pre-turn snapshot.
+						const payload =
+							typeof decoded.payload === "object" && decoded.payload !== null
+								? (decoded.payload as { conversationId?: unknown })
+								: undefined;
 						if (
+							typeof decoded.sessionId === "string" &&
+							decoded.sessionId &&
 							typeof payload?.conversationId === "string" &&
 							payload.conversationId
 						) {
 							pendingConversationSessions.add(decoded.sessionId);
 							conversationOnly = true;
 						}
-					}
-				} catch {
+						// Transition invalidation is gated on session_updated: only a
+						// session row change (agent_session_id or provider_conversation_id
+						// landing) means the "Switch to Chat" readiness may have flipped.
+						// PR/check/review events do not affect interface readiness.
+						if (
+							typeof decoded.sessionId === "string" &&
+							decoded.sessionId &&
+							(event as MessageEvent).type === "session_updated"
+						) {
+							pendingTransitionSessions.add(decoded.sessionId);
+						}
+					} catch {
 						// A malformed CDC payload still invalidates workspaces; it simply
 						// cannot target a conversation cache precisely.
 					}
@@ -135,7 +145,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 					source.onopen = () => {
 						setEventsConnectionState("connected");
 						// Events emitted during the gap were lost; refetch once on (re)open.
-						refreshWorkspaces();
+						scheduleCacheInvalidations();
 					};
 					source.onerror = () => {
 						// While readyState is CONNECTING the browser retries on its own;
@@ -144,9 +154,9 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 						setEventsConnectionState("disconnected");
 						if (source?.readyState === EVENTSOURCE_CLOSED) scheduleRetry();
 					};
-					source.onmessage = refreshWorkspaces; // unnamed events, if any
+					source.onmessage = scheduleCacheInvalidations; // unnamed events, if any
 					for (const type of CDC_EVENT_TYPES) {
-						source.addEventListener(type, refreshWorkspaces);
+						source.addEventListener(type, scheduleCacheInvalidations);
 					}
 					// EventSource auto-reconnects and resumes via Last-Event-ID while
 					// CONNECTING; scheduleRetry only covers the terminal CLOSED state.
@@ -157,7 +167,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 
 			const removeDaemonListener = aoBridge.daemon.onStatus(() => {
 				connectSource();
-				refreshWorkspaces();
+				scheduleCacheInvalidations();
 			});
 			// Rebind when the daemon comes back on a different port, independent of
 			// status-event ordering.


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Fixes the Windows half of <a href="https://github.com/Untrivial-ai/agent-orchestrator/issues/3753">#3753</a> — required for <a href="https://github.com/Untrivial-ai/agent-orchestrator/pull/3771">#3771</a> to work on Windows.</p>
<h2>Problem</h2>
<p>On Windows, <code>ResolveBinary</code> returns the npm <code>.cmd</code> shim (e.g.
<code>%APPDATA%\npm\claude.cmd</code>). AO's ACP driver passes that to the Node SDK
runtime via <code>env["CLAUDE_CODE_EXECUTABLE"]</code>, which the SDK feeds
<strong>directly</strong> into <code>child_process.spawn</code> with no <code>shell: true</code>. Node on
Windows cannot execute <code>.cmd</code> files that way — spawn throws <code>EINVAL</code>
before any ACP handshake.</p>
<p>Confirmed on clean upstream main (Windows): clicking "Switch to Chat" for
a Claude Code session fails silently — the button enables (after #3771)
but the spawn dies with <code>EINVAL</code>.</p>
<h3>Trace on Windows (clean main)</h3>

Step | Site | What happens
-- | -- | --
1 | claudeacp/driver.go:72 | plugin.ResolveBinary(ctx) → claude.cmd (npm shim)
2 | claudeacp/driver.go:82 | env["CLAUDE_CODE_EXECUTABLE"] = "claude.cmd"
3 | claude-agent-acp acp-agent.js:230 (claudeCliPath) | returns process.env.CLAUDE_CODE_EXECUTABLE verbatim
4 | claude-agent-sdk sdk.mjs (yye) | .cmd is not .js/.mjs/.ts/.tsx/.jsx → treats as native binary
5 | claude-agent-sdk sdk.mjs (spawnLocalProcess) | cye("claude.cmd", args, {stdio:["pipe","pipe","pipe"], windowsHide:true}) — no shell: true
6 | Node child_process.spawn on Windows | EINVAL — .cmd requires a shell


<p>Windows-gated cases skip on other platforms; the suite stays green
everywhere while exercising the Windows branches when run there.</p>
<h2>Scope</h2>
<p>Split out from #3771 per illegalcall's review ("this Windows <code>.cmd</code>
workaround addresses a separate post-click ACP launch failure... please
split it into its own issue/PR"). Readiness (#3771) and launch (this PR)
are independent fixes — #3771 enables the button, this PR makes the
click work on Windows.</p>
<p><strong>Base: <code>fix/interface-switch-native-session-poll</code></strong> (#3771's branch).
Merging this into #3771 gives the combined Windows fix: button enables
<strong>and</strong> click succeeds. Per Dhruv Sharma's instruction on #3771: raise
this PR with base = #3771's branch, merge it into the same branch, then
test combined.</p>
<h2>Checklist</h2>
<ul>
<li>[x] <code>context.Context</code> as first arg, cancellation checked (illegalcall inline)</li>
<li>[x] Direct tests: sibling <code>.exe</code>, quoted <code>%dp0%</code>, malformed/missing, pass-through/failure (illegalcall inline)</li>
<li>[x] Conventional commit (<code>fix(claudeacp):</code>)</li>
<li>[x] Surgical — one concern, no speculative abstractions</li>
<li>[x] <code>go test ./internal/adapters/chatdriver/claudeacp/...</code> — pass</li>
<li>[x] <code>go vet ./internal/adapters/chatdriver/claudeacp/...</code> — clean</li>
</ul></body></html><!--EndFragment-->
</body>
</html>Fixes the Windows half of [[#3753](https://github.com/Untrivial-ai/agent-orchestrator/issues/3753)](https://github.com/Untrivial-ai/agent-orchestrator/issues/3753) — required for [[#3771](https://github.com/Untrivial-ai/agent-orchestrator/pull/3771)](https://github.com/Untrivial-ai/agent-orchestrator/pull/3771) to work on Windows.

## Problem

On Windows, `ResolveBinary` returns the npm `.cmd` shim (e.g.
`%APPDATA%\npm\claude.cmd`). AO's ACP driver passes that to the Node SDK
runtime via `env["CLAUDE_CODE_EXECUTABLE"]`, which the SDK feeds
**directly** into `child_process.spawn` with no `shell: true`. Node on
Windows cannot execute `.cmd` files that way — spawn throws `EINVAL`
before any ACP handshake.

Confirmed on clean upstream main (Windows): clicking "Switch to Chat" for
a Claude Code session fails silently — the button enables (after #3771)
but the spawn dies with `EINVAL`.

### Trace on Windows (clean main)

| Step | Site | What happens |
|------|------|---------------|
| 1 | `claudeacp/driver.go:72` | `plugin.ResolveBinary(ctx)` → `claude.cmd` (npm shim) |
| 2 | `claudeacp/driver.go:82` | `env["CLAUDE_CODE_EXECUTABLE"] = "claude.cmd"` |
| 3 | `claude-agent-acp` `acp-agent.js:230` (`claudeCliPath`) | returns `process.env.CLAUDE_CODE_EXECUTABLE` verbatim |
| 4 | `claude-agent-sdk` `sdk.mjs` (`yye`) | `.cmd` is not `.js/.mjs/.ts/.tsx/.jsx` → treats as native binary |
| 5 | `claude-agent-sdk` `sdk.mjs` (`spawnLocalProcess`) | `cye("claude.cmd", args, {stdio:["pipe","pipe","pipe"], windowsHide:true})` — no `shell: true` |
| 6 | Node `child_process.spawn` on Windows | **`EINVAL`** — `.cmd` requires a shell |

The SDK's `eSe()` recognizes `.cmd` as a Windows executable extension, but
that's only consulted by `tSe()` (the `where.exe` PATH-lookup fallback).
When `CLAUDE_CODE_EXECUTABLE` is set, the path is used unmodified.

### Why #3771 alone isn't enough on Windows

| Capability | Mac/Linux | Windows |
|---|---|---|
| #3735 (poll + hook pinning) | hook fires → poll catches | hook never fires (ConPTY) |
| #3771 (history probe fresh-start) | bonus (redundant) | button enables ✅ |
| #3771 (CDC push invalidation) | latency: 1s → instant | helps, doesn't solve alone |
| #3771 alone — click works? | yes (`.exe`/shebang) | **no — `spawn EINVAL` on `.cmd`** ❌ |
| This PR — `.cmd` unwrap | n/a | **yes — `spawn` receives `.exe`** ✅ |

#3771 enables the button; this PR makes the click actually launch.
Together they complete the Windows path.

## Fix

`backend/internal/adapters/chatdriver/claudeacp/driver.go`

Add `resolveClaudeExe(ctx, binary)`, called from `Launch` after
`ResolveBinary` returns, before the ACP runtime inherits the env. On
non-Windows or non-`.cmd` paths it passes through unchanged.

Resolution order on Windows:
1. **Sibling `.exe`** — if `claude.exe` exists next to `claude.cmd`, use it.
2. **Parse the shim** — npm `.cmd` shims contain a quoted
   `"...\claude.exe" %*` line. Extract the quoted target, expand `%dp0%`
   to the shim's directory, and if the resolved path exists and is a
   file, use it.
3. **Fallback** — return the original `.cmd` path unchanged (spawn will
   fail with the original EINVAL — no behavior regression).

### `context.Context`

Per repo guidance (`context.Context` as the first argument for
functions doing I/O), `resolveClaudeExe` accepts `ctx` and checks
`ctx.Err()` at entry and inside the parse loop. Propagated from `Launch`
which already holds `ctx`.

## Tests

`backend/internal/adapters/chatdriver/claudeacp/driver_test.go` — 7 new
tests, covering the cases illegalcall asked for ("sibling `.exe`, quoted
`%dp0%` target, malformed or missing targets, and pass-through/failure
behavior"):

| Test | Case | Platforms |
|------|------|-----------|
| `TestResolveClaudeExePassThroughNonCmd` | non-`.cmd` + empty path pass through | all |
| `TestResolveClaudeExeCancelledContext` | cancelled ctx returns original immediately | all |
| `TestResolveClaudeExeMissingFile` | `.cmd` path that doesn't exist → pass-through | all |
| `TestResolveClaudeExeSiblingExe` | `claude.exe` next to `claude.cmd` → use `.exe` | Windows (skip elsewhere) |
| `TestResolveClaudeExeQuotedDp0Target` | `"%dp0%\...\claude.exe"` → expand + resolve | Windows (skip elsewhere) |
| `TestResolveClaudeExeMalformedCmd` | `.cmd` with no `.exe` reference → pass-through | Windows (skip elsewhere) |
| `TestResolveClaudeExeUnreadableCmd` | `.cmd` that can't be read → pass-through | Windows (skip elsewhere) |

Windows-gated cases skip on other platforms; the suite stays green
everywhere while exercising the Windows branches when run there.

## Scope

Split out from #3771 per illegalcall's review ("this Windows `.cmd`
workaround addresses a separate post-click ACP launch failure... please
split it into its own issue/PR"). Readiness (#3771) and launch (this PR)
are independent fixes — #3771 enables the button, this PR makes the
click work on Windows.

**Base: `fix/interface-switch-native-session-poll`** (#3771's branch).
Merging this into #3771 gives the combined Windows fix: button enables
**and** click succeeds. Per Dhruv Sharma's instruction on #3771: raise
this PR with base = #3771's branch, merge it into the same branch, then
test combined.

## Checklist

- [x] `context.Context` as first arg, cancellation checked (illegalcall inline)
- [x] Direct tests: sibling `.exe`, quoted `%dp0%`, malformed/missing, pass-through/failure (illegalcall inline)
- [x] Conventional commit (`fix(claudeacp):`)
- [x] Surgical — one concern, no speculative abstractions
- [x] `go test ./internal/adapters/chatdriver/claudeacp/...` — pass
- [x] `go vet ./internal/adapters/chatdriver/claudeacp/...` — clean