### PR TITLE
fix(spawn): type long-tail workspace failures

### DIFF
--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -436,6 +437,13 @@ func (r projectRepoResolver) RepoPath(projectID domain.ProjectID) (string, error
 	}
 	if rec.Path == "" {
 		return "", fmt.Errorf("project %q has no repo path on record: %w", projectID, sessionmanager.ErrProjectNotResolvable)
+	}
+	info, err := os.Stat(rec.Path)
+	if err != nil {
+		return "", fmt.Errorf("project %q repo path %q is unavailable: %v: %w", projectID, rec.Path, err, sessionmanager.ErrProjectNotResolvable)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("project %q repo path %q is not a directory: %w", projectID, rec.Path, sessionmanager.ErrProjectNotResolvable)
 	}
 	return rec.Path, nil
 }

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -440,7 +440,7 @@ func (r projectRepoResolver) RepoPath(projectID domain.ProjectID) (string, error
 	}
 	info, err := os.Stat(rec.Path)
 	if err != nil {
-		return "", fmt.Errorf("project %q repo path %q is unavailable: %v: %w", projectID, rec.Path, err, sessionmanager.ErrProjectNotResolvable)
+		return "", fmt.Errorf("project %q repo path %q is unavailable: %w: %w", projectID, rec.Path, err, sessionmanager.ErrProjectNotResolvable)
 	}
 	if !info.IsDir() {
 		return "", fmt.Errorf("project %q repo path %q is not a directory: %w", projectID, rec.Path, sessionmanager.ErrProjectNotResolvable)

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -603,7 +603,8 @@ func TestProjectRepoResolver_ResolvesRegisteredProject(t *testing.T) {
 	t.Cleanup(func() { _ = store.Close() })
 
 	ctx := context.Background()
-	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "mer", Path: "/repo/mer", RegisteredAt: time.Now()}); err != nil {
+	repoPath := t.TempDir()
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "mer", Path: repoPath, RegisteredAt: time.Now()}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -612,8 +613,8 @@ func TestProjectRepoResolver_ResolvesRegisteredProject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoPath(mer): %v", err)
 	}
-	if got != "/repo/mer" {
-		t.Fatalf("RepoPath(mer) = %q, want /repo/mer", got)
+	if got != repoPath {
+		t.Fatalf("RepoPath(mer) = %q, want %q", got, repoPath)
 	}
 	_, err = r.RepoPath("nope")
 	if err == nil {
@@ -622,6 +623,41 @@ func TestProjectRepoResolver_ResolvesRegisteredProject(t *testing.T) {
 	// Guard the sentinel wrapping so the HTTP 400 mapping can't silently regress.
 	if !errors.Is(err, sessionmanager.ErrProjectNotResolvable) {
 		t.Fatalf("unregistered-project error should wrap ErrProjectNotResolvable, got %v", err)
+	}
+}
+
+func TestProjectRepoResolver_RejectsUnavailableProjectPaths(t *testing.T) {
+	store, err := sqlitetest.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	filePath := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(filePath, []byte("not a repo"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cases := []domain.ProjectRecord{
+		{ID: "missing", Path: filepath.Join(t.TempDir(), "renamed")},
+		{ID: "file", Path: filePath},
+		{ID: "empty"},
+		{ID: "archived", Path: t.TempDir(), ArchivedAt: time.Now()},
+	}
+	ctx := context.Background()
+	for _, rec := range cases {
+		if err := store.UpsertProject(ctx, rec); err != nil {
+			t.Fatalf("UpsertProject(%s): %v", rec.ID, err)
+		}
+	}
+
+	resolver := projectRepoResolver{store: store}
+	for _, rec := range cases {
+		t.Run(rec.ID, func(t *testing.T) {
+			_, err := resolver.RepoPath(domain.ProjectID(rec.ID))
+			if !errors.Is(err, sessionmanager.ErrProjectNotResolvable) {
+				t.Fatalf("RepoPath(%s) err = %v, want ErrProjectNotResolvable", rec.ID, err)
+			}
+		})
 	}
 }
 

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -969,6 +969,9 @@ func toAPIError(err error) error {
 			"This session already has an agent switch in progress", nil)
 	case errors.Is(err, sessionmanager.ErrScratchBranchUnsupported):
 		return apierr.Invalid("SCRATCH_BRANCH_UNSUPPORTED", err.Error(), nil)
+	case errors.Is(err, sessionmanager.ErrWorkspaceProvisionFailed):
+		return apierr.Invalid("WORKSPACE_PROVISION_FAILED",
+			"Workspace setup failed. Review the project's symlinks and postCreate commands, then retry spawn", nil)
 	case errors.Is(err, ports.ErrWorkspaceBranchCheckedOutElsewhere):
 		return apierr.Conflict("BRANCH_CHECKED_OUT_ELSEWHERE", err.Error(), nil)
 	case errors.Is(err, ports.ErrWorkspaceDefaultBranchUnresolved):

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -2114,6 +2114,7 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 		{"chat auth required", fmt.Errorf("spawn: %w", ports.ErrChatAuthRequired), apierr.KindConflict, "CHAT_AUTH_REQUIRED"},
 		{"native conversation missing", fmt.Errorf("switch interface: %w", sessionmanager.ErrNativeConversationMissing), apierr.KindConflict, "NATIVE_SESSION_MISSING"},
 		{"native conversation unverified", fmt.Errorf("switch interface: %w", sessionmanager.ErrNativeConversationUnverified), apierr.KindConflict, "NATIVE_SESSION_UNVERIFIED"},
+		{"workspace provision failed", fmt.Errorf("spawn mer-1: provision: %w: postCreate: exit status 1", sessionmanager.ErrWorkspaceProvisionFailed), apierr.KindInvalid, "WORKSPACE_PROVISION_FAILED"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2143,6 +2144,25 @@ func TestToAPIErrorSwitchDeliveryUnconfirmedMessage(t *testing.T) {
 	const wantMessage = "The target agent started, but AO could not confirm that it accepted the continuation"
 	if apiError.Message != wantMessage {
 		t.Fatalf("message = %q, want %q", apiError.Message, wantMessage)
+	}
+}
+
+func TestToAPIErrorWorkspaceProvisionFailedIsActionableWithoutLeakingOutput(t *testing.T) {
+	err := fmt.Errorf("spawn mer-1: provision: %w: postCreate: secret command output", sessionmanager.ErrWorkspaceProvisionFailed)
+	mapped := toAPIError(err)
+
+	var apiError *apierr.Error
+	if !errors.As(mapped, &apiError) {
+		t.Fatalf("mapped = %v, want *apierr.Error", mapped)
+	}
+	if apiError.Code != "WORKSPACE_PROVISION_FAILED" {
+		t.Fatalf("code = %q, want WORKSPACE_PROVISION_FAILED", apiError.Code)
+	}
+	if !strings.Contains(apiError.Message, "symlinks and postCreate commands") {
+		t.Fatalf("message = %q, want project setup remedy", apiError.Message)
+	}
+	if strings.Contains(apiError.Message, "secret command output") {
+		t.Fatalf("message leaked command output: %q", apiError.Message)
 	}
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -49,6 +49,11 @@ var (
 	// ErrScratchBranchUnsupported means a caller tried to force git branch
 	// semantics onto a scratch project.
 	ErrScratchBranchUnsupported = errors.New("session: scratch projects do not support branches")
+	// ErrWorkspaceProvisionFailed means the workspace was materialized but its
+	// configured symlinks or post-create commands could not be applied. The
+	// underlying error remains available in logs while the API maps this
+	// sentinel to a stable, actionable spawn error.
+	ErrWorkspaceProvisionFailed = errors.New("session: workspace provisioning failed")
 	// ErrNotResumable means a terminated session cannot be relaunched: its adapter
 	// cannot natively resume it AND it has no prompt to fresh-launch from, and it is
 	// not an orchestrator (orchestrators are promptless by design and relaunch fresh
@@ -3557,9 +3562,12 @@ func HookPATH(executable func() (string, error), getenv func(string) string, pro
 // workspace never launches an agent.
 func (m *Manager) provisionWorkspace(ctx context.Context, project domain.ProjectRecord, workspacePath string) error {
 	if err := applySymlinks(project.Path, workspacePath, project.Config.Symlinks); err != nil {
-		return err
+		return fmt.Errorf("%w: symlinks: %v", ErrWorkspaceProvisionFailed, err)
 	}
-	return runPostCreate(ctx, workspacePath, project.Config.PostCreate)
+	if err := runPostCreate(ctx, workspacePath, project.Config.PostCreate); err != nil {
+		return fmt.Errorf("%w: postCreate: %v", ErrWorkspaceProvisionFailed, err)
+	}
+	return nil
 }
 
 // applySymlinks links each repo-relative path into the workspace. A source that

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -3562,10 +3562,10 @@ func HookPATH(executable func() (string, error), getenv func(string) string, pro
 // workspace never launches an agent.
 func (m *Manager) provisionWorkspace(ctx context.Context, project domain.ProjectRecord, workspacePath string) error {
 	if err := applySymlinks(project.Path, workspacePath, project.Config.Symlinks); err != nil {
-		return fmt.Errorf("%w: symlinks: %v", ErrWorkspaceProvisionFailed, err)
+		return fmt.Errorf("%w: symlinks: %w", ErrWorkspaceProvisionFailed, err)
 	}
 	if err := runPostCreate(ctx, workspacePath, project.Config.PostCreate); err != nil {
-		return fmt.Errorf("%w: postCreate: %v", ErrWorkspaceProvisionFailed, err)
+		return fmt.Errorf("%w: postCreate: %w", ErrWorkspaceProvisionFailed, err)
 	}
 	return nil
 }

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -4377,8 +4377,8 @@ func TestSpawn_EarlyFailurePreservesNonEmptyScratchWorkspace(t *testing.T) {
 	})
 
 	_, _, _, err = m.Spawn(ctx, ports.SpawnConfig{ProjectID: "scratch", Kind: domain.KindOrchestrator})
-	if err == nil || !strings.Contains(err.Error(), "provision") {
-		t.Fatalf("Spawn err = %v, want provisioning failure", err)
+	if !errors.Is(err, ErrWorkspaceProvisionFailed) {
+		t.Fatalf("Spawn err = %v, want ErrWorkspaceProvisionFailed", err)
 	}
 	failed, ok := st.sessions["scratch-1"]
 	if !ok {


### PR DESCRIPTION
## Summary
- reject registered git projects whose repo path was removed, renamed, archived, empty, or is no longer a directory with `PROJECT_NOT_RESOLVABLE`
- classify symlink and `postCreate` setup failures as `WORKSPACE_PROVISION_FAILED`
- return a fixed actionable provisioning remedy without leaking command output through the API

The chat-mode items in #3946 are already preflighted on `main`: session mode support, driver availability/compatibility, and auth are checked before a session row or workspace is created. `SKILL_NOT_FOUND` is not emitted by the current Go spawn path; named skills belong to the chat API and are not accepted as spawn input.

Fixes #3946
Refs #3873

## Tests
- `cd backend && go test ./internal/service/session ./internal/session_manager ./internal/daemon`
- `cd backend && go vet ./internal/service/session ./internal/session_manager ./internal/daemon`

## Risk
Low. The new filesystem validation is confined to git-backed project resolution. Scratch projects do not use this resolver.