### PR TITLE
fix: reset model scope across agent switches

### DIFF
--- a/backend/internal/session_manager/agent_switching.go
+++ b/backend/internal/session_manager/agent_switching.go
@@ -1101,6 +1101,10 @@ func (m *Manager) prepareTargetActivation(ctx context.Context, store ports.Agent
 		return preparedTargetActivation{}, fmt.Errorf("system prompt file: %w", err)
 	}
 	config := effectiveAgentConfig(rec.Kind, project.Config)
+	if roleOverride(rec.Kind, project.Config).Harness != harness {
+		config.Model = ""
+		config.Mode = ""
+	}
 	if model := strings.TrimSpace(modelOverride); model != "" {
 		config.Model = model
 	}

--- a/backend/internal/session_manager/agent_switching_test.go
+++ b/backend/internal/session_manager/agent_switching_test.go
@@ -399,6 +399,8 @@ type switchTestAgent struct {
 	launchPrompt        string
 	launchNativeID      string
 	launchModel         string
+	launchMode          string
+	launchPermissions   ports.PermissionMode
 	restorePrompt       string
 	restoreModel        string
 	launchSystemPrompt  string
@@ -577,6 +579,8 @@ func (a *switchTestAgent) GetLaunchCommand(_ context.Context, cfg ports.LaunchCo
 	a.launchPrompt = cfg.Prompt
 	a.launchNativeID = cfg.NativeSessionID
 	a.launchModel = cfg.Config.Model
+	a.launchMode = cfg.Config.Mode
+	a.launchPermissions = cfg.Config.Permissions
 	a.launchSystemPrompt = cfg.SystemPrompt
 	a.launchSystemFile = cfg.SystemPromptFile
 	return []string{"agent", "fresh", cfg.Prompt}, nil
@@ -1855,6 +1859,10 @@ func TestSwitchAgentTranscriptReadFailureUsesSingleTerminalFallback(t *testing.T
 func TestSwitchAgentResumesVerifiedPriorNativeSession(t *testing.T) {
 	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{}}
 	manager, store, _ := newSwitchTestManager(t, runtime)
+	project := store.projects["proj"]
+	project.Config.Worker.Harness = domain.HarnessCodex
+	project.Config.Worker.AgentConfig.Model = "target-model"
+	store.projects[project.ID] = project
 	target := manager.agents.(switchTestAgents)[domain.HarnessCodex].(*switchTestAgent)
 	target.available["codex-prior"] = ports.NativeSessionAvailabilityAvailable
 	now := time.Now().UTC().Add(-time.Hour)
@@ -1864,7 +1872,7 @@ func TestSwitchAgentResumesVerifiedPriorNativeSession(t *testing.T) {
 		LastGenerationID: "old-generation", CreatedAt: now, LastUsedAt: now,
 	}
 
-	sw, err := switchAgentSynchronously(context.Background(), manager, "proj-1", SwitchAgentConfig{TargetHarness: domain.HarnessCodex, Model: " target-model ", IdempotencyKey: "resume-prior"})
+	sw, err := switchAgentSynchronously(context.Background(), manager, "proj-1", SwitchAgentConfig{TargetHarness: domain.HarnessCodex, IdempotencyKey: "resume-prior"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1885,6 +1893,10 @@ func TestSwitchAgentResumesVerifiedPriorNativeSession(t *testing.T) {
 func TestSwitchAgentUnknownResumeEvidenceStartsFresh(t *testing.T) {
 	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{}}
 	manager, store, _ := newSwitchTestManager(t, runtime)
+	project := store.projects["proj"]
+	project.Config.Worker.Harness = domain.HarnessCodex
+	project.Config.Worker.AgentConfig.Model = "target-model"
+	store.projects[project.ID] = project
 	target := manager.agents.(switchTestAgents)[domain.HarnessCodex].(*switchTestAgent)
 	now := time.Now().UTC().Add(-time.Hour)
 	store.native["native-unknown"] = domain.AgentNativeSession{
@@ -1893,7 +1905,7 @@ func TestSwitchAgentUnknownResumeEvidenceStartsFresh(t *testing.T) {
 		LastGenerationID: "old-generation", CreatedAt: now, LastUsedAt: now,
 	}
 
-	sw, err := switchAgentSynchronously(context.Background(), manager, "proj-1", SwitchAgentConfig{TargetHarness: domain.HarnessCodex, Model: " target-model ", IdempotencyKey: "fresh-on-unknown"})
+	sw, err := switchAgentSynchronously(context.Background(), manager, "proj-1", SwitchAgentConfig{TargetHarness: domain.HarnessCodex, IdempotencyKey: "fresh-on-unknown"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1902,6 +1914,134 @@ func TestSwitchAgentUnknownResumeEvidenceStartsFresh(t *testing.T) {
 	}
 	if target.launchModel != "target-model" {
 		t.Fatalf("launch model = %q, want target-model", target.launchModel)
+	}
+}
+
+func TestSwitchAgentModelCodexToClaudeDropsSourceOverride(t *testing.T) {
+	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{}}
+	manager, store, _ := newSwitchTestManager(t, runtime)
+	rec := store.sessions["proj-1"]
+	rec.Harness = domain.HarnessCodex
+	store.sessions[rec.ID] = rec
+	project := store.projects[string(rec.ProjectID)]
+	project.Config.Worker.Harness = domain.HarnessCodex
+	project.Config.Worker.AgentConfig.Model = "gpt-5.4-mini"
+	store.projects[project.ID] = project
+	target := manager.agents.(switchTestAgents)[domain.HarnessClaudeCode].(*switchTestAgent)
+
+	switchRecord, err := switchAgentSynchronously(context.Background(), manager, rec.ID, SwitchAgentConfig{
+		TargetHarness:  domain.HarnessClaudeCode,
+		IdempotencyKey: "codex-to-claude-drops-model",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if switchRecord.State != domain.AgentSwitchCompleted {
+		t.Fatalf("switch state = %q, want completed", switchRecord.State)
+	}
+	if target.launchModel != "" {
+		t.Fatalf("Claude target launch model = %q, want no source override", target.launchModel)
+	}
+}
+
+func TestSwitchAgentModelClaudeToCodexDropsSourceOverride(t *testing.T) {
+	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{}}
+	manager, store, _ := newSwitchTestManager(t, runtime)
+	project := store.projects["proj"]
+	project.Config.Worker.Harness = domain.HarnessClaudeCode
+	project.Config.Worker.AgentConfig.Model = "opus"
+	store.projects[project.ID] = project
+	target := manager.agents.(switchTestAgents)[domain.HarnessCodex].(*switchTestAgent)
+
+	switchRecord, err := switchAgentSynchronously(context.Background(), manager, "proj-1", SwitchAgentConfig{
+		TargetHarness:  domain.HarnessCodex,
+		IdempotencyKey: "claude-to-codex-drops-model",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if switchRecord.State != domain.AgentSwitchCompleted {
+		t.Fatalf("switch state = %q, want completed", switchRecord.State)
+	}
+	if target.launchModel != "" {
+		t.Fatalf("Codex target launch model = %q, want no source override", target.launchModel)
+	}
+}
+
+func TestSwitchAgentModelUsesConfiguredTargetDefault(t *testing.T) {
+	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{}}
+	manager, store, _ := newSwitchTestManager(t, runtime)
+	project := store.projects["proj"]
+	project.Config.Worker.Harness = domain.HarnessCodex
+	project.Config.Worker.AgentConfig.Model = "target-default"
+	store.projects[project.ID] = project
+	target := manager.agents.(switchTestAgents)[domain.HarnessCodex].(*switchTestAgent)
+
+	switchRecord, err := switchAgentSynchronously(context.Background(), manager, "proj-1", SwitchAgentConfig{
+		TargetHarness:  domain.HarnessCodex,
+		IdempotencyKey: "configured-target-default",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if switchRecord.State != domain.AgentSwitchCompleted {
+		t.Fatalf("switch state = %q, want completed", switchRecord.State)
+	}
+	if target.launchModel != "target-default" {
+		t.Fatalf("Codex target launch model = %q, want configured target default", target.launchModel)
+	}
+}
+
+func TestSwitchAgentModelUsesExplicitTargetOverride(t *testing.T) {
+	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{}}
+	manager, store, _ := newSwitchTestManager(t, runtime)
+	project := store.projects["proj"]
+	project.Config.Worker.Harness = domain.HarnessClaudeCode
+	project.Config.Worker.AgentConfig.Model = "opus"
+	store.projects[project.ID] = project
+	target := manager.agents.(switchTestAgents)[domain.HarnessCodex].(*switchTestAgent)
+
+	switchRecord, err := switchAgentSynchronously(context.Background(), manager, "proj-1", SwitchAgentConfig{
+		TargetHarness:  domain.HarnessCodex,
+		Model:          "gpt-target",
+		IdempotencyKey: "explicit-target-model",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if switchRecord.State != domain.AgentSwitchCompleted {
+		t.Fatalf("switch state = %q, want completed", switchRecord.State)
+	}
+	if target.launchModel != "gpt-target" {
+		t.Fatalf("Codex target launch model = %q, want explicit target override", target.launchModel)
+	}
+}
+
+func TestSwitchAgentTargetConfigDropsSourceModeAndPreservesPermissions(t *testing.T) {
+	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{}}
+	manager, store, _ := newSwitchTestManager(t, runtime)
+	project := store.projects["proj"]
+	project.Config.AgentConfig.Permissions = domain.PermissionModeAuto
+	project.Config.Worker.Harness = domain.HarnessClaudeCode
+	project.Config.Worker.AgentConfig.Mode = "high"
+	store.projects[project.ID] = project
+	target := manager.agents.(switchTestAgents)[domain.HarnessCodex].(*switchTestAgent)
+
+	switchRecord, err := switchAgentSynchronously(context.Background(), manager, "proj-1", SwitchAgentConfig{
+		TargetHarness:  domain.HarnessCodex,
+		IdempotencyKey: "target-config-scope",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if switchRecord.State != domain.AgentSwitchCompleted {
+		t.Fatalf("switch state = %q, want completed", switchRecord.State)
+	}
+	if target.launchMode != "" {
+		t.Fatalf("Codex target launch mode = %q, want no source override", target.launchMode)
+	}
+	if target.launchPermissions != ports.PermissionModeAuto {
+		t.Fatalf("Codex target permissions = %q, want %q", target.launchPermissions, ports.PermissionModeAuto)
 	}
 }
 

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -918,6 +918,24 @@ func (q *Queries) ReserveQueuedConversationTurnForPromotion(ctx context.Context,
 	return result.RowsAffected()
 }
 
+const resetConversationAgentOverridesForSession = `-- name: ResetConversationAgentOverridesForSession :exec
+UPDATE conversations
+SET model = NULL, reasoning_effort = NULL, updated_at = ?
+WHERE current_session_id = ?
+`
+
+type ResetConversationAgentOverridesForSessionParams struct {
+	UpdatedAt        time.Time
+	CurrentSessionID *domain.SessionID
+}
+
+// An agent switch starts a new provider/model scope. Clear only the source
+// harness choices; approval posture is AO-owned and remains applicable.
+func (q *Queries) ResetConversationAgentOverridesForSession(ctx context.Context, arg ResetConversationAgentOverridesForSessionParams) error {
+	_, err := q.db.ExecContext(ctx, resetConversationAgentOverridesForSession, arg.UpdatedAt, arg.CurrentSessionID)
+	return err
+}
+
 const resolveConversationApproval = `-- name: ResolveConversationApproval :exec
 UPDATE conversation_activities
 SET status = 'resolved', detail_json = ?, revision = revision + 1, updated_at = ?

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -151,6 +151,13 @@ UPDATE conversations
 SET model = ?, reasoning_effort = ?, approval_mode = ?, updated_at = ?
 WHERE id = ?;
 
+-- An agent switch starts a new provider/model scope. Clear only the source
+-- harness choices; approval posture is AO-owned and remains applicable.
+-- name: ResetConversationAgentOverridesForSession :exec
+UPDATE conversations
+SET model = NULL, reasoning_effort = NULL, updated_at = ?
+WHERE current_session_id = ?;
+
 -- Token position for the conversation, latest wins.
 --
 -- The provider reports this after every tool call, so this UPDATE runs often and

--- a/backend/internal/storage/sqlite/store/agent_switching_store.go
+++ b/backend/internal/storage/sqlite/store/agent_switching_store.go
@@ -544,6 +544,11 @@ func (s *Store) ActivateAgentSwitchTarget(ctx context.Context, activation domain
 	if n != 1 {
 		return false, nil
 	}
+	if err := q.ResetConversationAgentOverridesForSession(ctx, gen.ResetConversationAgentOverridesForSessionParams{
+		UpdatedAt: activation.ActivatedAt, CurrentSessionID: &activation.SessionID,
+	}); err != nil {
+		return false, fmt.Errorf("activate agent switch target %s: reset conversation agent overrides: %w", activation.SwitchID, err)
+	}
 	targetRef := activation.TargetNativeSessionRef
 	n, err = q.MarkAgentSwitchTargetReady(ctx, gen.MarkAgentSwitchTargetReadyParams{
 		ActivatedAt: activation.ActivatedAt, ID: activation.SwitchID,

--- a/backend/internal/storage/sqlite/store/agent_switching_store_test.go
+++ b/backend/internal/storage/sqlite/store/agent_switching_store_test.go
@@ -927,6 +927,15 @@ func TestAgentSwitchSourceStopAndTargetActivationAreAtomicAndNarrow(t *testing.T
 	if err != nil {
 		t.Fatalf("create AO session: %v", err)
 	}
+	conversation, err := s.CreateConversation(ctx, "conversation-switch-activation", domain.ConversationScopeSession, session.ProjectID, session.ID, now)
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	if err := s.SetConversationSettings(ctx, conversation.ID, domain.ConversationSettings{
+		Model: "source-model", ReasoningEffort: "source-mode", ApprovalMode: domain.PermissionModeAcceptEdits,
+	}, now); err != nil {
+		t.Fatalf("set source conversation settings: %v", err)
+	}
 	target := domain.AgentNativeSession{
 		ID: "activation-target", AOSessionID: session.ID, Harness: domain.HarnessCodex,
 		NativeSessionID: "codex-native-id",
@@ -1048,6 +1057,10 @@ func TestAgentSwitchSourceStopAndTargetActivationAreAtomicAndNarrow(t *testing.T
 	if ok, err := s.ActivateAgentSwitchTarget(ctx, activation); err != nil || ok {
 		t.Fatalf("stale runtime handle activation: ok=%v err=%v", ok, err)
 	}
+	unchangedConversation, err := s.ConversationForSession(ctx, session.ID)
+	if err != nil || unchangedConversation.Settings.Model != "source-model" || unchangedConversation.Settings.ReasoningEffort != "source-mode" {
+		t.Fatalf("stale activation changed conversation settings: conversation=%+v err=%v", unchangedConversation, err)
+	}
 	unchanged, ok, err = s.GetSession(ctx, session.ID)
 	if err != nil || !ok || unchanged.Harness != domain.HarnessClaudeCode || unchanged.Activity.State != domain.ActivityExited {
 		t.Fatalf("stale runtime handle partially mutated session: session=%+v ok=%v err=%v", unchanged, ok, err)
@@ -1067,6 +1080,13 @@ func TestAgentSwitchSourceStopAndTargetActivationAreAtomicAndNarrow(t *testing.T
 	}
 	if !activated.FirstSignalAt.IsZero() {
 		t.Fatalf("target activation retained old hook receipt: %v", activated.FirstSignalAt)
+	}
+	activatedConversation, err := s.ConversationForSession(ctx, session.ID)
+	if err != nil {
+		t.Fatalf("get activated conversation: %v", err)
+	}
+	if activatedConversation.Settings.Model != "" || activatedConversation.Settings.ReasoningEffort != "" || activatedConversation.Settings.ApprovalMode != domain.PermissionModeAcceptEdits {
+		t.Fatalf("target activation conversation settings = %+v, want target-default model/mode and preserved approval", activatedConversation.Settings)
 	}
 	if activated.IsTerminated || activated.DisplayName != rec.DisplayName ||
 		activated.TerminateOnPRMerge != rec.TerminateOnPRMerge || activated.CleanupGeneration != rec.CleanupGeneration ||

--- a/frontend/src/renderer/components/SwitchAgentDialog.test.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.test.tsx
@@ -144,6 +144,42 @@ describe("SwitchAgentDialog", () => {
 		expect(onOpenChange).toHaveBeenCalledWith(false);
 	});
 
+	it("resets the previous target model when the active agent changes", async () => {
+		const { queryClient, rerender } = renderDialog();
+		const dialog = screen.getByRole("dialog", { name: "Switch agent" });
+		await userEvent.click(within(dialog).getByRole("button", { name: "Model" }));
+		await userEvent.click(screen.getByRole("menuitem", { name: "GPT-5.4 Mini" }));
+		expect(within(dialog).getByRole("button", { name: "Model" })).toHaveTextContent("GPT-5.4 Mini");
+
+		const switchedSession = { ...worker, provider: "codex" as const };
+		rerender(
+			<QueryClientProvider client={queryClient}>
+				<SwitchAgentDialog
+					container={document.body}
+					onOpenChange={vi.fn()}
+					open
+					session={switchedSession}
+				/>
+			</QueryClientProvider>,
+		);
+
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent(
+				"Use Claude Code's default",
+			),
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Switch" }));
+		expect(switchMocks.mutate).toHaveBeenLastCalledWith(
+			{
+				idempotencyKey: "idempotency-1",
+				model: "",
+				session: switchedSession,
+				targetHarness: "claude-code",
+			},
+			{ onSuccess: expect.any(Function) },
+		);
+	});
+
 	it("keeps admission controls visible but disabled while displaying Starting...", () => {
 		switchMocks.state.isPending = true;
 

--- a/frontend/src/renderer/components/SwitchAgentDialog.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.tsx
@@ -156,6 +156,12 @@ export function SwitchAgentDialog({ container, open, session, onOpenChange }: Sw
 	const [refreshingRecovery, setRefreshingRecovery] = useState(false);
 	const operationPending = admissionPending || recoverAgentSwitch.isPending;
 	useEffect(() => {
+		setTargetHarness(session.provider === "claude-code" ? "codex" : "claude-code");
+		setModel("");
+		setMode("");
+		setModelWarning(undefined);
+	}, [session.provider]);
+	useEffect(() => {
 		if (open && durableSwitching) onOpenChange(false);
 	}, [durableSwitching, onOpenChange, open]);
 	const clearFailedAttempt = () => {

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -56,6 +56,14 @@ export function conversationQueryKey(sessionId: string) {
 	return ["conversation", sessionId] as const;
 }
 
+export function conversationModelsQueryKey(sessionId: string) {
+	return ["conversation-models", sessionId] as const;
+}
+
+export function conversationConfigOptionsQueryKey(sessionId: string) {
+	return ["conversation-config-options", sessionId] as const;
+}
+
 const CONVERSATION_PAGE_SIZE = 200;
 const CONFIG_OPTIONS_POLL_INTERVAL_MS = 5_000;
 
@@ -482,7 +490,7 @@ function steerRefusal(error: unknown): string | undefined {
  */
 export function useConversationModels(sessionId: string | undefined, enabled: boolean) {
 	const query = useQuery({
-		queryKey: ["conversation-models", sessionId ?? ""],
+		queryKey: conversationModelsQueryKey(sessionId ?? ""),
 		enabled: Boolean(sessionId) && enabled,
 		// The catalog changes on the scale of provider releases, not turns.
 		staleTime: 5 * 60 * 1000,
@@ -514,7 +522,7 @@ export function useConversationModels(sessionId: string | undefined, enabled: bo
  */
 export function useConversationConfigOptions(sessionId: string | undefined, enabled: boolean) {
 	const queryClient = useQueryClient();
-	const queryKey = ["conversation-config-options", sessionId ?? ""] as const;
+	const queryKey = conversationConfigOptionsQueryKey(sessionId ?? "");
 	const query = useQuery({
 		queryKey,
 		enabled: Boolean(sessionId) && enabled,

--- a/frontend/src/renderer/hooks/useSwitchAgent.test.tsx
+++ b/frontend/src/renderer/hooks/useSwitchAgent.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceSession } from "../types/workspace";
+
+const { postMock } = vi.hoisted(() => ({ postMock: vi.fn() }));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { POST: postMock },
+	apiErrorMessage: () => "request failed",
+}));
+
+import { useSwitchAgent } from "./useSwitchAgent";
+
+const session = {
+	activity: { state: "active", lastActivityAt: "2026-06-10T00:00:00Z" },
+	branch: "ao/sess-1",
+	id: "sess-1",
+	kind: "worker",
+	provider: "codex",
+	prs: [],
+	status: "working",
+	terminalHandleId: "source-terminal",
+	title: "do the thing",
+	updatedAt: "2026-06-10T00:00:00Z",
+	workspaceId: "proj-1",
+	workspaceName: "my-app",
+} satisfies WorkspaceSession;
+
+function wrapper(queryClient: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+	};
+}
+
+beforeEach(() => {
+	postMock.mockReset();
+});
+
+describe("useSwitchAgent", () => {
+	it("omits the default model and refreshes target conversation state", async () => {
+		postMock.mockResolvedValue({
+			data: {
+				switch: {
+					agentHandoffStatus: "not_attempted",
+					fromHarness: "codex",
+					id: "switch-1",
+					state: "preparing_handoff",
+					targetHarness: "claude-code",
+				},
+			},
+			error: undefined,
+			response: { status: 202 },
+		});
+		const queryClient = new QueryClient({
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		});
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+		const { result } = renderHook(() => useSwitchAgent(), { wrapper: wrapper(queryClient) });
+
+		await result.current.mutateAsync({
+			session,
+			targetHarness: "claude-code",
+			model: " ",
+			idempotencyKey: "switch-request-1",
+		});
+
+		expect(postMock).toHaveBeenCalledWith(
+			"/api/v1/sessions/{sessionId}/switch-agent",
+			{
+				params: { path: { sessionId: "sess-1" } },
+				body: { targetHarness: "claude-code", idempotencyKey: "switch-request-1" },
+			},
+		);
+		await waitFor(() => {
+			expect(invalidate).toHaveBeenCalledWith({ queryKey: ["conversation", "sess-1"] });
+			expect(invalidate).toHaveBeenCalledWith({ queryKey: ["conversation-models", "sess-1"] });
+			expect(invalidate).toHaveBeenCalledWith({ queryKey: ["conversation-config-options", "sess-1"] });
+		});
+	});
+});

--- a/frontend/src/renderer/hooks/useSwitchAgent.ts
+++ b/frontend/src/renderer/hooks/useSwitchAgent.ts
@@ -3,6 +3,11 @@ import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import type { WorkspaceSession } from "../types/workspace";
 import { agentSwitchesQueryKey, type AgentSwitch } from "./useAgentSwitches";
+import {
+	conversationConfigOptionsQueryKey,
+	conversationModelsQueryKey,
+	conversationQueryKey,
+} from "./useConversation";
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 
 export type SwitchAgentHarness = components["schemas"]["SwitchAgentRequest"]["targetHarness"];
@@ -110,6 +115,11 @@ export function useSwitchAgent() {
 				agentSwitchesQueryKey(variables.session.id),
 				(current = []) => [agentSwitch, ...current.filter((entry) => entry.id !== agentSwitch.id)],
 			);
+			void queryClient.invalidateQueries({ queryKey: conversationQueryKey(variables.session.id) });
+			void queryClient.invalidateQueries({ queryKey: conversationModelsQueryKey(variables.session.id) });
+			void queryClient.invalidateQueries({
+				queryKey: conversationConfigOptionsQueryKey(variables.session.id),
+			});
 		},
 		onSettled: (_data, _error, variables) => {
 			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });


### PR DESCRIPTION
## What

Apply the cross-agent model reset fix directly to `main`.

- Clear stale conversation model and reasoning overrides after an agent switch.
- Scope configured model/mode values to their configured harness while preserving harness-neutral permissions.
- Preserve an explicit target-model selection for the target launch or resume.
- Reset renderer model/mode controls and refetch the target catalog after switching.
- Add backend, storage, hook, and dialog regression coverage.

## Why

PR #3976 was merged into `codex/agent-switching-ux` after that feature branch had already been merged into `main` by PR #3770. Git does not propagate later commits from a closed feature branch into `main`, so the fix is not currently present there.

This PR ports the exact #3976 change onto current `main` as one focused commit.

## How

The backend treats an agent switch as a new model scope. Project/role model and mode settings are retained only when their configured harness matches the target; permissions remain applicable across harnesses. A non-empty model explicitly supplied by the switch request then overrides the target model.

The renderer clears local selection state and invalidates the target model/config catalog after a successful switch. The SQLite query source was applied and generated Go verified with `npm run sqlc`.

## Testing

- `cd backend && go test ./internal/session_manager ./internal/storage/sqlite/store -count=1`
- `cd frontend && npm test -- src/renderer/hooks/useSwitchAgent.test.tsx src/renderer/components/SwitchAgentDialog.test.tsx` (11 tests)
- `npm run frontend:typecheck`

## Checklist

- [x] Branched from current `main`
- [x] One focused change; direct-main follow-up to #3976
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant backend and frontend checks pass locally
