### PR TITLE
fix: rename auto review settings toggle

### DIFF
--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -474,7 +474,7 @@ describe("ProjectSettingsForm", () => {
 
 		renderSettings("proj-1", undefined, "agents");
 
-		const toggle = await screen.findByRole("switch", { name: "Enable for new sessions" });
+		const toggle = await screen.findByRole("switch", { name: "Auto review PRs" });
 		expect(toggle).toBeChecked();
 
 		await userEvent.click(toggle);

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -532,14 +532,17 @@ function SettingsBody({
 								{reviewerWarning}
 							</p>
 						)}
-						<SettingsRow label={t("settings.project.autoReviewToggle")}>
-							<div className="flex items-center gap-2">
+						<div className="settings-row-bar">
+							<div className="flex shrink-0 items-center gap-1.5">
+								<span className="whitespace-nowrap text-sm leading-5 text-settings-label">
+									{t("settings.project.autoReviewToggle")}
+								</span>
 								<TooltipProvider delayDuration={0}>
 									<Tooltip>
 										<TooltipTrigger asChild>
 											<button
 												type="button"
-												className="inline-flex size-6 items-center justify-center rounded-md text-settings-muted transition-colors hover:bg-settings-menu-selected hover:text-settings-label focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+												className="inline-flex size-5 items-center justify-center rounded-md text-settings-muted transition-colors hover:bg-settings-menu-selected hover:text-settings-label focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
 												aria-label={t("settings.project.autoReviewDescription")}
 											>
 												<Info className="size-icon-sm" aria-hidden="true" />
@@ -550,6 +553,8 @@ function SettingsBody({
 										</TooltipContent>
 									</Tooltip>
 								</TooltipProvider>
+							</div>
+							<div className="flex min-w-0 flex-1 items-center justify-end">
 								<Switch
 									aria-label={t("settings.project.autoReviewToggle")}
 									checked={form.autoReview}
@@ -558,7 +563,7 @@ function SettingsBody({
 									size="sm"
 								/>
 							</div>
-						</SettingsRow>
+						</div>
 					</ProjectSettingsSection>
 				)}
 				</>

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -37,6 +37,7 @@ import { AgentModelCombobox } from "./settings/AgentModelCombobox";
 import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
 import { SettingsRow } from "./settings/SettingsRow";
 import { Switch } from "./ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 
 type Project = components["schemas"]["Project"];
 type ProjectConfig = components["schemas"]["ProjectConfig"];
@@ -532,21 +533,32 @@ function SettingsBody({
 							</p>
 						)}
 						<SettingsRow label={t("settings.project.autoReviewToggle")}>
-							<Switch
-								aria-label={t("settings.project.autoReviewToggle")}
-								checked={form.autoReview}
-								id="project-auto-review"
-								onCheckedChange={(checked) => setForm((f) => ({ ...f, autoReview: checked }))}
-								size="sm"
-							/>
+							<div className="flex items-center gap-2">
+								<TooltipProvider delayDuration={0}>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												className="inline-flex size-6 items-center justify-center rounded-md text-settings-muted transition-colors hover:bg-settings-menu-selected hover:text-settings-label focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+												aria-label={t("settings.project.autoReviewDescription")}
+											>
+												<Info className="size-icon-sm" aria-hidden="true" />
+											</button>
+										</TooltipTrigger>
+										<TooltipContent className="max-w-72 leading-normal" side="top">
+											{t("settings.project.autoReviewDescription")}
+										</TooltipContent>
+									</Tooltip>
+								</TooltipProvider>
+								<Switch
+									aria-label={t("settings.project.autoReviewToggle")}
+									checked={form.autoReview}
+									id="project-auto-review"
+									onCheckedChange={(checked) => setForm((f) => ({ ...f, autoReview: checked }))}
+									size="sm"
+								/>
+							</div>
 						</SettingsRow>
-						<div
-							className="mx-3 mb-2 -mt-1 flex items-start gap-2 rounded-md bg-settings-menu-selected/50 px-3 py-2 text-xs leading-5 text-settings-muted"
-							role="note"
-						>
-							<Info className="mt-0.5 size-icon-sm shrink-0 text-settings-muted" aria-hidden="true" />
-							<span>{t("settings.project.autoReviewDescription")}</span>
-						</div>
 					</ProjectSettingsSection>
 				)}
 				</>

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -11,7 +11,7 @@ import {
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { useEffect, useState } from "react";
-import { Pencil, RefreshCw } from "lucide-react";
+import { Info, Pencil, RefreshCw } from "lucide-react";
 import type { components } from "../../api/schema";
 import {
 	agentModelsQueryKey,
@@ -540,9 +540,13 @@ function SettingsBody({
 								size="sm"
 							/>
 						</SettingsRow>
-						<p className="px-1 text-xs leading-row text-settings-muted" role="note">
-							{t("settings.project.autoReviewDescription")}
-						</p>
+						<div
+							className="mx-3 mb-2 -mt-1 flex items-start gap-2 rounded-md bg-settings-menu-selected/50 px-3 py-2 text-xs leading-5 text-settings-muted"
+							role="note"
+						>
+							<Info className="mt-0.5 size-icon-sm shrink-0 text-settings-muted" aria-hidden="true" />
+							<span>{t("settings.project.autoReviewDescription")}</span>
+						</div>
 					</ProjectSettingsSection>
 				)}
 				</>

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1209,7 +1209,7 @@
 	"inspector.usage.totalTokensUnavailable": "Token insgesamt nicht verfügbar",
 	"inspector.usage.uncachedInputTokens": "Nicht zwischengespeicherte Eingabe-Token",
 	"settings.project.autoReview": "Auto review",
-	"settings.project.autoReviewToggle": "Enable for new sessions",
+	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
 	"settings.project.reviewer": "Reviewer"
 }

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -645,7 +645,7 @@
 	"settings.project.restartFailed": "Orchestrator restart failed: {{error}}",
 	"settings.project.reviewers": "Reviewers",
 	"settings.project.autoReview": "Auto review",
-	"settings.project.autoReviewToggle": "Enable for new sessions",
+	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
 	"settings.project.saveChanges": "Save changes",
 	"settings.project.saveFailed": "Save failed",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1225,7 +1225,7 @@
 	"inspector.usage.totalTokensUnavailable": "Tokens totales no disponibles",
 	"inspector.usage.uncachedInputTokens": "Tokens de entrada sin caché",
 	"settings.project.autoReview": "Auto review",
-	"settings.project.autoReviewToggle": "Enable for new sessions",
+	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
 	"settings.project.reviewer": "Reviewer"
 }

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1225,7 +1225,7 @@
 	"inspector.usage.totalTokensUnavailable": "Total des jetons indisponible",
 	"inspector.usage.uncachedInputTokens": "Jetons d'entrée non mis en cache",
 	"settings.project.autoReview": "Auto review",
-	"settings.project.autoReviewToggle": "Enable for new sessions",
+	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
 	"settings.project.reviewer": "Reviewer"
 }

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1209,7 +1209,7 @@
 	"inspector.usage.totalTokensUnavailable": "合計トークンを利用できません",
 	"inspector.usage.uncachedInputTokens": "未キャッシュ入力トークン",
 	"settings.project.autoReview": "Auto review",
-	"settings.project.autoReviewToggle": "Enable for new sessions",
+	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
 	"settings.project.reviewer": "Reviewer"
 }

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1209,7 +1209,7 @@
 	"inspector.usage.totalTokensUnavailable": "총 토큰을 사용할 수 없음",
 	"inspector.usage.uncachedInputTokens": "캐시되지 않은 입력 토큰",
 	"settings.project.autoReview": "Auto review",
-	"settings.project.autoReviewToggle": "Enable for new sessions",
+	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
 	"settings.project.reviewer": "Reviewer"
 }

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1225,7 +1225,7 @@
 	"inspector.usage.totalTokensUnavailable": "Total de tokens indisponível",
 	"inspector.usage.uncachedInputTokens": "Tokens de entrada sem cache",
 	"settings.project.autoReview": "Auto review",
-	"settings.project.autoReviewToggle": "Enable for new sessions",
+	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
 	"settings.project.reviewer": "Reviewer"
 }

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1191,7 +1191,7 @@
 	"inspector.usage.totalTokensUnavailable": "总令牌数不可用",
 	"inspector.usage.uncachedInputTokens": "未缓存输入令牌",
 	"settings.project.autoReview": "Auto review",
-	"settings.project.autoReviewToggle": "Enable for new sessions",
+	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
 	"settings.project.reviewer": "Reviewer"
 }


### PR DESCRIPTION
## Summary
- Rename the project settings auto-review toggle from “Enable for new sessions” to “Auto review PRs”.
- Move the auto-review description into a compact tooltip beside the toggle instead of showing helper text inline.
- Update the matching ProjectSettingsForm test expectation.
- Apply the label key update across renderer locale files so the UI is consistent.

## Tests
- `npm --prefix frontend test -- ProjectSettingsForm.test.tsx`
- `npm --prefix frontend run typecheck`

## Notes
- This is split out from PR #4137 so the settings-label change can be reviewed independently.
