### PR TITLE
fix(frontend): hide Cloud sign-in without WorkOS configuration

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1018,8 +1018,8 @@ function SessionRow({
 // email with a sign-out action in a dropdown.
 function CloudAccountRow({ tabIndex }: { tabIndex: number }) {
 	const { t } = useTranslation();
-	const { session, status, signIn, signOut } = useCloudSession();
-	if (status === "loading") return null;
+	const { configured, session, status, signIn, signOut } = useCloudSession();
+	if (!configured || status === "loading") return null;
 
 	if (status === "unauthenticated") {
 		return (
@@ -1080,8 +1080,8 @@ function CloudAccountRow({ tabIndex }: { tabIndex: number }) {
 // Icon-rail variant for collapsed sidebar.
 function CloudAccountRailButton({ tabIndex }: { tabIndex: number }) {
 	const { t } = useTranslation();
-	const { session, status, signIn, signOut } = useCloudSession();
-	if (status === "loading") return null;
+	const { configured, session, status, signIn, signOut } = useCloudSession();
+	if (!configured || status === "loading") return null;
 
 	if (status === "unauthenticated") {
 		return (

--- a/frontend/src/renderer/lib/cloud-session.test.ts
+++ b/frontend/src/renderer/lib/cloud-session.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { isCloudSignInConfigured } from "./cloud-session";
+
+describe("isCloudSignInConfigured", () => {
+  it("hides Cloud sign-in when the WorkOS client ID is absent", () => {
+    expect(isCloudSignInConfigured(undefined)).toBe(false);
+    expect(isCloudSignInConfigured("   ")).toBe(false);
+  });
+
+  it("shows Cloud sign-in when the WorkOS client ID is configured", () => {
+    expect(isCloudSignInConfigured("client_123")).toBe(true);
+  });
+});

--- a/frontend/src/renderer/lib/cloud-session.ts
+++ b/frontend/src/renderer/lib/cloud-session.ts
@@ -7,13 +7,21 @@ export type { CloudAccount };
 export type CloudSessionStatus = "loading" | "authenticated" | "unauthenticated";
 
 export interface UseCloudSessionResult {
+  configured: boolean;
   session: CloudAccount | null;
   status: CloudSessionStatus;
   signIn: (returnTo?: string) => void;
   signOut: () => Promise<void>;
 }
 
+export function isCloudSignInConfigured(
+  clientId = import.meta.env.VITE_WORKOS_CLIENT_ID,
+): boolean {
+  return Boolean(clientId?.trim());
+}
+
 export function useCloudSession(): UseCloudSessionResult {
+  const configured = isCloudSignInConfigured();
   const [session, setSession] = useState<CloudAccount | null>(null);
   const [status, setStatus] = useState<CloudSessionStatus>("loading");
 
@@ -50,5 +58,5 @@ export function useCloudSession(): UseCloudSessionResult {
     setStatus("unauthenticated");
   };
 
-  return { session, status, signIn, signOut };
+  return { configured, session, status, signIn, signOut };
 }


### PR DESCRIPTION
## Summary
- hide the desktop Cloud sign-in action when `VITE_WORKOS_CLIENT_ID` is absent or blank
- apply the check to both expanded and collapsed sidebar states
- cover configured and unconfigured client IDs

## Test plan
- [x] `npm test -- --run src/renderer/lib/cloud-session.test.ts src/renderer/components/Sidebar.test.tsx`
- [x] `npm run typecheck`

Made with [Cursor](https://cursor.com)