### PR TITLE
fix(scm): prevent transient PR fact regressions

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -325,8 +325,11 @@ type restListPull struct {
 		} `json:"repo"`
 	} `json:"head"`
 	Base struct {
-		Ref string `json:"ref"`
-		SHA string `json:"sha"`
+		Ref  string `json:"ref"`
+		SHA  string `json:"sha"`
+		Repo struct {
+			FullName string `json:"full_name"`
+		} `json:"repo"`
 	} `json:"base"`
 	User struct {
 		Login string `json:"login"`
@@ -341,6 +344,7 @@ func restListPullToSCM(pull restListPull) ports.SCMPRObservation {
 		ProviderID:        pull.NodeID,
 		URL:               firstNonEmpty(pull.HTMLURL, pull.URL),
 		Number:            pull.Number,
+		BaseRepo:          pull.Base.Repo.FullName,
 		State:             normalizePRState(pull.Draft, false, closed),
 		Draft:             pull.Draft,
 		Closed:            closed,

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -299,7 +299,7 @@ func TestParsePRURL(t *testing.T) {
 	}
 }
 
-func TestRestListPullToSCMCarriesHeadRepo(t *testing.T) {
+func TestRestListPullToSCMCarriesRepositoryIdentities(t *testing.T) {
 	var pull restListPull
 	pull.Number = 7
 	pull.State = "open"
@@ -307,6 +307,7 @@ func TestRestListPullToSCMCarriesHeadRepo(t *testing.T) {
 	pull.Head.SHA = "deadbeef"
 	pull.Head.Repo.FullName = "forker/hello"
 	pull.Base.Ref = "main"
+	pull.Base.Repo.FullName = "canonical/hello"
 
 	obs := restListPullToSCM(pull)
 	if obs.SourceBranch != "feat/x" {
@@ -314,6 +315,9 @@ func TestRestListPullToSCMCarriesHeadRepo(t *testing.T) {
 	}
 	if obs.HeadRepo != "forker/hello" {
 		t.Fatalf("HeadRepo = %q, want forker/hello", obs.HeadRepo)
+	}
+	if obs.BaseRepo != "canonical/hello" {
+		t.Fatalf("BaseRepo = %q, want canonical/hello", obs.BaseRepo)
 	}
 }
 

--- a/backend/internal/adapters/scm/gitlab/observer_provider.go
+++ b/backend/internal/adapters/scm/gitlab/observer_provider.go
@@ -277,6 +277,7 @@ func mrToSCMPRObservation(repo ports.SCMRepo, mr *restMR) ports.SCMPRObservation
 		URL:                      mr.WebURL,
 		HTMLURL:                  mr.WebURL,
 		Number:                   mr.IID,
+		BaseRepo:                 repo.Repo,
 		State:                    string(state),
 		Draft:                    mr.Draft,
 		Merged:                   merged,

--- a/backend/internal/adapters/scm/gitlab/provider_test.go
+++ b/backend/internal/adapters/scm/gitlab/provider_test.go
@@ -244,6 +244,9 @@ func TestListPRsByRepo(t *testing.T) {
 	if len(prs) != 2 {
 		t.Fatalf("got %d PRs, want 2", len(prs))
 	}
+	if prs[0].BaseRepo != "myorg/myrepo" {
+		t.Fatalf("BaseRepo = %q, want myorg/myrepo", prs[0].BaseRepo)
+	}
 	if prs[0].State != "open" {
 		t.Errorf("pr[0].State = %q, want %q", prs[0].State, "open")
 	}

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -333,7 +333,7 @@ func Run() error {
 	prReader := newMultiSCMProvider(cfg.GitLab, log)
 	prMerger := newMultiSCMMerger(cfg.GitLab, log)
 	if prReader != nil && prMerger != nil {
-		prActions = prsvc.NewActionService(prsvc.ActionDeps{Store: store, Merger: prMerger, Reader: prReader})
+		prActions = prsvc.NewActionService(prsvc.ActionDeps{Store: store, Merger: prMerger, Reader: prReader, Lifecycle: lcStack.LCM, Logger: log})
 	} else {
 		log.Warn("pr action service disabled: no usable SCM provider")
 	}

--- a/backend/internal/domain/pr.go
+++ b/backend/internal/domain/pr.go
@@ -26,6 +26,26 @@ type PRFacts struct {
 	UpdatedAt      time.Time
 }
 
+// DiscoveredPullRequest is the minimal, non-authoritative fact produced by PR
+// listing. Discovery proves that an open or draft PR exists and which session
+// owns its branch; it does not prove current CI, review, mergeability, or full
+// metadata. Persistence must therefore treat this as insert-only and leave an
+// existing PullRequest snapshot untouched.
+type DiscoveredPullRequest struct {
+	URL          string
+	SessionID    SessionID
+	Number       int
+	Draft        bool
+	UpdatedAt    time.Time
+	Provider     string
+	Host         string
+	Repo         string
+	ProviderID   string
+	SourceBranch string
+	TargetBranch string
+	HeadSHA      string
+}
+
 // PullRequest is the app-level representation of one tracked pull request as
 // persisted by the PR store. It is intentionally separate from the sqlc
 // generated sqlite row type so storage details do not leak outside sqlite.

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -79,6 +79,7 @@ type Store interface {
 	ListWorkspaceRepos(ctx context.Context, projectID string) ([]domain.WorkspaceRepoRecord, error)
 	ListPRsBySession(ctx context.Context, sessionID domain.SessionID) ([]domain.PullRequest, error)
 	ListChecks(ctx context.Context, prURL string) ([]domain.PullRequestCheck, error)
+	EnsureDiscoveredPR(ctx context.Context, pr domain.DiscoveredPullRequest) error
 	WriteSCMObservation(ctx context.Context, pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, reviewMode ports.ReviewWriteMode) error
 }
 
@@ -878,8 +879,8 @@ func (o *Observer) workspaceSCMSessionRepos(ctx context.Context, proj domain.Pro
 
 func repoForTrackedPR(pr domain.PullRequest, repos []ports.SCMRepo) (ports.SCMRepo, bool) {
 	if pr.Provider != "" && pr.Host != "" && pr.Repo != "" {
-		owner, name, ok := strings.Cut(pr.Repo, "/")
-		if !ok || owner == "" || name == "" {
+		owner, name, ok := splitRepoFullName(pr.Repo)
+		if !ok {
 			return ports.SCMRepo{}, false
 		}
 		return ports.SCMRepo{Provider: pr.Provider, Host: pr.Host, Owner: owner, Name: name, Repo: pr.Repo}, true
@@ -997,6 +998,20 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 	// re-fetched
 	listedPRs = map[string]bool{}
 	listedRepos = map[string]bool{}
+	type trackedSubject struct {
+		key  string
+		subj *subject
+	}
+	trackedByURL := map[string]trackedSubject{}
+	trackedByProviderID := map[string]trackedSubject{}
+	for key, subj := range subjects {
+		if url := strings.TrimSpace(subj.known.URL); url != "" {
+			trackedByURL[url] = trackedSubject{key: key, subj: subj}
+		}
+		if id := providerPRIdentityKey(subj.known.Provider, subj.known.Host, subj.known.ProviderID); id != "" {
+			trackedByProviderID[id] = trackedSubject{key: key, subj: subj}
+		}
+	}
 	for repoKey, repo := range repos {
 		g := guards[repoKey]
 		if g.err != nil {
@@ -1026,7 +1041,7 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 		// restrict refresh to only updated MRs rather than every tracked MR.
 		listedRepos[repoKey] = true
 		for _, pr := range pulls {
-			listedPRs[prKey(repo, pr.Number)] = true
+			listedPRs[prKey(repoForListedPR(repo, pr), pr.Number)] = true
 		}
 		for _, pr := range pulls {
 			if pr.Number <= 0 || pr.SourceBranch == "" {
@@ -1041,7 +1056,8 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 					continue
 				}
 			}
-			key := prKey(repo, pr.Number)
+			prRepo := repoForListedPR(repo, pr)
+			key := prKey(prRepo, pr.Number)
 			if _, ok := subjects[key]; ok {
 				continue
 			}
@@ -1057,17 +1073,41 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 			if !ok {
 				continue
 			}
-			known := domain.PullRequest{
-				URL:          firstNonEmpty(pr.URL, pr.HTMLURL),
+			url := firstNonEmpty(pr.URL, pr.HTMLURL)
+			if strings.TrimSpace(url) == "" {
+				continue
+			}
+			tracked, trackedAlready := trackedByURL[url]
+			providerIDKey := providerPRIdentityKey(prRepo.Provider, prRepo.Host, pr.ProviderID)
+			if !trackedAlready && providerIDKey != "" {
+				tracked, trackedAlready = trackedByProviderID[providerIDKey]
+			}
+			if trackedAlready {
+				// The provider returned the same canonical PR URL through another
+				// repository identity (for example, a pre-transfer remote that now
+				// redirects). Re-key the existing rich snapshot to the provider's
+				// canonical base repo instead of rediscovering a partial snapshot.
+				migrated := *tracked.subj
+				migrated.repo = prRepo
+				delete(subjects, tracked.key)
+				subjects[key] = &migrated
+				trackedByURL[url] = trackedSubject{key: key, subj: &migrated}
+				if providerIDKey != "" {
+					trackedByProviderID[providerIDKey] = trackedSubject{key: key, subj: &migrated}
+				}
+				continue
+			}
+			discovered := domain.DiscoveredPullRequest{
+				URL:          url,
 				SessionID:    sr.session.ID,
 				Number:       pr.Number,
 				Draft:        pr.Draft,
 				SourceBranch: pr.SourceBranch,
 				TargetBranch: pr.TargetBranch,
 				HeadSHA:      pr.HeadSHA,
-				Provider:     repo.Provider,
-				Host:         repo.Host,
-				Repo:         repoFullName(repo),
+				Provider:     prRepo.Provider,
+				Host:         prRepo.Host,
+				Repo:         repoFullName(prRepo),
 				ProviderID:   pr.ProviderID,
 				UpdatedAt:    now,
 			}
@@ -1077,23 +1117,76 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 			// reads every PR of the session from the store. Without this write, an
 			// open sibling/child discovered in the same poll would not yet be
 			// durable, and the session could terminate while that PR is still open.
-			if err := o.store.WriteSCMObservation(ctx, known, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
-				o.logger.Error("scm observer: persist discovered PR failed", "session", sr.session.ID, "pr", known.URL, "err", err)
+			if err := o.store.EnsureDiscoveredPR(ctx, discovered); err != nil {
+				o.logger.Error("scm observer: persist discovered PR failed", "session", sr.session.ID, "pr", discovered.URL, "err", err)
 				if markRepoFailed != nil {
-					markRepoFailed(repo)
+					markRepoFailed(prRepo)
 				}
 				continue
 			}
+			known := pullRequestFromDiscovery(discovered)
 			subjects[key] = &subject{
 				session: sr.session,
-				repo:    repo,
+				repo:    prRepo,
 				branch:  sr.branch,
 				known:   known,
 				hasPR:   true,
 			}
+			trackedByURL[url] = trackedSubject{key: key, subj: subjects[key]}
+			if providerIDKey != "" {
+				trackedByProviderID[providerIDKey] = trackedSubject{key: key, subj: subjects[key]}
+			}
 		}
 	}
 	return listedPRs, listedRepos
+}
+
+func providerPRIdentityKey(provider, host, providerID string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	host = strings.ToLower(strings.TrimSpace(host))
+	providerID = strings.TrimSpace(providerID)
+	if provider == "" || host == "" || providerID == "" {
+		return ""
+	}
+	return provider + "|" + host + "|" + providerID
+}
+
+// repoForListedPR prefers the base repository identity returned by the
+// provider over the identity used for the list request. Providers can redirect
+// renamed or transferred repositories while still serving the request, so the
+// requested remote name is not necessarily the repository that owns the PR
+// number.
+func repoForListedPR(scanned ports.SCMRepo, pr ports.SCMPRObservation) ports.SCMRepo {
+	fullName := strings.TrimSpace(pr.BaseRepo)
+	if fullName == "" || strings.EqualFold(fullName, repoFullName(scanned)) {
+		return scanned
+	}
+	owner, name, ok := splitRepoFullName(fullName)
+	if !ok {
+		return scanned
+	}
+	canonical := scanned
+	canonical.Owner = owner
+	canonical.Name = name
+	canonical.Repo = fullName
+	return canonical
+}
+
+func pullRequestFromDiscovery(pr domain.DiscoveredPullRequest) domain.PullRequest {
+	return domain.PullRequest{
+		URL:          pr.URL,
+		SessionID:    pr.SessionID,
+		Number:       pr.Number,
+		Draft:        pr.Draft,
+		UpdatedAt:    pr.UpdatedAt,
+		Provider:     pr.Provider,
+		Host:         pr.Host,
+		Repo:         pr.Repo,
+		ProviderID:   pr.ProviderID,
+		SourceBranch: pr.SourceBranch,
+		TargetBranch: pr.TargetBranch,
+		HeadSHA:      pr.HeadSHA,
+	}
 }
 
 func (o *Observer) authenticatedIdentity(ctx context.Context) (ports.SCMIdentity, bool) {
@@ -1772,7 +1865,7 @@ func domainFromObservation(sessionID domain.SessionID, sessionRecord domain.Sess
 		Provider:                 obs.Provider,
 		Host:                     obs.Host,
 		Repo:                     obs.Repo,
-		ProviderID:               obs.PR.ProviderID,
+		ProviderID:               firstNonEmpty(obs.PR.ProviderID, local.ProviderID),
 		SourceBranch:             obs.PR.SourceBranch,
 		TargetBranch:             obs.PR.TargetBranch,
 		HeadSHA:                  obs.PR.HeadSHA,
@@ -2056,19 +2149,25 @@ func repoFullName(repo ports.SCMRepo) string {
 }
 
 func ownerOf(full string) string {
-	parts := strings.SplitN(full, "/", 2)
-	if len(parts) == 2 {
-		return parts[0]
-	}
-	return ""
+	owner, _, _ := splitRepoFullName(full)
+	return owner
 }
 
 func nameOf(full string) string {
-	parts := strings.SplitN(full, "/", 2)
-	if len(parts) == 2 {
-		return parts[1]
+	_, name, ok := splitRepoFullName(full)
+	if !ok {
+		return full
 	}
-	return full
+	return name
+}
+
+func splitRepoFullName(full string) (owner, name string, ok bool) {
+	full = strings.Trim(strings.TrimSpace(full), "/")
+	i := strings.LastIndex(full, "/")
+	if i <= 0 || i == len(full)-1 {
+		return "", "", false
+	}
+	return full[:i], full[i+1:], true
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -37,7 +37,8 @@ type fakeStore struct {
 	checks         map[string][]domain.PullRequestCheck
 	writeErr       error
 
-	writes []fakeWrite
+	discoveries []domain.DiscoveredPullRequest
+	writes      []fakeWrite
 
 	listEntered chan struct{}
 	listRelease chan struct{}
@@ -105,6 +106,16 @@ func (s *fakeStore) ListChecks(_ context.Context, prURL string) ([]domain.PullRe
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]domain.PullRequestCheck(nil), s.checks[prURL]...), nil
+}
+
+func (s *fakeStore) EnsureDiscoveredPR(_ context.Context, pr domain.DiscoveredPullRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writeErr != nil {
+		return s.writeErr
+	}
+	s.discoveries = append(s.discoveries, pr)
+	return nil
 }
 
 func (s *fakeStore) WriteSCMObservation(_ context.Context, pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, reviewMode ports.ReviewWriteMode) error {
@@ -922,6 +933,9 @@ func TestPoll_IgnoresForkPRWithMatchingBranch(t *testing.T) {
 	if len(store.writes) != 0 {
 		t.Fatalf("fork PR must not be persisted, got %d writes", len(store.writes))
 	}
+	if len(store.discoveries) != 0 {
+		t.Fatalf("fork PR must not be discovered, got %d discoveries", len(store.discoveries))
+	}
 }
 
 func mustGit(t *testing.T, args ...string) {
@@ -1027,6 +1041,94 @@ func TestPoll_IgnoresUpstreamPRFromForeignHead(t *testing.T) {
 	if len(store.writes) != 0 {
 		t.Fatalf("foreign-head upstream PR must not be persisted, got %d writes", len(store.writes))
 	}
+	if len(store.discoveries) != 0 {
+		t.Fatalf("foreign-head upstream PR must not be discovered, got %d discoveries", len(store.discoveries))
+	}
+}
+
+func TestPoll_DedupesRedirectedRepoAliasByCanonicalBaseRepo(t *testing.T) {
+	dir := t.TempDir()
+	mustGit(t, "init", dir)
+	mustGit(t, "-C", dir, "remote", "add", "origin", "https://github.com/new/r.git")
+	mustGit(t, "-C", dir, "remote", "add", "old", "https://github.com/old/r.git")
+
+	canonical := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "new", Name: "r", Repo: "new/r"}
+	alias := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "old", Name: "r", Repo: "old/r"}
+	listed := ports.SCMPRObservation{
+		ProviderID:   "PR_stable_7",
+		URL:          "https://github.com/new/r/pull/7",
+		Number:       7,
+		BaseRepo:     "new/r",
+		SourceBranch: "ao/p-1/fix",
+		HeadRepo:     "new/r",
+		TargetBranch: "main",
+		HeadSHA:      "sha7",
+		Author:       "alice",
+	}
+	detailed := ports.SCMObservation{
+		Fetched: true, Provider: "github", Host: "github.com", Repo: "new/r",
+		PR: ports.SCMPRObservation{
+			ProviderID: "PR_stable_7", URL: "https://github.com/new/r/pull/7", Number: 7, State: "open",
+			SourceBranch: "ao/p-1/fix", HeadRepo: "new/r", TargetBranch: "main", HeadSHA: "sha7", Title: "PR",
+		},
+		CI:           ports.SCMCIObservation{Summary: string(domain.CIPassing), HeadSHA: "sha7"},
+		Review:       ports.SCMReviewObservation{Decision: string(domain.ReviewNone)},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeMergeable), Mergeable: true},
+	}
+	session := domain.SessionRecord{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "ao/p-1/root"}, AutoInjectReview: true}
+	aliasObservation := detailed
+	aliasObservation.Repo = alias.Repo
+	aliasObservation.PR.URL = "https://github.com/old/r/pull/7"
+	local, _, _, _, _ := domainFromObservation(session.ID, session, aliasObservation, domain.PullRequest{}, persistenceOptions{}, time.Unix(1, 0).UTC())
+	local.ReviewObservedAt = time.Unix(2, 0).UTC()
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{session},
+		projects: map[string]domain.ProjectRecord{"p": {ID: "p", Path: dir, RepoOriginURL: "https://github.com/new/r.git"}},
+		prs:      map[domain.SessionID][]domain.PullRequest{"p-1": {local}},
+		checks:   map[string][]domain.PullRequestCheck{},
+	}
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{
+			prKey(canonical, 0): {ETag: "canonical"},
+			prKey(alias, 0):     {ETag: "alias"},
+		},
+		openPRs: map[string][]ports.SCMPRObservation{
+			prKey(canonical, 0): {listed},
+			prKey(alias, 0):     {listed},
+		},
+		observations: map[string]ports.SCMObservation{prKey(canonical, 7): detailed},
+	}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(3, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.discoveries) != 0 {
+		t.Fatalf("redirected alias rediscovered an existing PR: %#v", store.discoveries)
+	}
+	if len(provider.fetchBatches) != 1 || len(provider.fetchBatches[0]) != 1 {
+		t.Fatalf("canonical PR should be fetched once, got batches %#v", provider.fetchBatches)
+	}
+	if got := provider.fetchBatches[0][0].Repo.Repo; got != canonical.Repo {
+		t.Fatalf("fetch repo = %q, want canonical %q", got, canonical.Repo)
+	}
+	if len(store.writes) == 0 {
+		t.Fatal("canonical observation should migrate the stored repository identity")
+	}
+	for _, write := range store.writes {
+		if write.pr.CI != domain.CIPassing || write.pr.Mergeability != domain.MergeMergeable {
+			t.Fatalf("identity migration downgraded readiness facts: %+v", write.pr)
+		}
+		if write.pr.Repo != canonical.Repo {
+			t.Fatalf("identity migration persisted repo %q, want %q", write.pr.Repo, canonical.Repo)
+		}
+	}
+}
+
+func TestSplitRepoFullNamePreservesNestedNamespace(t *testing.T) {
+	owner, name, ok := splitRepoFullName("group/subgroup/repo")
+	if !ok || owner != "group/subgroup" || name != "repo" {
+		t.Fatalf("split = %q, %q, %v", owner, name, ok)
+	}
 }
 
 // A newly discovered open PR is persisted as a baseline row during discovery,
@@ -1045,19 +1147,19 @@ func TestPoll_DiscoveredPRPersistedAsBaselineBeforeRefresh(t *testing.T) {
 	if err := obs.Poll(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	var baseline *domain.PullRequest
-	for i := range store.writes {
-		if store.writes[i].pr.Number == 1 {
-			baseline = &store.writes[i].pr
+	var baseline *domain.DiscoveredPullRequest
+	for i := range store.discoveries {
+		if store.discoveries[i].Number == 1 {
+			baseline = &store.discoveries[i]
 			break
 		}
 	}
 	if baseline == nil {
-		t.Fatalf("discovered PR #1 not persisted as a baseline row; writes=%#v", store.writes)
+		t.Fatalf("discovered PR #1 not persisted as a baseline row; discoveries=%#v", store.discoveries)
 		return
 	}
-	if baseline.Merged || baseline.Closed {
-		t.Fatalf("baseline row must be open, got merged=%v closed=%v", baseline.Merged, baseline.Closed)
+	if baseline.Draft {
+		t.Fatal("baseline row should be open, got draft")
 	}
 }
 

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
@@ -39,6 +40,21 @@ const (
 // merged as a bounded partial window.
 type SCMWriter interface {
 	WriteSCMObservation(ctx context.Context, pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, reviewMode ReviewWriteMode) error
+}
+
+// SCMDiscoveryWriter records the minimal fact that a PR exists. Discovery is
+// intentionally separate from SCMWriter because a repository listing does not
+// carry authoritative CI, review, mergeability, or full metadata. Ensuring an
+// already-known URL must never overwrite its richer stored observation.
+type SCMDiscoveryWriter interface {
+	EnsureDiscoveredPR(ctx context.Context, pr domain.DiscoveredPullRequest) error
+}
+
+// SCMMergeWriter projects a provider-confirmed merge into the durable PR facts
+// immediately. Polling remains a reconciliation path; callers should not wait
+// for the next observer tick after AO itself performed the mutation.
+type SCMMergeWriter interface {
+	RecordPRMerge(ctx context.Context, url, mergeCommitSHA string, mergedAt time.Time) (domain.PullRequest, error)
 }
 
 // PRClaimer atomically moves (or creates) a PR row for a target session and

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -132,6 +132,10 @@ type SCMPRObservation struct {
 	URLAlias string
 	// Number is the provider's PR number in the repository.
 	Number int
+	// BaseRepo is the provider's canonical full name for the repository that
+	// owns the PR number. It can differ from the repository used for the list
+	// request when a provider redirects a renamed or transferred repository.
+	BaseRepo string
 	// State is AO's normalized PR state: draft, open, merged, or closed.
 	State string
 	// Draft is true when the PR is marked draft/work-in-progress.

--- a/backend/internal/service/pr/action_service.go
+++ b/backend/internal/service/pr/action_service.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -19,6 +21,7 @@ var (
 
 type actionStore interface {
 	GetPR(ctx context.Context, url string) (domain.PullRequest, bool, error)
+	RecordPRMerge(ctx context.Context, url, mergeCommitSHA string, mergedAt time.Time) (domain.PullRequest, error)
 }
 
 type actionReader interface {
@@ -26,25 +29,45 @@ type actionReader interface {
 	FetchReviewThreads(ctx context.Context, ref ports.SCMPRRef) (ports.SCMReviewObservation, error)
 }
 
+type actionLifecycle interface {
+	ApplySCMObservation(ctx context.Context, id domain.SessionID, o ports.SCMObservation) error
+}
+
 // ActionDeps contains the storage and SCM boundaries used by ActionService.
 type ActionDeps struct {
-	Store  actionStore
-	Merger ports.SCMMerger
-	Reader actionReader
+	Store     actionStore
+	Merger    ports.SCMMerger
+	Reader    actionReader
+	Lifecycle actionLifecycle
+	Clock     func() time.Time
+	Logger    *slog.Logger
 }
 
 // ActionService validates current pull request state before applying mutations.
 type ActionService struct {
-	store  actionStore
-	merger ports.SCMMerger
-	reader actionReader
+	store     actionStore
+	merger    ports.SCMMerger
+	reader    actionReader
+	lifecycle actionLifecycle
+	clock     func() time.Time
+	logger    *slog.Logger
 }
 
 var _ ActionManager = (*ActionService)(nil)
 
 // NewActionService builds the guarded pull request action service.
 func NewActionService(deps ActionDeps) *ActionService {
-	return &ActionService{store: deps.Store, merger: deps.Merger, reader: deps.Reader}
+	s := &ActionService{
+		store: deps.Store, merger: deps.Merger, reader: deps.Reader,
+		lifecycle: deps.Lifecycle, clock: deps.Clock, logger: deps.Logger,
+	}
+	if s.clock == nil {
+		s.clock = time.Now
+	}
+	if s.logger == nil {
+		s.logger = slog.Default()
+	}
+	return s
 }
 
 // Merge re-fetches authoritative SCM state and then squash-merges only the
@@ -108,7 +131,43 @@ func (s *ActionService) Merge(ctx context.Context, request MergeRequest) (MergeR
 			return MergeResult{}, fmt.Errorf("merge pull request: %w", err)
 		}
 	}
+	s.projectSuccessfulMerge(ctx, tracked, fresh, review, out)
 	return MergeResult{PRNumber: tracked.Number, Method: string(ports.SCMMergeSquash), MergeCommitSHA: out.MergeCommitSHA}, nil
+}
+
+// projectSuccessfulMerge closes the command-to-observation gap. The provider
+// merge response is authoritative for terminal lifecycle, so AO records it and
+// emits lifecycle/notification effects immediately instead of waiting for the
+// periodic observer to rediscover the state. Projection failures do not turn a
+// successful external merge into an API failure; they are logged and the SCM
+// observer remains the reconciliation fallback.
+func (s *ActionService) projectSuccessfulMerge(ctx context.Context, tracked domain.PullRequest, fresh ports.SCMObservation, review ports.SCMReviewObservation, result ports.SCMMergeResult) {
+	// Once the provider accepted the mutation, client cancellation must not
+	// prevent AO from projecting the result it caused into local durable state.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	mergedAt := s.clock().UTC()
+	merged, err := s.store.RecordPRMerge(ctx, tracked.URL, result.MergeCommitSHA, mergedAt)
+	if err != nil {
+		s.logger.Error("pr merge succeeded but durable projection failed", "pr", tracked.URL, "err", err)
+		return
+	}
+	if s.lifecycle == nil {
+		return
+	}
+	fresh.Fetched = true
+	fresh.ObservedAt = mergedAt
+	fresh.PR.State = string(domain.PRStateMerged)
+	fresh.PR.Draft = false
+	fresh.PR.Merged = true
+	fresh.PR.Closed = false
+	fresh.PR.MergeCommitSHA = result.MergeCommitSHA
+	fresh.PR.MergedAtProvider = mergedAt
+	fresh.Review = review
+	fresh.Changed.Metadata = true
+	if err := s.lifecycle.ApplySCMObservation(ctx, merged.SessionID, fresh); err != nil {
+		s.logger.Error("pr merge projected but lifecycle reaction failed", "session", merged.SessionID, "pr", tracked.URL, "err", err)
+	}
 }
 
 func (s *ActionService) fetchMergeReadiness(ctx context.Context, ref ports.SCMPRRef) (ports.SCMObservation, ports.SCMReviewObservation, error) {

--- a/backend/internal/service/pr/action_service_test.go
+++ b/backend/internal/service/pr/action_service_test.go
@@ -1,21 +1,55 @@
 package pr
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 type fakeActionStore struct {
-	pr domain.PullRequest
-	ok bool
+	pr           domain.PullRequest
+	ok           bool
+	recordErr    error
+	recordCalls  int
+	recordedSHA  string
+	recordedTime time.Time
 }
 
 func (f *fakeActionStore) GetPR(context.Context, string) (domain.PullRequest, bool, error) {
 	return f.pr, f.ok, nil
+}
+
+func (f *fakeActionStore) RecordPRMerge(_ context.Context, _ string, mergeCommitSHA string, mergedAt time.Time) (domain.PullRequest, error) {
+	f.recordCalls++
+	f.recordedSHA = mergeCommitSHA
+	f.recordedTime = mergedAt
+	if f.recordErr != nil {
+		return domain.PullRequest{}, f.recordErr
+	}
+	f.pr.Merged = true
+	f.pr.Draft = false
+	f.pr.Closed = false
+	f.pr.MergeCommitSHA = mergeCommitSHA
+	f.pr.StateChangedAt = mergedAt
+	return f.pr, nil
+}
+
+type fakeActionLifecycle struct {
+	observations []ports.SCMObservation
+	sessionIDs   []domain.SessionID
+	err          error
+}
+
+func (f *fakeActionLifecycle) ApplySCMObservation(_ context.Context, id domain.SessionID, obs ports.SCMObservation) error {
+	f.sessionIDs = append(f.sessionIDs, id)
+	f.observations = append(f.observations, obs)
+	return f.err
 }
 
 type fakeSCMAction struct {
@@ -43,6 +77,7 @@ func (f *fakeSCMAction) MergePullRequest(_ context.Context, request ports.SCMMer
 func mergeableActionFixture() (domain.PullRequest, *fakeSCMAction) {
 	pr := domain.PullRequest{
 		URL:          "https://github.com/acme/widgets/pull/42",
+		SessionID:    "session-1",
 		Number:       42,
 		Provider:     "github",
 		Host:         "github.com",
@@ -61,7 +96,10 @@ func mergeableActionFixture() (domain.PullRequest, *fakeSCMAction) {
 
 func TestActionServiceMerge_GuardsAndSquashMergesExactHead(t *testing.T) {
 	pr, scm := mergeableActionFixture()
-	svc := NewActionService(ActionDeps{Store: &fakeActionStore{pr: pr, ok: true}, Reader: scm, Merger: scm})
+	store := &fakeActionStore{pr: pr, ok: true}
+	lifecycle := &fakeActionLifecycle{}
+	mergedAt := time.Date(2026, 8, 15, 2, 0, 0, 0, time.UTC)
+	svc := NewActionService(ActionDeps{Store: store, Reader: scm, Merger: scm, Lifecycle: lifecycle, Clock: func() time.Time { return mergedAt }})
 	result, err := svc.Merge(context.Background(), MergeRequest{PRID: "42", PRURL: pr.URL, ExpectedHeadSHA: pr.HeadSHA})
 	if err != nil {
 		t.Fatal(err)
@@ -71,6 +109,51 @@ func TestActionServiceMerge_GuardsAndSquashMergesExactHead(t *testing.T) {
 	}
 	if scm.mergeCalls != 1 || scm.request.ExpectedHeadSHA != pr.HeadSHA || scm.request.Method != ports.SCMMergeSquash {
 		t.Fatalf("request = %#v, calls = %d", scm.request, scm.mergeCalls)
+	}
+	if store.recordCalls != 1 || store.recordedSHA != "merge-sha" || !store.recordedTime.Equal(mergedAt) {
+		t.Fatalf("merge projection = calls %d sha %q time %s", store.recordCalls, store.recordedSHA, store.recordedTime)
+	}
+	if len(lifecycle.observations) != 1 || lifecycle.sessionIDs[0] != pr.SessionID {
+		t.Fatalf("lifecycle projection = sessions %#v observations %#v", lifecycle.sessionIDs, lifecycle.observations)
+	}
+	projected := lifecycle.observations[0]
+	if !projected.PR.Merged || projected.PR.Closed || projected.PR.Draft || projected.PR.MergeCommitSHA != "merge-sha" || !projected.ObservedAt.Equal(mergedAt) {
+		t.Fatalf("projected merged observation = %+v", projected)
+	}
+}
+
+func TestActionServiceMerge_ProjectionFailureDoesNotMisreportProviderMerge(t *testing.T) {
+	pr, scm := mergeableActionFixture()
+	store := &fakeActionStore{pr: pr, ok: true, recordErr: errors.New("disk full")}
+	var logs bytes.Buffer
+	svc := NewActionService(ActionDeps{
+		Store: store, Reader: scm, Merger: scm,
+		Logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	result, err := svc.Merge(context.Background(), MergeRequest{PRID: "42", PRURL: pr.URL, ExpectedHeadSHA: pr.HeadSHA})
+	if err != nil || result.MergeCommitSHA != "merge-sha" {
+		t.Fatalf("provider merge should remain successful: result=%+v err=%v", result, err)
+	}
+	if store.recordCalls != 1 || !bytes.Contains(logs.Bytes(), []byte("durable projection failed")) {
+		t.Fatalf("projection failure was not attempted/logged: calls=%d logs=%q", store.recordCalls, logs.String())
+	}
+}
+
+func TestActionServiceMerge_LifecycleFailureDoesNotMisreportProviderMerge(t *testing.T) {
+	pr, scm := mergeableActionFixture()
+	store := &fakeActionStore{pr: pr, ok: true}
+	lifecycle := &fakeActionLifecycle{err: errors.New("lifecycle unavailable")}
+	var logs bytes.Buffer
+	svc := NewActionService(ActionDeps{
+		Store: store, Reader: scm, Merger: scm, Lifecycle: lifecycle,
+		Logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	result, err := svc.Merge(context.Background(), MergeRequest{PRID: "42", PRURL: pr.URL, ExpectedHeadSHA: pr.HeadSHA})
+	if err != nil || result.MergeCommitSHA != "merge-sha" {
+		t.Fatalf("provider merge should remain successful: result=%+v err=%v", result, err)
+	}
+	if store.recordCalls != 1 || len(lifecycle.observations) != 1 || !bytes.Contains(logs.Bytes(), []byte("lifecycle reaction failed")) {
+		t.Fatalf("lifecycle failure was not attempted/logged: store calls=%d lifecycle calls=%d logs=%q", store.recordCalls, len(lifecycle.observations), logs.String())
 	}
 }
 

--- a/backend/internal/storage/sqlite/gen/pr.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr.sql.go
@@ -131,6 +131,56 @@ func (q *Queries) DeletePRByURL(ctx context.Context, url string) error {
 	return err
 }
 
+const ensureDiscoveredPR = `-- name: EnsureDiscoveredPR :exec
+INSERT INTO pr (
+    url, session_id, number, pr_state, updated_at,
+    provider, host, repo, provider_id, source_branch, target_branch, head_sha, is_draft,
+    auto_inject_ci
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+    COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
+ON CONFLICT (url) DO NOTHING
+`
+
+type EnsureDiscoveredPRParams struct {
+	URL          string
+	SessionID    domain.SessionID
+	Number       int64
+	PRState      domain.PRState
+	UpdatedAt    time.Time
+	Provider     string
+	Host         string
+	Repo         string
+	ProviderID   string
+	SourceBranch string
+	TargetBranch string
+	HeadSha      string
+	IsDraft      int64
+	ID           domain.SessionID
+}
+
+// A repository listing only proves identity plus open/draft lifecycle. It must
+// never replace an authoritative observation already stored for the same URL.
+func (q *Queries) EnsureDiscoveredPR(ctx context.Context, arg EnsureDiscoveredPRParams) error {
+	_, err := q.db.ExecContext(ctx, ensureDiscoveredPR,
+		arg.URL,
+		arg.SessionID,
+		arg.Number,
+		arg.PRState,
+		arg.UpdatedAt,
+		arg.Provider,
+		arg.Host,
+		arg.Repo,
+		arg.ProviderID,
+		arg.SourceBranch,
+		arg.TargetBranch,
+		arg.HeadSha,
+		arg.IsDraft,
+		arg.ID,
+	)
+	return err
+}
+
 const getDisplayPRFactsBySession = `-- name: GetDisplayPRFactsBySession :one
 SELECT
     pr.url,
@@ -639,6 +689,48 @@ type MovePRAliasReviewsParams struct {
 func (q *Queries) MovePRAliasReviews(ctx context.Context, arg MovePRAliasReviewsParams) error {
 	_, err := q.db.ExecContext(ctx, movePRAliasReviews, arg.CanonicalURL, arg.PreviousURL)
 	return err
+}
+
+const recordPRMerge = `-- name: RecordPRMerge :execrows
+UPDATE pr
+SET pr_state = 'merged',
+    state_changed_at = CASE
+        WHEN pr_state = 'merged' AND state_changed_at IS NOT NULL THEN state_changed_at
+        ELSE ?
+    END,
+    updated_at = ?,
+    is_draft = 0,
+    is_merged = 1,
+    is_closed = 0,
+    provider_state = 'merged',
+    merge_commit_sha = ?,
+    merged_at_provider = COALESCE(merged_at_provider, ?)
+WHERE url = ?
+`
+
+type RecordPRMergeParams struct {
+	StateChangedAt   sql.NullTime
+	UpdatedAt        time.Time
+	MergeCommitSha   string
+	MergedAtProvider sql.NullTime
+	URL              string
+}
+
+// A successful provider merge command is authoritative for terminal lifecycle.
+// Preserve CI/review/mergeability and semantic hashes; the observer may later
+// enrich the terminal snapshot without the command path erasing useful facts.
+func (q *Queries) RecordPRMerge(ctx context.Context, arg RecordPRMergeParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, recordPRMerge,
+		arg.StateChangedAt,
+		arg.UpdatedAt,
+		arg.MergeCommitSha,
+		arg.MergedAtProvider,
+		arg.URL,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const repointPRAliases = `-- name: RepointPRAliases :exec

--- a/backend/internal/storage/sqlite/queries/pr.sql
+++ b/backend/internal/storage/sqlite/queries/pr.sql
@@ -59,6 +59,37 @@ ON CONFLICT (url) DO UPDATE SET
     ci_observed_at = excluded.ci_observed_at,
     review_observed_at = excluded.review_observed_at;
 
+-- name: EnsureDiscoveredPR :exec
+-- A repository listing only proves identity plus open/draft lifecycle. It must
+-- never replace an authoritative observation already stored for the same URL.
+INSERT INTO pr (
+    url, session_id, number, pr_state, updated_at,
+    provider, host, repo, provider_id, source_branch, target_branch, head_sha, is_draft,
+    auto_inject_ci
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+    COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
+ON CONFLICT (url) DO NOTHING;
+
+-- name: RecordPRMerge :execrows
+-- A successful provider merge command is authoritative for terminal lifecycle.
+-- Preserve CI/review/mergeability and semantic hashes; the observer may later
+-- enrich the terminal snapshot without the command path erasing useful facts.
+UPDATE pr
+SET pr_state = 'merged',
+    state_changed_at = CASE
+        WHEN pr_state = 'merged' AND state_changed_at IS NOT NULL THEN state_changed_at
+        ELSE ?
+    END,
+    updated_at = ?,
+    is_draft = 0,
+    is_merged = 1,
+    is_closed = 0,
+    provider_state = 'merged',
+    merge_commit_sha = ?,
+    merged_at_provider = COALESCE(merged_at_provider, ?)
+WHERE url = ?;
+
 -- name: UpsertLegacyPR :exec
 INSERT INTO pr (
     url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at,

--- a/backend/internal/storage/sqlite/store/pr_facts_test.go
+++ b/backend/internal/storage/sqlite/store/pr_facts_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -179,5 +180,143 @@ func TestPRStateChangedAtFillsWhenProviderCreatedAtArrives(t *testing.T) {
 	}
 	if !got.StateChangedAt.Equal(createdAt) {
 		t.Fatalf("same-state stateChangedAt = %s, want provider creation time %s", got.StateChangedAt, createdAt)
+	}
+}
+
+func TestEnsureDiscoveredPRIsInsertOnly(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	owner, _ := s.CreateSession(ctx, sampleRecord("mer"))
+	other, _ := s.CreateSession(ctx, sampleRecord("mer"))
+	now := time.Date(2026, 8, 15, 1, 0, 0, 0, time.UTC)
+	url := "https://github.com/new/repo/pull/42"
+	authoritative := domain.PullRequest{
+		URL:          url,
+		SessionID:    owner.ID,
+		Number:       42,
+		CI:           domain.CIPassing,
+		Review:       domain.ReviewApproved,
+		Mergeability: domain.MergeMergeable,
+		UpdatedAt:    now,
+		Provider:     "github",
+		Host:         "github.com",
+		Repo:         "new/repo",
+		ProviderID:   "PR_stable_42",
+		SourceBranch: "feature",
+		TargetBranch: "main",
+		HeadSHA:      "authoritative-sha",
+		Title:        "Authoritative title",
+		MetadataHash: "metadata-hash",
+		CIHash:       "ci-hash",
+		ReviewHash:   "review-hash",
+		ObservedAt:   now,
+		CIObservedAt: now,
+	}
+	if err := s.WriteSCMObservation(ctx, authoritative, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatal(err)
+	}
+	seqBeforeRediscovery, err := s.LatestSeq(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A stale remote alias can list the same canonical URL with only partial
+	// fields. Ensuring that discovery must not downgrade any stored fact.
+	if err := s.EnsureDiscoveredPR(ctx, domain.DiscoveredPullRequest{
+		URL: url, SessionID: owner.ID, Number: 42, UpdatedAt: now.Add(time.Minute),
+		Provider: "github", Host: "github.com", Repo: "old/repo", ProviderID: "PR_stable_42",
+		SourceBranch: "feature", TargetBranch: "main", HeadSHA: "partial-sha",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seqAfterRediscovery, err := s.LatestSeq(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seqAfterRediscovery != seqBeforeRediscovery {
+		t.Fatalf("rediscovery emitted CDC: sequence advanced from %d to %d", seqBeforeRediscovery, seqAfterRediscovery)
+	}
+	got, ok, err := s.GetPR(ctx, url)
+	if err != nil || !ok {
+		t.Fatalf("GetPR: ok=%v err=%v", ok, err)
+	}
+	if got.CI != domain.CIPassing || got.Review != domain.ReviewApproved || got.Mergeability != domain.MergeMergeable {
+		t.Fatalf("discovery downgraded readiness facts: CI=%q review=%q mergeability=%q", got.CI, got.Review, got.Mergeability)
+	}
+	if got.Repo != "new/repo" || got.HeadSHA != "authoritative-sha" || got.Title != "Authoritative title" {
+		t.Fatalf("discovery replaced authoritative metadata: repo=%q sha=%q title=%q", got.Repo, got.HeadSHA, got.Title)
+	}
+	if got.MetadataHash != "metadata-hash" || got.CIHash != "ci-hash" || got.ReviewHash != "review-hash" {
+		t.Fatalf("discovery replaced acknowledgement hashes: metadata=%q ci=%q review=%q", got.MetadataHash, got.CIHash, got.ReviewHash)
+	}
+
+	newURL := "https://github.com/new/repo/pull/43"
+	if err := s.EnsureDiscoveredPR(ctx, domain.DiscoveredPullRequest{
+		URL: newURL, SessionID: owner.ID, Number: 43, Draft: true, UpdatedAt: now,
+		Provider: "github", Host: "github.com", Repo: "new/repo", ProviderID: "PR_stable_43",
+		SourceBranch: "feature/child", TargetBranch: "feature", HeadSHA: "new-sha",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	inserted, ok, err := s.GetPR(ctx, newURL)
+	if err != nil || !ok {
+		t.Fatalf("GetPR(new discovery): ok=%v err=%v", ok, err)
+	}
+	if !inserted.Draft || inserted.ProviderID != "PR_stable_43" || inserted.CI != domain.CIUnknown || inserted.Review != domain.ReviewNone || inserted.Mergeability != domain.MergeUnknown {
+		t.Fatalf("new discovery baseline = %+v", inserted)
+	}
+
+	if err := s.EnsureDiscoveredPR(ctx, domain.DiscoveredPullRequest{
+		URL: url, SessionID: other.ID, Number: 42, UpdatedAt: now,
+	}); err == nil {
+		t.Fatal("discovery must not silently move a PR to another session")
+	}
+}
+
+func TestRecordPRMergeImmediatelyProjectsTerminalState(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	owner, _ := s.CreateSession(ctx, sampleRecord("mer"))
+	observedAt := time.Date(2026, 8, 15, 2, 0, 0, 0, time.UTC)
+	mergedAt := observedAt.Add(time.Minute)
+	url := "https://github.com/acme/repo/pull/44"
+	if err := s.WriteSCMObservation(ctx, domain.PullRequest{
+		URL: url, SessionID: owner.ID, Number: 44, UpdatedAt: observedAt,
+		CI: domain.CIPassing, Review: domain.ReviewApproved, Mergeability: domain.MergeMergeable,
+		Provider: "github", Host: "github.com", Repo: "acme/repo",
+		SourceBranch: "feature", TargetBranch: "main", HeadSHA: "head-sha",
+		MetadataHash: "metadata", CIHash: "ci", ReviewHash: "review",
+	}, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+		t.Fatal(err)
+	}
+	seq, err := s.LatestSeq(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := s.RecordPRMerge(ctx, url, "merge-sha", mergedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !merged.Merged || merged.Closed || merged.Draft || merged.MergeCommitSHA != "merge-sha" {
+		t.Fatalf("terminal projection = %+v", merged)
+	}
+	if !merged.StateChangedAt.Equal(mergedAt) || !merged.MergedAtProvider.Equal(mergedAt) {
+		t.Fatalf("merge timestamps = state %s provider %s, want %s", merged.StateChangedAt, merged.MergedAtProvider, mergedAt)
+	}
+	if merged.CI != domain.CIPassing || merged.Review != domain.ReviewApproved || merged.Mergeability != domain.MergeMergeable {
+		t.Fatalf("terminal projection erased readiness facts: %+v", merged)
+	}
+	if merged.MetadataHash != "metadata" || merged.CIHash != "ci" || merged.ReviewHash != "review" {
+		t.Fatalf("terminal projection erased observer cursors: %+v", merged)
+	}
+	events, err := s.EventsAfter(ctx, seq, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Type != "pr_updated" || !strings.Contains(string(events[0].Payload), `"state":"merged"`) {
+		t.Fatalf("merge CDC events = %+v", events)
 	}
 }

--- a/backend/internal/storage/sqlite/store/pr_store.go
+++ b/backend/internal/storage/sqlite/store/pr_store.go
@@ -24,9 +24,11 @@ import (
 // drift between either interface and this implementation fails here at the point
 // of definition rather than later at the call sites in lifecycle_wiring / tests.
 var (
-	_ ports.PRWriter  = (*Store)(nil)
-	_ ports.SCMWriter = (*Store)(nil)
-	_ ports.PRClaimer = (*Store)(nil)
+	_ ports.PRWriter           = (*Store)(nil)
+	_ ports.SCMWriter          = (*Store)(nil)
+	_ ports.SCMDiscoveryWriter = (*Store)(nil)
+	_ ports.SCMMergeWriter     = (*Store)(nil)
+	_ ports.PRClaimer          = (*Store)(nil)
 )
 
 // WritePR persists a legacy PR observation — scalar facts, check runs, and the
@@ -47,6 +49,88 @@ func (s *Store) WritePR(ctx context.Context, pr domain.PullRequest, checks []dom
 // cadence than metadata/CI polling.
 func (s *Store) WriteSCMObservation(ctx context.Context, pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, reviewMode ports.ReviewWriteMode) error {
 	return s.writePR(ctx, pr, checks, reviews, threads, comments, reviewMode, false)
+}
+
+// EnsureDiscoveredPR inserts the minimal fact produced by repository listing.
+// If the canonical PR URL already exists for this session, its authoritative
+// metadata, CI, review, and mergeability facts remain untouched. Discovery is
+// not a claim operation, so an existing owner mismatch remains an error.
+func (s *Store) EnsureDiscoveredPR(ctx context.Context, pr domain.DiscoveredPullRequest) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.inTx(ctx, "ensure discovered pr", func(q *gen.Queries) error {
+		identity := normalizedPRIdentity(domain.PullRequest{
+			URL: pr.URL, SessionID: pr.SessionID, Provider: pr.Provider,
+			Host: pr.Host, Repo: pr.Repo, ProviderID: pr.ProviderID,
+		})
+		candidates, err := findPRIdentityCandidates(ctx, q, identity)
+		if err != nil {
+			return err
+		}
+		for _, existing := range candidates {
+			if existing.SessionID != pr.SessionID {
+				return fmt.Errorf("pr %s already belongs to session %s", pr.URL, existing.SessionID)
+			}
+		}
+		if len(candidates) != 0 {
+			return nil
+		}
+		state := domain.PRStateOpen
+		if pr.Draft {
+			state = domain.PRStateDraft
+		}
+		return q.EnsureDiscoveredPR(ctx, gen.EnsureDiscoveredPRParams{
+			URL:          pr.URL,
+			SessionID:    pr.SessionID,
+			Number:       int64(pr.Number),
+			PRState:      state,
+			UpdatedAt:    pr.UpdatedAt,
+			Provider:     identity.Provider,
+			Host:         identity.Host,
+			Repo:         identity.Repo,
+			ProviderID:   identity.ProviderID,
+			SourceBranch: pr.SourceBranch,
+			TargetBranch: pr.TargetBranch,
+			HeadSha:      pr.HeadSHA,
+			IsDraft:      boolInt(pr.Draft),
+			ID:           pr.SessionID,
+		})
+	})
+}
+
+// RecordPRMerge projects a successful SCM merge command into the existing PR
+// row and returns the resulting snapshot for lifecycle processing. The update
+// is deliberately narrow: terminal lifecycle and merge metadata change, while
+// CI, review, mergeability, and observer acknowledgement hashes are preserved.
+func (s *Store) RecordPRMerge(ctx context.Context, url, mergeCommitSHA string, mergedAt time.Time) (domain.PullRequest, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	var merged domain.PullRequest
+	err := s.inTx(ctx, "record pr merge", func(q *gen.Queries) error {
+		updated, err := q.RecordPRMerge(ctx, gen.RecordPRMergeParams{
+			StateChangedAt:   nullTime(mergedAt),
+			UpdatedAt:        mergedAt,
+			MergeCommitSha:   mergeCommitSHA,
+			MergedAtProvider: nullTime(mergedAt),
+			URL:              url,
+		})
+		if err != nil {
+			return err
+		}
+		if updated != 1 {
+			return fmt.Errorf("pr %s not found", url)
+		}
+		row, err := q.GetPR(ctx, url)
+		if err != nil {
+			return err
+		}
+		merged = prRowFromGen(row)
+		return nil
+	})
+	if err != nil {
+		return domain.PullRequest{}, err
+	}
+	return merged, nil
 }
 
 // ClaimPR moves (or creates) a PR row to pr.SessionID and applies the live SCM

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -745,6 +745,23 @@ flowchart TD
 
 ```
 
+PR listing and detailed observation have deliberately different persistence
+semantics. A list response proves only that an open or draft PR exists and can
+be attributed to a session, so discovery uses an insert-only baseline write.
+Only a successful detailed provider observation may replace CI, review,
+mergeability, metadata, and semantic acknowledgement hashes. Providers also
+carry the canonical base-repository identity from list responses so repository
+renames or transfers cannot make the same canonical PR URL appear new under a
+redirecting remote alias.
+
+SCM commands use the same durable-facts-first rule. When AO receives a
+successful merge response from a provider, the action service immediately
+projects only the terminal merge facts into SQLite and then runs lifecycle
+reactions. The resulting `pr_updated` change event makes API clients converge
+without waiting for the periodic observer. Provider polling remains the
+reconciliation path for mutations performed outside AO and for rare local
+projection failures.
+
 ### Runtime Reaper
 
 ```mermaid


### PR DESCRIPTION
## Summary
- separate partial PR discovery from authoritative SCM observation writes so repository listings can never erase CI, review, mergeability, metadata, or observer cursors
- identify listed PRs by the provider's canonical base repository and canonical URL, deduplicating stale remotes that redirect after repository transfers
- project successful in-app merges into durable PR state immediately, emit existing CDC, and run lifecycle reactions without waiting for the next poll
- preserve nested GitLab namespace parsing and document the durable-facts-first boundary

## Root cause
The observer used one full-snapshot upsert for two different fact strengths. A lightweight repository listing was treated as if it were an authoritative detailed observation. When both a canonical remote and a stale redirecting remote found the same PR, the partial discovery row overwrote rich readiness facts, producing a temporary **Checking merge readiness** state until the detailed refresh repaired it.

The merge action had the inverse consistency gap: it mutated the provider but did not project that confirmed result locally. Frontend invalidation therefore refetched stale SQLite facts until polling caught up.

## Verification
- `npm run sqlc`
- `cd backend && go build ./...`
- `npm run lint` (all AO runtime environment variables removed so CLI tests exercise their isolated harness)
- focused observer, SQLite store, SCM adapter, PR action service, and daemon tests

## Related issue
Addresses the SCM repository-transfer/discovery portion of #3252. The separate wrapper/PATH work described there is intentionally out of scope.
