### PR TITLE
fix(auth): complete WorkOS sign-in locally

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -73,6 +73,7 @@ import {
 import { browserDaemonOwnershipDecision, shouldReplacePortHolder } from "./shared/daemon-takeover";
 import { buildDaemonEnv, resolveShellEnv, type ShellRunner } from "./shared/shell-env";
 import {
+	findCloudDeepLinkArg,
 	handleCloudDeepLink,
 	installCloudIPC,
 	registerCloudProtocol,
@@ -1851,7 +1852,7 @@ app.on("open-url", (event, url) => {
 });
 
 app.on("second-instance", (_event, argv) => {
-	const deepLink = argv.find((value) => value.startsWith("ao-app://"));
+	const deepLink = findCloudDeepLinkArg(argv);
 	if (deepLink) {
 		void handleCloudDeepLinkAndFocus(deepLink);
 		return;
@@ -1992,9 +1993,8 @@ app.whenReady().then(async () => {
 	void startDaemon();
 	initAutoUpdates();
 
-	// Windows/Linux: on first launch, the deep-link URL may arrive as a
-	// process.argv entry (e.g. ao-app://callback?token=...).
-	const deepLinkArg = process.argv.find((a) => a.startsWith("ao-app://"));
+	// Some OS/browser launchers deliver the deep-link URL as a process.argv entry.
+	const deepLinkArg = findCloudDeepLinkArg(process.argv);
 	if (deepLinkArg) {
 		void handleCloudDeepLinkAndFocus(deepLinkArg);
 	}

--- a/frontend/src/main/cloud-auth.test.ts
+++ b/frontend/src/main/cloud-auth.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   encryptionAvailable: true,
   selectedStorageBackend: "gnome_libsecret",
   getAuthorizationUrlWithPKCE: vi.fn(),
+  ipcHandle: vi.fn(),
   openExternal: vi.fn(),
   showMessageBox: vi.fn(),
 }));
@@ -37,7 +38,7 @@ vi.mock("electron", () => ({
     setAsDefaultProtocolClient: vi.fn(),
   },
   dialog: { showMessageBox: mocks.showMessageBox },
-  ipcMain: { handle: vi.fn() },
+  ipcMain: { handle: mocks.ipcHandle },
   safeStorage: {
     decryptString: mocks.decryptString,
     encryptString: mocks.encryptString,
@@ -49,8 +50,10 @@ vi.mock("electron", () => ({
 
 import {
   beginCloudSignIn,
+  findCloudDeepLinkArg,
   getCloudSession,
   handleCloudDeepLink,
+  installCloudIPC,
   showCloudSignInFailure,
   signOutCloud,
 } from "./cloud-auth";
@@ -86,24 +89,40 @@ describe("native WorkOS authentication", () => {
     await rm(dataDir, { recursive: true, force: true });
   });
 
-  it("starts PKCE and exchanges the callback without an AO website", async () => {
-    await beginCloudSignIn(dataDir);
+  it("starts PKCE and completes sign-in on a loopback callback page", async () => {
+    const notifyRenderers = vi.fn();
+    await beginCloudSignIn(dataDir, notifyRenderers);
     expect(mocks.openExternal).toHaveBeenCalledWith(
       "https://workos.example/authorize",
     );
+    const authOptions = mocks.getAuthorizationUrlWithPKCE.mock.calls[0]?.[0] as
+      | { redirectUri: string }
+      | undefined;
+    expect(authOptions).toBeDefined();
     expect(mocks.getAuthorizationUrlWithPKCE).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "authkit",
         prompt: "login",
         maxAge: 0,
-        redirectUri: "ao-app://callback",
+        redirectUri: expect.stringMatching(
+          /^http:\/\/127\.0\.0\.1:(5174|3000|3001)\/callback$/,
+        ),
       }),
     );
 
-    const session = await handleCloudDeepLink(
-      "ao-app://callback?code=code_123&state=state_123",
-      dataDir,
+    const response = await fetch(
+      `${authOptions!.redirectUri}?code=code_123&state=state_123`,
     );
+    expect(response.status).toBe(200);
+    const page = await response.text();
+    expect(page).toContain("You can close this tab");
+    expect(page).toContain("ao-app://complete");
+    expect(notifyRenderers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: expect.objectContaining({ email: "person@example.com" }),
+      }),
+    );
+    const session = await getCloudSession(dataDir);
     expect(session).toMatchObject({
       authProvider: "workos",
       user: {
@@ -117,6 +136,92 @@ describe("native WorkOS authentication", () => {
     await expect(getCloudSession(dataDir)).resolves.toMatchObject({
       user: { email: "person@example.com" },
     });
+  });
+
+  it("still accepts the legacy ao-app callback", async () => {
+    await beginCloudSignIn(dataDir);
+
+    const session = await handleCloudDeepLink(
+      "ao-app://callback?code=code_123&state=state_123",
+      dataDir,
+    );
+
+    expect(session).toMatchObject({
+      user: { email: "person@example.com" },
+    });
+  });
+
+  it("accepts the focus-only completion deep link without exchanging a code", async () => {
+    await expect(
+      handleCloudDeepLink("ao-app://complete", dataDir),
+    ).resolves.toBeNull();
+    expect(mocks.authenticateWithCode).not.toHaveBeenCalled();
+  });
+
+  it("finds callback URLs inside OS/browser argv wrappers", () => {
+    expect(findCloudDeepLinkArg(["ao-app://callback?code=c&state=s"])).toBe(
+      "ao-app://callback?code=c&state=s",
+    );
+    expect(
+      findCloudDeepLinkArg([
+        "/Applications/Agent Orchestrator.app",
+        "\"ao-app://callback?code=c&state=s\"",
+      ]),
+    ).toBe("ao-app://callback?code=c&state=s");
+    expect(
+      findCloudDeepLinkArg([
+        "agent-orchestrator",
+        "--open-url=ao-app://callback?code=c&state=s",
+      ]),
+    ).toBe("ao-app://callback?code=c&state=s");
+    expect(findCloudDeepLinkArg(["--open-url=ao-app://complete"])).toBe(
+      "ao-app://complete",
+    );
+    expect(findCloudDeepLinkArg(["ao-app://ignored?code=c&state=s"])).toBeNull();
+  });
+
+  it("does not launch WorkOS again when a Cloud session already exists", async () => {
+    await beginCloudSignIn(dataDir);
+    await handleCloudDeepLink(
+      "ao-app://callback?code=code_123&state=state_123",
+      dataDir,
+    );
+    mocks.openExternal.mockClear();
+    mocks.getAuthorizationUrlWithPKCE.mockClear();
+
+    const session = await beginCloudSignIn(dataDir);
+
+    expect(session).toMatchObject({
+      user: { email: "person@example.com" },
+    });
+    expect(mocks.openExternal).not.toHaveBeenCalled();
+    expect(mocks.getAuthorizationUrlWithPKCE).not.toHaveBeenCalled();
+  });
+
+  it("notifies the renderer instead of launching WorkOS from IPC when already signed in", async () => {
+    await beginCloudSignIn(dataDir);
+    await handleCloudDeepLink(
+      "ao-app://callback?code=code_123&state=state_123",
+      dataDir,
+    );
+    mocks.openExternal.mockClear();
+    mocks.getAuthorizationUrlWithPKCE.mockClear();
+
+    const notifyRenderers = vi.fn();
+    installCloudIPC(() => dataDir, notifyRenderers);
+    const signInHandler = mocks.ipcHandle.mock.calls.find(
+      ([channel]) => channel === "cloud:signIn",
+    )?.[1];
+
+    await signInHandler?.();
+
+    expect(notifyRenderers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: expect.objectContaining({ email: "person@example.com" }),
+      }),
+    );
+    expect(mocks.openExternal).not.toHaveBeenCalled();
+    expect(mocks.getAuthorizationUrlWithPKCE).not.toHaveBeenCalled();
   });
 
   it("rejects callbacks whose OAuth state does not match", async () => {

--- a/frontend/src/main/cloud-auth.ts
+++ b/frontend/src/main/cloud-auth.ts
@@ -7,17 +7,26 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
 import type { CloudAccount } from "../shared/cloud-account";
 
 const CLIENT_ID =
   import.meta.env.VITE_WORKOS_CLIENT_ID?.trim() ||
   (process.env.VITEST ? "client_test" : "");
-const REDIRECT_URI = "ao-app://callback";
+const LOOPBACK_HOST = "127.0.0.1";
+const LOOPBACK_CALLBACK_PATH = "/callback";
+const LOOPBACK_CALLBACK_PORTS = [5174, 3000, 3001];
 const AUTH_STORE_FILE = "cloud-auth.bin";
 const LEGACY_SESSION_FILE = "cloud-session.json";
 const PKCE_TTL_MS = 10 * 60 * 1000;
 const workos = CLIENT_ID ? createWorkOS({ clientId: CLIENT_ID }) : null;
+const CALLBACK_PROTOCOL = "ao-app:";
+const CALLBACK_HOST = "callback";
+const CALLBACK_COMPLETE_HOST = "complete";
+const CALLBACK_COMPLETE_URL = "ao-app://complete";
+let activeCallbackServer: Server | null = null;
 
 interface StoredSession extends CloudAccount {
   accessToken: string;
@@ -128,6 +137,95 @@ async function removeAuthStore(dataDir: string): Promise<void> {
     rm(storePath(dataDir), { force: true }),
     rm(path.join(dataDir, LEGACY_SESSION_FILE), { force: true }),
   ]);
+}
+
+function closeActiveCallbackServer(): void {
+  const server = activeCallbackServer;
+  activeCallbackServer = null;
+  if (server?.listening) server.close();
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function callbackPage(
+  title: string,
+  message: string,
+  openApp = false,
+): string {
+  const escapedTitle = escapeHtml(title);
+  const escapedMessage = escapeHtml(message);
+  const openAppScript = openApp
+    ? `<script>
+    window.setTimeout(() => {
+      window.location.href = "${CALLBACK_COMPLETE_URL}";
+    }, 300);
+  </script>`
+    : "";
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapedTitle}</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      align-items: center;
+      background: #0f1014;
+      color: #f4f4f5;
+      display: flex;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      justify-content: center;
+      margin: 0;
+      min-height: 100vh;
+    }
+    main { max-width: 28rem; padding: 2rem; text-align: center; }
+    h1 { font-size: 1.5rem; margin: 0 0 0.75rem; }
+    p { color: #b9bbc6; line-height: 1.5; margin: 0; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>${escapedTitle}</h1>
+    <p>${escapedMessage}</p>
+  </main>
+  ${openAppScript}
+</body>
+</html>`;
+}
+
+function sendCallbackPage(
+  response: ServerResponse,
+  statusCode: number,
+  title: string,
+  message: string,
+  openApp = false,
+): void {
+  response.writeHead(statusCode, {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  response.end(callbackPage(title, message, openApp));
+}
+
+function loopbackCallbackURL(port: number): string {
+  return `http://${LOOPBACK_HOST}:${port}${LOOPBACK_CALLBACK_PATH}`;
+}
+
+function isAddressInUse(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "EADDRINUSE"
+  );
 }
 
 function displayName(user: User): string {
@@ -280,46 +378,18 @@ async function refreshCloudSession(
   }
 }
 
-export async function beginCloudSignIn(dataDir: string): Promise<void> {
-  if (!workos) {
-    throw new Error("WorkOS is not configured.");
-  }
-  const { url, state, codeVerifier } =
-    await workos.userManagement.getAuthorizationUrlWithPKCE({
-      clientId: CLIENT_ID,
-      provider: "authkit",
-      prompt: "login",
-      maxAge: 0,
-      redirectUri: REDIRECT_URI,
-    });
-  invalidateAuthOperations(dataDir);
-  const store = await readAuthStore(dataDir);
-  await writeAuthStore(dataDir, {
-    ...store,
-    pkce: {
-      codeVerifier,
-      state,
-      expiresAt: Date.now() + PKCE_TTL_MS,
-    },
-  });
-  await shell.openExternal(url);
-}
-
-export async function handleCloudDeepLink(
-  rawURL: string,
+async function completeCloudCallback(
+  params: URLSearchParams,
   dataDir: string,
-): Promise<CloudAccount | null> {
-  if (!workos) throw new Error("WorkOS is not configured.");
-  const url = new URL(rawURL);
-  if (url.protocol !== "ao-app:" || url.hostname !== "callback") return null;
-  const error = url.searchParams.get("error");
+): Promise<CloudAccount> {
+  const error = params.get("error");
   if (error) {
     throw new Error(
-      url.searchParams.get("error_description") || `WorkOS sign-in failed: ${error}`,
+      params.get("error_description") || `WorkOS sign-in failed: ${error}`,
     );
   }
-  const code = url.searchParams.get("code");
-  const callbackState = url.searchParams.get("state");
+  const code = params.get("code");
+  const callbackState = params.get("state");
   if (!code || !callbackState) throw new Error("WorkOS callback is incomplete.");
 
   const store = await readAuthStore(dataDir);
@@ -332,7 +402,7 @@ export async function handleCloudDeepLink(
     throw new Error("WorkOS callback state did not match.");
   }
 
-  const result = await workos.userManagement.authenticateWithCode({
+  const result = await workos!.userManagement.authenticateWithCode({
     clientId: CLIENT_ID,
     code,
     codeVerifier: store.pkce.codeVerifier,
@@ -346,7 +416,178 @@ export async function handleCloudDeepLink(
   return publicAccount(session);
 }
 
+async function startLoopbackCallbackServer(
+  dataDir: string,
+  notifyRenderers?: (session: CloudAccount | null) => void,
+): Promise<string> {
+  closeActiveCallbackServer();
+  for (const port of LOOPBACK_CALLBACK_PORTS) {
+    const server = createLoopbackCallbackServer(dataDir, notifyRenderers);
+    try {
+      await listenOnLoopbackPort(server, port);
+    } catch (error) {
+      server.close();
+      if (isAddressInUse(error)) continue;
+      throw error;
+    }
+    activeCallbackServer = server;
+    return loopbackCallbackURL(port);
+  }
+  throw new Error("No configured AO Cloud callback port is available.");
+}
+
+function createLoopbackCallbackServer(
+  dataDir: string,
+  notifyRenderers?: (session: CloudAccount | null) => void,
+): Server {
+  const server = createServer((request, response) => {
+    void (async () => {
+      try {
+        const url = new URL(
+          request.url ?? "/",
+          `http://${LOOPBACK_HOST}`,
+        );
+        if (url.pathname !== LOOPBACK_CALLBACK_PATH) {
+          sendCallbackPage(
+            response,
+            404,
+            "Not found",
+            "This AO Cloud sign-in callback URL is not valid.",
+          );
+          return;
+        }
+        const session = await completeCloudCallback(url.searchParams, dataDir);
+        notifyRenderers?.(session);
+        sendCallbackPage(
+          response,
+          200,
+          "Signed in to Agent Orchestrator",
+          "You can close this tab and return to Agent Orchestrator.",
+          true,
+        );
+      } catch (error) {
+        sendCallbackPage(
+          response,
+          400,
+          "Agent Orchestrator sign-in failed",
+          signInFailureDetail(error),
+        );
+      } finally {
+        setTimeout(() => {
+          if (activeCallbackServer === server) closeActiveCallbackServer();
+        }, 250);
+      }
+    })();
+  });
+  return server;
+}
+
+async function listenOnLoopbackPort(
+  server: Server,
+  port: number,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, LOOPBACK_HOST, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo | null;
+  if (!address) {
+    server.close();
+    throw new Error("AO Cloud callback server did not start.");
+  }
+}
+
+export async function beginCloudSignIn(
+  dataDir: string,
+  notifyRenderers?: (session: CloudAccount | null) => void,
+): Promise<CloudAccount | null> {
+  if (!workos) {
+    throw new Error("WorkOS is not configured.");
+  }
+  const existingSession = await getCloudSession(dataDir);
+  if (existingSession) return existingSession;
+  const redirectUri = await startLoopbackCallbackServer(
+    dataDir,
+    notifyRenderers,
+  );
+
+  let url: string;
+  let state: string;
+  let codeVerifier: string;
+  try {
+    ({ url, state, codeVerifier } =
+      await workos.userManagement.getAuthorizationUrlWithPKCE({
+        clientId: CLIENT_ID,
+        provider: "authkit",
+        prompt: "login",
+        maxAge: 0,
+        redirectUri,
+      }));
+  } catch (error) {
+    closeActiveCallbackServer();
+    throw error;
+  }
+  invalidateAuthOperations(dataDir);
+  const store = await readAuthStore(dataDir);
+  await writeAuthStore(dataDir, {
+    ...store,
+    pkce: {
+      codeVerifier,
+      state,
+      expiresAt: Date.now() + PKCE_TTL_MS,
+    },
+  });
+  await shell.openExternal(url);
+  return null;
+}
+
+export async function handleCloudDeepLink(
+  rawURL: string,
+  dataDir: string,
+): Promise<CloudAccount | null> {
+  const url = new URL(rawURL);
+  if (url.protocol !== CALLBACK_PROTOCOL) {
+    return null;
+  }
+  if (url.hostname === CALLBACK_COMPLETE_HOST) return null;
+  if (url.hostname !== CALLBACK_HOST) return null;
+  if (!workos) throw new Error("WorkOS is not configured.");
+  const account = await completeCloudCallback(url.searchParams, dataDir);
+  closeActiveCallbackServer();
+  return account;
+}
+
+export function findCloudDeepLinkArg(argv: readonly string[]): string | null {
+  for (const rawValue of argv) {
+    const value = rawValue.trim();
+    const callbackStart = value.toLowerCase().indexOf("ao-app://");
+    if (callbackStart < 0) continue;
+    const candidate = value
+      .slice(callbackStart)
+      .replace(/^["']+/, "")
+      .split(/\s+/)[0]
+      .replace(/[)"']+$/, "");
+    try {
+      const url = new URL(candidate);
+      if (
+        url.protocol === CALLBACK_PROTOCOL &&
+        (url.hostname === CALLBACK_HOST ||
+          url.hostname === CALLBACK_COMPLETE_HOST)
+      ) {
+        return candidate;
+      }
+    } catch {
+      // Keep scanning other argv entries; OS/browser wrappers vary here.
+    }
+  }
+  return null;
+}
+
 export async function signOutCloud(dataDir: string): Promise<void> {
+  closeActiveCallbackServer();
   invalidateAuthOperations(dataDir);
   await withAuthMutation(dataDir, () => removeAuthStore(dataDir));
 }
@@ -407,7 +648,11 @@ export function installCloudIPC(
       });
       return;
     }
-    await beginCloudSignIn(getDataDir());
+    const existingSession = await beginCloudSignIn(
+      getDataDir(),
+      notifyRenderers,
+    );
+    if (existingSession) notifyRenderers(existingSession);
   });
   ipcMain.handle("cloud:signOut", async () => {
     await signOutCloud(getDataDir());


### PR DESCRIPTION
## Summary
- use a temporary fixed-port 127.0.0.1 callback during WorkOS PKCE sign-in so the browser receives a final success page
- try WorkOS-configured callback ports in order: 5174, 3000, then 3001
- show "You can close this tab and return to Agent Orchestrator" after the code exchange completes
- trigger a focus-only ao-app://complete handoff from that success page so the browser still shows the native app-open prompt
- keep the existing ao-app://callback handling as a fallback for older in-flight auth redirects
- avoid relaunching WorkOS when a valid cloud session already exists

## Root cause
The sign-in flow used the custom ao-app:// callback as the primary redirect. Browsers present that as an external app launch prompt, and some OS/browser combinations pass the deep-link argument differently or leave the provider tab sitting on a page that keeps trying to hand off to Electron. Switching the token exchange to a local HTTP callback fixes the browser UX, but WorkOS requires the redirect URI to match the application settings exactly, so the callback must use one of the configured loopback ports instead of a random port. A separate ao-app://complete deep link restores the native prompt after the browser has already landed on the close-tab page.

## Validation
- npm --prefix frontend test -- cloud-auth
- npm run frontend:typecheck
- git diff --check -- frontend/src/main/cloud-auth.ts frontend/src/main/cloud-auth.test.ts frontend/src/main.ts