### PR TITLE
fix: honor current review injection policy

### DIFF
--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -1746,6 +1746,28 @@ func TestPRObservation_ReviewFeedbackNotInjectedWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestPRObservation_ReviewFeedbackNotInjectedAfterSessionDisabled(t *testing.T) {
+	m, st, msg := newManager()
+	rec := working("mer-1")
+	rec.AutoInjectReview = false
+	st.sessions[rec.ID] = rec
+	st.comments["pr1"] = []domain.PullRequestComment{{ID: "1", Author: "alice", Body: "captured while enabled", AutoInjectReview: true}}
+	st.reviews["pr1"] = []domain.PullRequestReview{{ID: "r1", Author: "alice", State: domain.ReviewChangesRequest, Body: "also captured while enabled", AutoInjectReview: true}}
+	o := ports.PRObservation{
+		Fetched: true,
+		URL:     "pr1",
+		CI:      domain.CIFailing,
+		Checks:  []ports.PRCheckObservation{{Name: "build", Status: domain.PRCheckFailed, LogTail: "boom"}},
+		Review:  domain.ReviewChangesRequest,
+	}
+	if err := m.ApplyPRObservation(ctx, rec.ID, o); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 || !strings.Contains(msg.msgs[0], "boom") || strings.Contains(msg.msgs[0], "captured while enabled") {
+		t.Fatalf("messages = %v, want CI only after current session policy is disabled", msg.msgs)
+	}
+}
+
 func TestPRObservation_MixedPersistedCommentDecisions(t *testing.T) {
 	m, st, msg := newManager()
 	st.sessions["mer-1"] = working("mer-1")
@@ -2370,6 +2392,25 @@ func TestApplyReviewBatchSendsCombinedAndDedups(t *testing.T) {
 	}
 	if outcome != ReviewDeliverySent || len(msg.msgs) != 1 {
 		t.Fatalf("repeat should suppress duplicate send, outcome=%q msgs=%v", outcome, msg.msgs)
+	}
+}
+
+func TestApplyReviewBatchNoopsAfterSessionDisabled(t *testing.T) {
+	m, st, msg := newManager()
+	rec := working("mer-1")
+	rec.AutoInjectReview = false
+	st.sessions[rec.ID] = rec
+	result := ReviewResult{
+		RunID: "run-1", BatchID: "batch-1", WorkerID: rec.ID, PRURL: "https://github.com/o/r/pull/1",
+		TargetSHA: "sha1", Verdict: domain.VerdictChangesRequested, Body: "captured while enabled",
+	}
+
+	outcome, err := m.ApplyReviewBatch(ctx, rec.ID, result.BatchID, []ReviewResult{result})
+	if err != nil {
+		t.Fatalf("ApplyReviewBatch: %v", err)
+	}
+	if outcome != ReviewDeliveryNoop || len(msg.msgs) != 0 || st.signatureWrites != 0 {
+		t.Fatalf("disabled current policy should no-op, outcome=%q msgs=%v signatureWrites=%d", outcome, msg.msgs, st.signatureWrites)
 	}
 }
 

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -56,7 +56,7 @@ func (m *Manager) ApplyReviewBatch(ctx context.Context, workerID domain.SessionI
 	if err != nil || !ok {
 		return ReviewDeliveryNoop, err
 	}
-	if cannotNudge(rec) {
+	if cannotNudge(rec) || !rec.AutoInjectReview {
 		return ReviewDeliveryNoop, nil
 	}
 	if m.guard == nil {
@@ -205,7 +205,7 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 		}
 	}
 
-	if hasUnresolvedComments(o.Comments) {
+	if rec.AutoInjectReview && hasUnresolvedComments(o.Comments) {
 		comments := unresolvedReviewComments(o.Comments)
 		for _, comment := range comments {
 			if !comment.AutoInjectReview {
@@ -227,7 +227,7 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 		}
 	}
 
-	if o.Review == domain.ReviewChangesRequest {
+	if rec.AutoInjectReview && o.Review == domain.ReviewChangesRequest {
 		for _, review := range reviews {
 			if review.State != domain.ReviewChangesRequest || !review.AutoInjectReview {
 				continue

--- a/backend/internal/service/review/review.go
+++ b/backend/internal/service/review/review.go
@@ -414,6 +414,13 @@ func (s *Service) deliverSubmitted(ctx context.Context, workerID domain.SessionI
 }
 
 func (s *Service) deliverableRuns(ctx context.Context, workerID domain.SessionID, runs []domain.ReviewRun) ([]domain.ReviewRun, error) {
+	session, ok, err := s.store.GetSession(ctx, workerID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || !session.AutoInjectReview {
+		return nil, nil
+	}
 	currentHeads, err := s.currentHeadsByPR(ctx, workerID)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/review/review_test.go
+++ b/backend/internal/service/review/review_test.go
@@ -227,6 +227,29 @@ func TestSubmitSnapshotsDisabledPolicyAndNeverDeliversOnRetry(t *testing.T) {
 	}
 }
 
+func TestSubmitCompletedRunDoesNotDeliverAfterSessionDisabled(t *testing.T) {
+	disabled := false
+	st := &fakeStore{
+		ok:                      true,
+		sessionAutoInjectReview: &disabled,
+		run: domain.ReviewRun{
+			ID: "run-1", SessionID: "mer-1", BatchID: "batch-1", PRURL: "pr1", TargetSHA: "sha1",
+			Status: domain.ReviewRunComplete, Verdict: domain.VerdictChangesRequested, Body: "captured while enabled", AutoInjectReview: true,
+		},
+		prs: []domain.PullRequest{{URL: "pr1", HeadSHA: "sha1"}},
+	}
+	reducer := &fakeReducer{outcome: lifecycle.ReviewDeliverySent}
+	svc := New(nil, st, WithLifecycleReducer(reducer))
+
+	run, err := svc.Submit(context.Background(), "mer-1", "run-1", domain.VerdictChangesRequested, "captured while enabled", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != domain.ReviewRunComplete || !run.AutoInjectReview || reducer.batchCalls != 0 || st.markCalls != 0 {
+		t.Fatalf("disabled current policy delivered or rewrote snapshot: run=%+v reducerCalls=%d markCalls=%d", run, reducer.batchCalls, st.markCalls)
+	}
+}
+
 func TestSubmitBatchRunDoesNotWaitForOtherRunningRuns(t *testing.T) {
 	now := time.Unix(100, 0).UTC()
 	st := &fakeStore{


### PR DESCRIPTION
## Summary
- require the current session review-injection policy for persisted SCM feedback delivery
- gate AO review-run selection and lifecycle delivery on the current policy while preserving per-feedback snapshots
- add regressions for disabling after feedback capture across SCM and AO review batches

Closes #3840

## Tests
- `cd backend && go test ./internal/lifecycle ./internal/service/review`
- `cd backend && go test ./...` *(pre-existing/environment failures in agent auth timeout tests and CLI tests; touched packages pass)*

## Risk
Low. Changes are limited to delivery eligibility checks and focused tests; persisted snapshot behavior is unchanged.