### PR TITLE
feat: validate workspace import before worker harness selection

### DIFF
--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -95,6 +95,27 @@ export function CreateProjectFlow({
 				} catch {
 					// Ancestor check failed — proceed without warning
 				}
+				// Preflight: scan workspace children and require at least one
+				// fully resolved repo before advancing to harness selection.
+				try {
+					const scan = await aoBridge.app.scanImportFolder({ path, mode: "workspace" });
+					const hasReadyRepo = scan.repos.some(
+						(repo) => repo.status !== "error" && repo.hasRemote && !repo.needsGitInit,
+					);
+					if (!hasReadyRepo) {
+						setError(
+							scan.repos.length === 0
+								? t("createProject.workspaceNoRepos")
+								: t("createProject.workspaceNoReadyRepos"),
+						);
+						setValidationScan(scan);
+						setModePickerOpen(false);
+						setFolderPickerOpen(true);
+						return;
+					}
+				} catch {
+					// Scan failed — fall through and let the backend validate.
+				}
 			}
 			if (path) {
 				setModePickerOpen(false);

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -167,6 +167,8 @@
 	"createProject.workspace": "Workspace",
 	"createProject.workspaceAgents": "Workspace-Agenten",
 	"createProject.workspaceDesc": "Mehrere Git-Repos unter einem übergeordneten Ordner.",
+	"createProject.workspaceNoReadyRepos": "Keine vollständig aufgelösten Repositories gefunden. Mindestens ein untergeordnetes Repository muss einen Origin-Remote konfiguriert haben.",
+	"createProject.workspaceNoRepos": "Keine Repositories in diesem Ordner erkannt. Ein Workspace muss mindestens ein untergeordnetes Git-Repository enthalten.",
 	"createProject.workspaceRoot": "Workspace-Root",
 	"daemon.hint.binaryMissing": "Führen Sie npm run build:daemon aus, um den Daemon neu zu bauen.",
 	"daemon.hint.conflict": "Stoppen Sie den konfliktierenden Daemon und starten Sie die Desktop-App neu.",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -167,6 +167,8 @@
 	"createProject.workspace": "Workspace",
 	"createProject.workspaceAgents": "Workspace agents",
 	"createProject.workspaceDesc": "Several Git repos that live under one parent folder.",
+	"createProject.workspaceNoReadyRepos": "No fully resolved repositories found. At least one child repository must have an origin remote configured.",
+	"createProject.workspaceNoRepos": "No repositories detected in this folder. A workspace must contain at least one child git repository.",
 	"createProject.workspaceRoot": "Workspace root",
 	"daemon.hint.binaryMissing": "Run npm run build:daemon to rebuild the daemon.",
 	"daemon.hint.conflict": "Stop the conflicting daemon, then restart the desktop app.",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -169,6 +169,8 @@
 	"createProject.workspace": "Espacio de trabajo",
 	"createProject.workspaceAgents": "Agentes del espacio de trabajo",
 	"createProject.workspaceDesc": "Varios repos Git bajo una carpeta principal.",
+	"createProject.workspaceNoReadyRepos": "No se encontraron repositorios completamente resueltos. Al menos un repositorio secundario debe tener un remoto de origen configurado.",
+	"createProject.workspaceNoRepos": "No se detectaron repositorios en esta carpeta. Un espacio de trabajo debe contener al menos un repositorio git secundario.",
 	"createProject.workspaceRoot": "Raíz del espacio de trabajo",
 	"daemon.hint.binaryMissing": "Ejecuta npm run build:daemon para recompilar el daemon.",
 	"daemon.hint.conflict": "Detén el daemon en conflicto y reinicia la aplicación de escritorio.",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -169,6 +169,8 @@
 	"createProject.workspace": "Espace de travail",
 	"createProject.workspaceAgents": "Agents de l'espace de travail",
 	"createProject.workspaceDesc": "Plusieurs dépôts Git sous un même dossier parent.",
+	"createProject.workspaceNoReadyRepos": "Aucun dépôt entièrement résolu trouvé. Au moins un dépôt enfant doit avoir un remote origin configuré.",
+	"createProject.workspaceNoRepos": "Aucun dépôt détecté dans ce dossier. Un espace de travail doit contenir au moins un dépôt git enfant.",
 	"createProject.workspaceRoot": "Racine de l'espace de travail",
 	"daemon.hint.binaryMissing": "Exécutez npm run build:daemon pour recompiler le daemon.",
 	"daemon.hint.conflict": "Arrêtez le daemon en conflit, puis redémarrez l'application de bureau.",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -167,6 +167,8 @@
 	"createProject.workspace": "ワークスペース",
 	"createProject.workspaceAgents": "ワークスペースエージェント",
 	"createProject.workspaceDesc": "1 つの親フォルダー配下にある複数の Git リポジトリ。",
+	"createProject.workspaceNoReadyRepos": "完全に解決されたリポジトリが見つかりません。少なくとも1つの子リポジトリにoriginリモートが設定されている必要があります。",
+	"createProject.workspaceNoRepos": "このフォルダにリポジトリが検出されませんでした。ワークスペースには少なくとも1つの子gitリポジトリが必要です。",
 	"createProject.workspaceRoot": "ワークスペースルート",
 	"daemon.hint.binaryMissing": "npm run build:daemon を実行してデーモンを再ビルドしてください。",
 	"daemon.hint.conflict": "競合しているデーモンを停止してから、デスクトップアプリを再起動してください。",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -167,6 +167,8 @@
 	"createProject.workspace": "워크스페이스",
 	"createProject.workspaceAgents": "워크스페이스 에이전트",
 	"createProject.workspaceDesc": "하나의 상위 폴더 아래에 있는 여러 Git 저장소.",
+	"createProject.workspaceNoReadyRepos": "완전히 해결된 리포지토리를 찾을 수 없습니다. 하나 이상의 하위 리포지토리에 origin 원격이 구성되어 있어야 합니다.",
+	"createProject.workspaceNoRepos": "이 폴더에서 리포지토리가 감지되지 않았습니다. 워크스페이스에는 하나 이상의 하위 git 리포지토리가 포함되어야 합니다.",
 	"createProject.workspaceRoot": "워크스페이스 루트",
 	"daemon.hint.binaryMissing": "npm run build:daemon을 실행하여 데몬을 다시 빌드하세요.",
 	"daemon.hint.conflict": "충돌하는 데몬을 중지한 뒤 데스크톱 앱을 다시 시작하세요.",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -169,6 +169,8 @@
 	"createProject.workspace": "Workspace",
 	"createProject.workspaceAgents": "Agentes do workspace",
 	"createProject.workspaceDesc": "Vários repositórios Git em uma pasta pai.",
+	"createProject.workspaceNoReadyRepos": "Nenhum repositório totalmente resolvido encontrado. Pelo menos um repositório filho deve ter um remote origin configurado.",
+	"createProject.workspaceNoRepos": "Nenhum repositório detectado nesta pasta. Um workspace deve conter pelo menos um repositório git filho.",
 	"createProject.workspaceRoot": "Raiz do workspace",
 	"daemon.hint.binaryMissing": "Execute npm run build:daemon para recompilar o daemon.",
 	"daemon.hint.conflict": "Pare o daemon em conflito e reinicie o app desktop.",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -167,6 +167,8 @@
 	"createProject.workspace": "工作区",
 	"createProject.workspaceAgents": "工作区代理",
 	"createProject.workspaceDesc": "位于同一父文件夹下的多个 Git 仓库。",
+	"createProject.workspaceNoReadyRepos": "未找到完全解析的仓库。至少一个子仓库必须配置 origin 远程。",
+	"createProject.workspaceNoRepos": "此文件夹中未检测到仓库。工作区必须包含至少一个子 git 仓库。",
 	"createProject.workspaceRoot": "工作区根目录",
 	"daemon.hint.binaryMissing": "请运行 npm run build:daemon 重新构建守护进程。",
 	"daemon.hint.conflict": "请先停止冲突的守护进程，然后重启桌面应用。",


### PR DESCRIPTION
Closes #3955

## Problem

Workspace imports can currently advance to worker agent harness selection (CreateProjectAgentSheet) even when the folder scan includes only unresolved child repos (
eeds_init). The user configures worker and orchestrator agents, clicks submit, and only **then** receives a backend rejection (WORKSPACE_NO_READY_REPOS or WORKSPACE_REPOS_REQUIRED). The validation should happen earlier in the flow so the user is blocked sooner.

## Solution

Added a **workspace preflight scan** in CreateProjectFlow.chooseDirectory() that mirrors the existing single_repo preflight pattern:

1. After the user selects a workspace folder, the frontend calls scanImportFolder({ path, mode: 'workspace' }) before setting selectedPath.
2. It checks whether any child repo is fully resolved (status !== 'error', hasRemote, and not 
eedsGitInit).
3. If **no ready repo exists**, the flow blocks and shows CreateProjectFolderDialog with the scan results and an appropriate error message. The agent harness selection sheet is never opened.
4. 
eeds_init child repos remain visible as **informational rows** (green check + 'Needs git init' label), matching the existing post-error recovery UI.
5. If the scan itself fails (edge case), the code silently falls through and lets the backend validate as before.

The backend WORKSPACE_NO_READY_REPOS / WORKSPACE_REPOS_REQUIRED checks in workspace_registration.go remain untouched as the authoritative backstop.

## Changes

### rontend/src/renderer/components/CreateProjectFlow.tsx`n- Added workspace preflight validation block (21 lines) in chooseDirectory() between the checkAncestorRepo call and the setSelectedPath call.
- Two distinct error messages: one for zero repos detected, one for repos found but none fully resolved.

### i18n locale files (8 files)
Added two new keys to all locale files (en, de, es, r, ja, ko, pt-BR, zh-CN):
- createProject.workspaceNoReadyRepos - shown when repos exist but none have an origin remote
- createProject.workspaceNoRepos - shown when the folder has zero child repos

## Verification

- 
pm run typecheck passes with zero errors in changed files (pre-existing errors in the unrelated packages/product-ui package are not affected).
- The change is purely additive: it adds an early-exit guard path using the same scanImportFolder and CreateProjectFolderDialog infrastructure already used by the post-error recovery flow.

## Notes

This is a follow-up to PR #3729, as noted in the issue.