### PR TITLE
fix: sort activity timeline by timestamp

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -765,7 +765,7 @@ describe("SessionInspector Activity section", () => {
 		expect(within(activityRow).getByText("Conflict")).toBeInTheDocument();
 	});
 
-	it("does not timestamp the live Activity state as a historical event", () => {
+	it("timestamps the live Activity state so it participates in chronological ordering", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2026-06-15T12:00:00Z"));
 
@@ -782,7 +782,7 @@ describe("SessionInspector Activity section", () => {
 		const activityRow = activitySection()
 			.getByText("Working")
 			.closest("[data-testid='inspector-timeline-event']") as HTMLElement;
-		expect(within(activityRow).queryByText("2h ago")).not.toBeInTheDocument();
+		expect(within(activityRow).getByText("2h ago")).toBeInTheDocument();
 	});
 
 	it("aligns text-row dots lower while keeping the Activity chip dot centered", () => {
@@ -934,19 +934,42 @@ describe("SessionInspector Activity section", () => {
 		expect(within(doneRow).getByText("30m ago")).toBeInTheDocument();
 	});
 
-	it("renders the current state before reverse-chronological historical milestones", () => {
+	it("orders Activity timeline rows by timestamp with the latest event on top", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2026-06-15T12:00:00Z"));
+		const summaries = [
+			prSummary(42, "draft", {
+				createdAt: "2026-06-15T08:00:00Z",
+				stateChangedAt: "2026-06-15T08:00:00Z",
+			}),
+			prSummary(41, "open", {
+				createdAt: "2026-06-15T11:30:00Z",
+				stateChangedAt: "2026-06-15T11:30:00Z",
+			}),
+			prSummary(40, "merged", {
+				createdAt: "2026-06-15T09:15:00Z",
+				stateChangedAt: "2026-06-15T10:45:00Z",
+			}),
+		];
 
 		renderWithQuery(
 			<SessionInspector
-				session={session([pr(42, "draft"), pr(41, "open"), pr(40, "merged")], {
-					status: "merged",
-					createdAt: "2026-06-15T09:00:00Z",
-					updatedAt: "2026-06-15T11:55:00Z",
-					activity: { state: "idle", lastActivityAt: "2026-06-15T10:00:00Z" },
-				})}
+				session={session(
+					[
+						pr(42, "draft", { url: `https://api.github.com/repos/acme/repo/pulls/42` }),
+						pr(41, "open", { url: `https://api.github.com/repos/acme/repo/pulls/41` }),
+						pr(40, "merged", { url: `https://api.github.com/repos/acme/repo/pulls/40` }),
+					],
+					{
+						status: "merged",
+						createdAt: "2026-06-15T09:00:00Z",
+						updatedAt: "2026-06-15T11:55:00Z",
+						activity: { state: "idle", lastActivityAt: "2026-06-15T10:00:00Z" },
+					},
+				)}
 			/>,
+			undefined,
+			(client) => client.setQueryData(sessionScmSummaryQueryKey("sess-1"), summaries),
 		);
 
 		const section = screen.getByText("Activity").closest("[data-testid='inspector-section']") as HTMLElement;
@@ -954,13 +977,13 @@ describe("SessionInspector Activity section", () => {
 			row.textContent?.replace(/\s+/g, " ").trim(),
 		);
 		expect(rows).toEqual([
-			"Idle",
-			"Done",
-			"Merged PR #40",
-			"Opened PR #40",
-			"Opened PR #41",
-			"Draft PR #42",
+			"Opened PR #4130m ago",
+			"Merged PR #401h ago",
+			"Done1h ago",
+			"Idle2h ago",
+			"Opened PR #402h ago",
 			"Created workspace3h ago",
+			"Draft PR #424h ago",
 		]);
 
 		const eventRows = section.querySelectorAll("[data-testid='inspector-timeline-event']");

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -662,77 +662,99 @@ function PRSummaryCard({ pr, sessionId }: { pr: SessionPRSummary; sessionId: str
 	);
 }
 
-function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: WorkspaceSession }) {
-	const history: InspectorTimelineEvent[] = [];
+type SortableTimelineEvent = InspectorTimelineEvent & { sortTime: number };
 
-	history.push({
-		tone: "neutral",
-		content: <>{appI18n.t("inspector.timeline.createdWorkspace")}</>,
-		timestamp: formatTimeCompact(session.createdAt ?? session.updatedAt),
-	});
+function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: WorkspaceSession }) {
+	const events: SortableTimelineEvent[] = [];
+	const pushEvent = (event: InspectorTimelineEvent, timestamp?: string | null) => {
+		events.push({ ...event, sortTime: timelineSortTime(timestamp) });
+	};
+	const createdAt = session.createdAt ?? session.updatedAt;
+
+	pushEvent(
+		{
+			tone: "neutral",
+			content: <>{appI18n.t("inspector.timeline.createdWorkspace")}</>,
+			timestamp: formatTimeCompact(createdAt),
+		},
+		createdAt,
+	);
 
 	for (const pr of prs.filter((pr) => pr.state === "draft")) {
-		history.push({
-			tone: "neutral",
-			content: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.draft")} />,
-			timestamp: prStateTime(pr),
-		});
+		pushEvent(
+			{
+				tone: "neutral",
+				content: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.draft")} />,
+				timestamp: prStateTime(pr),
+			},
+			pr.stateChangedAt,
+		);
 	}
 
 	for (const pr of prs.filter((pr) => pr.state !== "draft")) {
-		history.push({
-			tone: "neutral",
-			content: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.opened")} />,
-			timestamp: prCreatedTime(pr),
-		});
+		pushEvent(
+			{
+				tone: "neutral",
+				content: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.opened")} />,
+				timestamp: prCreatedTime(pr),
+			},
+			pr.createdAt,
+		);
 	}
 
 	for (const pr of prs.filter((pr) => pr.state === "merged")) {
-		history.push({
-			tone: "good",
-			content: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.merged")} />,
-			timestamp: prStateTime(pr),
-		});
+		pushEvent(
+			{
+				tone: "good",
+				content: <PRTimelineLink pr={pr} verb={appI18n.t("inspector.timeline.merged")} />,
+				timestamp: prStateTime(pr),
+			},
+			pr.stateChangedAt,
+		);
 	}
 
 	if (session.status === "merged") {
-		history.push({
-			tone: "good",
-			content: <>{appI18n.t("inspector.timeline.done")}</>,
-			timestamp: latestMergedTime(prs),
-		});
+		const mergedAt = latestMergedTimestamp(prs);
+		pushEvent(
+			{
+				tone: "good",
+				content: <>{appI18n.t("inspector.timeline.done")}</>,
+				timestamp: mergedAt ? formatTimeCompact(mergedAt) : null,
+			},
+			mergedAt,
+		);
 	}
 
-	// Current activity is a live reading, not a historical event. Keep it above
-	// the optional reverse-chronological history and do not imply that its last
-	// hook time is when the state transition occurred.
 	const activityView = getAgentActivityView(session.activity);
-	const current = {
-		tone: "now",
-		content: (
-			<span className="inline-flex flex-wrap items-center gap-1.5">
-				<span className="inline-flex align-middle">
-					<InspectorActivityPill activity={session.activity} />
-				</span>
-				{session.status === "no_signal" ? (
+	const activityAt = session.activity?.lastActivityAt ?? session.updatedAt ?? session.createdAt;
+	pushEvent(
+		{
+			tone: "now",
+			content: (
+				<span className="inline-flex flex-wrap items-center gap-1.5">
 					<span className="inline-flex align-middle">
-						<TimelinePill {...getSessionTimelinePillView("no_signal")} />
-				</span>
-			) : null}
-				{scmTimelineStates(session).map((state) => (
-					<span key={state} className="inline-flex align-middle">
-						<InspectorScmPill state={state} />
+						<InspectorActivityPill activity={session.activity} />
 					</span>
-				))}
-			</span>
-		),
-		timestamp: null,
-		markerTone: activityView.tone,
-		markerBreathe: activityView.breathe,
-	} satisfies InspectorTimelineEvent;
-	const events = [current, ...history.reverse()];
+					{session.status === "no_signal" ? (
+						<span className="inline-flex align-middle">
+							<TimelinePill {...getSessionTimelinePillView("no_signal")} />
+						</span>
+					) : null}
+					{scmTimelineStates(session).map((state) => (
+						<span key={state} className="inline-flex align-middle">
+							<InspectorScmPill state={state} />
+						</span>
+					))}
+				</span>
+			),
+			timestamp: activityAt ? formatTimeCompact(activityAt) : null,
+			markerTone: activityView.tone,
+			markerBreathe: activityView.breathe,
+		} satisfies InspectorTimelineEvent,
+		activityAt,
+	);
 
-	return <InspectorActivityTimelineView events={events} />;
+	return <InspectorActivityTimelineView events={[...events].sort((a, b) => b.sortTime - a.sortTime)} />;
 }
 
 function PRTimelineLink({ pr, verb }: { pr: SessionPRSummary; verb: string }) {
@@ -759,7 +781,7 @@ function prCreatedTime(pr: SessionPRSummary): string | null {
 	return pr.createdAt ? formatTimeCompact(pr.createdAt) : null;
 }
 
-function latestMergedTime(prs: SessionPRSummary[]): string | null {
+function latestMergedTimestamp(prs: SessionPRSummary[]): string | null {
 	let latest: { timestamp: string; milliseconds: number } | undefined;
 	for (const pr of prs) {
 		if (pr.state !== "merged" || !pr.stateChangedAt) continue;
@@ -769,7 +791,13 @@ function latestMergedTime(prs: SessionPRSummary[]): string | null {
 			latest = { timestamp: pr.stateChangedAt, milliseconds };
 		}
 	}
-	return latest ? formatTimeCompact(latest.timestamp) : null;
+	return latest?.timestamp ?? null;
+}
+
+function timelineSortTime(timestamp: string | null | undefined): number {
+	if (!timestamp) return Number.NEGATIVE_INFINITY;
+	const milliseconds = Date.parse(timestamp);
+	return Number.isFinite(milliseconds) ? milliseconds : Number.NEGATIVE_INFINITY;
 }
 
 type ScmTimelineState = "ci_failed" | "changes_requested" | "conflict";


### PR DESCRIPTION
## Summary
- Sort Activity timeline events by parsed timestamps descending so the latest entry appears on top
- Include the live activity row in timestamp ordering using lastActivityAt
- Update SessionInspector tests for timestamped live activity and latest-first ordering

## Tests
- npm --prefix frontend run typecheck
- npm --prefix frontend test -- SessionInspector.test.tsx

## Risks
- Rows with missing or unparsable timestamps sort to the bottom.