### PR TITLE
fix(telemetry): classify renderer spawn failures

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -60,6 +60,11 @@ The GitHub owner segment described under "What AO sends" is the one
 GitHub-derived value AO does send. It is limited to the owning
 organization or account and never includes the repository, path, or URL.
 
+When an orchestrator spawn fails, the renderer reports only the daemon's fixed
+error kind and stable error code, or a renderer-owned `network_error` or
+`invalid_response` kind when no daemon error envelope exists. Raw error messages
+are not sent with this event.
+
 The optional website waitlist is separate from product telemetry. If you submit
 an email address there, it is used to manage that waitlist as described in the
 [privacy policy](https://aoagents.dev/privacy).

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -50,6 +50,10 @@ vi.mock("../lib/api-client", () => ({
 		typeof error === "object" && error !== null && "code" in error
 			? String((error as { code: unknown }).code)
 			: undefined,
+	apiErrorKind: (error: unknown) =>
+		typeof error === "object" && error !== null && "error" in error
+			? String((error as { error: unknown }).error)
+			: undefined,
 	apiErrorRequestId: (error: unknown) =>
 		typeof error === "object" && error !== null && "requestId" in error
 			? String((error as { requestId: unknown }).requestId)

--- a/frontend/src/renderer/lib/api-client.test.ts
+++ b/frontend/src/renderer/lib/api-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	apiClient,
+	apiErrorKind,
 	apiErrorMessage,
 	getApiBaseUrl,
 	hasTrustedApiBaseUrl,
@@ -324,6 +325,11 @@ describe("api error telemetry", () => {
 });
 
 describe("apiErrorMessage", () => {
+	it("reads the semantic kind from a daemon error envelope", () => {
+		expect(apiErrorKind({ error: "conflict", code: "BRANCH_CHECKED_OUT_ELSEWHERE" })).toBe("conflict");
+		expect(apiErrorKind({ error: 409 })).toBeUndefined();
+	});
+
 	it("preserves daemon error codes next to human messages", () => {
 		expect(apiErrorMessage({ code: "AGENT_BINARY_NOT_FOUND", message: "agent binary not found on PATH" })).toBe(
 			"agent binary not found on PATH (AGENT_BINARY_NOT_FOUND)",

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -272,6 +272,15 @@ export function apiErrorCode(error: unknown): string | undefined {
 	return undefined;
 }
 
+/** Semantic kind from the daemon's stable error envelope. */
+export function apiErrorKind(error: unknown): string | undefined {
+	if (typeof error === "object" && error !== null) {
+		const body = error as { error?: unknown };
+		if (typeof body.error === "string" && body.error !== "") return body.error;
+	}
+	return undefined;
+}
+
 /** Correlation id from the daemon's stable error envelope. */
 export function apiErrorRequestId(error: unknown): string | undefined {
 	if (typeof error === "object" && error !== null) {

--- a/frontend/src/renderer/lib/spawn-orchestrator.test.ts
+++ b/frontend/src/renderer/lib/spawn-orchestrator.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { isChatPreflightError, OrchestratorSpawnError, spawnOrchestrator } from "./spawn-orchestrator";
+import {
+	isChatPreflightError,
+	OrchestratorSpawnError,
+	orchestratorSpawnFailureReason,
+	spawnOrchestrator,
+} from "./spawn-orchestrator";
 import { apiClient } from "./api-client";
 import { captureRendererEvent } from "./telemetry";
 
@@ -8,6 +13,10 @@ vi.mock("./api-client", () => ({
 	apiErrorCode: (error: unknown) =>
 		typeof error === "object" && error !== null && "code" in error
 			? String((error as { code: unknown }).code)
+			: undefined,
+	apiErrorKind: (error: unknown) =>
+		typeof error === "object" && error !== null && "error" in error
+			? String((error as { error: unknown }).error)
 			: undefined,
 	apiErrorRequestId: (error: unknown) =>
 		typeof error === "object" && error !== null && "requestId" in error
@@ -91,13 +100,15 @@ describe("spawnOrchestrator", () => {
 	it("emits the failed event and rethrows when the daemon rejects the spawn", async () => {
 		(apiClient.POST as ReturnType<typeof vi.fn>).mockResolvedValue({
 			data: undefined,
-			error: { message: "boom" },
+			error: { error: "internal", code: "SPAWN_INTERNAL", message: "boom" },
 			response: { status: 500 },
 		});
 		await expect(spawnOrchestrator("proj", "topbar")).rejects.toThrow("boom");
 		expect(captureMock).toHaveBeenCalledWith("ao.renderer.orchestrator_spawn_failed", {
 			project_id: "proj",
 			source: "topbar",
+			error_kind: "internal",
+			error_code: "SPAWN_INTERNAL",
 		});
 		expect(captureMock).not.toHaveBeenCalledWith("ao.renderer.orchestrator_spawn_succeeded", expect.anything());
 	});
@@ -106,6 +117,7 @@ describe("spawnOrchestrator", () => {
 		(apiClient.POST as ReturnType<typeof vi.fn>).mockResolvedValue({
 			data: undefined,
 			error: {
+				error: "bad_request",
 				code: "CHAT_DRIVER_UNAVAILABLE",
 				message: "chat driver is unavailable",
 				requestId: "request-42",
@@ -117,10 +129,30 @@ describe("spawnOrchestrator", () => {
 		expect(error).toBeInstanceOf(OrchestratorSpawnError);
 		expect(error).toMatchObject({
 			code: "CHAT_DRIVER_UNAVAILABLE",
+			kind: "bad_request",
 			requestId: "request-42",
 			status: 400,
 		});
 		expect((error as Error).message).toBe("chat driver is unavailable (CHAT_DRIVER_UNAVAILABLE)");
 		expect(isChatPreflightError(error)).toBe(true);
+	});
+
+	it("classifies transport failures without emitting raw error text", async () => {
+		(apiClient.POST as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("dial /Users/alice/private"));
+
+		await expect(spawnOrchestrator("proj", "board")).rejects.toThrow("dial");
+		expect(captureMock).toHaveBeenCalledWith("ao.renderer.orchestrator_spawn_failed", {
+			project_id: "proj",
+			source: "board",
+			error_kind: "network_error",
+		});
+	});
+
+	it("falls back to the HTTP status when an older daemon omits error kind", () => {
+		const error = new OrchestratorSpawnError("conflict", "BRANCH_CHECKED_OUT_ELSEWHERE", undefined, 409);
+		expect(orchestratorSpawnFailureReason(error)).toEqual({
+			error_kind: "conflict",
+			error_code: "BRANCH_CHECKED_OUT_ELSEWHERE",
+		});
 	});
 });

--- a/frontend/src/renderer/lib/spawn-orchestrator.ts
+++ b/frontend/src/renderer/lib/spawn-orchestrator.ts
@@ -1,4 +1,4 @@
-import { apiClient, apiErrorCode, apiErrorMessage, apiErrorRequestId } from "./api-client";
+import { apiClient, apiErrorCode, apiErrorKind, apiErrorMessage, apiErrorRequestId } from "./api-client";
 import type { OrchestratorSpawnSource } from "./orchestrator-spawn-sources";
 import { captureRendererEvent } from "./telemetry";
 import type { SessionMode } from "../types/conversation";
@@ -17,6 +17,20 @@ const CHAT_PREFLIGHT_CODES = new Set([
 	"CHAT_AUTH_REQUIRED",
 ]);
 
+const SPAWN_ERROR_KINDS = new Set([
+	"bad_request",
+	"not_found",
+	"conflict",
+	"forbidden",
+	"internal",
+	"not_implemented",
+]);
+
+export type OrchestratorSpawnFailureReason = {
+	error_kind: string;
+	error_code?: string;
+};
+
 /** A rejected orchestrator spawn without flattening the daemon's error envelope. */
 export class OrchestratorSpawnError extends Error {
 	constructor(
@@ -24,10 +38,24 @@ export class OrchestratorSpawnError extends Error {
 		readonly code?: string,
 		readonly requestId?: string,
 		readonly status?: number,
+		readonly kind?: string,
 	) {
 		super(message);
 		this.name = "OrchestratorSpawnError";
 	}
+}
+
+export function orchestratorSpawnFailureReason(error: unknown): OrchestratorSpawnFailureReason {
+	if (!(error instanceof OrchestratorSpawnError)) return { error_kind: "network_error" };
+	const errorCode = error.code?.trim();
+	const withCode = errorCode ? { error_code: errorCode } : {};
+	if (error.kind && SPAWN_ERROR_KINDS.has(error.kind)) return { error_kind: error.kind, ...withCode };
+	if (error.status === 400) return { error_kind: "bad_request", ...withCode };
+	if (error.status === 403) return { error_kind: "forbidden", ...withCode };
+	if (error.status === 404) return { error_kind: "not_found", ...withCode };
+	if (error.status === 409) return { error_kind: "conflict", ...withCode };
+	if (error.status && error.status >= 500) return { error_kind: "internal", ...withCode };
+	return { error_kind: "invalid_response", ...withCode };
 }
 
 export function isChatPreflightCode(code?: string): boolean {
@@ -62,13 +90,18 @@ export async function spawnOrchestrator(
 				apiErrorCode(error),
 				apiErrorRequestId(error),
 				response.status,
+				apiErrorKind(error),
 			);
 		}
 
 		void captureRendererEvent("ao.renderer.orchestrator_spawn_succeeded", { project_id: projectId, source });
 		return data.orchestrator.id;
 	} catch (err) {
-		void captureRendererEvent("ao.renderer.orchestrator_spawn_failed", { project_id: projectId, source });
+		void captureRendererEvent("ao.renderer.orchestrator_spawn_failed", {
+			project_id: projectId,
+			source,
+			...orchestratorSpawnFailureReason(err),
+		});
 		throw err;
 	}
 }

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -385,7 +385,7 @@ describe("telemetry sanitizers", () => {
 		}
 	});
 
-	it("keeps only the source enum on orchestrator_spawn events", async () => {
+	it("keeps source and typed reasons on orchestrator_spawn events", async () => {
 		const props = await sanitizeRendererProperties("ao.renderer.orchestrator_spawn_requested", {
 			project_id: "demo-project",
 			source: "board",
@@ -396,8 +396,19 @@ describe("telemetry sanitizers", () => {
 		const badSource = await sanitizeRendererProperties("ao.renderer.orchestrator_spawn_failed", {
 			project_id: "demo-project",
 			source: "/Users/alice/private",
+			error_kind: "internal",
+			error_code: "SPAWN_INTERNAL",
+			message: "raw error with /Users/alice/private",
 		});
 		expect(badSource).not.toHaveProperty("source");
+		expect(badSource).toMatchObject({ error_kind: "internal", error_code: "SPAWN_INTERNAL" });
+		expect(badSource).not.toHaveProperty("message");
+
+		const unsafeReason = await sanitizeRendererProperties("ao.renderer.orchestrator_spawn_failed", {
+			error_kind: "/Users/alice/private",
+			error_code: "raw user text",
+		});
+		expect(unsafeReason).toEqual({});
 	});
 
 	it("keeps every whitelisted spawn source (the shared ORCHESTRATOR_SPAWN_SOURCES list)", async () => {

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -441,6 +441,17 @@ async function sanitizeRendererContextProperties(properties?: TelemetryPropertie
 }
 
 const ORCHESTRATOR_SPAWN_SOURCE_SET = new Set<string>(ORCHESTRATOR_SPAWN_SOURCES);
+const ORCHESTRATOR_SPAWN_ERROR_KIND_SET = new Set([
+	"bad_request",
+	"not_found",
+	"conflict",
+	"forbidden",
+	"internal",
+	"not_implemented",
+	"network_error",
+	"invalid_response",
+]);
+const TELEMETRY_ERROR_CODE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
 
 const EDITOR_ID_SET = new Set<string>(EDITOR_IDS);
 const OPEN_TARGET_KIND_SET = new Set(["editor", "file_manager", "terminal"]);
@@ -485,6 +496,20 @@ export async function sanitizeRendererProperties(
 			if (projectIDHash) safe.project_id_hash = projectIDHash;
 			if (typeof properties?.source === "string" && ORCHESTRATOR_SPAWN_SOURCE_SET.has(properties.source)) {
 				safe.source = properties.source;
+			}
+			if (
+				event === "ao.renderer.orchestrator_spawn_failed" &&
+				typeof properties?.error_kind === "string" &&
+				ORCHESTRATOR_SPAWN_ERROR_KIND_SET.has(properties.error_kind)
+			) {
+				safe.error_kind = properties.error_kind;
+			}
+			if (
+				event === "ao.renderer.orchestrator_spawn_failed" &&
+				typeof properties?.error_code === "string" &&
+				TELEMETRY_ERROR_CODE_PATTERN.test(properties.error_code)
+			) {
+				safe.error_code = properties.error_code;
 			}
 			break;
 		}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -26,13 +26,14 @@ import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useOpenShellTerminal } from "../hooks/useShellTerminals";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
-import { apiClient, apiErrorCode, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
+import { apiClient, apiErrorCode, apiErrorKind, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { refreshDaemonStatus } from "../lib/daemon-status";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
 import { ShellProvider } from "../lib/shell-context";
 import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { captureOrchestratorReplacementFailure } from "../lib/orchestrator-replacement-telemetry";
+import { OrchestratorSpawnError, orchestratorSpawnFailureReason } from "../lib/spawn-orchestrator";
 import { applyDocumentTheme, applyDocumentThemeStyle } from "../lib/theme";
 import { aoBridge } from "../lib/bridge";
 import { handleModifierLinkClick } from "../lib/external-link-policy";
@@ -330,7 +331,13 @@ function ShellLayout() {
 					const message = spawnError
 						? apiErrorMessage(spawnError, `Failed to spawn orchestrator (${spawnResponse.status})`)
 						: `Failed to spawn orchestrator (${spawnResponse.status})`;
-					throw new Error(message);
+					throw new OrchestratorSpawnError(
+						message,
+						apiErrorCode(spawnError),
+						undefined,
+						spawnResponse.status,
+						apiErrorKind(spawnError),
+					);
 				}
 				void captureRendererEvent("ao.renderer.orchestrator_spawn_succeeded", {
 					project_id: workspace.id,
@@ -346,6 +353,7 @@ function ShellLayout() {
 				void captureRendererEvent("ao.renderer.orchestrator_spawn_failed", {
 					project_id: workspace.id,
 					source,
+					...orchestratorSpawnFailureReason(spawnError),
 				});
 				void navigate({ to: "/projects/$projectId", params: { projectId: workspace.id } });
 				const message = spawnError instanceof Error ? spawnError.message : "Could not start orchestrator";


### PR DESCRIPTION
## Summary
- attach the daemon's structured `error_kind` and stable `error_code` to `ao.renderer.orchestrator_spawn_failed`
- classify transport failures as `network_error` and malformed successful responses as `invalid_response`
- cover both shared orchestrator launchers and the direct project-add spawn path
- strictly allowlist kinds and uppercase machine codes so raw messages, paths, and request IDs cannot reach telemetry

Fixes #3944
Refs #3873

## Tests
- `npm --prefix frontend test -- --run src/renderer/lib/api-client.test.ts src/renderer/lib/spawn-orchestrator.test.ts src/renderer/lib/telemetry.test.ts`
- `npm run frontend:typecheck`

## Risk
Low. The API request and user-facing errors are unchanged; only sanitized event properties are added.
