### PR TITLE
fix(telemetry): stop dropping renderer app-active heartbeat

### DIFF
--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -512,12 +512,16 @@ export async function initTelemetry(): Promise<boolean> {
 			storage: telemetryStorage(),
 			window,
 			document,
+			// Ride the batched request queue like every other renderer event
+			// (loaded, route_viewed). An earlier `send_instantly: true` here
+			// fired an immediate, un-retried send during init that never
+			// reached PostHog in packaged builds, so renderer app-active
+			// dropped to zero while batched events kept landing.
 			capture: async () =>
 				Boolean(
 					posthog.capture(
 						postHogEventName("ao.app.active"),
 						withTelemetryContext(await sanitizeRendererProperties("ao.app.active", { channel: "renderer" })),
-						{ send_instantly: true },
 					),
 				),
 		});


### PR DESCRIPTION
## Summary

The desktop renderer's daily-active heartbeat (`ao.v2.app.active`) was effectively not reaching PostHog. Desktop DAU was being read almost entirely from CLI/daemon heartbeats, so the "active users" number under-represented real app opens by roughly 4-5x. This changes the renderer heartbeat to send the same batched way every other renderer event does, which restores delivery.

One line changes: remove `send_instantly: true` from the heartbeat capture in `frontend/src/renderer/lib/telemetry.ts`.

## Symptom

Reading `ao.v2.app.active` as DAU showed ~40 unique users/day. Broken down by `channel`, that number is 100% `cli`; the `renderer` channel contributes zero. Meanwhile the desktop app was clearly in use: `ao.v2.renderer.loaded` shows 130-200 renderer users/day over the same window.

## Root cause

Two issues stack, both in how `initTelemetry` wires the heartbeat:

1. The heartbeat was captured with `{ send_instantly: true }`. That routes the event to PostHog's immediate single-shot send path instead of the batched request queue. The first (and, per the reservation logic, effectively only) send fires during `posthog.init(...)`, and in packaged builds it does not land. Every other renderer event rides the batched queue and is delivered reliably.

2. The capture callback is `Boolean(posthog.capture(...))`. `posthog.capture()` returns a truthy result synchronously the moment the event is accepted, the network send is fire-and-forget, so the callback is always `true` even when delivery fails. The heartbeat only releases its daily reservation and retries when the callback returns `false`, so the retry path never fires in production, and the once-per-six-hour-slot reservation stays held. Net effect: exactly one delivery attempt per slot, at startup, with no retry and no way to notice it failed.

This PR fixes (1), which is the delivery problem. (2) is left in place intentionally: once the heartbeat is batched, holding the reservation is correct (the SDK owns retry/flush), and changing the success check would risk double-sends. It is called out here as a known latent issue rather than fixed in this PR to keep the change scoped.

## Evidence

All from live PostHog (project 475752) over the last 15 days, plus reading the code.

- The server-side ingestion transformation ("AO legacy CLI firehose cost control") only drops `app.active` when `channel = 'cli'` and the command is a routine poll. Renderer events (`channel = 'renderer'`) are explicitly preserved, so the transformation is not the cause.
- `ao.v2.app.active` by `channel`: `renderer` never appears; the series is entirely `cli`.
- `ao.v2.renderer.loaded` (renderer, batched): 130, 119, 113, 202, 155, 179... So the renderer's PostHog pipeline and the v1 to v2 name alias both work, and builds carrying this code are live.
- Controlled comparison of three renderer events:

| event | reserve-gated | send_instantly | daily unique users |
| --- | --- | --- | --- |
| `ao.v2.renderer.loaded` | no | no | ~130-200 |
| `ao.v2.renderer.route_viewed` | yes | no | ~120-200 |
| `ao.v2.app.active` | yes | yes | ~40 (all CLI; renderer = 0) |

`route_viewed` carries the exact same reserve-gating as `app.active` but is sent batched, and it lands at full volume. The only difference between the working `route_viewed` and the dead `app.active` is `send_instantly`.

## The fix

Capture the heartbeat with no `send_instantly` option, identical to `renderer.loaded` and `route_viewed`, so it uses the reliable batched queue.

## Testing

- `frontend/src/renderer/lib/telemetry.test.ts`: 29/29 pass, including the six-hour-slot retry test.
- `tsc --noEmit`: no type errors on the changed file.
- Not verified at runtime: confirming delivery in a packaged build (launch a packaged build with renderer DevTools and observe the `ao.v2.app.active` request succeed). This is the one step that needs a packaged build and could not be done in review; the unit tests and typecheck cover logic and compilation only.

## Follow-ups (not in this PR)

- Fix the always-truthy success check (item 2 above) so a genuinely failed heartbeat send is detectable, or drop the retry mechanism now that delivery is batched.
- Dashboards: until this ships and is adopted, desktop DAU should be read from `ao.v2.renderer.loaded` unique users (or `route_viewed`), not `ao.v2.app.active`, which is CLI-only.

## Origin

The `send_instantly: true` flag was added to the heartbeat in https://github.com/Untrivial-ai/agent-orchestrator/pull/2947 ("fix: reduce telemetry event volume"). The heartbeat itself was introduced in https://github.com/Untrivial-ai/agent-orchestrator/pull/2633, and the v2 rename in https://github.com/Untrivial-ai/agent-orchestrator/pull/3314.
