### PR TITLE
fix: polish landing docs

### DIFF
--- a/frontend/src/landing/src/app/docs/components/mdx.tsx
+++ b/frontend/src/landing/src/app/docs/components/mdx.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { isValidElement, type ReactNode } from "react";
-import { DownloadButton } from "@/app/components/DownloadButton";
+import { FaApple, FaLinux, FaWindows } from "react-icons/fa";
 import { slugify } from "@/lib/content-utils";
+import { getPlatformDownloads, getReleases } from "@/lib/releases";
 import { Tab, Tabs } from "./DocsTabs";
 
 // Text of a heading's children, so ids match the TOC's slugify(headingText).
@@ -173,18 +174,21 @@ export function PluginCard({
 
 type Status = "full" | "partial" | "none";
 const STATUS_LABEL: Record<Status, string> = { full: "Supported", partial: "Limited", none: "Not supported" };
-const STATUS_DOT: Record<Status, string> = { full: "bg-green-400", partial: "bg-amber-400", none: "bg-muted-foreground" };
+const PLATFORM_ICONS = {
+  macOS: FaApple,
+  Windows: FaWindows,
+  Linux: FaLinux,
+} as const;
 
 function PlatformCell({ platform, status }: { platform: "macos" | "linux" | "windows"; status: Status }) {
-  const logoName = platform === "macos" ? "apple" : platform;
   const title = platform === "macos" ? "macOS" : platform === "linux" ? "Linux" : "Windows";
+  const Icon = PLATFORM_ICONS[title];
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-2 rounded-xl border border-border bg-muted/30 px-3 py-2.5">
-      <Logo name={logoName} size={18} />
+    <div className="flex min-w-0 flex-1 items-center gap-3 rounded-xl border border-border bg-muted/30 px-3 py-2.5">
+      <Icon className="size-[18px] shrink-0" aria-hidden="true" />
       <div className="flex min-w-0 flex-col">
         <span className="text-[0.8125rem] font-semibold text-foreground">{title}</span>
         <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-          <span className={`inline-block size-1.5 rounded-full ${STATUS_DOT[status]}`} />
           {STATUS_LABEL[status]}
         </span>
       </div>
@@ -216,19 +220,60 @@ export function PlatformSupport({
 }
 
 const RELEASES_URL = "https://github.com/Untrivial-ai/agent-orchestrator/releases";
+const CHANNELS = ["Stable", "Nightly"] as const;
 
-export function InstallDownloads() {
+export async function InstallDownloads() {
+  const releases = await getReleases();
+  const platformDownloads = getPlatformDownloads(releases);
+
   return (
-    <div className="my-6 rounded-xl border border-border bg-muted/30 p-5">
+    <div className="my-6">
       <div className="mb-3 flex items-center justify-between">
         <div className="text-sm font-semibold text-foreground">Get Agent Orchestrator</div>
-        <a href={RELEASES_URL} className="text-xs text-muted-foreground transition-colors hover:text-foreground">
+        <a
+          href={RELEASES_URL}
+          className="inline-flex min-h-10 items-center rounded-lg border border-border bg-background px-3 py-2 text-xs font-medium text-foreground !no-underline transition-[background-color,border-color,transform] duration-150 hover:border-foreground/30 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-[0.96] motion-reduce:transition-none"
+        >
           View releases →
         </a>
       </div>
-      <div className="flex flex-wrap items-center gap-3">
-        <DownloadButton size="md" className="rounded-xl" />
-        <span className="text-sm text-muted-foreground">macOS · Linux · Windows</span>
+      <div className="grid gap-6 sm:grid-cols-3">
+        {platformDownloads.map((platform) => (
+          <div key={platform.name}>
+            <div className="text-sm font-semibold text-foreground">{platform.name}</div>
+            {CHANNELS.map((channel) => {
+              const builds = platform.builds.filter((item) => item.channel === channel);
+              if (builds.length === 0) return null;
+              return (
+                <div key={channel} className="mt-3">
+                  <div className="text-xs font-medium text-muted-foreground">{channel}</div>
+                  <div className="mt-2 space-y-2">
+                    {builds.map((downloadBuild) => (
+                      <div key={downloadBuild.label}>
+                        <a
+                          href={downloadBuild.href}
+                          download
+                          className="flex w-full items-center gap-2 rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm font-medium text-foreground !no-underline transition-colors hover:bg-muted/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                        >
+                          {(() => {
+                            const Icon =
+                              PLATFORM_ICONS[
+                                platform.name as keyof typeof PLATFORM_ICONS
+                              ];
+                            return Icon ? (
+                              <Icon className="mr-2 size-4 shrink-0" aria-hidden="true" />
+                            ) : null;
+                          })()}
+                          {downloadBuild.label}
+                        </a>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/landing/src/app/download/page.tsx
+++ b/frontend/src/landing/src/app/download/page.tsx
@@ -1,8 +1,14 @@
+import {
+  COMPANY,
+  DOWNLOAD_URL_LINUX,
+  DOWNLOAD_URL_MAC_ARM64,
+  DOWNLOAD_URL_MAC_X64,
+  DOWNLOAD_URL_WINDOWS,
+} from "@ao/shared/constants";
 import { Download } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import { FaApple, FaLinux, FaWindows } from "react-icons/fa";
-import { getPlatformDownloads, getReleases } from "@/lib/releases";
 import { AndroidAppCTA } from "./AndroidAppCTA";
 import { MobileAppCTA } from "./MobileAppCTA";
 import { PlatformDownloadButton } from "./PlatformDownloadButton";
@@ -14,20 +20,143 @@ export const metadata: Metadata = {
     "Download Agent Orchestrator for macOS, Windows, or Linux, or join the AO Mobile beta on iOS and Android.",
 };
 
-const PLATFORM_ICONS = {
-  macOS: FaApple,
-  Windows: FaWindows,
-  Linux: FaLinux,
-} as const;
+interface GitHubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+interface GitHubRelease {
+  draft: boolean;
+  prerelease: boolean;
+  tag_name: string;
+  assets: GitHubReleaseAsset[];
+}
+
+interface DownloadBuild {
+  channel: "Stable" | "Nightly";
+  href: string;
+  label: string;
+}
+
+async function getReleases(): Promise<GitHubRelease[]> {
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${COMPANY.GITHUB_REPO}/releases?per_page=30`,
+      {
+        headers: { Accept: "application/vnd.github+json" },
+        next: { revalidate: 3600 },
+      },
+    );
+
+    if (!response.ok) return [];
+    return (await response.json()) as GitHubRelease[];
+  } catch {
+    return [];
+  }
+}
+
+function assetUrl(
+  release: GitHubRelease | undefined,
+  exactName: string,
+  fallbackPattern?: RegExp,
+) {
+  const exact = release?.assets.find((asset) => asset.name === exactName);
+  if (exact) return exact.browser_download_url;
+  return release?.assets.find((asset) => fallbackPattern?.test(asset.name))
+    ?.browser_download_url;
+}
+
+function build(
+  label: string,
+  href: string | undefined,
+  channel: DownloadBuild["channel"],
+): DownloadBuild | null {
+  return href ? { label, href, channel } : null;
+}
+
+function available(builds: Array<DownloadBuild | null>): DownloadBuild[] {
+  return builds.filter((item): item is DownloadBuild => item !== null);
+}
 
 export default async function DownloadPage() {
   const releases = await getReleases();
-  const platformDownloads = getPlatformDownloads(releases).map(
-    (platform) => ({
-      ...platform,
-      icon: PLATFORM_ICONS[platform.name as keyof typeof PLATFORM_ICONS],
-    }),
+  const stable = releases.find(
+    (release) => !release.draft && !release.prerelease,
   );
+  const nightly = releases.find(
+    (release) =>
+      !release.draft &&
+      release.prerelease &&
+      release.tag_name.includes("-nightly."),
+  );
+
+  const platformDownloads = [
+    {
+      name: "macOS",
+      icon: FaApple,
+      builds: available([
+        build("Mac (Apple silicon)", DOWNLOAD_URL_MAC_ARM64, "Stable"),
+        build("Mac (Intel)", DOWNLOAD_URL_MAC_X64, "Stable"),
+        build(
+          "Mac (Apple silicon)",
+          assetUrl(nightly, "agent-orchestrator-darwin-arm64.zip"),
+          "Nightly",
+        ),
+        build(
+          "Mac (Intel)",
+          assetUrl(nightly, "agent-orchestrator-darwin-x64.zip"),
+          "Nightly",
+        ),
+      ]),
+    },
+    {
+      name: "Windows",
+      icon: FaWindows,
+      builds: available([
+        build("Windows (x64)", DOWNLOAD_URL_WINDOWS, "Stable"),
+        build(
+          "Windows (x64)",
+          assetUrl(nightly, "agent-orchestrator-win32-x64.exe"),
+          "Nightly",
+        ),
+      ]),
+    },
+    {
+      name: "Linux",
+      icon: FaLinux,
+      builds: available([
+        build("Linux AppImage (x64)", DOWNLOAD_URL_LINUX, "Stable"),
+        build(
+          "Linux .deb (x64)",
+          assetUrl(
+            stable,
+            "agent-orchestrator-linux-x64.deb",
+            /^agent-orchestrator[_-].*(?:amd64|x86_64)\.deb$/i,
+          ),
+          "Stable",
+        ),
+        build(
+          "Linux RPM (x64)",
+          assetUrl(
+            stable,
+            "agent-orchestrator-linux-x64.rpm",
+            /^agent-orchestrator-.*x86_64\.rpm$/i,
+          ),
+          "Stable",
+        ),
+        build(
+          "Linux AppImage (x64)",
+          assetUrl(nightly, "agent-orchestrator-linux-x64.AppImage"),
+          "Nightly",
+        ),
+        build(
+          "Linux .deb (x64)",
+          assetUrl(nightly, "agent-orchestrator-linux-x64.deb"),
+          "Nightly",
+        ),
+      ]),
+    },
+  ];
 
   return (
     <main className="min-h-[100dvh] bg-background text-foreground">

--- a/frontend/src/landing/src/app/download/page.tsx
+++ b/frontend/src/landing/src/app/download/page.tsx
@@ -1,14 +1,8 @@
-import {
-  COMPANY,
-  DOWNLOAD_URL_LINUX,
-  DOWNLOAD_URL_MAC_ARM64,
-  DOWNLOAD_URL_MAC_X64,
-  DOWNLOAD_URL_WINDOWS,
-} from "@ao/shared/constants";
 import { Download } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import { FaApple, FaLinux, FaWindows } from "react-icons/fa";
+import { getPlatformDownloads, getReleases } from "@/lib/releases";
 import { AndroidAppCTA } from "./AndroidAppCTA";
 import { MobileAppCTA } from "./MobileAppCTA";
 import { PlatformDownloadButton } from "./PlatformDownloadButton";
@@ -20,143 +14,20 @@ export const metadata: Metadata = {
     "Download Agent Orchestrator for macOS, Windows, or Linux, or join the AO Mobile beta on iOS and Android.",
 };
 
-interface GitHubReleaseAsset {
-  name: string;
-  browser_download_url: string;
-}
-
-interface GitHubRelease {
-  draft: boolean;
-  prerelease: boolean;
-  tag_name: string;
-  assets: GitHubReleaseAsset[];
-}
-
-interface DownloadBuild {
-  channel: "Stable" | "Nightly";
-  href: string;
-  label: string;
-}
-
-async function getReleases(): Promise<GitHubRelease[]> {
-  try {
-    const response = await fetch(
-      `https://api.github.com/repos/${COMPANY.GITHUB_REPO}/releases?per_page=30`,
-      {
-        headers: { Accept: "application/vnd.github+json" },
-        next: { revalidate: 3600 },
-      },
-    );
-
-    if (!response.ok) return [];
-    return (await response.json()) as GitHubRelease[];
-  } catch {
-    return [];
-  }
-}
-
-function assetUrl(
-  release: GitHubRelease | undefined,
-  exactName: string,
-  fallbackPattern?: RegExp,
-) {
-  const exact = release?.assets.find((asset) => asset.name === exactName);
-  if (exact) return exact.browser_download_url;
-  return release?.assets.find((asset) => fallbackPattern?.test(asset.name))
-    ?.browser_download_url;
-}
-
-function build(
-  label: string,
-  href: string | undefined,
-  channel: DownloadBuild["channel"],
-): DownloadBuild | null {
-  return href ? { label, href, channel } : null;
-}
-
-function available(builds: Array<DownloadBuild | null>): DownloadBuild[] {
-  return builds.filter((item): item is DownloadBuild => item !== null);
-}
+const PLATFORM_ICONS = {
+  macOS: FaApple,
+  Windows: FaWindows,
+  Linux: FaLinux,
+} as const;
 
 export default async function DownloadPage() {
   const releases = await getReleases();
-  const stable = releases.find(
-    (release) => !release.draft && !release.prerelease,
+  const platformDownloads = getPlatformDownloads(releases).map(
+    (platform) => ({
+      ...platform,
+      icon: PLATFORM_ICONS[platform.name as keyof typeof PLATFORM_ICONS],
+    }),
   );
-  const nightly = releases.find(
-    (release) =>
-      !release.draft &&
-      release.prerelease &&
-      release.tag_name.includes("-nightly."),
-  );
-
-  const platformDownloads = [
-    {
-      name: "macOS",
-      icon: FaApple,
-      builds: available([
-        build("Mac (Apple silicon)", DOWNLOAD_URL_MAC_ARM64, "Stable"),
-        build("Mac (Intel)", DOWNLOAD_URL_MAC_X64, "Stable"),
-        build(
-          "Mac (Apple silicon)",
-          assetUrl(nightly, "agent-orchestrator-darwin-arm64.zip"),
-          "Nightly",
-        ),
-        build(
-          "Mac (Intel)",
-          assetUrl(nightly, "agent-orchestrator-darwin-x64.zip"),
-          "Nightly",
-        ),
-      ]),
-    },
-    {
-      name: "Windows",
-      icon: FaWindows,
-      builds: available([
-        build("Windows (x64)", DOWNLOAD_URL_WINDOWS, "Stable"),
-        build(
-          "Windows (x64)",
-          assetUrl(nightly, "agent-orchestrator-win32-x64.exe"),
-          "Nightly",
-        ),
-      ]),
-    },
-    {
-      name: "Linux",
-      icon: FaLinux,
-      builds: available([
-        build("Linux AppImage (x64)", DOWNLOAD_URL_LINUX, "Stable"),
-        build(
-          "Linux .deb (x64)",
-          assetUrl(
-            stable,
-            "agent-orchestrator-linux-x64.deb",
-            /^agent-orchestrator[_-].*(?:amd64|x86_64)\.deb$/i,
-          ),
-          "Stable",
-        ),
-        build(
-          "Linux RPM (x64)",
-          assetUrl(
-            stable,
-            "agent-orchestrator-linux-x64.rpm",
-            /^agent-orchestrator-.*x86_64\.rpm$/i,
-          ),
-          "Stable",
-        ),
-        build(
-          "Linux AppImage (x64)",
-          assetUrl(nightly, "agent-orchestrator-linux-x64.AppImage"),
-          "Nightly",
-        ),
-        build(
-          "Linux .deb (x64)",
-          assetUrl(nightly, "agent-orchestrator-linux-x64.deb"),
-          "Nightly",
-        ),
-      ]),
-    },
-  ];
 
   return (
     <main className="min-h-[100dvh] bg-background text-foreground">

--- a/frontend/src/landing/src/lib/releases.ts
+++ b/frontend/src/landing/src/lib/releases.ts
@@ -1,0 +1,156 @@
+import {
+  COMPANY,
+  DOWNLOAD_URL_LINUX,
+  DOWNLOAD_URL_MAC_ARM64,
+  DOWNLOAD_URL_MAC_X64,
+  DOWNLOAD_URL_WINDOWS,
+} from "@ao/shared/constants";
+
+export interface GitHubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+export interface GitHubRelease {
+  draft: boolean;
+  prerelease: boolean;
+  tag_name: string;
+  assets: GitHubReleaseAsset[];
+}
+
+export interface DownloadBuild {
+  channel: "Stable" | "Nightly";
+  href: string;
+  label: string;
+}
+
+export interface PlatformDownloads {
+  name: string;
+  builds: DownloadBuild[];
+}
+
+export async function getReleases(): Promise<GitHubRelease[]> {
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${COMPANY.GITHUB_REPO}/releases?per_page=30`,
+      {
+        headers: { Accept: "application/vnd.github+json" },
+        next: { revalidate: 3600 },
+      },
+    );
+
+    if (!response.ok) return [];
+    return (await response.json()) as GitHubRelease[];
+  } catch {
+    return [];
+  }
+}
+
+function assetUrl(
+  release: GitHubRelease | undefined,
+  exactName: string,
+  fallbackPattern?: RegExp,
+) {
+  const exact = release?.assets.find((asset) => asset.name === exactName);
+  if (exact) return exact.browser_download_url;
+  return release?.assets.find((asset) => fallbackPattern?.test(asset.name))
+    ?.browser_download_url;
+}
+
+function build(
+  label: string,
+  href: string | undefined,
+  channel: DownloadBuild["channel"],
+): DownloadBuild | null {
+  return href ? { label, href, channel } : null;
+}
+
+function available(builds: Array<DownloadBuild | null>): DownloadBuild[] {
+  return builds.filter((item): item is DownloadBuild => item !== null);
+}
+
+export function findStableRelease(releases: GitHubRelease[]) {
+  return releases.find((release) => !release.draft && !release.prerelease);
+}
+
+export function findNightlyRelease(releases: GitHubRelease[]) {
+  return releases.find(
+    (release) =>
+      !release.draft &&
+      release.prerelease &&
+      release.tag_name.includes("-nightly."),
+  );
+}
+
+/** Per-platform Stable + Nightly download links, sourced from the latest GitHub releases. */
+export function getPlatformDownloads(
+  releases: GitHubRelease[],
+): PlatformDownloads[] {
+  const stable = findStableRelease(releases);
+  const nightly = findNightlyRelease(releases);
+
+  return [
+    {
+      name: "macOS",
+      builds: available([
+        build("Mac (Apple silicon)", DOWNLOAD_URL_MAC_ARM64, "Stable"),
+        build("Mac (Intel)", DOWNLOAD_URL_MAC_X64, "Stable"),
+        build(
+          "Mac (Apple silicon)",
+          assetUrl(nightly, "agent-orchestrator-darwin-arm64.zip"),
+          "Nightly",
+        ),
+        build(
+          "Mac (Intel)",
+          assetUrl(nightly, "agent-orchestrator-darwin-x64.zip"),
+          "Nightly",
+        ),
+      ]),
+    },
+    {
+      name: "Windows",
+      builds: available([
+        build("Windows (x64)", DOWNLOAD_URL_WINDOWS, "Stable"),
+        build(
+          "Windows (x64)",
+          assetUrl(nightly, "agent-orchestrator-win32-x64.exe"),
+          "Nightly",
+        ),
+      ]),
+    },
+    {
+      name: "Linux",
+      builds: available([
+        build("Linux AppImage (x64)", DOWNLOAD_URL_LINUX, "Stable"),
+        build(
+          "Linux .deb (x64)",
+          assetUrl(
+            stable,
+            "agent-orchestrator-linux-x64.deb",
+            /^agent-orchestrator[_-].*(?:amd64|x86_64)\.deb$/i,
+          ),
+          "Stable",
+        ),
+        build(
+          "Linux RPM (x64)",
+          assetUrl(
+            stable,
+            "agent-orchestrator-linux-x64.rpm",
+            /^agent-orchestrator-.*x86_64\.rpm$/i,
+          ),
+          "Stable",
+        ),
+        build(
+          "Linux AppImage (x64)",
+          assetUrl(nightly, "agent-orchestrator-linux-x64.AppImage"),
+          "Nightly",
+        ),
+        build(
+          "Linux .deb (x64)",
+          assetUrl(nightly, "agent-orchestrator-linux-x64.deb"),
+          "Nightly",
+        ),
+      ]),
+    },
+  ];
+}


### PR DESCRIPTION
## What

This PR is a docs-only follow-up to [PR #3826](https://github.com/Untrivial-ai/agent-orchestrator/pull/3826), which contains the main landing documentation rewrite. It polishes the documentation download block and platform support cards.

## Why

The docs download block rendered release links as underlined text with inherited list indentation. The platform cards also used generic logos and a status dot that added visual noise.

Because this PR is based on main and includes the base PR's branch history, GitHub shows the full landing-doc rewrite in the change summary. The changes introduced by this follow-up are limited to the docs components.

## How

- Reuse shared release discovery for the docs download block.
- Render stable and nightly builds as accordion-style download buttons.
- Add Apple, Windows, and Linux icons to download buttons and platform cards.
- Remove the supported-status indicator dot and align platform cards with the docs layout.
- Keep the download block free of inherited prose list indentation and link underlines.

## Testing

- npm run build from frontend/src/landing
- Confirmed http://localhost:3000/docs/installation/ returns HTTP 200.

The build passes. Next.js reports an existing workspace-root warning and GitHub release responses over the 2 MB data-cache limit; neither prevents the build from completing.

## Checklist

- [x] Branched from main (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows AGENTS.md conventions and PR hygiene
- [ ] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (frontend).
