### PR TITLE
fix(desktop): persist daemon output on the piped launch path

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -506,6 +506,10 @@ function appendDaemonOutput(text: string): void {
 // and dies with the app, so a crash leaves nothing to correlate with the request
 // ID the API handed out. Keep-daemon mode redirects stdio to this same file at
 // spawn time instead, so this writer is only for the piped path.
+//
+// Dev-only (review #3892): in a packaged build the daemon's output already
+// reaches the Electron console, and a second on-disk copy on every launch is
+// noise. The tee-log is a debugging aid for unpackaged runs.
 const DAEMON_LOG_MAX_BYTES = 8 * 1024 * 1024;
 let daemonLogStream: WriteStream | undefined;
 let daemonLogBytes = 0;
@@ -516,6 +520,10 @@ function daemonLogPath(): string {
 
 function openDaemonLog(): void {
 	closeDaemonLog();
+	// Packaged builds skip the durable log entirely; the stream stays undefined so
+	// writeDaemonLog/closeDaemonLog are no-ops. Keep-daemon mode is unaffected —
+	// it redirects stdio to the file at spawn time regardless of dev.
+	if (!isDev) return;
 	const logPath = daemonLogPath();
 	try {
 		mkdirSync(path.dirname(logPath), { recursive: true });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -58,7 +58,18 @@ import {
 } from "./main/ui-settings";
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+	closeSync,
+	createWriteStream,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	statSync,
+	writeFileSync,
+	type WriteStream,
+} from "node:fs";
 import { chmod, copyFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -488,6 +499,66 @@ function appendDaemonOutput(text: string): void {
 	daemonOutput = (daemonOutput + text).slice(-MAX_DAEMON_OUTPUT_CHARS);
 	const nextStatus = refreshSlowDaemonStartupDetails(daemonStatus, daemonOutput);
 	if (nextStatus !== daemonStatus) setDaemonStatus(nextStatus);
+}
+
+// Durable daemon log for the desktop-owned launch (issue #2689). Without it the
+// daemon's stderr — including a panic stack — lives only in the Electron console
+// and dies with the app, so a crash leaves nothing to correlate with the request
+// ID the API handed out. Keep-daemon mode redirects stdio to this same file at
+// spawn time instead, so this writer is only for the piped path.
+const DAEMON_LOG_MAX_BYTES = 8 * 1024 * 1024;
+let daemonLogStream: WriteStream | undefined;
+let daemonLogBytes = 0;
+
+function daemonLogPath(): string {
+	return path.join(os.homedir(), ".ao", ...(isDev ? [DEV_STATE_SUBDIR] : []), "daemon.log");
+}
+
+function openDaemonLog(): void {
+	closeDaemonLog();
+	const logPath = daemonLogPath();
+	try {
+		mkdirSync(path.dirname(logPath), { recursive: true });
+		// Rotate before appending so one long-lived install cannot grow the log
+		// without bound; one generation back is enough to survive a crash loop.
+		let size = 0;
+		try {
+			size = statSync(logPath).size;
+		} catch {
+			size = 0; // absent on first run
+		}
+		if (size >= DAEMON_LOG_MAX_BYTES) {
+			try {
+				renameSync(logPath, `${logPath}.1`);
+				size = 0;
+			} catch {
+				// Rotation is best-effort; appending to an oversized log still beats
+				// losing the crash output entirely.
+			}
+		}
+		daemonLogBytes = size;
+		daemonLogStream = createWriteStream(logPath, { flags: "a" });
+		daemonLogStream.on("error", () => {
+			// A failed log write must never take the app down with it.
+			daemonLogStream = undefined;
+		});
+	} catch {
+		console.warn(`AO: daemon log unavailable: ${logPath}`);
+		daemonLogStream = undefined;
+	}
+}
+
+function closeDaemonLog(): void {
+	daemonLogStream?.end();
+	daemonLogStream = undefined;
+	daemonLogBytes = 0;
+}
+
+function writeDaemonLog(text: string): void {
+	if (!daemonLogStream) return;
+	daemonLogStream.write(text);
+	daemonLogBytes += Buffer.byteLength(text);
+	if (daemonLogBytes >= DAEMON_LOG_MAX_BYTES) openDaemonLog();
 }
 
 // Menu installed on Windows where the native menu bar is hidden. The bar stays
@@ -1732,10 +1803,14 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	if (!keep) {
 		const scanStdout = createListenPortScanner(reportBoundPort);
 		const scanStderr = createListenPortScanner(reportBoundPort);
+		// Mirror the pipes to disk: the scanners still need them, so the log is a
+		// tee rather than the stdio redirect keep-daemon mode uses.
+		openDaemonLog();
 
 		child.stdout?.on("data", (chunk: Buffer) => {
 			const text = chunk.toString("utf8");
 			appendDaemonOutput(text);
+			writeDaemonLog(text);
 			console.log(text.trimEnd());
 			scanStdout(text);
 		});
@@ -1743,6 +1818,7 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		child.stderr?.on("data", (chunk: Buffer) => {
 			const text = chunk.toString("utf8");
 			appendDaemonOutput(text);
+			writeDaemonLog(text);
 			console.error(text.trimEnd());
 			scanStderr(text);
 		});
@@ -1797,6 +1873,12 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 
 	child.once("exit", (code, signal) => {
 		stopDiscovery();
+		// Stamp the exit before closing: a bare stack with no terminator reads as
+		// a truncated log, while "exited with SIGSEGV" names the failure outright.
+		writeDaemonLog(
+			`\n[ao] daemon exited ${signal ? `with ${signal}` : `with code ${code ?? "unknown"}`} at ${new Date().toISOString()}\n`,
+		);
+		closeDaemonLog();
 		if (daemonProcess !== child) return;
 		daemonProcess = null;
 		// An explicit stopDaemon() already set a clean `{ state: "stopped" }`.


### PR DESCRIPTION
## Problem

A desktop-launched daemon writes nothing to disk. The supervisor consumes the child's stdout/stderr pipes and forwards them to the Electron console, so once the app exits there is no record left — a panic stack disappears with it, and the request ID the API returns for log correlation has nothing to correlate against.

Only `AO_KEEP_DAEMON` produced a durable log, because that path redirects stdio to a file at spawn time. The normal packaged launch (`stdio: "pipe"`) has never written one.

Fixes #2689.

## Why not just redirect stdio

The piped path cannot simply point stdio at a file: the supervisor scans both streams for the bound port (`createListenPortScanner`), and port discovery would break. The log therefore has to be a tee — mirror each chunk to disk while leaving the scanners and the Electron console untouched.

## Change

All of it is confined to the `if (!keep)` branch in `frontend/src/main.ts`:

- Mirror stdout/stderr chunks to `~/.ao/daemon.log` (`~/.ao/<dev>/daemon.log` in dev) alongside the existing scanner and console handling.
- Rotate one generation at 8 MiB (`daemon.log` → `daemon.log.1`), checked on open and tracked while writing, so a long-lived install cannot grow it without bound.
- Stamp the exit reason before closing the stream. A bare stack with no terminator is indistinguishable from a truncated log; `[ao] daemon exited with SIGSEGV at <ISO>` names the failure outright.
- Every failure path is best-effort: a stream error clears the writer, an unopenable log warns once, and neither can take the app down. A missing log must never be worse than the current behavior.

Keep-daemon mode is untouched — it already redirects stdio to the same file at spawn time.

## Testing

- `npx tsc --noEmit` clean.
- `npx vitest run src/main/` — 312 passed, 1 skipped (24 files).
- Verified on a packaged build: rebuilt, installed to `/Applications`, and confirmed `~/.ao/daemon.log` receives fresh structured entries within seconds of launch, with the daemon running **without** `AO_KEEP_DAEMON` — the exact path this issue is about. Before the change the file's last write predated the run by three weeks.
