### PR TITLE
fix(cli): derive spawn name when omitted

### DIFF
--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -20,6 +20,8 @@ import (
 // daemon's spawn handler so a direct API call is held to the same limit.
 const maxDisplayNameLen = 20
 
+const fallbackSpawnDisplayName = "Untitled task"
+
 type spawnOptions struct {
 	project         string
 	harness         string
@@ -77,10 +79,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 			if opts.noTakeover && opts.claimPR == "" {
 				return usageError{fmt.Errorf("--no-takeover requires --claim-pr")}
 			}
-			name := strings.TrimSpace(opts.name)
-			if name == "" {
-				return usageError{fmt.Errorf("--name is required")}
-			}
+			name := spawnDisplayName(opts.name, opts.prompt, opts.issue)
 			if utf8.RuneCountInString(name) > maxDisplayNameLen {
 				return usageError{fmt.Errorf("--name must be %d characters or fewer", maxDisplayNameLen)}
 			}
@@ -194,11 +193,30 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 	f.StringVar(&opts.prompt, "prompt", "", "Initial prompt for the agent")
 	f.StringVar(&opts.issue, "issue", "", "Issue id to associate with the session")
 	f.StringVar(&opts.trackerProvider, "tracker-provider", "github", "Issue tracker provider: github or gitlab (default: github)")
-	f.StringVar(&opts.name, "name", "", "Display name shown in the sidebar (required, max 20 characters)")
+	f.StringVar(&opts.name, "name", "", "Display name shown in the sidebar (default: prompt or issue, max 20 characters)")
 	f.StringVar(&opts.claimPR, "claim-pr", "", "Immediately claim an existing PR for the spawned session")
 	f.BoolVar(&opts.noTakeover, "no-takeover", false, "Refuse if another active session owns the claimed PR (requires --claim-pr)")
 	f.BoolVar(&opts.skipAgentCheck, "skip-agent-check", false, "Skip advisory agent catalog install/auth preflight before spawning")
 	return cmd
+}
+
+func spawnDisplayName(explicit, prompt, issue string) string {
+	if name := strings.TrimSpace(explicit); name != "" {
+		return name
+	}
+
+	name := strings.Join(strings.Fields(prompt), " ")
+	if name == "" {
+		if issue = strings.Join(strings.Fields(issue), " "); issue != "" {
+			name = "Issue " + issue
+		} else {
+			name = fallbackSpawnDisplayName
+		}
+	}
+	if utf8.RuneCountInString(name) <= maxDisplayNameLen {
+		return name
+	}
+	return strings.TrimSpace(string([]rune(name)[:maxDisplayNameLen]))
 }
 
 func (c *commandContext) fetchAgentInventory(ctx context.Context, refresh bool) (agentInventory, error) {

--- a/backend/internal/cli/spawn_test.go
+++ b/backend/internal/cli/spawn_test.go
@@ -207,12 +207,26 @@ func TestSpawnNoTakeoverRequiresClaimPR(t *testing.T) {
 	}
 }
 
-// TestSpawnCommand_RequiresName asserts `ao spawn` rejects a missing --name
-// without contacting the daemon.
-func TestSpawnCommand_RequiresName(t *testing.T) {
-	_, _, err := executeCLI(t, Deps{}, "spawn", "--project", "demo", "--agent", "codex")
-	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "--name is required") {
-		t.Fatalf("err=%v exit=%d, want --name is required", err, ExitCode(err))
+func TestSpawnDisplayNameFallback(t *testing.T) {
+	tests := []struct {
+		name     string
+		explicit string
+		prompt   string
+		issue    string
+		want     string
+	}{
+		{name: "explicit wins", explicit: "Chosen label", prompt: "ignored", issue: "12", want: "Chosen label"},
+		{name: "prompt", prompt: "  Fix   failing auth tests  ", want: "Fix failing auth tes"},
+		{name: "unicode prompt", prompt: strings.Repeat("界", 21), want: strings.Repeat("界", 20)},
+		{name: "issue", issue: "  3911  ", want: "Issue 3911"},
+		{name: "untitled", want: fallbackSpawnDisplayName},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := spawnDisplayName(tt.explicit, tt.prompt, tt.issue); got != tt.want {
+				t.Fatalf("spawnDisplayName() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -250,7 +264,7 @@ func TestSpawnResolvesProjectFromEnvAndDefaultAgent(t *testing.T) {
 	writeRunFileFor(t, cfg, srv)
 	t.Setenv("AO_PROJECT_ID", "demo")
 
-	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "spawn", "--prompt", "Fix failing tests in auth", "--name", "worker")
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "spawn", "--prompt", "Fix failing tests in auth")
 	if err != nil {
 		t.Fatalf("spawn failed: %v stderr=%s", err, errOut)
 	}
@@ -260,7 +274,7 @@ func TestSpawnResolvesProjectFromEnvAndDefaultAgent(t *testing.T) {
 	if !strings.Contains(out, "[prompt 0 B, system 123 B]") {
 		t.Fatalf("output missing system-only prompt metrics: %s", out)
 	}
-	if req.ProjectID != "demo" || req.Harness != "codex" || req.DisplayName != "worker" {
+	if req.ProjectID != "demo" || req.Harness != "codex" || req.DisplayName != "Fix failing tests in" {
 		t.Fatalf("spawn request = %#v", req)
 	}
 	want := []string{"GET /api/v1/projects/demo", "POST /api/v1/agents/refresh", "POST /api/v1/sessions"}
@@ -836,9 +850,6 @@ func TestSpawnUnknownAuthRefreshesWarnsAndAllows(t *testing.T) {
 // TestSpawnCommand_RejectsInvalidKind asserts `ao spawn` rejects a --kind value
 // outside worker/orchestrator at the CLI boundary, without contacting the daemon.
 func TestSpawnCommand_RejectsInvalidKind(t *testing.T) {
-	// Pass a valid --name so this exercises the --kind boundary specifically:
-	// spawn validates the required --name before --kind, so omitting it would
-	// trip the "--name is required" error instead of the kind error.
 	_, _, err := executeCLI(t, Deps{}, "spawn", "--project", "demo", "--name", "orch", "--kind", "orchestartor")
 	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), `--kind must be "worker" or "orchestrator"`) {
 		t.Fatalf("err=%v exit=%d, want --kind validation error", err, ExitCode(err))

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -3380,7 +3380,7 @@ func TestSpawnOrchestrator_UsesCoordinatorPrompt(t *testing.T) {
 	for _, want := range []string{
 		"You are the human-facing orchestrator for project mer",
 		`ao spawn --project mer --name "<label>" --prompt "<clear worker task>"`,
-		"Before running `ao spawn`, count the `--name` label yourself",
+		"If omitted, AO derives a concise label from the prompt or issue",
 		"coordination-only by default",
 		"always spawn or redirect a worker session",
 		"Never edit source files, resolve merge conflicts, run implementation-focused changes",

--- a/backend/internal/session_manager/prompt.go
+++ b/backend/internal/session_manager/prompt.go
@@ -189,8 +189,7 @@ Your job is to coordinate work, not to perform implementation. Keep the project 
 - `+"`ao session get <worker-session-id>`"+` - inspect a worker session's details.
 - `+"`ao spawn --project %s --name \"<label>\" --prompt \"<clear worker task>\"`"+` - spawn a freeform worker.
 - `+"`ao spawn --project %s --name \"<label>\" --issue <issue-id>`"+` - spawn a worker for an issue.
-- `+"`--name`"+` is required: a deliberate sidebar label so the user can see what each worker is working on at a glance; labels must be 20 characters or fewer.
-- Before running `+"`ao spawn`"+`, count the `+"`--name`"+` label yourself. It must be 20 characters or fewer. If your first label is longer, shorten it before executing the command.
+- `+"`--name`"+` is recommended as a deliberate sidebar label and must be 20 characters or fewer. If omitted, AO derives a concise label from the prompt or issue.
 - Add `+"`--agent <name>`"+` when a worker must use a specific agent.
 - `+"`ao send --session <session-id> --message \"<message>\"`"+` - message a worker.
 - `+"`ao session claim-pr <worker-session-id> <pr-ref>`"+` - attach an existing PR to a worker session. Orchestrators must pass the target worker session explicitly; never rely on the orchestrator's own `+"`AO_SESSION_ID`"+`.


### PR DESCRIPTION
## Summary
- derive an omitted `ao spawn --name` from the normalized prompt
- fall back to `Issue <id>` or `Untitled task` when no prompt is available
- preserve explicit-name validation and Unicode-safe 20-character truncation
- update orchestrator guidance so an omitted label no longer blocks delegation

Fixes #3911
Refs #3873

## Tests
- `cd backend && env -u AO_SESSION_ID -u AO_PROJECT_ID go test ./internal/cli ./internal/session_manager`

## Risk
Low. Explicit names retain their existing validation; only the previously rejected omitted-name path changes.
