### PR TITLE
fix: link windows brand text to board

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -82,13 +82,14 @@ import { useKeybindingsStore } from "../stores/keybindings-store";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { CreateProjectFlow, type CreateProjectInput } from "./CreateProjectFlow";
 import { ResizeHandle } from "./ResizeHandle";
-import { isMacPlatform } from "../lib/platform";
+import { isMacPlatform, isWindowsPlatform } from "../lib/platform";
 import { useCloudSession } from "../lib/cloud-session";
 
 // macOS paints framed chrome: the fixed TitlebarNav cluster carries the
 // sidebar toggle + history arrows above this surface. Windows hangs the sidebar
 // under its custom titlebar.
 const isMac = isMacPlatform();
+const isWindows = isWindowsPlatform();
 const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
 // Shared styling for the per-project hover action buttons (orchestrator, kebab):
@@ -306,9 +307,26 @@ export function Sidebar({
 							{t("shell.orchestratorBoard")}
 						</TooltipContent>
 					</Tooltip>
-					<span className="sidebar-expanded-chrome min-w-0 flex-1 truncate text-sm font-bold leading-tight tracking-tight-lg text-foreground group-data-[collapsible=icon]:hidden">
-						Agent Orchestrator
-					</span>
+					{isWindows ? (
+						<span
+							aria-label={t("shell.orchestratorBoard")}
+							className="sidebar-expanded-chrome min-w-0 flex-1 truncate text-sm font-bold leading-tight tracking-tight-lg text-foreground group-data-[collapsible=icon]:hidden"
+							onClick={selection.goHome}
+							onKeyDown={(event: KeyboardEvent<HTMLSpanElement>) => {
+								if (event.key !== "Enter" && event.key !== " ") return;
+								event.preventDefault();
+								selection.goHome();
+							}}
+							role="button"
+							tabIndex={0}
+						>
+							Agent Orchestrator
+						</span>
+					) : (
+						<span className="sidebar-expanded-chrome min-w-0 flex-1 truncate text-sm font-bold leading-tight tracking-tight-lg text-foreground group-data-[collapsible=icon]:hidden">
+							Agent Orchestrator
+						</span>
+					)}
 					{isNightly && (
 						<span className="sidebar-expanded-chrome shrink-0 rounded-full bg-purple-subtle px-1.5 py-0.5 text-micro font-semibold leading-none text-purple-accent group-data-[collapsible=icon]:hidden">
 							{t("shell.nightly")}


### PR DESCRIPTION
## What

Made the Agent Orchestrator text clickable on Windows.

## Why

Logo already opens the board, but text was not doing same.

## Test

- `npm run frontend:typecheck`