### PR TITLE
fix(chat): make Stop authoritative for durable running turns

### DIFF
--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -47,7 +47,7 @@ type Store interface {
 	SettleTurn(ctx context.Context, conversationID, providerTurnID string, state domain.TurnState, errMessage string, now time.Time) error
 	SettleTurnByID(ctx context.Context, turnID string, state domain.TurnState, errMessage string, now time.Time) error
 	SettleOrphanedTurns(ctx context.Context, session domain.SessionID, now time.Time) error
-	GetRunningTurn(ctx context.Context, conversationID string) (id, providerTurnID string, ok bool, err error)
+	ListVisibleRunningTurnProviderIDs(ctx context.Context, conversationID string) ([]string, error)
 
 	SetConversationSettings(ctx context.Context, conversationID string, settings domain.ConversationSettings, now time.Time) error
 
@@ -1185,43 +1185,51 @@ func (c *Controller) interruptForHandoff(ctx context.Context) error {
 //     "no active turn" would leave the user staring at a Working bar they cannot
 //     dismiss. Reconcile the durable row instead.
 func (c *Controller) Interrupt(ctx context.Context) error {
+	// Stop's linearization point is the dispatch lock. A Send that acquired the
+	// lock first is existing work Stop should cancel; a Send that arrives after
+	// this point waits and is therefore post-Stop work that must survive.
+	c.sendMu.Lock()
 	cutoff := c.now()
-	turn, ok := c.awaitAcknowledgedTurn(ctx)
-	if !ok {
-		// Serialize against dispatch so its "durable row running, memory not yet
-		// updated" middle state cannot be mistaken for a lost turn.
-		c.sendMu.Lock()
-
-		c.mu.Lock()
-		pending := c.pendingTurnID
-		c.mu.Unlock()
-		if pending == "" {
-			_, providerTurnID, running, err := c.store.GetRunningTurn(ctx, c.conversation.ID)
-			if err != nil {
-				c.sendMu.Unlock()
-				return fmt.Errorf("check running turn: %w", err)
-			}
-			if !running {
-				c.sendMu.Unlock()
-				return ErrNoActiveTurn
-			}
-			if err := c.conv.Interrupt(ctx, providerTurnID); err != nil &&
-				!errors.Is(err, ports.ErrChatNoActiveTurn) {
-				c.log.Warn("provider interrupt during reconciliation failed",
-					"session", c.sessionID, "turn", providerTurnID, "error", err)
-			}
-			err = c.reconcileDurableTurnLocked(ctx, providerTurnID, cutoff)
-			c.sendMu.Unlock()
-			return err
-		}
-		// dispatch finished while we waited — interrupt normally.
-		turn = pending
-		c.sendMu.Unlock()
-	}
-
 	c.mu.Lock()
-	c.cancelQueuedAt = cutoff
+	turn := c.pendingTurnID
+	if turn != "" {
+		// Publish the queue cutoff before releasing sendMu. A completion can then
+		// win the provider race, but it cannot drain pre-Stop work as if Stop had
+		// never happened.
+		c.cancelQueuedAt = cutoff
+	}
 	c.mu.Unlock()
+
+	if turn == "" {
+		providerTurnIDs, err := c.store.ListVisibleRunningTurnProviderIDs(ctx, c.conversation.ID)
+		if err != nil {
+			c.sendMu.Unlock()
+			return fmt.Errorf("check running turns: %w", err)
+		}
+		if len(providerTurnIDs) == 0 {
+			c.sendMu.Unlock()
+			return ErrNoActiveTurn
+		}
+		// The list uses the snapshot's visibility and ordering rules, so its first
+		// row is the same running turn whose Working bar the user pressed Stop on.
+		providerTurnID := providerTurnIDs[0]
+		if err := c.conv.Interrupt(ctx, providerTurnID); err != nil &&
+			!errors.Is(err, ports.ErrChatNoActiveTurn) {
+			c.log.Warn("provider interrupt during reconciliation failed",
+				"session", c.sessionID, "turn", providerTurnID, "error", err)
+		}
+		err = c.reconcileDurableTurnsLocked(ctx, providerTurnID, providerTurnIDs, cutoff)
+		c.sendMu.Unlock()
+		return err
+	}
+	c.sendMu.Unlock()
+
+	// sendMu proved dispatch is complete, but the provider's turn-started event
+	// may still be in transit. Wait for this exact turn: if it completes and a
+	// post-Stop survivor starts, Stop must not follow ownership to that new turn.
+	if !c.awaitTurnAcknowledged(ctx, turn) {
+		return nil
+	}
 
 	if err := c.conv.Interrupt(ctx, turn); err != nil {
 		if errors.Is(err, ports.ErrChatNoActiveTurn) {
@@ -1239,7 +1247,11 @@ func (c *Controller) Interrupt(ctx context.Context) error {
 			if !stillPending {
 				return nil
 			}
-			return c.reconcileDurableTurnLocked(ctx, turn, cutoff)
+			providerTurnIDs, listErr := c.store.ListVisibleRunningTurnProviderIDs(ctx, c.conversation.ID)
+			if listErr != nil {
+				return fmt.Errorf("check running turns after provider refusal: %w", listErr)
+			}
+			return c.reconcileDurableTurnsLocked(ctx, turn, providerTurnIDs, cutoff)
 		}
 		// The interrupt did not happen, so the queue it was going to cancel is
 		// still the user's to send.
@@ -1251,31 +1263,47 @@ func (c *Controller) Interrupt(ctx context.Context) error {
 	return nil
 }
 
-// reconcileDurableTurnLocked settles a turn the controller can no longer cancel
-// through the normal path but durable state still shows as running. Callers hold
-// sendMu so settlement, memory cleanup, queue cancellation, and survivor dispatch
-// are one serialized transition. The cutoff is the original Stop time: a prompt
-// submitted while provider cancellation was pending is new work and must survive.
-func (c *Controller) reconcileDurableTurnLocked(
+// reconcileDurableTurnsLocked settles work the controller can no longer cancel
+// through the normal path but durable state still shows as running. Every visible
+// running row is settled because nested provider turns can coexist with the root;
+// leaving any one of them running would leave the same Working bar behind. Callers
+// hold sendMu so settlement, memory cleanup, queue cancellation, and survivor
+// dispatch are one serialized transition. The cutoff is the original Stop time: a
+// prompt submitted while provider cancellation was pending is new work and survives.
+func (c *Controller) reconcileDurableTurnsLocked(
 	ctx context.Context,
-	providerTurnID string,
+	targetProviderTurnID string,
+	visibleProviderTurnIDs []string,
 	cutoff time.Time,
 ) error {
 	now := c.now()
-	if err := c.store.SettleTurn(ctx, c.conversation.ID, providerTurnID,
-		domain.TurnStateInterrupted, "reconciled by interrupt", now); err != nil {
-		return fmt.Errorf("reconcile durable turn %s: %w", providerTurnID, err)
+	providerTurnIDs := make([]string, 0, len(visibleProviderTurnIDs)+1)
+	if targetProviderTurnID != "" {
+		providerTurnIDs = append(providerTurnIDs, targetProviderTurnID)
+	}
+	for _, providerTurnID := range visibleProviderTurnIDs {
+		if providerTurnID != "" && providerTurnID != targetProviderTurnID {
+			providerTurnIDs = append(providerTurnIDs, providerTurnID)
+		}
+	}
+	for _, providerTurnID := range providerTurnIDs {
+		if err := c.store.SettleTurn(ctx, c.conversation.ID, providerTurnID,
+			domain.TurnStateInterrupted, "", now); err != nil {
+			return fmt.Errorf("reconcile durable turn %s: %w", providerTurnID, err)
+		}
 	}
 
 	c.mu.Lock()
 	c.cancelQueuedAt = cutoff
-	if c.pendingTurnID == providerTurnID {
+	if c.pendingTurnID == targetProviderTurnID {
 		c.pendingTurnID = ""
 	}
-	if c.ackedTurnID == providerTurnID {
+	if c.ackedTurnID == targetProviderTurnID {
 		c.ackedTurnID = ""
 	}
-	c.state = ports.ChatControllerReady
+	if c.pendingTurnID == "" {
+		c.state = ports.ChatControllerReady
+	}
 	c.mu.Unlock()
 
 	c.reportActivity(ctx, domain.ActivityIdle, "chat.interrupt.reconciled", now)
@@ -1294,24 +1322,37 @@ func (c *Controller) reconcileDurableTurnLocked(
 // turn anyway: the provider is the authority on whether it can be cancelled, and
 // its refusal is already translated into a typed answer.
 func (c *Controller) awaitAcknowledgedTurn(ctx context.Context) (string, bool) {
+	c.mu.Lock()
+	pending := c.pendingTurnID
+	c.mu.Unlock()
+	if pending == "" || !c.awaitTurnAcknowledged(ctx, pending) {
+		return "", false
+	}
+	return pending, true
+}
+
+// awaitTurnAcknowledged waits only for the named turn. Ownership can move to a
+// queued post-Stop survivor while this wait is in progress; following that move
+// would interrupt new work the user submitted after pressing Stop.
+func (c *Controller) awaitTurnAcknowledged(ctx context.Context, turn string) bool {
 	deadline := time.Now().Add(turnAckWait)
 	for {
 		c.mu.Lock()
 		pending, acked := c.pendingTurnID, c.ackedTurnID
 		c.mu.Unlock()
 
-		if pending == "" {
-			return "", false
+		if pending != turn {
+			return false
 		}
-		if acked == pending || time.Now().After(deadline) {
-			return pending, true
+		if acked == turn || time.Now().After(deadline) {
+			return true
 		}
 
 		select {
 		case <-ctx.Done():
-			return pending, true
+			return true
 		case <-c.stopped:
-			return pending, true
+			return true
 		case <-time.After(20 * time.Millisecond):
 		}
 	}
@@ -1880,9 +1921,6 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 		})
 
 	case ports.ChatEventControllerState:
-		c.mu.Lock()
-		c.state = event.ControllerState
-		c.mu.Unlock()
 		if event.ControllerState == ports.ChatControllerStopped {
 			if err := c.store.SettleOrphanedTurns(ctx, c.sessionID, now); err != nil {
 				return err
@@ -1938,6 +1976,12 @@ func (c *Controller) afterProject(ctx context.Context, event ports.ChatEvent, pr
 	case ports.ChatEventInputRequested:
 		c.reportActivity(ctx, domain.ActivityWaitingInput, "chat.input.requested", now)
 	case ports.ChatEventControllerState:
+		// Volatile state moves only after the provider event and all of its durable
+		// cleanup committed. Otherwise a rollback can say "stopped" in memory while
+		// SQLite still contains live work.
+		c.mu.Lock()
+		c.state = event.ControllerState
+		c.mu.Unlock()
 		if event.ControllerState == ports.ChatControllerStopped {
 			c.reportActivity(ctx, domain.ActivityExited, "chat.controller.stopped", now)
 		}

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -47,6 +47,7 @@ type Store interface {
 	SettleTurn(ctx context.Context, conversationID, providerTurnID string, state domain.TurnState, errMessage string, now time.Time) error
 	SettleTurnByID(ctx context.Context, turnID string, state domain.TurnState, errMessage string, now time.Time) error
 	SettleOrphanedTurns(ctx context.Context, session domain.SessionID, now time.Time) error
+	GetRunningTurn(ctx context.Context, conversationID string) (id, providerTurnID string, ok bool, err error)
 
 	SetConversationSettings(ctx context.Context, conversationID string, settings domain.ConversationSettings, now time.Time) error
 
@@ -1169,10 +1170,43 @@ func (c *Controller) interruptForHandoff(ctx context.Context) error {
 // the next message instead of stopping would be the opposite of what the button
 // says. The cutoff is recorded before the provider call, so a completion that
 // races back cannot drain the queue the interrupt was about to cancel.
+// Durable state is what the UI renders, so it is also what Stop must be able to
+// act on. Two recovery paths reconcile the cases where in-memory tracking and the
+// durable turn row disagree:
+//
+//   - Memory says nothing is running but SQLite has a turn in 'running'. Either a
+//     projection failure kept the completion from committing, or Stop landed in
+//     the dispatch window after BindTurnToProvider wrote 'running' but before
+//     pendingTurnID was set. Taking sendMu first means dispatch has finished (and
+//     set pendingTurnID) before the disk is consulted — if a turn appeared while
+//     we waited, the normal interrupt path runs instead.
+//   - The provider answers ErrChatNoActiveTurn for a turn memory still tracks.
+//     The provider is the authority that the work already ended; surfacing a bare
+//     "no active turn" would leave the user staring at a Working bar they cannot
+//     dismiss. Reconcile the durable row instead.
 func (c *Controller) Interrupt(ctx context.Context) error {
 	turn, ok := c.awaitAcknowledgedTurn(ctx)
 	if !ok {
-		return ErrNoActiveTurn
+		// Serialize against dispatch so its "durable row running, memory not yet
+		// updated" middle state cannot be mistaken for a lost turn.
+		c.sendMu.Lock()
+		defer c.sendMu.Unlock()
+
+		c.mu.Lock()
+		pending := c.pendingTurnID
+		c.mu.Unlock()
+		if pending == "" {
+			_, providerTurnID, running, err := c.store.GetRunningTurn(ctx, c.conversation.ID)
+			if err != nil {
+				return fmt.Errorf("check running turn: %w", err)
+			}
+			if !running {
+				return ErrNoActiveTurn
+			}
+			return c.reconcileDurableTurn(ctx, providerTurnID)
+		}
+		// dispatch finished while we waited — interrupt normally.
+		turn = pending
 	}
 
 	c.mu.Lock()
@@ -1180,16 +1214,58 @@ func (c *Controller) Interrupt(ctx context.Context) error {
 	c.mu.Unlock()
 
 	if err := c.conv.Interrupt(ctx, turn); err != nil {
+		if errors.Is(err, ports.ErrChatNoActiveTurn) {
+			c.mu.Lock()
+			c.cancelQueuedAt = time.Time{}
+			c.mu.Unlock()
+			return c.reconcileDurableTurn(ctx, turn)
+		}
 		// The interrupt did not happen, so the queue it was going to cancel is
 		// still the user's to send.
 		c.mu.Lock()
 		c.cancelQueuedAt = time.Time{}
 		c.mu.Unlock()
-		if errors.Is(err, ports.ErrChatNoActiveTurn) {
-			return ErrNoActiveTurn
-		}
 		return fmt.Errorf("interrupt turn %s: %w", turn, err)
 	}
+	return nil
+}
+
+// reconcileDurableTurn settles a turn the controller can no longer cancel through
+// the normal path but durable state still shows as running. It delivers the full
+// Interrupt contract in one place — best-effort provider cancel, settle the row
+// as interrupted, clear in-memory tracking, cancel the queue behind it, report
+// idle — so both recovery paths behave identically.
+func (c *Controller) reconcileDurableTurn(ctx context.Context, providerTurnID string) error {
+	if err := c.conv.Interrupt(ctx, providerTurnID); err != nil {
+		if !errors.Is(err, ports.ErrChatNoActiveTurn) {
+			c.log.Warn("provider interrupt during reconciliation failed",
+				"session", c.sessionID, "turn", providerTurnID, "error", err)
+		}
+	}
+
+	if err := c.store.SettleTurn(ctx, c.conversation.ID, providerTurnID,
+		domain.TurnStateInterrupted, "reconciled by interrupt", c.now()); err != nil {
+		return fmt.Errorf("reconcile durable turn %s: %w", providerTurnID, err)
+	}
+
+	now := c.now()
+	c.mu.Lock()
+	c.cancelQueuedAt = now
+	if c.pendingTurnID == providerTurnID {
+		c.pendingTurnID = ""
+	}
+	if c.ackedTurnID == providerTurnID {
+		c.ackedTurnID = ""
+	}
+	c.state = ports.ChatControllerReady
+	c.mu.Unlock()
+
+	if err := c.store.CancelQueuedTurns(ctx, c.conversation.ID, now, now); err != nil {
+		c.log.Error("failed to cancel queued turns during reconciliation",
+			"session", c.sessionID, "error", err)
+	}
+
+	c.reportActivity(ctx, domain.ActivityIdle, "chat.interrupt.reconciled", now)
 	return nil
 }
 

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -1185,12 +1185,12 @@ func (c *Controller) interruptForHandoff(ctx context.Context) error {
 //     "no active turn" would leave the user staring at a Working bar they cannot
 //     dismiss. Reconcile the durable row instead.
 func (c *Controller) Interrupt(ctx context.Context) error {
+	cutoff := c.now()
 	turn, ok := c.awaitAcknowledgedTurn(ctx)
 	if !ok {
 		// Serialize against dispatch so its "durable row running, memory not yet
 		// updated" middle state cannot be mistaken for a lost turn.
 		c.sendMu.Lock()
-		defer c.sendMu.Unlock()
 
 		c.mu.Lock()
 		pending := c.pendingTurnID
@@ -1198,27 +1198,48 @@ func (c *Controller) Interrupt(ctx context.Context) error {
 		if pending == "" {
 			_, providerTurnID, running, err := c.store.GetRunningTurn(ctx, c.conversation.ID)
 			if err != nil {
+				c.sendMu.Unlock()
 				return fmt.Errorf("check running turn: %w", err)
 			}
 			if !running {
+				c.sendMu.Unlock()
 				return ErrNoActiveTurn
 			}
-			return c.reconcileDurableTurn(ctx, providerTurnID)
+			if err := c.conv.Interrupt(ctx, providerTurnID); err != nil &&
+				!errors.Is(err, ports.ErrChatNoActiveTurn) {
+				c.log.Warn("provider interrupt during reconciliation failed",
+					"session", c.sessionID, "turn", providerTurnID, "error", err)
+			}
+			err = c.reconcileDurableTurnLocked(ctx, providerTurnID, cutoff)
+			c.sendMu.Unlock()
+			return err
 		}
 		// dispatch finished while we waited — interrupt normally.
 		turn = pending
+		c.sendMu.Unlock()
 	}
 
 	c.mu.Lock()
-	c.cancelQueuedAt = c.now()
+	c.cancelQueuedAt = cutoff
 	c.mu.Unlock()
 
 	if err := c.conv.Interrupt(ctx, turn); err != nil {
 		if errors.Is(err, ports.ErrChatNoActiveTurn) {
+			// Serialize durable settlement, memory cleanup, and queue promotion so
+			// a message arriving after Stop cannot slip between those steps.
+			c.sendMu.Lock()
+			defer c.sendMu.Unlock()
+
+			// A committed completion may have won the sendMu race after the
+			// provider answered. It already consumed the cutoff and drained the
+			// queue, so do not overwrite its terminal state or a successor turn.
 			c.mu.Lock()
-			c.cancelQueuedAt = time.Time{}
+			stillPending := c.pendingTurnID == turn
 			c.mu.Unlock()
-			return c.reconcileDurableTurn(ctx, turn)
+			if !stillPending {
+				return nil
+			}
+			return c.reconcileDurableTurnLocked(ctx, turn, cutoff)
 		}
 		// The interrupt did not happen, so the queue it was going to cancel is
 		// still the user's to send.
@@ -1230,27 +1251,24 @@ func (c *Controller) Interrupt(ctx context.Context) error {
 	return nil
 }
 
-// reconcileDurableTurn settles a turn the controller can no longer cancel through
-// the normal path but durable state still shows as running. It delivers the full
-// Interrupt contract in one place — best-effort provider cancel, settle the row
-// as interrupted, clear in-memory tracking, cancel the queue behind it, report
-// idle — so both recovery paths behave identically.
-func (c *Controller) reconcileDurableTurn(ctx context.Context, providerTurnID string) error {
-	if err := c.conv.Interrupt(ctx, providerTurnID); err != nil {
-		if !errors.Is(err, ports.ErrChatNoActiveTurn) {
-			c.log.Warn("provider interrupt during reconciliation failed",
-				"session", c.sessionID, "turn", providerTurnID, "error", err)
-		}
-	}
-
+// reconcileDurableTurnLocked settles a turn the controller can no longer cancel
+// through the normal path but durable state still shows as running. Callers hold
+// sendMu so settlement, memory cleanup, queue cancellation, and survivor dispatch
+// are one serialized transition. The cutoff is the original Stop time: a prompt
+// submitted while provider cancellation was pending is new work and must survive.
+func (c *Controller) reconcileDurableTurnLocked(
+	ctx context.Context,
+	providerTurnID string,
+	cutoff time.Time,
+) error {
+	now := c.now()
 	if err := c.store.SettleTurn(ctx, c.conversation.ID, providerTurnID,
-		domain.TurnStateInterrupted, "reconciled by interrupt", c.now()); err != nil {
+		domain.TurnStateInterrupted, "reconciled by interrupt", now); err != nil {
 		return fmt.Errorf("reconcile durable turn %s: %w", providerTurnID, err)
 	}
 
-	now := c.now()
 	c.mu.Lock()
-	c.cancelQueuedAt = now
+	c.cancelQueuedAt = cutoff
 	if c.pendingTurnID == providerTurnID {
 		c.pendingTurnID = ""
 	}
@@ -1260,12 +1278,10 @@ func (c *Controller) reconcileDurableTurn(ctx context.Context, providerTurnID st
 	c.state = ports.ChatControllerReady
 	c.mu.Unlock()
 
-	if err := c.store.CancelQueuedTurns(ctx, c.conversation.ID, now, now); err != nil {
-		c.log.Error("failed to cancel queued turns during reconciliation",
-			"session", c.sessionID, "error", err)
-	}
-
 	c.reportActivity(ctx, domain.ActivityIdle, "chat.interrupt.reconciled", now)
+	// drainLocked consumes cancelQueuedAt, cancels only the pre-Stop queue, and
+	// immediately dispatches the oldest surviving post-Stop prompt.
+	c.drainLocked(ctx)
 	return nil
 }
 

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -1996,6 +1996,76 @@ type interruptRecorder struct {
 	attempts []string
 }
 
+// blockingInterruptRefusalConversation holds the provider refusal open so a
+// message can arrive after Stop began but before reconciliation runs.
+type blockingInterruptRefusalConversation struct {
+	*fakeConversation
+	started     chan struct{}
+	release     chan struct{}
+	startedOnce sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingInterruptRefusalConversation() *blockingInterruptRefusalConversation {
+	return &blockingInterruptRefusalConversation{
+		fakeConversation: newFakeConversation(),
+		started:          make(chan struct{}),
+		release:          make(chan struct{}),
+	}
+}
+
+func (c *blockingInterruptRefusalConversation) Interrupt(ctx context.Context, _ string) error {
+	c.startedOnce.Do(func() { close(c.started) })
+	select {
+	case <-c.release:
+		return ports.ErrChatNoActiveTurn
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *blockingInterruptRefusalConversation) unblock() {
+	c.releaseOnce.Do(func() { close(c.release) })
+}
+
+// completionBeforeRefusalConversation lets the committed completion win the
+// controller's send lock before the provider's stale refusal reaches Interrupt.
+type completionBeforeRefusalConversation struct {
+	*fakeConversation
+	emitted     chan struct{}
+	release     chan struct{}
+	emittedOnce sync.Once
+	releaseOnce sync.Once
+}
+
+func newCompletionBeforeRefusalConversation() *completionBeforeRefusalConversation {
+	return &completionBeforeRefusalConversation{
+		fakeConversation: newFakeConversation(),
+		emitted:          make(chan struct{}),
+		release:          make(chan struct{}),
+	}
+}
+
+func (c *completionBeforeRefusalConversation) Interrupt(ctx context.Context, turn string) error {
+	c.emittedOnce.Do(func() {
+		c.emit(ports.ChatEvent{
+			Kind: ports.ChatEventTurnCompleted, ProviderTurnID: turn,
+			TurnState: domain.TurnStateCompleted,
+		})
+		close(c.emitted)
+	})
+	select {
+	case <-c.release:
+		return ports.ErrChatNoActiveTurn
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *completionBeforeRefusalConversation) unblock() {
+	c.releaseOnce.Do(func() { close(c.release) })
+}
+
 func newInterruptRecorder() *interruptRecorder {
 	return &interruptRecorder{fakeConversation: newFakeConversation(), active: map[string]bool{}}
 }
@@ -2075,6 +2145,112 @@ func TestProviderRefusalReconcilesTheDurableTurnAsInterrupted(t *testing.T) {
 	})
 	if !hasActivitySignal(h.activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
 		t.Errorf("no idle signal after reconciliation; signals = %v", h.activity.snapshot())
+	}
+}
+
+// The recovery path must keep the same cutoff as the Stop request. The composer
+// remains available while provider cancellation is pending, and a later prompt
+// is new user intent rather than part of the queue that Stop was asked to clear.
+func TestProviderRefusalPreservesMessageQueuedAfterStop(t *testing.T) {
+	conv := newBlockingInterruptRefusalConversation()
+	t.Cleanup(conv.unblock)
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "running", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send running: %v", err)
+	}
+	conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "before stop", ClientMessageID: "c2",
+	}); err != nil {
+		t.Fatalf("Send before stop: %v", err)
+	}
+
+	interruptDone := make(chan error, 1)
+	go func() { interruptDone <- h.svc.Interrupt(ctx, testSession) }()
+	select {
+	case <-conv.started:
+	case <-time.After(4 * time.Second):
+		t.Fatal("provider interrupt did not start")
+	}
+
+	h.advance(time.Second)
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "after stop", ClientMessageID: "c3",
+	}); err != nil {
+		t.Fatalf("Send after stop: %v", err)
+	}
+	conv.unblock()
+	if err := <-interruptDone; err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		states := turnStateByText(t, s)
+		return states["before stop"] == domain.TurnStateInterrupted &&
+			states["after stop"] != domain.TurnStateQueued
+	})
+	states := turnStateByText(t, snapshot)
+	if got := states["after stop"]; got != domain.TurnStateRunning {
+		t.Fatalf("post-stop message = %q, want running", got)
+	}
+	if got := conv.sentTexts(); len(got) != 2 || got[1] != "after stop" {
+		t.Fatalf("provider received %v, want the post-stop message delivered", got)
+	}
+}
+
+// A provider can publish completion just before its interrupt call reports that
+// no active turn remains. If that completion commits first, reconciliation must
+// not overwrite it or the queue transition it already performed.
+func TestProviderRefusalDoesNotOverwriteCommittedCompletion(t *testing.T) {
+	conv := newCompletionBeforeRefusalConversation()
+	t.Cleanup(conv.unblock)
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "running", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send running: %v", err)
+	}
+	conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "before stop", ClientMessageID: "c2",
+	}); err != nil {
+		t.Fatalf("Send before stop: %v", err)
+	}
+
+	interruptDone := make(chan error, 1)
+	go func() { interruptDone <- h.svc.Interrupt(ctx, testSession) }()
+	select {
+	case <-conv.emitted:
+	case <-time.After(4 * time.Second):
+		t.Fatal("provider completion was not emitted")
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		states := turnStateByText(t, s)
+		return states["running"] == domain.TurnStateCompleted &&
+			states["before stop"] == domain.TurnStateInterrupted
+	})
+
+	conv.unblock()
+	if err := <-interruptDone; err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["running"].Terminal()
+	})
+	if got := turnStateByText(t, snapshot)["running"]; got != domain.TurnStateCompleted {
+		t.Fatalf("turn after committed completion = %q, want completed", got)
 	}
 }
 

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -1996,6 +1996,45 @@ type interruptRecorder struct {
 	attempts []string
 }
 
+// blockingDispatchConversation exposes the interval in which Send owns sendMu
+// but has not yet published pendingTurnID. Stop must wait for dispatch and then
+// retain the normal provider-ack grace period.
+type blockingDispatchConversation struct {
+	*interruptRecorder
+	sendStarted chan struct{}
+	releaseSend chan struct{}
+	attempted   chan struct{}
+	startOnce   sync.Once
+	attemptOnce sync.Once
+}
+
+func newBlockingDispatchConversation() *blockingDispatchConversation {
+	return &blockingDispatchConversation{
+		interruptRecorder: newInterruptRecorder(),
+		sendStarted:       make(chan struct{}),
+		releaseSend:       make(chan struct{}),
+		attempted:         make(chan struct{}),
+	}
+}
+
+func (c *blockingDispatchConversation) SendTurn(
+	ctx context.Context,
+	msg ports.ChatUserMessage,
+) (ports.ChatTurnRef, error) {
+	c.startOnce.Do(func() { close(c.sendStarted) })
+	select {
+	case <-c.releaseSend:
+		return c.fakeConversation.SendTurn(ctx, msg)
+	case <-ctx.Done():
+		return ports.ChatTurnRef{}, ctx.Err()
+	}
+}
+
+func (c *blockingDispatchConversation) Interrupt(ctx context.Context, turn string) error {
+	c.attemptOnce.Do(func() { close(c.attempted) })
+	return c.interruptRecorder.Interrupt(ctx, turn)
+}
+
 // blockingInterruptRefusalConversation holds the provider refusal open so a
 // message can arrive after Stop began but before reconciliation runs.
 type blockingInterruptRefusalConversation struct {
@@ -2120,6 +2159,46 @@ func TestInterruptWaitsForTheProviderToAcknowledgeTheTurn(t *testing.T) {
 	}
 }
 
+// Interrupt can begin while Send still owns the dispatch lock. Once dispatch
+// finishes, Stop must still wait for turn-started rather than treating the
+// provider's early refusal as proof that the new turn is stale.
+func TestInterruptWaitsForAcknowledgementAfterRacingDispatch(t *testing.T) {
+	conv := newBlockingDispatchConversation()
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	sendDone := make(chan error, 1)
+	go func() {
+		_, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+			Text: "go", ClientMessageID: "dispatch-race",
+		})
+		sendDone <- err
+	}()
+	select {
+	case <-conv.sendStarted:
+	case <-time.After(4 * time.Second):
+		t.Fatal("Send did not enter provider dispatch")
+	}
+
+	interruptDone := make(chan error, 1)
+	go func() { interruptDone <- h.svc.Interrupt(ctx, testSession) }()
+	close(conv.releaseSend)
+	if err := <-sendDone; err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	select {
+	case <-conv.attempted:
+		t.Fatal("Interrupt reached the provider before turn-started acknowledgement")
+	case <-time.After(100 * time.Millisecond):
+	}
+	conv.markActive("provider-turn-1")
+	conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	if err := <-interruptDone; err != nil {
+		t.Fatalf("Interrupt after acknowledgement: %v", err)
+	}
+}
+
 // A provider that refuses because the turn is genuinely gone must not strand the
 // user: the durable row still says running — that is what the UI renders — so
 // Interrupt reconciles it as interrupted instead of answering "nothing to stop"
@@ -2140,9 +2219,12 @@ func TestProviderRefusalReconcilesTheDurableTurnAsInterrupted(t *testing.T) {
 		t.Fatalf("Interrupt: %v", err)
 	}
 
-	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
 		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateInterrupted
 	})
+	if got := snapshot.Turns[0].ErrorMessage; got != "" {
+		t.Errorf("interrupted turn error message = %q, want empty", got)
+	}
 	if !hasActivitySignal(h.activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
 		t.Errorf("no idle signal after reconciliation; signals = %v", h.activity.snapshot())
 	}
@@ -2291,6 +2373,106 @@ func TestInterruptReconcilesStaleRunningTurnOnDisk(t *testing.T) {
 	})
 	if !hasActivitySignal(h.activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
 		t.Errorf("no idle signal after reconciliation; signals = %v", h.activity.snapshot())
+	}
+}
+
+// A root and a nested provider turn can both be durably running. The UI renders
+// the oldest visible row first, but clearing only that row would merely reveal a
+// second Working bar. Recovery cancels the visible root and settles the full
+// visible running set.
+func TestInterruptReconcilesAllVisibleRunningTurns(t *testing.T) {
+	conv := newInterruptRecorder()
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	if err := h.st.AdoptProviderTurn(ctx, h.ctrl.ConversationID(), testSession,
+		h.ctrl.Generation(), "root-turn", "provider-root", h.now()); err != nil {
+		t.Fatalf("AdoptProviderTurn root: %v", err)
+	}
+	h.advance(time.Second)
+	if err := h.st.AdoptProviderTurn(ctx, h.ctrl.ConversationID(), testSession,
+		h.ctrl.Generation(), "child-turn", "provider-child", h.now()); err != nil {
+		t.Fatalf("AdoptProviderTurn child: %v", err)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 2 && s.Turns[0].State == domain.TurnStateRunning &&
+			s.Turns[1].State == domain.TurnStateRunning
+	})
+
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 2 && s.Turns[0].State.Terminal() && s.Turns[1].State.Terminal()
+	})
+	for _, turn := range snapshot.Turns {
+		if turn.State != domain.TurnStateInterrupted {
+			t.Errorf("turn %s = %q, want interrupted", turn.ProviderTurnID, turn.State)
+		}
+	}
+	conv.activeMu.Lock()
+	attempts := append([]string(nil), conv.attempts...)
+	conv.activeMu.Unlock()
+	if len(attempts) != 1 || attempts[0] != "provider-root" {
+		t.Fatalf("provider interrupt attempts = %v, want visible root first", attempts)
+	}
+}
+
+// In the no-memory recovery path, provider cancellation happens under sendMu.
+// A prompt submitted after Stop therefore waits for stale settlement and then
+// starts as new work instead of replacing the recovery target.
+func TestInterruptDurableFallbackPreservesPostStopSend(t *testing.T) {
+	conv := newBlockingInterruptRefusalConversation()
+	t.Cleanup(conv.unblock)
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	if err := h.st.AdoptProviderTurn(ctx, h.ctrl.ConversationID(), testSession,
+		h.ctrl.Generation(), "stale-turn", "provider-stale", h.now()); err != nil {
+		t.Fatalf("AdoptProviderTurn: %v", err)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	interruptDone := make(chan error, 1)
+	go func() { interruptDone <- h.svc.Interrupt(ctx, testSession) }()
+	select {
+	case <-conv.started:
+	case <-time.After(4 * time.Second):
+		t.Fatal("durable fallback did not reach provider interrupt")
+	}
+
+	h.advance(time.Second)
+	sendDone := make(chan error, 1)
+	go func() {
+		_, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+			Text: "after stop", ClientMessageID: "post-stop-fallback",
+		})
+		sendDone <- err
+	}()
+	select {
+	case err := <-sendDone:
+		t.Fatalf("post-Stop Send crossed reconciliation lock early: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	conv.unblock()
+	if err := <-interruptDone; err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	if err := <-sendDone; err != nil {
+		t.Fatalf("post-Stop Send: %v", err)
+	}
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 2 && s.Turns[0].State == domain.TurnStateInterrupted &&
+			s.Turns[1].State == domain.TurnStateRunning
+	})
+	if snapshot.Turns[0].ProviderTurnID != "provider-stale" {
+		t.Fatalf("reconciled turn = %q, want provider-stale", snapshot.Turns[0].ProviderTurnID)
+	}
+	if got := conv.sentTexts(); len(got) != 1 || got[0] != "after stop" {
+		t.Fatalf("provider received %v, want only post-Stop work", got)
 	}
 }
 
@@ -2794,6 +2976,8 @@ func TestProviderStartedTurnIsAdoptedSoItsItemsCorrelate(t *testing.T) {
 type failingProjectStore struct {
 	chatsvc.Store
 	failMethod string
+	failed     chan struct{}
+	failOnce   sync.Once
 }
 
 func (s *failingProjectStore) ProjectProviderEvent(
@@ -2801,11 +2985,21 @@ func (s *failingProjectStore) ProjectProviderEvent(
 	generation, providerEventID, method, payloadJSON string, now time.Time,
 	project func(context.Context) error,
 ) (bool, error) {
-	if method == s.failMethod {
-		return false, errors.New("injected projection failure")
+	if method != s.failMethod {
+		return s.Store.ProjectProviderEvent(ctx, conversationID, session, generation,
+			providerEventID, method, payloadJSON, now, project)
 	}
-	return s.Store.ProjectProviderEvent(ctx, conversationID, session, generation,
-		providerEventID, method, payloadJSON, now, project)
+	projected, err := s.Store.ProjectProviderEvent(ctx, conversationID, session, generation,
+		providerEventID, method, payloadJSON, now, func(txCtx context.Context) error {
+			if err := project(txCtx); err != nil {
+				return err
+			}
+			// Fail after the projection callback so its SQLite writes roll back. This
+			// is the exact boundary that used to leak volatile state out of the tx.
+			return errors.New("injected projection failure")
+		})
+	s.failOnce.Do(func() { close(s.failed) })
+	return projected, err
 }
 
 // The exact #3749 sequence: the turn/completed projection fails (so the durable
@@ -2821,8 +3015,11 @@ func TestProjectionFailureThenStopStillStopsTheTurn(t *testing.T) {
 	counter := 0
 	activity := &recordingActivity{}
 	clock := time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)
+	failingStore := &failingProjectStore{
+		Store: st, failMethod: string(ports.ChatEventTurnCompleted), failed: make(chan struct{}),
+	}
 	svc := chatsvc.New(chatsvc.Options{
-		Store:    &failingProjectStore{Store: st, failMethod: string(ports.ChatEventTurnCompleted)},
+		Store:    failingStore,
 		Sessions: st,
 		Drivers:  fakeRegistry{driver: fakeDriver{conv: conv}},
 		Activity: activity,
@@ -2871,7 +3068,11 @@ func TestProjectionFailureThenStopStillStopsTheTurn(t *testing.T) {
 		ProviderTurnID: "provider-turn-1",
 		TurnState:      domain.TurnStateCompleted,
 	})
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-failingStore.failed:
+	case <-time.After(4 * time.Second):
+		t.Fatal("completion projection did not reach the injected rollback")
+	}
 
 	if err := svc.Interrupt(ctx, testSession); err != nil {
 		t.Fatalf("Interrupt: %v", err)
@@ -2894,6 +3095,32 @@ func TestProjectionFailureThenStopStillStopsTheTurn(t *testing.T) {
 	}
 	if !hasActivitySignal(activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
 		t.Errorf("no idle signal after reconciliation; signals = %v", activity.snapshot())
+	}
+}
+
+// Controller-state notifications perform durable cleanup before they change the
+// volatile controller state. If that transaction rolls back, memory must continue
+// reporting the last committed state rather than claiming the controller stopped.
+func TestControllerStateChangesOnlyAfterProjectionCommits(t *testing.T) {
+	var failingStore *failingProjectStore
+	h := newHarnessWithConversationAndStore(t, nil, func(st *sqlite.Store) chatsvc.Store {
+		failingStore = &failingProjectStore{
+			Store: st, failMethod: string(ports.ChatEventControllerState), failed: make(chan struct{}),
+		}
+		return failingStore
+	})
+	want := h.ctrl.State()
+
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventControllerState, ControllerState: ports.ChatControllerStopped,
+	})
+	select {
+	case <-failingStore.failed:
+	case <-time.After(4 * time.Second):
+		t.Fatal("controller-state projection did not reach the injected rollback")
+	}
+	if got := h.ctrl.State(); got != want {
+		t.Fatalf("controller state after rolled-back projection = %q, want committed %q", got, want)
 	}
 }
 

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -2050,10 +2050,11 @@ func TestInterruptWaitsForTheProviderToAcknowledgeTheTurn(t *testing.T) {
 	}
 }
 
-// A provider that refuses because the turn is genuinely gone must reach the client
-// as the same typed "nothing to interrupt" answer AO produces itself — not as a
-// protocol error that renders as an internal failure.
-func TestProviderRefusalBecomesTheTypedNoActiveTurnError(t *testing.T) {
+// A provider that refuses because the turn is genuinely gone must not strand the
+// user: the durable row still says running — that is what the UI renders — so
+// Interrupt reconciles it as interrupted instead of answering "nothing to stop"
+// while the Working bar stays up.
+func TestProviderRefusalReconcilesTheDurableTurnAsInterrupted(t *testing.T) {
 	conv := newInterruptRecorder() // never marks anything active
 	h := newHarnessWithConversation(t, conv)
 	ctx := context.Background()
@@ -2061,10 +2062,109 @@ func TestProviderRefusalBecomesTheTypedNoActiveTurnError(t *testing.T) {
 	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{Text: "go", ClientMessageID: "c1"}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
 
-	err := h.svc.Interrupt(ctx, testSession)
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateInterrupted
+	})
+	if !hasActivitySignal(h.activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
+		t.Errorf("no idle signal after reconciliation; signals = %v", h.activity.snapshot())
+	}
+}
+
+func hasActivitySignal(signals []ports.ActivitySignal, state domain.ActivityState, event string) bool {
+	for _, s := range signals {
+		if s.State == state && s.Event == event {
+			return true
+		}
+	}
+	return false
+}
+
+// The #3749 desync: a turn is 'running' on disk while the in-memory controller
+// has no pendingTurnID (a completed projection failed, or the daemon restarted
+// mid-turn). The UI reads disk and shows "Working"; Stop must act on what the
+// user sees rather than refuse with CHAT_NO_ACTIVE_TURN.
+func TestInterruptReconcilesStaleRunningTurnOnDisk(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	// Create the running turn directly in the store, bypassing the controller so
+	// its pendingTurnID stays empty — the desynced state.
+	const providerTurnID = "stale-running-turn"
+	if err := h.st.AdoptProviderTurn(ctx, h.ctrl.ConversationID(), testSession,
+		h.ctrl.Generation(), "stale-turn-id", providerTurnID, h.now()); err != nil {
+		t.Fatalf("AdoptProviderTurn: %v", err)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateInterrupted
+	})
+	if !hasActivitySignal(h.activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
+		t.Errorf("no idle signal after reconciliation; signals = %v", h.activity.snapshot())
+	}
+}
+
+// When memory and disk agree there is nothing running, Interrupt must still
+// answer ErrNoActiveTurn — the disk fallback must not invent work to stop.
+func TestInterruptReturnsNoActiveTurnWhenNoRunningTurnAnywhere(t *testing.T) {
+	h := newHarness(t)
+
+	err := h.svc.Interrupt(context.Background(), testSession)
 	if !errorsIs(err, chatsvc.ErrNoActiveTurn) {
 		t.Fatalf("err = %v, want ErrNoActiveTurn", err)
+	}
+}
+
+// Reconciliation is still the user's brake: anything queued behind the stale
+// turn is cancelled, not released into the provider.
+func TestInterruptReconciliationCancelsQueuedTurns(t *testing.T) {
+	conv := newInterruptRecorder() // never marks anything active
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "running", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send running: %v", err)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "queued", ClientMessageID: "c2",
+	}); err != nil {
+		t.Fatalf("Send queued: %v", err)
+	}
+
+	if err := h.svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		states := turnStateByText(t, s)
+		return states["running"] == domain.TurnStateInterrupted &&
+			states["queued"] == domain.TurnStateInterrupted
+	})
+	states := turnStateByText(t, snapshot)
+	if states["queued"] != domain.TurnStateInterrupted {
+		t.Errorf("queued turn = %q, want interrupted (cancelled, not dispatched)", states["queued"])
+	}
+	if got := h.conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; reconciliation must not release the queue", got)
 	}
 }
 
@@ -2511,4 +2611,135 @@ func TestProviderStartedTurnIsAdoptedSoItsItemsCorrelate(t *testing.T) {
 			t.Errorf("activity %q has no turn id; the timeline cannot group it", activity.Summary)
 		}
 	}
+}
+
+// failingProjectStore injects a projection failure for one event kind,
+// simulating a SettleTurn error or tx.Commit failure without corrupting SQLite.
+type failingProjectStore struct {
+	chatsvc.Store
+	failMethod string
+}
+
+func (s *failingProjectStore) ProjectProviderEvent(
+	ctx context.Context, conversationID string, session domain.SessionID,
+	generation, providerEventID, method, payloadJSON string, now time.Time,
+	project func(context.Context) error,
+) (bool, error) {
+	if method == s.failMethod {
+		return false, errors.New("injected projection failure")
+	}
+	return s.Store.ProjectProviderEvent(ctx, conversationID, session, generation,
+		providerEventID, method, payloadJSON, now, project)
+}
+
+// The exact #3749 sequence: the turn/completed projection fails (so the durable
+// row stays 'running' and the UI keeps showing "Working"), then the user presses
+// Stop and the provider refuses because the turn already ended on its side.
+// Interrupt must settle the durable row as interrupted, cancel the queue behind
+// it, and report idle — not answer CHAT_NO_ACTIVE_TURN and strand the user.
+func TestProjectionFailureThenStopStillStopsTheTurn(t *testing.T) {
+	conv := newInterruptRecorder() // never marks anything active -> always refuses
+	st := openStore(t)
+
+	var counterMu sync.Mutex
+	counter := 0
+	activity := &recordingActivity{}
+	clock := time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)
+	svc := chatsvc.New(chatsvc.Options{
+		Store:    &failingProjectStore{Store: st, failMethod: string(ports.ChatEventTurnCompleted)},
+		Sessions: st,
+		Drivers:  fakeRegistry{driver: fakeDriver{conv: conv}},
+		Activity: activity,
+		Log:      slog.New(slog.DiscardHandler),
+		NewID: func() string {
+			counterMu.Lock()
+			defer counterMu.Unlock()
+			counter++
+			return fmt.Sprintf("id-%03d", counter)
+		},
+		Now: func() time.Time { return clock },
+	})
+
+	ctrl, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID:     testSession,
+		ProjectID:     testProject,
+		Harness:       domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+	ctx := context.Background()
+
+	if _, err := svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "running", ClientMessageID: "c1",
+	}); err != nil {
+		t.Fatalf("Send running: %v", err)
+	}
+	conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	awaitStoreSnapshot(t, st, ctrl.ConversationID(), func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	if _, err := svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "queued", ClientMessageID: "c2",
+	}); err != nil {
+		t.Fatalf("Send queued: %v", err)
+	}
+
+	// The completion's projection fails: the durable row stays 'running' and
+	// afterProject never runs, so nothing drains and nothing reports idle.
+	conv.emit(ports.ChatEvent{
+		Kind:           ports.ChatEventTurnCompleted,
+		ProviderTurnID: "provider-turn-1",
+		TurnState:      domain.TurnStateCompleted,
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	if err := svc.Interrupt(ctx, testSession); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+
+	snapshot := awaitStoreSnapshot(t, st, ctrl.ConversationID(), func(s store.ConversationSnapshot) bool {
+		states := turnStateByText(t, s)
+		return states["running"] == domain.TurnStateInterrupted &&
+			states["queued"] == domain.TurnStateInterrupted
+	})
+	states := turnStateByText(t, snapshot)
+	if states["running"] != domain.TurnStateInterrupted {
+		t.Errorf("running turn = %q, want interrupted", states["running"])
+	}
+	if states["queued"] != domain.TurnStateInterrupted {
+		t.Errorf("queued turn = %q, want interrupted (cancelled, not dispatched)", states["queued"])
+	}
+	if got := conv.sentTexts(); len(got) != 1 {
+		t.Fatalf("provider received %v; reconciliation must not release the queue", got)
+	}
+	if !hasActivitySignal(activity.snapshot(), domain.ActivityIdle, "chat.interrupt.reconciled") {
+		t.Errorf("no idle signal after reconciliation; signals = %v", activity.snapshot())
+	}
+}
+
+// awaitStoreSnapshot is awaitSnapshot for tests that build their own service
+// rather than using the harness.
+func awaitStoreSnapshot(t *testing.T, st *sqlite.Store, conversationID string,
+	pred func(store.ConversationSnapshot) bool) store.ConversationSnapshot {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last store.ConversationSnapshot
+	for time.Now().Before(deadline) {
+		snapshot, err := st.LoadConversationSnapshot(context.Background(), conversationID)
+		if err != nil {
+			t.Fatalf("load snapshot: %v", err)
+		}
+		last = snapshot
+		if pred(snapshot) {
+			return snapshot
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("snapshot never satisfied the condition; last had %d messages, %d activities, %d turns",
+		len(last.Messages), len(last.Activities), len(last.Turns))
+	return last
 }

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -496,6 +496,28 @@ func (q *Queries) FailRolledBackConversationApprovals(ctx context.Context, arg F
 	return err
 }
 
+const getRunningTurnForConversation = `-- name: GetRunningTurnForConversation :one
+SELECT id, provider_turn_id FROM conversation_turns
+WHERE conversation_id = ? AND state = 'running'
+ORDER BY started_at DESC
+LIMIT 1
+`
+
+type GetRunningTurnForConversationRow struct {
+	ID             string
+	ProviderTurnID string
+}
+
+// The most recent turn SQLite still considers running. Interrupt uses it to
+// recover when in-memory turn tracking has lost the turn the UI is showing:
+// durable state is what the user sees, so it is what Stop must be able to act on.
+func (q *Queries) GetRunningTurnForConversation(ctx context.Context, conversationID string) (GetRunningTurnForConversationRow, error) {
+	row := q.db.QueryRowContext(ctx, getRunningTurnForConversation, conversationID)
+	var i GetRunningTurnForConversationRow
+	err := row.Scan(&i.ID, &i.ProviderTurnID)
+	return i, err
+}
+
 const insertConversation = `-- name: InsertConversation :exec
 
 INSERT INTO conversations (

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -496,28 +496,6 @@ func (q *Queries) FailRolledBackConversationApprovals(ctx context.Context, arg F
 	return err
 }
 
-const getRunningTurnForConversation = `-- name: GetRunningTurnForConversation :one
-SELECT id, provider_turn_id FROM conversation_turns
-WHERE conversation_id = ? AND state = 'running'
-ORDER BY started_at DESC
-LIMIT 1
-`
-
-type GetRunningTurnForConversationRow struct {
-	ID             string
-	ProviderTurnID string
-}
-
-// The most recent turn SQLite still considers running. Interrupt uses it to
-// recover when in-memory turn tracking has lost the turn the UI is showing:
-// durable state is what the user sees, so it is what Stop must be able to act on.
-func (q *Queries) GetRunningTurnForConversation(ctx context.Context, conversationID string) (GetRunningTurnForConversationRow, error) {
-	row := q.db.QueryRowContext(ctx, getRunningTurnForConversation, conversationID)
-	var i GetRunningTurnForConversationRow
-	err := row.Scan(&i.ID, &i.ProviderTurnID)
-	return i, err
-}
-
 const insertConversation = `-- name: InsertConversation :exec
 
 INSERT INTO conversations (
@@ -769,6 +747,66 @@ type InterruptRolledBackQueuedTurnsParams struct {
 func (q *Queries) InterruptRolledBackQueuedTurns(ctx context.Context, arg InterruptRolledBackQueuedTurnsParams) error {
 	_, err := q.db.ExecContext(ctx, interruptRolledBackQueuedTurns, arg.CompletedAt, arg.ConversationID)
 	return err
+}
+
+const listVisibleRunningTurnsForConversation = `-- name: ListVisibleRunningTurnsForConversation :many
+WITH RECURSIVE active_path(branch_id, max_sequence) AS (
+    SELECT conversations.active_branch_id, CAST(NULL AS INTEGER)
+    FROM conversations
+    WHERE conversations.id = ?1
+    UNION ALL
+    SELECT branch.parent_branch_id,
+           CASE
+               WHEN path.max_sequence IS NULL THEN branch.fork_after_sequence
+               WHEN branch.fork_after_sequence < path.max_sequence THEN branch.fork_after_sequence
+               ELSE path.max_sequence
+           END
+    FROM active_path AS path
+    JOIN conversation_branches AS branch ON branch.id = path.branch_id
+    WHERE branch.parent_branch_id IS NOT NULL
+)
+SELECT conversation_turns.provider_turn_id FROM conversation_turns
+JOIN active_path AS path ON path.branch_id = conversation_turns.branch_id
+WHERE conversation_turns.conversation_id = ?1
+  AND conversation_turns.state = 'running'
+  AND conversation_turns.promoted_to_turn_id IS NULL
+  AND (path.max_sequence IS NULL OR EXISTS (
+      SELECT 1 FROM conversation_messages AS lineage_message
+      WHERE lineage_message.turn_id = conversation_turns.id
+        AND lineage_message.sequence <= path.max_sequence
+      UNION ALL
+      SELECT 1 FROM conversation_activities AS lineage_activity
+      WHERE lineage_activity.turn_id = conversation_turns.id
+        AND lineage_activity.sequence <= path.max_sequence
+  ))
+ORDER BY conversation_turns.requested_at, conversation_turns.rowid
+`
+
+// The running turns visible on the active branch, in the same order as the
+// snapshot. Interrupt uses this exact projection when in-memory turn tracking
+// has lost what the UI is showing; nested provider turns mean more than one row
+// can legitimately be running at once, and Stop must not leave one behind.
+func (q *Queries) ListVisibleRunningTurnsForConversation(ctx context.Context, conversationID string) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listVisibleRunningTurnsForConversation, conversationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var provider_turn_id string
+		if err := rows.Scan(&provider_turn_id); err != nil {
+			return nil, err
+		}
+		items = append(items, provider_turn_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const markConversationCompacted = `-- name: MarkConversationCompacted :exec

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -336,14 +336,41 @@ SET state = 'failed',
     completed_at = ?
 WHERE handled_by_session_id = ? AND state IN ('queued', 'running');
 
--- The most recent turn SQLite still considers running. Interrupt uses it to
--- recover when in-memory turn tracking has lost the turn the UI is showing:
--- durable state is what the user sees, so it is what Stop must be able to act on.
--- name: GetRunningTurnForConversation :one
-SELECT id, provider_turn_id FROM conversation_turns
-WHERE conversation_id = ? AND state = 'running'
-ORDER BY started_at DESC
-LIMIT 1;
+-- The running turns visible on the active branch, in the same order as the
+-- snapshot. Interrupt uses this exact projection when in-memory turn tracking
+-- has lost what the UI is showing; nested provider turns mean more than one row
+-- can legitimately be running at once, and Stop must not leave one behind.
+-- name: ListVisibleRunningTurnsForConversation :many
+WITH RECURSIVE active_path(branch_id, max_sequence) AS (
+    SELECT conversations.active_branch_id, CAST(NULL AS INTEGER)
+    FROM conversations
+    WHERE conversations.id = sqlc.arg(conversation_id)
+    UNION ALL
+    SELECT branch.parent_branch_id,
+           CASE
+               WHEN path.max_sequence IS NULL THEN branch.fork_after_sequence
+               WHEN branch.fork_after_sequence < path.max_sequence THEN branch.fork_after_sequence
+               ELSE path.max_sequence
+           END
+    FROM active_path AS path
+    JOIN conversation_branches AS branch ON branch.id = path.branch_id
+    WHERE branch.parent_branch_id IS NOT NULL
+)
+SELECT conversation_turns.provider_turn_id FROM conversation_turns
+JOIN active_path AS path ON path.branch_id = conversation_turns.branch_id
+WHERE conversation_turns.conversation_id = sqlc.arg(conversation_id)
+  AND conversation_turns.state = 'running'
+  AND conversation_turns.promoted_to_turn_id IS NULL
+  AND (path.max_sequence IS NULL OR EXISTS (
+      SELECT 1 FROM conversation_messages AS lineage_message
+      WHERE lineage_message.turn_id = conversation_turns.id
+        AND lineage_message.sequence <= path.max_sequence
+      UNION ALL
+      SELECT 1 FROM conversation_activities AS lineage_activity
+      WHERE lineage_activity.turn_id = conversation_turns.id
+        AND lineage_activity.sequence <= path.max_sequence
+  ))
+ORDER BY conversation_turns.requested_at, conversation_turns.rowid;
 
 -- Overwrite the turn's changed-file summary. The provider re-sends the whole diff
 -- on every update, so the latest payload is the complete answer and there is

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -336,6 +336,15 @@ SET state = 'failed',
     completed_at = ?
 WHERE handled_by_session_id = ? AND state IN ('queued', 'running');
 
+-- The most recent turn SQLite still considers running. Interrupt uses it to
+-- recover when in-memory turn tracking has lost the turn the UI is showing:
+-- durable state is what the user sees, so it is what Stop must be able to act on.
+-- name: GetRunningTurnForConversation :one
+SELECT id, provider_turn_id FROM conversation_turns
+WHERE conversation_id = ? AND state = 'running'
+ORDER BY started_at DESC
+LIMIT 1;
+
 -- Overwrite the turn's changed-file summary. The provider re-sends the whole diff
 -- on every update, so the latest payload is the complete answer and there is
 -- nothing to merge with what was there before.

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -679,21 +679,19 @@ func (s *Store) SettleOrphanedTurns(ctx context.Context, session domain.SessionI
 	return nil
 }
 
-// GetRunningTurn returns the most recent turn SQLite still considers running.
-//
-// Interrupt uses it to recover from a desync where the in-memory controller has
-// lost track of a turn the durable state — and therefore the UI — still shows as
-// running. The durable row is what the user is looking at, so it is what Stop
-// must be able to act on.
-func (s *Store) GetRunningTurn(ctx context.Context, conversationID string) (id, providerTurnID string, ok bool, err error) {
-	row, err := s.qr.GetRunningTurnForConversation(ctx, conversationID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", "", false, nil
-	}
+// ListVisibleRunningTurnProviderIDs returns the same active-branch running turns,
+// in the same order, that a conversation snapshot exposes to clients. Interrupt
+// uses the full set because a root and nested provider turn may overlap; settling
+// only one would leave the UI's Working state behind.
+func (s *Store) ListVisibleRunningTurnProviderIDs(
+	ctx context.Context,
+	conversationID string,
+) ([]string, error) {
+	providerTurnIDs, err := s.qr.ListVisibleRunningTurnsForConversation(ctx, conversationID)
 	if err != nil {
-		return "", "", false, fmt.Errorf("get running turn for %s: %w", conversationID, err)
+		return nil, fmt.Errorf("list visible running turns for %s: %w", conversationID, err)
 	}
-	return row.ID, row.ProviderTurnID, true, nil
+	return providerTurnIDs, nil
 }
 
 // SetConversationSettings records the provider choices for the next turn.

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -679,6 +679,23 @@ func (s *Store) SettleOrphanedTurns(ctx context.Context, session domain.SessionI
 	return nil
 }
 
+// GetRunningTurn returns the most recent turn SQLite still considers running.
+//
+// Interrupt uses it to recover from a desync where the in-memory controller has
+// lost track of a turn the durable state — and therefore the UI — still shows as
+// running. The durable row is what the user is looking at, so it is what Stop
+// must be able to act on.
+func (s *Store) GetRunningTurn(ctx context.Context, conversationID string) (id, providerTurnID string, ok bool, err error) {
+	row, err := s.qr.GetRunningTurnForConversation(ctx, conversationID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, fmt.Errorf("get running turn for %s: %w", conversationID, err)
+	}
+	return row.ID, row.ProviderTurnID, true, nil
+}
+
 // SetConversationSettings records the provider choices for the next turn.
 //
 // An empty field is stored as NULL rather than as an empty string, so "the user

--- a/frontend/src/renderer/hooks/useConversation.test.tsx
+++ b/frontend/src/renderer/hooks/useConversation.test.tsx
@@ -306,6 +306,29 @@ describe("tool server reload refusals", () => {
 });
 
 describe("controller recovery", () => {
+	it("refreshes the conversation after Stop reports stale turn state", async () => {
+		postMock.mockResolvedValue({
+			data: undefined,
+			error: { code: "CHAT_NO_ACTIVE_TURN" },
+			response: { status: 409 },
+		});
+		const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+
+		const { result } = renderHook(() => useConversationCommands("ao-1"), { wrapper });
+		act(() => {
+			result.current.interrupt();
+		});
+
+		await waitFor(() => {
+			expect(postMock).toHaveBeenCalledWith(
+				"/api/v1/sessions/{sessionId}/conversation/interrupt",
+				{ params: { path: { sessionId: "ao-1" } } },
+			);
+			expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversation", "ao-1"] });
+		});
+		invalidateSpy.mockRestore();
+	});
+
 	it("resumes the agent and refreshes both chat and task state", async () => {
 		postMock.mockResolvedValue({ data: {}, error: undefined, response: { status: 200 } });
 		const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -222,6 +222,10 @@ export function useConversationCommands(sessionId: string | undefined) {
 			if (error) throw error;
 		},
 		onSuccess: invalidate,
+		// A failed interrupt (e.g. CHAT_NO_ACTIVE_TURN) means the cached turn
+		// state is wrong. Refetch so the UI discovers the real state instead of
+		// keeping a Working bar the user cannot dismiss.
+		onError: invalidate,
 	});
 
 	const resume = useMutation({

--- a/packages/mobile/lib/chat/useConversation.ts
+++ b/packages/mobile/lib/chat/useConversation.ts
@@ -225,7 +225,12 @@ export function useMobileConversation(
 	}, [refresh]);
 
 	const runAction = useCallback(
-		async <T,>(kind: ConversationAction, action: () => Promise<T>, resetHistoricalPages = false): Promise<T> => {
+		async <T,>(
+			kind: ConversationAction,
+			action: () => Promise<T>,
+			resetHistoricalPages = false,
+			refreshOnError = false,
+		): Promise<T> => {
 			setPendingActions((old) => old.includes(kind) ? old : [...old, kind]);
 			setActionError(undefined);
 			setActionErrors((old) => ({ ...old, [kind]: undefined }));
@@ -240,6 +245,9 @@ export function useMobileConversation(
 				setActionError(message);
 				setActionErrors((old) => ({ ...old, [kind]: message }));
 				setActionCodes((old) => ({ ...old, [kind]: conversationErrorCode(cause) }));
+				// A failed stop can mean the cached turn state is stale; reload so
+				// the user is not stuck looking at a Working bar that is not real.
+				if (refreshOnError) void refresh();
 				throw new Error(message);
 			} finally {
 				setPendingActions((old) => old.filter((candidate) => candidate !== kind));
@@ -301,7 +309,7 @@ export function useMobileConversation(
 		[cfg, runAction, sessionId],
 	);
 	const interrupt = useCallback(
-		() => runAction("interrupt", () => requireConfig(cfg, (c) => interruptConversation(c, sessionId))),
+		() => runAction("interrupt", () => requireConfig(cfg, (c) => interruptConversation(c, sessionId)), false, true),
 		[cfg, runAction, sessionId],
 	);
 	const resolveApprovalAction = useCallback(

--- a/packages/mobile/lib/chat/useConversation.ts
+++ b/packages/mobile/lib/chat/useConversation.ts
@@ -225,12 +225,7 @@ export function useMobileConversation(
 	}, [refresh]);
 
 	const runAction = useCallback(
-		async <T,>(
-			kind: ConversationAction,
-			action: () => Promise<T>,
-			resetHistoricalPages = false,
-			refreshOnError = false,
-		): Promise<T> => {
+		async <T,>(kind: ConversationAction, action: () => Promise<T>, resetHistoricalPages = false): Promise<T> => {
 			setPendingActions((old) => old.includes(kind) ? old : [...old, kind]);
 			setActionError(undefined);
 			setActionErrors((old) => ({ ...old, [kind]: undefined }));
@@ -245,9 +240,6 @@ export function useMobileConversation(
 				setActionError(message);
 				setActionErrors((old) => ({ ...old, [kind]: message }));
 				setActionCodes((old) => ({ ...old, [kind]: conversationErrorCode(cause) }));
-				// A failed stop can mean the cached turn state is stale; reload so
-				// the user is not stuck looking at a Working bar that is not real.
-				if (refreshOnError) void refresh();
 				throw new Error(message);
 			} finally {
 				setPendingActions((old) => old.filter((candidate) => candidate !== kind));
@@ -309,7 +301,7 @@ export function useMobileConversation(
 		[cfg, runAction, sessionId],
 	);
 	const interrupt = useCallback(
-		() => runAction("interrupt", () => requireConfig(cfg, (c) => interruptConversation(c, sessionId)), false, true),
+		() => runAction("interrupt", () => requireConfig(cfg, (c) => interruptConversation(c, sessionId))),
 		[cfg, runAction, sessionId],
 	);
 	const resolveApprovalAction = useCallback(


### PR DESCRIPTION
Fixes https://github.com/Untrivial-ai/agent-orchestrator/issues/3749

## Summary

- Treat the durable running turn rendered by the UI as actionable when Stop finds no in-memory turn.
- Make Stop linearize with dispatch under `sendMu`, capture the exact pre-Stop target and queue cutoff, and wait for that turn acknowledgment without following ownership to newer work.
- Reconcile every running turn visible on the active branch, including overlapping root and nested provider turns, while keeping provider cancellation best-effort.
- Move controller-state memory changes after the durable projection commits so a rollback cannot recreate the memory/SQLite split.
- Refetch the desktop conversation after an interrupt error so stale cached Working state is not left on screen.

PR #3890 is merged into `main` and supplies the nested-turn ownership rules this recovery path relies on. This PR is based directly on current `main` and contains only the focused recovery work for #3749.

The implementation was adapted from PR #3752 by @bluwwi and extracted from the tested recovery work in PR #3986. Contributor attribution is preserved in the commit history.

## Regression coverage

- The exact #3749 projection-rollback sequence: SQLite remains `running`, the provider refuses Stop, and reconciliation settles the durable state.
- A durable running turn with no in-memory pending ID.
- A genuine absence of both durable and in-memory running work.
- Stop racing an in-progress dispatch waits for provider acknowledgment.
- Root and nested visible running turns are both settled, while Stop targets the same oldest/root turn shown by the UI.
- Queue cancellation during recovery without accidental dispatch of pre-Stop work.
- A prompt submitted after Stop survives durable fallback and provider-refusal recovery.
- A completion committed before provider refusal is not overwritten.
- Controller state changes only after projection commit.
- Recovered interrupted turns have no error message.
- Desktop interrupt errors invalidate the conversation query.

## Verification

- `cd backend && go build ./...`
- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `cd backend && go test -race ./internal/service/chat -count=1`
- focused recovery/concurrency tests repeated under the race detector
- `npm run sqlc` with no generated drift
- `npm --prefix frontend run typecheck`
- focused frontend hook suite: 13 tests passed
- golangci-lint v2.12.2: 0 issues with an isolated cache
