### PR TITLE
fix(chat): enable Codex switch-to-chat for fresh TUI sessions

### DIFF
--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -362,6 +362,14 @@ func (m *Manager) runInterfaceTransition(
 	}
 }
 
+// nativeConversationID resolves the adapter's native conversation id for the
+// session's current interface. An empty id is only safe to pass through when
+// the adapter can distinguish a fresh TUI from a real conversation (it
+// implements AgentInterfaceHandoffHistoryProbe) AND the session has no
+// hook-derived conversation history. If any conversation metadata is set but
+// the native id is empty, the hooks fired but failed to capture the id — a
+// bug state where fresh-starting would silently discard the conversation, so
+// hard-block with ErrNativeConversationMissing instead.
 func (m *Manager) nativeConversationID(
 	ctx context.Context,
 	rec domain.SessionRecord,
@@ -385,7 +393,10 @@ func (m *Manager) nativeConversationID(
 	}
 	id = strings.TrimSpace(id)
 	if !ok || id == "" {
-		if _, hasProbe := handoff.(ports.AgentInterfaceHandoffHistoryProbe); hasProbe {
+		if _, hasProbe := handoff.(ports.AgentInterfaceHandoffHistoryProbe); hasProbe &&
+			rec.Metadata.LatestUserPrompt == "" &&
+			rec.Metadata.LatestAssistantUpdate == "" &&
+			rec.Metadata.NativeTranscriptPath == "" {
 			return "", handoff, nil
 		}
 		return "", handoff, fmt.Errorf("%w for %s", ErrNativeConversationMissing, rec.Harness)

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -385,6 +385,9 @@ func (m *Manager) nativeConversationID(
 	}
 	id = strings.TrimSpace(id)
 	if !ok || id == "" {
+		if _, hasProbe := handoff.(ports.AgentInterfaceHandoffHistoryProbe); hasProbe {
+			return "", handoff, nil
+		}
 		return "", handoff, fmt.Errorf("%w for %s", ErrNativeConversationMissing, rec.Harness)
 	}
 	return id, handoff, nil

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -510,6 +510,38 @@ func TestInterfaceTransitionStatusBlocksFreshStartWithoutHistoryProbe(t *testing
 	}
 }
 
+func TestInterfaceTransitionStatusBlocksFreshStartWithHistoryProbeAndConversationHistory(t *testing.T) {
+	store := newTransitionStore()
+	store.projects["proj"] = domain.ProjectRecord{ID: "proj", Path: "/repo"}
+	store.sessions["session-1"] = domain.SessionRecord{
+		ID: "session-1", ProjectID: "proj", Kind: domain.KindWorker,
+		Harness: domain.HarnessClaudeCode, Mode: domain.SessionModeTUI,
+		Metadata:      domain.SessionMetadata{WorkspacePath: "/ws/session-1", Branch: "ao/session-1", LatestUserPrompt: "implement the feature"},
+		Activity:      domain.Activity{State: domain.ActivityIdle, LastActivityAt: time.Now()},
+		FirstSignalAt: time.Now(),
+	}
+	log := &[]string{}
+	runtime := &transitionRuntime{fakeRuntime: &fakeRuntime{}, log: log}
+	chat := &transitionChat{log: log, supportsChat: true}
+	manager := New(Deps{
+		Runtime: runtime, Agents: singleAgent{agent: emptyTransitionAgent{}}, Workspace: &fakeWorkspace{},
+		Store: store, Chat: chat, Lifecycle: &fakeLCM{store: store.fakeStore},
+		LookPath:    func(string) (string, error) { return "/bin/true", nil },
+		NewLaunchID: func() string { return "generation-1" },
+	})
+
+	status, err := manager.InterfaceTransitionStatus(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("InterfaceTransitionStatus: %v", err)
+	}
+	if status.Supported {
+		t.Fatal("expected switch to be blocked when conversation history exists but native id is empty")
+	}
+	if status.ReasonCode != "NATIVE_SESSION_MISSING" {
+		t.Fatalf("reasonCode = %q, want NATIVE_SESSION_MISSING", status.ReasonCode)
+	}
+}
+
 func awaitTransition(t *testing.T, store *transitionStore, id string) domain.SessionInterfaceTransition {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
@@ -993,27 +1025,24 @@ func TestInterfaceTransitionTUIToChatReusesPersistedCodexRollout(t *testing.T) {
 // TestInterfaceTransitionFreshTUISessionResumesAfterHookCapture is a regression
 // test for a fresh TUI session where the SessionStart hook captures the native
 // session id. The transition must resume the persisted Codex conversation
+// rather than starting fresh, proving the identifiers are populated before
+// transition and the original conversation is resumed afterward.
 func TestInterfaceTransitionFreshTUISessionResumesAfterHookCapture(t *testing.T) {
 	manager, store, _, chat, _ := newTransitionManager(t, domain.SessionModeTUI)
 	codexHome := t.TempDir()
 	t.Setenv("CODEX_HOME", codexHome)
 	manager.agents = singleAgent{agent: codexagent.New()}
 
-	// Start with a fresh TUI session — no agentSessionID, no rollout.
 	id := "019fc430-1234-7abc-8def-0123456789ab"
 	rec := store.sessions["session-1"]
 	rec.Harness = domain.HarnessCodex
 	rec.Metadata.AgentSessionID = ""
 	store.sessions["session-1"] = rec
 
-	// Simulate the SessionStart hook: the hook captures the native session id
-	// and stores it on the session record, exactly as ApplyActivitySignal does
-	// in the real lifecycle manager.
 	rec = store.sessions["session-1"]
 	rec.Metadata.AgentSessionID = id
 	store.sessions["session-1"] = rec
 
-	// Verify the identifier was populated before transition.
 	preRec, ok, err := store.GetSession(context.Background(), "session-1")
 	if err != nil || !ok {
 		t.Fatalf("read pre-transition session: %v %v", err, ok)
@@ -1023,7 +1052,6 @@ func TestInterfaceTransitionFreshTUISessionResumesAfterHookCapture(t *testing.T)
 			preRec.Metadata.AgentSessionID, id)
 	}
 
-	// Materialize a rollout so the history probe finds a real conversation.
 	rolloutDir := filepath.Join(codexHome, "sessions", "2026", "08", "08")
 	if err := os.MkdirAll(rolloutDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -1033,7 +1061,6 @@ func TestInterfaceTransitionFreshTUISessionResumesAfterHookCapture(t *testing.T)
 		t.Fatal(err)
 	}
 
-	// The transition must resume (not fresh-start) because a real conversation exists.
 	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
 		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
 	if err != nil {

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -448,6 +448,68 @@ func TestInterfaceTransitionStatusAllowsSwitchToTUIWhenChatUnsupported(t *testin
 	}
 }
 
+func TestInterfaceTransitionStatusAllowsFreshStartWithHistoryProbe(t *testing.T) {
+	store := newTransitionStore()
+	store.projects["proj"] = domain.ProjectRecord{ID: "proj", Path: "/repo"}
+	store.sessions["session-1"] = domain.SessionRecord{
+		ID: "session-1", ProjectID: "proj", Kind: domain.KindWorker,
+		Harness: domain.HarnessClaudeCode, Mode: domain.SessionModeTUI,
+		Metadata:      domain.SessionMetadata{WorkspacePath: "/ws/session-1", Branch: "ao/session-1"},
+		Activity:      domain.Activity{State: domain.ActivityIdle, LastActivityAt: time.Now()},
+		FirstSignalAt: time.Now(),
+	}
+	log := &[]string{}
+	runtime := &transitionRuntime{fakeRuntime: &fakeRuntime{}, log: log}
+	chat := &transitionChat{log: log, supportsChat: true}
+	manager := New(Deps{
+		Runtime: runtime, Agents: singleAgent{agent: emptyTransitionAgent{}}, Workspace: &fakeWorkspace{},
+		Store: store, Chat: chat, Lifecycle: &fakeLCM{store: store.fakeStore},
+		LookPath:    func(string) (string, error) { return "/bin/true", nil },
+		NewLaunchID: func() string { return "generation-1" },
+	})
+
+	status, err := manager.InterfaceTransitionStatus(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("InterfaceTransitionStatus: %v", err)
+	}
+	if !status.Supported {
+		t.Fatalf("expected switch to be supported with history probe, got reasonCode=%q reason=%q",
+			status.ReasonCode, status.Reason)
+	}
+}
+
+func TestInterfaceTransitionStatusBlocksFreshStartWithoutHistoryProbe(t *testing.T) {
+	store := newTransitionStore()
+	store.projects["proj"] = domain.ProjectRecord{ID: "proj", Path: "/repo"}
+	store.sessions["session-1"] = domain.SessionRecord{
+		ID: "session-1", ProjectID: "proj", Kind: domain.KindWorker,
+		Harness: domain.HarnessClaudeCode, Mode: domain.SessionModeTUI,
+		Metadata:      domain.SessionMetadata{WorkspacePath: "/ws/session-1", Branch: "ao/session-1"},
+		Activity:      domain.Activity{State: domain.ActivityIdle, LastActivityAt: time.Now()},
+		FirstSignalAt: time.Now(),
+	}
+	log := &[]string{}
+	runtime := &transitionRuntime{fakeRuntime: &fakeRuntime{}, log: log}
+	chat := &transitionChat{log: log, supportsChat: true}
+	manager := New(Deps{
+		Runtime: runtime, Agents: singleAgent{agent: transitionAgent{}}, Workspace: &fakeWorkspace{},
+		Store: store, Chat: chat, Lifecycle: &fakeLCM{store: store.fakeStore},
+		LookPath:    func(string) (string, error) { return "/bin/true", nil },
+		NewLaunchID: func() string { return "generation-1" },
+	})
+
+	status, err := manager.InterfaceTransitionStatus(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("InterfaceTransitionStatus: %v", err)
+	}
+	if status.Supported {
+		t.Fatal("expected switch to be unsupported without history probe and empty native id")
+	}
+	if status.ReasonCode != "NATIVE_SESSION_MISSING" {
+		t.Fatalf("reasonCode = %q, want NATIVE_SESSION_MISSING", status.ReasonCode)
+	}
+}
+
 func awaitTransition(t *testing.T, store *transitionStore, id string) domain.SessionInterfaceTransition {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
@@ -924,6 +986,69 @@ func TestInterfaceTransitionTUIToChatReusesPersistedCodexRollout(t *testing.T) {
 	}
 	if chat.start.ProviderConversationID != id {
 		t.Fatalf("Chat resumed %q, want persisted Codex rollout %q",
+			chat.start.ProviderConversationID, id)
+	}
+}
+
+// TestInterfaceTransitionFreshTUISessionResumesAfterHookCapture is a regression
+// test for a fresh TUI session where the SessionStart hook captures the native
+// session id. The transition must resume the persisted Codex conversation
+func TestInterfaceTransitionFreshTUISessionResumesAfterHookCapture(t *testing.T) {
+	manager, store, _, chat, _ := newTransitionManager(t, domain.SessionModeTUI)
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	manager.agents = singleAgent{agent: codexagent.New()}
+
+	// Start with a fresh TUI session — no agentSessionID, no rollout.
+	id := "019fc430-1234-7abc-8def-0123456789ab"
+	rec := store.sessions["session-1"]
+	rec.Harness = domain.HarnessCodex
+	rec.Metadata.AgentSessionID = ""
+	store.sessions["session-1"] = rec
+
+	// Simulate the SessionStart hook: the hook captures the native session id
+	// and stores it on the session record, exactly as ApplyActivitySignal does
+	// in the real lifecycle manager.
+	rec = store.sessions["session-1"]
+	rec.Metadata.AgentSessionID = id
+	store.sessions["session-1"] = rec
+
+	// Verify the identifier was populated before transition.
+	preRec, ok, err := store.GetSession(context.Background(), "session-1")
+	if err != nil || !ok {
+		t.Fatalf("read pre-transition session: %v %v", err, ok)
+	}
+	if preRec.Metadata.AgentSessionID != id {
+		t.Fatalf("pre-transition AgentSessionID = %q, want %q (hook capture failed)",
+			preRec.Metadata.AgentSessionID, id)
+	}
+
+	// Materialize a rollout so the history probe finds a real conversation.
+	rolloutDir := filepath.Join(codexHome, "sessions", "2026", "08", "08")
+	if err := os.MkdirAll(rolloutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rollout := filepath.Join(rolloutDir, "rollout-2026-08-08T10-00-00-"+id+".jsonl")
+	if err := os.WriteFile(rollout, []byte("{\"type\":\"session_meta\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The transition must resume (not fresh-start) because a real conversation exists.
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("phase = %s, error = %s", settled.Phase, settled.ErrorDetail)
+	}
+	if settled.NativeConversationID != id {
+		t.Fatalf("native conversation = %q, want %q (transition did not resume the captured id)",
+			settled.NativeConversationID, id)
+	}
+	if chat.start.ProviderConversationID != id {
+		t.Fatalf("Chat resumed %q, want persisted Codex rollout %q (fresh-started instead of resuming)",
 			chat.start.ProviderConversationID, id)
 	}
 }


### PR DESCRIPTION
Codex switch-to-chat button was disabled when the TUI session had no prompt yet (`NATIVE_SESSION_MISSING`).

## Root cause

`nativeConversationID()` hard-blocked with `ErrNativeConversationMissing` when `agentSessionId` was empty — even though Codex implements `AgentInterfaceHandoffHistoryProbe`, which can distinguish a fresh TUI from a real conversation and decide fresh-start vs resume.

## Fix

If the adapter implements `AgentInterfaceHandoffHistoryProbe`, allow an empty native id through. `persistedNativeConversationID()` then uses the probe to decide fresh-start vs resume. Adapters without the probe keep the hard block.

## Tests

- `TestInterfaceTransitionStatusAllowsFreshStartWithHistoryProbe` — empty native id + probe → `Supported=true`
- `TestInterfaceTransitionStatusBlocksFreshStartWithoutHistoryProbe` — empty native id + no probe → `NATIVE_SESSION_MISSING`