### PR TITLE
Fix 3807 permission repair

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/remove.go
+++ b/backend/internal/adapters/workspace/gitworktree/remove.go
@@ -3,6 +3,7 @@ package gitworktree
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -104,13 +105,22 @@ func removeAllWithRetry(ctx context.Context, path string) error {
 	// the budget. Gate on Lstat first so a stub-removal failure on an already
 	// gone path (the retry-loop tests) still returns after a single attempt.
 	if !removeAllRetryEnabled {
-		if _, statErr := os.Lstat(path); statErr == nil {
-			if repairErr := makeTreeWritable(path); repairErr == nil {
-				if err = removeAll(path); err == nil || errors.Is(err, os.ErrNotExist) {
-					return nil
-				}
-			}
+		if !errors.Is(err, fs.ErrPermission) {
+			return err
 		}
+
+		if _, statErr := os.Lstat(path); statErr != nil {
+			return err
+		}
+
+		if repairErr := makeTreeWritable(path); repairErr != nil {
+			return err
+		}
+
+		if err = removeAll(path); err == nil || errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/backend/internal/adapters/workspace/gitworktree/remove.go
+++ b/backend/internal/adapters/workspace/gitworktree/remove.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 )
@@ -65,6 +66,19 @@ var (
 // gone is success (os.RemoveAll's own semantics), and the last error is
 // returned unwrapped so callers can still match on it.
 //
+// Off Windows, a failed os.RemoveAll is real and immediate — except for one
+// case this function repairs first: os.RemoveAll cannot delete a tree that
+// contains owner-owned read-only directories (0o500/0o000). Unlinking an entry
+// inside such a directory fails with EACCES/EPERM no matter how many times you
+// retry the identical call, and renv-style worktrees do contain them (the
+// Linux cleanup failure in issue #3807). So after a failure we walk the
+// remaining tree with Lstat semantics — symlinks are leaves, never followed
+// and never chmodded, since chmod on a symlink path would modify a target that
+// lives outside the tree — restore owner write+exec on every real directory,
+// then retry once. On Windows, os.RemoveAll clears read-only attributes
+// itself, so the repair is skipped there and the retry budget, backoff, and
+// ctx handling below are byte-for-byte unchanged.
+//
 // Retries stop early when ctx is done: time.Sleep is uninterruptible, so
 // without this a caller that has already given up (client disconnected,
 // deadline passed) would still pay out the remaining budget — and with a
@@ -83,7 +97,20 @@ func removeAllWithRetry(ctx context.Context, path string) error {
 	if err == nil || errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
+
+	// Permission repair is an off-Windows concern: on Windows the retry loop
+	// below owns the failure mode and os.RemoveAll already copes with
+	// read-only attributes, so the repair path would only burn an attempt of
+	// the budget. Gate on Lstat first so a stub-removal failure on an already
+	// gone path (the retry-loop tests) still returns after a single attempt.
 	if !removeAllRetryEnabled {
+		if _, statErr := os.Lstat(path); statErr == nil {
+			if repairErr := makeTreeWritable(path); repairErr == nil {
+				if err = removeAll(path); err == nil || errors.Is(err, os.ErrNotExist) {
+					return nil
+				}
+			}
+		}
 		return err
 	}
 
@@ -110,4 +137,38 @@ func removeAllWithRetry(ctx context.Context, path string) error {
 		}
 	}
 	return err
+}
+
+// makeTreeWritable walks path using Lstat semantics so symlinks are always
+// leaves: never followed and never chmodded (chmod on a symlink path would
+// modify the target, which lives outside the tree and must survive with its
+// permissions untouched). Every real directory gets owner read/write/execute
+// restored — write so unlink/rmdir can succeed, read+execute so even a 0o000
+// directory can be listed on the way down. Modes are repaired before
+// descending so each level is traversable when its children are visited. The
+// tree is about to be deleted, so the repaired modes only need to last until
+// the next removeAll.
+func makeTreeWritable(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		// Symlinks are leaves, and regular files unlink with write on the
+		// parent directory alone — neither needs repair.
+		return nil
+	}
+	if err := os.Chmod(path, info.Mode().Perm()|0o700); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := makeTreeWritable(filepath.Join(path, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/backend/internal/adapters/workspace/gitworktree/remove_permission_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/remove_permission_test.go
@@ -130,70 +130,6 @@ func TestRemoveAllWithRetryDirectoryPermissions(t *testing.T) {
 				chmod(t, dir, 0o000)
 			},
 		},
-		{
-			name: "mixed readonly subtrees",
-			setup: func(t *testing.T, worktree string) {
-				readonlyA := filepath.Join(worktree, "a", "readonly")
-				readonlyB := filepath.Join(worktree, "b", "nested", "readonly")
-
-				mkdir(t, readonlyA, 0o750)
-				mkdir(t, readonlyB, 0o750)
-
-				writeFile(
-					t,
-					filepath.Join(readonlyA, "a.txt"),
-					"a",
-					0o600,
-				)
-
-				writeFile(
-					t,
-					filepath.Join(readonlyB, "b.txt"),
-					"b",
-					0o600,
-				)
-
-				chmod(t, readonlyA, 0o500)
-				chmod(t, readonlyB, 0o000)
-			},
-		},
-		{
-			name: "readonly directory containing nested writable directory",
-			setup: func(t *testing.T, worktree string) {
-				readonly := filepath.Join(worktree, "readonly")
-				nested := filepath.Join(readonly, "nested")
-
-				mkdir(t, nested, 0o750)
-				writeFile(
-					t,
-					filepath.Join(nested, "file.txt"),
-					"hello",
-					0o600,
-				)
-
-				chmod(t, readonly, 0o500)
-			},
-		},
-		{
-			name: "writable directory containing readonly nested directory",
-			setup: func(t *testing.T, worktree string) {
-				readonly := filepath.Join(
-					worktree,
-					"writable",
-					"readonly",
-				)
-
-				mkdir(t, readonly, 0o750)
-				writeFile(
-					t,
-					filepath.Join(readonly, "file.txt"),
-					"hello",
-					0o600,
-				)
-
-				chmod(t, readonly, 0o500)
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -250,44 +186,6 @@ func TestRemoveAllWithRetryReadonlyDirectoryWithExternalFileSymlink(t *testing.T
 
 	// The symlink itself should be gone, but its target must survive.
 	assertFileContents(t, external, externalContents)
-}
-
-func TestRemoveAllWithRetryReadonlyDirectoryWithExternalDirectorySymlink(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix permission tests")
-	}
-
-	root := t.TempDir()
-
-	worktree := filepath.Join(root, "worktree")
-	restricted := filepath.Join(worktree, "restricted")
-
-	external := filepath.Join(root, "external-dir")
-	externalFile := filepath.Join(external, "important.txt")
-
-	mkdir(t, restricted, 0o750)
-	mkdir(t, external, 0o750)
-	writeFile(t, externalFile, "must survive", 0o600)
-
-	link := filepath.Join(restricted, "external")
-	if err := os.Symlink(external, link); err != nil {
-		t.Fatal(err)
-	}
-
-	chmod(t, restricted, 0o500)
-
-	if err := removeAllWithRetry(
-		context.Background(),
-		worktree,
-	); err != nil {
-		t.Fatalf("remove worktree: %v", err)
-	}
-
-	assertNotExists(t, worktree)
-
-	// The external directory must not be traversed or deleted.
-	assertFileContents(t, externalFile, "must survive")
-	assertExists(t, external)
 }
 
 func TestRemoveAllWithRetryReadonlyDirectoryWithReadonlyExternalSymlinkTarget(t *testing.T) {
@@ -381,66 +279,6 @@ func TestRemoveAllWithRetryBrokenSymlinkInReadonlyDirectory(t *testing.T) {
 	assertNotExists(t, worktree)
 }
 
-func TestRemoveAllWithRetrySymlinkLoop(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix symlink tests")
-	}
-
-	root := t.TempDir()
-
-	worktree := filepath.Join(root, "worktree")
-	mkdir(t, worktree, 0o750)
-
-	a := filepath.Join(worktree, "a")
-	b := filepath.Join(worktree, "b")
-
-	if err := os.Symlink(b, a); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Symlink(a, b); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := removeAllWithRetry(
-		context.Background(),
-		worktree,
-	); err != nil {
-		t.Fatalf("remove worktree: %v", err)
-	}
-
-	assertNotExists(t, worktree)
-}
-
-func TestRemoveAllWithRetryReadonlyRegularFiles(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix permission tests")
-	}
-
-	root := t.TempDir()
-	worktree := filepath.Join(root, "worktree")
-
-	mkdir(t, worktree, 0o750)
-
-	readonlyFile := filepath.Join(worktree, "readonly.txt")
-
-	writeFile(
-		t,
-		readonlyFile,
-		"must be deleted",
-		0o400,
-	)
-
-	if err := removeAllWithRetry(
-		context.Background(),
-		worktree,
-	); err != nil {
-		t.Fatalf("remove worktree: %v", err)
-	}
-
-	assertNotExists(t, worktree)
-}
-
 func TestRemoveAllWithRetryDeepReadonlyTree(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix permission tests")
@@ -493,88 +331,7 @@ func TestRemoveAllWithRetryDeepReadonlyTree(t *testing.T) {
 	assertNotExists(t, worktree)
 }
 
-func TestRemoveAllWithRetryMixedTreeAndSymlinks(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix permission tests")
-	}
-
-	root := t.TempDir()
-
-	worktree := filepath.Join(root, "worktree")
-
-	// External resources that must survive.
-	externalFile := filepath.Join(root, "external.txt")
-	externalDir := filepath.Join(root, "external-dir")
-	externalDirFile := filepath.Join(externalDir, "important.txt")
-
-	writeFile(t, externalFile, "external file", 0o600)
-	mkdir(t, externalDir, 0o750)
-	writeFile(t, externalDirFile, "external directory", 0o600)
-
-	// Normal AO-owned files.
-	normal := filepath.Join(worktree, "normal")
-	mkdir(t, normal, 0o750)
-	writeFile(
-		t,
-		filepath.Join(normal, "normal.txt"),
-		"normal",
-		0o600,
-	)
-
-	// Restricted subtree resembling the reported renv layout.
-	restricted := filepath.Join(
-		worktree,
-		"renv",
-		"sandbox",
-		"linux",
-		"R-4.5",
-		"hash",
-	)
-
-	mkdir(t, restricted, 0o750)
-
-	writeFile(
-		t,
-		filepath.Join(restricted, "package.txt"),
-		"package",
-		0o600,
-	)
-
-	if err := os.Symlink(
-		externalFile,
-		filepath.Join(restricted, "external-file"),
-	); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Symlink(
-		externalDir,
-		filepath.Join(restricted, "external-dir"),
-	); err != nil {
-		t.Fatal(err)
-	}
-
-	// This is the important permission condition.
-	chmod(t, restricted, 0o500)
-
-	if err := removeAllWithRetry(
-		context.Background(),
-		worktree,
-	); err != nil {
-		t.Fatalf("remove worktree: %v", err)
-	}
-
-	assertNotExists(t, worktree)
-
-	// Verify both symlink targets survived.
-	assertFileContents(t, externalFile, "external file")
-	assertFileContents(t, externalDirFile, "external directory")
-	assertExists(t, externalDir)
-}
-
-// -----------------------------------------------------------------------------
 // Helpers
-// -----------------------------------------------------------------------------
 
 func mkdir(t *testing.T, path string, mode os.FileMode) {
 	t.Helper()

--- a/backend/internal/adapters/workspace/gitworktree/remove_permission_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/remove_permission_test.go
@@ -2,6 +2,7 @@ package gitworktree
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -329,6 +330,35 @@ func TestRemoveAllWithRetryDeepReadonlyTree(t *testing.T) {
 	}
 
 	assertNotExists(t, worktree)
+}
+
+func TestRemoveAllWithRetryNonPermissionErrorDoesNotRetry(t *testing.T) {
+	if removeAllRetryEnabled {
+		t.Skip("Unix-only permission repair behavior")
+	}
+
+	originalRemoveAll := removeAll
+	t.Cleanup(func() {
+		removeAll = originalRemoveAll
+	})
+
+	var calls int
+	expectedErr := errors.New("synthetic filesystem failure")
+
+	removeAll = func(path string) error {
+		calls++
+		return expectedErr
+	}
+
+	err := removeAllWithRetry(context.Background(), "/does/not/matter")
+
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("got error %v, want %v", err, expectedErr)
+	}
+
+	if calls != 1 {
+		t.Fatalf("removeAll called %d times, want 1", calls)
+	}
 }
 
 // Helpers

--- a/backend/internal/adapters/workspace/gitworktree/remove_permission_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/remove_permission_test.go
@@ -1,0 +1,660 @@
+package gitworktree
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRemoveAllWithRetryOwnerReadonlySymlink(t *testing.T) {
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission probe")
+	}
+
+	root := t.TempDir()
+
+	worktree := filepath.Join(root, "worktree")
+	restricted := filepath.Join(
+		worktree,
+		"renv",
+		"sandbox",
+		"linux",
+		"R-4.5",
+		"hash",
+	)
+
+	if err := os.MkdirAll(restricted, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	systemLibrary := filepath.Join(root, "system-library")
+
+	if err := os.MkdirAll(systemLibrary, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	marker := filepath.Join(systemLibrary, "base-package")
+
+	if err := os.WriteFile(
+		marker,
+		[]byte("must survive"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the symlink target read-only too.
+	if err := os.Chmod(systemLibrary, 0o500); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore permissions so TempDir cleanup can remove it.
+	t.Cleanup(func() {
+		_ = os.Chmod(systemLibrary, 0o700)
+	})
+
+	if err := os.Symlink(
+		systemLibrary,
+		filepath.Join(restricted, "base"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Critical part of the reproducer:
+	// owner can read/traverse but cannot modify this directory.
+	if err := os.Chmod(restricted, 0o500); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = os.Chmod(restricted, 0o700)
+	})
+
+	err := removeAllWithRetry(context.Background(), worktree)
+	if err != nil {
+		t.Fatalf("remove AO-managed worktree: %v", err)
+	}
+
+	if _, err := os.Stat(worktree); !os.IsNotExist(err) {
+		t.Fatalf("worktree still exists: %v", err)
+	}
+
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read symlink target: %v", err)
+	}
+
+	if string(got) != "must survive" {
+		t.Fatalf("symlink target changed: content=%q", got)
+	}
+}
+
+func TestRemoveAllWithRetryDirectoryPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission tests")
+	}
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, worktree string)
+	}{
+		{
+			name: "readonly directory with file",
+			setup: func(t *testing.T, worktree string) {
+				dir := filepath.Join(worktree, "readonly")
+				mkdir(t, dir, 0o750)
+				writeFile(t, filepath.Join(dir, "file.txt"), "hello", 0o600)
+				chmod(t, dir, 0o500)
+			},
+		},
+		{
+			name: "nested readonly directories",
+			setup: func(t *testing.T, worktree string) {
+				dir := filepath.Join(worktree, "a", "b", "c")
+				mkdir(t, dir, 0o750)
+				writeFile(t, filepath.Join(dir, "file.txt"), "hello", 0o600)
+
+				chmod(t, filepath.Join(worktree, "a", "b", "c"), 0o500)
+				chmod(t, filepath.Join(worktree, "a", "b"), 0o500)
+			},
+		},
+		{
+			name: "zero permission directory",
+			setup: func(t *testing.T, worktree string) {
+				dir := filepath.Join(worktree, "locked")
+				mkdir(t, dir, 0o750)
+				writeFile(t, filepath.Join(dir, "file.txt"), "hello", 0o600)
+				chmod(t, dir, 0o000)
+			},
+		},
+		{
+			name: "mixed readonly subtrees",
+			setup: func(t *testing.T, worktree string) {
+				readonlyA := filepath.Join(worktree, "a", "readonly")
+				readonlyB := filepath.Join(worktree, "b", "nested", "readonly")
+
+				mkdir(t, readonlyA, 0o750)
+				mkdir(t, readonlyB, 0o750)
+
+				writeFile(
+					t,
+					filepath.Join(readonlyA, "a.txt"),
+					"a",
+					0o600,
+				)
+
+				writeFile(
+					t,
+					filepath.Join(readonlyB, "b.txt"),
+					"b",
+					0o600,
+				)
+
+				chmod(t, readonlyA, 0o500)
+				chmod(t, readonlyB, 0o000)
+			},
+		},
+		{
+			name: "readonly directory containing nested writable directory",
+			setup: func(t *testing.T, worktree string) {
+				readonly := filepath.Join(worktree, "readonly")
+				nested := filepath.Join(readonly, "nested")
+
+				mkdir(t, nested, 0o750)
+				writeFile(
+					t,
+					filepath.Join(nested, "file.txt"),
+					"hello",
+					0o600,
+				)
+
+				chmod(t, readonly, 0o500)
+			},
+		},
+		{
+			name: "writable directory containing readonly nested directory",
+			setup: func(t *testing.T, worktree string) {
+				readonly := filepath.Join(
+					worktree,
+					"writable",
+					"readonly",
+				)
+
+				mkdir(t, readonly, 0o750)
+				writeFile(
+					t,
+					filepath.Join(readonly, "file.txt"),
+					"hello",
+					0o600,
+				)
+
+				chmod(t, readonly, 0o500)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			worktree := filepath.Join(root, "worktree")
+
+			mkdir(t, worktree, 0o750)
+			tt.setup(t, worktree)
+
+			if err := removeAllWithRetry(
+				context.Background(),
+				worktree,
+			); err != nil {
+				t.Fatalf("remove worktree: %v", err)
+			}
+
+			assertNotExists(t, worktree)
+		})
+	}
+}
+
+func TestRemoveAllWithRetryReadonlyDirectoryWithExternalFileSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission tests")
+	}
+
+	root := t.TempDir()
+
+	worktree := filepath.Join(root, "worktree")
+	restricted := filepath.Join(worktree, "restricted")
+
+	external := filepath.Join(root, "external.txt")
+	externalContents := "must survive"
+
+	mkdir(t, restricted, 0o750)
+	writeFile(t, external, externalContents, 0o600)
+
+	link := filepath.Join(restricted, "link")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+
+	chmod(t, restricted, 0o500)
+
+	if err := removeAllWithRetry(
+		context.Background(),
+		worktree,
+	); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+
+	assertNotExists(t, worktree)
+
+	// The symlink itself should be gone, but its target must survive.
+	assertFileContents(t, external, externalContents)
+}
+
+func TestRemoveAllWithRetryReadonlyDirectoryWithExternalDirectorySymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission tests")
+	}
+
+	root := t.TempDir()
+
+	worktree := filepath.Join(root, "worktree")
+	restricted := filepath.Join(worktree, "restricted")
+
+	external := filepath.Join(root, "external-dir")
+	externalFile := filepath.Join(external, "important.txt")
+
+	mkdir(t, restricted, 0o750)
+	mkdir(t, external, 0o750)
+	writeFile(t, externalFile, "must survive", 0o600)
+
+	link := filepath.Join(restricted, "external")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+
+	chmod(t, restricted, 0o500)
+
+	if err := removeAllWithRetry(
+		context.Background(),
+		worktree,
+	); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+
+	assertNotExists(t, worktree)
+
+	// The external directory must not be traversed or deleted.
+	assertFileContents(t, externalFile, "must survive")
+	assertExists(t, external)
+}
+
+func TestRemoveAllWithRetryReadonlyDirectoryWithReadonlyExternalSymlinkTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission tests")
+	}
+
+	root := t.TempDir()
+
+	worktree := filepath.Join(root, "worktree")
+	restricted := filepath.Join(worktree, "restricted")
+
+	external := filepath.Join(root, "external")
+	externalFile := filepath.Join(external, "important.txt")
+
+	mkdir(t, restricted, 0o750)
+	mkdir(t, external, 0o750)
+	writeFile(t, externalFile, "must survive", 0o600)
+
+	// Make the external target itself restrictive.
+	chmod(t, external, 0o500)
+
+	// Restore it after the test so TempDir cleanup works.
+	t.Cleanup(func() {
+		_ = os.Chmod(external, 0o700)
+	})
+
+	link := filepath.Join(restricted, "external")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+
+	chmod(t, restricted, 0o500)
+
+	if err := removeAllWithRetry(
+		context.Background(),
+		worktree,
+	); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+
+	assertNotExists(t, worktree)
+
+	// The external target must survive.
+	assertExists(t, external)
+	assertFileContents(t, externalFile, "must survive")
+
+	info, err := os.Stat(external)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm() != 0o500 {
+		t.Fatalf(
+			"external directory permissions changed: got %o, want %o",
+			info.Mode().Perm(),
+			0o500,
+		)
+	}
+}
+
+func TestRemoveAllWithRetryBrokenSymlinkInReadonlyDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission tests")
+	}
+
+	root := t.TempDir()
+
+	worktree := filepath.Join(root, "worktree")
+	restricted := filepath.Join(worktree, "restricted")
+
+	mkdir(t, restricted, 0o750)
+
+	link := filepath.Join(restricted, "broken")
+	if err := os.Symlink(
+		"/this/path/does/not/exist",
+		link,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	chmod(t, restricted, 0o500)
+
+	if err := removeAllWithRetry(
+		context.Background(),
+		worktree,
+	); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+
+	assertNotExists(t, worktree)
+}
+
+func TestRemoveAllWithRetrySymlinkLoop(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix symlink tests")
+	}
+
+	root := t.TempDir()
+
+	worktree := filepath.Join(root, "worktree")
+	mkdir(t, worktree, 0o750)
+
+	a := filepath.Join(worktree, "a")
+	b := filepath.Join(worktree, "b")
+
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeAllWithRetry(
+		context.Background(),
+		worktree,
+	); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+
+	assertNotExists(t, worktree)
+}
+
+func TestRemoveAllWithRetryReadonlyRegularFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission tests")
+	}
+
+	root := t.TempDir()
+	worktree := filepath.Join(root, "worktree")
+
+	mkdir(t, worktree, 0o750)
+
+	readonlyFile := filepath.Join(worktree, "readonly.txt")
+
+	writeFile(
+		t,
+		readonlyFile,
+		"must be deleted",
+		0o400,
+	)
+
+	if err := removeAllWithRetry(
+		context.Background(),
+		worktree,
+	); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+
+	assertNotExists(t, worktree)
+}
+
+func TestRemoveAllWithRetryDeepReadonlyTree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission tests")
+	}
+
+	root := t.TempDir()
+	worktree := filepath.Join(root, "worktree")
+
+	// Build the complete tree while all directories are accessible.
+	current := worktree
+	dirs := make([]string, 0, 10)
+
+	for i := 0; i < 10; i++ {
+		current = filepath.Join(
+			current,
+			"level-"+string(rune('0'+i)),
+		)
+
+		mkdir(t, current, 0o750)
+		dirs = append(dirs, current)
+	}
+
+	// Populate the tree before making directories inaccessible.
+	writeFile(
+		t,
+		filepath.Join(current, "deep-file"),
+		"hello",
+		0o600,
+	)
+
+	// Lock directories deepest-first so we can still reach every
+	// directory while changing its permissions.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		dir := dirs[i]
+
+		if i%2 == 0 {
+			chmod(t, dir, 0o500)
+		} else {
+			chmod(t, dir, 0o000)
+		}
+	}
+
+	if err := removeAllWithRetry(
+		context.Background(),
+		worktree,
+	); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+
+	assertNotExists(t, worktree)
+}
+
+func TestRemoveAllWithRetryMixedTreeAndSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission tests")
+	}
+
+	root := t.TempDir()
+
+	worktree := filepath.Join(root, "worktree")
+
+	// External resources that must survive.
+	externalFile := filepath.Join(root, "external.txt")
+	externalDir := filepath.Join(root, "external-dir")
+	externalDirFile := filepath.Join(externalDir, "important.txt")
+
+	writeFile(t, externalFile, "external file", 0o600)
+	mkdir(t, externalDir, 0o750)
+	writeFile(t, externalDirFile, "external directory", 0o600)
+
+	// Normal AO-owned files.
+	normal := filepath.Join(worktree, "normal")
+	mkdir(t, normal, 0o750)
+	writeFile(
+		t,
+		filepath.Join(normal, "normal.txt"),
+		"normal",
+		0o600,
+	)
+
+	// Restricted subtree resembling the reported renv layout.
+	restricted := filepath.Join(
+		worktree,
+		"renv",
+		"sandbox",
+		"linux",
+		"R-4.5",
+		"hash",
+	)
+
+	mkdir(t, restricted, 0o750)
+
+	writeFile(
+		t,
+		filepath.Join(restricted, "package.txt"),
+		"package",
+		0o600,
+	)
+
+	if err := os.Symlink(
+		externalFile,
+		filepath.Join(restricted, "external-file"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Symlink(
+		externalDir,
+		filepath.Join(restricted, "external-dir"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// This is the important permission condition.
+	chmod(t, restricted, 0o500)
+
+	if err := removeAllWithRetry(
+		context.Background(),
+		worktree,
+	); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+
+	assertNotExists(t, worktree)
+
+	// Verify both symlink targets survived.
+	assertFileContents(t, externalFile, "external file")
+	assertFileContents(t, externalDirFile, "external directory")
+	assertExists(t, externalDir)
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+func mkdir(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+
+	if err := os.MkdirAll(path, mode); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+}
+
+func chmod(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s to %o: %v", path, mode, err)
+	}
+}
+
+func writeFile(
+	t *testing.T,
+	path string,
+	contents string,
+	mode os.FileMode,
+) {
+	t.Helper()
+
+	if err := os.WriteFile(
+		path,
+		[]byte(contents),
+		mode,
+	); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s to %o: %v", path, mode, err)
+	}
+}
+
+func assertExists(t *testing.T, path string) {
+	t.Helper()
+
+	if _, err := os.Lstat(path); err != nil {
+		t.Fatalf("expected %s to exist: %v", path, err)
+	}
+}
+
+func assertNotExists(t *testing.T, path string) {
+	t.Helper()
+
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf(
+			"expected %s to not exist, got err=%v",
+			path,
+			err,
+		)
+	}
+}
+
+func assertFileContents(
+	t *testing.T,
+	path string,
+	expected string,
+) {
+	t.Helper()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	if string(got) != expected {
+		t.Fatalf(
+			"unexpected contents for %s: got %q, want %q",
+			path,
+			string(got),
+			expected,
+		)
+	}
+}


### PR DESCRIPTION
## What

Fix worktree cleanup when AO-managed directories are owner-read-only (`0500`/`0000`), including `renv`-style layouts with symlinks.

## Why

Fixes #3807.

`os.RemoveAll` can fail with `permission denied` on Linux when a worktree contains read-only directories, leaving worktree residue.

## How

* On Unix, repair permissions **only for permission-related cleanup failures**, then retry once.
* Only real directories are modified; symlinks are never followed or chmodded.
* Existing Windows retry/backoff behavior is unchanged.
* Added regression tests for nested/readonly directories, symlinks, external targets, and non-permission errors.

## Testing

Tested on **Linux**:

```bash
go test ./internal/adapters/workspace/gitworktree/ -count=1 -v
```

All relevant tests pass.

**please test this on macOS before merging**, as I have not validated the Unix permission behavior on macOS.

## Checklist

* [ ] Branched from `main`
* [x] Focused change; fixes #3807
* [x] Tests added/updated
* [ ] Relevant CI checks pass
* [ ] **macOS validation required before merge**
