### PR TITLE
fix(mobile): allow cleartext HTTP to Tailscale CGNAT range on iOS

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -156,7 +156,10 @@ gitignored** — the run commands prebuild them for you.
 
 Cleartext HTTP to the bridge already works on both platforms: Android through
 `usesCleartextTraffic` in `app.json`, iOS through `NSAllowsLocalNetworking` in the prebuilt
-`Info.plist`.
+`Info.plist`. `NSAllowsLocalNetworking` only covers *local* destinations (RFC1918, link-local,
+`.local`), so plain HTTP to a Tailscale address needs its own App Transport Security exception —
+`app.json` adds one for the `100.64.0.0/10` CGNAT range. Any other non-local host has to use TLS
+(e.g. `tailscale serve` plus the app's **Use TLS** toggle).
 
 > **On `expo-dev-client`:** this package doesn't depend on it today, so the debug build
 > connects straight to Metro and has no in-app launcher or URL switcher. If you want the

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -24,7 +24,12 @@
 				"NSLocalNetworkUsageDescription": "AO connects to Agent Orchestrator running on your computer over your local network.",
 				"NSPhotoLibraryUsageDescription": "AO uses camera-related system features to help pair with your desktop.",
 				"NSAppTransportSecurity": {
-					"NSAllowsLocalNetworking": true
+					"NSAllowsLocalNetworking": true,
+					"NSExceptionDomains": {
+						"100.64.0.0/10": {
+							"NSExceptionAllowsInsecureHTTPLoads": true
+						}
+					}
 				},
 				"LSApplicationQueriesSchemes": ["github"]
 			}


### PR DESCRIPTION
## What

Add an App Transport Security exception for Tailscale's `100.64.0.0/10` CGNAT range to
`packages/mobile/app.json`, and correct the now-inaccurate cleartext claim in
`packages/mobile/README.md`.

```json
"NSAppTransportSecurity": {
	"NSAllowsLocalNetworking": true,
	"NSExceptionDomains": {
		"100.64.0.0/10": { "NSExceptionAllowsInsecureHTTPLoads": true }
	}
}
```

## Why

Fixes #3852 — the iOS app cannot connect to the desktop daemon over Tailscale. Entering the
Mac's Tailscale IP in manual connect always surfaces the *unreachable* copy, while the same
setup works over a LAN IP and Safari on the same phone reaches `http://<tailscale-ip>:3011/`
fine.

The request never leaves the device:

- RN's `fetch` goes through `NSURLSession`, which is the layer ATS governs.
- As of iOS/tvOS 17, ATS applies to IP-literal connections made through `URLSession` — older
  guidance saying IP addresses are exempt from ATS is outdated. Confirmed by Apple DTS:
  https://developer.apple.com/forums/thread/747421
- The app declared only `NSAllowsLocalNetworking`, which exempts *local* destinations (RFC1918,
  link-local, `.local`). Tailscale's `100.64.0.0/10` is not classified as local, so the cleartext
  connection is refused in-process — which is why LAN works and Safari (exempt from ATS) works.
- Android is unaffected: `usesCleartextTraffic: true` in the Expo build properties permits
  cleartext to any host, with no local/non-local distinction.

Tailscale is an advertised connection method for the mobile app (the manual-connect placeholder
is `192.168.x.x  or  my-pc.tailXXXX.ts.net`, and `config.ts` documents `host` as e.g.
`"100.101.102.103"`), so this is a gap between the shipped config and the intended UX.

## How

iOS 17+ accepts a CIDR block as an `NSExceptionDomains` key, so the exception is scoped to
exactly the CGNAT range instead of loosening ATS globally with `NSAllowsArbitraryLoads`. ATS
stays strict for every other destination; `NSAllowsLocalNetworking` is kept as-is for LAN.

Intentional omissions, to keep the diff minimal:

- No change to MagicDNS names (`*.ts.net`). Those resolve into the same range, but the app's
  own manual-connect flow is IP-based; a hostname exception can be added separately if wanted.
- No Android change — not affected.
- No app-code change; this is purely the ATS declaration plus the doc correction.

Note the exception only takes effect in a build that regenerates `Info.plist` (prebuild / EAS
build); it does not change an already-installed binary.

## Testing

- `node -e "JSON.parse(require('fs').readFileSync('packages/mobile/app.json','utf8'))"` — parses;
  indentation matches the file's existing tabs.

Full verification needs an iOS device on a tailnet, which I could not exercise end-to-end in
this environment. Repro / expected behavior for a reviewer with that setup:

1. Enable **Connect Mobile** on the desktop app (listener on `0.0.0.0:3011`).
2. Put the Mac and an iPhone on the same tailnet (plain Tailscale, no `serve`/funnel).
3. Rebuild the iOS app from this branch so the new `Info.plist` is generated
   (`npx expo run:ios --device` or an EAS build).
4. In manual connect, enter the Mac's Tailscale IP (`100.x.x.x`), port `3011`, **Use TLS** off.

Expected: the connection succeeds, as it already does with a LAN IP. With a deliberately wrong
password, the *auth* error ("Your desktop rejected the password") should appear rather than the
*unreachable* error — that distinction is the tell that the request now leaves the device.
Also worth confirming a LAN IP still connects, i.e. no regression from adding
`NSExceptionDomains` alongside `NSAllowsLocalNetworking`.

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue (`Fixes #3852`)
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [ ] Tests added/updated for user-visible behavior where it makes sense — n/a, this is a native
      ATS declaration in `app.json` with no JS-testable surface
- [ ] Relevant CI checks pass for the area touched — deferring to CI on this PR; locally I only
      validated that `app.json` still parses (no code paths touched)
