### PR TITLE
fix(claude-code): confirm native session id on --resume relaunch

### DIFF
--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -441,11 +441,11 @@ func TestGetAgentHooksInstallsClaudeHooks(t *testing.T) {
 	if len(config.Permissions) == 0 {
 		t.Fatalf("unrelated settings clobbered: %s", data)
 	}
-	// SessionStart must fire on resume (and clear/compact) as well as a fresh
-	// startup: a --resume relaunch otherwise never confirms the native session
-	// id under the new RuntimeLaunchID until the user types again (#4122).
-	if m := matcherForCommand(config.Hooks["SessionStart"], "ao hooks claude-code session-start"); m == nil || *m != "startup|resume|clear|compact" {
-		t.Fatalf("SessionStart matcher = %v, want startup|resume|clear|compact", m)
+	// SessionStart must fire on resume (and clear/compact/fork) as well as a
+	// fresh startup: a --resume relaunch otherwise never confirms the native
+	// session id under the new RuntimeLaunchID until the user types again (#4122).
+	if m := matcherForCommand(config.Hooks["SessionStart"], "ao hooks claude-code session-start"); m == nil || *m != "startup|resume|clear|compact|fork" {
+		t.Fatalf("SessionStart matcher = %v, want startup|resume|clear|compact|fork", m)
 	}
 	if m := matcherForCommand(config.Hooks["UserPromptSubmit"], "ao hooks claude-code user-prompt-submit"); m != nil {
 		t.Fatalf("UserPromptSubmit matcher = %v, want none", m)
@@ -490,8 +490,8 @@ func TestGetAgentHooksMigratesSessionStartMatcher(t *testing.T) {
 		t.Fatal(err)
 	}
 	groups := config.Hooks["SessionStart"]
-	if m := matcherForCommand(groups, "ao hooks claude-code session-start"); m == nil || *m != "startup|resume|clear|compact" {
-		t.Fatalf("SessionStart matcher = %v, want startup|resume|clear|compact", m)
+	if m := matcherForCommand(groups, "ao hooks claude-code session-start"); m == nil || *m != "startup|resume|clear|compact|fork" {
+		t.Fatalf("SessionStart matcher = %v, want startup|resume|clear|compact|fork", m)
 	}
 	if got := countClaudeHookCommand(groups, "ao hooks claude-code session-start"); got != 1 {
 		t.Fatalf("session-start command count = %d, want 1 in %#v", got, groups)

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -441,9 +441,11 @@ func TestGetAgentHooksInstallsClaudeHooks(t *testing.T) {
 	if len(config.Permissions) == 0 {
 		t.Fatalf("unrelated settings clobbered: %s", data)
 	}
-	// SessionStart carries the required matcher; UserPromptSubmit omits it.
-	if m := matcherForCommand(config.Hooks["SessionStart"], "ao hooks claude-code session-start"); m == nil || *m != "startup" {
-		t.Fatalf("SessionStart matcher = %v, want startup", m)
+	// SessionStart must fire on resume (and clear/compact) as well as a fresh
+	// startup: a --resume relaunch otherwise never confirms the native session
+	// id under the new RuntimeLaunchID until the user types again (#4122).
+	if m := matcherForCommand(config.Hooks["SessionStart"], "ao hooks claude-code session-start"); m == nil || *m != "startup|resume|clear|compact" {
+		t.Fatalf("SessionStart matcher = %v, want startup|resume|clear|compact", m)
 	}
 	if m := matcherForCommand(config.Hooks["UserPromptSubmit"], "ao hooks claude-code user-prompt-submit"); m != nil {
 		t.Fatalf("UserPromptSubmit matcher = %v, want none", m)
@@ -455,6 +457,47 @@ func TestGetAgentHooksInstallsClaudeHooks(t *testing.T) {
 	}
 	if m := matcherForCommand(config.Hooks["SessionEnd"], "ao hooks claude-code session-end"); m != nil {
 		t.Fatalf("SessionEnd matcher = %v, want none", m)
+	}
+}
+
+func TestGetAgentHooksMigratesSessionStartMatcher(t *testing.T) {
+	p := &Plugin{resolvedBinary: "claude"}
+	workspace := t.TempDir()
+	settingsPath := filepath.Join(workspace, ".claude", "settings.local.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Workspaces installed before #4122 registered SessionStart only under
+	// "startup". Reconcile must move the AO command onto the broader matcher
+	// without duplicating it or dropping a user's own startup hook.
+	existing := `{"hooks":{"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"ao hooks claude-code session-start","timeout":30},{"type":"command","command":"custom startup hook","timeout":5}]}]}}`
+	if err := os.WriteFile(settingsPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config struct {
+		Hooks map[string][]hooksjson.MatcherGroup `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	groups := config.Hooks["SessionStart"]
+	if m := matcherForCommand(groups, "ao hooks claude-code session-start"); m == nil || *m != "startup|resume|clear|compact" {
+		t.Fatalf("SessionStart matcher = %v, want startup|resume|clear|compact", m)
+	}
+	if got := countClaudeHookCommand(groups, "ao hooks claude-code session-start"); got != 1 {
+		t.Fatalf("session-start command count = %d, want 1 in %#v", got, groups)
+	}
+	if got := countClaudeHookCommand(groups, "custom startup hook"); got != 1 {
+		t.Fatalf("custom startup hook count = %d, want 1 in %#v", got, groups)
 	}
 }
 

--- a/backend/internal/adapters/agent/claudecode/hooks.go
+++ b/backend/internal/adapters/agent/claudecode/hooks.go
@@ -15,12 +15,14 @@ const (
 	claudeHookTimeout       = 30
 )
 
-// claudeStartupMatcher is referenced by pointer so SessionStart serializes with
-// its required "startup" matcher.
-var claudeStartupMatcher = "startup"
+// claudeSessionStartMatcher is referenced by pointer so SessionStart serializes
+// with Claude's documented source matcher. "startup" alone misses --resume
+// relaunches (and /clear, compact), so the native session id is not confirmed
+// under the new RuntimeLaunchID until the next user prompt (#4122).
+var claudeSessionStartMatcher = "startup|resume|clear|compact"
 
 // claudeManagedHooks is the source of truth for the hooks AO installs:
-// SessionStart (under the "startup" matcher), UserPromptSubmit, the tool-use
+// SessionStart (startup/resume/clear/compact), UserPromptSubmit, the tool-use
 // trio (PreToolUse, PostToolUse, PostToolUseFailure), PermissionRequest,
 // Stop, Notification, and SessionEnd. They report normalized session metadata
 // and activity-state signals back into AO's store (see DeriveActivityState).
@@ -35,7 +37,7 @@ var claudeStartupMatcher = "startup"
 // dialog appears and carries the blocking tool_name; `ao hooks` writes nothing
 // to stdout, so installing it never injects a permission decision.
 var claudeManagedHooks = []hooksjson.HookSpec{
-	{Event: "SessionStart", Matcher: &claudeStartupMatcher, Command: claudeHookCommandPrefix + "session-start"},
+	{Event: "SessionStart", Matcher: &claudeSessionStartMatcher, Command: claudeHookCommandPrefix + "session-start"},
 	{Event: "UserPromptSubmit", Command: claudeHookCommandPrefix + "user-prompt-submit"},
 	{Event: "PreToolUse", Command: claudeHookCommandPrefix + "pre-tool-use"},
 	{Event: "PostToolUse", Command: claudeHookCommandPrefix + "post-tool-use"},

--- a/backend/internal/adapters/agent/claudecode/hooks.go
+++ b/backend/internal/adapters/agent/claudecode/hooks.go
@@ -17,12 +17,12 @@ const (
 
 // claudeSessionStartMatcher is referenced by pointer so SessionStart serializes
 // with Claude's documented source matcher. "startup" alone misses --resume
-// relaunches (and /clear, compact), so the native session id is not confirmed
-// under the new RuntimeLaunchID until the next user prompt (#4122).
-var claudeSessionStartMatcher = "startup|resume|clear|compact"
+// relaunches (and /clear, compact, fork), so the native session id is not
+// confirmed under the new RuntimeLaunchID until the next user prompt (#4122).
+var claudeSessionStartMatcher = "startup|resume|clear|compact|fork"
 
 // claudeManagedHooks is the source of truth for the hooks AO installs:
-// SessionStart (startup/resume/clear/compact), UserPromptSubmit, the tool-use
+// SessionStart (startup/resume/clear/compact/fork), UserPromptSubmit, the tool-use
 // trio (PreToolUse, PostToolUse, PostToolUseFailure), PermissionRequest,
 // Stop, Notification, and SessionEnd. They report normalized session metadata
 // and activity-state signals back into AO's store (see DeriveActivityState).


### PR DESCRIPTION
## What

Register Claude Code's `SessionStart` hook under `startup|resume|clear|compact` instead of `startup` only, so a `--resume` relaunch confirms the native conversation id immediately.

## Why

Fixes https://github.com/Untrivial-ai/agent-orchestrator/issues/4122

After a TUI relaunch via `claude --resume` (failed interface-switch rollback, restore), switch-to-chat stays disabled with `native conversation id is not confirmed` until the user types again. `SessionStart` on resume uses source `resume`, which the old matcher never matched.

## How

- Change the managed Claude `SessionStart` matcher to Claude's documented sources: `startup|resume|clear|compact`.
- Existing workspaces migrate on the next `GetAgentHooks` install: `reconcileHook` moves the AO command onto the new matcher without duplicating it.

`clear` and `compact` are included because they are the other documented `SessionStart` sources that also start a new native generation in the same TUI.

## Testing

- `go test ./internal/adapters/agent/claudecode/ -count=1` (pass)
- Install test now asserts the broader matcher
- New test: pre-seeded `startup` matcher migrates without duplicating the AO command or dropping a user hook

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)

Made with [Cursor](https://cursor.com)