### PR TITLE
fix: clear kimi permission wait state

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/fake"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimchi"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/muse"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/primeagent"
@@ -46,7 +47,7 @@ var Derivers = map[string]DeriveFunc{
 	"cursor":      activitystate.StandardDeriveActivityState,
 	"qwen":        activitystate.StandardDeriveActivityState,
 	"copilot":     activitystate.StandardDeriveActivityState,
-	"kimi":        activitystate.StandardDeriveActivityState,
+	"kimi":        kimi.DeriveActivityState,
 	"cline":       activitystate.StandardDeriveActivityState,
 	"kiro":        activitystate.StandardDeriveActivityState,
 	"kilocode":    activitystate.StandardDeriveActivityState,

--- a/backend/internal/adapters/agent/kimi/activity.go
+++ b/backend/internal/adapters/agent/kimi/activity.go
@@ -1,0 +1,19 @@
+package kimi
+
+import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
+// DeriveActivityState maps Kimi lifecycle hooks onto AO activity facts.
+// PermissionResult clears the waiting-input state as soon as Kimi resumes the
+// turn after the user answers a permission request.
+func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+	switch event {
+	case "session-start", "user-prompt-submit", "permission-result":
+		return domain.ActivityActive, true
+	case "permission-request":
+		return domain.ActivityWaitingInput, true
+	case "stop":
+		return domain.ActivityIdle, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -234,6 +234,7 @@ func kimiHooksConfigBlock() string {
 		kimiHookEntry("SessionStart", "startup", "ao hooks kimi session-start") +
 		kimiHookEntry("UserPromptSubmit", "", "ao hooks kimi user-prompt-submit") +
 		kimiHookEntry("PermissionRequest", "", "ao hooks kimi permission-request") +
+		kimiHookEntry("PermissionResult", "", "ao hooks kimi permission-result") +
 		kimiHookEntry("Stop", "", "ao hooks kimi stop") +
 		kimiHooksSentinelEnd + "\n"
 }

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -353,6 +354,8 @@ timeout = 7
 		`command = "ao hooks kimi user-prompt-submit"`,
 		`event = "PermissionRequest"`,
 		`command = "ao hooks kimi permission-request"`,
+		`event = "PermissionResult"`,
+		`command = "ao hooks kimi permission-result"`,
 		`event = "Stop"`,
 		`command = "ao hooks kimi stop"`,
 		kimiHooksSentinelEnd,
@@ -363,6 +366,30 @@ timeout = 7
 	}
 	if _, err := os.Stat(kimiInstructionsPath(workspace)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("instructions path err = %v, want not exist", err)
+	}
+}
+
+func TestDeriveActivityState(t *testing.T) {
+	tests := []struct {
+		event  string
+		want   domain.ActivityState
+		wantOK bool
+	}{
+		{event: "session-start", want: domain.ActivityActive, wantOK: true},
+		{event: "user-prompt-submit", want: domain.ActivityActive, wantOK: true},
+		{event: "permission-request", want: domain.ActivityWaitingInput, wantOK: true},
+		{event: "permission-result", want: domain.ActivityActive, wantOK: true},
+		{event: "stop", want: domain.ActivityIdle, wantOK: true},
+		{event: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			got, ok := DeriveActivityState(tt.event, nil)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, %v)", tt.event, got, ok, tt.want, tt.wantOK)
+			}
+		})
 	}
 }
 

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -744,6 +744,29 @@ func TestHooks_RegisteredHarnessSessionStartReportsAgentSessionID(t *testing.T) 
 	}
 }
 
+func TestHooks_KimiPermissionResultReportsActive(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"session_id":"kimi-native-1"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "kimi", "permission-result")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+	}
+	want := setActivityAPIRequest{State: "active", Event: "permission-result", AgentSessionID: "kimi-native-1"}
+	if req != want {
+		t.Fatalf("body = %+v, want %+v", req, want)
+	}
+}
+
 func TestHooks_VibePostAgentReportsSessionIDAndIdle(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	cfg := setConfigEnv(t)


### PR DESCRIPTION
## Summary

- install a Kimi PermissionResult hook so AO receives the lifecycle event after permission prompts resolve
- derive Kimi activity state explicitly so permission-result clears waiting-input back to active
- cover hook config, activity derivation, and CLI hook reporting with tests

## Validation

- go test ./internal/adapters/agent/kimi ./internal/cli
