### PR TITLE
fix(inspector): collapse tabs to icons instead of truncating labels

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -225,7 +225,7 @@ describe("SessionInspector tabs", () => {
 		const summaryTab = screen.getByRole("tab", { name: "Summary" });
 
 		expect(summaryTab).not.toHaveClass("flex-1");
-		expect(summaryTab).toHaveClass("h-control-md", "px-1.5");
+		expect(summaryTab).toHaveClass("h-control-md", "px-1", "shrink-0");
 		expect(summaryTab).toHaveAttribute("title", "Summary");
 	});
 

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2808,13 +2808,16 @@ body.is-resizing-x [data-slot="inspector-container"] {
 }
 
 .session-inspector__tab-button {
+	flex: none;
 	gap: 0;
 }
 
 .session-inspector__responsive-label {
 	max-width: 5.5rem;
-	margin-left: var(--space-1);
+	margin-left: var(--space-0_5);
 	overflow: hidden;
+	/* Clip during the collapse animation — never ellipsize mid-label. */
+	text-overflow: clip;
 	opacity: 1;
 	transform: translateX(0);
 	transition:
@@ -2826,9 +2829,13 @@ body.is-resizing-x [data-slot="inspector-container"] {
 
 .session-inspector__tablist {
 	container: inspector-tabs / inline-size;
+	justify-content: flex-start;
 }
 
-@container inspector-tabs (max-width: 239px) {
+/* Keep labels until they nearly meet the pinned actions, then collapse to a
+ * tight icon cluster. Tuned just under the ~270px labeled content width so the
+ * default inspector (~274px tablist) still shows full words. */
+@container inspector-tabs (max-width: 268px) {
 	.session-inspector__responsive-label {
 		max-width: 0;
 		margin-left: 0;
@@ -2843,7 +2850,7 @@ body.is-resizing-x [data-slot="inspector-container"] {
 .session-split[data-terminal-live-resize="true"][data-inspector-label-mode="expanded"]
 	.session-inspector__responsive-label {
 	max-width: 5.5rem;
-	margin-left: var(--space-1);
+	margin-left: var(--space-0_5);
 	opacity: 1;
 	transform: translateX(0);
 }

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -48,12 +48,14 @@ describe("SessionInspectorShellView", () => {
 		expect(screen.getByRole("complementary", { name: "Session inspector" })).toBeInTheDocument();
 		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("aria-selected", "true");
-		expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass("min-w-0");
+		expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass("shrink-0");
 		expect(screen.getByRole("tab", { name: "Summary" })).not.toHaveClass("flex-1");
+		expect(screen.getByRole("tab", { name: "Summary" })).not.toHaveClass("min-w-0");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("tabindex", "0");
 		expect(screen.getByRole("tab", { name: "Browser" })).toHaveAttribute("tabindex", "-1");
 		const filesLabel = within(screen.getByRole("tab", { name: "Files" })).getByText("2 Files");
-		expect(filesLabel).toHaveClass("session-inspector__responsive-label", "min-w-0");
+		expect(filesLabel).toHaveClass("session-inspector__responsive-label");
+		expect(filesLabel).not.toHaveClass("truncate", "min-w-0");
 		expect(filesLabel).not.toHaveClass("@max-[350px]/inspector:hidden");
 		expect(screen.getByTestId("browser-unseen-indicator")).toBeInTheDocument();
 		fireEvent.click(screen.getByRole("tab", { name: "Browser" }));

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -100,7 +100,7 @@ export function SessionInspectorShellView({
 		<aside className={inspectorShellClass} aria-label={ariaLabel}>
 			<div className="session-inspector__topbar flex h-inspector-tabs shrink-0 items-center border-b border-border pl-2.5">
 				{isVisible ? (
-					<div className="session-inspector__tablist flex min-w-0 flex-1 items-center gap-0.5" role="tablist">
+					<div className="session-inspector__tablist flex min-w-0 flex-1 items-center justify-start gap-0" role="tablist">
 						{tabs.map((tab, index) => (
 							<button
 								aria-label={tab.label}
@@ -110,7 +110,7 @@ export function SessionInspectorShellView({
 								aria-selected={activeView === tab.id}
 								tabIndex={activeView === tab.id ? 0 : -1}
 								className={cn(
-									"session-inspector__tab-button inline-flex h-control-md min-w-0 items-center justify-center rounded-md px-1.5 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
+									"session-inspector__tab-button inline-flex h-control-md shrink-0 items-center justify-center rounded-md px-1 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
 									activeView === tab.id && "bg-interactive-active text-foreground",
 								)}
 								onClick={() => onViewChange(tab.id)}
@@ -130,7 +130,7 @@ export function SessionInspectorShellView({
 										</span>
 									) : null}
 								</span>
-								<span className="session-inspector__responsive-label min-w-0 truncate whitespace-nowrap text-2xs">
+								<span className="session-inspector__responsive-label whitespace-nowrap text-2xs">
 									{tab.displayLabel ?? tab.label}
 								</span>
 							</button>


### PR DESCRIPTION
## Summary
- Narrow inspector rails no longer ellipsize tab labels (`Summa…` / `Revie…`).
- Tabs keep full labels until space runs out, then collapse into a tight left-aligned icon cluster.
- Slightly tighter tab chrome so default-width inspectors can still show full words before collapsing.

## Test plan
- [ ] Open a session inspector at default width — tabs show full labels (Summary, Reviews, Browser, Files), not truncated text
- [ ] Drag the inspector narrower — labels disappear into icons before ellipsis appears; icons stay packed, not stretched
- [ ] Widen again — labels return cleanly
- [ ] Confirm notification + inspector toggle on the right still work and aren’t overlapped by tabs