### PR TITLE
fix: limit chat minimap to user prompts

### DIFF
--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -318,6 +318,33 @@ describe("ChatWorkspace timeline", () => {
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
+	it("limits conversation minimap navigation to human prompts", () => {
+		const snapshot = structuredClone(chatFixtureLongHistory(2));
+		snapshot.items.splice(1, 0, {
+			kind: "activity",
+			id: "loose-status",
+			sequence: 1.5,
+			revision: 1,
+			activityKind: "system",
+			status: "completed",
+			summary: "Automatic compaction completed",
+			createdAt: "2026-08-08T00:00:00Z",
+		});
+		render(<ChatWorkspace snapshot={snapshot} />);
+		const log = screen.getByRole("log");
+		const scrollbar = screen.getByRole("scrollbar", { name: "Conversation scrollbar" });
+		stubGeometry(log, { scrollHeight: 1800, clientHeight: 600, scrollTop: 0 });
+		stubGeometry(scrollbar, { scrollHeight: 600, clientHeight: 600, scrollTop: 0 });
+		fireEvent.scroll(log);
+
+		const markers = Array.from(
+			scrollbar.querySelectorAll<HTMLElement>("[data-chat-scroll-marker]"),
+		);
+		expect(markers).toHaveLength(2);
+		fireEvent.pointerEnter(markers[1]!);
+		expect(screen.getByRole("tooltip")).not.toHaveTextContent("Automatic compaction completed");
+	});
+
 	it("explains itself instead of showing an empty scroller", () => {
 		render(<ChatWorkspace snapshot={chatFixtureEmpty} />);
 		expect(screen.getByText("Start the conversation")).toBeInTheDocument();

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1022,7 +1022,8 @@ function Timeline({
 	);
 	const grouped = useMemo(() => groupByTurn({ ...snapshot, items }), [snapshot, items]);
 	const groups = useStableList(grouped, groupKey, sameGroup);
-	const previews = useMemo(() => groups.map(groupPreview), [groups]);
+	const navigableGroups = useMemo(() => groups.filter(groupHasHumanPrompt), [groups]);
+	const previews = useMemo(() => navigableGroups.map(groupPreview), [navigableGroups]);
 
 	const updateScrollbar = useCallback(() => {
 		const node = scroller.current;
@@ -1228,7 +1229,10 @@ function Timeline({
 						</div>
 					) : null}
 					{groups.map((group) => (
-						<div key={group.key} data-chat-scroll-anchor="">
+						<div
+							key={group.key}
+							data-chat-scroll-anchor={groupHasHumanPrompt(group) ? "" : undefined}
+						>
 							<TurnGroup
 								group={group}
 								sessionId={snapshot.sessionId}
@@ -1704,6 +1708,10 @@ function groupPreview(group: TimelineGroup): GroupPreview {
 			: firstActivity?.detail?.text || firstActivity?.detail?.output || firstActivity?.summary;
 	const detail = detailSource ? previewText(detailSource, 240) : undefined;
 	return { title, detail: detail && detail !== title ? detail : undefined };
+}
+
+function groupHasHumanPrompt(group: TimelineGroup): boolean {
+	return group.items.some((item) => item.kind === "message" && item.role === "user" && item.origin === "human");
 }
 
 function previewText(value: string, limit: number): string {


### PR DESCRIPTION
## Summary
- Limit chat minimap markers to turns that contain human user prompts
- Keep non-prompt timeline updates visible in chat without making them scroll navigation targets
- Add a regression test for non-prompt activity in the minimap

## Validation
- Previously passed on the source branch: 
- Could not rerun after rebasing onto updated `upstream/main`: this checkout was missing `frontend/node_modules`, and `npm ci` failed first on a root-owned npm cache, then with npm internal error `Exit handler never called!` using an isolated temp cache.