### PR TITLE
fix: group review comments by reviewer

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1486,10 +1486,12 @@ describe("SessionInspector summary reviews", () => {
 
 		expect(await screen.findByRole("button", { name: "Re-run review" })).toBeInTheDocument();
 		expect((await screen.findAllByText("Reviewable change 3")).length).toBeGreaterThan(0);
-		expect(screen.getAllByText(/2 unresolved/)).toHaveLength(2);
+		expect(screen.getAllByText(/2 unresolved/).length).toBeGreaterThanOrEqual(2);
+		expect(screen.queryByTestId("github-inline-comments")).not.toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: /maya.*2 unresolved/i }));
 		const comments = screen.getByTestId("github-inline-comments");
 		expect(comments).toHaveTextContent("Open comments");
-		expect(comments).toHaveTextContent("maya");
+		expect(comments).not.toHaveTextContent("maya");
 		expect(comments).toHaveTextContent("Sent to worker agent");
 		expect(comments).not.toHaveTextContent("a.ts:3");
 		expect(comments).not.toHaveTextContent("a.ts:9");
@@ -1609,6 +1611,8 @@ describe("SessionInspector summary reviews", () => {
 
 		expect(screen.queryByText("Not injected")).not.toBeInTheDocument();
 		expect(screen.getByText("External reviews")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Send to worker agent" })).not.toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: /maya.*2 unresolved/i }));
 		const sendButton = screen.getByRole("button", { name: "Send to worker agent" });
 		expect(sendButton).toBeEnabled();
 		await userEvent.click(sendButton);

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -445,7 +445,21 @@ describe("portable inspector presentations", () => {
 				groups={[
 					{
 						github: {
-							entries: [],
+							entries: [
+								{
+									body: undefined,
+									id: "unresolved-maya",
+									inlineComments: [
+										{ body: "Fix the first comment.", file: "src/panel.tsx", line: 10 },
+										{ body: "Fix the second comment.", file: "src/panel.tsx", line: 20 },
+									],
+									reviewerId: "maya",
+									reviewUrl: "https://example.com/review",
+									submittedAt: "",
+									submittedAtLabel: "",
+									verdict: { label: "Commented", tone: "neutral" },
+								},
+							],
 							unresolved: 2,
 							unresolvedBy: [
 								{
@@ -472,6 +486,7 @@ describe("portable inspector presentations", () => {
 			/>,
 		);
 
+		fireEvent.click(screen.getByRole("button", { name: /maya.*2 unresolved/i }));
 		const sendButtons = screen.getAllByRole("button", { name: "Send to worker agent" });
 		expect(sendButtons).toHaveLength(2);
 		fireEvent.click(sendButtons[0]!);

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -282,7 +282,7 @@ describe("portable inspector presentations", () => {
 		expect(screen.queryByText(newerBody)).not.toBeInTheDocument();
 	});
 
-	it("shows unresolved inline review comment bodies together above external reviews", async () => {
+	it("shows unresolved inline review comments inside each reviewer dropdown", async () => {
 		const onSendInlineComment = vi.fn().mockResolvedValue(undefined);
 		render(
 			<InspectorReviewsView
@@ -299,6 +299,19 @@ describe("portable inspector presentations", () => {
 									submittedAt: "2026-08-09T10:00:00Z",
 									submittedAtLabel: "1h ago",
 									verdict: { label: "Commented", tone: "neutral" },
+									inlineComments: [
+										{
+											body: "This branch leaks the resize listener on unmount.",
+											file: "src/panel.tsx",
+											line: 42,
+											url: "https://example.com/comment",
+										},
+										{
+											body: "This was sent to the worker already.",
+											autoInjectReview: true,
+											url: "https://example.com/comment-sent",
+										},
+									],
 								},
 							],
 							unresolved: 2,
@@ -336,9 +349,13 @@ describe("portable inspector presentations", () => {
 			/>,
 		);
 
+		expect(screen.queryByTestId("github-inline-comments")).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /maya.*2 unresolved/i })).toHaveAttribute("aria-expanded", "false");
+		expect(screen.queryByText("This branch leaks the resize listener on unmount.")).not.toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /maya.*2 unresolved/i }));
 		expect(screen.getByTestId("github-inline-comments")).toBeInTheDocument();
 		expect(screen.getByText("Open comments")).toBeInTheDocument();
-		expect(screen.getByText("2 unresolved")).toBeInTheDocument();
+		expect(screen.getAllByText("2 unresolved").length).toBeGreaterThanOrEqual(1);
 		expect(screen.queryByText("src/panel.tsx:42")).not.toBeInTheDocument();
 		expect(screen.getByText("This branch leaks the resize listener on unmount.")).toBeInTheDocument();
 		fireEvent.click(screen.getByRole("button", { name: "Send to worker agent" }));
@@ -368,7 +385,23 @@ describe("portable inspector presentations", () => {
 				groups={[
 					{
 						github: {
-							entries: [],
+							entries: [
+								{
+									body: undefined,
+									id: "unresolved-maya",
+									inlineComments: [
+										{
+											body: "Please tighten this spacing.",
+											url: "https://example.com/comment",
+										},
+									],
+									reviewerId: "maya",
+									reviewUrl: "https://example.com/review",
+									submittedAt: "",
+									submittedAtLabel: "",
+									verdict: { label: "Commented", tone: "neutral" },
+								},
+							],
 							unresolved: 1,
 							unresolvedBy: [
 								{
@@ -396,6 +429,7 @@ describe("portable inspector presentations", () => {
 			/>,
 		);
 
+		fireEvent.click(screen.getByRole("button", { name: /maya.*1 unresolved/i }));
 		fireEvent.click(screen.getByRole("button", { name: "Send to worker agent" }));
 
 		await waitFor(() => expect(screen.getByText("Unable to send. Retry.")).toHaveClass("text-error"));

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -770,7 +770,7 @@ function ReviewHistoryPager({
 		<div className="flex min-w-0 gap-1.5">
 			{onCollapse ? (
 				<button
-					className="flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover/30 hover:text-foreground"
+					className="flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-micro font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover/30 hover:text-foreground"
 					onClick={onCollapse}
 					type="button"
 				>
@@ -780,7 +780,7 @@ function ReviewHistoryPager({
 			) : null}
 			{remaining > 0 && onLoadMore ? (
 				<button
-					className="flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover/30 hover:text-foreground"
+					className="flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-micro font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover/30 hover:text-foreground"
 					onClick={onLoadMore}
 					type="button"
 				>

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -770,7 +770,7 @@ function ReviewHistoryPager({
 		<div className="flex min-w-0 gap-1.5">
 			{onCollapse ? (
 				<button
-					className="flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-micro font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover/30 hover:text-foreground"
+					className="flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover/30 hover:text-foreground"
 					onClick={onCollapse}
 					type="button"
 				>
@@ -780,7 +780,7 @@ function ReviewHistoryPager({
 			) : null}
 			{remaining > 0 && onLoadMore ? (
 				<button
-					className="flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-micro font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover/30 hover:text-foreground"
+					className="flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover/30 hover:text-foreground"
 					onClick={onLoadMore}
 					type="button"
 				>
@@ -942,7 +942,7 @@ function GithubInlineComments({
 	if (comments.length === 0) return null;
 	return (
 		<section className="overflow-hidden rounded-md border border-border/70 bg-background/35" data-testid="github-inline-comments">
-			<div className="flex min-w-0 items-center justify-between gap-2 border-b border-border/70 px-2.5 py-2 text-xs">
+			<div className="flex min-w-0 items-center justify-between gap-2 border-b border-border/70 px-2.5 py-2 text-2xs">
 				<span className="font-semibold text-foreground">{labels.openComments}</span>
 				<span className="shrink-0 font-semibold text-error">{labels.unresolvedCount(comments.length)}</span>
 			</div>
@@ -1005,9 +1005,9 @@ function InlineCommentRow({
 }) {
 	const body = comment.body?.trim();
 	return (
-		<div className="flex min-w-0 flex-col gap-1.5 px-2.5 py-2 text-xs">
+		<div className="flex min-w-0 flex-col gap-1.5 px-2.5 py-2 text-2xs">
 			{showReviewer && comment.reviewerId ? <span className="font-medium text-muted-foreground">{comment.reviewerId}</span> : null}
-			{body ? <p className="m-0 whitespace-pre-wrap break-words leading-normal text-foreground/90">{body}</p> : null}
+			{body ? <p className="m-0 whitespace-pre-wrap break-words leading-relaxed text-muted-foreground">{body}</p> : null}
 			<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
 				{sent ? (
 					<span className="inline-flex h-control-md items-center gap-1.5 rounded-md border border-border-strong bg-overlay/80 px-2.5 font-medium text-foreground shadow-sm [&_svg]:size-icon-xs">

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -403,6 +403,7 @@ export type InspectorInlineComment = {
 export type InspectorGithubReview = {
 	body?: string;
 	id: string;
+	inlineComments?: InspectorInlineComment[];
 	isBot?: boolean;
 	reviewerId: string;
 	reviewUrl?: string;
@@ -532,16 +533,11 @@ export function InspectorReviewsView({
 								>
 									{labels.githubSource}
 								</ReviewSourceLabel>
-								<GithubInlineComments
-									externalLink={externalLink}
-									labels={labels}
-									onSendInlineComment={onSendInlineComment}
-									reviewers={group.github.unresolvedBy}
-								/>
 								<GithubReviewHistory
 									entries={group.github.entries}
 									externalLink={externalLink}
 									labels={labels}
+									onSendInlineComment={onSendInlineComment}
 									renderAvatar={renderAvatar}
 									renderMarkdown={renderMarkdown}
 								/>
@@ -800,12 +796,14 @@ function GithubReviewHistory({
 	entries,
 	externalLink,
 	labels,
+	onSendInlineComment,
 	renderAvatar,
 	renderMarkdown,
 }: {
 	entries: InspectorGithubReview[];
 	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
+	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 }) {
@@ -820,6 +818,7 @@ function GithubReviewHistory({
 					externalLink={externalLink}
 					key={entry.id}
 					labels={labels}
+					onSendInlineComment={onSendInlineComment}
 					renderAvatar={renderAvatar}
 					renderMarkdown={renderMarkdown}
 				/>
@@ -833,6 +832,7 @@ function ExternalReviewCard({
 	entry,
 	externalLink,
 	labels,
+	onSendInlineComment,
 	renderAvatar,
 	renderMarkdown,
 }: {
@@ -840,11 +840,14 @@ function ExternalReviewCard({
 	entry: InspectorGithubReview;
 	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
+	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 }) {
 	const [open, setOpen] = useState(defaultOpen);
 	const body = entry.body?.trim();
+	const inlineComments = entry.inlineComments ?? [];
+	const openInlineCount = inlineComments.filter((comment) => comment.body?.trim() || comment.file || comment.url).length;
 	return (
 		<article className="overflow-hidden rounded-md border border-border bg-overlay/45" data-testid="github-review-card">
 			<button
@@ -862,9 +865,13 @@ function ExternalReviewCard({
 						</span>
 						{entry.isBot ? <span className="shrink-0 font-mono text-micro text-passive">{labels.bot}</span> : null}
 					</span>
-					{entry.submittedAtLabel ? (
-						<span className="font-mono text-micro text-passive">{labels.reviewedAt(entry.submittedAtLabel)}</span>
-					) : null}
+					<span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 font-mono text-micro text-passive">
+						{entry.submittedAtLabel ? <span>{labels.reviewedAt(entry.submittedAtLabel)}</span> : null}
+						{entry.submittedAtLabel && openInlineCount > 0 ? <span aria-hidden="true">·</span> : null}
+						{openInlineCount > 0 ? (
+							<span className="font-semibold text-error">{labels.unresolvedCount(openInlineCount)}</span>
+						) : null}
+					</span>
 				</span>
 				<VerdictBadge verdict={entry.verdict} />
 			</button>
@@ -881,6 +888,23 @@ function ExternalReviewCard({
 						onExpandedChange={() => undefined}
 						url={entry.reviewUrl}
 					/>
+					{openInlineCount > 0 ? (
+						<GithubInlineComments
+							externalLink={externalLink}
+							labels={labels}
+							onSendInlineComment={onSendInlineComment}
+							reviewers={[
+								{
+									count: openInlineCount,
+									isBot: entry.isBot,
+									links: inlineComments,
+									reviewerId: entry.reviewerId,
+									reviewUrl: entry.reviewUrl,
+								},
+							]}
+							showReviewer={false}
+						/>
+					) : null}
 				</div>
 			) : null}
 		</article>
@@ -892,11 +916,13 @@ function GithubInlineComments({
 	labels,
 	onSendInlineComment,
 	reviewers,
+	showReviewer = true,
 }: {
 	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	reviewers: InspectorUnresolvedReviewer[];
+	showReviewer?: boolean;
 }) {
 	// Manual sends are reflected immediately in local UI state after /send succeeds;
 	// persisted autoInjectReview still comes from the next backend PR observation.
@@ -948,6 +974,7 @@ function GithubInlineComments({
 							}
 						} : undefined}
 						sendError={sendErrorCommentIds.has(comment.id)}
+						showReviewer={showReviewer}
 						sent={Boolean(comment.autoInjectReview) || manuallySentCommentIds.has(comment.id)}
 						sending={sendingCommentIds.has(comment.id)}
 					/>
@@ -964,6 +991,7 @@ function InlineCommentRow({
 	onSend,
 	sendError = false,
 	sending = false,
+	showReviewer = true,
 	sent,
 }: {
 	comment: InspectorInlineComment & { reviewerId?: string };
@@ -972,12 +1000,13 @@ function InlineCommentRow({
 	onSend?: () => void;
 	sendError?: boolean;
 	sending?: boolean;
+	showReviewer?: boolean;
 	sent: boolean;
 }) {
 	const body = comment.body?.trim();
 	return (
 		<div className="flex min-w-0 flex-col gap-1.5 px-2.5 py-2 text-xs">
-			{comment.reviewerId ? <span className="font-medium text-muted-foreground">{comment.reviewerId}</span> : null}
+			{showReviewer && comment.reviewerId ? <span className="font-medium text-muted-foreground">{comment.reviewerId}</span> : null}
 			{body ? <p className="m-0 whitespace-pre-wrap break-words leading-normal text-foreground/90">{body}</p> : null}
 			<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
 				{sent ? (


### PR DESCRIPTION
## Summary
- move open inline review comments out of the shared External reviews block and into each reviewer’s collapsible review card
- keep reviewer cards collapsed by default, with unresolved counts visible in the card header
- preserve the per-comment Send to worker agent / Sent to worker agent controls inside each expanded reviewer card

## Stacked on
- #4044

## Tests
- `npm --prefix packages/product-ui test -- SessionInspectorView.test.tsx`
- `cd frontend && npx vitest run src/renderer/components/SessionInspector.test.tsx`
- `npm run frontend:typecheck`

## Risks / follow-ups
- This depends on #4044’s inline review worker-send UI and should be reviewed/merged after it.
