### PR TITLE
fix(cli): allow dots in sessionIDPattern to match projectIDPattern

### DIFF
--- a/backend/internal/adapters/runtime/conpty/runtime.go
+++ b/backend/internal/adapters/runtime/conpty/runtime.go
@@ -46,8 +46,13 @@ func conptyPartialCreateFailure(err error, handle ports.RuntimeHandle, cleanup p
 	return runtimeEffectFailure{err: err, handle: handle, effect: ports.RuntimeEffectPossible, cleanup: cleanup}
 }
 
-// validSessionID matches agent-orchestrator's assertValidSessionId.
-var validSessionID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+// validSessionID matches the CLI's sessionIDPattern (internal/cli/hooks.go):
+// the daemon issues session ids derived from project names, so dots are legal
+// and must not be rejected here. The leading [a-zA-Z0-9] anchor keeps a bare
+// "." / ".." impossible. The id is used only as a map key, the host process's
+// argv[0], and the registry identity — never as a path or pipe component — so
+// the widened alphabet is safe.
+var validSessionID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 // hostSession is the in-memory state for a live pty-host connection.
 type hostSession struct {
@@ -123,7 +128,7 @@ func New(opts Options) *Runtime {
 func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
 	id := string(cfg.SessionID)
 	if !validSessionID.MatchString(id) {
-		return ports.RuntimeHandle{}, conptyCreateFailure(fmt.Errorf("conpty: invalid session id %q: must match ^[a-zA-Z0-9_-]+$", id))
+		return ports.RuntimeHandle{}, conptyCreateFailure(fmt.Errorf("conpty: invalid session id %q: must match ^[a-zA-Z0-9][a-zA-Z0-9._-]*$", id))
 	}
 	if cfg.WorkspacePath == "" {
 		return ports.RuntimeHandle{}, conptyCreateFailure(fmt.Errorf("conpty: workspace path required"))

--- a/backend/internal/adapters/runtime/conpty/runtime_test.go
+++ b/backend/internal/adapters/runtime/conpty/runtime_test.go
@@ -478,7 +478,10 @@ func TestCreate_InvalidIDErrors(t *testing.T) {
 	rt := New(Options{Spawner: fakeSpawnerFor(t, nil, livePID())})
 	ctx := context.Background()
 
-	for _, bad := range []string{"", "has space", "has/slash", "has.dot"} {
+	// Dots are legal (session ids derive from project names — #4479) and are
+	// covered by TestCreate_AcceptsDottedSessionID; only characters outside
+	// the widened alphabet and leading-dot ids stay invalid here.
+	for _, bad := range []string{"", "has space", "has/slash", ".leading"} {
 		_, err := rt.Create(ctx, ports.RuntimeConfig{
 			SessionID:     domain.SessionID(bad),
 			WorkspacePath: "/tmp/w",
@@ -1162,6 +1165,52 @@ func TestIsAlive_RefusedIsGone_TimeoutIsTransient(t *testing.T) {
 func TestClientKill_Idempotent(t *testing.T) {
 	if err := clientKill("127.0.0.1:1"); err != nil {
 		t.Fatalf("clientKill on unreachable addr: %v", err)
+	}
+}
+
+// TestCreate_AcceptsDottedSessionID pins the #4479 boundary: session ids
+// derive from project names and legitimately contain dots, so conpty must
+// accept them like the CLI env bound and the tmux runtime do. The id is used
+// only as a map key / host argv[0] / registry identity — never as a path or
+// pipe component — so dots are safe here.
+func TestCreate_AcceptsDottedSessionID(t *testing.T) {
+	isolateRegistry(t)
+	hosts := map[string]*inProcHost{}
+	rt := New(Options{Spawner: fakeSpawnerFor(t, hosts, livePID())})
+
+	const dotted = "myproj.github.io-38"
+	handle, err := rt.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     domain.SessionID(dotted),
+		WorkspacePath: "/tmp/workspace",
+		Argv:          []string{"claude-code"},
+	})
+	if err != nil {
+		t.Fatalf("Create(%q): %v", dotted, err)
+	}
+	if handle.ID != dotted {
+		t.Fatalf("handle.ID = %q, want %q", handle.ID, dotted)
+	}
+	hosts[dotted].cleanup(t)
+}
+
+// TestCreate_RejectsUnsafeSessionIDs keeps the traversal anchor the widened
+// pattern promises: leading dots (".", "..", ".hidden") stay rejected, and so
+// does any other character outside the id alphabet. The assertion matches the
+// validation message specifically — a spawner failure must not count as a
+// rejection, otherwise a pattern mutation could survive on a spawn error.
+func TestCreate_RejectsUnsafeSessionIDs(t *testing.T) {
+	isolateRegistry(t)
+	rt := New(Options{})
+
+	for _, id := range []string{".", "..", ".hidden", "a/b", "a:b"} {
+		_, err := rt.Create(context.Background(), ports.RuntimeConfig{
+			SessionID:     domain.SessionID(id),
+			WorkspacePath: "/tmp/workspace",
+			Argv:          []string{"claude-code"},
+		})
+		if err == nil || !strings.Contains(err.Error(), "invalid session id") {
+			t.Errorf("Create(%q): err = %v, want the invalid-session-id validation error", id, err)
+		}
 	}
 }
 

--- a/backend/internal/cli/agent_process_unix_test.go
+++ b/backend/internal/cli/agent_process_unix_test.go
@@ -40,3 +40,34 @@ func TestAgentProcessSuperviseRejectsInvalidGeneration(t *testing.T) {
 		t.Fatal("invalid launch id should be rejected before starting the child")
 	}
 }
+
+// TestAgentProcessSuperviseAcceptsDottedProjectSessionID guards against a
+// regression where AO session ids derived from a dotted project id
+// ("{ProjectID}-{num}", e.g. a project named like a domain) were accepted by
+// projectIDPattern but rejected here, permanently failing every session for
+// that project regardless of num.
+func TestAgentProcessSuperviseAcceptsDottedProjectSessionID(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		In:           strings.NewReader(""),
+		ProcessAlive: func(int) bool { return true },
+	}, "agent-process", "supervise", "--session", "my.project-16", "--launch", "launch-3", "--", "sh", "-c", "printf ok")
+	if err != nil {
+		t.Fatalf("dotted project session id should be accepted: %v\nstderr=%s", err, errOut)
+	}
+	if out != "ok" {
+		t.Fatalf("stdout = %q, want ok", out)
+	}
+}
+
+func TestAgentProcessSuperviseRejectsTraversalSessionID(t *testing.T) {
+	for _, id := range []string{"../evil", "a/b", ".hidden"} {
+		_, _, err := executeCLI(t, Deps{}, "agent-process", "supervise", "--session", id, "--launch", "launch-3", "--", "true")
+		if err == nil {
+			t.Fatalf("session id %q should be rejected", id)
+		}
+	}
+}

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -24,7 +24,14 @@ import (
 // sessionIDPattern bounds the AO_SESSION_ID we will place in a request path to
 // the id alphabet the daemon issues. Validating the externally-set env value
 // before it reaches the loopback URL keeps it from steering the request.
-var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+//
+// Kept in sync with projectIDPattern (service/project/service.go), since AO
+// session ids are derived as "{ProjectID}-{num}": a project id may contain
+// dots, so this pattern must accept them too, or every session for such a
+// project fails validation here regardless of num. A leading dot is still
+// rejected, so ".." / "../" segments remain impossible and the id stays safe
+// to embed in both a URL path segment and a filename.
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
 const (
 	// hooksLogName is the file under AO_DATA_DIR where hook delivery failures

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -16,6 +16,21 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/pricing"
 )
 
+func TestSessionIDPattern(t *testing.T) {
+	accept := []string{"ao-7", "my-project-16", "my.project-16", "a.b.c-1"}
+	for _, id := range accept {
+		if !sessionIDPattern.MatchString(id) {
+			t.Errorf("sessionIDPattern should accept project-derived id %q (dotted project ids must stay usable)", id)
+		}
+	}
+	reject := []string{"", ".hidden", "../evil", "a/b", "..%2f"}
+	for _, id := range reject {
+		if sessionIDPattern.MatchString(id) {
+			t.Errorf("sessionIDPattern should reject %q", id)
+		}
+	}
+}
+
 type activityCapture struct {
 	body string
 	path string


### PR DESCRIPTION
## Problem

Any project whose id contains a dot (e.g. a project named like a domain, `myproject.example`) fails to spawn or restore **any** session, permanently, regardless of `num`. The agent process never starts — the tmux pane is left running a bare `cat`, and the session lands in an `exited` / `is_terminated=false` limbo that neither `restore` nor a full daemon restart can recover.

## Root cause

Two regexes that validate the same AO session id (`{ProjectID}-{num}`) are out of sync:

- `projectIDPattern` (`backend/internal/service/project/service.go`) allows dots: `^[A-Za-z0-9][A-Za-z0-9._-]*$`
- `sessionIDPattern` (`backend/internal/cli/hooks.go`) does not: `^[A-Za-z0-9_-]+$`

`session_manager.Manager` passes the session id raw into the supervisor wrapper:

```go
wrapped = append(wrapped, executable, "agent-process", "supervise", "--session", string(id), "--launch", launchID, "--")
```

`agent-process supervise` then rejects it before the agent binary is even started:

```go
if !sessionIDPattern.MatchString(sessionID) {
    return usageError{fmt.Errorf("invalid session id")}
}
```

So a dotted project id passes project-level validation but fails supervisor validation — the agent process is never launched.

Confirmed empirically against the built daemon binary:
```
--session "myproject.example-16"  → invalid session id
--session "myproject-3"           → (child runs fine)
```

Full repro and investigation: #3875

## Fix

Widen `sessionIDPattern` to match `projectIDPattern`:

```go
var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
```

A leading dot is still rejected, so `..` / `../` traversal segments remain impossible — the id stays safe to embed both in a URL path segment (`sessions/<id>/activity`) and in a filename.

## Testing

- `TestSessionIDPattern` (`hooks_test.go`) — unit-level accept/reject matrix, including dotted ids and traversal payloads.
- `TestAgentProcessSuperviseAcceptsDottedProjectSessionID` (`agent_process_unix_test.go`) — end-to-end: `agent-process supervise --session "my.project-16"` actually runs the child process and reports exit.
- `TestAgentProcessSuperviseRejectsTraversalSessionID` — `../evil`, `a/b`, `.hidden` still rejected.
- `gofmt -l .` clean on the whole backend module, `go build ./...`, `go vet ./...`, `go test ./...` (137 packages) all green.
- Manually verified end-to-end on a real dotted-name project: killed the stuck session, respawned with the patched daemon+CLI, new session came up `idle` with a live TUI (previously: `invalid session id` on every spawn attempt).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
