### PR TITLE
fix(desktop): stop Cmd+Alt+I from crashing the main process on macOS

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -85,7 +85,7 @@ import { keepDaemonAlive, shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { shouldSignalAttention, shouldToast } from "./main/notification-signals";
-import { buildWindowsAppMenuTemplate } from "./main/menu";
+import { buildMacAppMenuTemplate, buildWindowsAppMenuTemplate } from "./main/menu";
 import { ancestorRepositorySetupWarning, scanImportFolder } from "./main/import-folder-scan";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
@@ -314,14 +314,29 @@ function appendDaemonOutput(text: string): void {
 // out of sight, but the roles keep their accelerators alive (Reload, zoom, full
 // screen, edit commands). DevTools uses the AO browser toggle so the focused
 // Browser panel opens the same native Chromium surface as the toolbar.
+// Open DevTools for whatever is actually focused. Electron's built-in
+// toggleDevTools role assumes focus is on the BrowserWindow; in AO it is usually
+// on a WebContentsView, where that role crashes the main process. Everything
+// that toggles DevTools goes through here instead.
+function toggleDevToolsForFocusedSurface(): void {
+	const fallback = () => getShellWebContents()?.toggleDevTools();
+	const host = browserViewHost;
+	if (!host) {
+		fallback();
+		return;
+	}
+	void host.toggleDevToolsForLastFocused().then((state) => {
+		if (!state) fallback();
+	}).catch(fallback);
+}
+
 function buildWindowsAppMenu(): Menu {
+	return Menu.buildFromTemplate(buildWindowsAppMenuTemplate(toggleDevToolsForFocusedSurface));
+}
+
+function buildMacAppMenu(): Menu {
 	return Menu.buildFromTemplate(
-		buildWindowsAppMenuTemplate(() => {
-			const fallback = () => getShellWebContents()?.toggleDevTools();
-			void browserViewHost?.toggleDevToolsForLastFocused().then((state) => {
-				if (!state) fallback();
-			}).catch(fallback);
-		}),
+		buildMacAppMenuTemplate(app.name, toggleDevToolsForFocusedSurface),
 	);
 }
 
@@ -407,11 +422,15 @@ async function createWindowInternal(): Promise<void> {
 	// On Windows the app paints its own title bar (WindowTitlebar), so the native
 	// menu bar is hidden (autoHideMenuBar above). The role-based menu is still
 	// installed so its accelerators keep working and act on the focused pane;
-	// setMenuBarVisibility(false) keeps the strip itself out of view. macOS/Linux
-	// keep their native menus.
+	// setMenuBarVisibility(false) keeps the strip itself out of view. macOS gets
+	// its own menu for the DevTools reason below; Linux keeps the default one.
 	if (process.platform === "win32") {
 		Menu.setApplicationMenu(buildWindowsAppMenu());
 		mainWindow.setMenuBarVisibility(false);
+	} else if (process.platform === "darwin") {
+		// Replace Electron's default menu: its Toggle Developer Tools role crashes
+		// the main process whenever focus sits on a WebContentsView. See menu.ts.
+		Menu.setApplicationMenu(buildMacAppMenu());
 	}
 
 	// Harden navigation: never let renderer/terminal content open in-app windows or

--- a/frontend/src/main/menu.test.ts
+++ b/frontend/src/main/menu.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { buildWindowsAppMenuTemplate } from "./menu";
+import { describe, expect, it, vi } from "vitest";
+import { buildMacAppMenuTemplate, buildWindowsAppMenuTemplate } from "./menu";
 
 type MenuItem = ReturnType<typeof buildWindowsAppMenuTemplate>[number];
 type SubmenuItem = NonNullable<Extract<MenuItem["submenu"], readonly unknown[]>>[number];
@@ -26,5 +26,47 @@ describe("buildWindowsAppMenuTemplate", () => {
 
 	it("keeps the direct minus accelerator for zoom out", () => {
 		expect(viewSubmenu()).toContainEqual(expect.objectContaining({ accelerator: "Ctrl+-", role: "zoomOut" }));
+	});
+});
+
+describe("buildMacAppMenuTemplate", () => {
+	function macViewSubmenu(onToggleDevTools = () => undefined): readonly SubmenuItem[] {
+		const viewMenu = buildMacAppMenuTemplate("AO", onToggleDevTools).find((item) => item.label === "View");
+		if (!viewMenu || !Array.isArray(viewMenu.submenu)) throw new Error("View menu not found");
+		return viewMenu.submenu;
+	}
+
+	// The whole point of installing a macOS menu: Electron's toggleDevTools role
+	// reads webContents off the focused BrowserWindow, which is undefined while a
+	// WebContentsView holds focus, and that takes down the main process. The item
+	// must carry a click handler and must NOT fall back to the role.
+	it("routes DevTools through a click handler instead of the crashing role", () => {
+		const onToggleDevTools = vi.fn();
+		const devtools = macViewSubmenu(onToggleDevTools).filter(
+			(item) => item.label === "Toggle Developer Tools" || item.role === "toggleDevTools",
+		);
+
+		expect(devtools).toHaveLength(1);
+		expect(devtools[0].role).toBeUndefined();
+		expect(devtools[0].accelerator).toBe("Alt+Command+I");
+
+		devtools[0].click?.(
+			undefined as never,
+			undefined as never,
+			undefined as never,
+		);
+		expect(onToggleDevTools).toHaveBeenCalledTimes(1);
+	});
+
+	// Replacing the default menu also drops the standard app submenu, so Quit and
+	// Hide have to be spelled out or Cmd+Q silently stops working.
+	it("keeps the standard app submenu roles", () => {
+		const appMenu = buildMacAppMenuTemplate("AO", () => undefined)[0];
+		if (!Array.isArray(appMenu.submenu)) throw new Error("app menu not found");
+
+		expect(appMenu.label).toBe("AO");
+		expect(appMenu.submenu.map((item) => item.role)).toEqual(
+			expect.arrayContaining(["quit", "hide", "hideOthers", "unhide", "services", "about"]),
+		);
 	});
 });

--- a/frontend/src/main/menu.ts
+++ b/frontend/src/main/menu.ts
@@ -1,5 +1,71 @@
 import type { MenuItemConstructorOptions } from "electron";
 
+// macOS keeps Electron's default menu unless the app installs its own, and that
+// default wires View → Toggle Developer Tools to the built-in role. The role
+// resolves the target as `focusedWindow.webContents`, but AO's focus normally
+// lives on a WebContentsView (the Browser panel), not on the BrowserWindow — so
+// the role reads `webContents` off `undefined` and takes down the main process.
+//
+// Installing our own menu is the fix: every other entry stays a role, and only
+// DevTools routes through the same guarded toggle the toolbar and the renderer's
+// menu:action channel already use. The app submenu is spelled out because
+// replacing the default menu also replaces the standard Quit/Hide/Services
+// items, and losing Cmd+Q would be a worse bug than the one being fixed.
+export function buildMacAppMenuTemplate(
+	appName: string,
+	onToggleDevTools: () => void,
+): MenuItemConstructorOptions[] {
+	return [
+		{
+			label: appName,
+			submenu: [
+				{ role: "about" },
+				{ type: "separator" },
+				{ role: "services" },
+				{ type: "separator" },
+				{ role: "hide" },
+				{ role: "hideOthers" },
+				{ role: "unhide" },
+				{ type: "separator" },
+				{ role: "quit" },
+			],
+		},
+		{
+			label: "Edit",
+			submenu: [
+				{ role: "undo" },
+				{ role: "redo" },
+				{ type: "separator" },
+				{ role: "cut" },
+				{ role: "copy" },
+				{ role: "paste" },
+				{ role: "selectAll" },
+			],
+		},
+		{
+			label: "View",
+			submenu: [
+				{ role: "reload" },
+				{
+					label: "Toggle Developer Tools",
+					accelerator: "Alt+Command+I",
+					click: onToggleDevTools,
+				},
+				{ type: "separator" },
+				{ role: "resetZoom" },
+				{ role: "zoomIn" },
+				{ role: "zoomOut" },
+				{ type: "separator" },
+				{ role: "togglefullscreen" },
+			],
+		},
+		{
+			label: "Window",
+			submenu: [{ role: "minimize" }, { role: "zoom" }, { type: "separator" }, { role: "front" }],
+		},
+	];
+}
+
 export function buildWindowsAppMenuTemplate(onToggleDevTools?: () => void): MenuItemConstructorOptions[] {
 	const devtoolsItem: MenuItemConstructorOptions = onToggleDevTools
 		? {


### PR DESCRIPTION
Pressing the DevTools shortcut on macOS takes down the main process:

```
TypeError: Cannot read properties of undefined (reading 'toggleDevTools')
  at webContentsMethod (node:electron/js2c/browser_init)
  at Object.execute / MenuItem.click / a._executeCommand
```

The user sees the "A JavaScript error occurred in the main process" dialog and the app is gone.

### Cause

The trace runs through `MenuItem.click`, so the failure is in Electron's **default** menu, not in any AO handler. `buildWindowsAppMenu` is gated on `win32`, so macOS never installed an application menu and the default one stayed active — including its View → Toggle Developer Tools entry, which uses the built-in `role: "toggleDevTools"`.

That role resolves its target as `focusedWindow.webContents`. In AO focus normally sits on a `WebContentsView` (the Browser panel) rather than on the `BrowserWindow`, so the role reads `webContents` off `undefined`.

Worth noting that AO's own three DevTools paths were already guarded against exactly this — the toolbar shortcut, the `menu:action` IPC handler, and the Windows menu item. Only the default menu was outside that guard, which is why the crash looked arbitrary: it depended on where focus happened to be.

### Fix

Install a macOS application menu so the crashing role is never used. Every other entry stays a role; DevTools routes through the same guarded toggle the other three paths already use, extracted here as `toggleDevToolsForFocusedSurface` and shared with the Windows menu.

The app submenu (`about`/`services`/`hide`/`hideOthers`/`unhide`/`quit`) is spelled out deliberately: replacing the default menu also replaces the standard items, and silently losing Cmd+Q would be a worse regression than the bug being fixed. There is a test pinning those roles for that reason.

### Verification

Beyond the unit tests, I confirmed against the built bundle that the shipped macOS View menu carries `{label: "Toggle Developer Tools", accelerator: "Alt+Command+I", click: …}` with no `role`, and that `setApplicationMenu` runs on the `darwin` branch. Cmd+Opt+I now opens DevTools for the focused surface instead of terminating the main process.



Closes #4308
