### PR TITLE
fix: make light-mode terminal cursor high-contrast

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -234,6 +234,34 @@ describe("XtermTerminal", () => {
 		}
 	});
 
+	it("uses the terminal foreground for the light-mode block cursor", () => {
+		const style = document.createElement("style");
+		style.textContent = `
+			:root {
+				--color-bg-terminal-opaque: #f5f5f4;
+				--color-text-terminal: #24292f;
+				--color-working: #2563eb;
+			}
+		`;
+		document.head.appendChild(style);
+		delete document.documentElement.dataset.styleTheme;
+		useUiStore.setState({ themeStyle: "orchestrate" });
+
+		try {
+			render(<XtermTerminal theme="light" />);
+			expect(state.lastTerminal!.options.theme).toMatchObject({
+				background: "#f5f5f4",
+				foreground: "#24292f",
+				cursor: "#24292f",
+				cursorAccent: "#f5f5f4",
+			});
+		} finally {
+			style.remove();
+			delete document.documentElement.dataset.styleTheme;
+			act(() => useUiStore.setState({ themeStyle: "orchestrate" }));
+		}
+	});
+
 	it("does not reserve width for the hidden terminal scrollbar", () => {
 		render(<XtermTerminal theme="dark" />);
 

--- a/frontend/src/renderer/lib/terminal-themes.ts
+++ b/frontend/src/renderer/lib/terminal-themes.ts
@@ -44,7 +44,11 @@ export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
 	const light: ITheme = {
 		background: terminalBg,
 		foreground: terminalForeground,
-		cursor: terminalCursor,
+		// xterm block cursor fills with `cursor` and paints cell text in
+		// `cursorAccent`. --color-working is fine on dark plates but reads as a
+		// low-contrast wash on the light terminal bg (#f5f5f4), especially while
+		// blinking. Use the terminal foreground so the block stays visible.
+		cursor: terminalForeground,
 		cursorAccent: terminalBg,
 		selectionBackground: cssVar("--color-term-selection-light"),
 		selectionInactiveBackground: cssVar("--color-term-selection-inactive-light"),


### PR DESCRIPTION
## Summary
- Light xterm theme now sets `cursor` to the terminal foreground (`#24292f`) instead of `--color-working`, so the block cursor stays visible on `#f5f5f4`.
- Adds a regression test covering the light-mode cursor/accent pairing.
- Fixes #3814

## Test plan
- [ ] Switch desktop app to light theme, open a session in TUI mode
- [ ] Confirm the blinking cursor at “Add a follow-up” stays clearly visible through the blink cycle
- [ ] Confirm dark theme cursor is unchanged (still working/primary blue)
- [ ] `cd frontend && npx vitest run src/renderer/components/XtermTerminal.test.tsx -t "light-mode block cursor"`