### PR TITLE
fix: clear titlebar nav over chat session tabs

### DIFF
--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../lib/chat-fixture";
 import type { ConversationMessage, ConversationSnapshot } from "../../types/conversation";
 import { setApiBaseUrl } from "../../lib/api-client";
+import { useUiStore } from "../../stores/ui-store";
 
 const writeText = vi.fn(async (_text: string) => undefined);
 const menuAction = vi.fn(async (_action: string) => undefined);
@@ -22,6 +23,11 @@ vi.mock("../../lib/bridge", () => ({
 		clipboard: { writeText: (text: string) => writeText(text) },
 		menu: { action: (action: string) => menuAction(action) },
 	},
+}));
+
+vi.mock("../../lib/platform", () => ({
+	isMacPlatform: () => true,
+	isLinuxPlatform: () => false,
 }));
 
 /** A refetch: identical content, all-new objects, which is what JSON parsing gives. */
@@ -56,6 +62,7 @@ beforeEach(() => {
 	writeText.mockClear();
 	menuAction.mockClear();
 	setApiBaseUrl("http://127.0.0.1:3001");
+	useUiStore.setState({ isSidebarOpen: true });
 });
 
 afterEach(() => setApiBaseUrl(null));
@@ -168,6 +175,22 @@ describe("ChatWorkspace timeline", () => {
 		expect(screen.getByLabelText("Chat")).toHaveAttribute("data-session-role", "orchestrator");
 		expect(screen.getByTestId("session-workspace-topbar")).toBeInTheDocument();
 		expect(screen.getByTestId("session-action-region")).toBeInTheDocument();
+	});
+
+	it("clears the fixed titlebar nav when the sidebar is collapsed, like the terminal session", () => {
+		useUiStore.setState({ isSidebarOpen: false });
+		const { rerender } = render(<ChatWorkspace snapshot={chatFixture} />);
+
+		expect(screen.getByTestId("session-terminal-region")).toHaveClass(
+			"session-topbar-titlebar-clearance-mac",
+		);
+
+		useUiStore.setState({ isSidebarOpen: true });
+		rerender(<ChatWorkspace snapshot={chatFixture} />);
+
+		expect(screen.getByTestId("session-terminal-region")).not.toHaveClass(
+			"session-topbar-titlebar-clearance-mac",
+		);
 	});
 
 	it("keeps chat font controls scoped to the chat instead of native page zoom", () => {

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -44,6 +44,8 @@ import {
 import { cn } from "../../lib/utils";
 import { sameContent, useStableList } from "../../lib/stable-list";
 import { getApiBaseUrl, subscribeApiBaseUrl } from "../../lib/api-client";
+import { isLinuxPlatform, isMacPlatform } from "../../lib/platform";
+import { useUiStore } from "../../stores/ui-store";
 import type { SessionKind } from "../../types/workspace";
 import { AgentAvatar } from "../AgentAvatar";
 import { Button } from "../ui/button";
@@ -101,6 +103,8 @@ import {
 const CHAT_FONT_SIZE_MIN = 11;
 const CHAT_FONT_SIZE_MAX = 24;
 const CHAT_FONT_SIZE_DEFAULT = 12;
+const isMac = isMacPlatform();
+const isLinux = isLinuxPlatform();
 
 function clampChatFontSize(size: number): number {
 	return Math.min(CHAT_FONT_SIZE_MAX, Math.max(CHAT_FONT_SIZE_MIN, size));
@@ -684,12 +688,20 @@ function ChatHeader({
 	topbarBounds: TopbarBounds;
 }) {
 	const label = sessionTitle || snapshot.title || snapshot.sessionId;
+	// Match CenterPane: when the sidebar is off-canvas, the fixed TitlebarNav
+	// cluster sits over the session tab strip. Terminal already reserves that
+	// space; chat must too or the back/forward buttons land on the tab label.
+	const isSidebarOpen = useUiStore((state) => state.isSidebarOpen);
 	return (
 		<SessionTopbarPortal>
 			<header className="flex h-inspector-tabs w-full shrink-0 items-stretch bg-sidebar">
 				<div className="session-topbar-surface flex min-w-0 flex-1" data-testid="session-workspace-topbar">
 					<div
-						className="flex min-w-0 shrink items-center pr-1.5"
+						className={cn(
+							"flex min-w-0 shrink items-center pr-3",
+							!isFullscreen && !isSidebarOpen && isMac && "session-topbar-titlebar-clearance-mac",
+							!isFullscreen && !isSidebarOpen && isLinux && "session-topbar-titlebar-clearance-linux",
+						)}
 						data-testid="session-terminal-region"
 						style={{ width: topbarBounds.width > 0 ? topbarBounds.width : "100%" }}
 					>


### PR DESCRIPTION
## Summary
- Apply the same macOS/Linux `session-topbar-titlebar-clearance-*` padding the terminal session already uses when the sidebar is off-canvas.
- Stops the fixed TitlebarNav back/forward controls from overlapping the chat session tab (e.g. "Untitled task").

## Test plan
- [ ] On macOS, collapse the sidebar on a **chat** session and confirm back/forward no longer sit on the tab label.
- [ ] Expand the sidebar and confirm tab layout is unchanged.
- [ ] Compare with a **terminal** session: clearance behavior should match.
- [ ] `cd frontend && npm run test -- --run src/renderer/components/chat/ChatWorkspace.test.tsx`

## Before
<img width="254" height="109" alt="image" src="https://github.com/user-attachments/assets/96ae54ba-034a-4356-abc7-52cefc486a34" />
<img width="230" height="48" alt="image" src="https://github.com/user-attachments/assets/79c20905-0298-40c1-9c5a-699f099641fa" />

## After
<img width="526" height="95" alt="image" src="https://github.com/user-attachments/assets/af27c709-40bc-4049-a8d4-a9efadc86864" />
<img width="415" height="60" alt="image" src="https://github.com/user-attachments/assets/ae4d17ca-d127-4553-8643-98c9133a81c8" />
