### PR TITLE
fix: recover supervised sessions after Ctrl+C kills the agent in its pane

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -1189,7 +1189,10 @@ func buildLaunchCommand(cfg ports.RuntimeConfig) string {
 	if cfg.Env["AO_SUPERVISED_PROCESS"] == "1" {
 		// cat consumes and discards any input that arrived while the supervised
 		// child was exiting. Runtime Restart/Destroy replaces or kills the pane.
-		b.WriteString(`; exec cat >/dev/null`)
+		// The banner keeps the parked pane self-explanatory: without it, an
+		// interrupted agent leaves a screen that swallows keystrokes and looks
+		// hung. \r\n covers a child that died with the terminal still in raw mode.
+		b.WriteString(`; printf '\r\n[ao] agent exited - restore this session from the app to continue\r\n'; exec cat >/dev/null`)
 	} else {
 		// Keep the tmux session alive after an unsupervised agent exits so the
 		// operator can inspect it and use the historical manual-recovery shell.

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -499,6 +499,28 @@ func TestCreateLaunchCommandContainsKeepAliveShell(t *testing.T) {
 	}
 }
 
+func TestCreateLaunchCommandSupervisedParksOnBannerAndCat(t *testing.T) {
+	launchCmd := buildLaunchCommand(ports.RuntimeConfig{
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"myagent", "--flag"},
+		Env:           map[string]string{"AO_SUPERVISED_PROCESS": "1"},
+	})
+
+	// A supervised pane must never fall back to an interactive shell: bytes
+	// racing the child's exit could become shell commands.
+	if strings.Contains(launchCmd, `exec "${SHELL:-/bin/sh}" -i`) {
+		t.Fatalf("supervised launch command must not exec an interactive shell: %q", launchCmd)
+	}
+	if !strings.HasSuffix(launchCmd, `exec cat >/dev/null`) {
+		t.Fatalf("supervised launch command missing keep-alive stdin sink: %q", launchCmd)
+	}
+	// The parked pane explains itself instead of silently swallowing keystrokes.
+	banner := `printf '\r\n[ao] agent exited - restore this session from the app to continue\r\n'; exec cat >/dev/null`
+	if !strings.Contains(launchCmd, banner) {
+		t.Fatalf("supervised launch command missing exit banner before keep-alive sink: %q", launchCmd)
+	}
+}
+
 func TestCreateLaunchCommandKeepsConfiguredValuesOutOfArgv(t *testing.T) {
 	const secret = "configured-project-token"
 	r, fr := newTestRuntime(0)

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -563,6 +563,61 @@ describe("terminal restore", () => {
 		}
 	});
 
+	it.each([
+		["worker", worker],
+		["orchestrator", orchestrator],
+	])(
+		"posts resume-agent when a live %s session's supervised agent exited (Ctrl-C in the pane)",
+		async (_kind, session) => {
+			// The supervised keep-alive holds the tmux pane open, so the attachment
+			// stays "attached" and the session row stays live — the strip must key
+			// off the agent's exited activity, not the terminal or session lifecycle.
+			terminalState.value = "attached";
+			const view = renderPane({
+				...session,
+				status: "exited",
+				activity: { state: "exited", lastActivityAt: "2026-06-10T00:00:02Z" },
+				terminalHandleId: "term-1",
+			});
+			const invalidate = vi.spyOn(view.queryClient, "invalidateQueries").mockResolvedValue(undefined);
+			try {
+				expect(screen.getByText("Agent exited")).toBeInTheDocument();
+				await userEvent.click(screen.getByRole("button", { name: "Restore session" }));
+
+				await waitFor(() =>
+					expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/resume-agent", {
+						params: { path: { sessionId: session.id } },
+					}),
+				);
+				expect(invalidate).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
+			} finally {
+				view.restore();
+			}
+		},
+	);
+
+	it("offers no resume affordance while an agent switch is replacing the exited agent", () => {
+		terminalState.value = "attached";
+		const view = renderPane({
+			...worker,
+			status: "exited",
+			activity: { state: "exited", lastActivityAt: "2026-06-10T00:00:02Z" },
+			activeAgentSwitch: {
+				agentHandoffStatus: "requested",
+				fromHarness: "claude-code",
+				id: "switch-1",
+				state: "starting_target",
+				targetHarness: "codex",
+			},
+			terminalHandleId: "term-1",
+		});
+		try {
+			expect(screen.queryByRole("button", { name: "Restore session" })).not.toBeInTheDocument();
+		} finally {
+			view.restore();
+		}
+	});
+
 	it("offers restore when a merged session is terminated", () => {
 		const view = renderPane({
 			...worker,

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -33,7 +33,7 @@ import {
 } from "../lib/terminal-mux";
 import { cn } from "../lib/utils";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
-import { useRestoreSession } from "../hooks/useRestoreSession";
+import { useRestoreSession, useResumeAgentSession } from "../hooks/useRestoreSession";
 import { useShellTerminals } from "../hooks/useShellTerminals";
 import { XtermTerminal } from "./XtermTerminal";
 import { RestoreUnavailableDialog } from "./RestoreUnavailableDialog";
@@ -917,6 +917,7 @@ function AttachedTerminal({
 	const [restoreUnavailable, setRestoreUnavailable] = useState(false);
 	const queryClient = useQueryClient();
 	const restoreSessionById = useRestoreSession();
+	const resumeAgentById = useResumeAgentSession();
 	// A shell pane has no session, so it hands the hook its handle directly
 	// instead of reading one off `attachSession`.
 	const shellTerminalHandleId = terminalTarget?.kind === "shell" ? terminalTarget.handleId : undefined;
@@ -957,6 +958,17 @@ function AttachedTerminal({
 		terminalTarget?.kind !== "shell" &&
 		session !== undefined &&
 		!isSessionActive;
+	// The supervised keep-alive holds the tmux pane open after the agent dies
+	// (e.g. Ctrl-C), so the session stays live and the attachment never reports
+	// "exited". The pane itself must offer recovery: relaunch the agent in place
+	// via resume-agent, preserving the terminal identity and worktree.
+	const canResumeAgent =
+		terminalTarget?.kind !== "reviewer" &&
+		terminalTarget?.kind !== "shell" &&
+		session !== undefined &&
+		isSessionActive &&
+		session.activity?.state === "exited" &&
+		!session.activeAgentSwitch;
 
 	const handleReady = useCallback((handle: AttachableTerminal) => {
 		setTerminal(handle);
@@ -976,11 +988,15 @@ function AttachedTerminal({
 	}, [initFailed, onFatal]);
 	const handleLinkOpen = useSessionBrowserLink(session);
 	const restoreSession = useCallback(async () => {
-		if (!session?.id || !canRestoreSession || isRestoring) return;
+		if (!session?.id || (!canRestoreSession && !canResumeAgent) || isRestoring) return;
 		setIsRestoring(true);
 		setRestoreError(undefined);
 		try {
-			const result = await restoreSessionById(session.id);
+			// A terminated session needs the full restore (workspace recreation); a
+			// live session with an exited agent relaunches the agent in place.
+			const result = canRestoreSession
+				? await restoreSessionById(session.id)
+				: await resumeAgentById(session.id);
 			if (result.status === "not_resumable") {
 				setRestoreUnavailable(true);
 				return;
@@ -993,7 +1009,7 @@ function AttachedTerminal({
 		} finally {
 			setIsRestoring(false);
 		}
-	}, [canRestoreSession, isRestoring, restoreSessionById, session?.id, t]);
+	}, [canRestoreSession, canResumeAgent, isRestoring, restoreSessionById, resumeAgentById, session?.id, t]);
 
 	useEffect(() => {
 		if (!terminal) return;
@@ -1037,7 +1053,7 @@ function AttachedTerminal({
 		Boolean(handleId) &&
 		(!replaySettled || replayPaintPending) &&
 		(state === "connecting" || state === "attached");
-	const showEndedState = state === "exited" || canRestoreSession;
+	const showEndedState = state === "exited" || canRestoreSession || canResumeAgent;
 	const emptyStateTitle = session ? t("terminal.startingSession") : "Agent Orchestrator";
 	const emptyStateMessage = session
 		? session.kind === "orchestrator"
@@ -1050,6 +1066,7 @@ function AttachedTerminal({
 			{showEndedState && (
 				<TerminalEndedStrip
 					canRestore={canRestoreSession}
+					canResumeAgent={canResumeAgent}
 					error={restoreError}
 					isRestoring={isRestoring}
 					onRestore={restoreSession}
@@ -1135,33 +1152,36 @@ function ReplayCover() {
 
 type TerminalEndedStripProps = {
 	canRestore: boolean;
+	canResumeAgent?: boolean;
 	error?: string;
 	isRestoring: boolean;
 	onRestore: () => void;
 	variant: "reviewer" | "session" | "shell";
 };
 
-function TerminalEndedStrip({ canRestore, error, isRestoring, onRestore, variant }: TerminalEndedStripProps) {
+function TerminalEndedStrip({ canRestore, canResumeAgent, error, isRestoring, onRestore, variant }: TerminalEndedStripProps) {
 	const { t } = useTranslation();
-	const message = canRestore
-		? t("terminal.restoreToContinue")
-		: variant === "reviewer"
-			? t("terminal.reviewerEnded")
-			: variant === "shell"
-				? t("terminal.shellExited")
-				: t("terminal.sessionEndedNotTerminated");
+	const message = canResumeAgent
+		? t("terminal.agentExitedRestore")
+		: canRestore
+			? t("terminal.restoreToContinue")
+			: variant === "reviewer"
+				? t("terminal.reviewerEnded")
+				: variant === "shell"
+					? t("terminal.shellExited")
+					: t("terminal.sessionEndedNotTerminated");
 
 	return (
 		<div className="shrink-0 border-b border-border bg-surface/80 px-4 py-2">
 			<div className="flex min-h-control-board items-center gap-3">
 				<div className="min-w-0 flex-1">
 					<div className="font-mono text-caption font-medium uppercase tracking-wide-md text-muted-foreground">
-						{t("terminal.ended")}
+						{canResumeAgent ? t("terminal.agentExited") : t("terminal.ended")}
 					</div>
 					<div className="mt-0.5 truncate text-xs text-muted-foreground">{message}</div>
 				</div>
 				{error && <div className="max-w-content-max truncate text-xs text-destructive">{error}</div>}
-				{canRestore && (
+				{(canRestore || canResumeAgent) && (
 					<button
 						type="button"
 						aria-label={t("terminal.restoreSession")}

--- a/frontend/src/renderer/hooks/useRestoreSession.ts
+++ b/frontend/src/renderer/hooks/useRestoreSession.ts
@@ -7,15 +7,15 @@ import { workspaceQueryKey } from "./useWorkspaceQuery";
 export type RestoreSessionResult =
 	{ status: "success" } | { status: "not_resumable"; message: string } | { status: "error"; message: string };
 
-export function useRestoreSession(): (sessionId: string) => Promise<RestoreSessionResult> {
+function useRelaunchSession(
+	post: (sessionId: string) => Promise<{ data?: { mode?: string }; error?: unknown }>,
+): (sessionId: string) => Promise<RestoreSessionResult> {
 	const queryClient = useQueryClient();
 
 	return useCallback(
 		async (sessionId: string) => {
 			try {
-				const { data, error } = await apiClient.POST("/api/v1/sessions/{sessionId}/restore", {
-					params: { path: { sessionId } },
-				});
+				const { data, error } = await post(sessionId);
 				if (error) {
 					const code = (error as { code?: string }).code;
 					const message = apiErrorMessage(error, "Unable to restore session");
@@ -25,7 +25,7 @@ export function useRestoreSession(): (sessionId: string) => Promise<RestoreSessi
 					return { status: "error", message };
 				}
 				await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-				if (data?.restoreMode === "saved_prompt") {
+				if (data?.mode === "saved_prompt") {
 					void aoBridge.notifications
 						.show({
 							id: `restore-fallback:${sessionId}:${Date.now()}`,
@@ -44,6 +44,29 @@ export function useRestoreSession(): (sessionId: string) => Promise<RestoreSessi
 				};
 			}
 		},
-		[queryClient],
+		[post, queryClient],
 	);
+}
+
+export function useRestoreSession(): (sessionId: string) => Promise<RestoreSessionResult> {
+	const post = useCallback(async (sessionId: string) => {
+		const { data, error } = await apiClient.POST("/api/v1/sessions/{sessionId}/restore", {
+			params: { path: { sessionId } },
+		});
+		return { data: data ? { mode: data.restoreMode } : undefined, error };
+	}, []);
+	return useRelaunchSession(post);
+}
+
+// useResumeAgentSession relaunches an exited agent inside its still-live
+// session (terminal identity and worktree preserved) — the recovery path for
+// an agent killed in its pane (e.g. Ctrl-C) while the session row is alive.
+export function useResumeAgentSession(): (sessionId: string) => Promise<RestoreSessionResult> {
+	const post = useCallback(async (sessionId: string) => {
+		const { data, error } = await apiClient.POST("/api/v1/sessions/{sessionId}/resume-agent", {
+			params: { path: { sessionId } },
+		});
+		return { data: data ? { mode: data.resumeMode } : undefined, error };
+	}, []);
+	return useRelaunchSession(post);
 }

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -995,6 +995,8 @@
 	"termination.confirmAria": "Ja, Sitzung beenden",
 	"termination.dialog": "Sitzung beenden?",
 	"termination.dialogNamed": "{{title}} beenden?",
+	"terminal.agentExited": "Agent beendet",
+	"terminal.agentExitedRestore": "Der Agent wurde beendet. Stelle die Sitzung wieder her, um ihn hier neu zu starten.",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "Zurück zum Agent-Terminal",
 	"terminal.copiedToClipboard": "In die Zwischenablage kopiert",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1000,6 +1000,8 @@
 	"termination.confirmAria": "Yes, terminate session",
 	"termination.dialog": "Terminate session?",
 	"termination.dialogNamed": "Terminate {{title}}?",
+	"terminal.agentExited": "Agent exited",
+	"terminal.agentExitedRestore": "The agent exited. Restore to relaunch it in this session.",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "Back to agent terminal",
 	"terminal.copiedToClipboard": "Copied to clipboard",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1006,6 +1006,8 @@
 	"termination.confirmAria": "Sí, terminar sesión",
 	"termination.dialog": "¿Terminar sesión?",
 	"termination.dialogNamed": "¿Terminar {{title}}?",
+	"terminal.agentExited": "Agente finalizado",
+	"terminal.agentExitedRestore": "El agente finalizó. Restaura para relanzarlo en esta sesión.",
 	"terminal.agent": "agente",
 	"terminal.backToAgent": "Volver al terminal del agente",
 	"terminal.copiedToClipboard": "Copiado al portapapeles",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1006,6 +1006,8 @@
 	"termination.confirmAria": "Oui, terminer la session",
 	"termination.dialog": "Terminer la session ?",
 	"termination.dialogNamed": "Terminer {{title}} ?",
+	"terminal.agentExited": "Agent terminé",
+	"terminal.agentExitedRestore": "L'agent s'est arrêté. Restaurez pour le relancer dans cette session.",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "Retour au terminal de l'agent",
 	"terminal.copiedToClipboard": "Copié dans le presse-papiers",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -995,6 +995,8 @@
 	"termination.confirmAria": "はい、セッションを終了します",
 	"termination.dialog": "セッションを終了しますか？",
 	"termination.dialogNamed": "{{title}} を終了しますか？",
+	"terminal.agentExited": "エージェント終了",
+	"terminal.agentExitedRestore": "エージェントが終了しました。復元するとこのセッションで再起動します。",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "エージェントターミナルに戻る",
 	"terminal.copiedToClipboard": "クリップボードにコピーしました",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -995,6 +995,8 @@
 	"termination.confirmAria": "예, 세션 종료",
 	"termination.dialog": "세션을 종료하시겠습니까?",
 	"termination.dialogNamed": "{{title}}을(를) 종료하시겠습니까?",
+	"terminal.agentExited": "에이전트 종료됨",
+	"terminal.agentExitedRestore": "에이전트가 종료되었습니다. 복원하면 이 세션에서 다시 시작됩니다.",
 	"terminal.agent": "agent",
 	"terminal.backToAgent": "에이전트 터미널로 돌아가기",
 	"terminal.copiedToClipboard": "클립보드에 복사됨",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1006,6 +1006,8 @@
 	"termination.confirmAria": "Sim, encerrar sessão",
 	"termination.dialog": "Encerrar sessão?",
 	"termination.dialogNamed": "Encerrar {{title}}?",
+	"terminal.agentExited": "Agente encerrado",
+	"terminal.agentExitedRestore": "O agente foi encerrado. Restaure para reiniciá-lo nesta sessão.",
 	"terminal.agent": "agente",
 	"terminal.backToAgent": "Voltar ao terminal do agente",
 	"terminal.copiedToClipboard": "Copiado para a área de transferência",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -983,6 +983,8 @@
 	"termination.confirmAria": "是，终止会话",
 	"termination.dialog": "终止会话？",
 	"termination.dialogNamed": "终止 {{title}}？",
+	"terminal.agentExited": "代理已退出",
+	"terminal.agentExitedRestore": "代理已退出。恢复后将在此会话中重新启动。",
 	"terminal.agent": "代理",
 	"terminal.backToAgent": "返回代理终端",
 	"terminal.copiedToClipboard": "已复制到剪贴板",


### PR DESCRIPTION
## Problem

Ctrl+C in a supervised agent terminal (worker **or** orchestrator) permanently bricked the session with no recovery path:

1. Since #3548, supervised launches park the pane on \`exec cat >/dev/null\` after the agent exits. Ctrl+C kills the agent TUI → the pane silently swallows every keystroke with no banner; it looks hung.
2. Because \`cat\` holds the tmux pane open, \`tmux has-session\` stays true, so the session never becomes \`terminated\` — the supervisor's exit report (and the reaper's workload probe as fallback) flip **activity** to \`exited\`, but \`isTerminated\` stays false, by design.
3. \`TerminalPane\` gated its Restore button on the session being terminated → the button never appeared. The only affordance for an exited-but-live agent was a "Resume agent" control buried in the session inspector's Summary tab — and **orchestrators have no inspector at all** (\`SessionView.tsx\`: \`hasInspector = session && !isOrchestrator\`), so one Ctrl+C in an orchestrator = dead session, zero recovery affordance.
4. \`RestoreUnavailableDialog\` (create-new-orchestrator fallback) was only reachable via a failed restore attempt → also unreachable.

## Triage findings

The backend lifecycle was already sound: the supervisor posts \`process-exited\`, the reaper's supervised-workload probe covers a lost report, and \`ResumeAgentWithMode\` + \`POST /sessions/{id}/resume-agent\` already implement in-place relaunch (native resume, terminal identity and worktree preserved, role-specific system prompt rebuilt). The bricking was a pane-UX + affordance gap, so no backend lifecycle change was needed.

## Fix

- **tmux** (\`buildLaunchCommand\`): supervised panes now print \`[ao] agent exited - restore this session from the app to continue\` before \`exec cat >/dev/null\`. The input-swallowing safety property is unchanged — no interactive shell, stdin still drains into \`cat\`.
- **TerminalPane**: the ended strip now also appears when a live session's activity is \`exited\` (and no agent switch is in flight), with the button routed to \`/resume-agent\`; terminated sessions keep the existing \`/restore\` path. \`SESSION_NOT_RESUMABLE\` from either path opens the existing not-resumable dialog, making the create-new-orchestrator fallback reachable.
- New \`useResumeAgentSession\` hook mirroring \`useRestoreSession\` (shared implementation), including the saved-prompt fallback notification.

## Verification (real repro)

Booted an isolated daemon from this branch with a raw-mode stub \`claude\` binary (emulates a TUI: Ctrl+C arrives as a byte, agent exits cleanly). For **both a worker and an orchestrator**:

- Ctrl+C → pane shows the new banner, \`cat\` holds the pane, session lands in \`status: exited, isTerminated: false\`.
- \`POST /sessions/{id}/resume-agent\` → \`resumeMode: "native"\`, agent relaunched in the same pane with \`--resume <same pinned UUID>\` and the role's rebuilt system prompt; session returns to live status.
- Also confirmed the reaper's workload probe flips the state even when the supervisor's direct exit report fails to land.

## Tests

- \`tmux_test.go\`: new \`TestCreateLaunchCommandSupervisedParksOnBannerAndCat\` (banner precedes the sink; no interactive shell in supervised panes).
- \`TerminalPane.test.tsx\`: live worker/orchestrator with exited activity shows the strip and posts \`/resume-agent\`; no affordance while an agent switch is replacing the agent; existing terminated-session restore tests unchanged.
- \`go test ./internal/adapters/runtime/tmux/\`, frontend typecheck, and the full renderer vitest suite pass (pre-existing \`src/landing/**\` failures are an unrelated missing-workspace-install issue in this worktree).

## Risks / follow-ups

- The banner string is asserted in the tmux unit test; changing the copy requires updating both.
- Observation from the repro rig: the supervisor's exit report resolves the daemon from default run-file discovery; in multi-daemon dev setups it can post to the wrong daemon (harmless in production single-daemon installs, and the reaper probe covers it). Possible hardening: pin \`AO_RUN_FILE\` into session env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)