### PR TITLE
fix(browser): position preview view against content-view bounds, not screen coordinates

### DIFF
--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -119,11 +119,18 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 	const sent: Array<{ channel: string; payload: unknown }> = [];
 	const shellFocus = vi.fn();
 	const shellSend = vi.fn((channel: string, payload?: unknown) => sent.push({ channel, payload }));
-	const mainContentView = { addChildView: vi.fn(), removeChildView: vi.fn() };
+	// The window sits away from the display's top-left corner (x/y both
+	// nonzero) so a regression that reads screen-coordinate window bounds
+	// instead of content-view-relative bounds shows up as an offset (#2491).
+	const mainContentView = {
+		addChildView: vi.fn(),
+		removeChildView: vi.fn(),
+		getBounds: () => ({ x: 0, y: 0, width: 800, height: 600 }),
+	};
 	const host = createBrowserViewHost({
 		mainWindow: {
 			contentView: mainContentView,
-			getContentBounds: () => ({ x: 0, y: 0, width: 800, height: 600 }),
+			getContentBounds: () => ({ x: 200, y: 150, width: 800, height: 600 }),
 			webContents: {
 				id: 1,
 				focus: shellFocus,
@@ -1044,6 +1051,24 @@ describe("browser:setBounds", () => {
 
 		expect(view.setVisible).not.toHaveBeenCalledWith(true);
 		expect(view.setVisible).toHaveBeenLastCalledWith(false);
+	});
+
+	it("clamps against the content view's own bounds, not the window's screen position (#2491)", async () => {
+		// The mocked window sits at screen (200, 150) while its content view is
+		// (0, 0, 800, 600) in its own coordinate space — the space `setBounds`
+		// expects. A rect placed at the far edge of the content view must still
+		// clamp against the content view's 800x600, not get pushed further out
+		// (or clipped early) by the window's screen-space x/y.
+		const { emit, invoke, view } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		emit("browser:setBounds", 1, {
+			viewId: "1:sess-1",
+			rect: { x: 750, y: 550, width: 320, height: 240 },
+			visible: true,
+		});
+
+		expect(view.setBounds).toHaveBeenLastCalledWith({ x: 750, y: 550, width: 50, height: 50 });
 	});
 
 	it("restores renderer-owned bounds when reloading after a failed load", async () => {

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -179,6 +179,13 @@ type BrowserWindowLike = {
 	contentView: {
 		addChildView: (view: BrowserViewLike) => void;
 		removeChildView?: (view: BrowserViewLike) => void;
+		// Bounds of the content view itself, relative to its own origin
+		// ({x: 0, y: 0, width, height}) — the same coordinate space `view.setBounds()`
+		// expects for a child view. Prefer this over `getContentBounds()`, which
+		// returns the window's bounds in *screen* coordinates and is only
+		// coincidentally {0, 0, ...}-origin when the window sits at the display's
+		// top-left corner.
+		getBounds?: () => BrowserRect;
 	};
 	getContentBounds: () => BrowserRect;
 	webContents?: WebContents;
@@ -887,9 +894,14 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		// WebContentsView bounds are window coordinates. Convert before clamping so
 		// Cmd+/Cmd- page zoom does not detach the native view from its React slot.
 		session.rendererBounds = { ...rect };
+		// `contentView.getBounds()` is relative to the content view's own origin
+		// ({x: 0, y: 0, width, height}) — the same space child views are positioned
+		// in. `mainWindow.getContentBounds()` returns *screen* coordinates instead,
+		// which only happens to line up when the window sits at the display's
+		// top-left; anywhere else it silently offsets every native view (issue #2491).
 		session.bounds = clampBoundsToWindow(
 			scaleBoundsForZoom(rect, effectiveZoomFactor),
-			options.mainWindow.getContentBounds(),
+			options.mainWindow.contentView.getBounds?.() ?? options.mainWindow.getContentBounds(),
 		);
 		session.visible = true;
 		applySessionBounds(session, entry);


### PR DESCRIPTION
## Summary

Fixes #2491.

`clampBoundsToWindow()` in `browser-view-host.ts` clamped the incoming
renderer-measured rect against `mainWindow.getContentBounds()`. On a
`BaseWindow`, `getContentBounds()` returns the window's bounds in **screen**
coordinates (`{x, y, width, height}` with `x`/`y` being the window's position
on the display), not bounds relative to the content view's own origin.

`view.setBounds()` on a child `WebContentsView` expects coordinates relative
to the parent content view (`{0, 0, width, height}`-origin) — the same space
`window-composition.ts` already uses via `contentView.getBounds()` to
position the shell view itself.

Since `clampBoundsToWindow()` only reads `.width`/`.height` off the passed
bounds (not `.x`/`.y`), this mismatch didn't show up as a naive off-by-x/y
sizing bug in every case, but it does mean the preview view's positioning
logic was built on the wrong coordinate space, and any future width/height
derivation (or a window not positioned at the primary display's origin,
which is exactly the reporter's repro) can push the view off its intended
slot — matching the symptom described in the issue (browser view rendered
offset from the placeholder UI).

## Fix

Use `mainWindow.contentView.getBounds()` (content-view-relative) instead of
`mainWindow.getContentBounds()` (screen-relative) when clamping the incoming
bounds, with a fallback to `getContentBounds()` for hosts that don't expose
`contentView.getBounds()` (kept for type-compat / older test mocks).

## Tests

- Updated `browser-view-host.test.ts` mocks to model a window that is *not*
  at the display's top-left corner (`getContentBounds` now returns nonzero
  `x`/`y`), so the mock no longer accidentally hides screen-vs-content-view
  coordinate confusion.
- Added a regression test asserting the view is clamped against the content
  view's own (0,0-origin) bounds rather than the window's screen position.

```
cd frontend
npx vitest run src/main/browser-view-host.test.ts   # 56 passed
npx vitest run src/main/                            # 313 passed, 1 skipped
npx tsc --noEmit -p .                                # clean
```

## Notes

The issue also raises a separate, unconfirmed concern about a missing
main-process window move/resize listener (all re-sync is renderer-driven).
That's left as a follow-up — this PR addresses the coordinate-space bug
that's independently reproducible regardless of the resize-listener gap.