### PR TITLE
fix: sort sidebar sessions by updated time

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -474,7 +474,7 @@ describe("Sidebar", () => {
 		expect(navigateMock).not.toHaveBeenCalled();
 	});
 
-	it("lists worker sessions by last activity, newest first", () => {
+	it("lists worker sessions by updated time, newest first", () => {
 		const oldest: WorkspaceSession = {
 			...session,
 			id: "proj-1-old",
@@ -518,11 +518,11 @@ describe("Sidebar", () => {
 
 		const sessionButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-session-row] button[aria-label^="Open "]'));
 		expect(sessionButtons.map((button) => button.getAttribute("aria-label"))).toEqual([
-			"Open created fallback",
 			"Open invalid activity",
 			"Open no activity",
-			"Open new task",
 			"Open old task",
+			"Open new task",
+			"Open created fallback",
 		]);
 	});
 

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -212,7 +212,10 @@ function sessionNewer(a: WorkspaceSession, b: WorkspaceSession): boolean {
 	return a.id > b.id;
 }
 
-function sessionLastActiveNewer(a: WorkspaceSession, b: WorkspaceSession): boolean {
+function sessionRecentlyUpdatedNewer(a: WorkspaceSession, b: WorkspaceSession): boolean {
+	const aUpdated = timestamp(a.updatedAt);
+	const bUpdated = timestamp(b.updatedAt);
+	if (aUpdated !== bUpdated) return aUpdated > bUpdated;
 	const aLastActive = sessionLastActiveTimestamp(a);
 	const bLastActive = sessionLastActiveTimestamp(b);
 	if (aLastActive !== bLastActive) return aLastActive > bLastActive;
@@ -242,10 +245,10 @@ export function workerSessions(sessions: WorkspaceSession[]): WorkspaceSession[]
 	return sessions.filter((s) => !isOrchestratorSession(s));
 }
 
-/** Worker sessions ordered by agent activity, newest first. */
+/** Worker sessions ordered by session update time, newest first. */
 export function sortedWorkerSessions(sessions: WorkspaceSession[]): WorkspaceSession[] {
 	return workerSessions(sessions).sort((a, b) =>
-		sessionLastActiveNewer(b, a) ? 1 : sessionLastActiveNewer(a, b) ? -1 : 0,
+		sessionRecentlyUpdatedNewer(b, a) ? 1 : sessionRecentlyUpdatedNewer(a, b) ? -1 : 0,
 	);
 }
 


### PR DESCRIPTION
## Summary
- Sort sidebar worker sessions by `updatedAt` so recently changed chat sessions move to the top.
- Keep `activity.lastActivityAt`, `createdAt`, and `id` as deterministic fallback tie-breakers.
- Update the Sidebar ordering test for the new behavior.

## Tests
- `npm ci --prefix frontend`
- `npm ci`
- `npm ci --prefix packages/product-ui`
- `cd frontend && npm test -- --run src/renderer/components/Sidebar.test.tsx`
- `cd frontend && npm run typecheck`

## Risks
- Sidebar ordering now reflects any session-row update, not only agent activity-state transitions.
