### PR TITLE
feat(chat): system-browser escape hatches for chat links

### DIFF
--- a/frontend/src/renderer/components/chat/ChatMarkdown.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatMarkdown.test.tsx
@@ -141,6 +141,66 @@ describe("ChatMarkdown", () => {
 		openExternal.mockRestore();
 	});
 
+	it("opens a web link in the system browser on Cmd-click", () => {
+		const onLinkOpen = vi.fn();
+		const openExternal = vi.spyOn(aoBridge.app, "openExternal").mockResolvedValue(undefined);
+		renderWithLinkHandler("see [the issue](https://example.com/i/1)", onLinkOpen);
+
+		fireEvent.click(screen.getByRole("link", { name: "the issue" }), { metaKey: true });
+
+		expect(openExternal).toHaveBeenCalledWith("https://example.com/i/1");
+		expect(onLinkOpen).not.toHaveBeenCalled();
+		openExternal.mockRestore();
+	});
+
+	it("opens a web link in the system browser on Ctrl-click", () => {
+		const onLinkOpen = vi.fn();
+		const openExternal = vi.spyOn(aoBridge.app, "openExternal").mockResolvedValue(undefined);
+		renderWithLinkHandler("see [the issue](https://example.com/i/1)", onLinkOpen);
+
+		fireEvent.click(screen.getByRole("link", { name: "the issue" }), { ctrlKey: true });
+
+		expect(openExternal).toHaveBeenCalledWith("https://example.com/i/1");
+		expect(onLinkOpen).not.toHaveBeenCalled();
+		openExternal.mockRestore();
+	});
+
+	it("offers 'Open in system browser' on right-click, without opening in the panel", async () => {
+		const user = userEvent.setup();
+		const onLinkOpen = vi.fn();
+		const openExternal = vi.spyOn(aoBridge.app, "openExternal").mockResolvedValue(undefined);
+		renderWithLinkHandler("see [the issue](https://example.com/i/1)", onLinkOpen);
+
+		fireEvent.contextMenu(screen.getByRole("link", { name: "the issue" }));
+		await user.click(await screen.findByRole("menuitem", { name: "Open in system browser" }));
+
+		expect(openExternal).toHaveBeenCalledWith("https://example.com/i/1");
+		expect(onLinkOpen).not.toHaveBeenCalled();
+		openExternal.mockRestore();
+	});
+
+	it("offers 'Copy link address' on right-click", async () => {
+		const user = userEvent.setup();
+		const writeText = vi.spyOn(aoBridge.clipboard, "writeText").mockResolvedValue(undefined);
+		renderWithLinkHandler("see [the issue](https://example.com/i/1)", vi.fn());
+
+		fireEvent.contextMenu(screen.getByRole("link", { name: "the issue" }));
+		await user.click(await screen.findByRole("menuitem", { name: "Copy link address" }));
+
+		expect(writeText).toHaveBeenCalledWith("https://example.com/i/1");
+		writeText.mockRestore();
+	});
+
+	it("omits the system-browser item for non-web links but still offers copying", async () => {
+		// mailto must never reach shell.openExternal from the menu.
+		renderWithLinkHandler("[Email support](mailto:support@example.com)", vi.fn());
+
+		fireEvent.contextMenu(screen.getByRole("link", { name: "Email support" }));
+
+		expect(await screen.findByRole("menuitem", { name: "Copy link address" })).toBeInTheDocument();
+		expect(screen.queryByRole("menuitem", { name: "Open in system browser" })).not.toBeInTheDocument();
+	});
+
 	it("opens non-web links in the system browser", async () => {
 		const user = userEvent.setup();
 		const onLinkOpen = vi.fn();

--- a/frontend/src/renderer/components/chat/ChatMarkdown.tsx
+++ b/frontend/src/renderer/components/chat/ChatMarkdown.tsx
@@ -36,8 +36,15 @@ import Markdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { WrapText } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { aoBridge } from "../../lib/bridge";
 import { canonicalLanguage } from "../../lib/code-highlight";
 import { isWebLink, openLinkInSystemBrowser } from "../../lib/external-link-policy";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuTrigger,
+} from "../ui/context-menu";
 import { HighlightedCode } from "./HighlightedCode";
 import { CopyButton } from "./CopyButton";
 import "./code-theme.css";
@@ -210,7 +217,7 @@ function compactEmoji(children: ReactNode): ReactNode {
 
 function MarkdownLink({ href, children }: { href?: string; children?: ReactNode }) {
 	const onLinkOpen = useContext(OpenChatLink);
-	return (
+	const anchor = (
 		<a
 			href={href}
 			target="_blank"
@@ -218,7 +225,10 @@ function MarkdownLink({ href, children }: { href?: string; children?: ReactNode 
 			onClick={(event) => {
 				if (!href) return;
 				event.preventDefault();
-				if (!event.altKey && onLinkOpen && isWebLink(href)) {
+				// Cmd/Ctrl-click (the VS Code/Slack convention) and Option/Alt-click
+				// escape the in-app panel and go straight to the system browser.
+				const toSystemBrowser = event.metaKey || event.ctrlKey || event.altKey;
+				if (!toSystemBrowser && onLinkOpen && isWebLink(href)) {
 					onLinkOpen(href);
 					return;
 				}
@@ -228,6 +238,24 @@ function MarkdownLink({ href, children }: { href?: string; children?: ReactNode 
 		>
 			{children}
 		</a>
+	);
+	if (!href) return anchor;
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>{anchor}</ContextMenuTrigger>
+			<ContextMenuContent className="min-w-44">
+				{/* Only http(s) may reach shell.openExternal from here; other schemes
+				    still get their address copied. */}
+				{isWebLink(href) ? (
+					<ContextMenuItem onSelect={() => void openLinkInSystemBrowser(href)}>
+						Open in system browser
+					</ContextMenuItem>
+				) : null}
+				<ContextMenuItem onSelect={() => void aoBridge.clipboard.writeText(href)}>
+					Copy link address
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
 	);
 }
 
@@ -322,7 +350,8 @@ const COMPONENTS: Components = {
 	del: ({ children }) => <del className="text-muted-foreground">{children}</del>,
 
 	// Match terminal links: a plain HTTP(S) click uses the session's AO Browser;
-	// Option/Alt-click and non-web schemes use the system browser.
+	// Cmd/Ctrl- or Option/Alt-click and non-web schemes use the system browser,
+	// and right-click offers the system browser and copying the address.
 	a: MarkdownLink,
 
 	img: ({ src, alt }) => (


### PR DESCRIPTION
## Summary

Clicking a link in a chat message always opened it in the in-app AO Browser panel, and right-click offered nothing — there was no way to get a chat link into the system browser. This adds the standard escape hatches to `MarkdownLink` in `ChatMarkdown.tsx` (the single link surface for all chat prose, including PR/issue URLs agents write in messages):

1. **Plain left-click** — unchanged: opens in the in-app Browser panel via the session link handler.
2. **Right-click** — a context menu (built on the shared shadcn `ContextMenu` primitive already used by the sidebar) with **Open in system browser** and **Copy link address**. Open goes through the existing `app:openExternal` IPC path (main-process `shell.openExternal` behind the URL allowlist); copy uses the native clipboard bridge so it works without document focus.
3. **Cmd+click (macOS) / Ctrl+click (Win/Linux)** — opens directly in the system browser, matching the VS Code/Slack convention. The existing Option/Alt-click path is retained.

Security: the context menu's system-browser item is rendered for http(s) links only (`isWebLink`); non-web schemes (e.g. `mailto:`) get only *Copy link address*. Every open still passes through the main process allowlist in `external-open.ts` — `window.open` is never used.

Out of scope by design: structured PR/issue chips (`ProductExternalLink`) already open in the system browser and are untouched, as are links elsewhere in the app.

## Tests

- 5 new component tests in `ChatMarkdown.test.tsx`: Cmd-click and Ctrl-click route to `openExternal`, right-click menu offers and executes both items, and the mailto menu omits the system-browser item.
- Full frontend suite: 191 files, 2521 passed. `tsc --noEmit` clean.
- Verified live in the dev Electron app (isolated data mode) on a real chat message: plain click navigated the in-app Browser panel to the URL (confirmed via the native WebContentsView target), Cmd+click and the context-menu item opened the system browser through `shell.openExternal`, and *Copy link address* landed the exact URL on the native clipboard.

## Risks

- Each markdown link now mounts a Radix `ContextMenu` root (same per-item pattern the sidebar uses); no measurable rendering impact observed.
- Chat surface is on the deferred-localization list, so the two menu labels are intentionally hardcoded English like the rest of `ChatMarkdown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)