### PR TITLE
fix(browser): tighten and round the tab close button

### DIFF
--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -448,8 +448,8 @@ function ExpandedTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab
 			<button
 				aria-label={closeLabel}
 				className={cn(
-					"grid size-5 shrink-0 place-items-center overflow-hidden text-passive opacity-0",
-					"transition-opacity hover:bg-interactive-hover hover:text-foreground",
+					"mr-1.5 grid size-control-sm shrink-0 place-items-center overflow-hidden rounded-sm text-passive opacity-0",
+					"transition-[opacity,background-color,color] hover:bg-interactive-hover hover:text-foreground",
 					"group-hover/tab-row:opacity-100 group-focus-within/tab-row:opacity-100",
 					"disabled:pointer-events-none",
 				)}


### PR DESCRIPTION
## Summary
- The browser tab close button (docked side panel and popped-out fullscreen view — both share `BrowserTabsRail.tsx`) sat flush against the row edge with no rounding, making it look cramped and out of proportion with the rest of the row.
- Rounded it (`rounded-sm`) and gave it inset margin off the edge, sized to `size-control-sm` — the same treatment already used by the terminal tab's close button, for visual consistency with the rest of the app.

<img width="759" height="211" alt="image" src="https://github.com/user-attachments/assets/8a3b619a-19c1-4035-917c-a6ec1b991764" />


## Test plan
- Small, isolated Tailwind class change on a single button; no logic changes.