### PR TITLE
fix(daemon): recover sessions without false startup failure

### DIFF
--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -30,6 +30,8 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
+const startupReconcileWorkers = 4
+
 type notificationSink interface {
 	Notify(context.Context, ports.NotificationIntent) error
 	Resolve(context.Context, ports.NotificationResolution) error
@@ -204,6 +206,7 @@ func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.
 		DataDir:             cfg.DataDir,
 		BackgroundContext:   ctx,
 		Logger:              log,
+		ReconcileWorkers:    startupReconcileWorkers,
 	})
 	scmProvider := newMultiSCMProvider(cfg.GitLab, log)
 	// Build the multi-tracker dispatching to both GitHub and GitLab. The

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -194,6 +194,7 @@ type fakeDriver struct {
 	conv      ports.ChatConversation
 	startCfg  *ports.ChatStartConfig
 	resumeCfg *ports.ChatResumeConfig
+	probe     func() error
 	start     func(ports.ChatStartConfig) (ports.ChatConversation, error)
 	resume    func(ports.ChatResumeConfig) (ports.ChatConversation, error)
 }
@@ -226,6 +227,11 @@ func (d *sequenceDriver) Resume(context.Context, ports.ChatResumeConfig) (ports.
 
 func (d fakeDriver) Harness() domain.AgentHarness { return domain.HarnessCodex }
 func (d fakeDriver) Probe(context.Context) (ports.ChatCapabilities, error) {
+	if d.probe != nil {
+		if err := d.probe(); err != nil {
+			return nil, err
+		}
+	}
 	return productionCaps(), nil
 }
 func (d fakeDriver) Start(_ context.Context, cfg ports.ChatStartConfig) (ports.ChatConversation, error) {
@@ -280,6 +286,66 @@ func productionCaps() ports.ChatCapabilities {
 		ports.ChatCapabilityApprovals: true,
 		ports.ChatCapabilityInterrupt: true,
 		ports.ChatCapabilityResume:    true,
+	}
+}
+
+func TestSuccessfulChatProbeIsReusedByStart(t *testing.T) {
+	st := openStore(t)
+	probes := 0
+	nextID := 0
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers: fakeRegistry{driver: fakeDriver{
+			conv: newFakeConversation(),
+			probe: func() error {
+				probes++
+				return nil
+			},
+		}},
+		Log: slog.New(slog.DiscardHandler),
+		NewID: func() string {
+			nextID++
+			return fmt.Sprintf("probe-cache-%d", nextID)
+		},
+	})
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+
+	if err := svc.PreflightChat(context.Background(), domain.HarnessCodex); err != nil {
+		t.Fatalf("PreflightChat: %v", err)
+	}
+	if _, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if probes != 1 {
+		t.Fatalf("Probe calls = %d, want 1 successful probe reused by Start", probes)
+	}
+}
+
+func TestFailedChatProbeCanBeRetriedThenCached(t *testing.T) {
+	attempts := 0
+	driver := fakeDriver{probe: func() error {
+		attempts++
+		if attempts == 1 {
+			return errors.New("provider still installing")
+		}
+		return nil
+	}}
+	svc := chatsvc.New(chatsvc.Options{Drivers: fakeRegistry{driver: driver}})
+
+	if err := svc.PreflightChat(context.Background(), domain.HarnessCodex); err == nil {
+		t.Fatal("first PreflightChat must surface the transient probe failure")
+	}
+	if err := svc.PreflightChat(context.Background(), domain.HarnessCodex); err != nil {
+		t.Fatalf("second PreflightChat: %v", err)
+	}
+	if err := svc.PreflightChat(context.Background(), domain.HarnessCodex); err != nil {
+		t.Fatalf("cached PreflightChat: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("Probe attempts = %d, want one failed attempt plus one cached success", attempts)
 	}
 }
 

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -47,6 +47,8 @@ type Service struct {
 	startConfigs map[domain.SessionID]StartConfig
 	gateMu       sync.Mutex
 	gates        map[domain.SessionID]controllerGate
+	probeMu      sync.Mutex
+	probed       map[domain.AgentHarness]struct{}
 }
 
 // controllerGate serializes start/stop for one session without making provider
@@ -103,6 +105,7 @@ func New(opts Options) *Service {
 		controllers:  make(map[domain.SessionID]*Controller),
 		startConfigs: make(map[domain.SessionID]StartConfig),
 		gates:        make(map[domain.SessionID]controllerGate),
+		probed:       make(map[domain.AgentHarness]struct{}),
 	}
 }
 
@@ -240,12 +243,8 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 		return nil, fmt.Errorf("chat driver for %s: %w", cfg.Harness, err)
 	}
 
-	caps, err := driver.Probe(ctx)
-	if err != nil {
+	if err := s.ensureDriverReady(ctx, cfg.Harness, driver); err != nil {
 		return nil, err
-	}
-	if missing := ports.MissingProductionCapabilities(caps); len(missing) > 0 {
-		return nil, fmt.Errorf("%w: %s lacks %v", ports.ErrChatUnsupported, cfg.Harness, missing)
 	}
 
 	scope := domain.ConversationScopeSession
@@ -801,6 +800,21 @@ func (s *Service) PreflightChat(ctx context.Context, harness domain.AgentHarness
 	if err != nil {
 		return fmt.Errorf("%w: %s has no chat driver", ports.ErrChatUnsupported, harness)
 	}
+	return s.ensureDriverReady(ctx, harness, driver)
+}
+
+// ensureDriverReady performs the provider capability probe once per harness for
+// the lifetime of this service. Reconciliation can resume many sessions using
+// the same provider; launching a throwaway provider process for every one makes
+// startup scale with twice the number of sessions. Only successful production-
+// capable probes are cached, so a repaired install can be retried without a
+// daemon restart.
+func (s *Service) ensureDriverReady(ctx context.Context, harness domain.AgentHarness, driver ports.ChatDriver) error {
+	s.probeMu.Lock()
+	defer s.probeMu.Unlock()
+	if _, ok := s.probed[harness]; ok {
+		return nil
+	}
 	caps, err := driver.Probe(ctx)
 	if err != nil {
 		return err
@@ -808,6 +822,7 @@ func (s *Service) PreflightChat(ctx context.Context, harness domain.AgentHarness
 	if missing := ports.MissingProductionCapabilities(caps); len(missing) > 0 {
 		return fmt.Errorf("%w: %s lacks %v", ports.ErrChatUnsupported, harness, missing)
 	}
+	s.probed[harness] = struct{}{}
 	return nil
 }
 

--- a/backend/internal/session_manager/chat_spawn_test.go
+++ b/backend/internal/session_manager/chat_spawn_test.go
@@ -104,6 +104,41 @@ func (l *recordingLauncher) HasLiveChatController(domain.SessionID) bool {
 	return l.live
 }
 
+func TestReconcileLive_ChatRelaunchesInExistingWorktree(t *testing.T) {
+	launcher := &recordingLauncher{}
+	m, st, rt := newChatManager(launcher)
+	ws := m.workspace.(*fakeWorkspace)
+	lcm := m.lcm.(*fakeLCM)
+	rec := domain.SessionRecord{
+		ID: "mer-1", ProjectID: chatTestProject, Kind: domain.KindWorker,
+		Harness: domain.HarnessCodex, Mode: domain.SessionModeChat,
+		Metadata: domain.SessionMetadata{
+			Branch: "ao/mer-1/root", WorkspacePath: "/ws/mer-1",
+			ProviderConversationID: "thread-existing",
+		},
+	}
+	st.sessions[rec.ID] = rec
+
+	if err := m.reconcileLive(context.Background(), rec); err != nil {
+		t.Fatalf("reconcileLive: %v", err)
+	}
+	if len(launcher.started) != 1 || launcher.started[0].ProviderConversationID != "thread-existing" {
+		t.Fatalf("chat starts = %+v, want one native resume", launcher.started)
+	}
+	if rt.created != 0 {
+		t.Fatalf("terminal runtime Create calls = %d, want 0 for Chat", rt.created)
+	}
+	if ws.stashCalls != 0 {
+		t.Fatalf("StashUncommitted calls = %d, want 0", ws.stashCalls)
+	}
+	if lcm.terminated[rec.ID] != 0 || st.sessions[rec.ID].IsTerminated {
+		t.Fatalf("chat session was terminated during in-place recovery: calls=%d row=%+v", lcm.terminated[rec.ID], st.sessions[rec.ID])
+	}
+	if len(ws.restoreConfigs) != 1 || ws.restoreConfigs[0].Path != rec.Metadata.WorkspacePath {
+		t.Fatalf("Restore configs = %+v, want existing Chat worktree", ws.restoreConfigs)
+	}
+}
+
 func seedChatResumeSession(store *fakeStore, state domain.ActivityState) {
 	store.sessions["mer-1"] = domain.SessionRecord{
 		ID:        "mer-1",

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -308,6 +308,7 @@ type Manager struct {
 	attachmentSuffix    func() (string, error)
 	dataDir             string
 	clock               func() time.Time
+	reconcileWorkers    int
 	// openTranscriptFile is os.Open in production. The narrow seam lets tests
 	// deterministically prove that a post-stop transcript read failure falls
 	// back without advertising the provider path.
@@ -572,6 +573,10 @@ type Deps struct {
 	Executable func() (string, error)
 	// NewLaunchID overrides supervised-process generation for deterministic tests.
 	NewLaunchID func() string
+	// ReconcileWorkers bounds concurrent live-session recovery during daemon
+	// startup. Values below one preserve the serial default for embedders/tests;
+	// production explicitly opts into a small worker pool.
+	ReconcileWorkers int
 	// BackgroundContext owns work admitted by request-scoped methods. Nil keeps
 	// focused tests and embedders compatible by defaulting to Background.
 	BackgroundContext context.Context
@@ -598,6 +603,7 @@ func New(d Deps) *Manager {
 		attachmentSuffix:             randomSuffix,
 		dataDir:                      d.DataDir,
 		clock:                        d.Clock,
+		reconcileWorkers:             d.ReconcileWorkers,
 		openTranscriptFile:           os.Open,
 		lookPath:                     d.LookPath,
 		executable:                   d.Executable,
@@ -635,6 +641,9 @@ func New(d Deps) *Manager {
 		// write (rename, activity) — all of which use time.Now().UTC(). A local
 		// default produced mixed-timezone timestamps in `ao session get`.
 		m.clock = func() time.Time { return time.Now().UTC() }
+	}
+	if m.reconcileWorkers < 1 {
+		m.reconcileWorkers = 1
 	}
 	if m.backgroundContext == nil {
 		m.backgroundContext = context.Background()
@@ -1937,16 +1946,13 @@ func (m *Manager) saveAndTeardownOne(ctx context.Context, rec domain.SessionReco
 // reconcileLive handles a single non-terminated session on boot. If its runtime
 // session is still alive (tmux is the persistence layer, so it survives a daemon
 // crash) we adopt it: a no-op, the agent keeps running. If the runtime is gone,
-// the agent died with the daemon, so we save-and-tear-down to the SAME end state
-// a graceful shutdown produces: capture uncommitted work into a preserve ref,
-// record the session_worktrees restore marker, mark terminated, and remove the
-// worktree. RestoreAll (which Reconcile runs immediately after) then relaunches
-// it on this same boot, resuming history. Crash recovery thus matches graceful
-// restart instead of silently abandoning the session.
+// reattach the existing worktree and relaunch the controller in place. An
+// ordinary daemon restart must not turn every live session into a serial
+// stash/remove/recreate cycle before the HTTP listener can bind.
 //
-// If the work capture fails we mark terminated WITHOUT a marker and leave the
-// worktree intact: better to skip the relaunch than to tear down un-preserved
-// work or relaunch onto an inconsistent worktree.
+// The old capture-and-teardown path remains the safety fallback when in-place
+// recovery fails. It records a durable restore marker before removing anything,
+// so RestoreAll can retry without risking uncommitted work.
 func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) error {
 	project, err := m.loadProject(ctx, rec.ProjectID)
 	if err != nil {
@@ -1958,10 +1964,7 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 	}
 	// A chat controller is an in-process child of the daemon, so unlike tmux it can
 	// never have survived the crash: there is nothing to adopt and nothing to
-	// probe. It falls through to the same save-and-teardown a dead runtime gets,
-	// which is what records the restore marker RestoreAll needs — skipping that
-	// would leave the session marked live with no controller behind it, and it
-	// would never be resumed.
+	// probe. It falls through to the same in-place relaunch as a dead TUI runtime.
 	isChat := domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat
 
 	if !isChat {
@@ -1972,7 +1975,7 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 			case err == nil:
 			case errors.Is(err, ports.ErrRuntimeUnavailable):
 				// Normal after a machine reboot: the runtime is conclusively gone,
-				// so preserve work and create the restore marker below.
+				// so proceed to the in-place relaunch below.
 				alive = false
 			default:
 				// A failed probe is not proof of death: leave the session as-is.
@@ -1986,6 +1989,23 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 	if projectKind == domain.ProjectKindScratch {
 		return m.lcm.MarkTerminated(ctx, rec.ID)
 	}
+	ws, restoreErr := m.restoreSessionWorkspace(ctx, project, rec)
+	if restoreErr == nil {
+		_, relaunchErr := m.relaunchRestoredSession(ctx, rec, project, ws)
+		if relaunchErr == nil {
+			return nil
+		}
+		committed, verifyErr := m.liveRelaunchCommitted(ctx, rec)
+		if verifyErr != nil {
+			return fmt.Errorf("reconcile %s: relaunch failed (%w), then commit state became uncertain: %w", rec.ID, relaunchErr, verifyErr)
+		}
+		if committed {
+			m.logger.Warn("reconcile: relaunch reported an error after the controller commit; preserving the live session", "sessionID", rec.ID, "error", relaunchErr)
+			return nil
+		}
+		restoreErr = relaunchErr
+	}
+	m.logger.Warn("reconcile: in-place relaunch failed; falling back to save-and-teardown", "sessionID", rec.ID, "error", restoreErr)
 	if err := m.saveAndTeardownOne(ctx, rec, false); err != nil {
 		m.logger.Warn("reconcile: save-and-teardown failed; terminating without restore marker", "sessionID", rec.ID, "error", err)
 		if mErr := m.lcm.MarkTerminated(ctx, rec.ID); mErr != nil {
@@ -1993,6 +2013,29 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 		}
 	}
 	return nil
+}
+
+func (m *Manager) liveRelaunchCommitted(ctx context.Context, before domain.SessionRecord) (bool, error) {
+	after, ok, err := m.store.GetSession(ctx, before.ID)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, ErrNotFound
+	}
+	if after.IsTerminated {
+		return false, nil
+	}
+	if domain.NormalizeSessionMode(before.Mode) == domain.SessionModeChat {
+		generation := after.Metadata.ControllerGeneration
+		return generation != "" && generation != before.Metadata.ControllerGeneration, nil
+	}
+	launchID := after.Metadata.RuntimeLaunchID
+	if launchID != "" && launchID != before.Metadata.RuntimeLaunchID {
+		return true, nil
+	}
+	handleID := after.Metadata.RuntimeHandleID
+	return handleID != "" && handleID != before.Metadata.RuntimeHandleID, nil
 }
 
 // reconcileReap kills the leaked tmux session of a session the DB already marks
@@ -2051,18 +2094,7 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("reconcile: list sessions: %w", err)
 	}
-	for _, rec := range recs {
-		if rec.IsTerminated {
-			continue
-		}
-		if m.SessionMutationInProgress(rec.ID) {
-			m.logger.Warn("reconcile: session remains input-gated pending unambiguous agent-switch recovery", "sessionID", rec.ID)
-			continue
-		}
-		if err := m.reconcileLive(ctx, rec); err != nil {
-			m.logger.Error("reconcile: live pass failed, skipping", "sessionID", rec.ID, "error", err)
-		}
-	}
+	m.reconcileLivePass(ctx, recs)
 	for _, rec := range recs {
 		if !rec.IsTerminated {
 			continue
@@ -2079,6 +2111,45 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 	}
 	m.wakeTransitionMessageDispatcher()
 	return nil
+}
+
+func (m *Manager) reconcileLivePass(ctx context.Context, recs []domain.SessionRecord) {
+	live := make([]domain.SessionRecord, 0, len(recs))
+	for _, rec := range recs {
+		if rec.IsTerminated {
+			continue
+		}
+		if m.SessionMutationInProgress(rec.ID) {
+			m.logger.Warn("reconcile: session remains input-gated pending unambiguous agent-switch recovery", "sessionID", rec.ID)
+			continue
+		}
+		live = append(live, rec)
+	}
+	if len(live) == 0 {
+		return
+	}
+	workers := m.reconcileWorkers
+	if workers > len(live) {
+		workers = len(live)
+	}
+	jobs := make(chan domain.SessionRecord)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for rec := range jobs {
+				if err := m.reconcileLive(ctx, rec); err != nil {
+					m.logger.Error("reconcile: live pass failed, skipping", "sessionID", rec.ID, "error", err)
+				}
+			}
+		}()
+	}
+	for _, rec := range live {
+		jobs <- rec
+	}
+	close(jobs)
+	wg.Wait()
 }
 
 // RestoreAll relaunches every terminated session that was saved by the last

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ type fakeStore struct {
 	upsertWTErr   error
 	listAllErr    error
 	getProjectErr error
+	getSessionErr error
 	// agentSwitchStore is wired only by agent-switch tests so fakeLCM can model
 	// Lifecycle Manager's atomic ownership-boundary commands.
 	agentSwitchStore any
@@ -84,6 +86,9 @@ func (f *fakeStore) RecordSessionLatestUserPrompt(_ context.Context, id domain.S
 	return true, nil
 }
 func (f *fakeStore) GetSession(_ context.Context, id domain.SessionID) (domain.SessionRecord, bool, error) {
+	if f.getSessionErr != nil {
+		return domain.SessionRecord{}, false, f.getSessionErr
+	}
 	r, ok := f.sessions[id]
 	return r, ok, nil
 }
@@ -325,6 +330,26 @@ type blockingRestartRuntime struct {
 	*fakeRuntime
 	entered chan struct{}
 	release chan struct{}
+}
+
+type blockingAliveRuntime struct {
+	*fakeRuntime
+	entered chan domain.SessionID
+	release chan struct{}
+}
+
+func (r *blockingAliveRuntime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error) {
+	select {
+	case r.entered <- domain.SessionID(handle.ID):
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+	select {
+	case <-r.release:
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
 }
 
 func (r *blockingRestartRuntime) Restart(_ context.Context, handle ports.RuntimeHandle, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
@@ -6411,8 +6436,9 @@ func TestRestoreAll_WorkspaceProjectRootOnlyMarkerRestoresRegisteredChildren(t *
 	}
 }
 
-func TestReconcileLive_DeadSessionStashedAndTerminated(t *testing.T) {
+func TestReconcileLive_DeadSessionRelaunchesInExistingWorktree(t *testing.T) {
 	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
 	rt := &fakeRuntime{aliveByHandle: map[string]bool{}} // handle not alive
 	ws := &fakeWorkspace{stashRef: "refs/ao/preserved/s1"}
 	lcm := &fakeLCM{store: st}
@@ -6422,48 +6448,45 @@ func TestReconcileLive_DeadSessionStashedAndTerminated(t *testing.T) {
 	rec := domain.SessionRecord{
 		ID:           "s1",
 		ProjectID:    "p1",
+		Harness:      domain.HarnessClaudeCode,
 		IsTerminated: false,
 		Metadata: domain.SessionMetadata{
-			Branch: "ao/s1/root", WorkspacePath: "/wt/s1", RuntimeHandleID: "s1",
+			Branch: "ao/s1/root", WorkspacePath: "/wt/s1", RuntimeHandleID: "s1", AgentSessionID: "agent-s1",
 		},
 	}
+	st.sessions[rec.ID] = rec
 
 	if err := m.reconcileLive(context.Background(), rec); err != nil {
 		t.Fatalf("reconcileLive: %v", err)
 	}
-	if ws.stashCalls != 1 {
-		t.Fatalf("StashUncommitted calls = %d, want 1", ws.stashCalls)
+	if ws.stashCalls != 0 {
+		t.Fatalf("StashUncommitted calls = %d, want 0", ws.stashCalls)
 	}
-	if lcm.terminated["s1"] != 1 {
-		t.Fatalf("MarkTerminated(s1) = %d, want 1", lcm.terminated["s1"])
+	if lcm.terminated["s1"] != 0 {
+		t.Fatalf("MarkTerminated(s1) = %d, want 0", lcm.terminated["s1"])
 	}
-	if rt.destroyed != 0 {
-		t.Fatalf("Destroy calls = %d, want 0 (dead session: no tmux to kill)", rt.destroyed)
+	if rt.created != 1 {
+		t.Fatalf("Create calls = %d, want 1", rt.created)
 	}
-	// The crash-orphaned session must be saved for restore, exactly like a
-	// graceful shutdown: a session_worktrees marker carrying the preserve ref,
-	// and the worktree torn down so RestoreAll re-creates it clean.
-	rows := st.worktrees["s1"]
-	if len(rows) != 1 || rows[0].PreservedRef != "refs/ao/preserved/s1" {
-		t.Fatalf("session_worktrees marker for s1 = %+v, want one row with the preserve ref", rows)
+	if st.sessions["s1"].IsTerminated {
+		t.Fatal("reconciled session must remain live")
 	}
-	foundForceDestroy := false
+	if len(ws.restoreConfigs) != 1 || ws.restoreConfigs[0].Path != "/wt/s1" {
+		t.Fatalf("Restore configs = %+v, want the existing worktree path", ws.restoreConfigs)
+	}
 	for _, c := range ws.calls {
 		if c == "ForceDestroy:s1" {
-			foundForceDestroy = true
+			t.Fatalf("reconcileLive must preserve the existing worktree; calls = %v", ws.calls)
 		}
 	}
-	if !foundForceDestroy {
-		t.Fatalf("reconcileLive must ForceDestroy the worktree after capturing work; calls = %v", ws.calls)
+	if rows := st.worktrees["s1"]; len(rows) != 0 {
+		t.Fatalf("in-place recovery must not create a restore marker; got %+v", rows)
 	}
 }
 
-// TestReconcileLive_ClosesScopedShellTerminalsBeforeForceDestroy is the boot
-// path (crash recovery) half of the shutdown save-and-teardown coverage: it
-// calls the same saveAndTeardownOne SaveAndTeardownAll does, so the gate must
-// fire here too, not just for a graceful shutdown.
-func TestReconcileLive_ClosesScopedShellTerminalsBeforeForceDestroy(t *testing.T) {
+func TestReconcileLive_PreservesScopedShellTerminalsWithExistingWorktree(t *testing.T) {
 	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
 	rt := &fakeRuntime{aliveByHandle: map[string]bool{}} // handle not alive
 	ws := &fakeWorkspace{stashRef: "refs/ao/preserved/s1"}
 	var sharedLog []string
@@ -6477,38 +6500,108 @@ func TestReconcileLive_ClosesScopedShellTerminalsBeforeForceDestroy(t *testing.T
 	rec := domain.SessionRecord{
 		ID:           "s1",
 		ProjectID:    "p1",
+		Harness:      domain.HarnessClaudeCode,
 		IsTerminated: false,
 		Metadata: domain.SessionMetadata{
-			Branch: "ao/s1/root", WorkspacePath: "/wt/s1", RuntimeHandleID: "s1",
+			Branch: "ao/s1/root", WorkspacePath: "/wt/s1", RuntimeHandleID: "s1", AgentSessionID: "agent-s1",
 		},
 	}
+	st.sessions[rec.ID] = rec
 
 	if err := m.reconcileLive(context.Background(), rec); err != nil {
 		t.Fatalf("reconcileLive: %v", err)
 	}
 
-	if len(closer.began) != 1 || closer.began[0] != "s1" {
-		t.Fatalf("began = %v, want [s1]", closer.began)
+	if len(closer.began) != 0 {
+		t.Fatalf("began = %v, want no shell teardown", closer.began)
 	}
-	if len(closer.ended) != 1 || closer.ended[0] != "s1" {
-		t.Fatalf("ended = %v, want [s1]", closer.ended)
+	if len(closer.ended) != 0 {
+		t.Fatalf("ended = %v, want no shell teardown", closer.ended)
 	}
-	beginIdx, forceIdx, endIdx := -1, -1, -1
-	for i, c := range sharedLog {
-		switch c {
-		case "BeginSessionTeardown:s1":
-			beginIdx = i
-		case "ForceDestroy:s1":
-			forceIdx = i
-		case "EndSessionTeardown:s1":
-			endIdx = i
+	if strings.Contains(strings.Join(sharedLog, ","), "ForceDestroy:s1") {
+		t.Fatalf("existing worktree must not be destroyed; call log = %v", sharedLog)
+	}
+}
+
+func TestReconcileLive_RelaunchFailureFallsBackToCapturedTeardown(t *testing.T) {
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	rt := &fakeRuntime{aliveByHandle: map[string]bool{}}
+	ws := &fakeWorkspace{
+		createErr: errors.New("worktree cannot be reattached"),
+		stashRef:  "refs/ao/preserved/s1",
+	}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: lcm,
+		LookPath: func(string) (string, error) { return "/bin/true", nil },
+	})
+	rec := domain.SessionRecord{
+		ID: "s1", ProjectID: "p1", Harness: domain.HarnessClaudeCode,
+		Metadata: domain.SessionMetadata{
+			Branch: "ao/s1/root", WorkspacePath: "/wt/s1", RuntimeHandleID: "old", AgentSessionID: "agent-s1",
+		},
+	}
+	st.sessions[rec.ID] = rec
+
+	if err := m.reconcileLive(context.Background(), rec); err != nil {
+		t.Fatalf("reconcileLive: %v", err)
+	}
+	if ws.stashCalls != 1 || lcm.terminated[rec.ID] != 1 {
+		t.Fatalf("fallback must capture and terminate: stash=%d terminated=%d", ws.stashCalls, lcm.terminated[rec.ID])
+	}
+	rows := st.worktrees[rec.ID]
+	if len(rows) != 1 || rows[0].PreservedRef != ws.stashRef {
+		t.Fatalf("fallback restore marker = %+v, want preserve ref %q", rows, ws.stashRef)
+	}
+	foundForceDestroy := false
+	for _, call := range ws.calls {
+		if call == "ForceDestroy:s1" {
+			foundForceDestroy = true
 		}
 	}
-	if beginIdx == -1 || forceIdx == -1 || endIdx == -1 {
-		t.Fatalf("call log missing expected entries: %v", sharedLog)
+	if !foundForceDestroy {
+		t.Fatalf("fallback must remove the captured worktree; calls=%v", ws.calls)
 	}
-	if beginIdx >= forceIdx || forceIdx >= endIdx {
-		t.Fatalf("call order = %v, want begin, then force destroy, then end", sharedLog)
+}
+
+func TestReconcileLive_DoesNotTeardownAfterUncertainRelaunchCommit(t *testing.T) {
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	rt := &fakeRuntime{aliveByHandle: map[string]bool{}}
+	ws := &fakeWorkspace{stashRef: "refs/ao/preserved/s1"}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: lcm,
+		LookPath: func(string) (string, error) { return "/bin/true", nil },
+	})
+	rec := domain.SessionRecord{
+		ID: "s1", ProjectID: "p1", Harness: domain.HarnessClaudeCode,
+		Metadata: domain.SessionMetadata{
+			Branch: "ao/s1/root", WorkspacePath: "/wt/s1", RuntimeHandleID: "old", AgentSessionID: "agent-s1",
+		},
+	}
+	st.sessions[rec.ID] = rec
+	// MarkSpawned commits through the lifecycle fake, then relaunchSession reads
+	// the row back. Model storage becoming unavailable only at that final read.
+	st.getSessionErr = errors.New("readback unavailable")
+
+	err := m.reconcileLive(context.Background(), rec)
+	if err == nil {
+		t.Fatal("reconcileLive must report uncertain durable controller state")
+	}
+	if rt.created != 1 {
+		t.Fatalf("Create calls = %d, want 1 controller launched before readback failed", rt.created)
+	}
+	if ws.stashCalls != 0 || lcm.terminated[rec.ID] != 0 {
+		t.Fatalf("uncertain live controller must keep its worktree intact: stash=%d terminated=%d", ws.stashCalls, lcm.terminated[rec.ID])
+	}
+	for _, call := range ws.calls {
+		if call == "ForceDestroy:s1" {
+			t.Fatalf("uncertain live controller must not lose its worktree; calls=%v", ws.calls)
+		}
 	}
 }
 
@@ -6530,6 +6623,50 @@ func TestReconcileLive_AliveSessionAdoptedNoop(t *testing.T) {
 	}
 	if ws.stashCalls != 0 || lcm.terminated["s2"] != 0 || rt.destroyed != 0 {
 		t.Fatalf("adopt should be a no-op: stash=%d term=%d destroy=%d", ws.stashCalls, lcm.terminated["s2"], rt.destroyed)
+	}
+}
+
+func TestReconcile_LivePassUsesConfiguredConcurrency(t *testing.T) {
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	for _, id := range []domain.SessionID{"s1", "s2"} {
+		st.sessions[id] = domain.SessionRecord{
+			ID: id, ProjectID: "p1", Harness: domain.HarnessClaudeCode,
+			Metadata: domain.SessionMetadata{
+				Branch: "ao/" + string(id) + "/root", WorkspacePath: "/wt/" + string(id), RuntimeHandleID: string(id),
+			},
+		}
+	}
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAll := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseAll()
+	rt := &blockingAliveRuntime{
+		fakeRuntime: &fakeRuntime{},
+		entered:     make(chan domain.SessionID, 2),
+		release:     release,
+	}
+	m := New(Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: &fakeWorkspace{}, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+		LookPath:         func(string) (string, error) { return "/bin/true", nil },
+		ReconcileWorkers: 2,
+	})
+	done := make(chan error, 1)
+	go func() { done <- m.Reconcile(context.Background()) }()
+
+	seen := map[domain.SessionID]bool{}
+	for len(seen) < 2 {
+		select {
+		case id := <-rt.entered:
+			seen[id] = true
+		case <-time.After(time.Second):
+			t.Fatalf("live probes did not overlap; entered = %v", seen)
+		}
+	}
+	releaseAll()
+	if err := <-done; err != nil {
+		t.Fatalf("Reconcile: %v", err)
 	}
 }
 
@@ -6616,9 +6753,8 @@ func TestReconcileLive_ScratchDeadRuntimeTerminatesWithoutWorkspaceTeardown(t *t
 //     never torn down, and NO new session minted (the id-increment regression
 //     guard: adoption failure used to mint a fresh orchestrator id 14->15->16).
 //   - an alive worker is adopted as a no-op.
-//   - a worker whose runtime died with the daemon has its work captured (stashed
-//     into a preserve ref, restore marker written) and is relaunched on this same
-//     boot under its ORIGINAL id.
+//   - a worker whose runtime died with the daemon is relaunched in its existing
+//     worktree on this same boot under its ORIGINAL id.
 //   - a truly-dead session with no restore marker is NOT resurrected.
 func TestReconcile_AdoptAcrossDaemonRestart(t *testing.T) {
 	st := newFakeStore()
@@ -6644,7 +6780,8 @@ func TestReconcile_AdoptAcrossDaemonRestart(t *testing.T) {
 		ID: "mer-2", ProjectID: "mer", Kind: domain.KindWorker, Harness: domain.HarnessClaudeCode,
 		Metadata: domain.SessionMetadata{Branch: "ao/mer-2/root", WorkspacePath: "/ws/mer-2", RuntimeHandleID: "w-alive", AgentSessionID: "agent-2"},
 	}
-	// Dead worker: its runtime died with the daemon; capture + relaunch under same id.
+	// Dead worker: its runtime died with the daemon; relaunch under the same id
+	// without tearing down the worktree first.
 	st.sessions["mer-3"] = domain.SessionRecord{
 		ID: "mer-3", ProjectID: "mer", Kind: domain.KindWorker, Harness: domain.HarnessClaudeCode,
 		Metadata: domain.SessionMetadata{Branch: "ao/mer-3/root", WorkspacePath: "/ws/mer-3", RuntimeHandleID: "w-dead", AgentSessionID: "agent-3"},
@@ -6675,9 +6812,10 @@ func TestReconcile_AdoptAcrossDaemonRestart(t *testing.T) {
 	if rt.destroyed != 0 {
 		t.Fatalf("adopted sessions must not be destroyed; Destroy called %d times", rt.destroyed)
 	}
-	// Dead worker captured, then relaunched under its original id on this same boot.
-	if lcm.terminated["mer-3"] != 1 {
-		t.Fatalf("dead worker must be marked terminated once before relaunch; got %d", lcm.terminated["mer-3"])
+	// Dead worker relaunched under its original id on this same boot without an
+	// intermediate durable termination or worktree capture cycle.
+	if lcm.terminated["mer-3"] != 0 {
+		t.Fatalf("dead worker must not be marked terminated before relaunch; got %d", lcm.terminated["mer-3"])
 	}
 	if st.sessions["mer-3"].IsTerminated {
 		t.Fatal("dead worker must be relaunched (not terminated) after Reconcile")
@@ -6685,7 +6823,10 @@ func TestReconcile_AdoptAcrossDaemonRestart(t *testing.T) {
 	if rt.created != 1 {
 		t.Fatalf("exactly one runtime relaunch expected (the dead worker); got %d", rt.created)
 	}
-	// One-shot restore marker consumed so it never outlives one restart (#2319).
+	if ws.stashCalls != 0 {
+		t.Fatalf("dead worker must reuse its worktree without stashing; got %d stash calls", ws.stashCalls)
+	}
+	// In-place recovery needs no one-shot restore marker.
 	if rows := st.worktrees["mer-3"]; len(rows) != 0 {
 		t.Fatalf("restore marker for mer-3 must be deleted after relaunch; got %+v", rows)
 	}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -46,6 +46,10 @@ import { pathToFileURL } from "node:url";
 import { type DaemonLaunchSpec, bundledDaemonIdentityError, resolveDaemonLaunch } from "./shared/daemon-launch";
 import { createListenPortScanner, defaultRunFilePath, parseRunFile } from "./shared/daemon-discovery";
 import type { DaemonStatus } from "./shared/daemon-status";
+import {
+	refreshSlowDaemonStartupDetails,
+	slowDaemonStartupStatus,
+} from "./shared/daemon-startup-status";
 import { attachAppShortcuts } from "./main/app-shortcuts";
 import {
 	KEYBOARD_SHORTCUTS_HELP_CHANNEL,
@@ -310,6 +314,8 @@ const MAX_DAEMON_OUTPUT_CHARS = 12_000;
 
 function appendDaemonOutput(text: string): void {
 	daemonOutput = (daemonOutput + text).slice(-MAX_DAEMON_OUTPUT_CHARS);
+	const nextStatus = refreshSlowDaemonStartupDetails(daemonStatus, daemonOutput);
+	if (nextStatus !== daemonStatus) setDaemonStatus(nextStatus);
 }
 
 // Menu installed on Windows where the native menu bar is hidden. The bar stays
@@ -1319,30 +1325,22 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		}, RUN_FILE_POLL_MS);
 	}
 
-	// Neither source confirmed startup. Surface the captured process output so
-	// the renderer can explain why boot stalled instead of spinning forever or
-	// attempting workspace requests against an assumed port.
+	// Neither source confirmed startup yet. The child is still alive and both
+	// discovery mechanisms remain active, so surface this as slow progress rather
+	// than a failure. A later listen line or running.json handshake still moves
+	// the same launch to ready.
 	fallbackTimer = setTimeout(() => {
 		if (portConfirmed || daemonProcess !== child || daemonStoppingProcess === child) return;
-		// Keep running.json polling alive after surfacing the timeout. In
+		// Keep running.json polling alive after surfacing slow startup. In
 		// keep-daemon mode there are no stdout/stderr scanners, so the run file is
 		// the only way a slow-but-successful boot can still recover to ready.
 		fallbackTimer = undefined;
-		setDaemonStatus({
-			state: "error",
-			message: "AO daemon did not finish starting within 30 seconds.",
-			details:
-				daemonOutput.trim() ||
-				[
-					"No startup output was captured.",
-					`Executable: ${launch.command}`,
-					`Working directory: ${launch.cwd}`,
-					`Expected port confirmation from: ${handshakePath ?? "running.json"}`,
-				].join("\n"),
-			code: "not_ready",
+		setDaemonStatus(slowDaemonStartupStatus({
+			output: daemonOutput,
 			executablePath: launch.command,
 			workingDirectory: launch.cwd,
-		});
+			handshakePath,
+		}));
 	}, PORT_DISCOVERY_TIMEOUT_MS);
 
 	child.once("error", (error) => {

--- a/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
@@ -66,6 +66,25 @@ describe("DaemonFailureBanner", () => {
 		expect(container).toBeEmptyDOMElement();
 	});
 
+	it("shows slow startup as progress without offering a restart", () => {
+		render(
+			<DaemonFailureBanner
+				status={{
+					state: "starting",
+					message: "AO daemon is still starting. Session recovery can take a while.",
+					details: "restoring session mer-3",
+				}}
+			/>,
+		);
+
+		expect(screen.getByRole("status")).toHaveTextContent("AO daemon is not ready yet");
+		expect(screen.getByRole("status")).toHaveTextContent("AO daemon is still starting");
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Restart daemon" })).not.toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Show details" }));
+		expect(screen.getByText("restoring session mer-3")).toBeInTheDocument();
+	});
+
 	it("updates an already-mounted failure when the language changes", async () => {
 		render(<DaemonFailureBanner status={{ state: "error", code: "not_ready" }} />);
 		expect(screen.getByRole("button", { name: "Restart daemon" })).toBeInTheDocument();

--- a/frontend/src/renderer/components/DaemonFailureBanner.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.tsx
@@ -1,12 +1,13 @@
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Clock3 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { DaemonStatus } from "../../shared/daemon-status";
+import { isSlowDaemonStartupStatus } from "../../shared/daemon-startup-status";
 import { daemonFailureHint, daemonFailureMessage, daemonFailureTitle } from "../lib/daemon-failure";
 import { aoBridge } from "../lib/bridge";
 
 export function DaemonFailureBanner({ status }: { status: DaemonStatus }) {
-	if (!status.code || status.state === "ready") return null;
+	if ((!status.code && !isSlowDaemonStartupStatus(status)) || status.state === "ready") return null;
 	return <DaemonFailureContent status={status} />;
 }
 
@@ -17,15 +18,17 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 	const [restarting, setRestarting] = useState(false);
 	const [restartError, setRestartError] = useState<string | null>(null);
 	const copiedTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const slowStartup = isSlowDaemonStartupStatus(status);
 	const details = status.details?.trim();
-	const hint = daemonFailureHint(status, t);
-	const title = daemonFailureTitle(status, t);
+	const hint = slowStartup ? "" : daemonFailureHint(status, t);
+	const title = slowStartup ? t("daemon.title.notReady") : daemonFailureTitle(status, t);
 	const canRestart =
-		status.code === "not_ready" ||
-		status.code === "spawn_failed" ||
-		status.code === "exited" ||
-		status.code === "identity_mismatch" ||
-		status.code === "daemon_unreachable";
+		!slowStartup &&
+		(status.code === "not_ready" ||
+			status.code === "spawn_failed" ||
+			status.code === "exited" ||
+			status.code === "identity_mismatch" ||
+			status.code === "daemon_unreachable");
 	useEffect(() => {
 		setCopied(false);
 		return () => {
@@ -35,7 +38,7 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 	const copyDetails = async () => {
 		const lines = [
 			title,
-			t("daemon.details.code", { code: status.code ?? "unknown" }),
+			status.code ? t("daemon.details.code", { code: status.code }) : "",
 			t("daemon.details.message", { message: daemonFailureMessage(status, t) }),
 			details ? `\n${t("daemon.details.heading", { details })}` : "",
 		];
@@ -63,15 +66,22 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 	};
 	return (
 		<section
-			aria-live="assertive"
+			aria-live={slowStartup ? "polite" : "assertive"}
 			className="pointer-events-auto fixed top-3 right-3 z-overlay flex w-daemon-failure-toast flex-col rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-modal)] px-3.5 py-3 text-xs shadow-[var(--shadow-import-modal)]"
-			role="alert"
+			role={slowStartup ? "status" : "alert"}
 		>
 			<div className="flex items-start gap-3">
-				<AlertTriangle className="mt-0.5 size-icon-base shrink-0 text-error" aria-hidden="true" />
+				{slowStartup ? (
+					<Clock3
+						className="mt-0.5 size-icon-base shrink-0 text-[var(--color-text-import-muted)]"
+						aria-hidden="true"
+					/>
+				) : (
+					<AlertTriangle className="mt-0.5 size-icon-base shrink-0 text-error" aria-hidden="true" />
+				)}
 				<div className="min-w-0 flex-1">
 					<p className="font-medium text-(--color-text-import-title)">{title}</p>
-					<p className="mt-0.5 wrap-break-word text-[var(--color-text-import-muted)]">
+					<p className="mt-0.5 wrap-break-word text-pretty text-[var(--color-text-import-muted)]">
 						{daemonFailureMessage(status, t)}
 					</p>
 					{hint ? <p className="mt-1 text-[var(--color-text-import-muted)]">{hint}</p> : null}

--- a/frontend/src/shared/daemon-startup-status.test.ts
+++ b/frontend/src/shared/daemon-startup-status.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+	refreshSlowDaemonStartupDetails,
+	slowDaemonStartupStatus,
+} from "./daemon-startup-status";
+
+describe("slowDaemonStartupStatus", () => {
+	it("keeps a live child in starting state and refreshes captured output", () => {
+		const status = slowDaemonStartupStatus({
+			output: "initial recovery output",
+			executablePath: "/Applications/AO.app/ao",
+			workingDirectory: "/Users/example/.ao",
+			handshakePath: "/Users/example/.ao/running.json",
+		});
+
+		expect(status).toMatchObject({
+			state: "starting",
+			message: "AO daemon is still starting. Session recovery can take a while.",
+			details: "initial recovery output",
+			executablePath: "/Applications/AO.app/ao",
+			workingDirectory: "/Users/example/.ao",
+		});
+		expect(status.code).toBeUndefined();
+
+		expect(refreshSlowDaemonStartupDetails(status, "latest recovery output")).toMatchObject({
+			state: "starting",
+			details: "latest recovery output",
+		});
+	});
+
+	it("does not rewrite an ordinary starting status", () => {
+		const status = { state: "starting" as const };
+		expect(refreshSlowDaemonStartupDetails(status, "output")).toBe(status);
+	});
+});

--- a/frontend/src/shared/daemon-startup-status.ts
+++ b/frontend/src/shared/daemon-startup-status.ts
@@ -1,0 +1,44 @@
+import type { DaemonStatus } from "./daemon-status";
+
+export const SLOW_DAEMON_START_MESSAGE =
+	"AO daemon is still starting. Session recovery can take a while.";
+
+type SlowDaemonStartupInput = {
+	output: string;
+	executablePath: string;
+	workingDirectory: string;
+	handshakePath: string | null;
+};
+
+export function slowDaemonStartupStatus(input: SlowDaemonStartupInput): DaemonStatus {
+	return {
+		state: "starting",
+		message: SLOW_DAEMON_START_MESSAGE,
+		details: startupDetails(input),
+		executablePath: input.executablePath,
+		workingDirectory: input.workingDirectory,
+	};
+}
+
+export function isSlowDaemonStartupStatus(status: DaemonStatus): boolean {
+	return status.state === "starting" && status.message === SLOW_DAEMON_START_MESSAGE;
+}
+
+export function refreshSlowDaemonStartupDetails(status: DaemonStatus, output: string): DaemonStatus {
+	const details = output.trim();
+	if (!isSlowDaemonStartupStatus(status) || !details || details === status.details) {
+		return status;
+	}
+	return { ...status, details };
+}
+
+function startupDetails(input: SlowDaemonStartupInput): string {
+	const output = input.output.trim();
+	if (output) return output;
+	return [
+		"No startup output was captured yet.",
+		`Executable: ${input.executablePath}`,
+		`Working directory: ${input.workingDirectory}`,
+		`Expected port confirmation from: ${input.handshakePath ?? "running.json"}`,
+	].join("\n");
+}


### PR DESCRIPTION
Fixes #4064

## What changed

- Relaunch dead TUI and Chat controllers in their existing registered worktrees during startup instead of serially stashing, removing, recreating, and reapplying every worktree.
- Bound live-session reconciliation with four workers and reuse successful Chat capability probes for the daemon lifetime.
- Keep the durable capture/marker/teardown path as the safety fallback when an in-place relaunch cannot commit.
- Treat the Electron supervisor's 30-second threshold as slow progress while the child is still alive: use polite status semantics, keep startup details fresh, omit the misleading restart action, and transition automatically when readiness arrives.

## Why

The reported 4m36s startup was dominated by an O(N) destructive restore cycle. A machine reboot or native-runtime loss does not require AO to move a registered worktree at all: the durable session and worktree are already the state to recover. Relaunching the controller in place avoids expensive Git/antivirus work and removes the riskiest part of normal startup. The UI change also stops a healthy, progressing process from being labeled as failed if recovery still exceeds 30 seconds on slower machines.

## End-to-end verification

I launched the real Electron app from this checkout against an isolated `AO_DATA_DIR` and `AO_RUN_FILE`. The fixture used a real SQLite database, Git repository/worktrees, tmux sessions, and `ao agent-process supervise`; only the final model executable was a deterministic local stub so the drill made no provider calls.

1. Registered one project and spawned eight real sessions (`Recovery 01` through `Recovery 08`).
2. Added a unique uncommitted sentinel to every registered worktree and recorded each SHA-256 plus the original launch generation.
3. Stopped the app and killed only those eight runtime sessions, leaving all eight durable session rows live.
4. Restarted the real daemon. Resolver log to loopback listener: **1,174 ms**. All eight controller generations rotated; IDs and workspace paths stayed unchanged; all eight sentinel hashes were identical; no restore markers, stash operations, force-destroys, or fallback teardowns occurred.
5. Launched the real Electron supervisor behind a controlled startup gate. At **53 seconds**, the app still showed progress with live details, zero alert roles, and zero restart actions. Releasing the same supervised process cleared the banner automatically and loaded all eight sessions on the real board.

The local runtime drill used tmux on macOS. Windows ConPTY follows the same runtime contract; dead-runtime and Chat recovery, fallback safety, uncertain-commit handling, and worker concurrency are covered at the manager boundary.

### Slow startup after 53 seconds

![AO shows a neutral slow-start status with live details and no restart action](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-daemon-startup-readiness-4064/.issue-assets/daemon-startup-readiness-4064/01-slow-start.png)

### Automatic transition to the recovered board

![AO board after the same supervised process becomes ready, showing eight recovered sessions](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-daemon-startup-readiness-4064/.issue-assets/daemon-startup-readiness-4064/02-recovered-board.png)

Machine-readable evidence: [direct daemon recovery assertions](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-daemon-startup-readiness-4064/.issue-assets/daemon-startup-readiness-4064/direct-recovery-result.json), [Electron transition assertions](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-daemon-startup-readiness-4064/.issue-assets/daemon-startup-readiness-4064/electron-e2e-result.json), and [direct daemon log](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-daemon-startup-readiness-4064/.issue-assets/daemon-startup-readiness-4064/direct-recovery.log).

## Verification commands

- `cd backend && go test ./... -count=1 -p 4 && go build ./... && go vet ./...`
- `cd backend && go test -race ./internal/session_manager ./internal/service/chat`
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs` — 0 issues
- `cd frontend && npm run typecheck`
- `cd frontend && npm test` — 190 files, 2,483 passed, 1 skipped
- `cd frontend && npm run package` — production Electron package built successfully for darwin-arm64

The GitHub/GitLab `no usable token` warnings visible in the original report remain benign optional-tracker degradation and are unrelated to readiness.
