### PR TITLE
fix(chat): keep nested Codex turns from draining queued work

### DIFF
--- a/backend/internal/adapters/chatdriver/codexappserver/conversation.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conversation.go
@@ -148,12 +148,20 @@ func (c *conversation) pump() {
 		// as an absolute instant and has to become a remaining duration, and a
 		// normalizer that reads the clock itself cannot be tested deterministically.
 		for _, ev := range normalizeNotification(n, time.Now()) {
-			if ev.Kind == ports.ChatEventTurnStarted && ev.ProviderTurnID != "" {
+			rootConversation := ev.ProviderConversationID == "" || ev.ProviderConversationID == c.threadID
+			if ev.Kind == ports.ChatEventTurnStarted && ev.ProviderTurnID != "" && rootConversation {
 				c.mu.Lock()
 				c.activeTurn = ev.ProviderTurnID
 				// Snapshot the context position this turn starts from. Cheap on every
 				// turn, and the only way to know what a compaction reclaimed.
 				c.contextAtTurnStart = c.contextTokens
+				c.mu.Unlock()
+			}
+			if ev.Kind == ports.ChatEventTurnCompleted && rootConversation {
+				c.mu.Lock()
+				if c.activeTurn == ev.ProviderTurnID {
+					c.activeTurn = ""
+				}
 				c.mu.Unlock()
 			}
 			if ev.Kind == ports.ChatEventCompacted {

--- a/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
@@ -508,6 +508,42 @@ func TestNotificationsBecomeNeutralEvents(t *testing.T) {
 	}
 }
 
+// app-server multiplexes child-agent thread notifications over the root
+// connection. The adapter's fallback target must remain the root turn; otherwise
+// an interrupt without an explicit id can stop a child and leave the requested
+// root work running.
+func TestNestedThreadDoesNotReplaceRootActiveTurn(t *testing.T) {
+	d, srv := newTestDriver(t)
+	conv, err := d.Start(context.Background(), ports.ChatStartConfig{WorkspacePath: "/tmp/ws"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = conv.Close() }()
+
+	srv.push(`{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"root-turn","status":"inProgress","items":[]}}}`)
+	srv.push(`{"method":"turn/started","params":{"threadId":"child-thread-1","turn":{"id":"child-turn","status":"inProgress","items":[]}}}`)
+	root := nextEvent(t, conv.Events(), ports.ChatEventTurnStarted)
+	child := nextEvent(t, conv.Events(), ports.ChatEventTurnStarted)
+	if root.ProviderConversationID != "thread-1" || child.ProviderConversationID != "child-thread-1" {
+		t.Fatalf("normalized lifecycle threads = root %q child %q", root.ProviderConversationID, child.ProviderConversationID)
+	}
+
+	if err := conv.Interrupt(context.Background(), ""); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	sent := srv.awaitFrame(func(f frame) bool { return f.Method == "turn/interrupt" })
+	var params struct {
+		ThreadID string `json:"threadId"`
+		TurnID   string `json:"turnId"`
+	}
+	if err := json.Unmarshal(sent.Params, &params); err != nil {
+		t.Fatalf("decode turn/interrupt params: %v", err)
+	}
+	if params.ThreadID != "thread-1" || params.TurnID != "root-turn" {
+		t.Fatalf("interrupt target = %q/%q, want thread-1/root-turn", params.ThreadID, params.TurnID)
+	}
+}
+
 // Resume must not quietly become a fresh thread: that would present unrelated
 // history as continuous.
 func TestResumeFailureDoesNotFallBackToStart(t *testing.T) {

--- a/backend/internal/adapters/chatdriver/codexappserver/normalize.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/normalize.go
@@ -136,8 +136,9 @@ func normalizeNotification(n notification, now time.Time) []ports.ChatEvent {
 			return nil
 		}
 		return []ports.ChatEvent{{
-			Kind:           ports.ChatEventTurnStarted,
-			ProviderTurnID: firstNonEmpty(p.Turn.ID, turnIDFallback(n.Params)),
+			Kind:                   ports.ChatEventTurnStarted,
+			ProviderTurnID:         firstNonEmpty(p.Turn.ID, turnIDFallback(n.Params)),
+			ProviderConversationID: p.ThreadID,
 		}}
 
 	case codexproto.MethodTurnCompleted:
@@ -146,9 +147,10 @@ func normalizeNotification(n notification, now time.Time) []ports.ChatEvent {
 			return nil
 		}
 		ev := ports.ChatEvent{
-			Kind:           ports.ChatEventTurnCompleted,
-			ProviderTurnID: firstNonEmpty(p.Turn.ID, turnIDFallback(n.Params)),
-			TurnState:      turnStateFrom(string(p.Turn.Status)),
+			Kind:                   ports.ChatEventTurnCompleted,
+			ProviderTurnID:         firstNonEmpty(p.Turn.ID, turnIDFallback(n.Params)),
+			ProviderConversationID: p.ThreadID,
+			TurnState:              turnStateFrom(string(p.Turn.Status)),
 		}
 		if p.Turn.Error != nil && p.Turn.Error.Message != "" {
 			ev.Err = fmt.Errorf("%s", p.Turn.Error.Message)

--- a/backend/internal/adapters/chatdriver/codexappserver/normalize_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/normalize_test.go
@@ -37,12 +37,14 @@ func normalizeNone(t *testing.T, method, params string) {
 
 func TestNormalizeTurnLifecycle(t *testing.T) {
 	started := normalizeOne(t, "turn/started", `{"threadId":"th1","turn":{"id":"tu1","status":"inProgress","items":[]}}`)
-	if started.Kind != ports.ChatEventTurnStarted || started.ProviderTurnID != "tu1" {
+	if started.Kind != ports.ChatEventTurnStarted || started.ProviderTurnID != "tu1" ||
+		started.ProviderConversationID != "th1" {
 		t.Fatalf("turn/started -> %+v", started)
 	}
 
 	done := normalizeOne(t, "turn/completed", `{"threadId":"th1","turn":{"id":"tu1","status":"completed","items":[]}}`)
-	if done.Kind != ports.ChatEventTurnCompleted || done.TurnState != domain.TurnStateCompleted {
+	if done.Kind != ports.ChatEventTurnCompleted || done.TurnState != domain.TurnStateCompleted ||
+		done.ProviderConversationID != "th1" {
 		t.Fatalf("turn/completed -> %+v", done)
 	}
 }

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -712,6 +712,11 @@ type ChatEvent struct {
 
 	// ProviderTurnID is set on every event that belongs to a turn.
 	ProviderTurnID string
+	// ProviderConversationID identifies the native thread/session the event came
+	// from. It may differ from ChatConversation.ProviderConversationID for nested
+	// agent work. Empty preserves compatibility with providers whose protocol has
+	// no nested-conversation identity.
+	ProviderConversationID string
 	// ProviderItemID identifies the message or activity being reported.
 	ProviderItemID string
 	// ClientMessageID is the provider-carried idempotency key for a recovered user

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -261,7 +261,7 @@ func (c *Controller) importNativeHistory(
 		if event.ProviderEventID == "" {
 			return fmt.Errorf("native history event %s has no stable identity", event.Kind)
 		}
-		if _, err := c.projectEvent(ctx, event); err != nil {
+		if _, _, err := c.projectEvent(ctx, event); err != nil {
 			return fmt.Errorf("import native history event %s: %w", event.Kind, err)
 		}
 	}
@@ -796,7 +796,13 @@ func (c *Controller) dispatch(
 func (c *Controller) drain(ctx context.Context) {
 	c.sendMu.Lock()
 	defer c.sendMu.Unlock()
+	c.drainLocked(ctx)
+}
 
+// drainLocked is drain with the dispatch lock already held. Turn completion
+// uses it so committing the completion, clearing primary ownership, and claiming
+// the next queued request are one serialized lifecycle transition.
+func (c *Controller) drainLocked(ctx context.Context) {
 	c.mu.Lock()
 	cutoff := c.cancelQueuedAt
 	c.cancelQueuedAt = time.Time{}
@@ -902,6 +908,11 @@ func (c *Controller) BeginHandoff(
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	for {
+		// Quiescence is a dispatch boundary, not merely "pendingTurnID is empty".
+		// dispatch marks the durable row running before it installs pendingTurnID;
+		// without sendMu a handoff can observe that narrow middle state as neither
+		// queued nor active and start the target controller too early.
+		c.sendMu.Lock()
 		c.mu.Lock()
 		busy := c.pendingTurnID != ""
 		c.mu.Unlock()
@@ -909,14 +920,17 @@ func (c *Controller) BeginHandoff(
 			_, err := c.store.NextQueuedTurn(ctx, c.conversation.ID)
 			switch {
 			case errors.Is(err, domain.ErrNoQueuedTurn):
+				c.sendMu.Unlock()
 				return nil
 			case err != nil:
+				c.sendMu.Unlock()
 				c.AbortHandoff()
 				return fmt.Errorf("check queued turns before handoff: %w", err)
 			case policy == domain.SessionInterfaceTransitionDrain:
-				c.drain(ctx)
+				c.drainLocked(ctx)
 			}
 		}
+		c.sendMu.Unlock()
 		select {
 		case <-ctx.Done():
 			c.AbortHandoff()
@@ -1219,17 +1233,25 @@ func (c *Controller) project() {
 	ctx := context.WithoutCancel(context.Background())
 
 	for event := range c.conv.Events() {
-		projected, err := c.projectEvent(ctx, event)
+		// A lifecycle event and a concurrent Send must agree on whether the root
+		// conversation is busy. Holding the same lock Send/dispatch use closes the
+		// window between the durable projection and the in-memory ownership update.
+		lifecycle := event.Kind == ports.ChatEventTurnStarted || event.Kind == ports.ChatEventTurnCompleted
+		if lifecycle {
+			c.sendMu.Lock()
+		}
+		projected, primaryTurn, err := c.projectEvent(ctx, event)
 		if err != nil {
 			// A projection failure must not kill the provider stream. The store
 			// rolls the archive back with its projection, so durable state remains
 			// internally consistent and a later provider replay may retry it.
 			c.log.Error("failed to project chat event",
 				"session", c.sessionID, "kind", event.Kind, "error", err)
-			continue
+		} else if projected {
+			c.afterProject(ctx, event, primaryTurn)
 		}
-		if projected {
-			c.afterProject(ctx, event)
+		if lifecycle {
+			c.sendMu.Unlock()
 		}
 	}
 
@@ -1266,31 +1288,32 @@ func (c *Controller) project() {
 
 // projectEvent archives one normalized provider event and applies its durable
 // projection in the same SQLite transaction.
-func (c *Controller) projectEvent(ctx context.Context, event ports.ChatEvent) (bool, error) {
+func (c *Controller) projectEvent(ctx context.Context, event ports.ChatEvent) (bool, bool, error) {
 	record := map[string]any{
-		"kind":            event.Kind,
-		"providerEventId": event.ProviderEventID,
-		"providerTurnId":  event.ProviderTurnID,
-		"providerItemId":  event.ProviderItemID,
-		"clientMessageId": event.ClientMessageID,
-		"turnState":       event.TurnState,
-		"delta":           event.Delta,
-		"text":            event.Text,
-		"activityKind":    event.ActivityKind,
-		"activityStatus":  event.ActivityStatus,
-		"summary":         event.Summary,
-		"detail":          json.RawMessage(nonEmptyJSON(event.Detail)),
-		"requestId":       event.RequestID,
-		"decisions":       event.Decisions,
-		"controllerState": event.ControllerState,
-		"usage":           event.Usage,
-		"rateLimits":      event.RateLimits,
-		"title":           event.Title,
-		"plan":            event.Plan,
-		"reroute":         event.Reroute,
-		"account":         event.Account,
-		"threadState":     event.ThreadState,
-		"mcpServers":      event.MCPServers,
+		"kind":                   event.Kind,
+		"providerEventId":        event.ProviderEventID,
+		"providerTurnId":         event.ProviderTurnID,
+		"providerConversationId": event.ProviderConversationID,
+		"providerItemId":         event.ProviderItemID,
+		"clientMessageId":        event.ClientMessageID,
+		"turnState":              event.TurnState,
+		"delta":                  event.Delta,
+		"text":                   event.Text,
+		"activityKind":           event.ActivityKind,
+		"activityStatus":         event.ActivityStatus,
+		"summary":                event.Summary,
+		"detail":                 json.RawMessage(nonEmptyJSON(event.Detail)),
+		"requestId":              event.RequestID,
+		"decisions":              event.Decisions,
+		"controllerState":        event.ControllerState,
+		"usage":                  event.Usage,
+		"rateLimits":             event.RateLimits,
+		"title":                  event.Title,
+		"plan":                   event.Plan,
+		"reroute":                event.Reroute,
+		"account":                event.Account,
+		"threadState":            event.ThreadState,
+		"mcpServers":             event.MCPServers,
 	}
 	record["diff"] = event.Diff
 	if event.Input != nil {
@@ -1301,11 +1324,55 @@ func (c *Controller) projectEvent(ctx context.Context, event ports.ChatEvent) (b
 	}
 	payload, err := json.Marshal(record)
 	if err != nil {
-		return false, fmt.Errorf("encode provider event archive: %w", err)
+		return false, false, fmt.Errorf("encode provider event archive: %w", err)
 	}
-	return c.store.ProjectProviderEvent(ctx, c.conversation.ID, c.sessionID,
+	projected, err := c.store.ProjectProviderEvent(ctx, c.conversation.ID, c.sessionID,
 		c.generation, event.ProviderEventID, string(event.Kind), string(payload), c.now(),
 		func(txCtx context.Context) error { return c.apply(txCtx, event) })
+	if err != nil || !projected {
+		return projected, false, err
+	}
+	return true, c.applyCommittedTurnLifecycle(event), nil
+}
+
+// applyCommittedTurnLifecycle updates the controller's volatile ownership only
+// after the matching durable projection commits. Codex streams events for nested
+// child threads over the root connection, so only events from the conversation AO
+// opened are allowed to claim or release the primary turn.
+func (c *Controller) applyCommittedTurnLifecycle(event ports.ChatEvent) bool {
+	if event.Kind != ports.ChatEventTurnStarted && event.Kind != ports.ChatEventTurnCompleted {
+		return false
+	}
+	if event.ProviderConversationID != "" && event.ProviderConversationID != c.conv.ProviderConversationID() {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch event.Kind {
+	case ports.ChatEventTurnStarted:
+		// AO serializes root dispatch. A different turn id while one is pending is
+		// auxiliary provider work, even for a protocol that cannot name its thread.
+		if c.pendingTurnID != "" && c.pendingTurnID != event.ProviderTurnID {
+			return false
+		}
+		c.pendingTurnID = event.ProviderTurnID
+		c.ackedTurnID = event.ProviderTurnID
+		c.state = ports.ChatControllerBusy
+		return true
+	case ports.ChatEventTurnCompleted:
+		if c.pendingTurnID != event.ProviderTurnID {
+			return false
+		}
+		c.pendingTurnID = ""
+		if c.ackedTurnID == event.ProviderTurnID {
+			c.ackedTurnID = ""
+		}
+		c.state = ports.ChatControllerReady
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
@@ -1313,13 +1380,6 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 
 	switch event.Kind {
 	case ports.ChatEventTurnStarted:
-		c.mu.Lock()
-		c.pendingTurnID = event.ProviderTurnID
-		// The provider has confirmed this turn, so it will accept an interrupt for
-		// it. Until this arrives, it will not.
-		c.ackedTurnID = event.ProviderTurnID
-		c.state = ports.ChatControllerBusy
-		c.mu.Unlock()
 		// A turn AO dispatched already has a row, bound in dispatch. This covers the
 		// turn AO did NOT dispatch: a compaction, or work the provider resumed from its
 		// own history. Adopting it is what keeps every item it emits correlated, and
@@ -1348,15 +1408,6 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 			}, now)
 
 	case ports.ChatEventTurnCompleted:
-		c.mu.Lock()
-		if c.pendingTurnID == event.ProviderTurnID {
-			c.pendingTurnID = ""
-		}
-		if c.ackedTurnID == event.ProviderTurnID {
-			c.ackedTurnID = ""
-		}
-		c.state = ports.ChatControllerReady
-		c.mu.Unlock()
 		message := ""
 		if event.Err != nil {
 			message = event.Err.Error()
@@ -1694,15 +1745,20 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 // archive/projection transaction. Lifecycle writes touch the sessions table and
 // draining may call the provider, so either one inside the store transaction
 // would hold the single writer connection across another subsystem.
-func (c *Controller) afterProject(ctx context.Context, event ports.ChatEvent) {
+func (c *Controller) afterProject(ctx context.Context, event ports.ChatEvent, primaryTurn bool) {
 	now := c.now()
 	switch event.Kind {
 	case ports.ChatEventTurnStarted:
-		c.reportActivity(ctx, domain.ActivityActive, "chat.turn.started", now)
+		if primaryTurn {
+			c.reportActivity(ctx, domain.ActivityActive, "chat.turn.started", now)
+		}
 	case ports.ChatEventTurnCompleted:
+		if !primaryTurn {
+			return
+		}
 		c.reportActivity(ctx, domain.ActivityIdle, "chat.turn.completed", now)
 		// The settled turn is committed before another queued turn can dispatch.
-		c.drain(ctx)
+		c.drainLocked(ctx)
 	case ports.ChatEventApprovalRequested:
 		c.reportActivity(ctx, domain.ActivityWaitingInput, "chat.approval.requested", now)
 	case ports.ChatEventInputRequested:

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -1166,6 +1166,188 @@ func TestSendWhileBusyQueuesUntilTheTurnEnds(t *testing.T) {
 	}
 }
 
+// Codex can start nested turns while the root turn is still working. A child
+// completion is not conversation quiescence: dispatching queued automation at
+// that point injects it into the still-running root and leaves the AO turn minted
+// for that automation with no matching provider lifecycle.
+func TestNestedTurnCompletionDoesNotDrainQueueWhilePrimaryTurnRuns(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "root work", ClientMessageID: "c1", Origin: domain.MessageOriginHuman,
+	}); err != nil {
+		t.Fatalf("send root turn: %v", err)
+	}
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1",
+		ProviderConversationID: "thread-1",
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["root work"] == domain.TurnStateRunning
+	})
+
+	queued, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "queued automation", ClientMessageID: "c2", Origin: domain.MessageOriginAutomation,
+	})
+	if err != nil {
+		t.Fatalf("queue automation: %v", err)
+	}
+	if queued.State != domain.TurnStateQueued {
+		t.Fatalf("automation state = %q, want queued", queued.State)
+	}
+
+	h.conv.emit(
+		ports.ChatEvent{
+			Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-child-1",
+			ProviderConversationID: "child-thread-1",
+		},
+		ports.ChatEvent{
+			Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-child-1",
+			ProviderConversationID: "child-thread-1", TurnState: domain.TurnStateCompleted,
+		},
+		// This later root event is a deterministic barrier: once projected, the
+		// child's afterProject hook (including any incorrect drain) has finished.
+		ports.ChatEvent{
+			Kind: ports.ChatEventActivityCompleted, ProviderTurnID: "provider-turn-1",
+			ProviderItemID: "root-still-working", ActivityKind: domain.ActivityKindCommand,
+			ActivityStatus: domain.ActivityStatusCompleted, Summary: "root continued",
+		},
+	)
+
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		for _, activity := range s.Activities {
+			if activity.ProviderItemID == "root-still-working" {
+				return true
+			}
+		}
+		return false
+	})
+	states := turnStateByText(t, snapshot)
+	if states["queued automation"] != domain.TurnStateQueued {
+		t.Errorf("automation state after child completion = %q, want queued", states["queued automation"])
+	}
+	if got := h.conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; child completion must not drain queued automation", got)
+	}
+	if got := h.ctrl.State(); got != ports.ChatControllerBusy {
+		t.Errorf("controller state after child completion = %q, want busy", got)
+	}
+	for _, signal := range h.activity.snapshot() {
+		if signal.State == domain.ActivityIdle {
+			t.Fatalf("child completion reported the session idle: %+v", signal)
+		}
+	}
+
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-turn-1",
+		ProviderConversationID: "thread-1", TurnState: domain.TurnStateCompleted,
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["queued automation"] == domain.TurnStateRunning
+	})
+	if got := h.conv.sentTexts(); len(got) != 2 || got[1] != "queued automation" {
+		t.Fatalf("provider received %v, want automation only after root completion", got)
+	}
+	idleReported := false
+	for _, signal := range h.activity.snapshot() {
+		idleReported = idleReported || signal.State == domain.ActivityIdle
+	}
+	if !idleReported {
+		t.Fatal("root completion did not report the session idle")
+	}
+}
+
+// A Chat -> TUI handoff waits for the root turn and everything already queued
+// behind it. Nested Codex lifecycle must not make that drain look complete, nor
+// may it release the accepted queue into a root turn that is still running.
+func TestChatHandoffDrainWaitsForRootAfterNestedTurnCompletes(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "root work", ClientMessageID: "handoff-nested-1", Origin: domain.MessageOriginHuman,
+	}); err != nil {
+		t.Fatalf("send root turn: %v", err)
+	}
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1",
+		ProviderConversationID: "thread-1",
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["root work"] == domain.TurnStateRunning
+	})
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "accepted queue", ClientMessageID: "handoff-nested-2", Origin: domain.MessageOriginAutomation,
+	}); err != nil {
+		t.Fatalf("queue accepted turn: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.svc.PrepareChatHandoff(ctx, testSession, domain.SessionInterfaceTransitionDrain)
+	}()
+
+	h.conv.emit(
+		ports.ChatEvent{
+			Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-child-1",
+			ProviderConversationID: "child-thread-1",
+		},
+		ports.ChatEvent{
+			Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-child-1",
+			ProviderConversationID: "child-thread-1", TurnState: domain.TurnStateCompleted,
+		},
+		ports.ChatEvent{
+			Kind: ports.ChatEventActivityCompleted, ProviderTurnID: "provider-turn-1",
+			ProviderItemID: "handoff-root-still-working", ActivityKind: domain.ActivityKindCommand,
+			ActivityStatus: domain.ActivityStatusCompleted, Summary: "root continued",
+		},
+	)
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		for _, activity := range s.Activities {
+			if activity.ProviderItemID == "handoff-root-still-working" {
+				return true
+			}
+		}
+		return false
+	})
+
+	select {
+	case err := <-done:
+		t.Fatalf("handoff finished after child completion while root was active: %v", err)
+	default:
+	}
+	if got := h.conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; nested completion released the accepted queue", got)
+	}
+
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-turn-1",
+		ProviderConversationID: "thread-1", TurnState: domain.TurnStateCompleted,
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["accepted queue"] == domain.TurnStateRunning
+	})
+	select {
+	case err := <-done:
+		t.Fatalf("handoff finished before its accepted queue completed: %v", err)
+	default:
+	}
+
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-turn-2",
+		ProviderConversationID: "thread-1", TurnState: domain.TurnStateCompleted,
+	})
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("prepare handoff: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("handoff did not become quiescent after the root and accepted queue completed")
+	}
+}
+
 // Stop is a brake. Releasing the queue when the user presses it would be the
 // opposite of what the button says, so anything waiting is cancelled with the turn.
 func TestInterruptCancelsWhatIsQueuedBehindTheTurn(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve Codex's provider thread identity on normalized turn lifecycle events
- let only lifecycle events from the AO-owned root thread claim or release the controller's primary turn
- keep nested child turns durable for transcript correlation without reporting the session idle or draining queued work
- apply volatile turn ownership only after the SQLite projection commits
- serialize lifecycle projection, queue dispatch, and handoff quiescence checks at one dispatch boundary
- prevent nested child notifications from replacing the Codex adapter's fallback Stop target

## Root cause

Codex app-server multiplexes child-agent thread lifecycle notifications over the root conversation connection. AO discarded the notification's `threadId`, stored only one mutable active turn, and treated every `turn/completed` as conversation quiescence.

A child completion could therefore release queued automation while the root was still running. Codex accepted the message into that root, while AO had already minted and bound a different durable turn. Because that assigned provider turn never started, the row stayed `running` and a Chat → TUI drain waited indefinitely.

The CI race run also exposed the adjacent quiescence gap: dispatch marks a queued row running in SQLite just before installing its in-memory active-turn ID. A handoff checking those facts without the dispatch lock could briefly see neither queued nor active work and finish early. The handoff now evaluates both facts under the same lock as dispatch.

The added handoff regression covers the complete user-visible sequence: child completion cannot finish the handoff or release its accepted queue; root completion releases that queue; the handoff finishes only after the queue settles.

## Verification

- controller regression passed 50 consecutive times with the race detector
- focused controller/normalizer/adapter regressions passed 20×
- `go test -p 4 ./...`
- `go test -race -count=1 ./internal/service/chat ./internal/adapters/chatdriver/codexappserver`
- golangci-lint v2.12.2 with fresh Go/lint caches: 0 issues

Related follow-up: #3950 / #3951 durably acknowledge the recovered transition notice so the same historical recovery does not resurface after remounts or restarts.

Fixes #3878
