### PR TITLE
fix: put notifications before inspector and use PanelRight icon

### DIFF
--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -51,7 +51,9 @@ vi.mock("../lib/telemetry", () => ({
 	captureRendererException: vi.fn(),
 }));
 vi.mock("./NewTaskDialog", () => ({ NewTaskDialog: () => null }));
-vi.mock("./NotificationCenter", () => ({ NotificationCenter: () => null }));
+vi.mock("./NotificationCenter", () => ({
+	NotificationCenter: () => <button type="button" aria-label="Notifications">Notifications</button>,
+}));
 
 const worker: WorkspaceSession = {
 	id: "sess-1",
@@ -367,6 +369,19 @@ describe("ShellTopbar orchestrator actions", () => {
 });
 
 describe("ShellTopbar inspector state", () => {
+	it("places notifications before the inspector toggle on worker sessions", () => {
+		renderTopbarSessions([worker], "sess-1");
+
+		const actions = screen.getByTestId("workspace-topbar-actions");
+		const buttons = within(actions)
+			.getAllByRole("button")
+			.map((button) => button.getAttribute("aria-label"));
+		const notificationsIndex = buttons.indexOf("Notifications");
+		const inspectorIndex = buttons.indexOf("Close inspector panel");
+		expect(notificationsIndex).toBeGreaterThanOrEqual(0);
+		expect(inspectorIndex).toBeGreaterThan(notificationsIndex);
+	});
+
 	it("treats missing worker inspector state as open", async () => {
 		renderTopbarSessions([worker], "sess-1");
 

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { Folder, LayoutDashboard, PanelRightClose, PanelRightOpen, Plus, Trash2 } from "lucide-react";
+import { Folder, LayoutDashboard, PanelRight, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState, type ReactNode } from "react";
 import { animate, LayoutGroup, motion, useMotionValue, useReducedMotion } from "motion/react";
 import { NotificationCenter } from "./NotificationCenter";
@@ -368,6 +368,8 @@ export function ShellTopbar({
 								<TooltipContent side="bottom">{orchestratorTooltip}</TooltipContent>
 							</Tooltip>
 						) : null}
+						{/* Bell before inspector so expand/collapse stays the trailing control. */}
+						{!isOrchestrator ? <NotificationCenter style={noDragStyle} /> : null}
 						{/* Inspector collapse (worker sessions only — orchestrators have no rail). */}
 						{!isOrchestrator && (
 							<TopbarButton
@@ -378,17 +380,13 @@ export function ShellTopbar({
 								title={isInspectorOpen ? t("shell.closeInspectorTitle") : t("shell.openInspectorTitle")}
 								variant="icon"
 							>
-								{isInspectorOpen ? (
-									<PanelRightClose className="size-icon-md" aria-hidden="true" />
-								) : (
-									<PanelRightOpen className="size-icon-md" aria-hidden="true" />
-								)}
+								<PanelRight className="size-icon-md" aria-hidden="true" />
 							</TopbarButton>
 						)}
 					</>
 				) : null}
-				{/* The bell always trails the actions row, on every platform. */}
-				<NotificationCenter style={noDragStyle} />
+				{/* Bell trails the actions row when there is no inspector toggle after it. */}
+				{!(isSessionRoute && !isOrchestrator) ? <NotificationCenter style={noDragStyle} /> : null}
 			</div>
 		</motion.header>
 	</LayoutGroup>


### PR DESCRIPTION
## Summary
- Place the notification bell before the inspector toggle on worker sessions so expand/collapse stays the trailing control
- Replace PanelRightClose/PanelRightOpen with PanelRight to match the left sidebar’s PanelLeft style
- Cover the button order with a ShellTopbar unit test

## Test plan
- [ ] Open a worker session: confirm order is … → notifications → inspector toggle
- [ ] Confirm inspector icon is the right-panel glyph (no chevron)
- [ ] Toggle inspector open/closed; aria labels and behavior still work
- [ ] On board / orchestrator routes, notification bell still trails the actions row
- [ ] `npx vitest run src/renderer/components/ShellTopbar.test.tsx`

## Before
<img width="385" height="98" alt="image" src="https://github.com/user-attachments/assets/421b2c3c-bed7-43e0-9edc-2b6ead1537d9" />

## After
<img width="362" height="76" alt="image" src="https://github.com/user-attachments/assets/2a65c3ef-f8aa-4ddc-aca2-043a0066dc06" />