### PR TITLE
fix(chat): unblock Claude interface switch on Windows

### DIFF
--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -478,20 +479,49 @@ func SessionUUID(aoSessionID string) string {
 var claudeBinarySpec = binaryutil.BinarySpec{
 	Label:         "claude",
 	Names:         []string{"claude"},
-	WinNames:      []string{"claude.cmd", "claude.exe", "claude"},
+	WinNames:      []string{"claude.exe", "claude.cmd", "claude"},
 	UnixPaths:     []string{"/usr/local/bin/claude", "/opt/homebrew/bin/claude"},
 	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("claude", []string{".claude", "local", "claude"}),
 	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
-		{Base: binaryutil.WinAppData, Parts: []string{"npm", "claude.cmd"}},
+		{Base: binaryutil.WinAppData, Parts: []string{"npm", "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "claude.exe"}},
+		{Base: binaryutil.WinAppData, Parts: []string{"npm", "claude.cmd"}},
 	},
 }
 
 // ResolveClaudeBinary returns the path to the claude binary, or a wrapped
 // ports.ErrAgentBinaryNotFound when it is absent.
 func ResolveClaudeBinary(ctx context.Context) (string, error) {
-	return binaryutil.ResolveBinary(ctx, claudeBinarySpec)
+	binary, err := binaryutil.ResolveBinary(ctx, claudeBinarySpec)
+	if err != nil {
+		return "", err
+	}
+	return resolveNativeWindowsClaude(binary, runtime.GOOS), nil
+}
+
+// resolveNativeWindowsClaude unwraps the npm-generated command shim to the
+// native executable shipped by Claude Code. The ACP bridge passes this path to
+// Node child_process.spawn, which cannot execute .cmd files directly on current
+// Node releases.
+func resolveNativeWindowsClaude(path, goos string) string {
+	if goos != "windows" || !strings.EqualFold(filepath.Ext(path), ".cmd") {
+		return path
+	}
+	for _, candidate := range windowsNativeClaudeCandidatesForShim(path) {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return path
+}
+
+func windowsNativeClaudeCandidatesForShim(shim string) []string {
+	dir := filepath.Dir(shim)
+	return []string{
+		filepath.Join(dir, "claude.exe"),
+		filepath.Join(dir, "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe"),
+	}
 }
 
 func (p *Plugin) claudeBinary(ctx context.Context) (string, error) {

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -32,6 +32,38 @@ func TestNativeConversationIDUsesTheSameClaudeUUIDAcrossInterfaces(t *testing.T)
 	}
 }
 
+func TestWindowsNativeClaudeCandidatesForNPMShim(t *testing.T) {
+	shim := filepath.Join("prefix", "claude.cmd")
+	want := []string{
+		filepath.Join("prefix", "claude.exe"),
+		filepath.Join("prefix", "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe"),
+	}
+	if got := windowsNativeClaudeCandidatesForShim(shim); !reflect.DeepEqual(got, want) {
+		t.Fatalf("candidates = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveNativeWindowsClaudeFindsNPMExecutable(t *testing.T) {
+	prefix := t.TempDir()
+	shim := filepath.Join(prefix, "claude.cmd")
+	if err := os.WriteFile(shim, []byte("@echo off\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(prefix, "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, []byte("native claude"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveNativeWindowsClaude(shim, "windows"); got != want {
+		t.Fatalf("resolved binary = %q, want %q", got, want)
+	}
+	if got := resolveNativeWindowsClaude(shim, "linux"); got != shim {
+		t.Fatalf("non-Windows resolution = %q, want unchanged shim %q", got, shim)
+	}
+}
+
 func TestNativeConversationExistsRequiresPersistedClaudeTranscript(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("CLAUDE_CONFIG_DIR", configDir)

--- a/backend/internal/adapters/chatdriver/claudeacp/driver.go
+++ b/backend/internal/adapters/chatdriver/claudeacp/driver.go
@@ -50,7 +50,11 @@ func New(plugin claudePlugin, log *slog.Logger) ports.ChatDriver {
 			if _, err := resolveRuntime(ctx); err != nil {
 				return fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
 			}
-			if _, err := plugin.ResolveBinary(ctx); err != nil {
+			claudeBinary, err := plugin.ResolveBinary(ctx)
+			if err != nil {
+				return fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
+			}
+			if err := validateClaudeACPExecutable(claudeBinary, runtime.GOOS); err != nil {
 				return fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
 			}
 			status, err := plugin.AuthStatus(ctx)
@@ -73,6 +77,9 @@ func New(plugin claudePlugin, log *slog.Logger) ports.ChatDriver {
 			if err != nil {
 				return acpdriver.Launch{}, fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
 			}
+			if err := validateClaudeACPExecutable(claudeBinary, runtime.GOOS); err != nil {
+				return acpdriver.Launch{}, fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
+			}
 			env := make(map[string]string, len(cfg.Env)+1)
 			for key, value := range cfg.Env {
 				env[key] = value
@@ -90,6 +97,18 @@ func New(plugin claudePlugin, log *slog.Logger) ports.ChatDriver {
 		SessionMode:    claudeSessionMode,
 		SessionOptions: claudeSessionOptions,
 	}, log)
+}
+
+func validateClaudeACPExecutable(binary, goos string) error {
+	if goos != "windows" {
+		return nil
+	}
+	switch strings.ToLower(filepath.Ext(binary)) {
+	case ".cmd", ".bat":
+		return fmt.Errorf("Claude Code resolved to command shim %q, but Chat requires the native claude.exe; reinstall or update Claude Code", binary)
+	default:
+		return nil
+	}
 }
 
 func claudeSessionMeta(cfg acpdriver.LaunchConfig) map[string]any {

--- a/backend/internal/adapters/chatdriver/claudeacp/driver.go
+++ b/backend/internal/adapters/chatdriver/claudeacp/driver.go
@@ -105,7 +105,7 @@ func validateClaudeACPExecutable(binary, goos string) error {
 	}
 	switch strings.ToLower(filepath.Ext(binary)) {
 	case ".cmd", ".bat":
-		return fmt.Errorf("Claude Code resolved to command shim %q, but Chat requires the native claude.exe; reinstall or update Claude Code", binary)
+		return fmt.Errorf("resolved Claude Code command shim %q, but chat requires the native claude.exe; reinstall or update Claude Code", binary)
 	default:
 		return nil
 	}

--- a/backend/internal/adapters/chatdriver/claudeacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/claudeacp/driver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
@@ -43,6 +44,31 @@ func TestClaudeSessionOptionsUseACPConfigIDs(t *testing.T) {
 	want := []acpdriver.SessionOption{{ID: "model", Value: "sonnet"}, {ID: "effort", Value: "high"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("options = %#v, want %#v", got, want)
+	}
+}
+
+func TestValidateClaudeACPExecutableRejectsWindowsCommandShims(t *testing.T) {
+	tests := []struct {
+		name    string
+		binary  string
+		goos    string
+		wantErr bool
+	}{
+		{name: "native executable", binary: `C:\\npm\\claude.exe`, goos: "windows"},
+		{name: "cmd shim", binary: `C:\\npm\\claude.cmd`, goos: "windows", wantErr: true},
+		{name: "bat shim", binary: `C:\\npm\\claude.BAT`, goos: "windows", wantErr: true},
+		{name: "non-Windows shim", binary: "/tmp/claude.cmd", goos: "linux"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateClaudeACPExecutable(tc.binary, tc.goos)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateClaudeACPExecutable(%q, %q) error = %v, wantErr %v", tc.binary, tc.goos, err, tc.wantErr)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), "native claude.exe") {
+				t.Fatalf("error = %q, want actionable native executable guidance", err)
+			}
+		})
 	}
 }
 

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -243,6 +243,7 @@ func (m *Manager) runInterfaceTransition(
 	sourcePrepared := false
 	sourceStopped := false
 	modeChanged := false
+	var sourceRuntimeHandle ports.RuntimeHandle
 	fail := func(code string, cause error) {
 		if sourcePrepared && !sourceStopped {
 			m.abortSourceHandoff(transition)
@@ -253,7 +254,7 @@ func (m *Manager) runInterfaceTransition(
 			return
 		}
 		if sourceStopped {
-			m.rollbackInterfaceTransition(transition, modeChanged, code, cause)
+			m.rollbackInterfaceTransition(transition, sourceRuntimeHandle, modeChanged, code, cause)
 			return
 		}
 		_ = m.finishInterfaceTransition(transition.ID, domain.SessionInterfaceTransitionFailed, code, cause.Error())
@@ -275,6 +276,7 @@ func (m *Manager) runInterfaceTransition(
 		fail("SESSION_CHANGED", fmt.Errorf("session changed before the interface switch could start"))
 		return
 	}
+	sourceRuntimeHandle = runtimeHandle(rec.Metadata)
 	// Claim the raw terminal input path before target preflight or the first idle
 	// observation. Without this gate a mux client can submit work after the TUI is
 	// observed idle but before Destroy, and that accepted work is then killed by
@@ -699,6 +701,7 @@ func (m *Manager) startTransitionTarget(ctx context.Context, id domain.SessionID
 
 func (m *Manager) rollbackInterfaceTransition(
 	transition domain.SessionInterfaceTransition,
+	sourceRuntimeHandle ports.RuntimeHandle,
 	modeChanged bool,
 	code string,
 	cause error,
@@ -726,6 +729,17 @@ func (m *Manager) rollbackInterfaceTransition(
 			}
 			_ = m.finishInterfaceTransition(transition.ID, domain.SessionInterfaceTransitionRecovery,
 				"RECOVERY_REQUIRED", detail)
+			return
+		}
+	}
+	// A conclusive liveness probe can prove the source process exited even when
+	// its first teardown timed out. Clear any stale runtime registration using
+	// the handle captured before the controller epoch erased it, or rollback can
+	// fail to recreate the TUI with "session already exists" on ConPTY.
+	if transition.SourceMode != domain.SessionModeChat && sourceRuntimeHandle.ID != "" {
+		if err := m.runtime.Destroy(ctx, sourceRuntimeHandle); err != nil {
+			_ = m.finishInterfaceTransition(transition.ID, domain.SessionInterfaceTransitionRecovery,
+				"RECOVERY_REQUIRED", cause.Error()+"; source runtime cleanup: "+err.Error())
 			return
 		}
 	}

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -211,6 +211,7 @@ type transitionRuntime struct {
 	*fakeRuntime
 	log                        *[]string
 	stopErrors                 []error
+	runtimeOccupied            bool
 	outputForCall              func(int) string
 	outputCallTimes            []time.Time
 	blockAliveUntilContextDone bool
@@ -238,12 +239,23 @@ func (r *transitionRuntime) Destroy(ctx context.Context, handle ports.RuntimeHan
 			return err
 		}
 	}
-	return r.fakeRuntime.Destroy(ctx, handle)
+	err := r.fakeRuntime.Destroy(ctx, handle)
+	if err == nil {
+		r.runtimeOccupied = false
+	}
+	return err
 }
 
 func (r *transitionRuntime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
 	*r.log = append(*r.log, "start:tui")
-	return r.fakeRuntime.Create(ctx, cfg)
+	if r.runtimeOccupied {
+		return ports.RuntimeHandle{}, fmt.Errorf("session %q already exists", cfg.SessionID)
+	}
+	handle, err := r.fakeRuntime.Create(ctx, cfg)
+	if err == nil {
+		r.runtimeOccupied = true
+	}
+	return handle, err
 }
 
 func (r *transitionRuntime) GetOutput(ctx context.Context, handle ports.RuntimeHandle, lines int) (string, error) {
@@ -260,6 +272,7 @@ type transitionChat struct {
 	preparedPolicy   domain.SessionInterfaceTransitionPolicy
 	start            ChatStart
 	preflightErr     error
+	startErr         error
 	preflightStarted chan struct{}
 	preflightRelease chan struct{}
 	relayMessages    []string
@@ -285,6 +298,9 @@ func (c *transitionChat) PreflightChat(ctx context.Context, _ domain.AgentHarnes
 func (c *transitionChat) StartChat(_ context.Context, cfg ChatStart) (ChatStarted, error) {
 	c.start = cfg
 	*c.log = append(*c.log, "start:chat")
+	if c.startErr != nil {
+		return ChatStarted{}, c.startErr
+	}
 	started := ChatStarted{ProviderConversationID: cfg.ProviderConversationID, ControllerGeneration: "chat-generation"}
 	if cfg.ControllerReady != nil {
 		if err := cfg.ControllerReady(started); err != nil {
@@ -431,6 +447,34 @@ func TestInterfaceTransitionTUIToChatStopsBeforeStartingAndReusesNativeConversat
 	}
 	if got := fmt.Sprint(*log); got != "[stop:tui:runtime-1 start:chat]" {
 		t.Fatalf("controller order = %s", got)
+	}
+}
+
+func TestInterfaceTransitionRollbackClearsStaleTUIRuntimeBeforeRestore(t *testing.T) {
+	manager, store, runtime, chat, log := newTransitionManager(t, domain.SessionModeTUI)
+	runtime.runtimeOccupied = true
+	runtime.stopErrors = []error{errors.New("teardown timed out")}
+	runtime.aliveByHandle = map[string]bool{"runtime-1": false}
+	chat.startErr = errors.New("ACP session/new: spawn EINVAL")
+
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionFailed || settled.ErrorCode != "TARGET_RESUME_FAILED" {
+		t.Fatalf("transition = %+v, want failed target resume after successful rollback", settled)
+	}
+	if got := store.sessions["session-1"].Mode; got != domain.SessionModeTUI {
+		t.Fatalf("mode = %s, want restored TUI", got)
+	}
+	if runtime.created != 1 {
+		t.Fatalf("restored runtime create count = %d, want 1", runtime.created)
+	}
+	wantLog := "[stop:tui:runtime-1 start:chat stop:chat stop:tui:runtime-1 start:tui]"
+	if got := fmt.Sprint(*log); got != wantLog {
+		t.Fatalf("controller order = %s, want %s", got, wantLog)
 	}
 }
 


### PR DESCRIPTION
Fixes #3925

## Summary

- prefer and resolve the native `claude.exe` shipped by the user's Windows Claude Code npm installation instead of passing `claude.cmd` to the ACP Node runtime
- reject unresolved `.cmd`/`.bat` paths during ACP preflight with actionable guidance instead of surfacing opaque `spawn EINVAL`
- retain the source runtime handle through an interface transition and clear stale ConPTY registrations before rollback recreates the TUI
- add regression coverage for npm executable resolution, ACP shim validation, and failed-target rollback

AO continues to use the user's installed Claude Code CLI; the packaged ACP runtime remains provider-binary-free.

## Tests

- `go test ./internal/adapters/agent/claudecode ./internal/adapters/chatdriver/claudeacp ./internal/session_manager`
- `go test -race ./internal/adapters/agent/claudecode ./internal/adapters/chatdriver/claudeacp ./internal/session_manager`
- Windows/amd64 cross-compilation of the three affected test packages with `go test -c`
- `cd backend && go build ./...`
- `env -u AO_SESSION_ID -u AO_PROJECT_ID -u AO_ISSUE_ID go test ./...`
- `env -u AO_SESSION_ID -u AO_PROJECT_ID -u AO_ISSUE_ID npm run lint`

## Risk

Low and Windows-focused. Non-Windows binary resolution is unchanged. Older Windows Claude Code installations that expose only a command shim now receive a clear preflight error and must update/reinstall instead of entering the broken transition path.
