### PR TITLE
fix(chat): enable Switch to Chat on Windows — fresh-start readiness + .cmd shim resolution

### DIFF
--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -382,6 +382,12 @@ func (m *Manager) nativeConversationID(
 	}
 	id = strings.TrimSpace(id)
 	if !ok || id == "" {
+		// An adapter with a history probe can safely start fresh when the
+		// native id is missing; the probe distinguishes a real conversation
+		// from an empty TUI.
+		if _, ok := handoff.(ports.AgentInterfaceHandoffHistoryProbe); ok {
+			return "", handoff, nil
+		}
 		return "", handoff, fmt.Errorf("%w for %s", ErrNativeConversationMissing, rec.Harness)
 	}
 	return id, handoff, nil

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -824,6 +824,46 @@ func TestInterfaceTransitionTUIToChatStartsFreshWhenReservedIDHasNoHistory(t *te
 	}
 }
 
+func TestInterfaceTransitionTUIToChatAllowsFreshStartWhenNativeIDMissingWithProbe(t *testing.T) {
+	manager, store, _, chat, _ := newTransitionManager(t, domain.SessionModeTUI)
+	manager.agents = singleAgent{agent: emptyTransitionAgent{}}
+	rec := store.sessions["session-1"]
+	rec.Metadata.AgentSessionID = ""
+	store.sessions["session-1"] = rec
+
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("phase = %s, error = %s", settled.Phase, settled.ErrorDetail)
+	}
+	if settled.NativeConversationID != "" {
+		t.Fatalf("native conversation = %q, want fresh sentinel", settled.NativeConversationID)
+	}
+	if chat.start.ProviderConversationID != "" {
+		t.Fatalf("Chat resumed %q, want a fresh conversation", chat.start.ProviderConversationID)
+	}
+}
+
+func TestInterfaceTransitionTUIToChatBlocksWhenNativeIDMissingWithoutProbe(t *testing.T) {
+	manager, store, _, _, _ := newTransitionManager(t, domain.SessionModeTUI)
+	rec := store.sessions["session-1"]
+	rec.Metadata.AgentSessionID = ""
+	store.sessions["session-1"] = rec
+
+	_, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err == nil {
+		t.Fatal("expected NATIVE_SESSION_MISSING error, got nil")
+	}
+	if !errors.Is(err, ErrNativeConversationMissing) {
+		t.Fatalf("expected NATIVE_SESSION_MISSING, got %v", err)
+	}
+}
+
 func TestInterfaceTransitionTUIToChatStartsFreshWhenCodexRolloutIsMissing(t *testing.T) {
 	manager, store, _, chat, _ := newTransitionManager(t, domain.SessionModeTUI)
 	t.Setenv("CODEX_HOME", t.TempDir())


### PR DESCRIPTION
Two fixes that unblock the "Switch to Chat" button on Windows, where the interface transition dead-ends before a Chat session can start.

## Why

Refs [#3753](https://github.com/Untrivial-ai/agent-orchestrator/issues/3753)

On Windows the SessionStart hook does not fire for Codex (see #3820), so the native conversation id is never reported. The transition status then blocks as `NATIVE_SESSION_MISSING` and the "Switch to Chat" button stays disabled indefinitely. This is a simpler alternative to #3771 — instead of fabricating a synthetic UUID, it models the fresh-start path in transition readiness using the adapter's existing history probe.

The second fix addresses a separate Windows blocker: Claude Code ships as an npm `.cmd` shim, and Node `child_process.spawn` cannot execute `.cmd` files. Without resolving to the real `.exe`, the Chat spawn fails with `EINVAL` before the transition even begins.

## How

**Commit 1** — `fix(chat): allow fresh-start transition when adapter has history probe`

Commit 1 — fix(chat): allow fresh-start transition when adapter has history probe
If the adapter implements AgentInterfaceHandoffHistoryProbe, an empty native id is allowed through. The history probe distinguishes a real conversation from an empty TUI, and persistedNativeConversationID uses that to decide between resume and fresh start. Adapters without a probe keep the hard block. Two tests cover the new branch: fresh-start allowed with probe, and hard block without probe.

**Commit 2** — `fix(claudeacp): resolve Windows .cmd shim to .exe for Chat spawn`

`resolveClaudeExe` unwraps the npm `.cmd` shim: prefer a sibling `.exe`, else parse the shim's quoted `%dp0%` target path. 7 tests cover pass-through, cancelled context, missing file, sibling `.exe`, quoted `%dp0%` target, malformed shim, and unreadable shim. Windows-gated cases skip on other platforms.

## Testing

- `go test ./internal/adapters/chatdriver/claudeacp/... -count=1` — 11 pass, 1 skip (live)
- `go test ./internal/session_manager/... -run TestInterfaceTransition -count=1` — pass
- Verified on Windows: Codex "Switch to Chat" button enables, Claude Code Chat launches