### PR TITLE
fix: use click-to-edit for project settings text fields

### DIFF
--- a/frontend/src/renderer/components/IntakeFields.tsx
+++ b/frontend/src/renderer/components/IntakeFields.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { components } from "../../api/schema";
 import { cn } from "../lib/utils";
 import { Label } from "./ui/label";
-import { SettingsRow } from "./settings/SettingsRow";
-import { Input } from "./ui/input";
+import { SettingsInlineInput, SettingsRow } from "./settings/SettingsRow";
 import { Switch } from "./ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 
@@ -134,12 +133,11 @@ export function IntakeFields({
 							</SettingsRow>
 						)}
 						<SettingsRow label={t("settings.project.assignee")}>
-							<Input
+							<SettingsInlineInput
 								id="intakeAssignee"
-								aria-label={t("settings.project.assignee")}
-								className="settings-inline-input"
+								label={t("settings.project.assignee")}
 								value={form.assignee}
-								onChange={(e) => onChange({ assignee: e.target.value })}
+								onChange={(assignee) => onChange({ assignee })}
 								placeholder={t("settings.project.intakeAssigneePlaceholder")}
 							/>
 						</SettingsRow>

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -46,6 +46,11 @@ import { ProjectSettingsForm, type ProjectSettingsSaveState, type ProjectSetting
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import type { WorkspaceSummary } from "../types/workspace";
 
+async function beginEdit(label: string) {
+	await userEvent.click(await screen.findByRole("button", { name: `Edit ${label}` }));
+	return screen.getByLabelText(label);
+}
+
 function TestProjectSettings({
 	projectId,
 	section,
@@ -194,11 +199,39 @@ describe("ProjectSettingsForm", () => {
 		});
 
 		renderSettings();
-		await screen.findByLabelText("Project name");
+		await screen.findByRole("button", { name: "Edit Project name" });
 
 		// Close button is now in SettingsDialog, not in the form itself
 		expect(screen.queryByRole("button", { name: "Close settings" })).not.toBeInTheDocument();
 		expect(navigateMock).not.toHaveBeenCalled();
+	});
+
+	it("shows the project name as text with a pencil until edit is clicked", async () => {
+		mockProject({
+			id: "proj-1",
+			name: "Project One",
+			kind: "single_repo",
+			path: "/repo/project-one",
+			repo: "",
+			defaultBranch: "main",
+			config: {
+				worker: { agent: "codex" },
+				orchestrator: { agent: "claude-code" },
+			},
+		});
+
+		renderSettings();
+
+		expect(await screen.findByRole("button", { name: "Edit Project name" })).toHaveTextContent("Project One");
+		expect(screen.queryByRole("textbox", { name: "Project name" })).not.toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("button", { name: "Edit Project name" }));
+		expect(screen.getByRole("textbox", { name: "Project name" })).toHaveValue("Project One");
+		expect(screen.queryByRole("button", { name: "Edit Project name" })).not.toBeInTheDocument();
+
+		await userEvent.keyboard("{Escape}");
+		expect(await screen.findByRole("button", { name: "Edit Project name" })).toBeInTheDocument();
+		expect(screen.queryByRole("textbox", { name: "Project name" })).not.toBeInTheDocument();
 	});
 
 	it("does not navigate on Escape (dialog handles closing)", async () => {
@@ -216,7 +249,7 @@ describe("ProjectSettingsForm", () => {
 		});
 
 		renderSettings();
-		await screen.findByLabelText("Project name");
+		await screen.findByRole("button", { name: "Edit Project name" });
 
 		await userEvent.keyboard("{Escape}");
 
@@ -240,7 +273,7 @@ describe("ProjectSettingsForm", () => {
 
 		renderSettings("tg_content_factory_5863f66be3");
 
-		const projectName = await screen.findByLabelText("Project name");
+		const projectName = await beginEdit("Project name");
 		await userEvent.clear(projectName);
 		await userEvent.type(projectName, "TG Content Factory");
 		submitSettings();
@@ -391,10 +424,11 @@ describe("ProjectSettingsForm", () => {
 
 		renderSettings("proj-1", undefined, "workflow");
 
-		expect(await screen.findByLabelText("Default branch")).toHaveValue("develop");
-		expect(screen.getByLabelText("Session prefix")).toHaveValue("po");
+		expect(await beginEdit("Default branch")).toHaveValue("develop");
+		await userEvent.keyboard("{Escape}");
+		expect(await beginEdit("Session prefix")).toHaveValue("po");
 		const reviewerAgent = screen.getByRole("button", { name: "Default reviewer agent" });
-		expect(reviewerAgent).toHaveTextContent("claude-code");
+		expect(reviewerAgent).toHaveTextContent("Claude Code");
 	});
 
 	it("shows the full model catalog again after selecting a model", async () => {
@@ -577,7 +611,7 @@ describe("ProjectSettingsForm", () => {
 
 		renderSettings();
 
-		const projectName = await screen.findByLabelText("Project name");
+		const projectName = await beginEdit("Project name");
 		await userEvent.clear(projectName);
 		await userEvent.type(projectName, "Updated Project");
 		submitSettings();
@@ -603,7 +637,7 @@ describe("ProjectSettingsForm", () => {
 
 		renderSettings();
 
-		const projectName = await screen.findByLabelText("Project name");
+		const projectName = await beginEdit("Project name");
 		await userEvent.clear(projectName);
 		await userEvent.type(projectName, "   ");
 		submitSettings();
@@ -1192,7 +1226,7 @@ describe("ProjectSettingsForm", () => {
 			"href",
 			"https://github.com/acme/project-one",
 		);
-		await userEvent.type(screen.getByLabelText("Assignee"), "octocat");
+		await userEvent.type(await beginEdit("Assignee"), "octocat");
 
 		submitSettings();
 

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -23,7 +23,7 @@ import { buildIntake, deriveGitHubRepo, IntakeFields, type IntakeForm, intakeNee
 import { ReviewerSelect, reviewerTrustWarning } from "./ReviewerSelect";
 import { AgentModelCombobox } from "./settings/AgentModelCombobox";
 import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
-import { SettingsRow } from "./settings/SettingsRow";
+import { SettingsInputRow, SettingsRow } from "./settings/SettingsRow";
 import { SettingsSection } from "./settings/SettingsSection";
 import { Input } from "./ui/input";
 
@@ -664,33 +664,6 @@ function ModelRefreshButton({
 		>
 			<RefreshCw className={cn("size-icon-sm", pending && "animate-spin")} aria-hidden="true" />
 		</button>
-	);
-}
-
-function SettingsInputRow({
-	label,
-	id,
-	value,
-	onChange,
-	placeholder,
-}: {
-	label: string;
-	id: string;
-	value: string;
-	onChange: (value: string) => void;
-	placeholder?: string;
-}) {
-	return (
-		<SettingsRow label={label}>
-			<Input
-				id={id}
-				aria-label={label}
-				className="settings-inline-input"
-				value={value}
-				onChange={(event) => onChange(event.target.value)}
-				placeholder={placeholder}
-			/>
-		</SettingsRow>
 	);
 }
 

--- a/frontend/src/renderer/components/settings/SettingsRow.tsx
+++ b/frontend/src/renderer/components/settings/SettingsRow.tsx
@@ -1,5 +1,6 @@
-import { ChevronRight, type LucideIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import { ChevronRight, Pencil, type LucideIcon } from "lucide-react";
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "../../lib/utils";
 
 function SettingsRowLabel({ icon: Icon, label }: { icon?: LucideIcon; label: string }) {
@@ -28,6 +29,102 @@ export function SettingsRow({
 			<SettingsRowLabel icon={icon} label={label} />
 			<div className="flex min-w-0 flex-1 items-center justify-end">{children}</div>
 		</div>
+	);
+}
+
+/** Idle value + pencil; the input bar appears only after click. */
+export function SettingsInlineInput({
+	id,
+	label,
+	value,
+	onChange,
+	placeholder,
+	className,
+}: {
+	id: string;
+	label: string;
+	value: string;
+	onChange: (value: string) => void;
+	placeholder?: string;
+	className?: string;
+}) {
+	const { t } = useTranslation();
+	const [editing, setEditing] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (!editing) return;
+		const input = inputRef.current;
+		if (!input) return;
+		input.focus();
+		input.select();
+	}, [editing]);
+
+	const finishEditing = () => setEditing(false);
+
+	const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.key === "Enter") {
+			event.preventDefault();
+			finishEditing();
+			return;
+		}
+		if (event.key === "Escape") {
+			event.preventDefault();
+			event.stopPropagation();
+			finishEditing();
+		}
+	};
+
+	if (!editing) {
+		return (
+			<button
+				type="button"
+				className={cn("settings-inline-edit-trigger", className)}
+				aria-label={t("settings.field.edit", { label })}
+				onClick={() => setEditing(true)}
+			>
+				<span className="settings-row-value" title={value || placeholder}>
+					{value || placeholder}
+				</span>
+				<Pencil className="settings-inline-edit-icon" aria-hidden="true" />
+			</button>
+		);
+	}
+
+	return (
+		<input
+			ref={inputRef}
+			id={id}
+			aria-label={label}
+			className={cn("settings-inline-edit-input", className)}
+			value={value}
+			onChange={(event) => onChange(event.target.value)}
+			onBlur={finishEditing}
+			onKeyDown={onKeyDown}
+			placeholder={placeholder}
+		/>
+	);
+}
+
+export function SettingsInputRow({
+	icon,
+	label,
+	id,
+	value,
+	onChange,
+	placeholder,
+}: {
+	icon?: LucideIcon;
+	label: string;
+	id: string;
+	value: string;
+	onChange: (value: string) => void;
+	placeholder?: string;
+}) {
+	return (
+		<SettingsRow icon={icon} label={label}>
+			<SettingsInlineInput id={id} label={label} value={value} onChange={onChange} placeholder={placeholder} />
+		</SettingsRow>
 	);
 }
 

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -503,6 +503,7 @@
 	"settings.options.noMatches": "Keine passenden Optionen.",
 	"settings.options.searchAria": "{{label}} durchsuchen",
 	"settings.options.searchPlaceholder": "Optionen durchsuchen…",
+	"settings.field.edit": "{{label}} bearbeiten",
 	"settings.project.agents": "Agenten",
 	"settings.project.agentsRequired": "Worker- und Orchestrator-Agenten sind erforderlich.",
 	"settings.project.agentDefault": "(Agent-Standard)",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -487,6 +487,7 @@
 	"settings.options.noMatches": "No matching options.",
 	"settings.options.searchAria": "Search {{label}}",
 	"settings.options.searchPlaceholder": "Search options…",
+	"settings.field.edit": "Edit {{label}}",
 	"settings.preferences": "Preferences",
 	"settings.project.agents": "Agents",
 	"settings.project.agentsRequired": "Worker and orchestrator agents are required.",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -512,6 +512,7 @@
 	"settings.options.noMatches": "No hay opciones coincidentes.",
 	"settings.options.searchAria": "Buscar {{label}}",
 	"settings.options.searchPlaceholder": "Buscar opciones…",
+	"settings.field.edit": "Editar {{label}}",
 	"settings.project.agents": "Agentes",
 	"settings.project.agentsRequired": "Se requieren agentes de trabajo y orquestador.",
 	"settings.project.agentDefault": "(predeterminado del agente)",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -512,6 +512,7 @@
 	"settings.options.noMatches": "Aucune option correspondante.",
 	"settings.options.searchAria": "Rechercher {{label}}",
 	"settings.options.searchPlaceholder": "Rechercher des options…",
+	"settings.field.edit": "Modifier {{label}}",
 	"settings.project.agents": "Agents",
 	"settings.project.agentsRequired": "Les agents worker et orchestrateur sont obligatoires.",
 	"settings.project.agentDefault": "(valeur par défaut de l'agent)",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -503,6 +503,7 @@
 	"settings.options.noMatches": "一致するオプションがありません。",
 	"settings.options.searchAria": "{{label}}を検索",
 	"settings.options.searchPlaceholder": "オプションを検索…",
+	"settings.field.edit": "{{label}}を編集",
 	"settings.project.agents": "エージェント",
 	"settings.project.agentsRequired": "ワーカーとオーケストレーターのエージェントは必須です。",
 	"settings.project.agentDefault": "（エージェントのデフォルト）",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -503,6 +503,7 @@
 	"settings.options.noMatches": "일치하는 옵션이 없습니다.",
 	"settings.options.searchAria": "{{label}} 검색",
 	"settings.options.searchPlaceholder": "옵션 검색…",
+	"settings.field.edit": "{{label}} 편집",
 	"settings.project.agents": "에이전트",
 	"settings.project.agentsRequired": "워커 및 오케스트레이터 에이전트는 필수입니다.",
 	"settings.project.agentDefault": "(에이전트 기본값)",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -512,6 +512,7 @@
 	"settings.options.noMatches": "Nenhuma opção correspondente.",
 	"settings.options.searchAria": "Pesquisar {{label}}",
 	"settings.options.searchPlaceholder": "Pesquisar opções…",
+	"settings.field.edit": "Editar {{label}}",
 	"settings.project.agents": "Agentes",
 	"settings.project.agentsRequired": "Os agentes worker e orchestrator são obrigatórios.",
 	"settings.project.agentDefault": "(padrão do agente)",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -484,6 +484,7 @@
 	"settings.options.noMatches": "没有匹配的选项。",
 	"settings.options.searchAria": "搜索{{label}}",
 	"settings.options.searchPlaceholder": "搜索选项…",
+	"settings.field.edit": "编辑{{label}}",
 	"settings.preferences": "偏好设置",
 	"settings.project.agents": "代理",
 	"settings.project.agentsRequired": "Worker 与编排代理为必填项。",

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -722,6 +722,80 @@ button.settings-link-row:active {
 	}
 }
 
+@utility settings-inline-edit-trigger {
+	display: inline-flex;
+	max-width: min(var(--size-settings-row-value-max), var(--size-settings-row-value-max-percent));
+	min-width: 0;
+	flex: 0 1 auto;
+	align-items: center;
+	justify-content: flex-end;
+	gap: calc(var(--spacing) * 1.5);
+	border: 0;
+	background: transparent;
+	padding: 0;
+	color: var(--color-text-settings-muted);
+	outline: none;
+	cursor: pointer;
+	transition-property: color;
+	transition-duration: var(--duration-fast);
+
+	&:hover,
+	&:focus-visible {
+		color: var(--color-text-settings-row);
+	}
+
+	&:focus-visible {
+		border-radius: var(--radius-md);
+		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+	}
+
+	& .settings-row-value {
+		max-width: none;
+	}
+}
+
+@utility settings-inline-edit-icon {
+	width: var(--size-icon-sm);
+	height: var(--size-icon-sm);
+	flex-shrink: 0;
+	opacity: 0.7;
+}
+
+@utility settings-inline-edit-input {
+	width: var(--size-settings-inline-input-max);
+	max-width: var(--size-settings-inline-input-max);
+	min-width: 0;
+	flex: 0 1 auto;
+	height: var(--size-settings-inline-input-height);
+	border: 1px solid var(--color-border-settings-input);
+	border-radius: var(--radius-lg);
+	background-color: var(--color-bg-settings-input);
+	padding-inline: calc(var(--spacing) * 2.5);
+	font-size: var(--font-size-base);
+	line-height: 1.25rem;
+	color: var(--color-text-settings-input);
+	text-align: right;
+	outline: none;
+	box-shadow: none;
+	transition-property: border-color, box-shadow, color;
+	transition-duration: var(--duration-normal);
+
+	&::placeholder {
+		color: var(--color-text-settings-placeholder);
+	}
+
+	&:hover {
+		color: var(--color-text-settings-row);
+	}
+
+	&:focus-visible {
+		border-color: var(--bridge-accent);
+		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		color: var(--color-text-settings-row);
+		outline: none;
+	}
+}
+
 @utility settings-inline-input {
 	width: auto;
 	max-width: min(var(--size-settings-inline-input-max), var(--size-settings-inline-input-max-percent));


### PR DESCRIPTION
## Summary
- Project name, default branch, session prefix, and intake assignee now show as plain values with a pencil instead of a stretched input bar.
- Clicking the pencil opens a compact pill input; Enter, Escape, or blur returns to the idle state.
- Keeps the original settings input styling for edit mode at 12rem so short values are not lost in a wide empty field.

## Test plan
- [ ] Open project settings → Identity: name is text + pencil, no input bar
- [ ] Click the pencil: input appears, text is selected, you can edit
- [ ] Enter / click away: bar goes away, new value + pencil remain
- [ ] Workflow: default branch and session prefix use the same pattern
- [ ] Intake assignee uses the same pattern when intake is enabled
- [ ] Save still persists the edited values

<img width="300" height="114" alt="image" src="https://github.com/user-attachments/assets/48982d57-f96b-4186-bf7a-61f58cb0fd70" />
<img width="743" height="147" alt="image" src="https://github.com/user-attachments/assets/eb9c93c8-225e-45dd-8fb0-1b58eb057f92" />
