### PR TITLE
fix(frontend): restore Kanban topbar button

### DIFF
--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -239,22 +239,28 @@ describe("ShellTopbar orchestrator actions", () => {
 		if (!pulses) expect(indicator).not.toHaveClass("animate-status-pulse");
 	});
 
-	it("opens the board from the project name on orchestrator sessions", async () => {
+	it("shows a clear Kanban button on embedded orchestrator sessions", async () => {
 		renderTopbar(orchestrator, true);
 
-		expect(screen.queryByText("Kanban")).not.toBeInTheDocument();
-		await userEvent.click(screen.getByRole("button", { name: "Open Kanban" }));
+		const kanbanButton = screen.getByRole("button", { name: "Open Kanban" });
+		expect(kanbanButton).toHaveTextContent("Kanban");
+		expect(kanbanButton).toHaveClass("bg-accent-strong");
+		expect(screen.queryByText("my-app")).not.toBeInTheDocument();
+		await userEvent.click(kanbanButton);
 		expect(navigateMock).toHaveBeenCalledWith({
 			to: "/projects/$projectId",
 			params: { projectId: "proj-1" },
 		});
 	});
 
-	it("opens the board from the project-name crumb on the full orchestrator topbar", async () => {
+	it("opens the board from the Kanban button on the full orchestrator topbar", async () => {
 		renderTopbar(orchestrator);
 
+		const kanbanButton = screen.getByRole("button", { name: "Open Kanban" });
+		expect(kanbanButton).toHaveTextContent("Kanban");
+		expect(kanbanButton).toHaveClass("bg-accent-strong");
 		expect(screen.getByRole("button", { name: "New task" })).toHaveClass("bg-raised");
-		await userEvent.click(screen.getByRole("button", { name: "Open Kanban" }));
+		await userEvent.click(kanbanButton);
 		expect(navigateMock).toHaveBeenCalledWith({
 			to: "/projects/$projectId",
 			params: { projectId: "proj-1" },

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { GitBranch, PanelRightClose, PanelRightOpen, Plus, Trash2 } from "lucide-react";
+import { GitBranch, LayoutDashboard, PanelRightClose, PanelRightOpen, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { animate, LayoutGroup, motion, useMotionValue, useReducedMotion } from "motion/react";
 import { NotificationCenter } from "./NotificationCenter";
@@ -26,7 +26,6 @@ import { OrchestratorIcon } from "./icons";
 import { OrchestratorActivityIndicator } from "./OrchestratorActivityIndicator";
 import { getAgentActivityView } from "../lib/session-presentation";
 import { isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
-import { cn } from "../lib/utils";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { StatusPill } from "./StatusPill";
 import { TopbarButton, TopbarKillError, topbarHeaderClass, topbarProjectLabelClass } from "./TopbarButton";
@@ -43,11 +42,10 @@ const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperti
 // / inspector stay available. The variant is derived from the route, not props:
 // a sessionId in the URL swaps the lead to the session identity (orchestrator
 // crumb + mode badge, or worker branch + status pill) and the actions to
-// board/orchestrator + inspector controls (orchestrators open the board via the
-// project-name control; workers open their orchestrator); otherwise it's the
-// dashboard crumb plus the Orchestrator launcher when a project is in scope.
-// Embedded mode contributes session actions to the terminal bar — and for
-// orchestrators, the clickable project name that replaces the old Kanban button.
+// board/orchestrator + inspector controls (orchestrators open the Kanban board;
+// workers open their orchestrator); otherwise it's the dashboard crumb plus the
+// Orchestrator launcher when a project is in scope. Embedded mode contributes
+// only session actions to the terminal bar; other routes retain this full bar.
 // Pixel equivalents of the CSS custom properties used for titlebar clearance.
 // --size-titlebar-cluster-left (72) + --size-titlebar-cluster-width (3×28+2×4=92)
 // + --size-titlebar-content-gap (12) = 176; minus --size-center-panel-inset-mac (6) = 170.
@@ -182,7 +180,14 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 				{isSessionRoute && isOrchestrator ? (
 					<div className="inline-flex min-w-0 items-center gap-2">
 						<div className="inline-flex min-w-0 items-center gap-1.5">
-							<ProjectBoardLabelButton label={projectLabel} onOpen={openBoard} style={noDragStyle} />
+							<motion.span
+								layoutId="topbar-project-label"
+								layout="position"
+								className={topbarProjectLabelClass}
+								transition={{ type: "spring", stiffness: 400, damping: 40 }}
+							>
+								{projectLabel}
+							</motion.span>
 								<span aria-hidden="true" className="text-xs leading-none text-passive">
 									·
 								</span>
@@ -265,16 +270,6 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 					<>
 						{isOrchestrator ? (
 							<>
-								{/* Session routes mount this topbar embedded — the lead crumb
-								    above is hidden — so the project name must live here too. */}
-								{embedded ? (
-									<ProjectBoardLabelButton
-										className="mr-1"
-										label={projectLabel}
-										onOpen={openBoard}
-										style={noDragStyle}
-									/>
-								) : null}
 								<ProjectTerminationFeedback projectId={projectId} />
 								<TopbarButton
 									aria-label={t("shell.newTask")}
@@ -285,6 +280,15 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 								>
 									<Plus className="size-icon-lg" aria-hidden="true" />
 									{t("shell.newTask")}
+								</TopbarButton>
+								<TopbarButton
+									aria-label={t("shell.openKanban")}
+									onClick={openBoard}
+									style={noDragStyle}
+									variant="primary"
+								>
+									<LayoutDashboard className="size-icon-lg" aria-hidden="true" />
+									{t("shell.kanban")}
 								</TopbarButton>
 							</>
 						) : null}
@@ -347,41 +351,6 @@ export function ShellTopbar({ embedded = false }: { embedded?: boolean } = {}) {
 			</div>
 		</motion.header>
 	</LayoutGroup>
-	);
-}
-
-const projectBoardLabelTransition = { type: "spring" as const, stiffness: 400, damping: 40 };
-
-/** Project name → board. Outer `<button>` owns the click so Motion's shared-layout spring cannot swallow the first pointer event (#3682). */
-function ProjectBoardLabelButton({
-	label,
-	onOpen,
-	style,
-	className,
-}: {
-	label: string;
-	onOpen: () => void;
-	style?: React.CSSProperties;
-	className?: string;
-}) {
-	const { t } = useTranslation();
-	return (
-		<button
-			aria-label={t("shell.openKanban")}
-			className={cn("min-w-0 rounded-sm text-left hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring", className)}
-			onClick={onOpen}
-			style={style}
-			type="button"
-		>
-			<motion.span
-				layoutId="topbar-project-label"
-				layout="position"
-				className={topbarProjectLabelClass}
-				transition={projectBoardLabelTransition}
-			>
-				{label}
-			</motion.span>
-		</button>
 	);
 }
 


### PR DESCRIPTION
## Summary
- restore the dedicated dashboard-icon + Kanban action on orchestrator session topbars
- keep the project name as contextual text instead of an ambiguous navigation control
- cover both embedded and full topbar variants with navigation and presentation assertions

## Regression
PR #3696 removed the visible Kanban control while fixing the project-name double-click behavior. That made the project name the only route back to the board and obscured the action.

## Tests
- `cd frontend && npx vitest run --config vite.renderer.config.ts src/renderer/components/ShellTopbar.test.tsx` (29 passed)
- `cd frontend && npm run typecheck`