### PR TITLE
Improve pull request card layout

### DIFF
--- a/frontend/src/renderer/components/PRSummaryDisplay.test.tsx
+++ b/frontend/src/renderer/components/PRSummaryDisplay.test.tsx
@@ -39,7 +39,7 @@ describe("PRSummaryParts", () => {
 			</>,
 		);
 
-		expect(screen.getByRole("link", { name: "@ada" })).toHaveAttribute("href", "https://github.com/ada");
+		expect(screen.getByRole("link", { name: "ada" })).toHaveAttribute("href", "https://github.com/ada");
 		expect(screen.getByRole("link", { name: "Checks passing" })).toHaveAttribute(
 			"href",
 			"https://github.com/acme/repo/pull/7/checks",

--- a/packages/product-ui/src/GithubAvatar.tsx
+++ b/packages/product-ui/src/GithubAvatar.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { cn } from "./utils";
+
+export type GithubAvatarProps = {
+	login: string;
+	className?: string;
+};
+
+function initials(login: string): string {
+	return login
+		.replace(/^@/, "")
+		.trim()
+		.split(/[-_\s]+/)
+		.filter(Boolean)
+		.slice(0, 2)
+		.map((part) => part[0]?.toUpperCase() ?? "")
+		.join("") || "?";
+}
+
+export function GithubAvatar({ login, className }: GithubAvatarProps) {
+	const normalizedLogin = login.replace(/^@/, "").trim();
+	const [failed, setFailed] = useState(false);
+	const avatarURL = normalizedLogin
+		? `https://github.com/${encodeURIComponent(normalizedLogin)}.png?size=64`
+		: "";
+
+	if (avatarURL && !failed) {
+		return (
+			<img
+				alt=""
+				aria-hidden="true"
+				className={cn("size-icon-sm shrink-0 rounded-full object-cover", className)}
+				draggable={false}
+				loading="lazy"
+				onError={() => setFailed(true)}
+				referrerPolicy="no-referrer"
+				src={avatarURL}
+			/>
+		);
+	}
+
+	return (
+		<span
+			aria-hidden="true"
+			className={cn("inline-flex size-icon-sm shrink-0 items-center justify-center rounded-full bg-muted text-micro font-semibold text-muted-foreground", className)}
+		>
+			{initials(normalizedLogin)}
+		</span>
+	);
+}

--- a/packages/product-ui/src/PRSummaryDisplay.tsx
+++ b/packages/product-ui/src/PRSummaryDisplay.tsx
@@ -44,23 +44,22 @@ export function PRSummaryMeta({
 	const hasDiff = hasDiffMetadata(pr);
 	const authorHandle = pr.author?.replace(/^@/, "") ?? "";
 	const primary: ReactNode[] = [leading, branchRange].filter(Boolean);
+	let author: ReactNode = null;
 	if (authorHandle) {
-		primary.push(
+		author =
 			pr.provider === "github" ? (
 				<ExternalLink
 					className="inline-flex min-w-0 items-center gap-1 text-settings-label underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
 					href={`https://github.com/${encodeURIComponent(authorHandle)}`}
-					key="author"
 				>
-					{pr.provider === "github" ? <GithubAvatar className="size-3" login={authorHandle} /> : null}
-					@{authorHandle}
+					<GithubAvatar className="size-3" login={authorHandle} />
+					{authorHandle}
 				</ExternalLink>
 			) : (
-				<span key="author">@{authorHandle}</span>
-			),
-		);
+				<span>{authorHandle}</span>
+			);
 	}
-	if (primary.length === 0 && !hasDiff) {
+	if (primary.length === 0 && !hasDiff && !author) {
 		return null;
 	}
 	return (
@@ -75,6 +74,7 @@ export function PRSummaryMeta({
 					))}
 				</div>
 			) : null}
+			{author ? <div className="mt-0.5 min-w-0 break-words [overflow-wrap:anywhere] text-muted-foreground">{author}</div> : null}
 			{hasDiff ? <PRDiffMeta countNounLabel={countNounLabel} pr={pr} /> : null}
 		</div>
 	);

--- a/packages/product-ui/src/PRSummaryDisplay.tsx
+++ b/packages/product-ui/src/PRSummaryDisplay.tsx
@@ -66,7 +66,7 @@ export function PRSummaryMeta({
 	return (
 		<div className={cn("min-w-0 font-mono text-2xs leading-4", className)}>
 			{primary.length > 0 ? (
-				<div className="flex min-w-0 items-center gap-1.5 overflow-hidden text-muted-foreground">
+				<div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-muted-foreground">
 					{primary.map((part, index) => (
 						<Fragment key={index}>
 							{index > 0 ? <span className="shrink-0 text-passive">·</span> : null}
@@ -198,7 +198,7 @@ export function PRCardStatusSummary({
 								<PRCardStatusLink externalLink={externalLink} status={presentation.primary} />
 							</div>
 							{presentation.primary.detail ? (
-								<div className="mt-0.5 text-2xs leading-4 text-muted-foreground">
+								<div className="mt-0.5 min-w-0 break-words text-2xs leading-4 text-muted-foreground">
 									{presentation.primary.detail}
 								</div>
 							) : null}

--- a/packages/product-ui/src/PRSummaryDisplay.tsx
+++ b/packages/product-ui/src/PRSummaryDisplay.tsx
@@ -48,11 +48,11 @@ export function PRSummaryMeta({
 		primary.push(
 			pr.provider === "github" ? (
 				<ExternalLink
-					className="text-settings-label underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+					className="inline-flex min-w-0 items-center gap-1 text-settings-label underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
 					href={`https://github.com/${encodeURIComponent(authorHandle)}`}
 					key="author"
 				>
-					{pr.provider === "github" ? <GithubAvatar login={authorHandle} /> : null}
+					{pr.provider === "github" ? <GithubAvatar className="size-3" login={authorHandle} /> : null}
 					@{authorHandle}
 				</ExternalLink>
 			) : (

--- a/packages/product-ui/src/PRSummaryDisplay.tsx
+++ b/packages/product-ui/src/PRSummaryDisplay.tsx
@@ -1,6 +1,7 @@
 import { Fragment, type ReactNode } from "react";
 import type { ExternalLinkComponent } from "./external-link";
 import { ArrowUpRightIcon } from "./icons";
+import { GithubAvatar } from "./GithubAvatar";
 import type {
 	PRCardPresentation,
 	PRCardStatus,
@@ -51,6 +52,7 @@ export function PRSummaryMeta({
 					href={`https://github.com/${encodeURIComponent(authorHandle)}`}
 					key="author"
 				>
+					{pr.provider === "github" ? <GithubAvatar login={authorHandle} /> : null}
 					@{authorHandle}
 				</ExternalLink>
 			) : (

--- a/packages/product-ui/src/PRSummaryDisplay.tsx
+++ b/packages/product-ui/src/PRSummaryDisplay.tsx
@@ -70,7 +70,7 @@ export function PRSummaryMeta({
 					{primary.map((part, index) => (
 						<Fragment key={index}>
 							{index > 0 ? <span className="shrink-0 text-passive">·</span> : null}
-							<span className="min-w-0 truncate">{part}</span>
+							<span className="min-w-0 break-words [overflow-wrap:anywhere]">{part}</span>
 						</Fragment>
 					))}
 				</div>
@@ -167,7 +167,7 @@ export function PRCardStatusSummary({
 								<span aria-hidden="true" className="size-dot-sm shrink-0 rounded-full bg-current" />
 								{presentation.readiness.label}
 							</div>
-							<div className="mt-0.5 pl-4 text-2xs leading-4 text-muted-foreground">{presentation.readiness.detail}</div>
+							<div className="mt-0.5 min-w-0 break-words pl-4 text-2xs leading-4 text-muted-foreground">{presentation.readiness.detail}</div>
 						</div>
 						{action ? <div className="shrink-0 self-center">{action}</div> : null}
 					</div>

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -64,6 +64,7 @@ describe("SessionInspectorShellView", () => {
 
 		expect(screen.getByRole("complementary", { name: "Session inspector" })).toBeInTheDocument();
 		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist");
+		expect(screen.getByRole("tablist").parentElement?.nextElementSibling).toHaveClass("overflow-x-hidden");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("aria-selected", "true");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass("shrink-0");
 		expect(screen.getByRole("tab", { name: "Summary" })).not.toHaveClass("flex-1");

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -64,7 +64,10 @@ describe("SessionInspectorShellView", () => {
 
 		expect(screen.getByRole("complementary", { name: "Session inspector" })).toBeInTheDocument();
 		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist");
-		expect(screen.getByRole("tablist").parentElement?.nextElementSibling).toHaveClass("overflow-x-hidden");
+		expect(screen.getByRole("tablist").parentElement?.nextElementSibling).toHaveClass(
+			"board-scrollbar",
+			"overflow-x-hidden",
+		);
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("aria-selected", "true");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass("shrink-0");
 		expect(screen.getByRole("tab", { name: "Summary" })).not.toHaveClass("flex-1");

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -31,7 +31,7 @@ export type InspectorTab = {
 
 const inspectorShellClass = "@container/inspector flex h-full min-h-0 flex-col overflow-hidden";
 const inspectorBodyBaseClass = "min-h-0 flex-1";
-const inspectorScrollableBodyClass = "overflow-y-auto p-3 pb-4 @max-[300px]/inspector:px-2.5";
+const inspectorScrollableBodyClass = "overflow-x-hidden overflow-y-auto p-3 pb-4 @max-[300px]/inspector:px-2.5";
 export const inspectorEmptyClass = "text-xs text-settings-muted leading-normal";
 
 export function SessionInspectorShellView({

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -17,6 +17,7 @@ import type {
 	PRSummaryMetadata,
 } from "./pull-request-models";
 import { cn } from "./utils";
+import { GithubAvatar } from "./GithubAvatar";
 
 export type InspectorView = "summary" | "reviews" | "browser" | "files";
 
@@ -554,7 +555,6 @@ export function InspectorReviewsView({
 									onSendInlineComment={onSendInlineComment}
 									onRequestRereview={onRequestRereview}
 									onResolveInlineComment={onResolveInlineComment}
-									renderAvatar={renderAvatar}
 									renderMarkdown={renderMarkdown}
 								/>
 							</div>
@@ -815,7 +815,6 @@ function GithubReviewHistory({
 	onRequestRereview,
 	onResolveInlineComment,
 	onSendInlineComment,
-	renderAvatar,
 	renderMarkdown,
 }: {
 	entries: InspectorGithubReview[];
@@ -824,7 +823,6 @@ function GithubReviewHistory({
 	onRequestRereview?: (review: InspectorGithubReview) => Promise<void> | void;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
-	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 }) {
 	const sorted = [...entries].sort((a, b) => b.submittedAt.localeCompare(a.submittedAt));
@@ -841,7 +839,6 @@ function GithubReviewHistory({
 					onRequestRereview={onRequestRereview}
 					onResolveInlineComment={onResolveInlineComment}
 					onSendInlineComment={onSendInlineComment}
-					renderAvatar={renderAvatar}
 					renderMarkdown={renderMarkdown}
 				/>
 			))}
@@ -857,7 +854,6 @@ function ExternalReviewCard({
 	onRequestRereview,
 	onResolveInlineComment,
 	onSendInlineComment,
-	renderAvatar,
 	renderMarkdown,
 }: {
 	defaultOpen: boolean;
@@ -867,7 +863,6 @@ function ExternalReviewCard({
 	onRequestRereview?: (review: InspectorGithubReview) => Promise<void> | void;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
-	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 }) {
 	const [open, setOpen] = useState(defaultOpen);
@@ -888,7 +883,7 @@ function ExternalReviewCard({
 				<span className="flex min-w-0 flex-1 flex-col gap-0.5">
 					<span className="flex min-w-0 items-center gap-1.5">
 						<span className="inline-flex min-w-0 items-center gap-1 text-xs font-semibold text-foreground">
-							{renderAvatar(entry.reviewerId)}
+							<GithubAvatar login={entry.reviewerId} />
 							<span className="truncate">{entry.reviewerId}</span>
 						</span>
 						{entry.isBot ? <span className="shrink-0 font-mono text-micro text-passive">{labels.bot}</span> : null}
@@ -1087,7 +1082,12 @@ function InlineCommentRow({
 	const body = comment.body?.trim();
 	return (
 		<div className="flex min-w-0 flex-col gap-1.5 px-2.5 py-2 text-2xs">
-			{showReviewer && comment.reviewerId ? <span className="font-medium text-muted-foreground">{comment.reviewerId}</span> : null}
+			{showReviewer && comment.reviewerId ? (
+				<span className="inline-flex min-w-0 items-center gap-1.5 font-medium text-muted-foreground">
+					<GithubAvatar login={comment.reviewerId} />
+					<span className="truncate">{comment.reviewerId}</span>
+				</span>
+			) : null}
 			{body ? <p className="m-0 whitespace-pre-wrap break-words leading-relaxed text-muted-foreground">{body}</p> : null}
 			<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
 				{sent ? (

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -31,7 +31,7 @@ export type InspectorTab = {
 
 const inspectorShellClass = "@container/inspector flex h-full min-h-0 flex-col overflow-hidden";
 const inspectorBodyBaseClass = "min-h-0 flex-1";
-const inspectorScrollableBodyClass = "overflow-x-hidden overflow-y-auto p-3 pb-4 @max-[300px]/inspector:px-2.5";
+const inspectorScrollableBodyClass = "board-scrollbar overflow-x-hidden overflow-y-auto p-3 pb-4 @max-[300px]/inspector:px-2.5";
 export const inspectorEmptyClass = "text-xs text-settings-muted leading-normal";
 
 export function SessionInspectorShellView({

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -268,7 +268,7 @@ export function InspectorPullRequestCardView({
 	statusNotice?: ReactNode;
 }) {
 	return (
-		<article className="rounded-lg border border-(--color-border-settings-input) bg-(--color-bg-settings-input) px-3 py-2.5">
+		<article className="min-w-0 w-full rounded-lg border border-(--color-border-settings-input) bg-(--color-bg-settings-input) px-3 py-2.5">
 			{pr.title ? (
 				<ExternalLink
 					className="inline text-sm font-semibold leading-snug tracking-tight text-settings-label underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"

--- a/packages/product-ui/src/components.test.tsx
+++ b/packages/product-ui/src/components.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { AgentAvatar } from "./AgentAvatar";
+import { GithubAvatar } from "./GithubAvatar";
 import type { ExternalLinkProps } from "./external-link";
 import { PRCardStatusSummary, PRSummaryMeta, PRSummaryParts } from "./PRSummaryDisplay";
 import type { PRCardPresentation, PRSummaryPart } from "./pull-request-models";
@@ -18,6 +19,15 @@ function ExternalLink({ ariaLabel, children, stopPropagation, ...props }: Extern
 }
 
 describe("portable leaf components", () => {
+	it("renders GitHub avatars from the login and falls back to initials", () => {
+		const { container } = render(<GithubAvatar login="ada-lovelace" />);
+		const image = container.querySelector("img");
+
+		expect(image).toHaveAttribute("src", "https://github.com/ada-lovelace.png?size=64");
+		if (image) fireEvent.error(image);
+		expect(container).toHaveTextContent("AL");
+	});
+
 	it("renders an injected agent logo without owning app assets", () => {
 		render(<AgentAvatar logoSources={{ "claude-code": "/logos/claude.svg" }} provider="claude-code" />);
 

--- a/packages/product-ui/src/components.test.tsx
+++ b/packages/product-ui/src/components.test.tsx
@@ -62,7 +62,7 @@ describe("portable leaf components", () => {
 
 		expect(screen.getByText("feature → main")).toBeInTheDocument();
 		expect(screen.getByText("2 localized-file")).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "@ada" })).toHaveAttribute("href", "https://github.com/ada");
+		expect(screen.getByRole("link", { name: "ada" })).toHaveAttribute("href", "https://github.com/ada");
 		expect(screen.getByText("feature → main")).toHaveClass("break-words");
 	});
 

--- a/packages/product-ui/src/components.test.tsx
+++ b/packages/product-ui/src/components.test.tsx
@@ -63,6 +63,7 @@ describe("portable leaf components", () => {
 		expect(screen.getByText("feature → main")).toBeInTheDocument();
 		expect(screen.getByText("2 localized-file")).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: "@ada" })).toHaveAttribute("href", "https://github.com/ada");
+		expect(screen.getByText("feature → main")).toHaveClass("break-words");
 	});
 
 	it("renders precomputed PR presentation without controller dependencies", () => {

--- a/packages/product-ui/src/index.ts
+++ b/packages/product-ui/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./AgentAvatar";
+export * from "./GithubAvatar";
 export * from "./agent-capabilities";
 export * from "./agents";
 export * from "./external-link";


### PR DESCRIPTION
Improves pull request cards with GitHub avatars, responsive metadata wrapping, consistent scrollbars, and cleaner author display.

Change 1-avatar

Before 

<img width="368" height="185" alt="Screenshot From 2026-08-16 18-33-25" src="https://github.com/user-attachments/assets/5a85a418-2f39-4225-9740-66141c1c97cb" />


After 

<img width="434" height="672" alt="Screenshot From 2026-08-16 18-47-14" src="https://github.com/user-attachments/assets/c9729016-fb79-4643-a6b2-4f820ccd12da" />

Change 2- scroll bar 

Before 1

<img width="489" height="706" alt="Screenshot From 2026-08-16 18-56-02" src="https://github.com/user-attachments/assets/b33191bd-a836-43a1-9ae7-361c39442cf5" />

After 

<img width="561" height="862" alt="image" src="https://github.com/user-attachments/assets/de7ae048-276b-426c-99dd-1ba4dc7510c7" />


Change 3- pull request card responsiveness

Before 
 
<img width="434" height="672" alt="Screenshot From 2026-08-16 18-47-14" src="https://github.com/user-attachments/assets/b9114e38-8efe-461e-a957-5b51cf46f43e" />

After 

<img width="447" height="652" alt="image" src="https://github.com/user-attachments/assets/4b4ed0f9-4494-4295-aded-0126dce31499" />
<img width="447" height="652" alt="image" src="https://github.com/user-attachments/assets/8f422e34-33ea-4944-a21f-0e7cf69d14db" />

