### PR TITLE
fix(scm): reconcile stale transferred PR rows to prevent false merge conflict

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -312,6 +312,7 @@ func (p *Provider) FetchReviewThreads(ctx context.Context, ref ports.SCMPRRef) (
 type restListPull struct {
 	URL     string `json:"url"`
 	HTMLURL string `json:"html_url"`
+	NodeID  string `json:"node_id"`
 	Number  int    `json:"number"`
 	State   string `json:"state"`
 	Draft   bool   `json:"draft"`
@@ -337,6 +338,7 @@ type restListPull struct {
 func restListPullToSCM(pull restListPull) ports.SCMPRObservation {
 	closed := strings.EqualFold(pull.State, "closed")
 	return ports.SCMPRObservation{
+		ProviderID:        pull.NodeID,
 		URL:               firstNonEmpty(pull.HTMLURL, pull.URL),
 		Number:            pull.Number,
 		State:             normalizePRState(pull.Draft, false, closed),
@@ -372,7 +374,7 @@ func buildSCMBatchQuery(refs []ports.SCMPRRef) (string, []string) {
 
 func scmPRFields() string {
 	return strings.ReplaceAll(`
-number url state isDraft merged closed title additions deletions changedFiles
+number id url state isDraft merged closed title additions deletions changedFiles
 mergeable mergeStateStatus reviewDecision headRefName headRefOid baseRefName baseRefOid
 createdAt updatedAt mergedAt closedAt
 author{ login }
@@ -470,13 +472,23 @@ func scmObservationFromGraphQL(ref ports.SCMPRRef, pr map[string]any) ports.SCMO
 	merged := boolv(pr["merged"])
 	closed := boolv(pr["closed"]) && !merged
 	draft := boolv(pr["isDraft"])
+	canonicalRepo := repoFullName(ref.Repo)
+	if owner, repoName, _, err := parsePRURL(prURL); err == nil {
+		canonicalRepo = owner + "/" + repoName
+	}
+	urlAlias := strings.TrimSpace(ref.URL)
+	if urlAlias == strings.TrimSpace(prURL) {
+		urlAlias = ""
+	}
 	obs := ports.SCMObservation{
 		Fetched:  true,
 		Provider: ref.Repo.Provider,
 		Host:     ref.Repo.Host,
-		Repo:     repoFullName(ref.Repo),
+		Repo:     canonicalRepo,
 		PR: ports.SCMPRObservation{
+			ProviderID:               str(pr["id"]),
 			URL:                      prURL,
+			URLAlias:                 urlAlias,
 			Number:                   int(num(pr["number"])),
 			State:                    normalizePRState(draft, merged, closed),
 			Draft:                    draft,

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1260,6 +1260,42 @@ func TestSCMObservationUsesRollupStateWhenContextsPaginated(t *testing.T) {
 	}
 }
 
+func TestSCMBatchQueryRequestsStablePullRequestID(t *testing.T) {
+	query, _ := buildSCMBatchQuery([]ports.SCMPRRef{{
+		Repo:   ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "octocat", Name: "hello"},
+		Number: 42,
+	}})
+	if !strings.Contains(query, "number id url") {
+		t.Fatalf("batch query does not request the stable pull request id:\n%s", query)
+	}
+}
+
+func TestSCMObservationCarriesStableIDAndRequestedURLAlias(t *testing.T) {
+	fx := basePRFixture()
+	var pr map[string]any
+	fx.prData(func(m map[string]any) {
+		pr = m
+		m["id"] = "PR_kwDOStable"
+		m["url"] = "https://github.com/new-owner/hello/pull/42"
+	})
+	ref := ports.SCMPRRef{
+		Repo:   ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "old-owner", Name: "hello", Repo: "old-owner/hello"},
+		Number: 42,
+		URL:    "https://github.com/old-owner/hello/pull/42",
+	}
+
+	obs := scmObservationFromGraphQL(ref, pr)
+	if obs.PR.ProviderID != "PR_kwDOStable" {
+		t.Fatalf("ProviderID = %q, want PR_kwDOStable", obs.PR.ProviderID)
+	}
+	if obs.PR.URLAlias != ref.URL {
+		t.Fatalf("URLAlias = %q, want %s", obs.PR.URLAlias, ref.URL)
+	}
+	if obs.Repo != "new-owner/hello" {
+		t.Fatalf("Repo = %q, want canonical new-owner/hello", obs.Repo)
+	}
+}
+
 func TestSCMMergeabilityBlocksReviewRequiredAndDraft(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/backend/internal/adapters/scm/gitlab/observer_provider.go
+++ b/backend/internal/adapters/scm/gitlab/observer_provider.go
@@ -221,6 +221,7 @@ func (p *Provider) ListPRsByRepo(ctx context.Context, repo ports.SCMRepo, update
 }
 
 type restMR struct {
+	ID                  int64  `json:"id"`
 	IID                 int    `json:"iid"`
 	Title               string `json:"title"`
 	State               string `json:"state"`
@@ -272,6 +273,7 @@ func mrToSCMPRObservation(repo ports.SCMRepo, mr *restMR) ports.SCMPRObservation
 	merged := mr.State == "merged"
 	closed := mr.State == "closed" || mr.State == "locked"
 	return ports.SCMPRObservation{
+		ProviderID:               providerID(mr.ID),
 		URL:                      mr.WebURL,
 		HTMLURL:                  mr.WebURL,
 		Number:                   mr.IID,
@@ -293,6 +295,13 @@ func mrToSCMPRObservation(repo ports.SCMRepo, mr *restMR) ports.SCMPRObservation
 		MergedAtProvider:         safeTime(mr.MergedAt),
 		ClosedAtProvider:         safeTime(mr.ClosedAt),
 	}
+}
+
+func providerID(id int64) string {
+	if id <= 0 {
+		return ""
+	}
+	return strconv.FormatInt(id, 10)
 }
 
 func normalizeMRState(state string, draft bool) domain.PRState {
@@ -462,6 +471,13 @@ func (p *Provider) fetchSingleMR(ctx context.Context, ref ports.SCMPRRef) (ports
 	}
 
 	prObs := mrToSCMPRObservation(repo, &mr)
+	canonicalRepo := canonicalRepoFromMRURL(repo.Host, prObs.URL, repo.Repo)
+	if mr.SourceProjectID == 0 || mr.SourceProjectID == mr.TargetProjectID {
+		prObs.HeadRepo = canonicalRepo
+	}
+	if requestedURL := strings.TrimSpace(ref.URL); requestedURL != "" && requestedURL != strings.TrimSpace(prObs.URL) {
+		prObs.URLAlias = requestedURL
+	}
 	prObs.BaseSHA = mr.DiffRefs.BaseSHA
 	prObs.MergeCommitSHA = mr.MergeCommitSHA
 
@@ -522,12 +538,26 @@ func (p *Provider) fetchSingleMR(ctx context.Context, ref ports.SCMPRRef) (ports
 		ObservedAt:   now,
 		Provider:     "gitlab",
 		Host:         repo.Host,
-		Repo:         repo.Repo,
+		Repo:         canonicalRepo,
 		PR:           prObs,
 		CI:           ciObs,
 		Review:       ports.SCMReviewObservation{Decision: string(reviewDecision)},
 		Mergeability: mergeObs,
 	}, nil
+}
+
+func canonicalRepoFromMRURL(host, rawURL, fallback string) string {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || !strings.EqualFold(u.Host, strings.TrimSpace(host)) {
+		return fallback
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for i := 1; i+1 < len(parts); i++ {
+		if parts[i] == "-" && parts[i+1] == "merge_requests" {
+			return strings.Join(parts[:i], "/")
+		}
+	}
+	return fallback
 }
 
 // fetchSourceProjectCached resolves a fork MR source project's

--- a/backend/internal/adapters/scm/gitlab/provider_test.go
+++ b/backend/internal/adapters/scm/gitlab/provider_test.go
@@ -257,7 +257,7 @@ func TestListPRsByRepo(t *testing.T) {
 
 func TestFetchPullRequests(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v4/projects/myorg%2Fmyrepo/merge_requests/1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/oldorg%2Fmyrepo/merge_requests/1", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"iid":           1,
 			"title":         "Fix bug",
@@ -272,18 +272,18 @@ func TestFetchPullRequests(t *testing.T) {
 			"diff_refs":     map[string]any{"base_sha": "base123"},
 		})
 	})
-	mux.HandleFunc("/api/v4/projects/myorg%2Fmyrepo/pipelines", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/oldorg%2Fmyrepo/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]map[string]any{
 			{"id": 100, "status": "success", "sha": "abc123"},
 		})
 	})
-	mux.HandleFunc("/api/v4/projects/myorg%2Fmyrepo/pipelines/100/jobs", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/oldorg%2Fmyrepo/pipelines/100/jobs", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]map[string]any{
 			{"id": 200, "name": "build", "status": "success", "web_url": "https://gitlab.com/jobs/200"},
 			{"id": 201, "name": "test", "status": "success", "web_url": "https://gitlab.com/jobs/201"},
 		})
 	})
-	mux.HandleFunc("/api/v4/projects/myorg%2Fmyrepo/merge_requests/1/approvals", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/oldorg%2Fmyrepo/merge_requests/1/approvals", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"approved":           true,
 			"approvals_required": 1,
@@ -293,8 +293,8 @@ func TestFetchPullRequests(t *testing.T) {
 		})
 	})
 	_, p := testServer(t, mux)
-	repo := ports.SCMRepo{Provider: "gitlab", Host: "gitlab.com", Owner: "myorg", Name: "myrepo", Repo: "myorg/myrepo"}
-	ref := ports.SCMPRRef{Repo: repo, Number: 1, URL: "https://gitlab.com/myorg/myrepo/-/merge_requests/1"}
+	repo := ports.SCMRepo{Provider: "gitlab", Host: "gitlab.com", Owner: "oldorg", Name: "myrepo", Repo: "oldorg/myrepo"}
+	ref := ports.SCMPRRef{Repo: repo, Number: 1, URL: "https://gitlab.com/oldorg/myrepo/-/merge_requests/1"}
 
 	obs, err := p.FetchPullRequests(context.Background(), []ports.SCMPRRef{ref})
 	if err != nil {
@@ -309,6 +309,9 @@ func TestFetchPullRequests(t *testing.T) {
 	}
 	if o.Provider != "gitlab" {
 		t.Errorf("Provider = %q, want %q", o.Provider, "gitlab")
+	}
+	if o.Repo != "myorg/myrepo" {
+		t.Errorf("Repo = %q, want canonical myorg/myrepo", o.Repo)
 	}
 	if o.CI.Summary != "passing" {
 		t.Errorf("CI.Summary = %q, want %q", o.CI.Summary, "passing")
@@ -326,6 +329,20 @@ func TestFetchPullRequests(t *testing.T) {
 	// it must be parsed via the nested struct (not the broken dotted tag).
 	if got, want := o.PR.BaseSHA, "base123"; got != want {
 		t.Errorf("PR.BaseSHA = %q, want %q", got, want)
+	}
+	if o.PR.URLAlias != ref.URL {
+		t.Fatalf("PR.URLAlias = %q, want %q", o.PR.URLAlias, ref.URL)
+	}
+}
+
+func TestMergeRequestObservationCarriesStableGlobalID(t *testing.T) {
+	var mr restMR
+	if err := json.Unmarshal([]byte(`{"id":9001,"iid":42,"web_url":"https://gitlab.com/group/repo/-/merge_requests/42","state":"opened"}`), &mr); err != nil {
+		t.Fatal(err)
+	}
+	obs := mrToSCMPRObservation(ports.SCMRepo{Provider: "gitlab", Host: "gitlab.com", Repo: "group/repo"}, &mr)
+	if obs.ProviderID != "9001" {
+		t.Fatalf("ProviderID = %q, want 9001", obs.ProviderID)
 	}
 }
 

--- a/backend/internal/domain/pr.go
+++ b/backend/internal/domain/pr.go
@@ -30,7 +30,10 @@ type PRFacts struct {
 // persisted by the PR store. It is intentionally separate from the sqlc
 // generated sqlite row type so storage details do not leak outside sqlite.
 type PullRequest struct {
-	URL          string
+	URL string
+	// URLAlias is a transient provider-resolved URL that should point at URL.
+	// It is persisted in the alias table, not in the pr row itself.
+	URLAlias     string
 	SessionID    SessionID
 	Number       int
 	Draft        bool
@@ -48,6 +51,9 @@ type PullRequest struct {
 	Provider string
 	Host     string
 	Repo     string
+	// ProviderID is immutable within a provider and host and survives repository
+	// renames or transfers.
+	ProviderID string
 
 	SourceBranch   string
 	TargetBranch   string

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -1068,6 +1068,7 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 				Provider:     repo.Provider,
 				Host:         repo.Host,
 				Repo:         repoFullName(repo),
+				ProviderID:   pr.ProviderID,
 				UpdatedAt:    now,
 			}
 			// Persist the discovered PR as an open baseline row immediately, before
@@ -1758,6 +1759,7 @@ func domainFromObservation(sessionID domain.SessionID, sessionRecord domain.Sess
 	}
 	pr := domain.PullRequest{
 		URL:                      firstNonEmpty(obs.PR.URL, obs.PR.HTMLURL),
+		URLAlias:                 obs.PR.URLAlias,
 		SessionID:                sessionID,
 		Number:                   obs.PR.Number,
 		Draft:                    obs.PR.Draft,
@@ -1770,6 +1772,7 @@ func domainFromObservation(sessionID domain.SessionID, sessionRecord domain.Sess
 		Provider:                 obs.Provider,
 		Host:                     obs.Host,
 		Repo:                     obs.Repo,
+		ProviderID:               obs.PR.ProviderID,
 		SourceBranch:             obs.PR.SourceBranch,
 		TargetBranch:             obs.PR.TargetBranch,
 		HeadSHA:                  obs.PR.HeadSHA,

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -332,6 +332,31 @@ func testObs(num int) ports.SCMObservation {
 	}
 }
 
+func TestDomainFromObservationPreservesStableIdentityAndAliases(t *testing.T) {
+	oldURL := "https://github.com/old-owner/repo/pull/7"
+	currentURL := "https://github.com/new-owner/repo/pull/7"
+	obs := ports.SCMObservation{
+		Fetched:  true,
+		Provider: "github",
+		Host:     "github.com",
+		Repo:     "new-owner/repo",
+		PR: ports.SCMPRObservation{
+			ProviderID: "PR_stable_7",
+			URL:        currentURL,
+			URLAlias:   oldURL,
+			Number:     7,
+		},
+	}
+
+	pr, _, _, _, _ := domainFromObservation("repo-1", domain.SessionRecord{}, obs, domain.PullRequest{}, persistenceOptions{}, time.Unix(1, 0).UTC())
+	if pr.ProviderID != "PR_stable_7" {
+		t.Fatalf("ProviderID = %q, want PR_stable_7", pr.ProviderID)
+	}
+	if pr.URLAlias != oldURL {
+		t.Fatalf("URLAlias = %q, want %s", pr.URLAlias, oldURL)
+	}
+}
+
 func knownPR(num int) domain.PullRequest {
 	obs := testObs(num)
 	pr, _, _, _, _ := domainFromObservation("p-1", domain.SessionRecord{AutoInjectReview: true}, obs, domain.PullRequest{}, persistenceOptions{}, time.Unix(1, 0).UTC())
@@ -599,7 +624,7 @@ func TestPoll_RepoETag200DiscoversPRAndRefreshesSamePoll(t *testing.T) {
 	store := testStoreWithSession()
 	provider := &fakeProvider{
 		repoGuards:   map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
-		openPRs:      map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {{URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "feat", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha1"}}},
+		openPRs:      map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {{ProviderID: "PR_stable_1", URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "feat", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha1"}}},
 		observations: map[string]ports.SCMObservation{prKey(testRepo, 1): testObs(1)},
 	}
 	lc := &fakeLifecycle{}
@@ -615,6 +640,9 @@ func TestPoll_RepoETag200DiscoversPRAndRefreshesSamePoll(t *testing.T) {
 	}
 	if len(store.writes) < 1 || len(lc.observed) != 1 {
 		t.Fatalf("write/lifecycle missing: writes=%d lifecycle=%d", len(store.writes), len(lc.observed))
+	}
+	if store.writes[0].pr.ProviderID != "PR_stable_1" {
+		t.Fatalf("discovery ProviderID = %q, want PR_stable_1", store.writes[0].pr.ProviderID)
 	}
 }
 

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -123,8 +123,13 @@ type ScopedIdentityResolver interface {
 
 // SCMPRObservation carries provider-neutral PR metadata.
 type SCMPRObservation struct {
+	// ProviderID is the provider-owned immutable identifier for this PR/MR.
+	// Consumers scope it by the observation's provider and host.
+	ProviderID string
 	// URL is the canonical PR URL used as the persistence key.
 	URL string
+	// URLAlias is the previously requested URL when it resolved to URL.
+	URLAlias string
 	// Number is the provider's PR number in the repository.
 	Number int
 	// State is AO's normalized PR state: draft, open, merged, or closed.

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -260,6 +260,7 @@ type PR struct {
 	LastNudgeSignature       string
 	StateChangedAt           sql.NullTime
 	AutoInjectCI             bool
+	ProviderID               string
 }
 
 type PRCheck struct {
@@ -311,6 +312,11 @@ type PRReviewThread struct {
 	IsBot        int64
 	SemanticHash string
 	UpdatedAt    time.Time
+}
+
+type PRURLAlias struct {
+	AliasURL     string
+	CanonicalURL string
 }
 
 type Project struct {

--- a/backend/internal/storage/sqlite/gen/pr.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr.sql.go
@@ -57,6 +57,80 @@ func (q *Queries) ClaimPRForSession(ctx context.Context, arg ClaimPRForSessionPa
 	return err
 }
 
+const clearPRProviderIdentity = `-- name: ClearPRProviderIdentity :exec
+UPDATE pr SET provider_id = '' WHERE url = ?
+`
+
+func (q *Queries) ClearPRProviderIdentity(ctx context.Context, url string) error {
+	_, err := q.db.ExecContext(ctx, clearPRProviderIdentity, url)
+	return err
+}
+
+const deletePRAlias = `-- name: DeletePRAlias :exec
+DELETE FROM pr_url_alias WHERE alias_url = ?
+`
+
+func (q *Queries) DeletePRAlias(ctx context.Context, aliasUrl string) error {
+	_, err := q.db.ExecContext(ctx, deletePRAlias, aliasUrl)
+	return err
+}
+
+const deletePRAliasChecks = `-- name: DeletePRAliasChecks :exec
+DELETE FROM pr_checks WHERE pr_url = ?
+`
+
+func (q *Queries) DeletePRAliasChecks(ctx context.Context, prUrl string) error {
+	_, err := q.db.ExecContext(ctx, deletePRAliasChecks, prUrl)
+	return err
+}
+
+const deletePRAliasComments = `-- name: DeletePRAliasComments :exec
+DELETE FROM pr_comment WHERE pr_url = ?
+`
+
+func (q *Queries) DeletePRAliasComments(ctx context.Context, prUrl string) error {
+	_, err := q.db.ExecContext(ctx, deletePRAliasComments, prUrl)
+	return err
+}
+
+const deletePRAliasReviewRuns = `-- name: DeletePRAliasReviewRuns :exec
+DELETE FROM review_run WHERE pr_url = ?
+`
+
+// Rows left on the previous URL collided with the canonical review-run
+// idempotency key and therefore represent the same logical review pass.
+func (q *Queries) DeletePRAliasReviewRuns(ctx context.Context, prUrl string) error {
+	_, err := q.db.ExecContext(ctx, deletePRAliasReviewRuns, prUrl)
+	return err
+}
+
+const deletePRAliasReviewThreads = `-- name: DeletePRAliasReviewThreads :exec
+DELETE FROM pr_review_threads WHERE pr_url = ?
+`
+
+func (q *Queries) DeletePRAliasReviewThreads(ctx context.Context, prUrl string) error {
+	_, err := q.db.ExecContext(ctx, deletePRAliasReviewThreads, prUrl)
+	return err
+}
+
+const deletePRAliasReviews = `-- name: DeletePRAliasReviews :exec
+DELETE FROM pr_reviews WHERE pr_url = ?
+`
+
+func (q *Queries) DeletePRAliasReviews(ctx context.Context, prUrl string) error {
+	_, err := q.db.ExecContext(ctx, deletePRAliasReviews, prUrl)
+	return err
+}
+
+const deletePRByURL = `-- name: DeletePRByURL :exec
+DELETE FROM pr WHERE url = ?
+`
+
+func (q *Queries) DeletePRByURL(ctx context.Context, url string) error {
+	_, err := q.db.ExecContext(ctx, deletePRByURL, url)
+	return err
+}
+
 const getDisplayPRFactsBySession = `-- name: GetDisplayPRFactsBySession :one
 SELECT
     pr.url,
@@ -112,7 +186,7 @@ func (q *Queries) GetDisplayPRFactsBySession(ctx context.Context, sessionID doma
 }
 
 const getPR = `-- name: GetPR :one
-SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, auto_inject_ci FROM pr WHERE url = ?
+SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, auto_inject_ci, provider_id FROM pr WHERE url = ?
 `
 
 func (q *Queries) GetPR(ctx context.Context, url string) (PR, error) {
@@ -160,6 +234,131 @@ func (q *Queries) GetPR(ctx context.Context, url string) (PR, error) {
 		&i.LastNudgeSignature,
 		&i.StateChangedAt,
 		&i.AutoInjectCI,
+		&i.ProviderID,
+	)
+	return i, err
+}
+
+const getPRByProviderIdentity = `-- name: GetPRByProviderIdentity :one
+SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, auto_inject_ci, provider_id
+FROM pr
+WHERE provider = ?1
+  AND host = ?2
+  AND provider_id = ?3
+  AND provider_id != ''
+`
+
+type GetPRByProviderIdentityParams struct {
+	Provider   string
+	Host       string
+	ProviderID string
+}
+
+func (q *Queries) GetPRByProviderIdentity(ctx context.Context, arg GetPRByProviderIdentityParams) (PR, error) {
+	row := q.db.QueryRowContext(ctx, getPRByProviderIdentity, arg.Provider, arg.Host, arg.ProviderID)
+	var i PR
+	err := row.Scan(
+		&i.URL,
+		&i.SessionID,
+		&i.Number,
+		&i.PRState,
+		&i.ReviewDecision,
+		&i.CIState,
+		&i.Mergeability,
+		&i.UpdatedAt,
+		&i.Provider,
+		&i.Host,
+		&i.Repo,
+		&i.SourceBranch,
+		&i.TargetBranch,
+		&i.HeadSha,
+		&i.Title,
+		&i.Additions,
+		&i.Deletions,
+		&i.ChangedFiles,
+		&i.Author,
+		&i.BaseSha,
+		&i.MergeCommitSha,
+		&i.IsDraft,
+		&i.IsMerged,
+		&i.IsClosed,
+		&i.ProviderState,
+		&i.ProviderMergeable,
+		&i.ProviderMergeStateStatus,
+		&i.HtmlURL,
+		&i.CreatedAtProvider,
+		&i.UpdatedAtProvider,
+		&i.MergedAtProvider,
+		&i.ClosedAtProvider,
+		&i.MetadataHash,
+		&i.CIHash,
+		&i.ReviewHash,
+		&i.ObservedAt,
+		&i.CIObservedAt,
+		&i.ReviewObservedAt,
+		&i.LastNudgeSignature,
+		&i.StateChangedAt,
+		&i.AutoInjectCI,
+		&i.ProviderID,
+	)
+	return i, err
+}
+
+const getPRByURLOrAlias = `-- name: GetPRByURLOrAlias :one
+SELECT pr.url, pr.session_id, pr.number, pr.pr_state, pr.review_decision, pr.ci_state, pr.mergeability, pr.updated_at, pr.provider, pr.host, pr.repo, pr.source_branch, pr.target_branch, pr.head_sha, pr.title, pr.additions, pr.deletions, pr.changed_files, pr.author, pr.base_sha, pr.merge_commit_sha, pr.is_draft, pr.is_merged, pr.is_closed, pr.provider_state, pr.provider_mergeable, pr.provider_merge_state_status, pr.html_url, pr.created_at_provider, pr.updated_at_provider, pr.merged_at_provider, pr.closed_at_provider, pr.metadata_hash, pr.ci_hash, pr.review_hash, pr.observed_at, pr.ci_observed_at, pr.review_observed_at, pr.last_nudge_signature, pr.state_changed_at, pr.auto_inject_ci, pr.provider_id
+FROM pr
+WHERE pr.url = COALESCE(
+    (SELECT canonical_url FROM pr_url_alias WHERE alias_url = ?1),
+    ?1
+)
+`
+
+func (q *Queries) GetPRByURLOrAlias(ctx context.Context, url string) (PR, error) {
+	row := q.db.QueryRowContext(ctx, getPRByURLOrAlias, url)
+	var i PR
+	err := row.Scan(
+		&i.URL,
+		&i.SessionID,
+		&i.Number,
+		&i.PRState,
+		&i.ReviewDecision,
+		&i.CIState,
+		&i.Mergeability,
+		&i.UpdatedAt,
+		&i.Provider,
+		&i.Host,
+		&i.Repo,
+		&i.SourceBranch,
+		&i.TargetBranch,
+		&i.HeadSha,
+		&i.Title,
+		&i.Additions,
+		&i.Deletions,
+		&i.ChangedFiles,
+		&i.Author,
+		&i.BaseSha,
+		&i.MergeCommitSha,
+		&i.IsDraft,
+		&i.IsMerged,
+		&i.IsClosed,
+		&i.ProviderState,
+		&i.ProviderMergeable,
+		&i.ProviderMergeStateStatus,
+		&i.HtmlURL,
+		&i.CreatedAtProvider,
+		&i.UpdatedAtProvider,
+		&i.MergedAtProvider,
+		&i.ClosedAtProvider,
+		&i.MetadataHash,
+		&i.CIHash,
+		&i.ReviewHash,
+		&i.ObservedAt,
+		&i.CIObservedAt,
+		&i.ReviewObservedAt,
+		&i.LastNudgeSignature,
+		&i.StateChangedAt,
+		&i.AutoInjectCI,
+		&i.ProviderID,
 	)
 	return i, err
 }
@@ -273,7 +472,7 @@ func (q *Queries) ListPRFactsBySession(ctx context.Context, sessionID domain.Ses
 }
 
 const listPRsBySession = `-- name: ListPRsBySession :many
-SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, auto_inject_ci FROM pr
+SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, auto_inject_ci, provider_id FROM pr
 WHERE session_id = ?
 ORDER BY updated_at DESC
 `
@@ -329,6 +528,7 @@ func (q *Queries) ListPRsBySession(ctx context.Context, sessionID domain.Session
 			&i.LastNudgeSignature,
 			&i.StateChangedAt,
 			&i.AutoInjectCI,
+			&i.ProviderID,
 		); err != nil {
 			return nil, err
 		}
@@ -341,6 +541,147 @@ func (q *Queries) ListPRsBySession(ctx context.Context, sessionID domain.Session
 		return nil, err
 	}
 	return items, nil
+}
+
+const movePRAliasChecks = `-- name: MovePRAliasChecks :exec
+UPDATE OR IGNORE pr_checks SET pr_url = ?1 WHERE pr_url = ?2
+`
+
+type MovePRAliasChecksParams struct {
+	CanonicalURL string
+	PreviousURL  string
+}
+
+func (q *Queries) MovePRAliasChecks(ctx context.Context, arg MovePRAliasChecksParams) error {
+	_, err := q.db.ExecContext(ctx, movePRAliasChecks, arg.CanonicalURL, arg.PreviousURL)
+	return err
+}
+
+const movePRAliasComments = `-- name: MovePRAliasComments :exec
+UPDATE OR IGNORE pr_comment SET pr_url = ?1 WHERE pr_url = ?2
+`
+
+type MovePRAliasCommentsParams struct {
+	CanonicalURL string
+	PreviousURL  string
+}
+
+func (q *Queries) MovePRAliasComments(ctx context.Context, arg MovePRAliasCommentsParams) error {
+	_, err := q.db.ExecContext(ctx, movePRAliasComments, arg.CanonicalURL, arg.PreviousURL)
+	return err
+}
+
+const movePRAliasNotifications = `-- name: MovePRAliasNotifications :exec
+UPDATE notifications SET pr_url = ?1 WHERE pr_url = ?2
+`
+
+type MovePRAliasNotificationsParams struct {
+	CanonicalURL string
+	PreviousURL  string
+}
+
+func (q *Queries) MovePRAliasNotifications(ctx context.Context, arg MovePRAliasNotificationsParams) error {
+	_, err := q.db.ExecContext(ctx, movePRAliasNotifications, arg.CanonicalURL, arg.PreviousURL)
+	return err
+}
+
+const movePRAliasReviewRuns = `-- name: MovePRAliasReviewRuns :exec
+UPDATE OR IGNORE review_run SET pr_url = ?1 WHERE pr_url = ?2
+`
+
+type MovePRAliasReviewRunsParams struct {
+	CanonicalURL string
+	PreviousURL  string
+}
+
+func (q *Queries) MovePRAliasReviewRuns(ctx context.Context, arg MovePRAliasReviewRunsParams) error {
+	_, err := q.db.ExecContext(ctx, movePRAliasReviewRuns, arg.CanonicalURL, arg.PreviousURL)
+	return err
+}
+
+const movePRAliasReviewState = `-- name: MovePRAliasReviewState :exec
+UPDATE review SET pr_url = ?1 WHERE pr_url = ?2
+`
+
+type MovePRAliasReviewStateParams struct {
+	CanonicalURL string
+	PreviousURL  string
+}
+
+func (q *Queries) MovePRAliasReviewState(ctx context.Context, arg MovePRAliasReviewStateParams) error {
+	_, err := q.db.ExecContext(ctx, movePRAliasReviewState, arg.CanonicalURL, arg.PreviousURL)
+	return err
+}
+
+const movePRAliasReviewThreads = `-- name: MovePRAliasReviewThreads :exec
+UPDATE OR IGNORE pr_review_threads SET pr_url = ?1 WHERE pr_url = ?2
+`
+
+type MovePRAliasReviewThreadsParams struct {
+	CanonicalURL string
+	PreviousURL  string
+}
+
+func (q *Queries) MovePRAliasReviewThreads(ctx context.Context, arg MovePRAliasReviewThreadsParams) error {
+	_, err := q.db.ExecContext(ctx, movePRAliasReviewThreads, arg.CanonicalURL, arg.PreviousURL)
+	return err
+}
+
+const movePRAliasReviews = `-- name: MovePRAliasReviews :exec
+UPDATE OR IGNORE pr_reviews SET pr_url = ?1 WHERE pr_url = ?2
+`
+
+type MovePRAliasReviewsParams struct {
+	CanonicalURL string
+	PreviousURL  string
+}
+
+func (q *Queries) MovePRAliasReviews(ctx context.Context, arg MovePRAliasReviewsParams) error {
+	_, err := q.db.ExecContext(ctx, movePRAliasReviews, arg.CanonicalURL, arg.PreviousURL)
+	return err
+}
+
+const repointPRAliases = `-- name: RepointPRAliases :exec
+UPDATE pr_url_alias
+SET canonical_url = ?1
+WHERE canonical_url = ?2
+`
+
+type RepointPRAliasesParams struct {
+	CanonicalURL string
+	PreviousURL  string
+}
+
+func (q *Queries) RepointPRAliases(ctx context.Context, arg RepointPRAliasesParams) error {
+	_, err := q.db.ExecContext(ctx, repointPRAliases, arg.CanonicalURL, arg.PreviousURL)
+	return err
+}
+
+const resolveConflictingPRAliasNotifications = `-- name: ResolveConflictingPRAliasNotifications :exec
+UPDATE notifications
+SET status = 'read', resolved_at = COALESCE(notifications.resolved_at, notifications.created_at)
+WHERE notifications.pr_url = ?1
+  AND (notifications.status = 'unread' OR notifications.resolved_at IS NULL)
+  AND EXISTS (
+      SELECT 1 FROM notifications AS current
+      WHERE current.pr_url = ?2
+        AND current.session_id = notifications.session_id
+        AND current.type = notifications.type
+        AND (current.status = 'unread' OR current.resolved_at IS NULL)
+  )
+`
+
+type ResolveConflictingPRAliasNotificationsParams struct {
+	PreviousURL  string
+	CanonicalURL string
+}
+
+// Preserve both notification records when their open-dedupe keys collide:
+// the canonical notification stays open and the older alias notification
+// becomes resolved history before its URL is updated.
+func (q *Queries) ResolveConflictingPRAliasNotifications(ctx context.Context, arg ResolveConflictingPRAliasNotificationsParams) error {
+	_, err := q.db.ExecContext(ctx, resolveConflictingPRAliasNotifications, arg.PreviousURL, arg.CanonicalURL)
+	return err
 }
 
 const updatePRLastNudgeSignature = `-- name: UpdatePRLastNudgeSignature :exec
@@ -419,14 +760,14 @@ func (q *Queries) UpsertLegacyPR(ctx context.Context, arg UpsertLegacyPRParams) 
 const upsertPR = `-- name: UpsertPR :exec
 INSERT INTO pr (
     url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at,
-    provider, host, repo, source_branch, target_branch, head_sha, title,
+    provider, host, repo, provider_id, source_branch, target_branch, head_sha, title,
     additions, deletions, changed_files, author, base_sha, merge_commit_sha,
     is_draft, is_merged, is_closed,
     provider_state, provider_mergeable, provider_merge_state_status, html_url,
     created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider,
     metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, auto_inject_ci
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
 ON CONFLICT (url) DO UPDATE SET
     number = excluded.number,
@@ -448,6 +789,7 @@ ON CONFLICT (url) DO UPDATE SET
     provider = excluded.provider,
     host = excluded.host,
     repo = excluded.repo,
+    provider_id = CASE WHEN excluded.provider_id != '' THEN excluded.provider_id ELSE pr.provider_id END,
     source_branch = excluded.source_branch,
     target_branch = excluded.target_branch,
     head_sha = excluded.head_sha,
@@ -490,6 +832,7 @@ type UpsertPRParams struct {
 	Provider                 string
 	Host                     string
 	Repo                     string
+	ProviderID               string
 	SourceBranch             string
 	TargetBranch             string
 	HeadSha                  string
@@ -534,6 +877,7 @@ func (q *Queries) UpsertPR(ctx context.Context, arg UpsertPRParams) error {
 		arg.Provider,
 		arg.Host,
 		arg.Repo,
+		arg.ProviderID,
 		arg.SourceBranch,
 		arg.TargetBranch,
 		arg.HeadSha,
@@ -563,5 +907,21 @@ func (q *Queries) UpsertPR(ctx context.Context, arg UpsertPRParams) error {
 		arg.ReviewObservedAt,
 		arg.ID,
 	)
+	return err
+}
+
+const upsertPRAlias = `-- name: UpsertPRAlias :exec
+INSERT INTO pr_url_alias(alias_url, canonical_url)
+VALUES (?1, ?2)
+ON CONFLICT(alias_url) DO UPDATE SET canonical_url = excluded.canonical_url
+`
+
+type UpsertPRAliasParams struct {
+	AliasURL     string
+	CanonicalURL string
+}
+
+func (q *Queries) UpsertPRAlias(ctx context.Context, arg UpsertPRAliasParams) error {
+	_, err := q.db.ExecContext(ctx, upsertPRAlias, arg.AliasURL, arg.CanonicalURL)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -100,6 +100,7 @@ var shippedMigrations = map[int64]string{
 	94: "0094_agent_switch_recovery.sql",
 	95: "0095_allow_omp_harness.sql",
 	96: "0096_session_worktree_base_ref.sql",
+	97: "0097_pr_provider_identity.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0097_pr_provider_identity.sql
+++ b/backend/internal/storage/sqlite/migrations/0097_pr_provider_identity.sql
@@ -1,0 +1,25 @@
+-- Persist provider-native PR identity separately from mutable repository URLs.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pr ADD COLUMN provider_id TEXT NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX idx_pr_provider_identity
+    ON pr(provider, host, provider_id)
+    WHERE provider_id != '';
+
+CREATE TABLE pr_url_alias (
+    alias_url     TEXT PRIMARY KEY,
+    canonical_url TEXT NOT NULL REFERENCES pr(url) ON DELETE CASCADE,
+    CHECK (alias_url != canonical_url)
+);
+CREATE INDEX idx_pr_url_alias_canonical ON pr_url_alias(canonical_url);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_pr_url_alias_canonical;
+DROP TABLE IF EXISTS pr_url_alias;
+DROP INDEX IF EXISTS idx_pr_provider_identity;
+ALTER TABLE pr DROP COLUMN provider_id;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pr.sql
+++ b/backend/internal/storage/sqlite/queries/pr.sql
@@ -1,14 +1,14 @@
 -- name: UpsertPR :exec
 INSERT INTO pr (
     url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at,
-    provider, host, repo, source_branch, target_branch, head_sha, title,
+    provider, host, repo, provider_id, source_branch, target_branch, head_sha, title,
     additions, deletions, changed_files, author, base_sha, merge_commit_sha,
     is_draft, is_merged, is_closed,
     provider_state, provider_mergeable, provider_merge_state_status, html_url,
     created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider,
     metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, auto_inject_ci
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
 ON CONFLICT (url) DO UPDATE SET
     number = excluded.number,
@@ -30,6 +30,7 @@ ON CONFLICT (url) DO UPDATE SET
     provider = excluded.provider,
     host = excluded.host,
     repo = excluded.repo,
+    provider_id = CASE WHEN excluded.provider_id != '' THEN excluded.provider_id ELSE pr.provider_id END,
     source_branch = excluded.source_branch,
     target_branch = excluded.target_branch,
     head_sha = excluded.head_sha,
@@ -83,6 +84,95 @@ ON CONFLICT (url) DO UPDATE SET
 
 -- name: GetPR :one
 SELECT * FROM pr WHERE url = ?;
+
+-- name: GetPRByURLOrAlias :one
+SELECT pr.*
+FROM pr
+WHERE pr.url = COALESCE(
+    (SELECT canonical_url FROM pr_url_alias WHERE alias_url = sqlc.arg(url)),
+    sqlc.arg(url)
+);
+
+-- name: GetPRByProviderIdentity :one
+SELECT *
+FROM pr
+WHERE provider = sqlc.arg(provider)
+  AND host = sqlc.arg(host)
+  AND provider_id = sqlc.arg(provider_id)
+  AND provider_id != '';
+
+-- name: ClearPRProviderIdentity :exec
+UPDATE pr SET provider_id = '' WHERE url = ?;
+
+-- name: DeletePRByURL :exec
+DELETE FROM pr WHERE url = ?;
+
+-- name: DeletePRAlias :exec
+DELETE FROM pr_url_alias WHERE alias_url = ?;
+
+-- name: RepointPRAliases :exec
+UPDATE pr_url_alias
+SET canonical_url = sqlc.arg(canonical_url)
+WHERE canonical_url = sqlc.arg(previous_url);
+
+-- name: UpsertPRAlias :exec
+INSERT INTO pr_url_alias(alias_url, canonical_url)
+VALUES (sqlc.arg(alias_url), sqlc.arg(canonical_url))
+ON CONFLICT(alias_url) DO UPDATE SET canonical_url = excluded.canonical_url;
+
+-- name: MovePRAliasChecks :exec
+UPDATE OR IGNORE pr_checks SET pr_url = sqlc.arg(canonical_url) WHERE pr_url = sqlc.arg(previous_url);
+
+-- name: DeletePRAliasChecks :exec
+DELETE FROM pr_checks WHERE pr_url = ?;
+
+-- name: MovePRAliasReviews :exec
+UPDATE OR IGNORE pr_reviews SET pr_url = sqlc.arg(canonical_url) WHERE pr_url = sqlc.arg(previous_url);
+
+-- name: DeletePRAliasReviews :exec
+DELETE FROM pr_reviews WHERE pr_url = ?;
+
+-- name: MovePRAliasReviewThreads :exec
+UPDATE OR IGNORE pr_review_threads SET pr_url = sqlc.arg(canonical_url) WHERE pr_url = sqlc.arg(previous_url);
+
+-- name: DeletePRAliasReviewThreads :exec
+DELETE FROM pr_review_threads WHERE pr_url = ?;
+
+-- name: MovePRAliasComments :exec
+UPDATE OR IGNORE pr_comment SET pr_url = sqlc.arg(canonical_url) WHERE pr_url = sqlc.arg(previous_url);
+
+-- name: DeletePRAliasComments :exec
+DELETE FROM pr_comment WHERE pr_url = ?;
+
+-- Preserve both notification records when their open-dedupe keys collide:
+-- the canonical notification stays open and the older alias notification
+-- becomes resolved history before its URL is updated.
+-- name: ResolveConflictingPRAliasNotifications :exec
+UPDATE notifications
+SET status = 'read', resolved_at = COALESCE(notifications.resolved_at, notifications.created_at)
+WHERE notifications.pr_url = sqlc.arg(previous_url)
+  AND (notifications.status = 'unread' OR notifications.resolved_at IS NULL)
+  AND EXISTS (
+      SELECT 1 FROM notifications AS current
+      WHERE current.pr_url = sqlc.arg(canonical_url)
+        AND current.session_id = notifications.session_id
+        AND current.type = notifications.type
+        AND (current.status = 'unread' OR current.resolved_at IS NULL)
+  );
+
+-- name: MovePRAliasNotifications :exec
+UPDATE notifications SET pr_url = sqlc.arg(canonical_url) WHERE pr_url = sqlc.arg(previous_url);
+
+-- name: MovePRAliasReviewState :exec
+UPDATE review SET pr_url = sqlc.arg(canonical_url) WHERE pr_url = sqlc.arg(previous_url);
+
+-- name: MovePRAliasReviewRuns :exec
+UPDATE OR IGNORE review_run SET pr_url = sqlc.arg(canonical_url) WHERE pr_url = sqlc.arg(previous_url);
+
+-- Rows left on the previous URL collided with the canonical review-run
+-- idempotency key and therefore represent the same logical review pass.
+-- name: DeletePRAliasReviewRuns :exec
+DELETE FROM review_run WHERE pr_url = ?;
 
 -- name: ListPRsBySession :many
 SELECT * FROM pr

--- a/backend/internal/storage/sqlite/store/pr_identity_test.go
+++ b/backend/internal/storage/sqlite/store/pr_identity_test.go
@@ -1,0 +1,342 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestWriteSCMObservationReconcilesTransferredPRAndPreservesRelatedRows(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "repo")
+	session, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldURL := "https://github.com/old-owner/repo/pull/7"
+	currentURL := "https://github.com/new-owner/repo/pull/7"
+	oldAt := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	currentAt := oldAt.Add(time.Hour)
+	oldPR := domain.PullRequest{
+		URL:          oldURL,
+		SessionID:    session.ID,
+		Number:       7,
+		Provider:     "github",
+		Host:         "github.com",
+		Repo:         "old-owner/repo",
+		HeadSHA:      "old-head",
+		Title:        "stale title",
+		Mergeability: domain.MergeConflicting,
+		UpdatedAt:    oldAt,
+	}
+	if err := s.WriteSCMObservation(ctx, oldPR,
+		[]domain.PullRequestCheck{{Name: "old-check", CommitHash: "old-head", Status: domain.PRCheckFailed, CreatedAt: oldAt}},
+		[]domain.PullRequestReview{{ID: "old-review", Author: "alice", State: domain.ReviewChangesRequest, SubmittedAt: oldAt}},
+		[]domain.PullRequestReviewThread{{ThreadID: "old-thread", Path: "old.go", UpdatedAt: oldAt}},
+		[]domain.PullRequestComment{{ThreadID: "old-thread", ID: "old-comment", Body: "old comment", CreatedAt: oldAt}},
+		ports.ReviewWriteReplace,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalPR := domain.PullRequest{
+		URL:          currentURL,
+		SessionID:    session.ID,
+		Number:       7,
+		Provider:     "github",
+		Host:         "github.com",
+		Repo:         "new-owner/repo",
+		HeadSHA:      "current-head",
+		Title:        "current title",
+		Mergeability: domain.MergeBlocked,
+		UpdatedAt:    currentAt,
+	}
+	if err := s.WriteSCMObservation(ctx, canonicalPR,
+		[]domain.PullRequestCheck{{Name: "current-check", CommitHash: "current-head", Status: domain.PRCheckPassed, CreatedAt: currentAt}},
+		[]domain.PullRequestReview{{ID: "current-review", Author: "bob", State: domain.ReviewApproved, SubmittedAt: currentAt}},
+		[]domain.PullRequestReviewThread{{ThreadID: "current-thread", Path: "current.go", UpdatedAt: currentAt}},
+		[]domain.PullRequestComment{{ThreadID: "current-thread", ID: "current-comment", Body: "current comment", CreatedAt: currentAt}},
+		ports.ReviewWriteReplace,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalPR.ProviderID = "PR_stable_7"
+	canonicalPR.URLAlias = oldURL
+	canonicalPR.UpdatedAt = currentAt.Add(time.Minute)
+	if err := s.WriteSCMObservation(ctx, canonicalPR, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatal(err)
+	}
+
+	prs, err := s.ListPRsBySession(ctx, session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("PR rows = %d, want one canonical row: %+v", len(prs), prs)
+	}
+	if prs[0].URL != currentURL || prs[0].ProviderID != "PR_stable_7" || prs[0].HeadSHA != "current-head" || prs[0].Mergeability != domain.MergeBlocked {
+		t.Fatalf("canonical PR = %+v, want current provider observation", prs[0])
+	}
+	byAlias, ok, err := s.GetPR(ctx, oldURL)
+	if err != nil || !ok || byAlias.URL != currentURL {
+		t.Fatalf("GetPR(old URL) = %+v, ok=%v, err=%v; want canonical URL", byAlias, ok, err)
+	}
+
+	checks, err := s.ListChecks(ctx, currentURL)
+	if err != nil || len(checks) != 2 {
+		t.Fatalf("checks = %+v, err=%v; want both histories", checks, err)
+	}
+	reviews, err := s.ListPRReviews(ctx, currentURL)
+	if err != nil || len(reviews) != 2 {
+		t.Fatalf("reviews = %+v, err=%v; want both histories", reviews, err)
+	}
+	threads, err := s.ListPRReviewThreads(ctx, currentURL)
+	if err != nil || len(threads) != 2 {
+		t.Fatalf("threads = %+v, err=%v; want both histories", threads, err)
+	}
+	comments, err := s.ListPRComments(ctx, currentURL)
+	if err != nil || len(comments) != 2 {
+		t.Fatalf("comments = %+v, err=%v; want both histories", comments, err)
+	}
+}
+
+func TestClaimPRChecksStableIdentityOwnerBeforeReconciliation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "repo")
+	owner, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimant, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldURL := "https://github.com/old-owner/repo/pull/9"
+	currentURL := "https://github.com/new-owner/repo/pull/9"
+	if err := s.WriteSCMObservation(ctx, domain.PullRequest{
+		URL: oldURL, SessionID: owner.ID, Number: 9, Provider: "github", Host: "github.com", ProviderID: "PR_stable_9", UpdatedAt: time.Now().UTC(),
+	}, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatal(err)
+	}
+
+	outcome, err := s.ClaimPR(ctx, domain.PullRequest{
+		URL: currentURL, URLAlias: oldURL, SessionID: claimant.ID, Number: 9, Provider: "github", Host: "github.com", ProviderID: "PR_stable_9", UpdatedAt: time.Now().UTC(),
+	}, nil, nil, nil, nil, ports.ReviewWritePreserve, false)
+	if !errors.Is(err, ports.ErrPRClaimedByActiveSession) {
+		t.Fatalf("ClaimPR error = %v, want active-owner guard", err)
+	}
+	if outcome.PreviousOwner != owner.ID || outcome.OwnerTerminated {
+		t.Fatalf("ClaimPR outcome = %+v, want active owner %s", outcome, owner.ID)
+	}
+	prs, err := s.ListPRsBySession(ctx, owner.ID)
+	if err != nil || len(prs) != 1 || prs[0].URL != oldURL {
+		t.Fatalf("owner PRs after rejected claim = %+v, err=%v", prs, err)
+	}
+}
+
+func TestWriteSCMObservationReconcilesByStableIdentityWithoutURLAlias(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "repo")
+	session, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	oldURL := "https://github.com/old-owner/example/pull/12"
+	currentURL := "https://github.com/new-owner/example/pull/12"
+	for _, pr := range []domain.PullRequest{
+		{URL: oldURL, SessionID: session.ID, Number: 12, Provider: "github", Host: "github.com", ProviderID: "PR_stable_12", HeadSHA: "old", UpdatedAt: now},
+		{URL: currentURL, SessionID: session.ID, Number: 12, Provider: "github", Host: "github.com", ProviderID: "PR_stable_12", HeadSHA: "current", UpdatedAt: now.Add(time.Minute)},
+	} {
+		if err := s.WriteSCMObservation(ctx, pr, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+			t.Fatal(err)
+		}
+	}
+	prs, err := s.ListPRsBySession(ctx, session.ID)
+	if err != nil || len(prs) != 1 || prs[0].URL != currentURL || prs[0].HeadSHA != "current" {
+		t.Fatalf("PRs = %+v, err=%v; want current canonical observation", prs, err)
+	}
+}
+
+func TestWriteSCMObservationKeepsUnrelatedSameNumberPRsSeparate(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "repo")
+	session, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	for _, pr := range []domain.PullRequest{
+		{URL: "https://github.com/acme/api/pull/7", SessionID: session.ID, Number: 7, Provider: "github", Host: "github.com", ProviderID: "PR_api_7", UpdatedAt: now},
+		{URL: "https://github.com/acme/web/pull/7", SessionID: session.ID, Number: 7, Provider: "github", Host: "github.com", ProviderID: "PR_web_7", UpdatedAt: now.Add(time.Minute)},
+		{URL: "https://github.com/legacy/api/pull/7", SessionID: session.ID, Number: 7, Provider: "github", Host: "github.com", UpdatedAt: now.Add(2 * time.Minute)},
+	} {
+		if err := s.WriteSCMObservation(ctx, pr, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+			t.Fatal(err)
+		}
+	}
+	prs, err := s.ListPRsBySession(ctx, session.ID)
+	if err != nil || len(prs) != 3 {
+		t.Fatalf("PR rows = %+v, err=%v; want distinct provider identities and conservative legacy row", prs, err)
+	}
+}
+
+func TestWriteSCMObservationDoesNotEraseKnownProviderIdentity(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "repo")
+	session, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	url := "https://github.com/acme/example/pull/8"
+	withIdentity := domain.PullRequest{URL: url, SessionID: session.ID, Number: 8, Provider: "github", Host: "github.com", ProviderID: "PR_stable_8", UpdatedAt: time.Now().UTC()}
+	if err := s.WriteSCMObservation(ctx, withIdentity, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatal(err)
+	}
+	withoutIdentity := withIdentity
+	withoutIdentity.ProviderID = ""
+	withoutIdentity.UpdatedAt = withoutIdentity.UpdatedAt.Add(time.Minute)
+	if err := s.WriteSCMObservation(ctx, withoutIdentity, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.GetPR(ctx, url)
+	if err != nil || !ok || got.ProviderID != "PR_stable_8" {
+		t.Fatalf("GetPR = %+v, ok=%v, err=%v; want stable identity preserved", got, ok, err)
+	}
+}
+
+func TestLegacyPRWriteResolvesStoredURLAlias(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "repo")
+	session, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	oldURL := "https://github.com/old-owner/example/pull/30"
+	currentURL := "https://github.com/new-owner/example/pull/30"
+	if err := s.WriteSCMObservation(ctx, domain.PullRequest{
+		URL: currentURL, URLAlias: oldURL, SessionID: session.ID, Number: 30, Provider: "github", Host: "github.com", ProviderID: "PR_stable_30", UpdatedAt: now,
+	}, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WritePR(ctx, domain.PullRequest{
+		URL: oldURL, SessionID: session.ID, Number: 30, CI: domain.CIFailing, UpdatedAt: now.Add(time.Minute),
+	}, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	prs, err := s.ListPRsBySession(ctx, session.ID)
+	if err != nil || len(prs) != 1 || prs[0].URL != currentURL || prs[0].CI != domain.CIFailing {
+		t.Fatalf("PRs after legacy alias write = %+v, err=%v; want one updated canonical row", prs, err)
+	}
+}
+
+func TestClaimPRResolvesStoredURLAliasBeforeOwnerGuard(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "repo")
+	owner, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimant, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	oldURL := "https://github.com/old-owner/example/pull/31"
+	currentURL := "https://github.com/new-owner/example/pull/31"
+	if err := s.WriteSCMObservation(ctx, domain.PullRequest{
+		URL: currentURL, URLAlias: oldURL, SessionID: owner.ID, Number: 31, Provider: "github", Host: "github.com", ProviderID: "PR_stable_31", UpdatedAt: now,
+	}, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := s.ClaimPR(ctx, domain.PullRequest{
+		URL: oldURL, SessionID: claimant.ID, Number: 31, UpdatedAt: now.Add(time.Minute),
+	}, nil, nil, nil, nil, ports.ReviewWritePreserve, false)
+	if !errors.Is(err, ports.ErrPRClaimedByActiveSession) || outcome.PreviousOwner != owner.ID {
+		t.Fatalf("ClaimPR = outcome %+v, err=%v; want canonical active-owner guard", outcome, err)
+	}
+}
+
+func TestPRReconciliationRepointsNotificationAndReviewHistory(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "repo")
+	session, err := s.CreateSession(ctx, sampleRecord("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	oldURL := "https://github.com/old-owner/example/pull/21"
+	currentURL := "https://github.com/new-owner/example/pull/21"
+	for _, pr := range []domain.PullRequest{
+		{URL: oldURL, SessionID: session.ID, Number: 21, Provider: "github", Host: "github.com", UpdatedAt: now},
+		{URL: currentURL, SessionID: session.ID, Number: 21, Provider: "github", Host: "github.com", UpdatedAt: now.Add(time.Minute)},
+	} {
+		if err := s.WriteSCMObservation(ctx, pr, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, notification := range []domain.NotificationRecord{
+		{ID: "old-notification", SessionID: session.ID, ProjectID: "repo", PRURL: oldURL, Type: domain.NotificationReadyToMerge, Title: "old", Status: domain.NotificationUnread, CreatedAt: now},
+		{ID: "current-notification", SessionID: session.ID, ProjectID: "repo", PRURL: currentURL, Type: domain.NotificationReadyToMerge, Title: "current", Status: domain.NotificationUnread, CreatedAt: now.Add(time.Minute)},
+	} {
+		if _, created, err := s.CreateNotification(ctx, notification); err != nil || !created {
+			t.Fatalf("CreateNotification(%s) = created=%v err=%v", notification.ID, created, err)
+		}
+	}
+	review := domain.Review{ID: "review-21", SessionID: session.ID, ProjectID: "repo", Harness: domain.ReviewerCodex, PRURL: oldURL, CreatedAt: now, UpdatedAt: now}
+	if err := s.UpsertReview(ctx, review); err != nil {
+		t.Fatal(err)
+	}
+	for _, run := range []domain.ReviewRun{
+		{ID: "old-run", ReviewID: review.ID, SessionID: session.ID, Harness: review.Harness, PRURL: oldURL, TargetSHA: "old-head", Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved, CreatedAt: now},
+		{ID: "current-run", ReviewID: review.ID, SessionID: session.ID, Harness: review.Harness, PRURL: currentURL, TargetSHA: "current-head", Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved, CreatedAt: now.Add(time.Minute)},
+	} {
+		if err := s.InsertReviewRun(ctx, run); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := s.WriteSCMObservation(ctx, domain.PullRequest{
+		URL: currentURL, URLAlias: oldURL, SessionID: session.ID, Number: 21, Provider: "github", Host: "github.com", ProviderID: "PR_stable_21", UpdatedAt: now.Add(2 * time.Minute),
+	}, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatal(err)
+	}
+
+	notifications, err := s.ListNotifications(ctx, domain.NotificationListAll, time.Time{}, "", 10)
+	if err != nil || len(notifications) != 2 {
+		t.Fatalf("notifications = %+v, err=%v", notifications, err)
+	}
+	for _, notification := range notifications {
+		if notification.PRURL != currentURL {
+			t.Fatalf("notification %s PR URL = %q, want %q", notification.ID, notification.PRURL, currentURL)
+		}
+	}
+	storedReview, ok, err := s.GetReviewByID(ctx, review.ID)
+	if err != nil || !ok || storedReview.PRURL != currentURL {
+		t.Fatalf("review = %+v, ok=%v, err=%v", storedReview, ok, err)
+	}
+	runs, err := s.ListReviewRunsBySession(ctx, session.ID)
+	if err != nil || len(runs) != 2 {
+		t.Fatalf("review runs = %+v, err=%v", runs, err)
+	}
+	for _, run := range runs {
+		if run.PRURL != currentURL {
+			t.Fatalf("review run %s PR URL = %q, want %q", run.ID, run.PRURL, currentURL)
+		}
+	}
+}

--- a/backend/internal/storage/sqlite/store/pr_store.go
+++ b/backend/internal/storage/sqlite/store/pr_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -54,13 +55,29 @@ func (s *Store) WriteSCMObservation(ctx context.Context, pr domain.PullRequest, 
 func (s *Store) ClaimPR(ctx context.Context, pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, reviewMode ports.ReviewWriteMode, allowActiveTakeover bool) (ports.ClaimOutcome, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
+	pr = normalizedPRIdentity(pr)
 	var outcome ports.ClaimOutcome
 	err := s.inTx(ctx, "claim pr", func(q *gen.Queries) error {
-		owner, err := q.GetPRClaimAndOwner(ctx, pr.URL)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		var err error
+		pr, err = resolveWeakPRAlias(ctx, q, pr)
+		if err != nil {
 			return err
 		}
-		if err == nil {
+		candidates, err := findPRIdentityCandidates(ctx, q, pr)
+		if err != nil {
+			return err
+		}
+		for _, candidate := range candidates {
+			owner, err := q.GetPRClaimAndOwner(ctx, candidate.URL)
+			if err != nil {
+				return err
+			}
+			if owner.SessionID == pr.SessionID {
+				continue
+			}
+			if outcome.PreviousOwner != "" && outcome.PreviousOwner != owner.SessionID {
+				return fmt.Errorf("pr identity resolves to multiple sessions: %s and %s", outcome.PreviousOwner, owner.SessionID)
+			}
 			outcome.PreviousOwner = owner.SessionID
 			outcome.OwnerTerminated = owner.IsTerminated
 			if owner.SessionID != pr.SessionID && !owner.IsTerminated && !allowActiveTakeover {
@@ -88,21 +105,27 @@ func (s *Store) writePR(ctx context.Context, pr domain.PullRequest, checks []dom
 }
 
 func writePRRows(ctx context.Context, q *gen.Queries, pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, reviewMode ports.ReviewWriteMode, replaceLegacyComments, rejectReassignment bool) error {
-	if rejectReassignment {
-		existing, err := q.GetPR(ctx, pr.URL)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return err
-		}
-		if err == nil && existing.SessionID != pr.SessionID {
-			return fmt.Errorf("pr %s already belongs to session %s", pr.URL, existing.SessionID)
-		}
+	pr = normalizedPRIdentity(pr)
+	var err error
+	pr, err = resolveWeakPRAlias(ctx, q, pr)
+	if err != nil {
+		return err
 	}
 	if replaceLegacyComments {
+		if rejectReassignment {
+			existing, err := q.GetPR(ctx, pr.URL)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+			if err == nil && existing.SessionID != pr.SessionID {
+				return fmt.Errorf("pr %s already belongs to session %s", pr.URL, existing.SessionID)
+			}
+		}
 		if err := q.UpsertLegacyPR(ctx, genLegacyPRParams(pr)); err != nil {
 			return err
 		}
 	} else {
-		if err := q.UpsertPR(ctx, genPRParams(pr)); err != nil {
+		if err := upsertPRWithIdentity(ctx, q, pr, rejectReassignment); err != nil {
 			return err
 		}
 	}
@@ -218,6 +241,162 @@ func writePRRows(ctx context.Context, q *gen.Queries, pr domain.PullRequest, che
 	return nil
 }
 
+func normalizedPRIdentity(pr domain.PullRequest) domain.PullRequest {
+	pr.Provider = strings.ToLower(strings.TrimSpace(pr.Provider))
+	pr.Host = strings.ToLower(strings.TrimSpace(pr.Host))
+	pr.ProviderID = strings.TrimSpace(pr.ProviderID)
+	pr.URLAlias = strings.TrimSpace(pr.URLAlias)
+	return pr
+}
+
+func resolveWeakPRAlias(ctx context.Context, q *gen.Queries, pr domain.PullRequest) (domain.PullRequest, error) {
+	if pr.ProviderID != "" || pr.URLAlias != "" {
+		return pr, nil
+	}
+	existing, err := q.GetPRByURLOrAlias(ctx, pr.URL)
+	if errors.Is(err, sql.ErrNoRows) {
+		return pr, nil
+	}
+	if err != nil {
+		return domain.PullRequest{}, err
+	}
+	if existing.URL == pr.URL {
+		return pr, nil
+	}
+	pr.URLAlias = pr.URL
+	pr.URL = existing.URL
+	if pr.Provider == "" {
+		pr.Provider = existing.Provider
+	}
+	if pr.Host == "" {
+		pr.Host = existing.Host
+	}
+	if pr.Repo == "" {
+		pr.Repo = existing.Repo
+	}
+	pr.ProviderID = existing.ProviderID
+	return pr, nil
+}
+
+func upsertPRWithIdentity(ctx context.Context, q *gen.Queries, pr domain.PullRequest, rejectReassignment bool) error {
+	if pr.ProviderID == "" && pr.URLAlias == "" {
+		return q.UpsertPR(ctx, genPRParams(pr))
+	}
+	candidates, err := findPRIdentityCandidates(ctx, q, pr)
+	if err != nil {
+		return err
+	}
+	for _, existing := range candidates {
+		if rejectReassignment && existing.SessionID != pr.SessionID {
+			return fmt.Errorf("pr %s already belongs to session %s", existing.URL, existing.SessionID)
+		}
+		if existing.URL != pr.URL && existing.ProviderID != "" {
+			if err := q.ClearPRProviderIdentity(ctx, existing.URL); err != nil {
+				return err
+			}
+		}
+	}
+	if err := q.UpsertPR(ctx, genPRParams(pr)); err != nil {
+		return err
+	}
+	if err := q.DeletePRAlias(ctx, pr.URL); err != nil {
+		return err
+	}
+	for previousURL := range candidates {
+		if previousURL == pr.URL {
+			continue
+		}
+		if err := movePRAliasRows(ctx, q, previousURL, pr.URL); err != nil {
+			return err
+		}
+		if err := q.RepointPRAliases(ctx, gen.RepointPRAliasesParams{CanonicalURL: pr.URL, PreviousURL: previousURL}); err != nil {
+			return err
+		}
+		if err := q.DeletePRByURL(ctx, previousURL); err != nil {
+			return err
+		}
+		if err := q.UpsertPRAlias(ctx, gen.UpsertPRAliasParams{AliasURL: previousURL, CanonicalURL: pr.URL}); err != nil {
+			return err
+		}
+	}
+	if pr.URLAlias != "" && pr.URLAlias != pr.URL {
+		if err := q.UpsertPRAlias(ctx, gen.UpsertPRAliasParams{AliasURL: pr.URLAlias, CanonicalURL: pr.URL}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findPRIdentityCandidates(ctx context.Context, q *gen.Queries, pr domain.PullRequest) (map[string]gen.PR, error) {
+	candidates := map[string]gen.PR{}
+	addCandidate := func(row gen.PR, err error) error {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		candidates[row.URL] = row
+		return nil
+	}
+	if err := addCandidate(q.GetPR(ctx, pr.URL)); err != nil {
+		return nil, err
+	}
+	if pr.URLAlias != "" && pr.URLAlias != pr.URL {
+		if err := addCandidate(q.GetPRByURLOrAlias(ctx, pr.URLAlias)); err != nil {
+			return nil, err
+		}
+	}
+	if pr.ProviderID != "" && pr.Provider != "" && pr.Host != "" {
+		if err := addCandidate(q.GetPRByProviderIdentity(ctx, gen.GetPRByProviderIdentityParams{
+			Provider: pr.Provider, Host: pr.Host, ProviderID: pr.ProviderID,
+		})); err != nil {
+			return nil, err
+		}
+	}
+	return candidates, nil
+}
+
+func movePRAliasRows(ctx context.Context, q *gen.Queries, previousURL, canonicalURL string) error {
+	if err := q.MovePRAliasChecks(ctx, gen.MovePRAliasChecksParams{CanonicalURL: canonicalURL, PreviousURL: previousURL}); err != nil {
+		return err
+	}
+	if err := q.DeletePRAliasChecks(ctx, previousURL); err != nil {
+		return err
+	}
+	if err := q.MovePRAliasReviews(ctx, gen.MovePRAliasReviewsParams{CanonicalURL: canonicalURL, PreviousURL: previousURL}); err != nil {
+		return err
+	}
+	if err := q.DeletePRAliasReviews(ctx, previousURL); err != nil {
+		return err
+	}
+	if err := q.MovePRAliasReviewThreads(ctx, gen.MovePRAliasReviewThreadsParams{CanonicalURL: canonicalURL, PreviousURL: previousURL}); err != nil {
+		return err
+	}
+	if err := q.DeletePRAliasReviewThreads(ctx, previousURL); err != nil {
+		return err
+	}
+	if err := q.MovePRAliasComments(ctx, gen.MovePRAliasCommentsParams{CanonicalURL: canonicalURL, PreviousURL: previousURL}); err != nil {
+		return err
+	}
+	if err := q.DeletePRAliasComments(ctx, previousURL); err != nil {
+		return err
+	}
+	if err := q.ResolveConflictingPRAliasNotifications(ctx, gen.ResolveConflictingPRAliasNotificationsParams{CanonicalURL: canonicalURL, PreviousURL: previousURL}); err != nil {
+		return err
+	}
+	if err := q.MovePRAliasNotifications(ctx, gen.MovePRAliasNotificationsParams{CanonicalURL: canonicalURL, PreviousURL: previousURL}); err != nil {
+		return err
+	}
+	if err := q.MovePRAliasReviewState(ctx, gen.MovePRAliasReviewStateParams{CanonicalURL: canonicalURL, PreviousURL: previousURL}); err != nil {
+		return err
+	}
+	if err := q.MovePRAliasReviewRuns(ctx, gen.MovePRAliasReviewRunsParams{CanonicalURL: canonicalURL, PreviousURL: previousURL}); err != nil {
+		return err
+	}
+	return q.DeletePRAliasReviewRuns(ctx, previousURL)
+}
+
 func reviewThreadIDs(threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment) []string {
 	seen := map[string]bool{}
 	out := make([]string, 0, len(threads))
@@ -265,7 +444,7 @@ func (s *Store) UpdatePRLastNudgeSignature(ctx context.Context, url, payload str
 
 // GetPR returns the PR facts for a URL, or ok=false if absent.
 func (s *Store) GetPR(ctx context.Context, url string) (domain.PullRequest, bool, error) {
-	p, err := s.qr.GetPR(ctx, url)
+	p, err := s.qr.GetPRByURLOrAlias(ctx, url)
 	if errors.Is(err, sql.ErrNoRows) {
 		return domain.PullRequest{}, false, nil
 	}
@@ -370,6 +549,7 @@ func genPRParams(r domain.PullRequest) gen.UpsertPRParams {
 		Provider:                 r.Provider,
 		Host:                     r.Host,
 		Repo:                     r.Repo,
+		ProviderID:               r.ProviderID,
 		SourceBranch:             r.SourceBranch,
 		TargetBranch:             r.TargetBranch,
 		HeadSha:                  r.HeadSHA,
@@ -472,6 +652,7 @@ func prRowFromGen(p gen.PR) domain.PullRequest {
 		Provider:                 p.Provider,
 		Host:                     p.Host,
 		Repo:                     p.Repo,
+		ProviderID:               p.ProviderID,
 		SourceBranch:             p.SourceBranch,
 		TargetBranch:             p.TargetBranch,
 		HeadSHA:                  p.HeadSha,


### PR DESCRIPTION
## Summary

- normalize the historical `AgentWrapper/agent-orchestrator` and current `Untrivial-ai/agent-orchestrator` repository identities before mutable branch/head alias checks
- collapse transferred PR rows by GitHub's stable PR number and retain the newest authoritative observation
- cover the live #2870 shape: stale `CONFLICTING`/`DIRTY` old-owner row plus newer `MERGEABLE`/`BLOCKED` current-owner row with a different head SHA
- verify a newer genuinely conflicting current observation is still surfaced

## Before / after

Before, both session and detailed PR endpoints returned two rows for transferred PR #2870. The desktop PR card and activity rail could therefore render the stale old-owner row's `conflicting` state.

After, both read models treat those URLs as aliases of the transferred repository and return only the newer current-owner row (`blocked`, `review_required`). Alias handling remains unchanged for unrelated repositories, and a current real conflict still wins.

## Verification

- read-only reproduction against local session `agent-orchestrator-31` through both daemon endpoints
- `cd backend && env -u AO_PROJECT_ID -u AO_SESSION_ID go test ./...`
- `npm run frontend:typecheck`
- `git diff --check`

No frontend source changed; the visible card/activity correction follows from the corrected daemon payload, so no separate preview artifact was applicable.

Closes #3922
