### PR TITLE
fix: clear stuck chat working state

### DIFF
--- a/backend/internal/adapters/chatdriver/codexappserver/conversation.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conversation.go
@@ -157,7 +157,7 @@ func (c *conversation) pump() {
 				c.contextAtTurnStart = c.contextTokens
 				c.mu.Unlock()
 			}
-			if ev.Kind == ports.ChatEventTurnCompleted && rootConversation {
+			if ev.Kind == ports.ChatEventTurnCompleted && ev.ProviderTurnID != "" && rootConversation {
 				c.mu.Lock()
 				if c.activeTurn == ev.ProviderTurnID {
 					c.activeTurn = ""

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -155,6 +155,10 @@ type Controller struct {
 	// activeTurn maps a provider turn id to AO's turn id for the turn currently
 	// in flight, so a completion can be attributed without a round trip.
 	pendingTurnID string
+	// dispatchingTurnID is AO's durable turn row while SendTurn is in flight.
+	// Eager providers can emit turn/started before SendTurn returns with the
+	// provider id; that event must bind this row instead of adopting a duplicate.
+	dispatchingTurnID string
 	// ackedTurnID is the turn the PROVIDER has confirmed it started, which lags
 	// pendingTurnID by the round trip between turn/start returning and the
 	// turn-started notification arriving. Interrupt needs the distinction: a
@@ -746,8 +750,16 @@ func (c *Controller) dispatch(
 	// applying exactly when they were not watching.
 	msg.Settings = c.turnSettings()
 
+	c.mu.Lock()
+	c.dispatchingTurnID = turnID
+	c.mu.Unlock()
 	ref, err := c.conv.SendTurn(ctx, msg)
 	if err != nil {
+		c.mu.Lock()
+		if c.dispatchingTurnID == turnID {
+			c.dispatchingTurnID = ""
+		}
+		c.mu.Unlock()
 		// The provider may or may not have accepted it. Settle the turn as failed
 		// rather than retrying: a duplicate turn would run the work twice. Settling
 		// by AO's own turn id is required here — an undispatched turn has no
@@ -770,6 +782,11 @@ func (c *Controller) dispatch(
 	}
 
 	if err := c.store.BindTurnToProvider(ctx, turnID, ref.ProviderTurnID, c.now()); err != nil {
+		c.mu.Lock()
+		if c.dispatchingTurnID == turnID {
+			c.dispatchingTurnID = ""
+		}
+		c.mu.Unlock()
 		if deferred, ok := c.conv.(ports.ChatDeferredTurnStarter); ok {
 			deferred.DiscardDeferredTurn(ref.ProviderTurnID)
 		}
@@ -778,6 +795,9 @@ func (c *Controller) dispatch(
 
 	c.mu.Lock()
 	c.pendingTurnID = ref.ProviderTurnID
+	if c.dispatchingTurnID == turnID {
+		c.dispatchingTurnID = ""
+	}
 	// Dispatched, not yet acknowledged: turn/start returning is AO's fact, and the
 	// provider's own turn-started notification is the one an interrupt needs.
 	c.ackedTurnID = ""
@@ -1447,6 +1467,7 @@ func (c *Controller) applyCommittedTurnLifecycle(event ports.ChatEvent) bool {
 			return false
 		}
 		c.pendingTurnID = ""
+		c.dispatchingTurnID = ""
 		if c.ackedTurnID == event.ProviderTurnID {
 			c.ackedTurnID = ""
 		}
@@ -1462,15 +1483,25 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 
 	switch event.Kind {
 	case ports.ChatEventTurnStarted:
-		// A turn AO dispatched already has a row, bound in dispatch. This covers the
-		// turn AO did NOT dispatch: a compaction, or work the provider resumed from its
-		// own history. Adopting it is what keeps every item it emits correlated, and
-		// without that the activities arrive with no turn and the timeline quietly
-		// stops grouping them.
+		c.mu.Lock()
+		dispatchingTurnID := c.dispatchingTurnID
+		c.mu.Unlock()
 		if event.ProviderTurnID != "" {
-			if err := c.store.AdoptProviderTurn(ctx, c.conversation.ID, c.sessionID,
-				c.generation, c.newID(), event.ProviderTurnID, now); err != nil {
-				return fmt.Errorf("adopt provider-started turn %s: %w", event.ProviderTurnID, err)
+			rootConversation := event.ProviderConversationID == "" || event.ProviderConversationID == c.conv.ProviderConversationID()
+			if dispatchingTurnID != "" && rootConversation {
+				if err := c.store.BindTurnToProvider(ctx, dispatchingTurnID, event.ProviderTurnID, now); err != nil {
+					return fmt.Errorf("bind early provider-started turn %s: %w", event.ProviderTurnID, err)
+				}
+			} else {
+				// A turn AO dispatched already has a row, bound in dispatch. This covers
+				// the turn AO did NOT dispatch: a compaction, or work the provider resumed
+				// from its own history. Adopting it is what keeps every item it emits
+				// correlated, and without that the activities arrive with no turn and the
+				// timeline quietly stops grouping them.
+				if err := c.store.AdoptProviderTurn(ctx, c.conversation.ID, c.sessionID,
+					c.generation, c.newID(), event.ProviderTurnID, now); err != nil {
+					return fmt.Errorf("adopt provider-started turn %s: %w", event.ProviderTurnID, err)
+				}
 			}
 		}
 		return nil

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -65,6 +65,7 @@ type fakeConversation struct {
 	resolved  map[string]ports.ChatDecision
 	turnSeq   int
 	sendErr   error
+	onSend    func(providerTurnID string)
 	closeOnce sync.Once
 }
 
@@ -126,13 +127,19 @@ func (f *fakeConversation) Events() <-chan ports.ChatEvent       { return f.even
 
 func (f *fakeConversation) SendTurn(_ context.Context, msg ports.ChatUserMessage) (ports.ChatTurnRef, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	if f.sendErr != nil {
+		f.mu.Unlock()
 		return ports.ChatTurnRef{}, f.sendErr
 	}
 	f.sent = append(f.sent, msg)
 	f.turnSeq++
-	return ports.ChatTurnRef{ProviderTurnID: fmt.Sprintf("provider-turn-%d", f.turnSeq)}, nil
+	providerTurnID := fmt.Sprintf("provider-turn-%d", f.turnSeq)
+	onSend := f.onSend
+	f.mu.Unlock()
+	if onSend != nil {
+		onSend(providerTurnID)
+	}
+	return ports.ChatTurnRef{ProviderTurnID: providerTurnID}, nil
 }
 
 // sentTexts is what actually reached the provider, in order. Queuing is only real
@@ -795,6 +802,46 @@ func TestProjectsAFullTurnIntoDurableRows(t *testing.T) {
 
 	if len(snapshot.Activities) != 1 || snapshot.Activities[0].Summary != "git status --short" {
 		t.Fatalf("activities = %+v", snapshot.Activities)
+	}
+}
+
+func TestEarlyTurnStartedBindsDispatchingTurn(t *testing.T) {
+	conv := newFakeConversation()
+	conv.onSend = func(providerTurnID string) {
+		conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: providerTurnID})
+	}
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	turn, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text:            "race turn/start",
+		ClientMessageID: "early-start-1",
+		Origin:          domain.MessageOriginHuman,
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if turn.ProviderTurnID != "provider-turn-1" {
+		t.Fatalf("provider turn = %q, want provider-turn-1", turn.ProviderTurnID)
+	}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		if len(s.Turns) != 1 {
+			return false
+		}
+		turn := s.Turns[0]
+		return turn.ProviderTurnID == "provider-turn-1" && turn.State == domain.TurnStateRunning
+	})
+
+	conv.emit(ports.ChatEvent{
+		Kind:           ports.ChatEventTurnCompleted,
+		ProviderTurnID: "provider-turn-1",
+		TurnState:      domain.TurnStateCompleted,
+	})
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateCompleted
+	})
+	if len(snapshot.Turns) != 1 {
+		t.Fatalf("turns = %d, want 1: %+v", len(snapshot.Turns), snapshot.Turns)
 	}
 }
 

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -579,16 +579,16 @@ func (s *Store) AppendImportedUserMessage(
 // BindTurnToProvider records the provider's turn id once a send is accepted and
 // marks the turn running.
 func (s *Store) BindTurnToProvider(ctx context.Context, turnID, providerTurnID string, now time.Time) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-	if err := s.qw.BindConversationTurnProviderID(ctx, gen.BindConversationTurnProviderIDParams{
+	q, unlock := s.conversationWriter(ctx)
+	defer unlock()
+	if err := q.BindConversationTurnProviderID(ctx, gen.BindConversationTurnProviderIDParams{
 		ProviderTurnID: providerTurnID,
 		StartedAt:      sql.NullTime{Time: now, Valid: true},
 		ID:             turnID,
 	}); err != nil {
 		return fmt.Errorf("bind turn %s to provider turn %s: %w", turnID, providerTurnID, err)
 	}
-	if err := s.qw.MarkConversationTurnStarted(ctx, gen.MarkConversationTurnStartedParams{
+	if err := q.MarkConversationTurnStarted(ctx, gen.MarkConversationTurnStartedParams{
 		StartedAt: sql.NullTime{Time: now, Valid: true},
 		ID:        turnID,
 	}); err != nil {

--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -434,4 +434,27 @@ describe("unavailable states", () => {
 		const { field } = renderComposer({ willQueue: true });
 		expect(field.placeholder).toContain("sends when it finishes");
 	});
+
+	it("turns the primary composer action into stop while the agent is working and the draft is empty", async () => {
+		const onSend = vi.fn();
+		const onInterrupt = vi.fn();
+		render(<ChatComposer onSend={onSend} willQueue onInterrupt={onInterrupt} />);
+
+		await userEvent.click(screen.getByRole("button", { name: "Stop turn" }));
+
+		expect(onInterrupt).toHaveBeenCalledTimes(1);
+		expect(onSend).not.toHaveBeenCalled();
+	});
+
+	it("keeps the primary action as queue while the agent is working and a draft exists", async () => {
+		const onSend = vi.fn();
+		const onInterrupt = vi.fn();
+		render(<ChatComposer onSend={onSend} willQueue onInterrupt={onInterrupt} />);
+
+		await userEvent.type(screen.getByLabelText("Message the agent"), "follow up");
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+		expect(onSend).toHaveBeenCalledWith("follow up");
+		expect(onInterrupt).not.toHaveBeenCalled();
+	});
 });

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -42,7 +42,7 @@ import {
 	type KeyboardEvent,
 	type ReactNode,
 } from "react";
-import { ArrowUp, CornerDownRight, Loader2, Paperclip, X } from "lucide-react";
+import { ArrowUp, CornerDownRight, Loader2, Paperclip, Square, X } from "lucide-react";
 import { Button } from "../ui/button";
 import { cn } from "../../lib/utils";
 import { ComposerSuggestMenu } from "./ComposerSuggestMenu";
@@ -87,6 +87,7 @@ export function ChatComposer({
 	onStageAttachments,
 	nativeImages,
 	onSteer,
+	onInterrupt,
 	canSteer,
 	steerPending,
 	steerRefusal,
@@ -121,6 +122,8 @@ export function ChatComposer({
 	 * cannot steer and the choice is never offered.
 	 */
 	onSteer?: (text: string) => Promise<unknown>;
+	/** Stop the turn already running when there is no draft to send. */
+	onInterrupt?: () => void;
 	/** A turn is actually running, so there is something to steer into. */
 	canSteer?: boolean;
 	steerPending?: boolean;
@@ -201,6 +204,7 @@ export function ChatComposer({
 	// Enter is still pointing at.
 	const steering = Boolean(canSteer && onSteer) && delivery === "steer";
 	const canSend = (text.trim().length > 0 || staged) && !busy && !disabled && !steerPending;
+	const canStopTurn = Boolean(willQueue && onInterrupt && !disabled && text.trim() === "" && !staged);
 	const draftSeedId = draftSeed?.id;
 	const draftSeedText = draftSeed?.text;
 
@@ -588,13 +592,16 @@ export function ChatComposer({
 									: "Enter to send"}
 					</span>
 					<Button
-						type="submit"
+						type={canStopTurn ? "button" : "submit"}
 						size="icon-sm"
-						disabled={!canSend}
-						aria-label={steering ? "Steer the running turn" : "Send message"}
+						disabled={canStopTurn ? false : !canSend}
+						onClick={canStopTurn ? onInterrupt : undefined}
+						aria-label={canStopTurn ? "Stop turn" : steering ? "Steer the running turn" : "Send message"}
 						className="size-8 rounded-lg border-logo-accent bg-logo-accent text-logo-accent-foreground hover:bg-logo-accent-bright focus-visible:ring-logo-accent/45"
 					>
-						{steerPending ? (
+						{canStopTurn ? (
+							<Square aria-hidden="true" className="size-3.5 fill-current" />
+						) : steerPending ? (
 							<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
 						) : steering ? (
 							<CornerDownRight aria-hidden="true" className="size-3.5" />

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -217,6 +217,42 @@ describe("ChatWorkspace timeline", () => {
 		expect(composer?.parentElement).toHaveClass("mx-auto", "w-full", "max-w-3xl");
 	});
 
+	it("shows live working state inline with the current turn while the composer owns the stop action", () => {
+		const snapshot = structuredClone(chatFixture);
+		snapshot.items = snapshot.items.filter(
+			(item) => !(item.kind === "activity" && item.activityKind === "approval" && item.status === "pending"),
+		);
+
+		render(<ChatWorkspace snapshot={snapshot} onInterrupt={vi.fn()} />);
+
+		expect(screen.getByText(/^Working for /)).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Stop turn" })).toBeInTheDocument();
+	});
+
+	it("shows blocked turn state inline with the current turn", () => {
+		const snapshot = structuredClone(chatFixture);
+		snapshot.items.push({
+			kind: "activity",
+			id: "approval-1",
+			sequence: 99,
+			revision: 1,
+			turnId: "turn-2",
+			activityKind: "approval",
+			status: "pending",
+			summary: "Run command",
+			requestId: "approval-1",
+			decisions: [{ id: "accept", label: "Approve" }],
+			detail: { command: "npm test" },
+			createdAt: "2026-08-08T00:00:00Z",
+		});
+
+		render(<ChatWorkspace snapshot={snapshot} onInterrupt={vi.fn()} />);
+
+		expect(screen.getByRole("alert")).toHaveTextContent("The agent is waiting for your decision.");
+		expect(screen.getByText("Waiting for your decision")).toBeInTheDocument();
+		expect(screen.queryByText(/^Working for /)).not.toBeInTheDocument();
+	});
+
 	it("lets readers select conversation text", () => {
 		render(<ChatWorkspace snapshot={chatFixture} />);
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -33,7 +33,6 @@ import {
 	GitBranch,
 	Loader2,
 	MessageSquare,
-	Square,
 	TriangleAlert,
 	Undo2,
 } from "lucide-react";
@@ -77,8 +76,6 @@ import {
 	can,
 	isCompaction,
 	isSteer,
-	pendingApproval,
-	pendingUserInput,
 	queuedTurnIds,
 	type ConversationPlan,
 	type ConversationSnapshot,
@@ -270,9 +267,6 @@ export function ChatWorkspace({
 	mcpReloadError,
 }: ChatWorkspaceProps) {
 	const turn = activeTurn(snapshot);
-	const approval = pendingApproval(snapshot);
-	const userInput = pendingUserInput(snapshot);
-	const queuedCount = queuedTurnIds(snapshot).size;
 	const queuedMessages = useMemo(() => {
 		const messagesByTurn = new Map(
 			snapshot.items
@@ -413,14 +407,6 @@ export function ChatWorkspace({
 							Conversation branched; worktree files were left unchanged.
 						</p>
 					) : null}
-					{turn ? (
-						<LiveTurnBar
-							startedAt={turn.startedAt ?? turn.requestedAt}
-							blocked={Boolean(approval || userInput)}
-							queuedCount={queuedCount}
-							onInterrupt={onInterrupt}
-						/>
-					) : null}
 					{turn?.state === "running" && queuedMessages.length > 0 ? (
 						<QueuedMessageDock
 							messages={queuedMessages}
@@ -430,6 +416,7 @@ export function ChatWorkspace({
 					<ChatComposer
 						attachedTop={turn?.state === "running" && queuedMessages.length > 0}
 						onSend={(text, attachments) => onSend?.(text, attachments)}
+						onInterrupt={turn ? onInterrupt : undefined}
 						commandError={commandError}
 						settings={
 							onChooseSettings || onChooseConfigOption ? (
@@ -1397,6 +1384,9 @@ const TurnGroup = memo(function TurnGroup({
 			{/* Above the outcome divider: the changed files are part of what the turn
 			    did, and belong inside it rather than after it closes. */}
 			{group.diff ? <TurnChangedFiles diff={group.diff} live={group.live} /> : null}
+			{group.live ? (
+				<TurnLiveStatus startedAt={group.liveStartedAt} blocked={group.blocked} />
+			) : null}
 			{group.outcome ? (
 				<TurnOutcome
 					state={group.outcome.state}
@@ -1408,6 +1398,48 @@ const TurnGroup = memo(function TurnGroup({
 		</div>
 	);
 });
+
+function TurnLiveStatus({ startedAt, blocked }: { startedAt?: string; blocked?: boolean }) {
+	const [elapsed, setElapsed] = useState(() => elapsedSince(startedAt));
+
+	useEffect(() => {
+		if (blocked) return;
+		const timer = setInterval(() => setElapsed(elapsedSince(startedAt)), 1000);
+		return () => clearInterval(timer);
+	}, [blocked, startedAt]);
+
+	if (blocked) {
+		return (
+			<div className="border-b border-border pb-2 pt-0.5">
+				<span role="alert" className="sr-only">
+					The agent is waiting for your decision.
+				</span>
+				<span className="text-sm font-normal leading-5 text-muted-foreground">
+					Waiting for your decision
+				</span>
+			</div>
+		);
+	}
+
+	return (
+		<div className="border-b border-border pb-2 pt-0.5">
+			<span role="status" aria-live="polite" className="text-sm font-normal leading-5 text-muted-foreground">
+				Working for {elapsed}
+			</span>
+		</div>
+	);
+}
+
+function elapsedSince(iso?: string): string {
+	if (!iso) return "0s";
+	const start = new Date(iso).getTime();
+	if (Number.isNaN(start)) return "0s";
+	const seconds = Math.max(0, Math.round((Date.now() - start) / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
 
 function TimelineItem({
 	item,
@@ -1594,6 +1626,8 @@ type TimelineGroup = {
 	plan?: ConversationPlan;
 	/** The turn is still running, so its diff and plan can still change. */
 	live?: boolean;
+	liveStartedAt?: string;
+	blocked?: boolean;
 	/** The provider accepted this turn, so there is history it can be asked to drop. */
 	rollbackable?: boolean;
 };
@@ -1703,6 +1737,13 @@ function groupByTurn(snapshot: ConversationSnapshot): TimelineGroup[] {
 		group.diff = turn.diff;
 		group.plan = turn.plan?.steps.length ? turn.plan : undefined;
 		group.live = turn.state === "running";
+		group.liveStartedAt = turn.startedAt ?? turn.requestedAt;
+		group.blocked = group.items.some(
+			(item) =>
+				item.kind === "activity" &&
+				(item.activityKind === "approval" || item.activityKind === "user_input") &&
+				item.status === "pending",
+		);
 		if (turn.state === "running" || turn.state === "queued") continue;
 		group.rollbackable = Boolean(turn.providerTurnId);
 		group.outcome = {
@@ -1807,76 +1848,4 @@ function QueuedMessageDock({
 			})}
 		</div>
 	);
-}
-
-/**
- * The in-flight turn. Elapsed time is shown because a long silence is otherwise
- * indistinguishable from a hang, and "waiting on you" is called out so a blocked
- * turn is not mistaken for a slow one.
- */
-function LiveTurnBar({
-	startedAt,
-	blocked,
-	queuedCount = 0,
-	onInterrupt,
-}: {
-	startedAt: string;
-	blocked?: boolean;
-	/** Messages typed during this turn, waiting to be sent after it. */
-	queuedCount?: number;
-	onInterrupt?: () => void;
-}) {
-	const [elapsed, setElapsed] = useState(() => since(startedAt));
-
-	useEffect(() => {
-		const timer = setInterval(() => setElapsed(since(startedAt)), 1000);
-		return () => clearInterval(timer);
-	}, [startedAt]);
-
-	return (
-		<div className="flex items-center gap-2.5 rounded-md border border-border bg-surface px-3 py-2">
-			{blocked ? (
-				<span role="alert" className="sr-only">
-					The agent is waiting for your decision.
-				</span>
-			) : null}
-			{blocked ? (
-				<TriangleAlert aria-hidden="true" className="size-3.5 shrink-0 text-warning" />
-			) : (
-				<Loader2
-					aria-hidden="true"
-					className="size-3.5 shrink-0 animate-spin text-status-working opacity-100"
-				/>
-			)}
-			<strong className={cn("text-xs font-medium", blocked ? "text-warning" : "text-foreground")}>
-				{blocked ? "Waiting for your decision" : "Working"}
-			</strong>
-			<span className="text-[11px] tabular-nums text-muted-foreground">{elapsed}</span>
-			{queuedCount > 0 ? (
-				<span className="text-[11px] text-muted-foreground">
-					{queuedCount} {queuedCount === 1 ? "message" : "messages"} queued
-				</span>
-			) : null}
-			<Button
-				type="button"
-				size="sm"
-				variant="ghost"
-				onClick={onInterrupt}
-				className="ml-auto gap-1.5"
-			>
-				<Square aria-hidden="true" className="size-3" />
-				{queuedCount > 0 ? "Stop and clear queue" : "Stop turn"}
-			</Button>
-		</div>
-	);
-}
-
-function since(iso: string): string {
-	const start = new Date(iso).getTime();
-	if (Number.isNaN(start)) return "";
-	const seconds = Math.max(0, Math.round((Date.now() - start) / 1000));
-	if (seconds < 60) return `${seconds}s`;
-	const minutes = Math.floor(seconds / 60);
-	if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
-	return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
 }


### PR DESCRIPTION
## Summary

- Clear Codex app-server active-turn state when the root turn completes, so finished work no longer leaves the chat stuck in a working state.
- Bind eager provider `turn/started` events to the AO turn row currently being dispatched, avoiding duplicate adopted turns when start arrives before `SendTurn` returns.
- Move the stop affordance into the composer primary action and remove the old boxed Working bar.
- Render a slim Codex-style inline live-turn status in the timeline (`Working for …` / `Waiting for your decision`) with chat-aligned typography, color, and spacing.

## Validation

Local:

- `GOCACHE=/private/tmp/go-build go test -count=1 ./internal/service/chat ./internal/storage/sqlite/store ./internal/adapters/chatdriver/codexappserver`
- `npm test -- ChatWorkspace.test.tsx`
- `npm test -- ChatComposer.test.tsx`
- `npm run typecheck`

CI on `c1069d2ad`:

- Go: `lint`, `api-drift`, `build-test` passed
- Frontend: `renderer-smoke`, `test` passed
- CLI E2E: `container`, `native (ubuntu-latest)`, `native (macos-latest)`, `native (windows-latest)` passed
- gitleaks: `scan` passed
