### PR TITLE
fix: update Agy hooks for current Antigravity schema

### DIFF
--- a/backend/internal/adapters/agent/agy/agy_test.go
+++ b/backend/internal/adapters/agent/agy/agy_test.go
@@ -85,7 +85,9 @@ func TestGetRestoreCommand(t *testing.T) {
 		Permissions: ports.PermissionModeBypassPermissions,
 		Config:      ports.AgentConfig{Model: "gemini-3-flash"},
 		Session: ports.SessionRef{
-			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "native-id-123"},
+			Metadata: map[string]string{
+				ports.MetadataKeyAgentSessionID: "native-id-123",
+			},
 			WorkspacePath: "/tmp/ws",
 		},
 	})
@@ -138,17 +140,15 @@ func TestSessionInfo(t *testing.T) {
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
-	if info.AgentSessionID != "native-id-123" || info.Title != "My Title" || info.Summary != "My Summary" {
+	if info.AgentSessionID != "native-id-123" ||
+		info.Title != "My Title" ||
+		info.Summary != "My Summary" {
 		t.Fatalf("unexpected SessionInfo: %#v", info)
 	}
 }
 
 func TestHooksLifecycle(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "agy-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	plugin := &Plugin{}
 	cfg := ports.WorkspaceHookConfig{
@@ -165,8 +165,7 @@ func TestHooksLifecycle(t *testing.T) {
 	}
 
 	// 2. Install hooks.
-	err = plugin.GetAgentHooks(context.Background(), cfg)
-	if err != nil {
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
 		t.Fatal(err)
 	}
 
@@ -178,8 +177,8 @@ func TestHooksLifecycle(t *testing.T) {
 		t.Fatal("expected hooks to be installed after GetAgentHooks")
 	}
 
-	// Verify hooks.json structure
-	hooksJSONPath := filepath.Join(tmpDir, ".gemini", "hooks.json")
+	// Current Antigravity workspace hooks must be written to .agents/hooks.json.
+	hooksJSONPath := filepath.Join(tmpDir, ".agents", "hooks.json")
 	data, err := os.ReadFile(hooksJSONPath)
 	if err != nil {
 		t.Fatal(err)
@@ -190,32 +189,88 @@ func TestHooksLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(hookFile.Hooks) != len(agyManagedHooks) {
-		t.Fatalf("expected %d events in hooks, got %d", len(agyManagedHooks), len(hookFile.Hooks))
+	raw, ok := hookFile[agyManagedHookName]
+	if !ok {
+		t.Fatalf("expected top-level hook %q", agyManagedHookName)
 	}
 
-	for _, spec := range agyManagedHooks {
-		groups, ok := hookFile.Hooks[spec.Event]
-		if !ok {
-			t.Fatalf("expected event %q in hooks.json", spec.Event)
-		}
-		found := false
-		for _, group := range groups {
-			for _, h := range group.Hooks {
-				if h.Command == spec.Command {
-					found = true
-					break
-				}
-			}
-		}
-		if !found {
-			t.Fatalf("expected command %q for event %q", spec.Command, spec.Event)
-		}
+	var definition agyHookDefinition
+	if err := json.Unmarshal(raw, &definition); err != nil {
+		t.Fatal(err)
 	}
 
-	// 3. Uninstall hooks.
-	err = plugin.UninstallHooks(context.Background(), tmpDir)
+	if !hasAgyHookHandler(
+		definition.PreInvocation,
+		agyHookCommandPrefix+"before-agent",
+	) {
+		t.Fatal("expected PreInvocation before-agent hook")
+	}
+
+	if !hasAgyHookHandler(
+		definition.PostInvocation,
+		agyHookCommandPrefix+"after-agent",
+	) {
+		t.Fatal("expected PostInvocation after-agent hook")
+	}
+
+	if !hasAgyToolHook(
+		definition.PostToolUse,
+		agyHookCommandPrefix+"after-tool",
+	) {
+		t.Fatal("expected PostToolUse after-tool hook")
+	}
+
+	if !hasAgyHookHandler(
+		definition.Stop,
+		agyHookCommandPrefix+"after-agent",
+	) {
+		t.Fatal("expected Stop after-agent hook")
+	}
+
+	if len(definition.PostToolUse) != 1 {
+		t.Fatalf(
+			"expected one PostToolUse matcher group, got %d",
+			len(definition.PostToolUse),
+		)
+	}
+
+	if definition.PostToolUse[0].Matcher != "*" {
+		t.Fatalf(
+			"PostToolUse matcher = %q, want *",
+			definition.PostToolUse[0].Matcher,
+		)
+	}
+
+	// Legacy path must no longer be generated.
+	legacyHooksPath := filepath.Join(tmpDir, ".gemini", "hooks.json")
+	if _, err := os.Stat(legacyHooksPath); !os.IsNotExist(err) {
+		t.Fatalf(
+			"legacy hook file should not be generated at %s",
+			legacyHooksPath,
+		)
+	}
+
+	// 3. Reinstall should be idempotent.
+	before, err := os.ReadFile(hooksJSONPath)
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := os.ReadFile(hooksJSONPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(before) != string(after) {
+		t.Fatal("expected repeated GetAgentHooks to be idempotent")
+	}
+
+	// 4. Uninstall hooks.
+	if err := plugin.UninstallHooks(context.Background(), tmpDir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -225,6 +280,136 @@ func TestHooksLifecycle(t *testing.T) {
 	}
 	if installed {
 		t.Fatal("expected hooks to be uninstalled after UninstallHooks")
+	}
+}
+
+func TestGetAgentHooksPreservesUserHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	hooksDir := filepath.Join(tmpDir, ".agents")
+	if err := os.MkdirAll(hooksDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	hooksPath := filepath.Join(hooksDir, "hooks.json")
+
+	existing := `{
+  "user-linter": {
+    "PostToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/lint.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+
+	if err := os.WriteFile(hooksPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin := &Plugin{}
+	cfg := ports.WorkspaceHookConfig{
+		WorkspacePath: tmpDir,
+	}
+
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var hookFile agyHookFile
+	if err := json.Unmarshal(data, &hookFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := hookFile["user-linter"]; !ok {
+		t.Fatal("expected existing user hook to be preserved")
+	}
+
+	if _, ok := hookFile[agyManagedHookName]; !ok {
+		t.Fatalf("expected managed hook %q to be installed", agyManagedHookName)
+	}
+
+	if err := plugin.UninstallHooks(context.Background(), tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err = os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hookFile = nil
+	if err := json.Unmarshal(data, &hookFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := hookFile["user-linter"]; !ok {
+		t.Fatal("expected user hook to survive AO uninstall")
+	}
+
+	if _, ok := hookFile[agyManagedHookName]; ok {
+		t.Fatal("expected AO managed hook to be removed")
+	}
+}
+
+func TestAreHooksInstalledRequiresCompleteDefinition(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	hooksDir := filepath.Join(tmpDir, ".agents")
+	if err := os.MkdirAll(hooksDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	hooksPath := filepath.Join(hooksDir, "hooks.json")
+
+	incomplete := agyHookFile{}
+
+	raw, err := json.Marshal(agyHookDefinition{
+		PreInvocation: []agyHookHandler{
+			{
+				Type:    "command",
+				Command: agyHookCommandPrefix + "before-agent",
+				Timeout: agyHookTimeout,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	incomplete[agyManagedHookName] = raw
+
+	data, err := json.MarshalIndent(incomplete, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(hooksPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin := &Plugin{}
+
+	installed, err := plugin.AreHooksInstalled(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if installed {
+		t.Fatal("expected incomplete managed hooks to report not installed")
 	}
 }
 
@@ -247,6 +432,7 @@ func TestGetConfigSpecReportsModelField(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	want := []ports.ConfigField{
 		{
 			Key:         "model",
@@ -254,6 +440,7 @@ func TestGetConfigSpecReportsModelField(t *testing.T) {
 			Description: "Model override passed to `agy --model` (e.g. gemini-3-pro).",
 		},
 	}
+
 	if !reflect.DeepEqual(spec.Fields, want) {
 		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
 	}

--- a/backend/internal/adapters/agent/agy/hooks.go
+++ b/backend/internal/adapters/agent/agy/hooks.go
@@ -14,42 +14,94 @@ import (
 )
 
 const (
-	agyHooksDirName  = ".gemini"
+	// Current Antigravity workspace hooks live under .agents/hooks.json.
+	agyHooksDirName  = ".agents"
 	agyHooksFileName = "hooks.json"
 
+	// AO owns only this top-level hook definition. Other user-defined hooks in
+	// the same hooks.json file are preserved.
+	agyManagedHookName = "agent-orchestrator"
+
 	agyHookCommandPrefix = "ao hooks agy "
+	agyHookTimeout       = 10
 )
 
-type agyHookFile struct {
-	Hooks map[string][]agyMatcherGroup `json:"hooks"`
+// Antigravity hooks.json is a map of named hook definitions:
+//
+//	{
+//	  "my-hook": {
+//	    "PreInvocation": [...],
+//	    "PostToolUse": [...]
+//	  }
+//	}
+//
+// RawMessage at the top level lets AO preserve hook definitions it does not own.
+type agyHookFile map[string]json.RawMessage
+
+type agyHookDefinition struct {
+	PreInvocation  []agyHookHandler      `json:"PreInvocation,omitempty"`
+	PostInvocation []agyHookHandler      `json:"PostInvocation,omitempty"`
+	PostToolUse    []agyToolMatcherGroup `json:"PostToolUse,omitempty"`
+	Stop           []agyHookHandler      `json:"Stop,omitempty"`
 }
 
-type agyMatcherGroup struct {
-	Matcher *string        `json:"matcher,omitempty"`
-	Hooks   []agyHookEntry `json:"hooks"`
+type agyToolMatcherGroup struct {
+	Matcher string           `json:"matcher,omitempty"`
+	Hooks   []agyHookHandler `json:"hooks"`
 }
 
-type agyHookEntry struct {
-	Type    string `json:"type"`
+type agyHookHandler struct {
+	Type    string `json:"type,omitempty"`
 	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
 }
 
-type agyHookSpec struct {
-	Event   string
-	Command string
+func managedAgyHookDefinition() agyHookDefinition {
+	return agyHookDefinition{
+		PreInvocation: []agyHookHandler{
+			{
+				Type:    "command",
+				Command: agyHookCommandPrefix + "before-agent",
+				Timeout: agyHookTimeout,
+			},
+		},
+		PostInvocation: []agyHookHandler{
+			{
+				Type:    "command",
+				Command: agyHookCommandPrefix + "after-agent",
+				Timeout: agyHookTimeout,
+			},
+		},
+		PostToolUse: []agyToolMatcherGroup{
+			{
+				Matcher: "*",
+				Hooks: []agyHookHandler{
+					{
+						Type:    "command",
+						Command: agyHookCommandPrefix + "after-tool",
+						Timeout: agyHookTimeout,
+					},
+				},
+			},
+		},
+		// Antigravity Stop means the execution loop has stopped. It does not
+		// mean the TUI process/session has exited, so report idle rather than
+		// AO's session-end/exited event.
+		Stop: []agyHookHandler{
+			{
+				Type:    "command",
+				Command: agyHookCommandPrefix + "after-agent",
+				Timeout: agyHookTimeout,
+			},
+		},
+	}
 }
 
-var agyManagedHooks = []agyHookSpec{
-	{Event: "SessionStart", Command: agyHookCommandPrefix + "session-start"},
-	{Event: "SessionEnd", Command: agyHookCommandPrefix + "session-end"},
-	{Event: "BeforeAgent", Command: agyHookCommandPrefix + "before-agent"},
-	{Event: "AfterAgent", Command: agyHookCommandPrefix + "after-agent"},
-	{Event: "AfterTool", Command: agyHookCommandPrefix + "after-tool"},
-}
-
-// GetAgentHooks installs AO's Agy hooks into the worktree-local
-// .gemini/hooks.json file. Existing hook entries are preserved and duplicate
-// AO commands are not appended.
+// GetAgentHooks installs AO's activity hooks into the current Antigravity
+// workspace hook file at .agents/hooks.json.
+//
+// AO owns only the "agent-orchestrator" top-level definition. Any other
+// user-defined hook definitions are preserved.
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -59,40 +111,32 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	}
 
 	hooksPath := agyHooksPath(cfg.WorkspacePath)
-	topLevel, rawHooks, err := readAgyHooks(hooksPath)
+
+	hookFile, err := readAgyHooks(hooksPath)
 	if err != nil {
 		return fmt.Errorf("agy.GetAgentHooks: %w", err)
 	}
 
-	for event, specs := range groupAgyHooksByEvent() {
-		var existingGroups []agyMatcherGroup
-		if err := parseAgyHookType(rawHooks, event, &existingGroups); err != nil {
-			return fmt.Errorf("agy.GetAgentHooks: %w", err)
-		}
-		for _, spec := range specs {
-			if !agyHookCommandExists(existingGroups, spec.Command) {
-				entry := agyHookEntry{Type: "command", Command: spec.Command}
-				existingGroups = addAgyHook(existingGroups, entry)
-			}
-		}
-		if err := marshalAgyHookType(rawHooks, event, existingGroups); err != nil {
-			return fmt.Errorf("agy.GetAgentHooks: %w", err)
-		}
+	definitionJSON, err := json.Marshal(managedAgyHookDefinition())
+	if err != nil {
+		return fmt.Errorf("agy.GetAgentHooks: encode managed hooks: %w", err)
 	}
 
-	if err := writeAgyHooks(hooksPath, topLevel, rawHooks); err != nil {
+	hookFile[agyManagedHookName] = definitionJSON
+
+	if err := writeAgyHooks(hooksPath, hookFile); err != nil {
 		return fmt.Errorf("agy.GetAgentHooks: %w", err)
 	}
 
 	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(hooksPath), agyHooksFileName); err != nil {
 		return fmt.Errorf("agy.GetAgentHooks: gitignore: %w", err)
 	}
+
 	return nil
 }
 
-// UninstallHooks removes AO's Agy hooks from the workspace-local
-// .gemini/hooks.json file, leaving user-defined hooks untouched. A missing file
-// is a no-op.
+// UninstallHooks removes only AO's managed Antigravity hook definition.
+// User-defined hooks in the same .agents/hooks.json file are left untouched.
 func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -102,33 +146,27 @@ func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error
 	}
 
 	hooksPath := agyHooksPath(workspacePath)
+
 	if _, err := os.Stat(hooksPath); errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
-	topLevel, rawHooks, err := readAgyHooks(hooksPath)
+
+	hookFile, err := readAgyHooks(hooksPath)
 	if err != nil {
 		return fmt.Errorf("agy.UninstallHooks: %w", err)
 	}
 
-	for _, event := range agyManagedEvents() {
-		var groups []agyMatcherGroup
-		if err := parseAgyHookType(rawHooks, event, &groups); err != nil {
-			return fmt.Errorf("agy.UninstallHooks: %w", err)
-		}
-		groups = removeAgyManagedHooks(groups)
-		if err := marshalAgyHookType(rawHooks, event, groups); err != nil {
-			return fmt.Errorf("agy.UninstallHooks: %w", err)
-		}
-	}
+	delete(hookFile, agyManagedHookName)
 
-	if err := writeAgyHooks(hooksPath, topLevel, rawHooks); err != nil {
+	if err := writeAgyHooks(hooksPath, hookFile); err != nil {
 		return fmt.Errorf("agy.UninstallHooks: %w", err)
 	}
+
 	return nil
 }
 
-// AreHooksInstalled reports whether any AO Agy hook is present in the
-// workspace-local hooks file. A missing file means none are installed.
+// AreHooksInstalled reports whether AO's complete managed Antigravity activity
+// hook definition is present in the workspace hook file.
 func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (bool, error) {
 	if err := ctx.Err(); err != nil {
 		return false, err
@@ -138,171 +176,120 @@ func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (b
 	}
 
 	hooksPath := agyHooksPath(workspacePath)
+
 	if _, err := os.Stat(hooksPath); errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
-	_, rawHooks, err := readAgyHooks(hooksPath)
+
+	hookFile, err := readAgyHooks(hooksPath)
 	if err != nil {
 		return false, fmt.Errorf("agy.AreHooksInstalled: %w", err)
 	}
 
-	for _, event := range agyManagedEvents() {
-		var groups []agyMatcherGroup
-		if err := parseAgyHookType(rawHooks, event, &groups); err != nil {
-			return false, fmt.Errorf("agy.AreHooksInstalled: %w", err)
-		}
-		for _, group := range groups {
-			for _, hook := range group.Hooks {
-				if isAgyManagedHook(hook.Command) {
-					return true, nil
-				}
-			}
-		}
+	raw, ok := hookFile[agyManagedHookName]
+	if !ok {
+		return false, nil
 	}
-	return false, nil
+
+	var definition agyHookDefinition
+	if err := json.Unmarshal(raw, &definition); err != nil {
+		return false, fmt.Errorf(
+			"agy.AreHooksInstalled: parse %q hook: %w",
+			agyManagedHookName,
+			err,
+		)
+	}
+
+	return hasCompleteManagedAgyHooks(definition), nil
 }
 
 func agyHooksPath(workspacePath string) string {
 	return filepath.Join(workspacePath, agyHooksDirName, agyHooksFileName)
 }
 
-// readAgyHooks loads the hooks file into a top-level raw map plus the decoded
-// "hooks" sub-map, preserving keys AO doesn't manage. A missing or empty
-// file yields empty maps.
-func readAgyHooks(hooksPath string) (topLevel, rawHooks map[string]json.RawMessage, err error) {
-	topLevel = map[string]json.RawMessage{}
-	rawHooks = map[string]json.RawMessage{}
+func readAgyHooks(hooksPath string) (agyHookFile, error) {
+	hookFile := agyHookFile{}
 
-	data, err := os.ReadFile(hooksPath) //nolint:gosec // path built from caller-owned workspace dir
+	data, err := os.ReadFile(hooksPath) //nolint:gosec // caller-owned workspace path
 	if errors.Is(err, os.ErrNotExist) {
-		return topLevel, rawHooks, nil
+		return hookFile, nil
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("read %s: %w", hooksPath, err)
+		return nil, fmt.Errorf("read %s: %w", hooksPath, err)
 	}
+
 	if strings.TrimSpace(string(data)) == "" {
-		return topLevel, rawHooks, nil
+		return hookFile, nil
 	}
-	if err := json.Unmarshal(data, &topLevel); err != nil {
-		return nil, nil, fmt.Errorf("parse %s: %w", hooksPath, err)
+
+	if err := json.Unmarshal(data, &hookFile); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", hooksPath, err)
 	}
-	if hooksRaw, ok := topLevel["hooks"]; ok {
-		if err := json.Unmarshal(hooksRaw, &rawHooks); err != nil {
-			return nil, nil, fmt.Errorf("parse hooks in %s: %w", hooksPath, err)
-		}
+
+	if hookFile == nil {
+		hookFile = agyHookFile{}
 	}
-	return topLevel, rawHooks, nil
+
+	return hookFile, nil
 }
 
-// writeAgyHooks folds rawHooks back into topLevel and writes the file. An
-// empty hooks map drops the "hooks" key entirely.
-func writeAgyHooks(hooksPath string, topLevel, rawHooks map[string]json.RawMessage) error {
-	if len(rawHooks) == 0 {
-		delete(topLevel, "hooks")
-	} else {
-		hooksJSON, err := json.Marshal(rawHooks)
-		if err != nil {
-			return fmt.Errorf("encode hooks: %w", err)
-		}
-		topLevel["hooks"] = hooksJSON
+func writeAgyHooks(hooksPath string, hookFile agyHookFile) error {
+	if hookFile == nil {
+		hookFile = agyHookFile{}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o750); err != nil {
 		return fmt.Errorf("create hook dir: %w", err)
 	}
-	data, err := json.MarshalIndent(topLevel, "", "  ")
+
+	data, err := json.MarshalIndent(hookFile, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode %s: %w", hooksPath, err)
 	}
 	data = append(data, '\n')
+
 	if err := hookutil.AtomicWriteFile(hooksPath, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", hooksPath, err)
 	}
+
 	return nil
 }
 
-func groupAgyHooksByEvent() map[string][]agyHookSpec {
-	byEvent := map[string][]agyHookSpec{}
-	for _, spec := range agyManagedHooks {
-		byEvent[spec.Event] = append(byEvent[spec.Event], spec)
-	}
-	return byEvent
+func hasCompleteManagedAgyHooks(definition agyHookDefinition) bool {
+	return hasAgyHookHandler(
+		definition.PreInvocation,
+		agyHookCommandPrefix+"before-agent",
+	) &&
+		hasAgyHookHandler(
+			definition.PostInvocation,
+			agyHookCommandPrefix+"after-agent",
+		) &&
+		hasAgyToolHook(
+			definition.PostToolUse,
+			agyHookCommandPrefix+"after-tool",
+		) &&
+		hasAgyHookHandler(
+			definition.Stop,
+			agyHookCommandPrefix+"after-agent",
+		)
 }
 
-func agyManagedEvents() []string {
-	seen := map[string]bool{}
-	events := make([]string, 0, len(agyManagedHooks))
-	for _, spec := range agyManagedHooks {
-		if !seen[spec.Event] {
-			seen[spec.Event] = true
-			events = append(events, spec.Event)
-		}
-	}
-	return events
-}
-
-func isAgyManagedHook(command string) bool {
-	return strings.HasPrefix(command, agyHookCommandPrefix)
-}
-
-func removeAgyManagedHooks(groups []agyMatcherGroup) []agyMatcherGroup {
-	result := make([]agyMatcherGroup, 0, len(groups))
-	for _, group := range groups {
-		kept := make([]agyHookEntry, 0, len(group.Hooks))
-		for _, hook := range group.Hooks {
-			if !isAgyManagedHook(hook.Command) {
-				kept = append(kept, hook)
-			}
-		}
-		if len(kept) > 0 {
-			group.Hooks = kept
-			result = append(result, group)
-		}
-	}
-	return result
-}
-
-func parseAgyHookType(rawHooks map[string]json.RawMessage, event string, target *[]agyMatcherGroup) error {
-	data, ok := rawHooks[event]
-	if !ok {
-		return nil
-	}
-	if err := json.Unmarshal(data, target); err != nil {
-		return fmt.Errorf("parse %s hooks: %w", event, err)
-	}
-	return nil
-}
-
-func marshalAgyHookType(rawHooks map[string]json.RawMessage, event string, groups []agyMatcherGroup) error {
-	if len(groups) == 0 {
-		delete(rawHooks, event)
-		return nil
-	}
-	data, err := json.Marshal(groups)
-	if err != nil {
-		return fmt.Errorf("encode %s hooks: %w", event, err)
-	}
-	rawHooks[event] = data
-	return nil
-}
-
-func agyHookCommandExists(groups []agyMatcherGroup, command string) bool {
-	for _, group := range groups {
-		for _, hook := range group.Hooks {
-			if hook.Command == command {
-				return true
-			}
+func hasAgyHookHandler(handlers []agyHookHandler, command string) bool {
+	for _, handler := range handlers {
+		if handler.Command == command {
+			return true
 		}
 	}
 	return false
 }
 
-func addAgyHook(groups []agyMatcherGroup, hook agyHookEntry) []agyMatcherGroup {
-	for i, group := range groups {
-		if group.Matcher == nil {
-			groups[i].Hooks = append(groups[i].Hooks, hook)
-			return groups
+func hasAgyToolHook(groups []agyToolMatcherGroup, command string) bool {
+	for _, group := range groups {
+		for _, handler := range group.Hooks {
+			if handler.Command == command {
+				return true
+			}
 		}
 	}
-	return append(groups, agyMatcherGroup{Matcher: nil, Hooks: []agyHookEntry{hook}})
+	return false
 }


### PR DESCRIPTION
## What

Update the Agy hook integration to use the current Antigravity workspace hook format.

This replaces the legacy Agy hook configuration:

```text
.gemini/hooks.json
SessionStart
SessionEnd
BeforeAgent
AfterAgent
AfterTool
```

with the current Antigravity workspace hook configuration:

```text
.agents/hooks.json
PreInvocation
PostInvocation
PostToolUse
Stop
```

AO keeps its existing internal activity commands:

```text
PreInvocation  -> ao hooks agy before-agent
PostToolUse    -> ao hooks agy after-tool
PostInvocation -> ao hooks agy after-agent
Stop           -> ao hooks agy after-agent
```

## Why

Agy workers could launch and run normally, but AO could still show them as `No signal`.

The generated worktree contained `.gemini/hooks.json`, while current Antigravity did not consume those legacy workspace hooks. AO therefore never received an activity callback, so the worker eventually became `no_signal`.

This was reproduced with a real AO-managed Agy worker:

```text
harness: agy
activity.state: idle
status: no_signal
```

After using the current `.agents/hooks.json` schema, the same session began reporting activity correctly:

```text
harness: agy
activity.state: idle
status: idle
```

A fresh worker was then validated end-to-end and created `.agents/hooks.json` automatically without any manual worktree modification.

## How

- Move Agy workspace hooks to `.agents/hooks.json`.
- Use `PreInvocation`, `PostInvocation`, `PostToolUse`, and `Stop`.
- Preserve AO's existing internal activity event handling.
- Treat `Stop` as idle rather than process/session exit.
- Store AO hooks under a dedicated `agent-orchestrator` top-level definition.
- Preserve unrelated user-defined hooks.
- Make installation idempotent.
- Remove only AO-managed hooks during uninstall.
- Report hooks as installed only when the complete AO-managed definition is present.
- Stop generating legacy `.gemini/hooks.json`.

## Testing

Added/updated tests covering:

- installation into `.agents/hooks.json`
- current Antigravity event mappings
- absence of legacy `.gemini/hooks.json`
- idempotent installation
- preservation of user-defined hooks
- uninstall removing only AO-managed hooks
- incomplete managed definitions reporting as not installed

Validated locally with:

```bash
go test ./internal/adapters/agent/agy/... -count=1 -v
go test ./internal/cli/... -count=1
go test ./...
```

Also validated end-to-end with a fresh Agy TUI worker; the worker transitioned to `idle` instead of `no_signal` and generated `.agents/hooks.json` automatically.

## Checklist

- [x] Branch based directly on current upstream `main`
- [x] One focused Agy / Antigravity compatibility fix
- [x] Existing user hooks are preserved
- [x] Hook installation is idempotent
- [x] Legacy `.gemini/hooks.json` is no longer generated
- [x] Fresh Agy worker validated end-to-end
- [x] Relevant Go tests pass
