### PR TITLE
fix: restore Muse terminal scrolling

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -598,18 +598,20 @@ describe("terminal restore", () => {
 
 describe("providerScrollsByKeyboard", () => {
 	// opencode, its fork kilocode, and grok use TUIs that scroll their own transcripts
-	// by keyboard and ignore SGR wheel reports, so all must opt into the
+	// by keyboard and ignore SGR wheel reports, so they must opt into the
 	// PageUp/PageDown wheel routing (see XtermTerminal's paneScrollsByKeyboard).
 	it("is true for keyboard-scroll TUIs", () => {
 		expect(providerScrollsByKeyboard("opencode")).toBe(true);
 		expect(providerScrollsByKeyboard("kilocode")).toBe(true);
 		expect(providerScrollsByKeyboard("grok")).toBe(true);
-		expect(providerScrollsByKeyboard("muse")).toBe(true);
 	});
 
 	it("is false for mouse-report/native-scroll providers", () => {
 		expect(providerScrollsByKeyboard("codex")).toBe(false);
 		expect(providerScrollsByKeyboard("claude-code")).toBe(false);
+		// Muse writes its transcript to the normal buffer. PageUp is ignored by
+		// Muse, so wheel input must stay on the SGR -> tmux copy-mode path.
+		expect(providerScrollsByKeyboard("muse")).toBe(false);
 	});
 
 	it("is false when the provider is unknown", () => {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -841,9 +841,10 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 // Agents whose full-screen TUI keeps its own transcript and scrolls it only by
 // keyboard, ignoring SGR wheel reports. The terminal routes the wheel to
 // PageUp/PageDown for these (see XtermTerminal's paneScrollsByKeyboard).
-// kilocode is a fork of opencode and shares its TUI surface; grok and Muse Code
-// also use full-screen keyboard-scroll TUIs, so they scroll the same way.
-const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok", "muse"]);
+// kilocode is a fork of opencode and shares its TUI surface; grok also uses a
+// full-screen keyboard-scroll TUI, so both scroll the same way. Muse Code uses
+// the normal terminal buffer instead and must keep the SGR -> tmux scroll path.
+const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode", "grok"]);
 
 // Whether the given provider's TUI is one of the keyboard-scroll agents above.
 export function providerScrollsByKeyboard(provider?: string): boolean {


### PR DESCRIPTION
## Summary

- route Muse Code wheel input through the existing SGR-to-tmux scrollback path
- keep PageUp/PageDown translation limited to keyboard-scroll TUIs
- update the provider routing regression coverage

## Root cause

Muse Code uses the normal terminal buffer and ignores the PageUp/PageDown input that AO generated for its wheel events. This prevented wheel scrolling even though tmux scrollback was available.

## Impact

Mouse-wheel and trackpad scrolling work in Muse Code terminal sessions through tmux copy mode.

## Validation

Not run, per request.
