### PR TITLE
fix(workspace): persist child default branches

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -196,7 +196,7 @@ func (w *Workspace) CreateWorkspaceProject(ctx context.Context, cfg ports.Worksp
 			relativePath: rel,
 			repoPath:     repoPath,
 			outputPath:   outPath,
-			baseBranch:   firstNonEmpty(child.BaseBranch, cfg.BaseBranch),
+			baseBranch:   child.BaseBranch,
 		})
 	}
 	branch, err := w.workspaceProjectBranch(ctx, repos, firstNonEmpty(cfg.Branch, defaultSessionBranchName(cfg.SessionID)))

--- a/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
@@ -563,7 +563,6 @@ func setupOriginCloneOnBranch(t *testing.T, git, tmp, branch string) string {
 	t.Helper()
 	repo := setupOriginClone(t, git, tmp)
 	runGit(t, git, repo, "branch", "-m", "main", branch)
-	runGit(t, git, repo, "push", "origin", ":"+"main")
 	runGit(t, git, repo, "push", "-u", "origin", branch)
 	runGit(t, git, repo, "remote", "set-head", "origin", branch)
 	return repo

--- a/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
@@ -457,6 +457,68 @@ func TestWorkspaceIntegrationCreateInRemotelessRepo(t *testing.T) {
 	}
 }
 
+func TestWorkspaceIntegrationWorkspaceProjectInfersChildDefaultBranches(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	rootRepo := setupOriginClone(t, git, filepath.Join(tmp, "root"))
+	devChildRepo := setupOriginCloneOnBranch(t, git, filepath.Join(tmp, "dev-child"), "dev")
+	mainChildRepo := setupOriginClone(t, git, filepath.Join(tmp, "main-child"))
+
+	root := filepath.Join(tmp, "managed")
+	ws, err := New(Options{Binary: git, ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": rootRepo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	info, err := ws.CreateWorkspaceProject(context.Background(), ports.WorkspaceProjectConfig{
+		ProjectID:    "proj",
+		SessionID:    "sess",
+		Kind:         "worker",
+		Branch:       "ao/proj-1",
+		RootRepoPath: rootRepo,
+		BaseBranch:   "main",
+		Repos: []ports.WorkspaceProjectRepoConfig{
+			{
+				Name:         "api",
+				RelativePath: "services/api",
+				RepoPath:     devChildRepo,
+			},
+			{
+				Name:         "web",
+				RelativePath: "apps/web",
+				RepoPath:     mainChildRepo,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workspace project: %v", err)
+	}
+	if len(info.Worktrees) != 3 {
+		t.Fatalf("worktrees = %d, want root and two children: %#v", len(info.Worktrees), info.Worktrees)
+	}
+	devChildPath := filepath.Join(info.Root.Path, "services", "api")
+	if _, err := os.Stat(filepath.Join(devChildPath, "README.md")); err != nil {
+		t.Fatalf("dev child worktree missing seed file: %v", err)
+	}
+	devChildHead := gitOutput(t, git, devChildRepo, "rev-parse", "refs/heads/ao/proj-1")
+	devChildBase := gitOutput(t, git, devChildRepo, "rev-parse", "origin/dev")
+	if devChildHead != devChildBase {
+		t.Fatalf("dev child branch base = %s, want origin/dev %s", devChildHead, devChildBase)
+	}
+	mainChildHead := gitOutput(t, git, mainChildRepo, "rev-parse", "refs/heads/ao/proj-1")
+	mainChildBase := gitOutput(t, git, mainChildRepo, "rev-parse", "origin/main")
+	if mainChildHead != mainChildBase {
+		t.Fatalf("main child branch base = %s, want origin/main %s", mainChildHead, mainChildBase)
+	}
+	rootHead := gitOutput(t, git, rootRepo, "rev-parse", "refs/heads/ao/proj-1")
+	rootBase := gitOutput(t, git, rootRepo, "rev-parse", "origin/main")
+	if rootHead != rootBase {
+		t.Fatalf("root branch base = %s, want origin/main %s", rootHead, rootBase)
+	}
+	if err := ws.DestroyWorkspaceProject(context.Background(), info); err != nil {
+		t.Fatalf("destroy workspace project: %v", err)
+	}
+}
+
 func requireGit(t *testing.T) string {
 	t.Helper()
 	git, err := exec.LookPath("git")
@@ -495,6 +557,26 @@ func setupOriginClone(t *testing.T, git, tmp string) string {
 	runGit(t, git, repo, "checkout", "main")
 	runGit(t, git, repo, "reset", "--hard", "HEAD")
 	return repo
+}
+
+func setupOriginCloneOnBranch(t *testing.T, git, tmp, branch string) string {
+	t.Helper()
+	repo := setupOriginClone(t, git, tmp)
+	runGit(t, git, repo, "branch", "-m", "main", branch)
+	runGit(t, git, repo, "push", "origin", ":"+"main")
+	runGit(t, git, repo, "push", "-u", "origin", branch)
+	runGit(t, git, repo, "remote", "set-head", "origin", branch)
+	return repo
+}
+
+func gitOutput(t *testing.T, git, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(git, append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s -C %s %s: %v\n%s", git, dir, strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func runGit(t *testing.T, git, dir string, args ...string) {

--- a/backend/internal/devimport/importer_test.go
+++ b/backend/internal/devimport/importer_test.go
@@ -345,8 +345,8 @@ func TestRunCopiesWorkspaceChildRepos(t *testing.T) {
 	project := testProject("workspace", "/repos/workspace")
 	project.Kind = domain.ProjectKindWorkspace
 	repos := []domain.WorkspaceRepoRecord{
-		{ProjectID: domain.ProjectID(project.ID), Name: "api", RelativePath: "api", RepoOriginURL: "https://example.com/api.git", RegisteredAt: project.RegisteredAt},
-		{ProjectID: domain.ProjectID(project.ID), Name: "web", RelativePath: "web", RepoOriginURL: "https://example.com/web.git", RegisteredAt: project.RegisteredAt},
+		{ProjectID: domain.ProjectID(project.ID), Name: "api", RelativePath: "api", RepoOriginURL: "https://example.com/api.git", DefaultBranch: "dev", RegisteredAt: project.RegisteredAt},
+		{ProjectID: domain.ProjectID(project.ID), Name: "web", RelativePath: "web", RepoOriginURL: "https://example.com/web.git", DefaultBranch: "main", RegisteredAt: project.RegisteredAt},
 	}
 	if err := source.UpsertWorkspaceProject(ctx, project, repos); err != nil {
 		t.Fatal(err)
@@ -365,6 +365,9 @@ func TestRunCopiesWorkspaceChildRepos(t *testing.T) {
 	}
 	if len(got) != 2 || got[0].Name != "api" || got[1].Name != "web" {
 		t.Fatalf("workspace repos = %#v", got)
+	}
+	if got[0].DefaultBranch != "dev" || got[1].DefaultBranch != "main" {
+		t.Fatalf("workspace repo default branches = %#v", got)
 	}
 }
 

--- a/backend/internal/domain/project.go
+++ b/backend/internal/domain/project.go
@@ -46,6 +46,7 @@ type WorkspaceRepoRecord struct {
 	Name          string
 	RelativePath  string
 	RepoOriginURL string
+	DefaultBranch string
 	RegisteredAt  time.Time
 }
 

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -1084,13 +1084,21 @@ func TestManager_AddWorkspaceInsideAncestorRepo(t *testing.T) {
 func TestManager_AddWorkspaceInitializesPlainParent(t *testing.T) {
 	configureCommitter(t)
 	ctx := context.Background()
-	m := newManager(t)
+	store, err := sqlitetest.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	m := project.New(store)
 	parent := t.TempDir()
 	if err := os.WriteFile(filepath.Join(parent, "package.json"), []byte("{}\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	gitRepoWithCommit(t, filepath.Join(parent, "cli"))
-	gitRepoWithCommit(t, filepath.Join(parent, "api"))
+	apiRepo := gitRepoWithCommit(t, filepath.Join(parent, "api"))
+	if out, err := exec.Command("git", "-C", apiRepo, "branch", "-m", "main", "dev").CombinedOutput(); err != nil {
+		t.Fatalf("rename api branch: %v (%s)", err, out)
+	}
 
 	proj, err := m.Add(ctx, project.AddInput{Path: parent, ProjectID: ptr("ws"), AsWorkspace: true})
 	if err != nil {
@@ -1101,6 +1109,19 @@ func TestManager_AddWorkspaceInitializesPlainParent(t *testing.T) {
 	}
 	if len(proj.WorkspaceRepos) != 2 || proj.WorkspaceRepos[0].Name != "api" || proj.WorkspaceRepos[1].Name != "cli" {
 		t.Fatalf("WorkspaceRepos = %#v", proj.WorkspaceRepos)
+	}
+	registeredRepos, err := store.ListWorkspaceRepos(ctx, "ws")
+	if err != nil {
+		t.Fatalf("list workspace repos: %v", err)
+	}
+	if len(registeredRepos) != 2 {
+		t.Fatalf("registered workspace repos = %#v, want 2", registeredRepos)
+	}
+	if registeredRepos[0].Name != "api" || registeredRepos[0].DefaultBranch != "dev" {
+		t.Fatalf("registered api repo = %#v, want persisted default branch dev", registeredRepos[0])
+	}
+	if registeredRepos[1].Name != "cli" || registeredRepos[1].DefaultBranch != "main" {
+		t.Fatalf("registered cli repo = %#v, want persisted default branch main", registeredRepos[1])
 	}
 	ignored, err := os.ReadFile(filepath.Join(parent, ".gitignore"))
 	if err != nil {

--- a/backend/internal/service/project/workspace_registration.go
+++ b/backend/internal/service/project/workspace_registration.go
@@ -176,6 +176,7 @@ func detectWorkspaceChildren(ctx context.Context, parent string, projectID domai
 			Name:          name,
 			RelativePath:  filepath.ToSlash(name),
 			RepoOriginURL: resolveGitOriginURL(child),
+			DefaultBranch: resolveDefaultBranch(child),
 			RegisteredAt:  registeredAt,
 		})
 	}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -920,6 +920,7 @@ func (m *Manager) createSessionWorkspace(ctx context.Context, project domain.Pro
 			Name:         repo.Name,
 			RelativePath: repo.RelativePath,
 			RepoPath:     filepath.Join(project.Path, filepath.FromSlash(repo.RelativePath)),
+			BaseBranch:   repo.DefaultBranch,
 		})
 	}
 	info, err := workspaceProject.CreateWorkspaceProject(ctx, ports.WorkspaceProjectConfig{

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2001,8 +2001,8 @@ func TestSpawn_WorkspaceProjectRecordsRootAndChildWorktrees(t *testing.T) {
 		Config: testRoleAgents(),
 	}
 	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{
-		{Name: "api", RelativePath: "services/api"},
-		{Name: "web", RelativePath: "apps/web"},
+		{Name: "api", RelativePath: "services/api", DefaultBranch: "dev"},
+		{Name: "web", RelativePath: "apps/web", DefaultBranch: "main"},
 	}
 	rt := &fakeRuntime{}
 	ws := &fakeWorkspace{path: managedPath}
@@ -2034,10 +2034,11 @@ func TestSpawn_WorkspaceProjectRecordsRootAndChildWorktrees(t *testing.T) {
 	if want := filepath.Join(projectPath, "apps", "web"); ws.lastProjectCfg.Repos[1].RepoPath != want {
 		t.Fatalf("web repo path = %q, want %q", ws.lastProjectCfg.Repos[1].RepoPath, want)
 	}
-	for _, repo := range ws.lastProjectCfg.Repos {
-		if repo.BaseBranch != "" {
-			t.Fatalf("child repo %s base branch = %q, want empty so adapter infers per-repo default", repo.Name, repo.BaseBranch)
-		}
+	if got := ws.lastProjectCfg.Repos[0].BaseBranch; got != "dev" {
+		t.Fatalf("api base branch = %q, want dev", got)
+	}
+	if got := ws.lastProjectCfg.Repos[1].BaseBranch; got != "main" {
+		t.Fatalf("web base branch = %q, want main", got)
 	}
 	rows := st.worktrees["mer-1"]
 	if len(rows) != 3 {

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -492,4 +492,5 @@ type WorkspaceRepo struct {
 	RelativePath  string
 	RepoOriginURL string
 	RegisteredAt  time.Time
+	DefaultBranch string
 }

--- a/backend/internal/storage/sqlite/gen/workspace.sql.go
+++ b/backend/internal/storage/sqlite/gen/workspace.sql.go
@@ -95,26 +95,36 @@ func (q *Queries) ListSessionWorktrees(ctx context.Context, sessionID domain.Ses
 }
 
 const listWorkspaceRepos = `-- name: ListWorkspaceRepos :many
-SELECT project_id, name, relative_path, repo_origin_url, registered_at
+SELECT project_id, name, relative_path, repo_origin_url, default_branch, registered_at
 FROM workspace_repos
 WHERE project_id = ?
 ORDER BY name
 `
 
-func (q *Queries) ListWorkspaceRepos(ctx context.Context, projectID domain.ProjectID) ([]WorkspaceRepo, error) {
+type ListWorkspaceReposRow struct {
+	ProjectID     domain.ProjectID
+	Name          string
+	RelativePath  string
+	RepoOriginURL string
+	DefaultBranch string
+	RegisteredAt  time.Time
+}
+
+func (q *Queries) ListWorkspaceRepos(ctx context.Context, projectID domain.ProjectID) ([]ListWorkspaceReposRow, error) {
 	rows, err := q.db.QueryContext(ctx, listWorkspaceRepos, projectID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []WorkspaceRepo{}
+	items := []ListWorkspaceReposRow{}
 	for rows.Next() {
-		var i WorkspaceRepo
+		var i ListWorkspaceReposRow
 		if err := rows.Scan(
 			&i.ProjectID,
 			&i.Name,
 			&i.RelativePath,
 			&i.RepoOriginURL,
+			&i.DefaultBranch,
 			&i.RegisteredAt,
 		); err != nil {
 			return nil, err
@@ -165,11 +175,12 @@ func (q *Queries) UpsertSessionWorktree(ctx context.Context, arg UpsertSessionWo
 }
 
 const upsertWorkspaceRepo = `-- name: UpsertWorkspaceRepo :exec
-INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, registered_at)
-VALUES (?, ?, ?, ?, ?)
+INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, default_branch, registered_at)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT (project_id, name) DO UPDATE SET
     relative_path = excluded.relative_path,
     repo_origin_url = excluded.repo_origin_url,
+    default_branch = excluded.default_branch,
     registered_at = excluded.registered_at
 `
 
@@ -178,6 +189,7 @@ type UpsertWorkspaceRepoParams struct {
 	Name          string
 	RelativePath  string
 	RepoOriginURL string
+	DefaultBranch string
 	RegisteredAt  time.Time
 }
 
@@ -187,6 +199,7 @@ func (q *Queries) UpsertWorkspaceRepo(ctx context.Context, arg UpsertWorkspaceRe
 		arg.Name,
 		arg.RelativePath,
 		arg.RepoOriginURL,
+		arg.DefaultBranch,
 		arg.RegisteredAt,
 	)
 	return err

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -89,6 +89,7 @@ var shippedMigrations = map[int64]string{
 	83: "0083_reconcile_kimchi_prime_agent_harnesses.sql",
 	84: "0084_add_session_auto_inject_review.sql",
 	85: "0085_agent_switching.sql",
+	86: "0086_workspace_repo_default_branch.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0086_workspace_repo_default_branch.sql
+++ b/backend/internal/storage/sqlite/migrations/0086_workspace_repo_default_branch.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE workspace_repos ADD COLUMN default_branch TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE workspace_repos DROP COLUMN default_branch;

--- a/backend/internal/storage/sqlite/queries/workspace.sql
+++ b/backend/internal/storage/sqlite/queries/workspace.sql
@@ -2,15 +2,16 @@
 DELETE FROM workspace_repos WHERE project_id = ?;
 
 -- name: UpsertWorkspaceRepo :exec
-INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, registered_at)
-VALUES (?, ?, ?, ?, ?)
+INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, default_branch, registered_at)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT (project_id, name) DO UPDATE SET
     relative_path = excluded.relative_path,
     repo_origin_url = excluded.repo_origin_url,
+    default_branch = excluded.default_branch,
     registered_at = excluded.registered_at;
 
 -- name: ListWorkspaceRepos :many
-SELECT project_id, name, relative_path, repo_origin_url, registered_at
+SELECT project_id, name, relative_path, repo_origin_url, default_branch, registered_at
 FROM workspace_repos
 WHERE project_id = ?
 ORDER BY name;

--- a/backend/internal/storage/sqlite/store/project_store.go
+++ b/backend/internal/storage/sqlite/store/project_store.go
@@ -63,6 +63,7 @@ func (s *Store) writeWorkspaceProject(ctx context.Context, label string, r domai
 				Name:          repo.Name,
 				RelativePath:  repo.RelativePath,
 				RepoOriginURL: repo.RepoOriginURL,
+				DefaultBranch: repo.DefaultBranch,
 				RegisteredAt:  repo.RegisteredAt,
 			}); err != nil {
 				return err
@@ -85,6 +86,7 @@ func (s *Store) ListWorkspaceRepos(ctx context.Context, projectID string) ([]dom
 			Name:          row.Name,
 			RelativePath:  row.RelativePath,
 			RepoOriginURL: row.RepoOriginURL,
+			DefaultBranch: row.DefaultBranch,
 			RegisteredAt:  row.RegisteredAt,
 		})
 	}


### PR DESCRIPTION
## Summary

- detect and persist each workspace child repository default branch during registration
- pass the persisted branch into workspace materialization instead of inheriting the root branch
- retain per-repository `origin/HEAD` inference for migrated rows without branch metadata
- cover mixed `main`/`dev` workspace creation and metadata import

Closes #3810

## Tests

- `go test ./internal/service/project ./internal/session_manager ./internal/devimport ./internal/storage/sqlite/store ./internal/adapters/workspace/gitworktree -count=1`
- `go test ./internal/adapters/agent/kilocode -run TestAuthStatusUnknownWhenKeyOnlyComesFromInteractiveShell -count=1`

## Verification note

A full `go test ./... -count=1` run reached an unrelated timeout in `internal/adapters/agent/kilocode`; that isolated test passed immediately on rerun. All workspace-related packages pass.