### PR TITLE
fix(frontend): pin session controls to the right edge

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -199,7 +199,6 @@ export function SessionInspector({
 				) : undefined
 			}
 			filesView={session ? <FilesView filesView={filesView} onOpenFiles={onOpenFiles} /> : undefined}
-			headerActions={<span aria-hidden="true" className="session-inspector-actions-spacer" />}
 			isVisible={isInspectorVisible}
 			loadingText={session ? undefined : t("inspector.loadingSession")}
 			onViewChange={setView}

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -199,6 +199,7 @@ export function SessionInspector({
 				) : undefined
 			}
 			filesView={session ? <FilesView filesView={filesView} onOpenFiles={onOpenFiles} /> : undefined}
+			headerActions={<span aria-hidden="true" className="session-inspector-actions-spacer" />}
 			isVisible={isInspectorVisible}
 			loadingText={session ? undefined : t("inspector.loadingSession")}
 			onViewChange={setView}

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -962,6 +962,7 @@ describe("SessionView", () => {
 	it("locks responsive inspector labels to the opening target throughout the transition", () => {
 		vi.useFakeTimers();
 		try {
+			window.localStorage.setItem("ao.inspector.widthPx", "500");
 			act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
 			render(<SessionView sessionId="sess-1" />);
 
@@ -1039,13 +1040,23 @@ describe("SessionView", () => {
 		expect(inspectorOpen("sess-1")).toBe(true);
 	});
 
-	it("keeps global topbar actions out of the inspector header", () => {
+	it("keeps the inspector toggle and trailing notification pinned while the panel changes state", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		render(<SessionView sessionId="sess-1" />);
+		const actions = screen.getByTestId("session-pinned-actions");
+		const toggle = within(actions).getByRole("button", { name: "Close inspector panel" });
+		const notification = within(actions).getByRole("button", { name: "Notifications" });
+		const buttons = within(actions).getAllByRole("button");
+		expect(buttons.indexOf(notification)).toBeGreaterThan(buttons.indexOf(toggle));
+		expect(toggle).toHaveAttribute("aria-pressed", "true");
 
-		expect(screen.queryByTestId("session-inspector-actions")).not.toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: "Notifications" })).not.toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: "Close inspector panel" })).not.toBeInTheDocument();
+		fireEvent.click(toggle);
+
+		expect(inspectorOpen("sess-1")).toBe(false);
+		expect(screen.getByTestId("session-pinned-actions")).toBe(actions);
+		expect(screen.getByRole("button", { name: "Notifications" })).toBe(notification);
+		expect(screen.getByRole("button", { name: "Open inspector panel" })).toBe(toggle);
+		expect(toggle).toHaveAttribute("aria-pressed", "false");
 	});
 
 	it("restores and clamps the persisted inspector width in pixels", () => {

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -959,10 +959,9 @@ describe("SessionView", () => {
 		}
 	});
 
-	it("locks responsive inspector labels to the opening target throughout the transition", () => {
+	it("keeps inspector labels expanded at the default width throughout the opening transition", () => {
 		vi.useFakeTimers();
 		try {
-			window.localStorage.setItem("ao.inspector.widthPx", "500");
 			act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
 			render(<SessionView sessionId="sess-1" />);
 
@@ -1063,7 +1062,7 @@ describe("SessionView", () => {
 		window.localStorage.setItem("ao.inspector.widthPx", "240");
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		render(<SessionView sessionId="sess-1" />);
-		expect(document.documentElement.style.getPropertyValue("--ao-inspector-w")).toBe("360px");
+		expect(document.documentElement.style.getPropertyValue("--ao-inspector-w")).toBe("280px");
 	});
 
 	it("mounts the inspector in sync when navigating from an orchestrator session", () => {

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -1039,21 +1039,13 @@ describe("SessionView", () => {
 		expect(inspectorOpen("sess-1")).toBe(true);
 	});
 
-	it("keeps one inspector action cluster mounted while the panel opens and closes", () => {
+	it("keeps global topbar actions out of the inspector header", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		render(<SessionView sessionId="sess-1" />);
-		const actions = screen.getByTestId("session-inspector-actions");
-		const notification = screen.getByRole("button", { name: "Notifications" });
-		const toggle = screen.getByRole("button", { name: "Close inspector panel" });
-		expect(toggle).toHaveAttribute("aria-pressed", "true");
 
-		fireEvent.click(toggle);
-
-		expect(inspectorOpen("sess-1")).toBe(false);
-		expect(screen.getByTestId("session-inspector-actions")).toBe(actions);
-		expect(screen.getByRole("button", { name: "Notifications" })).toBe(notification);
-		expect(screen.getByRole("button", { name: "Open inspector panel" })).toBe(toggle);
-		expect(toggle).toHaveAttribute("aria-pressed", "false");
+		expect(screen.queryByTestId("session-inspector-actions")).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Notifications" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Close inspector panel" })).not.toBeInTheDocument();
 	});
 
 	it("restores and clamps the persisted inspector width in pixels", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { PanelRight, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import {
 	useCallback,
@@ -19,7 +19,6 @@ import { defaultShortcutBindings, shortcutBindingLabel } from "../../shared/shor
 import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
 import { SessionChatSurface } from "./chat/SessionChatSurface";
-import { NotificationCenter } from "./NotificationCenter";
 import { ResizeHandle } from "./ResizeHandle";
 import { SessionFilesView } from "./SessionFilesView";
 import { SessionInspector } from "./SessionInspector";
@@ -886,25 +885,6 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					</SessionInspectorRail>
 				) : null}
 			</div>
-			{hasInspector ? (
-				<div
-					className="session-inspector-persistent-actions"
-					data-testid="session-inspector-actions"
-					style={noDragStyle}
-				>
-					<NotificationCenter style={noDragStyle} />
-					<TopbarButton
-						aria-label={isInspectorOpen ? t("shell.closeInspector") : t("shell.openInspector")}
-						aria-pressed={isInspectorOpen}
-						onClick={() => toggleInspector(sessionId)}
-						style={noDragStyle}
-						title={isInspectorOpen ? t("shell.closeInspectorTitle") : t("shell.openInspectorTitle")}
-						variant="icon"
-					>
-						<PanelRight className="size-icon-md" aria-hidden="true" />
-					</TopbarButton>
-				</div>
-			) : null}
 			<SessionInterfaceSwitchDialog
 				open={interfaceSwitchDialogOpen}
 				target={interfaceTarget}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -57,13 +57,13 @@ import { matchesRendererShortcut } from "../stores/keybindings-store";
 import { useResolvedTheme, useUiStore, type InspectorView } from "../stores/ui-store";
 
 const INSPECTOR_DEFAULT_PX = 360;
-const INSPECTOR_MIN_PX = 360;
+const INSPECTOR_MIN_PX = 280;
 const INSPECTOR_MAX_PERCENT = 50;
 const INSPECTOR_SEPARATOR_RESERVE_PX = 8;
-// The inspector tab labels respond to the tablist's remaining width, after the
-// 76px pinned-action reserve and 10px leading inset. Keep the animation lock on
-// the same side of that breakpoint so labels do not reflow as the rail settles.
-const INSPECTOR_COMPACT_MAX_PX = 445;
+// The inspector tab labels respond to the tablist's remaining width. The
+// 239px tablist breakpoint plus the 76px pinned-action reserve and 10px leading
+// inset gives a 325px inspector breakpoint for the animation lock.
+const INSPECTOR_COMPACT_MAX_PX = 325;
 const TOPBAR_SECONDARY_COMPACT_MAX_PX = 759;
 const inspectorWidthStorageKey = "ao.inspector.widthPx";
 const inspectorWidthVar = "--ao-inspector-w";
@@ -235,7 +235,7 @@ function SessionInspectorRail({
 // The inspector uses the same Motion spring as the left sidebar (gap width +
 // x-transform). Dragging is useResizable and clamps at the responsive minimum;
 // only the explicit controls (topbar button / ⌘⇧B) collapse it. The preferred
-// 360px floor is clamped to the 50% maximum on narrow session splits, where
+// 280px floor is clamped to the 50% maximum on narrow session splits, where
 // the inspector tabs compact to icons.
 export function SessionView({ sessionId }: SessionViewProps) {
 	const { t } = useTranslation();

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Plus } from "lucide-react";
+import { PanelRight, Plus } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import {
 	useCallback,
@@ -19,6 +19,7 @@ import { defaultShortcutBindings, shortcutBindingLabel } from "../../shared/shor
 import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
 import { SessionChatSurface } from "./chat/SessionChatSurface";
+import { NotificationCenter } from "./NotificationCenter";
 import { ResizeHandle } from "./ResizeHandle";
 import { SessionFilesView } from "./SessionFilesView";
 import { SessionInspector } from "./SessionInspector";
@@ -59,7 +60,10 @@ const INSPECTOR_DEFAULT_PX = 360;
 const INSPECTOR_MIN_PX = 360;
 const INSPECTOR_MAX_PERCENT = 50;
 const INSPECTOR_SEPARATOR_RESERVE_PX = 8;
-const INSPECTOR_COMPACT_MAX_PX = 359;
+// The inspector tab labels respond to the tablist's remaining width, after the
+// 76px pinned-action reserve and 10px leading inset. Keep the animation lock on
+// the same side of that breakpoint so labels do not reflow as the rail settles.
+const INSPECTOR_COMPACT_MAX_PX = 445;
 const TOPBAR_SECONDARY_COMPACT_MAX_PX = 759;
 const inspectorWidthStorageKey = "ao.inspector.widthPx";
 const inspectorWidthVar = "--ao-inspector-w";
@@ -885,6 +889,22 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					</SessionInspectorRail>
 				) : null}
 			</div>
+			{hasInspector ? (
+				<div className="session-pinned-actions" data-testid="session-pinned-actions" style={noDragStyle}>
+					<TopbarButton
+						aria-label={isInspectorOpen ? t("shell.closeInspector") : t("shell.openInspector")}
+						aria-pressed={isInspectorOpen}
+						onClick={() => toggleInspector(sessionId)}
+						style={noDragStyle}
+						title={isInspectorOpen ? t("shell.closeInspectorTitle") : t("shell.openInspectorTitle")}
+						variant="icon"
+					>
+						<PanelRight className="size-icon-md" aria-hidden="true" />
+					</TopbarButton>
+					{/* Keep the global notification action trailing at the window edge. */}
+					<NotificationCenter style={noDragStyle} />
+				</div>
+			) : null}
 			<SessionInterfaceSwitchDialog
 				open={interfaceSwitchDialogOpen}
 				target={interfaceTarget}

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -398,20 +398,15 @@ describe("ShellTopbar orchestrator actions", () => {
 });
 
 describe("ShellTopbar inspector state", () => {
-	it("keeps inspector controls in the center topbar with notifications trailing", () => {
+	it("keeps the expanded worker controls out of the center topbar", () => {
 		renderTopbarSessions([worker], "sess-1");
 
-		const actions = screen.getByTestId("workspace-topbar-actions");
-		const buttons = within(actions)
-			.getAllByRole("button")
-			.map((button) => button.getAttribute("aria-label"));
-		const inspectorIndex = buttons.indexOf("Close inspector panel");
-		const notificationsIndex = buttons.indexOf("Notifications");
-		expect(inspectorIndex).toBeGreaterThanOrEqual(0);
-		expect(notificationsIndex).toBeGreaterThan(inspectorIndex);
+		expect(screen.getByTestId("session-pinned-actions-reserve")).toHaveAttribute("data-state", "collapsed");
+		expect(screen.queryByRole("button", { name: "Close inspector panel" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Notifications" })).not.toBeInTheDocument();
 	});
 
-	it("routes aria-pressed to the current worker session", () => {
+	it("sizes the pinned-action reserve for the current worker inspector state", () => {
 		useUiStore.setState({
 			inspectorSessions: {
 				"sess-1": { isOpen: true, view: "summary" },
@@ -420,25 +415,25 @@ describe("ShellTopbar inspector state", () => {
 		});
 		const view = renderTopbarSessions([worker, secondWorker], "sess-1");
 
-		expect(screen.getByRole("button", { name: "Close inspector panel" })).toHaveAttribute("aria-pressed", "true");
+		expect(screen.getByTestId("session-pinned-actions-reserve")).toHaveAttribute("data-state", "collapsed");
 
 		paramsMock.sessionId = "sess-2";
 		view.rerenderTopbar();
 
-		expect(screen.getByRole("button", { name: "Open inspector panel" })).toHaveAttribute("aria-pressed", "false");
+		expect(screen.getByTestId("session-pinned-actions-reserve")).toHaveAttribute("data-state", "expanded");
 	});
 
-	it("keeps the controls mounted while the inspector changes state", async () => {
+	it("keeps one reserve mounted while the inspector changes state", () => {
 		useUiStore.setState({ inspectorSessions: { "sess-1": { isOpen: false, view: "summary" } } });
-		renderTopbarSessions([worker], "sess-1");
-		const toggle = screen.getByRole("button", { name: "Open inspector panel" });
-		const notification = screen.getByRole("button", { name: "Notifications" });
+		const view = renderTopbarSessions([worker], "sess-1");
+		const reserve = screen.getByTestId("session-pinned-actions-reserve");
 
-		await userEvent.click(toggle);
+		useUiStore.setState({ inspectorSessions: { "sess-1": { isOpen: true, view: "summary" } } });
+		view.rerenderTopbar();
 
-		expect(useUiStore.getState().inspectorSessions["sess-1"]?.isOpen).toBe(true);
-		expect(screen.getByRole("button", { name: "Close inspector panel" })).toBe(toggle);
-		expect(screen.getByRole("button", { name: "Notifications" })).toBe(notification);
+		expect(screen.getByTestId("session-pinned-actions-reserve")).toBe(reserve);
+		expect(reserve).toHaveAttribute("data-state", "collapsed");
+		expect(within(reserve).queryByRole("button")).not.toBeInTheDocument();
 	});
 });
 

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -398,15 +398,20 @@ describe("ShellTopbar orchestrator actions", () => {
 });
 
 describe("ShellTopbar inspector state", () => {
-	it("keeps the expanded worker inspector controls out of the center topbar", () => {
+	it("keeps inspector controls in the center topbar with notifications trailing", () => {
 		renderTopbarSessions([worker], "sess-1");
 
-		expect(screen.getByTestId("collapsed-inspector-actions")).toHaveAttribute("data-state", "collapsed");
-		expect(screen.queryByRole("button", { name: "Close inspector panel" })).not.toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: "Open inspector panel" })).not.toBeInTheDocument();
+		const actions = screen.getByTestId("workspace-topbar-actions");
+		const buttons = within(actions)
+			.getAllByRole("button")
+			.map((button) => button.getAttribute("aria-label"));
+		const inspectorIndex = buttons.indexOf("Close inspector panel");
+		const notificationsIndex = buttons.indexOf("Notifications");
+		expect(inspectorIndex).toBeGreaterThanOrEqual(0);
+		expect(notificationsIndex).toBeGreaterThan(inspectorIndex);
 	});
 
-	it("sizes the persistent action spacer for the current worker inspector state", () => {
+	it("routes aria-pressed to the current worker session", () => {
 		useUiStore.setState({
 			inspectorSessions: {
 				"sess-1": { isOpen: true, view: "summary" },
@@ -415,25 +420,25 @@ describe("ShellTopbar inspector state", () => {
 		});
 		const view = renderTopbarSessions([worker, secondWorker], "sess-1");
 
-		expect(screen.getByTestId("collapsed-inspector-actions")).toHaveAttribute("data-state", "collapsed");
+		expect(screen.getByRole("button", { name: "Close inspector panel" })).toHaveAttribute("aria-pressed", "true");
 
 		paramsMock.sessionId = "sess-2";
 		view.rerenderTopbar();
 
-		expect(screen.getByTestId("collapsed-inspector-actions")).toHaveAttribute("data-state", "expanded");
+		expect(screen.getByRole("button", { name: "Open inspector panel" })).toHaveAttribute("aria-pressed", "false");
 	});
 
-	it("keeps one spacer mounted while the inspector changes state", () => {
+	it("keeps the controls mounted while the inspector changes state", async () => {
 		useUiStore.setState({ inspectorSessions: { "sess-1": { isOpen: false, view: "summary" } } });
-		const view = renderTopbarSessions([worker], "sess-1");
-		const slot = screen.getByTestId("collapsed-inspector-actions");
+		renderTopbarSessions([worker], "sess-1");
+		const toggle = screen.getByRole("button", { name: "Open inspector panel" });
+		const notification = screen.getByRole("button", { name: "Notifications" });
 
-		useUiStore.setState({ inspectorSessions: { "sess-1": { isOpen: true, view: "summary" } } });
-		view.rerenderTopbar();
+		await userEvent.click(toggle);
 
-		expect(screen.getByTestId("collapsed-inspector-actions")).toBe(slot);
-		expect(slot).toHaveAttribute("data-state", "collapsed");
-		expect(within(slot).queryByRole("button")).not.toBeInTheDocument();
+		expect(useUiStore.getState().inspectorSessions["sess-1"]?.isOpen).toBe(true);
+		expect(screen.getByRole("button", { name: "Close inspector panel" })).toBe(toggle);
+		expect(screen.getByRole("button", { name: "Notifications" })).toBe(notification);
 	});
 });
 

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { Folder, LayoutDashboard, PanelRight, Plus, Trash2 } from "lucide-react";
+import { Folder, LayoutDashboard, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState, type ReactNode } from "react";
 import { animate, LayoutGroup, motion, useMotionValue, useReducedMotion } from "motion/react";
 import { NotificationCenter } from "./NotificationCenter";
@@ -76,7 +76,6 @@ export function ShellTopbar({
 	const isInspectorOpen = useUiStore((state) =>
 		currentSessionId ? (state.inspectorSessions[currentSessionId]?.isOpen ?? true) : false,
 	);
-	const toggleInspector = useUiStore((state) => state.toggleInspector);
 	const restartingProjectIds = useUiStore((state) => state.restartingProjectIds);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const isSidebarOpen = useUiStore((state) => state.isSidebarOpen);
@@ -369,20 +368,14 @@ export function ShellTopbar({
 					</>
 				) : null}
 				{isSessionRoute && !isOrchestrator ? (
-					<>
-						<TopbarButton
-							aria-label={isInspectorOpen ? t("shell.closeInspector") : t("shell.openInspector")}
-							aria-pressed={isInspectorOpen}
-							onClick={() => currentSessionId && toggleInspector(currentSessionId)}
-							style={noDragStyle}
-							title={isInspectorOpen ? t("shell.closeInspectorTitle") : t("shell.openInspectorTitle")}
-							variant="icon"
-						>
-							<PanelRight className="size-icon-md" aria-hidden="true" />
-						</TopbarButton>
-						{/* Notifications are global topbar chrome, not an inspector tab action. */}
-						<NotificationCenter style={noDragStyle} />
-					</>
+					/* The pinned controls are owned by SessionView so they stay at the
+					   window's right edge. Reserve their width only when the rail is closed. */
+					<div
+						className="session-pinned-actions-reserve"
+						data-state={isInspectorOpen ? "collapsed" : "expanded"}
+						data-testid="session-pinned-actions-reserve"
+						aria-hidden="true"
+					/>
 				) : (
 					<NotificationCenter style={noDragStyle} />
 				)}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { Folder, LayoutDashboard, Plus, Trash2 } from "lucide-react";
+import { Folder, LayoutDashboard, PanelRight, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState, type ReactNode } from "react";
 import { animate, LayoutGroup, motion, useMotionValue, useReducedMotion } from "motion/react";
 import { NotificationCenter } from "./NotificationCenter";
@@ -76,6 +76,7 @@ export function ShellTopbar({
 	const isInspectorOpen = useUiStore((state) =>
 		currentSessionId ? (state.inspectorSessions[currentSessionId]?.isOpen ?? true) : false,
 	);
+	const toggleInspector = useUiStore((state) => state.toggleInspector);
 	const restartingProjectIds = useUiStore((state) => state.restartingProjectIds);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const isSidebarOpen = useUiStore((state) => state.isSidebarOpen);
@@ -368,15 +369,20 @@ export function ShellTopbar({
 					</>
 				) : null}
 				{isSessionRoute && !isOrchestrator ? (
-					/* Controls stay in one persistent overlay owned by SessionView. This
-					   spacer alone follows the inspector motion so neighboring actions do
-					   not jump as the center pane gains or loses the available width. */
-					<div
-						className="session-collapsed-inspector-actions"
-						data-state={isInspectorOpen ? "collapsed" : "expanded"}
-						data-testid="collapsed-inspector-actions"
-						aria-hidden="true"
-					/>
+					<>
+						<TopbarButton
+							aria-label={isInspectorOpen ? t("shell.closeInspector") : t("shell.openInspector")}
+							aria-pressed={isInspectorOpen}
+							onClick={() => currentSessionId && toggleInspector(currentSessionId)}
+							style={noDragStyle}
+							title={isInspectorOpen ? t("shell.closeInspectorTitle") : t("shell.openInspectorTitle")}
+							variant="icon"
+						>
+							<PanelRight className="size-icon-md" aria-hidden="true" />
+						</TopbarButton>
+						{/* Notifications are global topbar chrome, not an inspector tab action. */}
+						<NotificationCenter style={noDragStyle} />
+					</>
 				) : (
 					<NotificationCenter style={noDragStyle} />
 				)}

--- a/frontend/src/renderer/components/chat/ChatCompaction.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatCompaction.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ChatWorkspace } from "./ChatWorkspace";
 import type {
@@ -115,51 +116,57 @@ describe("compaction in the timeline", () => {
 	});
 });
 
-describe("the compact control", () => {
-	it("is offered next to the context readout", () => {
+describe("the /compact command", () => {
+	it("runs from the composer without reserving a separate action row", async () => {
+		const user = userEvent.setup();
 		const onCompact = vi.fn();
 		render(<ChatWorkspace snapshot={snapshot([assistantSaid])} onCompact={onCompact} />);
 
-		const button = screen.getByRole("button", { name: "Compact conversation history" });
-		button.click();
+		expect(
+			screen.queryByRole("button", { name: "Compact conversation history" }),
+		).not.toBeInTheDocument();
+		const field = screen.getByLabelText("Message the agent");
+		await user.type(field, "/compact");
+		await user.keyboard("{Enter}");
+
 		expect(onCompact).toHaveBeenCalledOnce();
+		expect(field).toHaveValue("");
+	});
+
+	it("offers compact alongside provider skills in the slash menu", async () => {
+		const user = userEvent.setup();
+		render(<ChatWorkspace snapshot={snapshot([assistantSaid])} onCompact={vi.fn()} />);
+
+		await user.type(screen.getByLabelText("Message the agent"), "/");
+		expect(screen.getByRole("option", { name: /compact/i })).toBeInTheDocument();
 	});
 
 	// Measured against a live app-server: thread/compact/start mid-turn silently
-	// interrupts the running turn, then compacts. The daemon refuses it for that
-	// reason, and the control says so before it is pressed rather than letting the
-	// user discover the loss afterwards.
-	it("is disabled while a turn is in flight, and explains why", () => {
+	// interrupts the running turn, then compacts. The command refuses locally and
+	// preserves the draft rather than letting the user discover the loss afterwards.
+	it("refuses while a turn is in flight and keeps the command editable", async () => {
+		const user = userEvent.setup();
+		const onCompact = vi.fn();
 		render(
 			<ChatWorkspace
 				snapshot={snapshot([assistantSaid], [
 					{ id: "t1", state: "running", requestedAt: "2026-08-02T10:00:00Z" },
 				])}
-				onCompact={vi.fn()}
+				onCompact={onCompact}
 			/>,
 		);
 
-		const button = screen.getByRole("button", { name: "Compact conversation history" });
-		expect(button).toBeDisabled();
-		expect(button.title).toContain("stop the current turn");
+		const field = screen.getByLabelText("Message the agent");
+		await user.type(field, "/compact");
+		await user.keyboard("{Enter}");
+
+		expect(onCompact).not.toHaveBeenCalled();
+		expect(field).toHaveValue("/compact");
+		expect(screen.getByRole("alert")).toHaveTextContent("Stop the current turn");
 	});
 
-	it("says when the conversation was last compacted", () => {
-		render(
-			<ChatWorkspace
-				snapshot={snapshot([assistantSaid], [], { compactedAt: "2026-08-02T10:00:00Z" })}
-				onCompact={vi.fn()}
-			/>,
-		);
-
-		expect(
-			screen.getByRole("button", { name: "Compact conversation history" }).title,
-		).toContain("Last compacted");
-	});
-
-	// A control that fails is worse than no control: once the daemon says this agent
-	// cannot compact, the affordance goes away and the reason is stated.
-	it("disappears when the provider cannot compact", () => {
+	it("surfaces a provider refusal only when the command is invoked", async () => {
+		const user = userEvent.setup();
 		render(
 			<ChatWorkspace
 				snapshot={snapshot([assistantSaid])}
@@ -168,29 +175,22 @@ describe("the compact control", () => {
 			/>,
 		);
 
-		expect(
-			screen.queryByRole("button", { name: "Compact conversation history" }),
-		).not.toBeInTheDocument();
-		expect(screen.getByText("This agent cannot compact its history")).toBeInTheDocument();
+		expect(screen.queryByText("This agent cannot compact its history")).not.toBeInTheDocument();
+		await user.type(screen.getByLabelText("Message the agent"), "/compact");
+		await user.keyboard("{Enter}");
+		expect(screen.getByRole("alert")).toHaveTextContent("This agent cannot compact its history");
 	});
 
-	// The provider takes ten seconds or so. A control that looked idle the whole time
-	// would invite a second click, and a second compaction.
-	it("reports that a compaction is running", () => {
+	it("does not start a second compaction while one is running", async () => {
+		const user = userEvent.setup();
+		const onCompact = vi.fn();
 		render(
-			<ChatWorkspace snapshot={snapshot([assistantSaid])} onCompact={vi.fn()} compacting />,
+			<ChatWorkspace snapshot={snapshot([assistantSaid])} onCompact={onCompact} compacting />,
 		);
 
-		const button = screen.getByRole("button", { name: "Compact conversation history" });
-		expect(button).toBeDisabled();
-		expect(button.textContent).toContain("Compacting");
-	});
-
-	// Nothing to press in a surface with no command wiring, e.g. the fixture preview.
-	it("is absent when the surface has no compact handler", () => {
-		render(<ChatWorkspace snapshot={snapshot([assistantSaid])} />);
-		expect(
-			screen.queryByRole("button", { name: "Compact conversation history" }),
-		).not.toBeInTheDocument();
+		await user.type(screen.getByLabelText("Message the agent"), "/compact");
+		await user.keyboard("{Enter}");
+		expect(onCompact).not.toHaveBeenCalled();
+		expect(screen.getByRole("alert")).toHaveTextContent("already being compacted");
 	});
 });

--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -71,7 +71,14 @@ describe("send keys", () => {
 
 		const actions = screen.getByRole("group", { name: "Send message controls" });
 		expect(within(actions).getByRole("button", { name: "Send message" })).toBeInTheDocument();
-		expect(within(actions).getByText("Enter to send")).toBeInTheDocument();
+		expect(within(actions).queryByText(/Enter to/)).not.toBeInTheDocument();
+	});
+
+	it("starts as a single-line field and grows only when the draft needs it", () => {
+		const { field } = renderComposer();
+		expect(field).toHaveAttribute("rows", "1");
+		expect(field).toHaveClass("min-h-9");
+		expect(field).not.toHaveClass("min-h-[3.25rem]");
 	});
 
 	it("uses the AO logo palette for the send control", async () => {
@@ -82,6 +89,20 @@ describe("send keys", () => {
 		await userEvent.type(field, "hello");
 		expect(send).toBeEnabled();
 		expect(send).toHaveClass("hover:bg-logo-accent-bright", "focus-visible:ring-logo-accent/45");
+	});
+
+	it("turns the empty send action into Stop while the agent is working", async () => {
+		const onInterrupt = vi.fn();
+		const { field } = renderComposer({ willQueue: true, onInterrupt });
+
+		const stop = screen.getByRole("button", { name: "Stop turn" });
+		expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
+		await userEvent.click(stop);
+		expect(onInterrupt).toHaveBeenCalledOnce();
+
+		await userEvent.type(field, "queue this next");
+		expect(screen.queryByRole("button", { name: "Stop turn" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
 	});
 
 	it("sends on Enter", async () => {

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -13,8 +13,8 @@
  * settings because the provider takes all three per turn: choosing one changes the
  * next message and never restarts the agent.
  *
- * Three completions live on top of a plain textarea — `/` for the agent's own
- * skills, `@` for worktree files, and pasted or dropped files. It is a textarea and
+ * Three completions live on top of a plain textarea — `/` for AO commands and the
+ * agent's own skills, `@` for worktree files, and pasted or dropped files. It is a textarea and
  * not a rich editor; the reasoning is in composerSuggest.ts, where the logic that
  * would otherwise justify one lives. What matters here is that the original
  * keyboard contract survives: Enter sends, Shift+Enter makes a newline, and no
@@ -94,6 +94,10 @@ export function ChatComposer({
 	draftSeed,
 	commandError,
 	attachedTop = false,
+	onCompact,
+	compacting,
+	compactUnavailable,
+	compactBlocked,
 }: {
 	onSend: (text: string, attachments?: FileAttachmentPayload[]) => void | Promise<unknown>;
 	/** The next-turn controls, rendered inline. Omitted in the fixture preview. */
@@ -135,6 +139,14 @@ export function ChatComposer({
 	commandError?: string;
 	/** A queued-message dock owns the shared rounded top edge. */
 	attachedTop?: boolean;
+	/** Run AO's built-in `/compact` command instead of sending it to the agent. */
+	onCompact?: () => void | Promise<unknown>;
+	/** The provider is already compacting this conversation. */
+	compacting?: boolean;
+	/** A typed provider refusal from the last compaction attempt. */
+	compactUnavailable?: string;
+	/** A running turn must be stopped before its history can be compacted. */
+	compactBlocked?: boolean;
 }) {
 	const [text, setText] = useState("");
 	const [caret, setCaret] = useState(0);
@@ -152,7 +164,6 @@ export function ChatComposer({
 	 * Queueing is the safe default and matches `ao send`: the daemon records the
 	 * message durably and dispatches it when the current turn finishes. Steering is
 	 * timing-sensitive and changes the running turn, so it stays an explicit choice.
-	 * The send hint names whichever destination is armed.
 	 */
 	const [delivery, setDelivery] = useState<"steer" | "queue">("queue");
 
@@ -185,13 +196,26 @@ export function ChatComposer({
 
 	const trigger = useMemo(() => findActiveTrigger(text, caret), [text, caret]);
 
+	const slashCommands = useMemo<ChatSkill[]>(() => {
+		if (!onCompact || compactUnavailable === "This agent cannot compact its history") return skills;
+		return [
+			{
+				name: "compact",
+				displayName: "compact",
+				description: "Summarize earlier history to reclaim context",
+				source: "AO",
+			},
+			...skills.filter((skill) => skill.name !== "compact"),
+		];
+	}, [compactUnavailable, onCompact, skills]);
+
 	const suggestions: Suggestion[] = useMemo(() => {
 		if (!trigger || trigger.start === dismissedAt) return [];
 		// An empty candidate list is the whole reason the sigil stays ordinary: with
-		// no skills there is nothing to open, so `/` types a slash.
-		if (trigger.kind === "skill") return rankSkills(skills, trigger.query);
+		// no commands or skills there is nothing to open, so `/` types a slash.
+		if (trigger.kind === "skill") return rankSkills(slashCommands, trigger.query);
 		return rankFiles(filePaths, trigger.query);
-	}, [trigger, dismissedAt, skills, filePaths]);
+	}, [trigger, dismissedAt, slashCommands, filePaths]);
 
 	const menuOpen = suggestions.length > 0;
 	// Clamped rather than trusted: the list re-ranks on every keystroke, so the
@@ -199,12 +223,13 @@ export function ChatComposer({
 	const activeIndex = Math.min(highlighted, suggestions.length - 1);
 
 	const staged = fileAttachments.attachments.length > 0;
+	const hasDraft = text.trim().length > 0 || staged;
 	// The control disappears the moment the turn ends, and the armed mode degrades
 	// with it: a steer with nothing in flight is refused, so it must never be what
 	// Enter is still pointing at.
 	const steering = Boolean(canSteer && onSteer) && delivery === "steer";
-	const canSend = (text.trim().length > 0 || staged) && !busy && !disabled && !steerPending;
-	const canStopTurn = Boolean(willQueue && onInterrupt && !disabled && text.trim() === "" && !staged);
+	const canSend = hasDraft && !busy && !disabled && !steerPending;
+	const canStopTurn = Boolean(willQueue && onInterrupt && !disabled && !hasDraft);
 	const draftSeedId = draftSeed?.id;
 	const draftSeedText = draftSeed?.text;
 
@@ -282,6 +307,31 @@ export function ChatComposer({
 
 		const body = text.trim();
 
+		if (body === "/compact" && onCompact) {
+			if (compactBlocked) {
+				setSendError("Stop the current turn before compacting.");
+				return;
+			}
+			if (compacting) {
+				setSendError("Conversation history is already being compacted.");
+				return;
+			}
+			if (compactUnavailable) {
+				setSendError(compactUnavailable);
+				return;
+			}
+			try {
+				await onCompact();
+			} catch {
+				setSendError("Conversation history could not be compacted. Try again.");
+				return;
+			}
+			applyText("", 0);
+			setDismissedAt(null);
+			setHighlighted(0);
+			return;
+		}
+
 		// Steering keeps the text in the box until the provider has taken it. The turn
 		// is already running, so a refusal is a real possibility — and a refusal that
 		// had already cleared the composer would lose what the user typed.
@@ -347,6 +397,14 @@ export function ChatComposer({
 
 	function onKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
 		if (menuOpen) {
+			// `/compact` takes no arguments. Once its exact name is present, Enter
+			// executes it directly instead of merely accepting the highlighted row and
+			// requiring a second Enter on the inserted trailing space.
+			if (event.key === "Enter" && text.trim() === "/compact" && onCompact) {
+				event.preventDefault();
+				void submit();
+				return;
+			}
 			// Only these keys are taken while the menu is open. Everything else falls
 			// through to the textarea, which is what keeps typing from being swallowed.
 			if (event.key === "ArrowDown" || event.key === "ArrowUp") {
@@ -497,7 +555,7 @@ export function ChatComposer({
 				onSelect={onSelectionChange}
 				onClick={onSelectionChange}
 				onPaste={onPaste}
-				rows={2}
+				rows={1}
 				disabled={disabled}
 				aria-label="Message the agent"
 				role="combobox"
@@ -512,11 +570,9 @@ export function ChatComposer({
 							? "Agent is working — this goes into the turn it is running"
 							: willQueue
 								? "Agent is working — this sends when it finishes"
-								: skills.length > 0
-									? "Ask the agent…  /  for skills, @ for files"
-									: "Ask the agent…  @ for files"
+								: "Message the agent…"
 				}
-				className="chat-composer-scrollbar max-h-40 min-h-[3.25rem] w-full resize-none overflow-y-hidden overscroll-contain bg-transparent px-1.5 py-1.5 text-sm leading-relaxed text-foreground outline-none placeholder:text-passive disabled:opacity-50"
+				className="chat-composer-scrollbar max-h-40 min-h-9 w-full resize-none overflow-y-hidden overscroll-contain bg-transparent px-1.5 py-1.5 text-sm leading-relaxed text-foreground outline-none placeholder:text-passive disabled:opacity-50"
 			/>
 
 			{attachmentError ? (
@@ -580,27 +636,19 @@ export function ChatComposer({
 				<div
 					role="group"
 					aria-label="Send message controls"
-					className="flex shrink-0 items-center gap-2"
+					className="flex shrink-0 items-center"
 				>
-					<span className="hidden text-[11px] text-muted-foreground sm:inline">
-						{menuOpen
-							? "Enter to insert"
-							: steering
-								? "Enter to steer"
-								: willQueue
-									? "Enter to queue"
-									: "Enter to send"}
-					</span>
 					<Button
 						type={canStopTurn ? "button" : "submit"}
 						size="icon-sm"
 						disabled={canStopTurn ? false : !canSend}
 						onClick={canStopTurn ? onInterrupt : undefined}
 						aria-label={canStopTurn ? "Stop turn" : steering ? "Steer the running turn" : "Send message"}
+						title={canStopTurn ? "Stop turn" : undefined}
 						className="size-8 rounded-lg border-logo-accent bg-logo-accent text-logo-accent-foreground hover:bg-logo-accent-bright focus-visible:ring-logo-accent/45"
 					>
 						{canStopTurn ? (
-							<Square aria-hidden="true" className="size-3.5 fill-current" />
+							<Square aria-hidden="true" className="size-2.5 fill-current" />
 						) : steerPending ? (
 							<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
 						) : steering ? (
@@ -624,7 +672,7 @@ export function ChatComposer({
  * and decides for itself what to abandon. Queueing waits for the turn to end and
  * then starts a new one from a cold start. For someone who has just realized they
  * asked for the wrong thing, that is the whole difference, so both are named and the
- * hint below says which one Enter is armed with.
+ * active choice is exposed visually and through `aria-pressed`.
  */
 function DeliveryChoice({
 	value,

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -24,7 +24,11 @@ describe("ChatComposer steering", () => {
 
 	it("defaults Enter to the durable queue path used by ao send", () => {
 		composer();
-		expect(screen.getByText("Enter to queue")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Queue for next" })).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+		expect(screen.queryByText(/Enter to/)).not.toBeInTheDocument();
 	});
 
 	it("queues by default while a turn is running", async () => {
@@ -43,7 +47,12 @@ describe("ChatComposer steering", () => {
 		composer({ onSteer, onSend });
 
 		await userEvent.click(screen.getByRole("button", { name: "Steer this turn" }));
-		expect(screen.getByText("Enter to steer")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Steer this turn" })).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+		expect(screen.getByRole("button", { name: "Steer the running turn" })).toBeInTheDocument();
+		expect(screen.queryByText(/Enter to/)).not.toBeInTheDocument();
 
 		await userEvent.type(screen.getByRole("combobox"), "and then ship it{Enter}");
 		expect(onSteer).toHaveBeenCalledWith("and then ship it");
@@ -105,13 +114,15 @@ describe("ChatComposer steering", () => {
 	it("offers nothing when the harness cannot steer", () => {
 		composer({ onSteer: undefined, canSteer: false });
 		expect(screen.queryByRole("button", { name: "Steer this turn" })).not.toBeInTheDocument();
-		expect(screen.getByText("Enter to queue")).toBeInTheDocument();
+		expect(screen.queryByText(/Enter to/)).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Send message" })).toBeInTheDocument();
 	});
 
 	it("offers nothing when no turn is in flight to steer", () => {
 		composer({ canSteer: false, willQueue: false });
 		expect(screen.queryByRole("button", { name: "Steer this turn" })).not.toBeInTheDocument();
-		expect(screen.getByText("Enter to send")).toBeInTheDocument();
+		expect(screen.queryByText(/Enter to/)).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Send message" })).toBeInTheDocument();
 	});
 });
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatWorkspace } from "./ChatWorkspace";
@@ -217,16 +217,27 @@ describe("ChatWorkspace timeline", () => {
 		expect(composer?.parentElement).toHaveClass("mx-auto", "w-full", "max-w-3xl");
 	});
 
-	it("shows live working state inline with the current turn while the composer owns the stop action", () => {
+	it("shows live working state inline with the current turn while the composer owns the stop action", async () => {
+		const user = userEvent.setup();
+		const onInterrupt = vi.fn();
 		const snapshot = structuredClone(chatFixture);
 		snapshot.items = snapshot.items.filter(
 			(item) => !(item.kind === "activity" && item.activityKind === "approval" && item.status === "pending"),
 		);
 
-		render(<ChatWorkspace snapshot={snapshot} onInterrupt={vi.fn()} />);
+		render(<ChatWorkspace snapshot={snapshot} onInterrupt={onInterrupt} />);
 
-		expect(screen.getByText(/^Working for /)).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Stop turn" })).toBeInTheDocument();
+		const status = screen.getByTestId("live-turn-status");
+		expect(screen.getByRole("log", { name: "Conversation" })).toContainElement(status);
+		expect(status).toHaveClass("min-h-6", "px-1");
+		expect(status).not.toHaveClass("border", "bg-surface", "rounded-md");
+		expect(status).toHaveTextContent(/^Working for /);
+		expect(within(status).queryByRole("button")).not.toBeInTheDocument();
+
+		const stop = screen.getByRole("button", { name: "Stop turn" });
+		expect(screen.getByLabelText("Message the agent").closest("form")).toContainElement(stop);
+		await user.click(stop);
+		expect(onInterrupt).toHaveBeenCalledOnce();
 	});
 
 	it("shows blocked turn state inline with the current turn", () => {
@@ -433,6 +444,8 @@ describe("ChatWorkspace timeline", () => {
 		stubGeometry(log, { scrollHeight: 4000, clientHeight: 800, scrollTop: 100 });
 		log.dispatchEvent(new Event("scroll"));
 		const jump = await screen.findByRole("button", { name: /jump to latest/i });
+		expect(jump).toHaveAttribute("title", "Jump to latest");
+		expect(jump).not.toHaveTextContent("Jump to latest");
 		expect(jump).toHaveClass(
 			"bg-raised",
 			"dark:bg-raised",

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -27,7 +27,6 @@ import {
 	type WheelEvent as ReactWheelEvent,
 } from "react";
 import {
-	Archive,
 	ArrowDown,
 	CornerDownRight,
 	GitBranch,
@@ -391,15 +390,6 @@ export function ChatWorkspace({
 
 			<div className="cursor-chat-composer-dock shrink-0 px-4 pb-3 pt-2">
 				<div className="mx-auto flex w-full max-w-3xl flex-col gap-2">
-					<div className="flex items-center justify-end">
-						<CompactButton
-							onCompact={onCompact}
-							compacting={compacting}
-							unavailable={compactUnavailable}
-							turnInFlight={Boolean(turn)}
-							compactedAt={snapshot.compactedAt}
-						/>
-					</div>
 					{discarded > 0 ? <RolledBackNotice count={discarded} /> : null}
 					{snapshot.branchedFromEarlierMessage ? (
 						<p className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
@@ -449,6 +439,10 @@ export function ChatWorkspace({
 						canSteer={Boolean(onSteer) && turn?.state === "running"}
 						steerPending={steerPending}
 						steerRefusal={steerRefusal}
+						onCompact={onCompact}
+						compacting={compacting}
+						compactUnavailable={compactUnavailable}
+						compactBlocked={Boolean(turn)}
 					/>
 				</div>
 			</div>
@@ -677,51 +671,6 @@ function ChatHeader({
 	);
 }
 
-function CompactButton({
-	onCompact,
-	compacting,
-	unavailable,
-	turnInFlight,
-	compactedAt,
-}: {
-	onCompact?: () => void;
-	compacting?: boolean;
-	unavailable?: string;
-	turnInFlight?: boolean;
-	compactedAt?: string;
-}) {
-	if (!onCompact) return null;
-	if (unavailable === "This agent cannot compact its history") {
-		return <span className="text-[11px] text-muted-foreground">{unavailable}</span>;
-	}
-
-	const title = turnInFlight
-		? "Finish or stop the current turn before compacting"
-		: compactedAt
-			? `Summarize earlier history to reclaim context. Last compacted ${new Date(compactedAt).toLocaleString()}.`
-			: "Summarize earlier history to reclaim context";
-
-	return (
-		<Button
-			type="button"
-			size="sm"
-			variant="ghost"
-			onClick={onCompact}
-			disabled={compacting || turnInFlight}
-			title={title}
-			aria-label="Compact conversation history"
-			className="h-5 gap-1 px-1.5 text-[11px]"
-		>
-			{compacting ? (
-				<Loader2 aria-hidden="true" className="size-3 animate-spin" />
-			) : (
-				<Archive aria-hidden="true" className="size-3" />
-			)}
-			{compacting ? "Compacting…" : "Compact"}
-		</Button>
-	);
-}
-
 /**
  * Controller health. A stopped or recovering controller is announced, because a
  * silent surface is indistinguishable from an agent that is simply thinking.
@@ -863,6 +812,7 @@ function Timeline({
 	const [pinned, setPinned] = useState(true);
 	const [hoveredMarker, setHoveredMarker] = useState<number | null>(null);
 	const [messageEdit, setMessageEdit] = useState<MessageEditDraft>();
+	const turn = activeTurn(snapshot);
 	const [scrollbar, setScrollbar] = useState({
 		visible: false,
 		top: 0,
@@ -1098,7 +1048,7 @@ function Timeline({
 		updateScrollbar();
 	}
 
-	if (items.length === 0 && !messageEdit) {
+	if (items.length === 0 && !messageEdit && !turn) {
 		return <EmptyState harness={snapshot.harness} />;
 	}
 
@@ -1163,6 +1113,9 @@ function Timeline({
 							/>
 						</div>
 					))}
+					{turn && !groups.some((group) => group.turnId === turn.id) ? (
+						<TurnLiveStatus startedAt={turn.startedAt ?? turn.requestedAt} />
+					) : null}
 					{messageEdit && !editedMessageVisible ? (
 						<div className="flex justify-end" data-chat-scroll-anchor="">
 							<HumanMessageEditor
@@ -1261,13 +1214,14 @@ function Timeline({
 			{!pinned ? (
 				<Button
 					type="button"
-					size="sm"
+					size="icon-sm"
 					variant="outline"
+					aria-label="Jump to latest"
+					title="Jump to latest"
 					onClick={() => setPinned(true)}
-					className="absolute bottom-3 left-1/2 -translate-x-1/2 gap-1.5 bg-raised shadow-sm hover:bg-surface dark:bg-raised dark:hover:bg-surface"
+					className="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-full bg-raised shadow-sm hover:bg-surface dark:bg-raised dark:hover:bg-surface"
 				>
-					<ArrowDown aria-hidden="true" className="size-3.5" />
-					Jump to latest
+					<ArrowDown aria-hidden="true" className="size-4" />
 				</Button>
 			) : null}
 		</div>
@@ -1408,23 +1362,27 @@ function TurnLiveStatus({ startedAt, blocked }: { startedAt?: string; blocked?: 
 		return () => clearInterval(timer);
 	}, [blocked, startedAt]);
 
-	if (blocked) {
-		return (
-			<div className="border-b border-border pb-2 pt-0.5">
+	return (
+		<div className="flex min-h-6 items-center gap-2 px-1 py-0.5" data-testid="live-turn-status">
+			{blocked ? (
 				<span role="alert" className="sr-only">
 					The agent is waiting for your decision.
 				</span>
-				<span className="text-sm font-normal leading-5 text-muted-foreground">
-					Waiting for your decision
-				</span>
-			</div>
-		);
-	}
-
-	return (
-		<div className="border-b border-border pb-2 pt-0.5">
-			<span role="status" aria-live="polite" className="text-sm font-normal leading-5 text-muted-foreground">
-				Working for {elapsed}
+			) : null}
+			{blocked ? (
+				<TriangleAlert aria-hidden="true" className="size-3.5 shrink-0 text-warning" />
+			) : (
+				<Loader2
+					aria-hidden="true"
+					className="size-3 shrink-0 animate-spin text-status-working opacity-100"
+				/>
+			)}
+			<span
+				role={blocked ? undefined : "status"}
+				aria-live={blocked ? undefined : "polite"}
+				className={cn("text-xs font-medium", blocked ? "text-warning" : "text-muted-foreground")}
+			>
+				{blocked ? "Waiting for your decision" : `Working for ${elapsed}`}
 			</span>
 		</div>
 	);

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -395,7 +395,7 @@ export function useConversationCommands(sessionId: string | undefined) {
 		resumeAgent: () => resume.mutateAsync(),
 		resumingAgent: resume.isPending,
 		resumeError: resume.error ? apiErrorMessage(resume.error) : undefined,
-		compact: () => compact.mutate(),
+		compact: () => compact.mutateAsync(),
 		chooseSettings: (settings: TurnSettings) => chooseSettings.mutate(settings),
 		/** A compaction is in flight provider-side and takes seconds, so it reads as
 		 *  its own state rather than folding into the generic busy flag, which also

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2095,6 +2095,45 @@ body.is-resizing-x [data-slot="inspector-container"] {
 	color: var(--color-text-topbar);
 }
 
+.session-pinned-actions-reserve {
+	display: flex;
+	width: 0;
+	min-width: 0;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: flex-end;
+	margin-left: calc(-1 * var(--space-2));
+	transition:
+		width var(--session-inspector-motion-duration, 400ms)
+			var(--session-inspector-motion-easing, linear(0, 0.333 12.5%, 0.642 25%, 0.813 37.5%, 0.902 50%, 0.949 62.5%, 0.974 75%, 0.986 87.5%, 1)),
+		margin-left var(--session-inspector-motion-duration, 400ms)
+			var(--session-inspector-motion-easing, linear(0, 0.333 12.5%, 0.642 25%, 0.813 37.5%, 0.902 50%, 0.949 62.5%, 0.974 75%, 0.986 87.5%, 1));
+}
+
+.session-pinned-actions-reserve[data-state="expanded"] {
+	width: calc(var(--size-topbar-control) + var(--size-topbar-control) + var(--space-2));
+	margin-left: 0;
+}
+
+.session-pinned-actions {
+	-webkit-app-region: no-drag;
+	position: absolute;
+	top: 0;
+	right: var(--space-3);
+	z-index: var(--z-index-chrome);
+	display: flex;
+	height: var(--size-inspector-tabs);
+	align-items: center;
+	gap: var(--space-2);
+}
+
+.session-inspector-actions-spacer {
+	width: calc(
+		var(--size-topbar-control) + var(--size-topbar-control) + var(--space-2) + var(--space-3)
+	);
+	flex: 0 0 auto;
+}
+
 @container workspace-topbar (max-width: 759px) {
 	.workspace-topbar-actions [data-priority="secondary"] [data-compact-label] {
 		inline-size: 0;
@@ -2173,6 +2212,7 @@ body.is-resizing-x [data-slot="inspector-container"] {
 @media (prefers-reduced-motion: reduce) {
 	.workspace-topbar-actions .topbar-control,
 	.workspace-topbar-actions [data-compact-label],
+	.session-pinned-actions-reserve,
 	.session-split[data-terminal-live-resize="true"]
 		.workspace-topbar-actions
 		[data-priority="secondary"].topbar-control,
@@ -2732,7 +2772,11 @@ body.is-resizing-x [data-slot="inspector-container"] {
 		transform 170ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-@container inspector (max-width: 359px) {
+.session-inspector__tablist {
+	container: inspector-tabs / inline-size;
+}
+
+@container inspector-tabs (max-width: 359px) {
 	.session-inspector__responsive-label {
 		max-width: 0;
 		margin-left: 0;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2095,45 +2095,6 @@ body.is-resizing-x [data-slot="inspector-container"] {
 	color: var(--color-text-topbar);
 }
 
-.session-collapsed-inspector-actions {
-	display: flex;
-	width: 0;
-	min-width: 0;
-	flex: 0 0 auto;
-	align-items: center;
-	justify-content: flex-end;
-	margin-left: calc(-1 * var(--space-2));
-	transition:
-		width var(--session-inspector-motion-duration, 400ms)
-			var(--session-inspector-motion-easing, linear(0, 0.333 12.5%, 0.642 25%, 0.813 37.5%, 0.902 50%, 0.949 62.5%, 0.974 75%, 0.986 87.5%, 1)),
-		margin-left var(--session-inspector-motion-duration, 400ms)
-			var(--session-inspector-motion-easing, linear(0, 0.333 12.5%, 0.642 25%, 0.813 37.5%, 0.902 50%, 0.949 62.5%, 0.974 75%, 0.986 87.5%, 1));
-}
-
-.session-collapsed-inspector-actions[data-state="expanded"] {
-	width: calc(var(--size-topbar-control) + var(--size-topbar-control) + var(--space-2));
-	margin-left: 0;
-}
-
-.session-inspector-persistent-actions {
-	-webkit-app-region: no-drag;
-	position: absolute;
-	top: 0;
-	right: var(--space-3);
-	z-index: var(--z-index-chrome);
-	display: flex;
-	height: var(--size-inspector-tabs);
-	align-items: center;
-	gap: var(--space-2);
-}
-
-.session-inspector-actions-spacer {
-	width: calc(
-		var(--size-topbar-control) + var(--size-topbar-control) + var(--space-2) + var(--space-3)
-	);
-	flex: 0 0 auto;
-}
-
 @container workspace-topbar (max-width: 759px) {
 	.workspace-topbar-actions [data-priority="secondary"] [data-compact-label] {
 		inline-size: 0;
@@ -2212,7 +2173,6 @@ body.is-resizing-x [data-slot="inspector-container"] {
 @media (prefers-reduced-motion: reduce) {
 	.workspace-topbar-actions .topbar-control,
 	.workspace-topbar-actions [data-compact-label],
-	.session-collapsed-inspector-actions,
 	.session-split[data-terminal-live-resize="true"]
 		.workspace-topbar-actions
 		[data-priority="secondary"].topbar-control,

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2776,7 +2776,7 @@ body.is-resizing-x [data-slot="inspector-container"] {
 	container: inspector-tabs / inline-size;
 }
 
-@container inspector-tabs (max-width: 359px) {
+@container inspector-tabs (max-width: 239px) {
 	.session-inspector__responsive-label {
 		max-width: 0;
 		margin-left: 0;

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -46,6 +46,7 @@ describe("SessionInspectorShellView", () => {
 		);
 
 		expect(screen.getByRole("complementary", { name: "Session inspector" })).toBeInTheDocument();
+		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("aria-selected", "true");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("tabindex", "0");
 		expect(screen.getByRole("tab", { name: "Browser" })).toHaveAttribute("tabindex", "-1");

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -48,7 +48,8 @@ describe("SessionInspectorShellView", () => {
 		expect(screen.getByRole("complementary", { name: "Session inspector" })).toBeInTheDocument();
 		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("aria-selected", "true");
-		expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass("min-w-0", "flex-1");
+		expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass("min-w-0");
+		expect(screen.getByRole("tab", { name: "Summary" })).not.toHaveClass("flex-1");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("tabindex", "0");
 		expect(screen.getByRole("tab", { name: "Browser" })).toHaveAttribute("tabindex", "-1");
 		const filesLabel = within(screen.getByRole("tab", { name: "Files" })).getByText("2 Files");

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -48,10 +48,11 @@ describe("SessionInspectorShellView", () => {
 		expect(screen.getByRole("complementary", { name: "Session inspector" })).toBeInTheDocument();
 		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("aria-selected", "true");
+		expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass("min-w-0", "flex-1");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("tabindex", "0");
 		expect(screen.getByRole("tab", { name: "Browser" })).toHaveAttribute("tabindex", "-1");
 		const filesLabel = within(screen.getByRole("tab", { name: "Files" })).getByText("2 Files");
-		expect(filesLabel).toHaveClass("session-inspector__responsive-label");
+		expect(filesLabel).toHaveClass("session-inspector__responsive-label", "min-w-0");
 		expect(filesLabel).not.toHaveClass("@max-[350px]/inspector:hidden");
 		expect(screen.getByTestId("browser-unseen-indicator")).toBeInTheDocument();
 		fireEvent.click(screen.getByRole("tab", { name: "Browser" }));

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -101,7 +101,7 @@ export function SessionInspectorShellView({
 		<aside className={inspectorShellClass} aria-label={ariaLabel}>
 			<div className="session-inspector__topbar flex h-inspector-tabs shrink-0 items-center border-b border-border pl-2.5">
 				{isVisible ? (
-					<div className="flex min-w-0 flex-1 items-center gap-0.5" role="tablist">
+					<div className="session-inspector__tablist flex min-w-0 flex-1 items-center gap-0.5" role="tablist">
 						{tabs.map((tab, index) => (
 							<button
 								aria-label={tab.label}

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -111,7 +111,7 @@ export function SessionInspectorShellView({
 								aria-selected={activeView === tab.id}
 								tabIndex={activeView === tab.id ? 0 : -1}
 								className={cn(
-									"session-inspector__tab-button inline-flex h-control-md shrink-0 items-center justify-center rounded-md px-1.5 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
+									"session-inspector__tab-button inline-flex h-control-md min-w-0 flex-1 items-center justify-center rounded-md px-1.5 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
 									activeView === tab.id && "bg-interactive-active text-foreground",
 								)}
 								onClick={() => onViewChange(tab.id)}
@@ -131,7 +131,7 @@ export function SessionInspectorShellView({
 										</span>
 									) : null}
 								</span>
-								<span className="session-inspector__responsive-label truncate whitespace-nowrap text-2xs">
+								<span className="session-inspector__responsive-label min-w-0 truncate whitespace-nowrap text-2xs">
 									{tab.displayLabel ?? tab.label}
 								</span>
 							</button>

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -111,7 +111,7 @@ export function SessionInspectorShellView({
 								aria-selected={activeView === tab.id}
 								tabIndex={activeView === tab.id ? 0 : -1}
 								className={cn(
-									"session-inspector__tab-button inline-flex h-control-md min-w-0 flex-1 items-center justify-center rounded-md px-1.5 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
+									"session-inspector__tab-button inline-flex h-control-md min-w-0 items-center justify-center rounded-md px-1.5 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
 									activeView === tab.id && "bg-interactive-active text-foreground",
 								)}
 								onClick={() => onViewChange(tab.id)}


### PR DESCRIPTION
## Summary

- keep the worker-session inspector toggle and notification bell pinned to the window’s far-right edge whether the inspector is open or closed
- order the controls as inspector toggle → notification bell so the bell remains the trailing/rightmost global action
- make the inspector tablist its own responsive container so Summary, Reviews, Browser, and Files labels compact based on the space actually left after the pinned controls
- align the inspector open/close label-mode lock with the tablist’s effective breakpoint to avoid late reflow during the spring transition

This corrects the combined layout regression from #3974 and #3864 while retaining the inspector sizing, navigation, persistent controls, and spring motion.

## Tests

- `cd frontend && npx vitest run --config vite.renderer.config.ts src/renderer/components/ShellTopbar.test.tsx src/renderer/components/SessionView.test.tsx src/renderer/components/SessionInspector.test.tsx` (178 passed)
- `cd packages/product-ui && npx vitest run src/SessionInspectorView.test.tsx` (7 passed)
- `cd frontend && npm run typecheck`
- `cd packages/product-ui && npm run typecheck`

## Risk

- Low and frontend-only. Notification behavior and inspector state are unchanged; the patch adjusts action ordering/placement and the tab-label responsive boundary.