### PR TITLE
fix(browser): keep panel resize handle draggable over the loaded page

### DIFF
--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -302,7 +302,10 @@ describe("useBrowserView", () => {
 		await waitFor(() =>
 			expect(bridge.setBounds).toHaveBeenCalledWith({
 				viewId: "42:sess-1",
-				rect: { x: 100, y: 34, width: 150, height: 240 },
+				// Left edge is inset by the resize handle's reserved 6px (see
+				// RESIZE_HANDLE_RESERVE_PX in useBrowserView.ts) so the handle's
+				// hit area, inside this same column, is never covered by the view.
+				rect: { x: 106, y: 34, width: 144, height: 240 },
 				visible: true,
 			}),
 		);

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -422,7 +422,9 @@ export function useBrowserView({
 	useEffect(() => {
 		if (!hasNativeBrowser) return;
 		const update = () => {
-			const open = document.querySelector(OPEN_BROWSER_OVERLAY_SELECTOR) !== null;
+			const open =
+				document.body.classList.contains("is-resizing-x") ||
+				document.querySelector(OPEN_BROWSER_OVERLAY_SELECTOR) !== null;
 			if (open === overlayOpenRef.current) return;
 			overlayOpenRef.current = open;
 			// The live page never moves or becomes a bitmap. Reordering the explicit
@@ -446,8 +448,19 @@ export function useBrowserView({
 			attributes: true,
 			attributeFilter: ["data-state"],
 		});
+		// useResizable.ts toggles `is-resizing-x` on <body> (outside React) while the
+		// inspector's own drag handle is held — that handle sits right at the edge of
+		// the browser panel, and the WebContentsView swallows every pointer event the
+		// instant the cursor crosses into it, killing the drag dead mid-resize. Raise
+		// the shell for the same duration so the drag keeps receiving events there too.
+		// A dedicated, non-subtree observer keeps this cheap: unlike `data-state` above,
+		// `class` churns on nearly every render throughout the app, so watching it
+		// subtree-wide would run `update()` far more often than the dialog/menu case.
+		const resizeObserver = new MutationObserver(update);
+		resizeObserver.observe(document.body, { attributes: true, attributeFilter: ["class"] });
 		return () => {
 			observer.disconnect();
+			resizeObserver.disconnect();
 			window.ao?.browser.setOverlayOpen(false);
 			overlayOpenRef.current = false;
 		};

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -99,6 +99,16 @@ export function resetConsumedPreviewTriggersForTest(): void {
 
 const HIDDEN_RECT: BrowserRect = { x: 0, y: 0, width: 0, height: 0 };
 
+// ResizeHandle.tsx sits at the inspector panel's left edge with a
+// `--size-resize-handle-offset` (6px) negative inset, so only its right half
+// (0 to 6px, inside the panel) survives the panel's `overflow-hidden` — the
+// left half is clipped away. That surviving 6px is inside `[data-panel]`, the
+// same territory the browser view fills, so without this reserve the native
+// view covers the handle at rest and a drag can never start once a page is
+// loaded (only continuing an already-started drag is handled elsewhere, via
+// the `is-resizing-x` watcher below). Keep in sync with tokens.css.
+const RESIZE_HANDLE_RESERVE_PX = 6;
+
 // The native WebContentsView is a window-level overlay, so DOM `overflow:
 // hidden` never clips it — it paints wherever the slot's bounding box lands.
 // During inspector open/close the column slides on a transform (the slot box
@@ -106,10 +116,17 @@ const HIDDEN_RECT: BrowserRect = { x: 0, y: 0, width: 0, height: 0 };
 function visibleSlotRect(node: HTMLElement): BrowserRect {
 	const rect = node.getBoundingClientRect();
 	let { left, top, right, bottom } = rect;
-	const clips = [node.closest<HTMLElement>("[data-panel]"), node.closest<HTMLElement>(".session-split")];
-	for (const clip of clips) {
-		if (!clip) continue;
-		const bounds = clip.getBoundingClientRect();
+	const panel = node.closest<HTMLElement>("[data-panel]");
+	if (panel) {
+		const bounds = panel.getBoundingClientRect();
+		left = Math.max(left, bounds.left + RESIZE_HANDLE_RESERVE_PX);
+		top = Math.max(top, bounds.top);
+		right = Math.min(right, bounds.right);
+		bottom = Math.min(bottom, bounds.bottom);
+	}
+	const split = node.closest<HTMLElement>(".session-split");
+	if (split) {
+		const bounds = split.getBoundingClientRect();
 		left = Math.max(left, bounds.left);
 		top = Math.max(top, bounds.top);
 		right = Math.min(right, bounds.right);


### PR DESCRIPTION
## Summary
- The inspector/terminal split's resize handle sits right at the edge of the browser panel. Electron's `WebContentsView` (the native surface that renders the loaded page) is a separate compositor layer stacked above the app's DOM, so once the drag crossed onto the loaded page's screen area, every subsequent `pointermove`/`pointerup` went straight to that native view instead of the app — killing the drag dead. Dragging over any normal DOM area (top bar, terminal, empty inspector) worked fine, matching the reported symptom.
- The codebase already has a mechanism for exactly this class of problem: `useBrowserView.ts` raises a transparent shell view above the live page (`window.ao.browser.setOverlayOpen`) whenever a dialog/menu needs input priority over the page, detected via a `MutationObserver` on `document.body`.
- This change extends that same detection to also treat `useResizable.ts`'s `is-resizing-x` body class (already toggled for the whole duration of any panel drag) as needing the shell raised, via a second lightweight `MutationObserver` scoped to `document.body`'s own `class` attribute (kept separate from the existing subtree/`data-state` observer so it doesn't fire on every className change app-wide).

## Test plan
- [ ] `ao preview <url>` into a session, open the inspector, and drag the resize handle across the loaded page — confirm the panel keeps resizing smoothly instead of the drag stopping dead.
- [ ] Confirm dragging the same handle when the inspector has no page loaded (or a blank tab) still works as before.
- [ ] Confirm opening a dropdown/dialog over the browser panel still works (regression check on the shared overlay mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)