### PR TITLE
fix(desktop): keep reviewer terminal reachable in Chat mode

### DIFF
--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -133,10 +133,25 @@ const { workspaces, workspaceQueryState, panels, shellTerminalsState } = vi.hois
 // platform hides the shell topbar, SessionView mounts it in-panel.)
 vi.mock("./ShellTopbar", () => ({ ShellTopbar: () => null }));
 vi.mock("./chat/SessionChatSurface", () => ({
-	SessionChatSurface: ({ onOpenShell, headerActions }: { onOpenShell?: () => void; headerActions?: ReactNode }) => (
+	SessionChatSurface: ({
+		onOpenShell,
+		headerActions,
+		reviewerTerminal,
+		onOpenReviewerTerminal,
+	}: {
+		onOpenShell?: () => void;
+		headerActions?: ReactNode;
+		reviewerTerminal?: { handleId: string; harness: string };
+		onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
+	}) => (
 		<div data-testid="chat-surface">
 			chat surface
 			{headerActions}
+			{reviewerTerminal ? (
+				<button type="button" onClick={() => onOpenReviewerTerminal?.(reviewerTerminal)}>
+					Reviewer
+				</button>
+			) : null}
 			<button type="button" onClick={onOpenShell}>
 				open shell from chat
 			</button>
@@ -709,6 +724,30 @@ describe("SessionView", () => {
 		render(<SessionView sessionId="sess-1" />);
 
 		await waitFor(() => expect(screen.getByTestId("reviewer-harness")).toHaveTextContent("codex"));
+	});
+
+	it("keeps the reviewer terminal reachable from a Chat session", async () => {
+		const worker = workerSession("sess-1");
+		worker.mode = "chat";
+		worker.prs = [{
+			url: "https://github.com/acme/repo/pull/7",
+			number: 7,
+			state: "open",
+			ci: "passing",
+			review: "none",
+			mergeability: "mergeable",
+			reviewComments: false,
+			updatedAt: "2026-06-15T00:00:00Z",
+		}];
+		reviewGetMock.mockResolvedValueOnce({
+			data: { reviewerHandleId: "review-sess-1", reviewerHarness: "codex", reviews: [], runs: [] },
+			error: undefined,
+		});
+
+		render(<SessionView sessionId="sess-1" />);
+		await screen.findByRole("button", { name: "Reviewer" });
+		fireEvent.click(screen.getByRole("button", { name: "Reviewer" }));
+		expect(screen.getByTestId("terminal-target")).toHaveTextContent("reviewer");
 	});
 
 	it("returns to the session terminal when the reviewer handle is cleared", async () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -282,11 +282,12 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	useEffect(() => {
 		setTerminalTarget((current) =>
 			current.kind === "reviewer" &&
+				reviewerQuery.isFetched &&
 			(!availableReviewerTerminal || availableReviewerTerminal.handleId !== current.handleId)
 				? { kind: "worker" }
 				: current,
 		);
-	}, [availableReviewerTerminal]);
+	}, [availableReviewerTerminal, reviewerQuery.isFetched]);
 	const isOrchestrator = session ? isOrchestratorSession(session) : false;
 	// Orchestrators get the full workspace width; only workers need the inspector rail.
 	const hasInspector = Boolean(session && !isOrchestrator);
@@ -641,6 +642,8 @@ export function SessionView({ sessionId }: SessionViewProps) {
 						{showChatSurface ? (
 							<SessionChatSurface
 								session={session}
+								reviewerTerminal={reviewerTerminal}
+								onOpenReviewerTerminal={selectReviewerTerminal}
 								headerActions={sessionHeaderActions}
 								controllerTransitioning={chatControllerTransitioning}
 								onOpenShell={addShellTerminal}

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -128,6 +128,8 @@ export interface ChatWorkspaceProps {
 	headerActions?: ReactNode;
 	/** Suppress a transient stopped snapshot while a mode handoff installs Chat. */
 	controllerTransitioning?: boolean;
+	reviewerTerminal?: { handleId: string; harness: string };
+	onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
 	/** Older durable history is available but not loaded into the DOM yet. */
 	hasOlder?: boolean;
 	loadingOlder?: boolean;
@@ -224,6 +226,8 @@ export function ChatWorkspace({
 	sessionRole = "worker",
 	headerActions,
 	controllerTransitioning,
+	reviewerTerminal,
+	onOpenReviewerTerminal,
 	hasOlder,
 	loadingOlder,
 	onLoadOlder,
@@ -707,6 +711,22 @@ function ChatHeader({
 										<span className="truncate">{label}</span>
 									</button>
 								</span>
+								{reviewerTerminal ? (
+									<span className="group relative inline-flex min-w-shell-tab-min self-stretch items-center gap-1.5 border-r border-border px-3 text-muted-foreground hover:bg-raised hover:text-foreground">
+										<AgentAvatar className="size-icon-base" decorative provider={reviewerTerminal.harness} />
+										<button
+											aria-label="Reviewer"
+											className="inline-flex min-w-flex-min max-w-shell-tab-max items-center gap-1.5 text-control font-medium leading-none"
+											onClick={() => onOpenReviewerTerminal?.(reviewerTerminal)}
+											role="tab"
+											tabIndex={0}
+											title={reviewerTerminal.harness}
+											type="button"
+										>
+											<span className="truncate">Reviewer</span>
+										</button>
+									</span>
+								) : null}
 							</div>
 							<Button
 								aria-label="New terminal"

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -383,6 +383,8 @@ export function ChatWorkspace({
 			<ChatHeader
 				snapshot={snapshot}
 				sessionTitle={sessionTitle}
+				reviewerTerminal={reviewerTerminal}
+				onOpenReviewerTerminal={onOpenReviewerTerminal}
 				headerActions={headerActions}
 				onOpenShell={onOpenShell}
 				openingShell={openingShell}
@@ -653,6 +655,8 @@ function readableItems(snapshot: ConversationSnapshot): ConversationItem[] {
 function ChatHeader({
 	snapshot,
 	sessionTitle,
+	reviewerTerminal,
+	onOpenReviewerTerminal,
 	headerActions,
 	onOpenShell,
 	openingShell,
@@ -666,6 +670,8 @@ function ChatHeader({
 }: {
 	snapshot: ConversationSnapshot;
 	sessionTitle?: string;
+	reviewerTerminal?: { handleId: string; harness: string };
+	onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
 	headerActions?: ReactNode;
 	onOpenShell?: () => void;
 	openingShell?: boolean;

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -25,6 +25,8 @@ import type { WorkspaceSession } from "../../types/workspace";
 
 export function SessionChatSurface({
 	session,
+	reviewerTerminal,
+	onOpenReviewerTerminal,
 	onOpenShell,
 	openingShell,
 	shellError,
@@ -32,6 +34,8 @@ export function SessionChatSurface({
 	controllerTransitioning,
 }: {
 	session: WorkspaceSession;
+	reviewerTerminal?: { handleId: string; harness: string };
+	onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
 	onOpenShell?: () => void;
 	openingShell?: boolean;
 	shellError?: string;
@@ -119,6 +123,8 @@ export function SessionChatSurface({
 			onLinkOpen={openLinkInBrowser}
 			sessionTitle={session.title}
 			sessionRole={session.kind}
+			reviewerTerminal={reviewerTerminal}
+			onOpenReviewerTerminal={onOpenReviewerTerminal}
 			headerActions={headerActions}
 			controllerTransitioning={controllerTransitioning}
 			hasOlder={hasOlder}


### PR DESCRIPTION
## Summary
- expose the active reviewer terminal as a tab in Chat mode
- preserve reviewer target during transient review query refetches
- add a regression test for selecting the reviewer from Chat mode

Fixes #3939

## Tests
- `git diff --check`
- Focused Vitest run was blocked because frontend dependencies are not installed (`Cannot find module vitest/config`).