### PR TITLE
fix(terminal): bound retained terminals and stop black-pane latches

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -380,6 +380,31 @@ describe("TerminalPane replay cover", () => {
 		}
 	});
 
+	it("attaches and lifts the cover even when activation preparation rejects", async () => {
+		prepareForActivationMock.mockRejectedValue(new Error("viewport gone"));
+		replaySettled.value = false;
+		const view = renderPane({ ...worker, terminalHandleId: "term-1" });
+		try {
+			await waitFor(() => expect(attachMock).toHaveBeenCalled());
+			replaySettled.value = true;
+			view.rerender(
+				<QueryClientProvider client={view.queryClient}>
+					<TerminalPane
+						daemonReady
+						fontSize={12}
+						session={{ ...worker, terminalHandleId: "term-1" }}
+						theme="dark"
+					/>
+				</QueryClientProvider>,
+			);
+			await waitFor(() =>
+				expect(screen.queryByTestId("terminal-replay-cover")).not.toBeInTheDocument(),
+			);
+		} finally {
+			view.restore();
+		}
+	});
+
 	it("keeps the replay cover silent even when attachment takes longer", () => {
 		vi.useFakeTimers();
 		try {
@@ -442,7 +467,31 @@ describe("TerminalCacheProvider", () => {
 		}
 	});
 
-	it("retains every visited terminal until an authoritative lifecycle cleanup", async () => {
+	it("reveals a returning retained terminal even when its preparation rejects", async () => {
+		const view = renderCachedPane({ session: sessionA, sessions: [sessionA, sessionB] });
+		try {
+			await waitFor(() => activeXterm());
+			view.show(sessionB);
+			await waitFor(() => expect(screen.getAllByTestId("xterm")).toHaveLength(2));
+
+			// Returning to a retained terminal runs the cached preparation path. A
+			// rejection there must not strand the entry in "preparing", which stays
+			// visibility:hidden and reads as a permanently black pane.
+			prepareForActivationMock.mockRejectedValue(new Error("viewport gone"));
+			view.show(sessionA);
+			await waitFor(() => {
+				const container = document.querySelector<HTMLElement>(
+					`[data-terminal-cache-key^="session:${sessionA.id}:worker|"]`,
+				);
+				expect(container?.dataset.terminalActivationPhase).toBe("visible");
+				expect(container?.style.visibility).not.toBe("hidden");
+			});
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("retains visited terminals up to the cap and evicts the oldest parked one beyond it", async () => {
 		const sessions = Array.from({ length: 7 }, (_, index) => ({
 			...worker,
 			id: `sess-retained-${index}`,
@@ -452,7 +501,7 @@ describe("TerminalCacheProvider", () => {
 		const view = renderCachedPane({ session: sessions[0], sessions });
 		try {
 			const oldest = await waitFor(() => activeXterm());
-			for (const session of sessions.slice(1)) {
+			for (const session of sessions.slice(1, 6)) {
 				view.show(session);
 				await waitFor(() =>
 					expect(
@@ -460,13 +509,25 @@ describe("TerminalCacheProvider", () => {
 					).not.toBeNull(),
 				);
 			}
-			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(7);
+			// Six visited sessions fit the cap, so nothing has been evicted yet.
+			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(6);
 			expect(oldest.isConnected).toBe(true);
 			expect(xtermUnmounts.value).toBe(0);
 
+			// The seventh evicts the least-recently-activated parked entry, keeping
+			// retained xterm buffers, renderer contexts and mux writers bounded.
+			view.show(sessions[6]);
+			await waitFor(() => expect(xtermUnmounts.value).toBe(1));
+			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(6);
+			expect(
+				document.querySelector(`[data-terminal-cache-key^="session:${sessions[0].id}:worker|"]`),
+			).toBeNull();
+
+			// Reopening an evicted session builds a fresh terminal over the covered
+			// replay path rather than resurrecting the disposed one.
 			view.show(sessions[0]);
-			await waitFor(() => expect(activeXterm()).toBe(oldest));
-			expect(xtermMounts.value).toBe(7);
+			await waitFor(() => expect(activeXterm()).not.toBe(oldest));
+			expect(xtermMounts.value).toBe(8);
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -74,6 +74,7 @@ type CachedTerminalEntry = TerminalCacheDescriptor & {
 	activationPhase: "parked" | "visible";
 	container: HTMLDivElement;
 	discardOnDeactivate?: boolean;
+	lastActivatedAt: number;
 	props: TerminalPaneProps;
 	terminal?: AttachableTerminal;
 };
@@ -90,6 +91,16 @@ type TerminalCacheController = {
 };
 
 const TerminalCacheContext = createContext<TerminalCacheController | null>(null);
+
+// Bound retained xterm buffers, renderer contexts and mux writers. The active
+// terminal is always retained; opening a seventh terminal evicts the oldest
+// parked entry, which can use the covered replay path when opened again.
+//
+// Without this bound every visited session keeps a mounted xterm — and with it
+// a WebGL context — for the lifetime of the renderer process. Chromium caps
+// live WebGL contexts and force-loses the oldest ones past that cap, so a
+// long-running window accumulates renderer failures until panes latch black.
+const MAX_RETAINED_TERMINALS = 6;
 
 function terminalTargetMatches(left?: TerminalTarget, right?: TerminalTarget): boolean {
 	if (left === right) return true;
@@ -231,7 +242,11 @@ function CachedTerminalPortal({
 		if (!active || entry.activationPhase !== "visible" || !terminal) return;
 		// Fit and scroll after the host is visible. This retains the cache's
 		// settled viewport behavior without putting a blank frame in front of it.
-		void terminal.prepareForActivation();
+		// A rejection must not go silent: the pane would look healthy while the
+		// viewport was never fitted.
+		void terminal.prepareForActivation().catch((error) => {
+			console.warn("Terminal activation preparation failed", error);
+		});
 	}, [
 		active,
 		entry,
@@ -269,6 +284,7 @@ export function TerminalCacheProvider({
 	const workspaceQuery = useWorkspaceQuery();
 	const shellTerminalsQuery = useShellTerminals();
 	const entriesRef = useRef(new Map<string, CachedTerminalEntry>());
+	const activationClockRef = useRef(0);
 	const activeRef = useRef<ActiveTerminalEntry | null>(null);
 	const parkingRef = useRef<HTMLDivElement | null>(null);
 	const muxPoolRef = useRef<TerminalMuxPool | null>(null);
@@ -336,6 +352,22 @@ export function TerminalCacheProvider({
 		[rerender],
 	);
 
+	// Deleting the entry drops its portal on the next render, which unmounts the
+	// XtermTerminal and releases both the terminal instance and its mux lease;
+	// removing the host node only cleans up the externally-created container.
+	const evictParkedBeyondCap = useCallback((keepCacheKey: string) => {
+		if (entriesRef.current.size <= MAX_RETAINED_TERMINALS) return;
+		const parked = [...entriesRef.current.values()]
+			.filter((candidate) => candidate.cacheKey !== keepCacheKey)
+			.sort((left, right) => left.lastActivatedAt - right.lastActivatedAt);
+		while (entriesRef.current.size > MAX_RETAINED_TERMINALS) {
+			const oldest = parked.shift();
+			if (!oldest) break;
+			entriesRef.current.delete(oldest.cacheKey);
+			oldest.container.remove();
+		}
+	}, []);
+
 	const activate = useCallback(
 		(descriptor: TerminalCacheDescriptor, props: TerminalPaneProps, slot: HTMLDivElement) => {
 			const parking = parkingRef.current;
@@ -380,17 +412,20 @@ export function TerminalCacheProvider({
 					activationId: 0,
 					activationPhase: "parked",
 					container,
+					lastActivatedAt: 0,
 					props: cachedProps,
 				};
 				entriesRef.current.set(entry.cacheKey, entry);
 			} else {
 				entry.props = cachedProps;
 			}
+			entry.lastActivatedAt = ++activationClockRef.current;
 			showTerminal(entry, slot);
 			activeRef.current = { key: entry.cacheKey, slot };
+			evictParkedBeyondCap(entry.cacheKey);
 			rerender();
 		},
-		[muxPool, rerender],
+		[evictParkedBeyondCap, muxPool, rerender],
 	);
 
 	const deactivate = useCallback(
@@ -917,8 +952,14 @@ function AttachedTerminal({
 		}
 		if (!replayPaintPending || !terminal) return;
 		let current = true;
-		void terminal.prepareForActivation().then(() => {
+		// Lift the cover even when preparation rejects. The cover is opaque, so a
+		// stuck one hides a working terminal behind a permanent blank surface.
+		const lift = () => {
 			if (current) setReplayPaintPending(false);
+		};
+		void terminal.prepareForActivation().then(lift, (error) => {
+			console.warn("Terminal replay paint preparation failed", error);
+			lift();
 		});
 		return () => {
 			current = false;
@@ -979,9 +1020,15 @@ function AttachedTerminal({
 		// before FitAddon has measured its real slot makes full-screen worker TUIs
 		// redraw once at 80×24 and again at the actual grid. Settle that first fit
 		// before attaching so the daemon receives only the authoritative size.
-		void terminal.prepareForActivation().then(() => {
+		// Attach even if preparation fails: a settled-fit error must cost one
+		// redraw at the wrong grid, never the whole session's output.
+		const attachNow = () => {
 			if (!current) return;
 			detach = attach(terminal);
+		};
+		void terminal.prepareForActivation().then(attachNow, (error) => {
+			console.warn("Terminal activation preparation failed", error);
+			attachNow();
 		});
 		return () => {
 			current = false;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -129,6 +129,11 @@ const COPY_TOAST_MS = 1400;
 const COLOR_SCHEME_UPDATE_MODE = 2031;
 const COLOR_SCHEME_QUERY = 996;
 
+// Upper bound on hiding a pane while its activation settles. Generous next to
+// the fit budget (FIT_CAP_MS) plus two paint frames, so it only fires when a
+// callback is genuinely never coming.
+const ACTIVATION_WATCHDOG_MS = 2000;
+
 function preparePastedText(text: string): string {
 	return text.replace(/\r?\n/g, "\r");
 }
@@ -1107,15 +1112,24 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		shell.addEventListener("dragover", dragOverInput);
 		shell.addEventListener("drop", dropInput);
 
+		// Guarded: xterm can throw out of scrollToBottom/viewport access when its
+		// renderer was torn down underneath us (a force-lost WebGL context, a
+		// disposed viewport). A throw here must never strand the activation
+		// promise, because a cache entry stuck in "preparing" stays
+		// visibility:hidden — a permanently black pane over a live session.
 		const showLatestOutput = () => {
-			term.scrollToBottom();
-			// Hidden output can leave the offscreen DOM scrollbar stale even
-			// after xterm's logical viewport moves. Synchronize it before either
-			// the first-load cover or retained-cache container is revealed.
-			const viewport = host.querySelector<HTMLElement>(".xterm-viewport");
-			if (!viewport) return;
-			viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
-			scheduleScrollbarUpdate();
+			try {
+				term.scrollToBottom();
+				// Hidden output can leave the offscreen DOM scrollbar stale even
+				// after xterm's logical viewport moves. Synchronize it before either
+				// the first-load cover or retained-cache container is revealed.
+				const viewport = host.querySelector<HTMLElement>(".xterm-viewport");
+				if (!viewport) return;
+				viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+				scheduleScrollbarUpdate();
+			} catch (error) {
+				console.warn("Unable to show latest terminal output", error);
+			}
 		};
 
 		let cancelActivationPreparation: (() => void) | null = null;
@@ -1124,16 +1138,23 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			return new Promise((resolve) => {
 				let firstFrame: number | null = null;
 				let paintFrame: number | null = null;
+				let watchdog: ReturnType<typeof setTimeout> | null = null;
 				let finished = false;
 				const finish = () => {
 					if (finished) return;
 					finished = true;
 					if (firstFrame !== null) cancelAnimationFrame(firstFrame);
 					if (paintFrame !== null) cancelAnimationFrame(paintFrame);
+					if (watchdog !== null) clearTimeout(watchdog);
 					if (cancelActivationPreparation === finish) cancelActivationPreparation = null;
 					resolve();
 				};
 				cancelActivationPreparation = finish;
+				// A settle callback or animation frame that never runs (background
+				// throttling, a renderer that stopped painting) would otherwise keep
+				// the entry hidden forever. Reveal on a deadline instead: a pane that
+				// is one frame short of settled beats a pane that is never shown.
+				watchdog = setTimeout(finish, ACTIVATION_WATCHDOG_MS);
 
 				const finishAcrossPaintFrames = () => {
 					if (finished) return;
@@ -1152,7 +1173,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				// The container is in its real slot but remains hidden. Wait for its
 				// dimensions to settle (including fullscreen/sidebar transitions), fit
 				// once, and avoid the old unconditional full-grid refresh.
-				scheduleStableFit(true, finishAcrossPaintFrames);
+				try {
+					scheduleStableFit(true, finishAcrossPaintFrames);
+				} catch (error) {
+					console.warn("Unable to prepare terminal for activation", error);
+					finish();
+				}
 			});
 		};
 


### PR DESCRIPTION
Refs #2333, #3803, #3787.

Terminal panes go black and stay black: the backend session is healthy, tmux has the content, but the pane paints nothing. Switching away and back does not help; only restarting the app clears it — which is why it reads as intermittent.

Two independent causes, both addressed here.

### 1. The retained-terminal cache is unbounded

`MAX_RETAINED_TERMINALS = 6` was removed in 4986af7d0 ("fix: retain terminals without eviction"). Since then every visited session keeps a mounted xterm — with its WebGL context and its mux lease — for the entire lifetime of the renderer process. Past Chromium's per-page WebGL context cap, the browser forcibly loses the *oldest* contexts, so the panes that go black are the ones visited earliest, not the ones doing anything wrong.

This restores the six-entry LRU. Eviction deletes the cache entry rather than only removing the host node: dropping the entry drops its portal on the next render, which unmounts `XtermTerminal` and releases both the terminal instance and its mux lease. Removing the container alone would clean up the DOM node and leak the rest.

The currently-active terminal is never evicted, and eviction considers only parked entries.

### 2. Activation and replay had no failure path

The activation state machine (`parked → preparing → ready → revealed → visible`) holds the pane at `visibility: hidden` during `preparing`. Any throw or rejection between those states leaves the cover on permanently — a black pane over a perfectly healthy session. Five such latches are closed:

- `showLatestOutput` wrapped, so a scroll failure costs one imperfect redraw instead of the pane
- a bounded watchdog on `prepareForActivation` (plus try/catch around `scheduleStableFit`), so a fit that never settles cannot hold the cover forever
- rejection handlers on the three `.then()` chains that drive attach, cached activation, and replay paint

The `replayPaintPending` latch was found by the added test rather than by reading the code: the opaque cover was never lifted when the replay-paint promise rejected.

### Relationship to the WebGL-loss work

The context-loss fallback in xuelongmu/agent-orchestrator#209 addresses the *reaction* to a lost WebGL context. This change removes the *accumulation* that causes contexts to be lost in the first place. They compose; neither subsumes the other.

### Tests

`TerminalPane.test.tsx` covers retention up to the cap and eviction of the oldest parked entry beyond it, plus the two rejection paths. 39 tests pass on this branch.

Note that `src/renderer/components/settings/AgentModelCombobox.test.tsx` fails on this branch — it fails identically on an untouched `main`, so it is pre-existing and unrelated.
