### PR TITLE
Add Product Hunt launch appeal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 <div align="center">
   <img src="assets/ao-logo.svg" alt="Agent Orchestrator" width="144" height="144" />
 
+  <br />
+
+  <a href="https://www.producthunt.com/products/agent-orchestrator?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-agent-orchestrator" target="_blank" rel="noopener noreferrer">
+    <img alt="Agent Orchestrator - Run a fleet of coding agents. Ship like a team. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1215599&amp;theme=light&amp;t=1786778713789" />
+  </a>
+
+  AO is live on Product Hunt today. If it is useful to you, an upvote or a short piece of feedback would mean a lot.
+
 ### Agent Orchestrator
 
 #### Plan, run, and supervise coding agents from one place.

--- a/frontend/src/landing/packages/shared/src/constants.ts
+++ b/frontend/src/landing/packages/shared/src/constants.ts
@@ -5,6 +5,7 @@ export const COMPANY = {
   DOCS_URL: "https://aoagents.dev/docs",
   GITHUB_URL: "https://github.com/Untrivial-ai/agent-orchestrator",
   GITHUB_REPO: "Untrivial-ai/agent-orchestrator",
+  PRODUCT_HUNT_URL: "https://www.producthunt.com/products/agent-orchestrator?launch=agent-orchestrator",
   STATUS_URL: "https://status.aoagents.dev",
   TRUST_URL: "https://aoagents.dev/privacy/",
   MAIL_TO: "mailto:prateek@untrivial.ai",

--- a/frontend/src/landing/src/app/components/HeroSection/HeroSection.tsx
+++ b/frontend/src/landing/src/app/components/HeroSection/HeroSection.tsx
@@ -6,8 +6,8 @@ import {
   TAGLINE,
 } from "@ao/shared/constants";
 import { Star } from "lucide-react";
-import { useState } from "react";
-import { FaGithub } from "react-icons/fa";
+import { useEffect, useState } from "react";
+import { FaGithub, FaProductHunt } from "react-icons/fa";
 import { track } from "@/lib/analytics";
 import { DownloadButton } from "../DownloadButton";
 import { ProductDemo } from "./components/ProductDemo";
@@ -15,6 +15,8 @@ import { ProductDemo } from "./components/ProductDemo";
 const INSTALL_COMMAND = "brew install agentwrapper/tap/agent-orchestrator";
 // Wraps at the path separators instead of mid-word once the pill goes two-line.
 const INSTALL_COMMAND_PARTS = INSTALL_COMMAND.split("/");
+// Product Hunt launch day closes at midnight Pacific Time on August 16, 2026.
+const PRODUCT_HUNT_LAUNCH_END_MS = Date.parse("2026-08-16T07:00:00.000Z");
 
 function formatStarCount(count: number) {
   if (count >= 1000) {
@@ -24,12 +26,28 @@ function formatStarCount(count: number) {
   return count.toString();
 }
 
+function formatLaunchCountdown(now = Date.now()) {
+  const remainingMs = PRODUCT_HUNT_LAUNCH_END_MS - now;
+
+  if (remainingMs <= 0) return "Final hours";
+
+  const totalSeconds = Math.floor(remainingMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}
+
 interface HeroSectionProps {
   initialStars: number | null;
 }
 
 export function HeroSection({ initialStars }: HeroSectionProps) {
   const [copiedCommand, setCopiedCommand] = useState(false);
+  const [launchCountdown, setLaunchCountdown] = useState("--:--:--");
   const stars = initialStars;
 
   const githubButtonLabel =
@@ -48,12 +66,48 @@ export function HeroSection({ initialStars }: HeroSectionProps) {
     window.setTimeout(() => setCopiedCommand(false), 1600);
   };
 
+  useEffect(() => {
+    const updateCountdown = () => setLaunchCountdown(formatLaunchCountdown());
+    updateCountdown();
+
+    const interval = window.setInterval(updateCountdown, 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
   return (
     <div className="relative">
       <div className="relative flex flex-col items-center overflow-hidden pt-24 pb-8 sm:pt-32 sm:pb-10 lg:pt-36 lg:pb-12">
         <div className="relative w-full max-w-[1600px] mx-auto px-4 sm:px-8 lg:px-[30px]">
           <div className="flex flex-col items-center text-center">
             <div className="space-y-5 sm:space-y-7 select-none">
+              <a
+                href={COMPANY.PRODUCT_HUNT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group mx-auto inline-flex w-full max-w-[min(100%,78rem)] items-center justify-between gap-2.5 rounded-[1.75rem] border border-[#da552f]/45 bg-[#da552f]/[0.07] px-3 py-2.5 text-sm font-normal tracking-[-0.3px] text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] ring-1 ring-[#da552f]/10 transition-[background-color,border-color,box-shadow,transform] duration-200 hover:-translate-y-0.5 hover:border-[#da552f]/70 hover:bg-[#da552f]/[0.11] hover:shadow-[0_18px_44px_-30px_rgba(218,85,47,0.85)] sm:w-auto sm:justify-center sm:gap-3 sm:rounded-[2rem] sm:px-5 sm:py-3 sm:text-lg"
+              >
+                <span className="flex min-w-0 items-center gap-2.5 sm:gap-3">
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-[#da552f] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.22)] sm:size-10">
+                    <FaProductHunt className="size-4.5 sm:size-5.5" aria-hidden="true" />
+                  </span>
+                  <span className="min-w-0 text-left leading-5 sm:leading-6 xl:whitespace-nowrap">
+                    <span className="sm:hidden">
+                      <span className="block">Live on Product Hunt today.</span>
+                      <span className="block text-muted-foreground">An upvote or note would mean a lot.</span>
+                    </span>
+                    <span className="hidden sm:inline">Today, Agent Orchestrator is live on Product Hunt.</span>
+                    <span className="hidden text-muted-foreground sm:inline"> An upvote or note would mean a lot.</span>
+                  </span>
+                </span>
+                <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-[#da552f]/35 bg-background/70 px-2 py-1 font-mono text-[11px] tracking-[0.3px] text-[#ff805d] sm:gap-2 sm:px-3 sm:py-1.5 sm:text-sm">
+                  <span className="size-1.5 rounded-full bg-[#da552f]" aria-hidden="true" />
+                  <time dateTime="2026-08-16T00:00:00-07:00">{launchCountdown}</time>
+                  <span className="hidden font-sans text-[10px] uppercase tracking-[0.14em] text-muted-foreground sm:inline">
+                    left
+                  </span>
+                </span>
+              </a>
+
               <h1 className="font-sans text-4xl sm:text-5xl md:text-6xl lg:text-[4.75rem] font-normal tracking-[-0.5px] leading-[0.98] text-foreground max-w-6xl mx-auto text-balance">
                 {TAGLINE}
               </h1>
@@ -89,6 +143,21 @@ export function HeroSection({ initialStars }: HeroSectionProps) {
                 ) : null}
               </a>
             </div>
+
+            <a
+              href="https://www.producthunt.com/products/agent-orchestrator?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-agent-orchestrator"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-flex rounded-[14px] transition-opacity hover:opacity-90"
+            >
+              <img
+                alt="Agent Orchestrator - Run a fleet of coding agents. Ship like a team. | Product Hunt"
+                className="h-[54px] w-[250px]"
+                height="54"
+                src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1215599&theme=light&t=1786778713789"
+                width="250"
+              />
+            </a>
 
             <div className="landing-install-command mt-4">
               <button


### PR DESCRIPTION
## Summary
- add a Product Hunt upvote badge and humble launch note to the README
- add a compact Product Hunt CTA under the landing hero buttons
- centralize the Product Hunt URL in shared company constants

## Testing
- npm run build