### PR TITLE
fix(windows): reduce daemon probe timeouts for faster app startup

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -547,7 +547,7 @@ const RUN_FILE_POLL_MS = 300;
 // Accept run-files stamped slightly before our spawn timestamp: the daemon's
 // clock reading and ours race within normal scheduling jitter.
 const RUN_FILE_FRESHNESS_SKEW_MS = 2_000;
-const DAEMON_PROBE_TIMEOUT_MS = 2_000;
+const DAEMON_PROBE_TIMEOUT_MS = process.platform === "win32" ? 500 : 2_000;
 
 function runFilePath(): string | null {
 	if (process.env.AO_RUN_FILE) return process.env.AO_RUN_FILE;
@@ -1087,7 +1087,6 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	// killed here), and a foreign non-AO process holding the port with a dead
 	// run-file PID is not replaced (out of scope). When no holder is detectable,
 	// skip straight to spawn.
-	const orphanProbe = await readDaemonProbe(resolvedDaemonPort(), "healthz");
 	const runFilePath_ = runFilePath();
 	let runFilePid: number | null = null;
 	if (runFilePath_) {
@@ -1097,6 +1096,13 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 			// run-file absent or unreadable; proceed without a PID.
 		}
 	}
+
+	// On Windows, skip the orphan probe when there is no run-file PID. Without a
+	// run-file there is no evidence a daemon was ever running, so the probe would
+	// just burn another timeout on a cold start.
+	const skipOrphanProbe = process.platform === "win32" && !runFilePid;
+	const orphanProbe = skipOrphanProbe ? null : await readDaemonProbe(resolvedDaemonPort(), "healthz");
+
 	// process.kill(pid, 0) does not kill; it throws iff the PID is not live.
 	let holderPidAlive = false;
 	if (runFilePid) {


### PR DESCRIPTION
## What happened

After #4013 fixed the flashing cmd windows on Windows, app startup got noticeably slower. On a cold start (no daemon running), the app just hangs for like 6 seconds before the daemon even starts spawning.

Turns out `startDaemonInner` runs three HTTP probes back to back and each one waits 2 full seconds to timeout. On localhost a refused connection comes back in like 20ms, so 2 seconds per probe is way too much.

## What this PR does

Two small changes, both Windows only:

1. Probe timeout goes from 2000ms to 500ms on Windows. Thats still plenty for localhost, and shaves off ~4.5 seconds on cold start.
2. Skip the orphan probe when theres no run file. If nothing suggests a daemon was ever running, no point burning another timeout checking for one.

macOS and Linux are not touched at all.

Closes #4138

## Test plan

- [x] daemon-launch, daemon-attach, daemon-takeover tests all pass (49 tests)
- [ ] Cold start on Windows should be noticeably faster
- [ ] Warm start (daemon already running) should work same as before
- [ ] macOS/Linux startup unchanged