### PR TITLE
Fix/linux collapsed sidebar titlebar overlap

### DIFF
--- a/frontend/src/renderer/components/CenterPanelShell.test.tsx
+++ b/frontend/src/renderer/components/CenterPanelShell.test.tsx
@@ -1,20 +1,28 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Platform is read at module-load time in CenterPanelShell (top-level const),
-// so we must mock before importing the component.
 const mockIsMac = vi.hoisted(() => vi.fn(() => false));
-vi.mock("../lib/platform", () => ({ isMacPlatform: mockIsMac }));
+const mockIsLinux = vi.hoisted(() => vi.fn(() => false));
+const uiState = vi.hoisted(() => ({ isSidebarOpen: true }));
+vi.mock("../lib/platform", () => ({
+	isMacPlatform: mockIsMac,
+	isLinuxPlatform: mockIsLinux,
+}));
 
 vi.mock("../hooks/useWindowFullScreen", () => ({ useWindowFullScreen: () => false }));
 vi.mock("../stores/ui-store", () => ({
-	useUiStore: (sel: (s: { isSidebarOpen: boolean }) => unknown) => sel({ isSidebarOpen: true }),
+	useUiStore: (sel: (s: { isSidebarOpen: boolean }) => unknown) => sel(uiState),
 }));
 
-// Import after mocks are set up.
 const { CenterPanelShell } = await import("./CenterPanelShell");
 
 describe("CenterPanelShell platform classes", () => {
+	beforeEach(() => {
+		mockIsMac.mockReturnValue(false);
+		mockIsLinux.mockReturnValue(false);
+		uiState.isSidebarOpen = true;
+	});
+
 	it("applies center-panel-shell--mac on macOS", () => {
 		mockIsMac.mockReturnValue(true);
 		const { container } = render(<CenterPanelShell>x</CenterPanelShell>);
@@ -22,14 +30,23 @@ describe("CenterPanelShell platform classes", () => {
 	});
 
 	it("does not apply center-panel-shell--mac on Linux", () => {
-		mockIsMac.mockReturnValue(false);
+		mockIsLinux.mockReturnValue(true);
 		const { container } = render(<CenterPanelShell>x</CenterPanelShell>);
 		expect(container.firstElementChild!.classList.contains("center-panel-shell--mac")).toBe(false);
 	});
 
 	it("does not apply center-panel-shell--mac on Windows", () => {
-		mockIsMac.mockReturnValue(false);
 		const { container } = render(<CenterPanelShell>x</CenterPanelShell>);
 		expect(container.firstElementChild!.classList.contains("center-panel-shell--mac")).toBe(false);
+	});
+
+	it("pads the framed titlebar past the Linux nav cluster when the sidebar is collapsed", () => {
+		mockIsLinux.mockReturnValue(true);
+		uiState.isSidebarOpen = false;
+		const { container } = render(<CenterPanelShell>x</CenterPanelShell>);
+		expect(container.firstElementChild!.classList.contains("center-panel-shell--titlebar-clearance-linux")).toBe(
+			true,
+		);
+		expect(container.firstElementChild!.classList.contains("center-panel-shell--titlebar-clearance")).toBe(false);
 	});
 });

--- a/frontend/src/renderer/components/CenterPanelShell.tsx
+++ b/frontend/src/renderer/components/CenterPanelShell.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { cn } from "../lib/utils";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
-import { isMacPlatform } from "../lib/platform";
+import { isLinuxPlatform, isMacPlatform } from "../lib/platform";
 import { useUiStore } from "../stores/ui-store";
 
 /**
@@ -11,7 +11,8 @@ import { useUiStore } from "../stores/ui-store";
  * `center-panel-surface`).
  *
  * `titlebarAlign` (default true) pulls Board/Terminal titles up level with the
- * fixed TitlebarNav cluster (macOS only — Win/Linux use the ShellTopbar instead).
+ * fixed TitlebarNav cluster on macOS and Linux. Windows keeps those controls in
+ * its custom titlebar, so it does not need this clearance.
  */
 export function CenterPanelShell({
 	className,
@@ -26,8 +27,11 @@ export function CenterPanelShell({
 }) {
 	const isSidebarOpen = useUiStore((state) => state.isSidebarOpen);
 	const isFullScreen = useWindowFullScreen();
-	const align = titlebarAlign && isMacPlatform();
+	const isMac = isMacPlatform();
+	const isLinux = isLinuxPlatform();
+	const align = titlebarAlign && isMac;
 	const titlebarClearance = align && !isSidebarOpen;
+	const linuxTitlebarClearance = titlebarAlign && isLinux && !isSidebarOpen;
 
 	return (
 		<div
@@ -36,6 +40,7 @@ export function CenterPanelShell({
 				align && "center-panel-shell--mac",
 				titlebarClearance && "center-panel-shell--titlebar-clearance",
 				titlebarClearance && isFullScreen && "center-panel-shell--titlebar-clearance-fullscreen",
+				linuxTitlebarClearance && "center-panel-shell--titlebar-clearance-linux",
 				align && isFullScreen && "center-panel-shell--fullscreen",
 				className,
 			)}

--- a/frontend/src/renderer/components/ShellTopbar.linux.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.linux.test.tsx
@@ -1,0 +1,78 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUiStore } from "../stores/ui-store";
+import { TooltipProvider } from "./ui/tooltip";
+
+const { paramsMock, useWorkspaceQueryMock } = vi.hoisted(() => ({
+	paramsMock: { projectId: undefined as string | undefined, sessionId: undefined as string | undefined },
+	useWorkspaceQueryMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+	return {
+		...actual,
+		useNavigate: () => vi.fn(),
+		useParams: () => paramsMock,
+	};
+});
+
+vi.mock("../hooks/useWorkspaceQuery", () => ({
+	useWorkspaceQuery: () => useWorkspaceQueryMock(),
+	workspaceQueryKey: ["workspaces"],
+}));
+
+vi.mock("../lib/platform", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/platform")>();
+	return {
+		...actual,
+		isLinuxPlatform: () => true,
+		isMacPlatform: () => false,
+		usesBoardActionsInPanel: () => false,
+		hidesShellTopbar: () => false,
+	};
+});
+
+vi.mock("./NotificationCenter", () => ({
+	NotificationCenter: () => <button aria-label="Notifications" type="button" />,
+}));
+
+const { ShellTopbar } = await import("./ShellTopbar");
+
+describe("ShellTopbar on Linux", () => {
+	beforeEach(() => {
+		paramsMock.projectId = undefined;
+		paramsMock.sessionId = undefined;
+		useWorkspaceQueryMock.mockReturnValue({ data: [], isError: false, isLoading: false });
+		useUiStore.setState({ isSidebarOpen: true });
+	});
+
+	it("pads the Board label past the collapse arrows when the sidebar is off-canvas", () => {
+		useUiStore.setState({ isSidebarOpen: false });
+		render(
+			<QueryClientProvider client={new QueryClient()}>
+				<TooltipProvider>
+					<ShellTopbar />
+				</TooltipProvider>
+			</QueryClientProvider>,
+		);
+
+		const header = screen.getByTestId("board-topbar-label").closest("header");
+		expect(header).toHaveStyle({ paddingLeft: "94px" });
+		expect(screen.getByTestId("board-topbar-label")).toHaveTextContent("Board");
+	});
+
+	it("keeps the default title padding while the sidebar is open", () => {
+		render(
+			<QueryClientProvider client={new QueryClient()}>
+				<TooltipProvider>
+					<ShellTopbar />
+				</TooltipProvider>
+			</QueryClientProvider>,
+		);
+
+		const header = screen.getByTestId("board-topbar-label").closest("header");
+		expect(header).toHaveStyle({ paddingLeft: "18px" });
+	});
+});

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -25,7 +25,7 @@ import { useUiStore } from "../stores/ui-store";
 import { OrchestratorIcon } from "./icons";
 import { OrchestratorActivityIndicator } from "./OrchestratorActivityIndicator";
 import { getAgentActivityView } from "../lib/session-presentation";
-import { isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
+import { isLinuxPlatform, isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { cn } from "../lib/utils";
 import { SHELL_PANEL_SPRING } from "../lib/motion-spring";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
@@ -57,9 +57,12 @@ const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperti
 // --size-titlebar-cluster-left (72) + --size-titlebar-cluster-width (3×28+2×4=92)
 // + --size-titlebar-content-gap (12) = 176; minus --size-center-panel-inset-mac (6) = 170.
 // Fullscreen: --space-2 (8) + 92 + 12 = 112.
+// Linux: --size-titlebar-cluster-left-linux (6) + 92 + 12 = 110; minus
+// --size-center-panel-inline-inset (16) because the framed panel keeps that gutter.
 const PADDING_DEFAULT = 18; // 1.125rem
 const PADDING_CLEARANCE = 170;
 const PADDING_CLEARANCE_FULLSCREEN = 112;
+const PADDING_CLEARANCE_LINUX = 94;
 
 export function ShellTopbar({
 	embedded = false,
@@ -82,12 +85,15 @@ export function ShellTopbar({
 	const isFullScreen = useWindowFullScreen();
 	const prefersReducedMotion = useReducedMotion();
 	const mac = isMacPlatform();
+	const linux = isLinuxPlatform();
 	const targetPaddingLeft =
-		!embedded && mac && !isSidebarOpen
+		!embedded && !isSidebarOpen && mac
 			? isFullScreen
 				? PADDING_CLEARANCE_FULLSCREEN
 				: PADDING_CLEARANCE
-			: PADDING_DEFAULT;
+			: !embedded && !isSidebarOpen && linux
+				? PADDING_CLEARANCE_LINUX
+				: PADDING_DEFAULT;
 	const paddingLeft = useMotionValue(targetPaddingLeft);
 	useEffect(() => {
 		const controls = animate(

--- a/frontend/src/renderer/components/TitlebarNav.linux.test.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.linux.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { history } = vi.hoisted(() => ({
+	history: {
+		back: vi.fn(),
+		forward: vi.fn(),
+		location: { state: { __TSR_index: 0 } },
+		subscribe: vi.fn(() => () => undefined),
+	},
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	useCanGoBack: () => false,
+	useRouter: () => ({ history }),
+}));
+
+vi.mock("../lib/platform", () => ({
+	isLinuxPlatform: () => true,
+	isMacPlatform: () => false,
+}));
+
+const { TitlebarNav } = await import("./TitlebarNav");
+
+describe("TitlebarNav on Linux", () => {
+	it("pins the collapse cluster to the Linux inset, not the macOS traffic-light offset", () => {
+		const { container } = render(<TitlebarNav />);
+
+		const nav = container.querySelector('[data-slot="titlebar-nav"]');
+		expect(nav).toHaveClass("left-titlebar-cluster-left-linux", "top-0.75");
+		expect(nav).not.toHaveClass("left-0");
+		expect(nav).not.toHaveClass("left-titlebar-cluster-left");
+	});
+});

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -61,9 +61,9 @@ export function TitlebarNav({
   // 12px hit target (centerline 18); the 40px clearance band is items-centered,
   // so top: -2px puts the toggle/arrows on that same centerline. Linux: no
   // traffic lights, so it sits at the sidebar's top-left within the reserved
-  // titlebar band.
+  // titlebar band (cluster-left-linux, not flush to the window edge).
   const leftClass = !isMac
-    ? "left-0"
+    ? "left-titlebar-cluster-left-linux"
     : isFullScreen
       ? "left-titlebar-cluster-left-fullscreen"
       : "left-titlebar-cluster-left";

--- a/frontend/src/renderer/components/WindowTitlebar.test.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.test.tsx
@@ -155,5 +155,7 @@ describe("WindowTitlebar", () => {
     expect(tokens).toMatch(
       /--size-center-panel-inset: 24px;\s*--size-center-panel-inline-inset: 16px;\s*--size-center-panel-bottom-inset: 14px;/s,
     );
+    expect(tokens).toContain("--size-titlebar-content-offset-linux");
+    expect(css).toContain(".center-panel-shell--titlebar-clearance-linux .center-panel-titlebar");
   });
 });

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -193,6 +193,7 @@
 	--spacing-window-titlebar: var(--size-window-titlebar);
 	--spacing-titlebar-content-offset: var(--size-titlebar-content-offset);
 	--spacing-titlebar-cluster-left: var(--size-titlebar-cluster-left);
+	--spacing-titlebar-cluster-left-linux: var(--size-titlebar-cluster-left-linux);
 	/* Fullscreen has no traffic lights — align the cluster to sidebar content. */
 	--spacing-titlebar-cluster-left-fullscreen: var(--space-2);
 	--spacing-traffic-light-clearance: var(--size-traffic-light-clearance);
@@ -521,7 +522,9 @@
 }
 
 .session-topbar-titlebar-clearance-linux {
-	padding-left: var(--size-titlebar-content-offset-linux);
+	/* Subtract the framed-panel inset: unlike macOS, Linux keeps
+	 * --size-center-panel-inline-inset when the sidebar is off-canvas. */
+	padding-left: calc(var(--size-titlebar-content-offset-linux) - var(--size-center-panel-inline-inset));
 }
 
 .center-panel-shell.center-panel-shell--session {
@@ -570,6 +573,12 @@
  * drops the traffic-light reserve so title sits next to the left-edge buttons. */
 .center-panel-shell--titlebar-clearance .center-panel-titlebar {
 	padding-left: calc(var(--size-titlebar-content-offset) - var(--size-center-panel-inset-mac));
+}
+
+/* Linux: same cluster clearance without the traffic-light reserve. Keep the
+ * framed inset in the subtract so Board/title text clears the arrows. */
+.center-panel-shell--titlebar-clearance-linux .center-panel-titlebar {
+	padding-left: calc(var(--size-titlebar-content-offset-linux) - var(--size-center-panel-inline-inset));
 }
 
 /* Fullscreen: the shell is flush, so measure from the cluster's own left edge. */

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -302,7 +302,7 @@
 	--size-sidebar-mobile: 288px;
 	--size-titlebar-cluster-left: 72px;
 	/* Linux has no traffic lights: the cluster sits at the sidebar's own left
-	 * inset (TitlebarNav `left-1.5`). */
+	 * inset (TitlebarNav `left-titlebar-cluster-left-linux`). */
 	--size-titlebar-cluster-left-linux: 6px;
 	/* TitlebarNav cluster: 3 × --size-control-md buttons + 2 × 4px flex gaps. */
 	--size-titlebar-cluster-width: calc(3 * var(--size-control-md) + 2 * 4px);
@@ -311,6 +311,9 @@
 	/* Clears fixed TitlebarNav (cluster-left + toggle/arrows) when the sidebar is off-canvas. */
 	--size-titlebar-content-offset: calc(
 		var(--size-titlebar-cluster-left) + var(--size-titlebar-cluster-width) + var(--size-titlebar-content-gap)
+	);
+	--size-titlebar-content-offset-linux: calc(
+		var(--size-titlebar-cluster-left-linux) + var(--size-titlebar-cluster-width) + var(--size-titlebar-content-gap)
 	);
 
 	/* Keep macOS traffic-light chrome aligned with the shared route topbar. */


### PR DESCRIPTION
Fixed #4062

## Summary
- On Linux the sidebar toggle and back/forward arrows stay fixed at the left edge when the sidebar is collapsed.
- The Board icon/label (and session tab strip) now pad past that cluster so they no longer overlap the arrows.
- Defines the missing Linux titlebar offset token and uses it for ShellTopbar, the framed panel, and session clearance.

## Test plan
- [ ] On Linux, open a project board with the sidebar expanded — Board label sits in the framed topbar as before.
- [ ] Collapse the left sidebar — collapse button and history arrows do not overlap the Board icon or “Board” text.
- [ ] Expand the sidebar again — spacing returns to the default inset.
- [ ] Collapse the sidebar on a session view — tabs/title clear the same cluster.
- [ ] macOS/Windows unchanged: traffic-light cluster and Windows titlebar behavior stay as they are.