### PR TITLE
fix(conpty): scope pty-host registry to the daemon instance

### DIFF
--- a/backend/internal/adapters/runtime/conpty/ptyregistry/ptyregistry_test.go
+++ b/backend/internal/adapters/runtime/conpty/ptyregistry/ptyregistry_test.go
@@ -25,6 +25,16 @@ func setupHome(t *testing.T) string {
 	return filepath.Join(dir, ".ao", "windows-pty-hosts.json")
 }
 
+// withRunFilePath sets the instance-scoped registry override for the
+// duration of the test and restores the previous value on cleanup, mirroring
+// withFakePidAlive above.
+func withRunFilePath(t *testing.T, path string) {
+	t.Helper()
+	orig := overrideDir
+	SetRunFilePath(path)
+	t.Cleanup(func() { overrideDir = orig })
+}
+
 func nowRFC3339() string {
 	return time.Now().UTC().Format(time.RFC3339)
 }
@@ -226,5 +236,83 @@ func TestAtomicWriteProducesValidJSON(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].PtyHostPID != 99 {
 		t.Fatalf("unexpected entries: %v", entries)
+	}
+}
+
+// TestSetRunFilePathScopesRegistryToInstanceDir verifies that pinning the
+// registry to a run-file's directory writes there instead of ~/.ao, even
+// though HOME still resolves to a different temp dir.
+func TestSetRunFilePathScopesRegistryToInstanceDir(t *testing.T) {
+	homeRegPath := setupHome(t)
+	withFakePidAlive(t, func(int) bool { return true })
+
+	instanceDir := t.TempDir()
+	withRunFilePath(t, filepath.Join(instanceDir, "running.json"))
+
+	e := Entry{SessionID: "s1", PtyHostPID: 1234, PipePath: "127.0.0.1:50000", RegisteredAt: nowRFC3339()}
+	if err := Register(e); err != nil {
+		t.Fatal(err)
+	}
+
+	wantPath := filepath.Join(instanceDir, "windows-pty-hosts.json")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected registry at instance dir %s: %v", wantPath, err)
+	}
+	if _, err := os.Stat(homeRegPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no registry written under HOME %s", homeRegPath)
+	}
+}
+
+// TestTwoInstancesWithDifferentRunFilePathsDoNotShareRegistry is the
+// regression test for the cross-instance session collision: two daemon
+// instances (e.g. a headless dev daemon and the desktop app) with different
+// AO_RUN_FILE locations must not clobber each other's same-named session
+// even though both resolve to one registry file today.
+func TestTwoInstancesWithDifferentRunFilePathsDoNotShareRegistry(t *testing.T) {
+	setupHome(t)
+	withFakePidAlive(t, func(int) bool { return true })
+
+	instanceA := t.TempDir()
+	instanceB := t.TempDir()
+
+	withRunFilePath(t, filepath.Join(instanceA, "running.json"))
+	if err := Register(Entry{SessionID: "demo-website-2", PtyHostPID: 100, PipePath: "127.0.0.1:50001", RegisteredAt: nowRFC3339()}); err != nil {
+		t.Fatal(err)
+	}
+
+	withRunFilePath(t, filepath.Join(instanceB, "running.json"))
+	if err := Register(Entry{SessionID: "demo-website-2", PtyHostPID: 200, PipePath: "127.0.0.1:50002", RegisteredAt: nowRFC3339()}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Instance A's own registration for the same session id must be
+	// untouched by instance B registering a session of the same name.
+	withRunFilePath(t, filepath.Join(instanceA, "running.json"))
+	got, err := List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].PtyHostPID != 100 {
+		t.Fatalf("expected instance A's own entry (pid 100) untouched by instance B, got %v", got)
+	}
+}
+
+// TestSetRunFilePathEmptyClearsOverride verifies the documented contract: an
+// empty path clears any override and reverts to the ~/.ao default. This is
+// what lets conpty.New(Options{}) -- the zero value used throughout this
+// package's own tests -- always start from a clean, deterministic registry
+// resolution regardless of what an earlier test configured.
+func TestSetRunFilePathEmptyClearsOverride(t *testing.T) {
+	regPath := setupHome(t)
+	withFakePidAlive(t, func(int) bool { return true })
+
+	withRunFilePath(t, filepath.Join(t.TempDir(), "running.json"))
+	withRunFilePath(t, "")
+
+	if err := Register(Entry{SessionID: "s1", PtyHostPID: 1, PipePath: "127.0.0.1:50000", RegisteredAt: nowRFC3339()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(regPath); err != nil {
+		t.Fatalf("expected default HOME-based registry at %s: %v", regPath, err)
 	}
 }

--- a/backend/internal/adapters/runtime/conpty/ptyregistry/registry.go
+++ b/backend/internal/adapters/runtime/conpty/ptyregistry/registry.go
@@ -24,10 +24,41 @@ type Entry struct {
 // pidalive_windows.go).
 var pidAlive = defaultPidAlive
 
-// registryFile resolves ~/.ao/windows-pty-hosts.json. Uses os.UserHomeDir()
-// so t.Setenv("HOME", dir) in tests redirects reads/writes to a temp dir.
-// ponytail: HOME-based resolution; no AO_DATA_DIR override needed here.
+// overrideDir, when set, is the directory the registry file lives in for
+// this daemon instance, taking precedence over the ~/.ao default. Set once by
+// SetRunFilePath at daemon startup, before any session activity begins, so
+// the unsynchronized package var has no concurrent access to race against.
+var overrideDir string
+
+// SetRunFilePath pins the registry to the directory containing this
+// instance's running.json (backend/internal/config's already-resolved,
+// absolute Config.RunFilePath). Two AO daemons on one machine — e.g. a
+// headless dev daemon and the desktop app, or two dev daemons — normally run
+// fully isolated via AO_RUN_FILE/AO_DATA_DIR overrides, but the registry
+// ignored that and always resolved to ~/.ao regardless: with the same
+// project checked out in both, their independently-numbered session ids
+// (e.g. "demo-website-2") could collide, and the second instance's
+// registration would silently overwrite the first's pty-host address,
+// attaching that session's terminal to the wrong process. Co-locating the
+// registry with each instance's own running.json keeps them isolated the
+// same way the SQLite store already is. An empty path clears any override,
+// reverting to the ~/.ao default.
+func SetRunFilePath(path string) {
+	if path == "" {
+		overrideDir = ""
+		return
+	}
+	overrideDir = filepath.Dir(path)
+}
+
+// registryFile resolves the pty-host registry path: overrideDir joined with
+// the registry filename when set via SetRunFilePath, otherwise
+// ~/.ao/windows-pty-hosts.json via os.UserHomeDir() so t.Setenv("HOME", dir)
+// in tests redirects reads/writes to a temp dir.
 func registryFile() (string, error) {
+	if overrideDir != "" {
+		return filepath.Join(overrideDir, "windows-pty-hosts.json"), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/backend/internal/adapters/runtime/conpty/runtime.go
+++ b/backend/internal/adapters/runtime/conpty/runtime.go
@@ -36,6 +36,13 @@ type Options struct {
 	// Spawner overrides the default OS-level process spawner. If nil,
 	// defaultSpawnHost is used (Windows-only; returns an error on other OSes).
 	Spawner hostSpawner
+
+	// RunFilePath is this daemon instance's running.json path (config.Config.
+	// RunFilePath). It scopes the B2 pty-host registry to the same directory,
+	// so two AO instances on one machine with different AO_RUN_FILE/
+	// AO_DATA_DIR overrides never share one registry -- see
+	// ptyregistry.SetRunFilePath. Empty uses the ~/.ao default.
+	RunFilePath string
 }
 
 // Runtime is the conpty runtime adapter.
@@ -53,6 +60,7 @@ type Runtime struct {
 
 // New creates a Runtime with the given options.
 func New(opts Options) *Runtime {
+	ptyregistry.SetRunFilePath(opts.RunFilePath)
 	sp := opts.Spawner
 	if sp == nil {
 		sp = defaultSpawnHost

--- a/backend/internal/adapters/runtime/conpty/runtime_test.go
+++ b/backend/internal/adapters/runtime/conpty/runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -165,6 +166,39 @@ func TestCreate_RegistersSession(t *testing.T) {
 	}
 
 	hosts["sess-abc"].cleanup(t)
+}
+
+// TestCreate_RunFilePathScopesRegistryToInstanceDir verifies Create honors
+// Options.RunFilePath, registering into that instance's own registry file
+// instead of the ~/.ao default. This is the fix for two AO daemon instances
+// on one machine (e.g. a headless dev daemon and the desktop app) silently
+// sharing one pty-host registry and cross-wiring same-named sessions.
+func TestCreate_RunFilePathScopesRegistryToInstanceDir(t *testing.T) {
+	isolateRegistry(t)
+	instanceDir := t.TempDir()
+	hosts := map[string]*inProcHost{}
+	rt := New(Options{
+		Spawner:     fakeSpawnerFor(t, hosts, livePID()),
+		RunFilePath: filepath.Join(instanceDir, "running.json"),
+	})
+
+	handle, err := rt.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     domain.SessionID("sess-scoped"),
+		WorkspacePath: "/tmp/workspace",
+		Argv:          []string{"claude-code"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if handle.ID != "sess-scoped" {
+		t.Fatalf("handle.ID = %q, want %q", handle.ID, "sess-scoped")
+	}
+	defer hosts["sess-scoped"].cleanup(t)
+
+	wantPath := filepath.Join(instanceDir, "windows-pty-hosts.json")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected registry at instance dir %s: %v", wantPath, err)
+	}
 }
 
 // TestCreate_DuplicateErrors verifies a second Create for the same session id fails.

--- a/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
+++ b/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
@@ -29,11 +29,16 @@ type Runtime interface {
 var _ Runtime = (*tmux.Runtime)(nil)
 var _ Runtime = (*conpty.Runtime)(nil)
 
-// New returns the per-platform runtime: tmux on Darwin/Linux, conpty on Windows.
-// log is accepted for signature stability with callers but is currently unused.
-func New(_ *slog.Logger) Runtime {
+// New returns the per-platform runtime: tmux on Darwin/Linux, conpty on
+// Windows. log is accepted for signature stability with callers but is
+// currently unused. runFilePath is this daemon instance's running.json path
+// (config.Config.RunFilePath); on Windows it scopes the conpty pty-host
+// registry to the same instance, so two AO daemons on one machine with
+// different AO_RUN_FILE/AO_DATA_DIR overrides never share one registry — see
+// ptyregistry.SetRunFilePath.
+func New(_ *slog.Logger, runFilePath string) Runtime {
 	if runtime.GOOS != "windows" {
 		return tmux.New(tmux.Options{})
 	}
-	return conpty.New(conpty.Options{})
+	return conpty.New(conpty.Options{RunFilePath: runFilePath})
 }

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -137,7 +137,7 @@ func Run() error {
 	// attach Stream and liveness; the CDC broadcaster feeds the session-state channel. The manager
 	// is handed to httpd, which mounts it at /mux. Raw PTY bytes never flow
 	// through the CDC change_log -- only session-state events do.
-	runtimeAdapter := runtimeselect.New(log)
+	runtimeAdapter := runtimeselect.New(log, cfg.RunFilePath)
 	managedPreview := previewserver.New(log, cfg.DataDir)
 	termMgr := terminal.NewManager(runtimeAdapter, cdcPipe.Broadcaster, log)
 	defer termMgr.Close()

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -185,7 +185,7 @@ func TestWiring_StartSessionBuildsSessionService(t *testing.T) {
 	lcm := lifecycle.New(store, nil)
 	cfg := config.Config{DataDir: t.TempDir()}
 
-	rt := runtimeselect.New(nil)
+	rt := runtimeselect.New(nil, cfg.RunFilePath)
 	messenger := newSessionMessenger(store, rt, log)
 	agents, err := buildAgentResolver(config.DefaultAgent, log)
 	if err != nil {
@@ -301,7 +301,7 @@ func TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	lcm := lifecycle.New(store, nil)
 	cfg := config.Config{DataDir: t.TempDir()}
-	rt := runtimeselect.New(nil)
+	rt := runtimeselect.New(nil, cfg.RunFilePath)
 	messenger := newSessionMessenger(store, rt, log)
 	agents, agentsErr := buildAgentResolver(config.DefaultAgent, log)
 	if agentsErr != nil {
@@ -360,7 +360,7 @@ func TestStartTrackerIntake_RunsEvenWithoutEnabledProjects(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	lcm := lifecycle.New(store, nil)
 	cfg := config.Config{DataDir: t.TempDir()}
-	rt := runtimeselect.New(nil)
+	rt := runtimeselect.New(nil, cfg.RunFilePath)
 	messenger := newSessionMessenger(store, rt, log)
 	agents, agentsErr := buildAgentResolver(config.DefaultAgent, log)
 	if agentsErr != nil {


### PR DESCRIPTION
## Summary

- The Windows ConPTY runtime's pty-host registry (`~/.ao/windows-pty-hosts.json`) was hardcoded to the default AO home directory via `os.UserHomeDir()`, ignoring the `AO_RUN_FILE`/`AO_DATA_DIR` overrides every other piece of daemon state (`ao.db`, `running.json`) already respects.
- Two AO daemon instances on one machine (e.g. a headless dev daemon at `~/.ao/dev` and the desktop app at `~/.ao`) therefore shared one registry file even though they're otherwise fully isolated.
- Session ids are numbered per-project within each instance's own local DB (`NextSessionNum`), so two instances with the same project can independently mint identical session ids (e.g. `demo-website-2`). The second instance's registration would then silently overwrite the first's pty-host address in the shared registry — attaching that session's terminal to the *wrong* process.
- `ptyregistry.SetRunFilePath` now scopes the registry to the directory containing the calling instance's own `running.json`, wired through `conpty.Options.RunFilePath` and a new `runFilePath` parameter on `runtimeselect.New`, sourced from the daemon's already-resolved `cfg.RunFilePath`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — new/changed packages pass cleanly; pre-existing failures on this Windows dev environment (`TestStabilizeWorkingDirectoryChdirsToDataDir`, tmux `/tmp`-path tests, `TestWriteAgentHandoffFileIsPrivateAtomicAndImmutable`, `TestSpawn_*` branch-namespace tests, `workspacewatch` watcher timing) reproduce identically on the unmodified base branch and are unrelated (none of those packages import `conpty`/`ptyregistry`/`runtimeselect`)
- [x] New regression test (`TestTwoInstancesWithDifferentRunFilePathsDoNotShareRegistry`) reproduces the exact cross-instance collision and verifies it no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)