### PR TITLE
fix: clamp session inspector drag floor on cold start

### DIFF
--- a/frontend/e2e/resize-clamp.spec.ts
+++ b/frontend/e2e/resize-clamp.spec.ts
@@ -59,7 +59,7 @@ test("inspector drag stops at minSize instead of collapsing; buttons still toggl
 	const y = separatorBox.y + separatorBox.height / 2;
 
 	// Drag the separator all the way to the right edge: the rail must clamp at
-	// its 30% minSize, not snap away.
+	// its 360px floor (or 50% of a narrow split), not snap away or crush below.
 	await dragPointer(
 		page,
 		{ x: separatorBox.x + separatorBox.width / 2, y },
@@ -69,7 +69,8 @@ test("inspector drag stops at minSize instead of collapsing; buttons still toggl
 	await expect(inspector).toBeVisible();
 	const inspectorBox = await inspector.boundingBox();
 	if (!inspectorBox) throw new Error("inspector hidden after drag");
-	expect(inspectorBox.width / groupBox.width).toBeGreaterThan(0.28);
+	const floor = Math.min(360, Math.floor(groupBox.width * 0.5));
+	expect(inspectorBox.width).toBeGreaterThanOrEqual(floor - 1);
 
 	// The explicit control still collapses…
 	await page.getByRole("button", { name: "Close inspector panel" }).click();

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -402,6 +402,7 @@ vi.mock("./ui/resizable", () => ({
 		panelRef,
 		onResize,
 		style: _style,
+		groupResizeBehavior: _groupResizeBehavior,
 		...rest
 	}: {
 		children?: ReactNode;
@@ -413,6 +414,7 @@ vi.mock("./ui/resizable", () => ({
 		panelRef?: Ref<FakePanelHandle | null>;
 		onResize?: (size: { asPercentage: number; inPixels: number }) => void;
 		style?: React.CSSProperties;
+		groupResizeBehavior?: "preserve-relative-size" | "preserve-pixel-size";
 	}) => {
 		let entry = panels.get(id);
 		if (!entry) {
@@ -919,7 +921,7 @@ describe("SessionView", () => {
 		render(<SessionView sessionId="sess-1" />);
 
 		expect(panelSizes("terminal")).toEqual(["72%", "50%"]);
-		expect(panelSizes("inspector")).toEqual(["360px", "360px", "50%"]);
+		expect(panelSizes("inspector")).toEqual(["360px", "30%", "50%"]);
 		expect(screen.getByTestId("panel-group")).toHaveStyle({
 			"--session-inspector-motion-duration": "320ms",
 			"--session-inspector-motion-easing": "cubic-bezier(0.16, 1, 0.3, 1)",
@@ -936,8 +938,37 @@ describe("SessionView", () => {
 		try {
 			render(<SessionView sessionId="sess-1" />);
 
-			expect(panelSizes("inspector")[1]).toBe("316px");
+			// After measure, min is expressed as a % of the group so rrp re-registers
+			// with a non-zero group size (316px of 640px ≈ 49.375%).
+			expect(panelSizes("inspector")[1]).toBe("49.375%");
 			expect(panelSizes("inspector")[2]).toBe("50%");
+		} finally {
+			clientWidth.mockRestore();
+		}
+	});
+
+	it("keeps a percentage inspector floor until the session split has a laid-out width", () => {
+		const clientWidth = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(0);
+		try {
+			render(<SessionView sessionId="sess-1" />);
+			expect(screen.getByTestId("panel-inspector")).toHaveAttribute("data-constraint-epoch", "0");
+			expect(panelSizes("inspector")[1]).toBe("30%");
+		} finally {
+			clientWidth.mockRestore();
+		}
+	});
+
+	it("installs a percentage inspector floor once the session split is measured", () => {
+		const clientWidth = vi
+			.spyOn(HTMLElement.prototype, "clientWidth", "get")
+			.mockImplementation(function (this: HTMLElement) {
+				return this.dataset.testid === "resize-handle" ? 8 : 1200;
+			});
+		try {
+			render(<SessionView sessionId="sess-1" />);
+			// 360px of 1200px — measure remounts the panel with this floor installed.
+			expect(panelSizes("inspector")[1]).toBe("30%");
+			expect(screen.getByTestId("panel-inspector")).toHaveAttribute("data-constraint-epoch", "1");
 		} finally {
 			clientWidth.mockRestore();
 		}
@@ -1180,6 +1211,16 @@ describe("SessionView", () => {
 		act(() => entry.onResize?.({ asPercentage: 0, inPixels: 0 }));
 		expect(inspectorOpen("sess-1")).toBe(true);
 		expect(window.localStorage.getItem("ao.inspector.widthPx")).toBe("400");
+	});
+
+	it("refuses to persist inspector widths crushed below the 360px floor", () => {
+		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
+		render(<SessionView sessionId="sess-1" />);
+		const entry = panels.get("inspector")!;
+		screen.getByTestId("resize-handle").setAttribute("data-separator", "active");
+
+		act(() => entry.onResize?.({ asPercentage: 12, inPixels: 180 }));
+		expect(window.localStorage.getItem("ao.inspector.widthPx")).toBeNull();
 	});
 
 	// Regression: rrp v4 reports observed DOM sizes as well as direct drags.

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -47,6 +47,7 @@ import { useResolvedTheme, useUiStore, type InspectorView } from "../stores/ui-s
 
 const INSPECTOR_DEFAULT_PX = 360;
 const INSPECTOR_MIN_PX = 360;
+const INSPECTOR_MIN_FALLBACK_PERCENT = 30;
 const INSPECTOR_MAX_PERCENT = 50;
 const INSPECTOR_SEPARATOR_RESERVE_PX = 8;
 const INSPECTOR_COLLAPSED_SIZE = "0%";
@@ -68,9 +69,17 @@ function inspectorMaxWidthPx(availableWidth?: number): number | undefined {
 	return Math.floor((availableWidth * INSPECTOR_MAX_PERCENT) / 100);
 }
 
-function inspectorMinSizeForWidth(availableWidth?: number): string {
+function inspectorMinSizeForWidth(groupWidth?: number): string {
+	// Always a non-zero floor (never "0%"). Before the split is measured, use the
+	// legacy 30% clamp that hard-stops drags. After measure, use the 360px floor
+	// as a percentage of the real group width.
+	if (!Number.isFinite(groupWidth) || !groupWidth || groupWidth <= 0) {
+		return `${INSPECTOR_MIN_FALLBACK_PERCENT}%`;
+	}
+	const availableWidth = Math.max(0, groupWidth - INSPECTOR_SEPARATOR_RESERVE_PX);
 	const maxWidth = inspectorMaxWidthPx(availableWidth);
-	return maxWidth === undefined ? "0%" : `${Math.min(INSPECTOR_MIN_PX, maxWidth)}px`;
+	const minPx = Math.min(INSPECTOR_MIN_PX, maxWidth ?? INSPECTOR_MIN_PX);
+	return `${Number.parseFloat(((minPx / groupWidth) * 100).toFixed(3))}%`;
 }
 
 function initialInspectorSize(availableWidth?: number): string {
@@ -130,6 +139,10 @@ type SessionViewProps = {
 // narrow session splits, where the inspector tabs compact to icons.
 // Content keeps a stable min-width inside the clipped panel so nothing reflows
 // mid-animation; the persisted pixel width is clamped by the panel constraints.
+// Cold start: rrp derives minSize:0 when the group has not laid out yet, and a
+// mere minSize prop tweak is not enough — collapse/expand worked because it
+// remounts the panel. After the first real measure we remount the inspector
+// once (constraint epoch) so the 360px / 30% floor is installed without a toggle.
 export function SessionView({ sessionId }: SessionViewProps) {
 	const { t } = useTranslation();
 	const workspaceQuery = useWorkspaceQuery();
@@ -149,7 +162,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const sessionSplitRef = useRef<HTMLDivElement | null>(null);
 	const terminalLiveResizeTimerRef = useRef<number | null>(null);
 	const initializedInspectorSessionIdRef = useRef<string | null>(null);
-	const [inspectorMinimumSize, setInspectorMinimumSize] = useState("0%");
+	const inspectorConstraintsHydratedRef = useRef(false);
+	const [inspectorMinimumSize, setInspectorMinimumSize] = useState(() => inspectorMinSizeForWidth());
+	const [inspectorConstraintEpoch, setInspectorConstraintEpoch] = useState(0);
 	const [inspectorMotionState, setInspectorMotionState] = useState<"closed" | "closing" | "open" | "opening">(
 		isInspectorOpen ? "open" : "closed",
 	);
@@ -196,10 +211,17 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		const element = sessionSplitRef.current;
 		if (!element) return;
 		const updateAvailableWidth = () => {
-			const groupWidth = element.clientWidth || window.innerWidth;
-			const nextWidth = Math.max(0, groupWidth - INSPECTOR_SEPARATOR_RESERVE_PX);
-			const nextMinimumSize = inspectorMinSizeForWidth(nextWidth);
+			const groupWidth = element.clientWidth;
+			if (groupWidth <= 0) return;
+			const nextMinimumSize = inspectorMinSizeForWidth(groupWidth);
 			setInspectorMinimumSize((currentSize) => (currentSize === nextMinimumSize ? currentSize : nextMinimumSize));
+			// Remount the inspector once the group has a real width. Changing
+			// minSize alone still left cold-start drags unbounded; collapse/expand
+			// worked because it tore the panel down and registered it again.
+			if (!inspectorConstraintsHydratedRef.current) {
+				inspectorConstraintsHydratedRef.current = true;
+				setInspectorConstraintEpoch((epoch) => epoch + 1);
+			}
 		};
 		updateAvailableWidth();
 		if (typeof ResizeObserver === "undefined") return;
@@ -693,6 +715,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		if (!hasInspector) {
 			setInspectorMotionState("closed");
 			stopTerminalLiveResize();
+			inspectorConstraintsHydratedRef.current = false;
+			setInspectorConstraintEpoch(0);
+			setInspectorMinimumSize(inspectorMinSizeForWidth());
 			return;
 		}
 		if (!inspectorImperativeReadyRef.current) {
@@ -765,7 +790,10 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		(size: PanelSize) => {
 			if (inspectorSeparatorRef.current?.getAttribute("data-separator") !== "active") return;
 			if (size.inPixels <= 0) return;
-			window.localStorage?.setItem(inspectorWidthStorageKey, String(Math.round(size.inPixels)));
+			// Never persist a crushed width from a frame that slipped past the floor.
+			const width = Math.round(size.inPixels);
+			if (width < INSPECTOR_MIN_PX) return;
+			window.localStorage?.setItem(inspectorWidthStorageKey, String(width));
 		},
 		[],
 	);
@@ -863,10 +891,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 							elementRef={inspectorSeparatorRef}
 						/>
 						<ResizablePanel
+							key={inspectorConstraintEpoch > 0 ? `inspector-ready-${inspectorConstraintEpoch}` : "inspector-pending"}
 							aria-hidden={!inspectorPanelVisible}
 							className="session-inspector-panel"
 							collapsible={!isInspectorOpen}
+							data-constraint-epoch={inspectorConstraintEpoch}
 							defaultSize={inspectorDefaultSize}
+							groupResizeBehavior="preserve-pixel-size"
 							id="inspector"
 							inert={!isInspectorOpen}
 							maxSize={`${INSPECTOR_MAX_PERCENT}%`}


### PR DESCRIPTION
## Summary
- Stop the session inspector (chat and terminal) from resizing to zero on cold start.
- `react-resizable-panels` was deriving `minSize: 0` before the split had a real width; changing the prop alone was not enough, which is why collapse/expand appeared to “fix” it.
- After the first real measure, remount the inspector once with a non-zero floor (~360px / 30%, clamped to 50% on narrow splits), refuse to persist crushed widths, and keep pixel size across window resize.

## Test plan
- [ ] Fresh app start → open a worker session → drag the inspector hard right on first load (before any toggle); it stops at the floor, not a sliver
- [ ] Collapse via the inspector toggle, reopen, drag again; floor still holds
- [ ] Repeat in both Chat UI and terminal mode
- [ ] Narrow the window so 50% < 360px; floor follows the 50% max
- [ ] `cd frontend && npx vitest run src/renderer/components/SessionView.test.tsx`

## Before
<img width="155" height="469" alt="image" src="https://github.com/user-attachments/assets/945e902c-fb3b-4dc7-aee5-e3dd884d828e" />


## After
<img width="384" height="951" alt="image" src="https://github.com/user-attachments/assets/484df1dc-a947-44f2-a2dd-0965f53f0e9e" />
