### PR TITLE
docs: research end-to-end terminal architecture

### DIFF
--- a/docs/research/terminal-architecture-e2e-visual.html
+++ b/docs/research/terminal-architecture-e2e-visual.html
@@ -1,0 +1,763 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="A visual companion to AO's end-to-end terminal architecture research and migration recommendation.">
+  <title>Where terminal truth lives — AO visual architecture study</title>
+  <style>
+    :root {
+      --paper: #f2efe7;
+      --paper-deep: #e8e3d8;
+      --ink: #122027;
+      --ink-soft: #43545a;
+      --night: #101c22;
+      --night-2: #172931;
+      --line: rgba(18, 32, 39, .16);
+      --cream: #fffaf0;
+      --coral: #f06c55;
+      --coral-soft: #ffd8cf;
+      --cyan: #62d7d0;
+      --cyan-soft: #caf5ef;
+      --acid: #d4e66d;
+      --gold: #e4b455;
+      --blue: #87aef4;
+      --shadow: 0 20px 60px rgba(18, 32, 39, .12);
+      --radius: 20px;
+      --serif: "Iowan Old Style", "Baskerville", "Times New Roman", serif;
+      --sans: "Avenir Next", "Segoe UI", sans-serif;
+      --mono: "SFMono-Regular", "Cascadia Code", "Roboto Mono", monospace;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background:
+        linear-gradient(rgba(18, 32, 39, .035) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(18, 32, 39, .035) 1px, transparent 1px),
+        var(--paper);
+      background-size: 36px 36px;
+      font: 17px/1.65 var(--sans);
+      text-rendering: optimizeLegibility;
+    }
+
+    a { color: inherit; }
+    button { font: inherit; }
+    code { font-family: var(--mono); }
+
+    .skip-link {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      z-index: 100;
+      padding: 10px 14px;
+      color: var(--cream);
+      background: var(--night);
+      border-radius: 8px;
+      transform: translateY(-150%);
+    }
+    .skip-link:focus { transform: none; }
+
+    .reading-progress {
+      position: fixed;
+      inset: 0 auto auto 0;
+      z-index: 80;
+      width: 0;
+      height: 4px;
+      background: linear-gradient(90deg, var(--coral), var(--gold), var(--cyan));
+    }
+
+    .shell {
+      display: grid;
+      grid-template-columns: 220px minmax(0, 1fr);
+      max-width: 1500px;
+      margin: 0 auto;
+    }
+
+    .rail {
+      position: sticky;
+      top: 0;
+      align-self: start;
+      height: 100vh;
+      padding: 36px 24px;
+      border-right: 1px solid var(--line);
+      background: rgba(242, 239, 231, .84);
+      backdrop-filter: blur(14px);
+    }
+    .rail-mark {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 44px;
+      font: 800 12px/1 var(--mono);
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+    .rail-mark::before {
+      width: 14px;
+      height: 14px;
+      content: "";
+      background: var(--coral);
+      border-radius: 50% 50% 8% 50%;
+      transform: rotate(45deg);
+    }
+    .rail nav { display: grid; gap: 4px; }
+    .rail nav a {
+      position: relative;
+      padding: 8px 10px 8px 18px;
+      color: #6d7778;
+      font: 650 13px/1.25 var(--sans);
+      text-decoration: none;
+      border-radius: 8px;
+      transition: .2s ease;
+    }
+    .rail nav a::before {
+      position: absolute;
+      top: 13px;
+      left: 3px;
+      width: 5px;
+      height: 5px;
+      content: "";
+      background: currentColor;
+      border-radius: 50%;
+      opacity: .35;
+    }
+    .rail nav a:hover,
+    .rail nav a.active {
+      color: var(--ink);
+      background: rgba(255, 255, 255, .6);
+    }
+    .rail nav a.active::before { background: var(--coral); opacity: 1; }
+    .rail-meta {
+      position: absolute;
+      right: 24px;
+      bottom: 28px;
+      left: 24px;
+      color: #6b7779;
+      font: 11px/1.6 var(--mono);
+    }
+
+    main { min-width: 0; overflow: hidden; }
+    section { scroll-margin-top: 30px; }
+    .page { padding: 0 clamp(28px, 6vw, 90px); }
+
+    .hero {
+      position: relative;
+      min-height: 94vh;
+      display: grid;
+      align-content: center;
+      padding-top: 70px;
+      padding-bottom: 70px;
+      isolation: isolate;
+    }
+    .hero::before {
+      position: absolute;
+      z-index: -1;
+      top: 9%;
+      right: -5%;
+      width: 430px;
+      aspect-ratio: 1;
+      content: "";
+      border: 1px solid rgba(18, 32, 39, .13);
+      border-radius: 50%;
+      box-shadow: inset 0 0 0 55px var(--paper), inset 0 0 0 56px rgba(18, 32, 39, .09), inset 0 0 0 110px var(--paper), inset 0 0 0 111px rgba(18, 32, 39, .07);
+      opacity: .85;
+    }
+    .eyebrow {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin: 0 0 24px;
+      color: var(--coral);
+      font: 800 12px/1 var(--mono);
+      letter-spacing: .15em;
+      text-transform: uppercase;
+    }
+    .eyebrow::after { width: 74px; height: 1px; content: ""; background: currentColor; }
+    h1 {
+      max-width: 980px;
+      margin: 0;
+      font: 500 clamp(58px, 8vw, 126px)/.88 var(--serif);
+      letter-spacing: -.065em;
+    }
+    h1 em { color: var(--coral); font-style: italic; }
+    .hero-deck {
+      max-width: 760px;
+      margin: 36px 0 0 clamp(0px, 9vw, 120px);
+      color: var(--ink-soft);
+      font: 500 clamp(20px, 2.2vw, 30px)/1.35 var(--sans);
+    }
+    .hero-deck strong { color: var(--ink); }
+    .hero-stats {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1px;
+      max-width: 940px;
+      margin-top: 58px;
+      overflow: hidden;
+      background: var(--line);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+    }
+    .stat { padding: 20px; background: rgba(255, 250, 240, .7); }
+    .stat b { display: block; font: 500 34px/1 var(--serif); }
+    .stat span { color: var(--ink-soft); font: 700 10px/1.4 var(--mono); letter-spacing: .08em; text-transform: uppercase; }
+
+    .chapter {
+      padding-top: 110px;
+      padding-bottom: 110px;
+      border-top: 1px solid var(--line);
+    }
+    .chapter-head {
+      display: grid;
+      grid-template-columns: 120px minmax(0, 1fr);
+      gap: 26px;
+      margin-bottom: 52px;
+    }
+    .chapter-no { padding-top: 12px; color: var(--coral); font: 800 12px/1 var(--mono); letter-spacing: .12em; }
+    h2 { max-width: 900px; margin: 0; font: 500 clamp(40px, 5vw, 74px)/.98 var(--serif); letter-spacing: -.045em; }
+    .chapter-intro { max-width: 800px; margin: 20px 0 0; color: var(--ink-soft); font-size: 20px; }
+    h3 { margin: 0; font: 600 25px/1.18 var(--serif); }
+    .kicker { color: var(--coral); font: 800 10px/1 var(--mono); letter-spacing: .12em; text-transform: uppercase; }
+
+    .terminal-chain {
+      position: relative;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 34px;
+      padding: 36px;
+      color: var(--cream);
+      background: var(--night);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+    }
+    .terminal-chain::after {
+      position: absolute;
+      right: 36px;
+      bottom: 24px;
+      color: rgba(255,255,255,.28);
+      content: "RAW BYTES → RAW BYTES → RAW BYTES";
+      font: 10px/1 var(--mono);
+      letter-spacing: .14em;
+    }
+    .chain-node { position: relative; min-height: 180px; padding: 20px; border: 1px solid rgba(255,255,255,.15); border-radius: 14px; background: rgba(255,255,255,.035); }
+    .chain-node:not(:last-child)::after {
+      position: absolute;
+      top: 50%;
+      right: -27px;
+      width: 20px;
+      content: "→";
+      color: var(--coral);
+      font: 26px/1 var(--mono);
+    }
+    .chain-node .index { color: var(--cyan); font: 11px/1 var(--mono); }
+    .chain-node b { display: block; margin: 24px 0 10px; font: 600 22px/1.1 var(--serif); }
+    .chain-node p { margin: 0; color: #aebdc1; font-size: 13px; line-height: 1.5; }
+    .chain-node.state-owner { border-color: rgba(240,108,85,.7); }
+    .chain-node.state-owner::before { position: absolute; top: -9px; right: 12px; padding: 4px 7px; content: "STATE"; color: var(--night); background: var(--coral); border-radius: 4px; font: 800 8px/1 var(--mono); letter-spacing: .1em; }
+
+    .pain-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 22px; }
+    .pain-card { min-height: 190px; padding: 24px; background: rgba(255,250,240,.72); border: 1px solid var(--line); border-radius: 14px; }
+    .pain-card .glyph { display: grid; place-items: center; width: 34px; height: 34px; margin-bottom: 26px; color: var(--night); background: var(--coral-soft); border-radius: 50%; font: 800 14px/1 var(--mono); }
+    .pain-card p { margin: 10px 0 0; color: var(--ink-soft); font-size: 14px; }
+
+    .thesis {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+    }
+    .thesis > div { padding: clamp(30px, 5vw, 68px); }
+    .thesis .no { background: var(--cream); }
+    .thesis .yes { color: var(--cream); background: var(--night); }
+    .thesis-label { margin-bottom: 28px; font: 800 11px/1 var(--mono); letter-spacing: .12em; text-transform: uppercase; }
+    .no .thesis-label { color: var(--coral); }
+    .yes .thesis-label { color: var(--cyan); }
+    .thesis blockquote { margin: 0 0 26px; font: 500 clamp(29px, 3vw, 47px)/1.04 var(--serif); }
+    .thesis p { margin: 0; color: var(--ink-soft); }
+    .thesis .yes p { color: #b9c8cc; }
+
+    .landscape { display: grid; gap: 14px; }
+    .option {
+      display: grid;
+      grid-template-columns: 190px 120px 1fr 200px;
+      gap: 24px;
+      align-items: center;
+      padding: 22px 24px;
+      background: rgba(255,250,240,.76);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+    }
+    .option.recommended { border: 2px solid var(--coral); background: var(--cream); }
+    .option-name b { display: block; font: 650 21px/1.1 var(--serif); }
+    .option-name small { color: var(--ink-soft); font: 10px/1.4 var(--mono); }
+    .status-pill { justify-self: start; padding: 6px 9px; border-radius: 99px; font: 800 9px/1 var(--mono); letter-spacing: .09em; text-transform: uppercase; }
+    .status-now { background: var(--cyan-soft); }
+    .status-core { background: var(--coral-soft); }
+    .status-study { background: #e4e5de; }
+    .option-copy { color: var(--ink-soft); font-size: 14px; }
+    .option-role { padding-left: 18px; border-left: 1px solid var(--line); font-size: 13px; }
+    .option-role b { display: block; color: var(--coral); font: 800 9px/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; }
+
+    .evidence-strip { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-top: 40px; }
+    .evidence { padding: 22px; border-top: 4px solid var(--cyan); background: var(--night); color: var(--cream); border-radius: 4px 4px 14px 14px; }
+    .evidence:nth-child(2) { border-color: var(--coral); }
+    .evidence:nth-child(3) { border-color: var(--gold); }
+    .evidence:nth-child(4) { border-color: var(--blue); }
+    .evidence b { display: block; margin-bottom: 11px; font: 600 20px/1 var(--serif); }
+    .evidence p { margin: 0; color: #afbec2; font-size: 13px; }
+    .evidence a { display: inline-block; margin-top: 18px; color: var(--cyan); font: 700 10px/1 var(--mono); text-decoration: none; }
+
+    .candidate-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+    .candidate { position: relative; min-height: 320px; padding: 30px; overflow: hidden; background: var(--cream); border: 1px solid var(--line); border-radius: var(--radius); }
+    .candidate::after { position: absolute; right: -30px; bottom: -56px; width: 160px; height: 160px; content: ""; border: 26px solid var(--paper-deep); border-radius: 50%; }
+    .candidate.target { color: var(--cream); background: var(--night); border-color: var(--night); }
+    .candidate.recommend { border: 3px solid var(--coral); }
+    .candidate-letter { color: var(--coral); font: 800 12px/1 var(--mono); letter-spacing: .12em; }
+    .candidate h3 { max-width: 75%; margin-top: 28px; font-size: 30px; }
+    .candidate p { max-width: 78%; color: var(--ink-soft); font-size: 14px; }
+    .candidate.target p { color: #aebfc3; }
+    .score { position: absolute; top: 26px; right: 26px; display: grid; place-items: center; width: 70px; height: 70px; background: conic-gradient(var(--coral) var(--score), rgba(120,130,132,.18) 0); border-radius: 50%; }
+    .score::before { position: absolute; width: 54px; height: 54px; content: ""; background: var(--cream); border-radius: 50%; }
+    .target .score::before { background: var(--night); }
+    .score b { position: relative; font: 700 17px/1 var(--mono); }
+    .candidate-tags { position: absolute; bottom: 26px; left: 30px; display: flex; flex-wrap: wrap; gap: 6px; max-width: 72%; }
+    .candidate-tags span { padding: 5px 8px; background: var(--paper-deep); border-radius: 4px; font: 700 9px/1 var(--mono); }
+    .target .candidate-tags span { color: var(--night); background: var(--cyan); }
+
+    .recommendation-banner {
+      display: grid;
+      grid-template-columns: 140px 1fr;
+      gap: 26px;
+      align-items: center;
+      margin-top: 22px;
+      padding: 30px;
+      background: var(--coral);
+      border-radius: 16px;
+    }
+    .recommendation-banner .arrow { font: 400 82px/1 var(--serif); text-align: center; }
+    .recommendation-banner b { display: block; font: 600 27px/1.1 var(--serif); }
+    .recommendation-banner p { margin: 8px 0 0; }
+
+    .architecture {
+      position: relative;
+      padding: clamp(28px, 5vw, 60px);
+      overflow: hidden;
+      color: var(--cream);
+      background: var(--night);
+      border-radius: 24px;
+      box-shadow: 0 35px 90px rgba(18,32,39,.22);
+    }
+    .architecture::before { position: absolute; inset: 0; content: ""; background: radial-gradient(circle at 80% 20%, rgba(98,215,208,.13), transparent 30%), radial-gradient(circle at 20% 90%, rgba(240,108,85,.11), transparent 26%); pointer-events: none; }
+    .arch-title { position: relative; display: flex; justify-content: space-between; gap: 24px; align-items: end; margin-bottom: 42px; }
+    .arch-title h3 { max-width: 700px; font-size: clamp(32px, 4vw, 53px); }
+    .arch-title span { color: var(--cyan); font: 700 10px/1 var(--mono); letter-spacing: .12em; }
+    .arch-grid { position: relative; display: grid; grid-template-columns: 1fr 90px 1.25fr 90px 1.7fr; gap: 14px; align-items: center; }
+    .arch-column { display: grid; gap: 12px; }
+    .arch-label { margin-bottom: 7px; color: #7f9399; font: 800 9px/1 var(--mono); letter-spacing: .13em; text-transform: uppercase; }
+    .arch-box { padding: 17px; border: 1px solid rgba(255,255,255,.16); border-radius: 11px; background: rgba(255,255,255,.045); }
+    .arch-box b { display: block; font: 600 17px/1.1 var(--serif); }
+    .arch-box small { display: block; margin-top: 5px; color: #91a5aa; font: 11px/1.35 var(--mono); }
+    .arch-box.client { border-left: 3px solid var(--blue); }
+    .arch-box.gateway { border-color: var(--gold); }
+    .arch-box.host { padding: 22px; border: 2px solid var(--coral); background: rgba(240,108,85,.06); }
+    .host-core { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin-top: 18px; }
+    .host-core div { padding: 12px; color: #c7d2d4; background: rgba(255,255,255,.055); border-radius: 7px; font: 10px/1.35 var(--mono); }
+    .arch-arrow { color: var(--cyan); font: 400 39px/1 var(--serif); text-align: center; }
+    .arch-foot { position: relative; display: flex; justify-content: space-between; gap: 20px; margin-top: 30px; padding-top: 22px; border-top: 1px solid rgba(255,255,255,.12); color: #9bafb4; font-size: 12px; }
+    .arch-foot b { color: var(--cream); }
+
+    .truth-rule { margin: 32px auto 0; max-width: 900px; padding: 32px; border-left: 5px solid var(--coral); font: 500 clamp(24px, 3vw, 38px)/1.2 var(--serif); background: rgba(255,250,240,.64); }
+
+    .protocol-flow { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+    .protocol-step { position: relative; min-height: 230px; padding: 23px; background: var(--cream); border: 1px solid var(--line); border-radius: 14px; }
+    .protocol-step:not(:last-child)::after { position: absolute; z-index: 2; top: 31px; right: -16px; width: 20px; content: "→"; color: var(--coral); font: 24px/1 var(--mono); }
+    .protocol-step .num { display: grid; place-items: center; width: 28px; height: 28px; margin-bottom: 35px; color: var(--cream); background: var(--night); border-radius: 50%; font: 800 10px/1 var(--mono); }
+    .protocol-step h3 { font-size: 20px; }
+    .protocol-step p { margin: 9px 0 0; color: var(--ink-soft); font-size: 13px; }
+    .protocol-step code { display: inline-block; margin-top: 16px; padding: 5px 7px; color: #0a5755; background: var(--cyan-soft); border-radius: 4px; font-size: 10px; }
+
+    .lease-demo { display: grid; grid-template-columns: 1fr 1.4fr; gap: 30px; margin-top: 46px; align-items: center; }
+    .lease-copy h3 { font-size: 36px; }
+    .lease-copy p { color: var(--ink-soft); }
+    .lease-copy ol { padding-left: 19px; color: var(--ink-soft); font-size: 14px; }
+    .lease-copy li { margin: 8px 0; padding-left: 7px; }
+    .screens { position: relative; min-height: 390px; }
+    .screen { position: absolute; overflow: hidden; color: var(--cyan); background: var(--night); border: 5px solid #263a43; border-radius: 12px; box-shadow: 0 20px 50px rgba(18,32,39,.22); }
+    .screen::before { display: block; height: 19px; content: "●  ●  ●"; padding: 7px 10px; color: #677b80; background: #263a43; font: 8px/1 var(--mono); }
+    .screen::after { display: block; padding: 16px; white-space: pre; content: "$ ao work\A session ready\A ▋"; font: 12px/1.7 var(--mono); }
+    .screen.controller { z-index: 2; top: 20px; left: 0; width: 68%; height: 300px; border-color: var(--coral); }
+    .screen.controller .screen-label { background: var(--coral); }
+    .screen.observer { z-index: 3; right: 0; bottom: 5px; width: 45%; height: 210px; }
+    .screen.phone { z-index: 4; right: 18%; bottom: 0; width: 23%; height: 245px; border-radius: 20px; transform: translateY(35px); }
+    .screen-label { position: absolute; right: 8px; bottom: 8px; padding: 5px 7px; color: var(--night); background: var(--cyan); border-radius: 3px; font: 800 8px/1 var(--mono); letter-spacing: .08em; }
+
+    .feature-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+    .feature { min-height: 185px; padding: 23px; background: rgba(255,250,240,.72); border: 1px solid var(--line); border-radius: 14px; }
+    .feature-head { display: flex; justify-content: space-between; gap: 12px; align-items: center; }
+    .feature-no { color: var(--coral); font: 800 10px/1 var(--mono); }
+    .feature-state { width: 10px; height: 10px; background: var(--acid); border-radius: 50%; box-shadow: 0 0 0 5px rgba(212,230,109,.25); }
+    .feature h3 { margin-top: 28px; font-size: 22px; }
+    .feature p { margin: 9px 0 0; color: var(--ink-soft); font-size: 13px; }
+
+    .roadmap { position: relative; display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+    .roadmap::before { position: absolute; top: 53px; right: 10%; left: 10%; height: 2px; content: ""; background: linear-gradient(90deg, var(--coral), var(--gold), var(--cyan)); }
+    .phase { position: relative; padding-top: 82px; }
+    .phase::before { position: absolute; z-index: 2; top: 42px; left: 28px; width: 22px; height: 22px; content: ""; background: var(--paper); border: 6px solid var(--coral); border-radius: 50%; }
+    .phase:nth-child(2)::before { border-color: var(--gold); }
+    .phase:nth-child(3)::before { border-color: var(--cyan); }
+    .phase-card { min-height: 500px; padding: 28px; background: var(--cream); border: 1px solid var(--line); border-radius: var(--radius); }
+    .phase:nth-child(2) .phase-card { background: #fff6e2; }
+    .phase:nth-child(3) .phase-card { color: var(--cream); background: var(--night); }
+    .phase-time { color: var(--coral); font: 800 11px/1 var(--mono); letter-spacing: .12em; text-transform: uppercase; }
+    .phase:nth-child(2) .phase-time { color: #9b6c12; }
+    .phase:nth-child(3) .phase-time { color: var(--cyan); }
+    .phase h3 { margin-top: 20px; font-size: 32px; }
+    .phase-outcome { margin: 18px 0 24px; padding-bottom: 22px; color: var(--ink-soft); border-bottom: 1px solid var(--line); font-size: 14px; }
+    .phase:nth-child(3) .phase-outcome { color: #aabdc1; border-color: rgba(255,255,255,.13); }
+    .phase ul { margin: 0; padding: 0; list-style: none; }
+    .phase li { position: relative; margin: 12px 0; padding-left: 20px; font-size: 13px; }
+    .phase li::before { position: absolute; top: 8px; left: 0; width: 7px; height: 7px; content: ""; background: currentColor; border-radius: 50%; opacity: .32; }
+    .phase-gate { margin-top: 24px; padding: 14px; color: var(--ink); background: var(--cyan-soft); border-radius: 8px; font: 700 11px/1.4 var(--mono); }
+
+    .risk-list { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+    details { background: rgba(255,250,240,.75); border: 1px solid var(--line); border-radius: 12px; }
+    summary { position: relative; padding: 20px 50px 20px 22px; cursor: pointer; font: 650 16px/1.3 var(--sans); list-style: none; }
+    summary::-webkit-details-marker { display: none; }
+    summary::after { position: absolute; top: 18px; right: 20px; content: "+"; color: var(--coral); font: 25px/1 var(--serif); }
+    details[open] summary::after { content: "−"; }
+    details p { margin: 0; padding: 0 22px 22px; color: var(--ink-soft); font-size: 14px; }
+
+    .closing {
+      position: relative;
+      min-height: 78vh;
+      display: grid;
+      align-content: center;
+      color: var(--cream);
+      background: var(--night);
+    }
+    .closing .page { position: relative; }
+    .closing .eyebrow { color: var(--cyan); }
+    .closing h2 { max-width: 1050px; font-size: clamp(50px, 7vw, 105px); }
+    .closing h2 em { color: var(--coral); font-style: italic; }
+    .closing p { max-width: 780px; color: #acbec2; font-size: 20px; }
+    .closing-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 36px; }
+    .button { display: inline-flex; align-items: center; gap: 12px; padding: 13px 18px; color: var(--night); background: var(--cyan); border-radius: 7px; font: 800 11px/1 var(--mono); letter-spacing: .05em; text-decoration: none; }
+    .button.secondary { color: var(--cream); background: transparent; border: 1px solid rgba(255,255,255,.25); }
+    .closing-meta { margin-top: 50px; color: #758a90; font: 11px/1.7 var(--mono); }
+
+    .reveal { opacity: 0; transform: translateY(18px); transition: opacity .6s ease, transform .6s ease; }
+    .reveal.visible { opacity: 1; transform: none; }
+
+    @media (max-width: 1120px) {
+      body { padding-bottom: 72px; }
+      .shell { grid-template-columns: 1fr; }
+      .rail { position: fixed; z-index: 70; top: auto; right: 12px; bottom: 12px; left: 12px; width: auto; height: auto; padding: 10px; overflow-x: auto; border: 1px solid var(--line); border-radius: 12px; box-shadow: var(--shadow); }
+      .rail-mark, .rail-meta { display: none; }
+      .rail nav { display: flex; width: max-content; }
+      .rail nav a { padding: 8px 11px; font-size: 11px; }
+      .rail nav a::before { display: none; }
+      .hero-stats { grid-template-columns: repeat(2, 1fr); }
+      .terminal-chain { grid-template-columns: repeat(2, 1fr); }
+      .chain-node:nth-child(2)::after { display: none; }
+      .option { grid-template-columns: 160px 105px 1fr; }
+      .option-role { grid-column: 3; padding: 0; border: 0; }
+      .arch-grid { grid-template-columns: 1fr 55px 1fr; }
+      .arch-grid .arch-arrow:nth-of-type(4), .arch-grid .arch-column:last-child { grid-column: 3; }
+      .protocol-flow { grid-template-columns: repeat(3, 1fr); }
+      .protocol-step:nth-child(3)::after { display: none; }
+    }
+
+    @media (max-width: 760px) {
+      body { font-size: 16px; }
+      .page { padding-right: 20px; padding-left: 20px; }
+      .hero { min-height: auto; padding-top: 90px; }
+      .hero::before { width: 270px; }
+      h1 { font-size: clamp(52px, 17vw, 80px); }
+      .hero-deck { margin-left: 0; }
+      .hero-stats { grid-template-columns: repeat(2, 1fr); }
+      .chapter { padding-top: 78px; padding-bottom: 78px; }
+      .chapter-head { grid-template-columns: 1fr; gap: 8px; }
+      .terminal-chain, .pain-grid, .thesis, .candidate-grid, .feature-grid, .roadmap, .risk-list, .lease-demo { grid-template-columns: 1fr; }
+      .terminal-chain { gap: 18px; }
+      .chain-node:not(:last-child)::after { top: auto; right: 50%; bottom: -19px; transform: rotate(90deg); }
+      .chain-node:nth-child(2)::after { display: block; }
+      .option { grid-template-columns: 1fr; gap: 12px; }
+      .option-role { grid-column: auto; }
+      .evidence-strip { grid-template-columns: repeat(2, 1fr); }
+      .recommendation-banner { grid-template-columns: 1fr; }
+      .recommendation-banner .arrow { text-align: left; }
+      .arch-grid { grid-template-columns: 1fr; }
+      .arch-arrow { transform: rotate(90deg); }
+      .arch-grid .arch-arrow:nth-of-type(4), .arch-grid .arch-column:last-child { grid-column: auto; }
+      .host-core { grid-template-columns: 1fr; }
+      .arch-foot { display: grid; }
+      .protocol-flow { grid-template-columns: 1fr; }
+      .protocol-step:not(:last-child)::after { top: auto; right: 50%; bottom: -17px; transform: rotate(90deg); }
+      .protocol-step:nth-child(3)::after { display: block; }
+      .screens { min-height: 350px; }
+      .roadmap::before { display: none; }
+      .phase { padding-top: 16px; }
+      .phase::before { display: none; }
+      .phase-card { min-height: auto; }
+      .closing { min-height: 84vh; padding-bottom: 70px; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      .reveal { opacity: 1; transform: none; transition: none; }
+    }
+
+    @media print {
+      .rail, .reading-progress { display: none; }
+      .shell { display: block; }
+      .hero, .chapter, .closing { break-inside: avoid; }
+      body { background: white; }
+      .reveal { opacity: 1; transform: none; }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div class="reading-progress" aria-hidden="true"></div>
+
+  <div class="shell">
+    <aside class="rail" aria-label="Document navigation">
+      <div class="rail-mark">AO systems study</div>
+      <nav>
+        <a href="#thesis">The problem</a>
+        <a href="#landscape">The landscape</a>
+        <a href="#candidates">The decision</a>
+        <a href="#target">Target system</a>
+        <a href="#protocol">State protocol</a>
+        <a href="#experience">Feature bar</a>
+        <a href="#migration">Migration</a>
+        <a href="#risks">Risks</a>
+      </nav>
+      <div class="rail-meta">VISUAL COMPANION<br>2026 · RESEARCH / DIRECTION</div>
+    </aside>
+
+    <main id="main">
+      <header class="hero page">
+        <p class="eyebrow">Terminal architecture · end to end</p>
+        <h1>Where terminal <em>truth</em> lives.</h1>
+        <p class="hero-deck">AO’s terminal is not just a canvas. It is a <strong>distributed state machine</strong> stretched across an agent, tmux, a PTY stream, the network, and a browser renderer.</p>
+        <div class="hero-stats" aria-label="Architecture summary">
+          <div class="stat"><b>3</b><span>stateful terminal layers today</span></div>
+          <div class="stat"><b>1</b><span>authority in the target system</span></div>
+          <div class="stat"><b>4.05</b><span>recommended bridge score / 5</span></div>
+          <div class="stat"><b>Now → Later</b><span>staged, reversible migration</span></div>
+        </div>
+      </header>
+
+      <section class="chapter page" id="thesis">
+        <div class="chapter-head reveal">
+          <div class="chapter-no">01 / THE PROBLEM</div>
+          <div><h2>Three layers can all be “right” and the screen can still be wrong.</h2><p class="chapter-intro">Today each viewer receives a fresh tmux attach stream and rebuilds a screen in xterm.js. That delivers local persistence, but every boundary can introduce a different idea of size, history, modes, and repaint timing.</p></div>
+        </div>
+
+        <div class="terminal-chain reveal" aria-label="Current AO terminal chain">
+          <div class="chain-node state-owner"><span class="index">01</span><b>Agent / TUI</b><p>Writes VT sequences inside a tmux pane. Its behavior depends on the pane’s TERM and current grid.</p></div>
+          <div class="chain-node state-owner"><span class="index">02</span><b>tmux</b><p>Owns the durable Unix process, screen, history, terminal modes, and pane dimensions.</p></div>
+          <div class="chain-node"><span class="index">03</span><b>Attach PTY</b><p>One fresh <code>tmux attach</code> per viewer emits handshakes and a non-atomic repaint.</p></div>
+          <div class="chain-node state-owner"><span class="index">04</span><b>xterm.js 5.5</b><p>Parses the stream again, owns client scrollback, fits the layout, then paints via WebGL or canvas.</p></div>
+        </div>
+
+        <div class="pain-grid reveal">
+          <article class="pain-card"><div class="glyph">↻</div><h3>Reattach artifacts</h3><p>A current screen arrives as a timed sequence of redraws, so users can see history fast-forward or stale intermediate frames.</p></article>
+          <article class="pain-card"><div class="glyph">↔</div><h3>Resize fights</h3><p>One PTY has one grid. Desktop, web, and phone viewers all measure different grids and can trigger reflow.</p></article>
+          <article class="pain-card"><div class="glyph">⌁</div><h3>WAN backlog</h3><p>Raw bytes preserve obsolete animations. A slow viewer can receive every paint instead of jumping to current state.</p></article>
+          <article class="pain-card"><div class="glyph">Aa</div><h3>Font / GPU drift</h3><p>Glyph metrics, font loading, DPR, WebGL atlases, and canvas fallback are coupled to session symptoms.</p></article>
+          <article class="pain-card"><div class="glyph">?</div><h3>Weak attribution</h3><p>The agent, tmux, attach PTY, transport, parser, and renderer can each plausibly own the same visual bug.</p></article>
+          <article class="pain-card"><div class="glyph">⊞</div><h3>Platform split</h3><p>Unix relies on tmux; Windows already has a centralized ConPTY host with a raw replay ring.</p></article>
+        </div>
+
+        <div class="thesis reveal" style="margin-top: 44px">
+          <div class="no"><div class="thesis-label">Tempting first move</div><blockquote>“Replace xterm.js and the regressions go away.”</blockquote><p>A new renderer still consumes a per-client attach stream, negotiates another size, reconstructs history from bytes, and inherits Unix/Windows divergence.</p></div>
+          <div class="yes"><div class="thesis-label">The architectural move</div><blockquote>Move terminal authority next to the process.</blockquote><p>Own the PTY, canonical size, VT state, scrollback, and ordered history once. Make every UI a resumable view of that truth.</p></div>
+        </div>
+      </section>
+
+      <section class="chapter page" id="landscape">
+        <div class="chapter-head reveal">
+          <div class="chapter-no">02 / THE LANDSCAPE</div>
+          <div><h2>Use each terminal project for what it is actually good at.</h2><p class="chapter-intro">No available project is a complete drop-in answer for AO’s cloud, browser, mobile, multi-client, Unix, and Windows requirements. The right architecture composes a strong core with an AO-owned protocol and client boundary.</p></div>
+        </div>
+
+        <div class="landscape reveal">
+          <article class="option"><div class="option-name"><b>xterm.js 6</b><small>BROWSER RENDERER</small></div><span class="status-pill status-now">ready now</span><div class="option-copy">Healthy, widely deployed, browser-native, rich addon ecosystem. Main-thread parsing, mobile gaps, and incomplete graphics remain.</div><div class="option-role"><b>AO role</b>Compatibility renderer and tactical upgrade</div></article>
+          <article class="option recommended"><div class="option-name"><b>libghostty-vt</b><small>HEADLESS VT CORE</small></div><span class="status-pill status-core">recommended</span><div class="option-copy">Cross-platform C/WASM API, damage rows, input encoding, and VT/text/HTML formatting. Renderer-agnostic; API still in flux.</div><div class="option-role"><b>AO role</b>Server state core, future WASM candidate</div></article>
+          <article class="option"><div class="option-name"><b>alacritty_terminal</b><small>RUST VT CORE</small></div><span class="status-pill status-study">fallback</span><div class="option-copy">Proven grid, search, damage, and serialization. Zed and Warp validate it—but their forks show the ownership cost.</div><div class="option-role"><b>AO role</b>Strong fallback if Ghostty integration fails</div></article>
+          <article class="option"><div class="option-name"><b>WezTerm / Termwiz</b><small>TERMINAL + MUX</small></div><span class="status-pill status-study">study</span><div class="option-copy">Excellent change journal and full-repaint fallback. Broad product surface and unstable extraction boundary.</div><div class="option-role"><b>AO role</b>Copy sequence and delta semantics</div></article>
+          <article class="option"><div class="option-name"><b>Zellij / tmux -CC</b><small>SESSION LAYERS</small></div><span class="status-pill status-study">bridge only</span><div class="option-copy">Useful collaboration and explicit control protocols. Neither provides AO’s final cross-platform semantic state contract.</div><div class="option-role"><b>AO role</b>Legacy bridge and UX reference</div></article>
+          <article class="option"><div class="option-name"><b>Mosh</b><small>SYNC MODEL</small></div><span class="status-pill status-study">steal ideas</span><div class="option-copy">Treats the screen as replicated state, skips obsolete frames, acknowledges state, and predicts conservative input.</div><div class="option-role"><b>AO role</b>WAN state-sync mental model</div></article>
+        </div>
+
+        <div class="evidence-strip reveal">
+          <article class="evidence"><b>VS Code</b><p>Persistent PTY service, headless xterm serializer, explicit replay completion, and high/low-watermark output acknowledgements.</p><a href="https://github.com/microsoft/vscode/blob/main/src/vs/platform/terminal/node/ptyService.ts">VIEW SOURCE ↗</a></article>
+          <article class="evidence"><b>Mosh</b><p>The current screen is state. Slow clients can skip old frames. Prediction is reconciled, not trusted blindly.</p><a href="https://mosh.org/mosh-paper-draft.pdf">READ PAPER ↗</a></article>
+          <article class="evidence"><b>Zellij</b><p>Read-only access, visible collaboration, independent client focus, and phone-specific viewport/touch affordances.</p><a href="https://zellij.dev/documentation/web-client.html">VIEW DOCS ↗</a></article>
+          <article class="evidence"><b>Warp / Zed</b><p>Keep execution remote and rendering local; preserve shell-semantic regions for richer command navigation.</p><a href="https://zed.dev/docs/remote-development">VIEW MODEL ↗</a></article>
+        </div>
+      </section>
+
+      <section class="chapter page" id="candidates">
+        <div class="chapter-head reveal">
+          <div class="chapter-no">03 / THE DECISION</div>
+          <div><h2>Bridge deliberately. Don’t force the final renderer into the first milestone.</h2><p class="chapter-intro">Candidate C wins as the next system because it moves authority without making browser rendering, accessibility, font shaping, and mobile interaction simultaneous launch blockers. Candidate D remains the destination.</p></div>
+        </div>
+
+        <div class="candidate-grid reveal">
+          <article class="candidate"><span class="candidate-letter">A / HARDEN</span><div class="score" style="--score:49%"><b>2.45</b></div><h3>tmux attach + xterm.js 6</h3><p>Improve measurement, replay markers, acknowledgements, and resize ownership while retaining the current chain.</p><div class="candidate-tags"><span>LOW RISK</span><span>ROLLBACK</span><span>NOT TARGET</span></div></article>
+          <article class="candidate"><span class="candidate-letter">B / BRIDGE</span><div class="score" style="--score:57%"><b>2.85</b></div><h3>tmux control mode + headless client</h3><p>Removes per-viewer attach PTYs, but leaves tmux as a Unix-only authority and cannot reconstruct every hidden mode safely.</p><div class="candidate-tags"><span>MEDIUM RISK</span><span>UNIX ONLY</span></div></article>
+          <article class="candidate recommend"><span class="candidate-letter">C / RECOMMENDED NEXT</span><div class="score" style="--score:81%"><b>4.05</b></div><h3>AO Terminal Host + VT compatibility</h3><p>The host owns PTY/ConPTY and libghostty state. Existing xterm clients receive one coherent VT snapshot, then live output.</p><div class="candidate-tags"><span>ATOMIC REATTACH</span><span>CROSS-PLATFORM</span><span>INCREMENTAL</span></div></article>
+          <article class="candidate target"><span class="candidate-letter">D / TARGET</span><div class="score" style="--score:92%"><b>4.60</b></div><h3>AO state protocol + purpose-built clients</h3><p>Clients render atomic snapshots and semantic deltas. No raw-history replay, nested parsing, or transport-level renderer lock-in.</p><div class="candidate-tags"><span>BEST CEILING</span><span>HIGHEST OWNERSHIP</span></div></article>
+        </div>
+
+        <div class="recommendation-banner reveal"><div class="arrow">C → D</div><div><b>Build the authority first. Earn the new renderer later.</b><p>Use A as stabilization and rollback. Use C to unify state and platforms. Let measured cloud and client needs pull the system toward D.</p></div></div>
+      </section>
+
+      <section class="chapter page" id="target">
+        <div class="chapter-head reveal">
+          <div class="chapter-no">04 / TARGET SYSTEM</div>
+          <div><h2>One terminal authority. Many resumable views.</h2><p class="chapter-intro">Run the state owner inside the workspace, beside the agent. The local daemon or cloud gateway authorizes and routes; it does not become the durable owner of terminal cells or secrets.</p></div>
+        </div>
+
+        <div class="architecture reveal" role="img" aria-label="Recommended AO terminal architecture">
+          <div class="arch-title"><h3>Workspace-side AO Terminal Host</h3><span>ONE HOST / TERMINAL SESSION</span></div>
+          <div class="arch-grid">
+            <div class="arch-column"><div class="arch-label">Resumable views</div><div class="arch-box client"><b>Electron</b><small>controller or observer</small></div><div class="arch-box client"><b>Web</b><small>browser over WAN</small></div><div class="arch-box client"><b>Phone</b><small>viewer by default</small></div></div>
+            <div class="arch-arrow">⇄</div>
+            <div class="arch-column"><div class="arch-label">Control plane</div><div class="arch-box gateway"><b>AO gateway / daemon</b><small>auth · attach ticket · routing · capability negotiation</small></div><div class="arch-box"><b>Legacy adapter</b><small>existing tmux sessions + rollback</small></div></div>
+            <div class="arch-arrow">⇄</div>
+            <div class="arch-column"><div class="arch-label">Inside the workspace</div><div class="arch-box host"><b>Terminal Host</b><small>owns process · PTY grid · generation · lease</small><div class="host-core"><div>LIBGHOSTTY-VT<br>screen + input modes</div><div>SNAPSHOT + DELTAS<br>bounded journal</div><div>SCROLLBACK<br>logical lines + search</div><div>IMAGE BLOBS<br>quota + references</div></div></div><div class="arch-box"><b>POSIX PTY / ConPTY → agent</b><small>the only platform-specific boundary</small></div></div>
+          </div>
+          <div class="arch-foot"><span><b>Local:</b> host and gateway may share a machine.</span><span><b>Cloud:</b> host stays with the workspace when every UI disconnects.</span><span><b>Recovery:</b> retain a raw-VT/manual attach path.</span></div>
+        </div>
+
+        <blockquote class="truth-rule reveal">The host owns the child process, PTY dimensions, VT state, and ordered history. Clients own presentation, selection, accessibility, and device interaction.</blockquote>
+      </section>
+
+      <section class="chapter page" id="protocol">
+        <div class="chapter-head reveal">
+          <div class="chapter-no">05 / STATE PROTOCOL</div>
+          <div><h2>Resume the screen you need—not every frame you missed.</h2><p class="chapter-intro">The protocol is AO-owned and versioned. It carries semantic terminal operations, never Ghostty structs or renderer buffers. WebSocket is enough initially; message semantics remain transport-independent.</p></div>
+        </div>
+
+        <div class="protocol-flow reveal">
+          <article class="protocol-step"><div class="num">01</div><h3>Negotiate</h3><p>Client declares protocol, renderer, input, viewport, and resume capabilities.</p><code>ClientHello</code></article>
+          <article class="protocol-step"><div class="num">02</div><h3>Authorize</h3><p>Gateway grants session-scoped viewer or controller role with a short-lived ticket.</p><code>Attach</code></article>
+          <article class="protocol-step"><div class="num">03</div><h3>Snapshot</h3><p>One atomic transfer: buffers, cursor, modes, palette, links, wrap metadata, and size.</p><code>Snapshot @ seq 840</code></article>
+          <article class="protocol-step"><div class="num">04</div><h3>Advance</h3><p>Small semantic row, cursor, mode, and metadata operations carry monotonic sequence IDs.</p><code>Delta 841…n</code></article>
+          <article class="protocol-step"><div class="num">05</div><h3>Acknowledge</h3><p>Slow viewers coalesce or reset to a new snapshot. Input and control are never dropped.</p><code>Ack / ResetRequired</code></article>
+        </div>
+
+        <div class="lease-demo reveal">
+          <div class="lease-copy"><span class="kicker">THE RESIZE RULE</span><h3>One grid needs one visible controller.</h3><p>A PTY cannot be 160×48 for a desktop and 52×22 for a phone at the same time. Make the tradeoff explicit instead of hiding it in “largest socket wins.”</p><ol><li>The controller’s measured grid sets canonical PTY dimensions.</li><li>Observers crop, pan, or letterbox without resizing the process.</li><li>Control transfer changes a visible lease generation atomically.</li><li>Phones join read-only and explicitly request takeover.</li></ol></div>
+          <div class="screens" aria-label="Controller and observer screen size illustration"><div class="screen controller"><span class="screen-label">CONTROLLER · CANONICAL GRID</span></div><div class="screen observer"><span class="screen-label">OBSERVER · CROP</span></div><div class="screen phone"><span class="screen-label">PHONE · VIEW</span></div></div>
+        </div>
+      </section>
+
+      <section class="chapter page" id="experience">
+        <div class="chapter-head reveal">
+          <div class="chapter-no">06 / FEATURE BAR</div>
+          <div><h2>“Best in class” is a complete interaction contract.</h2><p class="chapter-intro">Rendering ANSI is table stakes. Production readiness means local-feeling latency, coherent reattach, search, modern text, accessibility, rich content, and phone behavior all survive the same state model.</p></div>
+        </div>
+
+        <div class="feature-grid reveal">
+          <article class="feature"><div class="feature-head"><span class="feature-no">01 · LATENCY</span><span class="feature-state"></span></div><h3>Current state wins</h3><p>No obsolete animation backlog. Measure input → PTY → delta → paint. Predict only verified normal-shell input.</p></article>
+          <article class="feature"><div class="feature-head"><span class="feature-no">02 · REATTACH</span><span class="feature-state"></span></div><h3>Atomic first frame</h3><p>Cursor, title, palette, modes, alt screen, links, and mouse state arrive before input is enabled.</p></article>
+          <article class="feature"><div class="feature-head"><span class="feature-no">03 · HISTORY</span><span class="feature-state"></span></div><h3>Server search</h3><p>Page logical scrollback, preserve hard/soft wraps, and copy text without padded cells or full-history downloads.</p></article>
+          <article class="feature"><div class="feature-head"><span class="feature-no">04 · TEXT</span><span class="feature-state"></span></div><h3>Modern input + glyphs</h3><p>Graphemes, combining marks, fallback, ligatures, CJK IME, emoji, Kitty keyboard, compose, and dead keys.</p></article>
+          <article class="feature"><div class="feature-head"><span class="feature-no">05 · RICH CONTENT</span><span class="feature-state"></span></div><h3>Links and images</h3><p>Safe OSC 8 links and quota-controlled Kitty/SIXEL blobs that reconnect by reference, not giant inline replay.</p></article>
+          <article class="feature"><div class="feature-head"><span class="feature-no">06 · ACCESS</span><span class="feature-state"></span></div><h3>Semantics, not pixels</h3><p>DOM accessibility mirror, screen-reader updates, contrast, reduced motion, and keyboard-only selection/search.</p></article>
+          <article class="feature"><div class="feature-head"><span class="feature-no">07 · MOBILE</span><span class="feature-state"></span></div><h3>Touch-native viewing</h3><p>Long-press selection, touch scroll, pinch font size, safe areas, modifier row, and viewer-first control.</p></article>
+          <article class="feature"><div class="feature-head"><span class="feature-no">08 · COLLAB</span><span class="feature-state"></span></div><h3>Visible roles</h3><p>One controller, many observers, presence, explicit takeover, and no surprise resize from a dashboard thumbnail.</p></article>
+          <article class="feature"><div class="feature-head"><span class="feature-no">09 · DIAGNOSIS</span><span class="feature-state"></span></div><h3>Layer attribution</h3><p>Generation, sequence, resize lease, parser, font, DPR, and GPU backend—without terminal content in telemetry.</p></article>
+        </div>
+      </section>
+
+      <section class="chapter page" id="migration">
+        <div class="chapter-head reveal">
+          <div class="chapter-no">07 / MIGRATION</div>
+          <div><h2>Now, next, later—with an exit gate at every boundary.</h2><p class="chapter-intro">The plan avoids a flag day. Each phase improves the system independently, produces evidence for the next decision, and preserves a known rollback path.</p></div>
+        </div>
+
+        <div class="roadmap reveal">
+          <article class="phase"><div class="phase-card"><span class="phase-time">Now · Stabilize</span><h3>Make failure observable.</h3><p class="phase-outcome">Keep tmux and xterm deployable while defining the contracts the new host will inherit.</p><ul><li>Fixture corpus: output, input, resize, timing, semantic hashes, screenshots</li><li>Test xterm.js 6 across WebGL/canvas, DPR, fonts, IME, Unicode, and search</li><li>Add stream generation, replay completion, acknowledgements, and bounded queues</li><li>Introduce controller/viewer roles and a single resize lease</li><li>Measure attach-to-stable-frame and input-to-first-paint</li></ul><div class="phase-gate">GATE · Every regression is reproducible and no observer resizes the PTY.</div></div></article>
+          <article class="phase"><div class="phase-card"><span class="phase-time">Next · Establish authority</span><h3>Ship the Terminal Host.</h3><p class="phase-outcome">Move process and state ownership into the workspace without requiring a new renderer.</p><ul><li>Supervised per-session host with POSIX PTY and ConPTY adapters</li><li>Pin libghostty-vt behind a narrow AO-owned boundary</li><li>Shadow-parse current streams and compare fixture state</li><li>Send one coherent VT snapshot, replay barrier, then live output to xterm</li><li>Canary new sessions; retain legacy tmux sessions and creation fallback</li><li>Add bounded logical scrollback and server search</li></ul><div class="phase-gate">GATE · Atomic reconnect and identical POSIX/Windows protocol fixtures.</div></div></article>
+          <article class="phase"><div class="phase-card"><span class="phase-time">Later · Native state</span><h3>Earn renderer independence.</h3><p class="phase-outcome">Let cloud performance and interaction evidence justify a semantic client renderer.</p><ul><li>Version AO snapshot/delta protocol from observed host behavior</li><li>Run a hidden state renderer beside xterm and compare hashes</li><li>Build accessibility, IME, touch, shaping, and mobile into release gates</li><li>Move images to content-addressed blobs; preserve OSC 133 regions</li><li>Add guarded Mosh-style prediction for known-safe shell states</li><li>Graduate web, phone, and Electron independently</li></ul><div class="phase-gate">GATE · Native clients meet or beat xterm across the full feature bar.</div></div></article>
+        </div>
+      </section>
+
+      <section class="chapter page" id="risks">
+        <div class="chapter-head reveal">
+          <div class="chapter-no">08 / RISKS</div>
+          <div><h2>The difficult parts are known—and can become gates instead of surprises.</h2><p class="chapter-intro">The target trades inherited tmux behavior for deliberate product ownership. These are the questions that must stay visible while the bridge is built.</p></div>
+        </div>
+
+        <div class="risk-list reveal">
+          <details><summary>libghostty-vt API churn</summary><p>Pin revisions, wrap a tiny surface, keep AO-owned protocol types, and run a golden corpus on every upstream upgrade.</p></details>
+          <details><summary>The host crashes while owning the PTY</summary><p>Use per-session isolation, a supervisor, fault tests, and visible exit reasons. Keep tmux creation fallback until reliability is demonstrated.</p></details>
+          <details><summary>Cell width and shaping disagree</summary><p>The server determines semantic cells and negotiates width-table versions; clients shape inside those cells and report font metrics.</p></details>
+          <details><summary>A slow observer exhausts memory</summary><p>Use a bounded shared journal, per-client credit, delta coalescing, snapshot reset, and disconnection thresholds.</p></details>
+          <details><summary>Graphics become a resource attack</summary><p>Start disabled. Bound decoded bytes, dimensions, image count, storage, hyperlinks, OSC payloads, and retention before allocation.</p></details>
+          <details><summary>Accessibility arrives too late</summary><p>Treat the semantic accessibility tree, keyboard control, contrast, and reduced motion as first-renderer release gates.</p></details>
+          <details><summary>Recordings leak secrets</summary><p>Collect content-free timings by default. Make capture explicit, local-redacted, short-lived, and excluded from ordinary telemetry.</p></details>
+          <details><summary>Prediction corrupts TUI input</summary><p>Require narrow positive safety conditions, visually distinguish predicted cells, reconcile immediately, and disable on any uncertainty.</p></details>
+        </div>
+      </section>
+
+      <footer class="closing">
+        <div class="page reveal">
+          <p class="eyebrow">The recommendation in one line</p>
+          <h2>Move <em>truth</em> before pixels.</h2>
+          <p>Make the workspace Terminal Host authoritative. Use libghostty-vt to avoid reinventing terminal semantics. Keep xterm.js as a reversible client until AO’s state protocol, accessibility, and mobile experience prove a replacement is ready.</p>
+          <div class="closing-actions"><a class="button" href="terminal-architecture-e2e.md">READ THE FULL RESEARCH →</a><a class="button secondary" href="https://github.com/Untrivial-ai/agent-orchestrator/pull/4069">OPEN PR #4069 ↗</a></div>
+          <div class="closing-meta">Visual companion · canonical source: terminal-architecture-e2e.md · 40 external sources + 7 AO implementation references · prepared 2026-08-17</div>
+        </div>
+      </footer>
+    </main>
+  </div>
+
+  <script>
+    (() => {
+      const progress = document.querySelector('.reading-progress');
+      const links = [...document.querySelectorAll('.rail nav a')];
+      const sections = links.map((link) => document.querySelector(link.getAttribute('href'))).filter(Boolean);
+      const reveals = [...document.querySelectorAll('.reveal')];
+
+      const updateProgress = () => {
+        const scrollable = document.documentElement.scrollHeight - window.innerHeight;
+        progress.style.width = `${scrollable > 0 ? (window.scrollY / scrollable) * 100 : 0}%`;
+      };
+
+      const sectionObserver = new IntersectionObserver((entries) => {
+        const visible = entries.filter((entry) => entry.isIntersecting).sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (!visible) return;
+        links.forEach((link) => link.classList.toggle('active', link.getAttribute('href') === `#${visible.target.id}`));
+      }, { rootMargin: '-20% 0px -65%', threshold: [0, .2, .6] });
+
+      const revealObserver = new IntersectionObserver((entries, observer) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          entry.target.classList.add('visible');
+          observer.unobserve(entry.target);
+        });
+      }, { threshold: .08 });
+
+      sections.forEach((section) => sectionObserver.observe(section));
+      reveals.forEach((item, index) => {
+        item.style.transitionDelay = `${Math.min(index % 3, 2) * 70}ms`;
+        revealObserver.observe(item);
+      });
+      window.addEventListener('scroll', updateProgress, { passive: true });
+      updateProgress();
+    })();
+  </script>
+</body>
+</html>

--- a/docs/research/terminal-architecture-e2e.md
+++ b/docs/research/terminal-architecture-e2e.md
@@ -4,6 +4,8 @@
 **Date:** 2026-08-16  
 **Scope:** terminal process ownership, persistence, transport, multi-client synchronization, rendering, and interaction across AO desktop, web, mobile, local, cloud, Unix, and Windows
 
+**Visual companion:** [Read the illustrated architecture and migration guide](terminal-architecture-e2e-visual.html).
+
 ## Executive summary
 
 AO should not begin by replacing xterm.js. It should first replace the raw-byte, per-client terminal attachment model with a workspace-side **AO Terminal Host** that owns the PTY or ConPTY, maintains authoritative terminal state, and synchronizes atomic snapshots plus sequenced screen deltas to every client. The host should use `libghostty-vt` behind an AO-owned adapter, while xterm.js remains the compatibility renderer during the transition.

--- a/docs/research/terminal-architecture-e2e.md
+++ b/docs/research/terminal-architecture-e2e.md
@@ -30,7 +30,7 @@ This is an architectural inference from AO's failure modes and the referenced sy
 
 ## Baseline: what AO has today
 
-On Unix, the agent command runs in a tmux pane with `TERM=tmux-256color`; tmux owns the durable screen. For every WebSocket viewer, the daemon starts `tmux -u -T RGB attach-session` on a new local PTY whose `TERM` is `xterm-256color`, then relays raw bytes. Each attach therefore has its own terminal handshake and repaint. AO intentionally chose per-client tmux attaches because a shared attach stream would emit terminal queries only once and break later clients. [AO01] [AO02]
+On Unix, the agent command runs in a tmux pane whose `TERM` is `tmux-256color` under tmux's default configuration; a user's tmux `default-terminal` setting can override it. Tmux owns the durable screen. For every WebSocket viewer, the daemon starts `tmux -u -T RGB attach-session` on a new local PTY whose `TERM` is `xterm-256color`, then relays raw bytes. Each attach therefore has its own terminal handshake and repaint. AO intentionally chose per-client tmux attaches because a shared attach stream would emit terminal queries only once and break later clients. [AO01] [AO02]
 
 The React client feeds those bytes into xterm.js 5.5. It prefers WebGL, falls back to canvas, fits and refits around layout changes, and contains explicit replay buffering and cover logic to suppress the initial visible walk through history. [AO05] [AO06] [AO07] On Windows, a per-session host owns ConPTY, retains a raw byte ring, and broadcasts output; each attachment receives the ring as its initial replay. [AO04] The terminal manager reconciles competing attachment sizes, making size selection a server concern even though each viewer measures independently. [AO03]
 

--- a/docs/research/terminal-architecture-e2e.md
+++ b/docs/research/terminal-architecture-e2e.md
@@ -1,0 +1,544 @@
+# Terminal architecture end to end
+
+**Status:** research recommendation  
+**Date:** 2026-08-16  
+**Scope:** terminal process ownership, persistence, transport, multi-client synchronization, rendering, and interaction across AO desktop, web, mobile, local, cloud, Unix, and Windows
+
+## Executive summary
+
+AO should not begin by replacing xterm.js. It should first replace the raw-byte, per-client terminal attachment model with a workspace-side **AO Terminal Host** that owns the PTY or ConPTY, maintains authoritative terminal state, and synchronizes atomic snapshots plus sequenced screen deltas to every client. The host should use `libghostty-vt` behind an AO-owned adapter, while xterm.js remains the compatibility renderer during the transition.
+
+That ordering addresses the root causes shared by AO's rendering, reattach, resize, and cloud problems. Today, Unix output passes through the agent, tmux's screen model, a fresh `tmux attach` PTY for each viewer, WebSocket framing, and xterm.js. Windows already uses a different and more centralized ConPTY host. A renderer swap alone preserves the nested state machines, replay bursts, ambiguous resize ownership, and raw-stream WAN behavior.
+
+The recommended path is:
+
+1. **Now — harden and measure:** upgrade-test xterm.js 6, add deterministic terminal recordings and cross-platform visual/state fixtures, introduce explicit stream generations, replay completion, acknowledgements, and a single writer/resize lease. Keep the existing architecture deployable.
+2. **Next — establish terminal authority:** run a supervised Terminal Host beside each workspace. It owns the native POSIX PTY or Windows ConPTY and uses pinned `libghostty-vt` for headless state. Initially it emits an atomic VT snapshot followed by live output to existing xterm.js clients. New sessions opt in; tmux remains a rollback and legacy-session path.
+3. **Later — adopt a state protocol and purpose-built clients:** send versioned snapshots and screen deltas, page/search server scrollback, move images out of band, and add a browser renderer backed by `libghostty-vt` WASM or an AO renderer. Retire tmux as the mandatory session layer only after fidelity, accessibility, mobile, and recovery gates pass.
+
+`libghostty-vt` is the strongest terminal-core candidate: its current API targets macOS, Linux, Windows, and WebAssembly; exposes damage tracking and input encoding; and can serialize state as VT, text, or HTML. Its C API remains explicitly in flux, so AO must pin a revision and never expose Ghostty structures on the wire. xterm.js itself is healthy—6.0 shipped in December 2025—and remains the lowest-risk browser renderer in the near term. Its limitations are reasons to isolate it behind a client boundary, not reasons to make a renderer rewrite the first dependency of the cloud architecture. [S07] [S08] [S12] [S14] [S15]
+
+## Decision
+
+Build toward **Candidate C, AO Terminal Host with compatibility rendering**, then evolve it into **Candidate D, AO state protocol with native clients**. Use Candidate A, a hardened current stack, as the safe first stage. Do not adopt tmux control mode, Zellij, WezTerm's mux, or Mosh wholesale as the target; borrow their strongest protocol and collaboration techniques.
+
+The essential decision is where terminal truth lives:
+
+> One workspace-side process owns the child process, the PTY dimensions, the VT state, and the ordered history. Clients are resumable views and input principals—not independent terminal emulators attached to independent upstream PTYs.
+
+This is an architectural inference from AO's failure modes and the referenced systems, not a claim made by any one upstream project.
+
+## Baseline: what AO has today
+
+On Unix, the agent command runs in a tmux pane with `TERM=tmux-256color`; tmux owns the durable screen. For every WebSocket viewer, the daemon starts `tmux -u -T RGB attach-session` on a new local PTY whose `TERM` is `xterm-256color`, then relays raw bytes. Each attach therefore has its own terminal handshake and repaint. AO intentionally chose per-client tmux attaches because a shared attach stream would emit terminal queries only once and break later clients. [AO01] [AO02]
+
+The React client feeds those bytes into xterm.js 5.5. It prefers WebGL, falls back to canvas, fits and refits around layout changes, and contains explicit replay buffering and cover logic to suppress the initial visible walk through history. [AO05] [AO06] [AO07] On Windows, a per-session host owns ConPTY, retains a raw byte ring, and broadcasts output; each attachment receives the ring as its initial replay. [AO04] The terminal manager reconciles competing attachment sizes, making size selection a server concern even though each viewer measures independently. [AO03]
+
+The current system has useful properties: tmux keeps Unix processes alive across daemon and client restarts, offers mature scrollback and manual recovery, and reproduces a conventional terminal byte stream. But it also creates three independently stateful terminal stages:
+
+```text
+agent/TUI → tmux pane state → per-client tmux attach PTY → xterm.js state
+```
+
+The chain explains why bugs are difficult to locate. A stale frame can originate in the application, tmux's idea of the attached client size, attach-time redraw, dropped/coalesced transport bytes, xterm parser state, glyph metrics, or the GPU renderer. Windows does not exercise the same chain, so behavioral parity is accidental rather than architectural.
+
+### Failure mechanics
+
+| Symptom | Structural cause | Why a renderer swap is insufficient |
+|---|---|---|
+| Reattach/repaint artifacts | A new `tmux attach` emits a non-atomic redraw plus mode queries and responses; the browser consumes it incrementally. | A different renderer still sees the same redraw stream and timing. |
+| Multi-client resize fights | A PTY has one character grid, while viewers have different pixel and cell dimensions. Current policies select a winner implicitly. | Every emulator must render the one upstream grid; the ownership problem remains. |
+| Scrollback inconsistency | tmux, the replay path, and xterm.js each have different history and reflow semantics. | Client history cannot reconstruct history the server did not send consistently. |
+| WAN stalls and bursts | Raw output preserves every intermediate paint and lacks an application-level resumable state contract. | Faster drawing does not eliminate redundant network bytes or missing replay boundaries. |
+| Font/WebGL regressions | Glyph shaping, atlas invalidation, browser GPU drivers, and DOM sizing are client concerns. | A native or WASM renderer can improve these, but only after state/session problems are separated. |
+| Unix/Windows divergence | tmux is both persistence and screen authority on Unix; the ConPTY host is a byte-ring authority on Windows. | Choosing another browser renderer leaves two server lifecycles. |
+
+## Findings: renderer alternatives
+
+### xterm.js: retain as a bridge, not as the architecture
+
+xterm.js is actively maintained and broadly deployed. Version 6.0 added synchronized output handling, more detailed ligature control, OSC 52 clipboard support, WebGL fixes, and search improvements. Its repository provides search, fit, WebGL, canvas, image, ligature, Unicode, serialization, and headless packages, plus IME and screen-reader modes. [S07] [S08]
+
+Its important constraints are architectural:
+
+- Parsing and terminal state largely run on the browser main thread; the open worker/parser discussion documents the difficulty of separating parser state from rendering. [S10]
+- VT feature coverage is broad but not complete. SIXEL remains an external addon, and Kitty graphics support is still an active design area rather than a settled core capability. [S09] [S11]
+- Touch selection, gestures, and virtual-keyboard behavior require product-specific mobile work. xterm.js provides primitives, not a best-in-class phone terminal. [S11]
+- The server-side `@xterm/headless` plus serialize addon can create a coherent VT replay, but the client must parse the serialized VT again. That is a strong migration bridge, not an efficient final screen-state protocol. [S07] [S30]
+
+AO is on 5.5, so a controlled 6.x upgrade should be evaluated before attributing current problems to project health. The xterm.js maintainers are themselves investigating `libghostty` for parser/state hot paths, evidence that these two options can be complementary rather than mutually exclusive. [S45]
+
+### `libghostty-vt`: best headless core, not a drop-in browser widget
+
+Ghostty now separates its terminal core from its native application. `libghostty-vt` presents a C API for terminal state on macOS, Linux, Windows, and WebAssembly. Its render-state API exposes global and row-level dirty tracking and bulk row access intended to reduce cross-language and WASM boundary overhead. Its input API encodes keys according to active terminal modes. [S12] [S13] [S14]
+
+The formatter can emit current state as VT, plain text, or HTML and can include cursor, styles, hyperlinks, palette, terminal modes, scroll regions, tab stops, working directory, and Kitty keyboard state. That makes it unusually well suited to a gradual AO migration: the server can become authoritative while still sending an atomic VT reconstruction to xterm.js. [S15]
+
+`libghostty-vt` does **not** provide a finished HTML canvas, DOM, WebGL, or WebGPU terminal component. Ghostling demonstrates that the library is renderer-agnostic and can compile to standalone WASM, but the consumer supplies drawing, windowing, selection, accessibility, and interaction. [S16] The full Ghostty application demonstrates a high feature ceiling—grapheme clusters, ligatures, font fallback, GPU rendering, and Kitty graphics—but its GUI is not an embeddable cross-platform AO renderer. [S17]
+
+Risk: the API documentation explicitly says signatures are still in flux. AO should pin a tested revision, isolate it behind a tiny C ABI adapter or sidecar, keep golden VT fixtures, and define its own versioned wire schema. Ghostty enum values and memory layouts must never become AO protocol types. [S12] [S13]
+
+### `alacritty_terminal`: proven core, more integration ownership
+
+The Rust crate exposes a `Term`, grid, renderable content, search, damage tracking, and optional serialization. It is a real library rather than a GUI extraction. [S18] [S19] Zed uses a fork in its terminal implementation, while Warp describes using a fork of Alacritty's grid as the basis of its native product. [S36] [S38]
+
+That adoption is evidence of performance and flexibility, but the forks are also a warning: an adopter owns compatibility changes, shaping, renderer integration, serialization stability, and browser/WASM plumbing. Compared with `libghostty-vt`, Alacritty has no comparable C API and formatter explicitly designed for cross-language/WASM consumers. It remains the strongest fallback if Ghostty's API or licensing/integration constraints become unacceptable.
+
+### WezTerm/Termwiz: excellent ideas, too much product surface
+
+WezTerm is a cross-platform Rust terminal and multiplexer with native scrollback, mouse support, ligatures, color emoji, hyperlinks, images, and remote multiplexer domains. [S20] Its Termwiz `Surface` is especially relevant: it tracks change sequence numbers and can return either accumulated changes or a full repaint when history cannot satisfy a consumer. That is almost exactly the semantic AO needs for resumable multi-client viewing. [S21]
+
+However, Termwiz documents active development and potentially sweeping API changes. Adopting the complete WezTerm mux would import another workspace/session product, while extracting its terminal crates would still require an AO renderer and stable protocol wrapper. [S22] AO should copy the sequence/delta/full-repaint contract, not adopt WezTerm as the session authority.
+
+### Zed and Warp: product approaches, not embeddable answers
+
+Zed keeps its UI local and runs project work, including terminal processes, in a remote headless server. Its shipped terminal implementation is built around an Alacritty fork. [S35] [S36] A community Zed RFC/prototype proposes a persistent `pty-host`, a headless copy of the same `Term`, serialized snapshots, raw live bytes, and flow-control watermarks. That prototype is useful corroboration for AO's direction, but it is not evidence of shipped Zed behavior and must not be presented as such. [S37]
+
+Warp built a native Rust/Metal renderer, forked Alacritty's grid, and used shell integration to divide commands and output into semantic blocks. [S38] The techniques—GPU-native rendering, semantic command boundaries, and a full editor model—are attractive later. Warp's renderer and block UI are integral to its product, not a reusable browser component, and therefore do not solve AO's near-term cloud/browser requirement.
+
+### Renderer comparison
+
+| Option | Browser/Electron | Native/Windows core | Damage/state API | Rich-text ceiling | Integration maturity for AO | Best role |
+|---|---|---|---|---|---|---|
+| xterm.js 6 | Excellent, ready now | Browser only; headless Node available | Internal buffer + serialize; not a semantic wire protocol | Good; addons for images/ligatures, gaps remain | High | Compatibility renderer and tactical upgrade |
+| `libghostty-vt` | WASM core, no finished widget | macOS/Linux/Windows | Explicit render state and dirty rows | Very high | Medium; C API is in flux | Recommended server core and possible future client core |
+| `alacritty_terminal` | Possible Rust/WASM work, no finished widget | Strong Rust core | Renderable content and damage | High with adopter work | Medium-low | Fallback core or native-client foundation |
+| WezTerm/Termwiz | No AO-ready browser widget | Strong cross-platform app/crates | Strong sequence/change model | Very high | Low-medium; broad and unstable surface | Source of protocol ideas |
+| Warp/Zed implementations | No reusable browser component | Native product-specific | Product-specific | Very high | Low | Techniques and UX references only |
+
+## Findings: session and synchronization layer
+
+### Keep ordinary tmux attach
+
+Tmux remains an excellent local process-survival tool. It is installed, debuggable, familiar, and can repaint a terminal after a client disappears. For AO, ordinary attach also preserves terminal query/response behavior per viewer. The costs are the extra PTY/emulator layer, a process per attachment, terminal-dependent repaint streams, Unix-only persistence, and inefficient WAN semantics.
+
+This remains the right rollback path and the lowest-risk short-term architecture, but it cannot be the cloud target.
+
+### Tmux control mode (`-C`/`-CC`)
+
+Control mode turns tmux into a line protocol. `%output` messages carry pane bytes; clients explicitly set sizes; `pause-after` flow control can stop a slow consumer, which must recover with `capture-pane`. `-CC` adds application-oriented behavior used by iTerm2. [S23]
+
+It could eliminate each viewer's attached PTY and make pane lifecycle and output routing explicit. It does not provide an authoritative semantic terminal snapshot. `capture-pane` is a rendered text capture, not a complete transfer of cursor style, hidden modes, graphics, parser partial state, or every terminal capability. This limitation is an inference from tmux's documented control messages and capture recovery, and should be verified with a spike against AO's fixture corpus. It also leaves Windows on a separate path.
+
+Verdict: useful as a bounded legacy bridge or diagnostic transport, not the target architecture.
+
+### Zellij
+
+Zellij has first-class multi-user sessions and a browser client with authentication, read-only tokens, mobile viewport handling, and touch scrolling. [S24] Its multiplayer model permits clients to have independent focus/cursors. [S46] These are good interaction references.
+
+Zellij session resurrection serializes layouts and optionally viewport/scrollback; restarting exited commands is a separate, confirmation-gated feature, not transparent live-process persistence. [S25] Its current web client packages xterm.js assets, so adopting Zellij does not by itself migrate AO off xterm.js. [S26] It would also impose Zellij's panes, layouts, plugins, and session semantics underneath AO's own orchestration model.
+
+Verdict: steal its read-only tokens, explicit collaboration, and mobile affordances; do not make it AO's core dependency.
+
+### Mosh as a state-sync model
+
+Mosh's State Synchronization Protocol treats the terminal screen as replicated state rather than an ordered byte stream. It assigns state numbers, acknowledges the latest state received, skips obsolete intermediate screens, and supports conservative speculative local echo. [S27] This is the right mental model for AO over variable-latency networks.
+
+AO should not adopt Mosh's UDP roaming protocol wholesale. AO already needs authenticated browser transport, scrollback/search, multiple simultaneous viewers, and rich terminal extensions. The transferable ideas are:
+
+- sequence and acknowledge display state, not just transport packets;
+- allow a slow observer to jump to a recent full snapshot;
+- never let obsolete paint backlog block fresh input or the current screen;
+- predict only input known to be safe, then reconcile visibly.
+
+For agent TUIs, prediction must be much more conservative than for a shell prompt. AO should disable it in alternate screen, raw/no-echo mode, mouse reporting, bracketed composition, password entry, and whenever shell-integration confidence is absent. This is an AO design inference.
+
+### Embedded headless VT authority
+
+A headless emulator next to the process consumes the one canonical PTY output stream once. It can atomically snapshot the screen, retain logical scrollback, produce per-client deltas, track terminal modes, and answer reconnects without replaying every obsolete animation. Both POSIX PTYs and ConPTY produce VT streams; ConPTY explicitly translates legacy Console API operations into VT output and accepts VT input. [S28] [S29]
+
+This unifies Unix and Windows above the platform process adapter. It also creates responsibilities tmux previously supplied: process supervision, detach/reattach, resize policy, crash recovery, scrollback storage, and a manual escape hatch. Those responsibilities are substantial but align directly with AO's cloud product rather than with a third-party multiplexer UI.
+
+### Session-layer comparison
+
+| Session layer | Reattach fidelity | Scrollback authority | Multi-client size | WAN behavior | Windows parity | Main residual risk |
+|---|---|---|---|---|---|---|
+| tmux normal attach | Good eventual repaint; non-atomic attach | tmux plus client histories | Implicit/shared policy | Raw redraw stream | Separate ConPTY path | Nested emulators remain |
+| tmux control mode | Better lifecycle/flow visibility; snapshot incomplete | tmux capture plus client state | Explicit client sizes, still one pane grid | Better framing, still mostly raw bytes | Poor | Unix bridge becomes permanent |
+| Zellij | Strong within Zellij model | Zellij | Built-in collaboration | Browser-ready | Limited for AO's Windows requirement | Imports competing product semantics |
+| Mosh/SSP | Strong current-screen resync | Screen-focused; not AO search/history | Primarily one interactive client | Excellent under loss/latency | Model is portable | Not a ready browser/multi-view solution |
+| AO headless VT host | Atomic state + ordered resume | One server authority | Explicit writer lease and observer viewports | Coalesced deltas/resync | Native PTY/ConPTY adapters | Highest implementation ownership |
+
+## Competitor and adjacent-system teardown
+
+Public evidence varies. Where a vendor does not publish its terminal transport, this report says so rather than inferring architecture from screenshots.
+
+### VS Code remote terminals
+
+VS Code's current pty service is the most actionable reference. A persistent PTY is independent of the renderer. `XtermSerializer` feeds output and resize events to a headless xterm instance and uses the serialize addon to produce a compact VT replay, including terminal modes, for reconnect. The browser receives an explicit replay-complete event before live operation. [S30]
+
+The terminal process tracks unacknowledged output characters and pauses the PTY at a high watermark until client acknowledgements drain below a low watermark. The browser process manager sends those acknowledgements. [S31] [S32]
+
+Techniques to steal:
+
+- isolate the PTY owner from renderer/client lifecycle;
+- distinguish replay from live output explicitly;
+- keep a server-side emulator for coherent reconstruction;
+- implement credit/acknowledgement flow control;
+- preserve shell-integration metadata across reconnect.
+
+Limitation: serialized VT is still reparsed by the client and does not give multiple clients independent semantic delta streams. It is an excellent intermediate architecture for AO, not the final protocol.
+
+OpenVSCode Server is explicitly used as the basis for browser-hosted VS Code experiences including Gitpod and GitHub Codespaces, while code-server is a patched distribution of VS Code for browser access. [S33] [S34] These products therefore validate the operational pattern—remote extension/PTY services plus a browser xterm client—but are not independent evidence for a new renderer. Public Codespaces material does not establish an internal terminal protocol beyond that family resemblance.
+
+### Conductor and agent orchestrators
+
+Conductor documents workspaces with a terminal for each task, but its public documentation does not specify terminal renderer, persistence owner, replay format, or resize arbitration. [S39] No architecture claim should be made from the visible product alone. This lack of public detail is itself a useful boundary: AO's decision should rest on inspectable protocols and source, not competitor UI inference.
+
+Open agent terminal projects frequently use the same thin-relay pattern as AO. ttyd connects a command to xterm.js over the web and adds authentication, SSL, file transfer, IME/CJK, and graphics support. [S40] GoTTY states directly that it relays TTY input/output over WebSocket and recommends tmux to share one process. [S41] These systems demonstrate reach and simplicity, but not atomic multi-client state synchronization.
+
+### sshx
+
+sshx is a collaborative, end-to-end encrypted web terminal with reconnection, remote cursors, chat, and predictive echo. Its open source tree uses an xterm fork and client-side typeahead logic. [S42] The collaboration UX and guarded prediction are worth studying. Its relay-oriented collaboration model does not remove AO's need for a workspace-side canonical screen and durable cloud-session ownership.
+
+### Warp and Zed
+
+Warp demonstrates the ceiling of treating terminal output as structured application content: shell hooks establish command blocks, while native GPU rendering and an editor-like input model enable richer selection and workflows. [S38] Zed demonstrates the value of a small remote headless server while keeping latency-sensitive rendering local. [S35] AO should copy their separation of remote execution from local presentation and progressively add OSC 133/shell semantic regions; it should not couple process persistence to a proprietary/native UI model.
+
+### What to steal
+
+| Source | Technique | AO adaptation |
+|---|---|---|
+| VS Code | Persistent PTY service, headless serializer, replay sentinel, output acks | Immediate bridge architecture; later replace VT replay with screen snapshots/deltas |
+| Mosh | Latest-state synchronization, sequence/ack, guarded prediction | Coalesce observer updates; resume by sequence; normal-shell-only prediction |
+| WezTerm/Termwiz | Change journal that falls back to full repaint | Bounded delta log with snapshot reset on gaps |
+| Zellij | Viewer/controller collaboration, read-only access, mobile viewport UX | Explicit terminal roles, control requests, touch patterns |
+| sshx | Presence, remote cursors, predictive echo | Optional collaboration overlay and conservative typeahead |
+| Warp | Shell-semantic blocks | Preserve OSC 133 regions for search/navigation and agent-event correlation |
+| ttyd/GoTTY | Thin, deployable browser access | Keep a raw-VT compatibility route for recovery and debugging |
+
+## Best-in-class feature bar
+
+The feature bar is not “renders ANSI.” It is consistent behavior across a local desktop, a Chromium tab over a WAN, and a narrow touch device.
+
+| Area | Acceptance bar | Architectural implication |
+|---|---|---|
+| Perceived latency | Local input-to-first-paint p95 under one frame when the app echoes promptly; WAN typing remains responsive under 100–200 ms RTT; current screen is never stuck behind obsolete animation. | Timestamp input/output/paint; acknowledge state; coalesce superseded paints; add prediction only under proven-safe modes. |
+| Reattach | First visible frame is atomic and current; no “history fast-forward”; cursor, title, palette, modes, alt screen, and mouse state match before input is enabled. | Snapshot plus sequence, replay-complete barrier, full resync on gaps. |
+| Scrollback | Search is fast across retained history; wrapped logical lines survive resize; results page without downloading all history; copy preserves text rather than cell padding. | Server-owned logical scrollback with hard/soft-wrap metadata and paged search. |
+| Multi-client | One explicit controller owns input and canonical grid size; observers cannot resize the process; control transfer is visible and auditable. | Writer/resize lease, viewer role, presence, crop/pan/letterbox for observers. |
+| Keyboard and IME | Bracketed paste, focus, Kitty keyboard extensions, compose/dead keys, CJK IME, emoji, and key-up/repeat semantics work without double encoding. | Send normalized input/composition events; encode against server-known terminal modes. Kitty's protocol is a useful capability target. [S44] |
+| Mouse and alternate screen | Mode transitions are acknowledged before input; selection overrides are consistent; wheel behavior is defined for application mouse mode and normal scrollback. | Modes live in authoritative state; client interaction derives from the acknowledged snapshot. |
+| Text fidelity | Unicode grapheme clusters, width, combining marks, fallback fonts, ligatures, underline variants, and bidi limitations are deterministic and tested. | Version width tables; ship font metrics policy; compare state separately from glyph rasterization. |
+| Images and links | OSC 8 links are inspectable and safe; Kitty/SIXEL images are bounded, deduplicated, and reconnectable. | Content-addressed image blobs with quotas and references in screen state; never replay unlimited inline image payloads. Kitty's graphics protocol provides a strong interoperability target. [S43] |
+| Accessibility | Screen readers receive ordered textual updates; keyboard-only selection/search works; contrast and reduced-motion settings are honored. | Maintain a DOM accessibility mirror or equivalent semantic tree; canvas/GPU pixels alone are insufficient. |
+| Mobile | Touch scroll does not inject wheel events accidentally; long-press selection, copy, pinch font size, safe-area layout, and a configurable modifier/key row work; read-only viewing is excellent. | Phone-specific interaction layer and viewer-default role, not a shrunk desktop terminal. Zellij's web client is a useful reference. [S24] |
+| Observability | A report identifies application bytes, PTY state, protocol sequence, renderer, font, GPU backend, and resize/controller events without capturing secrets by default. | Layer-specific trace IDs and opt-in redacted recordings; no terminal contents in ordinary telemetry. |
+
+## Candidate end-to-end architectures
+
+Scores are a decision aid, not measured facts: 1 is poor and 5 is strong. “Delivery safety” rewards a smaller, reversible change. Weighted totals are an AO synthesis.
+
+| Criterion | Weight | A: harden tmux+xterm | B: tmux control + headless client | C: AO host + VT compatibility | D: AO host + state protocol/new renderer |
+|---|---:|---:|---:|---:|---:|
+| Reattach fidelity | 20% | 2 | 3 | 4 | 5 |
+| WAN and multi-client behavior | 20% | 2 | 3 | 4 | 5 |
+| Browser/mobile fit | 15% | 3 | 3 | 4 | 5 |
+| Unix/Windows parity | 15% | 2 | 2 | 5 | 5 |
+| Eliminates nested-state bugs | 10% | 1 | 3 | 4 | 5 |
+| Delivery safety | 10% | 5 | 3 | 3 | 1 |
+| Feature ceiling | 10% | 3 | 3 | 4 | 5 |
+| **Weighted total** | **100%** | **2.45** | **2.85** | **4.05** | **4.60** |
+
+### Candidate A — harden tmux attach and xterm.js
+
+Upgrade xterm.js, improve replay framing/observability, define resize ownership, and retain per-client `tmux attach`.
+
+- **Effort/risk:** low; weeks rather than quarters, depending on regression breadth.
+- **Windows/browser:** browser stays strong; Windows remains a parallel ConPTY implementation.
+- **Eliminates:** some xterm 5.5 bugs, hidden replay timing, ambiguous resize policy, weak diagnostics.
+- **Does not eliminate:** nested emulators, attach-time repaint, raw WAN output, duplicate Unix/Windows session semantics.
+- **Use:** mandatory stabilization and rollback stage, not target.
+
+### Candidate B — tmux control mode plus a headless state service
+
+Replace each normal attach with one control-mode connection and feed pane output into a headless emulator; clients receive serialized state or bytes.
+
+- **Effort/risk:** medium.
+- **Windows/browser:** browser is manageable; Windows still needs a separately designed authority.
+- **Eliminates:** per-client tmux attachment PTYs and some output-routing ambiguity.
+- **Does not eliminate:** tmux as a Unix-only state owner, incomplete initial-state reconstruction, two platform lifecycles.
+- **Use:** only if a spike proves it is a fast compatibility bridge for existing tmux sessions. Do not build the cloud contract around it.
+
+### Candidate C — AO Terminal Host with VT compatibility output
+
+A workspace-side host owns the native PTY/ConPTY and child. A pinned `libghostty-vt` instance consumes output and owns screen/scrollback state. On attach, it formats one coherent VT snapshot, marks replay complete, then sends live VT output to xterm.js. It journals sequence numbers and enforces one writer/resize lease.
+
+- **Effort/risk:** high but incremental; approximately one major subsystem with a feature-flagged session boundary.
+- **Windows/browser:** the platform split ends below the host; all clients remain xterm-compatible.
+- **Eliminates:** mandatory tmux layer for new sessions, per-client server PTYs, non-atomic history walk, inconsistent resize authority, daemon-coupled attachments.
+- **Residual:** client reparses VT; live output can still contain obsolete redraws; renderer-specific bugs remain.
+- **Use:** recommended next architecture.
+
+### Candidate D — AO Terminal Host, native state protocol, purpose-built clients
+
+The host sends atomic snapshots and compact semantic deltas. Clients render cells, glyph runs, cursor, selections, links, and image references without reconstructing history from VT. Browser clients use `libghostty-vt` WASM where parsing/input logic helps, or an AO WebGPU/canvas renderer with a DOM accessibility mirror. Native clients may share the same core.
+
+- **Effort/risk:** very high; renderer, protocol, accessibility, font shaping, mobile, and conformance are all product code.
+- **Windows/browser:** best possible parity; one stable AO protocol above platform adapters.
+- **Eliminates:** nested parsing, raw-byte replay, redundant WAN paints, renderer lock-in at the transport boundary.
+- **Residual:** AO owns a complex terminal UI and protocol forever.
+- **Use:** target evolution after Candidate C proves the server authority and protocol semantics.
+
+## Recommended target architecture
+
+```mermaid
+flowchart LR
+  subgraph Clients
+    D[Electron client]
+    W[Web client]
+    M[Phone viewer/controller]
+  end
+
+  D & W & M -->|authenticated binary terminal protocol| G[AO gateway / daemon]
+  G -->|authorized, resumable stream| H
+
+  subgraph Workspace
+    H[Per-session AO Terminal Host]
+    V[libghostty-vt adapter]
+    J[Snapshot + bounded delta journal]
+    S[Logical scrollback/search]
+    B[Content-addressed image blobs]
+    P[POSIX PTY or ConPTY]
+    A[Agent / shell / TUI]
+    H --- V
+    H --- J
+    H --- S
+    H --- B
+    H --> P --> A
+  end
+
+  T[Legacy tmux adapter] -. existing sessions / rollback .-> G
+```
+
+### Ownership and lifecycle
+
+- Run the Terminal Host inside the workspace, beside the process, so cloud terminal bytes do not depend on a desktop daemon staying connected.
+- Prefer one host process per terminal session for crash and memory isolation. A small workspace supervisor owns discovery and restarts, but a restarted host can restore only the last screen—not a child whose PTY owner died. This failure is equivalent in class to a tmux-server crash and must be measured explicitly.
+- Keep control-plane metadata in AO's durable store, but keep live terminal cells, scrollback, secrets, and image payloads in the workspace terminal service with bounded retention. Do not put high-volume terminal state through SQLite change events.
+- Use an unguessable short-lived attach ticket carrying session, user, role, and expiry. The gateway authenticates clients; the host still validates scoped authorization.
+- Preserve a local raw-VT/manual attach path for recovery. The Ghostty formatter can supply a coherent VT snapshot to a conventional terminal.
+
+### Canonical dimensions and multiple viewers
+
+A PTY has exactly one `(columns, rows)` grid; there is no technically correct way to give simultaneous controllers incompatible widths. ConPTY likewise exposes one pseudo-console size. [S28]
+
+AO should make the policy a visible product concept:
+
+1. A session has one **controller lease**. Its measured grid sets canonical PTY dimensions.
+2. Observers do not resize the PTY. They crop/pan, letterbox, or scale typography locally while preserving the canonical cell grid.
+3. A controller can transfer control; lease generation changes atomically and is shown to all clients.
+4. Phone clients attach read-only by default and can explicitly request control with a phone-appropriate canonical size.
+5. On controller loss, keep the last size for a grace period; then transfer according to an explicit policy, never “largest recent socket wins.”
+
+This makes resize bugs attributable and prevents a dashboard thumbnail or phone rotation from reflowing an agent's TUI.
+
+### Versioned synchronization protocol
+
+Define an AO-owned binary protocol. WebSocket is sufficient initially; WebTransport can be evaluated later without changing message semantics.
+
+**Attach and capability negotiation**
+
+```text
+ClientHello { protocol_versions, renderer_caps, input_caps, viewport, resume_token }
+Attach       { session_id, generation?, after_seq?, requested_role }
+ServerHello { protocol_version, session_generation, role, canonical_size, feature_caps }
+```
+
+**State transfer**
+
+- `Snapshot`: atomic primary and alternate buffers, active buffer, cursor, modes, palette, title, cwd/shell regions, hyperlinks, wrap metadata, image references, canonical dimensions, and `snapshot_seq`.
+- `Delta`: monotonic `(generation, seq)`, row/cell runs plus mode/cursor/metadata operations. Several obsolete deltas may be coalesced into the newest equivalent state.
+- `Ack`: latest applied sequence and optional receive credit. The host keeps only a bounded journal per session, not per client.
+- `ResetRequired`: a resume sequence is too old or capabilities changed; client discards derived state and requests a new snapshot.
+- `ScrollPage`/`Search`: pages logical history independently of the live viewport.
+- `ReplayComplete`: enables input only after the initial snapshot and modes are applied. Candidate C uses the same barrier around formatted VT.
+
+The protocol should carry semantic AO operations, never Rust/Zig/C structs. It needs golden compatibility fixtures and at least the current and previous protocol version during rolling cloud upgrades.
+
+**Input**
+
+Send text, key, composition, paste, mouse, focus, and resize/control requests as typed events. The host encodes terminal sequences using current authoritative modes. This avoids a stale client encoding Kitty keyboard or application-cursor keys against yesterday's mode. During compatibility, raw byte input can remain as a negotiated capability.
+
+**Flow control and latency**
+
+- Never block current display state behind an unbounded slow-client queue.
+- Pause PTY reads only as a last protection for the child; normally coalesce display deltas for slow observers.
+- Never drop input, lease, resize, or mode-control events.
+- Bound snapshots, scrollback, hyperlinks, OSC payloads, and decoded images before allocation.
+- Record input-received, PTY-written, PTY-read, delta-produced, client-applied, and frame-painted timestamps without recording content.
+
+### Rendering boundary
+
+The protocol should separate terminal semantics from drawing:
+
+- The state model establishes cells/graphemes, attributes, modes, links, cursor, image references, and logical history.
+- The renderer owns font discovery/fallback, shaping, ligatures, glyph atlas, selection visuals, GPU/canvas fallback, accessibility mirror, and device input UX.
+- A renderer cannot silently reinterpret widths. It negotiates a width-table/version capability and reports metrics.
+
+For the first browser renderer, evaluate two implementations behind the same conformance suite:
+
+1. `libghostty-vt` WASM plus a thin AO WebGPU/canvas renderer, using bulk render-state reads and Ghostty input encoding.
+2. A direct AO screen-delta renderer that does no VT parsing, with HarfBuzz-compatible shaping in WASM and canvas/WebGPU backends.
+
+The first reuses more terminal logic; the second has a smaller browser runtime once the server protocol is authoritative. Neither should block Candidate C.
+
+## Staged migration plan
+
+### Now: make the current stack measurable and deterministic
+
+**Session and protocol**
+
+- Specify controller/viewer roles and a single resize lease in the existing mux protocol.
+- Add terminal stream generation, monotonically ordered chunks, explicit initial-replay completion, and reconnect/resume outcomes.
+- Prototype output acknowledgements and bounded queues using VS Code's high/low-watermark design as the reference. [S31] [S32]
+- Measure binary WebSocket framing against current base64-in-JSON frames; adopt it if the compatibility and CPU results justify the change.
+
+**Renderer**
+
+- Run an xterm.js 6 upgrade branch through a fixture matrix before changing defaults. Test WebGL, canvas fallback, browser zoom, DPR changes, font loading/fallback, ligatures, IME, Unicode width, search, and resize convergence.
+- Keep WebGL fallback automatic and observable. A GPU backend is an implementation detail, not session state.
+- Do not enable images or new grapheme behavior globally until memory, paste/copy, and width regressions pass.
+
+**Test and attribution harness**
+
+- Record deterministic fixtures as `{initial size, input events, resize events, PTY byte chunks, timing markers}` plus expected semantic screen hashes and selected screenshots.
+- Include shells, long scrollback, rapid progress redraw, tmux attach, alternate-screen TUIs, mouse tracking, OSC 8, OSC 133, bracketed paste, CJK/emoji/combining marks, IME, Kitty keyboard, SIXEL/Kitty image rejection or rendering, and resize storms.
+- Replay each fixture into xterm 5.5, xterm 6, `libghostty-vt`, and later the AO state renderer. Compare semantic cells separately from pixels.
+- Add layer identifiers and sequences to diagnostics: agent PTY, tmux/control attach, daemon mux, client parser, renderer backend, font fingerprint, DPR, and lease generation.
+- Establish dashboards for attach-to-stable-frame, input-to-first-paint, bytes per rendered cell change, resync count, dropped/coalesced delta count, search latency, and renderer fallback/crash rate.
+
+**Exit criteria**
+
+- Regressions are reproducible from a shareable, secret-scrubbed fixture.
+- No observer can resize an interactive session.
+- Replay completion and stream generation are explicit in logs and tests.
+- xterm 6 is either shipped with measured parity or rejected with named failing fixtures.
+
+### Next: introduce the AO Terminal Host
+
+1. **Build the lifecycle shell.** Create a supervised, per-session host that survives client and daemon restarts. Start with POSIX PTY; put ConPTY behind the same host interface. Define discovery, attach tickets, graceful shutdown, resource caps, and raw-VT recovery.
+2. **Embed the state core.** Pin a `libghostty-vt` revision behind a narrow adapter. Feed output, resize once per lease event, and validate state against the fixture corpus. Shadow-parse existing terminal streams first; do not make it authoritative until divergence is understood.
+3. **Ship the compatibility replay.** Use the formatter to send one coherent VT snapshot to xterm.js, followed by an explicit replay-complete boundary and live bytes. Preserve modes and shell metadata. This should replace raw-ring/history fast-forward for opted-in sessions.
+4. **Unify platforms.** Move Windows ConPTY ownership under the same lifecycle, lease, replay, and flow-control contract. Keep only the PTY adapter platform-specific.
+5. **Canary new sessions.** Existing tmux sessions remain attached through the legacy path. New local sessions opt in by feature flag, followed by cloud workspaces. Support fallback at session creation rather than trying to migrate a live PTY between owners.
+6. **Add server scrollback.** Retain bounded logical history and hard/soft-wrap markers. Provide paged retrieval and search before reducing client scrollback retention.
+
+**Exit criteria**
+
+- Client/daemon restart reconnects atomically without a visible history walk.
+- POSIX and Windows pass the same protocol and semantic-screen fixtures.
+- Two observers plus one controller remain consistent under WAN delay, reconnect, and resize.
+- Host memory/CPU, scrollback quotas, child exit propagation, and crash behavior have load and fault-injection coverage.
+- A tmux/raw-VT rollback remains available for new-session creation.
+
+### Later: native screen sync and renderer independence
+
+1. Define snapshot/delta protocol v1 from observed compatibility-host behavior, not from a speculative renderer object model.
+2. Ship a hidden client renderer that consumes semantic deltas; run it side by side with xterm.js and compare screen hashes.
+3. Add DOM accessibility output, keyboard-only navigation, IME, touch selection, mobile modifier row, and viewer-first phone layouts before calling the renderer production-ready.
+4. Move large Kitty/SIXEL payloads into quota-controlled, content-addressed blobs. Add OSC 8 safety UI and shell-semantic command regions.
+5. Add conservative Mosh-style prediction only for verified normal-buffer, echoing shell input. Mark predicted cells and reconcile; automatically disable on raw mode, alternate screen, mouse reporting, IME composition, or uncertainty.
+6. Graduate clients independently: web/mobile first if network savings justify it; Electron may retain xterm longer. Remove VT compatibility only after all supported clients negotiate state protocol v1.
+7. Stop requiring tmux for new Unix sessions after recovery, manual attach, lifecycle, scrollback, and upgrade gates pass. Keep an explicit “run inside tmux” compatibility option for users and diagnostics if demand warrants it.
+
+**Exit criteria**
+
+- Native state clients meet or beat xterm on the feature bar and accessibility audit.
+- Resume after an intentionally lost network interval transfers a bounded snapshot/delta set, not elapsed raw output.
+- Cloud p95 input-to-paint and attach-to-stable-frame targets hold under representative RTT/loss.
+- No critical fixture differs across Electron, web, phone, POSIX, and Windows without a documented capability downgrade.
+
+## Risks and mitigations
+
+| Risk | Consequence | Mitigation / decision gate |
+|---|---|---|
+| `libghostty-vt` API churn | Build breakage or subtle state drift | Pin revisions; tiny adapter; AO-owned types; golden corpus; planned upgrade cadence. |
+| Host crash owns the PTY | Live child is lost | Per-session isolation, supervisor, crash-loop limits, fault tests, visible failure reason; retain tmux fallback until reliability is demonstrated. |
+| Server and client width/shaping disagree | Cursor and selection drift | Version grapheme/width policy; semantic hashes; server determines cells, client only shapes within them. |
+| Delta protocol overfits one renderer | Long-term lock-in reappears | Model terminal semantics, not GPU buffers or Ghostty structs; build two consumers in tests. |
+| Slow observers consume memory | Workspace instability | Bounded shared journal, per-client credit, coalescing, snapshot reset, disconnect limits. |
+| Rich image escape sequences exhaust resources | Memory/disk/security incidents | Disabled by default initially; strict decoded-byte/dimension/count quotas; blob validation and retention. |
+| Accessibility arrives late | New renderer cannot replace xterm | Accessibility tree and keyboard interaction are release gates from the first hidden renderer. |
+| Terminal recordings expose secrets | Trust/privacy failure | Content-free metrics by default; explicit opt-in capture; local redaction; short retention; never ordinary telemetry. |
+| Rolling cloud upgrades split protocol versions | Failed attaches | Capability negotiation, previous-version support, generation reset, raw-VT recovery. |
+| Shell prediction corrupts TUI input | User-visible wrong commands | Opt-in experimental flag; narrow positive safety conditions; instant disable and reconciliation. |
+
+## Open questions and validation spikes
+
+These questions should be answered before Candidate C's protocol is frozen:
+
+1. Does `libghostty-vt`'s formatter reconstruct every mode AO's xterm clients need after a snapshot, including alternate buffer, Kitty keyboard, mouse/focus reporting, partial parser state, and graphics references? Build fixtures; do not assume.
+2. Can scrollback be extracted and paged without copying the full Ghostty terminal state, or should AO own a parallel logical-line journal fed by parser events?
+3. What host packaging produces the lowest operational risk: cgo-linked Go, a Zig/C sidecar, or a Rust/Zig terminal service? Compare crash isolation, cross-compilation, signing, and Windows distribution.
+4. What is the canonical controller policy for noninteractive log sessions, agent-owned background TUIs, and user takeover? Product behavior must precede protocol fields.
+5. How much bandwidth does semantic delta encoding save on real agent TUIs versus compressed raw VT plus atomic snapshots? Measure recorded workloads at 50, 100, and 200 ms RTT with loss.
+6. Can `tmux -CC` produce a safe one-release bridge for already-running sessions, or does capture/mode incompleteness make ordinary attach more reliable? Validate, then discard the losing path.
+7. Which client should first consume native deltas: phone, browser, or Electron? Choose based on measured network/interaction benefit, not implementation novelty.
+
+## Sources and evidence quality
+
+Sources were accessed 2026-08-16. Primary repositories, source files, protocol papers, and official documentation were preferred. GitHub issues and maintainer discussions are used only to establish an active limitation or direction, not as guarantees. Product behavior inferred from sources is labeled in the body. Conductor's unpublished internals are intentionally left unknown.
+
+### AO implementation baseline
+
+- **[AO01]** AO, [`backend/internal/terminal/doc.go`](../../backend/internal/terminal/doc.go) — terminal transport rationale and per-client attach model.
+- **[AO02]** AO, [`backend/internal/adapters/runtime/tmux/tmux.go`](../../backend/internal/adapters/runtime/tmux/tmux.go) and [`commands.go`](../../backend/internal/adapters/runtime/tmux/commands.go) — tmux launch, attach, environment, sizing, and capture behavior.
+- **[AO03]** AO, [`backend/internal/terminal/manager.go`](../../backend/internal/terminal/manager.go) — attachment and authoritative-size reconciliation.
+- **[AO04]** AO, [`backend/internal/adapters/runtime/conpty/host.go`](../../backend/internal/adapters/runtime/conpty/host.go) and [`attach.go`](../../backend/internal/adapters/runtime/conpty/attach.go) — Windows host, raw replay ring, broadcast, and resize policy.
+- **[AO05]** AO, [`frontend/src/renderer/components/XtermTerminal.tsx`](../../frontend/src/renderer/components/XtermTerminal.tsx) — renderer/addon/fallback and fitting behavior.
+- **[AO06]** AO, [`frontend/src/renderer/hooks/useTerminalSession.ts`](../../frontend/src/renderer/hooks/useTerminalSession.ts) and [`terminal-mux.ts`](../../frontend/src/renderer/lib/terminal-mux.ts) — WebSocket framing, replay buffering, reconnect, and resize handling.
+- **[AO07]** AO, [`frontend/package.json`](../../frontend/package.json) — pinned xterm.js and addon version ranges.
+
+### Terminal cores and renderers
+
+- **[S07]** xterm.js maintainers, [xterm.js README and addon inventory](https://github.com/xtermjs/xterm.js), official repository.
+- **[S08]** xterm.js maintainers, [xterm.js releases](https://github.com/xtermjs/xterm.js/releases), official release history.
+- **[S09]** xterm.js maintainers, [Supported terminal sequences](https://xtermjs.org/docs/api/vtfeatures/), official capability matrix.
+- **[S10]** xterm.js maintainers, [Issue #3368: parser in a worker](https://github.com/xtermjs/xterm.js/issues/3368), open architectural discussion.
+- **[S11]** xterm.js maintainers, [Issue #5377: mobile touch support](https://github.com/xtermjs/xterm.js/issues/5377), active limitation/proposal.
+- **[S12]** Ghostty project, [`libghostty-vt` README](https://github.com/ghostty-org/ghostty/blob/main/README.md), official platform/API status.
+- **[S13]** Ghostty project, [`ghostty/vt.h`](https://github.com/ghostty-org/ghostty/blob/main/include/ghostty/vt.h), official C API.
+- **[S14]** Ghostty project, [`ghostty/vt/render.h`](https://github.com/ghostty-org/ghostty/blob/main/include/ghostty/vt/render.h), official damage/render-state API.
+- **[S15]** Ghostty project, [`ghostty/vt/formatter.h`](https://github.com/ghostty-org/ghostty/blob/main/include/ghostty/vt/formatter.h), official state formatting API.
+- **[S16]** Ghostty project, [Ghostling](https://github.com/ghostty-org/ghostling), official minimal renderer and WASM example.
+- **[S17]** Ghostty project, [Ghostty features](https://ghostty.org/docs/features), official full-application feature reference.
+- **[S18]** Alacritty project, [`alacritty_terminal` crate](https://docs.rs/alacritty_terminal/latest/alacritty_terminal/), official generated API documentation.
+- **[S19]** Alacritty project, [`alacritty_terminal::term`](https://docs.rs/alacritty_terminal/latest/alacritty_terminal/term/), official `Term`, search, render, and damage API.
+- **[S20]** WezTerm project, [WezTerm overview](https://wezterm.org/), official terminal/multiplexer feature documentation.
+- **[S21]** WezTerm project, [`termwiz::surface::Surface`](https://docs.rs/termwiz/latest/termwiz/surface/struct.Surface.html), official change-sequence API.
+- **[S22]** WezTerm project, [Termwiz README](https://docs.rs/crate/termwiz/latest/source/README.md), official scope and stability note.
+- **[S36]** Zed Industries, [`terminal` crate source](https://github.com/zed-industries/zed/tree/main/crates/terminal), official repository showing Alacritty-derived implementation.
+- **[S37]** Zed community, [Discussion #50584: persistent terminal prototype/RFC](https://github.com/zed-industries/zed/discussions/50584), explicitly non-shipped design evidence.
+- **[S38]** Warp, [How Warp works](https://www.warp.dev/blog/how-warp-works), vendor engineering account of its grid, renderer, and block model.
+- **[S45]** xterm.js maintainers, [Issue #5686: explore `libghostty` adoption](https://github.com/xtermjs/xterm.js/issues/5686), current exploratory direction.
+
+### Multiplexers, protocols, and platform PTYs
+
+- **[S23]** tmux project, [Control mode](https://github.com/tmux/tmux/wiki/Control-Mode), official protocol and flow-control documentation.
+- **[S24]** Zellij project, [Web client](https://zellij.dev/documentation/web-client.html), official authentication, mobile, and attach behavior.
+- **[S25]** Zellij project, [Session resurrection](https://zellij.dev/documentation/session-resurrection.html), official persistence boundaries.
+- **[S26]** Zellij project, [`xtask/src/assets.rs`](https://github.com/zellij-org/zellij/blob/main/xtask/src/assets.rs), official source showing packaged web-terminal assets.
+- **[S27]** Keith Winstein and Hari Balakrishnan, [Mosh: An Interactive Remote Shell for Mobile Clients](https://mosh.org/mosh-paper-draft.pdf), original protocol paper.
+- **[S28]** Microsoft, [Windows Console definitions: pseudo console](https://learn.microsoft.com/en-us/windows/console/definitions), official ConPTY model.
+- **[S29]** Microsoft Command Line team, [Introducing the Windows Pseudo Console (ConPTY)](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/), official engineering explanation.
+- **[S43]** Kitty project, [Terminal graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/), protocol specification.
+- **[S44]** Kitty project, [Keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/), protocol specification.
+- **[S46]** Zellij project, [Multiplayer sessions](https://zellij.dev/news/multiplayer-sessions/), official collaboration model.
+
+### Remote IDEs and browser terminal systems
+
+- **[S30]** Microsoft, [`ptyService.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/platform/terminal/node/ptyService.ts), current VS Code persistent PTY and serializer implementation.
+- **[S31]** Microsoft, [`terminalProcess.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/platform/terminal/node/terminalProcess.ts), current output acknowledgement/watermark implementation.
+- **[S32]** Microsoft, [`terminalProcessManager.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts), current browser-side acknowledgement path.
+- **[S33]** Gitpod, [OpenVSCode Server](https://github.com/gitpod-io/openvscode-server), official repository and deployment positioning.
+- **[S34]** Coder, [code-server FAQ](https://github.com/coder/code-server/blob/main/docs/FAQ.md), official relationship to VS Code web/server implementations.
+- **[S35]** Zed Industries, [Remote development](https://zed.dev/docs/remote-development), official local-client/headless-server model.
+- **[S39]** Conductor, [Workspaces](https://www.conductor.build/docs/core/workspaces), official public product documentation; no terminal internals disclosed.
+- **[S40]** ttyd project, [ttyd](https://github.com/tsl0922/ttyd), official repository and feature list.
+- **[S41]** GoTTY project, [GoTTY](https://github.com/yudai/gotty), official repository and raw WebSocket/tmux sharing description.
+- **[S42]** sshx project, [sshx](https://github.com/ekzhang/sshx), official repository and collaboration/predictive-echo implementation.
+
+## Bottom line
+
+AO's strategic terminal problem is not “which canvas draws ANSI fastest?” It is “which component owns truth, and how do many lossy, differently sized clients resume that truth?” Make the workspace Terminal Host authoritative, use `libghostty-vt` to avoid inventing terminal semantics, retain xterm.js as a reversible compatibility client, and let measured protocol and accessibility work—not renderer enthusiasm—determine when AO is ready to leave xterm.js behind.


### PR DESCRIPTION
## Summary

- documents the current Unix tmux and Windows ConPTY terminal paths and their failure boundaries
- evaluates xterm.js, libghostty-vt, Alacritty, WezTerm, Zed, Warp, tmux control mode, Zellij, Mosh, and browser terminal peers
- recommends a workspace-side AO Terminal Host with authoritative state, sequenced snapshots/deltas, and an xterm.js compatibility phase
- defines four candidate architectures, a feature bar, risks, validation spikes, and a staged now/next/later migration
- adds a self-contained responsive visual companion with architecture diagrams, decision cards, protocol flow, feature bar, and migration roadmap
- cites 40 external primary or first-party sources plus 7 AO implementation references

## Validation

- git diff --check
- HTML5 parse and JavaScript syntax validation
- fragment, local, and external link validation
- responsive visual render inspection
- previewed the visual guide in the AO Browser panel

## Scope

Docs only. No product code or generated artifacts changed. Product test suites were not run.