### PR TITLE
fix(terminal): defer xterm disposal and force the activation resize

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -469,6 +469,31 @@ describe("TerminalPane replay cover", () => {
 		}
 	});
 
+	it("attaches and lifts the cover even when activation preparation rejects", async () => {
+		prepareForActivationMock.mockRejectedValue(new Error("viewport gone"));
+		replaySettled.value = false;
+		const view = renderPane({ ...worker, terminalHandleId: "term-1" });
+		try {
+			await waitFor(() => expect(attachMock).toHaveBeenCalled());
+			replaySettled.value = true;
+			view.rerender(
+				<QueryClientProvider client={view.queryClient}>
+					<TerminalPane
+						daemonReady
+						fontSize={12}
+						session={{ ...worker, terminalHandleId: "term-1" }}
+						theme="dark"
+					/>
+				</QueryClientProvider>,
+			);
+			await waitFor(() =>
+				expect(screen.queryByTestId("terminal-replay-cover")).not.toBeInTheDocument(),
+			);
+		} finally {
+			view.restore();
+		}
+	});
+
 	it("keeps the replay cover silent even when attachment takes longer", () => {
 		vi.useFakeTimers();
 		try {
@@ -531,7 +556,31 @@ describe("TerminalCacheProvider", () => {
 		}
 	});
 
-	it("retains every visited terminal until an authoritative lifecycle cleanup", async () => {
+	it("reveals a returning retained terminal even when its preparation rejects", async () => {
+		const view = renderCachedPane({ session: sessionA, sessions: [sessionA, sessionB] });
+		try {
+			await waitFor(() => activeXterm());
+			view.show(sessionB);
+			await waitFor(() => expect(screen.getAllByTestId("xterm")).toHaveLength(2));
+
+			// Returning to a retained terminal runs the cached preparation path. A
+			// rejection there must not strand the entry in "preparing", which stays
+			// visibility:hidden and reads as a permanently black pane.
+			prepareForActivationMock.mockRejectedValue(new Error("viewport gone"));
+			view.show(sessionA);
+			await waitFor(() => {
+				const container = document.querySelector<HTMLElement>(
+					`[data-terminal-cache-key^="session:${sessionA.id}:worker|"]`,
+				);
+				expect(container?.dataset.terminalActivationPhase).toBe("visible");
+				expect(container?.style.visibility).not.toBe("hidden");
+			});
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("retains visited terminals up to the cap and evicts the oldest parked one beyond it", async () => {
 		const sessions = Array.from({ length: 7 }, (_, index) => ({
 			...worker,
 			id: `sess-retained-${index}`,
@@ -541,7 +590,7 @@ describe("TerminalCacheProvider", () => {
 		const view = renderCachedPane({ session: sessions[0], sessions });
 		try {
 			const oldest = await waitFor(() => activeXterm());
-			for (const session of sessions.slice(1)) {
+			for (const session of sessions.slice(1, 6)) {
 				view.show(session);
 				await waitFor(() =>
 					expect(
@@ -549,13 +598,25 @@ describe("TerminalCacheProvider", () => {
 					).not.toBeNull(),
 				);
 			}
-			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(7);
+			// Six visited sessions fit the cap, so nothing has been evicted yet.
+			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(6);
 			expect(oldest.isConnected).toBe(true);
 			expect(xtermUnmounts.value).toBe(0);
 
+			// The seventh evicts the least-recently-activated parked entry, keeping
+			// retained xterm buffers, renderer contexts and mux writers bounded.
+			view.show(sessions[6]);
+			await waitFor(() => expect(xtermUnmounts.value).toBe(1));
+			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(6);
+			expect(
+				document.querySelector(`[data-terminal-cache-key^="session:${sessions[0].id}:worker|"]`),
+			).toBeNull();
+
+			// Reopening an evicted session builds a fresh terminal over the covered
+			// replay path rather than resurrecting the disposed one.
 			view.show(sessions[0]);
-			await waitFor(() => expect(activeXterm()).toBe(oldest));
-			expect(xtermMounts.value).toBe(7);
+			await waitFor(() => expect(activeXterm()).not.toBe(oldest));
+			expect(xtermMounts.value).toBe(8);
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -80,6 +80,7 @@ type CachedTerminalEntry = TerminalCacheDescriptor & {
 	activationPhase: "parked" | "visible";
 	container: HTMLDivElement;
 	discardOnDeactivate?: boolean;
+	lastActivatedAt: number;
 	props: TerminalPaneProps;
 	terminal?: AttachableTerminal;
 };
@@ -96,6 +97,16 @@ type TerminalCacheController = {
 };
 
 const TerminalCacheContext = createContext<TerminalCacheController | null>(null);
+
+// Bound retained xterm buffers, renderer contexts and mux writers. The active
+// terminal is always retained; opening a seventh terminal evicts the oldest
+// parked entry, which can use the covered replay path when opened again.
+//
+// Without this bound every visited session keeps a mounted xterm — and with it
+// a WebGL context — for the lifetime of the renderer process. Chromium caps
+// live WebGL contexts and force-loses the oldest ones past that cap, so a
+// long-running window accumulates renderer failures until panes latch black.
+const MAX_RETAINED_TERMINALS = 6;
 
 function terminalTargetMatches(left?: TerminalTarget, right?: TerminalTarget): boolean {
 	if (left === right) return true;
@@ -242,7 +253,11 @@ function CachedTerminalPortal({
 		if (!active || entry.activationPhase !== "visible" || !terminal) return;
 		// Fit and scroll after the host is visible. This retains the cache's
 		// settled viewport behavior without putting a blank frame in front of it.
-		void terminal.prepareForActivation();
+		// A rejection must not go silent: the pane would look healthy while the
+		// viewport was never fitted.
+		void terminal.prepareForActivation().catch((error) => {
+			console.warn("Terminal activation preparation failed", error);
+		});
 	}, [
 		active,
 		entry,
@@ -280,6 +295,7 @@ export function TerminalCacheProvider({
 	const workspaceQuery = useWorkspaceQuery();
 	const shellTerminalsQuery = useShellTerminals();
 	const entriesRef = useRef(new Map<string, CachedTerminalEntry>());
+	const activationClockRef = useRef(0);
 	const activeRef = useRef<ActiveTerminalEntry | null>(null);
 	const parkingRef = useRef<HTMLDivElement | null>(null);
 	const muxPoolRef = useRef<TerminalMuxPool | null>(null);
@@ -347,6 +363,22 @@ export function TerminalCacheProvider({
 		[rerender],
 	);
 
+	// Deleting the entry drops its portal on the next render, which unmounts the
+	// XtermTerminal and releases both the terminal instance and its mux lease;
+	// removing the host node only cleans up the externally-created container.
+	const evictParkedBeyondCap = useCallback((keepCacheKey: string) => {
+		if (entriesRef.current.size <= MAX_RETAINED_TERMINALS) return;
+		const parked = [...entriesRef.current.values()]
+			.filter((candidate) => candidate.cacheKey !== keepCacheKey)
+			.sort((left, right) => left.lastActivatedAt - right.lastActivatedAt);
+		while (entriesRef.current.size > MAX_RETAINED_TERMINALS) {
+			const oldest = parked.shift();
+			if (!oldest) break;
+			entriesRef.current.delete(oldest.cacheKey);
+			oldest.container.remove();
+		}
+	}, []);
+
 	const activate = useCallback(
 		(descriptor: TerminalCacheDescriptor, props: TerminalPaneProps, slot: HTMLDivElement) => {
 			const parking = parkingRef.current;
@@ -391,17 +423,20 @@ export function TerminalCacheProvider({
 					activationId: 0,
 					activationPhase: "parked",
 					container,
+					lastActivatedAt: 0,
 					props: cachedProps,
 				};
 				entriesRef.current.set(entry.cacheKey, entry);
 			} else {
 				entry.props = cachedProps;
 			}
+			entry.lastActivatedAt = ++activationClockRef.current;
 			showTerminal(entry, slot);
 			activeRef.current = { key: entry.cacheKey, slot };
+			evictParkedBeyondCap(entry.cacheKey);
 			rerender();
 		},
-		[muxPool, rerender],
+		[evictParkedBeyondCap, muxPool, rerender],
 	);
 
 	const deactivate = useCallback(
@@ -952,8 +987,14 @@ function AttachedTerminal({
 		}
 		if (!replayPaintPending || !terminal) return;
 		let current = true;
-		void terminal.prepareForActivation().then(() => {
+		// Lift the cover even when preparation rejects. The cover is opaque, so a
+		// stuck one hides a working terminal behind a permanent blank surface.
+		const lift = () => {
 			if (current) setReplayPaintPending(false);
+		};
+		void terminal.prepareForActivation().then(lift, (error) => {
+			console.warn("Terminal replay paint preparation failed", error);
+			lift();
 		});
 		return () => {
 			current = false;
@@ -1015,9 +1056,15 @@ function AttachedTerminal({
 		// before FitAddon has measured its real slot makes full-screen worker TUIs
 		// redraw once at 80×24 and again at the actual grid. Settle that first fit
 		// before attaching so the daemon receives only the authoritative size.
-		void terminal.prepareForActivation().then(() => {
+		// Attach even if preparation fails: a settled-fit error must cost one
+		// redraw at the wrong grid, never the whole session's output.
+		const attachNow = () => {
 			if (!current) return;
 			detach = attach(terminal);
+		};
+		void terminal.prepareForActivation().then(attachNow, (error) => {
+			console.warn("Terminal activation preparation failed", error);
+			attachNow();
 		});
 		return () => {
 			current = false;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -132,6 +132,11 @@ const AUTOFOCUS_RETRY_FRAMES = 2;
 const COLOR_SCHEME_UPDATE_MODE = 2031;
 const COLOR_SCHEME_QUERY = 996;
 
+// Upper bound on hiding a pane while its activation settles. Generous next to
+// the fit budget (FIT_CAP_MS) plus two paint frames, so it only fires when a
+// callback is genuinely never coming.
+const ACTIVATION_WATCHDOG_MS = 2000;
+
 function preparePastedText(text: string): string {
 	return text.replace(/\r?\n/g, "\r");
 }
@@ -1166,15 +1171,24 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		shell.addEventListener("dragover", dragOverInput);
 		shell.addEventListener("drop", dropInput);
 
+		// Guarded: xterm can throw out of scrollToBottom/viewport access when its
+		// renderer was torn down underneath us (a force-lost WebGL context, a
+		// disposed viewport). A throw here must never strand the activation
+		// promise, because a cache entry stuck in "preparing" stays
+		// visibility:hidden — a permanently black pane over a live session.
 		const showLatestOutput = () => {
-			term.scrollToBottom();
-			// Hidden output can leave the offscreen DOM scrollbar stale even
-			// after xterm's logical viewport moves. Synchronize it before either
-			// the first-load cover or retained-cache container is revealed.
-			const viewport = host.querySelector<HTMLElement>(".xterm-viewport");
-			if (!viewport) return;
-			viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
-			scheduleScrollbarUpdate();
+			try {
+				term.scrollToBottom();
+				// Hidden output can leave the offscreen DOM scrollbar stale even
+				// after xterm's logical viewport moves. Synchronize it before either
+				// the first-load cover or retained-cache container is revealed.
+				const viewport = host.querySelector<HTMLElement>(".xterm-viewport");
+				if (!viewport) return;
+				viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+				scheduleScrollbarUpdate();
+			} catch (error) {
+				console.warn("Unable to show latest terminal output", error);
+			}
 		};
 
 		let cancelActivationPreparation: (() => void) | null = null;
@@ -1183,16 +1197,23 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			return new Promise((resolve) => {
 				let firstFrame: number | null = null;
 				let paintFrame: number | null = null;
+				let watchdog: ReturnType<typeof setTimeout> | null = null;
 				let finished = false;
 				const finish = () => {
 					if (finished) return;
 					finished = true;
 					if (firstFrame !== null) cancelAnimationFrame(firstFrame);
 					if (paintFrame !== null) cancelAnimationFrame(paintFrame);
+					if (watchdog !== null) clearTimeout(watchdog);
 					if (cancelActivationPreparation === finish) cancelActivationPreparation = null;
 					resolve();
 				};
 				cancelActivationPreparation = finish;
+				// A settle callback or animation frame that never runs (background
+				// throttling, a renderer that stopped painting) would otherwise keep
+				// the entry hidden forever. Reveal on a deadline instead: a pane that
+				// is one frame short of settled beats a pane that is never shown.
+				watchdog = setTimeout(finish, ACTIVATION_WATCHDOG_MS);
 
 				const finishAcrossPaintFrames = () => {
 					if (finished) return;
@@ -1211,7 +1232,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				// The container is in its real slot but remains hidden. Wait for its
 				// dimensions to settle (including fullscreen/sidebar transitions), fit
 				// once, and avoid the old unconditional full-grid refresh.
-				scheduleStableFit(true, finishAcrossPaintFrames);
+				try {
+					scheduleStableFit(true, finishAcrossPaintFrames);
+				} catch (error) {
+					console.warn("Unable to prepare terminal for activation", error);
+					finish();
+				}
 			});
 		};
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -1357,23 +1357,23 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			notifyCursorSchemeRef.current = () => {};
 			announcedCursorSchemeRef.current = null;
 			userInputListeners.clear();
-			const disposeTerminal = () => {
+			// xterm 5.5 schedules Viewport.syncScrollArea with a zero-delay timer
+			// during open(). Disposing in this same task clears RenderService's
+			// renderer first, so that pending callback throws while reading its
+			// dimensions. Handle replacement can hit exactly that window. Queue our
+			// disposal behind xterm's callback; all AO listeners and attachments are
+			// already detached above, so the terminal is inert during this one tick.
+			// (Upstream queues this delay only in DEV for the StrictMode probe
+			// mount; this change keeps it unconditional because handle replacement
+			// in production hits the same zero-delay window.)
+			window.setTimeout(() => {
 				try {
 					term.dispose();
 				} catch {
 					// Some renderer addons can throw during dispose in certain GPU
 					// environments; the terminal is being torn down regardless.
 				}
-			};
-			if (import.meta.env.DEV) {
-				// xterm's Viewport constructor queues an untracked zero-delay
-				// syncScrollArea(). React StrictMode immediately runs this cleanup after
-				// its development probe mount; queue disposal behind that callback so it
-				// cannot read the already-cleared renderer dimensions.
-				window.setTimeout(disposeTerminal, 0);
-			} else {
-				disposeTerminal();
-			}
+			}, 0);
 		};
 	}, []);
 

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -24,6 +24,7 @@ type FakeMux = {
 	mux: TerminalMux;
 	opens: Array<[string, number, number]>;
 	resizes: Array<[string, number, number]>;
+	forcedResizes: Array<[string, number, number]>;
 	inputs: Array<[string, string]>;
 	closes: string[];
 	events: string[];
@@ -52,6 +53,7 @@ function createFakeMux(): FakeMux {
 	const fake: FakeMux = {
 		opens: [],
 		resizes: [],
+		forcedResizes: [],
 		inputs: [],
 		closes: [],
 		events: [],
@@ -59,7 +61,10 @@ function createFakeMux(): FakeMux {
 		mux: {
 			open: (id, cols, rows) => fake.opens.push([id, cols, rows]),
 			sendInput: (id, input) => fake.inputs.push([id, input]),
-			resize: (id, cols, rows) => fake.resizes.push([id, cols, rows]),
+			resize: (id, cols, rows, force) => {
+				fake.resizes.push([id, cols, rows]);
+				if (force) fake.forcedResizes.push([id, cols, rows]);
+			},
 			close: (id) => {
 				fake.closes.push(id);
 				fake.events.push(`close:${id}`);
@@ -341,6 +346,27 @@ describe("useTerminalSession", () => {
 		act(() => view.result.current.syncVisibleSize(terminal.cols, terminal.rows));
 
 		expect(muxes[0].resizes.slice(initialResizes)).toEqual([["handle-1", 132, 47]]);
+		expect(muxes[0].forcedResizes).toEqual([["handle-1", 132, 47]]);
+	});
+
+	// The activation promote must reach the daemon even when the grid it
+	// republishes is identical to the last published one — the common case, since
+	// a parked terminal is refitted back to the size it already had. The daemon
+	// deduplicates repeat resizes, so an unforced call would be dropped and tmux
+	// would never be told to redraw, leaving the pane blank.
+	it("forces the activation resize when the grid is unchanged", () => {
+		const { view, terminal, muxes } = setup();
+		act(() => muxes[0].emitOpened("handle-1"));
+		act(() => terminal.emitResize(120, 40));
+		act(() => void vi.advanceTimersByTime(100));
+		const initialResizes = muxes[0].resizes.length;
+
+		view.rerender({ daemonReady: true, isVisible: false });
+		view.rerender({ daemonReady: true, isVisible: true });
+		act(() => view.result.current.syncVisibleSize(120, 40));
+
+		expect(muxes[0].resizes.slice(initialResizes)).toEqual([["handle-1", 120, 40]]);
+		expect(muxes[0].forcedResizes).toEqual([["handle-1", 120, 40]]);
 	});
 
 	it("collapses a drag's burst into one resize and does not re-send the settled grid", () => {

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -867,9 +867,13 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 			r.resizeTimer = null;
 		}
 		r.needsVisibleSizeSync = false;
-		const published = r.lastPublishedGrid;
-		if (published?.cols === cols && published.rows === rows) return;
-		r.mux.resize(r.handle, cols, rows);
+		// Force this one. The grid we are promoting back may be byte-identical to
+		// what was last published — a parked terminal reattaches at 0×0 and is
+		// refitted to the same size it had — and the daemon deduplicates repeat
+		// resizes, so the unforced call would be dropped and tmux would never be
+		// told to redraw. Only this activation path forces; ordinary resizes stay
+		// deduplicated.
+		r.mux.resize(r.handle, cols, rows, true);
 		r.lastPublishedGrid = { cols, rows };
 	}, []);
 


### PR DESCRIPTION
Refs #2333, #3803, #3787.

Stacked on #3901 — please review that one first; this PR's diff is the last commit only.

Two independent hardening changes around terminal activation and teardown. Neither is the primary black-pane fix; both close windows that can produce the same visible symptom.

### 1. Deferred disposal — a port of #3804

**This is not my work.** #3804 is open and unmerged; I am carrying its fix here because it becomes materially more relevant after #3901. Happy to drop this half if #3804 lands first, or to close it in favor of that PR.

xterm 5.5 schedules `Viewport.syncScrollArea` with a zero-delay timer during `open()`. Disposing in that same task clears `RenderService`'s renderer first, so the pending callback throws while reading its dimensions. Detaching listeners and the transport stays synchronous; only the final `term.dispose()` moves behind one macrotask, and every AO listener and attachment is already detached by then, so the terminal is inert for that tick.

Why it matters more now: #3901 restores an LRU cap on retained terminals, which means eviction disposes terminals far more often than the previous unbounded retention ever did. A race that was rare under "never dispose anything" is no longer rare.

### 2. Force the activation resize

The activation promote could never reach the daemon in the most common case.

A parked terminal reattaches at 0×0 and is then refitted back to the size it already had, so the grid being republished is usually byte-identical to `lastPublishedGrid`. `syncVisibleSize` returned early on exactly that equality, and even without the early return the daemon deduplicates repeat resizes — there is an explicit test for that, `TestServeDeduplicatesResizeUnlessExplicitlyForced`. So tmux was never asked to redraw, and the pane could stay blank.

The `force` flag already existed in the mux protocol and the backend already honored it. The renderer simply never sent it. Now this one activation path sends `force: true`; ordinary resizes stay deduplicated, preserving the behavior that backend test guards.

### Tests

The forced-resize regression fails without the change with an empty resize list — the daemon received nothing at all.

Note `src/renderer/components/settings/AgentModelCombobox.test.tsx` fails on this branch; it fails identically on an untouched `main`, so it is pre-existing and unrelated.
