### PR TITLE
fix(agent-devin): refuse to overwrite zero-byte ~/.claude.json (sibling of #3746)

### DIFF
--- a/backend/internal/adapters/agent/devin/devin.go
+++ b/backend/internal/adapters/agent/devin/devin.go
@@ -21,6 +21,7 @@
 package devin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -241,10 +242,16 @@ func ensureDevinNativeWorkspaceTrusted(configPath, workspacePath string) error {
 	data, err := os.ReadFile(configPath)
 	switch {
 	case err == nil:
-		if len(data) > 0 {
-			if err := json.Unmarshal(data, &root); err != nil {
-				return fmt.Errorf("devin: parse %s: %w", configPath, err)
-			}
+		if len(bytes.TrimSpace(data)) == 0 {
+			// A zero-byte read means we may have caught some other writer
+			// mid-truncate. Treat it like a corrupt file, not a missing one:
+			// refuse to write rather than silently replacing the user's real
+			// config (oauthAccount, projects history, etc.) with one containing
+			// only the trust entry.
+			return fmt.Errorf("devin: %s is empty; refusing to overwrite", configPath)
+		}
+		if err := json.Unmarshal(data, &root); err != nil {
+			return fmt.Errorf("devin: parse %s: %w", configPath, err)
 		}
 	case os.IsNotExist(err):
 		// Treat as empty config; we'll create it.
@@ -274,10 +281,16 @@ func ensureDevinWorkspaceTrusted(configPath, workspacePath string) error {
 	data, err := os.ReadFile(configPath)
 	switch {
 	case err == nil:
-		if len(data) > 0 {
-			if err := json.Unmarshal(data, &root); err != nil {
-				return fmt.Errorf("devin: parse %s: %w", configPath, err)
-			}
+		if len(bytes.TrimSpace(data)) == 0 {
+			// A zero-byte read means we may have caught some other writer
+			// mid-truncate. Treat it like a corrupt file, not a missing one:
+			// refuse to write rather than silently replacing the user's real
+			// config (oauthAccount, projects history, etc.) with one containing
+			// only the trust entry.
+			return fmt.Errorf("devin: %s is empty; refusing to overwrite", configPath)
+		}
+		if err := json.Unmarshal(data, &root); err != nil {
+			return fmt.Errorf("devin: parse %s: %w", configPath, err)
 		}
 	case os.IsNotExist(err):
 		// Treat as empty config; we'll create it.

--- a/backend/internal/adapters/agent/devin/devin_trust_test.go
+++ b/backend/internal/adapters/agent/devin/devin_trust_test.go
@@ -1,0 +1,49 @@
+package devin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A zero-byte ~/.claude.json (caught mid-truncate) must NOT be overwritten.
+// Sibling of claudecode #3746 / PR #3756: ensureDevinWorkspaceTrusted acts on
+// the same ~/.claude.json and had the same unguarded zero-byte read, which
+// would replace the user's real config (oauthAccount, projects history) with
+// one containing only the trust entry.
+func TestEnsureDevinWorkspaceTrustedRefusesZeroByteConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(cfg, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureDevinWorkspaceTrusted(cfg, "/some/worktree"); err == nil {
+		t.Fatal("expected error for zero-byte config, got nil (config would be overwritten)")
+	}
+	data, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("zero-byte config must not be overwritten; got %d bytes: %s", len(data), data)
+	}
+}
+
+// Same guard for devin's own trusted_workspaces.json.
+func TestEnsureDevinNativeWorkspaceTrustedRefusesZeroByteConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "trusted_workspaces.json")
+	if err := os.WriteFile(cfg, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureDevinNativeWorkspaceTrusted(cfg, "/some/worktree"); err == nil {
+		t.Fatal("expected error for zero-byte config, got nil (config would be overwritten)")
+	}
+	data, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("zero-byte config must not be overwritten; got %d bytes: %s", len(data), data)
+	}
+}


### PR DESCRIPTION
Fixes #3833.

`ensureDevinWorkspaceTrusted` and `ensureDevinNativeWorkspaceTrusted` had the same zero-byte data-loss bug as #3746 (fixed for `claudecode` in #3756). When the read of `~/.claude.json` (or Devin's `trusted_workspaces.json`) catches another writer mid-truncate and returns zero bytes with no error, `root` stayed empty and AO atomically replaced the user's real config — `oauthAccount`, `userID`, `projects` history — with one containing only the trust entry, logging the user out of Claude Code globally and wiping per-project history.

#3756 fixed only `claudecode.go`; the Devin adapter reaches the same `~/.claude.json` via the same unguarded read. This applies the identical guard to both Devin functions: when `len(bytes.TrimSpace(data)) == 0`, refuse to overwrite.

Tests: adds `TestEnsureDevinWorkspaceTrustedRefusesZeroByteConfig` and `TestEnsureDevinNativeWorkspaceTrustedRefusesZeroByteConfig`, mirroring #3756's `TestEnsureWorkspaceTrustedRefusesZeroByteConfig`. They fail on `main` (config overwritten) and pass with the guard. Full `devin` package and `go vet` clean.
