### PR TITLE
fix: center windows startup panel

### DIFF
--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -726,7 +726,12 @@ function ShellLayout() {
 						workspaceError={workspaceQuery.isError ? errorMessage(workspaceQuery.error) : undefined}
 						workspaces={workspaces}
 					/>
-					<main className={cn("flex min-w-0 flex-1 flex-col overflow-x-hidden", !isSidebarOpen && "sidebar-hidden")}>
+					<main
+						className={cn(
+							"flex min-w-0 flex-1 flex-col overflow-x-hidden",
+							(!isSidebarOpen || (isWindows && isStartupLoading)) && "sidebar-hidden",
+						)}
+					>
 						<div className="min-h-0 flex-1 overflow-x-hidden">
 							{/* Board/session routes render inside the same inset box the welcome board and settings paint for themselves, so every screen sits within the app's outer boundary. */}
 							{hideShellTopbar ? (
@@ -742,7 +747,7 @@ function ShellLayout() {
 						)
 					) : framedAppTopbar ? (
 						<CenterPanelShell className={routeParams.sessionId ? "center-panel-shell--session" : undefined}>
-							{routeParams.sessionId ? null : (
+							{routeParams.sessionId || (isWindows && isStartupLoading) ? null : (
 								<ShellTopbar />
 							)}
 							<div className="flex min-h-0 flex-1 flex-col">


### PR DESCRIPTION
## What

Fix Windows startup board spacing.

## Why

During loading, sidebar is hidden but center panel still acted like sidebar was there. So left side had no margin and right side had margin.

Also hide the Board topbar during startup, so the loader is the only thing shown.

## Before
<img width="722" height="317" alt="image" src="https://github.com/user-attachments/assets/fd0356af-bf66-40f8-a9ed-624895691dad" />

## After
<img width="1504" height="638" alt="image" src="https://github.com/user-attachments/assets/226e17de-de1e-4963-809a-15559d828bbf" />

## Test

- `npm run frontend:typecheck`
- `npm --prefix frontend run test -- shell-new-session-shortcut.test.tsx`