### PR TITLE
fix(browser-annotation): Enter sends, Shift+Enter for newline

### DIFF
--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -319,7 +319,7 @@ describe("annotate preload", () => {
 		expect(root.querySelector('[data-action="cancel"]')).toBeNull();
 		expect(primaryAction).toBeTruthy();
 		expect(primaryAction).toHaveAttribute("aria-label", "Send annotation");
-		expect(primaryAction).toHaveAttribute("title", "Send (⌘/Ctrl + Enter)");
+		expect(primaryAction).toHaveAttribute("title", "Send (Enter)");
 		expect(primaryAction?.disabled).toBe(true);
 		expect(textarea).not.toBeNull();
 		expect(textarea).toHaveAttribute("rows", "1");
@@ -329,9 +329,7 @@ describe("annotate preload", () => {
 		);
 
 		textarea!.value = "Make this button easier to notice.";
-		textarea!.dispatchEvent(
-			new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true, bubbles: true, cancelable: true }),
-		);
+		textarea!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
 
 		await vi.waitFor(() => {
 			expect(electronMocks.invoke).toHaveBeenCalledWith(

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -532,7 +532,7 @@ function openPrompt(
 	mount.innerHTML = `
 		<form class="prompt" aria-label="Annotate selection">
 			<textarea rows="1" aria-label="Annotation request" placeholder="Describe the change…"></textarea>
-			<button disabled type="submit" aria-label="Send annotation" title="Send (⌘/Ctrl + Enter)">
+			<button disabled type="submit" aria-label="Send annotation" title="Send (Enter)">
 				<svg viewBox="0 0 24 24" aria-hidden="true">
 					<path d="M12 19V5"></path>
 					<path d="m5 12 7-7 7 7"></path>
@@ -578,7 +578,7 @@ function openPrompt(
 		if (event.key === "Escape") {
 			event.preventDefault();
 			setEnabled(false, "escape");
-		} else if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+		} else if (event.key === "Enter" && !event.shiftKey) {
 			event.preventDefault();
 			submitAnnotation();
 		}


### PR DESCRIPTION
## Summary
- Browser annotation prompt textarea now sends on plain Enter instead of Ctrl/Cmd+Enter
- Shift+Enter keeps the default newline behavior (no longer intercepted)
- Updated the send button's title hint and the corresponding test

## Test plan
- [x] `npx vitest run src/annotate-preload.test.ts` — 16 passed