### PR TITLE
feat(frontend,backend): hide interface switch for adapters without Chat UI

### DIFF
--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -439,6 +439,10 @@ var _ interface {
 	AbortChatHandoff(domain.SessionID)
 } = chatLauncher{}
 
+func (c chatLauncher) SupportsChat(harness domain.AgentHarness) bool {
+	return c.svc.SupportsChat(harness)
+}
+
 func (c chatLauncher) PreflightChat(ctx context.Context, harness domain.AgentHarness) error {
 	return c.svc.PreflightChat(ctx, harness)
 }

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -767,6 +767,12 @@ func (f SnapshotPageReaderFunc) LoadConversationSnapshotPage(
 // without importing this package's config types. They are deliberately narrow:
 // the manager decides when, this package decides how.
 
+// SupportsChat reports whether a harness has a Chat driver at all, without
+// probing the local install. Use it to decide whether Chat is even offerable.
+func (s *Service) SupportsChat(harness domain.AgentHarness) bool {
+	return s.drivers.SupportsChat(harness)
+}
+
 // PreflightChat reports whether a harness can start in chat mode right now.
 //
 // Called before any durable state exists, so an unsupported request costs nothing

--- a/backend/internal/session_manager/chat_spawn.go
+++ b/backend/internal/session_manager/chat_spawn.go
@@ -23,6 +23,9 @@ import (
 // ChatLauncher starts the structured controller for a chat session. Implemented
 // by the chat service; nil in a build without chat support.
 type ChatLauncher interface {
+	// SupportsChat reports whether a harness has a Chat driver at all, without
+	// probing the local install. Use it to decide whether Chat is even offerable.
+	SupportsChat(harness domain.AgentHarness) bool
 	// PreflightChat reports whether a harness can start in chat mode right now.
 	// Called before any durable state exists so an unsupported request costs
 	// nothing.

--- a/backend/internal/session_manager/chat_spawn_test.go
+++ b/backend/internal/session_manager/chat_spawn_test.go
@@ -52,6 +52,8 @@ type recordingLauncher struct {
 	stopped []domain.SessionID
 }
 
+func (l *recordingLauncher) SupportsChat(_ domain.AgentHarness) bool { return true }
+
 func (l *recordingLauncher) PreflightChat(_ context.Context, harness domain.AgentHarness) error {
 	l.preflighted = append(l.preflighted, harness)
 	return l.preflightErr

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -85,6 +85,9 @@ func (m *Manager) InterfaceTransitionStatus(
 	if rec.IsTerminated {
 		status.ReasonCode = "SESSION_TERMINATED"
 		status.Reason = "Terminated sessions must be restored before switching interfaces."
+	} else if target == domain.SessionModeChat && (m.chat == nil || !m.chat.SupportsChat(rec.Harness)) {
+		status.ReasonCode = "CHAT_UNSUPPORTED"
+		status.Reason = fmt.Sprintf("%s does not support Chat UI.", rec.Harness)
 	} else if _, _, err := m.nativeConversationID(ctx, rec); err != nil {
 		if errors.Is(err, ErrInterfaceHandoffUnsupported) {
 			status.ReasonCode = "INTERFACE_HANDOFF_UNSUPPORTED"

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -277,6 +277,11 @@ type transitionChat struct {
 	preflightRelease chan struct{}
 	relayMessages    []string
 	relayIDs         []string
+	supportsChat     bool
+}
+
+func (c *transitionChat) SupportsChat(_ domain.AgentHarness) bool {
+	return c.supportsChat
 }
 
 func (c *transitionChat) PreflightChat(ctx context.Context, _ domain.AgentHarness) error {
@@ -387,7 +392,7 @@ func newTransitionManager(t *testing.T, mode domain.SessionMode) (*Manager, *tra
 	}
 	log := &[]string{}
 	runtime := &transitionRuntime{fakeRuntime: &fakeRuntime{}, log: log}
-	chat := &transitionChat{log: log}
+	chat := &transitionChat{log: log, supportsChat: true}
 	messenger := &fakeMessenger{}
 	store.messenger = messenger
 	counter := 0
@@ -405,6 +410,41 @@ func useFastInterfaceTransitionTimings(manager *Manager) {
 		pollInterval:   time.Millisecond,
 		idleSettle:     5 * time.Millisecond,
 		staleIdleLimit: 60 * time.Millisecond,
+	}
+}
+
+func TestInterfaceTransitionStatusHidesSwitchWhenChatUnsupported(t *testing.T) {
+	manager, _, _, chat, _ := newTransitionManager(t, domain.SessionModeTUI)
+	chat.supportsChat = false
+
+	status, err := manager.InterfaceTransitionStatus(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("InterfaceTransitionStatus: %v", err)
+	}
+	if status.TargetMode != domain.SessionModeChat {
+		t.Fatalf("target mode = %q, want chat", status.TargetMode)
+	}
+	if status.Supported {
+		t.Fatal("expected switch to be unsupported")
+	}
+	if status.ReasonCode != "CHAT_UNSUPPORTED" {
+		t.Fatalf("reasonCode = %q, want CHAT_UNSUPPORTED", status.ReasonCode)
+	}
+}
+
+func TestInterfaceTransitionStatusAllowsSwitchToTUIWhenChatUnsupported(t *testing.T) {
+	manager, _, _, chat, _ := newTransitionManager(t, domain.SessionModeChat)
+	chat.supportsChat = false
+
+	status, err := manager.InterfaceTransitionStatus(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("InterfaceTransitionStatus: %v", err)
+	}
+	if status.TargetMode != domain.SessionModeTUI {
+		t.Fatalf("target mode = %q, want tui", status.TargetMode)
+	}
+	if status.ReasonCode == "CHAT_UNSUPPORTED" {
+		t.Fatal("switching back to TUI should not report CHAT_UNSUPPORTED")
 	}
 }
 

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -17,7 +17,7 @@ const interfaceTransitionMock = vi.hoisted(() => ({
 }));
 const interfaceTransitionState = vi.hoisted(() => ({
 	status: undefined as
-		| { supported: boolean; targetMode?: "chat" | "tui"; reason?: string }
+		| { supported: boolean; targetMode?: "chat" | "tui"; reason?: string; reasonCode?: string }
 		| undefined,
 }));
 const reviewGetMock = vi.hoisted(() => vi.fn());
@@ -650,6 +650,33 @@ describe("SessionView", () => {
 
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 		expect(interfaceTransitionMock.start).toHaveBeenCalledWith({ targetMode: "chat", policy: "drain" });
+	});
+
+	it.each([
+		["worker", "sess-1"],
+		["orchestrator", "sess-orch"],
+	] as const)("hides the interface switch button for %s sessions when Chat UI is unsupported", (_label, sessionId) => {
+		interfaceTransitionState.status = { supported: false, targetMode: "chat", reasonCode: "CHAT_UNSUPPORTED" };
+		const session = workerSession(sessionId);
+		session.mode = "tui";
+		session.status = "idle";
+		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
+
+		render(<SessionView sessionId={sessionId} />);
+
+		expect(screen.queryByRole("button", { name: "Switch to chat UI" })).not.toBeInTheDocument();
+	});
+
+	it("shows the switch button when the adapter only reports a generic unsupported reason", () => {
+		interfaceTransitionState.status = { supported: false, targetMode: "chat", reasonCode: "INTERFACE_HANDOFF_UNSUPPORTED" };
+		const session = workerSession("sess-1");
+		session.mode = "tui";
+		session.status = "idle";
+		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
+
+		render(<SessionView sessionId="sess-1" />);
+
+		expect(screen.getByRole("button", { name: "Switch to chat UI" })).toBeInTheDocument();
 	});
 
 	it("walks backward through auxiliary terminals before returning to the permanent terminal", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -332,8 +332,11 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		}
 		setInterfaceSwitchDialogOpen(true);
 	}, [beginInterfaceSwitch, interfaceBusy, interfaceSwitch]);
+	// Adapters without a Chat driver cannot offer a switch into Chat UI; hide
+	// the button entirely rather than showing a permanently disabled control.
+	const interfaceSwitchUnsupported = interfaceSwitch.status?.reasonCode === "CHAT_UNSUPPORTED";
 	const showInterfaceSwitchAction = Boolean(
-		interfaceSwitch.status || interfaceSwitch.isLoading || interfaceSwitch.statusError,
+		!interfaceSwitchUnsupported && (interfaceSwitch.status || interfaceSwitch.isLoading || interfaceSwitch.statusError),
 	);
 	const interfaceSwitchAction = session && showInterfaceSwitchAction ? (
 		<SessionInterfaceSwitchButton


### PR DESCRIPTION
Hides the terminal ↔ Chat UI switch button for agents/adapters that do not have a Chat driver.

## Changes
- Backend: `GET /api/v1/sessions/{id}/interface-transition` now returns `reasonCode: CHAT_UNSUPPORTED` when the session's harness has no Chat driver and the target mode is Chat.
- Backend: added `SupportsChat` to the `ChatLauncher` interface and wired it through chat service / daemon lifecycle.
- Frontend: `SessionView` hides the switch button entirely when `reasonCode === "CHAT_UNSUPPORTED"` instead of rendering a disabled control.

## Verification
- Backend targeted tests: 820 passed (session_manager, service/session, daemon, service/chat).
- Frontend `SessionView.test.tsx`: 55 passed.
- Frontend `npm run typecheck`: passed.

## Notes
- No OpenAPI/schema regeneration needed; `reasonCode` already exists as a string in the response.
- Branched from `upstream/main` because the local session root has unrelated history.