### PR TITLE
Align agent review cards with external reviews

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1952,7 +1952,7 @@ describe("SessionInspector summary reviews", () => {
     expect(summary).not.toHaveTextContent("**auth validation**");
   });
 
-  it("does not show a View on PR CTA for review summaries", async () => {
+  it("links delivered AO review summaries to their GitHub review", async () => {
     mockCommonGets([], "reviewer-pane", [
       {
         ...reviewState(3, "up_to_date", "abc123"),
@@ -1965,7 +1965,10 @@ describe("SessionInspector summary reviews", () => {
     await openLatestAgentReview();
 
     expect(await screen.findByTestId("review-run-summary")).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: /View on PR/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
+      "href",
+      "https://example.com/pr/3#pullrequestreview-98765",
+    );
   });
 
   it.each([
@@ -2030,7 +2033,10 @@ describe("SessionInspector summary reviews", () => {
         expect(screen.queryByText("Changes requested")).not.toBeInTheDocument();
         expect(screen.queryByText("Earlier commit")).not.toBeInTheDocument();
       }
-      expect(screen.queryByRole("link", { name: "View on PR" })).not.toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
+        "href",
+        "https://example.com/pr/3#pullrequestreview-98765",
+      );
       // A run in flight gets its own live strip naming the harness, not just a
       // word on the button.
       if (status === "running") {
@@ -2332,6 +2338,68 @@ describe("SessionInspector summary reviews", () => {
       screen.getByRole("button", { name: "Request to re-review PR" }),
     ).toBeInTheDocument();
     expect(screen.queryByText("Asked for re-review")).not.toBeInTheDocument();
+  });
+
+  it("sends an AO review summary to the worker from the agent review card", async () => {
+    const run = {
+      ...approvedReview,
+      autoInjectReview: false,
+      body: "The empty-cart path still needs coverage.",
+      githubReviewId: "9876",
+      verdict: "changes_requested",
+    };
+    const state = {
+      ...reviewState(3, "changes_requested"),
+      latestRun: run,
+    };
+    const previous = getMock.getMockImplementation()!;
+    getMock.mockImplementation(async (path: string, opts?: unknown) => {
+      if (path === "/api/v1/sessions/{sessionId}/reviews") {
+        return {
+          data: {
+            reviewerHandleId: "reviewer-pane",
+            reviews: [state],
+            runs: [run],
+          },
+        };
+      }
+      return previous(path, opts);
+    });
+
+    renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+    await openReviewsSection();
+    await openLatestAgentReview();
+
+    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
+      "href",
+      "https://example.com/pr/3#pullrequestreview-9876",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Send to worker agent" }),
+    );
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/send",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: {
+            message: expect.stringContaining(
+              "Review:\nThe empty-cart path still needs coverage.",
+            ),
+          },
+        },
+      ),
+    );
+    expect(postMock).toHaveBeenCalledWith(
+      "/api/v1/sessions/{sessionId}/send",
+      expect.objectContaining({
+        body: {
+          message: expect.stringContaining("Reviewer: codex"),
+        },
+      }),
+    );
+    expect(screen.getByText("Sent to worker agent")).toBeInTheDocument();
   });
 
   it("marks SCM reviews and individual comments using their stored injection decision", async () => {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1476,6 +1476,14 @@ describe("SessionInspector summary reviews", () => {
     }
   };
 
+  const openLatestAgentReview = async () => {
+    const cards = await screen.findAllByTestId("agent-review-card");
+    const trigger = within(cards[0]).getByRole("button");
+    if (trigger.getAttribute("aria-expanded") === "false") {
+      await userEvent.click(trigger);
+    }
+  };
+
   it("triggers a review and opens the returned reviewer terminal", async () => {
     mockCommonGets([], "", [reviewState(3, "needs_review")]);
     const runningReview = {
@@ -1886,6 +1894,7 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
+    await openLatestAgentReview();
 
     const summary = await screen.findByTestId("review-run-summary");
     expect(summary).toHaveClass("line-clamp-4");
@@ -1912,6 +1921,7 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
+    await openLatestAgentReview();
 
     expect(await screen.findByTestId("review-run-summary")).not.toHaveClass(
       "line-clamp-4",
@@ -1934,6 +1944,7 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
+    await openLatestAgentReview();
 
     const summary = await screen.findByTestId("review-run-summary");
     expect(within(summary).getByText("auth validation").tagName).toBe("STRONG");
@@ -1951,6 +1962,7 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
+    await openLatestAgentReview();
 
     expect(await screen.findByTestId("review-run-summary")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /View on PR/ })).not.toBeInTheDocument();
@@ -1997,6 +2009,7 @@ describe("SessionInspector summary reviews", () => {
 
       renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
       await openReviewsSection();
+      await openLatestAgentReview();
 
       expect(await screen.findAllByText(runLabel)).not.toHaveLength(0);
       expect(
@@ -2628,6 +2641,7 @@ describe("SessionInspector summary reviews", () => {
 
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
+    await openLatestAgentReview();
 
     expect(
       await screen.findByText("codex asked for tests."),
@@ -2638,6 +2652,8 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "Load more · 1 earlier" }),
     );
+    const reviewCards = screen.getAllByTestId("agent-review-card");
+    await userEvent.click(within(reviewCards[1]).getByRole("button"));
     expect(
       screen.getByText("claude-code found nothing blocking."),
     ).toBeInTheDocument();

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2460,9 +2460,13 @@ describe("SessionInspector summary reviews", () => {
       screen.getByRole("button", { name: /maya.*Changes requested/i }),
     );
     await userEvent.click(screen.getByRole("button", { name: "Show more" }));
-    expect(screen.getByRole("link", { name: "View in file" })).toHaveAttribute(
-      "href",
-      "https://example.com/comment-9",
+    expect(screen.queryByRole("link", { name: "View in file" })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "View in file" })[0]).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(screen.getAllByRole("tooltip")[0]).toHaveTextContent(
+      "Opening files in AO is a work in progress",
     );
     const sendButton = screen.getByRole("button", {
       name: "Send to worker agent",

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2211,8 +2211,11 @@ describe("SessionInspector summary reviews", () => {
       within(externalReview).getByText("Reviewed 3d ago"),
     ).toBeInTheDocument();
     expect(
-      within(externalReview).queryByRole("link", { name: "View on PR" }),
-    ).not.toBeInTheDocument();
+      within(externalReview).getByRole("link", { name: "View on PR" }),
+    ).toHaveAttribute(
+      "href",
+      "https://example.com/pr/3#pullrequestreview-456",
+    );
     expect(
       within(externalReview).queryByRole("button", { name: "Request to re-review PR" }),
     ).not.toBeInTheDocument();
@@ -2457,6 +2460,10 @@ describe("SessionInspector summary reviews", () => {
       screen.getByRole("button", { name: /maya.*Changes requested/i }),
     );
     await userEvent.click(screen.getByRole("button", { name: "Show more" }));
+    expect(screen.getByRole("link", { name: "View in file" })).toHaveAttribute(
+      "href",
+      "https://example.com/comment-9",
+    );
     const sendButton = screen.getByRole("button", {
       name: "Send to worker agent",
     });
@@ -2505,6 +2512,10 @@ describe("SessionInspector summary reviews", () => {
       ),
     );
     expect(screen.getAllByText("Sent to worker agent")).toHaveLength(2);
+    expect(screen.getAllByText("Sent to worker agent")[0]).toHaveAttribute(
+      "title",
+      "Worker agent is working on this feedback",
+    );
   });
 
   it("marks an AO review using its stored injection decision", async () => {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1617,6 +1617,7 @@ function reviewLabels(t: TFunction): InspectorReviewLabels {
 		commentNumber: (number) => t("inspector.commentNumber", { number }),
 		unresolvedCount: (count) => t("inspector.unresolvedCount", { count }),
 		viewInFile: t("inspector.viewInFile"),
+		viewInFileWorkInProgress: t("inspector.viewInFileWorkInProgress"),
 		viewOnPR: t("inspector.viewOnPR"),
 	};
 }

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1610,6 +1610,7 @@ function reviewLabels(t: TFunction): InspectorReviewLabels {
 		sendToWorkerAgent: t("inspector.sendToWorkerAgent"),
 		sentToWorkerAgent: t("inspector.sentToWorkerAgent"),
 		sendToWorkerAgentError: t("inspector.sendToWorkerAgentError"),
+		workerAgentWorkingOnFeedback: t("inspector.workerAgentWorkingOnFeedback"),
 		showLatestReviewOnly: t("inspector.showLatestReviewOnly"),
 		showLess: t("inspector.showLess"),
 		showMore: t("inspector.showMore"),

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -18,6 +18,7 @@ import {
 	type InspectorGithubReview,
 	type InspectorReviewGroup,
 	type InspectorReviewLabels,
+	type InspectorReviewRun,
 	type InspectorTimelineEvent,
 	type InspectorView,
 } from "@aoagents/product-ui";
@@ -1441,6 +1442,13 @@ function MergedReviewsSection({
 		});
 		if (error) throw new Error(apiErrorMessage(error, "Unable to send review comment to worker agent"));
 	};
+	const sendAgentReviewToWorker = async (run: InspectorReviewRun) => {
+		const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/send", {
+			params: { path: { sessionId: session.id } },
+			body: { message: formatAgentReviewMessage(run) },
+		});
+		if (error) throw new Error(apiErrorMessage(error, "Unable to send agent review to worker agent"));
+	};
 	const groups: InspectorReviewGroup[] = rows.map(([number, { ao, github }]) => {
 		const aoRuns = ao ? [...(runsByPR.get(ao.prUrl) ?? [])].sort((a, b) => b.createdAt.localeCompare(a.createdAt)) : [];
 		const entries = github?.review?.reviews ?? [];
@@ -1448,6 +1456,7 @@ function MergedReviewsSection({
 		const reviewRuns = aoRuns.map((run) => {
 			const reviewUrl = aoReviewCommentUrl(run);
 			return {
+				autoInjectReview: run.autoInjectReview,
 				body: run.body,
 				createdAtLabel: formatTimeCompact(run.createdAt),
 				harness: run.harness || "reviewer",
@@ -1562,6 +1571,7 @@ function MergedReviewsSection({
 			labels={labels}
 			onRequestRereview={requestRereview}
 			onResolveInlineComment={resolveInlineComment}
+			onSendAgentReview={sendAgentReviewToWorker}
 			onSendInlineComment={sendInlineCommentToWorker}
 			renderAvatar={(harness) => (
 				<AgentAvatar className="size-5 shrink-0" decorative provider={harness} />
@@ -1645,6 +1655,25 @@ function formatInlineReviewCommentMessage(comment: InspectorInlineComment & { re
 	if (url) {
 		lines.push("", `Comment URL: ${url}`);
 	}
+	lines.push("", "You should not need to re-fetch review data unless you need additional context beyond what AO has provided here.");
+	return lines.join("\n");
+}
+
+function formatAgentReviewMessage(run: InspectorReviewRun): string {
+	const reviewer = sanitizeWorkerMessagePart(run.harness.trim() || "reviewer");
+	const verdict = sanitizeWorkerMessagePart(run.verdict.label.trim() || "Review complete");
+	const body = sanitizeWorkerMessagePart(run.body?.trim() || "No review summary provided.");
+	const url = sanitizeWorkerMessagePart(run.url?.trim() || "");
+	const lines = [
+		"An AO reviewer completed a review of your PR. Address any requested changes, commit the fixes, and push the branch to GitHub.",
+		"",
+		`Reviewer: ${reviewer}`,
+		`Verdict: ${verdict}`,
+		"",
+		"Review:",
+		body,
+	];
+	if (url) lines.push("", `Review URL: ${url}`);
 	lines.push("", "You should not need to re-fetch review data unless you need additional context beyond what AO has provided here.");
 	return lines.join("\n");
 }

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1564,7 +1564,7 @@ function MergedReviewsSection({
 			onResolveInlineComment={resolveInlineComment}
 			onSendInlineComment={sendInlineCommentToWorker}
 			renderAvatar={(harness) => (
-				<AgentAvatar className="size-icon-sm shrink-0" decorative provider={harness} />
+				<AgentAvatar className="size-5 shrink-0" decorative provider={harness} />
 			)}
 			renderMarkdown={renderReviewMarkdown}
 		/>

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -275,6 +275,7 @@
 	"inspector.sendToWorkerAgent": "An Worker-Agent senden",
 	"inspector.sentToWorkerAgent": "An Worker-Agent gesendet",
 	"inspector.sendToWorkerAgentError": "Senden fehlgeschlagen. Erneut versuchen.",
+	"inspector.workerAgentWorkingOnFeedback": "Der Worker-Agent bearbeitet dieses Feedback",
 	"inspector.viewInFile": "In Datei anzeigen",
 	"inspector.commentNumber": "Kommentar #{{number}}",
 	"inspector.loadMoreReviews": "Mehr laden · {{count}} frühere",

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -277,6 +277,7 @@
 	"inspector.sendToWorkerAgentError": "Senden fehlgeschlagen. Erneut versuchen.",
 	"inspector.workerAgentWorkingOnFeedback": "Der Worker-Agent bearbeitet dieses Feedback",
 	"inspector.viewInFile": "In Datei anzeigen",
+	"inspector.viewInFileWorkInProgress": "Das Öffnen von Dateien in AO ist in Arbeit",
 	"inspector.commentNumber": "Kommentar #{{number}}",
 	"inspector.loadMoreReviews": "Mehr laden · {{count}} frühere",
 	"inspector.showLatestReviewOnly": "Nur neueste anzeigen",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -274,6 +274,7 @@
 	"inspector.sendToWorkerAgent": "Send to worker agent",
 	"inspector.sentToWorkerAgent": "Sent to worker agent",
 	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
+	"inspector.workerAgentWorkingOnFeedback": "Worker agent is working on this feedback",
 	"inspector.viewInFile": "View in file",
 	"inspector.commentNumber": "Comment #{{number}}",
 	"inspector.loadMoreReviews": "Load more · {{count}} earlier",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -276,6 +276,7 @@
 	"inspector.sendToWorkerAgentError": "Unable to send. Retry.",
 	"inspector.workerAgentWorkingOnFeedback": "Worker agent is working on this feedback",
 	"inspector.viewInFile": "View in file",
+	"inspector.viewInFileWorkInProgress": "Opening files in AO is a work in progress",
 	"inspector.commentNumber": "Comment #{{number}}",
 	"inspector.loadMoreReviews": "Load more · {{count}} earlier",
 	"inspector.showLatestReviewOnly": "Show latest only",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -277,6 +277,7 @@
 	"inspector.sendToWorkerAgent": "Enviar al agente worker",
 	"inspector.sentToWorkerAgent": "Enviado al agente worker",
 	"inspector.sendToWorkerAgentError": "No se pudo enviar. Inténtalo de nuevo.",
+	"inspector.workerAgentWorkingOnFeedback": "El agente worker está trabajando en estos comentarios",
 	"inspector.viewInFile": "Ver en archivo",
 	"inspector.commentNumber": "Comentario n.º {{number}}",
 	"inspector.loadMoreReviews": "Cargar más · {{count}} anteriores",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -279,6 +279,7 @@
 	"inspector.sendToWorkerAgentError": "No se pudo enviar. Inténtalo de nuevo.",
 	"inspector.workerAgentWorkingOnFeedback": "El agente worker está trabajando en estos comentarios",
 	"inspector.viewInFile": "Ver en archivo",
+	"inspector.viewInFileWorkInProgress": "La apertura de archivos en AO está en desarrollo",
 	"inspector.commentNumber": "Comentario n.º {{number}}",
 	"inspector.loadMoreReviews": "Cargar más · {{count}} anteriores",
 	"inspector.showLatestReviewOnly": "Mostrar solo la última",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -279,6 +279,7 @@
 	"inspector.sendToWorkerAgentError": "Impossible d’envoyer. Réessayez.",
 	"inspector.workerAgentWorkingOnFeedback": "L’agent worker traite ce retour",
 	"inspector.viewInFile": "Voir dans le fichier",
+	"inspector.viewInFileWorkInProgress": "L’ouverture de fichiers dans AO est en cours de développement",
 	"inspector.commentNumber": "Commentaire n° {{number}}",
 	"inspector.loadMoreReviews": "Charger plus · {{count}} précédents",
 	"inspector.showLatestReviewOnly": "Afficher seulement la dernière",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -277,6 +277,7 @@
 	"inspector.sendToWorkerAgent": "Envoyer à l’agent worker",
 	"inspector.sentToWorkerAgent": "Envoyé à l’agent worker",
 	"inspector.sendToWorkerAgentError": "Impossible d’envoyer. Réessayez.",
+	"inspector.workerAgentWorkingOnFeedback": "L’agent worker traite ce retour",
 	"inspector.viewInFile": "Voir dans le fichier",
 	"inspector.commentNumber": "Commentaire n° {{number}}",
 	"inspector.loadMoreReviews": "Charger plus · {{count}} précédents",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -275,6 +275,7 @@
 	"inspector.sendToWorkerAgent": "Worker エージェントに送信",
 	"inspector.sentToWorkerAgent": "Worker エージェントに送信済み",
 	"inspector.sendToWorkerAgentError": "送信できませんでした。再試行してください。",
+	"inspector.workerAgentWorkingOnFeedback": "Worker エージェントがこのフィードバックに対応中です",
 	"inspector.viewInFile": "ファイルで表示",
 	"inspector.commentNumber": "コメント #{{number}}",
 	"inspector.loadMoreReviews": "さらに読み込む · 過去 {{count}} 件",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -277,6 +277,7 @@
 	"inspector.sendToWorkerAgentError": "送信できませんでした。再試行してください。",
 	"inspector.workerAgentWorkingOnFeedback": "Worker エージェントがこのフィードバックに対応中です",
 	"inspector.viewInFile": "ファイルで表示",
+	"inspector.viewInFileWorkInProgress": "AO でファイルを開く機能は開発中です",
 	"inspector.commentNumber": "コメント #{{number}}",
 	"inspector.loadMoreReviews": "さらに読み込む · 過去 {{count}} 件",
 	"inspector.showLatestReviewOnly": "最新のみ表示",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -277,6 +277,7 @@
 	"inspector.sendToWorkerAgentError": "보낼 수 없습니다. 다시 시도하세요.",
 	"inspector.workerAgentWorkingOnFeedback": "Worker 에이전트가 이 피드백을 처리하고 있습니다",
 	"inspector.viewInFile": "파일에서 보기",
+	"inspector.viewInFileWorkInProgress": "AO에서 파일 열기 기능은 개발 중입니다",
 	"inspector.commentNumber": "댓글 #{{number}}",
 	"inspector.loadMoreReviews": "더 불러오기 · 이전 {{count}}개",
 	"inspector.showLatestReviewOnly": "최신 항목만 표시",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -275,6 +275,7 @@
 	"inspector.sendToWorkerAgent": "Worker 에이전트로 보내기",
 	"inspector.sentToWorkerAgent": "Worker 에이전트로 보냄",
 	"inspector.sendToWorkerAgentError": "보낼 수 없습니다. 다시 시도하세요.",
+	"inspector.workerAgentWorkingOnFeedback": "Worker 에이전트가 이 피드백을 처리하고 있습니다",
 	"inspector.viewInFile": "파일에서 보기",
 	"inspector.commentNumber": "댓글 #{{number}}",
 	"inspector.loadMoreReviews": "더 불러오기 · 이전 {{count}}개",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -277,6 +277,7 @@
 	"inspector.sendToWorkerAgent": "Enviar ao agente worker",
 	"inspector.sentToWorkerAgent": "Enviado ao agente worker",
 	"inspector.sendToWorkerAgentError": "Não foi possível enviar. Tente novamente.",
+	"inspector.workerAgentWorkingOnFeedback": "O agente worker está trabalhando neste feedback",
 	"inspector.viewInFile": "Ver no arquivo",
 	"inspector.commentNumber": "Comentário nº {{number}}",
 	"inspector.loadMoreReviews": "Carregar mais · {{count}} anteriores",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -279,6 +279,7 @@
 	"inspector.sendToWorkerAgentError": "Não foi possível enviar. Tente novamente.",
 	"inspector.workerAgentWorkingOnFeedback": "O agente worker está trabalhando neste feedback",
 	"inspector.viewInFile": "Ver no arquivo",
+	"inspector.viewInFileWorkInProgress": "A abertura de arquivos no AO está em desenvolvimento",
 	"inspector.commentNumber": "Comentário nº {{number}}",
 	"inspector.loadMoreReviews": "Carregar mais · {{count}} anteriores",
 	"inspector.showLatestReviewOnly": "Mostrar apenas a mais recente",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -276,6 +276,7 @@
 	"inspector.sendToWorkerAgentError": "无法发送。请重试。",
 	"inspector.workerAgentWorkingOnFeedback": "Worker 代理正在处理此反馈",
 	"inspector.viewInFile": "在文件中查看",
+	"inspector.viewInFileWorkInProgress": "AO 中打开文件的功能正在开发中",
 	"inspector.commentNumber": "评论 #{{number}}",
 	"inspector.loadMoreReviews": "加载更多 · 之前 {{count}} 条",
 	"inspector.showLatestReviewOnly": "仅显示最新一条",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -274,6 +274,7 @@
 	"inspector.sendToWorkerAgent": "发送给 Worker 代理",
 	"inspector.sentToWorkerAgent": "已发送给 Worker 代理",
 	"inspector.sendToWorkerAgentError": "无法发送。请重试。",
+	"inspector.workerAgentWorkingOnFeedback": "Worker 代理正在处理此反馈",
 	"inspector.viewInFile": "在文件中查看",
 	"inspector.commentNumber": "评论 #{{number}}",
 	"inspector.loadMoreReviews": "加载更多 · 之前 {{count}} 条",

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -708,7 +708,7 @@ describe("portable inspector presentations", () => {
         "text-success",
       );
     });
-    expect(screen.getAllByRole("link", { name: "View in file" })).toHaveLength(
+    expect(screen.getAllByRole("link", { name: "View on PR" })).toHaveLength(
       2,
     );
   });

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -261,8 +261,14 @@ describe("portable inspector presentations", () => {
 
     const row = screen.getByTestId("review-pr-row");
     expect(row).not.toHaveAttribute("aria-expanded");
-    expect(screen.getByText("Looks good.")).toBeInTheDocument();
+    expect(screen.queryByText("Looks good.")).not.toBeInTheDocument();
     expect(screen.queryByText("Ship it.")).not.toBeInTheDocument();
+    const agentReview = screen.getByRole("button", {
+      name: /codex.*Approved/,
+    });
+    expect(agentReview).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(agentReview);
+    expect(screen.getByText("Looks good.")).toBeInTheDocument();
     const externalReview = screen.getByRole("button", {
       name: /review-bot.*Approved/,
     });

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -494,6 +494,9 @@ describe("portable inspector presentations", () => {
       name: "Request to re-review PR",
     });
     expect(viewPR.className).toBe(rereview.className);
+    expect(viewPR.firstElementChild?.className).toBe(
+      rereview.firstElementChild?.className,
+    );
     fireEvent.click(
       rereview,
     );
@@ -720,8 +723,16 @@ describe("portable inspector presentations", () => {
         "text-success",
       );
     });
-    expect(screen.getAllByRole("link", { name: "View in file" })).toHaveLength(
+    const viewInFileButtons = screen.getAllByRole("button", {
+      name: "View in file",
+    });
+    expect(viewInFileButtons).toHaveLength(
       2,
+    );
+    expect(screen.queryByRole("link", { name: "View in file" })).not.toBeInTheDocument();
+    expect(viewInFileButtons[0]).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getAllByRole("tooltip")[0]).toHaveTextContent(
+      "Opening files in AO is a work in progress",
     );
     expect(screen.getAllByText("Sent to worker agent")[0]).toHaveAttribute(
       "title",
@@ -987,5 +998,6 @@ const reviewLabels: InspectorReviewLabels = {
   commentNumber: (number) => `Comment ${number}`,
   unresolvedCount: (count) => `${count} unresolved`,
   viewInFile: "View in file",
+  viewInFileWorkInProgress: "Opening files in AO is a work in progress",
   viewOnPR: "View on PR",
 };

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -280,9 +280,112 @@ describe("portable inspector presentations", () => {
     expect(githubSummary).toBeInTheDocument();
     expect(githubSummary).toHaveClass("select-text");
     expect(screen.queryByText("Not injected")).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "View on PR" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
+      "href",
+      "https://example.com/review",
+    );
     expect(renderAvatar).toHaveBeenCalledWith("codex");
     expect(renderMarkdown).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends an agent review to the worker and keeps its PR link alongside the action", async () => {
+    const onSendAgentReview = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InspectorReviewsView
+        externalLink={ExternalLink}
+        groups={[
+          {
+            ao: {
+              runs: [
+                {
+                  body: "Please cover the empty state.",
+                  createdAtLabel: "5m ago",
+                  harness: "codex",
+                  id: "run-1",
+                  status: "delivered",
+                  url: "https://example.com/review",
+                  verdict: { label: "Changes requested", tone: "danger" },
+                },
+              ],
+            },
+            meta: "#12 · 5m ago",
+            number: 12,
+            title: "Portable inspector",
+          },
+        ]}
+        isLoading={false}
+        labels={reviewLabels}
+        onSendAgentReview={onSendAgentReview}
+        renderAvatar={() => null}
+        renderMarkdown={(body) => <p>{body}</p>}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /codex.*Changes requested/ }),
+    );
+    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
+      "href",
+      "https://example.com/review",
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Send to worker agent" }),
+    );
+
+    await waitFor(() => {
+      expect(onSendAgentReview).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "run-1" }),
+      );
+      expect(screen.getByText("Sent to worker agent")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps the agent review send action available after a failure", async () => {
+    render(
+      <InspectorReviewsView
+        externalLink={ExternalLink}
+        groups={[
+          {
+            ao: {
+              runs: [
+                {
+                  body: "Please cover the empty state.",
+                  createdAtLabel: "5m ago",
+                  harness: "codex",
+                  id: "run-1",
+                  status: "delivered",
+                  verdict: { label: "Changes requested", tone: "danger" },
+                },
+              ],
+            },
+            meta: "#12 · 5m ago",
+            number: 12,
+            title: "Portable inspector",
+          },
+        ]}
+        isLoading={false}
+        labels={reviewLabels}
+        onSendAgentReview={vi.fn().mockRejectedValue(new Error("send failed"))}
+        renderAvatar={() => null}
+        renderMarkdown={(body) => <p>{body}</p>}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /codex.*Changes requested/ }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Send to worker agent" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Unable to send. Retry.")).toHaveClass(
+        "text-error",
+      ),
+    );
+    expect(
+      screen.getByRole("button", { name: "Send to worker agent" }),
+    ).toBeInTheDocument();
   });
 
   it("shows the newest GitHub review when history prepends", () => {

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -613,7 +613,7 @@ describe("portable inspector presentations", () => {
             github: {
               entries: [
                 {
-                  body: "Please address the inline notes before merge.",
+                  body: "This branch leaks the resize listener on unmount.",
                   id: "github-review-1",
                   reviewerId: "maya",
                   reviewUrl: "https://example.com/review",
@@ -687,6 +687,13 @@ describe("portable inspector presentations", () => {
     expect(
       screen.getByText("This branch leaks the resize listener on unmount."),
     ).toBeInTheDocument();
+    expect(
+      screen.getAllByText("This branch leaks the resize listener on unmount."),
+    ).toHaveLength(1);
+    expect(screen.getByRole("link", { name: "View on PR" })).toHaveAttribute(
+      "href",
+      "https://example.com/review",
+    );
     fireEvent.click(screen.getByRole("button", { name: "Show more" }));
     fireEvent.click(
       screen.getByRole("button", { name: "Send to worker agent" }),
@@ -708,8 +715,12 @@ describe("portable inspector presentations", () => {
         "text-success",
       );
     });
-    expect(screen.getAllByRole("link", { name: "View on PR" })).toHaveLength(
+    expect(screen.getAllByRole("link", { name: "View in file" })).toHaveLength(
       2,
+    );
+    expect(screen.getAllByText("Sent to worker agent")[0]).toHaveAttribute(
+      "title",
+      "Worker agent is working on this feedback",
     );
   });
 
@@ -964,6 +975,7 @@ const reviewLabels: InspectorReviewLabels = {
   sendToWorkerAgent: "Send to worker agent",
   sentToWorkerAgent: "Sent to worker agent",
   sendToWorkerAgentError: "Unable to send. Retry.",
+  workerAgentWorkingOnFeedback: "Worker agent is working on this feedback",
   showLatestReviewOnly: "Show latest only",
   showLess: "Show less",
   showMore: "Show more",

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -489,8 +489,13 @@ describe("portable inspector presentations", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /maya.*Changes requested/ }),
     );
+    const viewPR = screen.getByRole("link", { name: "View on PR" });
+    const rereview = screen.getByRole("button", {
+      name: "Request to re-review PR",
+    });
+    expect(viewPR.className).toBe(rereview.className);
     fireEvent.click(
-      screen.getByRole("button", { name: "Request to re-review PR" }),
+      rereview,
     );
 
     await waitFor(() => {

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -861,6 +861,9 @@ function GithubReviewHistory({
 	);
 }
 
+const reviewHeaderActionClass =
+	"inline-flex h-7 min-w-0 max-w-full items-center justify-center rounded-md border border-border-strong px-1.5 text-center text-micro font-medium tracking-tight text-muted-foreground no-underline transition-colors hover:bg-interactive-hover hover:text-foreground @max-[300px]/inspector:w-full";
+
 function ExternalReviewCard({
 	defaultOpen,
 	entry,
@@ -909,7 +912,7 @@ function ExternalReviewCard({
 					) : <span aria-hidden="true" />}
 					<div className="flex min-w-0 flex-wrap items-center justify-end gap-2 @max-[300px]/inspector:w-full">
 						{reviewUrl ? (
-							<ExternalLink className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground no-underline transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground" href={reviewUrl}>
+							<ExternalLink className={reviewHeaderActionClass} href={reviewUrl}>
 								{labels.viewOnPR}
 							</ExternalLink>
 						) : null}
@@ -921,7 +924,7 @@ function ExternalReviewCard({
 								</span>
 							) : (
 								<button
-									className="inline-flex h-7 min-w-0 max-w-full items-center justify-center rounded-md border border-border-strong px-1.5 text-center text-micro font-medium tracking-tight text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground @max-[300px]/inspector:w-full"
+									className={reviewHeaderActionClass}
 									onClick={async () => {
 										setRereviewError(false);
 										try {

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, type ReactNode, useEffect, useState } from "react";
+import { type KeyboardEvent, type ReactNode, useEffect, useId, useState } from "react";
 import type { ExternalLinkComponent } from "./external-link";
 import {
 	ArrowUpRightIcon,
@@ -484,6 +484,7 @@ export type InspectorReviewLabels = {
 	commentNumber: (number: number) => string;
 	unresolvedCount: (count: number) => string;
 	viewInFile: string;
+	viewInFileWorkInProgress: string;
 	viewOnPR: string;
 };
 
@@ -862,7 +863,33 @@ function GithubReviewHistory({
 }
 
 const reviewHeaderActionClass =
-	"inline-flex h-7 min-w-0 max-w-full items-center justify-center rounded-md border border-border-strong px-1.5 text-center text-micro font-medium tracking-tight text-muted-foreground no-underline transition-colors hover:bg-interactive-hover hover:text-foreground @max-[300px]/inspector:w-full";
+	"inline-flex h-7 min-w-0 max-w-full appearance-none items-center justify-center rounded-md border border-border-strong bg-transparent px-2 text-center text-muted-foreground no-underline transition-colors hover:bg-interactive-hover hover:text-foreground @max-[300px]/inspector:w-full";
+const reviewHeaderActionLabelClass = "whitespace-nowrap font-sans text-xs font-medium leading-none tracking-normal";
+
+function ReviewHeaderAction({
+	children,
+	externalLink: ExternalLink,
+	href,
+	onClick,
+}: {
+	children: string;
+	externalLink: ExternalLinkComponent;
+	href?: string;
+	onClick?: () => Promise<void> | void;
+}) {
+	if (href) {
+		return (
+			<ExternalLink className={reviewHeaderActionClass} href={href}>
+				<span className={reviewHeaderActionLabelClass}>{children}</span>
+			</ExternalLink>
+		);
+	}
+	return (
+		<button className={reviewHeaderActionClass} onClick={onClick} type="button">
+			<span className={reviewHeaderActionLabelClass}>{children}</span>
+		</button>
+	);
+}
 
 function ExternalReviewCard({
 	defaultOpen,
@@ -912,9 +939,9 @@ function ExternalReviewCard({
 					) : <span aria-hidden="true" />}
 					<div className="flex min-w-0 flex-wrap items-center justify-end gap-2 @max-[300px]/inspector:w-full">
 						{reviewUrl ? (
-							<ExternalLink className={reviewHeaderActionClass} href={reviewUrl}>
+							<ReviewHeaderAction externalLink={ExternalLink} href={reviewUrl}>
 								{labels.viewOnPR}
-							</ExternalLink>
+							</ReviewHeaderAction>
 						) : null}
 						{showRereviewAction ? (
 							rereviewRequested ? (
@@ -923,8 +950,8 @@ function ExternalReviewCard({
 									{labels.rereviewRequested}
 								</span>
 							) : (
-								<button
-									className={reviewHeaderActionClass}
+								<ReviewHeaderAction
+									externalLink={ExternalLink}
 									onClick={async () => {
 										setRereviewError(false);
 										try {
@@ -934,10 +961,9 @@ function ExternalReviewCard({
 											setRereviewError(true);
 										}
 									}}
-									type="button"
 								>
 									{labels.requestRereviewPR}
-								</button>
+								</ReviewHeaderAction>
 							)
 						) : null}
 					</div>
@@ -949,7 +975,6 @@ function ExternalReviewCard({
 			) : null}
 			{openInlineCount > 0 ? (
 				<GithubInlineComments
-					externalLink={ExternalLink}
 					labels={labels}
 					onSendInlineComment={onSendInlineComment}
 					onResolveInlineComment={onResolveInlineComment}
@@ -1027,14 +1052,12 @@ function ReviewEntryDisclosure({
 const RESOLVED_COMMENT_DISPLAY_MS = 1000;
 
 function GithubInlineComments({
-	externalLink: ExternalLink,
 	labels,
 	onResolveInlineComment,
 	onSendInlineComment,
 	reviewers,
 	showReviewer = true,
 }: {
-	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
@@ -1085,7 +1108,6 @@ function GithubInlineComments({
 					<InlineCommentRow
 						comment={comment}
 						commentNumber={index + 1}
-						externalLink={ExternalLink}
 						key={comment.id}
 						labels={labels}
 						onResolve={onResolveInlineComment ? async () => {
@@ -1146,7 +1168,6 @@ function GithubInlineComments({
 function InlineCommentRow({
 	comment,
 	commentNumber,
-	externalLink: ExternalLink,
 	labels,
 	onResolve,
 	onSend,
@@ -1159,7 +1180,6 @@ function InlineCommentRow({
 }: {
 	comment: InspectorInlineComment & { reviewerId?: string };
 	commentNumber: number;
-	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
 	onResolve?: () => void;
 	onSend?: () => void;
@@ -1171,6 +1191,7 @@ function InlineCommentRow({
 	sent: boolean;
 }) {
 	const body = comment.body?.trim();
+	const viewInFileTooltipId = useId();
 	return (
 		<div className="flex min-w-0 flex-col gap-2 px-0 py-4 text-xs first:pt-2 last:pb-0">
 			{showReviewer && comment.reviewerId ? (
@@ -1215,11 +1236,23 @@ function InlineCommentRow({
 						{labels.resolveComment}
 					</button>
 				)}
-				{comment.url ? (
-					<ExternalLink className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground no-underline transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground" href={comment.url}>
+				<span className="group relative inline-flex">
+					<button
+						aria-describedby={viewInFileTooltipId}
+						aria-disabled="true"
+						className="inline-flex h-7 cursor-help items-center rounded-md border border-border/70 bg-transparent px-2 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+						type="button"
+					>
 						{labels.viewInFile}
-					</ExternalLink>
-				) : null}
+					</button>
+					<span
+						className="pointer-events-none invisible absolute bottom-full left-1/2 z-overlay mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground opacity-0 shadow-md transition-opacity group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+						id={viewInFileTooltipId}
+						role="tooltip"
+					>
+						{labels.viewInFileWorkInProgress}
+					</span>
+				</span>
 			</div>
 			{sendError && !sent ? <p className="m-0 text-2xs font-medium text-error">{labels.sendToWorkerAgentError}</p> : null}
 			{resolveError && !resolved ? <p className="m-0 text-2xs font-medium text-error">{labels.resolveReviewFailed}</p> : null}

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -477,6 +477,7 @@ export type InspectorReviewLabels = {
 	sendToWorkerAgent: string;
 	sentToWorkerAgent: string;
 	sendToWorkerAgentError: string;
+	workerAgentWorkingOnFeedback: string;
 	showLatestReviewOnly: string;
 	showLess: string;
 	showMore: string;
@@ -863,7 +864,7 @@ function GithubReviewHistory({
 function ExternalReviewCard({
 	defaultOpen,
 	entry,
-	externalLink,
+	externalLink: ExternalLink,
 	labels,
 	onRequestRereview,
 	onResolveInlineComment,
@@ -884,6 +885,10 @@ function ExternalReviewCard({
 	const [rereviewError, setRereviewError] = useState(false);
 	const body = entry.body?.trim();
 	const inlineComments = entry.inlineComments ?? [];
+	const repeatedInlineBody = Boolean(
+		body && inlineComments.some((comment) => normalizedReviewText(comment.body) === normalizedReviewText(body)),
+	);
+	const reviewUrl = entry.reviewUrl || entry.pullRequestUrl;
 	const openInlineCount = inlineComments.filter((comment) => comment.body?.trim() || comment.file || comment.url).length;
 	const showRereviewAction = Boolean(onRequestRereview && (entry.canRequestRereview ?? entry.verdict.tone !== "success"));
 	return (
@@ -897,42 +902,51 @@ function ExternalReviewCard({
 			testId="github-review-card"
 			verdict={entry.verdict}
 		>
-			{showRereviewAction ? (
+			{showRereviewAction || reviewUrl ? (
 				<div className="flex min-w-0 flex-wrap items-center justify-between gap-2 border-y border-border/50 py-2 @max-[300px]/inspector:flex-col @max-[300px]/inspector:items-stretch">
 					{openInlineCount > 0 ? (
 						<span className="font-mono text-2xs font-semibold text-error">{labels.unresolvedCount(openInlineCount)}</span>
 					) : <span aria-hidden="true" />}
-					{rereviewRequested ? (
-						<span className="inline-flex h-control-md items-center gap-1.5 text-2xs font-medium text-success">
-							<CheckIcon className="size-icon-xs shrink-0" />
-							{labels.rereviewRequested}
-						</span>
-					) : (
-						<button
-							className="inline-flex h-7 min-w-0 max-w-full items-center justify-center rounded-md border border-border-strong px-1.5 text-center text-micro font-medium tracking-tight text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground @max-[300px]/inspector:w-full"
-							onClick={async () => {
-								setRereviewError(false);
-								try {
-									await onRequestRereview?.(entry);
-									setRereviewRequested(true);
-								} catch {
-									setRereviewError(true);
-								}
-							}}
-							type="button"
-						>
-							{labels.requestRereviewPR}
-						</button>
-					)}
+					<div className="flex min-w-0 flex-wrap items-center justify-end gap-2 @max-[300px]/inspector:w-full">
+						{reviewUrl ? (
+							<ExternalLink className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground no-underline transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground" href={reviewUrl}>
+								{labels.viewOnPR}
+							</ExternalLink>
+						) : null}
+						{showRereviewAction ? (
+							rereviewRequested ? (
+								<span className="inline-flex h-control-md items-center gap-1.5 text-2xs font-medium text-success">
+									<CheckIcon className="size-icon-xs shrink-0" />
+									{labels.rereviewRequested}
+								</span>
+							) : (
+								<button
+									className="inline-flex h-7 min-w-0 max-w-full items-center justify-center rounded-md border border-border-strong px-1.5 text-center text-micro font-medium tracking-tight text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground @max-[300px]/inspector:w-full"
+									onClick={async () => {
+										setRereviewError(false);
+										try {
+											await onRequestRereview?.(entry);
+											setRereviewRequested(true);
+										} catch {
+											setRereviewError(true);
+										}
+									}}
+									type="button"
+								>
+									{labels.requestRereviewPR}
+								</button>
+							)
+						) : null}
+					</div>
 				</div>
 			) : null}
 			{rereviewError ? <p className="m-0 text-2xs font-medium text-error">{labels.rereviewRequestFailed}</p> : null}
-			{body ? (
+			{body && !repeatedInlineBody ? (
 				<ReviewMarkdownBody body={body} clamped={false} renderMarkdown={renderMarkdown} testId="github-review-summary" />
 			) : null}
 			{openInlineCount > 0 ? (
 				<GithubInlineComments
-					externalLink={externalLink}
+					externalLink={ExternalLink}
 					labels={labels}
 					onSendInlineComment={onSendInlineComment}
 					onResolveInlineComment={onResolveInlineComment}
@@ -950,6 +964,10 @@ function ExternalReviewCard({
 			) : null}
 		</ReviewEntryDisclosure>
 	);
+}
+
+function normalizedReviewText(value: string | undefined): string {
+	return value?.trim().replace(/\s+/g, " ") ?? "";
 }
 
 function ReviewEntryDisclosure({
@@ -1165,7 +1183,7 @@ function InlineCommentRow({
 			{body ? <p className="m-0 max-w-prose whitespace-pre-wrap break-words leading-relaxed text-muted-foreground">{body}</p> : null}
 			<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 border-t border-border/50 pt-2 text-2xs">
 				{sent ? (
-					<span className="inline-flex h-control-md items-center gap-1.5 rounded-md px-1.5 font-medium text-muted-foreground [&_svg]:size-icon-xs">
+					<span className="inline-flex h-control-md items-center gap-1.5 rounded-md px-1.5 font-medium text-muted-foreground [&_svg]:size-icon-xs" title={labels.workerAgentWorkingOnFeedback}>
 						<CheckIcon className="shrink-0 text-success" />
 						{labels.sentToWorkerAgent}
 					</span>
@@ -1196,7 +1214,7 @@ function InlineCommentRow({
 				)}
 				{comment.url ? (
 					<ExternalLink className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground no-underline transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground" href={comment.url}>
-						{labels.viewOnPR}
+						{labels.viewInFile}
 					</ExternalLink>
 				) : null}
 			</div>
@@ -1282,7 +1300,7 @@ function ReviewSummaryCard({
 				<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 border-t border-border/50 pt-2 text-2xs">
 					{body && onSend ? (
 						sent ? (
-							<span className="inline-flex h-control-md items-center gap-1.5 rounded-md px-1.5 font-medium text-muted-foreground [&_svg]:size-icon-xs">
+							<span className="inline-flex h-control-md items-center gap-1.5 rounded-md px-1.5 font-medium text-muted-foreground [&_svg]:size-icon-xs" title={labels.workerAgentWorkingOnFeedback}>
 								<CheckIcon className="shrink-0 text-success" />
 								{labels.sentToWorkerAgent}
 							</span>

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -388,6 +388,7 @@ export type InspectorVerdict = {
 };
 
 export type InspectorReviewRun = {
+	autoInjectReview?: boolean;
 	body?: string;
 	createdAtLabel: string;
 	harness: string;
@@ -492,6 +493,7 @@ export function InspectorReviewsView({
 	labels,
 	onRequestRereview,
 	onResolveInlineComment,
+	onSendAgentReview,
 	onSendInlineComment,
 	renderAvatar,
 	renderMarkdown,
@@ -502,6 +504,7 @@ export function InspectorReviewsView({
 	labels: InspectorReviewLabels;
 	onRequestRereview?: (review: InspectorGithubReview) => Promise<void> | void;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
+	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
@@ -535,11 +538,13 @@ export function InspectorReviewsView({
 								</ReviewSourceLabel>
 								<ReviewRuns
 									dimmed={group.ao.dimmed}
+									externalLink={externalLink}
 									historical={group.ao.historical}
 									labels={labels}
 									renderAvatar={renderAvatar}
 									renderMarkdown={renderMarkdown}
 									runs={group.ao.runs}
+									onSendAgentReview={onSendAgentReview}
 								/>
 							</div>
 						) : null}
@@ -685,15 +690,19 @@ function ReviewDisclosure({
 
 function ReviewRuns({
 	dimmed,
+	externalLink,
 	historical,
 	labels,
+	onSendAgentReview,
 	renderAvatar,
 	renderMarkdown,
 	runs,
 }: {
 	dimmed?: boolean;
+	externalLink: ExternalLinkComponent;
 	historical?: boolean;
 	labels: InspectorReviewLabels;
+	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 	runs: InspectorReviewRun[];
@@ -704,8 +713,10 @@ function ReviewRuns({
 	return (
 		<ReviewRunHistory
 			dimmed={dimmed}
+			externalLink={externalLink}
 			historical={historical}
 			labels={labels}
+			onSendAgentReview={onSendAgentReview}
 			renderAvatar={renderAvatar}
 			renderMarkdown={renderMarkdown}
 			runs={runs}
@@ -715,15 +726,19 @@ function ReviewRuns({
 
 function ReviewRunHistory({
 	dimmed,
+	externalLink,
 	historical,
 	labels,
+	onSendAgentReview,
 	renderAvatar,
 	renderMarkdown,
 	runs,
 }: {
 	dimmed?: boolean;
+	externalLink: ExternalLinkComponent;
 	historical?: boolean;
 	labels: InspectorReviewLabels;
+	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 	runs: InspectorReviewRun[];
@@ -738,14 +753,18 @@ function ReviewRunHistory({
 			{visible.map((run, index) => (
 				<ReviewSummaryCard
 					actor={run.harness || "reviewer"}
+					autoInjected={run.autoInjectReview}
 					body={run.status === "cancelled" || run.status === "failed" ? "" : run.body}
+					externalLink={externalLink}
 					isEarlier={historical || index > 0}
 					key={run.id}
 					labels={labels}
+					onSend={onSendAgentReview ? () => onSendAgentReview(run) : undefined}
 					renderAvatar={renderAvatar}
 					renderMarkdown={renderMarkdown}
 					testId="review-run-summary"
 					timestamp={run.createdAtLabel}
+					url={run.url}
 					verdict={run.verdict}
 				/>
 			))}
@@ -1189,29 +1208,43 @@ function InlineCommentRow({
 
 function ReviewSummaryCard({
 	actor,
+	autoInjected = false,
 	body: rawBody,
+	externalLink: ExternalLink,
 	isBot = false,
 	isEarlier = false,
 	labels,
+	onSend,
 	renderAvatar,
 	renderMarkdown,
 	testId,
 	timestamp,
+	url,
 	verdict,
 }: {
 	actor: string;
+	autoInjected?: boolean;
 	body?: string;
+	externalLink: ExternalLinkComponent;
 	isBot?: boolean;
 	isEarlier?: boolean;
 	labels: InspectorReviewLabels;
+	onSend?: () => Promise<void> | void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 	testId: string;
 	timestamp: string;
+	url?: string | null;
 	verdict: InspectorVerdict;
 }) {
 	const [open, setOpen] = useState(false);
 	const [expanded, setExpanded] = useState(false);
+	const [sent, setSent] = useState(autoInjected);
+	const [sending, setSending] = useState(false);
+	const [sendError, setSendError] = useState(false);
+	useEffect(() => {
+		if (autoInjected) setSent(true);
+	}, [autoInjected]);
 	const trimmed = rawBody?.trim();
 	const body = trimmed ? trimmed.replace(/\n{3,}/g, "\n\n") : trimmed;
 	const clamped = body ? isClampedSummary(body) : false;
@@ -1245,6 +1278,44 @@ function ReviewSummaryCard({
 				labels={labels}
 				onExpandedChange={() => setExpanded((open) => !open)}
 			/>
+			{body || url ? (
+				<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 border-t border-border/50 pt-2 text-2xs">
+					{body && onSend ? (
+						sent ? (
+							<span className="inline-flex h-control-md items-center gap-1.5 rounded-md px-1.5 font-medium text-muted-foreground [&_svg]:size-icon-xs">
+								<CheckIcon className="shrink-0 text-success" />
+								{labels.sentToWorkerAgent}
+							</span>
+						) : (
+							<button
+								className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-60"
+								disabled={sending}
+								onClick={async () => {
+									setSending(true);
+									setSendError(false);
+									try {
+										await onSend();
+										setSent(true);
+									} catch {
+										setSendError(true);
+									} finally {
+										setSending(false);
+									}
+								}}
+								type="button"
+							>
+								{labels.sendToWorkerAgent}
+							</button>
+						)
+					) : null}
+					{url ? (
+						<ExternalLink className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground no-underline transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground" href={url}>
+							{labels.viewOnPR}
+						</ExternalLink>
+					) : null}
+				</div>
+			) : null}
+			{sendError && !sent ? <p className="m-0 text-2xs font-medium text-error">{labels.sendToWorkerAgentError}</p> : null}
 		</ReviewEntryDisclosure>
 	);
 }

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -1196,7 +1196,7 @@ function InlineCommentRow({
 				)}
 				{comment.url ? (
 					<ExternalLink className="inline-flex h-7 items-center rounded-md border border-border/70 px-2 text-2xs font-medium text-muted-foreground no-underline transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground" href={comment.url}>
-						{labels.viewInFile}
+						{labels.viewOnPR}
 					</ExternalLink>
 				) : null}
 			</div>

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -868,83 +868,118 @@ function ExternalReviewCard({
 	const openInlineCount = inlineComments.filter((comment) => comment.body?.trim() || comment.file || comment.url).length;
 	const showRereviewAction = Boolean(onRequestRereview && (entry.canRequestRereview ?? entry.verdict.tone !== "success"));
 	return (
-		<article className="min-w-0 border-b border-border/70 py-3 first:pt-0 last:border-b-0 last:pb-0" data-testid="github-review-card">
+		<ReviewEntryDisclosure
+			actor={entry.reviewerId}
+			avatar={<GithubAvatar className="size-5" login={entry.reviewerId} />}
+			botLabel={entry.isBot ? labels.bot : undefined}
+			meta={entry.submittedAtLabel ? labels.reviewedAt(entry.submittedAtLabel) : undefined}
+			onOpenChange={setOpen}
+			open={open}
+			testId="github-review-card"
+			verdict={entry.verdict}
+		>
+			{showRereviewAction ? (
+				<div className="flex min-w-0 flex-wrap items-center justify-between gap-2 border-y border-border/50 py-2 @max-[300px]/inspector:flex-col @max-[300px]/inspector:items-stretch">
+					{openInlineCount > 0 ? (
+						<span className="font-mono text-2xs font-semibold text-error">{labels.unresolvedCount(openInlineCount)}</span>
+					) : <span aria-hidden="true" />}
+					{rereviewRequested ? (
+						<span className="inline-flex h-control-md items-center gap-1.5 text-2xs font-medium text-success">
+							<CheckIcon className="size-icon-xs shrink-0" />
+							{labels.rereviewRequested}
+						</span>
+					) : (
+						<button
+							className="inline-flex h-7 min-w-0 max-w-full items-center justify-center rounded-md border border-border-strong px-1.5 text-center text-micro font-medium tracking-tight text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground @max-[300px]/inspector:w-full"
+							onClick={async () => {
+								setRereviewError(false);
+								try {
+									await onRequestRereview?.(entry);
+									setRereviewRequested(true);
+								} catch {
+									setRereviewError(true);
+								}
+							}}
+							type="button"
+						>
+							{labels.requestRereviewPR}
+						</button>
+					)}
+				</div>
+			) : null}
+			{rereviewError ? <p className="m-0 text-2xs font-medium text-error">{labels.rereviewRequestFailed}</p> : null}
+			{body ? (
+				<ReviewMarkdownBody body={body} clamped={false} renderMarkdown={renderMarkdown} testId="github-review-summary" />
+			) : null}
+			{openInlineCount > 0 ? (
+				<GithubInlineComments
+					externalLink={externalLink}
+					labels={labels}
+					onSendInlineComment={onSendInlineComment}
+					onResolveInlineComment={onResolveInlineComment}
+					reviewers={[
+						{
+							count: openInlineCount,
+							isBot: entry.isBot,
+							links: inlineComments,
+							reviewerId: entry.reviewerId,
+							reviewUrl: entry.reviewUrl,
+						},
+					]}
+					showReviewer={false}
+				/>
+			) : null}
+		</ReviewEntryDisclosure>
+	);
+}
+
+function ReviewEntryDisclosure({
+	actor,
+	avatar,
+	botLabel,
+	children,
+	meta,
+	onOpenChange,
+	open,
+	testId,
+	verdict,
+}: {
+	actor: string;
+	avatar: ReactNode;
+	botLabel?: string;
+	children: ReactNode;
+	meta?: ReactNode;
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+	testId: string;
+	verdict: InspectorVerdict;
+}) {
+	return (
+		<article className="min-w-0 border-b border-border/70 py-3 first:pt-0 last:border-b-0 last:pb-0" data-testid={testId}>
 			<button
 				aria-expanded={open}
 				className="flex w-full min-w-0 items-start gap-2 rounded-md px-1 py-1 text-left transition-colors hover:bg-interactive-hover/30"
-				onClick={() => setOpen((current) => !current)}
+				onClick={() => onOpenChange(!open)}
 				type="button"
 			>
 				<ChevronIcon className="mt-0.5 size-icon-2xs shrink-0 text-passive" direction={open ? "down" : "right"} />
 				<span className="flex min-w-0 flex-1 flex-col gap-0.5">
 					<span className="flex min-w-0 items-center gap-1.5">
 						<span className="inline-flex min-w-0 items-center gap-1 text-xs font-semibold text-foreground">
-							<GithubAvatar className="size-5" login={entry.reviewerId} />
-							<span className="truncate">{entry.reviewerId}</span>
+							{avatar}
+							<span className="truncate">{actor}</span>
 						</span>
-						{entry.isBot ? <span className="shrink-0 font-mono text-micro text-passive">{labels.bot}</span> : null}
+						{botLabel ? <span className="shrink-0 font-mono text-micro text-passive">{botLabel}</span> : null}
 					</span>
-					<span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 font-mono text-micro text-passive">
-						{entry.submittedAtLabel ? <span>{labels.reviewedAt(entry.submittedAtLabel)}</span> : null}
-					</span>
+					{meta ? (
+						<span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 font-mono text-micro text-passive">
+							{meta}
+						</span>
+					) : null}
 				</span>
-				<VerdictBadge verdict={entry.verdict} />
+				<VerdictBadge verdict={verdict} />
 			</button>
-			{open ? (
-				<div className="flex min-w-0 flex-col gap-3 px-1 pt-3">
-					{showRereviewAction ? (
-						<div className="flex min-w-0 flex-wrap items-center justify-between gap-2 border-y border-border/50 py-2 @max-[300px]/inspector:flex-col @max-[300px]/inspector:items-stretch">
-							{openInlineCount > 0 ? (
-								<span className="font-mono text-2xs font-semibold text-error">{labels.unresolvedCount(openInlineCount)}</span>
-							) : <span aria-hidden="true" />}
-							{rereviewRequested ? (
-								<span className="inline-flex h-control-md items-center gap-1.5 text-2xs font-medium text-success">
-									<CheckIcon className="size-icon-xs shrink-0" />
-									{labels.rereviewRequested}
-								</span>
-							) : (
-								<button
-									className="inline-flex h-7 min-w-0 max-w-full items-center justify-center rounded-md border border-border-strong px-1.5 text-center text-micro font-medium tracking-tight text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground @max-[300px]/inspector:w-full"
-									onClick={async () => {
-										setRereviewError(false);
-										try {
-											await onRequestRereview?.(entry);
-											setRereviewRequested(true);
-										} catch {
-											setRereviewError(true);
-										}
-									}}
-									type="button"
-								>
-									{labels.requestRereviewPR}
-								</button>
-							)}
-						</div>
-					) : null}
-					{rereviewError ? <p className="m-0 text-2xs font-medium text-error">{labels.rereviewRequestFailed}</p> : null}
-					{body ? (
-						<ReviewMarkdownBody body={body} clamped={false} renderMarkdown={renderMarkdown} testId="github-review-summary" />
-					) : null}
-					{openInlineCount > 0 ? (
-						<GithubInlineComments
-							externalLink={externalLink}
-							labels={labels}
-							onSendInlineComment={onSendInlineComment}
-							onResolveInlineComment={onResolveInlineComment}
-							reviewers={[
-								{
-									count: openInlineCount,
-									isBot: entry.isBot,
-									links: inlineComments,
-									reviewerId: entry.reviewerId,
-									reviewUrl: entry.reviewUrl,
-								},
-							]}
-							showReviewer={false}
-						/>
-					) : null}
-				</div>
-			) : null}
+			{open ? <div className="flex min-w-0 flex-col gap-3 px-1 pt-3">{children}</div> : null}
 		</article>
 	);
 }
@@ -1175,24 +1210,27 @@ function ReviewSummaryCard({
 	timestamp: string;
 	verdict: InspectorVerdict;
 }) {
+	const [open, setOpen] = useState(false);
 	const [expanded, setExpanded] = useState(false);
 	const trimmed = rawBody?.trim();
 	const body = trimmed ? trimmed.replace(/\n{3,}/g, "\n\n") : trimmed;
 	const clamped = body ? isClampedSummary(body) : false;
 	return (
-		<article className="flex min-w-0 flex-col gap-1 rounded-md bg-overlay/50 px-2.5 py-2.5">
-			<span className="flex min-w-0 items-center gap-1.5">
-				<span className="inline-flex min-w-0 items-center gap-1 text-micro font-medium text-muted-foreground">
-					{renderAvatar(actor)}
-					<span className="truncate">{actor}</span>
-				</span>
-				{isBot ? <span className="shrink-0 font-mono text-micro text-passive">{labels.bot}</span> : null}
-				<VerdictBadge verdict={verdict} />
-				<span className="ml-auto inline-flex shrink-0 items-center gap-1.5 text-micro text-passive">
+		<ReviewEntryDisclosure
+			actor={actor}
+			avatar={renderAvatar(actor)}
+			botLabel={isBot ? labels.bot : undefined}
+			meta={
+				<>
 					{isEarlier ? <span>{labels.earlierPass}</span> : null}
-					<span className="font-mono">{timestamp}</span>
-				</span>
-			</span>
+					<span>{timestamp}</span>
+				</>
+			}
+			onOpenChange={setOpen}
+			open={open}
+			testId="agent-review-card"
+			verdict={verdict}
+		>
 			{body ? (
 				<ReviewMarkdownBody
 					body={body}
@@ -1207,7 +1245,7 @@ function ReviewSummaryCard({
 				labels={labels}
 				onExpandedChange={() => setExpanded((open) => !open)}
 			/>
-		</article>
+		</ReviewEntryDisclosure>
 	);
 }
 


### PR DESCRIPTION
## Summary

- use one disclosure-row presentation for agent and external reviews
- add agent-review actions to send the full summary to the worker and open the posted GitHub review
- preserve sent, loading, and failure states while keeping review history behavior intact
- update product UI and desktop inspector coverage for the shared design and actions

Before
<img width="750" height="1103" alt="image" src="https://github.com/user-attachments/assets/22310585-e620-48c5-a5df-fb2b8dd689e9" />

-----------------------------------



After
<img width="780" height="813" alt="image" src="https://github.com/user-attachments/assets/ba38107c-2ab9-42b8-8e49-3252ab3d302f" />
<img width="780" height="813" alt="image" src="https://github.com/user-attachments/assets/e736493d-3f9f-423b-ad86-3193b07a9f12" />
<img width="780" height="813" alt="image" src="https://github.com/user-attachments/assets/620f003f-4932-4a6e-8a5f-58f820cbce6b" />
<img width="780" height="813" alt="image" src="https://github.com/user-attachments/assets/6b296e02-0c07-41a8-9c23-686ae146ae1a" />
<img width="780" height="813" alt="image" src="https://github.com/user-attachments/assets/51d2a73f-2b4f-4847-ae25-34802e96a71d" />
<img width="473" height="1192" alt="image" src="https://github.com/user-attachments/assets/aadab95b-5819-4ff6-8863-0a0546cb4940" />


## Testing

- `npm test -- SessionInspectorView.test.tsx` in `packages/product-ui` (15 passed)
- `npx vitest run --config vite.renderer.config.ts SessionInspector.test.tsx --reporter=json` in `frontend` (93 passed)
- `npm run typecheck` in both packages
- `git diff --check`