### PR TITLE
Open review comments in Files

### DIFF
--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -243,6 +243,35 @@ describe("SessionFilesView", () => {
 		});
 	});
 
+	it("opens a requested review-comment file without highlighting when no line is available", async () => {
+		renderWithQuery(
+			<SessionFilesView
+				navigationTarget={{ path: "src/App.tsx", requestId: 1 }}
+				sessionId="sess-1"
+			/>,
+		);
+
+		expect(await screen.findByRole("button", { name: "Collapse src/App.tsx" })).toBeInTheDocument();
+		const code = await screen.findByText(diffLine("const value = 1;"));
+		expect(code.closest("[data-diff-row]")).not.toHaveClass("outline-accent/70");
+	});
+
+	it("leaves the file list unchanged when a review comment names an unavailable file", async () => {
+		renderWithQuery(
+			<SessionFilesView
+				navigationTarget={{ path: "src/missing.ts", line: 7, requestId: 1 }}
+				sessionId="sess-1"
+			/>,
+		);
+
+		expect(await screen.findByRole("button", { name: "Expand src/App.tsx" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Expand docs/guide.md" })).toBeInTheDocument();
+		expect(getMock).not.toHaveBeenCalledWith(
+			"/api/v1/sessions/{sessionId}/workspace/file",
+			expect.anything(),
+		);
+	});
+
 	it("filters and expands a changed file from the review list", async () => {
 		renderWithQuery(<SessionFilesView sessionId="sess-1" />);
 
@@ -310,10 +339,21 @@ describe("SessionFilesView", () => {
 			};
 		});
 
-		renderWithQuery(<SessionFilesView sessionId="sess-1" />);
+		renderWithQuery(
+			<SessionFilesView
+				navigationTarget={{ path: "src/OldName.tsx", requestId: 1 }}
+				sessionId="sess-1"
+			/>,
+		);
 
 		expect(await screen.findByText("src/OldName.tsx")).toBeInTheDocument();
 		expect(screen.getByText("src/NewName.tsx")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Collapse src/OldName.tsx -> src/NewName.tsx" })).toBeInTheDocument();
+		await waitFor(() =>
+			expect(getMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/workspace/file", {
+				params: { path: { sessionId: "sess-1" }, query: { path: "src/NewName.tsx" } },
+			}),
+		);
 	});
 
 	it("reports HEAD fallback when no base comparison is available", async () => {

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -227,6 +227,22 @@ describe("SessionFilesView", () => {
 		expect(await screen.findByText(diffLine("const value = 1;"))).toBeInTheDocument();
 	});
 
+	it("opens and highlights a requested review-comment line", async () => {
+		renderWithQuery(
+			<SessionFilesView
+				navigationTarget={{ path: "src/App.tsx", line: 1, requestId: 1 }}
+				sessionId="sess-1"
+			/>,
+		);
+
+		expect(await screen.findByRole("button", { name: "Collapse src/App.tsx" })).toBeInTheDocument();
+		const code = await screen.findByText(diffLine("const value = 1;"));
+		expect(code.closest("[data-diff-row]")).toHaveClass("outline-accent/70");
+		expect(getMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/workspace/file", {
+			params: { path: { sessionId: "sess-1" }, query: { path: "src/App.tsx" } },
+		});
+	});
+
 	it("filters and expands a changed file from the review list", async () => {
 		renderWithQuery(<SessionFilesView sessionId="sess-1" />);
 

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -69,7 +69,14 @@ type FileAnnotationModel = {
 type SessionFilesViewProps = {
 	sessionId: string;
 	isMaximized?: boolean;
+	navigationTarget?: SessionFilesNavigationTarget | null;
 	onToggleMaximized?: (next: boolean) => void;
+};
+
+export type SessionFilesNavigationTarget = {
+	path: string;
+	line?: number;
+	requestId: number;
 };
 
 const emptyFiles: WorkspaceFileSummary[] = [];
@@ -101,6 +108,7 @@ function canSplitCompare(status: WorkspaceFileStatus): boolean {
 export function SessionFilesView({
 	sessionId,
 	isMaximized = false,
+	navigationTarget,
 	onToggleMaximized,
 }: SessionFilesViewProps) {
 	const { t } = useTranslation();
@@ -120,6 +128,15 @@ export function SessionFilesView({
 	useEffect(() => subscribeWorkspaceFileChanges(sessionId, queryClient), [queryClient, sessionId]);
 	const files = filesQuery.data?.files ?? emptyFiles;
 	const changedFiles = useMemo(() => files.filter(isChangedWorkspaceFile), [files]);
+	const navigationFile = useMemo(
+		() =>
+			navigationTarget
+				? changedFiles.find(
+						(file) => file.path === navigationTarget.path || file.previousPath === navigationTarget.path,
+					)
+				: undefined,
+		[changedFiles, navigationTarget],
+	);
 
 	useEffect(() => {
 		annotationGenerationRef.current += 1;
@@ -130,6 +147,23 @@ export function SessionFilesView({
 		setAnnotationStatus("idle");
 		setAnnotationError("");
 	}, [sessionId]);
+
+	useEffect(() => {
+		if (!navigationTarget || !navigationFile) return;
+		setFilter("");
+		setExpandedPaths((current) => {
+			if (current.has(navigationFile.path)) return current;
+			const next = new Set(current);
+			next.add(navigationFile.path);
+			return next;
+		});
+		const frame = window.requestAnimationFrame(() => {
+			const fileRow = Array.from(rootRef.current?.querySelectorAll<HTMLElement>("[data-workspace-file-path]") ?? [])
+				.find((row) => row.dataset.workspaceFilePath === navigationFile.path);
+			fileRow?.scrollIntoView?.({ block: "start", inline: "nearest" });
+		});
+		return () => window.cancelAnimationFrame(frame);
+	}, [navigationFile, navigationTarget]);
 
 	useEffect(
 		() => () => {
@@ -336,6 +370,7 @@ export function SessionFilesView({
 						expandedPaths={expandedPaths}
 						files={visibleFiles}
 						isLoading={filesQuery.isPending}
+						navigationTarget={navigationTarget}
 						onExpandedPathsChange={setExpandedPaths}
 						onRetry={() => void filesQuery.refetch()}
 						sessionId={sessionId}
@@ -355,6 +390,7 @@ function ReviewFileList({
 	expandedPaths,
 	files,
 	isLoading,
+	navigationTarget,
 	onExpandedPathsChange,
 	onRetry,
 	sessionId,
@@ -367,6 +403,7 @@ function ReviewFileList({
 	expandedPaths: Set<string>;
 	files: WorkspaceFileSummary[];
 	isLoading: boolean;
+	navigationTarget?: SessionFilesNavigationTarget | null;
 	onExpandedPathsChange: (next: Set<string>) => void;
 	onRetry: () => void;
 	sessionId: string;
@@ -399,6 +436,12 @@ function ReviewFileList({
 						expanded={expandedPaths.has(file.path)}
 						file={file}
 						key={file.path}
+						navigationTarget={
+							navigationTarget &&
+							(file.path === navigationTarget.path || file.previousPath === navigationTarget.path)
+								? navigationTarget
+								: undefined
+						}
 						sessionId={sessionId}
 						split={split}
 						wrap={wrap}
@@ -413,6 +456,7 @@ function ReviewFileCard({
 	annotation,
 	expanded,
 	file,
+	navigationTarget,
 	sessionId,
 	split,
 	wrap,
@@ -420,6 +464,7 @@ function ReviewFileCard({
 	annotation: FileAnnotationModel;
 	expanded: boolean;
 	file: WorkspaceFileSummary;
+	navigationTarget?: SessionFilesNavigationTarget;
 	sessionId: string;
 	split: boolean;
 	wrap: boolean;
@@ -437,7 +482,7 @@ function ReviewFileCard({
 
 	return (
 		<AccordionItem asChild value={file.path}>
-			<li className="session-files-review-row overflow-hidden bg-transparent">
+			<li className="session-files-review-row overflow-hidden bg-transparent" data-workspace-file-path={file.path}>
 				<AccordionTrigger
 					aria-label={t(expanded ? "files.collapseFile" : "files.expandFile", { file: fileLabel(file) })}
 					className="flex min-w-0 flex-1 items-center gap-1.5 px-2.5 py-1 text-left"
@@ -475,6 +520,7 @@ function ReviewFileCard({
 							annotation={annotation}
 							detail={detailQuery.data}
 							filePath={file.path}
+							navigationTarget={navigationTarget}
 							onActiveSelectionChange={setSelectionOrMenuActive}
 							sessionId={sessionId}
 							split={split && canSplitCompare(file.status)}
@@ -547,6 +593,7 @@ function ReviewDiffBody({
 	annotation,
 	detail,
 	filePath,
+	navigationTarget,
 	onActiveSelectionChange,
 	sessionId,
 	split,
@@ -555,6 +602,7 @@ function ReviewDiffBody({
 	annotation: FileAnnotationModel;
 	detail: WorkspaceFileDetail;
 	filePath: string;
+	navigationTarget?: SessionFilesNavigationTarget;
 	onActiveSelectionChange: (active: boolean) => void;
 	sessionId: string;
 	split: boolean;
@@ -575,6 +623,7 @@ function ReviewDiffBody({
 		<DiffView
 			annotation={annotation}
 			filePath={filePath}
+			navigationTarget={navigationTarget}
 			onActiveSelectionChange={onActiveSelectionChange}
 			path={detail.path}
 			previousPath={detail.previousPath}
@@ -720,6 +769,7 @@ function useSharedScrollRowVirtualizer(
 function DiffView({
 	annotation,
 	filePath,
+	navigationTarget,
 	onActiveSelectionChange,
 	path,
 	previousPath,
@@ -731,6 +781,7 @@ function DiffView({
 }: {
 	annotation: FileAnnotationModel;
 	filePath: string;
+	navigationTarget?: SessionFilesNavigationTarget;
 	onActiveSelectionChange: (active: boolean) => void;
 	path: string;
 	previousPath?: string;
@@ -746,6 +797,24 @@ function DiffView({
 	const [menuState, setMenuState] = useState<DiffViewMenuState | null>(null);
 	const shouldVirtualize = !split && rows.length > ROW_VIRTUALIZE_THRESHOLD;
 	const { listRef, virtualizer } = useSharedScrollRowVirtualizer(containerRef, rows.length, shouldVirtualize);
+	const targetRowIndex = useMemo(() => {
+		const line = navigationTarget?.line;
+		if (line === undefined) return -1;
+		const newLineIndex = rows.findIndex((row) => row.kind !== "hunk" && row.newNo === line);
+		if (newLineIndex >= 0) return newLineIndex;
+		return rows.findIndex((row) => row.kind !== "hunk" && row.oldNo === line);
+	}, [navigationTarget, rows]);
+
+	useEffect(() => {
+		if (!navigationTarget || targetRowIndex < 0) return;
+		if (shouldVirtualize) virtualizer.scrollToIndex(targetRowIndex, { align: "center" });
+		const frame = window.requestAnimationFrame(() => {
+			const targetRow = Array.from(containerRef.current?.querySelectorAll<HTMLElement>("[data-diff-row]") ?? [])
+				.find((row) => row.dataset.rowIndex === String(targetRowIndex));
+			targetRow?.scrollIntoView?.({ block: "center", inline: "nearest" });
+		});
+		return () => window.cancelAnimationFrame(frame);
+	}, [navigationTarget, shouldVirtualize, targetRowIndex, virtualizer]);
 
 	useEffect(() => {
 		const onSelectionChange = () => {
@@ -810,7 +879,7 @@ function DiffView({
 				ref={containerRef}
 			>
 				{split ? (
-					<SplitDiff annotation={annotation} path={path} previousPath={previousPath} rows={rows} t={t} />
+					<SplitDiff annotation={annotation} path={path} previousPath={previousPath} rows={rows} t={t} targetRowIndex={targetRowIndex} />
 				) : shouldVirtualize ? (
 					<div
 						className={cn("relative", !wrap && "min-w-max")}
@@ -838,6 +907,7 @@ function DiffView({
 										path={path}
 										previousPath={previousPath}
 										row={row}
+										targeted={virtualRow.index === targetRowIndex}
 										t={t}
 										wrap={wrap}
 									/>
@@ -855,6 +925,7 @@ function DiffView({
 								path={path}
 								previousPath={previousPath}
 								row={row}
+								targeted={index === targetRowIndex}
 								t={t}
 								wrap={wrap}
 							/>
@@ -890,18 +961,23 @@ type DiffRowContentProps = {
 	path: string;
 	previousPath?: string;
 	row: DiffRow;
+	targeted: boolean;
 	t: TFunction;
 	wrap: boolean;
 };
 
 // One unified-view diff row, shared between the plain (non-virtualized) and
 // virtualized render paths so they can't drift apart from each other.
-function DiffRowContentInner({ annotation, index, path, previousPath, row, t, wrap }: DiffRowContentProps) {
+function DiffRowContentInner({ annotation, index, path, previousPath, row, targeted, t, wrap }: DiffRowContentProps) {
 	if (row.kind === "hunk") return <HunkBand row={row} />;
 	return (
 		<div>
 			<div
-				className={cn("group/line relative flex", diffRowTone[row.kind])}
+				className={cn(
+					"group/line relative flex",
+					diffRowTone[row.kind],
+					targeted && "outline outline-1 -outline-offset-1 outline-accent/70",
+				)}
 				data-diff-row=""
 				data-kind={row.kind}
 				data-new-no={row.newNo ?? ""}
@@ -951,6 +1027,7 @@ const DiffRowContent = memo(DiffRowContentInner, (prev, next) => {
 		prev.index !== next.index ||
 		prev.path !== next.path ||
 		prev.previousPath !== next.previousPath ||
+		prev.targeted !== next.targeted ||
 		prev.wrap !== next.wrap
 	) {
 		return false;
@@ -1011,12 +1088,14 @@ function SplitDiff({
 	previousPath,
 	rows,
 	t,
+	targetRowIndex,
 }: {
 	annotation: FileAnnotationModel;
 	path: string;
 	previousPath?: string;
 	rows: DiffRow[];
 	t: TFunction;
+	targetRowIndex: number;
 }) {
 	const splitRows = useMemo(() => toSplitRows(rows), [rows]);
 	return (
@@ -1035,6 +1114,7 @@ function SplitDiff({
 								rowIndex={splitRow.leftIndex}
 								side="old"
 								t={t}
+								targeted={splitRow.leftIndex === targetRowIndex}
 							/>
 							<SplitSide
 								annotation={annotation}
@@ -1044,6 +1124,7 @@ function SplitDiff({
 								rowIndex={splitRow.rightIndex}
 								side="new"
 								t={t}
+								targeted={splitRow.rightIndex === targetRowIndex}
 							/>
 						</div>
 						{(splitRow.leftIndex !== null && isAnnotationRow(annotation.target, path, splitRow.leftIndex)) ||
@@ -1065,6 +1146,7 @@ function SplitSide({
 	rowIndex,
 	side,
 	t,
+	targeted,
 }: {
 	annotation: FileAnnotationModel;
 	path: string;
@@ -1073,6 +1155,7 @@ function SplitSide({
 	rowIndex: number | null;
 	side: "old" | "new";
 	t: TFunction;
+	targeted: boolean;
 }) {
 	if (!row || rowIndex === null) return <div className="bg-surface-faint/20" aria-hidden="true" />;
 	const lineNo = side === "old" ? row.oldNo : row.newNo;
@@ -1080,7 +1163,11 @@ function SplitSide({
 	const target = lineNo == null ? null : lineAnnotationTarget(path, previousPath, row, rowIndex, side);
 	return (
 		<div
-			className={cn("group/line relative flex min-w-0", tone)}
+			className={cn(
+				"group/line relative flex min-w-0",
+				tone,
+				targeted && "outline outline-1 -outline-offset-1 outline-accent/70",
+			)}
 			data-diff-row=""
 			data-kind={row.kind}
 			data-new-no={row.newNo ?? ""}

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -140,6 +140,7 @@ const prStateLabelKeys: Record<SessionPRSummary["state"], MessageKey> = {
 export function SessionInspector({
 	session,
 	onOpenReviewerTerminal,
+	onViewInlineComment,
 	browserPoppedOut = false,
 	browserAnnotationQueue,
 	isInspectorVisible = true,
@@ -152,6 +153,7 @@ export function SessionInspector({
 }: {
 	session?: WorkspaceSession;
 	onOpenReviewerTerminal?: OpenReviewerTerminal;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 	browserPoppedOut?: boolean;
 	browserAnnotationQueue?: BrowserAnnotationQueueModel;
 	isInspectorVisible?: boolean;
@@ -223,7 +225,7 @@ export function SessionInspector({
 			loadingText={session ? undefined : t("inspector.loadingSession")}
 			onViewChange={setView}
 			reviewsView={
-				session ? <ReviewsView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : undefined
+				session ? <ReviewsView onOpenReviewerTerminal={onOpenReviewerTerminal} onViewInlineComment={onViewInlineComment} session={session} /> : undefined
 			}
 			summaryView={
 				session ? <SummaryView canOpenReviews={reviewsAvailable} onOpenReviews={() => setView("reviews")} session={session} /> : undefined
@@ -318,13 +320,15 @@ function SummaryView({
 function ReviewsView({
 	session,
 	onOpenReviewerTerminal,
+	onViewInlineComment,
 }: {
 	session: WorkspaceSession;
 	onOpenReviewerTerminal?: OpenReviewerTerminal;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 }) {
 	return (
 		<div role="tabpanel">
-			<ReviewsSection onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />
+			<ReviewsSection onOpenReviewerTerminal={onOpenReviewerTerminal} onViewInlineComment={onViewInlineComment} session={session} />
 		</div>
 	);
 }
@@ -1237,9 +1241,11 @@ function resolveDefaultReviewerHarness(config: ProjectConfig | undefined, worker
 function ReviewsSection({
 	session,
 	onOpenReviewerTerminal,
+	onViewInlineComment,
 }: {
 	session: WorkspaceSession;
 	onOpenReviewerTerminal?: OpenReviewerTerminal;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 }) {
 	const { t } = useTranslation();
 	const hasPr = sortedPRs(session).length > 0;
@@ -1410,6 +1416,7 @@ function ReviewsSection({
 			<MergedReviewsSection
 				githubPRs={githubReviews}
 				isLoading={scmSummary.isLoading}
+				onViewInlineComment={onViewInlineComment}
 				reviewStates={reviewStates}
 				runs={reviewsQuery.data?.runs ?? []}
 				session={session}
@@ -1428,12 +1435,14 @@ function ReviewsSection({
 function MergedReviewsSection({
 	githubPRs,
 	isLoading,
+	onViewInlineComment,
 	reviewStates,
 	runs,
 	session,
 }: {
 	githubPRs: SessionPRSummary[];
 	isLoading: boolean;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 	reviewStates: PRReviewState[];
 	runs: ReviewRunFacts[];
 	session: WorkspaceSession;
@@ -1667,6 +1676,7 @@ function MergedReviewsSection({
 			onResolveInlineComment={resolveInlineComment}
 			onSendAgentReview={sendAgentReviewToWorker}
 			onSendInlineComment={sendInlineCommentToWorker}
+			onViewInlineComment={onViewInlineComment}
 			renderAvatar={(harness) => (
 				<AgentAvatar className="size-5 shrink-0" decorative provider={harness} />
 			)}

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -305,12 +305,19 @@ vi.mock("./BrowserPanel", () => ({
 vi.mock("./SessionFilesView", () => ({
 	SessionFilesView: ({
 		isMaximized,
+		navigationTarget,
 		onToggleMaximized,
 	}: {
 		isMaximized?: boolean;
+		navigationTarget?: { path: string; line?: number; requestId: number } | null;
 		onToggleMaximized?: (next: boolean) => void;
 	}) => (
-		<button type="button" onClick={() => onToggleMaximized?.(!isMaximized)}>
+		<button
+			data-navigation-line={navigationTarget?.line}
+			data-navigation-path={navigationTarget?.path}
+			type="button"
+			onClick={() => onToggleMaximized?.(!isMaximized)}
+		>
 			{isMaximized ? "files center" : "files rail"}
 		</button>
 	),
@@ -357,12 +364,14 @@ vi.mock("./SessionInspector", () => ({
 		isInspectorVisible = true,
 		onOpenFiles,
 		onToggleBrowserPopOut,
+		onViewInlineComment,
 		view,
 	}: {
 		filesView?: ReactNode;
 		isInspectorVisible?: boolean;
 		onOpenFiles?: () => void;
 		onToggleBrowserPopOut?: () => void;
+		onViewInlineComment?: (comment: { file?: string; line?: number }) => void;
 		view?: string;
 	}) => {
 		inspectorVisibilityRenders.push(isInspectorVisible);
@@ -373,6 +382,9 @@ vi.mock("./SessionInspector", () => ({
 				</button>
 				<button type="button" onClick={onOpenFiles}>
 					open files
+				</button>
+				<button type="button" onClick={() => onViewInlineComment?.({ file: "src/App.tsx", line: 42 })}>
+					view comment in file
 				</button>
 				{view === "files" ? filesView : null}
 			</div>
@@ -1275,6 +1287,17 @@ describe("SessionView", () => {
 		).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "files center" })).not.toBeInTheDocument();
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
+	});
+
+	it("opens an inline review comment at its file and line in the files view", () => {
+		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "view comment in file" }));
+
+		const filesView = within(screen.getByTestId("panel-inspector")).getByRole("button", { name: "files rail" });
+		expect(filesView).toHaveAttribute("data-navigation-path", "src/App.tsx");
+		expect(filesView).toHaveAttribute("data-navigation-line", "42");
 	});
 
 	it("maximizes files over the whole app window and returns to the rail", () => {

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -315,6 +315,7 @@ vi.mock("./SessionFilesView", () => ({
 		<button
 			data-navigation-line={navigationTarget?.line}
 			data-navigation-path={navigationTarget?.path}
+			data-navigation-request={navigationTarget?.requestId}
 			type="button"
 			onClick={() => onToggleMaximized?.(!isMaximized)}
 		>
@@ -1298,6 +1299,10 @@ describe("SessionView", () => {
 		const filesView = within(screen.getByTestId("panel-inspector")).getByRole("button", { name: "files rail" });
 		expect(filesView).toHaveAttribute("data-navigation-path", "src/App.tsx");
 		expect(filesView).toHaveAttribute("data-navigation-line", "42");
+		expect(filesView).toHaveAttribute("data-navigation-request", "1");
+
+		fireEvent.click(screen.getByRole("button", { name: "view comment in file" }));
+		expect(filesView).toHaveAttribute("data-navigation-request", "2");
 	});
 
 	it("maximizes files over the whole app window and returns to the rail", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -21,7 +21,7 @@ import { CenterPane } from "./CenterPane";
 import { SessionChatSurface } from "./chat/SessionChatSurface";
 import { NotificationCenter } from "./NotificationCenter";
 import { ResizeHandle } from "./ResizeHandle";
-import { SessionFilesView } from "./SessionFilesView";
+import { SessionFilesView, type SessionFilesNavigationTarget } from "./SessionFilesView";
 import { SessionInspector } from "./SessionInspector";
 import {
 	SessionInterfaceActionGroup,
@@ -260,6 +260,12 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const [terminalTarget, setTerminalTarget] = useState<TerminalTarget>({ kind: "worker" });
 	const [browserPopOutState, setBrowserPopOutState] = useState({ sessionId, poppedOut: false });
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
+	const [filesNavigationTarget, setFilesNavigationTarget] = useState<SessionFilesNavigationTarget | null>(null);
+	const filesNavigationRequestRef = useRef(0);
+	useEffect(() => {
+		filesNavigationRequestRef.current = 0;
+		setFilesNavigationTarget(null);
+	}, [sessionId]);
 	const browserPoppedOut = browserPopOutState.sessionId === sessionId && browserPopOutState.poppedOut;
 	const [interfaceSwitchDialogOpen, setInterfaceSwitchDialogOpen] = useState(false);
 	const isNativeFullScreen = useWindowFullScreen();
@@ -644,6 +650,20 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		setInspectorOpenForSession(sessionId, true);
 	}, [sessionId, setInspectorOpenForSession, setInspectorViewForSession]);
 
+	const handleViewInlineComment = useCallback(
+		(comment: { file?: string; line?: number }) => {
+			if (!comment.file) return;
+			filesNavigationRequestRef.current += 1;
+			setFilesNavigationTarget({
+				path: comment.file,
+				line: comment.line,
+				requestId: filesNavigationRequestRef.current,
+			});
+			handleOpenFiles();
+		},
+		[handleOpenFiles],
+	);
+
 	const handleToggleFilesPopOut = useCallback(
 		(next: boolean) => {
 			if (next) setBrowserPopOutState({ sessionId, poppedOut: false });
@@ -903,12 +923,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 							browserPoppedOut={browserPoppedOut}
 							filesView={
 								session ? (
-									<SessionFilesView onToggleMaximized={handleToggleFilesPopOut} sessionId={session.id} />
+									<SessionFilesView navigationTarget={filesNavigationTarget} onToggleMaximized={handleToggleFilesPopOut} sessionId={session.id} />
 								) : null
 							}
 							isInspectorVisible={inspectorPanelVisible}
 							onOpenFiles={handleOpenFiles}
 							onOpenReviewerTerminal={selectReviewerTerminal}
+							onViewInlineComment={handleViewInlineComment}
 							onToggleBrowserPopOut={handleToggleBrowserPopOut}
 							onViewChange={(next: InspectorView) => setInspectorViewForSession(sessionId, next)}
 							view={inspectorView}
@@ -953,6 +974,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 						>
 							<SessionFilesView
 								isMaximized
+								navigationTarget={filesNavigationTarget}
 								onToggleMaximized={handleToggleFilesPopOut}
 								sessionId={session.id}
 							/>

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -137,6 +137,23 @@ describe("SessionInspectorShellView", () => {
 });
 
 describe("portable inspector presentations", () => {
+  it("renders no review actions when there is no PR review group", () => {
+    const { container } = render(
+      <InspectorReviewsView
+        externalLink={ExternalLink}
+        groups={[]}
+        isLoading={false}
+        labels={reviewLabels}
+        onViewInlineComment={vi.fn()}
+        renderAvatar={() => null}
+        renderMarkdown={(body) => <p>{body}</p>}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole("button", { name: "View in file" })).not.toBeInTheDocument();
+  });
+
   it("renders PR facts and host-owned actions from a neutral view model", () => {
     render(
       <InspectorPullRequestCardView
@@ -274,6 +291,9 @@ describe("portable inspector presentations", () => {
     expect(githubSummary).toHaveClass("select-text");
     expect(screen.queryByText("Not injected")).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "View on PR" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("github-inline-comments")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Comment actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "View in file" })).not.toBeInTheDocument();
     expect(renderAvatar).toHaveBeenCalledWith("codex");
     expect(renderMarkdown).toHaveBeenCalledTimes(2);
   });
@@ -610,6 +630,10 @@ describe("portable inspector presentations", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /maya.*Commented/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Comment actions" }));
+    expect(screen.queryByRole("button", { name: "View in file" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open on GitHub" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Comment actions" }));
     fireEvent.click(
       screen.getByRole("button", { name: "Send to worker agent" }),
     );
@@ -626,6 +650,7 @@ describe("portable inspector presentations", () => {
   });
 
   it("keeps resolved comments collapsed until requested", () => {
+    const onViewInlineComment = vi.fn();
     render(
       <InspectorReviewsView
         externalLink={ExternalLink}
@@ -643,11 +668,13 @@ describe("portable inspector presentations", () => {
                       file: "src/panel.tsx",
                       line: 8,
                       resolved: true,
-                      url: "https://example.com/comment",
+                    },
+                    {
+                      body: "This resolved note has no source location.",
+                      resolved: true,
                     },
                   ],
                   reviewerId: "maya",
-                  reviewUrl: "https://example.com/review",
                   submittedAt: "",
                   submittedAtLabel: "",
                   verdict: { label: "Commented", tone: "neutral" },
@@ -663,20 +690,30 @@ describe("portable inspector presentations", () => {
         ]}
         isLoading={false}
         labels={reviewLabels}
+        onViewInlineComment={onViewInlineComment}
         renderAvatar={() => null}
         renderMarkdown={(body) => <p>{body}</p>}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /maya.*Commented/i }));
-    expect(screen.getByText("Resolved comments · 1")).toBeInTheDocument();
+    expect(screen.getByText("Resolved comments · 2")).toBeInTheDocument();
     expect(
       screen.queryByText("This resolved note stays hidden by default."),
     ).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Resolved comments · 1" }));
+    fireEvent.click(screen.getByRole("button", { name: "Resolved comments · 2" }));
     expect(
       screen.getByText("This resolved note stays hidden by default."),
     ).toBeInTheDocument();
+    expect(screen.getByText("This resolved note has no source location.")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Comment actions" })).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: "Comment actions" }));
+    expect(screen.queryByRole("link", { name: "Open on GitHub" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy comment link" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "View in file" }));
+    expect(onViewInlineComment).toHaveBeenCalledWith(
+      expect.objectContaining({ file: "src/panel.tsx", line: 8, resolved: true }),
+    );
   });
 
   it("tracks URL-less inline comments independently when they share a review URL", async () => {

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -426,6 +426,7 @@ describe("portable inspector presentations", () => {
   it("shows unresolved inline review comments inside each reviewer dropdown", async () => {
     const onResolveInlineComment = vi.fn().mockResolvedValue(undefined);
     const onSendInlineComment = vi.fn().mockResolvedValue(undefined);
+    const onViewInlineComment = vi.fn();
     render(
       <InspectorReviewsView
         externalLink={ExternalLink}
@@ -489,6 +490,7 @@ describe("portable inspector presentations", () => {
         labels={reviewLabels}
         onResolveInlineComment={onResolveInlineComment}
         onSendInlineComment={onSendInlineComment}
+        onViewInlineComment={onViewInlineComment}
         renderAvatar={() => null}
         renderMarkdown={(body) => <p>{body}</p>}
       />,
@@ -540,10 +542,15 @@ describe("portable inspector presentations", () => {
       }),
     );
     await waitFor(() => expect(screen.getByText("Resolved")).toBeInTheDocument());
-    expect(screen.getByRole("link", { name: "View in file" })).toBeInTheDocument();
+    const viewInFile = screen.getByRole("button", { name: "View in file" });
+    expect(screen.queryByRole("link", { name: "View in file" })).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open on GitHub" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Copy comment link" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Copy file path" })).not.toBeInTheDocument();
+    fireEvent.click(viewInFile);
+    expect(onViewInlineComment).toHaveBeenCalledWith(
+      expect.objectContaining({ file: "src/panel.tsx", line: 42 }),
+    );
   });
 
   it("surfaces inline review comment send failures", async () => {

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -500,6 +500,7 @@ export function InspectorReviewsView({
 	onResolveInlineComment,
 	onSendAgentReview,
 	onSendInlineComment,
+	onViewInlineComment,
 	renderAvatar,
 	renderMarkdown,
 }: {
@@ -511,6 +512,7 @@ export function InspectorReviewsView({
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	onSendAgentReview?: (run: InspectorReviewRun) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 	renderAvatar: (harness: string) => ReactNode;
 	renderMarkdown: (body: string) => ReactNode;
 }) {
@@ -566,6 +568,7 @@ export function InspectorReviewsView({
 									onSendInlineComment={onSendInlineComment}
 									onRequestRereview={onRequestRereview}
 									onResolveInlineComment={onResolveInlineComment}
+									onViewInlineComment={onViewInlineComment}
 									renderMarkdown={renderMarkdown}
 								/>
 							</div>
@@ -825,6 +828,7 @@ function GithubReviewHistory({
 	onRequestRereview,
 	onResolveInlineComment,
 	onSendInlineComment,
+	onViewInlineComment,
 	renderMarkdown,
 }: {
 	entries: InspectorGithubReview[];
@@ -833,6 +837,7 @@ function GithubReviewHistory({
 	onRequestRereview?: (review: InspectorGithubReview) => Promise<void> | void;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 	renderMarkdown: (body: string) => ReactNode;
 }) {
 	const sorted = [...entries].sort((a, b) => b.submittedAt.localeCompare(a.submittedAt));
@@ -849,6 +854,7 @@ function GithubReviewHistory({
 					onRequestRereview={onRequestRereview}
 					onResolveInlineComment={onResolveInlineComment}
 					onSendInlineComment={onSendInlineComment}
+					onViewInlineComment={onViewInlineComment}
 					renderMarkdown={renderMarkdown}
 				/>
 			))}
@@ -863,6 +869,7 @@ function ExternalReviewCard({
 	labels,
 	onResolveInlineComment,
 	onSendInlineComment,
+	onViewInlineComment,
 	renderMarkdown,
 }: {
 	defaultOpen: boolean;
@@ -872,6 +879,7 @@ function ExternalReviewCard({
 	onRequestRereview?: (review: InspectorGithubReview) => Promise<void> | void;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 	renderMarkdown: (body: string) => ReactNode;
 }) {
 	const [open, setOpen] = useState(defaultOpen);
@@ -908,8 +916,8 @@ function ExternalReviewCard({
 			{open ? (
 				<div className="flex min-w-0 flex-col gap-3 px-1 pt-2 text-left">
 					{body ? <ReviewMarkdownBody body={body} clamped={false} renderMarkdown={renderMarkdown} testId="github-review-summary" /> : null}
-					<GithubInlineComments comments={openComments} externalLink={externalLink} labels={labels} onResolveInlineComment={onResolveInlineComment} onSendInlineComment={onSendInlineComment} reviewerId={entry.reviewerId} reviewUrl={entry.reviewUrl} />
-					{resolvedComments.length > 0 ? <ResolvedInlineComments comments={resolvedComments} externalLink={externalLink} labels={labels} reviewerId={entry.reviewerId} reviewUrl={entry.reviewUrl} /> : null}
+					<GithubInlineComments comments={openComments} externalLink={externalLink} labels={labels} onResolveInlineComment={onResolveInlineComment} onSendInlineComment={onSendInlineComment} onViewInlineComment={onViewInlineComment} reviewerId={entry.reviewerId} reviewUrl={entry.reviewUrl} />
+					{resolvedComments.length > 0 ? <ResolvedInlineComments comments={resolvedComments} externalLink={externalLink} labels={labels} onViewInlineComment={onViewInlineComment} reviewerId={entry.reviewerId} reviewUrl={entry.reviewUrl} /> : null}
 				</div>
 			) : null}
 		</article>
@@ -922,6 +930,7 @@ function GithubInlineComments({
 	labels,
 	onResolveInlineComment,
 	onSendInlineComment,
+	onViewInlineComment,
 	reviewerId,
 	reviewUrl,
 }: {
@@ -930,6 +939,7 @@ function GithubInlineComments({
 	labels: InspectorReviewLabels;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 	reviewerId: string;
 	reviewUrl?: string;
 }) {
@@ -941,7 +951,7 @@ function GithubInlineComments({
 				<ChevronIcon className="size-icon-2xs shrink-0" direction={open ? "down" : "right"} />
 				<span>{labels.openComments} · {comments.length}</span>
 			</button>
-			{open ? <InlineCommentList comments={comments} externalLink={ExternalLink} labels={labels} onResolveInlineComment={onResolveInlineComment} onSendInlineComment={onSendInlineComment} reviewerId={reviewerId} reviewUrl={reviewUrl} /> : null}
+			{open ? <InlineCommentList comments={comments} externalLink={ExternalLink} labels={labels} onResolveInlineComment={onResolveInlineComment} onSendInlineComment={onSendInlineComment} onViewInlineComment={onViewInlineComment} reviewerId={reviewerId} reviewUrl={reviewUrl} /> : null}
 		</section>
 	);
 }
@@ -950,12 +960,14 @@ function ResolvedInlineComments({
 	comments,
 	externalLink: ExternalLink,
 	labels,
+	onViewInlineComment,
 	reviewerId,
 	reviewUrl,
 }: {
 	comments: InspectorInlineComment[];
 	externalLink: ExternalLinkComponent;
 	labels: InspectorReviewLabels;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 	reviewerId: string;
 	reviewUrl?: string;
 }) {
@@ -966,7 +978,7 @@ function ResolvedInlineComments({
 				<ChevronIcon className="size-icon-2xs shrink-0" direction={open ? "down" : "right"} />
 				<span>{labels.resolvedComments(comments.length)}</span>
 			</button>
-			{open ? <InlineCommentList comments={comments} externalLink={ExternalLink} labels={labels} reviewerId={reviewerId} reviewUrl={reviewUrl} /> : null}
+			{open ? <InlineCommentList comments={comments} externalLink={ExternalLink} labels={labels} onViewInlineComment={onViewInlineComment} reviewerId={reviewerId} reviewUrl={reviewUrl} /> : null}
 		</section>
 	);
 }
@@ -977,6 +989,7 @@ function InlineCommentList({
 	labels,
 	onResolveInlineComment,
 	onSendInlineComment,
+	onViewInlineComment,
 	reviewerId,
 	reviewUrl,
 }: {
@@ -985,6 +998,7 @@ function InlineCommentList({
 	labels: InspectorReviewLabels;
 	onResolveInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
 	onSendInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => Promise<void> | void;
+	onViewInlineComment?: (comment: InspectorInlineComment & { reviewerId?: string }) => void;
 	reviewerId: string;
 	reviewUrl?: string;
 }) {
@@ -1008,6 +1022,7 @@ function InlineCommentList({
 					externalLink={externalLink}
 					key={comment.id}
 					labels={labels}
+					onView={onViewInlineComment && comment.file ? () => onViewInlineComment(comment) : undefined}
 					onResolve={!comment.resolved && onResolveInlineComment ? async () => {
 						setResolvingCommentIds((current) => new Set(current).add(comment.id));
 						setResolveErrorCommentIds((current) => {
@@ -1066,6 +1081,7 @@ function InlineCommentRow({
 	labels,
 	onResolve,
 	onSend,
+	onView,
 	resolveError = false,
 	resolvedSuccess = false,
 	resolving = false,
@@ -1078,6 +1094,7 @@ function InlineCommentRow({
 	labels: InspectorReviewLabels;
 	onResolve?: () => void;
 	onSend?: () => void;
+	onView?: () => void;
 	resolveError?: boolean;
 	resolvedSuccess?: boolean;
 	resolving?: boolean;
@@ -1132,7 +1149,7 @@ function InlineCommentRow({
 					{menuOpen ? (
 						<div className="isolate absolute right-0 top-8 z-[100] flex w-40 flex-col rounded-md border border-border-strong bg-[var(--color-bg-settings-menu)] p-1 text-2xs shadow-[0_16px_40px_rgba(0,0,0,0.65)]">
 							{onResolve ? <button className="rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-interactive-hover hover:text-foreground disabled:pointer-events-none disabled:opacity-60" disabled={resolving} onClick={() => void onResolve()} type="button">{labels.resolveComment}</button> : null}
-							{comment.url ? <ExternalLink className="rounded px-2 py-1.5 text-muted-foreground no-underline hover:bg-interactive-hover hover:text-foreground" href={comment.url}>{labels.viewInFile}</ExternalLink> : null}
+							{onView ? <button className="rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-interactive-hover hover:text-foreground" onClick={() => { setMenuOpen(false); onView(); }} type="button">{labels.viewInFile}</button> : null}
 							{comment.url ? <ExternalLink className="rounded px-2 py-1.5 text-muted-foreground no-underline hover:bg-interactive-hover hover:text-foreground" href={comment.url}>Open on GitHub</ExternalLink> : null}
 							<button className="rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-interactive-hover hover:text-foreground" onClick={() => void copy(comment.url)} type="button">Copy comment link</button>
 						</div>

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -1107,6 +1107,7 @@ function InlineCommentRow({
 	const body = comment.body?.trim();
 	const fileLabel = comment.file ? `${comment.file}${comment.line ? `:${comment.line}` : ""}` : labels.commentNumber(1);
 	const preview = body ? body.split("\n")[0] : "";
+	const hasMenuActions = Boolean(onResolve || onView || comment.url);
 	const copy = async (value?: string) => {
 		if (!value) return;
 		try {
@@ -1142,7 +1143,7 @@ function InlineCommentRow({
 						</button>
 					) : null}
 				</span>
-				<span className="relative flex shrink-0 items-start justify-end" onClick={(event) => event.stopPropagation()}>
+				{hasMenuActions ? <span className="relative flex shrink-0 items-start justify-end" onClick={(event) => event.stopPropagation()}>
 					<button aria-expanded={menuOpen} aria-label="Comment actions" className="inline-flex size-7 items-center justify-center rounded-md border border-border/70 text-muted-foreground transition-colors hover:border-border-strong hover:bg-interactive-hover hover:text-foreground" onClick={() => setMenuOpen((current) => !current)} type="button">
 						<MoreHorizontalIcon className="size-icon-xs" />
 					</button>
@@ -1151,10 +1152,10 @@ function InlineCommentRow({
 							{onResolve ? <button className="rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-interactive-hover hover:text-foreground disabled:pointer-events-none disabled:opacity-60" disabled={resolving} onClick={() => void onResolve()} type="button">{labels.resolveComment}</button> : null}
 							{onView ? <button className="rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-interactive-hover hover:text-foreground" onClick={() => { setMenuOpen(false); onView(); }} type="button">{labels.viewInFile}</button> : null}
 							{comment.url ? <ExternalLink className="rounded px-2 py-1.5 text-muted-foreground no-underline hover:bg-interactive-hover hover:text-foreground" href={comment.url}>Open on GitHub</ExternalLink> : null}
-							<button className="rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-interactive-hover hover:text-foreground" onClick={() => void copy(comment.url)} type="button">Copy comment link</button>
+							{comment.url ? <button className="rounded px-2 py-1.5 text-left text-muted-foreground hover:bg-interactive-hover hover:text-foreground" onClick={() => void copy(comment.url)} type="button">Copy comment link</button> : null}
 						</div>
 					) : null}
-				</span>
+				</span> : null}
 			</div>
 			{resolvedSuccess ? <p className="m-0 text-2xs font-medium text-success">{labels.resolvedReview}</p> : null}
 			{resolveError ? <p className="m-0 text-2xs font-medium text-error">{labels.resolveReviewFailed}</p> : null}


### PR DESCRIPTION
## Summary
- Route View in file actions from inline external-review comments to the internal Files tab
- Expand the matching workspace diff, center the referenced line, and highlight it
- Keep Open on GitHub as the separate external action and hide actions whose required metadata is unavailable
- Cover empty, partial, resolved, renamed, repeated-navigation, and unavailable-file states

## Validation
- Product UI focused tests: 13 passed
- Frontend focused tests: 194 passed
- Product UI and frontend TypeScript checks
- Production renderer build