### PR TITLE
fix(claude-code): reconcile stuck-active sessions via terminal activity detection

### DIFF
--- a/backend/internal/adapters/agent/claudecode/terminal_activity.go
+++ b/backend/internal/adapters/agent/claudecode/terminal_activity.go
@@ -1,0 +1,25 @@
+package claudecode
+
+import (
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// DetectTerminalActivity reports idle only when Claude's rendered surface
+// positively shows an idle composer: no active spinner/interrupt chrome and no
+// pending provider decision frame. Anything else is not authoritative.
+//
+// Claude Code's durable activity is hook-driven, and a turn that dies without
+// emitting its Stop hook (auth expiry, CLI crash, network loss) leaves the
+// session stuck active forever. This capability is what opts the adapter into
+// the activity observer's stale-active reconciliation, which screen-proves
+// idle after the hook state has been quiet past its staleness limit. Claude
+// intentionally does not implement ContinuousTerminalActivityDetector: hooks
+// stay authoritative while they flow, and the composer draft state must never
+// promote or demote sticky states on its own.
+func (p *Plugin) DetectTerminalActivity(output string) (domain.ActivityState, bool) {
+	if p.InspectTerminalSurface(output).Work == ports.TerminalSurfaceWorkIdle {
+		return domain.ActivityIdle, true
+	}
+	return "", false
+}

--- a/backend/internal/adapters/agent/claudecode/terminal_activity_test.go
+++ b/backend/internal/adapters/agent/claudecode/terminal_activity_test.go
@@ -1,0 +1,94 @@
+package claudecode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// claudeAbortedTurnScreen reproduces the live pane of a Claude Code session
+// whose turn died on an expired OAuth login: the turn's Stop hook never fired,
+// the composer holds an unsent user draft, and the CLI sits idle at the
+// prompt. Captured plain (tmux capture-pane without -e), which is exactly what
+// the activity observer's GetOutput provides.
+func claudeAbortedTurnScreen(draft string) string {
+	rule := strings.Repeat("─", 48)
+	return "⏺ Stopped watching Artifact: \"scm-observer.md\" (connection lost)\n" +
+		"\n" +
+		"⏺ Login expired · Please run /login\n" +
+		"\n" +
+		"✻ Worked for 0s\n" +
+		"\n" +
+		rule + "\n" +
+		draft +
+		rule + "\n" +
+		"\n" +
+		"  ⏵⏵ bypass permissions on (shift+tab to cycle) · PR #4090\n" +
+		"  ⧉  scm-observer"
+}
+
+func TestDetectTerminalActivityAuthoritativeIdleAfterAbortedTurn(t *testing.T) {
+	plugin := &Plugin{}
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{
+			name: "login expired with staged draft",
+			output: claudeAbortedTurnScreen("❯ so btw, the status isn't permanently stuck at \"Checking merge readiness\". It's stuck at that for\n" +
+				"  most of the time but keeps showing the merge status once in a while.\n"),
+		},
+		{
+			name:   "login expired with empty composer",
+			output: claudeAbortedTurnScreen("❯\n"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, ok := plugin.DetectTerminalActivity(tt.output)
+			if !ok || state != domain.ActivityIdle {
+				t.Fatalf("DetectTerminalActivity = (%q, %v), want (idle, true)", state, ok)
+			}
+		})
+	}
+}
+
+func TestDetectTerminalActivityFailsClosedOffIdle(t *testing.T) {
+	plugin := &Plugin{}
+	rule := strings.Repeat("─", 48)
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{
+			name:   "active spinner row",
+			output: "✶ Generating… (esc to interrupt · 2s)\n" + rule + "\n❯\n" + rule,
+		},
+		{
+			name: "active with interrupt hint in footer",
+			output: "✻ Computing… (24s · ↓ 114 tokens)\n" + rule + "\n❯\n" + rule +
+				"\n⏵⏵ auto mode on (shift+tab to cycle) · esc to interrupt · ← for agents",
+		},
+		{
+			name:   "permission dialog",
+			output: "Do you want to proceed?\n❯ 1. Yes\n  2. No\nPress enter to confirm",
+		},
+		{
+			name:   "no recognizable surface",
+			output: "plain build output\nwithout any provider chrome\n",
+		},
+		{
+			name:   "empty capture",
+			output: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, ok := plugin.DetectTerminalActivity(tt.output)
+			if ok {
+				t.Fatalf("DetectTerminalActivity = (%q, true), want not authoritative", state)
+			}
+		})
+	}
+}

--- a/backend/internal/observe/activity/observer_test.go
+++ b/backend/internal/observe/activity/observer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/muse"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -160,6 +161,72 @@ func TestPollLeavesOtherHarnessesUntouched(t *testing.T) {
 	sink := &fakeSink{}
 	runtime := &fakeRuntime{output: "› prompt\nmodel · ~/project\n"}
 	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{activeSession(now, domain.HarnessDroid)}},
+		sink,
+		runtime,
+		fakeAgents{domain.HarnessDroid: droid.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.calls != 0 || len(sink.signals) != 0 {
+		t.Fatalf("unaffected harness: output calls=%d signals=%+v", runtime.calls, sink.signals)
+	}
+}
+
+// claudeStuckActiveScreen is the rendered Claude Code surface after a turn
+// aborted without its Stop hook (expired login): idle composer holding an
+// unsent draft, provider footer below, no active chrome. This is the screen a
+// session stranded in durable "active" actually shows.
+const claudeStuckActiveScreen = "⏺ Login expired · Please run /login\n" +
+	"\n" +
+	"✻ Worked for 0s\n" +
+	"\n" +
+	"────────────────────────────────────────────────\n" +
+	"❯ so btw, the status isn't permanently stuck\n" +
+	"────────────────────────────────────────────────\n" +
+	"\n" +
+	"  ⏵⏵ bypass permissions on (shift+tab to cycle) · PR #4090\n"
+
+func TestPollReconcilesStaleClaudeCodeAfterAbortedTurn(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	session := activeSession(now, domain.HarnessClaudeCode)
+	sink := &fakeSink{}
+	runtime := &fakeRuntime{output: claudeStuckActiveScreen}
+	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{session}},
+		sink,
+		runtime,
+		fakeAgents{domain.HarnessClaudeCode: claudecode.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.signals) != 1 {
+		t.Fatalf("signals = %d, want 1", len(sink.signals))
+	}
+	signal := sink.signals[0]
+	if sink.id != session.ID || signal.State != domain.ActivityIdle || signal.Event != "terminal-idle" {
+		t.Fatalf("unexpected reconciliation: id=%q signal=%+v", sink.id, signal)
+	}
+	if !signal.ExpectedUpdatedAt.Equal(session.UpdatedAt) || signal.LaunchID != "launch-1" {
+		t.Fatalf("reconciliation fence = %+v, want updatedAt=%v launch=launch-1", signal, session.UpdatedAt)
+	}
+}
+
+func TestPollKeepsGenuineLongClaudeTurnActive(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	sink := &fakeSink{}
+	runtime := &fakeRuntime{output: "✻ Computing… (3m 10s · ↓ 114 tokens)\n" +
+		"────────────────────────────────────────────────\n" +
+		"❯\n" +
+		"────────────────────────────────────────────────\n" +
+		"⏵⏵ auto mode on (shift+tab to cycle) · esc to interrupt · ← for agents\n"}
+	observer := New(
 		fakeSessions{rows: []domain.SessionRecord{activeSession(now, domain.HarnessClaudeCode)}},
 		sink,
 		runtime,
@@ -170,8 +237,8 @@ func TestPollLeavesOtherHarnessesUntouched(t *testing.T) {
 	if err := observer.Poll(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if runtime.calls != 0 || len(sink.signals) != 0 {
-		t.Fatalf("unaffected harness: output calls=%d signals=%+v", runtime.calls, sink.signals)
+	if len(sink.signals) != 0 {
+		t.Fatalf("long active turn emitted reconciliation: %+v", sink.signals)
 	}
 }
 


### PR DESCRIPTION
Fixes #4142

## Summary

A Claude Code turn that dies without emitting its Stop hook (expired OAuth login, CLI crash, network loss) left the session's hook-driven activity stuck at `active`, so the app showed **status=working** forever while the CLI sat idle at its composer (live incident: `agent-orchestrator-139`, stranded on `Login expired · Please run /login`).

The activity observer already reconciles exactly this case — a session stale in `active` past 2 minutes is screen-proven against the adapter's `TerminalActivityDetector` — but the claude-code adapter never implemented that capability, so the observer skipped its sessions at the type assertion (`observer.go:111-114`).

This PR implements `DetectTerminalActivity` on the claude-code plugin, same pattern as codex (#3115): delegate to the existing `InspectTerminalSurface` and report an **authoritative idle only** when the current surface positively shows an idle composer with no active spinner/interrupt chrome and no pending decision frame. Anything else fails closed. Claude deliberately stays non-continuous: hooks remain authoritative while they flow; the observer only steps in for a stale `active`.

Scope note: this intentionally fixes claude-code only. The same class bug for other hook-only harnesses is tracked in #3387 (Kimi).

## Changes

- `backend/internal/adapters/agent/claudecode/terminal_activity.go` (new): `DetectTerminalActivity` delegating to `InspectTerminalSurface`, idle-only, fail-closed.
- `backend/internal/adapters/agent/claudecode/terminal_activity_test.go` (new): fixtures reproduce the real captured stuck screen (login-expired footer + staged draft, and empty-composer variant) → authoritative idle; active spinner, active footer hint, permission dialog, unrecognizable/empty output → not authoritative.
- `backend/internal/observe/activity/observer_test.go`: `TestPollLeavesOtherHarnessesUntouched` previously pinned claude-code as exempt from reconciliation (encoding the bug) — now uses droid as the detector-less example. Added `TestPollReconcilesStaleClaudeCodeAfterAbortedTurn` (stuck screen → one `terminal-idle` signal with launch/updatedAt fence) and `TestPollKeepsGenuineLongClaudeTurnActive` (real active chrome → no signal).

## Behavior notes

Implementing the `TerminalActivityDetector` port also opts claude-code into the two existing detector consumers beyond the observer, both matching codex's shipped behavior:
- `WaitForMessageDeliveryReady` now screen-proves the composer before injecting (previously: durable idle + first-hook-or-5s fallback) — strictly stronger evidence.
- The interface-transition drain's legacy fallback (only reachable when styled output is unavailable) can now prove idle for claude-code; it additionally requires `ComposerIsEmpty`, which claude-code already implements.

## Tests

- `go test ./internal/adapters/agent/claudecode/ ./internal/observe/activity/ ./internal/session_manager/ ./internal/lifecycle/` — pass
- Full `go test ./...` — pass (`internal/cli` requires all `AO_*` env unset; failures with leaked env are pre-existing and unrelated)
- Classifier hand-verified against the live stuck pane of `agent-orchestrator-139` (plain `tmux capture-pane`, which is what the observer's `GetOutput` provides): `Work=Idle`, so the observer converges the session within one tick after staleness.

## Risks / follow-ups

- A genuinely active turn whose rendering momentarily lacks both the spinner row and the footer interrupt hint could be sampled as idle; the next tool hook immediately re-asserts `active`, and this is the same trade-off codex has shipped since #3115.
- Follow-up filed separately: surface the `Login expired` screen as a distinct needs-input reason so users know to run `/login` instead of seeing a silent idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)