### PR TITLE
feat: define GitHub App cloud contract

### DIFF
--- a/contracts/cloud/openapi.yaml
+++ b/contracts/cloud/openapi.yaml
@@ -83,6 +83,131 @@ paths:
                     $ref: "#/components/schemas/Project"
         default:
           $ref: "#/components/responses/Error"
+  /api/cloud/v1/orgs/{orgId}/github/installations:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    get:
+      operationId: listGitHubInstallations
+      tags: [GitHub]
+      responses:
+        "200":
+          description: GitHub App installations connected to the organization.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [installations]
+                properties:
+                  installations:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/GitHubInstallation"
+        default:
+          $ref: "#/components/responses/Error"
+  /api/cloud/v1/orgs/{orgId}/github/installations/start:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      operationId: startGitHubInstallation
+      tags: [GitHub]
+      responses:
+        "201":
+          description: A short-lived GitHub App installation attempt.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GitHubInstallationStart"
+        default:
+          $ref: "#/components/responses/Error"
+  /api/cloud/v1/orgs/{orgId}/github/installations/{githubInstallationId}/sync:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/GitHubInstallationId"
+    post:
+      operationId: syncGitHubInstallation
+      tags: [GitHub]
+      responses:
+        "202":
+          description: Repository synchronization accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [installation]
+                properties:
+                  installation:
+                    $ref: "#/components/schemas/GitHubInstallation"
+        default:
+          $ref: "#/components/responses/Error"
+  /api/cloud/v1/orgs/{orgId}/github/installations/{githubInstallationId}/disconnect:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/GitHubInstallationId"
+    post:
+      operationId: disconnectGitHubInstallation
+      tags: [GitHub]
+      responses:
+        "200":
+          description: The GitHub App installation was disconnected from AO.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [installation]
+                properties:
+                  installation:
+                    $ref: "#/components/schemas/GitHubInstallation"
+        default:
+          $ref: "#/components/responses/Error"
+  /api/cloud/v1/orgs/{orgId}/github/repositories:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    get:
+      operationId: listGitHubRepositories
+      tags: [GitHub]
+      parameters:
+        - $ref: "#/components/parameters/Cursor"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: A page of repositories currently or historically granted to the organization.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GitHubRepositoryPage"
+        default:
+          $ref: "#/components/responses/Error"
+  /api/cloud/v1/orgs/{orgId}/github/projects:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      operationId: createProjectFromGitHub
+      tags: [GitHub, Projects]
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGitHubProjectInput"
+      responses:
+        "201":
+          description: Project created from an actively granted GitHub repository.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [project]
+                properties:
+                  project:
+                    $ref: "#/components/schemas/Project"
+        default:
+          $ref: "#/components/responses/Error"
   /api/cloud/v1/orgs/{orgId}/sessions:
     parameters:
       - $ref: "#/components/parameters/OrgId"
@@ -414,6 +539,13 @@ components:
       schema:
         type: string
         minLength: 1
+    GitHubInstallationId:
+      name: githubInstallationId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     Cursor:
       name: cursor
       in: query
@@ -595,6 +727,136 @@ components:
             $ref: "#/components/schemas/Project"
         page:
           $ref: "#/components/schemas/PageInfo"
+    GitHubInstallationStatus:
+      type: string
+      enum: [active, suspended, removed]
+    GitHubSyncStatus:
+      type: string
+      enum: [pending, syncing, ready, retry, failed]
+    GitHubInstallation:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - githubInstallationId
+        - accountLogin
+        - accountType
+        - status
+        - repositorySelection
+        - syncStatus
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        githubInstallationId:
+          type: integer
+          format: int64
+        accountLogin:
+          type: string
+        accountType:
+          type: string
+          enum: [User, Organization, Enterprise]
+        status:
+          $ref: "#/components/schemas/GitHubInstallationStatus"
+        repositorySelection:
+          type: string
+          enum: [all, selected]
+        syncStatus:
+          $ref: "#/components/schemas/GitHubSyncStatus"
+        lastSyncedAt:
+          type: string
+          format: date-time
+        lastError:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    GitHubInstallationStart:
+      type: object
+      additionalProperties: false
+      required: [installationUrl, expiresAt]
+      properties:
+        installationUrl:
+          type: string
+          format: uri
+        expiresAt:
+          type: string
+          format: date-time
+    GitHubRepositoryAccessState:
+      type: string
+      enum: [active, revoked]
+    GitHubRepository:
+      type: object
+      additionalProperties: false
+      required:
+        - githubRepositoryId
+        - name
+        - fullName
+        - htmlUrl
+        - defaultBranch
+        - visibility
+        - isPrivate
+        - isArchived
+        - access
+        - grantedAt
+      properties:
+        githubRepositoryId:
+          type: integer
+          format: int64
+        name:
+          type: string
+        fullName:
+          type: string
+        htmlUrl:
+          type: string
+          format: uri
+        defaultBranch:
+          type: string
+        visibility:
+          type: string
+        isPrivate:
+          type: boolean
+        isArchived:
+          type: boolean
+        access:
+          $ref: "#/components/schemas/GitHubRepositoryAccessState"
+        grantedAt:
+          type: string
+          format: date-time
+        revokedAt:
+          type: string
+          format: date-time
+    GitHubRepositoryPage:
+      type: object
+      additionalProperties: false
+      required: [items, page]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/GitHubRepository"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+    CreateGitHubProjectInput:
+      type: object
+      additionalProperties: false
+      required: [githubRepositoryId]
+      properties:
+        githubRepositoryId:
+          type: integer
+          format: int64
+        displayName:
+          type: string
+          minLength: 1
+          maxLength: 120
+        config:
+          type: object
+          additionalProperties: true
     SessionKind:
       type: string
       enum: [worker, orchestrator]

--- a/packages/cloud-client/src/client.ts
+++ b/packages/cloud-client/src/client.ts
@@ -2,10 +2,14 @@ import type {
   AgentProfile,
   ClientEvent,
   ClientEventPage,
+  CreateGitHubProjectInput,
   CreateProjectInput,
   CreateSessionInput,
   ErrorEnvelope,
   EventReplayOptions,
+  GitHubInstallation,
+  GitHubInstallationStart,
+  GitHubRepositoryPage,
   IdempotentRequestOptions,
   PaginationOptions,
   Project,
@@ -103,6 +107,80 @@ export class CloudClient {
     options: IdempotentRequestOptions,
   ): Promise<{ project: Project }> {
     return this.request(this.orgPath(orgId, "/projects"), {
+      method: "POST",
+      body: input,
+      idempotencyKey: options.idempotencyKey,
+      signal: options.signal,
+    });
+  }
+
+  async listGitHubInstallations(
+    orgId: string,
+    options: RequestOptions = {},
+  ): Promise<GitHubInstallation[]> {
+    const response = await this.request<{
+      installations: GitHubInstallation[];
+    }>(this.orgPath(orgId, "/github/installations"), options);
+    return response.installations;
+  }
+
+  startGitHubInstallation(
+    orgId: string,
+    options: RequestOptions = {},
+  ): Promise<GitHubInstallationStart> {
+    return this.request(this.orgPath(orgId, "/github/installations/start"), {
+      method: "POST",
+      signal: options.signal,
+    });
+  }
+
+  syncGitHubInstallation(
+    orgId: string,
+    installationId: string,
+    options: RequestOptions = {},
+  ): Promise<{ installation: GitHubInstallation }> {
+    return this.request(
+      this.orgPath(
+        orgId,
+        `/github/installations/${encodeURIComponent(installationId)}/sync`,
+      ),
+      { method: "POST", signal: options.signal },
+    );
+  }
+
+  disconnectGitHubInstallation(
+    orgId: string,
+    installationId: string,
+    options: RequestOptions = {},
+  ): Promise<{ installation: GitHubInstallation }> {
+    return this.request(
+      this.orgPath(
+        orgId,
+        `/github/installations/${encodeURIComponent(installationId)}/disconnect`,
+      ),
+      { method: "POST", signal: options.signal },
+    );
+  }
+
+  listGitHubRepositories(
+    orgId: string,
+    options: PaginationOptions = {},
+  ): Promise<GitHubRepositoryPage> {
+    return this.request(
+      this.withQuery(this.orgPath(orgId, "/github/repositories"), {
+        cursor: options.cursor,
+        limit: options.limit,
+      }),
+      { signal: options.signal },
+    );
+  }
+
+  createProjectFromGitHub(
+    orgId: string,
+    input: CreateGitHubProjectInput,
+    options: IdempotentRequestOptions,
+  ): Promise<{ project: Project }> {
+    return this.request(this.orgPath(orgId, "/github/projects"), {
       method: "POST",
       body: input,
       idempotencyKey: options.idempotencyKey,

--- a/packages/cloud-client/src/schema.ts
+++ b/packages/cloud-client/src/schema.ts
@@ -40,6 +40,116 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/cloud/v1/orgs/{orgId}/github/installations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        get: operations["listGitHubInstallations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cloud/v1/orgs/{orgId}/github/installations/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["startGitHubInstallation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cloud/v1/orgs/{orgId}/github/installations/{githubInstallationId}/sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+                githubInstallationId: components["parameters"]["GitHubInstallationId"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["syncGitHubInstallation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cloud/v1/orgs/{orgId}/github/installations/{githubInstallationId}/disconnect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+                githubInstallationId: components["parameters"]["GitHubInstallationId"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["disconnectGitHubInstallation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cloud/v1/orgs/{orgId}/github/repositories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        get: operations["listGitHubRepositories"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cloud/v1/orgs/{orgId}/github/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["createProjectFromGitHub"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/cloud/v1/orgs/{orgId}/sessions": {
         parameters: {
             query?: never;
@@ -350,6 +460,67 @@ export interface components {
         ProjectPage: {
             items: components["schemas"]["Project"][];
             page: components["schemas"]["PageInfo"];
+        };
+        /** @enum {string} */
+        GitHubInstallationStatus: "active" | "suspended" | "removed";
+        /** @enum {string} */
+        GitHubSyncStatus: "pending" | "syncing" | "ready" | "retry" | "failed";
+        GitHubInstallation: {
+            /** Format: uuid */
+            id: string;
+            /** Format: int64 */
+            githubInstallationId: number;
+            accountLogin: string;
+            /** @enum {string} */
+            accountType: "User" | "Organization" | "Enterprise";
+            status: components["schemas"]["GitHubInstallationStatus"];
+            /** @enum {string} */
+            repositorySelection: "all" | "selected";
+            syncStatus: components["schemas"]["GitHubSyncStatus"];
+            /** Format: date-time */
+            lastSyncedAt?: string;
+            lastError?: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        GitHubInstallationStart: {
+            /** Format: uri */
+            installationUrl: string;
+            /** Format: date-time */
+            expiresAt: string;
+        };
+        /** @enum {string} */
+        GitHubRepositoryAccessState: "active" | "revoked";
+        GitHubRepository: {
+            /** Format: int64 */
+            githubRepositoryId: number;
+            name: string;
+            fullName: string;
+            /** Format: uri */
+            htmlUrl: string;
+            defaultBranch: string;
+            visibility: string;
+            isPrivate: boolean;
+            isArchived: boolean;
+            access: components["schemas"]["GitHubRepositoryAccessState"];
+            /** Format: date-time */
+            grantedAt: string;
+            /** Format: date-time */
+            revokedAt?: string;
+        };
+        GitHubRepositoryPage: {
+            items: components["schemas"]["GitHubRepository"][];
+            page: components["schemas"]["PageInfo"];
+        };
+        CreateGitHubProjectInput: {
+            /** Format: int64 */
+            githubRepositoryId: number;
+            displayName?: string;
+            config?: {
+                [key: string]: unknown;
+            };
         };
         /** @enum {string} */
         SessionKind: "worker" | "orchestrator";
@@ -741,6 +912,7 @@ export interface components {
     parameters: {
         OrgId: string;
         SessionId: string;
+        GitHubInstallationId: string;
         Cursor: string;
         Limit: number;
         EventLimit: number;
@@ -829,6 +1001,166 @@ export interface operations {
         };
         responses: {
             /** @description Project created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        project: components["schemas"]["Project"];
+                    };
+                };
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    listGitHubInstallations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description GitHub App installations connected to the organization. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        installations: components["schemas"]["GitHubInstallation"][];
+                    };
+                };
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    startGitHubInstallation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A short-lived GitHub App installation attempt. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GitHubInstallationStart"];
+                };
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    syncGitHubInstallation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+                githubInstallationId: components["parameters"]["GitHubInstallationId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Repository synchronization accepted. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        installation: components["schemas"]["GitHubInstallation"];
+                    };
+                };
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    disconnectGitHubInstallation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+                githubInstallationId: components["parameters"]["GitHubInstallationId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The GitHub App installation was disconnected from AO. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        installation: components["schemas"]["GitHubInstallation"];
+                    };
+                };
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    listGitHubRepositories: {
+        parameters: {
+            query?: {
+                cursor?: components["parameters"]["Cursor"];
+                limit?: components["parameters"]["Limit"];
+            };
+            header?: never;
+            path: {
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A page of repositories currently or historically granted to the organization. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GitHubRepositoryPage"];
+                };
+            };
+            default: components["responses"]["Error"];
+        };
+    };
+    createProjectFromGitHub: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Reusing a key with the same command returns the original result.
+                 *     Reusing it with a different command returns an IDEMPOTENCY_CONFLICT.
+                 *      */
+                "Idempotency-Key": components["parameters"]["IdempotencyKey"];
+            };
+            path: {
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateGitHubProjectInput"];
+            };
+        };
+        responses: {
+            /** @description Project created from an actively granted GitHub repository. */
             201: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/cloud-client/src/types.ts
+++ b/packages/cloud-client/src/types.ts
@@ -16,6 +16,16 @@ export type Project = Schemas["Project"];
 export type CreateProjectInput = Schemas["CreateProjectInput"];
 export type ProjectPage = Schemas["ProjectPage"];
 
+export type GitHubInstallationStatus = Schemas["GitHubInstallationStatus"];
+export type GitHubSyncStatus = Schemas["GitHubSyncStatus"];
+export type GitHubInstallation = Schemas["GitHubInstallation"];
+export type GitHubInstallationStart = Schemas["GitHubInstallationStart"];
+export type GitHubRepositoryAccessState =
+  Schemas["GitHubRepositoryAccessState"];
+export type GitHubRepository = Schemas["GitHubRepository"];
+export type GitHubRepositoryPage = Schemas["GitHubRepositoryPage"];
+export type CreateGitHubProjectInput = Schemas["CreateGitHubProjectInput"];
+
 export type Session = Schemas["Session"];
 export type SessionKind = Schemas["SessionKind"];
 export type SessionActivityState = Schemas["SessionActivityState"];

--- a/packages/cloud-client/test/client.test.ts
+++ b/packages/cloud-client/test/client.test.ts
@@ -41,6 +41,73 @@ describe("CloudClient", () => {
     );
   });
 
+  it("manages organization-scoped GitHub App installations and repositories", async () => {
+    const installation = {
+      id: "d9916dbe-486c-43ec-91b8-379419767719",
+      githubInstallationId: 12345,
+      accountLogin: "acme",
+      accountType: "Organization",
+      status: "active",
+      repositorySelection: "selected",
+      syncStatus: "ready",
+      createdAt: "2026-08-11T00:00:00Z",
+      updatedAt: "2026-08-11T00:00:00Z",
+    } as const;
+    const fetchMock = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(jsonResponse({ installations: [installation] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          installationUrl: "https://github.com/apps/ao/installations/new",
+          expiresAt: "2026-08-11T00:10:00Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [],
+          page: { hasMore: false },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ installation }))
+      .mockResolvedValueOnce(jsonResponse({ project: { id: "project-1" } }));
+    const client = createCloudClient({
+      baseUrl: "https://cloud.example.com",
+      getAccessToken: () => "access-token",
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await expect(
+      client.listGitHubInstallations("tenant one"),
+    ).resolves.toEqual([installation]);
+    await client.startGitHubInstallation("tenant one");
+    await client.listGitHubRepositories("tenant one", {
+      cursor: "next page",
+      limit: 25,
+    });
+    await client.syncGitHubInstallation(
+      "tenant one",
+      "d9916dbe-486c-43ec-91b8-379419767719",
+    );
+    await client.createProjectFromGitHub(
+      "tenant one",
+      { githubRepositoryId: 98765 },
+      { idempotencyKey: "github-project-1" },
+    );
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "https://cloud.example.com/api/cloud/v1/orgs/tenant%20one/github/installations",
+      "https://cloud.example.com/api/cloud/v1/orgs/tenant%20one/github/installations/start",
+      "https://cloud.example.com/api/cloud/v1/orgs/tenant%20one/github/repositories?cursor=next+page&limit=25",
+      "https://cloud.example.com/api/cloud/v1/orgs/tenant%20one/github/installations/d9916dbe-486c-43ec-91b8-379419767719/sync",
+      "https://cloud.example.com/api/cloud/v1/orgs/tenant%20one/github/projects",
+    ]);
+    expect(fetchMock.mock.calls[1]?.[1]?.method).toBe("POST");
+    expect(fetchMock.mock.calls[3]?.[1]?.method).toBe("POST");
+    expect(requestHeaders(fetchMock, 4).get("Idempotency-Key")).toBe(
+      "github-project-1",
+    );
+  });
+
   it("scopes and encodes organization and session URLs", async () => {
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>


### PR DESCRIPTION
## Summary
- define organization-scoped GitHub App installation, sync, disconnect, repository, and project-import API contracts
- expose generated shared types and typed Cloud client methods without exposing grant IDs or provider credentials
- keep provider callback and webhook ingress private to the hosted implementation

## Test plan
- [x] `npm --prefix packages/cloud-client run generate`
- [x] `npm --prefix packages/cloud-client run typecheck`
- [x] `npm --prefix packages/cloud-client test`
- [x] `npm --prefix packages/cloud-client run build`


Made with [Cursor](https://cursor.com)