### PR TITLE
fix(terminal): stabilize xterm viewport, session-switch render, colors, and activity state

### DIFF
--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -373,6 +373,15 @@ func (m *Manager) ApplyRuntimeObservation(ctx context.Context, id domain.Session
 			if cur.Activity.State == domain.ActivityExited {
 				return cur, false
 			}
+			if m.sessionMutationInProgress(id) {
+				// A live pane whose supervised workload is "missing" while a
+				// spawn/restore/agent-switch mutation is mid-flight is the old
+				// process tree probed against new metadata (or vice versa), not
+				// an agent exit — the same guard the termination path below
+				// already applies. Marking exited here desyncs an actively
+				// relaunching session (#2047); the next probe re-decides.
+				return cur, false
+			}
 			next := cur
 			next.Activity = domain.Activity{State: domain.ActivityExited, LastActivityAt: timeOr(f.ObservedAt, now)}
 			delete(m.flights, id)
@@ -518,10 +527,20 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		return nil
 	}
 	// An explicit prompt submission is proof that an agent was relaunched in the
-	// preserved shell. Other same-generation callbacks may have been delayed
-	// behind the process-exit report and cannot resurrect an exited workload.
+	// preserved shell, and live-work hooks are equally strong evidence: the
+	// tool-use trio and permission-request are executed BY the agent process,
+	// so their arrival proves an agent is running right now. Without them, a
+	// stale `exited` (e.g. a workload-probe race across a daemon restart) pins
+	// an actively-working session on "exited" until the user happens to type a
+	// prompt (#2047): the reaper only transitions INTO exited, so nothing else
+	// ever corrects it. The asymmetry makes accepting them safe — a resurrect
+	// from a genuinely-delayed callback is re-marked exited by the reaper's
+	// next workload probe within one tick, while a wrongly-pinned exited never
+	// self-corrects. Turn-boundary callbacks (stop, notification, session-end)
+	// still cannot resurrect: they are exactly the deliveries that can trail a
+	// real process exit.
 	if rec.Activity.State == domain.ActivityExited && s.Valid && s.State != domain.ActivityExited &&
-		(s.State != domain.ActivityActive || s.Event != "user-prompt-submit") {
+		!isLiveAgentEvidence(s) {
 		m.mu.Unlock()
 		return nil
 	}
@@ -736,6 +755,22 @@ const maxInflightTools = 128
 // trio whose signals must not demote a sticky state on their own.
 func isToolUseEvent(event string) bool {
 	return event == "pre-tool-use" || isPostToolUseEvent(event)
+}
+
+// isLiveAgentEvidence reports whether an activity signal proves an agent
+// process is alive in the session's shell right now: an explicit prompt
+// submission, in-flight tool traffic, or a permission dialog appearing. Only
+// these signals may resurrect a session out of `exited`.
+func isLiveAgentEvidence(s ports.ActivitySignal) bool {
+	switch {
+	case s.State == domain.ActivityActive && s.Event == "user-prompt-submit":
+		return true
+	case s.State == domain.ActivityActive && isToolUseEvent(s.Event):
+		return true
+	case s.State == domain.ActivityBlocked && s.Event == "permission-request":
+		return true
+	}
+	return false
 }
 
 func isPostToolUseEvent(event string) bool {

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -668,6 +668,21 @@ func TestRuntimeObservation_ExitedWorkloadKeepsSessionLive(t *testing.T) {
 	}
 }
 
+func TestRuntimeObservation_WorkloadDeadSkippedDuringSessionMutation(t *testing.T) {
+	m, st, _ := newManager()
+	m.SetSessionOperationGate(fixedSessionOperationGate(true))
+	rec := working("mer-1")
+	rec.Metadata.RuntimeLaunchID = "launch-1"
+	st.sessions["mer-1"] = rec
+
+	if err := m.ApplyRuntimeObservation(ctx, "mer-1", ports.RuntimeFacts{Runtime: ports.ProbeAlive, Workload: ports.ProbeDead, LaunchID: "launch-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions["mer-1"]; got != rec {
+		t.Fatalf("workload-dead observation marked exited during session mutation: %+v", got)
+	}
+}
+
 func TestRuntimeObservation_AliveWorkloadCannotResurrectExitedSession(t *testing.T) {
 	m, st, _ := newManager()
 	rec := working("mer-1")
@@ -935,6 +950,72 @@ func TestActivity_StaleUserPromptDoesNotResumeExitedWorkload(t *testing.T) {
 	}
 	if got := st.sessions["mer-1"]; got != rec {
 		t.Fatalf("stale prompt resumed exited workload: %+v", got)
+	}
+}
+
+func TestActivity_ToolUseResumesExitedWorkload(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	rec.Activity.State = domain.ActivityExited
+	rec.Metadata.RuntimeLaunchID = "launch-2"
+	st.sessions["mer-1"] = rec
+	signalAt := time.Unix(123, 0).UTC()
+
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+		Valid:     true,
+		State:     domain.ActivityActive,
+		Event:     "pre-tool-use",
+		Timestamp: signalAt,
+		LaunchID:  "launch-2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityActive {
+		t.Fatalf("tool-use signal did not resume exited workload: %+v", got)
+	}
+}
+
+func TestActivity_PermissionRequestResumesExitedWorkload(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	rec.Activity.State = domain.ActivityExited
+	rec.Metadata.RuntimeLaunchID = "launch-2"
+	st.sessions["mer-1"] = rec
+
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+		Valid:    true,
+		State:    domain.ActivityBlocked,
+		Event:    "permission-request",
+		LaunchID: "launch-2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityBlocked {
+		t.Fatalf("permission-request did not resume exited workload: %+v", got)
+	}
+}
+
+func TestActivity_TurnBoundaryDoesNotResumeExitedWorkload(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	rec.Activity.State = domain.ActivityExited
+	rec.Metadata.RuntimeLaunchID = "launch-2"
+	st.sessions["mer-1"] = rec
+
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+		Valid:    true,
+		State:    domain.ActivityIdle,
+		Event:    "stop",
+		LaunchID: "launch-2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions["mer-1"]; got != rec {
+		t.Fatalf("turn-boundary callback resumed exited workload: %+v", got)
 	}
 }
 

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -392,7 +392,10 @@ describe("TerminalCacheProvider", () => {
 		}
 	});
 
-	it("retains every visited terminal until an authoritative lifecycle cleanup", async () => {
+	it("evicts the least-recently-shown parked terminal beyond the retention cap", async () => {
+		// Retention is bounded (MAX_RETAINED_TERMINALS = 6): each live xterm holds
+		// a WebGL context, and Chromium force-loses the oldest contexts past its
+		// per-page cap, blanking the earliest-visited panes (#2333).
 		const sessions = Array.from({ length: 7 }, (_, index) => ({
 			...worker,
 			id: `sess-retained-${index}`,
@@ -410,13 +413,19 @@ describe("TerminalCacheProvider", () => {
 					).not.toBeNull(),
 				);
 			}
-			expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(7);
-			expect(oldest.isConnected).toBe(true);
-			expect(xtermUnmounts.value).toBe(0);
+			await waitFor(() =>
+				expect(document.querySelectorAll("[data-terminal-cache-key]")).toHaveLength(6),
+			);
+			expect(
+				document.querySelector(`[data-terminal-cache-key^="session:${sessions[0].id}:worker|"]`),
+			).toBeNull();
+			expect(oldest.isConnected).toBe(false);
+			await waitFor(() => expect(xtermUnmounts.value).toBe(1));
 
+			// Revisiting the evicted session mounts a fresh terminal.
 			view.show(sessions[0]);
-			await waitFor(() => expect(activeXterm()).toBe(oldest));
-			expect(xtermMounts.value).toBe(7);
+			await waitFor(() => expect(activeXterm()).not.toBe(oldest));
+			expect(xtermMounts.value).toBe(8);
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -66,6 +66,7 @@ type CachedTerminalEntry = TerminalCacheDescriptor & {
 	activationPhase: "parked" | "preparing" | "ready" | "revealed" | "visible";
 	container: HTMLDivElement;
 	discardOnDeactivate?: boolean;
+	lastActivatedAt: number;
 	props: TerminalPaneProps;
 	terminal?: AttachableTerminal;
 };
@@ -82,6 +83,24 @@ type TerminalCacheController = {
 };
 
 const TerminalCacheContext = createContext<TerminalCacheController | null>(null);
+
+// Bound retained xterm buffers, renderer contexts and mux writers. Retaining
+// every visited terminal for the renderer's lifetime exceeds Chromium's
+// per-page WebGL context limit once enough sessions have been visited; the
+// browser then force-loses the OLDEST contexts, which is the "earliest-visited
+// panes go black while their sessions stay healthy" failure in #2333. The
+// active terminal is always retained; activating one beyond the cap evicts the
+// least-recently-activated parked entry, which takes the covered replay path
+// when opened again.
+const MAX_RETAINED_TERMINALS = 6;
+
+// A retained activation normally settles within a few frames (fit + two paint
+// frames). If any preparation step throws, rejects, or never completes, the
+// pane would otherwise sit at visibility:hidden forever — a black pane over a
+// healthy session (#2333). After this bound the cover is force-lifted; worst
+// case the viewport briefly shows its historical position instead of staying
+// invisible.
+const ACTIVATION_STALL_MS = 2000;
 
 function terminalTargetMatches(left?: TerminalTarget, right?: TerminalTarget): boolean {
 	if (left === right) return true;
@@ -212,6 +231,7 @@ function CachedTerminalPortal({
 	onPrepared,
 	onReveal,
 	onActivated,
+	onStalled,
 	onTerminalReady,
 }: {
 	active: boolean;
@@ -220,6 +240,7 @@ function CachedTerminalPortal({
 	onPrepared: (cacheKey: string, activationId: number) => void;
 	onReveal: (cacheKey: string, activationId: number) => void;
 	onActivated: (cacheKey: string, activationId: number) => void;
+	onStalled: (cacheKey: string, activationId: number) => void;
 	onTerminalReady: (cacheKey: string, terminal: AttachableTerminal) => void;
 }) {
 	const handleFatal = useCallback(
@@ -237,9 +258,15 @@ function CachedTerminalPortal({
 		if (!active || entry.activationPhase !== "preparing" || !terminal) return;
 		const activationId = entry.activationId;
 		let current = true;
-		void terminal.prepareForActivation().then(() => {
-			if (current) onPrepared(entry.cacheKey, activationId);
-		});
+		// A rejected preparation must still lift the cover: the pane is hidden
+		// until onPrepared advances the phase, so swallowing the rejection would
+		// leave a black pane over a healthy session (#2333).
+		void terminal
+			.prepareForActivation()
+			.catch(() => undefined)
+			.then(() => {
+				if (current) onPrepared(entry.cacheKey, activationId);
+			});
 		return () => {
 			current = false;
 		};
@@ -251,6 +278,24 @@ function CachedTerminalPortal({
 		entry.terminal,
 		onPrepared,
 	]);
+	// Watchdog for the hidden activation phases. Every legitimate transition
+	// re-renders this portal and re-arms the timer, so it only ever fires when a
+	// phase genuinely wedged (a preparation promise that never settles, a paint
+	// frame that never ran) — then the provider force-lifts the cover.
+	useEffect(() => {
+		if (
+			!active ||
+			entry.activationPhase === "visible" ||
+			entry.activationPhase === "parked"
+		) {
+			return;
+		}
+		const activationId = entry.activationId;
+		const timer = window.setTimeout(() => {
+			onStalled(entry.cacheKey, activationId);
+		}, ACTIVATION_STALL_MS);
+		return () => window.clearTimeout(timer);
+	}, [active, entry, entry.activationId, entry.activationPhase, onStalled]);
 	useLayoutEffect(() => {
 		if (!active || entry.activationPhase !== "ready") return;
 		onReveal(entry.cacheKey, entry.activationId);
@@ -299,6 +344,7 @@ export function TerminalCacheProvider({
 	const workspaceQuery = useWorkspaceQuery();
 	const shellTerminalsQuery = useShellTerminals();
 	const entriesRef = useRef(new Map<string, CachedTerminalEntry>());
+	const activationClockRef = useRef(0);
 	const activeRef = useRef<ActiveTerminalEntry | null>(null);
 	const parkingRef = useRef<HTMLDivElement | null>(null);
 	const muxPoolRef = useRef<TerminalMuxPool | null>(null);
@@ -372,14 +418,27 @@ export function TerminalCacheProvider({
 					activationId: 0,
 					activationPhase: "parked",
 					container,
+					lastActivatedAt: 0,
 					props: cachedProps,
 				};
 				entriesRef.current.set(entry.cacheKey, entry);
 			} else {
 				entry.props = cachedProps;
 			}
+			entry.lastActivatedAt = ++activationClockRef.current;
 			showTerminal(entry, slot);
 			activeRef.current = { key: entry.cacheKey, slot };
+			if (entriesRef.current.size > MAX_RETAINED_TERMINALS) {
+				const parked = [...entriesRef.current.values()]
+					.filter((candidate) => candidate.cacheKey !== entry.cacheKey)
+					.sort((left, right) => left.lastActivatedAt - right.lastActivatedAt);
+				while (entriesRef.current.size > MAX_RETAINED_TERMINALS) {
+					const oldest = parked.shift();
+					if (!oldest) break;
+					entriesRef.current.delete(oldest.cacheKey);
+					oldest.container.remove();
+				}
+			}
 			rerender();
 		},
 		[muxPool, rerender],
@@ -486,6 +545,32 @@ export function TerminalCacheProvider({
 				activeRef.current?.key !== cacheKey
 			) {
 				return;
+			}
+			activateTerminal(entry);
+			rerender();
+		},
+		[rerender],
+	);
+
+	const markStalled = useCallback(
+		(cacheKey: string, activationId: number) => {
+			const entry = entriesRef.current.get(cacheKey);
+			if (
+				!entry ||
+				entry.activationId !== activationId ||
+				entry.activationPhase === "visible" ||
+				entry.activationPhase === "parked" ||
+				activeRef.current?.key !== cacheKey
+			) {
+				return;
+			}
+			// Whatever step wedged, showing possibly-stale content beats an
+			// invisible pane. Best-effort snap to the tail first so the reveal
+			// matches what a completed preparation would have shown.
+			try {
+				entry.terminal?.showLatestOutput();
+			} catch {
+				// The renderer may be mid-teardown; the reveal below still applies.
 			}
 			activateTerminal(entry);
 			rerender();
@@ -604,6 +689,7 @@ export function TerminalCacheProvider({
 					onFatal={markFatal}
 					onPrepared={markPrepared}
 					onReveal={markReveal}
+					onStalled={markStalled}
 					onTerminalReady={markTerminalReady}
 				/>
 			))}
@@ -913,9 +999,14 @@ function AttachedTerminal({
 		}
 		if (!replayPaintPending || !terminal) return;
 		let current = true;
-		void terminal.prepareForActivation().then(() => {
-			if (current) setReplayPaintPending(false);
-		});
+		// A rejected preparation must still lift the first-load cover — the pane
+		// would otherwise stay covered over live output (#2333).
+		void terminal
+			.prepareForActivation()
+			.catch(() => undefined)
+			.then(() => {
+				if (current) setReplayPaintPending(false);
+			});
 		return () => {
 			current = false;
 		};
@@ -975,10 +1066,16 @@ function AttachedTerminal({
 		// before FitAddon has measured its real slot makes full-screen worker TUIs
 		// redraw once at 80×24 and again at the actual grid. Settle that first fit
 		// before attaching so the daemon receives only the authoritative size.
-		void terminal.prepareForActivation().then(() => {
-			if (!current) return;
-			detach = attach(terminal);
-		});
+		// Attach even if the preparation failed: a mis-sized first draw corrects
+		// on the next fit, but a skipped attach is a permanently blank pane
+		// (#2333).
+		void terminal
+			.prepareForActivation()
+			.catch(() => undefined)
+			.then(() => {
+				if (!current) return;
+				detach = attach(terminal);
+			});
 		return () => {
 			current = false;
 			detach?.();

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -16,6 +16,8 @@ const state = vi.hoisted(() => ({
 		scrollLines: ReturnType<typeof vi.fn>;
 		scrollToBottom: ReturnType<typeof vi.fn>;
 		refresh: ReturnType<typeof vi.fn>;
+		write: ReturnType<typeof vi.fn>;
+		dispose: ReturnType<typeof vi.fn>;
 		clear: ReturnType<typeof vi.fn>;
 		focus: ReturnType<typeof vi.fn>;
 		selectAll: ReturnType<typeof vi.fn>;
@@ -70,9 +72,9 @@ vi.mock("@xterm/xterm", () => ({
 		open(host: HTMLElement) {
 			host.appendChild(document.createElement("textarea"));
 		}
-		write() {}
+		write = vi.fn();
 		writeln() {}
-		dispose() {}
+		dispose = vi.fn();
 		onData(listener: (data: string) => void) {
 			this.dataListeners.add(listener);
 			return { dispose: () => this.dataListeners.delete(listener) };
@@ -180,6 +182,32 @@ describe("XtermTerminal", () => {
 		} finally {
 			vi.useRealTimers();
 			vi.unstubAllGlobals();
+		}
+	});
+
+	it("defers xterm dispose past unmount and drops writes to the dead handle", () => {
+		vi.useFakeTimers();
+		try {
+			let terminal: AttachableTerminal | undefined;
+			const { unmount } = render(
+				<XtermTerminal theme="dark" onReady={(ready) => { terminal = ready; }} />,
+			);
+			const fake = state.lastTerminal!;
+
+			unmount();
+			// Dispose must not run synchronously: queued write/viewport work from
+			// the old handle may still land this task (#3803).
+			expect(fake.dispose).not.toHaveBeenCalled();
+
+			const done = vi.fn();
+			terminal!.write(new Uint8Array([104, 105]), done);
+			expect(fake.write).not.toHaveBeenCalled();
+			expect(done).toHaveBeenCalledTimes(1);
+
+			vi.runAllTimers();
+			expect(fake.dispose).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
 		}
 	});
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -864,8 +864,23 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// Forward xterm's write callback: it fires once THIS chunk has been
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).
-			write: (data, done) => term.write(data, done),
-			writeln: (line) => term.writeln(line),
+			//
+			// Once teardown starts the handle goes inert immediately: final
+			// disposal is deferred a macrotask (see the cleanup below), and a late
+			// mux chunk must not enqueue new parse work into a terminal that is
+			// about to be disposed. The callback still fires so attachment
+			// bookkeeping never hangs on a dropped chunk.
+			write: (data, done) => {
+				if (disposed) {
+					done?.();
+					return;
+				}
+				term.write(data, done);
+			},
+			writeln: (line) => {
+				if (disposed) return;
+				term.writeln(line);
+			},
 			showLatestOutput,
 			prepareForActivation,
 			onUserInput: (listener) => {
@@ -902,12 +917,23 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			clearSuppressNativePaste();
 			keyInput.dispose();
 			userInputListeners.clear();
-			try {
-				term.dispose();
-			} catch {
-				// Some renderer addons can throw during dispose in certain GPU
-				// environments; the terminal is being torn down regardless.
-			}
+			// AO's listeners and transport are detached above, synchronously — the
+			// handle stopped accepting writes the moment `disposed` flipped. Only
+			// the final dispose() is deferred one macrotask: xterm queues viewport
+			// work (write parsing, Viewport.syncScrollArea) on its own microtask/
+			// timer queues, and disposing while that work is still queued lets a
+			// callback reach a torn-down renderer ("Cannot read properties of
+			// undefined (reading 'dimensions')" — issue #3803). One macrotask lets
+			// the already-queued work drain against a live instance; nothing new
+			// can be enqueued because every input path above is already detached.
+			window.setTimeout(() => {
+				try {
+					term.dispose();
+				} catch {
+					// Some renderer addons can throw during dispose in certain GPU
+					// environments; the terminal is being torn down regardless.
+				}
+			}, 0);
 		};
 	}, []);
 

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -530,26 +530,32 @@
 	--color-project-accent-violet: #c4b5fd;
 
 	/* Terminal ANSI palette. Keep this independent from product status colors:
-	   agent TUIs own the semantic meaning of these slots. */
+	   agent TUIs own the semantic meaning of these slots.
+
+	   The 12 chromatic slots track the de-facto standard terminal values (VS
+	   Code's integrated-terminal defaults) rather than a pastelized house mix:
+	   agent CLIs are designed against real terminal palettes, and the softened
+	   values read as washed-out next to the same CLI in Terminal.app (#2529).
+	   The neutral endpoints stay tuned to AO's terminal plate. */
 	--color-term-black: #1f2329;
-	--color-term-red: #f05d5e;
-	--color-term-green: #44c97a;
-	--color-term-yellow: #e5c34b;
-	--color-term-blue: #5b9cff;
-	--color-term-magenta: #c678dd;
-	--color-term-cyan: #56b6c2;
-	--color-term-white: #d7dae0;
+	--color-term-red: #cd3131;
+	--color-term-green: #0dbc79;
+	--color-term-yellow: #e5e510;
+	--color-term-blue: #2472c8;
+	--color-term-magenta: #bc3fbc;
+	--color-term-cyan: #11a8cd;
+	--color-term-white: #e5e5e5;
 	--color-term-selection-dark: rgb(77 141 255 / 0.3);
 	--color-term-selection-light: rgb(37 99 235 / 0.25);
 	--color-term-selection-inactive: rgb(128 128 128 / 0.2);
 	--color-term-selection-inactive-light: rgb(128 128 128 / 0.15);
-	--color-term-bright-black: #7f8792;
-	--color-term-bright-red: #ff7b7c;
-	--color-term-bright-green: #62df91;
-	--color-term-bright-yellow: #f2d66d;
-	--color-term-bright-blue: #79b1ff;
-	--color-term-bright-magenta: #d99aee;
-	--color-term-bright-cyan: #79d4df;
+	--color-term-bright-black: #666666;
+	--color-term-bright-red: #f14c4c;
+	--color-term-bright-green: #23d18b;
+	--color-term-bright-yellow: #f5f543;
+	--color-term-bright-blue: #3b8eea;
+	--color-term-bright-magenta: #d670d6;
+	--color-term-bright-cyan: #29b8db;
 	--color-term-bright-white: #f4f5f7;
 
 	/* ═══════════════════════════════════════════════════════════════
@@ -790,22 +796,28 @@
 	--color-settings-accent: var(--primary);
 	--color-settings-switch-on: var(--primary);
 
+	/* Light terminal ANSI palette: standard light-terminal values (VS Code's
+	   integrated-terminal light defaults) instead of the earlier darkened,
+	   desaturated mix, so colors match the same CLI in a native terminal
+	   (#2529). Black stays near the app's dark neutral; bright-white is a
+	   visible light gray, NOT re-darkened — TUIs use it for emphasis text and
+	   the old near-black value inverted their intent. */
 	--color-term-black: #24292f;
-	--color-term-red: #a13c37;
-	--color-term-green: #2e6b3e;
-	--color-term-yellow: #87660f;
-	--color-term-blue: #3b5aa6;
-	--color-term-magenta: #7b5799;
-	--color-term-cyan: #3d7a7a;
-	--color-term-white: #666d75;
-	--color-term-bright-black: #4c535b;
-	--color-term-bright-red: #7e3330;
-	--color-term-bright-green: #265231;
-	--color-term-bright-yellow: #6b5108;
-	--color-term-bright-blue: #31487f;
-	--color-term-bright-magenta: #5f4476;
-	--color-term-bright-cyan: #316061;
-	--color-term-bright-white: #24292f;
+	--color-term-red: #cd3131;
+	--color-term-green: #00bc00;
+	--color-term-yellow: #949800;
+	--color-term-blue: #0451a5;
+	--color-term-magenta: #bc05bc;
+	--color-term-cyan: #0598bc;
+	--color-term-white: #555555;
+	--color-term-bright-black: #666666;
+	--color-term-bright-red: #cd3131;
+	--color-term-bright-green: #14ce14;
+	--color-term-bright-yellow: #b5ba00;
+	--color-term-bright-blue: #0451a5;
+	--color-term-bright-magenta: #bc05bc;
+	--color-term-bright-cyan: #0598bc;
+	--color-term-bright-white: #a5a5a5;
 }
 
 


### PR DESCRIPTION
Fixes #3803, fixes #2333, fixes #2529, fixes #2047.

## What

Four terminal-stability fixes across the renderer and the activity lifecycle.

### #3803 — disposed-viewport crash on handle replacement
`XtermTerminal` unmount cleanup disposed the xterm instance synchronously while queued write/viewport work (WriteBuffer callbacks, `Viewport.syncScrollArea` microtasks) could still land in the same task, crashing the renderer with `Cannot read properties of undefined (reading 'dimensions')`. Cleanup now detaches all listeners/observers/timers synchronously but defers the final `term.dispose()` one macrotask, and the attachable handle drops `write`/`writeln` after disposal (still invoking `done` callbacks so attachment flow control can finish).

### #2333 — blank/glitched terminals after session switching
Two root causes:
- The retained-terminal cache became unbounded (4986af7d0), so each visited pane held a live WebGL context; past Chromium's per-page context cap the oldest contexts are force-lost and the earliest-visited panes render black. Retention is re-bounded at `MAX_RETAINED_TERMINALS = 6` with least-recently-shown eviction (evicted panes remount fresh on revisit).
- A rejected `prepareForActivation()` could leave the activation cover (`visibility:hidden`) down forever. All call sites now tolerate rejection, and a 2s activation-stall watchdog force-completes a stuck activation.

### #2529 — ANSI colors don't match a real terminal
The truecolor plumbing (tmux `-u -T RGB`, `TERM`/`COLORTERM`) already landed in #2980; the remaining gap was the palette itself. The 12 chromatic ANSI slots in `tokens.css` were a softened house mix (and the light theme darkened them further, with bright-white near-black — inverting TUI emphasis). Both themes now use the de-facto standard terminal values (VS Code integrated-terminal defaults), which agent CLIs are designed against. Neutral endpoints stay tuned to AO's terminal plate, per DESIGN.md's "terminal keeps its own palette".

### #2047 — Claude sessions misreport activity state
The `exited` activity state could pin wrongly and never self-correct (only `user-prompt-submit` could resurrect it; the reaper only transitions *into* exited). Two fixes in the lifecycle manager:
- Live-agent evidence — tool-use events and `permission-request`, which are executed by the agent process itself — now resurrects an exited state (turn-boundary callbacks like `stop`/`notification` still cannot). A wrong resurrect self-corrects on the reaper's next workload probe (~5s); a wrong exited previously pinned forever.
- The workload-dead→exited transition is skipped while a session mutation (spawn/restore/agent-switch) is in flight, matching the guard the termination path already had — probing an old process tree against new metadata mid-relaunch no longer desyncs the session to exited.

## Tests
- `XtermTerminal.test.tsx`: dispose is deferred past unmount; writes to a dead handle are dropped with `done` still invoked.
- `TerminalPane.test.tsx`: retention-cap eviction (7 visited → 6 retained, LRU evicted, fresh remount on revisit).
- `manager_test.go`: tool-use and permission-request resurrect exited; turn-boundary events do not; workload-dead observation is suppressed during session mutation.

## Validation
- `npm run typecheck` and full renderer suite: 177 files, 2233 passed / 1 skipped.
- `go test ./...`: all green (AO_* session env cleared for `internal/cli`).
- Palette change verified visually via an `ao preview` before/after harness (dark + light).

## Risks / follow-ups
- Eviction cap (6) restores the pre-4986af7d0 bound; panes beyond it lose scrollback on revisit (replay repaints latest output). If unbounded retention is wanted back, it needs a non-WebGL fallback for parked panes instead.
- Exited-resurrect intentionally excludes turn-boundary hooks; delayed `stop` events after a real exit remain ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)