### PR TITLE
fix: show project creation state after deleting last project

### DIFF
--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -363,6 +363,8 @@ function ShellLayout() {
 
 	const removeProject = useCallback(
 		async (projectId: string) => {
+			const isLastWorkspace =
+              workspaces.length === 1 && workspaces[0]?.id === projectId;
 			void addRendererExceptionStep("Project removal requested", {
 				source: "project-remove",
 				operation: "project_remove",
@@ -385,8 +387,11 @@ function ShellLayout() {
 			}
 			void captureRendererEvent("ao.renderer.project_removed", { project_id: projectId });
 			updateWorkspaces((current) => current.filter((item) => item.id !== projectId));
+			if (isLastWorkspace) {
+              void navigate({ to: "/" });
+}
 		},
-		[updateWorkspaces],
+		[navigate, updateWorkspaces, workspaces],
 	);
 
 	const restartOrchestrator = useCallback(


### PR DESCRIPTION
## What

Fixes #3824 : the project deletion flow when the deleted project is the last remaining workspace.

## Why

When Scratch is the only remaining project, deleting it can trigger the existing
"open Scratch when it is the only project" navigation before the asynchronous
deletion completes.

Once the deletion finishes, the workspace is empty but the app can remain on
`/projects/scratch`, so the empty project creation state is not shown.

## How

Detect when the project being deleted is the last workspace and navigate to `/`
after the deletion succeeds.

This allows the existing empty-project creation state to render correctly
without changing the existing Scratch auto-open behavior.

## Testing

- Verified deleting the only Scratch project opens the New Project panel.
- Verified deleting Scratch after other projects have been removed opens the New Project panel.
- Verified deleting a normal project while Scratch remains does not change behavior.
- Verified the existing Scratch auto-open behavior remains unchanged.
- `npm run typecheck` passes.
- Manually verified the deletion flow in the Electron app.
