### PR TITLE
docs: clarify agent-orchestrator.yaml is no longer generated

### DIFF
--- a/frontend/src/landing/content/docs/troubleshooting.mdx
+++ b/frontend/src/landing/content/docs/troubleshooting.mdx
@@ -32,6 +32,9 @@ ao doctor --json
 	<Accordion title="The UI looks stale after a daemon restart">
 		Leave the app open briefly so its SSE connection can reconnect and invalidate current queries. If it does not recover, restart the desktop app. The event stream supports replay, but a full app restart is the safest user-level recovery.
 	</Accordion>
+	<Accordion title="No agent-orchestrator.yaml appears in the project">
+		This is expected, not a bug. The rewrite stores project configuration in the daemon's SQLite database, not in a repository file, and `ao start` never writes one. See [Projects](/docs/configuration/projects) and [Migration](/docs/migration) for how project config works now, and use `ao project set-config` or the desktop settings UI to change it.
+	</Accordion>
 </Accordions>
 
 ## Agents And Sessions


### PR DESCRIPTION
## Summary

Fixes #3613. The reporter expected `ao start` to create a per-project
`agent-orchestrator.yaml`, per "the documentation." That file is gone from the
current architecture: project configuration is persisted by the daemon in
SQLite (see `backend/internal/domain/projectconfig.go`), and `ao start` (see
`backend/internal/cli/start.go`) only resolves/fetches/opens the desktop app —
it never writes any per-project config file.

The website docs (`configuration/projects.mdx`, `guides/multi-project.mdx`,
`migration.mdx`, `cli.mdx`, `plugins/index.mdx`) already say this clearly, but
there was no discoverable answer for someone who searches "where is my
agent-orchestrator.yaml" and lands on Troubleshooting. This adds a
troubleshooting FAQ entry that says plainly this is expected behavior, not a
bug, and links to the pages that explain how project config works now.

## Changes

- `frontend/src/landing/content/docs/troubleshooting.mdx`: add a "No
  agent-orchestrator.yaml appears in the project" entry under **Desktop And
  Daemon**, linking to `/docs/configuration/projects` and `/docs/migration`.

## Verification

- Confirmed no code path (`ao start`, `ao project set-config`, daemon) writes
  a per-project `agent-orchestrator.yaml` in the current Go rewrite.
- Confirmed existing docs pages already describe SQLite-backed config; this
  closes the discoverability gap rather than duplicating content.
- Checked MDX tag balance in the edited file (`<Accordions>`/`<Accordion>`
  counts match).

## Risk

Docs-only change, no runtime code touched.