### PR TITLE
fix(desktop): authenticate feature-build GitHub requests when a token is available

### DIFF
--- a/frontend/src/main/feature-builds.test.ts
+++ b/frontend/src/main/feature-builds.test.ts
@@ -364,3 +364,76 @@ describe("reconcileFeaturePin", () => {
 		expect(r.settings.feature).toEqual({ pr: 2270 });
 	});
 });
+
+// ---------------------------------------------------------------------------
+// GitHub token: raises the 60 req/hr unauthenticated cap to 5000 req/hr when
+// AO_GITHUB_TOKEN/GITHUB_TOKEN is set, purely best-effort.
+// ---------------------------------------------------------------------------
+
+describe("GitHub requests carry an Authorization header when a token is configured", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+	});
+
+	/** Stubs fetch to return an empty release list and records every call's headers. */
+	function stubFetchRecordingHeaders() {
+		const calls: { url: string; headers: Record<string, string> }[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string, init?: { headers?: Record<string, string> }) => {
+				calls.push({ url: String(url), headers: init?.headers ?? {} });
+				return { ok: true, json: async () => [] };
+			}),
+		);
+		return calls;
+	}
+
+	it("omits Authorization when no token env var is set", async () => {
+		const calls = stubFetchRecordingHeaders();
+		await listFeatureBuilds();
+		expect(calls).toHaveLength(1);
+		expect(calls[0].headers.Authorization).toBeUndefined();
+	});
+
+	it("adds Authorization: Bearer <token> when GITHUB_TOKEN is set", async () => {
+		vi.stubEnv("GITHUB_TOKEN", "gh-token-from-env");
+		const calls = stubFetchRecordingHeaders();
+		await listFeatureBuilds();
+		expect(calls[0].headers.Authorization).toBe("Bearer gh-token-from-env");
+	});
+
+	it("prefers AO_GITHUB_TOKEN over GITHUB_TOKEN when both are set", async () => {
+		vi.stubEnv("AO_GITHUB_TOKEN", "ao-specific-token");
+		vi.stubEnv("GITHUB_TOKEN", "ambient-token");
+		const calls = stubFetchRecordingHeaders();
+		await listFeatureBuilds();
+		expect(calls[0].headers.Authorization).toBe("Bearer ao-specific-token");
+	});
+
+	it("treats a blank/whitespace-only token as unset", async () => {
+		vi.stubEnv("GITHUB_TOKEN", "   ");
+		const calls = stubFetchRecordingHeaders();
+		await listFeatureBuilds();
+		expect(calls[0].headers.Authorization).toBeUndefined();
+	});
+
+	it("still authenticates the per-PR pulls lookup, not just the releases call", async () => {
+		vi.stubEnv("GITHUB_TOKEN", "gh-token-from-env");
+		const calls: { url: string; headers: Record<string, string> }[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string, init?: { headers?: Record<string, string> }) => {
+				calls.push({ url: String(url), headers: init?.headers ?? {} });
+				if (calls.length === 1) {
+					return { ok: true, json: async () => [makeRelease()] };
+				}
+				return { ok: true, json: async () => ({ state: "open" }) };
+			}),
+		);
+		await listFeatureBuilds();
+		expect(calls).toHaveLength(2);
+		expect(calls[1].url).toMatch(/\/pulls\/2270$/);
+		expect(calls[1].headers.Authorization).toBe("Bearer gh-token-from-env");
+	});
+});

--- a/frontend/src/main/feature-builds.ts
+++ b/frontend/src/main/feature-builds.ts
@@ -100,12 +100,29 @@ function parseMarker(body: string): MarkerPayload | null {
 	}
 }
 
+// Optional token for the GitHub REST calls below. AO_GITHUB_TOKEN takes
+// priority as the AO-specific override, falling back to the ambient
+// GITHUB_TOKEN a dev shell or CI runner commonly already exports -- the same
+// two-name precedence backend/internal/adapters/scm/github/auth.go's
+// EnvTokenSource uses for the daemon's own GitHub calls, kept in sync here so
+// the two independent GitHub clients agree on which env var wins. Purely
+// best-effort: unset means every call below stays unauthenticated exactly as
+// before, at the 60 req/hr limit rather than 5000. Read fresh (not cached)
+// since it's a cheap process.env lookup, not the daemon's `gh auth token`
+// shell-out that TTL caching exists to amortize.
+function resolveGitHubToken(): string | undefined {
+	const token = (process.env.AO_GITHUB_TOKEN || process.env.GITHUB_TOKEN || "").trim();
+	return token || undefined;
+}
+
 async function fetchJson<T>(url: string): Promise<T> {
+	const token = resolveGitHubToken();
 	const res = await fetch(url, {
 		headers: {
 			Accept: "application/vnd.github+json",
 			"X-GitHub-Api-Version": "2022-11-28",
 			"User-Agent": `ao-desktop/${app.getVersion()}`,
+			...(token ? { Authorization: `Bearer ${token}` } : {}),
 		},
 	});
 	if (!res.ok) throw new Error(`GitHub API ${res.status}: ${url}`);
@@ -118,10 +135,11 @@ async function isPrOpen(pr: number): Promise<boolean> {
 		const data = await fetchJson<{ state: string }>(`${GITHUB_API}/repos/${owner}/${repo}/pulls/${pr}`);
 		return data.state === "open";
 	} catch {
-		// ponytail: unauthenticated GitHub API hits the 60 req/hr limit; per-PR-state
-		// calls are batched/deduped below but could still be exhausted on large lists.
-		// Upgrade path: pass the app's OAuth token (if one exists) in the Authorization
-		// header to raise the limit to 5000 req/hr.
+		// Every call in this file goes through fetchJson, which attaches
+		// AO_GITHUB_TOKEN/GITHUB_TOKEN when set (5000 req/hr) and falls back to
+		// unauthenticated (60 req/hr) otherwise -- per-PR-state calls here are
+		// batched/deduped below but could still be exhausted on large lists when
+		// no token is configured.
 		//
 		// On any error keep the entry rather than incorrectly filtering it out.
 		return true;


### PR DESCRIPTION
## What

`frontend/src/main/feature-builds.ts` calls the public GitHub REST API entirely unauthenticated -- capped at 60 requests/hour. Each `listFeatureBuilds()` call fetches the releases list plus one `/pulls/<n>` lookup per unique feature-build PR. On a project with several concurrent feature builds (or just a busy dev machine polling repeatedly), that adds up fast. When the limit is exhausted, `isPrOpen()` deliberately fails open ("On any error keep the entry rather than incorrectly filtering it out"), so the degraded state is a stale/bloated feature-build picker rather than a clean error -- exactly the kind of thing worth avoiding rather than just tolerating.

This was flagged inline in the code itself:
```ts
// ponytail: unauthenticated GitHub API hits the 60 req/hr limit; per-PR-state
// calls are batched/deduped below but could still be exhausted on large lists.
// Upgrade path: pass the app's OAuth token (if one exists) in the Authorization
// header to raise the limit to 5000 req/hr.
```

## Fix

Add an optional `Authorization: Bearer <token>` header to every request `fetchJson()` makes, sourced from:
1. `AO_GITHUB_TOKEN` (an AO-specific override), falling back to
2. `GITHUB_TOKEN` (the ambient env var a dev shell or CI runner commonly already exports).

This mirrors the exact two-name precedence `backend/internal/adapters/scm/github/auth.go`'s `EnvTokenSource` already uses for the daemon's own GitHub calls -- kept in sync here since the Electron main process and the Go daemon are two independent GitHub clients with no shared token plumbing between them (Electron doesn't shell out to `gh`; that's exclusively the daemon's job per this codebase's existing architecture, so I scoped this to env-var-only rather than adding a new `gh auth token` shell-out from the main process).

Purely best-effort and fully backward compatible: when neither env var is set, every request stays unauthenticated exactly as before (60 req/hr). When one is set, requests are authenticated (5000 req/hr).

## Testing

- Added 5 new tests to `feature-builds.test.ts` covering: no token → no header; `GITHUB_TOKEN` set → `Authorization: Bearer <token>`; `AO_GITHUB_TOKEN` takes priority over `GITHUB_TOKEN` when both are set; a blank/whitespace-only token is treated as unset; and that the header reaches the per-PR `/pulls/<n>` lookup too, not just the releases call.
- Proved the new tests are meaningful via a stash-free patch-file round trip: reverse-applied just the implementation change (keeping the new tests), confirmed 3 of them failed against the unpatched code, reapplied and confirmed all 30 tests in the file pass.
- `npx tsc --noEmit` (via `--project tsconfig.json`) is clean.
- Full `feature-builds.test.ts` suite: 30/30 passing, no regressions to the existing 25 tests.
