### PR TITLE
Disable DevTools on blank browser pages

### DIFF
--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -214,6 +214,8 @@ function setupTabHost() {
 			id: number;
 			getURL: () => string;
 			loadURL: ReturnType<typeof vi.fn>;
+			openDevTools: ReturnType<typeof vi.fn>;
+			closeDevTools: ReturnType<typeof vi.fn>;
 			openWindow: (url: string) => void;
 			close: ReturnType<typeof vi.fn>;
 			};
@@ -273,6 +275,8 @@ function setupTabHost() {
 			},
 			stop: () => undefined,
 			close: vi.fn(),
+			openDevTools: vi.fn(),
+			closeDevTools: vi.fn(),
 			openWindow: (url: string) => {
 				const result = windowOpenHandler?.({ url });
 				if (result?.action === "allow") {
@@ -408,10 +412,22 @@ describe("native Chromium DevTools host", () => {
 		expect(openDevTools).toHaveBeenLastCalledWith({ mode: "undocked", activate: true });
 	});
 
+	it("does not open DevTools for a blank browser target", async () => {
+		const { invoke, openDevTools } = setupHost();
+		const nav = await invoke("browser:ensure", "sess-1");
+		const viewId = (nav as BrowserNavState).viewId;
+
+		const state = await invoke("browser:devtools", { viewId, operation: "open" });
+
+		expect(state).toMatchObject({ open: false, placement: "right" });
+		expect(openDevTools).not.toHaveBeenCalled();
+	});
+
 	it("reflects a manual native DevTools close in the browser toolbar state", async () => {
 		const { invoke, sent, webContentsListeners } = setupHost();
 		const nav = await invoke("browser:ensure", "sess-1");
 		const viewId = (nav as BrowserNavState).viewId;
+		await invoke("browser:navigate", { viewId, url: "http://localhost:3000/" });
 
 		await invoke("browser:devtools", { viewId, operation: "open" });
 		expect(sent.filter((entry) => entry.channel === "browser:devtoolsState").at(-1)?.payload).toMatchObject({
@@ -435,6 +451,32 @@ describe("native Chromium DevTools host", () => {
 			viewId,
 			open: false,
 		});
+	});
+
+	it("closes DevTools when the active page is cleared", async () => {
+		const { closeDevTools, invoke } = setupHost();
+		const nav = await invoke("browser:ensure", "sess-1");
+		const viewId = (nav as BrowserNavState).viewId;
+		await invoke("browser:navigate", { viewId, url: "http://localhost:3000/" });
+		await invoke("browser:devtools", { viewId, operation: "open" });
+
+		await invoke("browser:clear", viewId);
+
+		expect(closeDevTools).toHaveBeenCalledOnce();
+		expect(await invoke("browser:devtools", { viewId, operation: "open" })).toMatchObject({ open: false });
+	});
+
+	it("closes DevTools when switching to a blank tab", async () => {
+		const { invoke, views } = setupTabHost();
+		const nav = (await invoke("browser:ensure", "sess-1")) as BrowserNavState;
+		await invoke("browser:navigate", { viewId: nav.viewId, url: "http://localhost:3000/" });
+		await invoke("browser:devtools", { viewId: nav.viewId, operation: "open" });
+
+		await invoke("browser:openTab", { viewId: nav.viewId });
+
+		expect(views[0].webContents.closeDevTools).toHaveBeenCalledOnce();
+		expect(views[1].webContents.openDevTools).not.toHaveBeenCalled();
+		expect(await invoke("browser:devtools", { viewId: nav.viewId, operation: "open" })).toMatchObject({ open: false });
 	});
 
 });

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -512,7 +512,10 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			options,
 			entry,
 			() => entries.get(session.viewId)?.activeTabId === entry.tabId,
-			() => applySessionBounds(session, entry),
+			() => {
+				if (session.devtools && isBlankBrowserEntry(entry)) destroyDevTools(session);
+				applySessionBounds(session, entry);
+			},
 			() => pushTabsState(options, session),
 		);
 		wireFaviconEvents(view.webContents, entry, () => pushTabsState(options, session));
@@ -661,6 +664,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			applyBrowserViewBounds(previous.view, OFFSCREEN_BOUNDS, false);
 		}
 		session.activeTabId = tabId;
+		if (session.devtools && isBlankBrowserEntry(next)) destroyDevTools(session);
 		applySessionBounds(session, next);
 		pushNavState(options, next);
 		if (notify) pushTabsState(options, session, { kind: "selected", tabId });
@@ -774,6 +778,10 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		session: BrowserSessionEntry,
 	): Promise<BrowserDevToolsState> => {
 		const entry = activeEntry(session);
+		if (isBlankBrowserEntry(entry)) {
+			if (session.devtools) destroyDevTools(session);
+			return pushDevToolsState(session);
+		}
 		if (!entry.view.webContents.openDevTools) {
 			throw browserError("BROWSER_DEVTOOLS_UNAVAILABLE", "Browser DevTools are unavailable");
 		}
@@ -935,6 +943,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		if (!session) throw browserError("BROWSER_TARGET_UNAVAILABLE", "Browser target is unavailable");
 		const entry = activeEntry(session);
 		cancelAnnotation(options, entry, "navigation");
+		if (session.devtools) destroyDevTools(session);
 		session.visible = false;
 		session.bounds = OFFSCREEN_BOUNDS;
 		applySessionBounds(session, entry);
@@ -1459,6 +1468,11 @@ function activeEntry(session: BrowserSessionEntry): BrowserEntry {
 	const entry = session.tabs.get(session.activeTabId);
 	if (!entry) throw browserError("BROWSER_TARGET_UNAVAILABLE", "Active browser tab is unavailable");
 	return entry;
+}
+
+function isBlankBrowserEntry(entry: BrowserEntry): boolean {
+	const url = entry.view.webContents.getURL();
+	return !url || url === "about:blank";
 }
 
 function tabResult(entry: BrowserEntry, active: boolean): BrowserTabState & { untrustedExternalContent: true } {

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -161,6 +161,14 @@ describe("BrowserPanel", () => {
 		hookState.openDevTools.mockReset();
 		hookState.closeDevTools.mockReset();
 		hookState.devtoolsState = { viewId: "42:sess-1", open: false, activeTabId: "t1" };
+		hookState.navState = {
+			viewId: "42:sess-1",
+			url: "",
+			title: "",
+			canGoBack: false,
+			canGoForward: false,
+			isLoading: false,
+		};
 		hookState.setAnnotationMode.mockReset();
 		hookState.setAnnotationMode.mockResolvedValue(undefined);
 		postMock.mockReset();
@@ -309,6 +317,7 @@ describe("BrowserPanel", () => {
 	});
 
 	it("opens DevTools from a direct toolbar control", async () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:3000/" };
 		const { rerender } = render(
 			<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />,
 		);
@@ -322,6 +331,17 @@ describe("BrowserPanel", () => {
 		expect(screen.getAllByRole("button")).toHaveLength(toolbarButtonCount);
 		await userEvent.click(screen.getByRole("button", { name: "Close DevTools" }));
 		expect(hookState.closeDevTools).toHaveBeenCalledOnce();
+	});
+
+	it("disables DevTools until the active tab has a page", () => {
+		const { rerender } = render(
+			<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />,
+		);
+		expect(screen.getByRole("button", { name: "Open DevTools" })).toBeDisabled();
+
+		hookState.navState = { ...hookState.navState, url: "http://localhost:3000/" };
+		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		expect(screen.getByRole("button", { name: "Open DevTools" })).toBeEnabled();
 	});
 
 	it("marks blank native panels as opaque and loaded panels as live", () => {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -269,7 +269,10 @@ export function BrowserPanelView({
 		window.localStorage.setItem(RAIL_PINNED_STORAGE_KEY, next ? "1" : "0");
 	}, []);
 
-	const canUseDevTools = hasNativeBrowser && Boolean(viewId);
+	// Docked DevTools belongs to the native page view, which is intentionally
+	// hidden while the active target is blank. Keep close available for any
+	// in-flight state update, but do not offer an open action with no page.
+	const canUseDevTools = hasNativeBrowser && Boolean(viewId) && Boolean(navState.url || devtoolsState.open);
 
 	useEffect(() => {
 		setUrlInput(navState.url);


### PR DESCRIPTION
## What

- Disable the browser DevTools button until the active tab has loaded a page.
- Prevent shortcuts and menu actions from opening DevTools on a blank target.
- Automatically close DevTools when:
  - the active page is cleared;
  - the user switches to a blank tab.
- Preserve the existing docked-right behavior for loaded pages.

## Why

Blank browser targets use `about:blank` and their native page view is intentionally hidden so AO can display its empty-page UI.

Docked Chromium DevTools is attached to that hidden native view. As a result, DevTools was reported as open but remained invisible. Detached DevTools appeared because it used a separate window.

This change prevents the unsupported invisible state instead of unexpectedly changing the user's DevTools placement.

## How

- Added a main-process check for empty URLs and `about:blank`.
- Kept DevTools closed when an open request targets a blank page.
- Closed existing DevTools during page clearing or when activating a blank tab.
- Updated the browser toolbar to enable DevTools only when the active tab has a page. The close action remains available during in-flight state updates.
- Added regression coverage for blank targets, page clearing, blank-tab switching, and toolbar availability.

## Testing

- `cd frontend && npm test -- --run src/main/browser-view-host.test.ts src/renderer/components/BrowserPanel.test.tsx src/main/window-composition.test.ts`
  - 94 tests passed across 3 test files.
- `cd frontend && npm run typecheck`
  - Passed.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added for the affected user-visible behavior