### PR TITLE
perf: scope CDC refetch fan-out, batch session-list PR facts, stop idle shell re-renders, narrow preview poll

### DIFF
--- a/backend/internal/preview/poller.go
+++ b/backend/internal/preview/poller.go
@@ -14,7 +14,11 @@ import (
 const DefaultPollInterval = 250 * time.Millisecond
 
 type sessionPreviewSource interface {
-	ListAllSessions(ctx context.Context) ([]domain.SessionRecord, error)
+	// ListSessionPreviewRows returns sparse, non-terminated session records
+	// carrying only the identity/kind/preview/workspace fields this poller
+	// reads — a sub-second loop must not drag the full 38-column session
+	// projection (multi-KB prompt/transcript text) out of SQLite every tick.
+	ListSessionPreviewRows(ctx context.Context) ([]domain.SessionRecord, error)
 }
 
 type previewSetter interface {
@@ -101,7 +105,7 @@ func (p *Poller) Poll(ctx context.Context) error {
 	if p.source == nil || p.setter == nil {
 		return nil
 	}
-	sessions, err := p.source.ListAllSessions(ctx)
+	sessions, err := p.source.ListSessionPreviewRows(ctx)
 	if err != nil {
 		return fmt.Errorf("preview poller list sessions: %w", err)
 	}

--- a/backend/internal/preview/poller_test.go
+++ b/backend/internal/preview/poller_test.go
@@ -22,8 +22,16 @@ type previewSet struct {
 	url string
 }
 
-func (f *fakePreviewSessions) ListAllSessions(_ context.Context) ([]domain.SessionRecord, error) {
-	return append([]domain.SessionRecord(nil), f.sessions...), nil
+func (f *fakePreviewSessions) ListSessionPreviewRows(_ context.Context) ([]domain.SessionRecord, error) {
+	// Mirror the production query's contract: terminated sessions are excluded.
+	out := make([]domain.SessionRecord, 0, len(f.sessions))
+	for _, sess := range f.sessions {
+		if sess.IsTerminated {
+			continue
+		}
+		out = append(out, sess)
+	}
+	return out, nil
 }
 
 func (f *fakePreviewSessions) SetPreview(_ context.Context, id domain.SessionID, previewURL string) (domain.Session, error) {

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -32,6 +32,7 @@ type Store interface {
 	SetSessionReviewerHarness(ctx context.Context, id domain.SessionID, harness domain.ReviewerHarness, updatedAt time.Time) (bool, error)
 	GetDisplayPRFactsForSession(ctx context.Context, id domain.SessionID) (domain.PRFacts, bool, error)
 	ListPRFactsForSession(ctx context.Context, id domain.SessionID) ([]domain.PRFacts, error)
+	ListAllPRFacts(ctx context.Context) (map[domain.SessionID][]domain.PRFacts, error)
 	ListPRsBySession(ctx context.Context, sessionID domain.SessionID) ([]domain.PullRequest, error)
 	ListSessionWorktrees(ctx context.Context, id domain.SessionID) ([]domain.SessionWorktreeRecord, error)
 	ListChecks(ctx context.Context, prURL string) ([]domain.PullRequestCheck, error)
@@ -765,16 +766,19 @@ func (s *Service) List(ctx context.Context, filter ListFilter) ([]domain.Session
 	if err != nil {
 		return nil, err
 	}
+	// One batch PR-facts read for the whole list instead of one query per
+	// session; the endpoint refetches on every CDC burst, so the N+1 dominated
+	// its cost as session count grew.
+	factsBySession, err := s.store.ListAllPRFacts(ctx)
+	if err != nil {
+		return nil, err
+	}
 	out := make([]domain.Session, 0, len(recs))
 	for _, rec := range recs {
 		if !matchesSessionFilter(rec, filter) {
 			continue
 		}
-		sess, err := s.toSession(ctx, rec)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, sess)
+		out = append(out, s.assembleSession(rec, factsBySession[rec.ID]))
 	}
 	return out, nil
 }
@@ -937,6 +941,12 @@ func (s *Service) toSession(ctx context.Context, rec domain.SessionRecord) (doma
 	if err != nil {
 		return domain.Session{}, fmt.Errorf("pr facts %s: %w", rec.ID, err)
 	}
+	return s.assembleSession(rec, prs), nil
+}
+
+// assembleSession derives the display model from a record and its (already
+// fetched) PR facts. Shared by the single-session path and the batched list.
+func (s *Service) assembleSession(rec domain.SessionRecord, prs []domain.PRFacts) domain.Session {
 	prs = deduplicatePRFacts(prs)
 	return domain.Session{
 		SessionRecord:    rec,
@@ -944,7 +954,7 @@ func (s *Service) toSession(ctx context.Context, rec domain.SessionRecord) (doma
 		SCMStatus:        deriveSCMStatus(prs),
 		TerminalHandleID: rec.Metadata.RuntimeHandleID,
 		PRs:              prs,
-	}, nil
+	}
 }
 
 // now tolerates a zero-value Service (tests construct the struct literally

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -224,6 +224,14 @@ func (f *fakeStore) ListPRFactsForSession(_ context.Context, id domain.SessionID
 	return []domain.PRFacts{pr}, nil
 }
 
+func (f *fakeStore) ListAllPRFacts(context.Context) (map[domain.SessionID][]domain.PRFacts, error) {
+	out := make(map[domain.SessionID][]domain.PRFacts, len(f.pr))
+	for id, pr := range f.pr {
+		out[id] = []domain.PRFacts{pr}
+	}
+	return out, nil
+}
+
 func (f *fakeStore) ListChecks(_ context.Context, prURL string) ([]domain.PullRequestCheck, error) {
 	return append([]domain.PullRequestCheck(nil), f.checks[prURL]...), nil
 }

--- a/backend/internal/storage/sqlite/gen/pr.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr.sql.go
@@ -192,6 +192,84 @@ func (q *Queries) GetPRLastNudgeSignature(ctx context.Context, url string) (stri
 	return last_nudge_signature, err
 }
 
+const listAllPRFacts = `-- name: ListAllPRFacts :many
+SELECT
+    pr.session_id,
+    pr.url,
+    pr.number,
+    pr.pr_state,
+    pr.review_decision,
+    pr.ci_state,
+    pr.mergeability,
+    pr.source_branch,
+    pr.target_branch,
+    pr.head_sha,
+    pr.updated_at,
+    EXISTS (
+        SELECT 1
+        FROM pr_comment
+        WHERE pr_comment.pr_url = pr.url
+          AND pr_comment.resolved = 0
+          AND pr_comment.is_bot = 0
+    ) AS review_comments
+FROM pr
+ORDER BY pr.session_id, pr.updated_at DESC
+`
+
+type ListAllPRFactsRow struct {
+	SessionID      domain.SessionID
+	URL            string
+	Number         int64
+	PRState        domain.PRState
+	ReviewDecision domain.ReviewDecision
+	CIState        domain.CIState
+	Mergeability   domain.Mergeability
+	SourceBranch   string
+	TargetBranch   string
+	HeadSha        string
+	UpdatedAt      time.Time
+	ReviewComments bool
+}
+
+// One batch read of every session's PR snapshots for the session list. Same
+// projection and per-session ordering contract as ListPRFactsBySession, plus
+// the owning session_id so Go can group rows; replaces one query per session.
+func (q *Queries) ListAllPRFacts(ctx context.Context) ([]ListAllPRFactsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAllPRFacts)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAllPRFactsRow{}
+	for rows.Next() {
+		var i ListAllPRFactsRow
+		if err := rows.Scan(
+			&i.SessionID,
+			&i.URL,
+			&i.Number,
+			&i.PRState,
+			&i.ReviewDecision,
+			&i.CIState,
+			&i.Mergeability,
+			&i.SourceBranch,
+			&i.TargetBranch,
+			&i.HeadSha,
+			&i.UpdatedAt,
+			&i.ReviewComments,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPRFactsBySession = `-- name: ListPRFactsBySession :many
 SELECT
     pr.url,

--- a/backend/internal/storage/sqlite/gen/sessions.sql.go
+++ b/backend/internal/storage/sqlite/gen/sessions.sql.go
@@ -393,6 +393,55 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]ListAllSessionsRow, er
 	return items, nil
 }
 
+const listSessionPreviewRows = `-- name: ListSessionPreviewRows :many
+SELECT id, kind, is_terminated, workspace_path, preview_url, preview_revision
+FROM sessions
+WHERE is_terminated = 0
+`
+
+type ListSessionPreviewRowsRow struct {
+	ID              domain.SessionID
+	Kind            domain.SessionKind
+	IsTerminated    bool
+	WorkspacePath   string
+	PreviewURL      string
+	PreviewRevision int64
+}
+
+// Narrow projection for the preview poller's sub-second scan loop: identity,
+// kind, and preview/workspace fields only, not the multi-KB prompt and
+// transcript columns ListAllSessions carries. Terminated sessions are filtered
+// here because the poller always skips them.
+func (q *Queries) ListSessionPreviewRows(ctx context.Context) ([]ListSessionPreviewRowsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listSessionPreviewRows)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListSessionPreviewRowsRow{}
+	for rows.Next() {
+		var i ListSessionPreviewRowsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Kind,
+			&i.IsTerminated,
+			&i.WorkspacePath,
+			&i.PreviewURL,
+			&i.PreviewRevision,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSessionsByProject = `-- name: ListSessionsByProject :many
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,

--- a/backend/internal/storage/sqlite/queries/pr.sql
+++ b/backend/internal/storage/sqlite/queries/pr.sql
@@ -143,6 +143,32 @@ FROM pr
 WHERE pr.session_id = ?
 ORDER BY pr.updated_at DESC;
 
+-- name: ListAllPRFacts :many
+-- One batch read of every session's PR snapshots for the session list. Same
+-- projection and per-session ordering contract as ListPRFactsBySession, plus
+-- the owning session_id so Go can group rows; replaces one query per session.
+SELECT
+    pr.session_id,
+    pr.url,
+    pr.number,
+    pr.pr_state,
+    pr.review_decision,
+    pr.ci_state,
+    pr.mergeability,
+    pr.source_branch,
+    pr.target_branch,
+    pr.head_sha,
+    pr.updated_at,
+    EXISTS (
+        SELECT 1
+        FROM pr_comment
+        WHERE pr_comment.pr_url = pr.url
+          AND pr_comment.resolved = 0
+          AND pr_comment.is_bot = 0
+    ) AS review_comments
+FROM pr
+ORDER BY pr.session_id, pr.updated_at DESC;
+
 -- name: ClaimPRForSession :exec
 INSERT INTO pr (url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/backend/internal/storage/sqlite/queries/sessions.sql
+++ b/backend/internal/storage/sqlite/queries/sessions.sql
@@ -101,6 +101,15 @@ SELECT id, project_id, num, issue_id, kind, harness,
 FROM sessions ORDER BY project_id, num;
 
 
+-- name: ListSessionPreviewRows :many
+-- Narrow projection for the preview poller's sub-second scan loop: identity,
+-- kind, and preview/workspace fields only, not the multi-KB prompt and
+-- transcript columns ListAllSessions carries. Terminated sessions are filtered
+-- here because the poller always skips them.
+SELECT id, kind, is_terminated, workspace_path, preview_url, preview_revision
+FROM sessions
+WHERE is_terminated = 0;
+
 -- name: RenameSession :execrows
 UPDATE sessions SET display_name = ?, updated_at = ? WHERE id = ?;
 

--- a/backend/internal/storage/sqlite/store/pr_facts.go
+++ b/backend/internal/storage/sqlite/store/pr_facts.go
@@ -53,6 +53,36 @@ func (s *Store) ListPRFactsForSession(ctx context.Context, id domain.SessionID) 
 	return out, nil
 }
 
+// ListAllPRFacts returns every session's PR snapshots in one query, grouped by
+// owning session and newest-first within each group — the batch form of
+// ListPRFactsForSession for the session list read path. Sessions without PRs
+// have no map entry.
+func (s *Store) ListAllPRFacts(ctx context.Context) (map[domain.SessionID][]domain.PRFacts, error) {
+	rows, err := s.qr.ListAllPRFacts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list all pr facts: %w", err)
+	}
+	out := make(map[domain.SessionID][]domain.PRFacts)
+	for _, r := range rows {
+		out[r.SessionID] = append(out[r.SessionID], domain.PRFacts{
+			URL:            r.URL,
+			Number:         int(r.Number),
+			Draft:          r.PRState == domain.PRStateDraft,
+			Merged:         r.PRState == domain.PRStateMerged,
+			Closed:         r.PRState == domain.PRStateClosed,
+			CI:             r.CIState,
+			Review:         r.ReviewDecision,
+			Mergeability:   r.Mergeability,
+			ReviewComments: r.ReviewComments,
+			SourceBranch:   r.SourceBranch,
+			TargetBranch:   r.TargetBranch,
+			HeadSHA:        r.HeadSha,
+			UpdatedAt:      r.UpdatedAt,
+		})
+	}
+	return out, nil
+}
+
 func prFactsFromGen(r gen.GetDisplayPRFactsBySessionRow) domain.PRFacts {
 	state := r.PRState
 	return domain.PRFacts{

--- a/backend/internal/storage/sqlite/store/pr_facts_bench_test.go
+++ b/backend/internal/storage/sqlite/store/pr_facts_bench_test.go
@@ -1,0 +1,135 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
+)
+
+// Mirrors the shape observed on a real install (135 sessions, ~100 PRs): the
+// session-list read path fetches PR facts for every session on every refetch.
+const (
+	benchSessions          = 135
+	benchSessionsWithPR    = 90
+	benchCommentsPerPR     = 3
+	benchProject           = "bench"
+	benchPRFactsBatchEvery = 1
+)
+
+func seedPRFactsFixture(tb testing.TB) (*sqlite.Store, []domain.SessionID) {
+	tb.Helper()
+	s := sqlitetest.MustOpen(tb)
+	ctx := context.Background()
+	if err := s.UpsertProject(ctx, domain.ProjectRecord{
+		ID: benchProject, Path: "/tmp/" + benchProject, RegisteredAt: time.Now().UTC().Truncate(time.Second),
+	}); err != nil {
+		tb.Fatalf("seed project: %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	ids := make([]domain.SessionID, 0, benchSessions)
+	for i := 0; i < benchSessions; i++ {
+		rec, err := s.CreateSession(ctx, domain.SessionRecord{
+			ProjectID: benchProject,
+			Kind:      domain.KindWorker,
+			Harness:   domain.HarnessClaudeCode,
+			Activity:  domain.Activity{State: domain.ActivityActive, LastActivityAt: now},
+			Metadata:  domain.SessionMetadata{Branch: fmt.Sprintf("feat/b-%d", i), WorkspacePath: "/ws"},
+			CreatedAt: now,
+			UpdatedAt: now,
+		})
+		if err != nil {
+			tb.Fatalf("create session %d: %v", i, err)
+		}
+		ids = append(ids, rec.ID)
+		if i >= benchSessionsWithPR {
+			continue
+		}
+		url := fmt.Sprintf("https://github.com/x/y/pull/%d", i+1)
+		pr := domain.PullRequest{
+			URL: url, SessionID: rec.ID, Number: i + 1,
+			CI: domain.CIPassing, SourceBranch: fmt.Sprintf("feat/b-%d", i), TargetBranch: "main",
+			UpdatedAt: now, ObservedAt: now,
+		}
+		var comments []domain.PullRequestComment
+		for c := 0; c < benchCommentsPerPR; c++ {
+			comments = append(comments, domain.PullRequestComment{
+				ID:     fmt.Sprintf("c-%d-%d", i, c),
+				Author: "rev", Body: "comment body", CreatedAt: now,
+			})
+		}
+		if err := s.WriteSCMObservation(ctx, pr, nil, nil, nil, comments, ports.ReviewWritePreserve); err != nil {
+			tb.Fatalf("write pr %d: %v", i, err)
+		}
+	}
+	return s, ids
+}
+
+// BenchmarkListPRFactsPerSession is the pre-batch session-list pattern: one
+// ListPRFactsForSession query per session (1+N round-trips per list build).
+func BenchmarkListPRFactsPerSession(b *testing.B) {
+	s, ids := seedPRFactsFixture(b)
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		total := 0
+		for _, id := range ids {
+			facts, err := s.ListPRFactsForSession(ctx, id)
+			if err != nil {
+				b.Fatal(err)
+			}
+			total += len(facts)
+		}
+		if total != benchSessionsWithPR {
+			b.Fatalf("facts = %d, want %d", total, benchSessionsWithPR)
+		}
+	}
+}
+
+// BenchmarkListAllPRFacts is the batched replacement: one query for the whole
+// session list.
+func BenchmarkListAllPRFacts(b *testing.B) {
+	s, _ := seedPRFactsFixture(b)
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bySession, err := s.ListAllPRFacts(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(bySession) != benchSessionsWithPR {
+			b.Fatalf("sessions with facts = %d, want %d", len(bySession), benchSessionsWithPR)
+		}
+	}
+}
+
+// The batch read must agree with the per-session read it replaces, per session
+// and in order.
+func TestListAllPRFactsMatchesPerSessionReads(t *testing.T) {
+	s, ids := seedPRFactsFixture(t)
+	ctx := context.Background()
+	bySession, err := s.ListAllPRFacts(ctx)
+	if err != nil {
+		t.Fatalf("ListAllPRFacts: %v", err)
+	}
+	for _, id := range ids {
+		perSession, err := s.ListPRFactsForSession(ctx, id)
+		if err != nil {
+			t.Fatalf("ListPRFactsForSession(%s): %v", id, err)
+		}
+		batch := bySession[id]
+		if len(batch) != len(perSession) {
+			t.Fatalf("session %s: batch %d facts, per-session %d", id, len(batch), len(perSession))
+		}
+		for i := range perSession {
+			if batch[i] != perSession[i] {
+				t.Fatalf("session %s fact %d: batch %+v != per-session %+v", id, i, batch[i], perSession[i])
+			}
+		}
+	}
+}

--- a/backend/internal/storage/sqlite/store/session_preview_rows_bench_test.go
+++ b/backend/internal/storage/sqlite/store/session_preview_rows_bench_test.go
@@ -1,0 +1,123 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
+)
+
+// The preview poller scans sessions four times a second for the daemon's whole
+// lifetime, so the projection it reads is a standing cost. Mirror a real
+// install: ~135 sessions, multi-KB prompt/update text on each row.
+func seedPreviewRowsFixture(tb testing.TB) *sqlite.Store {
+	tb.Helper()
+	s := sqlitetest.MustOpen(tb)
+	ctx := context.Background()
+	if err := s.UpsertProject(ctx, domain.ProjectRecord{
+		ID: benchProject, Path: "/tmp/" + benchProject, RegisteredAt: time.Now().UTC().Truncate(time.Second),
+	}); err != nil {
+		tb.Fatalf("seed project: %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	prompt := strings.Repeat("perf task detail ", 256) // ~4 KB, like a real seeded prompt
+	for i := 0; i < benchSessions; i++ {
+		if _, err := s.CreateSession(ctx, domain.SessionRecord{
+			ProjectID: benchProject,
+			Kind:      domain.KindWorker,
+			Harness:   domain.HarnessClaudeCode,
+			Activity:  domain.Activity{State: domain.ActivityActive, LastActivityAt: now},
+			Metadata: domain.SessionMetadata{
+				Branch:                fmt.Sprintf("feat/p-%d", i),
+				WorkspacePath:         "/ws",
+				Prompt:                prompt,
+				LatestUserPrompt:      prompt,
+				LatestAssistantUpdate: prompt,
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}); err != nil {
+			tb.Fatalf("create session %d: %v", i, err)
+		}
+	}
+	return s
+}
+
+// BenchmarkPreviewPollListAllSessions is what the poller used to run per tick.
+func BenchmarkPreviewPollListAllSessions(b *testing.B) {
+	s := seedPreviewRowsFixture(b)
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		recs, err := s.ListAllSessions(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(recs) != benchSessions {
+			b.Fatalf("sessions = %d, want %d", len(recs), benchSessions)
+		}
+	}
+}
+
+// BenchmarkPreviewPollListSessionPreviewRows is the narrow replacement.
+func BenchmarkPreviewPollListSessionPreviewRows(b *testing.B) {
+	s := seedPreviewRowsFixture(b)
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		recs, err := s.ListSessionPreviewRows(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(recs) != benchSessions {
+			b.Fatalf("sessions = %d, want %d", len(recs), benchSessions)
+		}
+	}
+}
+
+// The narrow read must agree with the full read on the fields the poller uses.
+func TestListSessionPreviewRowsMatchesListAllSessions(t *testing.T) {
+	s := seedPreviewRowsFixture(t)
+	ctx := context.Background()
+	full, err := s.ListAllSessions(ctx)
+	if err != nil {
+		t.Fatalf("ListAllSessions: %v", err)
+	}
+	narrow, err := s.ListSessionPreviewRows(ctx)
+	if err != nil {
+		t.Fatalf("ListSessionPreviewRows: %v", err)
+	}
+	byID := make(map[domain.SessionID]domain.SessionRecord, len(narrow))
+	for _, rec := range narrow {
+		byID[rec.ID] = rec
+	}
+	live := 0
+	for _, rec := range full {
+		if rec.IsTerminated {
+			if _, ok := byID[rec.ID]; ok {
+				t.Fatalf("terminated session %s present in preview rows", rec.ID)
+			}
+			continue
+		}
+		live++
+		got, ok := byID[rec.ID]
+		if !ok {
+			t.Fatalf("session %s missing from preview rows", rec.ID)
+		}
+		if got.Kind != rec.Kind ||
+			got.IsTerminated != rec.IsTerminated ||
+			got.Metadata.WorkspacePath != rec.Metadata.WorkspacePath ||
+			got.Metadata.PreviewURL != rec.Metadata.PreviewURL ||
+			got.Metadata.PreviewRevision != rec.Metadata.PreviewRevision {
+			t.Fatalf("session %s: preview row %+v disagrees with full record", rec.ID, got)
+		}
+	}
+	if live != len(narrow) {
+		t.Fatalf("preview rows = %d, live sessions = %d", len(narrow), live)
+	}
+}

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -313,6 +313,31 @@ func (s *Store) ListAllSessions(ctx context.Context) ([]domain.SessionRecord, er
 	return mapListAllSessionsRows(rows), nil
 }
 
+// ListSessionPreviewRows returns sparse records for the preview poller's scan
+// loop: identity, kind, and preview/workspace fields only. All other
+// SessionRecord fields are zero values — callers must not treat these as full
+// records. Terminated sessions are excluded.
+func (s *Store) ListSessionPreviewRows(ctx context.Context) ([]domain.SessionRecord, error) {
+	rows, err := s.qr.ListSessionPreviewRows(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list session preview rows: %w", err)
+	}
+	out := make([]domain.SessionRecord, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, domain.SessionRecord{
+			ID:           r.ID,
+			Kind:         r.Kind,
+			IsTerminated: r.IsTerminated,
+			Metadata: domain.SessionMetadata{
+				WorkspacePath:   r.WorkspacePath,
+				PreviewURL:      r.PreviewURL,
+				PreviewRevision: r.PreviewRevision,
+			},
+		})
+	}
+	return out, nil
+}
+
 func mapListSessionsByProjectRows(rows []gen.ListSessionsByProjectRow) []domain.SessionRecord {
 	out := make([]domain.SessionRecord, 0, len(rows))
 	for _, r := range rows {

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -48,7 +48,8 @@ export function TitlebarNav({
 	onSidebarPreviewEnter?: React.PointerEventHandler<HTMLButtonElement>;
 }) {
 	const { t } = useTranslation();
-	const { isSidebarOpen, toggleSidebar } = useUiStore();
+	const isSidebarOpen = useUiStore((state) => state.isSidebarOpen);
+	const toggleSidebar = useUiStore((state) => state.toggleSidebar);
 	const router = useRouter();
 	const canGoBack = useCanGoBack();
 	const canGoForward = useCanGoForward();

--- a/frontend/src/renderer/components/TrayRuntime.tsx
+++ b/frontend/src/renderer/components/TrayRuntime.tsx
@@ -29,12 +29,14 @@ export function TrayRuntime() {
 	}, [workspaces]);
 
 	const lastPushed = useRef<string | null>(null);
-	const serialized = JSON.stringify(sessions);
 	useEffect(() => {
+		// Serialize inside the effect: it runs only when the memoized entries
+		// change identity, not on every unrelated shell render.
+		const serialized = JSON.stringify(sessions);
 		if (lastPushed.current === serialized) return;
 		lastPushed.current = serialized;
 		aoBridge.tray.setAttentionState({ sessions });
-	}, [serialized, sessions]);
+	}, [sessions]);
 
 	useEffect(() => {
 		return aoBridge.tray.onOpenSession((target) => {

--- a/frontend/src/renderer/components/WindowTitlebar.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.tsx
@@ -78,7 +78,9 @@ export function WindowTitlebar({
 }) {
 	const { t } = useTranslation();
 	const theme = useResolvedTheme();
-	const { isSidebarOpen, toggleSidebar, openGlobalSettings } = useUiStore();
+	const isSidebarOpen = useUiStore((state) => state.isSidebarOpen);
+	const toggleSidebar = useUiStore((state) => state.toggleSidebar);
+	const openGlobalSettings = useUiStore((state) => state.openGlobalSettings);
 	const [openMenu, setOpenMenu] = useState<MenuKey | null>(null);
 
 	// Electron draws the min/max/close overlay natively and can't read our CSS, so

--- a/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
+++ b/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
@@ -171,6 +171,34 @@ describe("useDaemonStatus", () => {
 		expect(setApiBaseUrlMock).toHaveBeenLastCalledWith("http://127.0.0.1:4777");
 	});
 
+	it("does not re-render consumers when a poll returns an unchanged status", async () => {
+		vi.useFakeTimers();
+		// Every poll answers with a fresh object carrying identical fields.
+		getStatusMock.mockImplementation(() => Promise.resolve({ state: "ready", port: 4777 }));
+		const queryClient = fakeQueryClient();
+		let renders = 0;
+		const { result } = renderHook(() => {
+			renders += 1;
+			return useDaemonStatus(queryClient);
+		});
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+		expect(result.current).toEqual({ state: "ready", port: 4777 });
+		const rendersAfterFirstStatus = renders;
+
+		// Three more ready-interval polls with identical payloads.
+		for (let i = 0; i < 3; i++) {
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(10_000);
+			});
+		}
+
+		expect(getStatusMock.mock.calls.length).toBeGreaterThanOrEqual(4);
+		expect(renders).toBe(rendersAfterFirstStatus);
+	});
+
 	it("still connects the transport when the initial IPC status call fails", async () => {
 		getStatusMock.mockRejectedValue(new Error("ipc unavailable"));
 		const queryClient = fakeQueryClient();

--- a/frontend/src/renderer/hooks/useDaemonStatus.ts
+++ b/frontend/src/renderer/hooks/useDaemonStatus.ts
@@ -8,6 +8,24 @@ import { createEventTransport } from "../lib/event-transport";
 const STATUS_REFRESH_MS = 2_000;
 const READY_STATUS_REFRESH_MS = 10_000;
 
+// Each poll answers with a fresh object even when nothing changed. Every
+// consumer of this hook (including the app shell) would re-render per poll
+// without a field-level equality bailout.
+function sameDaemonStatus(a: DaemonStatus, b: DaemonStatus): boolean {
+	return (
+		a.state === b.state &&
+		a.port === b.port &&
+		a.pid === b.pid &&
+		a.executablePath === b.executablePath &&
+		a.workingDirectory === b.workingDirectory &&
+		a.message === b.message &&
+		a.details === b.details &&
+		a.code === b.code &&
+		a.exitCode === b.exitCode &&
+		a.signal === b.signal
+	);
+}
+
 export function useDaemonStatus(queryClient: QueryClient = defaultQueryClient) {
 	const [status, setStatus] = useState<DaemonStatus>({ state: "stopped" });
 	const statusRef = useRef(status);
@@ -50,7 +68,8 @@ export function useDaemonStatus(queryClient: QueryClient = defaultQueryClient) {
 		const applyStatus = (nextStatus: DaemonStatus) => {
 			// Only point REST at the new port; the workspace refetch is the event
 			// transport's job (it invalidates, debounced, on every daemon status).
-			statusRef.current = nextStatus;
+			const unchanged = sameDaemonStatus(statusRef.current, nextStatus);
+			if (!unchanged) statusRef.current = nextStatus;
 			if (nextStatus.state === "ready" && nextStatus.port) {
 				applyDaemonStatus(nextStatus);
 				clearRefresh();
@@ -59,7 +78,8 @@ export function useDaemonStatus(queryClient: QueryClient = defaultQueryClient) {
 				applyDaemonStatus(nextStatus);
 				scheduleRefresh();
 			}
-			setStatus(nextStatus);
+			// Unchanged polls keep the previous object so consumers skip a render.
+			if (!unchanged) setStatus(nextStatus);
 		};
 
 		refreshStatus();

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -50,7 +50,7 @@ class EventSourceStub {
 		this.handlers.set(type, listener);
 	}
 	emit(type: string, data: string) {
-		this.handlers.get(type)?.({ data } as unknown as Event);
+		this.handlers.get(type)?.({ type, data } as unknown as Event);
 	}
 	close() {
 		this.closed = true;
@@ -137,6 +137,138 @@ describe("createEventTransport", () => {
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-scm-summary"] });
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-usage"] });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("routes a session_updated burst away from per-session SCM summaries and bounds the flush rate", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			const source = EventSourceStub.instances[0];
+
+			// Live-measured shape: an active agent emits ~3 session_updated
+			// events/second (usage-binding and activity CDC) with no PR changes.
+			for (let i = 0; i < 20; i++) {
+				source.emit(
+					"session_updated",
+					JSON.stringify({
+						seq: i,
+						projectId: "proj-1",
+						sessionId: "sess-1",
+						type: "session_updated",
+						payload: { id: "sess-1" },
+						createdAt: "2026-08-10T00:00:00Z",
+					}),
+				);
+				vi.advanceTimersByTime(320);
+			}
+			vi.advanceTimersByTime(2_000);
+
+			const calls = (queryClient.invalidateQueries as ReturnType<typeof vi.fn>).mock.calls.map((call) =>
+				(call[0] as { queryKey: readonly string[] }).queryKey.join("/"),
+			);
+			// No PR event arrived, so no per-session PR summary refetch at all.
+			expect(calls.filter((key) => key.startsWith("session-scm-summary"))).toHaveLength(0);
+			// Twenty events collapse into throttled workspace+usage rounds
+			// (~1/second) instead of one round per event.
+			const workspaceFlushes = calls.filter((key) => key === "workspaces").length;
+			expect(workspaceFlushes).toBeGreaterThan(0);
+			expect(workspaceFlushes).toBeLessThanOrEqual(8);
+			expect(calls.filter((key) => key === "session-usage")).toHaveLength(workspaceFlushes);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("scopes PR events to the owning session's SCM summary without touching usage", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"pr_updated",
+				JSON.stringify({
+					seq: 7,
+					projectId: "proj-1",
+					sessionId: "sess-9",
+					type: "pr_updated",
+					payload: { url: "https://github.com/x/y/pull/1" },
+					createdAt: "2026-08-10T00:00:00Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+				queryKey: ["session-scm-summary", "sess-9"],
+			});
+			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+				queryKey: ["session-scm-summary"],
+			});
+			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ["session-usage"] });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("falls back to the SCM summary root when a PR moves between sessions", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"pr_session_changed",
+				JSON.stringify({
+					seq: 8,
+					projectId: "proj-1",
+					sessionId: "sess-2",
+					type: "pr_session_changed",
+					payload: { url: "https://github.com/x/y/pull/2" },
+					createdAt: "2026-08-10T00:00:00Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+				queryKey: ["session-scm-summary"],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("flushes under a continuous sub-debounce event stream instead of starving", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			const source = EventSourceStub.instances[0];
+
+			// 100 ms spacing never lets a plain trailing debounce fire.
+			for (let i = 0; i < 50; i++) {
+				source.emit(
+					"session_updated",
+					JSON.stringify({
+						seq: i,
+						projectId: "proj-1",
+						sessionId: "sess-1",
+						type: "session_updated",
+						payload: { id: "sess-1" },
+						createdAt: "2026-08-10T00:00:00Z",
+					}),
+				);
+				vi.advanceTimersByTime(100);
+			}
+
+			const workspaceFlushes = (queryClient.invalidateQueries as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as { queryKey: readonly string[] }).queryKey.join("/") === "workspaces",
+			).length;
+			// 5 s of continuous events: flushed about once a second, not zero, not 50×.
+			expect(workspaceFlushes).toBeGreaterThanOrEqual(4);
+			expect(workspaceFlushes).toBeLessThanOrEqual(6);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -12,6 +12,13 @@ export type EventTransport = {
 };
 
 const INVALIDATE_DEBOUNCE_MS = 150;
+// A continuous CDC stream (an active agent emits several session_updated
+// events per second) would keep postponing a pure trailing debounce, so cap
+// how long a workspace flush can be deferred, and keep consecutive workspace
+// refetch rounds at least this far apart. Conversation invalidations stay on
+// the plain debounce so a streaming chat turn keeps its current cadence.
+const INVALIDATE_MAX_WAIT_MS = 1_000;
+const INVALIDATE_MIN_INTERVAL_MS = 1_000;
 // How long to wait before rebuilding an EventSource the browser gave up on
 // (readyState CLOSED — e.g. the daemon answered with a non-SSE response).
 const SSE_RETRY_MS = 5_000;
@@ -24,9 +31,11 @@ const EVENTSOURCE_CLOSED = 2;
 // `event: <type>`, so named events bypass EventSource.onmessage and must be
 // subscribed explicitly. Every one of these can change the project/session list
 // the sidebar renders, so they all trigger a (debounced) workspace refetch.
-const CDC_EVENT_TYPES = [
-	"session_created",
-	"session_updated",
+// Only the PR-shaped ones can change a session's SCM (PR detail) summary, and
+// only the session-shaped ones can change usage totals — the flush below uses
+// that split to avoid refetching every mounted per-session query on each event.
+const SESSION_EVENT_TYPES = ["session_created", "session_updated"] as const;
+const PR_EVENT_TYPES = [
 	"pr_created",
 	"pr_updated",
 	"pr_check_recorded",
@@ -34,6 +43,8 @@ const CDC_EVENT_TYPES = [
 	"pr_review_thread_added",
 	"pr_review_thread_resolved",
 ] as const;
+const CDC_EVENT_TYPES = [...SESSION_EVENT_TYPES, ...PR_EVENT_TYPES] as const;
+const PR_EVENT_TYPE_SET: ReadonlySet<string> = new Set(PR_EVENT_TYPES);
 
 /**
  * Wires live server state into the TanStack Query cache. Two sources feed it:
@@ -46,13 +57,69 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 	return {
 		connect() {
 			let debounce: ReturnType<typeof setTimeout> | undefined;
+			let conversationDebounce: ReturnType<typeof setTimeout> | undefined;
+			// Set while a workspace flush is pending; bounds how far the trailing
+			// debounce can slide under a continuous event stream.
+			let flushDeadline: number | undefined;
+			let lastFlushAt: number | undefined;
 			const pendingConversationSessions = new Set<string>();
-			let workspaceInvalidationPending = false;
+			// Scoped invalidation targets accumulated between flushes.
+			let workspacePending = false;
+			let usagePending = false;
+			let scmRootPending = false;
+			const pendingScmSessions = new Set<string>();
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
 			let sourceBaseUrl: string | undefined;
+			const flushInvalidations = () => {
+				debounce = undefined;
+				flushDeadline = undefined;
+				lastFlushAt = Date.now();
+				if (workspacePending) {
+					void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+					workspacePending = false;
+				}
+				if (scmRootPending) {
+					void queryClient.invalidateQueries({ queryKey: sessionScmSummaryQueryKey() });
+				} else {
+					for (const sessionId of pendingScmSessions) {
+						void queryClient.invalidateQueries({ queryKey: sessionScmSummaryQueryKey(sessionId) });
+					}
+				}
+				scmRootPending = false;
+				pendingScmSessions.clear();
+				if (usagePending) {
+					void queryClient.invalidateQueries({ queryKey: sessionUsageQueryRoot });
+					usagePending = false;
+				}
+			};
+			const flushConversationInvalidations = () => {
+				conversationDebounce = undefined;
+				for (const sessionId of pendingConversationSessions) {
+					void queryClient.invalidateQueries({ queryKey: conversationQueryKey(sessionId) });
+				}
+				pendingConversationSessions.clear();
+			};
+			const scheduleFlush = () => {
+				const now = Date.now();
+				if (flushDeadline === undefined) flushDeadline = now + INVALIDATE_MAX_WAIT_MS;
+				// Trailing debounce, but never past the deadline and never sooner
+				// than the minimum interval since the previous flush.
+				const debounceDelay = Math.max(0, Math.min(INVALIDATE_DEBOUNCE_MS, flushDeadline - now));
+				const throttleDelay = lastFlushAt === undefined ? 0 : Math.max(0, lastFlushAt + INVALIDATE_MIN_INTERVAL_MS - now);
+				if (debounce) clearTimeout(debounce);
+				debounce = setTimeout(flushInvalidations, Math.max(debounceDelay, throttleDelay));
+			};
+			const scheduleConversationFlush = () => {
+				if (conversationDebounce) clearTimeout(conversationDebounce);
+				conversationDebounce = setTimeout(flushConversationInvalidations, INVALIDATE_DEBOUNCE_MS);
+			};
 			const refreshWorkspaces = (event?: Event) => {
 				let conversationOnly = false;
+				// Refreshes without a CDC event (daemon status change, stream (re)open)
+				// recover an unknown gap, so everything is refetched.
+				let scmScope: "all" | "none" | string = event ? "none" : "all";
+				let usageRelevant = !event;
 				if (event && "data" in event) {
 					try {
 						const decoded = JSON.parse(String((event as MessageEvent).data)) as {
@@ -77,25 +144,39 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 							pendingConversationSessions.add(decoded.sessionId);
 							conversationOnly = true;
 						}
+						if (PR_EVENT_TYPE_SET.has(event.type)) {
+							// pr_session_changed moves a PR between sessions, so the summary
+							// of a session other than the envelope's may change too.
+							if (event.type !== "pr_session_changed" && typeof decoded.sessionId === "string" && decoded.sessionId) {
+								scmScope = decoded.sessionId;
+							} else {
+								scmScope = "all";
+							}
+						} else if (event.type === "session_created" || event.type === "session_updated") {
+							// Session-shaped events carry activity and usage-binding changes;
+							// PR summaries only change through the pr_* triggers above.
+							usageRelevant = true;
+						} else {
+							// Unnamed or unrecognized event: refresh everything.
+							scmScope = "all";
+							usageRelevant = true;
+						}
 					} catch {
-						// A malformed CDC payload still invalidates workspaces; it simply
-						// cannot target a conversation cache precisely.
+						// A malformed CDC payload still refreshes everything; it simply
+						// cannot be routed precisely.
+						scmScope = "all";
+						usageRelevant = true;
 					}
 				}
-				if (!conversationOnly) workspaceInvalidationPending = true;
-				if (debounce) clearTimeout(debounce);
-				debounce = setTimeout(() => {
-					if (workspaceInvalidationPending) {
-						void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-						void queryClient.invalidateQueries({ queryKey: sessionScmSummaryQueryKey() });
-						void queryClient.invalidateQueries({ queryKey: sessionUsageQueryRoot });
-						workspaceInvalidationPending = false;
-					}
-					for (const sessionId of pendingConversationSessions) {
-						void queryClient.invalidateQueries({ queryKey: conversationQueryKey(sessionId) });
-					}
-					pendingConversationSessions.clear();
-				}, INVALIDATE_DEBOUNCE_MS);
+				if (conversationOnly) {
+					scheduleConversationFlush();
+					return;
+				}
+				workspacePending = true;
+				if (usageRelevant) usagePending = true;
+				if (scmScope === "all") scmRootPending = true;
+				else if (scmScope !== "none") pendingScmSessions.add(scmScope);
+				scheduleFlush();
 			};
 
 			const scheduleRetry = () => {
@@ -159,6 +240,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 
 			return () => {
 				if (debounce) clearTimeout(debounce);
+				if (conversationDebounce) clearTimeout(conversationDebounce);
 				if (retryTimer) clearTimeout(retryTimer);
 				removeDaemonListener();
 				removeBaseUrlListener();

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CommandPalette } from "../components/CommandPalette";
 import { CenterPanelShell } from "../components/CenterPanelShell";
 import { DaemonFailureBanner } from "../components/DaemonFailureBanner";
@@ -100,7 +100,13 @@ function ShellLayout() {
 	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
 	const workspaceStartupBaselineRef = useRef(0);
 	const agentCatalogPortRef = useRef<number | undefined>(undefined);
-	const { themePreference, resolvedTheme, themeStyle, isSidebarOpen, toggleSidebar } = useUiStore();
+	// Field selectors, not a whole-store subscription: the shell must not
+	// re-render when unrelated UI state (inspector view, browser badges, …) moves.
+	const themePreference = useUiStore((state) => state.themePreference);
+	const resolvedTheme = useUiStore((state) => state.resolvedTheme);
+	const themeStyle = useUiStore((state) => state.themeStyle);
+	const isSidebarOpen = useUiStore((state) => state.isSidebarOpen);
+	const toggleSidebar = useUiStore((state) => state.toggleSidebar);
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const requestCreateProject = useUiStore((state) => state.requestCreateProject);
@@ -645,8 +651,15 @@ function ShellLayout() {
 		[],
 	);
 
+	// A fresh value object per render would re-render every useShell() consumer
+	// on every shell render regardless of whether shell state moved.
+	const shellContextValue = useMemo(
+		() => ({ daemonStatus, workspaceStartupState, createProject, initializeProjectRepository }),
+		[daemonStatus, workspaceStartupState, createProject, initializeProjectRepository],
+	);
+
 	return (
-		<ShellProvider value={{ daemonStatus, workspaceStartupState, createProject, initializeProjectRepository }}>
+		<ShellProvider value={shellContextValue}>
 			<SessionTopbarProvider>
 				<NotificationRuntime />
 				<TrayRuntime />


### PR DESCRIPTION
Profiled the live app first (135 sessions, real daemon + real database), then shipped the four highest-impact, well-scoped wins. No behavior changes beyond update timing bounds documented below; every win has a regression test and before/after numbers.

## How the hotspots were found

- Captured the live SSE `/api/v1/events` stream for 60s during agent activity: **187 `session_updated` events/min** (usage-binding + activity CDC), each of which made the renderer refetch the 99KB `/api/v1/sessions` payload, the usage summary, **and every mounted per-session PR summary** (prefix invalidation of `["session-scm-summary"]` = one HTTP request per visible session card).
- Measured `GET /api/v1/sessions` latency and traced its 1+N SQLite query pattern.
- Read-path review of renderer render churn (whole-store zustand subscriptions, per-poll fresh status objects) and daemon polling loops (preview poller reads all 38 session columns at 4Hz).

## Wins and measurements

| # | Change | Metric | Before | After | How measured |
|---|--------|--------|--------|-------|--------------|
| 1 | Scope + rate-bound CDC invalidation (`event-transport.ts`) | Invalidation rounds for 20 `session_updated` events at the live 320ms cadence (workspaces / scm-root / usage) | 20 / 20 / 20 | 7 / **0** / 7 | vitest fake-timer harness run against the old and new implementation |
| 1 | 〃 | Per-session PR summary refetch storms (HTTP requests per round ≈ visible cards) | every round | 0 on session bursts; scoped to the 1 owning session on PR events | same harness |
| 1 | 〃 | Sub-150ms continuous stream (50 events @ 100ms) | 1 starved flush **after** the stream ends (UI frozen while active) | ~1 flush/s while streaming (5 flushes) | same harness |
| 2 | Batch session-list PR facts (kill 1+N) | `Service.List` store cost, 135 sessions / 90 PRs | 2.85ms, 6030 allocs | 0.26ms, 2741 allocs (**10.8×**) | `go test -bench` `BenchmarkListPRFactsPerSession` vs `BenchmarkListAllPRFacts` (Apple M3) |
| 2 | 〃 | Live `GET /api/v1/sessions` (100 reqs, copy of real 135-session DB, before/after daemon binaries) | p50 10.3ms, p90 16.0ms | p50 3.8ms, p90 5.9ms | curl timing against both binaries on identical DB copies |
| 2 | 〃 | SQLite queries per list build | 1 + 135 | 2 | query pattern |
| 3 | Idle shell re-renders (`useDaemonStatus` equality bailout, zustand field selectors, memoized shell context, TrayRuntime stringify) | Consumer re-renders per unchanged 10s status poll (cascades through ShellLayout → Sidebar, board, titlebar, dialogs) | 1 per poll | 0 | render-count regression test (fails on the old hook) |
| 4 | Narrow preview-poller projection (`ListSessionPreviewRows`) | Per-tick cost of the 250ms scan, 135 sessions with ~4KB text columns | 1.62ms, 4.34MB allocs | 0.13ms, 0.12MB (**12× time, 36× bytes**) | `go test -bench` `BenchmarkPreviewPoll*` |

Compound effect during active agent work: the workspace/usage refetch round-trip rate drops ~3× (bounded at 1/s), each round no longer fans out N per-card PR summary requests, and each `/sessions` build costs ~2.6ms less in the daemon — while idle, the app shell stops re-rendering entirely between real changes.

**Update-timing bounds (deliberate):** workspace/scm/usage refetches now flush at most once per second under sustained CDC streams (previously either one round per event, or complete starvation while events arrived faster than the 150ms debounce). Isolated events keep the 150ms latency. Chat/conversation invalidation cadence is unchanged.

## Correctness guards

- `TestListAllPRFactsMatchesPerSessionReads` pins the batch read to the per-session read it replaces (order + fields).
- `TestListSessionPreviewRowsMatchesListAllSessions` pins the narrow poller read to `ListAllSessions` on every field the poller uses, including the terminated-session filter.
- New event-transport tests cover PR-event scoping, `pr_session_changed` root fallback, storm collapse, and no-starvation; the malformed-payload and unknown-event paths conservatively refetch everything, as before.
- Render-count test on `useDaemonStatus` fails against the previous implementation.

## Validation

- `cd backend && go test ./...` — green except pre-existing `internal/cli` failures that also fail on a clean checkout of `main` in this environment (they collide with the real daemon running on this machine).
- `go test -race` on touched packages (`service/session`, `sqlite/store`, `preview`, `httpd/...`) — green.
- `golangci-lint v2.12.2` — 0 issues.
- `frontend: npm run typecheck` — clean; `npm test` — green except two pre-existing `src/landing/*` suites that fail identically on a clean tree; renderer `vite build` — OK.
- Live daemon A/B: both binaries run against identical copies of the real database (data dir isolated in a scratch directory, separate port/run-file, shut down after measuring).
- No `ao preview` demo: nothing visual changed — the sidebar/board render identically; the change is network/CPU behavior, covered by the measurements above.

## Big-but-risky follow-ups (found while profiling, deliberately not done here)

1. **Reaper fork storm** — 3 subprocess forks per live session every 5s, including a full `ps -axo` process-table dump *per session* (`tmux.go:564`). Batch to one `ps` + one `tmux list-sessions` per tick. Touches liveness semantics, needs care around the "failed probe ≠ dead" rule.
2. **SSE `/api/v1/events` replays the entire `change_log` (29k+ rows, unbounded, no retention) on every connect** since the renderer never passes `?after=`. The client only uses events as invalidation signals and refetches on open anyway. Needs an API-contract decision (tail parameter or retention policy).
3. **Terminal mux emits one JSON+base64 frame per PTY read** with no coalescing; overflow kills the connection (`manager.go:529`). Binary frames + drain-and-concat would cut most of the per-byte cost.
4. **`GET /sessions/{id}/pr` runs 4 queries per PR alias** (checks/threads/reviews/comments) — same batching treatment as this PR's win 2.
5. Missing `(project_id, num)` index on `sessions` (every list sort builds a temp B-tree); `idx_change_log_project` is written on every trigger insert but never read.
6. No `pprof` endpoint in the daemon — worth adding behind a flag before the next perf pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
