### PR TITLE
fix(projects): retain list failure cause in logs

### DIFF
--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -116,7 +117,10 @@ func NewWithDeps(d Deps) *Service {
 func (m *Service) List(ctx context.Context) ([]Summary, error) {
 	projects, err := m.store.ListProjects(ctx)
 	if err != nil {
-		return nil, apierr.Internal("PROJECTS_LIST_FAILED", "Failed to load projects")
+		// Keep the storage cause in the error chain for request-correlated daemon
+		// logs, while the apierr keeps filesystem paths and SQLite details out of
+		// the wire response.
+		return nil, fmt.Errorf("list projects: %w: %w", apierr.Internal("PROJECTS_LIST_FAILED", "Failed to load projects"), err)
 	}
 	out := make([]Summary, 0, len(projects))
 	for _, row := range projects {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -121,6 +121,15 @@ type fakeProjectTeardowner struct {
 	err      error
 }
 
+type failingListStore struct {
+	project.Store
+	err error
+}
+
+func (s failingListStore) ListProjects(context.Context) ([]domain.ProjectRecord, error) {
+	return nil, s.err
+}
+
 type captureSink struct {
 	events []ports.TelemetryEvent
 }
@@ -273,6 +282,23 @@ func TestManager_CloneCleansUpFailedAndEmptyCheckouts(t *testing.T) {
 	}
 	if temporary, err := filepath.Glob(filepath.Join(destinationParent, ".ao-clone-*")); err != nil || len(temporary) != 0 {
 		t.Fatalf("temporary clone directories = %#v, %v", temporary, err)
+	}
+}
+
+func TestManager_ListPreservesStorageCauseBehindInternalError(t *testing.T) {
+	storageErr := errors.New("sqlite: attempt to write a readonly database")
+	m := project.New(failingListStore{err: storageErr})
+
+	_, err := m.List(context.Background())
+	if !errors.Is(err, storageErr) {
+		t.Fatalf("List err = %v, want wrapped storage cause", err)
+	}
+	var apiError *apierr.Error
+	if !errors.As(err, &apiError) {
+		t.Fatalf("List err = %v, want wrapped *apierr.Error", err)
+	}
+	if apiError.Code != "PROJECTS_LIST_FAILED" || apiError.Message != "Failed to load projects" {
+		t.Fatalf("api error = %#v, want redacted PROJECTS_LIST_FAILED", apiError)
 	}
 }
 


### PR DESCRIPTION
## Summary
- retain `ListProjects` storage failures in the service error chain
- keep the existing redacted `PROJECTS_LIST_FAILED` API envelope
- let the HTTP access logger record the actionable SQLite/filesystem cause under the response request ID

Refs #3855
Refs #3873

## Triage
The reported `dial tcp 127.0.0.1 ... operation not permitted` is an external sandbox policy, not an AO spawn failure: the same report says `ao doctor` fails its direct daemon probe and data-directory write check. AO intentionally keeps its unauthenticated primary control API on direct loopback. Routing it through an ambient HTTP proxy would expose that trusted local API to the proxy and is not a safe recovery.

The `PROJECTS_LIST_FAILED` diagnostics loss is an AO bug: the project service replaced the SQLite cause with a bare API error before the request logger could capture it. This PR fixes that without exposing internal paths or database details to clients.

## Tests
- `cd backend && go test ./internal/service/project ./internal/httpd`
- `cd backend && go vet ./internal/service/project ./internal/httpd`

## Risk
Low. The public status, code, and message are unchanged; only the server-side error chain gains the storage cause.