### PR TITLE
fix: remove blue focus rings from desktop chrome

### DIFF
--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -1193,7 +1193,7 @@ function FileAnnotationComposer({ annotation }: { annotation: FileAnnotationMode
 			<textarea
 				aria-label={t("files.feedbackLabel", { target: targetLabel })}
 				autoFocus
-				className="min-h-20 w-full resize-y rounded-md border border-input bg-background px-2.5 py-2 text-sm text-foreground outline-none placeholder:text-passive focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:opacity-60"
+				className="min-h-20 w-full resize-y rounded-md border border-input bg-background px-2.5 py-2 text-sm text-foreground outline-none placeholder:text-passive focus-visible:outline-none disabled:opacity-60"
 				disabled={annotation.status === "sending" || annotation.status === "sent"}
 				onChange={(event) => annotation.setDraft(event.target.value)}
 				onKeyDown={(event) => {

--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -88,7 +88,7 @@ describe("send keys", () => {
 
 		await userEvent.type(field, "hello");
 		expect(send).toBeEnabled();
-		expect(send).toHaveClass("hover:bg-logo-accent-bright", "focus-visible:ring-logo-accent/45");
+		expect(send).toHaveClass("hover:bg-logo-accent-bright");
 	});
 
 	it("turns the empty send action into Stop while the agent is working", async () => {

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -645,7 +645,7 @@ export function ChatComposer({
 						onClick={canStopTurn ? onInterrupt : undefined}
 						aria-label={canStopTurn ? "Stop turn" : steering ? "Steer the running turn" : "Send message"}
 						title={canStopTurn ? "Stop turn" : undefined}
-						className="size-8 rounded-lg border-logo-accent bg-logo-accent text-logo-accent-foreground hover:bg-logo-accent-bright focus-visible:ring-logo-accent/45"
+						className="size-8 rounded-lg border-logo-accent bg-logo-accent text-logo-accent-foreground hover:bg-logo-accent-bright"
 					>
 						{canStopTurn ? (
 							<Square aria-hidden="true" className="size-2.5 fill-current" />

--- a/frontend/src/renderer/components/ui/accordion.tsx
+++ b/frontend/src/renderer/components/ui/accordion.tsx
@@ -28,7 +28,7 @@ export function AccordionTrigger({
 		>
 			<AccordionPrimitive.Trigger
 				className={cn(
-					"flex min-w-0 flex-1 items-center text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+					"flex min-w-0 flex-1 items-center text-left focus-visible:outline-none",
 					className,
 				)}
 				{...props}

--- a/frontend/src/renderer/components/ui/badge.tsx
+++ b/frontend/src/renderer/components/ui/badge.tsx
@@ -13,7 +13,7 @@ export function Badge({
 		<span
 			data-slot="badge"
 			className={cn(
-				"inline-flex h-5 shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-full border border-transparent px-2 py-0.5 text-xs font-medium transition-[background-color,border-color,color,box-shadow] focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 [&>svg]:pointer-events-none [&>svg]:size-3",
+				"inline-flex h-5 shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-full border border-transparent px-2 py-0.5 text-xs font-medium transition-[background-color,border-color,color,box-shadow] focus-visible:outline-none [&>svg]:pointer-events-none [&>svg]:size-3",
 				variant === "neutral" && "bg-secondary text-secondary-foreground",
 				variant === "outline" && "border-border text-foreground hover:bg-muted",
 				variant === "accent" && "bg-primary text-primary-foreground",

--- a/frontend/src/renderer/components/ui/button.tsx
+++ b/frontend/src/renderer/components/ui/button.tsx
@@ -7,7 +7,7 @@ import { cn } from "../../lib/utils";
 // (primary). Footer variants match settings/modal action chrome tokens.
 // See DESIGN.md → Spacing / Color.
 const buttonVariants = cva(
-	"group/button inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent bg-clip-padding text-sm font-normal transition-[background-color,border-color,color,box-shadow,transform,opacity] duration-[100ms] ease-out outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 active:not-aria-[haspopup]:scale-[0.97] active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+	"group/button inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent bg-clip-padding text-sm font-normal transition-[background-color,border-color,color,box-shadow,transform,opacity] duration-[100ms] ease-out outline-none select-none focus-visible:outline-none active:not-aria-[haspopup]:scale-[0.97] active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {
@@ -18,9 +18,9 @@ const buttonVariants = cva(
 					"bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]",
 				ghost: "text-foreground hover:bg-muted dark:hover:bg-muted/50",
 				footer:
-					"h-(--size-settings-action-height) rounded-(--radius-settings-action) border-[var(--color-border-settings-input)] bg-[var(--color-bg-settings-input)] px-3 text-[length:var(--font-size-md)] leading-5 text-[var(--color-text-settings-row)] hover:bg-[var(--color-bg-settings-input)] hover:opacity-90 active:not-aria-[haspopup]:scale-100 active:not-aria-[haspopup]:translate-y-0 focus-visible:border-[var(--color-border-settings-input)] focus-visible:ring-0 focus-visible:shadow-[0_0_0_2px_var(--bridge-accent-weak)]",
+					"h-(--size-settings-action-height) rounded-(--radius-settings-action) border-[var(--color-border-settings-input)] bg-[var(--color-bg-settings-input)] px-3 text-[length:var(--font-size-md)] leading-5 text-[var(--color-text-settings-row)] hover:bg-[var(--color-bg-settings-input)] hover:opacity-90 active:not-aria-[haspopup]:scale-100 active:not-aria-[haspopup]:translate-y-0 focus-visible:outline-none",
 				"footer-primary":
-					"h-(--size-settings-action-height) rounded-(--radius-settings-action) border-transparent bg-[var(--color-settings-accent)] px-(--size-settings-footer-button-padding-x) text-[length:var(--font-size-md)] leading-5 text-[var(--color-settings-footer-button-primary-fg)] hover:bg-[var(--color-settings-accent)] hover:opacity-90 active:not-aria-[haspopup]:scale-100 active:not-aria-[haspopup]:translate-y-0 focus-visible:border-transparent focus-visible:ring-0 focus-visible:shadow-[0_0_0_2px_var(--bridge-accent-weak)]",
+					"h-(--size-settings-action-height) rounded-(--radius-settings-action) border-transparent bg-[var(--color-settings-accent)] px-(--size-settings-footer-button-padding-x) text-[length:var(--font-size-md)] leading-5 text-[var(--color-settings-footer-button-primary-fg)] hover:bg-[var(--color-settings-accent)] hover:opacity-90 active:not-aria-[haspopup]:scale-100 active:not-aria-[haspopup]:translate-y-0 focus-visible:outline-none",
 			},
 			size: {
 				default: "h-control-form px-3",

--- a/frontend/src/renderer/components/ui/dialog.tsx
+++ b/frontend/src/renderer/components/ui/dialog.tsx
@@ -62,7 +62,7 @@ function DialogContent({
 			>
 				{children}
 				{showCloseButton && (
-					<DialogPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+					<DialogPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
 						<XIcon className="size-4" />
 						<span className="sr-only">{t("common.close")}</span>
 					</DialogPrimitive.Close>

--- a/frontend/src/renderer/components/ui/input.tsx
+++ b/frontend/src/renderer/components/ui/input.tsx
@@ -6,7 +6,7 @@ export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttribute
 		<input
 			data-slot="input"
 			className={cn(
-				"h-control-form w-full min-w-0 rounded-md border border-transparent bg-input/50 px-3 py-1 text-sm text-foreground transition-[color,box-shadow,background-color] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+				"h-control-form w-full min-w-0 rounded-md border border-transparent bg-input/50 px-3 py-1 text-sm text-foreground transition-[color,box-shadow,background-color] outline-none placeholder:text-muted-foreground focus-visible:outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50",
 				className,
 			)}
 			ref={ref}

--- a/frontend/src/renderer/components/ui/resizable.tsx
+++ b/frontend/src/renderer/components/ui/resizable.tsx
@@ -28,7 +28,7 @@ function ResizableHandle({
 		<ResizablePrimitive.Separator
 			data-slot="resizable-handle"
 			className={cn(
-				"relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
+				"relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
 				className,
 			)}
 			{...props}

--- a/frontend/src/renderer/components/ui/select.tsx
+++ b/frontend/src/renderer/components/ui/select.tsx
@@ -29,7 +29,7 @@ function SelectTrigger({
 			data-slot="select-trigger"
 			data-size={size}
 			className={cn(
-				"flex w-fit items-center justify-between gap-2 rounded-md border border-transparent bg-input/50 px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow,background-color,border-color] outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive data-[placeholder]:text-muted-foreground data-[size=default]:h-control-board data-[size=sm]:h-control-form *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-icon-base [&_svg:not([class*='text-'])]:text-muted-foreground",
+				"flex w-fit items-center justify-between gap-2 rounded-md border border-transparent bg-input/50 px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow,background-color,border-color] outline-none focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive data-[placeholder]:text-muted-foreground data-[size=default]:h-control-board data-[size=sm]:h-control-form *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-icon-base [&_svg:not([class*='text-'])]:text-muted-foreground",
 				className,
 			)}
 			{...props}

--- a/frontend/src/renderer/components/ui/sheet.tsx
+++ b/frontend/src/renderer/components/ui/sheet.tsx
@@ -68,7 +68,7 @@ function SheetContent({
 			>
 				{children}
 				{showCloseButton && (
-					<SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+					<SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
 						<XIcon className="size-icon-base" />
 						<span className="sr-only">{t("common.close")}</span>
 					</SheetPrimitive.Close>

--- a/frontend/src/renderer/components/ui/sidebar.tsx
+++ b/frontend/src/renderer/components/ui/sidebar.tsx
@@ -419,7 +419,7 @@ function SidebarGroupLabel({
 			data-slot="sidebar-group-label"
 			data-sidebar="group-label"
 			className={cn(
-				"flex h-control-form shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-icon-base [&>svg]:shrink-0",
+				"flex h-control-form shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-hidden transition-[margin,opacity] duration-200 ease-linear [&>svg]:size-icon-base [&>svg]:shrink-0",
 				"group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
 				className,
 			)}
@@ -440,7 +440,7 @@ function SidebarGroupAction({
 			data-slot="sidebar-group-action"
 			data-sidebar="group-action"
 			className={cn(
-				"absolute top-4 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-icon-base [&>svg]:shrink-0",
+				"absolute top-4 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&>svg]:size-icon-base [&>svg]:shrink-0",
 				// Increases the hit area of the button on mobile.
 				"after:absolute after:-inset-2 md:after:hidden",
 				"group-data-[collapsible=icon]:hidden",
@@ -485,7 +485,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-	"peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-control-form! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-icon-base [&>svg]:shrink-0",
+	"peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-control-form! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-icon-base [&>svg]:shrink-0",
 	{
 		variants: {
 			variant: {
@@ -567,7 +567,7 @@ function SidebarMenuAction({
 			data-slot="sidebar-menu-action"
 			data-sidebar="menu-action"
 			className={cn(
-				"absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-icon-base [&>svg]:shrink-0",
+				"absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&>svg]:size-icon-base [&>svg]:shrink-0",
 				// Increases the hit area of the button on mobile.
 				"after:absolute after:-inset-2 md:after:hidden",
 				"peer-data-[size=sm]/menu-button:top-1",
@@ -681,7 +681,7 @@ function SidebarMenuSubButton({
 			data-size={size}
 			data-active={isActive}
 			className={cn(
-				"flex h-control-md min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-icon-base [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+				"flex h-control-md min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-icon-base [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
 				"data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
 				size === "sm" && "text-xs",
 				size === "md" && "text-sm",

--- a/frontend/src/renderer/components/ui/switch.tsx
+++ b/frontend/src/renderer/components/ui/switch.tsx
@@ -14,7 +14,7 @@ function Switch({ className, size = "default", ...props }: SwitchProps) {
 		<SwitchPrimitive.Root
 			data-slot="switch"
 			className={cn(
-				"peer relative inline-flex shrink-0 cursor-pointer items-center rounded-full border-transparent transition-[background-color,border-color,box-shadow] outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=unchecked]:bg-input/90",
+				"peer relative inline-flex shrink-0 cursor-pointer items-center rounded-full border-transparent transition-[background-color,border-color,box-shadow] outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=unchecked]:bg-input/90",
 				size === "sm" ? "h-4 w-8 border" : "h-5 w-11 border-2",
 				className,
 			)}

--- a/frontend/src/renderer/components/ui/tabs.tsx
+++ b/frontend/src/renderer/components/ui/tabs.tsx
@@ -19,7 +19,7 @@ export function TabsTrigger({ className, ...props }: React.ComponentPropsWithout
 	return (
 		<TabsPrimitive.Trigger
 			className={cn(
-				"inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-2 whitespace-nowrap rounded-full border border-transparent px-3 py-1 text-sm font-medium text-foreground/60 transition-[background-color,border-color,color,box-shadow] hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground dark:text-muted-foreground dark:hover:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+				"inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-2 whitespace-nowrap rounded-full border border-transparent px-3 py-1 text-sm font-medium text-foreground/60 transition-[background-color,border-color,color,box-shadow] hover:text-foreground focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground dark:text-muted-foreground dark:hover:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
 				className,
 			)}
 			{...props}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -734,8 +734,8 @@ button.settings-link-row:active {
 	}
 
 	&:focus-visible {
-		border-color: var(--bridge-accent);
-		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		border-color: var(--color-border-settings-input);
+		box-shadow: none;
 	}
 }
 
@@ -763,7 +763,7 @@ button.settings-link-row:active {
 
 	&:focus-visible {
 		border-radius: var(--radius-md);
-		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		box-shadow: none;
 	}
 
 	& .settings-row-value {
@@ -806,8 +806,8 @@ button.settings-link-row:active {
 	}
 
 	&:focus-visible {
-		border-color: var(--bridge-accent);
-		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		border-color: var(--color-border-settings-input);
+		box-shadow: none;
 		color: var(--color-text-settings-row);
 		outline: none;
 	}
@@ -841,8 +841,8 @@ button.settings-link-row:active {
 	}
 
 	&:focus-visible {
-		border-color: var(--bridge-accent);
-		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		border-color: var(--color-border-settings-input);
+		box-shadow: none;
 		color: var(--color-text-settings-row);
 		outline: none;
 	}
@@ -940,7 +940,7 @@ button.settings-link-row:active {
 }
 
 .composer-toolbar .composer-toolbar-option:focus-visible {
-	box-shadow: inset 0 0 0 2px var(--bridge-accent-weak);
+	box-shadow: none;
 }
 
 /* Inline value control inside the task composer's bottom toolbar. Reads as a
@@ -971,7 +971,7 @@ button.settings-link-row:active {
 
 	&:focus-visible {
 		border-color: transparent;
-		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		box-shadow: none;
 		outline: none;
 	}
 
@@ -1036,8 +1036,8 @@ button.settings-link-row:active {
 	}
 
 	&:focus-visible {
-		border-color: var(--bridge-accent);
-		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		border-color: var(--color-border-settings-input);
+		box-shadow: none;
 		color: var(--color-text-settings-row);
 		outline: none;
 	}
@@ -1081,7 +1081,7 @@ button.settings-link-row:active {
 	}
 
 	&:focus-visible {
-		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		box-shadow: none;
 	}
 }
 
@@ -1133,7 +1133,7 @@ button.settings-link-row:active {
 	}
 
 	&:focus-visible {
-		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		box-shadow: none;
 	}
 
 	&[data-state="checked"] {
@@ -1178,7 +1178,7 @@ button.settings-link-row:active {
 
 	&:focus-visible {
 		outline: none;
-		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+		box-shadow: none;
 	}
 }
 
@@ -1748,6 +1748,20 @@ body.is-resizing-x [data-slot="inspector-container"] {
 .sidebar-focusless :focus-visible {
 	background-color: var(--color-interactive-hover) !important;
 	outline: none !important;
+	box-shadow: none !important;
+}
+
+/* No blue focus rings anywhere — hover/active carry interaction feedback.
+   !important beats Tailwind focus / focus-visible ring and outline utilities. */
+:focus,
+:focus-visible {
+	outline: none !important;
+	outline-offset: 0 !important;
+	--tw-ring-shadow: 0 0 #0000 !important;
+	--tw-ring-offset-shadow: 0 0 #0000 !important;
+	--tw-ring-color: transparent !important;
+}
+:focus-visible {
 	box-shadow: none !important;
 }
 
@@ -3646,8 +3660,8 @@ html[data-native-browser-composition="true"][data-ao-platform="win32"] .files-po
 
 .browser-panel__url-input:focus {
 	box-shadow:
-		0 0 0 3px color-mix(in srgb, var(--color-accent) 18%, transparent),
-		inset 0 1px 0 color-mix(in srgb, white 6%, transparent);
+		inset 0 1px 0 color-mix(in srgb, white 6%, transparent),
+		0 1px 8px color-mix(in srgb, black 9%, transparent);
 }
 
 .browser-panel__content {


### PR DESCRIPTION
## Summary
- Suppress `:focus` / `:focus-visible` outlines and rings app-wide in the renderer
- Remove focus-ring classes from shared UI primitives (`Button`, `Input`, `Select`, etc.)
- Clear accent focus halos from settings/composer CSS utilities

## Test plan
- [ ] Click sidebar toggle, notifications, history, and other icon buttons — no blue ring
- [ ] Tab through controls — no blue ring remains after keypress
- [ ] Hover/active states still work as before

## Before
<img width="729" height="169" alt="image" src="https://github.com/user-attachments/assets/064d16f6-9aed-4132-bd91-8efd5efb0bd2" />
