### PR TITLE
fix(restore): fall back to a fresh launch when the native conversation is gone

### DIFF
--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1671,7 +1671,7 @@ func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation strin
 			systemPrompt, systemPromptFile, agentConfig, rec.Kind, m.dataDir, true)
 	} else {
 		argv, delivery, mode, err = restoreArgv(ctx, agent, rec.ID, ws.Path, rec.Metadata,
-			systemPrompt, systemPromptFile, agentConfig, rec.Kind, rec.Harness, m.dataDir)
+			systemPrompt, systemPromptFile, agentConfig, rec.Kind, rec.Harness, m.dataDir, env)
 	}
 	if err != nil {
 		m.cleanupSystemPromptDir(rec.ID)
@@ -3658,7 +3658,7 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 // signals via ok=false (e.g. no native session id captured yet). Returns
 // ErrNotResumable when transcript-preserving restore is required but unavailable,
 // or when a promptless, unresumable worker has nothing to restore from.
-func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, workspacePath string, meta domain.SessionMetadata, systemPrompt, systemPromptFile string, agentConfig ports.AgentConfig, kind domain.SessionKind, _ domain.AgentHarness, dataDir string) ([]string, ports.PromptDeliveryStrategy, RestoreMode, error) {
+func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, workspacePath string, meta domain.SessionMetadata, systemPrompt, systemPromptFile string, agentConfig ports.AgentConfig, kind domain.SessionKind, _ domain.AgentHarness, dataDir string, env map[string]string) ([]string, ports.PromptDeliveryStrategy, RestoreMode, error) {
 	ref := ports.SessionRef{
 		ID:            string(id),
 		WorkspacePath: workspacePath,
@@ -3668,11 +3668,34 @@ func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, wo
 	if err != nil {
 		return nil, "", "", fmt.Errorf("restore command: %w", err)
 	}
-	if ok {
+	// The id is real but the provider never persisted a conversation under it —
+	// a session torn down before its first turn, or one whose switch away failed
+	// after the source stopped. Resuming that id fails with "No conversation
+	// found" every time, so the id alone must not gate restore.
+	conversationLost := ok && nativeConversationMissing(ctx, agent, ref, meta.AgentSessionID, env)
+	if ok && !conversationLost {
 		return cmd, ports.PromptDeliveryInCommand, RestoreModeNative, nil
 	}
+	// A lost conversation is not the same as nothing to restore: the session
+	// reached the point of reserving an id, and its workspace holds whatever
+	// branch and commits it produced. Relaunch into that workspace even without
+	// a saved prompt, rather than stranding the work behind ErrNotResumable. A
+	// worker that never got that far (no id, no prompt) still stays unresumable.
 	return freshLaunchArgv(ctx, agent, id, workspacePath, meta, systemPrompt,
-		systemPromptFile, agentConfig, kind, dataDir, false)
+		systemPromptFile, agentConfig, kind, dataDir, conversationLost)
+}
+
+// nativeConversationMissing reports whether the agent can see a persisted
+// conversation behind the id AO would resume. Agents that cannot answer (no
+// probe, or a failed probe) are treated as present: a restore that might work
+// beats refusing one that would.
+func nativeConversationMissing(ctx context.Context, agent ports.Agent, ref ports.SessionRef, conversationID string, env map[string]string) bool {
+	probe, ok := agent.(ports.AgentInterfaceHandoffHistoryProbe)
+	if !ok || strings.TrimSpace(conversationID) == "" {
+		return false
+	}
+	exists, err := probe.NativeConversationExists(ctx, ref, conversationID, env)
+	return err == nil && !exists
 }
 
 // freshLaunchArgv builds the non-resume half of restoreArgv. Interface

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -3691,8 +3691,24 @@ func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, wo
 // beats refusing one that would.
 func nativeConversationMissing(ctx context.Context, agent ports.Agent, ref ports.SessionRef, conversationID string, env map[string]string) bool {
 	probe, ok := agent.(ports.AgentInterfaceHandoffHistoryProbe)
-	if !ok || strings.TrimSpace(conversationID) == "" {
+	if !ok {
 		return false
+	}
+	conversationID = strings.TrimSpace(conversationID)
+	if conversationID == "" {
+		handoff, ok := agent.(ports.AgentInterfaceHandoff)
+		if !ok {
+			return false
+		}
+		var err error
+		conversationID, ok, err = handoff.NativeConversationID(ctx, ref, domain.SessionModeTUI, "")
+		if err != nil || !ok {
+			return false
+		}
+		conversationID = strings.TrimSpace(conversationID)
+		if conversationID == "" {
+			return false
+		}
 	}
 	exists, err := probe.NativeConversationExists(ctx, ref, conversationID, env)
 	return err == nil && !exists

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -4058,6 +4058,30 @@ func (lostConversationAgent) NativeConversationExists(
 	return false, nil
 }
 
+type lostDerivedConversationAgent struct {
+	fakeAgent
+	probedID string
+}
+
+func (*lostDerivedConversationAgent) GetRestoreCommand(
+	context.Context, ports.RestoreConfig,
+) ([]string, bool, error) {
+	return []string{"resume", "derived-but-empty"}, true, nil
+}
+
+func (*lostDerivedConversationAgent) NativeConversationID(
+	context.Context, ports.SessionRef, domain.SessionMode, string,
+) (string, bool, error) {
+	return "derived-but-empty", true, nil
+}
+
+func (a *lostDerivedConversationAgent) NativeConversationExists(
+	_ context.Context, _ ports.SessionRef, conversationID string, _ map[string]string,
+) (bool, error) {
+	a.probedID = conversationID
+	return false, nil
+}
+
 // A reserved-but-empty conversation id must not gate restore. Resuming it fails
 // with "No conversation found" on every attempt, while the session's workspace
 // still holds its branch and commits — so the session relaunches fresh into that
@@ -4083,6 +4107,33 @@ func TestRestore_LostNativeConversationRelaunchesFresh(t *testing.T) {
 	}
 	if res.Mode == RestoreModeNative {
 		t.Errorf("restore mode = %q, want a fresh relaunch rather than a doomed --resume", res.Mode)
+	}
+	if rt.created != 1 {
+		t.Errorf("runtime.Create = %d, want 1: the workspace holds real work", rt.created)
+	}
+}
+
+func TestRestore_LostDerivedNativeConversationRelaunchesFresh(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, IsTerminated: true,
+		Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1/root"},
+		Activity: domain.Activity{State: domain.ActivityExited},
+	}
+	agent := &lostDerivedConversationAgent{}
+	rt := &fakeRuntime{}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{Runtime: rt, Agents: singleAgent{agent: agent}, Workspace: &fakeWorkspace{}, Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: lookPath})
+
+	res, err := m.RestoreWithMode(ctx, "mer-1")
+	if err != nil {
+		t.Fatalf("restore with a lost derived conversation: %v", err)
+	}
+	if res.Mode == RestoreModeNative {
+		t.Errorf("restore mode = %q, want a fresh relaunch rather than a doomed --resume", res.Mode)
+	}
+	if agent.probedID != "derived-but-empty" {
+		t.Errorf("probed conversation id = %q, want derived-but-empty", agent.probedID)
 	}
 	if rt.created != 1 {
 		t.Errorf("runtime.Create = %d, want 1: the workspace holds real work", rt.created)

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -4047,6 +4047,48 @@ func TestRestore_PromptlessWorkerNotResumable(t *testing.T) {
 	}
 }
 
+// lostConversationAgent reserves a native id but reports that no conversation
+// was ever persisted behind it — a session torn down before its first turn, or
+// one whose switch away failed after the source had already stopped.
+type lostConversationAgent struct{ *recordingAgent }
+
+func (lostConversationAgent) NativeConversationExists(
+	context.Context, ports.SessionRef, string, map[string]string,
+) (bool, error) {
+	return false, nil
+}
+
+// A reserved-but-empty conversation id must not gate restore. Resuming it fails
+// with "No conversation found" on every attempt, while the session's workspace
+// still holds its branch and commits — so the session relaunches fresh into that
+// workspace instead of being stranded.
+func TestRestore_LostNativeConversationRelaunchesFresh(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, IsTerminated: true,
+		// An id was reserved, but no prompt was saved: without the probe this
+		// resumes into a conversation that does not exist.
+		Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1/root", AgentSessionID: "reserved-but-empty"},
+		Activity: domain.Activity{State: domain.ActivityExited},
+	}
+	rec := &recordingAgent{}
+	agent := lostConversationAgent{recordingAgent: rec}
+	rt := &fakeRuntime{}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{Runtime: rt, Agents: singleAgent{agent: agent}, Workspace: &fakeWorkspace{}, Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: lookPath})
+
+	res, err := m.RestoreWithMode(ctx, "mer-1")
+	if err != nil {
+		t.Fatalf("restore with a lost conversation: %v", err)
+	}
+	if res.Mode == RestoreModeNative {
+		t.Errorf("restore mode = %q, want a fresh relaunch rather than a doomed --resume", res.Mode)
+	}
+	if rt.created != 1 {
+		t.Errorf("runtime.Create = %d, want 1: the workspace holds real work", rt.created)
+	}
+}
+
 // TestRestore_WorkerPointsAtCurrentOrchestrator: a restored worker's
 // coordination hint must reference the orchestrator active at restore time,
 // not the one from its original spawn.


### PR DESCRIPTION
A session whose provider never persisted a conversation cannot be restored: every attempt resolves to a native resume against an id the agent has never heard of, and fails with

```
No conversation found with session ID: <uuid>
```

on every retry. The work in the session's workspace — its branch and commits — is still there, but unreachable through the UI.

This happens when a session is torn down before its first turn, or when a switch away from it fails after the source has already stopped.

### Cause

`GetRestoreCommand` returns `ok=true` for any id it can produce, including a deterministically computed UUID that was reserved but never used. Having an id is treated as proof that a conversation exists behind it, so restore always chooses `--resume` and always fails.

### Fix

Ask the agent before trusting the id. `ports.AgentInterfaceHandoffHistoryProbe` already exists for exactly this distinction — it is implemented by both claude-code and codex — but was only consulted on interface transitions, never on the restore path. When it reports the conversation missing, relaunch into the same workspace instead.

Agents that cannot answer (no probe, or a probe that errors) are treated as *present*, so this never turns a restore that might work into one that refuses.

The promptless relaxation is deliberately narrow — `allowPromptless = conversationLost`, not an unconditional `true`. Reaching the point of reserving an id is not the same as having nothing to restore, but a worker that never got that far (no id **and** no prompt) must stay unresumable; two existing tests guard that case and a broader relaxation breaks them.

### Tests

`TestRestore_LostNativeConversationRelaunchesFresh` fails without the change with `restore mode = "native"` — the doomed path. `TestRestore_PromptlessWorkerNotResumable` and `TestRestore_AgyAndCopilotPromptlessWorkersWithoutAgentSessionIDNotResumable` still pass, confirming the narrower case is untouched.

Verified live: `POST /resume-agent` returned 200 with `"resumeMode":"saved_prompt"` and the agent came up in its own worktree with all commits intact.

### Adjacent, not fixed here

`POST /restore` returns 409 `SESSION_NOT_RESTORABLE` for an `exited` session with `is_terminated=0`, because it requires `IsTerminated=true` (#2702). `/resume-agent` is the correct path for that state and is what the UI button uses.
