### PR TITLE
fix(session): terminate interrupted spawns on boot reconcile

### DIFF
--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2066,6 +2066,19 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 		return err
 	}
 	projectKind := project.Kind.WithDefault()
+	// An interrupted spawn: the seed row was written, then the daemon died before
+	// the workspace or the runtime existed, so Spawn's rollback never ran. There
+	// is nothing to adopt, nothing to preserve, and nothing to restore — but the
+	// row still counts as an active session, and for an orchestrator that is
+	// load-bearing: EnsureOrchestrator returns the newest active orchestrator
+	// instead of spawning, so the project is pinned forever to a session with no
+	// terminal ("Preparing the orchestrator terminal…"). Terminate it here so the
+	// next request spawns a real one. Safe at boot: reconcile runs before the API
+	// serves, so no in-flight spawn can be observed mid-write.
+	if rec.Metadata.WorkspacePath == "" && runtimeHandle(rec.Metadata).ID == "" {
+		m.logger.Warn("reconcile: terminating interrupted spawn with no workspace or runtime", "sessionID", rec.ID)
+		return m.lcm.MarkTerminated(ctx, rec.ID)
+	}
 	if rec.Metadata.WorkspacePath == "" || (rec.Metadata.Branch == "" && projectKind != domain.ProjectKindScratch) {
 		return nil
 	}

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -7477,3 +7477,32 @@ func (m *flipOnNudgeMessenger) Send(_ context.Context, _ domain.SessionID, msg s
 	}
 	return nil
 }
+
+// TestReconcileLive_InterruptedSpawnTerminated locks the fix for the orphaned
+// orchestrator: a daemon killed mid-Spawn leaves a non-terminated row with no
+// workspace and no runtime handle, and EnsureOrchestrator would return that row
+// forever instead of spawning a session with a real terminal. Boot reconcile
+// must terminate it, without stashing or destroying anything (there is nothing
+// on disk to stash).
+func TestReconcileLive_InterruptedSpawnTerminated(t *testing.T) {
+	st := newFakeStore()
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	lcm := &fakeLCM{store: st}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st, Messenger: &fakeMessenger{}, Lifecycle: lcm, LookPath: lookPath})
+
+	rec := domain.SessionRecord{
+		ID: "s9", ProjectID: "p1", Kind: domain.KindOrchestrator, IsTerminated: false,
+	}
+
+	if err := m.reconcileLive(context.Background(), rec); err != nil {
+		t.Fatalf("reconcileLive: %v", err)
+	}
+	if lcm.terminated["s9"] != 1 {
+		t.Fatalf("MarkTerminated(s9) = %d, want 1", lcm.terminated["s9"])
+	}
+	if ws.stashCalls != 0 || rt.destroyed != 0 {
+		t.Fatalf("nothing to tear down: stash=%d destroy=%d", ws.stashCalls, rt.destroyed)
+	}
+}


### PR DESCRIPTION
Fixes #4079

## What changed

- Boot reconcile now terminates a live session that has neither a workspace path nor a runtime handle, instead of skipping it. That pair is only reachable if the daemon died between `Spawn`'s seed-row write and `createSessionWorkspace`, so the row is an interrupted spawn with nothing to adopt, preserve, or restore.
- Everything else in `reconcileLive` is untouched: workspace present + runtime alive still adopts, workspace present + runtime dead still takes the save-and-teardown path that preserves work and records the restore marker.

The row matters because `EnsureOrchestrator` returns the newest *active* orchestrator rather than spawning one, so a single interrupted spawn pins a project to a session that has no terminal and never will — "Preparing the orchestrator terminal" on every launch, surviving restarts, with no way out from inside the app. The reaper logs `session has no runtime handle metadata, skipping` for it every 5s meanwhile.

Not covered by #4071: that PR changed how the reconcile pass runs and how the supervisor reports a slow boot, but the `WorkspacePath == ""` early return is unchanged, so these rows are still skipped. Reproduced against `main` at 3348277 before writing this.

I put the fix in reconcile rather than having `EnsureOrchestrator` skip handle-less orchestrators, since that hides the row instead of clearing it and leaves it counted as active everywhere else. Happy to switch if you'd rather.

## Verification

- `go test ./internal/session_manager/ ./internal/daemon/... ./internal/service/session/` — 793 passed, including the new `TestReconcileLive_InterruptedSpawnTerminated`
- `go test -race ./internal/session_manager/` — 482 passed
- `golangci-lint v2.12.2 run ./internal/session_manager/...` — 0 issues
- `go build ./...`, `go vet ./internal/session_manager/` — clean

End to end, one daemon built from `main` and one from this branch, against the same throwaway data dir (full repro script in #4079):

```
main @ 3348277, after restart
  POST /api/v1/orchestrators -> {"orchestrator":{"id":"repro-1"}}   dead row handed back

this branch, same data dir
  WARN "reconcile: terminating interrupted spawn with no workspace or runtime" sessionID=repro-1
  POST /api/v1/orchestrators -> {"orchestrator":{"id":"repro-2"}}   real handle, real worktree, live tmux
```

One caveat on the full `npm run lint` gate: `go test ./...` fails here in `adapters/agent/{kilocode,opencode}` (3s auth-probe deadlines, they pass in isolation), `gitdefault`, and `service/project` (git hitting `.git/index: Not a directory` under tmpdirs). All reproduce on a clean `main` on this machine and none are in a package this PR touches.
