### PR TITLE
fix: simplify review PR actions

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1940,38 +1940,19 @@ describe("SessionInspector summary reviews", () => {
     expect(summary).not.toHaveTextContent("**auth validation**");
   });
 
-  // An AO pass only gets a review-comment anchor once it is submitted to
-  // GitHub, so without a fallback an unsubmitted pass is a dead end.
-  it("links a run to its GitHub review, falling back to the PR when it has none", async () => {
+  it("does not show a View on PR CTA for review summaries", async () => {
     mockCommonGets([], "reviewer-pane", [
       {
         ...reviewState(3, "up_to_date", "abc123"),
         latestRun: { ...approvedReview, githubReviewId: "98765" },
       },
     ]);
-    const { unmount } = renderWithQuery(
-      <SessionInspector session={session([pr(3, "open")])} />,
-    );
-    await openReviewsSection();
-    expect(
-      await screen.findByRole("link", { name: /View on PR/ }),
-    ).toHaveAttribute(
-      "href",
-      "https://example.com/pr/3#pullrequestreview-98765",
-    );
-    unmount();
 
-    mockCommonGets([], "reviewer-pane", [
-      {
-        ...reviewState(3, "up_to_date", "abc123"),
-        latestRun: { ...approvedReview, githubReviewId: "" },
-      },
-    ]);
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
-    expect(
-      await screen.findByRole("link", { name: /View on PR/ }),
-    ).toBeInTheDocument();
+
+    expect(await screen.findByTestId("review-run-summary")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /View on PR/ })).not.toBeInTheDocument();
   });
 
   it.each([
@@ -2035,10 +2016,7 @@ describe("SessionInspector summary reviews", () => {
         expect(screen.queryByText("Changes requested")).not.toBeInTheDocument();
         expect(screen.queryByText("Earlier commit")).not.toBeInTheDocument();
       }
-      expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
-        "href",
-        "https://example.com/pr/3#pullrequestreview-98765",
-      );
+      expect(screen.queryByRole("link", { name: "View on PR" })).not.toBeInTheDocument();
       // A run in flight gets its own live strip naming the harness, not just a
       // word on the button.
       if (status === "running") {
@@ -2213,8 +2191,11 @@ describe("SessionInspector summary reviews", () => {
       within(externalReview).getByText("Reviewed 3d ago"),
     ).toBeInTheDocument();
     expect(
-      within(externalReview).getByRole("link", { name: "View on PR" }),
-    ).toHaveAttribute("href", "https://example.com/pr/3#pullrequestreview-456");
+      within(externalReview).queryByRole("link", { name: "View on PR" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(externalReview).queryByRole("button", { name: "Request to re-review PR" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("External reviews")).toBeInTheDocument();
   });
 

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1461,6 +1461,7 @@ function MergedReviewsSection({
 			unresolvedByReviewer.delete(entry.reviewerId);
 			return {
 				body: entry.body,
+				canRequestRereview: canRequestPRRereview(entry.verdict, github?.url),
 				id: entry.reviewUrl || `${entry.reviewerId}:${entry.submittedAt}`,
 				pullRequestUrl: github?.url,
 				inlineComments: (reviewer?.links ?? []).map((link) => ({
@@ -1482,6 +1483,7 @@ function MergedReviewsSection({
 		for (const reviewer of unresolvedByReviewer.values()) {
 			externalEntries.push({
 				body: undefined,
+				canRequestRereview: canRequestPRRereview("changes_requested", github?.url),
 				id: `unresolved:${reviewer.reviewerId}:${number}`,
 				pullRequestUrl: github?.url,
 				inlineComments: reviewer.links.map((link) => ({
@@ -1563,6 +1565,11 @@ function MergedReviewsSection({
 			renderMarkdown={renderReviewMarkdown}
 		/>
 	);
+}
+
+function canRequestPRRereview(verdict: string | undefined, pullRequestUrl: string | undefined): boolean {
+	if (!pullRequestUrl) return false;
+	return verdict !== "approved";
 }
 
 function reviewLabels(t: TFunction): InspectorReviewLabels {

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -274,6 +274,7 @@ describe("portable inspector presentations", () => {
     expect(githubSummary).toBeInTheDocument();
     expect(githubSummary).toHaveClass("select-text");
     expect(screen.queryByText("Not injected")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "View on PR" })).not.toBeInTheDocument();
     expect(renderAvatar).toHaveBeenCalledWith("codex");
     expect(renderMarkdown).toHaveBeenCalledTimes(2);
   });
@@ -392,6 +393,47 @@ describe("portable inspector presentations", () => {
         screen.queryByRole("button", { name: "Request to re-review PR" }),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("does not offer re-review for an approved external review", () => {
+    render(
+      <InspectorReviewsView
+        externalLink={ExternalLink}
+        groups={[
+          {
+            github: {
+              entries: [
+                {
+                  body: "Looks good.",
+                  id: "github-review-approved",
+                  reviewerId: "maya",
+                  reviewUrl: "https://example.com/review",
+                  submittedAt: "2026-08-09T10:00:00Z",
+                  submittedAtLabel: "1h ago",
+                  verdict: { label: "Approved", tone: "success" },
+                },
+              ],
+              unresolved: 0,
+              unresolvedBy: [],
+            },
+            meta: "#12",
+            number: 12,
+            title: "Portable inspector",
+          },
+        ]}
+        isLoading={false}
+        labels={reviewLabels}
+        onRequestRereview={vi.fn()}
+        renderAvatar={() => null}
+        renderMarkdown={(body) => <p>{body}</p>}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /maya.*Approved/ }));
+
+    expect(
+      screen.queryByRole("button", { name: "Request to re-review PR" }),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the re-review action available and shows an error when the callback fails", async () => {

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -408,6 +408,7 @@ export type InspectorInlineComment = {
 
 export type InspectorGithubReview = {
 	body?: string;
+	canRequestRereview?: boolean;
 	id: string;
 	inlineComments?: InspectorInlineComment[];
 	isBot?: boolean;
@@ -534,7 +535,6 @@ export function InspectorReviewsView({
 								</ReviewSourceLabel>
 								<ReviewRuns
 									dimmed={group.ao.dimmed}
-									externalLink={externalLink}
 									historical={group.ao.historical}
 									labels={labels}
 									renderAvatar={renderAvatar}
@@ -685,7 +685,6 @@ function ReviewDisclosure({
 
 function ReviewRuns({
 	dimmed,
-	externalLink,
 	historical,
 	labels,
 	renderAvatar,
@@ -693,7 +692,6 @@ function ReviewRuns({
 	runs,
 }: {
 	dimmed?: boolean;
-	externalLink: ExternalLinkComponent;
 	historical?: boolean;
 	labels: InspectorReviewLabels;
 	renderAvatar: (harness: string) => ReactNode;
@@ -706,7 +704,6 @@ function ReviewRuns({
 	return (
 		<ReviewRunHistory
 			dimmed={dimmed}
-			externalLink={externalLink}
 			historical={historical}
 			labels={labels}
 			renderAvatar={renderAvatar}
@@ -718,7 +715,6 @@ function ReviewRuns({
 
 function ReviewRunHistory({
 	dimmed,
-	externalLink,
 	historical,
 	labels,
 	renderAvatar,
@@ -726,7 +722,6 @@ function ReviewRunHistory({
 	runs,
 }: {
 	dimmed?: boolean;
-	externalLink: ExternalLinkComponent;
 	historical?: boolean;
 	labels: InspectorReviewLabels;
 	renderAvatar: (harness: string) => ReactNode;
@@ -744,7 +739,6 @@ function ReviewRunHistory({
 				<ReviewSummaryCard
 					actor={run.harness || "reviewer"}
 					body={run.status === "cancelled" || run.status === "failed" ? "" : run.body}
-					externalLink={externalLink}
 					isEarlier={historical || index > 0}
 					key={run.id}
 					labels={labels}
@@ -752,7 +746,6 @@ function ReviewRunHistory({
 					renderMarkdown={renderMarkdown}
 					testId="review-run-summary"
 					timestamp={run.createdAtLabel}
-					url={run.url}
 					verdict={run.verdict}
 				/>
 			))}
@@ -873,6 +866,7 @@ function ExternalReviewCard({
 	const body = entry.body?.trim();
 	const inlineComments = entry.inlineComments ?? [];
 	const openInlineCount = inlineComments.filter((comment) => comment.body?.trim() || comment.file || comment.url).length;
+	const showRereviewAction = Boolean(onRequestRereview && (entry.canRequestRereview ?? entry.verdict.tone !== "success"));
 	return (
 		<article className="min-w-0 border-b border-border/70 py-3 first:pt-0 last:border-b-0 last:pb-0" data-testid="github-review-card">
 			<button
@@ -898,7 +892,7 @@ function ExternalReviewCard({
 			</button>
 			{open ? (
 				<div className="flex min-w-0 flex-col gap-3 px-1 pt-3">
-					{onRequestRereview ? (
+					{showRereviewAction ? (
 						<div className="flex min-w-0 flex-wrap items-center justify-between gap-2 border-y border-border/50 py-2 @max-[300px]/inspector:flex-col @max-[300px]/inspector:items-stretch">
 							{openInlineCount > 0 ? (
 								<span className="font-mono text-2xs font-semibold text-error">{labels.unresolvedCount(openInlineCount)}</span>
@@ -914,7 +908,7 @@ function ExternalReviewCard({
 									onClick={async () => {
 										setRereviewError(false);
 										try {
-											await onRequestRereview(entry);
+											await onRequestRereview?.(entry);
 											setRereviewRequested(true);
 										} catch {
 											setRereviewError(true);
@@ -931,14 +925,6 @@ function ExternalReviewCard({
 					{body ? (
 						<ReviewMarkdownBody body={body} clamped={false} renderMarkdown={renderMarkdown} testId="github-review-summary" />
 					) : null}
-					<ReviewLinks
-						clamped={false}
-						expanded={false}
-						externalLink={externalLink}
-						labels={labels}
-						onExpandedChange={() => undefined}
-						url={entry.reviewUrl}
-					/>
 					{openInlineCount > 0 ? (
 						<GithubInlineComments
 							externalLink={externalLink}
@@ -1169,7 +1155,6 @@ function InlineCommentRow({
 function ReviewSummaryCard({
 	actor,
 	body: rawBody,
-	externalLink,
 	isBot = false,
 	isEarlier = false,
 	labels,
@@ -1177,12 +1162,10 @@ function ReviewSummaryCard({
 	renderMarkdown,
 	testId,
 	timestamp,
-	url,
 	verdict,
 }: {
 	actor: string;
 	body?: string;
-	externalLink: ExternalLinkComponent;
 	isBot?: boolean;
 	isEarlier?: boolean;
 	labels: InspectorReviewLabels;
@@ -1190,7 +1173,6 @@ function ReviewSummaryCard({
 	renderMarkdown: (body: string) => ReactNode;
 	testId: string;
 	timestamp: string;
-	url?: string | null;
 	verdict: InspectorVerdict;
 }) {
 	const [expanded, setExpanded] = useState(false);
@@ -1222,10 +1204,8 @@ function ReviewSummaryCard({
 			<ReviewLinks
 				clamped={clamped}
 				expanded={expanded}
-				externalLink={externalLink}
 				labels={labels}
 				onExpandedChange={() => setExpanded((open) => !open)}
-				url={url}
 			/>
 		</article>
 	);
@@ -1266,38 +1246,20 @@ function ReviewMarkdownBody({
 function ReviewLinks({
 	clamped,
 	expanded,
-	externalLink: ExternalLink,
 	labels,
 	onExpandedChange,
-	renderViewLabel,
-	url,
 }: {
 	clamped: boolean;
 	expanded: boolean;
-	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
 	onExpandedChange: () => void;
-	renderViewLabel?: string;
-	url?: string | null;
 }) {
-	if (!clamped && !url) return null;
+	if (!clamped) return null;
 	return (
 		<span className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-micro text-passive">
-			{clamped ? (
-				<button className="font-medium transition-colors hover:text-foreground" onClick={onExpandedChange} type="button">
-					{expanded ? labels.showLess : labels.showMore}
-				</button>
-			) : null}
-			{clamped && url ? <span aria-hidden="true">·</span> : null}
-			{url ? (
-				<ExternalLink
-					className="inline-flex items-center gap-0.5 font-medium no-underline transition-colors hover:text-foreground"
-					href={url}
-				>
-					{renderViewLabel ?? labels.viewOnPR}
-					<ArrowUpRightIcon className="size-2.5 shrink-0" />
-				</ExternalLink>
-			) : null}
+			<button className="font-medium transition-colors hover:text-foreground" onClick={onExpandedChange} type="button">
+				{expanded ? labels.showLess : labels.showMore}
+			</button>
 		</span>
 	);
 }


### PR DESCRIPTION
## Summary
- Remove the Reviews tab’s "View on PR" CTA from AO and external review summaries.
- Gate the "Request to re-review PR" action so approved reviews do not show it, while changes-requested/unapproved review entries remain requestable.
- Rename the auto-inject reviews setting to "Auto inject review comments".
- Exclude PR-author self reviews/comments from the External reviews list.
- Treat open and draft PRs as reviewable, and hide the Reviews tab when all PRs are merged/closed.
- Add/adjust tests for the updated review action and tab eligibility behavior.

## Tests
- npm --prefix frontend run typecheck
- npm --prefix frontend test -- SessionInspector.test.tsx session-reviews.test.ts
- npm --prefix packages/product-ui run typecheck
- npm --prefix packages/product-ui test -- SessionInspectorView.test.tsx
- npm --prefix packages/product-ui run build

## Risks
- Existing PR/review URLs are still retained in data models, but the summary-level external link is intentionally hidden from the Reviews tab UI.
- Self-review filtering is based on comparing review/comment actor IDs with the PR author ID provided by SCM summary data.