### PR TITLE
fix(chat): do not anchor native-history checkpoint on failed turns

### DIFF
--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -302,7 +302,13 @@ func (p *nativeHistoryCheckpoint) captureAOHighWater(
 	var latest *domain.ConversationTurn
 	for i := range turns {
 		turn := &turns[i]
-		if turn.HandledBySessionID != sessionID || !turn.State.Terminal() || turn.ProviderTurnID == "" {
+		// Only completed turns anchor the high-water mark. A provider promises to
+		// reproduce settled work during history load, but a failed or interrupted
+		// turn's items carry no such promise: Claude forks its next prompt from the
+		// pre-failure transcript entry, leaving the failed turn (e.g. a synthetic
+		// auth-error message) on a dead branch that session/load never replays.
+		// Requiring one of those items would make every future switch time out.
+		if turn.HandledBySessionID != sessionID || turn.State != domain.TurnStateCompleted || turn.ProviderTurnID == "" {
 			continue
 		}
 		if latest == nil || turn.RequestedAt.After(latest.RequestedAt) {

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -712,6 +712,158 @@ func TestInterfaceHandoffRejectsSettledReplayBeforeLatestSessionCheckpoint(t *te
 	}
 }
 
+func TestInterfaceHandoffDoesNotAnchorReplayCheckpointOnFailedTurn(t *testing.T) {
+	st := openStore(t)
+	now := time.Date(2026, 8, 19, 3, 0, 0, 0, time.UTC)
+	existing, err := st.CreateConversation(context.Background(), "failed-anchor-conversation",
+		domain.ConversationScopeSession, testProject, testSession, now)
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if err := st.ClaimChatControllerGeneration(context.Background(), testSession, "old-generation", now); err != nil {
+		t.Fatalf("ClaimChatControllerGeneration: %v", err)
+	}
+	// An older completed Chat round trip that the provider will replay.
+	created, err := st.AppendUserMessage(context.Background(), existing.ID, testSession, "old-generation",
+		domain.ConversationMessage{
+			ID: "settled-user", Text: "What changed?", Origin: domain.MessageOriginHuman,
+			ClientMessageID: "settled-client-id",
+		}, "settled-turn", now)
+	if err != nil || !created {
+		t.Fatalf("AppendUserMessage settled: created=%v err=%v", created, err)
+	}
+	if err := st.BindTurnToProvider(context.Background(), "settled-turn", "native-turn-1", now); err != nil {
+		t.Fatalf("BindTurnToProvider settled: %v", err)
+	}
+	if err := st.SettleAssistantMessage(context.Background(), existing.ID,
+		"native-answer-1", "native-turn-1", "Nothing is dirty.", "settled-answer", now); err != nil {
+		t.Fatalf("SettleAssistantMessage settled: %v", err)
+	}
+	if err := st.SettleTurn(context.Background(), existing.ID, "native-turn-1",
+		domain.TurnStateCompleted, "", now); err != nil {
+		t.Fatalf("SettleTurn settled: %v", err)
+	}
+	// A newer failed Chat turn. Its synthetic auth-error answer lives on a dead
+	// transcript branch: the provider forked the next TUI prompt from the entry
+	// before this turn, so session/load never replays these items.
+	later := now.Add(time.Minute)
+	created, err = st.AppendUserMessage(context.Background(), existing.ID, testSession, "old-generation",
+		domain.ConversationMessage{
+			ID: "failed-user", Text: "Spawn a worker to fix the link behavior.", Origin: domain.MessageOriginHuman,
+			ClientMessageID: "failed-client-id",
+		}, "failed-turn", later)
+	if err != nil || !created {
+		t.Fatalf("AppendUserMessage failed turn: created=%v err=%v", created, err)
+	}
+	if err := st.BindTurnToProvider(context.Background(), "failed-turn", "native-turn-2", later); err != nil {
+		t.Fatalf("BindTurnToProvider failed turn: %v", err)
+	}
+	if err := st.SettleAssistantMessage(context.Background(), existing.ID,
+		"native-error-1", "native-turn-2",
+		"Failed to authenticate: OAuth session expired and could not be refreshed", "failed-answer", later); err != nil {
+		t.Fatalf("SettleAssistantMessage failed turn: %v", err)
+	}
+	if err := st.SettleTurn(context.Background(), existing.ID, "native-turn-2",
+		domain.TurnStateFailed, "authentication_failed", later); err != nil {
+		t.Fatalf("SettleTurn failed turn: %v", err)
+	}
+
+	// The user re-ran the request in the terminal after fixing auth; hooks
+	// captured that newest round trip, and the provider replays it.
+	rec, found, err := st.GetSession(context.Background(), testSession)
+	if err != nil || !found {
+		t.Fatalf("load session: found=%v err=%v", found, err)
+	}
+	rec.Metadata.LatestUserPrompt = "Spawn a worker to fix the link behavior in the terminal."
+	rec.Metadata.LatestAssistantUpdate = "Worker spawned."
+	if err := st.UpdateSession(context.Background(), rec); err != nil {
+		t.Fatalf("seed native replay checkpoint: %v", err)
+	}
+
+	conv := &nativeHistoryConversation{
+		fakeConversation: newFakeConversation(),
+		events: []ports.ChatEvent{
+			{Kind: ports.ChatEventTurnStarted, ProviderEventID: "history-start-1", ProviderTurnID: "native-turn-1"},
+			{
+				Kind: ports.ChatEventUserMessageCompleted, ProviderEventID: "history-user-1",
+				ProviderTurnID: "native-turn-1", ProviderItemID: "history-item-1", Text: "What changed?",
+			},
+			{
+				Kind: ports.ChatEventMessageCompleted, ProviderEventID: "history-answer-1",
+				ProviderTurnID: "native-turn-1", ProviderItemID: "history-item-2", Text: "Nothing is dirty.",
+			},
+			{
+				Kind: ports.ChatEventTurnCompleted, ProviderEventID: "history-complete-1",
+				ProviderTurnID: "native-turn-1", TurnState: domain.TurnStateCompleted,
+			},
+			{Kind: ports.ChatEventTurnStarted, ProviderEventID: "history-start-2", ProviderTurnID: "native-turn-tui"},
+			{
+				Kind: ports.ChatEventUserMessageCompleted, ProviderEventID: "history-user-2",
+				ProviderTurnID: "native-turn-tui", ProviderItemID: "history-item-3",
+				Text: "Spawn a worker to fix the link behavior in the terminal.",
+			},
+			{
+				Kind: ports.ChatEventMessageCompleted, ProviderEventID: "history-answer-2",
+				ProviderTurnID: "native-turn-tui", ProviderItemID: "history-item-4", Text: "Worker spawned.",
+			},
+			{
+				Kind: ports.ChatEventTurnCompleted, ProviderEventID: "history-complete-2",
+				ProviderTurnID: "native-turn-tui", TurnState: domain.TurnStateCompleted,
+			},
+		},
+	}
+	var idMu sync.Mutex
+	nextID := 0
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Reader: chatsvc.SnapshotReaderFunc(func(ctx context.Context, conversationID string) (chatsvc.ConversationRows, error) {
+			rows, err := st.LoadConversationSnapshot(ctx, conversationID)
+			if err != nil {
+				return chatsvc.ConversationRows{}, err
+			}
+			return chatsvc.ConversationRows{
+				Conversation: rows.Conversation,
+				Turns:        rows.Turns,
+				Messages:     rows.Messages,
+				Activities:   rows.Activities,
+			}, nil
+		}),
+		Drivers: fakeRegistry{driver: fakeDriver{conv: conv}},
+		Log:     slog.New(slog.DiscardHandler),
+		NewID: func() string {
+			idMu.Lock()
+			defer idMu.Unlock()
+			nextID++
+			return fmt.Sprintf("failed-anchor-%d", nextID)
+		},
+	})
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+
+	ctrl, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(), ProviderConversationID: "thread-1", RequireNativeHistory: true,
+	})
+	if err != nil {
+		t.Fatalf("Start resume = %v, want success: a failed turn's never-replayed items must not gate the handoff", err)
+	}
+	snapshot, err := st.LoadConversationSnapshot(context.Background(), ctrl.ConversationID())
+	if err != nil {
+		t.Fatalf("LoadConversationSnapshot: %v", err)
+	}
+	// The failed turn stays durable in AO's projection even though the provider
+	// never replays it.
+	var failedState domain.TurnState
+	for _, turn := range snapshot.Turns {
+		if turn.ProviderTurnID == "native-turn-2" {
+			failedState = turn.State
+		}
+	}
+	if failedState != domain.TurnStateFailed {
+		t.Fatalf("failed turn state = %q, want preserved %q (turns = %#v)",
+			failedState, domain.TurnStateFailed, snapshot.Turns)
+	}
+}
+
 func TestSlowNativeHistoryDoesNotBlockOtherControllerLookups(t *testing.T) {
 	st := openStore(t)
 	conv := &blockingHistoryConversation{


### PR DESCRIPTION
Fixes #4120

## Summary

The TUI→Chat interface-switch settle checkpoint (`captureAOHighWater`) anchored on the latest **terminal** turn, including `failed`/`interrupted` ones. A failed turn's items carry no replay guarantee: Claude forks the next prompt from the pre-failure transcript entry, leaving the failed turn (e.g. a synthetic `Failed to authenticate…` assistant message) on a dead `parentUuid` branch that `session/load` never replays. Because terminal-mode turns never update AO's chat projection, the failed turn stayed the anchor forever and **every** switch attempt timed out after 45s with `chat conversation history is not settled: context deadline exceeded`, then rolled back.

This is the root cause of the live incident on orchestrator session `agent-orchestrator-88` (2026-08-19 03:15Z); the mechanism was verified by replaying the live transcript through the real `claude-agent-acp` adapter — the failed turn's items were absent from the replay (dead branch), exactly as the checkpoint required them.

The fix anchors the high-water mark only on `TurnStateCompleted` turns. The hook-derived `latestUserPrompt` / `latestAssistantUpdate` checkpoint fields still guard freshness of the newest terminal-side facts, and the failed turn's rows remain durable in AO's projection (asserted in the test).

## Tests

- New `TestInterfaceHandoffDoesNotAnchorReplayCheckpointOnFailedTurn` models the incident (completed turn + newer failed auth-error turn whose items never replay). On unfixed code it fails with the exact production error after 45.1s; with the fix it passes in 0.13s.
- `go test ./internal/service/chat/ ./internal/session_manager/` — all pass.

## Known risks / follow-ups

- After a failed turn, a stale replay missing that turn's items is now accepted; `latestUserPrompt`/`latestAssistantUpdate` still gate on the newest hook facts, and reconciliation preserves the failed turn's durable rows, so no history is lost.
- Two adjacent defects observed in the same incident are filed separately: the post-rollback "native conversation id is not confirmed" window (SessionStart hook only matches `startup`, not `resume`), and the 45s blind poll over an immutable cached ACP replay.
- `AO_CHAT_E2E=1` real-daemon suite not run (real model calls); covered by the focused unit regression instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)