### PR TITLE
fix(chat): quiet routine command failures

### DIFF
--- a/frontend/src/renderer/components/chat/ActivityRun.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.tsx
@@ -15,7 +15,11 @@ import { useState } from "react";
 import { ChevronRight, Loader2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { ActivityRow } from "./ChatTimelineItems";
-import { ACTIVITY_SUMMARY_BUTTON_CLASS, commandCategory } from "./activity-command";
+import {
+	ACTIVITY_SUMMARY_BUTTON_CLASS,
+	commandCategory,
+	isNonzeroCommandExit,
+} from "./activity-command";
 import type { ConversationActivity } from "../../types/conversation";
 
 export function ActivityRun({ activities }: { activities: ConversationActivity[] }) {
@@ -24,7 +28,10 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 	// choice either way.
 	const [override, setOverride] = useState<boolean | null>(null);
 	const running = activities.some((a) => a.status === "running");
-	const failed = activities.filter((a) => a.status === "failed").length;
+	const nonzeroExits = activities.filter(isNonzeroCommandExit).length;
+	const failed = activities.filter(
+		(activity) => activity.status === "failed" && !isNonzeroCommandExit(activity),
+	).length;
 	const cancelled = activities.filter((a) => a.status === "cancelled").length;
 
 	// A single call is its own best summary — collapsing one row into a count of
@@ -48,6 +55,11 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 				className={ACTIVITY_SUMMARY_BUTTON_CLASS}
 			>
 				<span className="text-[11.5px] text-muted-foreground">{summarize(activities)}</span>
+				{nonzeroExits > 0 ? (
+					<span className="text-[11px] text-muted-foreground/70">
+						{nonzeroExits} exited
+					</span>
+				) : null}
 				{failed > 0 ? (
 					<span className="text-[11px] text-destructive">
 						{failed} failed

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -568,10 +568,6 @@ function TerminalInput({ text, truncated }: { text: string; truncated?: boolean 
  * the viewport of someone reading back through a build log is worse than making
  * them scroll down once.
  *
- * The caveat below it is not boilerplate. The provider drops output, and it does
- * so differently per source, so the note says which source this is and why it may
- * be incomplete rather than hedging the same way about both.
- *
  * The text is what a terminal would have shown, not the bytes: output arrives with
  * its escape sequences intact — nothing in the stack strips them — so a colourized
  * test run rendered here verbatim is a wall of `[0m`, and a progress bar is a
@@ -613,13 +609,6 @@ function CommandOutput({ activity }: { activity: ConversationActivity }) {
 				<p className="text-[10px] leading-relaxed text-warning">
 					This command printed more than AO stores, so the output above stops early. Open a shell in
 					the worktree to see the rest.
-				</p>
-			) : detail?.outputMayBePartial ? (
-				<p className="text-[10px] leading-relaxed text-muted-foreground/70">
-					{detail.outputSource === "stream"
-						? "Streamed live as the command runs. The provider drops the first chunk, so the beginning may be missing."
-						: "Rolled up by the provider after the command finished, and observed to drop the beginning."}{" "}
-					Open a shell in the worktree for the full run.
 				</p>
 			) : null}
 		</>
@@ -699,7 +688,14 @@ function ActivityState({
 	}
 	if (status === "failed") {
 		return (
-			<span className="shrink-0 font-mono text-[10px] tabular-nums text-destructive">
+			<span
+				className={cn(
+					"shrink-0 font-mono text-[10px] tabular-nums",
+					activity.activityKind === "command"
+						? "text-muted-foreground/70"
+						: "text-destructive",
+				)}
+			>
 				{detail?.exitCode !== undefined ? `exit ${detail.exitCode}` : "failed"}
 			</span>
 		);

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -59,6 +59,7 @@ import {
 	ACTIVITY_SUMMARY_BUTTON_CLASS,
 	commandCategory,
 	exploredFileCount,
+	isNonzeroCommandExit,
 } from "./activity-command";
 import { Button } from "../ui/button";
 import {
@@ -691,9 +692,7 @@ function ActivityState({
 			<span
 				className={cn(
 					"shrink-0 font-mono text-[10px] tabular-nums",
-					activity.activityKind === "command"
-						? "text-muted-foreground/70"
-						: "text-destructive",
+					isNonzeroCommandExit(activity) ? "text-muted-foreground/70" : "text-destructive",
 				)}
 			>
 				{detail?.exitCode !== undefined ? `exit ${detail.exitCode}` : "failed"}

--- a/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
@@ -215,6 +215,45 @@ describe("ActivityRun with a streaming command", () => {
 		);
 		expect(container.querySelector("pre")).toBeNull();
 	});
+
+	it("summarizes grouped non-zero command exits without destructive styling", () => {
+		const secondCommand = commandActivity(
+			{ command: "npm run typecheck", exitCode: 2 },
+			"failed",
+		);
+		secondCommand.id = "act-2";
+		secondCommand.sequence = 2;
+
+		render(
+			<ActivityRun
+				activities={[
+					commandActivity({ command: "npm test", exitCode: 1 }, "failed"),
+					secondCommand,
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("2 exited")).toHaveClass("text-muted-foreground/70");
+		expect(screen.getByText("2 exited")).not.toHaveClass("text-destructive");
+		expect(screen.queryByText("2 failed")).not.toBeInTheDocument();
+	});
+
+	it("keeps real grouped failures destructive when mixed with a command exit", () => {
+		const failedPlan = plan("act-2");
+		failedPlan.status = "failed";
+
+		render(
+			<ActivityRun
+				activities={[
+					commandActivity({ command: "npm test", exitCode: 1 }, "failed"),
+					failedPlan,
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("1 exited")).toHaveClass("text-muted-foreground/70");
+		expect(screen.getByText("1 failed")).toHaveClass("text-destructive");
+	});
 });
 
 describe("ActivityRow command labels", () => {
@@ -266,6 +305,17 @@ describe("ActivityRow command labels", () => {
 		expect(container.querySelector(".lucide-square-terminal")).toBeNull();
 		expect(row.querySelector(".flex-1")).toBeNull();
 		expect(row.textContent).toMatch(/^Checked repositoryexit 1/);
+	});
+
+	it("keeps command failures without exit metadata destructive", () => {
+		render(
+			<ActivityRow
+				activity={commandActivity({ command: "search the web", reason: "provider error" }, "failed")}
+			/>,
+		);
+
+		expect(screen.getByText("failed")).toHaveClass("text-destructive");
+		expect(screen.getByText("failed")).not.toHaveClass("text-muted-foreground/70");
 	});
 
 	it("shows an interrupted command as stopped instead of leaving a live spinner", () => {

--- a/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
@@ -5,9 +5,9 @@ import { ActivityRow, TurnChangedFiles } from "./ChatTimelineItems";
 import { ActivityRun } from "./ActivityRun";
 import type { ConversationActivity, TurnDiff } from "../../types/conversation";
 
-// These cover the two honesty rules this surface exists to keep: a changed-file
-// list never claims to be complete when it was cut, and command output always says
-// which channel it came from and why it may be missing its beginning.
+// These cover the two signal rules this surface exists to keep: a changed-file
+// list never claims to be complete when it was cut, and command output only adds
+// a warning when AO actually stopped storing it.
 
 function diff(overrides: Partial<TurnDiff> = {}): TurnDiff {
 	return {
@@ -108,7 +108,7 @@ describe("ActivityRow command output", () => {
 		expect(pre?.textContent).toBe("ok  pkg/a\n");
 	});
 
-	it("explains a streamed partial as a dropped beginning, not a generic caveat", () => {
+	it("does not add provider provenance below streamed output", () => {
 		render(
 			<ActivityRow
 				activity={commandActivity(
@@ -117,10 +117,11 @@ describe("ActivityRow command output", () => {
 				)}
 			/>,
 		);
-		expect(screen.getByText(/Streamed live as the command runs/i)).toBeInTheDocument();
+		expect(screen.getByText("tick-2")).toBeInTheDocument();
+		expect(screen.queryByText(/Streamed live as the command runs/i)).not.toBeInTheDocument();
 	});
 
-	it("names the aggregate as the provider's post-hoc roll-up", async () => {
+	it("does not add provider provenance below aggregate output", async () => {
 		render(
 			<ActivityRow
 				activity={commandActivity({
@@ -131,7 +132,8 @@ describe("ActivityRow command output", () => {
 			/>,
 		);
 		await userEvent.click(screen.getByRole("button"));
-		expect(screen.getByText(/Rolled up by the provider after the command finished/i)).toBeInTheDocument();
+		expect(screen.getByText("done")).toBeInTheDocument();
+		expect(screen.queryByText(/Rolled up by the provider after the command finished/i)).not.toBeInTheDocument();
 	});
 
 	it("warns when output hit the storage cap", async () => {
@@ -259,7 +261,8 @@ describe("ActivityRow command labels", () => {
 			"font-normal",
 			"text-muted-foreground",
 		);
-		expect(screen.getByText("exit 1")).toHaveClass("text-destructive");
+		expect(screen.getByText("exit 1")).toHaveClass("text-muted-foreground/70");
+		expect(screen.getByText("exit 1")).not.toHaveClass("text-destructive");
 		expect(container.querySelector(".lucide-square-terminal")).toBeNull();
 		expect(row.querySelector(".flex-1")).toBeNull();
 		expect(row.textContent).toMatch(/^Checked repositoryexit 1/);

--- a/frontend/src/renderer/components/chat/activity-command.ts
+++ b/frontend/src/renderer/components/chat/activity-command.ts
@@ -1,9 +1,22 @@
+import type { ConversationActivity } from "../../types/conversation";
+
 /** The user-facing category of a shell command in the chat timeline. */
 export type CommandCategory = "read" | "search" | "vcs" | "run";
 
 /** Shared chrome for one command summary and a collapsed run of commands. */
 export const ACTIVITY_SUMMARY_BUTTON_CLASS =
 	"group/run flex w-full items-center gap-1.5 rounded-sm py-0.5 pr-1 text-left transition-colors hover:bg-interactive-hover";
+
+/** A completed shell command that reported an ordinary non-zero process exit. */
+export function isNonzeroCommandExit(activity: ConversationActivity): boolean {
+	const exitCode = activity.detail?.exitCode;
+	return (
+		activity.activityKind === "command" &&
+		activity.status === "failed" &&
+		typeof exitCode === "number" &&
+		exitCode !== 0
+	);
+}
 
 const READERS = new Set(["cat", "sed", "nl", "head", "tail", "bat", "less", "more", "wc", "jq"]);
 const SEARCHERS = new Set(["rg", "grep", "find", "fd", "ls", "tree", "glob", "ag"]);

--- a/frontend/src/renderer/types/conversation.ts
+++ b/frontend/src/renderer/types/conversation.ts
@@ -185,8 +185,7 @@ export interface CommandDetail {
 	output?: string;
 	/**
 	 * Provider output aggregation was observed to drop leading bytes even on tiny
-	 * commands, so this is display data and the UI says so rather than presenting
-	 * it as the record of what ran.
+	 * commands, so this display data is not an authoritative record of what ran.
 	 *
 	 * Set for BOTH output sources. Measured on codex-cli 0.146.0: a command
 	 * printing tick-1..tick-8 lost tick-1 from the delta stream and from the
@@ -199,8 +198,7 @@ export interface CommandDetail {
 	 * `stream` is accumulated output deltas: it exists while the command is still
 	 * running, and it is the only source for a command that never completes.
 	 * `aggregate` is the provider's own roll-up, which only appears on completion
-	 * and is all a fast command produces. Both are partial, for different reasons,
-	 * which is why the UI names the reason instead of hedging identically.
+	 * and is all a fast command produces.
 	 */
 	outputSource?: "stream" | "aggregate";
 	/** Accumulation stopped at the daemon's cap; the command printed more. */


### PR DESCRIPTION
## Summary

- render actual non-zero shell exits in a muted neutral tone while preserving destructive styling for provider/tool failures without exit metadata
- apply the same distinction to collapsed activity runs, separating muted `N exited` from destructive `N failed`
- remove noisy partial-output provenance footers from command output
- retain the actionable storage-truncation warning

## Verification

- `npm test -- src/renderer/components/chat/TurnChangedFiles.test.tsx src/renderer/components/chat/ActivityRun.test.tsx` — 23 passed
- `npm run typecheck` — passed
- `git diff --check` — passed
- Regression coverage confirms command failures without exit metadata stay destructive, grouped non-zero exits are muted, and mixed groups retain a destructive count for real failures
- Native Electron DOM assertions confirmed `exit 1` uses `text-muted-foreground/70`; streamed, aggregate, and “open a shell” provenance copy all had zero matches

## Notes

Provider partial-output metadata remains available in the conversation model; this only removes the non-actionable explanatory footer from the chat UI. The warning for output truncated by AO's storage cap is unchanged.
