### PR TITLE
fix: order sidebar workers by last activity

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -474,6 +474,29 @@ describe("Sidebar", () => {
 		expect(navigateMock).not.toHaveBeenCalled();
 	});
 
+	it("lists worker sessions by last activity, newest first", () => {
+		const oldest: WorkspaceSession = {
+			...session,
+			id: "proj-1-old",
+			title: "old task",
+			createdAt: "2026-06-29T00:00:00Z",
+			updatedAt: "2026-07-02T00:00:00Z",
+			activity: { state: "idle", lastActivityAt: "2026-07-01T00:00:00Z" },
+		};
+		const newest: WorkspaceSession = {
+			...session,
+			id: "proj-1-new",
+			title: "new task",
+			createdAt: "2026-07-01T00:00:00Z",
+			updatedAt: "2026-07-01T00:00:00Z",
+			activity: { state: "active", lastActivityAt: "2026-07-02T00:00:00Z" },
+		};
+		renderSidebar({ workspaces: [{ ...workspace, sessions: [oldest, newest] }] });
+
+		const sessionButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-session-row] button[aria-label^="Open "]'));
+		expect(sessionButtons.map((button) => button.getAttribute("aria-label"))).toEqual(["Open new task", "Open old task"]);
+	});
+
 	it("navigates to the project board when the project row button is clicked", async () => {
 		const user = userEvent.setup();
 		renderSidebar();

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -491,10 +491,39 @@ describe("Sidebar", () => {
 			updatedAt: "2026-07-01T00:00:00Z",
 			activity: { state: "active", lastActivityAt: "2026-07-02T00:00:00Z" },
 		};
-		renderSidebar({ workspaces: [{ ...workspace, sessions: [oldest, newest] }] });
+		const noActivity: WorkspaceSession = {
+			...session,
+			id: "proj-1-no-activity",
+			title: "no activity",
+			createdAt: "2026-06-29T00:00:00Z",
+			updatedAt: "2026-07-03T00:00:00Z",
+		};
+		const invalidActivity: WorkspaceSession = {
+			...session,
+			id: "proj-1-invalid-activity",
+			title: "invalid activity",
+			createdAt: "2026-06-29T00:00:00Z",
+			updatedAt: "2026-07-04T00:00:00Z",
+			activity: { state: "idle", lastActivityAt: "not-a-timestamp" },
+		};
+		const createdFallback: WorkspaceSession = {
+			...session,
+			id: "proj-1-created-fallback",
+			title: "created fallback",
+			createdAt: "2026-07-05T00:00:00Z",
+			updatedAt: "not-a-timestamp",
+			activity: { state: "idle", lastActivityAt: "also-not-a-timestamp" },
+		};
+		renderSidebar({ workspaces: [{ ...workspace, sessions: [oldest, newest, noActivity, invalidActivity, createdFallback] }] });
 
 		const sessionButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-session-row] button[aria-label^="Open "]'));
-		expect(sessionButtons.map((button) => button.getAttribute("aria-label"))).toEqual(["Open new task", "Open old task"]);
+		expect(sessionButtons.map((button) => button.getAttribute("aria-label"))).toEqual([
+			"Open created fallback",
+			"Open invalid activity",
+			"Open no activity",
+			"Open new task",
+			"Open old task",
+		]);
 	});
 
 	it("navigates to the project board when the project row button is clicked", async () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -29,6 +29,7 @@ import {
 	newestActiveOrchestrator,
 	type WorkspaceSession,
 	type WorkspaceSummary,
+	sortedWorkerSessions,
 	workerSessions,
 } from "../types/workspace";
 import { getAgentActivityView } from "../lib/session-presentation";
@@ -545,7 +546,7 @@ function ProjectItem({
 	// Keep completed PR sessions reachable while their runtime still exists.
 	// Only termination removes a worker from the sidebar; archived sessions stay
 	// reachable through SessionsBoard.
-	const sessions = workerSessions(workspace.sessions).filter((session) => session.isTerminated !== true);
+	const sessions = sortedWorkerSessions(workspace.sessions).filter((session) => session.isTerminated !== true);
 	// The project's live orchestrator (if any) backs the hover Orchestrator
 	// button: navigate to it when present, otherwise spawn one first.
 	const orchestrator = newestActiveOrchestrator(workspace.sessions);

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -213,19 +213,29 @@ function sessionNewer(a: WorkspaceSession, b: WorkspaceSession): boolean {
 }
 
 function sessionLastActiveNewer(a: WorkspaceSession, b: WorkspaceSession): boolean {
-	const aActivity = timestamp(a.activity?.lastActivityAt);
-	const bActivity = timestamp(b.activity?.lastActivityAt);
-	if (aActivity !== bActivity) return aActivity > bActivity;
-	const aUpdated = timestamp(a.updatedAt);
-	const bUpdated = timestamp(b.updatedAt);
-	if (aUpdated !== bUpdated) return aUpdated > bUpdated;
-	return sessionNewer(a, b);
+	const aLastActive = sessionLastActiveTimestamp(a);
+	const bLastActive = sessionLastActiveTimestamp(b);
+	if (aLastActive !== bLastActive) return aLastActive > bLastActive;
+	return a.id > b.id;
+}
+
+function sessionLastActiveTimestamp(session: WorkspaceSession): number {
+	return (
+		validTimestamp(session.activity?.lastActivityAt) ??
+		validTimestamp(session.updatedAt) ??
+		validTimestamp(session.createdAt) ??
+		0
+	);
 }
 
 function timestamp(value?: string): number {
-	if (!value) return 0;
+	return validTimestamp(value) ?? 0;
+}
+
+function validTimestamp(value?: string): number | undefined {
+	if (!value) return undefined;
 	const parsed = Date.parse(value);
-	return Number.isNaN(parsed) ? 0 : parsed;
+	return Number.isNaN(parsed) ? undefined : parsed;
 }
 
 export function workerSessions(sessions: WorkspaceSession[]): WorkspaceSession[] {

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -212,6 +212,16 @@ function sessionNewer(a: WorkspaceSession, b: WorkspaceSession): boolean {
 	return a.id > b.id;
 }
 
+function sessionLastActiveNewer(a: WorkspaceSession, b: WorkspaceSession): boolean {
+	const aActivity = timestamp(a.activity?.lastActivityAt);
+	const bActivity = timestamp(b.activity?.lastActivityAt);
+	if (aActivity !== bActivity) return aActivity > bActivity;
+	const aUpdated = timestamp(a.updatedAt);
+	const bUpdated = timestamp(b.updatedAt);
+	if (aUpdated !== bUpdated) return aUpdated > bUpdated;
+	return sessionNewer(a, b);
+}
+
 function timestamp(value?: string): number {
 	if (!value) return 0;
 	const parsed = Date.parse(value);
@@ -220,6 +230,13 @@ function timestamp(value?: string): number {
 
 export function workerSessions(sessions: WorkspaceSession[]): WorkspaceSession[] {
 	return sessions.filter((s) => !isOrchestratorSession(s));
+}
+
+/** Worker sessions ordered by agent activity, newest first. */
+export function sortedWorkerSessions(sessions: WorkspaceSession[]): WorkspaceSession[] {
+	return workerSessions(sessions).sort((a, b) =>
+		sessionLastActiveNewer(b, a) ? 1 : sessionLastActiveNewer(a, b) ? -1 : 0,
+	);
 }
 
 export function sessionIsActive(session: WorkspaceSession): boolean {


### PR DESCRIPTION
## Summary
- order project worker sessions by agent activity timestamp, newest first
- fall back to session update/creation timestamps for older or incomplete records
- add sidebar regression coverage for SCM updates not representing agent activity
- Feedback from the user: https://discord.com/channels/1476302178913357958/1526316936546357258/1537880185096118365

## Tests
- `git diff --check`
- Focused Vitest/typecheck attempted; blocked by missing root workspace dependencies for `packages/product-ui` (React, clsx, tailwind-merge).

### Before
<img width="1101" height="846" alt="Screenshot 2026-08-16 at 2 23 26 PM" src="https://github.com/user-attachments/assets/ce72d008-d974-447c-ad16-6762eb94c02c" />

### After
<img width="1326" height="854" alt="Screenshot 2026-08-16 at 2 23 39 PM" src="https://github.com/user-attachments/assets/8bed8ce1-7391-466a-91fa-096b3d8fc1b7" />


## Risk
- Sidebar ordering only; no API or persistence changes.