### PR TITLE
fix: make ao available in reviewer launches

### DIFF
--- a/backend/internal/adapters/reviewer/codex/codex.go
+++ b/backend/internal/adapters/reviewer/codex/codex.go
@@ -47,7 +47,7 @@ func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation
 	if err != nil {
 		return ports.ReviewCommandSpec{}, err
 	}
-	extra, err := codexReadOnlyArgs()
+	extra, err := codexReadOnlyArgs(inv)
 	if err != nil {
 		return ports.ReviewCommandSpec{}, err
 	}
@@ -61,7 +61,7 @@ func (r *Reviewer) ReviewRestoreCommand(ctx context.Context, inv ports.ReviewInv
 	if err != nil || !ok {
 		return cmd, ok, err
 	}
-	extra, err := codexReadOnlyArgs()
+	extra, err := codexReadOnlyArgs(inv)
 	if err != nil {
 		return ports.ReviewCommandSpec{}, false, err
 	}
@@ -106,12 +106,17 @@ func insertBeforeLastArg(argv []string, extra ...string) []string {
 	return append(out, argv[len(argv)-1])
 }
 
-func codexReadOnlyArgs() ([]string, error) {
+func codexReadOnlyArgs(inv ports.ReviewInvocation) ([]string, error) {
 	extra := []string{"--sandbox", "read-only"}
 	// Shell commands inherit only Codex's core environment by default. Preserve
 	// the AO location overrides the reviewer needs to submit to this daemon.
+	values := map[string]string{
+		"AO_PORT":     os.Getenv("AO_PORT"),
+		"AO_DATA_DIR": firstNonEmpty(inv.DataDir, os.Getenv("AO_DATA_DIR")),
+		"AO_RUN_FILE": firstNonEmpty(inv.RunFilePath, os.Getenv("AO_RUN_FILE")),
+	}
 	for _, name := range []string{"AO_PORT", "AO_DATA_DIR", "AO_RUN_FILE"} {
-		value := os.Getenv(name)
+		value := values[name]
 		if value == "" {
 			continue
 		}
@@ -122,4 +127,13 @@ func codexReadOnlyArgs() ([]string, error) {
 		extra = append(extra, "-c", "shell_environment_policy.set."+name+"="+string(encoded))
 	}
 	return extra, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/backend/internal/adapters/reviewer/codex/codex_test.go
+++ b/backend/internal/adapters/reviewer/codex/codex_test.go
@@ -38,14 +38,16 @@ func (a *captureAgent) SessionInfo(context.Context, ports.SessionRef) (ports.Ses
 
 func TestReviewCommandUsesReadOnlySandbox(t *testing.T) {
 	t.Setenv("AO_PORT", "3103")
-	t.Setenv("AO_DATA_DIR", "/tmp/ao data")
-	t.Setenv("AO_RUN_FILE", "/tmp/ao data/running.json")
+	t.Setenv("AO_DATA_DIR", "/wrong/data")
+	t.Setenv("AO_RUN_FILE", "/wrong/running.json")
 	agent := &captureAgent{}
 	r := &Reviewer{agent: agent}
 
 	got, err := r.ReviewCommand(context.Background(), ports.ReviewInvocation{
 		ReviewerID:    "review-w1",
 		WorkspacePath: "/ws/w1",
+		DataDir:       "/tmp/ao data",
+		RunFilePath:   "/tmp/ao data/running.json",
 		Prompt:        "review it",
 		SystemPrompt:  "review only",
 	})
@@ -112,8 +114,8 @@ func TestReviewCommandUsesHiddenSystemPromptFile(t *testing.T) {
 
 func TestReviewRestoreCommandUsesNativeSessionIDAndReadOnlySandbox(t *testing.T) {
 	t.Setenv("AO_PORT", "3103")
-	t.Setenv("AO_DATA_DIR", "")
-	t.Setenv("AO_RUN_FILE", "")
+	t.Setenv("AO_DATA_DIR", "/wrong/data")
+	t.Setenv("AO_RUN_FILE", "/wrong/running.json")
 	agent := &captureAgent{}
 	r := &Reviewer{agent: agent}
 
@@ -121,6 +123,8 @@ func TestReviewRestoreCommandUsesNativeSessionIDAndReadOnlySandbox(t *testing.T)
 		ReviewerID:       "review-w1",
 		AgentSessionID:   "codex-native-1",
 		WorkspacePath:    "/ws/w1",
+		DataDir:          "/tmp/ao data",
+		RunFilePath:      "/tmp/ao data/running.json",
 		SystemPromptFile: "/ao/prompts/reviewer/system.md",
 	})
 	if err != nil {
@@ -129,7 +133,14 @@ func TestReviewRestoreCommandUsesNativeSessionIDAndReadOnlySandbox(t *testing.T)
 	if !ok {
 		t.Fatal("ReviewRestoreCommand ok = false, want true")
 	}
-	want := []string{"agent", "resume", "--sandbox", "read-only", "-c", `shell_environment_policy.set.AO_PORT="3103"`, "codex-native-1"}
+	want := []string{
+		"agent", "resume",
+		"--sandbox", "read-only",
+		"-c", `shell_environment_policy.set.AO_PORT="3103"`,
+		"-c", `shell_environment_policy.set.AO_DATA_DIR="/tmp/ao data"`,
+		"-c", `shell_environment_policy.set.AO_RUN_FILE="/tmp/ao data/running.json"`,
+		"codex-native-1",
+	}
 	if !slices.Equal(got.Argv, want) {
 		t.Fatalf("argv = %#v, want %#v", got.Argv, want)
 	}

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -242,7 +242,9 @@ func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.
 		Sessions: store,
 		PRs:      store,
 		Projects: store,
-		Launcher: reviewcore.NewLauncher(reviewers, runtime, cfg.DataDir, reviewcore.WithAgentAuth(reviewerAgentAuth{agents: agents})),
+		Launcher: reviewcore.NewLauncher(reviewers, runtime, cfg.DataDir,
+			reviewcore.WithRunFilePath(cfg.RunFilePath),
+			reviewcore.WithAgentAuth(reviewerAgentAuth{agents: agents})),
 	})
 	reviewSvc := reviewsvc.New(reviewEngine, store,
 		reviewsvc.WithLifecycleReducer(lcm),

--- a/backend/internal/ports/reviewer.go
+++ b/backend/internal/ports/reviewer.go
@@ -104,6 +104,10 @@ type ReviewInvocation struct {
 	// DataDir is AO's owned state root. Reviewer prelaunch hooks may use it for
 	// profile installation but must not write outside AO/workspace boundaries.
 	DataDir string
+	// RunFilePath is the daemon run-file reviewer-local AO CLI calls must use to
+	// find this daemon. Some harnesses filter shell command environments, so
+	// adapters may need to pass this value through their own command config.
+	RunFilePath string
 	// Prompt and SystemPrompt are the review instructions AO authored centrally,
 	// mirroring the worker's LaunchConfig.Prompt / SystemPrompt split: SystemPrompt
 	// carries the standing reviewer role, Prompt the per-pass task. A prompt-driven

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -19,6 +20,14 @@ const cancelInterruptDelay = 150 * time.Millisecond
 const defaultReviewerInitialDelay = 500 * time.Millisecond
 
 const reviewerTaskMessagePrefix = "Read and follow the AO review task in `"
+
+// EnvRunFile points reviewer-local AO CLI calls at the live daemon run-file.
+const EnvRunFile = "AO_RUN_FILE"
+
+// EnvAOCommandWarning records why AO could not guarantee a reviewer-local `ao`
+// command. Review launch remains best-effort so provider reviews can still be
+// posted and later reconciled, but this makes the degraded path diagnosable.
+const EnvAOCommandWarning = "AO_REVIEW_AO_COMMAND_WARNING"
 
 // Launcher spawns, re-notifies, and probes a reviewer over a worker's worktree.
 // It is the side of the engine that talks to the reviewer registry and runtime;
@@ -90,10 +99,12 @@ type reviewerRuntime interface {
 // runtime. The reviewer reuses the worker's worktree (a fresh session worktree
 // would branch off the default branch and so would not contain the PR changes).
 type agentLauncher struct {
-	reviewers ports.ReviewerResolver
-	runtime   reviewerRuntime
-	dataDir   string
-	auth      agentAuthResolver
+	reviewers  ports.ReviewerResolver
+	runtime    reviewerRuntime
+	dataDir    string
+	runFile    string
+	auth       agentAuthResolver
+	executable func() (string, error)
 }
 
 type preLaunchReviewer interface {
@@ -120,9 +131,27 @@ func WithAgentAuth(auth agentAuthResolver) LauncherOption {
 	}
 }
 
+// WithExecutable overrides os.Executable for reviewer PATH pinning. Production
+// leaves this unset; tests use it to model the daemon binary that should make a
+// bare `ao review submit` available inside reviewer panes.
+func WithExecutable(executable func() (string, error)) LauncherOption {
+	return func(l *agentLauncher) {
+		l.executable = executable
+	}
+}
+
+// WithRunFilePath pins reviewer-local AO CLI calls to this daemon's run-file.
+// This is intentionally separate from AO_DATA_DIR: the CLI discovers the live
+// daemon from AO_RUN_FILE, not from the durable data directory.
+func WithRunFilePath(path string) LauncherOption {
+	return func(l *agentLauncher) {
+		l.runFile = path
+	}
+}
+
 // NewLauncher builds the production reviewer launcher.
-func NewLauncher(reviewers ports.ReviewerResolver, runtime reviewerRuntime, dataDir string, opts ...LauncherOption) Launcher {
-	l := &agentLauncher{reviewers: reviewers, runtime: runtime, dataDir: dataDir}
+func NewLauncher(reviewers ports.ReviewerResolver, rt reviewerRuntime, dataDir string, opts ...LauncherOption) Launcher {
+	l := &agentLauncher{reviewers: reviewers, runtime: rt, dataDir: dataDir, executable: os.Executable}
 	for _, opt := range opts {
 		opt(l)
 	}
@@ -219,6 +248,7 @@ func (l *agentLauncher) invocation(spec LaunchSpec) ports.ReviewInvocation {
 		ReviewIndex:     spec.ReviewIndex,
 		WorkspacePath:   spec.WorkspacePath,
 		DataDir:         l.dataDir,
+		RunFilePath:     l.runFile,
 		Prompt:          prompt,
 		SystemPrompt:    systemPrompt,
 	}
@@ -292,6 +322,7 @@ func (l *agentLauncher) prepareIdleInvocation(spec LaunchSpec) (ports.ReviewInvo
 		AgentSessionID:   spec.AgentSessionID,
 		WorkspacePath:    spec.WorkspacePath,
 		DataDir:          l.dataDir,
+		RunFilePath:      l.runFile,
 		Prompt:           prompt,
 		SystemPrompt:     "",
 		SystemPromptFile: systemPath,
@@ -497,12 +528,68 @@ func (l *agentLauncher) runtimeEnv(ctx context.Context, spec LaunchSpec, argv []
 	env["AO_REVIEW_HARNESS"] = string(spec.Harness)
 	env[sessionmanager.EnvProjectID] = string(spec.ProjectID)
 	env[sessionmanager.EnvDataDir] = l.dataDir
-	path, err := sessionmanager.HookPATH(os.Executable, os.Getenv, env)
+	if strings.TrimSpace(l.runFile) != "" {
+		env[EnvRunFile] = l.runFile
+	}
+	path, err := sessionmanager.HookPATH(l.executable, os.Getenv, env)
 	if err == nil {
 		env["PATH"] = path
+	} else if shimDir, shimErr := l.ensureAOShimDir(); shimErr == nil {
+		env["PATH"] = prependPathDir(shimDir, env["PATH"])
+	} else {
+		env[EnvAOCommandWarning] = fmt.Sprintf("PATH pin failed: %v; AO shim fallback failed: %v", err, shimErr)
 	}
 	sessionmanager.AugmentRuntimePATHForLaunchBinary(ctx, env, argv, exec.LookPath)
 	return env
+}
+
+func (l *agentLauncher) ensureAOShimDir() (string, error) {
+	if strings.TrimSpace(l.dataDir) == "" {
+		return "", fmt.Errorf("reviewer AO shim data directory is required")
+	}
+	exe, err := l.executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve AO executable: %w", err)
+	}
+	if !filepath.IsAbs(exe) {
+		exe, err = filepath.Abs(exe)
+		if err != nil {
+			return "", fmt.Errorf("make AO executable absolute: %w", err)
+		}
+	}
+	shimDir := filepath.Join(l.dataDir, "reviewer-runtime", "bin")
+	if err := os.MkdirAll(shimDir, 0o700); err != nil {
+		return "", fmt.Errorf("create reviewer AO shim directory: %w", err)
+	}
+	shimPath := filepath.Join(shimDir, "ao")
+	if runtime.GOOS == "windows" {
+		shimPath += ".cmd"
+	}
+	if err := os.WriteFile(shimPath, []byte(aoShimScript(exe)), 0o600); err != nil {
+		return "", fmt.Errorf("write reviewer AO shim: %w", err)
+	}
+	if err := os.Chmod(shimPath, 0o700); err != nil { // #nosec G302 -- the reviewer shim must be executable by the AO user.
+		return "", fmt.Errorf("mark reviewer AO shim executable: %w", err)
+	}
+	return shimDir, nil
+}
+
+func aoShimScript(executable string) string {
+	if runtime.GOOS == "windows" {
+		return "@echo off\r\n\"" + executable + "\" %*\r\n"
+	}
+	return "#!/bin/sh\nexec " + shellQuote(executable) + ` "$@"` + "\n"
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+func prependPathDir(dir, path string) string {
+	if strings.TrimSpace(path) == "" {
+		return dir
+	}
+	return dir + string(os.PathListSeparator) + path
 }
 
 func (l *agentLauncher) Notify(ctx context.Context, handleID string, spec LaunchSpec) error {

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -35,11 +36,13 @@ func TestLauncherSpawnEnvCannotOverrideWorkerContext(t *testing.T) {
 		sessionmanager.EnvProjectID: "hacked-project",
 		sessionmanager.EnvDataDir:   "hacked-data",
 		"AO_REVIEW_SESSION_ID":      "hacked-review",
+		EnvRunFile:                  "hacked-run-file",
 		"REVIEW_ONLY":               "1",
 	}}
 	rt := &fakeRuntime{}
 	dataDir := t.TempDir()
-	l := NewLauncher(fakeReviewerResolver{reviewer: reviewer, ok: true}, rt, dataDir)
+	runFile := filepath.Join(t.TempDir(), "running.json")
+	l := NewLauncher(fakeReviewerResolver{reviewer: reviewer, ok: true}, rt, dataDir, WithRunFilePath(runFile))
 
 	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
 		t.Fatalf("Spawn: %v", err)
@@ -65,6 +68,97 @@ func TestLauncherSpawnEnvCannotOverrideWorkerContext(t *testing.T) {
 	}
 	if rt.createCfg.Env[sessionmanager.EnvDataDir] != dataDir {
 		t.Fatalf("%s = %q, want %q", sessionmanager.EnvDataDir, rt.createCfg.Env[sessionmanager.EnvDataDir], dataDir)
+	}
+	if rt.createCfg.Env[EnvRunFile] != runFile {
+		t.Fatalf("%s = %q, want %q", EnvRunFile, rt.createCfg.Env[EnvRunFile], runFile)
+	}
+}
+
+func TestLauncherSpawnPinsPATHToAOExecutable(t *testing.T) {
+	aoDir := t.TempDir()
+	aoExe := filepath.Join(aoDir, "ao")
+	reviewer := &fakeReviewer{env: map[string]string{"PATH": "/reviewer/bin"}}
+	rt := &fakeRuntime{}
+	l := NewLauncher(
+		fakeReviewerResolver{reviewer: reviewer, ok: true},
+		rt,
+		t.TempDir(),
+		WithExecutable(func() (string, error) { return aoExe, nil }),
+	)
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	parts := strings.Split(rt.createCfg.Env["PATH"], string(os.PathListSeparator))
+	if len(parts) < 2 || parts[0] != aoDir || parts[1] != "/reviewer/bin" {
+		t.Fatalf("reviewer PATH = %q, want AO dir before adapter PATH", rt.createCfg.Env["PATH"])
+	}
+}
+
+func TestLauncherSpawnCreatesAOShimWhenExecutableIsNotNamedAO(t *testing.T) {
+	dataDir := t.TempDir()
+	exe := filepath.Join(t.TempDir(), "ao-dev-daemon")
+	reviewer := &fakeReviewer{env: map[string]string{"PATH": "/reviewer/bin"}}
+	rt := &fakeRuntime{}
+	l := NewLauncher(
+		fakeReviewerResolver{reviewer: reviewer, ok: true},
+		rt,
+		dataDir,
+		WithExecutable(func() (string, error) { return exe, nil }),
+	)
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	shimDir := filepath.Join(dataDir, "reviewer-runtime", "bin")
+	parts := strings.Split(rt.createCfg.Env["PATH"], string(os.PathListSeparator))
+	if len(parts) < 2 || parts[0] != shimDir || parts[1] != "/reviewer/bin" {
+		t.Fatalf("reviewer PATH = %q, want shim dir before adapter PATH", rt.createCfg.Env["PATH"])
+	}
+	shimPath := filepath.Join(shimDir, "ao")
+	if runtime.GOOS == "windows" {
+		shimPath += ".cmd"
+	}
+	shim, err := os.ReadFile(shimPath)
+	if err != nil {
+		t.Fatalf("read AO shim: %v", err)
+	}
+	if !strings.Contains(string(shim), exe) {
+		t.Fatalf("AO shim = %q, want executable %q", shim, exe)
+	}
+}
+
+func TestLauncherSpawnWarnsWhenPATHPinAndShimFail(t *testing.T) {
+	reviewer := &fakeReviewer{env: map[string]string{"PATH": "/reviewer/bin"}}
+	rt := &fakeRuntime{}
+	calls := 0
+	l := NewLauncher(
+		fakeReviewerResolver{reviewer: reviewer, ok: true},
+		rt,
+		t.TempDir(),
+		WithExecutable(func() (string, error) {
+			calls++
+			if calls == 1 {
+				return filepath.Join(t.TempDir(), "ao-dev-daemon"), nil
+			}
+			return "", errors.New("executable unavailable")
+		}),
+	)
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if !rt.created {
+		t.Fatal("runtime.Create was not called")
+	}
+	if rt.createCfg.Env["PATH"] != "/reviewer/bin" {
+		t.Fatalf("PATH = %q, want original reviewer PATH", rt.createCfg.Env["PATH"])
+	}
+	warning := rt.createCfg.Env[EnvAOCommandWarning]
+	if !strings.Contains(warning, "PATH pin failed") || !strings.Contains(warning, "AO shim fallback failed") || !strings.Contains(warning, "executable unavailable") {
+		t.Fatalf("%s = %q, want combined PATH/shim warning", EnvAOCommandWarning, warning)
 	}
 }
 
@@ -441,16 +535,26 @@ func TestLauncherRestoreTerminalStartsIdlePane(t *testing.T) {
 }
 
 func TestLauncherRestoreTerminalUsesReviewerRestoreCommandWhenAvailable(t *testing.T) {
+	aoDir := t.TempDir()
+	aoExe := filepath.Join(aoDir, "ao")
 	reviewer := &fakeRestoringReviewer{
 		restoreOK: true,
 		restoreSpec: ports.ReviewCommandSpec{
 			Argv:           []string{"agent", "resume", "native-reviewer-1"},
+			Env:            map[string]string{"PATH": "/restore/bin"},
 			InitialMessage: "restored task",
 		},
 	}
 	rt := &fakeRuntime{}
 	dataDir := t.TempDir()
-	l := NewLauncher(fakeReviewerResolver{reviewer: reviewer, ok: true}, rt, dataDir)
+	runFile := filepath.Join(t.TempDir(), "running.json")
+	l := NewLauncher(
+		fakeReviewerResolver{reviewer: reviewer, ok: true},
+		rt,
+		dataDir,
+		WithRunFilePath(runFile),
+		WithExecutable(func() (string, error) { return aoExe, nil }),
+	)
 	spec := launchSpec()
 	spec.AgentSessionID = "native-reviewer-1"
 
@@ -472,6 +576,13 @@ func TestLauncherRestoreTerminalUsesReviewerRestoreCommandWhenAvailable(t *testi
 	}
 	if strings.Join(rt.createCfg.Argv, " ") != "agent resume native-reviewer-1" {
 		t.Fatalf("runtime argv = %#v", rt.createCfg.Argv)
+	}
+	parts := strings.Split(rt.createCfg.Env["PATH"], string(os.PathListSeparator))
+	if len(parts) < 2 || parts[0] != aoDir || parts[1] != "/restore/bin" {
+		t.Fatalf("restore PATH = %q, want AO dir before restore command PATH", rt.createCfg.Env["PATH"])
+	}
+	if rt.createCfg.Env[EnvRunFile] != runFile {
+		t.Fatalf("restore %s = %q, want %q", EnvRunFile, rt.createCfg.Env[EnvRunFile], runFile)
 	}
 	if rt.sentMsg != "restored task" {
 		t.Fatalf("initial message = %q, want restored task", rt.sentMsg)


### PR DESCRIPTION
## Summary
- apply the same `sessionmanager.HookPATH` AO path pinning used for worker agent launches to reviewer launches, so `ao review submit` resolves inside reviewer panes
- propagate the resolved `AO_RUN_FILE` into reviewer launch env and Codex filtered shell configuration so reviewer-local AO CLI calls discover the live daemon even when the harness/sandbox does not inherit the default runfile location
- create an AO-owned `ao` shim under the data dir when the running executable is not named `ao`, and fail launch with actionable context if neither direct PATH pinning nor shim fallback can guarantee `ao`
- cover spawn, restore, Codex filtered shell env, and fallback failure paths with regression tests

Closes #3755

## Tests
- `cd backend && go test ./internal/review ./internal/adapters/reviewer/codex ./internal/daemon ./internal/service/review ./internal/httpd/controllers`
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs ./internal/review ./internal/adapters/reviewer/codex ./internal/daemon ./internal/ports`

## Notes
- Kept this to reviewer launch reliability: correct AO binary plus correct daemon runfile. SCM observer reconciliation is intentionally not included in this PR.
