### PR TITLE
fix(topbar): stop showing in-review sessions as a breathing 'Working' pill (#2345)

### DIFF
--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -22,7 +22,7 @@ import { addRendererExceptionStep, captureRendererEvent, captureRendererExceptio
 import { useUiStore } from "../stores/ui-store";
 import { OrchestratorIcon } from "./icons";
 import { OrchestratorActivityIndicator } from "./OrchestratorActivityIndicator";
-import { getAgentActivityView } from "../lib/session-presentation";
+import { getAgentActivityView, getSessionStatusPillView } from "../lib/session-presentation";
 import { isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { StatusPill } from "./StatusPill";
 import { TopbarButton, TopbarKillError, topbarHeaderClass, topbarProjectLabelClass } from "./TopbarButton";
@@ -365,7 +365,7 @@ function ProjectTerminationFeedback({ projectId }: { projectId: string | undefin
 	);
 }
 function SessionStatusPill({ session }: { session: WorkspaceSession }) {
-	const { label, tone, breathe } = getAgentActivityView(session.activity);
+	const { label, tone, breathe } = getSessionStatusPillView(session);
 	return (
 		<StatusPill label={label} tone={tone} breathe={breathe} leading="none" className="px-3.5 py-2 text-sm" />
 	);

--- a/frontend/src/renderer/lib/session-presentation.test.ts
+++ b/frontend/src/renderer/lib/session-presentation.test.ts
@@ -4,6 +4,7 @@ import {
 	getAgentActivityView,
 	getAttentionZoneView,
 	getSessionDotView,
+	getSessionStatusPillView,
 	getSessionStatusView,
 	getSessionTimelinePillView,
 	isAgentActivityWorking,
@@ -197,6 +198,48 @@ describe("session presentation", () => {
 			dot: "var(--color-status-in-review)",
 			titleClassName: "text-status-in-review",
 			dotClassName: "bg-status-in-review",
+		});
+	});
+
+	describe("getSessionStatusPillView", () => {
+		it("surfaces raw activity while the agent is not active, ignoring SCM state", () => {
+			expect(
+				getSessionStatusPillView(
+					sessionWith({ activity: { state: "idle", lastActivityAt: "" }, scmStatus: "pr_open" }),
+				),
+			).toMatchObject({ label: "Idle", breathe: false });
+			expect(
+				getSessionStatusPillView(sessionWith({ activity: { state: "waiting_input", lastActivityAt: "" } })),
+			).toMatchObject({ label: "Input Needed", breathe: false });
+		});
+
+		it.each([["pr_open"], ["draft"], ["review_pending"]] as const)(
+			"shows %s as In review instead of a breathing Working",
+			(scmStatus) => {
+				const view = getSessionStatusPillView(
+					sessionWith({ activity: { state: "active", lastActivityAt: "" }, scmStatus }),
+				);
+				expect(view).toMatchObject({ label: "In review", breathe: false });
+			},
+		);
+
+		it("shows Ready to merge for a mergeable active session", () => {
+			const view = getSessionStatusPillView(
+				sessionWith({ activity: { state: "active", lastActivityAt: "" }, scmStatus: "mergeable" }),
+			);
+			expect(view).toMatchObject({ label: "Ready to merge", breathe: false });
+		});
+
+		it("keeps a breathing Working pill for an active session with no SCM state", () => {
+			const view = getSessionStatusPillView(sessionWith({ activity: { state: "active", lastActivityAt: "" } }));
+			expect(view).toMatchObject({ label: "Working", breathe: true });
+		});
+
+		it("derives In review from the compatibility fallback when an older daemon omits scmStatus", () => {
+			const view = getSessionStatusPillView(
+				sessionWith({ activity: { state: "active", lastActivityAt: "" }, prs: [openPr] }),
+			);
+			expect(view).toMatchObject({ label: "In review", breathe: false });
 		});
 	});
 

--- a/frontend/src/renderer/lib/session-presentation.ts
+++ b/frontend/src/renderer/lib/session-presentation.ts
@@ -266,6 +266,36 @@ export function getSessionDotView(session: Pick<WorkspaceSession, "activity" | "
 	};
 }
 
+export type SessionStatusPillView = {
+	label: string;
+	tone: string;
+	breathe: boolean;
+};
+
+// The topbar status pill merges live agent activity with an authoritative SCM
+// state the same way the sidebar dot does (getSessionDotView). While the agent
+// is not active we surface the raw activity state; once active, an open/draft
+// PR or other SCM outcome takes precedence so an in-review session is never
+// shown as a breathing "Working". This keeps the topbar consistent with the
+// board's attention zones and the sidebar dot.
+export function getSessionStatusPillView(
+	session: Pick<WorkspaceSession, "activity" | "scmStatus" | "prs">,
+): SessionStatusPillView {
+	const activity = getAgentActivityView(session.activity);
+	if (activity.state !== "active") {
+		return { label: activity.label, tone: activity.tone, breathe: activity.breathe };
+	}
+
+	const contextStatus = session.scmStatus ?? fallbackSCMStatus(session.prs) ?? "working";
+	const zone = attentionZone(contextStatus);
+	const zoneView = attentionZoneViews[zone];
+	return {
+		label: zoneView.label,
+		tone: zoneView.dot,
+		breathe: zone === "working",
+	};
+}
+
 export type SessionTimelinePillStatus = Extract<SessionStatus, "no_signal" | "ci_failed" | "changes_requested">;
 
 export type SessionTimelinePillView = {


### PR DESCRIPTION
Fixes #2345

## Summary
The topbar status pill (`SessionStatusPill` in `ShellTopbar.tsx`) rendered purely from live agent activity (`getAgentActivityView`) and ignored SCM/PR review state. A session with an open/draft PR that is active (including stale-active) was shown as a breathing orange **Working** pill, while the board files it under **In review** and the sidebar dot already blends the PR context.

This mirrors the established `getSessionDotView` merged model: surface raw activity while the agent is not active; when active, let an authoritative SCM status win through the existing attention-zone taxonomy so in-review sessions show a non-breathing **In review** / **Ready to merge** / **Needs you** instead of a misleading **Working**.

## Changes
- Add `getSessionStatusPillView` in `frontend/src/renderer/lib/session-presentation.ts` (reuses `attentionZone`, `attentionZoneViews`, `fallbackSCMStatus`).
- Point `SessionStatusPill` in `ShellTopbar.tsx` at it.
- Regression tests in `session-presentation.test.ts`.

## Tests
- `npx vitest run src/renderer/lib/session-presentation.test.ts` — 73 passed
- `npx vitest run src/renderer/components/{ShellTopbar,Sidebar,SessionView,SessionsBoard}.test.tsx` — 129 passed
- `npx tsc --noEmit` — clean
