### PR TITLE
feat: add Agy Chat driver over stream-json

### DIFF
--- a/backend/internal/adapters/agent/agy/activity.go
+++ b/backend/internal/adapters/agent/agy/activity.go
@@ -1,27 +1,43 @@
 package agy
 
 import (
+	"encoding/json"
+
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
-// DeriveActivityState maps an Agy hook event onto an AO activity state. The
-// bool is false when the event carries no activity signal.
-//
-// event is the AO hook sub-command name installed in agyManagedHooks:
-// "session-start", "session-end", "before-agent", "after-agent", "after-tool".
-func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+// DeriveActivityState maps the current Antigravity workspace-hook events onto
+// AO activity. PreInvocation proves an execution is running. PostToolUse keeps
+// the session active after a tool finishes. Stop is the provider-owned execution
+// boundary; fullyIdle=false means background/asynchronous work is still alive,
+// so AO must not advertise the worker as idle yet.
+func DeriveActivityState(event string, payload []byte) (domain.ActivityState, bool) {
 	switch event {
-	case "before-agent":
+	case "pre-invocation", "post-tool-use":
 		return domain.ActivityActive, true
-	case "after-agent":
+	case "stop":
+		if fullyIdle, known := agyStopFullyIdle(payload); known && !fullyIdle {
+			return domain.ActivityActive, true
+		}
 		return domain.ActivityIdle, true
-	case "after-tool":
-		return domain.ActivityActive, true
-	case "session-end":
-		return domain.ActivityExited, true
-	case "session-start":
-		return "", false
 	default:
 		return "", false
 	}
+}
+
+func agyStopFullyIdle(payload []byte) (bool, bool) {
+	var p struct {
+		FullyIdle      *bool `json:"fullyIdle"`
+		FullyIdleSnake *bool `json:"fully_idle"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return false, false
+	}
+	if p.FullyIdle != nil {
+		return *p.FullyIdle, true
+	}
+	if p.FullyIdleSnake != nil {
+		return *p.FullyIdleSnake, true
+	}
+	return false, false
 }

--- a/backend/internal/adapters/agent/agy/activity_test.go
+++ b/backend/internal/adapters/agent/agy/activity_test.go
@@ -27,7 +27,7 @@ func TestDeriveActivityState(t *testing.T) {
 			got, ok := DeriveActivityState(tt.event, []byte(tt.payload))
 			if got != tt.want || ok != tt.wantOK {
 				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, %v)",
-					t.event, got, ok, tt.want, tt.wantOK)
+					tt.event, got, ok, tt.want, tt.wantOK)
 			}
 		})
 	}

--- a/backend/internal/adapters/agent/agy/activity_test.go
+++ b/backend/internal/adapters/agent/agy/activity_test.go
@@ -8,24 +8,26 @@ import (
 
 func TestDeriveActivityState(t *testing.T) {
 	tests := []struct {
-		name   string
-		event  string
-		want   domain.ActivityState
-		wantOK bool
+		name    string
+		event   string
+		payload string
+		want    domain.ActivityState
+		wantOK  bool
 	}{
-		{"before agent -> active", "before-agent", domain.ActivityActive, true},
-		{"after agent -> idle", "after-agent", domain.ActivityIdle, true},
-		{"after tool -> active", "after-tool", domain.ActivityActive, true},
-		{"session end -> exited", "session-end", domain.ActivityExited, true},
-		{"session start -> no signal", "session-start", "", false},
-		{"unknown event -> no signal", "unknown", "", false},
+		{"pre invocation -> active", "pre-invocation", `{}`, domain.ActivityActive, true},
+		{"post tool use -> active", "post-tool-use", `{}`, domain.ActivityActive, true},
+		{"stop fully idle -> idle", "stop", `{"fullyIdle":true}`, domain.ActivityIdle, true},
+		{"stop background work -> active", "stop", `{"fullyIdle":false}`, domain.ActivityActive, true},
+		{"stop legacy snake case -> idle", "stop", `{"fully_idle":true}`, domain.ActivityIdle, true},
+		{"stop missing fullyIdle degrades to idle", "stop", `{}`, domain.ActivityIdle, true},
+		{"unknown event -> no signal", "unknown", `{}`, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := DeriveActivityState(tt.event, []byte(`{}`))
+			got, ok := DeriveActivityState(tt.event, []byte(tt.payload))
 			if got != tt.want || ok != tt.wantOK {
 				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, %v)",
-					tt.event, got, ok, tt.want, tt.wantOK)
+					t.event, got, ok, tt.want, tt.wantOK)
 			}
 		})
 	}

--- a/backend/internal/adapters/agent/agy/agy.go
+++ b/backend/internal/adapters/agent/agy/agy.go
@@ -45,6 +45,15 @@ func New() *Plugin {
 
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
+var _ ports.AgentExitDetector = (*Plugin)(nil)
+
+// ExitDetectionMode opts Agy TUI into AO's generic process supervisor. Current
+// Antigravity workspace hooks expose execution boundaries (Stop) but no
+// SessionEnd event, so process ownership is the authoritative way to detect the
+// CLI itself exiting while the terminal runtime remains alive.
+func (p *Plugin) ExitDetectionMode() ports.AgentExitDetectionMode {
+	return ports.AgentExitDetectionSupervisor
+}
 
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {

--- a/backend/internal/adapters/agent/agy/agy_test.go
+++ b/backend/internal/adapters/agent/agy/agy_test.go
@@ -144,6 +144,10 @@ func TestSessionInfo(t *testing.T) {
 }
 
 func TestHooksLifecycle(t *testing.T) {
+	originalExecutable := agyCurrentExecutable
+	agyCurrentExecutable = func() (string, error) { return "/opt/agent orchestrator/ao", nil }
+	t.Cleanup(func() { agyCurrentExecutable = originalExecutable })
+
 	tmpDir := t.TempDir()
 	plugin := &Plugin{}
 	cfg := ports.WorkspaceHookConfig{WorkspacePath: tmpDir}
@@ -199,6 +203,10 @@ func TestHooksLifecycle(t *testing.T) {
 		t.Fatal("install removed Agy Chat hook set")
 	}
 
+	prefix, err := agyHookCommandPrefix()
+	if err != nil {
+		t.Fatal(err)
+	}
 	raw, ok := file[agyManagedHookName]
 	if !ok {
 		t.Fatalf("missing %q hook set", agyManagedHookName)
@@ -207,14 +215,14 @@ func TestHooksLifecycle(t *testing.T) {
 	if err := json.Unmarshal(raw, &definition); err != nil {
 		t.Fatal(err)
 	}
-	if len(definition.PreInvocation) != 1 || definition.PreInvocation[0].Command != "ao hooks agy pre-invocation" {
+	if len(definition.PreInvocation) != 1 || definition.PreInvocation[0].Command != prefix+"pre-invocation" {
 		t.Fatalf("unexpected PreInvocation hooks: %#v", definition.PreInvocation)
 	}
 	if len(definition.PostToolUse) != 1 || definition.PostToolUse[0].Matcher != "*" ||
-		len(definition.PostToolUse[0].Hooks) != 1 || definition.PostToolUse[0].Hooks[0].Command != "ao hooks agy post-tool-use" {
+		len(definition.PostToolUse[0].Hooks) != 1 || definition.PostToolUse[0].Hooks[0].Command != prefix+"post-tool-use" {
 		t.Fatalf("unexpected PostToolUse hooks: %#v", definition.PostToolUse)
 	}
-	if len(definition.Stop) != 1 || definition.Stop[0].Command != "ao hooks agy stop" {
+	if len(definition.Stop) != 1 || definition.Stop[0].Command != prefix+"stop" {
 		t.Fatalf("unexpected Stop hooks: %#v", definition.Stop)
 	}
 
@@ -245,6 +253,49 @@ func TestHooksLifecycle(t *testing.T) {
 	}
 	if _, ok := file[agyManagedHookName]; ok {
 		t.Fatal("uninstall left TUI hook set behind")
+	}
+}
+
+func TestAreHooksInstalledRejectsLegacyBareAOCommands(t *testing.T) {
+	originalExecutable := agyCurrentExecutable
+	agyCurrentExecutable = func() (string, error) { return "/opt/ao/bin/ao", nil }
+	t.Cleanup(func() { agyCurrentExecutable = originalExecutable })
+
+	tmpDir := t.TempDir()
+	hooksJSONPath := filepath.Join(tmpDir, ".agents", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksJSONPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{
+  "agent-orchestrator-tui": {
+    "PreInvocation": [{"type":"command","command":"ao hooks agy pre-invocation","timeout":30}],
+    "PostToolUse": [{"matcher":"*","hooks":[{"type":"command","command":"ao hooks agy post-tool-use","timeout":30}]}],
+    "Stop": [{"type":"command","command":"ao hooks agy stop","timeout":30}]
+  }
+}
+`
+	if err := os.WriteFile(hooksJSONPath, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin := &Plugin{}
+	installed, err := plugin.AreHooksInstalled(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed {
+		t.Fatal("legacy PATH-dependent hook commands must be refreshed")
+	}
+
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: tmpDir}); err != nil {
+		t.Fatal(err)
+	}
+	installed, err = plugin.AreHooksInstalled(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !installed {
+		t.Fatal("expected refreshed absolute hook commands to be installed")
 	}
 }
 

--- a/backend/internal/adapters/agent/agy/agy_test.go
+++ b/backend/internal/adapters/agent/agy/agy_test.go
@@ -144,87 +144,107 @@ func TestSessionInfo(t *testing.T) {
 }
 
 func TestHooksLifecycle(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "agy-test-*")
-	if err != nil {
+	tmpDir := t.TempDir()
+	plugin := &Plugin{}
+	cfg := ports.WorkspaceHookConfig{WorkspacePath: tmpDir}
+
+	hooksJSONPath := filepath.Join(tmpDir, ".agents", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksJSONPath), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
-
-	plugin := &Plugin{}
-	cfg := ports.WorkspaceHookConfig{
-		WorkspacePath: tmpDir,
+	seed := `{
+  "user-hook": {
+    "Stop": [{"type":"command","command":"./user-stop.sh"}]
+  },
+  "agent-orchestrator-chat": {
+    "PreInvocation": [{"type":"command","command":"ao agy-chat-hook pre-invocation"}]
+  }
+}
+`
+	if err := os.WriteFile(hooksJSONPath, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
 	}
 
-	// 1. Initially hooks should not be installed.
 	installed, err := plugin.AreHooksInstalled(context.Background(), tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if installed {
-		t.Fatal("expected hooks to not be installed initially")
+		t.Fatal("user/chat hooks must not count as TUI hooks")
 	}
 
-	// 2. Install hooks.
-	err = plugin.GetAgentHooks(context.Background(), cfg)
-	if err != nil {
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
 		t.Fatal(err)
 	}
-
 	installed, err = plugin.AreHooksInstalled(context.Background(), tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !installed {
-		t.Fatal("expected hooks to be installed after GetAgentHooks")
+		t.Fatal("expected TUI hooks to be installed")
 	}
 
-	// Verify hooks.json structure
-	hooksJSONPath := filepath.Join(tmpDir, ".gemini", "hooks.json")
 	data, err := os.ReadFile(hooksJSONPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	var hookFile agyHookFile
-	if err := json.Unmarshal(data, &hookFile); err != nil {
+	var file agyHookFile
+	if err := json.Unmarshal(data, &file); err != nil {
 		t.Fatal(err)
 	}
-
-	if len(hookFile.Hooks) != len(agyManagedHooks) {
-		t.Fatalf("expected %d events in hooks, got %d", len(agyManagedHooks), len(hookFile.Hooks))
+	if _, ok := file["user-hook"]; !ok {
+		t.Fatal("install removed user hook set")
+	}
+	if _, ok := file["agent-orchestrator-chat"]; !ok {
+		t.Fatal("install removed Agy Chat hook set")
 	}
 
-	for _, spec := range agyManagedHooks {
-		groups, ok := hookFile.Hooks[spec.Event]
-		if !ok {
-			t.Fatalf("expected event %q in hooks.json", spec.Event)
-		}
-		found := false
-		for _, group := range groups {
-			for _, h := range group.Hooks {
-				if h.Command == spec.Command {
-					found = true
-					break
-				}
-			}
-		}
-		if !found {
-			t.Fatalf("expected command %q for event %q", spec.Command, spec.Event)
-		}
+	raw, ok := file[agyManagedHookName]
+	if !ok {
+		t.Fatalf("missing %q hook set", agyManagedHookName)
 	}
-
-	// 3. Uninstall hooks.
-	err = plugin.UninstallHooks(context.Background(), tmpDir)
-	if err != nil {
+	var definition agyHookDefinition
+	if err := json.Unmarshal(raw, &definition); err != nil {
 		t.Fatal(err)
 	}
+	if len(definition.PreInvocation) != 1 || definition.PreInvocation[0].Command != "ao hooks agy pre-invocation" {
+		t.Fatalf("unexpected PreInvocation hooks: %#v", definition.PreInvocation)
+	}
+	if len(definition.PostToolUse) != 1 || definition.PostToolUse[0].Matcher != "*" ||
+		len(definition.PostToolUse[0].Hooks) != 1 || definition.PostToolUse[0].Hooks[0].Command != "ao hooks agy post-tool-use" {
+		t.Fatalf("unexpected PostToolUse hooks: %#v", definition.PostToolUse)
+	}
+	if len(definition.Stop) != 1 || definition.Stop[0].Command != "ao hooks agy stop" {
+		t.Fatalf("unexpected Stop hooks: %#v", definition.Stop)
+	}
 
+	if err := plugin.UninstallHooks(context.Background(), tmpDir); err != nil {
+		t.Fatal(err)
+	}
 	installed, err = plugin.AreHooksInstalled(context.Background(), tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if installed {
-		t.Fatal("expected hooks to be uninstalled after UninstallHooks")
+		t.Fatal("expected TUI hooks to be removed")
+	}
+
+	data, err = os.ReadFile(hooksJSONPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file = nil
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := file["user-hook"]; !ok {
+		t.Fatal("uninstall removed user hook set")
+	}
+	if _, ok := file["agent-orchestrator-chat"]; !ok {
+		t.Fatal("uninstall removed Agy Chat hook set")
+	}
+	if _, ok := file[agyManagedHookName]; ok {
+		t.Fatal("uninstall left TUI hook set behind")
 	}
 }
 

--- a/backend/internal/adapters/agent/agy/exit_test.go
+++ b/backend/internal/adapters/agent/agy/exit_test.go
@@ -1,0 +1,14 @@
+package agy
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestExitDetectionModeUsesSupervisor(t *testing.T) {
+	plugin := New()
+	if got := plugin.ExitDetectionMode(); got != ports.AgentExitDetectionSupervisor {
+		t.Fatalf("ExitDetectionMode() = %q, want %q", got, ports.AgentExitDetectionSupervisor)
+	}
+}

--- a/backend/internal/adapters/agent/agy/hooks.go
+++ b/backend/internal/adapters/agent/agy/hooks.go
@@ -124,8 +124,9 @@ func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error
 }
 
 // AreHooksInstalled reports whether the current Antigravity workspace file
-// contains AO's TUI hook set. Legacy .gemini/hooks.json entries deliberately do
-// not count: current Agy does not load that file as a workspace hook source.
+// contains AO's TUI hook set with commands pointing at this exact AO binary.
+// A legacy bare `ao hooks agy ...` command deliberately does not count: desktop
+// launches may not put AO on PATH, so those stale hook sets must be refreshed.
 func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (bool, error) {
 	if err := ctx.Err(); err != nil {
 		return false, err
@@ -150,7 +151,11 @@ func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (b
 	if err := json.Unmarshal(raw, &definition); err != nil {
 		return false, fmt.Errorf("agy.AreHooksInstalled: parse managed hook set: %w", err)
 	}
-	return agyDefinitionHasManagedHook(definition), nil
+	hookCommandPrefix, err := agyHookCommandPrefix()
+	if err != nil {
+		return false, fmt.Errorf("agy.AreHooksInstalled: resolve AO hook executable: %w", err)
+	}
+	return agyDefinitionHasManagedHooks(definition, hookCommandPrefix), nil
 }
 
 func agyHooksPath(workspacePath string) string {
@@ -212,28 +217,42 @@ func quoteHookExecutable(path string) string {
 	return "'" + strings.ReplaceAll(path, "'", "'\"'\"'") + "'"
 }
 
-func isManagedAgyHookCommand(command, event string) bool {
-	command = strings.TrimSpace(command)
-	return strings.HasSuffix(command, agyHookCommandSuffix+event) || command == "ao"+agyHookCommandSuffix+event
-}
+func agyDefinitionHasManagedHooks(definition agyHookDefinition, prefix string) bool {
+	wantPre := prefix + "pre-invocation"
+	wantPost := prefix + "post-tool-use"
+	wantStop := prefix + "stop"
 
-func agyDefinitionHasManagedHook(definition agyHookDefinition) bool {
+	hasPre := false
 	for _, hook := range definition.PreInvocation {
-		if isManagedAgyHookCommand(hook.Command, "pre-invocation") {
-			return true
+		if strings.TrimSpace(hook.Command) == wantPre {
+			hasPre = true
+			break
 		}
 	}
+
+	hasPost := false
 	for _, group := range definition.PostToolUse {
+		if group.Matcher != "*" {
+			continue
+		}
 		for _, hook := range group.Hooks {
-			if isManagedAgyHookCommand(hook.Command, "post-tool-use") {
-				return true
+			if strings.TrimSpace(hook.Command) == wantPost {
+				hasPost = true
+				break
 			}
 		}
-	}
-	for _, hook := range definition.Stop {
-		if isManagedAgyHookCommand(hook.Command, "stop") {
-			return true
+		if hasPost {
+			break
 		}
 	}
-	return false
+
+	hasStop := false
+	for _, hook := range definition.Stop {
+		if strings.TrimSpace(hook.Command) == wantStop {
+			hasStop = true
+			break
+		}
+	}
+
+	return hasPre && hasPost && hasStop
 }

--- a/backend/internal/adapters/agent/agy/hooks.go
+++ b/backend/internal/adapters/agent/agy/hooks.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
@@ -14,12 +15,14 @@ import (
 )
 
 const (
-	agyHooksDirName     = ".agents"
-	agyHooksFileName    = "hooks.json"
-	agyManagedHookName  = "agent-orchestrator-tui"
-	agyHookCommandPrefix = "ao hooks agy "
+	agyHooksDirName      = ".agents"
+	agyHooksFileName     = "hooks.json"
+	agyManagedHookName   = "agent-orchestrator-tui"
+	agyHookCommandSuffix = " hooks agy "
 	agyHookTimeout       = 30
 )
+
+var agyCurrentExecutable = os.Executable
 
 // Antigravity workspace hooks use a named hook-set at the top level of
 // <workspace>/.agents/hooks.json. Pre/PostToolUse use matcher groups; the
@@ -27,9 +30,9 @@ const (
 type agyHookFile map[string]json.RawMessage
 
 type agyHookDefinition struct {
-	PreInvocation []agyHookEntry       `json:"PreInvocation,omitempty"`
+	PreInvocation []agyHookEntry        `json:"PreInvocation,omitempty"`
 	PostToolUse   []agyHookMatcherGroup `json:"PostToolUse,omitempty"`
-	Stop          []agyHookEntry       `json:"Stop,omitempty"`
+	Stop          []agyHookEntry        `json:"Stop,omitempty"`
 }
 
 type agyHookMatcherGroup struct {
@@ -55,6 +58,11 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 		return errors.New("agy.GetAgentHooks: WorkspacePath is required")
 	}
 
+	hookCommandPrefix, err := agyHookCommandPrefix()
+	if err != nil {
+		return fmt.Errorf("agy.GetAgentHooks: resolve AO hook executable: %w", err)
+	}
+
 	hooksPath := agyHooksPath(cfg.WorkspacePath)
 	file, err := readAgyHookFile(hooksPath)
 	if err != nil {
@@ -63,16 +71,16 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 
 	definition := agyHookDefinition{
 		PreInvocation: []agyHookEntry{{
-			Type: "command", Command: agyHookCommandPrefix + "pre-invocation", Timeout: agyHookTimeout,
+			Type: "command", Command: hookCommandPrefix + "pre-invocation", Timeout: agyHookTimeout,
 		}},
 		PostToolUse: []agyHookMatcherGroup{{
 			Matcher: "*",
 			Hooks: []agyHookEntry{{
-				Type: "command", Command: agyHookCommandPrefix + "post-tool-use", Timeout: agyHookTimeout,
+				Type: "command", Command: hookCommandPrefix + "post-tool-use", Timeout: agyHookTimeout,
 			}},
 		}},
 		Stop: []agyHookEntry{{
-			Type: "command", Command: agyHookCommandPrefix + "stop", Timeout: agyHookTimeout,
+			Type: "command", Command: hookCommandPrefix + "stop", Timeout: agyHookTimeout,
 		}},
 	}
 	raw, err := json.Marshal(definition)
@@ -185,21 +193,45 @@ func writeAgyHookFile(hooksPath string, file agyHookFile) error {
 	return nil
 }
 
+func agyHookCommandPrefix() (string, error) {
+	executable, err := agyCurrentExecutable()
+	if err != nil {
+		return "", err
+	}
+	executable = strings.TrimSpace(executable)
+	if executable == "" {
+		return "", errors.New("current AO executable path is empty")
+	}
+	return quoteHookExecutable(executable) + agyHookCommandSuffix, nil
+}
+
+func quoteHookExecutable(path string) string {
+	if runtime.GOOS == "windows" {
+		return `"` + path + `"`
+	}
+	return "'" + strings.ReplaceAll(path, "'", "'\"'\"'") + "'"
+}
+
+func isManagedAgyHookCommand(command, event string) bool {
+	command = strings.TrimSpace(command)
+	return strings.HasSuffix(command, agyHookCommandSuffix+event) || command == "ao"+agyHookCommandSuffix+event
+}
+
 func agyDefinitionHasManagedHook(definition agyHookDefinition) bool {
 	for _, hook := range definition.PreInvocation {
-		if strings.HasPrefix(hook.Command, agyHookCommandPrefix) {
+		if isManagedAgyHookCommand(hook.Command, "pre-invocation") {
 			return true
 		}
 	}
 	for _, group := range definition.PostToolUse {
 		for _, hook := range group.Hooks {
-			if strings.HasPrefix(hook.Command, agyHookCommandPrefix) {
+			if isManagedAgyHookCommand(hook.Command, "post-tool-use") {
 				return true
 			}
 		}
 	}
 	for _, hook := range definition.Stop {
-		if strings.HasPrefix(hook.Command, agyHookCommandPrefix) {
+		if isManagedAgyHookCommand(hook.Command, "stop") {
 			return true
 		}
 	}

--- a/backend/internal/adapters/agent/agy/hooks.go
+++ b/backend/internal/adapters/agent/agy/hooks.go
@@ -14,42 +14,39 @@ import (
 )
 
 const (
-	agyHooksDirName  = ".gemini"
-	agyHooksFileName = "hooks.json"
-
+	agyHooksDirName     = ".agents"
+	agyHooksFileName    = "hooks.json"
+	agyManagedHookName  = "agent-orchestrator-tui"
 	agyHookCommandPrefix = "ao hooks agy "
+	agyHookTimeout       = 30
 )
 
-type agyHookFile struct {
-	Hooks map[string][]agyMatcherGroup `json:"hooks"`
+// Antigravity workspace hooks use a named hook-set at the top level of
+// <workspace>/.agents/hooks.json. Pre/PostToolUse use matcher groups; the
+// invocation and Stop events use a flat list of handlers.
+type agyHookFile map[string]json.RawMessage
+
+type agyHookDefinition struct {
+	PreInvocation []agyHookEntry       `json:"PreInvocation,omitempty"`
+	PostToolUse   []agyHookMatcherGroup `json:"PostToolUse,omitempty"`
+	Stop          []agyHookEntry       `json:"Stop,omitempty"`
 }
 
-type agyMatcherGroup struct {
-	Matcher *string        `json:"matcher,omitempty"`
+type agyHookMatcherGroup struct {
+	Matcher string         `json:"matcher"`
 	Hooks   []agyHookEntry `json:"hooks"`
 }
 
 type agyHookEntry struct {
-	Type    string `json:"type"`
+	Type    string `json:"type,omitempty"`
 	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
 }
 
-type agyHookSpec struct {
-	Event   string
-	Command string
-}
-
-var agyManagedHooks = []agyHookSpec{
-	{Event: "SessionStart", Command: agyHookCommandPrefix + "session-start"},
-	{Event: "SessionEnd", Command: agyHookCommandPrefix + "session-end"},
-	{Event: "BeforeAgent", Command: agyHookCommandPrefix + "before-agent"},
-	{Event: "AfterAgent", Command: agyHookCommandPrefix + "after-agent"},
-	{Event: "AfterTool", Command: agyHookCommandPrefix + "after-tool"},
-}
-
-// GetAgentHooks installs AO's Agy hooks into the worktree-local
-// .gemini/hooks.json file. Existing hook entries are preserved and duplicate
-// AO commands are not appended.
+// GetAgentHooks installs AO's Agy TUI hooks into the current Antigravity
+// workspace hook file. Existing named hook sets (including the Agy Chat
+// driver's agent-orchestrator-chat set) are preserved byte-for-byte at the
+// semantic JSON level.
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -59,40 +56,42 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	}
 
 	hooksPath := agyHooksPath(cfg.WorkspacePath)
-	topLevel, rawHooks, err := readAgyHooks(hooksPath)
+	file, err := readAgyHookFile(hooksPath)
 	if err != nil {
 		return fmt.Errorf("agy.GetAgentHooks: %w", err)
 	}
 
-	for event, specs := range groupAgyHooksByEvent() {
-		var existingGroups []agyMatcherGroup
-		if err := parseAgyHookType(rawHooks, event, &existingGroups); err != nil {
-			return fmt.Errorf("agy.GetAgentHooks: %w", err)
-		}
-		for _, spec := range specs {
-			if !agyHookCommandExists(existingGroups, spec.Command) {
-				entry := agyHookEntry{Type: "command", Command: spec.Command}
-				existingGroups = addAgyHook(existingGroups, entry)
-			}
-		}
-		if err := marshalAgyHookType(rawHooks, event, existingGroups); err != nil {
-			return fmt.Errorf("agy.GetAgentHooks: %w", err)
-		}
+	definition := agyHookDefinition{
+		PreInvocation: []agyHookEntry{{
+			Type: "command", Command: agyHookCommandPrefix + "pre-invocation", Timeout: agyHookTimeout,
+		}},
+		PostToolUse: []agyHookMatcherGroup{{
+			Matcher: "*",
+			Hooks: []agyHookEntry{{
+				Type: "command", Command: agyHookCommandPrefix + "post-tool-use", Timeout: agyHookTimeout,
+			}},
+		}},
+		Stop: []agyHookEntry{{
+			Type: "command", Command: agyHookCommandPrefix + "stop", Timeout: agyHookTimeout,
+		}},
 	}
+	raw, err := json.Marshal(definition)
+	if err != nil {
+		return fmt.Errorf("agy.GetAgentHooks: encode managed hooks: %w", err)
+	}
+	file[agyManagedHookName] = raw
 
-	if err := writeAgyHooks(hooksPath, topLevel, rawHooks); err != nil {
+	if err := writeAgyHookFile(hooksPath, file); err != nil {
 		return fmt.Errorf("agy.GetAgentHooks: %w", err)
 	}
-
 	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(hooksPath), agyHooksFileName); err != nil {
 		return fmt.Errorf("agy.GetAgentHooks: gitignore: %w", err)
 	}
 	return nil
 }
 
-// UninstallHooks removes AO's Agy hooks from the workspace-local
-// .gemini/hooks.json file, leaving user-defined hooks untouched. A missing file
-// is a no-op.
+// UninstallHooks removes only AO's TUI hook set. Other Antigravity hook sets,
+// including user hooks and AO's independent Chat hook set, remain untouched.
 func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -105,30 +104,20 @@ func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error
 	if _, err := os.Stat(hooksPath); errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
-	topLevel, rawHooks, err := readAgyHooks(hooksPath)
+	file, err := readAgyHookFile(hooksPath)
 	if err != nil {
 		return fmt.Errorf("agy.UninstallHooks: %w", err)
 	}
-
-	for _, event := range agyManagedEvents() {
-		var groups []agyMatcherGroup
-		if err := parseAgyHookType(rawHooks, event, &groups); err != nil {
-			return fmt.Errorf("agy.UninstallHooks: %w", err)
-		}
-		groups = removeAgyManagedHooks(groups)
-		if err := marshalAgyHookType(rawHooks, event, groups); err != nil {
-			return fmt.Errorf("agy.UninstallHooks: %w", err)
-		}
-	}
-
-	if err := writeAgyHooks(hooksPath, topLevel, rawHooks); err != nil {
+	delete(file, agyManagedHookName)
+	if err := writeAgyHookFile(hooksPath, file); err != nil {
 		return fmt.Errorf("agy.UninstallHooks: %w", err)
 	}
 	return nil
 }
 
-// AreHooksInstalled reports whether any AO Agy hook is present in the
-// workspace-local hooks file. A missing file means none are installed.
+// AreHooksInstalled reports whether the current Antigravity workspace file
+// contains AO's TUI hook set. Legacy .gemini/hooks.json entries deliberately do
+// not count: current Agy does not load that file as a workspace hook source.
 func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (bool, error) {
 	if err := ctx.Err(); err != nil {
 		return false, err
@@ -141,76 +130,51 @@ func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (b
 	if _, err := os.Stat(hooksPath); errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
-	_, rawHooks, err := readAgyHooks(hooksPath)
+	file, err := readAgyHookFile(hooksPath)
 	if err != nil {
 		return false, fmt.Errorf("agy.AreHooksInstalled: %w", err)
 	}
-
-	for _, event := range agyManagedEvents() {
-		var groups []agyMatcherGroup
-		if err := parseAgyHookType(rawHooks, event, &groups); err != nil {
-			return false, fmt.Errorf("agy.AreHooksInstalled: %w", err)
-		}
-		for _, group := range groups {
-			for _, hook := range group.Hooks {
-				if isAgyManagedHook(hook.Command) {
-					return true, nil
-				}
-			}
-		}
+	raw, ok := file[agyManagedHookName]
+	if !ok {
+		return false, nil
 	}
-	return false, nil
+	var definition agyHookDefinition
+	if err := json.Unmarshal(raw, &definition); err != nil {
+		return false, fmt.Errorf("agy.AreHooksInstalled: parse managed hook set: %w", err)
+	}
+	return agyDefinitionHasManagedHook(definition), nil
 }
 
 func agyHooksPath(workspacePath string) string {
 	return filepath.Join(workspacePath, agyHooksDirName, agyHooksFileName)
 }
 
-// readAgyHooks loads the hooks file into a top-level raw map plus the decoded
-// "hooks" sub-map, preserving keys AO doesn't manage. A missing or empty
-// file yields empty maps.
-func readAgyHooks(hooksPath string) (topLevel, rawHooks map[string]json.RawMessage, err error) {
-	topLevel = map[string]json.RawMessage{}
-	rawHooks = map[string]json.RawMessage{}
-
-	data, err := os.ReadFile(hooksPath) //nolint:gosec // path built from caller-owned workspace dir
+func readAgyHookFile(hooksPath string) (agyHookFile, error) {
+	file := agyHookFile{}
+	data, err := os.ReadFile(hooksPath) //nolint:gosec // path is rooted in caller-owned workspace
 	if errors.Is(err, os.ErrNotExist) {
-		return topLevel, rawHooks, nil
+		return file, nil
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("read %s: %w", hooksPath, err)
+		return nil, fmt.Errorf("read %s: %w", hooksPath, err)
 	}
 	if strings.TrimSpace(string(data)) == "" {
-		return topLevel, rawHooks, nil
+		return file, nil
 	}
-	if err := json.Unmarshal(data, &topLevel); err != nil {
-		return nil, nil, fmt.Errorf("parse %s: %w", hooksPath, err)
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", hooksPath, err)
 	}
-	if hooksRaw, ok := topLevel["hooks"]; ok {
-		if err := json.Unmarshal(hooksRaw, &rawHooks); err != nil {
-			return nil, nil, fmt.Errorf("parse hooks in %s: %w", hooksPath, err)
-		}
+	if file == nil {
+		file = agyHookFile{}
 	}
-	return topLevel, rawHooks, nil
+	return file, nil
 }
 
-// writeAgyHooks folds rawHooks back into topLevel and writes the file. An
-// empty hooks map drops the "hooks" key entirely.
-func writeAgyHooks(hooksPath string, topLevel, rawHooks map[string]json.RawMessage) error {
-	if len(rawHooks) == 0 {
-		delete(topLevel, "hooks")
-	} else {
-		hooksJSON, err := json.Marshal(rawHooks)
-		if err != nil {
-			return fmt.Errorf("encode hooks: %w", err)
-		}
-		topLevel["hooks"] = hooksJSON
-	}
-
+func writeAgyHookFile(hooksPath string, file agyHookFile) error {
 	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o750); err != nil {
 		return fmt.Errorf("create hook dir: %w", err)
 	}
-	data, err := json.MarshalIndent(topLevel, "", "  ")
+	data, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode %s: %w", hooksPath, err)
 	}
@@ -221,88 +185,23 @@ func writeAgyHooks(hooksPath string, topLevel, rawHooks map[string]json.RawMessa
 	return nil
 }
 
-func groupAgyHooksByEvent() map[string][]agyHookSpec {
-	byEvent := map[string][]agyHookSpec{}
-	for _, spec := range agyManagedHooks {
-		byEvent[spec.Event] = append(byEvent[spec.Event], spec)
-	}
-	return byEvent
-}
-
-func agyManagedEvents() []string {
-	seen := map[string]bool{}
-	events := make([]string, 0, len(agyManagedHooks))
-	for _, spec := range agyManagedHooks {
-		if !seen[spec.Event] {
-			seen[spec.Event] = true
-			events = append(events, spec.Event)
+func agyDefinitionHasManagedHook(definition agyHookDefinition) bool {
+	for _, hook := range definition.PreInvocation {
+		if strings.HasPrefix(hook.Command, agyHookCommandPrefix) {
+			return true
 		}
 	}
-	return events
-}
-
-func isAgyManagedHook(command string) bool {
-	return strings.HasPrefix(command, agyHookCommandPrefix)
-}
-
-func removeAgyManagedHooks(groups []agyMatcherGroup) []agyMatcherGroup {
-	result := make([]agyMatcherGroup, 0, len(groups))
-	for _, group := range groups {
-		kept := make([]agyHookEntry, 0, len(group.Hooks))
+	for _, group := range definition.PostToolUse {
 		for _, hook := range group.Hooks {
-			if !isAgyManagedHook(hook.Command) {
-				kept = append(kept, hook)
-			}
-		}
-		if len(kept) > 0 {
-			group.Hooks = kept
-			result = append(result, group)
-		}
-	}
-	return result
-}
-
-func parseAgyHookType(rawHooks map[string]json.RawMessage, event string, target *[]agyMatcherGroup) error {
-	data, ok := rawHooks[event]
-	if !ok {
-		return nil
-	}
-	if err := json.Unmarshal(data, target); err != nil {
-		return fmt.Errorf("parse %s hooks: %w", event, err)
-	}
-	return nil
-}
-
-func marshalAgyHookType(rawHooks map[string]json.RawMessage, event string, groups []agyMatcherGroup) error {
-	if len(groups) == 0 {
-		delete(rawHooks, event)
-		return nil
-	}
-	data, err := json.Marshal(groups)
-	if err != nil {
-		return fmt.Errorf("encode %s hooks: %w", event, err)
-	}
-	rawHooks[event] = data
-	return nil
-}
-
-func agyHookCommandExists(groups []agyMatcherGroup, command string) bool {
-	for _, group := range groups {
-		for _, hook := range group.Hooks {
-			if hook.Command == command {
+			if strings.HasPrefix(hook.Command, agyHookCommandPrefix) {
 				return true
 			}
 		}
 	}
-	return false
-}
-
-func addAgyHook(groups []agyMatcherGroup, hook agyHookEntry) []agyMatcherGroup {
-	for i, group := range groups {
-		if group.Matcher == nil {
-			groups[i].Hooks = append(groups[i].Hooks, hook)
-			return groups
+	for _, hook := range definition.Stop {
+		if strings.HasPrefix(hook.Command, agyHookCommandPrefix) {
+			return true
 		}
 	}
-	return append(groups, agyMatcherGroup{Matcher: nil, Hooks: []agyHookEntry{hook}})
+	return false
 }

--- a/backend/internal/adapters/chatdriver/agyjson/conversation.go
+++ b/backend/internal/adapters/chatdriver/agyjson/conversation.go
@@ -56,6 +56,9 @@ type activeTurn struct {
 	cancel      context.CancelFunc
 	permission  ports.PermissionMode
 	interrupted bool
+	resultSeen  bool
+	resultState domain.TurnState
+	resultErr   error
 }
 
 var (
@@ -190,13 +193,6 @@ func (c *conversation) Close() error {
 
 func (c *conversation) runTurn(ctx context.Context, turnID string, msg ports.ChatUserMessage) {
 	defer c.wg.Done()
-	defer func() {
-		c.mu.Lock()
-		if c.active != nil && c.active.id == turnID {
-			c.active = nil
-		}
-		c.mu.Unlock()
-	}()
 
 	args := c.turnArgs(msg)
 	cmd := aoprocess.CommandContext(ctx, c.binary, args...)
@@ -244,6 +240,12 @@ func (c *conversation) runTurn(ctx context.Context, turnID string, msg ports.Cha
 
 	c.mu.Lock()
 	interrupted := c.active != nil && c.active.id == turnID && c.active.interrupted
+	resultState := domain.TurnStateCompleted
+	var resultErr error
+	if c.active != nil && c.active.id == turnID && c.active.resultSeen {
+		resultState = c.active.resultState
+		resultErr = c.active.resultErr
+	}
 	c.mu.Unlock()
 
 	if interrupted {
@@ -264,7 +266,9 @@ func (c *conversation) runTurn(ctx context.Context, turnID string, msg ports.Cha
 	}
 	if !resultSeen {
 		c.finishTurnWithError(turnID, errors.New("agy stream ended without a result event"), false)
+		return
 	}
+	c.emitTurnCompleted(turnID, resultState, resultErr)
 }
 
 func (c *conversation) turnArgs(msg ports.ChatUserMessage) []string {
@@ -373,35 +377,51 @@ func (c *conversation) normalizeStepUpdate(turnID string, update map[string]any)
 }
 
 func (c *conversation) normalizeResult(turnID string, result map[string]any) {
+	state := domain.TurnStateCompleted
+	var resultErr error
+
 	if result == nil {
-		err := errors.New("agy result event is missing its result payload")
-		c.emitError(turnID, err)
-		c.emitTurnCompleted(turnID, domain.TurnStateFailed, err)
-		return
-	}
-	response, _ := result["response"].(string)
-	status, _ := result["status"].(string)
-	errorText, _ := result["error"].(string)
-	if response != "" {
-		c.emit(ports.ChatEvent{
-			Kind:            ports.ChatEventMessageCompleted,
-			ProviderEventID: c.newEventID(turnID, "message-completed"),
-			ProviderTurnID:  turnID,
-			ProviderItemID:  turnID + "-assistant",
-			Text:            response,
-		})
-	}
-	if usage, ok := result["usage"].(map[string]any); ok {
-		c.emitUsage(turnID, usage)
-	}
-	if status == "ERROR" || errorText != "" {
-		if errorText == "" {
-			errorText = "Agy reported an error"
+		state = domain.TurnStateFailed
+		resultErr = errors.New("agy result event is missing its result payload")
+	} else {
+		response, _ := result["response"].(string)
+		status, _ := result["status"].(string)
+		errorText, _ := result["error"].(string)
+
+		if response != "" {
+			c.emit(ports.ChatEvent{
+				Kind:            ports.ChatEventMessageCompleted,
+				ProviderEventID: c.newEventID(turnID, "message-completed"),
+				ProviderTurnID:  turnID,
+				ProviderItemID:  turnID + "-assistant",
+				Text:            response,
+			})
 		}
-		c.emitTurnCompleted(turnID, domain.TurnStateFailed, errors.New(errorText))
-		return
+
+		if usage, ok := result["usage"].(map[string]any); ok {
+			c.emitUsage(turnID, usage)
+		}
+
+		if strings.EqualFold(status, "error") || errorText != "" {
+			state = domain.TurnStateFailed
+			if errorText == "" {
+				errorText = "Agy reported an error"
+			}
+			resultErr = errors.New(errorText)
+		}
 	}
-	c.emitTurnCompleted(turnID, domain.TurnStateCompleted, nil)
+
+	// The result frame is terminal at the protocol level, but the child process
+	// may not have exited yet. Record its outcome here and let runTurn publish
+	// turn.completed only after cmd.Wait returns. Otherwise the Chat queue can
+	// dispatch the next turn while this process is still the active owner.
+	c.mu.Lock()
+	if c.active != nil && c.active.id == turnID {
+		c.active.resultSeen = true
+		c.active.resultState = state
+		c.active.resultErr = resultErr
+	}
+	c.mu.Unlock()
 }
 
 func (c *conversation) emitUsage(turnID string, usage map[string]any) {
@@ -427,6 +447,15 @@ func (c *conversation) emitUsage(turnID string, usage map[string]any) {
 }
 
 func (c *conversation) emitTurnCompleted(turnID string, state domain.TurnState, err error) {
+	// Release ownership before publishing completion. The Chat service drains
+	// queued turns synchronously from this event, so publishing first creates a
+	// race where SendTurn still observes the previous turn as active.
+	c.mu.Lock()
+	if c.active != nil && c.active.id == turnID {
+		c.active = nil
+	}
+	c.mu.Unlock()
+
 	c.emit(ports.ChatEvent{
 		Kind:            ports.ChatEventTurnCompleted,
 		ProviderEventID: c.newEventID(turnID, "completed"),

--- a/backend/internal/adapters/chatdriver/agyjson/conversation.go
+++ b/backend/internal/adapters/chatdriver/agyjson/conversation.go
@@ -44,7 +44,6 @@ type conversation struct {
 	closed                 bool
 
 	events      chan ports.ChatEvent
-	turnSeq     atomic.Uint64
 	eventSeq    atomic.Uint64
 	approvalSeq atomic.Uint64
 	wg          sync.WaitGroup
@@ -90,7 +89,12 @@ func (c *conversation) SendTurn(ctx context.Context, msg ports.ChatUserMessage) 
 		return ports.ChatTurnRef{}, fmt.Errorf("%w: Agy stream-json chat does not expose a per-turn reasoning-effort control", ports.ErrChatConfigOptionInvalid)
 	}
 
-	turnID := fmt.Sprintf("agy-turn-%d", c.turnSeq.Add(1))
+	turnToken, err := randomToken()
+	if err != nil {
+		return ports.ChatTurnRef{}, fmt.Errorf("agy chat: create provider turn id: %w", err)
+	}
+	turnID := "agy-turn-" + turnToken
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closed {

--- a/backend/internal/adapters/chatdriver/agyjson/conversation.go
+++ b/backend/internal/adapters/chatdriver/agyjson/conversation.go
@@ -1,0 +1,702 @@
+package agyjson
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/processenv"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+const maxStreamLineBytes = 8 << 20
+
+type conversation struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	binary                string
+	workspacePath         string
+	env                   map[string]string
+	model                 string
+	permissions           ports.PermissionMode
+	systemPrompt          string
+	additionalDirectories []string
+	hookToken             string
+	log                   *slog.Logger
+
+	mu                     sync.Mutex
+	providerConversationID string
+	deferred               map[string]ports.ChatUserMessage
+	approvals              map[string]chan ports.ChatDecision
+	active                 *activeTurn
+	closed                 bool
+
+	events      chan ports.ChatEvent
+	turnSeq     atomic.Uint64
+	eventSeq    atomic.Uint64
+	approvalSeq atomic.Uint64
+	wg          sync.WaitGroup
+	closeOnce   sync.Once
+}
+
+type activeTurn struct {
+	id          string
+	cancel      context.CancelFunc
+	permission  ports.PermissionMode
+	interrupted bool
+}
+
+var (
+	_ ports.ChatConversation        = (*conversation)(nil)
+	_ ports.ChatDeferredTurnStarter = (*conversation)(nil)
+)
+
+func (c *conversation) ProviderConversationID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.providerConversationID
+}
+
+func (c *conversation) Capabilities() ports.ChatCapabilities { return capabilities() }
+
+func (c *conversation) Events() <-chan ports.ChatEvent { return c.events }
+
+func (c *conversation) SendTurn(ctx context.Context, msg ports.ChatUserMessage) (ports.ChatTurnRef, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ChatTurnRef{}, err
+	}
+	if strings.TrimSpace(msg.Text) == "" {
+		return ports.ChatTurnRef{}, errors.New("agy chat: message text is required")
+	}
+	if len(msg.Content) != 0 {
+		return ports.ChatTurnRef{}, fmt.Errorf("%w: Agy stream-json chat does not support structured content blocks", ports.ErrChatUnsupported)
+	}
+	if strings.TrimSpace(msg.Settings.Effort) != "" {
+		return ports.ChatTurnRef{}, fmt.Errorf("%w: Agy stream-json chat does not expose a per-turn reasoning-effort control", ports.ErrChatConfigOptionInvalid)
+	}
+
+	turnID := fmt.Sprintf("agy-turn-%d", c.turnSeq.Add(1))
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return ports.ChatTurnRef{}, errors.New("agy chat: conversation is closed")
+	}
+	if c.active != nil {
+		return ports.ChatTurnRef{}, errors.New("agy chat: a turn is already active")
+	}
+	c.deferred[turnID] = msg
+	return ports.ChatTurnRef{ProviderTurnID: turnID}, nil
+}
+
+func (c *conversation) StartDeferredTurn(providerTurnID string) error {
+	c.mu.Lock()
+	msg, ok := c.deferred[providerTurnID]
+	if !ok {
+		c.mu.Unlock()
+		return fmt.Errorf("agy chat: deferred turn %s not found", providerTurnID)
+	}
+	if c.closed {
+		delete(c.deferred, providerTurnID)
+		c.mu.Unlock()
+		return errors.New("agy chat: conversation is closed")
+	}
+	if c.active != nil {
+		c.mu.Unlock()
+		return fmt.Errorf("agy chat: turn %s is already active", c.active.id)
+	}
+	delete(c.deferred, providerTurnID)
+	turnCtx, cancel := context.WithCancel(c.ctx)
+	c.active = &activeTurn{
+		id: providerTurnID, cancel: cancel,
+		permission: effectivePermission(c.permissions, msg.Settings.Approval),
+	}
+	c.wg.Add(1)
+	c.mu.Unlock()
+
+	go c.runTurn(turnCtx, providerTurnID, msg)
+	return nil
+}
+
+func (c *conversation) DiscardDeferredTurn(providerTurnID string) {
+	c.mu.Lock()
+	delete(c.deferred, providerTurnID)
+	c.mu.Unlock()
+}
+
+func (c *conversation) Interrupt(ctx context.Context, providerTurnID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.active == nil || c.active.id != providerTurnID {
+		return ports.ErrChatNoActiveTurn
+	}
+	c.active.interrupted = true
+	c.active.cancel()
+	return nil
+}
+
+func (c *conversation) ResolveRequest(ctx context.Context, requestID string, decision ports.ChatDecision) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if decision.ID != "allow" && decision.ID != "deny" {
+		return ports.ErrChatDecisionNotOffered
+	}
+
+	c.mu.Lock()
+	ch, ok := c.approvals[requestID]
+	if ok {
+		delete(c.approvals, requestID)
+	}
+	c.mu.Unlock()
+	if !ok {
+		return ports.ErrChatRequestNotPending
+	}
+	select {
+	case ch <- decision:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.ctx.Done():
+		return ports.ErrChatRequestNotPending
+	}
+}
+
+func (c *conversation) Close() error {
+	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		c.closed = true
+		c.mu.Unlock()
+		c.cancel()
+		c.wg.Wait()
+		close(c.events)
+	})
+	return nil
+}
+
+func (c *conversation) runTurn(ctx context.Context, turnID string, msg ports.ChatUserMessage) {
+	defer c.wg.Done()
+	defer func() {
+		c.mu.Lock()
+		if c.active != nil && c.active.id == turnID {
+			c.active = nil
+		}
+		c.mu.Unlock()
+	}()
+
+	args := c.turnArgs(msg)
+	cmd := aoprocess.CommandContext(ctx, c.binary, args...)
+	cmd.Dir = c.workspacePath
+	env := cloneMap(c.env)
+	env[hookTokenEnv] = c.hookToken
+	cmd.Env = processenv.Merge(env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		c.finishTurnWithError(turnID, fmt.Errorf("open stdout: %w", err), false)
+		return
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		c.finishTurnWithError(turnID, fmt.Errorf("start agy: %w", err), false)
+		return
+	}
+
+	c.emit(ports.ChatEvent{
+		Kind:            ports.ChatEventTurnStarted,
+		ProviderEventID: c.newEventID(turnID, "started"),
+		ProviderTurnID:  turnID,
+		ControllerState: ports.ChatControllerBusy,
+	})
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 64<<10), maxStreamLineBytes)
+	resultSeen := false
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		seen, normalizeErr := c.normalizeStreamLine(turnID, line)
+		if normalizeErr != nil {
+			c.emitError(turnID, normalizeErr)
+			continue
+		}
+		resultSeen = resultSeen || seen
+	}
+	scanErr := scanner.Err()
+	waitErr := cmd.Wait()
+
+	c.mu.Lock()
+	interrupted := c.active != nil && c.active.id == turnID && c.active.interrupted
+	c.mu.Unlock()
+
+	if interrupted {
+		c.emitTurnCompleted(turnID, domain.TurnStateInterrupted, nil)
+		return
+	}
+	if scanErr != nil {
+		c.finishTurnWithError(turnID, fmt.Errorf("read agy stream: %w", scanErr), false)
+		return
+	}
+	if waitErr != nil && !resultSeen {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = waitErr.Error()
+		}
+		c.finishTurnWithError(turnID, errors.New(detail), false)
+		return
+	}
+	if !resultSeen {
+		c.finishTurnWithError(turnID, errors.New("agy stream ended without a result event"), false)
+	}
+}
+
+func (c *conversation) turnArgs(msg ports.ChatUserMessage) []string {
+	args := []string{"--output-format", "stream-json", "--add-dir", c.workspacePath}
+	for _, dir := range c.additionalDirectories {
+		if dir = strings.TrimSpace(dir); dir != "" && dir != c.workspacePath {
+			args = append(args, "--add-dir", dir)
+		}
+	}
+	model := strings.TrimSpace(msg.Settings.Model)
+	if model == "" {
+		model = c.model
+	}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	if id := c.ProviderConversationID(); id != "" {
+		args = append(args, "--conversation", id)
+	}
+	if effectivePermission(c.permissions, msg.Settings.Approval) == ports.PermissionModeBypassPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+	args = append(args, "--print", msg.Text)
+	return args
+}
+
+func (c *conversation) normalizeStreamLine(turnID string, line []byte) (bool, error) {
+	var envelope struct {
+		Event          string         `json:"event"`
+		ConversationID string         `json:"conversation_id"`
+		StepUpdate     map[string]any `json:"step_update"`
+		Result         map[string]any `json:"result"`
+	}
+	if err := json.Unmarshal(line, &envelope); err != nil {
+		return false, fmt.Errorf("decode agy stream event: %w", err)
+	}
+	switch envelope.Event {
+	case "init":
+		if envelope.ConversationID == "" {
+			return false, errors.New("agy init event has no conversation_id")
+		}
+		if err := c.observeProviderID(envelope.ConversationID); err != nil {
+			return false, err
+		}
+		return false, nil
+	case "step_update":
+		c.normalizeStepUpdate(turnID, envelope.StepUpdate)
+		return false, nil
+	case "result":
+		c.normalizeResult(turnID, envelope.Result)
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func (c *conversation) normalizeStepUpdate(turnID string, update map[string]any) {
+	if update == nil {
+		return
+	}
+	stepType, _ := update["step_type"].(string)
+	state, _ := update["state"].(string)
+	step := int64Value(update["step_index"])
+	itemID := fmt.Sprintf("%s-step-%d", turnID, step)
+
+	switch stepType {
+	case "agent_response":
+		delta, _ := update["text_delta"].(string)
+		if state == "ACTIVE" && delta != "" {
+			c.emit(ports.ChatEvent{
+				Kind:            ports.ChatEventMessageDelta,
+				ProviderEventID: c.newEventID(turnID, "message-delta"),
+				ProviderTurnID:  turnID,
+				ProviderItemID:  turnID + "-assistant",
+				Delta:           delta,
+			})
+		}
+	case "tool":
+		name, _ := update["tool_name"].(string)
+		detail := toolDetail(update)
+		status := domain.ActivityStatusRunning
+		kind := domain.ActivityKindCommand
+		if strings.HasPrefix(name, "mcp") {
+			kind = domain.ActivityKindMCPTool
+		}
+		eventKind := ports.ChatEventActivityStarted
+		switch state {
+		case "DONE":
+			status = domain.ActivityStatusCompleted
+			eventKind = ports.ChatEventActivityCompleted
+		case "ERROR":
+			status = domain.ActivityStatusFailed
+			eventKind = ports.ChatEventActivityCompleted
+		}
+		c.emit(ports.ChatEvent{
+			Kind:            eventKind,
+			ProviderEventID: c.newEventID(turnID, "tool"),
+			ProviderTurnID:  turnID,
+			ProviderItemID:  itemID,
+			ActivityKind:    kind,
+			ActivityStatus:  status,
+			Summary:         firstNonEmpty(name, "Agy tool"),
+			Detail:          detail,
+		})
+	}
+}
+
+func (c *conversation) normalizeResult(turnID string, result map[string]any) {
+	if result == nil {
+		err := errors.New("agy result event is missing its result payload")
+		c.emitError(turnID, err)
+		c.emitTurnCompleted(turnID, domain.TurnStateFailed, err)
+		return
+	}
+	response, _ := result["response"].(string)
+	status, _ := result["status"].(string)
+	errorText, _ := result["error"].(string)
+	if response != "" {
+		c.emit(ports.ChatEvent{
+			Kind:            ports.ChatEventMessageCompleted,
+			ProviderEventID: c.newEventID(turnID, "message-completed"),
+			ProviderTurnID:  turnID,
+			ProviderItemID:  turnID + "-assistant",
+			Text:            response,
+		})
+	}
+	if usage, ok := result["usage"].(map[string]any); ok {
+		c.emitUsage(turnID, usage)
+	}
+	if status == "ERROR" || errorText != "" {
+		if errorText == "" {
+			errorText = "Agy reported an error"
+		}
+		c.emitTurnCompleted(turnID, domain.TurnStateFailed, errors.New(errorText))
+		return
+	}
+	c.emitTurnCompleted(turnID, domain.TurnStateCompleted, nil)
+}
+
+func (c *conversation) emitUsage(turnID string, usage map[string]any) {
+	input := int64MapValue(usage, "input_tokens", "inputTokens")
+	output := int64MapValue(usage, "output_tokens", "outputTokens")
+	cached := int64MapValue(usage, "cache_read_tokens", "cached_tokens", "cachedTokens")
+	total := int64MapValue(usage, "total_tokens", "totalTokens")
+	if total == 0 {
+		total = input + output + cached
+	}
+	c.emit(ports.ChatEvent{
+		Kind:            ports.ChatEventUsage,
+		ProviderEventID: c.newEventID(turnID, "usage"),
+		ProviderTurnID:  turnID,
+		Usage: &ports.ChatUsage{
+			InputTokens:  input,
+			OutputTokens: output,
+			CachedTokens: cached,
+			TotalTokens:  total,
+			TotalsKnown:  true,
+		},
+	})
+}
+
+func (c *conversation) emitTurnCompleted(turnID string, state domain.TurnState, err error) {
+	c.emit(ports.ChatEvent{
+		Kind:            ports.ChatEventTurnCompleted,
+		ProviderEventID: c.newEventID(turnID, "completed"),
+		ProviderTurnID:  turnID,
+		TurnState:       state,
+		Err:             err,
+	})
+}
+
+func (c *conversation) finishTurnWithError(turnID string, err error, interrupted bool) {
+	if interrupted {
+		c.emitTurnCompleted(turnID, domain.TurnStateInterrupted, nil)
+		return
+	}
+	c.emitError(turnID, err)
+	c.emitTurnCompleted(turnID, domain.TurnStateFailed, err)
+}
+
+func (c *conversation) emitError(turnID string, err error) {
+	if err == nil {
+		return
+	}
+	c.emit(ports.ChatEvent{
+		Kind:            ports.ChatEventError,
+		ProviderEventID: c.newEventID(turnID, "error"),
+		ProviderTurnID:  turnID,
+		Err:             err,
+		Summary:         err.Error(),
+	})
+}
+
+func (c *conversation) emit(event ports.ChatEvent) {
+	select {
+	case c.events <- event:
+	case <-c.ctx.Done():
+	}
+}
+
+func (c *conversation) newEventID(turnID, kind string) string {
+	return fmt.Sprintf("%s:%s:%d", turnID, kind, c.eventSeq.Add(1))
+}
+
+func (c *conversation) observeProviderID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("agy chat: provider conversation id is empty")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.providerConversationID != "" && c.providerConversationID != id {
+		return fmt.Errorf("agy chat: provider conversation changed from %s to %s", c.providerConversationID, id)
+	}
+	c.providerConversationID = id
+	return nil
+}
+
+// HandleAgyChatHook bridges Antigravity's blocking hooks into AO Chat events.
+// onProviderID is invoked immediately after token/identity validation so the
+// daemon can persist a newly allocated native conversation before a tool waits
+// for human approval.
+func (c *conversation) HandleAgyChatHook(
+	ctx context.Context,
+	event string,
+	token string,
+	payload []byte,
+	onProviderID func(string) error,
+) (map[string]any, error) {
+	if subtle.ConstantTimeCompare([]byte(token), []byte(c.hookToken)) != 1 {
+		return nil, errors.New("agy chat hook token is invalid")
+	}
+	var common struct {
+		ConversationID string `json:"conversationId"`
+	}
+	if err := json.Unmarshal(payload, &common); err != nil {
+		return nil, fmt.Errorf("decode agy hook payload: %w", err)
+	}
+	if err := c.observeProviderID(common.ConversationID); err != nil {
+		return nil, err
+	}
+	if onProviderID != nil {
+		if err := onProviderID(common.ConversationID); err != nil {
+			return nil, err
+		}
+	}
+
+	switch event {
+	case "pre-invocation":
+		return c.handlePreInvocation(payload)
+	case "pre-tool-use":
+		return c.handlePreToolUse(ctx, payload)
+	default:
+		return nil, fmt.Errorf("agy chat: unsupported hook event %q", event)
+	}
+}
+
+func (c *conversation) handlePreInvocation(payload []byte) (map[string]any, error) {
+	var input struct {
+		InvocationNum int `json:"invocationNum"`
+	}
+	if err := json.Unmarshal(payload, &input); err != nil {
+		return nil, err
+	}
+	steps := []map[string]string{}
+	if input.InvocationNum == 0 && strings.TrimSpace(c.systemPrompt) != "" {
+		steps = append(steps, map[string]string{"ephemeralMessage": c.systemPrompt})
+	}
+	return map[string]any{"injectSteps": steps}, nil
+}
+
+func (c *conversation) handlePreToolUse(ctx context.Context, payload []byte) (map[string]any, error) {
+	var input struct {
+		StepIdx  int64 `json:"stepIdx"`
+		ToolCall struct {
+			Name string         `json:"name"`
+			Args map[string]any `json:"args"`
+		} `json:"toolCall"`
+	}
+	if err := json.Unmarshal(payload, &input); err != nil {
+		return nil, err
+	}
+	if input.ToolCall.Name == "ask_question" || input.ToolCall.Name == "ask_permission" {
+		return map[string]any{
+			"decision": "deny",
+			"reason":   "This Agy Chat driver does not yet support provider-side interactive questions; ask in normal assistant text instead.",
+		}, nil
+	}
+
+	mode := c.currentApprovalMode()
+	if toolAutoAllowed(mode, input.ToolCall.Name) {
+		return map[string]any{"decision": "allow"}, nil
+	}
+
+	c.mu.Lock()
+	turnID := ""
+	if c.active != nil {
+		turnID = c.active.id
+	}
+	c.mu.Unlock()
+	if turnID == "" {
+		return map[string]any{"decision": "deny", "reason": "AO has no active turn for this tool call."}, nil
+	}
+
+	requestID := fmt.Sprintf("%s-approval-%d", turnID, c.approvalSeq.Add(1))
+	decisionCh := make(chan ports.ChatDecision, 1)
+	c.mu.Lock()
+	c.approvals[requestID] = decisionCh
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		delete(c.approvals, requestID)
+		c.mu.Unlock()
+	}()
+
+	detail, _ := json.Marshal(map[string]any{
+		"tool":    input.ToolCall.Name,
+		"args":    input.ToolCall.Args,
+		"stepIdx": input.StepIdx,
+	})
+	c.emit(ports.ChatEvent{
+		Kind:            ports.ChatEventApprovalRequested,
+		ProviderEventID: c.newEventID(turnID, "approval"),
+		ProviderTurnID:  turnID,
+		ProviderItemID:  fmt.Sprintf("%s-tool-%d", turnID, input.StepIdx),
+		RequestID:       requestID,
+		Summary:         "Allow Agy to use " + firstNonEmpty(input.ToolCall.Name, "this tool") + "?",
+		Detail:          detail,
+		Decisions: []ports.ChatDecisionOption{
+			{ID: "allow", Label: "Allow"},
+			{ID: "deny", Label: "Deny"},
+		},
+	})
+
+	select {
+	case decision := <-decisionCh:
+		if decision.ID == "allow" {
+			return map[string]any{"decision": "allow"}, nil
+		}
+		return map[string]any{"decision": "deny", "reason": "Denied in Agent Orchestrator."}, nil
+	case <-ctx.Done():
+		return map[string]any{"decision": "deny", "reason": "Approval request was cancelled."}, nil
+	case <-c.ctx.Done():
+		return map[string]any{"decision": "deny", "reason": "Agy Chat controller stopped."}, nil
+	}
+}
+
+func (c *conversation) currentApprovalMode() ports.PermissionMode {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.active != nil {
+		return c.active.permission
+	}
+	return c.permissions
+}
+
+func effectivePermission(base, turn ports.PermissionMode) ports.PermissionMode {
+	if turn != "" {
+		return turn
+	}
+	return base
+}
+
+func toolAutoAllowed(mode ports.PermissionMode, tool string) bool {
+	switch mode {
+	case ports.PermissionModeAuto, ports.PermissionModeBypassPermissions:
+		return true
+	case ports.PermissionModeAcceptEdits:
+		switch tool {
+		case "view_file", "list_dir", "find_by_name", "grep_search", "list_permissions",
+			"write_to_file", "replace_file_content", "multi_replace_file_content":
+			return true
+		}
+	default:
+		switch tool {
+		case "view_file", "list_dir", "find_by_name", "grep_search", "list_permissions":
+			return true
+		}
+	}
+	return false
+}
+
+func toolDetail(update map[string]any) []byte {
+	detail := map[string]any{}
+	if info, ok := update["tool_info"].(map[string]any); ok {
+		if params, ok := info["parameters"]; ok {
+			detail["parameters"] = params
+		}
+		if value, ok := info["error"]; ok {
+			detail["error"] = value
+		}
+	}
+	if output, ok := update["output"]; ok {
+		detail["output"] = output
+	}
+	data, _ := json.Marshal(detail)
+	return data
+}
+
+func int64Value(v any) int64 {
+	switch value := v.(type) {
+	case float64:
+		return int64(value)
+	case int64:
+		return value
+	case int:
+		return int64(value)
+	case json.Number:
+		parsed, _ := value.Int64()
+		return parsed
+	case string:
+		parsed, _ := strconv.ParseInt(value, 10, 64)
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func int64MapValue(values map[string]any, keys ...string) int64 {
+	for _, key := range keys {
+		if value, ok := values[key]; ok {
+			return int64Value(value)
+		}
+	}
+	return 0
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/backend/internal/adapters/chatdriver/agyjson/driver.go
+++ b/backend/internal/adapters/chatdriver/agyjson/driver.go
@@ -1,0 +1,263 @@
+// Package agyjson implements AO Chat UI over Agy's machine-readable print mode.
+// The native Agy terminal adapter remains unchanged; this driver is used only
+// when a session explicitly runs in Chat mode.
+package agyjson
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+const (
+	hookDirName        = ".agents"
+	hookFileName       = "hooks.json"
+	managedHookName    = "agent-orchestrator-chat"
+	hookTokenEnv       = "AO_AGY_CHAT_HOOK_TOKEN"
+	hookCommandPrefix  = "ao agy-chat-hook "
+	hookTimeoutSeconds = 3600
+)
+
+type agyPlugin interface {
+	ResolveBinary(context.Context) (string, error)
+	AuthStatus(context.Context) (ports.AgentAuthStatus, error)
+}
+
+// Driver opens Agy conversations using `agy --print --output-format stream-json`.
+type Driver struct {
+	plugin agyPlugin
+	log    *slog.Logger
+}
+
+func New(plugin agyPlugin, log *slog.Logger) *Driver {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Driver{plugin: plugin, log: log}
+}
+
+var _ ports.ChatDriver = (*Driver)(nil)
+
+func (d *Driver) Harness() domain.AgentHarness { return domain.HarnessAgy }
+
+func capabilities() ports.ChatCapabilities {
+	return ports.ChatCapabilities{
+		ports.ChatCapabilityStreaming: true,
+		ports.ChatCapabilityTools:     true,
+		ports.ChatCapabilityApprovals: true,
+		ports.ChatCapabilityInterrupt: true,
+		ports.ChatCapabilityResume:    true,
+		ports.ChatCapabilityUsage:     true,
+	}
+}
+
+// Probe verifies the installed Agy exposes structured print output. That surface
+// is the machine protocol for this driver; terminal rendering is never scraped.
+func (d *Driver) Probe(ctx context.Context) (ports.ChatCapabilities, error) {
+	binary, err := d.plugin.ResolveBinary(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
+	}
+	status, authErr := d.plugin.AuthStatus(ctx)
+	if authErr == nil && status == ports.AgentAuthStatusUnauthorized {
+		return nil, ports.ErrChatAuthRequired
+	}
+	if authErr != nil {
+		d.log.Debug("agy auth probe inconclusive; continuing", "error", authErr)
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := aoprocess.CommandContext(probeCtx, binary, "--help").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%w: read Agy help: %v", ports.ErrChatDriverIncompatible, err)
+	}
+	if !bytes.Contains(out, []byte("--output-format")) || !bytes.Contains(out, []byte("stream-json")) {
+		return nil, fmt.Errorf("%w: installed Agy does not expose --output-format stream-json", ports.ErrChatDriverIncompatible)
+	}
+	return capabilities(), nil
+}
+
+func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.ChatConversation, error) {
+	if len(cfg.MCPServers) != 0 {
+		return nil, fmt.Errorf("%w: Agy stream-json chat does not yet support AO-supplied MCP servers", ports.ErrChatUnsupported)
+	}
+	binary, err := d.plugin.ResolveBinary(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
+	}
+	return d.newConversation(ctx, binary, conversationConfig{
+		sessionID:             cfg.SessionID,
+		workspacePath:         cfg.WorkspacePath,
+		env:                   cfg.Env,
+		model:                 cfg.Model,
+		permissions:           cfg.Permissions,
+		systemPrompt:          cfg.SystemPrompt,
+		additionalDirectories: cfg.AdditionalDirectories,
+	})
+}
+
+func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.ChatConversation, error) {
+	if len(cfg.MCPServers) != 0 {
+		return nil, fmt.Errorf("%w: Agy stream-json chat does not yet support AO-supplied MCP servers", ports.ErrChatUnsupported)
+	}
+	providerID := strings.TrimSpace(cfg.ProviderConversationID)
+	if providerID == "" {
+		return nil, fmt.Errorf("%w: Agy conversation id is empty", ports.ErrChatResumeFailed)
+	}
+	binary, err := d.plugin.ResolveBinary(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
+	}
+	conv, err := d.newConversation(ctx, binary, conversationConfig{
+		sessionID:              cfg.SessionID,
+		workspacePath:          cfg.WorkspacePath,
+		env:                    cfg.Env,
+		permissions:            cfg.Permissions,
+		systemPrompt:           cfg.SystemPrompt,
+		additionalDirectories:  cfg.AdditionalDirectories,
+		providerConversationID: providerID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ports.ErrChatResumeFailed, err)
+	}
+	return conv, nil
+}
+
+type conversationConfig struct {
+	sessionID              domain.SessionID
+	workspacePath          string
+	env                    map[string]string
+	model                  string
+	permissions            ports.PermissionMode
+	systemPrompt           string
+	additionalDirectories  []string
+	providerConversationID string
+}
+
+func (d *Driver) newConversation(ctx context.Context, binary string, cfg conversationConfig) (*conversation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(cfg.workspacePath) == "" {
+		return nil, errors.New("agy chat: workspace path is required")
+	}
+	if err := installChatHooks(cfg.workspacePath); err != nil {
+		return nil, fmt.Errorf("agy chat: install hooks: %w", err)
+	}
+	token, err := randomToken()
+	if err != nil {
+		return nil, fmt.Errorf("agy chat: create hook token: %w", err)
+	}
+	convCtx, cancel := context.WithCancel(context.Background())
+	return &conversation{
+		ctx:                    convCtx,
+		cancel:                 cancel,
+		binary:                 binary,
+		workspacePath:          cfg.workspacePath,
+		env:                    cloneMap(cfg.env),
+		model:                  strings.TrimSpace(cfg.model),
+		permissions:            cfg.permissions,
+		systemPrompt:           cfg.systemPrompt,
+		additionalDirectories:  append([]string(nil), cfg.additionalDirectories...),
+		providerConversationID: strings.TrimSpace(cfg.providerConversationID),
+		hookToken:              token,
+		events:                 make(chan ports.ChatEvent, 512),
+		deferred:               make(map[string]ports.ChatUserMessage),
+		approvals:              make(map[string]chan ports.ChatDecision),
+		log:                    d.log,
+	}, nil
+}
+
+func randomToken() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func cloneMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+type hookFile map[string]json.RawMessage
+
+type hookHandler struct {
+	Type    string `json:"type,omitempty"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+type hookMatcherGroup struct {
+	Matcher string        `json:"matcher"`
+	Hooks   []hookHandler `json:"hooks"`
+}
+
+type hookDefinition struct {
+	PreInvocation []hookHandler      `json:"PreInvocation"`
+	PreToolUse    []hookMatcherGroup `json:"PreToolUse"`
+}
+
+func installChatHooks(workspacePath string) error {
+	hooksDir := filepath.Join(workspacePath, hookDirName)
+	hooksPath := filepath.Join(hooksDir, hookFileName)
+	file := hookFile{}
+	if data, err := os.ReadFile(hooksPath); err == nil && strings.TrimSpace(string(data)) != "" {
+		if err := json.Unmarshal(data, &file); err != nil {
+			return fmt.Errorf("parse %s: %w", hooksPath, err)
+		}
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read %s: %w", hooksPath, err)
+	}
+	if file == nil {
+		file = hookFile{}
+	}
+
+	definition := hookDefinition{
+		PreInvocation: []hookHandler{{
+			Type: "command", Command: hookCommandPrefix + "pre-invocation", Timeout: hookTimeoutSeconds,
+		}},
+		PreToolUse: []hookMatcherGroup{{
+			Matcher: "*",
+			Hooks: []hookHandler{{
+				Type: "command", Command: hookCommandPrefix + "pre-tool-use", Timeout: hookTimeoutSeconds,
+			}},
+		}},
+	}
+	raw, err := json.Marshal(definition)
+	if err != nil {
+		return err
+	}
+	file[managedHookName] = raw
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(hooksDir, 0o750); err != nil {
+		return err
+	}
+	if err := hookutil.AtomicWriteFile(hooksPath, data, 0o600); err != nil {
+		return err
+	}
+	return hookutil.EnsureWorkspaceGitignore(hooksDir, hookFileName)
+}

--- a/backend/internal/adapters/chatdriver/agyjson/driver_test.go
+++ b/backend/internal/adapters/chatdriver/agyjson/driver_test.go
@@ -3,12 +3,12 @@ package agyjson
 import (
 	"context"
 	"encoding/json"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 func TestInstallChatHooksPreservesUserDefinitions(t *testing.T) {
@@ -155,5 +155,77 @@ func TestSendTurnRejectsUnsupportedEffort(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected reasoning effort to be rejected")
+	}
+}
+
+func TestNormalizeResultDefersTurnCompletionUntilProcessExit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := &conversation{
+		ctx:       ctx,
+		cancel:    cancel,
+		events:    make(chan ports.ChatEvent, 4),
+		deferred:  map[string]ports.ChatUserMessage{},
+		approvals: map[string]chan ports.ChatDecision{},
+		active: &activeTurn{
+			id: "agy-turn-1",
+		},
+	}
+
+	c.normalizeResult("agy-turn-1", map[string]any{
+		"status": "SUCCESS",
+	})
+
+	c.mu.Lock()
+	seen := c.active != nil && c.active.resultSeen
+	state := c.active.resultState
+	c.mu.Unlock()
+
+	if !seen {
+		t.Fatal("result was not recorded on active turn")
+	}
+	if state != domain.TurnStateCompleted {
+		t.Fatalf("result state = %q, want completed", state)
+	}
+
+	select {
+	case event := <-c.events:
+		if event.Kind == ports.ChatEventTurnCompleted {
+			t.Fatal("turn completed was emitted before the provider process exited")
+		}
+	default:
+	}
+}
+
+func TestEmitTurnCompletedReleasesActiveTurnBeforePublishing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := &conversation{
+		ctx:       ctx,
+		cancel:    cancel,
+		events:    make(chan ports.ChatEvent, 4),
+		deferred:  map[string]ports.ChatUserMessage{},
+		approvals: map[string]chan ports.ChatDecision{},
+		active: &activeTurn{
+			id: "agy-turn-1",
+		},
+	}
+
+	c.emitTurnCompleted("agy-turn-1", domain.TurnStateCompleted, nil)
+
+	c.mu.Lock()
+	active := c.active
+	c.mu.Unlock()
+
+	if active != nil {
+		t.Fatalf("active turn = %#v, want nil before completion is consumed", active)
+	}
+
+	if _, err := c.SendTurn(context.Background(), ports.ChatUserMessage{
+		Text: "next turn",
+	}); err != nil {
+		t.Fatalf("next turn rejected after completion: %v", err)
 	}
 }

--- a/backend/internal/adapters/chatdriver/agyjson/driver_test.go
+++ b/backend/internal/adapters/chatdriver/agyjson/driver_test.go
@@ -1,0 +1,159 @@
+package agyjson
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestInstallChatHooksPreservesUserDefinitions(t *testing.T) {
+	workspace := t.TempDir()
+	hooksDir := filepath.Join(workspace, ".agents")
+	if err := os.MkdirAll(hooksDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	hooksPath := filepath.Join(hooksDir, "hooks.json")
+	if err := os.WriteFile(hooksPath, []byte(`{"user-hook":{"Stop":[{"type":"command","command":"echo done"}]}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installChatHooks(workspace); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var file hookFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := file["user-hook"]; !ok {
+		t.Fatal("existing user hook was removed")
+	}
+	raw, ok := file[managedHookName]
+	if !ok {
+		t.Fatalf("managed hook %q missing", managedHookName)
+	}
+	var definition hookDefinition
+	if err := json.Unmarshal(raw, &definition); err != nil {
+		t.Fatal(err)
+	}
+	if len(definition.PreInvocation) != 1 || definition.PreInvocation[0].Command != hookCommandPrefix+"pre-invocation" {
+		t.Fatalf("unexpected PreInvocation hooks: %#v", definition.PreInvocation)
+	}
+	if len(definition.PreToolUse) != 1 || definition.PreToolUse[0].Matcher != "*" || len(definition.PreToolUse[0].Hooks) != 1 || definition.PreToolUse[0].Hooks[0].Command != hookCommandPrefix+"pre-tool-use" {
+		t.Fatalf("unexpected PreToolUse hooks: %#v", definition.PreToolUse)
+	}
+}
+
+func TestPreInvocationPersistsProviderIDAndInjectsSystemPrompt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := &conversation{
+		ctx:          ctx,
+		cancel:       cancel,
+		hookToken:    "secret",
+		systemPrompt: "follow AO rules",
+		events:       make(chan ports.ChatEvent, 4),
+		deferred:     map[string]ports.ChatUserMessage{},
+		approvals:    map[string]chan ports.ChatDecision{},
+	}
+	persisted := ""
+	response, err := c.HandleAgyChatHook(
+		context.Background(),
+		"pre-invocation",
+		"secret",
+		[]byte(`{"conversationId":"native-123","invocationNum":0}`),
+		func(id string) error { persisted = id; return nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted != "native-123" || c.ProviderConversationID() != "native-123" {
+		t.Fatalf("provider id not persisted: callback=%q conversation=%q", persisted, c.ProviderConversationID())
+	}
+	steps, ok := response["injectSteps"].([]map[string]string)
+	if !ok || len(steps) != 1 || steps[0]["ephemeralMessage"] != "follow AO rules" {
+		t.Fatalf("unexpected hook response: %#v", response)
+	}
+}
+
+func TestPreToolUseApprovalRoundTrip(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := &conversation{
+		ctx:         ctx,
+		cancel:      cancel,
+		hookToken:   "secret",
+		events:      make(chan ports.ChatEvent, 4),
+		deferred:    map[string]ports.ChatUserMessage{},
+		approvals:   map[string]chan ports.ChatDecision{},
+		permissions: ports.PermissionModeDefault,
+		active:      &activeTurn{id: "agy-turn-1", permission: ports.PermissionModeDefault},
+	}
+
+	type result struct {
+		response map[string]any
+		err      error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		response, err := c.HandleAgyChatHook(
+			context.Background(),
+			"pre-tool-use",
+			"secret",
+			[]byte(`{"conversationId":"native-123","stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"git status"}}}`),
+			nil,
+		)
+		resultCh <- result{response: response, err: err}
+	}()
+
+	select {
+	case event := <-c.events:
+		if event.Kind != ports.ChatEventApprovalRequested {
+			t.Fatalf("event kind = %q, want approval_requested", event.Kind)
+		}
+		if err := c.ResolveRequest(context.Background(), event.RequestID, ports.ChatDecision{ID: "allow"}); err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("approval event was not emitted")
+	}
+
+	select {
+	case got := <-resultCh:
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		if got.response["decision"] != "allow" {
+			t.Fatalf("decision = %#v, want allow", got.response)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("hook did not resume after approval")
+	}
+}
+
+func TestSendTurnRejectsUnsupportedEffort(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := &conversation{
+		ctx:       ctx,
+		cancel:    cancel,
+		events:    make(chan ports.ChatEvent, 1),
+		deferred:  map[string]ports.ChatUserMessage{},
+		approvals: map[string]chan ports.ChatDecision{},
+	}
+	_, err := c.SendTurn(context.Background(), ports.ChatUserMessage{
+		Text:     "hello",
+		Settings: ports.ChatTurnSettings{Effort: "high"},
+	})
+	if err == nil {
+		t.Fatal("expected reasoning effort to be rejected")
+	}
+}

--- a/backend/internal/adapters/chatdriver/agyjson/driver_test.go
+++ b/backend/internal/adapters/chatdriver/agyjson/driver_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -227,5 +228,50 @@ func TestEmitTurnCompletedReleasesActiveTurnBeforePublishing(t *testing.T) {
 		Text: "next turn",
 	}); err != nil {
 		t.Fatalf("next turn rejected after completion: %v", err)
+	}
+}
+
+func TestSendTurnProviderIDsRemainUniqueAcrossRestart(t *testing.T) {
+	newConversation := func() *conversation {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		return &conversation{
+			ctx:       ctx,
+			cancel:    cancel,
+			events:    make(chan ports.ChatEvent, 4),
+			deferred:  make(map[string]ports.ChatUserMessage),
+			approvals: make(map[string]chan ports.ChatDecision),
+		}
+	}
+
+	beforeRestart := newConversation()
+	first, err := beforeRestart.SendTurn(context.Background(), ports.ChatUserMessage{
+		Text: "before restart",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	afterRestart := newConversation()
+	second, err := afterRestart.SendTurn(context.Background(), ports.ChatUserMessage{
+		Text: "after restart",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first.ProviderTurnID == second.ProviderTurnID {
+		t.Fatalf(
+			"provider turn id reused across conversation restart: %q",
+			first.ProviderTurnID,
+		)
+	}
+
+	if !strings.HasPrefix(first.ProviderTurnID, "agy-turn-") {
+		t.Fatalf("first provider turn id = %q", first.ProviderTurnID)
+	}
+	if !strings.HasPrefix(second.ProviderTurnID, "agy-turn-") {
+		t.Fatalf("second provider turn id = %q", second.ProviderTurnID)
 	}
 }

--- a/backend/internal/adapters/chatdriver/registry/registry.go
+++ b/backend/internal/adapters/chatdriver/registry/registry.go
@@ -10,11 +10,13 @@ package registry
 import (
 	"log/slog"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agy"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimchi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/agyjson"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/claudeacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/codexappserver"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/droidacp"
@@ -48,13 +50,14 @@ func New(drivers ...ports.ChatDriver) *Registry {
 //
 // Codex uses its native app-server protocol. Claude Code uses AO's reusable ACP
 // transport plus claude-agent-acp, pointed at the user's own Claude executable.
-// OpenCode and Droid expose ACP themselves, so AO launches the exact executable
-// resolved by each existing agent plugin. No path scrapes terminal output or
-// packages a second provider CLI.
+// OpenCode and Droid expose ACP themselves. Agy uses its native headless
+// stream-json protocol plus workspace hooks for approvals; its terminal adapter
+// stays untouched and continues to provide the native TUI path.
 //
-// Every other harness stays TUI-only until the same is true of it. The driver
-// reuses the harness's existing agent plugin for binary resolution and auth, so
-// registration adds no second answer to "is this agent installed and logged in".
+// Every other harness stays TUI-only until it exposes a safe structured control
+// surface. Drivers reuse each harness's existing agent plugin for binary
+// resolution and auth, so registration adds no second answer to "is this agent
+// installed and logged in".
 func Build(log *slog.Logger) *Registry {
 	return New(
 		codexappserver.New(codex.New(), log),
@@ -62,6 +65,7 @@ func Build(log *slog.Logger) *Registry {
 		opencodeacp.New(opencode.New(), log),
 		droidacp.New(droid.New(), log),
 		kimchiacp.New(kimchi.New(), log),
+		agyjson.New(agy.New(), log),
 	)
 }
 

--- a/backend/internal/adapters/chatdriver/registry/registry_test.go
+++ b/backend/internal/adapters/chatdriver/registry/registry_test.go
@@ -12,8 +12,8 @@ import (
 //
 // Registration is the whole capability gate — a harness with no driver here cannot
 // run chat mode — so the shipped set is a release decision, not an implementation
-// detail. Codex uses its native app-server; Claude, OpenCode, and Droid use the
-// reusable ACP transport. Every remaining harness is still deliberately TUI-only.
+// detail. Codex uses its native app-server; Claude, OpenCode, Droid, and Kimchi use
+// structured provider protocols; Agy uses its native stream-json headless mode.
 func TestShippedChatDrivers(t *testing.T) {
 	r := Build(nil)
 
@@ -23,6 +23,7 @@ func TestShippedChatDrivers(t *testing.T) {
 		domain.HarnessOpenCode,
 		domain.HarnessDroid,
 		domain.HarnessKimchi,
+		domain.HarnessAgy,
 	} {
 		if !r.SupportsChat(harness) {
 			t.Errorf("%s has no chat driver", harness)

--- a/backend/internal/cli/agy_chat_hook.go
+++ b/backend/internal/cli/agy_chat_hook.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	agyChatHookTokenHeader = "X-AO-Agy-Hook-Token"
+	agyChatHookTokenEnv    = "AO_AGY_CHAT_HOOK_TOKEN"
+	maxAgyChatHookPayload  = 4 << 20
+)
+
+type agyChatHookRequest struct {
+	Payload json.RawMessage `json:"payload"`
+}
+
+func newAgyChatHookCommand(ctx *commandContext) *cobra.Command {
+	return &cobra.Command{
+		Use:    "agy-chat-hook <event>",
+		Short:  "Internal Agy Chat hook bridge",
+		Hidden: true,
+		Args:   usageArgs(cobra.ExactArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			event := strings.TrimSpace(args[0])
+			if event != "pre-invocation" && event != "pre-tool-use" {
+				return usageError{err: fmt.Errorf("unsupported Agy Chat hook event %q", event)}
+			}
+			return runAgyChatHook(cmd, ctx, event)
+		},
+	}
+}
+
+func runAgyChatHook(cmd *cobra.Command, ctx *commandContext, event string) error {
+	payload, err := io.ReadAll(io.LimitReader(cmd.InOrStdin(), maxAgyChatHookPayload+1))
+	if err != nil {
+		return agyChatHookFailure(cmd, event, fmt.Errorf("read hook payload: %w", err))
+	}
+	if len(payload) == 0 || len(payload) > maxAgyChatHookPayload || !json.Valid(payload) {
+		return agyChatHookFailure(cmd, event, fmt.Errorf("hook payload must be valid JSON under %d bytes", maxAgyChatHookPayload))
+	}
+
+	sessionID := strings.TrimSpace(os.Getenv("AO_SESSION_ID"))
+	token := strings.TrimSpace(os.Getenv(agyChatHookTokenEnv))
+	if sessionID == "" || token == "" {
+		return agyChatHookFailure(cmd, event, fmt.Errorf("Agy Chat hook environment is incomplete"))
+	}
+
+	path := "/internal/agy-chat/" + url.PathEscape(sessionID) + "/" + url.PathEscape(event)
+	var response map[string]any
+	err = ctx.doJSONPathWithHeadersAndTimeout(
+		cmd.Context(),
+		http.MethodPost,
+		path,
+		agyChatHookRequest{Payload: json.RawMessage(payload)},
+		&response,
+		map[string]string{agyChatHookTokenHeader: token},
+		61*time.Minute,
+	)
+	if err != nil {
+		return agyChatHookFailure(cmd, event, err)
+	}
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(response)
+}
+
+// PreToolUse must fail closed: Antigravity expects a valid decision object on
+// stdout, and a daemon outage must never turn into implicit permission. For
+// PreInvocation there is no deny-shaped response, so returning the error makes
+// the turn fail rather than silently dropping AO's system instructions.
+func agyChatHookFailure(cmd *cobra.Command, event string, err error) error {
+	if event != "pre-tool-use" {
+		return err
+	}
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+		"decision": "deny",
+		"reason":   "Agent Orchestrator could not validate this tool call: " + err.Error(),
+	})
+}

--- a/backend/internal/cli/agy_completion.go
+++ b/backend/internal/cli/agy_completion.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+const (
+	maxAgyCompletionPromptLen = 2 << 10
+	maxAgyCompletionResultLen = 12 << 10
+)
+
+// relayAgyAfterAgent reports an Agy execution boundary to the project's current
+// orchestrator. This is intentionally keyed to Agy's AfterAgent hook rather than
+// generic worker-idle state: upstream AO deliberately removed idle nudges because
+// idle is not a reliable completion signal. AfterAgent is provider-owned evidence
+// that one Agy execution ended, while the message still tells the orchestrator to
+// verify the requested task independently instead of treating the provider turn as
+// proof of task success.
+func (c *commandContext) relayAgyAfterAgent(
+	ctx context.Context,
+	workerID string,
+	conversation hookConversationSnapshot,
+) error {
+	projectID := strings.TrimSpace(os.Getenv("AO_PROJECT_ID"))
+	if projectID == "" {
+		return nil
+	}
+
+	params := url.Values{}
+	params.Set("project", projectID)
+	params.Set("active", "true")
+	var res sessionListResponse
+	if err := c.getJSON(ctx, apiPath("sessions", params), &res); err != nil {
+		return fmt.Errorf("list project sessions: %w", err)
+	}
+
+	orchestrator, ok := selectAgyCompletionOrchestrator(res.Sessions, workerID)
+	if !ok {
+		return nil
+	}
+
+	message := formatAgyCompletionMessage(workerID, conversation)
+	path := "sessions/" + url.PathEscape(orchestrator.ID) + "/send"
+	if err := c.postJSON(ctx, path, sendAPIRequest{Message: message}, nil); err != nil {
+		return fmt.Errorf("send completion to orchestrator %s: %w", orchestrator.ID, err)
+	}
+	return nil
+}
+
+// selectAgyCompletionOrchestrator resolves a safe current orchestration target.
+// Idle orchestrators are always eligible. An active Codex orchestrator is also
+// eligible because the Codex adapter explicitly supports mid-turn steering.
+// Waiting/blocked/exited sessions are never written to by an automated hook.
+func selectAgyCompletionOrchestrator(sessions []sessionDTO, workerID string) (sessionDTO, bool) {
+	candidates := make([]sessionDTO, 0, 1)
+	for _, session := range sessions {
+		if session.ID == workerID || session.Kind != string(domain.KindOrchestrator) || session.IsTerminated {
+			continue
+		}
+		switch session.Activity.State {
+		case string(domain.ActivityIdle):
+			candidates = append(candidates, session)
+		case string(domain.ActivityActive):
+			if domain.AgentHarness(session.Harness) == domain.HarnessCodex {
+				candidates = append(candidates, session)
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return sessionDTO{}, false
+	}
+
+	// A project normally has one active orchestrator. If stale rows coexist,
+	// prefer the most recently updated one, then ID for deterministic tests.
+	sort.Slice(candidates, func(i, j int) bool {
+		if !candidates[i].UpdatedAt.Equal(candidates[j].UpdatedAt) {
+			return candidates[i].UpdatedAt.After(candidates[j].UpdatedAt)
+		}
+		return candidates[i].ID < candidates[j].ID
+	})
+	return candidates[0], true
+}
+
+func formatAgyCompletionMessage(workerID string, conversation hookConversationSnapshot) string {
+	workerID = domain.SanitizeControlChars(strings.TrimSpace(workerID))
+	prompt := capHookText(conversation.LatestUserPrompt, maxAgyCompletionPromptLen)
+	result := capHookText(conversation.LatestAssistantUpdate, maxAgyCompletionResultLen)
+
+	var msg strings.Builder
+	fmt.Fprintf(&msg, "[AO Agy execution] Worker %s reached its AfterAgent execution boundary.\n", workerID)
+	msg.WriteString("This means the Agy execution ended; it does not prove the requested task succeeded. Verify the worker's repo/PR/tests and decide whether more work is needed.\n")
+	if prompt != "" {
+		fmt.Fprintf(&msg, "\nWorker request:\n%s\n", prompt)
+	}
+	if result != "" {
+		fmt.Fprintf(&msg, "\nWorker final response:\n%s\n", result)
+	} else {
+		msg.WriteString("\nWorker final response: <none reported by Agy>\n")
+	}
+	return msg.String()
+}

--- a/backend/internal/cli/agy_completion.go
+++ b/backend/internal/cli/agy_completion.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -14,20 +15,63 @@ import (
 const (
 	maxAgyCompletionPromptLen = 2 << 10
 	maxAgyCompletionResultLen = 12 << 10
+	maxAgyStopErrorLen        = 4 << 10
 )
 
-// relayAgyAfterAgent reports an Agy execution boundary to the project's current
-// orchestrator. This is intentionally keyed to Agy's AfterAgent hook rather than
-// generic worker-idle state: upstream AO deliberately removed idle nudges because
-// idle is not a reliable completion signal. AfterAgent is provider-owned evidence
-// that one Agy execution ended, while the message still tells the orchestrator to
-// verify the requested task independently instead of treating the provider turn as
-// proof of task success.
-func (c *commandContext) relayAgyAfterAgent(
+type agyStopOutcome struct {
+	ExecutionNum      int
+	TerminationReason string
+	Error             string
+	FullyIdle         *bool
+}
+
+func parseAgyStopOutcome(payload []byte) agyStopOutcome {
+	var native struct {
+		ExecutionNum           int    `json:"executionNum"`
+		ExecutionNumSnake      int    `json:"execution_num"`
+		TerminationReason      string `json:"terminationReason"`
+		TerminationReasonSnake string `json:"termination_reason"`
+		Error                  string `json:"error"`
+		FullyIdle              *bool  `json:"fullyIdle"`
+		FullyIdleSnake         *bool  `json:"fully_idle"`
+	}
+	_ = json.Unmarshal(payload, &native)
+	out := agyStopOutcome{
+		ExecutionNum:      native.ExecutionNum,
+		TerminationReason: strings.TrimSpace(native.TerminationReason),
+		Error:             capHookText(native.Error, maxAgyStopErrorLen),
+		FullyIdle:         native.FullyIdle,
+	}
+	if out.ExecutionNum == 0 {
+		out.ExecutionNum = native.ExecutionNumSnake
+	}
+	if out.TerminationReason == "" {
+		out.TerminationReason = strings.TrimSpace(native.TerminationReasonSnake)
+	}
+	if out.FullyIdle == nil {
+		out.FullyIdle = native.FullyIdleSnake
+	}
+	return out
+}
+
+func (o agyStopOutcome) readyForRelay() bool {
+	return o.FullyIdle == nil || *o.FullyIdle
+}
+
+// relayAgyStop reports the provider-owned Agy Stop execution boundary to the
+// project's current orchestrator. Unlike generic worker-idle state, Stop tells
+// AO why the provider execution ended. The relay deliberately separates that
+// provider outcome from task success: the orchestrator must still verify the
+// repo/PR/tests before deciding whether the requested work is complete.
+func (c *commandContext) relayAgyStop(
 	ctx context.Context,
 	workerID string,
 	conversation hookConversationSnapshot,
+	outcome agyStopOutcome,
 ) error {
+	if !outcome.readyForRelay() {
+		return nil
+	}
 	projectID := strings.TrimSpace(os.Getenv("AO_PROJECT_ID"))
 	if projectID == "" {
 		return nil
@@ -46,7 +90,7 @@ func (c *commandContext) relayAgyAfterAgent(
 		return nil
 	}
 
-	message := formatAgyCompletionMessage(workerID, conversation)
+	message := formatAgyCompletionMessage(workerID, conversation, outcome)
 	path := "sessions/" + url.PathEscape(orchestrator.ID) + "/send"
 	if err := c.postJSON(ctx, path, sendAPIRequest{Message: message}, nil); err != nil {
 		return fmt.Errorf("send completion to orchestrator %s: %w", orchestrator.ID, err)
@@ -57,7 +101,7 @@ func (c *commandContext) relayAgyAfterAgent(
 // selectAgyCompletionOrchestrator resolves a safe current orchestration target.
 // Idle orchestrators are always eligible. An active Codex orchestrator is also
 // eligible because the Codex adapter explicitly supports mid-turn steering.
-// Waiting/blocked/exited sessions are never written to by an automated hook.
+// Waiting/blocked/exited sessions are never selected by this automated hook.
 func selectAgyCompletionOrchestrator(sessions []sessionDTO, workerID string) (sessionDTO, bool) {
 	candidates := make([]sessionDTO, 0, 1)
 	for _, session := range sessions {
@@ -88,21 +132,34 @@ func selectAgyCompletionOrchestrator(sessions []sessionDTO, workerID string) (se
 	return candidates[0], true
 }
 
-func formatAgyCompletionMessage(workerID string, conversation hookConversationSnapshot) string {
+func formatAgyCompletionMessage(workerID string, conversation hookConversationSnapshot, outcome agyStopOutcome) string {
 	workerID = domain.SanitizeControlChars(strings.TrimSpace(workerID))
 	prompt := capHookText(conversation.LatestUserPrompt, maxAgyCompletionPromptLen)
 	result := capHookText(conversation.LatestAssistantUpdate, maxAgyCompletionResultLen)
+	reason := domain.SanitizeControlChars(strings.TrimSpace(outcome.TerminationReason))
 
 	var msg strings.Builder
-	fmt.Fprintf(&msg, "[AO Agy execution] Worker %s reached its AfterAgent execution boundary.\n", workerID)
-	msg.WriteString("This means the Agy execution ended; it does not prove the requested task succeeded. Verify the worker's repo/PR/tests and decide whether more work is needed.\n")
+	fmt.Fprintf(&msg, "[AO Agy execution] Worker %s reached its native Stop execution boundary.\n", workerID)
+	msg.WriteString("This reports the provider execution outcome; it does not prove the requested task succeeded. Verify the worker's repo/PR/tests and decide whether more work is needed.\n")
+	if outcome.ExecutionNum != 0 {
+		fmt.Fprintf(&msg, "\nExecution: %d\n", outcome.ExecutionNum)
+	}
+	if reason != "" {
+		fmt.Fprintf(&msg, "Provider termination: %s\n", reason)
+	}
+	if outcome.Error != "" {
+		fmt.Fprintf(&msg, "Provider error: %s\n", outcome.Error)
+	}
+	if outcome.FullyIdle != nil {
+		fmt.Fprintf(&msg, "Provider fully idle: %t\n", *outcome.FullyIdle)
+	}
 	if prompt != "" {
 		fmt.Fprintf(&msg, "\nWorker request:\n%s\n", prompt)
 	}
 	if result != "" {
 		fmt.Fprintf(&msg, "\nWorker final response:\n%s\n", result)
 	} else {
-		msg.WriteString("\nWorker final response: <none reported by Agy>\n")
+		msg.WriteString("\nWorker final response: <not included in Agy Stop payload; verify durable workspace state>\n")
 	}
 	return msg.String()
 }

--- a/backend/internal/cli/agy_completion_test.go
+++ b/backend/internal/cli/agy_completion_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestSelectAgyCompletionOrchestratorPrefersNewestSafeSession(t *testing.T) {
+	old := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	newer := old.Add(time.Minute)
+	sessions := []sessionDTO{
+		{ID: "worker-1", ProjectID: "mer", Kind: string(domain.KindWorker), Harness: "agy", Activity: sessionActivity{State: string(domain.ActivityIdle)}, UpdatedAt: newer},
+		{ID: "orch-blocked", ProjectID: "mer", Kind: string(domain.KindOrchestrator), Harness: "codex", Activity: sessionActivity{State: string(domain.ActivityBlocked)}, UpdatedAt: newer.Add(time.Minute)},
+		{ID: "orch-old", ProjectID: "mer", Kind: string(domain.KindOrchestrator), Harness: "claude-code", Activity: sessionActivity{State: string(domain.ActivityIdle)}, UpdatedAt: old},
+		{ID: "orch-new", ProjectID: "mer", Kind: string(domain.KindOrchestrator), Harness: "codex", Activity: sessionActivity{State: string(domain.ActivityActive)}, UpdatedAt: newer},
+	}
+
+	got, ok := selectAgyCompletionOrchestrator(sessions, "worker-1")
+	if !ok {
+		t.Fatal("expected a safe orchestrator")
+	}
+	if got.ID != "orch-new" {
+		t.Fatalf("orchestrator = %q, want orch-new", got.ID)
+	}
+}
+
+func TestSelectAgyCompletionOrchestratorRejectsUnsafeActiveHarness(t *testing.T) {
+	sessions := []sessionDTO{{
+		ID: "orch-1", ProjectID: "mer", Kind: string(domain.KindOrchestrator), Harness: "claude-code",
+		Activity: sessionActivity{State: string(domain.ActivityActive)},
+	}}
+	if got, ok := selectAgyCompletionOrchestrator(sessions, "worker-1"); ok {
+		t.Fatalf("unexpected orchestrator %+v", got)
+	}
+}
+
+func TestFormatAgyCompletionMessageSeparatesExecutionFromTaskSuccess(t *testing.T) {
+	msg := formatAgyCompletionMessage("worker-1", hookConversationSnapshot{
+		LatestUserPrompt:      "rebase PR #135",
+		LatestAssistantUpdate: "Rebased and resolved conflicts.",
+	})
+	for _, want := range []string{
+		"Worker worker-1 reached its AfterAgent execution boundary",
+		"does not prove the requested task succeeded",
+		"rebase PR #135",
+		"Rebased and resolved conflicts.",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestHooksAgyAfterAgentRelaysFinalResultToCodexOrchestrator(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "worker-1")
+	t.Setenv("AO_PROJECT_ID", "mer")
+	t.Setenv("AO_RUNTIME_LAUNCH_ID", "launch-1")
+	cfg := setConfigEnv(t)
+
+	var (
+		mu              sync.Mutex
+		activityRequest setActivityAPIRequest
+		relayRequest    sendAPIRequest
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/worker-1/activity":
+			if err := json.NewDecoder(r.Body).Decode(&activityRequest); err != nil {
+				t.Errorf("decode activity request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions":
+			if got := r.URL.Query().Get("project"); got != "mer" {
+				t.Errorf("project query = %q, want mer", got)
+			}
+			if got := r.URL.Query().Get("active"); got != "true" {
+				t.Errorf("active query = %q, want true", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"sessions":[{"id":"orch-1","projectId":"mer","kind":"orchestrator","harness":"codex","activity":{"state":"active","lastActivityAt":"2026-08-14T11:00:00Z"},"isTerminated":false,"createdAt":"2026-08-14T10:00:00Z","updatedAt":"2026-08-14T11:00:00Z","status":"active"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/orch-1/send":
+			mu.Lock()
+			defer mu.Unlock()
+			if err := json.NewDecoder(r.Body).Decode(&relayRequest); err != nil {
+				t.Errorf("decode relay request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	writeRunFileFor(t, cfg, srv)
+
+	payload := `{"session_id":"agy-native-1","prompt":"rebase PR #135","prompt_response":"Rebased and resolved conflicts."}`
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(payload),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "agy", "after-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if activityRequest.State != "idle" || activityRequest.LatestAssistantUpdate != "Rebased and resolved conflicts." {
+		t.Fatalf("activity request = %+v", activityRequest)
+	}
+	mu.Lock()
+	gotRelay := relayRequest.Message
+	mu.Unlock()
+	if !strings.Contains(gotRelay, "Worker worker-1 reached its AfterAgent execution boundary") {
+		t.Fatalf("relay = %q", gotRelay)
+	}
+	if !strings.Contains(gotRelay, "Rebased and resolved conflicts.") {
+		t.Fatalf("relay missing final result: %q", gotRelay)
+	}
+}

--- a/backend/internal/cli/agy_completion_test.go
+++ b/backend/internal/cli/agy_completion_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,16 +42,50 @@ func TestSelectAgyCompletionOrchestratorRejectsUnsafeActiveHarness(t *testing.T)
 	}
 }
 
-func TestFormatAgyCompletionMessageSeparatesExecutionFromTaskSuccess(t *testing.T) {
-	msg := formatAgyCompletionMessage("worker-1", hookConversationSnapshot{
-		LatestUserPrompt:      "rebase PR #135",
-		LatestAssistantUpdate: "Rebased and resolved conflicts.",
+func TestParseAgyStopOutcome(t *testing.T) {
+	outcome := parseAgyStopOutcome([]byte(`{
+		"executionNum": 4,
+		"terminationReason": "error",
+		"error": "Out of credits",
+		"fullyIdle": true
+	}`))
+	if outcome.ExecutionNum != 4 || outcome.TerminationReason != "error" || outcome.Error != "Out of credits" {
+		t.Fatalf("unexpected outcome: %+v", outcome)
+	}
+	if outcome.FullyIdle == nil || !*outcome.FullyIdle {
+		t.Fatalf("fullyIdle = %v, want true", outcome.FullyIdle)
+	}
+	if !outcome.readyForRelay() {
+		t.Fatal("fully-idle Stop should be relayed")
+	}
+}
+
+func TestParseAgyStopOutcomeBackgroundWorkIsNotReadyForRelay(t *testing.T) {
+	outcome := parseAgyStopOutcome([]byte(`{"terminationReason":"model_stop","fullyIdle":false}`))
+	if outcome.FullyIdle == nil || *outcome.FullyIdle {
+		t.Fatalf("fullyIdle = %v, want false", outcome.FullyIdle)
+	}
+	if outcome.readyForRelay() {
+		t.Fatal("Stop with active background work must not be relayed")
+	}
+}
+
+func TestFormatAgyCompletionMessageSeparatesProviderOutcomeFromTaskSuccess(t *testing.T) {
+	fullyIdle := true
+	msg := formatAgyCompletionMessage("worker-1", hookConversationSnapshot{}, agyStopOutcome{
+		ExecutionNum:      2,
+		TerminationReason: "error",
+		Error:             "Out of credits",
+		FullyIdle:         &fullyIdle,
 	})
 	for _, want := range []string{
-		"Worker worker-1 reached its AfterAgent execution boundary",
+		"Worker worker-1 reached its native Stop execution boundary",
 		"does not prove the requested task succeeded",
-		"rebase PR #135",
-		"Rebased and resolved conflicts.",
+		"Execution: 2",
+		"Provider termination: error",
+		"Provider error: Out of credits",
+		"Provider fully idle: true",
+		"verify durable workspace state",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("message %q does not contain %q", msg, want)
@@ -58,7 +93,7 @@ func TestFormatAgyCompletionMessageSeparatesExecutionFromTaskSuccess(t *testing.
 	}
 }
 
-func TestHooksAgyAfterAgentRelaysFinalResultToCodexOrchestrator(t *testing.T) {
+func TestHooksAgyStopRelaysProviderFailureToCodexOrchestrator(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "worker-1")
 	t.Setenv("AO_PROJECT_ID", "mer")
 	t.Setenv("AO_RUNTIME_LAUNCH_ID", "launch-1")
@@ -101,25 +136,87 @@ func TestHooksAgyAfterAgentRelaysFinalResultToCodexOrchestrator(t *testing.T) {
 	defer srv.Close()
 	writeRunFileFor(t, cfg, srv)
 
-	payload := `{"session_id":"agy-native-1","prompt":"rebase PR #135","prompt_response":"Rebased and resolved conflicts."}`
-	_, _, err := executeCLI(t, Deps{
+	payload := `{
+		"conversationId":"agy-native-1",
+		"transcriptPath":"/tmp/agy-transcript.jsonl",
+		"executionNum":2,
+		"terminationReason":"error",
+		"error":"Out of credits",
+		"fullyIdle":true
+	}`
+	out, _, err := executeCLI(t, Deps{
 		In:           strings.NewReader(payload),
 		ProcessAlive: func(int) bool { return true },
-	}, "hooks", "agy", "after-agent")
+	}, "hooks", "agy", "stop")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if activityRequest.State != "idle" || activityRequest.LatestAssistantUpdate != "Rebased and resolved conflicts." {
+	if activityRequest.State != "idle" || activityRequest.Event != "stop" {
 		t.Fatalf("activity request = %+v", activityRequest)
+	}
+	if activityRequest.AgentSessionID != "agy-native-1" || activityRequest.TranscriptPath != "/tmp/agy-transcript.jsonl" {
+		t.Fatalf("native metadata = %+v", activityRequest)
 	}
 	mu.Lock()
 	gotRelay := relayRequest.Message
 	mu.Unlock()
-	if !strings.Contains(gotRelay, "Worker worker-1 reached its AfterAgent execution boundary") {
-		t.Fatalf("relay = %q", gotRelay)
+	for _, want := range []string{
+		"Worker worker-1 reached its native Stop execution boundary",
+		"Provider termination: error",
+		"Provider error: Out of credits",
+	} {
+		if !strings.Contains(gotRelay, want) {
+			t.Fatalf("relay %q does not contain %q", gotRelay, want)
+		}
 	}
-	if !strings.Contains(gotRelay, "Rebased and resolved conflicts.") {
-		t.Fatalf("relay missing final result: %q", gotRelay)
+
+	var hookOutput agyStopHookOutput
+	if err := json.Unmarshal([]byte(out), &hookOutput); err != nil {
+		t.Fatalf("decode Stop hook stdout %q: %v", out, err)
+	}
+	if hookOutput.Decision != "allow" {
+		t.Fatalf("Stop decision = %q, want allow", hookOutput.Decision)
+	}
+}
+
+func TestHooksAgyStopWithBackgroundWorkDoesNotRelay(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "worker-1")
+	t.Setenv("AO_PROJECT_ID", "mer")
+	t.Setenv("AO_RUNTIME_LAUNCH_ID", "launch-1")
+	cfg := setConfigEnv(t)
+
+	var listCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/worker-1/activity":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions":
+			listCalls.Add(1)
+			http.Error(w, "relay should not run", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	writeRunFileFor(t, cfg, srv)
+
+	out, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"conversationId":"agy-native-1","terminationReason":"model_stop","fullyIdle":false}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "agy", "stop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listCalls.Load() != 0 {
+		t.Fatalf("project session list calls = %d, want 0", listCalls.Load())
+	}
+	var hookOutput agyStopHookOutput
+	if err := json.Unmarshal([]byte(out), &hookOutput); err != nil {
+		t.Fatalf("decode Stop hook stdout %q: %v", out, err)
+	}
+	if hookOutput.Decision != "allow" {
+		t.Fatalf("Stop decision = %q, want allow", hookOutput.Decision)
 	}
 }

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -243,6 +243,18 @@ type sessionStartHookOutput struct {
 	} `json:"hookSpecificOutput"`
 }
 
+type agyPreInvocationHookOutput struct {
+	InjectSteps []agyInjectedStep `json:"injectSteps,omitempty"`
+}
+
+type agyInjectedStep struct {
+	EphemeralMessage string `json:"ephemeralMessage"`
+}
+
+type agyStopHookOutput struct {
+	Decision string `json:"decision"`
+}
+
 // newHooksCommand builds the hidden `ao hooks <agent> <event>` command that
 // agent CLIs invoke from their workspace-local hook config. It reads the native
 // hook payload from stdin and the AO session id from AO_SESSION_ID, derives an
@@ -284,6 +296,12 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 		// the empty payload and exit 0: a failed hook must not break the
 		// agent. The deriver tolerates an empty payload.
 		c.reportHookFailure(agent, event, sessionID, fmt.Errorf("read stdin: %w", err))
+	}
+	if domain.AgentHarness(agent) == domain.HarnessAgy {
+		// Antigravity consumes event-specific JSON from stdout. Defer the reply
+		// so activity/relay failures remain best-effort while the provider still
+		// receives a syntactically valid native hook response.
+		defer c.emitAgyNativeHookResponse(agent, event, sessionID, payload)
 	}
 	if shouldEmitSessionStartContext(agent, event) {
 		c.emitSessionStartContext(agent, event, sessionID)
@@ -328,8 +346,9 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 		c.reportHookFailure(agent, event, sessionID, err)
 		return nil
 	}
-	if domain.AgentHarness(agent) == domain.HarnessAgy && event == "after-agent" {
-		if err := c.relayAgyAfterAgent(ctx, sessionID, conversation); err != nil {
+	if domain.AgentHarness(agent) == domain.HarnessAgy && event == "stop" {
+		outcome := parseAgyStopOutcome(payload)
+		if err := c.relayAgyStop(ctx, sessionID, conversation, outcome); err != nil {
 			c.reportHookFailure(agent, event, sessionID, fmt.Errorf("relay execution result: %w", err))
 		}
 	}
@@ -405,6 +424,54 @@ func (c *commandContext) emitSessionStartContext(agent, event, sessionID string)
 	if err := json.NewEncoder(c.deps.Out).Encode(out); err != nil {
 		c.reportHookFailure(agent, event, sessionID, fmt.Errorf("write session-start context: %w", err))
 	}
+}
+
+// emitAgyNativeHookResponse satisfies Antigravity's current workspace-hook
+// stdout contract. PreInvocation injects AO's standing system prompt only on the
+// first model invocation; later invocations return an empty object so the large
+// prompt is not duplicated into provider context. Stop explicitly allows the
+// provider to terminate — AO observes the outcome but never forces a retry from
+// inside this hook.
+func (c *commandContext) emitAgyNativeHookResponse(agent, event, sessionID string, payload []byte) {
+	var out any = struct{}{}
+	switch event {
+	case "pre-invocation":
+		response := agyPreInvocationHookOutput{}
+		var native struct {
+			InvocationNum      *int `json:"invocationNum"`
+			InvocationNumSnake *int `json:"invocation_num"`
+		}
+		_ = json.Unmarshal(payload, &native)
+		invocationNum := native.InvocationNum
+		if invocationNum == nil {
+			invocationNum = native.InvocationNumSnake
+		}
+		if invocationNum != nil && *invocationNum == 0 {
+			dataDir := strings.TrimSpace(os.Getenv("AO_DATA_DIR"))
+			if dataDir != "" {
+				path := filepath.Join(dataDir, "prompts", sessionID, "system.md")
+				data, err := os.ReadFile(path) //nolint:gosec // sessionID is bounded by sessionIDPattern.
+				switch {
+				case err == nil && strings.TrimSpace(string(data)) != "":
+					response.InjectSteps = []agyInjectedStep{{EphemeralMessage: strings.TrimSpace(string(data))}}
+				case err != nil && !errorsIsNotExist(err):
+					c.reportHookFailure(agent, event, sessionID, fmt.Errorf("read system prompt: %w", err))
+				}
+			}
+		}
+		out = response
+	case "stop":
+		out = agyStopHookOutput{Decision: "allow"}
+	case "post-tool-use":
+		out = struct{}{}
+	}
+	if err := json.NewEncoder(c.deps.Out).Encode(out); err != nil {
+		c.reportHookFailure(agent, event, sessionID, fmt.Errorf("write native hook response: %w", err))
+	}
+}
+
+func errorsIsNotExist(err error) bool {
+	return os.IsNotExist(err)
 }
 
 // reportHookFailure surfaces a hook delivery failure without breaking the

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -326,6 +326,12 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 		// Surface the failure for diagnosis, but exit 0: a failed activity
 		// report must not disrupt the agent.
 		c.reportHookFailure(agent, event, sessionID, err)
+		return nil
+	}
+	if domain.AgentHarness(agent) == domain.HarnessAgy && event == "after-agent" {
+		if err := c.relayAgyAfterAgent(ctx, sessionID, conversation); err != nil {
+			c.reportHookFailure(agent, event, sessionID, fmt.Errorf("relay execution result: %w", err))
+		}
 	}
 	return nil
 }

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -175,12 +175,21 @@ func hookConversationFacts(payload []byte) hookConversationSnapshot {
 		LastAssistantMessageCamel string `json:"lastAssistantMessage"`
 		AssistantMessage          string `json:"assistant_message"`
 		AssistantMessageCamel     string `json:"assistantMessage"`
+		PromptResponse            string `json:"prompt_response"`
+		PromptResponseCamel       string `json:"promptResponse"`
 		TranscriptPath            string `json:"transcript_path"`
 		TranscriptPathCamel       string `json:"transcriptPath"`
 	}
 	_ = json.Unmarshal(payload, &p)
 	userPrompt := firstHookValue(p.Prompt, p.UserPrompt, p.UserPromptCamel)
-	assistant := firstHookValue(p.LastAssistantMessage, p.LastAssistantMessageCamel, p.AssistantMessage, p.AssistantMessageCamel)
+	assistant := firstHookValue(
+		p.LastAssistantMessage,
+		p.LastAssistantMessageCamel,
+		p.AssistantMessage,
+		p.AssistantMessageCamel,
+		p.PromptResponse,
+		p.PromptResponseCamel,
+	)
 	// AO's own handoff request and continuation kickoff are coordination turns,
 	// not the latest real user instruction. They remain in provider history but
 	// must not overwrite deterministic user intent.
@@ -295,7 +304,7 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 	toolName, toolUseID := activityMeta(payload)
 	conversation := hookConversationSnapshot{}
 	switch domain.AgentHarness(agent) {
-	case domain.HarnessClaudeCode, domain.HarnessCodex:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessAgy:
 		conversation = hookConversationFacts(payload)
 	}
 	path := "sessions/" + url.PathEscape(sessionID) + "/activity"

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -431,9 +431,10 @@ func (c *commandContext) emitSessionStartContext(agent, event, sessionID string)
 // first model invocation; later invocations return an empty object so the large
 // prompt is not duplicated into provider context. Stop explicitly allows the
 // provider to terminate — AO observes the outcome but never forces a retry from
-// inside this hook.
+// inside this hook. Legacy hook events return without writing so they cannot
+// append a second JSON document to older SessionStart-compatible responses.
 func (c *commandContext) emitAgyNativeHookResponse(agent, event, sessionID string, payload []byte) {
-	var out any = struct{}{}
+	var out any
 	switch event {
 	case "pre-invocation":
 		response := agyPreInvocationHookOutput{}
@@ -464,6 +465,8 @@ func (c *commandContext) emitAgyNativeHookResponse(agent, event, sessionID strin
 		out = agyStopHookOutput{Decision: "allow"}
 	case "post-tool-use":
 		out = struct{}{}
+	default:
+		return
 	}
 	if err := json.NewEncoder(c.deps.Out).Encode(out); err != nil {
 		c.reportHookFailure(agent, event, sessionID, fmt.Errorf("write native hook response: %w", err))

--- a/backend/internal/cli/hooks_agy_test.go
+++ b/backend/internal/cli/hooks_agy_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHooks_AgyAfterAgentReportsConversationFacts(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	t.Setenv("AO_RUNTIME_LAUNCH_ID", "launch-3")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	payload := `{
+		"session_id":"agy-native-1",
+		"prompt":"rebase PR #135 and resolve the conflicts",
+		"prompt_response":"Rebased the branch and resolved the conflicts."
+	}`
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(payload),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "agy", "after-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.State != "idle" || req.Event != "after-agent" {
+		t.Fatalf("activity = state %q event %q, want idle/after-agent", req.State, req.Event)
+	}
+	if req.AgentSessionID != "agy-native-1" {
+		t.Fatalf("agent session id = %q, want agy-native-1", req.AgentSessionID)
+	}
+	if req.LatestUserPrompt != "rebase PR #135 and resolve the conflicts" {
+		t.Fatalf("latest user prompt = %q", req.LatestUserPrompt)
+	}
+	if req.LatestAssistantUpdate != "Rebased the branch and resolved the conflicts." {
+		t.Fatalf("latest assistant update = %q", req.LatestAssistantUpdate)
+	}
+	if req.LaunchID != "launch-3" {
+		t.Fatalf("launch id = %q, want launch-3", req.LaunchID)
+	}
+}

--- a/backend/internal/cli/hooks_agy_test.go
+++ b/backend/internal/cli/hooks_agy_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestHooks_AgyAfterAgentReportsConversationFacts(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
+	t.Setenv("AO_PROJECT_ID", "")
 	t.Setenv("AO_RUNTIME_LAUNCH_ID", "launch-3")
 	cfg := setConfigEnv(t)
 	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)

--- a/backend/internal/cli/hooks_agy_test.go
+++ b/backend/internal/cli/hooks_agy_test.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestHooks_AgyAfterAgentReportsConversationFacts(t *testing.T) {
+func TestHooks_AgyStopReportsNativeFacts(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	t.Setenv("AO_PROJECT_ID", "")
 	t.Setenv("AO_RUNTIME_LAUNCH_ID", "launch-3")
@@ -16,14 +18,17 @@ func TestHooks_AgyAfterAgentReportsConversationFacts(t *testing.T) {
 	writeRunFileFor(t, cfg, srv)
 
 	payload := `{
-		"session_id":"agy-native-1",
-		"prompt":"rebase PR #135 and resolve the conflicts",
-		"prompt_response":"Rebased the branch and resolved the conflicts."
+		"conversationId":"agy-native-1",
+		"transcriptPath":"/tmp/agy-transcript.jsonl",
+		"executionNum":1,
+		"terminationReason":"model_stop",
+		"error":"",
+		"fullyIdle":true
 	}`
-	_, _, err := executeCLI(t, Deps{
+	out, _, err := executeCLI(t, Deps{
 		In:           strings.NewReader(payload),
 		ProcessAlive: func(int) bool { return true },
-	}, "hooks", "agy", "after-agent")
+	}, "hooks", "agy", "stop")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,19 +37,106 @@ func TestHooks_AgyAfterAgentReportsConversationFacts(t *testing.T) {
 	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
 		t.Fatal(err)
 	}
-	if req.State != "idle" || req.Event != "after-agent" {
-		t.Fatalf("activity = state %q event %q, want idle/after-agent", req.State, req.Event)
+	if req.State != "idle" || req.Event != "stop" {
+		t.Fatalf("activity = state %q event %q, want idle/stop", req.State, req.Event)
 	}
 	if req.AgentSessionID != "agy-native-1" {
 		t.Fatalf("agent session id = %q, want agy-native-1", req.AgentSessionID)
 	}
-	if req.LatestUserPrompt != "rebase PR #135 and resolve the conflicts" {
-		t.Fatalf("latest user prompt = %q", req.LatestUserPrompt)
-	}
-	if req.LatestAssistantUpdate != "Rebased the branch and resolved the conflicts." {
-		t.Fatalf("latest assistant update = %q", req.LatestAssistantUpdate)
+	if req.TranscriptPath != "/tmp/agy-transcript.jsonl" {
+		t.Fatalf("transcript path = %q", req.TranscriptPath)
 	}
 	if req.LaunchID != "launch-3" {
 		t.Fatalf("launch id = %q, want launch-3", req.LaunchID)
+	}
+
+	var response agyStopHookOutput
+	if err := json.Unmarshal([]byte(out), &response); err != nil {
+		t.Fatalf("decode Stop hook stdout %q: %v", out, err)
+	}
+	if response.Decision != "allow" {
+		t.Fatalf("Stop decision = %q, want allow", response.Decision)
+	}
+}
+
+func TestHooks_AgyPreInvocationReportsActiveAndInjectsSystemPrompt(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	t.Setenv("AO_PROJECT_ID", "")
+	t.Setenv("AO_RUNTIME_LAUNCH_ID", "launch-3")
+	cfg := setConfigEnv(t)
+
+	promptDir := filepath.Join(cfg.dataDir, "prompts", "ao-7")
+	if err := os.MkdirAll(promptDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "system.md"), []byte("AO SYSTEM RULE"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+	payload := `{
+		"conversationId":"agy-native-1",
+		"transcriptPath":"/tmp/agy-transcript.jsonl",
+		"invocationNum":0
+	}`
+	out, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(payload),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "agy", "pre-invocation")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.State != "active" || req.Event != "pre-invocation" {
+		t.Fatalf("activity = state %q event %q, want active/pre-invocation", req.State, req.Event)
+	}
+	if req.AgentSessionID != "agy-native-1" || req.TranscriptPath != "/tmp/agy-transcript.jsonl" {
+		t.Fatalf("native metadata = %+v", req)
+	}
+
+	var response agyPreInvocationHookOutput
+	if err := json.Unmarshal([]byte(out), &response); err != nil {
+		t.Fatalf("decode PreInvocation stdout %q: %v", out, err)
+	}
+	if len(response.InjectSteps) != 1 || response.InjectSteps[0].EphemeralMessage != "AO SYSTEM RULE" {
+		t.Fatalf("injectSteps = %#v", response.InjectSteps)
+	}
+}
+
+func TestHooks_AgyLaterPreInvocationDoesNotDuplicateSystemPrompt(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	t.Setenv("AO_PROJECT_ID", "")
+	t.Setenv("AO_RUNTIME_LAUNCH_ID", "launch-3")
+	cfg := setConfigEnv(t)
+
+	promptDir := filepath.Join(cfg.dataDir, "prompts", "ao-7")
+	if err := os.MkdirAll(promptDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "system.md"), []byte("AO SYSTEM RULE"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, _ := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+	out, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"conversationId":"agy-native-1","invocationNum":1}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "agy", "pre-invocation")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var response agyPreInvocationHookOutput
+	if err := json.Unmarshal([]byte(out), &response); err != nil {
+		t.Fatalf("decode PreInvocation stdout %q: %v", out, err)
+	}
+	if len(response.InjectSteps) != 0 {
+		t.Fatalf("later invocation duplicated standing prompt: %#v", response.InjectSteps)
 	}
 }

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -198,6 +198,7 @@ func NewRootCommand(deps Deps) *cobra.Command {
 	root.AddCommand(newPreviewCommand(ctx))
 	root.AddCommand(newBrowserCommand(ctx))
 	root.AddCommand(newHooksCommand(ctx))
+	root.AddCommand(newAgyChatHookCommand(ctx))
 	root.AddCommand(newAgentProcessCommand(ctx))
 	root.AddCommand(newLaunchCommand(ctx))
 	root.AddCommand(newPtyHostCommand())
@@ -228,7 +229,7 @@ func shouldEmitCLIInvocation(cmd *cobra.Command) bool {
 	// "ao completion"/"ao help" are shell setup and self-documentation.
 	// "ao pty-host" and "ao agent-process" are internal runtime processes.
 	// None reflect user activity.
-	case "ao daemon", "ao start", "ao completion", "ao help", "ao pty-host", "ao agent-process", "ao agent-process supervise":
+	case "ao daemon", "ao start", "ao completion", "ao help", "ao pty-host", "ao agent-process", "ao agent-process supervise", "ao agy-chat-hook":
 		return false
 	default:
 		return true

--- a/backend/internal/httpd/agy_chat_hooks.go
+++ b/backend/internal/httpd/agy_chat_hooks.go
@@ -1,0 +1,84 @@
+package httpd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+)
+
+const (
+	agyChatHookTokenHeader = "X-AO-Agy-Hook-Token"
+	maxAgyChatHookBody     = 4 << 20
+)
+
+type agyChatHookService interface {
+	HandleAgyChatHook(
+		ctx context.Context,
+		sessionID domain.SessionID,
+		event string,
+		token string,
+		payload []byte,
+	) (map[string]any, error)
+}
+
+type agyChatHookRequest struct {
+	Payload json.RawMessage `json:"payload"`
+}
+
+// mountAgyChatHooks installs the long-lived loopback callback used by
+// Antigravity's blocking PreToolUse hook. It stays outside the bounded REST
+// timeout group because a legitimate approval may wait on a person for minutes.
+func mountAgyChatHooks(r chi.Router, conversations *controllers.ConversationsController) {
+	if conversations == nil || conversations.Svc == nil {
+		return
+	}
+	svc, ok := conversations.Svc.(agyChatHookService)
+	if !ok {
+		return
+	}
+
+	r.Post("/internal/agy-chat/{sessionId}/{event}", func(w http.ResponseWriter, req *http.Request) {
+		if !localControlRequest(req) {
+			envelope.WriteAPIError(w, req, http.StatusForbidden, "forbidden", "LOCAL_CONTROL_REQUIRED", "Agy Chat hooks are loopback-only", nil)
+			return
+		}
+		event := strings.TrimSpace(chi.URLParam(req, "event"))
+		if event != "pre-invocation" && event != "pre-tool-use" {
+			envelope.WriteAPIError(w, req, http.StatusNotFound, "not_found", "AGY_CHAT_HOOK_UNKNOWN", "unknown Agy Chat hook event", nil)
+			return
+		}
+		if strings.TrimSpace(req.Header.Get(agyChatHookTokenHeader)) == "" {
+			envelope.WriteAPIError(w, req, http.StatusForbidden, "forbidden", "AGY_CHAT_HOOK_TOKEN_REQUIRED", "Agy Chat hook token is required", nil)
+			return
+		}
+
+		req.Body = http.MaxBytesReader(w, req.Body, maxAgyChatHookBody)
+		var body agyChatHookRequest
+		dec := json.NewDecoder(req.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&body); err != nil || len(body.Payload) == 0 {
+			envelope.WriteAPIError(w, req, http.StatusBadRequest, "bad_request", "INVALID_JSON", "request body must contain an Agy hook payload", nil)
+			return
+		}
+
+		response, err := svc.HandleAgyChatHook(
+			req.Context(),
+			domain.SessionID(chi.URLParam(req, "sessionId")),
+			event,
+			req.Header.Get(agyChatHookTokenHeader),
+			body.Payload,
+		)
+		if err != nil {
+			envelope.WriteAPIError(w, req, http.StatusConflict, "conflict", "AGY_CHAT_HOOK_REJECTED", "Agy Chat hook was rejected", nil)
+			return
+		}
+		envelope.WriteJSON(w, http.StatusOK, response)
+	})
+}

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -68,6 +68,7 @@ func NewRouterWithControl(cfg config.Config, log *slog.Logger, termMgr *terminal
 	mountTelemetry(r, cfg, deps.Telemetry)
 	mountMobile(r, deps.Mobile)
 	mountMobileDevices(r, &controllers.MobileDevicesController{Registry: deps.DeviceRoster, Presence: deps.DeviceLive})
+	mountAgyChatHooks(r, api.conversations)
 	api.Register(r)
 
 	return r

--- a/backend/internal/service/chat/agy_hooks.go
+++ b/backend/internal/service/chat/agy_hooks.go
@@ -1,0 +1,80 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// agyChatHookConversation is intentionally private to the Chat service. Agy's
+// hook bridge is an adapter detail, not part of the provider-neutral Chat port.
+type agyChatHookConversation interface {
+	HandleAgyChatHook(
+		ctx context.Context,
+		event string,
+		token string,
+		payload []byte,
+		onProviderID func(string) error,
+	) (map[string]any, error)
+}
+
+// lateProviderConversationStore is optional so the broad Chat Store interface
+// and its focused test doubles do not gain an Agy-specific persistence method.
+type lateProviderConversationStore interface {
+	RecordLateChatProviderConversationID(
+		ctx context.Context,
+		sessionID domain.SessionID,
+		conversationID string,
+		branchID string,
+		generation string,
+		providerConversationID string,
+		now time.Time,
+	) error
+}
+
+// HandleAgyChatHook serves the blocking Antigravity workspace hooks used by the
+// Agy Chat driver. The driver authenticates the per-controller token before it
+// invokes onProviderID; persistence therefore cannot be mutated by an unrelated
+// local request that merely knows a session id.
+func (s *Service) HandleAgyChatHook(
+	ctx context.Context,
+	id domain.SessionID,
+	event string,
+	token string,
+	payload []byte,
+) (map[string]any, error) {
+	if _, err := s.requireChatSession(ctx, id); err != nil {
+		return nil, err
+	}
+	controller, err := s.Controller(id)
+	if err != nil {
+		return nil, err
+	}
+	target, ok := controller.conv.(agyChatHookConversation)
+	if !ok {
+		return nil, fmt.Errorf("Agy Chat hooks: controller does not support the hook bridge")
+	}
+	writer, ok := s.store.(lateProviderConversationStore)
+	if !ok {
+		return nil, fmt.Errorf("Agy Chat hooks: store cannot persist a late provider conversation id")
+	}
+
+	return target.HandleAgyChatHook(ctx, event, token, payload, func(providerID string) error {
+		providerID = strings.TrimSpace(providerID)
+		if providerID == "" {
+			return fmt.Errorf("Agy Chat hooks: provider conversation id is empty")
+		}
+		return writer.RecordLateChatProviderConversationID(
+			ctx,
+			id,
+			controller.conversation.ID,
+			controller.conversation.ActiveBranchID,
+			controller.generation,
+			providerID,
+			s.now(),
+		)
+	})
+}

--- a/backend/internal/storage/sqlite/store/chat_provider_id.go
+++ b/backend/internal/storage/sqlite/store/chat_provider_id.go
@@ -1,0 +1,120 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// RecordLateChatProviderConversationID persists a native thread id discovered
+// after a Chat controller has already been committed. Agy allocates the id only
+// once its first headless turn starts, so Start cannot return it synchronously.
+//
+// The controller generation fences a stale hook from an older controller. Both
+// the live session row and its active branch are updated in one transaction so a
+// daemon restart and a future branch read cannot disagree about native identity.
+func (s *Store) RecordLateChatProviderConversationID(
+	ctx context.Context,
+	sessionID domain.SessionID,
+	conversationID string,
+	branchID string,
+	generation string,
+	providerConversationID string,
+	now time.Time,
+) error {
+	providerConversationID = strings.TrimSpace(providerConversationID)
+	if providerConversationID == "" {
+		return fmt.Errorf("record late chat provider id: provider conversation id is required")
+	}
+	if strings.TrimSpace(generation) == "" {
+		return fmt.Errorf("record late chat provider id: controller generation is required")
+	}
+	if strings.TrimSpace(conversationID) == "" || strings.TrimSpace(branchID) == "" {
+		return fmt.Errorf("record late chat provider id: conversation and branch are required")
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("record late chat provider id: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var current string
+	err = tx.QueryRowContext(ctx, `
+SELECT provider_conversation_id
+FROM sessions
+WHERE id = ?
+  AND session_mode = 'chat'
+  AND is_terminated = 0
+  AND controller_generation = ?
+LIMIT 1`, string(sessionID), generation).Scan(&current)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("record late chat provider id: live controller generation no longer owns session %s", sessionID)
+		}
+		return fmt.Errorf("record late chat provider id: read session: %w", err)
+	}
+	if current != "" && current != providerConversationID {
+		return fmt.Errorf("record late chat provider id: session %s already belongs to native conversation %s", sessionID, current)
+	}
+	if current == "" {
+		result, execErr := tx.ExecContext(ctx, `
+UPDATE sessions
+SET provider_conversation_id = ?, updated_at = ?
+WHERE id = ?
+  AND session_mode = 'chat'
+  AND is_terminated = 0
+  AND controller_generation = ?
+  AND provider_conversation_id = ''`,
+			providerConversationID, now, string(sessionID), generation)
+		if execErr != nil {
+			return fmt.Errorf("record late chat provider id: update session: %w", execErr)
+		}
+		rows, rowsErr := result.RowsAffected()
+		if rowsErr != nil || rows != 1 {
+			return fmt.Errorf("record late chat provider id: session ownership changed during update")
+		}
+	}
+
+	var branchCurrent string
+	err = tx.QueryRowContext(ctx, `
+SELECT provider_conversation_id
+FROM conversation_branches
+WHERE id = ? AND conversation_id = ?
+LIMIT 1`, branchID, conversationID).Scan(&branchCurrent)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("record late chat provider id: active conversation branch no longer exists")
+		}
+		return fmt.Errorf("record late chat provider id: read branch: %w", err)
+	}
+	if branchCurrent != "" && branchCurrent != providerConversationID {
+		return fmt.Errorf("record late chat provider id: branch %s already belongs to native conversation %s", branchID, branchCurrent)
+	}
+	if branchCurrent == "" {
+		result, execErr := tx.ExecContext(ctx, `
+UPDATE conversation_branches
+SET provider_conversation_id = ?
+WHERE id = ? AND conversation_id = ? AND provider_conversation_id = ''`,
+			providerConversationID, branchID, conversationID)
+		if execErr != nil {
+			return fmt.Errorf("record late chat provider id: update branch: %w", execErr)
+		}
+		rows, rowsErr := result.RowsAffected()
+		if rowsErr != nil || rows != 1 {
+			return fmt.Errorf("record late chat provider id: branch ownership changed during update")
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("record late chat provider id: commit: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/telemetrymeta/cli.go
+++ b/backend/internal/telemetrymeta/cli.go
@@ -30,6 +30,7 @@ var routineInternalCLICommands = []string{
 	"ao project get",
 	"ao orchestrator ls",
 	"ao hooks",
+	"ao agy-chat-hook",
 	"ao pty-host",
 }
 

--- a/backend/internal/telemetrymeta/cli_test.go
+++ b/backend/internal/telemetrymeta/cli_test.go
@@ -14,6 +14,7 @@ func TestIsRoutineInternalCLICommandNormalizesLegacyShapes(t *testing.T) {
 		"ao  hooks",
 		"AO HOOKS",
 		"ao hooks claude-code post-tool-use",
+		"ao agy-chat-hook pre-tool-use",
 		"ao session get sess-123",
 		"ao session agent-switch ls sess-123",
 		"ao session handoff submit --switch switch-1",


### PR DESCRIPTION
## Summary

Add native Chat mode support for Agy / Antigravity using its structured
`stream-json` print interface.

The existing Agy terminal adapter remains unchanged. This adds a separate Chat
driver that streams structured provider events into AO's durable conversation
model.

## What changed

- add an Agy `stream-json` Chat driver
- register Agy as a shipped Chat-capable harness
- stream assistant responses, tool activity, usage, and terminal turn state
- persist the native Agy conversation ID for daemon restart/resume
- resume subsequent turns through Agy's native `--conversation` support
- install workspace-local `.agents/hooks.json` Chat hooks while preserving
  existing user hook definitions
- bridge `PreInvocation` for AO system-prompt injection
- bridge `PreToolUse` into AO approval requests
- add a loopback-only authenticated hook endpoint and hidden CLI bridge
- support interrupt and queued Chat turns
- classify the internal Agy hook command correctly for telemetry
- ensure queued turns are dispatched only after the previous Agy subprocess has
  fully exited
- use restart-safe provider turn IDs so resumed conversations cannot collide
  with previously persisted turns

## Why

Agy previously only had AO's native terminal/TUI integration. Its CLI now
provides a machine-readable streaming interface, which allows AO to integrate it
with Chat mode without scraping terminal output.

This keeps the two interfaces separate:

- TUI mode continues using the existing Agy terminal adapter
- Chat mode uses `agy --output-format stream-json --print ...`

## Validation

Automated coverage includes:

- Chat driver registration
- workspace hook merge/preservation
- system-prompt injection
- approval hook round-trip
- unsupported per-turn effort handling
- queued-turn completion ordering
- provider turn ID uniqueness across driver restarts
- Agy hook telemetry classification

Manual end-to-end validation covered:

- Chat session spawn
- streamed assistant messages
- tool activity projection
- multi-turn queue ordering
- interrupt
- daemon restart and native conversation resume
- provider context continuity across restart

Queue E2E completed three queued turns in order without the previous
`agy chat: a turn is already active` race.

Restart/resume E2E successfully continued the native Agy conversation after a
daemon restart and retained prior conversation context.

Approval behavior has automated coverage; a full interactive approval E2E was
not included in the manual validation pass.

## Notes

A direct Agy CLI test showed that provider/model failures are surfaced as real
turn failures rather than being converted into successful AO turns. The Chat
driver intentionally preserves those provider errors.