### PR TITLE
feat: nudge SCM polling on agent turn end

### DIFF
--- a/backend/internal/daemon/scm_wiring.go
+++ b/backend/internal/daemon/scm_wiring.go
@@ -41,6 +41,7 @@ func startSCMObserver(ctx context.Context, store *sqlite.Store, lcm *lifecycle.M
 	}
 	provider := scmmulti.New(named...)
 	observer := scmobserve.New(provider, store, lcm, scmobserve.Config{Logger: logger, ScopedIdentityResolver: provider})
+	lcm.SetSCMNudger(observer)
 	return observer.Start(ctx)
 }
 

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -109,6 +109,11 @@ type sessionOperationGate interface {
 	SessionMutationInProgress(id domain.SessionID) bool
 }
 
+// scmNudger is the non-blocking wake boundary for prompt SCM discovery.
+type scmNudger interface {
+	Nudge()
+}
+
 type pendingLaunch struct {
 	launchID string
 	ready    chan struct{}
@@ -169,6 +174,7 @@ type Manager struct {
 	projects         projectConfigLoader
 	operationGateMu  sync.RWMutex
 	operationGate    sessionOperationGate
+	scmNudger        scmNudger
 
 	mu        sync.Mutex
 	window    time.Duration
@@ -248,6 +254,14 @@ func (m *Manager) SetSessionOperationGate(gate sessionOperationGate) {
 	m.operationGateMu.Lock()
 	m.operationGate = gate
 	m.operationGateMu.Unlock()
+}
+
+// SetSCMNudger late-binds the observer because lifecycle is constructed before
+// SCM providers during daemon startup.
+func (m *Manager) SetSCMNudger(nudger scmNudger) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.scmNudger = nudger
 }
 
 func (m *Manager) sessionMutationInProgress(id domain.SessionID) bool {
@@ -525,6 +539,12 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		(s.State != domain.ActivityActive || s.Event != "user-prompt-submit") {
 		m.mu.Unlock()
 		return nil
+	}
+	// A normalized stop hook is the cheapest reliable signal that a worker turn
+	// may just have created or pushed a PR. The observer coalesces these calls,
+	// so this must remain a non-blocking hint rather than lifecycle work.
+	if s.Event == "stop" && m.scmNudger != nil {
+		m.scmNudger.Nudge()
 	}
 	// Event-tagged signals fold through the session's tool-flight state first:
 	// they may be suppressed (state write skipped) by the blocked-precedence

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -541,8 +541,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		return nil
 	}
 	// A normalized stop hook is the cheapest reliable signal that a worker turn
-	// may just have created or pushed a PR. The observer coalesces these calls,
-	// so this must remain a non-blocking hint rather than lifecycle work.
+	// may just have mutated PR state (create, ready, close, reopen, or push). The
+	// observer coalesces these calls, so this remains a non-blocking hint rather
+	// than lifecycle work or command-pattern matching.
 	if s.Event == "stop" && m.scmNudger != nil {
 		m.scmNudger.Nudge()
 	}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -332,6 +332,12 @@ type fakeCompletionTerminator struct {
 	err   error
 }
 
+type fakeSCMNudger struct {
+	calls int
+}
+
+func (f *fakeSCMNudger) Nudge() { f.calls++ }
+
 func (f *fakeCompletionTerminator) Kill(_ context.Context, _ domain.SessionID) (bool, error) {
 	f.calls++
 	return true, f.err
@@ -910,6 +916,41 @@ func TestActivity_MissingSessionReturnsNotFound(t *testing.T) {
 	err := m.ApplyActivitySignal(ctx, "missing-1", ports.ActivitySignal{Valid: true, State: domain.ActivityWaitingInput})
 	if !errors.Is(err, ports.ErrSessionNotFound) {
 		t.Fatalf("err = %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestActivity_StopSignalNudgesSCMObserver(t *testing.T) {
+	m, st, _ := newManager()
+	nudger := &fakeSCMNudger{}
+	m.SetSCMNudger(nudger)
+	rec := working("mer-1")
+	rec.Metadata.RuntimeLaunchID = "launch-2"
+	st.sessions[rec.ID] = rec
+
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		Valid: true, State: domain.ActivityIdle, Event: "stop", LaunchID: "launch-2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Repeated stop hooks are still useful signals even when activity is
+	// already idle; the observer owns coalescing them.
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		Valid: true, State: domain.ActivityIdle, Event: "stop", LaunchID: "launch-2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		Valid: true, State: domain.ActivityActive, Event: "post-tool-use", LaunchID: "launch-2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		Valid: true, State: domain.ActivityIdle, Event: "stop", LaunchID: "stale-launch",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if nudger.calls != 2 {
+		t.Fatalf("SCM nudge calls = %d, want 2 accepted stop signals only", nudger.calls)
 	}
 }
 

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -27,6 +27,10 @@ import (
 const (
 	// DefaultTickInterval is the SCM observer's PR/CI polling cadence.
 	DefaultTickInterval = 30 * time.Second
+	// DefaultNudgeDebounce coalesces turn-end signals before an out-of-band
+	// poll. This keeps discovery responsive without issuing one provider scan
+	// per agent hook when several sessions finish together.
+	DefaultNudgeDebounce = 2 * time.Second
 	// DefaultReviewInterval is the minimum interval between review-thread polls
 	// for a PR whose review state warrants thread refresh.
 	DefaultReviewInterval = 2 * time.Minute
@@ -152,6 +156,9 @@ func defaultRateLimitCooldown(now time.Time) time.Duration {
 type Config struct {
 	// Tick is the fast PR/CI polling interval. Zero uses DefaultTickInterval.
 	Tick time.Duration
+	// NudgeDebounce is the coalescing window for out-of-band polls. Zero uses
+	// DefaultNudgeDebounce.
+	NudgeDebounce time.Duration
 	// ReviewInterval is the slower review-thread refresh interval.
 	ReviewInterval time.Duration
 	// Clock supplies timestamps for observations and tests. Nil uses time.Now.
@@ -228,6 +235,11 @@ type Observer struct {
 	lifecycle Lifecycle
 	// tick is the active PR/CI polling cadence.
 	tick time.Duration
+	// nudgeDebounce is the coalescing window for out-of-band polls.
+	nudgeDebounce time.Duration
+	// nudges is a level-triggered, non-blocking wake signal. Its single slot
+	// coalesces concurrent callers before the poll loop observes them.
+	nudges chan struct{}
 	// reviewInterval is the minimum duration between review-thread fetches per PR.
 	reviewInterval time.Duration
 	// clock supplies observation timestamps.
@@ -254,9 +266,12 @@ type Observer struct {
 // New constructs an Observer with default cadence/cache settings for zero
 // values in cfg.
 func New(provider Provider, store Store, lifecycle Lifecycle, cfg Config) *Observer {
-	o := &Observer{provider: provider, store: store, lifecycle: lifecycle, tick: cfg.Tick, reviewInterval: cfg.ReviewInterval, clock: cfg.Clock, logger: cfg.Logger, identityResolver: cfg.IdentityResolver, scopedIdentityResolver: cfg.ScopedIdentityResolver, Cache: newCache(cfg.CacheMax), rateLimitUntil: map[string]time.Time{}}
+	o := &Observer{provider: provider, store: store, lifecycle: lifecycle, tick: cfg.Tick, nudgeDebounce: cfg.NudgeDebounce, nudges: make(chan struct{}, 1), reviewInterval: cfg.ReviewInterval, clock: cfg.Clock, logger: cfg.Logger, identityResolver: cfg.IdentityResolver, scopedIdentityResolver: cfg.ScopedIdentityResolver, Cache: newCache(cfg.CacheMax), rateLimitUntil: map[string]time.Time{}}
 	if o.tick <= 0 {
 		o.tick = DefaultTickInterval
+	}
+	if o.nudgeDebounce <= 0 {
+		o.nudgeDebounce = DefaultNudgeDebounce
 	}
 	if o.reviewInterval <= 0 {
 		o.reviewInterval = DefaultReviewInterval
@@ -268,6 +283,15 @@ func New(provider Provider, store Store, lifecycle Lifecycle, cfg Config) *Obser
 		o.logger = slog.Default()
 	}
 	return o
+}
+
+// Nudge requests one debounced out-of-band poll. It is safe for concurrent
+// callers and never blocks the lifecycle hook delivering the signal.
+func (o *Observer) Nudge() {
+	select {
+	case o.nudges <- struct{}{}:
+	default:
+	}
 }
 
 // Start launches the observer loop. The first Poll runs immediately inside the
@@ -290,7 +314,65 @@ func (o *Observer) Start(ctx context.Context) <-chan struct{} {
 		})
 		return o.Poll(ctx)
 	}
-	return observe.StartPollLoop(ctx, o.tick, poll, o.logger, "scm observer")
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runPoll := func(label string) {
+			if err := poll(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				o.logger.Error("scm observer: "+label+" poll failed", "err", err)
+			}
+		}
+		runPoll("initial")
+
+		ticker := time.NewTicker(o.tick)
+		defer ticker.Stop()
+		var (
+			nudgeTimer *time.Timer
+			nudgeC     <-chan time.Time
+		)
+		defer func() {
+			if nudgeTimer != nil {
+				nudgeTimer.Stop()
+			}
+		}()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				// A scheduled poll satisfies any pending wake request. Cancel the
+				// debounce timer so a nudge just before the tick cannot cause two
+				// provider scans a few seconds apart.
+				if nudgeTimer != nil {
+					nudgeTimer.Stop()
+					nudgeTimer = nil
+					nudgeC = nil
+					select {
+					case <-o.nudges:
+					default:
+					}
+				}
+				runPoll("scheduled")
+			case <-o.nudges:
+				if nudgeTimer == nil {
+					nudgeTimer = time.NewTimer(o.nudgeDebounce)
+					nudgeC = nudgeTimer.C
+				}
+			case <-nudgeC:
+				nudgeTimer = nil
+				nudgeC = nil
+				// A concurrent caller may have filled the one-slot channel after
+				// the loop armed the timer. It belongs to this same debounce
+				// window, so consume it before polling.
+				select {
+				case <-o.nudges:
+				default:
+				}
+				runPoll("nudged")
+			}
+		}
+	}()
+	return done
 }
 
 type subject struct {

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -41,6 +41,10 @@ type fakeStore struct {
 
 	listEntered chan struct{}
 	listRelease chan struct{}
+	pollDelay   time.Duration
+	listCalls   int
+	pollActive  int
+	maxActive   int
 }
 
 type fakeWrite struct {
@@ -53,6 +57,19 @@ type fakeWrite struct {
 }
 
 func (s *fakeStore) ListAllSessions(ctx context.Context) ([]domain.SessionRecord, error) {
+	s.mu.Lock()
+	s.listCalls++
+	s.pollActive++
+	if s.pollActive > s.maxActive {
+		s.maxActive = s.pollActive
+	}
+	delay := s.pollDelay
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.pollActive--
+		s.mu.Unlock()
+	}()
 	if s.listEntered != nil {
 		select {
 		case <-s.listEntered:
@@ -67,9 +84,24 @@ func (s *fakeStore) ListAllSessions(ctx context.Context) ([]domain.SessionRecord
 		case <-s.listRelease:
 		}
 	}
+	if delay > 0 {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]domain.SessionRecord(nil), s.sessions...), nil
+}
+
+func (s *fakeStore) pollStats() (calls, maxActive int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.listCalls, s.maxActive
 }
 
 func (s *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {
@@ -271,6 +303,84 @@ func (l *fakeLifecycle) ApplySCMObservation(_ context.Context, _ domain.SessionI
 func newTestObserver(store *fakeStore, provider *fakeProvider, lc Lifecycle, now time.Time) *Observer {
 	cfg := Config{Clock: func() time.Time { return now }, Tick: time.Hour, Logger: quietSlog(), CacheMax: 128, IdentityResolver: provider}
 	return New(provider, store, lc, cfg)
+}
+
+func waitForPollCalls(t *testing.T, store *fakeStore, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if calls, _ := store.pollStats(); calls >= want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	calls, _ := store.pollStats()
+	t.Fatalf("poll calls = %d, want at least %d", calls, want)
+}
+
+func TestObserverNudgeCoalescesConcurrentCalls(t *testing.T) {
+	store := &fakeStore{}
+	provider := &fakeProvider{}
+	observer := New(provider, store, &fakeLifecycle{}, Config{
+		Tick:          time.Hour,
+		NudgeDebounce: 25 * time.Millisecond,
+		Logger:        quietSlog(),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := observer.Start(ctx)
+	waitForPollCalls(t, store, 1)
+
+	var callers sync.WaitGroup
+	for range 32 {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			observer.Nudge()
+		}()
+	}
+	callers.Wait()
+	waitForPollCalls(t, store, 2)
+	time.Sleep(2 * observer.nudgeDebounce)
+	if calls, _ := store.pollStats(); calls != 2 {
+		t.Fatalf("poll calls after concurrent nudges = %d, want initial + one nudged poll", calls)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("observer did not stop")
+	}
+}
+
+func TestObserverNudgeDoesNotRacePollAndTickerContinues(t *testing.T) {
+	store := &fakeStore{pollDelay: 20 * time.Millisecond}
+	provider := &fakeProvider{}
+	observer := New(provider, store, &fakeLifecycle{}, Config{
+		Tick:          70 * time.Millisecond,
+		NudgeDebounce: 5 * time.Millisecond,
+		Logger:        quietSlog(),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := observer.Start(ctx)
+	waitForPollCalls(t, store, 1)
+
+	for range 16 {
+		observer.Nudge()
+	}
+	waitForPollCalls(t, store, 2)
+	// The regular ticker is not reset by the out-of-band poll.
+	waitForPollCalls(t, store, 3)
+	if _, maxActive := store.pollStats(); maxActive != 1 {
+		t.Fatalf("maximum concurrent polls = %d, want 1", maxActive)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("observer did not stop")
+	}
 }
 
 func TestDispatchOrderIsDeterministic(t *testing.T) {

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -104,6 +104,25 @@ func (s *fakeStore) pollStats() (calls, maxActive int) {
 	return s.listCalls, s.maxActive
 }
 
+func (s *fakeStore) latestWrite() (fakeWrite, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.writes) == 0 {
+		return fakeWrite{}, false
+	}
+	return s.writes[len(s.writes)-1], true
+}
+
+func (s *fakeStore) trackPRAndClearWrites(sessionID domain.SessionID, pr domain.PullRequest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.prs == nil {
+		s.prs = map[domain.SessionID][]domain.PullRequest{}
+	}
+	s.prs[sessionID] = []domain.PullRequest{pr}
+	s.writes = nil
+}
+
 func (s *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -318,6 +337,20 @@ func waitForPollCalls(t *testing.T, store *fakeStore, want int) {
 	t.Fatalf("poll calls = %d, want at least %d", calls, want)
 }
 
+func waitForWrite(t *testing.T, store *fakeStore, matches func(fakeWrite) bool) fakeWrite {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if write, ok := store.latestWrite(); ok && matches(write) {
+			return write
+		}
+		time.Sleep(time.Millisecond)
+	}
+	write, _ := store.latestWrite()
+	t.Fatalf("timed out waiting for matching SCM write; latest = %#v", write)
+	return fakeWrite{}
+}
+
 func TestObserverNudgeCoalescesConcurrentCalls(t *testing.T) {
 	store := &fakeStore{}
 	provider := &fakeProvider{}
@@ -373,6 +406,59 @@ func TestObserverNudgeDoesNotRacePollAndTickerContinues(t *testing.T) {
 	waitForPollCalls(t, store, 3)
 	if _, maxActive := store.pollStats(); maxActive != 1 {
 		t.Fatalf("maximum concurrent polls = %d, want 1", maxActive)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("observer did not stop")
+	}
+}
+
+func TestObserverNudgeRefreshesDraftPRBecomingReady(t *testing.T) {
+	store := testStoreWithSession()
+	draft := testObs(1)
+	draft.PR.Draft = true
+	draft.PR.State = "draft"
+	draft.PR.HeadRepo = "o/r"
+	provider := &fakeProvider{
+		repoGuards:   map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "draft-v1"}},
+		openPRs:      map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {draft.PR}},
+		observations: map[string]ports.SCMObservation{prKey(testRepo, 1): draft},
+	}
+	observer := New(provider, store, &fakeLifecycle{}, Config{
+		Tick:          time.Hour,
+		NudgeDebounce: 5 * time.Millisecond,
+		Logger:        quietSlog(),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := observer.Start(ctx)
+
+	// Establish the draft baseline from the observer's immediate startup poll.
+	draftWrite := waitForWrite(t, store, func(write fakeWrite) bool {
+		return write.pr.Draft && write.pr.MetadataHash == metadataSemanticHash(draft)
+	})
+	store.trackPRAndClearWrites("p-1", draftWrite.pr)
+
+	ready := draft
+	ready.PR.Draft = false
+	ready.PR.State = "open"
+	provider.mu.Lock()
+	provider.repoGuards[prKey(testRepo, 0)] = ports.SCMGuardResult{ETag: "ready-v2"}
+	provider.openPRs[prKey(testRepo, 0)] = []ports.SCMPRObservation{ready.PR}
+	provider.observations[prKey(testRepo, 1)] = ready
+	provider.mu.Unlock()
+
+	observer.Nudge()
+	readyWrite := waitForWrite(t, store, func(write fakeWrite) bool {
+		return !write.pr.Draft && write.pr.MetadataHash == metadataSemanticHash(ready)
+	})
+	if readyWrite.pr.Draft || readyWrite.pr.ProviderState == "draft" {
+		t.Fatalf("nudged poll kept PR in draft state: %#v", readyWrite.pr)
+	}
+	if calls, _ := store.pollStats(); calls != 2 {
+		t.Fatalf("poll calls = %d, want startup + one nudged ready-state refresh", calls)
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary

- reduce agent-driven PR discovery and state-refresh latency from up to the 30-second fallback interval to about 2 seconds after an accepted agent turn-end signal
- cover the full mutation class: PR creation, draft→ready, close, reopen, and pushes to an existing PR branch
- add a concurrent-safe, non-blocking SCM observer nudge channel with a 2-second debounce window
- coalesce concurrent turn-end hooks into one poll and let a regular tick satisfy a pending nudge, avoiding back-to-back provider scans
- wire normalized agent stop hooks through lifecycle after session/generation fencing; terminal command parsing was intentionally avoided because one provider-neutral turn-end signal covers all supported PR mutations
- preserve the independent 30-second scheduled poll as the fallback

## Before / after

Before, a PR created or mutated by an agent could remain stale in the sidebar until the next SCM tick, adding up to about 30 seconds of latency. After, the accepted turn-end hook schedules one debounced poll, so the sidebar normally reflects the mutation in about 2 seconds.

## Tests

- added an end-to-end observer-loop test that establishes a draft PR, changes it to ready, nudges the observer, and verifies the ready state is persisted without waiting for the hourly test ticker
- go test ./... (with all AO_* environment variables unset)
- npm run lint (with all AO_* environment variables unset)
- go test -race ./internal/observe/scm ./internal/lifecycle ./internal/daemon
- repeated focused nudge, draft→ready, debounce, and lifecycle wiring tests (20 runs)

## Risk

The nudge performs the existing full observer poll. Discovery and refresh remain scoped by the observer to tracked sessions, branches, PRs, and repositories; no new provider API path, command parsing, or persisted state was added.