### PR TITLE
Keep browser tabs closable and DevTools controls visible

### DIFF
--- a/frontend/src/main/agent-browser-runtime.test.ts
+++ b/frontend/src/main/agent-browser-runtime.test.ts
@@ -436,7 +436,7 @@ describe("agent-browser structured output", () => {
 
 const nativeBinary = process.env.AO_AGENT_BROWSER_TEST_BINARY;
 describe.skipIf(!nativeBinary)("agent-browser native compatibility", () => {
-	it("connects the pinned native daemon through AO's scoped CDP bridge", async () => {
+	it("connects the pinned native daemon and keeps native tab lifecycle commands aligned", async () => {
 		class DebuggerFixture extends EventEmitter {
 			attached = false;
 			attach() {
@@ -461,21 +461,31 @@ describe.skipIf(!nativeBinary)("agent-browser native compatibility", () => {
 				return {};
 			}
 		}
-		const debug = new DebuggerFixture();
+		const targets = [
+			{
+				id: "t1",
+				url: "http://localhost:5173/",
+				title: "Fixture",
+				debugger: new DebuggerFixture(),
+			},
+		];
 		const provider = {
-			listTargets: () => [
-				{
-					id: "t1",
-					url: "http://localhost:5173/",
-					title: "Fixture",
-					debugger: debug,
-				},
-			],
-			createTarget: async () => {
-				throw new Error("unexpected target creation");
+			listTargets: () => targets,
+			createTarget: async (url: string) => {
+				const target = {
+					id: `t${targets.length + 1}`,
+					url,
+					title: "New tab",
+					debugger: new DebuggerFixture(),
+				};
+				targets.push(target);
+				return target;
 			},
 			activateTarget: () => undefined,
-			closeTarget: () => undefined,
+			closeTarget: (targetId: string) => {
+				const index = targets.findIndex((target) => target.id === targetId);
+				if (index >= 0) targets.splice(index, 1);
+			},
 		};
 		const runtime = new AgentBrowserRuntime({
 			binaryPath: nativeBinary!,
@@ -484,6 +494,11 @@ describe.skipIf(!nativeBinary)("agent-browser native compatibility", () => {
 		try {
 			const result = await runtime.runAction("native-fixture", "get", { property: "url" }, provider);
 			expect(result.url).toBe("http://localhost:5173/");
+			const created = await runtime.runAction("native-fixture", "tab-new", {}, provider);
+			expect(created.tabId).toBe("t2");
+			expect(targets.map((target) => target.id)).toEqual(["t1", "t2"]);
+			await runtime.runAction("native-fixture", "tab-close", { tabId: "t2" }, provider);
+			expect(targets.map((target) => target.id)).toEqual(["t1"]);
 			const screenshot = await runtime.screenshot("native-fixture", provider);
 			expect(screenshot).toMatchObject({ width: 1, height: 1 });
 		} finally {

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -696,6 +696,25 @@ describe("agent browser runtime", () => {
 		expect(debuggerSendCommand).toHaveBeenCalledWith("Page.navigate", { url: "http://localhost:4173/" });
 	});
 
+	it("keeps UI-created tabs in the native registry after the daemon has connected", async () => {
+		const { host, invoke, runtime, views } = setupTabHost();
+		await host.execute("sess-1", "snapshot");
+		const state = (await invoke("browser:ensure", "sess-1")) as { viewId: string };
+
+		for (let index = 0; index < 6; index += 1) {
+			await invoke("browser:openTab", { viewId: state.viewId });
+		}
+
+		const nativeNewTabCalls = vi
+			.mocked(runtime.runAction)
+			.mock.calls.filter(([, action]) => action === "tab-new");
+		expect(nativeNewTabCalls).toHaveLength(6);
+		expect(views).toHaveLength(7);
+
+		await invoke("browser:closeTab", { viewId: state.viewId, tabId: "t7" });
+
+		expect(views[6].webContents.close).toHaveBeenCalledTimes(1);
+	});
 
 	it("keeps stable logical tab IDs, separate targets, and the selected tab active", async () => {
 		const { emit, host, invoke, views } = setupTabHost();

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -1172,8 +1172,30 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	handle("browser:openTab", async (event, input: BrowserOpenTabInput) => {
 		const session = entries.get(input.viewId);
 		if (!session || !isRendererOwned(event, input.viewId)) return emptyTabsState(input.viewId);
-		await openTab(session, input.url, true);
-		return listTabs(session);
+		let url = input.url;
+		if (url) {
+			const normalized = normalizeBrowserURL(url);
+			if (!isAllowedBrowserURL(normalized.href, options.rendererOrigin)) {
+				throw browserError("NAVIGATION_FAILED", "Unsupported browser URL");
+			}
+			url = normalized.href;
+		}
+		if (!options.agentBrowserRuntime) {
+			await openTab(session, url, true);
+			return listTabs(session);
+		}
+		return queueNativeOperation(session, async () => {
+			// Let agent-browser create UI tabs too so its stable tab registry and
+			// AO's WebContentsView IDs stay aligned for later select/close commands.
+			await options.agentBrowserRuntime!.runAction(
+				session.sessionId,
+				"tab-new",
+				{ url },
+				agentBrowserTargets(session),
+			);
+			session.nativeActiveTabId = session.activeTabId;
+			return listTabs(session);
+		});
 	});
 	handle("browser:annotation:setMode", (event, input: BrowserAnnotationModeInput) => setAnnotationMode(event, input));
 	on("browser:destroy", (event, viewId: string) => {

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -314,13 +314,23 @@ describe("BrowserPanel", () => {
 		);
 		const toolbarButtonCount = screen.getAllByRole("button").length;
 
-		await userEvent.click(screen.getByRole("button", { name: "Open DevTools" }));
+		const openButton = screen.getByRole("button", { name: "Open DevTools" });
+		expect(openButton).toHaveAttribute("aria-pressed", "false");
+		await userEvent.click(openButton);
 		expect(hookState.openDevTools).toHaveBeenCalledOnce();
 
 		hookState.devtoolsState = { viewId: "42:sess-1", open: true, activeTabId: "t1" };
 		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 		expect(screen.getAllByRole("button")).toHaveLength(toolbarButtonCount);
-		await userEvent.click(screen.getByRole("button", { name: "Close DevTools" }));
+		const closeButton = screen.getByRole("button", { name: "Close DevTools" });
+		expect(closeButton).toHaveAttribute("aria-pressed", "true");
+		expect(closeButton).toHaveClass(
+			"bg-accent-strong",
+			"text-accent-foreground",
+			"hover:bg-accent-strong",
+			"dark:hover:bg-accent-strong",
+		);
+		await userEvent.click(closeButton);
 		expect(hookState.closeDevTools).toHaveBeenCalledOnce();
 	});
 

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -458,7 +458,11 @@ export function BrowserPanelView({
 				) : null}
 				<Button
 					aria-label={t(devtoolsState.open ? "browser.closeDevTools" : "browser.openDevTools")}
-					className={cn(devtoolsState.open && "bg-accent-weak text-accent")}
+					aria-pressed={devtoolsState.open}
+					className={cn(
+						devtoolsState.open &&
+							"bg-accent-strong text-accent-foreground hover:bg-accent-strong dark:hover:bg-accent-strong",
+					)}
 					disabled={!canUseDevTools}
 					onClick={() => void (devtoolsState.open ? closeDevTools() : openDevTools())}
 					size="icon-sm"


### PR DESCRIPTION
## What

Fixes browser tabs that could not be closed after multiple tabs were opened, and improves DevTools button visibility while it is active.

## Why

UI-created tabs were added directly to AO’s Electron tab list after the native agent-browser daemon had already connected. The daemon therefore did not know about those tabs, causing close commands to fail with “Tab not found.”

The active DevTools button also inherited the ghost button’s dark hover styling, making the icon difficult to see.

## How

- Route UI tab creation through the existing native `tab-new` lifecycle so AO and agent-browser stay synchronized.
- Preserve direct tab creation as the fallback when the native runtime is unavailable.
- Give the active DevTools button a persistent high-contrast accent state, including hover.
- Expose the DevTools toggle state through `aria-pressed`.
- Add regression coverage for the seven-tab workflow and native tab lifecycle.

## Files affected

- `frontend/src/main/browser-view-host.ts`
  - Synchronizes UI-created tabs with the native browser runtime.
- `frontend/src/main/browser-view-host.test.ts`
  - Covers creating multiple UI tabs after daemon initialization and closing one.
- `frontend/src/main/agent-browser-runtime.test.ts`
  - Verifies native tab creation and closure using the bundled agent-browser binary.
- `frontend/src/renderer/components/BrowserPanel.tsx`
  - Improves active DevTools button contrast and accessibility state.
- `frontend/src/renderer/components/BrowserPanel.test.tsx`
  - Verifies the DevTools active state and styling.

## Testing

- `npm test -- --run src/main/browser-view-host.test.ts src/main/agent-browser-runtime.test.ts`
  - 73 passed, 1 skipped.
- `npm test -- --run src/renderer/components/BrowserPanel.test.tsx`
  - 33 passed.
- `npm run typecheck`

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Tests added for user-visible behavior
- [x] Relevant CI checks pass