### PR TITLE
fix(ui): separate technical attention from Needs you

### DIFF
--- a/frontend/e2e/smoke-board.spec.ts
+++ b/frontend/e2e/smoke-board.spec.ts
@@ -27,6 +27,12 @@ test("renderer: card moves columns when its status changes @T0 @BRD", async ({ p
 	await expect(page.locator(columnCard("action", "mover"))).toBeVisible();
 	await expect(page.locator(columnCard("working", "mover"))).toHaveCount(0);
 	await expect(page.locator(columnCard("action", "mover"))).toContainText("Input needed");
+
+	// A technical status remains prominent but leaves the human-input column.
+	await page.evaluate(() => window.__aoFakeAgent!.setStatus("mover", "no_signal", "idle"));
+	await expect(page.locator(columnCard("technical", "mover"))).toBeVisible();
+	await expect(page.locator(columnCard("technical", "mover"))).toContainText("No signal");
+	await expect(page.locator(columnCard("action", "mover"))).toHaveCount(0);
 });
 
 // #2483 BRD-006.

--- a/frontend/e2e/smoke-t0.spec.ts
+++ b/frontend/e2e/smoke-t0.spec.ts
@@ -161,10 +161,13 @@ test("renderer: board state rehydrates after a renderer relaunch @T0 @DMN", asyn
 test("renderer: board renders all status columns @T0 @BRD", async ({ page }) => {
 	await page.goto("/");
 	const columns = page.getByTestId("board-column");
-	await expect(columns).toHaveCount(4);
-	// Left→right flow: work → needs-you → review → merge.
+	await expect(columns).toHaveCount(5);
+	// Left→right flow: work → needs-you → technical → review → merge.
 	await expect(page.locator('[data-testid="board-column"][data-column="working"]')).toContainText("Working");
 	await expect(page.locator('[data-testid="board-column"][data-column="action"]')).toContainText("Needs you");
+	await expect(page.locator('[data-testid="board-column"][data-column="technical"]')).toContainText(
+		"Technical attention",
+	);
 	await expect(page.locator('[data-testid="board-column"][data-column="pending"]')).toContainText("In review");
 	await expect(page.locator('[data-testid="board-column"][data-column="merge"]')).toContainText("Ready to merge");
 });

--- a/frontend/src/main/tray.test.ts
+++ b/frontend/src/main/tray.test.ts
@@ -88,21 +88,28 @@ describe("createTrayController", () => {
 		expect(tray.tooltip).toBe("1 session needs attention");
 	});
 
-	it("shows the count and orders merge-ready sessions above needs-you", () => {
+	it("shows the count and orders merge-ready, needs-you, and technical sections", () => {
 		const { controller, tray } = setup();
 		controller.setState({
 			sessions: [
 				entry({ sessionId: "needs", title: "needs you", zone: "action" }),
+				entry({ sessionId: "technical", title: "hook failed", zone: "technical" }),
 				entry({ sessionId: "ready", title: "ready", zone: "merge" }),
 			],
 		});
-		expect(tray.title).toBe("2");
-		expect(tray.tooltip).toBe("2 sessions need attention");
+		expect(tray.title).toBe("3");
+		expect(tray.tooltip).toBe("3 sessions need attention");
 		const labels = tray.template.map((i) => i.label);
 		expect(labels).toContain("Ready to merge");
 		expect(labels).toContain("Needs you");
+		expect(labels).toContain("Technical attention");
 		expect(labels.indexOf("Ready to merge")).toBeLessThan(labels.indexOf("Needs you"));
-		expect(sessionItems(tray).map((i) => i.label)).toEqual(["ready  ·  note-tauri", "needs you  ·  note-tauri"]);
+		expect(labels.indexOf("Needs you")).toBeLessThan(labels.indexOf("Technical attention"));
+		expect(sessionItems(tray).map((i) => i.label)).toEqual([
+			"ready  ·  note-tauri",
+			"needs you  ·  note-tauri",
+			"hook failed  ·  note-tauri",
+		]);
 	});
 
 	it("hands a session click to the openSession delegate", () => {
@@ -150,5 +157,15 @@ describe("createTrayController", () => {
 		expect(tray.tooltip).toBe("1 个会话需要关注");
 		expect(tray.template.some((i) => i.label === "需要你处理")).toBe(true);
 		expect(tray.template.some((i) => i.label === "显示 Agent Orchestrator")).toBe(true);
+	});
+
+	it("localizes the technical attention section independently from Needs you", () => {
+		const { controller, tray } = setup();
+		controller.setState({ sessions: [entry({ sessionId: "s1", zone: "technical" })] });
+		expect(tray.template.some((i) => i.label === "Technical attention")).toBe(true);
+
+		controller.setLocale("zh-CN");
+		expect(tray.template.some((i) => i.label === "技术问题")).toBe(true);
+		expect(tray.template.some((i) => i.label === "需要你处理")).toBe(false);
 	});
 });

--- a/frontend/src/main/tray.ts
+++ b/frontend/src/main/tray.ts
@@ -7,9 +7,13 @@ import type { TrayAttentionState, TrayAttentionZone, TrayOpenSessionTarget, Tray
 
 const MAX_MENU_SESSIONS = 8;
 
-const zoneRank: Record<TrayAttentionZone, number> = { merge: 0, action: 1 };
+const zoneRank: Record<TrayAttentionZone, number> = { merge: 0, action: 1, technical: 2 };
 
-const zoneLabelKey: Record<TrayAttentionZone, MessageKey> = { merge: "zone.merge", action: "zone.action" };
+const zoneLabelKey: Record<TrayAttentionZone, MessageKey> = {
+	merge: "zone.merge",
+	action: "zone.action",
+	technical: "zone.technical",
+};
 
 function format(template: string, vars: Record<string, string | number>): string {
 	return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) => String(vars[key] ?? match));

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -195,7 +195,7 @@ describe("global board first launch", () => {
 
 		expect(await screen.findByText("fix the bug")).toBeInTheDocument();
 		expect(screen.queryByText("Import to Agent Orchestrator")).not.toBeInTheDocument();
-		expect(columnCount()).toBe(4);
+		expect(columnCount()).toBe(5);
 	});
 
 	it("keeps populated columns visible after the daemon reports a startup failure", async () => {
@@ -217,7 +217,7 @@ describe("global board first launch", () => {
 
 		expect(await screen.findByText("fix the bug")).toBeInTheDocument();
 		expect(screen.queryByTestId("daemon-startup-loader")).not.toBeInTheDocument();
-		expect(columnCount()).toBe(4);
+		expect(columnCount()).toBe(5);
 	});
 });
 
@@ -380,6 +380,6 @@ describe("project board with no sessions", () => {
 
 		expect(await screen.findByText("fix the bug")).toBeInTheDocument();
 		expect(screen.queryByText("No worker sessions yet")).not.toBeInTheDocument();
-		expect(columnCount()).toBe(4);
+		expect(columnCount()).toBe(5);
 	});
 });

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -427,10 +427,15 @@ describe("SessionsBoard", () => {
 		expect(within(draftCard).getByText("Draft PR").closest("span")).toHaveClass("text-status-in-review");
 	});
 
-	it("places an exited live session in Needs you with an Exited badge", () => {
+	it("separates human input from technical attention and preserves status badges", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				workspaceWithSessions([
+					boardSession({ id: "s-input", title: "answer-agent", status: "needs_input" }),
+					boardSession({ id: "s-no-signal", title: "missing-hook", status: "no_signal" }),
+					boardSession({ id: "s-ci", title: "failing-ci", status: "ci_failed" }),
+					boardSession({ id: "s-changes", title: "review-fixes", status: "changes_requested" }),
+					boardSession({ id: "s-unknown", title: "unknown-state", status: "unknown" }),
 					{
 						id: "s-exited",
 						workspaceId: "p1",
@@ -452,9 +457,20 @@ describe("SessionsBoard", () => {
 		renderBoard("p1");
 
 		const needsYouColumn = screen.getByText("Needs you").closest("section") as HTMLElement;
+		const technicalColumn = screen.getByText("Technical attention").closest("section") as HTMLElement;
 		expect(needsYouColumn.firstElementChild).toHaveClass("h-12");
-		expect(within(needsYouColumn).getByText("agent-exited-task")).toBeInTheDocument();
-		expect(within(needsYouColumn).getByText("Exited").closest("span")).toHaveClass("text-status-exited");
+		expect(within(needsYouColumn).getByLabelText("1 Needs you session")).toHaveTextContent("1");
+		expect(within(needsYouColumn).getByText("answer-agent")).toBeInTheDocument();
+		for (const title of ["agent-exited-task", "missing-hook", "failing-ci", "review-fixes", "unknown-state"]) {
+			expect(within(needsYouColumn).queryByText(title)).not.toBeInTheDocument();
+			expect(within(technicalColumn).getByText(title)).toBeInTheDocument();
+		}
+		expect(within(technicalColumn).getByLabelText("5 Technical attention sessions")).toHaveTextContent("5");
+		expect(within(technicalColumn).getByText("Exited").closest("span")).toHaveClass("text-status-exited");
+		expect(within(technicalColumn).getByText("No signal")).toBeInTheDocument();
+		expect(within(technicalColumn).getByText("CI failed")).toBeInTheDocument();
+		expect(within(technicalColumn).getByText("Changes requested")).toBeInTheDocument();
+		expect(within(technicalColumn).getByText("Unknown status")).toBeInTheDocument();
 	});
 
 	it("renders an idle-first work lane with a separate lower working section", () => {
@@ -1095,6 +1111,7 @@ describe("SessionsBoard", () => {
 					boardSession({ id: "s-idle", title: "idle worker", status: "idle" }),
 					boardSession({ id: "s-working", title: "working worker", status: "working" }),
 					boardSession({ id: "s-action", title: "action worker", status: "needs_input" }),
+					boardSession({ id: "s-technical", title: "technical worker", status: "no_signal" }),
 					boardSession({ id: "s-review", title: "review worker", status: "review_pending" }),
 					boardSession({ id: "s-ready", title: "ready worker", status: "mergeable" }),
 					boardSession({ id: "s-merged", title: "merged worker", status: "merged" }),
@@ -1109,7 +1126,7 @@ describe("SessionsBoard", () => {
 		const laneScrollers = screen
 			.getAllByTestId("board-column")
 			.flatMap((column) => Array.from(column.querySelectorAll<HTMLElement>(".overflow-y-auto")));
-		expect(laneScrollers).toHaveLength(4);
+		expect(laneScrollers).toHaveLength(5);
 		for (const scroller of laneScrollers) {
 			expect(scroller).toHaveClass("board-scrollbar", "overflow-y-auto");
 		}

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -125,7 +125,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	// First-run orientation replaces the empty column shells (only once the
 	// query has resolved, so the welcome never flashes over real data): the
 	// global board teaches the app before any project exists, and a fresh
-	// project board invites the first task instead of showing four zeros.
+	// project board invites the first task instead of showing empty column shells.
 	const isDaemonReady = usesPreviewWorkspaceData || (shell ? shell.daemonStatus.state === "ready" : true);
 	const daemonHasFailed = Boolean(shell?.daemonStatus.code);
 	const workspaceStartupState = shell?.workspaceStartupState ?? "ready";

--- a/frontend/src/renderer/components/TrayRuntime.test.tsx
+++ b/frontend/src/renderer/components/TrayRuntime.test.tsx
@@ -59,6 +59,7 @@ function workspaces(): WorkspaceSummary[] {
 			sessions: [
 				worker({ id: "s-need", title: "needs it", status: "needs_input" }),
 				worker({ id: "s-work", title: "working", status: "working" }),
+				worker({ id: "s-tech", title: "repair hook", status: "no_signal" }),
 				worker({ id: "s-merge", title: "merge me", status: "mergeable" }),
 				worker({ id: "s-merged", title: "already merged", status: "merged" }),
 				worker({ id: "orch", title: "orchestrator", kind: "orchestrator", status: "needs_input" }),
@@ -80,6 +81,13 @@ describe("TrayRuntime", () => {
 		expect(h.setAttentionState).toHaveBeenLastCalledWith({
 			sessions: [
 				{ projectId: "proj-1", projectName: "note-tauri", sessionId: "s-need", title: "needs it", zone: "action" },
+				{
+					projectId: "proj-1",
+					projectName: "note-tauri",
+					sessionId: "s-tech",
+					title: "repair hook",
+					zone: "technical",
+				},
 				{ projectId: "proj-1", projectName: "note-tauri", sessionId: "s-merge", title: "merge me", zone: "merge" },
 			],
 		});

--- a/frontend/src/renderer/components/TrayRuntime.tsx
+++ b/frontend/src/renderer/components/TrayRuntime.tsx
@@ -15,7 +15,7 @@ export function TrayRuntime() {
 			for (const session of workerSessions(workspace.sessions)) {
 				const zone = attentionZone(session);
 				if (zone === "merge" && session.status === "merged") continue;
-				if (zone !== "action" && zone !== "merge") continue;
+				if (zone !== "action" && zone !== "technical" && zone !== "merge") continue;
 				entries.push({
 					projectId: workspace.id,
 					projectName: workspace.name,

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1040,6 +1040,7 @@
 	"zone.done": "Beendet",
 	"zone.merge": "Bereit zum Mergen",
 	"zone.pending": "In Review",
+	"zone.technical": "Technischer Handlungsbedarf",
 	"zone.working": "In Arbeit",
 	"settings.developer": "Developer",
 	"settings.help": "Help",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1050,6 +1050,7 @@
 	"zone.done": "Terminated",
 	"zone.merge": "Ready to merge",
 	"zone.pending": "In review",
+	"zone.technical": "Technical attention",
 	"zone.working": "Working",
 	"newTask.task": "Task",
 	"newTask.taskPlaceholder": "e.g. Fix the flaky checkout test (optional)…",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1054,6 +1054,7 @@
 	"zone.done": "Terminado",
 	"zone.merge": "Listo para fusionar",
 	"zone.pending": "En revisión",
+	"zone.technical": "Atención técnica",
 	"zone.working": "Trabajando",
 	"settings.developer": "Developer",
 	"settings.help": "Help",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1054,6 +1054,7 @@
 	"zone.done": "Terminé",
 	"zone.merge": "Prêt à fusionner",
 	"zone.pending": "En revue",
+	"zone.technical": "Attention technique",
 	"zone.working": "En cours",
 	"settings.developer": "Developer",
 	"settings.help": "Help",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1040,6 +1040,7 @@
 	"zone.done": "終了済み",
 	"zone.merge": "マージ準備完了",
 	"zone.pending": "レビュー中",
+	"zone.technical": "技術対応",
 	"zone.working": "作業中",
 	"settings.developer": "Developer",
 	"settings.help": "Help",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1040,6 +1040,7 @@
 	"zone.done": "종료됨",
 	"zone.merge": "병합 준비 완료",
 	"zone.pending": "리뷰 중",
+	"zone.technical": "기술 점검 필요",
 	"zone.working": "작업 중",
 	"settings.developer": "Developer",
 	"settings.help": "Help",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1054,6 +1054,7 @@
 	"zone.done": "Encerrado",
 	"zone.merge": "Pronto para merge",
 	"zone.pending": "Em revisão",
+	"zone.technical": "Atenção técnica",
 	"zone.working": "Em andamento",
 	"settings.developer": "Developer",
 	"settings.help": "Help",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1035,6 +1035,7 @@
 	"zone.done": "已终止",
 	"zone.merge": "可合并",
 	"zone.pending": "评审中",
+	"zone.technical": "技术问题",
 	"zone.working": "工作中",
 	"settings.developer": "开发者",
 	"settings.help": "帮助",

--- a/frontend/src/renderer/lib/command-palette.test.ts
+++ b/frontend/src/renderer/lib/command-palette.test.ts
@@ -52,6 +52,7 @@ function workspaces(): WorkspaceSummary[] {
 				session({ id: "w-working", title: "refactor loader", status: "working" }),
 				session({ id: "w-merge", title: "ship banner", status: "mergeable" }),
 				session({ id: "w-action", title: "fix flake", status: "needs_input" }),
+				session({ id: "w-technical", title: "repair hook", status: "no_signal" }),
 				session({ id: "w-pr", title: "add cache", status: "pr_open", prs: [pr(42)] }),
 				session({ id: "w-synthetic", title: "scratch", branch: "session/w-synthetic" }),
 				session({ id: "orch", title: "orchestrate", kind: "orchestrator" }),
@@ -131,14 +132,18 @@ describe("buildCommands grouping", () => {
 });
 
 describe("buildCommands attention", () => {
-	it("includes ready-to-merge AND attention-needing sessions, ordered merge-first", () => {
+	it("includes merge-ready, human-input, and technical sessions in zone priority order", () => {
 		const items = buildCommands({ workspaces: workspaces() });
 		const attention = items.filter((item) => item.group === "attention");
 		const ids = attention.map((item) => item.id);
 		expect(ids).toContain("attention:w-merge");
 		expect(ids).toContain("attention:w-action");
+		expect(ids).toContain("attention:w-technical");
 		expect(ids).not.toContain("attention:w-working");
 		expect(ids.indexOf("attention:w-merge")).toBeLessThan(ids.indexOf("attention:w-action"));
+		expect(ids.indexOf("attention:w-action")).toBeLessThan(ids.indexOf("attention:w-technical"));
+		expect(byId(items).get("attention:w-action")?.zone).toBe("action");
+		expect(byId(items).get("attention:w-technical")?.zone).toBe("technical");
 	});
 
 	it("omits the current session from Needs attention (already in view)", () => {
@@ -146,6 +151,7 @@ describe("buildCommands attention", () => {
 		const ids = new Set(items.map((item) => item.id));
 		expect(ids.has("attention:w-merge")).toBe(false);
 		expect(ids.has("attention:w-action")).toBe(true);
+		expect(ids.has("attention:w-technical")).toBe(true);
 	});
 });
 
@@ -157,6 +163,8 @@ describe("buildCommands sessions", () => {
 		expect(ids.has("session:w-merge")).toBe(false);
 		expect(ids.has("attention:w-action")).toBe(true);
 		expect(ids.has("session:w-action")).toBe(false);
+		expect(ids.has("attention:w-technical")).toBe(true);
+		expect(ids.has("session:w-technical")).toBe(false);
 		expect(ids.has("session:w-working")).toBe(false);
 		expect(ids.has("session:w-synthetic")).toBe(true);
 	});
@@ -386,7 +394,7 @@ describe("result caps", () => {
 });
 
 function isAttentionInZone(item: CommandItem): boolean {
-	return item.zone === "action" || item.zone === "merge";
+	return item.zone === "action" || item.zone === "technical" || item.zone === "merge";
 }
 
 describe("filterCommands / matchScore", () => {

--- a/frontend/src/renderer/lib/command-palette.ts
+++ b/frontend/src/renderer/lib/command-palette.ts
@@ -342,7 +342,7 @@ export function matchScore(query: string, item: CommandItem): number {
 }
 
 function isAttentionItem(item: CommandItem): boolean {
-	return item.zone === "action" || item.zone === "merge";
+	return item.zone === "action" || item.zone === "technical" || item.zone === "merge";
 }
 
 function attentionRank(item: CommandItem): number {

--- a/frontend/src/renderer/lib/session-presentation.test.ts
+++ b/frontend/src/renderer/lib/session-presentation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
 	attentionZone,
+	attentionZoneOrder,
+	boardAttentionZoneOrder,
 	getAgentActivityView,
 	getAttentionZoneView,
 	getSessionStatusView,
@@ -91,11 +93,11 @@ describe("session presentation", () => {
 		["approved", "merge", "Ready to merge"],
 		["mergeable", "merge", "Ready to merge"],
 		["needs_input", "action", "Needs you"],
-		["exited", "action", "Needs you"],
-		["no_signal", "action", "Needs you"],
-		["ci_failed", "action", "Needs you"],
-		["changes_requested", "action", "Needs you"],
-		["unknown", "action", "Needs you"],
+		["exited", "technical", "Technical attention"],
+		["no_signal", "technical", "Technical attention"],
+		["ci_failed", "technical", "Technical attention"],
+		["changes_requested", "technical", "Technical attention"],
+		["unknown", "technical", "Technical attention"],
 		["review_pending", "pending", "In review"],
 		["pr_open", "pending", "In review"],
 		["draft", "pending", "In review"],
@@ -106,6 +108,11 @@ describe("session presentation", () => {
 	] as const)("maps %s to the %s attention zone", (status, zone, label) => {
 		expect(attentionZone(sessionWith({ status }))).toBe(zone);
 		expect(getAttentionZoneView(status)).toMatchObject({ zone, label });
+	});
+
+	it("orders merge, human, and technical attention consistently across consumers", () => {
+		expect(attentionZoneOrder).toEqual(["merge", "action", "technical", "pending", "working", "done"]);
+		expect(boardAttentionZoneOrder).toEqual(["working", "action", "technical", "pending", "merge"]);
 	});
 
 	it("keeps activity indicator color independent from PR and CI presentation", () => {
@@ -122,6 +129,19 @@ describe("session presentation", () => {
 			titleClassName: "text-status-in-review",
 			dotClassName: "bg-status-in-review",
 		});
+	});
+
+	it("uses a prominent technical tone without changing status-specific badges", () => {
+		expect(getAttentionZoneView("no_signal")).toMatchObject({
+		zone: "technical",
+		dot: "var(--color-status-exited)",
+		titleClassName: "text-status-exited",
+		dotClassName: "bg-status-exited",
+	});
+		expect(getSessionStatusView("no_signal")).toMatchObject({
+		label: "No signal",
+		className: "text-status-unknown",
+	});
 	});
 
 	it("classifies only backend-derived idle sessions for the work lane", () => {

--- a/frontend/src/renderer/lib/session-presentation.ts
+++ b/frontend/src/renderer/lib/session-presentation.ts
@@ -68,6 +68,9 @@ export const attentionZoneLabel: Record<AttentionZone, string> = {
 	get action() {
 		return getAttentionZoneViewForZone("action").label;
 	},
+	get technical() {
+		return getAttentionZoneViewForZone("technical").label;
+	},
 	get pending() {
 		return getAttentionZoneViewForZone("pending").label;
 	},

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -8,6 +8,8 @@ import {
 	orchestratorHealth,
 	sessionIsActive,
 	sessionNeedsAttention,
+	sessionNeedsHumanInput,
+	sessionNeedsTechnicalAttention,
 	toAgentProvider,
 	toSessionActivity,
 	toSessionStatus,
@@ -201,8 +203,11 @@ describe("sessionNeedsAttention", () => {
 		},
 	);
 
-	it("treats no_signal as needing attention", () => {
-		expect(sessionNeedsAttention(sessionWith({ status: "no_signal" }))).toBe(true);
+	it("distinguishes a human question from technical attention", () => {
+		expect(sessionNeedsHumanInput(sessionWith({ status: "needs_input" }))).toBe(true);
+		expect(sessionNeedsHumanInput(sessionWith({ status: "no_signal" }))).toBe(false);
+		expect(sessionNeedsTechnicalAttention(sessionWith({ status: "no_signal" }))).toBe(true);
+		expect(sessionNeedsTechnicalAttention(sessionWith({ status: "needs_input" }))).toBe(false);
 	});
 
 	it("is false for statuses that don't need the user", () => {
@@ -312,11 +317,11 @@ describe("attentionZone", () => {
 		["mergeable", "merge"],
 		["approved", "merge"],
 		["needs_input", "action"],
-		["exited", "action"],
-		["no_signal", "action"],
-		["ci_failed", "action"],
-		["changes_requested", "action"],
-		["unknown", "action"],
+		["exited", "technical"],
+		["no_signal", "technical"],
+		["ci_failed", "technical"],
+		["changes_requested", "technical"],
+		["unknown", "technical"],
 		["review_pending", "pending"],
 		["pr_open", "pending"],
 		["draft", "pending"],

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -213,7 +213,16 @@ export function sessionIsActive(session: WorkspaceSession): boolean {
 }
 
 export function sessionNeedsAttention(session: WorkspaceSession): boolean {
+	const zone = presentationAttentionZone(session);
+	return zone === "action" || zone === "technical";
+}
+
+export function sessionNeedsHumanInput(session: WorkspaceSession): boolean {
 	return presentationAttentionZone(session) === "action";
+}
+
+export function sessionNeedsTechnicalAttention(session: WorkspaceSession): boolean {
+	return presentationAttentionZone(session) === "technical";
 }
 
 export { attentionZone, attentionZoneLabel, attentionZoneOrder } from "../lib/session-presentation";

--- a/frontend/src/shared/tray.ts
+++ b/frontend/src/shared/tray.ts
@@ -1,4 +1,4 @@
-export type TrayAttentionZone = "action" | "merge";
+export type TrayAttentionZone = "action" | "technical" | "merge";
 
 export type TraySessionEntry = {
 	projectId: string;

--- a/packages/mobile/app/(tabs)/index.tsx
+++ b/packages/mobile/app/(tabs)/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "expo-router";
 import { useCallback, useMemo, useState } from "react";
 import { ActivityIndicator, Platform, Pressable, RefreshControl, SectionList, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { attentionOf, type DashboardSession } from "../../lib/api";
+import type { DashboardSession } from "../../lib/api";
 import { classifyConnectionFailure, describeConnectionFailure } from "../../lib/connectionError";
 import { haptics } from "../../lib/haptics";
 import { groupSessions, type BoardSection, type BoardZone } from "../../lib/agentsView";
@@ -60,17 +60,14 @@ export default function FleetScreen() {
 	);
 
 	const counts = useMemo(() => {
-		let working = 0;
-		let needsYou = 0;
-		let mergeable = 0;
-		for (const s of sessions) {
-			const a = attentionOf(s);
-			if (a === "working") working++;
-			else if (a === "respond" || a === "action") needsYou++;
-			else if (a === "merge") mergeable++;
-		}
-		return { working, needsYou, mergeable };
-	}, [sessions]);
+		const count = (zone: BoardZone) => sections.find((section) => section.zone === zone)?.data.length ?? 0;
+		return {
+			working: count("working"),
+			needsYou: count("action"),
+			technical: count("technical"),
+			mergeable: count("merge"),
+		};
+	}, [sections]);
 
 	// A stat scrolls to its section. Guarded: scrollToLocation on a section that
 	// isn't rendered warns and does nothing, so a zero-count stat is inert rather
@@ -131,6 +128,7 @@ export default function FleetScreen() {
 			<View style={styles.stats}>
 				<Stat n={counts.working} label="working" color={t.orange} onPress={() => jumpTo("working")} />
 				<Stat n={counts.needsYou} label="need you" color={t.amber} onPress={() => jumpTo("action")} />
+				<Stat n={counts.technical} label="technical" color={t.red} onPress={() => jumpTo("technical")} />
 				<Stat n={counts.mergeable} label="mergeable" color={t.green} onPress={() => jumpTo("merge")} />
 			</View>
 
@@ -255,13 +253,15 @@ const makeStyles = (t: Theme) =>
 		errorActions: { flexDirection: "row", gap: 10, alignItems: "center" },
 		stats: {
 			flexDirection: "row",
+			flexWrap: "wrap",
 			gap: 10,
 			paddingHorizontal: 16,
 			paddingTop: 4,
 			paddingBottom: 10,
 		},
 		stat: {
-			flex: 1,
+			flexBasis: "40%",
+			flexGrow: 1,
 			backgroundColor: t.bgElevated,
 			borderRadius: 12,
 			borderWidth: 1,

--- a/packages/mobile/app/(tabs)/orchestrator.tsx
+++ b/packages/mobile/app/(tabs)/orchestrator.tsx
@@ -14,7 +14,7 @@ import { useTheme, useThemedStyles } from "../../lib/ThemeProvider";
 import { useTabScrollToTop } from "../../lib/useTabScrollToTop";
 import { Button, cardShell, Dot, EmptyState, IconButton, ScreenHeader } from "../../lib/ui";
 
-const ZONE_ORDER: AttentionLevel[] = ["merge", "respond", "review", "pending", "working", "done"];
+const ZONE_ORDER: AttentionLevel[] = ["merge", "respond", "technical", "review", "pending", "working", "done"];
 
 export default function OrchestratorScreen() {
 	const t = useTheme();

--- a/packages/mobile/lib/agentsView.test.ts
+++ b/packages/mobile/lib/agentsView.test.ts
@@ -18,17 +18,16 @@ const session = (over: Partial<DashboardSession> = {}): DashboardSession =>
 const pr = (over: Partial<DashboardPR> = {}): DashboardPR => ({ number: 1, url: "", state: "open", ...over });
 
 describe("boardZoneOf", () => {
-	it("uses desktop's four columns in its order", () => {
-		expect(BOARD_ZONES).toEqual(["working", "action", "pending", "merge"]);
+	it("uses desktop's five columns in its order", () => {
+		expect(BOARD_ZONES).toEqual(["working", "action", "technical", "pending", "merge"]);
 	});
 
-	// Desktop files ci_failed and changes_requested under "Needs you" rather than
-	// giving review its own column; mobile used to split them.
-	it("folds review and respond into Needs you", () => {
+	it("reserves Needs you for human input and separates technical recovery", () => {
 		expect(boardZoneOf(session({ status: "needs_input" }))).toBe("action");
 		expect(boardZoneOf(session({ status: "stuck" }))).toBe("action");
-		expect(boardZoneOf(session({ status: "ci_failed" }))).toBe("action");
-		expect(boardZoneOf(session({ status: "changes_requested" }))).toBe("action");
+		for (const status of ["ci_failed", "changes_requested", "no_signal", "exited", "unknown"]) {
+			expect(boardZoneOf(session({ status }))).toBe("technical");
+		}
 	});
 
 	it("maps the remaining zones straight through", () => {
@@ -46,6 +45,7 @@ describe("zoneMeta", () => {
 		expect(BOARD_ZONES.map((z) => zoneMeta(darkTheme, z).label)).toEqual([
 			"Working",
 			"Needs you",
+			"Technical attention",
 			"In review",
 			"Ready to merge",
 		]);
@@ -86,6 +86,16 @@ describe("groupSessions", () => {
 		]);
 		expect(sections.map((s) => s.zone)).toEqual(["working", "action"]);
 		expect(archived.map((s) => s.id)).toEqual(["z"]);
+	});
+
+	it("keeps human and technical sessions in distinct ordered sections", () => {
+		const { sections } = groupSessions(darkTheme, [
+			session({ id: "technical", status: "no_signal" }),
+			session({ id: "human", status: "needs_input" }),
+		]);
+		expect(sections.map((section) => section.zone)).toEqual(["action", "technical"]);
+		expect(sections[0].data.map((item) => item.id)).toEqual(["human"]);
+		expect(sections[1].data.map((item) => item.id)).toEqual(["technical"]);
 	});
 
 	// A run of empty section titles is most of a phone screen.

--- a/packages/mobile/lib/agentsView.ts
+++ b/packages/mobile/lib/agentsView.ts
@@ -10,22 +10,22 @@ import { prLifecycle, type Tone } from "./prView";
 import { attentionOf } from "./sessionStatus";
 import type { Theme } from "./theme";
 
-/** The four board columns, as desktop names them. */
-export type BoardZone = "working" | "action" | "pending" | "merge";
+/** The five board columns, as desktop names them. */
+export type BoardZone = "working" | "action" | "technical" | "pending" | "merge";
 
 /** Desktop's left-to-right column order (`boardAttentionZoneOrder`). */
-export const BOARD_ZONES: BoardZone[] = ["working", "action", "pending", "merge"];
+export const BOARD_ZONES: BoardZone[] = ["working", "action", "technical", "pending", "merge"];
 
 /**
  * Which column a session belongs in.
  *
  * A presentation mapping over `attentionOf`, not a replacement for it — the
- * orchestrator tab's zone pills use its finer six-bucket taxonomy, and changing
+ * orchestrator tab's zone pills use its finer attention taxonomy, and changing
  * that would change them too.
  *
- * `respond` and `review` both fold into `action`: desktop files `ci_failed` and
- * `changes_requested` under "Needs you" rather than giving review its own
- * column, and a phone has even less room to split them.
+ * The portable product contract reserves `action` for a human question and
+ * gives technical recovery its own zone. `review` remains the mobile API's
+ * legacy fallback for PR facts that have not produced a concrete status.
  */
 export function boardZoneOf(session: DashboardSession): BoardZone {
 	switch (attentionOf(session)) {
@@ -33,10 +33,13 @@ export function boardZoneOf(session: DashboardSession): BoardZone {
 			return "merge";
 		case "pending":
 			return "pending";
+		case "technical":
+			return "technical";
 		case "respond":
 		case "action":
-		case "review":
 			return "action";
+		case "review":
+			return "technical";
 		default:
 			// `working` and `done`. A session only reaches here as `done` when it is
 			// finished but its runtime is still alive — a dead one is archived
@@ -51,6 +54,8 @@ export function zoneMeta(t: Theme, zone: BoardZone): { label: string; color: str
 			return { label: "Ready to merge", color: t.green };
 		case "action":
 			return { label: "Needs you", color: t.amber };
+		case "technical":
+			return { label: "Technical attention", color: t.red };
 		case "pending":
 			return { label: "In review", color: t.textTertiary };
 		default:

--- a/packages/mobile/lib/orchestratorView.test.ts
+++ b/packages/mobile/lib/orchestratorView.test.ts
@@ -114,9 +114,11 @@ describe("zoneCounts", () => {
 			session({ status: "working" }),
 			session({ status: "working" }),
 			session({ status: "needs_input" }),
+			session({ status: "no_signal" }),
 		]);
 		expect(counts.working).toBe(2);
 		expect(counts.respond).toBe(1);
+		expect(counts.technical).toBe(1);
 	});
 
 	it("is empty for no sessions", () => {

--- a/packages/mobile/lib/sessionStatus.test.ts
+++ b/packages/mobile/lib/sessionStatus.test.ts
@@ -92,9 +92,19 @@ describe("attentionOf", () => {
 		expect(attentionOf(session({ status: "stuck" }))).toBe("respond");
 	});
 
-	it("maps failing CI and requested changes to review", () => {
-		expect(attentionOf(session({ status: "ci_failed" }))).toBe("review");
+	it("keeps fact-only failing PRs in the legacy review bucket", () => {
+		expect(attentionOf(session({ status: "ci_failed" }))).toBe("technical");
 		expect(attentionOf(session({ prs: [{ number: 1, url: "u", ciStatus: "failing" }] as never }))).toBe("review");
+	});
+
+	it("maps every concrete recovery status to technical attention", () => {
+		for (const status of ["no_signal", "exited", "ci_failed", "changes_requested", "unknown"]) {
+			expect(attentionOf(session({ status }))).toBe("technical");
+		}
+	});
+
+	it("overrides a stale server attention bucket for a concrete technical status", () => {
+		expect(attentionOf(session({ status: "no_signal", attentionLevel: "action" }))).toBe("technical");
 	});
 
 	it("defaults to working", () => {

--- a/packages/mobile/lib/sessionStatus.ts
+++ b/packages/mobile/lib/sessionStatus.ts
@@ -7,6 +7,13 @@ import type { DashboardSession } from "./api";
 import type { AttentionLevel } from "./theme";
 
 const TERMINAL_STATUSES = new Set(["killed", "terminated", "done", "cleanup", "errored", "merged"]);
+const TECHNICAL_ATTENTION_STATUSES = new Set([
+	"no_signal",
+	"exited",
+	"ci_failed",
+	"changes_requested",
+	"unknown",
+]);
 
 export function isTerminalStatus(status?: string | null): boolean {
 	return !!status && TERMINAL_STATUSES.has(status);
@@ -14,6 +21,9 @@ export function isTerminalStatus(status?: string | null): boolean {
 
 // Fallback attention bucket when the server didn't compute attentionLevel.
 export function attentionOf(s: DashboardSession): AttentionLevel {
+	// Older daemons may still report these as a generic action/review bucket.
+	// The client owns the presentation distinction: none is a human question.
+	if (s.status && TECHNICAL_ATTENTION_STATUSES.has(s.status)) return "technical";
 	if (s.attentionLevel) return s.attentionLevel as AttentionLevel;
 	const pr = s.pr ?? s.prs?.[0];
 	if (s.status === "merged" || s.status === "done" || isTerminalStatus(s.status)) return "done";

--- a/packages/mobile/lib/theme.test.ts
+++ b/packages/mobile/lib/theme.test.ts
@@ -159,6 +159,12 @@ describe("theme-aware helpers", () => {
 			const meta = attentionMetaFor(t);
 			expect(meta.merge.color).toBe(t.green);
 			expect(meta.working.color).toBe(t.orange);
+			expect(meta.technical).toMatchObject({
+				label: "Technical attention",
+				color: t.red,
+				tint: t.tintRed,
+				order: 2,
+			});
 		}
 	});
 

--- a/packages/mobile/lib/theme.ts
+++ b/packages/mobile/lib/theme.ts
@@ -251,7 +251,15 @@ export function terminalTheme(scheme: ColorScheme): TerminalTheme {
 // ---- Status vocabulary -----------------------------------------------------
 
 // AO's attention levels, in urgency order. Drives the board sections.
-export type AttentionLevel = "merge" | "action" | "respond" | "review" | "pending" | "working" | "done";
+export type AttentionLevel =
+	| "merge"
+	| "action"
+	| "respond"
+	| "technical"
+	| "review"
+	| "pending"
+	| "working"
+	| "done";
 
 export type AttentionMeta = { label: string; color: string; tint: string; order: number };
 
@@ -260,10 +268,11 @@ export function attentionMetaFor(t: Theme): Record<string, AttentionMeta> {
 		merge: { label: "Ready to merge", color: t.green, tint: t.tintGreen, order: 0 },
 		action: { label: "Needs you", color: t.amber, tint: t.tintAmber, order: 1 },
 		respond: { label: "Needs you", color: t.amber, tint: t.tintAmber, order: 1 },
-		review: { label: "Review", color: t.red, tint: t.tintRed, order: 2 },
-		pending: { label: "In review", color: t.textTertiary, tint: t.bgSubtle, order: 3 },
-		working: { label: "Working", color: t.orange, tint: t.tintOrange, order: 4 },
-		done: { label: "Done", color: t.textTertiary, tint: t.bgSubtle, order: 5 },
+		technical: { label: "Technical attention", color: t.red, tint: t.tintRed, order: 2 },
+		review: { label: "Review", color: t.red, tint: t.tintRed, order: 3 },
+		pending: { label: "In review", color: t.textTertiary, tint: t.bgSubtle, order: 4 },
+		working: { label: "Working", color: t.orange, tint: t.tintOrange, order: 5 },
+		done: { label: "Done", color: t.textTertiary, tint: t.bgSubtle, order: 6 },
 	};
 }
 

--- a/packages/product-ui/src/SessionsBoardView.test.tsx
+++ b/packages/product-ui/src/SessionsBoardView.test.tsx
@@ -52,6 +52,9 @@ describe("SessionsBoardView", () => {
 		const sessions: BoardSessionPresentation[] = [
 			baseSession,
 			{ ...baseSession, id: "working", status: "working", title: "working task" },
+			{ ...baseSession, id: "human", status: "needs_input", title: "human question" },
+			{ ...baseSession, id: "technical", status: "no_signal", title: "missing signal" },
+			{ ...baseSession, id: "review", status: "review_pending", title: "review task" },
 			{ ...baseSession, id: "ready", status: "mergeable", title: "ready task" },
 			{ ...baseSession, id: "merged", status: "merged", title: "merged task" },
 		];
@@ -68,10 +71,37 @@ describe("SessionsBoardView", () => {
 		expect(within(workLane).getByRole("region", { name: "Idle sessions" })).toHaveTextContent("portable task");
 		expect(within(workLane).getByRole("region", { name: "Working sessions" })).toHaveTextContent("working task");
 		expect(workLane.querySelectorAll(".overflow-y-auto")).toHaveLength(1);
+		expect(screen.getAllByTestId("board-column").map((column) => column.dataset.column)).toEqual([
+			"working",
+			"action",
+			"technical",
+			"pending",
+			"merge",
+		]);
+		const humanLane = screen.getByRole("region", { name: "Needs you sessions" });
+		expect(within(humanLane).getByLabelText("1 Needs you session")).toHaveTextContent("1");
+		expect(within(humanLane).getByText("human question")).toBeInTheDocument();
+		const technicalLane = screen.getByRole("region", { name: "Technical attention sessions" });
+		expect(within(technicalLane).getByLabelText("1 Technical attention session")).toHaveTextContent("1");
+		expect(within(technicalLane).getByText("missing signal")).toBeInTheDocument();
 
 		const mergeLane = screen.getByRole("region", { name: "Ready / Merged sessions" });
 		expect(within(mergeLane).getByLabelText("1 ready session")).toHaveTextContent("1");
 		expect(within(mergeLane).getByLabelText("1 merged session")).toHaveTextContent("1");
+	});
+
+	it("keeps an empty technical lane visible with an accessible zero count", () => {
+		render(
+			<SessionsBoardGridView
+				columns={boardAttentionZoneOrder.map((zone) => getAttentionZoneViewForZone(zone))}
+				labels={splitLabels}
+				renderSessionCard={(session) => <div>{session.title}</div>}
+				sessions={[baseSession]}
+			/>,
+		);
+
+		const technicalLane = screen.getByRole("region", { name: "Technical attention sessions" });
+		expect(within(technicalLane).getByLabelText("0 Technical attention sessions")).toHaveTextContent("0");
 	});
 
 	it("renders a neutral card with grouped multi-PR, usage, and action presentation", () => {

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -91,7 +91,7 @@ export function SessionsBoardGridView<TSession extends BoardSessionPresentation>
 
 	return (
 		<div className="h-full overflow-x-auto overflow-y-hidden">
-			<div className="relative grid h-full min-w-[64rem] grid-cols-4 divide-x divide-border-strong xl:min-w-0">
+			<div className="relative grid h-full min-w-[80rem] grid-cols-5 divide-x divide-border-strong 2xl:min-w-0">
 				<div
 					aria-hidden="true"
 					className="pointer-events-none absolute inset-x-0 top-12 z-10 border-t border-border-strong"
@@ -179,7 +179,9 @@ function BoardColumnView<TSession extends BoardSessionPresentation>({
 				<span className={cn("font-mono text-2xs font-medium uppercase tracking-wide-sm", column.titleClassName)}>
 					{column.label}
 				</span>
-				<span className="ml-auto font-mono text-2xs leading-none text-passive">{sessions.length}</span>
+				<span className="ml-auto font-mono text-2xs leading-none text-passive">
+					<SessionCount count={sessions.length} label={column.label} format={labels.countSessions} />
+				</span>
 			</div>
 			<div className="board-scrollbar min-h-0 flex-1 overflow-y-auto px-3 pb-3 pt-3">
 				<div className="flex min-h-full flex-col gap-2.5">

--- a/packages/product-ui/src/session-presentation.test.ts
+++ b/packages/product-ui/src/session-presentation.test.ts
@@ -1,13 +1,35 @@
 import { describe, expect, it } from "vitest";
+import { SESSION_STATUSES, type SessionStatus } from "./session-models";
 import {
 	attentionZone,
+	attentionZoneOrder,
+	boardAttentionZoneOrder,
 	getAgentActivityView,
 	getAttentionZoneView,
 	getSessionStatusView,
 	getSessionTimelinePillView,
 	isAgentActivityWorking,
 	isSessionIdle,
+	type AttentionZone,
 } from "./session-presentation";
+
+const expectedAttentionZones: Record<SessionStatus, AttentionZone> = {
+	working: "working",
+	pr_open: "pending",
+	draft: "pending",
+	ci_failed: "technical",
+	review_pending: "pending",
+	changes_requested: "technical",
+	approved: "merge",
+	mergeable: "merge",
+	merged: "merge",
+	needs_input: "action",
+	exited: "technical",
+	no_signal: "technical",
+	idle: "working",
+	terminated: "done",
+	unknown: "technical",
+};
 
 describe("session presentation", () => {
 	it.each([
@@ -34,14 +56,13 @@ describe("session presentation", () => {
 		);
 	});
 
-	it.each([
-		["approved", "merge"],
-		["needs_input", "action"],
-		["review_pending", "pending"],
-		["working", "working"],
-		["terminated", "done"],
-	] as const)("maps %s to the %s attention zone", (status, zone) => {
-		expect(attentionZone(status)).toBe(zone);
+	it.each(SESSION_STATUSES)("maps %s to exactly one attention zone", (status) => {
+		expect(attentionZone(status)).toBe(expectedAttentionZones[status]);
+	});
+
+	it("publishes stable attention and board ordering", () => {
+		expect(attentionZoneOrder).toEqual(["merge", "action", "technical", "pending", "working", "done"]);
+		expect(boardAttentionZoneOrder).toEqual(["working", "action", "technical", "pending", "merge"]);
 	});
 
 	it("keeps lifecycle predicates independent of presentation labels", () => {

--- a/packages/product-ui/src/session-presentation.ts
+++ b/packages/product-ui/src/session-presentation.ts
@@ -40,6 +40,7 @@ const englishLabels: Record<SessionPresentationMessageKey, string> = {
 	"status.unknown": "Unknown status",
 	"zone.merge": "Ready to merge",
 	"zone.action": "Needs you",
+	"zone.technical": "Technical attention",
 	"zone.pending": "In review",
 	"zone.working": "Working",
 	"zone.done": "Terminated",
@@ -164,7 +165,7 @@ export function getSessionStatusView(
 	};
 }
 
-export type AttentionZone = "merge" | "action" | "pending" | "working" | "done";
+export type AttentionZone = "merge" | "action" | "technical" | "pending" | "working" | "done";
 
 export type AttentionZoneView = {
 	zone: AttentionZone;
@@ -199,6 +200,15 @@ const attentionZoneBases: Record<AttentionZone, AttentionZoneBase> = {
 		titleClassName: "text-status-needs-you",
 		dotClassName: "bg-status-needs-you",
 	},
+	technical: {
+		zone: "technical",
+		labelKey: "zone.technical",
+		glow: "color-mix(in srgb, var(--color-status-exited) 6%, transparent)",
+		dot: "var(--color-status-exited)",
+		dotGlow: true,
+		titleClassName: "text-status-exited",
+		dotClassName: "bg-status-exited",
+	},
 	pending: {
 		zone: "pending",
 		labelKey: "zone.pending",
@@ -228,8 +238,8 @@ const attentionZoneBases: Record<AttentionZone, AttentionZoneBase> = {
 	},
 };
 
-export const attentionZoneOrder: AttentionZone[] = ["merge", "action", "pending", "working", "done"];
-export const boardAttentionZoneOrder: AttentionZone[] = ["working", "action", "pending", "merge"];
+export const attentionZoneOrder: AttentionZone[] = ["merge", "action", "technical", "pending", "working", "done"];
+export const boardAttentionZoneOrder: AttentionZone[] = ["working", "action", "technical", "pending", "merge"];
 
 export function attentionZone(input: SessionStatus | SessionStatusModel): AttentionZone {
 	const status = typeof input === "string" ? input : input.status;
@@ -241,12 +251,13 @@ export function attentionZone(input: SessionStatus | SessionStatusModel): Attent
 		case "terminated":
 			return "done";
 		case "needs_input":
+			return "action";
 		case "exited":
 		case "no_signal":
 		case "ci_failed":
 		case "changes_requested":
 		case "unknown":
-			return "action";
+			return "technical";
 		case "review_pending":
 		case "pr_open":
 		case "draft":


### PR DESCRIPTION
## What

- add a shared `technical` attention zone and keep `needs_input` exclusively in human-facing **Needs you**
- classify `no_signal`, `exited`, `ci_failed`, `changes_requested`, and `unknown` as technical attention
- update the five-lane board order, counts, zero states, accessibility labels, command-palette quota/order, tray presentation, translations, and responsive desktop layout
- align the existing mobile adapter, section order, counts, and narrow-screen stats with the shared product contract

## Why

The previous presentation contract grouped technical failures and review blockers under **Needs you**, conflating sessions that require human input with sessions that need technical investigation. This change separates those concepts without changing backend status derivation or the status-specific badge and timeline semantics.

Fixes #3909

## Scope

This is intentionally a product-UI contract change only. It does not change SessionStart, hook grace periods, restore behavior, routing, controllers, or backend status derivation. Native/toast input notifications also remain specific to `needs_input`.

## Compatibility notes

- Mobile has no dependency on `@aoagents/product-ui`, whose public entry also exports DOM components. Its existing adapter is therefore kept semantically aligned through an exhaustive status table instead of adding a broader package/Metro dependency.
- Concrete mobile technical statuses now override a stale generic server attention bucket; explicit `unknown` is technical, while an absent/null status retains the existing working fallback.
- The tray attention-zone union is internal and ephemeral; it now carries `technical` alongside `action` and `merge`, with no persisted wire migration.

## Validation

- `npm run product-ui:check` — 61 tests, typecheck, and build passed
- `npm --prefix frontend test` — 2,225 passed, 1 skipped
- `npm run frontend:typecheck`
- `npm --prefix frontend run typecheck:e2e`
- `npm --prefix packages/mobile test` — 382 passed
- `npm --prefix packages/mobile run typecheck`
- `npm run lint`
- `npm --prefix frontend run test:e2e -- e2e/smoke-board.spec.ts e2e/smoke-t0.spec.ts` — 14 passed
- `npm pack --dry-run` in `packages/product-ui`
- independent exact-head UI/state review at `1e8f3984d3bbbb4c4f527433680ec0c2b854c378` — no findings; five-lane wide/narrow reachability, accessible counts, command-palette ordering, tray inclusion, and mobile contract alignment verified
