### PR TITLE
chore(terminal): remove Clear context-menu item that never persisted on agent TUI panes

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -461,7 +461,7 @@ describe("XtermTerminal", () => {
 		Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
 	});
 
-	it("runs context menu copy, select all, and clear against the xterm instance", async () => {
+	it("runs context menu copy and select all against the xterm instance", async () => {
 		const { container } = render(<XtermTerminal theme="dark" />);
 		const host = container.firstElementChild!;
 		state.lastTerminal!.selection = "menu copy";
@@ -474,10 +474,6 @@ describe("XtermTerminal", () => {
 		fireEvent.contextMenu(host);
 		fireEvent.click(await screen.findByText("Select All"));
 		expect(state.lastTerminal!.selectAll).toHaveBeenCalled();
-
-		fireEvent.contextMenu(host);
-		fireEvent.click(await screen.findByText("Clear"));
-		expect(state.lastTerminal!.clear).toHaveBeenCalled();
 	});
 
 	it("pastes from the context menu through the terminal paste path", async () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -230,7 +230,7 @@ type TerminalContextMenuState = {
 	link: string | null;
 };
 
-type TerminalContextMenuAction = "copy" | "paste" | "selectAll" | "clear";
+type TerminalContextMenuAction = "copy" | "paste" | "selectAll";
 
 type TerminalContextMenuActions = Record<TerminalContextMenuAction, () => void>;
 
@@ -505,10 +505,6 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			}
 		};
 		contextMenuActionsRef.current = {
-			clear: () => {
-				term.clear();
-				focusTerminal();
-			},
 			copy: () => {
 				copySelection();
 				focusTerminal();
@@ -1061,8 +1057,6 @@ export function XtermTerminal(props: XtermTerminalProps) {
 					</DropdownMenuItem>
 					<DropdownMenuItem onSelect={() => runContextMenuAction("paste")}>{t("titlebar.paste")}</DropdownMenuItem>
 					<DropdownMenuItem onSelect={() => runContextMenuAction("selectAll")}>{t("titlebar.selectAll")}</DropdownMenuItem>
-					<DropdownMenuSeparator />
-					<DropdownMenuItem onSelect={() => runContextMenuAction("clear")}>{t("terminal.clear")}</DropdownMenuItem>
 					{props.onToggleFullscreen ? (
 						<DropdownMenuItem
 							onSelect={() => {

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -885,7 +885,6 @@
 	"termination.dialogNamed": "{{title}} beenden?",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "Zurück zum Agent-Terminal",
-	"terminal.clear": "Leeren",
 	"terminal.close": "Terminal schließen",
 	"terminal.closeNamed": "Terminal {{title}} schließen",
 	"terminal.closeSessionTab": "Sitzungs-Tab {{label}} schließen",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -876,7 +876,6 @@
 	"termination.dialogNamed": "Terminate {{title}}?",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "Back to agent terminal",
-	"terminal.clear": "Clear",
 	"terminal.close": "Close terminal",
 	"terminal.closeNamed": "Close terminal {{title}}",
 	"terminal.closeSessionTab": "Close session tab {{label}}",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -896,7 +896,6 @@
 	"termination.dialogNamed": "¿Terminar {{title}}?",
 	"terminal.agent": "agente",
 	"terminal.backToAgent": "Volver al terminal del agente",
-	"terminal.clear": "Limpiar",
 	"terminal.close": "Cerrar terminal",
 	"terminal.closeNamed": "Cerrar terminal {{title}}",
 	"terminal.closeSessionTab": "Cerrar pestaña de sesión {{label}}",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -896,7 +896,6 @@
 	"termination.dialogNamed": "Terminer {{title}} ?",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "Retour au terminal de l'agent",
-	"terminal.clear": "Effacer",
 	"terminal.close": "Fermer le terminal",
 	"terminal.closeNamed": "Fermer le terminal {{title}}",
 	"terminal.closeSessionTab": "Fermer l'onglet de session {{label}}",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -885,7 +885,6 @@
 	"termination.dialogNamed": "{{title}} を終了しますか？",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "エージェントターミナルに戻る",
-	"terminal.clear": "クリア",
 	"terminal.close": "ターミナルを閉じる",
 	"terminal.closeNamed": "ターミナル {{title}} を閉じる",
 	"terminal.closeSessionTab": "セッションタブ {{label}} を閉じる",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -885,7 +885,6 @@
 	"termination.dialogNamed": "{{title}}을(를) 종료하시겠습니까?",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "에이전트 터미널로 돌아가기",
-	"terminal.clear": "지우기",
 	"terminal.close": "터미널 닫기",
 	"terminal.closeNamed": "터미널 {{title}} 닫기",
 	"terminal.closeSessionTab": "세션 탭 {{label}} 닫기",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -896,7 +896,6 @@
 	"termination.dialogNamed": "Encerrar {{title}}?",
 	"terminal.agent": "agente",
 	"terminal.backToAgent": "Voltar ao terminal do agente",
-	"terminal.clear": "Limpar",
 	"terminal.close": "Fechar terminal",
 	"terminal.closeNamed": "Fechar terminal {{title}}",
 	"terminal.closeSessionTab": "Fechar aba da sessão {{label}}",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -872,7 +872,6 @@
 	"termination.dialogNamed": "终止 {{title}}？",
 	"terminal.agent": "代理",
 	"terminal.backToAgent": "返回代理终端",
-	"terminal.clear": "清空",
 	"terminal.close": "关闭终端",
 	"terminal.closeNamed": "关闭终端 {{title}}",
 	"terminal.closeSessionTab": "关闭会话标签页 {{label}}",


### PR DESCRIPTION
## What
Removes the "Clear" context-menu item from the terminal pane (`XtermTerminal.tsx`), along with its associated test coverage and now-unused i18n strings across all locales.

## Why
The Clear action only cleared the local xterm.js buffer (`term.clear()`). For shell panes this looked correct, but for agent TUI panes (Codex, Claude Code, etc.) the agent process owns and continuously repaints its own transcript from memory on every redraw (resize, tick, etc.), so the cleared view would immediately repopulate — making the button appear broken/inconsistent depending on pane type.

Investigated a proper fix (runtime-level scrollback truncation for tmux/conpty, plus a provider-aware "Clear conversation" action sending `/clear` to the agent). On review, decided against shipping either:
- Runtime-level clear only ever fixes the shell-pane case; it can't stop a TUI from repainting its own transcript.
- A "Clear conversation" button would just duplicate a command (`/clear`) every supported agent CLI already exposes natively — users can type it directly in the terminal today, no UI needed.

Given that, the button wasn't earning its complexity. Removing it entirely rather than shipping a partially-working or duplicative feature.

## How
- Removed the "Clear" item from the terminal context menu and its handler in `XtermTerminal.tsx`.
- Removed the corresponding test case in `XtermTerminal.test.tsx`.
- Removed the now-unused `terminal.clear` (or equivalent) i18n key from all locale files (`en`, `de`, `es`, `fr`, `ja`, `ko`, `pt-BR`, `zh-CN`).
- No backend changes — this is a pure UI removal.
- Intentional omission: no replacement action was added. Users who want to clear an agent's transcript/context can already type `/clear` directly in the terminal, which is the native, provider-supported way to do it.

## Testing
- `npm --prefix frontend run typecheck`
- Targeted vitest run for `XtermTerminal.test.tsx`
- Manual: opened the terminal context menu on both a shell pane and an agent (Codex) pane in dev — Clear item no longer appears in either.

before :

<img width="161" height="210" alt="Screenshot 2026-08-14 at 5 03 13 PM" src="https://github.com/user-attachments/assets/609d15f8-d3e7-4bb2-b8fe-780a9fae2f1e" />

after:

changes(suggested) - two diffrent buttons
<img width="174" height="239" alt="Screenshot 2026-08-14 at 11 19 45 AM" src="https://github.com/user-attachments/assets/3891a857-35a5-4764-824e-ce48f9900c0d" />

changes(approved by @illegalcall)
<img width="155" height="154" alt="Screenshot 2026-08-14 at 4 59 53 PM" src="https://github.com/user-attachments/assets/25605e8f-5780-4cf8-bd90-544f74d46e69" />


## Checklist
- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)