### PR TITLE
fix: remove onboarding agent refresh button

### DIFF
--- a/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
@@ -5,22 +5,24 @@ import { describe, expect, it, vi } from "vitest";
 import { agentsQueryKey } from "../hooks/useAgentsQuery";
 import { CreateProjectAgentSheet, defaultAuthorizedAgent, RequiredAgentField } from "./CreateProjectAgentSheet";
 
-function renderSheet(onSubmit = vi.fn().mockResolvedValue(undefined)) {
-	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-	queryClient.setQueryData(agentsQueryKey, {
-		supported: [
-			{ id: "claude-code", label: "claude-code" },
-			{ id: "codex", label: "codex" },
-		],
-		installed: [
-			{ id: "claude-code", label: "claude-code", authStatus: "authorized" },
-			{ id: "codex", label: "codex", authStatus: "authorized" },
-		],
-		authorized: [
-			{ id: "claude-code", label: "claude-code", authStatus: "authorized" },
-			{ id: "codex", label: "codex", authStatus: "authorized" },
-		],
-	});
+function renderSheet(onSubmit = vi.fn().mockResolvedValue(undefined), queryClient?: QueryClient) {
+	queryClient ??= new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	if (queryClient.getQueryData(agentsQueryKey) === undefined) {
+		queryClient.setQueryData(agentsQueryKey, {
+			supported: [
+				{ id: "claude-code", label: "claude-code" },
+				{ id: "codex", label: "codex" },
+			],
+			installed: [
+				{ id: "claude-code", label: "claude-code", authStatus: "authorized" },
+				{ id: "codex", label: "codex", authStatus: "authorized" },
+			],
+			authorized: [
+				{ id: "claude-code", label: "claude-code", authStatus: "authorized" },
+				{ id: "codex", label: "codex", authStatus: "authorized" },
+			],
+		});
+	}
 	render(
 		<QueryClientProvider client={queryClient}>
 			<CreateProjectAgentSheet
@@ -96,6 +98,12 @@ describe("CreateProjectAgentSheet", () => {
 			orchestratorAgent: "claude-code",
 			trackerIntake: undefined,
 		});
+	});
+
+	it("does not show a manual agent catalog refresh action", () => {
+		renderSheet();
+
+		expect(screen.queryByRole("button", { name: "Refresh agents" })).not.toBeInTheDocument();
 	});
 
 	it("blocks submit when intake is enabled with no assignee, then passes the intake payload once one is set", async () => {

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	canSubmitProjectSetup,
 	ProjectSetupFormView,
@@ -9,7 +9,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { TriangleAlert, X, type LucideIcon } from "lucide-react";
 import { memo, useEffect, useState, type ReactNode } from "react";
 import type { components } from "../../api/schema";
-import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
+import { agentsQueryKey, agentsQueryOptions, refreshAgentsIfStale } from "../hooks/useAgentsQuery";
 import { AGENT_OPTIONS } from "../lib/agent-options";
 import {
 	agentLabelCompare,
@@ -113,10 +113,6 @@ export function CreateProjectAgentSheet({
 		...agentsQueryOptions,
 		enabled: open,
 	});
-	const refreshAgentsMutation = useMutation({
-		mutationFn: refreshAgents,
-		onSuccess: (next) => queryClient.setQueryData(agentsQueryKey, next),
-	});
 	const agents = agentsQuery.data;
 	const installedAgents = agents?.installed ?? [];
 	const agentOptions = agents?.authorized ?? [];
@@ -127,11 +123,7 @@ export function CreateProjectAgentSheet({
 			? agentsQuery.error.message
 			: t("createProject.couldNotLoadAgents")
 		: null;
-	const displayError = refreshAgentsMutation.isError
-		? refreshAgentsMutation.error instanceof Error
-			? refreshAgentsMutation.error.message
-			: t("createProject.couldNotRefreshAgents")
-		: agentsError;
+	const displayError = agentsError;
 	const [workerAgent, setWorkerAgent] = useState("");
 	const [orchestratorAgent, setOrchestratorAgent] = useState("");
 	const [workerAgentTouched, setWorkerAgentTouched] = useState(false);
@@ -150,6 +142,13 @@ export function CreateProjectAgentSheet({
 		!isBusy &&
 		!isLoadingAgents;
 	const sheetError = error ? projectSheetError(error) : null;
+
+	useEffect(() => {
+		if (!open) return;
+		void refreshAgentsIfStale().then((next) => {
+			if (next) queryClient.setQueryData(agentsQueryKey, next);
+		});
+	}, [open, queryClient]);
 
 	useEffect(() => {
 		if (!open) return;
@@ -233,11 +232,8 @@ export function CreateProjectAgentSheet({
 							error: displayError,
 							loading: isLoadingAgents,
 							loadingMessage: t("createProject.loadingAgents"),
-							onRefresh: () => refreshAgentsMutation.mutate(),
-							refreshLabel: refreshAgentsMutation.isPending
-								? t("createProject.refreshing")
-								: t("createProject.refreshAgents"),
-							refreshing: refreshAgentsMutation.isPending,
+							onRetry: () => void agentsQuery.refetch(),
+							refreshing: false,
 							retryLabel: t("createProject.retry"),
 						}}
 						alert={

--- a/packages/product-ui/src/ProjectViews.test.tsx
+++ b/packages/product-ui/src/ProjectViews.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
 import type { ComponentProps } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	ProjectGeneralSettingsView,
 	ProjectModePickerView,
@@ -25,6 +26,8 @@ const modeLabels = {
 function ExternalLink(props: ComponentProps<"a">) {
 	return <a {...props} />;
 }
+
+afterEach(() => cleanup());
 
 describe("project models", () => {
 	it("validates settings in user-action order", () => {
@@ -99,6 +102,35 @@ describe("project presentation", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Create and start" }));
 		expect(onSubmit).toHaveBeenCalledOnce();
 		expect(screen.getByText("Nested repository")).toBeInTheDocument();
+	});
+
+	it("can hide the normal refresh action while keeping an error retry", () => {
+		const onRetry = vi.fn();
+		render(
+			<ProjectSetupFormView
+				agentControls={{ worker: <span>Worker control</span>, orchestrator: <span>Orchestrator control</span> }}
+				agents={{
+					cacheMessage: "Cached",
+					error: "Could not load agents",
+					loading: false,
+					loadingMessage: "Loading",
+					onRetry,
+					refreshing: false,
+					retryLabel: "Retry",
+				}}
+				canSubmit={false}
+				intakeControl={<span>Intake control</span>}
+				isBusy={false}
+				onCancel={vi.fn()}
+				onSubmit={vi.fn()}
+				submitLabel="Create and start"
+				cancelLabel="Cancel"
+			/>,
+		);
+
+		expect(screen.queryByRole("button", { name: "Refresh" })).not.toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		expect(onRetry).toHaveBeenCalledOnce();
 	});
 
 	it("renders project identity and workspace repository summaries", () => {

--- a/packages/product-ui/src/ProjectViews.tsx
+++ b/packages/product-ui/src/ProjectViews.tsx
@@ -240,8 +240,9 @@ export function ProjectSetupFormView({
 		error?: string | null;
 		loading: boolean;
 		loadingMessage: string;
-		onRefresh: () => void;
-		refreshLabel: string;
+		onRefresh?: () => void;
+		onRetry?: () => void;
+		refreshLabel?: string;
 		refreshing: boolean;
 		retryLabel: string;
 	};
@@ -274,14 +275,16 @@ export function ProjectSetupFormView({
 
 			<div className="flex items-center justify-between gap-3 text-xs leading-row text-[var(--color-text-agents-sheet-description)]">
 				<span>{agents.cacheMessage}</span>
-				<button
-					type="button"
-					className="shrink-0 rounded text-[var(--color-text-agents-sheet-title)] underline-offset-2 hover:underline disabled:pointer-events-none disabled:opacity-50"
-					disabled={agents.refreshing}
-					onClick={agents.onRefresh}
-				>
-					{agents.refreshLabel}
-				</button>
+				{agents.onRefresh && agents.refreshLabel && (
+					<button
+						type="button"
+						className="shrink-0 rounded text-[var(--color-text-agents-sheet-title)] underline-offset-2 hover:underline disabled:pointer-events-none disabled:opacity-50"
+						disabled={agents.refreshing}
+						onClick={agents.onRefresh}
+					>
+						{agents.refreshLabel}
+					</button>
+				)}
 			</div>
 
 			{agents.error && (
@@ -290,14 +293,16 @@ export function ProjectSetupFormView({
 					role="alert"
 				>
 					<span>{agents.error}</span>
-					<button
-						type="button"
-						className="shrink-0 rounded text-[var(--color-text-agents-sheet-title)] underline-offset-2 hover:underline disabled:pointer-events-none disabled:opacity-50"
-						disabled={agents.refreshing}
-						onClick={agents.onRefresh}
-					>
-						{agents.retryLabel}
-					</button>
+					{(agents.onRetry ?? agents.onRefresh) && (
+						<button
+							type="button"
+							className="shrink-0 rounded text-[var(--color-text-agents-sheet-title)] underline-offset-2 hover:underline disabled:pointer-events-none disabled:opacity-50"
+							disabled={agents.refreshing}
+							onClick={agents.onRetry ?? agents.onRefresh}
+						>
+							{agents.retryLabel}
+						</button>
+					)}
 				</div>
 			)}
 


### PR DESCRIPTION
## Summary
- Remove the manual agent catalog refresh button from the first-project onboarding agent sheet.
- Keep onboarding rendering immediately from the cached `/api/v1/agents` query result.
- Passively refresh the agent catalog cache when the sheet opens via the existing throttled `refreshAgentsIfStale()` path, so fresh daemon-probed catalog data replaces the cached view without user action.
- Preserve an error-only Retry action that refetches the existing agents query without forcing a catalog refresh.
- Make `ProjectSetupFormView` support agent sections without a normal refresh action while still allowing retry actions for errors.

## Behavior
The daemon already refreshes the agent catalog on boot. Onboarding now treats that refresh as system-owned: users see the currently cached catalog right away, and the UI updates automatically when the refreshed catalog is available. If the initial cached catalog load fails, onboarding still offers Retry without reintroducing the normal Refresh agents button. Settings and other advanced surfaces can still provide manual refresh where needed.

## Validation
- `PATH=/Users/nikhilachale/.nvm/versions/node/v22.23.1/bin:$PATH npm test -- CreateProjectAgentSheet.test.tsx`
- `PATH=/Users/nikhilachale/.nvm/versions/node/v22.23.1/bin:/Users/nikhilachale/Desktop/agent-orchestrator/frontend/node_modules/.bin:$PATH vitest run packages/product-ui/src/ProjectViews.test.tsx --environment jsdom`
- `PATH=/Users/nikhilachale/.nvm/versions/node/v22.23.1/bin:$PATH npm run frontend:typecheck`