### PR TITLE
fix(frontend): streamline chat composer

### DIFF
--- a/frontend/src/renderer/components/chat/ChatCompaction.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatCompaction.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ChatWorkspace } from "./ChatWorkspace";
 import type {
@@ -115,51 +116,57 @@ describe("compaction in the timeline", () => {
 	});
 });
 
-describe("the compact control", () => {
-	it("is offered next to the context readout", () => {
+describe("the /compact command", () => {
+	it("runs from the composer without reserving a separate action row", async () => {
+		const user = userEvent.setup();
 		const onCompact = vi.fn();
 		render(<ChatWorkspace snapshot={snapshot([assistantSaid])} onCompact={onCompact} />);
 
-		const button = screen.getByRole("button", { name: "Compact conversation history" });
-		button.click();
+		expect(
+			screen.queryByRole("button", { name: "Compact conversation history" }),
+		).not.toBeInTheDocument();
+		const field = screen.getByLabelText("Message the agent");
+		await user.type(field, "/compact");
+		await user.keyboard("{Enter}");
+
 		expect(onCompact).toHaveBeenCalledOnce();
+		expect(field).toHaveValue("");
+	});
+
+	it("offers compact alongside provider skills in the slash menu", async () => {
+		const user = userEvent.setup();
+		render(<ChatWorkspace snapshot={snapshot([assistantSaid])} onCompact={vi.fn()} />);
+
+		await user.type(screen.getByLabelText("Message the agent"), "/");
+		expect(screen.getByRole("option", { name: /compact/i })).toBeInTheDocument();
 	});
 
 	// Measured against a live app-server: thread/compact/start mid-turn silently
-	// interrupts the running turn, then compacts. The daemon refuses it for that
-	// reason, and the control says so before it is pressed rather than letting the
-	// user discover the loss afterwards.
-	it("is disabled while a turn is in flight, and explains why", () => {
+	// interrupts the running turn, then compacts. The command refuses locally and
+	// preserves the draft rather than letting the user discover the loss afterwards.
+	it("refuses while a turn is in flight and keeps the command editable", async () => {
+		const user = userEvent.setup();
+		const onCompact = vi.fn();
 		render(
 			<ChatWorkspace
 				snapshot={snapshot([assistantSaid], [
 					{ id: "t1", state: "running", requestedAt: "2026-08-02T10:00:00Z" },
 				])}
-				onCompact={vi.fn()}
+				onCompact={onCompact}
 			/>,
 		);
 
-		const button = screen.getByRole("button", { name: "Compact conversation history" });
-		expect(button).toBeDisabled();
-		expect(button.title).toContain("stop the current turn");
+		const field = screen.getByLabelText("Message the agent");
+		await user.type(field, "/compact");
+		await user.keyboard("{Enter}");
+
+		expect(onCompact).not.toHaveBeenCalled();
+		expect(field).toHaveValue("/compact");
+		expect(screen.getByRole("alert")).toHaveTextContent("Stop the current turn");
 	});
 
-	it("says when the conversation was last compacted", () => {
-		render(
-			<ChatWorkspace
-				snapshot={snapshot([assistantSaid], [], { compactedAt: "2026-08-02T10:00:00Z" })}
-				onCompact={vi.fn()}
-			/>,
-		);
-
-		expect(
-			screen.getByRole("button", { name: "Compact conversation history" }).title,
-		).toContain("Last compacted");
-	});
-
-	// A control that fails is worse than no control: once the daemon says this agent
-	// cannot compact, the affordance goes away and the reason is stated.
-	it("disappears when the provider cannot compact", () => {
+	it("surfaces a provider refusal only when the command is invoked", async () => {
+		const user = userEvent.setup();
 		render(
 			<ChatWorkspace
 				snapshot={snapshot([assistantSaid])}
@@ -168,29 +175,22 @@ describe("the compact control", () => {
 			/>,
 		);
 
-		expect(
-			screen.queryByRole("button", { name: "Compact conversation history" }),
-		).not.toBeInTheDocument();
-		expect(screen.getByText("This agent cannot compact its history")).toBeInTheDocument();
+		expect(screen.queryByText("This agent cannot compact its history")).not.toBeInTheDocument();
+		await user.type(screen.getByLabelText("Message the agent"), "/compact");
+		await user.keyboard("{Enter}");
+		expect(screen.getByRole("alert")).toHaveTextContent("This agent cannot compact its history");
 	});
 
-	// The provider takes ten seconds or so. A control that looked idle the whole time
-	// would invite a second click, and a second compaction.
-	it("reports that a compaction is running", () => {
+	it("does not start a second compaction while one is running", async () => {
+		const user = userEvent.setup();
+		const onCompact = vi.fn();
 		render(
-			<ChatWorkspace snapshot={snapshot([assistantSaid])} onCompact={vi.fn()} compacting />,
+			<ChatWorkspace snapshot={snapshot([assistantSaid])} onCompact={onCompact} compacting />,
 		);
 
-		const button = screen.getByRole("button", { name: "Compact conversation history" });
-		expect(button).toBeDisabled();
-		expect(button.textContent).toContain("Compacting");
-	});
-
-	// Nothing to press in a surface with no command wiring, e.g. the fixture preview.
-	it("is absent when the surface has no compact handler", () => {
-		render(<ChatWorkspace snapshot={snapshot([assistantSaid])} />);
-		expect(
-			screen.queryByRole("button", { name: "Compact conversation history" }),
-		).not.toBeInTheDocument();
+		await user.type(screen.getByLabelText("Message the agent"), "/compact");
+		await user.keyboard("{Enter}");
+		expect(onCompact).not.toHaveBeenCalled();
+		expect(screen.getByRole("alert")).toHaveTextContent("already being compacted");
 	});
 });

--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -71,7 +71,14 @@ describe("send keys", () => {
 
 		const actions = screen.getByRole("group", { name: "Send message controls" });
 		expect(within(actions).getByRole("button", { name: "Send message" })).toBeInTheDocument();
-		expect(within(actions).getByText("Enter to send")).toBeInTheDocument();
+		expect(within(actions).queryByText(/Enter to/)).not.toBeInTheDocument();
+	});
+
+	it("starts as a single-line field and grows only when the draft needs it", () => {
+		const { field } = renderComposer();
+		expect(field).toHaveAttribute("rows", "1");
+		expect(field).toHaveClass("min-h-9");
+		expect(field).not.toHaveClass("min-h-[3.25rem]");
 	});
 
 	it("uses the AO logo palette for the send control", async () => {

--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -91,6 +91,20 @@ describe("send keys", () => {
 		expect(send).toHaveClass("hover:bg-logo-accent-bright", "focus-visible:ring-logo-accent/45");
 	});
 
+	it("turns the empty send action into Stop while the agent is working", async () => {
+		const onInterrupt = vi.fn();
+		const { field } = renderComposer({ turnActive: true, onInterrupt });
+
+		const stop = screen.getByRole("button", { name: "Stop turn" });
+		expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
+		await userEvent.click(stop);
+		expect(onInterrupt).toHaveBeenCalledOnce();
+
+		await userEvent.type(field, "queue this next");
+		expect(screen.queryByRole("button", { name: "Stop turn" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+	});
+
 	it("sends on Enter", async () => {
 		const { onSend, field } = renderComposer();
 		await userEvent.type(field, "hello");

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -42,7 +42,7 @@ import {
 	type KeyboardEvent,
 	type ReactNode,
 } from "react";
-import { ArrowUp, CornerDownRight, Loader2, Paperclip, X } from "lucide-react";
+import { ArrowUp, CornerDownRight, Loader2, Paperclip, Square, X } from "lucide-react";
 import { Button } from "../ui/button";
 import { cn } from "../../lib/utils";
 import { ComposerSuggestMenu } from "./ComposerSuggestMenu";
@@ -79,6 +79,9 @@ export function ChatComposer({
 	onSend,
 	busy,
 	willQueue,
+	turnActive,
+	onInterrupt,
+	queuedCount = 0,
 	disabled,
 	settings,
 	skills = [],
@@ -105,6 +108,11 @@ export function ChatComposer({
 	busy?: boolean;
 	/** The agent is mid-turn, so this message is held until the turn ends. */
 	willQueue?: boolean;
+	/** The primary action becomes Stop while a turn is active and no draft is ready. */
+	turnActive?: boolean;
+	onInterrupt?: () => void;
+	/** Queued messages are cleared when the active turn is stopped. */
+	queuedCount?: number;
 	disabled?: boolean;
 	/** The provider's skills. Empty leaves `/` an ordinary character. */
 	skills?: ChatSkill[];
@@ -220,11 +228,13 @@ export function ChatComposer({
 	const activeIndex = Math.min(highlighted, suggestions.length - 1);
 
 	const staged = fileAttachments.attachments.length > 0;
+	const hasDraft = text.trim().length > 0 || staged;
 	// The control disappears the moment the turn ends, and the armed mode degrades
 	// with it: a steer with nothing in flight is refused, so it must never be what
 	// Enter is still pointing at.
 	const steering = Boolean(canSteer && onSteer) && delivery === "steer";
-	const canSend = (text.trim().length > 0 || staged) && !busy && !disabled && !steerPending;
+	const canSend = hasDraft && !busy && !disabled && !steerPending;
+	const stopping = Boolean(turnActive && !hasDraft);
 	const draftSeedId = draftSeed?.id;
 	const draftSeedText = draftSeed?.text;
 
@@ -634,13 +644,25 @@ export function ChatComposer({
 					className="flex shrink-0 items-center"
 				>
 					<Button
-						type="submit"
+						type={stopping ? "button" : "submit"}
 						size="icon-sm"
-						disabled={!canSend}
-						aria-label={steering ? "Steer the running turn" : "Send message"}
+						disabled={stopping ? !onInterrupt || busy : !canSend}
+						aria-label={
+							stopping
+								? queuedCount > 0
+									? "Stop turn and clear queued messages"
+									: "Stop turn"
+								: steering
+									? "Steer the running turn"
+									: "Send message"
+						}
+						title={stopping ? "Stop turn" : undefined}
+						onClick={stopping ? onInterrupt : undefined}
 						className="size-8 rounded-lg border-logo-accent bg-logo-accent text-logo-accent-foreground hover:bg-logo-accent-bright focus-visible:ring-logo-accent/45"
 					>
-						{steerPending ? (
+						{stopping ? (
+							<Square aria-hidden="true" className="size-2.5 fill-current" />
+						) : steerPending ? (
 							<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
 						) : steering ? (
 							<CornerDownRight aria-hidden="true" className="size-3.5" />

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -13,8 +13,8 @@
  * settings because the provider takes all three per turn: choosing one changes the
  * next message and never restarts the agent.
  *
- * Three completions live on top of a plain textarea — `/` for the agent's own
- * skills, `@` for worktree files, and pasted or dropped files. It is a textarea and
+ * Three completions live on top of a plain textarea — `/` for AO commands and the
+ * agent's own skills, `@` for worktree files, and pasted or dropped files. It is a textarea and
  * not a rich editor; the reasoning is in composerSuggest.ts, where the logic that
  * would otherwise justify one lives. What matters here is that the original
  * keyboard contract survives: Enter sends, Shift+Enter makes a newline, and no
@@ -93,6 +93,10 @@ export function ChatComposer({
 	draftSeed,
 	commandError,
 	attachedTop = false,
+	onCompact,
+	compacting,
+	compactUnavailable,
+	compactBlocked,
 }: {
 	onSend: (text: string, attachments?: FileAttachmentPayload[]) => void | Promise<unknown>;
 	/** The next-turn controls, rendered inline. Omitted in the fixture preview. */
@@ -132,6 +136,14 @@ export function ChatComposer({
 	commandError?: string;
 	/** A queued-message dock owns the shared rounded top edge. */
 	attachedTop?: boolean;
+	/** Run AO's built-in `/compact` command instead of sending it to the agent. */
+	onCompact?: () => void | Promise<unknown>;
+	/** The provider is already compacting this conversation. */
+	compacting?: boolean;
+	/** A typed provider refusal from the last compaction attempt. */
+	compactUnavailable?: string;
+	/** A running turn must be stopped before its history can be compacted. */
+	compactBlocked?: boolean;
 }) {
 	const [text, setText] = useState("");
 	const [caret, setCaret] = useState(0);
@@ -149,7 +161,6 @@ export function ChatComposer({
 	 * Queueing is the safe default and matches `ao send`: the daemon records the
 	 * message durably and dispatches it when the current turn finishes. Steering is
 	 * timing-sensitive and changes the running turn, so it stays an explicit choice.
-	 * The send hint names whichever destination is armed.
 	 */
 	const [delivery, setDelivery] = useState<"steer" | "queue">("queue");
 
@@ -182,13 +193,26 @@ export function ChatComposer({
 
 	const trigger = useMemo(() => findActiveTrigger(text, caret), [text, caret]);
 
+	const slashCommands = useMemo<ChatSkill[]>(() => {
+		if (!onCompact || compactUnavailable === "This agent cannot compact its history") return skills;
+		return [
+			{
+				name: "compact",
+				displayName: "compact",
+				description: "Summarize earlier history to reclaim context",
+				source: "AO",
+			},
+			...skills.filter((skill) => skill.name !== "compact"),
+		];
+	}, [compactUnavailable, onCompact, skills]);
+
 	const suggestions: Suggestion[] = useMemo(() => {
 		if (!trigger || trigger.start === dismissedAt) return [];
 		// An empty candidate list is the whole reason the sigil stays ordinary: with
-		// no skills there is nothing to open, so `/` types a slash.
-		if (trigger.kind === "skill") return rankSkills(skills, trigger.query);
+		// no commands or skills there is nothing to open, so `/` types a slash.
+		if (trigger.kind === "skill") return rankSkills(slashCommands, trigger.query);
 		return rankFiles(filePaths, trigger.query);
-	}, [trigger, dismissedAt, skills, filePaths]);
+	}, [trigger, dismissedAt, slashCommands, filePaths]);
 
 	const menuOpen = suggestions.length > 0;
 	// Clamped rather than trusted: the list re-ranks on every keystroke, so the
@@ -278,6 +302,31 @@ export function ChatComposer({
 
 		const body = text.trim();
 
+		if (body === "/compact" && onCompact) {
+			if (compactBlocked) {
+				setSendError("Stop the current turn before compacting.");
+				return;
+			}
+			if (compacting) {
+				setSendError("Conversation history is already being compacted.");
+				return;
+			}
+			if (compactUnavailable) {
+				setSendError(compactUnavailable);
+				return;
+			}
+			try {
+				await onCompact();
+			} catch {
+				setSendError("Conversation history could not be compacted. Try again.");
+				return;
+			}
+			applyText("", 0);
+			setDismissedAt(null);
+			setHighlighted(0);
+			return;
+		}
+
 		// Steering keeps the text in the box until the provider has taken it. The turn
 		// is already running, so a refusal is a real possibility — and a refusal that
 		// had already cleared the composer would lose what the user typed.
@@ -343,6 +392,14 @@ export function ChatComposer({
 
 	function onKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
 		if (menuOpen) {
+			// `/compact` takes no arguments. Once its exact name is present, Enter
+			// executes it directly instead of merely accepting the highlighted row and
+			// requiring a second Enter on the inserted trailing space.
+			if (event.key === "Enter" && text.trim() === "/compact" && onCompact) {
+				event.preventDefault();
+				void submit();
+				return;
+			}
 			// Only these keys are taken while the menu is open. Everything else falls
 			// through to the textarea, which is what keeps typing from being swallowed.
 			if (event.key === "ArrowDown" || event.key === "ArrowUp") {
@@ -493,7 +550,7 @@ export function ChatComposer({
 				onSelect={onSelectionChange}
 				onClick={onSelectionChange}
 				onPaste={onPaste}
-				rows={2}
+				rows={1}
 				disabled={disabled}
 				aria-label="Message the agent"
 				role="combobox"
@@ -508,11 +565,9 @@ export function ChatComposer({
 							? "Agent is working — this goes into the turn it is running"
 							: willQueue
 								? "Agent is working — this sends when it finishes"
-								: skills.length > 0
-									? "Ask the agent…  /  for skills, @ for files"
-									: "Ask the agent…  @ for files"
+								: "Message the agent…"
 				}
-				className="chat-composer-scrollbar max-h-40 min-h-[3.25rem] w-full resize-none overflow-y-hidden overscroll-contain bg-transparent px-1.5 py-1.5 text-sm leading-relaxed text-foreground outline-none placeholder:text-passive disabled:opacity-50"
+				className="chat-composer-scrollbar max-h-40 min-h-9 w-full resize-none overflow-y-hidden overscroll-contain bg-transparent px-1.5 py-1.5 text-sm leading-relaxed text-foreground outline-none placeholder:text-passive disabled:opacity-50"
 			/>
 
 			{attachmentError ? (
@@ -576,17 +631,8 @@ export function ChatComposer({
 				<div
 					role="group"
 					aria-label="Send message controls"
-					className="flex shrink-0 items-center gap-2"
+					className="flex shrink-0 items-center"
 				>
-					<span className="hidden text-[11px] text-muted-foreground sm:inline">
-						{menuOpen
-							? "Enter to insert"
-							: steering
-								? "Enter to steer"
-								: willQueue
-									? "Enter to queue"
-									: "Enter to send"}
-					</span>
 					<Button
 						type="submit"
 						size="icon-sm"
@@ -617,7 +663,7 @@ export function ChatComposer({
  * and decides for itself what to abandon. Queueing waits for the turn to end and
  * then starts a new one from a cold start. For someone who has just realized they
  * asked for the wrong thing, that is the whole difference, so both are named and the
- * hint below says which one Enter is armed with.
+ * active choice is exposed visually and through `aria-pressed`.
  */
 function DeliveryChoice({
 	value,

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -24,7 +24,11 @@ describe("ChatComposer steering", () => {
 
 	it("defaults Enter to the durable queue path used by ao send", () => {
 		composer();
-		expect(screen.getByText("Enter to queue")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Queue for next" })).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+		expect(screen.queryByText(/Enter to/)).not.toBeInTheDocument();
 	});
 
 	it("queues by default while a turn is running", async () => {
@@ -43,7 +47,12 @@ describe("ChatComposer steering", () => {
 		composer({ onSteer, onSend });
 
 		await userEvent.click(screen.getByRole("button", { name: "Steer this turn" }));
-		expect(screen.getByText("Enter to steer")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Steer this turn" })).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+		expect(screen.getByRole("button", { name: "Steer the running turn" })).toBeInTheDocument();
+		expect(screen.queryByText(/Enter to/)).not.toBeInTheDocument();
 
 		await userEvent.type(screen.getByRole("combobox"), "and then ship it{Enter}");
 		expect(onSteer).toHaveBeenCalledWith("and then ship it");
@@ -105,13 +114,15 @@ describe("ChatComposer steering", () => {
 	it("offers nothing when the harness cannot steer", () => {
 		composer({ onSteer: undefined, canSteer: false });
 		expect(screen.queryByRole("button", { name: "Steer this turn" })).not.toBeInTheDocument();
-		expect(screen.getByText("Enter to queue")).toBeInTheDocument();
+		expect(screen.queryByText(/Enter to/)).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Send message" })).toBeInTheDocument();
 	});
 
 	it("offers nothing when no turn is in flight to steer", () => {
 		composer({ canSteer: false, willQueue: false });
 		expect(screen.queryByRole("button", { name: "Steer this turn" })).not.toBeInTheDocument();
-		expect(screen.getByText("Enter to send")).toBeInTheDocument();
+		expect(screen.queryByText(/Enter to/)).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Send message" })).toBeInTheDocument();
 	});
 });
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -415,6 +415,8 @@ describe("ChatWorkspace timeline", () => {
 		stubGeometry(log, { scrollHeight: 4000, clientHeight: 800, scrollTop: 100 });
 		log.dispatchEvent(new Event("scroll"));
 		const jump = await screen.findByRole("button", { name: /jump to latest/i });
+		expect(jump).toHaveAttribute("title", "Jump to latest");
+		expect(jump).not.toHaveTextContent("Jump to latest");
 		expect(jump).toHaveClass(
 			"bg-raised",
 			"dark:bg-raised",

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -217,6 +217,24 @@ describe("ChatWorkspace timeline", () => {
 		expect(composer?.parentElement).toHaveClass("mx-auto", "w-full", "max-w-3xl");
 	});
 
+	it("renders an active turn as a compact status line instead of a boxed panel", async () => {
+		const user = userEvent.setup();
+		const onInterrupt = vi.fn();
+		const snapshot = {
+			...chatFixture,
+			items: chatFixture.items.filter((item) => item.id !== "a-7"),
+		};
+		render(<ChatWorkspace snapshot={snapshot} onInterrupt={onInterrupt} />);
+
+		const status = screen.getByTestId("live-turn-status");
+		expect(status).toHaveClass("min-h-6", "px-1.5");
+		expect(status).not.toHaveClass("border", "bg-surface", "rounded-md");
+		expect(status).toHaveTextContent("Working");
+
+		await user.click(screen.getByRole("button", { name: "Stop turn" }));
+		expect(onInterrupt).toHaveBeenCalledOnce();
+	});
+
 	it("lets readers select conversation text", () => {
 		render(<ChatWorkspace snapshot={chatFixture} />);
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatWorkspace } from "./ChatWorkspace";
@@ -217,7 +217,7 @@ describe("ChatWorkspace timeline", () => {
 		expect(composer?.parentElement).toHaveClass("mx-auto", "w-full", "max-w-3xl");
 	});
 
-	it("renders an active turn as a compact status line instead of a boxed panel", async () => {
+	it("puts working state in the timeline and Stop in the composer action", async () => {
 		const user = userEvent.setup();
 		const onInterrupt = vi.fn();
 		const snapshot = {
@@ -227,11 +227,15 @@ describe("ChatWorkspace timeline", () => {
 		render(<ChatWorkspace snapshot={snapshot} onInterrupt={onInterrupt} />);
 
 		const status = screen.getByTestId("live-turn-status");
-		expect(status).toHaveClass("min-h-6", "px-1.5");
+		expect(screen.getByRole("log", { name: "Conversation" })).toContainElement(status);
+		expect(status).toHaveClass("min-h-6", "px-1");
 		expect(status).not.toHaveClass("border", "bg-surface", "rounded-md");
 		expect(status).toHaveTextContent("Working");
+		expect(within(status).queryByRole("button")).not.toBeInTheDocument();
 
-		await user.click(screen.getByRole("button", { name: "Stop turn" }));
+		const stop = screen.getByRole("button", { name: "Stop turn" });
+		expect(screen.getByLabelText("Message the agent").closest("form")).toContainElement(stop);
+		await user.click(stop);
 		expect(onInterrupt).toHaveBeenCalledOnce();
 	});
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1223,13 +1223,14 @@ function Timeline({
 			{!pinned ? (
 				<Button
 					type="button"
-					size="sm"
+					size="icon-sm"
 					variant="outline"
+					aria-label="Jump to latest"
+					title="Jump to latest"
 					onClick={() => setPinned(true)}
-					className="absolute bottom-3 left-1/2 -translate-x-1/2 gap-1.5 bg-raised shadow-sm hover:bg-surface dark:bg-raised dark:hover:bg-surface"
+					className="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-full bg-raised shadow-sm hover:bg-surface dark:bg-raised dark:hover:bg-surface"
 				>
-					<ArrowDown aria-hidden="true" className="size-3.5" />
-					Jump to latest
+					<ArrowDown aria-hidden="true" className="size-4" />
 				</Button>
 			) : null}
 		</div>

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -27,7 +27,6 @@ import {
 	type WheelEvent as ReactWheelEvent,
 } from "react";
 import {
-	Archive,
 	ArrowDown,
 	CornerDownRight,
 	GitBranch,
@@ -397,15 +396,6 @@ export function ChatWorkspace({
 
 			<div className="cursor-chat-composer-dock shrink-0 px-4 pb-3 pt-2">
 				<div className="mx-auto flex w-full max-w-3xl flex-col gap-2">
-					<div className="flex items-center justify-end">
-						<CompactButton
-							onCompact={onCompact}
-							compacting={compacting}
-							unavailable={compactUnavailable}
-							turnInFlight={Boolean(turn)}
-							compactedAt={snapshot.compactedAt}
-						/>
-					</div>
 					{discarded > 0 ? <RolledBackNotice count={discarded} /> : null}
 					{snapshot.branchedFromEarlierMessage ? (
 						<p className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
@@ -462,6 +452,10 @@ export function ChatWorkspace({
 						canSteer={Boolean(onSteer) && turn?.state === "running"}
 						steerPending={steerPending}
 						steerRefusal={steerRefusal}
+						onCompact={onCompact}
+						compacting={compacting}
+						compactUnavailable={compactUnavailable}
+						compactBlocked={Boolean(turn)}
 					/>
 				</div>
 			</div>
@@ -687,51 +681,6 @@ function ChatHeader({
 				</div>
 			</header>
 		</SessionTopbarPortal>
-	);
-}
-
-function CompactButton({
-	onCompact,
-	compacting,
-	unavailable,
-	turnInFlight,
-	compactedAt,
-}: {
-	onCompact?: () => void;
-	compacting?: boolean;
-	unavailable?: string;
-	turnInFlight?: boolean;
-	compactedAt?: string;
-}) {
-	if (!onCompact) return null;
-	if (unavailable === "This agent cannot compact its history") {
-		return <span className="text-[11px] text-muted-foreground">{unavailable}</span>;
-	}
-
-	const title = turnInFlight
-		? "Finish or stop the current turn before compacting"
-		: compactedAt
-			? `Summarize earlier history to reclaim context. Last compacted ${new Date(compactedAt).toLocaleString()}.`
-			: "Summarize earlier history to reclaim context";
-
-	return (
-		<Button
-			type="button"
-			size="sm"
-			variant="ghost"
-			onClick={onCompact}
-			disabled={compacting || turnInFlight}
-			title={title}
-			aria-label="Compact conversation history"
-			className="h-5 gap-1 px-1.5 text-[11px]"
-		>
-			{compacting ? (
-				<Loader2 aria-hidden="true" className="size-3 animate-spin" />
-			) : (
-				<Archive aria-hidden="true" className="size-3" />
-			)}
-			{compacting ? "Compacting…" : "Compact"}
-		</Button>
 	);
 }
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1783,7 +1783,10 @@ function LiveTurnBar({
 	}, [startedAt]);
 
 	return (
-		<div className="flex items-center gap-2.5 rounded-md border border-border bg-surface px-3 py-2">
+		<div
+			className="flex min-h-6 items-center gap-2 px-1.5"
+			data-testid="live-turn-status"
+		>
 			{blocked ? (
 				<span role="alert" className="sr-only">
 					The agent is waiting for your decision.
@@ -1794,12 +1797,17 @@ function LiveTurnBar({
 			) : (
 				<Loader2
 					aria-hidden="true"
-					className="size-3.5 shrink-0 animate-spin text-status-working opacity-100"
+					className="size-3 shrink-0 animate-spin text-status-working opacity-100"
 				/>
 			)}
-			<strong className={cn("text-xs font-medium", blocked ? "text-warning" : "text-foreground")}>
+			<span
+				className={cn(
+					"text-xs font-medium",
+					blocked ? "text-warning" : "text-muted-foreground",
+				)}
+			>
 				{blocked ? "Waiting for your decision" : "Working"}
-			</strong>
+			</span>
 			<span className="text-[11px] tabular-nums text-muted-foreground">{elapsed}</span>
 			{queuedCount > 0 ? (
 				<span className="text-[11px] text-muted-foreground">
@@ -1811,10 +1819,11 @@ function LiveTurnBar({
 				size="sm"
 				variant="ghost"
 				onClick={onInterrupt}
-				className="ml-auto gap-1.5"
+				aria-label={queuedCount > 0 ? "Stop turn and clear queued messages" : "Stop turn"}
+				className="ml-auto h-6 gap-1 px-1.5 text-[11px] text-muted-foreground"
 			>
-				<Square aria-hidden="true" className="size-3" />
-				{queuedCount > 0 ? "Stop and clear queue" : "Stop turn"}
+				<Square aria-hidden="true" className="size-2.5" />
+				{queuedCount > 0 ? "Stop + clear queue" : "Stop"}
 			</Button>
 		</div>
 	);

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -32,7 +32,6 @@ import {
 	GitBranch,
 	Loader2,
 	MessageSquare,
-	Square,
 	TriangleAlert,
 	Undo2,
 } from "lucide-react";
@@ -269,8 +268,6 @@ export function ChatWorkspace({
 	mcpReloadError,
 }: ChatWorkspaceProps) {
 	const turn = activeTurn(snapshot);
-	const approval = pendingApproval(snapshot);
-	const userInput = pendingUserInput(snapshot);
 	const queuedCount = queuedTurnIds(snapshot).size;
 	const queuedMessages = useMemo(() => {
 		const messagesByTurn = new Map(
@@ -403,14 +400,6 @@ export function ChatWorkspace({
 							Conversation branched; worktree files were left unchanged.
 						</p>
 					) : null}
-					{turn ? (
-						<LiveTurnBar
-							startedAt={turn.startedAt ?? turn.requestedAt}
-							blocked={Boolean(approval || userInput)}
-							queuedCount={queuedCount}
-							onInterrupt={onInterrupt}
-						/>
-					) : null}
 					{turn?.state === "running" && queuedMessages.length > 0 ? (
 						<QueuedMessageDock
 							messages={queuedMessages}
@@ -440,6 +429,9 @@ export function ChatWorkspace({
 						}
 						busy={busy}
 						willQueue={Boolean(turn)}
+						turnActive={Boolean(turn)}
+						onInterrupt={onInterrupt}
+						queuedCount={queuedCount}
 						disabled={snapshot.controller.state === "stopped"}
 						skills={skills}
 						filePaths={filePaths}
@@ -825,6 +817,8 @@ function Timeline({
 	const [pinned, setPinned] = useState(true);
 	const [hoveredMarker, setHoveredMarker] = useState<number | null>(null);
 	const [messageEdit, setMessageEdit] = useState<MessageEditDraft>();
+	const turn = activeTurn(snapshot);
+	const blocked = Boolean(pendingApproval(snapshot) || pendingUserInput(snapshot));
 	const [scrollbar, setScrollbar] = useState({
 		visible: false,
 		top: 0,
@@ -1060,7 +1054,7 @@ function Timeline({
 		updateScrollbar();
 	}
 
-	if (items.length === 0 && !messageEdit) {
+	if (items.length === 0 && !messageEdit && !turn) {
 		return <EmptyState harness={snapshot.harness} />;
 	}
 
@@ -1138,6 +1132,13 @@ function Timeline({
 								onSend={submitMessageEdit}
 							/>
 						</div>
+					) : null}
+					{turn ? (
+						<LiveTurnStatus
+							startedAt={turn.startedAt ?? turn.requestedAt}
+							blocked={blocked}
+							queuedCount={queued.size}
+						/>
 					) : null}
 				</div>
 			</div>
@@ -1760,21 +1761,19 @@ function QueuedMessageDock({
 }
 
 /**
- * The in-flight turn. Elapsed time is shown because a long silence is otherwise
- * indistinguishable from a hang, and "waiting on you" is called out so a blocked
- * turn is not mistaken for a slow one.
+ * The in-flight turn, rendered as the final line of the conversation rather than
+ * a second control bar above the composer. Elapsed time keeps a long silence from
+ * looking like a hang; stopping the turn belongs to the composer's primary action.
  */
-function LiveTurnBar({
+function LiveTurnStatus({
 	startedAt,
 	blocked,
 	queuedCount = 0,
-	onInterrupt,
 }: {
 	startedAt: string;
 	blocked?: boolean;
 	/** Messages typed during this turn, waiting to be sent after it. */
 	queuedCount?: number;
-	onInterrupt?: () => void;
 }) {
 	const [elapsed, setElapsed] = useState(() => since(startedAt));
 
@@ -1785,7 +1784,7 @@ function LiveTurnBar({
 
 	return (
 		<div
-			className="flex min-h-6 items-center gap-2 px-1.5"
+			className="flex min-h-6 items-center gap-2 px-1 py-0.5"
 			data-testid="live-turn-status"
 		>
 			{blocked ? (
@@ -1815,17 +1814,6 @@ function LiveTurnBar({
 					{queuedCount} {queuedCount === 1 ? "message" : "messages"} queued
 				</span>
 			) : null}
-			<Button
-				type="button"
-				size="sm"
-				variant="ghost"
-				onClick={onInterrupt}
-				aria-label={queuedCount > 0 ? "Stop turn and clear queued messages" : "Stop turn"}
-				className="ml-auto h-6 gap-1 px-1.5 text-[11px] text-muted-foreground"
-			>
-				<Square aria-hidden="true" className="size-2.5" />
-				{queuedCount > 0 ? "Stop + clear queue" : "Stop"}
-			</Button>
 		</div>
 	);
 }

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -395,7 +395,7 @@ export function useConversationCommands(sessionId: string | undefined) {
 		resumeAgent: () => resume.mutateAsync(),
 		resumingAgent: resume.isPending,
 		resumeError: resume.error ? apiErrorMessage(resume.error) : undefined,
-		compact: () => compact.mutate(),
+		compact: () => compact.mutateAsync(),
 		chooseSettings: (settings: TurnSettings) => chooseSettings.mutate(settings),
 		/** A compaction is in flight provider-side and takes seconds, so it reads as
 		 *  its own state rather than folding into the generic busy flag, which also


### PR DESCRIPTION
## Summary
- remove the permanent Compact action row and expose compaction as the built-in `/compact` command
- make the empty composer start at one text line and grow with its content
- remove redundant Enter-to-send/queue/steer helper copy while preserving accessible delivery-state labels
- replace the boxed active-turn card with a slim status line and compact Stop action
- keep `/compact` drafts intact when compaction is blocked or unavailable

## Tests
- `cd frontend && npm run typecheck`
- `cd frontend && npm test -- --run src/renderer/components/chat src/renderer/hooks/useConversation.test.tsx` (289 passed)

## Review note
This is stacked on #4017 so it can be reviewed independently from the session-layout fix. Retarget to `main` after #4017 merges.