### PR TITLE
fix: drop leftover chat strip controls to match terminal

### DIFF
--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -193,28 +193,21 @@ describe("ChatWorkspace timeline", () => {
 		);
 	});
 
-	it("keeps chat font controls scoped to the chat instead of native page zoom", () => {
-		render(<ChatWorkspace snapshot={chatFixture} />);
+	it("leaves new-terminal and display controls out of the chat strip, like the terminal session", () => {
+		render(<ChatWorkspace snapshot={chatFixture} onOpenShell={vi.fn()} />);
 
-		fireEvent.click(screen.getByRole("button", { name: "Decrease font size" }));
-		fireEvent.click(screen.getByRole("button", { name: "Increase font size" }));
-
-		expect(menuAction).not.toHaveBeenCalled();
+		const terminalRegion = screen.getByTestId("session-terminal-region");
+		expect(terminalRegion).toContainElement(screen.getByRole("tablist", { name: "Chat tabs" }));
+		expect(terminalRegion).not.toContainElement(screen.queryByRole("button", { name: "New terminal" }));
+		expect(screen.queryByRole("toolbar", { name: "Chat display controls" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Decrease font size" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Fullscreen" })).not.toBeInTheDocument();
 	});
 
-	it("starts chat text at 12px and updates its scoped font size with the controls", () => {
+	it("starts chat text at 12px without a topbar font control", () => {
 		render(<ChatWorkspace snapshot={chatFixture} />);
 		const chat = screen.getByLabelText("Chat");
 
-		expect(screen.getByLabelText("Chat font size: 12 pixels")).toHaveTextContent("12px");
-		expect(chat.style.getPropertyValue("--chat-font-size")).toBe("12px");
-
-		fireEvent.click(screen.getByRole("button", { name: "Increase font size" }));
-		expect(screen.getByLabelText("Chat font size: 13 pixels")).toHaveTextContent("13px");
-		expect(chat.style.getPropertyValue("--chat-font-size")).toBe("13px");
-
-		fireEvent.click(screen.getByRole("button", { name: "Decrease font size" }));
-		expect(screen.getByLabelText("Chat font size: 12 pixels")).toHaveTextContent("12px");
 		expect(chat.style.getPropertyValue("--chat-font-size")).toBe("12px");
 	});
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -32,11 +32,7 @@ import {
 	CornerDownRight,
 	GitBranch,
 	Loader2,
-	Maximize2,
 	MessageSquare,
-	Minimize2,
-	Minus,
-	Plus,
 	Square,
 	TriangleAlert,
 	Undo2,
@@ -100,15 +96,9 @@ import {
 	type TurnSettings,
 } from "../../types/conversation";
 
-const CHAT_FONT_SIZE_MIN = 11;
-const CHAT_FONT_SIZE_MAX = 24;
 const CHAT_FONT_SIZE_DEFAULT = 12;
 const isMac = isMacPlatform();
 const isLinux = isLinuxPlatform();
-
-function clampChatFontSize(size: number): number {
-	return Math.min(CHAT_FONT_SIZE_MAX, Math.max(CHAT_FONT_SIZE_MIN, size));
-}
 
 type TopbarBounds = {
 	leftInset: number;
@@ -301,25 +291,12 @@ export function ChatWorkspace({
 	// The turn a confirmation is open for. Undo is not reversible and it changes what
 	// the agent knows, so it is never one click.
 	const [confirming, setConfirming] = useState<string | undefined>(undefined);
-	const [chatFontSize, setChatFontSize] = useState(CHAT_FONT_SIZE_DEFAULT);
-	const [isFullscreen, setIsFullscreen] = useState(false);
 	const surfaceRef = useRef<HTMLElement | null>(null);
 	const [topbarBounds, setTopbarBounds] = useState<TopbarBounds>({
 		leftInset: 0,
 		rightInset: 0,
 		width: 0,
 	});
-
-	const fullscreenTarget = useCallback(() => {
-		const surface = surfaceRef.current;
-		return surface?.closest<HTMLElement>(".center-panel-surface") ?? surface;
-	}, []);
-
-	useEffect(() => {
-		const handleFullscreenChange = () => setIsFullscreen(document.fullscreenElement === fullscreenTarget());
-		document.addEventListener("fullscreenchange", handleFullscreenChange);
-		return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
-	}, [fullscreenTarget]);
 
 	useEffect(() => {
 		const surface = surfaceRef.current;
@@ -349,24 +326,6 @@ export function ChatWorkspace({
 		return () => observer.disconnect();
 	}, []);
 
-	const updateChatFontSize = useCallback((delta: number) => {
-		setChatFontSize((current) => clampChatFontSize(current + delta));
-	}, []);
-
-	const toggleFullscreen = useCallback(async () => {
-		const target = fullscreenTarget();
-		if (!target) return;
-		try {
-			if (document.fullscreenElement === target) {
-				await document.exitFullscreen();
-				return;
-			}
-			await target.requestFullscreen();
-		} catch (error) {
-			console.warn("Unable to toggle chat fullscreen", error);
-		}
-	}, [fullscreenTarget]);
-
 	// Offered only while the agent is idle. The daemon refuses a rollback mid-turn,
 	// and a control that exists to be refused is worse than one that waits.
 	const rollbackTarget = onRollback && !turn ? (id: string) => setConfirming(id) : undefined;
@@ -382,7 +341,7 @@ export function ChatWorkspace({
 			className="cursor-chat-surface flex h-full min-h-0 flex-col [font-size:var(--chat-font-size)]"
 			data-session-mode={snapshot.mode}
 			data-session-role={sessionRole}
-			style={{ "--chat-font-size": `${chatFontSize}px` } as CSSProperties}
+			style={{ "--chat-font-size": `${CHAT_FONT_SIZE_DEFAULT}px` } as CSSProperties}
 		>
 			<ChatHeader
 				snapshot={snapshot}
@@ -390,14 +349,6 @@ export function ChatWorkspace({
 				reviewerTerminal={reviewerTerminal}
 				onOpenReviewerTerminal={onOpenReviewerTerminal}
 				headerActions={headerActions}
-				onOpenShell={onOpenShell}
-				openingShell={openingShell}
-				shellError={shellError}
-				fontSize={chatFontSize}
-				onDecreaseFontSize={() => updateChatFontSize(-1)}
-				onIncreaseFontSize={() => updateChatFontSize(1)}
-				isFullscreen={isFullscreen}
-				onToggleFullscreen={() => void toggleFullscreen()}
 				topbarBounds={topbarBounds}
 			/>
 			{/* Ordered by what blocks what. A session that needs credentials cannot make
@@ -662,14 +613,6 @@ function ChatHeader({
 	reviewerTerminal,
 	onOpenReviewerTerminal,
 	headerActions,
-	onOpenShell,
-	openingShell,
-	shellError,
-	fontSize,
-	onDecreaseFontSize,
-	onIncreaseFontSize,
-	isFullscreen,
-	onToggleFullscreen,
 	topbarBounds,
 }: {
 	snapshot: ConversationSnapshot;
@@ -677,14 +620,6 @@ function ChatHeader({
 	reviewerTerminal?: { handleId: string; harness: string };
 	onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
 	headerActions?: ReactNode;
-	onOpenShell?: () => void;
-	openingShell?: boolean;
-	shellError?: string;
-	fontSize: number;
-	onDecreaseFontSize: () => void;
-	onIncreaseFontSize: () => void;
-	isFullscreen: boolean;
-	onToggleFullscreen: () => void;
 	topbarBounds: TopbarBounds;
 }) {
 	const label = sessionTitle || snapshot.title || snapshot.sessionId;
@@ -699,107 +634,51 @@ function ChatHeader({
 					<div
 						className={cn(
 							"flex min-w-0 shrink items-center pr-3",
-							!isFullscreen && !isSidebarOpen && isMac && "session-topbar-titlebar-clearance-mac",
-							!isFullscreen && !isSidebarOpen && isLinux && "session-topbar-titlebar-clearance-linux",
+							!isSidebarOpen && isMac && "session-topbar-titlebar-clearance-mac",
+							!isSidebarOpen && isLinux && "session-topbar-titlebar-clearance-linux",
 						)}
 						data-testid="session-terminal-region"
 						style={{ width: topbarBounds.width > 0 ? topbarBounds.width : "100%" }}
 					>
-						<div className="flex h-full min-w-flex-min flex-1 items-center">
-							<div
-								aria-label="Chat tabs"
-								className="scrollbar-none flex min-w-flex-min flex-1 self-stretch items-center overflow-x-auto"
-								role="tablist"
+						<div
+							aria-label="Chat tabs"
+							className="scrollbar-none flex h-full min-w-flex-min flex-1 items-center overflow-x-auto"
+							role="tablist"
+						>
+							<span
+								data-terminal-role="primary"
+								className="group relative inline-flex min-w-shell-tab-min self-stretch items-center gap-1.5 border-r border-border bg-overlay px-3 text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground/80"
 							>
-								<span
-									data-terminal-role="primary"
-									className="group relative inline-flex min-w-shell-tab-min self-stretch items-center gap-1.5 border-r border-border bg-overlay px-3 text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground/80"
+								<AgentAvatar className="size-icon-base" decorative provider={snapshot.harness} />
+								<button
+									aria-current
+									aria-label={label}
+									aria-selected
+									className="inline-flex min-w-flex-min max-w-shell-tab-max items-center gap-1.5 text-control font-medium leading-none text-foreground transition-colors"
+									role="tab"
+									tabIndex={0}
+									title={label}
+									type="button"
 								>
-									<AgentAvatar className="size-icon-base" decorative provider={snapshot.harness} />
+									<span className="truncate">{label}</span>
+								</button>
+							</span>
+							{reviewerTerminal ? (
+								<span className="group relative inline-flex min-w-shell-tab-min self-stretch items-center gap-1.5 border-r border-border px-3 text-muted-foreground hover:bg-raised hover:text-foreground">
+									<AgentAvatar className="size-icon-base" decorative provider={reviewerTerminal.harness} />
 									<button
-										aria-current
-										aria-label={label}
-										aria-selected
-										className="inline-flex min-w-flex-min max-w-shell-tab-max items-center gap-1.5 text-control font-medium leading-none text-foreground transition-colors"
+										aria-label="Reviewer"
+										className="inline-flex min-w-flex-min max-w-shell-tab-max items-center gap-1.5 text-control font-medium leading-none"
+										onClick={() => onOpenReviewerTerminal?.(reviewerTerminal)}
 										role="tab"
 										tabIndex={0}
-										title={label}
+										title={reviewerTerminal.harness}
 										type="button"
 									>
-										<span className="truncate">{label}</span>
+										<span className="truncate">Reviewer</span>
 									</button>
 								</span>
-								{reviewerTerminal ? (
-									<span className="group relative inline-flex min-w-shell-tab-min self-stretch items-center gap-1.5 border-r border-border px-3 text-muted-foreground hover:bg-raised hover:text-foreground">
-										<AgentAvatar className="size-icon-base" decorative provider={reviewerTerminal.harness} />
-										<button
-											aria-label="Reviewer"
-											className="inline-flex min-w-flex-min max-w-shell-tab-max items-center gap-1.5 text-control font-medium leading-none"
-											onClick={() => onOpenReviewerTerminal?.(reviewerTerminal)}
-											role="tab"
-											tabIndex={0}
-											title={reviewerTerminal.harness}
-											type="button"
-										>
-											<span className="truncate">Reviewer</span>
-										</button>
-									</span>
-								) : null}
-							</div>
-							<Button
-								aria-label="New terminal"
-								className="shrink-0 text-muted-foreground"
-								disabled={!onOpenShell || openingShell}
-								onClick={onOpenShell}
-								size="icon-sm"
-								title={shellError || "New terminal"}
-								type="button"
-								variant="outline"
-							>
-								{openingShell ? (
-									<Loader2 aria-hidden="true" className="size-icon-md animate-spin" />
-								) : (
-									<Plus aria-hidden="true" className="size-icon-md" />
-								)}
-							</Button>
-						</div>
-						<div
-							aria-label="Chat display controls"
-							className="ml-1.5 flex shrink-0 items-center gap-0.5 border-l border-border/70 pl-1.5"
-							role="toolbar"
-						>
-							<ChatTopbarControl
-								disabled={fontSize <= CHAT_FONT_SIZE_MIN}
-								label="Decrease font size"
-								onClick={onDecreaseFontSize}
-							>
-								<Minus aria-hidden="true" className="size-icon-sm" />
-							</ChatTopbarControl>
-							<span
-								aria-label={`Chat font size: ${fontSize} pixels`}
-								className="w-font-size-label text-center font-mono text-micro tabular-nums text-muted-foreground"
-							>
-								{fontSize}px
-							</span>
-							<ChatTopbarControl
-								disabled={fontSize >= CHAT_FONT_SIZE_MAX}
-								label="Increase font size"
-								onClick={onIncreaseFontSize}
-							>
-								<Plus aria-hidden="true" className="size-icon-sm" />
-							</ChatTopbarControl>
-							<div aria-hidden="true" className="mx-1 h-4 w-px bg-border/70" />
-							<ChatTopbarControl
-								isPressed={isFullscreen}
-								label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-								onClick={onToggleFullscreen}
-							>
-								{isFullscreen ? (
-									<Minimize2 aria-hidden="true" className="size-icon-md" />
-								) : (
-									<Maximize2 aria-hidden="true" className="size-icon-md" />
-								)}
-							</ChatTopbarControl>
+							) : null}
 						</div>
 					</div>
 					<div className="ml-auto flex shrink-0 items-center px-3" data-testid="session-action-region">
@@ -808,36 +687,6 @@ function ChatHeader({
 				</div>
 			</header>
 		</SessionTopbarPortal>
-	);
-}
-
-function ChatTopbarControl({
-	children,
-	disabled,
-	isPressed,
-	label,
-	onClick,
-}: {
-	children: ReactNode;
-	disabled?: boolean;
-	isPressed?: boolean;
-	label: string;
-	onClick: () => void;
-}) {
-	return (
-		<Button
-			aria-label={label}
-			aria-pressed={isPressed}
-			className="size-control-sm p-0 text-passive"
-			disabled={disabled}
-			onClick={onClick}
-			size="icon-sm"
-			title={label}
-			type="button"
-			variant="ghost"
-		>
-			{children}
-		</Button>
 	);
 }
 


### PR DESCRIPTION
## Summary
- Remove the leftover chat tab-strip controls (new terminal, font size, fullscreen) so chat matches the terminal session chrome
- Keep new terminal in the session actions on the right, same as terminal sessions
- Cover the strip with a ChatWorkspace unit test

## Test plan
- [ ] New Chat UI session: tab strip shows only the chat tab (no +, 12px, or fullscreen)
- [ ] New Terminal session: strip still has no display controls
- [ ] Add a terminal from a Chat UI session: chrome does not change to hide leftover chat-only controls
- [ ] Worker new-terminal action still works from the right-side session actions
- [ ] `npx vitest run src/renderer/components/chat/ChatWorkspace.test.tsx src/renderer/components/SessionView.test.tsx`

## Before
<img width="887" height="150" alt="image" src="https://github.com/user-attachments/assets/7a40448c-9a73-4b49-a597-9fc2e48a8736" />


## After
<img width="935" height="194" alt="image" src="https://github.com/user-attachments/assets/90a832a6-c502-4ada-9773-91e9e5c6e6c6" />
