### PR TITLE
fix(frontend): polish left sidebar peek

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -186,6 +186,8 @@ export function Sidebar({
 	const { state, setOpen } = useSidebar();
 	const isCollapsed = state === "collapsed";
 	const [expandedChromeVisible, setExpandedChromeVisible] = useState(!isCollapsed);
+	const [preserveOverlayChrome, setPreserveOverlayChrome] = useState(isOverlay);
+	const overlayChromeVisible = isOverlay || preserveOverlayChrome;
 	// One IPC subscription for both footer variants of the restart-to-update prompt.
 	const updateStatus = useUpdateStatus();
 	// Daemon status for the smoke suite's sr-only mirror in the footer. Null when
@@ -201,6 +203,11 @@ export function Sidebar({
 			setExpandedChromeVisible(true);
 		}
 	}, [isCollapsed]);
+
+	useLayoutEffect(() => {
+		if (isOverlay) setPreserveOverlayChrome(true);
+		else if (!isCollapsed) setPreserveOverlayChrome(false);
+	}, [isCollapsed, isOverlay]);
 
 	// Disclosure state: projects are expanded by default; a project id present in
 	// this set is collapsed (sessions hidden).
@@ -264,8 +271,8 @@ export function Sidebar({
 			className={cn(
 				"sidebar-focusless",
 				hideEdgeBorder ? "border-transparent" : "border-r-0 group-data-[side=left]:border-r-0",
-				isOverlay && "z-sidebar-preview shadow-2xl",
-				isOverlay || !underTopbar
+				overlayChromeVisible && "z-sidebar-preview opacity-[0.97] shadow-2xl",
+				overlayChromeVisible || !underTopbar
 					? "top-0 h-svh!"
 					: "top-(--sidebar-chrome-offset) h-[calc(100svh-var(--sidebar-chrome-offset))]!",
 			)}
@@ -273,7 +280,7 @@ export function Sidebar({
 			<SidebarHeader
 				className={cn(
 					"gap-0 p-0 px-3 pt-2 group-data-[collapsible=icon]:px-1.5 group-data-[collapsible=icon]:pt-2",
-					isOverlay && underTopbar && "pt-(--sidebar-chrome-offset)!",
+					overlayChromeVisible && underTopbar && "pt-(--sidebar-chrome-offset)!",
 				)}
 			>
 				{/* Brand (project-sidebar__brand); in the icon rail it becomes the old

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -83,6 +83,7 @@ const isWindows = isWindowsPlatform();
 const isLinux = isLinuxPlatform();
 const framedAppTopbar = usesFramedAppTopbar();
 const shellTopbarHiddenByPlatform = hidesShellTopbar();
+const SIDEBAR_PEEK_CLOSE_DELAY_MS = 80;
 
 // Persistent app shell: the Sidebar + shared state survive route changes; only
 // the <Outlet> content (board / session / settings / …) swaps. Lifted out of
@@ -215,13 +216,12 @@ function ShellLayout() {
 	}, [cancelSidebarPeekClose, isSidebarOpen]);
 
 	const scheduleSidebarPeekClose = useCallback(() => {
-		if (isSidebarOpen) return;
-		cancelSidebarPeekClose();
+		if (isSidebarOpen || sidebarPeekCloseTimerRef.current !== undefined) return;
 		sidebarPeekCloseTimerRef.current = window.setTimeout(() => {
 			setIsSidebarPeekOpen(false);
 			sidebarPeekCloseTimerRef.current = undefined;
-		}, 140);
-	}, [cancelSidebarPeekClose, isSidebarOpen]);
+		}, SIDEBAR_PEEK_CLOSE_DELAY_MS);
+	}, [isSidebarOpen]);
 
 	const navigateSession = useCallback(
 		(direction: -1 | 1) => {


### PR DESCRIPTION
## What changed

- shorten the collapsed sidebar hover-preview close delay to 80 ms
- keep the preview at 97% opacity
- preserve full-height overlay chrome through the exit transition so it does not shrink before sliding away

## Scope

This PR changes only the left sidebar hover/peek behavior. It does not modify the top bar, right inspector, notification center, or terminal UI.

## Validation

- `npm run frontend:typecheck`
