### PR TITLE
fix: tighten agent auth probes

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/google/uuid v1.6.0
+	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -65,6 +65,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pressly/goose/v3 v3.27.1 h1:6uEvcprBybDmW4hcz3gYujhARhye+GoWKhEWyzD5sh4=

--- a/backend/internal/adapters/agent/agy/agy_test.go
+++ b/backend/internal/adapters/agent/agy/agy_test.go
@@ -353,7 +353,13 @@ func assertRawJSONEqual(t *testing.T, want, got json.RawMessage) {
 func TestAuthStatus(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", "")
-	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	adcPath := filepath.Join(t.TempDir(), "application-default-credentials.json")
+	if err := os.WriteFile(adcPath, []byte(`{"type":"authorized_user"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// ADC authenticates Google Cloud clients, but is not an Antigravity CLI
+	// credential according to the official auth flow.
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", adcPath)
 	plugin := &Plugin{resolvedBinary: "agy"}
 
 	status, err := plugin.AuthStatus(context.Background())

--- a/backend/internal/adapters/agent/agy/agy_test.go
+++ b/backend/internal/adapters/agent/agy/agy_test.go
@@ -351,14 +351,17 @@ func assertRawJSONEqual(t *testing.T, want, got json.RawMessage) {
 }
 
 func TestAuthStatus(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
 	plugin := &Plugin{resolvedBinary: "agy"}
 
 	status, err := plugin.AuthStatus(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if status != ports.AgentAuthStatusAuthorized {
-		t.Errorf("AuthStatus() = %v, want AgentAuthStatusAuthorized", status)
+	if status != ports.AgentAuthStatusUnknown {
+		t.Errorf("AuthStatus() = %v, want AgentAuthStatusUnknown", status)
 	}
 }
 

--- a/backend/internal/adapters/agent/agy/auth.go
+++ b/backend/internal/adapters/agent/agy/auth.go
@@ -2,9 +2,6 @@ package agy
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -16,33 +13,8 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if _, err := p.ResolveBinary(ctx); err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
-	if agyADCCredentialConfigured() {
-		return ports.AgentAuthStatusAuthorized, nil
-	}
-	// Browser and enterprise logins are held in OS credential stores. AGY does
-	// not document a non-interactive account-status command, so their absence
-	// cannot safely be inferred here.
+	// Antigravity authenticates through its OS keyring and browser sign-in. The
+	// official CLI does not expose a documented non-interactive credential file
+	// or status command, so local auth cannot safely be inferred here.
 	return ports.AgentAuthStatusUnknown, nil
-}
-
-func agyADCCredentialConfigured() bool {
-	if path := strings.TrimSpace(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")); path != "" {
-		return nonEmptyRegularFile(path)
-	}
-	if configHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); configHome != "" {
-		return nonEmptyRegularFile(filepath.Join(configHome, "gcloud", "application_default_credentials.json"))
-	}
-	if appData := strings.TrimSpace(os.Getenv("APPDATA")); appData != "" {
-		return nonEmptyRegularFile(filepath.Join(appData, "gcloud", "application_default_credentials.json"))
-	}
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return false
-	}
-	return nonEmptyRegularFile(filepath.Join(home, ".config", "gcloud", "application_default_credentials.json"))
-}
-
-func nonEmptyRegularFile(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.Mode().IsRegular() && info.Size() > 0
 }

--- a/backend/internal/adapters/agent/agy/auth.go
+++ b/backend/internal/adapters/agent/agy/auth.go
@@ -2,6 +2,9 @@ package agy
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -13,5 +16,33 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if _, err := p.ResolveBinary(ctx); err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
-	return ports.AgentAuthStatusAuthorized, nil
+	if agyADCCredentialConfigured() {
+		return ports.AgentAuthStatusAuthorized, nil
+	}
+	// Browser and enterprise logins are held in OS credential stores. AGY does
+	// not document a non-interactive account-status command, so their absence
+	// cannot safely be inferred here.
+	return ports.AgentAuthStatusUnknown, nil
+}
+
+func agyADCCredentialConfigured() bool {
+	if path := strings.TrimSpace(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")); path != "" {
+		return nonEmptyRegularFile(path)
+	}
+	if configHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); configHome != "" {
+		return nonEmptyRegularFile(filepath.Join(configHome, "gcloud", "application_default_credentials.json"))
+	}
+	if appData := strings.TrimSpace(os.Getenv("APPDATA")); appData != "" {
+		return nonEmptyRegularFile(filepath.Join(appData, "gcloud", "application_default_credentials.json"))
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	return nonEmptyRegularFile(filepath.Join(home, ".config", "gcloud", "application_default_credentials.json"))
+}
+
+func nonEmptyRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular() && info.Size() > 0
 }

--- a/backend/internal/adapters/agent/agy/auth_test.go
+++ b/backend/internal/adapters/agent/agy/auth_test.go
@@ -1,25 +1,4 @@
 package agy
 
-import (
-	"os"
-	"path/filepath"
-	"testing"
-)
-
-func TestAgyADCCredentialConfiguredFromExplicitFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "adc.json")
-	if err := os.WriteFile(path, []byte(`{"type":"authorized_user"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
-	if !agyADCCredentialConfigured() {
-		t.Fatal("expected explicit Application Default Credentials to be detected")
-	}
-}
-
-func TestAgyADCCredentialConfiguredRejectsMissingFile(t *testing.T) {
-	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "missing.json"))
-	if agyADCCredentialConfigured() {
-		t.Fatal("missing Application Default Credentials must not authorize AGY")
-	}
-}
+// Antigravity auth is stored in the OS keyring and intentionally has no
+// filesystem-only probe. AuthStatus behavior is covered by the adapter tests.

--- a/backend/internal/adapters/agent/agy/auth_test.go
+++ b/backend/internal/adapters/agent/agy/auth_test.go
@@ -1,0 +1,25 @@
+package agy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAgyADCCredentialConfiguredFromExplicitFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "adc.json")
+	if err := os.WriteFile(path, []byte(`{"type":"authorized_user"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+	if !agyADCCredentialConfigured() {
+		t.Fatal("expected explicit Application Default Credentials to be detected")
+	}
+}
+
+func TestAgyADCCredentialConfiguredRejectsMissingFile(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "missing.json"))
+	if agyADCCredentialConfigured() {
+		t.Fatal("missing Application Default Credentials must not authorize AGY")
+	}
+}

--- a/backend/internal/adapters/agent/aider/auth.go
+++ b/backend/internal/adapters/agent/aider/auth.go
@@ -106,7 +106,8 @@ func fileContainsAPIKey(text string) bool {
 			continue
 		}
 		lower := strings.ToLower(line)
-		if !strings.Contains(lower, "api") || !strings.Contains(lower, "key") {
+		listEntry := strings.HasPrefix(line, "-") && strings.Contains(line, "=")
+		if !listEntry && (!strings.Contains(lower, "api") || !strings.Contains(lower, "key")) {
 			continue
 		}
 		if valueAfterAssignment(line) != "" {
@@ -125,6 +126,18 @@ func valueAfterAssignment(line string) string {
 		value := strings.Trim(strings.TrimSpace(after), `"'`)
 		if value != "" && !strings.EqualFold(value, "null") && !strings.EqualFold(value, "none") {
 			return value
+		}
+	}
+	// Aider's documented `api-key` YAML option is a list of provider=value
+	// entries (for example `- gemini=...`), so it does not have the word
+	// "key" on the left side of the assignment.
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, "-") {
+		if _, after, ok := strings.Cut(strings.TrimSpace(strings.TrimPrefix(trimmed, "-")), "="); ok {
+			value := strings.Trim(strings.TrimSpace(after), `"'`)
+			if value != "" && !strings.EqualFold(value, "null") && !strings.EqualFold(value, "none") {
+				return value
+			}
 		}
 	}
 	return ""

--- a/backend/internal/adapters/agent/aider/auth_test.go
+++ b/backend/internal/adapters/agent/aider/auth_test.go
@@ -40,6 +40,22 @@ func TestAiderLocalAuthStatusAuthorizedWithConfigFile(t *testing.T) {
 	}
 }
 
+func TestAiderLocalAuthStatusAuthorizedWithDocumentedAPIKeyList(t *testing.T) {
+	clearAiderAuthEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, ".aider.conf.yml"), []byte("api-key:\n  - openrouter=sk-test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, ok, err := aiderLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestAiderLocalAuthStatusAuthorizedWithDotEnv(t *testing.T) {
 	clearAiderAuthEnv(t)
 	home := t.TempDir()

--- a/backend/internal/adapters/agent/amp/auth.go
+++ b/backend/internal/adapters/agent/amp/auth.go
@@ -34,11 +34,51 @@ func ampLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error
 	if strings.TrimSpace(os.Getenv("AMP_API_KEY")) != "" {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
+	if status, ok, err := ampSecretsAuthStatus(ampSecretsPath()); err != nil || ok {
+		return status, ok, err
+	}
 	status, ok, err := ampSettingsAuthStatus(ampSettingsPath())
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	return status, ok, nil
+}
+
+// Amp documents its persisted CLI credentials in ~/.local/share/amp/secrets.json.
+// The schema has changed across CLI releases, so only credential-shaped fields
+// are considered; arbitrary settings in the file must not imply authentication.
+func ampSecretsPath() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".local", "share", "amp", "secrets.json")
+	}
+	return ""
+}
+
+func ampSecretsAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
+	if path == "" {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	var values map[string]any
+	if err := json.Unmarshal(data, &values); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	for key, value := range values {
+		lower := strings.ToLower(key)
+		if !strings.Contains(lower, "token") && !strings.Contains(lower, "secret") && !strings.Contains(lower, "key") {
+			continue
+		}
+		if strings.TrimSpace(stringValue(value)) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+	}
+	return ports.AgentAuthStatusUnknown, true, nil
 }
 
 func ampSettingsPath() string {

--- a/backend/internal/adapters/agent/amp/auth.go
+++ b/backend/internal/adapters/agent/amp/auth.go
@@ -71,12 +71,15 @@ func ampSettingsAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 			if strings.TrimSpace(stringValue(value)) != "" {
 				return ports.AgentAuthStatusAuthorized, true, nil
 			}
-			return ports.AgentAuthStatusUnauthorized, true, nil
+			return ports.AgentAuthStatusUnknown, false, nil
 		}
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }
 
+// ampUsageAuthStatus recognizes Amp's own signed-in account output. It is
+// deliberately authorization-only: a failed or unfamiliar usage command does
+// not prove that an interactive launch cannot authenticate.
 func ampUsageAuthStatus(ctx context.Context, binary string) (ports.AgentAuthStatus, error) {
 	if binary == "" {
 		return ports.AgentAuthStatusUnknown, nil
@@ -86,12 +89,12 @@ func ampUsageAuthStatus(ctx context.Context, binary string) (ports.AgentAuthStat
 
 	out, err := authprobe.CmdRunner(probeCtx, binary, "usage", "--no-color")
 	if probeCtx.Err() != nil {
+		if probeCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+			return ports.AgentAuthStatusUnknown, nil
+		}
 		return ports.AgentAuthStatusUnknown, probeCtx.Err()
 	}
-	if status := authprobe.StatusFromText(string(out)); status != ports.AgentAuthStatusUnknown {
-		return status, nil
-	}
-	if err == nil {
+	if err == nil && strings.Contains(strings.ToLower(string(out)), "signed in as") {
 		return ports.AgentAuthStatusAuthorized, nil
 	}
 	return ports.AgentAuthStatusUnknown, nil

--- a/backend/internal/adapters/agent/amp/auth_test.go
+++ b/backend/internal/adapters/agent/amp/auth_test.go
@@ -39,7 +39,7 @@ func TestAmpSettingsAuthStatusAuthorizedWithAPIKey(t *testing.T) {
 	}
 }
 
-func TestAmpSettingsAuthStatusUnauthorizedWithEmptyAPIKey(t *testing.T) {
+func TestAmpSettingsAuthStatusUnknownWithEmptyAPIKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	if err := os.WriteFile(path, []byte(`{"amp.apiKey":""}`), 0o600); err != nil {
 		t.Fatal(err)
@@ -49,19 +49,19 @@ func TestAmpSettingsAuthStatusUnauthorizedWithEmptyAPIKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 
-func TestAmpUsageAuthStatusAuthorizedOnSuccessfulUsage(t *testing.T) {
+func TestAmpUsageAuthStatusAuthorizedWhenSignedIn(t *testing.T) {
 	t.Setenv("AMP_API_KEY", "")
 	t.Setenv("AMP_SETTINGS_FILE", filepath.Join(t.TempDir(), "missing-settings.json"))
-	restore := mockAuthProbeRunner(t, func(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	restore := mockAmpAuthProbeRunner(t, func(_ context.Context, name string, arg ...string) ([]byte, error) {
 		if name != "amp" || !reflect.DeepEqual(arg, []string{"usage", "--no-color"}) {
 			t.Fatalf("command = %s %#v, want amp usage --no-color", name, arg)
 		}
-		return []byte("Credits remaining: 100"), nil
+		return []byte("Signed in as agentsubs@pkarnal.com\nIndividual credits: -$0.07 remaining"), nil
 	})
 	defer restore()
 
@@ -74,24 +74,22 @@ func TestAmpUsageAuthStatusAuthorizedOnSuccessfulUsage(t *testing.T) {
 	}
 }
 
-func TestAmpUsageAuthStatusUnauthorizedFromUsageOutput(t *testing.T) {
-	t.Setenv("AMP_API_KEY", "")
-	t.Setenv("AMP_SETTINGS_FILE", filepath.Join(t.TempDir(), "missing-settings.json"))
-	restore := mockAuthProbeRunner(t, func(ctx context.Context, name string, arg ...string) ([]byte, error) {
+func TestAmpUsageAuthStatusUnknownWhenNotConfirmed(t *testing.T) {
+	restore := mockAmpAuthProbeRunner(t, func(context.Context, string, ...string) ([]byte, error) {
 		return []byte("login required"), errors.New("exit status 1")
 	})
 	defer restore()
 
-	got, err := (&Plugin{resolvedBinary: "amp"}).AuthStatus(context.Background())
+	got, err := ampUsageAuthStatus(context.Background(), "amp")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("AuthStatus = %q, want %q", got, ports.AgentAuthStatusUnauthorized)
+	if got != ports.AgentAuthStatusUnknown {
+		t.Fatalf("AuthStatus = %q, want %q", got, ports.AgentAuthStatusUnknown)
 	}
 }
 
-func mockAuthProbeRunner(t *testing.T, runner func(context.Context, string, ...string) ([]byte, error)) func() {
+func mockAmpAuthProbeRunner(t *testing.T, runner func(context.Context, string, ...string) ([]byte, error)) func() {
 	t.Helper()
 	previous := authprobe.CmdRunner
 	authprobe.CmdRunner = runner

--- a/backend/internal/adapters/agent/amp/auth_test.go
+++ b/backend/internal/adapters/agent/amp/auth_test.go
@@ -39,6 +39,17 @@ func TestAmpSettingsAuthStatusAuthorizedWithAPIKey(t *testing.T) {
 	}
 }
 
+func TestAmpSecretsAuthStatusAuthorizedWithDocumentedSecretsFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	if err := os.WriteFile(path, []byte(`{"accessToken":"amp-token"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, ok, err := ampSecretsAuthStatus(path)
+	if err != nil || !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v, %v), want (authorized, true, nil)", status, ok, err)
+	}
+}
+
 func TestAmpSettingsAuthStatusUnknownWithEmptyAPIKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	if err := os.WriteFile(path, []byte(`{"amp.apiKey":""}`), 0o600); err != nil {

--- a/backend/internal/adapters/agent/auggie/auth.go
+++ b/backend/internal/adapters/agent/auggie/auth.go
@@ -2,9 +2,7 @@ package auggie
 
 import (
 	"context"
-	"time"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -12,29 +10,9 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
-	}
-	return auggieAccountAuthStatus(ctx, binary)
-}
-
-func auggieAccountAuthStatus(ctx context.Context, binary string) (ports.AgentAuthStatus, error) {
-	if binary == "" {
-		return ports.AgentAuthStatusUnknown, nil
-	}
-	probeCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
-	defer cancel()
-
-	out, err := authprobe.CmdRunner(probeCtx, binary, "account", "status")
-	if probeCtx.Err() != nil {
-		return ports.AgentAuthStatusUnknown, probeCtx.Err()
-	}
-	if status := authprobe.StatusFromText(string(out)); status != ports.AgentAuthStatusUnknown {
-		return status, nil
-	}
-	if err == nil {
-		return ports.AgentAuthStatusAuthorized, nil
 	}
 	return ports.AgentAuthStatusUnknown, nil
 }

--- a/backend/internal/adapters/agent/auggie/auth.go
+++ b/backend/internal/adapters/agent/auggie/auth.go
@@ -2,6 +2,10 @@ package auggie
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -14,5 +18,71 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
+	if status, ok, err := auggieLocalAuthStatus(ctx); err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	} else if ok {
+		return status, nil
+	}
 	return ports.AgentAuthStatusUnknown, nil
+}
+
+func auggieLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if strings.TrimSpace(os.Getenv("AUGMENT_SESSION_AUTH")) != "" {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	return auggieSessionAuthStatus(filepath.Join(home, ".augment", "session.json"))
+}
+
+// auggieSessionAuthStatus checks Auggie's documented login session file
+// without exposing its contents. The session is JSON and must contain a
+// non-empty token value to count as local authorization evidence.
+func auggieSessionAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	var session any
+	if err := json.Unmarshal(data, &session); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if auggieSessionHasToken(session) {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func auggieSessionHasToken(value any) bool {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			if (strings.EqualFold(key, "token") || strings.EqualFold(key, "accessToken") || strings.EqualFold(key, "access_token")) && stringSetting(child) != "" {
+				return true
+			}
+			if auggieSessionHasToken(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if auggieSessionHasToken(child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func stringSetting(value any) string {
+	text, _ := value.(string)
+	return strings.TrimSpace(text)
 }

--- a/backend/internal/adapters/agent/auggie/auth_test.go
+++ b/backend/internal/adapters/agent/auggie/auth_test.go
@@ -2,53 +2,17 @@ package auggie
 
 import (
 	"context"
-	"errors"
-	"reflect"
 	"testing"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestAuthStatusUsesAuggieAccountStatus(t *testing.T) {
-	restore := stubAuggieAuthRunner(t, func(_ context.Context, name string, arg ...string) ([]byte, error) {
-		if name != "auggie" {
-			t.Fatalf("binary = %q, want auggie", name)
-		}
-		if !reflect.DeepEqual(arg, []string{"account", "status"}) {
-			t.Fatalf("args = %#v, want [account status]", arg)
-		}
-		return []byte("Credits remaining: 42\n"), nil
-	})
-	defer restore()
-
+func TestAuthStatusIsUnknownWithoutDocumentedStatusProbe(t *testing.T) {
 	status, err := (&Plugin{resolvedBinary: "auggie"}).AuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	if status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusUnknown)
 	}
-}
-
-func TestAuthStatusUnauthorizedFromAuggieAccountStatus(t *testing.T) {
-	restore := stubAuggieAuthRunner(t, func(context.Context, string, ...string) ([]byte, error) {
-		return []byte("You are not currently logged in to Augment.\nRun 'auggie login' to authenticate first.\n"), errors.New("exit status 1")
-	})
-	defer restore()
-
-	status, err := (&Plugin{resolvedBinary: "auggie"}).AuthStatus(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusUnauthorized)
-	}
-}
-
-func stubAuggieAuthRunner(t *testing.T, runner func(context.Context, string, ...string) ([]byte, error)) func() {
-	t.Helper()
-	previous := authprobe.CmdRunner
-	authprobe.CmdRunner = runner
-	return func() { authprobe.CmdRunner = previous }
 }

--- a/backend/internal/adapters/agent/auggie/auth_test.go
+++ b/backend/internal/adapters/agent/auggie/auth_test.go
@@ -2,17 +2,49 @@ package auggie
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestAuthStatusIsUnknownWithoutDocumentedStatusProbe(t *testing.T) {
+func TestAuthStatusIsUnknownWithoutLocalEvidence(t *testing.T) {
+	t.Setenv("AUGMENT_SESSION_AUTH", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
 	status, err := (&Plugin{resolvedBinary: "auggie"}).AuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if status != ports.AgentAuthStatusUnknown {
 		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestAuggieLocalAuthStatusAuthorizedWithSessionEnv(t *testing.T) {
+	t.Setenv("AUGMENT_SESSION_AUTH", `{"token":"session-token"}`)
+
+	status, ok, err := auggieLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestAuggieSessionAuthStatusAuthorizedWithStoredSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(path, []byte(`{"accessToken":"session-token"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := auggieSessionAuthStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
 	}
 }

--- a/backend/internal/adapters/agent/authprobe/authprobe.go
+++ b/backend/internal/adapters/agent/authprobe/authprobe.go
@@ -9,15 +9,6 @@ import (
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
-// DefaultCommands are cheap local auth/status probes common across agent CLIs.
-// Unsupported commands usually exit quickly with help text and are treated as
-// unknown rather than unauthorized.
-var DefaultCommands = [][]string{
-	{"auth", "status"},
-	{"login", "status"},
-	{"providers", "list"},
-}
-
 // CmdRunner runs the command and returns the combined stdout/stderr.
 // It is exposed as a package variable to allow mocking in tests.
 var CmdRunner = func(ctx context.Context, name string, arg ...string) ([]byte, error) {
@@ -25,6 +16,8 @@ var CmdRunner = func(ctx context.Context, name string, arg ...string) ([]byte, e
 }
 
 // CLIStatus runs bounded local CLI probes and classifies their output.
+// Callers must pass adapter-specific commands; catalog refresh should not run
+// a generic sequence of auth-like commands against every installed binary.
 func CLIStatus(ctx context.Context, binary string, commands [][]string) (ports.AgentAuthStatus, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, err
@@ -33,7 +26,7 @@ func CLIStatus(ctx context.Context, binary string, commands [][]string) (ports.A
 		return ports.AgentAuthStatusUnknown, nil
 	}
 	if len(commands) == 0 {
-		commands = DefaultCommands
+		return ports.AgentAuthStatusUnknown, nil
 	}
 	for _, args := range commands {
 		status, err := commandStatus(ctx, binary, args)
@@ -53,6 +46,9 @@ func commandStatus(ctx context.Context, binary string, args []string) (ports.Age
 
 	out, err := CmdRunner(probeCtx, binary, args...)
 	if probeCtx.Err() != nil {
+		if probeCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+			return ports.AgentAuthStatusUnknown, nil
+		}
 		return ports.AgentAuthStatusUnknown, probeCtx.Err()
 	}
 	status := StatusFromText(string(out))

--- a/backend/internal/adapters/agent/authprobe/authprobe_test.go
+++ b/backend/internal/adapters/agent/authprobe/authprobe_test.go
@@ -49,7 +49,7 @@ func TestCLIStatus_Mocked(t *testing.T) {
 				return []byte(tt.mockOutput), tt.mockError
 			}
 
-			status, err := CLIStatus(context.Background(), "mockbinary", nil)
+			status, err := CLIStatus(context.Background(), "mockbinary", [][]string{{"auth", "status"}})
 			if (err != nil) != tt.wantError {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -57,6 +57,44 @@ func TestCLIStatus_Mocked(t *testing.T) {
 				t.Errorf("CLIStatus() = %v, want %v", status, tt.wantStatus)
 			}
 		})
+	}
+}
+
+func TestCLIStatusRequiresExplicitCommands(t *testing.T) {
+	oldCmdRunner := CmdRunner
+	defer func() { CmdRunner = oldCmdRunner }()
+	called := false
+	CmdRunner = func(ctx context.Context, name string, arg ...string) ([]byte, error) {
+		called = true
+		return []byte("authenticated"), nil
+	}
+
+	status, err := CLIStatus(context.Background(), "mockbinary", nil)
+	if err != nil {
+		t.Fatalf("CLIStatus: %v", err)
+	}
+	if status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusUnknown)
+	}
+	if called {
+		t.Fatal("CLIStatus ran a command without explicit adapter commands")
+	}
+}
+
+func TestCLIStatusTimeoutDegradesToUnknown(t *testing.T) {
+	oldCmdRunner := CmdRunner
+	defer func() { CmdRunner = oldCmdRunner }()
+	CmdRunner = func(ctx context.Context, name string, arg ...string) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	status, err := CLIStatus(context.Background(), "mockbinary", [][]string{{"auth", "status"}})
+	if err != nil {
+		t.Fatalf("CLIStatus: %v", err)
+	}
+	if status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/autohand/auth.go
+++ b/backend/internal/adapters/agent/autohand/auth.go
@@ -70,12 +70,16 @@ func autohandCloudAuthReady(config map[string]json.RawMessage) (ready, known boo
 		return false, false
 	}
 	var auth struct {
-		Token string `json:"token"`
+		Token        string `json:"token"`
+		APIKeyHelper string `json:"apiKeyHelper"`
 	}
 	if err := json.Unmarshal(authRaw, &auth); err != nil {
 		return false, false
 	}
-	return usableSecret(auth.Token), true
+	// apiKeyHelper is a documented command which Autohand invokes to obtain an
+	// API key. Its configured presence is credential evidence, although AO does
+	// not execute arbitrary user commands merely to answer an advisory probe.
+	return usableSecret(auth.Token) || strings.TrimSpace(auth.APIKeyHelper) != "", true
 }
 
 func usableSecret(value string) bool {

--- a/backend/internal/adapters/agent/autohand/auth.go
+++ b/backend/internal/adapters/agent/autohand/auth.go
@@ -77,9 +77,10 @@ func autohandCloudAuthReady(config map[string]json.RawMessage) (ready, known boo
 		return false, false
 	}
 	// apiKeyHelper is a documented command which Autohand invokes to obtain an
-	// API key. Its configured presence is credential evidence, although AO does
-	// not execute arbitrary user commands merely to answer an advisory probe.
-	return usableSecret(auth.Token) || strings.TrimSpace(auth.APIKeyHelper) != "", true
+	// API key. Its presence alone does not prove the command still exists or
+	// yields a usable key, and AO must not execute arbitrary user commands for
+	// an advisory probe.
+	return usableSecret(auth.Token), true
 }
 
 func usableSecret(value string) bool {

--- a/backend/internal/adapters/agent/autohand/auth.go
+++ b/backend/internal/adapters/agent/autohand/auth.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -18,8 +17,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
-	binary, err := p.ResolveBinary(ctx)
-	if err != nil {
+	if _, err := p.ResolveBinary(ctx); err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
 	for _, name := range []string{
@@ -34,7 +32,9 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if err != nil || status != ports.AgentAuthStatusUnknown {
 		return status, err
 	}
-	return authprobe.CLIStatus(ctx, binary, [][]string{{"auth", "status"}})
+	// The documented CLI flow prompts for browser sign-in on first use; it does
+	// not expose a stable non-interactive `auth status` command.
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 func autohandConfigAuthStatus(configPath string) (ports.AgentAuthStatus, error) {

--- a/backend/internal/adapters/agent/autohand/auth.go
+++ b/backend/internal/adapters/agent/autohand/auth.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -17,7 +18,23 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
-	return autohandConfigAuthStatus(autohandConfigPath())
+	binary, err := p.ResolveBinary(ctx)
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	}
+	for _, name := range []string{
+		"AUTOHAND_API_KEY", "AUTOHAND_AUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+		"GOOGLE_API_KEY", "OPENROUTER_API_KEY", "MISTRAL_API_KEY", "GROQ_API_KEY",
+	} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return ports.AgentAuthStatusAuthorized, nil
+		}
+	}
+	status, err := autohandConfigAuthStatus(autohandConfigPath())
+	if err != nil || status != ports.AgentAuthStatusUnknown {
+		return status, err
+	}
+	return authprobe.CLIStatus(ctx, binary, [][]string{{"auth", "status"}})
 }
 
 func autohandConfigAuthStatus(configPath string) (ports.AgentAuthStatus, error) {

--- a/backend/internal/adapters/agent/autohand/auth.go
+++ b/backend/internal/adapters/agent/autohand/auth.go
@@ -42,7 +42,7 @@ func autohandConfigAuthStatus(configPath string) (ports.AgentAuthStatus, error) 
 		return ports.AgentAuthStatusAuthorized, nil
 	}
 	if authKnown {
-		return ports.AgentAuthStatusUnauthorized, nil
+		return ports.AgentAuthStatusUnknown, nil
 	}
 	return ports.AgentAuthStatusUnknown, nil
 }

--- a/backend/internal/adapters/agent/autohand/auth_test.go
+++ b/backend/internal/adapters/agent/autohand/auth_test.go
@@ -1,12 +1,42 @@
 package autohand
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
+
+func TestAutohandAuthStatusUsesDocumentedStatusCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AUTOHAND_CONFIG", "")
+	for _, name := range []string{
+		"AUTOHAND_API_KEY", "AUTOHAND_AUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY",
+		"GEMINI_API_KEY", "GOOGLE_API_KEY", "OPENROUTER_API_KEY", "MISTRAL_API_KEY", "GROQ_API_KEY",
+	} {
+		t.Setenv(name, "")
+	}
+	previous := authprobe.CmdRunner
+	authprobe.CmdRunner = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "autohand" || !reflect.DeepEqual(args, []string{"auth", "status"}) {
+			t.Fatalf("command = %s %#v, want autohand auth status", name, args)
+		}
+		return []byte("Authenticated as agent@example.com"), nil
+	}
+	defer func() { authprobe.CmdRunner = previous }()
+
+	status, err := (&Plugin{resolvedBinary: "autohand"}).AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	}
+}
 
 func TestAutohandConfigAuthStatusAuthorized(t *testing.T) {
 	path := writeAutohandAuthConfig(t, `{

--- a/backend/internal/adapters/agent/autohand/auth_test.go
+++ b/backend/internal/adapters/agent/autohand/auth_test.go
@@ -27,11 +27,38 @@ func TestAutohandAuthStatusUnknownWithoutDocumentedLocalCredential(t *testing.T)
 	}
 }
 
+func TestAutohandAuthStatusUsesAUTOHAND_CONFIG(t *testing.T) {
+	t.Setenv("AUTOHAND_CONFIG", writeAutohandAuthConfig(t, `{
+  "auth": {"apiKeyHelper": "read-autohand-key"}
+}`))
+	status, err := (&Plugin{resolvedBinary: "autohand"}).AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestAutohandConfigAuthStatusAuthorized(t *testing.T) {
 	path := writeAutohandAuthConfig(t, `{
   "auth": {"token": "session-token", "user": {"email": "agent@example.com"}},
   "provider": "zai",
   "zai": {"apiKey": "real-provider-key", "model": "glm-5.1"}
+}`)
+
+	got, err := autohandConfigAuthStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = %q, want %q", got, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestAutohandConfigAuthStatusAuthorizedWithAPIKeyHelper(t *testing.T) {
+	path := writeAutohandAuthConfig(t, `{
+  "auth": {"apiKeyHelper": "security find-generic-password -w -s autohand"}
 }`)
 
 	got, err := autohandConfigAuthStatus(path)

--- a/backend/internal/adapters/agent/autohand/auth_test.go
+++ b/backend/internal/adapters/agent/autohand/auth_test.go
@@ -24,7 +24,7 @@ func TestAutohandConfigAuthStatusAuthorized(t *testing.T) {
 	}
 }
 
-func TestAutohandConfigAuthStatusUnauthorizedWithMissingCloudToken(t *testing.T) {
+func TestAutohandConfigAuthStatusUnknownWithMissingCloudToken(t *testing.T) {
 	path := writeAutohandAuthConfig(t, `{
   "auth": {"token": ""},
   "provider": "zai",
@@ -35,8 +35,8 @@ func TestAutohandConfigAuthStatusUnauthorizedWithMissingCloudToken(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = %q, want %q", got, ports.AgentAuthStatusUnauthorized)
+	if got != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = %q, want %q", got, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/autohand/auth_test.go
+++ b/backend/internal/adapters/agent/autohand/auth_test.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestAutohandAuthStatusUsesDocumentedStatusCommand(t *testing.T) {
+func TestAutohandAuthStatusUnknownWithoutDocumentedLocalCredential(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("AUTOHAND_CONFIG", "")
 	for _, name := range []string{
@@ -20,21 +18,12 @@ func TestAutohandAuthStatusUsesDocumentedStatusCommand(t *testing.T) {
 	} {
 		t.Setenv(name, "")
 	}
-	previous := authprobe.CmdRunner
-	authprobe.CmdRunner = func(_ context.Context, name string, args ...string) ([]byte, error) {
-		if name != "autohand" || !reflect.DeepEqual(args, []string{"auth", "status"}) {
-			t.Fatalf("command = %s %#v, want autohand auth status", name, args)
-		}
-		return []byte("Authenticated as agent@example.com"), nil
-	}
-	defer func() { authprobe.CmdRunner = previous }()
-
 	status, err := (&Plugin{resolvedBinary: "autohand"}).AuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	if status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/autohand/auth_test.go
+++ b/backend/internal/adapters/agent/autohand/auth_test.go
@@ -29,7 +29,7 @@ func TestAutohandAuthStatusUnknownWithoutDocumentedLocalCredential(t *testing.T)
 
 func TestAutohandAuthStatusUsesAUTOHAND_CONFIG(t *testing.T) {
 	t.Setenv("AUTOHAND_CONFIG", writeAutohandAuthConfig(t, `{
-  "auth": {"apiKeyHelper": "read-autohand-key"}
+  "auth": {"token": "session-token"}
 }`))
 	status, err := (&Plugin{resolvedBinary: "autohand"}).AuthStatus(context.Background())
 	if err != nil {
@@ -56,7 +56,7 @@ func TestAutohandConfigAuthStatusAuthorized(t *testing.T) {
 	}
 }
 
-func TestAutohandConfigAuthStatusAuthorizedWithAPIKeyHelper(t *testing.T) {
+func TestAutohandConfigAuthStatusUnknownWithAPIKeyHelper(t *testing.T) {
 	path := writeAutohandAuthConfig(t, `{
   "auth": {"apiKeyHelper": "security find-generic-password -w -s autohand"}
 }`)
@@ -65,8 +65,8 @@ func TestAutohandConfigAuthStatusAuthorizedWithAPIKeyHelper(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = %q, want %q", got, ports.AgentAuthStatusAuthorized)
+	if got != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = %q, want %q", got, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -406,8 +406,10 @@ func claudeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, er
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) != "" {
-		return ports.AgentAuthStatusAuthorized, true, nil
+	for _, name := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
 	}
 	cfgPath, err := claudeConfigPath()
 	if err != nil {

--- a/backend/internal/adapters/agent/cline/auth.go
+++ b/backend/internal/adapters/agent/cline/auth.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -16,7 +15,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -25,7 +24,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 type clineProvidersFile struct {
@@ -70,7 +69,7 @@ func clineProviderAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, 
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	if strings.TrimSpace(string(data)) == "" {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 
 	var file clineProvidersFile
@@ -78,14 +77,14 @@ func clineProviderAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, 
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	if len(file.Providers) == 0 {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 
 	if provider, ok := configuredClineProvider(file); ok {
 		if providerAuthorized(provider.Settings) {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/cline/auth.go
+++ b/backend/internal/adapters/agent/cline/auth.go
@@ -19,6 +19,9 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
+	if strings.TrimSpace(os.Getenv("CLINE_API_KEY")) != "" {
+		return ports.AgentAuthStatusAuthorized, nil
+	}
 	if status, ok, err := clineProviderAuthStatus(ctx); err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	} else if ok {

--- a/backend/internal/adapters/agent/cline/auth_test.go
+++ b/backend/internal/adapters/agent/cline/auth_test.go
@@ -61,6 +61,17 @@ func TestClineProviderAuthStatusAuthorizedWithAPIKey(t *testing.T) {
 	}
 }
 
+func TestClineAuthStatusAuthorizedWithDocumentedEnvKey(t *testing.T) {
+	t.Setenv("CLINE_API_KEY", "cline-key")
+	status, err := (&Plugin{resolvedBinary: "cline"}).AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestClineProviderAuthStatusUnknownWithExpiredOAuth(t *testing.T) {
 	writeClineProvidersFile(t, `{
 		"version": 1,

--- a/backend/internal/adapters/agent/cline/auth_test.go
+++ b/backend/internal/adapters/agent/cline/auth_test.go
@@ -61,7 +61,7 @@ func TestClineProviderAuthStatusAuthorizedWithAPIKey(t *testing.T) {
 	}
 }
 
-func TestClineProviderAuthStatusUnauthorizedWithExpiredOAuth(t *testing.T) {
+func TestClineProviderAuthStatusUnknownWithExpiredOAuth(t *testing.T) {
 	writeClineProvidersFile(t, `{
 		"version": 1,
 		"lastUsedProvider": "cline",
@@ -82,8 +82,8 @@ func TestClineProviderAuthStatusUnauthorizedWithExpiredOAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/continueagent/auth.go
+++ b/backend/internal/adapters/agent/continueagent/auth.go
@@ -2,6 +2,7 @@ package continueagent
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,12 +12,40 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
+var _ ports.AgentAuthChecker = (*Plugin)(nil)
+
+// AuthStatus reports Continue credentials that can be checked without sending
+// a model prompt. Continue has no non-interactive status command.
+func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
+	if _, err := p.ResolveBinary(ctx); err != nil {
+		if errors.Is(err, ports.ErrAgentBinaryNotFound) {
+			return ports.AgentAuthStatusUnknown, nil
+		}
+		return ports.AgentAuthStatusUnknown, err
+	}
+	status, ok, err := continueLocalAuthStatus(ctx)
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	}
+	if ok {
+		return status, nil
+	}
+	return ports.AgentAuthStatusUnknown, nil
+}
+
+var continueAPIKeyEnvVars = []string{
+	"CONTINUE_API_KEY",
+	"ANTHROPIC_API_KEY",
+}
+
 func continueLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	if strings.TrimSpace(os.Getenv("CONTINUE_API_KEY")) != "" {
-		return ports.AgentAuthStatusAuthorized, true, nil
+	for _, name := range continueAPIKeyEnvVars {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
 	}
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
 		status, ok, err := continueConfigAuthStatus(filepath.Join(home, ".continue", "config.yaml"))

--- a/backend/internal/adapters/agent/continueagent/auth.go
+++ b/backend/internal/adapters/agent/continueagent/auth.go
@@ -93,7 +93,7 @@ func continueConfigHasCredential(node *yaml.Node) bool {
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := strings.ToLower(strings.TrimSpace(node.Content[i].Value))
 			value := strings.Trim(strings.TrimSpace(node.Content[i+1].Value), `"'`)
-			if (strings.Contains(key, "apikey") || strings.Contains(key, "api_key") || strings.Contains(key, "token")) &&
+			if continueConfigKeyIsCredential(key) &&
 				value != "" &&
 				!strings.EqualFold(value, "null") &&
 				!strings.EqualFold(value, "none") {
@@ -105,4 +105,9 @@ func continueConfigHasCredential(node *yaml.Node) bool {
 		}
 	}
 	return false
+}
+
+func continueConfigKeyIsCredential(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	return key == "apikey" || key == "api_key" || strings.HasSuffix(key, "token")
 }

--- a/backend/internal/adapters/agent/continueagent/auth_test.go
+++ b/backend/internal/adapters/agent/continueagent/auth_test.go
@@ -22,7 +22,9 @@ func TestContinueLocalAuthStatusAuthorizedFromEnv(t *testing.T) {
 }
 
 func TestContinueLocalAuthStatusUnknownWithoutEnv(t *testing.T) {
-	t.Setenv("CONTINUE_API_KEY", "")
+	for _, name := range continueAPIKeyEnvVars {
+		t.Setenv(name, "")
+	}
 	t.Setenv("HOME", t.TempDir())
 
 	status, ok, err := continueLocalAuthStatus(context.Background())

--- a/backend/internal/adapters/agent/continueagent/auth_test.go
+++ b/backend/internal/adapters/agent/continueagent/auth_test.go
@@ -50,3 +50,19 @@ func TestContinueConfigAuthStatusAuthorizedWithAPIKey(t *testing.T) {
 		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
 	}
 }
+
+func TestContinueConfigAuthStatusUnknownWithOnlyTokenLimits(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	config := "models:\n  - provider: anthropic\n    defaultCompletionOptions:\n      maxTokens: 1500\n"
+	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := continueConfigAuthStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}

--- a/backend/internal/adapters/agent/continueagent/continueagent_test.go
+++ b/backend/internal/adapters/agent/continueagent/continueagent_test.go
@@ -30,9 +30,9 @@ func TestManifest(t *testing.T) {
 	}
 }
 
-func TestDoesNotImplementAuthChecker(t *testing.T) {
-	if _, ok := any(&Plugin{}).(ports.AgentAuthChecker); ok {
-		t.Fatal("Continue must not implement AgentAuthChecker; catalog refresh must not run model-call auth probes")
+func TestImplementsAuthChecker(t *testing.T) {
+	if _, ok := any(&Plugin{}).(ports.AgentAuthChecker); !ok {
+		t.Fatal("Continue must implement AgentAuthChecker using local credential evidence")
 	}
 }
 

--- a/backend/internal/adapters/agent/copilot/auth.go
+++ b/backend/internal/adapters/agent/copilot/auth.go
@@ -2,6 +2,7 @@ package copilot
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +38,7 @@ func copilotLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, e
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	for _, name := range copilotTokenEnvVars {
-		if strings.TrimSpace(os.Getenv(name)) != "" {
+		if copilotUsableToken(os.Getenv(name)) {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
@@ -56,9 +57,6 @@ func copilotLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, e
 	if configOK {
 		return configStatus, true, nil
 	}
-	if status, ok, err := copilotSessionStateAuthStatus(ctx, filepath.Join(home, ".copilot", "session-state")); err != nil || ok {
-		return status, ok, err
-	}
 	if status, ok, err := copilotGHAuthStatus(ctx); err != nil || ok {
 		return status, ok, err
 	}
@@ -73,46 +71,23 @@ func copilotConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	text := strings.TrimSpace(string(data))
-	if text == "" {
+	if strings.TrimSpace(string(data)) == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	if textContainsTokenAssignment(text) {
-		return ports.AgentAuthStatusAuthorized, true, nil
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(data, &config); err != nil {
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	return ports.AgentAuthStatusUnknown, false, nil
-}
-
-func copilotSessionStateAuthStatus(ctx context.Context, dir string) (ports.AgentAuthStatus, bool, error) {
-	if err := ctx.Err(); err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	paths, err := filepath.Glob(filepath.Join(dir, "*", "events.jsonl"))
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	for _, path := range paths {
-		if err := ctx.Err(); err != nil {
-			return ports.AgentAuthStatusUnknown, false, err
-		}
-		data, err := os.ReadFile(path)
-		if os.IsNotExist(err) {
-			continue
-		}
-		if err != nil {
-			return ports.AgentAuthStatusUnknown, false, err
-		}
-		if copilotEventsShowModelUse(string(data)) {
+	for _, key := range []string{"authToken", "accessToken", "token"} {
+		var token string
+		if err := json.Unmarshal(config[key], &token); err == nil && copilotUsableToken(token) {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
+	if copilotLoggedInUser(config) {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
 	return ports.AgentAuthStatusUnknown, false, nil
-}
-
-func copilotEventsShowModelUse(text string) bool {
-	return strings.Contains(text, `"model":`) ||
-		strings.Contains(text, `"type":"tool.execution_complete"`) ||
-		strings.Contains(text, `"type":"message"`)
 }
 
 func copilotGHAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
@@ -128,25 +103,19 @@ func copilotGHAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	return ports.AgentAuthStatusUnknown, false, nil
 }
 
-func textContainsTokenAssignment(text string) bool {
-	for _, line := range strings.Split(text, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "#") {
-			continue
-		}
-		lower := strings.ToLower(line)
-		if !strings.Contains(lower, "token") && !strings.Contains(lower, "auth") {
-			continue
-		}
-		for _, sep := range []string{":", "="} {
-			_, after, ok := strings.Cut(line, sep)
-			if !ok {
-				continue
-			}
-			value := strings.Trim(strings.TrimSpace(strings.TrimRight(after, ",")), `"'`)
-			if value != "" && !strings.EqualFold(value, "null") && !strings.EqualFold(value, "none") {
-				return true
-			}
+func copilotUsableToken(value string) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && !strings.HasPrefix(value, "ghp_")
+}
+
+func copilotLoggedInUser(config map[string]json.RawMessage) bool {
+	var users map[string]json.RawMessage
+	if err := json.Unmarshal(config["loggedInUsers"], &users); err != nil {
+		return false
+	}
+	for _, user := range users {
+		if len(user) > 0 && string(user) != "null" && string(user) != `""` {
+			return true
 		}
 	}
 	return false

--- a/backend/internal/adapters/agent/copilot/auth.go
+++ b/backend/internal/adapters/agent/copilot/auth.go
@@ -76,7 +76,7 @@ func copilotConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 	}
 	var config map[string]json.RawMessage
 	if err := json.Unmarshal(data, &config); err != nil {
-		return ports.AgentAuthStatusUnknown, false, nil
+		return ports.AgentAuthStatusUnknown, false, err
 	}
 	for _, key := range []string{"authToken", "accessToken", "token"} {
 		var token string

--- a/backend/internal/adapters/agent/copilot/auth.go
+++ b/backend/internal/adapters/agent/copilot/auth.go
@@ -5,18 +5,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -25,7 +23,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 var copilotTokenEnvVars = []string{
@@ -77,7 +75,7 @@ func copilotConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 	}
 	text := strings.TrimSpace(string(data))
 	if text == "" {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	if textContainsTokenAssignment(text) {
 		return ports.AgentAuthStatusAuthorized, true, nil
@@ -118,20 +116,15 @@ func copilotEventsShowModelUse(text string) bool {
 }
 
 func copilotGHAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
-	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	out, err := aoprocess.CommandContext(probeCtx, "gh", "auth", "token").CombinedOutput()
-	if probeCtx.Err() != nil {
-		return ports.AgentAuthStatusUnknown, false, probeCtx.Err()
+	status, err := authprobe.CLIStatus(ctx, "gh", [][]string{{"auth", "status"}})
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
 	}
-	text := strings.TrimSpace(string(out))
-	if err == nil && text != "" {
+	if status == ports.AgentAuthStatusAuthorized {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
-	if strings.Contains(strings.ToLower(text), "no oauth token") || strings.Contains(strings.ToLower(text), "not logged") {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
+	// GitHub CLI state is only one Copilot credential source. A negative result
+	// cannot rule out Copilot's own stored OAuth or token credentials.
 	return ports.AgentAuthStatusUnknown, false, nil
 }
 

--- a/backend/internal/adapters/agent/copilot/auth.go
+++ b/backend/internal/adapters/agent/copilot/auth.go
@@ -42,6 +42,9 @@ func copilotLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, e
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
+	if copilotBYOKConfigured() {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -50,7 +53,7 @@ func copilotLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, e
 	if home == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	configStatus, configOK, err := copilotConfigAuthStatus(filepath.Join(home, ".copilot", "config.json"))
+	configStatus, configOK, err := copilotConfigAuthStatus(filepath.Join(copilotHomeDir(home), "config.json"))
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
@@ -61,6 +64,21 @@ func copilotLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, e
 		return status, ok, err
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+// copilotBYOKConfigured recognizes Copilot CLI's documented local BYOK setup.
+// An API key is optional because providers such as local Ollama do not require
+// one; the endpoint and model identify a usable provider configuration.
+func copilotBYOKConfigured() bool {
+	return strings.TrimSpace(os.Getenv("COPILOT_PROVIDER_BASE_URL")) != "" &&
+		strings.TrimSpace(os.Getenv("COPILOT_MODEL")) != ""
+}
+
+func copilotHomeDir(home string) string {
+	if path := strings.TrimSpace(os.Getenv("COPILOT_HOME")); path != "" {
+		return path
+	}
+	return filepath.Join(home, ".copilot")
 }
 
 func copilotConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {

--- a/backend/internal/adapters/agent/copilot/auth_test.go
+++ b/backend/internal/adapters/agent/copilot/auth_test.go
@@ -1,0 +1,49 @@
+package copilot
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestCopilotLocalAuthStatusAuthorizedWithBYOKProvider(t *testing.T) {
+	clearCopilotAuthProbeEnv(t)
+	t.Setenv("COPILOT_PROVIDER_BASE_URL", "http://localhost:11434")
+	t.Setenv("COPILOT_MODEL", "llama3.2")
+
+	status, ok, err := copilotLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestCopilotLocalAuthStatusUsesCopilotHome(t *testing.T) {
+	clearCopilotAuthProbeEnv(t)
+	dir := t.TempDir()
+	t.Setenv("COPILOT_HOME", dir)
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"authToken":"oauth-token"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := copilotLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func clearCopilotAuthProbeEnv(t *testing.T) {
+	t.Helper()
+	clearCopilotAuthEnv(t)
+	for _, name := range []string{"COPILOT_PROVIDER_BASE_URL", "COPILOT_PROVIDER_TYPE", "COPILOT_PROVIDER_API_KEY", "COPILOT_MODEL", "COPILOT_HOME"} {
+		t.Setenv(name, "")
+	}
+}

--- a/backend/internal/adapters/agent/copilot/copilot_test.go
+++ b/backend/internal/adapters/agent/copilot/copilot_test.go
@@ -424,6 +424,9 @@ func TestAuthStatusAuthorizedFromEnv(t *testing.T) {
 
 func TestCopilotClassicPATIsNotAnAuthorizationSignal(t *testing.T) {
 	clearCopilotAuthEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("GH_TOKEN", "ghp_classic_token")
 
 	status, ok, err := copilotLocalAuthStatus(context.Background())

--- a/backend/internal/adapters/agent/copilot/copilot_test.go
+++ b/backend/internal/adapters/agent/copilot/copilot_test.go
@@ -437,7 +437,7 @@ func TestCopilotConfigAuthStatusAuthorizedWithPlainTextToken(t *testing.T) {
 	}
 }
 
-func TestCopilotConfigAuthStatusUnauthorizedWithEmptyConfig(t *testing.T) {
+func TestCopilotConfigAuthStatusUnknownWithEmptyConfig(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	if err := os.WriteFile(configPath, []byte(" \n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -447,8 +447,8 @@ func TestCopilotConfigAuthStatusUnauthorizedWithEmptyConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/copilot/copilot_test.go
+++ b/backend/internal/adapters/agent/copilot/copilot_test.go
@@ -422,6 +422,19 @@ func TestAuthStatusAuthorizedFromEnv(t *testing.T) {
 	}
 }
 
+func TestCopilotClassicPATIsNotAnAuthorizationSignal(t *testing.T) {
+	clearCopilotAuthEnv(t)
+	t.Setenv("GH_TOKEN", "ghp_classic_token")
+
+	status, ok, err := copilotLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
 func TestCopilotConfigAuthStatusAuthorizedWithPlainTextToken(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	if err := os.WriteFile(configPath, []byte(`{"authToken":"token"}`), 0o600); err != nil {
@@ -452,22 +465,18 @@ func TestCopilotConfigAuthStatusUnknownWithEmptyConfig(t *testing.T) {
 	}
 }
 
-func TestCopilotSessionStateAuthStatusAuthorizedWithModelEvent(t *testing.T) {
-	dir := t.TempDir()
-	sessionDir := filepath.Join(dir, "session-1")
-	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(sessionDir, "events.jsonl"), []byte(`{"type":"tool.execution_complete","data":{"model":"claude-sonnet-4.5"}}`), 0o600); err != nil {
+func TestCopilotConfigAuthStatusDoesNotTreatAuthModeAsCredential(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"authMode":"github"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	status, ok, err := copilotSessionStateAuthStatus(context.Background(), dir)
+	status, ok, err := copilotConfigAuthStatus(configPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/crush/auth.go
+++ b/backend/internal/adapters/agent/crush/auth.go
@@ -2,7 +2,6 @@ package crush
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,11 +53,10 @@ func crushLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, err
 		crushGoogleCredentialConfigured() {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
-	dataDir, ok := crushDataDir()
-	if !ok {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	return crushProvidersAuthStatus(filepath.Join(dataDir, "providers.json"))
+	// providers.json is Crush's downloaded model/provider catalog, not a
+	// credential store. It can contain provider metadata and must not be used
+	// as evidence that a user is authenticated.
+	return ports.AgentAuthStatusUnknown, false, nil
 }
 
 func crushGoogleCredentialConfigured() bool {
@@ -81,49 +79,4 @@ func crushGoogleCredentialConfigured() bool {
 func crushNonEmptyRegularFile(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.Mode().IsRegular() && info.Size() > 0
-}
-
-func crushDataDir() (string, bool) {
-	if dataDir := strings.TrimSpace(os.Getenv("CRUSH_DATA_DIR")); dataDir != "" {
-		return dataDir, true
-	}
-	if dataHome := strings.TrimSpace(os.Getenv("XDG_DATA_HOME")); dataHome != "" {
-		return filepath.Join(dataHome, "crush"), true
-	}
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return "", false
-	}
-	return filepath.Join(home, ".local", "share", "crush"), true
-}
-
-type crushProviderAuth struct {
-	APIKey string `json:"api_key"`
-}
-
-func crushProvidersAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	if strings.TrimSpace(string(data)) == "" {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-
-	var providers []crushProviderAuth
-	if err := json.Unmarshal(data, &providers); err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	if len(providers) == 0 {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	for _, provider := range providers {
-		if strings.TrimSpace(provider.APIKey) != "" {
-			return ports.AgentAuthStatusAuthorized, true, nil
-		}
-	}
-	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/crush/auth.go
+++ b/backend/internal/adapters/agent/crush/auth.go
@@ -30,11 +30,57 @@ func crushLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, err
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
+	for _, name := range []string{
+		"HYPER_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "VERCEL_API_KEY",
+		"GEMINI_API_KEY", "ZAI_API_KEY", "MINIMAX_API_KEY", "SYNTHETIC_API_KEY",
+		"HF_TOKEN", "CEREBRAS_API_KEY", "OPENROUTER_API_KEY", "IONET_API_KEY",
+		"ALIBABA_SINGAPORE_API_KEY", "ALIBABA_US_API_KEY", "GROQ_API_KEY",
+		"AVIAN_API_KEY", "OPENCODE_API_KEY", "AZURE_OPENAI_API_KEY", "MOONSHOT_API_KEY",
+		"AWS_BEARER_TOKEN_BEDROCK",
+	} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+	}
+	if strings.TrimSpace(os.Getenv("AWS_ACCESS_KEY_ID")) != "" &&
+		strings.TrimSpace(os.Getenv("AWS_SECRET_ACCESS_KEY")) != "" {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
+	if strings.TrimSpace(os.Getenv("AWS_PROFILE")) != "" {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
+	if strings.TrimSpace(os.Getenv("VERTEXAI_PROJECT")) != "" &&
+		strings.TrimSpace(os.Getenv("VERTEXAI_LOCATION")) != "" &&
+		crushGoogleCredentialConfigured() {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
 	dataDir, ok := crushDataDir()
 	if !ok {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	return crushProvidersAuthStatus(filepath.Join(dataDir, "providers.json"))
+}
+
+func crushGoogleCredentialConfigured() bool {
+	if path := strings.TrimSpace(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")); path != "" {
+		return crushNonEmptyRegularFile(path)
+	}
+	if configHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); configHome != "" {
+		return crushNonEmptyRegularFile(filepath.Join(configHome, "gcloud", "application_default_credentials.json"))
+	}
+	if appData := strings.TrimSpace(os.Getenv("APPDATA")); appData != "" {
+		return crushNonEmptyRegularFile(filepath.Join(appData, "gcloud", "application_default_credentials.json"))
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	return crushNonEmptyRegularFile(filepath.Join(home, ".config", "gcloud", "application_default_credentials.json"))
+}
+
+func crushNonEmptyRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular() && info.Size() > 0
 }
 
 func crushDataDir() (string, bool) {

--- a/backend/internal/adapters/agent/crush/auth.go
+++ b/backend/internal/adapters/agent/crush/auth.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -15,7 +14,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -24,7 +23,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 func crushLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
@@ -80,5 +79,5 @@ func crushProvidersAuthStatus(path string) (ports.AgentAuthStatus, bool, error) 
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
-	return ports.AgentAuthStatusUnauthorized, true, nil
+	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/crush/auth_test.go
+++ b/backend/internal/adapters/agent/crush/auth_test.go
@@ -20,15 +20,15 @@ func TestCrushProvidersAuthStatusAuthorizedWithAPIKey(t *testing.T) {
 	}
 }
 
-func TestCrushProvidersAuthStatusUnauthorizedWithEmptyAPIKeys(t *testing.T) {
+func TestCrushProvidersAuthStatusUnknownWithEmptyAPIKeys(t *testing.T) {
 	path := writeCrushProviders(t, `[{"id":"anthropic","api_key":""}]`)
 
 	status, ok, err := crushProvidersAuthStatus(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/crush/auth_test.go
+++ b/backend/internal/adapters/agent/crush/auth_test.go
@@ -1,17 +1,15 @@
 package crush
 
 import (
-	"os"
-	"path/filepath"
+	"context"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestCrushProvidersAuthStatusAuthorizedWithAPIKey(t *testing.T) {
-	path := writeCrushProviders(t, `[{"id":"anthropic","api_key":"sk-test"}]`)
-
-	status, ok, err := crushProvidersAuthStatus(path)
+func TestCrushLocalAuthStatusAuthorizedWithDocumentedEnv(t *testing.T) {
+	t.Setenv("HYPER_API_KEY", "test-key")
+	status, ok, err := crushLocalAuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -20,23 +18,15 @@ func TestCrushProvidersAuthStatusAuthorizedWithAPIKey(t *testing.T) {
 	}
 }
 
-func TestCrushProvidersAuthStatusUnknownWithEmptyAPIKeys(t *testing.T) {
-	path := writeCrushProviders(t, `[{"id":"anthropic","api_key":""}]`)
-
-	status, ok, err := crushProvidersAuthStatus(path)
+func TestCrushLocalAuthStatusDoesNotUseProviderCatalog(t *testing.T) {
+	for _, name := range []string{"HYPER_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"} {
+		t.Setenv(name, "")
+	}
+	status, ok, err := crushLocalAuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ok || status != ports.AgentAuthStatusUnknown {
 		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
-}
-
-func writeCrushProviders(t *testing.T, content string) string {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "providers.json")
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	return path
 }

--- a/backend/internal/adapters/agent/cursor/auth.go
+++ b/backend/internal/adapters/agent/cursor/auth.go
@@ -19,6 +19,9 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
+	if strings.TrimSpace(os.Getenv("CURSOR_API_KEY")) != "" {
+		return ports.AgentAuthStatusAuthorized, nil
+	}
 	if status, err := cursorCLIAuthStatus(ctx, binary); err == nil && status != ports.AgentAuthStatusUnknown {
 		return status, nil
 	} else if err != nil && ctx.Err() != nil {

--- a/backend/internal/adapters/agent/cursor/auth.go
+++ b/backend/internal/adapters/agent/cursor/auth.go
@@ -2,9 +2,7 @@ package cursor
 
 import (
 	"context"
-	"encoding/json"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
@@ -27,90 +25,9 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if err != nil && ctx.Err() != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
-	if status, ok, err := cursorLocalAuthStatus(ctx); err != nil {
-		return ports.AgentAuthStatusUnknown, err
-	} else if ok {
-		return status, nil
-	}
 	return ports.AgentAuthStatusUnknown, nil
 }
 
 func cursorCLIAuthStatus(ctx context.Context, binary string) (ports.AgentAuthStatus, error) {
 	return authprobe.CLIStatus(ctx, binary, [][]string{{"status"}})
-}
-
-func cursorLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
-	if err := ctx.Err(); err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	if home == "" {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	return cursorConfigAuthStatus(filepath.Join(home, ".cursor", "cli-config.json"))
-}
-
-func cursorConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	if strings.TrimSpace(string(data)) == "" {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	type cursorConfig struct {
-		AuthInfo struct {
-			Email       string `json:"email"`
-			DisplayName string `json:"displayName"`
-			UserID      any    `json:"userId"`
-			AuthID      string `json:"authId"`
-		} `json:"authInfo"`
-	}
-
-	var cfgs []cursorConfig
-	if err := json.Unmarshal(data, &cfgs); err != nil {
-		var cfg cursorConfig
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			return ports.AgentAuthStatusUnknown, false, err
-		}
-		cfgs = []cursorConfig{cfg}
-	}
-	for _, cfg := range cfgs {
-		if cursorConfigHasIdentity(cfg) {
-			return ports.AgentAuthStatusAuthorized, true, nil
-		}
-	}
-	return ports.AgentAuthStatusUnknown, false, nil
-}
-
-func cursorConfigHasIdentity(cfg struct {
-	AuthInfo struct {
-		Email       string `json:"email"`
-		DisplayName string `json:"displayName"`
-		UserID      any    `json:"userId"`
-		AuthID      string `json:"authId"`
-	} `json:"authInfo"`
-}) bool {
-	if cfg.AuthInfo.UserID != nil {
-		switch v := cfg.AuthInfo.UserID.(type) {
-		case string:
-			if strings.TrimSpace(v) != "" {
-				return true
-			}
-		default:
-			return true
-		}
-	}
-	if strings.TrimSpace(cfg.AuthInfo.AuthID) != "" ||
-		strings.TrimSpace(cfg.AuthInfo.Email) != "" ||
-		strings.TrimSpace(cfg.AuthInfo.DisplayName) != "" {
-		return true
-	}
-	return false
 }

--- a/backend/internal/adapters/agent/cursor/auth.go
+++ b/backend/internal/adapters/agent/cursor/auth.go
@@ -29,7 +29,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 func cursorCLIAuthStatus(ctx context.Context, binary string) (ports.AgentAuthStatus, error) {

--- a/backend/internal/adapters/agent/cursor/auth_test.go
+++ b/backend/internal/adapters/agent/cursor/auth_test.go
@@ -2,8 +2,6 @@ package cursor
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -37,36 +35,6 @@ func TestCursorCLIAuthStatusUnknownFromKeychainError(t *testing.T) {
 	}
 }
 
-func TestCursorConfigAuthStatusAuthorizedWithAuthInfo(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "cli-config.json")
-	if err := os.WriteFile(path, []byte(`{"authInfo":{"email":"user@example.com","userId":"user-1","authId":"auth-1"}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	status, ok, err := cursorConfigAuthStatus(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
-	}
-}
-
-func TestCursorConfigAuthStatusUnknownWithoutAuthInfo(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "cli-config.json")
-	if err := os.WriteFile(path, []byte(`{"model":{"modelId":"cursor-default"}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	status, ok, err := cursorConfigAuthStatus(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok || status != ports.AgentAuthStatusUnknown {
-		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
-	}
-}
-
 type assertErr string
 
 func (e assertErr) Error() string {
@@ -83,14 +51,4 @@ func stubCursorAuthCommand(t *testing.T, wantArgs []string, out []byte, err erro
 		return out, err
 	}
 	return func() { authprobe.CmdRunner = previous }
-}
-
-func TestCursorConfigAuthStatusUnknownWhenMissing(t *testing.T) {
-	status, ok, err := cursorConfigAuthStatus(filepath.Join(t.TempDir(), "missing.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok || status != ports.AgentAuthStatusUnknown {
-		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
-	}
 }

--- a/backend/internal/adapters/agent/devin/auth.go
+++ b/backend/internal/adapters/agent/devin/auth.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -14,7 +13,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -23,7 +22,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, [][]string{{"auth", "status"}})
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 func devinLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
@@ -50,7 +49,7 @@ func devinCredentialsAuthStatus(path string) (ports.AgentAuthStatus, bool, error
 	}
 	text := strings.TrimSpace(string(data))
 	if text == "" {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	lower := strings.ToLower(text)
 	if strings.Contains(lower, "windsurf_api_key") ||

--- a/backend/internal/adapters/agent/devin/auth.go
+++ b/backend/internal/adapters/agent/devin/auth.go
@@ -3,7 +3,6 @@ package devin
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -29,32 +28,7 @@ func devinLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, err
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	if home == "" {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	return devinCredentialsAuthStatus(filepath.Join(home, ".local", "share", "devin", "credentials.toml"))
-}
-
-func devinCredentialsAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	text := strings.TrimSpace(string(data))
-	if text == "" {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	lower := strings.ToLower(text)
-	if strings.Contains(lower, "windsurf_api_key") ||
-		strings.Contains(lower, "devin_api_url") ||
-		strings.Contains(lower, "devin_webapp_host") {
+	if key := strings.TrimSpace(os.Getenv("DEVIN_API_KEY")); strings.HasPrefix(key, "cog_") && len(key) > len("cog_") {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil

--- a/backend/internal/adapters/agent/devin/auth_test.go
+++ b/backend/internal/adapters/agent/devin/auth_test.go
@@ -45,7 +45,7 @@ func TestDevinCredentialsAuthStatusAuthorized(t *testing.T) {
 	}
 }
 
-func TestDevinCredentialsAuthStatusUnauthorizedWithEmptyFile(t *testing.T) {
+func TestDevinCredentialsAuthStatusUnknownWithEmptyFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "credentials.toml")
 	if err := os.WriteFile(path, nil, 0o600); err != nil {
 		t.Fatal(err)
@@ -55,7 +55,7 @@ func TestDevinCredentialsAuthStatusUnauthorizedWithEmptyFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }

--- a/backend/internal/adapters/agent/devin/auth_test.go
+++ b/backend/internal/adapters/agent/devin/auth_test.go
@@ -2,60 +2,18 @@ package devin
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-	"reflect"
 	"testing"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestAuthStatusAuthorizedFromAuthStatusOutput(t *testing.T) {
-	previous := authprobe.CmdRunner
-	authprobe.CmdRunner = func(ctx context.Context, name string, arg ...string) ([]byte, error) {
-		if name != "devin" || !reflect.DeepEqual(arg, []string{"auth", "status"}) {
-			t.Fatalf("command = %s %#v, want devin auth status", name, arg)
-		}
-		return []byte("Logged in (via Devin).\n\nUser:\n  Email: agentsubs@example.com\n"), nil
-	}
-	defer func() { authprobe.CmdRunner = previous }()
-
+func TestAuthStatusAuthorizedFromDocumentedAPIKey(t *testing.T) {
+	t.Setenv("DEVIN_API_KEY", "cog_test")
 	got, err := (&Plugin{resolvedBinary: "devin"}).AuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got != ports.AgentAuthStatusAuthorized {
 		t.Fatalf("AuthStatus = %q, want %q", got, ports.AgentAuthStatusAuthorized)
-	}
-}
-
-func TestDevinCredentialsAuthStatusAuthorized(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "credentials.toml")
-	if err := os.WriteFile(path, []byte("windsurf_api_key = \"token\"\ndevin_api_url = \"https://api.devin.ai\"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	status, ok, err := devinCredentialsAuthStatus(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
-	}
-}
-
-func TestDevinCredentialsAuthStatusUnknownWithEmptyFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "credentials.toml")
-	if err := os.WriteFile(path, nil, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	status, ok, err := devinCredentialsAuthStatus(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok || status != ports.AgentAuthStatusUnknown {
-		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }

--- a/backend/internal/adapters/agent/droid/auth.go
+++ b/backend/internal/adapters/agent/droid/auth.go
@@ -46,9 +46,6 @@ func droidFactoryAuthStatus(factoryDir string) (ports.AgentAuthStatus, bool, err
 	if factoryDir == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	if fileHasContent(filepath.Join(factoryDir, "auth.v2.file")) && fileHasContent(filepath.Join(factoryDir, "auth.v2.key")) {
-		return ports.AgentAuthStatusAuthorized, true, nil
-	}
 	return droidSettingsAuthStatus(filepath.Join(factoryDir, "settings.json"))
 }
 
@@ -73,7 +70,7 @@ func droidSettingsAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 	for _, model := range settings.CustomModels {
 		if strings.TrimSpace(model.Model) != "" &&
 			strings.TrimSpace(model.BaseURL) != "" &&
-			strings.TrimSpace(model.APIKey) != "" {
+			droidConfiguredSecret(model.APIKey) {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
@@ -83,7 +80,17 @@ func droidSettingsAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 	return ports.AgentAuthStatusUnknown, false, nil
 }
 
-func fileHasContent(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir() && info.Size() > 0
+// droidConfiguredSecret recognizes literal keys and the documented
+// ${ENV_VAR} interpolation used by Droid's custom model settings. An
+// unresolved placeholder is not evidence that the user is authenticated.
+func droidConfiguredSecret(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") {
+		name := strings.TrimSpace(value[2 : len(value)-1])
+		return name != "" && strings.TrimSpace(os.Getenv(name)) != ""
+	}
+	return !strings.HasPrefix(value, "$")
 }

--- a/backend/internal/adapters/agent/droid/auth.go
+++ b/backend/internal/adapters/agent/droid/auth.go
@@ -22,7 +22,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if err != nil || ok {
 		return status, err
 	}
-	return ports.AgentAuthStatusUnauthorized, nil
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 func droidLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
@@ -78,7 +78,7 @@ func droidSettingsAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 		}
 	}
 	if len(settings.CustomModels) > 0 {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/droid/auth_test.go
+++ b/backend/internal/adapters/agent/droid/auth_test.go
@@ -21,7 +21,7 @@ func TestAuthStatusAuthorizedFromFactoryAPIKey(t *testing.T) {
 	}
 }
 
-func TestDroidFactoryAuthStatusAuthorizedFromAuthFiles(t *testing.T) {
+func TestDroidFactoryAuthStatusIgnoresUndocumentedAuthFiles(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "auth.v2.file"), []byte("encrypted auth"), 0o600); err != nil {
 		t.Fatal(err)
@@ -34,8 +34,24 @@ func TestDroidFactoryAuthStatusAuthorizedFromAuthFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestDroidFactoryAuthStatusDoesNotTreatUnresolvedEnvPlaceholderAsKey(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{"customModels":[{"model":"custom","baseUrl":"https://api.example.com","apiKey":"${PROVIDER_API_KEY}"}]}`
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(settings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := droidFactoryAuthStatus(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/droid/auth_test.go
+++ b/backend/internal/adapters/agent/droid/auth_test.go
@@ -55,7 +55,7 @@ func TestDroidFactoryAuthStatusAuthorizedFromCustomModelAPIKey(t *testing.T) {
 	}
 }
 
-func TestDroidFactoryAuthStatusUnauthorizedFromCustomModelWithoutAPIKey(t *testing.T) {
+func TestDroidFactoryAuthStatusUnknownFromCustomModelWithoutAPIKey(t *testing.T) {
 	dir := t.TempDir()
 	settings := `{"customModels":[{"model":"claude-sonnet-4-5-20250929","baseUrl":"https://api.anthropic.com","apiKey":""}]}`
 	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(settings), 0o600); err != nil {
@@ -66,7 +66,7 @@ func TestDroidFactoryAuthStatusUnauthorizedFromCustomModelWithoutAPIKey(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }

--- a/backend/internal/adapters/agent/goose/auth.go
+++ b/backend/internal/adapters/agent/goose/auth.go
@@ -29,6 +29,8 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 
 var gooseAPIKeyEnvVars = []string{
 	"GOOSE_API_KEY",
+	"GOOSE_PROVIDER__API_KEY",
+	"GOOSE_EDITOR_API_KEY",
 	"OPENAI_API_KEY",
 	"ANTHROPIC_API_KEY",
 	"GEMINI_API_KEY",
@@ -104,7 +106,7 @@ func gooseAuthStatusFromConfig(path string) (ports.AgentAuthStatus, bool, error)
 	if err := yaml.Unmarshal(data, &root); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	if gooseConfigHasCredential(&root) || gooseConfigHasConfiguredProvider(&root) {
+	if gooseConfigHasCredential(&root) {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
@@ -132,32 +134,6 @@ func gooseConfigHasCredential(node *yaml.Node) bool {
 				return true
 			}
 			if gooseConfigHasCredential(node.Content[i+1]) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func gooseConfigHasConfiguredProvider(node *yaml.Node) bool {
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case yaml.DocumentNode, yaml.SequenceNode:
-		for _, child := range node.Content {
-			if gooseConfigHasConfiguredProvider(child) {
-				return true
-			}
-		}
-	case yaml.MappingNode:
-		for i := 0; i+1 < len(node.Content); i += 2 {
-			key := strings.ToLower(strings.TrimSpace(node.Content[i].Value))
-			value := strings.ToLower(strings.Trim(strings.TrimSpace(node.Content[i+1].Value), `"'`))
-			if key == "configured" && (value == "true" || value == "yes" || value == "1") {
-				return true
-			}
-			if gooseConfigHasConfiguredProvider(node.Content[i+1]) {
 				return true
 			}
 		}

--- a/backend/internal/adapters/agent/goose/auth.go
+++ b/backend/internal/adapters/agent/goose/auth.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 
 	yaml "gopkg.in/yaml.v3"
@@ -16,7 +15,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -25,7 +24,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 var gooseAPIKeyEnvVars = []string{
@@ -98,7 +97,7 @@ func gooseAuthStatusFromConfig(path string) (ports.AgentAuthStatus, bool, error)
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	if strings.TrimSpace(string(data)) == "" {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 
 	var root yaml.Node

--- a/backend/internal/adapters/agent/goose/auth.go
+++ b/backend/internal/adapters/agent/goose/auth.go
@@ -81,11 +81,15 @@ func gooseConfigPaths() []string {
 
 	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
 		add(filepath.Join(xdg, "goose", "config.yaml"))
+		add(filepath.Join(xdg, "goose", "secrets.yaml"))
 	}
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
 		// Goose stores config here on macOS as well, rather than under
 		// os.UserConfigDir's "Application Support" path.
 		add(filepath.Join(home, ".config", "goose", "config.yaml"))
+		// Goose falls back to this plaintext secret store when its keyring is
+		// disabled or unavailable. Keyring-only credentials remain unknown.
+		add(filepath.Join(home, ".config", "goose", "secrets.yaml"))
 	}
 	return paths
 }

--- a/backend/internal/adapters/agent/goose/auth_test.go
+++ b/backend/internal/adapters/agent/goose/auth_test.go
@@ -1,0 +1,29 @@
+package goose
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestGooseLocalAuthStatusReadsSecretsFile(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	if err := os.MkdirAll(filepath.Join(configHome, "goose"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configHome, "goose", "secrets.yaml"), []byte("OPENAI_API_KEY: test-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := gooseLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -264,7 +264,7 @@ func TestAuthStatusAuthorizedFromGooseConfig(t *testing.T) {
 	}
 }
 
-func TestAuthStatusUnauthorizedFromEmptyGooseConfig(t *testing.T) {
+func TestAuthStatusUnknownFromEmptyGooseConfig(t *testing.T) {
 	clearGooseAuthEnv(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -283,8 +283,8 @@ func TestAuthStatusUnauthorizedFromEmptyGooseConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("AuthStatus = %q, want %q", got, ports.AgentAuthStatusUnauthorized)
+	if got != ports.AgentAuthStatusUnknown {
+		t.Fatalf("AuthStatus = %q, want %q", got, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -250,7 +250,7 @@ func TestAuthStatusAuthorizedFromGooseConfig(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(configPath, []byte("providers:\n  openrouter:\n    configured: true\n    model: anthropic/claude-sonnet-4\n"), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte("GOOSE_PROVIDER__API_KEY: test-key\nproviders:\n  openrouter:\n    model: anthropic/claude-sonnet-4\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	plugin := &Plugin{resolvedBinary: "goose"}

--- a/backend/internal/adapters/agent/grok/auth.go
+++ b/backend/internal/adapters/agent/grok/auth.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -15,7 +14,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -24,7 +23,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 func grokLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
@@ -51,7 +50,7 @@ func grokLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	if strings.TrimSpace(string(data)) == "" {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 
 	var entries map[string]json.RawMessage
@@ -59,7 +58,7 @@ func grokLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	if len(entries) == 0 {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	for key, value := range entries {
 		if strings.TrimSpace(key) == "" {
@@ -70,5 +69,5 @@ func grokLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
-	return ports.AgentAuthStatusUnauthorized, true, nil
+	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/grok/auth.go
+++ b/backend/internal/adapters/agent/grok/auth.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
-
 	"github.com/pelletier/go-toml/v2"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
@@ -36,18 +36,18 @@ func grokLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
 
-	home, err := os.UserHomeDir()
+	grokHome, err := grokConfigDir()
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	if home == "" {
+	if grokHome == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	configStatus, configOK, err := grokConfigAuthStatus(filepath.Join(home, ".grok", "config.toml"))
+	configStatus, configOK, err := grokConfigAuthStatus(filepath.Join(grokHome, "config.toml"))
 	if err != nil || configOK {
 		return configStatus, configOK, err
 	}
-	path := filepath.Join(home, ".grok", "auth.json")
+	path := filepath.Join(grokHome, "auth.json")
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return ports.AgentAuthStatusUnknown, false, nil
@@ -80,6 +80,21 @@ func grokLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 		}
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+// grokConfigDir follows Grok Build's GROK_HOME override for all local state.
+func grokConfigDir() (string, error) {
+	if home := strings.TrimSpace(os.Getenv("GROK_HOME")); home != "" {
+		return home, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if home == "" {
+		return "", nil
+	}
+	return filepath.Join(home, ".grok"), nil
 }
 
 // grokConfigAuthStatus recognizes the documented per-model api_key and

--- a/backend/internal/adapters/agent/grok/auth.go
+++ b/backend/internal/adapters/agent/grok/auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+
 	"github.com/pelletier/go-toml/v2"
 )
 

--- a/backend/internal/adapters/agent/grok/auth.go
+++ b/backend/internal/adapters/agent/grok/auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/pelletier/go-toml/v2"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
@@ -30,7 +31,7 @@ func grokLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	if strings.TrimSpace(os.Getenv("GROK_API_KEY")) != "" || strings.TrimSpace(os.Getenv("XAI_API_KEY")) != "" {
+	if strings.TrimSpace(os.Getenv("XAI_API_KEY")) != "" {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
 
@@ -40,6 +41,10 @@ func grokLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	}
 	if home == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	configStatus, configOK, err := grokConfigAuthStatus(filepath.Join(home, ".grok", "config.toml"))
+	if err != nil || configOK {
+		return configStatus, configOK, err
 	}
 	path := filepath.Join(home, ".grok", "auth.json")
 	data, err := os.ReadFile(path)
@@ -64,10 +69,63 @@ func grokLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 		if strings.TrimSpace(key) == "" {
 			continue
 		}
-		trimmed := strings.TrimSpace(string(value))
-		if trimmed != "" && trimmed != "null" && trimmed != "{}" {
+		var session struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		}
+		if json.Unmarshal(value, &session) == nil &&
+			(strings.TrimSpace(session.AccessToken) != "" || strings.TrimSpace(session.RefreshToken) != "") {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+// grokConfigAuthStatus recognizes the documented per-model api_key and
+// env_key settings. Other config values (model IDs, base URLs, etc.) are not
+// evidence of authentication.
+func grokConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	var config map[string]any
+	if err := toml.Unmarshal(data, &config); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if hasGrokConfiguredSecret(config) {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func hasGrokConfiguredSecret(value any) bool {
+	switch value := value.(type) {
+	case map[string]any:
+		for key, child := range value {
+			switch key {
+			case "api_key":
+				if s, ok := child.(string); ok && strings.TrimSpace(s) != "" && !strings.HasPrefix(strings.TrimSpace(s), "$") {
+					return true
+				}
+			case "env_key":
+				if name, ok := child.(string); ok && strings.TrimSpace(os.Getenv(strings.TrimSpace(name))) != "" {
+					return true
+				}
+			}
+			if hasGrokConfiguredSecret(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range value {
+			if hasGrokConfiguredSecret(child) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/backend/internal/adapters/agent/grok/auth_test.go
+++ b/backend/internal/adapters/agent/grok/auth_test.go
@@ -21,6 +21,43 @@ func TestGrokLocalAuthStatusAuthorizedWithAPIKeyEnv(t *testing.T) {
 	}
 }
 
+func TestGrokLocalAuthStatusIgnoresUndocumentedGrokAPIKeyEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GROK_API_KEY", "grok-test")
+	t.Setenv("XAI_API_KEY", "")
+
+	status, ok, err := grokLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestGrokLocalAuthStatusAuthorizedWithConfiguredModelAPIKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	grokDir := filepath.Join(home, ".grok")
+	if err := os.MkdirAll(grokDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(grokDir, "config.toml"), []byte("[model.grok-build]\napi_key = \"xai-test\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := grokLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestGrokLocalAuthStatusAuthorizedWithAuthFile(t *testing.T) {
 	writeGrokAuthFile(t, `{
 		"https://auth.x.ai::account": {
@@ -40,6 +77,18 @@ func TestGrokLocalAuthStatusAuthorizedWithAuthFile(t *testing.T) {
 
 func TestGrokLocalAuthStatusUnknownWithEmptyAuthFile(t *testing.T) {
 	writeGrokAuthFile(t, `{}`)
+
+	status, ok, err := grokLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestGrokLocalAuthStatusIgnoresAuthEntryWithoutTokens(t *testing.T) {
+	writeGrokAuthFile(t, `{"https://auth.x.ai::account":{"email":"user@example.com"}}`)
 
 	status, ok, err := grokLocalAuthStatus(context.Background())
 	if err != nil {

--- a/backend/internal/adapters/agent/grok/auth_test.go
+++ b/backend/internal/adapters/agent/grok/auth_test.go
@@ -38,15 +38,15 @@ func TestGrokLocalAuthStatusAuthorizedWithAuthFile(t *testing.T) {
 	}
 }
 
-func TestGrokLocalAuthStatusUnauthorizedWithEmptyAuthFile(t *testing.T) {
+func TestGrokLocalAuthStatusUnknownWithEmptyAuthFile(t *testing.T) {
 	writeGrokAuthFile(t, `{}`)
 
 	status, ok, err := grokLocalAuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/grok/auth_test.go
+++ b/backend/internal/adapters/agent/grok/auth_test.go
@@ -58,6 +58,22 @@ func TestGrokLocalAuthStatusAuthorizedWithConfiguredModelAPIKey(t *testing.T) {
 	}
 }
 
+func TestGrokLocalAuthStatusUsesGrokHome(t *testing.T) {
+	grokHome := t.TempDir()
+	t.Setenv("GROK_HOME", grokHome)
+	if err := os.WriteFile(filepath.Join(grokHome, "auth.json"), []byte(`{"default":{"access_token":"token"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := grokLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestGrokLocalAuthStatusAuthorizedWithAuthFile(t *testing.T) {
 	writeGrokAuthFile(t, `{
 		"https://auth.x.ai::account": {

--- a/backend/internal/adapters/agent/kilocode/auth.go
+++ b/backend/internal/adapters/agent/kilocode/auth.go
@@ -36,6 +36,9 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	defer cancel()
 	out, err := aoprocess.CommandContext(probeCtx, binary, "auth", "list").CombinedOutput()
 	if probeCtx.Err() != nil {
+		if probeCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+			return ports.AgentAuthStatusUnknown, nil
+		}
 		return ports.AgentAuthStatusUnknown, probeCtx.Err()
 	}
 	status, ok := kilocodeAuthListStatus(string(out))

--- a/backend/internal/adapters/agent/kimi/auth.go
+++ b/backend/internal/adapters/agent/kimi/auth.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/pelletier/go-toml/v2"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)

--- a/backend/internal/adapters/agent/kimi/auth.go
+++ b/backend/internal/adapters/agent/kimi/auth.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/pelletier/go-toml/v2"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
@@ -29,6 +29,8 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 
 var kimiAPIKeyEnvVars = []string{
 	"KIMI_API_KEY",
+	"OPENAI_API_KEY",
+	// Legacy Kimi Code distributions also accepted these names.
 	"KIMI_CODE_API_KEY",
 	"MOONSHOT_API_KEY",
 }
@@ -42,24 +44,62 @@ func kimiLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
-	home, ok := kimiCodeHome()
+	homes, ok := kimiAuthHomes()
 	if !ok {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	configStatus, configOK, err := kimiConfigAuthStatus(filepath.Join(home, "config.toml"))
-	if err != nil || configStatus == ports.AgentAuthStatusAuthorized {
-		return configStatus, configOK, err
-	}
-	credentialsStatus, credentialsOK, err := kimiCredentialsAuthStatus(filepath.Join(home, "credentials", "kimi-code.json"))
-	if err != nil || credentialsOK {
-		return credentialsStatus, credentialsOK, err
-	}
-	if configOK {
-		return configStatus, configOK, nil
+	for _, home := range homes {
+		for _, configName := range []string{"config.toml", "config.json"} {
+			status, found, err := kimiConfigAuthStatus(filepath.Join(home, configName))
+			if err != nil || found {
+				return status, found, err
+			}
+		}
+		// Legacy Kimi Code stored its hosted OAuth token at this fixed path.
+		status, found, err := kimiCredentialsAuthStatus(filepath.Join(home, "credentials", "kimi-code.json"))
+		if err != nil || found {
+			return status, found, err
+		}
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }
 
+func kimiAuthHomes() ([]string, bool) {
+	userHome, err := os.UserHomeDir()
+	if err != nil && strings.TrimSpace(os.Getenv("KIMI_SHARE_DIR")) == "" &&
+		strings.TrimSpace(os.Getenv(kimiCodeHomeEnv)) == "" {
+		return nil, false
+	}
+
+	candidates := []string{
+		strings.TrimSpace(os.Getenv("KIMI_SHARE_DIR")),
+		strings.TrimSpace(os.Getenv(kimiCodeHomeEnv)),
+	}
+	if candidates[0] == "" && userHome != "" {
+		candidates[0] = filepath.Join(userHome, ".kimi")
+	}
+	if candidates[1] == "" && userHome != "" {
+		candidates[1] = filepath.Join(userHome, ".kimi-code")
+	}
+
+	homes := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		clean := filepath.Clean(candidate)
+		if _, exists := seen[clean]; exists {
+			continue
+		}
+		seen[clean] = struct{}{}
+		homes = append(homes, clean)
+	}
+	return homes, len(homes) > 0
+}
+
+// kimiCodeHome retains the legacy KIMI_CODE_HOME lookup used by runtime hook
+// isolation. Auth detection additionally checks the current KIMI_SHARE_DIR.
 func kimiCodeHome() (string, bool) {
 	if home := strings.TrimSpace(os.Getenv(kimiCodeHomeEnv)); home != "" {
 		return home, true
@@ -71,7 +111,20 @@ func kimiCodeHome() (string, bool) {
 	return filepath.Join(home, ".kimi-code"), true
 }
 
-var kimiAPIKeyLineRE = regexp.MustCompile(`(?m)^\s*api_key\s*=\s*("([^"]*)"|'([^']*)'|([^\s#]+))`)
+type kimiOAuthRef struct {
+	Storage string `json:"storage" toml:"storage"`
+	Key     string `json:"key" toml:"key"`
+}
+
+type kimiCredentialSource struct {
+	APIKey string            `json:"api_key" toml:"api_key"`
+	Env    map[string]string `json:"env" toml:"env"`
+	OAuth  *kimiOAuthRef     `json:"oauth" toml:"oauth"`
+}
+
+type kimiAuthConfig struct {
+	Providers map[string]kimiCredentialSource `json:"providers" toml:"providers"`
+}
 
 func kimiConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 	data, err := os.ReadFile(path)
@@ -84,21 +137,56 @@ func kimiConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 	if strings.TrimSpace(string(data)) == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	matches := kimiAPIKeyLineRE.FindAllStringSubmatch(string(data), -1)
-	if len(matches) == 0 {
-		return ports.AgentAuthStatusUnknown, false, nil
+	var config kimiAuthConfig
+	var decodeErr error
+	if strings.EqualFold(filepath.Ext(path), ".json") {
+		decodeErr = json.Unmarshal(data, &config)
+	} else {
+		decodeErr = toml.Unmarshal(data, &config)
 	}
-	for _, match := range matches {
-		for _, group := range match[2:] {
-			if strings.TrimSpace(group) != "" {
-				return ports.AgentAuthStatusAuthorized, true, nil
-			}
+	if decodeErr != nil {
+		return ports.AgentAuthStatusUnknown, false, decodeErr
+	}
+	for _, provider := range config.Providers {
+		if strings.TrimSpace(provider.APIKey) != "" || kimiProviderEnvHasCredential(provider.Env) {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+		if provider.OAuth == nil || strings.TrimSpace(provider.OAuth.Key) == "" {
+			continue
+		}
+		credentialPath := kimiOAuthCredentialPath(filepath.Dir(path), provider.OAuth.Key)
+		status, found, err := kimiCredentialsAuthStatus(credentialPath)
+		if err != nil || found {
+			return status, found, err
 		}
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }
 
+func kimiProviderEnvHasCredential(env map[string]string) bool {
+	for name, value := range env {
+		normalized := strings.ToUpper(strings.TrimSpace(name))
+		if strings.TrimSpace(value) != "" &&
+			(strings.HasSuffix(normalized, "_API_KEY") || strings.HasSuffix(normalized, "_TOKEN")) {
+			return true
+		}
+	}
+	return false
+}
+
+func kimiOAuthCredentialPath(home, key string) string {
+	name := strings.TrimPrefix(strings.TrimSpace(key), "oauth/")
+	name = filepath.Base(filepath.FromSlash(name))
+	if name == "" || name == "." {
+		return ""
+	}
+	return filepath.Join(home, "credentials", name+".json")
+}
+
 func kimiCredentialsAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
+	if strings.TrimSpace(path) == "" {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return ports.AgentAuthStatusUnknown, false, nil

--- a/backend/internal/adapters/agent/kimi/auth.go
+++ b/backend/internal/adapters/agent/kimi/auth.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -16,7 +15,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -25,7 +24,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 var kimiAPIKeyEnvVars = []string{
@@ -96,7 +95,7 @@ func kimiConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 			}
 		}
 	}
-	return ports.AgentAuthStatusUnauthorized, true, nil
+	return ports.AgentAuthStatusUnknown, false, nil
 }
 
 func kimiCredentialsAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
@@ -122,5 +121,5 @@ func kimiCredentialsAuthStatus(path string) (ports.AgentAuthStatus, bool, error)
 		strings.TrimSpace(credentials.RefreshToken) != "" {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
-	return ports.AgentAuthStatusUnauthorized, true, nil
+	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/kimi/auth_test.go
+++ b/backend/internal/adapters/agent/kimi/auth_test.go
@@ -108,7 +108,7 @@ api_key = "secret"
 	}
 }
 
-func TestKimiConfigAuthStatusUnauthorizedWithEmptyAPIKey(t *testing.T) {
+func TestKimiConfigAuthStatusUnknownWithEmptyAPIKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(path, []byte(`
 [providers.zai-coding-plan]
@@ -121,8 +121,8 @@ api_key = ""
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 
@@ -141,7 +141,7 @@ func TestKimiCredentialsAuthStatusAuthorizedWithRefreshToken(t *testing.T) {
 	}
 }
 
-func TestKimiCredentialsAuthStatusUnauthorizedWithEmptyTokens(t *testing.T) {
+func TestKimiCredentialsAuthStatusUnknownWithEmptyTokens(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "kimi-code.json")
 	if err := os.WriteFile(path, []byte(`{"access_token":"","refresh_token":"","token_type":"bearer"}`), 0o600); err != nil {
 		t.Fatal(err)
@@ -151,7 +151,7 @@ func TestKimiCredentialsAuthStatusUnauthorizedWithEmptyTokens(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }

--- a/backend/internal/adapters/agent/kimi/auth_test.go
+++ b/backend/internal/adapters/agent/kimi/auth_test.go
@@ -21,8 +21,91 @@ func TestKimiLocalAuthStatusAuthorizedWithEnvKey(t *testing.T) {
 	}
 }
 
-func TestKimiLocalAuthStatusUsesKimiCodeHome(t *testing.T) {
+func TestKimiLocalAuthStatusAuthorizedWithOpenAIEnvKey(t *testing.T) {
+	clearKimiAuthEnv(t)
+	t.Setenv("OPENAI_API_KEY", "openai-key")
+
+	status, ok, err := kimiLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestKimiLocalAuthStatusUsesCurrentShareDirJSONConfig(t *testing.T) {
+	clearKimiAuthEnv(t)
 	home := t.TempDir()
+	t.Setenv("KIMI_SHARE_DIR", home)
+	t.Setenv("KIMI_CODE_HOME", t.TempDir())
+	if err := os.WriteFile(filepath.Join(home, "config.json"), []byte(`{
+  "providers": {
+    "openai": {"type": "openai_responses", "api_key": "secret"}
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := kimiLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestKimiConfigAuthStatusAuthorizedWithOAuthReference(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.toml")
+	if err := os.WriteFile(configPath, []byte(`
+[providers."managed:kimi-code"]
+type = "kimi"
+api_key = ""
+oauth = { storage = "file", key = "oauth/kimi-code" }
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	credentialsDir := filepath.Join(home, "credentials")
+	if err := os.MkdirAll(credentialsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(credentialsDir, "kimi-code.json"), []byte(`{"refresh_token":"token"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := kimiConfigAuthStatus(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestKimiConfigAuthStatusUnknownWithOAuthReferenceButNoToken(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte(`
+[providers."managed:kimi-code"]
+oauth = { storage = "file", key = "oauth/kimi-code" }
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := kimiConfigAuthStatus(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestKimiLocalAuthStatusUsesKimiCodeHome(t *testing.T) {
+	clearKimiAuthEnv(t)
+	home := t.TempDir()
+	t.Setenv("KIMI_SHARE_DIR", t.TempDir())
 	t.Setenv("KIMI_CODE_HOME", home)
 	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
 [providers.zai-coding-plan]
@@ -43,7 +126,9 @@ base_url = "https://api.z.ai/api/coding/paas/v4"
 }
 
 func TestKimiLocalAuthStatusUsesKimiCredentials(t *testing.T) {
+	clearKimiAuthEnv(t)
 	home := t.TempDir()
+	t.Setenv("KIMI_SHARE_DIR", t.TempDir())
 	t.Setenv("KIMI_CODE_HOME", home)
 	credentialsDir := filepath.Join(home, "credentials")
 	if err := os.MkdirAll(credentialsDir, 0o700); err != nil {
@@ -63,7 +148,9 @@ func TestKimiLocalAuthStatusUsesKimiCredentials(t *testing.T) {
 }
 
 func TestKimiLocalAuthStatusCredentialsOverrideEmptyConfigAPIKeys(t *testing.T) {
+	clearKimiAuthEnv(t)
 	home := t.TempDir()
+	t.Setenv("KIMI_SHARE_DIR", t.TempDir())
 	t.Setenv("KIMI_CODE_HOME", home)
 	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
 [providers.zai-coding-plan]
@@ -87,6 +174,13 @@ api_key = ""
 	}
 	if !ok || status != ports.AgentAuthStatusAuthorized {
 		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func clearKimiAuthEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range kimiAPIKeyEnvVars {
+		t.Setenv(name, "")
 	}
 }
 

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
+
+var kimiAPIKeyLineRE = regexp.MustCompile(`(?m)^\s*api_key\s*=\s*("([^"]*)"|'([^']*)'|([^\s#]+))`)
 
 const (
 	kimiInstructionsDirName  = ".kimi-code"

--- a/backend/internal/adapters/agent/kiro/auth.go
+++ b/backend/internal/adapters/agent/kiro/auth.go
@@ -2,6 +2,8 @@ package kiro
 
 import (
 	"context"
+	"os"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -14,6 +16,9 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	binary, err := p.kiroBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
+	}
+	if strings.TrimSpace(os.Getenv("KIRO_API_KEY")) != "" {
+		return ports.AgentAuthStatusAuthorized, nil
 	}
 	return kiroWhoamiAuthStatus(ctx, binary)
 }

--- a/backend/internal/adapters/agent/kiro/auth.go
+++ b/backend/internal/adapters/agent/kiro/auth.go
@@ -22,15 +22,7 @@ func kiroWhoamiAuthStatus(ctx context.Context, binary string) (ports.AgentAuthSt
 	if binary == "" {
 		return ports.AgentAuthStatusUnknown, nil
 	}
-	out, err := authprobe.CmdRunner(ctx, binary, "whoami")
-	if ctx.Err() != nil {
-		return ports.AgentAuthStatusUnknown, ctx.Err()
-	}
-	if status := authprobe.StatusFromText(string(out)); status != ports.AgentAuthStatusUnknown {
-		return status, nil
-	}
-	if err == nil {
-		return ports.AgentAuthStatusAuthorized, nil
-	}
-	return ports.AgentAuthStatusUnknown, nil
+	// Kiro documents `whoami` as its authentication-status command. Keep the
+	// probe bounded so catalog refresh cannot hang on a broken CLI install.
+	return authprobe.CLIStatus(ctx, binary, [][]string{{"whoami", "--format", "json"}})
 }

--- a/backend/internal/adapters/agent/kiro/kiro_test.go
+++ b/backend/internal/adapters/agent/kiro/kiro_test.go
@@ -342,8 +342,8 @@ func TestAuthStatusUsesKiroWhoami(t *testing.T) {
 		if name != "kiro-cli" {
 			t.Fatalf("binary = %q, want kiro-cli", name)
 		}
-		if !reflect.DeepEqual(arg, []string{"whoami"}) {
-			t.Fatalf("args = %#v, want [whoami]", arg)
+		if !reflect.DeepEqual(arg, []string{"whoami", "--format", "json"}) {
+			t.Fatalf("args = %#v, want [whoami --format json]", arg)
 		}
 		return []byte("Logged in with Google\nEmail: nicachale456@gmail.com\n"), nil
 	})

--- a/backend/internal/adapters/agent/muse/auth.go
+++ b/backend/internal/adapters/agent/muse/auth.go
@@ -88,12 +88,12 @@ func museAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 		if strings.TrimSpace(meta.AccessToken) != "" {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	case "api_key", "api-key", "apikey":
 		if strings.TrimSpace(meta.APIKey) != "" {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/muse/auth_test.go
+++ b/backend/internal/adapters/agent/muse/auth_test.go
@@ -58,8 +58,8 @@ func TestMuseAuthJSONStatusOAuthRequiresAccessToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/omp/auth.go
+++ b/backend/internal/adapters/agent/omp/auth.go
@@ -10,6 +10,7 @@ import (
 
 	_ "modernc.org/sqlite" // register sqlite driver for OMP auth database probes
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -19,7 +20,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 // auth store, then falls back to cheap CLI status probes when the file is
 // absent or inconclusive.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	_, err := p.ResolveBinary(ctx)
+	binary, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -28,7 +29,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return ports.AgentAuthStatusUnknown, nil
+	return authprobe.CLIStatus(ctx, binary, [][]string{{"auth", "status"}})
 }
 
 func ompLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {

--- a/backend/internal/adapters/agent/omp/auth.go
+++ b/backend/internal/adapters/agent/omp/auth.go
@@ -10,7 +10,6 @@ import (
 
 	_ "modernc.org/sqlite" // register sqlite driver for OMP auth database probes
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -20,7 +19,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 // auth store, then falls back to cheap CLI status probes when the file is
 // absent or inconclusive.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -29,7 +28,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 func ompLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
@@ -81,7 +80,7 @@ func ompAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	if len(entries) == 0 {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	for provider, entry := range entries {
 		if strings.TrimSpace(provider) == "" {
@@ -91,7 +90,7 @@ func ompAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
-	return ports.AgentAuthStatusUnauthorized, true, nil
+	return ports.AgentAuthStatusUnknown, false, nil
 }
 
 func ompAgentDBAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
@@ -127,7 +126,7 @@ func ompAgentDBAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
 	if total > 0 {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/omp/auth_test.go
+++ b/backend/internal/adapters/agent/omp/auth_test.go
@@ -1,15 +1,38 @@
 package omp
 
 import (
+	"context"
 	"database/sql"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	_ "modernc.org/sqlite"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
+
+func TestOMPAuthStatusUsesDocumentedStatusCommand(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
+	previous := authprobe.CmdRunner
+	authprobe.CmdRunner = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "omp" || !reflect.DeepEqual(args, []string{"auth", "status"}) {
+			t.Fatalf("command = %q %#v, want omp auth status", name, args)
+		}
+		return []byte("Logged in"), nil
+	}
+	t.Cleanup(func() { authprobe.CmdRunner = previous })
+
+	status, err := (&Plugin{resolvedBinary: "omp"}).AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	}
+}
 
 func TestOMPAuthJSONStatusAuthorizedWithKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "auth.json")

--- a/backend/internal/adapters/agent/omp/auth_test.go
+++ b/backend/internal/adapters/agent/omp/auth_test.go
@@ -24,7 +24,7 @@ func TestOMPAuthJSONStatusAuthorizedWithKey(t *testing.T) {
 	}
 }
 
-func TestOMPAuthJSONStatusUnauthorizedWhenEmpty(t *testing.T) {
+func TestOMPAuthJSONStatusUnknownWhenEmpty(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "auth.json")
 	writeFile(t, path, `{}`)
 
@@ -32,8 +32,8 @@ func TestOMPAuthJSONStatusUnauthorizedWhenEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status=%q ok=%v, want unauthorized true", status, ok)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status=%q ok=%v, want unknown false", status, ok)
 	}
 }
 

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -191,6 +191,9 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 
 	out, err := aoprocess.CommandContext(probeCtx, binary, "auth", "list").CombinedOutput()
 	if probeCtx.Err() != nil {
+		if probeCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+			return ports.AgentAuthStatusUnknown, nil
+		}
 		return ports.AgentAuthStatusUnknown, probeCtx.Err()
 	}
 	text := strings.ToLower(string(out))

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -197,7 +197,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 		return ports.AgentAuthStatusUnknown, probeCtx.Err()
 	}
 	text := strings.ToLower(string(out))
-	if strings.Contains(text, "0 credentials") {
+	if strings.Contains(text, "0 credentials") || strings.Contains(text, "no credentials") || strings.Contains(text, "not authenticated") {
 		return ports.AgentAuthStatusUnknown, nil
 	}
 	if strings.Contains(text, "credential") && err == nil {

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -232,6 +232,25 @@ func TestOpenCodeAuthStatusUnknownWithZeroCredentials(t *testing.T) {
 	}
 }
 
+func TestOpenCodeAuthStatusUnknownWithNoCredentials(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OPENCODE_DATA_DIR", filepath.Join(dir, "missing-data"))
+	for _, name := range opencodeAPIKeyEnvVars {
+		t.Setenv(name, "")
+	}
+	binary := filepath.Join(dir, "opencode")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nprintf 'No credentials found\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	status, err := (&Plugin{resolvedBinary: binary}).AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("AuthStatus = %q, want %q", status, ports.AgentAuthStatusUnknown)
+	}
+}
+
 func TestOpenCodeLocalAuthStatusUnknownWhenMissing(t *testing.T) {
 	clearOpenCodeAuthEnv(t)
 	home := t.TempDir()

--- a/backend/internal/adapters/agent/pi/auth.go
+++ b/backend/internal/adapters/agent/pi/auth.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -15,16 +14,12 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, err
-	}
 	if status, ok, err := piLocalAuthStatus(ctx); err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 func piLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
@@ -71,7 +66,7 @@ func piAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
 	if len(entries) == 0 {
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	for provider, entry := range entries {
 		if strings.TrimSpace(provider) == "" {
@@ -81,5 +76,5 @@ func piAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
-	return ports.AgentAuthStatusUnauthorized, true, nil
+	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/pi/auth.go
+++ b/backend/internal/adapters/agent/pi/auth.go
@@ -26,6 +26,15 @@ func piLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error)
 	if err := ctx.Err(); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
+	for _, name := range []string{
+		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+		"MISTRAL_API_KEY", "GROQ_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY",
+		"DEEPSEEK_API_KEY", "ZAI_API_KEY", "CEREBRAS_API_KEY", "KIMI_API_KEY",
+	} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+	}
 	configDir, ok := piConfigDir()
 	if !ok {
 		return ports.AgentAuthStatusUnknown, false, nil

--- a/backend/internal/adapters/agent/pi/auth.go
+++ b/backend/internal/adapters/agent/pi/auth.go
@@ -81,9 +81,34 @@ func piAuthJSONStatus(path string) (ports.AgentAuthStatus, bool, error) {
 		if strings.TrimSpace(provider) == "" {
 			continue
 		}
-		if strings.TrimSpace(entry.Key) != "" {
+		if piAuthKeyIsResolved(entry.Key) {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func piAuthKeyIsResolved(key string) bool {
+	key = strings.TrimSpace(key)
+	if key == "" || strings.HasPrefix(key, "!") {
+		// Avoid executing configured commands during a global auth probe. Their
+		// result remains unknown until Pi resolves them while launching.
+		return false
+	}
+
+	resolved := true
+	expanded := os.Expand(key, func(name string) string {
+		switch name {
+		case "$", "!":
+			// Pi documents $$ and $! as escaped literal prefixes.
+			return name
+		default:
+			value, ok := os.LookupEnv(name)
+			if !ok || strings.TrimSpace(value) == "" {
+				resolved = false
+			}
+			return value
+		}
+	})
+	return resolved && strings.TrimSpace(expanded) != ""
 }

--- a/backend/internal/adapters/agent/pi/auth_test.go
+++ b/backend/internal/adapters/agent/pi/auth_test.go
@@ -20,6 +20,42 @@ func TestPiAuthJSONStatusAuthorizedWithProviderKey(t *testing.T) {
 	}
 }
 
+func TestPiAuthJSONStatusAuthorizedWithResolvedEnvKey(t *testing.T) {
+	t.Setenv("PI_TEST_API_KEY", "resolved-key")
+	path := writePiAuthJSON(t, `{"zai":{"type":"api_key","key":"$PI_TEST_API_KEY"}}`)
+
+	status, ok, err := piAuthJSONStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestPiAuthJSONStatusUnknownWithUnresolvedKey(t *testing.T) {
+	t.Setenv("PI_MISSING_API_KEY", "")
+	tests := map[string]string{
+		"missing environment variable":        `{"zai":{"type":"api_key","key":"$PI_MISSING_API_KEY"}}`,
+		"missing braced environment variable": `{"zai":{"type":"api_key","key":"${PI_MISSING_API_KEY}"}}`,
+		"unverified command":                  `{"zai":{"type":"api_key","key":"!false"}}`,
+	}
+
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := writePiAuthJSON(t, content)
+
+			status, ok, err := piAuthJSONStatus(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ok || status != ports.AgentAuthStatusUnknown {
+				t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+			}
+		})
+	}
+}
+
 func TestPiAuthJSONStatusUnknownWhenEmpty(t *testing.T) {
 	path := writePiAuthJSON(t, `{}`)
 

--- a/backend/internal/adapters/agent/pi/auth_test.go
+++ b/backend/internal/adapters/agent/pi/auth_test.go
@@ -20,15 +20,15 @@ func TestPiAuthJSONStatusAuthorizedWithProviderKey(t *testing.T) {
 	}
 }
 
-func TestPiAuthJSONStatusUnauthorizedWhenEmpty(t *testing.T) {
+func TestPiAuthJSONStatusUnknownWhenEmpty(t *testing.T) {
 	path := writePiAuthJSON(t, `{}`)
 
 	status, ok, err := piAuthJSONStatus(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/primeagent/auth.go
+++ b/backend/internal/adapters/agent/primeagent/auth.go
@@ -1,0 +1,201 @@
+package primeagent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+var _ ports.AgentAuthChecker = (*Plugin)(nil)
+
+// AuthStatus checks Prime Agent's documented credential sources without
+// starting a session or making a provider request.
+func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
+	if _, err := p.ResolveBinary(ctx); err != nil {
+		if errors.Is(err, ports.ErrAgentBinaryNotFound) {
+			return ports.AgentAuthStatusUnknown, nil
+		}
+		return ports.AgentAuthStatusUnknown, err
+	}
+	status, ok, err := primeLocalAuthStatus(ctx)
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	}
+	if ok {
+		return status, nil
+	}
+	return ports.AgentAuthStatusUnknown, nil
+}
+
+var primeAPIKeyEnvVars = []string{
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_OAUTH_TOKEN",
+	"AZURE_OPENAI_API_KEY",
+	"OPENAI_API_KEY",
+	"PRIME_API_KEY",
+	"DEEPSEEK_API_KEY",
+	"GEMINI_API_KEY",
+	"GOOGLE_CLOUD_API_KEY",
+	"MISTRAL_API_KEY",
+	"GROQ_API_KEY",
+	"CEREBRAS_API_KEY",
+	"CLOUDFLARE_API_KEY",
+	"XAI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"AI_GATEWAY_API_KEY",
+	"ZAI_API_KEY",
+	"OPENCODE_API_KEY",
+	"HF_TOKEN",
+	"FIREWORKS_API_KEY",
+	"KIMI_API_KEY",
+	"MINIMAX_API_KEY",
+	"MINIMAX_CN_API_KEY",
+	"XIAOMI_API_KEY",
+	"XIAOMI_TOKEN_PLAN_CN_API_KEY",
+	"XIAOMI_TOKEN_PLAN_AMS_API_KEY",
+	"XIAOMI_TOKEN_PLAN_SGP_API_KEY",
+	"AWS_BEARER_TOKEN_BEDROCK",
+}
+
+func primeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	for _, name := range primeAPIKeyEnvVars {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+	}
+	if primeAWSCredentialEnvConfigured() || primeGoogleCredentialConfigured() {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
+
+	dir, ok := primeConfigDir()
+	if !ok {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	for _, name := range []string{"auth.json", "models.json"} {
+		status, found, err := primeCredentialJSONStatus(filepath.Join(dir, name), name == "auth.json")
+		if err != nil || found {
+			return status, found, err
+		}
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func primeConfigDir() (string, bool) {
+	for _, name := range []string{primeAgentCodingAgentDirEnv, "PI_CODING_AGENT_DIR"} {
+		if dir := strings.TrimSpace(os.Getenv(name)); dir != "" {
+			return dir, true
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", false
+	}
+	return filepath.Join(home, ".prime", "agent"), true
+}
+
+func primeAWSCredentialEnvConfigured() bool {
+	if strings.TrimSpace(os.Getenv("AWS_PROFILE")) != "" ||
+		strings.TrimSpace(os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")) != "" ||
+		strings.TrimSpace(os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")) != "" {
+		return true
+	}
+	if strings.TrimSpace(os.Getenv("AWS_ACCESS_KEY_ID")) != "" &&
+		strings.TrimSpace(os.Getenv("AWS_SECRET_ACCESS_KEY")) != "" {
+		return true
+	}
+	return strings.TrimSpace(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")) != "" &&
+		strings.TrimSpace(os.Getenv("AWS_ROLE_ARN")) != ""
+}
+
+func primeGoogleCredentialConfigured() bool {
+	project := strings.TrimSpace(os.Getenv("GOOGLE_CLOUD_PROJECT"))
+	if project == "" {
+		project = strings.TrimSpace(os.Getenv("GOOGLE_CLOUD_PROJECT_ID"))
+	}
+	if project == "" {
+		project = strings.TrimSpace(os.Getenv("GCLOUD_PROJECT"))
+	}
+	if project == "" || strings.TrimSpace(os.Getenv("GOOGLE_CLOUD_LOCATION")) == "" {
+		return false
+	}
+	if path := strings.TrimSpace(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")); path != "" {
+		return primeNonEmptyRegularFile(path)
+	}
+	if configHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); configHome != "" {
+		return primeNonEmptyRegularFile(filepath.Join(configHome, "gcloud", "application_default_credentials.json"))
+	}
+	if appData := strings.TrimSpace(os.Getenv("APPDATA")); appData != "" {
+		return primeNonEmptyRegularFile(filepath.Join(appData, "gcloud", "application_default_credentials.json"))
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	return primeNonEmptyRegularFile(filepath.Join(home, ".config", "gcloud", "application_default_credentials.json"))
+}
+
+func primeNonEmptyRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular() && info.Size() > 0
+}
+
+func primeCredentialJSONStatus(path string, allowPlainKey bool) (ports.AgentAuthStatus, bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if primeJSONHasCredential(value, allowPlainKey) {
+		return ports.AgentAuthStatusAuthorized, true, nil
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func primeJSONHasCredential(value any, allowPlainKey bool) bool {
+	switch value := value.(type) {
+	case []any:
+		for _, child := range value {
+			if primeJSONHasCredential(child, allowPlainKey) {
+				return true
+			}
+		}
+	case map[string]any:
+		for key, child := range value {
+			if allowPlainKey && strings.HasPrefix(strings.ToLower(strings.TrimSpace(key)), "mcp:") {
+				continue
+			}
+			normalized := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(key, "_", ""), "-", ""))
+			if text, ok := child.(string); ok && strings.TrimSpace(text) != "" {
+				switch normalized {
+				case "apikey", "access", "refresh", "accesstoken", "refreshtoken", "oauthtoken":
+					return true
+				case "key":
+					if allowPlainKey {
+						return true
+					}
+				}
+			}
+			if primeJSONHasCredential(child, allowPlainKey) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/backend/internal/adapters/agent/primeagent/auth.go
+++ b/backend/internal/adapters/agent/primeagent/auth.go
@@ -180,7 +180,7 @@ func primeJSONHasCredential(value any, allowPlainKey bool) bool {
 		}
 	case map[string]any:
 		for key, child := range value {
-			if allowPlainKey && strings.HasPrefix(strings.ToLower(strings.TrimSpace(key)), "mcp:") {
+			if strings.HasPrefix(strings.ToLower(strings.TrimSpace(key)), "mcp:") {
 				continue
 			}
 			normalized := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(key, "_", ""), "-", ""))

--- a/backend/internal/adapters/agent/primeagent/auth.go
+++ b/backend/internal/adapters/agent/primeagent/auth.go
@@ -83,6 +83,10 @@ func primeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, err
 	if err != nil || found {
 		return status, found, err
 	}
+	status, found, err = primeCredentialJSONStatus(filepath.Join(dir, "models.json"), false)
+	if err != nil || found {
+		return status, found, err
+	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }
 

--- a/backend/internal/adapters/agent/primeagent/auth.go
+++ b/backend/internal/adapters/agent/primeagent/auth.go
@@ -79,11 +79,9 @@ func primeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, err
 	if !ok {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	for _, name := range []string{"auth.json", "models.json"} {
-		status, found, err := primeCredentialJSONStatus(filepath.Join(dir, name), name == "auth.json")
-		if err != nil || found {
-			return status, found, err
-		}
+	status, found, err := primeCredentialJSONStatus(filepath.Join(dir, "auth.json"), true)
+	if err != nil || found {
+		return status, found, err
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/primeagent/auth_test.go
+++ b/backend/internal/adapters/agent/primeagent/auth_test.go
@@ -56,7 +56,7 @@ func TestPrimeLocalAuthStatusUnknownForEmptyAuthFile(t *testing.T) {
 	}
 }
 
-func TestPrimeLocalAuthStatusIgnoresModelsFileCredentials(t *testing.T) {
+func TestPrimeLocalAuthStatusAuthorizedFromModelsFileCredentials(t *testing.T) {
 	clearPrimeCredentialEnv(t)
 	dir := t.TempDir()
 	t.Setenv(primeAgentCodingAgentDirEnv, dir)
@@ -67,8 +67,8 @@ func TestPrimeLocalAuthStatusIgnoresModelsFileCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ok || status != ports.AgentAuthStatusUnknown {
-		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
 	}
 }
 

--- a/backend/internal/adapters/agent/primeagent/auth_test.go
+++ b/backend/internal/adapters/agent/primeagent/auth_test.go
@@ -86,6 +86,20 @@ func TestPrimeCredentialJSONIgnoresMCPOnlyCredentials(t *testing.T) {
 	}
 }
 
+func TestPrimeModelsJSONIgnoresMCPOnlyCredentials(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "models.json")
+	if err := os.WriteFile(path, []byte(`{"mcp:notion":{"accessToken":"mcp-token"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, ok, err := primeCredentialJSONStatus(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
 func TestPrimeCredentialJSONAuthorizedFromOAuth(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "auth.json")
 	if err := os.WriteFile(path, []byte(`{"openai-codex":{"type":"oauth","access":"oauth-token"}}`), 0o600); err != nil {

--- a/backend/internal/adapters/agent/primeagent/auth_test.go
+++ b/backend/internal/adapters/agent/primeagent/auth_test.go
@@ -1,0 +1,100 @@
+package primeagent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestPrimeLocalAuthStatusAuthorizedFromProviderEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	status, ok, err := primeLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestPrimeLocalAuthStatusAuthorizedFromAuthFile(t *testing.T) {
+	clearPrimeCredentialEnv(t)
+	dir := t.TempDir()
+	t.Setenv(primeAgentCodingAgentDirEnv, dir)
+	path := filepath.Join(dir, "auth.json")
+	if err := os.WriteFile(path, []byte(`{"anthropic":{"type":"api_key","key":"test-key"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := primeLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestPrimeLocalAuthStatusUnknownForEmptyAuthFile(t *testing.T) {
+	clearPrimeCredentialEnv(t)
+	dir := t.TempDir()
+	t.Setenv(primeAgentCodingAgentDirEnv, dir)
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := primeLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestPrimeCredentialJSONIgnoresMCPOnlyCredentials(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(path, []byte(`{"mcp:notion":{"accessToken":"mcp-token"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, ok, err := primeCredentialJSONStatus(path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestPrimeCredentialJSONAuthorizedFromOAuth(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(path, []byte(`{"openai-codex":{"type":"oauth","access":"oauth-token"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, ok, err := primeCredentialJSONStatus(path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func clearPrimeCredentialEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range primeAPIKeyEnvVars {
+		t.Setenv(name, "")
+	}
+	for _, name := range []string{
+		"AWS_PROFILE", "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN",
+		"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID",
+		"GCLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION", "XDG_CONFIG_HOME", "APPDATA",
+	} {
+		t.Setenv(name, "")
+	}
+}

--- a/backend/internal/adapters/agent/primeagent/auth_test.go
+++ b/backend/internal/adapters/agent/primeagent/auth_test.go
@@ -56,6 +56,22 @@ func TestPrimeLocalAuthStatusUnknownForEmptyAuthFile(t *testing.T) {
 	}
 }
 
+func TestPrimeLocalAuthStatusIgnoresModelsFileCredentials(t *testing.T) {
+	clearPrimeCredentialEnv(t)
+	dir := t.TempDir()
+	t.Setenv(primeAgentCodingAgentDirEnv, dir)
+	if err := os.WriteFile(filepath.Join(dir, "models.json"), []byte(`{"providers":{"custom":{"apiKey":"looks-like-a-key"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, ok, err := primeLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
 func TestPrimeCredentialJSONIgnoresMCPOnlyCredentials(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "auth.json")
 	if err := os.WriteFile(path, []byte(`{"mcp:notion":{"accessToken":"mcp-token"}}`), 0o600); err != nil {

--- a/backend/internal/adapters/agent/qwen/auth.go
+++ b/backend/internal/adapters/agent/qwen/auth.go
@@ -32,6 +32,9 @@ var qwenAPIKeyEnvVars = []string{
 	"QWEN_API_KEY",
 	"BAILIAN_CODING_PLAN_API_KEY",
 	"OPENAI_API_KEY",
+	"ANTHROPIC_API_KEY",
+	"GEMINI_API_KEY",
+	"GOOGLE_API_KEY",
 	"OPENROUTER_API_KEY",
 	"REQUESTY_API_KEY",
 	"DASHSCOPE_API_KEY",
@@ -54,11 +57,33 @@ func qwenLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	if home == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	settingsPath := filepath.Join(home, ".qwen", "settings.json")
+	qwenHome := qwenHomeDir(home)
+	settingsPath := filepath.Join(qwenHome, "settings.json")
 	if status, ok, err := qwenAuthStatusFromSettings(settingsPath); err != nil || ok {
 		return status, ok, err
 	}
-	return ports.AgentAuthStatusUnknown, false, nil
+	names, err := qwenConfiguredEnvNamesFromSettings(settingsPath)
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	return qwenGlobalEnvAuthStatus(qwenHome, home, names...)
+}
+
+// qwenHomeDir mirrors Qwen Code's QWEN_HOME override for global state. Project
+// settings and .env files deliberately are not considered here: the catalog's
+// auth probe has no session workspace, so the daemon's current directory is not
+// a valid substitute for a project directory.
+func qwenHomeDir(home string) string {
+	if path := strings.TrimSpace(os.Getenv("QWEN_HOME")); path != "" {
+		if path == "~" {
+			return home
+		}
+		if strings.HasPrefix(path, "~/") {
+			return filepath.Join(home, strings.TrimPrefix(path, "~/"))
+		}
+		return path
+	}
+	return filepath.Join(home, ".qwen")
 }
 
 func qwenAuthStatusFromSettings(path string) (ports.AgentAuthStatus, bool, error) {
@@ -77,10 +102,29 @@ func qwenAuthStatusFromSettings(path string) (ports.AgentAuthStatus, bool, error
 	if err := json.Unmarshal(data, &root); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	if containsQwenAPIKey(root) || qwenConfiguredEnvPresent(root) {
+	if containsQwenAPIKey(root) || qwenConfiguredEnvPresent(root) || qwenSettingsEnvPresent(root, qwenConfiguredEnvNames(root)...) {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+// qwenSettingsEnvPresent recognizes the documented settings.json "env" map,
+// whose values are loaded as Qwen's lowest-priority credential source.
+func qwenSettingsEnvPresent(value any, extraNames ...string) bool {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	env, ok := root["env"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for name, value := range env {
+		if qwenKnownAPIKeyEnvVar(name, extraNames...) && stringSetting(value) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func qwenConfiguredEnvPresent(value any) bool {
@@ -100,6 +144,101 @@ func qwenConfiguredEnvPresent(value any) bool {
 			if qwenConfiguredEnvPresent(child) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func qwenConfiguredEnvNamesFromSettings(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, err
+	}
+	return qwenConfiguredEnvNames(root), nil
+}
+
+func qwenConfiguredEnvNames(value any) []string {
+	var names []string
+	var visit func(any)
+	visit = func(value any) {
+		switch v := value.(type) {
+		case map[string]any:
+			for key, child := range v {
+				if strings.EqualFold(key, "envKey") {
+					if name := stringSetting(child); name != "" && !containsQwenEnvName(names, name) {
+						names = append(names, name)
+					}
+				}
+				visit(child)
+			}
+		case []any:
+			for _, child := range v {
+				visit(child)
+			}
+		}
+	}
+	visit(value)
+	return names
+}
+
+func qwenGlobalEnvAuthStatus(qwenHome, home string, extraNames ...string) (ports.AgentAuthStatus, bool, error) {
+	// Qwen falls back to these user-scoped .env files only after its
+	// workspace search. The workspace search cannot be performed safely by a
+	// global catalog probe, which has no workspace input.
+	for _, path := range []string{filepath.Join(qwenHome, ".env"), filepath.Join(home, ".env")} {
+		status, ok, err := qwenEnvFileAuthStatus(path, extraNames...)
+		if err != nil || ok {
+			return status, ok, err
+		}
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func qwenEnvFileAuthStatus(path string, extraNames ...string) (ports.AgentAuthStatus, bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok || !qwenKnownAPIKeyEnvVar(strings.TrimSpace(key), extraNames...) {
+			continue
+		}
+		if strings.Trim(strings.TrimSpace(value), `"'`) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func qwenKnownAPIKeyEnvVar(name string, extraNames ...string) bool {
+	for _, candidate := range qwenAPIKeyEnvVars {
+		if name == candidate {
+			return true
+		}
+	}
+	for _, candidate := range extraNames {
+		if name == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func containsQwenEnvName(names []string, target string) bool {
+	for _, name := range names {
+		if name == target {
+			return true
 		}
 	}
 	return false

--- a/backend/internal/adapters/agent/qwen/auth.go
+++ b/backend/internal/adapters/agent/qwen/auth.go
@@ -24,7 +24,9 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	// Qwen Code removed the standalone `qwen auth` command. Its documentation
+	// names `qwen doctor` as the non-interactive way to inspect auth state.
+	return authprobe.CLIStatus(ctx, binary, [][]string{{"doctor"}})
 }
 
 var qwenAPIKeyEnvVars = []string{

--- a/backend/internal/adapters/agent/qwen/auth.go
+++ b/backend/internal/adapters/agent/qwen/auth.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -15,8 +14,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
-	if err != nil {
+	if _, err := p.ResolveBinary(ctx); err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
 	if status, ok, err := qwenLocalAuthStatus(ctx); err != nil {
@@ -24,9 +22,10 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	// Qwen Code removed the standalone `qwen auth` command. Its documentation
-	// names `qwen doctor` as the non-interactive way to inspect auth state.
-	return authprobe.CLIStatus(ctx, binary, [][]string{{"doctor"}})
+	// Qwen documents /doctor as an in-session command. Do not invoke the CLI
+	// with a "doctor" positional argument: it would enter the interactive
+	// surface rather than provide a documented, non-interactive auth probe.
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 var qwenAPIKeyEnvVars = []string{
@@ -48,7 +47,6 @@ func qwenLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
@@ -56,7 +54,15 @@ func qwenLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	if home == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
-	return qwenAuthStatusFromSettings(filepath.Join(home, ".qwen", "settings.json"))
+	settingsPath := filepath.Join(home, ".qwen", "settings.json")
+	if status, ok, err := qwenAuthStatusFromSettings(settingsPath); err != nil || ok {
+		return status, ok, err
+	}
+	names, err := qwenConfiguredEnvNamesFromSettings(settingsPath)
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	return qwenProjectEnvAuthStatus(names...)
 }
 
 func qwenAuthStatusFromSettings(path string) (ports.AgentAuthStatus, bool, error) {
@@ -75,10 +81,128 @@ func qwenAuthStatusFromSettings(path string) (ports.AgentAuthStatus, bool, error
 	if err := json.Unmarshal(data, &root); err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
-	if containsQwenAPIKey(root) {
+	if containsQwenAPIKey(root) || qwenConfiguredEnvPresent(root) {
 		return ports.AgentAuthStatusAuthorized, true, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func qwenConfiguredEnvPresent(value any) bool {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			if strings.EqualFold(key, "envKey") && strings.TrimSpace(stringSetting(child)) != "" &&
+				strings.TrimSpace(os.Getenv(stringSetting(child))) != "" {
+				return true
+			}
+			if qwenConfiguredEnvPresent(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if qwenConfiguredEnvPresent(child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func qwenConfiguredEnvNamesFromSettings(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, err
+	}
+	return qwenConfiguredEnvNames(root), nil
+}
+
+func qwenConfiguredEnvNames(value any) []string {
+	var names []string
+	var visit func(any)
+	visit = func(value any) {
+		switch v := value.(type) {
+		case map[string]any:
+			for key, child := range v {
+				if strings.EqualFold(key, "envKey") {
+					if name := stringSetting(child); name != "" && !containsQwenEnvName(names, name) {
+						names = append(names, name)
+					}
+				}
+				visit(child)
+			}
+		case []any:
+			for _, child := range v {
+				visit(child)
+			}
+		}
+	}
+	visit(value)
+	return names
+}
+
+func qwenProjectEnvAuthStatus(extraNames ...string) (ports.AgentAuthStatus, bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil || cwd == "" {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	for _, path := range []string{filepath.Join(cwd, ".env"), filepath.Join(cwd, ".qwen", ".env")} {
+		status, ok, err := qwenEnvFileAuthStatus(path, extraNames...)
+		if err != nil || ok {
+			return status, ok, err
+		}
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func qwenEnvFileAuthStatus(path string, extraNames ...string) (ports.AgentAuthStatus, bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok || !qwenKnownAPIKeyEnvVar(strings.TrimSpace(key), extraNames...) {
+			continue
+		}
+		if strings.Trim(strings.TrimSpace(value), `"'`) != "" {
+			return ports.AgentAuthStatusAuthorized, true, nil
+		}
+	}
+	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+func qwenKnownAPIKeyEnvVar(name string, extraNames ...string) bool {
+	for _, candidate := range qwenAPIKeyEnvVars {
+		if name == candidate {
+			return true
+		}
+	}
+	for _, candidate := range extraNames {
+		if name == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func containsQwenEnvName(names []string, target string) bool {
+	for _, name := range names {
+		if name == target {
+			return true
+		}
+	}
+	return false
 }
 
 func containsQwenAPIKey(value any) bool {

--- a/backend/internal/adapters/agent/qwen/auth.go
+++ b/backend/internal/adapters/agent/qwen/auth.go
@@ -58,11 +58,7 @@ func qwenLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	if status, ok, err := qwenAuthStatusFromSettings(settingsPath); err != nil || ok {
 		return status, ok, err
 	}
-	names, err := qwenConfiguredEnvNamesFromSettings(settingsPath)
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	return qwenProjectEnvAuthStatus(names...)
+	return ports.AgentAuthStatusUnknown, false, nil
 }
 
 func qwenAuthStatusFromSettings(path string) (ports.AgentAuthStatus, bool, error) {
@@ -104,105 +100,6 @@ func qwenConfiguredEnvPresent(value any) bool {
 			if qwenConfiguredEnvPresent(child) {
 				return true
 			}
-		}
-	}
-	return false
-}
-
-func qwenConfiguredEnvNamesFromSettings(path string) ([]string, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	var root any
-	if err := json.Unmarshal(data, &root); err != nil {
-		return nil, err
-	}
-	return qwenConfiguredEnvNames(root), nil
-}
-
-func qwenConfiguredEnvNames(value any) []string {
-	var names []string
-	var visit func(any)
-	visit = func(value any) {
-		switch v := value.(type) {
-		case map[string]any:
-			for key, child := range v {
-				if strings.EqualFold(key, "envKey") {
-					if name := stringSetting(child); name != "" && !containsQwenEnvName(names, name) {
-						names = append(names, name)
-					}
-				}
-				visit(child)
-			}
-		case []any:
-			for _, child := range v {
-				visit(child)
-			}
-		}
-	}
-	visit(value)
-	return names
-}
-
-func qwenProjectEnvAuthStatus(extraNames ...string) (ports.AgentAuthStatus, bool, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	if cwd == "" {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	for _, path := range []string{filepath.Join(cwd, ".env"), filepath.Join(cwd, ".qwen", ".env")} {
-		status, ok, err := qwenEnvFileAuthStatus(path, extraNames...)
-		if err != nil || ok {
-			return status, ok, err
-		}
-	}
-	return ports.AgentAuthStatusUnknown, false, nil
-}
-
-func qwenEnvFileAuthStatus(path string, extraNames ...string) (ports.AgentAuthStatus, bool, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
-		if !ok || !qwenKnownAPIKeyEnvVar(strings.TrimSpace(key), extraNames...) {
-			continue
-		}
-		if strings.Trim(strings.TrimSpace(value), `"'`) != "" {
-			return ports.AgentAuthStatusAuthorized, true, nil
-		}
-	}
-	return ports.AgentAuthStatusUnknown, false, nil
-}
-
-func qwenKnownAPIKeyEnvVar(name string, extraNames ...string) bool {
-	for _, candidate := range qwenAPIKeyEnvVars {
-		if name == candidate {
-			return true
-		}
-	}
-	for _, candidate := range extraNames {
-		if name == candidate {
-			return true
-		}
-	}
-	return false
-}
-
-func containsQwenEnvName(names []string, target string) bool {
-	for _, name := range names {
-		if name == target {
-			return true
 		}
 	}
 	return false

--- a/backend/internal/adapters/agent/qwen/auth.go
+++ b/backend/internal/adapters/agent/qwen/auth.go
@@ -150,7 +150,10 @@ func qwenConfiguredEnvNames(value any) []string {
 
 func qwenProjectEnvAuthStatus(extraNames ...string) (ports.AgentAuthStatus, bool, error) {
 	cwd, err := os.Getwd()
-	if err != nil || cwd == "" {
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, false, err
+	}
+	if cwd == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	for _, path := range []string{filepath.Join(cwd, ".env"), filepath.Join(cwd, ".qwen", ".env")} {

--- a/backend/internal/adapters/agent/qwen/auth_test.go
+++ b/backend/internal/adapters/agent/qwen/auth_test.go
@@ -83,36 +83,6 @@ func TestQwenAuthStatusFromSettingsAuthorizedWithConfiguredEnvKey(t *testing.T) 
 	}
 }
 
-func TestQwenEnvFileAuthStatusAuthorizedWithDocumentedProviderKey(t *testing.T) {
-	path := filepath.Join(t.TempDir(), ".env")
-	if err := os.WriteFile(path, []byte("OPENROUTER_API_KEY=router-key\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	status, ok, err := qwenEnvFileAuthStatus(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
-	}
-}
-
-func TestQwenEnvFileAuthStatusAuthorizedWithConfiguredProviderKey(t *testing.T) {
-	path := filepath.Join(t.TempDir(), ".env")
-	if err := os.WriteFile(path, []byte("CUSTOM_QWEN_KEY=custom-key\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	status, ok, err := qwenEnvFileAuthStatus(path, "CUSTOM_QWEN_KEY")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
-	}
-}
-
 func TestQwenAuthStatusFromSettingsUnknownWhenMissing(t *testing.T) {
 	status, ok, err := qwenAuthStatusFromSettings(filepath.Join(t.TempDir(), "missing.json"))
 	if err != nil {
@@ -127,7 +97,6 @@ func TestAuthStatusWithoutLocalEvidenceStaysUnknown(t *testing.T) {
 	for _, name := range qwenAPIKeyEnvVars {
 		t.Setenv(name, "")
 	}
-	t.Chdir(t.TempDir())
 	status, err := (&Plugin{resolvedBinary: "qwen"}).AuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/backend/internal/adapters/agent/qwen/auth_test.go
+++ b/backend/internal/adapters/agent/qwen/auth_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -69,6 +67,52 @@ func TestQwenAuthStatusFromSettingsAuthorizedWithSecurityAuthAPIKey(t *testing.T
 	}
 }
 
+func TestQwenAuthStatusFromSettingsAuthorizedWithConfiguredEnvKey(t *testing.T) {
+	t.Setenv("CUSTOM_QWEN_KEY", "configured-key")
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"modelProviders":{"custom":{"envKey":"CUSTOM_QWEN_KEY"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := qwenAuthStatusFromSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestQwenEnvFileAuthStatusAuthorizedWithDocumentedProviderKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("OPENROUTER_API_KEY=router-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := qwenEnvFileAuthStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestQwenEnvFileAuthStatusAuthorizedWithConfiguredProviderKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("CUSTOM_QWEN_KEY=custom-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := qwenEnvFileAuthStatus(path, "CUSTOM_QWEN_KEY")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestQwenAuthStatusFromSettingsUnknownWhenMissing(t *testing.T) {
 	status, ok, err := qwenAuthStatusFromSettings(filepath.Join(t.TempDir(), "missing.json"))
 	if err != nil {
@@ -79,27 +123,16 @@ func TestQwenAuthStatusFromSettingsUnknownWhenMissing(t *testing.T) {
 	}
 }
 
-func TestAuthStatusUsesQwenDoctor(t *testing.T) {
-	restore := mockQwenAuthProbeRunner(t, func(_ context.Context, name string, arg ...string) ([]byte, error) {
-		if name != "qwen" || !reflect.DeepEqual(arg, []string{"doctor"}) {
-			t.Fatalf("command = %s %#v, want qwen doctor", name, arg)
-		}
-		return []byte("Authentication: authenticated"), nil
-	})
-	defer restore()
-
+func TestAuthStatusWithoutLocalEvidenceStaysUnknown(t *testing.T) {
+	for _, name := range qwenAPIKeyEnvVars {
+		t.Setenv(name, "")
+	}
+	t.Chdir(t.TempDir())
 	status, err := (&Plugin{resolvedBinary: "qwen"}).AuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	if status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusUnknown)
 	}
-}
-
-func mockQwenAuthProbeRunner(t *testing.T, runner func(context.Context, string, ...string) ([]byte, error)) func() {
-	t.Helper()
-	previous := authprobe.CmdRunner
-	authprobe.CmdRunner = runner
-	return func() { authprobe.CmdRunner = previous }
 }

--- a/backend/internal/adapters/agent/qwen/auth_test.go
+++ b/backend/internal/adapters/agent/qwen/auth_test.go
@@ -21,6 +21,18 @@ func TestQwenLocalAuthStatusAuthorizedWithProviderEnv(t *testing.T) {
 	}
 }
 
+func TestQwenLocalAuthStatusAuthorizedWithDocumentedProtocolEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
+
+	status, ok, err := qwenLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestQwenAuthStatusFromSettingsAuthorizedWithModelProviderAPIKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	content := `{
@@ -83,6 +95,90 @@ func TestQwenAuthStatusFromSettingsAuthorizedWithConfiguredEnvKey(t *testing.T) 
 	}
 }
 
+func TestQwenAuthStatusFromSettingsAuthorizedWithDocumentedEnv(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"env":{"GEMINI_API_KEY":"gemini-key"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := qwenAuthStatusFromSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestQwenEnvFileAuthStatusAuthorizedWithDocumentedProviderKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("OPENROUTER_API_KEY=router-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := qwenEnvFileAuthStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestQwenGlobalEnvAuthStatusUsesQwenHome(t *testing.T) {
+	home := t.TempDir()
+	qwenHome := filepath.Join(home, "custom-qwen")
+	if err := os.MkdirAll(qwenHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(qwenHome, ".env"), []byte("GOOGLE_API_KEY=google-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := qwenGlobalEnvAuthStatus(qwenHome, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestQwenGlobalEnvAuthStatusIgnoresDaemonWorkingDirectory(t *testing.T) {
+	root := t.TempDir()
+	qwenHome := filepath.Join(root, "qwen")
+	if err := os.MkdirAll(qwenHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("QWEN_API_KEY=project-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+
+	status, ok, err := qwenGlobalEnvAuthStatus(qwenHome, filepath.Join(root, "home"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
+func TestQwenEnvFileAuthStatusAuthorizedWithConfiguredProviderKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("CUSTOM_QWEN_KEY=custom-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := qwenEnvFileAuthStatus(path, "CUSTOM_QWEN_KEY")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
 func TestQwenAuthStatusFromSettingsUnknownWhenMissing(t *testing.T) {
 	status, ok, err := qwenAuthStatusFromSettings(filepath.Join(t.TempDir(), "missing.json"))
 	if err != nil {
@@ -97,6 +193,11 @@ func TestAuthStatusWithoutLocalEvidenceStaysUnknown(t *testing.T) {
 	for _, name := range qwenAPIKeyEnvVars {
 		t.Setenv(name, "")
 	}
+	t.Setenv("QWEN_HOME", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Chdir(t.TempDir())
 	status, err := (&Plugin{resolvedBinary: "qwen"}).AuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/backend/internal/adapters/agent/qwen/auth_test.go
+++ b/backend/internal/adapters/agent/qwen/auth_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -75,4 +77,29 @@ func TestQwenAuthStatusFromSettingsUnknownWhenMissing(t *testing.T) {
 	if ok || status != ports.AgentAuthStatusUnknown {
 		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
+}
+
+func TestAuthStatusUsesQwenDoctor(t *testing.T) {
+	restore := mockQwenAuthProbeRunner(t, func(_ context.Context, name string, arg ...string) ([]byte, error) {
+		if name != "qwen" || !reflect.DeepEqual(arg, []string{"doctor"}) {
+			t.Fatalf("command = %s %#v, want qwen doctor", name, arg)
+		}
+		return []byte("Authentication: authenticated"), nil
+	})
+	defer restore()
+
+	status, err := (&Plugin{resolvedBinary: "qwen"}).AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func mockQwenAuthProbeRunner(t *testing.T, runner func(context.Context, string, ...string) ([]byte, error)) func() {
+	t.Helper()
+	previous := authprobe.CmdRunner
+	authprobe.CmdRunner = runner
+	return func() { authprobe.CmdRunner = previous }
 }

--- a/backend/internal/adapters/agent/registry/registry_test.go
+++ b/backend/internal/adapters/agent/registry/registry_test.go
@@ -60,17 +60,7 @@ func TestGetAgentHooksFootprintIsGitignored(t *testing.T) {
 }
 
 func TestEveryHarnessReportsAuthStatus(t *testing.T) {
-	authCheckerExempt := map[string]string{
-		"continue":    "Continue auth probes require sending a model prompt, so catalog refresh must not run them",
-		"prime-agent": "Prime Agent has no documented non-interactive local auth probe; spawn remains authoritative",
-	}
 	for _, ha := range Harnessed() {
-		if reason, exempt := authCheckerExempt[string(ha.Harness)]; exempt {
-			if _, ok := ha.Agent.(ports.AgentAuthChecker); ok {
-				t.Errorf("%s implements ports.AgentAuthChecker but is exempt: %s", ha.Harness, reason)
-			}
-			continue
-		}
 		if _, ok := ha.Agent.(ports.AgentAuthChecker); !ok {
 			t.Errorf("%s does not implement ports.AgentAuthChecker", ha.Harness)
 		}

--- a/backend/internal/adapters/agent/vibe/auth.go
+++ b/backend/internal/adapters/agent/vibe/auth.go
@@ -46,6 +46,10 @@ func vibeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 		vibeHome = filepath.Join(home, ".vibe")
 	}
 
+	// AuthStatus is a catalog-level probe and has no session workspace. Do not
+	// inspect a project .vibe/config.toml from the daemon's current directory:
+	// it could belong to an unrelated checkout and report its credentials for
+	// every session. The global Vibe config remains valid evidence here.
 	envVars, err := vibeAPIKeyEnvVars(filepath.Join(vibeHome, "config.toml"))
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, false, err

--- a/backend/internal/adapters/agent/vibe/auth.go
+++ b/backend/internal/adapters/agent/vibe/auth.go
@@ -46,7 +46,7 @@ func vibeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 		vibeHome = filepath.Join(home, ".vibe")
 	}
 
-	envVars, err := vibeAPIKeyEnvVars(vibeConfigPath(vibeHome))
+	envVars, err := vibeAPIKeyEnvVars(filepath.Join(vibeHome, "config.toml"))
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
@@ -59,18 +59,6 @@ func vibeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 		}
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
-}
-
-// vibeConfigPath follows Vibe's documented precedence: project configuration
-// first, then the Vibe-home configuration.
-func vibeConfigPath(vibeHome string) string {
-	if cwd, err := os.Getwd(); err == nil && cwd != "" {
-		projectConfig := filepath.Join(cwd, ".vibe", "config.toml")
-		if _, err := os.Stat(projectConfig); err == nil {
-			return projectConfig
-		}
-	}
-	return filepath.Join(vibeHome, "config.toml")
 }
 
 func vibeAPIKeyEnvVars(configPath string) ([]string, error) {

--- a/backend/internal/adapters/agent/vibe/auth.go
+++ b/backend/internal/adapters/agent/vibe/auth.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
@@ -17,7 +16,7 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.ResolveBinary(ctx)
+	_, err := p.ResolveBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -26,7 +25,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	} else if ok {
 		return status, nil
 	}
-	return authprobe.CLIStatus(ctx, binary, nil)
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 const (
@@ -116,7 +115,7 @@ func vibeEnvFileAuthStatus(path, envVar string) (ports.AgentAuthStatus, bool, er
 		if strings.Trim(strings.TrimSpace(value), `"'`) != "" {
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
-		return ports.AgentAuthStatusUnauthorized, true, nil
+		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }

--- a/backend/internal/adapters/agent/vibe/auth.go
+++ b/backend/internal/adapters/agent/vibe/auth.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
@@ -31,7 +28,6 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 const (
 	// This names the default env var Vibe reads; it is not a credential value.
 	vibeDefaultAPIKeyEnvVar = "MISTRAL_API_KEY" //nolint:gosec // env var name, not a credential value
-	vibeKeychainService     = "vibe"
 )
 
 func vibeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, error) {
@@ -50,7 +46,7 @@ func vibeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 		vibeHome = filepath.Join(home, ".vibe")
 	}
 
-	envVars, err := vibeAPIKeyEnvVars(filepath.Join(vibeHome, "config.toml"))
+	envVars, err := vibeAPIKeyEnvVars(vibeConfigPath(vibeHome))
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, false, err
 	}
@@ -62,15 +58,19 @@ func vibeLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 			return status, ok, err
 		}
 	}
-	if status, ok, err := vibeSessionLogAuthStatus(ctx, filepath.Join(vibeHome, "logs", "session")); err != nil || ok {
-		return status, ok, err
-	}
-	for _, envVar := range envVars {
-		if status, ok, err := vibeKeychainAuthStatus(ctx, envVar); err != nil || ok {
-			return status, ok, err
+	return ports.AgentAuthStatusUnknown, false, nil
+}
+
+// vibeConfigPath follows Vibe's documented precedence: project configuration
+// first, then the Vibe-home configuration.
+func vibeConfigPath(vibeHome string) string {
+	if cwd, err := os.Getwd(); err == nil && cwd != "" {
+		projectConfig := filepath.Join(cwd, ".vibe", "config.toml")
+		if _, err := os.Stat(projectConfig); err == nil {
+			return projectConfig
 		}
 	}
-	return ports.AgentAuthStatusUnknown, false, nil
+	return filepath.Join(vibeHome, "config.toml")
 }
 
 func vibeAPIKeyEnvVars(configPath string) ([]string, error) {
@@ -118,59 +118,6 @@ func vibeEnvFileAuthStatus(path, envVar string) (ports.AgentAuthStatus, bool, er
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
-}
-
-func vibeKeychainAuthStatus(ctx context.Context, envVar string) (ports.AgentAuthStatus, bool, error) {
-	if runtime.GOOS != "darwin" {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	if strings.TrimSpace(envVar) == "" {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	out, err := aoprocess.CommandContext(probeCtx, "security", "find-generic-password", "-s", vibeKeychainService, "-a", envVar, "-w").CombinedOutput()
-	if probeCtx.Err() != nil {
-		return ports.AgentAuthStatusUnknown, false, nil
-	}
-	if err == nil && strings.TrimSpace(string(out)) != "" {
-		return ports.AgentAuthStatusAuthorized, true, nil
-	}
-	return ports.AgentAuthStatusUnknown, false, nil
-}
-
-func vibeSessionLogAuthStatus(ctx context.Context, dir string) (ports.AgentAuthStatus, bool, error) {
-	if err := ctx.Err(); err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	paths, err := filepath.Glob(filepath.Join(dir, "session_*", "messages.jsonl"))
-	if err != nil {
-		return ports.AgentAuthStatusUnknown, false, err
-	}
-	for _, path := range paths {
-		if err := ctx.Err(); err != nil {
-			return ports.AgentAuthStatusUnknown, false, err
-		}
-		data, err := os.ReadFile(path)
-		if os.IsNotExist(err) {
-			continue
-		}
-		if err != nil {
-			return ports.AgentAuthStatusUnknown, false, err
-		}
-		if vibeMessagesShowModelUse(string(data)) {
-			return ports.AgentAuthStatusAuthorized, true, nil
-		}
-	}
-	return ports.AgentAuthStatusUnknown, false, nil
-}
-
-func vibeMessagesShowModelUse(text string) bool {
-	return strings.Contains(text, `"role": "assistant"`) ||
-		strings.Contains(text, `"role":"assistant"`) ||
-		strings.Contains(text, `"reasoning_content"`) ||
-		strings.Contains(text, `"session_completion_tokens"`)
 }
 
 func containsString(values []string, target string) bool {

--- a/backend/internal/adapters/agent/vibe/vibe_test.go
+++ b/backend/internal/adapters/agent/vibe/vibe_test.go
@@ -80,6 +80,30 @@ func TestVibeAPIKeyEnvVarsReadsConfig(t *testing.T) {
 	}
 }
 
+func TestVibeLocalAuthStatusIgnoresDaemonWorkingDirectoryProjectConfig(t *testing.T) {
+	clearVibeAuthEnv(t, vibeDefaultAPIKeyEnvVar, "VIBE_CODE_API_KEY", "PROJECT_VIBE_KEY")
+	project := t.TempDir()
+	projectConfig := filepath.Join(project, ".vibe", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(projectConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectConfig, []byte("api_key_env_var = \"PROJECT_VIBE_KEY\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	globalHome := filepath.Join(t.TempDir(), ".vibe")
+	t.Setenv("VIBE_HOME", globalHome)
+	t.Setenv("PROJECT_VIBE_KEY", "project-only-key")
+	t.Chdir(project)
+
+	status, ok, err := vibeLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
+	}
+}
+
 func TestVibeEnvFileAuthStatusAuthorized(t *testing.T) {
 	envPath := filepath.Join(t.TempDir(), ".env")
 	if err := os.WriteFile(envPath, []byte("MISTRAL_API_KEY=test-key\n"), 0o600); err != nil {

--- a/backend/internal/adapters/agent/vibe/vibe_test.go
+++ b/backend/internal/adapters/agent/vibe/vibe_test.go
@@ -97,7 +97,7 @@ func TestVibeEnvFileAuthStatusAuthorized(t *testing.T) {
 	}
 }
 
-func TestVibeEnvFileAuthStatusUnauthorizedForEmptyValue(t *testing.T) {
+func TestVibeEnvFileAuthStatusUnknownForEmptyValue(t *testing.T) {
 	envPath := filepath.Join(t.TempDir(), ".env")
 	if err := os.WriteFile(envPath, []byte("MISTRAL_API_KEY=\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -107,8 +107,8 @@ func TestVibeEnvFileAuthStatusUnauthorizedForEmptyValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ok || status != ports.AgentAuthStatusUnauthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusUnauthorized)
+	if ok || status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = (%q, %v), want (%q, false)", status, ok, ports.AgentAuthStatusUnknown)
 	}
 }
 

--- a/backend/internal/adapters/agent/vibe/vibe_test.go
+++ b/backend/internal/adapters/agent/vibe/vibe_test.go
@@ -110,22 +110,6 @@ func TestVibeEnvFileAuthStatusUnknownForEmptyValue(t *testing.T) {
 	}
 }
 
-func TestVibeConfigPathPrefersProjectConfig(t *testing.T) {
-	project := t.TempDir()
-	projectConfig := filepath.Join(project, ".vibe", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(projectConfig), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(projectConfig, []byte("api_key_env_var = \"PROJECT_VIBE_KEY\"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Chdir(project)
-
-	if got := vibeConfigPath(filepath.Join(t.TempDir(), ".vibe")); got != projectConfig {
-		t.Fatalf("vibeConfigPath() = %q, want %q", got, projectConfig)
-	}
-}
-
 func clearVibeAuthEnv(t *testing.T, names ...string) {
 	t.Helper()
 	for _, name := range names {

--- a/backend/internal/adapters/agent/vibe/vibe_test.go
+++ b/backend/internal/adapters/agent/vibe/vibe_test.go
@@ -3,11 +3,9 @@ package vibe
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -112,79 +110,19 @@ func TestVibeEnvFileAuthStatusUnknownForEmptyValue(t *testing.T) {
 	}
 }
 
-func TestVibeSessionLogAuthStatusAuthorizedWithAssistantMessage(t *testing.T) {
-	dir := t.TempDir()
-	sessionDir := filepath.Join(dir, "session_20260625_071829_d5e8a6eb")
-	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+func TestVibeConfigPathPrefersProjectConfig(t *testing.T) {
+	project := t.TempDir()
+	projectConfig := filepath.Join(project, ".vibe", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(projectConfig), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(sessionDir, "messages.jsonl"), []byte(`{"role":"assistant","content":"Hello"}`), 0o600); err != nil {
+	if err := os.WriteFile(projectConfig, []byte("api_key_env_var = \"PROJECT_VIBE_KEY\"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	t.Chdir(project)
 
-	status, ok, err := vibeSessionLogAuthStatus(context.Background(), dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok || status != ports.AgentAuthStatusAuthorized {
-		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
-	}
-}
-
-func TestVibeKeychainAuthStatus(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("This test only runs on non-Darwin platforms")
-	}
-
-	// 1. Create a temp directory for the fake security binary
-	tmpDir := t.TempDir()
-
-	// 2. Write a fake `security` script/binary that creates a sentinel file
-	//    when invoked — proving it was called
-	sentinelFile := filepath.Join(tmpDir, "security_was_called")
-
-	var fakeSecurityScript string
-	var scriptContent string
-	if runtime.GOOS == "windows" {
-		fakeSecurityScript = filepath.Join(tmpDir, "security.bat")
-		scriptContent = fmt.Sprintf("echo called > %s\r\n", sentinelFile)
-	} else {
-		fakeSecurityScript = filepath.Join(tmpDir, "security")
-		scriptContent = fmt.Sprintf("#!/bin/sh\ntouch %s\n", sentinelFile)
-	}
-
-	err := os.WriteFile(fakeSecurityScript, []byte(scriptContent), 0o755)
-	if err != nil {
-		t.Fatalf("failed to write fake security executable: %v", err)
-	}
-
-	// 3. Prepend our fake binary dir to PATH
-	originalPath := os.Getenv("PATH")
-	t.Cleanup(func() { os.Setenv("PATH", originalPath) })
-	os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+originalPath)
-
-	// 4. Call the function
-	status, ok, err := vibeKeychainAuthStatus(
-		context.Background(),
-		"test-env-var",
-	)
-
-	// 5. Assert return values
-	if status != ports.AgentAuthStatusUnknown {
-		t.Errorf("status = %q, want %q", status, ports.AgentAuthStatusUnknown)
-	}
-	if ok {
-		t.Errorf("ok = true, want false")
-	}
-	if err != nil {
-		t.Errorf("err = %v, want nil", err)
-	}
-
-	// 6. CRITICAL: Assert sentinel was NOT created
-	//    This proves security was never invoked
-	_, statErr := os.Stat(sentinelFile)
-	if !os.IsNotExist(statErr) {
-		t.Errorf("security binary was invoked but should have been skipped on non-Darwin")
+	if got := vibeConfigPath(filepath.Join(t.TempDir(), ".vibe")); got != projectConfig {
+		t.Fatalf("vibeConfigPath() = %q, want %q", got, projectConfig)
 	}
 }
 


### PR DESCRIPTION
## Summary

Tightens authentication reporting for all 27 shipped agent adapters after auditing their current documented credential sources and safe, non-interactive status interfaces.

Closes #4002.

## Adapter coverage

Every adapter participates in catalog authentication reporting. The checks are advisory and use only documented, local evidence:

| Adapter | Documented evidence checked |
| --- | --- |
| Claude Code | `claude auth status`, API key, OAuth/config state |
| Codex | `codex login status` |
| OpenCode | provider environment keys, auth store/database, `opencode auth list` |
| Grok | `XAI_API_KEY`, provider config, access/refresh-token auth state |
| Cursor | `CURSOR_API_KEY`, `cursor-agent status` |
| Qwen | provider environment keys and `~/.qwen/settings.json`; no daemon-CWD project files |
| GitHub Copilot | supported token env vars, Copilot config, `gh auth status` |
| Kimi | current and legacy Kimi config/auth stores and documented provider credentials |
| Muse | `META_API_KEY` and global Muse auth store |
| Droid | `FACTORY_API_KEY` and documented BYOK provider configuration |
| Amp | API key, settings/secrets files, signed-in `amp usage --no-color` output |
| AGY | binary/install readiness only; browser/keychain login remains unknown without a safe local status interface |
| Crush | documented provider env vars, AWS credential chain, Vertex ADC |
| Aider | documented provider env vars and Aider config files |
| Goose | documented provider/editor API-key env vars and Goose config |
| Auggie | binary readiness; interactive-only account state remains unknown |
| Continue | `CONTINUE_API_KEY`, supported provider env/config credentials |
| Devin | documented `DEVIN_API_KEY` credentials |
| OMP | local auth database/auth JSON and `omp auth status` |
| Cline | `CLINE_API_KEY`, configured provider API/OAuth credentials |
| Kiro | `KIRO_API_KEY`, `kiro-cli whoami --format json` |
| Kilo Code | documented provider env/config/database state and `kilo auth list` |
| Vibe | global `VIBE_HOME` config and `.env` plus provider env vars |
| Pi | documented provider env vars and `auth.json` |
| Kimchi | `KIMCHI_API_KEY` and global Kimchi config |
| Prime Agent | model-provider env/auth/config, AWS credentials, Google ADC; MCP-only credentials ignored |
| Autohand | documented env/config credentials; arbitrary `apiKeyHelper` commands are not executed |

## Scope and safety

- Global catalog probes never inspect the daemon’s current directory as a project workspace.
- No probe sends a model prompt, performs a model call, or consumes provider credits.
- `authorized` requires positive credential evidence. Missing, malformed, expired, interactive-only, keyring-only, partial, or otherwise unverified state remains `unknown` rather than blocking launch.
- Agent launch remains the authoritative credential validation step.
- Prime Agent ignores MCP integration credentials in both `auth.json` and `models.json`; only model-provider credentials count as authorization evidence.

## Validation

- `cd backend && GOCACHE=/private/tmp/ao-pr4114-go-build go test ./internal/adapters/agent/...`
- `git diff --check`
- GitHub Actions run lint, API-drift, backend build/tests, secret scanning, and CLI E2E on macOS, Ubuntu, and Windows.
