### PR TITLE
fix(ui): hide reviews without pull requests

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -608,7 +608,7 @@ describe("SessionInspector PR section", () => {
     expect(screen.getByText("No pull request opened yet.")).toBeInTheDocument();
   });
 
-  it("keeps PR and session policies in Summary while review policies live in Reviews", async () => {
+  it("keeps durable session policies in Summary and operational review controls in Reviews", async () => {
     renderWithQuery(<SessionInspector session={session([pr(7, "open")])} />);
 
     expect(screen.getByText("Session controls")).toBeInTheDocument();
@@ -618,6 +618,7 @@ describe("SessionInspector PR section", () => {
         .getByRole("switch", { name })
         .closest("[data-slot='inspector-policy-row']") as HTMLElement;
     const ciRow = policyRow("Automatically send CI failures");
+    const reviewRow = policyRow("Automatically send reviews");
     const terminateRow = policyRow(
       "Terminate session when pull requests merge",
     );
@@ -632,16 +633,15 @@ describe("SessionInspector PR section", () => {
 
     expect(appearsBefore(prCard, ciRow)).toBe(true);
     expect(ciRow.className).toBe(terminateRow.className);
+    expect(reviewRow.className).toBe(terminateRow.className);
     expect(ciRow.parentElement).not.toHaveClass(
       "rounded-lg",
       "border",
       "bg-surface",
     );
-    expect(
-      screen.queryByRole("switch", { name: "Automatically send reviews" }),
-    ).not.toBeInTheDocument();
     for (const name of [
       "Automatically send CI failures",
+      "Automatically send reviews",
       "Terminate session when pull requests merge",
     ]) {
       const toggle = screen.getByRole("switch", { name });
@@ -667,8 +667,9 @@ describe("SessionInspector PR section", () => {
       await screen.findByRole("button", { name: "Run review" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("switch", { name: "Automatically send reviews" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("switch", { name: "Automatically send reviews" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Auto review" })).toBeInTheDocument();
   });
 
   it("persists the CI injection default before a PR exists", async () => {
@@ -2461,7 +2462,6 @@ describe("SessionInspector summary reviews", () => {
 
   it("persists the automatic review injection toggle", async () => {
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
-    await openReviewsSection();
 
     const toggle = screen.getByRole("switch", {
       name: "Automatically send reviews",
@@ -2879,15 +2879,39 @@ describe("SessionInspector summary reviews", () => {
     );
   });
 
-  it("keeps the Reviews tab available when the session has no PRs", async () => {
+  it("hides Reviews when the session has no PR while keeping its durable preference in Summary", async () => {
     mockCommonGets();
     renderWithQuery(<SessionInspector session={session([])} />);
 
     await screen.findByRole("tab", { name: /Summary/ });
-    await userEvent.click(screen.getByRole("tab", { name: /Reviews/ }));
+    expect(screen.queryByRole("tab", { name: /Reviews/ })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent?.trim())).toEqual([
+      "Summary",
+      "Browser",
+      "Files",
+    ]);
     expect(
       screen.getByRole("switch", { name: "Automatically send reviews" }),
     ).toBeInTheDocument();
     expect(screen.getByText("No pull request opened yet.")).toBeInTheDocument();
+  });
+
+  it("falls back to Summary when a controlled Reviews selection has no PR", async () => {
+    const onViewChange = vi.fn();
+    renderWithQuery(
+      <SessionInspector
+        onViewChange={onViewChange}
+        session={session([])}
+        view="reviews"
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.queryByRole("tab", { name: "Reviews" })).not.toBeInTheDocument();
+    expect(screen.getByText("Session controls")).toBeInTheDocument();
+    await waitFor(() => expect(onViewChange).toHaveBeenCalledWith("summary"));
   });
 });

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -165,6 +165,7 @@ export function SessionInspector({
 	const { t } = useTranslation();
 	const [internalView, setInternalView] = useState<InspectorView>("summary");
 	const requestedView = viewProp ?? internalView;
+	const hasPullRequests = session ? sortedPRs(session).length > 0 : false;
 	// Badge the Browser tab when a preview target arrived without us opening it.
 	const browserUnseen = useUiStore((state) =>
 		session ? Boolean(state.inspectorSessions[session.id]?.browserUnseen) : false,
@@ -175,19 +176,28 @@ export function SessionInspector({
 		onViewChange?.(next);
 		if (next === "files") onOpenFiles?.();
 	};
-	const view: InspectorView = requestedView;
-	const tabs = VIEW_DEFS.map((entry) => {
-		const label = t(entry.labelKey);
-		return {
-			...entry,
-			badge: entry.id === "browser" && browserUnseen,
-			displayLabel:
-				entry.id === "files" && filesChangedCount !== undefined
-					? t("files.tabCount", { count: filesChangedCount })
-					: label,
-			label,
-		};
-	});
+	// A persisted/controlled Reviews selection can outlive the last PR. Keep the
+	// shell on a real, visible tab instead of rendering an empty, unlabelled body.
+	const view: InspectorView = requestedView === "reviews" && !hasPullRequests ? "summary" : requestedView;
+	useEffect(() => {
+		if (view === requestedView) return;
+		setInternalView(view);
+		onViewChange?.(view);
+	}, [onViewChange, requestedView, view]);
+	const tabs = VIEW_DEFS.filter((entry) => entry.id !== "reviews" || hasPullRequests).map(
+		(entry) => {
+			const label = t(entry.labelKey);
+			return {
+				...entry,
+				badge: entry.id === "browser" && browserUnseen,
+				displayLabel:
+					entry.id === "files" && filesChangedCount !== undefined
+						? t("files.tabCount", { count: filesChangedCount })
+						: label,
+				label,
+			};
+		},
+	);
 	return (
 		<SessionInspectorShellView
 			activeView={view}
@@ -861,6 +871,7 @@ function SessionControls({ session }: { session: WorkspaceSession }) {
 	return (
 		<Section title={t("inspector.sessionControls")}>
 			<AutoInjectCIPolicyControl session={session} />
+			<AutoInjectReviewPolicyControl session={session} />
 			{session.kind === "orchestrator" ? null : canTerminateNow ? (
 				<div className="flex items-center justify-between gap-3 py-1">
 					<span className="min-w-0 text-xs font-medium text-settings-label">{t("inspector.terminateShort")}</span>
@@ -1324,15 +1335,8 @@ function ReviewsSection({
 			((pr.review?.reviews?.length ?? 0) > 0 ||
 				(pr.review?.unresolvedBy ?? []).some((reviewer) => reviewer.count > 0)),
 	);
-	const hasPRs = sortedPRs(session).length > 0;
-
 	return (
 		<div className="p-2">
-			{hasPRs ? null : (
-				<Section surface title={t("inspector.review.controls")}>
-					<AutoInjectReviewPolicyControl session={session} />
-				</Section>
-			)}
 			{/* Running a review is an action; reading them is a list. The action stays
 			    on top, then one list carrying both sources keyed by PR. */}
 			<ReviewPanel
@@ -1858,8 +1862,7 @@ function ReviewPanel({
 							) : null}
 						</div>
 					</div>
-					<AutoInjectReviewPolicyControl session={session} />
-					</div>
+				</div>
 				{reviewRunning ? (
 					<div className="mt-3 flex items-center gap-2 border-t border-border pt-3">
 						<Loader2 aria-hidden="true" className="size-icon-sm shrink-0 animate-spin text-muted-foreground" />


### PR DESCRIPTION
## Summary

- hide the Reviews inspector tab when a session has no pull request
- redirect a stale Reviews selection to Summary when PR context disappears
- keep review automation settings available under Session controls

## Verification

- `cd frontend && npm test -- src/renderer/components/SessionInspector.test.tsx` (92 tests passed)
- `cd frontend && npm run typecheck`
- native Electron verification in isolated mode: confirmed the Reviews tab is absent for a no-PR session

## Risk

Low. The change is limited to review-related inspector visibility and fallback selection, with focused component coverage.
