### PR TITLE
Add reviews tab to session inspector

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1800,6 +1800,8 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={session([])} />);
 
 		await screen.findByRole("tab", { name: /Summary/ });
-		expect(screen.getByRole("tab", { name: /Reviews/ })).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("tab", { name: /Reviews/ }));
+		expect(screen.getByRole("switch", { name: "Automatically send reviews" })).toBeInTheDocument();
+		expect(screen.getByText("No pull request opened yet.")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -391,7 +391,7 @@ describe("SessionInspector PR section", () => {
 		expect(screen.getByText("No pull request opened yet.")).toBeInTheDocument();
 	});
 
-	it("renders PRs and reviews before the stacked compact policy rows", async () => {
+	it("keeps PR and session policies in Summary while review policies live in Reviews", async () => {
 		renderWithQuery(<SessionInspector session={session([pr(7, "open")])} />);
 
 		expect(screen.getByText("Session controls")).toBeInTheDocument();
@@ -399,24 +399,16 @@ describe("SessionInspector PR section", () => {
 		const policyRow = (name: string) =>
 			screen.getByRole("switch", { name }).closest("[data-slot='inspector-policy-row']") as HTMLElement;
 		const ciRow = policyRow("Automatically send CI failures");
-		const reviewRow = policyRow("Automatically send reviews");
 		const terminateRow = policyRow("Terminate session when pull requests merge");
 		const prCard = prSection("Pull request").getByText("PR #7").closest("article") as HTMLElement;
-		const runReview = await screen.findByRole("button", { name: "Run review" });
 		const appearsBefore = (first: HTMLElement, second: HTMLElement) =>
 			Boolean(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
 
-		expect(ciRow.nextElementSibling).toBe(reviewRow);
 		expect(appearsBefore(prCard, ciRow)).toBe(true);
-		expect(appearsBefore(runReview, ciRow)).toBe(true);
 		expect(ciRow.className).toBe(terminateRow.className);
-		expect(reviewRow.className).toBe(terminateRow.className);
 		expect(ciRow.parentElement).not.toHaveClass("rounded-lg", "border", "bg-surface");
-		for (const name of [
-			"Automatically send CI failures",
-			"Automatically send reviews",
-			"Terminate session when pull requests merge",
-		]) {
+		expect(screen.queryByRole("switch", { name: "Automatically send reviews" })).not.toBeInTheDocument();
+		for (const name of ["Automatically send CI failures", "Terminate session when pull requests merge"]) {
 			const toggle = screen.getByRole("switch", { name });
 			expect(toggle).toHaveClass("h-4", "w-8", "rounded-full");
 			expect(toggle.querySelector("[data-slot='switch-thumb']")).toHaveClass("size-3", "rounded-full");
@@ -431,6 +423,10 @@ describe("SessionInspector PR section", () => {
 				name: "When disabled, AO keeps this session open after all pull requests merge.",
 			}),
 		).toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("tab", { name: "Reviews" }));
+		expect(await screen.findByRole("button", { name: "Run review" })).toBeInTheDocument();
+		expect(screen.getByRole("switch", { name: "Automatically send reviews" })).toBeInTheDocument();
 	});
 
 	it("persists the CI injection default before a PR exists", async () => {
@@ -948,11 +944,17 @@ describe("SessionInspector Activity section", () => {
 });
 
 describe("SessionInspector tabs", () => {
-	it("exposes Summary, Browser, and Files as inspector tabs", () => {
+	it("exposes Reviews after Summary and keeps review content out of Summary", async () => {
+		mockCommonGets([], "", [reviewState(1, "needs_review")]);
 		renderWithQuery(<SessionInspector session={session([pr(1, "open")])} />);
 		const tabs = screen.getAllByRole("tab").map((el) => el.textContent?.trim());
-		expect(tabs).toEqual(["Summary", "Browser", "Files"]);
-		expect(screen.queryByRole("tab", { name: /Reviews/ })).not.toBeInTheDocument();
+		expect(tabs).toEqual(["Summary", "Reviews", "Browser", "Files"]);
+		expect(screen.queryByText("Review controls")).not.toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("tab", { name: "Reviews" }));
+
+		expect(await screen.findByText("Review controls")).toBeInTheDocument();
+		expect(screen.queryByText("Pull request")).not.toBeInTheDocument();
 	});
 
 	it("does not render the overview card in the summary", () => {
@@ -966,9 +968,10 @@ describe("SessionInspector tabs", () => {
 });
 
 describe("SessionInspector summary reviews", () => {
-	// PR rows start collapsed, so opening the Summary tab alone shows only their titles.
-	// Reveal every row, since these tests are about what a review says.
+	// Review rows start collapsed. Open the Reviews tab and reveal every row,
+	// since these tests are about what a review says.
 	const openReviewsSection = async () => {
+		await userEvent.click(screen.getByRole("tab", { name: "Reviews" }));
 		// Rows arrive with the reviews query, so wait for them before expanding.
 		const rows = await screen.findAllByTestId("review-pr-row").catch(() => []);
 		for (const row of rows) {
@@ -1173,10 +1176,11 @@ describe("SessionInspector summary reviews", () => {
 		mockCommonGets([], "reviewer-pane", [running]);
 
 		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+		await openReviewsSection();
 		await screen.findByText("Review in progress · codex");
 
 		expect(screen.queryByText("Reviewable change 3")).not.toBeInTheDocument();
-		expect(screen.queryByText("Reviews")).not.toBeInTheDocument();
+		expect(screen.queryByText("Review summary")).not.toBeInTheDocument();
 	});
 
 	it("shows eligible and up-to-date open PR review rows", async () => {
@@ -1791,11 +1795,11 @@ describe("SessionInspector summary reviews", () => {
 		);
 	});
 
-	it("does not expose the Reviews tab when the session has no PRs", async () => {
+	it("keeps the Reviews tab available when the session has no PRs", async () => {
 		mockCommonGets();
 		renderWithQuery(<SessionInspector session={session([])} />);
 
 		await screen.findByRole("tab", { name: /Summary/ });
-		expect(screen.queryByRole("tab", { name: /Reviews/ })).not.toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: /Reviews/ })).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -28,6 +28,7 @@ import {
 	Play,
 	Trash2,
 	Loader2,
+	MessageSquare,
 	X,
 } from "lucide-react";
 import type { components } from "../../api/schema";
@@ -70,7 +71,7 @@ type OpenReviewerTerminal = (target: { handleId: string; harness: string }) => v
 
 export type { InspectorView } from "@aoagents/product-ui";
 
-const VIEW_DEFS: { id: InspectorView; labelKey: "inspector.summary" | "inspector.browser" | "inspector.files"; icon: ReactNode }[] = [
+const VIEW_DEFS: { id: InspectorView; labelKey: "inspector.summary" | "inspector.reviewTab" | "inspector.browser" | "inspector.files"; icon: ReactNode }[] = [
 	{
 		id: "summary",
 		labelKey: "inspector.summary",
@@ -84,6 +85,11 @@ const VIEW_DEFS: { id: InspectorView; labelKey: "inspector.summary" | "inspector
 				<circle cx="4" cy="17" r="1" />
 			</svg>
 		),
+	},
+	{
+		id: "reviews",
+		labelKey: "inspector.reviewTab",
+		icon: <MessageSquare aria-hidden="true" />,
 	},
 	{
 		id: "browser",
@@ -111,7 +117,7 @@ const prStateLabelKeys: Record<SessionPRSummary["state"], MessageKey> = {
 };
 
 /**
- * Tabbed inspector rail beside the terminal (Summary · Browser · Files).
+ * Tabbed inspector rail beside the terminal (Summary · Reviews · Browser · Files).
  */
 export function SessionInspector({
 	session,
@@ -185,21 +191,18 @@ export function SessionInspector({
 			filesView={session ? <FilesView filesView={filesView} onOpenFiles={onOpenFiles} /> : undefined}
 			loadingText={session ? undefined : t("inspector.loadingSession")}
 			onViewChange={setView}
+			reviewsView={
+				session ? <ReviewsView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : undefined
+			}
 			summaryView={
-				session ? <SummaryView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : undefined
+				session ? <SummaryView session={session} /> : undefined
 			}
 			tabs={tabs}
 		/>
 	);
 }
 
-function SummaryView({
-	session,
-	onOpenReviewerTerminal,
-}: {
-	session: WorkspaceSession;
-	onOpenReviewerTerminal?: OpenReviewerTerminal;
-}) {
+function SummaryView({ session }: { session: WorkspaceSession }) {
 	const { t } = useTranslation();
 	const query = useSessionScmSummary(session.id);
 	const prSummaries = sessionPRDisplaySummaries(session, query.data);
@@ -227,8 +230,21 @@ function SummaryView({
 				</div>
 			}
 			pullRequestTitle={prSectionTitle}
-			reviews={hasPRs ? <ReviewsSection onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : null}
 		/>
+	);
+}
+
+function ReviewsView({
+	session,
+	onOpenReviewerTerminal,
+}: {
+	session: WorkspaceSession;
+	onOpenReviewerTerminal?: OpenReviewerTerminal;
+}) {
+	return (
+		<div role="tabpanel">
+			<ReviewsSection onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />
+		</div>
 	);
 }
 
@@ -507,7 +523,6 @@ function SessionControls({ session }: { session: WorkspaceSession }) {
 	return (
 		<Section title={t("inspector.sessionControls")}>
 			<AutoInjectCIPolicyControl session={session} />
-			<AutoInjectReviewPolicyControl session={session} />
 			{session.kind === "orchestrator" ? null : canTerminateNow ? (
 				<div className="flex items-center justify-between gap-3 py-1">
 					<span className="min-w-0 text-xs font-medium text-settings-label">{t("inspector.terminateShort")}</span>
@@ -1447,6 +1462,7 @@ function ReviewPanel({
 					</TooltipProvider>
 				) : null}
 				<div className="review-run-controls-container min-w-0 divide-y divide-border/70">
+					<AutoInjectReviewPolicyControl session={session} />
 					<div className="flex min-h-10 min-w-0 items-center justify-between gap-3 py-2">
 						<span className="min-w-0 text-xs font-medium text-foreground">
 							{t("inspector.selectReviewerAgent")}

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -955,9 +955,15 @@ function ReviewsSection({
 			((pr.review?.reviews?.length ?? 0) > 0 ||
 				(pr.review?.unresolvedBy ?? []).some((reviewer) => reviewer.count > 0)),
 	);
+	const hasPRs = sortedPRs(session).length > 0;
 
 	return (
 		<div className="p-2">
+			{hasPRs ? null : (
+				<Section surface title={t("inspector.review.controls")}>
+					<AutoInjectReviewPolicyControl session={session} />
+				</Section>
+			)}
 			{/* Running a review is an action; reading them is a list. The action stays
 			    on top, then one list carrying both sources keyed by PR. */}
 			<ReviewPanel

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -266,6 +266,7 @@
 	"inspector.earlierPass": "früherer Lauf",
 	"inspector.previousLabel": "Vorherig:",
 	"inspector.reviews": "Review-Zusammenfassung",
+	"inspector.reviewTab": "Reviews",
 	"inspector.session": "Sitzung",
 	"inspector.started": "Gestartet",
 	"inspector.startedFromPrompt": "Aus gespeichertem Prompt gestartet",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -266,6 +266,7 @@
 	"inspector.earlierPass": "earlier pass",
 	"inspector.previousLabel": "Previous:",
 	"inspector.reviews": "Review summary",
+	"inspector.reviewTab": "Reviews",
 	"inspector.session": "Session",
 	"inspector.started": "Started",
 	"inspector.startedFromPrompt": "Started from saved prompt",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -268,7 +268,7 @@
 	"inspector.earlierPass": "ejecución anterior",
 	"inspector.previousLabel": "Anterior:",
 	"inspector.reviews": "Resumen de revisiones",
-	"inspector.reviewTab": "Reseñas",
+	"inspector.reviewTab": "Revisiones",
 	"inspector.session": "Sesión",
 	"inspector.started": "Iniciado",
 	"inspector.startedFromPrompt": "Iniciado desde el prompt guardado",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -268,6 +268,7 @@
 	"inspector.earlierPass": "ejecución anterior",
 	"inspector.previousLabel": "Anterior:",
 	"inspector.reviews": "Resumen de revisiones",
+	"inspector.reviewTab": "Reseñas",
 	"inspector.session": "Sesión",
 	"inspector.started": "Iniciado",
 	"inspector.startedFromPrompt": "Iniciado desde el prompt guardado",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -268,6 +268,7 @@
 	"inspector.earlierPass": "exécution précédente",
 	"inspector.previousLabel": "Précédent :",
 	"inspector.reviews": "Résumé des revues",
+	"inspector.reviewTab": "Revues",
 	"inspector.session": "Session",
 	"inspector.started": "Démarré",
 	"inspector.startedFromPrompt": "Démarré à partir du prompt enregistré",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -266,6 +266,7 @@
 	"inspector.earlierPass": "以前の実行",
 	"inspector.previousLabel": "前回:",
 	"inspector.reviews": "レビュー概要",
+	"inspector.reviewTab": "レビュー",
 	"inspector.session": "セッション",
 	"inspector.started": "開始",
 	"inspector.startedFromPrompt": "保存済みプロンプトから開始",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -266,6 +266,7 @@
 	"inspector.earlierPass": "이전 실행",
 	"inspector.previousLabel": "이전:",
 	"inspector.reviews": "리뷰 요약",
+	"inspector.reviewTab": "리뷰",
 	"inspector.session": "세션",
 	"inspector.started": "시작됨",
 	"inspector.startedFromPrompt": "저장된 프롬프트에서 시작됨",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -268,6 +268,7 @@
 	"inspector.earlierPass": "execução anterior",
 	"inspector.previousLabel": "Anterior:",
 	"inspector.reviews": "Resumo das revisões",
+	"inspector.reviewTab": "Revisões",
 	"inspector.session": "Sessão",
 	"inspector.started": "Iniciado",
 	"inspector.startedFromPrompt": "Iniciado a partir do prompt salvo",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -266,6 +266,7 @@
 	"inspector.earlierPass": "较早的评审",
 	"inspector.previousLabel": "上一次：",
 	"inspector.reviews": "评审摘要",
+	"inspector.reviewTab": "评审",
 	"inspector.session": "会话",
 	"inspector.started": "开始时间",
 	"inspector.startedFromPrompt": "从已保存的提示启动",

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -27,7 +27,7 @@ export type SettingsModal =
 
 /** Worker detail view toggles — Changes (Git rail) is the default. */
 export type WorkbenchTab = "changes" | "files" | "terminal";
-export type InspectorView = "summary" | "browser" | "files";
+export type InspectorView = "summary" | "reviews" | "browser" | "files";
 
 export type InspectorSessionState = {
 	isOpen: boolean;

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -23,6 +23,7 @@ function ExternalLink({ ariaLabel, children, stopPropagation, ...props }: Extern
 
 const tabs = [
 	{ id: "summary" as const, icon: <svg />, label: "Summary" },
+	{ id: "reviews" as const, icon: <svg />, label: "Reviews" },
 	{ badge: true, id: "browser" as const, icon: <svg />, label: "Browser" },
 	{ displayLabel: "2 Files", id: "files" as const, icon: <svg />, label: "Files" },
 ];
@@ -38,6 +39,7 @@ describe("SessionInspectorShellView", () => {
 				browserView={<div role="tabpanel">browser slot</div>}
 				filesView={<div role="tabpanel">files slot</div>}
 				onViewChange={onViewChange}
+				reviewsView={<div role="tabpanel">reviews slot</div>}
 				summaryView={<div role="tabpanel">summary slot</div>}
 				tabs={tabs}
 			/>,
@@ -54,8 +56,20 @@ describe("SessionInspectorShellView", () => {
 		fireEvent.click(screen.getByRole("tab", { name: "Browser" }));
 		expect(onViewChange).toHaveBeenCalledWith("browser");
 		fireEvent.keyDown(screen.getByRole("tab", { name: "Summary" }), { key: "ArrowRight" });
-		expect(onViewChange).toHaveBeenLastCalledWith("browser");
-		expect(screen.getByRole("tab", { name: "Browser" })).toHaveFocus();
+		expect(onViewChange).toHaveBeenLastCalledWith("reviews");
+		expect(screen.getByRole("tab", { name: "Reviews" })).toHaveFocus();
+
+		rerender(
+			<SessionInspectorShellView
+				activeView="reviews"
+				ariaLabel="Session inspector"
+				browserPoppedOut={false}
+				onViewChange={onViewChange}
+				reviewsView={<div role="tabpanel">reviews slot</div>}
+				tabs={tabs}
+			/>,
+		);
+		expect(screen.getByText("reviews slot")).toBeInTheDocument();
 
 		rerender(
 			<SessionInspectorShellView

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -19,7 +19,7 @@ import type {
 } from "./pull-request-models";
 import { cn } from "./utils";
 
-export type InspectorView = "summary" | "browser" | "files";
+export type InspectorView = "summary" | "reviews" | "browser" | "files";
 
 export type InspectorTab = {
 	badge?: boolean;
@@ -42,6 +42,7 @@ export function SessionInspectorShellView({
 	filesView,
 	loadingText,
 	onViewChange,
+	reviewsView,
 	summaryView,
 	tabs,
 }: {
@@ -52,6 +53,7 @@ export function SessionInspectorShellView({
 	filesView?: ReactNode;
 	loadingText?: string;
 	onViewChange: (view: InspectorView) => void;
+	reviewsView?: ReactNode;
 	summaryView?: ReactNode;
 	tabs: InspectorTab[];
 }) {
@@ -141,6 +143,7 @@ export function SessionInspectorShellView({
 				)}
 			>
 				{activeView === "summary" ? summaryView : null}
+				{activeView === "reviews" ? reviewsView : null}
 				{activeView === "browser" ? browserView : null}
 				{activeView === "files" ? filesView : null}
 			</div>


### PR DESCRIPTION
Moves review controls, history, and external feedback into a dedicated Reviews tab. Keeps Summary focused on pull requests, session controls, and activity.

<img width="521" height="877" alt="image" src="https://github.com/user-attachments/assets/d7c753e6-f373-4cd6-82c1-89275913709d" />
<img width="521" height="877" alt="image" src="https://github.com/user-attachments/assets/9b81919e-a0cf-4456-acc2-e46c20ce1567" />
