### PR TITLE
fix(spawn): recover missing branch refs

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/commands.go
+++ b/backend/internal/adapters/workspace/gitworktree/commands.go
@@ -1,7 +1,5 @@
 package gitworktree
 
-import "strings"
-
 func checkRefFormatBranchArgs(repo, branch string) []string {
 	return []string{"-C", repo, "check-ref-format", "--branch", branch}
 }
@@ -134,16 +132,4 @@ func cherryPickNoCommitArgs(worktree, commitSHA string) []string {
 // ignoredCountArgs lists files skipped because of .gitignore (dry-run, no mutation).
 func ignoredCountArgs(worktree string) []string {
 	return []string{"-C", worktree, "status", "--ignored", "--porcelain"}
-}
-
-func configuredBaseRefCandidates(defaultBranch string) []string {
-	if strings.Contains(defaultBranch, "/") {
-		// A qualified default ("upstream/main") is used verbatim; git's refname
-		// disambiguation already falls back to refs/heads/<defaultBranch>.
-		return []string{defaultBranch}
-	}
-	// The local head comes after origin/<defaultBranch> so remote-tracking
-	// still wins when present, but a remoteless repo can base new branches
-	// on its local default branch instead of failing BRANCH_NOT_FETCHED.
-	return []string{"origin/" + defaultBranch, "refs/heads/" + defaultBranch}
 }

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -306,6 +306,9 @@ func (w *Workspace) CreateWorkspaceProject(ctx context.Context, cfg ports.Worksp
 		}
 		refs, err := w.resolveWorktreeRefs(ctx, remoteCtx, repos[i].repoPath, branch, repos[i].baseBranch)
 		if err != nil {
+			if errors.Is(err, errNoBaseRef) {
+				return ports.WorkspaceProjectInfo{}, branchNotFetchedError(branch, err)
+			}
 			return ports.WorkspaceProjectInfo{}, fmt.Errorf("gitworktree: resolve workspace repo %q base: %w", repos[i].name, err)
 		}
 		repos[i].seedRef = refs.seedRef
@@ -977,7 +980,10 @@ func (w *Workspace) addWorktree(ctx context.Context, repo, path, branch, baseBra
 		return "", err
 	}
 	if conflict, ok := findWorktreeByBranch(records, branch); ok && filepath.Clean(conflict.Path) != filepath.Clean(path) {
-		return "", fmt.Errorf("%w: %q is checked out at %q", ErrBranchCheckedOutElsewhere, branch, conflict.Path)
+		return "", fmt.Errorf(
+			"%w: %q is checked out at %q; use that worktree, choose another branch, or preserve its changes and run `git worktree remove -- %q` before retrying",
+			ErrBranchCheckedOutElsewhere, branch, conflict.Path, conflict.Path,
+		)
 	}
 	// A registration at path whose directory is gone makes a plain add fail
 	// ("is a missing but already registered worktree; use 'add -f' to
@@ -1002,7 +1008,7 @@ func (w *Workspace) addWorktree(ctx context.Context, repo, path, branch, baseBra
 			refs, err := w.resolveWorktreeRefsWithBudget(ctx, repo, branch, baseBranch)
 			if err != nil {
 				if errors.Is(err, errNoBaseRef) {
-					return "", fmt.Errorf("%w: %q has no local head, no remote, and no tag — run `git fetch` then retry", ErrBranchNotFetched, branch)
+					return "", branchNotFetchedError(branch, err)
 				}
 				return "", err
 			}
@@ -1018,7 +1024,7 @@ func (w *Workspace) addWorktree(ctx context.Context, repo, path, branch, baseBra
 		err = resolveErr
 		if err != nil {
 			if errors.Is(err, errNoBaseRef) {
-				return "", fmt.Errorf("%w: %q has no local head, no remote, and no tag — run `git fetch` then retry", ErrBranchNotFetched, branch)
+				return "", branchNotFetchedError(branch, err)
 			}
 			return "", err
 		}
@@ -1240,7 +1246,7 @@ func (w *Workspace) revParse(ctx context.Context, repo, ref string) (string, err
 
 func (w *Workspace) validateBranch(ctx context.Context, repo, branch string) error {
 	if _, err := w.run(ctx, w.binary, checkRefFormatBranchArgs(repo, branch)...); err != nil {
-		return fmt.Errorf("%w: %q (%w)", ErrBranchInvalid, branch, err)
+		return fmt.Errorf("%w: %q is not accepted by `git check-ref-format --branch`; choose a valid branch name", ErrBranchInvalid, branch)
 	}
 	return nil
 }
@@ -1259,7 +1265,7 @@ type worktreeRefs struct {
 
 func (w *Workspace) resolveWorktreeRefs(ctx, remoteCtx context.Context, repo, branch, baseBranch string) (worktreeRefs, error) {
 	if strings.TrimSpace(baseBranch) != "" {
-		return w.resolveWorktreeRefsFromDefault(ctx, repo, branch, baseBranch)
+		return w.resolveWorktreeRefsFromDefault(ctx, remoteCtx, repo, branch, baseBranch)
 	}
 	resolver := gitdefault.New(w.binary, gitdefault.Runner(w.run))
 	remote, requestedRef, requestedExists, requestedErr := resolver.FindCachedRemoteBranch(ctx, repo, branch)
@@ -1274,6 +1280,14 @@ func (w *Workspace) resolveWorktreeRefs(ctx, remoteCtx context.Context, repo, br
 			// ref in this case, so preserve the legacy fallback to that branch.
 			if requestedExists {
 				return worktreeRefs{seedRef: requestedRef, baseRef: requestedRef}, nil
+			}
+			// The remote may expose the explicitly requested branch without a
+			// symbolic HEAD. Fetching that exact ref is safe and gives AO a usable
+			// seed even though no authoritative comparison base is available.
+			if remote != "" {
+				if _, fetchErr := w.run(remoteCtx, w.binary, fetchBranchArgs(repo, remote, branch)...); fetchErr == nil {
+					return worktreeRefs{seedRef: requestedRef, baseRef: requestedRef}, nil
+				}
 			}
 			return worktreeRefs{}, fmt.Errorf(
 				"%w: %s; configure this repository's primary remote and cached HEAD (for example, `git -C %q remote set-head <remote> <branch>`) and retry",
@@ -1313,13 +1327,68 @@ func (w *Workspace) resolveWorktreeRefsWithBudget(ctx context.Context, repo, bra
 	return w.resolveWorktreeRefs(ctx, remoteCtx, repo, branch, baseBranch)
 }
 
-func (w *Workspace) resolveWorktreeRefsFromDefault(ctx context.Context, repo, branch, defaultBranch string) (worktreeRefs, error) {
-	requestedRef := "origin/" + branch
-	requestedExists, err := w.refExists(ctx, repo, requestedRef)
+func (w *Workspace) resolveWorktreeRefsFromDefault(ctx, remoteCtx context.Context, repo, branch, defaultBranch string) (worktreeRefs, error) {
+	target, err := w.ResolveDefaultBranch(ctx, repo, defaultBranch)
 	if err != nil {
 		return worktreeRefs{}, err
 	}
-	baseCandidates := configuredBaseRefCandidates(defaultBranch)
+	refs, err := w.resolveCachedWorktreeRefsFromDefault(ctx, repo, branch, defaultBranch, target)
+	if !errors.Is(err, errNoBaseRef) {
+		return refs, err
+	}
+	initialErr := err
+
+	var fetchErrs []error
+	branches := []string{target.Branch, branch}
+	for i, candidate := range branches {
+		if target.Remote == "" || candidate == "" || (i > 0 && candidate == branches[0]) {
+			continue
+		}
+		if _, fetchErr := w.run(remoteCtx, w.binary, fetchBranchArgs(repo, target.Remote, candidate)...); fetchErr != nil {
+			fetchErrs = append(fetchErrs, fmt.Errorf("fetch %s/%s: %w", target.Remote, candidate, fetchErr))
+			if remoteCtx.Err() != nil {
+				return worktreeRefs{}, errors.Join(initialErr, remoteCtx.Err())
+			}
+		}
+	}
+	refs, retryErr := w.resolveCachedWorktreeRefsFromDefault(ctx, repo, branch, defaultBranch, target)
+	if retryErr == nil {
+		return refs, nil
+	}
+	if !errors.Is(retryErr, errNoBaseRef) {
+		return worktreeRefs{}, retryErr
+	}
+	if len(fetchErrs) == 0 {
+		return worktreeRefs{}, retryErr
+	}
+	return worktreeRefs{}, fmt.Errorf("%w: automatic fetch failed: %w", retryErr, errors.Join(fetchErrs...))
+}
+
+func (w *Workspace) resolveCachedWorktreeRefsFromDefault(
+	ctx context.Context,
+	repo, branch, defaultBranch string,
+	target ports.WorkspaceDefaultBranch,
+) (worktreeRefs, error) {
+	requestedRef := ""
+	if target.Remote != "" {
+		requestedRef = "refs/remotes/" + target.Remote + "/" + branch
+	}
+	requestedExists := false
+	if requestedRef != "" {
+		var err error
+		requestedExists, err = w.refExists(ctx, repo, requestedRef)
+		if err != nil {
+			return worktreeRefs{}, err
+		}
+	}
+	baseCandidates := []string{target.BaseRef}
+	// ResolveDefaultBranch leaves slash-containing names intact unless their
+	// prefix matches a configured remote. Only an unqualified branch gets the
+	// local-head fallback; this avoids confusing a literal branch such as
+	// release/2026 with a remote-qualified ref.
+	if target.Branch == defaultBranch {
+		baseCandidates = append(baseCandidates, "refs/heads/"+defaultBranch)
+	}
 	for _, ref := range baseCandidates {
 		exists, err := w.refExists(ctx, repo, ref)
 		if err != nil {
@@ -1353,9 +1422,19 @@ func (w *Workspace) resolveWorktreeRefsFromDefault(ctx context.Context, repo, br
 			return worktreeRefs{seedRef: ref, baseRef: ref}, nil
 		}
 	}
-	allCandidates := append([]string{requestedRef}, baseCandidates...)
+	allCandidates := append([]string(nil), baseCandidates...)
+	if requestedRef != "" {
+		allCandidates = append([]string{requestedRef}, allCandidates...)
+	}
 	allCandidates = append(allCandidates, fallbackCandidates...)
 	return worktreeRefs{}, fmt.Errorf("%w for branch %q (tried %s)", errNoBaseRef, branch, strings.Join(allCandidates, ", "))
+}
+
+func branchNotFetchedError(branch string, cause error) error {
+	return fmt.Errorf(
+		"%w: %q is unavailable after AO tried the selected remote and configured default branch; fetch it manually, then retry: %w",
+		ErrBranchNotFetched, branch, cause,
+	)
 }
 
 func (w *Workspace) refExists(ctx context.Context, repo, ref string) (bool, error) {

--- a/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
@@ -568,6 +568,58 @@ func TestWorkspaceIntegrationAutoUsesRequestedRemoteBranchWithoutRemoteHead(t *t
 	}
 }
 
+func TestWorkspaceIntegrationCreateFetchesMissingSlashDefaultFromPrimaryRemote(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, filepath.Join(tmp, "source"))
+	origin := gitOutput(t, git, repo, "remote", "get-url", "origin")
+	defaultBranch := "release/2026"
+	sessionBranch := "ao/proj-session"
+
+	publisher := filepath.Join(tmp, "publisher")
+	run(t, git, "clone", origin, publisher)
+	runGit(t, git, publisher, "config", "user.email", "ao@example.com")
+	runGit(t, git, publisher, "config", "user.name", "Ao Agents")
+	runGit(t, git, publisher, "checkout", "-b", defaultBranch)
+	if err := os.WriteFile(filepath.Join(publisher, "remote.txt"), []byte("remote branch\n"), 0o644); err != nil {
+		t.Fatalf("write remote branch file: %v", err)
+	}
+	runGit(t, git, publisher, "add", "remote.txt")
+	runGit(t, git, publisher, "commit", "-m", "remote branch")
+	runGit(t, git, publisher, "push", "origin", defaultBranch)
+
+	if err := exec.Command(git, "-C", repo, "show-ref", "--verify", "--quiet", "refs/remotes/origin/"+defaultBranch).Run(); err == nil {
+		t.Fatalf("test setup unexpectedly fetched origin/%s", defaultBranch)
+	}
+
+	ws, err := New(Options{
+		Binary:       git,
+		ManagedRoot:  filepath.Join(tmp, "managed"),
+		RepoResolver: StaticRepoResolver{"proj": repo},
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	info, err := ws.Create(context.Background(), ports.WorkspaceConfig{
+		ProjectID:  "proj",
+		SessionID:  "sess",
+		Branch:     sessionBranch,
+		BaseBranch: defaultBranch,
+	})
+	if err != nil {
+		t.Fatalf("create from unfetched slash default branch: %v", err)
+	}
+	if info.BaseRef != "refs/remotes/origin/"+defaultBranch {
+		t.Fatalf("base ref = %q, want origin slash branch", info.BaseRef)
+	}
+	if _, err := os.Stat(filepath.Join(info.Path, "remote.txt")); err != nil {
+		t.Fatalf("fetched remote branch file missing: %v", err)
+	}
+	if err := ws.Destroy(context.Background(), info); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+}
+
 func TestWorkspaceIntegrationRequestedRemoteBranchKeepsDefaultComparisonBase(t *testing.T) {
 	git := requireGit(t)
 	for _, tc := range []struct {
@@ -576,7 +628,7 @@ func TestWorkspaceIntegrationRequestedRemoteBranchKeepsDefaultComparisonBase(t *
 		wantBaseRef string
 	}{
 		{name: "automatic default", wantBaseRef: "refs/remotes/origin/main"},
-		{name: "explicit default", baseBranch: "main", wantBaseRef: "origin/main"},
+		{name: "explicit default", baseBranch: "main", wantBaseRef: "refs/remotes/origin/main"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tmp := t.TempDir()

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -51,20 +51,6 @@ func TestCommandArgs(t *testing.T) {
 	}
 }
 
-func TestConfiguredBaseRefCandidates(t *testing.T) {
-	got := configuredBaseRefCandidates("main")
-	want := []string{"origin/main", "refs/heads/main"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("candidates = %#v, want %#v", got, want)
-	}
-
-	got = configuredBaseRefCandidates("upstream/main")
-	want = []string{"upstream/main"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("qualified candidates = %#v, want %#v", got, want)
-	}
-}
-
 func TestParseWorktreePorcelain(t *testing.T) {
 	input := strings.Join([]string{
 		"worktree /repo",
@@ -993,6 +979,9 @@ func TestAddWorktreeRefusesBranchCheckedOutElsewhere(t *testing.T) {
 	if !strings.Contains(err.Error(), strconv.Quote(otherPath)) {
 		t.Fatalf("err = %v, want message to include conflicting path %q", err, otherPath)
 	}
+	if !strings.Contains(err.Error(), "git worktree remove --") {
+		t.Fatalf("err = %v, want a precise worktree remedy", err)
+	}
 }
 
 // TestCreateRejectsInvalidBranchName covers the residual of #152 Bug 3: a branch
@@ -1021,6 +1010,9 @@ func TestCreateRejectsInvalidBranchName(t *testing.T) {
 	if !strings.Contains(err.Error(), "bad branch!!") {
 		t.Fatalf("err = %v, want message to include the rejected branch name", err)
 	}
+	if !strings.Contains(err.Error(), "git check-ref-format --branch") {
+		t.Fatalf("err = %v, want valid-branch remediation", err)
+	}
 }
 
 // TestAddWorktreeReportsBranchNotFetched covers Bug 3 (b): if no local head,
@@ -1043,6 +1035,12 @@ func TestAddWorktreeReportsBranchNotFetched(t *testing.T) {
 			return nil, nil
 		case strings.Contains(joined, "worktree list --porcelain"):
 			return nil, nil
+		case strings.HasSuffix(joined, " remote"):
+			return []byte("origin\n"), nil
+		case strings.Contains(joined, "config --get checkout.defaultRemote"):
+			return nil, commandError{args: args, err: exitOne}
+		case strings.Contains(joined, " fetch "):
+			return nil, commandError{args: args, err: exitOne}
 		case strings.Contains(joined, "rev-parse"):
 			return nil, commandError{args: args, err: exitOne}
 		default:
@@ -1055,6 +1053,9 @@ func TestAddWorktreeReportsBranchNotFetched(t *testing.T) {
 	})
 	if !errors.Is(err, ports.ErrWorkspaceBranchNotFetched) {
 		t.Fatalf("err = %v, want ports.ErrWorkspaceBranchNotFetched", err)
+	}
+	if !strings.Contains(err.Error(), "after AO tried") {
+		t.Fatalf("err = %v, want automatic-fetch remediation", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- when spawn has no usable local/default/tag base, fetch the exact requested remote branch and configured default branch before failing
- update only remote-tracking refs; ordinary new-branch creation remains network-free
- keep checked-out worktrees non-destructive while naming the owning path and safe remedies
- normalize invalid-branch guidance around `git check-ref-format --branch`

Fixes #3942
Refs #3873

## Tests
- `cd backend && go test ./internal/adapters/workspace/gitworktree ./internal/service/session`
- `cd backend && go vet ./internal/adapters/workspace/gitworktree`

Includes a real local-remote integration test proving a previously unfetched branch is fetched and materialized.

## Risk
Targeted fetches may prompt for existing Git credentials when the repository has no usable local base. Fetch failure remains a typed `BRANCH_NOT_FETCHED` response with manual remediation; no worktree or user changes are deleted.
