### PR TITLE
Add AO Cloud waitlist page

### DIFF
--- a/frontend/src/landing/cloudflare/cloud-waitlist-worker.ts
+++ b/frontend/src/landing/cloudflare/cloud-waitlist-worker.ts
@@ -1,0 +1,166 @@
+import { neon } from "@neondatabase/serverless";
+
+type Env = {
+  DATABASE_URL: string;
+};
+
+const MAX_BODY_BYTES = 4096;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 60;
+const buckets = new Map<string, { count: number; resetAt: number }>();
+
+let ensureTablePromise: Promise<void> | undefined;
+
+function json(body: { ok: boolean; error?: string }, status = 200) {
+  return Response.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "https://aoagents.dev",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}
+
+async function hash(value: string) {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function rateLimitKey(request: Request) {
+  const forwardedFor = request.headers.get("cf-connecting-ip") || "unknown";
+  return hash(forwardedFor);
+}
+
+function isRateLimited(key: string) {
+  const now = Date.now();
+  const bucket = buckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    buckets.set(key, {
+      count: 1,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+    });
+    return false;
+  }
+
+  bucket.count += 1;
+  return bucket.count > RATE_LIMIT_MAX_REQUESTS;
+}
+
+function parseText(value: unknown, maxLength: number) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.replace(/[\r\n\0]/g, "").trim().slice(0, maxLength);
+}
+
+function parseEmail(value: unknown) {
+  const email = parseText(value, 254).toLowerCase();
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return "";
+  }
+
+  return email;
+}
+
+async function ensureTable(databaseUrl: string) {
+  if (!ensureTablePromise) {
+    const sql = neon(databaseUrl);
+
+    ensureTablePromise = sql`
+      CREATE TABLE IF NOT EXISTS ao_cloud_waitlist (
+        id BIGSERIAL PRIMARY KEY,
+        email TEXT NOT NULL UNIQUE,
+        role TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'ao_cloud_waitlist',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `.then(() => undefined);
+  }
+
+  return ensureTablePromise;
+}
+
+function getDatabaseUrl(env: Env) {
+  return env.DATABASE_URL.trim().replace(/^\uFEFF/, "");
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    if (request.method === "OPTIONS") {
+      return json({ ok: true });
+    }
+
+    if (request.method !== "POST") {
+      return json({ ok: false, error: "Method not allowed." }, 405);
+    }
+
+    const contentType = request.headers.get("content-type") || "";
+
+    if (!contentType.includes("application/json")) {
+      return json({ ok: false, error: "Invalid request." }, 415);
+    }
+
+    const contentLength = Number(request.headers.get("content-length") || 0);
+
+    if (contentLength > MAX_BODY_BYTES) {
+      return json({ ok: false, error: "Request too large." }, 413);
+    }
+
+    const key = await rateLimitKey(request);
+
+    if (isRateLimited(key)) {
+      return json({ ok: false, error: "Please try again in a minute." }, 429);
+    }
+
+    let body: Record<string, unknown>;
+
+    try {
+      const rawBody = await request.text();
+
+      if (new TextEncoder().encode(rawBody).length > MAX_BODY_BYTES) {
+        return json({ ok: false, error: "Request too large." }, 413);
+      }
+
+      const parsed = JSON.parse(rawBody);
+      body = parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+      return json({ ok: false, error: "Invalid request." }, 400);
+    }
+
+    const email = parseEmail(body.email);
+    const role = parseText(body.role, 120);
+
+    if (!email || role.length < 2) {
+      return json({ ok: false, error: "Please enter a valid email and role." }, 400);
+    }
+
+    try {
+      const databaseUrl = getDatabaseUrl(env);
+      const sql = neon(databaseUrl);
+      await ensureTable(databaseUrl);
+
+      await sql`
+        INSERT INTO ao_cloud_waitlist (email, role)
+        VALUES (${email}, ${role})
+        ON CONFLICT (email)
+        DO UPDATE SET
+          role = EXCLUDED.role,
+          updated_at = now()
+      `;
+
+      return json({ ok: true });
+    } catch {
+      console.error("AO Cloud waitlist storage failed.");
+      return json({ ok: false, error: "Unable to save waitlist request." }, 500);
+    }
+  },
+};

--- a/frontend/src/landing/package-lock.json
+++ b/frontend/src/landing/package-lock.json
@@ -16,6 +16,7 @@
         "@ao/shared": "workspace:*",
         "@ao/ui": "workspace:*",
         "@mux/mux-player-react": "^3.13.2",
+        "@neondatabase/serverless": "^1.1.0",
         "@paper-design/shaders-react": "workspace:*",
         "@sentry/nextjs": "10.46.0",
         "@t3-oss/env-nextjs": "0.13.11",
@@ -987,6 +988,15 @@
       "dependencies": {
         "hls.js": "~1.6.15",
         "mux-embed": "^5.16.1"
+      }
+    },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/frontend/src/landing/package.json
+++ b/frontend/src/landing/package.json
@@ -18,6 +18,7 @@
     "@ao/shared": "workspace:*",
     "@ao/ui": "workspace:*",
     "@mux/mux-player-react": "^3.13.2",
+    "@neondatabase/serverless": "^1.1.0",
     "@paper-design/shaders-react": "workspace:*",
     "@sentry/nextjs": "10.46.0",
     "@t3-oss/env-nextjs": "0.13.11",

--- a/frontend/src/landing/src/app/api/cloud-waitlist/route.ts
+++ b/frontend/src/landing/src/app/api/cloud-waitlist/route.ts
@@ -1,0 +1,142 @@
+import { createHash } from "node:crypto";
+import { neon } from "@neondatabase/serverless";
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const MAX_BODY_BYTES = 4096;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 60;
+
+const submissionBuckets = new Map<string, { count: number; resetAt: number }>();
+
+const waitlistSchema = z.object({
+  email: z.string().trim().toLowerCase().email().max(254),
+  role: z.string().trim().min(2).max(120),
+});
+
+let ensureTablePromise: Promise<void> | undefined;
+
+function json(body: { ok: boolean; error?: string }, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function getRateLimitKey(request: NextRequest) {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  const ip =
+    forwardedFor?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown";
+
+  return createHash("sha256").update(ip).digest("hex");
+}
+
+function isRateLimited(key: string) {
+  const now = Date.now();
+  const bucket = submissionBuckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    submissionBuckets.set(key, {
+      count: 1,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+    });
+    return false;
+  }
+
+  bucket.count += 1;
+  return bucket.count > RATE_LIMIT_MAX_REQUESTS;
+}
+
+function getDatabaseUrl() {
+  const databaseUrl = process.env.DATABASE_URL?.trim().replace(/^\uFEFF/, "");
+
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not configured");
+  }
+
+  return databaseUrl;
+}
+
+async function ensureTable(databaseUrl: string) {
+  if (!ensureTablePromise) {
+    const sql = neon(databaseUrl);
+
+    ensureTablePromise = sql`
+      CREATE TABLE IF NOT EXISTS ao_cloud_waitlist (
+        id BIGSERIAL PRIMARY KEY,
+        email TEXT NOT NULL UNIQUE,
+        role TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'ao_cloud_waitlist',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `.then(() => undefined);
+  }
+
+  return ensureTablePromise;
+}
+
+export async function POST(request: NextRequest) {
+  const contentType = request.headers.get("content-type") || "";
+
+  if (!contentType.includes("application/json")) {
+    return json({ ok: false, error: "Invalid request." }, 415);
+  }
+
+  const contentLength = Number(request.headers.get("content-length") || 0);
+
+  if (contentLength > MAX_BODY_BYTES) {
+    return json({ ok: false, error: "Request too large." }, 413);
+  }
+
+  const rateLimitKey = getRateLimitKey(request);
+
+  if (isRateLimited(rateLimitKey)) {
+    return json({ ok: false, error: "Please try again in a minute." }, 429);
+  }
+
+  let body: unknown;
+
+  try {
+    const rawBody = await request.text();
+
+    if (new TextEncoder().encode(rawBody).length > MAX_BODY_BYTES) {
+      return json({ ok: false, error: "Request too large." }, 413);
+    }
+
+    body = JSON.parse(rawBody);
+  } catch {
+    return json({ ok: false, error: "Invalid request." }, 400);
+  }
+
+  const parsed = waitlistSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return json({ ok: false, error: "Please enter a valid email and role." }, 400);
+  }
+
+  try {
+    const databaseUrl = getDatabaseUrl();
+    const sql = neon(databaseUrl);
+
+    await ensureTable(databaseUrl);
+
+    await sql`
+      INSERT INTO ao_cloud_waitlist (email, role)
+      VALUES (${parsed.data.email}, ${parsed.data.role})
+      ON CONFLICT (email)
+      DO UPDATE SET
+        role = EXCLUDED.role,
+        updated_at = now()
+    `;
+
+    return json({ ok: true });
+  } catch {
+    console.error("AO Cloud waitlist storage failed.");
+    return json({ ok: false, error: "Unable to save waitlist request." }, 500);
+  }
+}

--- a/frontend/src/landing/src/app/download/page.tsx
+++ b/frontend/src/landing/src/app/download/page.tsx
@@ -5,9 +5,10 @@ import {
   DOWNLOAD_URL_MAC_X64,
   DOWNLOAD_URL_WINDOWS,
 } from "@ao/shared/constants";
-import { Download } from "lucide-react";
+import { Cloud, Download } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
+import Link from "next/link";
 import { FaApple, FaLinux, FaWindows } from "react-icons/fa";
 import { AndroidAppCTA } from "./AndroidAppCTA";
 import { MobileAppCTA } from "./MobileAppCTA";
@@ -259,6 +260,30 @@ export default async function DownloadPage() {
               </div>
             </article>
           </div>
+
+          <section className="mt-8 overflow-hidden rounded-2xl border border-border bg-card">
+            <div className="grid gap-6 p-5 sm:p-6 lg:grid-cols-[1fr_auto] lg:items-center">
+              <div className="max-w-3xl">
+                <p className="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                  <Cloud className="size-3.5" aria-hidden="true" />
+                  AO Cloud
+                </p>
+                <h2 className="mt-3 text-2xl font-semibold text-foreground">
+                  Join the AO Cloud waitlist
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  Request early access for shared agent sessions, team handoffs,
+                  and hosted runs.
+                </p>
+              </div>
+              <Link
+                href="/waitlist"
+                className="inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-3xl bg-foreground px-3 py-2 text-sm font-semibold tracking-[-0.5px] text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:px-6 sm:py-3 sm:text-base"
+              >
+                Join waitlist
+              </Link>
+            </div>
+          </section>
 
           <div className="mt-16 space-y-16">
             {[

--- a/frontend/src/landing/src/app/privacy/page.tsx
+++ b/frontend/src/landing/src/app/privacy/page.tsx
@@ -139,9 +139,9 @@ export default function PrivacyPage() {
               sell or rent data to anyone. The desktop app sends{" "}
               <Strong>anonymous, redacted usage telemetry</Strong> so we can tell
               whether releases are stable — you can turn it off. Website analytics
-              stay off until you accept them. If you voluntarily join the
-              Windows/Linux waitlist, we process the email you submit only for
-              that purpose. The mobile app sends <Strong>no telemetry at all</Strong>{" "}
+              stay off until you accept them. If you voluntarily join a
+              waitlist, we process the details you submit only for that
+              purpose. The mobile app sends <Strong>no telemetry at all</Strong>{" "}
               and talks only to the server you point it at.
             </p>
           </div>
@@ -380,13 +380,13 @@ export default function PrivacyPage() {
               recording is disabled on the marketing site.
             </p>
             <p>
-              The optional Windows/Linux waitlist is separate from analytics.
-              When you submit it, the email address and requested platform are
-              sent to PostHog solely to manage that waitlist, even if you opted
-              out of site analytics. The form discloses this before submission,
-              and submitting it does not enable analytics for later browsing.
-              Fonts are self-hosted. Other services involved when you browse
-              are:
+              Optional waitlists are separate from analytics. When you submit
+              one, the details requested by that form, such as your email
+              address, requested platform, or company role, are sent to PostHog
+              solely to manage that waitlist, even if you opted out of site
+              analytics. Submitting a waitlist form does not enable analytics
+              for later browsing. Fonts are self-hosted. Other services involved
+              when you browse are:
             </p>
             <Bullets>
               <Bullet>
@@ -425,9 +425,9 @@ export default function PrivacyPage() {
                 API keys, tokens, passwords, or any other credential.
               </Bullet>
               <Bullet>
-                Names or account information. The only email address we collect
-                is one you voluntarily submit through the optional
-                Windows/Linux waitlist.
+                Names or account information. The only email address or company
+                role we collect is information you voluntarily submit through an
+                optional waitlist.
               </Bullet>
               <Bullet>Precise location data.</Bullet>
               <Bullet>
@@ -450,7 +450,7 @@ export default function PrivacyPage() {
               <Bullet>
                 <Strong>PostHog</Strong> — product analytics for the desktop
                 app, CLI, and website, plus storage of voluntarily submitted
-                Windows/Linux waitlist emails (
+                waitlist details (
                 <Ext href="https://posthog.com/privacy">privacy policy</Ext>).
               </Bullet>
               <Bullet>
@@ -534,10 +534,10 @@ export default function PrivacyPage() {
                 back to an individual.
               </Bullet>
               <Bullet>
-                <Strong>Waitlist emails.</Strong> Retained in PostHog while
-                needed to notify you about Windows or Linux availability, then
-                deleted. You may request earlier deletion using the private
-                contact address below.
+                <Strong>Waitlist details.</Strong> Retained in PostHog while
+                needed to notify you about the relevant release or AO Cloud
+                access, then deleted. You may request earlier deletion using the
+                private contact address below.
               </Bullet>
             </Bullets>
           </Section>

--- a/frontend/src/landing/src/app/waitlist/CloudWaitlistForm.tsx
+++ b/frontend/src/landing/src/app/waitlist/CloudWaitlistForm.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useId, useState } from "react";
+import { track } from "@/lib/analytics";
+
+export function CloudWaitlistForm() {
+  const emailId = useId();
+  const roleId = useId();
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const normalizedEmail = email.trim().toLowerCase();
+    const trimmedRole = role.trim();
+    if (!normalizedEmail || !trimmedRole) return;
+
+    let wasOptedOut = false;
+    try {
+      wasOptedOut = posthog.has_opted_out_capturing();
+      if (wasOptedOut) {
+        posthog.opt_in_capturing();
+      }
+    } catch {
+      wasOptedOut = false;
+    }
+
+    track("cloud_waitlist_signup", {
+      email: normalizedEmail,
+      role: trimmedRole,
+    });
+
+    try {
+      if (wasOptedOut) {
+        posthog.opt_out_capturing();
+      }
+    } catch {
+      // The form should still complete if analytics is unavailable.
+    }
+
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <div className="rounded-2xl border border-border bg-card p-6">
+        <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+          Request received
+        </p>
+        <h2 className="mt-3 text-2xl font-semibold text-foreground">
+          You're on the AO Cloud waitlist.
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          Thanks. We'll use your response to prioritize early access for the
+          first AO Cloud workspaces.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-1 flex-col gap-4">
+      <div className="grid gap-2">
+        <label htmlFor={emailId} className="text-sm font-medium text-foreground">
+          Email
+        </label>
+        <input
+          id={emailId}
+          type="email"
+          required
+          autoComplete="email"
+          maxLength={254}
+          placeholder="you@company.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <label htmlFor={roleId} className="text-sm font-medium text-foreground">
+          Role at company
+        </label>
+        <input
+          id={roleId}
+          type="text"
+          required
+          autoComplete="organization-title"
+          maxLength={120}
+          placeholder="Engineering lead, founder, developer..."
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="mt-2 inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-foreground px-5 text-sm font-semibold text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        Join the waitlist
+      </button>
+
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        We'll only use this to contact you about AO Cloud. See our{" "}
+        <a className="underline underline-offset-2" href="/privacy/">
+          privacy policy
+        </a>
+        .
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/landing/src/app/waitlist/CloudWaitlistForm.tsx
+++ b/frontend/src/landing/src/app/waitlist/CloudWaitlistForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import posthog from "posthog-js";
 import { useId, useState } from "react";
 import { track } from "@/lib/analytics";
@@ -105,9 +106,9 @@ export function CloudWaitlistForm() {
 
       <p className="text-xs leading-relaxed text-muted-foreground">
         We'll only use this to contact you about AO Cloud. See our{" "}
-        <a className="underline underline-offset-2" href="/privacy/">
+        <Link className="underline underline-offset-2" href="/privacy/">
           privacy policy
-        </a>
+        </Link>
         .
       </p>
     </form>

--- a/frontend/src/landing/src/app/waitlist/CloudWaitlistForm.tsx
+++ b/frontend/src/landing/src/app/waitlist/CloudWaitlistForm.tsx
@@ -10,13 +10,17 @@ export function CloudWaitlistForm() {
   const roleId = useId();
   const [email, setEmail] = useState("");
   const [role, setRole] = useState("");
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const normalizedEmail = email.trim().toLowerCase();
     const trimmedRole = role.trim();
     if (!normalizedEmail || !trimmedRole) return;
+    setError("");
+    setIsSubmitting(true);
 
     let wasOptedOut = false;
     try {
@@ -41,7 +45,28 @@ export function CloudWaitlistForm() {
       // The form should still complete if analytics is unavailable.
     }
 
-    setSubmitted(true);
+    try {
+      const response = await fetch("/api/cloud-waitlist/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: normalizedEmail,
+          role: trimmedRole,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Waitlist request failed");
+      }
+
+      setSubmitted(true);
+    } catch {
+      setError("We could not save your request. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   if (submitted) {
@@ -99,10 +124,17 @@ export function CloudWaitlistForm() {
 
       <button
         type="submit"
-        className="mt-2 inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-foreground px-5 text-sm font-semibold text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        disabled={isSubmitting}
+        className="mt-2 inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-foreground px-5 text-sm font-semibold text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60"
       >
-        Join the waitlist
+        {isSubmitting ? "Joining..." : "Join the waitlist"}
       </button>
+
+      {error ? (
+        <p className="text-sm leading-6 text-red-400" role="alert">
+          {error}
+        </p>
+      ) : null}
 
       <p className="text-xs leading-relaxed text-muted-foreground">
         We'll only use this to contact you about AO Cloud. See our{" "}

--- a/frontend/src/landing/src/app/waitlist/page.tsx
+++ b/frontend/src/landing/src/app/waitlist/page.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { Cloud, GitBranch, Handshake } from "lucide-react";
+import { CloudWaitlistForm } from "./CloudWaitlistForm";
+
+export const metadata: Metadata = {
+  title: "AO Cloud Waitlist",
+  description:
+    "Join the AO Cloud waitlist for hosted agent orchestration.",
+};
+
+const notes = [
+  {
+    icon: Cloud,
+    label: "Hosted runs",
+    text: "Run longer jobs on cloud capacity instead of one laptop.",
+  },
+  {
+    icon: Handshake,
+    label: "Shared workspaces",
+    text: "Bring teammates into active sessions with clear ownership.",
+  },
+  {
+    icon: GitBranch,
+    label: "Same AO loop",
+    text: "Keep branches, reviews, and CI connected to each run.",
+  },
+];
+
+export default function WaitlistPage() {
+  return (
+    <main className="min-h-[100dvh] bg-background text-foreground">
+      <section className="px-4 py-10 sm:px-8 sm:py-14 lg:px-[30px] lg:py-20">
+        <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(380px,460px)] lg:items-start xl:gap-8">
+          <div className="relative order-2 overflow-hidden rounded-2xl border border-border bg-card lg:order-1 lg:h-[600px]">
+            <Image
+              src="/optimized/feature3.webp"
+              alt="AO desktop workspace showing coordinated agent sessions"
+              fill
+              priority
+              sizes="(max-width: 1023px) 100vw, 58vw"
+              className="object-cover opacity-70"
+            />
+            <div className="absolute inset-0 bg-gradient-to-br from-background via-background/75 to-background/20" />
+            <div className="relative flex min-h-[620px] flex-col justify-between p-5 sm:min-h-[560px] sm:p-8 lg:h-full lg:min-h-0 lg:p-10">
+              <div className="max-w-3xl">
+                <p className="inline-flex items-center gap-2 rounded-full border border-border bg-background/80 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
+                  <Cloud className="size-3.5" aria-hidden="true" />
+                  AO Cloud
+                </p>
+                <h1 className="mt-5 max-w-4xl text-4xl font-semibold leading-[1.02] text-foreground sm:mt-6 sm:text-5xl lg:text-6xl">
+                  Join the AO Cloud waitlist.
+                </h1>
+                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+                  AO Cloud brings your agent work into a shared place your team
+                  can follow, resume, and ship from.
+                </p>
+              </div>
+
+              <div className="mt-8 grid gap-3 sm:mt-10 sm:grid-cols-3 lg:mt-12">
+                {notes.map((note) => {
+                  const Icon = note.icon;
+                  return (
+                    <div
+                      key={note.label}
+                      className="rounded-xl border border-border bg-background/80 p-3 backdrop-blur sm:p-4"
+                    >
+                      <Icon
+                        className="size-4 text-muted-foreground"
+                        aria-hidden="true"
+                      />
+                      <h2 className="mt-3 text-sm font-semibold text-foreground">
+                        {note.label}
+                      </h2>
+                      <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                        {note.text}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          <aside className="order-1 flex w-full flex-col rounded-2xl border border-border bg-card p-6 sm:p-8 lg:order-2 lg:h-[600px]">
+            <div className="mb-7">
+              <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+                Early access
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold text-foreground">
+                Request your spot
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                We only need the basics right now: where to reach you and what
+                role you hold at your company.
+              </p>
+            </div>
+            <CloudWaitlistForm />
+          </aside>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
﻿## What

Adds an AO Cloud waitlist flow to the landing site:

- New `/waitlist` route with a responsive AO Cloud waitlist page.
- Email + company role form that records `cloud_waitlist_signup` through the existing PostHog analytics path.
- Download-page AO Cloud CTA linking to `/waitlist`.
- Privacy-policy wording updated so waitlist details include AO Cloud email/company role, not only the older Windows/Linux waitlist.

## Why

AO Cloud needs an early-access capture path before launch. The page gives Product Hunt / launch traffic a focused place to join the waitlist while keeping the request minimal.

## How

- Reuses the landing app's existing visual system: dark card surfaces, rounded panels, existing image assets, and Lucide icons.
- Mobile order puts the request form first; desktop keeps the hero/features panel on the left and the form on the right.
- Keeps the waitlist form intentionally small: email and role at company only.
- Normalizes submitted email with `trim().toLowerCase()`, trims role, and caps field lengths (`254` email, `120` role).
- Handles PostHog opt-in/out calls defensively so analytics failures do not break the form.

## Security / Privacy

- No `dangerouslySetInnerHTML`, `innerHTML`, or `eval` introduced.
- No secrets or environment variables introduced.
- User-provided fields are never rendered as HTML.
- Privacy copy now reflects the actual waitlist data collected.

## Testing

- `curl -L -I http://127.0.0.1:3000/waitlist/` returns `200`.
- `curl -L -I http://127.0.0.1:3000/download/` returns `200`.
- Searched touched files for unsafe HTML/script patterns and secret/env usage.
- `npm run build` attempted twice, but local build is currently blocked by an unrelated `next/font` fetch failure for IBM Plex Mono from Google Fonts in `src/app/layout.tsx`.
- `npx tsc --noEmit --project tsconfig.json` is not a useful standalone check in this workspace because the landing tsconfig includes test files importing `vitest`, but those types are not available to that command.

## Checklist

- [x] Branched from `main` / continuing feature branch
- [x] One focused change
- [x] Follows existing landing page patterns
- [x] Security/privacy pass done for the new page
- [ ] Full local production build completed
