### PR TITLE
chore(mobile): stamp app version 1.2.0

### DIFF
--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -2,7 +2,7 @@
 	"expo": {
 		"name": "AO",
 		"slug": "ao-mobile",
-		"version": "1.1.0",
+		"version": "1.2.0",
 		"orientation": "portrait",
 		"icon": "./assets/icon.png",
 		"userInterfaceStyle": "automatic",


### PR DESCRIPTION
Bumps the Expo marketing version in `packages/mobile/app.json` from `1.1.0` to `1.2.0`.

## Why

`1.1.0` was stamped on Aug 3 (#3494). Since then `packages/mobile` has taken 129 files of change across these merged PRs:

- #3472, #3843 — Chat UI, then chat UI improvements and optimisations
- #3674 — device roster (see, mute, and remove paired phones)
- #3707 — Connect Mobile pairing over Tailscale, including iOS
- #3661, #3704 — PostHog product analytics and a per-name event rate cap
- #3545 — iOS photo library purpose string

That is a minor release worth of work shipping under the same version label. TestFlight and Play show the version prominently and the build number only in fine print, so testers currently can't tell this build apart from the Aug 3 one in bug reports.

## Notes

Build numbers are unaffected and stay automatic — `eas.json` uses `appVersionSource: remote` with `autoIncrement` on the `production` profile, so iOS `buildNumber` / Android `versionCode` still increment server-side per build. This bump is only the user-facing semver string.

Same shape as #3494, which also touched `app.json` alone.