### PR TITLE
feat(notifications): change badge background to red

### DIFF
--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -295,7 +295,7 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 						<Bell className="size-icon-base" aria-hidden="true" />
 					)}
 					{unreadCount > 0 ? (
-						<span className="pointer-events-none absolute right-px top-px grid h-3 min-w-3 place-items-center rounded-full bg-accent-strong px-0.5 font-mono text-[7px] font-semibold leading-none text-accent-foreground shadow-sm ring-1 ring-background">
+						<span className="pointer-events-none absolute right-px top-px grid h-3 min-w-3 place-items-center rounded-full bg-red-500 px-0.5 font-mono text-[7px] font-semibold leading-none text-white shadow-sm ring-1 ring-background">
 							{unreadCount > 99 ? "99+" : unreadCount}
 						</span>
 					) : null}


### PR DESCRIPTION
Change the notification icon badge background color from  to  for better visibility of unread notifications.

**Changes:**
- Updated badge background:  → 
- Updated badge text color:  →  for better contrast

**File modified:** 