### PR TITLE
feat(telemetry): price agent usage and export cost to PostHog

### DIFF
--- a/backend/internal/adapters/telemetry/posthog.go
+++ b/backend/internal/adapters/telemetry/posthog.go
@@ -34,6 +34,7 @@ var remoteEventNameAliases = map[string]string{
 	"ao.renderer.loaded":         "ao.v2.renderer.loaded",
 	"ao.renderer.api_error":      "ao.v2.renderer.api_error",
 	"ao.renderer.daemon_failure": "ao.v2.renderer.daemon_failure",
+	"ao.session.turn_usage":      "ao.v2.session.turn_usage",
 }
 
 var remoteCommandTokens = map[string]struct{}{
@@ -187,6 +188,19 @@ var remotePayloadAllowlist = map[string]map[string]struct{}{
 		"harness":     {},
 		"kind":        {},
 		"operation":   {},
+	},
+	"ao.session.turn_usage": {
+		"harness":               {},
+		"kind":                  {},
+		"model":                 {},
+		"model_priced":          {},
+		"input_tokens":          {},
+		"uncached_input_tokens": {},
+		"output_tokens":         {},
+		"cache_read_tokens":     {},
+		"cache_write_tokens":    {},
+		"total_tokens":          {},
+		"cost_usd":              {},
 	},
 	"ao.session.spawned": {
 		"duration_ms": {},

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -45,6 +45,7 @@ import (
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
 	settingssvc "github.com/aoagents/agent-orchestrator/backend/internal/service/settings"
 	usagesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/usage"
+	"github.com/aoagents/agent-orchestrator/backend/internal/service/usagecost"
 	"github.com/aoagents/agent-orchestrator/backend/internal/skillassets"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 	"github.com/aoagents/agent-orchestrator/backend/internal/terminal"
@@ -313,7 +314,9 @@ func Run() error {
 				usagePipeline.NotifyInventoryChanged()
 			}
 		})
-		ingestor := usagepipeline.NewIngestor(store, usagepipeline.IngestorConfig{})
+		ingestor := usagepipeline.NewIngestor(store, usagepipeline.IngestorConfig{
+			OnUsageApplied: usagecost.NewEmitter(telemetrySink, store).OnApplied,
+		})
 		usagePipeline = usagepipeline.NewPipeline(store, ingestor, []string{
 			roots.ClaudeProjects,
 			roots.CodexSessions,

--- a/backend/internal/observe/usage/ingestor.go
+++ b/backend/internal/observe/usage/ingestor.go
@@ -37,6 +37,11 @@ type IngestorConfig struct {
 	RecordBytes      int
 	FinalizationWait time.Duration
 	Clock            func() time.Time
+	// OnUsageApplied, when set, is invoked after a chunk's usage events are
+	// durably committed (exactly once, guarded by the source cursor). It lets a
+	// consumer price and export the events without this package depending on
+	// telemetry or pricing. Best-effort: it must not block or error the ingest.
+	OnUsageApplied func(context.Context, domain.SessionID, []domain.ModelUsageEvent)
 }
 
 // IngestResult tells the coordinator whether another immediate chunk, source
@@ -61,6 +66,7 @@ type Ingestor struct {
 	now              func() time.Time
 	openTranscript   func(string) (*os.File, error)
 	afterRead        func()
+	onUsageApplied   func(context.Context, domain.SessionID, []domain.ModelUsageEvent)
 }
 
 // NewIngestor constructs a bounded transcript ingestor.
@@ -84,6 +90,7 @@ func NewIngestor(store ingestorStore, cfg IngestorConfig) *Ingestor {
 		finalizationWait: cfg.FinalizationWait,
 		now:              cfg.Clock,
 		openTranscript:   os.Open,
+		onUsageApplied:   cfg.OnUsageApplied,
 	}
 }
 
@@ -311,6 +318,11 @@ func (i *Ingestor) Ingest(ctx context.Context, sourceID int64) (IngestResult, er
 			return result, nil
 		}
 		return result, fmt.Errorf("apply usage source %d: %w", source.Source.ID, err)
+	}
+	if i.onUsageApplied != nil && len(parsed.Events) > 0 {
+		// Events are now durably committed and the cursor advanced, so this
+		// fires exactly once per event across the source's lifetime.
+		i.onUsageApplied(ctx, source.SessionID, parsed.Events)
 	}
 	result.Reconcile = parsed.newCodexChild
 	if parsed.Cursor.State == domain.UsageSourceComplete {

--- a/backend/internal/observe/usage/usage_applied_test.go
+++ b/backend/internal/observe/usage/usage_applied_test.go
@@ -1,0 +1,49 @@
+package usage
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// The OnUsageApplied callback must fire after a chunk's events are durably
+// applied, carrying the source's session id and the parsed usage events. This
+// is the exactly-once seam the cost exporter hangs off.
+func TestIngestorFiresOnUsageAppliedAfterApply(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	store, source, path, now := seedCodexIngestionSource(t, dataDir)
+
+	transcript := `{"type":"session_meta","payload":{"model_provider":"openai"}}` + "\n" +
+		`{"type":"turn_context","payload":{"model":"gpt-5.6"}}` + "\n" +
+		string(codexTokenLine("2026-07-28T10:00:00Z", 100, 60, 0, 20, 5)) + "\n"
+	mustNoError(t, os.WriteFile(path, []byte(transcript), 0o600))
+
+	var gotSession domain.SessionID
+	var gotEvents []domain.ModelUsageEvent
+	calls := 0
+	ingestor := NewIngestor(store, IngestorConfig{
+		Clock: func() time.Time { return now },
+		OnUsageApplied: func(_ context.Context, sid domain.SessionID, evs []domain.ModelUsageEvent) {
+			calls++
+			gotSession = sid
+			gotEvents = append(gotEvents, evs...)
+		},
+	})
+	if _, err := ingestor.Ingest(ctx, source.ID); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	if len(gotEvents) == 0 {
+		t.Fatal("OnUsageApplied was not called with any events")
+	}
+	if want := sourceSessionID(t, store, source.ID); gotSession != want {
+		t.Fatalf("callback session = %q, want %q", gotSession, want)
+	}
+	if gotEvents[0].ModelID == "" {
+		t.Fatalf("event missing model id: %+v", gotEvents[0])
+	}
+}

--- a/backend/internal/pricing/pricing.go
+++ b/backend/internal/pricing/pricing.go
@@ -1,0 +1,70 @@
+// Package pricing turns model token counts into a USD cost estimate.
+//
+// The rate table is the single source of truth for cost telemetry. Rates are
+// published Anthropic list prices in USD per million tokens; cache-write is the
+// 5-minute write rate and cache-read is the cache-hit rate. Update the table
+// here when prices change. Unknown models return ok=false and a zero cost so
+// callers can still record token counts without inventing a price.
+package pricing
+
+import "strings"
+
+// Rates are USD per one million tokens for each token class.
+type Rates struct {
+	Input      float64
+	Output     float64
+	CacheWrite float64
+	CacheRead  float64
+}
+
+// modelRates maps a coarse model family to its rates. Model ids vary across
+// versions (claude-opus-4-8, claude-sonnet-4-5, claude-3-5-haiku-latest, ...),
+// so lookup matches on the family token contained in the id rather than the
+// exact string, which keeps the table stable across point releases.
+var modelRates = []struct {
+	family string
+	rates  Rates
+}{
+	{"opus", Rates{Input: 15, Output: 75, CacheWrite: 18.75, CacheRead: 1.50}},
+	{"sonnet", Rates{Input: 3, Output: 15, CacheWrite: 3.75, CacheRead: 0.30}},
+	{"haiku", Rates{Input: 0.80, Output: 4, CacheWrite: 1.00, CacheRead: 0.08}},
+}
+
+// RatesFor returns the rate card for a model id and whether it was recognized.
+func RatesFor(model string) (Rates, bool) {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return Rates{}, false
+	}
+	for _, r := range modelRates {
+		if strings.Contains(m, r.family) {
+			return r.rates, true
+		}
+	}
+	return Rates{}, false
+}
+
+// Cost estimates the USD cost of a turn. inputTokens should be the fresh
+// (uncached) input count, since cache reads and writes are priced separately.
+// It returns the dollar figure and whether the model was priced; an unpriced
+// model yields (0, false) so the caller records tokens with a zero cost rather
+// than a wrong one. Negative token counts are clamped to zero.
+func Cost(model string, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens int64) (float64, bool) {
+	rates, ok := RatesFor(model)
+	if !ok {
+		return 0, false
+	}
+	const perToken = 1.0 / 1_000_000.0
+	cost := float64(nonNeg(inputTokens))*rates.Input*perToken +
+		float64(nonNeg(outputTokens))*rates.Output*perToken +
+		float64(nonNeg(cacheReadTokens))*rates.CacheRead*perToken +
+		float64(nonNeg(cacheWriteTokens))*rates.CacheWrite*perToken
+	return cost, true
+}
+
+func nonNeg(v int64) int64 {
+	if v < 0 {
+		return 0
+	}
+	return v
+}

--- a/backend/internal/pricing/pricing_test.go
+++ b/backend/internal/pricing/pricing_test.go
@@ -1,0 +1,59 @@
+package pricing
+
+import (
+	"math"
+	"testing"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func TestRatesForMatchesFamilyAcrossVersions(t *testing.T) {
+	cases := map[string]Rates{
+		"claude-opus-4-8":         {Input: 15, Output: 75, CacheWrite: 18.75, CacheRead: 1.50},
+		"claude-sonnet-4-5":       {Input: 3, Output: 15, CacheWrite: 3.75, CacheRead: 0.30},
+		"claude-3-5-haiku-latest": {Input: 0.80, Output: 4, CacheWrite: 1.00, CacheRead: 0.08},
+		"CLAUDE-OPUS-5":           {Input: 15, Output: 75, CacheWrite: 18.75, CacheRead: 1.50},
+	}
+	for model, want := range cases {
+		got, ok := RatesFor(model)
+		if !ok {
+			t.Fatalf("RatesFor(%q) not recognized", model)
+		}
+		if got != want {
+			t.Fatalf("RatesFor(%q) = %+v, want %+v", model, got, want)
+		}
+	}
+}
+
+func TestRatesForUnknownOrEmpty(t *testing.T) {
+	for _, model := range []string{"", "   ", "gpt-4o", "gemini-2.5-pro"} {
+		if _, ok := RatesFor(model); ok {
+			t.Fatalf("RatesFor(%q) unexpectedly recognized", model)
+		}
+	}
+}
+
+func TestCostSonnetSplitTokens(t *testing.T) {
+	cost, ok := Cost("claude-sonnet-4-5", 1_000_000, 1_000_000, 1_000_000, 1_000_000)
+	if !ok {
+		t.Fatal("expected sonnet to be priced")
+	}
+	want := 3.0 + 15.0 + 0.30 + 3.75
+	if !approx(cost, want) {
+		t.Fatalf("cost = %v, want %v", cost, want)
+	}
+}
+
+func TestCostUnknownModelIsZeroAndFalse(t *testing.T) {
+	cost, ok := Cost("gpt-4o", 1_000_000, 1_000_000, 0, 0)
+	if ok || cost != 0 {
+		t.Fatalf("unknown model: got (%v,%v), want (0,false)", cost, ok)
+	}
+}
+
+func TestCostClampsNegativeTokens(t *testing.T) {
+	cost, ok := Cost("claude-opus-4-8", -5, -5, -5, -5)
+	if !ok || cost != 0 {
+		t.Fatalf("negative tokens: got (%v,%v), want (0,true)", cost, ok)
+	}
+}

--- a/backend/internal/service/usagecost/emitter.go
+++ b/backend/internal/service/usagecost/emitter.go
@@ -1,0 +1,89 @@
+// Package usagecost prices normalized usage events from the ingestion pipeline
+// and emits them to telemetry. It is the bridge between the local usage
+// subsystem (which never leaves the daemon) and PostHog, where cost can be
+// summed across users, days, sessions, and harnesses.
+package usagecost
+
+import (
+	"context"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/pricing"
+)
+
+// sessionStore resolves a session's harness/kind/project for tagging.
+type sessionStore interface {
+	GetSession(context.Context, domain.SessionID) (domain.SessionRecord, bool, error)
+}
+
+// Emitter turns applied usage events into priced ao.session.turn_usage
+// telemetry. Each ingested event is applied exactly once by the pipeline (a
+// durable cursor guards re-processing), so emitting here is exactly-once after
+// commit: no dedupe marker is needed. It is best-effort, a nil sink or a
+// failed session lookup degrades to emitting nothing rather than erroring.
+type Emitter struct {
+	sink  ports.EventSink
+	store sessionStore
+	now   func() time.Time
+}
+
+// NewEmitter constructs a usage-cost emitter.
+func NewEmitter(sink ports.EventSink, store sessionStore) *Emitter {
+	return &Emitter{sink: sink, store: store, now: time.Now}
+}
+
+// OnApplied prices and emits one telemetry event per applied usage event. It
+// matches the ingestor's OnUsageApplied callback signature and runs only after
+// the events have been durably committed.
+func (e *Emitter) OnApplied(ctx context.Context, sessionID domain.SessionID, events []domain.ModelUsageEvent) {
+	if e == nil || e.sink == nil || len(events) == 0 {
+		return
+	}
+	var (
+		harness string
+		kind    string
+		project domain.ProjectID
+	)
+	if e.store != nil {
+		if rec, ok, err := e.store.GetSession(ctx, sessionID); err == nil && ok {
+			harness = string(rec.Harness)
+			kind = string(rec.Kind)
+			project = rec.ProjectID
+		}
+	}
+	sid := sessionID
+	for _, ev := range events {
+		t := ev.Tokens
+		// Fresh (uncached) input is billed at the input rate; cache read/write
+		// are separate line items. Pricing the uncached count avoids charging
+		// cached tokens twice.
+		cost, priced := pricing.Cost(ev.ModelID, t.UncachedInputTokens, t.OutputTokens, t.CacheReadTokens, t.CacheWriteTokens)
+		payload := map[string]any{
+			"harness":               harness,
+			"kind":                  kind,
+			"model":                 ev.ModelID,
+			"model_priced":          priced,
+			"input_tokens":          t.InputTokens,
+			"uncached_input_tokens": t.UncachedInputTokens,
+			"output_tokens":         t.OutputTokens,
+			"cache_read_tokens":     t.CacheReadTokens,
+			"cache_write_tokens":    t.CacheWriteTokens,
+			"total_tokens":          t.InputTokens + t.OutputTokens + t.CacheReadTokens + t.CacheWriteTokens,
+			"cost_usd":              cost,
+		}
+		ev := ports.TelemetryEvent{
+			Name:       "ao.session.turn_usage",
+			Source:     "usage_cost",
+			OccurredAt: e.now(),
+			Level:      ports.TelemetryLevelInfo,
+			SessionID:  &sid,
+			Payload:    payload,
+		}
+		if project != "" {
+			ev.ProjectID = &project
+		}
+		e.sink.Emit(context.Background(), ev)
+	}
+}

--- a/backend/internal/service/usagecost/emitter_test.go
+++ b/backend/internal/service/usagecost/emitter_test.go
@@ -1,0 +1,85 @@
+package usagecost
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type captureSink struct{ events []ports.TelemetryEvent }
+
+func (c *captureSink) Emit(_ context.Context, ev ports.TelemetryEvent) {
+	c.events = append(c.events, ev)
+}
+func (c *captureSink) Close(context.Context) error { return nil }
+
+type fakeStore struct{ rec domain.SessionRecord }
+
+func (f fakeStore) GetSession(context.Context, domain.SessionID) (domain.SessionRecord, bool, error) {
+	return f.rec, f.rec.ID != "", nil
+}
+
+func opusEvent() domain.ModelUsageEvent {
+	return domain.ModelUsageEvent{
+		ModelID: "claude-opus-4-8",
+		Tokens: domain.UsageTokenMetrics{
+			InputTokens: 1_000_000, UncachedInputTokens: 1_000_000, OutputTokens: 1_000_000,
+		},
+	}
+}
+
+func TestOnAppliedPricesAndTagsFromRecord(t *testing.T) {
+	sink := &captureSink{}
+	e := NewEmitter(sink, fakeStore{rec: domain.SessionRecord{ID: "ao-1", ProjectID: "proj", Kind: domain.KindWorker, Harness: "claude-code"}})
+	e.OnApplied(context.Background(), "ao-1", []domain.ModelUsageEvent{opusEvent()})
+
+	if len(sink.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(sink.events))
+	}
+	ev := sink.events[0]
+	if ev.Name != "ao.session.turn_usage" {
+		t.Fatalf("name = %q", ev.Name)
+	}
+	if ev.SessionID == nil || *ev.SessionID != "ao-1" || ev.ProjectID == nil || *ev.ProjectID != "proj" {
+		t.Fatalf("ids = %v / %v", ev.SessionID, ev.ProjectID)
+	}
+	if ev.Payload["harness"] != "claude-code" {
+		t.Fatalf("harness = %v (must come from the record, not the caller)", ev.Payload["harness"])
+	}
+	// Opus: 1M uncached input @ $15 + 1M output @ $75 = $90.
+	if cost := ev.Payload["cost_usd"].(float64); math.Abs(cost-90.0) > 1e-9 {
+		t.Fatalf("cost_usd = %v, want 90", cost)
+	}
+	if ev.Payload["model_priced"].(bool) != true {
+		t.Fatalf("model_priced = %v", ev.Payload["model_priced"])
+	}
+}
+
+func TestOnAppliedUnknownModelZeroCostStillEmits(t *testing.T) {
+	sink := &captureSink{}
+	e := NewEmitter(sink, fakeStore{rec: domain.SessionRecord{ID: "ao-1", Harness: "codex"}})
+	e.OnApplied(context.Background(), "ao-1", []domain.ModelUsageEvent{{
+		ModelID: "gpt-5", Tokens: domain.UsageTokenMetrics{UncachedInputTokens: 500, OutputTokens: 500},
+	}})
+	if len(sink.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(sink.events))
+	}
+	p := sink.events[0].Payload
+	if p["cost_usd"].(float64) != 0 || p["model_priced"].(bool) != false {
+		t.Fatalf("unknown model payload = %+v", p)
+	}
+}
+
+func TestOnAppliedNilSinkAndEmptyEventsAreNoops(t *testing.T) {
+	// nil sink: constructing with nil must not panic and must emit nothing.
+	NewEmitter(nil, fakeStore{}).OnApplied(context.Background(), "ao-1", []domain.ModelUsageEvent{opusEvent()})
+
+	sink := &captureSink{}
+	NewEmitter(sink, fakeStore{}).OnApplied(context.Background(), "ao-1", nil)
+	if len(sink.events) != 0 {
+		t.Fatalf("empty events emitted %d", len(sink.events))
+	}
+}


### PR DESCRIPTION
## What

main already collects per-session token aggregates locally
(`internal/service/usage` + `GET /api/v1/usage/sessions`), but it has
**no dollar cost** and emits **nothing to PostHog**, so cost can't be
seen across users, days, sessions, or harnesses. This adds that missing
half, and only that half, without duplicating collection.

## How it works

The ingestion pipeline applies each parsed usage chunk exactly once
(a durable source cursor guards re-processing). This change hangs a
priced telemetry emit off that same exactly-once seam:

1. `observe/usage` gains an optional `OnUsageApplied(sessionID, events)`
   callback on the ingestor, invoked only after `ApplyUsageChunk`
   commits. Because the cursor has advanced, each event fires the
   callback exactly once, **no dedupe marker or DB migration needed**.
   The package stays free of any telemetry/pricing dependency.
2. `service/usagecost.Emitter` prices each event (`internal/pricing`)
   and emits `ao.session.turn_usage`. Fresh uncached input is billed at
   the input rate; cache read/write are separate line items. Harness,
   kind, and project come from the stored session record, so tags can't
   be spoofed. Unknown models emit tokens with `cost_usd: 0` /
   `model_priced: false`.
3. The daemon wires the emitter into the ingestor; the event is
   allowlisted with its `ao.v2.session.turn_usage` alias.

Best-effort throughout: a nil sink or a failed session lookup emits
nothing and never blocks or errors ingestion.

## Pricing

Single editable table of Anthropic list prices (USD per million tokens),
cache-write at 1.25x input, cache-read at 0.1x input:

| Model  | input | output | cache write | cache read |
|--------|-------|--------|-------------|------------|
| Opus   | 15    | 75     | 18.75       | 1.50       |
| Sonnet | 3     | 15     | 3.75        | 0.30       |
| Haiku  | 0.80  | 4      | 1.00        | 0.08       |

## Why this shape

An earlier attempt (#4000, now closed) reimplemented collection with a
separate parser/endpoint/hook and collided with main's shipped feature.
This version reuses main's collector and adds only pricing + emission.

## Verification

- The `OnUsageApplied` callback fires with the parsed events and the
  correct session id after a real ingest (integration test over the
  sqlite store, a real transcript file, and the durable cursor).
- The emitter prices Opus 1M uncached-in + 1M out at $90, records an
  unknown model at $0 / `model_priced:false`, tags harness from the
  record (not the caller), and no-ops on a nil sink or empty events.
- `pricing` unit tests (families, unknown, negative clamp).
- The daemon boots to ready with the emitter wired and shuts down clean.
- `gofmt`, `go vet`, and the touched-package tests pass.

Not driven live end-to-end to PostHog, that would require injecting into
the real `~/.claude` transcript roots; the new code paths are exercised
through the ingest pipeline and the emitter in tests.
