### PR TITLE
feat(renderer): zero-friction in-product user surveys

### DIFF
--- a/frontend/src/renderer/components/SurveyPrompt.tsx
+++ b/frontend/src/renderer/components/SurveyPrompt.tsx
@@ -1,0 +1,45 @@
+import { useSyncExternalStore } from "react";
+
+import {
+	answerCurrentSurvey,
+	dismissCurrentSurvey,
+	getCurrentSurvey,
+	subscribeSurvey,
+} from "../lib/survey";
+
+/**
+ * A single, unobtrusive one-tap survey card. Renders nothing until a trigger
+ * offers a survey; the controller guarantees at most one per user per week, so
+ * this never nags. Non-blocking (bottom-right, dismissible) so it can't
+ * interrupt work.
+ */
+export function SurveyPrompt() {
+	const survey = useSyncExternalStore(subscribeSurvey, getCurrentSurvey, getCurrentSurvey);
+	if (!survey) return null;
+
+	return (
+		<div className="fixed bottom-4 right-4 z-50 w-72 rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-lg">
+			<button
+				type="button"
+				aria-label="Dismiss"
+				onClick={dismissCurrentSurvey}
+				className="absolute right-2.5 top-2 text-lg leading-none text-muted-foreground hover:text-foreground"
+			>
+				×
+			</button>
+			<p className="pr-4 text-sm font-medium">{survey.question}</p>
+			<div className="mt-3 flex flex-col gap-1.5">
+				{survey.choices.map((choice) => (
+					<button
+						key={choice}
+						type="button"
+						onClick={() => answerCurrentSurvey(choice)}
+						className="rounded-lg border border-border px-3 py-1.5 text-left text-[13px] transition-colors hover:bg-accent hover:text-accent-foreground"
+					>
+						{choice}
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/SurveyPrompt.tsx
+++ b/frontend/src/renderer/components/SurveyPrompt.tsx
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 
 import {
 	answerCurrentSurvey,
@@ -7,39 +7,164 @@ import {
 	subscribeSurvey,
 } from "../lib/survey";
 
+// Scoped styles, injected once. They lean on AO's own theme tokens
+// (--color-popover, --color-accent, …) so the card tracks light/dark with the
+// rest of the app and needs no Tailwind utility guesswork.
+const STYLE_ID = "ao-survey-styles";
+const CSS = `
+@keyframes ao-survey-rise{from{opacity:0;transform:translateY(10px) scale(.985)}to{opacity:1;transform:none}}
+.aoq{position:fixed;bottom:18px;right:18px;z-index:60;width:320px;
+  background:var(--color-popover,#fff);color:var(--color-popover-foreground,#141821);
+  border:1px solid var(--color-border,#e6e9ef);border-radius:16px;
+  box-shadow:0 1px 2px rgba(0,0,0,.10),0 18px 44px -14px rgba(0,0,0,.45);
+  padding:15px 16px 14px;animation:ao-survey-rise .22s cubic-bezier(.2,.7,.2,1);font-size:14px}
+.aoq-hd{display:flex;align-items:center;gap:7px;margin-bottom:9px}
+.aoq-dot{width:15px;height:15px;border-radius:5px;flex:none;background:var(--color-accent,#2f5ff0);
+  box-shadow:0 0 0 4px var(--color-accent-weak,#f0f4ff)}
+.aoq-eye{font-size:11px;font-weight:700;color:var(--color-muted-foreground,#6b7480)}
+.aoq-x{margin-left:auto;width:22px;height:22px;border:none;background:none;cursor:pointer;border-radius:6px;
+  font-size:16px;line-height:1;color:var(--color-muted-foreground,#9aa2ad)}
+.aoq-x:hover{color:var(--color-popover-foreground,#141821);background:var(--color-accent-weak,#eef1f5)}
+.aoq-q{margin:0 0 12px;font-size:15px;font-weight:600;letter-spacing:-.01em;line-height:1.35}
+.aoq-opts{display:flex;flex-direction:column;gap:7px}
+.aoq-opt{position:relative;text-align:left;cursor:pointer;font:inherit;font-size:13.5px;
+  border:1px solid var(--color-border,#e6e9ef);background:transparent;color:inherit;border-radius:11px;padding:9px 12px;
+  transition:background .13s,border-color .13s}
+.aoq-opt:hover{background:var(--color-accent-weak,#f0f4ff);border-color:var(--color-accent,#2f5ff0)}
+.aoq-opt.sel{background:var(--color-accent,#2f5ff0);color:var(--color-accent-foreground,#fff);
+  border-color:var(--color-accent,#2f5ff0);font-weight:600}
+.aoq-opt.sel::after{content:"✓";position:absolute;right:12px;top:50%;transform:translateY(-50%);font-size:12px}
+.aoq-foot{margin-top:11px;font-size:11px;color:var(--color-muted-foreground,#9aa2ad)}
+.aoq-ta{width:100%;min-height:74px;resize:none;font:inherit;font-size:13.5px;color:inherit;
+  background:var(--color-bg-primary,#f6f7f9);border:1px solid var(--color-border,#e6e9ef);border-radius:11px;padding:9px 11px}
+.aoq-ta:focus{outline:none;border-color:var(--color-accent,#2f5ff0)}
+.aoq-row{display:flex;gap:8px;margin-top:9px}
+.aoq-send{flex:1;font:inherit;font-size:13.5px;font-weight:600;cursor:pointer;border:none;border-radius:11px;padding:9px;
+  background:var(--color-accent,#2f5ff0);color:var(--color-accent-foreground,#fff)}
+.aoq-skip{font:inherit;font-size:13px;cursor:pointer;border:1px solid var(--color-border,#e6e9ef);background:none;
+  color:var(--color-muted-foreground,#6b7480);border-radius:11px;padding:9px 14px}
+.aoq-thanks{display:flex;align-items:center;gap:8px;font-weight:500;padding:6px 0}
+.aoq-ok{width:20px;height:20px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;
+  background:var(--color-accent,#2f5ff0);color:var(--color-accent-foreground,#fff)}
+`;
+function ensureStyles() {
+	if (typeof document === "undefined" || document.getElementById(STYLE_ID)) return;
+	const el = document.createElement("style");
+	el.id = STYLE_ID;
+	el.textContent = CSS;
+	document.head.appendChild(el);
+}
+
 /**
- * A single, unobtrusive one-tap survey card. Renders nothing until a trigger
- * offers a survey; the controller guarantees at most one per user per week, so
- * this never nags. Non-blocking (bottom-right, dismissible) so it can't
- * interrupt work.
+ * The single, unobtrusive survey card. Renders nothing until a trigger offers a
+ * survey; the controller guarantees at most one per user per week. Supports one
+ * tap (auto-submit), multi-select (+ Done), and short answer (+ Send / Skip).
  */
 export function SurveyPrompt() {
 	const survey = useSyncExternalStore(subscribeSurvey, getCurrentSurvey, getCurrentSurvey);
+	const [picked, setPicked] = useState<string[]>([]);
+	const [text, setText] = useState("");
+	const [thanks, setThanks] = useState<string | null>(null);
+
+	ensureStyles();
+	if (!survey && !thanks) return null;
+
+	const finish = (msg: string, submit?: () => void) => {
+		submit?.();
+		setPicked([]);
+		setText("");
+		setThanks(msg);
+		window.setTimeout(() => setThanks(null), 1400);
+	};
+
+	if (thanks) {
+		return (
+			<div className="aoq" role="status">
+				<div className="aoq-thanks">
+					<span className="aoq-ok">✓</span>
+					{thanks}
+				</div>
+			</div>
+		);
+	}
 	if (!survey) return null;
 
+	const toggle = (choice: string) =>
+		setPicked((p) => (p.includes(choice) ? p.filter((c) => c !== choice) : [...p, choice]));
+
 	return (
-		<div className="fixed bottom-4 right-4 z-50 w-72 rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-lg">
-			<button
-				type="button"
-				aria-label="Dismiss"
-				onClick={dismissCurrentSurvey}
-				className="absolute right-2.5 top-2 text-lg leading-none text-muted-foreground hover:text-foreground"
-			>
-				×
-			</button>
-			<p className="pr-4 text-sm font-medium">{survey.question}</p>
-			<div className="mt-3 flex flex-col gap-1.5">
-				{survey.choices.map((choice) => (
-					<button
-						key={choice}
-						type="button"
-						onClick={() => answerCurrentSurvey(choice)}
-						className="rounded-lg border border-border px-3 py-1.5 text-left text-[13px] transition-colors hover:bg-accent hover:text-accent-foreground"
-					>
-						{choice}
-					</button>
-				))}
+		<div className="aoq" role="dialog" aria-label="Quick question">
+			<div className="aoq-hd">
+				<span className="aoq-dot" aria-hidden />
+				<span className="aoq-eye">Quick question</span>
+				<button
+					type="button"
+					className="aoq-x"
+					aria-label="Dismiss"
+					onClick={() => finish("No problem", () => dismissCurrentSurvey())}
+				>
+					×
+				</button>
 			</div>
+			<p className="aoq-q">{survey.question}</p>
+
+			{survey.input === "text" ? (
+				<>
+					<textarea
+						className="aoq-ta"
+						placeholder={survey.placeholder}
+						value={text}
+						onChange={(e) => setText(e.target.value)}
+					/>
+					<div className="aoq-row">
+						<button
+							type="button"
+							className="aoq-send"
+							onClick={() => finish("Thanks — got it", () => answerCurrentSurvey(text.trim() || "(empty)"))}
+						>
+							Send
+						</button>
+						<button type="button" className="aoq-skip" onClick={() => finish("No problem", () => dismissCurrentSurvey())}>
+							Skip
+						</button>
+					</div>
+				</>
+			) : (
+				<>
+					<div className="aoq-opts">
+						{(survey.choices ?? []).map((choice) => {
+							const sel = picked.includes(choice);
+							return (
+								<button
+									key={choice}
+									type="button"
+									className={sel ? "aoq-opt sel" : "aoq-opt"}
+									onClick={() =>
+										survey.input === "multi"
+											? toggle(choice)
+											: finish("Thanks — noted", () => answerCurrentSurvey(choice))
+									}
+								>
+									{choice}
+								</button>
+							);
+						})}
+					</div>
+					{survey.input === "multi" ? (
+						<div className="aoq-row">
+							<button
+								type="button"
+								className="aoq-send"
+								onClick={() => finish("Thanks — noted", () => answerCurrentSurvey(picked))}
+							>
+								Done
+							</button>
+						</div>
+					) : (
+						<div className="aoq-foot">One tap · helps us improve AO</div>
+					)}
+				</>
+			)}
 		</div>
 	);
 }

--- a/frontend/src/renderer/lib/spawn-orchestrator.ts
+++ b/frontend/src/renderer/lib/spawn-orchestrator.ts
@@ -1,5 +1,6 @@
 import { apiClient, apiErrorCode, apiErrorMessage, apiErrorRequestId } from "./api-client";
 import type { OrchestratorSpawnSource } from "./orchestrator-spawn-sources";
+import { onSessionSpawned, onSpawnFailed } from "./survey";
 import { captureRendererEvent } from "./telemetry";
 import type { SessionMode } from "../types/conversation";
 
@@ -66,9 +67,11 @@ export async function spawnOrchestrator(
 		}
 
 		void captureRendererEvent("ao.renderer.orchestrator_spawn_succeeded", { project_id: projectId, source });
+		onSessionSpawned();
 		return data.orchestrator.id;
 	} catch (err) {
 		void captureRendererEvent("ao.renderer.orchestrator_spawn_failed", { project_id: projectId, source });
+		onSpawnFailed();
 		throw err;
 	}
 }

--- a/frontend/src/renderer/lib/survey/README.md
+++ b/frontend/src/renderer/lib/survey/README.md
@@ -1,76 +1,81 @@
 # In-product micro-surveys
 
 Zero-friction, one-tap questions that fill the gaps behavioral telemetry can't:
-is a repo **work / personal / learning**, is there a **team**, would they **miss
-us**, what **broke**. Each is anchored to a moment (a repo just added, a spawn
-that failed) so the answer is an obvious fact, never a "which kind of user am
-I?" deliberation.
+profession, is there a team, how people actually work, would they miss us, what
+broke, and open feedback. Each is anchored to a moment (opened the app, added a
+repo, finished/failed a session) so the answer is an obvious fact, not a "which
+kind of user am I?" deliberation.
 
 ## Why custom, not PostHog's native surveys
 
-The renderer deliberately sets `disable_surveys: true` and
-`advanced_disable_flags: true` (see `lib/telemetry.ts`) because `/surveys` and
-`/flags` poll PostHog on init and are billed per request, pure cost for ~2k
-users. So this ships its own tiny prompt and records the answer as an **ordinary
-captured event**. No extra network requests, no `/flags` dependency, no
-`survey:write` API key, and full control of the one-tap UX. Nothing needs to be
-created in PostHog.
+The renderer sets `disable_surveys: true` and `advanced_disable_flags: true`
+(see `lib/telemetry.ts`) because `/surveys` and `/flags` poll PostHog on init
+and are billed per request, pure cost for ~2k users. So this ships its own tiny
+prompt and records the answer as an **ordinary captured event**. No extra
+network requests, no `survey:write` key, nothing to create in PostHog.
 
-## What it emits
+## The card
+
+One dismissible card, bottom-right, that slides up after a completed action and
+appears **at most once per user per week**. Three input types:
+
+- **single** — one tap, auto-submits.
+- **multi** — toggle several, then Done.
+- **text** — a short-answer box with Send / Skip.
+
+## Events
 
 | Event | When | Properties |
 |---|---|---|
 | `ao.renderer.survey_shown` | a survey is displayed | `survey` |
-| `ao.renderer.survey_answered` | user taps a choice | `survey`, `choice` |
+| `ao.renderer.survey_answered` | user submits | `survey`, `choice` (+ `choices[]` for multi) |
 | `ao.renderer.survey_dismissed` | user closes it | `survey` |
 
-## The surveys (see `definitions.ts`)
+## The pool (see `definitions.ts`)
 
-| id | Trigger | Question |
-|---|---|---|
-| `repo-who` | project added | Who else works in this repo? |
-| `repo-purpose` | project added | This project is… |
-| `pmf` | spawn ≥ 3 | If AO disappeared tomorrow? |
-| `what-broke` | spawn failed | What went wrong? |
-| `why-ao` | 2nd session | AO is most useful to you for… |
-| `would-pay` | spawn ≥ 5, only Work + My-team users | Would your team pay for this? |
+| id | Trigger | Input | Question |
+|---|---|---|---|
+| `profile` | app open | single | What best describes you? |
+| `repo-who` | repo added | single | Who else works in this repo? |
+| `repo-purpose` | repo added | single | This project is… |
+| `pmf` | 3rd spawn | single | If AO disappeared tomorrow? |
+| `task-type` | after a session | multi | What did you use this agent for? |
+| `autonomy` | after a session | single | How closely did you watch it? |
+| `wish` | 5th spawn | text | One thing you wish AO did automatically? |
+| `would-pay` | 5th spawn, Work + My-team only | single | Is AO worth paying for? |
+| `feedback` | 8th spawn | text | Anything you'd tell the team? |
+| `blocker` | spawn failed | multi | Biggest thing slowing you down? |
 
-Guarantees (enforced in `surveyController.ts`, unit-tested): **at most one
-survey per user per week**, never re-ask an answered or dismissed one,
-activation gates via `minSpawns`, and `would-pay` only reaches users who already
-said Work + My team, so it can never nag a student.
+Guarantees (in `surveyController.ts`, unit-tested): one per user per week, never
+re-ask an answered or dismissed one, activation gates via `minSpawns`, and
+`would-pay` reaches only users who already said Work + My team, so it can never
+nag a student.
 
-## Wiring (already done)
+## Wiring
 
+- `routes/__root.tsx` → `onAppStart()` on open; `<SurveyPrompt />` mounted once.
 - `lib/spawn-orchestrator.ts` → `onSessionSpawned()` on success, `onSpawnFailed()` on failure.
-- `routes/_shell.tsx` → `onProjectAdded()` after `project_add_succeeded`.
-- `routes/__root.tsx` → `<SurveyPrompt />` mounted once (fixed, dismissible, bottom-right).
+- `routes/_shell.tsx` → `onProjectAdded()` after a project is added.
 
-## Turning answers into decisions (the whole point)
+## Turning answers into decisions
 
-Cross the PMF answer against the repo answers and **actual retention**, whoever
-says "I'd be lost", whose repos are Work + My team, *and* who keeps coming back,
-is your ICP, discovered from data:
+Cross the PMF answer against profile / repo answers and **actual retention** —
+whoever says "I'd be lost", is a Developer/Founder on a Work + My-team repo, and
+keeps coming back, is your ICP, discovered from data, not assumed:
 
 ```sql
 select
-  a_pmf.choice                              as pmf,
-  a_purpose.choice                          as purpose,
-  a_who.choice                              as team,
-  count(distinct a_pmf.person_id)           as users,
+  a_pmf.choice as pmf, a_profile.choice as profile, a_who.choice as team,
+  count(distinct a_pmf.person_id) as users,
   round(100 * countIf(a_pmf.person_id in (
      select distinct person_id from events
      where event='ao.session.spawned' and timestamp > now() - interval 7 day
-  )) / count(distinct a_pmf.person_id), 1)  as still_active_pct
+  )) / count(distinct a_pmf.person_id), 1) as still_active_pct
 from (select person_id, properties.choice as choice from events
       where event='ao.renderer.survey_answered' and properties.survey='pmf') a_pmf
 left join (select person_id, properties.choice as choice from events
-      where event='ao.renderer.survey_answered' and properties.survey='repo-purpose') a_purpose using(person_id)
+      where event='ao.renderer.survey_answered' and properties.survey='profile') a_profile using(person_id)
 left join (select person_id, properties.choice as choice from events
       where event='ao.renderer.survey_answered' and properties.survey='repo-who') a_who using(person_id)
-group by pmf, purpose, team
-order by still_active_pct desc
+group by pmf, profile, team order by still_active_pct desc
 ```
-
-The row with the highest `still_active_pct` is the segment to double down on in
-onboarding, messaging, and pricing.

--- a/frontend/src/renderer/lib/survey/README.md
+++ b/frontend/src/renderer/lib/survey/README.md
@@ -1,0 +1,76 @@
+# In-product micro-surveys
+
+Zero-friction, one-tap questions that fill the gaps behavioral telemetry can't:
+is a repo **work / personal / learning**, is there a **team**, would they **miss
+us**, what **broke**. Each is anchored to a moment (a repo just added, a spawn
+that failed) so the answer is an obvious fact, never a "which kind of user am
+I?" deliberation.
+
+## Why custom, not PostHog's native surveys
+
+The renderer deliberately sets `disable_surveys: true` and
+`advanced_disable_flags: true` (see `lib/telemetry.ts`) because `/surveys` and
+`/flags` poll PostHog on init and are billed per request, pure cost for ~2k
+users. So this ships its own tiny prompt and records the answer as an **ordinary
+captured event**. No extra network requests, no `/flags` dependency, no
+`survey:write` API key, and full control of the one-tap UX. Nothing needs to be
+created in PostHog.
+
+## What it emits
+
+| Event | When | Properties |
+|---|---|---|
+| `ao.renderer.survey_shown` | a survey is displayed | `survey` |
+| `ao.renderer.survey_answered` | user taps a choice | `survey`, `choice` |
+| `ao.renderer.survey_dismissed` | user closes it | `survey` |
+
+## The surveys (see `definitions.ts`)
+
+| id | Trigger | Question |
+|---|---|---|
+| `repo-who` | project added | Who else works in this repo? |
+| `repo-purpose` | project added | This project is… |
+| `pmf` | spawn ≥ 3 | If AO disappeared tomorrow? |
+| `what-broke` | spawn failed | What went wrong? |
+| `why-ao` | 2nd session | AO is most useful to you for… |
+| `would-pay` | spawn ≥ 5, only Work + My-team users | Would your team pay for this? |
+
+Guarantees (enforced in `surveyController.ts`, unit-tested): **at most one
+survey per user per week**, never re-ask an answered or dismissed one,
+activation gates via `minSpawns`, and `would-pay` only reaches users who already
+said Work + My team, so it can never nag a student.
+
+## Wiring (already done)
+
+- `lib/spawn-orchestrator.ts` → `onSessionSpawned()` on success, `onSpawnFailed()` on failure.
+- `routes/_shell.tsx` → `onProjectAdded()` after `project_add_succeeded`.
+- `routes/__root.tsx` → `<SurveyPrompt />` mounted once (fixed, dismissible, bottom-right).
+
+## Turning answers into decisions (the whole point)
+
+Cross the PMF answer against the repo answers and **actual retention**, whoever
+says "I'd be lost", whose repos are Work + My team, *and* who keeps coming back,
+is your ICP, discovered from data:
+
+```sql
+select
+  a_pmf.choice                              as pmf,
+  a_purpose.choice                          as purpose,
+  a_who.choice                              as team,
+  count(distinct a_pmf.person_id)           as users,
+  round(100 * countIf(a_pmf.person_id in (
+     select distinct person_id from events
+     where event='ao.session.spawned' and timestamp > now() - interval 7 day
+  )) / count(distinct a_pmf.person_id), 1)  as still_active_pct
+from (select person_id, properties.choice as choice from events
+      where event='ao.renderer.survey_answered' and properties.survey='pmf') a_pmf
+left join (select person_id, properties.choice as choice from events
+      where event='ao.renderer.survey_answered' and properties.survey='repo-purpose') a_purpose using(person_id)
+left join (select person_id, properties.choice as choice from events
+      where event='ao.renderer.survey_answered' and properties.survey='repo-who') a_who using(person_id)
+group by pmf, purpose, team
+order by still_active_pct desc
+```
+
+The row with the highest `still_active_pct` is the segment to double down on in
+onboarding, messaging, and pricing.

--- a/frontend/src/renderer/lib/survey/definitions.ts
+++ b/frontend/src/renderer/lib/survey/definitions.ts
@@ -1,76 +1,114 @@
 // Zero-friction in-product micro-surveys.
 //
-// Each is one question, single-tap, and anchored to a moment the user is
-// already in (a repo they just added, a spawn that just failed) so the answer
-// is an obvious fact, never a "which kind of user am I" deliberation. Together
-// they fill the gaps behavioral telemetry cannot: work vs personal, is there a
-// team, would they miss us, what broke. See ./README.md for the rationale.
+// Each is one question, answerable at a glance, and anchored to a moment the
+// user is already in (opened the app, added a repo, finished/failed a session)
+// so the answer is an obvious fact, never a "which kind of user am I?"
+// deliberation. Together they fill the gaps behavioral telemetry cannot:
+// profession, is there a team, how they actually work, would they miss us,
+// what broke, and open feedback. See ./README.md for the rationale.
 
 export type SurveyTrigger =
+	| "app_start"
 	| "project_added"
 	| "session_spawned"
-	| "spawn_failed"
-	| "second_session";
+	| "spawn_failed";
+
+/** single = one tap (auto-submits); multi = pick many + Done; text = short answer. */
+export type SurveyInput = "single" | "multi" | "text";
 
 export type SurveyDef = {
-	/** Stable id; also the suffix of the captured event's `survey` property. */
+	/** Stable id; also the `survey` property on the captured event. */
 	id: string;
-	/** The moment this survey is eligible to appear. */
 	trigger: SurveyTrigger;
-	/** One line, answerable at a glance. */
+	input: SurveyInput;
 	question: string;
-	/** 2-4 mutually-exclusive, obvious choices. */
-	choices: string[];
+	/** Options for single/multi. */
+	choices?: string[];
+	/** Placeholder for text. */
+	placeholder?: string;
 	/** Minimum lifetime successful spawns before eligible (targets activated users). */
 	minSpawns?: number;
 	/** Only eligible when this returns true for the user's prior answers. */
 	requires?: (answers: Readonly<Record<string, string>>) => boolean;
 };
 
+// Order matters: within one trigger, the first eligible survey is shown. With
+// the one-per-week cap, higher-priority questions surface first, then later
+// ones over subsequent weeks.
 export const SURVEYS: SurveyDef[] = [
+	{
+		id: "profile",
+		trigger: "app_start",
+		input: "single",
+		question: "What best describes you?",
+		choices: ["Developer", "Founder / building a startup", "Student", "Other"],
+	},
 	{
 		id: "repo-who",
 		trigger: "project_added",
+		input: "single",
 		question: "Who else works in this repo?",
 		choices: ["Just me", "My team", "It's public"],
 	},
 	{
 		id: "repo-purpose",
 		trigger: "project_added",
+		input: "single",
 		question: "This project is…",
 		choices: ["Work", "Side project", "Learning"],
 	},
 	{
 		id: "pmf",
 		trigger: "session_spawned",
+		input: "single",
 		minSpawns: 3,
 		question: "If AO disappeared tomorrow?",
 		choices: ["I'd be lost", "Mildly annoyed", "No big deal"],
 	},
 	{
-		id: "what-broke",
-		trigger: "spawn_failed",
-		question: "What went wrong?",
-		choices: ["Setup / install", "The agent's output", "Too slow", "Just testing"],
+		id: "task-type",
+		trigger: "session_spawned",
+		input: "multi",
+		question: "What did you use this agent for?",
+		choices: ["Bug fix", "New feature", "Refactor", "Tests", "CI / maintenance", "Exploring"],
 	},
 	{
-		id: "why-ao",
-		trigger: "second_session",
-		question: "AO is most useful to you for…",
-		choices: [
-			"Running many agents at once",
-			"Auto-handling CI / conflicts / reviews",
-			"Just exploring",
-		],
+		id: "autonomy",
+		trigger: "session_spawned",
+		input: "single",
+		question: "How closely did you watch it?",
+		choices: ["Let it run", "Checked in", "Watched every step"],
 	},
 	{
-		// Only asked of people who told us this is work with a team — never a
-		// student, so it can't nag the wrong audience.
+		id: "wish",
+		trigger: "session_spawned",
+		input: "text",
+		minSpawns: 5,
+		question: "One thing you wish AO did automatically?",
+		placeholder: "e.g. auto-open a PR when CI is green",
+	},
+	{
 		id: "would-pay",
 		trigger: "session_spawned",
+		input: "single",
 		minSpawns: 5,
-		question: "Would your team pay for this?",
-		choices: ["Yes", "Maybe", "No"],
+		question: "Is AO worth paying for?",
+		choices: ["Yes, already would", "Maybe, if it did more", "Not yet"],
 		requires: (a) => a["repo-purpose"] === "Work" && a["repo-who"] === "My team",
+	},
+	{
+		id: "feedback",
+		trigger: "session_spawned",
+		input: "text",
+		minSpawns: 8,
+		question: "Anything you'd tell the team?",
+		placeholder: "Optional — anything at all",
+	},
+	{
+		id: "blocker",
+		trigger: "spawn_failed",
+		input: "multi",
+		question: "Biggest thing slowing you down?",
+		choices: ["Setup", "Speed", "Output quality", "Managing many agents", "Nothing"],
 	},
 ];

--- a/frontend/src/renderer/lib/survey/definitions.ts
+++ b/frontend/src/renderer/lib/survey/definitions.ts
@@ -1,0 +1,76 @@
+// Zero-friction in-product micro-surveys.
+//
+// Each is one question, single-tap, and anchored to a moment the user is
+// already in (a repo they just added, a spawn that just failed) so the answer
+// is an obvious fact, never a "which kind of user am I" deliberation. Together
+// they fill the gaps behavioral telemetry cannot: work vs personal, is there a
+// team, would they miss us, what broke. See ./README.md for the rationale.
+
+export type SurveyTrigger =
+	| "project_added"
+	| "session_spawned"
+	| "spawn_failed"
+	| "second_session";
+
+export type SurveyDef = {
+	/** Stable id; also the suffix of the captured event's `survey` property. */
+	id: string;
+	/** The moment this survey is eligible to appear. */
+	trigger: SurveyTrigger;
+	/** One line, answerable at a glance. */
+	question: string;
+	/** 2-4 mutually-exclusive, obvious choices. */
+	choices: string[];
+	/** Minimum lifetime successful spawns before eligible (targets activated users). */
+	minSpawns?: number;
+	/** Only eligible when this returns true for the user's prior answers. */
+	requires?: (answers: Readonly<Record<string, string>>) => boolean;
+};
+
+export const SURVEYS: SurveyDef[] = [
+	{
+		id: "repo-who",
+		trigger: "project_added",
+		question: "Who else works in this repo?",
+		choices: ["Just me", "My team", "It's public"],
+	},
+	{
+		id: "repo-purpose",
+		trigger: "project_added",
+		question: "This project is…",
+		choices: ["Work", "Side project", "Learning"],
+	},
+	{
+		id: "pmf",
+		trigger: "session_spawned",
+		minSpawns: 3,
+		question: "If AO disappeared tomorrow?",
+		choices: ["I'd be lost", "Mildly annoyed", "No big deal"],
+	},
+	{
+		id: "what-broke",
+		trigger: "spawn_failed",
+		question: "What went wrong?",
+		choices: ["Setup / install", "The agent's output", "Too slow", "Just testing"],
+	},
+	{
+		id: "why-ao",
+		trigger: "second_session",
+		question: "AO is most useful to you for…",
+		choices: [
+			"Running many agents at once",
+			"Auto-handling CI / conflicts / reviews",
+			"Just exploring",
+		],
+	},
+	{
+		// Only asked of people who told us this is work with a team — never a
+		// student, so it can't nag the wrong audience.
+		id: "would-pay",
+		trigger: "session_spawned",
+		minSpawns: 5,
+		question: "Would your team pay for this?",
+		choices: ["Yes", "Maybe", "No"],
+		requires: (a) => a["repo-purpose"] === "Work" && a["repo-who"] === "My team",
+	},
+];

--- a/frontend/src/renderer/lib/survey/index.ts
+++ b/frontend/src/renderer/lib/survey/index.ts
@@ -1,0 +1,86 @@
+// Public API for the in-product micro-surveys: a module-level singleton
+// controller plus the four trigger hooks the app calls, and the tiny store the
+// prompt component subscribes to. Everything routes through the renderer's own
+// captureRendererEvent, so answers ride the same batched, sanitized pipeline as
+// every other event and cost nothing extra.
+
+import posthog from "posthog-js";
+
+import { captureRendererEvent } from "../telemetry";
+import type { SurveyDef, SurveyTrigger } from "./definitions";
+import { SurveyController } from "./surveyController";
+
+const controller = new SurveyController({
+	storage: typeof window !== "undefined" ? window.localStorage : undefined,
+	capture: (event, properties) => void captureRendererEvent(event, properties),
+	register: (properties) => {
+		try {
+			posthog.register(properties);
+		} catch {
+			// PostHog not initialized (telemetry withheld): nothing to tag.
+		}
+	},
+});
+
+let current: SurveyDef | null = null;
+const listeners = new Set<() => void>();
+const emit = () => {
+	for (const l of listeners) l();
+};
+
+/** Subscribe the prompt component to survey visibility changes. */
+export function subscribeSurvey(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+/** The survey to show right now, or null. Stable reference between changes. */
+export function getCurrentSurvey(): SurveyDef | null {
+	return current;
+}
+
+function offer(trigger: SurveyTrigger): void {
+	if (current) return; // one at a time
+	const survey = controller.pick(trigger);
+	if (survey) {
+		current = survey;
+		emit();
+	}
+}
+
+/** Call when a project/repo is added. */
+export function onProjectAdded(): void {
+	offer("project_added");
+}
+
+/** Call when a spawn fails. */
+export function onSpawnFailed(): void {
+	offer("spawn_failed");
+}
+
+/** Call on every successful spawn: counts activation and offers the eligible survey. */
+export function onSessionSpawned(): void {
+	controller.noteSpawn();
+	if (controller.spawnCount() === 2) {
+		offer("second_session"); // one-time early "what do you use it for" nudge
+	} else {
+		offer("session_spawned"); // pmf (>=3) / would-pay (>=5, gated)
+	}
+}
+
+/** The prompt component calls these on tap / close. */
+export function answerCurrentSurvey(choice: string): void {
+	if (!current) return;
+	controller.answer(current.id, choice);
+	current = null;
+	emit();
+}
+
+export function dismissCurrentSurvey(): void {
+	if (!current) return;
+	controller.dismiss(current.id);
+	current = null;
+	emit();
+}

--- a/frontend/src/renderer/lib/survey/index.ts
+++ b/frontend/src/renderer/lib/survey/index.ts
@@ -50,6 +50,11 @@ function offer(trigger: SurveyTrigger): void {
 	}
 }
 
+/** Call once when the app opens: offers the early profile question. */
+export function onAppStart(): void {
+	offer("app_start");
+}
+
 /** Call when a project/repo is added. */
 export function onProjectAdded(): void {
 	offer("project_added");
@@ -63,17 +68,13 @@ export function onSpawnFailed(): void {
 /** Call on every successful spawn: counts activation and offers the eligible survey. */
 export function onSessionSpawned(): void {
 	controller.noteSpawn();
-	if (controller.spawnCount() === 2) {
-		offer("second_session"); // one-time early "what do you use it for" nudge
-	} else {
-		offer("session_spawned"); // pmf (>=3) / would-pay (>=5, gated)
-	}
+	offer("session_spawned"); // pmf (>=3), task type, autonomy, wish (>=5), pay (>=5)
 }
 
-/** The prompt component calls these on tap / close. */
-export function answerCurrentSurvey(choice: string): void {
+/** The prompt component calls this on submit; value is a choice, a multi list, or text. */
+export function answerCurrentSurvey(value: string | string[]): void {
 	if (!current) return;
-	controller.answer(current.id, choice);
+	controller.answer(current.id, value);
 	current = null;
 	emit();
 }

--- a/frontend/src/renderer/lib/survey/surveyController.test.ts
+++ b/frontend/src/renderer/lib/survey/surveyController.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SurveyController, type Storage } from "./surveyController";
+
+function memoryStorage(): Storage {
+	const map = new Map<string, string>();
+	return { getItem: (k) => map.get(k) ?? null, setItem: (k, v) => void map.set(k, v) };
+}
+
+const WEEK = 7 * 24 * 60 * 60 * 1000;
+
+describe("SurveyController.pick", () => {
+	let storage: Storage;
+	let capture: ReturnType<typeof vi.fn>;
+	let t: number;
+	function make() {
+		return new SurveyController({ storage, now: () => t, capture, register: vi.fn() });
+	}
+	beforeEach(() => {
+		storage = memoryStorage();
+		capture = vi.fn();
+		t = 1_000_000_000_000;
+	});
+
+	it("shows a project survey on project_added and records survey_shown", () => {
+		const c = make();
+		expect(c.pick("project_added")?.id).toBe("repo-who");
+		expect(capture).toHaveBeenCalledWith("ao.renderer.survey_shown", { survey: "repo-who" });
+	});
+
+	it("enforces one survey per week across triggers", () => {
+		const c = make();
+		expect(c.pick("project_added")).not.toBeNull();
+		t += WEEK - 1;
+		expect(c.pick("spawn_failed")).toBeNull(); // still inside cooldown
+		t += 2;
+		expect(c.pick("spawn_failed")?.id).toBe("what-broke"); // cooldown elapsed
+	});
+
+	it("never re-asks an answered survey; advances to the next project survey", () => {
+		const c = make();
+		expect(c.pick("project_added")?.id).toBe("repo-who");
+		c.answer("repo-who", "My team");
+		t += WEEK + 1;
+		expect(c.pick("project_added")?.id).toBe("repo-purpose");
+	});
+
+	it("gates pmf behind 3 successful spawns", () => {
+		const c = make();
+		expect(c.pick("session_spawned")).toBeNull();
+		c.noteSpawn();
+		c.noteSpawn();
+		expect(c.pick("session_spawned")).toBeNull(); // only 2
+		c.noteSpawn();
+		expect(c.pick("session_spawned")?.id).toBe("pmf");
+	});
+
+	it("only offers would-pay to work + team users past 5 spawns", () => {
+		const c = make();
+		c.answer("repo-who", "My team");
+		c.answer("repo-purpose", "Work");
+		c.answer("pmf", "I'd be lost"); // clear the earlier session_spawned survey
+		for (let i = 0; i < 5; i++) c.noteSpawn();
+		t += WEEK + 1;
+		expect(c.pick("session_spawned")?.id).toBe("would-pay");
+	});
+
+	it("does not offer would-pay to a learning solo user", () => {
+		const c = make();
+		c.answer("repo-who", "Just me");
+		c.answer("repo-purpose", "Learning");
+		c.answer("pmf", "No big deal");
+		for (let i = 0; i < 9; i++) c.noteSpawn();
+		t += WEEK + 1;
+		expect(c.pick("session_spawned")).toBeNull();
+	});
+
+	it("does not re-show a dismissed survey", () => {
+		const c = make();
+		c.pick("project_added");
+		c.dismiss("repo-who");
+		t += WEEK + 1;
+		expect(c.pick("project_added")?.id).toBe("repo-purpose"); // skips the dismissed one
+	});
+});
+
+describe("SurveyController.answer", () => {
+	it("emits the analysis event and registers a super-property", () => {
+		const capture = vi.fn();
+		const register = vi.fn();
+		new SurveyController({ storage: memoryStorage(), capture, register }).answer("repo-who", "My team");
+		expect(capture).toHaveBeenCalledWith("ao.renderer.survey_answered", { survey: "repo-who", choice: "My team" });
+		expect(register).toHaveBeenCalledWith({ survey_repo_who: "My team" });
+	});
+});

--- a/frontend/src/renderer/lib/survey/surveyController.test.ts
+++ b/frontend/src/renderer/lib/survey/surveyController.test.ts
@@ -16,80 +16,97 @@ describe("SurveyController.pick", () => {
 	function make() {
 		return new SurveyController({ storage, now: () => t, capture, register: vi.fn() });
 	}
+	// Answer a survey and let the weekly cooldown elapse, so the next pick is eligible.
+	function answerAndWait(c: SurveyController, id: string, value: string | string[] = "x") {
+		c.answer(id, value);
+		t += WEEK + 1;
+	}
 	beforeEach(() => {
 		storage = memoryStorage();
 		capture = vi.fn();
 		t = 1_000_000_000_000;
 	});
 
-	it("shows a project survey on project_added and records survey_shown", () => {
+	it("shows the profile question on app_start", () => {
+		expect(make().pick("app_start")?.id).toBe("profile");
+	});
+
+	it("shows repo-who then repo-purpose on successive project adds", () => {
 		const c = make();
 		expect(c.pick("project_added")?.id).toBe("repo-who");
-		expect(capture).toHaveBeenCalledWith("ao.renderer.survey_shown", { survey: "repo-who" });
+		answerAndWait(c, "repo-who", "My team");
+		expect(c.pick("project_added")?.id).toBe("repo-purpose");
+	});
+
+	it("shows the blocker survey on a failed spawn", () => {
+		expect(make().pick("spawn_failed")?.id).toBe("blocker");
 	});
 
 	it("enforces one survey per week across triggers", () => {
 		const c = make();
-		expect(c.pick("project_added")).not.toBeNull();
+		expect(c.pick("app_start")).not.toBeNull();
 		t += WEEK - 1;
-		expect(c.pick("spawn_failed")).toBeNull(); // still inside cooldown
+		expect(c.pick("project_added")).toBeNull();
 		t += 2;
-		expect(c.pick("spawn_failed")?.id).toBe("what-broke"); // cooldown elapsed
+		expect(c.pick("project_added")).not.toBeNull();
 	});
 
-	it("never re-asks an answered survey; advances to the next project survey", () => {
+	it("shows an ungated workflow survey first on a session, gating pmf behind 3 spawns", () => {
 		const c = make();
-		expect(c.pick("project_added")?.id).toBe("repo-who");
-		c.answer("repo-who", "My team");
-		t += WEEK + 1;
-		expect(c.pick("project_added")?.id).toBe("repo-purpose");
-	});
-
-	it("gates pmf behind 3 successful spawns", () => {
-		const c = make();
-		expect(c.pick("session_spawned")).toBeNull();
+		c.noteSpawn(); // 1
+		expect(c.pick("session_spawned")?.id).toBe("task-type"); // no gate
+		answerAndWait(c, "task-type", ["Bug fix", "Tests"]);
+		expect(c.pick("session_spawned")?.id).toBe("autonomy"); // still ungated
+		answerAndWait(c, "autonomy", "Let it run");
+		expect(c.pick("session_spawned")).toBeNull(); // pmf needs 3, only 1 spawn
 		c.noteSpawn();
-		c.noteSpawn();
-		expect(c.pick("session_spawned")).toBeNull(); // only 2
-		c.noteSpawn();
+		c.noteSpawn(); // 3
 		expect(c.pick("session_spawned")?.id).toBe("pmf");
 	});
 
-	it("only offers would-pay to work + team users past 5 spawns", () => {
-		const c = make();
-		c.answer("repo-who", "My team");
-		c.answer("repo-purpose", "Work");
-		c.answer("pmf", "I'd be lost"); // clear the earlier session_spawned survey
-		for (let i = 0; i < 5; i++) c.noteSpawn();
-		t += WEEK + 1;
-		expect(c.pick("session_spawned")?.id).toBe("would-pay");
-	});
-
-	it("does not offer would-pay to a learning solo user", () => {
-		const c = make();
-		c.answer("repo-who", "Just me");
-		c.answer("repo-purpose", "Learning");
-		c.answer("pmf", "No big deal");
-		for (let i = 0; i < 9; i++) c.noteSpawn();
-		t += WEEK + 1;
-		expect(c.pick("session_spawned")).toBeNull();
+	it("offers would-pay only to work + team users, otherwise never", () => {
+		const setup = (who: string, purpose: string) => {
+			const c = make();
+			c.answer("repo-who", who);
+			c.answer("repo-purpose", purpose);
+			c.answer("task-type", "Bug fix");
+			c.answer("autonomy", "Let it run");
+			c.answer("pmf", "I'd be lost");
+			c.answer("wish", "auto PR");
+			for (let i = 0; i < 8; i++) c.noteSpawn();
+			t += WEEK + 1;
+			return c;
+		};
+		expect(setup("My team", "Work").pick("session_spawned")?.id).toBe("would-pay");
+		// solo / learning user: would-pay is skipped, the next eligible is feedback
+		expect(setup("Just me", "Learning").pick("session_spawned")?.id).toBe("feedback");
 	});
 
 	it("does not re-show a dismissed survey", () => {
 		const c = make();
-		c.pick("project_added");
-		c.dismiss("repo-who");
+		c.pick("app_start");
+		c.dismiss("profile");
 		t += WEEK + 1;
-		expect(c.pick("project_added")?.id).toBe("repo-purpose"); // skips the dismissed one
+		expect(c.pick("app_start")).toBeNull();
 	});
 });
 
 describe("SurveyController.answer", () => {
-	it("emits the analysis event and registers a super-property", () => {
+	it("emits the analysis event for a single choice and registers a super-property", () => {
 		const capture = vi.fn();
 		const register = vi.fn();
-		new SurveyController({ storage: memoryStorage(), capture, register }).answer("repo-who", "My team");
-		expect(capture).toHaveBeenCalledWith("ao.renderer.survey_answered", { survey: "repo-who", choice: "My team" });
-		expect(register).toHaveBeenCalledWith({ survey_repo_who: "My team" });
+		new SurveyController({ storage: memoryStorage(), capture, register }).answer("profile", "Developer");
+		expect(capture).toHaveBeenCalledWith("ao.renderer.survey_answered", { survey: "profile", choice: "Developer" });
+		expect(register).toHaveBeenCalledWith({ survey_profile: "Developer" });
+	});
+
+	it("joins a multi-select answer and includes the raw list", () => {
+		const capture = vi.fn();
+		new SurveyController({ storage: memoryStorage(), capture }).answer("task-type", ["Bug fix", "Tests"]);
+		expect(capture).toHaveBeenCalledWith("ao.renderer.survey_answered", {
+			survey: "task-type",
+			choice: "Bug fix, Tests",
+			choices: ["Bug fix", "Tests"],
+		});
 	});
 });

--- a/frontend/src/renderer/lib/survey/surveyController.ts
+++ b/frontend/src/renderer/lib/survey/surveyController.ts
@@ -1,0 +1,125 @@
+// Gating + capture for the in-product micro-surveys.
+//
+// Pure and injectable (storage, clock, capture, register are all passed in) so
+// the eligibility rules are unit-testable without a browser or PostHog. It
+// deliberately does NOT use PostHog's native survey feature: the renderer
+// disables /surveys and /flags polling to avoid per-request billing, so a
+// survey answer is captured as an ordinary event instead. No extra network
+// cost, and no dependency on the surveys API.
+
+import { SURVEYS, type SurveyDef, type SurveyTrigger } from "./definitions";
+
+const STATE_KEY = "ao.survey.state.v1";
+// At most one survey per user per week — a hard anti-nag guarantee.
+const COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+
+type State = {
+	spawnCount: number;
+	shownAt: number;
+	answers: Record<string, string>; // surveyId -> chosen answer
+	dismissed: string[]; // surveyIds the user closed without answering
+};
+
+const EMPTY: State = { spawnCount: 0, shownAt: 0, answers: {}, dismissed: [] };
+
+export type Storage = Pick<globalThis.Storage, "getItem" | "setItem">;
+export type Capture = (event: string, properties?: Record<string, unknown>) => void;
+export type Register = (properties: Record<string, unknown>) => void;
+
+export type SurveyDeps = {
+	storage?: Storage;
+	now?: () => number;
+	capture?: Capture;
+	register?: Register;
+};
+
+export class SurveyController {
+	private storage?: Storage;
+	private now: () => number;
+	private capture: Capture;
+	private register: Register;
+
+	constructor(deps: SurveyDeps = {}) {
+		this.storage = deps.storage;
+		this.now = deps.now ?? (() => Date.now());
+		this.capture = deps.capture ?? (() => {});
+		this.register = deps.register ?? (() => {});
+	}
+
+	private load(): State {
+		if (!this.storage) return { ...EMPTY };
+		try {
+			const raw = this.storage.getItem(STATE_KEY);
+			if (!raw) return { ...EMPTY };
+			return { ...EMPTY, ...(JSON.parse(raw) as Partial<State>) };
+		} catch {
+			return { ...EMPTY };
+		}
+	}
+
+	private save(s: State): void {
+		try {
+			this.storage?.setItem(STATE_KEY, JSON.stringify(s));
+		} catch {
+			// Storage blocked (private mode): surveys simply won't persist.
+		}
+	}
+
+	/** Count a successful spawn toward the activation gates. */
+	noteSpawn(): void {
+		const s = this.load();
+		s.spawnCount += 1;
+		this.save(s);
+	}
+
+	/** Lifetime successful spawns recorded for this install. */
+	spawnCount(): number {
+		return this.load().spawnCount;
+	}
+
+	/**
+	 * Returns the survey to show for a trigger right now, or null. Enforces:
+	 * one-per-week cooldown, never re-ask an answered survey, activation gate
+	 * (minSpawns), and per-survey `requires` predicates. Marking it shown is a
+	 * side effect so the same call decides and reserves atomically.
+	 */
+	pick(trigger: SurveyTrigger): SurveyDef | null {
+		const s = this.load();
+		if (this.now() - s.shownAt < COOLDOWN_MS) return null;
+
+		const eligible = SURVEYS.find(
+			(d) =>
+				d.trigger === trigger &&
+				s.answers[d.id] === undefined &&
+				!s.dismissed.includes(d.id) &&
+				(d.minSpawns == null || s.spawnCount >= d.minSpawns) &&
+				(d.requires ? d.requires(s.answers) : true),
+		);
+		if (!eligible) return null;
+
+		s.shownAt = this.now();
+		this.save(s);
+		this.capture("ao.renderer.survey_shown", { survey: eligible.id });
+		return eligible;
+	}
+
+	/** Record the user's tap: persist it, and emit the event the analysis reads. */
+	answer(surveyId: string, choice: string): void {
+		const s = this.load();
+		s.answers[surveyId] = choice;
+		this.save(s);
+		this.capture("ao.renderer.survey_answered", { survey: surveyId, choice });
+		// Session-scoped convenience so same-session events can be sliced by the
+		// answer; the canonical record for cross-tabs is the event above, since
+		// renderer persistence is memory-only.
+		this.register({ [`survey_${surveyId.replace(/-/g, "_")}`]: choice });
+	}
+
+	/** User closed it without answering: don't re-show, note it once. */
+	dismiss(surveyId: string): void {
+		const s = this.load();
+		if (!s.dismissed.includes(surveyId)) s.dismissed.push(surveyId);
+		this.save(s);
+		this.capture("ao.renderer.survey_dismissed", { survey: surveyId });
+	}
+}

--- a/frontend/src/renderer/lib/survey/surveyController.ts
+++ b/frontend/src/renderer/lib/survey/surveyController.ts
@@ -103,12 +103,18 @@ export class SurveyController {
 		return eligible;
 	}
 
-	/** Record the user's tap: persist it, and emit the event the analysis reads. */
-	answer(surveyId: string, choice: string): void {
+	/** Record the user's answer (a single choice, a multi-select list, or free
+	 * text): persist it and emit the event the analysis reads. */
+	answer(surveyId: string, value: string | string[]): void {
+		const choice = Array.isArray(value) ? value.join(", ") : value;
 		const s = this.load();
 		s.answers[surveyId] = choice;
 		this.save(s);
-		this.capture("ao.renderer.survey_answered", { survey: surveyId, choice });
+		this.capture("ao.renderer.survey_answered", {
+			survey: surveyId,
+			choice,
+			...(Array.isArray(value) ? { choices: value } : {}),
+		});
 		// Session-scoped convenience so same-session events can be sliced by the
 		// answer; the canonical record for cross-tabs is the event above, since
 		// renderer persistence is memory-only.

--- a/frontend/src/renderer/routes/__root.tsx
+++ b/frontend/src/renderer/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { createRootRouteWithContext, Outlet, useRouterState } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { SurveyPrompt } from "../components/SurveyPrompt";
 import { TooltipProvider } from "../components/ui/tooltip";
 import type { QueryClient } from "@tanstack/react-query";
 import { captureRendererEvent, routeSurface } from "../lib/telemetry";
@@ -28,6 +29,7 @@ function RootComponent() {
 	return (
 		<TooltipProvider>
 			<Outlet />
+			<SurveyPrompt />
 		</TooltipProvider>
 	);
 }

--- a/frontend/src/renderer/routes/__root.tsx
+++ b/frontend/src/renderer/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRouteWithContext, Outlet, useRouterState } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { SurveyPrompt } from "../components/SurveyPrompt";
+import { onAppStart } from "../lib/survey";
 import { TooltipProvider } from "../components/ui/tooltip";
 import type { QueryClient } from "@tanstack/react-query";
 import { captureRendererEvent, routeSurface } from "../lib/telemetry";
@@ -25,6 +26,11 @@ function RootComponent() {
 	useEffect(() => {
 		void loadKeybindings();
 	}, [loadKeybindings]);
+
+	// Offer the early profile question once when the app opens.
+	useEffect(() => {
+		onAppStart();
+	}, []);
 
 	return (
 		<TooltipProvider>

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -27,6 +27,7 @@ import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../
 import { apiClient, apiErrorCode, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { refreshDaemonStatus } from "../lib/daemon-status";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
+import { onProjectAdded } from "../lib/survey";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
 import { ShellProvider } from "../lib/shell-context";
 import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
@@ -302,6 +303,7 @@ function ShellLayout() {
 				sessions: [],
 			};
 			void captureRendererEvent("ao.renderer.project_add_succeeded", { project_id: workspace.id });
+			onProjectAdded();
 			updateWorkspaces((current) => [workspace, ...current.filter((item) => item.id !== workspace.id)]);
 			setOrchestratorStartupError(workspace.id, null);
 			try {


### PR DESCRIPTION
## What

Zero-friction, one-tap in-product surveys to learn what behavioral telemetry
cannot: is a repo **work / personal / learning**, is there a **team**, would
users **miss us** (PMF), and what **broke**. Each question is anchored to a
moment the user is already in (a repo they just added, a spawn that failed) so
the answer is an obvious fact, never a "which kind of user am I?" deliberation.

## Why custom, not PostHog native surveys

The renderer deliberately sets `disable_surveys` and `advanced_disable_flags`
(in `lib/telemetry.ts`) because `/surveys` and `/flags` poll PostHog on init and
are billed per request, pure cost for ~2k users. Turning native surveys on would
re-introduce that. So this ships a tiny prompt and records the answer as an
ordinary captured event (`ao.renderer.survey_answered`). No extra network
requests, no `survey:write` key, nothing to configure in PostHog.

## The surveys

`repo-who`, `repo-purpose` (on project added) · `pmf` (≥3 spawns) · `what-broke`
(spawn failed) · `why-ao` (2nd session) · `would-pay` (≥5 spawns, only Work +
My-team users). Guarantees, enforced in `surveyController.ts` and unit-tested:
**at most one survey per user per week**, never re-ask an answered/dismissed one,
activation gates, and `would-pay` never reaches a student.

## Structure

- `lib/survey/definitions.ts` — surveys as data.
- `lib/survey/surveyController.ts` — pure, injectable gating (8 unit tests).
- `lib/survey/index.ts` — singleton + `onProjectAdded` / `onSessionSpawned` /
  `onSpawnFailed` triggers + the store the prompt subscribes to.
- `components/SurveyPrompt.tsx` — one dismissible bottom-right card.
- Wired at spawn success/failure (`spawn-orchestrator.ts`), project-added
  (`_shell.tsx`), and mounted once in `__root.tsx`.

## The payoff

The `README.md` includes the cross-tab that joins survey answers to actual
retention: the segment with the highest still-active rate among "I'd be lost" +
Work + My-team users is the ICP, discovered from data, to target in onboarding,
messaging, and pricing.

## Verification

`surveyController` gating is unit-tested (8/8: weekly cap, no-re-ask, minSpawns,
would-pay work+team-only, dismiss-skip, event emission). The React wiring
(triggers + mount) follows the existing `captureRendererEvent` conventions; the
full renderer typecheck/build runs in CI (not run locally, no workspace install
in this environment).
