### PR TITLE
feat(renderer): add sidebar invite that opens the survey

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -19,9 +19,10 @@ import {
 	Search,
 	Settings,
 	Trash2,
+	X,
 	User,
 } from "lucide-react";
-import { useEffect, useId, useLayoutEffect, useRef, useState, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
+import { useEffect, useId, useLayoutEffect, useRef, useState, useSyncExternalStore, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import type { UpdateStatus } from "../../main/update-settings";
 import {
@@ -44,6 +45,7 @@ import { useTerminateSession } from "../hooks/useTerminateSession";
 import { useResizable } from "../hooks/useResizable";
 import { useShellMaybe } from "../lib/shell-context";
 import { useUpdateStatus } from "../hooks/useUpdateStatus";
+import { dismissInvite, openSurvey, optOutOfInvite, subscribeSurvey, surveyInviteVisible } from "../lib/survey";
 import { effectiveShortcutBindings, shortcutBindingKeys } from "../../shared/shortcuts";
 import {
 	ContextMenu,
@@ -52,6 +54,7 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "./ui/context-menu";
+import { Button } from "./ui/button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -448,6 +451,7 @@ export function Sidebar({
 					className="sidebar-expanded-chrome relative flex w-full min-w-46.5 flex-col gap-0.5 transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0"
 				>
 					<RestartToUpdateRow status={updateStatus} tabIndex={isCollapsed ? -1 : 0} />
+					<SurveyInviteRow tabIndex={isCollapsed ? -1 : 0} updatePending={updateStatus.state === "downloaded"} />
 					<CloudAccountRow tabIndex={isCollapsed ? -1 : 0} />
 					<button
 						aria-label={t("shell.settings")}
@@ -1200,6 +1204,49 @@ function RestartToUpdateRow({ status, tabIndex }: { status: UpdateStatus; tabInd
 				className={cn("h-1.5 w-1.5 shrink-0 rounded-full", escalated ? "bg-working" : "bg-passive")}
 			/>
 		</button>
+	);
+}
+
+// SurveyInviteRow invites the user to a short survey. Modeled on the quiet,
+// dismissible feedback cards apps like Linear and GitHub use: a subtle bordered
+// card with fully readable neutral text, where a single accent button is the
+// only coloured element and the clear click target, so the card gets noticed
+// without shouting. It appears only at eligible, randomized moments
+// (surveyInviteVisible), yields to a pending update so only one prompt shows,
+// and the ✕ opens a small menu: remind me later (48h snooze) or don't show
+// again (retired for good).
+function SurveyInviteRow({ tabIndex, updatePending }: { tabIndex: number; updatePending: boolean }) {
+	const { t } = useTranslation();
+	// Subscribe so dismiss / opt-out / complete hide the card immediately, rather
+	// than lingering until some unrelated sidebar re-render.
+	const visible = useSyncExternalStore(subscribeSurvey, surveyInviteVisible, surveyInviteVisible);
+	if (updatePending || !visible) return null;
+	return (
+		<div className="rounded-lg border border-border bg-card p-2.5">
+			<div className="flex items-start justify-between gap-2">
+				<span className="text-control font-medium text-foreground">{t("survey.inviteTitle")}</span>
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<button
+							aria-label={t("survey.inviteDismiss")}
+							className="-mt-0.5 -mr-1 grid size-5 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground [&_svg]:size-3.5"
+							tabIndex={tabIndex}
+							type="button"
+						>
+							<X aria-hidden="true" />
+						</button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent side="top" align="end" className="min-w-44">
+						<DropdownMenuItem onSelect={() => dismissInvite()}>{t("survey.remindLater")}</DropdownMenuItem>
+						<DropdownMenuItem onSelect={() => optOutOfInvite()}>{t("survey.dontShowAgain")}</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+			<p className="mt-0.5 text-caption text-muted-foreground">{t("survey.inviteSubtitle")}</p>
+			<Button className="mt-2 w-full" onClick={() => openSurvey()} size="sm" tabIndex={tabIndex} variant="primary">
+				{t("survey.inviteCta")}
+			</Button>
+		</div>
 	);
 }
 

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1221,5 +1221,11 @@
 	"survey.back": "Zurück",
 	"survey.skip": "Überspringen",
 	"survey.continue": "Weiter",
-	"survey.finish": "Fertigstellen"
+	"survey.finish": "Fertigstellen",
+	"survey.inviteTitle": "Gestalte AO mit",
+	"survey.inviteSubtitle": "Ein paar kurze Fragen",
+	"survey.inviteCta": "Umfrage starten",
+	"survey.inviteDismiss": "Umfrage-Einladung ausblenden",
+	"survey.remindLater": "Später erinnern",
+	"survey.dontShowAgain": "Nicht mehr anzeigen"
 }

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1203,5 +1203,11 @@
 	"survey.back": "Back",
 	"survey.skip": "Skip",
 	"survey.continue": "Continue",
-	"survey.finish": "Finish"
+	"survey.finish": "Finish",
+	"survey.inviteTitle": "Help shape AO",
+	"survey.inviteSubtitle": "A few quick questions",
+	"survey.inviteCta": "Take survey",
+	"survey.inviteDismiss": "Dismiss survey invite",
+	"survey.remindLater": "Remind me later",
+	"survey.dontShowAgain": "Don't show again"
 }

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1237,5 +1237,11 @@
 	"survey.back": "Atrás",
 	"survey.skip": "Omitir",
 	"survey.continue": "Continuar",
-	"survey.finish": "Finalizar"
+	"survey.finish": "Finalizar",
+	"survey.inviteTitle": "Ayuda a dar forma a AO",
+	"survey.inviteSubtitle": "Unas preguntas rápidas",
+	"survey.inviteCta": "Responder encuesta",
+	"survey.inviteDismiss": "Descartar invitación a la encuesta",
+	"survey.remindLater": "Recordármelo más tarde",
+	"survey.dontShowAgain": "No volver a mostrar"
 }

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1237,5 +1237,11 @@
 	"survey.back": "Retour",
 	"survey.skip": "Ignorer",
 	"survey.continue": "Continuer",
-	"survey.finish": "Terminer"
+	"survey.finish": "Terminer",
+	"survey.inviteTitle": "Façonnez AO",
+	"survey.inviteSubtitle": "Quelques questions rapides",
+	"survey.inviteCta": "Répondre à l'enquête",
+	"survey.inviteDismiss": "Masquer l'invitation à l'enquête",
+	"survey.remindLater": "Me le rappeler plus tard",
+	"survey.dontShowAgain": "Ne plus afficher"
 }

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1221,5 +1221,11 @@
 	"survey.back": "戻る",
 	"survey.skip": "スキップ",
 	"survey.continue": "次へ",
-	"survey.finish": "完了"
+	"survey.finish": "完了",
+	"survey.inviteTitle": "AO づくりに参加",
+	"survey.inviteSubtitle": "簡単な質問がいくつか",
+	"survey.inviteCta": "アンケートに回答",
+	"survey.inviteDismiss": "アンケートの案内を閉じる",
+	"survey.remindLater": "後で通知",
+	"survey.dontShowAgain": "今後表示しない"
 }

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1221,5 +1221,11 @@
 	"survey.back": "뒤로",
 	"survey.skip": "건너뛰기",
 	"survey.continue": "계속",
-	"survey.finish": "완료"
+	"survey.finish": "완료",
+	"survey.inviteTitle": "AO 만들기에 참여",
+	"survey.inviteSubtitle": "짧은 질문 몇 개",
+	"survey.inviteCta": "설문 참여",
+	"survey.inviteDismiss": "설문 안내 닫기",
+	"survey.remindLater": "나중에 알림",
+	"survey.dontShowAgain": "다시 표시하지 않음"
 }

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1237,5 +1237,11 @@
 	"survey.back": "Voltar",
 	"survey.skip": "Pular",
 	"survey.continue": "Continuar",
-	"survey.finish": "Concluir"
+	"survey.finish": "Concluir",
+	"survey.inviteTitle": "Ajude a moldar o AO",
+	"survey.inviteSubtitle": "Algumas perguntas rápidas",
+	"survey.inviteCta": "Responder pesquisa",
+	"survey.inviteDismiss": "Dispensar convite da pesquisa",
+	"survey.remindLater": "Lembrar mais tarde",
+	"survey.dontShowAgain": "Não mostrar novamente"
 }

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1203,5 +1203,11 @@
 	"survey.back": "返回",
 	"survey.skip": "跳过",
 	"survey.continue": "继续",
-	"survey.finish": "完成"
+	"survey.finish": "完成",
+	"survey.inviteTitle": "参与塑造 AO",
+	"survey.inviteSubtitle": "几个简短的问题",
+	"survey.inviteCta": "参与调查",
+	"survey.inviteDismiss": "关闭调查邀请",
+	"survey.remindLater": "稍后提醒",
+	"survey.dontShowAgain": "不再显示"
 }


### PR DESCRIPTION
Adds a "Help shape AO" row to the sidebar footer, styled like the restart-to-update row so it reads as a native part of the app rather than an interruption. Stacked on #4106.

- Shows only at eligible, randomized moments (`surveyInviteVisible`): never after the user has completed the survey, and not within 48 hours of being crossed.
- Yields to a pending update (`updatePending`) so only one footer prompt is ever visible; the two cannot collide.
- Carries a x that snoozes the invite for 48 hours. Structured as a row, not one large button, so the dismiss control is not nested inside another button.
- Clicking the row opens the survey from #4106.

Targets `ao/ao-25/survey` (#4106), not `main`; review that one first.
