### PR TITLE
fix(desktop): preserve Intel Node JIT entitlement

### DIFF
--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -48,45 +48,6 @@ Windows installers follow the same boundary (#4502): the NSIS maker
 when signing credentials are present in the environment, so the public build
 stays unsigned while the conductor signs with its own credentials downstream.
 
-## macOS signing contract for the bundled ACP runtime
-
-This repository builds unsigned, so `packagerConfig.osxSign` — and the per-file
-hook `macSignOptionsForFile` in `frontend/forge.config.ts` — never runs on
-published bytes. The canonical signer re-signs the bundle downstream and is the
-only place the following contract is enforced. Whoever signs a bundle containing
-`<App>.app/Contents/Resources/acp-runtime/node/bin/node` must:
-
-- give the nested Node `com.apple.security.cs.allow-jit` **and**
-  `com.apple.security.cs.allow-unsigned-executable-memory` if and only if the
-  binary contains an x86_64 Mach-O slice (a thin x64 binary, or a universal
-  carrying an x64 slice); an arm64-only binary keeps `allow-jit` alone. V8 uses
-  mprotect for JIT on x64, which Hardened Runtime blocks without the second
-  entitlement, and the Node then crashes in `SetPermissions` (#3879);
-- derive that decision from the Mach-O header of the file being signed
-  (`frontend/makers/macho-archs.ts`, `machoHasX86_64Slice`), never from the
-  signing host's architecture (`process.arch`, `uname -m`): one signing host
-  handles both architectures;
-- fail the signing pass when that binary cannot be read or parsed — never fall
-  back to the host architecture or to no entitlements;
-- leave every other bundle file on `@electron/osx-sign` defaults; widening the
-  executable-memory entitlement beyond the x64 ACP Node is out of scope.
-
-Before publication, the final artifacts must prove the contract: the nested
-Node's entitlements are inspected in the signed bundle, and the shipped x64
-zip's Node actually executes JavaScript on a native Intel runner (the public
-build matrix's `macos-15-intel` leg is the precedent). Keep the arm64
-verification as well.
-
-The verifier-side counterpart is rule 5 of
-`frontend/scripts/verify-mac-artifact.sh`: `codesign -d --entitlements :-` on
-the nested Node, `lipo -archs` for the arch decision, and a guarded `node -e`
-execution only after codesign, Gatekeeper, and stapler all pass. The JS helper
-and `lipo` agree on the one invariant that matters — "contains an x86_64
-slice"; `lipo` may print `arm64e` for an arm64 slice (it names slices from
-cpusubtype) where the helper reports `arm64` (it classifies by cputype), which
-is intentional. Confirm what actually landed on the bytes with
-`codesign -d --entitlements :- <node> | plutil -p`.
-
 ## Channels
 
 - **Stable** releases are deliberate production cuts. After all verification
@@ -104,8 +65,7 @@ but changing it in this repository is not a release trigger.
 
 ## Artifact verification
 
-The conductor owns the authoritative verification and publication gates; this
-script is the local diagnostic counterpart, not the publication gate. For a
+The conductor owns the authoritative verification and publication gates. For a
 local diagnosis of a downloaded macOS artifact, use the repository's supported
 verification script:
 

--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -48,6 +48,45 @@ Windows installers follow the same boundary (#4502): the NSIS maker
 when signing credentials are present in the environment, so the public build
 stays unsigned while the conductor signs with its own credentials downstream.
 
+## macOS signing contract for the bundled ACP runtime
+
+This repository builds unsigned, so `packagerConfig.osxSign` — and the per-file
+hook `macSignOptionsForFile` in `frontend/forge.config.ts` — never runs on
+published bytes. The canonical signer re-signs the bundle downstream and is the
+only place the following contract is enforced. Whoever signs a bundle containing
+`<App>.app/Contents/Resources/acp-runtime/node/bin/node` must:
+
+- give the nested Node `com.apple.security.cs.allow-jit` **and**
+  `com.apple.security.cs.allow-unsigned-executable-memory` if and only if the
+  binary contains an x86_64 Mach-O slice (a thin x64 binary, or a universal
+  carrying an x64 slice); an arm64-only binary keeps `allow-jit` alone. V8 uses
+  mprotect for JIT on x64, which Hardened Runtime blocks without the second
+  entitlement, and the Node then crashes in `SetPermissions` (#3879);
+- derive that decision from the Mach-O header of the file being signed
+  (`frontend/makers/macho-archs.ts`, `machoHasX86_64Slice`), never from the
+  signing host's architecture (`process.arch`, `uname -m`): one signing host
+  handles both architectures;
+- fail the signing pass when that binary cannot be read or parsed — never fall
+  back to the host architecture or to no entitlements;
+- leave every other bundle file on `@electron/osx-sign` defaults; widening the
+  executable-memory entitlement beyond the x64 ACP Node is out of scope.
+
+Before publication, the final artifacts must prove the contract: the nested
+Node's entitlements are inspected in the signed bundle, and the shipped x64
+zip's Node actually executes JavaScript on a native Intel runner (the public
+build matrix's `macos-15-intel` leg is the precedent). Keep the arm64
+verification as well.
+
+The verifier-side counterpart is rule 5 of
+`frontend/scripts/verify-mac-artifact.sh`: `codesign -d --entitlements :-` on
+the nested Node, `lipo -archs` for the arch decision, and a guarded `node -e`
+execution only after codesign, Gatekeeper, and stapler all pass. The JS helper
+and `lipo` agree on the one invariant that matters — "contains an x86_64
+slice"; `lipo` may print `arm64e` for an arm64 slice (it names slices from
+cpusubtype) where the helper reports `arm64` (it classifies by cputype), which
+is intentional. Confirm what actually landed on the bytes with
+`codesign -d --entitlements :- <node> | plutil -p`.
+
 ## Channels
 
 - **Stable** releases are deliberate production cuts. After all verification
@@ -65,7 +104,8 @@ but changing it in this repository is not a release trigger.
 
 ## Artifact verification
 
-The conductor owns the authoritative verification and publication gates. For a
+The conductor owns the authoritative verification and publication gates; this
+script is the local diagnostic counterpart, not the publication gate. For a
 local diagnosis of a downloaded macOS artifact, use the repository's supported
 verification script:
 

--- a/frontend/forge.config.test.ts
+++ b/frontend/forge.config.test.ts
@@ -1,4 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MachOParseError } from "./makers/macho-archs";
 
 // postMake's dmg/zip branches only need to prove they call the right
 // maker-dmg functions with the right gates; the functions' own behavior
@@ -19,6 +23,67 @@ vi.mock("./makers/maker-dmg", async (importOriginal) => {
 });
 
 import config, { extraResourcesForPlatform, macSignOptionsForFile } from "./forge.config";
+
+// Minimal synthetic Mach-O headers (thin little-endian + fat big-endian), the
+// two on-disk layouts the signing selector must tell apart. Full parser
+// coverage lives in makers/macho-archs.test.ts; here the fixtures exist so the
+// per-file signing decision is exercised against real file bytes.
+const CPU_TYPE_X86_64 = 0x01000007;
+const CPU_TYPE_ARM64 = 0x0100000c;
+
+function thinMachO(cputype: number): Buffer {
+	const buffer = Buffer.alloc(16);
+	buffer.writeUInt32LE(0xfeedfacf, 0);
+	buffer.writeUInt32LE(cputype, 4);
+	return buffer;
+}
+
+function fatMachO(entries: number[]): Buffer {
+	const buffer = Buffer.alloc(8 + entries.length * 20);
+	buffer.writeUInt32BE(0xcafebabe, 0);
+	buffer.writeUInt32BE(entries.length, 4);
+	entries.forEach((cputype, index) => {
+		buffer.writeUInt32BE(cputype, 8 + index * 20);
+	});
+	return buffer;
+}
+
+function withHostArch<T>(arch: string, run: () => T): T {
+	const descriptor = Object.getOwnPropertyDescriptor(process, "arch");
+	Object.defineProperty(process, "arch", { get: () => arch, configurable: true });
+	try {
+		return run();
+	} finally {
+		if (descriptor) Object.defineProperty(process, "arch", descriptor);
+	}
+}
+
+let fixtureDir: string;
+
+// The nested Node must sit at the real bundle path shape: the endsWith gate
+// and the content selector are two halves of one decision.
+function acpNodeWith(contents: Buffer): string {
+	const binDir = join(
+		fixtureDir,
+		"Agent Orchestrator.app",
+		"Contents",
+		"Resources",
+		"acp-runtime",
+		"node",
+		"bin",
+	);
+	mkdirSync(binDir, { recursive: true });
+	writeFileSync(join(binDir, "node"), contents);
+	return join(binDir, "node");
+}
+
+beforeEach(() => {
+	fixtureDir = mkdtempSync(join(tmpdir(), "forge-signing-"));
+});
+
+afterEach(() => {
+	rmSync(fixtureDir, { recursive: true, force: true });
+});
 
 describe("native runtime resources", () => {
 	it.each(["darwin", "linux"] as const)("bundles tmux on %s", (platform) => {
@@ -56,32 +121,52 @@ afterEach(() => {
 });
 
 describe("macOS signing", () => {
+	const NODE_ENTITLEMENTS = [
+		"com.apple.security.cs.allow-jit",
+		"com.apple.security.cs.allow-unsigned-executable-memory",
+	];
+
 	it("allows the bundled Node runtime to execute V8 JIT code on Intel Macs", () => {
-		expect(
-			macSignOptionsForFile(
-				"/tmp/Agent Orchestrator.app/Contents/Resources/acp-runtime/node/bin/node",
-				"x64",
-			),
-		).toEqual({
-			entitlements: [
-				"com.apple.security.cs.allow-jit",
-				"com.apple.security.cs.allow-unsigned-executable-memory",
-			],
+		expect(macSignOptionsForFile(acpNodeWith(thinMachO(CPU_TYPE_X86_64)))).toEqual({
+			entitlements: NODE_ENTITLEMENTS,
+		});
+	});
+
+	it("keeps the override for a universal binary carrying an x86_64 slice", () => {
+		expect(macSignOptionsForFile(acpNodeWith(fatMachO([CPU_TYPE_X86_64, CPU_TYPE_ARM64])))).toEqual({
+			entitlements: NODE_ENTITLEMENTS,
 		});
 	});
 
 	it("keeps electron-osx-sign defaults for every other bundle file", () => {
-		expect(
-			macSignOptionsForFile(
-				"/tmp/Agent Orchestrator.app/Contents/MacOS/agent-orchestrator",
-			),
-		).toEqual({});
+		const foreign = join(fixtureDir, "elsewhere", "agent-orchestrator");
+		mkdirSync(join(fixtureDir, "elsewhere"), { recursive: true });
+		writeFileSync(foreign, thinMachO(CPU_TYPE_X86_64));
+		expect(macSignOptionsForFile(foreign)).toEqual({});
 	});
 
-	it("keeps the narrower default JIT entitlement on Apple silicon", () => {
-		expect(
-			macSignOptionsForFile("/tmp/Agent Orchestrator.app/Contents/Resources/acp-runtime/node/bin/node", "arm64"),
-		).toEqual({});
+	it("keeps the narrower default JIT entitlement when the binary has no x86_64 slice", () => {
+		expect(macSignOptionsForFile(acpNodeWith(thinMachO(CPU_TYPE_ARM64)))).toEqual({});
+		expect(macSignOptionsForFile(acpNodeWith(fatMachO([CPU_TYPE_ARM64])))).toEqual({});
+	});
+
+	it("fails the signing pass when the file cannot be parsed", () => {
+		expect(() => macSignOptionsForFile(acpNodeWith(Buffer.from("garbage header")))).toThrow(
+			MachOParseError,
+		);
+		expect(() =>
+			macSignOptionsForFile(acpNodeWith(Buffer.from([0xcf, 0xfa, 0xed, 0xfe]))),
+		).toThrow(MachOParseError);
+	});
+
+	it("never consults the host architecture", () => {
+		const acpNode = acpNodeWith(thinMachO(CPU_TYPE_ARM64));
+		const fromX64Host = withHostArch("x64", () => macSignOptionsForFile(acpNode));
+		const fromArm64Host = withHostArch("arm64", () => macSignOptionsForFile(acpNode));
+		const fromAbsurdHost = withHostArch("ppc64", () => macSignOptionsForFile(acpNode));
+		expect(fromX64Host).toEqual({});
+		expect(fromArm64Host).toEqual({});
+		expect(fromAbsurdHost).toEqual({});
 	});
 
 	it.each([

--- a/frontend/forge.config.test.ts
+++ b/frontend/forge.config.test.ts
@@ -1,4 +1,23 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+// postMake's dmg/zip branches only need to prove they call the right
+// maker-dmg functions with the right gates; the functions' own behavior
+// (sealDmg's credential matrix, verifyMacArtifact's script invocation) is
+// covered by makers/maker-dmg.test.ts. Mocking the whole module keeps this
+// suite from spawning codesign/xcrun/bash indirectly through the real chain.
+// vi.mock's factory is hoisted above the rest of the file (including plain
+// const declarations), so the mock fns themselves must go through vi.hoisted.
+const { sealDmg, verifyDmg, verifyMacArtifact, isSigningConfigured } = vi.hoisted(() => ({
+	sealDmg: vi.fn<(path: string) => Promise<boolean>>(),
+	verifyDmg: vi.fn<(path: string) => Promise<void>>(async () => undefined),
+	verifyMacArtifact: vi.fn<(path: string) => Promise<void>>(async () => undefined),
+	isSigningConfigured: vi.fn<() => boolean>(),
+}));
+vi.mock("./makers/maker-dmg", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./makers/maker-dmg")>();
+	return { ...actual, sealDmg, verifyDmg, verifyMacArtifact, isSigningConfigured };
+});
+
 import config, { extraResourcesForPlatform, macSignOptionsForFile } from "./forge.config";
 
 describe("native runtime resources", () => {
@@ -30,6 +49,10 @@ async function loadMacSignOptions(env: {
 afterEach(() => {
 	vi.unstubAllEnvs();
 	vi.resetModules();
+	sealDmg.mockReset();
+	verifyDmg.mockReset().mockImplementation(async () => undefined);
+	verifyMacArtifact.mockReset().mockImplementation(async () => undefined);
+	isSigningConfigured.mockReset();
 });
 
 describe("macOS signing", () => {
@@ -81,6 +104,78 @@ describe("macOS signing", () => {
 
 	it("leaves unsigned local packages unsigned", async () => {
 		await expect(loadMacSignOptions({})).resolves.toBeUndefined();
+	});
+});
+
+describe("postMake artifact verification", () => {
+	// #3879: a valid outer seal did not prove the bundled Intel ACP Node could
+	// actually run JavaScript. The dmg branch already ran verify-mac-artifact.sh
+	// through sealDmg/verifyDmg; these cases prove the zip branch — the artifact
+	// electron-updater installs auto-updates from, and per-arch what CI ships
+	// for x64 — gets the same nested-Node check instead of shipping unverified.
+	function darwinResult(artifacts: string[]) {
+		return [{ artifacts, packageJSON: {}, platform: "darwin" as const, arch: "x64" as const }];
+	}
+
+	it("verifies a signed zip with the canonical script, gated on isSigningConfigured", async () => {
+		isSigningConfigured.mockReturnValue(true);
+		const makeResults = darwinResult(["/out/make/zip/agent-orchestrator-darwin-x64.zip"]);
+
+		await config.hooks?.postMake?.({} as never, makeResults);
+
+		expect(verifyMacArtifact).toHaveBeenCalledWith("/out/make/zip/agent-orchestrator-darwin-x64.zip");
+	});
+
+	it("skips zip verification for an unsigned local build", async () => {
+		isSigningConfigured.mockReturnValue(false);
+		const makeResults = darwinResult(["/out/make/zip/agent-orchestrator-darwin-x64.zip"]);
+
+		await config.hooks?.postMake?.({} as never, makeResults);
+
+		expect(verifyMacArtifact).not.toHaveBeenCalled();
+	});
+
+	it("still seals and verifies the dmg through the existing sealDmg/verifyDmg path", async () => {
+		isSigningConfigured.mockReturnValue(true);
+		sealDmg.mockResolvedValue(true);
+		const makeResults = darwinResult(["/out/make/app.dmg"]);
+
+		await config.hooks?.postMake?.({} as never, makeResults);
+
+		expect(sealDmg).toHaveBeenCalledWith("/out/make/app.dmg");
+		expect(verifyDmg).toHaveBeenCalledWith("/out/make/app.dmg");
+		expect(verifyMacArtifact).not.toHaveBeenCalled();
+	});
+
+	it("verifies both the dmg and the zip when a make run produces both", async () => {
+		isSigningConfigured.mockReturnValue(true);
+		sealDmg.mockResolvedValue(true);
+		const makeResults = darwinResult([
+			"/out/make/zip/agent-orchestrator-darwin-x64.zip",
+			"/out/make/app.dmg",
+		]);
+
+		await config.hooks?.postMake?.({} as never, makeResults);
+
+		expect(verifyMacArtifact).toHaveBeenCalledWith("/out/make/zip/agent-orchestrator-darwin-x64.zip");
+		expect(verifyDmg).toHaveBeenCalledWith("/out/make/app.dmg");
+	});
+
+	it("never verifies non-darwin artifacts", async () => {
+		const makeResults = [
+			{
+				artifacts: ["/out/make/agent-orchestrator.exe"],
+				packageJSON: {},
+				platform: "win32" as const,
+				arch: "x64" as const,
+			},
+		];
+
+		await config.hooks?.postMake?.({} as never, makeResults);
+
+		expect(sealDmg).not.toHaveBeenCalled();
+		expect(verifyDmg).not.toHaveBeenCalled();
+		expect(verifyMacArtifact).not.toHaveBeenCalled();
 	});
 });
 

--- a/frontend/forge.config.test.ts
+++ b/frontend/forge.config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import config, { extraResourcesForPlatform } from "./forge.config";
+import config, { extraResourcesForPlatform, macSignOptionsForFile } from "./forge.config";
 
 describe("native runtime resources", () => {
 	it.each(["darwin", "linux"] as const)("bundles tmux on %s", (platform) => {
@@ -8,6 +8,29 @@ describe("native runtime resources", () => {
 
 	it("does not bundle tmux on Windows", () => {
 		expect(extraResourcesForPlatform("win32")).not.toContain("tmux");
+	});
+});
+
+describe("macOS signing", () => {
+	it("allows the bundled Node runtime to execute V8 JIT code on Intel Macs", () => {
+		expect(
+			macSignOptionsForFile(
+				"/tmp/Agent Orchestrator.app/Contents/Resources/acp-runtime/node/bin/node",
+			),
+		).toEqual({
+			entitlements: [
+				"com.apple.security.cs.allow-jit",
+				"com.apple.security.cs.allow-unsigned-executable-memory",
+			],
+		});
+	});
+
+	it("keeps electron-osx-sign defaults for every other bundle file", () => {
+		expect(
+			macSignOptionsForFile(
+				"/tmp/Agent Orchestrator.app/Contents/MacOS/agent-orchestrator",
+			),
+		).toEqual({});
 	});
 });
 

--- a/frontend/forge.config.test.ts
+++ b/frontend/forge.config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import config, { extraResourcesForPlatform, macSignOptionsForFile } from "./forge.config";
 
 describe("native runtime resources", () => {
@@ -11,11 +11,33 @@ describe("native runtime resources", () => {
 	});
 });
 
+type MacSignOptions = {
+	identity?: string;
+	optionsForFile?: typeof macSignOptionsForFile;
+};
+
+async function loadMacSignOptions(env: {
+	APPLE_SIGNING_IDENTITY?: string;
+	CSC_LINK?: string;
+}): Promise<MacSignOptions | undefined> {
+	vi.stubEnv("APPLE_SIGNING_IDENTITY", env.APPLE_SIGNING_IDENTITY ?? "");
+	vi.stubEnv("CSC_LINK", env.CSC_LINK ?? "");
+	vi.resetModules();
+	const { default: envConfig } = await import("./forge.config");
+	return envConfig.packagerConfig?.osxSign as MacSignOptions | undefined;
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.resetModules();
+});
+
 describe("macOS signing", () => {
 	it("allows the bundled Node runtime to execute V8 JIT code on Intel Macs", () => {
 		expect(
 			macSignOptionsForFile(
 				"/tmp/Agent Orchestrator.app/Contents/Resources/acp-runtime/node/bin/node",
+				"x64",
 			),
 		).toEqual({
 			entitlements: [
@@ -31,6 +53,34 @@ describe("macOS signing", () => {
 				"/tmp/Agent Orchestrator.app/Contents/MacOS/agent-orchestrator",
 			),
 		).toEqual({});
+	});
+
+	it("keeps the narrower default JIT entitlement on Apple silicon", () => {
+		expect(
+			macSignOptionsForFile("/tmp/Agent Orchestrator.app/Contents/Resources/acp-runtime/node/bin/node", "arm64"),
+		).toEqual({});
+	});
+
+	it.each([
+		{
+			name: "an explicit signing identity",
+			env: { APPLE_SIGNING_IDENTITY: "Developer ID Application: AO (TEAMID)" },
+			identity: "Developer ID Application: AO (TEAMID)",
+		},
+		{
+			name: "a CSC_LINK certificate",
+			env: { CSC_LINK: "base64-certificate" },
+			identity: undefined,
+		},
+	])("wires the per-file override when signing with $name", async ({ env, identity }) => {
+		const signOptions = await loadMacSignOptions(env);
+
+		expect(signOptions?.identity).toBe(identity);
+		expect(signOptions?.optionsForFile).toEqual(expect.any(Function));
+	});
+
+	it("leaves unsigned local packages unsigned", async () => {
+		await expect(loadMacSignOptions({})).resolves.toBeUndefined();
 	});
 });
 

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -5,6 +5,7 @@ import { rebuild } from "@electron/rebuild";
 import electronPackage from "electron/package.json";
 import MakerNSIS from "./makers/maker-nsis";
 import MakerDMG, { isSigningConfigured, sealDmg, verifyDmg, verifyMacArtifact } from "./makers/maker-dmg";
+import { machoHasX86_64Slice } from "./makers/macho-archs";
 import MakerAppImage from "./makers/maker-appimage";
 import { existsSync, readdirSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -73,19 +74,30 @@ export function extraResourcesForPlatform(platform: NodeJS.Platform): string[] {
 
 const ACP_RUNTIME_NODE_PATH = "/Contents/Resources/acp-runtime/node/bin/node";
 // V8 uses MAP_JIT on arm64 and mprotect on x64. electron-osx-sign's default
-// allows only the former, so its re-signing makes the bundled Node crash on Intel.
+// allows only the former, so its re-signing makes the bundled Node crash on
+// Intel (#3879). Which entitlements a file needs is a property of its bytes,
+// not of the signing machine: @electron/osx-sign hands optionsForFile only the
+// path, and one signing host may sign both the arm64 and the x64 artifact —
+// the canonical release signer does exactly that. So the selector below keys
+// off the Mach-O header of the file being signed (thin x64, or a universal
+// carrying an x64 slice), never off process.arch. The public CI build stays
+// unsigned, so this hook runs for locally signed builds and stands as the
+// reference implementation the canonical signer mirrors; see
+// frontend/docs/desktop-release.md.
 const ACP_RUNTIME_NODE_ENTITLEMENTS = [
 	"com.apple.security.cs.allow-jit",
 	"com.apple.security.cs.allow-unsigned-executable-memory",
 ];
 
-export function macSignOptionsForFile(
-	filePath: string,
-	arch: NodeJS.Architecture = process.arch,
-): { entitlements?: string[] } {
-	return arch === "x64" && filePath.endsWith(ACP_RUNTIME_NODE_PATH)
-		? { entitlements: ACP_RUNTIME_NODE_ENTITLEMENTS }
-		: {};
+export function macSignOptionsForFile(filePath: string): { entitlements?: string[] } {
+	// Cheap gate first: optionsForFile is invoked for every Mach-O in the
+	// bundle, and only the nested Node path can need an override.
+	if (!filePath.endsWith(ACP_RUNTIME_NODE_PATH)) return {};
+	// Fail closed: an unreadable or unparseable binary throws out of
+	// optionsForFile and aborts the signing pass. Never fall back to
+	// process.arch or to "no entitlements" — silently signing the Intel Node
+	// without allow-unsigned-executable-memory is exactly the #3879 crash.
+	return machoHasX86_64Slice(filePath) ? { entitlements: ACP_RUNTIME_NODE_ENTITLEMENTS } : {};
 }
 
 // parseReleaseRepo turns an "owner/repo" string (from AO_RELEASE_REPO) into the

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -79,8 +79,11 @@ const ACP_RUNTIME_NODE_ENTITLEMENTS = [
 	"com.apple.security.cs.allow-unsigned-executable-memory",
 ];
 
-export function macSignOptionsForFile(filePath: string): { entitlements?: string[] } {
-	return filePath.endsWith(ACP_RUNTIME_NODE_PATH)
+export function macSignOptionsForFile(
+	filePath: string,
+	arch: NodeJS.Architecture = process.arch,
+): { entitlements?: string[] } {
+	return arch === "x64" && filePath.endsWith(ACP_RUNTIME_NODE_PATH)
 		? { entitlements: ACP_RUNTIME_NODE_ENTITLEMENTS }
 		: {};
 }

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -4,7 +4,7 @@ import { VitePlugin } from "@electron-forge/plugin-vite";
 import { rebuild } from "@electron/rebuild";
 import electronPackage from "electron/package.json";
 import MakerNSIS from "./makers/maker-nsis";
-import MakerDMG, { sealDmg, verifyDmg } from "./makers/maker-dmg";
+import MakerDMG, { isSigningConfigured, sealDmg, verifyDmg, verifyMacArtifact } from "./makers/maker-dmg";
 import MakerAppImage from "./makers/maker-appimage";
 import { existsSync, readdirSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -207,17 +207,32 @@ const config: ForgeConfig = {
 		//
 		// Then PROVE the seal. sealDmg exiting 0 only says three commands ran on
 		// this machine; it does not say Gatekeeper accepts the published bytes with
-		// a stapled ticket. verify-mac-artifact.sh is the canonical gate for that
-		// (#3288 workstreams 1 and 2), and #3267 decision 3 step 4 asks for exactly
-		// this check on the dmg. Run only when sealDmg actually sealed: an unsigned
-		// local or desktop-testing build has nothing to verify and must keep
-		// producing its dmg.
+		// a stapled ticket, or that a bundled nested executable (the Intel ACP
+		// Node, #3879) actually runs. verify-mac-artifact.sh is the canonical gate
+		// for both (#3288 workstreams 1 and 2; #3879 for the nested-Node check),
+		// and #3267 decision 3 step 4 asks for exactly this check on the dmg. Run
+		// only when sealDmg actually sealed: an unsigned local or desktop-testing
+		// build has nothing to verify and must keep producing its dmg.
+		//
+		// The zip needs the SAME nested-Node check but no separate sealing step:
+		// its inner .app was already signed/notarized/stapled by packagerConfig
+		// above, so verifying it only needs the same "was this build actually
+		// signed" gate sealDmg uses (isSigningConfigured), not a seal call of its
+		// own. Without this, the dmg-only check left the maker-zip artifact — the
+		// one electron-updater actually installs auto-updates from, per
+		// makers/maker-dmg.ts's ERR_UPDATER_ZIP_FILE_NOT_FOUND note, and per-arch
+		// the artifact CI ships for x64 — completely unverified: a regression of
+		// exactly the crash #3879 fixed could ship without any automated gate
+		// catching it.
 		postMake: async (_forgeConfig, makeResults) => {
 			for (const result of makeResults) {
 				if (result.platform !== "darwin") continue;
 				for (const artifact of result.artifacts) {
-					if (!artifact.endsWith(".dmg")) continue;
-					if (await sealDmg(artifact)) await verifyDmg(artifact);
+					if (artifact.endsWith(".dmg")) {
+						if (await sealDmg(artifact)) await verifyDmg(artifact);
+					} else if (artifact.endsWith(".zip") && isSigningConfigured()) {
+						await verifyMacArtifact(artifact);
+					}
 				}
 			}
 			return makeResults;

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -71,6 +71,20 @@ export function extraResourcesForPlatform(platform: NodeJS.Platform): string[] {
 	];
 }
 
+const ACP_RUNTIME_NODE_PATH = "/Contents/Resources/acp-runtime/node/bin/node";
+// V8 uses MAP_JIT on arm64 and mprotect on x64. electron-osx-sign's default
+// allows only the former, so its re-signing makes the bundled Node crash on Intel.
+const ACP_RUNTIME_NODE_ENTITLEMENTS = [
+	"com.apple.security.cs.allow-jit",
+	"com.apple.security.cs.allow-unsigned-executable-memory",
+];
+
+export function macSignOptionsForFile(filePath: string): { entitlements?: string[] } {
+	return filePath.endsWith(ACP_RUNTIME_NODE_PATH)
+		? { entitlements: ACP_RUNTIME_NODE_ENTITLEMENTS }
+		: {};
+}
+
 // parseReleaseRepo turns an "owner/repo" string (from AO_RELEASE_REPO) into the
 // publisher-github { owner, name } shape, falling back to the production default
 // when unset or malformed.
@@ -109,9 +123,12 @@ const config: ForgeConfig = {
 		//    `notarytool store-credentials`. See ao-macos-signed-release runbook.
 		// Both are valid NotaryToolCredentials, so no cast is needed.
 		osxSign: process.env.APPLE_SIGNING_IDENTITY
-			? { identity: process.env.APPLE_SIGNING_IDENTITY }
+			? {
+					identity: process.env.APPLE_SIGNING_IDENTITY,
+					optionsForFile: macSignOptionsForFile,
+				}
 			: process.env.CSC_LINK
-				? {}
+				? { optionsForFile: macSignOptionsForFile }
 				: undefined,
 		osxNotarize: process.env.AO_NOTARY_PROFILE
 			? { keychainProfile: process.env.AO_NOTARY_PROFILE }

--- a/frontend/makers/macho-archs.test.ts
+++ b/frontend/makers/macho-archs.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MachOParseError, machoArchs, machoHasX86_64Slice } from "./macho-archs";
+
+// Fixtures are synthesized buffers with the exact byte layouts observed on
+// disk (thin arm64: cf fa ed fe | 0c 00 00 01; fat: ca fe ba be | 00 00 00 02
+// with 20-byte entries), so no binary fixtures are committed and the suite
+// runs on any platform.
+const CPU_TYPE_X86_64 = 0x01000007;
+const CPU_TYPE_ARM64 = 0x0100000c;
+
+let fixtureDir: string;
+
+function writeFixture(name: string, contents: Buffer): string {
+	const filePath = join(fixtureDir, name);
+	writeFileSync(filePath, contents);
+	return filePath;
+}
+
+// Thin header: magic, cputype, cpusubtype, filetype — all 32-bit fields in the
+// writer's byte order. Endianness of the fixture is decided by `bigEndian`,
+// which is a property of the file, not of the host running the test.
+function thinMachO(cputype: number, options: { bigEndian?: boolean; subtype?: number } = {}): Buffer {
+	const buffer = Buffer.alloc(16);
+	if (options.bigEndian) {
+		buffer.writeUInt32BE(0xfeedfacf, 0);
+		buffer.writeUInt32BE(cputype, 4);
+		buffer.writeUInt32BE(options.subtype ?? 0, 8);
+	} else {
+		buffer.writeUInt32LE(0xfeedfacf, 0);
+		buffer.writeUInt32LE(cputype, 4);
+		buffer.writeUInt32LE(options.subtype ?? 0, 8);
+	}
+	return buffer;
+}
+
+// Fat header: magic + nfat_arch big-endian, then 20-byte (FAT_MAGIC) or
+// 32-byte (FAT_MAGIC_64) fat_arch entries whose first field is the cputype.
+function fatMachO(
+	entries: number[],
+	options: { is64?: boolean; nfatArchOverride?: number } = {},
+): Buffer {
+	const magic = options.is64 ? 0xcafebabf : 0xcafebabe;
+	const stride = options.is64 ? 32 : 20;
+	const nfatArch = options.nfatArchOverride ?? entries.length;
+	const buffer = Buffer.alloc(8 + entries.length * stride);
+	buffer.writeUInt32BE(magic, 0);
+	buffer.writeUInt32BE(nfatArch, 4);
+	entries.forEach((cputype, index) => {
+		buffer.writeUInt32BE(cputype, 8 + index * stride);
+	});
+	return buffer;
+}
+
+// process.arch is an own accessor on process; pin it per call and always
+// restore, so the "never consult the host architecture" contract is proven
+// by construction rather than by a comment.
+function withHostArch<T>(arch: string, run: () => T): T {
+	const descriptor = Object.getOwnPropertyDescriptor(process, "arch");
+	Object.defineProperty(process, "arch", { get: () => arch, configurable: true });
+	try {
+		return run();
+	} finally {
+		if (descriptor) Object.defineProperty(process, "arch", descriptor);
+	}
+}
+
+beforeEach(() => {
+	fixtureDir = mkdtempSync(join(tmpdir(), "macho-archs-"));
+});
+
+afterEach(() => {
+	rmSync(fixtureDir, { recursive: true, force: true });
+	vi.restoreAllMocks();
+});
+
+describe("machoArchs", () => {
+	it("reads a thin x86_64 image", () => {
+		expect(machoArchs(writeFixture("thin-x64", thinMachO(CPU_TYPE_X86_64)))).toEqual(["x86_64"]);
+	});
+
+	it("reads a thin arm64 image", () => {
+		expect(machoArchs(writeFixture("thin-arm64", thinMachO(CPU_TYPE_ARM64)))).toEqual(["arm64"]);
+	});
+
+	it("classifies an arm64e slice as arm64 (cputype, not cpusubtype)", () => {
+		// lipo -archs prints "arm64e" for cpusubtype 0x80000002; the cputype is
+		// plain arm64. The policy only asks for x86_64 slices, so the names the
+		// two implementations print may differ — this pins the intentional
+		// divergence so nobody "fixes" it.
+		expect(
+			machoArchs(writeFixture("thin-arm64e", thinMachO(CPU_TYPE_ARM64, { subtype: 0x80000002 }))),
+		).toEqual(["arm64"]);
+	});
+
+	it("derives endianness from the magic, not the host", () => {
+		const bigEndian = writeFixture("thin-be", thinMachO(CPU_TYPE_ARM64, { bigEndian: true }));
+		expect(machoArchs(bigEndian)).toEqual(["arm64"]);
+	});
+
+	it("reads a universal binary with x86_64 and arm64 slices", () => {
+		expect(machoArchs(writeFixture("fat", fatMachO([CPU_TYPE_X86_64, CPU_TYPE_ARM64])))).toEqual([
+			"x86_64",
+			"arm64",
+		]);
+	});
+
+	it("reads an arm64-only universal binary written as FAT_MAGIC_64", () => {
+		expect(machoArchs(writeFixture("fat64", fatMachO([CPU_TYPE_ARM64], { is64: true })))).toEqual([
+			"arm64",
+		]);
+	});
+
+	it("does not mask a 32-bit i386 cputype into x86_64", () => {
+		expect(() => machoArchs(writeFixture("i386", thinMachO(0x00000007)))).toThrow(MachOParseError);
+	});
+
+	it("rejects an unknown cputype", () => {
+		expect(() => machoArchs(writeFixture("unknown", thinMachO(0x0100000b)))).toThrow(
+			/unsupported cputype/,
+		);
+	});
+
+	it("rejects a truncated thin header", () => {
+		expect(() => machoArchs(writeFixture("short", Buffer.from([0xcf, 0xfa, 0xed, 0xfe])))).toThrow(
+			MachOParseError,
+		);
+	});
+
+	it("rejects a fat header whose slices run past the end of the file", () => {
+		expect(
+			() => machoArchs(writeFixture("fat-short", fatMachO([CPU_TYPE_X86_64], { nfatArchOverride: 3 }))),
+		).toThrow(/truncated fat header/);
+	});
+
+	it("rejects nfat_arch values that cannot describe a real binary", () => {
+		expect(() => machoArchs(writeFixture("fat-zero", fatMachO([], { nfatArchOverride: 0 })))).toThrow(
+			/invalid fat header/,
+		);
+		expect(() =>
+			machoArchs(writeFixture("fat-huge", fatMachO([CPU_TYPE_X86_64], { nfatArchOverride: 9999 }))),
+		).toThrow(/invalid fat header/);
+	});
+
+	it.each([
+		{ name: "pe", contents: Buffer.from("MZ\x90\x00\x03\x00\x00\x00\x04\x00", "binary") },
+		{ name: "elf", contents: Buffer.from("\x7fELF\x02\x01\x01\x00", "binary") },
+		{ name: "text", contents: Buffer.from("definitely not a binary") },
+	])("rejects non-Mach-O magic ($name)", ({ contents }) => {
+		expect(() => machoArchs(writeFixture("not-macho", contents))).toThrow(MachOParseError);
+	});
+
+	it("rejects a missing file and a directory", () => {
+		expect(() => machoArchs(join(fixtureDir, "does-not-exist"))).toThrow(MachOParseError);
+		expect(() => machoArchs(fixtureDir)).toThrow(MachOParseError);
+	});
+
+	it("never consults the host architecture", () => {
+		const fixture = writeFixture("host-independent", thinMachO(CPU_TYPE_X86_64));
+		const fromX64Host = withHostArch("x64", () => machoArchs(fixture));
+		const fromArm64Host = withHostArch("arm64", () => machoArchs(fixture));
+		const fromAbsurdHost = withHostArch("ppc64", () => machoArchs(fixture));
+		expect(fromX64Host).toEqual(["x86_64"]);
+		expect(fromArm64Host).toEqual(["x86_64"]);
+		expect(fromAbsurdHost).toEqual(["x86_64"]);
+	});
+
+	it("cross-checks against a real Mach-O on macOS", () => {
+		if (process.platform !== "darwin") return;
+		const expected = process.arch === "x64" ? "x86_64" : "arm64";
+		expect(machoArchs(process.execPath)).toContain(expected);
+	});
+});
+
+describe("machoHasX86_64Slice", () => {
+	it("is true for a thin x86_64 binary and a universal carrying x86_64", () => {
+		expect(machoHasX86_64Slice(writeFixture("q-thin-x64", thinMachO(CPU_TYPE_X86_64)))).toBe(true);
+		expect(
+			machoHasX86_64Slice(writeFixture("q-fat-x64", fatMachO([CPU_TYPE_X86_64, CPU_TYPE_ARM64]))),
+		).toBe(true);
+	});
+
+	it("is false for an arm64-only binary", () => {
+		expect(machoHasX86_64Slice(writeFixture("q-thin-arm64", thinMachO(CPU_TYPE_ARM64)))).toBe(false);
+		expect(machoHasX86_64Slice(writeFixture("q-fat64-arm64", fatMachO([CPU_TYPE_ARM64], { is64: true })))).toBe(
+			false,
+		);
+	});
+});

--- a/frontend/makers/macho-archs.ts
+++ b/frontend/makers/macho-archs.ts
@@ -1,0 +1,110 @@
+import { closeSync, fstatSync, openSync, readSync } from "node:fs";
+
+// Mach-O header constants. Universal ("fat") binaries start with FAT_MAGIC /
+// FAT_MAGIC_64 stored big-endian; thin Mach-O images start with MH_MAGIC /
+// MH_MAGIC_64 stored in the writer's byte order, so the endianness is derived
+// from the magic itself, never from the running host.
+const FAT_MAGIC = 0xcafebabe;
+const FAT_MAGIC_64 = 0xcafebabf;
+const MH_MAGIC = 0xfeedface;
+const MH_MAGIC_64 = 0xfeedfacf;
+// Both supported slices are 64-bit ABIs. Classify by cputype only, never by
+// cpusubtype: `lipo -archs` prints "arm64e" for cpusubtype 0x80000002, but the
+// cputype is plain arm64, and neither slice needs the x64 executable-memory
+// entitlement this module gates. The JS helper and the verifier's `lipo -archs`
+// agree on the one invariant that matters: "contains an x86_64 slice".
+const CPU_TYPE_X86_64 = 0x01000007;
+const CPU_TYPE_ARM64 = 0x0100000c;
+// Real universal binaries carry 1-2 slices. The bound also rejects Java class
+// files, whose magic is the same 0xCAFEBABE.
+const MAX_FAT_ARCHES = 16;
+// Largest header we ever read: fat magic + nfat_arch + MAX_FAT_ARCHES 32-byte
+// fat_64 entries. The bundled ACP Node alone is ~113 MB; this keeps the parse
+// a prefix read instead of loading the binary.
+const MAX_HEADER_BYTES = 8 + MAX_FAT_ARCHES * 32;
+
+export type MachOArch = "x86_64" | "arm64";
+
+// Thrown for any file that cannot be read or whose header is not a well-formed
+// Mach-O (thin or fat). Signing callers must let it propagate: failing the
+// signing pass is the contract, not silently falling back to a guess.
+export class MachOParseError extends Error {
+	constructor(
+		message: string,
+		readonly filePath: string,
+	) {
+		super(`${message}: ${filePath}`);
+		this.name = "MachOParseError";
+	}
+}
+
+// Architectures present in the file, one entry per slice in slice order,
+// de-duplicated. Reads at most MAX_HEADER_BYTES of the file, never the whole
+// binary.
+export function machoArchs(filePath: string): MachOArch[] {
+	let fd: number;
+	try {
+		fd = openSync(filePath, "r");
+	} catch (error) {
+		throw new MachOParseError(`cannot open (${(error as NodeJS.ErrnoException)?.code ?? error})`, filePath);
+	}
+	try {
+		const stats = fstatSync(fd);
+		if (!stats.isFile()) {
+			throw new MachOParseError("not a regular file", filePath);
+		}
+		// readSync may legally return fewer bytes than requested even for a
+		// regular file, so accumulate until the header is complete or EOF.
+		const header = Buffer.alloc(MAX_HEADER_BYTES);
+		let total = 0;
+		while (total < header.length) {
+			const read = readSync(fd, header, total, header.length - total, total);
+			if (read === 0) break;
+			total += read;
+		}
+		if (total < 8) {
+			throw new MachOParseError("truncated Mach-O header", filePath);
+		}
+		const magicBE = header.readUInt32BE(0);
+		const magicLE = header.readUInt32LE(0);
+		if (magicBE === FAT_MAGIC || magicBE === FAT_MAGIC_64) {
+			const stride = magicBE === FAT_MAGIC_64 ? 32 : 20;
+			const nfatArch = header.readUInt32BE(4);
+			if (nfatArch === 0 || nfatArch > MAX_FAT_ARCHES) {
+				throw new MachOParseError(`invalid fat header (nfat_arch ${nfatArch})`, filePath);
+			}
+			if (8 + nfatArch * stride > total) {
+				throw new MachOParseError("truncated fat header", filePath);
+			}
+			const archs: MachOArch[] = [];
+			for (let index = 0; index < nfatArch; index += 1) {
+				const arch = classify(header.readUInt32BE(8 + index * stride), filePath);
+				if (!archs.includes(arch)) archs.push(arch);
+			}
+			return archs;
+		}
+		if (magicLE === MH_MAGIC_64 || magicLE === MH_MAGIC) {
+			return [classify(header.readUInt32LE(4), filePath)];
+		}
+		// Byte-swapped thin header: written by a host whose byte order differs
+		// from this machine's.
+		if (magicBE === MH_MAGIC_64 || magicBE === MH_MAGIC) {
+			return [classify(header.readUInt32BE(4), filePath)];
+		}
+		throw new MachOParseError(`not a Mach-O image (magic 0x${magicBE.toString(16).padStart(8, "0")})`, filePath);
+	} finally {
+		closeSync(fd);
+	}
+}
+
+// The one predicate the signing policy needs: does the binary contain an
+// x86_64 slice (a thin x64 binary, or a universal carrying an x64 slice)?
+export function machoHasX86_64Slice(filePath: string): boolean {
+	return machoArchs(filePath).includes("x86_64");
+}
+
+function classify(cputype: number, filePath: string): MachOArch {
+	if (cputype === CPU_TYPE_X86_64) return "x86_64";
+	if (cputype === CPU_TYPE_ARM64) return "arm64";
+	throw new MachOParseError(`unsupported cputype 0x${cputype.toString(16)}`, filePath);
+}

--- a/frontend/makers/maker-dmg.ts
+++ b/frontend/makers/maker-dmg.ts
@@ -132,6 +132,14 @@ function resolveSigningIdentity(env: NodeJS.ProcessEnv): string | undefined {
 	return undefined;
 }
 
+// isSigningConfigured mirrors the same "was this build actually signed"
+// question sealDmg answers for the dmg container, exposed for other artifacts
+// (e.g. the zip maker's output) that need the identical gate: an unsigned
+// local/testing build has nothing a Gatekeeper-facing verifier can check.
+export function isSigningConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+	return resolveSigningIdentity(env) !== undefined;
+}
+
 // resolveNotaryArgs mirrors packagerConfig.osxNotarize's two credential shapes:
 // an AO_NOTARY_PROFILE notarytool keychain profile locally, or the App Store
 // Connect API key trio in CI.
@@ -224,23 +232,40 @@ export async function sealDmg(dmgPath: string, env: NodeJS.ProcessEnv = process.
 const VERIFY_SCRIPT = "scripts/verify-mac-artifact.sh";
 
 /**
- * verifyDmg runs the canonical post-seal gate on a sealed .dmg.
+ * verifyMacArtifact runs the canonical post-seal gate on any signed macOS
+ * artifact (.dmg, .zip, or .app) — verify-mac-artifact.sh dispatches on the
+ * extension itself (rule 4/5 in that script's header).
  *
- * Sealing and proving the seal are different things: sealDmg only proves the
- * three commands exited 0 on this machine, not that the published bytes are
- * something Gatekeeper accepts with a stapled ticket. verify-mac-artifact.sh is
- * the one canonical check (#3288 workstreams 1 and 2) and exists specifically so
+ * Producing and proving an artifact are different things: sealing (or the
+ * packager's own osxSign/osxNotarize) only proves the relevant commands exited
+ * 0 on this machine, not that the published bytes are something Gatekeeper
+ * accepts with a stapled ticket, or that a bundled nested executable (the
+ * Intel ACP Node, #3879) actually runs. verify-mac-artifact.sh is the one
+ * canonical check (#3288 workstreams 1 and 2) and exists specifically so
  * nobody hand-rolls a variant of it and draws a wrong conclusion.
  *
- * Only meaningful on a sealed dmg, so callers gate on sealDmg's return value.
+ * Only meaningful on a signed artifact, so callers gate accordingly (sealDmg's
+ * return value for the dmg container; isSigningConfigured for the zip, whose
+ * inner .app was already signed/notarized/stapled by packagerConfig before any
+ * maker ran).
  */
-export async function verifyDmg(dmgPath: string, scriptPath: string = path.resolve(VERIFY_SCRIPT)): Promise<void> {
+export async function verifyMacArtifact(
+	artifactPath: string,
+	scriptPath: string = path.resolve(VERIFY_SCRIPT),
+): Promise<void> {
 	if (!existsSync(scriptPath)) {
-		throw new Error(`[dmg] cannot verify ${dmgPath}: ${scriptPath} not found (run electron-forge from frontend/)`);
+		throw new Error(
+			`[dmg] cannot verify ${artifactPath}: ${scriptPath} not found (run electron-forge from frontend/)`,
+		);
 	}
-	console.log(`[dmg] verifying ${dmgPath}`);
-	const { stdout } = await run("bash", [scriptPath, dmgPath], { maxBuffer: 10 * 1024 * 1024 });
+	console.log(`[dmg] verifying ${artifactPath}`);
+	const { stdout } = await run("bash", [scriptPath, artifactPath], { maxBuffer: 10 * 1024 * 1024 });
 	if (stdout) console.log(stdout.trim());
 }
+
+// Kept as a thin, dmg-specific alias: existing callers and the dmg-oriented
+// name/log-message stay unchanged. verifyMacArtifact is the generic entry
+// point new callers (e.g. the zip artifact) should use directly.
+export const verifyDmg = verifyMacArtifact;
 
 export { MakerDMG };

--- a/frontend/makers/maker-dmg.ts
+++ b/frontend/makers/maker-dmg.ts
@@ -240,9 +240,11 @@ const VERIFY_SCRIPT = "scripts/verify-mac-artifact.sh";
  * packager's own osxSign/osxNotarize) only proves the relevant commands exited
  * 0 on this machine, not that the published bytes are something Gatekeeper
  * accepts with a stapled ticket, or that a bundled nested executable (the
- * Intel ACP Node, #3879) actually runs. verify-mac-artifact.sh is the one
- * canonical check (#3288 workstreams 1 and 2) and exists specifically so
- * nobody hand-rolls a variant of it and draws a wrong conclusion.
+ * Intel ACP Node, #3879) actually runs. verify-mac-artifact.sh is the
+ * canonical local check (#3288 workstreams 1 and 2) and exists specifically so
+ * nobody hand-rolls a variant of it and draws a wrong conclusion; the
+ * pre-publication gate for canonical releases is the release conductor's own
+ * verifier (frontend/docs/desktop-release.md).
  *
  * Only meaningful on a signed artifact, so callers gate accordingly (sealDmg's
  * return value for the dmg container; isSigningConfigured for the zip, whose

--- a/frontend/scripts/verify-mac-artifact.sh
+++ b/frontend/scripts/verify-mac-artifact.sh
@@ -42,6 +42,13 @@
 #      entitlements they need. The x64 ACP Node can pass `codesign --verify`
 #      while crashing as soon as V8 compiles JavaScript (#3879). Zip/app checks
 #      therefore inspect its final entitlements and execute the shipped binary.
+#      The arch decision here is made from the binary itself (`lipo -archs`),
+#      the same content-based invariant the signing-side selector implements
+#      (frontend/makers/macho-archs.ts) — never from the host architecture.
+#      Scope: this script is the local diagnostic and the public
+#      mac-update-e2e baseline check; the pre-publication gate for canonical
+#      releases is the release conductor's own verifier
+#      (frontend/docs/desktop-release.md).
 #
 # Exit codes: 0 all checks passed, 1 a check failed, 2 usage error.
 
@@ -195,7 +202,7 @@ if [[ "$ARTIFACT" != *.dmg ]]; then
 			echo "    ok: ACP Node architecture ($acp_node_archs)"
 			case " $acp_node_archs " in
 			*" x86_64 "*)
-				run_check "ACP Node x64 executable-memory entitlement" \
+				run_check "ACP Node x64 executable-memory entitlement (archs:$acp_node_archs)" \
 					has_acp_node_entitlement "com.apple.security.cs.allow-unsigned-executable-memory"
 				;;
 			esac

--- a/frontend/scripts/verify-mac-artifact.sh
+++ b/frontend/scripts/verify-mac-artifact.sh
@@ -38,6 +38,11 @@
 #      decision 3 step 4 specifies. Using `-t exec` on a dmg assesses the wrong
 #      thing. `-vv` stays mandatory for both (rule 2).
 #
+#   5. A valid bundle seal does not prove that nested executables received the
+#      entitlements they need. The x64 ACP Node can pass `codesign --verify`
+#      while crashing as soon as V8 compiles JavaScript (#3879). Zip/app checks
+#      therefore inspect its final entitlements and execute the shipped binary.
+#
 # Exit codes: 0 all checks passed, 1 a check failed, 2 usage error.
 
 set -euo pipefail
@@ -51,6 +56,7 @@ Verifies a macOS release artifact is signed, notarized and stapled:
   spctl -a -vv -t exec                                  (.zip / .app)
   spctl -a -vv -t open --context context:primary-signature   (.dmg)
   xcrun stapler validate
+  bundled ACP Node entitlements + JavaScript execution       (.zip / .app)
 
 A .zip is extracted with `ditto -x -k` first (never `unzip`), and the single
 .app bundle inside it is checked. A .dmg is checked as the container it is,
@@ -115,7 +121,7 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
 	exit 2
 fi
 
-for tool in codesign spctl xcrun ditto; do
+for tool in codesign spctl xcrun ditto grep lipo plutil; do
 	if ! command -v "$tool" >/dev/null 2>&1; then
 		echo "verify-mac-artifact: required tool not found: $tool" >&2
 		exit 2
@@ -163,10 +169,36 @@ run_check() {
 	fi
 }
 
+has_acp_node_entitlement() {
+	local entitlement="$1"
+	codesign -d --entitlements :- "$ACP_NODE" 2>/dev/null \
+		| plutil -p - \
+		| grep -Fq "\"$entitlement\" => true"
+}
+
 # Seal intact. --deep walks nested code (helpers, frameworks, the bundled
 # daemon); --strict rejects the loosened defaults. A .dmg has no nested code for
 # --deep to walk, so the same invocation is correct for both.
 run_check "codesign" codesign --verify --deep --strict --verbose=2 "$APP"
+
+# Prove the nested runtime works, not merely that its signature is structurally
+# valid. A dmg is intentionally not mounted by this verifier (rule 4), so the
+# matching zip/app verification is the place where nested code is checked.
+if [[ "$ARTIFACT" != *.dmg ]]; then
+	ACP_NODE="$APP/Contents/Resources/acp-runtime/node/bin/node"
+	run_check "ACP Node is bundled" test -x "$ACP_NODE"
+	if [[ -x "$ACP_NODE" ]]; then
+		run_check "ACP Node allow-jit entitlement" \
+			has_acp_node_entitlement "com.apple.security.cs.allow-jit"
+		acp_node_archs="$(lipo -archs "$ACP_NODE")"
+		case " $acp_node_archs " in
+		*" x86_64 "*)
+			run_check "ACP Node x64 executable-memory entitlement" \
+				has_acp_node_entitlement "com.apple.security.cs.allow-unsigned-executable-memory"
+			;;
+		esac
+	fi
+fi
 
 # Gatekeeper would accept it. -vv is mandatory (rule 2); expect
 # "accepted" plus "source=Notarized Developer ID". The assessment type depends
@@ -180,6 +212,13 @@ fi
 
 # The notarization ticket is actually attached to these bytes (rule 3).
 run_check "stapler" xcrun stapler validate "$APP"
+
+# Never execute code from an artifact until every trust check above has passed.
+# Entitlement inspection is non-executing; this final smoke test is not.
+if [[ $failed -eq 0 && "$ARTIFACT" != *.dmg ]]; then
+	run_check "ACP Node JavaScript execution" "$ACP_NODE" -e \
+		'console.log("ACP runtime JavaScript OK")'
+fi
 
 if [[ $failed -ne 0 ]]; then
 	echo "verify-mac-artifact: FAILED for $ARTIFACT" >&2

--- a/frontend/scripts/verify-mac-artifact.sh
+++ b/frontend/scripts/verify-mac-artifact.sh
@@ -190,13 +190,19 @@ if [[ "$ARTIFACT" != *.dmg ]]; then
 	if [[ -x "$ACP_NODE" ]]; then
 		run_check "ACP Node allow-jit entitlement" \
 			has_acp_node_entitlement "com.apple.security.cs.allow-jit"
-		acp_node_archs="$(lipo -archs "$ACP_NODE")"
-		case " $acp_node_archs " in
-		*" x86_64 "*)
-			run_check "ACP Node x64 executable-memory entitlement" \
-				has_acp_node_entitlement "com.apple.security.cs.allow-unsigned-executable-memory"
-			;;
-		esac
+		echo "--> ACP Node architecture: lipo -archs $ACP_NODE"
+		if acp_node_archs="$(lipo -archs "$ACP_NODE")"; then
+			echo "    ok: ACP Node architecture ($acp_node_archs)"
+			case " $acp_node_archs " in
+			*" x86_64 "*)
+				run_check "ACP Node x64 executable-memory entitlement" \
+					has_acp_node_entitlement "com.apple.security.cs.allow-unsigned-executable-memory"
+				;;
+			esac
+		else
+			echo "::error::verify-mac-artifact: ACP Node architecture inspection failed for $APP" >&2
+			failed=1
+		fi
 	fi
 fi
 

--- a/frontend/scripts/verify-mac-artifact.test.mjs
+++ b/frontend/scripts/verify-mac-artifact.test.mjs
@@ -10,9 +10,11 @@ import { fileURLToPath } from "node:url";
 // Honest scope: the three real checks (codesign, spctl, stapler) cannot be
 // exercised here. Mocking them convincingly would require real Apple signing
 // material, and a mock that always passes proves nothing about the gate. The
-// meaningful verification of the core logic is the release pipeline's
-// post-staple gate running this script against real published artifacts
-// (#3288 workstream 1).
+// meaningful verification of the core logic happens against real published
+// artifacts: the public mac-update-e2e workflow runs this script against the
+// published baseline and the installed app, developers run it as the local
+// diagnostic, and the release conductor's pre-publication gate applies the
+// same nested-Node rules (frontend/docs/desktop-release.md).
 //
 // What IS covered here, on any platform with no signing material at all:
 // the script parses, every usage/precondition path exits 2 with a clear

--- a/frontend/scripts/verify-mac-artifact.test.mjs
+++ b/frontend/scripts/verify-mac-artifact.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
 import { execFile } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, statSync, mkdirSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync, statSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,12 +21,17 @@ import { fileURLToPath } from "node:url";
 
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "verify-mac-artifact.sh");
 
-function run(args) {
+function run(args, env = {}) {
 	return new Promise((resolve) => {
-		execFile("bash", [SCRIPT, ...args], (err, stdout, stderr) => {
+		execFile("bash", [SCRIPT, ...args], { env: { ...process.env, ...env } }, (err, stdout, stderr) => {
 			resolve({ code: err?.code ?? 0, stdout, stderr });
 		});
 	});
+}
+
+function writeExecutable(path, contents) {
+	writeFileSync(path, `#!/usr/bin/env bash\n${contents}`);
+	chmodSync(path, 0o755);
 }
 
 let dir;
@@ -117,6 +122,37 @@ describe("verify-mac-artifact.sh", () => {
 		expect(stderr).toContain("no such file");
 	});
 
+	it("never executes nested code when an artifact fails a trust check", async () => {
+		const mockBin = join(dir, "mock-bin");
+		const app = join(dir, "Untrusted.app");
+		const node = join(app, "Contents", "Resources", "acp-runtime", "node", "bin", "node");
+		const sentinel = join(dir, "nested-node-executed");
+		mkdirSync(mockBin, { recursive: true });
+		mkdirSync(dirname(node), { recursive: true });
+
+		writeExecutable(join(mockBin, "uname"), "echo Darwin\n");
+		writeExecutable(join(mockBin, "codesign"), 'if [[ "$1" == "-d" ]]; then echo "<plist><dict></dict></plist>"; fi\n');
+		writeExecutable(join(mockBin, "spctl"), "exit 1\n");
+		writeExecutable(join(mockBin, "xcrun"), "exit 0\n");
+		writeExecutable(join(mockBin, "ditto"), "exit 0\n");
+		writeExecutable(join(mockBin, "lipo"), "echo x86_64\n");
+		writeExecutable(
+			join(mockBin, "plutil"),
+			"echo '  \"com.apple.security.cs.allow-jit\" => true'\n" +
+				"echo '  \"com.apple.security.cs.allow-unsigned-executable-memory\" => true'\n",
+		);
+		writeExecutable(node, 'echo executed > "$ACP_NODE_SENTINEL"\n');
+
+		const { code, stderr } = await run([app], {
+			PATH: `${mockBin}:${process.env.PATH}`,
+			ACP_NODE_SENTINEL: sentinel,
+		});
+
+		expect(code).toBe(1);
+		expect(stderr).toContain("spctl failed");
+		expect(existsSync(sentinel)).toBe(false);
+	});
+
 	it("encodes the verified command set (ditto, spctl -vv, stapler validate)", async () => {
 		const { readFileSync } = await import("node:fs");
 		const src = readFileSync(SCRIPT, "utf8");
@@ -132,5 +168,15 @@ describe("verify-mac-artifact.sh", () => {
 		// ...and the dmg container must be assessed on open against the primary
 		// signature (#3267 decision 3 step 4), never with -t exec.
 		expect(src).toContain("spctl -a -vv -t open --context context:primary-signature");
+		// A valid outer seal can still contain the Intel Node regression from
+		// #3879, so the canonical gate also checks the final nested executable.
+		expect(src).toContain("Contents/Resources/acp-runtime/node/bin/node");
+		expect(src).toContain("com.apple.security.cs.allow-jit");
+		expect(src).toContain("com.apple.security.cs.allow-unsigned-executable-memory");
+		expect(src).toContain('console.log("ACP runtime JavaScript OK")');
+		expect(src).toContain('if [[ $failed -eq 0 && "$ARTIFACT" != *.dmg ]]');
+		expect(src.indexOf('run_check "ACP Node JavaScript execution"')).toBeGreaterThan(
+			src.indexOf('run_check "stapler"'),
+		);
 	});
 });

--- a/frontend/scripts/verify-mac-artifact.test.mjs
+++ b/frontend/scripts/verify-mac-artifact.test.mjs
@@ -15,9 +15,9 @@ import { fileURLToPath } from "node:url";
 // (#3288 workstream 1).
 //
 // What IS covered here, on any platform with no signing material at all:
-// the script parses, and every usage/precondition path exits 2 with a clear
-// message before touching macOS-only tooling. That is the half that a
-// non-macOS CI runner can honestly assert.
+// the script parses, every usage/precondition path exits 2 with a clear
+// message, and mocked trust failures prove nested code is never executed before
+// verification succeeds. Real Apple trust decisions remain release evidence.
 
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "verify-mac-artifact.sh");
 


### PR DESCRIPTION
Refs #3879.

## What changed

- Applies a per-file entitlement override only to the bundled ACP Node at `Contents/Resources/acp-runtime/node/bin/node`, and selects it **from the binary content**: the override applies iff the Mach-O header of the file being signed contains an x86_64 slice (a thin x64 binary, or a universal carrying x64). arm64-only binaries keep the default `allow-jit`.
- **The signing host's architecture is never consulted.** `@electron/osx-sign` passes `optionsForFile` only `(filePath)`, and the canonical downstream signer processes both arm64 and x64 artifacts from one host, so `process.arch` was the wrong selector (review follow-up). The new `frontend/makers/macho-archs.ts` parses the Mach-O header (thin `MH_MAGIC_64`, fat `FAT_MAGIC`/`FAT_MAGIC_64`; endianness derived from the magic, cputype-only classification) and `macSignOptionsForFile` keys off it. Tests stub `process.arch` to `x64`, `arm64`, and a nonsense value and pin identical results.
- **Fails closed**: an unreadable or unparseable file at the nested-Node path throws out of `optionsForFile` and aborts the signing pass — no silent fallback to defaults, which is exactly the #3879 crash.
- Preserves `allow-jit` and adds `allow-unsigned-executable-memory`, which x64 V8 needs when Hardened Runtime blocks executable-memory permission changes.
- Leaves every other bundle file on `@electron/osx-sign` defaults.
- Wires the override through both supported Forge signing inputs: `APPLE_SIGNING_IDENTITY` and `CSC_LINK`; unsigned local packages remain unsigned.
- Documents the canonical signing contract in `frontend/docs/desktop-release.md` ("macOS signing contract for the bundled ACP runtime"), including pre-publication duties: inspect the nested Node's entitlements in the final artifact and execute the final x64 zip's Node on a native Intel runner, keeping the arm64 verification.
- Extends `frontend/scripts/verify-mac-artifact.sh` to inspect the final nested Node entitlements and execute it only after codesign, Gatekeeper, and stapler all pass. The script is the local diagnostic and the public mac-update-e2e baseline check; the pre-publication gate remains the release conductor's verifier, which now has a documented contract to mirror.

Scope note: the public CI build in `build-artifacts.yml` stays intentionally unsigned, so `osxSign`/`optionsForFile` do not run there — the entitlement decision is enforced wherever signing actually happens (locally signed builds today; the canonical signer once it mirrors the documented contract).

The branch is rebased on current `main`.

## Review follow-up addressed

- Arch selection is keyed off the artifact being signed, not the host (`arch` parameter removed).
- The public verifier is documented as the local diagnostic counterpart, not the publication gate.
- Removed the unrelated `AgentModelCombobox` locale-formatting commit and the net-zero screenshot add/remove pair (tree verified byte-identical apart from the locale file).
- `Closes` demoted to `Refs` until the paired conductor-side change lands (contract in `desktop-release.md`).

## Tests

- Focused suites: 69 passed — new Mach-O parser tests, forge.config signing/postMake, maker-dmg, verify-mac-artifact smoke.
- Mach-O parser coverage: synthetic thin/fat fixtures (incl. `FAT_MAGIC_64`, byte-swapped thin, arm64e cputype-only classification, i386 not masked into x86_64), truncated/garbage/non-Mach-O headers throw, host-arch independence, macOS sanity check against a real Mach-O.
- Frontend typecheck and e2e typecheck: passed. Full frontend suite: 267 files; 3,594 passed, 7 skipped, and 12 failed — all 12 in `browser-profile-import.test.ts`, from a local `better-sqlite3` build carrying the Electron ABI after a local packaged build (environment artifact; neither the module nor that file is touched by this branch).
- Shell syntax and shellcheck: passed.
- Trust-order regression: a mocked untrusted app fails `spctl` and the nested Node sentinel is never executed.
- Real signer A/B (original round): official Node v22.23.2 x64, `@electron/osx-sign` 1.3.3, Hardened Runtime — the entitlement list is unchanged; only the selection mechanism moved from host arch to file content.

## A/B evidence

The screenshots are attached as review evidence and are not part of the PR code diff.

### A — current Forge defaults produce a valid seal but Node crashes

![Before: x64 V8 crashes with exit 133](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/pr-assets-3896/.issue-assets/pr-3896/a-before-intel-node-crash.png)

The final x64 Node has `allow-jit` but not `allow-unsigned-executable-memory`. The outer app seal is valid, yet JavaScript hits the reported V8 `SetPermissions` assertion and exits 133.

### B — the selector signs the same Node with the required x64 entitlement

![After: x64 Node executes JavaScript](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/pr-assets-3896/.issue-assets/pr-3896/b-after-intel-node-runs.png)

The same signed Node and command exit 0. This exercises the exact Packager → osx-sign → nested Node/V8 boundary changed by the PR.

## Remaining for #3879

The change that reaches users is the canonical signer's entitlement step in the private release repository. This PR ships the public contract (`desktop-release.md`), the content-based reference implementation (`machoHasX86_64Slice`), and the local diagnostic; `Closes` returns once the conductor side lands:

1. its signing step applies the entitlements per the documented contract (x64-slice predicate, fail-closed);
2. its final-artifact verifier inspects the nested Node and executes the final x64 zip on a native Intel runner.
