### PR TITLE
feat: add testimonial submission page

### DIFF
--- a/.github/.gitleaks.toml
+++ b/.github/.gitleaks.toml
@@ -175,6 +175,13 @@ title = "gitleaks config"
     # Ignore false positives on the public company URL (rule matches brand name + nearby alnum).
     regexes = [
         '''(?i)linkedin\.com/company/agent-orchestrator''',
+        # Ordinary testimonial form identifiers and copy that overlap the legacy
+        # LinkedIn credential rules' overly broad character-count patterns.
+        '''(?i)linkedinprofileurl\(trimmedlinkedinurl''',
+        '''(?i)linkedinurl:\s*trimmedlinkedinurl''',
+        '''(?i)linkedinurl,\s*setlinkedinurl''',
+        '''(?i)linkedin profile for the accompanying''',
+        '''(?i)linkedin,\s*messagesquarequote''',
     ]
     # Historical false positives from the ReverbCode rewrite graft (#2166).
     # All offenders are example secret-patterns in security docs and

--- a/frontend/src/landing/cloudflare/testimonial-submissions-worker.ts
+++ b/frontend/src/landing/cloudflare/testimonial-submissions-worker.ts
@@ -1,0 +1,198 @@
+import { neon } from "@neondatabase/serverless";
+
+type Env = {
+  DATABASE_URL: string;
+};
+
+const MAX_BODY_BYTES = 32_768;
+const MAX_TESTIMONIAL_WORDS = 500;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 20;
+const buckets = new Map<string, { count: number; resetAt: number }>();
+
+let ensureTablePromise: Promise<void> | undefined;
+
+function json(body: { ok: boolean; error?: string }, status = 200) {
+  return Response.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "https://aoagents.dev",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}
+
+async function hash(value: string) {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function rateLimitKey(request: Request) {
+  return hash(request.headers.get("cf-connecting-ip") || "unknown");
+}
+
+function isRateLimited(key: string) {
+  const now = Date.now();
+  const bucket = buckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    buckets.set(key, {
+      count: 1,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+    });
+    return false;
+  }
+
+  bucket.count += 1;
+  return bucket.count > RATE_LIMIT_MAX_REQUESTS;
+}
+
+function parseSingleLine(value: unknown, maxLength: number) {
+  return typeof value === "string"
+    ? value.replace(/[\r\n\0]/g, "").trim().slice(0, maxLength)
+    : "";
+}
+
+function parseTestimonial(value: unknown) {
+  return typeof value === "string"
+    ? value.replace(/\0/g, "").trim().slice(0, 10_000)
+    : "";
+}
+
+function countWords(value: string) {
+  return value.trim() ? value.trim().split(/\s+/u).length : 0;
+}
+
+function validLinkedInProfileUrl(value: string) {
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname.toLowerCase().replace(/^www\./, "");
+    return (
+      url.protocol === "https:" &&
+      hostname === "linkedin.com" &&
+      /^\/in\/[^/]+\/?$/u.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function validTweetUrl(value: string) {
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname.toLowerCase().replace(/^(?:www\.|mobile\.)/, "");
+    return (
+      url.protocol === "https:" &&
+      (hostname === "x.com" || hostname === "twitter.com") &&
+      /^\/[^/]+\/status\/\d+\/?$/u.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function ensureTable(databaseUrl: string) {
+  if (!ensureTablePromise) {
+    const sql = neon(databaseUrl);
+
+    ensureTablePromise = sql`
+      CREATE TABLE IF NOT EXISTS ao_testimonial_submissions (
+        id BIGSERIAL PRIMARY KEY,
+        testimonial TEXT NOT NULL,
+        linkedin_url TEXT NOT NULL UNIQUE,
+        tweet_url TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        source TEXT NOT NULL DEFAULT 'ao_testimonial_submission',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `.then(() => undefined);
+  }
+
+  return ensureTablePromise;
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    if (request.method === "OPTIONS") {
+      return json({ ok: true });
+    }
+
+    if (request.method !== "POST") {
+      return json({ ok: false, error: "Method not allowed." }, 405);
+    }
+
+    const contentType = request.headers.get("content-type") || "";
+
+    if (!contentType.includes("application/json")) {
+      return json({ ok: false, error: "Invalid request." }, 415);
+    }
+
+    const contentLength = Number(request.headers.get("content-length") || 0);
+
+    if (contentLength > MAX_BODY_BYTES) {
+      return json({ ok: false, error: "Request too large." }, 413);
+    }
+
+    if (isRateLimited(await rateLimitKey(request))) {
+      return json({ ok: false, error: "Please try again in a minute." }, 429);
+    }
+
+    let body: Record<string, unknown>;
+
+    try {
+      const rawBody = await request.text();
+
+      if (new TextEncoder().encode(rawBody).length > MAX_BODY_BYTES) {
+        return json({ ok: false, error: "Request too large." }, 413);
+      }
+
+      const parsed = JSON.parse(rawBody);
+      body = parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+      return json({ ok: false, error: "Invalid request." }, 400);
+    }
+
+    const testimonial = parseTestimonial(body.testimonial);
+    const linkedinUrl = parseSingleLine(body.linkedinUrl, 500);
+    const tweetUrl = parseSingleLine(body.tweetUrl, 500);
+    const testimonialWords = countWords(testimonial);
+
+    if (
+      testimonial.length < 20 ||
+      testimonialWords > MAX_TESTIMONIAL_WORDS ||
+      !validLinkedInProfileUrl(linkedinUrl) ||
+      (tweetUrl && !validTweetUrl(tweetUrl))
+    ) {
+      return json({ ok: false, error: "Please check your testimonial and profile links." }, 400);
+    }
+
+    try {
+      const databaseUrl = env.DATABASE_URL.trim().replace(/^\uFEFF/, "");
+      const sql = neon(databaseUrl);
+
+      await ensureTable(databaseUrl);
+
+      await sql`
+        INSERT INTO ao_testimonial_submissions (testimonial, linkedin_url, tweet_url)
+        VALUES (${testimonial}, ${linkedinUrl}, ${tweetUrl || null})
+        ON CONFLICT (linkedin_url)
+        DO UPDATE SET
+          testimonial = EXCLUDED.testimonial,
+          tweet_url = EXCLUDED.tweet_url,
+          status = 'pending',
+          updated_at = now()
+      `;
+
+      return json({ ok: true });
+    } catch {
+      console.error("AO testimonial storage failed.");
+      return json({ ok: false, error: "Unable to save testimonial." }, 500);
+    }
+  },
+};

--- a/frontend/src/landing/cloudflare/testimonial-submissions-worker.ts
+++ b/frontend/src/landing/cloudflare/testimonial-submissions-worker.ts
@@ -5,7 +5,7 @@ type Env = {
 };
 
 const MAX_BODY_BYTES = 32_768;
-const MAX_TESTIMONIAL_WORDS = 500;
+const MAX_TESTIMONIAL_WORDS = 350;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 20;
 const buckets = new Map<string, { count: number; resetAt: number }>();

--- a/frontend/src/landing/src/app/api/testimonial-submissions/route.ts
+++ b/frontend/src/landing/src/app/api/testimonial-submissions/route.ts
@@ -1,0 +1,166 @@
+import { createHash } from "node:crypto";
+import { neon } from "@neondatabase/serverless";
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  countWords,
+  isLinkedInProfileUrl,
+  isTweetUrl,
+  MAX_TESTIMONIAL_WORDS,
+} from "@/lib/testimonial-submission";
+
+const MAX_BODY_BYTES = 32_768;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 20;
+
+const submissionBuckets = new Map<string, { count: number; resetAt: number }>();
+
+const testimonialSchema = z.object({
+  testimonial: z
+    .string()
+    .trim()
+    .min(20)
+    .max(10_000)
+    .refine((value) => countWords(value) <= MAX_TESTIMONIAL_WORDS),
+  linkedinUrl: z.string().trim().max(500).refine(isLinkedInProfileUrl),
+  tweetUrl: z
+    .string()
+    .trim()
+    .max(500)
+    .refine((value) => !value || isTweetUrl(value))
+    .optional()
+    .default(""),
+});
+
+let ensureTablePromise: Promise<void> | undefined;
+
+function json(body: { ok: boolean; error?: string }, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function getRateLimitKey(request: NextRequest) {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  const ip =
+    forwardedFor?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown";
+
+  return createHash("sha256").update(ip).digest("hex");
+}
+
+function isRateLimited(key: string) {
+  const now = Date.now();
+  const bucket = submissionBuckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    submissionBuckets.set(key, {
+      count: 1,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+    });
+    return false;
+  }
+
+  bucket.count += 1;
+  return bucket.count > RATE_LIMIT_MAX_REQUESTS;
+}
+
+function getDatabaseUrl() {
+  const databaseUrl = process.env.DATABASE_URL?.trim().replace(/^\uFEFF/, "");
+
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not configured");
+  }
+
+  return databaseUrl;
+}
+
+async function ensureTable(databaseUrl: string) {
+  if (!ensureTablePromise) {
+    const sql = neon(databaseUrl);
+
+    ensureTablePromise = sql`
+      CREATE TABLE IF NOT EXISTS ao_testimonial_submissions (
+        id BIGSERIAL PRIMARY KEY,
+        testimonial TEXT NOT NULL,
+        linkedin_url TEXT NOT NULL UNIQUE,
+        tweet_url TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        source TEXT NOT NULL DEFAULT 'ao_testimonial_submission',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `.then(() => undefined);
+  }
+
+  return ensureTablePromise;
+}
+
+export async function POST(request: NextRequest) {
+  const contentType = request.headers.get("content-type") || "";
+
+  if (!contentType.includes("application/json")) {
+    return json({ ok: false, error: "Invalid request." }, 415);
+  }
+
+  const contentLength = Number(request.headers.get("content-length") || 0);
+
+  if (contentLength > MAX_BODY_BYTES) {
+    return json({ ok: false, error: "Request too large." }, 413);
+  }
+
+  if (isRateLimited(getRateLimitKey(request))) {
+    return json({ ok: false, error: "Please try again in a minute." }, 429);
+  }
+
+  let body: unknown;
+
+  try {
+    const rawBody = await request.text();
+
+    if (new TextEncoder().encode(rawBody).length > MAX_BODY_BYTES) {
+      return json({ ok: false, error: "Request too large." }, 413);
+    }
+
+    body = JSON.parse(rawBody);
+  } catch {
+    return json({ ok: false, error: "Invalid request." }, 400);
+  }
+
+  const parsed = testimonialSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return json({ ok: false, error: "Please check your testimonial and profile links." }, 400);
+  }
+
+  try {
+    const databaseUrl = getDatabaseUrl();
+    const sql = neon(databaseUrl);
+
+    await ensureTable(databaseUrl);
+
+    await sql`
+      INSERT INTO ao_testimonial_submissions (testimonial, linkedin_url, tweet_url)
+      VALUES (
+        ${parsed.data.testimonial},
+        ${parsed.data.linkedinUrl},
+        ${parsed.data.tweetUrl || null}
+      )
+      ON CONFLICT (linkedin_url)
+      DO UPDATE SET
+        testimonial = EXCLUDED.testimonial,
+        tweet_url = EXCLUDED.tweet_url,
+        status = 'pending',
+        updated_at = now()
+    `;
+
+    return json({ ok: true });
+  } catch {
+    console.error("AO testimonial storage failed.");
+    return json({ ok: false, error: "Unable to save testimonial." }, 500);
+  }
+}

--- a/frontend/src/landing/src/app/privacy/page.tsx
+++ b/frontend/src/landing/src/app/privacy/page.tsx
@@ -1,10 +1,10 @@
 import { COMPANY } from "@ao/shared/constants";
 import type { Metadata } from "next";
 
-const LAST_UPDATED = "30 July 2026";
+const LAST_UPDATED = "19 August 2026";
 
 const description =
-  "How Agent Orchestrator handles data in AO Mobile, the desktop app and CLI, and aoagents.dev: local-first operation, optional analytics, and waitlist email processing.";
+  "How Agent Orchestrator handles data in AO Mobile, the desktop app and CLI, and aoagents.dev: local-first operation, optional analytics, waitlists, and testimonial submissions.";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
@@ -140,8 +140,9 @@ export default function PrivacyPage() {
               <Strong>anonymous, redacted usage telemetry</Strong> so we can tell
               whether releases are stable — you can turn it off. Website analytics
               stay off until you accept them. If you voluntarily join a
-              waitlist, we process the details you submit only for that
-              purpose. The mobile app sends <Strong>no telemetry at all</Strong>{" "}
+              waitlist or send us a testimonial, we process the details you
+              submit only for the purpose described on that form. The mobile
+              app sends <Strong>no telemetry at all</Strong>{" "}
               and talks only to the server you point it at.
             </p>
           </div>
@@ -380,13 +381,18 @@ export default function PrivacyPage() {
               recording is disabled on the marketing site.
             </p>
             <p>
-              Optional waitlists are separate from analytics. When you submit
-              one, the details requested by that form, such as your email
-              address, requested platform, or company role, are sent to PostHog
-              solely to manage that waitlist, even if you opted out of site
-              analytics. Submitting a waitlist form does not enable analytics
-              for later browsing. Fonts are self-hosted. Other services involved
-              when you browse are:
+              Optional waitlists and testimonial submissions are separate from
+              analytics. When you submit one, the details requested by that form
+              are sent to the relevant submission endpoint and stored solely to
+              manage that request. Waitlist forms may also send their requested
+              details to PostHog even if you opted out of site analytics;
+              submitting a form does not enable analytics for later browsing.
+              Testimonial submissions include the testimonial, your public
+              LinkedIn profile URL, and any optional public X post URL. We use
+              those details to review and, with the permission granted on the
+              form, publish your testimonial with public attribution on the AO
+              website. Fonts are self-hosted. Other services involved when you
+              browse are:
             </p>
             <Bullets>
               <Bullet>
@@ -538,6 +544,12 @@ export default function PrivacyPage() {
                 needed to notify you about the relevant release or AO Cloud
                 access, then deleted. You may request earlier deletion using the
                 private contact address below.
+              </Bullet>
+              <Bullet>
+                <Strong>Testimonial submissions.</Strong> Retained while they
+                are reviewed or displayed on the AO website, including the
+                supplied public LinkedIn and optional X post URLs. You may
+                request deletion using the private contact address below.
               </Bullet>
             </Bullets>
           </Section>

--- a/frontend/src/landing/src/app/sitemap.ts
+++ b/frontend/src/landing/src/app/sitemap.ts
@@ -32,6 +32,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 0.8,
 		},
 		{
+			url: `${baseUrl}/testimonials/`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.7,
+		},
+		{
 			url: `${baseUrl}/privacy/`,
 			lastModified: new Date("2026-07-30"),
 			changeFrequency: "yearly",

--- a/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
+++ b/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
@@ -114,7 +114,7 @@ export function TestimonialForm() {
           placeholder="What changed in the way you work after using AO? A specific outcome or moment is especially helpful."
           value={testimonial}
           onChange={(event) => setTestimonial(limitWords(event.target.value))}
-          className="min-h-44 w-full resize-y rounded-xl border border-border bg-background px-4 py-3 text-sm leading-6 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          className="min-h-44 w-full resize-y rounded-xl border border-border bg-background px-4 py-3 text-sm leading-6 text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring"
         />
         <p id={testimonialHelpId} className="text-xs leading-5 text-muted-foreground">
           100–300 words recommended. Concrete details make the strongest stories.

--- a/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
+++ b/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import { useId, useState } from "react";
+import {
+  countWords,
+  isLinkedInProfileUrl,
+  isTweetUrl,
+  limitWords,
+} from "@/lib/testimonial-submission";
+
+const TWEET_INTENT_URL =
+  "https://twitter.com/intent/tweet?text=I%27ve%20been%20using%20%40aoagents%20to%20run%20coding%20agents%20in%20parallel.%20Here%27s%20what%20I%20think%3A&url=https%3A%2F%2Faoagents.dev";
+
+export function TestimonialForm() {
+  const testimonialId = useId();
+  const testimonialHelpId = useId();
+  const linkedinId = useId();
+  const tweetId = useId();
+  const [testimonial, setTestimonial] = useState("");
+  const [linkedinUrl, setLinkedinUrl] = useState("");
+  const [tweetUrl, setTweetUrl] = useState("");
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const wordCount = countWords(testimonial);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+
+    const trimmedTestimonial = testimonial.trim();
+    const trimmedLinkedinUrl = linkedinUrl.trim();
+    const trimmedTweetUrl = tweetUrl.trim();
+
+    if (trimmedTestimonial.length < 20) {
+      setError("Please add a little more detail to your testimonial.");
+      return;
+    }
+    if (!isLinkedInProfileUrl(trimmedLinkedinUrl)) {
+      setError("Please enter a valid LinkedIn profile URL.");
+      return;
+    }
+    if (trimmedTweetUrl && !isTweetUrl(trimmedTweetUrl)) {
+      setError("Please enter a direct link to your post on X.");
+      return;
+    }
+
+    setError("");
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch("/api/testimonial-submissions/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          testimonial: trimmedTestimonial,
+          linkedinUrl: trimmedLinkedinUrl,
+          tweetUrl: trimmedTweetUrl,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Testimonial submission failed");
+      }
+
+      setSubmitted(true);
+    } catch {
+      setError("We could not save your testimonial. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="flex flex-1 flex-col justify-center rounded-2xl border border-border bg-background/60 p-6">
+        <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+          Testimonial received
+        </p>
+        <h2 className="mt-3 text-2xl font-semibold text-foreground">
+          Thank you for sharing your AO story.
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          We&apos;ll review it for the testimonials section of our website and
+          use your LinkedIn profile for the accompanying attribution.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-1 flex-col gap-4">
+      <div className="grid gap-2">
+        <div className="flex items-end justify-between gap-4">
+          <label
+            htmlFor={testimonialId}
+            className="text-sm font-medium text-foreground"
+          >
+            Your testimonial
+          </label>
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {wordCount} {wordCount === 1 ? "word" : "words"}
+          </span>
+        </div>
+        <textarea
+          id={testimonialId}
+          required
+          rows={8}
+          maxLength={10_000}
+          aria-describedby={testimonialHelpId}
+          placeholder="What changed in the way you work after using AO? A specific outcome or moment is especially helpful."
+          value={testimonial}
+          onChange={(event) => setTestimonial(limitWords(event.target.value))}
+          className="min-h-44 w-full resize-y rounded-xl border border-border bg-background px-4 py-3 text-sm leading-6 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <p id={testimonialHelpId} className="text-xs leading-5 text-muted-foreground">
+          100–300 words recommended. Concrete details make the strongest stories.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        <label
+          htmlFor={linkedinId}
+          className="text-sm font-medium text-foreground"
+        >
+          LinkedIn profile
+        </label>
+        <input
+          id={linkedinId}
+          type="url"
+          inputMode="url"
+          required
+          autoComplete="url"
+          maxLength={500}
+          placeholder="https://www.linkedin.com/in/your-name"
+          value={linkedinUrl}
+          onChange={(event) => setLinkedinUrl(event.target.value)}
+          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <p className="text-xs leading-5 text-muted-foreground">
+          We&apos;ll use your public profile photo, company, and role for attribution.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        <div className="flex items-center justify-between gap-4">
+          <label htmlFor={tweetId} className="text-sm font-medium text-foreground">
+            Tweet about AO <span className="font-normal text-muted-foreground">(optional)</span>
+          </label>
+          <a
+            href={TWEET_INTENT_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-xs font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
+          >
+            Draft a tweet
+            <ExternalLink className="size-3" aria-hidden="true" />
+          </a>
+        </div>
+        <input
+          id={tweetId}
+          type="url"
+          inputMode="url"
+          maxLength={500}
+          placeholder="https://x.com/your-name/status/..."
+          value={tweetUrl}
+          onChange={(event) => setTweetUrl(event.target.value)}
+          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <p className="text-xs leading-5 text-muted-foreground">
+          Tweet your experience, then paste the link so we can embed it directly.
+        </p>
+      </div>
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="mt-1 inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-foreground px-5 text-sm font-semibold text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isSubmitting ? "Submitting..." : "Submit testimonial"}
+      </button>
+
+      {error ? (
+        <p className="text-sm leading-6 text-red-400" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        By submitting, you give AO permission to feature your testimonial and
+        public LinkedIn attribution on our website. See our{" "}
+        <Link className="underline underline-offset-2" href="/privacy/">
+          privacy policy
+        </Link>
+        .
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
+++ b/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
@@ -96,12 +96,12 @@ export function TestimonialForm() {
         <div className="flex items-end justify-between gap-4">
           <label
             htmlFor={testimonialId}
-            className="text-sm font-medium text-foreground"
+            className="text-sm font-medium text-foreground lg:text-base"
           >
             Your testimonial
           </label>
           {wordCount > 0 ? (
-            <span className="text-xs tabular-nums text-muted-foreground">
+            <span className="text-xs tabular-nums text-muted-foreground lg:text-sm">
               {wordCount} {wordCount === 1 ? "word" : "words"}
             </span>
           ) : null}
@@ -115,9 +115,9 @@ export function TestimonialForm() {
           placeholder="What changed in the way you work after using AO? A specific outcome or moment is especially helpful."
           value={testimonial}
           onChange={(event) => setTestimonial(limitWords(event.target.value))}
-          className="min-h-44 w-full resize-y rounded-xl border border-border bg-background px-4 py-3 text-sm leading-6 text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring"
+          className="min-h-44 w-full resize-y rounded-xl border border-border bg-background px-4 py-3 text-sm leading-6 text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring lg:text-base lg:leading-7"
         />
-        <p id={testimonialHelpId} className="text-xs leading-5 text-muted-foreground">
+        <p id={testimonialHelpId} className="text-xs leading-5 text-muted-foreground lg:text-sm lg:leading-6">
           100–300 words recommended. Concrete details make the strongest stories.
         </p>
       </div>
@@ -125,7 +125,7 @@ export function TestimonialForm() {
       <div className="grid gap-2">
         <label
           htmlFor={linkedinId}
-          className="text-sm font-medium text-foreground"
+          className="text-sm font-medium text-foreground lg:text-base"
         >
           LinkedIn profile
         </label>
@@ -139,20 +139,20 @@ export function TestimonialForm() {
           placeholder="https://www.linkedin.com/in/your-name"
           value={linkedinUrl}
           onChange={(event) => setLinkedinUrl(event.target.value)}
-          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring"
+          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring lg:text-base"
         />
       </div>
 
       <div className="grid gap-2">
         <div className="flex items-center justify-between gap-4">
-          <label htmlFor={tweetId} className="text-sm font-medium text-foreground">
+          <label htmlFor={tweetId} className="text-sm font-medium text-foreground lg:text-base">
             Tweet about AO <span className="font-normal text-muted-foreground">(optional)</span>
           </label>
           <a
             href={TWEET_INTENT_URL}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-1 text-xs font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
+            className="inline-flex items-center gap-1 text-xs font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground lg:text-sm"
           >
             Draft a tweet
             <ExternalLink className="size-3" aria-hidden="true" />
@@ -166,9 +166,9 @@ export function TestimonialForm() {
           placeholder="https://x.com/your-name/status/..."
           value={tweetUrl}
           onChange={(event) => setTweetUrl(event.target.value)}
-          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring"
+          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring lg:text-base"
         />
-        <p className="text-xs leading-5 text-muted-foreground">
+        <p className="text-xs leading-5 text-muted-foreground lg:text-sm lg:leading-6">
           Tweet your experience, then paste the link so we can embed it directly.
         </p>
       </div>
@@ -176,7 +176,7 @@ export function TestimonialForm() {
       <button
         type="submit"
         disabled={isSubmitting}
-        className="mt-1 inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-foreground px-5 text-sm font-semibold text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60"
+        className="mt-1 inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-foreground px-5 text-sm font-semibold text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60 lg:text-base"
       >
         {isSubmitting ? "Submitting..." : "Submit testimonial"}
       </button>

--- a/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
+++ b/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
@@ -101,9 +101,11 @@ export function TestimonialForm() {
           >
             Your testimonial
           </label>
-          <span className="text-xs tabular-nums text-muted-foreground">
-            {wordCount} {wordCount === 1 ? "word" : "words"}
-          </span>
+          {wordCount > 0 ? (
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {wordCount} {wordCount === 1 ? "word" : "words"}
+            </span>
+          ) : null}
         </div>
         <textarea
           id={testimonialId}

--- a/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
+++ b/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
@@ -140,7 +140,7 @@ export function TestimonialForm() {
           placeholder="https://www.linkedin.com/in/your-name"
           value={linkedinUrl}
           onChange={(event) => setLinkedinUrl(event.target.value)}
-          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring"
         />
       </div>
 
@@ -167,7 +167,7 @@ export function TestimonialForm() {
           placeholder="https://x.com/your-name/status/..."
           value={tweetUrl}
           onChange={(event) => setTweetUrl(event.target.value)}
-          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring"
         />
         <p className="text-xs leading-5 text-muted-foreground">
           Tweet your experience, then paste the link so we can embed it directly.

--- a/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
+++ b/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
@@ -122,7 +122,7 @@ export function TestimonialForm() {
           className="min-h-44 w-full resize-y rounded-xl border border-border bg-background px-4 py-3 text-sm leading-6 text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring lg:text-base lg:leading-7"
         />
         <p id={testimonialHelpId} className="text-xs leading-5 text-muted-foreground lg:text-sm lg:leading-6">
-          100–300 words recommended. Concrete details make the strongest stories.
+          30–100 words recommended. Concrete details make the strongest stories.
         </p>
       </div>
 

--- a/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
+++ b/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
@@ -142,9 +142,6 @@ export function TestimonialForm() {
           onChange={(event) => setLinkedinUrl(event.target.value)}
           className="min-h-12 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
         />
-        <p className="text-xs leading-5 text-muted-foreground">
-          We&apos;ll use your public profile photo, company, and role for attribution.
-        </p>
       </div>
 
       <div className="grid gap-2">

--- a/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
+++ b/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
@@ -6,7 +6,7 @@ import {
   countWords,
   isLinkedInProfileUrl,
   isTweetUrl,
-  limitWords,
+  keepWithinWordLimit,
 } from "@/lib/testimonial-submission";
 
 const TWEET_INTENT_URL =
@@ -114,7 +114,11 @@ export function TestimonialForm() {
           aria-describedby={testimonialHelpId}
           placeholder="What changed in the way you work after using AO? A specific outcome or moment is especially helpful."
           value={testimonial}
-          onChange={(event) => setTestimonial(limitWords(event.target.value))}
+          onChange={(event) =>
+            setTestimonial((currentValue) =>
+              keepWithinWordLimit(event.target.value, currentValue),
+            )
+          }
           className="min-h-44 w-full resize-y rounded-xl border border-border bg-background px-4 py-3 text-sm leading-6 text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring lg:text-base lg:leading-7"
         />
         <p id={testimonialHelpId} className="text-xs leading-5 text-muted-foreground lg:text-sm lg:leading-6">

--- a/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
+++ b/frontend/src/landing/src/app/testimonials/TestimonialForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { ExternalLink } from "lucide-react";
 import { useId, useState } from "react";
 import {
@@ -188,14 +187,6 @@ export function TestimonialForm() {
         </p>
       ) : null}
 
-      <p className="text-xs leading-relaxed text-muted-foreground">
-        By submitting, you give AO permission to feature your testimonial and
-        public LinkedIn attribution on our website. See our{" "}
-        <Link className="underline underline-offset-2" href="/privacy/">
-          privacy policy
-        </Link>
-        .
-      </p>
     </form>
   );
 }

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -21,7 +21,7 @@ export default function TestimonialsPage() {
   return (
     <main className="min-h-[100dvh] bg-background text-foreground">
       <section className="px-4 py-10 sm:px-8 sm:py-14 lg:px-[30px] lg:py-20">
-        <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(400px,480px)] lg:items-start xl:gap-8">
+        <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-2 lg:items-start xl:gap-8">
           <div className="relative overflow-hidden rounded-2xl border border-border bg-card lg:h-[760px]">
             <Image
               src="/optimized/feature2.webp"

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { Linkedin, MessageSquareQuote, Quote } from "lucide-react";
+import { MessageSquareQuote, Quote } from "lucide-react";
 import { TestimonialForm } from "./TestimonialForm";
 
 export const metadata: Metadata = {
@@ -8,24 +8,6 @@ export const metadata: Metadata = {
   description:
     "Submit your Agent Orchestrator testimonial for the AO website.",
 };
-
-const notes = [
-  {
-    icon: MessageSquareQuote,
-    label: "Tell the real story",
-    text: "Share the moment AO changed how you run or review agent work.",
-  },
-  {
-    icon: Linkedin,
-    label: "Add your attribution",
-    text: "Your public LinkedIn profile gives the story a face, company, and role.",
-  },
-  {
-    icon: Quote,
-    label: "Join the website",
-    text: "Selected stories will appear in the testimonials section on aoagents.dev.",
-  },
-];
 
 const testimonialExamples = [
   "AO really changes the way you develop. The orchestrator and kanban have been a game changer. I’m no longer confused about what agent is doing what; scoping tasks and spawning them off has been a breeze.",
@@ -71,28 +53,6 @@ export default function TestimonialsPage() {
                 </p>
               </div>
 
-              <div className="mt-8 grid gap-3 sm:mt-10 sm:grid-cols-3 lg:mt-12">
-                {notes.map((note) => {
-                  const Icon = note.icon;
-                  return (
-                    <div
-                      key={note.label}
-                      className="rounded-xl border border-border bg-background/80 p-3 backdrop-blur sm:p-4"
-                    >
-                      <Icon
-                        className="size-4 text-muted-foreground"
-                        aria-hidden="true"
-                      />
-                      <h2 className="mt-3 text-sm font-semibold text-foreground">
-                        {note.label}
-                      </h2>
-                      <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                        {note.text}
-                      </p>
-                    </div>
-                  );
-                })}
-              </div>
             </div>
           </div>
 

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -21,7 +21,7 @@ export default function TestimonialsPage() {
     <main className="min-h-[100dvh] bg-background text-foreground">
       <section className="px-4 py-10 sm:px-8 sm:py-14 lg:px-[30px] lg:py-20">
         <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(400px,480px)] lg:items-start xl:gap-8">
-          <div className="relative order-2 overflow-hidden rounded-2xl border border-border bg-card lg:order-1 lg:h-[760px]">
+          <div className="relative overflow-hidden rounded-2xl border border-border bg-card lg:h-[760px]">
             <Image
               src="/optimized/feature2.webp"
               alt="AO desktop showing agent work moving toward review"
@@ -52,7 +52,7 @@ export default function TestimonialsPage() {
             </div>
           </div>
 
-          <aside className="order-1 flex w-full flex-col rounded-2xl border border-border bg-card p-6 sm:p-8 lg:order-2 lg:min-h-[760px]">
+          <aside className="flex w-full flex-col rounded-2xl border border-border bg-card p-6 sm:p-8 lg:min-h-[760px]">
             <div className="mb-6">
               <h2 className="text-2xl font-semibold text-foreground">
                 Submit a testimonial

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -1,0 +1,111 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { Linkedin, MessageSquareQuote, Quote } from "lucide-react";
+import { TestimonialForm } from "./TestimonialForm";
+
+export const metadata: Metadata = {
+  title: "Share Your AO Story",
+  description:
+    "Submit your Agent Orchestrator testimonial for the AO website.",
+};
+
+const notes = [
+  {
+    icon: MessageSquareQuote,
+    label: "Tell the real story",
+    text: "Share the moment AO changed how you run or review agent work.",
+  },
+  {
+    icon: Linkedin,
+    label: "Add your attribution",
+    text: "Your public LinkedIn profile gives the story a face, company, and role.",
+  },
+  {
+    icon: Quote,
+    label: "Join the website",
+    text: "Selected stories will appear in the testimonials section on aoagents.dev.",
+  },
+];
+
+export default function TestimonialsPage() {
+  return (
+    <main className="min-h-[100dvh] bg-background text-foreground">
+      <section className="px-4 py-10 sm:px-8 sm:py-14 lg:px-[30px] lg:py-20">
+        <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(400px,480px)] lg:items-start xl:gap-8">
+          <div className="relative order-2 overflow-hidden rounded-2xl border border-border bg-card lg:order-1 lg:h-[760px]">
+            <Image
+              src="/optimized/feature2.webp"
+              alt="AO desktop showing agent work moving toward review"
+              fill
+              priority
+              sizes="(max-width: 1023px) 100vw, 58vw"
+              className="object-cover opacity-55"
+            />
+            <div className="absolute inset-0 bg-gradient-to-br from-background via-background/80 to-background/30" />
+            <Quote
+              className="absolute -right-8 top-14 size-44 rotate-6 text-foreground/[0.04] sm:size-64"
+              strokeWidth={1}
+              aria-hidden="true"
+            />
+
+            <div className="relative flex min-h-[680px] flex-col justify-between p-5 sm:min-h-[650px] sm:p-8 lg:h-full lg:min-h-0 lg:p-10">
+              <div className="max-w-3xl">
+                <p className="inline-flex items-center gap-2 rounded-full border border-border bg-background/80 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
+                  <MessageSquareQuote className="size-3.5" aria-hidden="true" />
+                  Community stories
+                </p>
+                <h1 className="mt-5 max-w-4xl text-4xl font-semibold leading-[1.02] text-foreground sm:mt-6 sm:text-5xl lg:text-6xl">
+                  Put your AO experience into words.
+                </h1>
+                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+                  Tell other builders what changed when you started orchestrating
+                  coding agents with AO. We&apos;ll feature selected stories in the
+                  testimonials section of our website.
+                </p>
+              </div>
+
+              <div className="mt-8 grid gap-3 sm:mt-10 sm:grid-cols-3 lg:mt-12">
+                {notes.map((note) => {
+                  const Icon = note.icon;
+                  return (
+                    <div
+                      key={note.label}
+                      className="rounded-xl border border-border bg-background/80 p-3 backdrop-blur sm:p-4"
+                    >
+                      <Icon
+                        className="size-4 text-muted-foreground"
+                        aria-hidden="true"
+                      />
+                      <h2 className="mt-3 text-sm font-semibold text-foreground">
+                        {note.label}
+                      </h2>
+                      <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                        {note.text}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          <aside className="order-1 flex w-full flex-col rounded-2xl border border-border bg-card p-6 sm:p-8 lg:order-2 lg:min-h-[760px]">
+            <div className="mb-6">
+              <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+                Your perspective
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold text-foreground">
+                Submit a testimonial
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                The most useful testimonials name a before, an after, and one
+                concrete result.
+              </p>
+            </div>
+            <TestimonialForm />
+          </aside>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -38,7 +38,7 @@ export default function TestimonialsPage() {
               aria-hidden="true"
             />
 
-            <div className="relative flex min-h-[680px] flex-col justify-between p-5 sm:min-h-[650px] sm:p-8 lg:h-full lg:min-h-0 lg:p-10">
+            <div className="relative flex min-h-[420px] flex-col justify-between p-5 sm:min-h-[460px] sm:p-8 lg:h-full lg:min-h-0 lg:p-10">
               <div className="max-w-3xl">
                 <h1 className="max-w-4xl text-4xl font-semibold leading-[1.02] text-foreground sm:text-5xl lg:text-6xl">
                   Put your AO experience into words.

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -14,6 +14,7 @@ const testimonialExamples = [
   "With AO Mobile, I’m able to ship things on the fly, and my agents are never blocked on my input anymore.",
   "Before AO, I would ship at most 2–3 PRs a day. Now I consistently ship 5+ PRs every day at work.",
   "There hasn’t been a day in the last two months when I opened another IDE or ran a coding agent in a terminal app. AO really changes how you think about work. It’s a mindset shift you can’t go back from.",
+  "AO automatically gets the right agent to address CI failures and review comments. My agents are much more autonomous now, and with the orchestrator + kanban, I’m able to manage more and more of them.",
 ];
 
 export default function TestimonialsPage() {

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -70,14 +70,14 @@ export default function TestimonialsPage() {
             </h2>
           </div>
 
-          <div className="grid md:grid-cols-2">
+          <div className="grid sm:grid-cols-2">
             {testimonialExamples.map((example, index) => (
               <blockquote
                 key={example}
                 className={`group relative border-border py-7 first:pt-8 ${
                   index > 0 ? "border-t" : ""
-                } ${index < 2 ? "md:border-t-0" : "md:border-t"} ${
-                  index % 2 === 1 ? "md:border-l md:pl-8" : "md:pr-8"
+                } ${index < 2 ? "sm:border-t-0" : "sm:border-t"} ${
+                  index % 2 === 1 ? "sm:border-l sm:pl-8" : "sm:pr-8"
                 }`}
               >
                 <div className="flex items-center justify-between gap-4">

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -26,7 +26,7 @@ const testimonialExamples = [
 export default function TestimonialsPage() {
   return (
     <main
-      className={`${testimonialSans.className} min-h-[100dvh] bg-background text-foreground`}
+      className={`${testimonialSans.className} min-h-[100dvh] bg-background font-[450] text-foreground`}
     >
       <section className="px-4 py-10 sm:px-8 sm:py-14 lg:px-[30px] lg:py-20">
         <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-2 lg:items-start xl:gap-8">

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -77,7 +77,12 @@ export default function TestimonialsPage() {
                 className={`group relative border-border py-7 first:pt-8 ${
                   index > 0 ? "border-t" : ""
                 } ${index < 2 ? "sm:border-t-0" : "sm:border-t"} ${
-                  index % 2 === 1 ? "sm:border-l sm:pl-8" : "sm:pr-8"
+                  index === testimonialExamples.length - 1 &&
+                  testimonialExamples.length % 2 === 1
+                    ? "sm:col-span-2"
+                    : index % 2 === 1
+                      ? "sm:border-l sm:pl-8"
+                      : "sm:pr-8"
                 }`}
               >
                 <div className="flex items-center justify-between gap-4">

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -58,10 +58,7 @@ export default function TestimonialsPage() {
 
           <aside className="order-1 flex w-full flex-col rounded-2xl border border-border bg-card p-6 sm:p-8 lg:order-2 lg:min-h-[760px]">
             <div className="mb-6">
-              <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
-                Your perspective
-              </p>
-              <h2 className="mt-3 text-2xl font-semibold text-foreground">
+              <h2 className="text-2xl font-semibold text-foreground">
                 Submit a testimonial
               </h2>
               <p className="mt-3 text-sm leading-6 text-muted-foreground">

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -55,7 +55,7 @@ export default function TestimonialsPage() {
 
           <aside className="flex w-full flex-col rounded-2xl border border-border bg-card p-6 sm:p-8 lg:min-h-[760px]">
             <div className="mb-6">
-              <h2 className="text-2xl font-semibold text-foreground">
+              <h2 className="text-2xl font-semibold text-foreground lg:text-3xl">
                 Submit a testimonial
               </h2>
             </div>

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from "next";
 import Image from "next/image";
+import { Onest } from "next/font/google";
 import { Quote } from "lucide-react";
 import { TestimonialForm } from "./TestimonialForm";
+
+const testimonialSans = Onest({
+  subsets: ["latin"],
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "Share Your AO Story",
@@ -19,7 +25,9 @@ const testimonialExamples = [
 
 export default function TestimonialsPage() {
   return (
-    <main className="min-h-[100dvh] bg-background text-foreground">
+    <main
+      className={`${testimonialSans.className} min-h-[100dvh] bg-background text-foreground`}
+    >
       <section className="px-4 py-10 sm:px-8 sm:py-14 lg:px-[30px] lg:py-20">
         <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-2 lg:items-start xl:gap-8">
           <div className="relative overflow-hidden rounded-2xl border border-border bg-card lg:h-[760px]">

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -27,6 +27,13 @@ const notes = [
   },
 ];
 
+const testimonialExamples = [
+  "AO really changes the way you develop. The orchestrator and kanban have been a game changer. I’m no longer confused about what agent is doing what; scoping tasks and spawning them off has been a breeze.",
+  "With AO Mobile, I’m able to ship things on the fly, and my agents are never blocked on my input anymore.",
+  "Before AO, I would ship at most 2–3 PRs a day. Now I consistently ship 5+ PRs every day at work.",
+  "There hasn’t been a day in the last two months when I opened another IDE or ran a coding agent in a terminal app. AO really changes how you think about work. It’s a mindset shift you can’t go back from.",
+];
+
 export default function TestimonialsPage() {
   return (
     <main className="min-h-[100dvh] bg-background text-foreground">
@@ -105,6 +112,49 @@ export default function TestimonialsPage() {
             <TestimonialForm />
           </aside>
         </div>
+
+        <section className="mx-auto mt-6 max-w-7xl overflow-hidden rounded-2xl border border-border bg-card p-6 sm:p-8 lg:p-10">
+          <div className="grid gap-4 border-b border-border pb-7 sm:grid-cols-[minmax(0,1fr)_minmax(280px,420px)] sm:items-end">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+                A useful starting point
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold text-foreground sm:text-3xl">
+                Examples of good testimonials
+              </h2>
+            </div>
+            <p className="text-sm leading-6 text-muted-foreground sm:text-right">
+              Specific outcomes, honest before-and-after moments, and concrete
+              changes are more useful than generic praise.
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2">
+            {testimonialExamples.map((example, index) => (
+              <blockquote
+                key={example}
+                className={`group relative border-border py-7 first:pt-8 ${
+                  index > 0 ? "border-t" : ""
+                } ${index < 2 ? "md:border-t-0" : "md:border-t"} ${
+                  index % 2 === 1 ? "md:border-l md:pl-8" : "md:pr-8"
+                }`}
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                    Example {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <Quote
+                    className="size-5 text-foreground/10 transition-colors group-hover:text-foreground/20"
+                    aria-hidden="true"
+                  />
+                </div>
+                <p className="mt-5 max-w-2xl text-base leading-7 text-foreground/90 sm:text-lg sm:leading-8">
+                  “{example}”
+                </p>
+              </blockquote>
+            ))}
+          </div>
+        </section>
       </section>
     </main>
   );

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { Onest } from "next/font/google";
+import { Bricolage_Grotesque } from "next/font/google";
 import { Quote } from "lucide-react";
 import { TestimonialForm } from "./TestimonialForm";
 
-const testimonialSans = Onest({
+const testimonialDisplay = Bricolage_Grotesque({
+  weight: "600",
   subsets: ["latin"],
   display: "swap",
 });
@@ -25,9 +26,7 @@ const testimonialExamples = [
 
 export default function TestimonialsPage() {
   return (
-    <main
-      className={`${testimonialSans.className} min-h-[100dvh] bg-background font-[450] text-foreground`}
-    >
+    <main className="min-h-[100dvh] bg-background text-foreground">
       <section className="px-4 py-10 sm:px-8 sm:py-14 lg:px-[30px] lg:py-20">
         <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-2 lg:items-start xl:gap-8">
           <div className="relative overflow-hidden rounded-2xl border border-border bg-card lg:h-[760px]">
@@ -48,7 +47,9 @@ export default function TestimonialsPage() {
 
             <div className="relative flex flex-col justify-between p-5 sm:p-8 lg:h-full lg:p-10">
               <div className="max-w-3xl">
-                <h1 className="max-w-4xl text-4xl font-semibold leading-[1.02] text-foreground sm:text-5xl lg:text-6xl">
+                <h1
+                  className={`${testimonialDisplay.className} max-w-4xl text-4xl font-semibold leading-[1.02] text-foreground sm:text-5xl lg:text-6xl`}
+                >
                   Put your AO experience into words.
                 </h1>
                 <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
@@ -94,7 +95,9 @@ export default function TestimonialsPage() {
           className="mx-auto mt-6 max-w-7xl scroll-mt-20 overflow-hidden rounded-2xl border border-border bg-card p-6 sm:p-8 lg:p-10"
         >
           <div className="border-b border-border pb-7">
-            <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">
+            <h2
+              className={`${testimonialDisplay.className} text-2xl font-semibold text-foreground sm:text-3xl`}
+            >
               Examples of good testimonials
             </h2>
           </div>

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -50,12 +50,12 @@ export default function TestimonialsPage() {
                 </p>
               </div>
 
-              <div className="mt-auto hidden border-t border-border/70 pt-6 lg:block">
-                <div className="grid grid-cols-2 gap-6">
-                  {testimonialExamples.slice(1, 3).map((example) => (
+              <div className="mt-10 border-t border-border/70 pt-6 lg:mt-auto">
+                <div className="grid gap-x-6 gap-y-5 lg:grid-cols-2">
+                  {testimonialExamples.slice(1, 5).map((example, index) => (
                     <blockquote
                       key={example}
-                      className="text-sm leading-6 text-foreground/80"
+                      className={`${index > 0 ? "hidden lg:block" : ""} text-sm leading-6 text-foreground/80`}
                     >
                       “{example}”
                     </blockquote>

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { MessageSquareQuote, Quote } from "lucide-react";
+import { Quote } from "lucide-react";
 import { TestimonialForm } from "./TestimonialForm";
 
 export const metadata: Metadata = {
@@ -39,11 +39,7 @@ export default function TestimonialsPage() {
 
             <div className="relative flex min-h-[680px] flex-col justify-between p-5 sm:min-h-[650px] sm:p-8 lg:h-full lg:min-h-0 lg:p-10">
               <div className="max-w-3xl">
-                <p className="inline-flex items-center gap-2 rounded-full border border-border bg-background/80 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
-                  <MessageSquareQuote className="size-3.5" aria-hidden="true" />
-                  Community stories
-                </p>
-                <h1 className="mt-5 max-w-4xl text-4xl font-semibold leading-[1.02] text-foreground sm:mt-6 sm:text-5xl lg:text-6xl">
+                <h1 className="max-w-4xl text-4xl font-semibold leading-[1.02] text-foreground sm:text-5xl lg:text-6xl">
                   Put your AO experience into words.
                 </h1>
                 <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
@@ -61,29 +57,16 @@ export default function TestimonialsPage() {
               <h2 className="text-2xl font-semibold text-foreground">
                 Submit a testimonial
               </h2>
-              <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                The most useful testimonials name a before, an after, and one
-                concrete result.
-              </p>
             </div>
             <TestimonialForm />
           </aside>
         </div>
 
         <section className="mx-auto mt-6 max-w-7xl overflow-hidden rounded-2xl border border-border bg-card p-6 sm:p-8 lg:p-10">
-          <div className="grid gap-4 border-b border-border pb-7 sm:grid-cols-[minmax(0,1fr)_minmax(280px,420px)] sm:items-end">
-            <div>
-              <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
-                A useful starting point
-              </p>
-              <h2 className="mt-3 text-2xl font-semibold text-foreground sm:text-3xl">
-                Examples of good testimonials
-              </h2>
-            </div>
-            <p className="text-sm leading-6 text-muted-foreground sm:text-right">
-              Specific outcomes, honest before-and-after moments, and concrete
-              changes are more useful than generic praise.
-            </p>
+          <div className="border-b border-border pb-7">
+            <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">
+              Examples of good testimonials
+            </h2>
           </div>
 
           <div className="grid md:grid-cols-2">

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -38,7 +38,7 @@ export default function TestimonialsPage() {
               aria-hidden="true"
             />
 
-            <div className="relative flex min-h-[420px] flex-col justify-between p-5 sm:min-h-[460px] sm:p-8 lg:h-full lg:min-h-0 lg:p-10">
+            <div className="relative flex flex-col justify-between p-5 sm:p-8 lg:h-full lg:p-10">
               <div className="max-w-3xl">
                 <h1 className="max-w-4xl text-4xl font-semibold leading-[1.02] text-foreground sm:text-5xl lg:text-6xl">
                   Put your AO experience into words.

--- a/frontend/src/landing/src/app/testimonials/page.tsx
+++ b/frontend/src/landing/src/app/testimonials/page.tsx
@@ -50,6 +50,24 @@ export default function TestimonialsPage() {
                 </p>
               </div>
 
+              <div className="mt-auto hidden border-t border-border/70 pt-6 lg:block">
+                <div className="grid grid-cols-2 gap-6">
+                  {testimonialExamples.slice(1, 3).map((example) => (
+                    <blockquote
+                      key={example}
+                      className="text-sm leading-6 text-foreground/80"
+                    >
+                      “{example}”
+                    </blockquote>
+                  ))}
+                </div>
+                <a
+                  href="#testimonial-examples"
+                  className="mt-6 inline-flex text-sm font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
+                >
+                  More examples below ↓
+                </a>
+              </div>
             </div>
           </div>
 
@@ -63,7 +81,10 @@ export default function TestimonialsPage() {
           </aside>
         </div>
 
-        <section className="mx-auto mt-6 max-w-7xl overflow-hidden rounded-2xl border border-border bg-card p-6 sm:p-8 lg:p-10">
+        <section
+          id="testimonial-examples"
+          className="mx-auto mt-6 max-w-7xl scroll-mt-20 overflow-hidden rounded-2xl border border-border bg-card p-6 sm:p-8 lg:p-10"
+        >
           <div className="border-b border-border pb-7">
             <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">
               Examples of good testimonials

--- a/frontend/src/landing/src/lib/testimonial-submission.test.ts
+++ b/frontend/src/landing/src/lib/testimonial-submission.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	countWords,
+	isLinkedInProfileUrl,
+	isTweetUrl,
+	limitWords,
+} from "./testimonial-submission";
+
+describe("testimonial word limits", () => {
+	it("counts words separated by any whitespace", () => {
+		expect(countWords("  AO makes\nparallel work\tclear.  ")).toBe(5);
+	});
+
+	it("leaves submissions within the limit unchanged", () => {
+		expect(limitWords("one  two\nthree", 3)).toBe("one  two\nthree");
+	});
+
+	it("truncates text after the final allowed word", () => {
+		expect(limitWords("one  two\nthree four", 3)).toBe("one  two\nthree");
+	});
+
+	it("enforces the submission cap for pasted text", () => {
+		const pastedText = Array.from({ length: 501 }, (_, index) => `word-${index}`).join(" ");
+		expect(countWords(limitWords(pastedText))).toBe(500);
+	});
+});
+
+describe("testimonial profile links", () => {
+	it("accepts LinkedIn profile URLs", () => {
+		expect(isLinkedInProfileUrl("https://www.linkedin.com/in/example-person/")).toBe(true);
+	});
+
+	it("rejects non-profile LinkedIn URLs", () => {
+		expect(isLinkedInProfileUrl("https://www.linkedin.com/company/example")).toBe(false);
+	});
+
+	it("accepts X and legacy Twitter status URLs", () => {
+		expect(isTweetUrl("https://x.com/example/status/1234567890")).toBe(true);
+		expect(isTweetUrl("https://twitter.com/example/status/1234567890")).toBe(true);
+	});
+
+	it("rejects social profile URLs without a status", () => {
+		expect(isTweetUrl("https://x.com/example")).toBe(false);
+	});
+});

--- a/frontend/src/landing/src/lib/testimonial-submission.test.ts
+++ b/frontend/src/landing/src/lib/testimonial-submission.test.ts
@@ -31,7 +31,7 @@ describe("testimonial word limits", () => {
 
 	it("rejects pasted text above the submission cap", () => {
 		const currentValue = "An existing testimonial.";
-		const pastedText = Array.from({ length: 501 }, (_, index) => `word-${index}`).join(" ");
+		const pastedText = Array.from({ length: 351 }, (_, index) => `word-${index}`).join(" ");
 		expect(keepWithinWordLimit(pastedText, currentValue)).toBe(currentValue);
 	});
 });

--- a/frontend/src/landing/src/lib/testimonial-submission.test.ts
+++ b/frontend/src/landing/src/lib/testimonial-submission.test.ts
@@ -4,7 +4,7 @@ import {
 	countWords,
 	isLinkedInProfileUrl,
 	isTweetUrl,
-	limitWords,
+	keepWithinWordLimit,
 } from "./testimonial-submission";
 
 describe("testimonial word limits", () => {
@@ -13,16 +13,26 @@ describe("testimonial word limits", () => {
 	});
 
 	it("leaves submissions within the limit unchanged", () => {
-		expect(limitWords("one  two\nthree", 3)).toBe("one  two\nthree");
+		expect(keepWithinWordLimit("one  two\nthree", "", 3)).toBe("one  two\nthree");
 	});
 
-	it("truncates text after the final allowed word", () => {
-		expect(limitWords("one  two\nthree four", 3)).toBe("one  two\nthree");
+	it("preserves whitespace while the submission is at the limit", () => {
+		expect(keepWithinWordLimit("one  two\nthree  ", "one  two\nthree", 3)).toBe(
+			"one  two\nthree  ",
+		);
 	});
 
-	it("enforces the submission cap for pasted text", () => {
+	it("rejects edits above the limit without rewriting the current text", () => {
+		const currentValue = "one  two\nthree  ";
+		expect(keepWithinWordLimit(`${currentValue}four`, currentValue, 3)).toBe(
+			currentValue,
+		);
+	});
+
+	it("rejects pasted text above the submission cap", () => {
+		const currentValue = "An existing testimonial.";
 		const pastedText = Array.from({ length: 501 }, (_, index) => `word-${index}`).join(" ");
-		expect(countWords(limitWords(pastedText))).toBe(500);
+		expect(keepWithinWordLimit(pastedText, currentValue)).toBe(currentValue);
 	});
 });
 

--- a/frontend/src/landing/src/lib/testimonial-submission.ts
+++ b/frontend/src/landing/src/lib/testimonial-submission.ts
@@ -1,0 +1,50 @@
+export const MAX_TESTIMONIAL_WORDS = 500;
+
+export function countWords(value: string) {
+	return value.trim() ? value.trim().split(/\s+/u).length : 0;
+}
+
+export function limitWords(value: string, maxWords = MAX_TESTIMONIAL_WORDS) {
+	let wordCount = 0;
+	let lastAllowedIndex = value.length;
+
+	for (const match of value.matchAll(/\S+/gu)) {
+		wordCount += 1;
+		if (wordCount === maxWords) {
+			lastAllowedIndex = (match.index ?? 0) + match[0].length;
+		}
+		if (wordCount > maxWords) {
+			return value.slice(0, lastAllowedIndex);
+		}
+	}
+
+	return value;
+}
+
+export function isLinkedInProfileUrl(value: string) {
+	try {
+		const url = new URL(value);
+		const hostname = url.hostname.toLowerCase().replace(/^www\./, "");
+		return (
+			url.protocol === "https:" &&
+			hostname === "linkedin.com" &&
+			/^\/in\/[^/]+\/?$/u.test(url.pathname)
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function isTweetUrl(value: string) {
+	try {
+		const url = new URL(value);
+		const hostname = url.hostname.toLowerCase().replace(/^(?:www\.|mobile\.)/, "");
+		return (
+			url.protocol === "https:" &&
+			(hostname === "x.com" || hostname === "twitter.com") &&
+			/^\/[^/]+\/status\/\d+\/?$/u.test(url.pathname)
+		);
+	} catch {
+		return false;
+	}
+}

--- a/frontend/src/landing/src/lib/testimonial-submission.ts
+++ b/frontend/src/landing/src/lib/testimonial-submission.ts
@@ -1,4 +1,4 @@
-export const MAX_TESTIMONIAL_WORDS = 500;
+export const MAX_TESTIMONIAL_WORDS = 350;
 
 export function countWords(value: string) {
 	return value.trim() ? value.trim().split(/\s+/u).length : 0;

--- a/frontend/src/landing/src/lib/testimonial-submission.ts
+++ b/frontend/src/landing/src/lib/testimonial-submission.ts
@@ -4,21 +4,12 @@ export function countWords(value: string) {
 	return value.trim() ? value.trim().split(/\s+/u).length : 0;
 }
 
-export function limitWords(value: string, maxWords = MAX_TESTIMONIAL_WORDS) {
-	let wordCount = 0;
-	let lastAllowedIndex = value.length;
-
-	for (const match of value.matchAll(/\S+/gu)) {
-		wordCount += 1;
-		if (wordCount === maxWords) {
-			lastAllowedIndex = (match.index ?? 0) + match[0].length;
-		}
-		if (wordCount > maxWords) {
-			return value.slice(0, lastAllowedIndex);
-		}
-	}
-
-	return value;
+export function keepWithinWordLimit(
+	nextValue: string,
+	currentValue: string,
+	maxWords = MAX_TESTIMONIAL_WORDS,
+) {
+	return countWords(nextValue) <= maxWords ? nextValue : currentValue;
 }
 
 export function isLinkedInProfileUrl(value: string) {


### PR DESCRIPTION
## Summary

- add a responsive `/testimonials/` landing page with writing examples and polished desktop/mobile layouts
- collect testimonial copy, a required LinkedIn profile, and an optional X post while recommending 30–100 words and enforcing a hidden 350-word cap
- add Next.js and Cloudflare submission handlers backed by the `ao_testimonial_submissions` Neon table, plus validation, privacy, and sitemap updates

## Tests

- `npm run frontend:typecheck`
- `npm run build` (from `frontend/src/landing`)
- `npx vitest run --config vite.renderer.config.ts src/landing/src/lib/testimonial-submission.test.ts` (from `frontend`)

## Deployment follow-up

- deploy `frontend/src/landing/cloudflare/testimonial-submissions-worker.ts` with the production `DATABASE_URL`
- route `/api/testimonial-submissions/*` to that worker so the static landing deployment persists submissions

## Notes

The production build passes. Next.js emits its existing non-fatal warning that GitHub release API responses exceed the 2 MB data-cache limit.