### PR TITLE
fix(frontend): skip slide-in spring for sidebar peek overlay

### DIFF
--- a/frontend/src/renderer/components/ui/sidebar.tsx
+++ b/frontend/src/renderer/components/ui/sidebar.tsx
@@ -208,8 +208,13 @@ function Sidebar({
 	const isOffcanvasCollapsed = state === "collapsed" && collapsible === "offcanvas";
 	const isIconCollapsed = state === "collapsed" && collapsible === "icon";
 	const containerX = isOffcanvasCollapsed ? (side === "left" ? "-100%" : "100%") : "0%";
+	// Peek overlays skip the slide-in spring entirely: the hover-preview close
+	// timer in _shell.tsx reads getBoundingClientRect() on every pointermove,
+	// and a mid-animation rect made the preview vanish before the cursor could
+	// reach it (#3372). Overlays are temporary, so appearing instantly reads as
+	// intentional rather than janky.
 	const activeTransition: typeof SHELL_PANEL_SPRING | { duration: number } =
-		!isReady || prefersReducedMotion ? { duration: 0 } : SHELL_PANEL_SPRING;
+		!isReady || prefersReducedMotion || overlay ? { duration: 0 } : SHELL_PANEL_SPRING;
 
 	// Target width for the gap placeholder. Animating the actual width lets the
 	// flex sibling <main> follow in real time instead of snapping separately.


### PR DESCRIPTION
## Summary
- Fixes #3372: the sidebar hover-preview vanished before the cursor could reach it.
- Root cause: while the peek overlay slides in via a Motion spring transition, the global `pointermove` handler in `_shell.tsx` reads `getBoundingClientRect()` on the sidebar container to decide whether to keep it open. During the animation that rect reflects the mid-transition position, not the resting one, so the 140ms auto-close timer can fire before the slide-in settles.
- Fix: when the sidebar renders as a peek overlay (`overlay` prop), skip the spring transition so it appears at its resting position instantly — matching the "cleanest" option suggested in the issue. This removes the race entirely since `getBoundingClientRect()` is correct from t=0.

## Test plan
- [x] `npm run typecheck` — no new errors (pre-existing unrelated errors in `packages/product-ui`, unrelated to this change)
- [x] `npm test` (vitest) — `Sidebar.test.tsx` passes (54/54); remaining failures are pre-existing/unrelated (landing-page tests missing the `cheerio` dependency)
- [ ] Manual verification of hover-preview in the desktop app (not run in this environment)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>