### PR TITLE
fix(chat): disable attachment-only steering sends

### DIFF
--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -231,7 +231,11 @@ export function ChatComposer({
 	// with it: a steer with nothing in flight is refused, so it must never be what
 	// Enter is still pointing at.
 	const steering = Boolean(canSteer && onSteer) && delivery === "steer";
-	const canSend = hasDraft && !busy && !disabled && !steerPending;
+	// Attachments cannot be steered: the steer branch delivers text only and refuses
+	// an empty body. A staged file must not light up the send button on its own while
+	// steering is armed, or Enter would silently do nothing.
+	const canSend =
+		(text.trim().length > 0 || (staged && !steering)) && !busy && !disabled && !steerPending;
 	const canStopTurn = Boolean(willQueue && onInterrupt && !disabled && !hasDraft);
 	const draftSeedId = draftSeed?.id;
 	const draftSeedText = draftSeed?.text;

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -1,9 +1,12 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ChatComposer } from "./ChatComposer";
 import { ChatWorkspace } from "./ChatWorkspace";
 import { chatFixture } from "../../lib/chat-fixture";
+
+const png = (name = "shot.png") =>
+	new File([new Uint8Array([137, 80, 78, 71])], name, { type: "image/png" });
 
 // Steering sends guidance INTO the running turn instead of queueing behind it. The
 // thing these tests protect is that the choice is legible: Enter changing meaning
@@ -102,6 +105,38 @@ describe("ChatComposer steering", () => {
 			"aria-pressed",
 			"true",
 		);
+	});
+
+	it("keeps attachment-only drafts out of steer and available to queue", async () => {
+		const onSteer = vi.fn().mockResolvedValue(undefined);
+		const onSend = vi.fn();
+		const stage = vi.fn().mockResolvedValue([".ao/attachments/shot.png"]);
+		composer({ onSteer, onSend, onStageAttachments: stage });
+
+		await userEvent.click(screen.getByRole("button", { name: "Steer this turn" }));
+
+		const field = screen.getByRole("combobox");
+		await userEvent.click(field);
+		fireEvent.paste(field, { clipboardData: { files: [png()], items: [] } });
+		await waitFor(() => expect(screen.getAllByRole("listitem")).toHaveLength(1));
+
+		expect(screen.getByRole("button", { name: "Steer the running turn" })).toBeDisabled();
+		await userEvent.keyboard("{Enter}");
+		expect(onSteer).not.toHaveBeenCalled();
+		expect(onSend).not.toHaveBeenCalled();
+		expect(stage).not.toHaveBeenCalled();
+		expect(screen.getAllByRole("listitem")).toHaveLength(1);
+
+		await userEvent.click(screen.getByRole("button", { name: "Queue for next" }));
+		expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+		await userEvent.click(field);
+		await userEvent.keyboard("{Enter}");
+
+		await waitFor(() => expect(stage).toHaveBeenCalledOnce());
+		expect(onSend).toHaveBeenCalledWith(
+			"Attached files (read these files in the workspace):\n- .ao/attachments/shot.png",
+		);
+		await waitFor(() => expect(screen.queryAllByRole("listitem")).toHaveLength(0));
 	});
 
 	it("reports the daemon's refusal without a second message of its own", () => {


### PR DESCRIPTION
Fixes #4081.

## What changed

While a Chat turn is running, attachment-only drafts no longer enable the composer send action when **Steer this turn** is selected. Steering accepts text only, so the button and Enter path now match that contract.

The staged attachment is deliberately retained. Adding text makes steering valid; switching to **Queue for next** immediately re-enables send and preserves the attachment for the queued message.

This was split out of #4005 during deep review so each PR owns one issue.

## Tests

`ChatSteer.test.tsx` now exercises the actual keyboard boundary:

- focuses the textarea before pressing Enter;
- proves attachment-only steering disables send;
- proves Enter calls neither steer, queue/send, nor attachment staging;
- proves the attachment stays present;
- proves switching to Queue re-enables submission and then stages/sends the attachment.

Verification:
- focused ChatSteer suite: 19 passed;
- frontend typecheck: passed;
- full frontend suite: 190 files; 2,501 passed and 1 skipped.

## Real Electron A/B evidence

Both runs used a live streaming Claude Chat turn, **Steer this turn**, `steer-proof.txt`, an empty textarea, and a fresh isolated `AO_DATA_DIR`. The screenshots are attached as review evidence and are not part of the PR code diff.

### Before — current main exposes an enabled no-op

![Before: attachment-only steering misleadingly enables send](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/pr-assets-4082/.issue-assets/pr-4082/a-before-enabled-noop.png)

Pressing Enter sends no steer request, queues no message, and gives no feedback.

### After — impossible action is disabled

![After: attachment-only steering is disabled](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/pr-assets-4082/.issue-assets/pr-4082/b-after-disabled-retained.png)

The attachment remains available, and the same live run verified that switching to Queue re-enables send.
