### PR TITLE
fix(board): prevent card metadata overlap

### DIFF
--- a/frontend/e2e/smoke-board.spec.ts
+++ b/frontend/e2e/smoke-board.spec.ts
@@ -43,7 +43,7 @@ test("renderer: SSE pushes card updates without a manual refresh @T0 @BRD", asyn
 	await expect(page.locator(columnCard("merge", "live"))).toContainText("Ready");
 });
 
-test("renderer: narrow card metadata wraps without clipping the status @BRD", async ({ page }) => {
+test("renderer: narrow card status truncates without overlapping metadata @BRD", async ({ page }) => {
 	await installFakeAgent(page, {
 		workers: [{ id: "review", title: "Review worker", status: "review_pending", activity: "idle" }],
 	});
@@ -70,12 +70,17 @@ test("renderer: narrow card metadata wraps without clipping the status @BRD", as
 	const statusMetrics = await status.evaluate((element) => ({
 		clientWidth: element.clientWidth,
 		scrollWidth: element.scrollWidth,
+		overflow: getComputedStyle(element).overflow,
+		textOverflow: getComputedStyle(element).textOverflow,
+		whiteSpace: getComputedStyle(element).whiteSpace,
 	}));
 	const statusBox = await status.boundingBox();
 	const usageBox = await usage.boundingBox();
 
-	expect(statusMetrics.scrollWidth).toBeLessThanOrEqual(statusMetrics.clientWidth);
+	expect(statusMetrics.scrollWidth).toBeGreaterThan(statusMetrics.clientWidth);
+	expect(statusMetrics).toMatchObject({ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" });
 	expect(statusBox).not.toBeNull();
 	expect(usageBox).not.toBeNull();
-	expect(usageBox!.y).toBeGreaterThanOrEqual(statusBox!.y + statusBox!.height);
+	expect(Math.abs(usageBox!.y - statusBox!.y)).toBeLessThan(2);
+	expect(statusBox!.x + statusBox!.width).toBeLessThanOrEqual(usageBox!.x);
 });

--- a/frontend/e2e/smoke-board.spec.ts
+++ b/frontend/e2e/smoke-board.spec.ts
@@ -42,3 +42,40 @@ test("renderer: SSE pushes card updates without a manual refresh @T0 @BRD", asyn
 	await expect(page.locator(columnCard("merge", "live"))).toBeVisible();
 	await expect(page.locator(columnCard("merge", "live"))).toContainText("Ready");
 });
+
+test("renderer: narrow card metadata wraps without clipping the status @BRD", async ({ page }) => {
+	await installFakeAgent(page, {
+		workers: [{ id: "review", title: "Review worker", status: "review_pending", activity: "idle" }],
+	});
+	await page.route("**/api/v1/usage/sessions**", (route) =>
+		route.fulfill({
+			contentType: "application/json",
+			body: JSON.stringify({
+				sessions: [{ sessionId: "review", totalTokens: 24_600_000, incomplete: false }],
+			}),
+		}),
+	);
+	await page.goto("/#/");
+
+	const card = page.locator(columnCard("pending", "review"));
+	const status = card.getByText("Review pending", { exact: true });
+	const usage = card.getByText("24.6M tok", { exact: true });
+	await expect(usage).toBeVisible();
+
+	// Reproduce the effective card width reached at enlarged browser zoom.
+	await card.evaluate((element) => {
+		(element as HTMLElement).style.width = "12rem";
+	});
+
+	const statusMetrics = await status.evaluate((element) => ({
+		clientWidth: element.clientWidth,
+		scrollWidth: element.scrollWidth,
+	}));
+	const statusBox = await status.boundingBox();
+	const usageBox = await usage.boundingBox();
+
+	expect(statusMetrics.scrollWidth).toBeLessThanOrEqual(statusMetrics.clientWidth);
+	expect(statusBox).not.toBeNull();
+	expect(usageBox).not.toBeNull();
+	expect(usageBox!.y).toBeGreaterThanOrEqual(statusBox!.y + statusBox!.height);
+});

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -263,7 +263,7 @@ describe("SessionsBoard", () => {
 		const terminateButton = within(idleCard).getByRole("button", { name: "Terminate brand-font-pipeline" });
 		expect(terminateButton).toHaveClass("opacity-0", "group-hover:opacity-100", "group-focus-within:opacity-100");
 		expect(terminateButton.querySelector("svg")).toHaveClass("lucide-trash-2");
-		expect(within(idleCard).getByText("Idle").parentElement).toHaveClass("flex", "justify-between");
+		expect(within(idleCard).getByText("Idle").parentElement?.parentElement).toHaveClass("flex");
 		expect(within(idleCard).getByText("brand-font-pipeline")).toHaveClass("font-semibold", "line-clamp-2");
 	});
 
@@ -341,8 +341,8 @@ describe("SessionsBoard", () => {
 
 		renderBoard("p1");
 		const card = screen.getByText("active-card-task").closest('[data-testid="board-session-card"]') as HTMLElement;
-		const working = within(card).getByText("Working").closest("span") as HTMLElement;
-		expect(working.querySelector("span")).toHaveClass("bg-status-working", "animate-status-pulse");
+		const working = within(card).getByText("Working").parentElement as HTMLElement;
+		expect(working.querySelector('[aria-hidden="true"]')).toHaveClass("bg-status-working", "animate-status-pulse");
 	});
 
 	it("keeps a spawning card labeled Working when raw activity has not become active", () => {
@@ -422,9 +422,9 @@ describe("SessionsBoard", () => {
 		const noSignalCard = screen.getByText("no-signal-card-task").closest('[data-testid="board-session-card"]') as HTMLElement;
 		const draftCard = screen.getByText("draft-card-task").closest('[data-testid="board-session-card"]') as HTMLElement;
 
-		expect(within(idleCard).getByText("Idle").closest("span")).toHaveClass("text-status-idle");
-		expect(within(noSignalCard).getByText("No signal").closest("span")).toHaveClass("text-status-unknown");
-		expect(within(draftCard).getByText("Draft PR").closest("span")).toHaveClass("text-status-in-review");
+		expect(within(idleCard).getByText("Idle").parentElement).toHaveClass("text-status-idle");
+		expect(within(noSignalCard).getByText("No signal").parentElement).toHaveClass("text-status-unknown");
+		expect(within(draftCard).getByText("Draft PR").parentElement).toHaveClass("text-status-in-review");
 	});
 
 	it("places an exited live session in Needs you with an Exited badge", () => {
@@ -454,7 +454,7 @@ describe("SessionsBoard", () => {
 		const needsYouColumn = screen.getByText("Needs you").closest("section") as HTMLElement;
 		expect(needsYouColumn.firstElementChild).toHaveClass("h-12");
 		expect(within(needsYouColumn).getByText("agent-exited-task")).toBeInTheDocument();
-		expect(within(needsYouColumn).getByText("Exited").closest("span")).toHaveClass("text-status-exited");
+		expect(within(needsYouColumn).getByText("Exited").parentElement).toHaveClass("text-status-exited");
 	});
 
 	it("renders an idle-first work lane with a separate lower working section", () => {
@@ -531,7 +531,7 @@ describe("SessionsBoard", () => {
 		expect(within(workLane).queryByText("idle-with-pr-task")).not.toBeInTheDocument();
 
 		const idleCard = screen.getByText("idle-no-pr-task").closest('[data-testid="board-session-card"]') as HTMLElement;
-		const badge = within(idleCard).getByText("Idle").closest("span");
+		const badge = within(idleCard).getByText("Idle").parentElement;
 		expect(badge).toHaveClass("text-status-idle");
 		expect(badge).not.toHaveClass("text-status-working");
 	});
@@ -1145,7 +1145,7 @@ describe("SessionsBoard", () => {
 		expect(
 			within(archivedMergedCard!).queryByRole("button", { name: "Terminate archived merged worker" }),
 		).not.toBeInTheDocument();
-		expect(within(archivedMergedCard!).getByText("Merged").closest("span")).toHaveClass("text-status-merged");
+		expect(within(archivedMergedCard!).getByText("Merged").parentElement).toHaveClass("text-status-merged");
 		expect(within(archive).getByRole("button", { name: "Restore archived merged worker" })).toBeInTheDocument();
 	});
 

--- a/packages/product-ui/src/SessionsBoardView.test.tsx
+++ b/packages/product-ui/src/SessionsBoardView.test.tsx
@@ -112,7 +112,7 @@ describe("SessionsBoardView", () => {
 		expect(onOpen).toHaveBeenCalledOnce();
 	});
 
-	it("wraps card metrics below the status before the labels can collide", () => {
+	it("truncates the status before card metrics can collide", () => {
 		render(
 			<SessionCardView
 				externalLink={ExternalLink}
@@ -131,10 +131,13 @@ describe("SessionsBoardView", () => {
 			/>,
 		);
 
-		const status = screen.getByText("Review pending");
-		const metadataRow = status.parentElement;
-		expect(status).toHaveClass("shrink-0");
-		expect(metadataRow).toHaveClass("flex-wrap", "gap-x-2", "gap-y-1");
+		const statusLabel = screen.getByText("Review pending");
+		const status = statusLabel.parentElement;
+		const metadataRow = status?.parentElement;
+		expect(statusLabel).toHaveClass("min-w-0", "truncate");
+		expect(status).toHaveClass("min-w-0", "flex-1");
+		expect(metadataRow).toHaveClass("flex", "items-center", "gap-2");
+		expect(metadataRow).not.toHaveClass("flex-wrap");
 		expect(screen.getByText("24.6M tok").parentElement).toHaveClass("shrink-0", "whitespace-nowrap");
 	});
 

--- a/packages/product-ui/src/SessionsBoardView.test.tsx
+++ b/packages/product-ui/src/SessionsBoardView.test.tsx
@@ -112,6 +112,32 @@ describe("SessionsBoardView", () => {
 		expect(onOpen).toHaveBeenCalledOnce();
 	});
 
+	it("wraps card metrics below the status before the labels can collide", () => {
+		render(
+			<SessionCardView
+				externalLink={ExternalLink}
+				labels={{
+					formatTime: () => "1h ago",
+					intakeIssue: (id) => `Issue ${id}`,
+					pr: {
+						short: "PR",
+						states: { closed: "closed", draft: "draft", merged: "merged", open: "open" },
+					},
+					updatedAt: (timestamp) => `Updated ${timestamp}`,
+				}}
+				renderAvatar={(provider) => <span role="img" aria-label={provider}>C</span>}
+				session={{ ...baseSession, status: "review_pending" }}
+				usage={{ accessibleLabel: "24,600,000 tokens", compactLabel: "24.6M tok" }}
+			/>,
+		);
+
+		const status = screen.getByText("Review pending");
+		const metadataRow = status.parentElement;
+		expect(status).toHaveClass("shrink-0");
+		expect(metadataRow).toHaveClass("flex-wrap", "gap-x-2", "gap-y-1");
+		expect(screen.getByText("24.6M tok").parentElement).toHaveClass("shrink-0", "whitespace-nowrap");
+	});
+
 	it("keeps archive expansion controlled and preserves the grid list", () => {
 		const onExpandedChange = vi.fn();
 		const { rerender } = render(

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -464,9 +464,9 @@ export function SessionCardView({
 			</div>
 			<div aria-hidden="true" className="mx-3.5 my-px h-px bg-border" />
 			<div className="flex flex-col gap-1.5 px-3.5 py-2">
-				<div className="flex items-center justify-between gap-2">
+				<div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
 					<span
-						className={cn("inline-flex min-w-0 items-center gap-1.5 truncate text-2xs font-medium", badge.className)}
+						className={cn("inline-flex shrink-0 items-center gap-1.5 text-2xs font-medium", badge.className)}
 						style={showLiveActivity ? { color: activity.tone } : undefined}
 					>
 						<span

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -464,9 +464,9 @@ export function SessionCardView({
 			</div>
 			<div aria-hidden="true" className="mx-3.5 my-px h-px bg-border" />
 			<div className="flex flex-col gap-1.5 px-3.5 py-2">
-				<div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
+				<div className="flex items-center gap-2">
 					<span
-						className={cn("inline-flex shrink-0 items-center gap-1.5 text-2xs font-medium", badge.className)}
+						className={cn("inline-flex min-w-0 flex-1 items-center gap-1.5 text-2xs font-medium", badge.className)}
 						style={showLiveActivity ? { color: activity.tone } : undefined}
 					>
 						<span
@@ -476,7 +476,7 @@ export function SessionCardView({
 								showLiveActivity ? activity.indicatorClassName : "bg-current",
 							)}
 						/>
-						{badge.label}
+						<span className="min-w-0 truncate">{badge.label}</span>
 					</span>
 					<div className="ml-auto flex shrink-0 items-center gap-1.5 whitespace-nowrap font-mono text-2xs text-passive">
 						{usage ? renderUsage(usage) : null}


### PR DESCRIPTION
## Summary

- keep session-card status, token usage, and timestamp on a single metadata row
- ellipsize the flexible status label before it can intersect fixed token/time metadata at enlarged zoom
- add unit and Playwright coverage for the narrow-card layout

## Tests

- `npm --prefix packages/product-ui test` (50 passed)
- `npm --prefix packages/product-ui run typecheck`
- `npm --prefix packages/product-ui run build`
- `npm --prefix frontend test -- SessionsBoard` (36 passed)
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run typecheck:e2e`
- `npx playwright test e2e/smoke-board.spec.ts` from `frontend/` (3 passed)

## Risk

Low. The change is limited to the shared session-card metadata row. The status label now owns the flexible width and truncates with an ellipsis; token usage and time remain fixed and readable.