### PR TITLE
Refine Linux scrollbars

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -320,7 +320,7 @@ describe("Sidebar", () => {
 		renderSidebar();
 
 		const content = document.querySelector('[data-sidebar="content"]');
-		expect(content).toHaveClass("overflow-y-auto");
+		expect(content).toHaveClass("overflow-y-auto", "project-sidebar-scrollbar");
 		expect(content).not.toHaveClass("scrollbar-none");
 		expect(content).not.toContainElement(screen.getByText("Projects"));
 	});

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -391,7 +391,7 @@ export function Sidebar({
 				</div>
 			</div>
 
-			<SidebarContent className="gap-0 px-2 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-1.5">
+			<SidebarContent className="project-sidebar-scrollbar gap-0 px-2 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-1.5">
 				<SidebarGroup className="p-0">
 					{/* Tree (project-sidebar__tree) */}
 					<SidebarGroupContent>

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1386,6 +1386,58 @@ textarea,
 	background: transparent;
 }
 
+/* Chromium uses the desktop theme's chunky native horizontal scrollbar on
+   Linux. Keep the board scroller compact and rounded there without changing
+   macOS overlay scrollbars or Windows behavior. */
+.platform-linux .board-horizontal-scrollbar::-webkit-scrollbar {
+	height: 6px;
+}
+
+.platform-linux .board-horizontal-scrollbar::-webkit-scrollbar-button {
+	display: none;
+	width: 0;
+	height: 0;
+}
+
+.platform-linux .board-horizontal-scrollbar::-webkit-scrollbar-track,
+.platform-linux .board-horizontal-scrollbar::-webkit-scrollbar-corner {
+	background: transparent;
+}
+
+.platform-linux .board-horizontal-scrollbar::-webkit-scrollbar-thumb {
+	min-width: 24px;
+	border-radius: 999px;
+	background-color: color-mix(in srgb, var(--color-scrollbar) 42%, transparent);
+}
+
+.platform-linux .board-horizontal-scrollbar::-webkit-scrollbar-thumb:hover {
+	background-color: color-mix(in srgb, var(--color-scrollbar) 56%, transparent);
+}
+
+.platform-linux .project-sidebar-scrollbar::-webkit-scrollbar {
+	width: 6px;
+}
+
+.platform-linux .project-sidebar-scrollbar::-webkit-scrollbar-button {
+	display: none;
+	width: 0;
+	height: 0;
+}
+
+.platform-linux .project-sidebar-scrollbar::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.platform-linux .project-sidebar-scrollbar::-webkit-scrollbar-thumb {
+	min-height: 24px;
+	border-radius: 999px;
+	background-color: color-mix(in srgb, var(--color-scrollbar) 42%, transparent);
+}
+
+.platform-linux .project-sidebar-scrollbar::-webkit-scrollbar-thumb:hover {
+	background-color: color-mix(in srgb, var(--color-scrollbar) 56%, transparent);
+}
+
 @supports (-moz-appearance: none) {
 	.board-scrollbar {
 		scrollbar-width: thin;

--- a/packages/product-ui/src/SessionsBoardView.test.tsx
+++ b/packages/product-ui/src/SessionsBoardView.test.tsx
@@ -99,6 +99,7 @@ describe("SessionsBoardView", () => {
 		const mergeLane = screen.getByRole("region", { name: "Ready / Merged sessions" });
 		expect(within(mergeLane).getByLabelText("1 ready session")).toHaveTextContent("1");
 		expect(within(mergeLane).getByLabelText("1 merged session")).toHaveTextContent("1");
+		expect(screen.getByTestId("board-horizontal-scroll")).toHaveClass("board-horizontal-scrollbar");
 	});
 
 	it("renders a neutral card with grouped multi-PR, usage, and action presentation", () => {

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -103,7 +103,10 @@ export function SessionsBoardGridView<TSession extends BoardSessionPresentation>
 	}
 
 	return (
-		<div className="h-full overflow-x-auto overflow-y-hidden">
+		<div
+			className="board-horizontal-scrollbar h-full overflow-x-auto overflow-y-hidden"
+			data-testid="board-horizontal-scroll"
+		>
 			<div className="relative grid h-full min-w-[64rem] grid-cols-4 divide-x divide-border-strong xl:min-w-0">
 				<div
 					aria-hidden="true"


### PR DESCRIPTION
## Summary

- replace the native Linux board scrollbar with a compact rounded horizontal thumb
- apply the same Linux-only treatment to the project sidebar scrollbar
- leave macOS and Windows scrollbar behavior unchanged

Before
<img width="1920" height="1200" alt="Screenshot From 2026-08-15 03-11-28" src="https://github.com/user-attachments/assets/3adca053-c34f-4874-85d2-f00325681699" />


After
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/08fd8a7c-7ee1-4656-a179-8bdf78bc49dc" />


## Why

Chromium inherited the Linux desktop theme's thick, boxy scrollbars because the board and project sidebar overflow containers had no dedicated styling hooks.

## Validation

- `npm test -- --run src/renderer/components/Sidebar.test.tsx`
- `npm test -- --run src/SessionsBoardView.test.tsx` in `packages/product-ui`
- `npm run typecheck` in `frontend`
- `npm run typecheck` in `packages/product-ui`
