### PR TITLE
fix(windows): hide daemon child process consoles

### DIFF
--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 const (
@@ -262,7 +263,7 @@ func hasDiscoverySource(agentID string) bool {
 }
 
 func modelCommand(ctx context.Context, binary string, args []string, workingDir string, env map[string]string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, binary, args...) //nolint:gosec // binary is adapter-resolved, args are static
+	cmd := aoprocess.CommandContext(ctx, binary, args...) //nolint:gosec // binary is adapter-resolved, args are static
 	cmd.WaitDelay = commandTerminationWait
 	if strings.TrimSpace(workingDir) != "" {
 		cmd.Dir = workingDir

--- a/backend/internal/adapters/agent/muse/muse.go
+++ b/backend/internal/adapters/agent/muse/muse.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 const adapterID = "muse"
@@ -227,7 +227,7 @@ func resolveMuseBinary(ctx context.Context, spec binaryutil.BinarySpec) (string,
 }
 
 func isOfficialMuseBinary(ctx context.Context, binary string) bool {
-	cmd := exec.CommandContext(ctx, binary, "--version")
+	cmd := aoprocess.CommandContext(ctx, binary, "--version")
 	cmd.Env = append(os.Environ(), "MUSE_NO_AUTO_UPDATE=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/backend/internal/adapters/chatdriver/acp/process_windows.go
+++ b/backend/internal/adapters/chatdriver/acp/process_windows.go
@@ -6,11 +6,13 @@ import (
 	"os/exec"
 	"strconv"
 	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 func configureProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+		CreationFlags: windows.CREATE_NO_WINDOW | windows.CREATE_NEW_PROCESS_GROUP,
 		HideWindow:    true,
 	}
 }
@@ -22,7 +24,10 @@ func killProcessTree(cmd *exec.Cmd) error {
 	// Node launches the provider as a child. taskkill /T is the Windows equivalent
 	// of killing the Unix process group and avoids leaving Claude behind.
 	kill := exec.Command("taskkill", "/PID", strconv.Itoa(cmd.Process.Pid), "/T", "/F")
-	kill.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	kill.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NO_WINDOW,
+		HideWindow:    true,
+	}
 	if err := kill.Run(); err != nil {
 		return cmd.Process.Kill()
 	}

--- a/backend/internal/adapters/chatdriver/acp/process_windows_test.go
+++ b/backend/internal/adapters/chatdriver/acp/process_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package acp
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestConfigureProcessGroupHidesConsoleWindow(t *testing.T) {
+	cmd := exec.Command("node.exe")
+
+	configureProcessGroup(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr = nil, want hidden Windows process attributes")
+	}
+	if got := cmd.SysProcAttr.CreationFlags; got&windows.CREATE_NO_WINDOW == 0 {
+		t.Fatalf("CreationFlags = %#x, want CREATE_NO_WINDOW", got)
+	}
+	if got := cmd.SysProcAttr.CreationFlags; got&windows.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Fatalf("CreationFlags = %#x, want CREATE_NEW_PROCESS_GROUP", got)
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Fatal("HideWindow = false, want true")
+	}
+}

--- a/backend/internal/adapters/chatdriver/claudeacp/driver.go
+++ b/backend/internal/adapters/chatdriver/claudeacp/driver.go
@@ -21,6 +21,7 @@ import (
 	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 const minimumNodeMajor = 22
@@ -223,7 +224,7 @@ func requireFile(path, label string) error {
 func requireNodeVersion(ctx context.Context, node string) error {
 	// node is the explicit AO override or the validated executable inside AO's
 	// packaged resources, never prompt/provider input.
-	out, err := exec.CommandContext(ctx, node, "--version").Output() //nolint:gosec // Resolved local executable, not provider input.
+	out, err := aoprocess.CommandContext(ctx, node, "--version").Output() //nolint:gosec // Resolved local executable, not provider input.
 	if err != nil {
 		return fmt.Errorf("run packaged Node: %w", err)
 	}

--- a/backend/internal/adapters/chatdriver/codexappserver/driver.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -18,6 +17,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/processenv"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // clientName identifies AO to the provider. It shows up in the app-server's
@@ -225,7 +225,7 @@ func (v codexVersion) String() string {
 }
 
 func installedCodexVersion(ctx context.Context, bin string) (string, error) {
-	output, err := exec.CommandContext(ctx, bin, "--version").CombinedOutput()
+	output, err := aoprocess.CommandContext(ctx, bin, "--version").CombinedOutput()
 	if err != nil {
 		return "", err
 	}
@@ -387,7 +387,7 @@ func approvalSettings(mode ports.PermissionMode) (policy, sandbox string) {
 
 // spawnAppServer is the real launcher.
 func spawnAppServer(ctx context.Context, bin, workdir string, env []string) (*process, error) {
-	cmd := exec.Command(bin, "app-server")
+	cmd := aoprocess.Command(bin, "app-server")
 	cmd.Dir = workdir
 	if len(env) > 0 {
 		cmd.Env = env

--- a/backend/internal/adapters/chatdriver/kimchiacp/version.go
+++ b/backend/internal/adapters/chatdriver/kimchiacp/version.go
@@ -3,10 +3,11 @@ package kimchiacp
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // minimumKimchiVersion is the oldest Kimchi build known to support ACP mode.
@@ -20,7 +21,7 @@ var semverPattern = regexp.MustCompile(`\b(\d+)\.(\d+)\.(\d+)\b`)
 // triplet, and returns an error if the binary is too old or the version
 // output is unparseable.
 func versionProbe(ctx context.Context, bin string) error {
-	output, err := exec.CommandContext(ctx, bin, "--version").CombinedOutput()
+	output, err := aoprocess.CommandContext(ctx, bin, "--version").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("read Kimchi version: %w", err)
 	}

--- a/backend/internal/adapters/container/dockerreap/reap.go
+++ b/backend/internal/adapters/container/dockerreap/reap.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // SessionLabel is the label key a worker's own `docker run` should set to
@@ -51,7 +52,7 @@ type commandRunner interface {
 type execRunner struct{}
 
 func (execRunner) Output(ctx context.Context, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := aoprocess.CommandContext(ctx, name, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/backend/internal/adapters/reviewer/agy/agy.go
+++ b/backend/internal/adapters/reviewer/agy/agy.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	agentagy "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agy"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/reviewgateway"
 )
 
@@ -38,7 +38,7 @@ func New() *Reviewer {
 	return &Reviewer{
 		resolveBinary: agentagy.ResolveAgyBinary,
 		run: func(ctx context.Context, env map[string]string, binary string, args ...string) ([]byte, error) {
-			cmd := exec.CommandContext(ctx, binary, args...)
+			cmd := aoprocess.CommandContext(ctx, binary, args...)
 			cmd.Env = appendEnvironment(os.Environ(), env)
 			return cmd.CombinedOutput()
 		},

--- a/backend/internal/adapters/reviewer/goose/goose.go
+++ b/backend/internal/adapters/reviewer/goose/goose.go
@@ -7,13 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	workergoose "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/goose"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/reviewgateway"
 )
 
@@ -53,7 +53,7 @@ func New() *Reviewer {
 	return &Reviewer{
 		resolveBinary: workergoose.ResolveGooseBinary,
 		run: func(ctx context.Context, env map[string]string, binary string, args ...string) ([]byte, error) {
-			cmd := exec.CommandContext(ctx, binary, args...)
+			cmd := aoprocess.CommandContext(ctx, binary, args...)
 			cmd.Env = appendEnvironment(os.Environ(), env)
 			return cmd.CombinedOutput()
 		},

--- a/backend/internal/adapters/reviewer/pi/pi.go
+++ b/backend/internal/adapters/reviewer/pi/pi.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -14,6 +13,7 @@ import (
 	agentpi "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/pi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/reviewgateway"
 )
 
@@ -47,7 +47,7 @@ func New() *Reviewer {
 	return &Reviewer{
 		resolveBinary: agentpi.ResolvePiBinary,
 		runHelp: func(ctx context.Context, binary string) ([]byte, error) {
-			return exec.CommandContext(ctx, binary, "--help").CombinedOutput()
+			return aoprocess.CommandContext(ctx, binary, "--help").CombinedOutput()
 		},
 	}
 }

--- a/backend/internal/adapters/reviewer/vibe/vibe.go
+++ b/backend/internal/adapters/reviewer/vibe/vibe.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -15,6 +14,7 @@ import (
 	agentvibe "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/vibe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/reviewgateway"
 )
 
@@ -64,7 +64,7 @@ func New() *Reviewer {
 	return &Reviewer{
 		resolveBinary: agentvibe.ResolveVibeBinary,
 		run: func(ctx context.Context, env map[string]string, binary string, args ...string) ([]byte, error) {
-			cmd := exec.CommandContext(ctx, binary, args...)
+			cmd := aoprocess.CommandContext(ctx, binary, args...)
 			cmd.Env = appendEnvironment(os.Environ(), env)
 			return cmd.CombinedOutput()
 		},

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -417,14 +417,14 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 
 	// Stage all tracked and non-ignored untracked files into the temp index.
 	// GIT_INDEX_FILE overrides the index so the real index is never touched.
-	addCmd := exec.CommandContext(ctx, w.binary, addAllTempIndexArgs(path)...)
+	addCmd := aoprocess.CommandContext(ctx, w.binary, addAllTempIndexArgs(path)...)
 	addCmd.Env = append(os.Environ(), "GIT_INDEX_FILE="+tmpIdxPath)
 	if out, err := addCmd.CombinedOutput(); err != nil {
 		return "", commandError{args: append([]string{w.binary}, addAllTempIndexArgs(path)...), output: string(out), err: err}
 	}
 
 	// Write the staged tree to get a tree SHA.
-	writeTreeCmd := exec.CommandContext(ctx, w.binary, writeTreeArgs(path)...)
+	writeTreeCmd := aoprocess.CommandContext(ctx, w.binary, writeTreeArgs(path)...)
 	writeTreeCmd.Env = append(os.Environ(), "GIT_INDEX_FILE="+tmpIdxPath)
 	treeOut, err := writeTreeCmd.CombinedOutput()
 	if err != nil {
@@ -696,7 +696,7 @@ func parseObservedWorkspaceCommits(output string) []ports.WorkspaceCommit {
 // returned commandError. Exit code detection happens in the caller.
 func (w *Workspace) runCherryPickNoCommit(ctx context.Context, worktree, commitSHA string) error {
 	args := cherryPickNoCommitArgs(worktree, commitSHA)
-	cmd := exec.CommandContext(ctx, w.binary, args...)
+	cmd := aoprocess.CommandContext(ctx, w.binary, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return commandError{args: append([]string{w.binary}, args...), output: string(out), err: err}

--- a/backend/internal/mobilebridge/magicdns.go
+++ b/backend/internal/mobilebridge/magicdns.go
@@ -3,9 +3,10 @@ package mobilebridge
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"strings"
 	"time"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // tailscaleTimeout bounds every CLI call. The Connect Mobile status endpoint is
@@ -18,7 +19,7 @@ type TailscaleRunner func(ctx context.Context, args ...string) ([]byte, error)
 
 // execTailscale is the production TailscaleRunner.
 func execTailscale(ctx context.Context, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, "tailscale", args...).Output()
+	return aoprocess.CommandContext(ctx, "tailscale", args...).Output()
 }
 
 // TailscaleInfo is what the local daemon can tell us about this node.

--- a/backend/internal/workspacewatch/watcher.go
+++ b/backend/internal/workspacewatch/watcher.go
@@ -10,12 +10,13 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // Watch subscribes to relevant changes below the workspace roots until ctx is cancelled. The
@@ -112,11 +113,11 @@ type gitWorkspace struct {
 }
 
 func discoverGitWorkspace(ctx context.Context, root string) gitWorkspace {
-	gitDirRaw, err := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--absolute-git-dir").Output()
+	gitDirRaw, err := aoprocess.CommandContext(ctx, "git", "-C", root, "rev-parse", "--absolute-git-dir").Output()
 	if err != nil {
 		return gitWorkspace{}
 	}
-	filesRaw, err := exec.CommandContext(ctx, "git", "-C", root, "ls-files", "-z", "--cached", "--others", "--exclude-standard").Output()
+	filesRaw, err := aoprocess.CommandContext(ctx, "git", "-C", root, "ls-files", "-z", "--cached", "--others", "--exclude-standard").Output()
 	if err != nil {
 		return gitWorkspace{}
 	}
@@ -132,14 +133,14 @@ func discoverGitWorkspace(ctx context.Context, root string) gitWorkspace {
 		filepath.Join(gitDir, "HEAD"): {},
 	}
 	commonDir := gitDir
-	if raw, commonErr := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--git-common-dir").Output(); commonErr == nil {
+	if raw, commonErr := aoprocess.CommandContext(ctx, "git", "-C", root, "rev-parse", "--git-common-dir").Output(); commonErr == nil {
 		commonDir = strings.TrimSpace(string(raw))
 		if !filepath.IsAbs(commonDir) {
 			commonDir = filepath.Join(root, commonDir)
 		}
 	}
 	metadataFiles[filepath.Join(commonDir, "packed-refs")] = struct{}{}
-	if raw, refErr := exec.CommandContext(ctx, "git", "-C", root, "symbolic-ref", "-q", "HEAD").Output(); refErr == nil {
+	if raw, refErr := aoprocess.CommandContext(ctx, "git", "-C", root, "symbolic-ref", "-q", "HEAD").Output(); refErr == nil {
 		ref := strings.TrimSpace(string(raw))
 		if ref != "" {
 			metadataFiles[filepath.Join(commonDir, filepath.FromSlash(ref))] = struct{}{}
@@ -273,7 +274,7 @@ func gitIgnored(ctx context.Context, root, target string) bool {
 	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return false
 	}
-	return exec.CommandContext(ctx, "git", "-C", root, "check-ignore", "-q", "--", filepath.ToSlash(rel)).Run() == nil
+	return aoprocess.CommandContext(ctx, "git", "-C", root, "check-ignore", "-q", "--", filepath.ToSlash(rel)).Run() == nil
 }
 
 func isWithin(root, target string) bool {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
 		"build:acp-runtime": "node ./scripts/build-acp-runtime.mjs",
 		"browser-runtime:prepare": "node ./scripts/prepare-agent-browser.mjs",
 		"build:daemon": "node ./scripts/build-daemon.mjs",
-		"predev": "npm run build:daemon && node ./scripts/ensure-browser-runtime.mjs && npm run build:acp-runtime",
+		"predev": "npm run build:daemon -- --dev && node ./scripts/ensure-browser-runtime.mjs && npm run build:acp-runtime",
 		"dev": "electron-forge start",
 		"dev:web": "VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts",
 		"prepackage": "npm run build:daemon && npm run browser-runtime:prepare && npm run build:acp-runtime",

--- a/frontend/scripts/build-acp-runtime.mjs
+++ b/frontend/scripts/build-acp-runtime.mjs
@@ -128,7 +128,7 @@ for (const name of nativeClaudePackages) {
 writeFileSync(markerPath, `${JSON.stringify({ signature: buildSignature, node: NODE_VERSION }, null, 2)}\n`);
 
 function run(command, args, options = {}) {
-	const result = spawnSync(command, args, { stdio: "inherit", ...options });
+	const result = spawnSync(command, args, { stdio: "inherit", windowsHide: true, ...options });
 	if (result.error) throw result.error;
 	if (result.status !== 0) throw new Error(`${command} exited ${result.status}`);
 }

--- a/frontend/scripts/build-daemon.mjs
+++ b/frontend/scripts/build-daemon.mjs
@@ -10,8 +10,9 @@ const repoRoot = resolve(frontendRoot, "..");
 const backendRoot = join(repoRoot, "backend");
 const outDir = join(frontendRoot, "daemon");
 const outPath = join(outDir, process.platform === "win32" ? "ao.exe" : "ao");
+const isWindowsDev = process.platform === "win32" && process.argv.includes("--dev");
 const windowsDevOutDir = join(outDir, `dev-${Date.now()}-${process.pid}`);
-const buildOutPath = process.platform === "win32" ? join(windowsDevOutDir, "ao.exe") : outPath;
+const buildOutPath = isWindowsDev ? join(windowsDevOutDir, "ao.exe") : outPath;
 const windowsDevManifestPath = join(outDir, "dev-daemon.json");
 const minimumGoVersion = parseMinimumGoVersion(readFileSync(join(backendRoot, "go.mod"), "utf8"));
 
@@ -34,7 +35,7 @@ if (versionResult.status !== 0 || !actualGoVersion || !meetsMinimumVersion(actua
 	process.exit(1);
 }
 
-if (process.platform === "win32") {
+if (isWindowsDev) {
 	mkdirSync(windowsDevOutDir, { recursive: true });
 } else {
 	rmSync(outDir, { recursive: true, force: true });
@@ -56,7 +57,7 @@ if (result.status !== 0) {
 	process.exit(result.status ?? 1);
 }
 
-if (process.platform === "win32") {
+if (isWindowsDev) {
 	writeFileSync(windowsDevManifestPath, `${JSON.stringify({ path: buildOutPath }, null, 2)}\n`);
 	cleanupOldWindowsDevDaemons(buildOutPath);
 }

--- a/frontend/scripts/build-daemon.mjs
+++ b/frontend/scripts/build-daemon.mjs
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -10,6 +10,9 @@ const repoRoot = resolve(frontendRoot, "..");
 const backendRoot = join(repoRoot, "backend");
 const outDir = join(frontendRoot, "daemon");
 const outPath = join(outDir, process.platform === "win32" ? "ao.exe" : "ao");
+const windowsDevOutDir = join(outDir, `dev-${Date.now()}-${process.pid}`);
+const buildOutPath = process.platform === "win32" ? join(windowsDevOutDir, "ao.exe") : outPath;
+const windowsDevManifestPath = join(outDir, "dev-daemon.json");
 const minimumGoVersion = parseMinimumGoVersion(readFileSync(join(backendRoot, "go.mod"), "utf8"));
 
 if (!minimumGoVersion) {
@@ -17,7 +20,7 @@ if (!minimumGoVersion) {
 	process.exit(1);
 }
 
-const versionResult = spawnSync("go", ["version"], { encoding: "utf8" });
+const versionResult = spawnSync("go", ["version"], { encoding: "utf8", windowsHide: true });
 if (versionResult.error) {
 	console.error(
 		`Go ${minimumGoVersion.join(".")}+ is required, but Go could not be started: ${versionResult.error.message}`,
@@ -31,12 +34,17 @@ if (versionResult.status !== 0 || !actualGoVersion || !meetsMinimumVersion(actua
 	process.exit(1);
 }
 
-rmSync(outDir, { recursive: true, force: true });
-mkdirSync(outDir, { recursive: true });
+if (process.platform === "win32") {
+	mkdirSync(windowsDevOutDir, { recursive: true });
+} else {
+	rmSync(outDir, { recursive: true, force: true });
+	mkdirSync(outDir, { recursive: true });
+}
 
-const result = spawnSync("go", ["build", "-o", outPath, "./cmd/ao"], {
+const result = spawnSync("go", ["build", "-o", buildOutPath, "./cmd/ao"], {
 	cwd: backendRoot,
 	stdio: "inherit",
+	windowsHide: true,
 });
 
 if (result.error) {
@@ -46,4 +54,34 @@ if (result.error) {
 
 if (result.status !== 0) {
 	process.exit(result.status ?? 1);
+}
+
+if (process.platform === "win32") {
+	writeFileSync(windowsDevManifestPath, `${JSON.stringify({ path: buildOutPath }, null, 2)}\n`);
+	cleanupOldWindowsDevDaemons(buildOutPath);
+}
+
+function cleanupOldWindowsDevDaemons(activePath) {
+	const activeDir = dirname(activePath);
+	let entries;
+	try {
+		entries = readdirSync(outDir, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory() && entry.name.startsWith("dev-"))
+			.map((entry) => {
+				const dir = join(outDir, entry.name);
+				return { dir, mtimeMs: statSync(dir).mtimeMs };
+			})
+			.sort((a, b) => b.mtimeMs - a.mtimeMs);
+	} catch {
+		return;
+	}
+	for (const entry of entries.slice(5)) {
+		if (entry.dir === activeDir) continue;
+		try {
+			rmSync(entry.dir, { recursive: true, force: true });
+		} catch {
+			// Old session processes can keep their exe locked. They will be cleaned
+			// up by a later dev build after the process exits.
+		}
+	}
 }

--- a/frontend/scripts/build-daemon.mjs
+++ b/frontend/scripts/build-daemon.mjs
@@ -37,6 +37,15 @@ if (versionResult.status !== 0 || !actualGoVersion || !meetsMinimumVersion(actua
 
 if (isWindowsDev) {
 	mkdirSync(windowsDevOutDir, { recursive: true });
+} else if (process.platform === "win32") {
+	// A running dev daemon may still hold an older dev-* binary open. Keep the
+	// output directory in place and remove only the files that the packaged
+	// build owns; locked dev folders can remain without affecting the bundled
+	// daemon path.
+	mkdirSync(outDir, { recursive: true });
+	rmSync(outPath, { force: true });
+	rmSync(windowsDevManifestPath, { force: true });
+	cleanupOldWindowsDevDaemons(undefined);
 } else {
 	rmSync(outDir, { recursive: true, force: true });
 	mkdirSync(outDir, { recursive: true });
@@ -63,7 +72,7 @@ if (isWindowsDev) {
 }
 
 function cleanupOldWindowsDevDaemons(activePath) {
-	const activeDir = dirname(activePath);
+	const activeDir = activePath ? dirname(activePath) : "";
 	let entries;
 	try {
 		entries = readdirSync(outDir, { withFileTypes: true })
@@ -76,7 +85,7 @@ function cleanupOldWindowsDevDaemons(activePath) {
 	} catch {
 		return;
 	}
-	for (const entry of entries.slice(5)) {
+	for (const entry of entries.slice(activePath ? 5 : 0)) {
 		if (entry.dir === activeDir) continue;
 		try {
 			rmSync(entry.dir, { recursive: true, force: true });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -600,7 +600,7 @@ const runLoginShell: ShellRunner = (shellPath, args) =>
 		};
 		let child: ReturnType<typeof spawn>;
 		try {
-			child = spawn(shellPath, args, { stdio: ["ignore", "pipe", "ignore"] });
+			child = spawn(shellPath, args, { stdio: ["ignore", "pipe", "ignore"], windowsHide: true });
 		} catch {
 			finish(null);
 			return;
@@ -936,6 +936,27 @@ function resolvedDaemonPort(): number {
 	return isDev && !process.env.AO_PORT ? DEV_DAEMON_PORT : expectedDaemonPort(process.env);
 }
 
+function daemonLaunchEnv(): NodeJS.ProcessEnv {
+	if (!isDev || process.platform !== "win32") {
+		return process.env;
+	}
+	try {
+		const daemonDir = path.resolve(app.getAppPath(), "daemon");
+		const manifestPath = path.join(daemonDir, "dev-daemon.json");
+		const parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as { path?: unknown };
+		if (typeof parsed.path === "string") {
+			const daemonPath = path.resolve(parsed.path.trim());
+			const relativePath = path.relative(daemonDir, daemonPath);
+			if (relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
+				return { ...process.env, AO_DEV_DAEMON_BINARY: daemonPath };
+			}
+		}
+	} catch {
+		// Fall back to the legacy fixed dev path; build-daemon writes the manifest.
+	}
+	return process.env;
+}
+
 async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	if (daemonProcess) {
 		return daemonStatus;
@@ -947,7 +968,7 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	await ensureShellEnv();
 
 	const launch = resolveDaemonLaunch(
-		process.env,
+		daemonLaunchEnv(),
 		app.isPackaged,
 		process.resourcesPath,
 		app.getAppPath(),

--- a/frontend/src/shared/daemon-launch.test.ts
+++ b/frontend/src/shared/daemon-launch.test.ts
@@ -14,11 +14,40 @@ describe("resolveDaemonLaunch", () => {
 		});
 	});
 
-	it("runs the backend daemon from source in dev without an explicit command", () => {
+	it("runs the backend daemon from source in non-Windows dev without an explicit command", () => {
 		expect(resolveDaemonLaunch({}, false, "/resources", "/repo/frontend", "/home/user", "darwin")).toEqual({
 			command: "go",
 			args: ["run", "./cmd/ao", "daemon"],
 			cwd: "/repo/frontend/../backend",
+			shell: false,
+			source: "dev",
+		});
+	});
+
+	it("uses the prebuilt daemon exe in Windows dev", () => {
+		expect(resolveDaemonLaunch({}, false, "/resources", "C:\\repo\\frontend", "C:\\Users\\alice", "win32")).toEqual({
+			command: "C:\\repo\\frontend/daemon/ao.exe",
+			args: ["daemon"],
+			cwd: "C:\\repo\\frontend",
+			shell: false,
+			source: "dev",
+		});
+	});
+
+	it("uses the versioned daemon exe in Windows dev when build-daemon wrote one", () => {
+		expect(
+			resolveDaemonLaunch(
+				{ AO_DEV_DAEMON_BINARY: "C:\\repo\\frontend\\daemon\\dev-123\\ao.exe" },
+				false,
+				"/resources",
+				"C:\\repo\\frontend",
+				"C:\\Users\\alice",
+				"win32",
+			),
+		).toEqual({
+			command: "C:\\repo\\frontend\\daemon\\dev-123\\ao.exe",
+			args: ["daemon"],
+			cwd: "C:\\repo\\frontend",
 			shell: false,
 			source: "dev",
 		});

--- a/frontend/src/shared/daemon-launch.ts
+++ b/frontend/src/shared/daemon-launch.ts
@@ -34,6 +34,15 @@ export function resolveDaemonLaunch(
 	}
 
 	if (!isPackaged) {
+		if (platform === "win32") {
+			return {
+				command: env.AO_DEV_DAEMON_BINARY?.trim() || joinPath(appPath, "daemon", bundledDaemonBinaryName(platform)),
+				args: ["daemon"],
+				cwd: appPath,
+				shell: false,
+				source: "dev",
+			};
+		}
 		return {
 			command: "go",
 			args: ["run", "./cmd/ao", "daemon"],


### PR DESCRIPTION
Fixes https://github.com/Untrivial-ai/agent-orchestrator/issues/4012

## What happened
On Windows, AO can show black Command Prompt windows for a moment and then close them again. A user reported that this happens repeatedly while using AO, sometimes 5-6 times, and it looks broken.

This is mainly a Windows problem. When a desktop app starts console programs in the background, Windows can show a command window unless the process is started with hidden-window flags.

## Why it happened
There were two places where this could happen:

1. In dev mode, `npm run dev` started the daemon through `go run`. On Windows, `go run` starts extra compiler/helper processes, so startup could flash several command windows.
2. In the normal downloaded Windows app, the daemon also starts background tools like Git, Docker, Tailscale, agent version checks, reviewer tools, and ACP provider processes. Some of these were not using AO's hidden process wrapper.

There was also a related dev-mode problem: if an old AO session was still using `frontend/daemon/ao.exe`, Windows could keep that file locked. The next `npm run dev` could then fail while trying to delete or replace it.

## What changed
- Windows dev mode now builds the daemon first and starts the built `ao.exe` instead of using `go run` at app startup.
- Windows dev builds use versioned daemon folders, so an old running session does not block the next build.
- Background helper processes launched by the daemon now use the existing hidden-process wrapper on Windows.
- ACP provider processes still keep their process-group cleanup behavior, but no longer need to show a console window.
- Mac and Linux dev behavior is unchanged.
- Packaged daemon location is unchanged.

## Before 

https://github.com/user-attachments/assets/2b6f5464-251b-4336-b757-69ca42bce39c





## After 
it works fine :)

## Tested
- `npm --prefix frontend run test -- src/shared/daemon-launch.test.ts`
- `go test ./internal/workspacewatch -run '^$'`
- focused backend compile check for touched packages
- `git diff --check upstream/main..HEAD`
- `npm --prefix frontend run build:daemon`

## Note
Full frontend typecheck currently fails in this local checkout because `packages/product-ui/src/SessionsBoardView.tsx` cannot resolve `motion/react`. That is unrelated to this PR; the changed frontend test passes.