### PR TITLE
fix(release): install product UI dependencies

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -63,7 +63,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: |
+            frontend/package-lock.json
+            packages/product-ui/package-lock.json
       # The daemon is compiled by build-daemon.mjs during premake, so the Go
       # toolchain must be present and pinned on every runner.
       - uses: actions/setup-go@v5
@@ -71,6 +73,9 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
       - run: npm ci
+      - name: Install product UI dependencies
+        run: npm ci
+        working-directory: packages/product-ui
       - name: Verify WorkOS build configuration
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- install packages/product-ui dependencies in the unsigned desktop artifact workflow
- include its lockfile in setup-node cache invalidation
- restore bare-import resolution for clsx and tailwind-merge during production packaging

## Verification
- clean npm ci in frontend
- clean npm ci in packages/product-ui
- npm run build in packages/product-ui
- local macOS npm run make passed the production Vite bundle phase that failed in Actions
- workflow YAML parse and git diff --check

## Risk
Low. This changes only dependency installation for the unsigned build-artifacts workflow; signing, notarization, publishing, and application code are unchanged.