### PR TITLE
fix(desktop): label the default reviewer with its display name

### DIFF
--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -1,4 +1,5 @@
 import type { components } from "../../api/schema";
+import { agentLabel } from "../lib/agent-options";
 import { buildRankedAgentOptions } from "../lib/agent-select-options";
 import { KNOWN_REVIEWER_HARNESS_IDS } from "../lib/reviewer-harnesses";
 import { AgentAvatar } from "./AgentAvatar";
@@ -58,9 +59,12 @@ export function ReviewerSelect({
 	supported?: components["schemas"]["AgentInfo"][];
 	excludedHarness?: string;
 }) {
+	// Until the daemon's catalog arrives these entries carry the whole menu, so
+	// label them the way the catalog would rather than printing bare ids: without
+	// this the same row reads "claude-code" now and "Claude Code" a moment later.
 	const fallbackAgents: components["schemas"]["AgentInfo"][] = [...KNOWN_REVIEWER_HARNESS_IDS].map((id) => ({
 		id,
-		label: id,
+		label: agentLabel(id),
 	}));
 	const filteredSupported = (supported ?? fallbackAgents).filter((a) => KNOWN_REVIEWER_HARNESS_IDS.has(a.id));
 	const supportedAgents = filteredSupported.length > 0 ? filteredSupported : fallbackAgents;

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1084,8 +1084,50 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={sessionWithProvider([pr(3, "open")], "codex")} />);
 		await openReviewsSection();
 
-		expect(await screen.findByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("codex");
+		expect(await screen.findByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("Codex");
 		expect(screen.queryByText("reviewer")).not.toBeInTheDocument();
+	});
+
+	// The label is a display name, not the wire id: the trigger used to print the
+	// raw harness id, which read as a second, selectable "claude-code" entry
+	// alongside the catalog's properly-cased "Claude Code".
+	it("labels the default reviewer with its display name, not the raw id", async () => {
+		getMock.mockImplementation(async (path: string) => {
+			if (path === "/api/v1/agents") {
+				const agents = ["claude-code", "codex", "opencode"].map((id) => ({ id, label: id }));
+				return { data: { supported: agents, installed: agents, authorized: agents } };
+			}
+			if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
+				return { data: { sessionId: "sess-1", files: [], truncated: false }, error: undefined };
+			}
+			if (path === "/api/v1/sessions/{sessionId}/reviews") {
+				return { data: { reviewerHandleId: "", reviews: [] } };
+			}
+			if (path === "/api/v1/projects/{id}") {
+				return {
+					data: {
+						status: "ok",
+						project: {
+							id: "ws-1",
+							kind: "git",
+							name: "my-app",
+							path: "/repo",
+							repo: "my-app",
+							defaultBranch: "main",
+							config: {},
+						},
+					},
+				};
+			}
+			return { data: undefined };
+		});
+
+		renderWithQuery(<SessionInspector session={sessionWithProvider([pr(3, "open")], "claude-code")} />);
+		await openReviewsSection();
+
+		const trigger = await screen.findByRole("button", { name: /Select reviewer agent/ });
+		expect(trigger).toHaveTextContent("Claude Code");
+		expect(trigger).not.toHaveTextContent("claude-code");
 	});
 
 	it("configures session auto-review and disables manual controls", async () => {
@@ -1228,7 +1270,7 @@ describe("SessionInspector summary reviews", () => {
 
 		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
 		await openReviewsSection();
-		await screen.findByText("Review in progress · codex");
+		await screen.findByText("Review in progress · Codex");
 
 		expect(screen.queryByText("Reviewable change 3")).not.toBeInTheDocument();
 		expect(screen.queryByText("Review summary")).not.toBeInTheDocument();
@@ -1244,7 +1286,7 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={session([pr(3, "open"), pr(4, "open"), pr(5, "draft")])} />);
 		await openReviewsSection();
 
-		expect(screen.getByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("codex");
+		expect(screen.getByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("Codex");
 		expect(screen.queryByText("Reviewable change 3")).not.toBeInTheDocument();
 		expect(await screen.findByText("Reviewable change 4")).toBeInTheDocument();
 		expect(
@@ -1388,7 +1430,7 @@ describe("SessionInspector summary reviews", () => {
 			// A run in flight gets its own live strip naming the harness, not just a
 			// word on the button.
 			if (status === "running") {
-				expect(screen.getByText("Review in progress · codex")).toBeInTheDocument();
+				expect(screen.getByText("Review in progress · Codex")).toBeInTheDocument();
 			} else {
 				expect(screen.queryByText(/is reviewing this change/)).not.toBeInTheDocument();
 			}
@@ -1636,7 +1678,7 @@ describe("SessionInspector summary reviews", () => {
 
 		const picker = await screen.findByRole("button", { name: /Select reviewer agent/ });
 		await userEvent.click(picker);
-		expect(screen.getAllByRole("menuitem", { name: /codex/ })).toHaveLength(1);
+		expect(screen.getAllByRole("menuitem", { name: /codex/i })).toHaveLength(1);
 		expect(screen.getByRole("menuitem", { name: /opencode/ })).toBeInTheDocument();
 		await userEvent.click(screen.getByRole("menuitem", { name: /opencode/ }));
 
@@ -1648,8 +1690,8 @@ describe("SessionInspector summary reviews", () => {
 		);
 
 		await userEvent.click(picker);
-		expect(screen.getAllByRole("menuitem", { name: /codex/ })).toHaveLength(1);
-		await userEvent.click(screen.getByRole("menuitem", { name: /codex/ }));
+		expect(screen.getAllByRole("menuitem", { name: /codex/i })).toHaveLength(1);
+		await userEvent.click(screen.getByRole("menuitem", { name: /codex/i }));
 
 		await waitFor(() =>
 			expect(postMock).toHaveBeenLastCalledWith("/api/v1/sessions/{sessionId}/reviews/switch", {
@@ -1681,8 +1723,8 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={session([pr(3, "open"), pr(4, "open")])} />);
 		await openReviewsSection();
 
-		expect(await screen.findByText("Review in progress · codex")).toBeInTheDocument();
-		expect(screen.queryByText("Review in progress · claude-code")).not.toBeInTheDocument();
+		expect(await screen.findByText("Review in progress · Codex")).toBeInTheDocument();
+		expect(screen.queryByText("Review in progress · Claude Code")).not.toBeInTheDocument();
 	});
 
 	it("keeps older harness summaries behind explicit pagination when selecting the next agent", async () => {
@@ -1750,7 +1792,7 @@ describe("SessionInspector summary reviews", () => {
 
 		// AO runs one reviewer per worker, so a second harness cannot start
 		// alongside it. Say so rather than silently ignoring the choice.
-		expect(screen.getByText("Review in progress · codex")).toBeInTheDocument();
+		expect(screen.getByText("Review in progress · Codex")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: /Select reviewer agent/ })).toBeDisabled();
 	});
 
@@ -1852,7 +1894,7 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
 		await openReviewsSection();
 
-		expect(await screen.findByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("codex");
+		expect(await screen.findByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("Codex");
 		expect(screen.queryByText("reviewer")).not.toBeInTheDocument();
 		expect(screen.queryByText("sess-1")).not.toBeInTheDocument();
 		expect(screen.queryByText("review session")).not.toBeInTheDocument();

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -56,6 +56,7 @@ import { Button } from "./ui/button";
 import { cn } from "../lib/utils";
 import { SessionTerminationPopover } from "./SessionTerminationPopover";
 import { ReviewerSelect } from "./ReviewerSelect";
+import { agentLabel } from "../lib/agent-options";
 import { agentsQueryOptions } from "../hooks/useAgentsQuery";
 import { Switch } from "./ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
@@ -1416,7 +1417,7 @@ function ReviewPanel({
 							authorized={agentCatalog?.authorized}
 							contentAlign="end"
 							defaultHarness={resolvedDefaultHarness}
-							defaultOptionLabel={resolvedDefaultHarness}
+							defaultOptionLabel={agentLabel(resolvedDefaultHarness)}
 							disabled={reviewRunning || autoReviewEnabled || isKilling || isSwitchingReviewer || isTriggering || isCancelling}
 							installed={agentCatalog?.installed}
 							onChange={(next) => onReviewerOverrideChange(next as ReviewerHarness | "")}
@@ -1474,7 +1475,9 @@ function ReviewPanel({
 					<div className="mt-3 flex items-center gap-2 border-t border-border pt-3">
 						<Loader2 aria-hidden="true" className="size-icon-sm shrink-0 animate-spin text-muted-foreground" />
 						<span className="min-w-0 flex-1 truncate text-2xs font-medium text-muted-foreground">
-							{isCancelling ? t("inspector.review.cancelling") : `Review in progress · ${activeReviewerHarness}`}
+							{isCancelling
+								? t("inspector.review.cancelling")
+								: `Review in progress · ${agentLabel(activeReviewerHarness)}`}
 						</span>
 					</div>
 				) : null}


### PR DESCRIPTION
## Problem

#3959 landed dynamic default-reviewer resolution (`resolveDefaultReviewerHarness`), but the label-facing strings still print the raw harness id instead of the catalog's display name:

- The `__default__` menu entry (`defaultOptionLabel={resolvedDefaultHarness}`) shows `codex` instead of `Codex`.
- The "Review in progress · ${activeReviewerHarness}" strip shows the same raw id.

Now that the default is resolved dynamically rather than hardcoded to `claude-code`, this is more visible: the same agent can read as two different names within the same menu (raw id for the default entry, display name for every other catalog entry).

## Change

Builds on #3959 — reuses its harness-resolution logic unchanged and only wraps the label-facing strings in `agentLabel()`:

- `ReviewerSelect.tsx`: fallback agent entries now label with `agentLabel(id)` instead of the bare id.
- `SessionInspector.tsx`: `defaultOptionLabel` and the "Review in progress" strip now go through `agentLabel()`.

## Testing

- `npx vitest run src/renderer/components/SessionInspector.test.tsx` — 84 passed.
- `npx tsc --noEmit` — clean (pre-existing unrelated `motion/react` module error in `packages/product-ui` aside).
