### PR TITLE
fix(frontend): stabilize switch agent selector

### DIFF
--- a/frontend/e2e/switch-agent-dialog.spec.ts
+++ b/frontend/e2e/switch-agent-dialog.spec.ts
@@ -3,9 +3,8 @@ import { installFakeAgent } from "./support/fake-bridge";
 
 const projectId = "switch-agent-dialog";
 
-test.use({ reducedMotion: "reduce" });
-
 async function openSwitchAgentDialog(page: Page) {
+	await page.emulateMedia({ reducedMotion: "reduce" });
 	await installFakeAgent(page, {
 		projectId,
 		projectName: projectId,
@@ -53,7 +52,7 @@ async function openSwitchAgentDialog(page: Page) {
 	};
 }
 
-test("renderer: switch-agent selector remains compact inside a wide terminal", async ({ page }) => {
+test("renderer: switch-agent selector remains compact inside a wide terminal @T0", async ({ page }) => {
 	const { dialog, terminalPanel } = await openSwitchAgentDialog(page);
 	await expect(dialog).toHaveCSS("width", "420px");
 	await expect
@@ -61,7 +60,7 @@ test("renderer: switch-agent selector remains compact inside a wide terminal", a
 		.toBeGreaterThan(420);
 });
 
-test("renderer: switch-agent selector stays inside a narrow terminal", async ({ page }) => {
+test("renderer: switch-agent selector stays inside a narrow terminal @T0", async ({ page }) => {
 	await page.setViewportSize({ width: 960, height: 720 });
 	const { dialog, terminalPanel } = await openSwitchAgentDialog(page);
 	const dialogBox = await dialog.boundingBox();

--- a/frontend/e2e/switch-agent-dialog.spec.ts
+++ b/frontend/e2e/switch-agent-dialog.spec.ts
@@ -1,0 +1,76 @@
+import { expect, type Page, test } from "@playwright/test";
+import { installFakeAgent } from "./support/fake-bridge";
+
+const projectId = "switch-agent-dialog";
+
+test.use({ reducedMotion: "reduce" });
+
+async function openSwitchAgentDialog(page: Page) {
+	await installFakeAgent(page, {
+		projectId,
+		projectName: projectId,
+		workers: [{ id: "switch-worker", provider: "claude-code", title: "Switch worker" }],
+	});
+	await page.route("http://127.0.0.1:8080/api/v1/**", async (route) => {
+		const pathname = new URL(route.request().url()).pathname;
+		if (pathname === `/api/v1/projects/${projectId}`) {
+			await route.fulfill({
+				json: {
+					status: "ok",
+					project: {
+						id: projectId,
+						agent: "claude-code",
+						config: { worker: { agent: "claude-code" } },
+					},
+				},
+			});
+			return;
+		}
+		if (pathname === "/api/v1/agents/codex/models") {
+			await route.fulfill({
+				json: {
+					agentId: "codex",
+					allowCustom: false,
+					fetchedAt: "2026-08-15T00:00:00Z",
+					models: [{ id: "gpt-5.4", label: "GPT-5.4", isDefault: true }],
+					selectionMode: "catalog",
+					source: "test",
+					stale: false,
+				},
+			});
+			return;
+		}
+		await route.fulfill({ json: { status: "ok" } });
+	});
+
+	await page.goto(`/#/projects/${projectId}/sessions/switch-worker`);
+	await page.getByRole("button", { name: "Switch agent", exact: true }).click();
+	const dialog = page.getByRole("dialog", { name: "Switch agent" });
+	await expect(dialog).toBeVisible();
+	return {
+		dialog,
+		terminalPanel: page.getByRole("tabpanel", { name: "Switch worker terminal" }),
+	};
+}
+
+test("renderer: switch-agent selector remains compact inside a wide terminal", async ({ page }) => {
+	const { dialog, terminalPanel } = await openSwitchAgentDialog(page);
+	await expect(dialog).toHaveCSS("width", "420px");
+	await expect
+		.poll(async () => (await terminalPanel.boundingBox())?.width ?? 0)
+		.toBeGreaterThan(420);
+});
+
+test("renderer: switch-agent selector stays inside a narrow terminal", async ({ page }) => {
+	await page.setViewportSize({ width: 960, height: 720 });
+	const { dialog, terminalPanel } = await openSwitchAgentDialog(page);
+	const dialogBox = await dialog.boundingBox();
+	const terminalBox = await terminalPanel.boundingBox();
+
+	expect(dialogBox).not.toBeNull();
+	expect(terminalBox).not.toBeNull();
+	expect(dialogBox!.x).toBeGreaterThanOrEqual(terminalBox!.x + 16);
+	expect(dialogBox!.x + dialogBox!.width).toBeLessThanOrEqual(
+		terminalBox!.x + terminalBox!.width - 16,
+	);
+});

--- a/frontend/src/renderer/components/SwitchAgentDialog.test.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.test.tsx
@@ -94,7 +94,6 @@ describe("SwitchAgentDialog", () => {
 		expect(dialog).toHaveAttribute("data-slot", "dialog-content");
 		const backdrop = screen.getByTestId("switch-agent-terminal-backdrop");
 		expect(backdrop).toHaveClass("agent-switch-terminal-scrim");
-		expect(dialog).toHaveClass("w-dialog-md");
 		expect(
 			within(dialog).getByText(
 				"Move this session from Claude Code to another agent. AO will preserve the current native session and hand off the work.",

--- a/frontend/src/renderer/components/SwitchAgentDialog.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.tsx
@@ -223,7 +223,7 @@ export function SwitchAgentDialog({ container, open, session, onOpenChange }: Sw
 					/>
 				}
 				showCloseButton={false}
-				className="absolute left-1/2 top-1/2 z-overlay w-dialog-md max-w-none -translate-x-1/2 -translate-y-1/2 gap-0 overflow-hidden rounded-xl border border-border-strong bg-surface/95 p-0 text-foreground shadow-xl shadow-black/20 data-[state=open]:animate-modal-in data-[state=closed]:animate-modal-out motion-reduce:animate-none"
+				className="absolute left-1/2 top-1/2 z-overlay w-[min(var(--size-dialog-md),calc(100%-var(--space-8)))] max-w-none -translate-x-1/2 -translate-y-1/2 gap-0 overflow-hidden rounded-xl border border-border-strong bg-surface/95 p-0 text-foreground shadow-xl shadow-black/20 data-[state=open]:animate-modal-in data-[state=closed]:animate-modal-out motion-reduce:animate-none"
 			>
 					<DialogClose asChild>
 						<button

--- a/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
+++ b/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
@@ -70,19 +70,25 @@ function switchPresentation(
 }
 
 function SwitchControlHarness({
+	onOpenChangeObserved,
 	presentation,
 	session,
 }: {
+	onOpenChangeObserved?: (open: boolean) => void;
 	presentation?: AgentSwitchPresentation;
 	session: WorkspaceSession;
 }) {
 	const [container, setContainer] = useState<HTMLDivElement | null>(null);
 	const [open, setOpen] = useState(false);
+	const handleOpenChange = (nextOpen: boolean) => {
+		onOpenChangeObserved?.(nextOpen);
+		setOpen(nextOpen);
+	};
 	return (
 		<div className="relative" data-testid="terminal-container" ref={setContainer}>
 			<TerminalSwitchAgentButton
 				container={container}
-				onOpenChange={setOpen}
+				onOpenChange={handleOpenChange}
 				open={open}
 				presentation={presentation}
 				session={session}
@@ -95,6 +101,7 @@ function SwitchControlHarness({
 function renderControl(
 	session: WorkspaceSession = worker,
 	presentation?: AgentSwitchPresentation,
+	onOpenChangeObserved?: (open: boolean) => void,
 ) {
 	const queryClient = new QueryClient({
 		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -102,7 +109,12 @@ function renderControl(
 	const control = (nextSession: WorkspaceSession, nextPresentation = presentation) => (
 		<QueryClientProvider client={queryClient}>
 			<TooltipProvider>
-				<SwitchControlHarness key={nextSession.id} presentation={nextPresentation} session={nextSession} />
+				<SwitchControlHarness
+					key={nextSession.id}
+					onOpenChangeObserved={onOpenChangeObserved}
+					presentation={nextPresentation}
+					session={nextSession}
+				/>
 			</TooltipProvider>
 		</QueryClientProvider>
 	);
@@ -195,6 +207,21 @@ describe("TerminalSwitchAgentButton", () => {
 		});
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("keeps the open selector stable when the toolbar button is reactivated", async () => {
+		const openChanges = vi.fn();
+		renderControl(worker, undefined, openChanges);
+		const button = await screen.findByRole("button", { name: "Switch agent" });
+
+		await userEvent.click(button);
+		expect(screen.getByRole("dialog", { name: "Switch agent" })).toBeInTheDocument();
+		openChanges.mockClear();
+
+		await userEvent.click(button);
+
+		expect(openChanges).not.toHaveBeenCalled();
+		expect(screen.getByRole("dialog", { name: "Switch agent" })).toBeInTheDocument();
 	});
 
 	it("closes after accepted admission without waiting for durable observer invalidations", async () => {

--- a/frontend/src/renderer/components/TerminalSwitchAgentButton.tsx
+++ b/frontend/src/renderer/components/TerminalSwitchAgentButton.tsx
@@ -68,7 +68,14 @@ export function TerminalSwitchAgentButton({
 							warning && "text-warning hover:bg-warning/10 hover:text-warning",
 						)}
 						disabled={blocksNewSwitch}
-						onClick={() => handleOpenChange(true)}
+						onClick={() => {
+							if (!open) handleOpenChange(true);
+						}}
+						onPointerDown={(event) => {
+							if (!open) return;
+							event.preventDefault();
+							event.stopPropagation();
+						}}
 						type="button"
 						variant="icon"
 					>


### PR DESCRIPTION
## What

- keep the terminal-scoped Switch agent selector at the 420px dialog token on wide panes and within a 16px gutter on narrow panes
- make repeated activation of the already-open toolbar control a no-op instead of closing and reopening the Radix dialog
- cover the browser-computed wide/narrow geometry and the repeated activation state sequence

## Why

Fixes #4039.

The shared dialog primitive contributes `w-full`, while the custom `w-dialog-md` class was not recognized as a conflicting Tailwind utility. Both survived merging and the later full-width rule won. Separately, the non-modal dialog treated a pointer-down on the toolbar control as an outside dismissal before the control's click handler reopened it.

## How

- use an arbitrary width utility so `tailwind-merge` replaces the shared `w-full`; cap it against the terminal containing block rather than the viewport
- intercept pointer activation only while the selector is already open, with an `onClick` guard covering keyboard and assistive-technology activation
- replace the former class-name assertion with real computed-width Playwright coverage

## Testing

- `npm test` — 185 files passed; 2,397 tests passed, 1 skipped
- `npm run typecheck`
- `npx vite build --config vite.renderer.config.ts`
- `frontend/e2e/switch-agent-dialog.spec.ts` against an isolated `dev:web` renderer — 2 passed (wide and narrow terminal cases)
- targeted red/green verification for repeated activation — 23 component tests passed

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
