### PR TITLE
fix(desktop): Linux titlebar cluster + kanban board padding

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -290,6 +290,38 @@ describe("SessionsBoard", () => {
 		expect(within(idleCard).getByText("brand-font-pipeline")).toHaveClass("font-semibold", "line-clamp-2");
 	});
 
+	it("insets the lane grid so it does not touch the framed panel border", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "radic",
+					path: "/tmp/radic",
+					sessions: [
+						{
+							id: "s1",
+							workspaceId: "p1",
+							workspaceName: "radic",
+							title: "brand-font-pipeline",
+							provider: "claude-code",
+							branch: "ao/radic-5",
+							status: "idle",
+							activity: { state: "idle", lastActivityAt: "2026-01-01T00:00:00Z" },
+							updatedAt: "2026-01-01T00:00:00Z",
+							prs: [],
+						},
+					],
+				},
+			],
+			isError: false,
+		});
+
+		renderBoard("p1");
+
+		const grid = screen.getByTestId("board-horizontal-scroll");
+		expect(grid.parentElement).toHaveClass("px-2", "pb-2", "pt-1.5");
+	});
+
 	it("shows compact token usage on active and archived cards and hides empty totals", async () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -335,20 +335,24 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						spawnError={visibleSpawnError}
 					/>
 				) : (
-					<SessionsBoardGridView
-						columns={columns}
-						key={projectId ?? "all"}
-						labels={boardLabels}
-						renderSessionCard={(session) => (
-							<BoardSessionCardAdapter
-								onOpen={() => openSession(session)}
-								onTerminate={() => terminateSession.mutate(session)}
-								session={session}
-								usage={usageBySession.get(session.id)}
-							/>
-						)}
-						sessions={activeSessions}
-					/>
+					// The desktop frames the board inside a rounded surface; inset the
+					// lane grid so column dividers and cards never touch that border.
+					<div className="h-full px-2 pb-2 pt-1.5">
+						<SessionsBoardGridView
+							columns={columns}
+							key={projectId ?? "all"}
+							labels={boardLabels}
+							renderSessionCard={(session) => (
+								<BoardSessionCardAdapter
+									onOpen={() => openSession(session)}
+									onTerminate={() => terminateSession.mutate(session)}
+									session={session}
+									usage={usageBySession.get(session.id)}
+								/>
+							)}
+							sessions={activeSessions}
+						/>
+					</div>
 				)}
 			</div>
 

--- a/frontend/src/renderer/components/ShellTopbar.linux.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.linux.test.tsx
@@ -59,7 +59,8 @@ describe("ShellTopbar on Linux", () => {
 		);
 
 		const header = screen.getByTestId("board-topbar-label").closest("header");
-		expect(header).toHaveStyle({ paddingLeft: "94px" });
+		// Cluster left (26) + cluster width (92) + content gap (12) - panel inline inset (16).
+		expect(header).toHaveStyle({ paddingLeft: "114px" });
 		expect(screen.getByTestId("board-topbar-label")).toHaveTextContent("Board");
 	});
 

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -62,7 +62,11 @@ const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperti
 const PADDING_DEFAULT = 18; // 1.125rem
 const PADDING_CLEARANCE = 170;
 const PADDING_CLEARANCE_FULLSCREEN = 112;
-const PADDING_CLEARANCE_LINUX = 94;
+// Off-canvas the Linux cluster shifts right to clear the framed panel border, so
+// measure the reserve from that inset, relative to the panel's own left edge:
+// --size-titlebar-cluster-left-linux-panel (26) + --size-titlebar-cluster-width
+// (92) + --size-titlebar-content-gap (12) - --size-center-panel-inline-inset (16).
+const PADDING_CLEARANCE_LINUX = 114;
 
 export function ShellTopbar({
 	embedded = false,

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -119,12 +119,9 @@ export const SIDEBAR_MAX_WIDTH = 420;
 type SidebarProps = {
 	/** Hide the sidebar's right edge stroke on the welcome board inset chrome. */
 	hideEdgeBorder?: boolean;
-	/** Render the expanded sidebar over content without reserving layout width. */
-	isOverlay?: boolean;
 	underTopbar?: boolean;
 	/** Chrome height to clear when underTopbar is set. Defaults to --size-toolbar. */
 	topbarOffset?: "toolbar" | "titlebar" | "trafficLights" | "session";
-	onPreviewLeave?: () => void;
 	workspaceError?: string;
 	workspaces: WorkspaceSummary[];
 	onCloneProject: (input: CloneProjectInput) => Promise<void>;
@@ -170,15 +167,12 @@ function SessionStatusDot({ session }: { session: WorkspaceSession }) {
 }
 
 // Built on shadcn's sidebar primitives (components/ui/sidebar): the provider in
-// _shell owns the persistent open state plus a transient hover-preview state.
-// Collapsed sidebars move fully off-canvas; previews return as overlays without
-// reserving layout width.
+// _shell owns the persistent open state. Collapsed sidebars move fully
+// off-canvas.
 export function Sidebar({
 	hideEdgeBorder = false,
-	isOverlay = false,
 	underTopbar = true,
 	topbarOffset = "toolbar",
-	onPreviewLeave,
 	workspaceError,
 	workspaces,
 	onCloneProject,
@@ -257,30 +251,21 @@ export function Sidebar({
 		});
 
 	return (
-		// Pinned sidebars start below shell chrome. Hover previews paint a
-		// full-height surface behind the titlebar while their content keeps the
-		// same chrome clearance, leaving the titlebar controls unobstructed.
+		// Pinned sidebars start below shell chrome, leaving the titlebar controls
+		// unobstructed.
 		<SidebarRoot
 			collapsible="offcanvas"
 			data-expanded-chrome={expandedChromeVisible ? "visible" : "hidden"}
 			data-topbar-offset={underTopbar ? topbarOffset : undefined}
-			onPointerLeave={onPreviewLeave}
-			overlay={isOverlay}
 			className={cn(
 				"sidebar-focusless",
 				hideEdgeBorder ? "border-transparent" : "border-r-0 group-data-[side=left]:border-r-0",
-				isOverlay && "z-sidebar-preview shadow-2xl",
-				isOverlay || !underTopbar
+				!underTopbar
 					? "top-0 h-svh!"
 					: "top-(--sidebar-chrome-offset) h-[calc(100svh-var(--sidebar-chrome-offset))]!",
 			)}
 		>
-			<SidebarHeader
-				className={cn(
-					"gap-0 p-0 px-3 pt-2 group-data-[collapsible=icon]:px-1.5 group-data-[collapsible=icon]:pt-2",
-					isOverlay && underTopbar && "pt-(--sidebar-chrome-offset)!",
-				)}
-			>
+			<SidebarHeader className="gap-0 p-0 px-3 pt-2 group-data-[collapsible=icon]:px-1.5 group-data-[collapsible=icon]:pt-2">
 				{/* Brand (project-sidebar__brand); in the icon rail it becomes the old
             36px board button wrapping the 22px accent mark. */}
 				<div

--- a/frontend/src/renderer/components/TitlebarNav.linux.test.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.linux.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useUiStore } from "../stores/ui-store";
 
 const { history } = vi.hoisted(() => ({
 	history: {
@@ -23,6 +24,10 @@ vi.mock("../lib/platform", () => ({
 const { TitlebarNav } = await import("./TitlebarNav");
 
 describe("TitlebarNav on Linux", () => {
+	afterEach(() => {
+		useUiStore.setState({ isSidebarOpen: true });
+	});
+
 	it("pins the collapse cluster to the Linux inset, not the macOS traffic-light offset", () => {
 		const { container } = render(<TitlebarNav />);
 
@@ -30,5 +35,14 @@ describe("TitlebarNav on Linux", () => {
 		expect(nav).toHaveClass("left-titlebar-cluster-left-linux", "top-0.75");
 		expect(nav).not.toHaveClass("left-0");
 		expect(nav).not.toHaveClass("left-titlebar-cluster-left");
+	});
+
+	it("shifts the cluster clear of the framed panel border when the sidebar is off-canvas", () => {
+		useUiStore.setState({ isSidebarOpen: false });
+		const { container } = render(<TitlebarNav />);
+
+		const nav = container.querySelector('[data-slot="titlebar-nav"]');
+		expect(nav).toHaveClass("left-titlebar-cluster-left-linux-panel");
+		expect(nav).not.toHaveClass("left-titlebar-cluster-left-linux");
 	});
 });

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -59,9 +59,13 @@ export function TitlebarNav({
   // 12px hit target (centerline 18); the 40px clearance band is items-centered,
   // so top: -2px puts the toggle/arrows on that same centerline. Linux: no
   // traffic lights, so it sits at the sidebar's top-left within the reserved
-  // titlebar band (cluster-left-linux, not flush to the window edge).
+  // titlebar band (cluster-left-linux, not flush to the window edge) — and when
+  // the sidebar is off-canvas it shifts right to clear the framed centre
+  // panel's left border instead of straddling it.
   const leftClass = !isMac
-    ? "left-titlebar-cluster-left-linux"
+    ? isSidebarOpen
+      ? "left-titlebar-cluster-left-linux"
+      : "left-titlebar-cluster-left-linux-panel"
     : isFullScreen
       ? "left-titlebar-cluster-left-fullscreen"
       : "left-titlebar-cluster-left";

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -42,12 +42,10 @@ export function TitlebarNav({
   historyLocked = false,
   hasSessionTopbar = false,
   isFullScreen = false,
-  onSidebarPreviewEnter,
 }: {
   historyLocked?: boolean;
   hasSessionTopbar?: boolean;
   isFullScreen?: boolean;
-  onSidebarPreviewEnter?: React.PointerEventHandler<HTMLButtonElement>;
 }) {
   const { t } = useTranslation();
   const { isSidebarOpen, toggleSidebar } = useUiStore();
@@ -92,7 +90,6 @@ export function TitlebarNav({
           isSidebarOpen ? t("shell.collapseSidebar") : t("shell.expandSidebar")
         }
         onClick={toggleSidebar}
-        onPointerEnter={onSidebarPreviewEnter}
         title={
           isSidebarOpen
             ? t("titlebar.collapseSidebarShortcut")

--- a/frontend/src/renderer/components/WindowTitlebar.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.tsx
@@ -138,11 +138,7 @@ function WindowControls({
   );
 }
 
-export function WindowTitlebar({
-  onSidebarPreviewEnter,
-}: {
-  onSidebarPreviewEnter?: React.PointerEventHandler<HTMLButtonElement>;
-}) {
+export function WindowTitlebar() {
   const { t } = useTranslation();
   const { isSidebarOpen, toggleSidebar } = useUiStore();
   const router = useRouter();
@@ -191,7 +187,6 @@ export function WindowTitlebar({
         }
         className="window-titlebar__toggle"
         onClick={toggleSidebar}
-        onPointerEnter={onSidebarPreviewEnter}
         title={
           isSidebarOpen
             ? t("shell.collapseSidebarTitle")

--- a/frontend/src/renderer/components/ui/sidebar.tsx
+++ b/frontend/src/renderer/components/ui/sidebar.tsx
@@ -154,7 +154,6 @@ function Sidebar({
 	side = "left",
 	variant = "sidebar",
 	collapsible = "offcanvas",
-	overlay = false,
 	className,
 	children,
 	...props
@@ -162,7 +161,6 @@ function Sidebar({
 	side?: "left" | "right";
 	variant?: "sidebar" | "floating" | "inset";
 	collapsible?: "offcanvas" | "icon" | "none";
-	overlay?: boolean;
 }) {
 	const { t } = useTranslation();
 	const prefersReducedMotion = useReducedMotion();
@@ -214,7 +212,7 @@ function Sidebar({
 	// Target width for the gap placeholder. Animating the actual width lets the
 	// flex sibling <main> follow in real time instead of snapping separately.
 	const gapTargetWidth =
-		overlay || isOffcanvasCollapsed
+		isOffcanvasCollapsed
 			? 0
 			: isIconCollapsed
 				? variant === "floating" || variant === "inset"
@@ -232,7 +230,6 @@ function Sidebar({
 			className="group peer hidden text-sidebar-foreground md:block"
 			data-state={state}
 			data-collapsible={state === "collapsed" ? collapsible : ""}
-			data-overlay={overlay ? "true" : "false"}
 			data-variant={variant}
 			data-side={side}
 			data-slot="sidebar"

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -138,8 +138,6 @@ function ShellLayout() {
 	const handledShellNonceRef = useRef(newShellTerminalNonce);
 	const [isKeyboardShortcutsOpen, setIsKeyboardShortcutsOpen] = useState(false);
 	const [isKeyboardShortcutsSettingsOpen, setIsKeyboardShortcutsSettingsOpen] = useState(false);
-	const [isSidebarPeekOpen, setIsSidebarPeekOpen] = useState(false);
-	const sidebarPeekCloseTimerRef = useRef<number | undefined>(undefined);
 	const routeParams = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
 	useEffect(() => {
 		document.addEventListener("click", handleModifierLinkClick);
@@ -202,27 +200,6 @@ function ShellLayout() {
 		!usesPreviewWorkspaceData &&
 		!daemonStatus.code &&
 		(daemonStatus.state !== "ready" || workspaceStartupState === "loading");
-	const cancelSidebarPeekClose = useCallback(() => {
-		if (sidebarPeekCloseTimerRef.current === undefined) return;
-		window.clearTimeout(sidebarPeekCloseTimerRef.current);
-		sidebarPeekCloseTimerRef.current = undefined;
-	}, []);
-
-	const previewSidebar = useCallback(() => {
-		if (isSidebarOpen) return;
-		cancelSidebarPeekClose();
-		setIsSidebarPeekOpen(true);
-	}, [cancelSidebarPeekClose, isSidebarOpen]);
-
-	const scheduleSidebarPeekClose = useCallback(() => {
-		if (isSidebarOpen) return;
-		cancelSidebarPeekClose();
-		sidebarPeekCloseTimerRef.current = window.setTimeout(() => {
-			setIsSidebarPeekOpen(false);
-			sidebarPeekCloseTimerRef.current = undefined;
-		}, 140);
-	}, [cancelSidebarPeekClose, isSidebarOpen]);
-
 	const navigateSession = useCallback(
 		(direction: -1 | 1) => {
 			if (!scopedProjectId) return;
@@ -539,47 +516,6 @@ function ShellLayout() {
 	}, [themePreference]);
 
 	useEffect(() => {
-		if (!isSidebarOpen) return;
-		cancelSidebarPeekClose();
-		setIsSidebarPeekOpen(false);
-	}, [cancelSidebarPeekClose, isSidebarOpen]);
-
-	useEffect(() => cancelSidebarPeekClose, [cancelSidebarPeekClose]);
-
-	useEffect(() => {
-		if (!isSidebarPeekOpen || isSidebarOpen) return;
-
-		const handlePointerMove = (event: PointerEvent) => {
-			const target = event.target instanceof Element ? event.target : null;
-			const isInSidebarPortal = Boolean(target?.closest('[role="dialog"], [role="listbox"], [role="menu"]'));
-			// TitlebarNav / WindowTitlebar sit above the peek in z-order; keep the
-			// preview open while the pointer is on those controls so hover→click
-			// to pin still works.
-			const isInTitlebarChrome = Boolean(
-				target?.closest("[data-slot='titlebar-nav'], .window-titlebar"),
-			);
-			const sidebar = document.querySelector<HTMLElement>('[data-slot="sidebar-container"]');
-			const bounds = sidebar?.getBoundingClientRect();
-			const isInSidebar = Boolean(
-				bounds &&
-				event.clientX >= bounds.left &&
-				event.clientX <= bounds.right &&
-				event.clientY >= bounds.top &&
-				event.clientY <= bounds.bottom,
-			);
-
-			if (isInSidebar || isInSidebarPortal || isInTitlebarChrome) {
-				cancelSidebarPeekClose();
-				return;
-			}
-			scheduleSidebarPeekClose();
-		};
-
-		window.addEventListener("pointermove", handlePointerMove);
-		return () => window.removeEventListener("pointermove", handlePointerMove);
-	}, [cancelSidebarPeekClose, isSidebarOpen, isSidebarPeekOpen, scheduleSidebarPeekClose]);
-
-	useEffect(() => {
 		if (daemonStatus.state !== "ready" || !daemonStatus.port) return;
 		if (agentCatalogPortRef.current === daemonStatus.port) return;
 
@@ -746,7 +682,7 @@ function ShellLayout() {
 				{/* Windows-only custom title bar (sidebar toggle + File/Edit/View/…
             menu); paints the chrome the frameless window drops. Renders null on
             macOS/Linux. */}
-				<WindowTitlebar onSidebarPreviewEnter={previewSidebar} />
+				<WindowTitlebar />
 				{/* App routes render their topbar inside the framed panel, matching the board chrome across platforms while leaving OS titlebars native. */}
 				{!framedAppTopbar && !hideShellTopbar && !routeParams.sessionId ? <ShellTopbar /> : null}
 				{/* Controlled by the ui-store so TitlebarNav / Topbar toggles (which
@@ -756,11 +692,9 @@ function ShellLayout() {
 					className="min-h-0 flex-1 flex-col overflow-x-hidden"
 					keyboardShortcut={false}
 					onOpenChange={(open) => {
-						cancelSidebarPeekClose();
-						setIsSidebarPeekOpen(false);
 						if (open !== isSidebarOpen) toggleSidebar();
 					}}
-					open={!isStartupLoading && (isSidebarOpen || isSidebarPeekOpen)}
+					open={!isStartupLoading && isSidebarOpen}
 					style={
 						{
 							"--sidebar-width": "var(--ao-sidebar-w, var(--size-sidebar-default))",
@@ -774,8 +708,6 @@ function ShellLayout() {
               below its custom titlebar. */}
 				<Sidebar
 					hideEdgeBorder={isWelcomeBoard}
-					isOverlay={isSidebarPeekOpen && !isSidebarOpen}
-					onPreviewLeave={scheduleSidebarPeekClose}
 					underTopbar={isMac || isWindows || isLinux}
 						topbarOffset={isWindows ? "titlebar" : hideShellTopbar ? "trafficLights" : "toolbar"}
 						onCloneProject={cloneProject}
@@ -846,7 +778,6 @@ function ShellLayout() {
 						hasSessionTopbar={Boolean(routeParams.sessionId)}
 						historyLocked={isWelcomeBoard}
 						isFullScreen={isFullScreen}
-						onSidebarPreviewEnter={previewSidebar}
 					/>
 				</SidebarProvider>
 				<OrchestratorReplacementDialog

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -193,7 +193,11 @@
 	--spacing-window-titlebar: var(--size-window-titlebar);
 	--spacing-titlebar-content-offset: var(--size-titlebar-content-offset);
 	--spacing-titlebar-cluster-left: var(--size-titlebar-cluster-left);
+	/* Linux has no traffic lights — the cluster sits at the sidebar's own inset,
+	 * and clears the framed panel border when the sidebar is off-canvas. */
 	--spacing-titlebar-cluster-left-linux: var(--size-titlebar-cluster-left-linux);
+	--spacing-titlebar-cluster-left-linux-panel: var(--size-titlebar-cluster-left-linux-panel);
+	--spacing-titlebar-content-offset-linux: var(--size-titlebar-content-offset-linux);
 	/* Fullscreen has no traffic lights — align the cluster to sidebar content. */
 	--spacing-titlebar-cluster-left-fullscreen: var(--space-2);
 	--spacing-traffic-light-clearance: var(--size-traffic-light-clearance);

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -154,14 +154,13 @@ vi.mock("../components/ShellTopbar", () => ({ ShellTopbar: () => null }));
 vi.mock("../components/TitlebarNav", async () => {
 	const { useUiStore: useStore } = await vi.importActual<typeof import("../stores/ui-store")>("../stores/ui-store");
 	return {
-		TitlebarNav: ({ onSidebarPreviewEnter }: { onSidebarPreviewEnter?: () => void }) => {
+		TitlebarNav: () => {
 			const isSidebarOpen = useStore((state) => state.isSidebarOpen);
 			const toggleSidebar = useStore((state) => state.toggleSidebar);
 			return (
 				<button
 					aria-label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
 					onClick={toggleSidebar}
-					onPointerEnter={onSidebarPreviewEnter}
 					type="button"
 				/>
 			);
@@ -200,10 +199,10 @@ vi.mock("../components/GlobalNewTaskDialog", async () => {
 vi.mock("../components/Sidebar", async () => {
 	const { useUiStore: useStore } = await vi.importActual<typeof import("../stores/ui-store")>("../stores/ui-store");
 	return {
-		Sidebar: ({ isOverlay, onPreviewLeave, topbarOffset }: { isOverlay?: boolean; onPreviewLeave?: () => void; topbarOffset?: string }) => {
+		Sidebar: ({ topbarOffset }: { topbarOffset?: string }) => {
 			const nonce = useStore((state) => state.createProjectNonce);
 			return (
-				<div data-overlay={isOverlay ? "true" : "false"} data-testid="sidebar" data-topbar-offset={topbarOffset} onPointerLeave={onPreviewLeave}>
+				<div data-testid="sidebar" data-topbar-offset={topbarOffset}>
 					{nonce > 0 ? <div data-testid="create-project-flow" /> : null}
 				</div>
 			);
@@ -409,38 +408,24 @@ describe("shell workspace startup", () => {
 	});
 });
 
-describe("shell sidebar hover preview", () => {
-	it("temporarily overlays a collapsed sidebar from the titlebar toggle and closes after pointer leave", async () => {
+describe("shell sidebar toggle", () => {
+	it("keeps a collapsed sidebar closed until the titlebar toggle is clicked", async () => {
 		useUiStore.setState({ isSidebarOpen: false });
 		await renderShell();
 
 		const provider = screen.getByTestId("sidebar-provider");
-		const sidebar = screen.getByTestId("sidebar");
-		const previewTrigger = screen.getByRole("button", { name: "Expand sidebar" });
-		expect(screen.queryByRole("button", { name: "Preview sidebar" })).not.toBeInTheDocument();
+		const toggle = screen.getByRole("button", { name: "Expand sidebar" });
 
 		expect(provider).toHaveAttribute("data-open", "false");
-		fireEvent.pointerEnter(previewTrigger);
-
-		expect(provider).toHaveAttribute("data-open", "true");
-		expect(sidebar).toHaveAttribute("data-overlay", "true");
+		// Hover no longer previews the sidebar — only the click pins it open.
+		fireEvent.pointerEnter(toggle);
+		expect(provider).toHaveAttribute("data-open", "false");
 		expect(useUiStore.getState().isSidebarOpen).toBe(false);
 
-		fireEvent.pointerMove(window, { clientX: 500, clientY: 300 });
-		await waitFor(() => expect(provider).toHaveAttribute("data-open", "false"));
-		expect(useUiStore.getState().isSidebarOpen).toBe(false);
-	});
-
-	it("pins the sidebar open when the titlebar toggle is clicked", async () => {
-		useUiStore.setState({ isSidebarOpen: false });
-		await renderShell();
-
-		const previewTrigger = screen.getByRole("button", { name: "Expand sidebar" });
-		fireEvent.pointerEnter(previewTrigger);
-		fireEvent.click(previewTrigger);
+		fireEvent.click(toggle);
 
 		expect(useUiStore.getState().isSidebarOpen).toBe(true);
-		expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "true");
+		expect(provider).toHaveAttribute("data-open", "true");
 		expect(screen.getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
 	});
 });

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -301,9 +301,13 @@
 	--size-sidebar-default: 240px;
 	--size-sidebar-mobile: 288px;
 	--size-titlebar-cluster-left: 72px;
-	/* Linux has no traffic lights: the cluster sits at the sidebar's own left
-	 * inset (TitlebarNav `left-titlebar-cluster-left-linux`). */
+	/* Linux has no traffic lights: with the sidebar open the cluster sits at the
+	 * sidebar's own left inset (TitlebarNav `left-titlebar-cluster-left-linux`). */
 	--size-titlebar-cluster-left-linux: 6px;
+	/* Sidebar off-canvas: the framed centre panel is flush-left, so the cluster
+	 * must clear its border (--size-center-panel-inline-inset) instead of
+	 * straddling it. */
+	--size-titlebar-cluster-left-linux-panel: calc(var(--size-center-panel-inline-inset) + 10px);
 	/* TitlebarNav cluster: 3 × --size-control-md buttons + 2 × 4px flex gaps. */
 	--size-titlebar-cluster-width: calc(3 * var(--size-control-md) + 2 * 4px);
 	/* Breathing room between the last arrow and the adjacent in-panel title. */
@@ -312,8 +316,10 @@
 	--size-titlebar-content-offset: calc(
 		var(--size-titlebar-cluster-left) + var(--size-titlebar-cluster-width) + var(--size-titlebar-content-gap)
 	);
+	/* Same clearance measured from the off-canvas Linux cluster inset. */
 	--size-titlebar-content-offset-linux: calc(
-		var(--size-titlebar-cluster-left-linux) + var(--size-titlebar-cluster-width) + var(--size-titlebar-content-gap)
+		var(--size-titlebar-cluster-left-linux-panel) + var(--size-titlebar-cluster-width) +
+			var(--size-titlebar-content-gap)
 	);
 
 	/* Keep macOS traffic-light chrome aligned with the shared route topbar. */


### PR DESCRIPTION
## Summary

- With the sidebar closed, the titlebar nav cluster sat right on top of the framed panel border. It now gets its own inset in that state (panel inset + 10px), and the content offset and clearance were re-measured to match. Sidebar open is unchanged.
- The kanban lane grid ran flush against the rounded surface, so dividers and cards touched the frame. Wrapped it in a padded container.
- Also carries a sidebar hover-preview removal that was already committed on this branch.
- Builds on #4141 — extends its Linux cluster tokens for the off-canvas case instead of replacing them.

# Before 

https://github.com/user-attachments/assets/4a70b9f8-bb51-45a5-af9c-9c9004c75c63


# After 
https://drive.google.com/file/d/1Su6GynXPpwm9yQsl40wZ7H7nh8QGI_9i/view?usp=sharing


## Test plan

- `tsc --noEmit` clean.
- `vitest run src/renderer/components/SessionsBoard.test.tsx` — 38 passed.
- `vitest run src/renderer/test/shell-new-session-shortcut.test.tsx` — 19 passed.
- Verified in the real Electron app on Linux (Hyprland/Wayland), both sidebar states: cluster clears the panel border when closed, stays sidebar-aligned when open; board grid no longer touches the frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
