### PR TITLE
feat: detect Crush terminal activity

### DIFF
--- a/backend/internal/adapters/agent/crush/activity.go
+++ b/backend/internal/adapters/agent/crush/activity.go
@@ -1,6 +1,46 @@
 package crush
 
-import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+import (
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+var crushTerminalEscape = regexp.MustCompile(`\x1b(?:\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]|\][^\x07]*(?:\x07|\x1b\\))`)
+
+// Real Crush v0.80.0 captures from tmux show the active composer as:
+//
+//	> Ready...  or  > Ready?
+//	:::
+//	:::
+//
+// and an active turn as:
+//
+//	> Working!
+//	:::
+//	:::
+//
+// Permission prompts are backed by Crush's permissions dialog, whose title is
+// "Permission Required" with Allow / Allow for Session / Deny actions.
+var crushReadyPlaceholders = []string{
+	"ready!",
+	"ready...",
+	"ready?",
+	"ready for instructions",
+}
+
+var crushWorkingPlaceholders = []string{
+	"working!",
+	"working...",
+	"brrrrr...",
+	"prrrrrrrr...",
+	"processing...",
+	"thinking...",
+}
+
+const crushPermissionDialogLookahead = 24
 
 // DeriveActivityState maps a Crush hook event onto an AO activity state.
 // Currently a no-op since Crush doesn't have full hooks support like Claude Code and Codex.
@@ -11,4 +51,110 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
 	// No-op for now since Crush doesn't have full hooks support
 	return "", false
+}
+
+// ContinuouslyDetectTerminalActivity remains disabled because Crush's Yolo
+// completion signal is delivered through desktop notifications, not pane text.
+// Enabling reconciliation without a pane-visible idle edge can leave sessions
+// stuck active after a Yolo turn completes.
+func (p *Plugin) ContinuouslyDetectTerminalActivity() bool { return false }
+
+// DetectTerminalActivity recognizes authoritative states in Crush's TUI. The
+// newest marker wins so stale prompt or permission text in scrollback cannot
+// override the current terminal state.
+func (p *Plugin) DetectTerminalActivity(output string) (domain.ActivityState, bool) {
+	lines := crushTerminalLines(output)
+	if len(lines) == 0 {
+		return "", false
+	}
+	start := len(lines) - 30
+	if start < 0 {
+		start = 0
+	}
+	recent := lines[start:]
+
+	for i := len(recent) - 1; i >= 0; i-- {
+		line := strings.ToLower(recent[i])
+		switch {
+		case crushLineLooksWaitingInput(recent, i):
+			return domain.ActivityWaitingInput, true
+		case crushLineLooksActive(line):
+			return domain.ActivityActive, true
+		case crushLineLooksIdle(line):
+			return domain.ActivityIdle, true
+		}
+	}
+	return "", false
+}
+
+func crushLineLooksWaitingInput(lines []string, index int) bool {
+	line := strings.ToLower(lines[index])
+	if crushLineLooksQuestionDialog(lines, index) {
+		return true
+	}
+	if !strings.Contains(line, "permission required") {
+		return false
+	}
+	end := min(index+crushPermissionDialogLookahead, len(lines)-1)
+	hasAllow := false
+	hasDeny := false
+	for _, nearby := range lines[index+1 : end+1] {
+		nearby = strings.ToLower(nearby)
+		button := strings.Trim(nearby, " │")
+		if strings.HasPrefix(button, "allow") {
+			hasAllow = true
+		}
+		if strings.HasPrefix(button, "deny") {
+			hasDeny = true
+		}
+	}
+	return hasAllow && hasDeny
+}
+
+func crushLineLooksQuestionDialog(lines []string, index int) bool {
+	text := crushDialogLineText(lines[index])
+	return strings.HasPrefix(text, "? ") && strings.TrimSpace(strings.TrimPrefix(text, "?")) != ""
+}
+
+func crushDialogLineText(line string) string {
+	return strings.Trim(line, " │")
+}
+
+func crushLineLooksActive(line string) bool {
+	if strings.Contains(line, "esc to interrupt") || strings.Contains(line, "ctrl+c to interrupt") {
+		return true
+	}
+	if strings.Contains(line, "agent is busy, please wait") ||
+		strings.Contains(line, "agent is working, please wait") {
+		return true
+	}
+	return crushPromptLineHasPlaceholder(line, crushWorkingPlaceholders)
+}
+
+func crushLineLooksIdle(line string) bool {
+	return crushPromptLineHasPlaceholder(line, crushReadyPlaceholders)
+}
+
+func crushPromptLineHasPlaceholder(line string, placeholders []string) bool {
+	line = strings.TrimSpace(line)
+	for _, marker := range []string{">", "y"} {
+		if after, ok := strings.CutPrefix(line, marker); ok {
+			text := strings.TrimSpace(after)
+			return slices.Contains(placeholders, text)
+		}
+	}
+	return false
+}
+
+func crushTerminalLines(output string) []string {
+	plain := crushTerminalEscape.ReplaceAllString(strings.ReplaceAll(output, "\r", "\n"), "")
+	raw := strings.Split(plain, "\n")
+	lines := raw[:0]
+	for _, line := range raw {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
 }

--- a/backend/internal/adapters/agent/crush/activity.go
+++ b/backend/internal/adapters/agent/crush/activity.go
@@ -42,6 +42,8 @@ var crushWorkingPlaceholders = []string{
 
 const crushPermissionDialogLookahead = 24
 
+const crushQuestionLookahead = 4
+
 // DeriveActivityState maps a Crush hook event onto an AO activity state.
 // Currently a no-op since Crush doesn't have full hooks support like Claude Code and Codex.
 // The bool is false to indicate no activity signal is available.
@@ -113,7 +115,26 @@ func crushLineLooksWaitingInput(lines []string, index int) bool {
 
 func crushLineLooksQuestionDialog(lines []string, index int) bool {
 	text := crushDialogLineText(lines[index])
-	return strings.HasPrefix(text, "? ") && strings.TrimSpace(strings.TrimPrefix(text, "?")) != ""
+	if !strings.HasPrefix(text, "? ") || strings.TrimSpace(strings.TrimPrefix(text, "?")) == "" {
+		return false
+	}
+	end := min(index+crushQuestionLookahead, len(lines)-1)
+	for _, nearby := range lines[index+1 : end+1] {
+		if crushQuestionAnswerRow(nearby) {
+			return true
+		}
+	}
+	return false
+}
+
+func crushQuestionAnswerRow(line string) bool {
+	line = crushDialogLineText(line)
+	if strings.HasPrefix(line, "> ") || strings.HasPrefix(line, "❯ ") ||
+		strings.HasPrefix(line, "› ") || strings.HasPrefix(line, "○ ") ||
+		strings.HasPrefix(line, "◯ ") {
+		return true
+	}
+	return len(line) >= 3 && line[0] >= '1' && line[0] <= '9' && line[1] == '.' && line[2] == ' '
 }
 
 func crushDialogLineText(line string) string {

--- a/backend/internal/adapters/agent/crush/activity.go
+++ b/backend/internal/adapters/agent/crush/activity.go
@@ -129,13 +129,17 @@ func crushLineLooksQuestionDialog(lines []string, index int) bool {
 
 func crushQuestionAnswerRow(line string) bool {
 	line = crushDialogLineText(line)
-	if strings.HasPrefix(line, "> ") || strings.HasPrefix(line, "❯ ") ||
+	if strings.HasPrefix(line, "┃ ") || strings.HasPrefix(line, "> ") || strings.HasPrefix(line, "❯ ") ||
 		strings.HasPrefix(line, "› ") || strings.HasPrefix(line, "○ ") ||
 		strings.HasPrefix(line, "◯ ") {
 		return true
 	}
 	return len(line) >= 3 && line[0] >= '1' && line[0] <= '9' && line[1] == '.' && line[2] == ' '
 }
+
+// ContinuouslyDetectTerminalActivityWhileWaiting opts Crush into terminal
+// reconciliation after AO has recorded a waiting-input state.
+func (p *Plugin) ContinuouslyDetectTerminalActivityWhileWaiting() bool { return true }
 
 func crushDialogLineText(line string) string {
 	return strings.Trim(line, " │")

--- a/backend/internal/adapters/agent/crush/activity_test.go
+++ b/backend/internal/adapters/agent/crush/activity_test.go
@@ -114,7 +114,7 @@ func TestDetectTerminalActivity(t *testing.T) {
 		{
 			name: "question dialog",
 			output: "\x1b[38;5;212m?\x1b[0m Which environment should I use?\n" +
-				"\x1b[38;5;212m❯\x1b[0m production\n" +
+				"\x1b[38;5;212m┃\x1b[0m production\n" +
 				"  staging\n",
 			want: domain.ActivityWaitingInput,
 			ok:   true,

--- a/backend/internal/adapters/agent/crush/activity_test.go
+++ b/backend/internal/adapters/agent/crush/activity_test.go
@@ -113,9 +113,9 @@ func TestDetectTerminalActivity(t *testing.T) {
 		},
 		{
 			name: "question dialog",
-			output: "? Which environment should I use?\n" +
-				"  1. production\n" +
-				"  2. staging\n",
+			output: "\x1b[38;5;212m?\x1b[0m Which environment should I use?\n" +
+				"\x1b[38;5;212m❯\x1b[0m production\n" +
+				"  staging\n",
 			want: domain.ActivityWaitingInput,
 			ok:   true,
 		},
@@ -143,6 +143,10 @@ func TestDetectTerminalActivity(t *testing.T) {
 		{
 			name:   "question in transcript rejected",
 			output: "The answer is ? Which environment should I use?\n",
+		},
+		{
+			name:   "question-shaped transcript without answer row rejected",
+			output: "? Is this a question in the transcript?\n",
 		},
 		{
 			name:   "confirmation prose rejected",

--- a/backend/internal/adapters/agent/crush/activity_test.go
+++ b/backend/internal/adapters/agent/crush/activity_test.go
@@ -2,6 +2,8 @@ package crush
 
 import (
 	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
 func TestDeriveActivityStateReturnsFalse(t *testing.T) {
@@ -11,5 +13,164 @@ func TestDeriveActivityStateReturnsFalse(t *testing.T) {
 	}
 	if state != "" {
 		t.Fatalf("unexpected non-empty state: got %q", state)
+	}
+}
+
+func TestDetectTerminalActivity(t *testing.T) {
+	// These snippets mirror tmux capture-pane output from Crush v0.80.0:
+	// the current composer row is prefixed with ">", and Crush paints ":::" rows
+	// below it. Ready... was observed on fresh startup and Ready? after a turn.
+	tests := []struct {
+		name   string
+		output string
+		want   domain.ActivityState
+		ok     bool
+	}{
+		{
+			name: "idle ready prompt",
+			output: "chat transcript\n" +
+				"\x1b[2m  > Ready...\x1b[0m\n" +
+				"\x1b[32m::: \x1b[0m\n" +
+				"\x1b[32m::: \x1b[0m\n" +
+				"gpt-5 · coding-session · 12k tokens\n",
+			want: domain.ActivityIdle,
+			ok:   true,
+		},
+		{
+			name: "completed turn back at prompt",
+			output: "chat transcript\n" +
+				"OK\n" +
+				"GLM-4.6 via Z.AI 6s\n" +
+				"\x1b[2m  > Ready?\x1b[0m\n" +
+				"\x1b[32m::: \x1b[0m\n" +
+				"\x1b[32m::: \x1b[0m\n" +
+				"gpt-5 · coding-session · 12k tokens\n",
+			want: domain.ActivityIdle,
+			ok:   true,
+		},
+		{
+			name: "active working prompt",
+			output: "assistant text\n" +
+				"Thinking..\n" +
+				"\x1b[2m  > Working!\x1b[0m\n" +
+				"\x1b[32m::: \x1b[0m\n" +
+				"\x1b[32m::: \x1b[0m\n" +
+				"gpt-5 · coding-session · 12k tokens\n",
+			want: domain.ActivityActive,
+			ok:   true,
+		},
+		{
+			name:   "yolo placeholder has no pane idle marker",
+			output: "Y Yolo mode!\n",
+		},
+		{
+			name: "active interrupt hint",
+			output: "running bash\n" +
+				"Working (13s · esc to interrupt)\n",
+			want: domain.ActivityActive,
+			ok:   true,
+		},
+		{
+			name: "permission prompt",
+			output: "Permission Required\n" +
+				"Tool Bash\n" +
+				"Allow  Allow for Session\n" +
+				"Deny\n",
+			want: domain.ActivityWaitingInput,
+			ok:   true,
+		},
+		{
+			name: "multiline edit permission dialog",
+			output: "Permission Required\n" +
+				"Edit file\n" +
+				"Path: /work/backend/main.go\n" +
+				"Changes:\n" +
+				"- old line\n" +
+				"+ new line\n" +
+				"Review the proposed changes\n" +
+				"Allow\n" +
+				"Allow for Session\n" +
+				"Deny\n",
+			want: domain.ActivityWaitingInput,
+			ok:   true,
+		},
+		{
+			name: "bordered permission dialog",
+			output: "╭────────────────────────────╮\n" +
+				"│ Permission Required        │\n" +
+				"│ Edit file                  │\n" +
+				"│ Path: /work/main.go        │\n" +
+				"│ Changes:                   │\n" +
+				"│ - old line                 │\n" +
+				"│ + new line                 │\n" +
+				"│ Review the proposed diff   │\n" +
+				"│ Allow                     │\n" +
+				"│ Allow for Session         │\n" +
+				"│ Deny                      │\n" +
+				"╰────────────────────────────╯\n",
+			want: domain.ActivityWaitingInput,
+			ok:   true,
+		},
+		{
+			name: "question dialog",
+			output: "? Which environment should I use?\n" +
+				"  1. production\n" +
+				"  2. staging\n",
+			want: domain.ActivityWaitingInput,
+			ok:   true,
+		},
+		{
+			name: "multiple inline questions",
+			output: "? Which environment should I use?\n" +
+				"  1. production\n" +
+				"? Should I update the lockfile?\n" +
+				"  1. yes\n" +
+				"  2. no\n",
+			want: domain.ActivityWaitingInput,
+			ok:   true,
+		},
+		{
+			name: "newest marker wins",
+			output: "\x1b[2m  > Ready...\x1b[0m\n" +
+				"Working (13s · esc to interrupt)\n",
+			want: domain.ActivityActive,
+			ok:   true,
+		},
+		{
+			name:   "transcript text rejected",
+			output: "The UI may say Ready... or Thinking... depending on state.\n",
+		},
+		{
+			name:   "question in transcript rejected",
+			output: "The answer is ? Which environment should I use?\n",
+		},
+		{
+			name:   "confirmation prose rejected",
+			output: "The instructions say press enter to confirm or esc to go back.\n",
+		},
+		{
+			name:   "prompt marker in transcript rejected without known placeholder",
+			output: "> Explain the codebase\n",
+		},
+		{
+			name: "historical marker outside lookback rejected",
+			output: "> Ready...\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n" +
+				"11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n" +
+				"21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := (&Plugin{}).DetectTerminalActivity(tt.output)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("DetectTerminalActivity() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestContinuouslyDetectTerminalActivity(t *testing.T) {
+	if (&Plugin{}).ContinuouslyDetectTerminalActivity() {
+		t.Fatal("ContinuouslyDetectTerminalActivity() = true, want false until Crush exposes pane-visible completion markers")
 	}
 }

--- a/backend/internal/adapters/agent/crush/crush.go
+++ b/backend/internal/adapters/agent/crush/crush.go
@@ -41,6 +41,7 @@ func New() *Plugin {
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
 var _ ports.ContinuousTerminalActivityDetector = (*Plugin)(nil)
+var _ ports.WaitingTerminalActivityDetector = (*Plugin)(nil)
 
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {

--- a/backend/internal/adapters/agent/crush/crush.go
+++ b/backend/internal/adapters/agent/crush/crush.go
@@ -1,10 +1,10 @@
 // Package crush implements the Crush agent adapter: launching new sessions,
 // resuming sessions by native ID, and reading session info.
 //
-// Crush differs from other agents in that it doesn't yet expose AO-compatible
-// activity hooks. GetAgentHooks only injects AO's standing system prompt through
-// project-local context configuration; activity tracking still falls back to
-// basic session ID management.
+// Crush differs from hook-driven agents in that it doesn't yet expose
+// AO-compatible activity hooks. GetAgentHooks only injects AO's standing system
+// prompt through project-local context configuration; activity is reconciled
+// from conservative terminal UI markers.
 package crush
 
 import (
@@ -40,6 +40,7 @@ func New() *Plugin {
 
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
+var _ ports.ContinuousTerminalActivityDetector = (*Plugin)(nil)
 
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {

--- a/backend/internal/adapters/agent/crush/hooks.go
+++ b/backend/internal/adapters/agent/crush/hooks.go
@@ -146,7 +146,7 @@ func applyCrushModelOverride(workspacePath, modelOverride string) error {
 }
 
 // AreHooksInstalled reports whether AO's Crush system-prompt context file is
-// present. Crush still lacks activity hooks; this reports only the prompt
+// present. Crush activity is terminal-derived, so this reports only the prompt
 // injection hook surface AO manages for Crush.
 func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (bool, error) {
 	if err := ctx.Err(); err != nil {

--- a/backend/internal/observe/activity/observer.go
+++ b/backend/internal/observe/activity/observer.go
@@ -114,11 +114,13 @@ func (o *Observer) reconcile(ctx context.Context, session domain.SessionRecord, 
 	}
 	continuous, ok := agent.(ports.ContinuousTerminalActivityDetector)
 	if !ok || !continuous.ContinuouslyDetectTerminalActivity() {
-		// A detected waiting-input state still needs sampling so a terminal
-		// prompt can prove that the user answered and the turn resumed.
-		if session.Activity.State != domain.ActivityWaitingInput &&
-			(session.Activity.State != domain.ActivityActive || session.Activity.LastActivityAt.IsZero() ||
-				now.Sub(session.Activity.LastActivityAt) < o.staleAfter) {
+		if session.Activity.State == domain.ActivityWaitingInput {
+			waitingDetector, canRecoverWaiting := agent.(ports.WaitingTerminalActivityDetector)
+			if !canRecoverWaiting || !waitingDetector.ContinuouslyDetectTerminalActivityWhileWaiting() {
+				return
+			}
+		} else if session.Activity.State != domain.ActivityActive || session.Activity.LastActivityAt.IsZero() ||
+			now.Sub(session.Activity.LastActivityAt) < o.staleAfter {
 			return
 		}
 	} else if session.Activity.State != domain.ActivityActive &&

--- a/backend/internal/observe/activity/observer.go
+++ b/backend/internal/observe/activity/observer.go
@@ -114,8 +114,11 @@ func (o *Observer) reconcile(ctx context.Context, session domain.SessionRecord, 
 	}
 	continuous, ok := agent.(ports.ContinuousTerminalActivityDetector)
 	if !ok || !continuous.ContinuouslyDetectTerminalActivity() {
-		if session.Activity.State != domain.ActivityActive || session.Activity.LastActivityAt.IsZero() ||
-			now.Sub(session.Activity.LastActivityAt) < o.staleAfter {
+		// A detected waiting-input state still needs sampling so a terminal
+		// prompt can prove that the user answered and the turn resumed.
+		if session.Activity.State != domain.ActivityWaitingInput &&
+			(session.Activity.State != domain.ActivityActive || session.Activity.LastActivityAt.IsZero() ||
+				now.Sub(session.Activity.LastActivityAt) < o.staleAfter) {
 			return
 		}
 	} else if session.Activity.State != domain.ActivityActive &&

--- a/backend/internal/observe/activity/observer_test.go
+++ b/backend/internal/observe/activity/observer_test.go
@@ -190,6 +190,29 @@ func TestPollReconcilesWaitingCrushAfterUserResponds(t *testing.T) {
 	}
 }
 
+func TestPollPreservesClaudeWaitingInputWithoutContinuousCapability(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	session := activeSession(now, domain.HarnessClaudeCode)
+	session.Activity = domain.Activity{State: domain.ActivityWaitingInput, LastActivityAt: now.Add(-time.Second)}
+	session.UpdatedAt = now.Add(-time.Second)
+	sink := &fakeSink{}
+	runtime := &fakeRuntime{output: claudeStuckActiveScreen}
+	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{session}},
+		sink,
+		runtime,
+		fakeAgents{domain.HarnessClaudeCode: claudecode.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.calls != 0 || len(sink.signals) != 0 {
+		t.Fatalf("sticky Claude waiting state was sampled: output calls=%d signals=%+v", runtime.calls, sink.signals)
+	}
+}
+
 func TestPollLeavesOtherHarnessesUntouched(t *testing.T) {
 	now := time.Unix(500, 0).UTC()
 	sink := &fakeSink{}

--- a/backend/internal/observe/activity/observer_test.go
+++ b/backend/internal/observe/activity/observer_test.go
@@ -158,24 +158,35 @@ func TestPollContinuouslyReconcilesMuse(t *testing.T) {
 }
 
 func TestPollReconcilesWaitingCrushAfterUserResponds(t *testing.T) {
-	now := time.Unix(500, 0).UTC()
-	session := activeSession(now, domain.HarnessCrush)
-	session.Activity = domain.Activity{State: domain.ActivityWaitingInput, LastActivityAt: now.Add(-time.Second)}
-	session.UpdatedAt = now.Add(-time.Second)
-	sink := &fakeSink{}
-	observer := New(
-		fakeSessions{rows: []domain.SessionRecord{session}},
-		sink,
-		&fakeRuntime{output: "> Working!\n"},
-		fakeAgents{domain.HarnessCrush: crush.New()},
-		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
-	)
+	for _, tt := range []struct {
+		name   string
+		output string
+		want   domain.ActivityState
+	}{
+		{name: "resumed active", output: "> Working!\n", want: domain.ActivityActive},
+		{name: "resumed idle", output: "> Ready?\n", want: domain.ActivityIdle},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Unix(500, 0).UTC()
+			session := activeSession(now, domain.HarnessCrush)
+			session.Activity = domain.Activity{State: domain.ActivityWaitingInput, LastActivityAt: now.Add(-time.Second)}
+			session.UpdatedAt = now.Add(-time.Second)
+			sink := &fakeSink{}
+			observer := New(
+				fakeSessions{rows: []domain.SessionRecord{session}},
+				sink,
+				&fakeRuntime{output: tt.output},
+				fakeAgents{domain.HarnessCrush: crush.New()},
+				Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+			)
 
-	if err := observer.Poll(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if len(sink.signals) != 1 || sink.signals[0].State != domain.ActivityActive {
-		t.Fatalf("unexpected reconciliation: %+v", sink.signals)
+			if err := observer.Poll(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if len(sink.signals) != 1 || sink.signals[0].State != tt.want {
+				t.Fatalf("unexpected reconciliation: %+v", sink.signals)
+			}
+		})
 	}
 }
 

--- a/backend/internal/observe/activity/observer_test.go
+++ b/backend/internal/observe/activity/observer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/crush"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/muse"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -153,6 +154,28 @@ func TestPollContinuouslyReconcilesMuse(t *testing.T) {
 				t.Fatalf("unexpected reconciliation: %+v", sink.signals)
 			}
 		})
+	}
+}
+
+func TestPollReconcilesWaitingCrushAfterUserResponds(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	session := activeSession(now, domain.HarnessCrush)
+	session.Activity = domain.Activity{State: domain.ActivityWaitingInput, LastActivityAt: now.Add(-time.Second)}
+	session.UpdatedAt = now.Add(-time.Second)
+	sink := &fakeSink{}
+	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{session}},
+		sink,
+		&fakeRuntime{output: "> Working!\n"},
+		fakeAgents{domain.HarnessCrush: crush.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.signals) != 1 || sink.signals[0].State != domain.ActivityActive {
+		t.Fatalf("unexpected reconciliation: %+v", sink.signals)
 	}
 }
 

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -250,6 +250,13 @@ type ContinuousTerminalActivityDetector interface {
 	ContinuouslyDetectTerminalActivity() bool
 }
 
+// WaitingTerminalActivityDetector is implemented by non-continuous terminal
+// detectors that can authoritatively recover from a durable waiting-input state.
+type WaitingTerminalActivityDetector interface {
+	TerminalActivityDetector
+	ContinuouslyDetectTerminalActivityWhileWaiting() bool
+}
+
 // PromptReadinessHints describes when an after-start prompt should be sent.
 // Empty patterns mean "send immediately" unless the adapter also implements
 // TerminalActivityDetector, in which case AO waits for an authoritative idle


### PR DESCRIPTION
## Summary
- add continuous terminal activity detection for Crush TUI sessions
- derive idle, active, and waiting-input from recent terminal UI markers
- document real Crush v0.80.0 tmux-captured ready/completed/active prompt markers
- cover marker precedence and fail-closed transcript cases in Crush adapter tests

## Tests
- cd backend && go test ./internal/adapters/agent/crush -v
- cd backend && go test ./internal/observe/activity ./internal/session_manager
- cd backend && go test ./internal/adapters/agent/...

## Notes
- Real local captures covered fresh ready prompt, active generation, and completed turn back at prompt. The harmless shell-command prompt executed without showing a permission dialog in this local config, so permission/user-input coverage remains synthetic but keyed to Crush's explicit dialog/user-input UI labels.
- The first full adapter sweep initially hit flaky unrelated failures in fake timing and auth timeout tests; rerunning those packages passed, and the final full adapter sweep passed.