### PR TITLE
fix(inspector): remember a session's inspector tab across session switches

### DIFF
--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -1381,6 +1381,25 @@ describe("SessionView", () => {
 		expect(inspectorButton()).toHaveAttribute("data-view", "files");
 	});
 
+	// Regression: the "initialized" marker used to live in a component-local
+	// ref, which is recreated whenever SessionView unmounts. Remounting an
+	// already-visited session (e.g. across a route transition) then looked
+	// identical to a first-ever visit and forced the tab back to Summary. The
+	// marker now lives in the ui-store's persisted inspectorSessions state, so
+	// it survives unmount/remount, not just re-renders of one mounted instance.
+	it("remembers the tab a session was left on after unmounting and remounting the view", () => {
+		const view = render(<SessionView sessionId="sess-1" />);
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+
+		fireEvent.click(screen.getByRole("button", { name: "open files" }));
+		expect(inspectorButton()).toHaveAttribute("data-view", "files");
+
+		view.unmount();
+
+		render(<SessionView sessionId="sess-1" />);
+		expect(inspectorButton()).toHaveAttribute("data-view", "files");
+	});
+
 	it("keeps Summary selected when preview content arrives with the async workspace response", () => {
 		const secondWorker = workerSession("sess-2");
 		secondWorker.previewUrl = "http://localhost:5173/";

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -1362,6 +1362,25 @@ describe("SessionView", () => {
 		expect(browserUnseen("sess-2")).toBe(false);
 	});
 
+	// Regression: the session-entry effect that defaults a brand-new session to
+	// Summary tracked only the single most-recently-initialized session ID, so
+	// re-entering ANY session that was not the immediately preceding one looked
+	// identical to a first-ever visit and forced it back to Summary — silently
+	// discarding whatever tab (Files, Browser) the user had left it on.
+	it("remembers the tab a session was left on when returning to it after visiting another session", () => {
+		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+
+		fireEvent.click(screen.getByRole("button", { name: "open files" }));
+		expect(inspectorButton()).toHaveAttribute("data-view", "files");
+
+		rerender(<SessionView sessionId="sess-2" />);
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+
+		rerender(<SessionView sessionId="sess-1" />);
+		expect(inspectorButton()).toHaveAttribute("data-view", "files");
+	});
+
 	it("keeps Summary selected when preview content arrives with the async workspace response", () => {
 		const secondWorker = workerSession("sess-2");
 		secondWorker.previewUrl = "http://localhost:5173/";

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -254,7 +254,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const previewBaselineRef = useRef<{ sessionId: string; key: string } | null>(null);
 	const sessionSplitRef = useRef<HTMLDivElement | null>(null);
 	const terminalLiveResizeTimerRef = useRef<number | null>(null);
-	const initializedInspectorSessionIdRef = useRef<string | null>(null);
+	const initializedInspectorSessionIdsRef = useRef<Set<string>>(new Set());
 	const [inspectorSettledClosed, setInspectorSettledClosed] = useState(!isInspectorOpen);
 	const inspectorPanelVisible = isInspectorOpen || !inspectorSettledClosed;
 	const [terminalTarget, setTerminalTarget] = useState<TerminalTarget>({ kind: "worker" });
@@ -587,12 +587,17 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// preview auto-opens Browser onto a view the hook has already torn down.
 	const hasBrowserContent = !terminated && Boolean(previewUrl || browserUrl);
 
-	// Entering a session always starts on Summary. Treat browser content that
-	// already existed when the route resolved as the baseline for that visit;
-	// only preview work arriving afterward may reveal Browser automatically.
+	// Entering a session for the first time ever always starts on Summary.
+	// Tracking only the single most-recently-initialized session id here would
+	// make re-entering any OTHER previously-visited session look identical to a
+	// first-ever visit, forcing it back to Summary and discarding whatever tab
+	// the user had left it on — track every session id this view has ever
+	// initialized instead. Treat browser content that already existed when the
+	// route resolved as the baseline for that visit; only preview work arriving
+	// afterward may reveal Browser automatically.
 	useLayoutEffect(() => {
-		if (!session || initializedInspectorSessionIdRef.current === sessionId) return;
-		initializedInspectorSessionIdRef.current = sessionId;
+		if (!session || initializedInspectorSessionIdsRef.current.has(sessionId)) return;
+		initializedInspectorSessionIdsRef.current.add(sessionId);
 		if (!hasInspector) return;
 		const current = useUiStore.getState().inspectorSessions[sessionId];
 		setInspectorViewForSession(sessionId, "summary");

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -248,13 +248,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const setInspectorOpenForSession = useUiStore((state) => state.setInspectorOpen);
 	const toggleInspector = useUiStore((state) => state.toggleInspector);
 	const setInspectorViewForSession = useUiStore((state) => state.setInspectorView);
+	const initializeInspectorSession = useUiStore((state) => state.initializeInspectorSession);
 	const setBrowserContentRevealed = useUiStore((state) => state.setBrowserContentRevealed);
 	const setBrowserUnseen = useUiStore((state) => state.setBrowserUnseen);
 	const { daemonStatus } = useShell();
 	const previewBaselineRef = useRef<{ sessionId: string; key: string } | null>(null);
 	const sessionSplitRef = useRef<HTMLDivElement | null>(null);
 	const terminalLiveResizeTimerRef = useRef<number | null>(null);
-	const initializedInspectorSessionIdsRef = useRef<Set<string>>(new Set());
 	const [inspectorSettledClosed, setInspectorSettledClosed] = useState(!isInspectorOpen);
 	const inspectorPanelVisible = isInspectorOpen || !inspectorSettledClosed;
 	const [terminalTarget, setTerminalTarget] = useState<TerminalTarget>({ kind: "worker" });
@@ -587,31 +587,19 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// preview auto-opens Browser onto a view the hook has already torn down.
 	const hasBrowserContent = !terminated && Boolean(previewUrl || browserUrl);
 
-	// Entering a session for the first time ever always starts on Summary.
-	// Tracking only the single most-recently-initialized session id here would
-	// make re-entering any OTHER previously-visited session look identical to a
-	// first-ever visit, forcing it back to Summary and discarding whatever tab
-	// the user had left it on — track every session id this view has ever
-	// initialized instead. Treat browser content that already existed when the
-	// route resolved as the baseline for that visit; only preview work arriving
-	// afterward may reveal Browser automatically.
+	// Entering a session for the first time ever always starts on Summary. This
+	// must fire exactly once per session's *lifetime*, not once per "was this
+	// the last session I looked at" or "is this view currently mounted" — so
+	// the initialized flag lives in the ui-store (inspectorSessions[sessionId])
+	// rather than a component-local ref, and survives both re-entering a
+	// different previously-visited session and unmounting/remounting this view
+	// entirely (e.g. across route transitions). Treat browser content that
+	// already existed when the route resolved as the baseline for that visit;
+	// only preview work arriving afterward may reveal Browser automatically.
 	useLayoutEffect(() => {
-		if (!session || initializedInspectorSessionIdsRef.current.has(sessionId)) return;
-		initializedInspectorSessionIdsRef.current.add(sessionId);
-		if (!hasInspector) return;
-		const current = useUiStore.getState().inspectorSessions[sessionId];
-		setInspectorViewForSession(sessionId, "summary");
-		if (current?.browserContentRevealed === undefined) {
-			setBrowserContentRevealed(sessionId, hasBrowserContent);
-		}
-	}, [
-		hasBrowserContent,
-		hasInspector,
-		session,
-		sessionId,
-		setBrowserContentRevealed,
-		setInspectorViewForSession,
-	]);
+		if (!session) return;
+		initializeInspectorSession(sessionId, hasBrowserContent, hasInspector);
+	}, [hasBrowserContent, hasInspector, session, sessionId, initializeInspectorSession]);
 
 	useLayoutEffect(() => {
 		setTerminalTarget({ kind: "worker" });

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -36,6 +36,8 @@ export type InspectorSessionState = {
 	browserContentRevealed?: boolean;
 	/** Real browser activity occurred while Browser was not visible. */
 	browserUnseen?: boolean;
+	/** The session-entry defaulting (Summary tab, baseline browser reveal) has already run once for this session's lifetime. */
+	initialized?: boolean;
 };
 
 // Selection (which project/session is open) now lives in the URL — the router
@@ -95,6 +97,14 @@ type UiState = {
 	setInspectorOpen: (sessionId: string, isOpen: boolean) => void;
 	toggleInspector: (sessionId: string) => void;
 	setInspectorView: (sessionId: string, view: InspectorView) => void;
+	/**
+	 * Runs the "entering this session" defaults — Summary tab, baseline browser
+	 * reveal — exactly once per session's lifetime. Backed by persisted store
+	 * state (not a component-local ref) so it stays a no-op across unmount and
+	 * remount of the session view, not just across re-renders of one mounted
+	 * instance.
+	 */
+	initializeInspectorSession: (sessionId: string, hasBrowserContent: boolean, hasInspector: boolean) => void;
 	setBrowserContentRevealed: (sessionId: string, revealed: boolean) => void;
 	setBrowserUnseen: (sessionId: string, unseen: boolean) => void;
 	setCommandPaletteOpen: (open: boolean) => void;
@@ -224,6 +234,26 @@ export const useUiStore = create<UiState>((set, get) => ({
 				inspectorSessions: {
 					...state.inspectorSessions,
 					[sessionId]: { ...current, view, browserUnseen },
+				},
+			};
+		}),
+	initializeInspectorSession: (sessionId, hasBrowserContent, hasInspector) =>
+		set((state) => {
+			// Sessions without an inspector (e.g. orchestrator sessions) must not
+			// gain a store entry at all — leave inspectorSessions[sessionId]
+			// undefined so callers that key off its presence stay correct.
+			if (!hasInspector) return state;
+			const current = inspectorState(state.inspectorSessions, sessionId);
+			if (current.initialized) return state;
+			return {
+				inspectorSessions: {
+					...state.inspectorSessions,
+					[sessionId]: {
+						...current,
+						initialized: true,
+						view: "summary",
+						browserContentRevealed: current.browserContentRevealed ?? hasBrowserContent,
+					},
 				},
 			};
 		}),


### PR DESCRIPTION
## What

Fixes the inspector rail's active tab (Summary/Browser/Files) resetting to Summary when switching back to a previously-visited session, discarding whatever tab the user had left it on.

## Why

Reported symptom: work on the Files (FILE DIFF) or Browser tab in one session, switch to another session, then switch back — the previous tab selection is gone and Summary shows instead. The right-panel state should persist per session across session switches.

Root cause: the session-entry effect in `SessionView.tsx` that defaults a **brand-new** session to the Summary tab (added in #3864) tracked only the single most-recently-initialized session id (`initializedInspectorSessionIdRef`, a plain `string | null` ref). Re-entering *any* session that wasn't the immediately preceding one looked identical to a first-ever visit, so the effect unconditionally forced it back to Summary via `setInspectorViewForSession(sessionId, "summary")` — even though that session's tab selection was already correctly persisted per-session in the ui-store (`inspectorSessions[sessionId].view`).

## How

Track every session id this view has ever initialized in a `Set<string>` instead of a single last-seen id, so the "default new sessions to Summary" effect only fires once per session's *lifetime*, not once per "was this the last session I looked at." This mirrors the existing `current?.browserContentRevealed === undefined` guard two lines below in the same effect, which already handled this correctly for that field.

No changes to the native browser-view (WebContentsView) visibility plumbing — investigated that path first (it's per-session and correctly scoped) before finding the actual bug was purely in this React-level tab-selection effect.

**Update from review (@neversettle17-101):** the component-local `Set` was itself recreated whenever `SessionView` unmounts (e.g. across a route transition), so re-mounting an already-visited session still looked like a first-ever visit. Moved the "initialized" marker into the ui-store's persisted `inspectorSessions[sessionId]` state via a new, idempotent `initializeInspectorSession(sessionId, hasBrowserContent, hasInspector)` action (no-ops once `initialized` is already true), so it survives unmount/remount, not just re-renders of one mounted instance. `hasInspector` is threaded through in addition to the reviewer's suggested signature so sessions without an inspector (orchestrators) still never gain a store entry, matching the prior behavior.

## Testing

All testing below was run locally in the worktree at `.claude/worktrees/fix-browser-view-session-switch-race` (branch `fix/inspector-tab-resets-on-session-revisit`).

- `remembers the tab a session was left on when returning to it after visiting another session` (`SessionView.test.tsx`) — opens Files on session A, switches to session B, switches back to A, asserts Files is still selected. Confirmed it fails against the pre-fix code (`data-view="summary"` instead of `"files"`) and passes after.
- `remembers the tab a session was left on after unmounting and remounting the view` (`SessionView.test.tsx`) — selects Files on session A, unmounts `SessionView`, remounts the same session, asserts Files is still selected. Added per review feedback; independently reverted just the source (keeping the test) to confirm it fails against the component-local-ref version (`data-view="summary"`) and passes against the store-backed version.
- `npx vitest run --config vite.renderer.config.ts src/renderer/components/SessionView.test.tsx src/renderer/components/SessionInspector.test.tsx src/renderer/hooks/useBrowserView.test.tsx` — 185/185 pass.
- `npx tsc --noEmit -p .` — clean.
- Full frontend suite: only pre-existing, unrelated failures (macOS-only path assertions running on Windows, landing-page/analytics tests, network-socket tests) — none touch the changed files.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant CI checks pass for the area touched (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)