### PR TITLE
feat(workspaces): remote workspaces — run agents on a VM over SSH

### DIFF
--- a/docs/adr/0002-remote-workspaces-over-ssh.md
+++ b/docs/adr/0002-remote-workspaces-over-ssh.md
@@ -1,0 +1,156 @@
+# 2. Remote workspaces: one daemon per machine, reached over an SSH port-forward
+
+Date: 2026-08-11
+Status: Proposed
+
+## Context
+
+A common way to work is a thin laptop and a fat VM: the compute, the checkouts,
+the credentials and the automations all live on the VM, and the laptop is where
+you sit. Today AO has no answer for that. The desktop app spawns a daemon on the
+machine it runs on, and every session runs there. Discussion #2855 is an
+unanswered user asking to point the desktop app at a remote daemon; issue #13
+listed "Remote session support (SSH + tmux on remote machines)" and was closed
+as rewrite-migration cleanup with an invitation to refile.
+
+Two shapes were considered.
+
+**A. One laptop daemon that places individual sessions on a VM over SSH.** The
+control plane stays local; a session gains a placement, and the local daemon
+shells out to run tmux and the agent on the far side.
+
+**B. One daemon per machine; the client connects to whichever one it is pointed
+at.** The VM runs an ordinary, unmodified AO daemon against its own filesystem.
+
+Shape A was designed in full first, and the design is what argued against it.
+Because every consumer that addresses a live session holds nothing but a
+`ports.RuntimeHandle{ID string}`, routing has to be a pure function of that
+string, which forces the host to be encoded into the handle id — and the id
+space is mintable by project names, so a folder can forge a remote handle and
+get a healthy session reaped. Beyond that, `gitworktree` bypasses its own
+command runner in ten places (so it cannot be remoted by swapping the runner),
+`binaryutil.LookPath` resolves agent binaries to *laptop* absolute paths that
+then land in the remote pane's `argv[0]`, hooks and the system-prompt file are
+written to the local filesystem at the remote path, and `AO_BROWSER_CAPABILITY`
+— a live capability token — sits in the environment that would be exported to a
+third machine. Each is solvable; together they are a large, permanently
+load-bearing surface, and every one of them exists only because a single daemon
+is trying to act on a filesystem that is not its own.
+
+Shape B has none of those problems, because on the far side nothing is remote:
+the daemon, the git worktrees, the tmux server, the agent binary and the hooks
+are all local to each other. What it needs instead is a transport, and a client
+that can hold more than one daemon endpoint.
+
+## Decision
+
+**A workspace is a machine that runs its own AO daemon.** The laptop is the
+`local` workspace. A remote workspace is an SSH target the desktop app reaches
+through a loopback port-forward.
+
+The decisive detail is that this needs almost no client change either. The
+renderer already addresses the daemon through a single mutable base URL that the
+supervisor hands it on the `daemon:status` channel, and the terminal-mux
+WebSocket and SSE stream both derive from that base. So the supervisor opens
+
+```
+ssh -N -L <freeLocalPort>:127.0.0.1:<remoteDaemonPort> <target>
+```
+
+and publishes `<freeLocalPort>` as the daemon port. Every existing renderer
+feature — the board, sessions, diffs, terminals — then runs against the remote
+daemon unmodified.
+
+### Consequences for the bind rule
+
+**Neither daemon's bind changes, and no new listener is added.** This is the
+central reason to prefer the forward over widening the daemon's bind: the remote
+daemon stays `127.0.0.1`-only, so it is reachable only by processes on the VM
+and by whoever can already open an authenticated SSH session to it. AGENTS.md's
+loopback-only hard rule holds on both machines, and unlike ADR-0001 this feature
+needs no exception to it.
+
+Authentication is SSH's, not AO's. AO persists no key material and writes no
+`known_hosts`; it shells out to the user's own `ssh`, for the same reason
+`docs/stack.md` shells out to `git` rather than embedding go-git — `~/.ssh/config`
+(ProxyJump, Match, Include, IdentityAgent) is the identical artifact class, and
+reimplementing it is the go-git mistake.
+
+### Security posture
+
+- **`BatchMode=yes` is load-bearing, not hygiene.** The supervisor has no
+  controlling tty, so it can answer neither a passphrase prompt nor the
+  interactive "Are you sure you want to continue connecting?" for an unknown
+  host key. BatchMode turns both into an immediate, classifiable failure instead
+  of a process that hangs forever.
+- **`StrictHostKeyChecking` is deliberately never set.** BatchMode already makes
+  an unknown key fail closed. Setting it to `no` or `accept-new` is exactly the
+  bypass this design refuses: an unknown host is surfaced to the user with the
+  instruction to connect once themselves and see the fingerprint, and a *changed*
+  host key is reported as the security event it is. AO never edits
+  `known_hosts`.
+- **The ControlMaster socket is a credential.** It is a persistent, always-warm,
+  authenticated remote-shell channel that AO creates and keeps alive. `0700` on
+  `~/.ao/ssh` is the entire access control and `ControlPersist=60` is the
+  exposure window after last use. Accepted: it is the same trust the user's own
+  shell already holds, and without multiplexing every status poll pays a full
+  TCP and auth handshake.
+- **AO never installs anything on the remote.** A host without `ao` is reported
+  with the command to run. Executing package installs across a fleet of machines
+  the maintainers do not own would make AO a configuration-management tool; the
+  local analogue (a missing tmux) is likewise a hard preflight failure, not an
+  install.
+- **The registry holds no secrets.** An entry is an id and an SSH target — a
+  hostname, or better an alias from the user's own `~/.ssh/config`.
+
+### What lives where
+
+`~/.ao/workspaces.json` is supervisor state, not daemon state: it names which
+daemons the client can reach, so requiring the machine it points at to be up in
+order to read it would be circular. Each daemon keeps its own `~/.ao` on its own
+machine, which reads AGENTS.md's `~/.ao` rule as "local state under the local
+`~/.ao`" — the rule is about never using OS-default app-data locations, and that
+holds unchanged on both ends.
+
+### Failure semantics
+
+OpenSSH exits **255 for its own failures** and otherwise forwards the remote
+command's status, so a bare non-zero exit cannot be attributed to a side. AO
+classifies that split explicitly, because a broken tunnel reported as a dead
+daemon would violate the hard rule that a failed probe is not proof a session
+died. A dropped tunnel leaves the remote daemon and its tmux sessions running
+untouched, so the client holds the session in a reconnecting state and re-dials
+rather than tearing anything down.
+
+## Alternatives rejected
+
+- **Widen the daemon's bind to the LAN or the VM's public interface.** This is
+  the obvious reading of "connect the app to a remote daemon" and it is the one
+  thing the codebase forbids by design. It would also require AO to own
+  authentication and transport security for a full remote-control API — far
+  beyond ADR-0001's home-network, opt-in, single-password posture.
+- **Session placement (shape A).** Deferred, not refuted. It is the better
+  answer to "run *this one task* on the big machine while I keep working
+  locally", and it can be layered on later. It is the wrong first step, because
+  it pays the entire remote-filesystem cost before delivering the ordinary case.
+- **An AO-specific agent daemon on the VM.** The VM already runs the daemon we
+  want; adding a second AO-authored service to supervise it is unnecessary.
+- **`golang.org/x/crypto/ssh` in-process.** Forces AO to own key material,
+  passphrase prompting with no UI to prompt from, agent forwarding, and a
+  `known_hosts` TOFU policy. AO persists exactly one secret today (ADR-0001's
+  rotating LAN password) and does not persist GitHub tokens at all. Shelling out
+  also gets resize and SIGWINCH propagation for free.
+
+## Status of the implementation
+
+Landed: the registry, the SSH transport and failure taxonomy, supervisor
+placement and re-dial, and the workspace switcher in settings.
+
+Not yet addressed:
+
+- Moving an existing session between workspaces. Placement is chosen per client,
+  and sessions belong to the daemon that spawned them.
+- A cross-workspace view. Only the selected workspace's board is shown.
+- `ao` CLI parity: the CLI still talks to the local daemon only.
+- Windows as the client. The failure path is graceful (a missing `ssh` is
+  reported as such), but it is untested.

--- a/docs/adr/0002-remote-workspaces-over-ssh.md
+++ b/docs/adr/0002-remote-workspaces-over-ssh.md
@@ -144,7 +144,31 @@ rather than tearing anything down.
 ## Status of the implementation
 
 Landed: the registry, the SSH transport and failure taxonomy, supervisor
-placement and re-dial, and the workspace switcher in settings.
+placement and re-dial, the workspace switcher (including a picker over the
+user's `~/.ssh/config` aliases), and port discovery via the remote run-file.
+
+Verified against a real remote host, end to end: the desktop app attaches to
+the VM's daemon over the forward, starts one when none is running, serves the
+whole UI from it (`/api/v1/projects`, `/sessions`, `/agents/refresh`), and
+upgrades the terminal-mux WebSocket through the tunnel (HTTP 101).
+
+Four bugs were found only by connecting to a real host, and none of them was
+reachable from unit tests — they are recorded here because each is a trap for
+the next person touching this code:
+
+1. **`ssh` re-parses the remote command.** Everything after the target is
+   joined into one string and re-split by the remote login shell, so local argv
+   boundaries do not survive. `["/bin/sh", "-c", "command -v ao"]` arrived as
+   `/bin/sh -c command -v ao`, running the no-op `command` builtin — exit 0. The
+   preflight *passed* on a host with no `ao` installed.
+2. **`ControlMaster` + `ControlPersist` forks the tunnel to the background** and
+   exits 0 in the foreground, so the supervisor saw its child die while the
+   forward was still alive in a process it could no longer kill.
+3. **The remote port cannot be assumed.** `AO_PORT` is only a request; with the
+   port taken the daemon binds an ephemeral one and records it. The test host
+   had 3001 in use, so the tunnel was forwarding to an unrelated service.
+4. **Concurrent connects each spawned a tunnel.** The local path had shared one
+   in-flight attempt for years; the remote branch runs before that guard.
 
 Not yet addressed:
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -697,16 +697,12 @@ async function inspectExistingDaemon(
 async function refreshDaemonStatus(): Promise<DaemonStatus> {
 	// A remote workspace's liveness is the tunnel's, and the local daemon's
 	// run-file says nothing about it. Probe the forwarded port instead.
-	if (remoteConnection && remoteWorkspace) {
-		const health = await readDaemonProbe(remoteConnection.localPort, "healthz");
-		if (!health) {
-			setDaemonStatus({
-				state: "stopped",
-				workspaceId: remoteWorkspace.id,
-				message: `Lost the connection to ${remoteWorkspace.sshTarget}.`,
-				code: "daemon_unreachable",
-			});
-		}
+	// Keyed on placement, not on the connection: a connect that failed leaves no
+	// connection, and this is exactly the case that must keep re-dialling.
+	if (remoteWorkspace) {
+		const connection = remoteConnection;
+		const health = !connection || connection.closed() ? null : await readDaemonProbe(connection.localPort, "healthz");
+		if (!health) await reconnectRemoteWorkspace(remoteWorkspace);
 		return daemonStatus;
 	}
 	if (daemonProcess) {
@@ -747,9 +743,17 @@ async function refreshDaemonStatus(): Promise<DaemonStatus> {
 // one port. Both daemons keep their 127.0.0.1-only bind.
 // ---------------------------------------------------------------------------
 
-/** The live tunnel, when the active workspace is remote. */
+/** The live tunnel, when the active workspace is remote and connected. */
 let remoteConnection: RemoteConnection | null = null;
-/** The workspace `remoteConnection` belongs to; null while local. */
+/**
+ * The remote workspace the client is placed on, null while local.
+ *
+ * Tracked independently of `remoteConnection`, and specifically survives a
+ * failed connect: placement is what the user chose, while the connection is
+ * only whether it is reachable right now. Collapsing the two would end the
+ * re-dial loop the moment a connect failed, stranding the user on a host that
+ * is merely asleep.
+ */
 let remoteWorkspace: RemoteWorkspace | null = null;
 
 /** The ~/.ao state dir, or null before the run-file path is known. */
@@ -765,12 +769,56 @@ async function ensureControlDir(stateDir: string): Promise<string> {
 	return dir;
 }
 
-/** Drop the tunnel. The remote daemon is deliberately left running — its
- * persistence across client restarts is the entire point of the feature. */
-function disconnectRemoteWorkspace(): void {
+/**
+ * Drop the tunnel. The remote daemon is deliberately left running — its
+ * persistence across client restarts is the entire point of the feature.
+ *
+ * `forgetPlacement` also clears which workspace we are on, which is right when
+ * leaving it and wrong when merely re-dialling it.
+ */
+function disconnectRemoteWorkspace(forgetPlacement = false): void {
 	remoteConnection?.dispose();
 	remoteConnection = null;
-	remoteWorkspace = null;
+	if (forgetPlacement) remoteWorkspace = null;
+}
+
+/**
+ * Minimum gap between re-dial attempts. The status poll runs every 2s, and a
+ * host that is asleep or off the network would otherwise be hammered with a
+ * full preflight per tick.
+ */
+const REMOTE_RECONNECT_INTERVAL_MS = 10_000;
+let remoteReconnectAt = 0;
+let remoteReconnecting = false;
+
+/**
+ * Re-dial a remote workspace whose tunnel dropped.
+ *
+ * A dropped tunnel is a transport fact and nothing more: the remote daemon and
+ * its tmux sessions are still running, so this must never be reported as the
+ * session dying — the same rule the repository applies to failed runtime
+ * probes. The status stays `starting` while re-dialling so the renderer waits
+ * rather than tearing its terminals down over a wifi blink.
+ */
+async function reconnectRemoteWorkspace(workspace: RemoteWorkspace): Promise<void> {
+	if (remoteReconnecting) return;
+	if (daemonStatus.state === "ready") {
+		setDaemonStatus({
+			state: "starting",
+			workspaceId: workspace.id,
+			message: `Reconnecting to ${workspace.sshTarget}…`,
+		});
+	}
+	if (Date.now() - remoteReconnectAt < REMOTE_RECONNECT_INTERVAL_MS) return;
+
+	remoteReconnecting = true;
+	remoteReconnectAt = Date.now();
+	try {
+		disconnectRemoteWorkspace();
+		await startRemoteWorkspaceDaemon();
+	} finally {
+		remoteReconnecting = false;
+	}
 }
 
 /** Which workspace the supervisor should connect to right now. */
@@ -790,7 +838,7 @@ async function startRemoteWorkspaceDaemon(): Promise<boolean> {
 	const workspace = await activeWorkspace();
 	if (!workspace) {
 		// Switched back to local: drop any tunnel before the local daemon starts.
-		disconnectRemoteWorkspace();
+		disconnectRemoteWorkspace(true);
 		return false;
 	}
 
@@ -801,6 +849,9 @@ async function startRemoteWorkspaceDaemon(): Promise<boolean> {
 	if (remoteConnection && remoteWorkspace?.id === workspace.id && daemonStatus.state === "ready") return true;
 	disconnectRemoteWorkspace();
 
+	// Record the placement before dialling, so a connect that fails still leaves
+	// the supervisor knowing where it is meant to be and re-dialling.
+	remoteWorkspace = workspace;
 	setDaemonStatus({ state: "starting", workspaceId: workspace.id });
 	try {
 		const connection = await connectRemoteWorkspace(workspace, {
@@ -808,7 +859,6 @@ async function startRemoteWorkspaceDaemon(): Promise<boolean> {
 			probe: readDaemonProbe,
 		});
 		remoteConnection = connection;
-		remoteWorkspace = workspace;
 		// No identity check here, unlike the local attach path: the remote daemon
 		// is a different installation with a different executable path, and
 		// comparing it against this bundle would reject every healthy VM.
@@ -835,7 +885,7 @@ async function startRemoteWorkspaceDaemon(): Promise<boolean> {
  * re-attaches to it through the ordinary attach path.
  */
 async function switchWorkspaceConnection(): Promise<DaemonStatus> {
-	disconnectRemoteWorkspace();
+	disconnectRemoteWorkspace(true);
 	return startDaemon();
 }
 
@@ -1274,9 +1324,11 @@ function stopDaemon(): DaemonStatus {
 	// Stopping a remote workspace closes the tunnel only. The remote daemon keeps
 	// running by design: surviving a client restart (or a closed laptop lid) is
 	// the reason the daemon lives on the VM in the first place.
-	if (remoteConnection) {
-		const workspaceId = remoteWorkspace?.id;
-		disconnectRemoteWorkspace();
+	if (remoteWorkspace) {
+		const workspaceId = remoteWorkspace.id;
+		// Forget the placement too: an explicit stop must not be undone by the
+		// re-dial loop on the very next status poll.
+		disconnectRemoteWorkspace(true);
 		setDaemonStatus({ state: "stopped", workspaceId });
 		return daemonStatus;
 	}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -30,6 +30,19 @@ import { listFeatureBuilds, getActiveFeatureBuild } from "./main/feature-builds"
 import { readUpdateSettings, type UpdateSettings, type UpdateStatus } from "./main/update-settings";
 import { readKeybindingOverrides, writeKeybindingOverrides } from "./main/keybinding-settings";
 import { coerceUiSettings, readUiSettings, writeUiSettings, type UiSettings } from "./main/ui-settings";
+import {
+	addRemoteWorkspace,
+	readWorkspaceRegistry,
+	removeRemoteWorkspace,
+	setActiveWorkspace,
+} from "./main/workspace-registry";
+import {
+	connectRemoteWorkspace,
+	RemoteWorkspaceError,
+	type RemoteConnection,
+} from "./main/remote-workspace";
+import { sshFailureCode } from "./shared/ssh-failure";
+import { resolveWorkspace, type RemoteWorkspace, type WorkspaceRegistry } from "./shared/workspaces";
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import { closeSync, existsSync, openSync, readFileSync } from "node:fs";
@@ -682,6 +695,20 @@ async function inspectExistingDaemon(
 }
 
 async function refreshDaemonStatus(): Promise<DaemonStatus> {
+	// A remote workspace's liveness is the tunnel's, and the local daemon's
+	// run-file says nothing about it. Probe the forwarded port instead.
+	if (remoteConnection && remoteWorkspace) {
+		const health = await readDaemonProbe(remoteConnection.localPort, "healthz");
+		if (!health) {
+			setDaemonStatus({
+				state: "stopped",
+				workspaceId: remoteWorkspace.id,
+				message: `Lost the connection to ${remoteWorkspace.sshTarget}.`,
+				code: "daemon_unreachable",
+			});
+		}
+		return daemonStatus;
+	}
 	if (daemonProcess) {
 		return daemonStatus;
 	}
@@ -710,7 +737,112 @@ async function refreshDaemonStatus(): Promise<DaemonStatus> {
 	return daemonStatus;
 }
 
+// ---------------------------------------------------------------------------
+// Remote workspaces
+//
+// A remote workspace runs its own daemon; the supervisor reaches it through an
+// SSH loopback forward and hands the renderer the *local* end of that forward as
+// `daemon:status.port`. The renderer therefore needs no remote-awareness at all:
+// its base URL, SSE stream and terminal-mux WebSocket already derive from that
+// one port. Both daemons keep their 127.0.0.1-only bind.
+// ---------------------------------------------------------------------------
+
+/** The live tunnel, when the active workspace is remote. */
+let remoteConnection: RemoteConnection | null = null;
+/** The workspace `remoteConnection` belongs to; null while local. */
+let remoteWorkspace: RemoteWorkspace | null = null;
+
+/** The ~/.ao state dir, or null before the run-file path is known. */
+function aoStateDir(): string | null {
+	const runFile = runFilePath();
+	return runFile ? path.dirname(runFile) : null;
+}
+
+/** ControlMaster sockets live under ~/.ao/ssh, created 0700 (AGENTS.md ~/.ao rule). */
+async function ensureControlDir(stateDir: string): Promise<string> {
+	const dir = path.join(stateDir, "ssh");
+	await mkdir(dir, { recursive: true, mode: 0o700 });
+	return dir;
+}
+
+/** Drop the tunnel. The remote daemon is deliberately left running — its
+ * persistence across client restarts is the entire point of the feature. */
+function disconnectRemoteWorkspace(): void {
+	remoteConnection?.dispose();
+	remoteConnection = null;
+	remoteWorkspace = null;
+}
+
+/** Which workspace the supervisor should connect to right now. */
+async function activeWorkspace(): Promise<RemoteWorkspace | null> {
+	const stateDir = aoStateDir();
+	if (!stateDir) return null;
+	const resolved = resolveWorkspace(await readWorkspaceRegistry(stateDir));
+	return "error" in resolved ? null : resolved.workspace;
+}
+
+/**
+ * Connect to a remote workspace and publish it as the daemon status. Returns
+ * false when the active workspace is local, so the caller falls through to the
+ * unchanged local spawn path.
+ */
+async function startRemoteWorkspaceDaemon(): Promise<boolean> {
+	const workspace = await activeWorkspace();
+	if (!workspace) {
+		// Switched back to local: drop any tunnel before the local daemon starts.
+		disconnectRemoteWorkspace();
+		return false;
+	}
+
+	const stateDir = aoStateDir();
+	if (!stateDir) return false;
+
+	// Reconnecting to the same workspace is a no-op while the tunnel is healthy.
+	if (remoteConnection && remoteWorkspace?.id === workspace.id && daemonStatus.state === "ready") return true;
+	disconnectRemoteWorkspace();
+
+	setDaemonStatus({ state: "starting", workspaceId: workspace.id });
+	try {
+		const connection = await connectRemoteWorkspace(workspace, {
+			controlDir: await ensureControlDir(stateDir),
+			probe: readDaemonProbe,
+		});
+		remoteConnection = connection;
+		remoteWorkspace = workspace;
+		// No identity check here, unlike the local attach path: the remote daemon
+		// is a different installation with a different executable path, and
+		// comparing it against this bundle would reject every healthy VM.
+		setDaemonStatus({ state: "ready", port: connection.localPort, workspaceId: workspace.id });
+	} catch (error) {
+		const failure = error instanceof RemoteWorkspaceError ? error.failure : null;
+		setDaemonStatus({
+			state: "error",
+			workspaceId: workspace.id,
+			message: failure?.message ?? `Could not connect to ${workspace.sshTarget}.`,
+			details: failure?.details || undefined,
+			code: failure ? sshFailureCode(failure.kind) : "host_unreachable",
+		});
+	}
+	return true;
+}
+
+/**
+ * Repoint the client after the active workspace changed.
+ *
+ * Only a *remote* connection is torn down. A running local daemon is left
+ * alone: it is this machine's, killing it would drop supervision of local
+ * sessions the user did not ask to leave, and switching back to local simply
+ * re-attaches to it through the ordinary attach path.
+ */
+async function switchWorkspaceConnection(): Promise<DaemonStatus> {
+	disconnectRemoteWorkspace();
+	return startDaemon();
+}
+
 async function startDaemon(): Promise<DaemonStatus> {
+	// Placement is decided before any local spawn machinery runs: a remote
+	// workspace must never fall through and boot a second local daemon.
+	if (await startRemoteWorkspaceDaemon()) return daemonStatus;
 	if (daemonStartPromise) {
 		return daemonStartPromise;
 	}
@@ -1139,6 +1271,15 @@ function stopDaemon(): DaemonStatus {
 	// An explicit stop (or a newer restart request) cancels any deferred restart
 	// left waiting for a previously slow child to exit.
 	daemonRestartAfterExitProcess = null;
+	// Stopping a remote workspace closes the tunnel only. The remote daemon keeps
+	// running by design: surviving a client restart (or a closed laptop lid) is
+	// the reason the daemon lives on the VM in the first place.
+	if (remoteConnection) {
+		const workspaceId = remoteWorkspace?.id;
+		disconnectRemoteWorkspace();
+		setDaemonStatus({ state: "stopped", workspaceId });
+		return daemonStatus;
+	}
 	if (!daemonProcess) {
 		setDaemonStatus({ state: "stopped" });
 		return daemonStatus;
@@ -1223,6 +1364,33 @@ ipcMain.handle("daemon:restart", async () => {
 		return reportDaemonRestartFailure(error);
 	}
 });
+// Workspace registry. Every mutation that can change *which* machine the client
+// is pointed at re-runs the daemon start path, so the switch is atomic from the
+// renderer's point of view: it gets one `daemon:status` with the new port.
+async function withWorkspaceRegistry<T>(operation: (stateDir: string) => Promise<T>, fallback: T): Promise<T> {
+	const stateDir = aoStateDir();
+	return stateDir ? operation(stateDir) : fallback;
+}
+
+ipcMain.handle("workspaces:list", async (): Promise<WorkspaceRegistry> =>
+	withWorkspaceRegistry((stateDir) => readWorkspaceRegistry(stateDir), { remotes: [] }),
+);
+ipcMain.handle("workspaces:add", async (_event, workspace: RemoteWorkspace): Promise<WorkspaceRegistry> =>
+	withWorkspaceRegistry((stateDir) => addRemoteWorkspace(stateDir, workspace), { remotes: [] }),
+);
+ipcMain.handle("workspaces:remove", async (_event, id: string): Promise<WorkspaceRegistry> => {
+	// Removing the workspace currently in use must drop its tunnel, or the
+	// renderer would keep talking to a machine that is no longer registered.
+	const registry = await withWorkspaceRegistry((stateDir) => removeRemoteWorkspace(stateDir, id), { remotes: [] });
+	if (remoteWorkspace?.id === id) await switchWorkspaceConnection();
+	return registry;
+});
+ipcMain.handle("workspaces:setActive", async (_event, id: string): Promise<WorkspaceRegistry> => {
+	const registry = await withWorkspaceRegistry((stateDir) => setActiveWorkspace(stateDir, id), { remotes: [] });
+	await switchWorkspaceConnection();
+	return registry;
+});
+
 ipcMain.handle("app:getVersion", () => app.getVersion());
 ipcMain.handle("app:openExternal", async (_event, url: string) => {
 	await openAllowedAppExternalURL(url, shell);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -859,12 +859,20 @@ async function startRemoteWorkspaceDaemon(): Promise<boolean> {
 			probe: readDaemonProbe,
 		});
 		remoteConnection = connection;
+		console.log(
+			`AO: workspace ${workspace.id} connected on 127.0.0.1:${connection.localPort} ` +
+				`-> ${workspace.sshTarget}:${connection.remotePort} (${connection.started ? "started" : "attached to"} remote daemon)`,
+		);
 		// No identity check here, unlike the local attach path: the remote daemon
 		// is a different installation with a different executable path, and
 		// comparing it against this bundle would reject every healthy VM.
 		setDaemonStatus({ state: "ready", port: connection.localPort, workspaceId: workspace.id });
 	} catch (error) {
 		const failure = error instanceof RemoteWorkspaceError ? error.failure : null;
+		// Logged as well as surfaced: the UI shows the remedy, but a transport
+		// failure is the kind of thing users paste into a bug report, and the
+		// local daemon path logs its failures the same way.
+		console.error(`AO: workspace ${workspace.id} (${workspace.sshTarget}) failed: ${failure?.kind ?? "unknown"}`);
 		setDaemonStatus({
 			state: "error",
 			workspaceId: workspace.id,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -830,11 +830,32 @@ async function activeWorkspace(): Promise<RemoteWorkspace | null> {
 }
 
 /**
+ * In-flight remote connect, so concurrent callers share one attempt.
+ *
+ * The local path has had this since forever as `daemonStartPromise`, but the
+ * remote branch runs *before* that guard and so needs its own: the supervisor
+ * calls startDaemon from app-ready, from the status IPC and from the re-dial
+ * loop, and without de-duplication each call spawned its own `ssh -N`. Only the
+ * last was retained, so every other one leaked a forward and a local port for
+ * the lifetime of the app.
+ */
+let remoteStartPromise: Promise<boolean> | null = null;
+
+/**
  * Connect to a remote workspace and publish it as the daemon status. Returns
  * false when the active workspace is local, so the caller falls through to the
  * unchanged local spawn path.
  */
 async function startRemoteWorkspaceDaemon(): Promise<boolean> {
+	if (remoteStartPromise) return remoteStartPromise;
+	const attempt = startRemoteWorkspaceDaemonInner().finally(() => {
+		if (remoteStartPromise === attempt) remoteStartPromise = null;
+	});
+	remoteStartPromise = attempt;
+	return attempt;
+}
+
+async function startRemoteWorkspaceDaemonInner(): Promise<boolean> {
 	const workspace = await activeWorkspace();
 	if (!workspace) {
 		// Switched back to local: drop any tunnel before the local daemon starts.

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -42,6 +42,8 @@ import {
 	type RemoteConnection,
 } from "./main/remote-workspace";
 import { sshFailureCode } from "./shared/ssh-failure";
+import { readSshConfigHosts } from "./main/ssh-config";
+import type { SshConfigHost } from "./shared/ssh-config";
 import { resolveWorkspace, type RemoteWorkspace, type WorkspaceRegistry } from "./shared/workspaces";
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
@@ -1456,6 +1458,9 @@ async function withWorkspaceRegistry<T>(operation: (stateDir: string) => Promise
 ipcMain.handle("workspaces:list", async (): Promise<WorkspaceRegistry> =>
 	withWorkspaceRegistry((stateDir) => readWorkspaceRegistry(stateDir), { remotes: [] }),
 );
+// Read-only convenience for the picker. AO never writes ssh_config, the same
+// way it never writes known_hosts.
+ipcMain.handle("workspaces:sshHosts", async (): Promise<SshConfigHost[]> => readSshConfigHosts(os.homedir()));
 ipcMain.handle("workspaces:add", async (_event, workspace: RemoteWorkspace): Promise<WorkspaceRegistry> =>
 	withWorkspaceRegistry((stateDir) => addRemoteWorkspace(stateDir, workspace), { remotes: [] }),
 );

--- a/frontend/src/main/remote-workspace.test.ts
+++ b/frontend/src/main/remote-workspace.test.ts
@@ -157,6 +157,32 @@ describe("connectRemoteWorkspace", () => {
 		connection.dispose();
 	});
 
+	// A dropped tunnel is a transport fact, and the supervisor re-dials on it.
+	// If `closed()` stayed false after the process died, a wifi blink would
+	// strand the client on a dead forward forever.
+	it("reports a tunnel that died on its own as closed", async () => {
+		const { calls, spawn } = fakeSpawn({});
+		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer }));
+		expect(connection.closed()).toBe(false);
+
+		const tunnel = calls.find((call) => call.args.includes("-N"));
+		tunnel?.child.emit("close", 255);
+		expect(connection.closed()).toBe(true);
+	});
+
+	it("reports a disposed tunnel as closed and ignores a second dispose", async () => {
+		const { calls, spawn } = fakeSpawn({});
+		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer }));
+		const tunnel = calls.find((call) => call.args.includes("-N"));
+
+		connection.dispose();
+		expect(connection.closed()).toBe(true);
+		tunnel!.child.killed = null;
+		connection.dispose();
+		// A second dispose must not signal again — the pid may have been recycled.
+		expect(tunnel?.child.killed).toBeNull();
+	});
+
 	it("surfaces a missing ssh client distinctly from an unreachable host", async () => {
 		const spawn = (() => {
 			const child = new FakeSsh();

--- a/frontend/src/main/remote-workspace.test.ts
+++ b/frontend/src/main/remote-workspace.test.ts
@@ -1,0 +1,170 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import type { DaemonProbe, DaemonProber } from "../shared/daemon-attach";
+import { connectRemoteWorkspace, RemoteWorkspaceError, type RemoteWorkspaceDeps } from "./remote-workspace";
+import type { RemoteWorkspace } from "../shared/workspaces";
+
+const workspace: RemoteWorkspace = { id: "build-vm", sshTarget: "build-vm" };
+
+/** A spawned ssh the test drives by hand. */
+class FakeSsh extends EventEmitter {
+	readonly stdout = new EventEmitter();
+	readonly stderr = new EventEmitter();
+	killed: NodeJS.Signals | null = null;
+	kill(signal: NodeJS.Signals) {
+		this.killed = signal;
+		this.emit("close", null);
+		return true;
+	}
+	finish(exitCode: number, stderr = "") {
+		if (stderr) this.stderr.emit("data", Buffer.from(stderr));
+		this.emit("close", exitCode);
+	}
+}
+
+type Invocation = { args: string[]; child: FakeSsh };
+
+/**
+ * Script the fake ssh by role. Preflight (`command -v ao`) and the start command
+ * complete immediately with the given exit code; the tunnel (`-N`) stays open
+ * until disposed, exactly as `ssh -N` does.
+ *
+ * `daemonStarted` flips when the start command runs, so a probe can model the
+ * only sequence that matters: nothing answers until the daemon is launched.
+ */
+function fakeSpawn(plan: { preflight?: number; start?: number; preflightStderr?: string }) {
+	const calls: Invocation[] = [];
+	const state = { daemonStarted: false };
+	const spawn = (_command: string, args: string[]) => {
+		const child = new FakeSsh();
+		calls.push({ args, child });
+		if (args.includes("-N")) return child;
+
+		const isPreflight = args.at(-1) === "command -v ao";
+		const code = isPreflight ? (plan.preflight ?? 0) : (plan.start ?? 0);
+		if (!isPreflight && code === 0) state.daemonStarted = true;
+		queueMicrotask(() => child.finish(code, isPreflight ? (plan.preflightStderr ?? "") : ""));
+		return child;
+	};
+	return { calls, state, spawn: spawn as unknown as (c: string, a: string[]) => ChildProcess };
+}
+
+const probeOk: DaemonProbe = { status: "ok", service: "agent-orchestrator-daemon", pid: 42 };
+
+const answer: DaemonProber = async (_port, endpoint) => ({
+	...probeOk,
+	status: endpoint === "healthz" ? "ok" : "ready",
+});
+
+/** A prober that stays silent until the fake ssh has actually started a daemon. */
+function probeAfterStart(state: { daemonStarted: boolean }): DaemonProber {
+	return async (port, endpoint) => (state.daemonStarted ? answer(port, endpoint) : null);
+}
+
+/**
+ * A deterministic clock: every injected sleep advances it by exactly the
+ * requested amount, so readiness budgets expire in zero real time and the
+ * timeout paths are testable at all.
+ */
+function fakeClock() {
+	let millis = 0;
+	return { now: () => millis, delay: async (ms: number) => void (millis += ms) };
+}
+
+function deps(overrides: Partial<RemoteWorkspaceDeps> & Pick<RemoteWorkspaceDeps, "spawn" | "probe">): RemoteWorkspaceDeps {
+	return {
+		controlDir: "/tmp/ao-ssh",
+		allocatePort: async () => 51234,
+		...fakeClock(),
+		...overrides,
+	};
+}
+
+describe("connectRemoteWorkspace", () => {
+	it("attaches to an already-running remote daemon without starting one", async () => {
+		const { calls, spawn } = fakeSpawn({});
+		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer }));
+
+		expect(connection).toMatchObject({ localPort: 51234, remotePort: 3001, started: false });
+		// Exactly two invocations: the preflight and the tunnel. No start command.
+		expect(calls).toHaveLength(2);
+		expect(calls[1].args).toContain("51234:127.0.0.1:3001");
+		connection.dispose();
+		expect(calls[1].child.killed).toBe("SIGTERM");
+	});
+
+	it("starts the daemon when nothing answers, then reports started", async () => {
+		const { calls, state, spawn } = fakeSpawn({});
+		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: probeAfterStart(state) }));
+
+		expect(connection.started).toBe(true);
+		const start = calls.at(-1)?.args.at(-1) ?? "";
+		expect(start).toContain("ao daemon");
+		expect(start).toContain("setsid");
+		expect(start).toContain("nohup");
+		connection.dispose();
+	});
+
+	// Detect and report; never install. AO does not become a config-management
+	// tool for machines its maintainers do not own.
+	it("reports a missing remote ao binary as an install instruction, not a transport error", async () => {
+		const { spawn } = fakeSpawn({ preflight: 127 });
+		const error = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer })).catch((e) => e);
+
+		expect(error).toBeInstanceOf(RemoteWorkspaceError);
+		expect(error.failure.kind).toBe("remote_command_failed");
+		expect(error.message).toContain("No `ao` binary on build-vm");
+		expect(error.message).not.toContain("install it for you");
+	});
+
+	it("classifies an unverified host key rather than blaming the daemon", async () => {
+		const { spawn } = fakeSpawn({
+			preflight: 255,
+			preflightStderr: "No ED25519 host key is known for build-vm and you have requested strict checking.",
+		});
+		const error = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer })).catch((e) => e);
+
+		expect(error.failure.kind).toBe("host_key_unverified");
+		// The remedy must put the fingerprint in front of the user, not bypass it.
+		expect(error.message).toContain("ssh build-vm");
+	});
+
+	// A failed connect must not leave an orphaned `ssh -N` holding a local port.
+	it("tears the tunnel down when the daemon never becomes ready", async () => {
+		const { calls, spawn } = fakeSpawn({});
+		const error = await connectRemoteWorkspace(
+			workspace,
+			deps({ spawn, probe: async () => null }),
+		).catch((e) => e);
+
+		expect(error).toBeInstanceOf(RemoteWorkspaceError);
+		expect(error.message).toContain("never became ready");
+		const tunnel = calls.find((call) => call.args.includes("-N"));
+		expect(tunnel?.child.killed).toBe("SIGTERM");
+	});
+
+	it("honours a per-workspace remote port on both the forward and the start command", async () => {
+		const { calls, state, spawn } = fakeSpawn({});
+		const connection = await connectRemoteWorkspace(
+			{ ...workspace, remotePort: 4100 },
+			deps({ spawn, probe: probeAfterStart(state) }),
+		);
+
+		expect(connection.remotePort).toBe(4100);
+		expect(calls.find((call) => call.args.includes("-N"))?.args).toContain("51234:127.0.0.1:4100");
+		expect(calls.at(-1)?.args.at(-1)).toContain("AO_PORT='4100'");
+		connection.dispose();
+	});
+
+	it("surfaces a missing ssh client distinctly from an unreachable host", async () => {
+		const spawn = (() => {
+			const child = new FakeSsh();
+			queueMicrotask(() => child.emit("error", Object.assign(new Error("spawn ssh ENOENT"), { code: "ENOENT" })));
+			return child;
+		}) as unknown as (c: string, a: string[]) => ChildProcess;
+
+		const error = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer })).catch((e) => e);
+		expect(error.failure.kind).toBe("ssh_missing");
+	});
+});

--- a/frontend/src/main/remote-workspace.test.ts
+++ b/frontend/src/main/remote-workspace.test.ts
@@ -17,7 +17,8 @@ class FakeSsh extends EventEmitter {
 		this.emit("close", null);
 		return true;
 	}
-	finish(exitCode: number, stderr = "") {
+	finish(exitCode: number, stderr = "", stdout = "") {
+		if (stdout) this.stdout.emit("data", Buffer.from(stdout));
 		if (stderr) this.stderr.emit("data", Buffer.from(stderr));
 		this.emit("close", exitCode);
 	}
@@ -25,30 +26,56 @@ class FakeSsh extends EventEmitter {
 
 type Invocation = { args: string[]; child: FakeSsh };
 
+/** The remote port the fake daemon reports. Deliberately not 3001: the run-file
+ * is the authority, and a test that used the default would not notice the
+ * connect guessing instead of discovering. */
+const REMOTE_PORT = 43215;
+
 /**
- * Script the fake ssh by role. Preflight (`command -v ao`) and the start command
- * complete immediately with the given exit code; the tunnel (`-N`) stays open
- * until disposed, exactly as `ssh -N` does.
+ * Script the fake ssh by role, modelling the real connect sequence:
+ * preflight (`command -v ao`) → run-file read → start → run-file poll → tunnel.
  *
- * `daemonStarted` flips when the start command runs, so a probe can model the
- * only sequence that matters: nothing answers until the daemon is launched.
+ * `alreadyRunning` decides whether the first run-file read finds a live daemon,
+ * which is the fork between attaching and starting. The tunnel (`-N`) stays open
+ * until disposed, exactly as an unmultiplexed `ssh -N` does.
  */
-function fakeSpawn(plan: { preflight?: number; start?: number; preflightStderr?: string }) {
+function fakeSpawn(plan: {
+	preflight?: number;
+	start?: number;
+	preflightStderr?: string;
+	alreadyRunning?: boolean;
+	neverPublishesPort?: boolean;
+}) {
 	const calls: Invocation[] = [];
-	const state = { daemonStarted: false };
+	const state = { daemonStarted: plan.alreadyRunning ?? false };
+	const runFile = () => JSON.stringify({ pid: 4242, port: REMOTE_PORT, startedAt: "2026-08-12T00:00:00Z" });
+
 	const spawn = (_command: string, args: string[]) => {
 		const child = new FakeSsh();
 		calls.push({ args, child });
 		if (args.includes("-N")) return child;
 
-		const isPreflight = args.at(-1)?.includes("command -v ao") ?? false;
-		const code = isPreflight ? (plan.preflight ?? 0) : (plan.start ?? 0);
-		if (!isPreflight && code === 0) state.daemonStarted = true;
-		queueMicrotask(() => child.finish(code, isPreflight ? (plan.preflightStderr ?? "") : ""));
+		const script = args.at(-1) ?? "";
+		queueMicrotask(() => {
+			if (script.includes("command -v ao")) {
+				child.finish(plan.preflight ?? 0, plan.preflightStderr ?? "");
+			} else if (script.includes("running.json")) {
+				// Empty stdout is the normal "no live daemon" answer, not an error.
+				const live = state.daemonStarted && !plan.neverPublishesPort;
+				child.finish(0, "", live ? runFile() : "");
+			} else {
+				const code = plan.start ?? 0;
+				if (code === 0) state.daemonStarted = true;
+				child.finish(code);
+			}
+		});
 		return child;
 	};
 	return { calls, state, spawn: spawn as unknown as (c: string, a: string[]) => ChildProcess };
 }
+
+const isTunnel = (call: Invocation) => call.args.includes("-N");
+const isStart = (call: Invocation) => (call.args.at(-1) ?? "").includes("ao daemon");
 
 const probeOk: DaemonProbe = { status: "ok", service: "agent-orchestrator-daemon", pid: 42 };
 
@@ -56,11 +83,6 @@ const answer: DaemonProber = async (_port, endpoint) => ({
 	...probeOk,
 	status: endpoint === "healthz" ? "ok" : "ready",
 });
-
-/** A prober that stays silent until the fake ssh has actually started a daemon. */
-function probeAfterStart(state: { daemonStarted: boolean }): DaemonProber {
-	return async (port, endpoint) => (state.daemonStarted ? answer(port, endpoint) : null);
-}
 
 /**
  * A deterministic clock: every injected sleep advances it by exactly the
@@ -83,27 +105,49 @@ function deps(overrides: Partial<RemoteWorkspaceDeps> & Pick<RemoteWorkspaceDeps
 
 describe("connectRemoteWorkspace", () => {
 	it("attaches to an already-running remote daemon without starting one", async () => {
+		const { calls, spawn } = fakeSpawn({ alreadyRunning: true });
+		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer }));
+
+		expect(connection).toMatchObject({ localPort: 51234, remotePort: REMOTE_PORT, started: false });
+		expect(calls.some(isStart)).toBe(false);
+		connection.dispose();
+		expect(calls.find(isTunnel)?.child.killed).toBe("SIGTERM");
+	});
+
+	// The bug this pins, found on a real host: AO_PORT is only a request. With
+	// 3001 taken the daemon binds an ephemeral port and records it, so forwarding
+	// to a guessed 3001 reaches whatever *else* is listening there.
+	it("forwards to the port the run-file reports, not the default", async () => {
+		const { calls, spawn } = fakeSpawn({ alreadyRunning: true });
+		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer }));
+
+		expect(connection.remotePort).toBe(REMOTE_PORT);
+		expect(calls.find(isTunnel)?.args).toContain(`51234:127.0.0.1:${REMOTE_PORT}`);
+		connection.dispose();
+	});
+
+	it("starts the daemon when none is running, then reports started", async () => {
 		const { calls, spawn } = fakeSpawn({});
 		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer }));
 
-		expect(connection).toMatchObject({ localPort: 51234, remotePort: 3001, started: false });
-		// Exactly two invocations: the preflight and the tunnel. No start command.
-		expect(calls).toHaveLength(2);
-		expect(calls[1].args).toContain("51234:127.0.0.1:3001");
-		connection.dispose();
-		expect(calls[1].child.killed).toBe("SIGTERM");
-	});
-
-	it("starts the daemon when nothing answers, then reports started", async () => {
-		const { calls, state, spawn } = fakeSpawn({});
-		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: probeAfterStart(state) }));
-
 		expect(connection.started).toBe(true);
-		const start = calls.at(-1)?.args.at(-1) ?? "";
+		const start = calls.find(isStart)?.args.at(-1) ?? "";
 		expect(start).toContain("ao daemon");
+		// setsid (with a nohup fallback) is what keeps the daemon alive after the
+		// SSH session that launched it goes away.
 		expect(start).toContain("setsid");
 		expect(start).toContain("nohup");
+		// Nothing pins the port when the user expressed no preference.
+		expect(start).not.toContain("AO_PORT");
 		connection.dispose();
+	});
+
+	it("gives up when a started daemon never publishes a port", async () => {
+		const { spawn } = fakeSpawn({ neverPublishesPort: true });
+		const error = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer })).catch((e) => e);
+
+		expect(error).toBeInstanceOf(RemoteWorkspaceError);
+		expect(error.message).toContain("never reported a listening port");
 	});
 
 	// Detect and report; never install. AO does not become a config-management
@@ -131,32 +175,30 @@ describe("connectRemoteWorkspace", () => {
 	});
 
 	// A failed connect must not leave an orphaned `ssh -N` holding a local port.
-	it("tears the tunnel down when the daemon never becomes ready", async () => {
-		const { calls, spawn } = fakeSpawn({});
-		const error = await connectRemoteWorkspace(
-			workspace,
-			deps({ spawn, probe: async () => null }),
-		).catch((e) => e);
+	// The daemon was confirmed listening before the tunnel opened, so a failure
+	// here is the forward's fault and must not be blamed on the daemon.
+	it("tears the tunnel down when the forward never carries the daemon", async () => {
+		const { calls, spawn } = fakeSpawn({ alreadyRunning: true });
+		const error = await connectRemoteWorkspace(workspace, deps({ spawn, probe: async () => null })).catch((e) => e);
 
 		expect(error).toBeInstanceOf(RemoteWorkspaceError);
-		expect(error.message).toContain("never became ready");
-		const tunnel = calls.find((call) => call.args.includes("-N"));
-		expect(tunnel?.child.killed).toBe("SIGTERM");
+		expect(error.message).toContain("did not answer");
+		expect(calls.find(isTunnel)?.child.killed).toBe("SIGTERM");
 	});
 
-	it("honours a per-workspace remote port on both the forward and the start command", async () => {
-		const { calls, state, spawn } = fakeSpawn({});
+	it("passes a configured remote port to the daemon it starts, as a preference", async () => {
+		const { calls, spawn } = fakeSpawn({});
 		const connection = await connectRemoteWorkspace(
 			{ ...workspace, remotePort: 4100 },
-			deps({ spawn, probe: probeAfterStart(state) }),
+			deps({ spawn, probe: answer }),
 		);
 
-		expect(connection.remotePort).toBe(4100);
-		expect(calls.find((call) => call.args.includes("-N"))?.args).toContain("51234:127.0.0.1:4100");
 		// Assert on what the remote /bin/sh actually receives, i.e. after the
 		// remote login shell strips the outer layer of quoting.
-		const sent = calls.at(-1)?.args.at(-1) ?? "";
+		const sent = calls.find(isStart)?.args.at(-1) ?? "";
 		expect(sent.slice(1, -1).replaceAll(`'\\''`, "'")).toContain("AO_PORT='4100'");
+		// ...but the run-file still decides where the tunnel actually points.
+		expect(connection.remotePort).toBe(REMOTE_PORT);
 		connection.dispose();
 	});
 
@@ -164,19 +206,19 @@ describe("connectRemoteWorkspace", () => {
 	// If `closed()` stayed false after the process died, a wifi blink would
 	// strand the client on a dead forward forever.
 	it("reports a tunnel that died on its own as closed", async () => {
-		const { calls, spawn } = fakeSpawn({});
+		const { calls, spawn } = fakeSpawn({ alreadyRunning: true });
 		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer }));
 		expect(connection.closed()).toBe(false);
 
-		const tunnel = calls.find((call) => call.args.includes("-N"));
+		const tunnel = calls.find(isTunnel);
 		tunnel?.child.emit("close", 255);
 		expect(connection.closed()).toBe(true);
 	});
 
 	it("reports a disposed tunnel as closed and ignores a second dispose", async () => {
-		const { calls, spawn } = fakeSpawn({});
+		const { calls, spawn } = fakeSpawn({ alreadyRunning: true });
 		const connection = await connectRemoteWorkspace(workspace, deps({ spawn, probe: answer }));
-		const tunnel = calls.find((call) => call.args.includes("-N"));
+		const tunnel = calls.find(isTunnel);
 
 		connection.dispose();
 		expect(connection.closed()).toBe(true);

--- a/frontend/src/main/remote-workspace.test.ts
+++ b/frontend/src/main/remote-workspace.test.ts
@@ -41,7 +41,7 @@ function fakeSpawn(plan: { preflight?: number; start?: number; preflightStderr?:
 		calls.push({ args, child });
 		if (args.includes("-N")) return child;
 
-		const isPreflight = args.at(-1) === "command -v ao";
+		const isPreflight = args.at(-1)?.includes("command -v ao") ?? false;
 		const code = isPreflight ? (plan.preflight ?? 0) : (plan.start ?? 0);
 		if (!isPreflight && code === 0) state.daemonStarted = true;
 		queueMicrotask(() => child.finish(code, isPreflight ? (plan.preflightStderr ?? "") : ""));
@@ -153,7 +153,10 @@ describe("connectRemoteWorkspace", () => {
 
 		expect(connection.remotePort).toBe(4100);
 		expect(calls.find((call) => call.args.includes("-N"))?.args).toContain("51234:127.0.0.1:4100");
-		expect(calls.at(-1)?.args.at(-1)).toContain("AO_PORT='4100'");
+		// Assert on what the remote /bin/sh actually receives, i.e. after the
+		// remote login shell strips the outer layer of quoting.
+		const sent = calls.at(-1)?.args.at(-1) ?? "";
+		expect(sent.slice(1, -1).replaceAll(`'\\''`, "'")).toContain("AO_PORT='4100'");
 		connection.dispose();
 	});
 

--- a/frontend/src/main/remote-workspace.ts
+++ b/frontend/src/main/remote-workspace.ts
@@ -56,6 +56,13 @@ export type RemoteConnection = {
 	remotePort: number;
 	/** True when this connect started the remote daemon rather than attaching. */
 	started: boolean;
+	/**
+	 * True once the tunnel process is gone, whether disposed or dropped on its
+	 * own (laptop sleep, wifi loss, VM reboot). A dropped tunnel says nothing
+	 * about the remote daemon, which keeps running — so this is a signal to
+	 * re-dial, never to conclude the session died.
+	 */
+	closed: () => boolean;
 	/** Tear the tunnel down. Idempotent. */
 	dispose: () => void;
 };
@@ -280,26 +287,28 @@ export async function connectRemoteWorkspace(
 		tunnelStderr = `${tunnelStderr}${chunk.toString("utf8")}`.slice(-4000);
 	});
 
-	let disposed = false;
+	// One flag for both "we tore it down" and "it died on us": a later dispose
+	// must not signal a recycled pid, and the supervisor needs to see a dropped
+	// tunnel so it can re-dial.
+	let gone = false;
+	const closed = () => gone;
 	const dispose = () => {
-		if (disposed) return;
-		disposed = true;
+		if (gone) return;
+		gone = true;
 		tunnel.kill("SIGTERM");
 	};
-	// A tunnel that dies on its own must not leave `disposed` false, or a later
-	// dispose would signal a recycled pid.
 	tunnel.on("close", () => {
-		disposed = true;
+		gone = true;
 	});
 
 	try {
 		if (await waitForReady(deps.probe, localPort, ATTACH_PROBE_TIMEOUT_MS, delay, now)) {
-			return { localPort, remotePort, started: false, dispose };
+			return { localPort, remotePort, started: false, closed, dispose };
 		}
 		// Nothing answered. Distinguish "the tunnel itself failed" from "the tunnel
 		// is fine, no daemon is listening yet" — starting a daemon over a dead
 		// transport would only produce a second, more confusing failure.
-		if (disposed) {
+		if (gone) {
 			throw new RemoteWorkspaceError(classifySshFailure(null, tunnelStderr, workspace.sshTarget));
 		}
 		await startRemoteDaemon(spawn, workspace, control, remotePort);
@@ -310,7 +319,7 @@ export async function connectRemoteWorkspace(
 				details: `${tunnelStderr}\nSee ~/.ao/daemon.log on ${workspace.sshTarget}.`.trim(),
 			});
 		}
-		return { localPort, remotePort, started: true, dispose };
+		return { localPort, remotePort, started: true, closed, dispose };
 	} catch (error) {
 		dispose();
 		throw error;

--- a/frontend/src/main/remote-workspace.ts
+++ b/frontend/src/main/remote-workspace.ts
@@ -1,0 +1,318 @@
+// Connecting the supervisor to a remote workspace's daemon.
+//
+// The whole feature rests on one fact: the renderer addresses the daemon
+// through a single mutable base URL that the supervisor hands it
+// (`daemon:status` → renderer/lib/daemon-status.ts), and the terminal-mux
+// WebSocket derives its URL from that same base. So if the supervisor points
+// that base at a loopback port which SSH forwards to the remote daemon, every
+// existing renderer feature — REST, SSE, terminals — works unmodified, and the
+// remote daemon keeps its 127.0.0.1-only bind. AO gains no network listener,
+// and `AGENTS.md`'s bind rule is respected on both machines.
+//
+// Connect sequence, in order, because each step's failure has a different
+// remedy and must not be reported as the next step's:
+//
+//   1. preflight  — is `ssh` here, is the host reachable, is `ao` there
+//   2. tunnel     — `ssh -N -L <local>:127.0.0.1:<remote>`
+//   3. attach     — probe the forwarded port; a daemon may already be running
+//   4. start      — only if nothing answered, launch `ao daemon` detached
+//   5. wait       — poll until /healthz and /readyz agree
+//
+// Process plumbing lives here; the argv builders and the failure taxonomy are
+// pure modules under shared/ so they can be tested without opening a socket.
+
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import {
+	CONNECT_TIMEOUT_SECONDS,
+	controlPath,
+	controlPathFits,
+	remoteCommandArgv,
+	shellQuote,
+	tunnelArgv,
+} from "../shared/ssh-command";
+import {
+	aoNotInstalledFailure,
+	classifySshFailure,
+	sshClientMissingFailure,
+	type SshFailure,
+} from "../shared/ssh-failure";
+import type { DaemonProber } from "../shared/daemon-attach";
+import { DEFAULT_DAEMON_PORT } from "../shared/daemon-attach";
+import type { RemoteWorkspace } from "../shared/workspaces";
+
+/** Bound on a single preflight/start command, including the ssh handshake. */
+const REMOTE_COMMAND_TIMEOUT_MS = (CONNECT_TIMEOUT_SECONDS + 10) * 1000;
+/** How long to wait for an already-running remote daemon to answer. */
+const ATTACH_PROBE_TIMEOUT_MS = 3_000;
+/** How long to wait for a freshly started remote daemon to become ready. */
+const START_READY_TIMEOUT_MS = 30_000;
+const READY_POLL_INTERVAL_MS = 250;
+
+export type RemoteConnection = {
+	/** Loopback port on this machine that reaches the remote daemon. */
+	localPort: number;
+	/** The port the daemon binds on the remote side. */
+	remotePort: number;
+	/** True when this connect started the remote daemon rather than attaching. */
+	started: boolean;
+	/** Tear the tunnel down. Idempotent. */
+	dispose: () => void;
+};
+
+export class RemoteWorkspaceError extends Error {
+	readonly failure: SshFailure;
+	constructor(failure: SshFailure) {
+		super(failure.message);
+		this.name = "RemoteWorkspaceError";
+		this.failure = failure;
+	}
+}
+
+type SpawnFn = (command: string, args: string[]) => ChildProcess;
+
+export type RemoteWorkspaceDeps = {
+	/** Directory for ControlMaster sockets; must already exist, mode 0700. */
+	controlDir: string;
+	/** Reuses the supervisor's existing /healthz|/readyz prober. */
+	probe: DaemonProber;
+	spawn?: SpawnFn;
+	/** Allocates a free loopback port; injectable so tests never bind. */
+	allocatePort?: () => Promise<number>;
+	/** Injectable clock and sleep, so readiness budgets are testable without waiting. */
+	delay?: (ms: number) => Promise<void>;
+	now?: () => number;
+};
+
+type RunResult = { exitCode: number | null; stdout: string; stderr: string };
+
+const defaultDelay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Ask the OS for a free loopback port by binding zero and releasing it.
+ *
+ * This is inherently a TOCTOU: the port can be taken between release and ssh's
+ * bind. That is acceptable and not worth a lock — the loss is a failed connect
+ * the user can retry, and the alternative (holding the socket while ssh binds)
+ * is impossible. Binding 127.0.0.1 rather than 0.0.0.0 also guarantees the
+ * forward we later create is never externally reachable.
+ */
+async function allocateLoopbackPort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.on("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (address === null || typeof address === "string") {
+				server.close(() => reject(new Error("could not allocate a loopback port")));
+				return;
+			}
+			const { port } = address;
+			server.close(() => resolve(port));
+		});
+	});
+}
+
+/** Resolve the ControlMaster socket, degrading to no multiplexing if it will not fit. */
+function resolveControl(controlDir: string, sshTarget: string): { path: string } | null {
+	const candidate = controlPath(controlDir, sshTarget);
+	// Over the sockaddr_un budget OpenSSH fails the entire connection, so a path
+	// too long must degrade to an unmultiplexed connection rather than hard-fail.
+	// Slower (a handshake per command), but it works.
+	return controlPathFits(candidate) ? { path: candidate } : null;
+}
+
+/** Run one ssh command to completion, capturing both streams separately. */
+function runSsh(spawn: SpawnFn, args: string[], timeoutMs: number): Promise<RunResult> {
+	return new Promise((resolve, reject) => {
+		let child: ChildProcess;
+		try {
+			child = spawn("ssh", args);
+		} catch {
+			reject(new RemoteWorkspaceError(sshClientMissingFailure()));
+			return;
+		}
+
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		child.stdout?.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString("utf8");
+		});
+		// stdout and stderr are deliberately NOT merged: the local ssh client
+		// writes its own diagnostics to stderr, and interleaving them into the
+		// remote command's stdout would corrupt anything we parse from it.
+		child.stderr?.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString("utf8");
+		});
+
+		// ConnectTimeout bounds only the TCP connect, and is not consulted at all
+		// by a multiplexed client (which connects to a local Unix socket), so the
+		// caller's own deadline is the real bound.
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			child.kill("SIGKILL");
+			resolve({ exitCode: null, stdout, stderr: `${stderr}\nssh timed out after ${timeoutMs}ms` });
+		}, timeoutMs);
+
+		child.on("error", (error: NodeJS.ErrnoException) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			// ENOENT here means no ssh binary, which is a different remedy from
+			// every transport failure and must not be classified as one.
+			reject(new RemoteWorkspaceError(error.code === "ENOENT" ? sshClientMissingFailure() : classifySshFailure(null, String(error), "")));
+		});
+		child.on("close", (code) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve({ exitCode: code, stdout, stderr });
+		});
+	});
+}
+
+/**
+ * Confirm the host answers and carries an `ao` binary, before a tunnel exists.
+ *
+ * `command -v ao` runs through the interposed /bin/sh, and its failure is
+ * reported as "install ao there", never as an install AO performs itself.
+ */
+async function preflight(spawn: SpawnFn, workspace: RemoteWorkspace, control: { path: string } | null): Promise<void> {
+	const argv = remoteCommandArgv({ sshTarget: workspace.sshTarget, control, script: "command -v ao" });
+	const result = await runSsh(spawn, argv, REMOTE_COMMAND_TIMEOUT_MS);
+	if (result.exitCode === 0) return;
+	// A clean non-zero from the remote shell means ssh worked and `ao` is absent;
+	// anything else is a transport problem and gets the transport's diagnosis.
+	const failure = classifySshFailure(result.exitCode, result.stderr, workspace.sshTarget);
+	throw new RemoteWorkspaceError(failure.kind === "remote_command_failed" ? aoNotInstalledFailure(workspace.sshTarget) : failure);
+}
+
+/**
+ * Start the remote daemon, detached from this SSH session.
+ *
+ * `setsid` (with a `nohup` fallback for hosts without it) is what keeps the
+ * daemon alive after the connection that launched it goes away — otherwise
+ * sshd's SIGHUP on channel close takes the daemon with it, and closing the
+ * laptop lid would kill every remote session.
+ *
+ * stdin is redirected from /dev/null and both output streams to the remote
+ * ~/.ao log, so the command cannot block waiting to write into a closing pipe.
+ * `ao daemon` already refuses to start when one is bound to the port, so a
+ * racing second connect is harmless.
+ */
+async function startRemoteDaemon(
+	spawn: SpawnFn,
+	workspace: RemoteWorkspace,
+	control: { path: string } | null,
+	remotePort: number,
+): Promise<void> {
+	// The port is exported rather than used as a command prefix: `setsid FOO=1 ao`
+	// would have setsid try to exec "FOO=1" as the program name.
+	const launch = `ao daemon >> "$HOME/.ao/daemon.log" 2>&1 < /dev/null &`;
+	const script = [
+		'mkdir -p "$HOME/.ao"',
+		`AO_PORT=${shellQuote(String(remotePort))}`,
+		"export AO_PORT",
+		`if command -v setsid > /dev/null 2>&1; then setsid ${launch} else nohup ${launch} fi`,
+	].join("; ");
+
+	const argv = remoteCommandArgv({ sshTarget: workspace.sshTarget, control, script });
+	const result = await runSsh(spawn, argv, REMOTE_COMMAND_TIMEOUT_MS);
+	if (result.exitCode !== 0) {
+		throw new RemoteWorkspaceError(classifySshFailure(result.exitCode, result.stderr, workspace.sshTarget));
+	}
+}
+
+/**
+ * Poll the forwarded port until the daemon reports both healthy and ready.
+ *
+ * Both endpoints must agree on the pid, mirroring the local attach path: a
+ * daemon that answers /healthz but not /readyz is still booting, and pointing
+ * the renderer at it would surface as a wall of failed requests.
+ */
+async function waitForReady(
+	probe: DaemonProber,
+	localPort: number,
+	budgetMs: number,
+	delay: (ms: number) => Promise<void>,
+	now: () => number,
+): Promise<boolean> {
+	const deadline = now() + budgetMs;
+	for (;;) {
+		const health = await probe(localPort, "healthz");
+		if (health) {
+			const ready = await probe(localPort, "readyz");
+			if (ready && ready.pid === health.pid) return true;
+		}
+		if (now() >= deadline) return false;
+		await delay(READY_POLL_INTERVAL_MS);
+	}
+}
+
+/**
+ * Establish a connection to a remote workspace's daemon, starting it if needed.
+ *
+ * On any failure the tunnel is torn down before throwing, so a failed connect
+ * never leaves an orphaned `ssh -N` holding a port.
+ */
+export async function connectRemoteWorkspace(
+	workspace: RemoteWorkspace,
+	deps: RemoteWorkspaceDeps,
+): Promise<RemoteConnection> {
+	const spawn = deps.spawn ?? ((command, args) => nodeSpawn(command, args, { stdio: ["ignore", "pipe", "pipe"] }));
+	const allocatePort = deps.allocatePort ?? allocateLoopbackPort;
+	const delay = deps.delay ?? defaultDelay;
+	const now = deps.now ?? Date.now;
+	const remotePort = workspace.remotePort ?? DEFAULT_DAEMON_PORT;
+	const control = resolveControl(deps.controlDir, workspace.sshTarget);
+
+	await preflight(spawn, workspace, control);
+
+	const localPort = await allocatePort();
+	const tunnel = spawn("ssh", tunnelArgv({ sshTarget: workspace.sshTarget, control, localPort, remotePort }));
+
+	// `ssh -N` normally stays silent and running; anything it prints is a
+	// diagnosis for a connect that is about to fail its probes, so keep the tail.
+	let tunnelStderr = "";
+	tunnel.stderr?.on("data", (chunk: Buffer) => {
+		tunnelStderr = `${tunnelStderr}${chunk.toString("utf8")}`.slice(-4000);
+	});
+
+	let disposed = false;
+	const dispose = () => {
+		if (disposed) return;
+		disposed = true;
+		tunnel.kill("SIGTERM");
+	};
+	// A tunnel that dies on its own must not leave `disposed` false, or a later
+	// dispose would signal a recycled pid.
+	tunnel.on("close", () => {
+		disposed = true;
+	});
+
+	try {
+		if (await waitForReady(deps.probe, localPort, ATTACH_PROBE_TIMEOUT_MS, delay, now)) {
+			return { localPort, remotePort, started: false, dispose };
+		}
+		// Nothing answered. Distinguish "the tunnel itself failed" from "the tunnel
+		// is fine, no daemon is listening yet" — starting a daemon over a dead
+		// transport would only produce a second, more confusing failure.
+		if (disposed) {
+			throw new RemoteWorkspaceError(classifySshFailure(null, tunnelStderr, workspace.sshTarget));
+		}
+		await startRemoteDaemon(spawn, workspace, control, remotePort);
+		if (!(await waitForReady(deps.probe, localPort, START_READY_TIMEOUT_MS, delay, now))) {
+			throw new RemoteWorkspaceError({
+				kind: "remote_command_failed",
+				message: `Started \`ao daemon\` on ${workspace.sshTarget}, but it never became ready.`,
+				details: `${tunnelStderr}\nSee ~/.ao/daemon.log on ${workspace.sshTarget}.`.trim(),
+			});
+		}
+		return { localPort, remotePort, started: true, dispose };
+	} catch (error) {
+		dispose();
+		throw error;
+	}
+}

--- a/frontend/src/main/remote-workspace.ts
+++ b/frontend/src/main/remote-workspace.ts
@@ -13,10 +13,16 @@
 // remedy and must not be reported as the next step's:
 //
 //   1. preflight  — is `ssh` here, is the host reachable, is `ao` there
-//   2. tunnel     — `ssh -N -L <local>:127.0.0.1:<remote>`
-//   3. attach     — probe the forwarded port; a daemon may already be running
-//   4. start      — only if nothing answered, launch `ao daemon` detached
-//   5. wait       — poll until /healthz and /readyz agree
+//   2. discover   — read the remote run-file for a LIVE daemon and its real port
+//   3. start      — only if none, launch `ao daemon` detached, then re-discover
+//   4. tunnel     — `ssh -N -L <local>:127.0.0.1:<discovered>`
+//   5. wait       — probe the forward until /healthz and /readyz agree
+//
+// The port is discovered, never assumed. `AO_PORT` is only a *request*: when it
+// is taken the daemon binds an ephemeral port instead and records the real one
+// in ~/.ao/running.json (the same handshake the local supervisor trusts).
+// Forwarding to a guessed 3001 on a busy host reaches whatever else is
+// listening there, not AO.
 //
 // Process plumbing lives here; the argv builders and the failure taxonomy are
 // pure modules under shared/ so they can be tested without opening a socket.
@@ -38,16 +44,17 @@ import {
 	type SshFailure,
 } from "../shared/ssh-failure";
 import type { DaemonProber } from "../shared/daemon-attach";
-import { DEFAULT_DAEMON_PORT } from "../shared/daemon-attach";
+import { parseRunFile } from "../shared/daemon-discovery";
 import type { RemoteWorkspace } from "../shared/workspaces";
 
 /** Bound on a single preflight/start command, including the ssh handshake. */
 const REMOTE_COMMAND_TIMEOUT_MS = (CONNECT_TIMEOUT_SECONDS + 10) * 1000;
-/** How long to wait for an already-running remote daemon to answer. */
-const ATTACH_PROBE_TIMEOUT_MS = 3_000;
-/** How long to wait for a freshly started remote daemon to become ready. */
+/** How long to wait for a freshly started remote daemon to publish its port. */
 const START_READY_TIMEOUT_MS = 30_000;
+/** How long the forward gets to carry a daemon already known to be listening. */
+const TUNNEL_READY_TIMEOUT_MS = 10_000;
 const READY_POLL_INTERVAL_MS = 250;
+const RUN_FILE_POLL_INTERVAL_MS = 500;
 
 export type RemoteConnection = {
 	/** Loopback port on this machine that reaches the remote daemon. */
@@ -213,15 +220,15 @@ async function startRemoteDaemon(
 	spawn: SpawnFn,
 	workspace: RemoteWorkspace,
 	control: { path: string } | null,
-	remotePort: number,
+	preferredPort: number | null,
 ): Promise<void> {
 	// The port is exported rather than used as a command prefix: `setsid FOO=1 ao`
-	// would have setsid try to exec "FOO=1" as the program name.
+	// would have setsid try to exec "FOO=1" as the program name. It is only a
+	// request; the daemon records what it actually bound in the run-file.
 	const launch = `ao daemon >> "$HOME/.ao/daemon.log" 2>&1 < /dev/null &`;
 	const script = [
 		'mkdir -p "$HOME/.ao"',
-		`AO_PORT=${shellQuote(String(remotePort))}`,
-		"export AO_PORT",
+		...(preferredPort === null ? [] : [`AO_PORT=${shellQuote(String(preferredPort))}`, "export AO_PORT"]),
 		`if command -v setsid > /dev/null 2>&1; then setsid ${launch} else nohup ${launch} fi`,
 	].join("; ");
 
@@ -264,6 +271,55 @@ async function waitForReady(
  * On any failure the tunnel is torn down before throwing, so a failed connect
  * never leaves an orphaned `ssh -N` holding a port.
  */
+/**
+ * Read the remote run-file, but only when it describes a LIVE daemon.
+ *
+ * A stale run-file (daemon killed, host rebooted) must not be trusted, so the
+ * recorded pid is checked with `kill -0` on the remote before the contents are
+ * returned — the remote analogue of the local attach path's isProcessAlive.
+ * Empty stdout means "no live daemon", which is a normal outcome, not an error.
+ */
+async function readRemoteRunFile(
+	spawn: SpawnFn,
+	workspace: RemoteWorkspace,
+	control: { path: string } | null,
+): Promise<{ pid: number; port: number } | null> {
+	const script = [
+		'f="$HOME/.ao/running.json"',
+		'[ -f "$f" ] || exit 0',
+		`p=$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\\([0-9][0-9]*\\).*/\\1/p' "$f" | head -n 1)`,
+		'[ -n "$p" ] && kill -0 "$p" 2>/dev/null && cat "$f"',
+	].join("; ");
+
+	const result = await runSsh(
+		spawn,
+		remoteCommandArgv({ sshTarget: workspace.sshTarget, control, script }),
+		REMOTE_COMMAND_TIMEOUT_MS,
+	);
+	if (result.exitCode !== 0) {
+		throw new RemoteWorkspaceError(classifySshFailure(result.exitCode, result.stderr, workspace.sshTarget));
+	}
+	const info = parseRunFile(result.stdout.trim());
+	return info ? { pid: info.pid, port: info.port } : null;
+}
+
+/** Poll the remote run-file until a freshly started daemon publishes its port. */
+async function pollRemoteRunFile(
+	spawn: SpawnFn,
+	workspace: RemoteWorkspace,
+	control: { path: string } | null,
+	delay: (ms: number) => Promise<void>,
+	now: () => number,
+): Promise<{ pid: number; port: number } | null> {
+	const deadline = now() + START_READY_TIMEOUT_MS;
+	for (;;) {
+		const live = await readRemoteRunFile(spawn, workspace, control);
+		if (live) return live;
+		if (now() >= deadline) return null;
+		await delay(RUN_FILE_POLL_INTERVAL_MS);
+	}
+}
+
 export async function connectRemoteWorkspace(
 	workspace: RemoteWorkspace,
 	deps: RemoteWorkspaceDeps,
@@ -272,13 +328,30 @@ export async function connectRemoteWorkspace(
 	const allocatePort = deps.allocatePort ?? allocateLoopbackPort;
 	const delay = deps.delay ?? defaultDelay;
 	const now = deps.now ?? Date.now;
-	const remotePort = workspace.remotePort ?? DEFAULT_DAEMON_PORT;
 	const control = resolveControl(deps.controlDir, workspace.sshTarget);
 
 	await preflight(spawn, workspace, control);
 
+	// The run-file is always the authority on the port. A configured
+	// remotePort is only a preference handed to a daemon we start: AO_PORT is a
+	// request, and a daemon that finds it taken binds elsewhere and says so.
+	let live = await readRemoteRunFile(spawn, workspace, control);
+	const started = live === null;
+	if (!live) {
+		await startRemoteDaemon(spawn, workspace, control, workspace.remotePort ?? null);
+		live = await pollRemoteRunFile(spawn, workspace, control, delay, now);
+	}
+	if (!live) {
+		throw new RemoteWorkspaceError({
+			kind: "remote_command_failed",
+			message: `Started \`ao daemon\` on ${workspace.sshTarget}, but it never reported a listening port.`,
+			details: `See ~/.ao/daemon.log on ${workspace.sshTarget}.`,
+		});
+	}
+	const remotePort = live.port;
+
 	const localPort = await allocatePort();
-	const tunnel = spawn("ssh", tunnelArgv({ sshTarget: workspace.sshTarget, control, localPort, remotePort }));
+	const tunnel = spawn("ssh", tunnelArgv({ sshTarget: workspace.sshTarget, localPort, remotePort }));
 
 	// `ssh -N` normally stays silent and running; anything it prints is a
 	// diagnosis for a connect that is about to fail its probes, so keep the tail.
@@ -302,24 +375,20 @@ export async function connectRemoteWorkspace(
 	});
 
 	try {
-		if (await waitForReady(deps.probe, localPort, ATTACH_PROBE_TIMEOUT_MS, delay, now)) {
-			return { localPort, remotePort, started: false, closed, dispose };
+		if (!(await waitForReady(deps.probe, localPort, TUNNEL_READY_TIMEOUT_MS, delay, now))) {
+			// The daemon was confirmed listening before the tunnel was opened, so a
+			// failure here is the forward's, not the daemon's.
+			throw new RemoteWorkspaceError(
+				gone
+					? classifySshFailure(null, tunnelStderr, workspace.sshTarget)
+					: {
+							kind: "unreachable",
+							message: `Opened a tunnel to ${workspace.sshTarget}, but its daemon did not answer on port ${remotePort}.`,
+							details: tunnelStderr.trim(),
+						},
+			);
 		}
-		// Nothing answered. Distinguish "the tunnel itself failed" from "the tunnel
-		// is fine, no daemon is listening yet" — starting a daemon over a dead
-		// transport would only produce a second, more confusing failure.
-		if (gone) {
-			throw new RemoteWorkspaceError(classifySshFailure(null, tunnelStderr, workspace.sshTarget));
-		}
-		await startRemoteDaemon(spawn, workspace, control, remotePort);
-		if (!(await waitForReady(deps.probe, localPort, START_READY_TIMEOUT_MS, delay, now))) {
-			throw new RemoteWorkspaceError({
-				kind: "remote_command_failed",
-				message: `Started \`ao daemon\` on ${workspace.sshTarget}, but it never became ready.`,
-				details: `${tunnelStderr}\nSee ~/.ao/daemon.log on ${workspace.sshTarget}.`.trim(),
-			});
-		}
-		return { localPort, remotePort, started: true, closed, dispose };
+		return { localPort, remotePort, started, closed, dispose };
 	} catch (error) {
 		dispose();
 		throw error;

--- a/frontend/src/main/ssh-config.ts
+++ b/frontend/src/main/ssh-config.ts
@@ -1,0 +1,75 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { dedupeSshHosts, parseSshConfig, type SshConfigHost } from "../shared/ssh-config";
+
+/** Depth cap for Include chains: ssh allows nesting, and a cycle must not hang the UI. */
+const MAX_INCLUDE_DEPTH = 4;
+/** Upper bound on files read, so a pathological glob cannot stall the picker. */
+const MAX_FILES = 64;
+
+/**
+ * Expand one Include path. ssh resolves a relative Include against ~/.ssh, and
+ * supports globs, which are common in the `Include config.d/*` idiom.
+ *
+ * Only a trailing `*` is expanded — the case people actually write. Anything
+ * fancier is skipped rather than half-supported, because this list is a
+ * convenience and ssh remains the authority on what a target resolves to.
+ */
+async function expandInclude(pattern: string, homeDir: string): Promise<string[]> {
+	const absolute = pattern.startsWith("~/")
+		? path.join(homeDir, pattern.slice(2))
+		: path.isAbsolute(pattern)
+			? pattern
+			: path.join(homeDir, ".ssh", pattern);
+
+	if (!absolute.includes("*")) return [absolute];
+
+	const dir = path.dirname(absolute);
+	const base = path.basename(absolute);
+	if (base.indexOf("*") !== base.length - 1) return [];
+	const prefix = base.slice(0, -1);
+	try {
+		const entries = await readdir(dir, { withFileTypes: true });
+		return entries
+			.filter((entry) => entry.isFile() && entry.name.startsWith(prefix))
+			.map((entry) => path.join(dir, entry.name));
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Read the user's ssh_config Host aliases, following Include directives.
+ *
+ * Never throws: an absent, unreadable or malformed config means the picker
+ * shows nothing and the user types a target by hand, which is exactly the
+ * behaviour without this feature. It is read-only — AO does not write
+ * ssh_config, the same way it does not write known_hosts.
+ */
+export async function readSshConfigHosts(homeDir: string): Promise<SshConfigHost[]> {
+	const visited = new Set<string>();
+	const lists: SshConfigHost[][] = [];
+
+	const walk = async (file: string, depth: number): Promise<void> => {
+		if (depth > MAX_INCLUDE_DEPTH || visited.size >= MAX_FILES || visited.has(file)) return;
+		visited.add(file);
+
+		let text: string;
+		try {
+			text = await readFile(file, "utf8");
+		} catch {
+			return;
+		}
+
+		const { hosts, includes } = parseSshConfig(text);
+		lists.push(hosts);
+		for (const include of includes) {
+			for (const resolved of await expandInclude(include, homeDir)) {
+				await walk(resolved, depth + 1);
+			}
+		}
+	};
+
+	await walk(path.join(homeDir, ".ssh", "config"), 0);
+	return dedupeSshHosts(lists);
+}

--- a/frontend/src/main/workspace-registry.test.ts
+++ b/frontend/src/main/workspace-registry.test.ts
@@ -1,0 +1,105 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	addRemoteWorkspace,
+	LOCAL_WORKSPACE_ID,
+	readWorkspaceRegistry,
+	removeRemoteWorkspace,
+	setActiveWorkspace,
+	WORKSPACES_FILE_NAME,
+	WorkspaceRegistryError,
+} from "./workspace-registry";
+
+const vm = { id: "build-vm", sshTarget: "build-vm" };
+const gpu = { id: "gpu", sshTarget: "deepak@10.0.0.5" };
+
+let stateDir: string;
+
+beforeEach(async () => {
+	stateDir = await mkdtemp(path.join(tmpdir(), "ao-workspaces-"));
+});
+
+const registryFile = () => path.join(stateDir, WORKSPACES_FILE_NAME);
+
+describe("readWorkspaceRegistry", () => {
+	it("returns the default when the file is absent", async () => {
+		expect(await readWorkspaceRegistry(stateDir)).toEqual({ remotes: [] });
+	});
+
+	// A hand-mangled or half-written file must never stop the app from booting
+	// into the local workspace, which is the incumbent behaviour.
+	it.each(["", "{", '{"remotes": "nope"}'])("falls back to the default for %j", async (contents) => {
+		await writeFile(registryFile(), contents);
+		expect(await readWorkspaceRegistry(stateDir)).toEqual({ remotes: [] });
+	});
+});
+
+describe("addRemoteWorkspace", () => {
+	it("persists a workspace atomically and reads it back", async () => {
+		await addRemoteWorkspace(stateDir, vm);
+		expect(await readWorkspaceRegistry(stateDir)).toEqual({ remotes: [vm] });
+		expect(JSON.parse(await readFile(registryFile(), "utf8"))).toEqual({ remotes: [vm] });
+	});
+
+	it("rejects an invalid entry before touching the file", async () => {
+		await expect(addRemoteWorkspace(stateDir, { id: "LOCAL", sshTarget: "h" })).rejects.toBeInstanceOf(
+			WorkspaceRegistryError,
+		);
+		expect(await readWorkspaceRegistry(stateDir)).toEqual({ remotes: [] });
+	});
+
+	it("rejects a duplicate id rather than overwriting a working target", async () => {
+		await addRemoteWorkspace(stateDir, vm);
+		await expect(addRemoteWorkspace(stateDir, { ...vm, sshTarget: "impostor" })).rejects.toThrow(/already exists/);
+		expect((await readWorkspaceRegistry(stateDir)).remotes).toEqual([vm]);
+	});
+
+	// Two IPC calls arriving together must not lose one another through a
+	// read-then-write race; every mutation runs on the serialising queue.
+	it("serialises concurrent adds", async () => {
+		await Promise.all([addRemoteWorkspace(stateDir, vm), addRemoteWorkspace(stateDir, gpu)]);
+		const registry = await readWorkspaceRegistry(stateDir);
+		expect(registry.remotes.map((remote) => remote.id).sort()).toEqual(["build-vm", "gpu"]);
+	});
+});
+
+describe("setActiveWorkspace", () => {
+	it("persists a remote and an explicit local alike", async () => {
+		await addRemoteWorkspace(stateDir, vm);
+		expect((await setActiveWorkspace(stateDir, "build-vm")).activeId).toBe("build-vm");
+		expect((await setActiveWorkspace(stateDir, LOCAL_WORKSPACE_ID)).activeId).toBe(LOCAL_WORKSPACE_ID);
+	});
+
+	it("refuses an unknown id", async () => {
+		await expect(setActiveWorkspace(stateDir, "ghost")).rejects.toThrow(/Unknown workspace/);
+	});
+});
+
+describe("removeRemoteWorkspace", () => {
+	it("removes an inactive workspace and leaves the active one alone", async () => {
+		await addRemoteWorkspace(stateDir, vm);
+		await addRemoteWorkspace(stateDir, gpu);
+		await setActiveWorkspace(stateDir, "build-vm");
+
+		const registry = await removeRemoteWorkspace(stateDir, "gpu");
+		expect(registry).toEqual({ activeId: "build-vm", remotes: [vm] });
+	});
+
+	// Falling back to an explicit local, not to undefined: undefined would
+	// re-arm the single-remote auto-select and move the user onto whatever VM
+	// happens to be left.
+	it("pins local when the active workspace is the one removed", async () => {
+		await addRemoteWorkspace(stateDir, vm);
+		await addRemoteWorkspace(stateDir, gpu);
+		await setActiveWorkspace(stateDir, "gpu");
+
+		const registry = await removeRemoteWorkspace(stateDir, "gpu");
+		expect(registry).toEqual({ activeId: LOCAL_WORKSPACE_ID, remotes: [vm] });
+	});
+
+	it("refuses an unknown id", async () => {
+		await expect(removeRemoteWorkspace(stateDir, "ghost")).rejects.toThrow(/Unknown workspace/);
+	});
+});

--- a/frontend/src/main/workspace-registry.ts
+++ b/frontend/src/main/workspace-registry.ts
@@ -1,0 +1,129 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+	coerceWorkspaceRegistry,
+	DEFAULT_WORKSPACE_REGISTRY,
+	LOCAL_WORKSPACE_ID,
+	validateRemoteWorkspace,
+	type RemoteWorkspace,
+	type WorkspaceRegistry,
+} from "../shared/workspaces";
+
+export { LOCAL_WORKSPACE_ID } from "../shared/workspaces";
+export type { RemoteWorkspace, WorkspaceRegistry } from "../shared/workspaces";
+
+/**
+ * File holding the remote-workspace registry under the ~/.ao state dir.
+ *
+ * Supervisor state, not daemon state: it names which daemons this client can
+ * connect to, so it cannot live in any one daemon's SQLite — reaching the
+ * registry must not require the machine it points at to be up. The precedent is
+ * the other supervisor-owned JSON under ~/.ao (running.json, mobile/config.json,
+ * ui-settings.json), and it holds no credentials: an SSH target is a hostname,
+ * and key material stays with the user's own ssh client.
+ */
+export const WORKSPACES_FILE_NAME = "workspaces.json";
+
+let registryOperationQueue: Promise<void> = Promise.resolve();
+
+function registryFile(stateDir: string): string {
+	return path.join(stateDir, WORKSPACES_FILE_NAME);
+}
+
+async function readRegistryUnlocked(stateDir: string): Promise<WorkspaceRegistry> {
+	let raw: string;
+	try {
+		raw = await readFile(registryFile(stateDir), "utf8");
+	} catch {
+		return { ...DEFAULT_WORKSPACE_REGISTRY };
+	}
+	try {
+		return coerceWorkspaceRegistry(JSON.parse(raw));
+	} catch {
+		// A truncated or hand-mangled file must not stop the app from booting into
+		// the local workspace, which is exactly the incumbent behaviour.
+		return { ...DEFAULT_WORKSPACE_REGISTRY };
+	}
+}
+
+async function writeRegistryUnlocked(stateDir: string, registry: WorkspaceRegistry): Promise<WorkspaceRegistry> {
+	const next = coerceWorkspaceRegistry(registry);
+	await mkdir(stateDir, { recursive: true, mode: 0o750 });
+	const data = `${JSON.stringify(next, null, 2)}\n`;
+	const tmp = path.join(stateDir, `.workspaces-${process.pid}-${Date.now()}.json`);
+	await writeFile(tmp, data, { mode: 0o600 });
+	await rename(tmp, registryFile(stateDir));
+	return next;
+}
+
+function runRegistryOperation<T>(operation: () => Promise<T>): Promise<T> {
+	const queued = registryOperationQueue.then(operation, operation);
+	registryOperationQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	return queued;
+}
+
+/** Read the registry, tolerating a missing or corrupt file (returns defaults). */
+export async function readWorkspaceRegistry(stateDir: string): Promise<WorkspaceRegistry> {
+	return readRegistryUnlocked(stateDir);
+}
+
+/**
+ * Read-modify-write the registry under the serialising queue, so two IPC calls
+ * arriving together cannot lose one another's edit through a read-then-write
+ * race. The mutator may throw to abort without writing.
+ */
+async function updateWorkspaceRegistry(
+	stateDir: string,
+	mutate: (current: WorkspaceRegistry) => WorkspaceRegistry,
+): Promise<WorkspaceRegistry> {
+	return runRegistryOperation(async () => {
+		const current = await readRegistryUnlocked(stateDir);
+		return writeRegistryUnlocked(stateDir, mutate(current));
+	});
+}
+
+/** Thrown for user-correctable registry edits; the message is surfaced verbatim. */
+export class WorkspaceRegistryError extends Error {}
+
+/** Register a remote workspace. Rejects a duplicate id rather than overwriting. */
+export async function addRemoteWorkspace(stateDir: string, input: RemoteWorkspace): Promise<WorkspaceRegistry> {
+	const invalid = validateRemoteWorkspace(input);
+	if (invalid) throw new WorkspaceRegistryError(invalid.message);
+	return updateWorkspaceRegistry(stateDir, (current) => {
+		if (current.remotes.some((remote) => remote.id === input.id.trim())) {
+			throw new WorkspaceRegistryError(`Workspace "${input.id.trim()}" already exists.`);
+		}
+		return { ...current, remotes: [...current.remotes, input] };
+	});
+}
+
+/**
+ * Remove a remote workspace. Removing the active one falls back to an explicit
+ * `local` rather than to undefined: the user is mid-session on this client, and
+ * silently re-triggering the single-remote auto-select would move them onto a
+ * different VM.
+ */
+export async function removeRemoteWorkspace(stateDir: string, id: string): Promise<WorkspaceRegistry> {
+	return updateWorkspaceRegistry(stateDir, (current) => {
+		const remotes = current.remotes.filter((remote) => remote.id !== id);
+		if (remotes.length === current.remotes.length) {
+			throw new WorkspaceRegistryError(`Unknown workspace "${id}".`);
+		}
+		return current.activeId === id
+			? { activeId: LOCAL_WORKSPACE_ID, remotes }
+			: { ...current, remotes };
+	});
+}
+
+/** Point the client at a workspace. `local` is a valid, persisted choice. */
+export async function setActiveWorkspace(stateDir: string, id: string): Promise<WorkspaceRegistry> {
+	return updateWorkspaceRegistry(stateDir, (current) => {
+		if (id !== LOCAL_WORKSPACE_ID && !current.remotes.some((remote) => remote.id === id)) {
+			throw new WorkspaceRegistryError(`Unknown workspace "${id}".`);
+		}
+		return { ...current, activeId: id };
+	});
+}

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -7,6 +7,7 @@ import type {
 	BrowserTabsState,
 } from "./main/browser-view-host";
 import type { DaemonStatus } from "./shared/daemon-status";
+import type { RemoteWorkspace, WorkspaceRegistry } from "./shared/workspaces";
 import type { TelemetryBootstrap } from "./shared/telemetry";
 import type { MigrationState } from "./main/app-state";
 import type { UpdateSettings, UpdateStatus } from "./main/update-settings";
@@ -166,6 +167,15 @@ const api = {
 				ipcRenderer.off("daemon:status", wrapped);
 			};
 		},
+	},
+	// Which machine the client runs agents on. `setActive` also repoints the
+	// connection, so the renderer learns the new daemon port through the ordinary
+	// `daemon:status` event rather than from this call's return value.
+	workspaces: {
+		list: () => ipcRenderer.invoke("workspaces:list") as Promise<WorkspaceRegistry>,
+		add: (workspace: RemoteWorkspace) => ipcRenderer.invoke("workspaces:add", workspace) as Promise<WorkspaceRegistry>,
+		remove: (id: string) => ipcRenderer.invoke("workspaces:remove", id) as Promise<WorkspaceRegistry>,
+		setActive: (id: string) => ipcRenderer.invoke("workspaces:setActive", id) as Promise<WorkspaceRegistry>,
 	},
 	telemetry: {
 		getBootstrap: () => ipcRenderer.invoke("telemetry:getBootstrap") as Promise<TelemetryBootstrap | null>,

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -8,6 +8,7 @@ import type {
 } from "./main/browser-view-host";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { RemoteWorkspace, WorkspaceRegistry } from "./shared/workspaces";
+import type { SshConfigHost } from "./shared/ssh-config";
 import type { TelemetryBootstrap } from "./shared/telemetry";
 import type { MigrationState } from "./main/app-state";
 import type { UpdateSettings, UpdateStatus } from "./main/update-settings";
@@ -173,6 +174,7 @@ const api = {
 	// `daemon:status` event rather than from this call's return value.
 	workspaces: {
 		list: () => ipcRenderer.invoke("workspaces:list") as Promise<WorkspaceRegistry>,
+		sshHosts: () => ipcRenderer.invoke("workspaces:sshHosts") as Promise<SshConfigHost[]>,
 		add: (workspace: RemoteWorkspace) => ipcRenderer.invoke("workspaces:add", workspace) as Promise<WorkspaceRegistry>,
 		remove: (id: string) => ipcRenderer.invoke("workspaces:remove", id) as Promise<WorkspaceRegistry>,
 		setActive: (id: string) => ipcRenderer.invoke("workspaces:setActive", id) as Promise<WorkspaceRegistry>,

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -64,6 +64,13 @@ vi.mock("../lib/bridge", () => ({
 		app: { getVersion, openExternal },
 		clipboard: { writeText },
 		daemon: { getStatus: getDaemonStatus },
+		workspaces: {
+			list: async () => ({ remotes: [] }),
+			sshHosts: async () => [],
+			add: async () => ({ remotes: [] }),
+			remove: async () => ({ remotes: [] }),
+			setActive: async () => ({ remotes: [] }),
+		},
 		updateSettings: { get: getUpdate, set: setUpdate },
 		uiSettings: { get: getUiSettings, set: setUiSettings },
 		keybindings: {

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -10,11 +10,18 @@ import { SettingsSection } from "./settings/SettingsSection";
 import { UpdatesSection } from "./settings/UpdatesSection";
 import { DevSettingsSection } from "./settings/DevSettingsSection";
 import { KeyboardShortcutsSettingsDialog } from "./settings/KeyboardShortcutsSettingsDialog";
+import { WorkspacesSection } from "./settings/WorkspacesSection";
+import { useShellMaybe } from "../lib/shell-context";
 
 export type GlobalSettingsSection = "general" | "updates" | "developer" | "help" | "all";
 
 export function GlobalSettingsForm({ section = "all" }: { section?: GlobalSettingsSection }) {
 	const { t } = useTranslation();
+	// Read the shell's existing status rather than mounting a second
+	// useDaemonStatus: that hook owns the event transport and the polling loop,
+	// and a duplicate would run both twice. Settings can render outside the
+	// shell, so the status is optional.
+	const daemonStatus = useShellMaybe()?.daemonStatus ?? { state: "stopped" as const };
 	const [mobileOpen, setMobileOpen] = useState(false);
 	const [reportProblemOpen, setReportProblemOpen] = useState(false);
 	const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
@@ -35,6 +42,7 @@ export function GlobalSettingsForm({ section = "all" }: { section?: GlobalSettin
 							onConnectMobile={() => setMobileOpen(true)}
 							titleHidden={leadingTitleHidden}
 						/>
+						<WorkspacesSection daemonStatus={daemonStatus} />
 						<SettingsSection title={t("settings.preferences")}>
 							<SettingsLinkRow
 								icon={Keyboard}

--- a/frontend/src/renderer/components/settings/WorkspacesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/WorkspacesSection.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceRegistry } from "../../../shared/workspaces";
+import { WorkspacesSection } from "./WorkspacesSection";
+
+const vm = { id: "build-vm", sshTarget: "build-vm" };
+
+const bridge = {
+	list: vi.fn<[], Promise<WorkspaceRegistry>>(),
+	add: vi.fn<[unknown], Promise<WorkspaceRegistry>>(),
+	remove: vi.fn<[string], Promise<WorkspaceRegistry>>(),
+	setActive: vi.fn<[string], Promise<WorkspaceRegistry>>(),
+};
+
+vi.mock("../../lib/bridge", () => ({
+	aoBridge: {
+		get workspaces() {
+			return bridge;
+		},
+	},
+}));
+
+async function renderSection(registry: WorkspaceRegistry, daemonStatus = { state: "ready" as const, port: 51234 }) {
+	bridge.list.mockResolvedValue(registry);
+	await act(async () => {
+		render(<WorkspacesSection daemonStatus={daemonStatus} />);
+		await Promise.resolve();
+	});
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("WorkspacesSection", () => {
+	it("always offers the local workspace, even with none registered", async () => {
+		await renderSection({ remotes: [] });
+		expect(screen.getByRole("button", { name: /this computer/i })).toHaveAttribute("aria-pressed", "true");
+	});
+
+	it("lists a registered workspace by its ssh target", async () => {
+		await renderSection({ activeId: "local", remotes: [vm] });
+		expect(screen.getByRole("button", { name: /^build-vm/ })).toBeInTheDocument();
+	});
+
+	// The supervisor auto-connects a single registered remote when the user has
+	// never chosen, so showing "This computer" as selected would be a lie.
+	it("marks the single registered remote as selected when nothing was ever chosen", async () => {
+		await renderSection({ remotes: [vm] });
+		expect(screen.getByRole("button", { name: /^build-vm/ })).toHaveAttribute("aria-pressed", "true");
+		expect(screen.getByRole("button", { name: /this computer/i })).toHaveAttribute("aria-pressed", "false");
+	});
+
+	// ...and an explicit "Local" must survive, or registering one VM silently
+	// moves the user's work onto it.
+	it("keeps local selected when local was chosen explicitly", async () => {
+		await renderSection({ activeId: "local", remotes: [vm] });
+		expect(screen.getByRole("button", { name: /this computer/i })).toHaveAttribute("aria-pressed", "true");
+	});
+
+	it("switches workspace through the supervisor", async () => {
+		bridge.setActive.mockResolvedValue({ activeId: "build-vm", remotes: [vm] });
+		await renderSection({ activeId: "local", remotes: [vm] });
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /^build-vm/ }));
+		});
+		expect(bridge.setActive).toHaveBeenCalledWith("build-vm");
+	});
+
+	it("validates a new workspace inline before the supervisor is called", async () => {
+		await renderSection({ remotes: [] });
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /add a remote workspace/i }));
+		});
+
+		fireEvent.change(screen.getByLabelText(/workspace name/i), { target: { value: "Build VM" } });
+		fireEvent.change(screen.getByLabelText(/ssh target/i), { target: { value: "build-vm" } });
+
+		expect(screen.getByRole("alert")).toHaveTextContent(/lowercase letters/i);
+		expect(screen.getByRole("button", { name: /^add$/i })).toBeDisabled();
+		expect(bridge.add).not.toHaveBeenCalled();
+	});
+
+	it("adds a valid workspace and closes the form", async () => {
+		bridge.add.mockResolvedValue({ remotes: [vm] });
+		await renderSection({ remotes: [] });
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /add a remote workspace/i }));
+		});
+
+		fireEvent.change(screen.getByLabelText(/workspace name/i), { target: { value: "build-vm" } });
+		fireEvent.change(screen.getByLabelText(/ssh target/i), { target: { value: "build-vm" } });
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+		});
+
+		expect(bridge.add).toHaveBeenCalledWith(vm);
+		await waitFor(() => expect(screen.queryByLabelText(/workspace name/i)).not.toBeInTheDocument());
+	});
+
+	it("surfaces a rejected add without closing the form", async () => {
+		bridge.add.mockRejectedValue(new Error('Workspace "build-vm" already exists.'));
+		await renderSection({ remotes: [] });
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /add a remote workspace/i }));
+		});
+		fireEvent.change(screen.getByLabelText(/workspace name/i), { target: { value: "build-vm" } });
+		fireEvent.change(screen.getByLabelText(/ssh target/i), { target: { value: "build-vm" } });
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+		});
+
+		expect(screen.getByText(/already exists/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/workspace name/i)).toBeInTheDocument();
+	});
+
+	// The remedy lives in the message (accept the host key, load your key,
+	// install `ao` there); an icon-only failure would strand the user.
+	it("shows the connection failure message on the selected workspace", async () => {
+		await renderSection(
+			{ activeId: "build-vm", remotes: [vm] },
+			{ state: "error", message: "build-vm is not in your known_hosts." } as never,
+		);
+		expect(screen.getByText(/not in your known_hosts/i)).toBeInTheDocument();
+	});
+
+	it("removes a workspace through the supervisor", async () => {
+		bridge.remove.mockResolvedValue({ remotes: [] });
+		await renderSection({ activeId: "local", remotes: [vm] });
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /remove build-vm/i }));
+		});
+		expect(bridge.remove).toHaveBeenCalledWith("build-vm");
+	});
+
+	it("offers no way to remove the local workspace", async () => {
+		await renderSection({ remotes: [] });
+		expect(screen.queryByRole("button", { name: /remove/i })).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/renderer/components/settings/WorkspacesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/WorkspacesSection.test.tsx
@@ -10,10 +10,10 @@ import { WorkspacesSection } from "./WorkspacesSection";
 const vm = { id: "build-vm", sshTarget: "build-vm" };
 
 const bridge = {
-	list: vi.fn<[], Promise<WorkspaceRegistry>>(),
-	add: vi.fn<[unknown], Promise<WorkspaceRegistry>>(),
-	remove: vi.fn<[string], Promise<WorkspaceRegistry>>(),
-	setActive: vi.fn<[string], Promise<WorkspaceRegistry>>(),
+	list: vi.fn<() => Promise<WorkspaceRegistry>>(),
+	add: vi.fn<(workspace: unknown) => Promise<WorkspaceRegistry>>(),
+	remove: vi.fn<(id: string) => Promise<WorkspaceRegistry>>(),
+	setActive: vi.fn<(id: string) => Promise<WorkspaceRegistry>>(),
 };
 
 vi.mock("../../lib/bridge", () => ({

--- a/frontend/src/renderer/components/settings/WorkspacesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/WorkspacesSection.test.tsx
@@ -14,6 +14,7 @@ const bridge = {
 	add: vi.fn<(workspace: unknown) => Promise<WorkspaceRegistry>>(),
 	remove: vi.fn<(id: string) => Promise<WorkspaceRegistry>>(),
 	setActive: vi.fn<(id: string) => Promise<WorkspaceRegistry>>(),
+	sshHosts: vi.fn<() => Promise<{ alias: string; hostName?: string }[]>>(),
 };
 
 vi.mock("../../lib/bridge", () => ({
@@ -24,8 +25,13 @@ vi.mock("../../lib/bridge", () => ({
 	},
 }));
 
-async function renderSection(registry: WorkspaceRegistry, daemonStatus = { state: "ready" as const, port: 51234 }) {
+async function renderSection(
+	registry: WorkspaceRegistry,
+	daemonStatus = { state: "ready" as const, port: 51234 },
+	hosts: { alias: string; hostName?: string }[] = [],
+) {
 	bridge.list.mockResolvedValue(registry);
+	bridge.sshHosts.mockResolvedValue(hosts);
 	await act(async () => {
 		render(<WorkspacesSection daemonStatus={daemonStatus} />);
 		await Promise.resolve();
@@ -136,6 +142,45 @@ describe("WorkspacesSection", () => {
 			fireEvent.click(screen.getByRole("button", { name: /remove build-vm/i }));
 		});
 		expect(bridge.remove).toHaveBeenCalledWith("build-vm");
+	});
+
+	// The point of the picker: a target you already have in ~/.ssh/config should
+	// be a click, not a retyped hostname.
+	it("offers ssh_config aliases and fills both fields from one click", async () => {
+		await renderSection({ remotes: [] }, undefined, [{ alias: "dev-training-vm", hostName: "10.0.0.8" }]);
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /add a remote workspace/i }));
+		});
+
+		await act(async () => {
+			fireEvent.click(await screen.findByRole("button", { name: "dev-training-vm" }));
+		});
+		expect(screen.getByLabelText(/ssh target/i)).toHaveValue("dev-training-vm");
+		// The id is coerced to the registry's stricter rules, so the form is valid
+		// immediately rather than opening pre-filled with something rejected.
+		expect(screen.getByLabelText(/workspace name/i)).toHaveValue("dev-training-vm");
+		expect(screen.getByRole("button", { name: /^add$/i })).toBeEnabled();
+	});
+
+	it("stops overwriting the name once the user has typed one", async () => {
+		await renderSection({ remotes: [] }, undefined, [{ alias: "gpu" }]);
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /add a remote workspace/i }));
+		});
+		fireEvent.change(screen.getByLabelText(/workspace name/i), { target: { value: "mine" } });
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "gpu" }));
+		});
+		expect(screen.getByLabelText(/workspace name/i)).toHaveValue("mine");
+	});
+
+	it("hides aliases that are already registered", async () => {
+		await renderSection({ remotes: [vm] }, undefined, [{ alias: "build-vm" }, { alias: "gpu" }]);
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: /add a remote workspace/i }));
+		});
+		expect(screen.queryByRole("button", { name: "build-vm" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "gpu" })).toBeInTheDocument();
 	});
 
 	it("offers no way to remove the local workspace", async () => {

--- a/frontend/src/renderer/components/settings/WorkspacesSection.tsx
+++ b/frontend/src/renderer/components/settings/WorkspacesSection.tsx
@@ -1,0 +1,217 @@
+import { useState } from "react";
+import { Check, Laptop, Loader2, Plus, Server, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { LOCAL_WORKSPACE_ID, validateRemoteWorkspace, workspaceLabel } from "../../../shared/workspaces";
+import type { DaemonStatus } from "../../../shared/daemon-status";
+import { useWorkspaces } from "../../hooks/useWorkspaces";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { cn } from "../../lib/utils";
+import { SettingsSection } from "./SettingsSection";
+
+/**
+ * Pick the machine agents run on.
+ *
+ * Each workspace runs its own AO daemon; selecting one repoints this client at
+ * it over SSH. Only the selected workspace's state is shown anywhere in the app,
+ * so this row is the single place the answer to "where is my work happening"
+ * lives — which is why the connection status is rendered inline on the row
+ * rather than left to the daemon banner.
+ */
+export function WorkspacesSection({ daemonStatus, titleHidden }: { daemonStatus: DaemonStatus; titleHidden?: boolean }) {
+	const { t } = useTranslation();
+	const { registry, activeId, error, add, remove, setActive, clearError } = useWorkspaces();
+	const [adding, setAdding] = useState(false);
+
+	const rows = [
+		{ id: LOCAL_WORKSPACE_ID, label: t("workspaces.local"), detail: t("workspaces.localHint"), removable: false },
+		...registry.remotes.map((remote) => ({
+			id: remote.id,
+			label: workspaceLabel(remote),
+			detail: remote.sshTarget,
+			removable: true,
+		})),
+	];
+
+	return (
+		<SettingsSection title={t("workspaces.title")} sectionId="workspaces" titleHidden={titleHidden}>
+			{rows.map((row) => (
+				<WorkspaceRow
+					key={row.id}
+					{...row}
+					selected={row.id === activeId}
+					// The daemon status describes whichever workspace is selected, so it
+					// is only meaningful on that row.
+					status={row.id === activeId ? daemonStatus : undefined}
+					onSelect={() => void setActive(row.id)}
+					onRemove={() => void remove(row.id)}
+				/>
+			))}
+
+			{adding ? (
+				<AddWorkspaceForm
+					onCancel={() => {
+						clearError();
+						setAdding(false);
+					}}
+					onSubmit={async (workspace) => {
+						if (await add(workspace)) setAdding(false);
+					}}
+				/>
+			) : (
+				<button
+					type="button"
+					onClick={() => setAdding(true)}
+					className="settings-row-bar w-full text-left transition-colors hover:bg-settings-menu-selected"
+				>
+					<div className="flex shrink-0 items-center gap-(--size-settings-row-icon-gap)">
+						<Plus className="size-icon-lg shrink-0 text-settings-muted" aria-hidden="true" />
+						<span className="whitespace-nowrap text-sm leading-5 text-settings-label">{t("workspaces.add")}</span>
+					</div>
+				</button>
+			)}
+
+			{error ? (
+				<p role="alert" className="px-1 text-xs leading-4 text-destructive">
+					{error}
+				</p>
+			) : null}
+		</SettingsSection>
+	);
+}
+
+function WorkspaceRow({
+	id,
+	label,
+	detail,
+	removable,
+	selected,
+	status,
+	onSelect,
+	onRemove,
+}: {
+	id: string;
+	label: string;
+	detail: string;
+	removable: boolean;
+	selected: boolean;
+	status?: DaemonStatus;
+	onSelect: () => void;
+	onRemove: () => void;
+}) {
+	const { t } = useTranslation();
+	const Icon = id === LOCAL_WORKSPACE_ID ? Laptop : Server;
+
+	return (
+		<div className={cn("settings-row-bar", selected && "bg-settings-menu-selected")}>
+			<button
+				type="button"
+				aria-pressed={selected}
+				onClick={onSelect}
+				className="flex min-w-0 flex-1 items-center gap-(--size-settings-row-icon-gap) text-left"
+			>
+				<Icon className="size-icon-lg shrink-0 text-settings-muted" aria-hidden="true" />
+				<span className="min-w-0 flex-1">
+					<span className="block truncate text-sm leading-5 text-settings-label">{label}</span>
+					<span className="block truncate text-xs leading-4 text-settings-muted">{detail}</span>
+				</span>
+				{selected ? <ConnectionState status={status} /> : null}
+			</button>
+			{removable ? (
+				<button
+					type="button"
+					onClick={onRemove}
+					aria-label={t("workspaces.removeAria", { name: label })}
+					className="ml-2 shrink-0 rounded p-1 text-settings-muted transition-colors hover:text-destructive"
+				>
+					<Trash2 className="size-icon-base" aria-hidden="true" />
+				</button>
+			) : null}
+		</div>
+	);
+}
+
+/**
+ * The selected workspace's connection state. A failure is shown as text here
+ * and not merely as an icon: for a remote workspace the message carries the
+ * remedy (accept the host key, load your key, install `ao` there), and losing
+ * it would leave the user with a silent, unexplained disconnection.
+ */
+function ConnectionState({ status }: { status?: DaemonStatus }) {
+	const { t } = useTranslation();
+	if (!status) return null;
+
+	if (status.state === "starting") {
+		return (
+			<span className="ml-2 flex shrink-0 items-center gap-1 text-xs text-settings-muted">
+				<Loader2 className="size-icon-base animate-spin" aria-hidden="true" />
+				{t("workspaces.connecting")}
+			</span>
+		);
+	}
+	if (status.state === "ready") {
+		return (
+			<span className="ml-2 flex shrink-0 items-center gap-1 text-xs text-settings-muted">
+				<Check className="size-icon-base" aria-hidden="true" />
+				{t("workspaces.connected")}
+			</span>
+		);
+	}
+	return <span className="ml-2 max-w-[18rem] shrink-0 truncate text-xs text-destructive">{status.message}</span>;
+}
+
+function AddWorkspaceForm({
+	onCancel,
+	onSubmit,
+}: {
+	onCancel: () => void;
+	onSubmit: (workspace: { id: string; sshTarget: string }) => void;
+}) {
+	const { t } = useTranslation();
+	const [id, setId] = useState("");
+	const [sshTarget, setSshTarget] = useState("");
+	// Validated with the same function the supervisor uses, so the inline
+	// message and the persisted rejection can never disagree.
+	const invalid = validateRemoteWorkspace({ id, sshTarget });
+	const touched = id !== "" || sshTarget !== "";
+
+	return (
+		<form
+			className="flex w-full flex-col gap-2 rounded-md bg-settings-menu-selected/50 p-3"
+			onSubmit={(event) => {
+				event.preventDefault();
+				if (!invalid) onSubmit({ id: id.trim(), sshTarget: sshTarget.trim() });
+			}}
+		>
+			<div className="flex gap-2">
+				<Input
+					value={id}
+					onChange={(event) => setId(event.target.value)}
+					placeholder={t("workspaces.idPlaceholder")}
+					aria-label={t("workspaces.id")}
+					autoFocus
+				/>
+				<Input
+					value={sshTarget}
+					onChange={(event) => setSshTarget(event.target.value)}
+					placeholder={t("workspaces.targetPlaceholder")}
+					aria-label={t("workspaces.target")}
+				/>
+			</div>
+			<p className="text-xs leading-4 text-settings-muted">{t("workspaces.targetHint")}</p>
+			{touched && invalid ? (
+				<p role="alert" className="text-xs leading-4 text-destructive">
+					{invalid.message}
+				</p>
+			) : null}
+			<div className="flex justify-end gap-2">
+				<Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+					{t("workspaces.cancel")}
+				</Button>
+				<Button type="submit" size="sm" disabled={Boolean(invalid)}>
+					{t("workspaces.save")}
+				</Button>
+			</div>
+		</form>
+	);
+}

--- a/frontend/src/renderer/components/settings/WorkspacesSection.tsx
+++ b/frontend/src/renderer/components/settings/WorkspacesSection.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Check, Laptop, Loader2, Plus, Server, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { LOCAL_WORKSPACE_ID, validateRemoteWorkspace, workspaceLabel } from "../../../shared/workspaces";
+import { workspaceIdFromAlias, type SshConfigHost } from "../../../shared/ssh-config";
 import type { DaemonStatus } from "../../../shared/daemon-status";
 import { useWorkspaces } from "../../hooks/useWorkspaces";
 import { Button } from "../ui/button";
@@ -20,7 +21,7 @@ import { SettingsSection } from "./SettingsSection";
  */
 export function WorkspacesSection({ daemonStatus, titleHidden }: { daemonStatus: DaemonStatus; titleHidden?: boolean }) {
 	const { t } = useTranslation();
-	const { registry, activeId, error, add, remove, setActive, clearError } = useWorkspaces();
+	const { registry, sshHosts, activeId, error, add, remove, setActive, clearError } = useWorkspaces();
 	const [adding, setAdding] = useState(false);
 
 	const rows = [
@@ -50,6 +51,7 @@ export function WorkspacesSection({ daemonStatus, titleHidden }: { daemonStatus:
 
 			{adding ? (
 				<AddWorkspaceForm
+					sshHosts={sshHosts.filter((host) => !registry.remotes.some((remote) => remote.sshTarget === host.alias))}
 					onCancel={() => {
 						clearError();
 						setAdding(false);
@@ -161,15 +163,26 @@ function ConnectionState({ status }: { status?: DaemonStatus }) {
 }
 
 function AddWorkspaceForm({
+	sshHosts,
 	onCancel,
 	onSubmit,
 }: {
+	sshHosts: SshConfigHost[];
 	onCancel: () => void;
 	onSubmit: (workspace: { id: string; sshTarget: string }) => void;
 }) {
 	const { t } = useTranslation();
 	const [id, setId] = useState("");
 	const [sshTarget, setSshTarget] = useState("");
+	// Whether the user has named the workspace themselves. Until they do,
+	// picking a host also fills the id, so the common case is one click; once
+	// they type a name we stop overwriting it.
+	const [idTouched, setIdTouched] = useState(false);
+
+	const pickHost = (alias: string) => {
+		setSshTarget(alias);
+		if (!idTouched) setId(workspaceIdFromAlias(alias));
+	};
 	// Validated with the same function the supervisor uses, so the inline
 	// message and the persisted rejection can never disagree.
 	const invalid = validateRemoteWorkspace({ id, sshTarget });
@@ -183,10 +196,35 @@ function AddWorkspaceForm({
 				if (!invalid) onSubmit({ id: id.trim(), sshTarget: sshTarget.trim() });
 			}}
 		>
+			{sshHosts.length > 0 ? (
+				<div className="flex flex-col gap-1.5">
+					<span className="text-xs leading-4 text-settings-muted">{t("workspaces.fromSshConfig")}</span>
+					<div className="flex max-h-40 flex-wrap gap-1.5 overflow-y-auto">
+						{sshHosts.map((host) => (
+							<button
+								key={host.alias}
+								type="button"
+								onClick={() => pickHost(host.alias)}
+								title={host.hostName}
+								aria-pressed={sshTarget === host.alias}
+								className={cn(
+									"rounded-md border border-transparent bg-input/50 px-2 py-1 text-xs text-settings-label transition-colors hover:bg-settings-menu-selected",
+									sshTarget === host.alias && "border-ring bg-settings-menu-selected",
+								)}
+							>
+								{host.alias}
+							</button>
+						))}
+					</div>
+				</div>
+			) : null}
 			<div className="flex gap-2">
 				<Input
 					value={id}
-					onChange={(event) => setId(event.target.value)}
+					onChange={(event) => {
+						setIdTouched(true);
+						setId(event.target.value);
+					}}
 					placeholder={t("workspaces.idPlaceholder")}
 					aria-label={t("workspaces.id")}
 					autoFocus

--- a/frontend/src/renderer/hooks/useWorkspaces.ts
+++ b/frontend/src/renderer/hooks/useWorkspaces.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useState } from "react";
+import { aoBridge } from "../lib/bridge";
+import { LOCAL_WORKSPACE_ID, resolveWorkspace, type RemoteWorkspace, type WorkspaceRegistry } from "../../shared/workspaces";
+
+/**
+ * The remote-workspace registry, as the settings UI sees it.
+ *
+ * Mutations go through the supervisor, which owns both the file and the SSH
+ * tunnel. Selecting a workspace does not return the new connection state: the
+ * supervisor repoints the client and the result arrives on the ordinary
+ * `daemon:status` channel, the same one a local daemon start uses. That is
+ * deliberate — the UI has exactly one source of truth for "which daemon am I
+ * talking to, and is it up".
+ */
+export function useWorkspaces() {
+	const [registry, setRegistry] = useState<WorkspaceRegistry>({ remotes: [] });
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		try {
+			setRegistry(await aoBridge.workspaces.list());
+			setError(null);
+		} catch {
+			// IPC unavailable (browser preview, broken preload): remote workspaces
+			// need the Electron supervisor, so an empty registry is the honest state.
+			setRegistry({ remotes: [] });
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		void load();
+	}, [load]);
+
+	// Every mutation reports its own failure rather than throwing: these are
+	// user-correctable (duplicate id, bad target), not exceptions.
+	const run = useCallback(async (operation: () => Promise<WorkspaceRegistry>): Promise<boolean> => {
+		setError(null);
+		try {
+			setRegistry(await operation());
+			return true;
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : String(cause));
+			return false;
+		}
+	}, []);
+
+	return {
+		registry,
+		loading,
+		error,
+		/** The workspace the client is pointed at, resolved the same way the supervisor resolves it. */
+		activeId: activeWorkspaceId(registry),
+		add: useCallback((workspace: RemoteWorkspace) => run(() => aoBridge.workspaces.add(workspace)), [run]),
+		remove: useCallback((id: string) => run(() => aoBridge.workspaces.remove(id)), [run]),
+		setActive: useCallback((id: string) => run(() => aoBridge.workspaces.setActive(id)), [run]),
+		clearError: useCallback(() => setError(null), []),
+	};
+}
+
+/**
+ * Which workspace is in effect — not merely which one is persisted. With one
+ * remote registered and no explicit choice, the supervisor connects to it, so
+ * the UI must show that rather than a misleading "Local".
+ */
+export function activeWorkspaceId(registry: WorkspaceRegistry): string {
+	const resolved = resolveWorkspace(registry);
+	if ("error" in resolved) return LOCAL_WORKSPACE_ID;
+	return resolved.workspace?.id ?? LOCAL_WORKSPACE_ID;
+}

--- a/frontend/src/renderer/hooks/useWorkspaces.ts
+++ b/frontend/src/renderer/hooks/useWorkspaces.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { aoBridge } from "../lib/bridge";
 import { LOCAL_WORKSPACE_ID, resolveWorkspace, type RemoteWorkspace, type WorkspaceRegistry } from "../../shared/workspaces";
+import type { SshConfigHost } from "../../shared/ssh-config";
 
 /**
  * The remote-workspace registry, as the settings UI sees it.
@@ -14,6 +15,7 @@ import { LOCAL_WORKSPACE_ID, resolveWorkspace, type RemoteWorkspace, type Worksp
  */
 export function useWorkspaces() {
 	const [registry, setRegistry] = useState<WorkspaceRegistry>({ remotes: [] });
+	const [sshHosts, setSshHosts] = useState<SshConfigHost[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 
@@ -32,6 +34,16 @@ export function useWorkspaces() {
 
 	useEffect(() => {
 		void load();
+		// Best-effort, and deliberately inside the promise chain: an absent or
+		// unreadable ssh_config just means an empty picker and a hand-typed
+		// target. The bridge section itself can also be missing (browser preview,
+		// or a renderer hot-reloaded against an older preload), and that must
+		// degrade the picker rather than throw out of the effect and blank the
+		// whole settings page.
+		void Promise.resolve()
+			.then(() => aoBridge.workspaces.sshHosts())
+			.then(setSshHosts)
+			.catch(() => setSshHosts([]));
 	}, [load]);
 
 	// Every mutation reports its own failure rather than throwing: these are
@@ -49,6 +61,7 @@ export function useWorkspaces() {
 
 	return {
 		registry,
+		sshHosts,
 		loading,
 		error,
 		/** The workspace the client is pointed at, resolved the same way the supervisor resolves it. */

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -874,9 +874,7 @@
 	"zone.done": "Beendet",
 	"zone.merge": "Bereit zum Mergen",
 	"zone.pending": "In Review",
-	"zone.working": "In Arbeit"
-
-,
+	"zone.working": "In Arbeit",
 	"settings.developer": "Developer",
 	"settings.help": "Help",
 	"settings.navSectionsAria": "Settings sections",
@@ -899,5 +897,19 @@
 	"settings.dev.activitySpreadLabel": "Activity spread (min)",
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
-	"settings.dev.resetReload": "Reset & Reload"
+	"settings.dev.resetReload": "Reset & Reload",
+	"workspaces.title": "Arbeitsbereich",
+	"workspaces.local": "Dieser Computer",
+	"workspaces.localHint": "Agenten laufen lokal",
+	"workspaces.add": "Entfernten Arbeitsbereich hinzufugen",
+	"workspaces.id": "Name des Arbeitsbereichs",
+	"workspaces.idPlaceholder": "build-vm",
+	"workspaces.target": "SSH-Ziel",
+	"workspaces.targetPlaceholder": "benutzer@host",
+	"workspaces.targetHint": "Ein Host, den du bereits per ssh erreichst. Ein Host-Alias aus ~/.ssh/config ist am besten.",
+	"workspaces.removeAria": "{{name}} entfernen",
+	"workspaces.connecting": "Verbinden",
+	"workspaces.connected": "Verbunden",
+	"workspaces.cancel": "Abbrechen",
+	"workspaces.save": "Hinzufugen"
 }

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -911,5 +911,6 @@
 	"workspaces.connecting": "Verbinden",
 	"workspaces.connected": "Verbunden",
 	"workspaces.cancel": "Abbrechen",
-	"workspaces.save": "Hinzufugen"
+	"workspaces.save": "Hinzufugen",
+	"workspaces.fromSshConfig": "Aus deiner ~/.ssh/config"
 }

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -879,5 +879,19 @@
 	"zone.done": "Terminated",
 	"zone.merge": "Ready to merge",
 	"zone.pending": "In review",
-	"zone.working": "Working"
+	"zone.working": "Working",
+	"workspaces.title": "Workspace",
+	"workspaces.local": "This computer",
+	"workspaces.localHint": "Agents run locally",
+	"workspaces.add": "Add a remote workspace",
+	"workspaces.id": "Workspace name",
+	"workspaces.idPlaceholder": "build-vm",
+	"workspaces.target": "SSH target",
+	"workspaces.targetPlaceholder": "user@host",
+	"workspaces.targetHint": "A host you can already reach with ssh. A Host alias from ~/.ssh/config works best.",
+	"workspaces.removeAria": "Remove {{name}}",
+	"workspaces.connecting": "Connecting",
+	"workspaces.connected": "Connected",
+	"workspaces.cancel": "Cancel",
+	"workspaces.save": "Add"
 }

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -893,5 +893,6 @@
 	"workspaces.connecting": "Connecting",
 	"workspaces.connected": "Connected",
 	"workspaces.cancel": "Cancel",
-	"workspaces.save": "Add"
+	"workspaces.save": "Add",
+	"workspaces.fromSshConfig": "From your ~/.ssh/config"
 }

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -887,9 +887,7 @@
 	"zone.done": "Terminado",
 	"zone.merge": "Listo para fusionar",
 	"zone.pending": "En revisión",
-	"zone.working": "Trabajando"
-
-,
+	"zone.working": "Trabajando",
 	"settings.developer": "Developer",
 	"settings.help": "Help",
 	"settings.navSectionsAria": "Settings sections",
@@ -913,5 +911,19 @@
 	"settings.dev.activitySpreadLabel": "Activity spread (min)",
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
-	"settings.dev.resetReload": "Reset & Reload"
+	"settings.dev.resetReload": "Reset & Reload",
+	"workspaces.title": "Espacio de trabajo",
+	"workspaces.local": "Este ordenador",
+	"workspaces.localHint": "Los agentes se ejecutan localmente",
+	"workspaces.add": "Anadir un espacio remoto",
+	"workspaces.id": "Nombre del espacio",
+	"workspaces.idPlaceholder": "build-vm",
+	"workspaces.target": "Destino SSH",
+	"workspaces.targetPlaceholder": "usuario@host",
+	"workspaces.targetHint": "Un host al que ya puedas conectarte con ssh. Un alias Host de ~/.ssh/config funciona mejor.",
+	"workspaces.removeAria": "Eliminar {{name}}",
+	"workspaces.connecting": "Conectando",
+	"workspaces.connected": "Conectado",
+	"workspaces.cancel": "Cancelar",
+	"workspaces.save": "Anadir"
 }

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -925,5 +925,6 @@
 	"workspaces.connecting": "Conectando",
 	"workspaces.connected": "Conectado",
 	"workspaces.cancel": "Cancelar",
-	"workspaces.save": "Anadir"
+	"workspaces.save": "Anadir",
+	"workspaces.fromSshConfig": "De tu ~/.ssh/config"
 }

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -887,9 +887,7 @@
 	"zone.done": "Terminé",
 	"zone.merge": "Prêt à fusionner",
 	"zone.pending": "En revue",
-	"zone.working": "En cours"
-
-,
+	"zone.working": "En cours",
 	"settings.developer": "Developer",
 	"settings.help": "Help",
 	"settings.navSectionsAria": "Settings sections",
@@ -913,5 +911,19 @@
 	"settings.dev.activitySpreadLabel": "Activity spread (min)",
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
-	"settings.dev.resetReload": "Reset & Reload"
+	"settings.dev.resetReload": "Reset & Reload",
+	"workspaces.title": "Espace de travail",
+	"workspaces.local": "Cet ordinateur",
+	"workspaces.localHint": "Les agents s'executent en local",
+	"workspaces.add": "Ajouter un espace distant",
+	"workspaces.id": "Nom de l'espace",
+	"workspaces.idPlaceholder": "build-vm",
+	"workspaces.target": "Cible SSH",
+	"workspaces.targetPlaceholder": "utilisateur@hote",
+	"workspaces.targetHint": "Un hote deja joignable avec ssh. Un alias Host de ~/.ssh/config est preferable.",
+	"workspaces.removeAria": "Supprimer {{name}}",
+	"workspaces.connecting": "Connexion",
+	"workspaces.connected": "Connecte",
+	"workspaces.cancel": "Annuler",
+	"workspaces.save": "Ajouter"
 }

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -925,5 +925,6 @@
 	"workspaces.connecting": "Connexion",
 	"workspaces.connected": "Connecte",
 	"workspaces.cancel": "Annuler",
-	"workspaces.save": "Ajouter"
+	"workspaces.save": "Ajouter",
+	"workspaces.fromSshConfig": "Depuis votre ~/.ssh/config"
 }

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -874,9 +874,7 @@
 	"zone.done": "終了済み",
 	"zone.merge": "マージ準備完了",
 	"zone.pending": "レビュー中",
-	"zone.working": "作業中"
-
-,
+	"zone.working": "作業中",
 	"settings.developer": "Developer",
 	"settings.help": "Help",
 	"settings.navSectionsAria": "Settings sections",
@@ -899,5 +897,19 @@
 	"settings.dev.activitySpreadLabel": "Activity spread (min)",
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
-	"settings.dev.resetReload": "Reset & Reload"
+	"settings.dev.resetReload": "Reset & Reload",
+	"workspaces.title": "ワークスペース",
+	"workspaces.local": "このコンピュータ",
+	"workspaces.localHint": "エージェントはローカルで実行されます",
+	"workspaces.add": "リモートワークスペースを追加",
+	"workspaces.id": "ワークスペース名",
+	"workspaces.idPlaceholder": "build-vm",
+	"workspaces.target": "SSH 接続先",
+	"workspaces.targetPlaceholder": "user@host",
+	"workspaces.targetHint": "すでに ssh で接続できるホスト。~/.ssh/config の Host エイリアスが最適です。",
+	"workspaces.removeAria": "{{name}} を削除",
+	"workspaces.connecting": "接続中",
+	"workspaces.connected": "接続済み",
+	"workspaces.cancel": "キャンセル",
+	"workspaces.save": "追加"
 }

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -911,5 +911,6 @@
 	"workspaces.connecting": "接続中",
 	"workspaces.connected": "接続済み",
 	"workspaces.cancel": "キャンセル",
-	"workspaces.save": "追加"
+	"workspaces.save": "追加",
+	"workspaces.fromSshConfig": "~/.ssh/config から"
 }

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -874,9 +874,7 @@
 	"zone.done": "종료됨",
 	"zone.merge": "병합 준비 완료",
 	"zone.pending": "리뷰 중",
-	"zone.working": "작업 중"
-
-,
+	"zone.working": "작업 중",
 	"settings.developer": "Developer",
 	"settings.help": "Help",
 	"settings.navSectionsAria": "Settings sections",
@@ -899,5 +897,19 @@
 	"settings.dev.activitySpreadLabel": "Activity spread (min)",
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
-	"settings.dev.resetReload": "Reset & Reload"
+	"settings.dev.resetReload": "Reset & Reload",
+	"workspaces.title": "작업 공간",
+	"workspaces.local": "이 컴퓨터",
+	"workspaces.localHint": "에이전트가 로컬에서 실행됩니다",
+	"workspaces.add": "원격 작업 공간 추가",
+	"workspaces.id": "작업 공간 이름",
+	"workspaces.idPlaceholder": "build-vm",
+	"workspaces.target": "SSH 대상",
+	"workspaces.targetPlaceholder": "user@host",
+	"workspaces.targetHint": "이미 ssh로 접속할 수 있는 호스트입니다. ~/.ssh/config의 Host 별칭을 권장합니다.",
+	"workspaces.removeAria": "{{name}} 제거",
+	"workspaces.connecting": "연결 중",
+	"workspaces.connected": "연결됨",
+	"workspaces.cancel": "취소",
+	"workspaces.save": "추가"
 }

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -911,5 +911,6 @@
 	"workspaces.connecting": "연결 중",
 	"workspaces.connected": "연결됨",
 	"workspaces.cancel": "취소",
-	"workspaces.save": "추가"
+	"workspaces.save": "추가",
+	"workspaces.fromSshConfig": "~/.ssh/config에서"
 }

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -887,9 +887,7 @@
 	"zone.done": "Encerrado",
 	"zone.merge": "Pronto para merge",
 	"zone.pending": "Em revisão",
-	"zone.working": "Em andamento"
-
-,
+	"zone.working": "Em andamento",
 	"settings.developer": "Developer",
 	"settings.help": "Help",
 	"settings.navSectionsAria": "Settings sections",
@@ -913,5 +911,19 @@
 	"settings.dev.activitySpreadLabel": "Activity spread (min)",
 	"settings.dev.activitySpreadAria": "Activity spread in minutes",
 	"settings.dev.resetDefaultsLabel": "Reset defaults",
-	"settings.dev.resetReload": "Reset & Reload"
+	"settings.dev.resetReload": "Reset & Reload",
+	"workspaces.title": "Espaco de trabalho",
+	"workspaces.local": "Este computador",
+	"workspaces.localHint": "Os agentes rodam localmente",
+	"workspaces.add": "Adicionar espaco remoto",
+	"workspaces.id": "Nome do espaco",
+	"workspaces.idPlaceholder": "build-vm",
+	"workspaces.target": "Destino SSH",
+	"workspaces.targetPlaceholder": "usuario@host",
+	"workspaces.targetHint": "Um host que voce ja alcanca com ssh. Um alias Host do ~/.ssh/config funciona melhor.",
+	"workspaces.removeAria": "Remover {{name}}",
+	"workspaces.connecting": "Conectando",
+	"workspaces.connected": "Conectado",
+	"workspaces.cancel": "Cancelar",
+	"workspaces.save": "Adicionar"
 }

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -925,5 +925,6 @@
 	"workspaces.connecting": "Conectando",
 	"workspaces.connected": "Conectado",
 	"workspaces.cancel": "Cancelar",
-	"workspaces.save": "Adicionar"
+	"workspaces.save": "Adicionar",
+	"workspaces.fromSshConfig": "Do seu ~/.ssh/config"
 }

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -879,5 +879,19 @@
 	"settings.dev.activitySpreadLabel": "活动分布（分钟）",
 	"settings.dev.activitySpreadAria": "活动分布（分钟）",
 	"settings.dev.resetDefaultsLabel": "重置默认值",
-	"settings.dev.resetReload": "重置并重新加载"
+	"settings.dev.resetReload": "重置并重新加载",
+	"workspaces.title": "工作区",
+	"workspaces.local": "本机",
+	"workspaces.localHint": "代理在本地运行",
+	"workspaces.add": "添加远程工作区",
+	"workspaces.id": "工作区名称",
+	"workspaces.idPlaceholder": "build-vm",
+	"workspaces.target": "SSH 目标",
+	"workspaces.targetPlaceholder": "user@host",
+	"workspaces.targetHint": "一台你已经可以用 ssh 连接的主机。建议使用 ~/.ssh/config 中的 Host 别名。",
+	"workspaces.removeAria": "移除 {{name}}",
+	"workspaces.connecting": "正在连接",
+	"workspaces.connected": "已连接",
+	"workspaces.cancel": "取消",
+	"workspaces.save": "添加"
 }

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -893,5 +893,6 @@
 	"workspaces.connecting": "正在连接",
 	"workspaces.connected": "已连接",
 	"workspaces.cancel": "取消",
-	"workspaces.save": "添加"
+	"workspaces.save": "添加",
+	"workspaces.fromSshConfig": "来自 ~/.ssh/config"
 }

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -146,6 +146,14 @@ export const aoBridge: AoBridge =
 			get: async () => ({ locale: "en" as const }),
 			set: async (settings) => ({ locale: coerceLocale(settings.locale) }),
 		},
+		// Remote workspaces need the Electron supervisor to hold the SSH tunnel,
+		// so the browser fallback is always the local workspace with none listed.
+		workspaces: {
+			list: async () => ({ remotes: [] }),
+			add: async () => ({ remotes: [] }),
+			remove: async () => ({ remotes: [] }),
+			setActive: async () => ({ remotes: [] }),
+		},
 		keybindings: {
 			get: async () => ({}),
 			set: async (overrides) => overrides,

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -150,6 +150,7 @@ export const aoBridge: AoBridge =
 		// so the browser fallback is always the local workspace with none listed.
 		workspaces: {
 			list: async () => ({ remotes: [] }),
+			sshHosts: async () => [],
 			add: async () => ({ remotes: [] }),
 			remove: async () => ({ remotes: [] }),
 			setActive: async () => ({ remotes: [] }),

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -190,6 +190,12 @@ if (typeof window !== "undefined") {
 				locale: settings.locale as "en",
 			}),
 		},
+		workspaces: {
+			list: async () => ({ remotes: [] }),
+			add: async () => ({ remotes: [] }),
+			remove: async () => ({ remotes: [] }),
+			setActive: async () => ({ remotes: [] }),
+		},
 		keybindings: {
 			get: async () => ({}),
 			set: async (overrides) => overrides,

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -192,6 +192,7 @@ if (typeof window !== "undefined") {
 		},
 		workspaces: {
 			list: async () => ({ remotes: [] }),
+			sshHosts: async () => [],
 			add: async () => ({ remotes: [] }),
 			remove: async () => ({ remotes: [] }),
 			setActive: async () => ({ remotes: [] }),

--- a/frontend/src/shared/daemon-status.ts
+++ b/frontend/src/shared/daemon-status.ts
@@ -13,10 +13,26 @@ export type DaemonFailureCode =
 	| "port_unconfirmed"
 	| "not_ready"
 	| "identity_mismatch"
-	| "datadir_unwritable";
+	| "datadir_unwritable"
+	// Remote-workspace failures. Each is a distinct remedy, and none of them is
+	// evidence that the remote daemon is down — a broken tunnel must never be
+	// reported as a dead daemon.
+	| "ssh_missing"
+	| "host_unreachable"
+	| "host_key_changed"
+	| "host_key_unverified"
+	| "host_auth_failed"
+	| "remote_ao_missing";
 
 export type DaemonStatus = {
 	state: "starting" | "ready" | "stopped" | "error";
+	/**
+	 * The workspace this status describes: `local`, or a registered remote id.
+	 * `port` is always a loopback port on *this* machine — for a remote
+	 * workspace it is the local end of an SSH forward, which is what lets the
+	 * renderer address a remote daemon with no changes at all.
+	 */
+	workspaceId?: string;
 	port?: number;
 	pid?: number;
 	executablePath?: string;

--- a/frontend/src/shared/ssh-command.test.ts
+++ b/frontend/src/shared/ssh-command.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+	CONTROL_PATH_MAX_BYTES,
+	controlPath,
+	controlPathFits,
+	remoteCommandArgv,
+	shellQuote,
+	sshControlFlags,
+	tunnelArgv,
+} from "./ssh-command";
+
+const control = { path: "/home/u/.ao/ssh/m-deadbeef" };
+
+describe("sshControlFlags", () => {
+	// Asserted verbatim: each flag is load-bearing and the order is part of the
+	// contract these tests exist to pin.
+	it("emits the full multiplexed block in fixed order", () => {
+		expect(sshControlFlags(control)).toEqual([
+			"-o",
+			"ControlMaster=auto",
+			"-o",
+			"ControlPath=/home/u/.ao/ssh/m-deadbeef",
+			"-o",
+			"ControlPersist=60",
+			"-o",
+			"ConnectTimeout=5",
+			"-o",
+			"BatchMode=yes",
+			"-o",
+			"ServerAliveInterval=15",
+			"-o",
+			"ServerAliveCountMax=3",
+			"-o",
+			"LogLevel=ERROR",
+		]);
+	});
+
+	it("omits only the ControlMaster options when unmultiplexed", () => {
+		expect(sshControlFlags(null)).toEqual(sshControlFlags(control).slice(6));
+	});
+
+	// BatchMode is what turns an unknown host key into an immediate failure
+	// instead of an unanswerable prompt on a tty-less supervisor.
+	it("always sets BatchMode", () => {
+		expect(sshControlFlags(null)).toContain("BatchMode=yes");
+	});
+
+	// Setting this at all is the bypass the design refuses.
+	it("never sets StrictHostKeyChecking", () => {
+		expect(sshControlFlags(control).join(" ")).not.toContain("StrictHostKeyChecking");
+	});
+});
+
+describe("controlPath", () => {
+	it("is stable and fixed-width per target", () => {
+		const first = controlPath("/home/u/.ao/ssh", "build-vm");
+		expect(first).toBe(controlPath("/home/u/.ao/ssh/", "build-vm"));
+		expect(first).toMatch(/^\/home\/u\/\.ao\/ssh\/m-[0-9a-f]{8}$/);
+	});
+
+	it("distinguishes targets", () => {
+		expect(controlPath("/d", "a")).not.toBe(controlPath("/d", "b"));
+	});
+
+	it("measures the sockaddr_un budget in bytes, not characters", () => {
+		const nonAscii = `/${"é".repeat(CONTROL_PATH_MAX_BYTES - 10)}`;
+		expect(nonAscii.length).toBeLessThan(CONTROL_PATH_MAX_BYTES);
+		expect(controlPathFits(controlPath(nonAscii, "vm"))).toBe(false);
+		expect(controlPathFits(controlPath("/tmp", "vm"))).toBe(true);
+	});
+});
+
+describe("tunnelArgv", () => {
+	it("forwards a local port to the remote loopback and runs no remote command", () => {
+		expect(tunnelArgv({ sshTarget: "build-vm", control, localPort: 51234, remotePort: 3001 })).toEqual([
+			...sshControlFlags(control),
+			"-N",
+			"-L",
+			"51234:127.0.0.1:3001",
+			"build-vm",
+		]);
+	});
+
+	// The remote daemon binds 127.0.0.1; a remote resolver that maps `localhost`
+	// to ::1 first would have the forward refused.
+	it("targets 127.0.0.1 rather than localhost", () => {
+		const argv = tunnelArgv({ sshTarget: "vm", control: null, localPort: 1, remotePort: 2 });
+		expect(argv).toContain("1:127.0.0.1:2");
+		expect(argv.join(" ")).not.toContain("localhost");
+	});
+
+	it("puts the target last so nothing can be read as a flag to it", () => {
+		expect(tunnelArgv({ sshTarget: "vm", control, localPort: 1, remotePort: 2 }).at(-1)).toBe("vm");
+	});
+});
+
+describe("remoteCommandArgv", () => {
+	// sshd runs a remote command with the account's login shell; fish and csh do
+	// not parse POSIX scripts, so /bin/sh is interposed unconditionally.
+	it("always interposes /bin/sh -c", () => {
+		expect(remoteCommandArgv({ sshTarget: "vm", control, script: "ao daemon" })).toEqual([
+			...sshControlFlags(control),
+			"vm",
+			"/bin/sh",
+			"-c",
+			"ao daemon",
+		]);
+	});
+
+	it("passes the script as one argv element, so no local shell is involved", () => {
+		const argv = remoteCommandArgv({ sshTarget: "vm", control: null, script: "a; b && c > /dev/null" });
+		expect(argv.at(-1)).toBe("a; b && c > /dev/null");
+	});
+});
+
+describe("shellQuote", () => {
+	it.each([
+		["plain", "'plain'"],
+		["with space", "'with space'"],
+		["$HOME", "'$HOME'"],
+		["`id`", "'`id`'"],
+		["a'b", `'a'\\''b'`],
+	])("quotes %j", (input, expected) => {
+		expect(shellQuote(input)).toBe(expected);
+	});
+
+	// The three-layer case: a workspace path containing a space, a quote and a
+	// dollar sign, interpolated into a script that ssh hands to /bin/sh.
+	it("survives interpolation into a remote script", () => {
+		const script = `cd -- ${shellQuote(`/home/u/it's $HOME dir`)} && pwd -P`;
+		expect(script).toBe(`cd -- '/home/u/it'\\''s $HOME dir' && pwd -P`);
+	});
+});

--- a/frontend/src/shared/ssh-command.test.ts
+++ b/frontend/src/shared/ssh-command.test.ts
@@ -103,13 +103,31 @@ describe("remoteCommandArgv", () => {
 			"vm",
 			"/bin/sh",
 			"-c",
-			"ao daemon",
+			"'ao daemon'",
 		]);
 	});
 
-	it("passes the script as one argv element, so no local shell is involved", () => {
+	// Regression, found against a real host: ssh joins everything after the
+	// target into one string and the remote login shell re-splits it, so an
+	// unquoted `command -v ao` arrived as `/bin/sh -c command -v ao` and ran the
+	// no-op `command` builtin — exit 0, no output, every probe passing vacuously.
+	it("quotes the script so it survives the remote shell's re-parse", () => {
+		expect(remoteCommandArgv({ sshTarget: "vm", control: null, script: "command -v ao" }).at(-1)).toBe(
+			"'command -v ao'",
+		);
+	});
+
+	it("keeps operators inside the quoted script rather than leaking them to the remote shell", () => {
 		const argv = remoteCommandArgv({ sshTarget: "vm", control: null, script: "a; b && c > /dev/null" });
-		expect(argv.at(-1)).toBe("a; b && c > /dev/null");
+		expect(argv.at(-1)).toBe("'a; b && c > /dev/null'");
+	});
+
+	// The script already contains shellQuote'd values; the escape must nest.
+	it("nests correctly around values the script itself quoted", () => {
+		const script = `AO_PORT=${shellQuote("4100")}; export AO_PORT`;
+		const sent = remoteCommandArgv({ sshTarget: "vm", control: null, script }).at(-1) ?? "";
+		// What the remote shell yields after stripping one layer of quoting.
+		expect(sent.slice(1, -1).replaceAll(`'\\''`, "'")).toBe(script);
 	});
 });
 

--- a/frontend/src/shared/ssh-command.test.ts
+++ b/frontend/src/shared/ssh-command.test.ts
@@ -72,8 +72,12 @@ describe("controlPath", () => {
 
 describe("tunnelArgv", () => {
 	it("forwards a local port to the remote loopback and runs no remote command", () => {
-		expect(tunnelArgv({ sshTarget: "build-vm", control, localPort: 51234, remotePort: 3001 })).toEqual([
-			...sshControlFlags(control),
+		expect(tunnelArgv({ sshTarget: "build-vm", localPort: 51234, remotePort: 3001 })).toEqual([
+			"-o",
+			"ControlMaster=no",
+			"-o",
+			"ControlPath=none",
+			...sshControlFlags(null),
 			"-N",
 			"-L",
 			"51234:127.0.0.1:3001",
@@ -81,16 +85,28 @@ describe("tunnelArgv", () => {
 		]);
 	});
 
+	// Regression, found against a real host: ControlMaster=auto + ControlPersist
+	// makes ssh fork the master to the background and exit 0 in the foreground.
+	// The supervisor would read that as the tunnel dying while the forward was
+	// still alive in a process it could no longer kill — leaking both. Passed
+	// explicitly because the user's ~/.ssh/config may set ControlMaster globally.
+	it("never multiplexes the tunnel, so the process cannot fork away from the forward", () => {
+		const argv = tunnelArgv({ sshTarget: "vm", localPort: 1, remotePort: 2 });
+		expect(argv).toContain("ControlMaster=no");
+		expect(argv).toContain("ControlPath=none");
+		expect(argv.join(" ")).not.toContain("ControlPersist");
+	});
+
 	// The remote daemon binds 127.0.0.1; a remote resolver that maps `localhost`
 	// to ::1 first would have the forward refused.
 	it("targets 127.0.0.1 rather than localhost", () => {
-		const argv = tunnelArgv({ sshTarget: "vm", control: null, localPort: 1, remotePort: 2 });
+		const argv = tunnelArgv({ sshTarget: "vm", localPort: 1, remotePort: 2 });
 		expect(argv).toContain("1:127.0.0.1:2");
 		expect(argv.join(" ")).not.toContain("localhost");
 	});
 
 	it("puts the target last so nothing can be read as a flag to it", () => {
-		expect(tunnelArgv({ sshTarget: "vm", control, localPort: 1, remotePort: 2 }).at(-1)).toBe("vm");
+		expect(tunnelArgv({ sshTarget: "vm", localPort: 1, remotePort: 2 }).at(-1)).toBe("vm");
 	});
 });
 

--- a/frontend/src/shared/ssh-command.ts
+++ b/frontend/src/shared/ssh-command.ts
@@ -1,0 +1,178 @@
+// Pure argv builders for every `ssh` invocation AO makes.
+//
+// Kept separate from the process plumbing (main/ssh-tunnel.ts) and free of
+// node:*/electron so the flag block can be asserted verbatim in unit tests. The
+// flags are load-bearing, not hygiene — each one is justified below, in the
+// house style of the tmux adapter's flag rationale.
+//
+// AO shells out to the user's own ssh client and never embeds an SSH library:
+// no key material, no passphrase prompts it cannot answer, no known_hosts
+// policy of its own, and ~/.ssh/config (ProxyJump, Match, Include,
+// IdentityAgent) keeps working for free. This is the same call docs/stack.md
+// makes for git over go-git.
+//
+// No node:* imports here, deliberately: the vite-plugin-electron-renderer
+// polyfill breaks them under vitest (see daemon-attach.ts), and these builders
+// are exercised directly by the renderer's tests.
+
+/** Seconds ssh keeps a multiplexed master alive after the last client exits. */
+const CONTROL_PERSIST_SECONDS = 60;
+/** Seconds ssh waits for the TCP connect before giving up. */
+export const CONNECT_TIMEOUT_SECONDS = 5;
+/**
+ * Protocol keepalives: 15s × 3 surfaces a genuinely dead peer (laptop sleep,
+ * wifi drop, VM reboot) as a connection error in ~45s instead of an indefinite
+ * stall, and they run regardless of data so an idle tunnel stays up.
+ */
+const SERVER_ALIVE_INTERVAL_SECONDS = 15;
+const SERVER_ALIVE_COUNT_MAX = 3;
+
+/**
+ * A Unix socket path is capped at 104 bytes on Darwin and 108 on Linux, and
+ * OpenSSH fails the whole connection when ControlPath exceeds it. Hashing the
+ * target keeps the basename fixed-width; the caller degrades to a shorter
+ * directory past this budget rather than hard-failing.
+ */
+export const CONTROL_PATH_MAX_BYTES = 100;
+
+/**
+ * FNV-1a, 32-bit, rendered as 8 hex chars. This is a *uniqueness* hash for a
+ * socket filename, not a security boundary — the ControlPath is already inside
+ * a 0700 directory — so a non-cryptographic hash with no node:crypto dependency
+ * is the right tool. Two targets colliding would share a master connection;
+ * with 2^32 buckets over a handful of registered hosts that is not a real risk.
+ */
+function shortHash(value: string): string {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < value.length; i += 1) {
+		hash ^= value.charCodeAt(i);
+		// FNV prime 16777619, via shifts so the intermediate stays in int32.
+		hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+	}
+	return hash.toString(16).padStart(8, "0");
+}
+
+/**
+ * The ControlMaster socket for a target. Note this is a persistent, always-warm,
+ * authenticated remote-shell credential that AO creates and keeps alive: `0700`
+ * on the containing directory is the entire access control, and ControlPersist
+ * is the exposure window after the last use.
+ *
+ * OpenSSH's own `%C` token is deliberately unused — it expands inside ssh,
+ * after we would have built the path, which defeats the length check.
+ */
+export function controlPath(controlDir: string, sshTarget: string): string {
+	return `${controlDir.replace(/\/+$/, "")}/m-${shortHash(sshTarget)}`;
+}
+
+/**
+ * True when `controlPath` fits in the platform's sockaddr_un budget. Measured in
+ * UTF-8 bytes, not characters: a non-ASCII home directory costs more than its
+ * length suggests, and the kernel counts bytes.
+ */
+export function controlPathFits(candidate: string): boolean {
+	return new TextEncoder().encode(candidate).length <= CONTROL_PATH_MAX_BYTES;
+}
+
+/**
+ * The shared flag block, in fixed order so tests can assert it verbatim.
+ *
+ * - **ControlMaster/Path/Persist** — one authenticated TCP connection per host,
+ *   reused by the tunnel, the readiness probes and the daemon-start command.
+ *   Without it every probe pays a full TCP + auth handshake.
+ * - **ConnectTimeout** — bounds the connect, not the command; callers still
+ *   impose their own deadline, because a *multiplexed* client connects to a
+ *   local Unix socket and never consults this value.
+ * - **BatchMode=yes** — load-bearing. The supervisor has no controlling tty, so
+ *   it can answer neither a passphrase prompt nor the interactive
+ *   "Are you sure you want to continue connecting?" for an unknown host key.
+ *   BatchMode turns both into an immediate, classifiable failure instead of a
+ *   process that hangs forever.
+ * - **LogLevel=ERROR** — keeps "Warning: Permanently added …" out of surfaced
+ *   error strings.
+ *
+ * `StrictHostKeyChecking` is deliberately not set at all: BatchMode already
+ * makes an unknown key fail closed, and setting it to `no`/`accept-new` is
+ * exactly the bypass this design refuses. `IdentityFile`, `User`, `Port` and
+ * `ProxyJump` are likewise not passed — the bare target goes to the user's own
+ * client so their ~/.ssh/config governs.
+ */
+export function sshControlFlags(control: { path: string } | null): string[] {
+	const flags: string[] = [];
+	if (control) {
+		flags.push(
+			"-o",
+			"ControlMaster=auto",
+			"-o",
+			`ControlPath=${control.path}`,
+			"-o",
+			`ControlPersist=${CONTROL_PERSIST_SECONDS}`,
+		);
+	}
+	flags.push(
+		"-o",
+		`ConnectTimeout=${CONNECT_TIMEOUT_SECONDS}`,
+		"-o",
+		"BatchMode=yes",
+		"-o",
+		`ServerAliveInterval=${SERVER_ALIVE_INTERVAL_SECONDS}`,
+		"-o",
+		`ServerAliveCountMax=${SERVER_ALIVE_COUNT_MAX}`,
+		"-o",
+		"LogLevel=ERROR",
+	);
+	return flags;
+}
+
+export type SshTargetOptions = {
+	sshTarget: string;
+	/** ControlMaster socket, or null to run unmultiplexed. */
+	control: { path: string } | null;
+};
+
+/**
+ * `ssh -N -L <localPort>:127.0.0.1:<remotePort> <target>` — the forward that
+ * lets the client reach a remote daemon which is still bound to loopback only.
+ *
+ * The remote side of the forward is `127.0.0.1` and never `localhost`: the
+ * remote resolver may map `localhost` to `::1` first, and a daemon bound to
+ * 127.0.0.1 would refuse it.
+ *
+ * `-N` runs no remote command, so sshd never allocates a shell — the forward is
+ * the entire purpose of the connection.
+ */
+export function tunnelArgv(options: SshTargetOptions & { localPort: number; remotePort: number }): string[] {
+	return [
+		...sshControlFlags(options.control),
+		"-N",
+		"-L",
+		`${options.localPort}:127.0.0.1:${options.remotePort}`,
+		options.sshTarget,
+	];
+}
+
+/**
+ * A remote command invocation.
+ *
+ * The command is always interposed with `/bin/sh -c`. sshd executes a remote
+ * command with the *account's login shell*, which AO does not control: `fish`,
+ * `csh` and `tcsh` do not parse POSIX `$?`, `&&` chains or `>/dev/null 2>&1` the
+ * same way, so a script written for `sh` and handed to sshd silently misbehaves
+ * on those accounts. Pinning `/bin/sh` removes the variable entirely.
+ *
+ * `script` is passed as a single argv element, so the local shell is never
+ * involved and nothing here needs local quoting. Any value interpolated *into*
+ * `script` still needs POSIX single-quoting — use {@link shellQuote}.
+ */
+export function remoteCommandArgv(options: SshTargetOptions & { script: string }): string[] {
+	return [...sshControlFlags(options.control), options.sshTarget, "/bin/sh", "-c", options.script];
+}
+
+/**
+ * POSIX single-quote a value for interpolation into a remote script. Single
+ * quotes suppress every expansion; an embedded `'` is closed, escaped and
+ * reopened (`'\''`), which is the only escape a POSIX shell honours inside them.
+ */
+export function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/frontend/src/shared/ssh-command.ts
+++ b/frontend/src/shared/ssh-command.ts
@@ -160,12 +160,20 @@ export function tunnelArgv(options: SshTargetOptions & { localPort: number; remo
  * same way, so a script written for `sh` and handed to sshd silently misbehaves
  * on those accounts. Pinning `/bin/sh` removes the variable entirely.
  *
- * `script` is passed as a single argv element, so the local shell is never
- * involved and nothing here needs local quoting. Any value interpolated *into*
- * `script` still needs POSIX single-quoting — use {@link shellQuote}.
+ * **The script must be quoted, and this is the trap.** Local argv boundaries do
+ * not survive the trip: `ssh` joins everything after the target into ONE string
+ * and hands it to the remote login shell, which re-splits it on whitespace. So
+ * passing `["/bin/sh", "-c", "command -v ao"]` arrives as
+ * `/bin/sh -c command -v ao` — the remote shell runs the no-op builtin
+ * `command` with `$0=-v`, which exits 0 and prints nothing. Every probe would
+ * then "succeed" while testing nothing.
+ *
+ * Quoting the script makes it survive that one re-parse. Values interpolated
+ * *into* the script are quoted independently; the nesting is correct because
+ * {@link shellQuote}'s `'\''` escape is itself quote-safe.
  */
 export function remoteCommandArgv(options: SshTargetOptions & { script: string }): string[] {
-	return [...sshControlFlags(options.control), options.sshTarget, "/bin/sh", "-c", options.script];
+	return [...sshControlFlags(options.control), options.sshTarget, "/bin/sh", "-c", shellQuote(options.script)];
 }
 
 /**

--- a/frontend/src/shared/ssh-command.ts
+++ b/frontend/src/shared/ssh-command.ts
@@ -140,10 +140,28 @@ export type SshTargetOptions = {
  *
  * `-N` runs no remote command, so sshd never allocates a shell — the forward is
  * the entire purpose of the connection.
+ *
+ * **The tunnel is deliberately NOT multiplexed, and this is load-bearing.**
+ * `ControlMaster=auto` together with `ControlPersist` makes ssh fork the master
+ * into the background and exit 0 in the foreground. The supervisor would then
+ * see its child exit immediately and conclude the tunnel had died, while the
+ * forward was in fact alive in a process it no longer had a handle on — so
+ * tearing the connection down would leak both the forward and the master
+ * socket. A dedicated foreground connection makes the process lifetime and the
+ * forward's lifetime the same thing, which is what the supervisor's
+ * `closed()` / `dispose()` contract assumes.
+ *
+ * Both options are passed explicitly rather than merely omitted: the user's own
+ * `~/.ssh/config` may set `ControlMaster` globally, which would silently
+ * reintroduce the fork.
  */
-export function tunnelArgv(options: SshTargetOptions & { localPort: number; remotePort: number }): string[] {
+export function tunnelArgv(options: { sshTarget: string; localPort: number; remotePort: number }): string[] {
 	return [
-		...sshControlFlags(options.control),
+		"-o",
+		"ControlMaster=no",
+		"-o",
+		"ControlPath=none",
+		...sshControlFlags(null),
 		"-N",
 		"-L",
 		`${options.localPort}:127.0.0.1:${options.remotePort}`,

--- a/frontend/src/shared/ssh-config.test.ts
+++ b/frontend/src/shared/ssh-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { dedupeSshHosts, parseSshConfig, workspaceIdFromAlias } from "./ssh-config";
+
+describe("parseSshConfig", () => {
+	it("reads aliases and their HostName", () => {
+		const { hosts } = parseSshConfig(`
+Host build-vm
+  HostName 10.0.0.5
+  User deepak
+
+Host gpu
+  HostName gpu.internal
+`);
+		expect(hosts).toEqual([
+			{ alias: "build-vm", hostName: "10.0.0.5" },
+			{ alias: "gpu", hostName: "gpu.internal" },
+		]);
+	});
+
+	// `Host a b` declares both, and a following HostName applies to both.
+	it("handles several aliases on one Host line", () => {
+		const { hosts } = parseSshConfig("Host vm1 vm1.local\n  HostName 10.0.0.9");
+		expect(hosts).toEqual([
+			{ alias: "vm1", hostName: "10.0.0.9" },
+			{ alias: "vm1.local", hostName: "10.0.0.9" },
+		]);
+	});
+
+	// Patterns match hosts, they do not name one — there is nothing to connect to.
+	it.each(["*", "*.internal", "prod-?", "!staging"])("skips the pattern %j", (pattern) => {
+		expect(parseSshConfig(`Host ${pattern}\n  User root`).hosts).toEqual([]);
+	});
+
+	it("ignores comments and blank lines", () => {
+		const { hosts } = parseSshConfig("# Host commented\n\n  Host real # trailing\n");
+		expect(hosts).toEqual([{ alias: "real" }]);
+	});
+
+	it("accepts the `Key=value` form and is case-insensitive on keywords", () => {
+		const { hosts } = parseSshConfig("HOST=vm\n  hostname=example.com");
+		expect(hosts).toEqual([{ alias: "vm", hostName: "example.com" }]);
+	});
+
+	it("collects Include paths for the caller to resolve", () => {
+		const { includes } = parseSshConfig('Include config.d/*\nInclude "~/other/conf"\nHost vm');
+		expect(includes).toEqual(["config.d/*", "~/other/conf"]);
+	});
+
+	it("returns nothing for an empty or junk file rather than throwing", () => {
+		expect(parseSshConfig("")).toEqual({ hosts: [], includes: [] });
+		expect(parseSshConfig("!!! not a config")).toEqual({ hosts: [], includes: [] });
+	});
+});
+
+describe("dedupeSshHosts", () => {
+	// ssh itself takes the first value it sees for a host, so the picker agrees.
+	it("keeps the first definition of an alias", () => {
+		expect(
+			dedupeSshHosts([
+				[{ alias: "vm", hostName: "first" }],
+				[{ alias: "vm", hostName: "second" }, { alias: "other" }],
+			]),
+		).toEqual([{ alias: "vm", hostName: "first" }, { alias: "other" }]);
+	});
+});
+
+describe("workspaceIdFromAlias", () => {
+	// Registry ids are stricter than ssh aliases, so the suggestion has to be
+	// coerced or the form would open pre-filled with something invalid.
+	it.each([
+		["build-vm", "build-vm"],
+		["Build_VM.local", "build-vm-local"],
+		["ssh.deepaksilaych.me", "ssh-deepaksilaych-me"],
+		["--weird--", "weird"],
+		["!!!", ""],
+	])("suggests %j -> %j", (alias, expected) => {
+		expect(workspaceIdFromAlias(alias)).toBe(expected);
+	});
+
+	it("stays within the id length limit and never ends in a dash", () => {
+		const id = workspaceIdFromAlias(`${"a".repeat(30)}.${"b".repeat(30)}`);
+		expect(id.length).toBeLessThanOrEqual(32);
+		expect(id).not.toMatch(/-$/);
+	});
+});

--- a/frontend/src/shared/ssh-config.ts
+++ b/frontend/src/shared/ssh-config.ts
@@ -1,0 +1,101 @@
+// Reading Host aliases out of the user's ~/.ssh/config.
+//
+// A workspace's target is "whatever you would type after `ssh`", and for most
+// people that is an alias they already maintain. Offering those aliases makes
+// the common case a click instead of a retyped hostname, and an alias is the
+// better answer anyway: it carries ProxyJump, User, Port and IdentityFile with
+// it, none of which AO wants to model.
+//
+// Pure and node:*-free (see daemon-attach.ts); the Electron main process owns
+// the file reads and Include resolution.
+
+/**
+ * A Host alias, with the HostName it resolves to when the config states one.
+ * `hostName` is shown as secondary text so two similar aliases can be told
+ * apart; it is never what AO connects to — the alias is, so the user's own
+ * config keeps governing.
+ */
+export type SshConfigHost = {
+	alias: string;
+	hostName?: string;
+};
+
+/**
+ * Parse Host aliases from one ssh_config file.
+ *
+ * Deliberately shallow: it reads `Host` and `HostName` and ignores everything
+ * else. This is a convenience list for a picker, not a config interpreter — ssh
+ * itself remains the only thing that resolves a target, so being incomplete
+ * here costs the user a manual entry, never a wrong connection.
+ *
+ * Returns `Include` paths separately, because resolving them needs the
+ * filesystem and this module stays pure.
+ */
+export function parseSshConfig(text: string): { hosts: SshConfigHost[]; includes: string[] } {
+	const hosts: SshConfigHost[] = [];
+	const includes: string[] = [];
+	// Aliases declared on the current `Host` line, so a following HostName can
+	// be attached to all of them (`Host a b` is legal and means both).
+	let current: SshConfigHost[] = [];
+
+	for (const rawLine of text.split("\n")) {
+		// Comments run to end of line; a keyword may be separated from its
+		// arguments by whitespace or by `=`.
+		const line = rawLine.replace(/#.*$/, "").trim();
+		if (line === "") continue;
+		const match = /^(\w+)[\s=]+(.+)$/.exec(line);
+		if (!match) continue;
+		const keyword = match[1].toLowerCase();
+		const value = match[2].trim();
+
+		if (keyword === "host") {
+			current = [];
+			for (const alias of value.split(/\s+/)) {
+				// Patterns and negations match hosts, they do not name one, so there
+				// is nothing to connect to. `Host *` is the usual example.
+				if (alias === "" || /[*?!]/.test(alias)) continue;
+				const host = { alias };
+				current.push(host);
+				hosts.push(host);
+			}
+		} else if (keyword === "hostname") {
+			for (const host of current) host.hostName = value;
+		} else if (keyword === "include") {
+			// Include takes one or more (possibly quoted, possibly globbed) paths.
+			for (const token of value.split(/\s+/)) {
+				const cleaned = token.replace(/^["']|["']$/g, "");
+				if (cleaned !== "") includes.push(cleaned);
+			}
+		}
+	}
+
+	return { hosts, includes };
+}
+
+/** Merge host lists from several files, keeping the first definition of an alias. */
+export function dedupeSshHosts(lists: SshConfigHost[][]): SshConfigHost[] {
+	const seen = new Set<string>();
+	const merged: SshConfigHost[] = [];
+	for (const list of lists) {
+		for (const host of list) {
+			if (seen.has(host.alias)) continue;
+			seen.add(host.alias);
+			merged.push(host);
+		}
+	}
+	return merged;
+}
+
+/**
+ * Suggest a workspace id for an alias: the registry's id rules are stricter
+ * than ssh's alias rules, so `Build_VM.local` has to become `build-vm-local`.
+ * Returns "" when nothing usable survives, and the user names it themselves.
+ */
+export function workspaceIdFromAlias(alias: string): string {
+	return alias
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 32)
+		.replace(/-+$/, "");
+}

--- a/frontend/src/shared/ssh-failure.test.ts
+++ b/frontend/src/shared/ssh-failure.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { classifySshFailure, SSH_TRANSPORT_EXIT_CODE } from "./ssh-failure";
+
+const classify = (code: number | null, stderr: string) => classifySshFailure(code, stderr, "build-vm");
+
+describe("classifySshFailure", () => {
+	// OpenSSH exits 255 for its own failures and otherwise forwards the remote
+	// status. Getting this split wrong reports a broken tunnel as a dead daemon.
+	it("attributes a non-255 exit to the remote command", () => {
+		expect(classify(127, "").kind).toBe("remote_command_failed");
+		expect(classify(1, "").message).toContain("exited with status 1");
+	});
+
+	it("treats death by signal as a transport failure, not a remote one", () => {
+		expect(classify(null, "").kind).toBe("unreachable");
+	});
+
+	// A changed key also prints "Host key verification failed", so the louder,
+	// security-relevant case has to be tested first or it is masked.
+	it("distinguishes a changed host key from an unknown one", () => {
+		const changed = classify(
+			SSH_TRANSPORT_EXIT_CODE,
+			"@@@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @@@\nHost key verification failed.",
+		);
+		expect(changed.kind).toBe("host_key_changed");
+		// Never offer to fix it for them: the remedy is theirs to verify.
+		expect(changed.message).toContain("remove the old entry");
+
+		const unknown = classify(SSH_TRANSPORT_EXIT_CODE, "No ED25519 host key is known for build-vm.");
+		expect(unknown.kind).toBe("host_key_unverified");
+	});
+
+	it.each([
+		"Permission denied (publickey).",
+		"Too many authentication failures",
+		"deepak@build-vm: Permission denied (publickey,password).",
+	])("classifies %j as an auth failure", (stderr) => {
+		expect(classify(SSH_TRANSPORT_EXIT_CODE, stderr).kind).toBe("auth_failed");
+	});
+
+	it.each(["ssh: connect to host build-vm port 22: Connection refused", "ssh: Could not resolve hostname build-vm", ""])(
+		"falls back to unreachable for %j",
+		(stderr) => {
+			expect(classify(SSH_TRANSPORT_EXIT_CODE, stderr).kind).toBe("unreachable");
+		},
+	);
+
+	it("keeps the raw stderr as details so an unmatched failure is still diagnosable", () => {
+		expect(classify(SSH_TRANSPORT_EXIT_CODE, "  some novel ssh error\n").details).toBe("some novel ssh error");
+	});
+});

--- a/frontend/src/shared/ssh-failure.ts
+++ b/frontend/src/shared/ssh-failure.ts
@@ -1,0 +1,113 @@
+// Classifying why an `ssh` invocation failed.
+//
+// OpenSSH exits **255 for its own failures** and otherwise forwards the remote
+// command's status, so a bare non-zero exit cannot be attributed to a side. The
+// distinction is not cosmetic: a transport failure must never be reported as
+// "the remote daemon is down", because the supervisor would then offer to start
+// a daemon that is already running fine behind a broken tunnel — and the
+// repository's hard rule is that a failed probe is not proof of death.
+//
+// Pure and node:*-free so the stderr matching can be table-tested.
+
+/** Why a remote workspace could not be reached. Each maps to a distinct remedy. */
+export type SshFailureKind =
+	/** The host key changed — a real security event, never auto-accepted. */
+	| "host_key_changed"
+	/** The host is unknown and BatchMode cannot answer the prompt. */
+	| "host_key_unverified"
+	/** Reached the host; it refused our credentials. */
+	| "auth_failed"
+	/** Never reached the host: DNS, routing, refused, or timed out. */
+	| "unreachable"
+	/** No `ssh` binary on this machine. */
+	| "ssh_missing"
+	/** ssh worked; the remote command itself exited non-zero. */
+	| "remote_command_failed";
+
+export type SshFailure = { kind: SshFailureKind; message: string; details: string };
+
+/** The exit status OpenSSH uses for its own failures, as opposed to forwarding. */
+export const SSH_TRANSPORT_EXIT_CODE = 255;
+
+// Matched against the local ssh client's stderr. These strings are stable across
+// OpenSSH releases; anything unmatched degrades to "unreachable" with the raw
+// stderr attached rather than being guessed at.
+const HOST_KEY_CHANGED = /REMOTE HOST IDENTIFICATION HAS CHANGED|Host key verification failed/i;
+const HOST_KEY_UNKNOWN = /No (?:ECDSA |ED25519 |RSA )?host key is known|Host key for .* has changed|not known by any other names/i;
+const AUTH_FAILED = /Permission denied|Too many authentication failures|no such identity|Authentication failed/i;
+
+/**
+ * Classify a completed ssh invocation. `exitCode` is null when the process died
+ * on a signal, which is treated as a transport failure — the same conservative
+ * side as an ssh-attributed exit.
+ */
+export function classifySshFailure(exitCode: number | null, stderr: string, sshTarget: string): SshFailure {
+	const details = stderr.trim();
+
+	if (exitCode !== SSH_TRANSPORT_EXIT_CODE && exitCode !== null) {
+		return {
+			kind: "remote_command_failed",
+			message: `The command on ${sshTarget} exited with status ${exitCode}.`,
+			details,
+		};
+	}
+
+	// Order matters: a changed key also prints "Host key verification failed",
+	// so the louder, security-relevant case is tested first.
+	if (HOST_KEY_CHANGED.test(details) && /IDENTIFICATION HAS CHANGED/i.test(details)) {
+		return {
+			kind: "host_key_changed",
+			message:
+				`The host key for ${sshTarget} has changed. This can mean the machine was rebuilt — ` +
+				`or that the connection is being intercepted. Verify the new key, then remove the old ` +
+				`entry from ~/.ssh/known_hosts yourself.`,
+			details,
+		};
+	}
+	if (HOST_KEY_UNKNOWN.test(details) || HOST_KEY_CHANGED.test(details)) {
+		return {
+			kind: "host_key_unverified",
+			message:
+				`${sshTarget} is not in your known_hosts. Connect once yourself with ` +
+				`\`ssh ${sshTarget}\` and accept the key, so you see the fingerprint before trusting it.`,
+			details,
+		};
+	}
+	if (AUTH_FAILED.test(details)) {
+		return {
+			kind: "auth_failed",
+			message: `${sshTarget} refused your credentials. Check that your key is loaded (\`ssh-add -l\`).`,
+			details,
+		};
+	}
+	return {
+		kind: "unreachable",
+		message: `Could not reach ${sshTarget} over SSH.`,
+		details,
+	};
+}
+
+/** The failure for a spawn that never produced a process because ssh is absent. */
+export function sshClientMissingFailure(): SshFailure {
+	return {
+		kind: "ssh_missing",
+		message: "No `ssh` client was found on this machine. Remote workspaces need OpenSSH.",
+		details: "",
+	};
+}
+
+/**
+ * The failure for a remote host with no `ao` binary. Detect and report the exact
+ * command; never run an installer. AO does not become a configuration-management
+ * tool for machines its users' maintainers do not own — the same answer AO gives
+ * for a missing local tmux.
+ */
+export function aoNotInstalledFailure(sshTarget: string): SshFailure {
+	return {
+		kind: "remote_command_failed",
+		message:
+			`No \`ao\` binary on ${sshTarget}. Install Agent Orchestrator there and make sure ` +
+			`\`ao\` is on the PATH of a non-interactive SSH login (~/.profile, not ~/.bashrc).`,
+		details: "",
+	};
+}

--- a/frontend/src/shared/ssh-failure.ts
+++ b/frontend/src/shared/ssh-failure.ts
@@ -9,6 +9,8 @@
 //
 // Pure and node:*-free so the stderr matching can be table-tested.
 
+import type { DaemonFailureCode } from "./daemon-status";
+
 /** Why a remote workspace could not be reached. Each maps to a distinct remedy. */
 export type SshFailureKind =
 	/** The host key changed — a real security event, never auto-accepted. */
@@ -85,6 +87,28 @@ export function classifySshFailure(exitCode: number | null, stderr: string, sshT
 		message: `Could not reach ${sshTarget} over SSH.`,
 		details,
 	};
+}
+
+/**
+ * Map a transport failure onto the supervisor's status vocabulary, so the
+ * renderer's existing daemon-failure surface can render it without knowing
+ * anything about SSH.
+ */
+export function sshFailureCode(kind: SshFailureKind): DaemonFailureCode {
+	switch (kind) {
+		case "host_key_changed":
+			return "host_key_changed";
+		case "host_key_unverified":
+			return "host_key_unverified";
+		case "auth_failed":
+			return "host_auth_failed";
+		case "ssh_missing":
+			return "ssh_missing";
+		case "remote_command_failed":
+			return "remote_ao_missing";
+		default:
+			return "host_unreachable";
+	}
 }
 
 /** The failure for a spawn that never produced a process because ssh is absent. */

--- a/frontend/src/shared/workspaces.test.ts
+++ b/frontend/src/shared/workspaces.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+	coerceWorkspaceRegistry,
+	LOCAL_WORKSPACE_ID,
+	resolveWorkspace,
+	validateRemoteWorkspace,
+	workspaceLabel,
+	type WorkspaceRegistry,
+} from "./workspaces";
+
+const vm = { id: "build-vm", sshTarget: "build-vm" };
+const other = { id: "gpu", sshTarget: "deepak@10.0.0.5" };
+
+describe("validateRemoteWorkspace", () => {
+	it("accepts a kebab id and a bare ssh alias", () => {
+		expect(validateRemoteWorkspace(vm)).toBeNull();
+		expect(validateRemoteWorkspace(other)).toBeNull();
+	});
+
+	it.each([
+		["", "id"],
+		[LOCAL_WORKSPACE_ID, "id"],
+		["Build-VM", "id"],
+		["build--vm", "id"],
+		["-build", "id"],
+		["build-", "id"],
+		["b".repeat(33), "id"],
+	])("rejects id %j", (id, field) => {
+		expect(validateRemoteWorkspace({ id, sshTarget: "host" })?.field).toBe(field);
+	});
+
+	it.each(["", "  ", "-p 22 host", "host with space"])("rejects ssh target %j", (sshTarget) => {
+		expect(validateRemoteWorkspace({ id: "vm", sshTarget })?.field).toBe("sshTarget");
+	});
+
+	it("rejects a target that ssh would parse as a flag", () => {
+		expect(validateRemoteWorkspace({ id: "vm", sshTarget: "-oProxyCommand=touch/pwn" })?.field).toBe("sshTarget");
+	});
+});
+
+describe("workspaceLabel", () => {
+	it("falls back to the id when the display name is absent or blank", () => {
+		expect(workspaceLabel(vm)).toBe("build-vm");
+		expect(workspaceLabel({ ...vm, displayName: "  " })).toBe("build-vm");
+		expect(workspaceLabel({ ...vm, displayName: "Build VM" })).toBe("Build VM");
+	});
+});
+
+describe("coerceWorkspaceRegistry", () => {
+	it("returns the default for anything that is not an object", () => {
+		for (const value of [null, undefined, 42, "x", []]) {
+			expect(coerceWorkspaceRegistry(value)).toEqual({ remotes: [] });
+		}
+	});
+
+	it("drops unusable entries instead of throwing, so the app still boots", () => {
+		const registry = coerceWorkspaceRegistry({
+			remotes: [vm, { id: "LOCAL" }, { id: "ok", sshTarget: "" }, null, other],
+		});
+		expect(registry.remotes).toEqual([vm, other]);
+	});
+
+	it("keeps the first of duplicate ids", () => {
+		const registry = coerceWorkspaceRegistry({
+			remotes: [vm, { id: "build-vm", sshTarget: "impostor" }],
+		});
+		expect(registry.remotes).toEqual([vm]);
+	});
+
+	it("preserves an explicit local activeId", () => {
+		expect(coerceWorkspaceRegistry({ activeId: LOCAL_WORKSPACE_ID, remotes: [vm] }).activeId).toBe(LOCAL_WORKSPACE_ID);
+	});
+
+	it("drops an activeId whose remote did not survive coercion", () => {
+		const registry = coerceWorkspaceRegistry({ activeId: "gone", remotes: [vm] });
+		expect(registry.activeId).toBeUndefined();
+	});
+
+	it("round-trips a serialized registry", () => {
+		const registry: WorkspaceRegistry = { activeId: "gpu", remotes: [vm, other] };
+		expect(coerceWorkspaceRegistry(JSON.parse(JSON.stringify(registry)))).toEqual(registry);
+	});
+});
+
+describe("resolveWorkspace", () => {
+	it("prefers an explicit id over the persisted active one", () => {
+		const registry: WorkspaceRegistry = { activeId: "gpu", remotes: [vm, other] };
+		expect(resolveWorkspace(registry, "build-vm")).toEqual({ workspace: vm });
+	});
+
+	it("treats an explicit local as the laptop", () => {
+		const registry: WorkspaceRegistry = { activeId: "gpu", remotes: [other] };
+		expect(resolveWorkspace(registry, LOCAL_WORKSPACE_ID)).toEqual({ workspace: null });
+	});
+
+	it("errors rather than falling back when an explicit id is unknown", () => {
+		expect(resolveWorkspace({ remotes: [vm] }, "typo")).toEqual({ error: 'Unknown workspace "typo".' });
+	});
+
+	it("uses the persisted active id", () => {
+		expect(resolveWorkspace({ activeId: "gpu", remotes: [vm, other] })).toEqual({ workspace: other });
+	});
+
+	it("auto-selects the single registered remote when the user has never chosen", () => {
+		expect(resolveWorkspace({ remotes: [vm] })).toEqual({ workspace: vm });
+	});
+
+	// The regression this file exists for: auto-select must not override a
+	// deliberate "Local", or registering one VM silently moves every session.
+	it("never overrides an explicit local with the single-remote rule", () => {
+		expect(resolveWorkspace({ activeId: LOCAL_WORKSPACE_ID, remotes: [vm] })).toEqual({ workspace: null });
+	});
+
+	it("stays local when several remotes are registered and none is active", () => {
+		expect(resolveWorkspace({ remotes: [vm, other] })).toEqual({ workspace: null });
+	});
+
+	it("stays local for an empty registry", () => {
+		expect(resolveWorkspace({ remotes: [] })).toEqual({ workspace: null });
+	});
+});

--- a/frontend/src/shared/workspaces.ts
+++ b/frontend/src/shared/workspaces.ts
@@ -1,0 +1,206 @@
+// The workspace registry: which machines this client can run agents on.
+//
+// A *workspace* is a machine that runs its own AO daemon. The laptop is always
+// workspace `local` and is not stored. A remote workspace is an SSH target whose
+// daemon the supervisor reaches through a loopback port-forward, so the daemon
+// on the far side keeps its `127.0.0.1`-only bind (backend/internal/config:
+// LoopbackHost) and AO gains no network-facing listener.
+//
+// This module is pure: no node:*, no electron. The Electron main process owns
+// the fs reads/writes (see main/workspace-registry.ts), which is the same split
+// ui-locale.ts / main/ui-settings.ts already uses. Keeping it pure also keeps it
+// importable from the renderer for the workspace switcher's types.
+//
+// Semantics ported from `sess` (github.com/deepaksilaych/sess, MIT): a named
+// remote registry, and the explicit > active > single-configured > local
+// resolution order.
+
+/** The reserved id for the machine the client itself runs on. Never stored. */
+export const LOCAL_WORKSPACE_ID = "local";
+
+/**
+ * Workspace ids are lowercase kebab: they appear in error strings, in the
+ * ControlPath hash input, and (eventually) in URLs, and a case-insensitive
+ * filesystem must not be able to collide two of them.
+ */
+const WORKSPACE_ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const WORKSPACE_ID_MAX_LENGTH = 32;
+
+export type RemoteWorkspace = {
+	/** Stable id, unique across the registry and never `local`. */
+	id: string;
+	/**
+	 * Exactly what the user would type after `ssh`: a plain `user@host`, or
+	 * (preferred) a `Host` alias from their own ~/.ssh/config, so ProxyJump,
+	 * Match, IdentityAgent and friends keep working. AO reads no keys and writes
+	 * no known_hosts — it shells out to the user's own ssh client, for the same
+	 * reason docs/stack.md shells out to git rather than embedding go-git.
+	 */
+	sshTarget: string;
+	/** Optional human label for the switcher; falls back to the id. */
+	displayName?: string;
+	/**
+	 * The loopback port the remote daemon binds, when it is not the default. The
+	 * remote reads AO_PORT the same way the local one does (backend/internal/
+	 * config: DefaultPort), so a VM running a non-default daemon needs this to be
+	 * reachable. Absent means the default.
+	 */
+	remotePort?: number;
+};
+
+export type WorkspaceRegistry = {
+	/**
+	 * The workspace the client is currently pointed at, or undefined when the
+	 * user has never chosen one.
+	 *
+	 * The distinction matters: `undefined` lets the single-registered-remote rule
+	 * in resolveWorkspace apply, while an explicit `"local"` pins the laptop and
+	 * must never be overridden. Collapsing the two would silently move a user who
+	 * clicked "Local" onto their VM the moment they registered one.
+	 */
+	activeId?: string;
+	remotes: RemoteWorkspace[];
+};
+
+export const DEFAULT_WORKSPACE_REGISTRY: WorkspaceRegistry = {
+	remotes: [],
+};
+
+/** Human label for a workspace, for the switcher and for error messages. */
+export function workspaceLabel(workspace: RemoteWorkspace): string {
+	return workspace.displayName?.trim() || workspace.id;
+}
+
+export type WorkspaceValidationError = { field: "id" | "sshTarget"; message: string };
+
+/**
+ * Validate a single remote entry. Returns null when it is usable. Callers
+ * surface the message verbatim, so it is phrased for a user, not a log.
+ */
+export function validateRemoteWorkspace(
+	input: Pick<RemoteWorkspace, "id" | "sshTarget">,
+): WorkspaceValidationError | null {
+	const id = input.id.trim();
+	if (id === "") return { field: "id", message: "Workspace id is required." };
+	if (id === LOCAL_WORKSPACE_ID) {
+		return { field: "id", message: `"${LOCAL_WORKSPACE_ID}" is reserved for this machine.` };
+	}
+	if (id.length > WORKSPACE_ID_MAX_LENGTH) {
+		return { field: "id", message: `Workspace id must be at most ${WORKSPACE_ID_MAX_LENGTH} characters.` };
+	}
+	if (!WORKSPACE_ID_PATTERN.test(id)) {
+		return {
+			field: "id",
+			message: "Workspace id must be lowercase letters, digits and single dashes (e.g. build-vm).",
+		};
+	}
+
+	const target = input.sshTarget.trim();
+	if (target === "") return { field: "sshTarget", message: "SSH target is required." };
+	// The target is passed to the user's ssh client as one argv element, never
+	// through a shell, so shell metacharacters are not an injection vector here.
+	// Whitespace is still rejected: it is always a typo (`ssh -p 22 host` pasted
+	// whole), and accepting it would make the ControlPath hash input ambiguous.
+	if (/\s/.test(target)) {
+		return { field: "sshTarget", message: "SSH target must not contain spaces. Use a ~/.ssh/config Host alias." };
+	}
+	// A leading `-` would be parsed by ssh as a flag rather than a destination.
+	if (target.startsWith("-")) {
+		return { field: "sshTarget", message: "SSH target must not start with a dash." };
+	}
+	return null;
+}
+
+function coerceRemote(value: unknown): RemoteWorkspace | null {
+	if (typeof value !== "object" || value === null) return null;
+	const candidate = value as Partial<RemoteWorkspace>;
+	if (typeof candidate.id !== "string" || typeof candidate.sshTarget !== "string") return null;
+	const id = candidate.id.trim();
+	const sshTarget = candidate.sshTarget.trim();
+	if (validateRemoteWorkspace({ id, sshTarget })) return null;
+
+	const remote: RemoteWorkspace = { id, sshTarget };
+	const displayName = typeof candidate.displayName === "string" ? candidate.displayName.trim() : "";
+	if (displayName !== "") remote.displayName = displayName;
+	// An out-of-range port is dropped to the default rather than rejecting the
+	// whole entry: the workspace is still usable, just on the standard port.
+	if (isValidPort(candidate.remotePort)) remote.remotePort = candidate.remotePort;
+	return remote;
+}
+
+function isValidPort(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+/**
+ * Coerce parsed JSON into a registry, dropping anything unusable rather than
+ * throwing: a hand-edited or partially-written workspaces.json must never stop
+ * the app from booting into the local workspace. Duplicate ids keep the first
+ * occurrence, so the file stays deterministic.
+ */
+export function coerceWorkspaceRegistry(value: unknown): WorkspaceRegistry {
+	if (typeof value !== "object" || value === null) return { ...DEFAULT_WORKSPACE_REGISTRY };
+	const candidate = value as Partial<WorkspaceRegistry>;
+
+	const remotes: RemoteWorkspace[] = [];
+	const seen = new Set<string>();
+	if (Array.isArray(candidate.remotes)) {
+		for (const entry of candidate.remotes) {
+			const remote = coerceRemote(entry);
+			if (!remote || seen.has(remote.id)) continue;
+			seen.add(remote.id);
+			remotes.push(remote);
+		}
+	}
+
+	// An activeId naming a remote that did not survive coercion is dropped to
+	// undefined rather than leaving the client pointed at nothing. `local` is
+	// preserved verbatim: it is a real choice, not a missing one.
+	const rawActive = typeof candidate.activeId === "string" ? candidate.activeId.trim() : "";
+	const activeId = rawActive === LOCAL_WORKSPACE_ID || seen.has(rawActive) ? rawActive : undefined;
+
+	return activeId === undefined ? { remotes } : { activeId, remotes };
+}
+
+/**
+ * The workspace to connect to, in `sess`'s resolution order:
+ *
+ *   1. an explicit id (a `--workspace` flag or a switcher click),
+ *   2. the persisted active id — including an explicit `local`,
+ *   3. the single configured remote, when exactly one is registered and the
+ *      user has never chosen,
+ *   4. local.
+ *
+ * Rule 3 makes the single-VM case (the motivating one) zero-ceremony on first
+ * run, and rule 2 is what stops it from overriding a deliberate "Local" — which
+ * is why LOCAL_WORKSPACE_ID is a nameable value rather than just an absence.
+ *
+ * Returns null for the local workspace, or the remote to dial. An explicit id
+ * that resolves to nothing is an error, never a silent fallthrough to local:
+ * running an agent on the wrong machine is not a recoverable mistake.
+ */
+export function resolveWorkspace(
+	registry: WorkspaceRegistry,
+	explicitId?: string,
+): { workspace: RemoteWorkspace | null } | { error: string } {
+	const byId = (id: string) => registry.remotes.find((remote) => remote.id === id) ?? null;
+
+	if (explicitId !== undefined && explicitId !== "") {
+		if (explicitId === LOCAL_WORKSPACE_ID) return { workspace: null };
+		const explicit = byId(explicitId);
+		return explicit ? { workspace: explicit } : { error: `Unknown workspace "${explicitId}".` };
+	}
+
+	if (registry.activeId === LOCAL_WORKSPACE_ID) return { workspace: null };
+	if (registry.activeId !== undefined) {
+		const active = byId(registry.activeId);
+		// coerceWorkspaceRegistry already guarantees this resolves for a file-backed
+		// registry, but one may also be built in memory. Fall through rather than
+		// error: no caller asked for this id in this call.
+		if (active) return { workspace: active };
+	}
+
+	if (registry.remotes.length === 1) return { workspace: registry.remotes[0] };
+
+	return { workspace: null };
+}


### PR DESCRIPTION
Closes #3853.

## Problem

If your laptop is a thin client and your VM holds the code, compute and
credentials, AO can't help you: the desktop app spawns a daemon on the machine
it runs on, and every session runs there. Discussion #2855 asks for exactly
this; issue #13 listed it before being closed as rewrite cleanup.

## What this does

A **workspace** is a machine that runs its own AO daemon. `local` is unchanged.
A remote workspace is an SSH target the supervisor reaches through a loopback
port-forward:

```
ssh -N -L <freePort>:127.0.0.1:<remoteDaemonPort> <target>
```

The renderer already addresses the daemon through one mutable base URL handed
to it on `daemon:status`, and the mux WebSocket and SSE derive from that base.
So publishing the forward's local end as the daemon port makes **the entire
renderer work against a remote daemon unmodified**. Pick the machine in
Settings → Workspace; aliases come from your `~/.ssh/config`.

## Why this shape

The alternative — one laptop daemon that *places individual sessions* on a VM —
was designed in full first, and the design argued against it. Routing must be a
pure function of `RuntimeHandle.ID`, which forces the host into the handle id,
and that id space is mintable from project names, so a folder can forge a remote
handle and get a healthy session reaped. Plus `gitworktree` bypasses its own
command runner in ten places, `binaryutil.LookPath` puts *laptop* paths in the
remote pane's `argv[0]`, hooks and the system-prompt file are written locally at
the remote path, and `AO_BROWSER_CAPABILITY` would be exported to a third
machine. All solvable; all existing only because one daemon is acting on a
filesystem that isn't its own. It remains the better answer to "run this one
task on the big machine" and can layer on later — see the ADR.

## Security posture

- **No bind change, no new listener.** Both daemons stay `127.0.0.1`-only, so
  unlike ADR-0001 this needs **no exception** to the loopback-only hard rule.
- **Auth is SSH's.** AO shells out to your `ssh`, holds no key material, writes
  no `known_hosts`. `~/.ssh/config` governs.
- `BatchMode=yes` is load-bearing — the supervisor has no tty and can answer
  neither a passphrase prompt nor an unknown-host-key prompt.
- **`StrictHostKeyChecking` is never set.** An unknown key is surfaced to you
  with the instruction to connect once and see the fingerprint; a *changed* key
  is reported as the security event it is.
- **AO never installs anything remotely.** A host without `ao` is reported with
  the command to run.

## Verification

Verified end to end against a real VM, not just unit tests: the app attaches to
the remote daemon (or starts one), serves the whole UI from it, and upgrades the
terminal-mux WebSocket through the tunnel (HTTP 101).

Real-host testing found **four bugs that unit tests structurally could not**,
each now with a regression test:

| Bug | Why tests missed it |
|---|---|
| `ssh` rejoins argv and the remote shell re-splits it, so `command -v ao` ran the no-op `command` builtin — **preflight passed on a host with no `ao`** | tests asserted the *local* argv, which was correct |
| `ControlMaster`+`ControlPersist` makes `ssh -N` **fork and exit 0**; supervisor read that as "tunnel died" and leaked the forward | a fake child process doesn't fork |
| **Remote port was guessed**; 3001 was taken on the VM so the daemon bound elsewhere and the tunnel hit an unrelated service | no fake reproduces a busy port |
| Concurrent connects each spawned a tunnel | the local path's de-dup guard runs after the remote branch |

1578 tests pass. The 5 failing `landing/generate-markdown-twins` tests fail
identically on a clean `main` and are unrelated.

## Deliberately out of scope

Moving a session between workspaces; a cross-workspace board; `ao` CLI parity
(still local-daemon only); Windows as the client (the failure path is graceful —
a missing `ssh` is reported as such — but it is untested).

## Review order

The commits are meant to be read in order, ADR first.
