### PR TITLE
fix: isolate ChatUI history by session

### DIFF
--- a/backend/internal/domain/conversation.go
+++ b/backend/internal/domain/conversation.go
@@ -35,6 +35,13 @@ const (
 	ConversationScopeProject ConversationScope = "project"
 )
 
+// ConversationContextResetProviderItemID returns the durable identity of the
+// hidden activity that separates a fresh project orchestrator context from the
+// project conversation history that came before it.
+func ConversationContextResetProviderItemID(session SessionID) string {
+	return "ao-context-reset:" + string(session)
+}
+
 // TurnState is the lifecycle of one request and the agent work that follows it.
 type TurnState string
 

--- a/backend/internal/domain/conversation_test.go
+++ b/backend/internal/domain/conversation_test.go
@@ -1,0 +1,10 @@
+package domain
+
+import "testing"
+
+func TestConversationContextResetProviderItemID(t *testing.T) {
+	const session = SessionID("orchestrator-2")
+	if got := ConversationContextResetProviderItemID(session); got != "ao-context-reset:orchestrator-2" {
+		t.Fatalf("ConversationContextResetProviderItemID() = %q", got)
+	}
+}

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -38,6 +38,7 @@ const (
 // the SQLite store.
 type Store interface {
 	CreateConversation(ctx context.Context, id string, scope domain.ConversationScope, project domain.ProjectID, session domain.SessionID, now time.Time) (domain.ConversationRecord, error)
+	CreateProjectConversationWithContextReset(ctx context.Context, id string, project domain.ProjectID, session domain.SessionID, reset domain.ConversationActivity, now time.Time) (domain.ConversationRecord, error)
 	ConversationForSession(ctx context.Context, session domain.SessionID) (domain.ConversationRecord, error)
 	ClaimChatControllerGeneration(ctx context.Context, session domain.SessionID, generation string, now time.Time) error
 	ConversationBranch(ctx context.Context, conversationID, branchID string) (domain.ConversationBranch, error)

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -1086,7 +1086,8 @@ func TestFreshProjectControllerRecordsNativeContextBoundary(t *testing.T) {
 		t.Fatalf("activities = %#v, want old history plus context boundary", snapshot.Activities)
 	}
 	boundary := snapshot.Activities[1]
-	if boundary.Kind != domain.ActivityKindSystem || boundary.ProviderItemID != "ao-context-reset:p1-2" {
+	if boundary.Kind != domain.ActivityKindSystem ||
+		boundary.ProviderItemID != domain.ConversationContextResetProviderItemID(replacement) {
 		t.Fatalf("boundary = %#v", boundary)
 	}
 	var detail map[string]string
@@ -1154,7 +1155,7 @@ func TestFreshProjectControllerStartFailureKeepsPreviousHistoryHidden(t *testing
 		t.Fatalf("LoadConversationSnapshot: %v", err)
 	}
 	if len(snapshot.Activities) != 1 ||
-		snapshot.Activities[0].ProviderItemID != "ao-context-reset:"+string(replacement) {
+		snapshot.Activities[0].ProviderItemID != domain.ConversationContextResetProviderItemID(replacement) {
 		t.Fatalf("reset boundary after failed start = %#v", snapshot.Activities)
 	}
 	page, err := st.LoadConversationSnapshotPage(ctx, conversation.ID, 0, 10)

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -941,9 +942,15 @@ func TestFreshProjectControllerRecordsNativeContextBoundary(t *testing.T) {
 
 	const replacement = domain.SessionID("p1-2")
 	if _, err := st.CreateSession(ctx, domain.SessionRecord{
-		ID: replacement, ProjectID: testProject, Kind: domain.KindOrchestrator,
-		Harness: domain.HarnessCodex, Mode: domain.SessionModeChat,
-		CreatedAt: now, UpdatedAt: now,
+		ID:        replacement,
+		ProjectID: testProject,
+		Kind:      domain.KindOrchestrator,
+		Harness:   domain.HarnessCodex,
+		Mode:      domain.SessionModeChat,
+		Activity:  domain.Activity{State: domain.ActivityActive, LastActivityAt: now},
+		Metadata:  domain.SessionMetadata{Branch: "feat/replacement", WorkspacePath: t.TempDir()},
+		CreatedAt: now,
+		UpdatedAt: now,
 	}); err != nil {
 		t.Fatalf("seed replacement session: %v", err)
 	}
@@ -994,6 +1001,75 @@ func TestFreshProjectControllerRecordsNativeContextBoundary(t *testing.T) {
 	}
 	if detail["event"] != "context.reset" {
 		t.Fatalf("boundary event = %q", detail["event"])
+	}
+}
+
+func TestFreshProjectControllerStartFailureKeepsPreviousHistoryHidden(t *testing.T) {
+	st := openStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC)
+	conversation, err := st.CreateConversation(ctx, "project-conversation",
+		domain.ConversationScopeProject, testProject, testSession, now)
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if _, err := st.AppendUserMessage(ctx, conversation.ID, testSession, "old-generation",
+		domain.ConversationMessage{
+			ID: "old-message", Text: "old orchestrator history", Origin: domain.MessageOriginHuman,
+		}, "old-turn", now.Add(time.Second)); err != nil {
+		t.Fatalf("seed old history: %v", err)
+	}
+
+	replacementRecord, err := st.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: testProject,
+		Kind:      domain.KindOrchestrator,
+		Harness:   domain.HarnessCodex,
+		Mode:      domain.SessionModeChat,
+		Activity:  domain.Activity{State: domain.ActivityActive, LastActivityAt: now},
+		Metadata:  domain.SessionMetadata{Branch: "feat/replacement", WorkspacePath: t.TempDir()},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("seed replacement session: %v", err)
+	}
+	replacement := replacementRecord.ID
+
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers: fakeRegistry{driver: fakeDriver{
+			start: func(ports.ChatStartConfig) (ports.ChatConversation, error) {
+				return nil, errors.New("provider failed")
+			},
+		}},
+		Log: slog.New(slog.DiscardHandler),
+		NewID: func() string {
+			return "boundary-id"
+		},
+		Now: func() time.Time { return now.Add(2 * time.Second) },
+	})
+	if _, err := svc.Start(ctx, chatsvc.StartConfig{
+		SessionID: replacement, ProjectID: testProject, Kind: domain.KindOrchestrator,
+		Harness: domain.HarnessCodex, WorkspacePath: t.TempDir(),
+	}); err == nil || !strings.Contains(err.Error(), "provider failed") {
+		t.Fatalf("Start replacement error = %v, want provider failure", err)
+	}
+
+	snapshot, err := st.LoadConversationSnapshot(ctx, conversation.ID)
+	if err != nil {
+		t.Fatalf("LoadConversationSnapshot: %v", err)
+	}
+	if len(snapshot.Activities) != 1 ||
+		snapshot.Activities[0].ProviderItemID != "ao-context-reset:"+string(replacement) {
+		t.Fatalf("reset boundary after failed start = %#v", snapshot.Activities)
+	}
+	page, err := st.LoadConversationSnapshotPage(ctx, conversation.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("LoadConversationSnapshotPage: %v", err)
+	}
+	if len(page.Messages) != 0 || len(page.Activities) != 0 || len(page.Turns) != 0 || page.HasMoreBefore {
+		t.Fatalf("page after failed start = messages %#v activities %#v turns %#v hasMore %v, want empty",
+			page.Messages, page.Activities, page.Turns, page.HasMoreBefore)
 	}
 }
 

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -306,7 +306,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 			Status:         domain.ActivityStatusCompleted,
 			Summary:        "Agent context reset.",
 			Detail:         detail,
-			ProviderItemID: "ao-context-reset:" + string(cfg.SessionID),
+			ProviderItemID: domain.ConversationContextResetProviderItemID(cfg.SessionID),
 		}
 	}
 	conversationID := s.newID()

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -341,7 +341,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 			ID:             s.newID(),
 			Kind:           domain.ActivityKindSystem,
 			Status:         domain.ActivityStatusCompleted,
-			Summary:        "Started a fresh agent context. Earlier project history remains visible in AO but was not loaded into this agent.",
+			Summary:        "Agent context reset.",
 			Detail:         detail,
 			ProviderItemID: "ao-context-reset:" + string(cfg.SessionID),
 		}, s.now()); boundaryErr != nil {

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -272,8 +272,35 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	if cfg.Kind == domain.KindOrchestrator {
 		scope = domain.ConversationScopeProject
 	}
-	conversation, err := s.store.CreateConversation(
-		ctx, s.newID(), scope, cfg.ProjectID, cfg.SessionID, s.now())
+	now := s.now()
+	var resetBoundary domain.ConversationActivity
+	freshProjectContext := scope == domain.ConversationScopeProject && cfg.ProviderConversationID == ""
+	if freshProjectContext {
+		detail, marshalErr := json.Marshal(map[string]string{
+			"event":  "context.reset",
+			"reason": "native conversation was unavailable",
+		})
+		if marshalErr != nil {
+			return nil, fmt.Errorf("encode fresh context boundary: %w", marshalErr)
+		}
+		resetBoundary = domain.ConversationActivity{
+			ID:             s.newID(),
+			Kind:           domain.ActivityKindSystem,
+			Status:         domain.ActivityStatusCompleted,
+			Summary:        "Agent context reset.",
+			Detail:         detail,
+			ProviderItemID: "ao-context-reset:" + string(cfg.SessionID),
+		}
+	}
+	conversationID := s.newID()
+	var conversation domain.ConversationRecord
+	if freshProjectContext {
+		conversation, err = s.store.CreateProjectConversationWithContextReset(
+			ctx, conversationID, cfg.ProjectID, cfg.SessionID, resetBoundary, now)
+	} else {
+		conversation, err = s.store.CreateConversation(
+			ctx, conversationID, scope, cfg.ProjectID, cfg.SessionID, now)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("open conversation: %w", err)
 	}
@@ -327,29 +354,6 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	// it. Settling here covers every way a controller can come up, and is a no-op
 	// for a session that has none of it.
 	s.settleOrphanedWork(ctx, cfg.SessionID, conversation.ID)
-	if conversation.Scope == domain.ConversationScopeProject &&
-		conversation.LatestSequence > 0 && cfg.ProviderConversationID == "" {
-		detail, marshalErr := json.Marshal(map[string]string{
-			"event":  "context.reset",
-			"reason": "native conversation was unavailable",
-		})
-		if marshalErr != nil {
-			_ = conv.Close()
-			return nil, fmt.Errorf("encode fresh context boundary: %w", marshalErr)
-		}
-		if boundaryErr := s.store.UpsertActivity(ctx, conversation.ID, "", domain.ConversationActivity{
-			ID:             s.newID(),
-			Kind:           domain.ActivityKindSystem,
-			Status:         domain.ActivityStatusCompleted,
-			Summary:        "Agent context reset.",
-			Detail:         detail,
-			ProviderItemID: "ao-context-reset:" + string(cfg.SessionID),
-		}, s.now()); boundaryErr != nil {
-			_ = conv.Close()
-			return nil, fmt.Errorf("record fresh context boundary: %w", boundaryErr)
-		}
-	}
-
 	// A fresh generation per launch, so events from the controller this one
 	// replaced can be told apart from the current one's.
 	controller := newController(

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -1399,6 +1399,26 @@ func (q *Queries) SelectConversationBySession(ctx context.Context, currentSessio
 	return i, err
 }
 
+const selectConversationContextResetSequence = `-- name: SelectConversationContextResetSequence :one
+SELECT CAST(COALESCE(MAX(sequence), 0) AS INTEGER) AS sequence
+FROM conversation_activities
+WHERE conversation_id = ?
+  AND kind = 'system'
+  AND provider_item_id = ?
+`
+
+type SelectConversationContextResetSequenceParams struct {
+	ConversationID string
+	ProviderItemID string
+}
+
+func (q *Queries) SelectConversationContextResetSequence(ctx context.Context, arg SelectConversationContextResetSequenceParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, selectConversationContextResetSequence, arg.ConversationID, arg.ProviderItemID)
+	var sequence int64
+	err := row.Scan(&sequence)
+	return sequence, err
+}
+
 const selectConversationEditAnchor = `-- name: SelectConversationEditAnchor :one
 WITH RECURSIVE active_path(branch_id, max_sequence) AS (
     SELECT conversations.active_branch_id, CAST(NULL AS INTEGER)

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -891,6 +891,13 @@ SELECT * FROM conversation_activities
 WHERE conversation_id = ? AND provider_item_id = ?
 LIMIT 1;
 
+-- name: SelectConversationContextResetSequence :one
+SELECT CAST(COALESCE(MAX(sequence), 0) AS INTEGER) AS sequence
+FROM conversation_activities
+WHERE conversation_id = ?
+  AND kind = 'system'
+  AND provider_item_id = ?;
+
 -- Activities the agent still remembers, filtered the same way messages are and for
 -- the same reason. See SelectConversationMessages.
 -- name: SelectConversationActivities :many

--- a/backend/internal/storage/sqlite/store/conversation_history_store_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_history_store_test.go
@@ -404,7 +404,7 @@ func TestProjectConversationPageStartsAtCurrentContextReset(t *testing.T) {
 	if got := texts(page.Messages); !reflect.DeepEqual(got, []string{"fresh orchestrator work"}) {
 		t.Fatalf("page messages = %v", got)
 	}
-	if got := activitySummaries(page.Activities); !reflect.DeepEqual(got, []string{"Started a fresh agent context."}) {
+	if got := activitySummaries(page.Activities); len(got) != 0 {
 		t.Fatalf("page activities = %v", got)
 	}
 	if page.HasMoreBefore {

--- a/backend/internal/storage/sqlite/store/conversation_history_store_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_history_store_test.go
@@ -46,6 +46,22 @@ func conversationFixture(t *testing.T) (*sqlite.Store, domain.SessionID, string)
 	return s, session.ID, conversation.ID
 }
 
+func texts(messages []domain.ConversationMessage) []string {
+	out := make([]string, 0, len(messages))
+	for _, message := range messages {
+		out = append(out, message.Text)
+	}
+	return out
+}
+
+func activitySummaries(activities []domain.ConversationActivity) []string {
+	out := make([]string, 0, len(activities))
+	for _, activity := range activities {
+		out = append(out, activity.Summary)
+	}
+	return out
+}
+
 func TestProjectConversationRebindsAcrossOrchestratorReplacement(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
@@ -321,6 +337,87 @@ func TestConversationSnapshotPagesCombinedTimelineBySequence(t *testing.T) {
 	}
 	if got := []string{older.Messages[0].Text, older.Messages[1].Text}; !reflect.DeepEqual(got, []string{"two", "three"}) {
 		t.Fatalf("older messages = %v", got)
+	}
+}
+
+func TestProjectConversationPageStartsAtCurrentContextReset(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "project-reset")
+
+	firstRecord := sampleRecord("project-reset")
+	firstRecord.Kind = domain.KindOrchestrator
+	firstRecord.Mode = domain.SessionModeChat
+	first, err := s.CreateSession(ctx, firstRecord)
+	if err != nil {
+		t.Fatalf("create first orchestrator: %v", err)
+	}
+	conversation, err := s.CreateConversation(ctx, "project-reset-conversation", domain.ConversationScopeProject,
+		"project-reset", first.ID, histClock)
+	if err != nil {
+		t.Fatalf("create project conversation: %v", err)
+	}
+	if _, err := s.AppendUserMessage(ctx, conversation.ID, first.ID, "gen-1", domain.ConversationMessage{
+		ID: "old-message", Text: "old orchestrator history", Origin: domain.MessageOriginHuman,
+	}, "old-turn", histClock.Add(time.Second)); err != nil {
+		t.Fatalf("append old message: %v", err)
+	}
+	if err := s.UpsertActivity(ctx, conversation.ID, "", domain.ConversationActivity{
+		ID: "old-activity", Kind: domain.ActivityKindSystem, Status: domain.ActivityStatusCompleted,
+		Summary: "old project activity", ProviderItemID: "old-project-history",
+	}, histClock.Add(2*time.Second)); err != nil {
+		t.Fatalf("append old activity: %v", err)
+	}
+
+	secondRecord := sampleRecord("project-reset")
+	secondRecord.Kind = domain.KindOrchestrator
+	secondRecord.Mode = domain.SessionModeChat
+	second, err := s.CreateSession(ctx, secondRecord)
+	if err != nil {
+		t.Fatalf("create replacement orchestrator: %v", err)
+	}
+	rebound, err := s.CreateConversation(ctx, "unused-replacement-conversation", domain.ConversationScopeProject,
+		"project-reset", second.ID, histClock.Add(3*time.Second))
+	if err != nil {
+		t.Fatalf("rebind project conversation: %v", err)
+	}
+	if rebound.ID != conversation.ID {
+		t.Fatalf("rebound conversation = %q, want %q", rebound.ID, conversation.ID)
+	}
+	if err := s.UpsertActivity(ctx, conversation.ID, "", domain.ConversationActivity{
+		ID: "context-reset", Kind: domain.ActivityKindSystem, Status: domain.ActivityStatusCompleted,
+		Summary:        "Started a fresh agent context.",
+		ProviderItemID: "ao-context-reset:" + string(second.ID),
+	}, histClock.Add(4*time.Second)); err != nil {
+		t.Fatalf("append reset boundary: %v", err)
+	}
+	if _, err := s.AppendUserMessage(ctx, conversation.ID, second.ID, "gen-2", domain.ConversationMessage{
+		ID: "fresh-message", Text: "fresh orchestrator work", Origin: domain.MessageOriginHuman,
+	}, "fresh-turn", histClock.Add(5*time.Second)); err != nil {
+		t.Fatalf("append fresh message: %v", err)
+	}
+
+	page, err := s.LoadConversationSnapshotPage(ctx, conversation.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("LoadConversationSnapshotPage: %v", err)
+	}
+	if got := texts(page.Messages); !reflect.DeepEqual(got, []string{"fresh orchestrator work"}) {
+		t.Fatalf("page messages = %v", got)
+	}
+	if got := activitySummaries(page.Activities); !reflect.DeepEqual(got, []string{"Started a fresh agent context."}) {
+		t.Fatalf("page activities = %v", got)
+	}
+	if page.HasMoreBefore {
+		t.Fatalf("page HasMoreBefore = true; old orchestrator history must not be pageable from replacement")
+	}
+
+	older, err := s.LoadConversationSnapshotPage(ctx, conversation.ID, page.OldestSequence, 10)
+	if err != nil {
+		t.Fatalf("older page: %v", err)
+	}
+	if len(older.Messages) != 0 || len(older.Activities) != 0 || older.HasMoreBefore {
+		t.Fatalf("older page = messages %#v activities %#v hasMore %v, want empty at reset boundary",
+			older.Messages, older.Activities, older.HasMoreBefore)
 	}
 }
 

--- a/backend/internal/storage/sqlite/store/conversation_history_store_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_history_store_test.go
@@ -62,6 +62,14 @@ func activitySummaries(activities []domain.ConversationActivity) []string {
 	return out
 }
 
+func turnIDs(turns []domain.ConversationTurn) []string {
+	out := make([]string, 0, len(turns))
+	for _, turn := range turns {
+		out = append(out, turn.ID)
+	}
+	return out
+}
+
 func TestProjectConversationRebindsAcrossOrchestratorReplacement(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
@@ -384,6 +392,14 @@ func TestProjectConversationPageStartsAtCurrentContextReset(t *testing.T) {
 	if rebound.ID != conversation.ID {
 		t.Fatalf("rebound conversation = %q, want %q", rebound.ID, conversation.ID)
 	}
+	pending, err := s.LoadConversationSnapshotPage(ctx, conversation.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("pending reset page: %v", err)
+	}
+	if len(pending.Messages) != 0 || len(pending.Activities) != 0 || len(pending.Turns) != 0 || pending.HasMoreBefore {
+		t.Fatalf("pending reset page = messages %#v activities %#v turns %#v hasMore %v, want empty",
+			pending.Messages, pending.Activities, pending.Turns, pending.HasMoreBefore)
+	}
 	if err := s.UpsertActivity(ctx, conversation.ID, "", domain.ConversationActivity{
 		ID: "context-reset", Kind: domain.ActivityKindSystem, Status: domain.ActivityStatusCompleted,
 		Summary:        "Started a fresh agent context.",
@@ -407,6 +423,9 @@ func TestProjectConversationPageStartsAtCurrentContextReset(t *testing.T) {
 	if got := activitySummaries(page.Activities); len(got) != 0 {
 		t.Fatalf("page activities = %v", got)
 	}
+	if got := turnIDs(page.Turns); !reflect.DeepEqual(got, []string{"fresh-turn"}) {
+		t.Fatalf("page turns = %v", got)
+	}
 	if page.HasMoreBefore {
 		t.Fatalf("page HasMoreBefore = true; old orchestrator history must not be pageable from replacement")
 	}
@@ -418,6 +437,58 @@ func TestProjectConversationPageStartsAtCurrentContextReset(t *testing.T) {
 	if len(older.Messages) != 0 || len(older.Activities) != 0 || older.HasMoreBefore {
 		t.Fatalf("older page = messages %#v activities %#v hasMore %v, want empty at reset boundary",
 			older.Messages, older.Activities, older.HasMoreBefore)
+	}
+}
+
+func TestProjectConversationFreshContextRebindWritesResetBoundaryAtomically(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "project-atomic-reset")
+
+	firstRecord := sampleRecord("project-atomic-reset")
+	firstRecord.Kind = domain.KindOrchestrator
+	firstRecord.Mode = domain.SessionModeChat
+	first, err := s.CreateSession(ctx, firstRecord)
+	if err != nil {
+		t.Fatalf("create first orchestrator: %v", err)
+	}
+	conversation, err := s.CreateConversation(ctx, "project-atomic-conversation", domain.ConversationScopeProject,
+		"project-atomic-reset", first.ID, histClock)
+	if err != nil {
+		t.Fatalf("create project conversation: %v", err)
+	}
+	if _, err := s.AppendUserMessage(ctx, conversation.ID, first.ID, "gen-1", domain.ConversationMessage{
+		ID: "old-message", Text: "old orchestrator history", Origin: domain.MessageOriginHuman,
+	}, "old-turn", histClock.Add(time.Second)); err != nil {
+		t.Fatalf("append old message: %v", err)
+	}
+
+	secondRecord := sampleRecord("project-atomic-reset")
+	secondRecord.Kind = domain.KindOrchestrator
+	secondRecord.Mode = domain.SessionModeChat
+	second, err := s.CreateSession(ctx, secondRecord)
+	if err != nil {
+		t.Fatalf("create replacement orchestrator: %v", err)
+	}
+	rebound, err := s.CreateProjectConversationWithContextReset(ctx, "unused-atomic-conversation",
+		"project-atomic-reset", second.ID, domain.ConversationActivity{
+			ID: "context-reset", Kind: domain.ActivityKindSystem, Status: domain.ActivityStatusCompleted,
+			Summary:        "Agent context reset.",
+			ProviderItemID: "ao-context-reset:" + string(second.ID),
+		}, histClock.Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("atomic rebind: %v", err)
+	}
+	if rebound.ID != conversation.ID {
+		t.Fatalf("rebound conversation = %q, want %q", rebound.ID, conversation.ID)
+	}
+	page, err := s.LoadConversationSnapshotPage(ctx, conversation.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("LoadConversationSnapshotPage: %v", err)
+	}
+	if len(page.Messages) != 0 || len(page.Activities) != 0 || len(page.Turns) != 0 || page.HasMoreBefore {
+		t.Fatalf("page after atomic reset = messages %#v activities %#v turns %#v hasMore %v, want empty",
+			page.Messages, page.Activities, page.Turns, page.HasMoreBefore)
 	}
 }
 

--- a/backend/internal/storage/sqlite/store/conversation_history_store_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_history_store_test.go
@@ -403,7 +403,7 @@ func TestProjectConversationPageStartsAtCurrentContextReset(t *testing.T) {
 	if err := s.UpsertActivity(ctx, conversation.ID, "", domain.ConversationActivity{
 		ID: "context-reset", Kind: domain.ActivityKindSystem, Status: domain.ActivityStatusCompleted,
 		Summary:        "Started a fresh agent context.",
-		ProviderItemID: "ao-context-reset:" + string(second.ID),
+		ProviderItemID: domain.ConversationContextResetProviderItemID(second.ID),
 	}, histClock.Add(4*time.Second)); err != nil {
 		t.Fatalf("append reset boundary: %v", err)
 	}
@@ -474,7 +474,7 @@ func TestProjectConversationFreshContextRebindWritesResetBoundaryAtomically(t *t
 		"project-atomic-reset", second.ID, domain.ConversationActivity{
 			ID: "context-reset", Kind: domain.ActivityKindSystem, Status: domain.ActivityStatusCompleted,
 			Summary:        "Agent context reset.",
-			ProviderItemID: "ao-context-reset:" + string(second.ID),
+			ProviderItemID: domain.ConversationContextResetProviderItemID(second.ID),
 		}, histClock.Add(2*time.Second))
 	if err != nil {
 		t.Fatalf("atomic rebind: %v", err)

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -1827,6 +1827,20 @@ func (s *Store) LoadConversationSnapshotPage(
 	if beforeSequence <= 0 || beforeSequence > conv.LatestSequence+1 {
 		beforeSequence = conv.LatestSequence + 1
 	}
+	visibleAfterSequence, err := s.conversationVisibleAfterSequence(ctx, conv)
+	if err != nil {
+		return ConversationSnapshot{}, err
+	}
+	if beforeSequence <= visibleAfterSequence {
+		snapshot := ConversationSnapshot{
+			Conversation:               conversationToDomain(conv),
+			BranchPoints:               s.conversationBranchPoints(ctx, conversationID),
+			BranchedFromEarlierMessage: s.conversationBranchedFromEarlierMessage(ctx, conversationID, conv.ActiveBranchID),
+			OldestSequence:             visibleAfterSequence,
+			HasMoreBefore:              false,
+		}
+		return snapshot, nil
+	}
 	fetchLimit := limit + 1
 
 	messageRows, err := s.qr.SelectConversationMessagesPage(ctx, gen.SelectConversationMessagesPageParams{
@@ -1848,10 +1862,14 @@ func (s *Store) LoadConversationSnapshotPage(
 
 	sequences := make([]int64, 0, len(messageRows)+len(activityRows))
 	for _, row := range messageRows {
-		sequences = append(sequences, row.Sequence)
+		if row.Sequence >= visibleAfterSequence {
+			sequences = append(sequences, row.Sequence)
+		}
 	}
 	for _, row := range activityRows {
-		sequences = append(sequences, row.Sequence)
+		if row.Sequence >= visibleAfterSequence {
+			sequences = append(sequences, row.Sequence)
+		}
 	}
 	sort.Slice(sequences, func(i, j int) bool { return sequences[i] > sequences[j] })
 	hasMore := int64(len(sequences)) > limit
@@ -1861,6 +1879,12 @@ func (s *Store) LoadConversationSnapshotPage(
 	oldest := beforeSequence
 	if len(sequences) > 0 {
 		oldest = sequences[len(sequences)-1]
+	}
+	if oldest < visibleAfterSequence {
+		oldest = visibleAfterSequence
+	}
+	if oldest <= visibleAfterSequence {
+		hasMore = false
 	}
 
 	turnRows, err := s.qr.SelectConversationTurnsPage(ctx, gen.SelectConversationTurnsPageParams{
@@ -1885,16 +1909,33 @@ func (s *Store) LoadConversationSnapshotPage(
 	// SQL returns newest-first so LIMIT is useful; the API contract remains
 	// oldest-first inside each page.
 	for i := len(messageRows) - 1; i >= 0; i-- {
-		if messageRows[i].Sequence >= oldest {
+		if messageRows[i].Sequence >= oldest && messageRows[i].Sequence >= visibleAfterSequence {
 			snapshot.Messages = append(snapshot.Messages, messageToDomain(messageRows[i]))
 		}
 	}
 	for i := len(activityRows) - 1; i >= 0; i-- {
-		if activityRows[i].Sequence >= oldest {
+		if activityRows[i].Sequence >= oldest && activityRows[i].Sequence >= visibleAfterSequence {
 			snapshot.Activities = append(snapshot.Activities, activityToDomain(activityRows[i]))
 		}
 	}
 	return snapshot, nil
+}
+
+func (s *Store) conversationVisibleAfterSequence(
+	ctx context.Context,
+	conv gen.Conversation,
+) (int64, error) {
+	if conv.Scope != domain.ConversationScopeProject || conv.CurrentSessionID == nil || *conv.CurrentSessionID == "" {
+		return 0, nil
+	}
+	sequence, err := s.qr.SelectConversationContextResetSequence(ctx, gen.SelectConversationContextResetSequenceParams{
+		ConversationID: conv.ID,
+		ProviderItemID: "ao-context-reset:" + string(*conv.CurrentSessionID),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("select context reset boundary for conversation %s: %w", conv.ID, err)
+	}
+	return sequence, nil
 }
 
 // LoadConversationSnapshot reads a whole conversation. Items come back ordered by

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -1862,12 +1862,12 @@ func (s *Store) LoadConversationSnapshotPage(
 
 	sequences := make([]int64, 0, len(messageRows)+len(activityRows))
 	for _, row := range messageRows {
-		if row.Sequence >= visibleAfterSequence {
+		if row.Sequence > visibleAfterSequence {
 			sequences = append(sequences, row.Sequence)
 		}
 	}
 	for _, row := range activityRows {
-		if row.Sequence >= visibleAfterSequence {
+		if row.Sequence > visibleAfterSequence {
 			sequences = append(sequences, row.Sequence)
 		}
 	}
@@ -1880,7 +1880,7 @@ func (s *Store) LoadConversationSnapshotPage(
 	if len(sequences) > 0 {
 		oldest = sequences[len(sequences)-1]
 	}
-	if oldest < visibleAfterSequence {
+	if len(sequences) == 0 || oldest < visibleAfterSequence {
 		oldest = visibleAfterSequence
 	}
 	if oldest <= visibleAfterSequence {
@@ -1909,12 +1909,12 @@ func (s *Store) LoadConversationSnapshotPage(
 	// SQL returns newest-first so LIMIT is useful; the API contract remains
 	// oldest-first inside each page.
 	for i := len(messageRows) - 1; i >= 0; i-- {
-		if messageRows[i].Sequence >= oldest && messageRows[i].Sequence >= visibleAfterSequence {
+		if messageRows[i].Sequence >= oldest && messageRows[i].Sequence > visibleAfterSequence {
 			snapshot.Messages = append(snapshot.Messages, messageToDomain(messageRows[i]))
 		}
 	}
 	for i := len(activityRows) - 1; i >= 0; i-- {
-		if activityRows[i].Sequence >= oldest && activityRows[i].Sequence >= visibleAfterSequence {
+		if activityRows[i].Sequence >= oldest && activityRows[i].Sequence > visibleAfterSequence {
 			snapshot.Activities = append(snapshot.Activities, activityToDomain(activityRows[i]))
 		}
 	}

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -124,6 +124,127 @@ func (s *Store) CreateConversation(
 	}, nil
 }
 
+// CreateProjectConversationWithContextReset rebinds an existing project
+// conversation and records the fresh-context boundary in the same transaction.
+// The boundary is written before provider startup so paged readers never expose
+// the previous orchestrator's rows under the replacement session.
+func (s *Store) CreateProjectConversationWithContextReset(
+	ctx context.Context,
+	id string,
+	project domain.ProjectID,
+	session domain.SessionID,
+	reset domain.ConversationActivity,
+	now time.Time,
+) (domain.ConversationRecord, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	if existing, err := s.qw.SelectProjectConversation(ctx, project); err == nil {
+		detail := string(reset.Detail)
+		err = s.inTx(ctx, "rebind project conversation with reset", func(q *gen.Queries) error {
+			if err := q.BindProjectConversationSession(ctx, gen.BindProjectConversationSessionParams{
+				CurrentSessionID: &session,
+				UpdatedAt:        now,
+				ID:               existing.ID,
+			}); err != nil {
+				return fmt.Errorf("bind project conversation %s to %s: %w", existing.ID, session, err)
+			}
+			if existing.LatestSequence <= 0 || reset.ProviderItemID == "" {
+				return nil
+			}
+			_, lookupErr := q.SelectConversationActivityByProviderItem(ctx,
+				gen.SelectConversationActivityByProviderItemParams{
+					ConversationID: existing.ID,
+					ProviderItemID: reset.ProviderItemID,
+				})
+			if lookupErr == nil {
+				return q.SettleConversationActivity(ctx, gen.SettleConversationActivityParams{
+					Status:         reset.Status,
+					Summary:        reset.Summary,
+					DetailJson:     detail,
+					UpdatedAt:      now,
+					ConversationID: existing.ID,
+					ProviderItemID: reset.ProviderItemID,
+				})
+			}
+			if !errors.Is(lookupErr, sql.ErrNoRows) {
+				return fmt.Errorf("lookup reset boundary %s: %w", reset.ProviderItemID, lookupErr)
+			}
+			sequence, seqErr := q.NextConversationSequence(ctx, gen.NextConversationSequenceParams{
+				UpdatedAt: now,
+				ID:        existing.ID,
+			})
+			if seqErr != nil {
+				return fmt.Errorf("allocate reset boundary sequence: %w", seqErr)
+			}
+			existing.LatestSequence = sequence
+			return q.InsertConversationActivity(ctx, gen.InsertConversationActivityParams{
+				ID:             reset.ID,
+				ConversationID: existing.ID,
+				TurnID:         sql.NullString{},
+				Sequence:       sequence,
+				Kind:           reset.Kind,
+				Status:         reset.Status,
+				Summary:        reset.Summary,
+				DetailJson:     detail,
+				RequestID:      reset.RequestID,
+				ProviderItemID: reset.ProviderItemID,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			})
+		})
+		if err != nil {
+			return domain.ConversationRecord{}, err
+		}
+		existing.CurrentSessionID = &session
+		existing.UpdatedAt = now
+		return conversationToDomain(existing), nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return domain.ConversationRecord{}, fmt.Errorf("select project conversation for %s: %w", project, err)
+	}
+
+	rootBranchID := id + ":root"
+	err := s.inTx(ctx, "insert project conversation", func(q *gen.Queries) error {
+		owner, getErr := q.GetSession(ctx, session)
+		if getErr != nil {
+			return fmt.Errorf("select controller session %s: %w", session, getErr)
+		}
+		if insertErr := q.InsertConversation(ctx, gen.InsertConversationParams{
+			ID:               id,
+			Scope:            domain.ConversationScopeProject,
+			ProjectID:        project,
+			SessionID:        nil,
+			CurrentSessionID: &session,
+			ActiveBranchID:   rootBranchID,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}); insertErr != nil {
+			return insertErr
+		}
+		return q.InsertConversationBranch(ctx, gen.InsertConversationBranchParams{
+			ID:                     rootBranchID,
+			ConversationID:         id,
+			SessionID:              nullableString(string(session)),
+			ProviderConversationID: owner.ProviderConversationID,
+			ForkAfterSequence:      0,
+			CreatedAt:              now,
+		})
+	})
+	if err != nil {
+		return domain.ConversationRecord{}, fmt.Errorf("insert project conversation %s: %w", id, err)
+	}
+
+	return domain.ConversationRecord{
+		ID:             id,
+		Scope:          domain.ConversationScopeProject,
+		ProjectID:      project,
+		SessionID:      session,
+		ActiveBranchID: rootBranchID,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}, nil
+}
+
 // CreateConversationBranch records a provider-thread child without changing the
 // active controller. Activation is a separate transaction after the replacement
 // provider controller is ready.
@@ -1904,7 +2025,9 @@ func (s *Store) LoadConversationSnapshotPage(
 		HasMoreBefore:              hasMore,
 	}
 	for _, row := range turnRows {
-		snapshot.Turns = append(snapshot.Turns, turnToDomain(row))
+		if conversationTurnVisibleAfterSequence(row, conv, visibleAfterSequence) {
+			snapshot.Turns = append(snapshot.Turns, turnToDomain(row))
+		}
 	}
 	// SQL returns newest-first so LIMIT is useful; the API contract remains
 	// oldest-first inside each page.
@@ -1935,7 +2058,53 @@ func (s *Store) conversationVisibleAfterSequence(
 	if err != nil {
 		return 0, fmt.Errorf("select context reset boundary for conversation %s: %w", conv.ID, err)
 	}
+	if sequence == 0 {
+		pending, pendingErr := s.projectConversationResetPending(ctx, conv)
+		if pendingErr != nil {
+			return 0, pendingErr
+		}
+		if pending {
+			return conv.LatestSequence, nil
+		}
+	}
 	return sequence, nil
+}
+
+func (s *Store) projectConversationResetPending(ctx context.Context, conv gen.Conversation) (bool, error) {
+	if conv.Scope != domain.ConversationScopeProject ||
+		conv.CurrentSessionID == nil ||
+		*conv.CurrentSessionID == "" ||
+		conv.LatestSequence <= 0 {
+		return false, nil
+	}
+	current, err := s.qr.GetSession(ctx, *conv.CurrentSessionID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("select current session %s: %w", *conv.CurrentSessionID, err)
+	}
+	if current.ProviderConversationID != "" {
+		return false, nil
+	}
+	active, err := s.qr.SelectConversationBranch(ctx, gen.SelectConversationBranchParams{
+		ConversationID: conv.ID,
+		BranchID:       conv.ActiveBranchID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("select active branch %s: %w", conv.ActiveBranchID, err)
+	}
+	return active.SessionID.Valid && active.SessionID.String != string(*conv.CurrentSessionID), nil
+}
+
+func conversationTurnVisibleAfterSequence(row gen.ConversationTurn, conv gen.Conversation, visibleAfterSequence int64) bool {
+	if visibleAfterSequence <= 0 || conv.CurrentSessionID == nil {
+		return true
+	}
+	return row.HandledBySessionID == *conv.CurrentSessionID
 }
 
 // LoadConversationSnapshot reads a whole conversation. Items come back ordered by

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -39,6 +39,15 @@ var ErrNoQueuedTurn = domain.ErrNoQueuedTurn
 // owns it. The caller must not contact the provider after this outcome.
 var ErrQueuedTurnNotAvailable = errors.New("queued turn is not available for promotion")
 
+type conversationCreateOptions struct {
+	id           string
+	scope        domain.ConversationScope
+	project      domain.ProjectID
+	session      domain.SessionID
+	contextReset *domain.ConversationActivity
+	now          time.Time
+}
+
 // CreateConversation opens a worker's session-scoped conversation or rebinds an
 // orchestrator's project-scoped narrative to its current session. Returning the
 // existing row makes controller restart and clean orchestrator replacement
@@ -51,77 +60,13 @@ func (s *Store) CreateConversation(
 	session domain.SessionID,
 	now time.Time,
 ) (domain.ConversationRecord, error) {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-
-	if scope == domain.ConversationScopeProject {
-		if existing, err := s.qw.SelectProjectConversation(ctx, project); err == nil {
-			if err := s.qw.BindProjectConversationSession(ctx, gen.BindProjectConversationSessionParams{
-				CurrentSessionID: &session,
-				UpdatedAt:        now,
-				ID:               existing.ID,
-			}); err != nil {
-				return domain.ConversationRecord{}, fmt.Errorf("bind project conversation %s to %s: %w", existing.ID, session, err)
-			}
-			existing.CurrentSessionID = &session
-			existing.UpdatedAt = now
-			return conversationToDomain(existing), nil
-		} else if !errors.Is(err, sql.ErrNoRows) {
-			return domain.ConversationRecord{}, fmt.Errorf("select project conversation for %s: %w", project, err)
-		}
-	} else {
-		scope = domain.ConversationScopeSession
-		if existing, err := s.qw.SelectConversationBySession(ctx, &session); err == nil {
-			return conversationToDomain(existing), nil
-		} else if !errors.Is(err, sql.ErrNoRows) {
-			return domain.ConversationRecord{}, fmt.Errorf("select conversation for %s: %w", session, err)
-		}
-	}
-
-	var ownerSession *domain.SessionID
-	if scope == domain.ConversationScopeSession {
-		ownerSession = &session
-	}
-	rootBranchID := id + ":root"
-	err := s.inTx(ctx, "insert conversation", func(q *gen.Queries) error {
-		owner, getErr := q.GetSession(ctx, session)
-		if getErr != nil {
-			return fmt.Errorf("select controller session %s: %w", session, getErr)
-		}
-		if insertErr := q.InsertConversation(ctx, gen.InsertConversationParams{
-			ID:               id,
-			Scope:            scope,
-			ProjectID:        project,
-			SessionID:        ownerSession,
-			CurrentSessionID: &session,
-			ActiveBranchID:   rootBranchID,
-			CreatedAt:        now,
-			UpdatedAt:        now,
-		}); insertErr != nil {
-			return insertErr
-		}
-		return q.InsertConversationBranch(ctx, gen.InsertConversationBranchParams{
-			ID:                     rootBranchID,
-			ConversationID:         id,
-			SessionID:              nullableString(string(session)),
-			ProviderConversationID: owner.ProviderConversationID,
-			ForkAfterSequence:      0,
-			CreatedAt:              now,
-		})
+	return s.createConversation(ctx, conversationCreateOptions{
+		id:      id,
+		scope:   scope,
+		project: project,
+		session: session,
+		now:     now,
 	})
-	if err != nil {
-		return domain.ConversationRecord{}, fmt.Errorf("insert conversation %s: %w", id, err)
-	}
-
-	return domain.ConversationRecord{
-		ID:             id,
-		Scope:          scope,
-		ProjectID:      project,
-		SessionID:      session,
-		ActiveBranchID: rootBranchID,
-		CreatedAt:      now,
-		UpdatedAt:      now,
-	}, nil
 }
 
 // CreateProjectConversationWithContextReset rebinds an existing project
@@ -136,112 +81,147 @@ func (s *Store) CreateProjectConversationWithContextReset(
 	reset domain.ConversationActivity,
 	now time.Time,
 ) (domain.ConversationRecord, error) {
+	return s.createConversation(ctx, conversationCreateOptions{
+		id:           id,
+		scope:        domain.ConversationScopeProject,
+		project:      project,
+		session:      session,
+		contextReset: &reset,
+		now:          now,
+	})
+}
+
+func (s *Store) createConversation(
+	ctx context.Context,
+	options conversationCreateOptions,
+) (domain.ConversationRecord, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 
-	if existing, err := s.qw.SelectProjectConversation(ctx, project); err == nil {
-		detail := string(reset.Detail)
-		err = s.inTx(ctx, "rebind project conversation with reset", func(q *gen.Queries) error {
-			if err := q.BindProjectConversationSession(ctx, gen.BindProjectConversationSessionParams{
-				CurrentSessionID: &session,
-				UpdatedAt:        now,
-				ID:               existing.ID,
-			}); err != nil {
-				return fmt.Errorf("bind project conversation %s to %s: %w", existing.ID, session, err)
+	scope := options.scope
+	if scope == domain.ConversationScopeProject {
+		if existing, err := s.qw.SelectProjectConversation(ctx, options.project); err == nil {
+			transactionName := "rebind project conversation"
+			if options.contextReset != nil {
+				transactionName += " with reset"
 			}
-			if existing.LatestSequence <= 0 || reset.ProviderItemID == "" {
-				return nil
-			}
-			_, lookupErr := q.SelectConversationActivityByProviderItem(ctx,
-				gen.SelectConversationActivityByProviderItemParams{
-					ConversationID: existing.ID,
-					ProviderItemID: reset.ProviderItemID,
+			err = s.inTx(ctx, transactionName, func(q *gen.Queries) error {
+				if err := q.BindProjectConversationSession(ctx, gen.BindProjectConversationSessionParams{
+					CurrentSessionID: &options.session,
+					UpdatedAt:        options.now,
+					ID:               existing.ID,
+				}); err != nil {
+					return fmt.Errorf("bind project conversation %s to %s: %w", existing.ID, options.session, err)
+				}
+				if options.contextReset == nil ||
+					existing.LatestSequence <= 0 ||
+					options.contextReset.ProviderItemID == "" {
+					return nil
+				}
+				reset := options.contextReset
+				detail := string(reset.Detail)
+				_, lookupErr := q.SelectConversationActivityByProviderItem(ctx,
+					gen.SelectConversationActivityByProviderItemParams{
+						ConversationID: existing.ID,
+						ProviderItemID: reset.ProviderItemID,
+					})
+				if lookupErr == nil {
+					return q.SettleConversationActivity(ctx, gen.SettleConversationActivityParams{
+						Status:         reset.Status,
+						Summary:        reset.Summary,
+						DetailJson:     detail,
+						UpdatedAt:      options.now,
+						ConversationID: existing.ID,
+						ProviderItemID: reset.ProviderItemID,
+					})
+				}
+				if !errors.Is(lookupErr, sql.ErrNoRows) {
+					return fmt.Errorf("lookup reset boundary %s: %w", reset.ProviderItemID, lookupErr)
+				}
+				sequence, seqErr := q.NextConversationSequence(ctx, gen.NextConversationSequenceParams{
+					UpdatedAt: options.now,
+					ID:        existing.ID,
 				})
-			if lookupErr == nil {
-				return q.SettleConversationActivity(ctx, gen.SettleConversationActivityParams{
+				if seqErr != nil {
+					return fmt.Errorf("allocate reset boundary sequence: %w", seqErr)
+				}
+				existing.LatestSequence = sequence
+				return q.InsertConversationActivity(ctx, gen.InsertConversationActivityParams{
+					ID:             reset.ID,
+					ConversationID: existing.ID,
+					TurnID:         sql.NullString{},
+					Sequence:       sequence,
+					Kind:           reset.Kind,
 					Status:         reset.Status,
 					Summary:        reset.Summary,
 					DetailJson:     detail,
-					UpdatedAt:      now,
-					ConversationID: existing.ID,
+					RequestID:      reset.RequestID,
 					ProviderItemID: reset.ProviderItemID,
+					CreatedAt:      options.now,
+					UpdatedAt:      options.now,
 				})
-			}
-			if !errors.Is(lookupErr, sql.ErrNoRows) {
-				return fmt.Errorf("lookup reset boundary %s: %w", reset.ProviderItemID, lookupErr)
-			}
-			sequence, seqErr := q.NextConversationSequence(ctx, gen.NextConversationSequenceParams{
-				UpdatedAt: now,
-				ID:        existing.ID,
 			})
-			if seqErr != nil {
-				return fmt.Errorf("allocate reset boundary sequence: %w", seqErr)
+			if err != nil {
+				return domain.ConversationRecord{}, err
 			}
-			existing.LatestSequence = sequence
-			return q.InsertConversationActivity(ctx, gen.InsertConversationActivityParams{
-				ID:             reset.ID,
-				ConversationID: existing.ID,
-				TurnID:         sql.NullString{},
-				Sequence:       sequence,
-				Kind:           reset.Kind,
-				Status:         reset.Status,
-				Summary:        reset.Summary,
-				DetailJson:     detail,
-				RequestID:      reset.RequestID,
-				ProviderItemID: reset.ProviderItemID,
-				CreatedAt:      now,
-				UpdatedAt:      now,
-			})
-		})
-		if err != nil {
-			return domain.ConversationRecord{}, err
+			existing.CurrentSessionID = &options.session
+			existing.UpdatedAt = options.now
+			return conversationToDomain(existing), nil
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return domain.ConversationRecord{}, fmt.Errorf("select project conversation for %s: %w", options.project, err)
 		}
-		existing.CurrentSessionID = &session
-		existing.UpdatedAt = now
-		return conversationToDomain(existing), nil
-	} else if !errors.Is(err, sql.ErrNoRows) {
-		return domain.ConversationRecord{}, fmt.Errorf("select project conversation for %s: %w", project, err)
+	} else {
+		scope = domain.ConversationScopeSession
+		if existing, err := s.qw.SelectConversationBySession(ctx, &options.session); err == nil {
+			return conversationToDomain(existing), nil
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return domain.ConversationRecord{}, fmt.Errorf("select conversation for %s: %w", options.session, err)
+		}
 	}
 
-	rootBranchID := id + ":root"
-	err := s.inTx(ctx, "insert project conversation", func(q *gen.Queries) error {
-		owner, getErr := q.GetSession(ctx, session)
+	var ownerSession *domain.SessionID
+	if scope == domain.ConversationScopeSession {
+		ownerSession = &options.session
+	}
+	rootBranchID := options.id + ":root"
+	err := s.inTx(ctx, "insert conversation", func(q *gen.Queries) error {
+		owner, getErr := q.GetSession(ctx, options.session)
 		if getErr != nil {
-			return fmt.Errorf("select controller session %s: %w", session, getErr)
+			return fmt.Errorf("select controller session %s: %w", options.session, getErr)
 		}
 		if insertErr := q.InsertConversation(ctx, gen.InsertConversationParams{
-			ID:               id,
-			Scope:            domain.ConversationScopeProject,
-			ProjectID:        project,
-			SessionID:        nil,
-			CurrentSessionID: &session,
+			ID:               options.id,
+			Scope:            scope,
+			ProjectID:        options.project,
+			SessionID:        ownerSession,
+			CurrentSessionID: &options.session,
 			ActiveBranchID:   rootBranchID,
-			CreatedAt:        now,
-			UpdatedAt:        now,
+			CreatedAt:        options.now,
+			UpdatedAt:        options.now,
 		}); insertErr != nil {
 			return insertErr
 		}
 		return q.InsertConversationBranch(ctx, gen.InsertConversationBranchParams{
 			ID:                     rootBranchID,
-			ConversationID:         id,
-			SessionID:              nullableString(string(session)),
+			ConversationID:         options.id,
+			SessionID:              nullableString(string(options.session)),
 			ProviderConversationID: owner.ProviderConversationID,
 			ForkAfterSequence:      0,
-			CreatedAt:              now,
+			CreatedAt:              options.now,
 		})
 	})
 	if err != nil {
-		return domain.ConversationRecord{}, fmt.Errorf("insert project conversation %s: %w", id, err)
+		return domain.ConversationRecord{}, fmt.Errorf("insert conversation %s: %w", options.id, err)
 	}
 
 	return domain.ConversationRecord{
-		ID:             id,
-		Scope:          domain.ConversationScopeProject,
-		ProjectID:      project,
-		SessionID:      session,
+		ID:             options.id,
+		Scope:          scope,
+		ProjectID:      options.project,
+		SessionID:      options.session,
 		ActiveBranchID: rootBranchID,
-		CreatedAt:      now,
-		UpdatedAt:      now,
+		CreatedAt:      options.now,
+		UpdatedAt:      options.now,
 	}, nil
 }
 
@@ -2057,7 +2037,7 @@ func (s *Store) conversationVisibleAfterSequence(
 	}
 	sequence, err := s.qr.SelectConversationContextResetSequence(ctx, gen.SelectConversationContextResetSequenceParams{
 		ConversationID: conv.ID,
-		ProviderItemID: "ao-context-reset:" + string(*conv.CurrentSessionID),
+		ProviderItemID: domain.ConversationContextResetProviderItemID(*conv.CurrentSessionID),
 	})
 	if err != nil {
 		return 0, fmt.Errorf("select context reset boundary for conversation %s: %w", conv.ID, err)

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -3,16 +3,34 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConversationSnapshot } from "../../types/conversation";
 import type { WorkspaceSession } from "../../types/workspace";
 import { useUiStore } from "../../stores/ui-store";
 import { workspaceQueryKey } from "../../hooks/useWorkspaceQuery";
 
 const LINK = "http://localhost:5173";
 
+function snapshotFor(sessionId: string): ConversationSnapshot {
+	return {
+		capabilities: [],
+		conversationId: `conv-${sessionId}`,
+		sessionId,
+		harness: "codex",
+		mode: "chat",
+		controller: { state: "ready" },
+		items: [],
+		turns: [],
+		settings: {},
+		oldestSequence: 0,
+		latestSequence: 0,
+		hasMoreBefore: false,
+	};
+}
+
 const { postMock, conversationState } = vi.hoisted(() => ({
 	postMock: vi.fn(),
 	conversationState: {
-		snapshot: { capabilities: [] } as { capabilities: string[] } | undefined,
+		snapshot: undefined as ConversationSnapshot | undefined,
 		isLoading: false,
 		unavailable: undefined as { message: string } | undefined,
 		error: undefined as string | undefined,
@@ -27,7 +45,10 @@ vi.mock("../../lib/api-client", () => ({
 }));
 
 vi.mock("../../hooks/useConversation", () => ({
-	useConversation: () => conversationState,
+	useConversation: (sessionId: string) => ({
+		...conversationState,
+		snapshot: conversationState.snapshot ?? snapshotFor(sessionId),
+	}),
 	useConversationCommands: () => ({}),
 	useConversationConfigOptions: () => ({ options: [] }),
 	useConversationModels: () => ({ models: [] }),
@@ -39,14 +60,17 @@ vi.mock("../../hooks/useConversation", () => ({
 vi.mock("./ChatWorkspace", () => ({
 	ChatWorkspace: ({
 		onLinkOpen,
+		snapshot,
 		switchAgentControl,
 		shellTarget,
 	}: {
 		onLinkOpen?: (url: string) => void;
+		snapshot: { sessionId: string };
 		switchAgentControl?: ReactNode;
 		shellTarget?: { handleId: string };
 	}) => (
 		<div>
+			<div>Rendered {snapshot.sessionId}</div>
 			<button type="button" onClick={() => onLinkOpen?.(LINK)}>
 				Open chat link
 			</button>
@@ -82,7 +106,7 @@ function Wrapper({ client, children }: { client: QueryClient; children: ReactNod
 
 beforeEach(() => {
 	postMock.mockReset().mockResolvedValue({ data: {}, error: undefined });
-	conversationState.snapshot = { capabilities: [] };
+	conversationState.snapshot = undefined;
 	conversationState.isLoading = false;
 	conversationState.unavailable = undefined;
 	conversationState.error = undefined;
@@ -170,5 +194,31 @@ describe("SessionChatSurface link routing", () => {
 
 		expect(screen.getByTestId("shell-target")).toHaveTextContent("shell-1");
 		expect(screen.queryByText("Conversation unavailable")).not.toBeInTheDocument();
+	});
+
+	it("does not render a previous orchestrator conversation while another orchestrator is selected", () => {
+		const first = { ...session, id: "proj-orchestrator-1", kind: "orchestrator" as const };
+		const second = { ...session, id: "proj-orchestrator-2", kind: "orchestrator" as const };
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		});
+
+		const view = render(
+			<Wrapper client={queryClient}>
+				<SessionChatSurface session={first} />
+			</Wrapper>,
+		);
+
+		expect(screen.getByText("Rendered proj-orchestrator-1")).toBeInTheDocument();
+
+		conversationState.snapshot = snapshotFor("proj-orchestrator-1");
+		view.rerender(
+			<Wrapper client={queryClient}>
+				<SessionChatSurface session={second} />
+			</Wrapper>,
+		);
+
+		expect(screen.queryByText("Rendered proj-orchestrator-1")).not.toBeInTheDocument();
+		expect(screen.getByText("Loading conversation…")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -57,28 +57,35 @@ vi.mock("../../hooks/useConversation", () => ({
 	useWorkspaceFilePaths: () => ({ paths: [], truncated: false }),
 }));
 
-vi.mock("./ChatWorkspace", () => ({
-	ChatWorkspace: ({
-		onLinkOpen,
-		snapshot,
-		switchAgentControl,
-		shellTarget,
-	}: {
-		onLinkOpen?: (url: string) => void;
-		snapshot: { sessionId: string };
-		switchAgentControl?: ReactNode;
-		shellTarget?: { handleId: string };
-	}) => (
-		<div>
-			<div>Rendered {snapshot.sessionId}</div>
-			<button type="button" onClick={() => onLinkOpen?.(LINK)}>
-				Open chat link
-			</button>
-			{shellTarget ? <div data-testid="shell-target">{shellTarget.handleId}</div> : null}
-			{switchAgentControl}
-		</div>
-	),
-}));
+vi.mock("./ChatWorkspace", async () => {
+	const { useState } = await vi.importActual<typeof import("react")>("react");
+	return {
+		ChatWorkspace: ({
+			onLinkOpen,
+			snapshot,
+			switchAgentControl,
+			shellTarget,
+		}: {
+			onLinkOpen?: (url: string) => void;
+			snapshot: { sessionId: string };
+			switchAgentControl?: ReactNode;
+			shellTarget?: { handleId: string };
+		}) => {
+			const [mountedSessionId] = useState(snapshot.sessionId);
+			return (
+				<div>
+					<div>Mounted {mountedSessionId}</div>
+					<div>Rendered {snapshot.sessionId}</div>
+					<button type="button" onClick={() => onLinkOpen?.(LINK)}>
+						Open chat link
+					</button>
+					{shellTarget ? <div data-testid="shell-target">{shellTarget.handleId}</div> : null}
+					{switchAgentControl}
+				</div>
+			);
+		},
+	};
+});
 
 vi.mock("../TerminalSwitchAgentButton", () => ({
 	TerminalSwitchAgentButton: () => <button aria-label="Switch agent" type="button" />,
@@ -196,7 +203,7 @@ describe("SessionChatSurface link routing", () => {
 		expect(screen.queryByText("Conversation unavailable")).not.toBeInTheDocument();
 	});
 
-	it("does not render a previous orchestrator conversation while another orchestrator is selected", () => {
+	it("remounts the chat workspace when switching between chat sessions", () => {
 		const first = { ...session, id: "proj-orchestrator-1", kind: "orchestrator" as const };
 		const second = { ...session, id: "proj-orchestrator-2", kind: "orchestrator" as const };
 		const queryClient = new QueryClient({
@@ -209,16 +216,17 @@ describe("SessionChatSurface link routing", () => {
 			</Wrapper>,
 		);
 
+		expect(screen.getByText("Mounted proj-orchestrator-1")).toBeInTheDocument();
 		expect(screen.getByText("Rendered proj-orchestrator-1")).toBeInTheDocument();
 
-		conversationState.snapshot = snapshotFor("proj-orchestrator-1");
 		view.rerender(
 			<Wrapper client={queryClient}>
 				<SessionChatSurface session={second} />
 			</Wrapper>,
 		);
 
-		expect(screen.queryByText("Rendered proj-orchestrator-1")).not.toBeInTheDocument();
-		expect(screen.getByText("Loading conversation…")).toBeInTheDocument();
+		expect(screen.getByText("Mounted proj-orchestrator-2")).toBeInTheDocument();
+		expect(screen.getByText("Rendered proj-orchestrator-2")).toBeInTheDocument();
+		expect(screen.queryByText("Mounted proj-orchestrator-1")).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -111,13 +111,14 @@ export function SessionChatSurface({
 	const [switchSelectorContainer, setSwitchSelectorContainer] = useState<HTMLDivElement | null>(null);
 	const switchMutation = useSwitchAgentState(session.id);
 	const renderShellFallback = Boolean(shellTarget && session);
+	const snapshotSessionMismatch = Boolean(snapshot && snapshot.sessionId !== session.id);
 	const renderSnapshot =
-		snapshot ??
+		(snapshotSessionMismatch ? undefined : snapshot) ??
 		(renderShellFallback
 			? unavailableConversationSnapshot(session)
 			: undefined);
 
-	if (isLoading && !renderShellFallback) {
+	if ((isLoading || snapshotSessionMismatch) && !renderShellFallback) {
 		return (
 			<Centered>
 				<Loader2 aria-hidden="true" className="size-4 animate-spin text-muted-foreground" />
@@ -158,6 +159,7 @@ export function SessionChatSurface({
 
 	return (
 		<ChatWorkspace
+			key={session.id}
 			snapshot={renderSnapshot}
 			onLinkOpen={openLinkInBrowser}
 			sessionTitle={session.title}


### PR DESCRIPTION
## Summary
- prevent ChatUI from rendering a conversation snapshot that belongs to a previously selected session
- remount `ChatWorkspace` when the selected session changes so retained timeline/composer state cannot carry across orchestrators
- hide project conversation pages before the current orchestrator's `ao-context-reset:<session>` boundary, so a replacement orchestrator does not page in the previous orchestrator's history
- filter stale queued/running turns at the same reset boundary so old turn state cannot make the replacement orchestrator appear busy
- persist the fresh-context reset boundary atomically with project conversation rebinds before provider startup
- strengthen regression coverage with a stateful workspace mock and a store-level project conversation rebind/reset test

## Root cause
Project-scoped conversations are intentionally rebound when an orchestrator is replaced. The frontend-only fix reset retained React state, but the paged conversation API could still return rows from before the fresh agent context boundary. That made old orchestrator history visible again after switching/replacing orchestrators.

This PR now treats the context-reset system activity for the current project orchestrator as the first visible sequence for paged ChatUI reads. The boundary activity remains stored as internal metadata, but it is not returned in paged ChatUI reads; older turns, messages, and activities are not returned or pageable from the replacement orchestrator view. The fresh-context boundary is written in the same transaction as the project conversation rebind before provider startup, so provider-start failures do not expose old history under the replacement session.

## Tests
- `cd frontend && PATH=/Users/nikhilachale/.nvm/versions/node/v22.23.1/bin:$PATH npm test -- SessionChatSurface.test.tsx`
- `cd backend && GOCACHE=/private/tmp/go-build go test ./internal/storage/sqlite/store`
- `cd backend && GOCACHE=/private/tmp/go-build go test ./internal/service/chat`
- `cd backend && GOCACHE=/private/tmp/go-build go test ./internal/httpd/controllers -run TestConversation`
