### PR TITLE
fix: detect agent binaries from package manager shims

### DIFF
--- a/backend/internal/adapters/agent/aider/aider.go
+++ b/backend/internal/adapters/agent/aider/aider.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -149,6 +150,14 @@ func ResolveAiderBinary(ctx context.Context) (string, error) {
 				return "", err
 			}
 		}
+		for _, candidate := range binaryutil.WindowsPackageManagerBinCandidates("aider") {
+			if hookutil.IsExecutableFile(candidate) {
+				return candidate, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
 		return "", fmt.Errorf("aider: %w", ports.ErrAgentBinaryNotFound)
 	}
 
@@ -162,6 +171,7 @@ func ResolveAiderBinary(ctx context.Context) (string, error) {
 	}
 	if home, err := os.UserHomeDir(); err == nil {
 		candidates = append([]string{filepath.Join(home, ".local", "bin", "aider")}, candidates...)
+		candidates = append(candidates, binaryutil.UnixPackageManagerBinCandidates(home, "aider")...)
 	}
 
 	for _, candidate := range candidates {

--- a/backend/internal/adapters/agent/binaryutil/binaryutil.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil.go
@@ -116,10 +116,12 @@ func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
 			}
 			candidates = append(candidates, filepath.Join(append([]string{base}, wp.Parts...)...))
 		}
+		candidates = append(candidates, WindowsPackageManagerBinCandidates(executableNames(spec)...)...)
 	} else {
 		candidates = append(candidates, spec.UnixPaths...)
 		if home, err := os.UserHomeDir(); err == nil {
 			candidates = append(candidates, joinAll(home, spec.UnixHomePaths)...)
+			candidates = append(candidates, UnixPackageManagerBinCandidates(home, spec.Names...)...)
 			if spec.NodeManaged {
 				nodeManagerCandidates, err := UnixNodeManagerBinCandidates(ctx, home, spec.Names...)
 				if err != nil {
@@ -140,6 +142,107 @@ func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
 	}
 
 	return "", fmt.Errorf("%s: %w", spec.Label, ports.ErrAgentBinaryNotFound)
+}
+
+// UnixPackageManagerBinCandidates returns cheap, deterministic user-level
+// package-manager shim paths that are commonly absent from GUI-launched PATHs.
+func UnixPackageManagerBinCandidates(home string, names ...string) []string {
+	if home == "" {
+		return nil
+	}
+	out := make([]string, 0, len(names)*7)
+	for _, name := range names {
+		out = append(out,
+			filepath.Join(string(filepath.Separator), "home", "linuxbrew", ".linuxbrew", "bin", name),
+			filepath.Join(string(filepath.Separator), "snap", "bin", name),
+			filepath.Join(home, ".bun", "bin", name),
+			filepath.Join(home, ".yarn", "bin", name),
+			filepath.Join(home, ".config", "yarn", "global", "node_modules", ".bin", name),
+			filepath.Join(home, ".local", "share", "mise", "shims", name),
+			filepath.Join(home, ".asdf", "shims", name),
+		)
+	}
+	return out
+}
+
+// WindowsPackageManagerBinCandidates returns cheap, deterministic user/system
+// package-manager shim paths that are commonly absent from service PATHs.
+func WindowsPackageManagerBinCandidates(names ...string) []string {
+	home, _ := os.UserHomeDir()
+	appData := os.Getenv("APPDATA")
+	localAppData := os.Getenv("LOCALAPPDATA")
+	programData := os.Getenv("ProgramData")
+	if programData == "" {
+		programData = os.Getenv("PROGRAMDATA")
+	}
+	voltaHome := os.Getenv("VOLTA_HOME")
+	nvmSymlink := os.Getenv("NVM_SYMLINK")
+	out := make([]string, 0, len(names)*8)
+	for _, name := range names {
+		if home != "" {
+			out = append(out,
+				filepath.Join(home, "scoop", "shims", name+".exe"),
+				filepath.Join(home, "scoop", "shims", name+".cmd"),
+				filepath.Join(home, ".local", "bin", name+".exe"),
+				filepath.Join(home, ".local", "bin", name+".cmd"),
+			)
+		}
+		if appData != "" {
+			out = append(out,
+				filepath.Join(appData, "npm", name+".cmd"),
+				filepath.Join(appData, "npm", name+".exe"),
+				filepath.Join(appData, "npm", name),
+			)
+		}
+		if programData != "" {
+			out = append(out,
+				filepath.Join(programData, "chocolatey", "bin", name+".exe"),
+				filepath.Join(programData, "chocolatey", "bin", name+".bat"),
+				filepath.Join(programData, "chocolatey", "bin", name+".cmd"),
+			)
+		}
+		if localAppData != "" {
+			out = append(out,
+				filepath.Join(localAppData, "pnpm", name+".cmd"),
+				filepath.Join(localAppData, "pnpm", name+".exe"),
+				filepath.Join(localAppData, "Yarn", "bin", name+".cmd"),
+				filepath.Join(localAppData, "Yarn", "bin", name+".exe"),
+				filepath.Join(localAppData, "Volta", "bin", name+".cmd"),
+				filepath.Join(localAppData, "Volta", "bin", name+".exe"),
+				filepath.Join(localAppData, "mise", "shims", name+".exe"),
+				filepath.Join(localAppData, "mise", "shims", name+".cmd"),
+			)
+		}
+		if voltaHome != "" {
+			out = append(out,
+				filepath.Join(voltaHome, "bin", name+".cmd"),
+				filepath.Join(voltaHome, "bin", name+".exe"),
+			)
+		}
+		if nvmSymlink != "" {
+			out = append(out,
+				filepath.Join(nvmSymlink, name+".cmd"),
+				filepath.Join(nvmSymlink, name+".exe"),
+			)
+		}
+	}
+	return out
+}
+
+func executableNames(spec BinarySpec) []string {
+	if len(spec.Names) > 0 {
+		return spec.Names
+	}
+	out := make([]string, 0, len(spec.WinNames))
+	for _, name := range spec.WinNames {
+		name = strings.TrimSuffix(name, ".exe")
+		name = strings.TrimSuffix(name, ".cmd")
+		name = strings.TrimSuffix(name, ".bat")
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 // joinAll joins each component slice onto base into an absolute candidate path.

--- a/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
@@ -75,6 +75,106 @@ func TestResolveBinaryFallsBackToHomeCandidate(t *testing.T) {
 	}
 }
 
+func TestResolveBinaryFallsBackToUnixPackageManagerCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix package-manager candidate shape")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	bin := filepath.Join(home, ".local", "share", "mise", "shims", "widget")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveBinary(context.Background(), BinarySpec{
+		Label: "widget",
+		Names: []string{"widget"},
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got %q, want %q", got, bin)
+	}
+}
+
+func TestUnixPackageManagerBinCandidates(t *testing.T) {
+	home := filepath.Join(string(filepath.Separator), "Users", "tester")
+	got := UnixPackageManagerBinCandidates(home, "widget")
+	want := []string{
+		filepath.Join(string(filepath.Separator), "home", "linuxbrew", ".linuxbrew", "bin", "widget"),
+		filepath.Join(string(filepath.Separator), "snap", "bin", "widget"),
+		filepath.Join(home, ".bun", "bin", "widget"),
+		filepath.Join(home, ".yarn", "bin", "widget"),
+		filepath.Join(home, ".config", "yarn", "global", "node_modules", ".bin", "widget"),
+		filepath.Join(home, ".local", "share", "mise", "shims", "widget"),
+		filepath.Join(home, ".asdf", "shims", "widget"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestWindowsPackageManagerBinCandidates(t *testing.T) {
+	home := filepath.Join(string(filepath.Separator), "Users", "tester")
+	appData := filepath.Join(home, "AppData", "Roaming")
+	localAppData := filepath.Join(home, "AppData", "Local")
+	programData := filepath.Join(string(filepath.Separator), "ProgramData")
+	voltaHome := filepath.Join(home, "Volta")
+	nvmSymlink := filepath.Join(home, "AppData", "Roaming", "nvm-current")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("APPDATA", appData)
+	t.Setenv("LOCALAPPDATA", localAppData)
+	t.Setenv("ProgramData", programData)
+	t.Setenv("PROGRAMDATA", programData)
+	t.Setenv("VOLTA_HOME", voltaHome)
+	t.Setenv("NVM_SYMLINK", nvmSymlink)
+
+	got := WindowsPackageManagerBinCandidates("widget")
+	want := []string{
+		filepath.Join(home, "scoop", "shims", "widget.exe"),
+		filepath.Join(home, "scoop", "shims", "widget.cmd"),
+		filepath.Join(home, ".local", "bin", "widget.exe"),
+		filepath.Join(home, ".local", "bin", "widget.cmd"),
+		filepath.Join(appData, "npm", "widget.cmd"),
+		filepath.Join(appData, "npm", "widget.exe"),
+		filepath.Join(appData, "npm", "widget"),
+		filepath.Join(programData, "chocolatey", "bin", "widget.exe"),
+		filepath.Join(programData, "chocolatey", "bin", "widget.bat"),
+		filepath.Join(programData, "chocolatey", "bin", "widget.cmd"),
+		filepath.Join(localAppData, "pnpm", "widget.cmd"),
+		filepath.Join(localAppData, "pnpm", "widget.exe"),
+		filepath.Join(localAppData, "Yarn", "bin", "widget.cmd"),
+		filepath.Join(localAppData, "Yarn", "bin", "widget.exe"),
+		filepath.Join(localAppData, "Volta", "bin", "widget.cmd"),
+		filepath.Join(localAppData, "Volta", "bin", "widget.exe"),
+		filepath.Join(localAppData, "mise", "shims", "widget.exe"),
+		filepath.Join(localAppData, "mise", "shims", "widget.cmd"),
+		filepath.Join(voltaHome, "bin", "widget.cmd"),
+		filepath.Join(voltaHome, "bin", "widget.exe"),
+		filepath.Join(nvmSymlink, "widget.cmd"),
+		filepath.Join(nvmSymlink, "widget.exe"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestResolveBinaryFallsBackToNodeManagerCandidate(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix node-manager candidate shape")

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -345,6 +345,7 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 		if home, err := os.UserHomeDir(); err == nil {
 			candidates = append(candidates, filepath.Join(home, ".cargo", "bin", "codex.exe"))
 		}
+		candidates = append(candidates, binaryutil.WindowsPackageManagerBinCandidates("codex")...)
 		for _, candidate := range candidates {
 			if fileExists(candidate) {
 				return resolveNativeWindowsCodex(candidate), nil
@@ -385,6 +386,7 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 			filepath.Join(home, ".local", "bin", "codex"),
 			filepath.Join(home, ".cargo", "bin", "codex"),
 		)
+		candidates = append(candidates, binaryutil.UnixPackageManagerBinCandidates(home, "codex")...)
 		nodeManagerCandidates, err := binaryutil.UnixNodeManagerBinCandidates(ctx, home, "codex")
 		if err != nil {
 			return "", err

--- a/backend/internal/adapters/agent/copilot/copilot.go
+++ b/backend/internal/adapters/agent/copilot/copilot.go
@@ -203,6 +203,7 @@ func ResolveCopilotBinary(ctx context.Context) (string, error) {
 		if home, err := os.UserHomeDir(); err == nil {
 			candidates = append(candidates, filepath.Join(home, ".copilot", "bin", "copilot.exe"))
 		}
+		candidates = append(candidates, binaryutil.WindowsPackageManagerBinCandidates("copilot")...)
 		for _, candidate := range candidates {
 			if hookutil.IsExecutableFile(candidate) {
 				return candidate, nil
@@ -231,6 +232,7 @@ func ResolveCopilotBinary(ctx context.Context) (string, error) {
 			filepath.Join(home, ".copilot", "bin", "copilot"),
 			filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage", "github.copilot-chat", "copilotCli", "copilot"),
 		)
+		candidates = append(candidates, binaryutil.UnixPackageManagerBinCandidates(home, "copilot")...)
 		nodeManagerCandidates, err := binaryutil.UnixNodeManagerBinCandidates(ctx, home, "copilot")
 		if err != nil {
 			return "", err

--- a/backend/internal/adapters/agent/cursor/cursor.go
+++ b/backend/internal/adapters/agent/cursor/cursor.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/pkg/agentruntime"
@@ -164,6 +165,14 @@ func ResolveCursorBinary(ctx context.Context) (string, error) {
 				return "", err
 			}
 		}
+		for _, candidate := range binaryutil.WindowsPackageManagerBinCandidates("cursor-agent") {
+			if hookutil.IsExecutableFile(candidate) {
+				return candidate, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
 		return "", fmt.Errorf("cursor: %w", ports.ErrAgentBinaryNotFound)
 	}
 
@@ -174,6 +183,7 @@ func ResolveCursorBinary(ctx context.Context) (string, error) {
 	candidates := []string{}
 	if home, err := os.UserHomeDir(); err == nil {
 		candidates = append(candidates, filepath.Join(home, ".local", "bin", "cursor-agent"))
+		candidates = append(candidates, binaryutil.UnixPackageManagerBinCandidates(home, "cursor-agent")...)
 	}
 	candidates = append(candidates,
 		"/usr/local/bin/cursor-agent",

--- a/backend/internal/adapters/agent/muse/muse.go
+++ b/backend/internal/adapters/agent/muse/muse.go
@@ -188,6 +188,10 @@ var museBinarySpec = binaryutil.BinarySpec{
 	UnixHomePaths: [][]string{
 		{".local", "bin", "muse"}, // official Meta installer default
 	},
+	WinPaths: []binaryutil.WinPath{
+		{Base: binaryutil.WinAppData, Parts: []string{"npm", "muse.cmd"}},
+		{Base: binaryutil.WinAppData, Parts: []string{"npm", "muse.exe"}},
+	},
 }
 
 // ResolveMuseBinary finds the official Meta Muse Code launcher. The `muse`

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -509,6 +509,10 @@ func ResolveOpenCodeBinary(ctx context.Context) (string, error) {
 				filepath.Join(appData, "npm", "opencode.exe"),
 			)
 		}
+		candidates = append(candidates, binaryutil.WindowsPackageManagerBinCandidates("opencode")...)
+		if home, err := os.UserHomeDir(); err == nil {
+			candidates = append(candidates, filepath.Join(home, ".opencode", "bin", "opencode.exe"))
+		}
 		for _, candidate := range candidates {
 			if hookutil.IsExecutableFile(candidate) {
 				return candidate, nil
@@ -529,6 +533,7 @@ func ResolveOpenCodeBinary(ctx context.Context) (string, error) {
 			filepath.Join(home, ".local", "bin", "opencode"),
 			filepath.Join(home, ".opencode", "bin", "opencode"),
 		)
+		candidates = append(candidates, binaryutil.UnixPackageManagerBinCandidates(home, "opencode")...)
 		nodeManagerCandidates, err := binaryutil.UnixNodeManagerBinCandidates(ctx, home, "opencode")
 		if err != nil {
 			return "", err

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -330,6 +330,18 @@ func TestResolveOpenCodeBinaryFallbacks(t *testing.T) {
 				return writeOpenCodeExecutable(t, filepath.Join(home, ".nvm", "versions", "node", "v22.23.1", "bin", "opencode"))
 			},
 		},
+		{
+			name: "mise shim",
+			seed: func(t *testing.T, home string) string {
+				return writeOpenCodeExecutable(t, filepath.Join(home, ".local", "share", "mise", "shims", "opencode"))
+			},
+		},
+		{
+			name: "bun global",
+			seed: func(t *testing.T, home string) string {
+				return writeOpenCodeExecutable(t, filepath.Join(home, ".bun", "bin", "opencode"))
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- add shared package-manager fallback paths for agent binary resolution across macOS, Linux, and Windows
- cover common Windows shims from npm, Scoop, Chocolatey, pnpm, Yarn, Volta, Mise, and nvm-windows
- extend custom resolvers for OpenCode, Codex, Copilot, Cursor, Aider, and Muse

## Why
Packaged AO can run with a thinner PATH than the user's terminal, so installed agent CLIs may be reported as needs install. This addresses #4067, where OpenCode was installed on Windows but not detected.

## Validation
- go test ./internal/adapters/agent/binaryutil ./internal/adapters/agent/opencode ./internal/adapters/agent/codex ./internal/adapters/agent/copilot ./internal/adapters/agent/cursor ./internal/adapters/agent/aider ./internal/adapters/agent/muse