### PR TITLE
fix(kanban): track OpenCode activity and required reviews

### DIFF
--- a/backend/internal/adapters/agent/opencode/activity.go
+++ b/backend/internal/adapters/agent/opencode/activity.go
@@ -13,6 +13,8 @@ func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
 		return domain.ActivityActive, true
 	case "user-prompt-submit":
 		return domain.ActivityActive, true
+	case "active":
+		return domain.ActivityActive, true
 	case "stop":
 		return domain.ActivityIdle, true
 	case "permission-blocked":

--- a/backend/internal/adapters/agent/opencode/activity.go
+++ b/backend/internal/adapters/agent/opencode/activity.go
@@ -15,6 +15,8 @@ func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
 		return domain.ActivityActive, true
 	case "stop":
 		return domain.ActivityIdle, true
+	case "permission-blocked":
+		return domain.ActivityBlocked, true
 	default:
 		return "", false
 	}

--- a/backend/internal/adapters/agent/opencode/activity_test.go
+++ b/backend/internal/adapters/agent/opencode/activity_test.go
@@ -15,7 +15,9 @@ func TestDeriveActivityState(t *testing.T) {
 	}{
 		{"session start -> active", "session-start", domain.ActivityActive, true},
 		{"user prompt -> active", "user-prompt-submit", domain.ActivityActive, true},
+		{"tool or reply -> active", "active", domain.ActivityActive, true},
 		{"stop -> idle", "stop", domain.ActivityIdle, true},
+		{"permission or question -> blocked", "permission-blocked", domain.ActivityBlocked, true},
 		{"unknown event -> no signal", "frobnicate", "", false},
 	}
 	for _, tt := range tests {

--- a/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
+++ b/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
@@ -4,6 +4,8 @@
 // activity events:
 //   session.created                       -> `ao hooks opencode session-start`
 //   message.updated / message.part.updated -> `ao hooks opencode user-prompt-submit`
+//   message.updated (assistant in_progress) -> `ao hooks opencode active`
+//   tool.start / tool.end                  -> `ao hooks opencode active`
 //   session.status (status.type == idle)   -> `ao hooks opencode stop`
 //   client.permissionRequest               -> `ao hooks opencode permission-blocked`
 //
@@ -128,6 +130,13 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
               callHookSync("session-start", { session_id: msg.sessionID })
             }
             if (msg.role === "assistant" && msg.modelID) currentModel = msg.modelID
+            // Detect when assistant is actively working (not just idle)
+            if (msg.role === "assistant" && msg.status === "in_progress") {
+              const sessionID = msg.sessionID ?? currentSessionID
+              if (sessionID) {
+                callHookSync("active", { session_id: sessionID, model: currentModel ?? "" })
+              }
+            }
             // Fallback: some `opencode run` flows never deliver message.part.updated
             // for the prompt, so start the turn from the user message itself.
             if (msg.role === "user") {
@@ -172,6 +181,25 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
             const sessionID = props?.sessionID ?? currentSessionID
             if (!sessionID) break
             callHookSync("permission-blocked", { session_id: sessionID, model: currentModel ?? "" })
+            break
+          }
+
+          case "tool.start": {
+            // Detect when opencode starts using a tool - indicates active work
+            const props = (event as any).properties
+            const sessionID = props?.sessionID ?? currentSessionID
+            if (!sessionID) break
+            callHookSync("active", { session_id: sessionID, model: currentModel ?? "" })
+            break
+          }
+
+          case "tool.end": {
+            // When tool completes, report activity but don't immediately go idle
+            // - let session.status idle handle that
+            const props = (event as any).properties
+            const sessionID = props?.sessionID ?? currentSessionID
+            if (!sessionID) break
+            callHookSync("active", { session_id: sessionID, model: currentModel ?? "" })
             break
           }
         }

--- a/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
+++ b/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
@@ -4,10 +4,9 @@
 // activity events:
 //   session.created                       -> `ao hooks opencode session-start`
 //   message.updated / message.part.updated -> `ao hooks opencode user-prompt-submit`
-//   message.updated (assistant in_progress) -> `ao hooks opencode active`
-//   tool.start / tool.end                  -> `ao hooks opencode active`
+//   tool.execute.before / tool.execute.after -> `ao hooks opencode active`
 //   session.status (status.type == idle)   -> `ao hooks opencode stop`
-//   client.permissionRequest               -> `ao hooks opencode permission-blocked`
+//   permission.ask (status == ask)         -> `ao hooks opencode permission-blocked`
 //
 // The opencode-native session id (and prompt/model where known) is piped to the
 // hook command as JSON on stdin, run with cwd set to the worktree so AO can
@@ -130,13 +129,6 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
               callHookSync("session-start", { session_id: msg.sessionID })
             }
             if (msg.role === "assistant" && msg.modelID) currentModel = msg.modelID
-            // Detect when assistant is actively working (not just idle)
-            if (msg.role === "assistant" && msg.status === "in_progress") {
-              const sessionID = msg.sessionID ?? currentSessionID
-              if (sessionID) {
-                callHookSync("active", { session_id: sessionID, model: currentModel ?? "" })
-              }
-            }
             // Fallback: some `opencode run` flows never deliver message.part.updated
             // for the prompt, so start the turn from the user message itself.
             if (msg.role === "user") {
@@ -174,40 +166,24 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
             break
           }
 
-          case "client.permissionRequest": {
-            // Detect permission blocker dialogs (e.g., directory access, tool use)
-            // and notify AO so the session moves to "needs you" section.
-            const props = (event as any).properties
-            const sessionID = props?.sessionID ?? currentSessionID
-            if (!sessionID) break
-            callHookSync("permission-blocked", { session_id: sessionID, model: currentModel ?? "" })
-            break
-          }
-
-          case "tool.start": {
-            // Detect when opencode starts using a tool - indicates active work
-            const props = (event as any).properties
-            const sessionID = props?.sessionID ?? currentSessionID
-            if (!sessionID) break
-            callHookSync("active", { session_id: sessionID, model: currentModel ?? "" })
-            break
-          }
-
-          case "tool.end": {
-            // When tool completes, report activity but don't immediately go idle
-            // - let session.status idle handle that
-            const props = (event as any).properties
-            const sessionID = props?.sessionID ?? currentSessionID
-            if (!sessionID) break
-            callHookSync("active", { session_id: sessionID, model: currentModel ?? "" })
-            break
-          }
         }
       } catch (err) {
         // A malformed/unexpected event payload must never crash opencode; log
         // it (tagged with the event type) for diagnosis and move on.
         logHookFailure(`event:${(event as any)?.type ?? "unknown"}`, err instanceof Error ? err.message : String(err))
       }
+    },
+    "permission.ask": async (input, output) => {
+      if (output.status !== "ask") return
+      callHookSync("permission-blocked", { session_id: input.sessionID, model: currentModel ?? "" })
+    },
+    "tool.execute.before": async (input) => {
+      callHookSync("active", { session_id: input.sessionID, model: currentModel ?? "" })
+    },
+    "tool.execute.after": async (input) => {
+      // Tool completion is still activity; session.status(idle) owns the
+      // transition back to idle after the turn finishes.
+      callHookSync("active", { session_id: input.sessionID, model: currentModel ?? "" })
     },
   }
 }

--- a/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
+++ b/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
@@ -33,6 +33,10 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
   let currentSessionID: string | null = null
   // The model of the most recent assistant message, forwarded for context.
   let currentModel: string | null = null
+  // AO fences each provider generation with AO_RUNTIME_LAUNCH_ID; carry it in
+  // the payload so hooks work even when child-process env inheritance is
+  // trimmed by the host runtime.
+  const launchID: string = (process.env.AO_RUNTIME_LAUNCH_ID ?? "").trim()
   const messageStore = new Map<string, any>()
 
   // Wrap in `sh -c` with a guard so a missing `ao` binary is a silent no-op
@@ -71,7 +75,8 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
     try {
       const result = Bun.spawnSync(hookCmd(hookName), {
         cwd: directory,
-        stdin: new TextEncoder().encode(JSON.stringify(payload) + "\n"),
+        env: { ...process.env, AO_RUNTIME_LAUNCH_ID: launchID },
+        stdin: new TextEncoder().encode(JSON.stringify({ ...payload, launch_id: launchID }) + "\n"),
         stdout: "ignore",
         stderr: "pipe",
         timeout: HOOK_TIMEOUT_MS,

--- a/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
+++ b/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
@@ -1,10 +1,11 @@
 // agent-orchestrator: managed opencode activity plugin (do not edit)
 //
-// It maps opencode's native lifecycle events onto AO's three normalized
+// It maps opencode's native lifecycle events onto AO's normalized
 // activity events:
 //   session.created                       -> `ao hooks opencode session-start`
 //   message.updated / message.part.updated -> `ao hooks opencode user-prompt-submit`
 //   session.status (status.type == idle)   -> `ao hooks opencode stop`
+//   client.permissionRequest               -> `ao hooks opencode permission-blocked`
 //
 // The opencode-native session id (and prompt/model where known) is piped to the
 // hook command as JSON on stdin, run with cwd set to the worktree so AO can
@@ -161,6 +162,16 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
             const sessionID = props?.sessionID ?? currentSessionID
             if (!sessionID) break
             callHookSync("stop", { session_id: sessionID, model: currentModel ?? "" })
+            break
+          }
+
+          case "client.permissionRequest": {
+            // Detect permission blocker dialogs (e.g., directory access, tool use)
+            // and notify AO so the session moves to "needs you" section.
+            const props = (event as any).properties
+            const sessionID = props?.sessionID ?? currentSessionID
+            if (!sessionID) break
+            callHookSync("permission-blocked", { session_id: sessionID, model: currentModel ?? "" })
             break
           }
         }

--- a/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
+++ b/backend/internal/adapters/agent/opencode/assets/ao-activity.ts
@@ -6,7 +6,8 @@
 //   message.updated / message.part.updated -> `ao hooks opencode user-prompt-submit`
 //   tool.execute.before / tool.execute.after -> `ao hooks opencode active`
 //   session.status (status.type == idle)   -> `ao hooks opencode stop`
-//   permission.ask (status == ask)         -> `ao hooks opencode permission-blocked`
+//   permission.asked / question.asked      -> `ao hooks opencode permission-blocked`
+//   permission/question reply or rejection -> `ao hooks opencode active`
 //
 // The opencode-native session id (and prompt/model where known) is piped to the
 // hook command as JSON on stdin, run with cwd set to the worktree so AO can
@@ -166,16 +167,29 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
             break
           }
 
+          case "permission.asked":
+          case "question.asked": {
+            const sessionID = (event as any).properties?.sessionID ?? currentSessionID
+            if (!sessionID) break
+            callHookSync("permission-blocked", { session_id: sessionID, model: currentModel ?? "" })
+            break
+          }
+
+          case "permission.replied":
+          case "question.replied":
+          case "question.rejected": {
+            const sessionID = (event as any).properties?.sessionID ?? currentSessionID
+            if (!sessionID) break
+            callHookSync("active", { session_id: sessionID, model: currentModel ?? "" })
+            break
+          }
+
         }
       } catch (err) {
         // A malformed/unexpected event payload must never crash opencode; log
         // it (tagged with the event type) for diagnosis and move on.
         logHookFailure(`event:${(event as any)?.type ?? "unknown"}`, err instanceof Error ? err.message : String(err))
       }
-    },
-    "permission.ask": async (input, output) => {
-      if (output.status !== "ask") return
-      callHookSync("permission-blocked", { session_id: input.sessionID, model: currentModel ?? "" })
     },
     "tool.execute.before": async (input) => {
       callHookSync("active", { session_id: input.sessionID, model: currentModel ?? "" })

--- a/backend/internal/adapters/agent/opencode/hooks.go
+++ b/backend/internal/adapters/agent/opencode/hooks.go
@@ -71,7 +71,7 @@ var opencodePluginSource string
 // opencodeManagedEvents are the three normalized activity events the embedded
 // plugin reports. They are defined here (not parsed from the file) so tests can
 // assert the plugin wires every one via the `ao hooks opencode <event>` command.
-var opencodeManagedEvents = []string{"session-start", "user-prompt-submit", "stop", "permission-blocked"}
+var opencodeManagedEvents = []string{"session-start", "user-prompt-submit", "active", "stop", "permission-blocked"}
 
 // GetAgentHooks installs AO's opencode activity plugin into the worktree-local
 // .opencode/plugins/ directory, and materializes the using-ao skill into

--- a/backend/internal/adapters/agent/opencode/hooks.go
+++ b/backend/internal/adapters/agent/opencode/hooks.go
@@ -71,7 +71,7 @@ var opencodePluginSource string
 // opencodeManagedEvents are the three normalized activity events the embedded
 // plugin reports. They are defined here (not parsed from the file) so tests can
 // assert the plugin wires every one via the `ao hooks opencode <event>` command.
-var opencodeManagedEvents = []string{"session-start", "user-prompt-submit", "stop"}
+var opencodeManagedEvents = []string{"session-start", "user-prompt-submit", "stop", "permission-blocked"}
 
 // GetAgentHooks installs AO's opencode activity plugin into the worktree-local
 // .opencode/plugins/ directory, and materializes the using-ao skill into

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -577,6 +577,14 @@ func TestGetAgentHooksInstallsPlugin(t *testing.T) {
 			t.Fatalf("plugin subscribes to unsupported opencode event %q:\n%s", unsupported, body)
 		}
 	}
+	// The plugin must carry the runtime launch id in hook payloads so the CLI
+	// can fence signals even when child-process env inheritance is trimmed.
+	if !strings.Contains(body, "launch_id:") {
+		t.Fatalf("installed plugin missing launch_id in hook payload:\n%s", body)
+	}
+	if !strings.Contains(body, "AO_RUNTIME_LAUNCH_ID") {
+		t.Fatalf("installed plugin missing AO_RUNTIME_LAUNCH_ID reference:\n%s", body)
+	}
 	// Guard against regressing back to subscribing to the deprecated/unreliable
 	// session.idle event (the quoted event string is how a `case` would name it;
 	// the explanatory comment mentions it unquoted, which is fine).

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -560,6 +560,18 @@ func TestGetAgentHooksInstallsPlugin(t *testing.T) {
 			t.Fatalf("installed plugin missing opencode event %q:\n%s", marker, body)
 		}
 	}
+	// Permissions and tool execution are exposed as named plugin hooks, not
+	// event-bus event types.
+	for _, hook := range []string{`"permission.ask":`, `"tool.execute.before":`, `"tool.execute.after":`} {
+		if !strings.Contains(body, hook) {
+			t.Fatalf("installed plugin missing opencode hook %q:\n%s", hook, body)
+		}
+	}
+	for _, unsupported := range []string{`"client.permissionRequest"`, `"permission.asked"`, `"tool.start"`, `"tool.end"`} {
+		if strings.Contains(body, unsupported) {
+			t.Fatalf("plugin subscribes to unsupported opencode event %q:\n%s", unsupported, body)
+		}
+	}
 	// Guard against regressing back to subscribing to the deprecated/unreliable
 	// session.idle event (the quoted event string is how a `case` would name it;
 	// the explanatory comment mentions it unquoted, which is fine).

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -560,14 +560,19 @@ func TestGetAgentHooksInstallsPlugin(t *testing.T) {
 			t.Fatalf("installed plugin missing opencode event %q:\n%s", marker, body)
 		}
 	}
-	// Permissions and tool execution are exposed as named plugin hooks, not
-	// event-bus event types.
-	for _, hook := range []string{`"permission.ask":`, `"tool.execute.before":`, `"tool.execute.after":`} {
+	// Tool execution is exposed as named plugin hooks. Permission approvals and
+	// explicit questions are emitted through opencode's generic event callback.
+	for _, hook := range []string{`"tool.execute.before":`, `"tool.execute.after":`} {
 		if !strings.Contains(body, hook) {
 			t.Fatalf("installed plugin missing opencode hook %q:\n%s", hook, body)
 		}
 	}
-	for _, unsupported := range []string{`"client.permissionRequest"`, `"permission.asked"`, `"tool.start"`, `"tool.end"`} {
+	for _, eventCase := range []string{`case "permission.asked":`, `case "permission.replied":`, `case "question.asked":`, `case "question.replied":`, `case "question.rejected":`} {
+		if !strings.Contains(body, eventCase) {
+			t.Fatalf("installed plugin missing opencode event handler %q:\n%s", eventCase, body)
+		}
+	}
+	for _, unsupported := range []string{`"client.permissionRequest"`, `"permission.ask":`, `"tool.start"`, `"tool.end"`} {
 		if strings.Contains(body, unsupported) {
 			t.Fatalf("plugin subscribes to unsupported opencode event %q:\n%s", unsupported, body)
 		}

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -130,6 +130,25 @@ func hookAgentSessionID(payload []byte) string {
 	return id
 }
 
+// hookLaunchID extracts the runtime launch id a plugin embeds in its payload.
+// It is a fallback for AO_RUNTIME_LAUNCH_ID when child-process env inheritance
+// is trimmed by the agent runtime.
+func hookLaunchID(payload []byte) string {
+	var p struct {
+		LaunchID      string `json:"launch_id"`
+		LaunchIDCamel string `json:"launchId"`
+	}
+	_ = json.Unmarshal(payload, &p)
+	id := strings.TrimSpace(p.LaunchID)
+	if id == "" {
+		id = strings.TrimSpace(p.LaunchIDCamel)
+	}
+	if len(id) > maxActivityMetaLen {
+		return ""
+	}
+	return id
+}
+
 // hookUsageMetadata extracts provider-native usage metadata. It deliberately
 // decodes separately from conversation facts because hook producers may emit
 // a malformed field in one projection while the other remains useful.
@@ -292,6 +311,11 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 		return nil
 	}
 
+	launchID := validLaunchID(os.Getenv("AO_RUNTIME_LAUNCH_ID"))
+	if launchID == "" {
+		launchID = validLaunchID(hookLaunchID(payload))
+	}
+
 	toolName, toolUseID := activityMeta(payload)
 	conversation := hookConversationSnapshot{}
 	switch domain.AgentHarness(agent) {
@@ -307,7 +331,7 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 		LatestUserPrompt:      conversation.LatestUserPrompt,
 		LatestAssistantUpdate: conversation.LatestAssistantUpdate,
 		TranscriptPath:        conversation.TranscriptPath,
-		LaunchID:              validLaunchID(os.Getenv("AO_RUNTIME_LAUNCH_ID")),
+		LaunchID:              launchID,
 		Usage:                 usage,
 	}
 	if hasActivity {
@@ -334,11 +358,15 @@ func (c *commandContext) runReviewHook(ctx context.Context, agent, event, review
 	if !hasActivity && agentSessionID == "" {
 		return nil
 	}
+	launchID := validLaunchID(os.Getenv("AO_RUNTIME_LAUNCH_ID"))
+	if launchID == "" {
+		launchID = validLaunchID(hookLaunchID(payload))
+	}
 	path := "reviews/" + url.PathEscape(reviewSessionID) + "/activity"
 	req := setReviewActivityAPIRequest{
 		Event:          event,
 		AgentSessionID: agentSessionID,
-		LaunchID:       validLaunchID(os.Getenv("AO_RUNTIME_LAUNCH_ID")),
+		LaunchID:       launchID,
 	}
 	if hasActivity {
 		req.State = string(state)

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -276,6 +276,31 @@ func TestHooks_ThreadsRuntimeLaunchID(t *testing.T) {
 	}
 }
 
+func TestHooks_PayloadLaunchIDFallbackWhenEnvUnset(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"launch_id":"launch-from-payload"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "opencode", "permission-blocked")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.LaunchID != "launch-from-payload" {
+		t.Fatalf("launch id = %q, want launch-from-payload", req.LaunchID)
+	}
+	if got := capturedState(t, capture); got != "blocked" {
+		t.Errorf("state = %q, want blocked", got)
+	}
+}
+
 func TestHooks_StopReportsIdle(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	cfg := setConfigEnv(t)

--- a/backend/pkg/contract/status.go
+++ b/backend/pkg/contract/status.go
@@ -248,12 +248,12 @@ func prPipelineStatus(pr PRFacts) SessionStatus {
 		return StatusChangesRequested
 	case pr.Mergeability == MergeMergeable:
 		return StatusMergeable
+	case pr.Review == ReviewRequired:
+		return StatusReviewPending
 	case pr.Mergeability == MergeBlocked:
 		return StatusPROpen
 	case pr.Review == ReviewApproved:
 		return StatusApproved
-	case pr.Review == ReviewRequired:
-		return StatusReviewPending
 	default:
 		return StatusPROpen
 	}

--- a/backend/pkg/contract/status_test.go
+++ b/backend/pkg/contract/status_test.go
@@ -86,6 +86,7 @@ func TestDeriveSCMStatusPipelineAndWorstWins(t *testing.T) {
 		{"merged", []contract.PRFacts{{Merged: true}}, contract.StatusMerged},
 		{"open", []contract.PRFacts{{}}, contract.StatusPROpen},
 		{"review pending", []contract.PRFacts{{Review: contract.ReviewRequired}}, contract.StatusReviewPending},
+		{"review pending with provider merge blocker", []contract.PRFacts{{Review: contract.ReviewRequired, Mergeability: contract.MergeBlocked}}, contract.StatusReviewPending},
 		{"approved", []contract.PRFacts{{Review: contract.ReviewApproved}}, contract.StatusApproved},
 		{"mergeable", []contract.PRFacts{{Mergeability: contract.MergeMergeable}}, contract.StatusMergeable},
 		{"merge blocked", []contract.PRFacts{{Mergeability: contract.MergeBlocked}}, contract.StatusPROpen},


### PR DESCRIPTION
## Summary

Improve Kanban status tracking for OpenCode sessions and ensure GitHub pull requests awaiting review appear in the In Review column.

Fixes #4087.

## Changes

- Report OpenCode session creation, prompt submission, tool execution, and resumed permission/question flows as active work.
- Observe OpenCode's real generic events: `permission.asked` and `question.asked` move a session to Needs You; reply/reject events return it to Working.
- Remove the ineffective `permission.ask` plugin hook, which OpenCode declares but does not invoke in its active permission flow.
- Continue reporting OpenCode idle transitions from session status events.
- Add normalized active and permission-blocked activity mappings to the OpenCode adapter.
- Give required-review facts precedence over generic provider merge blockers so pull requests awaiting review display as In Review instead of PR Open.
- Add regression coverage for supported OpenCode events/hooks and the required-review status combination emitted by GitHub.

## Kanban behavior

For OpenCode activity:

- Session start, prompt submission, tool execution, or a prompt response -> Working
- Permission approval or explicit answer required -> Needs You
- Session idle -> the applicable idle or SCM-derived status

For tracked pull requests:

- Review required -> In Review
- CI failing -> CI Failed
- Changes requested or unresolved review feedback -> Changes Requested
- Mergeable -> Ready to Merge
- Merged -> Merged

Live agent activity takes precedence over SCM status. Once OpenCode becomes idle, the applicable pull-request status is shown.

## Verification

- `go build ./...`
- `go test -p 1 ./...`
- `go vet ./...`
- Focused OpenCode, activity-dispatch, and CLI tests
- Bun compilation of the installed OpenCode plugin

