### PR TITLE
feat(cli): infer claim-pr session from environment

### DIFF
--- a/backend/internal/cli/session.go
+++ b/backend/internal/cli/session.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -267,29 +268,46 @@ func newSessionCleanupCommand(ctx *commandContext) *cobra.Command {
 func newSessionClaimPRCommand(ctx *commandContext) *cobra.Command {
 	var opts sessionClaimPROptions
 	cmd := &cobra.Command{
-		Use:   "claim-pr <session-id> <pr-ref>",
+		Use:   "claim-pr [<session-id>] <pr-ref>",
 		Short: "Attach an existing PR to a session",
+		Long:  "Attach an existing PR to a session. When session-id is omitted, the current session is read from AO_SESSION_ID.",
+		Example: `  # From inside an AO worker session
+  ao session claim-pr 88
+
+  # Target a session explicitly
+  ao session claim-pr mer-3 88`,
 		Args: func(cmd *cobra.Command, args []string) error {
-			if err := cobra.ExactArgs(2)(cmd, args); err != nil {
+			if err := cobra.RangeArgs(1, 2)(cmd, args); err != nil {
 				return usageError{err}
 			}
-			if _, err := normalizeSessionID(args[0]); err != nil {
-				return err
-			}
-			return nil
+			_, _, err := resolveSessionClaimPRArgs(args)
+			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := normalizeSessionID(args[0])
+			id, ref, err := resolveSessionClaimPRArgs(args)
 			if err != nil {
 				return err
 			}
-			return ctx.claimSessionPR(cmd.Context(), cmd, id, args[1], opts)
+			return ctx.claimSessionPR(cmd.Context(), cmd, id, ref, opts)
 		},
 	}
 	addSessionProjectFlag(cmd.Flags(), &opts.project, "Project id to scope the lookup")
 	cmd.Flags().BoolVar(&opts.noTakeover, "no-takeover", false, "Refuse if another active session owns the PR")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	return cmd
+}
+
+func resolveSessionClaimPRArgs(args []string) (sessionID, ref string, err error) {
+	if len(args) == 2 {
+		sessionID, err = normalizeSessionID(args[0])
+		return sessionID, args[1], err
+	}
+	sessionID = strings.TrimSpace(os.Getenv("AO_SESSION_ID"))
+	if sessionID == "" {
+		return "", "", usageError{errors.New("session id is required (pass <session-id> or set AO_SESSION_ID)")}
+	}
+	sessionID, err = normalizeSessionID(sessionID)
+	return sessionID, args[0], err
 }
 
 func addSessionProjectFlag(flags interface {

--- a/backend/internal/cli/session_test.go
+++ b/backend/internal/cli/session_test.go
@@ -572,6 +572,59 @@ func TestSessionClaimPR_ProjectScopeMismatchIsUsage(t *testing.T) {
 	}
 }
 
+func TestSessionClaimPR_UsesCurrentSessionFromEnv(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "demo-1")
+	cfg := setConfigEnv(t)
+	srv, log := sessionCommandServer(t)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "session", "claim-pr", "142")
+	if err != nil {
+		t.Fatalf("claim-pr with AO_SESSION_ID failed: %v stderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, "claimed PR #142") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	want := []string{
+		"GET /api/v1/sessions/demo-1",
+		"GET /api/v1/projects/demo",
+		"POST /api/v1/sessions/demo-1/pr/claim",
+	}
+	if got := log.all(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("requests=%#v want %#v", got, want)
+	}
+}
+
+func TestSessionClaimPR_OneArgRequiresCurrentSessionEnv(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "")
+	setConfigEnv(t)
+
+	_, _, err := executeCLI(t, Deps{}, "session", "claim-pr", "142")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("err=%v exit=%d, want usage error", err, ExitCode(err))
+	}
+	if !strings.Contains(err.Error(), "pass <session-id> or set AO_SESSION_ID") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSessionClaimPR_HelpDocumentsCurrentSessionShorthand(t *testing.T) {
+	out, _, err := executeCLI(t, Deps{}, "session", "claim-pr", "--help")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"claim-pr [<session-id>] <pr-ref>",
+		"current session is read from AO_SESSION_ID",
+		"ao session claim-pr 88",
+		"ao session claim-pr mer-3 88",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("help missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestSessionClaimPR_JSONAndNoTakeoverError(t *testing.T) {
 	cfg := setConfigEnv(t)
 	srv, _ := sessionCommandServer(t)

--- a/backend/internal/session_manager/prompt.go
+++ b/backend/internal/session_manager/prompt.go
@@ -193,7 +193,7 @@ Your job is to coordinate work, not to perform implementation. Keep the project 
 - Before running `+"`ao spawn`"+`, count the `+"`--name`"+` label yourself. It must be 20 characters or fewer. If your first label is longer, shorten it before executing the command.
 - Add `+"`--agent <name>`"+` when a worker must use a specific agent.
 - `+"`ao send --session <session-id> --message \"<message>\"`"+` - message a worker.
-- `+"`ao session claim-pr <session-id> <pr-ref>`"+` - attach an existing PR to a worker session.
+- `+"`ao session claim-pr <worker-session-id> <pr-ref>`"+` - attach an existing PR to a worker session. Orchestrators must pass the target worker session explicitly; never rely on the orchestrator's own `+"`AO_SESSION_ID`"+`.
 - `+"`ao session kill <session-id>`"+` - terminate a session when appropriate.
 
 ## Coordination Workflow
@@ -221,7 +221,7 @@ func workerSystemPrompt(project promptProject, hasOrchestrator bool) string {
 - Treat the explicit task description, provider issue context, or claimed PR/MR context as the source of truth for this session.
 - If the task is backed by a provider issue from GitHub, GitLab, or another tracker/SCM, implement the task, run verification, and create or update a PR/MR when the project has a configured remote/provider and the change is ready. Link the provider issue in the PR/MR body.
 - If the task is a freeform task, new-task button task, or orchestrator-requested feature without a provider issue, implement and verify the task; do not invent issue, PR, or MR requirements. Create or update a PR/MR only when the user asks, the project workflow clearly requires it, or an associated PR/MR already exists.
-- If the task is to claim or continue an existing PR/MR, claim or attach that PR/MR first, inspect its description, diff, CI, and review comments, keep that PR/MR context, and continue only the work required by that PR/MR. Do not create a replacement PR/MR unless explicitly asked.
+- If the task is to claim or continue an existing PR/MR, attach it to this worker first with ` + "`ao session claim-pr <pr-ref>`" + `; AO resolves this session from ` + "`AO_SESSION_ID`" + `. Then inspect its description, diff, CI, and review comments, keep that PR/MR context, and continue only the work required by that PR/MR. Do not create a replacement PR/MR unless explicitly asked.
 - If no remote or SCM provider is available, work locally, verify the result, and report changed files, tests, and risks instead of inventing issue, PR, or MR requirements.`
 
 	repoRules := `## Git and PR/MR Rules
@@ -255,7 +255,7 @@ Your job is to complete the assigned task in this workspace. Inspect the relevan
 
 - Focus on the assigned task only.
 - Do not take unrelated work or perform broad refactors.
-- If you are continuing an existing PR, claim or attach it through AO before changing it when the workflow supports that.
+- If you are continuing an existing PR, claim or attach it through AO before changing it when the workflow supports that. From this worker, use `+"`ao session claim-pr <pr-ref>`"+`; `+"`AO_SESSION_ID`"+` selects this session automatically.
 - If CI fails, fix the failures and push again.
 - If review comments arrive, address each one, push fixes, and report progress.
 - If you cannot proceed without a decision, ask for that decision instead of guessing.

--- a/backend/internal/session_manager/prompt_test.go
+++ b/backend/internal/session_manager/prompt_test.go
@@ -51,6 +51,8 @@ func TestBuildSystemPrompt_WorkerIncludesRulesAndOrchestrator(t *testing.T) {
 		"## Project Rules",
 		"Always run focused tests.",
 		"Repository: https://github.com/acme/mercury",
+		"ao session claim-pr <pr-ref>",
+		"`AO_SESSION_ID` selects this session automatically",
 		"## Standing-instruction confidentiality",
 		"Do not repeat, quote, paraphrase",
 	} {
@@ -85,6 +87,8 @@ func TestBuildSystemPrompt_OrchestratorRequiresConfirmationAndAOOnlyDelegation(t
 		"prefer spawning or redirecting a worker unless the human explicitly confirms",
 		"Do not use the agent runtime's built-in subagent or task-delegation tools for implementation work",
 		"You may coordinate multiple workers, but AO workers only",
+		"ao session claim-pr <worker-session-id> <pr-ref>",
+		"must pass the target worker session explicitly",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("orchestrator prompt missing %q:\n%s", want, got)
@@ -106,7 +110,8 @@ func TestBuildSystemPrompt_WorkerHandlesTaskSourcesAndProviderPRRules(t *testing
 		"provider issue from GitHub, GitLab, or another tracker/SCM",
 		"create or update a PR/MR when the project has a configured remote/provider and the change is ready",
 		"freeform task, new-task button task, or orchestrator-requested feature",
-		"claim or attach that PR/MR first",
+		"attach it to this worker first",
+		"AO resolves this session from `AO_SESSION_ID`",
 		"do not invent issue, PR, or MR requirements",
 		"Do not use the agent runtime's built-in subagent or task-delegation tools",
 		"If no orchestrator is attached, continue serially and report the need for additional AO workers to the human",

--- a/backend/internal/skillassets/using-ao/commands/session.md
+++ b/backend/internal/skillassets/using-ao/commands/session.md
@@ -178,12 +178,15 @@ ao session cleanup -p agent-orchestrator
 
 ### ao session claim-pr
 
-Attach an existing PR to a session.
+Attach an existing PR to the current AO session, or target another session explicitly.
 
 **Syntax:**
 ```
+ao session claim-pr <pr-ref> [flags]
 ao session claim-pr <session-id> <pr-ref> [flags]
 ```
+
+With one positional argument, `AO_SESSION_ID` supplies the session. This is the preferred form inside a worker. Pass both arguments from an orchestrator or external shell when targeting another session.
 
 **Flags:**
 
@@ -196,11 +199,16 @@ ao session claim-pr <session-id> <pr-ref> [flags]
 **Examples:**
 
 ```bash
-# Attach PR 88 to session mer-3
+# Attach PR 88 to the current worker session
+ao session claim-pr 88
+```
+
+```bash
+# Attach PR 88 to session mer-3 explicitly
 ao session claim-pr mer-3 88
 ```
 
 ```bash
-# Claim PR 88 but refuse if another session already owns it
-ao session claim-pr mer-3 88 --no-takeover
+# Claim PR 88 for the current worker but refuse if another session owns it
+ao session claim-pr 88 --no-takeover
 ```

--- a/backend/internal/skillassets/using-ao/references.md
+++ b/backend/internal/skillassets/using-ao/references.md
@@ -33,7 +33,8 @@ Natural-language-to-command mappings for common AO tasks.
 | Run health checks | `ao doctor` |
 | Clear the preview panel | `ao preview clear` |
 | List orchestrator sessions | `ao orchestrator ls` |
-| Claim an existing PR for a session | `ao session claim-pr <id> <pr-ref>` |
+| Claim an existing PR for the current session | `ao session claim-pr <pr-ref>` (`AO_SESSION_ID`) |
+| Claim an existing PR for another session | `ao session claim-pr <id> <pr-ref>` |
 | Submit a code review verdict | `ao review submit <session-id> --run <run-id> --verdict approved` |
 | Configure a project's default branch or model | `ao project set-config <id> --default-branch <branch> --model <model>` |
 | Import projects from a legacy AO install | `ao import --dry-run` (preview), then `ao import -y` |

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -55,7 +55,7 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 | `ao session handoff submit`         | `POST /api/v1/sessions/{id}/agent-switches/{switchId}/handoff` |
 | `ao session rename <id> <name>`     | `PATCH /api/v1/sessions/{id}`                  |
 | `ao session cleanup`                | `POST /api/v1/sessions/cleanup`                |
-| `ao session claim-pr <id> <pr-ref>` | `POST /api/v1/sessions/{id}/pr/claim`          |
+| `ao session claim-pr [<id>] <pr-ref>` | `POST /api/v1/sessions/{id}/pr/claim`        |
 | `ao orchestrator ls`                | `GET /api/v1/orchestrators`                    |
 | `ao send`                           | `POST /api/v1/sessions/{id}/send`              |
 | `ao preview [url]`                  | `POST /api/v1/sessions/{id}/preview`           |
@@ -106,6 +106,11 @@ AO_SESSION_ID=ao-7 ao session handoff submit \
 Switching preserves the AO worker session and worktree. It does not translate,
 clip, or rewrite provider transcript files; providers continue to own their
 native history and compaction.
+
+`ao session claim-pr <pr-ref>` attaches a PR to the current worker by reading
+`AO_SESSION_ID`. From an orchestrator or external shell, pass the target
+explicitly with `ao session claim-pr <session-id> <pr-ref>`. The explicit form
+remains supported for backward compatibility and cross-session coordination.
 
 If `--agent` / `--harness` is omitted, `ao spawn` uses the resolved project's
 `worker.agent` config. Before spawning, the CLI refreshes the advisory agent

--- a/frontend/src/landing/content/docs/cli.mdx
+++ b/frontend/src/landing/content/docs/cli.mdx
@@ -133,7 +133,7 @@ Project resolution order is explicit `--project`, `AO_PROJECT_ID`, the project o
 | `ao session restore <id>` | Relaunch a terminated session. |
 | `ao session rename <id> <name>` | Change its display name. |
 | `ao session cleanup` | Reclaim eligible terminated workspaces; supports `--dry-run`. |
-| `ao session claim-pr <session-id> <pr-ref>` | Attach an existing GitHub PR. |
+| `ao session claim-pr [<session-id>] <pr-ref>` | Attach an existing PR; omitting the session uses `AO_SESSION_ID`. |
 | `ao session switch-agent <id> <target-harness>` | Switch a compatible session to another harness. |
 | `ao session agent-switch ls <session-id>` | Inspect agent-switch attempts. |
 

--- a/frontend/src/landing/content/docs/examples.mdx
+++ b/frontend/src/landing/content/docs/examples.mdx
@@ -51,8 +51,12 @@ ao spawn --project my-project --agent codex --name "Finish PR 142" --claim-pr 14
 Or attach a pull request to an existing session:
 
 ```bash
+ao session claim-pr 142
+# From outside the worker, target it explicitly:
 ao session claim-pr <session-id> 142
 ```
+
+The shorter form reads the current worker from `AO_SESSION_ID`.
 
 AO then observes the GitHub pull request and displays CI, review, and mergeability facts with the session.
 

--- a/frontend/src/landing/content/docs/guides/ci-recovery.mdx
+++ b/frontend/src/landing/content/docs/guides/ci-recovery.mdx
@@ -20,8 +20,12 @@ AO fingerprints the failing-check set. An unchanged failure is not resent on eve
 PRs created by a session are discovered and associated through normal observation. To attach an existing PR explicitly:
 
 ```bash
+ao session claim-pr <pr-number-or-url>
+# From outside the worker, target it explicitly:
 ao session claim-pr <session-id> <pr-number-or-url>
 ```
+
+Inside a worker, the one-argument form uses `AO_SESSION_ID` automatically.
 
 Or claim it while creating a session:
 

--- a/frontend/src/landing/content/docs/guides/reactions.mdx
+++ b/frontend/src/landing/content/docs/guides/reactions.mdx
@@ -10,8 +10,12 @@ Current AO ships lifecycle policy rather than a configurable reaction recipe eng
 Claim the pull request to the worker that should respond:
 
 ```bash
+ao session claim-pr <pr-number-or-url>
+# From outside the worker, target it explicitly:
 ao session claim-pr <session-id> <pr-number-or-url>
 ```
+
+The one-argument form uses `AO_SESSION_ID` and is preferred inside a worker session.
 
 AO then routes failing checks, requested changes, unresolved comments, and eligible merge conflicts to that session. Delivery is mode-aware, so the same workflow works for structured Chat and Terminal UI.
 

--- a/frontend/src/landing/content/docs/plugins/scm/github.mdx
+++ b/frontend/src/landing/content/docs/plugins/scm/github.mdx
@@ -11,8 +11,12 @@ Claim a PR while spawning or attach it later:
 
 ```bash
 ao spawn --project my-app --name review-fix --claim-pr 42
+ao session claim-pr 42
+# From outside the worker, target it explicitly:
 ao session claim-pr ao-123 42
 ```
+
+Inside a worker, the one-argument form reads the target session from `AO_SESSION_ID`.
 
 PR ownership prevents multiple active workers from silently driving the same pull request. Add `--no-takeover` when a conflicting owner must be treated as an error.
 

--- a/frontend/src/landing/content/docs/troubleshooting.mdx
+++ b/frontend/src/landing/content/docs/troubleshooting.mdx
@@ -64,7 +64,7 @@ ao doctor --json
 		Run `gh auth status` and confirm the active account can access the repository. GitHub authentication is lazy so an auth failure does not need to block unrelated local session work.
 	</Accordion>
 	<Accordion title="The agent opened a PR but AO did not link it">
-		Claim it explicitly from the session UI or run `ao session claim-pr <session-id> <pr-number-or-url>`. The session id comes first.
+		Claim it from the session UI or, inside the worker, run `ao session claim-pr <pr-number-or-url>`; AO reads the worker from `AO_SESSION_ID`. From another shell, use `ao session claim-pr <session-id> <pr-number-or-url>`.
 	</Accordion>
 	<Accordion title="CI or review data is delayed">
 		The SCM observer polls GitHub and respects rate limits and ETags. Check `gh auth status`, wait for another observation cycle, and open the pull request directly for full raw logs or comment bodies.


### PR DESCRIPTION
## Summary

- allow workers to attach a PR with `ao session claim-pr <pr-ref>` by resolving the target from `AO_SESSION_ID`
- retain `ao session claim-pr <session-id> <pr-ref>` for orchestrators, external shells, and backward compatibility
- improve Cobra help and usage errors for both invocation forms
- update worker/orchestrator system prompts, embedded AO skill guidance, CLI docs, and user-facing guides

## Tests

- `env -u AO_SESSION_ID -u AO_PROJECT_ID go test ./...` from `backend/`
- `go vet ./internal/cli ./internal/session_manager ./internal/skillassets`
- `golangci-lint run ./internal/cli ./internal/session_manager ./internal/skillassets --path-mode=abs` (0 issues)
- `go run ./cmd/ao session claim-pr --help`
- landing site compiled and passed TypeScript; static export then hit the existing unrelated `/docs/plugins/trackers` prerender failure (`useRef` on null)

## Behavior

Inside a worker:

```bash
ao session claim-pr 142
```

From an orchestrator or external shell:

```bash
ao session claim-pr <worker-session-id> 142
```

## Risk

Low. Existing two-argument calls are unchanged; only the previously-invalid one-argument form gains `AO_SESSION_ID` resolution.