### PR TITLE
fix(usage): collect cost data for Chat sessions

### DIFF
--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -198,7 +198,7 @@ func (c *Collector) ReactivateSession(
 	if err != nil {
 		return err
 	}
-	nativeID := boundedUsageMetadata(session.Metadata.AgentSessionID)
+	nativeID := usageNativeSessionID(session)
 	var current *domain.UsageBindingRecord
 	for index := len(bindings) - 1; index >= 0; index-- {
 		binding := &bindings[index]
@@ -235,7 +235,7 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 	signal.Harness = session.Harness
 	signal.NativeSessionID = boundedUsageMetadata(signal.NativeSessionID)
 	if signal.NativeSessionID == "" {
-		signal.NativeSessionID = boundedUsageMetadata(session.Metadata.AgentSessionID)
+		signal.NativeSessionID = usageNativeSessionID(session)
 	}
 	if signal.NativeSessionID == "" {
 		signal.NativeSessionID = nativeIDFromTranscript(signal.TranscriptPath)
@@ -479,7 +479,7 @@ func (c *Collector) BackfillActive(ctx context.Context) error {
 		if session.IsTerminated || !SupportedHarness(session.Harness) {
 			continue
 		}
-		nativeID := boundedUsageMetadata(session.Metadata.AgentSessionID)
+		nativeID := usageNativeSessionID(session)
 		if nativeID == "" || !nativeUsageIDPattern.MatchString(nativeID) {
 			continue
 		}
@@ -488,6 +488,21 @@ func (c *Collector) BackfillActive(ctx context.Context) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// usageNativeSessionID returns the provider transcript identity for the
+// session's committed interface. Chat controllers persist that identity as the
+// provider conversation id because they have no terminal hook to populate the
+// agent session id. TUI controllers populate the agent session id through their
+// native hook pipeline. Prefer the Chat field only when it is present so older
+// migrated records can still fall back to their hook-derived identity.
+func usageNativeSessionID(session domain.SessionRecord) string {
+	nativeID := session.Metadata.AgentSessionID
+	if domain.NormalizeSessionMode(session.Mode) == domain.SessionModeChat &&
+		strings.TrimSpace(session.Metadata.ProviderConversationID) != "" {
+		nativeID = session.Metadata.ProviderConversationID
+	}
+	return boundedUsageMetadata(nativeID)
 }
 
 func (c *Collector) backfillSession(ctx context.Context, session domain.SessionRecord, nativeID string) error {

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -394,6 +394,37 @@ func TestCollectorReactivateSessionPreservesCursorWithoutHook(t *testing.T) {
 	}
 }
 
+func TestCollectorRegistersChatUsageWhenLifecycleMarksControllerSpawned(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestChatSession(t, store, domain.HarnessCodex, "", false)
+
+	root := filepath.Join(t.TempDir(), "sessions")
+	path := filepath.Join(root, "2026", "08", "18", "rollout-native-chat.jsonl")
+	writeUsageFixture(t, path, codexSessionMetaFixture(t, "native-chat", ""))
+	collector := NewCollector(store, SourceRoots{CodexSessions: root}, nil)
+	manager := lifecycle.New(store, nil)
+	manager.SetUsageFinalizer(collector)
+
+	mustNoError(t, manager.MarkSpawned(context.Background(), session.ID, domain.SessionMetadata{
+		ProviderConversationID: "native-chat",
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("chat usage bindings=%+v err=%v, want one binding for the provider conversation", bindings, err)
+	}
+	if bindings[0].NativeRootID != "native-chat" || bindings[0].State != domain.UsageBindingActive {
+		t.Fatalf("chat usage binding=%+v, want active native-chat binding", bindings[0])
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 {
+		t.Fatalf("chat usage sources=%+v err=%v, want the provider rollout", sources, err)
+	}
+	wantPath := canonicalUsagePath(t, path)
+	if sources[0].ArtifactPath != wantPath {
+		t.Fatalf("chat usage source path=%q, want %q", sources[0].ArtifactPath, wantPath)
+	}
+}
+
 func TestCollectorReactivateSessionRejectsStaleLaunch(t *testing.T) {
 	store := collectorTestStore(t)
 	session := collectorTestSession(t, store, domain.HarnessCodex, "native-stale", false)
@@ -971,6 +1002,27 @@ func TestCollectorBackfillsOnlyNonTerminatedSupportedSessions(t *testing.T) {
 	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
 	if err != nil || len(sources) != 1 {
 		t.Fatalf("active sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorBackfillsChatSessionFromProviderConversationID(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestChatSession(t, store, domain.HarnessCodex, "native-chat-backfill", false)
+	root := filepath.Join(t.TempDir(), "sessions")
+	path := filepath.Join(root, "2026", "08", "18", "rollout-native-chat-backfill.jsonl")
+	writeUsageFixture(t, path, codexSessionMetaFixture(t, "native-chat-backfill", ""))
+	collector := NewCollector(store, SourceRoots{CodexSessions: root}, nil)
+
+	mustNoError(t, collector.BackfillActive(context.Background()), "backfill chat usage")
+	binding, ok, err := store.GetUsageBinding(
+		context.Background(), session.ID, session.Harness, "native-chat-backfill",
+	)
+	if err != nil || !ok || binding.State != domain.UsageBindingActive {
+		t.Fatalf("chat backfill binding=%+v ok=%v err=%v", binding, ok, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), binding.ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("chat backfill sources=%+v err=%v", sources, err)
 	}
 }
 
@@ -1757,6 +1809,32 @@ func assertNoUsageSourcesForSession(t *testing.T, store *sqlite.Store, sessionID
 
 func collectorTestSession(t *testing.T, store *sqlite.Store, harness domain.AgentHarness, nativeID string, terminated bool) domain.SessionRecord {
 	return collectorTestSessionWithActivity(t, store, harness, nativeID, terminated, domain.ActivityIdle)
+}
+
+func collectorTestChatSession(
+	t *testing.T,
+	store *sqlite.Store,
+	harness domain.AgentHarness,
+	providerConversationID string,
+	terminated bool,
+) domain.SessionRecord {
+	t.Helper()
+	now := time.Now().UTC()
+	session, err := store.CreateSession(context.Background(), domain.SessionRecord{
+		ProjectID:    "usage-test",
+		Kind:         domain.KindWorker,
+		Harness:      harness,
+		Mode:         domain.SessionModeChat,
+		Activity:     domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
+		IsTerminated: terminated,
+		Metadata: domain.SessionMetadata{
+			ProviderConversationID: providerConversationID,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	mustNoError(t, err)
+	return session
 }
 
 func collectorTestSessionWithActivity(


### PR DESCRIPTION
## Summary

- collect usage for Chat workers from their provider conversation identity
- keep TUI collection on the hook-derived agent session identity
- apply the identity selection consistently during lifecycle reactivation, hook fallback, and daemon-start backfill
- cover both the live Chat controller lifecycle and startup recovery paths

## Root cause

A fresh Chat controller persists its native transcript identity in `provider_conversation_id`. It has no terminal hook, so `agent_session_id` remains empty. The usage collector previously consulted only `agent_session_id`, which meant it could not create a usage binding or discover the provider JSONL transcript for Chat-only sessions.

Switching the same session to TUI copied the native identity into `agent_session_id`. That made the existing transcript discoverable immediately, which is why cost observability appeared to start working after the interface conversion.

This change selects `provider_conversation_id` for committed Chat sessions and preserves `agent_session_id` for TUI sessions. Older migrated Chat records still fall back to their hook-derived identity when no provider conversation ID exists.

**Root-cause confidence:** High — confirmed through the lifecycle call path, persisted SQLite state, transcript timestamps, API responses, a red-before-green regression, and the native Electron flow below.

## Actual Electron end-to-end evidence

The reproduction and verification used the real Electron checkout with isolated state under `~/.ao/dev`; neither screenshot comes from a mock or browser-only preview.

### Before

A fresh Chat Codex worker had already completed its turn and the conversation endpoint reported 18,213 tokens, while `/api/v1/usage/sessions/<id>` remained empty and the board card had no token badge. Converting that exact session to TUI exposed the same 18,213 tokens immediately without another model turn.

![Before the fix: the Chat cost check card has no token badge](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/e622b94379eb4e2c3625224ffd130bdeacb607ae/.pr-assets/chat-cost-observability/before.png)

### After

A new post-fix Codex worker remained in Chat mode with empty `runtime_launch_id` and `agent_session_id`. Its provider-conversation usage binding became active, `/api/v1/usage/sessions/<id>` returned 18,218 tokens, and the board rendered `18.2K tok` without any interface conversion.

![After the fix: the fresh Chat worker shows 18.2K tokens without switching to TUI](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/e622b94379eb4e2c3625224ffd130bdeacb607ae/.pr-assets/chat-cost-observability/after.png)

The immutable evidence assets are stored at commit [`e622b943`](https://github.com/Untrivial-ai/agent-orchestrator/commit/e622b94379eb4e2c3625224ffd130bdeacb607ae).

## Verification

- `cd backend && go build ./...`
- `cd backend && env -u AO_PROJECT_ID -u AO_SESSION_ID GOFLAGS=-p=1 go test ./...`
- `cd backend && go test -race ./internal/service/usage`
- focused lifecycle and startup-backfill regressions, three consecutive runs
- `env -u AO_PROJECT_ID -u AO_SESSION_ID GOFLAGS=-p=1 npm run lint` (`0 issues`)

## Risk

Low. The behavior change is confined to choosing the already-persisted provider transcript identity for Chat sessions. TUI identity selection and unsupported harness behavior are unchanged.
