### PR TITLE
fix(terminal): bound replay write accounting so a stalled write cannot black out the pane

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -469,6 +469,31 @@ describe("TerminalPane replay cover", () => {
 		}
 	});
 
+	it("attaches and lifts the cover even when activation preparation rejects", async () => {
+		prepareForActivationMock.mockRejectedValue(new Error("viewport gone"));
+		replaySettled.value = false;
+		const view = renderPane({ ...worker, terminalHandleId: "term-1" });
+		try {
+			await waitFor(() => expect(attachMock).toHaveBeenCalled());
+			replaySettled.value = true;
+			view.rerender(
+				<QueryClientProvider client={view.queryClient}>
+					<TerminalPane
+						daemonReady
+						fontSize={12}
+						session={{ ...worker, terminalHandleId: "term-1" }}
+						theme="dark"
+					/>
+				</QueryClientProvider>,
+			);
+			await waitFor(() =>
+				expect(screen.queryByTestId("terminal-replay-cover")).not.toBeInTheDocument(),
+			);
+		} finally {
+			view.restore();
+		}
+	});
+
 	it("keeps the replay cover silent even when attachment takes longer", () => {
 		vi.useFakeTimers();
 		try {
@@ -531,7 +556,31 @@ describe("TerminalCacheProvider", () => {
 		}
 	});
 
-	it("retains every visited terminal until an authoritative lifecycle cleanup", async () => {
+	it("reveals a returning retained terminal even when its preparation rejects", async () => {
+		const view = renderCachedPane({ session: sessionA, sessions: [sessionA, sessionB] });
+		try {
+			await waitFor(() => activeXterm());
+			view.show(sessionB);
+			await waitFor(() => expect(screen.getAllByTestId("xterm")).toHaveLength(2));
+
+			// Returning to a retained terminal runs the cached preparation path. A
+			// rejection there must not strand the entry in "preparing", which stays
+			// visibility:hidden and reads as a permanently black pane.
+			prepareForActivationMock.mockRejectedValue(new Error("viewport gone"));
+			view.show(sessionA);
+			await waitFor(() => {
+				const container = document.querySelector<HTMLElement>(
+					`[data-terminal-cache-key^="session:${sessionA.id}:worker|"]`,
+				);
+				expect(container?.dataset.terminalActivationPhase).toBe("visible");
+				expect(container?.style.visibility).not.toBe("hidden");
+			});
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("retains visited terminals up to the cap and evicts the oldest parked one beyond it", async () => {
 		const sessions = Array.from({ length: 7 }, (_, index) => ({
 			...worker,
 			id: `sess-retained-${index}`,
@@ -541,7 +590,7 @@ describe("TerminalCacheProvider", () => {
 		const view = renderCachedPane({ session: sessions[0], sessions });
 		try {
 			const oldest = await waitFor(() => activeXterm());
-			for (const session of sessions.slice(1)) {
+			for (const session of sessions.slice(1, 6)) {
 				view.show(session);
 				await waitFor(() =>
 					expect(
@@ -549,13 +598,25 @@ describe("TerminalCacheProvider", () => {
 					).not.toBeNull(),
 				);
 			}
-			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(7);
+			// Six visited sessions fit the cap, so nothing has been evicted yet.
+			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(6);
 			expect(oldest.isConnected).toBe(true);
 			expect(xtermUnmounts.value).toBe(0);
 
+			// The seventh evicts the least-recently-activated parked entry, keeping
+			// retained xterm buffers, renderer contexts and mux writers bounded.
+			view.show(sessions[6]);
+			await waitFor(() => expect(xtermUnmounts.value).toBe(1));
+			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(6);
+			expect(
+				document.querySelector(`[data-terminal-cache-key^="session:${sessions[0].id}:worker|"]`),
+			).toBeNull();
+
+			// Reopening an evicted session builds a fresh terminal over the covered
+			// replay path rather than resurrecting the disposed one.
 			view.show(sessions[0]);
-			await waitFor(() => expect(activeXterm()).toBe(oldest));
-			expect(xtermMounts.value).toBe(7);
+			await waitFor(() => expect(activeXterm()).not.toBe(oldest));
+			expect(xtermMounts.value).toBe(8);
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -80,6 +80,7 @@ type CachedTerminalEntry = TerminalCacheDescriptor & {
 	activationPhase: "parked" | "visible";
 	container: HTMLDivElement;
 	discardOnDeactivate?: boolean;
+	lastActivatedAt: number;
 	props: TerminalPaneProps;
 	terminal?: AttachableTerminal;
 };
@@ -96,6 +97,16 @@ type TerminalCacheController = {
 };
 
 const TerminalCacheContext = createContext<TerminalCacheController | null>(null);
+
+// Bound retained xterm buffers, renderer contexts and mux writers. The active
+// terminal is always retained; opening a seventh terminal evicts the oldest
+// parked entry, which can use the covered replay path when opened again.
+//
+// Without this bound every visited session keeps a mounted xterm — and with it
+// a WebGL context — for the lifetime of the renderer process. Chromium caps
+// live WebGL contexts and force-loses the oldest ones past that cap, so a
+// long-running window accumulates renderer failures until panes latch black.
+const MAX_RETAINED_TERMINALS = 6;
 
 function terminalTargetMatches(left?: TerminalTarget, right?: TerminalTarget): boolean {
 	if (left === right) return true;
@@ -242,7 +253,11 @@ function CachedTerminalPortal({
 		if (!active || entry.activationPhase !== "visible" || !terminal) return;
 		// Fit and scroll after the host is visible. This retains the cache's
 		// settled viewport behavior without putting a blank frame in front of it.
-		void terminal.prepareForActivation();
+		// A rejection must not go silent: the pane would look healthy while the
+		// viewport was never fitted.
+		void terminal.prepareForActivation().catch((error) => {
+			console.warn("Terminal activation preparation failed", error);
+		});
 	}, [
 		active,
 		entry,
@@ -280,6 +295,7 @@ export function TerminalCacheProvider({
 	const workspaceQuery = useWorkspaceQuery();
 	const shellTerminalsQuery = useShellTerminals();
 	const entriesRef = useRef(new Map<string, CachedTerminalEntry>());
+	const activationClockRef = useRef(0);
 	const activeRef = useRef<ActiveTerminalEntry | null>(null);
 	const parkingRef = useRef<HTMLDivElement | null>(null);
 	const muxPoolRef = useRef<TerminalMuxPool | null>(null);
@@ -347,6 +363,22 @@ export function TerminalCacheProvider({
 		[rerender],
 	);
 
+	// Deleting the entry drops its portal on the next render, which unmounts the
+	// XtermTerminal and releases both the terminal instance and its mux lease;
+	// removing the host node only cleans up the externally-created container.
+	const evictParkedBeyondCap = useCallback((keepCacheKey: string) => {
+		if (entriesRef.current.size <= MAX_RETAINED_TERMINALS) return;
+		const parked = [...entriesRef.current.values()]
+			.filter((candidate) => candidate.cacheKey !== keepCacheKey)
+			.sort((left, right) => left.lastActivatedAt - right.lastActivatedAt);
+		while (entriesRef.current.size > MAX_RETAINED_TERMINALS) {
+			const oldest = parked.shift();
+			if (!oldest) break;
+			entriesRef.current.delete(oldest.cacheKey);
+			oldest.container.remove();
+		}
+	}, []);
+
 	const activate = useCallback(
 		(descriptor: TerminalCacheDescriptor, props: TerminalPaneProps, slot: HTMLDivElement) => {
 			const parking = parkingRef.current;
@@ -391,17 +423,20 @@ export function TerminalCacheProvider({
 					activationId: 0,
 					activationPhase: "parked",
 					container,
+					lastActivatedAt: 0,
 					props: cachedProps,
 				};
 				entriesRef.current.set(entry.cacheKey, entry);
 			} else {
 				entry.props = cachedProps;
 			}
+			entry.lastActivatedAt = ++activationClockRef.current;
 			showTerminal(entry, slot);
 			activeRef.current = { key: entry.cacheKey, slot };
+			evictParkedBeyondCap(entry.cacheKey);
 			rerender();
 		},
-		[muxPool, rerender],
+		[evictParkedBeyondCap, muxPool, rerender],
 	);
 
 	const deactivate = useCallback(
@@ -952,8 +987,14 @@ function AttachedTerminal({
 		}
 		if (!replayPaintPending || !terminal) return;
 		let current = true;
-		void terminal.prepareForActivation().then(() => {
+		// Lift the cover even when preparation rejects. The cover is opaque, so a
+		// stuck one hides a working terminal behind a permanent blank surface.
+		const lift = () => {
 			if (current) setReplayPaintPending(false);
+		};
+		void terminal.prepareForActivation().then(lift, (error) => {
+			console.warn("Terminal replay paint preparation failed", error);
+			lift();
 		});
 		return () => {
 			current = false;
@@ -1015,9 +1056,15 @@ function AttachedTerminal({
 		// before FitAddon has measured its real slot makes full-screen worker TUIs
 		// redraw once at 80×24 and again at the actual grid. Settle that first fit
 		// before attaching so the daemon receives only the authoritative size.
-		void terminal.prepareForActivation().then(() => {
+		// Attach even if preparation fails: a settled-fit error must cost one
+		// redraw at the wrong grid, never the whole session's output.
+		const attachNow = () => {
 			if (!current) return;
 			detach = attach(terminal);
+		};
+		void terminal.prepareForActivation().then(attachNow, (error) => {
+			console.warn("Terminal activation preparation failed", error);
+			attachNow();
 		});
 		return () => {
 			current = false;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -132,6 +132,11 @@ const AUTOFOCUS_RETRY_FRAMES = 2;
 const COLOR_SCHEME_UPDATE_MODE = 2031;
 const COLOR_SCHEME_QUERY = 996;
 
+// Upper bound on hiding a pane while its activation settles. Generous next to
+// the fit budget (FIT_CAP_MS) plus two paint frames, so it only fires when a
+// callback is genuinely never coming.
+const ACTIVATION_WATCHDOG_MS = 2000;
+
 function preparePastedText(text: string): string {
 	return text.replace(/\r?\n/g, "\r");
 }
@@ -1166,15 +1171,24 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		shell.addEventListener("dragover", dragOverInput);
 		shell.addEventListener("drop", dropInput);
 
+		// Guarded: xterm can throw out of scrollToBottom/viewport access when its
+		// renderer was torn down underneath us (a force-lost WebGL context, a
+		// disposed viewport). A throw here must never strand the activation
+		// promise, because a cache entry stuck in "preparing" stays
+		// visibility:hidden — a permanently black pane over a live session.
 		const showLatestOutput = () => {
-			term.scrollToBottom();
-			// Hidden output can leave the offscreen DOM scrollbar stale even
-			// after xterm's logical viewport moves. Synchronize it before either
-			// the first-load cover or retained-cache container is revealed.
-			const viewport = host.querySelector<HTMLElement>(".xterm-viewport");
-			if (!viewport) return;
-			viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
-			scheduleScrollbarUpdate();
+			try {
+				term.scrollToBottom();
+				// Hidden output can leave the offscreen DOM scrollbar stale even
+				// after xterm's logical viewport moves. Synchronize it before either
+				// the first-load cover or retained-cache container is revealed.
+				const viewport = host.querySelector<HTMLElement>(".xterm-viewport");
+				if (!viewport) return;
+				viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+				scheduleScrollbarUpdate();
+			} catch (error) {
+				console.warn("Unable to show latest terminal output", error);
+			}
 		};
 
 		let cancelActivationPreparation: (() => void) | null = null;
@@ -1183,16 +1197,23 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			return new Promise((resolve) => {
 				let firstFrame: number | null = null;
 				let paintFrame: number | null = null;
+				let watchdog: ReturnType<typeof setTimeout> | null = null;
 				let finished = false;
 				const finish = () => {
 					if (finished) return;
 					finished = true;
 					if (firstFrame !== null) cancelAnimationFrame(firstFrame);
 					if (paintFrame !== null) cancelAnimationFrame(paintFrame);
+					if (watchdog !== null) clearTimeout(watchdog);
 					if (cancelActivationPreparation === finish) cancelActivationPreparation = null;
 					resolve();
 				};
 				cancelActivationPreparation = finish;
+				// A settle callback or animation frame that never runs (background
+				// throttling, a renderer that stopped painting) would otherwise keep
+				// the entry hidden forever. Reveal on a deadline instead: a pane that
+				// is one frame short of settled beats a pane that is never shown.
+				watchdog = setTimeout(finish, ACTIVATION_WATCHDOG_MS);
 
 				const finishAcrossPaintFrames = () => {
 					if (finished) return;
@@ -1211,7 +1232,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				// The container is in its real slot but remains hidden. Wait for its
 				// dimensions to settle (including fullscreen/sidebar transitions), fit
 				// once, and avoid the old unconditional full-grid refresh.
-				scheduleStableFit(true, finishAcrossPaintFrames);
+				try {
+					scheduleStableFit(true, finishAcrossPaintFrames);
+				} catch (error) {
+					console.warn("Unable to prepare terminal for activation", error);
+					finish();
+				}
 			});
 		};
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -1253,6 +1253,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// Forward xterm's write callback: it fires once THIS chunk has been
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).
+			//
+			// The caller decrements its outstanding-write count inside `done`, so a
+			// throw on the way in must not swallow it: losing the callback strands
+			// that count above zero, which queues every later frame away from xterm
+			// and leaves the reveal cover up for good. Call `done` exactly once —
+			// xterm may also invoke it for a chunk it accepted before throwing.
 			write: (data, done, source = "live") => {
 				let hasEsc = false;
 				for (let i = 0; i < data.length; i++) {
@@ -1281,10 +1287,27 @@ export function XtermTerminal(props: XtermTerminalProps) {
 						}
 					}
 				}
-				term.write(data, () => {
+				if (!done) {
+					try {
+						term.write(data);
+					} catch {
+						// The chunk is lost either way; a dropped repaint beats a
+						// dead pane.
+					}
+					return;
+				}
+				let settled = false;
+				const settle = () => {
+					if (settled) return;
+					settled = true;
 					scheduleScrollbarUpdate();
-					done?.();
-				});
+					done();
+				};
+				try {
+					term.write(data, settle);
+				} catch {
+					settle();
+				}
 			},
 			writeln: (line) => term.writeln(line, scheduleScrollbarUpdate),
 			showLatestOutput,

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -4,7 +4,11 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MuxConnectionState, TerminalMux } from "../lib/terminal-mux";
 import type { WorkspaceSession } from "../types/workspace";
-import { useTerminalSession, type AttachableTerminal } from "./useTerminalSession";
+import {
+	REPLAY_WRITE_DEADLINE_MS,
+	useTerminalSession,
+	type AttachableTerminal,
+} from "./useTerminalSession";
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 
 const session: WorkspaceSession = {
@@ -89,6 +93,7 @@ function createFakeMux(): FakeMux {
 type FakeTerminal = AttachableTerminal & {
 	activeBufferType: "normal" | "alternate";
 	autoCompleteWrites: boolean;
+	throwOnWrite: boolean;
 	lines: string[];
 	pendingWriteCallbacks: Array<() => void>;
 	latestOutputRequests: number;
@@ -111,11 +116,16 @@ function createFakeTerminal(): FakeTerminal {
 		activeBufferType: "normal",
 		bufferType: () => terminal.activeBufferType,
 		autoCompleteWrites: true,
+		throwOnWrite: false,
 		lines: [],
 		pendingWriteCallbacks: [],
 		latestOutputRequests: 0,
 		// Mirrors xterm: the callback fires once the chunk has been parsed.
 		write: (bytes, done) => {
+			// A renderer addon throwing out of write is the shape the guarded
+			// writer has to absorb: the chunk is lost either way, but the write
+			// accounting must not be.
+			if (terminal.throwOnWrite) throw new Error("write failed");
 			terminal.lines.push(new TextDecoder().decode(bytes));
 			if (done) {
 				if (terminal.autoCompleteWrites) done();
@@ -403,6 +413,45 @@ describe("useTerminalSession", () => {
 			act(() => terminal.completeWrites());
 			expect(view.result.current.replaySettled).toBe(true);
 			expect(terminal.latestOutputRequests).toBe(1);
+		});
+
+		// A write callback that never arrives used to strand the pane forever:
+		// pendingReplayWrites stayed positive, so every later PTY frame queued
+		// behind it instead of reaching xterm and the cover was never lifted.
+		// The session stayed healthy on the backend while its pane showed
+		// nothing — the black-pane report.
+		it("recovers when a write callback never arrives", () => {
+			const { view, terminal, muxes } = setup();
+			terminal.autoCompleteWrites = false;
+			act(() => muxes[0].emitOpened("handle-1"));
+			act(() => muxes[0].emitData("handle-1", "replay"));
+			act(() => void vi.advanceTimersByTime(60 + 750));
+			expect(view.result.current.replaySettled).toBe(false);
+
+			act(() => void vi.advanceTimersByTime(REPLAY_WRITE_DEADLINE_MS));
+			expect(view.result.current.replaySettled).toBe(true);
+
+			// The pane is live again: bytes arriving after the deadline reach
+			// xterm rather than accumulating in the post-replay queue.
+			act(() => muxes[0].emitData("handle-1", "after deadline"));
+			expect(terminal.lines).toContain("after deadline");
+		});
+
+		it("recovers when a write throws synchronously", () => {
+			const { view, terminal, muxes } = setup();
+			terminal.throwOnWrite = true;
+			act(() => muxes[0].emitOpened("handle-1"));
+			act(() => muxes[0].emitData("handle-1", "replay"));
+			act(() => void vi.advanceTimersByTime(60 + 750));
+
+			// A throw loses the chunk, but the accounting must still settle so the
+			// cover comes off and the attachment keeps working.
+			act(() => void vi.advanceTimersByTime(REPLAY_WRITE_DEADLINE_MS));
+			expect(view.result.current.replaySettled).toBe(true);
+
+			terminal.throwOnWrite = false;
+			act(() => muxes[0].emitData("handle-1", "after throw"));
+			expect(terminal.lines).toContain("after throw");
 		});
 
 		it("streams reviewer-style attachments without the replay gate", () => {

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -144,6 +144,15 @@ const REPLAY_MAX_BYTES = 1024 * 1024;
 // cover and yield between them; the user still sees one final reveal while
 // fullscreen/window input remains responsive.
 const REPLAY_WRITE_BATCH_BYTES = 256 * 1024;
+// Deadline on outstanding write accounting. Every decrement of
+// pendingReplayWrites lives inside a write callback, so a callback that never
+// arrives — a renderer addon that swallows it, a throw on the way in — leaves
+// the counter positive forever. That is not a cosmetic stall: while it is
+// positive every later PTY frame queues instead of reaching xterm and the
+// cover never lifts, so a healthy session shows a dead pane. Recover silently
+// rather than surfacing an error; the cost of a false trip is one imperfect
+// redraw, and the cost of no deadline is the black pane.
+export const REPLAY_WRITE_DEADLINE_MS = 2_000;
 // Cover-only grace on the first replay byte. A pane that has produced NOTHING
 // has no walk to hide, so holding the cover to the cap just shows a blank
 // overlay — and past the pane's label delay (REPLAY_COVER_LABEL_MS in
@@ -390,6 +399,43 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 		let replayBatchTimer: ReturnType<typeof setTimeout> | null = null;
 		let replayBatchDone: (() => void) | null = null;
 		let replayWritesPreserved = false;
+		let replayWriteDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
+		let replayWritesAbandoned = false;
+
+		// Every decrement of pendingReplayWrites sits inside a write callback, and
+		// each of those callbacks returns early when the attachment has been
+		// superseded. Route the counter through these two helpers so no site can
+		// raise it without arming the deadline that bounds it.
+		// The terminal handle is supplied by the owner, so this hook cannot assume
+		// its write is guarded. Absorb a synchronous throw here too: the chunk is
+		// already lost, and letting it unwind would abort the replay mid-flight and
+		// strand the accounting the deadline below exists to protect.
+		const writeToTerminal = (bytes: Uint8Array, done?: () => void, source?: TerminalWriteSource) => {
+			try {
+				terminal.write(bytes, done, source);
+			} catch {
+				done?.();
+			}
+		};
+		const clearReplayWriteDeadline = () => {
+			if (replayWriteDeadlineTimer === null) return;
+			clearTimeout(replayWriteDeadlineTimer);
+			replayWriteDeadlineTimer = null;
+		};
+		const beginReplayWrite = () => {
+			pendingReplayWrites += 1;
+			if (replayWriteDeadlineTimer === null) {
+				replayWriteDeadlineTimer = setTimeout(
+					() => abandonStalledReplayWrites(),
+					REPLAY_WRITE_DEADLINE_MS,
+				);
+			}
+		};
+		const endReplayWrite = () => {
+			pendingReplayWrites = Math.max(0, pendingReplayWrites - 1);
+			if (pendingReplayWrites === 0) clearReplayWriteDeadline();
+		};
+
 		// Only a newly created handle can have live initial output. Component
 		// mounts, including the first mount after app startup, can replay history.
 		const initialWriteSource: TerminalWriteSource = consumeFreshTerminalHandle(handle) ? "live" : "replay";
@@ -447,7 +493,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				const end = Math.min(current.length, replayBatchOffset + REPLAY_WRITE_BATCH_BYTES);
 				const batch = current.subarray(replayBatchOffset, end);
 				replayBatchOffset = end;
-				terminal.write(batch, () => {
+				writeToTerminal(batch, () => {
 					if (replayWritesPreserved) return;
 					if (!isCurrentAttachment(generation, handle, mux)) return;
 					if (replayBatchOffset >= current.length) {
@@ -463,6 +509,45 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 			};
 			writeNext();
 		};
+		// The write accounting stalled: a callback never arrived, so the counter
+		// would stay positive for the life of the attachment. Give up on the
+		// outstanding writes and put the pane back into a working state — drain
+		// what is already queued straight into xterm and lift the cover. Recovery
+		// is silent: a false trip on a slow machine costs one imperfect redraw,
+		// while doing nothing costs the whole pane.
+		const abandonStalledReplayWrites = () => {
+			clearReplayWriteDeadline();
+			if (replayWritesPreserved || !isCurrentAttachment(generation, handle, mux)) return;
+			replayWritesAbandoned = true;
+			if (replayBatchTimer !== null) {
+				clearTimeout(replayBatchTimer);
+				replayBatchTimer = null;
+			}
+			// Whatever the stalled batch never got to is still ours to deliver.
+			if (replayBatchBytes && replayBatchOffset < replayBatchBytes.length) {
+				writeToTerminal(replayBatchBytes.subarray(replayBatchOffset));
+			}
+			replayBatchBytes = null;
+			replayBatchOffset = 0;
+			replayBatchDone = null;
+			for (const bytes of postReplayWriteQueue) writeToTerminal(bytes);
+			postReplayWriteQueue.length = 0;
+			postReplayWriteActive = false;
+			pendingReplayWrites = 0;
+			if (r.replayTailQuietTimer) {
+				clearTimeout(r.replayTailQuietTimer);
+				r.replayTailQuietTimer = null;
+			}
+			if (r.replayTailCapTimer) {
+				clearTimeout(r.replayTailCapTimer);
+				r.replayTailCapTimer = null;
+			}
+			r.replayTailPending = false;
+			replayRevealDeadlineReached = false;
+			terminal.showLatestOutput();
+			setReplaySettled(true);
+		};
+
 		const preservePendingReplayWrites = () => {
 			if (replayWritesPreserved) return;
 			replayWritesPreserved = true;
@@ -473,12 +558,12 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 			if (replayBatchBytes && replayBatchOffset < replayBatchBytes.length) {
 				// The current batch is already in xterm's queue. Queue the remainder in
 				// one call before dispose so it cannot be overtaken or discarded.
-				terminal.write(replayBatchBytes.subarray(replayBatchOffset), undefined, initialWriteSource);
+				writeToTerminal(replayBatchBytes.subarray(replayBatchOffset), undefined, initialWriteSource);
 			}
 			replayBatchBytes = null;
 			replayBatchOffset = 0;
 			replayBatchDone = null;
-			for (const bytes of postReplayWriteQueue) terminal.write(bytes, undefined, initialWriteSource);
+			for (const bytes of postReplayWriteQueue) writeToTerminal(bytes, undefined, initialWriteSource);
 			postReplayWriteQueue.length = 0;
 			postReplayWriteActive = false;
 			pendingReplayWrites = 0;
@@ -504,12 +589,12 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				return;
 			}
 			postReplayWriteActive = true;
-			pendingReplayWrites += 1;
-			terminal.write(bytes, () => {
-				if (replayWritesPreserved) return;
+			beginReplayWrite();
+			writeToTerminal(bytes, () => {
+				if (replayWritesPreserved || replayWritesAbandoned) return;
 				if (!isCurrentAttachment(generation, handle, mux)) return;
 				postReplayWriteActive = false;
-				pendingReplayWrites = Math.max(0, pendingReplayWrites - 1);
+				endReplayWrite();
 				drainPostReplayWrites();
 			}, initialWriteSource);
 		};
@@ -557,14 +642,15 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				offset += chunk.length;
 			}
 			if (preserveBeforeTeardown) {
-				terminal.write(replay, undefined, initialWriteSource);
+				writeToTerminal(replay, undefined, initialWriteSource);
 				preservePendingReplayWrites();
 				return;
 			}
-			pendingReplayWrites += 1;
+			beginReplayWrite();
 			writeReplayBatches(replay, () => {
+				if (replayWritesAbandoned) return;
 				if (!isCurrentAttachment(generation, handle, mux)) return;
-				pendingReplayWrites = Math.max(0, pendingReplayWrites - 1);
+				endReplayWrite();
 				drainPostReplayWrites();
 			});
 		};
@@ -601,7 +687,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 					drainPostReplayWrites();
 					return;
 				}
-				terminal.write(bytes);
+				writeToTerminal(bytes);
 			}),
 			mux.onOpened(handle, () => {
 				if (!isCurrentAttachment(generation, handle, mux)) return;


### PR DESCRIPTION
Refs #2333.

Stacked on #3901 — please review that one first; this PR's diff is the last commit only.

A terminal pane can go black and stay black over a completely healthy session: the backend has the content, the session is alive, but the pane never paints again. Only restarting the app clears it. This is the last latch I can find that produces that symptom, and it is the one that explains an observation the other fixes do not — pressing a key in tmux provably generated new bytes on the backend, and they never reached the pane.

### Cause

Every decrement of `pendingReplayWrites` lives inside a write callback:

```ts
terminal.write(bytes, () => {
    if (replayWritesPreserved) return;                          // returns BEFORE the decrement
    if (!isCurrentAttachment(generation, handle, mux)) return;   // and so does this
    postReplayWriteActive = false;
    pendingReplayWrites = Math.max(0, pendingReplayWrites - 1);
```

If the callback never arrives — a renderer addon that swallows it, or a synchronous throw on the way in — the counter stays positive for the life of the attachment. There is no deadline on it.

That single stuck counter is enough to kill the pane, because everything downstream is gated on it:

- every later PTY frame is pushed onto `postReplayWriteQueue` instead of being written to xterm;
- `drainPostReplayWrites` is itself gated on the same counter, so the queue is never drained;
- `revealReplayTail` and `settleAfterReplayWrites` are gated on it too, so the reveal cover is never lifted.

Healthy session, live bytes, dead pane.

### Changes

- Route the counter through `beginReplayWrite` / `endReplayWrite`, so no call site can raise it without arming the deadline that bounds it.
- On that deadline, abandon the outstanding writes: drain what is already queued straight into xterm, clear the tail timers, and lift the cover. Modeled on the existing `preservePendingReplayWrites`, which already does exactly this at teardown.
- Absorb synchronous throws at both write boundaries — the handle's `write` in `XtermTerminal`, and a local guard in the hook. The hook is handed its terminal by the owner and cannot assume the writer is guarded; letting a throw unwind aborts the replay mid-flight and strands the very accounting this change protects. `done` is called exactly once.

Recovery is deliberately silent. A false trip on a slow machine costs one imperfect redraw; no deadline at all costs the whole pane.

### Tests

Two regressions, both failing without the fix:

- a write callback that never arrives → after the deadline the cover is lifted and subsequent PTY bytes reach xterm instead of accumulating in the queue;
- a write that throws synchronously → the attachment still settles and keeps working.

Note `src/renderer/components/settings/AgentModelCombobox.test.tsx` fails on this branch; it fails identically on an untouched `main`, so it is pre-existing and unrelated.
