### PR TITLE
fix(cli): allow dots in sessionIDPattern to match projectIDPattern

### DIFF
--- a/backend/internal/cli/agent_process_unix_test.go
+++ b/backend/internal/cli/agent_process_unix_test.go
@@ -40,3 +40,34 @@ func TestAgentProcessSuperviseRejectsInvalidGeneration(t *testing.T) {
 		t.Fatal("invalid launch id should be rejected before starting the child")
 	}
 }
+
+// TestAgentProcessSuperviseAcceptsDottedProjectSessionID guards against a
+// regression where AO session ids derived from a dotted project id
+// ("{ProjectID}-{num}", e.g. a project named like a domain) were accepted by
+// projectIDPattern but rejected here, permanently failing every session for
+// that project regardless of num.
+func TestAgentProcessSuperviseAcceptsDottedProjectSessionID(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		In:           strings.NewReader(""),
+		ProcessAlive: func(int) bool { return true },
+	}, "agent-process", "supervise", "--session", "my.project-16", "--launch", "launch-3", "--", "sh", "-c", "printf ok")
+	if err != nil {
+		t.Fatalf("dotted project session id should be accepted: %v\nstderr=%s", err, errOut)
+	}
+	if out != "ok" {
+		t.Fatalf("stdout = %q, want ok", out)
+	}
+}
+
+func TestAgentProcessSuperviseRejectsTraversalSessionID(t *testing.T) {
+	for _, id := range []string{"../evil", "a/b", ".hidden"} {
+		_, _, err := executeCLI(t, Deps{}, "agent-process", "supervise", "--session", id, "--launch", "launch-3", "--", "true")
+		if err == nil {
+			t.Fatalf("session id %q should be rejected", id)
+		}
+	}
+}

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -21,7 +21,14 @@ import (
 // sessionIDPattern bounds the AO_SESSION_ID we will place in a request path to
 // the id alphabet the daemon issues. Validating the externally-set env value
 // before it reaches the loopback URL keeps it from steering the request.
-var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+//
+// Kept in sync with projectIDPattern (service/project/service.go), since AO
+// session ids are derived as "{ProjectID}-{num}": a project id may contain
+// dots, so this pattern must accept them too, or every session for such a
+// project fails validation here regardless of num. A leading dot is still
+// rejected, so ".." / "../" segments remain impossible and the id stays safe
+// to embed in both a URL path segment and a filename.
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
 const (
 	// hooksLogName is the file under AO_DATA_DIR where hook delivery failures

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -13,6 +13,21 @@ import (
 	"testing"
 )
 
+func TestSessionIDPattern(t *testing.T) {
+	accept := []string{"ao-7", "my-project-16", "my.project-16", "a.b.c-1"}
+	for _, id := range accept {
+		if !sessionIDPattern.MatchString(id) {
+			t.Errorf("sessionIDPattern should accept project-derived id %q (dotted project ids must stay usable)", id)
+		}
+	}
+	reject := []string{"", ".hidden", "../evil", "a/b", "..%2f"}
+	for _, id := range reject {
+		if sessionIDPattern.MatchString(id) {
+			t.Errorf("sessionIDPattern should reject %q", id)
+		}
+	}
+}
+
 type activityCapture struct {
 	body string
 	path string


### PR DESCRIPTION
## Summary

AO session ids are derived as `{ProjectID}-{num}` (`storage/sqlite/store/session_store.go`). `projectIDPattern` (`service/project/service.go`) allows dots in a project id, but `sessionIDPattern` — used to validate `--session` before starting the supervised agent process in `agent-process supervise`, and by the hook handlers — did not.

Any project whose id contains a dot (e.g. a domain-name project like `axisrow.github.io`) therefore fails `invalid session id` on **every** session, for every `num`, permanently. Kill+respawn and daemon restarts don't help since the id itself never becomes valid.

Closes #3875.

## What

Widen `sessionIDPattern` to match `projectIDPattern`. A leading dot is still rejected, so `..` / `../` traversal segments remain impossible; the id stays safe to embed in both a URL path segment and a filename.

## Verification

```bash
go test ./internal/cli/...
```

Reproduced live before the fix: spawning a worker in a project with a dot in its id (e.g. `axisrow.github.io`) failed immediately with `invalid session id`, tmux pane exiting instantly. After the fix, the same spawn succeeds and the supervisor process stays alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)