### PR TITLE
fix(workspace): preserve automatic default refresh

### DIFF
--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -965,7 +965,10 @@ func (m *Manager) refreshDefaultBranchesBestEffort(ctx context.Context, project 
 	baseRefs := make(map[string]string)
 	targets := []defaultBranchRefreshTarget{{
 		repoPath:         project.Path,
-		configuredBranch: project.Config.WithDefaults().DefaultBranch,
+		// Translate the automatic-default sentinel before handing it to the
+		// adapter. An empty branch tells the resolver to inspect this
+		// repository's own remote HEAD; "auto" is not a Git branch name.
+		configuredBranch: project.Config.WorktreeBaseBranch(),
 	}}
 	if project.Kind.WithDefault() == domain.ProjectKindWorkspace {
 		repos, err := m.store.ListWorkspaceRepos(ctx, project.ID)

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -964,7 +964,7 @@ func (m *Manager) refreshDefaultBranchesBestEffort(ctx context.Context, project 
 	}
 	baseRefs := make(map[string]string)
 	targets := []defaultBranchRefreshTarget{{
-		repoPath:         project.Path,
+		repoPath: project.Path,
 		// Translate the automatic-default sentinel before handing it to the
 		// adapter. An empty branch tells the resolver to inspect this
 		// repository's own remote HEAD; "auto" is not a Git branch name.

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -3264,11 +3264,14 @@ func TestSpawn_FetchesWorkspaceChildDefaultBranchesBeforeCreatingProject(t *test
 		t.Fatal(err)
 	}
 	want := []fetchDefaultBranchCall{
-		{repoPath: "/repo/mer", remote: "origin", branch: "auto", baseRef: "refs/remotes/origin/auto"},
+		{repoPath: "/repo/mer", remote: "origin", branch: "main", baseRef: "refs/remotes/origin/main"},
 		{repoPath: filepath.Join("/repo/mer", "api"), remote: "origin", branch: "release/2026", baseRef: "refs/remotes/origin/release/2026"},
 	}
 	if !reflect.DeepEqual(ws.fetches, want) {
 		t.Fatalf("fetches = %#v, want %#v", ws.fetches, want)
+	}
+	if got, want := ws.resolves[0], (resolveDefaultBranchCall{repoPath: "/repo/mer", configuredBranch: ""}); got != want {
+		t.Fatalf("root resolution = %#v, want %#v", got, want)
 	}
 	if got, want := ws.lastProjectCfg.Repos[0].BaseRef, "refs/remotes/origin/release/2026"; got != want {
 		t.Fatalf("child create base ref = %q, want %q", got, want)


### PR DESCRIPTION
## Summary

- translate the internal `auto` default-branch sentinel before resolving and refreshing the workspace root
- retain per-repository remote `HEAD` inference introduced by #3983
- cover the root automatic-default path in the workspace refresh test

## Root cause

#3861 passed the literal `auto` sentinel to the Git default-branch resolver. The resolver interprets non-empty values as real branch names, which made it attempt to refresh `origin/auto` instead of the repository's configured default branch.

## Validation

- `go test ./internal/session_manager -count=1`
