### PR TITLE
fix(browser): target Markdown blocks in annotations

### DIFF
--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -235,6 +235,48 @@ describe("annotate preload", () => {
 		expect(payload.selection.contexts.map((context) => context.classes)).toEqual([[], []]);
 	});
 
+	it("selects a Markdown table cell when hovering nested cell content", async () => {
+		const markdown = document.createElement("main");
+		markdown.className = "markdown-body";
+		const table = setElementBounds(document.createElement("table"), {
+			left: 20,
+			top: 30,
+			width: 600,
+			height: 240,
+		});
+		const body = document.createElement("tbody");
+		const row = document.createElement("tr");
+		const cell = setElementBounds(document.createElement("td"), {
+			left: 220,
+			top: 110,
+			width: 180,
+			height: 52,
+		});
+		const label = document.createElement("strong");
+		label.textContent = "Codex";
+		cell.appendChild(label);
+		row.appendChild(cell);
+		body.appendChild(row);
+		table.appendChild(body);
+		markdown.appendChild(table);
+		document.body.appendChild(markdown);
+
+		dispatchPageEvent(label, "pointermove");
+
+		expect(highlightStyle().left).toBe("220px");
+		expect(highlightStyle().top).toBe("110px");
+		expect(highlightStyle().width).toBe("180px");
+		expect(highlightStyle().height).toBe("52px");
+
+		dispatchPageEvent(label, "click");
+		const payload = await submitPrompt("Change this agent entry.");
+
+		expect(payload.selection.kind).toBe("element");
+		if (payload.selection.kind !== "element") throw new Error("expected an element selection");
+		expect(payload.selection.context.tag).toBe("td");
+		expect(payload.selection.context.visibleText).toBe("Codex");
+	});
+
 	it("keeps the nearest classed component target outside Markdown previews", async () => {
 		const card = setElementBounds(document.createElement("section"), {
 			left: 20,

--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -64,6 +64,12 @@ function setAnnotationMode(enabled: boolean): void {
 function elementWithBounds(id: string, bounds: Bounds): HTMLButtonElement {
 	const element = document.createElement("button");
 	element.id = id;
+	setElementBounds(element, bounds);
+	document.body.appendChild(element);
+	return element;
+}
+
+function setElementBounds<T extends Element>(element: T, bounds: Bounds): T {
 	Object.defineProperty(element, "getBoundingClientRect", {
 		configurable: true,
 		value: () =>
@@ -79,7 +85,6 @@ function elementWithBounds(id: string, bounds: Bounds): HTMLButtonElement {
 				toJSON: () => ({}),
 			}) as DOMRect,
 	});
-	document.body.appendChild(element);
 	return element;
 }
 
@@ -193,6 +198,63 @@ describe("annotate preload", () => {
 		expect(payload.selection.kind).toBe("element");
 		if (payload.selection.kind !== "element") throw new Error("expected an element selection");
 		expect(payload.selection.context.selector).toBe("button#first");
+	});
+
+	it("selects semantic Markdown blocks instead of the document wrapper", async () => {
+		const markdown = document.createElement("main");
+		markdown.className = "markdown-body";
+		const heading = setElementBounds(document.createElement("h2"), {
+			left: 24,
+			top: 32,
+			width: 320,
+			height: 40,
+		});
+		heading.textContent = "Install";
+		const paragraph = setElementBounds(document.createElement("p"), {
+			left: 24,
+			top: 88,
+			width: 560,
+			height: 56,
+		});
+		const emphasis = document.createElement("strong");
+		emphasis.textContent = "desktop app";
+		paragraph.append("Download the ", emphasis, ".");
+		markdown.append(heading, paragraph);
+		document.body.appendChild(markdown);
+
+		shiftKeyDown();
+		dispatchPageEvent(heading, "click");
+		dispatchPageEvent(emphasis, "click");
+		shiftKeyDown();
+
+		const payload = await submitPrompt("Revise these sections.");
+
+		expect(payload.selection.kind).toBe("elements");
+		if (payload.selection.kind !== "elements") throw new Error("expected an elements selection");
+		expect(payload.selection.contexts.map((context) => context.tag)).toEqual(["h2", "p"]);
+		expect(payload.selection.contexts.map((context) => context.classes)).toEqual([[], []]);
+	});
+
+	it("keeps the nearest classed component target outside Markdown previews", async () => {
+		const card = setElementBounds(document.createElement("section"), {
+			left: 20,
+			top: 30,
+			width: 400,
+			height: 180,
+		});
+		card.className = "settings-card";
+		const label = document.createElement("span");
+		label.textContent = "Updates";
+		card.appendChild(label);
+		document.body.appendChild(card);
+
+		dispatchPageEvent(label, "click");
+		const payload = await submitPrompt("Adjust this component.");
+
+		expect(payload.selection.kind).toBe("element");
+		if (payload.selection.kind !== "element") throw new Error("expected an element selection");
+		expect(payload.selection.context.tag).toBe("section");
+		expect(payload.selection.context.classes).toEqual(["settings-card"]);
 	});
 
 	it("renders a compact auto-growing prompt and submits from the embedded action", async () => {

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -26,6 +26,8 @@ const PROMPT_MAX_HEIGHT = 360;
 const PROMPT_COMPACT_CHROME_HEIGHT = 48;
 const PROMPT_EXPANDED_CHROME_HEIGHT = 48;
 const TEXTAREA_MIN_HEIGHT = 32;
+const MARKDOWN_ANNOTATION_TARGETS =
+	"h1, h2, h3, h4, h5, h6, p, ul, ol, li, blockquote, pre, table, th, td, figure, figcaption, img, hr, details, summary";
 
 ipcRenderer.on("browser:annotation:setMode", (_event, input: { enabled?: boolean }) => {
 	setEnabled(Boolean(input?.enabled), "disabled");
@@ -190,10 +192,19 @@ function annotationTarget(target: EventTarget | null): Element | null {
 	if (!(target instanceof Element)) return null;
 	const element =
 		target.closest("button, a, input, textarea, select, [role]") ??
+		markdownAnnotationTarget(target) ??
 		target.closest("[data-testid], [id], [class]") ??
 		target;
 	if (element === document.documentElement || element === document.body) return null;
 	return element;
+}
+
+function markdownAnnotationTarget(target: Element): Element | null {
+	// Goldmark emits semantic nodes without classes inside one classed layout
+	// wrapper. Prefer the content block before the generic component heuristic
+	// promotes every Markdown annotation to the full document wrapper.
+	if (!target.closest(".markdown-body")) return null;
+	return target.closest(MARKDOWN_ANNOTATION_TARGETS);
 }
 
 // Registered as FontFace objects from decoded bytes rather than an @font-face


### PR DESCRIPTION
Fixes #3929

## Summary

- Select semantic Markdown blocks before the generic class/id ancestor fallback.
- Resolve nested Markdown table content to its individual `th` or `td` cell.
- Preserve interactive-element targeting and ordinary app component selection.
- Add regression coverage for headings, paragraphs, table cells, and non-Markdown classed components.

## Runtime note

`ao preview` opens new content in the installed AO Browser panel; it does not hot-load an unmerged Electron annotation preload. The installed `0.12.1-nightly.202608130248` bundle predates this PR and contains the old targeting path. A package built from this branch contains the Markdown-aware preload.

## Tests

- `cd frontend && npm test -- src/annotate-preload.test.ts` (16 tests)
- `cd frontend && npm run typecheck`
- `cd frontend && npm run typecheck:e2e`
- `cd frontend && AO_AGENT_BROWSER_TEST_BINARY="$PWD/agent-browser/agent-browser" npx vitest run` (177 files, 2,229 tests before the table-specific follow-up)
- `cd frontend && npm run package`
- `cd packages/product-ui && npm run typecheck && npm test && npm run build`
- `cd backend && go build ./... && go test ./...`

## Risk

The Markdown-aware path is scoped to `.markdown-body`; normal page targeting remains unchanged.