### PR TITLE
fix: validate Claude models against ACP catalog

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/config_options.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
@@ -195,6 +196,46 @@ func choiceOffered(choices []ports.ChatConfigOptionChoice, value string) bool {
 		}
 	}
 	return false
+}
+
+// validateAdvertisedSessionOptions checks adapter-provided turn overrides
+// against the live catalog before any ACP setter runs. An empty catalog retains
+// compatibility with agents that support setters but do not advertise options;
+// once a catalog exists, it is authoritative for both option ids and values.
+func validateAdvertisedSessionOptions(catalog []ports.ChatConfigOption, requested []SessionOption) error {
+	if len(catalog) == 0 {
+		return nil
+	}
+	for _, request := range requested {
+		if request.ID == "" || request.Value == "" {
+			continue
+		}
+		var advertised *ports.ChatConfigOption
+		for i := range catalog {
+			if catalog[i].ID == request.ID {
+				advertised = &catalog[i]
+				break
+			}
+		}
+		if advertised == nil {
+			return fmt.Errorf("%w: ACP session config option %q is not advertised by the active provider", ports.ErrChatConfigOptionInvalid, request.ID)
+		}
+		if advertised.Type != ports.ChatConfigOptionSelect {
+			return fmt.Errorf("%w: ACP session config option %q does not accept a select value", ports.ErrChatConfigOptionInvalid, request.ID)
+		}
+		if choiceOffered(advertised.Choices, request.Value) {
+			continue
+		}
+		offered := make([]string, 0, len(advertised.Choices))
+		for _, choice := range advertised.Choices {
+			offered = append(offered, choice.Value)
+		}
+		return fmt.Errorf(
+			"%w: ACP session config option %q does not offer value %q; choose Agent default or an advertised value (%s)",
+			ports.ErrChatConfigOptionInvalid, request.ID, request.Value, strings.Join(offered, ", "),
+		)
+	}
+	return nil
 }
 
 func cloneConfigOptions(options []ports.ChatConfigOption) []ports.ChatConfigOption {

--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -230,9 +230,17 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 	sessionID := c.sessionID
 	modeFor := c.modeFor
 	optionsFor := c.optionsFor
+	configOptions := cloneConfigOptions(c.configOptions)
 	c.mu.Unlock()
 	if sessionID == "" {
 		return errors.New("ACP session is not open")
+	}
+	var sessionOptions []SessionOption
+	if optionsFor != nil {
+		sessionOptions = optionsFor(settings)
+		if err := validateAdvertisedSessionOptions(configOptions, sessionOptions); err != nil {
+			return err
+		}
 	}
 	if modeFor != nil {
 		if mode := modeFor(settings.Approval); mode != "" {
@@ -247,7 +255,7 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 		}
 	}
 	if optionsFor != nil {
-		for _, option := range optionsFor(settings) {
+		for _, option := range sessionOptions {
 			if option.ID == "" || option.Value == "" {
 				continue
 			}

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -984,6 +984,140 @@ func TestACPDriverExposesAndMutatesAdvertisedConfigOptions(t *testing.T) {
 	}
 }
 
+func TestACPDriverRejectsTurnModelMissingFromAdvertisedCatalog(t *testing.T) {
+	agent := &fakeAgent{
+		newConfig:          []acpsdk.SessionConfigOption{selectConfigOption("model", "Model", "model", "sonnet", "sonnet")},
+		promptNoPermission: true,
+	}
+	driver := newModelCatalogTestDriver(agent)
+
+	conv, err := driver.Start(context.Background(), ports.ChatStartConfig{WorkspacePath: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer conv.Close()
+
+	if _, err := conv.SendTurn(context.Background(), ports.ChatUserMessage{
+		Text:     "use opus",
+		Settings: ports.ChatTurnSettings{Model: "opus"},
+	}); !errors.Is(err, ports.ErrChatConfigOptionInvalid) {
+		t.Fatalf("SendTurn error = %v, want ErrChatConfigOptionInvalid", err)
+	}
+	agent.mu.Lock()
+	setCalls := agent.setCalls
+	agent.mu.Unlock()
+	if setCalls != 0 {
+		t.Fatalf("provider config setter called %d times for an unadvertised model", setCalls)
+	}
+
+	// Validation must not poison the conversation: choosing an advertised value
+	// on the same instance can still prepare and run a turn.
+	ref, err := conv.SendTurn(context.Background(), ports.ChatUserMessage{
+		Text:     "use sonnet",
+		Settings: ports.ChatTurnSettings{Model: "sonnet"},
+	})
+	if err != nil {
+		t.Fatalf("retry SendTurn: %v", err)
+	}
+	if err := conv.(ports.ChatDeferredTurnStarter).StartDeferredTurn(ref.ProviderTurnID); err != nil {
+		t.Fatalf("retry StartDeferredTurn: %v", err)
+	}
+	for {
+		event := nextEvent(t, conv.Events())
+		if event.Kind == ports.ChatEventTurnCompleted {
+			if event.TurnState != domain.TurnStateCompleted {
+				t.Fatalf("retry turn state = %q", event.TurnState)
+			}
+			break
+		}
+	}
+}
+
+func TestACPDriverRejectsStaleCrossProviderModelBeforeProviderExecution(t *testing.T) {
+	agent := &fakeAgent{
+		newConfig: []acpsdk.SessionConfigOption{selectConfigOption("model", "Model", "model", "sonnet", "sonnet")},
+	}
+	driver := newModelCatalogTestDriver(agent)
+
+	conv, err := driver.Start(context.Background(), ports.ChatStartConfig{WorkspacePath: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer conv.Close()
+
+	if _, err := conv.SendTurn(context.Background(), ports.ChatUserMessage{
+		Text:     "stale model",
+		Settings: ports.ChatTurnSettings{Model: "gpt-5.4-mini"},
+	}); !errors.Is(err, ports.ErrChatConfigOptionInvalid) {
+		t.Fatalf("SendTurn error = %v, want ErrChatConfigOptionInvalid", err)
+	}
+	agent.mu.Lock()
+	setCalls := agent.setCalls
+	agent.mu.Unlock()
+	if setCalls != 0 {
+		t.Fatalf("provider config setter called %d times for a cross-provider model", setCalls)
+	}
+}
+
+func TestACPDriverUsesAdvertisedDefaultWhenTurnHasNoModelOverride(t *testing.T) {
+	agent := &fakeAgent{
+		newConfig:          []acpsdk.SessionConfigOption{selectConfigOption("model", "Model", "model", "provider/sonnet-default", "provider/sonnet-default")},
+		promptNoPermission: true,
+	}
+	driver := newModelCatalogTestDriver(agent)
+
+	conv, err := driver.Start(context.Background(), ports.ChatStartConfig{WorkspacePath: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer conv.Close()
+
+	ref, err := conv.SendTurn(context.Background(), ports.ChatUserMessage{Text: "use the provider default"})
+	if err != nil {
+		t.Fatalf("SendTurn: %v", err)
+	}
+	if err := conv.(ports.ChatDeferredTurnStarter).StartDeferredTurn(ref.ProviderTurnID); err != nil {
+		t.Fatalf("StartDeferredTurn: %v", err)
+	}
+	for {
+		event := nextEvent(t, conv.Events())
+		if event.Kind == ports.ChatEventTurnCompleted {
+			break
+		}
+	}
+
+	agent.mu.Lock()
+	gotModel, setCalls := agent.options["model"], agent.setCalls
+	agent.mu.Unlock()
+	if gotModel != "" || setCalls != 0 {
+		t.Fatalf("provider received model override %q across %d calls; want advertised default left unchanged", gotModel, setCalls)
+	}
+	options, err := conv.(ports.ChatConfigOptionController).ListConfigOptions(context.Background())
+	if err != nil {
+		t.Fatalf("ListConfigOptions: %v", err)
+	}
+	if len(options) != 1 || options[0].Current.Select != "provider/sonnet-default" {
+		t.Fatalf("effective model option = %#v", options)
+	}
+}
+
+func newModelCatalogTestDriver(agent *fakeAgent) *Driver {
+	driver := New(Config{
+		Harness:      domain.HarnessClaudeCode,
+		Capabilities: ports.ChatCapabilities{ports.ChatCapabilityStreaming: true},
+		Probe:        func(context.Context) error { return nil },
+		Launch:       func(context.Context, LaunchConfig) (Launch, error) { return Launch{Command: "fake"}, nil },
+		SessionOptions: func(settings ports.ChatTurnSettings) []SessionOption {
+			if settings.Model == "" {
+				return nil
+			}
+			return []SessionOption{{ID: "model", Value: settings.Model}}
+		},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	driver.spawn = fakeSpawn(agent)
+	return driver
+}
+
 func TestACPDriverExposesDynamicAvailableCommandsAsSkills(t *testing.T) {
 	agent := &fakeAgent{}
 	driver := New(Config{

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -52,6 +52,7 @@ export function SessionChatSurface({
 	const configOptions = useConversationConfigOptions(
 		session.id,
 		Boolean(snapshot && can(snapshot, "config_options")),
+		session.provider,
 	);
 	// A provider config catalog may cover only model, only mode, or both.
 	// Suppress native controls only for dimensions the provider catalog replaces;

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
@@ -86,4 +86,55 @@ describe("ACP session config options", () => {
 		await user.click(screen.getByRole("menuitem", { name: "Sonnet 5" }));
 		expect(onChange).toHaveBeenCalledWith("model", { value: "sonnet" });
 	});
+
+	it("never renders an unadvertised model as selectable", async () => {
+		const user = userEvent.setup();
+		render(
+			<TurnSettingsBar
+				models={[]}
+				settings={{}}
+				configOptions={[
+					{
+						...OPTIONS[0],
+						currentValue: "provider/sonnet",
+						choices: [{ value: "provider/sonnet", name: "Sonnet" }],
+					},
+				]}
+				onChangeConfigOption={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Model" }));
+		expect(screen.getByRole("menuitem", { name: /Sonnet/ })).toBeInTheDocument();
+		expect(screen.queryByRole("menuitem", { name: /Opus/i })).not.toBeInTheDocument();
+	});
+
+	it("updates its label to the provider current value when the catalog changes", () => {
+		const { rerender } = render(
+			<TurnSettingsBar
+				models={[]}
+				settings={{}}
+				configOptions={[OPTIONS[0]]}
+				onChangeConfigOption={vi.fn()}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent("Opus 5");
+
+		rerender(
+			<TurnSettingsBar
+				models={[]}
+				settings={{}}
+				configOptions={[
+					{
+						...OPTIONS[0],
+						currentValue: "sonnet",
+						choices: [{ value: "sonnet", name: "Sonnet 5" }],
+					},
+				]}
+				onChangeConfigOption={vi.fn()}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent("Sonnet 5");
+		expect(screen.queryByText("Opus 5")).not.toBeInTheDocument();
+	});
 });

--- a/frontend/src/renderer/hooks/useConversation.test.tsx
+++ b/frontend/src/renderer/hooks/useConversation.test.tsx
@@ -4,20 +4,25 @@ import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
-const { getMock, postMock, apiErrorCodeMock, apiErrorMessageMock } = vi.hoisted(() => ({
+const { getMock, postMock, patchMock, apiErrorCodeMock, apiErrorMessageMock } = vi.hoisted(() => ({
 	getMock: vi.fn(),
 	postMock: vi.fn(),
+	patchMock: vi.fn(),
 	apiErrorCodeMock: vi.fn(),
 	apiErrorMessageMock: vi.fn(),
 }));
 
 vi.mock("../lib/api-client", () => ({
-	apiClient: { GET: getMock, POST: postMock, PATCH: vi.fn() },
+	apiClient: { GET: getMock, POST: postMock, PATCH: patchMock },
 	apiErrorCode: apiErrorCodeMock,
 	apiErrorMessage: apiErrorMessageMock,
 }));
 
-import { useConversation, useConversationCommands } from "./useConversation";
+import {
+	useConversation,
+	useConversationCommands,
+	useConversationConfigOptions,
+} from "./useConversation";
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -75,8 +80,71 @@ const WIRE = {
 beforeEach(() => {
 	getMock.mockReset();
 	postMock.mockReset();
+	patchMock.mockReset();
 	apiErrorCodeMock.mockReset().mockReturnValue(undefined);
 	apiErrorMessageMock.mockReset().mockReturnValue("failed");
+});
+
+describe("ACP config option catalog", () => {
+	it("refetches for an agent change and adopts the target provider current model", async () => {
+		getMock
+			.mockResolvedValueOnce({
+				data: {
+					options: [{ id: "model", type: "select", currentValue: "opus", choices: [{ value: "opus", name: "Opus" }] }],
+				},
+				error: undefined,
+			})
+			.mockResolvedValueOnce({
+				data: {
+					options: [{ id: "model", type: "select", currentValue: "sonnet", choices: [{ value: "sonnet", name: "Sonnet" }] }],
+				},
+				error: undefined,
+			});
+
+		const { result, rerender } = renderHook(
+			({ agent }) => useConversationConfigOptions("ao-1", true, agent),
+			{ initialProps: { agent: "codex" }, wrapper },
+		);
+		await waitFor(() => expect(result.current.options[0]?.currentValue).toBe("opus"));
+
+		rerender({ agent: "claude" });
+		await waitFor(() => expect(result.current.options[0]?.currentValue).toBe("sonnet"));
+		expect(getMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("shows a retryable rejection and refreshes away the invalid selection", async () => {
+		getMock
+			.mockResolvedValueOnce({
+				data: {
+					options: [{ id: "model", type: "select", currentValue: "opus", choices: [{ value: "opus", name: "Opus" }] }],
+				},
+				error: undefined,
+			})
+			.mockResolvedValueOnce({
+				data: {
+					options: [{ id: "model", type: "select", currentValue: "sonnet", choices: [{ value: "sonnet", name: "Sonnet" }] }],
+				},
+				error: undefined,
+			});
+		patchMock.mockResolvedValue({
+			data: undefined,
+			error: { message: "model is no longer available" },
+		});
+		apiErrorMessageMock.mockReturnValue("model is no longer available");
+
+		const { result } = renderHook(
+			() => useConversationConfigOptions("ao-1", true, "claude"),
+			{ wrapper },
+		);
+		await waitFor(() => expect(result.current.options[0]?.currentValue).toBe("opus"));
+
+		await act(async () => {
+			await result.current.setOption("model", { value: "opus" }).catch(() => {});
+		});
+		await waitFor(() => expect(result.current.options[0]?.currentValue).toBe("sonnet"));
+		expect(result.current.error).toMatch(/choose an advertised option and try again/i);
+		expect(patchMock).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("useConversation snapshot mapping", () => {

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -512,9 +512,16 @@ export function useConversationModels(sessionId: string | undefined, enabled: bo
  * the effort choices, for example). The daemon therefore returns the complete
  * catalog after every mutation and that response replaces the cache atomically.
  */
-export function useConversationConfigOptions(sessionId: string | undefined, enabled: boolean) {
+export function useConversationConfigOptions(
+	sessionId: string | undefined,
+	enabled: boolean,
+	providerScope = "",
+) {
 	const queryClient = useQueryClient();
-	const queryKey = ["conversation-config-options", sessionId ?? ""] as const;
+	// Agent switches keep the AO session id but replace the live provider process.
+	// Scope the cache by provider so the old agent's catalog is never reused while
+	// the replacement controller advertises its own options.
+	const queryKey = ["conversation-config-options", sessionId ?? "", providerScope] as const;
 	const query = useQuery({
 		queryKey,
 		enabled: Boolean(sessionId) && enabled,
@@ -553,6 +560,11 @@ export function useConversationConfigOptions(sessionId: string | undefined, enab
 			return (data?.options ?? []) as ChatConfigOption[];
 		},
 		onSuccess: (options) => queryClient.setQueryData(queryKey, options),
+		onSettled: async () => {
+			// The provider can rebuild dependent choices after either accepting or
+			// rejecting a mutation. Always re-read its authoritative catalog.
+			await queryClient.invalidateQueries({ queryKey });
+		},
 	});
 
 	return {
@@ -560,7 +572,9 @@ export function useConversationConfigOptions(sessionId: string | undefined, enab
 		setOption: (optionId: string, value: ChatConfigOptionValue) =>
 			mutation.mutateAsync({ optionId, value }),
 		pending: mutation.isPending,
-		error: mutation.error ? apiErrorMessage(mutation.error) : undefined,
+		error: mutation.error
+			? `Provider rejected this setting. Choose an advertised option and try again. ${apiErrorMessage(mutation.error)}`
+			: undefined,
 	};
 }
 


### PR DESCRIPTION
## Summary

- Validate Claude model selections against the active ACP provider catalog.
- Reject unsupported or stale model IDs before provider execution.
- Use the provider-advertised default when no explicit model is selected.
- Refresh the renderer catalog after agent changes and option mutations.
- Show actionable retry guidance after provider rejection.

## Root cause

Persisted model selections could outlive the active Claude account’s available models. AO could then submit an unsupported model such as Opus or a cross-provider ID, causing provider rejection and making the conversation difficult to recover.

## Validation

- ACP adapter tests pass.
- Renderer focused tests pass.
- Frontend TypeScript typecheck passes.
- Manual Electron test using Agent default completed `hi` successfully.

