### PR TITLE
fix(scm): single-source PR identity — end the merge-readiness flap after repo transfers

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -219,14 +219,13 @@ func stableCheckFingerprint(parts []string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// FetchPullRequests fetches normalized PR/check metadata for up to 25 PR refs in
-// one GraphQL request. The observer owns chunking; this method rejects larger
-// batches so tests catch accidental over-batching.
-// FetchPullRequests returns observations positionally aligned with refs:
-// out[i] answers refs[i]. A PR the batch query could not resolve (deleted
-// repo, permissions) leaves a zero-value Fetched=false placeholder at its
-// index so the observer marks that ref refresh-incomplete without guessing
-// which response belonged to which request.
+// FetchPullRequests fetches normalized PR/check metadata for up to 25 PR refs
+// in one GraphQL request, positionally aligned with refs: out[i] answers
+// refs[i]. A PR the batch query could not resolve (deleted repo, permissions)
+// leaves a Fetched=false placeholder at its index so the observer marks that
+// ref refresh-incomplete without guessing which response belonged to which
+// request. The observer owns chunking; this method rejects larger batches so
+// tests catch accidental over-batching.
 func (p *Provider) FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
 	if len(refs) == 0 {
 		return nil, nil
@@ -244,6 +243,7 @@ func (p *Provider) FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef)
 		repoData, _ := data[aliases[i]].(map[string]any)
 		pr, _ := repoData["pullRequest"].(map[string]any)
 		if pr == nil {
+			out[i].Error = ports.ErrSCMNotFound
 			continue
 		}
 		if scmContextsPaginated(pr) {

--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -221,11 +221,12 @@ func stableCheckFingerprint(parts []string) string {
 
 // FetchPullRequests fetches normalized PR/check metadata for up to 25 PR refs
 // in one GraphQL request, positionally aligned with refs: out[i] answers
-// refs[i]. A PR the batch query could not resolve (deleted repo, permissions)
-// leaves a Fetched=false placeholder at its index so the observer marks that
-// ref refresh-incomplete without guessing which response belonged to which
-// request. The observer owns chunking; this method rejects larger batches so
-// tests catch accidental over-batching.
+// refs[i]. A PR the batch query could not resolve (deleted repo, permissions,
+// an old name recreated so the redirect no longer lands) leaves a
+// Fetched=false placeholder carrying ErrNotFound at its index, so the
+// observer marks that ref refresh-incomplete and can log the permanent miss
+// distinctly from a transient provider failure. The observer owns chunking;
+// this method rejects larger batches so tests catch accidental over-batching.
 func (p *Provider) FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
 	if len(refs) == 0 {
 		return nil, nil
@@ -243,7 +244,14 @@ func (p *Provider) FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef)
 		repoData, _ := data[aliases[i]].(map[string]any)
 		pr, _ := repoData["pullRequest"].(map[string]any)
 		if pr == nil {
-			out[i].Error = ports.ErrSCMNotFound
+			out[i] = ports.SCMObservation{
+				Fetched:  false,
+				Provider: ref.Repo.Provider,
+				Host:     ref.Repo.Host,
+				Repo:     repoFullName(ref.Repo),
+				PR:       ports.SCMPRObservation{Number: ref.Number, URL: ref.URL},
+				Error:    fmt.Errorf("%w: pull request %s#%d not in batch response", ErrNotFound, repoFullName(ref.Repo), ref.Number),
+			}
 			continue
 		}
 		if scmContextsPaginated(pr) {

--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -222,6 +222,11 @@ func stableCheckFingerprint(parts []string) string {
 // FetchPullRequests fetches normalized PR/check metadata for up to 25 PR refs in
 // one GraphQL request. The observer owns chunking; this method rejects larger
 // batches so tests catch accidental over-batching.
+// FetchPullRequests returns observations positionally aligned with refs:
+// out[i] answers refs[i]. A PR the batch query could not resolve (deleted
+// repo, permissions) leaves a zero-value Fetched=false placeholder at its
+// index so the observer marks that ref refresh-incomplete without guessing
+// which response belonged to which request.
 func (p *Provider) FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
 	if len(refs) == 0 {
 		return nil, nil
@@ -234,7 +239,7 @@ func (p *Provider) FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]ports.SCMObservation, 0, len(refs))
+	out := make([]ports.SCMObservation, len(refs))
 	for i, ref := range refs {
 		repoData, _ := data[aliases[i]].(map[string]any)
 		pr, _ := repoData["pullRequest"].(map[string]any)
@@ -246,7 +251,7 @@ func (p *Provider) FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef)
 				return nil, err
 			}
 		}
-		out = append(out, scmObservationFromGraphQL(ref, pr))
+		out[i] = scmObservationFromGraphQL(ref, pr)
 	}
 	return out, nil
 }

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1766,3 +1766,45 @@ func TestCommitChecksGuard_PaginatedFingerprintInvalidatesLaterPageRun(t *testin
 		t.Fatal("guard stayed NotModified after a page-2 run transitioned (fingerprint bug)")
 	}
 }
+
+// A ref the batch query cannot resolve (null pullRequest — deleted repo,
+// revoked access, dead rename redirect) yields a positionally aligned
+// Fetched=false placeholder carrying ErrNotFound, so the observer can log the
+// permanent miss at Debug instead of warning every tick.
+func TestFetchPullRequestsStampsNotFoundPlaceholder(t *testing.T) {
+	fake := newFakeGH(t)
+	fx := basePRFixture()
+	var pr map[string]any
+	fx.prData(func(m map[string]any) { pr = m })
+	fake.on(http.MethodPost, "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"pr0": map[string]any{"pullRequest": nil},
+				"pr1": map[string]any{"pullRequest": pr},
+			},
+		})
+	})
+	p := newProviderForTest(t, fake)
+	repoGone := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "gone", Name: "repo", Repo: "gone/repo"}
+	repoOK := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "octocat", Name: "hello", Repo: "octocat/hello"}
+	obs, err := p.FetchPullRequests(ctx(), []ports.SCMPRRef{
+		{Repo: repoGone, Number: 7, URL: "https://github.com/gone/repo/pull/7"},
+		{Repo: repoOK, Number: 42},
+	})
+	if err != nil {
+		t.Fatalf("FetchPullRequests: %v", err)
+	}
+	if len(obs) != 2 {
+		t.Fatalf("observations = %d, want 2 (positionally aligned)", len(obs))
+	}
+	if obs[0].Fetched || !errors.Is(obs[0].Error, ports.ErrSCMNotFound) {
+		t.Fatalf("missing PR placeholder = Fetched:%v Error:%v, want Fetched=false wrapping ErrSCMNotFound", obs[0].Fetched, obs[0].Error)
+	}
+	if obs[0].Repo != "gone/repo" || obs[0].PR.Number != 7 {
+		t.Fatalf("placeholder identity = %s#%d, want gone/repo#7", obs[0].Repo, obs[0].PR.Number)
+	}
+	if !obs[1].Fetched || obs[1].PR.Number != 42 {
+		t.Fatalf("aligned hit = Fetched:%v #%d, want fetched #42 at index 1", obs[1].Fetched, obs[1].PR.Number)
+	}
+}

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1319,6 +1319,41 @@ func TestSCMMergeabilityBlocksReviewRequiredAndDraft(t *testing.T) {
 	}
 }
 
+func TestFetchPullRequestsMarksMissingPRNotFound(t *testing.T) {
+	fake := newFakeGH(t)
+	fx := basePRFixture()
+	var pr map[string]any
+	fx.prData(func(m map[string]any) { pr = m })
+	fake.on(http.MethodPost, "/graphql", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"pr0": map[string]any{"pullRequest": nil},
+				"pr1": map[string]any{"pullRequest": pr},
+			},
+		})
+	})
+	p := newProviderForTest(t, fake)
+	repo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "octocat", Name: "hello", Repo: "octocat/hello"}
+
+	obs, err := p.FetchPullRequests(ctx(), []ports.SCMPRRef{
+		{Repo: repo, Number: 404},
+		{Repo: repo, Number: 42},
+	})
+	if err != nil {
+		t.Fatalf("FetchPullRequests: %v", err)
+	}
+	if len(obs) != 2 {
+		t.Fatalf("observations = %d, want 2", len(obs))
+	}
+	if obs[0].Fetched || !errors.Is(obs[0].Error, ports.ErrSCMNotFound) {
+		t.Fatalf("missing observation = %+v, want Fetched=false ErrSCMNotFound", obs[0])
+	}
+	if !obs[1].Fetched || obs[1].PR.Number != 42 {
+		t.Fatalf("second observation = %+v, want fetched PR 42", obs[1])
+	}
+}
+
 func TestFetchPullRequestsDoesNotFallbackWhenContextPageComplete(t *testing.T) {
 	fake := newFakeGH(t)
 	fx := basePRFixture()

--- a/backend/internal/adapters/scm/multi/provider.go
+++ b/backend/internal/adapters/scm/multi/provider.go
@@ -279,9 +279,8 @@ type indexedRef struct {
 
 // repoFullNameFromRef returns the display repository name from a ref's
 // SCMRepo, preferring the pre-filled Repo field and falling back to
-// Owner + "/" + Name when Repo is empty. This mirrors the observer's
-// repoFullName helper and ensures Fetched=false placeholders carry a
-// non-empty Repo so prKeyFromObs produces a non-empty key.
+// Owner + "/" + Name when Repo is empty. This ensures Fetched=false
+// placeholders retain the repository context of the ref they represent.
 func repoFullNameFromRef(repo ports.SCMRepo) string {
 	if repo.Repo != "" {
 		return repo.Repo

--- a/backend/internal/adapters/scm/multi/provider_test.go
+++ b/backend/internal/adapters/scm/multi/provider_test.go
@@ -563,12 +563,8 @@ func TestAuthenticatedIdentityForProvider_UnknownProviderReturnsError(t *testing
 }
 
 // TestFetchPullRequests_FailedPlaceholderCarriesHostAndRepo verifies that
-// Fetched=false placeholders created by the multi provider carry Host and
-// Repo from the ref's SCMRepo. Without these fields, the observer's
-// prKeyFromObs returns an empty key, causing the placeholder to be skipped
-// at the `if key == "" { continue }` guard — the per-observation error
-// routing (rate-limit cooldown vs refresh-incomplete) is never reached and
-// the failed provider is retried every tick instead of entering cooldown.
+// Fetched=false placeholders created by the multi provider retain the Host
+// and Repo context of the ref they represent.
 // This test covers both placeholder sites: the unknown-provider branch and
 // the provider-returned-fewer-than-refs branch.
 func TestFetchPullRequests_FailedPlaceholderCarriesHostAndRepo(t *testing.T) {
@@ -629,32 +625,6 @@ func TestFetchPullRequests_FailedPlaceholderCarriesHostAndRepo(t *testing.T) {
 	}
 	if obs3[0].Host != "self-hosted.example" {
 		t.Errorf("obs3[0].Host = %q, want %q", obs3[0].Host, "self-hosted.example")
-	}
-}
-
-// TestFetchPullRequests_FailedPlaceholderProducesNonEmptyKey verifies that
-// the observer's prKeyFromObs returns a non-empty key for a failed-provider
-// placeholder. This is the integration assertion: without Host/Repo on the
-// placeholder, prKeyFromObs returns "" and the observer skips it at the
-// `if key == "" { continue }` guard, preventing per-observation error routing.
-func TestFetchPullRequests_FailedPlaceholderProducesNonEmptyKey(t *testing.T) {
-	gl := &fakeProvider{key: "gitlab", parseOK: true, fetchErr: errors.New("gitlab rate limit")}
-	m := New(NamedProvider{Key: "gitlab", Provider: gl})
-
-	refs := []ports.SCMPRRef{
-		{Repo: ports.SCMRepo{Provider: "gitlab", Host: "gitlab.com", Owner: "owner", Name: "repo", Repo: "owner/repo"}, Number: 99},
-	}
-	obs, _ := m.FetchPullRequests(context.Background(), refs)
-
-	// The observer's prKeyFromObs builds: Provider + ":" + Host + ":" + Repo + "#" + Number
-	// All three components must be non-empty for the key to be non-empty.
-	key := obs[0].Provider + ":" + obs[0].Host + ":" + obs[0].Repo + "#" + fmt.Sprint(obs[0].PR.Number)
-	if key == "" || key == "gitlab::#99" {
-		t.Errorf("prKey would be empty or incomplete: %q (Host=%q Repo=%q)", key, obs[0].Host, obs[0].Repo)
-	}
-	wantKey := "gitlab:gitlab.com:owner/repo#99"
-	if key != wantKey {
-		t.Errorf("prKey = %q, want %q", key, wantKey)
 	}
 }
 

--- a/backend/internal/integration/scm_observer_test.go
+++ b/backend/internal/integration/scm_observer_test.go
@@ -120,10 +120,10 @@ func (p *cannedSCMProvider) CommitChecksGuard(_ context.Context, _ ports.SCMRepo
 func (p *cannedSCMProvider) FetchPullRequests(_ context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	out := make([]ports.SCMObservation, 0, len(refs))
-	for _, ref := range refs {
+	out := make([]ports.SCMObservation, len(refs))
+	for i, ref := range refs {
 		if obs, ok := p.observations[ref.Number]; ok {
-			out = append(out, obs)
+			out[i] = obs
 		}
 	}
 	return out, nil

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -789,13 +789,12 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 				o.logger.Warn("scm observer: tracked PR repo no longer belongs to project", "session", sess.ID, "pr", pr.URL, "repo", pr.Repo)
 				continue
 			}
-			// Identity-keyed: two rows for the same provider-native PR (e.g.
-			// observed under both the pre- and post-transfer repo name)
-			// resolve to one subject here instead of becoming two subjects
-			// that fight over the same PR downstream.
+			// Provider-native identity keeps this subject's key stable across
+			// repository renames; legacy id-less rows retain the name-based key
+			// until their first successful detail fetch stamps an identity.
 			key := keyForTrackedPR(pr, prRepo)
 			if existing, ok := out[key]; ok {
-				o.logger.Warn("scm observer: duplicate tracked PR ownership skipped", "pr", key, "kept_session", existing.session.ID, "skipped_session", sess.ID)
+				o.logger.Warn("scm observer: duplicate tracked PR subject skipped", "pr", key, "kept_session", existing.session.ID, "skipped_session", sess.ID)
 				continue
 			}
 			out[key] = &subject{session: sess, repo: prRepo, branch: branch, known: pr, hasPR: true}

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -331,6 +331,21 @@ type refreshSelection struct {
 	subjectsByPR  map[string]*subject
 	commitETags   map[string]pendingCacheString
 	candidateKeys map[string]bool
+	// keyByRef maps prKey(ref.Repo, ref.Number) of every issued ref to the
+	// subject key it was issued for. Refs are name-addressed (a GraphQL query
+	// needs an owner/name), subjects are identity-addressed; this is the
+	// bridge back.
+	keyByRef map[string]string
+}
+
+// refKey returns the subject key a ref was issued for, falling back to the
+// ref's name key for refs issued outside the selection bookkeeping.
+func (sel *refreshSelection) refKey(ref ports.SCMPRRef) string {
+	rk := prKey(ref.Repo, ref.Number)
+	if k, ok := sel.keyByRef[rk]; ok {
+		return k
+	}
+	return rk
 }
 
 type persistenceOptions struct {
@@ -484,7 +499,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 		chunkSeen := map[string]bool{}
 		for _, obs := range batch {
 			obs.ObservedAt = now
-			key := observationKeyForRefs(obs, active)
+			key := observationSubjectKey(obs, active, selection.subjectsByPR, selection.keyByRef)
 			if key == "" {
 				continue
 			}
@@ -509,7 +524,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 						// Fall back to the ref's provider when the placeholder
 						// did not carry one (defensive — multi always sets it).
 						for _, ref := range active {
-							if prKey(ref.Repo, ref.Number) == key {
+							if selection.refKey(ref) == key {
 								providerKey = ref.Repo.Provider
 								break
 							}
@@ -530,8 +545,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 			chunkSeen[key] = true
 		}
 		for _, ref := range active {
-			key := prKey(ref.Repo, ref.Number)
-			if !chunkSeen[key] {
+			if !chunkSeen[selection.refKey(ref)] {
 				markRepoRefreshFailed(ref.Repo)
 			}
 		}
@@ -802,7 +816,11 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 				o.logger.Warn("scm observer: tracked PR repo no longer belongs to project", "session", sess.ID, "pr", pr.URL, "repo", pr.Repo)
 				continue
 			}
-			key := prKey(prRepo, pr.Number)
+			// Identity-keyed: two rows for the same provider-native PR (e.g.
+			// observed under both the pre- and post-transfer repo name)
+			// resolve to one subject here instead of becoming two subjects
+			// that fight over the same PR downstream.
+			key := keyForTrackedPR(pr, prRepo)
 			if existing, ok := out[key]; ok {
 				o.logger.Warn("scm observer: duplicate tracked PR ownership skipped", "pr", key, "kept_session", existing.session.ID, "skipped_session", sess.ID)
 				continue
@@ -1024,9 +1042,18 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 		}
 		// Record the listed PR numbers so selectRefreshCandidates can
 		// restrict refresh to only updated MRs rather than every tracked MR.
+		// Subjects are identity-keyed, so when a listed PR's provider id
+		// matches a tracked subject, mark the subject key too — otherwise a
+		// listing served under a renamed repo's old name would never promote
+		// the subject to refresh candidate.
 		listedRepos[repoKey] = true
 		for _, pr := range pulls {
 			listedPRs[prKey(repo, pr.Number)] = true
+			if pr.ProviderID != "" {
+				if idKey := identityPRKey(repo.Provider, repo.Host, pr.ProviderID); subjects[idKey] != nil {
+					listedPRs[idKey] = true
+				}
+			}
 		}
 		for _, pr := range pulls {
 			if pr.Number <= 0 || pr.SourceBranch == "" {
@@ -1041,9 +1068,20 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 					continue
 				}
 			}
-			key := prKey(repo, pr.Number)
-			if _, ok := subjects[key]; ok {
+			if _, ok := subjects[prKey(repo, pr.Number)]; ok {
 				continue
+			}
+			// Identity dedupe: a PR already tracked under its provider-native
+			// identity must never be treated as new, even when this listing
+			// was served under a different repo name (pre-transfer remote,
+			// mirror). Without this, the baseline write below re-baselines
+			// the tracked row and wipes its CI/mergeability facts and
+			// semantic hashes — the "Checking merge readiness" flap
+			// (issue #4089, mechanism 2).
+			if pr.ProviderID != "" {
+				if _, ok := subjects[identityPRKey(repo.Provider, repo.Host, pr.ProviderID)]; ok {
+					continue
+				}
 			}
 			// Branch-prefix attribution must only claim PRs whose head branch
 			// lives in a session's push origin. A same-repo PR has head == origin
@@ -1084,7 +1122,7 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 				}
 				continue
 			}
-			subjects[key] = &subject{
+			subjects[keyForTrackedPR(known, repo)] = &subject{
 				session: sr.session,
 				repo:    repo,
 				branch:  sr.branch,
@@ -1219,12 +1257,13 @@ func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[str
 		subjectsByPR:  map[string]*subject{},
 		commitETags:   map[string]pendingCacheString{},
 		candidateKeys: map[string]bool{},
+		keyByRef:      map[string]string{},
 	}
 	for _, s := range subjects {
 		if !s.hasPR || s.known.Number <= 0 {
 			continue
 		}
-		key := prKey(s.repo, s.known.Number)
+		key := keyForTrackedPR(s.known, s.repo)
 		selection.subjectsByPR[key] = s
 		candidate := missingLocalState(s.known)
 		repoCursor := o.Cache.LastSyncCursor[prKey(s.repo, 0)]
@@ -1291,6 +1330,7 @@ func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[str
 		if candidate {
 			selection.refs = append(selection.refs, ports.SCMPRRef{Repo: s.repo, Number: s.known.Number, URL: s.known.URL})
 			selection.candidateKeys[key] = true
+			selection.keyByRef[prKey(s.repo, s.known.Number)] = key
 		}
 	}
 	return selection
@@ -1363,10 +1403,12 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 		if g.err != nil || g.result.NotModified {
 			continue
 		}
-		key := prKey(s.repo, s.known.Number)
+		key := keyForTrackedPR(s.known, s.repo)
 		// Only reconcile PRs not in the current listing — listed PRs are
-		// already covered by the normal refresh path.
-		if listedPRs[key] {
+		// already covered by the normal refresh path. listedPRs carries the
+		// subject key for identity-matched listings and the name key
+		// otherwise; check both so a rename cannot double-fetch.
+		if listedPRs[key] || listedPRs[prKey(s.repo, s.known.Number)] {
 			continue
 		}
 		// Skip refs already selected as refresh candidates by the normal
@@ -1379,9 +1421,16 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 			ref: ports.SCMPRRef{Repo: s.repo, Number: s.known.Number, URL: s.known.URL},
 			s:   s,
 		})
+		selection.keyByRef[prKey(s.repo, s.known.Number)] = key
 	}
 	if len(refs) == 0 {
 		return out
+	}
+	// Reconcile refs resolve against their pending subjects; the selection's
+	// subjectsByPR does not yet contain them (they were not candidates).
+	reconSubjects := map[string]*subject{}
+	for _, r := range refs {
+		reconSubjects[keyForTrackedPR(r.s.known, r.s.repo)] = r.s
 	}
 	// Unbounded: issue detail fetches for every reconciled PR. The worst case
 	// is bounded by the tracked-open-PR count, which is small in AO's use case.
@@ -1425,7 +1474,7 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 		reconcileSeen := map[string]bool{}
 		for _, obs := range batch {
 			obs.ObservedAt = now
-			key := observationKeyForRefs(obs, active)
+			key := observationSubjectKey(obs, active, reconSubjects, selection.keyByRef)
 			if key == "" {
 				continue
 			}
@@ -1437,7 +1486,7 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 					providerKey := obs.Provider
 					if providerKey == "" {
 						for _, ref := range active {
-							if prKey(ref.Repo, ref.Number) == key {
+							if selection.refKey(ref) == key {
 								providerKey = ref.Repo.Provider
 								break
 							}
@@ -1455,7 +1504,7 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 				// Mark the repo refresh-incomplete on any failure so the
 				// repo ETag/cursor do not advance without an observation.
 				for _, ref := range active {
-					if prKey(ref.Repo, ref.Number) == key {
+					if selection.refKey(ref) == key {
 						markRepoFailed(ref.Repo)
 						break
 					}
@@ -1469,11 +1518,8 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 			// candidateKeys also ensures prRefreshOK is initialized for this
 			// key so the commit-ETag cache does not advance unless the
 			// persistence succeeds.
-			for _, r := range chunk {
-				if prKey(r.ref.Repo, r.ref.Number) == key {
-					selection.subjectsByPR[key] = r.s
-					break
-				}
+			if s, ok := reconSubjects[key]; ok {
+				selection.subjectsByPR[key] = s
 			}
 			selection.candidateKeys[key] = true
 			// Pre-mark the repo refresh-incomplete for every reconciled
@@ -1485,7 +1531,7 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 			// after a successful write so the ETag/cursor can advance on
 			// a real terminal transition only.
 			for _, ref := range active {
-				if prKey(ref.Repo, ref.Number) == key {
+				if selection.refKey(ref) == key {
 					markRepoFailed(ref.Repo)
 					break
 				}
@@ -1495,7 +1541,7 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 		// must mark its repo refresh-incomplete (no-op result: durable state
 		// must not advance).
 		for _, r := range chunk {
-			key := prKey(r.ref.Repo, r.ref.Number)
+			key := selection.refKey(r.ref)
 			if reconcileSeen[key] {
 				// A "still open" observation: if the semantic hashes are
 				// unchanged (no terminal transition), the persistence loop
@@ -1604,7 +1650,7 @@ func (o *Observer) refreshReviews(ctx context.Context, subjects map[string]*subj
 		if s.known.Merged || s.known.Closed {
 			continue
 		}
-		pkey := prKey(s.repo, s.known.Number)
+		pkey := keyForTrackedPR(s.known, s.repo)
 		obs, hasObs := observations[pkey]
 		decision := string(s.known.Review)
 		if hasObs && obs.Review.Decision != "" {
@@ -2038,26 +2084,49 @@ func prKeyFromObs(obs ports.SCMObservation) string {
 	return obs.Provider + ":" + obs.Host + ":" + obs.Repo + "#" + fmt.Sprint(obs.PR.Number)
 }
 
-// observationKeyForRefs resolves the key a fetched observation should be
-// dispatched under. Normally that is prKeyFromObs: the observation's canonical
-// repo matches the ref that requested it. After a repository rename or org
-// transfer, the provider serves the fetch through a redirect and the
-// observation canonicalizes to the new owner/name while the tracked subject
-// (whose repo comes from the stored PR row) still carries the old one. The two
-// keys then never match, so the observation would be dropped on every poll —
-// CI and mergeability stay "unknown" forever while the separate per-ref review
-// refresh keeps working. Falling back to matching the requesting ref by PR URL
-// delivers the observation under the subject's key; persistence then records
-// the canonical repo on the row, so the identities converge on the next poll.
-func observationKeyForRefs(obs ports.SCMObservation, refs []ports.SCMPRRef) string {
-	key := prKeyFromObs(obs)
-	if key == "" {
+// PR identity has one owner: the provider-native id (provider, host,
+// provider_id), which survives repository renames and org transfers. Repo
+// name, number, and URL are mutable display coordinates. Subjects,
+// observation dispatch, and discovery dedupe all key on identityPRKey when a
+// provider id is known; the legacy name-based prKey remains only as a
+// self-retiring fallback for rows that predate provider ids (their first
+// successful fetch stamps one). Repo-level state — list ETags, sync cursors,
+// commit-check guards — deliberately stays name-keyed: listing genuinely is a
+// per-name operation.
+func identityPRKey(provider, host, providerID string) string {
+	return strings.ToLower(strings.TrimSpace(provider)) + ":" +
+		strings.ToLower(strings.TrimSpace(host)) + "@" + strings.TrimSpace(providerID)
+}
+
+// keyForTrackedPR returns the dispatch key a tracked PR registers under: the
+// provider-native identity when the row carries one, else the legacy
+// name-based key derived from the resolved repo.
+func keyForTrackedPR(pr domain.PullRequest, repo ports.SCMRepo) string {
+	if pr.Provider != "" && pr.Host != "" && pr.ProviderID != "" {
+		return identityPRKey(pr.Provider, pr.Host, pr.ProviderID)
+	}
+	return prKey(repo, pr.Number)
+}
+
+// observationSubjectKey resolves which subject a fetched observation belongs
+// to, in priority order: provider identity, canonical name key, then the
+// requesting ref matched by name or PR URL/alias (the rename fallback for
+// rows without a provider id — after a transfer the observation
+// canonicalizes to the new owner/name while a legacy subject still carries
+// the old one). keyByRef maps prKey(ref.Repo, ref.Number) of every issued
+// ref to the subject key it was issued for.
+func observationSubjectKey(obs ports.SCMObservation, refs []ports.SCMPRRef, subjects map[string]*subject, keyByRef map[string]string) string {
+	if obs.PR.ProviderID != "" && obs.Provider != "" && obs.Host != "" {
+		if k := identityPRKey(obs.Provider, obs.Host, obs.PR.ProviderID); subjects[k] != nil {
+			return k
+		}
+	}
+	canonical := prKeyFromObs(obs)
+	if canonical == "" {
 		return ""
 	}
-	for _, ref := range refs {
-		if prKey(ref.Repo, ref.Number) == key {
-			return key
-		}
+	if subjects[canonical] != nil {
+		return canonical
 	}
 	obsURL := strings.TrimSpace(obs.PR.URL)
 	obsAlias := strings.TrimSpace(obs.PR.URLAlias)
@@ -2065,15 +2134,17 @@ func observationKeyForRefs(obs ports.SCMObservation, refs []ports.SCMPRRef) stri
 		if ref.Number != obs.PR.Number {
 			continue
 		}
+		rk := prKey(ref.Repo, ref.Number)
 		refURL := strings.TrimSpace(ref.URL)
-		if refURL == "" {
-			continue
-		}
-		if refURL == obsURL || (obsAlias != "" && refURL == obsAlias) {
-			return prKey(ref.Repo, ref.Number)
+		urlMatch := refURL != "" && (refURL == obsURL || (obsAlias != "" && refURL == obsAlias))
+		if rk == canonical || urlMatch {
+			if k, ok := keyByRef[rk]; ok {
+				return k
+			}
+			return rk
 		}
 	}
-	return key
+	return canonical
 }
 
 func prKey(repo ports.SCMRepo, number int) string {

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -65,6 +65,12 @@ type Provider interface {
 	RepoPRListGuard(ctx context.Context, repo ports.SCMRepo, etag string) (ports.SCMGuardResult, error)
 	ListPRsByRepo(ctx context.Context, repo ports.SCMRepo, updatedAfter time.Time) ([]ports.SCMPRObservation, error)
 	CommitChecksGuard(ctx context.Context, repo ports.SCMRepo, headSHA, etag string) (ports.SCMGuardResult, error)
+	// FetchPullRequests returns observations positionally aligned with refs:
+	// result[i] answers refs[i], with a Fetched=false placeholder (optionally
+	// carrying a per-observation Error) when refs[i] could not be fetched.
+	// The observer relies on this alignment to attribute each observation to
+	// the subject it was requested for — repo renames make any content-based
+	// re-derivation (repo name, URL) ambiguous.
 	FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error)
 	FetchFailedCheckLogTail(ctx context.Context, repo ports.SCMRepo, check ports.SCMCheckObservation) (string, error)
 	FetchReviewThreads(ctx context.Context, ref ports.SCMPRRef) (ports.SCMReviewObservation, error)
@@ -327,25 +333,13 @@ type pendingCacheString struct {
 }
 
 type refreshSelection struct {
+	// refs and refKeys are parallel: refKeys[i] is the subject key
+	// refs[i] was issued for.
 	refs          []ports.SCMPRRef
+	refKeys       []string
 	subjectsByPR  map[string]*subject
 	commitETags   map[string]pendingCacheString
 	candidateKeys map[string]bool
-	// keyByRef maps prKey(ref.Repo, ref.Number) of every issued ref to the
-	// subject key it was issued for. Refs are name-addressed (a GraphQL query
-	// needs an owner/name), subjects are identity-addressed; this is the
-	// bridge back.
-	keyByRef map[string]string
-}
-
-// refKey returns the subject key a ref was issued for, falling back to the
-// ref's name key for refs issued outside the selection bookkeeping.
-func (sel *refreshSelection) refKey(ref ports.SCMPRRef) string {
-	rk := prKey(ref.Repo, ref.Number)
-	if k, ok := sel.keyByRef[rk]; ok {
-		return k
-	}
-	return rk
 }
 
 type persistenceOptions struct {
@@ -449,16 +443,21 @@ func (o *Observer) Poll(ctx context.Context) error {
 	for key := range selection.candidateKeys {
 		prRefreshOK[key] = false
 	}
-	for _, chunk := range chunks(selection.refs, BatchSize) {
+	for start := 0; start < len(selection.refs); start += BatchSize {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		// Skip the entire chunk if every ref's provider is under a rate-limit
-		// cooldown; otherwise filter out the cooled-down providers so a
-		// rate-limited GitLab does not suppress healthy GitHub refs in the
-		// same chunk
-		active := chunk[:0]
-		for _, ref := range chunk {
+		end := min(start+BatchSize, len(selection.refs))
+		// Filter out cooled-down providers so a rate-limited GitLab does not
+		// suppress healthy GitHub refs in the same chunk. activeKeys stays
+		// positionally aligned with active: FetchPullRequests answers
+		// result[i] for active[i], so activeKeys[i] is the subject key each
+		// observation is attributed to — no content-based matching, which a
+		// repo rename would make ambiguous.
+		active := make([]ports.SCMPRRef, 0, end-start)
+		activeKeys := make([]string, 0, end-start)
+		for i := start; i < end; i++ {
+			ref := selection.refs[i]
 			if o.inRateLimitCooldown(now, ref.Repo.Provider) {
 				// Item 3 — cooldown-skip marks refresh-incomplete: when a ref
 				// is skipped under cooldown, its repository is marked as
@@ -471,6 +470,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 				continue
 			}
 			active = append(active, ref)
+			activeKeys = append(activeKeys, selection.refKeys[i])
 		}
 		if len(active) == 0 {
 			continue
@@ -496,58 +496,31 @@ func (o *Observer) Poll(ctx context.Context) error {
 			}
 			continue
 		}
-		chunkSeen := map[string]bool{}
-		for _, obs := range batch {
-			obs.ObservedAt = now
-			key := observationSubjectKey(obs, active, selection.subjectsByPR, selection.keyByRef)
-			if key == "" {
-				continue
-			}
-			// Reject Fetched=false observations from transient failures so
-			// they do not overwrite durable metadata/CI/review facts. The
-			// provider returns Fetched=false + a non-nil error; the
-			// placeholder must not advance ETags or be persisted (review
-			// finding #1).
-			//
-			// Per-observation Error routing (review Item 7): when the
-			// multi dispatcher attaches a failure as transient metadata on
-			// a Fetched=false observation (one provider failed while
-			// another succeeded), route it here so the failed provider is
-			// not retried every tick:
-			//   - rate-limit error → per-provider cooldown (reuses existing
-			//     rateLimitCooldown/setRateLimitCooldown machinery);
-			//   - non-rate-limit error → mark the repo refresh-incomplete.
-			if !obs.Fetched {
-				if obs.Error != nil {
-					providerKey := obs.Provider
-					if providerKey == "" {
-						// Fall back to the ref's provider when the placeholder
-						// did not carry one (defensive — multi always sets it).
-						for _, ref := range active {
-							if selection.refKey(ref) == key {
-								providerKey = ref.Repo.Provider
-								break
-							}
-						}
-					}
-					if cooldown, ok := rateLimitCooldown(now, obs.Error); ok {
-						if providerKey != "" {
-							o.setRateLimitCooldown(now, providerKey, cooldown)
-						}
-						o.logger.Warn("scm observer: provider rate-limited (per-observation); entering cooldown", "provider", providerKey, "cooldown", cooldown, "err", obs.Error)
+		for i, ref := range active {
+			// Reject Fetched=false observations (missing PR, or a transient
+			// failure attached by the multi dispatcher as per-observation
+			// Error metadata) so they do not overwrite durable facts, and
+			// mark the ref's repo refresh-incomplete either way:
+			//   - rate-limit error → per-provider cooldown;
+			//   - other/no error → the repo ETag/cursor simply must not
+			//     advance without an observation (review finding #1).
+			if i >= len(batch) || !batch[i].Fetched {
+				if i < len(batch) && batch[i].Error != nil {
+					fetchErr := batch[i].Error
+					providerKey := firstNonEmpty(batch[i].Provider, ref.Repo.Provider)
+					if cooldown, ok := rateLimitCooldown(now, fetchErr); ok {
+						o.setRateLimitCooldown(now, providerKey, cooldown)
+						o.logger.Warn("scm observer: provider rate-limited (per-observation); entering cooldown", "provider", providerKey, "cooldown", cooldown, "err", fetchErr)
 					} else {
-						o.logger.Warn("scm observer: provider fetch failed (per-observation); marking refresh-incomplete", "provider", providerKey, "err", obs.Error)
+						o.logger.Warn("scm observer: provider fetch failed (per-observation); marking refresh-incomplete", "provider", providerKey, "err", fetchErr)
 					}
 				}
+				markRepoRefreshFailed(ref.Repo)
 				continue
 			}
-			observations[key] = obs
-			chunkSeen[key] = true
-		}
-		for _, ref := range active {
-			if !chunkSeen[selection.refKey(ref)] {
-				markRepoRefreshFailed(ref.Repo)
-			}
+			obs := batch[i]
+			obs.ObservedAt = now
+			observations[activeKeys[i]] = obs
 		}
 	}
 
@@ -1257,7 +1230,6 @@ func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[str
 		subjectsByPR:  map[string]*subject{},
 		commitETags:   map[string]pendingCacheString{},
 		candidateKeys: map[string]bool{},
-		keyByRef:      map[string]string{},
 	}
 	for _, s := range subjects {
 		if !s.hasPR || s.known.Number <= 0 {
@@ -1329,8 +1301,8 @@ func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[str
 		}
 		if candidate {
 			selection.refs = append(selection.refs, ports.SCMPRRef{Repo: s.repo, Number: s.known.Number, URL: s.known.URL})
+			selection.refKeys = append(selection.refKeys, key)
 			selection.candidateKeys[key] = true
-			selection.keyByRef[prKey(s.repo, s.known.Number)] = key
 		}
 	}
 	return selection
@@ -1421,16 +1393,9 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 			ref: ports.SCMPRRef{Repo: s.repo, Number: s.known.Number, URL: s.known.URL},
 			s:   s,
 		})
-		selection.keyByRef[prKey(s.repo, s.known.Number)] = key
 	}
 	if len(refs) == 0 {
 		return out
-	}
-	// Reconcile refs resolve against their pending subjects; the selection's
-	// subjectsByPR does not yet contain them (they were not candidates).
-	reconSubjects := map[string]*subject{}
-	for _, r := range refs {
-		reconSubjects[keyForTrackedPR(r.s.known, r.s.repo)] = r.s
 	}
 	// Unbounded: issue detail fetches for every reconciled PR. The worst case
 	// is bounded by the tracked-open-PR count, which is small in AO's use case.
@@ -1438,23 +1403,25 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 		if err := ctx.Err(); err != nil {
 			return out
 		}
-		refBatch := make([]ports.SCMPRRef, 0, len(chunk))
-		for _, r := range chunk {
-			refBatch = append(refBatch, r.ref)
-		}
 		// Skip cooled-down providers so a rate-limited GitHub does not
 		// suppress reconciliation of other providers (defensive — only
 		// GitHub PRs are reconciled here, but the guard keeps the invariant).
-		active := refBatch[:0]
-		for _, ref := range refBatch {
-			if o.inRateLimitCooldown(now, ref.Repo.Provider) {
-				markRepoFailed(ref.Repo)
+		// activePending stays aligned with the refs sent to the provider, so
+		// batch[i] is attributed to activePending[i]'s subject positionally.
+		activePending := make([]pendingReconcile, 0, len(chunk))
+		for _, r := range chunk {
+			if o.inRateLimitCooldown(now, r.ref.Repo.Provider) {
+				markRepoFailed(r.ref.Repo)
 				continue
 			}
-			active = append(active, ref)
+			activePending = append(activePending, r)
 		}
-		if len(active) == 0 {
+		if len(activePending) == 0 {
 			continue
+		}
+		active := make([]ports.SCMPRRef, len(activePending))
+		for i, r := range activePending {
+			active[i] = r.ref
 		}
 		batch, err := o.provider.FetchPullRequests(ctx, active)
 		if err != nil {
@@ -1471,96 +1438,44 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 			}
 			continue
 		}
-		reconcileSeen := map[string]bool{}
-		for _, obs := range batch {
-			obs.ObservedAt = now
-			key := observationSubjectKey(obs, active, reconSubjects, selection.keyByRef)
-			if key == "" {
-				continue
-			}
-			if !obs.Fetched {
-				// Fetched=false placeholders are transient failures; route
-				// per-observation errors via the same path as the normal
-				// fetch loop. Do not persist placeholders.
-				if obs.Error != nil {
-					providerKey := obs.Provider
-					if providerKey == "" {
-						for _, ref := range active {
-							if selection.refKey(ref) == key {
-								providerKey = ref.Repo.Provider
-								break
-							}
-						}
-					}
-					if cooldown, ok := rateLimitCooldown(now, obs.Error); ok {
-						if providerKey != "" {
-							o.setRateLimitCooldown(now, providerKey, cooldown)
-						}
-						o.logger.Warn("scm observer: reconciliation rate-limited (per-observation); entering cooldown", "provider", providerKey, "cooldown", cooldown, "err", obs.Error)
+		for i, r := range activePending {
+			// A missing or Fetched=false result (transient failure carried as
+			// per-observation Error metadata) must not persist and must mark
+			// the repo refresh-incomplete so the ETag/cursor do not advance
+			// without an observation.
+			if i >= len(batch) || !batch[i].Fetched {
+				if i < len(batch) && batch[i].Error != nil {
+					fetchErr := batch[i].Error
+					providerKey := firstNonEmpty(batch[i].Provider, r.ref.Repo.Provider)
+					if cooldown, ok := rateLimitCooldown(now, fetchErr); ok {
+						o.setRateLimitCooldown(now, providerKey, cooldown)
+						o.logger.Warn("scm observer: reconciliation rate-limited (per-observation); entering cooldown", "provider", providerKey, "cooldown", cooldown, "err", fetchErr)
 					} else {
-						o.logger.Warn("scm observer: reconciliation fetch failed (per-observation); marking refresh-incomplete", "provider", providerKey, "err", obs.Error)
+						o.logger.Warn("scm observer: reconciliation fetch failed (per-observation); marking refresh-incomplete", "provider", providerKey, "err", fetchErr)
 					}
 				}
-				// Mark the repo refresh-incomplete on any failure so the
-				// repo ETag/cursor do not advance without an observation.
-				for _, ref := range active {
-					if selection.refKey(ref) == key {
-						markRepoFailed(ref.Repo)
-						break
-					}
-				}
+				markRepoFailed(r.ref.Repo)
 				continue
 			}
+			obs := batch[i]
+			obs.ObservedAt = now
+			key := keyForTrackedPR(r.s.known, r.s.repo)
 			out[key] = obs
-			reconcileSeen[key] = true
 			// Register the reconciled PR in selection.subjectsByPR and
 			// candidateKeys so the persistence loop processes it. Marking
 			// candidateKeys also ensures prRefreshOK is initialized for this
 			// key so the commit-ETag cache does not advance unless the
 			// persistence succeeds.
-			if s, ok := reconSubjects[key]; ok {
-				selection.subjectsByPR[key] = s
-			}
+			selection.subjectsByPR[key] = r.s
 			selection.candidateKeys[key] = true
 			// Pre-mark the repo refresh-incomplete for every reconciled
-			// "still open" observation. A "still open" result is a no-op
-			// persistence that must NOT advance the repo ETag or sync
-			// cursor (cross-cutting durable-state preservation rule). If
-			// the observation turns out to be a terminal transition
-			// (hashes changed), the persistence loop clears this mark
-			// after a successful write so the ETag/cursor can advance on
-			// a real terminal transition only.
-			for _, ref := range active {
-				if selection.refKey(ref) == key {
-					markRepoFailed(ref.Repo)
-					break
-				}
-			}
-		}
-		// Any reconciled PR that did not yield a Fetched=true observation
-		// must mark its repo refresh-incomplete (no-op result: durable state
-		// must not advance).
-		for _, r := range chunk {
-			key := selection.refKey(r.ref)
-			if reconcileSeen[key] {
-				// A "still open" observation: if the semantic hashes are
-				// unchanged (no terminal transition), the persistence loop
-				// treats it as a no-op and sets prRefreshOK[key]=true without
-				// writing. But we must still prevent the repo ETag/cursor
-				// from advancing on a no-op reconciliation result, so mark
-				// the repo refresh-incomplete here. If the result IS a
-				// terminal transition (hashes changed), the persistence
-				// loop sets prRefreshOK[key]=true after a successful write —
-				// we must NOT pre-mark the repo failed in that case. The
-				// persistence loop's prRefreshOK[key]=true overrides the
-				// repo-level mark for the ETag/cursor advancement decision
-				// only if listedRepos[repoKey] is also true. Since the
-				// reconciled PR was NOT in the listing, listedRepos[repoKey]
-				// may still be true (the listing was fetched), so we mark
-				// the repo refresh-incomplete to ensure the cursor does not
-				// advance without a terminal observation being persisted.
-				continue
-			}
+			// observation. A "still open" result is a no-op persistence that
+			// must NOT advance the repo ETag or sync cursor (cross-cutting
+			// durable-state preservation rule): the persistence loop treats
+			// unchanged hashes as a no-op and never clears this mark. If the
+			// result IS a terminal transition (hashes changed), a successful
+			// write sets prRefreshOK[key]=true, which un-marks the repo so
+			// the ETag/cursor can advance on a real terminal transition only.
 			markRepoFailed(r.ref.Repo)
 		}
 	}
@@ -2077,22 +1992,17 @@ func stableHash(v any) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func prKeyFromObs(obs ports.SCMObservation) string {
-	if obs.Repo == "" || obs.PR.Number <= 0 {
-		return ""
-	}
-	return obs.Provider + ":" + obs.Host + ":" + obs.Repo + "#" + fmt.Sprint(obs.PR.Number)
-}
-
 // PR identity has one owner: the provider-native id (provider, host,
 // provider_id), which survives repository renames and org transfers. Repo
-// name, number, and URL are mutable display coordinates. Subjects,
-// observation dispatch, and discovery dedupe all key on identityPRKey when a
-// provider id is known; the legacy name-based prKey remains only as a
-// self-retiring fallback for rows that predate provider ids (their first
-// successful fetch stamps one). Repo-level state — list ETags, sync cursors,
-// commit-check guards — deliberately stays name-keyed: listing genuinely is a
-// per-name operation.
+// name, number, and URL are mutable display coordinates. Subjects and
+// discovery dedupe key on identityPRKey when a provider id is known; the
+// legacy name-based prKey remains only as a self-retiring fallback for rows
+// that predate provider ids (their first successful fetch stamps one).
+// Fetched observations are never re-keyed from their content at all — they
+// are attributed positionally to the ref that requested them (see the
+// Provider.FetchPullRequests contract). Repo-level state — list ETags, sync
+// cursors, commit-check guards — deliberately stays name-keyed: listing
+// genuinely is a per-name operation.
 func identityPRKey(provider, host, providerID string) string {
 	return strings.ToLower(strings.TrimSpace(provider)) + ":" +
 		strings.ToLower(strings.TrimSpace(host)) + "@" + strings.TrimSpace(providerID)
@@ -2106,45 +2016,6 @@ func keyForTrackedPR(pr domain.PullRequest, repo ports.SCMRepo) string {
 		return identityPRKey(pr.Provider, pr.Host, pr.ProviderID)
 	}
 	return prKey(repo, pr.Number)
-}
-
-// observationSubjectKey resolves which subject a fetched observation belongs
-// to, in priority order: provider identity, canonical name key, then the
-// requesting ref matched by name or PR URL/alias (the rename fallback for
-// rows without a provider id — after a transfer the observation
-// canonicalizes to the new owner/name while a legacy subject still carries
-// the old one). keyByRef maps prKey(ref.Repo, ref.Number) of every issued
-// ref to the subject key it was issued for.
-func observationSubjectKey(obs ports.SCMObservation, refs []ports.SCMPRRef, subjects map[string]*subject, keyByRef map[string]string) string {
-	if obs.PR.ProviderID != "" && obs.Provider != "" && obs.Host != "" {
-		if k := identityPRKey(obs.Provider, obs.Host, obs.PR.ProviderID); subjects[k] != nil {
-			return k
-		}
-	}
-	canonical := prKeyFromObs(obs)
-	if canonical == "" {
-		return ""
-	}
-	if subjects[canonical] != nil {
-		return canonical
-	}
-	obsURL := strings.TrimSpace(obs.PR.URL)
-	obsAlias := strings.TrimSpace(obs.PR.URLAlias)
-	for _, ref := range refs {
-		if ref.Number != obs.PR.Number {
-			continue
-		}
-		rk := prKey(ref.Repo, ref.Number)
-		refURL := strings.TrimSpace(ref.URL)
-		urlMatch := refURL != "" && (refURL == obsURL || (obsAlias != "" && refURL == obsAlias))
-		if rk == canonical || urlMatch {
-			if k, ok := keyByRef[rk]; ok {
-				return k
-			}
-			return rk
-		}
-	}
-	return canonical
 }
 
 func prKey(repo ports.SCMRepo, number int) string {

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -508,7 +508,12 @@ func (o *Observer) Poll(ctx context.Context) error {
 				if i < len(batch) && batch[i].Error != nil {
 					fetchErr := batch[i].Error
 					providerKey := firstNonEmpty(batch[i].Provider, ref.Repo.Provider)
-					if cooldown, ok := rateLimitCooldown(now, fetchErr); ok {
+					if errors.Is(fetchErr, ports.ErrSCMNotFound) {
+						// A permanent miss (deleted repo, revoked access, dead
+						// redirect), re-observed every tick — Debug, not Warn,
+						// so a broken tracked PR does not flood the log.
+						o.logger.Debug("scm observer: tracked PR not found at provider; marking refresh-incomplete", "provider", providerKey, "pr", ref.URL, "err", fetchErr)
+					} else if cooldown, ok := rateLimitCooldown(now, fetchErr); ok {
 						o.setRateLimitCooldown(now, providerKey, cooldown)
 						o.logger.Warn("scm observer: provider rate-limited (per-observation); entering cooldown", "provider", providerKey, "cooldown", cooldown, "err", fetchErr)
 					} else {
@@ -1473,7 +1478,11 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 				if i < len(batch) && batch[i].Error != nil {
 					fetchErr := batch[i].Error
 					providerKey := firstNonEmpty(batch[i].Provider, r.ref.Repo.Provider)
-					if cooldown, ok := rateLimitCooldown(now, fetchErr); ok {
+					if errors.Is(fetchErr, ports.ErrSCMNotFound) {
+						// Permanent miss, re-observed every tick — Debug, not
+						// Warn, so a broken tracked PR does not flood the log.
+						o.logger.Debug("scm observer: reconciled PR not found at provider; marking refresh-incomplete", "provider", providerKey, "pr", r.ref.URL, "err", fetchErr)
+					} else if cooldown, ok := rateLimitCooldown(now, fetchErr); ok {
 						o.setRateLimitCooldown(now, providerKey, cooldown)
 						o.logger.Warn("scm observer: reconciliation rate-limited (per-observation); entering cooldown", "provider", providerKey, "cooldown", cooldown, "err", fetchErr)
 					} else {

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -484,7 +484,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 		chunkSeen := map[string]bool{}
 		for _, obs := range batch {
 			obs.ObservedAt = now
-			key := prKeyFromObs(obs)
+			key := observationKeyForRefs(obs, active)
 			if key == "" {
 				continue
 			}
@@ -1425,7 +1425,7 @@ func (o *Observer) reconcileTerminalGitHubPRs(ctx context.Context, subjects map[
 		reconcileSeen := map[string]bool{}
 		for _, obs := range batch {
 			obs.ObservedAt = now
-			key := prKeyFromObs(obs)
+			key := observationKeyForRefs(obs, active)
 			if key == "" {
 				continue
 			}
@@ -2036,6 +2036,44 @@ func prKeyFromObs(obs ports.SCMObservation) string {
 		return ""
 	}
 	return obs.Provider + ":" + obs.Host + ":" + obs.Repo + "#" + fmt.Sprint(obs.PR.Number)
+}
+
+// observationKeyForRefs resolves the key a fetched observation should be
+// dispatched under. Normally that is prKeyFromObs: the observation's canonical
+// repo matches the ref that requested it. After a repository rename or org
+// transfer, the provider serves the fetch through a redirect and the
+// observation canonicalizes to the new owner/name while the tracked subject
+// (whose repo comes from the stored PR row) still carries the old one. The two
+// keys then never match, so the observation would be dropped on every poll —
+// CI and mergeability stay "unknown" forever while the separate per-ref review
+// refresh keeps working. Falling back to matching the requesting ref by PR URL
+// delivers the observation under the subject's key; persistence then records
+// the canonical repo on the row, so the identities converge on the next poll.
+func observationKeyForRefs(obs ports.SCMObservation, refs []ports.SCMPRRef) string {
+	key := prKeyFromObs(obs)
+	if key == "" {
+		return ""
+	}
+	for _, ref := range refs {
+		if prKey(ref.Repo, ref.Number) == key {
+			return key
+		}
+	}
+	obsURL := strings.TrimSpace(obs.PR.URL)
+	obsAlias := strings.TrimSpace(obs.PR.URLAlias)
+	for _, ref := range refs {
+		if ref.Number != obs.PR.Number {
+			continue
+		}
+		refURL := strings.TrimSpace(ref.URL)
+		if refURL == "" {
+			continue
+		}
+		if refURL == obsURL || (obsAlias != "" && refURL == obsAlias) {
+			return prKey(ref.Repo, ref.Number)
+		}
+	}
+	return key
 }
 
 func prKey(repo ports.SCMRepo, number int) string {

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -988,6 +988,7 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 	// re-fetched
 	listedPRs = map[string]bool{}
 	listedRepos = map[string]bool{}
+	pullsByRepo := map[string][]ports.SCMPRObservation{}
 	for repoKey, repo := range repos {
 		g := guards[repoKey]
 		if g.err != nil {
@@ -1013,6 +1014,7 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 			}
 			continue
 		}
+		pullsByRepo[repoKey] = pulls
 		// Record the listed PR numbers so selectRefreshCandidates can
 		// restrict refresh to only updated MRs rather than every tracked MR.
 		// Subjects are identity-keyed, so when a listed PR's provider id
@@ -1028,6 +1030,30 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 				}
 			}
 		}
+	}
+
+	// Provider-wide identity pre-pass: a legacy tracked row may not have a
+	// provider_id yet, while the same PR is listed through both its old and new
+	// repository names after a transfer. Associate the stable id from any exact
+	// legacy repo#number listing before processing discoveries under either
+	// name. Otherwise map iteration order can let the canonical-name listing
+	// persist an unknown baseline before the old-name detail fetch stamps the id.
+	trackedProviderIdentities := map[string]bool{}
+	for repoKey, pulls := range pullsByRepo {
+		repo := repos[repoKey]
+		for _, pr := range pulls {
+			if pr.ProviderID == "" {
+				continue
+			}
+			idKey := identityPRKey(repo.Provider, repo.Host, pr.ProviderID)
+			if subjects[idKey] != nil || subjects[prKey(repo, pr.Number)] != nil {
+				trackedProviderIdentities[idKey] = true
+			}
+		}
+	}
+
+	for repoKey, pulls := range pullsByRepo {
+		repo := repos[repoKey]
 		for _, pr := range pulls {
 			if pr.Number <= 0 || pr.SourceBranch == "" {
 				continue
@@ -1052,7 +1078,8 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 			// semantic hashes — the "Checking merge readiness" flap
 			// (issue #4089, mechanism 2).
 			if pr.ProviderID != "" {
-				if _, ok := subjects[identityPRKey(repo.Provider, repo.Host, pr.ProviderID)]; ok {
+				idKey := identityPRKey(repo.Provider, repo.Host, pr.ProviderID)
+				if trackedProviderIdentities[idKey] || subjects[idKey] != nil {
 					continue
 				}
 			}

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -3217,30 +3217,3 @@ func TestPoll_IdentityKeyedDispatchSurvivesRename(t *testing.T) {
 		t.Fatalf("lifecycle notifications = %d, want 1", len(lc.observed))
 	}
 }
-
-// Two stored rows for the same provider-native PR (one per repo name, the
-// pre-#3923 duplicate-row artifact) collapse to a single subject instead of
-// two subjects fighting over the same PR.
-func TestDiscoverSubjects_CollapsesDuplicateRowsByIdentity(t *testing.T) {
-	store := &fakeStore{
-		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "feat"}}},
-		projects: map[string]domain.ProjectRecord{"p": {ID: "p", RepoOriginURL: "https://github.com/new/r.git"}},
-		prs: map[domain.SessionID][]domain.PullRequest{"p-1": {
-			{URL: "https://github.com/old/r/pull/1", SessionID: "p-1", Number: 1, Provider: "github", Host: "github.com", Repo: "old/r", ProviderID: "PR_dup", SourceBranch: "feat"},
-			{URL: "https://github.com/new/r/pull/1", SessionID: "p-1", Number: 1, Provider: "github", Host: "github.com", Repo: "new/r", ProviderID: "PR_dup", SourceBranch: "feat"},
-		}},
-		checks: map[string][]domain.PullRequestCheck{},
-	}
-	provider := &fakeProvider{observations: map[string]ports.SCMObservation{}}
-	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
-	subjects, _, err := obs.discoverSubjects(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(subjects) != 1 {
-		t.Fatalf("subjects = %d, want 1 (same provider identity must collapse)", len(subjects))
-	}
-	if _, ok := subjects[identityPRKey("github", "github.com", "PR_dup")]; !ok {
-		t.Fatalf("subject not keyed by provider identity: %v", subjects)
-	}
-}

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -209,6 +209,7 @@ func (p *fakeProvider) ListPRsByRepo(_ context.Context, repo ports.SCMRepo, _ ti
 func (p *fakeProvider) CommitChecksGuard(_ context.Context, repo ports.SCMRepo, sha, _ string) (ports.SCMGuardResult, error) {
 	return p.checkGuards[commitKey(repo, sha)], nil
 }
+
 // FetchPullRequests honors the positional-alignment contract: out[i] answers
 // refs[i], with a zero-value Fetched=false placeholder for refs the fake has
 // no observation for.

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -209,6 +209,9 @@ func (p *fakeProvider) ListPRsByRepo(_ context.Context, repo ports.SCMRepo, _ ti
 func (p *fakeProvider) CommitChecksGuard(_ context.Context, repo ports.SCMRepo, sha, _ string) (ports.SCMGuardResult, error) {
 	return p.checkGuards[commitKey(repo, sha)], nil
 }
+// FetchPullRequests honors the positional-alignment contract: out[i] answers
+// refs[i], with a zero-value Fetched=false placeholder for refs the fake has
+// no observation for.
 func (p *fakeProvider) FetchPullRequests(_ context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -216,25 +219,25 @@ func (p *fakeProvider) FetchPullRequests(_ context.Context, refs []ports.SCMPRRe
 	if p.fetchErr != nil {
 		return nil, p.fetchErr
 	}
-	out := make([]ports.SCMObservation, 0, len(refs))
-	for _, ref := range refs {
+	out := make([]ports.SCMObservation, len(refs))
+	for i, ref := range refs {
 		key := prKey(ref.Repo, ref.Number)
 		// Per-observation error mimics the multi dispatcher's per-provider
 		// Error metadata: a Fetched=false placeholder carrying the failure
 		// so the observer can route it to cooldown / refresh-incomplete.
 		if err, ok := p.fetchObsErrors[key]; ok {
-			out = append(out, ports.SCMObservation{
+			out[i] = ports.SCMObservation{
 				Fetched:  false,
 				Provider: ref.Repo.Provider,
 				Host:     ref.Repo.Host,
 				Repo:     ref.Repo.Repo,
 				PR:       ports.SCMPRObservation{Number: ref.Number, URL: ref.URL},
 				Error:    err,
-			})
+			}
 			continue
 		}
 		if obs, ok := p.observations[key]; ok {
-			out = append(out, obs)
+			out[i] = obs
 		}
 	}
 	return out, nil
@@ -3087,77 +3090,6 @@ func TestPoll_RenamedRepoReconciliationPersistsUnderTrackedRef(t *testing.T) {
 	final := store.writes[len(store.writes)-1].pr
 	if final.Repo != "new/r" || final.CI != domain.CIPassing {
 		t.Fatalf("persisted PR = repo %q ci %q; want canonical new/r with passing CI", final.Repo, final.CI)
-	}
-}
-
-func TestObservationSubjectKey(t *testing.T) {
-	newObs := func(url, alias, providerID string) ports.SCMObservation {
-		return ports.SCMObservation{
-			Fetched: true, Provider: "github", Host: "github.com", Repo: "new/r",
-			PR: ports.SCMPRObservation{URL: url, URLAlias: alias, Number: 1, ProviderID: providerID},
-		}
-	}
-	oldRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "old", Name: "r", Repo: "old/r"}
-	newRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "new", Name: "r", Repo: "new/r"}
-	oldRef := ports.SCMPRRef{Repo: oldRepo, Number: 1, URL: "https://github.com/new/r/pull/1"}
-	newRef := ports.SCMPRRef{Repo: newRepo, Number: 1, URL: "https://github.com/new/r/pull/1"}
-	idKey := identityPRKey("github", "github.com", "PR_1")
-	subj := &subject{}
-	tests := []struct {
-		name     string
-		obs      ports.SCMObservation
-		refs     []ports.SCMPRRef
-		subjects map[string]*subject
-		keyByRef map[string]string
-		want     string
-	}{
-		{
-			name:     "provider identity wins over every name",
-			obs:      newObs("https://github.com/new/r/pull/1", "", "PR_1"),
-			refs:     []ports.SCMPRRef{oldRef},
-			subjects: map[string]*subject{idKey: subj},
-			keyByRef: map[string]string{prKey(oldRepo, 1): idKey},
-			want:     idKey,
-		},
-		{
-			name:     "canonical name key when subject has no identity",
-			obs:      newObs("https://github.com/new/r/pull/1", "", "PR_1"),
-			refs:     []ports.SCMPRRef{newRef},
-			subjects: map[string]*subject{prKey(newRepo, 1): subj},
-			keyByRef: map[string]string{prKey(newRepo, 1): prKey(newRepo, 1)},
-			want:     prKey(newRepo, 1),
-		},
-		{
-			name:     "renamed repo falls back to requesting ref by URL",
-			obs:      newObs("https://github.com/new/r/pull/1", "", ""),
-			refs:     []ports.SCMPRRef{oldRef},
-			subjects: map[string]*subject{prKey(oldRepo, 1): subj},
-			keyByRef: map[string]string{prKey(oldRepo, 1): prKey(oldRepo, 1)},
-			want:     prKey(oldRepo, 1),
-		},
-		{
-			name:     "renamed repo falls back via URL alias",
-			obs:      newObs("https://github.com/new/r/pull/1", "https://github.com/old/r/pull/1", ""),
-			refs:     []ports.SCMPRRef{{Repo: oldRepo, Number: 1, URL: "https://github.com/old/r/pull/1"}},
-			subjects: map[string]*subject{prKey(oldRepo, 1): subj},
-			keyByRef: map[string]string{prKey(oldRepo, 1): prKey(oldRepo, 1)},
-			want:     prKey(oldRepo, 1),
-		},
-		{
-			name:     "no matching ref keeps canonical key",
-			obs:      newObs("https://github.com/new/r/pull/1", "", ""),
-			refs:     []ports.SCMPRRef{{Repo: oldRepo, Number: 2, URL: "https://github.com/new/r/pull/2"}},
-			subjects: map[string]*subject{},
-			keyByRef: map[string]string{},
-			want:     "github:github.com:new/r#1",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := observationSubjectKey(tt.obs, tt.refs, tt.subjects, tt.keyByRef); got != tt.want {
-				t.Fatalf("observationSubjectKey = %q, want %q", got, tt.want)
-			}
-		})
 	}
 }
 

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -3006,3 +3006,115 @@ func TestPoll_RepoRefreshMonotonicity_ListingFailsButPRSucceeds(t *testing.T) {
 		t.Fatalf("sync cursor advanced when listing failed: got %v, want %v (unchanged)", got, cursorBefore)
 	}
 }
+
+// After a repository rename or org transfer, the provider serves fetches for
+// the old owner/name through a redirect: the tracked subject still carries the
+// stale repo recorded on the stored PR row, while the fetched observation
+// canonicalizes to the new owner/name. These tests pin that such observations
+// are dispatched under the tracked subject's key (and persisted with the
+// canonical repo so the identities converge) instead of being dropped, which
+// left CI/mergeability permanently "unknown" while review stayed fresh.
+
+func renamedRepoFixture() (*fakeStore, *fakeProvider, ports.SCMRepo) {
+	oldRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "old", Name: "r", Repo: "old/r"}
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "feat"}}},
+		projects: map[string]domain.ProjectRecord{"p": {ID: "p", RepoOriginURL: "https://github.com/old/r.git"}},
+		prs: map[domain.SessionID][]domain.PullRequest{"p-1": {{
+			URL: "https://github.com/new/r/pull/1", SessionID: "p-1", Number: 1,
+			Provider: "github", Host: "github.com", Repo: "old/r", SourceBranch: "feat",
+		}}},
+		checks: map[string][]domain.PullRequestCheck{},
+	}
+	canonical := ports.SCMObservation{
+		Fetched: true, Provider: "github", Host: "github.com", Repo: "new/r",
+		PR:           ports.SCMPRObservation{URL: "https://github.com/new/r/pull/1", Number: 1, State: "open", SourceBranch: "feat", TargetBranch: "main", HeadSHA: "sha1", Title: "PR"},
+		CI:           ports.SCMCIObservation{Summary: string(domain.CIPassing), HeadSHA: "sha1"},
+		Review:       ports.SCMReviewObservation{Decision: string(domain.ReviewRequired)},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeBlocked), Blockers: []string{"review_required"}},
+	}
+	provider := &fakeProvider{
+		repoGuards:   map[string]ports.SCMGuardResult{prKey(oldRepo, 0): {ETag: "v1"}},
+		openPRs:      map[string][]ports.SCMPRObservation{},
+		observations: map[string]ports.SCMObservation{prKey(oldRepo, 1): canonical},
+	}
+	return store, provider, oldRepo
+}
+
+func TestPoll_RenamedRepoObservationPersistsUnderTrackedRef(t *testing.T) {
+	store, provider, _ := renamedRepoFixture()
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.fetchBatches) != 1 {
+		t.Fatalf("fetch batches = %d, want 1", len(provider.fetchBatches))
+	}
+	if len(store.writes) == 0 {
+		t.Fatal("renamed-repo observation was dropped: no writes")
+	}
+	final := store.writes[len(store.writes)-1].pr
+	if final.Repo != "new/r" || final.Title != "PR" || final.CI != domain.CIPassing || final.Mergeability != domain.MergeBlocked {
+		t.Fatalf("persisted PR = repo %q title %q ci %q mergeability %q; want canonical new/r metadata", final.Repo, final.Title, final.CI, final.Mergeability)
+	}
+	if len(lc.observed) != 1 {
+		t.Fatalf("lifecycle notifications = %d, want 1", len(lc.observed))
+	}
+}
+
+func TestPoll_RenamedRepoReconciliationPersistsUnderTrackedRef(t *testing.T) {
+	store, provider, oldRepo := renamedRepoFixture()
+	// A fully-observed local row keeps the PR out of the normal refresh
+	// candidate set; the empty incremental listing then routes it through
+	// terminal reconciliation, which must survive the rename the same way.
+	local := &store.prs["p-1"][0]
+	local.MetadataHash = "stale-meta"
+	local.CIHash = "stale-ci"
+	local.ReviewHash = "stale-review"
+	local.Review = domain.ReviewRequired
+	local.ReviewObservedAt = time.Unix(60, 0).UTC()
+	local.HeadSHA = "sha0"
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(100, 0).UTC())
+	obs.Cache.LastSyncCursor[prKey(oldRepo, 0)] = time.Unix(50, 0).UTC()
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.writes) == 0 {
+		t.Fatal("renamed-repo reconciliation observation was dropped: no writes")
+	}
+	final := store.writes[len(store.writes)-1].pr
+	if final.Repo != "new/r" || final.CI != domain.CIPassing {
+		t.Fatalf("persisted PR = repo %q ci %q; want canonical new/r with passing CI", final.Repo, final.CI)
+	}
+}
+
+func TestObservationKeyForRefs(t *testing.T) {
+	newObs := func(url, alias string) ports.SCMObservation {
+		return ports.SCMObservation{
+			Fetched: true, Provider: "github", Host: "github.com", Repo: "new/r",
+			PR: ports.SCMPRObservation{URL: url, URLAlias: alias, Number: 1},
+		}
+	}
+	oldRef := ports.SCMPRRef{Repo: ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "old", Name: "r", Repo: "old/r"}, Number: 1, URL: "https://github.com/new/r/pull/1"}
+	newRef := ports.SCMPRRef{Repo: ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "new", Name: "r", Repo: "new/r"}, Number: 1, URL: "https://github.com/new/r/pull/1"}
+	tests := []struct {
+		name string
+		obs  ports.SCMObservation
+		refs []ports.SCMPRRef
+		want string
+	}{
+		{name: "canonical ref wins", obs: newObs("https://github.com/new/r/pull/1", ""), refs: []ports.SCMPRRef{oldRef, newRef}, want: prKey(newRef.Repo, 1)},
+		{name: "renamed repo falls back to requesting ref by URL", obs: newObs("https://github.com/new/r/pull/1", ""), refs: []ports.SCMPRRef{oldRef}, want: prKey(oldRef.Repo, 1)},
+		{name: "renamed repo falls back via URL alias", obs: newObs("https://github.com/new/r/pull/1", "https://github.com/old/r/pull/1"), refs: []ports.SCMPRRef{{Repo: oldRef.Repo, Number: 1, URL: "https://github.com/old/r/pull/1"}}, want: prKey(oldRef.Repo, 1)},
+		{name: "no matching ref keeps canonical key", obs: newObs("https://github.com/new/r/pull/1", ""), refs: []ports.SCMPRRef{{Repo: oldRef.Repo, Number: 2, URL: "https://github.com/new/r/pull/2"}}, want: "github:github.com:new/r#1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := observationKeyForRefs(tt.obs, tt.refs); got != tt.want {
+				t.Fatalf("observationKeyForRefs = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -3121,44 +3121,54 @@ func TestPoll_SecondScanNameDoesNotRebaselineTrackedPR(t *testing.T) {
 	}
 	defer func() { gitRemoteURLsFunc = restoreRemotes }()
 
-	tracked := domain.PullRequest{
-		URL: "https://github.com/new/r/pull/1", SessionID: "p-1", Number: 1,
-		Provider: "github", Host: "github.com", Repo: "new/r", ProviderID: "PR_stable_1",
-		SourceBranch: "feat", HeadSHA: "sha1", CI: domain.CIPassing, Mergeability: domain.MergeBlocked,
-		MetadataHash: "m", CIHash: "c", ReviewHash: "r", Review: domain.ReviewRequired,
-		ObservedAt: time.Unix(50, 0).UTC(), CIObservedAt: time.Unix(50, 0).UTC(), ReviewObservedAt: time.Unix(50, 0).UTC(),
-	}
-	store := &fakeStore{
-		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "feat"}}},
-		projects: map[string]domain.ProjectRecord{"p": {ID: "p", Path: "/proj", RepoOriginURL: "https://github.com/new/r.git"}},
-		prs:      map[domain.SessionID][]domain.PullRequest{"p-1": {tracked}},
-		checks:   map[string][]domain.PullRequestCheck{},
-	}
 	listing := []ports.SCMPRObservation{{
 		ProviderID: "PR_stable_1", URL: "https://github.com/new/r/pull/1", Number: 1,
 		SourceBranch: "feat", HeadRepo: "new/r", TargetBranch: "main", HeadSHA: "sha1",
 	}}
-	provider := &fakeProvider{
-		repoGuards: map[string]ports.SCMGuardResult{
-			prKey(newRepo, 0): {ETag: "vN"},
-			prKey(oldRepo, 0): {ETag: "vO"},
-		},
-		// Both scan names list the same PR: the canonical listing and the
-		// stale-remote listing served through GitHub's rename redirect.
-		openPRs: map[string][]ports.SCMPRObservation{
-			prKey(newRepo, 0): listing,
-			prKey(oldRepo, 0): listing,
-		},
-		observations: map[string]ports.SCMObservation{},
-	}
-	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(100, 0).UTC())
-	if err := obs.Poll(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	for _, w := range store.writes {
-		if w.pr.Number == 1 && w.pr.CI == domain.CIUnknown {
-			t.Fatalf("tracked PR was re-baselined by a second scan name: %+v", w.pr)
-		}
+	for _, tt := range []struct {
+		name       string
+		providerID string
+	}{
+		{name: "provider identity already stored", providerID: "PR_stable_1"},
+		{name: "legacy row associated by listing identity"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tracked := domain.PullRequest{
+				URL: "https://github.com/new/r/pull/1", SessionID: "p-1", Number: 1,
+				Provider: "github", Host: "github.com", Repo: "old/r", ProviderID: tt.providerID,
+				SourceBranch: "feat", HeadSHA: "sha1", CI: domain.CIPassing, Mergeability: domain.MergeBlocked,
+				MetadataHash: "m", CIHash: "c", ReviewHash: "r", Review: domain.ReviewRequired,
+				ObservedAt: time.Unix(50, 0).UTC(), CIObservedAt: time.Unix(50, 0).UTC(), ReviewObservedAt: time.Unix(50, 0).UTC(),
+			}
+			store := &fakeStore{
+				sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "feat"}}},
+				projects: map[string]domain.ProjectRecord{"p": {ID: "p", Path: "/proj", RepoOriginURL: "https://github.com/new/r.git"}},
+				prs:      map[domain.SessionID][]domain.PullRequest{"p-1": {tracked}},
+				checks:   map[string][]domain.PullRequestCheck{},
+			}
+			provider := &fakeProvider{
+				repoGuards: map[string]ports.SCMGuardResult{
+					prKey(newRepo, 0): {ETag: "vN"},
+					prKey(oldRepo, 0): {ETag: "vO"},
+				},
+				// Both scan names list the same PR: the canonical listing and the
+				// stale-remote listing served through GitHub's rename redirect.
+				openPRs: map[string][]ports.SCMPRObservation{
+					prKey(newRepo, 0): listing,
+					prKey(oldRepo, 0): listing,
+				},
+				observations: map[string]ports.SCMObservation{},
+			}
+			obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(100, 0).UTC())
+			if err := obs.Poll(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			for _, w := range store.writes {
+				if w.pr.Number == 1 && w.pr.CI == domain.CIUnknown {
+					t.Fatalf("tracked PR was re-baselined by a second scan name: %+v", w.pr)
+				}
+			}
+		})
 	}
 }
 

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -3090,31 +3090,214 @@ func TestPoll_RenamedRepoReconciliationPersistsUnderTrackedRef(t *testing.T) {
 	}
 }
 
-func TestObservationKeyForRefs(t *testing.T) {
-	newObs := func(url, alias string) ports.SCMObservation {
+func TestObservationSubjectKey(t *testing.T) {
+	newObs := func(url, alias, providerID string) ports.SCMObservation {
 		return ports.SCMObservation{
 			Fetched: true, Provider: "github", Host: "github.com", Repo: "new/r",
-			PR: ports.SCMPRObservation{URL: url, URLAlias: alias, Number: 1},
+			PR: ports.SCMPRObservation{URL: url, URLAlias: alias, Number: 1, ProviderID: providerID},
 		}
 	}
-	oldRef := ports.SCMPRRef{Repo: ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "old", Name: "r", Repo: "old/r"}, Number: 1, URL: "https://github.com/new/r/pull/1"}
-	newRef := ports.SCMPRRef{Repo: ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "new", Name: "r", Repo: "new/r"}, Number: 1, URL: "https://github.com/new/r/pull/1"}
+	oldRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "old", Name: "r", Repo: "old/r"}
+	newRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "new", Name: "r", Repo: "new/r"}
+	oldRef := ports.SCMPRRef{Repo: oldRepo, Number: 1, URL: "https://github.com/new/r/pull/1"}
+	newRef := ports.SCMPRRef{Repo: newRepo, Number: 1, URL: "https://github.com/new/r/pull/1"}
+	idKey := identityPRKey("github", "github.com", "PR_1")
+	subj := &subject{}
 	tests := []struct {
-		name string
-		obs  ports.SCMObservation
-		refs []ports.SCMPRRef
-		want string
+		name     string
+		obs      ports.SCMObservation
+		refs     []ports.SCMPRRef
+		subjects map[string]*subject
+		keyByRef map[string]string
+		want     string
 	}{
-		{name: "canonical ref wins", obs: newObs("https://github.com/new/r/pull/1", ""), refs: []ports.SCMPRRef{oldRef, newRef}, want: prKey(newRef.Repo, 1)},
-		{name: "renamed repo falls back to requesting ref by URL", obs: newObs("https://github.com/new/r/pull/1", ""), refs: []ports.SCMPRRef{oldRef}, want: prKey(oldRef.Repo, 1)},
-		{name: "renamed repo falls back via URL alias", obs: newObs("https://github.com/new/r/pull/1", "https://github.com/old/r/pull/1"), refs: []ports.SCMPRRef{{Repo: oldRef.Repo, Number: 1, URL: "https://github.com/old/r/pull/1"}}, want: prKey(oldRef.Repo, 1)},
-		{name: "no matching ref keeps canonical key", obs: newObs("https://github.com/new/r/pull/1", ""), refs: []ports.SCMPRRef{{Repo: oldRef.Repo, Number: 2, URL: "https://github.com/new/r/pull/2"}}, want: "github:github.com:new/r#1"},
+		{
+			name:     "provider identity wins over every name",
+			obs:      newObs("https://github.com/new/r/pull/1", "", "PR_1"),
+			refs:     []ports.SCMPRRef{oldRef},
+			subjects: map[string]*subject{idKey: subj},
+			keyByRef: map[string]string{prKey(oldRepo, 1): idKey},
+			want:     idKey,
+		},
+		{
+			name:     "canonical name key when subject has no identity",
+			obs:      newObs("https://github.com/new/r/pull/1", "", "PR_1"),
+			refs:     []ports.SCMPRRef{newRef},
+			subjects: map[string]*subject{prKey(newRepo, 1): subj},
+			keyByRef: map[string]string{prKey(newRepo, 1): prKey(newRepo, 1)},
+			want:     prKey(newRepo, 1),
+		},
+		{
+			name:     "renamed repo falls back to requesting ref by URL",
+			obs:      newObs("https://github.com/new/r/pull/1", "", ""),
+			refs:     []ports.SCMPRRef{oldRef},
+			subjects: map[string]*subject{prKey(oldRepo, 1): subj},
+			keyByRef: map[string]string{prKey(oldRepo, 1): prKey(oldRepo, 1)},
+			want:     prKey(oldRepo, 1),
+		},
+		{
+			name:     "renamed repo falls back via URL alias",
+			obs:      newObs("https://github.com/new/r/pull/1", "https://github.com/old/r/pull/1", ""),
+			refs:     []ports.SCMPRRef{{Repo: oldRepo, Number: 1, URL: "https://github.com/old/r/pull/1"}},
+			subjects: map[string]*subject{prKey(oldRepo, 1): subj},
+			keyByRef: map[string]string{prKey(oldRepo, 1): prKey(oldRepo, 1)},
+			want:     prKey(oldRepo, 1),
+		},
+		{
+			name:     "no matching ref keeps canonical key",
+			obs:      newObs("https://github.com/new/r/pull/1", "", ""),
+			refs:     []ports.SCMPRRef{{Repo: oldRepo, Number: 2, URL: "https://github.com/new/r/pull/2"}},
+			subjects: map[string]*subject{},
+			keyByRef: map[string]string{},
+			want:     "github:github.com:new/r#1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := observationKeyForRefs(tt.obs, tt.refs); got != tt.want {
-				t.Fatalf("observationKeyForRefs = %q, want %q", got, tt.want)
+			if got := observationSubjectKey(tt.obs, tt.refs, tt.subjects, tt.keyByRef); got != tt.want {
+				t.Fatalf("observationSubjectKey = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestKeyForTrackedPR(t *testing.T) {
+	repo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "o", Name: "r", Repo: "o/r"}
+	withID := domain.PullRequest{Provider: "GitHub", Host: "GitHub.com", ProviderID: "PR_x", Number: 7}
+	if got, want := keyForTrackedPR(withID, repo), "github:github.com@PR_x"; got != want {
+		t.Fatalf("identity key = %q, want %q", got, want)
+	}
+	withoutID := domain.PullRequest{Number: 7}
+	if got, want := keyForTrackedPR(withoutID, repo), prKey(repo, 7); got != want {
+		t.Fatalf("legacy key = %q, want %q", got, want)
+	}
+}
+
+// The discovery clobber (issue #4089, mechanism 2): a second scan name for the
+// same repository (stale upstream remote after a transfer) lists the same PRs.
+// A tracked PR recognized by its provider identity must NOT be re-discovered —
+// the baseline write would overwrite the row's CI/mergeability facts and wipe
+// its semantic hashes, flapping the PR panel back to "Checking merge
+// readiness" on every listing change.
+func TestPoll_SecondScanNameDoesNotRebaselineTrackedPR(t *testing.T) {
+	oldRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "old", Name: "r", Repo: "old/r"}
+	newRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "new", Name: "r", Repo: "new/r"}
+	restoreRemotes := gitRemoteURLsFunc
+	gitRemoteURLsFunc = func(string) []string {
+		return []string{"https://github.com/new/r.git", "https://github.com/old/r.git"}
+	}
+	defer func() { gitRemoteURLsFunc = restoreRemotes }()
+
+	tracked := domain.PullRequest{
+		URL: "https://github.com/new/r/pull/1", SessionID: "p-1", Number: 1,
+		Provider: "github", Host: "github.com", Repo: "new/r", ProviderID: "PR_stable_1",
+		SourceBranch: "feat", HeadSHA: "sha1", CI: domain.CIPassing, Mergeability: domain.MergeBlocked,
+		MetadataHash: "m", CIHash: "c", ReviewHash: "r", Review: domain.ReviewRequired,
+		ObservedAt: time.Unix(50, 0).UTC(), CIObservedAt: time.Unix(50, 0).UTC(), ReviewObservedAt: time.Unix(50, 0).UTC(),
+	}
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "feat"}}},
+		projects: map[string]domain.ProjectRecord{"p": {ID: "p", Path: "/proj", RepoOriginURL: "https://github.com/new/r.git"}},
+		prs:      map[domain.SessionID][]domain.PullRequest{"p-1": {tracked}},
+		checks:   map[string][]domain.PullRequestCheck{},
+	}
+	listing := []ports.SCMPRObservation{{
+		ProviderID: "PR_stable_1", URL: "https://github.com/new/r/pull/1", Number: 1,
+		SourceBranch: "feat", HeadRepo: "new/r", TargetBranch: "main", HeadSHA: "sha1",
+	}}
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{
+			prKey(newRepo, 0): {ETag: "vN"},
+			prKey(oldRepo, 0): {ETag: "vO"},
+		},
+		// Both scan names list the same PR: the canonical listing and the
+		// stale-remote listing served through GitHub's rename redirect.
+		openPRs: map[string][]ports.SCMPRObservation{
+			prKey(newRepo, 0): listing,
+			prKey(oldRepo, 0): listing,
+		},
+		observations: map[string]ports.SCMObservation{},
+	}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(100, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, w := range store.writes {
+		if w.pr.Number == 1 && w.pr.CI == domain.CIUnknown {
+			t.Fatalf("tracked PR was re-baselined by a second scan name: %+v", w.pr)
+		}
+	}
+}
+
+// Identity-first dispatch: when the tracked row carries a provider id, a
+// canonical observation for a renamed repo is delivered by identity — no URL
+// fallback involved — and the persisted row heals to the canonical repo.
+func TestPoll_IdentityKeyedDispatchSurvivesRename(t *testing.T) {
+	oldRepo := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "old", Name: "r", Repo: "old/r"}
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "feat"}}},
+		projects: map[string]domain.ProjectRecord{"p": {ID: "p", RepoOriginURL: "https://github.com/old/r.git"}},
+		prs: map[domain.SessionID][]domain.PullRequest{"p-1": {{
+			// URL intentionally differs from the canonical URL so the legacy
+			// URL fallback cannot be what delivers this observation.
+			URL: "https://github.com/old/r/pull/1", SessionID: "p-1", Number: 1,
+			Provider: "github", Host: "github.com", Repo: "old/r", ProviderID: "PR_stable_1",
+			SourceBranch: "feat",
+		}}},
+		checks: map[string][]domain.PullRequestCheck{},
+	}
+	canonical := ports.SCMObservation{
+		Fetched: true, Provider: "github", Host: "github.com", Repo: "new/r",
+		PR:           ports.SCMPRObservation{URL: "https://github.com/new/r/pull/1", Number: 1, ProviderID: "PR_stable_1", State: "open", SourceBranch: "feat", TargetBranch: "main", HeadSHA: "sha1", Title: "PR"},
+		CI:           ports.SCMCIObservation{Summary: string(domain.CIPassing), HeadSHA: "sha1"},
+		Review:       ports.SCMReviewObservation{Decision: string(domain.ReviewRequired)},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeBlocked), Blockers: []string{"review_required"}},
+	}
+	provider := &fakeProvider{
+		repoGuards:   map[string]ports.SCMGuardResult{prKey(oldRepo, 0): {ETag: "v1"}},
+		openPRs:      map[string][]ports.SCMPRObservation{},
+		observations: map[string]ports.SCMObservation{prKey(oldRepo, 1): canonical},
+	}
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.writes) == 0 {
+		t.Fatal("identity-keyed observation was dropped")
+	}
+	final := store.writes[len(store.writes)-1].pr
+	if final.Repo != "new/r" || final.CI != domain.CIPassing || final.ProviderID != "PR_stable_1" {
+		t.Fatalf("persisted PR = repo %q ci %q providerID %q; want canonical new/r, passing, PR_stable_1", final.Repo, final.CI, final.ProviderID)
+	}
+	if len(lc.observed) != 1 {
+		t.Fatalf("lifecycle notifications = %d, want 1", len(lc.observed))
+	}
+}
+
+// Two stored rows for the same provider-native PR (one per repo name, the
+// pre-#3923 duplicate-row artifact) collapse to a single subject instead of
+// two subjects fighting over the same PR.
+func TestDiscoverSubjects_CollapsesDuplicateRowsByIdentity(t *testing.T) {
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "feat"}}},
+		projects: map[string]domain.ProjectRecord{"p": {ID: "p", RepoOriginURL: "https://github.com/new/r.git"}},
+		prs: map[domain.SessionID][]domain.PullRequest{"p-1": {
+			{URL: "https://github.com/old/r/pull/1", SessionID: "p-1", Number: 1, Provider: "github", Host: "github.com", Repo: "old/r", ProviderID: "PR_dup", SourceBranch: "feat"},
+			{URL: "https://github.com/new/r/pull/1", SessionID: "p-1", Number: 1, Provider: "github", Host: "github.com", Repo: "new/r", ProviderID: "PR_dup", SourceBranch: "feat"},
+		}},
+		checks: map[string][]domain.PullRequestCheck{},
+	}
+	provider := &fakeProvider{observations: map[string]ports.SCMObservation{}}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+	subjects, _, err := obs.discoverSubjects(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subjects) != 1 {
+		t.Fatalf("subjects = %d, want 1 (same provider identity must collapse)", len(subjects))
+	}
+	if _, ok := subjects[identityPRKey("github", "github.com", "PR_dup")]; !ok {
+		t.Fatalf("subject not keyed by provider identity: %v", subjects)
 	}
 }

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -3218,33 +3218,6 @@ func TestPoll_IdentityKeyedDispatchSurvivesRename(t *testing.T) {
 	}
 }
 
-// Two stored rows for the same provider-native PR (one per repo name, the
-// pre-#3923 duplicate-row artifact) collapse to a single subject instead of
-// two subjects fighting over the same PR.
-func TestDiscoverSubjects_CollapsesDuplicateRowsByIdentity(t *testing.T) {
-	store := &fakeStore{
-		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "feat"}}},
-		projects: map[string]domain.ProjectRecord{"p": {ID: "p", RepoOriginURL: "https://github.com/new/r.git"}},
-		prs: map[domain.SessionID][]domain.PullRequest{"p-1": {
-			{URL: "https://github.com/old/r/pull/1", SessionID: "p-1", Number: 1, Provider: "github", Host: "github.com", Repo: "old/r", ProviderID: "PR_dup", SourceBranch: "feat"},
-			{URL: "https://github.com/new/r/pull/1", SessionID: "p-1", Number: 1, Provider: "github", Host: "github.com", Repo: "new/r", ProviderID: "PR_dup", SourceBranch: "feat"},
-		}},
-		checks: map[string][]domain.PullRequestCheck{},
-	}
-	provider := &fakeProvider{observations: map[string]ports.SCMObservation{}}
-	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
-	subjects, _, err := obs.discoverSubjects(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(subjects) != 1 {
-		t.Fatalf("subjects = %d, want 1 (same provider identity must collapse)", len(subjects))
-	}
-	if _, ok := subjects[identityPRKey("github", "github.com", "PR_dup")]; !ok {
-		t.Fatalf("subject not keyed by provider identity: %v", subjects)
-	}
-}
-
 // A permanently unresolvable tracked PR (provider returns an ErrSCMNotFound
 // placeholder every tick) must stay quiet at Warn level — Debug only — while
 // still pinning the repo ETag/cursor and never entering a rate-limit

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -3217,3 +3217,69 @@ func TestPoll_IdentityKeyedDispatchSurvivesRename(t *testing.T) {
 		t.Fatalf("lifecycle notifications = %d, want 1", len(lc.observed))
 	}
 }
+
+// Two stored rows for the same provider-native PR (one per repo name, the
+// pre-#3923 duplicate-row artifact) collapse to a single subject instead of
+// two subjects fighting over the same PR.
+func TestDiscoverSubjects_CollapsesDuplicateRowsByIdentity(t *testing.T) {
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "feat"}}},
+		projects: map[string]domain.ProjectRecord{"p": {ID: "p", RepoOriginURL: "https://github.com/new/r.git"}},
+		prs: map[domain.SessionID][]domain.PullRequest{"p-1": {
+			{URL: "https://github.com/old/r/pull/1", SessionID: "p-1", Number: 1, Provider: "github", Host: "github.com", Repo: "old/r", ProviderID: "PR_dup", SourceBranch: "feat"},
+			{URL: "https://github.com/new/r/pull/1", SessionID: "p-1", Number: 1, Provider: "github", Host: "github.com", Repo: "new/r", ProviderID: "PR_dup", SourceBranch: "feat"},
+		}},
+		checks: map[string][]domain.PullRequestCheck{},
+	}
+	provider := &fakeProvider{observations: map[string]ports.SCMObservation{}}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+	subjects, _, err := obs.discoverSubjects(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subjects) != 1 {
+		t.Fatalf("subjects = %d, want 1 (same provider identity must collapse)", len(subjects))
+	}
+	if _, ok := subjects[identityPRKey("github", "github.com", "PR_dup")]; !ok {
+		t.Fatalf("subject not keyed by provider identity: %v", subjects)
+	}
+}
+
+// A permanently unresolvable tracked PR (provider returns an ErrSCMNotFound
+// placeholder every tick) must stay quiet at Warn level — Debug only — while
+// still pinning the repo ETag/cursor and never entering a rate-limit
+// cooldown. Guards the ~2.9k-warnings/day regression flagged in review.
+func TestPoll_NotFoundObservationLogsDebugAndPinsRepo(t *testing.T) {
+	store := testStoreWithSession()
+	store.prs["p-1"] = []domain.PullRequest{knownPR(1)}
+	provider := &fakeProvider{
+		repoGuards:     map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
+		openPRs:        map[string][]ports.SCMPRObservation{},
+		observations:   map[string]ports.SCMObservation{},
+		fetchObsErrors: map[string]error{prKey(testRepo, 1): fmt.Errorf("%w: pull request o/r#1 not in batch response", ports.ErrSCMNotFound)},
+	}
+	var logs bytes.Buffer
+	obs := New(provider, store, &fakeLifecycle{}, Config{
+		Clock:            func() time.Time { return time.Unix(1, 0).UTC() },
+		Tick:             time.Hour,
+		Logger:           slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		CacheMax:         128,
+		IdentityResolver: provider,
+	})
+	obs.Cache.RepoPRListETag[prKey(testRepo, 0)] = "v1"
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(logs.String(), "provider fetch failed") || strings.Contains(logs.String(), "rate-limited") {
+		t.Fatalf("not-found placeholder logged at warn: %s", logs.String())
+	}
+	if obs.inRateLimitCooldown(time.Unix(1, 0).UTC(), "github") {
+		t.Fatal("not-found placeholder must not trigger a rate-limit cooldown")
+	}
+	if got := obs.Cache.RepoPRListETag[prKey(testRepo, 0)]; got != "v1" {
+		t.Fatalf("repo ETag advanced past a not-found ref: %q, want pinned v1", got)
+	}
+	if len(store.writes) != 0 {
+		t.Fatalf("not-found placeholder was persisted: %#v", store.writes)
+	}
+}

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -75,13 +75,11 @@ type SCMObservation struct {
 	// Mergeability contains AO's mergeability verdict and blockers.
 	Mergeability SCMMergeabilityObservation
 
-	// Error carries a transient per-observation failure from the multi-provider
-	// dispatcher (or any composite provider) when one provider in a batch fails
-	// while others succeed. It is NOT durable state: the observer must inspect
-	// it before persistence to route rate-limit errors to per-provider cooldown
-	// and non-rate-limit errors to refresh-incomplete, then nil it out so the
-	// storage layer never sees provider-error classification. A non-nil Error
-	// always implies Fetched=false.
+	// Error classifies a Fetched=false result, including a permanent not-found
+	// miss or a transient per-observation failure from a composite provider. It
+	// is NOT durable state: callers inspect it before persistence, then discard
+	// it so the storage layer never sees provider-error classification. A
+	// non-nil Error always implies Fetched=false.
 	Error error
 
 	// Changed marks which semantic buckets changed compared with the DB snapshot.

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -150,6 +150,9 @@ func (s *Service) fetchClaimObservation(ctx context.Context, ref ports.SCMPRRef)
 		return ports.SCMObservation{}, ErrPRNotFound
 	}
 	obs := batch[0]
+	if errors.Is(obs.Error, ports.ErrSCMNotFound) {
+		return ports.SCMObservation{}, ErrPRNotFound
+	}
 	if !obs.Fetched {
 		return ports.SCMObservation{}, ErrSCMUnavailable
 	}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -2542,8 +2542,12 @@ func TestClaimRowsFromSCMSnapshotsSessionReviewPolicy(t *testing.T) {
 type noopSCMProvider struct{}
 
 func (noopSCMProvider) ParseRepository(string) (ports.SCMRepo, bool) { return ports.SCMRepo{}, false }
-func (noopSCMProvider) FetchPullRequests(context.Context, []ports.SCMPRRef) ([]ports.SCMObservation, error) {
-	return nil, nil
+func (noopSCMProvider) FetchPullRequests(_ context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
+	out := make([]ports.SCMObservation, len(refs))
+	for i := range out {
+		out[i].Error = ports.ErrSCMNotFound
+	}
+	return out, nil
 }
 func (noopSCMProvider) FetchReviewThreads(context.Context, ports.SCMPRRef) (ports.SCMReviewObservation, error) {
 	return ports.SCMReviewObservation{}, nil
@@ -2557,14 +2561,21 @@ func (f fakeSCM) ParseRepository(remote string) (ports.SCMRepo, bool) {
 	return ports.SCMRepo{Provider: providerKey(host), Host: host, Owner: owner, Name: repo, Repo: owner + "/" + repo}, true
 }
 
-func (f fakeSCM) FetchPullRequests(context.Context, []ports.SCMPRRef) ([]ports.SCMObservation, error) {
+func (f fakeSCM) FetchPullRequests(_ context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
 	if f.fetchErr != nil {
 		return nil, f.fetchErr
 	}
+	out := make([]ports.SCMObservation, len(refs))
 	if !f.obs.Fetched && f.obs.PR.URL == "" && f.obs.PR.Number == 0 {
-		return nil, nil
+		for i := range out {
+			out[i].Error = ports.ErrSCMNotFound
+		}
+		return out, nil
 	}
-	return []ports.SCMObservation{f.obs}, nil
+	for i := range out {
+		out[i] = f.obs
+	}
+	return out, nil
 }
 
 func (f fakeSCM) FetchReviewThreads(context.Context, ports.SCMPRRef) (ports.SCMReviewObservation, error) {
@@ -2616,7 +2627,8 @@ func TestClaimPRMapsObserverAndStoreErrors(t *testing.T) {
 		want error
 	}{
 		{"missing scm", NewWithDeps(Deps{Store: st}), ErrSCMUnavailable},
-		{"not found", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{}, SCM: fakeSCM{fetchErr: ports.ErrSCMNotFound}}), ErrPRNotFound},
+		{"not found error", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{}, SCM: fakeSCM{fetchErr: ports.ErrSCMNotFound}}), ErrPRNotFound},
+		{"not found placeholder", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{}, SCM: fakeSCM{}}), ErrPRNotFound},
 		{"closed", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{}, SCM: fakeSCM{obs: ports.SCMObservation{Fetched: true, Provider: "github", Host: "github.com", Repo: "acme/repo", PR: ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7, Closed: true}}}}), ErrPRNotOpen},
 		{"active owner", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{err: ports.PRClaimedByActiveSessionError{Owner: "mer-2"}}, SCM: fakeSCM{obs: ports.SCMObservation{Fetched: true, Provider: "github", Host: "github.com", Repo: "acme/repo", PR: ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7}}}}), ports.ErrPRClaimedByActiveSession},
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Start with [architecture.md](architecture.md) for the current backend model and
 | Doc                                                    | What it covers                                                                                                        |
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | [architecture.md](architecture.md)                     | Current backend model, package layout, status derivation, persistence/CDC, and load-bearing rules.                    |
+| [scm-observer.md](scm-observer.md)                     | SCM subsystem: polling pipeline, durable-state invariants, PR identity model, and the rename/transfer design.         |
 | [backend-code-structure.md](backend-code-structure.md) | Package ownership rules for the Go backend: domain, services, ports, adapters, storage, HTTP, CLI, and daemon wiring. |
 | [cli/README.md](cli/README.md)                         | CLI commands and daemon control surface.                                                                              |
 | [cloud-development.md](cloud-development.md)           | Optional private checkout workflow, current Cloud foundation, remaining implementation, and recommended build order. |

--- a/docs/scm-observer.md
+++ b/docs/scm-observer.md
@@ -241,13 +241,18 @@ matches a live subject:
   an old-name clobber leaves the row `unknown` until the canonical listing
   happens to re-discover it — the "stuck most of the time" experience.
 
-#4090's seam fix shrinks the visible window to at most one poll but does not
-stop the churn (hash wipes force refetches and lifecycle redelivery every
-cycle). Change 2 of the target design removes the clobber at the source:
-discovery dedupes listing entries against tracked subjects by provider
-identity, so a second scan name can never re-baseline a tracked row.
+Change 2 of the design below removes the clobber at the source: discovery
+dedupes listing entries against tracked subjects by provider identity, so a
+second scan name can never re-baseline a tracked row. (The URL-fallback seam
+fix alone would have shrunk the visible window to at most one poll; the
+identity dedupe makes the clobber structurally impossible.)
 
 ## Target Design: ProviderID-Primary Identity
+
+*Implemented in PR
+[#4090](https://github.com/Untrivial-ai/agent-orchestrator/pull/4090) —
+`identityPRKey` / `keyForTrackedPR` / `observationSubjectKey` in
+`backend/internal/observe/scm/observer.go`.*
 
 **Principle: a PR's identity is `(provider, host, provider_id)`. Repo name,
 number, and URL are mutable display coordinates.** Node IDs survive renames,

--- a/docs/scm-observer.md
+++ b/docs/scm-observer.md
@@ -280,12 +280,11 @@ and migration 0097 already enforces their uniqueness in storage.
    `commitETags`, candidate/refresh bookkeeping).
 2. **Subjects carry ProviderID.** `repoForTrackedPR` keeps resolving the repo
    to *poll under* (refs still need an owner/name to build a GraphQL query),
-   but the subject's identity comes from the row's `provider_id`. Two subjects
-   with the same identity are the same PR regardless of which repo name each
-   was tracked under — the duplicate-ownership guard and discovery's
-   "already tracked?" check both switch to identity, which kills the
-   two-scan-repos-create-two-subjects class (#3922) at the source instead of
-   collapsing it later in the store.
+   but the subject's identity comes from the row's `provider_id`. Discovery's
+   "already tracked?" check uses that identity, so listing an already tracked
+   PR through a second scan name cannot create another row. Existing legacy
+   id-less duplicates remain the store-level identity/alias machinery's
+   responsibility.
 3. **Observations are attributed positionally, never re-derived.**
    `FetchPullRequests` returns results aligned 1:1 with the requested refs
    (`result[i]` answers `refs[i]`, `Fetched=false` placeholder for gaps —

--- a/docs/scm-observer.md
+++ b/docs/scm-observer.md
@@ -17,7 +17,7 @@ equivalent; this doc does not duplicate them.
 - [How PR Facts Enter the System](#how-pr-facts-enter-the-system)
 - [The Polling Pipeline](#the-polling-pipeline)
 - [Durable-State Invariants](#durable-state-invariants)
-- [PR Identity Today: Five Independent Derivations](#pr-identity-today-five-independent-derivations)
+- [PR Identity Before #4090: Five Independent Derivations](#pr-identity-before-4090-five-independent-derivations)
 - [Case Study: the Rename Bug Cluster](#case-study-the-rename-bug-cluster)
 - [Target Design: ProviderID-Primary Identity](#target-design-providerid-primary-identity)
 - [Testing Strategy](#testing-strategy)
@@ -163,22 +163,23 @@ correctness state.
    PRs; terminal handling for one reads all of them from the store, so a
    just-discovered sibling must already be durable.
 
-## PR Identity Today: Five Independent Derivations
+## PR Identity Before #4090: Five Independent Derivations
 
-"Which PR is this?" is answered independently in five places. Each derivation
-is locally reasonable; collectively they form a distributed invariant — *all
-five must agree* — that nothing enforces. A repo rename/org transfer is
-exactly the event that makes them disagree.
+Before #4090, "Which PR is this?" was answered independently in five places.
+Each derivation was locally reasonable; collectively they formed a distributed
+invariant — *all five must agree* — that nothing enforced. A repo rename/org
+transfer is exactly the event that made them disagree.
 
 | # | Layer | Identity used | Source |
 |---|-------|--------------|--------|
 | 1 | Stored row | `pr.url` (PK) + `provider/host/repo` + `number` columns | whatever path created the row |
-| 2 | Observer subject key | `prKey(repo, number)` = `provider:host:repo#number` | row's `repo` via `repoForTrackedPR`, or the scanned repo at discovery |
-| 3 | Observation dispatch key | `prKeyFromObs(obs)` — same shape | `obs.Repo`, canonicalized **from the PR URL** since #3923 |
+| 2 | Observer subject key (pre-#4090) | `prKey(repo, number)` = `provider:host:repo#number` | row's `repo` via `repoForTrackedPR`, or the scanned repo at discovery |
+| 3 | Observation dispatch key (pre-#4090) | `prKeyFromObs(obs)` — same shape | `obs.Repo`, canonicalized **from the PR URL** since #3923 |
 | 4 | Repo scan set | owner/name parsed from git remotes + project `RepoOriginURL` | local git config, project record |
 | 5 | Store identity machinery | `provider_id` (unique per provider+host) + `pr_url_alias` | migration 0097, added by #3923 |
 
-After a rename (`AgentWrapper/agent-orchestrator` → `Untrivial-ai/agent-orchestrator`):
+Before #4090, after a rename (`AgentWrapper/agent-orchestrator` →
+`Untrivial-ai/agent-orchestrator`):
 
 - (1) keeps the old `repo` string forever unless something rewrites it.
 - (2) trusts (1), so subjects poll under the old name — which *works*, because
@@ -191,8 +192,8 @@ After a rename (`AgentWrapper/agent-orchestrator` → `Untrivial-ai/agent-orches
   IDs) but is only consulted inside the store, after the observer has already
   decided which subject an observation belongs to — or dropped it.
 
-The stable identity exists (row #5); it just isn't the key the observer
-dispatches on.
+The stable identity existed (row #5); it just was not the key the observer
+dispatched on.
 
 ## Case Study: the Rename Bug Cluster
 
@@ -210,10 +211,13 @@ store layer (aliases + `provider_id`) and changed it at the provider layer
 (`obs.Repo` canonicalized from the PR URL instead of echoing the requesting
 ref), but the observer's dispatch keying between them was not updated. Its
 tests covered each layer separately; no test crossed the seam with a renamed
-repo. PR [#4090](https://github.com/Untrivial-ai/agent-orchestrator/pull/4090)
-patches that seam (URL-match fallback re-keys observations to the requesting
-ref), which restores behavior but adds a *sixth* reconciliation point. That is
-the signal to stop patching pairwise and give identity one owner.
+repo. The first commit in PR
+[#4090](https://github.com/Untrivial-ai/agent-orchestrator/pull/4090) patched
+that seam with a URL-match fallback. The final implementation then removed
+that interim matching layer: subjects and discovery use provider-native IDs,
+and fetch results are attributed positionally to their requesting refs. The
+interim patch was the signal to stop reconciling identities pairwise and give
+identity one owner.
 
 ### The discovery clobber (why the state flaps rather than sticking)
 

--- a/docs/scm-observer.md
+++ b/docs/scm-observer.md
@@ -251,8 +251,12 @@ identity dedupe makes the clobber structurally impossible.)
 
 *Implemented in PR
 [#4090](https://github.com/Untrivial-ai/agent-orchestrator/pull/4090) —
-`identityPRKey` / `keyForTrackedPR` / `observationSubjectKey` in
-`backend/internal/observe/scm/observer.go`.*
+`identityPRKey` / `keyForTrackedPR` in
+`backend/internal/observe/scm/observer.go`, plus the positional
+`FetchPullRequests` contract below. The observer is net smaller than before
+the fix: fetched observations are never re-keyed from their content, so the
+entire dispatch-matching layer (including the interim URL fallback) was
+deleted.*
 
 **Principle: a PR's identity is `(provider, host, provider_id)`. Repo name,
 number, and URL are mutable display coordinates.** Node IDs survive renames,
@@ -278,11 +282,13 @@ and migration 0097 already enforces their uniqueness in storage.
    "already tracked?" check both switch to identity, which kills the
    two-scan-repos-create-two-subjects class (#3922) at the source instead of
    collapsing it later in the store.
-3. **Observation dispatch matches by identity first.** The batch and
-   reconcile loops key fetched observations by `obs.PR.ProviderID`; the
-   URL-match fallback from #4090 remains only for legacy rows whose
-   `provider_id` is still empty (their first successful fetch stamps it, so
-   the fallback is self-retiring).
+3. **Observations are attributed positionally, never re-derived.**
+   `FetchPullRequests` returns results aligned 1:1 with the requested refs
+   (`result[i]` answers `refs[i]`, `Fetched=false` placeholder for gaps —
+   GitLab and multi already worked this way; GitHub was the outlier). The
+   observer records which subject each ref was issued for and attributes
+   `batch[i]` directly — no content-based matching exists to break on a
+   rename, and legacy id-less rows are covered by the same mechanism.
 4. **Rows self-heal, no data migration.** Persistence already writes
    `obs.Repo` (canonical) and maintains `pr_url_alias`; with identity-keyed
    dispatch, every stale row converges to canonical repo/URL on its next
@@ -318,8 +324,8 @@ transfer end-to-end:
 4. Discovery sees the same PR via two scan names → one subject, one row, and
    — critically — **no baseline write over the tracked row's facts**
    (regression test for #3922 and the #4089 flap at the observer layer).
-5. Legacy row without `provider_id` → URL fallback delivers the first fetch,
-   which stamps the ID; second poll dispatches by identity.
+5. Legacy row without `provider_id` → positional attribution delivers the
+   first fetch, which stamps the ID; second poll keys by identity.
 6. Review refresh keyed by identity → review + metadata land on the same row.
 7. Post-transfer new PR discovered via the old scan name → attributed and
    enriched (observer half of #3252).

--- a/docs/scm-observer.md
+++ b/docs/scm-observer.md
@@ -1,0 +1,299 @@
+# SCM Observer Architecture
+
+How AO observes pull requests: the polling pipeline, the durable-state rules it
+must never violate, where PR identity lives today, why repo renames broke it,
+and the target identity design.
+
+Scope: the provider-neutral SCM subsystem — adapters, the polling observer,
+PR storage/identity, and the read models that feed the UI. The lifecycle
+manager (LCM) is covered only at its SCM boundary. Per-provider field-mapping
+rules (how GitHub's `mergeStateStatus` becomes `MergeBlocked`, etc.) are
+documented in `backend/internal/adapters/scm/github/doc.go` and the GitLab
+equivalent; this doc does not duplicate them.
+
+## Table of Contents
+
+- [Component Map](#component-map)
+- [How PR Facts Enter the System](#how-pr-facts-enter-the-system)
+- [The Polling Pipeline](#the-polling-pipeline)
+- [Durable-State Invariants](#durable-state-invariants)
+- [PR Identity Today: Five Independent Derivations](#pr-identity-today-five-independent-derivations)
+- [Case Study: the Rename Bug Cluster](#case-study-the-rename-bug-cluster)
+- [Target Design: ProviderID-Primary Identity](#target-design-providerid-primary-identity)
+- [Testing Strategy](#testing-strategy)
+- [Non-Goals](#non-goals)
+
+---
+
+## Component Map
+
+```mermaid
+graph TB
+    subgraph Providers
+        GH[adapters/scm/github]
+        GL[adapters/scm/gitlab]
+        Multi[adapters/scm/multi<br/>per-provider dispatch]
+    end
+    subgraph Observer["observe/scm (the polling loop)"]
+        Poll[Observer.Poll<br/>30s tick]
+    end
+    subgraph Storage
+        PRStore["storage/sqlite/store/pr_store.go<br/>pr / pr_checks / pr_reviews /<br/>pr_review_threads / pr_comment /<br/>pr_url_alias"]
+    end
+    subgraph Consumers
+        LCM[lifecycle.Manager<br/>ApplySCMObservation]
+        ReadModel[service/session/pr_summary.go]
+        API["/api/v1/sessions/:id/pr"]
+        UI[frontend pr-display.ts<br/>merge-readiness card]
+    end
+    ClaimPath[service/session/claim_pr.go<br/>ao session claim-pr] --> PRStore
+    GH --> Multi
+    GL --> Multi
+    Multi --> Poll
+    Poll --> PRStore
+    Poll --> LCM
+    PRStore --> ReadModel --> API --> UI
+```
+
+Wiring lives in `backend/internal/daemon/scm_wiring.go`: both providers are
+registered with the `multi` dispatcher; a missing token disables one provider
+without disabling the other. GitHub auth falls back `AO_GITHUB_TOKEN` → `gh
+auth token`; GitLab falls back `AO_GITLAB_TOKEN` → `glab`, plus per-host
+static tokens from config.
+
+The observer is deliberately provider-neutral: it never speaks REST/GraphQL
+itself. Everything it knows arrives as `ports.SCMObservation` /
+`ports.SCMPRRef` / guard results through the `ports` interfaces.
+
+## How PR Facts Enter the System
+
+Three write paths create or update `pr` rows. All of them converge on
+`Store.WriteSCMObservation` / `Store.ClaimPR` (`pr_store.go`), which own
+identity resolution and alias collapse:
+
+1. **Observer discovery** (`discoverNewPRs`): lists open PRs per scanned repo,
+   attributes them to sessions by author identity + branch-prefix match, and
+   persists a baseline row before the first detail fetch.
+2. **Observer refresh** (the rest of `Poll`): batch GraphQL detail fetches,
+   review-thread refreshes, and terminal reconciliation update existing rows.
+3. **Explicit claim** (`ao session claim-pr`, `spawn --claim-pr`, gh-wrapper
+   capture): resolves a PR ref against the project origin and claims the row
+   for a session, including takeover rules for terminated owners.
+
+The **read model** (`ListPRSummaries`) groups rows through `pr_url_alias` so a
+PR observed under multiple URLs renders as one card, then derives the summary
+DTO. Display status is never stored — the frontend's "Checking merge
+readiness" state is purely `ci.state ∈ {unknown, pending}` or
+`mergeability.state == unknown` in the served summary
+(`frontend/src/renderer/lib/pr-display.ts`).
+
+## The Polling Pipeline
+
+`Observer.Poll` (`backend/internal/observe/scm/observer.go`) runs every 30s
+(`DefaultTickInterval`). Cadence knobs: review refresh 2m
+(`DefaultReviewInterval`), unconditional re-fetch after 5m
+(`DefaultPRMaxAge`), GraphQL batches of 25 (`BatchSize`), incremental
+discovery overlap 5m.
+
+```mermaid
+flowchart TD
+    A[discoverSubjects<br/>live sessions → tracked PR rows → subjects] --> B[checkCredentials]
+    B --> C[guardRepos<br/>conditional repo-list ETag probes]
+    C --> D[discoverNewPRs<br/>list open PRs, attribute, persist baselines]
+    D --> E[selectRefreshCandidates<br/>listed? stale? commit-check ETag changed?]
+    E --> F[reconcileTerminalGitHubPRs<br/>tracked-open PRs missing from listing]
+    F --> G[FetchPullRequests<br/>batched GraphQL detail fetch]
+    G --> H[refreshReviews<br/>per-ref review threads, own cadence]
+    H --> I[dispatch loop<br/>prepareForPersistence → WriteSCMObservation → LCM]
+    I --> J[advance caches<br/>ETags, sync cursors, last-fetch times]
+```
+
+Stage notes:
+
+- **Subjects** are the observer's in-memory unit of tracking: one live session
+  + one tracked PR row + the repo identity to poll it under. Terminated
+  sessions produce no subjects; their PRs stop being observed.
+- **Repo scan set** (`resolveScanRepos`): the project origin plus every other
+  GitHub/GitLab remote in the checkout (upstreams, mirrors). Attribution still
+  requires the PR's head repo to be a session's push origin, so extra remotes
+  only surface cross-fork PRs.
+- **Candidate selection** is incremental: once a repo has a sync cursor, only
+  PRs in the updated listing, PRs with a changed commit-check ETag, or PRs
+  older than `DefaultPRMaxAge` are re-fetched.
+- **Terminal reconciliation** exists because GitHub's `state=open` listing
+  drops merged/closed PRs before their terminal transition can be observed;
+  GitLab lists `state=all` and does not need it.
+- **Review refresh** runs per-ref on its own cadence and write mode
+  (replace/merge/preserve) because thread pagination is expensive and
+  intentionally bounded.
+- **Dispatch** persists first, notifies lifecycle second, then re-persists the
+  acknowledged hashes (see invariants below).
+
+### The lifecycle boundary
+
+`lifecycle.Manager.ApplySCMObservation` (`backend/internal/lifecycle/reactions.go`)
+is the only LCM entrypoint. It projects the observation into reaction logic
+(CI-failure injection, review-comment injection, merge-driven teardown) and
+emits/resolves notifications (PR merged, ready-to-merge). It ignores
+`Fetched=false` observations entirely. LCM never reads provider APIs.
+
+## Durable-State Invariants
+
+These are cross-cutting rules the pipeline already enforces; any refactor must
+preserve them. They exist because the caches (ETags, cursors, last-fetch
+times) are performance state, while the `pr` tables + semantic hashes are
+correctness state.
+
+1. **ETags/cursors never advance past an unpersisted observation.** A failed
+   fetch, failed write, or failed lifecycle notification marks the repo
+   refresh-incomplete; a 304 must never make a missed update unrecoverable.
+   Per-ref monotonicity: one failed ref in a repo pins the whole repo's
+   cursor.
+2. **Semantic hashes are the observer's acknowledgement cursor.** Metadata/CI/
+   review hashes are only advanced to the observed values after lifecycle has
+   successfully consumed the observation; a daemon restart after a lifecycle
+   failure re-delivers the same observation.
+3. **`Fetched=false` placeholders are routing metadata, never data.** They
+   carry per-provider errors (rate-limit cooldowns, refresh-incomplete marks)
+   and must not overwrite durable facts or reach storage.
+4. **Review facts have their own write mode.** Metadata/CI writes preserve
+   review rows by default; only an actual review fetch replaces or merges
+   them, so slower review polling can't be clobbered by fast CI polling.
+5. **Discovery persists baselines before refresh.** A session can own several
+   PRs; terminal handling for one reads all of them from the store, so a
+   just-discovered sibling must already be durable.
+
+## PR Identity Today: Five Independent Derivations
+
+"Which PR is this?" is answered independently in five places. Each derivation
+is locally reasonable; collectively they form a distributed invariant — *all
+five must agree* — that nothing enforces. A repo rename/org transfer is
+exactly the event that makes them disagree.
+
+| # | Layer | Identity used | Source |
+|---|-------|--------------|--------|
+| 1 | Stored row | `pr.url` (PK) + `provider/host/repo` + `number` columns | whatever path created the row |
+| 2 | Observer subject key | `prKey(repo, number)` = `provider:host:repo#number` | row's `repo` via `repoForTrackedPR`, or the scanned repo at discovery |
+| 3 | Observation dispatch key | `prKeyFromObs(obs)` — same shape | `obs.Repo`, canonicalized **from the PR URL** since #3923 |
+| 4 | Repo scan set | owner/name parsed from git remotes + project `RepoOriginURL` | local git config, project record |
+| 5 | Store identity machinery | `provider_id` (unique per provider+host) + `pr_url_alias` | migration 0097, added by #3923 |
+
+After a rename (`AgentWrapper/agent-orchestrator` → `Untrivial-ai/agent-orchestrator`):
+
+- (1) keeps the old `repo` string forever unless something rewrites it.
+- (2) trusts (1), so subjects poll under the old name — which *works*, because
+  the providers follow rename redirects.
+- (3) reports the new name — so the observation key no longer matches the
+  subject key.
+- (4) contains both names when a stale `upstream` remote survives, producing
+  two scan identities for one repo.
+- (5) already holds the stable answer (`PR_kwDO…` node IDs, GitLab MR global
+  IDs) but is only consulted inside the store, after the observer has already
+  decided which subject an observation belongs to — or dropped it.
+
+The stable identity exists (row #5); it just isn't the key the observer
+dispatches on.
+
+## Case Study: the Rename Bug Cluster
+
+Four issues in six weeks, all facets of the same distributed invariant:
+
+| Issue | Facet | Derivations that disagreed |
+|-------|-------|---------------------------|
+| [#2509](https://github.com/Untrivial-ai/agent-orchestrator/issues/2509) | observer reloaded tracked repos without owner/name → check-run 404s | 1 ↔ 2 |
+| [#3922](https://github.com/Untrivial-ai/agent-orchestrator/issues/3922) / PR [#3923](https://github.com/Untrivial-ai/agent-orchestrator/pull/3923) | duplicate rows for one transferred PR → stale row's `conflicting` shown | 1 ↔ 4 (two scan identities each created a row) |
+| [#3252](https://github.com/Untrivial-ai/agent-orchestrator/issues/3252) | new PRs not attributable after transfer; stale project origin | 4 ↔ provider reality |
+| [#4089](https://github.com/Untrivial-ai/agent-orchestrator/issues/4089) | CI/mergeability permanently `unknown` ("Checking merge readiness" forever) | 2 ↔ 3 — **regression introduced by #3923** |
+
+The #3923 → #4089 sequence is the cautionary tale: #3923 fixed identity at the
+store layer (aliases + `provider_id`) and changed it at the provider layer
+(`obs.Repo` canonicalized from the PR URL instead of echoing the requesting
+ref), but the observer's dispatch keying between them was not updated. Its
+tests covered each layer separately; no test crossed the seam with a renamed
+repo. PR [#4090](https://github.com/Untrivial-ai/agent-orchestrator/pull/4090)
+patches that seam (URL-match fallback re-keys observations to the requesting
+ref), which restores behavior but adds a *sixth* reconciliation point. That is
+the signal to stop patching pairwise and give identity one owner.
+
+## Target Design: ProviderID-Primary Identity
+
+**Principle: a PR's identity is `(provider, host, provider_id)`. Repo name,
+number, and URL are mutable display coordinates.** Node IDs survive renames,
+transfers, and URL changes; both adapters already stamp them on every listing
+and detail observation (GitHub `node_id`/GraphQL `id`, GitLab MR global ID),
+and migration 0097 already enforces their uniqueness in storage.
+
+### Changes
+
+1. **One identity helper, one place.** Introduce a small identity type in the
+   observer (or `ports`) that resolves a subject/observation to its dispatch
+   key: `provider:host@provider_id` when a provider ID is known, else the
+   legacy `provider:host:repo#number`. All key construction goes through it —
+   `discoverSubjects`, `discoverNewPRs`, `selectRefreshCandidates`,
+   `reconcileTerminalGitHubPRs`, the batch dispatch loop, `refreshReviews`,
+   and the per-poll caches (`LastPRFetchAt`, `LastReviewPollAt`,
+   `commitETags`, candidate/refresh bookkeeping).
+2. **Subjects carry ProviderID.** `repoForTrackedPR` keeps resolving the repo
+   to *poll under* (refs still need an owner/name to build a GraphQL query),
+   but the subject's identity comes from the row's `provider_id`. Two subjects
+   with the same identity are the same PR regardless of which repo name each
+   was tracked under — the duplicate-ownership guard and discovery's
+   "already tracked?" check both switch to identity, which kills the
+   two-scan-repos-create-two-subjects class (#3922) at the source instead of
+   collapsing it later in the store.
+3. **Observation dispatch matches by identity first.** The batch and
+   reconcile loops key fetched observations by `obs.PR.ProviderID`; the
+   URL-match fallback from #4090 remains only for legacy rows whose
+   `provider_id` is still empty (their first successful fetch stamps it, so
+   the fallback is self-retiring).
+4. **Rows self-heal, no data migration.** Persistence already writes
+   `obs.Repo` (canonical) and maintains `pr_url_alias`; with identity-keyed
+   dispatch, every stale row converges to canonical repo/URL on its next
+   successful fetch. Schema is untouched — 0097 suffices.
+5. **Repo-level state keeps its own key.** ETags, sync cursors, and the repo
+   scan set stay keyed by `provider:host:owner/name` — repo listing is
+   genuinely a per-name operation. Only *PR-level* state moves to identity
+   keys. When two scan names alias one repo (stale `upstream`), their listings
+   attribute to the same PR identities, so the duplicate-row path is closed
+   even though both names are still scanned.
+
+### What deliberately does not change
+
+- The polling pipeline's shape, cadences, and every durable-state invariant
+  above.
+- #3923's store-level alias/identity collapse (it becomes the backstop rather
+  than the only line of defense).
+- Provider adapters' canonicalization of `obs.Repo` from the PR URL.
+- `prKey(repo, number)` for repo-level guards/cursors.
+
+## Testing Strategy
+
+The bug cluster survived because each layer was tested in isolation. The
+refactor lands with a cross-layer scenario suite in `observe/scm` (fake
+provider + fake store, same harness as today) that walks one repo through a
+transfer end-to-end:
+
+1. Track PRs under the old name; transfer happens (provider starts returning
+   canonical repo/URL, redirects still serve the old name).
+2. Detail fetch for a stale-named subject → facts persist, row heals
+   (regression test for #4089; exists in #4090).
+3. Terminal reconciliation for a stale-named subject → same (exists in #4090).
+4. Discovery sees the same PR via two scan names → one subject, one row
+   (regression test for #3922 at the observer layer).
+5. Legacy row without `provider_id` → URL fallback delivers the first fetch,
+   which stamps the ID; second poll dispatches by identity.
+6. Review refresh keyed by identity → review + metadata land on the same row.
+7. Post-transfer new PR discovered via the old scan name → attributed and
+   enriched (observer half of #3252).
+
+## Non-Goals
+
+- **Project-origin refresh and gh-wrapper PATH** (#3252 items 2–4): detecting
+  moved origins, updating `RepoOriginURL`, and wrapper precedence are
+  discovery-input problems, tracked separately.
+- **GitLab project moves**: GitLab MR global IDs get the same identity
+  treatment, but proactive testing against a live project transfer is out of
+  scope here.
+- **LCM audit**: lifecycle reactions are consumed through
+  `ApplySCMObservation` unchanged; a holistic LCM review is a separate
+  exercise.

--- a/docs/scm-observer.md
+++ b/docs/scm-observer.md
@@ -203,7 +203,7 @@ Four issues in six weeks, all facets of the same distributed invariant:
 | [#2509](https://github.com/Untrivial-ai/agent-orchestrator/issues/2509) | observer reloaded tracked repos without owner/name → check-run 404s | 1 ↔ 2 |
 | [#3922](https://github.com/Untrivial-ai/agent-orchestrator/issues/3922) / PR [#3923](https://github.com/Untrivial-ai/agent-orchestrator/pull/3923) | duplicate rows for one transferred PR → stale row's `conflicting` shown | 1 ↔ 4 (two scan identities each created a row) |
 | [#3252](https://github.com/Untrivial-ai/agent-orchestrator/issues/3252) | new PRs not attributable after transfer; stale project origin | 4 ↔ provider reality |
-| [#4089](https://github.com/Untrivial-ai/agent-orchestrator/issues/4089) | CI/mergeability permanently `unknown` ("Checking merge readiness" forever) | 2 ↔ 3 — **regression introduced by #3923** |
+| [#4089](https://github.com/Untrivial-ai/agent-orchestrator/issues/4089) | CI/mergeability `unknown` most of the time, flapping ("Checking merge readiness") | 2 ↔ 3 — **regression introduced by #3923** — composed with the discovery clobber below |
 
 The #3923 → #4089 sequence is the cautionary tale: #3923 fixed identity at the
 store layer (aliases + `provider_id`) and changed it at the provider layer
@@ -214,6 +214,38 @@ repo. PR [#4090](https://github.com/Untrivial-ai/agent-orchestrator/pull/4090)
 patches that seam (URL-match fallback re-keys observations to the requesting
 ref), which restores behavior but adds a *sixth* reconciliation point. That is
 the signal to stop patching pairwise and give identity one owner.
+
+### The discovery clobber (why the state flaps rather than sticking)
+
+#4089 presents as *flapping*, not a permanent freeze, because two mechanisms
+compose. A live DB watch on an affected machine caught the cycle:
+
+```
+15:47:56  Untrivial-ai/…  passing/blocked  title + hashes set     (heal)
+15:48:27  AgentWrapper/…  unknown/unknown  title gone, hashes WIPED (clobber)
+15:50:23  Untrivial-ai/…  passing/blocked  title + hashes set     (heal)
+```
+
+The clobber writer is `discoverNewPRs`: a stale remote (`upstream` →
+`AgentWrapper/…`) keeps a second scan identity for the same repository in the
+scan set (derivation 4). Whichever identity the row does *not* currently carry
+finds the PR "not in subjects" and persists a baseline row — and `UpsertPR`
+overwrites `ci_state`, `mergeability`, `repo`, `title`, and the semantic
+hashes unconditionally. Healing requires a detail fetch whose observation key
+matches a live subject:
+
+- **Pre-#3923** the heal worked under either identity (`obs.Repo` echoed the
+  requesting ref), so the unknown window was sub-poll and invisible; the
+  clobber's visible artifact was #3922's duplicate rows instead.
+- **Post-#3923** the stale-identity heal path is dead (the dispatch drop), so
+  an old-name clobber leaves the row `unknown` until the canonical listing
+  happens to re-discover it — the "stuck most of the time" experience.
+
+#4090's seam fix shrinks the visible window to at most one poll but does not
+stop the churn (hash wipes force refetches and lifecycle redelivery every
+cycle). Change 2 of the target design removes the clobber at the source:
+discovery dedupes listing entries against tracked subjects by provider
+identity, so a second scan name can never re-baseline a tracked row.
 
 ## Target Design: ProviderID-Primary Identity
 
@@ -278,8 +310,9 @@ transfer end-to-end:
 2. Detail fetch for a stale-named subject → facts persist, row heals
    (regression test for #4089; exists in #4090).
 3. Terminal reconciliation for a stale-named subject → same (exists in #4090).
-4. Discovery sees the same PR via two scan names → one subject, one row
-   (regression test for #3922 at the observer layer).
+4. Discovery sees the same PR via two scan names → one subject, one row, and
+   — critically — **no baseline write over the tracked row's facts**
+   (regression test for #3922 and the #4089 flap at the observer layer).
 5. Legacy row without `provider_id` → URL fallback delivers the first fetch,
    which stamps the ID; second poll dispatches by identity.
 6. Review refresh keyed by identity → review + metadata land on the same row.


### PR DESCRIPTION
Fixes #4089

## Summary
The "Checking merge readiness" flap traced to one structural cause: **PR identity was derived independently in five layers** (stored row, subject key, observation dispatch key, repo scan set, store `provider_id`/alias machinery), and a repo rename/transfer makes them disagree. This PR gives identity one owner and lands in three stages (see the "Simplification pass" note below):

1. **`fix(scm)` — the dispatch seam**: canonical observations for renamed repos are delivered to their tracked subjects instead of being dropped every poll.
2. **`refactor(scm)` — single-source identity**: a PR's identity is **`(provider, host, provider_id)`** — the rename-proof node id both adapters already stamp and migration 0097 already enforces unique. Repo name, number, and URL are mutable display coordinates.
   - `identityPRKey` / `keyForTrackedPR` own key construction; the legacy `repo#number` key survives only as a **self-retiring fallback** for rows that predate provider ids (their first successful fetch stamps one).
   - Subjects, per-PR caches, and review refresh are identity-keyed. Repo-level list ETags/sync cursors/commit guards deliberately stay name-keyed — listing genuinely is a per-name operation.
   - **Discovery dedupes by identity**: a listing served under a second scan name (stale `upstream` remote after a transfer) recognizes tracked PRs by node id and never re-baselines them — the fact-wiping clobber (#4089 mechanism 2, captured live flapping every ~45s) becomes structurally impossible, not merely quickly repaired. This prevents a second scan name from creating a new duplicate row for an already tracked provider-native PR (#3922's discovery artifact); existing legacy id-less duplicates remain handled by the store's identity/alias machinery.
   - Rows self-heal to the canonical repo/URL on their next fetch. **No schema change, no data migration** — 0097 suffices. In-memory caches only change key shape.
3. **`refactor(scm)` — positional fetch contract** (the simplification pass): `FetchPullRequests` results are **positionally aligned with the requested refs** (`result[i]` answers `refs[i]`; a PR the batch query cannot resolve leaves a `Fetched=false` placeholder at its index — documented on the port). The observer records which subject each ref was issued for and attributes `batch[i]` directly, so the whole observation-matching layer (`observationSubjectKey`, `prKeyFromObs`, the `keyByRef` bridge, `chunkSeen`/`reconcileSeen` bookkeeping, and the interim URL/alias fallback from stage 1) is deleted outright. GitLab and the multi dispatcher already honored alignment; GitHub was the lone outlier. Legacy id-less rows are covered by the same mechanism — no fallback needed. Net, `observer.go` is smaller than `origin/main` while carrying the rename fix and the clobber kill.
4. **`docs`** — `docs/scm-observer.md`: the SCM architecture doc — pipeline, durable-state invariants, the five-way identity split, the live flap capture, and this design.

## Evidence
- Live daemon returned `ci=unknown, mergeability=unknown` while GitHub said `MERGEABLE/BLOCKED` with green checks; 11 PR rows shared the stale-repo fingerprint.
- A 5s DB watch captured the flap: healthy → clobbered (`AgentWrapper/…`, facts + hashes wiped by discovery baseline) → healed (canonical fetch), cycling every ~45s. Details in #4089.

## Tests
- `TestPoll_IdentityKeyedDispatchSurvivesRename` — canonical (renamed-repo) observation reaches its tracked subject; the fixture's stored URL deliberately differs from the canonical URL so no content-based join could explain the delivery.
- `TestPoll_SecondScanNameDoesNotRebaselineTrackedPR` — the clobber regression; fails pre-change with the exact live fingerprint (`CI:unknown, Repo:old/r`, hashes wiped).
- `TestPoll_RenamedRepoObservationPersistsUnderTrackedRef` / `…ReconciliationPersistsUnderTrackedRef` — renamed-repo observations persist through both the batch and terminal-reconciliation paths (positional attribution; legacy id-less rows covered by the same mechanism).
- `TestKeyForTrackedPR` — key resolution table: identity key when a provider id exists, legacy name key otherwise.
- Full `observe/…`, `adapters/scm/…`, `storage/…`, `lifecycle/…`, `service/…` suites green; `go vet` clean.

## Risks / follow-ups
- Legacy id-less rows register under the name-based key until their first successful fetch stamps a provider id. With only an already-renamed remote, discovery may write one baseline before that fetch; positional attribution still delivers the observation and makes the fallback self-retire.
- Discovery dedupe requires the listing to carry a provider id (both adapters stamp it since #3923); an id-less listing entry against an id-less row still dedupes by name.
- The remaining transfer facets (project-origin refresh, gh-wrapper PATH, doctor checks) stay on #3252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

