### PR TITLE
fix(chat): place compact action in composer tools

### DIFF
--- a/frontend/src/renderer/components/chat/ChatCompaction.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatCompaction.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ChatWorkspace } from "./ChatWorkspace";
@@ -116,21 +116,17 @@ describe("compaction in the timeline", () => {
 	});
 });
 
-describe("the /compact command", () => {
-	it("runs from the composer without reserving a separate action row", async () => {
-		const user = userEvent.setup();
+describe("the compact control", () => {
+	it("is offered in the composer message tools", () => {
 		const onCompact = vi.fn();
 		render(<ChatWorkspace snapshot={snapshot([assistantSaid])} onCompact={onCompact} />);
 
-		expect(
-			screen.queryByRole("button", { name: "Compact conversation history" }),
-		).not.toBeInTheDocument();
-		const field = screen.getByLabelText("Message the agent");
-		await user.type(field, "/compact");
-		await user.keyboard("{Enter}");
-
+		const tools = screen.getByRole("group", { name: "Message tools" });
+		const compactButton = within(tools).getByRole("button", {
+			name: "Compact conversation history",
+		});
+		compactButton.click();
 		expect(onCompact).toHaveBeenCalledOnce();
-		expect(field).toHaveValue("");
 	});
 
 	it("offers compact alongside provider skills in the slash menu", async () => {
@@ -175,7 +171,7 @@ describe("the /compact command", () => {
 			/>,
 		);
 
-		expect(screen.queryByText("This agent cannot compact its history")).not.toBeInTheDocument();
+		expect(screen.getByText("This agent cannot compact its history")).toBeInTheDocument();
 		await user.type(screen.getByLabelText("Message the agent"), "/compact");
 		await user.keyboard("{Enter}");
 		expect(screen.getByRole("alert")).toHaveTextContent("This agent cannot compact its history");

--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -74,6 +74,21 @@ describe("send keys", () => {
 		expect(within(actions).queryByText(/Enter to/)).not.toBeInTheDocument();
 	});
 
+	it("keeps optional footer actions with message tools, away from send controls", () => {
+		render(
+			<ChatComposer
+				onSend={vi.fn()}
+				onStageAttachments={vi.fn().mockResolvedValue([])}
+				settings={<button type="button">Model</button>}
+				footerAction={<button type="button">Compact</button>}
+			/>,
+		);
+		const tools = screen.getByRole("group", { name: "Message tools" });
+		expect(within(tools).getByRole("button", { name: "Compact" })).toBeInTheDocument();
+		const actions = screen.getByRole("group", { name: "Send message controls" });
+		expect(within(actions).queryByRole("button", { name: "Compact" })).not.toBeInTheDocument();
+	});
+
 	it("starts as a single-line field and grows only when the draft needs it", () => {
 		const { field } = renderComposer();
 		expect(field).toHaveAttribute("rows", "1");

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -81,6 +81,7 @@ export function ChatComposer({
 	willQueue,
 	disabled,
 	settings,
+	footerAction,
 	skills = [],
 	filePaths = [],
 	filePathsTruncated,
@@ -102,6 +103,8 @@ export function ChatComposer({
 	onSend: (text: string, attachments?: FileAttachmentPayload[]) => void | Promise<unknown>;
 	/** The next-turn controls, rendered inline. Omitted in the fixture preview. */
 	settings?: ReactNode;
+	/** Optional secondary action rendered with message tools in the lower input row. */
+	footerAction?: ReactNode;
 	/** A send is in flight. */
 	busy?: boolean;
 	/** The agent is mid-turn, so this message is held until the turn ends. */
@@ -631,6 +634,14 @@ export function ChatComposer({
 						<span aria-hidden="true" className="mx-1 h-4 w-px shrink-0 bg-border" />
 					) : null}
 					{settings}
+					{footerAction ? (
+						<>
+							{canAttach || settings ? (
+								<span aria-hidden="true" className="mx-1 h-4 w-px shrink-0 bg-border" />
+							) : null}
+							{footerAction}
+						</>
+					) : null}
 				</div>
 
 				<div

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -27,6 +27,7 @@ import {
 	type WheelEvent as ReactWheelEvent,
 } from "react";
 import {
+	Archive,
 	ArrowDown,
 	CornerDownRight,
 	GitBranch,
@@ -707,6 +708,15 @@ export function ChatWorkspace({
 									/>
 								) : null
 							}
+							footerAction={
+								<CompactButton
+									onCompact={onCompact}
+									compacting={compacting}
+									unavailable={compactUnavailable}
+									turnInFlight={Boolean(turn)}
+									compactedAt={snapshot.compactedAt}
+								/>
+							}
 							busy={busy}
 							willQueue={Boolean(turn)}
 							disabled={snapshot.controller.state === "stopped"}
@@ -766,6 +776,45 @@ export function ChatWorkspace({
 				}}
 			/>
 		</section>
+	);
+}
+
+function CompactButton({
+	onCompact,
+	compacting,
+	unavailable,
+	turnInFlight,
+	compactedAt,
+}: {
+	onCompact?: () => void;
+	compacting?: boolean;
+	unavailable?: string;
+	turnInFlight?: boolean;
+	compactedAt?: string;
+}) {
+	if (!onCompact) return null;
+	if (unavailable === "This agent cannot compact its history") {
+		return <span className="text-[11px] text-muted-foreground">{unavailable}</span>;
+	}
+	const title = turnInFlight
+		? "Finish or stop the current turn before compacting"
+		: compactedAt
+			? `Summarize earlier history to reclaim context. Last compacted ${new Date(compactedAt).toLocaleString()}.`
+			: "Summarize earlier history to reclaim context";
+	return (
+		<Button
+			type="button"
+			size="sm"
+			variant="ghost"
+			onClick={onCompact}
+			disabled={compacting || turnInFlight}
+			title={title}
+			aria-label="Compact conversation history"
+			className="h-5 gap-1 px-1.5 text-[11px]"
+		>
+			{compacting ? <Loader2 aria-hidden="true" className="size-3 animate-spin" /> : <Archive aria-hidden="true" className="size-3" />}
+			{compacting ? "Compacting…" : "Compact"}
+		</Button>
 	);
 }
 


### PR DESCRIPTION
## Summary
- add a generic `footerAction` slot to `ChatComposer`
- render Compact in the lower-left Message tools group
- update composer and compaction placement coverage

## Verification
- Focused tests: `ChatComposer.test.tsx` and `ChatCompaction.test.tsx` — 49 passed
- Electron Forge launched successfully in isolated mode
- Full renderer suite was attempted but hung after JSDOM `scrollTo()` warnings
- Typecheck is currently blocked by an existing missing `motion/react` module in `packages/product-ui`