### PR TITLE
fix(session): stop stale origin/main ref from inflating workspace diff file count

### DIFF
--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -574,6 +574,77 @@ func TestWorkspaceFilesRecomputesRecordedRefAfterBaseMoves(t *testing.T) {
 	}
 }
 
+// TestWorkspaceFilesExcludeMainChangesMergedInAfterStaleOriginRef reproduces a
+// file-count inflation bug: AO never runs `git fetch` against a session
+// worktree, so its refs/remotes/origin/main tracking ref can go stale relative
+// to the real upstream. When the branch later merges a newer main in (e.g. to
+// resolve a merge conflict), recomputing the compare base from that stale ref
+// still "succeeds" but lands on an earlier commit than the branch's true
+// merge point, so unrelated commits that landed on main afterward leak into
+// the diff as if they were part of the PR.
+func TestWorkspaceFilesExcludeMainChangesMergedInAfterStaleOriginRef(t *testing.T) {
+	repo := newWorkspaceRepo(t)
+	runGit(t, repo, "branch", "-M", "main")
+
+	// M1: a commit lands on main before the session spawns. AO records this
+	// as the session's origin/main tracking ref at spawn time.
+	writeWorkspaceFile(t, repo, "unrelated-1.go", "package main\n")
+	runGit(t, repo, "add", "unrelated-1.go")
+	runGit(t, repo, "commit", "-m", "unrelated change 1")
+	m1 := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+	runGit(t, repo, "update-ref", "refs/remotes/origin/main", m1)
+
+	// The session's feature branch forks from here and makes its own change.
+	runGit(t, repo, "switch", "-c", "ao/work")
+	writeWorkspaceFile(t, repo, "pr-file.go", "package main\n")
+	runGit(t, repo, "add", "pr-file.go")
+	runGit(t, repo, "commit", "-m", "pr change")
+
+	// M2: an unrelated PR merges into main after the session spawned. Nothing
+	// in AO refreshes refs/remotes/origin/main, so it still points at M1.
+	runGit(t, repo, "switch", "main")
+	writeWorkspaceFile(t, repo, "unrelated-2.go", "package main\n")
+	runGit(t, repo, "add", "unrelated-2.go")
+	runGit(t, repo, "commit", "-m", "unrelated change 2")
+	m2 := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+
+	// The developer resolves a conflict by merging current main into their
+	// branch. HEAD gains M2 as an ancestor, but the stale tracking ref doesn't move.
+	runGit(t, repo, "switch", "ao/work")
+	runGit(t, repo, "merge", "main", "-m", "merge main to resolve conflict")
+
+	st := newFakeStore()
+	st.projects["proj"] = domain.ProjectRecord{ID: "proj", Config: domain.ProjectConfig{DefaultBranch: "main"}}
+	st.sessions["ao-1"] = domain.SessionRecord{
+		ID:        "ao-1",
+		ProjectID: "proj",
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: repo,
+			DiffBaseRef:   "origin/main",
+		},
+	}
+	// AO's own PR sync has observed GitHub's current base tip (M2) even though
+	// the local origin/main tracking ref hasn't moved.
+	st.prs["ao-1"] = []domain.PullRequest{
+		{URL: "pr", SessionID: "ao-1", Number: 1, TargetBranch: "main", BaseSHA: m2},
+	}
+
+	files, err := (&Service{store: st}).ListWorkspaceFiles(context.Background(), "ao-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := map[string]WorkspaceFileSummary{}
+	for _, file := range files.Files {
+		byPath[file.Path] = file
+	}
+	if byPath["pr-file.go"].Status != WorkspaceFileAdded {
+		t.Fatalf("pr-file.go status = %q, want added", byPath["pr-file.go"].Status)
+	}
+	if got, ok := byPath["unrelated-2.go"]; ok && got.Status != WorkspaceFileUnmodified {
+		t.Fatalf("unrelated-2.go leaked into the diff via a stale origin/main tracking ref: %#v (compare base %q)", got, files.CompareBaseSHA)
+	}
+}
+
 func TestWorkspaceFilesPRFallbackPrefersDefaultTargetPR(t *testing.T) {
 	repo := newWorkspaceRepo(t)
 	runGit(t, repo, "branch", "-M", "main")

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -283,19 +283,25 @@ func (s *Service) workspaceComparePRs(ctx context.Context, id domain.SessionID) 
 func resolveWorkspaceCompare(ctx context.Context, root, recordedSHA, recordedRef, defaultBranch string, prs []domain.PullRequest) workspaceCompareTarget {
 	recordedSHA = strings.TrimSpace(recordedSHA)
 	recordedRef = strings.TrimSpace(recordedRef)
+	var refBased *workspaceCompareTarget
 	if recordedRef != "" && recordedRef != "HEAD" {
 		for _, ref := range workspaceBaseRefCandidates(recordedRef) {
 			if sha, ok := gitMergeBase(ctx, root, ref); ok {
-				return workspaceCompareTarget{BaseSHA: sha, BaseRef: ref, Mode: WorkspaceCompareBase}
+				target := workspaceCompareTarget{BaseSHA: sha, BaseRef: ref, Mode: WorkspaceCompareBase}
+				refBased = &target
+				break
 			}
 		}
 	}
-	if recordedSHA != "" && gitCommitExists(ctx, root, recordedSHA) {
-		return workspaceCompareTarget{BaseSHA: recordedSHA, BaseRef: recordedRef, Mode: WorkspaceCompareBase}
-	}
+	// A local remote-tracking ref (e.g. origin/main) can go stale: nothing in
+	// AO fetches a session worktree, so if the branch later merges a newer
+	// main in (e.g. to resolve a conflict) without that ref moving, the merge
+	// base above still resolves but lands earlier than the branch's true fork
+	// point, pulling unrelated main commits into the diff. Prefer the PR's
+	// own, independently-synced base commit whenever it's at least as
+	// advanced as the ref-based candidate.
 	if pr, ok := selectWorkspaceComparePR(prs, defaultBranch); ok {
-		baseSHA := strings.TrimSpace(pr.BaseSHA)
-		if gitCommitExists(ctx, root, baseSHA) {
+		if baseSHA := strings.TrimSpace(pr.BaseSHA); baseSHA != "" && gitCommitExists(ctx, root, baseSHA) {
 			// pr.BaseSHA is the target branch's current tip, not the commit the
 			// session forked from. If the target branch has advanced since, diff
 			// straight against it would also surface every base-only change
@@ -304,8 +310,16 @@ func resolveWorkspaceCompare(ctx context.Context, root, recordedSHA, recordedRef
 			if merged, ok := gitMergeBase(ctx, root, baseSHA); ok {
 				baseSHA = merged
 			}
-			return workspaceCompareTarget{BaseSHA: baseSHA, BaseRef: strings.TrimSpace(pr.TargetBranch), Mode: WorkspaceCompareBase}
+			if refBased == nil || gitIsAncestor(ctx, root, refBased.BaseSHA, baseSHA) {
+				return workspaceCompareTarget{BaseSHA: baseSHA, BaseRef: strings.TrimSpace(pr.TargetBranch), Mode: WorkspaceCompareBase}
+			}
 		}
+	}
+	if refBased != nil {
+		return *refBased
+	}
+	if recordedSHA != "" && gitCommitExists(ctx, root, recordedSHA) {
+		return workspaceCompareTarget{BaseSHA: recordedSHA, BaseRef: recordedRef, Mode: WorkspaceCompareBase}
 	}
 	for _, ref := range workspaceBaseRefCandidates(defaultBranch) {
 		if sha, ok := gitMergeBase(ctx, root, ref); ok {
@@ -427,6 +441,13 @@ func gitMergeBase(ctx context.Context, root, ref string) (string, bool) {
 	}
 	sha := strings.TrimSpace(out)
 	return sha, sha != ""
+}
+
+// gitIsAncestor reports whether ancestor is reachable from descendant
+// (including ancestor == descendant).
+func gitIsAncestor(ctx context.Context, root, ancestor, descendant string) bool {
+	_, err := gitWorkspaceOutput(ctx, root, "merge-base", "--is-ancestor", ancestor, descendant)
+	return err == nil
 }
 
 func (s *Service) listWorkspaceProjectFiles(ctx context.Context, rec domain.SessionRecord, project domain.ProjectRecord) (WorkspaceFiles, error) {


### PR DESCRIPTION
## Summary
- The session workspace Files tab was showing far more changed files than the PR actually has (e.g. 130 vs. the real 48), and the count would degrade from correct to wrong over a PR's lifetime.
- Root cause: AO never runs `git fetch` against a session worktree, so its `refs/remotes/origin/main` tracking ref can go stale relative to the real upstream. `resolveWorkspaceCompare` recomputes the compare base against that ref on every request; when the branch later merges a newer `main` in (e.g. to resolve a conflict) without the ref moving, the recomputed merge base still "succeeds" but lands earlier than the branch's true fork point, so every unrelated commit that landed on `main` afterward leaks into the diff as if it were part of the PR.
- Fix: prefer the PR's own, independently-synced base commit (`pr.BaseSHA`, re-derived through `git merge-base` as before) whenever it's at least as advanced as the ref-based candidate, since AO's PR sync keeps that current regardless of whether the local tracking ref has been refreshed.

## Test plan
- [x] Added `TestWorkspaceFilesExcludeMainChangesMergedInAfterStaleOriginRef`, which reproduces the bug (fails on the old code, passes with the fix) by simulating a stale `origin/main` tracking ref and a branch that later merges current `main` in.
- [x] `go build ./...`
- [x] `go vet ./internal/service/session/...`
- [x] `go test ./internal/service/session/... -count=1` (all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)