### PR TITLE
fix(browser): keep fullscreen tabs on right

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -222,6 +222,27 @@ describe("BrowserPanel", () => {
 		expect(input).toHaveValue("http://localhost:4173/");
 	});
 
+	it("keeps the maximized tab rail on the right side of the viewport", () => {
+		window.localStorage.removeItem("ao-browser-tabs-w");
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut session={session} />);
+
+		const viewport = screen.getByTestId("browser-viewport");
+		const rail = screen.getByTestId("browser-tabs-rail");
+		const resizeHandle = screen.getByTestId("browser-tabs-resize-handle");
+		expect(viewport.nextElementSibling).toBe(rail);
+		expect(rail).toHaveClass("border-l");
+		expect(rail).not.toHaveClass("border-r");
+		expect(resizeHandle).toHaveClass("left-0");
+
+		fireEvent.pointerDown(resizeHandle, { clientX: 220 });
+		fireEvent.pointerMove(window, { clientX: 190 });
+		fireEvent.pointerUp(window);
+
+		expect(document.documentElement.style.getPropertyValue("--ao-browser-tabs-w")).toBe("250px");
+		expect(window.localStorage.getItem("ao-browser-tabs-w")).toBe("250");
+		window.localStorage.removeItem("ao-browser-tabs-w");
+	});
+
 	it("threads the session preview URL into the browser view (which drives navigation)", () => {
 		render(
 			<BrowserPanel

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -540,22 +540,6 @@ export function BrowserPanelView({
 				) : null}
 			</form>
 			<div className="browser-panel__body flex min-h-0 flex-1 overflow-hidden">
-				{/* Docked keeps the rail on the right (out of the way of the toolbar/
-				    address bar); popped-out keeps it on the left. */}
-				{poppedOut ? (
-					<BrowserTabsRail
-						activeTabId={activeTabId}
-						onCloseTab={closeTab}
-						onOpenTab={handleOpenTab}
-						onPinnedChange={handlePinnedChange}
-						onReorderTabs={reorderTabs}
-						onSelectTab={handleSelectTab}
-						pinned={pinned}
-						poppedOut={poppedOut}
-						ref={railRef}
-						tabs={tabs}
-					/>
-				) : null}
 				<div
 					className="browser-panel__viewport relative min-h-0 flex-1 overflow-hidden bg-background"
 					data-testid="browser-viewport"
@@ -579,20 +563,20 @@ export function BrowserPanelView({
 						</p>
 					) : null}
 				</div>
-				{!poppedOut ? (
-					<BrowserTabsRail
-						activeTabId={activeTabId}
-						onCloseTab={closeTab}
-						onOpenTab={handleOpenTab}
-						onPinnedChange={handlePinnedChange}
-						onReorderTabs={reorderTabs}
-						onSelectTab={handleSelectTab}
-						pinned={pinned}
-						poppedOut={poppedOut}
-						ref={railRef}
-						tabs={tabs}
-					/>
-				) : null}
+				{/* Keep tabs on the right in both docked and popped-out layouts so
+				    maximizing the browser preserves their spatial origin. */}
+				<BrowserTabsRail
+					activeTabId={activeTabId}
+					onCloseTab={closeTab}
+					onOpenTab={handleOpenTab}
+					onPinnedChange={handlePinnedChange}
+					onReorderTabs={reorderTabs}
+					onSelectTab={handleSelectTab}
+					pinned={pinned}
+					poppedOut={poppedOut}
+					ref={railRef}
+					tabs={tabs}
+				/>
 			</div>
 		</div>
 	);

--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -73,8 +73,8 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 	// Popped-out/fullscreen (which has room to spare) is permanently expanded.
 	// Docked defaults to collapsed (0px, no reserved column) with tab access via
 	// the toolbar's hover trigger; `pinned` restores an always-visible icon rail
-	// for users who want one. Docked sits on the right of the viewport (out of
-	// the way of the address bar); popped-out stays on the left.
+	// for users who want one. Both modes keep tabs on the right of the viewport
+	// so expanding the browser doesn't reverse their position.
 	const expanded = poppedOut;
 	const collapsed = !expanded && !pinned;
 
@@ -84,10 +84,10 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 		defaultWidth: RAIL_DEFAULT_WIDTH,
 		min: RAIL_MIN_WIDTH,
 		max: RAIL_MAX_WIDTH,
-		// The resize handle only ever renders in popped-out mode, which keeps
-		// the rail on the left with the handle on its own right edge — grows
-		// when dragged rightward, away from the viewport.
-		edge: "right",
+		// The resize handle only ever renders in popped-out mode. The rail stays
+		// on the right, so its handle sits on the left edge and grows toward the
+		// viewport when dragged leftward.
+		edge: "left",
 	});
 
 	const clearOpenTimer = useCallback(() => {
@@ -212,7 +212,7 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 		<div
 			className={cn(
 				"browser-tabs-rail relative flex h-full shrink-0 flex-col border-border bg-surface",
-				expanded ? "border-r" : pinned ? "border-l" : "",
+				expanded || pinned ? "border-l" : "",
 				expanded ? "w-(--ao-browser-tabs-w)" : pinned ? "w-8" : "w-0",
 			)}
 			data-testid="browser-tabs-rail"
@@ -296,7 +296,8 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 			</nav>
 			{expanded ? (
 				<div
-					className="absolute inset-y-0 right-0 w-1.5 cursor-col-resize touch-none"
+					className="absolute inset-y-0 left-0 w-1.5 cursor-col-resize touch-none"
+					data-testid="browser-tabs-resize-handle"
 					onDoubleClick={onResizeDoubleClick}
 					onPointerDown={onResizePointerDown}
 				/>


### PR DESCRIPTION
## Summary

- keep the expanded browser tab rail on the right in both docked and fullscreen layouts
- move the fullscreen divider and resize handle to the rail left edge
- add regression coverage for placement and leftward resize behavior

## Testing

- npm test -- src/renderer/components/BrowserPanel.test.tsx
- npm run typecheck
- npm test (191 files passed; 2,515 tests passed; 1 skipped)

## Verification note

Native visual verification was unavailable because another development checkout already held the Electron single-instance profile. That process was left untouched.