### PR TITLE
fix(sessions): store activity timestamps in UTC so SQL comparisons hold

### DIFF
--- a/backend/internal/observe/activity/observer.go
+++ b/backend/internal/observe/activity/observer.go
@@ -74,7 +74,12 @@ func New(sessions sessionSource, sink activitySink, runtime outputReader, agents
 		o.outputLines = DefaultOutputLines
 	}
 	if o.clock == nil {
-		o.clock = time.Now
+		// UTC, not bare time.Now: this timestamp becomes sessions.activity_last_at,
+		// and the SQLite driver stores a time.Time by its String() form. A
+		// local-zone value keeps its monotonic reading and offset, which then
+		// fails to compare as a timestamp against the "… +0000 UTC" rows the
+		// other writers produce.
+		o.clock = func() time.Time { return time.Now().UTC() }
 	}
 	if o.logger == nil {
 		o.logger = slog.Default()

--- a/backend/internal/observe/reaper/reaper.go
+++ b/backend/internal/observe/reaper/reaper.go
@@ -96,7 +96,13 @@ func New(sink runtimeObservationSink, sessions sessionSource, runtime runtimePro
 		r.tick = DefaultTickInterval
 	}
 	if r.clock == nil {
-		r.clock = time.Now
+		// UTC, not bare time.Now: the observed timestamp reaches sessions.
+		// activity_last_at, and the SQLite driver stores a time.Time by its
+		// String() form. A local-zone value keeps its monotonic reading and
+		// offset ("… +0700 +07 m=+995.1"), which no longer compares as a
+		// timestamp against the "… +0000 UTC" rows every other writer produces —
+		// and those comparisons gate the agent-switch source-stop predicate.
+		r.clock = func() time.Time { return time.Now().UTC() }
 	}
 	if r.logger == nil {
 		r.logger = slog.Default()

--- a/backend/internal/storage/sqlite/migrate_activity_zone_test.go
+++ b/backend/internal/storage/sqlite/migrate_activity_zone_test.go
@@ -68,13 +68,13 @@ func TestMigration0088NormalizesLocalZoneActivityTimestamps(t *testing.T) {
 	// The normalized column has to compare as a timestamp again: this is the
 	// predicate the agent-switch source stop runs, and the value it compares
 	// against is a later instant in UTC.
-	var comparable int
+	var comparableRows int
 	if err := db.QueryRow(
 		`SELECT COUNT(*) FROM sessions WHERE activity_last_at <= '2026-08-12 16:00:00.000000 +0000 UTC'`,
-	).Scan(&comparable); err != nil {
+	).Scan(&comparableRows); err != nil {
 		t.Fatal(err)
 	}
-	if comparable != len(seed) {
-		t.Errorf("rows comparing as timestamps = %d, want %d", comparable, len(seed))
+	if comparableRows != len(seed) {
+		t.Errorf("rows comparing as timestamps = %d, want %d", comparableRows, len(seed))
 	}
 }

--- a/backend/internal/storage/sqlite/migrate_activity_zone_test.go
+++ b/backend/internal/storage/sqlite/migrate_activity_zone_test.go
@@ -11,11 +11,11 @@ import (
 // directly in SQL, so such a row stops behaving like a timestamp: a "+0800"
 // wall clock sorts above the UTC rendering of a later instant, and the
 // agent-switch source-stop predicate then matches zero rows and strands the
-// saga. Migration 0088 rewrites those rows to the canonical UTC form.
-func TestMigration0088NormalizesLocalZoneActivityTimestamps(t *testing.T) {
+// saga. Migration 0120 rewrites those rows to the canonical UTC form.
+func TestMigration0120NormalizesLocalZoneActivityTimestamps(t *testing.T) {
 	db := openTestDB(t)
 
-	upTo(t, db, 87)
+	upTo(t, db, 94)
 
 	now := time.Now().UTC()
 	if _, err := db.Exec(`INSERT INTO projects (id, path, display_name, registered_at)
@@ -50,7 +50,7 @@ func TestMigration0088NormalizesLocalZoneActivityTimestamps(t *testing.T) {
 		}
 	}
 
-	upTo(t, db, 88)
+	upTo(t, db, 120)
 
 	// CAST to TEXT to see the stored bytes: scanning the column into a string
 	// lets the driver re-render it as RFC 3339, which would hide the very

--- a/backend/internal/storage/sqlite/migrate_activity_zone_test.go
+++ b/backend/internal/storage/sqlite/migrate_activity_zone_test.go
@@ -1,0 +1,80 @@
+package sqlite
+
+import (
+	"testing"
+	"time"
+)
+
+// Sessions whose activity was last written from a local-zone clock carry the
+// zone (and sometimes a monotonic reading) in the column, because the driver
+// stores a time.Time by its String() form. activity_last_at is compared
+// directly in SQL, so such a row stops behaving like a timestamp: a "+0800"
+// wall clock sorts above the UTC rendering of a later instant, and the
+// agent-switch source-stop predicate then matches zero rows and strands the
+// saga. Migration 0088 rewrites those rows to the canonical UTC form.
+func TestMigration0088NormalizesLocalZoneActivityTimestamps(t *testing.T) {
+	db := openTestDB(t)
+
+	upTo(t, db, 87)
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO projects (id, path, display_name, registered_at)
+		VALUES ('p1', '/tmp/p1', 'proj', ?)`, now); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+
+	seed := []struct {
+		id      string
+		written string
+		want    string
+	}{
+		// Monotonic reading and an east-of-UTC zone: the shape a bare time.Now()
+		// leaves behind, and the one that reproduced the stranded switch.
+		{"ao-1", "2026-06-28 18:45:08.349363 +0800 CST m=+25660.013723251", "2026-06-28 10:45:08.349363 +0000 UTC"},
+		// Same, with the fractional second one digit shorter — Go trims trailing
+		// zeros, which moves the offset's position in the string.
+		{"ao-2", "2026-07-02 18:05:06.42722 +0800 CST m=+3515.018840501", "2026-07-02 10:05:06.42722 +0000 UTC"},
+		// Local zone without any monotonic reading; equally uncomparable.
+		{"ao-3", "2026-08-12 22:14:57.047745 +0700 +07", "2026-08-12 15:14:57.047745 +0000 UTC"},
+		// Crossing back over midnight.
+		{"ao-4", "2026-07-27 07:03:53.393954 +0800 CST m=+50790.035115335", "2026-07-26 23:03:53.393954 +0000 UTC"},
+		// West of UTC shifts forward instead.
+		{"ao-5", "2026-07-27 07:03:53.393954 -0500 EST m=+50790.035115335", "2026-07-27 12:03:53.393954 +0000 UTC"},
+		// Already canonical: must be left byte-for-byte alone.
+		{"ao-6", "2026-07-27 07:03:53.393954 +0000 UTC", "2026-07-27 07:03:53.393954 +0000 UTC"},
+	}
+	for n, s := range seed {
+		if _, err := db.Exec(`INSERT INTO sessions (id, project_id, num, kind, activity_state, activity_last_at, is_terminated, created_at, updated_at)
+			VALUES (?, 'p1', ?, 'worker', 'exited', ?, 0, ?, ?)`, s.id, n+1, s.written, now, now); err != nil {
+			t.Fatalf("seed session %s: %v", s.id, err)
+		}
+	}
+
+	upTo(t, db, 88)
+
+	// CAST to TEXT to see the stored bytes: scanning the column into a string
+	// lets the driver re-render it as RFC 3339, which would hide the very
+	// difference under test.
+	for _, s := range seed {
+		var got string
+		if err := db.QueryRow(`SELECT CAST(activity_last_at AS TEXT) FROM sessions WHERE id = ?`, s.id).Scan(&got); err != nil {
+			t.Fatalf("read %s: %v", s.id, err)
+		}
+		if got != s.want {
+			t.Errorf("%s activity_last_at = %q, want %q", s.id, got, s.want)
+		}
+	}
+
+	// The normalized column has to compare as a timestamp again: this is the
+	// predicate the agent-switch source stop runs, and the value it compares
+	// against is a later instant in UTC.
+	var comparable int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE activity_last_at <= '2026-08-12 16:00:00.000000 +0000 UTC'`,
+	).Scan(&comparable); err != nil {
+		t.Fatal(err)
+	}
+	if comparable != len(seed) {
+		t.Errorf("rows comparing as timestamps = %d, want %d", comparable, len(seed))
+	}
+}

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -124,6 +124,7 @@ var shippedMigrations = map[int64]string{
 	117: "0117_allow_kimi_usage.sql",
 	118: "0118_cancelled_conversation_turns.sql",
 	119: "0119_finalize_completed_conversation_plans.sql",
+	120: "0120_normalize_activity_last_at.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0120_normalize_activity_last_at.sql
+++ b/backend/internal/storage/sqlite/migrations/0120_normalize_activity_last_at.sql
@@ -1,0 +1,67 @@
+-- +goose Up
+-- Rewrite sessions.activity_last_at values that a local-zone clock left in the
+-- column. The driver stores a time.Time by its String() form, so a value written
+-- from time.Now() (rather than time.Now().UTC()) kept both its zone and its
+-- monotonic reading:
+--
+--   2026-06-28 18:45:08.349363 +0800 CST m=+25660.013723251
+--
+-- against the form every other writer produces:
+--
+--   2026-06-28 10:45:08.349363 +0000 UTC
+--
+-- activity_last_at is compared directly in SQL, and those comparisons are
+-- lexicographic. A "+0800" wall clock sorts above the UTC rendering of a LATER
+-- instant, so the agent-switch source-stop predicate
+-- (activity_last_at <= stopped_at) silently matched zero rows: the confirmation
+-- reported a phantom concurrent ownership change and stranded the saga in
+-- stopping_source, where neither resume nor a repeat switch could recover it.
+--
+-- Shift each affected row back to UTC and re-render it in the canonical form.
+-- Rows already ending in "+0000 UTC" are untouched.
+--
+-- Two shape details this has to respect:
+--  * The offset is found by search, not at a fixed column: Go trims trailing
+--    zeros from the fractional second, so ".42722 +0800" and ".349363 +0800"
+--    place the sign differently.
+--  * The fractional digits are carried over verbatim. strftime's %f renders
+--    milliseconds only, which would silently truncate microsecond precision.
+
+-- +goose StatementBegin
+UPDATE sessions
+SET activity_last_at =
+    strftime('%Y-%m-%d %H:%M:%S',
+        substr(activity_last_at, 1, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') - 1),
+        (CASE substr(activity_last_at, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') + 1, 1)
+            WHEN '+' THEN '-' ELSE '+' END)
+            || substr(activity_last_at, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') + 2, 2) || ' hours',
+        (CASE substr(activity_last_at, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') + 1, 1)
+            WHEN '+' THEN '-' ELSE '+' END)
+            || substr(activity_last_at, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') + 4, 2) || ' minutes'
+    )
+    || CASE
+        WHEN instr(substr(activity_last_at, 1, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') - 1), '.') = 0
+        THEN ''
+        ELSE substr(
+            substr(activity_last_at, 1, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') - 1),
+            instr(substr(activity_last_at, 1, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') - 1), '.')
+        )
+    END
+    || ' +0000 UTC'
+-- Matched by "not already UTC" rather than by the monotonic suffix: a
+-- local-zone value breaks the comparison whether or not it carried a monotonic
+-- reading, and both shapes exist in the wild ("… +0700 +07 m=+995.1" and
+-- "… +0700 +07").
+WHERE activity_last_at NOT LIKE '% +0000 UTC'
+  AND substr(activity_last_at, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') + 1, 1) IN ('+', '-')
+  AND strftime('%Y-%m-%d %H:%M:%S',
+        substr(activity_last_at, 1, instr(activity_last_at, ' ') + instr(substr(activity_last_at, instr(activity_last_at, ' ') + 1), ' ') - 1),
+        '+00 hours'
+      ) IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- Irreversible by design: the original strings carried a monotonic reading that
+-- was never meaningful outside the process that wrote it, and the normalized
+-- values are what every reader and comparison already expects.
+SELECT 1;

--- a/backend/internal/storage/sqlite/store/agent_switching_store_test.go
+++ b/backend/internal/storage/sqlite/store/agent_switching_store_test.go
@@ -1427,6 +1427,62 @@ func TestAgentSwitchSourceStopAndTargetActivationAreAtomicAndNarrow(t *testing.T
 	}
 }
 
+// The source-stop predicate compares activity_last_at in SQL, and the driver
+// stores a time.Time by its String() form. A session whose activity was last
+// written from a local-zone clock ("… +0700 +07 m=+995.1") must still compare as
+// a timestamp against the UTC value the confirmation carries — otherwise the
+// UPDATE matches zero rows, the confirmation reports a phantom ownership change,
+// and the saga is stranded in stopping_source with no recovery path.
+func TestConfirmAgentSwitchSourceStoppedAcceptsLocalZoneActivity(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "switch-zone")
+	rec := sampleRecord("switch-zone")
+	now := rec.CreatedAt
+	rec.Metadata.RuntimeHandleID = "source-handle"
+	rec.Metadata.RuntimeLaunchID = "source-runtime-generation"
+	// East of UTC, so the rendered wall clock sorts ABOVE the UTC rendering of a
+	// later instant — exactly what breaks a lexicographic comparison.
+	zone := time.FixedZone("+07", 7*60*60)
+	rec.Activity = domain.Activity{State: domain.ActivityActive, LastActivityAt: now.In(zone)}
+	session, err := s.CreateSession(ctx, rec)
+	if err != nil {
+		t.Fatalf("create AO session: %v", err)
+	}
+
+	sw := domain.AgentSwitch{
+		ID: "switch-zone", SessionID: session.ID, IdempotencyKey: "switch-zone",
+		RequestFingerprint: domain.ComputeAgentSwitchRequestFingerprint(session.ID, domain.HarnessCodex, ""),
+		FromHarness:        domain.HarnessClaudeCode,
+		TargetHarness:      domain.HarnessCodex, State: domain.AgentSwitchPreparingHandoff,
+		AgentHandoffStatus: domain.AgentHandoffNotAttempted, SourceGenerationID: "source-switch-generation",
+		RequestedAt: now, UpdatedAt: now,
+	}
+	stored, created, err := s.CreateAgentSwitch(ctx, sw)
+	if err != nil || !created {
+		t.Fatalf("create switch: created=%v err=%v", created, err)
+	}
+	advanceAgentSwitchFixtureWithMutation(ctx, t, s, &stored, domain.AgentSwitchStoppingSource, now.Add(time.Second), func(sw *domain.AgentSwitch) {
+		sw.TargetStartMode = domain.AgentSwitchTargetStartFresh
+		sw.TargetGenerationID = "target-generation"
+	})
+
+	confirmed, err := s.ConfirmAgentSwitchSourceStopped(ctx, domain.AgentSwitchSourceStopConfirmation{
+		SwitchID: sw.ID, SessionID: session.ID, SourceHarness: domain.HarnessClaudeCode,
+		SourceGenerationID:            "source-switch-generation",
+		ExpectedSourceRuntimeLaunchID: "source-runtime-generation",
+		TargetGenerationID:            "target-generation",
+		StoppedAt:                     now.Add(2 * time.Second).UTC(),
+	})
+	if err != nil || !confirmed {
+		t.Fatalf("confirm source stopped over local-zone activity: confirmed=%v err=%v", confirmed, err)
+	}
+	exited, ok, err := s.GetSession(ctx, session.ID)
+	if err != nil || !ok || exited.Activity.State != domain.ActivityExited {
+		t.Fatalf("source stop did not land: session=%+v ok=%v err=%v", exited, ok, err)
+	}
+}
+
 func TestAgentSwitchOwnershipTransactionsRejectTerminatedSession(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -605,5 +605,13 @@ func normalActivity(a domain.Activity, fallback time.Time) domain.Activity {
 	if a.LastActivityAt.IsZero() {
 		a.LastActivityAt = time.Now().UTC()
 	}
+	// The driver stores a time.Time by its String() form, so the zone and any
+	// monotonic reading survive into the column. Rows written from a local-zone
+	// clock ("… +0700 +07 m=+995.1") then stop comparing as timestamps against
+	// UTC rows, and activity_last_at is compared directly in SQL — the
+	// agent-switch source-stop predicate is one such comparison, and a mismatched
+	// row silently matches zero rows there. Normalize every writer's value here
+	// rather than trusting each caller's clock.
+	a.LastActivityAt = a.LastActivityAt.UTC()
 	return a
 }


### PR DESCRIPTION
Fixes #3899.

An agent switch could strand itself in `stopping_source` with no way out: the source agent was already gone, resume answered `AGENT_RESUME_IN_PROGRESS`, a repeat switch failed the same way, and the daemon then **refused to start** because boot reconciliation returned the same error.

The cause is a storage detail, not a saga bug. `modernc.org/sqlite` stores a `time.Time` by its `String()` form, so a value written from a local-zone clock keeps its offset and monotonic reading:

```
2026-06-28 18:45:08.349363 +0800 CST m=+25660.013723251
```

instead of the form every other writer produces:

```
2026-06-28 10:45:08.349363 +0000 UTC
```

`activity_last_at` is compared directly in SQL, and SQLite compares these as strings — a `+0800` wall clock sorts above the UTC rendering of a *later* instant. `MarkSessionAgentSwitchSourceStopped` gates on `activity_last_at <= stopped_at`, so against such a row it matches zero rows, which the caller reads as "ownership changed concurrently".

### Changes

Three levels, because each alone leaves a gap:

- **Sources** — `observe/reaper/reaper.go` and `observe/activity/observer.go` emit UTC.
- **Storage** — `normalActivity` normalizes `LastActivityAt` on every write path, rather than trusting each caller's clock. This is the durable guard: a future writer with a bare `time.Now()` cannot reintroduce the bug.
- **Data** — migration `0088` rewrites rows already stored in the local-zone form.

### Migration notes

The migration matches on `activity_last_at NOT LIKE '% +0000 UTC'` rather than on the monotonic suffix, because both shapes occur in the wild (`… +0700 +07 m=+995.1` and `… +0700 +07`). The offset is located by search rather than at a fixed column, since Go trims trailing zeros from fractional seconds and that moves the sign's position. Fractional digits are carried over verbatim — `strftime`'s `%f` renders milliseconds only and would truncate microseconds.

### Tests

- `agent_switching_store_test.go` — fails without the storage change with exactly the production symptom: `confirmed=false, err=nil`.
- `migrate_activity_zone_test.go` — 6 cases (monotonic, short fraction, no-monotonic local zone, midnight crossing, west-of-UTC, already-canonical). It reads via `CAST(activity_last_at AS TEXT)`: scanning the column into a string lets the driver re-render it as RFC 3339 and hide the very difference under test.

Verified on an affected profile: 184 malformed rows → 0, the stranded saga moved `stopping_source` → `failed`, and the daemon boots again with sessions intact.
