### PR TITLE
fix(chat): refresh interface switch readiness from CDC

### DIFF
--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -59,7 +59,10 @@ class EventSourceStub {
 }
 
 function fakeQueryClient() {
-	return { invalidateQueries: vi.fn() } as unknown as Parameters<typeof createEventTransport>[0];
+	return {
+		invalidateQueries: vi.fn(),
+		getQueryData: vi.fn(),
+	} as unknown as Parameters<typeof createEventTransport>[0];
 }
 
 beforeEach(() => {
@@ -172,6 +175,100 @@ describe("createEventTransport", () => {
 			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ["workspaces"] });
 			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
 				queryKey: ["session-scm-summary"],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("invalidates missing native-session readiness for the named session", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			vi.mocked(queryClient.getQueryData).mockReturnValue({
+				supported: false,
+				targetMode: "chat",
+				reasonCode: "NATIVE_SESSION_MISSING",
+				reason: "no native conversation found for codex",
+			});
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"session_updated",
+				JSON.stringify({
+					seq: 43,
+					projectId: "proj-1",
+					sessionId: "tui-1",
+					type: "session_updated",
+					payload: { id: "tui-1", activity: "idle", isTerminated: false },
+					createdAt: "2026-08-10T13:42:39Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+				queryKey: ["session-interface-transition", "tui-1"],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not refresh settled transition readiness for unrelated session updates", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			vi.mocked(queryClient.getQueryData).mockReturnValue({
+				supported: true,
+				targetMode: "chat",
+			});
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"session_updated",
+				JSON.stringify({
+					seq: 44,
+					projectId: "proj-1",
+					sessionId: "tui-1",
+					type: "session_updated",
+					payload: { id: "tui-1", isPinned: true },
+					createdAt: "2026-08-10T13:43:39Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+				queryKey: ["session-interface-transition", "tui-1"],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not refresh missing native-session readiness for a non-session event", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			vi.mocked(queryClient.getQueryData).mockReturnValue({
+				supported: false,
+				targetMode: "chat",
+				reasonCode: "NATIVE_SESSION_MISSING",
+				reason: "no native conversation found for codex",
+			});
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"pr_updated",
+				JSON.stringify({
+					seq: 45,
+					projectId: "proj-1",
+					sessionId: "tui-1",
+					type: "pr_updated",
+					payload: { url: "https://github.com/example/repo/pull/1" },
+					createdAt: "2026-08-10T13:44:39Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+				queryKey: ["session-interface-transition", "tui-1"],
 			});
 		} finally {
 			vi.useRealTimers();

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -6,6 +6,10 @@ import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { sessionScmSummaryQueryKey } from "../hooks/useSessionScmSummary";
 import { conversationQueryKey } from "../hooks/useConversation";
 import { sessionUsageQueryRoot } from "../hooks/useSessionUsageSummaries";
+import {
+	sessionInterfaceTransitionQueryKey,
+	type SessionInterfaceTransitionStatus,
+} from "../hooks/useSessionInterfaceTransition";
 
 export type EventTransport = {
 	connect: () => () => void;
@@ -22,8 +26,9 @@ const EVENTSOURCE_CLOSED = 2;
 // CDC event types the daemon pushes over the SSE stream (see
 // backend/internal/cdc/event.go). The SSE writer tags each frame with
 // `event: <type>`, so named events bypass EventSource.onmessage and must be
-// subscribed explicitly. Every one of these can change the project/session list
-// the sidebar renders, so they all trigger a (debounced) workspace refetch.
+// subscribed explicitly. Most can change the project/session list the sidebar
+// renders; conversation-bearing updates and transient readiness updates are
+// routed to their narrower query keys below.
 const CDC_EVENT_TYPES = [
 	"session_created",
 	"session_updated",
@@ -39,23 +44,25 @@ const CDC_EVENT_TYPES = [
  * Wires live server state into the TanStack Query cache. Two sources feed it:
  *   - daemon lifecycle over Electron IPC (coming up/down changes session availability)
  *   - the backend CDC stream over SSE (project/session/PR changes)
- * Both invalidate the ["workspaces"] query so the UI refetches. Invalidations are
- * debounced because a single user action can emit a burst of CDC events.
+ * Both route invalidations to the affected query keys so the UI refetches.
+ * Invalidations are debounced because one action can emit a burst of CDC events.
  */
 export function createEventTransport(queryClient: QueryClient): EventTransport {
 	return {
 		connect() {
 			let debounce: ReturnType<typeof setTimeout> | undefined;
 			const pendingConversationSessions = new Set<string>();
+			const pendingTransitionSessions = new Set<string>();
 			let workspaceInvalidationPending = false;
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
 			let sourceBaseUrl: string | undefined;
-			const refreshWorkspaces = (event?: Event) => {
-				let conversationOnly = false;
+			const scheduleCacheInvalidations = (event?: Event) => {
+				let skipWorkspaceInvalidation = false;
 				if (event && "data" in event) {
 					try {
 						const decoded = JSON.parse(String((event as MessageEvent).data)) as {
+							type?: unknown;
 							sessionId?: unknown;
 							payload?: unknown;
 						};
@@ -68,21 +75,36 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 							typeof decoded.payload === "object" && decoded.payload !== null
 								? (decoded.payload as { conversationId?: unknown })
 								: undefined;
-						if (
-							typeof decoded.sessionId === "string" &&
-							decoded.sessionId &&
-							typeof payload?.conversationId === "string" &&
-							payload.conversationId
-						) {
-							pendingConversationSessions.add(decoded.sessionId);
-							conversationOnly = true;
+						const sessionId =
+							typeof decoded.sessionId === "string" && decoded.sessionId
+								? decoded.sessionId
+								: undefined;
+						if (sessionId) {
+							if (
+								typeof payload?.conversationId === "string" &&
+								payload.conversationId
+							) {
+								pendingConversationSessions.add(sessionId);
+								skipWorkspaceInvalidation = true;
+							}
+							if (decoded.type === "session_updated") {
+								// The sessions CDC trigger fires when the provider-native id is
+								// captured. Wake only a mounted query that is waiting for that id;
+								// its narrow poll remains the fallback for a missed/reordered event.
+								const readiness = queryClient.getQueryData<SessionInterfaceTransitionStatus>(
+									sessionInterfaceTransitionQueryKey(sessionId),
+								);
+								if (readiness?.reasonCode === "NATIVE_SESSION_MISSING") {
+									pendingTransitionSessions.add(sessionId);
+								}
+							}
 						}
 					} catch {
 						// A malformed CDC payload still invalidates workspaces; it simply
 						// cannot target a conversation cache precisely.
 					}
 				}
-				if (!conversationOnly) workspaceInvalidationPending = true;
+				if (!skipWorkspaceInvalidation) workspaceInvalidationPending = true;
 				if (debounce) clearTimeout(debounce);
 				debounce = setTimeout(() => {
 					if (workspaceInvalidationPending) {
@@ -95,6 +117,12 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 						void queryClient.invalidateQueries({ queryKey: conversationQueryKey(sessionId) });
 					}
 					pendingConversationSessions.clear();
+					for (const sessionId of pendingTransitionSessions) {
+						void queryClient.invalidateQueries({
+							queryKey: sessionInterfaceTransitionQueryKey(sessionId),
+						});
+					}
+					pendingTransitionSessions.clear();
 				}, INVALIDATE_DEBOUNCE_MS);
 			};
 
@@ -128,7 +156,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 					source.onopen = () => {
 						setEventsConnectionState("connected");
 						// Events emitted during the gap were lost; refetch once on (re)open.
-						refreshWorkspaces();
+						scheduleCacheInvalidations();
 					};
 					source.onerror = () => {
 						// While readyState is CONNECTING the browser retries on its own;
@@ -137,9 +165,9 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 						setEventsConnectionState("disconnected");
 						if (source?.readyState === EVENTSOURCE_CLOSED) scheduleRetry();
 					};
-					source.onmessage = refreshWorkspaces; // unnamed events, if any
+					source.onmessage = scheduleCacheInvalidations; // unnamed events, if any
 					for (const type of CDC_EVENT_TYPES) {
-						source.addEventListener(type, refreshWorkspaces);
+						source.addEventListener(type, scheduleCacheInvalidations);
 					}
 					// EventSource auto-reconnects and resumes via Last-Event-ID while
 					// CONNECTING; scheduleRetry only covers the terminal CLOSED state.
@@ -150,7 +178,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 
 			const removeDaemonListener = aoBridge.daemon.onStatus(() => {
 				connectSource();
-				refreshWorkspaces();
+				scheduleCacheInvalidations();
 			});
 			// Rebind when the daemon comes back on a different port, independent of
 			// status-event ordering.


### PR DESCRIPTION
Fixes [#3753](https://github.com/Untrivial-ai/agent-orchestrator/issues/3753).

Focused alternative to [#3771](https://github.com/Untrivial-ai/agent-orchestrator/pull/3771). This PR addresses the reported stale readiness state without changing backend handoff semantics.

## Problem

The daemon already emits `session_updated` when a provider-native session id is captured, but the renderer did not route that event to the interface-transition readiness query. Current polling eventually recovers, but readiness can lag and the event path remains disconnected from the cache it changes.

## Solution

- Route `session_updated` to the exact `sessionInterfaceTransitionQueryKey(sessionId)`.
- Only schedule that invalidation when the mounted query is waiting on `NATIVE_SESSION_MISSING`.
- Keep the existing one-second poll as a fallback for missed or reordered SSE events.
- Rename the invalidation scheduler to reflect that it now routes workspace, conversation, and transition cache updates.

## Safety

- No backend transition behavior changes.
- No synthetic or hardcoded provider conversation ids.
- No fresh-conversation fallback that could lose TUI context.
- No migration or generated API changes.
- Settled readiness and non-session CDC events do not trigger transition refetches.

## Verification

- `cd frontend && npm test -- --run src/renderer/lib/event-transport.test.ts src/renderer/hooks/useSessionInterfaceTransition.test.tsx` — 17 tests passed.
- `cd frontend && npm run typecheck` — passed.
- Native Electron isolated timing check: hook completed at 352 ms, supported readiness refetched at 647 ms, and the button enabled at 751 ms, before the one-second poll fallback.
- Manual dev Electron E2E confirmed: the Switch to Chat button enabled in place after the first Codex prompt without navigating away.
