### PR TITLE
fix(lifecycle): deduplicate review feedback across internal and SCM lanes

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -686,7 +686,7 @@ func buildReviewThreadsQuery(ref ports.SCMPRRef, beforeCursor string, includeRev
 	return fmt.Sprintf(`query{
 repo: repository(owner:%s,name:%s){ pullRequest(number:%d){ reviewDecision%s reviewThreads(last:%d, before:%s){ nodes{
   id isResolved path line
-  comments(first:%d){ nodes{ id body url author{ login __typename } } }
+  comments(first:%d){ nodes{ id body url pullRequestReview{ url } author{ login __typename } } }
 } pageInfo{ hasPreviousPage startCursor } } } }
 }`, graphQLString(ref.Repo.Owner), graphQLString(ref.Repo.Name), ref.Number, reviewSelection, githubReviewThreadPageSize, before, githubReviewCommentLimitPerThread)
 }
@@ -731,16 +731,18 @@ func scmThreadFromGraphQL(th map[string]any) ports.SCMReviewThreadObservation {
 	allCommentsBot := len(commentNodes) > 0
 	for _, cn := range commentNodes {
 		author, _ := cn["author"].(map[string]any)
+		review, _ := cn["pullRequestReview"].(map[string]any)
 		isBot := isBotAuthor(author)
 		if !isBot {
 			allCommentsBot = false
 		}
 		out.Comments = append(out.Comments, ports.SCMReviewCommentObservation{
-			ID:     str(cn["id"]),
-			Author: str(author["login"]),
-			Body:   str(cn["body"]),
-			URL:    str(cn["url"]),
-			IsBot:  isBot,
+			ID:        str(cn["id"]),
+			Author:    str(author["login"]),
+			Body:      str(cn["body"]),
+			URL:       str(cn["url"]),
+			ReviewURL: str(review["url"]),
+			IsBot:     isBot,
 		})
 	}
 	out.IsBot = allCommentsBot

--- a/backend/internal/adapters/scm/github/review_parent_url_test.go
+++ b/backend/internal/adapters/scm/github/review_parent_url_test.go
@@ -1,0 +1,75 @@
+package github
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestBuildReviewThreadsQueryIncludesParentReviewURL(t *testing.T) {
+	query := buildReviewThreadsQuery(
+		ports.SCMPRRef{
+			Repo: ports.SCMRepo{
+				Owner: "acme",
+				Name:  "repo",
+			},
+			Number: 7,
+		},
+		"",
+		false,
+	)
+
+	if !strings.Contains(query, "pullRequestReview{ url }") {
+		t.Fatalf(
+			"review-thread query must request each comment's parent review URL; query:\n%s",
+			query,
+		)
+	}
+}
+
+func TestSCMThreadFromGraphQLCarriesParentReviewURL(t *testing.T) {
+	const reviewURL = "https://github.com/acme/repo/pull/7#pullrequestreview-4949207965"
+
+	thread := scmThreadFromGraphQL(map[string]any{
+		"id":         "THREAD_1",
+		"isResolved": false,
+		"path":       "extra.txt",
+		"line":       float64(1),
+		"comments": map[string]any{
+			"nodes": []any{
+				map[string]any{
+					"id":   "COMMENT_1",
+					"body": "Remove this file.",
+					"url":  "https://github.com/acme/repo/pull/7#discussion_r1",
+					"pullRequestReview": map[string]any{
+						"url": reviewURL,
+					},
+					"author": map[string]any{
+						"login":      "reviewer",
+						"__typename": "User",
+					},
+				},
+			},
+		},
+	})
+
+	if len(thread.Comments) != 1 {
+		t.Fatalf("comments = %#v; want exactly 1", thread.Comments)
+	}
+
+	// Reflection keeps this regression compilable before the DTO grows
+	// the ReviewURL field. The expected RED is behavioral, not a build error.
+	comment := reflect.ValueOf(thread.Comments[0])
+	field := comment.FieldByName("ReviewURL")
+	if !field.IsValid() {
+		t.Fatalf("SCMReviewCommentObservation must expose ReviewURL")
+	}
+	if field.Kind() != reflect.String {
+		t.Fatalf("ReviewURL kind = %s, want string", field.Kind())
+	}
+	if got := field.String(); got != reviewURL {
+		t.Fatalf("ReviewURL = %q, want %q", got, reviewURL)
+	}
+}

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -99,7 +99,100 @@ func (m *Manager) ApplyReviewBatch(ctx context.Context, workerID domain.SessionI
 		// delivered — it must re-fire once the session is workable again.
 		return ReviewDeliveryNoop, nil
 	}
+	for _, r := range results {
+		if err := m.markSCMReviewCovered(ctx, r); err != nil {
+			return ReviewDeliveryNoop, err
+		}
+	}
 	return ReviewDeliverySent, nil
+}
+
+// markSCMReviewCovered records that AO already delivered the provider review
+// represented by an internal reviewer result. A later SCM observation of the
+// same GitHub review must therefore not wake the worker a second time.
+//
+// GithubReviewID is GitHub's numeric review/database ID. The SCM observer uses
+// an opaque GraphQL node ID for PullRequestReview.ID, so the two lanes are
+// correlated through the numeric ID embedded in the provider review URL.
+func (m *Manager) markSCMReviewCovered(ctx context.Context, r ReviewResult) error {
+	prURL := strings.TrimSpace(r.PRURL)
+	reviewID := strings.TrimSpace(r.GithubReviewID)
+	if prURL == "" || reviewID == "" {
+		return nil
+	}
+
+	key := reviewDeliveryCoverageKey(prURL, reviewID)
+	sig := string(domain.ReviewChangesRequest)
+
+	m.react.mu.Lock()
+	defer m.react.mu.Unlock()
+
+	if !m.react.loaded[prURL] {
+		if err := m.loadPRSignaturesLocked(ctx, prURL); err != nil {
+			return err
+		}
+		m.react.loaded[prURL] = true
+	}
+
+	m.react.seen[key] = sig
+	return m.persistPRSignaturesLocked(ctx, prURL)
+}
+
+// scmReviewCoveredByInternalReview reports whether an SCM review is another
+// representation of feedback already delivered through AO's internal
+// reviewer lane.
+func (m *Manager) scmReviewCoveredByInternalReview(
+	ctx context.Context,
+	prURL string,
+	review domain.PullRequestReview,
+) (bool, error) {
+	reviewID := githubReviewDatabaseIDFromURL(review.URL)
+	if strings.TrimSpace(prURL) == "" || reviewID == "" {
+		return false, nil
+	}
+
+	key := reviewDeliveryCoverageKey(prURL, reviewID)
+	sig := string(domain.ReviewChangesRequest)
+
+	m.react.mu.Lock()
+	defer m.react.mu.Unlock()
+
+	if !m.react.loaded[prURL] {
+		if err := m.loadPRSignaturesLocked(ctx, prURL); err != nil {
+			return false, err
+		}
+		m.react.loaded[prURL] = true
+	}
+
+	return m.react.seen[key] == sig, nil
+}
+
+func reviewDeliveryCoverageKey(prURL, reviewID string) string {
+	return "review-delivered:" + prURL + ":" + reviewID
+}
+
+// githubReviewDatabaseIDFromURL extracts the numeric database ID from a GitHub
+// review URL such as ".../pull/7#pullrequestreview-4949207965".
+func githubReviewDatabaseIDFromURL(reviewURL string) string {
+	const marker = "#pullrequestreview-"
+
+	i := strings.LastIndex(reviewURL, marker)
+	if i < 0 {
+		return ""
+	}
+
+	id := strings.TrimSpace(reviewURL[i+len(marker):])
+	if id == "" {
+		return ""
+	}
+
+	for _, r := range id {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+
+	return id
 }
 
 type reactionState struct {
@@ -172,6 +265,15 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	if cannotNudge(rec) {
 		return nil
 	}
+	reviewURLByCommentID := make(map[string]string, len(o.Comments))
+	for _, comment := range o.Comments {
+		commentID := strings.TrimSpace(comment.ID)
+		reviewURL := strings.TrimSpace(comment.ReviewURL)
+		if commentID != "" && reviewURL != "" {
+			reviewURLByCommentID[commentID] = reviewURL
+		}
+	}
+
 	reviews, err := m.store.ListPRReviews(ctx, o.URL)
 	if err != nil {
 		return fmt.Errorf("list persisted reviews for %s: %w", o.URL, err)
@@ -181,6 +283,12 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 		return fmt.Errorf("list persisted comments for %s: %w", o.URL, err)
 	}
 	o.Comments = prCommentObservations(comments)
+	for i := range o.Comments {
+		commentID := strings.TrimSpace(o.Comments[i].ID)
+		if reviewURL := reviewURLByCommentID[commentID]; reviewURL != "" {
+			o.Comments[i].ReviewURL = reviewURL
+		}
+	}
 	// A single PR can trip several actionable conditions at once (failing CI,
 	// unresolved review comments, a merge conflict). Queue every applicable nudge
 	// and send them together, so each surfaces independently instead of one
@@ -220,6 +328,32 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			if !comment.AutoInjectReview {
 				continue
 			}
+			covered, coverageErr := m.scmReviewCoveredByInternalReview(
+				ctx,
+				o.URL,
+				domain.PullRequestReview{URL: comment.ReviewURL},
+			)
+			if coverageErr != nil {
+				slog.Default().Warn(
+					"lifecycle: failed to check internal review coverage for comment",
+					"pr", o.URL,
+					"comment", comment.ID,
+					"error", coverageErr,
+				)
+			} else if covered {
+				key, sig := reviewCommentReactionDedup(o.URL, comment, o.Review)
+				if markErr := m.markPRReactionCovered(ctx, o.URL, key, sig); markErr != nil {
+					slog.Default().Warn(
+						"lifecycle: failed to persist covered review-comment identity",
+						"pr", o.URL,
+						"comment", comment.ID,
+						"thread", comment.ThreadID,
+						"error", markErr,
+					)
+				}
+				continue
+			}
+
 			commentSlice := []ports.PRCommentObservation{comment}
 			msg := formatReviewCommentsMessage(commentSlice)
 			if ident != "your PR" {
@@ -228,11 +362,17 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			if o.URL != "" {
 				msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
 			}
-			sig := reviewCommentsSignature(commentSlice)
-			if sig == "" {
-				sig = string(o.Review)
-			}
-			nudges = append(nudges, pendingNudge{key: "comment:" + o.URL, sig: sig, msg: msg, maxAttempts: reviewMaxNudge})
+			// A review thread represents one actionable finding. Replies inside
+			// that same thread must not create a fresh lifecycle nudge merely
+			// because the provider assigned the reply a new comment ID.
+			key, sig := reviewCommentReactionDedup(o.URL, comment, o.Review)
+
+			nudges = append(nudges, pendingNudge{
+				key:         key,
+				sig:         sig,
+				msg:         msg,
+				maxAttempts: reviewMaxNudge,
+			})
 		}
 	}
 
@@ -241,6 +381,21 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			if review.State != domain.ReviewChangesRequest || !review.AutoInjectReview {
 				continue
 			}
+
+			covered, coverageErr := m.scmReviewCoveredByInternalReview(ctx, o.URL, review)
+			if coverageErr != nil {
+				// Coverage lookup failures fail open: risking one duplicate nudge
+				// is safer than silently swallowing genuine review feedback.
+				slog.Default().Warn(
+					"lifecycle: failed to check internal review coverage",
+					"pr", o.URL,
+					"review", review.ID,
+					"error", coverageErr,
+				)
+			} else if covered {
+				continue
+			}
+
 			msg := formatReviewChangesRequestedMessage(review)
 			if ident != "your PR" {
 				msg = strings.Replace(msg, "your PR", ident, 1)
@@ -506,6 +661,21 @@ func scmToPRObservation(o ports.SCMObservation) ports.PRObservation {
 			LogTail:    logTail,
 		})
 	}
+	for _, thread := range o.Review.Threads {
+		for _, comment := range thread.Comments {
+			pr.Comments = append(pr.Comments, ports.PRCommentObservation{
+				ID:        comment.ID,
+				ThreadID:  thread.ID,
+				Author:    comment.Author,
+				File:      thread.Path,
+				Line:      thread.Line,
+				Body:      comment.Body,
+				URL:       comment.URL,
+				ReviewURL: comment.ReviewURL,
+				Resolved:  thread.Resolved,
+			})
+		}
+	}
 	return pr
 }
 
@@ -717,6 +887,55 @@ func unresolvedReviewComments(comments []ports.PRCommentObservation) []ports.PRC
 	return unresolved
 }
 
+func reviewCommentReactionDedup(
+	prURL string,
+	comment ports.PRCommentObservation,
+	review domain.ReviewDecision,
+) (key, sig string) {
+	dedupID := strings.TrimSpace(comment.ThreadID)
+	if dedupID != "" {
+		dedupID = "thread:" + dedupID
+	} else if commentID := strings.TrimSpace(comment.ID); commentID != "" {
+		dedupID = "comment:" + commentID
+	}
+
+	sig = dedupID
+	if sig == "" {
+		sig = reviewCommentsSignature([]ports.PRCommentObservation{comment})
+	}
+	if sig == "" {
+		sig = string(review)
+	}
+
+	key = "comment:" + prURL
+	if dedupID != "" {
+		key += ":" + dedupID
+	}
+	return key, sig
+}
+
+func (m *Manager) markPRReactionCovered(
+	ctx context.Context,
+	prURL, key, sig string,
+) error {
+	prURL = strings.TrimSpace(prURL)
+	if prURL == "" || strings.TrimSpace(key) == "" || sig == "" {
+		return nil
+	}
+
+	m.react.mu.Lock()
+	defer m.react.mu.Unlock()
+
+	if !m.react.loaded[prURL] {
+		if err := m.loadPRSignaturesLocked(ctx, prURL); err != nil {
+			return err
+		}
+		m.react.loaded[prURL] = true
+	}
+
+	m.react.seen[key] = sig
+	return m.persistPRSignaturesLocked(ctx, prURL)
+}
 func reviewCommentsSignature(comments []ports.PRCommentObservation) string {
 	parts := make([]string, 0, len(comments))
 	for _, c := range comments {

--- a/backend/internal/lifecycle/review_cross_lane_dedup_test.go
+++ b/backend/internal/lifecycle/review_cross_lane_dedup_test.go
@@ -1,0 +1,497 @@
+package lifecycle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestReviewBatchSuppressesDuplicateSCMReviewNudge(t *testing.T) {
+	m, st, msg := newManager()
+
+	workerID := domain.SessionID("mer-review-dedup")
+	prURL := "https://github.com/acme/repo/pull/7"
+	st.sessions[workerID] = working(workerID)
+
+	outcome, err := m.ApplyReviewBatch(
+		context.Background(),
+		workerID,
+		"batch-1",
+		[]ReviewResult{{
+			RunID:          "run-1",
+			BatchID:        "batch-1",
+			WorkerID:       workerID,
+			PRURL:          prURL,
+			TargetSHA:      "deadbeef",
+			Verdict:        domain.VerdictChangesRequested,
+			Body:           "Remove extra.txt",
+			GithubReviewID: "4949207965",
+		}},
+	)
+	if err != nil {
+		t.Fatalf("ApplyReviewBatch: %v", err)
+	}
+	if outcome != ReviewDeliverySent {
+		t.Fatalf("ApplyReviewBatch outcome = %q, want %q", outcome, ReviewDeliverySent)
+	}
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf("internal review should wake worker exactly once; got %d messages: %#v", got, msg.msgs)
+	}
+
+	// The SCM observer sees the same GitHub review through GraphQL, where the
+	// review ID is an opaque node ID but the review URL still carries the
+	// numeric GitHub review/database ID reported by AO's reviewer.
+	st.reviews[prURL] = []domain.PullRequestReview{{
+		ID:               "PRR_kwDOopaque",
+		Author:           "reviewer",
+		State:            domain.ReviewChangesRequest,
+		URL:              prURL + "#pullrequestreview-4949207965",
+		Body:             "Remove extra.txt",
+		TargetSHA:        "deadbeef",
+		AutoInjectReview: true,
+	}}
+
+	err = m.ApplyPRObservation(
+		context.Background(),
+		workerID,
+		ports.PRObservation{
+			Fetched: true,
+			URL:     prURL,
+			Review:  domain.ReviewChangesRequest,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ApplyPRObservation: %v", err)
+	}
+
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf(
+			"SCM observation of the already-delivered GitHub review must not wake worker again; got %d messages: %#v",
+			got,
+			msg.msgs,
+		)
+	}
+}
+
+func TestPRObservation_WorkerReplyInSameReviewThreadDoesNotRenudge(t *testing.T) {
+	m, st, msg := newManager()
+
+	workerID := domain.SessionID("mer-thread-dedup")
+	prURL := "https://github.com/acme/repo/pull/8"
+	st.sessions[workerID] = working(workerID)
+
+	// First observation: the reviewer leaves one actionable finding.
+	st.comments[prURL] = []domain.PullRequestComment{
+		{
+			ThreadID:         "thread-1",
+			ID:               "review-comment-1",
+			Author:           "reviewer",
+			File:             "extra.txt",
+			Line:             1,
+			Body:             "Remove this out-of-scope file.",
+			Resolved:         false,
+			AutoInjectReview: true,
+		},
+	}
+
+	err := m.ApplyPRObservation(
+		context.Background(),
+		workerID,
+		ports.PRObservation{
+			Fetched: true,
+			URL:     prURL,
+		},
+	)
+	if err != nil {
+		t.Fatalf("first ApplyPRObservation: %v", err)
+	}
+
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf(
+			"reviewer comment should wake worker exactly once; got %d messages: %#v",
+			got,
+			msg.msgs,
+		)
+	}
+
+	// Second observation: after addressing the finding, the worker replies in
+	// the SAME review thread. GitHub assigns the reply a different comment ID,
+	// but it is not a new actionable review finding and must not wake the worker
+	// again merely because the thread snapshot changed.
+	st.comments[prURL] = append(
+		st.comments[prURL],
+		domain.PullRequestComment{
+			ThreadID:         "thread-1",
+			ID:               "worker-reply-1",
+			Author:           "worker",
+			File:             "extra.txt",
+			Line:             1,
+			Body:             "Removed in the latest commit.",
+			Resolved:         false,
+			AutoInjectReview: true,
+		},
+	)
+
+	err = m.ApplyPRObservation(
+		context.Background(),
+		workerID,
+		ports.PRObservation{
+			Fetched: true,
+			URL:     prURL,
+		},
+	)
+	if err != nil {
+		t.Fatalf("second ApplyPRObservation: %v", err)
+	}
+
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf(
+			"worker reply in an already-notified review thread must not wake worker again; got %d messages: %#v",
+			got,
+			msg.msgs,
+		)
+	}
+}
+
+func TestPRObservation_NewReviewThreadStillNudges(t *testing.T) {
+	m, st, msg := newManager()
+
+	workerID := domain.SessionID("mer-new-thread")
+	prURL := "https://github.com/acme/repo/pull/9"
+	st.sessions[workerID] = working(workerID)
+
+	st.comments[prURL] = []domain.PullRequestComment{
+		{
+			ThreadID:         "thread-1",
+			ID:               "comment-1",
+			Author:           "reviewer",
+			File:             "a.go",
+			Line:             10,
+			Body:             "Fix finding one.",
+			Resolved:         false,
+			AutoInjectReview: true,
+		},
+	}
+
+	err := m.ApplyPRObservation(
+		context.Background(),
+		workerID,
+		ports.PRObservation{
+			Fetched: true,
+			URL:     prURL,
+		},
+	)
+	if err != nil {
+		t.Fatalf("first ApplyPRObservation: %v", err)
+	}
+
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf("first review thread should wake worker once; got %d messages: %#v", got, msg.msgs)
+	}
+
+	st.comments[prURL] = append(
+		st.comments[prURL],
+		domain.PullRequestComment{
+			ThreadID:         "thread-2",
+			ID:               "comment-2",
+			Author:           "reviewer",
+			File:             "b.go",
+			Line:             20,
+			Body:             "Fix finding two.",
+			Resolved:         false,
+			AutoInjectReview: true,
+		},
+	)
+
+	err = m.ApplyPRObservation(
+		context.Background(),
+		workerID,
+		ports.PRObservation{
+			Fetched: true,
+			URL:     prURL,
+		},
+	)
+	if err != nil {
+		t.Fatalf("second ApplyPRObservation: %v", err)
+	}
+
+	if got := len(msg.msgs); got != 2 {
+		t.Fatalf(
+			"a genuinely new review thread must still wake worker; got %d messages: %#v",
+			got,
+			msg.msgs,
+		)
+	}
+}
+
+func TestReviewBatchSuppressesInlineCommentFromSameSCMReview(t *testing.T) {
+	m, st, msg := newManager()
+
+	workerID := domain.SessionID("mer-inline-cross-lane")
+	prURL := "https://github.com/acme/repo/pull/10"
+	const reviewID = "4949207965"
+	reviewURL := prURL + "#pullrequestreview-" + reviewID
+
+	st.sessions[workerID] = working(workerID)
+
+	outcome, err := m.ApplyReviewBatch(
+		context.Background(),
+		workerID,
+		"batch-inline-cross-lane",
+		[]ReviewResult{
+			{
+				RunID:          "run-inline-cross-lane",
+				BatchID:        "batch-inline-cross-lane",
+				WorkerID:       workerID,
+				PRURL:          prURL,
+				TargetSHA:      "deadbeef",
+				Verdict:        domain.VerdictChangesRequested,
+				Body:           "Remove extra.txt",
+				GithubReviewID: reviewID,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ApplyReviewBatch: %v", err)
+	}
+	if outcome != ReviewDeliverySent {
+		t.Fatalf("ApplyReviewBatch outcome = %q, want %q", outcome, ReviewDeliverySent)
+	}
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf(
+			"internal reviewer should wake worker exactly once; got %d messages: %#v",
+			got,
+			msg.msgs,
+		)
+	}
+
+	// The SCM observer has already persisted the durable comment before
+	// lifecycle runs. Durable comments intentionally do not carry ReviewURL.
+	st.comments[prURL] = []domain.PullRequestComment{
+		{
+			ThreadID:         "thread-1",
+			ID:               "comment-1",
+			Author:           "reviewer",
+			File:             "extra.txt",
+			Line:             1,
+			Body:             "Remove this file.",
+			URL:              prURL + "#discussion_r1",
+			Resolved:         false,
+			AutoInjectReview: true,
+		},
+	}
+
+	// The live SCM observation DOES know which submitted review owns the
+	// comment. Lifecycle must use that transient correlation even though it
+	// reloads the durable comment rows before reacting.
+	err = m.ApplySCMObservation(
+		context.Background(),
+		workerID,
+		ports.SCMObservation{
+			Fetched: true,
+			PR: ports.SCMPRObservation{
+				URL: prURL,
+			},
+			Review: ports.SCMReviewObservation{
+				Decision: string(domain.ReviewChangesRequest),
+				Threads: []ports.SCMReviewThreadObservation{
+					{
+						ID:       "thread-1",
+						Path:     "extra.txt",
+						Line:     1,
+						Resolved: false,
+						Comments: []ports.SCMReviewCommentObservation{
+							{
+								ID:        "comment-1",
+								Author:    "reviewer",
+								Body:      "Remove this file.",
+								URL:       prURL + "#discussion_r1",
+								ReviewURL: reviewURL,
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ApplySCMObservation: %v", err)
+	}
+
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf(
+			"inline comment from a GitHub review already delivered by the internal reviewer must not wake worker again; got %d messages: %#v",
+			got,
+			msg.msgs,
+		)
+	}
+}
+
+func TestInlineReviewCoverageSuppressesSameThreadReplyAfterRestart(t *testing.T) {
+	m1, st, msg := newManager()
+
+	workerID := domain.SessionID("mer-inline-restart")
+	prURL := "https://github.com/acme/repo/pull/11"
+	const reviewID = "4949207965"
+	reviewURL := prURL + "#pullrequestreview-" + reviewID
+
+	st.sessions[workerID] = working(workerID)
+
+	// AO's internal reviewer delivers the finding first.
+	outcome, err := m1.ApplyReviewBatch(
+		context.Background(),
+		workerID,
+		"batch-inline-restart",
+		[]ReviewResult{
+			{
+				RunID:          "run-inline-restart",
+				BatchID:        "batch-inline-restart",
+				WorkerID:       workerID,
+				PRURL:          prURL,
+				TargetSHA:      "deadbeef",
+				Verdict:        domain.VerdictChangesRequested,
+				Body:           "Remove extra.txt",
+				GithubReviewID: reviewID,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ApplyReviewBatch: %v", err)
+	}
+	if outcome != ReviewDeliverySent {
+		t.Fatalf("ApplyReviewBatch outcome = %q, want %q", outcome, ReviewDeliverySent)
+	}
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf("internal review messages = %d, want 1", got)
+	}
+
+	reviewerComment := domain.PullRequestComment{
+		ThreadID:         "thread-1",
+		ID:               "comment-reviewer",
+		Author:           "reviewer",
+		File:             "extra.txt",
+		Line:             1,
+		Body:             "Remove this file.",
+		URL:              prURL + "#discussion_r1",
+		Resolved:         false,
+		AutoInjectReview: true,
+	}
+
+	// SCM later observes the inline comment belonging to that same review.
+	// It must be covered by the already-delivered internal review.
+	st.comments[prURL] = []domain.PullRequestComment{reviewerComment}
+
+	err = m1.ApplySCMObservation(
+		context.Background(),
+		workerID,
+		ports.SCMObservation{
+			Fetched: true,
+			PR: ports.SCMPRObservation{
+				URL: prURL,
+			},
+			Review: ports.SCMReviewObservation{
+				Decision: string(domain.ReviewChangesRequest),
+				Threads: []ports.SCMReviewThreadObservation{
+					{
+						ID:       "thread-1",
+						Path:     "extra.txt",
+						Line:     1,
+						Resolved: false,
+						Comments: []ports.SCMReviewCommentObservation{
+							{
+								ID:        "comment-reviewer",
+								Author:    "reviewer",
+								Body:      "Remove this file.",
+								URL:       reviewerComment.URL,
+								ReviewURL: reviewURL,
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("initial ApplySCMObservation: %v", err)
+	}
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf(
+			"covered inline comment re-woke worker before restart; got %d messages: %#v",
+			got,
+			msg.msgs,
+		)
+	}
+
+	// Simulate a daemon restart: same durable store, fresh Manager/reaction state.
+	m2 := New(st, msg)
+
+	workerReply := domain.PullRequestComment{
+		ThreadID:         "thread-1",
+		ID:               "comment-worker-reply",
+		Author:           "worker",
+		File:             "extra.txt",
+		Line:             1,
+		Body:             "Addressed in deadbeef.",
+		URL:              prURL + "#discussion_r2",
+		Resolved:         false,
+		AutoInjectReview: true,
+	}
+
+	st.comments[prURL] = []domain.PullRequestComment{
+		reviewerComment,
+		workerReply,
+	}
+
+	// The reviewer comment still carries its parent review correlation. The
+	// worker reply deliberately does not: suppression of that reply must come
+	// from the persisted thread-level dedup marker.
+	err = m2.ApplySCMObservation(
+		context.Background(),
+		workerID,
+		ports.SCMObservation{
+			Fetched: true,
+			PR: ports.SCMPRObservation{
+				URL: prURL,
+			},
+			Review: ports.SCMReviewObservation{
+				Decision: string(domain.ReviewChangesRequest),
+				Threads: []ports.SCMReviewThreadObservation{
+					{
+						ID:       "thread-1",
+						Path:     "extra.txt",
+						Line:     1,
+						Resolved: false,
+						Comments: []ports.SCMReviewCommentObservation{
+							{
+								ID:        "comment-reviewer",
+								Author:    "reviewer",
+								Body:      "Remove this file.",
+								URL:       reviewerComment.URL,
+								ReviewURL: reviewURL,
+							},
+							{
+								ID:     "comment-worker-reply",
+								Author: "worker",
+								Body:   "Addressed in deadbeef.",
+								URL:    workerReply.URL,
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("post-restart ApplySCMObservation: %v", err)
+	}
+
+	if got := len(msg.msgs); got != 1 {
+		t.Fatalf(
+			"same-thread worker reply after restart must remain covered; got %d messages: %#v",
+			got,
+			msg.msgs,
+		)
+	}
+}

--- a/backend/internal/lifecycle/review_parent_url_projection_test.go
+++ b/backend/internal/lifecycle/review_parent_url_projection_test.go
@@ -1,0 +1,61 @@
+package lifecycle
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestSCMToPRObservationPreservesParentReviewCorrelation(t *testing.T) {
+	const (
+		prURL     = "https://github.com/acme/repo/pull/7"
+		reviewURL = "https://github.com/acme/repo/pull/7#pullrequestreview-4949207965"
+	)
+
+	got := scmToPRObservation(ports.SCMObservation{
+		Fetched: true,
+		PR: ports.SCMPRObservation{
+			URL: prURL,
+		},
+		Review: ports.SCMReviewObservation{
+			Threads: []ports.SCMReviewThreadObservation{
+				{
+					ID:   "thread-1",
+					Path: "extra.txt",
+					Line: 1,
+					Comments: []ports.SCMReviewCommentObservation{
+						{
+							ID:        "comment-1",
+							Author:    "reviewer",
+							Body:      "Remove this file.",
+							URL:       prURL + "#discussion_r1",
+							ReviewURL: reviewURL,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if len(got.Comments) != 1 {
+		t.Fatalf(
+			"scmToPRObservation dropped review comments needed for parent-review correlation; got %d comments",
+			len(got.Comments),
+		)
+	}
+
+	// Reflection keeps the regression compilable before PRCommentObservation
+	// grows the transient ReviewURL correlation field.
+	comment := reflect.ValueOf(got.Comments[0])
+	field := comment.FieldByName("ReviewURL")
+	if !field.IsValid() {
+		t.Fatalf("PRCommentObservation must expose transient ReviewURL correlation")
+	}
+	if field.Kind() != reflect.String {
+		t.Fatalf("ReviewURL kind = %s, want string", field.Kind())
+	}
+	if gotURL := field.String(); gotURL != reviewURL {
+		t.Fatalf("ReviewURL = %q, want %q", gotURL, reviewURL)
+	}
+}

--- a/backend/internal/ports/pr_observations.go
+++ b/backend/internal/ports/pr_observations.go
@@ -48,13 +48,15 @@ type PRCheckObservation struct {
 
 // PRCommentObservation is one review comment observed on the PR.
 type PRCommentObservation struct {
-	ID               string
-	ThreadID         string
-	Author           string
-	File             string
-	Line             int
-	Body             string
-	URL              string
+	ID       string
+	ThreadID string
+	Author   string
+	File     string
+	Line     int
+	Body     string
+	URL      string
+	// ReviewURL links this comment to its submitted review when known.
+	ReviewURL        string
 	Resolved         bool
 	AutoInjectReview bool
 }

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -286,6 +286,8 @@ type SCMReviewCommentObservation struct {
 	Body string
 	// URL is a provider link to the comment.
 	URL string
+	// ReviewURL is the provider link to the submitted review that owns this comment.
+	ReviewURL string
 	// IsBot is true when the provider identifies the author as a bot.
 	IsBot bool
 }


### PR DESCRIPTION
## What

Prevent duplicate worker nudges when AO's internal reviewer and the SCM observer surface the same GitHub review feedback through separate lifecycle lanes.

This change:

- correlates an internal AO review with the later GitHub review observation;
- suppresses duplicate formal-review and inline-comment nudges for that same review;
- deduplicates review comments at the review-thread level so replies in an already-notified thread do not wake the worker again;
- persists the thread-level marker so the suppression survives a daemon restart;
- keeps genuinely new review threads actionable.

## Why

AO's internal reviewer delivery and SCM observation are separate lifecycle paths. The same GitHub review can therefore be delivered once by `ApplyReviewBatch` and then observed again by `ApplyPRObservation`, causing the owning worker to be nudged twice for one finding.

Inline review comments have a related duplicate path: a reply in the same review thread receives a new provider comment ID and can otherwise look like a new actionable finding.

## How

- Request each GraphQL review comment's parent `pullRequestReview.url` and carry it transiently through the SCM/PR observation ports. No database migration is added.
- Persist cross-lane coverage after successful internal review delivery using the GitHub numeric review/database ID.
- Suppress formal-review and inline-comment nudges when that same provider review was already delivered internally.
- Deduplicate review comments by `ThreadID` when available, falling back to comment ID when necessary.
- Persist the covered thread marker so suppression survives daemon restart.
- Fail open on coverage lookup errors so genuine review feedback is not silently dropped.

Intentional trade-off: follow-up comments in the exact same existing review thread remain deduplicated. A distinct new review thread or distinct new review still produces a nudge.

## Testing

Validated after rebasing onto current `main`:

```text
go test -count=1 ./internal/adapters/scm/github ./internal/lifecycle ./internal/observe/scm ./internal/ports
go build ./...
go vet ./...
git diff origin/main...HEAD --check
```
All of the above pass.

Regression coverage includes:

- internal review followed by the same formal SCM review;
- inline comment from the same SCM review;
- worker reply in the same review thread;
- persistence across daemon restart;
- a genuinely new review thread still nudging;
- GraphQL parent-review URL projection through transient observation types.

A pre-rebase `go test ./...` run on this Windows host had platform/environment-dependent failures. A clean detached worktree at the same base commit produced the same failing package set, so those failures were not introduced by this patch.

`go test -race` could not be executed locally because this Windows Go environment has `CGO_ENABLED=0` and no C compiler installed. CI should provide the authoritative race result.

## Checklist

- [x] Branched from `main` and rebased onto current `main`
- [x] One focused change; no matching existing issue/PR found
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for the affected behavior
- [ ] Relevant CI checks pass for the area touched