### PR TITLE
feat: inline external review comments in Reviews inspector

### DIFF
--- a/backend/internal/autoreview/coordinator_test.go
+++ b/backend/internal/autoreview/coordinator_test.go
@@ -62,7 +62,7 @@ func TestEvaluateSessionEligibility(t *testing.T) {
 		{name: "waiting input", mutate: func(f *fakeStore) { f.session.Activity.State = domain.ActivityWaitingInput }},
 		{name: "blocked", mutate: func(f *fakeStore) { f.session.Activity.State = domain.ActivityBlocked }},
 		{name: "terminated", mutate: func(f *fakeStore) { f.session.IsTerminated = true }},
-		{name: "draft", mutate: func(f *fakeStore) { f.prs[0].Draft = true }},
+		{name: "draft", want: true, mutate: func(f *fakeStore) { f.prs[0].Draft = true }},
 		{name: "closed", mutate: func(f *fakeStore) { f.prs[0].Closed = true }},
 		{name: "merged", mutate: func(f *fakeStore) { f.prs[0].Merged = true }},
 		{name: "missing head", mutate: func(f *fakeStore) { f.prs[0].HeadSHA = "" }},

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -7738,6 +7738,10 @@ components:
           type: string
         hasUnresolvedHumanComments:
           type: boolean
+        resolvedBy:
+          items:
+            $ref: '#/components/schemas/SessionPRUnresolvedReviewer'
+          type: array
         reviews:
           items:
             $ref: '#/components/schemas/SessionPRReviewEntry'

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -682,6 +682,7 @@ type SessionPRReviewSummary struct {
 	Decision                   domain.ReviewDecision         `json:"decision" enum:"none,approved,changes_requested,review_required"`
 	HasUnresolvedHumanComments bool                          `json:"hasUnresolvedHumanComments"`
 	UnresolvedBy               []SessionPRUnresolvedReviewer `json:"unresolvedBy"`
+	ResolvedBy                 []SessionPRUnresolvedReviewer `json:"resolvedBy,omitempty"`
 	Reviews                    []SessionPRReviewEntry        `json:"reviews,omitempty"`
 }
 
@@ -697,7 +698,7 @@ type SessionPRReviewEntry struct {
 	AutoInjectReview bool                  `json:"autoInjectReview"`
 }
 
-// SessionPRUnresolvedReviewer groups unresolved human comments by reviewer.
+// SessionPRUnresolvedReviewer groups review comments by reviewer.
 type SessionPRUnresolvedReviewer struct {
 	ReviewerID string                       `json:"reviewerId"`
 	Count      int                          `json:"count"`
@@ -706,7 +707,7 @@ type SessionPRUnresolvedReviewer struct {
 	IsBot      bool                         `json:"isBot,omitempty"`
 }
 
-// SessionPRReviewCommentLink points to one unresolved review comment.
+// SessionPRReviewCommentLink points to one review comment.
 type SessionPRReviewCommentLink struct {
 	URL              string `json:"url,omitempty"`
 	File             string `json:"file,omitempty"`
@@ -780,14 +781,8 @@ func newSessionPRCISummary(in sessionsvc.PRCISummary) SessionPRCISummary {
 }
 
 func newSessionPRReviewSummary(in sessionsvc.PRReviewSummary) SessionPRReviewSummary {
-	reviewers := make([]SessionPRUnresolvedReviewer, 0, len(in.UnresolvedBy))
-	for _, reviewer := range in.UnresolvedBy {
-		links := make([]SessionPRReviewCommentLink, 0, len(reviewer.Links))
-		for _, link := range reviewer.Links {
-			links = append(links, SessionPRReviewCommentLink{URL: link.URL, File: link.File, Line: link.Line, Body: link.Body, AutoInjectReview: link.AutoInjectReview})
-		}
-		reviewers = append(reviewers, SessionPRUnresolvedReviewer{ReviewerID: reviewer.ReviewerID, Count: reviewer.Count, Links: links, ReviewURL: reviewer.ReviewURL, IsBot: reviewer.IsBot})
-	}
+	reviewers := newSessionPRCommentReviewers(in.UnresolvedBy)
+	resolvedReviewers := newSessionPRCommentReviewers(in.ResolvedBy)
 	entries := make([]SessionPRReviewEntry, 0, len(in.Reviews))
 	for _, review := range in.Reviews {
 		entries = append(entries, SessionPRReviewEntry{
@@ -800,7 +795,19 @@ func newSessionPRReviewSummary(in sessionsvc.PRReviewSummary) SessionPRReviewSum
 			AutoInjectReview: review.AutoInjectReview,
 		})
 	}
-	return SessionPRReviewSummary{Decision: in.Decision, HasUnresolvedHumanComments: in.HasUnresolvedHumanComments, UnresolvedBy: reviewers, Reviews: entries}
+	return SessionPRReviewSummary{Decision: in.Decision, HasUnresolvedHumanComments: in.HasUnresolvedHumanComments, UnresolvedBy: reviewers, ResolvedBy: resolvedReviewers, Reviews: entries}
+}
+
+func newSessionPRCommentReviewers(in []sessionsvc.PRUnresolvedReviewer) []SessionPRUnresolvedReviewer {
+	reviewers := make([]SessionPRUnresolvedReviewer, 0, len(in))
+	for _, reviewer := range in {
+		links := make([]SessionPRReviewCommentLink, 0, len(reviewer.Links))
+		for _, link := range reviewer.Links {
+			links = append(links, SessionPRReviewCommentLink{URL: link.URL, File: link.File, Line: link.Line, Body: link.Body, AutoInjectReview: link.AutoInjectReview})
+		}
+		reviewers = append(reviewers, SessionPRUnresolvedReviewer{ReviewerID: reviewer.ReviewerID, Count: reviewer.Count, Links: links, ReviewURL: reviewer.ReviewURL, IsBot: reviewer.IsBot})
+	}
+	return reviewers
 }
 
 func newSessionPRMergeabilitySummary(in sessionsvc.PRMergeabilitySummary) SessionPRMergeabilitySummary {

--- a/backend/internal/review/planner.go
+++ b/backend/internal/review/planner.go
@@ -19,7 +19,7 @@ const (
 	ReviewStateUpToDate = contract.AOReviewUpToDate
 	// ReviewStateChangesRequested means AO requested changes on the PR's current head.
 	ReviewStateChangesRequested = contract.AOReviewChangesRequested
-	// ReviewStateIneligible means the PR is draft, closed, merged, or missing required facts.
+	// ReviewStateIneligible means the PR is closed, merged, or missing required facts.
 	ReviewStateIneligible = contract.AOReviewIneligible
 )
 
@@ -51,7 +51,7 @@ func Plan(prs []domain.PullRequest, runs []domain.ReviewRun) []PRReviewState {
 		if run, ok := latestCompletedRunForOtherSHA(runs, review.PRURL, review.TargetSHA); ok {
 			review.PreviousRun = &run
 		}
-		if pr.URL == "" || pr.HeadSHA == "" || pr.Draft || pr.Merged || pr.Closed {
+		if pr.URL == "" || pr.HeadSHA == "" || pr.Merged || pr.Closed {
 			review.Status = ReviewStateIneligible
 			if run, ok := latest[review.PRURL+"\x00"+review.TargetSHA]; ok {
 				review.LatestRun = &run

--- a/backend/internal/review/planner_test.go
+++ b/backend/internal/review/planner_test.go
@@ -16,7 +16,7 @@ func TestPlanStatuses(t *testing.T) {
 		want StateStatus
 	}{
 		{name: "open needs review", pr: planPR("pr1", 1, "sha1"), want: ReviewStateNeedsReview},
-		{name: "draft ineligible", pr: withDraft(planPR("pr1", 1, "sha1")), want: ReviewStateIneligible},
+		{name: "draft needs review", pr: withDraft(planPR("pr1", 1, "sha1")), want: ReviewStateNeedsReview},
 		{name: "merged ineligible", pr: withMerged(planPR("pr1", 1, "sha1")), want: ReviewStateIneligible},
 		{name: "closed ineligible", pr: withClosed(planPR("pr1", 1, "sha1")), want: ReviewStateIneligible},
 		{name: "approved current sha up to date", pr: planPR("pr1", 1, "sha1"), runs: []domain.ReviewRun{

--- a/backend/internal/service/review/review.go
+++ b/backend/internal/service/review/review.go
@@ -90,6 +90,7 @@ type Store interface {
 	ListPRsBySession(ctx context.Context, id domain.SessionID) ([]domain.PullRequest, error)
 	ListPRReviews(ctx context.Context, prURL string) ([]domain.PullRequestReview, error)
 	ListPRComments(ctx context.Context, prURL string) ([]domain.PullRequestComment, error)
+	MarkPRCommentResolved(ctx context.Context, prURL, commentID string) (bool, error)
 }
 
 // Reducer is the lifecycle reaction boundary used after a review result has
@@ -357,6 +358,11 @@ func (s *Service) ResolveReviewComment(ctx context.Context, workerID domain.Sess
 			return fmt.Errorf("%w: %w", ErrInvalid, err)
 		}
 		return err
+	}
+	if updated, err := s.store.MarkPRCommentResolved(ctx, pr.URL, target.ID); err != nil {
+		return err
+	} else if !updated {
+		return fmt.Errorf("%w: review comment is not tracked for this PR", ErrNotFound)
 	}
 	s.emit("ao.review.comment_resolved", workerID, map[string]any{"provider": pr.Provider})
 	return nil

--- a/backend/internal/service/review/review_test.go
+++ b/backend/internal/service/review/review_test.go
@@ -29,6 +29,7 @@ type fakeStore struct {
 	agentSessionUpdate int
 	markCalls          int
 	markedIDs          []string
+	resolvedCommentIDs []string
 }
 
 func (f *fakeStore) GetReviewByID(_ context.Context, id string) (domain.Review, bool, error) {
@@ -137,6 +138,19 @@ func (f *fakeStore) ListPRComments(_ context.Context, prURL string) ([]domain.Pu
 	return out, nil
 }
 
+func (f *fakeStore) MarkPRCommentResolved(_ context.Context, prURL, commentID string) (bool, error) {
+	f.resolvedCommentIDs = append(f.resolvedCommentIDs, commentID)
+	comments := f.prComments[prURL]
+	for i := range comments {
+		if comments[i].ID == commentID {
+			comments[i].Resolved = true
+			f.prComments[prURL] = comments
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 type fakeReviewResolver struct {
 	request ports.SCMReviewResolveRequest
 	err     error
@@ -163,7 +177,7 @@ func TestResolveReviewCommentResolvesTrackedThread(t *testing.T) {
 	store := &fakeStore{
 		prs: []domain.PullRequest{{URL: prURL, Number: 7, Provider: "github", Repo: "acme/widget"}},
 		prComments: map[string][]domain.PullRequestComment{
-			prURL: {{ThreadID: "thread-1", URL: commentURL}},
+			prURL: {{ThreadID: "thread-1", ID: "comment-1", URL: commentURL}},
 		},
 	}
 	resolver := &fakeReviewResolver{}
@@ -174,6 +188,35 @@ func TestResolveReviewCommentResolvesTrackedThread(t *testing.T) {
 	}
 	if resolver.request.ThreadID != "thread-1" || resolver.request.PR.Number != 7 {
 		t.Fatalf("request = %#v", resolver.request)
+	}
+	if got := store.resolvedCommentIDs; len(got) != 1 || got[0] != "comment-1" {
+		t.Fatalf("resolved comment ids = %#v", got)
+	}
+	if !store.prComments[prURL][0].Resolved {
+		t.Fatalf("comment was not marked resolved: %#v", store.prComments[prURL][0])
+	}
+}
+
+func TestResolveReviewCommentDoesNotPersistWhenProviderFails(t *testing.T) {
+	prURL := "https://github.com/acme/widget/pull/7"
+	commentURL := "https://github.com/acme/widget/pull/7#discussion_r1"
+	store := &fakeStore{
+		prs: []domain.PullRequest{{URL: prURL, Number: 7, Provider: "github", Repo: "acme/widget"}},
+		prComments: map[string][]domain.PullRequestComment{
+			prURL: {{ThreadID: "thread-1", ID: "comment-1", URL: commentURL}},
+		},
+	}
+	resolver := &fakeReviewResolver{err: errors.New("provider down")}
+	svc := New(nil, store, WithReviewResolver(resolver))
+
+	if err := svc.ResolveReviewComment(context.Background(), "mer-1", prURL, commentURL); err == nil {
+		t.Fatal("ResolveReviewComment error = nil, want provider failure")
+	}
+	if len(store.resolvedCommentIDs) != 0 {
+		t.Fatalf("resolved comment ids = %#v, want none", store.resolvedCommentIDs)
+	}
+	if store.prComments[prURL][0].Resolved {
+		t.Fatalf("comment was marked resolved after provider failure")
 	}
 }
 

--- a/backend/internal/service/session/pr_summary.go
+++ b/backend/internal/service/session/pr_summary.go
@@ -160,29 +160,43 @@ func summarizeReview(pr domain.PullRequest, comments []domain.PullRequestComment
 		return out
 	}
 	byReviewer := map[string]int{}
+	resolvedByReviewer := map[string]int{}
 	order := []string{}
+	resolvedOrder := []string{}
 	links := map[string][]PRReviewCommentLink{}
+	resolvedLinks := map[string][]PRReviewCommentLink{}
 	isBot := map[string]bool{}
+	resolvedIsBot := map[string]bool{}
 	for _, c := range comments {
-		if c.Resolved || c.IsBot {
+		if c.IsBot {
 			continue
 		}
 		reviewer := strings.TrimSpace(c.Author)
 		if reviewer == "" {
 			reviewer = "unknown"
 		}
-		if _, ok := byReviewer[reviewer]; !ok {
-			order = append(order, reviewer)
-		}
-		byReviewer[reviewer]++
-		isBot[reviewer] = c.IsBot
-		links[reviewer] = append(links[reviewer], PRReviewCommentLink{
+		link := PRReviewCommentLink{
 			URL:              c.URL,
 			File:             c.File,
 			Line:             c.Line,
 			Body:             c.Body,
 			AutoInjectReview: c.AutoInjectReview,
-		})
+		}
+		if c.Resolved {
+			if _, ok := resolvedByReviewer[reviewer]; !ok {
+				resolvedOrder = append(resolvedOrder, reviewer)
+			}
+			resolvedByReviewer[reviewer]++
+			resolvedIsBot[reviewer] = c.IsBot
+			resolvedLinks[reviewer] = append(resolvedLinks[reviewer], link)
+			continue
+		}
+		if _, ok := byReviewer[reviewer]; !ok {
+			order = append(order, reviewer)
+		}
+		byReviewer[reviewer]++
+		isBot[reviewer] = c.IsBot
+		links[reviewer] = append(links[reviewer], link)
 	}
 	latestReviews := latestChangesRequestedReviews(reviews)
 	reviewURLByAuthor := map[string]string{}
@@ -217,6 +231,16 @@ func summarizeReview(pr domain.PullRequest, comments []domain.PullRequestComment
 			Links:      links[reviewer],
 			ReviewURL:  reviewURLByAuthor[reviewer],
 			IsBot:      isBot[reviewer],
+		})
+	}
+	sort.Strings(resolvedOrder)
+	for _, reviewer := range resolvedOrder {
+		out.ResolvedBy = append(out.ResolvedBy, PRUnresolvedReviewer{
+			ReviewerID: reviewer,
+			Count:      resolvedByReviewer[reviewer],
+			Links:      resolvedLinks[reviewer],
+			ReviewURL:  reviewURLByAuthor[reviewer],
+			IsBot:      resolvedIsBot[reviewer],
 		})
 	}
 	for _, reviewer := range out.UnresolvedBy {

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -3259,6 +3259,9 @@ func TestListPRSummariesExposesReviewSummariesButKeepsRawLogsAndCommentBodiesPri
 	} else if reviewer.Links[0].Body != "raw body must stay private" || reviewer.Links[1].Body != "another raw body" {
 		t.Fatalf("comment bodies = %+v", reviewer.Links)
 	}
+	if len(pr.Review.ResolvedBy) != 1 || pr.Review.ResolvedBy[0].Count != 1 || pr.Review.ResolvedBy[0].Links[0].Body != "resolved body" {
+		t.Fatalf("resolved comments = %+v", pr.Review.ResolvedBy)
+	}
 	if pr.Mergeability.State != domain.MergeConflicting || len(pr.Mergeability.ConflictFiles) != 0 || !containsString(pr.Mergeability.Reasons, "conflicts") {
 		t.Fatalf("mergeability = %+v", pr.Mergeability)
 	}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -3229,6 +3229,7 @@ func TestListPRSummariesExposesReviewSummariesButKeepsRawLogsAndCommentBodiesPri
 	stList.comments[prURL] = []domain.PullRequestComment{
 		{Author: "reviewer-a", File: "main.go", Line: 12, Body: "raw body must stay private", URL: "https://github.com/acme/repo/pull/7#discussion_r1", AutoInjectReview: false},
 		{Author: "ci-bot", File: "main.go", Line: 13, Body: "bot body", URL: "https://github.com/acme/repo/pull/7#discussion_r2", IsBot: true},
+		{Author: "reviewer-a", File: "main.go", Line: 14, Body: "resolved body", URL: "https://github.com/acme/repo/pull/7#discussion_r4", Resolved: true},
 		{Author: "reviewer-a", File: "test.go", Line: 22, Body: "another raw body", URL: "https://github.com/acme/repo/pull/7#discussion_r3", AutoInjectReview: true},
 	}
 

--- a/backend/internal/storage/sqlite/gen/pr_comment.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr_comment.sql.go
@@ -110,6 +110,23 @@ func (q *Queries) ListPRComments(ctx context.Context, prUrl string) ([]PRComment
 	return items, nil
 }
 
+const markPRCommentResolved = `-- name: MarkPRCommentResolved :execrows
+UPDATE pr_comment SET resolved = TRUE WHERE pr_url = ? AND comment_id = ?
+`
+
+type MarkPRCommentResolvedParams struct {
+	PRURL     string
+	CommentID string
+}
+
+func (q *Queries) MarkPRCommentResolved(ctx context.Context, arg MarkPRCommentResolvedParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markPRCommentResolved, arg.PRURL, arg.CommentID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const upsertPRComment = `-- name: UpsertPRComment :exec
 INSERT INTO pr_comment (pr_url, comment_id, author, file, line, body, resolved, created_at, thread_id, url, is_bot, auto_inject_review)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/backend/internal/storage/sqlite/queries/pr_comment.sql
+++ b/backend/internal/storage/sqlite/queries/pr_comment.sql
@@ -22,6 +22,9 @@ DELETE FROM pr_comment WHERE pr_url = ? AND thread_id = '';
 -- name: DeletePRComment :exec
 DELETE FROM pr_comment WHERE pr_url = ? AND comment_id = ?;
 
+-- name: MarkPRCommentResolved :execrows
+UPDATE pr_comment SET resolved = TRUE WHERE pr_url = ? AND comment_id = ?;
+
 -- name: ListPRComments :many
 SELECT pr_url, comment_id, author, file, line, body, resolved, created_at, thread_id, url, is_bot, auto_inject_review
 FROM pr_comment WHERE pr_url = ? ORDER BY created_at, comment_id;

--- a/backend/internal/storage/sqlite/store/pr_store.go
+++ b/backend/internal/storage/sqlite/store/pr_store.go
@@ -493,6 +493,17 @@ func (s *Store) ListPRComments(ctx context.Context, prURL string) ([]domain.Pull
 	return out, nil
 }
 
+// MarkPRCommentResolved records a provider-resolved review comment locally.
+func (s *Store) MarkPRCommentResolved(ctx context.Context, prURL, commentID string) (bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	affected, err := s.qw.MarkPRCommentResolved(ctx, gen.MarkPRCommentResolvedParams{PRURL: prURL, CommentID: commentID})
+	if err != nil {
+		return false, fmt.Errorf("mark pr comment resolved %s/%s: %w", prURL, commentID, err)
+	}
+	return affected > 0, nil
+}
+
 // ListPRReviewThreads returns a PR's review threads, oldest first.
 func (s *Store) ListPRReviewThreads(ctx context.Context, prURL string) ([]domain.PullRequestReviewThread, error) {
 	rows, err := s.qr.ListPRReviewThreads(ctx, prURL)

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -934,6 +934,43 @@ func TestPRCommentsReplace(t *testing.T) {
 	}
 }
 
+func TestMarkPRCommentResolved(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	r, _ := s.CreateSession(ctx, sampleRecord("mer"))
+	now := time.Now().UTC().Truncate(time.Second)
+	pr := domain.PullRequest{URL: "pr1", SessionID: r.ID, UpdatedAt: now}
+	if err := s.WritePR(ctx, pr, nil, []domain.PullRequestComment{
+		{ID: "c1", Author: "a", Body: "nit", URL: "comment-1", CreatedAt: now},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := s.MarkPRCommentResolved(ctx, "pr1", "c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("MarkPRCommentResolved updated = false, want true")
+	}
+	comments, err := s.ListPRComments(ctx, "pr1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || !comments[0].Resolved {
+		t.Fatalf("comments = %+v, want c1 resolved", comments)
+	}
+
+	updated, err = s.MarkPRCommentResolved(ctx, "pr1", "missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("MarkPRCommentResolved missing updated = true, want false")
+	}
+}
+
 func TestWriteSCMObservationPersistsMetadataChecksReviewsAndComments(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/backend/pkg/contract/scm.go
+++ b/backend/pkg/contract/scm.go
@@ -82,7 +82,7 @@ type PullRequestCISummary struct {
 	AutoInjectCI  bool                      `json:"autoInjectCI"`
 }
 
-// PullRequestReviewCommentLink points to one unresolved review comment.
+// PullRequestReviewCommentLink points to one review comment.
 type PullRequestReviewCommentLink struct {
 	URL              string `json:"url,omitempty"`
 	File             string `json:"file,omitempty"`
@@ -91,7 +91,7 @@ type PullRequestReviewCommentLink struct {
 	AutoInjectReview bool   `json:"autoInjectReview"`
 }
 
-// PullRequestUnresolvedReviewer groups unresolved comments by reviewer.
+// PullRequestUnresolvedReviewer groups review comments by reviewer.
 type PullRequestUnresolvedReviewer struct {
 	ReviewerID string                         `json:"reviewerId"`
 	Count      int                            `json:"count"`
@@ -116,6 +116,7 @@ type PullRequestReviewSummary struct {
 	Decision                   ReviewDecision                  `json:"decision"`
 	HasUnresolvedHumanComments bool                            `json:"hasUnresolvedHumanComments"`
 	UnresolvedBy               []PullRequestUnresolvedReviewer `json:"unresolvedBy"`
+	ResolvedBy                 []PullRequestUnresolvedReviewer `json:"resolvedBy,omitempty"`
 	Reviews                    []PullRequestSubmittedReview    `json:"reviews"`
 }
 

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2678,6 +2678,7 @@ export interface components {
             /** @enum {string} */
             decision: "none" | "approved" | "changes_requested" | "review_required";
             hasUnresolvedHumanComments: boolean;
+            resolvedBy?: components["schemas"]["SessionPRUnresolvedReviewer"][];
             reviews?: components["schemas"]["SessionPRReviewEntry"][];
             unresolvedBy: components["schemas"]["SessionPRUnresolvedReviewer"][];
         };

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1507,14 +1507,6 @@ describe("SessionInspector summary reviews", () => {
     }
   };
 
-  const openLatestAgentReview = async () => {
-    const cards = await screen.findAllByTestId("agent-review-card");
-    const trigger = within(cards[0]).getByRole("button");
-    if (trigger.getAttribute("aria-expanded") === "false") {
-      await userEvent.click(trigger);
-    }
-  };
-
   it("triggers a review and opens the returned reviewer terminal", async () => {
     mockCommonGets([], "", [reviewState(3, "needs_review")]);
     const runningReview = {
@@ -1925,7 +1917,6 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
-    await openLatestAgentReview();
 
     const summary = await screen.findByTestId("review-run-summary");
     expect(summary).toHaveClass("line-clamp-4");
@@ -1952,7 +1943,6 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
-    await openLatestAgentReview();
 
     expect(await screen.findByTestId("review-run-summary")).not.toHaveClass(
       "line-clamp-4",
@@ -1975,7 +1965,6 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
-    await openLatestAgentReview();
 
     const summary = await screen.findByTestId("review-run-summary");
     expect(within(summary).getByText("auth validation").tagName).toBe("STRONG");
@@ -1983,7 +1972,7 @@ describe("SessionInspector summary reviews", () => {
     expect(summary).not.toHaveTextContent("**auth validation**");
   });
 
-  it("links delivered AO review summaries to their GitHub review", async () => {
+  it("does not show a View on PR CTA for review summaries", async () => {
     mockCommonGets([], "reviewer-pane", [
       {
         ...reviewState(3, "up_to_date", "abc123"),
@@ -1993,13 +1982,9 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
-    await openLatestAgentReview();
 
     expect(await screen.findByTestId("review-run-summary")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
-      "href",
-      "https://example.com/pr/3#pullrequestreview-98765",
-    );
+    expect(screen.queryByRole("link", { name: /View on PR/ })).not.toBeInTheDocument();
   });
 
   it.each([
@@ -2043,7 +2028,6 @@ describe("SessionInspector summary reviews", () => {
 
       renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
       await openReviewsSection();
-      await openLatestAgentReview();
 
       expect(await screen.findAllByText(runLabel)).not.toHaveLength(0);
       expect(
@@ -2064,10 +2048,7 @@ describe("SessionInspector summary reviews", () => {
         expect(screen.queryByText("Changes requested")).not.toBeInTheDocument();
         expect(screen.queryByText("Earlier commit")).not.toBeInTheDocument();
       }
-      expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
-        "href",
-        "https://example.com/pr/3#pullrequestreview-98765",
-      );
+      expect(screen.queryByRole("link", { name: "View on PR" })).not.toBeInTheDocument();
       // A run in flight gets its own live strip naming the harness, not just a
       // word on the button.
       if (status === "running") {
@@ -2154,8 +2135,7 @@ describe("SessionInspector summary reviews", () => {
       screen.getByRole("button", { name: /maya.*Commented/i }),
     );
     const comments = screen.getByTestId("github-inline-comments");
-    await userEvent.click(screen.getByRole("button", { name: "Show more" }));
-    expect(comments).toHaveTextContent("Open comments");
+    expect(comments).toHaveTextContent("Open comments · 2");
     expect(comments).not.toHaveTextContent("maya");
     expect(comments).toHaveTextContent("Sent to worker agent");
     expect(comments).toHaveTextContent("a.ts:3");
@@ -2269,18 +2249,15 @@ describe("SessionInspector summary reviews", () => {
       within(externalReview).getByText("Reviewed 3d ago"),
     ).toBeInTheDocument();
     expect(
-      within(externalReview).getByRole("link", { name: "View on PR" }),
-    ).toHaveAttribute(
-      "href",
-      "https://example.com/pr/3#pullrequestreview-456",
-    );
+      within(externalReview).queryByRole("link", { name: "View on PR" }),
+    ).not.toBeInTheDocument();
     expect(
       within(externalReview).queryByRole("button", { name: "Request to re-review PR" }),
     ).not.toBeInTheDocument();
     expect(screen.getByText("External reviews")).toBeInTheDocument();
   });
 
-  it("requests a PR re-review with the reviewer and PR identity before showing success", async () => {
+  it("does not show PR re-review CTAs in external review rows", async () => {
     const previous = getMock.getMockImplementation()!;
     getMock.mockImplementation(async (path: string, opts?: unknown) => {
       if (path === "/api/v1/sessions/{sessionId}/pr") {
@@ -2317,150 +2294,15 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: /maya.*Changes requested/i }),
     );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Request to re-review PR" }),
-    );
 
-    await waitFor(() => {
-      expect(postMock).toHaveBeenCalledWith(
-        "/api/v1/sessions/{sessionId}/reviews/rerequest",
-        {
-          params: { path: { sessionId: "sess-1" } },
-          body: {
-            pullRequestUrl: "https://api.github.com/repos/acme/repo/pulls/3",
-            reviewerId: "maya",
-          },
-        },
-      );
-      expect(screen.getByText("Asked for re-review")).toBeInTheDocument();
-    });
     expect(
       screen.queryByRole("button", { name: "Request to re-review PR" }),
     ).not.toBeInTheDocument();
-  });
-
-  it("keeps the PR re-review action available when the API request fails", async () => {
-    const previous = getMock.getMockImplementation()!;
-    getMock.mockImplementation(async (path: string, opts?: unknown) => {
-      if (path === "/api/v1/sessions/{sessionId}/pr") {
-        return {
-          data: {
-            prs: [
-              prSummary(3, "open", {
-                review: {
-                  decision: "changes_requested",
-                  hasUnresolvedHumanComments: false,
-                  reviews: [
-                    {
-                      reviewerId: "maya",
-                      verdict: "changes_requested",
-                      submittedAt: "2026-06-16T11:00:00Z",
-                      reviewUrl:
-                        "https://example.com/pr/3#pullrequestreview-456",
-                      body: "Please request another look after the fixes.",
-                      autoInjectReview: false,
-                    },
-                  ],
-                  unresolvedBy: [],
-                },
-              }),
-            ],
-          },
-        };
-      }
-      return previous(path, opts);
-    });
-    postMock.mockImplementation(async (path: string) => {
-      if (path === "/api/v1/sessions/{sessionId}/reviews/rerequest") {
-        return { error: { message: "GitHub rejected the request" } };
-      }
-      return { data: { ok: true, sessionId: "sess-1" }, error: undefined };
-    });
-
-    renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
-    await openReviewsSection();
-    await userEvent.click(
-      await screen.findByRole("button", { name: /maya.*Changes requested/i }),
+    expect(screen.getByText("Please request another look after the fixes.")).toBeInTheDocument();
+    expect(postMock).not.toHaveBeenCalledWith(
+      "/api/v1/sessions/{sessionId}/reviews/rerequest",
+      expect.anything(),
     );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Request to re-review PR" }),
-    );
-
-    await waitFor(() =>
-      expect(postMock).toHaveBeenCalledWith(
-        "/api/v1/sessions/{sessionId}/reviews/rerequest",
-        expect.objectContaining({
-          body: expect.objectContaining({ reviewerId: "maya" }),
-        }),
-      ),
-    );
-    expect(screen.getByText("Unable to request re-review")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Request to re-review PR" }),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Asked for re-review")).not.toBeInTheDocument();
-  });
-
-  it("sends an AO review summary to the worker from the agent review card", async () => {
-    const run = {
-      ...approvedReview,
-      autoInjectReview: false,
-      body: "The empty-cart path still needs coverage.",
-      githubReviewId: "9876",
-      verdict: "changes_requested",
-    };
-    const state = {
-      ...reviewState(3, "changes_requested"),
-      latestRun: run,
-    };
-    const previous = getMock.getMockImplementation()!;
-    getMock.mockImplementation(async (path: string, opts?: unknown) => {
-      if (path === "/api/v1/sessions/{sessionId}/reviews") {
-        return {
-          data: {
-            reviewerHandleId: "reviewer-pane",
-            reviews: [state],
-            runs: [run],
-          },
-        };
-      }
-      return previous(path, opts);
-    });
-
-    renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
-    await openReviewsSection();
-    await openLatestAgentReview();
-
-    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
-      "href",
-      "https://example.com/pr/3#pullrequestreview-9876",
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Send to worker agent" }),
-    );
-
-    await waitFor(() =>
-      expect(postMock).toHaveBeenCalledWith(
-        "/api/v1/sessions/{sessionId}/send",
-        {
-          params: { path: { sessionId: "sess-1" } },
-          body: {
-            message: expect.stringContaining(
-              "Review:\nThe empty-cart path still needs coverage.",
-            ),
-          },
-        },
-      ),
-    );
-    expect(postMock).toHaveBeenCalledWith(
-      "/api/v1/sessions/{sessionId}/send",
-      expect.objectContaining({
-        body: {
-          message: expect.stringContaining("Reviewer: codex"),
-        },
-      }),
-    );
-    expect(screen.getByText("Sent to worker agent")).toBeInTheDocument();
   });
 
   it("marks SCM reviews and individual comments using their stored injection decision", async () => {
@@ -2517,15 +2359,6 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(
       screen.getByRole("button", { name: /maya.*Changes requested/i }),
     );
-    await userEvent.click(screen.getByRole("button", { name: "Show more" }));
-    expect(screen.queryByRole("link", { name: "View in file" })).not.toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "View in file" })[0]).toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
-    expect(screen.getAllByRole("tooltip")[0]).toHaveTextContent(
-      "Opening files in AO is a work in progress",
-    );
     const sendButton = screen.getByRole("button", {
       name: "Send to worker agent",
     });
@@ -2556,28 +2389,10 @@ describe("SessionInspector summary reviews", () => {
         message: expect.stringContaining("Reviewer: @maya"),
       },
     });
-    const resolveButton = screen
-      .getAllByRole("button", { name: "Resolve comment" })
-      .find((button) => !button.hasAttribute("disabled"));
-    expect(resolveButton).toBeDefined();
-    await userEvent.click(resolveButton!);
-    await waitFor(() =>
-      expect(postMock).toHaveBeenCalledWith(
-        "/api/v1/sessions/{sessionId}/reviews/comments/resolve",
-        {
-          params: { path: { sessionId: "sess-1" } },
-          body: {
-            pullRequestUrl: "https://api.github.com/repos/acme/repo/pulls/3",
-            commentUrl: "https://example.com/comment-9",
-          },
-        },
-      ),
-    );
+    expect(
+      screen.queryByRole("button", { name: "Resolve comment" }),
+    ).not.toBeInTheDocument();
     expect(screen.getAllByText("Sent to worker agent")).toHaveLength(2);
-    expect(screen.getAllByText("Sent to worker agent")[0]).toHaveAttribute(
-      "title",
-      "Worker agent is working on this feedback",
-    );
   });
 
   it("marks an AO review using its stored injection decision", async () => {
@@ -2782,7 +2597,6 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
-    await openLatestAgentReview();
 
     expect(
       await screen.findByText("codex asked for tests."),
@@ -2793,8 +2607,6 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "Load more · 1 earlier" }),
     );
-    const reviewCards = screen.getAllByTestId("agent-review-card");
-    await userEvent.click(within(reviewCards[1]).getByRole("button"));
     expect(
       screen.getByText("claude-code found nothing blocking."),
     ).toBeInTheDocument();

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -639,6 +639,8 @@ describe("SessionInspector PR section", () => {
       "border",
       "bg-surface",
     );
+
+
     for (const name of [
       "Automatically fix CI failures",
       "Automatically fix review comments",
@@ -670,6 +672,7 @@ describe("SessionInspector PR section", () => {
       screen.queryByRole("switch", { name: "Automatically fix review comments" }),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Auto review" })).toBeInTheDocument();
+
   });
 
   it("persists the CI injection default before a PR exists", async () => {
@@ -1447,6 +1450,34 @@ describe("SessionInspector tabs", () => {
     expect(screen.queryByText("Pull request")).not.toBeInTheDocument();
   });
 
+  it("keeps the Reviews tab available for draft PRs", async () => {
+    mockCommonGets([], "", [reviewState(1, "needs_review")]);
+    renderWithQuery(<SessionInspector session={session([pr(1, "draft")])} />);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Reviews" }));
+
+    expect(await screen.findByText("Review controls")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Review latest commit" })).not.toBeDisabled();
+  });
+
+  it("hides the Reviews tab when every PR is merged or closed", async () => {
+    mockCommonGets([], "", [reviewState(1, "up_to_date"), reviewState(2, "up_to_date")]);
+    renderWithQuery(
+      <SessionInspector
+        session={session([pr(1, "merged"), pr(2, "closed")])}
+        view="reviews"
+      />,
+    );
+
+    expect(screen.queryByRole("tab", { name: "Reviews" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.queryByText("Review controls")).not.toBeInTheDocument();
+    expect(screen.queryByText("View review details")).not.toBeInTheDocument();
+  });
+
   it("does not render the overview card in the summary", () => {
     renderWithQuery(
       <SessionInspector
@@ -2070,6 +2101,7 @@ describe("SessionInspector summary reviews", () => {
                 url: "https://example.com/pr/3",
                 htmlUrl: "https://example.com/pr/3",
                 state: "open",
+                author: "ada",
                 ci: {
                   state: "passing",
                   failingChecks: [],
@@ -2158,6 +2190,7 @@ describe("SessionInspector summary reviews", () => {
                 url: "https://example.com/pr/3",
                 htmlUrl: "https://example.com/pr/3",
                 state: "open",
+                author: "ada",
                 ci: {
                   state: "passing",
                   failingChecks: [],
@@ -2182,8 +2215,30 @@ describe("SessionInspector summary reviews", () => {
                         "https://example.com/pr/3#pullrequestreview-456",
                       autoInjectReview: true,
                     },
+                    {
+                      reviewerId: "ada",
+                      verdict: "changes_requested",
+                      submittedAt: "2026-06-16T12:00:00Z",
+                      body: "Self review should stay hidden.",
+                      reviewUrl:
+                        "https://example.com/pr/3#pullrequestreview-789",
+                      autoInjectReview: true,
+                    },
                   ],
-                  unresolvedBy: [],
+                  unresolvedBy: [
+                    {
+                      reviewerId: "ada",
+                      count: 1,
+                      links: [
+                        {
+                          body: "Self comment should stay hidden.",
+                          file: "self.ts",
+                          line: 1,
+                          autoInjectReview: true,
+                        },
+                      ],
+                    },
+                  ],
                 },
               },
             ],
@@ -2203,6 +2258,9 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(reviewCard);
     const summary = await screen.findByTestId("github-review-summary");
     const externalReview = summary.closest("article") as HTMLElement;
+    expect(screen.queryByRole("button", { name: /ada/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Self review should stay hidden.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Self comment should stay hidden.")).not.toBeInTheDocument();
     expect(summary).toHaveClass("select-text");
     expect(within(summary).getByText("ready").tagName).toBe("STRONG");
     expect(within(summary).getByText("Ship it").tagName).toBe("LI");

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1492,6 +1492,9 @@ function MergedReviewsSection({
 		const unresolvedReviewers = (github?.review?.unresolvedBy ?? []).filter(
 			(reviewer) => !externalReviewActorMatchesPRAuthor(reviewer.reviewerId, github?.author),
 		);
+		const resolvedReviewers = (github?.review?.resolvedBy ?? []).filter(
+			(reviewer) => !externalReviewActorMatchesPRAuthor(reviewer.reviewerId, github?.author),
+		);
 		const unresolved = unresolvedReviewers.reduce((count, reviewer) => count + reviewer.count, 0);
 		const reviewRuns = aoRuns.map((run) => {
 			const reviewUrl = aoReviewCommentUrl(run);
@@ -1509,9 +1512,14 @@ function MergedReviewsSection({
 		const unresolvedByReviewer = new Map(
 			unresolvedReviewers.map((reviewer) => [reviewer.reviewerId, reviewer]),
 		);
+		const resolvedByReviewer = new Map(
+			resolvedReviewers.map((reviewer) => [reviewer.reviewerId, reviewer]),
+		);
 		const externalEntries = entries.map((entry) => {
 			const reviewer = unresolvedByReviewer.get(entry.reviewerId);
+			const resolvedReviewer = resolvedByReviewer.get(entry.reviewerId);
 			unresolvedByReviewer.delete(entry.reviewerId);
+			resolvedByReviewer.delete(entry.reviewerId);
 			return {
 				body: entry.body,
 				canRequestRereview: canRequestPRRereview(entry.verdict, github?.url),
@@ -1525,6 +1533,15 @@ function MergedReviewsSection({
 					pullRequestUrl: github?.url,
 					url: link.url || reviewer?.reviewUrl,
 				})),
+				resolvedComments: (resolvedReviewer?.links ?? []).map((link) => ({
+					autoInjectReview: link.autoInjectReview,
+					body: link.body,
+					file: link.file,
+					line: link.line,
+					pullRequestUrl: github?.url,
+					resolved: true,
+					url: link.url || resolvedReviewer?.reviewUrl,
+				})),
 				isBot: entry.isBot,
 				reviewerId: entry.reviewerId,
 				reviewUrl: entry.reviewUrl,
@@ -1534,6 +1551,8 @@ function MergedReviewsSection({
 			};
 		});
 		for (const reviewer of unresolvedByReviewer.values()) {
+			const resolvedReviewer = resolvedByReviewer.get(reviewer.reviewerId);
+			resolvedByReviewer.delete(reviewer.reviewerId);
 			externalEntries.push({
 				body: undefined,
 				canRequestRereview: canRequestPRRereview("changes_requested", github?.url),
@@ -1545,6 +1564,39 @@ function MergedReviewsSection({
 					file: link.file,
 					line: link.line,
 					pullRequestUrl: github?.url,
+					url: link.url || reviewer.reviewUrl,
+				})),
+				resolvedComments: (resolvedReviewer?.links ?? []).map((link) => ({
+					autoInjectReview: link.autoInjectReview,
+					body: link.body,
+					file: link.file,
+					line: link.line,
+					pullRequestUrl: github?.url,
+					resolved: true,
+					url: link.url || resolvedReviewer?.reviewUrl,
+				})),
+				isBot: reviewer.isBot,
+				reviewerId: reviewer.reviewerId,
+				reviewUrl: reviewer.reviewUrl,
+				submittedAt: "",
+				submittedAtLabel: "",
+				verdict: githubVerdict("none", t),
+			});
+		}
+		for (const reviewer of resolvedByReviewer.values()) {
+			externalEntries.push({
+				body: undefined,
+				canRequestRereview: false,
+				id: `resolved:${reviewer.reviewerId}:${number}`,
+				pullRequestUrl: github?.url,
+				inlineComments: [],
+				resolvedComments: reviewer.links.map((link) => ({
+					autoInjectReview: link.autoInjectReview,
+					body: link.body,
+					file: link.file,
+					line: link.line,
+					pullRequestUrl: github?.url,
+					resolved: true,
 					url: link.url || reviewer.reviewUrl,
 				})),
 				isBot: reviewer.isBot,

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -166,7 +166,6 @@ export function SessionInspector({
 	const { t } = useTranslation();
 	const [internalView, setInternalView] = useState<InspectorView>("summary");
 	const requestedView = viewProp ?? internalView;
-	const hasPullRequests = session ? sortedPRs(session).length > 0 : false;
 	// Badge the Browser tab when a preview target arrived without us opening it.
 	const browserUnseen = useUiStore((state) =>
 		session ? Boolean(state.inspectorSessions[session.id]?.browserUnseen) : false,
@@ -177,28 +176,30 @@ export function SessionInspector({
 		onViewChange?.(next);
 		if (next === "files") onOpenFiles?.();
 	};
-	// A persisted/controlled Reviews selection can outlive the last PR. Keep the
-	// shell on a real, visible tab instead of rendering an empty, unlabelled body.
-	const view: InspectorView = requestedView === "reviews" && !hasPullRequests ? "summary" : requestedView;
+	// A persisted/controlled Reviews selection can outlive the last reviewable PR.
+	// Keep the shell on a real, visible tab instead of rendering an empty, unlabelled body.
+	const reviewsAvailable = reviewsTabVisible(session);
+	const availableViewDefs = reviewsAvailable
+		? VIEW_DEFS
+		: VIEW_DEFS.filter((entry) => entry.id !== "reviews");
+	const view: InspectorView = availableViewDefs.some((entry) => entry.id === requestedView) ? requestedView : "summary";
 	useEffect(() => {
 		if (view === requestedView) return;
 		setInternalView(view);
 		onViewChange?.(view);
 	}, [onViewChange, requestedView, view]);
-	const tabs = VIEW_DEFS.filter((entry) => entry.id !== "reviews" || hasPullRequests).map(
-		(entry) => {
-			const label = t(entry.labelKey);
-			return {
-				...entry,
-				badge: entry.id === "browser" && browserUnseen,
-				displayLabel:
-					entry.id === "files" && filesChangedCount !== undefined
-						? t("files.tabCount", { count: filesChangedCount })
-						: label,
-				label,
-			};
-		},
-	);
+	const tabs = availableViewDefs.map((entry) => {
+		const label = t(entry.labelKey);
+		return {
+			...entry,
+			badge: entry.id === "browser" && browserUnseen,
+			displayLabel:
+				entry.id === "files" && filesChangedCount !== undefined
+					? t("files.tabCount", { count: filesChangedCount })
+					: label,
+			label,
+		};
+	});
 	return (
 		<SessionInspectorShellView
 			activeView={view}
@@ -225,14 +226,37 @@ export function SessionInspector({
 				session ? <ReviewsView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : undefined
 			}
 			summaryView={
-				session ? <SummaryView onOpenReviews={() => setView("reviews")} session={session} /> : undefined
+				session ? <SummaryView canOpenReviews={reviewsAvailable} onOpenReviews={() => setView("reviews")} session={session} /> : undefined
 			}
 			tabs={tabs}
 		/>
 	);
 }
 
-function SummaryView({ onOpenReviews, session }: { onOpenReviews: () => void; session: WorkspaceSession }) {
+function reviewsTabVisible(session: WorkspaceSession | undefined): boolean {
+	if (!session) return true;
+	return sortedPRs(session).some((pr) => pr.state === "open" || pr.state === "draft");
+}
+
+function externalReviewActorMatchesPRAuthor(actor: string | undefined, author: string | undefined): boolean {
+	const normalizedActor = normalizeReviewerId(actor);
+	const normalizedAuthor = normalizeReviewerId(author);
+	return normalizedActor !== "" && normalizedActor === normalizedAuthor;
+}
+
+function normalizeReviewerId(value: string | undefined): string {
+	return value?.trim().replace(/^@+/, "").toLowerCase() ?? "";
+}
+
+function SummaryView({
+	canOpenReviews,
+	onOpenReviews,
+	session,
+}: {
+	canOpenReviews: boolean;
+	onOpenReviews: () => void;
+	session: WorkspaceSession;
+}) {
 	const { t } = useTranslation();
 	const query = useSessionScmSummary(session.id);
 	const developerMode = useUiStore((state) => state.developerMode);
@@ -261,6 +285,7 @@ function SummaryView({ onOpenReviews, session }: { onOpenReviews: () => void; se
 					{hasPRs ? (
 						prSummaries.map((pr) => (
 							<PRSummaryCard
+								canOpenReviews={canOpenReviews}
 								key={pr.url || pr.htmlUrl || pr.number}
 								onOpenReviews={onOpenReviews}
 								pr={pr}
@@ -929,7 +954,17 @@ function updateSessionMergePolicy(
 	}));
 }
 
-function PRSummaryCard({ onOpenReviews, pr, sessionId }: { onOpenReviews: () => void; pr: SessionPRSummary; sessionId: string }) {
+function PRSummaryCard({
+	canOpenReviews,
+	onOpenReviews,
+	pr,
+	sessionId,
+}: {
+	canOpenReviews: boolean;
+	onOpenReviews: () => void;
+	pr: SessionPRSummary;
+	sessionId: string;
+}) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const presentation = prCardPresentation(pr);
@@ -961,8 +996,8 @@ function PRSummaryCard({ onOpenReviews, pr, sessionId }: { onOpenReviews: () => 
 		card: presentation,
 		href: prBrowserUrl(pr),
 		stateLabel: t(prStateLabelKeys[pr.state]),
-		reviewDetailsAction: pr.review.decision !== "none" ? (
-				<button className="whitespace-nowrap text-2xs text-settings-muted underline-offset-2 hover:underline" onClick={onOpenReviews} type="button">
+		reviewDetailsAction: canOpenReviews && pr.review.decision !== "none" ? (
+			<button className="whitespace-nowrap text-2xs text-settings-muted underline-offset-2 hover:underline" onClick={onOpenReviews} type="button">
 				{t("pr.review.viewDetails")} ↗
 			</button>
 		) : undefined,
@@ -1332,7 +1367,7 @@ function ReviewsSection({
 	const prSummaries = sessionPRDisplaySummaries(session, scmSummary.data);
 	const githubReviews = prSummaries.filter(
 		(pr) =>
-			pr.state === "open" &&
+			(pr.state === "open" || pr.state === "draft") &&
 			((pr.review?.reviews?.length ?? 0) > 0 ||
 				(pr.review?.unresolvedBy ?? []).some((reviewer) => reviewer.count > 0)),
 	);
@@ -1451,8 +1486,13 @@ function MergedReviewsSection({
 	};
 	const groups: InspectorReviewGroup[] = rows.map(([number, { ao, github }]) => {
 		const aoRuns = ao ? [...(runsByPR.get(ao.prUrl) ?? [])].sort((a, b) => b.createdAt.localeCompare(a.createdAt)) : [];
-		const entries = github?.review?.reviews ?? [];
-		const unresolved = (github?.review?.unresolvedBy ?? []).reduce((count, reviewer) => count + reviewer.count, 0);
+		const entries = (github?.review?.reviews ?? []).filter(
+			(entry) => !externalReviewActorMatchesPRAuthor(entry.reviewerId, github?.author),
+		);
+		const unresolvedReviewers = (github?.review?.unresolvedBy ?? []).filter(
+			(reviewer) => !externalReviewActorMatchesPRAuthor(reviewer.reviewerId, github?.author),
+		);
+		const unresolved = unresolvedReviewers.reduce((count, reviewer) => count + reviewer.count, 0);
 		const reviewRuns = aoRuns.map((run) => {
 			const reviewUrl = aoReviewCommentUrl(run);
 			return {
@@ -1467,7 +1507,7 @@ function MergedReviewsSection({
 			};
 		});
 		const unresolvedByReviewer = new Map(
-			(github?.review?.unresolvedBy ?? []).map((reviewer) => [reviewer.reviewerId, reviewer]),
+			unresolvedReviewers.map((reviewer) => [reviewer.reviewerId, reviewer]),
 		);
 		const externalEntries = entries.map((entry) => {
 			const reviewer = unresolvedByReviewer.get(entry.reviewerId);
@@ -1532,11 +1572,11 @@ function MergedReviewsSection({
 						entries: externalEntries,
 						notInjected:
 							entries.some((review) => review.autoInjectReview === false) ||
-							(github.review?.unresolvedBy ?? []).some((reviewer) =>
+							unresolvedReviewers.some((reviewer) =>
 								reviewer.links.some((link) => link.autoInjectReview === false),
 							),
 						unresolved,
-						unresolvedBy: (github.review?.unresolvedBy ?? []).map((reviewer) => ({
+						unresolvedBy: unresolvedReviewers.map((reviewer) => ({
 							count: reviewer.count,
 							isBot: reviewer.isBot,
 							links: reviewer.links.map((link) => ({
@@ -1562,7 +1602,9 @@ function MergedReviewsSection({
 			title: (ao?.title ?? github?.title)?.trim() || `PR #${number}`,
 			verdict: ao ? reviewVerdict(ao) : undefined,
 		};
-	});
+	}).filter((group) =>
+		Boolean(group.ao || (group.github && (group.github.entries.length > 0 || group.github.unresolved > 0))),
+	);
 	return (
 		<InspectorReviewsView
 			externalLink={ProductExternalLink}

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -269,7 +269,7 @@
 	"inspector.rereviewRequested": "Asked for re-review",
 	"inspector.rereviewRequestFailed": "Unable to request re-review",
 	"inspector.resolveComment": "Resolve comment",
-	"inspector.resolvedReview": "Resolved",
+	"inspector.resolvedReview": "Comment resolved",
 	"inspector.resolveReviewFailed": "Unable to resolve. Retry.",
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -262,7 +262,7 @@
 	"inspector.reviewBySource.github": "External reviews",
 	"inspector.unresolvedCount": "{{count}} unresolved comments",
 	"inspector.openComments": "Open comments",
-	"inspector.openInlineComments": "{{count}} open inline comments",
+	"inspector.openInlineComments": "{{count}} open comments",
 	"inspector.requestRereviewPR": "Request to re-review PR",
 	"inspector.reviewedAt": "Reviewed {{time}}",
 	"inspector.resolvedComments": "Resolved comments · {{count}}",

--- a/frontend/src/renderer/lib/session-reviews.test.ts
+++ b/frontend/src/renderer/lib/session-reviews.test.ts
@@ -68,10 +68,15 @@ const reviewState = (number: number, status: PRReviewState["status"]): PRReviewS
 // merge silently re-forked them — pin the behaviour so a second copy can't drift
 // back in unnoticed.
 describe("shared review eligibility helpers", () => {
-	it("keeps only the review states belonging to a session's open PRs", () => {
-		const target = session({ prs: [pr(1), pr(2, "draft"), pr(3, "merged")] });
-		const states = [reviewState(1, "needs_review"), reviewState(2, "ineligible"), reviewState(3, "up_to_date")];
-		expect(openReviewStatesFor(target, states).map((state) => state.prNumber)).toEqual([1]);
+	it("keeps only the review states belonging to a session's open or draft PRs", () => {
+		const target = session({ prs: [pr(1), pr(2, "draft"), pr(3, "merged"), pr(4, "closed")] });
+		const states = [
+			reviewState(1, "needs_review"),
+			reviewState(2, "needs_review"),
+			reviewState(3, "up_to_date"),
+			reviewState(4, "up_to_date"),
+		];
+		expect(openReviewStatesFor(target, states).map((state) => state.prNumber)).toEqual([1, 2]);
 	});
 
 	it("reports a running review across the session's open PRs", () => {

--- a/frontend/src/renderer/lib/session-reviews.ts
+++ b/frontend/src/renderer/lib/session-reviews.ts
@@ -36,11 +36,11 @@ export function sessionReviewsQueryOptions(session: WorkspaceSession, enabled: b
 	});
 }
 
-/** Review states for a session's open (non-draft) PRs, matching ReviewPanel semantics. */
+/** Review states for a session's active PRs. Open and draft PRs can be reviewed; merged/closed PRs cannot. */
 export function openReviewStatesFor(session: WorkspaceSession, reviewStates: PRReviewState[]): PRReviewState[] {
 	const openPRURLs = new Set(
 		sortedPRs(session)
-			.filter((pr) => pr.state === "open")
+			.filter((pr) => pr.state === "open" || pr.state === "draft")
 			.map((pr) => pr.url),
 	);
 	return reviewStates.filter((reviewState) => openPRURLs.has(reviewState.prUrl));

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -1,5 +1,4 @@
 import {
-  act,
   fireEvent,
   render,
   screen,
@@ -261,14 +260,8 @@ describe("portable inspector presentations", () => {
 
     const row = screen.getByTestId("review-pr-row");
     expect(row).not.toHaveAttribute("aria-expanded");
-    expect(screen.queryByText("Looks good.")).not.toBeInTheDocument();
-    expect(screen.queryByText("Ship it.")).not.toBeInTheDocument();
-    const agentReview = screen.getByRole("button", {
-      name: /codex.*Approved/,
-    });
-    expect(agentReview).toHaveAttribute("aria-expanded", "false");
-    fireEvent.click(agentReview);
     expect(screen.getByText("Looks good.")).toBeInTheDocument();
+    expect(screen.queryByText("Ship it.")).not.toBeInTheDocument();
     const externalReview = screen.getByRole("button", {
       name: /review-bot.*Approved/,
     });
@@ -280,112 +273,9 @@ describe("portable inspector presentations", () => {
     expect(githubSummary).toBeInTheDocument();
     expect(githubSummary).toHaveClass("select-text");
     expect(screen.queryByText("Not injected")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
-      "href",
-      "https://example.com/review",
-    );
+    expect(screen.queryByRole("link", { name: "View on PR" })).not.toBeInTheDocument();
     expect(renderAvatar).toHaveBeenCalledWith("codex");
     expect(renderMarkdown).toHaveBeenCalledTimes(2);
-  });
-
-  it("sends an agent review to the worker and keeps its PR link alongside the action", async () => {
-    const onSendAgentReview = vi.fn().mockResolvedValue(undefined);
-    render(
-      <InspectorReviewsView
-        externalLink={ExternalLink}
-        groups={[
-          {
-            ao: {
-              runs: [
-                {
-                  body: "Please cover the empty state.",
-                  createdAtLabel: "5m ago",
-                  harness: "codex",
-                  id: "run-1",
-                  status: "delivered",
-                  url: "https://example.com/review",
-                  verdict: { label: "Changes requested", tone: "danger" },
-                },
-              ],
-            },
-            meta: "#12 · 5m ago",
-            number: 12,
-            title: "Portable inspector",
-          },
-        ]}
-        isLoading={false}
-        labels={reviewLabels}
-        onSendAgentReview={onSendAgentReview}
-        renderAvatar={() => null}
-        renderMarkdown={(body) => <p>{body}</p>}
-      />,
-    );
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /codex.*Changes requested/ }),
-    );
-    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
-      "href",
-      "https://example.com/review",
-    );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Send to worker agent" }),
-    );
-
-    await waitFor(() => {
-      expect(onSendAgentReview).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "run-1" }),
-      );
-      expect(screen.getByText("Sent to worker agent")).toBeInTheDocument();
-    });
-  });
-
-  it("keeps the agent review send action available after a failure", async () => {
-    render(
-      <InspectorReviewsView
-        externalLink={ExternalLink}
-        groups={[
-          {
-            ao: {
-              runs: [
-                {
-                  body: "Please cover the empty state.",
-                  createdAtLabel: "5m ago",
-                  harness: "codex",
-                  id: "run-1",
-                  status: "delivered",
-                  verdict: { label: "Changes requested", tone: "danger" },
-                },
-              ],
-            },
-            meta: "#12 · 5m ago",
-            number: 12,
-            title: "Portable inspector",
-          },
-        ]}
-        isLoading={false}
-        labels={reviewLabels}
-        onSendAgentReview={vi.fn().mockRejectedValue(new Error("send failed"))}
-        renderAvatar={() => null}
-        renderMarkdown={(body) => <p>{body}</p>}
-      />,
-    );
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /codex.*Changes requested/ }),
-    );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Send to worker agent" }),
-    );
-
-    await waitFor(() =>
-      expect(screen.getByText("Unable to send. Retry.")).toHaveClass(
-        "text-error",
-      ),
-    );
-    expect(
-      screen.getByRole("button", { name: "Send to worker agent" }),
-    ).toBeInTheDocument();
   });
 
   it("shows the newest GitHub review when history prepends", () => {
@@ -448,8 +338,7 @@ describe("portable inspector presentations", () => {
     expect(screen.queryByText(newerBody)).not.toBeInTheDocument();
   });
 
-  it("requests re-review before marking an external review as asked", async () => {
-    const onRequestRereview = vi.fn().mockResolvedValue(undefined);
+  it("keeps external review actions inside comments and does not show re-review CTAs", () => {
     render(
       <InspectorReviewsView
         externalLink={ExternalLink}
@@ -477,39 +366,20 @@ describe("portable inspector presentations", () => {
         ]}
         isLoading={false}
         labels={reviewLabels}
-        onRequestRereview={onRequestRereview}
+        onRequestRereview={vi.fn()}
         renderAvatar={() => null}
         renderMarkdown={(body) => <p>{body}</p>}
       />,
     );
 
-    expect(
-      screen.queryByRole("button", { name: "Request to re-review PR" }),
-    ).not.toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("button", { name: /maya.*Changes requested/ }),
     );
-    const viewPR = screen.getByRole("link", { name: "View on PR" });
-    const rereview = screen.getByRole("button", {
-      name: "Request to re-review PR",
-    });
-    expect(viewPR.className).toBe(rereview.className);
-    expect(viewPR.firstElementChild?.className).toBe(
-      rereview.firstElementChild?.className,
-    );
-    fireEvent.click(
-      rereview,
-    );
 
-    await waitFor(() => {
-      expect(onRequestRereview).toHaveBeenCalledWith(
-        expect.objectContaining({ reviewerId: "maya" }),
-      );
-      expect(screen.getByText("Asked for re-review")).toBeInTheDocument();
-      expect(
-        screen.queryByRole("button", { name: "Request to re-review PR" }),
-      ).not.toBeInTheDocument();
-    });
+    expect(
+      screen.queryByRole("button", { name: "Request to re-review PR" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Please take another pass after fixes land.")).toBeInTheDocument();
   });
 
   it("does not offer re-review for an approved external review", () => {
@@ -553,65 +423,8 @@ describe("portable inspector presentations", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps the re-review action available and shows an error when the callback fails", async () => {
-    const onRequestRereview = vi
-      .fn()
-      .mockRejectedValue(new Error("request failed"));
-    render(
-      <InspectorReviewsView
-        externalLink={ExternalLink}
-        groups={[
-          {
-            github: {
-              entries: [
-                {
-                  body: "Please take another pass after fixes land.",
-                  id: "github-review-1",
-                  reviewerId: "maya",
-                  reviewUrl: "https://example.com/review",
-                  submittedAt: "2026-08-09T10:00:00Z",
-                  submittedAtLabel: "1h ago",
-                  verdict: { label: "Changes requested", tone: "danger" },
-                },
-              ],
-              unresolved: 0,
-              unresolvedBy: [],
-            },
-            meta: "#12",
-            number: 12,
-            title: "Portable inspector",
-          },
-        ]}
-        isLoading={false}
-        labels={reviewLabels}
-        onRequestRereview={onRequestRereview}
-        renderAvatar={() => null}
-        renderMarkdown={(body) => <p>{body}</p>}
-      />,
-    );
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /maya.*Changes requested/ }),
-    );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Request to re-review PR" }),
-    );
-
-    await waitFor(() =>
-      expect(onRequestRereview).toHaveBeenCalledWith(
-        expect.objectContaining({ reviewerId: "maya" }),
-      ),
-    );
-    expect(screen.getByText("Unable to request re-review")).toHaveClass(
-      "text-error",
-    );
-    expect(
-      screen.getByRole("button", { name: "Request to re-review PR" }),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Asked for re-review")).not.toBeInTheDocument();
-  });
-
   it("shows unresolved inline review comments inside each reviewer dropdown", async () => {
+    const onResolveInlineComment = vi.fn().mockResolvedValue(undefined);
     const onSendInlineComment = vi.fn().mockResolvedValue(undefined);
     render(
       <InspectorReviewsView
@@ -621,7 +434,7 @@ describe("portable inspector presentations", () => {
             github: {
               entries: [
                 {
-                  body: "This branch leaks the resize listener on unmount.",
+                  body: "Please address the inline notes before merge.",
                   id: "github-review-1",
                   reviewerId: "maya",
                   reviewUrl: "https://example.com/review",
@@ -631,6 +444,7 @@ describe("portable inspector presentations", () => {
                   inlineComments: [
                     {
                       body: "This branch leaks the resize listener on unmount.",
+                      autoInjectReview: false,
                       file: "src/panel.tsx",
                       line: 42,
                       url: "https://example.com/comment",
@@ -650,6 +464,7 @@ describe("portable inspector presentations", () => {
                   links: [
                     {
                       body: "This branch leaks the resize listener on unmount.",
+                      autoInjectReview: false,
                       file: "src/panel.tsx",
                       line: 42,
                       url: "https://example.com/comment",
@@ -672,6 +487,7 @@ describe("portable inspector presentations", () => {
         ]}
         isLoading={false}
         labels={reviewLabels}
+        onResolveInlineComment={onResolveInlineComment}
         onSendInlineComment={onSendInlineComment}
         renderAvatar={() => null}
         renderMarkdown={(body) => <p>{body}</p>}
@@ -689,20 +505,12 @@ describe("portable inspector presentations", () => {
     ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /maya.*Commented/i }));
     expect(screen.getByTestId("github-inline-comments")).toBeInTheDocument();
-    expect(screen.getByText("Open comments")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open comments · 2" })).toBeInTheDocument();
     expect(screen.getByText("#12 · 2 unresolved")).toBeInTheDocument();
     expect(screen.getByText("src/panel.tsx:42")).toBeInTheDocument();
     expect(
       screen.getByText("This branch leaks the resize listener on unmount."),
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByText("This branch leaks the resize listener on unmount."),
-    ).toHaveLength(1);
-    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
-      "href",
-      "https://example.com/review",
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
     fireEvent.click(
       screen.getByRole("button", { name: "Send to worker agent" }),
     );
@@ -718,26 +526,24 @@ describe("portable inspector presentations", () => {
     await waitFor(() => {
       const sentLabels = screen.getAllByText("Sent to worker agent");
       expect(sentLabels).toHaveLength(2);
-      expect(sentLabels[0]?.closest("span")).toHaveClass("text-muted-foreground");
-      expect(sentLabels[0]?.closest("span")?.querySelector("svg")).toHaveClass(
-        "text-success",
-      );
+      expect(sentLabels[0]?.closest("span")).toHaveClass("text-success");
     });
-    const viewInFileButtons = screen.getAllByRole("button", {
-      name: "View in file",
-    });
-    expect(viewInFileButtons).toHaveLength(
-      2,
+    fireEvent.click(screen.getAllByRole("button", { name: "Comment actions" })[0]!);
+    fireEvent.click(screen.getByRole("button", { name: "Resolve comment" }));
+    expect(onResolveInlineComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: "This branch leaks the resize listener on unmount.",
+        file: "src/panel.tsx",
+        line: 42,
+        reviewerId: "maya",
+        url: "https://example.com/comment",
+      }),
     );
-    expect(screen.queryByRole("link", { name: "View in file" })).not.toBeInTheDocument();
-    expect(viewInFileButtons[0]).toHaveAttribute("aria-disabled", "true");
-    expect(screen.getAllByRole("tooltip")[0]).toHaveTextContent(
-      "Opening files in AO is a work in progress",
-    );
-    expect(screen.getAllByText("Sent to worker agent")[0]).toHaveAttribute(
-      "title",
-      "Worker agent is working on this feedback",
-    );
+    await waitFor(() => expect(screen.getByText("Resolved")).toBeInTheDocument());
+    expect(screen.getByRole("link", { name: "View in file" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open on GitHub" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy comment link" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy file path" })).not.toBeInTheDocument();
   });
 
   it("surfaces inline review comment send failures", async () => {
@@ -757,6 +563,7 @@ describe("portable inspector presentations", () => {
                   inlineComments: [
                     {
                       body: "Please tighten this spacing.",
+                      autoInjectReview: false,
                       url: "https://example.com/comment",
                     },
                   ],
@@ -774,6 +581,7 @@ describe("portable inspector presentations", () => {
                   links: [
                     {
                       body: "Please tighten this spacing.",
+                      autoInjectReview: false,
                       url: "https://example.com/comment",
                     },
                   ],
@@ -810,8 +618,7 @@ describe("portable inspector presentations", () => {
     expect(screen.queryByText("Sent to worker agent")).not.toBeInTheDocument();
   });
 
-  it("shows a resolved comment before removing it from the list", async () => {
-    const onResolveInlineComment = vi.fn().mockResolvedValue(undefined);
+  it("keeps resolved comments collapsed until requested", () => {
     render(
       <InspectorReviewsView
         externalLink={ExternalLink}
@@ -821,10 +628,14 @@ describe("portable inspector presentations", () => {
               entries: [
                 {
                   body: undefined,
-                  id: "unresolved-maya",
-                  inlineComments: [
+                  id: "review-maya",
+                  inlineComments: [],
+                  resolvedComments: [
                     {
-                      body: "Please tighten this spacing.",
+                      body: "This resolved note stays hidden by default.",
+                      file: "src/panel.tsx",
+                      line: 8,
+                      resolved: true,
                       url: "https://example.com/comment",
                     },
                   ],
@@ -835,45 +646,30 @@ describe("portable inspector presentations", () => {
                   verdict: { label: "Commented", tone: "neutral" },
                 },
               ],
-              unresolved: 1,
-              unresolvedBy: [
-                {
-                  count: 1,
-                  links: [
-                    {
-                      body: "Please tighten this spacing.",
-                      url: "https://example.com/comment",
-                    },
-                  ],
-                  reviewerId: "maya",
-                },
-              ],
+              unresolved: 0,
+              unresolvedBy: [],
             },
-            meta: "#12 · 1 unresolved",
+            meta: "#12",
             number: 12,
             title: "Portable inspector",
           },
         ]}
         isLoading={false}
         labels={reviewLabels}
-        onResolveInlineComment={onResolveInlineComment}
         renderAvatar={() => null}
         renderMarkdown={(body) => <p>{body}</p>}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /maya.*Commented/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Resolve comment" }));
-    await waitFor(() => {
-      expect(onResolveInlineComment).toHaveBeenCalledTimes(1);
-      expect(screen.getByText("Resolved")).toBeInTheDocument();
-    });
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1100));
-    });
-    expect(screen.queryByText("Please tighten this spacing.")).not.toBeInTheDocument();
-    expect(screen.queryByText("Resolved")).not.toBeInTheDocument();
+    expect(screen.getByText("Resolved comments · 1")).toBeInTheDocument();
+    expect(
+      screen.queryByText("This resolved note stays hidden by default."),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Resolved comments · 1" }));
+    expect(
+      screen.getByText("This resolved note stays hidden by default."),
+    ).toBeInTheDocument();
   });
 
   it("tracks URL-less inline comments independently when they share a review URL", async () => {
@@ -891,11 +687,13 @@ describe("portable inspector presentations", () => {
                   inlineComments: [
                     {
                       body: "Fix the first comment.",
+                      autoInjectReview: false,
                       file: "src/panel.tsx",
                       line: 10,
                     },
                     {
                       body: "Fix the second comment.",
+                      autoInjectReview: false,
                       file: "src/panel.tsx",
                       line: 20,
                     },
@@ -914,11 +712,13 @@ describe("portable inspector presentations", () => {
                   links: [
                     {
                       body: "Fix the first comment.",
+                      autoInjectReview: false,
                       file: "src/panel.tsx",
                       line: 10,
                     },
                     {
                       body: "Fix the second comment.",
+                      autoInjectReview: false,
                       file: "src/panel.tsx",
                       line: 20,
                     },
@@ -942,7 +742,6 @@ describe("portable inspector presentations", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /maya.*Commented/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
     const sendButtons = screen.getAllByRole("button", {
       name: "Send to worker agent",
     });
@@ -978,7 +777,7 @@ const reviewLabels: InspectorReviewLabels = {
   noPastReviewSummaries: "No summaries",
   notInjected: "Not injected",
   openComments: "Open comments",
-  openInlineComments: (count) => `${count} open inline comments`,
+  openInlineComments: (count) => `${count} open comments`,
   requestRereviewPR: "Request to re-review PR",
   reviews: "Reviews",
   reviewedAt: (time) => `Reviewed ${time}`,
@@ -991,13 +790,11 @@ const reviewLabels: InspectorReviewLabels = {
   sendToWorkerAgent: "Send to worker agent",
   sentToWorkerAgent: "Sent to worker agent",
   sendToWorkerAgentError: "Unable to send. Retry.",
-  workerAgentWorkingOnFeedback: "Worker agent is working on this feedback",
   showLatestReviewOnly: "Show latest only",
   showLess: "Show less",
   showMore: "Show more",
   commentNumber: (number) => `Comment ${number}`,
   unresolvedCount: (count) => `${count} unresolved`,
   viewInFile: "View in file",
-  viewInFileWorkInProgress: "Opening files in AO is a work in progress",
   viewOnPR: "View on PR",
 };

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -790,11 +790,13 @@ const reviewLabels: InspectorReviewLabels = {
   sendToWorkerAgent: "Send to worker agent",
   sentToWorkerAgent: "Sent to worker agent",
   sendToWorkerAgentError: "Unable to send. Retry.",
+  workerAgentWorkingOnFeedback: "Worker agent is working on this feedback.",
   showLatestReviewOnly: "Show latest only",
   showLess: "Show less",
   showMore: "Show more",
   commentNumber: (number) => `Comment ${number}`,
   unresolvedCount: (count) => `${count} unresolved`,
   viewInFile: "View in file",
+  viewInFileWorkInProgress: "View in file is coming soon.",
   viewOnPR: "View on PR",
 };

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, type ReactNode, useEffect, useId, useState } from "react";
+import { type KeyboardEvent, type ReactNode, useEffect, useState } from "react";
 import type { ExternalLinkComponent } from "./external-link";
 import {
 	ArrowUpRightIcon,
@@ -6,6 +6,8 @@ import {
 	CheckIcon,
 	ChevronIcon,
 	GitPullRequestIcon,
+	MessageSquareIcon,
+	MoreHorizontalIcon,
 } from "./icons";
 import {
 	PRCardStatusSummary,
@@ -388,7 +390,6 @@ export type InspectorVerdict = {
 };
 
 export type InspectorReviewRun = {
-	autoInjectReview?: boolean;
 	body?: string;
 	createdAtLabel: string;
 	harness: string;
@@ -404,6 +405,7 @@ export type InspectorInlineComment = {
 	file?: string;
 	line?: number;
 	pullRequestUrl?: string;
+	resolved?: boolean;
 	url?: string;
 };
 
@@ -414,6 +416,7 @@ export type InspectorGithubReview = {
 	inlineComments?: InspectorInlineComment[];
 	isBot?: boolean;
 	pullRequestUrl?: string;
+	resolvedComments?: InspectorInlineComment[];
 	reviewerId: string;
 	reviewUrl?: string;
 	submittedAt: string;
@@ -477,14 +480,12 @@ export type InspectorReviewLabels = {
 	sendToWorkerAgent: string;
 	sentToWorkerAgent: string;
 	sendToWorkerAgentError: string;
-	workerAgentWorkingOnFeedback: string;
 	showLatestReviewOnly: string;
 	showLess: string;
 	showMore: string;
 	commentNumber: (number: number) => string;
 	unresolvedCount: (count: number) => string;
 	viewInFile: string;
-	viewInFileWorkInProgress: string;
 	viewOnPR: string;
 };
 
@@ -495,7 +496,6 @@ export function InspectorReviewsView({
 	labels,
 	onRequestRereview,
 	onResolveInlineComment,
-	onSendAgentReview,
 	onSendInlineComment,
 	renderAvatar,
 	renderMarkdown,
@@ -506,7 +506,6 @@ export function InspectorReviewsView({
 	labels: InspectorReviewLabels;
 	onRequestRereview?: (review: InspectorGithubReview) => Promise<void> | void;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
-	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
@@ -540,13 +539,11 @@ export function InspectorReviewsView({
 								</ReviewSourceLabel>
 								<ReviewRuns
 									dimmed={group.ao.dimmed}
-									externalLink={externalLink}
 									historical={group.ao.historical}
 									labels={labels}
 									renderAvatar={renderAvatar}
 									renderMarkdown={renderMarkdown}
 									runs={group.ao.runs}
-									onSendAgentReview={onSendAgentReview}
 								/>
 							</div>
 						) : null}
@@ -644,7 +641,7 @@ function ReviewDisclosure({
 	if (!collapsible) {
 		return (
 			<article
-				className="overflow-hidden rounded-lg border border-border bg-settings-row"
+				className="relative overflow-visible rounded-lg border border-border bg-settings-row"
 				data-testid="review-pr-row"
 			>
 				<div className="flex min-w-0 flex-col gap-1 border-b border-border/70 px-3 py-2.5">
@@ -666,7 +663,7 @@ function ReviewDisclosure({
 		);
 	}
 	return (
-		<article className="overflow-hidden rounded-lg border border-border bg-settings-row">
+		<article className="relative overflow-visible rounded-lg border border-border bg-settings-row">
 			<button
 				aria-expanded={open}
 				data-testid="review-pr-row"
@@ -692,19 +689,15 @@ function ReviewDisclosure({
 
 function ReviewRuns({
 	dimmed,
-	externalLink,
 	historical,
 	labels,
-	onSendAgentReview,
 	renderAvatar,
 	renderMarkdown,
 	runs,
 }: {
 	dimmed?: boolean;
-	externalLink: ExternalLinkComponent;
 	historical?: boolean;
 	labels: InspectorReviewLabels;
-	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 	runs: InspectorReviewRun[];
@@ -715,10 +708,8 @@ function ReviewRuns({
 	return (
 		<ReviewRunHistory
 			dimmed={dimmed}
-			externalLink={externalLink}
 			historical={historical}
 			labels={labels}
-			onSendAgentReview={onSendAgentReview}
 			renderAvatar={renderAvatar}
 			renderMarkdown={renderMarkdown}
 			runs={runs}
@@ -728,19 +719,15 @@ function ReviewRuns({
 
 function ReviewRunHistory({
 	dimmed,
-	externalLink,
 	historical,
 	labels,
-	onSendAgentReview,
 	renderAvatar,
 	renderMarkdown,
 	runs,
 }: {
 	dimmed?: boolean;
-	externalLink: ExternalLinkComponent;
 	historical?: boolean;
 	labels: InspectorReviewLabels;
-	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 	runs: InspectorReviewRun[];
@@ -755,18 +742,14 @@ function ReviewRunHistory({
 			{visible.map((run, index) => (
 				<ReviewSummaryCard
 					actor={run.harness || "reviewer"}
-					autoInjected={run.autoInjectReview}
 					body={run.status === "cancelled" || run.status === "failed" ? "" : run.body}
-					externalLink={externalLink}
 					isEarlier={historical || index > 0}
 					key={run.id}
 					labels={labels}
-					onSend={onSendAgentReview ? () => onSendAgentReview(run) : undefined}
 					renderAvatar={renderAvatar}
 					renderMarkdown={renderMarkdown}
 					testId="review-run-summary"
 					timestamp={run.createdAtLabel}
-					url={run.url}
 					verdict={run.verdict}
 				/>
 			))}
@@ -862,41 +845,11 @@ function GithubReviewHistory({
 	);
 }
 
-const reviewHeaderActionClass =
-	"inline-flex h-7 min-w-0 max-w-full appearance-none items-center justify-center rounded-md border border-border-strong bg-transparent px-2 text-center text-muted-foreground no-underline transition-colors hover:bg-interactive-hover hover:text-foreground @max-[300px]/inspector:w-full";
-const reviewHeaderActionLabelClass = "whitespace-nowrap font-sans text-xs font-medium leading-none tracking-normal";
-
-function ReviewHeaderAction({
-	children,
-	externalLink: ExternalLink,
-	href,
-	onClick,
-}: {
-	children: string;
-	externalLink: ExternalLinkComponent;
-	href?: string;
-	onClick?: () => Promise<void> | void;
-}) {
-	if (href) {
-		return (
-			<ExternalLink className={reviewHeaderActionClass} href={href}>
-				<span className={reviewHeaderActionLabelClass}>{children}</span>
-			</ExternalLink>
-		);
-	}
-	return (
-		<button className={reviewHeaderActionClass} onClick={onClick} type="button">
-			<span className={reviewHeaderActionLabelClass}>{children}</span>
-		</button>
-	);
-}
-
 function ExternalReviewCard({
 	defaultOpen,
 	entry,
-	externalLink: ExternalLink,
+	externalLink,
 	labels,
-	onRequestRereview,
 	onResolveInlineComment,
 	onSendInlineComment,
 	renderMarkdown,
@@ -911,413 +864,318 @@ function ExternalReviewCard({
 	renderMarkdown: (body: string) => ReactNode;
 }) {
 	const [open, setOpen] = useState(defaultOpen);
-	const [rereviewRequested, setRereviewRequested] = useState(false);
-	const [rereviewError, setRereviewError] = useState(false);
 	const body = entry.body?.trim();
-	const inlineComments = entry.inlineComments ?? [];
-	const repeatedInlineBody = Boolean(
-		body && inlineComments.some((comment) => normalizedReviewText(comment.body) === normalizedReviewText(body)),
-	);
-	const reviewUrl = entry.reviewUrl || entry.pullRequestUrl;
-	const openInlineCount = inlineComments.filter((comment) => comment.body?.trim() || comment.file || comment.url).length;
-	const showRereviewAction = Boolean(onRequestRereview && (entry.canRequestRereview ?? entry.verdict.tone !== "success"));
+	const openComments = (entry.inlineComments ?? []).filter((comment) => comment.body?.trim() || comment.file || comment.url);
+	const resolvedComments = (entry.resolvedComments ?? []).filter((comment) => comment.body?.trim() || comment.file || comment.url);
 	return (
-		<ReviewEntryDisclosure
-			actor={entry.reviewerId}
-			avatar={<GithubAvatar className="size-5" login={entry.reviewerId} />}
-			botLabel={entry.isBot ? labels.bot : undefined}
-			meta={entry.submittedAtLabel ? labels.reviewedAt(entry.submittedAtLabel) : undefined}
-			onOpenChange={setOpen}
-			open={open}
-			testId="github-review-card"
-			verdict={entry.verdict}
-		>
-			{showRereviewAction || reviewUrl ? (
-				<div className="flex min-w-0 flex-wrap items-center justify-between gap-2 border-y border-border/50 py-2 @max-[300px]/inspector:flex-col @max-[300px]/inspector:items-stretch">
-					{openInlineCount > 0 ? (
-						<span className="font-mono text-2xs font-semibold text-error">{labels.unresolvedCount(openInlineCount)}</span>
-					) : <span aria-hidden="true" />}
-					<div className="flex min-w-0 flex-wrap items-center justify-end gap-2 @max-[300px]/inspector:w-full">
-						{reviewUrl ? (
-							<ReviewHeaderAction externalLink={ExternalLink} href={reviewUrl}>
-								{labels.viewOnPR}
-							</ReviewHeaderAction>
-						) : null}
-						{showRereviewAction ? (
-							rereviewRequested ? (
-								<span className="inline-flex h-control-md items-center gap-1.5 text-2xs font-medium text-success">
-									<CheckIcon className="size-icon-xs shrink-0" />
-									{labels.rereviewRequested}
-								</span>
-							) : (
-								<ReviewHeaderAction
-									externalLink={ExternalLink}
-									onClick={async () => {
-										setRereviewError(false);
-										try {
-											await onRequestRereview?.(entry);
-											setRereviewRequested(true);
-										} catch {
-											setRereviewError(true);
-										}
-									}}
-								>
-									{labels.requestRereviewPR}
-								</ReviewHeaderAction>
-							)
-						) : null}
-					</div>
-				</div>
-			) : null}
-			{rereviewError ? <p className="m-0 text-2xs font-medium text-error">{labels.rereviewRequestFailed}</p> : null}
-			{body && !repeatedInlineBody ? (
-				<ReviewMarkdownBody body={body} clamped={false} renderMarkdown={renderMarkdown} testId="github-review-summary" />
-			) : null}
-			{openInlineCount > 0 ? (
-				<GithubInlineComments
-					labels={labels}
-					onSendInlineComment={onSendInlineComment}
-					onResolveInlineComment={onResolveInlineComment}
-					reviewers={[
-						{
-							count: openInlineCount,
-							isBot: entry.isBot,
-							links: inlineComments,
-							reviewerId: entry.reviewerId,
-							reviewUrl: entry.reviewUrl,
-						},
-					]}
-					showReviewer={false}
-				/>
-			) : null}
-		</ReviewEntryDisclosure>
-	);
-}
-
-function normalizedReviewText(value: string | undefined): string {
-	return value?.trim().replace(/\s+/g, " ") ?? "";
-}
-
-function ReviewEntryDisclosure({
-	actor,
-	avatar,
-	botLabel,
-	children,
-	meta,
-	onOpenChange,
-	open,
-	testId,
-	verdict,
-}: {
-	actor: string;
-	avatar: ReactNode;
-	botLabel?: string;
-	children: ReactNode;
-	meta?: ReactNode;
-	onOpenChange: (open: boolean) => void;
-	open: boolean;
-	testId: string;
-	verdict: InspectorVerdict;
-}) {
-	return (
-		<article className="min-w-0 border-b border-border/70 py-3 first:pt-0 last:border-b-0 last:pb-0" data-testid={testId}>
+		<article className="relative min-w-0 border-b border-border/70 py-2 first:pt-0 last:border-b-0 last:pb-0" data-testid="github-review-card">
 			<button
 				aria-expanded={open}
-				className="flex w-full min-w-0 items-start gap-2 rounded-md px-1 py-1 text-left transition-colors hover:bg-interactive-hover/30"
-				onClick={() => onOpenChange(!open)}
+				className="grid w-full min-w-0 grid-cols-[auto_1fr_auto_auto] items-center gap-x-3 gap-y-1 rounded-md px-1.5 py-1.5 text-left transition-colors hover:bg-interactive-hover/30"
+				onClick={() => setOpen((current) => !current)}
 				type="button"
 			>
-				<ChevronIcon className="mt-0.5 size-icon-2xs shrink-0 text-passive" direction={open ? "down" : "right"} />
-				<span className="flex min-w-0 flex-1 flex-col gap-0.5">
-					<span className="flex min-w-0 items-center gap-1.5">
-						<span className="inline-flex min-w-0 items-center gap-1 text-xs font-semibold text-foreground">
-							{avatar}
-							<span className="truncate">{actor}</span>
-						</span>
-						{botLabel ? <span className="shrink-0 font-mono text-micro text-passive">{botLabel}</span> : null}
+				<GithubAvatar className="size-6 shrink-0" login={entry.reviewerId} />
+				<span className="flex min-w-0 flex-col gap-0.5">
+					<span className="flex min-w-0 items-center gap-1.5 text-xs font-semibold text-foreground">
+						<span className="truncate">{entry.reviewerId}</span>
+						{entry.isBot ? <span className="shrink-0 font-mono text-micro text-passive">{labels.bot}</span> : null}
 					</span>
-					{meta ? (
-						<span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 font-mono text-micro text-passive">
-							{meta}
+					{entry.submittedAtLabel ? <span className="font-mono text-micro text-passive">{labels.reviewedAt(entry.submittedAtLabel)}</span> : null}
+				</span>
+				<span className={cn("flex shrink-0 items-center gap-2 whitespace-nowrap pr-1 text-2xs font-medium", reviewerVerdictTone[entry.verdict.tone])}>
+					<span>{entry.verdict.label}</span>
+					{openComments.length > 0 ? (
+						<span className="inline-flex items-center gap-1.5 rounded-sm px-0.5 text-muted-foreground" title={labels.openInlineComments(openComments.length)}>
+							<MessageSquareIcon className="size-icon-2xs" />
+							<span>{openComments.length}</span>
 						</span>
 					) : null}
 				</span>
-				<VerdictBadge verdict={verdict} />
+				<ChevronIcon className="size-icon-2xs shrink-0 text-passive" direction={open ? "down" : "right"} />
 			</button>
-			{open ? <div className="flex min-w-0 flex-col gap-3 px-1 pt-3">{children}</div> : null}
+			{open ? (
+				<div className="flex min-w-0 flex-col gap-3 px-1 pt-2 text-left">
+					{body ? <ReviewMarkdownBody body={body} clamped={false} renderMarkdown={renderMarkdown} testId="github-review-summary" /> : null}
+					<GithubInlineComments comments={openComments} externalLink={externalLink} labels={labels} onResolveInlineComment={onResolveInlineComment} onSendInlineComment={onSendInlineComment} reviewerId={entry.reviewerId} reviewUrl={entry.reviewUrl} />
+					{resolvedComments.length > 0 ? <ResolvedInlineComments comments={resolvedComments} externalLink={externalLink} labels={labels} reviewerId={entry.reviewerId} reviewUrl={entry.reviewUrl} /> : null}
+				</div>
+			) : null}
 		</article>
 	);
 }
 
-const RESOLVED_COMMENT_DISPLAY_MS = 1000;
-
 function GithubInlineComments({
+	comments,
+	externalLink: ExternalLink,
 	labels,
 	onResolveInlineComment,
 	onSendInlineComment,
-	reviewers,
-	showReviewer = true,
+	reviewerId,
+	reviewUrl,
 }: {
+	comments: InspectorInlineComment[];
+	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
-	reviewers: InspectorUnresolvedReviewer[];
-	showReviewer?: boolean;
+	reviewerId: string;
+	reviewUrl?: string;
 }) {
-	// Manual sends are reflected immediately in local UI state after /send succeeds;
-	// persisted autoInjectReview still comes from the next backend PR observation.
+	const [open, setOpen] = useState(true);
+	if (comments.length === 0) return null;
+	return (
+		<section className="min-w-0" data-testid="github-inline-comments">
+			<button aria-expanded={open} className="flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 text-left text-xs font-semibold text-muted-foreground transition-colors hover:text-foreground" onClick={() => setOpen((current) => !current)} type="button">
+				<ChevronIcon className="size-icon-2xs shrink-0" direction={open ? "down" : "right"} />
+				<span>{labels.openComments} · {comments.length}</span>
+			</button>
+			{open ? <InlineCommentList comments={comments} externalLink={ExternalLink} labels={labels} onResolveInlineComment={onResolveInlineComment} onSendInlineComment={onSendInlineComment} reviewerId={reviewerId} reviewUrl={reviewUrl} /> : null}
+		</section>
+	);
+}
+
+function ResolvedInlineComments({
+	comments,
+	externalLink: ExternalLink,
+	labels,
+	reviewerId,
+	reviewUrl,
+}: {
+	comments: InspectorInlineComment[];
+	externalLink: ExternalLinkComponent;
+	labels: InspectorReviewLabels;
+	reviewerId: string;
+	reviewUrl?: string;
+}) {
+	const [open, setOpen] = useState(false);
+	return (
+		<section className="min-w-0 border-t border-border/60 pt-2" data-testid="github-resolved-comments">
+			<button aria-expanded={open} className="flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 text-left text-xs font-semibold text-muted-foreground transition-colors hover:text-foreground" onClick={() => setOpen((current) => !current)} type="button">
+				<ChevronIcon className="size-icon-2xs shrink-0" direction={open ? "down" : "right"} />
+				<span>{labels.resolvedComments(comments.length)}</span>
+			</button>
+			{open ? <InlineCommentList comments={comments} externalLink={ExternalLink} labels={labels} reviewerId={reviewerId} reviewUrl={reviewUrl} /> : null}
+		</section>
+	);
+}
+
+function InlineCommentList({
+	comments,
+	externalLink,
+	labels,
+	onResolveInlineComment,
+	onSendInlineComment,
+	reviewerId,
+	reviewUrl,
+}: {
+	comments: InspectorInlineComment[];
+	externalLink: ExternalLinkComponent;
+	labels: InspectorReviewLabels;
+	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
+	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
+	reviewerId: string;
+	reviewUrl?: string;
+}) {
+	const [manuallyResolvedCommentIds, setManuallyResolvedCommentIds] = useState<Set<string>>(() => new Set());
 	const [manuallySentCommentIds, setManuallySentCommentIds] = useState<Set<string>>(() => new Set());
+	const [resolvingCommentIds, setResolvingCommentIds] = useState<Set<string>>(() => new Set());
+	const [resolveErrorCommentIds, setResolveErrorCommentIds] = useState<Set<string>>(() => new Set());
 	const [sendingCommentIds, setSendingCommentIds] = useState<Set<string>>(() => new Set());
 	const [sendErrorCommentIds, setSendErrorCommentIds] = useState<Set<string>>(() => new Set());
-	const [resolvedCommentIds, setResolvedCommentIds] = useState<Set<string>>(() => new Set());
-	const [removedResolvedCommentIds, setRemovedResolvedCommentIds] = useState<Set<string>>(() => new Set());
-	const [resolveErrorCommentIds, setResolveErrorCommentIds] = useState<Set<string>>(() => new Set());
-	const [visibleCount, setVisibleCount] = useState(1);
-	const comments = reviewers.flatMap((reviewer) =>
-		reviewer.links
-			.filter((link) => link.body?.trim() || link.file || link.url)
-			.map((link, index) => ({
-				...link,
-				id: `${reviewer.reviewerId}:${link.url ?? `${link.file ?? ""}:${link.line ?? ""}:${index}`}`,
-				reviewerId: reviewer.reviewerId,
-				url: link.url || reviewer.reviewUrl,
-			})),
-	);
-	useEffect(() => {
-		if (resolvedCommentIds.size === 0) return;
-		const timeout = window.setTimeout(() => {
-			setRemovedResolvedCommentIds((current) => {
-				const next = new Set(current);
-				for (const id of resolvedCommentIds) next.add(id);
-				return next;
-			});
-		}, RESOLVED_COMMENT_DISPLAY_MS);
-		return () => window.clearTimeout(timeout);
-	}, [resolvedCommentIds]);
-	const remainingComments = comments.filter((comment) => !removedResolvedCommentIds.has(comment.id));
-	if (remainingComments.length === 0) return null;
-	const visibleComments = remainingComments.slice(0, visibleCount);
-	const hasMore = visibleComments.length < remainingComments.length;
+	const keyedComments = comments.map((comment, index) => ({
+		...comment,
+		id: `${reviewerId}:${comment.url ?? `${comment.file ?? ""}:${comment.line ?? ""}:${index}`}`,
+		reviewerId,
+		url: comment.url || reviewUrl,
+	}));
 	return (
-		<section className="min-w-0 border-t border-border/70 pt-4" data-testid="github-inline-comments">
-			<div className="flex min-w-0 items-center justify-between gap-2 pb-2 text-xs">
-				<span className="font-semibold uppercase tracking-wide text-muted-foreground">{labels.openComments}</span>
-			</div>
-			<div className="divide-y divide-border/60">
-				{visibleComments.map((comment, index) => (
-					<InlineCommentRow
-						comment={comment}
-						commentNumber={index + 1}
-						key={comment.id}
-						labels={labels}
-						onResolve={onResolveInlineComment ? async () => {
-								setResolveErrorCommentIds((current) => {
-									const next = new Set(current);
-									next.delete(comment.id);
-									return next;
-								});
-								try {
-									await onResolveInlineComment(comment);
-									setResolvedCommentIds((current) => new Set(current).add(comment.id));
-								} catch {
-									setResolveErrorCommentIds((current) => new Set(current).add(comment.id));
-								}
-							} : undefined}
-						onSend={onSendInlineComment ? async () => {
-							setSendingCommentIds((current) => new Set(current).add(comment.id));
-							setSendErrorCommentIds((current) => {
+		<div className="divide-y divide-border/60">
+			{keyedComments.map((comment) => (
+				<InlineCommentRow
+					comment={comment}
+					externalLink={externalLink}
+					key={comment.id}
+					labels={labels}
+					onResolve={!comment.resolved && onResolveInlineComment ? async () => {
+						setResolvingCommentIds((current) => new Set(current).add(comment.id));
+						setResolveErrorCommentIds((current) => {
+							const next = new Set(current);
+							next.delete(comment.id);
+							return next;
+						});
+						try {
+							await onResolveInlineComment(comment);
+							setManuallyResolvedCommentIds((current) => new Set(current).add(comment.id));
+						} catch {
+							setResolveErrorCommentIds((current) => new Set(current).add(comment.id));
+						} finally {
+							setResolvingCommentIds((current) => {
 								const next = new Set(current);
 								next.delete(comment.id);
 								return next;
 							});
-							try {
-								await onSendInlineComment(comment);
-								setManuallySentCommentIds((current) => new Set(current).add(comment.id));
-							} catch {
-								setSendErrorCommentIds((current) => new Set(current).add(comment.id));
-							} finally {
-								setSendingCommentIds((current) => {
-									const next = new Set(current);
-									next.delete(comment.id);
-									return next;
-								});
-							}
-						} : undefined}
-						sendError={sendErrorCommentIds.has(comment.id)}
-						resolveError={resolveErrorCommentIds.has(comment.id)}
-						resolved={resolvedCommentIds.has(comment.id)}
-						showReviewer={showReviewer}
-						sent={Boolean(comment.autoInjectReview) || manuallySentCommentIds.has(comment.id)}
-						sending={sendingCommentIds.has(comment.id)}
-					/>
-				))}
-			</div>
-			{remainingComments.length > 1 ? (
-				<button
-					className="mt-3 flex w-full items-center justify-center rounded-md border border-dashed border-border px-2 py-1.5 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover/30 hover:text-foreground"
-					onClick={() => setVisibleCount(hasMore ? Math.min(visibleCount + 3, remainingComments.length) : 1)}
-					type="button"
-				>
-					{hasMore ? labels.showMore : labels.showLess}
-				</button>
-			) : null}
-		</section>
+						}
+					} : undefined}
+					onSend={comment.autoInjectReview === false && onSendInlineComment ? async () => {
+						setSendingCommentIds((current) => new Set(current).add(comment.id));
+						setSendErrorCommentIds((current) => {
+							const next = new Set(current);
+							next.delete(comment.id);
+							return next;
+						});
+						try {
+							await onSendInlineComment(comment);
+							setManuallySentCommentIds((current) => new Set(current).add(comment.id));
+						} catch {
+							setSendErrorCommentIds((current) => new Set(current).add(comment.id));
+						} finally {
+							setSendingCommentIds((current) => {
+								const next = new Set(current);
+								next.delete(comment.id);
+								return next;
+							});
+						}
+					} : undefined}
+					resolveError={resolveErrorCommentIds.has(comment.id)}
+					resolvedSuccess={manuallyResolvedCommentIds.has(comment.id)}
+					resolving={resolvingCommentIds.has(comment.id)}
+					sendError={sendErrorCommentIds.has(comment.id)}
+					sent={Boolean(comment.autoInjectReview) || manuallySentCommentIds.has(comment.id)}
+					sending={sendingCommentIds.has(comment.id)}
+				/>
+			))}
+		</div>
 	);
 }
 
 function InlineCommentRow({
 	comment,
-	commentNumber,
+	externalLink: ExternalLink,
 	labels,
 	onResolve,
 	onSend,
 	resolveError = false,
-	resolved = false,
+	resolvedSuccess = false,
+	resolving = false,
 	sendError = false,
 	sending = false,
-	showReviewer = true,
 	sent,
 }: {
-	comment: InspectorInlineComment & { reviewerId?: string };
-	commentNumber: number;
+	comment: InspectorInlineComment & { id: string; reviewerId?: string };
+	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
 	onResolve?: () => void;
 	onSend?: () => void;
 	resolveError?: boolean;
-	resolved?: boolean;
+	resolvedSuccess?: boolean;
+	resolving?: boolean;
 	sendError?: boolean;
 	sending?: boolean;
-	showReviewer?: boolean;
 	sent: boolean;
 }) {
+	const [expanded, setExpanded] = useState(false);
+	const [menuOpen, setMenuOpen] = useState(false);
 	const body = comment.body?.trim();
-	const viewInFileTooltipId = useId();
+	const fileLabel = comment.file ? `${comment.file}${comment.line ? `:${comment.line}` : ""}` : labels.commentNumber(1);
+	const preview = body ? body.split("\n")[0] : "";
+	const copy = async (value?: string) => {
+		if (!value) return;
+		try {
+			await navigator.clipboard?.writeText(value);
+		} catch {
+			// Clipboard access may be unavailable in tests or restricted contexts.
+		}
+	};
 	return (
-		<div className="flex min-w-0 flex-col gap-2 px-0 py-4 text-xs first:pt-2 last:pb-0">
-			{showReviewer && comment.reviewerId ? (
-				<span className="inline-flex min-w-0 items-center gap-1.5 font-medium text-muted-foreground">
-					<GithubAvatar login={comment.reviewerId} />
-					<span className="truncate">{comment.reviewerId}</span>
+		<div className="relative flex min-w-0 flex-col gap-1.5 py-2.5 text-xs">
+			<div aria-expanded={expanded} className="grid w-full min-w-0 cursor-pointer grid-cols-[1fr_auto_auto] items-start gap-2 rounded-md py-1 text-left transition-colors hover:bg-interactive-hover/20" onClick={() => setExpanded((current) => !current)} onKeyDown={(event) => {
+				if (event.key === "Enter" || event.key === " ") {
+					event.preventDefault();
+					setExpanded((current) => !current);
+				}
+			}} role="button" tabIndex={0}>
+				<span className="flex min-w-0 flex-col gap-1">
+					<span className="flex min-w-0 items-center gap-1.5 font-mono text-2xs font-semibold text-foreground">
+						<ChevronIcon className="size-icon-2xs shrink-0 text-passive" direction={expanded ? "down" : "right"} />
+						<span className="truncate" title={fileLabel}>{fileLabel}</span>
+					</span>
+					{body ? <span className={cn("text-muted-foreground", expanded ? "whitespace-pre-wrap break-words" : "truncate")}>{expanded ? body : preview}</span> : null}
 				</span>
-			) : null}
-			<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-2xs font-mono text-passive">
-				<span className="font-semibold text-foreground">#{commentNumber}</span>
-				{comment.file ? <span className="min-w-0 break-words">{comment.file}{comment.line ? `:${comment.line}` : ""}</span> : null}
-			</div>
-			{body ? <p className="m-0 max-w-prose whitespace-pre-wrap break-words leading-relaxed text-muted-foreground">{body}</p> : null}
-			<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 border-t border-border/50 pt-2 text-2xs">
-				{sent ? (
-					<span className="inline-flex h-control-md items-center gap-1.5 rounded-md px-1.5 font-medium text-muted-foreground [&_svg]:size-icon-xs" title={labels.workerAgentWorkingOnFeedback}>
-						<CheckIcon className="shrink-0 text-success" />
-						{labels.sentToWorkerAgent}
-					</span>
-				) : (
-					<button
-						className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-60"
-						disabled={sending || !onSend}
-						onClick={onSend}
-						type="button"
-					>
-						{labels.sendToWorkerAgent}
+				<span className="flex shrink-0 items-center justify-end" onClick={(event) => event.stopPropagation()}>
+					{sent ? (
+						<span className="inline-flex h-7 items-center gap-1.5 rounded-md px-1.5 text-2xs font-medium text-success">
+							<CheckIcon className="size-icon-xs shrink-0" />
+							{labels.sentToWorkerAgent}
+						</span>
+					) : onSend ? (
+						<button className="inline-flex h-control-md shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent bg-secondary bg-clip-padding px-2.5 text-xs font-normal text-secondary-foreground transition-[background-color,border-color,color,box-shadow,transform,opacity] duration-[100ms] ease-out hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] focus-visible:border-ring focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30 active:scale-[0.97] active:translate-y-px disabled:pointer-events-none disabled:opacity-50" disabled={sending} onClick={onSend} type="button">
+							{labels.sendToWorkerAgent}
+						</button>
+					) : null}
+				</span>
+				<span className="relative flex shrink-0 items-start justify-end" onClick={(event) => event.stopPropagation()}>
+					<button aria-expanded={menuOpen} aria-label="Comment actions" className="inline-flex size-7 items-center justify-center rounded-md border border-border/70 text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground" onClick={() => setMenuOpen((current) => !current)} type="button">
+						<MoreHorizontalIcon className="size-icon-xs" />
 					</button>
-				)}
-				{resolved ? (
-					<span className="inline-flex h-7 items-center gap-1.5 rounded-md px-1.5 text-2xs font-medium text-muted-foreground">
-						<CheckIcon className="size-icon-xs shrink-0 text-success" />
-						{labels.resolvedReview}
-					</span>
-				) : (
-					<button
-						className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground"
-						disabled={!onResolve || !comment.url}
-						onClick={onResolve}
-						type="button"
-					>
-						{labels.resolveComment}
-					</button>
-				)}
-				<span className="group relative inline-flex">
-					<button
-						aria-describedby={viewInFileTooltipId}
-						aria-disabled="true"
-						className="inline-flex h-7 cursor-help items-center rounded-md border border-border/70 bg-transparent px-2 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
-						type="button"
-					>
-						{labels.viewInFile}
-					</button>
-					<span
-						className="pointer-events-none invisible absolute bottom-full left-1/2 z-overlay mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground opacity-0 shadow-md transition-opacity group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
-						id={viewInFileTooltipId}
-						role="tooltip"
-					>
-						{labels.viewInFileWorkInProgress}
-					</span>
+					{menuOpen ? (
+						<div className="isolate absolute right-0 top-8 z-[100] flex w-40 flex-col rounded-md border border-border-strong bg-[var(--color-bg-settings-menu)] p-1 text-2xs shadow-[0_16px_40px_rgba(0,0,0,0.65)]">
+							{onResolve ? <button className="rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-interactive-hover hover:text-foreground disabled:pointer-events-none disabled:opacity-60" disabled={resolving} onClick={() => void onResolve()} type="button">{labels.resolveComment}</button> : null}
+							{comment.url ? <ExternalLink className="rounded px-2 py-1.5 text-muted-foreground no-underline hover:bg-interactive-hover hover:text-foreground" href={comment.url}>{labels.viewInFile}</ExternalLink> : null}
+							{comment.url ? <ExternalLink className="rounded px-2 py-1.5 text-muted-foreground no-underline hover:bg-interactive-hover hover:text-foreground" href={comment.url}>Open on GitHub</ExternalLink> : null}
+							<button className="rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-interactive-hover hover:text-foreground" onClick={() => void copy(comment.url)} type="button">Copy comment link</button>
+						</div>
+					) : null}
 				</span>
 			</div>
+			{resolvedSuccess ? <p className="m-0 text-2xs font-medium text-success">{labels.resolvedReview}</p> : null}
+			{resolveError ? <p className="m-0 text-2xs font-medium text-error">{labels.resolveReviewFailed}</p> : null}
 			{sendError && !sent ? <p className="m-0 text-2xs font-medium text-error">{labels.sendToWorkerAgentError}</p> : null}
-			{resolveError && !resolved ? <p className="m-0 text-2xs font-medium text-error">{labels.resolveReviewFailed}</p> : null}
 		</div>
 	);
 }
 
 function ReviewSummaryCard({
 	actor,
-	autoInjected = false,
 	body: rawBody,
-	externalLink: ExternalLink,
 	isBot = false,
 	isEarlier = false,
 	labels,
-	onSend,
 	renderAvatar,
 	renderMarkdown,
 	testId,
 	timestamp,
-	url,
 	verdict,
 }: {
 	actor: string;
-	autoInjected?: boolean;
 	body?: string;
-	externalLink: ExternalLinkComponent;
 	isBot?: boolean;
 	isEarlier?: boolean;
 	labels: InspectorReviewLabels;
-	onSend?: () => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 	testId: string;
 	timestamp: string;
-	url?: string | null;
 	verdict: InspectorVerdict;
 }) {
-	const [open, setOpen] = useState(false);
 	const [expanded, setExpanded] = useState(false);
-	const [sent, setSent] = useState(autoInjected);
-	const [sending, setSending] = useState(false);
-	const [sendError, setSendError] = useState(false);
-	useEffect(() => {
-		if (autoInjected) setSent(true);
-	}, [autoInjected]);
 	const trimmed = rawBody?.trim();
 	const body = trimmed ? trimmed.replace(/\n{3,}/g, "\n\n") : trimmed;
 	const clamped = body ? isClampedSummary(body) : false;
 	return (
-		<ReviewEntryDisclosure
-			actor={actor}
-			avatar={renderAvatar(actor)}
-			botLabel={isBot ? labels.bot : undefined}
-			meta={
-				<>
+		<article className="flex min-w-0 flex-col gap-1 rounded-md bg-overlay/50 px-2.5 py-2.5">
+			<span className="flex min-w-0 items-center gap-1.5">
+				<span className="inline-flex min-w-0 items-center gap-1 text-micro font-medium text-muted-foreground">
+					{renderAvatar(actor)}
+					<span className="truncate">{actor}</span>
+				</span>
+				{isBot ? <span className="shrink-0 font-mono text-micro text-passive">{labels.bot}</span> : null}
+				<VerdictBadge verdict={verdict} />
+				<span className="ml-auto inline-flex shrink-0 items-center gap-1.5 text-micro text-passive">
 					{isEarlier ? <span>{labels.earlierPass}</span> : null}
-					<span>{timestamp}</span>
-				</>
-			}
-			onOpenChange={setOpen}
-			open={open}
-			testId="agent-review-card"
-			verdict={verdict}
-		>
+					<span className="font-mono">{timestamp}</span>
+				</span>
+			</span>
 			{body ? (
 				<ReviewMarkdownBody
 					body={body}
@@ -1332,45 +1190,7 @@ function ReviewSummaryCard({
 				labels={labels}
 				onExpandedChange={() => setExpanded((open) => !open)}
 			/>
-			{body || url ? (
-				<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 border-t border-border/50 pt-2 text-2xs">
-					{body && onSend ? (
-						sent ? (
-							<span className="inline-flex h-control-md items-center gap-1.5 rounded-md px-1.5 font-medium text-muted-foreground [&_svg]:size-icon-xs" title={labels.workerAgentWorkingOnFeedback}>
-								<CheckIcon className="shrink-0 text-success" />
-								{labels.sentToWorkerAgent}
-							</span>
-						) : (
-							<button
-								className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-60"
-								disabled={sending}
-								onClick={async () => {
-									setSending(true);
-									setSendError(false);
-									try {
-										await onSend();
-										setSent(true);
-									} catch {
-										setSendError(true);
-									} finally {
-										setSending(false);
-									}
-								}}
-								type="button"
-							>
-								{labels.sendToWorkerAgent}
-							</button>
-						)
-					) : null}
-					{url ? (
-						<ExternalLink className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground no-underline transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground" href={url}>
-							{labels.viewOnPR}
-						</ExternalLink>
-					) : null}
-				</div>
-			) : null}
-			{sendError && !sent ? <p className="m-0 text-2xs font-medium text-error">{labels.sendToWorkerAgentError}</p> : null}
-		</ReviewEntryDisclosure>
+		</article>
 	);
 }
 

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -480,12 +480,14 @@ export type InspectorReviewLabels = {
 	sendToWorkerAgent: string;
 	sentToWorkerAgent: string;
 	sendToWorkerAgentError: string;
+	workerAgentWorkingOnFeedback: string;
 	showLatestReviewOnly: string;
 	showLess: string;
 	showMore: string;
 	commentNumber: (number: number) => string;
 	unresolvedCount: (count: number) => string;
 	viewInFile: string;
+	viewInFileWorkInProgress: string;
 	viewOnPR: string;
 };
 
@@ -496,6 +498,7 @@ export function InspectorReviewsView({
 	labels,
 	onRequestRereview,
 	onResolveInlineComment,
+	onSendAgentReview,
 	onSendInlineComment,
 	renderAvatar,
 	renderMarkdown,
@@ -506,6 +509,7 @@ export function InspectorReviewsView({
 	labels: InspectorReviewLabels;
 	onRequestRereview?: (review: InspectorGithubReview) => Promise<void> | void;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
+	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
@@ -541,6 +545,7 @@ export function InspectorReviewsView({
 									dimmed={group.ao.dimmed}
 									historical={group.ao.historical}
 									labels={labels}
+									onSendAgentReview={onSendAgentReview}
 									renderAvatar={renderAvatar}
 									renderMarkdown={renderMarkdown}
 									runs={group.ao.runs}
@@ -691,6 +696,7 @@ function ReviewRuns({
 	dimmed,
 	historical,
 	labels,
+	onSendAgentReview,
 	renderAvatar,
 	renderMarkdown,
 	runs,
@@ -698,6 +704,7 @@ function ReviewRuns({
 	dimmed?: boolean;
 	historical?: boolean;
 	labels: InspectorReviewLabels;
+	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 	runs: InspectorReviewRun[];
@@ -710,6 +717,7 @@ function ReviewRuns({
 			dimmed={dimmed}
 			historical={historical}
 			labels={labels}
+			onSendAgentReview={onSendAgentReview}
 			renderAvatar={renderAvatar}
 			renderMarkdown={renderMarkdown}
 			runs={runs}
@@ -721,6 +729,7 @@ function ReviewRunHistory({
 	dimmed,
 	historical,
 	labels,
+	onSendAgentReview,
 	renderAvatar,
 	renderMarkdown,
 	runs,
@@ -728,6 +737,7 @@ function ReviewRunHistory({
 	dimmed?: boolean;
 	historical?: boolean;
 	labels: InspectorReviewLabels;
+	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 	runs: InspectorReviewRun[];
@@ -746,6 +756,7 @@ function ReviewRunHistory({
 					isEarlier={historical || index > 0}
 					key={run.id}
 					labels={labels}
+					onSend={onSendAgentReview ? () => onSendAgentReview(run) : undefined}
 					renderAvatar={renderAvatar}
 					renderMarkdown={renderMarkdown}
 					testId="review-run-summary"
@@ -1140,8 +1151,7 @@ function ReviewSummaryCard({
 	body: rawBody,
 	isBot = false,
 	isEarlier = false,
-	labels,
-	renderAvatar,
+	labels,	onSend,	renderAvatar,
 	renderMarkdown,
 	testId,
 	timestamp,
@@ -1152,6 +1162,7 @@ function ReviewSummaryCard({
 	isBot?: boolean;
 	isEarlier?: boolean;
 	labels: InspectorReviewLabels;
+	onSend?: () => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 	testId: string;
@@ -1162,6 +1173,9 @@ function ReviewSummaryCard({
 	const trimmed = rawBody?.trim();
 	const body = trimmed ? trimmed.replace(/\n{3,}/g, "\n\n") : trimmed;
 	const clamped = body ? isClampedSummary(body) : false;
+	const [sent, setSent] = useState(false);
+	const [sending, setSending] = useState(false);
+	const [sendError, setSendError] = useState(false);
 	return (
 		<article className="flex min-w-0 flex-col gap-1 rounded-md bg-overlay/50 px-2.5 py-2.5">
 			<span className="flex min-w-0 items-center gap-1.5">
@@ -1174,6 +1188,32 @@ function ReviewSummaryCard({
 				<span className="ml-auto inline-flex shrink-0 items-center gap-1.5 text-micro text-passive">
 					{isEarlier ? <span>{labels.earlierPass}</span> : null}
 					<span className="font-mono">{timestamp}</span>
+					{onSend ? sent ? (
+						<span className="inline-flex items-center gap-1.5 text-success" title={labels.workerAgentWorkingOnFeedback}>
+							<CheckIcon className="size-icon-xs shrink-0" />
+							{labels.sentToWorkerAgent}
+						</span>
+					) : (
+						<button
+							className="inline-flex h-control-md items-center justify-center gap-1.5 rounded-md bg-secondary px-2.5 text-xs font-normal text-secondary-foreground transition-colors hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] disabled:pointer-events-none disabled:opacity-50"
+							disabled={sending}
+							onClick={async () => {
+								setSending(true);
+								setSendError(false);
+								try {
+									await onSend();
+									setSent(true);
+								} catch {
+									setSendError(true);
+								} finally {
+									setSending(false);
+								}
+							}}
+							type="button"
+						>
+							{labels.sendToWorkerAgent}
+						</button>
+					) : null}
 				</span>
 			</span>
 			{body ? (
@@ -1184,6 +1224,7 @@ function ReviewSummaryCard({
 					testId={testId}
 				/>
 			) : null}
+			{sendError ? <p className="m-0 text-2xs font-medium text-error">{labels.sendToWorkerAgentError}</p> : null}
 			<ReviewLinks
 				clamped={clamped}
 				expanded={expanded}

--- a/packages/product-ui/src/icons.tsx
+++ b/packages/product-ui/src/icons.tsx
@@ -142,6 +142,16 @@ export function MessageSquareIcon(props: IconProps) {
 	);
 }
 
+export function MoreHorizontalIcon(props: IconProps) {
+	return (
+		<Icon name="more-horizontal" {...props}>
+			<circle cx="12" cy="12" r="1" />
+			<circle cx="19" cy="12" r="1" />
+			<circle cx="5" cy="12" r="1" />
+		</Icon>
+	);
+}
+
 export function PaperclipIcon(props: IconProps) {
 	return (
 		<Icon name="paperclip" {...props}>

--- a/packages/product-ui/src/scm-models.ts
+++ b/packages/product-ui/src/scm-models.ts
@@ -79,6 +79,7 @@ export type PullRequestReviewSummary = {
 	decision: ReviewDecision;
 	hasUnresolvedHumanComments: boolean;
 	unresolvedBy: PullRequestUnresolvedReviewer[];
+	resolvedBy?: PullRequestUnresolvedReviewer[];
 	reviews: PullRequestSubmittedReview[];
 };
 


### PR DESCRIPTION
## Summary
- Rework External reviews inside the existing Reviews inspector as compact collapsible rows, with reviewer identity, timestamp, verdict, comment icon/count, nested review summary, and expandable open/resolved inline comments.
- Keep inline comment actions inside the comment row: secondary-style “Send to worker agent” when auto-inject is disabled, green sent state, and a three-dot menu with Resolve comment, View in file, Open on GitHub, and Copy comment link.
- Persist resolved external review comments through the backend after a successful resolve action, then refresh local SCM data so the External reviews list defaults to unresolved/open comments only.
- Exclude PR-author self reviews/comments from External reviews, allow open and draft PRs to run reviews, and hide Reviews when all PRs are merged/closed.
- Polish the External reviews UI: remove the old View-on-PR CTA, align/pad verdict/comment metadata, remove vertical nesting lines, prevent menu clipping/overlap, and rename review/CI automation labels.

## Tests
- `npm --prefix packages/product-ui run typecheck`
- `npm --prefix packages/product-ui test -- SessionInspectorView.test.tsx`
- `npm --prefix packages/product-ui run build`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend test -- SessionInspector.test.tsx session-reviews.test.ts`
- `npm --prefix frontend test -- SessionInspector.test.tsx`
- `cd backend && go test ./internal/service/session ./internal/httpd/controllers ./internal/service/review ./internal/storage/sqlite/store ./pkg/contract`
- `cd backend && go test ./...` *(fails locally on existing environment-dependent failures: agent auth timeout tests, CLI hook AO_LAUNCH_ID leakage, spawn daemon 404 expectations)*

## Risks / Notes
- Self-review filtering depends on the SCM summary carrying the PR author login; if absent, external review entries are preserved rather than hidden.
- Resolved comments are still available via the PR summary contract, but remain collapsed by default in the inspector.
