### PR TITLE
docs: Discord invite fallback + fix stale AgentWrapper links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discord.com/invite/UZv7JjxbwG
     about: Questions, mentoring, and the daily contributor sync (10:00 PM IST).
   - name: Contributing guide
-    url: https://github.com/AgentWrapper/agent-orchestrator/blob/main/CONTRIBUTING.md
+    url: https://github.com/Untrivial-ai/agent-orchestrator/blob/main/CONTRIBUTING.md
     about: How to claim issues, open PRs, and work with maintainers.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,6 @@ How you validated this locally (commands, scenarios, screenshots if UI).
 
 - [ ] Branched from `main` (or continuing an existing PR branch)
 - [ ] One focused change; links the related issue when applicable
-- [ ] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
+- [ ] Follows [AGENTS.md](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
 - [ ] Tests added/updated for user-visible behavior where it makes sense
 - [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,23 @@ Start on Discord so scope is clear before you invest time.
 **Daily contributor sync:** every day at **10:00 PM IST**
 
 - **Discord** → questions, mentoring, sync, realtime unblocking
-- **GitHub** → bugs, proposals, design threads, review
+- **GitHub Discussions / Issues** → bugs, proposals, design threads, review (also the fallback if Discord is unreachable)
 
 Non-trivial work? Comment on the issue or ping Discord first. Get a thumbs-up, then build.
+
+### If the Discord invite fails
+
+Some people see Discord’s **“Invite invalid or expired”** screen even though the published invite is still live. Common causes: network blocks, account restrictions, or client glitches — not an intentional ban on newcomers.
+
+**Workarounds:**
+
+1. Open the invite in a desktop browser while logged into Discord: https://discord.com/invite/UZv7JjxbwG
+2. Try another network / VPN if Discord is blocked in your region
+3. If you still cannot join, use **GitHub instead** — no Discord required:
+   - [Discussions](https://github.com/Untrivial-ai/agent-orchestrator/discussions) for Q&A and community chat
+   - [Issues](https://github.com/Untrivial-ai/agent-orchestrator/issues) for bugs and feature proposals
+
+Please do **not** wait on Discord access to file a bug or open a PR.
 
 ## Ways to contribute
 
@@ -23,9 +37,9 @@ Non-trivial work? Comment on the issue or ping Discord first. Get a thumbs-up, t
 
 ## Quick start
 
-1. **Join Discord** — say hi and get guidance
+1. **Join Discord** (or GitHub Discussions if the invite fails) — say hi and get guidance
 2. **Read the contract** — [AGENTS.md](AGENTS.md) (layout, commands, hard rules, PR hygiene)
-3. **Pick something focused** — [open issues](https://github.com/AgentWrapper/agent-orchestrator/issues); prefer `good-first-issue` / `help wanted`
+3. **Pick something focused** — [open issues](https://github.com/Untrivial-ai/agent-orchestrator/issues); prefer `good-first-issue` / `help wanted`
 4. **Claim it** — comment `I'd like to work on this` and wait for assignment
 5. **Open a clear PR** — narrow change, link the issue, user-visible impact, tests
 6. **Iterate** — address review; maintainers merge
@@ -51,6 +65,6 @@ Also follow **PR hygiene** in [AGENTS.md](AGENTS.md): branch from `main`, one is
 
 ## Code of Conduct
 
-Be respectful, constructive, and assume good intent. Report problems to maintainers via Discord DM.
+Be respectful, constructive, and assume good intent. Report problems to maintainers via Discord DM, or via a private GitHub security/advisory channel if Discord is unavailable.
 
 Thanks for making agent-orchestrator better for the next person who shows up.


### PR DESCRIPTION
## What

Document a **GitHub fallback** when the Discord invite shows “invalid or expired”, and fix stale `AgentWrapper` → `Untrivial-ai` links in contributor docs/templates.

## Why

Several users (see #3869 and Discussion #3868) open the official invite from GitHub and get Discord’s **invalid/expired** modal. CONTRIBUTING currently treats Discord as the first onboarding step with no documented alternative, so people assume the project is blocking joins.

The public invite (`UZv7JjxbwG`) still resolves server-side with no expiry, so this is often network/account/client related — but the docs should not hard-gate contribution on Discord access.

## How

- `CONTRIBUTING.md`: add “If the Discord invite fails” with workarounds + Discussions/Issues links; note Discord is preferred but not required
- Fix stale org links in CONTRIBUTING, PR template, and issue template contact link

## Testing

- Docs-only change; reviewed rendered markdown via `git diff`

## Checklist

- [x] Branched from `main`
- [x] One focused change; links #3869 / Discussion #3868
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests N/A (docs)
- [x] Relevant CI N/A (docs)

Related: https://github.com/Untrivial-ai/agent-orchestrator/discussions/3868