### PR TITLE
fix: send inline review comments to worker

### DIFF
--- a/frontend/scripts/prepare-agent-browser.mjs
+++ b/frontend/scripts/prepare-agent-browser.mjs
@@ -6,6 +6,8 @@ const VERSION = "0.33.1";
 const RELEASE_BASE = `https://github.com/vercel-labs/agent-browser/releases/download/v${VERSION}`;
 const OUTPUT_DIR = path.resolve("agent-browser");
 const quiet = process.argv.includes("--quiet");
+const DOWNLOAD_ATTEMPTS = 3;
+const DOWNLOAD_RETRY_DELAY_MS = 1000;
 
 const TARGETS = {
 	"darwin-arm64": {
@@ -43,9 +45,11 @@ await mkdir(OUTPUT_DIR, { recursive: true });
 if ((await fileSHA256(binaryPath)) !== target.sha256) {
 	const temporaryPath = `${binaryPath}.download`;
 	await rm(temporaryPath, { force: true });
-	const response = await fetch(`${RELEASE_BASE}/${target.asset}`, { redirect: "follow" });
-	if (!response.ok || !response.body) {
-		throw new Error(`download agent-browser ${VERSION}: HTTP ${response.status}`);
+	const response = await fetchWithRetry(`${RELEASE_BASE}/${target.asset}`, {
+		description: `agent-browser ${VERSION}`,
+	});
+	if (!response.body) {
+		throw new Error(`download agent-browser ${VERSION}: empty response body`);
 	}
 	await writeFile(temporaryPath, response.body);
 	const actual = await fileSHA256(temporaryPath);
@@ -97,7 +101,29 @@ async function readText(file) {
 }
 
 async function downloadText(url, destination) {
-	const response = await fetch(url, { redirect: "follow" });
-	if (!response.ok) throw new Error(`download ${url}: HTTP ${response.status}`);
+	const response = await fetchWithRetry(url, { description: url });
 	await writeFile(destination, await response.text(), "utf8");
+}
+
+async function fetchWithRetry(url, { description }) {
+	let lastError;
+	for (let attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt += 1) {
+		try {
+			const response = await fetch(url, { redirect: "follow" });
+			if (response.ok) return response;
+			lastError = new Error(`HTTP ${response.status}`);
+		} catch (error) {
+			lastError = error;
+		}
+
+		if (attempt < DOWNLOAD_ATTEMPTS) {
+			if (!quiet) console.warn(`Download ${description} failed; retrying (${attempt}/${DOWNLOAD_ATTEMPTS})`);
+			await delay(DOWNLOAD_RETRY_DELAY_MS * attempt);
+		}
+	}
+	throw new Error(`download ${description}: ${lastError?.message ?? String(lastError)}`);
+}
+
+function delay(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1609,6 +1609,22 @@ describe("SessionInspector summary reviews", () => {
 
 		expect(await screen.findByText("Not injected")).toBeInTheDocument();
 		expect(screen.getByText("External reviews")).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: "Send to worker agent" }));
+		await waitFor(() =>
+			expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/send", {
+				params: { path: { sessionId: "sess-1" } },
+				body: {
+					message: expect.stringContaining("Location: a.ts:9"),
+				},
+			}),
+		);
+		expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/send", {
+			params: { path: { sessionId: "sess-1" } },
+			body: {
+				message: expect.stringContaining("Reviewer: @maya"),
+			},
+		});
+		expect(screen.getAllByText("Sent to worker agent")).toHaveLength(2);
 	});
 
 	it("marks an AO review using its stored injection decision", async () => {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1607,9 +1607,11 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
 		await openReviewsSection();
 
-		expect(await screen.findByText("Not injected")).toBeInTheDocument();
+		expect(screen.queryByText("Not injected")).not.toBeInTheDocument();
 		expect(screen.getByText("External reviews")).toBeInTheDocument();
-		await userEvent.click(screen.getByRole("button", { name: "Send to worker agent" }));
+		const sendButton = screen.getByRole("button", { name: "Send to worker agent" });
+		expect(sendButton).toBeEnabled();
+		await userEvent.click(sendButton);
 		await waitFor(() =>
 			expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/send", {
 				params: { path: { sessionId: "sess-1" } },
@@ -1642,7 +1644,7 @@ describe("SessionInspector summary reviews", () => {
 		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
 		await openReviewsSection();
 
-		expect(await screen.findByText("Not injected")).toBeInTheDocument();
+		expect(screen.queryByText("Not injected")).not.toBeInTheDocument();
 		expect(screen.getByText("Agent reviews")).toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1623,6 +1623,12 @@ describe("SessionInspector summary reviews", () => {
 		expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/send", {
 			params: { path: { sessionId: "sess-1" } },
 			body: {
+				message: expect.stringContaining("commit the fix, and push the branch to GitHub"),
+			},
+		});
+		expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/send", {
+			params: { path: { sessionId: "sess-1" } },
+			body: {
 				message: expect.stringContaining("Reviewer: @maya"),
 			},
 		});

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1273,7 +1273,8 @@ describe("SessionInspector summary reviews", () => {
 		await screen.findByText("Review in progress · Codex");
 
 		expect(screen.queryByText("Reviewable change 3")).not.toBeInTheDocument();
-		expect(screen.queryByText("Review summary")).not.toBeInTheDocument();
+		expect(screen.getByText("Review summary")).toBeInTheDocument();
+		expect(screen.getByText("No past review summaries yet.")).toBeInTheDocument();
 	});
 
 	it("shows eligible and up-to-date open PR review rows", async () => {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1273,8 +1273,7 @@ describe("SessionInspector summary reviews", () => {
 		await screen.findByText("Review in progress · Codex");
 
 		expect(screen.queryByText("Reviewable change 3")).not.toBeInTheDocument();
-		expect(screen.getByText("Review summary")).toBeInTheDocument();
-		expect(screen.getByText("No past review summaries yet.")).toBeInTheDocument();
+		expect(screen.queryByText("Review summary")).not.toBeInTheDocument();
 	});
 
 	it("shows eligible and up-to-date open PR review rows", async () => {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -14,6 +14,7 @@ import {
 	SessionInspectorSummaryView,
 	inspectorEmptyClass,
 	type InspectorPullRequest,
+	type InspectorInlineComment,
 	type InspectorReviewGroup,
 	type InspectorReviewLabels,
 	type InspectorTimelineEvent,
@@ -1089,6 +1090,14 @@ function MergedReviewsSection({
 	}
 	const rows = [...byNumber.entries()].sort(([a], [b]) => b - a);
 	const labels = reviewLabels(t);
+	const sendInlineCommentToWorker = async (comment: InspectorInlineComment & { reviewerId?: string }) => {
+		if (usePreviewData) return;
+		const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/send", {
+			params: { path: { sessionId: session.id } },
+			body: { message: formatInlineReviewCommentMessage(comment) },
+		});
+		if (error) throw new Error(apiErrorMessage(error, "Unable to send review comment to worker agent"));
+	};
 	const groups: InspectorReviewGroup[] = rows.map(([number, { ao, github }]) => {
 		const aoRuns = ao ? [...(runsByPR.get(ao.prUrl) ?? [])].sort((a, b) => b.createdAt.localeCompare(a.createdAt)) : [];
 		const entries = github?.review?.reviews ?? [];
@@ -1201,6 +1210,7 @@ function MergedReviewsSection({
 			groups={groups}
 			isLoading={isLoading}
 			labels={labels}
+			onSendInlineComment={sendInlineCommentToWorker}
 			renderAvatar={(harness) => (
 				<AgentAvatar className="size-icon-sm shrink-0" decorative provider={harness} />
 			)}
@@ -1251,6 +1261,32 @@ function renderReviewMarkdown(body: string) {
 			{body}
 		</ReactMarkdown>
 	);
+}
+
+function formatInlineReviewCommentMessage(comment: InspectorInlineComment & { reviewerId?: string }): string {
+	const reviewer = sanitizeWorkerMessagePart(comment.reviewerId?.trim() || "unknown reviewer");
+	const file = sanitizeWorkerMessagePart(comment.file?.trim() || "");
+	const location = file ? `${file}${comment.line ? `:${comment.line}` : ""}` : "general PR comment";
+	const body = sanitizeWorkerMessagePart(comment.body?.trim() || "No comment body provided.");
+	const url = sanitizeWorkerMessagePart(comment.url?.trim() || "");
+	const lines = [
+		`A reviewer left an unresolved inline comment on your PR. Address it and push fixes.`,
+		"",
+		`Reviewer: @${reviewer}`,
+		`Location: ${location}`,
+		"",
+		"Comment:",
+		body,
+	];
+	if (url) {
+		lines.push("", `Comment URL: ${url}`);
+	}
+	lines.push("", "You should not need to re-fetch review data unless you need additional context beyond what AO has provided here.");
+	return lines.join("\n");
+}
+
+function sanitizeWorkerMessagePart(value: string): string {
+	return value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "");
 }
 
 function projectConfig(project: components["schemas"]["ProjectOrDegraded"] | undefined): ProjectConfig | undefined {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1270,7 +1270,7 @@ function formatInlineReviewCommentMessage(comment: InspectorInlineComment & { re
 	const body = sanitizeWorkerMessagePart(comment.body?.trim() || "No comment body provided.");
 	const url = sanitizeWorkerMessagePart(comment.url?.trim() || "");
 	const lines = [
-		`A reviewer left an unresolved inline comment on your PR. Address it and push fixes.`,
+		`A reviewer left an unresolved inline comment on your PR. Address it, commit the fix, and push the branch to GitHub.`,
 		"",
 		`Reviewer: @${reviewer}`,
 		`Location: ${location}`,

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1236,6 +1236,7 @@ function reviewLabels(t: TFunction): InspectorReviewLabels {
 		resolvedComments: (count) => t("inspector.resolvedComments", { count }),
 		sendToWorkerAgent: t("inspector.sendToWorkerAgent"),
 		sentToWorkerAgent: t("inspector.sentToWorkerAgent"),
+		sendToWorkerAgentError: t("inspector.sendToWorkerAgentError"),
 		showLatestReviewOnly: t("inspector.showLatestReviewOnly"),
 		showLess: t("inspector.showLess"),
 		showMore: t("inspector.showMore"),

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1091,7 +1091,6 @@ function MergedReviewsSection({
 	const rows = [...byNumber.entries()].sort(([a], [b]) => b - a);
 	const labels = reviewLabels(t);
 	const sendInlineCommentToWorker = async (comment: InspectorInlineComment & { reviewerId?: string }) => {
-		if (usePreviewData) return;
 		const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/send", {
 			params: { path: { sessionId: session.id } },
 			body: { message: formatInlineReviewCommentMessage(comment) },

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -268,6 +268,7 @@
 	"inspector.resolvedComments": "Resolved comments · {{count}}",
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",
+	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
 	"inspector.viewInFile": "View in file",
 	"inspector.commentNumber": "Kommentar #{{number}}",
 	"inspector.loadMoreReviews": "Mehr laden · {{count}} frühere",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -267,6 +267,7 @@
 	"inspector.resolvedComments": "Resolved comments · {{count}}",
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",
+	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
 	"inspector.viewInFile": "View in file",
 	"inspector.commentNumber": "Comment #{{number}}",
 	"inspector.loadMoreReviews": "Load more · {{count}} earlier",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -270,6 +270,7 @@
 	"inspector.resolvedComments": "Resolved comments · {{count}}",
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",
+	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
 	"inspector.viewInFile": "View in file",
 	"inspector.commentNumber": "Comentario n.º {{number}}",
 	"inspector.loadMoreReviews": "Cargar más · {{count}} anteriores",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -270,6 +270,7 @@
 	"inspector.resolvedComments": "Resolved comments · {{count}}",
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",
+	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
 	"inspector.viewInFile": "View in file",
 	"inspector.commentNumber": "Commentaire n° {{number}}",
 	"inspector.loadMoreReviews": "Charger plus · {{count}} précédents",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -268,6 +268,7 @@
 	"inspector.resolvedComments": "Resolved comments · {{count}}",
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",
+	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
 	"inspector.viewInFile": "View in file",
 	"inspector.commentNumber": "コメント #{{number}}",
 	"inspector.loadMoreReviews": "さらに読み込む · 過去 {{count}} 件",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -268,6 +268,7 @@
 	"inspector.resolvedComments": "Resolved comments · {{count}}",
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",
+	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
 	"inspector.viewInFile": "View in file",
 	"inspector.commentNumber": "댓글 #{{number}}",
 	"inspector.loadMoreReviews": "더 불러오기 · 이전 {{count}}개",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -270,6 +270,7 @@
 	"inspector.resolvedComments": "Resolved comments · {{count}}",
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",
+	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
 	"inspector.viewInFile": "View in file",
 	"inspector.commentNumber": "Comentário nº {{number}}",
 	"inspector.loadMoreReviews": "Carregar mais · {{count}} anteriores",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -267,6 +267,7 @@
 	"inspector.resolvedComments": "Resolved comments · {{count}}",
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",
+	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
 	"inspector.viewInFile": "View in file",
 	"inspector.commentNumber": "评论 #{{number}}",
 	"inspector.loadMoreReviews": "加载更多 · 之前 {{count}} 条",

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
 	InspectorActivityTimelineView,
@@ -282,7 +282,8 @@ describe("portable inspector presentations", () => {
 		expect(screen.queryByText(newerBody)).not.toBeInTheDocument();
 	});
 
-	it("shows unresolved inline review comment bodies together above external reviews", () => {
+	it("shows unresolved inline review comment bodies together above external reviews", async () => {
+		const onSendInlineComment = vi.fn().mockResolvedValue(undefined);
 		render(
 			<InspectorReviewsView
 				externalLink={ExternalLink}
@@ -329,6 +330,7 @@ describe("portable inspector presentations", () => {
 				]}
 				isLoading={false}
 				labels={reviewLabels}
+				onSendInlineComment={onSendInlineComment}
 				renderAvatar={() => null}
 				renderMarkdown={(body) => <p>{body}</p>}
 			/>,
@@ -339,8 +341,18 @@ describe("portable inspector presentations", () => {
 		expect(screen.getByText("2 unresolved")).toBeInTheDocument();
 		expect(screen.queryByText("src/panel.tsx:42")).not.toBeInTheDocument();
 		expect(screen.getByText("This branch leaks the resize listener on unmount.")).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Send to worker agent" })).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Send to worker agent" }));
+		expect(onSendInlineComment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: "This branch leaks the resize listener on unmount.",
+				file: "src/panel.tsx",
+				line: 42,
+				reviewerId: "maya",
+				url: "https://example.com/comment",
+			}),
+		);
 		expect(screen.getByText("Sent to worker agent")).toHaveClass("text-success");
+		await waitFor(() => expect(screen.getAllByText("Sent to worker agent")).toHaveLength(2));
 		expect(screen.getAllByRole("link", { name: "View in file" })).toHaveLength(2);
 	});
 

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -223,7 +223,7 @@ describe("portable inspector presentations", () => {
 		expect(externalReview).toHaveAttribute("aria-expanded", "false");
 		fireEvent.click(externalReview);
 		expect(screen.getByText("Ship it.")).toBeInTheDocument();
-		expect(screen.getByText("Not injected")).toBeInTheDocument();
+		expect(screen.queryByText("Not injected")).not.toBeInTheDocument();
 		expect(renderAvatar).toHaveBeenCalledWith("codex");
 		expect(renderMarkdown).toHaveBeenCalledTimes(2);
 	});
@@ -352,8 +352,10 @@ describe("portable inspector presentations", () => {
 			}),
 		);
 		await waitFor(() => {
-			expect(screen.getAllByText("Sent to worker agent")).toHaveLength(2);
-			expect(screen.getAllByText("Sent to worker agent")[0]).toHaveClass("text-success");
+			const sentLabels = screen.getAllByText("Sent to worker agent");
+			expect(sentLabels).toHaveLength(2);
+			expect(sentLabels[0]?.closest("span")).toHaveClass("bg-overlay/80", "border-border-strong");
+			expect(sentLabels[0]?.closest("span")?.querySelector("svg")).toHaveClass("text-success");
 		});
 		expect(screen.getAllByRole("link", { name: "View in file" })).toHaveLength(2);
 	});
@@ -400,7 +402,6 @@ describe("portable inspector presentations", () => {
 		expect(screen.getByRole("button", { name: "Send to worker agent" })).toBeInTheDocument();
 		expect(screen.queryByText("Sent to worker agent")).not.toBeInTheDocument();
 	});
-
 
 });
 

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -401,22 +401,6 @@ describe("portable inspector presentations", () => {
 		expect(screen.queryByText("Sent to worker agent")).not.toBeInTheDocument();
 	});
 
-	it("shows an empty review summary instead of a blank reviews area", () => {
-		render(
-			<InspectorReviewsView
-				externalLink={ExternalLink}
-				groups={[]}
-				isLoading={false}
-				labels={reviewLabels}
-				renderAvatar={() => null}
-				renderMarkdown={(body) => <p>{body}</p>}
-			/>,
-		);
-
-		expect(screen.getByText("Reviews")).toBeInTheDocument();
-		expect(screen.getByText("No summaries")).toBeInTheDocument();
-	});
-
 
 });
 

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -403,6 +403,59 @@ describe("portable inspector presentations", () => {
 		expect(screen.queryByText("Sent to worker agent")).not.toBeInTheDocument();
 	});
 
+	it("tracks URL-less inline comments independently when they share a review URL", async () => {
+		const onSendInlineComment = vi.fn().mockResolvedValue(undefined);
+		render(
+			<InspectorReviewsView
+				externalLink={ExternalLink}
+				groups={[
+					{
+						github: {
+							entries: [],
+							unresolved: 2,
+							unresolvedBy: [
+								{
+									count: 2,
+									links: [
+										{ body: "Fix the first comment.", file: "src/panel.tsx", line: 10 },
+										{ body: "Fix the second comment.", file: "src/panel.tsx", line: 20 },
+									],
+									reviewerId: "maya",
+									reviewUrl: "https://example.com/review",
+								},
+							],
+						},
+						meta: "#12 · 2 unresolved",
+						number: 12,
+						title: "Portable inspector",
+					},
+				]}
+				isLoading={false}
+				labels={reviewLabels}
+				onSendInlineComment={onSendInlineComment}
+				renderAvatar={() => null}
+				renderMarkdown={(body) => <p>{body}</p>}
+			/>,
+		);
+
+		const sendButtons = screen.getAllByRole("button", { name: "Send to worker agent" });
+		expect(sendButtons).toHaveLength(2);
+		fireEvent.click(sendButtons[0]!);
+
+		await waitFor(() => expect(screen.getByText("Sent to worker agent")).toBeInTheDocument());
+		expect(screen.getAllByRole("button", { name: "Send to worker agent" })).toHaveLength(1);
+		expect(onSendInlineComment).toHaveBeenCalledTimes(1);
+		expect(onSendInlineComment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: "Fix the first comment.",
+				file: "src/panel.tsx",
+				line: 10,
+				reviewerId: "maya",
+				url: "https://example.com/review",
+			}),
+		);
+	});
+
 });
 
 const reviewLabels: InspectorReviewLabels = {

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -401,6 +401,22 @@ describe("portable inspector presentations", () => {
 		expect(screen.queryByText("Sent to worker agent")).not.toBeInTheDocument();
 	});
 
+	it("shows an empty review summary instead of a blank reviews area", () => {
+		render(
+			<InspectorReviewsView
+				externalLink={ExternalLink}
+				groups={[]}
+				isLoading={false}
+				labels={reviewLabels}
+				renderAvatar={() => null}
+				renderMarkdown={(body) => <p>{body}</p>}
+			/>,
+		);
+
+		expect(screen.getByText("Reviews")).toBeInTheDocument();
+		expect(screen.getByText("No summaries")).toBeInTheDocument();
+	});
+
 
 });
 

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -351,9 +351,54 @@ describe("portable inspector presentations", () => {
 				url: "https://example.com/comment",
 			}),
 		);
-		expect(screen.getByText("Sent to worker agent")).toHaveClass("text-success");
-		await waitFor(() => expect(screen.getAllByText("Sent to worker agent")).toHaveLength(2));
+		await waitFor(() => {
+			expect(screen.getAllByText("Sent to worker agent")).toHaveLength(2);
+			expect(screen.getAllByText("Sent to worker agent")[0]).toHaveClass("text-success");
+		});
 		expect(screen.getAllByRole("link", { name: "View in file" })).toHaveLength(2);
+	});
+
+	it("surfaces inline review comment send failures", async () => {
+		const onSendInlineComment = vi.fn().mockRejectedValue(new Error("send failed"));
+		render(
+			<InspectorReviewsView
+				externalLink={ExternalLink}
+				groups={[
+					{
+						github: {
+							entries: [],
+							unresolved: 1,
+							unresolvedBy: [
+								{
+									count: 1,
+									links: [
+										{
+											body: "Please tighten this spacing.",
+											url: "https://example.com/comment",
+										},
+									],
+									reviewerId: "maya",
+								},
+							],
+						},
+						meta: "#12 · 1 unresolved",
+						number: 12,
+						title: "Portable inspector",
+					},
+				]}
+				isLoading={false}
+				labels={reviewLabels}
+				onSendInlineComment={onSendInlineComment}
+				renderAvatar={() => null}
+				renderMarkdown={(body) => <p>{body}</p>}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Send to worker agent" }));
+
+		await waitFor(() => expect(screen.getByText("Unable to send. Retry.")).toHaveClass("text-error"));
+		expect(screen.getByRole("button", { name: "Send to worker agent" })).toBeInTheDocument();
+		expect(screen.queryByText("Sent to worker agent")).not.toBeInTheDocument();
 	});
 
 
@@ -375,6 +420,7 @@ const reviewLabels: InspectorReviewLabels = {
 	resolvedComments: (count) => `Resolved comments · ${count}`,
 	sendToWorkerAgent: "Send to worker agent",
 	sentToWorkerAgent: "Sent to worker agent",
+	sendToWorkerAgentError: "Unable to send. Retry.",
 	showLatestReviewOnly: "Show latest only",
 	showLess: "Show less",
 	showMore: "Show more",

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -473,6 +473,7 @@ export function InspectorReviewsView({
 	groups,
 	isLoading,
 	labels,
+	onSendInlineComment,
 	renderAvatar,
 	renderMarkdown,
 }: {
@@ -480,6 +481,7 @@ export function InspectorReviewsView({
 	groups: InspectorReviewGroup[];
 	isLoading: boolean;
 	labels: InspectorReviewLabels;
+	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 }) {
@@ -533,6 +535,7 @@ export function InspectorReviewsView({
 								<GithubInlineComments
 									externalLink={externalLink}
 									labels={labels}
+									onSendInlineComment={onSendInlineComment}
 									reviewers={group.github.unresolvedBy}
 								/>
 								<GithubReviewHistory
@@ -887,18 +890,22 @@ function ExternalReviewCard({
 function GithubInlineComments({
 	externalLink: ExternalLink,
 	labels,
+	onSendInlineComment,
 	reviewers,
 }: {
 	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
+	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	reviewers: InspectorUnresolvedReviewer[];
 }) {
+	const [sentCommentIds, setSentCommentIds] = useState<Set<string>>(() => new Set());
+	const [sendingCommentIds, setSendingCommentIds] = useState<Set<string>>(() => new Set());
 	const comments = reviewers.flatMap((reviewer) =>
 		reviewer.links
 			.filter((link) => link.body?.trim() || link.file || link.url)
 			.map((link, index) => ({
 				...link,
-				id: `${reviewer.reviewerId}:${link.url ?? link.file ?? index}`,
+				id: `${reviewer.reviewerId}:${link.url ?? `${link.file ?? ""}:${link.line ?? ""}:${index}`}`,
 				reviewerId: reviewer.reviewerId,
 				url: link.url || reviewer.reviewUrl,
 			})),
@@ -917,6 +924,24 @@ function GithubInlineComments({
 						externalLink={ExternalLink}
 						key={comment.id}
 						labels={labels}
+						onSend={onSendInlineComment ? async () => {
+							setSendingCommentIds((current) => new Set(current).add(comment.id));
+							try {
+								await onSendInlineComment(comment);
+								setSentCommentIds((current) => new Set(current).add(comment.id));
+							} catch {
+								// Keep the UI in the unsent state; this surface intentionally only
+								// renders the two worker-agent states requested for inline comments.
+							} finally {
+								setSendingCommentIds((current) => {
+									const next = new Set(current);
+									next.delete(comment.id);
+									return next;
+								});
+							}
+						} : undefined}
+						sent={Boolean(comment.autoInjectReview) || sentCommentIds.has(comment.id)}
+						sending={sendingCommentIds.has(comment.id)}
 					/>
 				))}
 			</div>
@@ -928,10 +953,16 @@ function InlineCommentRow({
 	comment,
 	externalLink: ExternalLink,
 	labels,
+	onSend,
+	sending = false,
+	sent,
 }: {
 	comment: InspectorInlineComment & { reviewerId?: string };
 	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
+	onSend?: () => void;
+	sending?: boolean;
+	sent: boolean;
 }) {
 	const body = comment.body?.trim();
 	return (
@@ -939,11 +970,13 @@ function InlineCommentRow({
 			{comment.reviewerId ? <span className="font-medium text-muted-foreground">{comment.reviewerId}</span> : null}
 			{body ? <p className="m-0 whitespace-pre-wrap break-words leading-normal text-foreground/90">{body}</p> : null}
 			<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-				{comment.autoInjectReview ? (
+				{sent ? (
 					<span className="font-medium text-success">{labels.sentToWorkerAgent}</span>
 				) : (
 					<button
-						className="inline-flex h-control-md items-center gap-1.5 rounded-md border border-border-strong bg-overlay/80 px-2.5 font-medium text-foreground shadow-sm transition-colors hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 [&_svg]:size-icon-xs"
+						className="inline-flex h-control-md items-center gap-1.5 rounded-md border border-border-strong bg-overlay/80 px-2.5 font-medium text-foreground shadow-sm transition-colors hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-60 [&_svg]:size-icon-xs"
+						disabled={sending || !onSend}
+						onClick={onSend}
 						type="button"
 					>
 						<BotIcon className="shrink-0 text-muted-foreground" />

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -493,7 +493,13 @@ export function InspectorReviewsView({
 			</InspectorSection>
 		);
 	}
-	if (groups.length === 0) return null;
+	if (groups.length === 0) {
+		return (
+			<InspectorSection surface title={labels.reviews}>
+				<p className={inspectorEmptyClass}>{labels.noPastReviewSummaries}</p>
+			</InspectorSection>
+		);
+	}
 	return (
 		<InspectorSection surface={false} title={labels.reviews}>
 			<div className="flex flex-col gap-2">

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -459,6 +459,7 @@ export type InspectorReviewLabels = {
 	resolvedComments: (count: number) => string;
 	sendToWorkerAgent: string;
 	sentToWorkerAgent: string;
+	sendToWorkerAgentError: string;
 	showLatestReviewOnly: string;
 	showLess: string;
 	showMore: string;
@@ -900,6 +901,7 @@ function GithubInlineComments({
 }) {
 	const [sentCommentIds, setSentCommentIds] = useState<Set<string>>(() => new Set());
 	const [sendingCommentIds, setSendingCommentIds] = useState<Set<string>>(() => new Set());
+	const [sendErrorCommentIds, setSendErrorCommentIds] = useState<Set<string>>(() => new Set());
 	const comments = reviewers.flatMap((reviewer) =>
 		reviewer.links
 			.filter((link) => link.body?.trim() || link.file || link.url)
@@ -926,12 +928,16 @@ function GithubInlineComments({
 						labels={labels}
 						onSend={onSendInlineComment ? async () => {
 							setSendingCommentIds((current) => new Set(current).add(comment.id));
+							setSendErrorCommentIds((current) => {
+								const next = new Set(current);
+								next.delete(comment.id);
+								return next;
+							});
 							try {
 								await onSendInlineComment(comment);
 								setSentCommentIds((current) => new Set(current).add(comment.id));
 							} catch {
-								// Keep the UI in the unsent state; this surface intentionally only
-								// renders the two worker-agent states requested for inline comments.
+								setSendErrorCommentIds((current) => new Set(current).add(comment.id));
 							} finally {
 								setSendingCommentIds((current) => {
 									const next = new Set(current);
@@ -940,6 +946,7 @@ function GithubInlineComments({
 								});
 							}
 						} : undefined}
+						sendError={sendErrorCommentIds.has(comment.id)}
 						sent={Boolean(comment.autoInjectReview) || sentCommentIds.has(comment.id)}
 						sending={sendingCommentIds.has(comment.id)}
 					/>
@@ -954,6 +961,7 @@ function InlineCommentRow({
 	externalLink: ExternalLink,
 	labels,
 	onSend,
+	sendError = false,
 	sending = false,
 	sent,
 }: {
@@ -961,6 +969,7 @@ function InlineCommentRow({
 	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
 	onSend?: () => void;
+	sendError?: boolean;
 	sending?: boolean;
 	sent: boolean;
 }) {
@@ -989,6 +998,7 @@ function InlineCommentRow({
 					</ExternalLink>
 				) : null}
 			</div>
+			{sendError && !sent ? <p className="m-0 text-2xs font-medium text-error">{labels.sendToWorkerAgentError}</p> : null}
 		</div>
 	);
 }

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -3,6 +3,7 @@ import type { ExternalLinkComponent } from "./external-link";
 import {
 	ArrowUpRightIcon,
 	BotIcon,
+	CheckIcon,
 	ChevronIcon,
 	GitPullRequestIcon,
 } from "./icons";
@@ -510,7 +511,6 @@ export function InspectorReviewsView({
 							<div className="flex min-w-0 flex-col gap-2">
 								<ReviewSourceLabel
 									icon={<BotIcon />}
-									marker={group.ao.notInjected ? labels.notInjected : undefined}
 								>
 									{labels.aoSource}
 								</ReviewSourceLabel>
@@ -529,7 +529,6 @@ export function InspectorReviewsView({
 							<div className="flex min-w-0 flex-col gap-2">
 								<ReviewSourceLabel
 									icon={<GitPullRequestIcon />}
-									marker={group.github.notInjected ? labels.notInjected : undefined}
 								>
 									{labels.githubSource}
 								</ReviewSourceLabel>
@@ -899,7 +898,9 @@ function GithubInlineComments({
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	reviewers: InspectorUnresolvedReviewer[];
 }) {
-	const [sentCommentIds, setSentCommentIds] = useState<Set<string>>(() => new Set());
+	// Manual sends are reflected immediately in local UI state after /send succeeds;
+	// persisted autoInjectReview still comes from the next backend PR observation.
+	const [manuallySentCommentIds, setManuallySentCommentIds] = useState<Set<string>>(() => new Set());
 	const [sendingCommentIds, setSendingCommentIds] = useState<Set<string>>(() => new Set());
 	const [sendErrorCommentIds, setSendErrorCommentIds] = useState<Set<string>>(() => new Set());
 	const comments = reviewers.flatMap((reviewer) =>
@@ -935,7 +936,7 @@ function GithubInlineComments({
 							});
 							try {
 								await onSendInlineComment(comment);
-								setSentCommentIds((current) => new Set(current).add(comment.id));
+								setManuallySentCommentIds((current) => new Set(current).add(comment.id));
 							} catch {
 								setSendErrorCommentIds((current) => new Set(current).add(comment.id));
 							} finally {
@@ -947,7 +948,7 @@ function GithubInlineComments({
 							}
 						} : undefined}
 						sendError={sendErrorCommentIds.has(comment.id)}
-						sent={Boolean(comment.autoInjectReview) || sentCommentIds.has(comment.id)}
+						sent={Boolean(comment.autoInjectReview) || manuallySentCommentIds.has(comment.id)}
 						sending={sendingCommentIds.has(comment.id)}
 					/>
 				))}
@@ -980,7 +981,10 @@ function InlineCommentRow({
 			{body ? <p className="m-0 whitespace-pre-wrap break-words leading-normal text-foreground/90">{body}</p> : null}
 			<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
 				{sent ? (
-					<span className="font-medium text-success">{labels.sentToWorkerAgent}</span>
+					<span className="inline-flex h-control-md items-center gap-1.5 rounded-md border border-border-strong bg-overlay/80 px-2.5 font-medium text-foreground shadow-sm [&_svg]:size-icon-xs">
+						<CheckIcon className="shrink-0 text-success" />
+						{labels.sentToWorkerAgent}
+					</span>
 				) : (
 					<button
 						className="inline-flex h-control-md items-center gap-1.5 rounded-md border border-border-strong bg-overlay/80 px-2.5 font-medium text-foreground shadow-sm transition-colors hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-60 [&_svg]:size-icon-xs"

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -493,13 +493,7 @@ export function InspectorReviewsView({
 			</InspectorSection>
 		);
 	}
-	if (groups.length === 0) {
-		return (
-			<InspectorSection surface title={labels.reviews}>
-				<p className={inspectorEmptyClass}>{labels.noPastReviewSummaries}</p>
-			</InspectorSection>
-		);
-	}
+	if (groups.length === 0) return null;
 	return (
 		<InspectorSection surface={false} title={labels.reviews}>
 			<div className="flex flex-col gap-2">

--- a/packages/product-ui/src/icons.tsx
+++ b/packages/product-ui/src/icons.tsx
@@ -73,6 +73,14 @@ export function BotIcon(props: IconProps) {
 	);
 }
 
+export function CheckIcon(props: IconProps) {
+	return (
+		<Icon name="check" {...props}>
+			<path d="M20 6 9 17l-5-5" />
+		</Icon>
+	);
+}
+
 export function FileCodeIcon(props: IconProps) {
 	return (
 		<Icon name="file-code-2" {...props}>


### PR DESCRIPTION
## Summary
- wire each open inline review comment’s “Send to worker agent” control to the existing session send-message API
- send reviewer, file/line, comment body, and comment URL in the worker message
- explicitly instruct the worker to address the review comment, commit the fix, and push the branch to GitHub
- keep the inline comment UI to the requested states only: “Send to worker agent” and “Sent to worker agent”
- update the sent state immediately after a successful send, with persisted auto-send state still coming from backend PR observation
- remove the “Not injected” marker from review sections
- retry transient browser-runtime download failures in CI preparation

## Tests
- `npm --prefix packages/product-ui test -- SessionInspectorView.test.tsx`
- `cd frontend && npx vitest run src/renderer/components/SessionInspector.test.tsx`
- `npm --prefix frontend run browser-runtime:prepare -- --quiet`
- `npm run frontend:typecheck`

## Risks / follow-ups
- Manual sent status is local UI state until the next refresh/observation; comments injected by automatic review sending rely on their per-comment backend `autoInjectReview` value.
