### PR TITLE
fix(desktop): keep shells and agent switching inside the chat surface

### DIFF
--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -142,6 +142,9 @@ vi.mock("./chat/SessionChatSurface", () => ({
 		onOpenReviewerTerminal,
 		reviewerTarget,
 		onSelectChat,
+		shellTerminals = [],
+		shellTarget,
+		onSelectShellTerminal,
 	}: {
 		onOpenShell?: () => void;
 		headerActions?: ReactNode;
@@ -149,6 +152,9 @@ vi.mock("./chat/SessionChatSurface", () => ({
 		onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
 		reviewerTarget?: { kind: "reviewer"; handleId: string; harness: string; sessionId: string };
 		onSelectChat?: () => void;
+		shellTerminals?: Array<{ handleId: string; title: string }>;
+		shellTarget?: { kind: "shell"; handleId: string };
+		onSelectShellTerminal?: (handleId: string) => void;
 	}) => (
 		<div data-testid="chat-surface">
 			chat surface
@@ -162,6 +168,23 @@ vi.mock("./chat/SessionChatSurface", () => ({
 				<div data-testid="terminal-target">reviewer</div>
 			) : null}
 			{reviewerTarget ? (
+				<button type="button" onClick={onSelectChat}>
+					select chat tab
+				</button>
+			) : null}
+			<div data-testid="shell-tabs">
+				{shellTerminals.map((shell) => (
+					<button
+						key={shell.handleId}
+						onClick={() => onSelectShellTerminal?.(shell.handleId)}
+						type="button"
+					>
+						{shell.title}
+					</button>
+				))}
+			</div>
+			{shellTarget ? <div data-testid="terminal-target">shell</div> : null}
+			{shellTarget ? (
 				<button type="button" onClick={onSelectChat}>
 					select chat tab
 				</button>
@@ -489,12 +512,15 @@ describe("SessionView", () => {
 		render(<SessionView sessionId="sess-1" />);
 		expect(screen.getByTestId("chat-surface")).toBeInTheDocument();
 
+		// Selecting the shell keeps the chat surface mounted — the shell renders
+		// as a tab inside it instead of swapping in the terminal CenterPane.
 		act(() => useUiStore.getState().setActiveShellTerminal("chat-shell"));
-		expect(screen.getByText("terminal center")).toBeInTheDocument();
-		expect(screen.queryByTestId("chat-surface")).not.toBeInTheDocument();
-
-		fireEvent.click(screen.getByRole("button", { name: "select agent tab" }));
 		expect(screen.getByTestId("chat-surface")).toBeInTheDocument();
+		expect(screen.getByTestId("terminal-target")).toHaveTextContent("shell");
+
+		fireEvent.click(screen.getByRole("button", { name: "select chat tab" }));
+		expect(screen.getByTestId("chat-surface")).toBeInTheDocument();
+		expect(screen.queryByTestId("terminal-target")).not.toBeInTheDocument();
 	});
 
 	// The strip only ever shows the session on screen — pinning another session's
@@ -543,12 +569,16 @@ describe("SessionView", () => {
 		render(<SessionView sessionId="sess-1" />);
 		expect(screen.getByText("chat surface")).toBeInTheDocument();
 
+		// Opening a shell from chat keeps the chat surface mounted: the shell is
+		// a tab in its header and renders as the surface's active pane.
 		fireEvent.click(screen.getByRole("button", { name: "open shell from chat" }));
-		expect(screen.getByText("terminal center")).toBeInTheDocument();
-		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("chat shell");
-
-		fireEvent.click(screen.getByRole("button", { name: "select agent tab" }));
 		expect(screen.getByText("chat surface")).toBeInTheDocument();
+		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("chat shell");
+		expect(screen.getByTestId("terminal-target")).toHaveTextContent("shell");
+
+		fireEvent.click(screen.getByRole("button", { name: "select chat tab" }));
+		expect(screen.getByText("chat surface")).toBeInTheDocument();
+		expect(screen.queryByTestId("terminal-target")).not.toBeInTheDocument();
 	});
 
 	it.each([

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -620,9 +620,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const routedTerminalTarget = terminalTargetBelongsToSession(terminalTarget, sessionId)
 		? terminalTarget
 		: ({ kind: "worker" } satisfies TerminalTarget);
-	// Chat surface stays mounted in chat mode for worker + reviewer targets;
-	// it renders the terminal pane as a tab when the reviewer is the active target.
-	const showChatSurface = session?.mode === "chat" && (routedTerminalTarget.kind === "worker" || routedTerminalTarget.kind === "reviewer");
+	// Chat surface stays mounted in chat mode for worker, reviewer, and shell
+	// targets. A terminal pane (reviewer or shell) renders as a tab inside the
+	// chat surface, so opening one never costs the user the conversation.
+	const chatTargetKind = routedTerminalTarget.kind;
+	const showChatSurface =
+		session?.mode === "chat" &&
+		(chatTargetKind === "worker" || chatTargetKind === "reviewer" || chatTargetKind === "shell");
 
 	// The pane shows one terminal at a time, so selecting a shell or the reviewer
 	// takes the agent's terminal off screen while the route still points here.
@@ -831,6 +835,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 										routedTerminalTarget.kind === "reviewer" ? routedTerminalTarget : undefined
 									}
 									onSelectChat={selectSessionTerminal}
+									shellTerminals={shellTerminals}
+									shellTarget={
+										routedTerminalTarget.kind === "shell" ? routedTerminalTarget : undefined
+									}
+									onSelectShellTerminal={selectShellTerminal}
+									onCloseShellTerminal={closeShellTerminalByHandle}
+									onRenameShellTerminal={renameShellTerminalByHandle}
 									daemonReady={daemonStatus.state === "ready"}
 									theme={theme}
 									headerActions={sessionHeaderActions}

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -20,6 +20,8 @@ const writeText = vi.fn(async (_text: string) => undefined);
 const menuAction = vi.fn(async (_action: string) => undefined);
 const previousTabListeners = new Set<() => void>();
 const nextTabListeners = new Set<() => void>();
+const closeShellTerminalListeners = new Set<() => void>();
+const closeShellTerminalShortcutStates: boolean[] = [];
 type TerminalPaneTestProps = {
 	fontSize?: number;
 	isFullscreen?: boolean;
@@ -40,6 +42,13 @@ vi.mock("../../lib/bridge", () => ({
 			onNextTabShortcut: (listener: () => void) => {
 				nextTabListeners.add(listener);
 				return () => nextTabListeners.delete(listener);
+			},
+			onCloseShellTerminalShortcut: (listener: () => void) => {
+				closeShellTerminalListeners.add(listener);
+				return () => closeShellTerminalListeners.delete(listener);
+			},
+			setCloseShellTerminalShortcutEnabled: (enabled: boolean) => {
+				closeShellTerminalShortcutStates.push(enabled);
 			},
 		},
 		clipboard: { writeText: (text: string) => writeText(text) },
@@ -93,6 +102,8 @@ beforeEach(() => {
 	menuAction.mockClear();
 	previousTabListeners.clear();
 	nextTabListeners.clear();
+	closeShellTerminalListeners.clear();
+	closeShellTerminalShortcutStates.length = 0;
 	terminalPaneState.props = undefined;
 	window.localStorage.clear();
 	setApiBaseUrl("http://127.0.0.1:3001");
@@ -1030,5 +1041,64 @@ describe("ChatWorkspace shell tabs", () => {
 		act(() => [...nextTabListeners][0]?.());
 		expect(onSelectChat).toHaveBeenCalledOnce();
 	});
-});
 
+	it("cycles shell → reviewer → chat on the desktop previous-tab shortcut", () => {
+		const onOpenReviewerTerminal = vi.fn();
+		const onSelectShellTerminal = vi.fn();
+		const onSelectChat = vi.fn();
+		const common = {
+			snapshot: idleSnapshot(),
+			session: chatSession,
+			reviewerTerminal: { handleId: "review-1", harness: "codex" },
+			onOpenReviewerTerminal,
+			shellTerminals: shells,
+			onSelectShellTerminal,
+			onSelectChat,
+		};
+		const view = render(<ChatWorkspace {...common} shellTarget={shellTarget("shell-1")} />);
+
+		act(() => [...previousTabListeners][0]?.());
+		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "review-1", harness: "codex" });
+
+		view.rerender(
+			<ChatWorkspace
+				{...common}
+				reviewerTarget={{
+					kind: "reviewer",
+					handleId: "review-1",
+					harness: "codex",
+					sessionId: chatFixture.sessionId,
+				}}
+			/>,
+		);
+		act(() => [...previousTabListeners][0]?.());
+		expect(onSelectChat).toHaveBeenCalledOnce();
+	});
+
+	it("enables the close-shell shortcut and closes the active shell tab", () => {
+		const onCloseShellTerminal = vi.fn();
+		const view = render(
+			<ChatWorkspace
+				snapshot={idleSnapshot()}
+				session={chatSession}
+				shellTerminals={shells}
+				shellTarget={shellTarget("shell-2")}
+				onCloseShellTerminal={onCloseShellTerminal}
+			/>,
+		);
+
+		expect(closeShellTerminalShortcutStates.at(-1)).toBe(true);
+		act(() => [...closeShellTerminalListeners][0]?.());
+		expect(onCloseShellTerminal).toHaveBeenCalledWith("shell-2");
+
+		view.rerender(
+			<ChatWorkspace
+				snapshot={idleSnapshot()}
+				session={chatSession}
+				shellTerminals={shells}
+				onCloseShellTerminal={onCloseShellTerminal}
+			/>,
+		);
+		expect(closeShellTerminalShortcutStates.at(-1)).toBe(false);
+	});
+});

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -57,6 +57,7 @@ vi.mock("../TerminalPane", () => ({
 vi.mock("../../lib/platform", () => ({
 	isMacPlatform: () => true,
 	isLinuxPlatform: () => false,
+	isWindowsPlatform: () => false,
 }));
 
 /** A refetch: identical content, all-new objects, which is what JSON parsing gives. */
@@ -916,3 +917,118 @@ describe("ChatWorkspace reviewer tabs", () => {
 		expect(onSelectChat).toHaveBeenCalledOnce();
 	});
 });
+
+describe("ChatWorkspace shell tabs", () => {
+	const shells = [
+		{
+			handleId: "shell-1",
+			sessionId: chatFixture.sessionId,
+			title: "chat worktree shell",
+			workingDir: "/p",
+			createdAt: "2026-08-04T00:00:00Z",
+		},
+		{
+			handleId: "shell-2",
+			sessionId: chatFixture.sessionId,
+			title: "second shell",
+			workingDir: "/p",
+			createdAt: "2026-08-04T00:10:00Z",
+		},
+	];
+	const shellTarget = (handleId: string) => {
+		const shell = shells.find((candidate) => candidate.handleId === handleId)!;
+		return {
+			kind: "shell" as const,
+			generation: shell.createdAt,
+			handleId,
+			sessionId: chatFixture.sessionId,
+			title: shell.title,
+		};
+	};
+
+	// Shells are tabs inside the chat surface (#4033): opening one must not cost
+	// the conversation — the conversation panel hides instead of unmounting,
+	// exactly like the reviewer pane.
+	it("renders a selected shell as the tab body and hides, not unmounts, the conversation", () => {
+		render(
+			<ChatWorkspace
+				snapshot={idleSnapshot()}
+				session={chatSession}
+				shellTerminals={shells}
+				shellTarget={shellTarget("shell-1")}
+				onSelectChat={vi.fn()}
+			/>,
+		);
+		expect(screen.getByTestId("chat-shell-terminal")).toBeInTheDocument();
+		expect(screen.getByTestId("chat-conversation-panel")).toHaveAttribute("hidden");
+		expect(screen.getByTestId("chat-conversation-panel")).toHaveAttribute("inert");
+
+		expect(screen.getByRole("tab", { name: "chat worktree shell" })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+		expect(screen.getByRole("tab", { name: "second shell" })).toHaveAttribute(
+			"aria-selected",
+			"false",
+		);
+	});
+
+	it("passes the routed shell target straight to the terminal pane", () => {
+		render(
+			<ChatWorkspace
+				snapshot={idleSnapshot()}
+				session={chatSession}
+				shellTerminals={shells}
+				shellTarget={shellTarget("shell-2")}
+			/>,
+		);
+		expect(terminalPaneState.props).toMatchObject({ terminalTarget: shellTarget("shell-2") });
+	});
+
+	it("cycles chat → reviewer → shells → chat on the desktop next-tab shortcut", () => {
+		const onOpenReviewerTerminal = vi.fn();
+		const onSelectShellTerminal = vi.fn();
+		const onSelectChat = vi.fn();
+		const common = {
+			snapshot: idleSnapshot(),
+			session: chatSession,
+			shellTerminals: shells,
+			onSelectShellTerminal,
+			onSelectChat,
+		};
+		const view = render(
+			<ChatWorkspace
+				{...common}
+				reviewerTerminal={{ handleId: "review-1", harness: "codex" }}
+				onOpenReviewerTerminal={onOpenReviewerTerminal}
+			/>,
+		);
+
+		// From chat: the reviewer comes first.
+		act(() => [...nextTabListeners][0]?.());
+		expect(onOpenReviewerTerminal).toHaveBeenCalledOnce();
+
+		// From the reviewer: the first shell.
+		view.rerender(
+			<ChatWorkspace
+				{...common}
+				reviewerTerminal={{ handleId: "review-1", harness: "codex" }}
+				onOpenReviewerTerminal={onOpenReviewerTerminal}
+				reviewerTarget={{
+					kind: "reviewer",
+					handleId: "review-1",
+					harness: "codex",
+					sessionId: chatFixture.sessionId,
+				}}
+			/>,
+		);
+		act(() => [...nextTabListeners][0]?.());
+		expect(onSelectShellTerminal).toHaveBeenCalledWith("shell-1");
+
+		// From the last shell: wraps to chat.
+		view.rerender(<ChatWorkspace {...common} shellTarget={shellTarget("shell-2")} />);
+		act(() => [...nextTabListeners][0]?.());
+		expect(onSelectChat).toHaveBeenCalledOnce();
+	});
+});
+

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -1042,6 +1042,25 @@ describe("ChatWorkspace shell tabs", () => {
 		expect(onSelectChat).toHaveBeenCalledOnce();
 	});
 
+	it("cycles from the focused worker tab on Ctrl+Tab", () => {
+		const onSelectShellTerminal = vi.fn();
+		render(
+			<ChatWorkspace
+				snapshot={idleSnapshot()}
+				session={chatSession}
+				shellTerminals={shells}
+				onSelectShellTerminal={onSelectShellTerminal}
+				onSelectChat={vi.fn()}
+			/>,
+		);
+
+		const workerTab = screen.getByRole("tab", { name: "ao-14" });
+		workerTab.focus();
+		fireEvent.keyDown(workerTab, { key: "Tab", ctrlKey: true });
+
+		expect(onSelectShellTerminal).toHaveBeenCalledWith("shell-1");
+	});
+
 	it("cycles shell → reviewer → chat on the desktop previous-tab shortcut", () => {
 		const onOpenReviewerTerminal = vi.fn();
 		const onSelectShellTerminal = vi.fn();

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -484,6 +484,24 @@ export function ChatWorkspace({
 		shellTarget,
 		shellTerminals,
 	]);
+	const handleChatTabsKeyDown = useCallback(
+		(event: ReactKeyboardEvent<HTMLDivElement>) => {
+			if (
+				event.target instanceof HTMLElement &&
+				event.target.getAttribute("role") === "tab" &&
+				event.key === "Tab" &&
+				event.ctrlKey &&
+				!event.altKey &&
+				!event.metaKey
+			) {
+				event.preventDefault();
+				selectAdjacentTab(event.shiftKey ? -1 : 1);
+				return;
+			}
+			handleTerminalTabListKeyDown(event);
+		},
+		[selectAdjacentTab],
+	);
 
 	useEffect(
 		() =>
@@ -538,6 +556,7 @@ export function ChatWorkspace({
 				onSelectShellTerminal={onSelectShellTerminal}
 				onCloseShellTerminal={onCloseShellTerminal}
 				onRenameShellTerminal={onRenameShellTerminal}
+				onTabsKeyDown={handleChatTabsKeyDown}
 				switchAgentControl={switchAgentControl}
 				headerActions={headerActions}
 				inline={isFullscreen}
@@ -865,6 +884,7 @@ function ChatHeader({
 	onSelectShellTerminal,
 	onCloseShellTerminal,
 	onRenameShellTerminal,
+	onTabsKeyDown,
 	switchAgentControl,
 	headerActions,
 	inline,
@@ -885,6 +905,7 @@ function ChatHeader({
 	onSelectShellTerminal?: (handleId: string) => void;
 	onCloseShellTerminal?: (handleId: string) => void;
 	onRenameShellTerminal?: (handleId: string, title: string) => void;
+	onTabsKeyDown?: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
 	/** The in-place agent-switch control, same entry point as the terminal pane. */
 	switchAgentControl?: ReactNode;
 	headerActions?: ReactNode;
@@ -914,7 +935,7 @@ function ChatHeader({
 					<div
 						aria-label="Chat tabs"
 						className="scrollbar-none flex h-full min-w-flex-min flex-1 items-center overflow-x-auto"
-						onKeyDown={handleTerminalTabListKeyDown}
+						onKeyDown={onTabsKeyDown ?? handleTerminalTabListKeyDown}
 						role="tablist"
 					>
 						<span

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -46,6 +46,7 @@ import {
 } from "../../lib/design-tokens";
 import { isLinuxPlatform, isMacPlatform } from "../../lib/platform";
 import { handleTerminalTabListKeyDown } from "../../lib/terminal-tabs";
+import type { ShellTerminal } from "../../hooks/useShellTerminals";
 import { useUiStore } from "../../stores/ui-store";
 import type { TerminalTarget } from "../../types/terminal";
 import type { SessionKind, WorkspaceSession } from "../../types/workspace";
@@ -53,6 +54,7 @@ import { AgentAvatar } from "../AgentAvatar";
 import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ConfirmDialog";
 import { SessionTopbarPortal } from "../SessionTopbarPortal";
+import { ShellTerminalTab } from "../ShellTerminalTab";
 import { TerminalPane } from "../TerminalPane";
 import {
 	ActivityRow,
@@ -122,6 +124,7 @@ function initialTerminalFontSize(): number {
 }
 
 type ReviewerTerminalTarget = Extract<TerminalTarget, { kind: "reviewer" }>;
+type ShellTerminalTarget = Extract<TerminalTarget, { kind: "shell" }>;
 
 const isMac = isMacPlatform();
 const isLinux = isLinuxPlatform();
@@ -184,6 +187,18 @@ export interface ChatWorkspaceProps {
 	reviewerTarget?: ReviewerTerminalTarget;
 	/** Switch the active tab back to the chat timeline. */
 	onSelectChat?: () => void;
+	/** This session's standalone shells, rendered as tabs after the reviewer. */
+	shellTerminals?: ShellTerminal[];
+	/** The selected shell pane, if any. Mirrors reviewerTarget. */
+	shellTarget?: ShellTerminalTarget;
+	onSelectShellTerminal?: (handleId: string) => void;
+	onCloseShellTerminal?: (handleId: string) => void;
+	onRenameShellTerminal?: (handleId: string, title: string) => void;
+	/** The in-place agent-switch control. Owned by the surface (which owns query
+	    wiring) so this pure view stays renderable without query providers. */
+	switchAgentControl?: ReactNode;
+	/** Receives the body element the agent-switch dialog anchors to. */
+	switchDialogContainer?: (node: HTMLDivElement | null) => void;
 	/** Daemon readiness for the reviewer terminal pane. */
 	daemonReady?: boolean;
 	/** Resolved color theme for the reviewer terminal pane. */
@@ -261,6 +276,13 @@ export function ChatWorkspace({
 	session,
 	reviewerTarget,
 	onSelectChat,
+	shellTerminals,
+	shellTarget,
+	onSelectShellTerminal,
+	onCloseShellTerminal,
+	onRenameShellTerminal,
+	switchAgentControl,
+	switchDialogContainer,
 	daemonReady,
 	theme,
 	hasOlder,
@@ -315,6 +337,7 @@ export function ChatWorkspace({
 	// offered. Keeping these separate preserves a selected reviewer while an active
 	// session temporarily becomes terminated and later returns.
 	const reviewerActive = Boolean(reviewerTarget && session);
+	const shellActive = Boolean(shellTarget && session);
 	const queuedMessages = useMemo(() => {
 		const messagesByTurn = new Map(
 			snapshot.items
@@ -425,13 +448,45 @@ export function ChatWorkspace({
 		}
 	}, []);
 
+	// Cycle chat → reviewer → shells in strip order, wrapping. With no auxiliary
+	// tabs there is nothing to cycle to and the shortcut is a no-op.
 	const selectAdjacentTab = useCallback(() => {
-		if (reviewerActive) {
+		if (shellActive) {
+			const shells = shellTerminals ?? [];
+			const index = shells.findIndex((shell) => shell.handleId === shellTarget?.handleId);
+			const nextShell = shells[index + 1];
+			if (nextShell) {
+				onSelectShellTerminal?.(nextShell.handleId);
+				return;
+			}
 			onSelectChat?.();
 			return;
 		}
-		if (reviewerTerminal) onOpenReviewerTerminal?.(reviewerTerminal);
-	}, [onOpenReviewerTerminal, onSelectChat, reviewerActive, reviewerTerminal]);
+		if (reviewerActive) {
+			const firstShell = shellTerminals?.[0];
+			if (firstShell) {
+				onSelectShellTerminal?.(firstShell.handleId);
+				return;
+			}
+			onSelectChat?.();
+			return;
+		}
+		if (reviewerTerminal) {
+			onOpenReviewerTerminal?.(reviewerTerminal);
+			return;
+		}
+		const firstShell = shellTerminals?.[0];
+		if (firstShell) onSelectShellTerminal?.(firstShell.handleId);
+	}, [
+		onOpenReviewerTerminal,
+		onSelectChat,
+		onSelectShellTerminal,
+		reviewerActive,
+		reviewerTerminal,
+		shellActive,
+		shellTarget,
+		shellTerminals,
+	]);
 
 	useEffect(() => {
 		const disposePrevious = aoBridge.app.onPreviousTabShortcut(selectAdjacentTab);
@@ -466,10 +521,24 @@ export function ChatWorkspace({
 				onOpenReviewerTerminal={onOpenReviewerTerminal}
 				reviewerActive={reviewerActive}
 				onSelectChat={onSelectChat}
+				shellTerminals={shellTerminals}
+				shellActiveHandleId={shellActive ? shellTarget?.handleId : undefined}
+				onSelectShellTerminal={onSelectShellTerminal}
+				onCloseShellTerminal={onCloseShellTerminal}
+				onRenameShellTerminal={onRenameShellTerminal}
+				switchAgentControl={switchAgentControl}
 				headerActions={headerActions}
 				inline={isFullscreen}
 				topbarBounds={topbarBounds}
 			/>
+			{/* The body host anchors the agent-switch dialog and holds whichever tab is
+			    active: the reviewer pane, a shell pane, or the chat timeline. The
+			    container ref is handed up so the surface (not this pure view) owns the
+			    dialog's state. */}
+			<div
+				className="relative flex min-h-0 flex-1 flex-col"
+				ref={switchDialogContainer}
+			>
 			{reviewerTarget && session ? (
 				<div
 					aria-label="Reviewer terminal"
@@ -495,13 +564,35 @@ export function ChatWorkspace({
 					</div>
 				</div>
 			) : null}
+			{shellTarget && session ? (
+				<div
+					aria-label="Shell terminal"
+					className="relative min-h-0 flex-1"
+					data-testid="chat-shell-panel"
+					onWheelCapture={handleWheelZoom}
+					role="tabpanel"
+				>
+					<div className="h-full min-h-0 pl-2" data-testid="chat-shell-terminal">
+						<TerminalPane
+							daemonReady={Boolean(daemonReady)}
+							fontSize={terminalFontSize}
+							isFullscreen={isFullscreen}
+							onChangeFontSize={updateTerminalFontSize}
+							onToggleFullscreen={toggleFullscreen}
+							session={session}
+							terminalTarget={shellTarget}
+							theme={theme ?? "dark"}
+						/>
+					</div>
+				</div>
+			) : null}
 			<div
-				aria-hidden={reviewerActive}
+				aria-hidden={reviewerActive || shellActive}
 				aria-label="Chat conversation"
 				className="flex min-h-0 flex-1 flex-col"
 				data-testid="chat-conversation-panel"
-				hidden={reviewerActive}
-				inert={reviewerActive ? true : undefined}
+				hidden={reviewerActive || shellActive}
+				inert={reviewerActive || shellActive ? true : undefined}
 				role="tabpanel"
 			>
 				{/* Ordered by what blocks what. A session that needs credentials cannot make
@@ -607,13 +698,14 @@ export function ChatWorkspace({
 					</div>
 				</div>
 			</div>
+			</div>
 
 			{/* The copy has to be honest about the cost: this is not "hide these
 			    messages", it is "the agent forgets them". Nothing in the worktree is
 			    reverted either, and a user who assumed otherwise would be badly
 			    surprised, so it is said out loud. */}
 			<ConfirmDialog
-				open={Boolean(confirming) && !reviewerActive}
+				open={Boolean(confirming) && !reviewerActive && !shellActive}
 				onOpenChange={(open) => {
 					if (!open) setConfirming(undefined);
 				}}
@@ -756,6 +848,12 @@ function ChatHeader({
 	onOpenReviewerTerminal,
 	reviewerActive,
 	onSelectChat,
+	shellTerminals,
+	shellActiveHandleId,
+	onSelectShellTerminal,
+	onCloseShellTerminal,
+	onRenameShellTerminal,
+	switchAgentControl,
 	headerActions,
 	inline,
 	topbarBounds,
@@ -768,12 +866,23 @@ function ChatHeader({
 	reviewerActive?: boolean;
 	/** Return the tab strip to the chat tab. */
 	onSelectChat?: () => void;
+	/** This session's standalone shells, as tabs after the reviewer. */
+	shellTerminals?: ShellTerminal[];
+	/** The selected shell tab, if any. */
+	shellActiveHandleId?: string;
+	onSelectShellTerminal?: (handleId: string) => void;
+	onCloseShellTerminal?: (handleId: string) => void;
+	onRenameShellTerminal?: (handleId: string, title: string) => void;
+	/** The in-place agent-switch control, same entry point as the terminal pane. */
+	switchAgentControl?: ReactNode;
 	headerActions?: ReactNode;
 	/** Fullscreen content cannot see the normal topbar portal outside its subtree. */
 	inline?: boolean;
 	topbarBounds: TopbarBounds;
 }) {
 	const label = sessionTitle || snapshot.title || snapshot.sessionId;
+	// The chat tab is "selected" only when neither terminal pane is the body.
+	const timelineActive = !reviewerActive && !shellActiveHandleId;
 	// Match CenterPane: when the sidebar is off-canvas, the fixed TitlebarNav
 	// cluster sits over the session tab strip. Terminal already reserves that
 	// space; chat must too or the back/forward buttons land on the tab label.
@@ -800,23 +909,23 @@ function ChatHeader({
 							data-terminal-role="primary"
 							className={cn(
 								"group relative inline-flex min-w-shell-tab-min self-stretch items-center gap-1.5 border-r border-border px-3",
-								reviewerActive
-									? "text-muted-foreground hover:bg-raised hover:text-foreground"
-									: "bg-overlay text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground/80",
+								timelineActive
+									? "bg-overlay text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground/80"
+									: "text-muted-foreground hover:bg-raised hover:text-foreground",
 							)}
 						>
 							<AgentAvatar className="size-icon-base" decorative provider={snapshot.harness} />
 							<button
-								aria-current={reviewerActive ? undefined : true}
+								aria-current={timelineActive ? true : undefined}
 								aria-label={label}
-								aria-selected={!reviewerActive}
+								aria-selected={timelineActive}
 								className={cn(
 									"inline-flex min-w-flex-min max-w-shell-tab-max items-center gap-1.5 text-control font-medium leading-none transition-colors",
-									reviewerActive ? "text-muted-foreground" : "text-foreground",
+									timelineActive ? "text-foreground" : "text-muted-foreground",
 								)}
-								onClick={reviewerActive ? onSelectChat : undefined}
+								onClick={timelineActive ? undefined : onSelectChat}
 								role="tab"
-								tabIndex={!reviewerActive || !reviewerTerminal ? 0 : -1}
+								tabIndex={timelineActive || (!reviewerTerminal && !shellTerminals?.length) ? 0 : -1}
 								title={label}
 								type="button"
 							>
@@ -851,9 +960,27 @@ function ChatHeader({
 								</button>
 							</span>
 						) : null}
+						{/* The same shared shell tab the terminal pane strip and the
+						    standalone terminals screen use, so all three never drift. */}
+						{(shellTerminals ?? []).map((shell) => (
+							<ShellTerminalTab
+								key={shell.handleId}
+								appearance="connected"
+								isActive={shell.handleId === shellActiveHandleId}
+								onClose={() => onCloseShellTerminal?.(shell.handleId)}
+								onRename={
+									onRenameShellTerminal
+										? (title) => onRenameShellTerminal(shell.handleId, title)
+										: undefined
+								}
+								onSelect={() => onSelectShellTerminal?.(shell.handleId)}
+								shell={shell}
+							/>
+						))}
 					</div>
 				</div>
-				<div className="ml-auto flex shrink-0 items-center px-3" data-testid="session-action-region">
+				<div className="ml-auto flex shrink-0 items-center gap-1 px-3" data-testid="session-action-region">
+					{switchAgentControl}
 					{headerActions}
 				</div>
 			</div>

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -450,33 +450,30 @@ export function ChatWorkspace({
 
 	// Cycle chat → reviewer → shells in strip order, wrapping. With no auxiliary
 	// tabs there is nothing to cycle to and the shortcut is a no-op.
-	const selectAdjacentTab = useCallback(() => {
-		if (shellActive) {
-			const shells = shellTerminals ?? [];
-			const index = shells.findIndex((shell) => shell.handleId === shellTarget?.handleId);
-			const nextShell = shells[index + 1];
-			if (nextShell) {
-				onSelectShellTerminal?.(nextShell.handleId);
-				return;
-			}
+	const selectAdjacentTab = useCallback((direction: -1 | 1) => {
+		const tabs = [
+			{ kind: "chat" as const },
+			...(reviewerTerminal ? [{ kind: "reviewer" as const }] : []),
+			...(shellTerminals ?? []).map((shell) => ({ kind: "shell" as const, handleId: shell.handleId })),
+		];
+		if (tabs.length <= 1) return;
+		const activeIndex = shellActive
+			? tabs.findIndex((tab) => tab.kind === "shell" && tab.handleId === shellTarget?.handleId)
+			: reviewerActive
+				? tabs.findIndex((tab) => tab.kind === "reviewer")
+				: 0;
+		const currentIndex = activeIndex >= 0 ? activeIndex : 0;
+		const next = tabs[(currentIndex + direction + tabs.length) % tabs.length];
+		if (!next) return;
+		if (next.kind === "chat") {
 			onSelectChat?.();
 			return;
 		}
-		if (reviewerActive) {
-			const firstShell = shellTerminals?.[0];
-			if (firstShell) {
-				onSelectShellTerminal?.(firstShell.handleId);
-				return;
-			}
-			onSelectChat?.();
+		if (next.kind === "reviewer") {
+			if (reviewerTerminal) onOpenReviewerTerminal?.(reviewerTerminal);
 			return;
 		}
-		if (reviewerTerminal) {
-			onOpenReviewerTerminal?.(reviewerTerminal);
-			return;
-		}
-		const firstShell = shellTerminals?.[0];
-		if (firstShell) onSelectShellTerminal?.(firstShell.handleId);
+		onSelectShellTerminal?.(next.handleId);
 	}, [
 		onOpenReviewerTerminal,
 		onSelectChat,
@@ -488,14 +485,29 @@ export function ChatWorkspace({
 		shellTerminals,
 	]);
 
+	useEffect(
+		() =>
+			aoBridge.app.onCloseShellTerminalShortcut(() => {
+				if (shellTarget) onCloseShellTerminal?.(shellTarget.handleId);
+			}),
+		[onCloseShellTerminal, shellTarget],
+	);
+
 	useEffect(() => {
-		const disposePrevious = aoBridge.app.onPreviousTabShortcut(selectAdjacentTab);
-		const disposeNext = aoBridge.app.onNextTabShortcut(selectAdjacentTab);
+		const disposePrevious = aoBridge.app.onPreviousTabShortcut(() => selectAdjacentTab(-1));
+		const disposeNext = aoBridge.app.onNextTabShortcut(() => selectAdjacentTab(1));
 		return () => {
 			disposePrevious();
 			disposeNext();
 		};
 	}, [selectAdjacentTab]);
+
+	useEffect(() => {
+		aoBridge.app.setCloseShellTerminalShortcutEnabled(
+			Boolean(shellTarget && onCloseShellTerminal),
+		);
+		return () => aoBridge.app.setCloseShellTerminalShortcutEnabled(false);
+	}, [onCloseShellTerminal, shellTarget]);
 
 	// Offered only while the agent is idle. The daemon refuses a rollback mid-turn,
 	// and a control that exists to be refused is worse than one that waits.

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -34,11 +34,24 @@ vi.mock("../../hooks/useConversation", () => ({
 }));
 
 vi.mock("./ChatWorkspace", () => ({
-	ChatWorkspace: ({ onLinkOpen }: { onLinkOpen?: (url: string) => void }) => (
-		<button type="button" onClick={() => onLinkOpen?.(LINK)}>
-			Open chat link
-		</button>
+	ChatWorkspace: ({
+		onLinkOpen,
+		switchAgentControl,
+	}: {
+		onLinkOpen?: (url: string) => void;
+		switchAgentControl?: ReactNode;
+	}) => (
+		<div>
+			<button type="button" onClick={() => onLinkOpen?.(LINK)}>
+				Open chat link
+			</button>
+			{switchAgentControl}
+		</div>
 	),
+}));
+
+vi.mock("../TerminalSwitchAgentButton", () => ({
+	TerminalSwitchAgentButton: () => <button aria-label="Switch agent" type="button" />,
 }));
 
 import { SessionChatSurface } from "./SessionChatSurface";
@@ -89,5 +102,20 @@ describe("SessionChatSurface link routing", () => {
 			body: { url: LINK },
 		});
 		await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: workspaceQueryKey }));
+	});
+
+	// The chat surface offers the same in-place agent switch the terminal pane's
+	// tab strip does (#4033): the control must be reachable without leaving chat.
+	it("offers the in-place agent switch inside the chat surface", () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		});
+		render(
+			<Wrapper client={queryClient}>
+				<SessionChatSurface session={session} />
+			</Wrapper>,
+		);
+
+		expect(screen.getByRole("button", { name: "Switch agent" })).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -9,22 +9,25 @@ import { workspaceQueryKey } from "../../hooks/useWorkspaceQuery";
 
 const LINK = "http://localhost:5173";
 
-const { postMock } = vi.hoisted(() => ({ postMock: vi.fn() }));
+const { postMock, conversationState } = vi.hoisted(() => ({
+	postMock: vi.fn(),
+	conversationState: {
+		snapshot: { capabilities: [] } as { capabilities: string[] } | undefined,
+		isLoading: false,
+		unavailable: undefined as { message: string } | undefined,
+		error: undefined as string | undefined,
+		hasOlder: false,
+		isLoadingOlder: false,
+		loadOlder: vi.fn(),
+	},
+}));
 
 vi.mock("../../lib/api-client", () => ({
 	apiClient: { POST: postMock },
 }));
 
 vi.mock("../../hooks/useConversation", () => ({
-	useConversation: () => ({
-		snapshot: { capabilities: [] },
-		isLoading: false,
-		unavailable: undefined,
-		error: undefined,
-		hasOlder: false,
-		isLoadingOlder: false,
-		loadOlder: vi.fn(),
-	}),
+	useConversation: () => conversationState,
 	useConversationCommands: () => ({}),
 	useConversationConfigOptions: () => ({ options: [] }),
 	useConversationModels: () => ({ models: [] }),
@@ -37,14 +40,17 @@ vi.mock("./ChatWorkspace", () => ({
 	ChatWorkspace: ({
 		onLinkOpen,
 		switchAgentControl,
+		shellTarget,
 	}: {
 		onLinkOpen?: (url: string) => void;
 		switchAgentControl?: ReactNode;
+		shellTarget?: { handleId: string };
 	}) => (
 		<div>
 			<button type="button" onClick={() => onLinkOpen?.(LINK)}>
 				Open chat link
 			</button>
+			{shellTarget ? <div data-testid="shell-target">{shellTarget.handleId}</div> : null}
 			{switchAgentControl}
 		</div>
 	),
@@ -58,6 +64,7 @@ import { SessionChatSurface } from "./SessionChatSurface";
 
 const session = {
 	id: "sess-1",
+	terminalHandleId: "handle-1",
 	workspaceId: "proj-1",
 	workspaceName: "my-app",
 	title: "chat worker",
@@ -75,6 +82,13 @@ function Wrapper({ client, children }: { client: QueryClient; children: ReactNod
 
 beforeEach(() => {
 	postMock.mockReset().mockResolvedValue({ data: {}, error: undefined });
+	conversationState.snapshot = { capabilities: [] };
+	conversationState.isLoading = false;
+	conversationState.unavailable = undefined;
+	conversationState.error = undefined;
+	conversationState.hasOlder = false;
+	conversationState.isLoadingOlder = false;
+	conversationState.loadOlder = vi.fn();
 	useUiStore.setState({ inspectorSessions: {} });
 });
 
@@ -117,5 +131,44 @@ describe("SessionChatSurface link routing", () => {
 		);
 
 		expect(screen.getByRole("button", { name: "Switch agent" })).toBeInTheDocument();
+	});
+
+	it("does not offer in-place agent switching before the runtime handle exists", () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		});
+		render(
+			<Wrapper client={queryClient}>
+				<SessionChatSurface session={{ ...session, terminalHandleId: undefined }} />
+			</Wrapper>,
+		);
+
+		expect(screen.queryByRole("button", { name: "Switch agent" })).not.toBeInTheDocument();
+	});
+
+	it("keeps a selected shell renderable when the conversation is unavailable", () => {
+		conversationState.snapshot = undefined;
+		conversationState.unavailable = { message: "Controller is unavailable" };
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		});
+
+		render(
+			<Wrapper client={queryClient}>
+				<SessionChatSurface
+					session={session}
+					shellTarget={{
+						kind: "shell",
+						handleId: "shell-1",
+						sessionId: session.id,
+						title: "shell",
+						generation: "2026-08-16T00:00:00Z",
+					}}
+				/>
+			</Wrapper>,
+		);
+
+		expect(screen.getByTestId("shell-target")).toHaveTextContent("shell-1");
+		expect(screen.queryByText("Conversation unavailable")).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -24,6 +24,7 @@ import {
 import { useSessionBrowserLink } from "../../hooks/useSessionBrowserLink";
 import type { ShellTerminal } from "../../hooks/useShellTerminals";
 import { can } from "../../types/conversation";
+import type { ConversationSnapshot } from "../../types/conversation";
 import type { Theme } from "../../stores/ui-store";
 import type { TerminalTarget } from "../../types/terminal";
 import type { WorkspaceSession } from "../../types/workspace";
@@ -109,8 +110,14 @@ export function SessionChatSurface({
 	const [switchSelectorOpen, setSwitchSelectorOpen] = useState(false);
 	const [switchSelectorContainer, setSwitchSelectorContainer] = useState<HTMLDivElement | null>(null);
 	const switchMutation = useSwitchAgentState(session.id);
+	const renderShellFallback = Boolean(shellTarget && session);
+	const renderSnapshot =
+		snapshot ??
+		(renderShellFallback
+			? unavailableConversationSnapshot(session)
+			: undefined);
 
-	if (isLoading) {
+	if (isLoading && !renderShellFallback) {
 		return (
 			<Centered>
 				<Loader2 aria-hidden="true" className="size-4 animate-spin text-muted-foreground" />
@@ -123,7 +130,7 @@ export function SessionChatSurface({
 	// run Chat is a state to explain rather than an error to spin on. A compatible
 	// session may switch interfaces, but retrying this failed controller by itself
 	// cannot change the answer.
-	if (unavailable) {
+	if (unavailable && !renderShellFallback) {
 		return (
 			<Centered>
 				<AlertTriangle aria-hidden="true" className="size-4 text-warning" />
@@ -138,7 +145,7 @@ export function SessionChatSurface({
 		);
 	}
 
-	if (error || !snapshot) {
+	if (error || !renderSnapshot) {
 		return (
 			<Centered>
 				<AlertTriangle aria-hidden="true" className="size-4 text-destructive" />
@@ -151,7 +158,7 @@ export function SessionChatSurface({
 
 	return (
 		<ChatWorkspace
-			snapshot={snapshot}
+			snapshot={renderSnapshot}
 			onLinkOpen={openLinkInBrowser}
 			sessionTitle={session.title}
 			sessionRole={session.kind}
@@ -166,13 +173,15 @@ export function SessionChatSurface({
 			onCloseShellTerminal={onCloseShellTerminal}
 			onRenameShellTerminal={onRenameShellTerminal}
 			switchAgentControl={
-				<TerminalSwitchAgentButton
-					container={switchSelectorContainer}
-					onOpenChange={setSwitchSelectorOpen}
-					open={switchSelectorOpen}
-					session={session}
-					switchError={switchMutation.error}
-				/>
+				session.terminalHandleId ? (
+					<TerminalSwitchAgentButton
+						container={switchSelectorContainer}
+						onOpenChange={setSwitchSelectorOpen}
+						open={switchSelectorOpen}
+						session={session}
+						switchError={switchMutation.error}
+					/>
+				) : undefined
 			}
 			switchDialogContainer={setSwitchSelectorContainer}
 			daemonReady={daemonReady}
@@ -218,21 +227,21 @@ export function SessionChatSurface({
 			filePaths={paths}
 			filePathsTruncated={truncated}
 			onStageAttachments={stageAttachments}
-			nativeImages={can(snapshot, "images")}
+			nativeImages={can(renderSnapshot, "images")}
 			// Gated on what the daemon advertises, so the control is never drawn for a
 			// harness that cannot steer. The refusal check stays as a backstop: it
 			// covers the window before the controller reports, and it is the last word
 			// afterwards, since the capability is a property of the driver.
-			onSteer={can(snapshot, "steer") && !commands.steerUnsupported ? commands.steer : undefined}
+			onSteer={can(renderSnapshot, "steer") && !commands.steerUnsupported ? commands.steer : undefined}
 			onPromoteQueuedTurn={
-				can(snapshot, "steer") && !commands.steerUnsupported
+				can(renderSnapshot, "steer") && !commands.steerUnsupported
 					? commands.promoteQueuedTurn
 					: undefined
 			}
 			steerPending={commands.steerPending}
 			steerRefusal={commands.steerRefusal}
 			onReloadMcpServers={
-				!can(snapshot, "mcp_reload") || commands.mcpReloadUnsupported
+				!can(renderSnapshot, "mcp_reload") || commands.mcpReloadUnsupported
 					? undefined
 					: () => {
 							// The rejection is already held by the mutation and rendered from
@@ -244,6 +253,26 @@ export function SessionChatSurface({
 			mcpReloadError={commands.mcpReloadError}
 		/>
 	);
+}
+
+function unavailableConversationSnapshot(session: WorkspaceSession): ConversationSnapshot {
+	return {
+		conversationId: session.id,
+		sessionId: session.id,
+		harness: session.provider,
+		mode: "chat",
+		controller: { state: "stopped", error: "Conversation unavailable" },
+		latestSequence: 0,
+		oldestSequence: 0,
+		hasMoreBefore: false,
+		activeBranchId: "branch-root",
+		branchPoints: [],
+		settings: {},
+		mcpServers: [],
+		capabilities: [],
+		turns: [],
+		items: [],
+	};
 }
 
 function Centered({ children }: { children: React.ReactNode }) {

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -8,8 +8,10 @@
  */
 
 import { AlertTriangle, Loader2 } from "lucide-react";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { ChatWorkspace } from "./ChatWorkspace";
+import { useSwitchAgentState } from "../../hooks/useSwitchAgent";
+import { TerminalSwitchAgentButton } from "../TerminalSwitchAgentButton";
 import {
 	useConversation,
 	useConversationCommands,
@@ -20,6 +22,7 @@ import {
 	useWorkspaceFilePaths,
 } from "../../hooks/useConversation";
 import { useSessionBrowserLink } from "../../hooks/useSessionBrowserLink";
+import type { ShellTerminal } from "../../hooks/useShellTerminals";
 import { can } from "../../types/conversation";
 import type { Theme } from "../../stores/ui-store";
 import type { TerminalTarget } from "../../types/terminal";
@@ -31,6 +34,11 @@ export function SessionChatSurface({
 	onOpenReviewerTerminal,
 	reviewerTarget,
 	onSelectChat,
+	shellTerminals,
+	shellTarget,
+	onSelectShellTerminal,
+	onCloseShellTerminal,
+	onRenameShellTerminal,
 	daemonReady,
 	theme,
 	onOpenShell,
@@ -44,6 +52,13 @@ export function SessionChatSurface({
 	onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
 	reviewerTarget?: Extract<TerminalTarget, { kind: "reviewer" }>;
 	onSelectChat?: () => void;
+	/** This session's standalone shells, rendered as tabs in the chat header. */
+	shellTerminals?: ShellTerminal[];
+	/** The selected shell pane, if any. Mirrors reviewerTarget. */
+	shellTarget?: Extract<TerminalTarget, { kind: "shell" }>;
+	onSelectShellTerminal?: (handleId: string) => void;
+	onCloseShellTerminal?: (handleId: string) => void;
+	onRenameShellTerminal?: (handleId: string, title: string) => void;
 	daemonReady?: boolean;
 	theme?: Theme;
 	onOpenShell?: () => void;
@@ -87,6 +102,13 @@ export function SessionChatSurface({
 	const { paths, truncated } = useWorkspaceFilePaths(session.id, Boolean(snapshot));
 	const stageAttachments = useStageAttachments(session.id);
 	const openLinkInBrowser = useSessionBrowserLink(session);
+	// In-place agent switching is the same session-level operation in either
+	// interface; the chat header offers the same entry point the terminal pane's
+	// tab strip does. Mirrors CenterPane: dialog open flag plus the element the
+	// dialog anchors to (the workspace body, handed up by ChatWorkspace).
+	const [switchSelectorOpen, setSwitchSelectorOpen] = useState(false);
+	const [switchSelectorContainer, setSwitchSelectorContainer] = useState<HTMLDivElement | null>(null);
+	const switchMutation = useSwitchAgentState(session.id);
 
 	if (isLoading) {
 		return (
@@ -138,6 +160,21 @@ export function SessionChatSurface({
 			onOpenReviewerTerminal={onOpenReviewerTerminal}
 			reviewerTarget={reviewerTarget}
 			onSelectChat={onSelectChat}
+			shellTerminals={shellTerminals}
+			shellTarget={shellTarget}
+			onSelectShellTerminal={onSelectShellTerminal}
+			onCloseShellTerminal={onCloseShellTerminal}
+			onRenameShellTerminal={onRenameShellTerminal}
+			switchAgentControl={
+				<TerminalSwitchAgentButton
+					container={switchSelectorContainer}
+					onOpenChange={setSwitchSelectorOpen}
+					open={switchSelectorOpen}
+					session={session}
+					switchError={switchMutation.error}
+				/>
+			}
+			switchDialogContainer={setSwitchSelectorContainer}
 			daemonReady={daemonReady}
 			theme={theme}
 			headerActions={headerActions}


### PR DESCRIPTION
Part of #4033 — closes its shell and agent-switch gaps.

## Summary

Two constructs that work in Terminal UI now work the same in Chat UI, without leaving the conversation:

**Shells are tabs in the chat header (Gap 1).** Previously `showChatSurface` only stayed mounted for `worker`/`reviewer` targets, so opening a shell unmounted the entire chat surface — timeline, composer draft, scroll position — and swapped in `CenterPane`. Now a shell target renders its `TerminalPane` as the tab body inside the chat surface (the routed `TerminalTarget` passed straight through, mirroring `reviewerTarget` from #4027), and the conversation panel hides with `hidden`/`inert` instead of unmounting — drafts, attachments, edits, and scroll survive.

Shell tabs use the shared `ShellTerminalTab` (already used by `CenterPane` and the terminals screen "so the three never drift"), which brings select/close/**rename** along for free. The desktop next/previous tab shortcuts (Ctrl+Tab / Ctrl+Shift+Tab) now cycle chat → reviewer → shells in strip order.

**Agent switching has an entry point in chat (Gap 2).** `CenterPane` rendered `TerminalSwitchAgentButton`; the chat surface had nothing, even though `useSwitchAgent` was already chat-aware (it invalidates conversation queries). The same control now renders in the chat header's action region. The mutation state lives in `SessionChatSurface` — which owns query wiring — so `ChatWorkspace` stays a provider-free pure view (its documented contract; enforced by existing fixture tests).

## Changes (6 files, +377/−28)

| File | What |
|---|---|
| `SessionView.tsx` | `showChatSurface` stays mounted for `shell` targets; passes the routed shell target + shell list/select/close/rename into the chat surface. |
| `SessionChatSurface.tsx` | Forwards shell props; owns the agent-switch dialog state + mutation; hands the button and a body-container ref down. |
| `ChatWorkspace.tsx` | Shell pane parallel to the reviewer pane (same `TerminalPane` target passthrough, zoom/fullscreen wiring); shell tabs via shared `ShellTerminalTab`; `timelineActive` generalization so the chat tab deactivates for either terminal pane; next-tab shortcut cycles through shells; renders the passed-down switch control. |
| tests | ChatWorkspace: shell pane hides-not-unmounts the conversation, target passthrough, Ctrl+Tab cycling. SessionView: shells-from-chat stay inside the chat surface. SessionChatSurface: switch control offered in chat. |

## What's deliberately not here

- **Full tab-strip unification (Gap 3 remainder):** the chat/reviewer tabs remain hand-rolled in `ChatHeader`; extracting one shared strip with `CenterPane` remains a follow-up on #4033.
- CenterPane's deep in-flight switch UX (input locking, source focus, announcements) — the chat surface already reflects controller transitions through its own banners; the button/dialog/mutation flow is identical.

## Test

- `npm run typecheck` — ✅ 0 errors
- `vitest run --exclude 'src/landing/**'` — ✅ 173 files, 2352 passed, 0 failures
- `src/landing` failures are pre-existing on the base branch and unrelated.

Rebased onto `main` after #4027 merged; see [the screenshot comment](https://github.com/Untrivial-ai/agent-orchestrator/pull/4036#issuecomment-5301564255) for live-app captures.
