### PR TITLE
fix(chat): stop freezes, attachment loss, and turn-state desync

### DIFF
--- a/backend/e2e/chat_composer_test.go
+++ b/backend/e2e/chat_composer_test.go
@@ -3,6 +3,9 @@
 package e2e
 
 import (
+	"bytes"
+	"encoding/base64"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -149,4 +152,80 @@ func TestChatAttachmentIsStagedIntoTheWorktreeAndReadableByTheAgent(t *testing.T
 			t.Errorf("staged attachment %q shows up as a workspace change (%s)", file.Path, file.Status)
 		}
 	}
+}
+
+// The #3884 data-loss seam, driven end to end: an attachment staged before a
+// daemon restart must still resolve — same preview URL, same bytes — after
+// startup recovery has recreated the session's worktree, and the resumed agent
+// must still be able to read the same .ao/attachments/... path its
+// conversation history names.
+func TestChatAttachmentSurvivesADaemonRestart(t *testing.T) {
+	requireE2E(t)
+	dataDir := t.TempDir()
+	d := startDaemon(t, dataDir)
+	project := seedProject(t, d, "attachrestart")
+	session := chatSession(t, d, project, "Reply with exactly: READY")
+
+	const onePixelPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg=="
+	wantBytes, err := base64.StdEncoding.DecodeString(onePixelPNG)
+	if err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+
+	var staged struct {
+		Paths []string `json:"paths"`
+	}
+	d.mustCall("POST", "/sessions/"+session+"/attachments", http.StatusCreated,
+		map[string]any{"attachments": []map[string]any{{"mimeType": "image/png", "data": onePixelPNG}}},
+		&staged)
+	if len(staged.Paths) != 1 {
+		t.Fatalf("staged %d paths, want 1: %+v", len(staged.Paths), staged.Paths)
+	}
+	path := staged.Paths[0]
+	previewPath := "/sessions/" + session + "/preview/files/" + path
+
+	if got := rawGET(t, d, previewPath); !bytes.Equal(got, wantBytes) {
+		t.Fatalf("preview before restart returned %d bytes, want the staged image", len(got))
+	}
+
+	// The user quits the app; the next boot's recovery recreates the worktree.
+	d.stop()
+	restarted := startDaemon(t, dataDir)
+	restarted.awaitLiveController(session, 3*time.Minute)
+
+	// The same URL the durable conversation embeds must keep answering with the
+	// original bytes — this is the request that returned PREVIEW_FILE_NOT_FOUND
+	// before attachments had a durable owner.
+	if got := rawGET(t, restarted, previewPath); !bytes.Equal(got, wantBytes) {
+		t.Fatalf("preview after restart returned %d bytes, want the staged image", len(got))
+	}
+
+	// And the resumed agent can still open the path its history names.
+	send(t, restarted, session,
+		"Run `test -f "+path+" && echo FOUND || echo MISSING` and reply with its exact output.",
+		"attach-restart-read")
+	snap := restarted.awaitConversation(session, 3*time.Minute, "the resumed agent to look for the image",
+		func(s snapshot) bool { return terminal(s.Turns[len(s.Turns)-1].State) })
+	if !contains(snap.assistantText(), "FOUND") {
+		t.Fatalf("the resumed agent could not see the restored image at %s:\n%s", path, describe(snap))
+	}
+}
+
+// rawGET fetches an API path and returns the body bytes without assuming JSON,
+// which is what an <img> tag does with a preview URL.
+func rawGET(t *testing.T, d *daemon, path string) []byte {
+	t.Helper()
+	res, err := httpClient.Get(d.baseURL + path)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s = %d: %s\n%s", path, res.StatusCode, body, d.tailLog())
+	}
+	return body
 }

--- a/backend/internal/adapters/chatdriver/codexappserver/conversation.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conversation.go
@@ -148,12 +148,20 @@ func (c *conversation) pump() {
 		// as an absolute instant and has to become a remaining duration, and a
 		// normalizer that reads the clock itself cannot be tested deterministically.
 		for _, ev := range normalizeNotification(n, time.Now()) {
-			if ev.Kind == ports.ChatEventTurnStarted && ev.ProviderTurnID != "" {
+			rootConversation := ev.ProviderConversationID == "" || ev.ProviderConversationID == c.threadID
+			if ev.Kind == ports.ChatEventTurnStarted && ev.ProviderTurnID != "" && rootConversation {
 				c.mu.Lock()
 				c.activeTurn = ev.ProviderTurnID
 				// Snapshot the context position this turn starts from. Cheap on every
 				// turn, and the only way to know what a compaction reclaimed.
 				c.contextAtTurnStart = c.contextTokens
+				c.mu.Unlock()
+			}
+			if ev.Kind == ports.ChatEventTurnCompleted && rootConversation {
+				c.mu.Lock()
+				if c.activeTurn == ev.ProviderTurnID {
+					c.activeTurn = ""
+				}
 				c.mu.Unlock()
 			}
 			if ev.Kind == ports.ChatEventCompacted {

--- a/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
@@ -508,6 +508,42 @@ func TestNotificationsBecomeNeutralEvents(t *testing.T) {
 	}
 }
 
+// app-server multiplexes child-agent thread notifications over the root
+// connection. The adapter's fallback target must remain the root turn; otherwise
+// an interrupt without an explicit id can stop a child and leave the requested
+// root work running.
+func TestNestedThreadDoesNotReplaceRootActiveTurn(t *testing.T) {
+	d, srv := newTestDriver(t)
+	conv, err := d.Start(context.Background(), ports.ChatStartConfig{WorkspacePath: "/tmp/ws"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = conv.Close() }()
+
+	srv.push(`{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"root-turn","status":"inProgress","items":[]}}}`)
+	srv.push(`{"method":"turn/started","params":{"threadId":"child-thread-1","turn":{"id":"child-turn","status":"inProgress","items":[]}}}`)
+	root := nextEvent(t, conv.Events(), ports.ChatEventTurnStarted)
+	child := nextEvent(t, conv.Events(), ports.ChatEventTurnStarted)
+	if root.ProviderConversationID != "thread-1" || child.ProviderConversationID != "child-thread-1" {
+		t.Fatalf("normalized lifecycle threads = root %q child %q", root.ProviderConversationID, child.ProviderConversationID)
+	}
+
+	if err := conv.Interrupt(context.Background(), ""); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	sent := srv.awaitFrame(func(f frame) bool { return f.Method == "turn/interrupt" })
+	var params struct {
+		ThreadID string `json:"threadId"`
+		TurnID   string `json:"turnId"`
+	}
+	if err := json.Unmarshal(sent.Params, &params); err != nil {
+		t.Fatalf("decode turn/interrupt params: %v", err)
+	}
+	if params.ThreadID != "thread-1" || params.TurnID != "root-turn" {
+		t.Fatalf("interrupt target = %q/%q, want thread-1/root-turn", params.ThreadID, params.TurnID)
+	}
+}
+
 // Resume must not quietly become a fresh thread: that would present unrelated
 // history as continuous.
 func TestResumeFailureDoesNotFallBackToStart(t *testing.T) {

--- a/backend/internal/adapters/chatdriver/codexappserver/normalize.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/normalize.go
@@ -136,8 +136,9 @@ func normalizeNotification(n notification, now time.Time) []ports.ChatEvent {
 			return nil
 		}
 		return []ports.ChatEvent{{
-			Kind:           ports.ChatEventTurnStarted,
-			ProviderTurnID: firstNonEmpty(p.Turn.ID, turnIDFallback(n.Params)),
+			Kind:                   ports.ChatEventTurnStarted,
+			ProviderTurnID:         firstNonEmpty(p.Turn.ID, turnIDFallback(n.Params)),
+			ProviderConversationID: p.ThreadID,
 		}}
 
 	case codexproto.MethodTurnCompleted:
@@ -146,9 +147,10 @@ func normalizeNotification(n notification, now time.Time) []ports.ChatEvent {
 			return nil
 		}
 		ev := ports.ChatEvent{
-			Kind:           ports.ChatEventTurnCompleted,
-			ProviderTurnID: firstNonEmpty(p.Turn.ID, turnIDFallback(n.Params)),
-			TurnState:      turnStateFrom(string(p.Turn.Status)),
+			Kind:                   ports.ChatEventTurnCompleted,
+			ProviderTurnID:         firstNonEmpty(p.Turn.ID, turnIDFallback(n.Params)),
+			ProviderConversationID: p.ThreadID,
+			TurnState:              turnStateFrom(string(p.Turn.Status)),
 		}
 		if p.Turn.Error != nil && p.Turn.Error.Message != "" {
 			ev.Err = fmt.Errorf("%s", p.Turn.Error.Message)

--- a/backend/internal/adapters/chatdriver/codexappserver/normalize_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/normalize_test.go
@@ -37,12 +37,14 @@ func normalizeNone(t *testing.T, method, params string) {
 
 func TestNormalizeTurnLifecycle(t *testing.T) {
 	started := normalizeOne(t, "turn/started", `{"threadId":"th1","turn":{"id":"tu1","status":"inProgress","items":[]}}`)
-	if started.Kind != ports.ChatEventTurnStarted || started.ProviderTurnID != "tu1" {
+	if started.Kind != ports.ChatEventTurnStarted || started.ProviderTurnID != "tu1" ||
+		started.ProviderConversationID != "th1" {
 		t.Fatalf("turn/started -> %+v", started)
 	}
 
 	done := normalizeOne(t, "turn/completed", `{"threadId":"th1","turn":{"id":"tu1","status":"completed","items":[]}}`)
-	if done.Kind != ports.ChatEventTurnCompleted || done.TurnState != domain.TurnStateCompleted {
+	if done.Kind != ports.ChatEventTurnCompleted || done.TurnState != domain.TurnStateCompleted ||
+		done.ProviderConversationID != "th1" {
 		t.Fatalf("turn/completed -> %+v", done)
 	}
 }

--- a/backend/internal/attachments/attachments.go
+++ b/backend/internal/attachments/attachments.go
@@ -1,0 +1,211 @@
+// Package attachments owns the canonical bytes for files a user attaches to a
+// session. The worktree copy under .ao/attachments is a projection for the
+// agent; it lives in a disposable git worktree that daemon recovery recreates,
+// which is exactly when a worktree-only attachment disappears while the durable
+// conversation still points at it (#3884). The canonical copy lives under AO's
+// data dir and shares the conversation's lifetime instead of the worktree's.
+package attachments
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WorktreeDir is the worktree-relative directory attachments are projected
+// into. It matches the references embedded in durable conversation history, so
+// it can never change without a migration for every stored message.
+const WorktreeDir = ".ao/attachments"
+
+// Dir returns the canonical directory for one session's attachments.
+func Dir(dataDir, sessionID string) string {
+	return filepath.Join(dataDir, "attachments", sessionID)
+}
+
+// ValidName reports whether name is a bare filename AO could have generated for
+// an attachment. It is the gate between a request path and the filesystem: no
+// separators, no traversal, no hidden files, ASCII-safe charset only.
+func ValidName(name string) bool {
+	if name == "" || len(name) > 255 {
+		return false
+	}
+	if name != filepath.Base(name) || strings.HasPrefix(name, ".") {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// RefName extracts and validates the filename from a worktree-relative
+// attachment reference like ".ao/attachments/attachment-ab12cd.png". It reports
+// false for anything that is not a well-formed AO attachment reference.
+func RefName(ref string) (string, bool) {
+	rest, ok := strings.CutPrefix(filepath.ToSlash(ref), WorktreeDir+"/")
+	if !ok {
+		return "", false
+	}
+	if !ValidName(rest) {
+		return "", false
+	}
+	return rest, true
+}
+
+// Store writes one canonical attachment atomically: the bytes land in a temp
+// file first and are renamed into place, so a crash mid-write can never leave a
+// half-written file that later serves as the "durable" copy.
+func Store(dataDir, sessionID, name string, data []byte) error {
+	if dataDir == "" {
+		return errors.New("attachments: data dir is required")
+	}
+	if !ValidName(name) {
+		return fmt.Errorf("attachments: invalid name %q", name)
+	}
+	dir := Dir(dataDir, sessionID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("attachments: create %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".tmp-"+name+"-*")
+	if err != nil {
+		return fmt.Errorf("attachments: temp file for %s: %w", name, err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("attachments: chmod %s: %w", name, err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("attachments: write %s: %w", name, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("attachments: close %s: %w", name, err)
+	}
+	if err := os.Rename(tmpName, filepath.Join(dir, name)); err != nil {
+		return fmt.Errorf("attachments: commit %s: %w", name, err)
+	}
+	return nil
+}
+
+// Open opens the canonical copy of one attachment for serving. The name is
+// validated before it touches the filesystem, and only regular files are
+// served — a symlink planted in the canonical dir must not become an escape.
+func Open(dataDir, sessionID, name string) (*os.File, os.FileInfo, error) {
+	if dataDir == "" || !ValidName(name) {
+		return nil, nil, fs.ErrNotExist
+	}
+	path := filepath.Join(Dir(dataDir, sessionID), name)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, fs.ErrNotExist
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return file, info, nil
+}
+
+// Materialize projects every canonical attachment for the session into the
+// worktree so the agent can read the same .ao/attachments/... paths its
+// conversation history names. Existing worktree files are left alone: the
+// worktree copy of a name that exists in both places is at least as new.
+func Materialize(dataDir, sessionID, workspacePath string) (int, error) {
+	if dataDir == "" || workspacePath == "" {
+		return 0, nil
+	}
+	entries, err := os.ReadDir(Dir(dataDir, sessionID))
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("attachments: read canonical dir: %w", err)
+	}
+	dest := filepath.Join(workspacePath, filepath.FromSlash(WorktreeDir))
+	copied := 0
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() || !ValidName(entry.Name()) {
+			continue
+		}
+		target := filepath.Join(dest, entry.Name())
+		if _, err := os.Lstat(target); err == nil {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(Dir(dataDir, sessionID), entry.Name()))
+		if err != nil {
+			return copied, fmt.Errorf("attachments: read canonical %s: %w", entry.Name(), err)
+		}
+		if copied == 0 {
+			if err := os.MkdirAll(dest, 0o750); err != nil {
+				return copied, fmt.Errorf("attachments: create %s: %w", dest, err)
+			}
+		}
+		if err := os.WriteFile(target, data, 0o600); err != nil {
+			return copied, fmt.Errorf("attachments: materialize %s: %w", entry.Name(), err)
+		}
+		copied++
+	}
+	return copied, nil
+}
+
+// ImportWorktree copies attachments that exist only in the worktree into
+// canonical storage. This is the upgrade path for attachments staged by builds
+// that wrote worktree-only copies: it runs before the destructive teardown that
+// would otherwise delete their only bytes. Names already present canonically
+// are skipped, so re-running is cheap and idempotent.
+func ImportWorktree(dataDir, sessionID, workspacePath string) (int, error) {
+	if dataDir == "" || workspacePath == "" {
+		return 0, nil
+	}
+	src := filepath.Join(workspacePath, filepath.FromSlash(WorktreeDir))
+	entries, err := os.ReadDir(src)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("attachments: read worktree dir: %w", err)
+	}
+	imported := 0
+	for _, entry := range entries {
+		// Symlinks are deliberately not followed: a link out of the worktree must
+		// not be able to pull arbitrary files into durable storage.
+		if !entry.Type().IsRegular() || !ValidName(entry.Name()) {
+			continue
+		}
+		if _, err := os.Lstat(filepath.Join(Dir(dataDir, sessionID), entry.Name())); err == nil {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(src, entry.Name()))
+		if err != nil {
+			return imported, fmt.Errorf("attachments: read worktree %s: %w", entry.Name(), err)
+		}
+		if err := Store(dataDir, sessionID, entry.Name(), data); err != nil {
+			return imported, err
+		}
+		imported++
+	}
+	return imported, nil
+}
+
+// Remove deletes the session's canonical attachment directory. Only for
+// permanent deletion of the owning session — never for runtime teardown or
+// worktree recycling, which is exactly the mistake that motivated this package.
+func Remove(dataDir, sessionID string) error {
+	if dataDir == "" || sessionID == "" {
+		return nil
+	}
+	return os.RemoveAll(Dir(dataDir, sessionID))
+}

--- a/backend/internal/attachments/attachments_test.go
+++ b/backend/internal/attachments/attachments_test.go
@@ -27,11 +27,11 @@ func TestRefNameOnlyAcceptsWorktreeAttachmentRefs(t *testing.T) {
 		t.Fatalf("RefName = %q/%v", name, ok)
 	}
 	for _, ref := range []string{
-		"attachment-ab.png",                 // no prefix
-		".ao/attachments/../secrets.txt",    // traversal
-		".ao/attachments/sub/file.png",      // nested
-		"src/.ao/attachments/file.png",      // wrong root
-		".ao/attachments/",                  // empty name
+		"attachment-ab.png",              // no prefix
+		".ao/attachments/../secrets.txt", // traversal
+		".ao/attachments/sub/file.png",   // nested
+		"src/.ao/attachments/file.png",   // wrong root
+		".ao/attachments/",               // empty name
 		".ao/attachmentsevil/attachment.png",
 	} {
 		if _, ok := RefName(ref); ok {

--- a/backend/internal/attachments/attachments_test.go
+++ b/backend/internal/attachments/attachments_test.go
@@ -1,0 +1,120 @@
+package attachments
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidNameRejectsEscapes(t *testing.T) {
+	for _, name := range []string{
+		"", ".", "..", "../evil.png", "a/b.png", `a\b.png`, ".hidden",
+		"attachment ab.png", "attachment\x00.png", "café.png",
+	} {
+		if ValidName(name) {
+			t.Errorf("ValidName(%q) = true, want false", name)
+		}
+	}
+	for _, name := range []string{"attachment-ab12cd.png", "attachment-1.bin", "legacy_2.JPG"} {
+		if !ValidName(name) {
+			t.Errorf("ValidName(%q) = false, want true", name)
+		}
+	}
+}
+
+func TestRefNameOnlyAcceptsWorktreeAttachmentRefs(t *testing.T) {
+	if name, ok := RefName(".ao/attachments/attachment-ab.png"); !ok || name != "attachment-ab.png" {
+		t.Fatalf("RefName = %q/%v", name, ok)
+	}
+	for _, ref := range []string{
+		"attachment-ab.png",                 // no prefix
+		".ao/attachments/../secrets.txt",    // traversal
+		".ao/attachments/sub/file.png",      // nested
+		"src/.ao/attachments/file.png",      // wrong root
+		".ao/attachments/",                  // empty name
+		".ao/attachmentsevil/attachment.png",
+	} {
+		if _, ok := RefName(ref); ok {
+			t.Errorf("RefName(%q) accepted, want rejected", ref)
+		}
+	}
+}
+
+func TestStoreOpenRoundTrip(t *testing.T) {
+	dataDir := t.TempDir()
+	if err := Store(dataDir, "s1", "attachment-ab.png", []byte("bytes")); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	file, info, err := Open(dataDir, "s1", "attachment-ab.png")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("canonical file mode = %v, want 0600", info.Mode().Perm())
+	}
+	// One session must never resolve another session's files.
+	if _, _, err := Open(dataDir, "s2", "attachment-ab.png"); err == nil {
+		t.Error("Open under a different session id succeeded, want failure")
+	}
+	if _, _, err := Open(dataDir, "s1", "../s1/attachment-ab.png"); err == nil {
+		t.Error("Open with traversal succeeded, want failure")
+	}
+}
+
+func TestImportWorktreeSkipsSymlinksAndInvalidNames(t *testing.T) {
+	dataDir := t.TempDir()
+	worktree := t.TempDir()
+	dir := filepath.Join(worktree, ".ao", "attachments")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "attachment-1.png"), []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(secret, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(dir, "attachment-2.png")); err != nil {
+		t.Fatal(err)
+	}
+
+	imported, err := ImportWorktree(dataDir, "s1", worktree)
+	if err != nil {
+		t.Fatalf("ImportWorktree: %v", err)
+	}
+	if imported != 1 {
+		t.Fatalf("imported = %d, want 1 (symlink skipped)", imported)
+	}
+	if _, err := os.Stat(filepath.Join(Dir(dataDir, "s1"), "attachment-2.png")); err == nil {
+		t.Error("symlinked attachment was imported; links must not pull outside bytes into durable storage")
+	}
+}
+
+func TestMaterializeDoesNotOverwriteNewerWorktreeCopy(t *testing.T) {
+	dataDir := t.TempDir()
+	worktree := t.TempDir()
+	if err := Store(dataDir, "s1", "attachment-1.png", []byte("old")); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(worktree, ".ao", "attachments")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "attachment-1.png"), []byte("newer"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	copied, err := Materialize(dataDir, "s1", worktree)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if copied != 0 {
+		t.Fatalf("copied = %d, want 0", copied)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "attachment-1.png"))
+	if err != nil || string(got) != "newer" {
+		t.Fatalf("worktree copy = %q err=%v, want untouched \"newer\"", got, err)
+	}
+}

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -125,6 +125,7 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 			Usage:         deps.UsageHooks,
 			PreviewServer: deps.PreviewServer,
 			Capabilities:  deps.SessionCapabilities,
+			DataDir:       cfg.DataDir,
 		},
 		usage:         &controllers.UsageController{Svc: deps.UsageSummary},
 		prs:           &controllers.PRsController{Svc: deps.PRs},

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/attachments"
+	attachmentstore "github.com/aoagents/agent-orchestrator/backend/internal/attachments"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
@@ -432,7 +432,7 @@ func (c *SessionsController) previewFile(w http.ResponseWriter, r *http.Request)
 	// the worktree copy is gone: conversation history outlives the disposable
 	// worktree, so the URLs embedded in it must too (#3884). Ordinary preview
 	// files remain confined to the current workspace.
-	if name, ok := attachments.RefName(asset); ok {
+	if name, ok := attachmentstore.RefName(asset); ok {
 		if _, exists := previewutil.EntryAtPath(sess.Metadata.WorkspacePath, asset); !exists {
 			if c.serveDurableAttachment(w, r, sessionID(r), name) {
 				return
@@ -448,7 +448,7 @@ func (c *SessionsController) previewFile(w http.ResponseWriter, r *http.Request)
 func (c *SessionsController) serveDurableAttachment(
 	w http.ResponseWriter, r *http.Request, id domain.SessionID, name string,
 ) bool {
-	file, info, err := attachments.Open(c.DataDir, string(id), name)
+	file, info, err := attachmentstore.Open(c.DataDir, string(id), name)
 	if err != nil {
 		return false
 	}

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/attachments"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
@@ -147,6 +148,9 @@ type SessionsController struct {
 	Usage         UsageHookRecorder
 	PreviewServer ManagedPreviewServer
 	Capabilities  SessionCapabilityValidator
+	// DataDir locates durable attachment storage, so preview URLs embedded in
+	// conversation history keep resolving after the worktree copy is recycled.
+	DataDir string
 }
 
 // Register mounts the session routes on the supplied router.
@@ -423,7 +427,34 @@ func (c *SessionsController) previewFile(w http.ResponseWriter, r *http.Request)
 		envelope.WriteError(w, r, err)
 		return
 	}
-	c.serveWorkspacePreviewFile(w, r, sess.Metadata.WorkspacePath, chi.URLParam(r, "*"))
+	asset := chi.URLParam(r, "*")
+	// An AO-generated attachment reference is served from durable storage when
+	// the worktree copy is gone: conversation history outlives the disposable
+	// worktree, so the URLs embedded in it must too (#3884). Ordinary preview
+	// files remain confined to the current workspace.
+	if name, ok := attachments.RefName(asset); ok {
+		if _, exists := previewutil.EntryAtPath(sess.Metadata.WorkspacePath, asset); !exists {
+			if c.serveDurableAttachment(w, r, sessionID(r), name) {
+				return
+			}
+		}
+	}
+	c.serveWorkspacePreviewFile(w, r, sess.Metadata.WorkspacePath, asset)
+}
+
+// serveDurableAttachment writes the canonical copy of one attachment. Reports
+// false when there is no canonical copy, so the caller can fall through to the
+// ordinary workspace lookup and its error shape.
+func (c *SessionsController) serveDurableAttachment(
+	w http.ResponseWriter, r *http.Request, id domain.SessionID, name string,
+) bool {
+	file, info, err := attachments.Open(c.DataDir, string(id), name)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = file.Close() }()
+	http.ServeContent(w, r, info.Name(), info.ModTime(), file)
+	return true
 }
 
 // PreviewOrigin serves a workspace preview from its isolated *.localhost

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/attachments"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
@@ -2516,5 +2517,65 @@ func TestSessionsAPI_ClaimPRErrors(t *testing.T) {
 			body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/pr/claim", tc.body)
 			assertErrorCode(t, body, status, tc.code, tc.want)
 		})
+	}
+}
+
+// After daemon recovery recreates a worktree, the .ao/attachments/... URLs
+// embedded in durable conversation history must keep resolving from durable
+// storage (#3884). Ordinary preview files stay confined to the live workspace.
+func TestSessionsAPI_PreviewServesDurableAttachmentAfterWorktreeLoss(t *testing.T) {
+	svc := newFakeSessionService()
+	workspace := t.TempDir()
+	dataDir := t.TempDir()
+	s := svc.sessions["ao-1"]
+	s.Metadata = domain.SessionMetadata{WorkspacePath: workspace}
+	svc.sessions["ao-1"] = s
+
+	// The canonical copy exists; the recreated worktree has no projection yet.
+	if err := attachments.Store(dataDir, "ao-1", "attachment-ab12cd.png", []byte("durable-bytes")); err != nil {
+		t.Fatalf("store canonical attachment: %v", err)
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithControl(
+		config.Config{DataDir: dataDir}, log, nil, httpd.APIDeps{Sessions: svc}, httpd.ControlDeps{}))
+	t.Cleanup(srv.Close)
+
+	body, status, _ := doRequest(t, srv, http.MethodGet,
+		"/api/v1/sessions/ao-1/preview/files/.ao/attachments/attachment-ab12cd.png", "")
+	if status != http.StatusOK || string(body) != "durable-bytes" {
+		t.Fatalf("durable attachment = %d %q, want 200 with canonical bytes", status, body)
+	}
+
+	// A live worktree copy wins over the canonical one: it is what the agent
+	// most recently saw.
+	dir := filepath.Join(workspace, ".ao", "attachments")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "attachment-ab12cd.png"), []byte("worktree-bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body, status, _ = doRequest(t, srv, http.MethodGet,
+		"/api/v1/sessions/ao-1/preview/files/.ao/attachments/attachment-ab12cd.png", "")
+	if status != http.StatusOK || string(body) != "worktree-bytes" {
+		t.Fatalf("worktree attachment = %d %q, want 200 with worktree bytes", status, body)
+	}
+
+	// Traversal through the attachment prefix must not reach durable storage.
+	if _, status, _ := doRequest(t, srv, http.MethodGet,
+		"/api/v1/sessions/ao-1/preview/files/.ao/attachments/../../../attachment-ab12cd.png", ""); status == http.StatusOK {
+		t.Fatalf("traversal request = %d, want failure", status)
+	}
+
+	// Another session must never see this session's attachments.
+	other := domain.Session{SessionRecord: domain.SessionRecord{
+		ID: "ao-2", ProjectID: "ao", Kind: domain.KindWorker,
+		Metadata: domain.SessionMetadata{WorkspacePath: t.TempDir()},
+	}, Status: domain.StatusIdle}
+	svc.sessions["ao-2"] = other
+	if _, status, _ := doRequest(t, srv, http.MethodGet,
+		"/api/v1/sessions/ao-2/preview/files/.ao/attachments/attachment-ab12cd.png", ""); status != http.StatusNotFound {
+		t.Fatalf("cross-session attachment = %d, want 404", status)
 	}
 }

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -712,6 +712,11 @@ type ChatEvent struct {
 
 	// ProviderTurnID is set on every event that belongs to a turn.
 	ProviderTurnID string
+	// ProviderConversationID identifies the native thread/session the event came
+	// from. It may differ from ChatConversation.ProviderConversationID for nested
+	// agent work. Empty preserves compatibility with providers whose protocol has
+	// no nested-conversation identity.
+	ProviderConversationID string
 	// ProviderItemID identifies the message or activity being reported.
 	ProviderItemID string
 	// ClientMessageID is the provider-carried idempotency key for a recovered user

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -173,10 +173,20 @@ type Controller struct {
 	mcpServers     map[string]domain.ConversationMCPServer
 	mcpServerOrder []string
 
+	// handoffSettleWait bounds how long an interrupt-policy handoff waits for the
+	// provider to settle the turn it was asked to cancel. The terminal is the
+	// escape hatch for a runaway command; a provider that accepted the interrupt
+	// but never reports completion must not be able to wedge the switch.
+	handoffSettleWait time.Duration
+
 	stopped  chan struct{}
 	once     sync.Once
 	closeErr error
 }
+
+// defaultHandoffSettleWait is generous for a healthy provider killing a process
+// and reporting completion, while still bounding a wedged one.
+const defaultHandoffSettleWait = 10 * time.Second
 
 // ErrNoActiveTurn reports an interrupt with nothing to cancel.
 var ErrNoActiveTurn = errors.New("no active turn")
@@ -198,19 +208,20 @@ func newController(
 	now Clock,
 ) *Controller {
 	c := &Controller{
-		sessionID:    sessionID,
-		conversation: conversation,
-		generation:   generation,
-		conv:         conv,
-		store:        store,
-		activity:     activity,
-		log:          log,
-		newID:        newID,
-		now:          now,
-		state:        ports.ChatControllerReady,
-		settings:     conversation.Settings,
-		mcpServers:   map[string]domain.ConversationMCPServer{},
-		stopped:      make(chan struct{}),
+		sessionID:         sessionID,
+		conversation:      conversation,
+		generation:        generation,
+		conv:              conv,
+		store:             store,
+		activity:          activity,
+		log:               log,
+		newID:             newID,
+		now:               now,
+		state:             ports.ChatControllerReady,
+		settings:          conversation.Settings,
+		mcpServers:        map[string]domain.ConversationMCPServer{},
+		handoffSettleWait: defaultHandoffSettleWait,
+		stopped:           make(chan struct{}),
 	}
 	// Seeded from the durable row so a reconnect merges onto what is already known
 	// rather than starting from blank and reporting a conversation as having no
@@ -909,6 +920,15 @@ func (c *Controller) BeginHandoff(
 		c.drain(ctx)
 	}
 
+	// An interrupted turn should settle within moments of the provider accepting
+	// the cancel. If it never does — the provider is wedged on the very command
+	// the user is trying to escape — the switch must not wait forever: the
+	// terminal on the other side of this handoff is the escape hatch (#3945).
+	var settleDeadline time.Time
+	if policy == domain.SessionInterfaceTransitionInterrupt {
+		settleDeadline = time.Now().Add(c.handoffSettleWait)
+	}
+
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -919,7 +939,20 @@ func (c *Controller) BeginHandoff(
 		c.sendMu.Lock()
 		c.mu.Lock()
 		busy := c.pendingTurnID != ""
+		pending := c.pendingTurnID
 		c.mu.Unlock()
+		if busy && !settleDeadline.IsZero() && time.Now().After(settleDeadline) {
+			// The user chose to stop; the durable row is settled on their behalf
+			// so the handoff can complete and the terminal can take over.
+			c.log.Warn("interrupted turn never settled before handoff; reconciling",
+				"session", c.sessionID, "turn", pending)
+			if err := c.reconcileDurableTurn(ctx, pending); err != nil {
+				c.sendMu.Unlock()
+				c.AbortHandoff()
+				return fmt.Errorf("settle interrupted turn for handoff: %w", err)
+			}
+			busy = false
+		}
 		if !busy {
 			_, err := c.store.NextQueuedTurn(ctx, c.conversation.ID)
 			switch {

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -264,7 +264,7 @@ func (c *Controller) importNativeHistory(
 		if event.ProviderEventID == "" {
 			return fmt.Errorf("native history event %s has no stable identity", event.Kind)
 		}
-		if _, err := c.projectEvent(ctx, event); err != nil {
+		if _, _, err := c.projectEvent(ctx, event); err != nil {
 			return fmt.Errorf("import native history event %s: %w", event.Kind, err)
 		}
 	}
@@ -799,7 +799,13 @@ func (c *Controller) dispatch(
 func (c *Controller) drain(ctx context.Context) {
 	c.sendMu.Lock()
 	defer c.sendMu.Unlock()
+	c.drainLocked(ctx)
+}
 
+// drainLocked is drain with the dispatch lock already held. Turn completion
+// uses it so committing the completion, clearing primary ownership, and claiming
+// the next queued request are one serialized lifecycle transition.
+func (c *Controller) drainLocked(ctx context.Context) {
 	c.mu.Lock()
 	cutoff := c.cancelQueuedAt
 	c.cancelQueuedAt = time.Time{}
@@ -905,6 +911,11 @@ func (c *Controller) BeginHandoff(
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	for {
+		// Quiescence is a dispatch boundary, not merely "pendingTurnID is empty".
+		// dispatch marks the durable row running before it installs pendingTurnID;
+		// without sendMu a handoff can observe that narrow middle state as neither
+		// queued nor active and start the target controller too early.
+		c.sendMu.Lock()
 		c.mu.Lock()
 		busy := c.pendingTurnID != ""
 		c.mu.Unlock()
@@ -912,14 +923,17 @@ func (c *Controller) BeginHandoff(
 			_, err := c.store.NextQueuedTurn(ctx, c.conversation.ID)
 			switch {
 			case errors.Is(err, domain.ErrNoQueuedTurn):
+				c.sendMu.Unlock()
 				return nil
 			case err != nil:
+				c.sendMu.Unlock()
 				c.AbortHandoff()
 				return fmt.Errorf("check queued turns before handoff: %w", err)
 			case policy == domain.SessionInterfaceTransitionDrain:
-				c.drain(ctx)
+				c.drainLocked(ctx)
 			}
 		}
+		c.sendMu.Unlock()
 		select {
 		case <-ctx.Done():
 			c.AbortHandoff()
@@ -1222,17 +1236,25 @@ func (c *Controller) project() {
 	ctx := context.WithoutCancel(context.Background())
 
 	for event := range c.conv.Events() {
-		projected, err := c.projectEvent(ctx, event)
+		// A lifecycle event and a concurrent Send must agree on whether the root
+		// conversation is busy. Holding the same lock Send/dispatch use closes the
+		// window between the durable projection and the in-memory ownership update.
+		lifecycle := event.Kind == ports.ChatEventTurnStarted || event.Kind == ports.ChatEventTurnCompleted
+		if lifecycle {
+			c.sendMu.Lock()
+		}
+		projected, primaryTurn, err := c.projectEvent(ctx, event)
 		if err != nil {
 			// A projection failure must not kill the provider stream. The store
 			// rolls the archive back with its projection, so durable state remains
 			// internally consistent and a later provider replay may retry it.
 			c.log.Error("failed to project chat event",
 				"session", c.sessionID, "kind", event.Kind, "error", err)
-			continue
+		} else if projected {
+			c.afterProject(ctx, event, primaryTurn)
 		}
-		if projected {
-			c.afterProject(ctx, event)
+		if lifecycle {
+			c.sendMu.Unlock()
 		}
 	}
 
@@ -1269,31 +1291,32 @@ func (c *Controller) project() {
 
 // projectEvent archives one normalized provider event and applies its durable
 // projection in the same SQLite transaction.
-func (c *Controller) projectEvent(ctx context.Context, event ports.ChatEvent) (bool, error) {
+func (c *Controller) projectEvent(ctx context.Context, event ports.ChatEvent) (bool, bool, error) {
 	record := map[string]any{
-		"kind":            event.Kind,
-		"providerEventId": event.ProviderEventID,
-		"providerTurnId":  event.ProviderTurnID,
-		"providerItemId":  event.ProviderItemID,
-		"clientMessageId": event.ClientMessageID,
-		"turnState":       event.TurnState,
-		"delta":           event.Delta,
-		"text":            event.Text,
-		"activityKind":    event.ActivityKind,
-		"activityStatus":  event.ActivityStatus,
-		"summary":         event.Summary,
-		"detail":          json.RawMessage(nonEmptyJSON(event.Detail)),
-		"requestId":       event.RequestID,
-		"decisions":       event.Decisions,
-		"controllerState": event.ControllerState,
-		"usage":           event.Usage,
-		"rateLimits":      event.RateLimits,
-		"title":           event.Title,
-		"plan":            event.Plan,
-		"reroute":         event.Reroute,
-		"account":         event.Account,
-		"threadState":     event.ThreadState,
-		"mcpServers":      event.MCPServers,
+		"kind":                   event.Kind,
+		"providerEventId":        event.ProviderEventID,
+		"providerTurnId":         event.ProviderTurnID,
+		"providerConversationId": event.ProviderConversationID,
+		"providerItemId":         event.ProviderItemID,
+		"clientMessageId":        event.ClientMessageID,
+		"turnState":              event.TurnState,
+		"delta":                  event.Delta,
+		"text":                   event.Text,
+		"activityKind":           event.ActivityKind,
+		"activityStatus":         event.ActivityStatus,
+		"summary":                event.Summary,
+		"detail":                 json.RawMessage(nonEmptyJSON(event.Detail)),
+		"requestId":              event.RequestID,
+		"decisions":              event.Decisions,
+		"controllerState":        event.ControllerState,
+		"usage":                  event.Usage,
+		"rateLimits":             event.RateLimits,
+		"title":                  event.Title,
+		"plan":                   event.Plan,
+		"reroute":                event.Reroute,
+		"account":                event.Account,
+		"threadState":            event.ThreadState,
+		"mcpServers":             event.MCPServers,
 	}
 	record["diff"] = event.Diff
 	if event.Input != nil {
@@ -1304,11 +1327,55 @@ func (c *Controller) projectEvent(ctx context.Context, event ports.ChatEvent) (b
 	}
 	payload, err := json.Marshal(record)
 	if err != nil {
-		return false, fmt.Errorf("encode provider event archive: %w", err)
+		return false, false, fmt.Errorf("encode provider event archive: %w", err)
 	}
-	return c.store.ProjectProviderEvent(ctx, c.conversation.ID, c.sessionID,
+	projected, err := c.store.ProjectProviderEvent(ctx, c.conversation.ID, c.sessionID,
 		c.generation, event.ProviderEventID, string(event.Kind), string(payload), c.now(),
 		func(txCtx context.Context) error { return c.apply(txCtx, event) })
+	if err != nil || !projected {
+		return projected, false, err
+	}
+	return true, c.applyCommittedTurnLifecycle(event), nil
+}
+
+// applyCommittedTurnLifecycle updates the controller's volatile ownership only
+// after the matching durable projection commits. Codex streams events for nested
+// child threads over the root connection, so only events from the conversation AO
+// opened are allowed to claim or release the primary turn.
+func (c *Controller) applyCommittedTurnLifecycle(event ports.ChatEvent) bool {
+	if event.Kind != ports.ChatEventTurnStarted && event.Kind != ports.ChatEventTurnCompleted {
+		return false
+	}
+	if event.ProviderConversationID != "" && event.ProviderConversationID != c.conv.ProviderConversationID() {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch event.Kind {
+	case ports.ChatEventTurnStarted:
+		// AO serializes root dispatch. A different turn id while one is pending is
+		// auxiliary provider work, even for a protocol that cannot name its thread.
+		if c.pendingTurnID != "" && c.pendingTurnID != event.ProviderTurnID {
+			return false
+		}
+		c.pendingTurnID = event.ProviderTurnID
+		c.ackedTurnID = event.ProviderTurnID
+		c.state = ports.ChatControllerBusy
+		return true
+	case ports.ChatEventTurnCompleted:
+		if c.pendingTurnID != event.ProviderTurnID {
+			return false
+		}
+		c.pendingTurnID = ""
+		if c.ackedTurnID == event.ProviderTurnID {
+			c.ackedTurnID = ""
+		}
+		c.state = ports.ChatControllerReady
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
@@ -1316,13 +1383,6 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 
 	switch event.Kind {
 	case ports.ChatEventTurnStarted:
-		c.mu.Lock()
-		c.pendingTurnID = event.ProviderTurnID
-		// The provider has confirmed this turn, so it will accept an interrupt for
-		// it. Until this arrives, it will not.
-		c.ackedTurnID = event.ProviderTurnID
-		c.state = ports.ChatControllerBusy
-		c.mu.Unlock()
 		// A turn AO dispatched already has a row, bound in dispatch. This covers the
 		// turn AO did NOT dispatch: a compaction, or work the provider resumed from its
 		// own history. Adopting it is what keeps every item it emits correlated, and
@@ -1351,15 +1411,6 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 			}, now)
 
 	case ports.ChatEventTurnCompleted:
-		c.mu.Lock()
-		if c.pendingTurnID == event.ProviderTurnID {
-			c.pendingTurnID = ""
-		}
-		if c.ackedTurnID == event.ProviderTurnID {
-			c.ackedTurnID = ""
-		}
-		c.state = ports.ChatControllerReady
-		c.mu.Unlock()
 		message := ""
 		if event.Err != nil {
 			message = event.Err.Error()
@@ -1697,15 +1748,20 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 // archive/projection transaction. Lifecycle writes touch the sessions table and
 // draining may call the provider, so either one inside the store transaction
 // would hold the single writer connection across another subsystem.
-func (c *Controller) afterProject(ctx context.Context, event ports.ChatEvent) {
+func (c *Controller) afterProject(ctx context.Context, event ports.ChatEvent, primaryTurn bool) {
 	now := c.now()
 	switch event.Kind {
 	case ports.ChatEventTurnStarted:
-		c.reportActivity(ctx, domain.ActivityActive, "chat.turn.started", now)
+		if primaryTurn {
+			c.reportActivity(ctx, domain.ActivityActive, "chat.turn.started", now)
+		}
 	case ports.ChatEventTurnCompleted:
+		if !primaryTurn {
+			return
+		}
 		c.reportActivity(ctx, domain.ActivityIdle, "chat.turn.completed", now)
 		// The settled turn is committed before another queued turn can dispatch.
-		c.drain(ctx)
+		c.drainLocked(ctx)
 	case ports.ChatEventApprovalRequested:
 		c.reportActivity(ctx, domain.ActivityWaitingInput, "chat.approval.requested", now)
 	case ports.ChatEventInputRequested:

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -47,6 +47,7 @@ type Store interface {
 	SettleTurn(ctx context.Context, conversationID, providerTurnID string, state domain.TurnState, errMessage string, now time.Time) error
 	SettleTurnByID(ctx context.Context, turnID string, state domain.TurnState, errMessage string, now time.Time) error
 	SettleOrphanedTurns(ctx context.Context, session domain.SessionID, now time.Time) error
+	GetRunningTurn(ctx context.Context, conversationID string) (id, providerTurnID string, ok bool, err error)
 
 	SetConversationSettings(ctx context.Context, conversationID string, settings domain.ConversationSettings, now time.Time) error
 
@@ -1090,10 +1091,43 @@ const turnAckWait = 3 * time.Second
 // the next message instead of stopping would be the opposite of what the button
 // says. The cutoff is recorded before the provider call, so a completion that
 // races back cannot drain the queue the interrupt was about to cancel.
+// Durable state is what the UI renders, so it is also what Stop must be able to
+// act on. Two recovery paths reconcile the cases where in-memory tracking and the
+// durable turn row disagree:
+//
+//   - Memory says nothing is running but SQLite has a turn in 'running'. Either a
+//     projection failure kept the completion from committing, or Stop landed in
+//     the dispatch window after BindTurnToProvider wrote 'running' but before
+//     pendingTurnID was set. Taking sendMu first means dispatch has finished (and
+//     set pendingTurnID) before the disk is consulted — if a turn appeared while
+//     we waited, the normal interrupt path runs instead.
+//   - The provider answers ErrChatNoActiveTurn for a turn memory still tracks.
+//     The provider is the authority that the work already ended; surfacing a bare
+//     "no active turn" would leave the user staring at a Working bar they cannot
+//     dismiss. Reconcile the durable row instead.
 func (c *Controller) Interrupt(ctx context.Context) error {
 	turn, ok := c.awaitAcknowledgedTurn(ctx)
 	if !ok {
-		return ErrNoActiveTurn
+		// Serialize against dispatch so its "durable row running, memory not yet
+		// updated" middle state cannot be mistaken for a lost turn.
+		c.sendMu.Lock()
+		defer c.sendMu.Unlock()
+
+		c.mu.Lock()
+		pending := c.pendingTurnID
+		c.mu.Unlock()
+		if pending == "" {
+			_, providerTurnID, running, err := c.store.GetRunningTurn(ctx, c.conversation.ID)
+			if err != nil {
+				return fmt.Errorf("check running turn: %w", err)
+			}
+			if !running {
+				return ErrNoActiveTurn
+			}
+			return c.reconcileDurableTurn(ctx, providerTurnID)
+		}
+		// dispatch finished while we waited — interrupt normally.
+		turn = pending
 	}
 
 	c.mu.Lock()
@@ -1101,16 +1135,58 @@ func (c *Controller) Interrupt(ctx context.Context) error {
 	c.mu.Unlock()
 
 	if err := c.conv.Interrupt(ctx, turn); err != nil {
+		if errors.Is(err, ports.ErrChatNoActiveTurn) {
+			c.mu.Lock()
+			c.cancelQueuedAt = time.Time{}
+			c.mu.Unlock()
+			return c.reconcileDurableTurn(ctx, turn)
+		}
 		// The interrupt did not happen, so the queue it was going to cancel is
 		// still the user's to send.
 		c.mu.Lock()
 		c.cancelQueuedAt = time.Time{}
 		c.mu.Unlock()
-		if errors.Is(err, ports.ErrChatNoActiveTurn) {
-			return ErrNoActiveTurn
-		}
 		return fmt.Errorf("interrupt turn %s: %w", turn, err)
 	}
+	return nil
+}
+
+// reconcileDurableTurn settles a turn the controller can no longer cancel through
+// the normal path but durable state still shows as running. It delivers the full
+// Interrupt contract in one place — best-effort provider cancel, settle the row
+// as interrupted, clear in-memory tracking, cancel the queue behind it, report
+// idle — so both recovery paths behave identically.
+func (c *Controller) reconcileDurableTurn(ctx context.Context, providerTurnID string) error {
+	if err := c.conv.Interrupt(ctx, providerTurnID); err != nil {
+		if !errors.Is(err, ports.ErrChatNoActiveTurn) {
+			c.log.Warn("provider interrupt during reconciliation failed",
+				"session", c.sessionID, "turn", providerTurnID, "error", err)
+		}
+	}
+
+	if err := c.store.SettleTurn(ctx, c.conversation.ID, providerTurnID,
+		domain.TurnStateInterrupted, "reconciled by interrupt", c.now()); err != nil {
+		return fmt.Errorf("reconcile durable turn %s: %w", providerTurnID, err)
+	}
+
+	now := c.now()
+	c.mu.Lock()
+	c.cancelQueuedAt = now
+	if c.pendingTurnID == providerTurnID {
+		c.pendingTurnID = ""
+	}
+	if c.ackedTurnID == providerTurnID {
+		c.ackedTurnID = ""
+	}
+	c.state = ports.ChatControllerReady
+	c.mu.Unlock()
+
+	if err := c.store.CancelQueuedTurns(ctx, c.conversation.ID, now, now); err != nil {
+		c.log.Error("failed to cancel queued turns during reconciliation",
+			"session", c.sessionID, "error", err)
+	}
+
+	c.reportActivity(ctx, domain.ActivityIdle, "chat.interrupt.reconciled", now)
 	return nil
 }
 

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -1737,10 +1737,11 @@ func TestInterruptWaitsForTheProviderToAcknowledgeTheTurn(t *testing.T) {
 	}
 }
 
-// A provider that refuses because the turn is genuinely gone must reach the client
-// as the same typed "nothing to interrupt" answer AO produces itself — not as a
-// protocol error that renders as an internal failure.
-func TestProviderRefusalBecomesTheTypedNoActiveTurnError(t *testing.T) {
+// A provider that refuses because the turn is genuinely gone must not strand the
+// user: the durable row still says running — that is what the UI renders — so
+// Interrupt reconciles it as interrupted instead of answering "nothing to stop"
+// while the Working bar stays up.
+func TestProviderRefusalReconcilesTheDurableTurnAsInterrupted(t *testing.T) {
 	conv := newInterruptRecorder() // never marks anything active
 	h := newHarnessWithConversation(t, conv)
 	ctx := context.Background()
@@ -1748,10 +1749,109 @@ func TestProviderRefusalBecomesTheTypedNoActiveTurnError(t *testing.T) {
 	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{Text: "go", ClientMessageID: "c1"}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
 
-	err := h.svc.Interrupt(ctx, testSession)
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateInterrupted
+	})
+	if !hasActivitySignal(h.activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
+		t.Errorf("no idle signal after reconciliation; signals = %v", h.activity.snapshot())
+	}
+}
+
+func hasActivitySignal(signals []ports.ActivitySignal, state domain.ActivityState, event string) bool {
+	for _, s := range signals {
+		if s.State == state && s.Event == event {
+			return true
+		}
+	}
+	return false
+}
+
+// The #3749 desync: a turn is 'running' on disk while the in-memory controller
+// has no pendingTurnID (a completed projection failed, or the daemon restarted
+// mid-turn). The UI reads disk and shows "Working"; Stop must act on what the
+// user sees rather than refuse with CHAT_NO_ACTIVE_TURN.
+func TestInterruptReconcilesStaleRunningTurnOnDisk(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	// Create the running turn directly in the store, bypassing the controller so
+	// its pendingTurnID stays empty — the desynced state.
+	const providerTurnID = "stale-running-turn"
+	if err := h.st.AdoptProviderTurn(ctx, h.ctrl.ConversationID(), testSession,
+		h.ctrl.Generation(), "stale-turn-id", providerTurnID, h.now()); err != nil {
+		t.Fatalf("AdoptProviderTurn: %v", err)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateInterrupted
+	})
+	if !hasActivitySignal(h.activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
+		t.Errorf("no idle signal after reconciliation; signals = %v", h.activity.snapshot())
+	}
+}
+
+// When memory and disk agree there is nothing running, Interrupt must still
+// answer ErrNoActiveTurn — the disk fallback must not invent work to stop.
+func TestInterruptReturnsNoActiveTurnWhenNoRunningTurnAnywhere(t *testing.T) {
+	h := newHarness(t)
+
+	err := h.svc.Interrupt(context.Background(), testSession)
 	if !errorsIs(err, chatsvc.ErrNoActiveTurn) {
 		t.Fatalf("err = %v, want ErrNoActiveTurn", err)
+	}
+}
+
+// Reconciliation is still the user's brake: anything queued behind the stale
+// turn is cancelled, not released into the provider.
+func TestInterruptReconciliationCancelsQueuedTurns(t *testing.T) {
+	conv := newInterruptRecorder() // never marks anything active
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "running", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send running: %v", err)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "queued", ClientMessageID: "c2",
+	}); err != nil {
+		t.Fatalf("Send queued: %v", err)
+	}
+
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		states := turnStateByText(t, s)
+		return states["running"] == domain.TurnStateInterrupted &&
+			states["queued"] == domain.TurnStateInterrupted
+	})
+	states := turnStateByText(t, snapshot)
+	if states["queued"] != domain.TurnStateInterrupted {
+		t.Errorf("queued turn = %q, want interrupted (cancelled, not dispatched)", states["queued"])
+	}
+	if got := h.conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; reconciliation must not release the queue", got)
 	}
 }
 
@@ -2198,4 +2298,135 @@ func TestProviderStartedTurnIsAdoptedSoItsItemsCorrelate(t *testing.T) {
 			t.Errorf("activity %q has no turn id; the timeline cannot group it", activity.Summary)
 		}
 	}
+}
+
+// failingProjectStore injects a projection failure for one event kind,
+// simulating a SettleTurn error or tx.Commit failure without corrupting SQLite.
+type failingProjectStore struct {
+	chatsvc.Store
+	failMethod string
+}
+
+func (s *failingProjectStore) ProjectProviderEvent(
+	ctx context.Context, conversationID string, session domain.SessionID,
+	generation, providerEventID, method, payloadJSON string, now time.Time,
+	project func(context.Context) error,
+) (bool, error) {
+	if method == s.failMethod {
+		return false, errors.New("injected projection failure")
+	}
+	return s.Store.ProjectProviderEvent(ctx, conversationID, session, generation,
+		providerEventID, method, payloadJSON, now, project)
+}
+
+// The exact #3749 sequence: the turn/completed projection fails (so the durable
+// row stays 'running' and the UI keeps showing "Working"), then the user presses
+// Stop and the provider refuses because the turn already ended on its side.
+// Interrupt must settle the durable row as interrupted, cancel the queue behind
+// it, and report idle — not answer CHAT_NO_ACTIVE_TURN and strand the user.
+func TestProjectionFailureThenStopStillStopsTheTurn(t *testing.T) {
+	conv := newInterruptRecorder() // never marks anything active -> always refuses
+	st := openStore(t)
+
+	var counterMu sync.Mutex
+	counter := 0
+	activity := &recordingActivity{}
+	clock := time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)
+	svc := chatsvc.New(chatsvc.Options{
+		Store:    &failingProjectStore{Store: st, failMethod: string(ports.ChatEventTurnCompleted)},
+		Sessions: st,
+		Drivers:  fakeRegistry{driver: fakeDriver{conv: conv}},
+		Activity: activity,
+		Log:      slog.New(slog.DiscardHandler),
+		NewID: func() string {
+			counterMu.Lock()
+			defer counterMu.Unlock()
+			counter++
+			return fmt.Sprintf("id-%03d", counter)
+		},
+		Now: func() time.Time { return clock },
+	})
+
+	ctrl, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID:     testSession,
+		ProjectID:     testProject,
+		Harness:       domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+	ctx := context.Background()
+
+	if _, err := svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "running", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send running: %v", err)
+	}
+	conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	awaitStoreSnapshot(t, st, ctrl.ConversationID(), func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	if _, err := svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "queued", ClientMessageID: "c2",
+	}); err != nil {
+		t.Fatalf("Send queued: %v", err)
+	}
+
+	// The completion's projection fails: the durable row stays 'running' and
+	// afterProject never runs, so nothing drains and nothing reports idle.
+	conv.emit(ports.ChatEvent{
+		Kind:           ports.ChatEventTurnCompleted,
+		ProviderTurnID: "provider-turn-1",
+		TurnState:      domain.TurnStateCompleted,
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	if err := svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	snapshot := awaitStoreSnapshot(t, st, ctrl.ConversationID(), func(s store.ConversationSnapshot) bool {
+		states := turnStateByText(t, s)
+		return states["running"] == domain.TurnStateInterrupted &&
+			states["queued"] == domain.TurnStateInterrupted
+	})
+	states := turnStateByText(t, snapshot)
+	if states["running"] != domain.TurnStateInterrupted {
+		t.Errorf("running turn = %q, want interrupted", states["running"])
+	}
+	if states["queued"] != domain.TurnStateInterrupted {
+		t.Errorf("queued turn = %q, want interrupted (cancelled, not dispatched)", states["queued"])
+	}
+	if got := conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; reconciliation must not release the queue", got)
+	}
+	if !hasActivitySignal(activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
+		t.Errorf("no idle signal after reconciliation; signals = %v", activity.snapshot())
+	}
+}
+
+// awaitStoreSnapshot is awaitSnapshot for tests that build their own service
+// rather than using the harness.
+func awaitStoreSnapshot(t *testing.T, st *sqlite.Store, conversationID string,
+	pred func(store.ConversationSnapshot) bool) store.ConversationSnapshot {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last store.ConversationSnapshot
+	for time.Now().Before(deadline) {
+		snapshot, err := st.LoadConversationSnapshot(context.Background(), conversationID)
+		if err != nil {
+			t.Fatalf("load snapshot: %v", err)
+		}
+		last = snapshot
+		if pred(snapshot) {
+			return snapshot
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("snapshot never satisfied the condition; last had %d messages, %d activities, %d turns",
+		len(last.Messages), len(last.Activities), len(last.Turns))
+	return last
 }

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -1166,6 +1166,188 @@ func TestSendWhileBusyQueuesUntilTheTurnEnds(t *testing.T) {
 	}
 }
 
+// Codex can start nested turns while the root turn is still working. A child
+// completion is not conversation quiescence: dispatching queued automation at
+// that point injects it into the still-running root and leaves the AO turn minted
+// for that automation with no matching provider lifecycle.
+func TestNestedTurnCompletionDoesNotDrainQueueWhilePrimaryTurnRuns(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "root work", ClientMessageID: "c1", Origin: domain.MessageOriginHuman,
+	}); err != nil {
+		t.Fatalf("send root turn: %v", err)
+	}
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1",
+		ProviderConversationID: "thread-1",
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["root work"] == domain.TurnStateRunning
+	})
+
+	queued, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "queued automation", ClientMessageID: "c2", Origin: domain.MessageOriginAutomation,
+	})
+	if err != nil {
+		t.Fatalf("queue automation: %v", err)
+	}
+	if queued.State != domain.TurnStateQueued {
+		t.Fatalf("automation state = %q, want queued", queued.State)
+	}
+
+	h.conv.emit(
+		ports.ChatEvent{
+			Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-child-1",
+			ProviderConversationID: "child-thread-1",
+		},
+		ports.ChatEvent{
+			Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-child-1",
+			ProviderConversationID: "child-thread-1", TurnState: domain.TurnStateCompleted,
+		},
+		// This later root event is a deterministic barrier: once projected, the
+		// child's afterProject hook (including any incorrect drain) has finished.
+		ports.ChatEvent{
+			Kind: ports.ChatEventActivityCompleted, ProviderTurnID: "provider-turn-1",
+			ProviderItemID: "root-still-working", ActivityKind: domain.ActivityKindCommand,
+			ActivityStatus: domain.ActivityStatusCompleted, Summary: "root continued",
+		},
+	)
+
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		for _, activity := range s.Activities {
+			if activity.ProviderItemID == "root-still-working" {
+				return true
+			}
+		}
+		return false
+	})
+	states := turnStateByText(t, snapshot)
+	if states["queued automation"] != domain.TurnStateQueued {
+		t.Errorf("automation state after child completion = %q, want queued", states["queued automation"])
+	}
+	if got := h.conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; child completion must not drain queued automation", got)
+	}
+	if got := h.ctrl.State(); got != ports.ChatControllerBusy {
+		t.Errorf("controller state after child completion = %q, want busy", got)
+	}
+	for _, signal := range h.activity.snapshot() {
+		if signal.State == domain.ActivityIdle {
+			t.Fatalf("child completion reported the session idle: %+v", signal)
+		}
+	}
+
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-turn-1",
+		ProviderConversationID: "thread-1", TurnState: domain.TurnStateCompleted,
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["queued automation"] == domain.TurnStateRunning
+	})
+	if got := h.conv.sentTexts(); len(got) != 2 || got[1] != "queued automation" {
+		t.Fatalf("provider received %v, want automation only after root completion", got)
+	}
+	idleReported := false
+	for _, signal := range h.activity.snapshot() {
+		idleReported = idleReported || signal.State == domain.ActivityIdle
+	}
+	if !idleReported {
+		t.Fatal("root completion did not report the session idle")
+	}
+}
+
+// A Chat -> TUI handoff waits for the root turn and everything already queued
+// behind it. Nested Codex lifecycle must not make that drain look complete, nor
+// may it release the accepted queue into a root turn that is still running.
+func TestChatHandoffDrainWaitsForRootAfterNestedTurnCompletes(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "root work", ClientMessageID: "handoff-nested-1", Origin: domain.MessageOriginHuman,
+	}); err != nil {
+		t.Fatalf("send root turn: %v", err)
+	}
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1",
+		ProviderConversationID: "thread-1",
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["root work"] == domain.TurnStateRunning
+	})
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "accepted queue", ClientMessageID: "handoff-nested-2", Origin: domain.MessageOriginAutomation,
+	}); err != nil {
+		t.Fatalf("queue accepted turn: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.svc.PrepareChatHandoff(ctx, testSession, domain.SessionInterfaceTransitionDrain)
+	}()
+
+	h.conv.emit(
+		ports.ChatEvent{
+			Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-child-1",
+			ProviderConversationID: "child-thread-1",
+		},
+		ports.ChatEvent{
+			Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-child-1",
+			ProviderConversationID: "child-thread-1", TurnState: domain.TurnStateCompleted,
+		},
+		ports.ChatEvent{
+			Kind: ports.ChatEventActivityCompleted, ProviderTurnID: "provider-turn-1",
+			ProviderItemID: "handoff-root-still-working", ActivityKind: domain.ActivityKindCommand,
+			ActivityStatus: domain.ActivityStatusCompleted, Summary: "root continued",
+		},
+	)
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		for _, activity := range s.Activities {
+			if activity.ProviderItemID == "handoff-root-still-working" {
+				return true
+			}
+		}
+		return false
+	})
+
+	select {
+	case err := <-done:
+		t.Fatalf("handoff finished after child completion while root was active: %v", err)
+	default:
+	}
+	if got := h.conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; nested completion released the accepted queue", got)
+	}
+
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-turn-1",
+		ProviderConversationID: "thread-1", TurnState: domain.TurnStateCompleted,
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["accepted queue"] == domain.TurnStateRunning
+	})
+	select {
+	case err := <-done:
+		t.Fatalf("handoff finished before its accepted queue completed: %v", err)
+	default:
+	}
+
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-turn-2",
+		ProviderConversationID: "thread-1", TurnState: domain.TurnStateCompleted,
+	})
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("prepare handoff: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("handoff did not become quiescent after the root and accepted queue completed")
+	}
+}
+
 // Stop is a brake. Releasing the queue when the user presses it would be the
 // opposite of what the button says, so anything waiting is cancelled with the turn.
 func TestInterruptCancelsWhatIsQueuedBehindTheTurn(t *testing.T) {

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -2430,3 +2430,77 @@ func awaitStoreSnapshot(t *testing.T, st *sqlite.Store, conversationID string,
 		len(last.Messages), len(last.Activities), len(last.Turns))
 	return last
 }
+
+// The terminal is the escape hatch for a runaway command. An interrupt-policy
+// handoff whose provider accepts the cancel but never reports turn completion
+// must still finish: the durable turn is reconciled as interrupted after a
+// bounded wait instead of the switch spinning forever (#3945).
+func TestInterruptHandoffCompletesWhenProviderNeverSettlesTheTurn(t *testing.T) {
+	conv := newInterruptRecorder()
+	st := openStore(t)
+
+	var counterMu sync.Mutex
+	counter := 0
+	activity := &recordingActivity{}
+	clock := time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)
+	svc := chatsvc.New(chatsvc.Options{
+		Store:    st,
+		Sessions: st,
+		Drivers:  fakeRegistry{driver: fakeDriver{conv: conv}},
+		Activity: activity,
+		Log:      slog.New(slog.DiscardHandler),
+		NewID: func() string {
+			counterMu.Lock()
+			defer counterMu.Unlock()
+			counter++
+			return fmt.Sprintf("id-%03d", counter)
+		},
+		Now:               func() time.Time { return clock },
+		HandoffSettleWait: 150 * time.Millisecond,
+	})
+	ctrl, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID:     testSession,
+		ProjectID:     testProject,
+		Harness:       domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+	ctx := context.Background()
+
+	if _, err := svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "npm run dev", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	conv.markActive("provider-turn-1")
+	conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	awaitStoreSnapshot(t, st, ctrl.ConversationID(), func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	// The provider accepts the interrupt but never emits turn/completed — the
+	// wedged state a runaway dev server can produce.
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.PrepareChatHandoff(ctx, testSession, domain.SessionInterfaceTransitionInterrupt)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("PrepareChatHandoff: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handoff never completed; the terminal escape hatch is wedged")
+	}
+
+	snapshot := awaitStoreSnapshot(t, st, ctrl.ConversationID(), func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State.Terminal()
+	})
+	if got := snapshot.Turns[0].State; got != domain.TurnStateInterrupted {
+		t.Errorf("turn state = %q, want interrupted", got)
+	}
+}

--- a/backend/internal/service/chat/output_diff_test.go
+++ b/backend/internal/service/chat/output_diff_test.go
@@ -201,6 +201,59 @@ func TestCommandOutputIsCappedAndSaysSo(t *testing.T) {
 	}
 }
 
+// Once output is capped, further deltas must not touch the row at all. Every
+// revision bump fires a CDC event, an SSE push, and a full snapshot refetch in
+// the client; a dev server in watch mode streaming past the cap turned that
+// into a re-render storm that froze the session page (#3945).
+func TestCappedOutputStopsBumpingRevision(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "npm run dev", ClientMessageID: "c1", Origin: domain.MessageOriginHuman,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	h.conv.emit(
+		ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"},
+		startedCommand("provider-turn-1", "exec-1", "npm run dev"),
+	)
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Activities) == 1 })
+
+	// One delta larger than the cap truncates in a single append.
+	h.conv.emit(outputDelta("provider-turn-1", "exec-1",
+		strings.Repeat("x", store.MaxCommandOutputChars+1)))
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		for _, a := range s.Activities {
+			if a.ProviderItemID == "exec-1" && a.CommandOutputTruncated {
+				return true
+			}
+		}
+		return false
+	})
+	truncatedRevision := findActivity(t, snapshot, "exec-1").Revision
+
+	// The runaway command keeps printing. A later, unrelated projection is the
+	// barrier proving every delta before it has been applied.
+	for i := 0; i < 10; i++ {
+		h.conv.emit(outputDelta("provider-turn-1", "exec-1", "[vite] page reload\n"))
+	}
+	h.conv.emit(startedCommand("provider-turn-1", "exec-2", "barrier"))
+	snapshot = h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Activities) == 2
+	})
+
+	after := findActivity(t, snapshot, "exec-1")
+	if after.Revision != truncatedRevision {
+		t.Errorf("revision moved from %d to %d after truncation; capped deltas must not touch the row",
+			truncatedRevision, after.Revision)
+	}
+	if len(after.CommandOutput) != store.MaxCommandOutputChars {
+		t.Errorf("stored output = %d chars, want the cap %d", len(after.CommandOutput), store.MaxCommandOutputChars)
+	}
+}
+
 // A delta whose activity does not exist is dropped, not turned into a row of its
 // own. The provider can emit output before the item/started that names the command,
 // and an activity invented from a delta would have no command on it.

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -41,6 +41,9 @@ type Service struct {
 	log        *slog.Logger
 	newID      IDFactory
 	now        Clock
+	// handoffSettleWait is applied to every controller this service starts; see
+	// Options.HandoffSettleWait.
+	handoffSettleWait time.Duration
 
 	mu           sync.RWMutex
 	controllers  map[domain.SessionID]*Controller
@@ -78,6 +81,10 @@ type Options struct {
 	Log      *slog.Logger
 	NewID    IDFactory
 	Now      Clock
+	// HandoffSettleWait bounds how long an interrupt-policy handoff waits for the
+	// provider to settle the cancelled turn before reconciling it. Zero uses the
+	// production default; tests shorten it.
+	HandoffSettleWait time.Duration
 }
 
 // New builds a Chat service.
@@ -91,18 +98,19 @@ func New(opts Options) *Service {
 		now = func() time.Time { return time.Now().UTC() }
 	}
 	return &Service{
-		store:        opts.Store,
-		reader:       opts.Reader,
-		pageReader:   opts.PageReader,
-		sessions:     opts.Sessions,
-		drivers:      opts.Drivers,
-		activity:     opts.Activity,
-		log:          log,
-		newID:        opts.NewID,
-		now:          now,
-		controllers:  make(map[domain.SessionID]*Controller),
-		startConfigs: make(map[domain.SessionID]StartConfig),
-		gates:        make(map[domain.SessionID]controllerGate),
+		store:             opts.Store,
+		reader:            opts.Reader,
+		pageReader:        opts.PageReader,
+		sessions:          opts.Sessions,
+		drivers:           opts.Drivers,
+		activity:          opts.Activity,
+		log:               log,
+		newID:             opts.NewID,
+		now:               now,
+		handoffSettleWait: opts.HandoffSettleWait,
+		controllers:       make(map[domain.SessionID]*Controller),
+		startConfigs:      make(map[domain.SessionID]StartConfig),
+		gates:             make(map[domain.SessionID]controllerGate),
 	}
 }
 
@@ -334,6 +342,9 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	// replaced can be told apart from the current one's.
 	controller := newController(
 		cfg.SessionID, conversation, generation, conv, s.store, s.activity, s.log, s.newID, s.now)
+	if s.handoffSettleWait > 0 {
+		controller.handoffSettleWait = s.handoffSettleWait
+	}
 	if cfg.ProviderConversationID != "" {
 		// The provider's native thread is the continuity authority across TUI and
 		// Chat. Import it before the live projector starts so the first notification

--- a/backend/internal/session_manager/attachments_test.go
+++ b/backend/internal/session_manager/attachments_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/attachments"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -42,12 +43,13 @@ func TestWriteSpawnAttachments(t *testing.T) {
 
 func TestStageAttachmentsUsesNeutralFileNames(t *testing.T) {
 	dir := t.TempDir()
+	dataDir := t.TempDir()
 	st := newFakeStore()
 	st.sessions["ao-1"] = domain.SessionRecord{
 		ID:       "ao-1",
 		Metadata: domain.SessionMetadata{WorkspacePath: dir},
 	}
-	m := New(Deps{Store: st, Workspace: &fakeWorkspace{}})
+	m := New(Deps{Store: st, Workspace: &fakeWorkspace{}, DataDir: dataDir})
 
 	refs, err := m.StageAttachments(context.Background(), "ao-1", []ports.SpawnAttachment{
 		{Ext: ".html", Data: []byte("<main>hi</main>")},
@@ -63,6 +65,15 @@ func TestStageAttachmentsUsesNeutralFileNames(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, filepath.FromSlash(refs[0]))); err != nil {
 		t.Fatalf("staged attachment missing on disk: %v", err)
+	}
+	// The canonical copy is what survives worktree recreation; staging must
+	// write it, not just the worktree projection.
+	name, ok := attachments.RefName(refs[0])
+	if !ok {
+		t.Fatalf("ref %q is not a valid attachment reference", refs[0])
+	}
+	if _, err := os.Stat(filepath.Join(attachments.Dir(dataDir, "ao-1"), name)); err != nil {
+		t.Fatalf("canonical attachment copy missing: %v", err)
 	}
 }
 
@@ -95,4 +106,92 @@ func TestAppendAttachmentReferences(t *testing.T) {
 			t.Errorf("got %q, want %q", got, "brief")
 		}
 	})
+}
+
+// The full #3884 seam: a staged attachment must survive the exact
+// save-and-teardown → restore cycle daemon recovery runs, including a legacy
+// attachment that existed only in the worktree (staged by a build without
+// durable storage). StashUncommitted skips ignored files by design, so without
+// the durable copy these bytes have no other owner.
+func TestAttachmentsSurviveTeardownAndRestore(t *testing.T) {
+	dataDir := t.TempDir()
+	worktree := t.TempDir()
+
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	ws := &fakeWorkspace{path: worktree}
+	m := New(Deps{
+		Runtime:   &fakeRuntime{},
+		Agents:    fakeAgents{},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: &fakeLCM{store: st},
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+		DataDir:   dataDir,
+	})
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Metadata:  domain.SessionMetadata{WorkspacePath: worktree, Branch: "ao/mer-1/root", AgentSessionID: "agent-w"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+
+	staged := []byte("png-bytes-of-a-screenshot")
+	refs, err := m.StageAttachments(context.Background(), "mer-1", []ports.SpawnAttachment{
+		{Ext: ".png", Data: staged},
+	})
+	if err != nil {
+		t.Fatalf("StageAttachments: %v", err)
+	}
+	name, ok := attachments.RefName(refs[0])
+	if !ok {
+		t.Fatalf("staged ref %q is not a valid attachment reference", refs[0])
+	}
+	canonical := filepath.Join(attachments.Dir(dataDir, "mer-1"), name)
+	if got, err := os.ReadFile(canonical); err != nil || string(got) != string(staged) {
+		t.Fatalf("canonical copy after staging: err=%v content=%q", err, got)
+	}
+
+	// A legacy attachment written by a build that predates durable storage:
+	// worktree-only, no canonical copy.
+	legacy := []byte("older-screenshot")
+	legacyPath := filepath.Join(worktree, ".ao", "attachments", "attachment-legacy1.png")
+	if err := os.WriteFile(legacyPath, legacy, 0o600); err != nil {
+		t.Fatalf("write legacy attachment: %v", err)
+	}
+
+	if err := m.SaveAndTeardownAll(ctx); err != nil {
+		t.Fatalf("SaveAndTeardownAll: %v", err)
+	}
+	// Teardown must have imported the legacy bytes before the worktree died.
+	if got, err := os.ReadFile(filepath.Join(attachments.Dir(dataDir, "mer-1"), "attachment-legacy1.png")); err != nil || string(got) != string(legacy) {
+		t.Fatalf("legacy attachment not imported at teardown: err=%v content=%q", err, got)
+	}
+
+	// The fake workspace records ForceDestroy without touching disk; do the
+	// destructive part for real so restore has nothing to lean on.
+	if err := os.RemoveAll(filepath.Join(worktree, ".ao")); err != nil {
+		t.Fatalf("simulate worktree destruction: %v", err)
+	}
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll: %v", err)
+	}
+
+	for file, want := range map[string][]byte{
+		filepath.Join(worktree, filepath.FromSlash(refs[0])): staged,
+		legacyPath: legacy,
+	} {
+		got, err := os.ReadFile(file)
+		if err != nil {
+			t.Errorf("attachment missing after restore: %v", err)
+			continue
+		}
+		if string(got) != string(want) {
+			t.Errorf("attachment %s = %q after restore, want %q", file, got, want)
+		}
+	}
 }

--- a/backend/internal/session_manager/chat_attachments.go
+++ b/backend/internal/session_manager/chat_attachments.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/attachments"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -28,9 +29,9 @@ import (
 func (m *Manager) StageAttachments(
 	ctx context.Context,
 	id domain.SessionID,
-	attachments []ports.SpawnAttachment,
+	files []ports.SpawnAttachment,
 ) ([]string, error) {
-	if len(attachments) == 0 {
+	if len(files) == 0 {
 		return nil, nil
 	}
 
@@ -52,8 +53,8 @@ func (m *Manager) StageAttachments(
 		return nil, fmt.Errorf("create attachments dir: %w", err)
 	}
 
-	refs := make([]string, 0, len(attachments))
-	for i, a := range attachments {
+	refs := make([]string, 0, len(files))
+	for i, a := range files {
 		ext := a.Ext
 		if ext == "" {
 			ext = ".bin"
@@ -63,6 +64,14 @@ func (m *Manager) StageAttachments(
 			return nil, fmt.Errorf("name attachment %d: %w", i+1, err)
 		}
 		name := "attachment-" + suffix + ext
+		// Canonical copy first: the durable conversation will reference this file
+		// forever, while the worktree copy below lives only until the next
+		// worktree recycle. If the durable write fails the attachment is refused
+		// outright — a file that renders today and vanishes on the next restart
+		// is the data loss this ordering exists to prevent (#3884).
+		if err := attachments.Store(m.dataDir, string(id), name, a.Data); err != nil {
+			return nil, fmt.Errorf("store attachment %d durably: %w", i+1, err)
+		}
 		if err := os.WriteFile(filepath.Join(dir, name), a.Data, 0o600); err != nil {
 			return nil, fmt.Errorf("write attachment %d: %w", i+1, err)
 		}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/attachments"
+	attachmentstore "github.com/aoagents/agent-orchestrator/backend/internal/attachments"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
@@ -1907,7 +1907,7 @@ func (m *Manager) saveAndTeardownOne(ctx context.Context, rec domain.SessionReco
 	// last moment the bytes of a legacy worktree-only attachment exist (#3884).
 	// Best-effort with a loud log: a failed import must not block the teardown,
 	// but a silent one would hide data loss.
-	if imported, err := attachments.ImportWorktree(m.dataDir, string(rec.ID), ws.Path); err != nil {
+	if imported, err := attachmentstore.ImportWorktree(m.dataDir, string(rec.ID), ws.Path); err != nil {
 		m.logger.Error("save-teardown-all: import worktree attachments failed; attachment bytes may be lost",
 			"sessionID", rec.ID, "error", err)
 	} else if imported > 0 {
@@ -2178,7 +2178,7 @@ func (m *Manager) RestoreAll(ctx context.Context) error {
 		// Step 2b: project durable attachments back into the recreated worktree
 		// before the controller relaunches, so the resumed agent can read the
 		// same .ao/attachments/... paths its conversation history names (#3884).
-		if copied, matErr := attachments.Materialize(m.dataDir, string(rec.ID), ws.Path); matErr != nil {
+		if copied, matErr := attachmentstore.Materialize(m.dataDir, string(rec.ID), ws.Path); matErr != nil {
 			m.logger.Error("restore-all: rematerialize attachments failed", "sessionID", rec.ID, "error", matErr)
 		} else if copied > 0 {
 			if err := m.workspace.AddExclude(ctx, ws, "/"+attachmentsDir+"/"); err != nil {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/attachments"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
@@ -1901,7 +1902,20 @@ func (m *Manager) saveAndTeardownOne(ctx context.Context, rec domain.SessionReco
 		}
 	}
 
-	// 6. Force-remove the worktree (safe: work is captured in step 1 and the
+	// 6. Import any attachments that exist only in the worktree into durable
+	// storage. StashUncommitted deliberately skips ignored files, so this is the
+	// last moment the bytes of a legacy worktree-only attachment exist (#3884).
+	// Best-effort with a loud log: a failed import must not block the teardown,
+	// but a silent one would hide data loss.
+	if imported, err := attachments.ImportWorktree(m.dataDir, string(rec.ID), ws.Path); err != nil {
+		m.logger.Error("save-teardown-all: import worktree attachments failed; attachment bytes may be lost",
+			"sessionID", rec.ID, "error", err)
+	} else if imported > 0 {
+		m.logger.Info("save-teardown-all: imported worktree-only attachments",
+			"sessionID", rec.ID, "count", imported)
+	}
+
+	// 7. Force-remove the worktree (safe: work is captured in step 1 and the
 	// DB write in step 2 is already committed).
 	if err := m.workspace.ForceDestroy(ctx, ws); err != nil {
 		m.logger.Warn("save-teardown-all: force destroy failed", "sessionID", rec.ID, "error", err)
@@ -2158,6 +2172,17 @@ func (m *Manager) RestoreAll(ctx context.Context) error {
 					}
 					// Continue: always relaunch even on conflict (never delete the ref here).
 				}
+			}
+		}
+
+		// Step 2b: project durable attachments back into the recreated worktree
+		// before the controller relaunches, so the resumed agent can read the
+		// same .ao/attachments/... paths its conversation history names (#3884).
+		if copied, matErr := attachments.Materialize(m.dataDir, string(rec.ID), ws.Path); matErr != nil {
+			m.logger.Error("restore-all: rematerialize attachments failed", "sessionID", rec.ID, "error", matErr)
+		} else if copied > 0 {
+			if err := m.workspace.AddExclude(ctx, ws, "/"+attachmentsDir+"/"); err != nil {
+				m.logger.Warn("restore-all: exclude attachments dir", "sessionID", rec.ID, "error", err)
 			}
 		}
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -936,7 +936,7 @@ func TestSend_WritesAttachmentAndAppendsReference(t *testing.T) {
 	}
 	msg := &fakeMessenger{}
 	ws := &fakeWorkspace{}
-	m := New(Deps{Store: st, Messenger: msg, Workspace: ws})
+	m := New(Deps{Store: st, Messenger: msg, Workspace: ws, DataDir: t.TempDir()})
 
 	attachment := &ports.SpawnAttachment{Ext: ".png", Data: []byte("snapshot-bytes")}
 	if err := m.Send(ctx, "mer-1", "Make the button blue.", attachment); err != nil {
@@ -1007,7 +1007,7 @@ func TestSend_RejectsAttachmentWithEmptyWorkspace(t *testing.T) {
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker}
 	msg := &fakeMessenger{}
 	ws := &fakeWorkspace{}
-	m := New(Deps{Store: st, Messenger: msg, Workspace: ws})
+	m := New(Deps{Store: st, Messenger: msg, Workspace: ws, DataDir: t.TempDir()})
 
 	attachment := &ports.SpawnAttachment{Ext: ".png", Data: []byte("snapshot-bytes")}
 	err := m.Send(ctx, "mer-1", "Make the button blue.", attachment)

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -81,6 +81,7 @@ SET command_output = substr(command_output || ?1, 1, ?2),
 WHERE conversation_id = ?4
   AND provider_item_id = ?5
   AND status <> 'cancelled'
+  AND command_output_truncated = 0
 `
 
 type AppendConversationActivityOutputParams struct {
@@ -106,6 +107,12 @@ type AppendConversationActivityOutputParams struct {
 //
 // execrows so the caller can tell "appended" from "no such activity yet", which
 // is a real case: a delta can arrive before the item/started that creates the row.
+//
+// A row whose output is already truncated is skipped entirely: the stored text
+// cannot change, so bumping revision would fire a CDC event, an SSE push, and a
+// full snapshot refetch per delta for bytes nobody will ever see. A dev server in
+// watch mode emits dozens of deltas per second past the cap; without this guard
+// that becomes a client-side re-render storm that freezes the session page.
 // NOTE: keep these comments ASCII. sqlc locates its star-expansion edits by byte
 // offset, so a multi-byte character here silently corrupts later queries.
 func (q *Queries) AppendConversationActivityOutput(ctx context.Context, arg AppendConversationActivityOutputParams) (int64, error) {
@@ -134,6 +141,7 @@ SET streamed_text = substr(streamed_text || ?1, 1, ?2),
 WHERE conversation_id = ?4
   AND provider_item_id = ?5
   AND status <> 'cancelled'
+  AND streamed_text_truncated = 0
 `
 
 type AppendConversationActivityStreamedTextParams struct {

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -444,6 +444,28 @@ func (q *Queries) FailRolledBackConversationApprovals(ctx context.Context, arg F
 	return err
 }
 
+const getRunningTurnForConversation = `-- name: GetRunningTurnForConversation :one
+SELECT id, provider_turn_id FROM conversation_turns
+WHERE conversation_id = ? AND state = 'running'
+ORDER BY started_at DESC
+LIMIT 1
+`
+
+type GetRunningTurnForConversationRow struct {
+	ID             string
+	ProviderTurnID string
+}
+
+// The most recent turn SQLite still considers running. Interrupt uses it to
+// recover when in-memory turn tracking has lost the turn the UI is showing:
+// durable state is what the user sees, so it is what Stop must be able to act on.
+func (q *Queries) GetRunningTurnForConversation(ctx context.Context, conversationID string) (GetRunningTurnForConversationRow, error) {
+	row := q.db.QueryRowContext(ctx, getRunningTurnForConversation, conversationID)
+	var i GetRunningTurnForConversationRow
+	err := row.Scan(&i.ID, &i.ProviderTurnID)
+	return i, err
+}
+
 const insertConversation = `-- name: InsertConversation :exec
 
 INSERT INTO conversations (

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -329,6 +329,15 @@ SET state = 'failed',
     completed_at = ?
 WHERE handled_by_session_id = ? AND state IN ('queued', 'running');
 
+-- The most recent turn SQLite still considers running. Interrupt uses it to
+-- recover when in-memory turn tracking has lost the turn the UI is showing:
+-- durable state is what the user sees, so it is what Stop must be able to act on.
+-- name: GetRunningTurnForConversation :one
+SELECT id, provider_turn_id FROM conversation_turns
+WHERE conversation_id = ? AND state = 'running'
+ORDER BY started_at DESC
+LIMIT 1;
+
 -- Overwrite the turn's changed-file summary. The provider re-sends the whole diff
 -- on every update, so the latest payload is the complete answer and there is
 -- nothing to merge with what was there before.

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -769,6 +769,12 @@ WHERE conversation_id = ? AND kind = 'user_input' AND status = 'pending';
 --
 -- execrows so the caller can tell "appended" from "no such activity yet", which
 -- is a real case: a delta can arrive before the item/started that creates the row.
+--
+-- A row whose output is already truncated is skipped entirely: the stored text
+-- cannot change, so bumping revision would fire a CDC event, an SSE push, and a
+-- full snapshot refetch per delta for bytes nobody will ever see. A dev server in
+-- watch mode emits dozens of deltas per second past the cap; without this guard
+-- that becomes a client-side re-render storm that freezes the session page.
 -- NOTE: keep these comments ASCII. sqlc locates its star-expansion edits by byte
 -- offset, so a multi-byte character here silently corrupts later queries.
 -- name: AppendConversationActivityOutput :execrows
@@ -782,7 +788,8 @@ SET command_output = substr(command_output || sqlc.arg(delta), 1, sqlc.arg(max_o
     updated_at = sqlc.arg(updated_at)
 WHERE conversation_id = sqlc.arg(conversation_id)
   AND provider_item_id = sqlc.arg(provider_item_id)
-  AND status <> 'cancelled';
+  AND status <> 'cancelled'
+  AND command_output_truncated = 0;
 
 -- Append provider prose streamed for one activity, capped in one statement.
 --
@@ -808,7 +815,8 @@ SET streamed_text = substr(streamed_text || sqlc.arg(delta), 1, sqlc.arg(max_tex
     updated_at = sqlc.arg(updated_at)
 WHERE conversation_id = sqlc.arg(conversation_id)
   AND provider_item_id = sqlc.arg(provider_item_id)
-  AND status <> 'cancelled';
+  AND status <> 'cancelled'
+  AND streamed_text_truncated = 0;
 
 -- Replace the streamed text with the provider's settled version.
 --

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -679,6 +679,23 @@ func (s *Store) SettleOrphanedTurns(ctx context.Context, session domain.SessionI
 	return nil
 }
 
+// GetRunningTurn returns the most recent turn SQLite still considers running.
+//
+// Interrupt uses it to recover from a desync where the in-memory controller has
+// lost track of a turn the durable state — and therefore the UI — still shows as
+// running. The durable row is what the user is looking at, so it is what Stop
+// must be able to act on.
+func (s *Store) GetRunningTurn(ctx context.Context, conversationID string) (id, providerTurnID string, ok bool, err error) {
+	row, err := s.qr.GetRunningTurnForConversation(ctx, conversationID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, fmt.Errorf("get running turn for %s: %w", conversationID, err)
+	}
+	return row.ID, row.ProviderTurnID, true, nil
+}
+
 // SetConversationSettings records the provider choices for the next turn.
 //
 // An empty field is stored as NULL rather than as an empty string, so "the user

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -214,6 +214,10 @@ export function useConversationCommands(sessionId: string | undefined) {
 			if (error) throw error;
 		},
 		onSuccess: invalidate,
+		// A failed interrupt (e.g. CHAT_NO_ACTIVE_TURN) means the cached turn
+		// state is wrong. Refetch so the UI discovers the real state instead of
+		// keeping a Working bar the user cannot dismiss.
+		onError: invalidate,
 	});
 
 	const resume = useMutation({

--- a/packages/mobile/lib/chat/useConversation.ts
+++ b/packages/mobile/lib/chat/useConversation.ts
@@ -225,7 +225,12 @@ export function useMobileConversation(
 	}, [refresh]);
 
 	const runAction = useCallback(
-		async <T,>(kind: ConversationAction, action: () => Promise<T>, resetHistoricalPages = false): Promise<T> => {
+		async <T,>(
+			kind: ConversationAction,
+			action: () => Promise<T>,
+			resetHistoricalPages = false,
+			refreshOnError = false,
+		): Promise<T> => {
 			setPendingActions((old) => old.includes(kind) ? old : [...old, kind]);
 			setActionError(undefined);
 			setActionErrors((old) => ({ ...old, [kind]: undefined }));
@@ -240,6 +245,9 @@ export function useMobileConversation(
 				setActionError(message);
 				setActionErrors((old) => ({ ...old, [kind]: message }));
 				setActionCodes((old) => ({ ...old, [kind]: conversationErrorCode(cause) }));
+				// A failed stop can mean the cached turn state is stale; reload so
+				// the user is not stuck looking at a Working bar that is not real.
+				if (refreshOnError) void refresh();
 				throw new Error(message);
 			} finally {
 				setPendingActions((old) => old.filter((candidate) => candidate !== kind));
@@ -301,7 +309,7 @@ export function useMobileConversation(
 		[cfg, runAction, sessionId],
 	);
 	const interrupt = useCallback(
-		() => runAction("interrupt", () => requireConfig(cfg, (c) => interruptConversation(c, sessionId))),
+		() => runAction("interrupt", () => requireConfig(cfg, (c) => interruptConversation(c, sessionId)), false, true),
 		[cfg, runAction, sessionId],
 	);
 	const resolveApprovalAction = useCallback(


### PR DESCRIPTION
Fixes #3945, fixes #3884, fixes #3878, fixes #3749 — the P1 reliability/data-loss cluster in the Chat UI surface.

These four bugs share one theme: durable conversation state, in-memory controller state, and the disposable worktree had mismatched lifetimes and authority. This PR makes durable state authoritative for what the user sees and can act on, and stops ephemeral state (worktrees, nested provider turns, capped output deltas) from destroying or wedging it.

## #3945 — Chat UI freezes when a command exceeds the output cap; Terminal unreachable

**Root causes fixed:**
- `AppendConversationActivityOutput` (and its streamed-text sibling) kept bumping `revision`/`updated_at` on every delta after the 64K cap, firing a CDC event → SSE push → full snapshot refetch per delta for bytes that could no longer change. A vite dev server past the cap turned that into a re-render storm that froze the page. The queries now skip the row entirely once its truncation flag is set (`AND command_output_truncated = 0`), so capped deltas produce **zero** CDC traffic. The settled aggregate on `item/completed` still lands.
- An interrupt-policy chat→TUI handoff waited forever for the provider to settle the cancelled turn. If the provider is wedged on the very command the user is escaping, the switch never completed ("policy dialog that cannot complete"). `BeginHandoff` now bounds that wait (`handoffSettleWait`, 10s default) and reconciles the durable turn as interrupted so the switch always completes — the terminal is the escape hatch and must always be reachable.

## #3884 — restart recovery deletes image attachments (data loss)

Attachment bytes now have a durable owner: `$AO_DATA_DIR/attachments/<session-id>/` (new `internal/attachments` package), with the worktree `.ao/attachments` copy demoted to a projection. Follows the fix direction laid out in the issue:

- **Stage atomically:** canonical copy first (tmp+rename, 0600); a failed durable write refuses the attachment instead of accepting bytes that vanish on the next restart. The existing worktree-relative refs are unchanged.
- **Serve durably:** the preview route serves strictly-validated `.ao/attachments/<name>` references from durable storage when the worktree copy is missing; a live worktree copy still wins; ordinary preview files stay confined to the workspace.
- **Restore projection:** `RestoreAll` rematerializes the session's durable attachments into the recreated worktree (and re-adds the git exclude) before the controller relaunches.
- **Upgrade safely:** `saveAndTeardownOne` imports legacy worktree-only attachments into durable storage *before* `ForceDestroy` — the exact seam that used to delete their only bytes. Covers attachments staged by pre-fix builds, including spawn attachments.
- **Cleanup tied to durable ownership:** canonical bytes are never removed on runtime teardown or worktree recycling.
- **Security:** strict name validation (no separators/traversal/hidden files), symlinks never followed into or out of durable storage, cross-session access impossible by construction.

## #3878 — nested Codex turns drain queued automation prematurely

Applies the fix from PR #3890 by @Dhruv-Sharma01 (rebased cleanly onto main; commit authorship preserved): `ChatEvent` carries `ProviderConversationID`, only root-thread lifecycle events can claim/release primary turn ownership, in-memory ownership updates move to post-commit (`applyCommittedTurnLifecycle`), nested completions no longer report idle or drain the queue, handoff quiescence is serialized behind `sendMu`, and adapter interrupts target the root turn.

## #3749 — "Stop turn" returns CHAT_NO_ACTIVE_TURN while the UI shows a running turn

Composes the approach from PR #3752 by @xRealBlue on top of the nested-turn lifecycle fix:

- **Durable-state fallback:** when memory says nothing is running but SQLite has a `running` turn (failed projection, restart, dispatch race), `Interrupt` reconciles it instead of refusing — serialized behind `sendMu` so a mid-dispatch state can't be misread.
- **Provider-refusal reconciliation:** `ErrChatNoActiveTurn` for a turn memory still tracks now settles the durable row rather than surfacing a bare error that leaves the user stuck on "Working".
- **`reconcileDurableTurn`** delivers the full Interrupt contract in one place: best-effort provider cancel, settle as interrupted, clear memory, cancel the queue behind it, report idle.
- **Client resilience:** the renderer and mobile clients refetch the conversation when an interrupt fails, so a stale "Working" bar is discovered instead of kept.

The projection-transaction half of the desync (memory mutated inside a rollback-able transaction) is fixed structurally by the post-commit lifecycle handling from the #3878 fix.

## Tests

New coverage (all requested seams):
- **Attachment survival across restart:** `TestAttachmentsSurviveTeardownAndRestore` (manager-level, incl. legacy import), `TestSessionsAPI_PreviewServesDurableAttachmentAfterWorktreeLoss` (HTTP incl. traversal + cross-session rejection), `internal/attachments` unit tests (validation, symlink skip, atomic store), and the lifecycle-level e2e `TestChatAttachmentSurvivesADaemonRestart` (real daemon, real codex, real restart — the exact repro from the issue).
- **Stop-turn authority under desync:** `TestInterruptReconcilesStaleRunningTurnOnDisk`, `TestProviderRefusalReconcilesTheDurableTurnAsInterrupted`, `TestInterruptReconciliationCancelsQueuedTurns`, `TestInterruptReturnsNoActiveTurnWhenNoRunningTurnAnywhere`, and `TestProjectionFailureThenStopStillStopsTheTurn` (the exact #3749 sequence: failed `turn/completed` projection, then Stop).
- **Output-cap non-wedge:** `TestCappedOutputStopsBumpingRevision` (revision frozen after truncation), `TestInterruptHandoffCompletesWhenProviderNeverSettlesTheTurn` (bounded escape to Terminal).
- **Nested-turn automation ordering:** `TestNestedTurnCompletionDoesNotDrainQueueWhilePrimaryTurnRuns`, `TestChatHandoffDrainWaitsForRootAfterNestedTurnCompletes`, plus adapter/normalizer tests (from #3890).

Validation run:
- `go test ./...` — green (the `internal/cli` spawn tests fail only when AO_* env vars from a live AO session leak into the test env; they pass with a clean env and fail identically on unmodified `main`).
- `cd frontend && npm run typecheck` — clean.
- End-to-end: `AO_CHAT_E2E=1 go test ./e2e/ -run TestChatAttachmentSurvivesADaemonRestart` — real daemon binary, real codex session, attachment staged → daemon stop → recovery → same preview URL serves the same bytes and the resumed agent reads the same path.

## Known follow-ups (out of scope)

- #3878's "acknowledgement recovery for a dispatched provider ID that never emits turn.started" is not implemented here (nor in #3890); Stop-based reconciliation covers user recovery in the meantime.
- The `groupByTurn` presentation defect (parent activity anchored above completed child cards) from #3878's "UI clarity" section is a separate rendering change.
- #3950/#3951 (interface-switch recovery banner persistence) remain separate.

## Relationship to open PRs

- #3890 (nested turns) is included as its own commit with original authorship — this PR supersedes it only by also carrying the three sibling fixes; happy to rebase if #3890 lands first.
- #3752 (stop-turn desync) is re-implemented here on top of the nested-turn lifecycle (the two PRs conflict in `controller.go`); its author is credited as commit co-author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
