### PR TITLE
fix(scm): require ownership before attributing PRs; handle transfers and Codex discovery

### DIFF
--- a/backend/internal/integration/scm_observer_test.go
+++ b/backend/internal/integration/scm_observer_test.go
@@ -99,6 +99,10 @@ func (p *cannedSCMProvider) ParseRepository(remote string) (ports.SCMRepo, bool)
 	return p.parsedRepo, true
 }
 
+func (p *cannedSCMProvider) AuthenticatedIdentity(context.Context) (ports.SCMIdentity, error) {
+	return ports.SCMIdentity{Login: "octocat", Human: true}, nil
+}
+
 func (p *cannedSCMProvider) RepoPRListGuard(_ context.Context, _ ports.SCMRepo, _ string) (ports.SCMGuardResult, error) {
 	return ports.SCMGuardResult{ETag: "repo-etag"}, nil
 }
@@ -108,6 +112,9 @@ func (p *cannedSCMProvider) ListPRsByRepo(_ context.Context, _ ports.SCMRepo, _ 
 	defer p.mu.Unlock()
 	out := make([]ports.SCMPRObservation, 0, len(p.detected))
 	for _, pr := range p.detected {
+		if pr.Author == "" {
+			pr.Author = "octocat"
+		}
 		out = append(out, pr)
 	}
 	return out, nil
@@ -214,9 +221,10 @@ func newSCMFixture(t *testing.T, branch string) *scmFixture {
 	lcm.SetCompletionTerminator(lifecycleMarkTerminator{lcm: lcm})
 	provider := newCannedSCMProvider()
 	observer := scmobserve.New(provider, store, lcm, scmobserve.Config{
-		Tick:   time.Hour,
-		Clock:  func() time.Time { return now },
-		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Tick:             time.Hour,
+		Clock:            func() time.Time { return now },
+		Logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		IdentityResolver: provider,
 	})
 	return &scmFixture{
 		store:    store,

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -160,7 +160,8 @@ type Config struct {
 	Logger *slog.Logger
 	// CacheMax bounds each in-memory ETag/review cache. Zero uses DefaultCacheMax.
 	CacheMax int
-	// IdentityResolver resolves the active SCM account lazily. Nil preserves branch-based discovery.
+	// IdentityResolver resolves the active SCM account lazily. Automatic PR
+	// attribution is disabled when neither identity resolver is available.
 	IdentityResolver ports.SCMIdentityResolver
 	// ScopedIdentityResolver resolves the authenticated identity per provider key.
 	// When set, the observer resolves identities for all providers upfront in
@@ -758,14 +759,7 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 			if !found || !p.ArchivedAt.IsZero() {
 				continue
 			}
-			if p.RepoOriginURL == "" && p.Path != "" {
-				if url := resolveGitOriginURL(p.Path); url != "" {
-					p.RepoOriginURL = url
-					if err := o.store.UpsertProject(ctx, p); err != nil {
-						o.logger.Warn("scm observer: backfill origin URL persist failed", "project", p.ID, "err", err)
-					}
-				}
-			}
+			p = o.refreshProjectOriginURL(ctx, p)
 			projects[sess.ProjectID] = p
 			proj = p
 			if origin, ok := o.provider.ParseRepository(p.RepoOriginURL); ok {
@@ -811,6 +805,39 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 		}
 	}
 	return out, sessionRepos, nil
+}
+
+// refreshProjectOriginURL keeps the durable project identity aligned with the
+// checkout's current push origin. Repository transfers commonly leave the
+// stored owner/name stale while git remote origin has already followed the
+// provider redirect; using that stale identity makes the head-repo provenance
+// guard reject legitimate PRs from the transferred repository.
+func (o *Observer) refreshProjectOriginURL(ctx context.Context, p domain.ProjectRecord) domain.ProjectRecord {
+	if strings.TrimSpace(p.Path) == "" {
+		return p
+	}
+	url := resolveGitOriginURL(p.Path)
+	if strings.TrimSpace(url) == "" {
+		return p
+	}
+	current, currentOK := o.provider.ParseRepository(url)
+	if !currentOK {
+		return p
+	}
+	if persisted, persistedOK := o.provider.ParseRepository(p.RepoOriginURL); persistedOK && sameRepoIdentity(persisted, current) {
+		return p
+	}
+	p.RepoOriginURL = url
+	if err := o.store.UpsertProject(ctx, p); err != nil {
+		o.logger.Warn("scm observer: refresh origin URL persist failed", "project", p.ID, "err", err)
+	}
+	return p
+}
+
+func sameRepoIdentity(a, b ports.SCMRepo) bool {
+	return strings.EqualFold(a.Provider, b.Provider) &&
+		strings.EqualFold(a.Host, b.Host) &&
+		strings.EqualFold(repoFullName(a), repoFullName(b))
 }
 
 // resolveScanRepos returns the deduped set of repos whose open-PR lists should be
@@ -979,11 +1006,12 @@ func pendingRepoRefreshes(guards map[string]repoGuardState) map[string]bool {
 // NotModified against a known ETag are skipped, since nothing new can have
 // appeared since the last poll.
 func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRepo, subjects map[string]*subject, guards map[string]repoGuardState, now time.Time, markRepoFailed func(ports.SCMRepo)) (listedPRs, listedRepos map[string]bool) {
-	// Resolve identities per-provider when a ScopedIdentityResolver is wired.
-	// This ensures GitHub PRs are checked against the GitHub identity and
-	// GitLab PRs against the GitLab identity. Falls back to the single-
-	// provider IdentityResolver path for backward compatibility.
-	identities, identityKnown := o.resolveIdentities(ctx, sessionRepos)
+	// Resolve identities per provider. Branch and head-repository matches are
+	// necessary provenance signals, but are not ownership proof in a shared
+	// repository: another user can create the same branch name. Discovery
+	// therefore fails closed for a provider whose authenticated owner cannot be
+	// resolved; an explicitly claimed PR remains tracked independently.
+	identities := o.resolveIdentities(ctx, sessionRepos)
 	byRepo := map[string][]sessionRepo{}
 	repos := map[string]ports.SCMRepo{}
 	for _, sr := range sessionRepos {
@@ -1032,14 +1060,12 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 			if pr.Number <= 0 || pr.SourceBranch == "" {
 				continue
 			}
-			if identityKnown {
-				id, ok := identities[identityKey(repo.Provider, repo.Host)]
-				if !ok {
-					id, ok = identities[fallbackIdentityKey] // fallback single-identity
-				}
-				if ok && !strings.EqualFold(strings.TrimSpace(pr.Author), id.Login) {
-					continue
-				}
+			id, ok := identities[identityKey(repo.Provider, repo.Host)]
+			if !ok {
+				id, ok = identities[fallbackIdentityKey]
+			}
+			if !ok || !strings.EqualFold(strings.TrimSpace(pr.Author), id.Login) {
+				continue
 			}
 			key := prKey(repo, pr.Number)
 			if _, ok := subjects[key]; ok {
@@ -1065,6 +1091,7 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 				SourceBranch: pr.SourceBranch,
 				TargetBranch: pr.TargetBranch,
 				HeadSHA:      pr.HeadSHA,
+				Author:       pr.Author,
 				Provider:     repo.Provider,
 				Host:         repo.Host,
 				Repo:         repoFullName(repo),
@@ -1101,12 +1128,12 @@ func (o *Observer) authenticatedIdentity(ctx context.Context) (ports.SCMIdentity
 	}
 	identity, err := o.identityResolver.AuthenticatedIdentity(ctx)
 	if err != nil {
-		o.logger.Debug("scm observer: authenticated identity unavailable; preserving branch-based discovery", "err", err)
+		o.logger.Debug("scm observer: authenticated identity unavailable; skipping automatic attribution", "err", err)
 		return ports.SCMIdentity{}, false
 	}
 	identity.Login = strings.TrimSpace(identity.Login)
-	if !identity.Human || identity.Login == "" {
-		o.logger.Debug("scm observer: authenticated human identity unavailable; preserving branch-based discovery")
+	if identity.Login == "" {
+		o.logger.Debug("scm observer: authenticated identity has no login; skipping automatic attribution")
 		return ports.SCMIdentity{}, false
 	}
 	return identity, true
@@ -1117,15 +1144,14 @@ func (o *Observer) authenticatedIdentity(ctx context.Context) (ports.SCMIdentity
 // are resolved upfront (one call per unique provider+host pair) and cached in
 // a map keyed by identityKey(provider, host). This ensures a self-managed
 // GitLab host gets its own identity, distinct from gitlab.com. If identity
-// resolution fails for one provider+host, PRs from that provider+host fall
-// back to branch-based discovery while other providers continue normally.
+// resolution fails for one provider+host, automatic attribution is skipped for
+// that provider+host while other providers continue normally.
 // When no ScopedIdentityResolver is available, it falls back to the
 // single-provider IdentityResolver path.
-func (o *Observer) resolveIdentities(ctx context.Context, sessionRepos []sessionRepo) (map[string]ports.SCMIdentity, bool) {
+func (o *Observer) resolveIdentities(ctx context.Context, sessionRepos []sessionRepo) map[string]ports.SCMIdentity {
 	if o.scopedIdentityResolver != nil {
 		seen := map[string]bool{}
 		identities := make(map[string]ports.SCMIdentity)
-		anyKnown := false
 		for _, sr := range sessionRepos {
 			ik := identityKey(sr.repo.Provider, sr.repo.Host)
 			if seen[ik] {
@@ -1134,25 +1160,24 @@ func (o *Observer) resolveIdentities(ctx context.Context, sessionRepos []session
 			seen[ik] = true
 			id, err := o.scopedIdentityResolver.AuthenticatedIdentityForProvider(ctx, sr.repo.Provider, sr.repo.Host)
 			if err != nil {
-				o.logger.Debug("scm observer: per-provider identity unavailable; preserving branch-based discovery for provider", "provider", sr.repo.Provider, "host", sr.repo.Host, "err", err)
+				o.logger.Debug("scm observer: per-provider identity unavailable; skipping automatic attribution for provider", "provider", sr.repo.Provider, "host", sr.repo.Host, "err", err)
 				continue
 			}
 			id.Login = strings.TrimSpace(id.Login)
-			if !id.Human || id.Login == "" {
-				o.logger.Debug("scm observer: per-provider human identity unavailable; preserving branch-based discovery for provider", "provider", sr.repo.Provider, "host", sr.repo.Host)
+			if id.Login == "" {
+				o.logger.Debug("scm observer: per-provider identity has no login; skipping automatic attribution for provider", "provider", sr.repo.Provider, "host", sr.repo.Host)
 				continue
 			}
 			identities[ik] = id
-			anyKnown = true
 		}
-		return identities, anyKnown
+		return identities
 	}
 	// Fallback: single-provider IdentityResolver path.
 	identity, ok := o.authenticatedIdentity(ctx)
 	if !ok {
-		return nil, false
+		return nil
 	}
-	return map[string]ports.SCMIdentity{fallbackIdentityKey: identity}, true
+	return map[string]ports.SCMIdentity{fallbackIdentityKey: identity}
 }
 
 // matchSession picks the session that owns sourceBranch. A session owns the

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -164,6 +164,9 @@ func (p *fakeProvider) AuthenticatedIdentity(context.Context) (ports.SCMIdentity
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.identityCalls++
+	if p.identity.Login == "" && p.identityErr == nil {
+		return ports.SCMIdentity{Login: "alice", Human: true}, nil
+	}
 	return p.identity, p.identityErr
 }
 
@@ -204,7 +207,16 @@ func (p *fakeProvider) ListPRsByRepo(_ context.Context, repo ports.SCMRepo, _ ti
 	if p.listErr != nil {
 		return nil, p.listErr
 	}
-	return p.openPRs[prKey(repo, 0)], nil
+	pulls := append([]ports.SCMPRObservation(nil), p.openPRs[prKey(repo, 0)]...)
+	for i := range pulls {
+		// Real provider list responses always carry an author. Most observer
+		// fixtures predate ownership-aware attribution, so default their omitted
+		// author to the fake provider's authenticated account.
+		if pulls[i].Author == "" {
+			pulls[i].Author = "alice"
+		}
+	}
+	return pulls, nil
 }
 func (p *fakeProvider) CommitChecksGuard(_ context.Context, repo ports.SCMRepo, sha, _ string) (ports.SCMGuardResult, error) {
 	return p.checkGuards[commitKey(repo, sha)], nil
@@ -325,7 +337,7 @@ func testStoreWithSession() *fakeStore {
 func testObs(num int) ports.SCMObservation {
 	return ports.SCMObservation{
 		Fetched: true, Provider: "github", Host: "github.com", Repo: "o/r",
-		PR:           ports.SCMPRObservation{URL: "https://github.com/o/r/pull/" + fmt.Sprint(num), Number: num, State: "open", SourceBranch: "feat", TargetBranch: "main", HeadSHA: "sha" + fmt.Sprint(num), Title: "PR"},
+		PR:           ports.SCMPRObservation{URL: "https://github.com/o/r/pull/" + fmt.Sprint(num), Number: num, State: "open", SourceBranch: "feat", TargetBranch: "main", HeadSHA: "sha" + fmt.Sprint(num), Title: "PR", Author: "alice"},
 		CI:           ports.SCMCIObservation{Summary: string(domain.CIPassing), HeadSHA: "sha" + fmt.Sprint(num), Checks: []ports.SCMCheckObservation{{Name: "build", Status: string(domain.PRCheckPassed), Conclusion: "success", URL: "ci"}}},
 		Review:       ports.SCMReviewObservation{Decision: string(domain.ReviewNone)},
 		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeMergeable), Mergeable: true},
@@ -618,7 +630,7 @@ func TestPoll_RepoETag200DiscoversPRAndRefreshesSamePoll(t *testing.T) {
 	}
 }
 
-func TestPoll_DiscoversOnlyPRsFromAuthenticatedHuman(t *testing.T) {
+func TestPoll_ForeignPRNotAttributed(t *testing.T) {
 	store := testStoreWithSession()
 	provider := &fakeProvider{
 		repoGuards: map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
@@ -652,21 +664,21 @@ func TestPoll_DiscoversOnlyPRsFromAuthenticatedHuman(t *testing.T) {
 	}
 }
 
-func TestPoll_PreservesBranchDiscoveryWithoutHumanIdentity(t *testing.T) {
+func TestPoll_SkipsAutomaticAttributionWithoutIdentityProvenance(t *testing.T) {
 	tests := []struct {
 		name        string
 		identity    ports.SCMIdentity
 		identityErr error
 	}{
 		{name: "lookup error", identityErr: errors.New("identity unavailable")},
-		{name: "bot account", identity: ports.SCMIdentity{Login: "ao-bot", Human: false}},
+		{name: "empty login", identity: ports.SCMIdentity{Login: " ", Human: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := testStoreWithSession()
 			provider := &fakeProvider{
 				repoGuards:   map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
-				openPRs:      map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {{URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "feat", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha1", Author: "other"}}},
+				openPRs:      map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {{URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "feat", HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha1", Author: "alice"}}},
 				observations: map[string]ports.SCMObservation{prKey(testRepo, 1): testObs(1)},
 				identity:     tt.identity,
 				identityErr:  tt.identityErr,
@@ -675,10 +687,35 @@ func TestPoll_PreservesBranchDiscoveryWithoutHumanIdentity(t *testing.T) {
 			if err := obs.Poll(context.Background()); err != nil {
 				t.Fatal(err)
 			}
-			if len(provider.fetchBatches) != 1 || provider.fetchBatches[0][0].Number != 1 {
-				t.Fatalf("branch fallback did not discover PR: %#v", provider.fetchBatches)
+			if len(provider.fetchBatches) != 0 {
+				t.Fatalf("PR was fetched without owner provenance: %#v", provider.fetchBatches)
+			}
+			if len(store.writes) != 0 {
+				t.Fatalf("PR was persisted without owner provenance: %#v", store.writes)
 			}
 		})
+	}
+}
+
+func TestPoll_DiscoversPRFromAuthenticatedBot(t *testing.T) {
+	store := testStoreWithSession()
+	botObs := testObs(1)
+	botObs.PR.Author = "ao-bot"
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
+		openPRs: map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {{
+			URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "feat", HeadRepo: "o/r",
+			TargetBranch: "main", HeadSHA: "sha1", Author: "ao-bot",
+		}}},
+		observations: map[string]ports.SCMObservation{prKey(testRepo, 1): botObs},
+		identity:     ports.SCMIdentity{Login: "ao-bot", Human: false},
+	}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.writes) == 0 || store.writes[0].pr.SessionID != "p-1" {
+		t.Fatalf("authenticated bot's PR was not attributed: %#v", store.writes)
 	}
 }
 
@@ -963,6 +1000,80 @@ func TestPoll_DiscoversCrossForkPRFromUpstreamRemote(t *testing.T) {
 	}
 	if !fetched {
 		t.Fatalf("cross-fork PR must be refreshed against upstream, batches=%#v", provider.fetchBatches)
+	}
+}
+
+func TestPoll_DiscoversPRAfterRepositoryTransfer(t *testing.T) {
+	dir := t.TempDir()
+	mustGit(t, "init", dir)
+	mustGit(t, "-C", dir, "remote", "add", "origin", "https://github.com/new-owner/r.git")
+
+	movedRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "new-owner", Name: "r", Repo: "new-owner/r"}
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "ao/p-1/root"}}},
+		projects: map[string]domain.ProjectRecord{"p": {
+			ID:            "p",
+			Path:          dir,
+			RepoOriginURL: "https://github.com/old-owner/r.git",
+		}},
+		prs:    map[domain.SessionID][]domain.PullRequest{},
+		checks: map[string][]domain.PullRequestCheck{},
+	}
+	movedObs := ports.SCMObservation{
+		Fetched: true, Provider: "github", Host: "github.com", Repo: "new-owner/r",
+		PR: ports.SCMPRObservation{
+			URL: "https://github.com/new-owner/r/pull/3250", Number: 3250, State: "open",
+			SourceBranch: "ao/p-1/fix", HeadRepo: "new-owner/r", TargetBranch: "main",
+			HeadSHA: "sha1", Title: "PR", Author: "alice",
+		},
+		CI:           ports.SCMCIObservation{Summary: string(domain.CIPassing), HeadSHA: "sha1"},
+		Review:       ports.SCMReviewObservation{Decision: string(domain.ReviewNone)},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeMergeable), Mergeable: true},
+	}
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{prKey(movedRepo, 0): {ETag: "moved"}},
+		openPRs: map[string][]ports.SCMPRObservation{prKey(movedRepo, 0): {{
+			URL: "https://github.com/new-owner/r/pull/3250", Number: 3250,
+			SourceBranch: "ao/p-1/fix", HeadRepo: "new-owner/r", TargetBranch: "main",
+			HeadSHA: "sha1", Author: "alice",
+		}}},
+		observations: map[string]ports.SCMObservation{prKey(movedRepo, 3250): movedObs},
+	}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.projects["p"].RepoOriginURL; got != "https://github.com/new-owner/r.git" {
+		t.Fatalf("project origin = %q, want moved origin", got)
+	}
+	if len(store.writes) == 0 || store.writes[0].pr.SessionID != "p-1" || store.writes[0].pr.Repo != "new-owner/r" {
+		t.Fatalf("transferred-repo PR was not attributed: %#v", store.writes)
+	}
+}
+
+// Codex can invoke the real gh binary directly, so discovery must come from
+// durable session/repository facts rather than wrapper interception.
+func TestPoll_DiscoversCodexSessionPRWithoutGHWrapper(t *testing.T) {
+	store := testStoreWithSession()
+	store.sessions[0].Harness = domain.HarnessCodex
+	store.sessions[0].Metadata.Branch = "ao/p-1/root"
+	prObs := testObs(17)
+	prObs.PR.SourceBranch = "ao/p-1/fix"
+	prObs.PR.Author = "alice"
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
+		openPRs: map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {{
+			URL: "https://github.com/o/r/pull/17", Number: 17, SourceBranch: "ao/p-1/fix",
+			HeadRepo: "o/r", TargetBranch: "main", HeadSHA: "sha17", Author: "alice",
+		}}},
+		observations: map[string]ports.SCMObservation{prKey(testRepo, 17): prObs},
+	}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.writes) == 0 || store.writes[0].pr.SessionID != "p-1" || store.writes[0].pr.Number != 17 {
+		t.Fatalf("Codex PR was not discovered by observer polling: %#v", store.writes)
 	}
 }
 

--- a/backend/internal/observe/scm/scoped_identity_test.go
+++ b/backend/internal/observe/scm/scoped_identity_test.go
@@ -255,8 +255,8 @@ func TestPoll_ScopedIdentityFallbackToSingleResolver(t *testing.T) {
 }
 
 // TestPoll_ScopedIdentityPartialFailure verifies that when identity resolution
-// fails for one provider, PRs from the other provider are still discovered
-// against their matching identity (finding #7).
+// fails for one provider, only that provider fails closed while PRs from the
+// other provider are still discovered against their matching identity.
 func TestPoll_ScopedIdentityPartialFailure(t *testing.T) {
 	store := testStoreWithTwoSessions()
 	provider := &hostAwareProvider{fakeProvider: &fakeProvider{
@@ -303,11 +303,10 @@ func TestPoll_ScopedIdentityPartialFailure(t *testing.T) {
 		t.Fatalf("github PR #1 should be fetched (identity resolved), got fetched=%v", fetched)
 	}
 
-	// GitLab PR #3 should also be fetched — identity resolution failed for
-	// GitLab, so PRs from that provider fall back to branch-based discovery
-	// (no identity check, so any matching branch is accepted).
-	if !fetched[3] {
-		t.Fatalf("gitlab PR #3 should be fetched (identity failure → branch-based discovery), got fetched=%v", fetched)
+	// GitLab PR #3 must not be fetched: without the authenticated owner there
+	// is no proof that the matching branch belongs to this AO session.
+	if fetched[3] {
+		t.Fatalf("gitlab PR #3 was fetched without identity provenance, got fetched=%v", fetched)
 	}
 
 	// Both providers should have been queried.


### PR DESCRIPTION
## Summary

- require provider-scoped authenticated author ownership before branch-based PR attribution, failing closed when provenance is unavailable
- refresh durable project origin identity from the checkout before discovery so transferred repositories use the current owner/repo
- keep Codex PR discovery on the polling observer path, independent of gh wrapper interception
- persist the discovered PR author and cover legitimate human/bot ownership

## Tests

- `env -u AO_PROJECT_ID -u AO_SESSION_ID go test ./...`
- `npm run typecheck` (from `frontend/`)

## Compatibility / risk

Identity lookup failures now defer automatic attribution until a later successful poll or an explicit claim. This is intentional fail-closed behavior to prevent foreign PRs from entering a session lifecycle. The change is scoped away from the transferred-row alias/deduplication work in #3922.

Fixes #3259
Fixes #3252