### PR TITLE
fix(cline): reconcile completed turns to idle

### DIFF
--- a/backend/internal/adapters/agent/cline/activity.go
+++ b/backend/internal/adapters/agent/cline/activity.go
@@ -1,0 +1,73 @@
+package cline
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+var clineTerminalEscape = regexp.MustCompile(`\x1b(?:\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]|\][^\x07]*(?:\x07|\x1b\\))`)
+
+// ContinuouslyDetectTerminalActivity opts Cline into terminal reconciliation
+// on every observer tick. Completion hooks provide the primary transition, but
+// the idle composer is the fallback when Cline omits or loses a callback.
+func (p *Plugin) ContinuouslyDetectTerminalActivity() bool { return true }
+
+// DetectTerminalActivity recognizes authoritative current-state markers in
+// Cline's TUI. The newest marker wins so retained transcript text cannot
+// override the current composer or generation indicator.
+func (p *Plugin) DetectTerminalActivity(output string) (domain.ActivityState, bool) {
+	lines := clineTerminalLines(output)
+	if len(lines) == 0 {
+		return "", false
+	}
+	start := len(lines) - 30
+	if start < 0 {
+		start = 0
+	}
+	recent := lines[start:]
+
+	for i := len(recent) - 1; i >= 0; i-- {
+		line := strings.ToLower(recent[i])
+		if strings.Contains(line, "thinking... (esc to cancel)") {
+			return domain.ActivityActive, true
+		}
+		if clineEmptyComposer(recent[i]) && clineModeFooterAfter(recent, i) {
+			return domain.ActivityIdle, true
+		}
+	}
+	return "", false
+}
+
+func clineEmptyComposer(line string) bool {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "❯") {
+		return false
+	}
+	prompt := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(line, "❯")))
+	return prompt == "ask anything..." || prompt == "plan something..."
+}
+
+func clineModeFooterAfter(lines []string, composer int) bool {
+	for _, line := range lines[composer+1:] {
+		line = strings.ToLower(line)
+		if strings.Contains(line, "plan") && strings.Contains(line, "act") && strings.Contains(line, "(tab)") {
+			return true
+		}
+	}
+	return false
+}
+
+func clineTerminalLines(output string) []string {
+	plain := clineTerminalEscape.ReplaceAllString(strings.ReplaceAll(output, "\r", "\n"), "")
+	raw := strings.Split(plain, "\n")
+	lines := raw[:0]
+	for _, line := range raw {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/backend/internal/adapters/agent/cline/activity_test.go
+++ b/backend/internal/adapters/agent/cline/activity_test.go
@@ -68,7 +68,6 @@ func TestDetectTerminalActivityRejectsTranscriptText(t *testing.T) {
 func TestClineManagedHooksClearCompletedTurns(t *testing.T) {
 	want := map[string]string{
 		"TaskComplete": "stop",
-		"TaskError":    "stop",
 	}
 	for _, spec := range clineManagedHooks {
 		if subcommand, ok := want[spec.Event]; ok {

--- a/backend/internal/adapters/agent/cline/activity_test.go
+++ b/backend/internal/adapters/agent/cline/activity_test.go
@@ -1,0 +1,84 @@
+package cline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func readClineFixture(t *testing.T, name string) string {
+	t.Helper()
+	output, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(output)
+}
+
+func TestDetectTerminalActivityClineFrames(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+		want    domain.ActivityState
+	}{
+		{"completed turn at empty composer", "idle_composer.txt", domain.ActivityIdle},
+		{"active generation", "active_generation.txt", domain.ActivityActive},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := (&Plugin{}).DetectTerminalActivity(readClineFixture(t, tt.fixture))
+			if got != tt.want || !ok {
+				t.Fatalf("DetectTerminalActivity(%s) = (%q, %v), want (%q, true)", tt.fixture, got, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectTerminalActivityUsesNewestMarker(t *testing.T) {
+	idle := readClineFixture(t, "idle_composer.txt")
+	active := readClineFixture(t, "active_generation.txt")
+	tests := []struct {
+		name   string
+		output string
+		want   domain.ActivityState
+	}{
+		{"generation after old composer", idle + "\n" + active, domain.ActivityActive},
+		{"composer after old generation", active + "\n" + idle, domain.ActivityIdle},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := (&Plugin{}).DetectTerminalActivity(tt.output)
+			if got != tt.want || !ok {
+				t.Fatalf("DetectTerminalActivity() = (%q, %v), want (%q, true)", got, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectTerminalActivityRejectsTranscriptText(t *testing.T) {
+	output := "The docs call the placeholder Ask anything... and the toggle Plan / Act (Tab).\n"
+	got, ok := (&Plugin{}).DetectTerminalActivity(output)
+	if ok {
+		t.Fatalf("DetectTerminalActivity(transcript) = (%q, true), want no signal", got)
+	}
+}
+
+func TestClineManagedHooksClearCompletedTurns(t *testing.T) {
+	want := map[string]string{
+		"TaskComplete": "stop",
+		"TaskError":    "stop",
+	}
+	for _, spec := range clineManagedHooks {
+		if subcommand, ok := want[spec.Event]; ok {
+			if spec.Subcommand != subcommand {
+				t.Fatalf("%s subcommand = %q, want %q", spec.Event, spec.Subcommand, subcommand)
+			}
+			delete(want, spec.Event)
+		}
+	}
+	for event := range want {
+		t.Errorf("missing managed %s hook", event)
+	}
+}

--- a/backend/internal/adapters/agent/cline/activity_test.go
+++ b/backend/internal/adapters/agent/cline/activity_test.go
@@ -65,6 +65,13 @@ func TestDetectTerminalActivityRejectsTranscriptText(t *testing.T) {
 	}
 }
 
+func TestDetectTerminalActivityDoesNotOverrideToolApproval(t *testing.T) {
+	got, ok := (&Plugin{}).DetectTerminalActivity(readClineFixture(t, "tool_approval.txt"))
+	if ok {
+		t.Fatalf("DetectTerminalActivity(tool approval) = (%q, true), want no signal", got)
+	}
+}
+
 func TestClineManagedHooksClearCompletedTurns(t *testing.T) {
 	want := map[string]string{
 		"TaskComplete": "stop",

--- a/backend/internal/adapters/agent/cline/cline.go
+++ b/backend/internal/adapters/agent/cline/cline.go
@@ -39,6 +39,7 @@ func New() *Plugin {
 
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
+var _ ports.ContinuousTerminalActivityDetector = (*Plugin)(nil)
 
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {

--- a/backend/internal/adapters/agent/cline/hooks.go
+++ b/backend/internal/adapters/agent/cline/hooks.go
@@ -53,11 +53,15 @@ type clineHookSpec struct {
 //   - UserPromptSubmit -> user-prompt-submit  (user message submitted: active)
 //   - PreToolUse       -> permission-request  (about to act: approval point)
 //   - TaskCancel       -> stop                (task cancelled/aborted: idle)
+//   - TaskComplete     -> stop                (task completed normally: idle)
+//   - TaskError        -> stop                (task ended with an error: idle)
 var clineManagedHooks = []clineHookSpec{
 	{Event: "TaskStart", Subcommand: "session-start"},
 	{Event: "UserPromptSubmit", Subcommand: "user-prompt-submit"},
 	{Event: "PreToolUse", Subcommand: "permission-request"},
 	{Event: "TaskCancel", Subcommand: "stop"},
+	{Event: "TaskComplete", Subcommand: "stop"},
+	{Event: "TaskError", Subcommand: "stop"},
 }
 
 // GetAgentHooks installs AO's Cline hook scripts into the worktree-local

--- a/backend/internal/adapters/agent/cline/hooks.go
+++ b/backend/internal/adapters/agent/cline/hooks.go
@@ -54,14 +54,12 @@ type clineHookSpec struct {
 //   - PreToolUse       -> permission-request  (about to act: approval point)
 //   - TaskCancel       -> stop                (task cancelled/aborted: idle)
 //   - TaskComplete     -> stop                (task completed normally: idle)
-//   - TaskError        -> stop                (task ended with an error: idle)
 var clineManagedHooks = []clineHookSpec{
 	{Event: "TaskStart", Subcommand: "session-start"},
 	{Event: "UserPromptSubmit", Subcommand: "user-prompt-submit"},
 	{Event: "PreToolUse", Subcommand: "permission-request"},
 	{Event: "TaskCancel", Subcommand: "stop"},
 	{Event: "TaskComplete", Subcommand: "stop"},
-	{Event: "TaskError", Subcommand: "stop"},
 }
 
 // GetAgentHooks installs AO's Cline hook scripts into the worktree-local

--- a/backend/internal/adapters/agent/cline/testdata/active_generation.txt
+++ b/backend/internal/adapters/agent/cline/testdata/active_generation.txt
@@ -1,0 +1,8 @@
+❯ Inspect the activity observer.
+
+* I'll trace the terminal reconciliation path.
+
+Thinking... (esc to cancel)
+Claude Opus 5 (medium) █████ (8,711) $0.05                 ○ Plan ● Act (Tab)
+agent-orchestrator-133 (ao/agent-orchestrator-133/root)
+⏵⏵ Auto-approve all enabled (Shift+Tab)

--- a/backend/internal/adapters/agent/cline/testdata/idle_composer.txt
+++ b/backend/internal/adapters/agent/cline/testdata/idle_composer.txt
@@ -1,0 +1,11 @@
+❯ how's it going?
+
+* Going well, thanks! I'm ready to dig into the agent-orchestrator repo
+  whenever you are.
+
+────────────────────────────────────────────────────────────────────────────────
+❯ Ask anything...
+────────────────────────────────────────────────────────────────────────────────
+Claude Opus 5 (medium) █████ (8,647) $0.05                 ○ Plan ● Act (Tab)
+agent-orchestrator-133 (ao/agent-orchestrator-133/root)
+⏵⏵ Auto-approve all enabled (Shift+Tab)

--- a/backend/internal/adapters/agent/cline/testdata/tool_approval.txt
+++ b/backend/internal/adapters/agent/cline/testdata/tool_approval.txt
@@ -1,0 +1,13 @@
+I'll run the focused adapter tests.
+
+Approve tool call?
+
+run_commands
+
+  $ go test ./internal/adapters/agent/cline
+
+[y] approve  [n] deny
+
+Claude Opus 5 (medium) █████ (8,711) $0.05                 ○ Plan ● Act (Tab)
+agent-orchestrator-133 (ao/agent-orchestrator-133/root)
+⏵⏵ Auto-approve all disabled (Shift+Tab)


### PR DESCRIPTION
Fixes #4048.

## Summary

- install Cline's native `TaskComplete` hook so successful turns clear `active` immediately; error termination remains covered by Cline's existing `TaskCancel` dispatch
- add a continuous terminal activity classifier that recognizes Cline's empty `Ask anything...` / `Plan something...` composer as idle and its `Thinking... (esc to cancel)` indicator as active
- use recent, ANSI-normalized terminal markers with newest-marker precedence to avoid transcript false positives
- cover live idle-composer output, active generation, retained-marker ordering, completion-hook coverage, and transcript rejection

## Tests

- `cd backend && go build ./...`
- `cd backend && go test ./internal/adapters/agent/cline ./internal/observe/activity ./internal/adapters/agent/activitydispatch`
- `cd backend && env -i HOME=\"$HOME\" PATH=\"$PATH\" TMPDIR=\"${TMPDIR:-/tmp}\" go test ./...`

## Risks / follow-ups

- Terminal detection necessarily follows Cline's rendered labels; the native completion/cancel hooks are the primary path, while the classifier is a fallback for missing callbacks. Tests pin the current Cline 3.0.55 markers observed during reproduction.
- Like the existing Codex/Muse continuous detectors, detector-based message-delivery readiness remains bounded by the caller timeout if no authoritative TUI marker matches.