### PR TITLE
fix(reviews): name the reviewer the daemon would actually run

### DIFF
--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -1,4 +1,5 @@
 import type { components } from "../../api/schema";
+import { agentLabel } from "../lib/agent-options";
 import { buildRankedAgentOptions } from "../lib/agent-select-options";
 import { KNOWN_REVIEWER_HARNESS_IDS } from "../lib/reviewer-harnesses";
 import { AgentAvatar } from "./AgentAvatar";
@@ -52,9 +53,12 @@ export function ReviewerSelect({
 	installed?: components["schemas"]["AgentInfo"][];
 	supported?: components["schemas"]["AgentInfo"][];
 }) {
+	// Until the daemon's catalog arrives these entries carry the whole menu, so
+	// label them the way the catalog would rather than printing bare ids: without
+	// this the same row reads "claude-code" now and "Claude Code" a moment later.
 	const fallbackAgents: components["schemas"]["AgentInfo"][] = [...KNOWN_REVIEWER_HARNESS_IDS].map((id) => ({
 		id,
-		label: id,
+		label: agentLabel(id),
 	}));
 	const filteredSupported = (supported ?? fallbackAgents).filter((a) => KNOWN_REVIEWER_HARNESS_IDS.has(a.id));
 	const supportedAgents = filteredSupported.length > 0 ? filteredSupported : fallbackAgents;

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -157,6 +157,40 @@ function mockCommonGets(_unusedRuns: unknown[] = [], reviewerHandleId = "", revi
 	});
 }
 
+// Same shape as mockCommonGets but with no reviewer configured on the project,
+// so the default reviewer has to be derived from the worker's own harness.
+function mockGetsWithoutProjectReviewer() {
+	getMock.mockImplementation(async (path: string) => {
+		if (path === "/api/v1/agents") {
+			const agents = ["claude-code", "codex", "opencode"].map((id) => ({ id, label: id }));
+			return { data: { supported: agents, installed: agents, authorized: agents } };
+		}
+		if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
+			return { data: { sessionId: "sess-1", files: [], truncated: false }, error: undefined };
+		}
+		if (path === "/api/v1/sessions/{sessionId}/reviews") {
+			return { data: { reviewerHandleId: "", reviews: [] } };
+		}
+		if (path === "/api/v1/projects/{id}") {
+			return {
+				data: {
+					status: "ok",
+					project: {
+						id: "ws-1",
+						kind: "git",
+						name: "my-app",
+						path: "/repo",
+						repo: "my-app",
+						defaultBranch: "main",
+						config: {},
+					},
+				},
+			};
+		}
+		return { data: undefined };
+	});
+}
+
 const approvedReview = {
 	id: "run-1",
 	reviewId: "review-1",
@@ -996,7 +1030,10 @@ describe("SessionInspector summary reviews", () => {
 		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "reviewer-pane", harness: "codex" });
 	});
 
-	it("shows claude-code as the default reviewer before a run exists", async () => {
+	// The daemon inherits the worker's harness when no reviewer is configured
+	// (ResolveReviewerHarness), so a codex worker reviews with codex. Naming
+	// claude-code here told the user one agent and ran another.
+	it("names the worker's own harness as the default reviewer before a run exists", async () => {
 		getMock.mockImplementation(async (path: string) => {
 			if (path === "/api/v1/sessions/{sessionId}/reviews") {
 				return { data: { reviewerHandleId: "", reviews: [] } };
@@ -1023,8 +1060,35 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={sessionWithProvider([pr(3, "open")], "codex")} />);
 		await openReviewsSection();
 
-		expect(await screen.findByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("claude-code");
+		expect(await screen.findByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("Codex");
 		expect(screen.queryByText("reviewer")).not.toBeInTheDocument();
+	});
+
+	// A worker whose harness is not in the inherited set falls through to the
+	// daemon's final fallback, which is claude-code. The project config must stay
+	// empty here: a configured reviewer outranks both the worker harness and the
+	// fallback.
+	it("falls back to claude-code when the worker harness is not an inherited reviewer", async () => {
+		mockGetsWithoutProjectReviewer();
+
+		renderWithQuery(<SessionInspector session={sessionWithProvider([pr(3, "open")], "amp")} />);
+		await openReviewsSection();
+
+		expect(await screen.findByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("Claude Code");
+	});
+
+	// The label is a display name, not the wire id: the trigger used to print the
+	// raw harness id, which read as a second, selectable "claude-code" entry
+	// alongside the catalog's properly-cased "Claude Code".
+	it("labels the default reviewer with its display name, not the raw id", async () => {
+		mockGetsWithoutProjectReviewer();
+
+		renderWithQuery(<SessionInspector session={sessionWithProvider([pr(3, "open")], "claude-code")} />);
+		await openReviewsSection();
+
+		const trigger = await screen.findByRole("button", { name: /Select reviewer agent/ });
+		expect(trigger).toHaveTextContent("Claude Code");
+		expect(trigger).not.toHaveTextContent("claude-code");
 	});
 
 	it("hides review summary sections when no review data exists", async () => {
@@ -1083,7 +1147,7 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={session([pr(3, "open"), pr(4, "open"), pr(5, "draft")])} />);
 		await openReviewsSection();
 
-		expect(screen.getByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("codex");
+		expect(screen.getByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("Codex");
 		expect(screen.queryByText("Reviewable change 3")).not.toBeInTheDocument();
 		expect(await screen.findByText("Reviewable change 4")).toBeInTheDocument();
 		expect(
@@ -1648,7 +1712,7 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
 		await openReviewsSection();
 
-		expect(await screen.findByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("codex");
+		expect(await screen.findByRole("button", { name: /Select reviewer agent/ })).toHaveTextContent("Codex");
 		expect(screen.queryByText("reviewer")).not.toBeInTheDocument();
 		expect(screen.queryByText("sess-1")).not.toBeInTheDocument();
 		expect(screen.queryByText("review session")).not.toBeInTheDocument();

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -55,6 +55,8 @@ import { Button } from "./ui/button";
 import { cn } from "../lib/utils";
 import { SessionTerminationPopover } from "./SessionTerminationPopover";
 import { ReviewerSelect } from "./ReviewerSelect";
+import { inheritedReviewerHarness } from "../lib/reviewer-harnesses";
+import { agentLabel } from "../lib/agent-options";
 import { agentsQueryOptions } from "../hooks/useAgentsQuery";
 import { Switch } from "./ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
@@ -1342,7 +1344,14 @@ function ReviewPanel({
 		.filter((run): run is NonNullable<typeof run> => Boolean(run))
 		.sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
 	const latest = runningRun ?? newestRun;
-	const harness = latest?.harness || config?.reviewers?.[0]?.harness || "claude-code";
+	// Name the reviewer the daemon would actually pick. Its resolution order is
+	// session preference, then project config, then the worker's own harness when
+	// that harness is a supported reviewer, and claude-code only as the final
+	// fallback (see ResolveReviewerHarness). Omitting the worker step made this
+	// label claim claude-code for a codex worker with no project config, so the
+	// pane named one agent while a different one ran.
+	const harness =
+		latest?.harness || config?.reviewers?.[0]?.harness || inheritedReviewerHarness(session.provider) || "claude-code";
 	const projectDefaultLabel = t("newTask.projectDefault");
 	const hasReviewerSession = reviewerHandleId.trim() !== "";
 	const reviewRunning = openReviewStates.some((reviewState) => reviewState.status === "running");
@@ -1403,8 +1412,8 @@ function ReviewPanel({
 							ariaLabel={t("inspector.selectReviewerAgent")}
 							authorized={agentCatalog?.authorized}
 							defaultHarness={harness}
-							defaultOptionLabel={harness ? `${projectDefaultLabel} (${harness})` : projectDefaultLabel}
-							defaultTriggerLabel={harness || projectDefaultLabel}
+							defaultOptionLabel={harness ? `${projectDefaultLabel} (${agentLabel(harness)})` : projectDefaultLabel}
+							defaultTriggerLabel={harness ? agentLabel(harness) : projectDefaultLabel}
 							disabled={reviewRunning || isKilling || isSwitchingReviewer || isTriggering || isCancelling}
 							installed={agentCatalog?.installed}
 							onChange={(next) => onReviewerOverrideChange(next as ReviewerHarness | "")}

--- a/frontend/src/renderer/lib/reviewer-harnesses.ts
+++ b/frontend/src/renderer/lib/reviewer-harnesses.ts
@@ -47,3 +47,23 @@ export const KNOWN_REVIEWER_HARNESS_IDS: ReadonlySet<string> = new Set(REVIEWER_
 export function toReviewerHarnessId(value?: string): ReviewerHarnessId | undefined {
 	return value && KNOWN_REVIEWER_HARNESS_IDS.has(value) ? (value as ReviewerHarnessId) : undefined;
 }
+
+// Mirrors domain.ProjectConfig.ResolveReviewerHarness: with no project reviewer
+// configured, only this original, unattended-safe set is inherited from the
+// worker's own harness. Every other reviewer requires an explicit choice, so a
+// new experimental adapter never silently becomes a project's reviewer. Keep
+// this list in step with the daemon's switch — it is deliberately much narrower
+// than KNOWN_REVIEWER_HARNESS_IDS.
+const WORKER_INHERITED_REVIEWER_IDS: ReadonlySet<string> = new Set([
+	"claude-code",
+	"codex",
+	"opencode",
+	"muse",
+	"kimchi",
+] satisfies readonly ReviewerHarnessId[]);
+
+// The reviewer a worker harness contributes when nothing else names one, or
+// undefined when that harness is not inherited and the caller must fall back.
+export function inheritedReviewerHarness(worker?: string): ReviewerHarnessId | undefined {
+	return worker && WORKER_INHERITED_REVIEWER_IDS.has(worker) ? (worker as ReviewerHarnessId) : undefined;
+}


### PR DESCRIPTION
## Summary

The Review panel resolved its default-reviewer label in three steps — last run, project config, then a hardcoded `claude-code` — while the daemon resolves in four: session preference, project config, the worker's own harness when that harness is an inherited reviewer, and `claude-code` only as the final fallback.

The missing worker step is the whole bug. A codex worker in a project with no configured reviewer was labelled `claude-code`, and pressing Run started codex. Picking Claude Code from the menu is what made the two agree, because that writes a session preference and both sides then take their first branch.

Closes #3914.

## What

- `inheritedReviewerHarness` mirrors `ResolveReviewerHarness`'s switch rather than the full reviewer vocabulary: only the original unattended-safe set is inherited, so a new experimental adapter never silently becomes a project's reviewer.
- Label the picker with display names instead of wire ids. The trigger printed the raw harness id while the menu row for the same agent printed the catalog's "Claude Code", so one agent read as two entries — which is what made the mismatch look like a duplicate. `ReviewerSelect`'s pre-catalog fallback options had the same problem from the other end: they carried `label: id`, so the entire menu was lowercase until `/api/v1/agents` resolved and then flipped case.
- The existing "shows claude-code as the default reviewer before a run exists" test pinned the wrong behaviour for a codex worker; it now asserts the inherited harness.

## Verification

```bash
npm run frontend:typecheck
npx vitest run src/renderer/components/SessionInspector.test.tsx   # 77 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)