### PR TITLE
feat(frontend): move terminal fullscreen to context menu

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -445,7 +445,7 @@ describe("CenterPane toolbar session label", () => {
 		act(() => document.dispatchEvent(new Event("fullscreenchange")));
 
 		expect(screen.queryByTestId("session-action-region")).not.toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Exit fullscreen" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Exit fullscreen" })).toBeNull();
 		Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
 	});
 
@@ -482,7 +482,7 @@ describe("CenterPane toolbar session label", () => {
 			name: "Terminal display controls",
 		});
 		expect(tabList.contains(toolbar)).toBe(false);
-		expect(toolbar).toContainElement(screen.getByRole("button", { name: "Fullscreen terminal" }));
+		expect(toolbar).toContainElement(screen.getByRole("button", { name: "Decrease terminal font size" }));
 	});
 
 	it("reveals scroll chevrons only when the tab strip actually overflows", () => {

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, ChevronLeft, ChevronRight, Maximize2, Minimize2, Minus, Plus, TriangleAlert } from "lucide-react";
+import { ArrowRight, ChevronLeft, ChevronRight, Minus, Plus, TriangleAlert } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type ReactNode, type WheelEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { defaultShortcutBindings, shortcutBindingLabel } from "../../shared/shortcuts";
@@ -369,18 +369,6 @@ export function CenterPane({
 						>
 							<Plus aria-hidden="true" className="size-icon-sm" />
 						</TerminalControl>
-						<div aria-hidden="true" className="mx-1 h-4 w-px bg-border/70" />
-						<TerminalControl
-							isPressed={isFullscreen}
-							label={isFullscreen ? t("terminal.exitFullscreen") : t("terminal.fullscreen")}
-							onClick={() => void toggleFullscreen()}
-						>
-							{isFullscreen ? (
-								<Minimize2 aria-hidden="true" className="size-icon-md" />
-							) : (
-								<Maximize2 aria-hidden="true" className="size-icon-md" />
-							)}
-						</TerminalControl>
 					</div>
 				</div>
 				{isFullscreen ? null : (
@@ -416,7 +404,9 @@ export function CenterPane({
 						daemonReady={daemonReady}
 						fontSize={fontSize}
 						focusRequested={switchPermissionRequired && target.kind === "worker"}
+						isFullscreen={isFullscreen}
 						inputDisabled={agentInputDisabled && target.kind === "worker"}
+						onToggleFullscreen={toggleFullscreen}
 						session={session}
 						terminalTarget={target}
 						theme={theme}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -44,6 +44,9 @@ type TerminalPaneProps = {
 	daemonReady: boolean;
 	terminalTarget?: TerminalTarget;
 	fontSize: number;
+	isFullscreen?: boolean;
+	/** Enter or exit fullscreen for the terminal pane that owns this xterm. */
+	onToggleFullscreen?: () => void;
 	/** Refuse agent PTY input while a controller transition owns the source. */
 	inputDisabled?: boolean;
 	/** Focus the terminal when an in-flight controller asks for human input. */
@@ -106,6 +109,8 @@ function terminalPropsMatch(left: TerminalPaneProps, right: TerminalPaneProps): 
 		left.theme === right.theme &&
 		left.daemonReady === right.daemonReady &&
 		left.fontSize === right.fontSize &&
+		left.isFullscreen === right.isFullscreen &&
+		left.onToggleFullscreen === right.onToggleFullscreen &&
 		left.inputDisabled === right.inputDisabled &&
 		left.focusRequested === right.focusRequested &&
 		left.createMux === right.createMux &&
@@ -641,6 +646,8 @@ export function TerminalPane({
 	daemonReady,
 	terminalTarget: requestedTerminalTarget,
 	fontSize,
+	isFullscreen,
+	onToggleFullscreen,
 	inputDisabled,
 	focusRequested,
 }: TerminalPaneProps) {
@@ -706,7 +713,17 @@ export function TerminalPane({
 		);
 	}
 
-	const props = { session, theme, daemonReady, terminalTarget, fontSize, inputDisabled, focusRequested };
+	const props = {
+		session,
+		theme,
+		daemonReady,
+		terminalTarget,
+		fontSize,
+		isFullscreen,
+		onToggleFullscreen,
+		inputDisabled,
+		focusRequested,
+	};
 	const descriptor = cacheDescriptor(session, terminalTarget);
 	if (cache && descriptor) {
 		return <CachedTerminalSlot descriptor={descriptor} props={props} />;
@@ -719,7 +736,9 @@ export function TerminalPane({
 			theme={theme}
 			daemonReady={daemonReady}
 			fontSize={fontSize}
+			isFullscreen={isFullscreen}
 			inputDisabled={inputDisabled}
+			onToggleFullscreen={onToggleFullscreen}
 			focusRequested={focusRequested}
 			terminalTarget={terminalTarget}
 		/>
@@ -863,6 +882,8 @@ function AttachedTerminal({
 	daemonReady,
 	terminalTarget,
 	fontSize,
+	isFullscreen,
+	onToggleFullscreen,
 	inputDisabled,
 	focusRequested,
 	createMux,
@@ -1039,10 +1060,12 @@ function AttachedTerminal({
 					ariaLabel={terminalTarget?.kind === "shell" ? t("terminal.shellAria") : t("terminal.sessionAria")}
 					fontSize={fontSize}
 					focusRequested={focusRequested}
+					isFullscreen={isFullscreen}
 					isVisible={isVisible}
 					onError={handleInitError}
 					onLinkOpen={handleLinkOpen}
 					onReady={handleReady}
+					onToggleFullscreen={onToggleFullscreen}
 					onVisibleSize={syncVisibleSize}
 					paneScrollsByKeyboard={providerScrollsByKeyboard(provider)}
 					theme={theme}

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -333,6 +333,31 @@ describe("XtermTerminal", () => {
 		expect(trigger.style.top).toBe("88px");
 	});
 
+	it("toggles terminal fullscreen from the right-click menu", async () => {
+		const onToggleFullscreen = vi.fn();
+		const { container, rerender } = render(
+			<div className="terminal-pane-frame">
+				<XtermTerminal isFullscreen={false} onToggleFullscreen={onToggleFullscreen} theme="dark" />
+			</div>,
+		);
+
+		fireEvent.contextMenu(container.querySelector(".terminal-pane-frame")!.firstElementChild!);
+		fireEvent.click(await screen.findByText("Fullscreen terminal"));
+		expect(onToggleFullscreen).toHaveBeenCalledOnce();
+
+		const pane = container.querySelector(".terminal-pane-frame") as HTMLElement;
+		Object.defineProperty(document, "fullscreenElement", { configurable: true, value: pane });
+		rerender(
+			<div className="terminal-pane-frame">
+				<XtermTerminal isFullscreen onToggleFullscreen={onToggleFullscreen} theme="dark" />
+			</div>,
+		);
+		fireEvent.contextMenu(pane.firstElementChild!);
+		const exitFullscreenItem = await screen.findByText("Exit fullscreen");
+		expect(pane.contains(exitFullscreenItem.closest<HTMLElement>("[role='menu']"))).toBe(true);
+		Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
+	});
+
 	it("runs context menu copy, select all, and clear against the xterm instance", async () => {
 		const { container } = render(<XtermTerminal theme="dark" />);
 		const host = container.firstElementChild!;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -50,7 +50,10 @@ export type XtermTerminalProps = {
 	ariaLabel?: string;
 	className?: string;
 	fontSize?: number;
+	isFullscreen?: boolean;
 	theme: Theme;
+	/** Enter or exit fullscreen for the terminal pane that owns this xterm. */
+	onToggleFullscreen?: () => void;
 	/**
 	 * The pane app scrolls its transcript by keyboard (PageUp/PageDown) rather
 	 * than acting on SGR wheel reports — e.g. opencode, which enables mouse
@@ -937,6 +940,15 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		if (term) callbacksRef.current.onVisibleSize?.(term.cols, term.rows);
 	}, [props.isVisible]);
 
+	const fullscreenElement = document.fullscreenElement;
+	const contextMenuPortalContainer =
+		props.isFullscreen &&
+		fullscreenElement instanceof HTMLElement &&
+		hostRef.current &&
+		fullscreenElement.contains(hostRef.current)
+			? fullscreenElement
+			: undefined;
+
 	return (
 		<>
 			<div
@@ -973,6 +985,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 					align="start"
 					className="min-w-36"
 					onCloseAutoFocus={(event) => event.preventDefault()}
+					portalContainer={contextMenuPortalContainer}
 					side="right"
 					sideOffset={2}
 				>
@@ -997,6 +1010,16 @@ export function XtermTerminal(props: XtermTerminalProps) {
 					<DropdownMenuItem onSelect={() => runContextMenuAction("selectAll")}>{t("titlebar.selectAll")}</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					<DropdownMenuItem onSelect={() => runContextMenuAction("clear")}>{t("terminal.clear")}</DropdownMenuItem>
+					{props.onToggleFullscreen ? (
+						<DropdownMenuItem
+							onSelect={() => {
+								setContextMenuOpen(false);
+								callbacksRef.current.onToggleFullscreen?.();
+							}}
+						>
+							{props.isFullscreen ? t("terminal.exitFullscreen") : t("terminal.fullscreen")}
+						</DropdownMenuItem>
+					) : null}
 				</DropdownMenuContent>
 			</DropdownMenu>
 		</>

--- a/frontend/src/renderer/components/ui/dropdown-menu.tsx
+++ b/frontend/src/renderer/components/ui/dropdown-menu.tsx
@@ -8,11 +8,14 @@ export const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
 
 export function DropdownMenuContent({
 	className,
+	portalContainer,
 	sideOffset = 6,
 	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content> & {
+	portalContainer?: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>["container"];
+}) {
 	return (
-		<DropdownMenuPrimitive.Portal>
+		<DropdownMenuPrimitive.Portal container={portalContainer}>
 			<DropdownMenuPrimitive.Content
 				sideOffset={sideOffset}
 				className={cn(


### PR DESCRIPTION
## Summary
- remove the terminal fullscreen control from the top bar
- expose Fullscreen terminal / Exit fullscreen in the terminal right-click menu
- keep the menu inside the fullscreen element so exiting fullscreen remains available

## Verification
- npm test -- src/renderer/components/XtermTerminal.test.tsx -t 'toggles terminal fullscreen from the right-click menu'
- npm test -- src/renderer/components/CenterPane.test.tsx -t 'hides session-level actions while the terminal is fullscreen'
- npm run typecheck

## Scope
This PR changes only terminal fullscreen entry/exit behavior. Font-size controls and shortcuts are intentionally unchanged.