### PR TITLE
fix(browser): re-measure preview bounds on OS-level window resize/move

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -99,6 +99,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					onMaximized: () => () => undefined,
 					isFullScreen: async () => false,
 					onFullScreen: () => () => undefined,
+					onRemeasure: () => () => undefined,
 				},
 				theme: {
 					set: async () => undefined,
@@ -585,6 +586,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					onMaximized: () => () => undefined,
 					isFullScreen: async () => false,
 					onFullScreen: () => () => undefined,
+					onRemeasure: () => () => undefined,
 				},
 				theme: {
 					set: async () => undefined,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -582,6 +582,20 @@ async function createWindowInternal(): Promise<void> {
 	mainWindow.on("leave-full-screen", pushFullScreen);
 	mainWindow.on("maximize", pushMaximized);
 	mainWindow.on("unmaximize", pushMaximized);
+	// The native browser preview's bounds are entirely renderer-driven (measured
+	// from a placeholder DOM node via ResizeObserver/window "resize"). An
+	// OS-level window move, resize, or maximize toggle does not reliably fire
+	// those DOM signals on every platform/window manager, which leaves the
+	// WebContentsView painted at stale bounds. Forward these window events so
+	// the renderer can re-measure and re-send bounds regardless of whether its
+	// own listeners fired.
+	const pushRemeasure = () => {
+		getShellWebContents()?.send("window:remeasure");
+	};
+	mainWindow.on("resize", pushRemeasure);
+	mainWindow.on("move", pushRemeasure);
+	mainWindow.on("maximize", pushRemeasure);
+	mainWindow.on("unmaximize", pushRemeasure);
 	mainWindow.on("blur", () => {
 		keybindingRecordingActive = false;
 	});

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -239,6 +239,17 @@ const api = {
 				ipcRenderer.off("window:fullscreen", wrapped);
 			};
 		},
+		// Fired by the main process on OS-level window resize/move/maximize/
+		// unmaximize, so panels whose bounds are computed in the renderer (the
+		// native browser preview) can re-measure even when the DOM's own
+		// resize/ResizeObserver signals don't fire for that change.
+		onRemeasure: (listener: () => void) => {
+			const wrapped = () => listener();
+			ipcRenderer.on("window:remeasure", wrapped);
+			return () => {
+				ipcRenderer.off("window:remeasure", wrapped);
+			};
+		},
 	},
 	theme: {
 		// Propagate the app's theme preference to Electron's nativeTheme so embedded

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -683,6 +683,65 @@ describe("useBrowserView", () => {
 		}
 	});
 
+	it("re-measures on a main-process window:remeasure signal (OS-level resize/move the DOM's own listeners can miss)", async () => {
+		vi.useFakeTimers();
+		try {
+			const bridge = setupBridge();
+			let remeasureListener: (() => void) | undefined;
+			const onRemeasure = vi.fn((listener: () => void) => {
+				remeasureListener = listener;
+				return () => {
+					remeasureListener = undefined;
+				};
+			});
+			window.ao = { ...window.ao!, window: { ...window.ao!.window, onRemeasure } };
+			const slot = createSlot();
+			const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+			await act(async () => {
+				await Promise.resolve();
+			});
+			act(() =>
+				bridge.emit({
+					viewId: "42:sess-1",
+					url: "http://localhost:3000/",
+					title: "",
+					canGoBack: false,
+					canGoForward: false,
+					isLoading: false,
+				}),
+			);
+			act(() => result.current.slotRef(slot));
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(onRemeasure).toHaveBeenCalled();
+			bridge.setBounds.mockClear();
+
+			// The OS moved/resized the window without the DOM's own resize/
+			// ResizeObserver signals firing for it; main forwards the raw event.
+			slot.getBoundingClientRect = vi.fn(() => ({
+				x: 400,
+				y: 50,
+				width: 320,
+				height: 240,
+				top: 50,
+				right: 720,
+				bottom: 290,
+				left: 400,
+				toJSON: () => ({}),
+			}));
+			act(() => remeasureListener?.());
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(bridge.setBounds).toHaveBeenCalledWith(
+				expect.objectContaining({ rect: expect.objectContaining({ x: 400, width: 320 }) }),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("hides the native view when inactive and on unmount without destroying session state", async () => {
 		const bridge = setupBridge();
 		const slot = createSlot();

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -549,10 +549,18 @@ export function useBrowserView({
 		window.addEventListener("resize", handle);
 		window.addEventListener("scroll", handle, true);
 		document.addEventListener("fullscreenchange", handleFullscreenChange);
+		// The main process forwards OS-level window resize/move/maximize events
+		// here (see main.ts). The DOM's own resize/ResizeObserver signals do not
+		// reliably fire for every one of those on every platform/window manager,
+		// which otherwise leaves the native preview painted at stale bounds.
+		// Settle-measure to also catch move-triggered layout shifts (position-only,
+		// no DOM resize) the same way the pop-out/inspector-collapse paths do.
+		const offRemeasure = window.ao?.window.onRemeasure(() => scheduleSettleMeasure());
 		return () => {
 			window.removeEventListener("resize", handle);
 			window.removeEventListener("scroll", handle, true);
 			document.removeEventListener("fullscreenchange", handleFullscreenChange);
+			offRemeasure?.();
 			observerRef.current?.disconnect();
 			cancelScheduledMeasure();
 			if (settleTimerRef.current !== null) window.clearTimeout(settleTimerRef.current);

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -38,6 +38,7 @@ export const aoBridge: AoBridge =
 			onMaximized: () => () => undefined,
 			isFullScreen: async () => false,
 			onFullScreen: () => () => undefined,
+			onRemeasure: () => () => undefined,
 		},
 		theme: {
 			set: async () => undefined,

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -127,6 +127,7 @@ if (typeof window !== "undefined") {
 			onMaximized: () => () => undefined,
 			isFullScreen: async () => false,
 			onFullScreen: () => () => undefined,
+			onRemeasure: () => () => undefined,
 		},
 		theme: {
 			set: async () => undefined,


### PR DESCRIPTION
## Summary

Fixes #2491.

The native browser preview's `WebContentsView` bounds are computed entirely
renderer-side (`useBrowserView`): a `ResizeObserver` on the placeholder slot
plus a `window` `resize`/`scroll` listener measure the slot and send bounds
to the main process (`browser:setBounds`), which clamps and applies them
directly via `view.setBounds()`.

There was no main-process listener for the `BrowserWindow`'s own
`resize`/`move`/`maximize`/`unmaximize` events. All re-sync depended
entirely on the renderer's own DOM signals firing for those OS-level
changes — which the issue's traced investigation flagged as the likely
fragility behind the view rendering at stale/misaligned bounds.

## Fix

- `main.ts`: forward `resize`/`move`/`maximize`/`unmaximize` from the
  `BrowserWindow` to the renderer over a new `window:remeasure` IPC event
  (mirrors the existing `window:fullscreen` channel/pattern).
- `preload.ts`: expose it as `window.ao.window.onRemeasure`.
- `useBrowserView.ts`: settle-measure (immediate + ~280ms settle re-measure)
  on that signal, the same handling already used for pop-out and inspector
  collapse/expand transitions — both of those are also position-only shifts
  the `ResizeObserver` alone can miss.

This closes the gap called out in the issue without guessing at the
DPI/compositor-level question (Wayland vs X11 vs fractional scaling) — it
makes bounds re-sync independent of whether the DOM's own resize signals
fire for a given OS-level window change, on any platform.

## Tests

- Added a renderer test asserting a `window:remeasure` signal triggers a
  re-measure and re-send of bounds using the slot's latest geometry.
- `npx vitest run src/renderer/hooks/useBrowserView.test.tsx
  src/main/browser-view-host.test.ts` — 82 passed.
- `npm run typecheck` — clean.
- Full `npx vitest run` — only pre-existing failures in unrelated
  `src/landing/**` tests (missing `cheerio` dependency in that
  subproject), no relation to this change.