### PR TITLE
fix(scm): allow claiming open draft pull requests

### DIFF
--- a/backend/internal/cli/session_test.go
+++ b/backend/internal/cli/session_test.go
@@ -645,6 +645,53 @@ func TestSessionClaimPR_JSONAndNoTakeoverError(t *testing.T) {
 	}
 }
 
+// TestSessionClaimPR_Draft covers #4171 from the CLI side: claiming a draft PR
+// succeeds and the draft state survives into `--json` output instead of the
+// daemon answering PR_NOT_OPEN.
+func TestSessionClaimPR_Draft(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions/demo-1":
+			_, _ = io.WriteString(w, `{"session":`+sessionJSON("demo-1", "demo", "worker", "working", false)+`}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/demo":
+			_, _ = io.WriteString(w, `{"status":"ok","project":{"id":"demo","name":"Demo","path":"/repo/demo","repo":"https://github.com/aoagents/agent-orchestrator","defaultBranch":"main"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/demo-1/pr/claim":
+			var req claimPRRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			_, _ = io.WriteString(w, `{"ok":true,"sessionId":"demo-1","prs":[{"url":`+jsonQuote(req.PR)+`,"number":4168,"state":"draft","ci":"pending","review":"none","mergeability":"unknown","reviewComments":false,"updatedAt":"2026-08-20T12:00:00Z"}],"branchChanged":false,"takenOverFrom":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "session", "claim-pr", "demo-1", "4168")
+	if err != nil {
+		t.Fatalf("claim-pr draft failed: %v stderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, "claimed PR #4168") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	out, errOut, err = executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "session", "claim-pr", "demo-1", "4168", "--json")
+	if err != nil {
+		t.Fatalf("claim-pr draft --json failed: %v stderr=%s", err, errOut)
+	}
+	var got claimPRResponse
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("bad json err=%v out=%s", err, out)
+	}
+	if len(got.PRs) != 1 || got.PRs[0].State != "draft" {
+		t.Fatalf("claim response = %#v, want a single draft PR", got.PRs)
+	}
+}
+
 func TestSessionClaimPR_GitLabMR(t *testing.T) {
 	cfg := setConfigEnv(t)
 	var capturedReq claimPRRequest

--- a/backend/internal/cli/spawn_test.go
+++ b/backend/internal/cli/spawn_test.go
@@ -112,6 +112,49 @@ func TestSpawnClaimPRWiring(t *testing.T) {
 	}
 }
 
+// TestSpawnClaimPR_Draft covers #4171: `ao spawn --claim-pr` on a draft PR must
+// keep the spawned session instead of rolling it back with PR_NOT_OPEN.
+func TestSpawnClaimPR_Draft(t *testing.T) {
+	cfg := setConfigEnv(t)
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appendPrimaryRequest(&requests, r)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/demo":
+			_, _ = io.WriteString(w, `{"status":"ok","project":{"id":"demo","name":"Demo","path":"/repo/demo","repo":"https://github.com/aoagents/agent-orchestrator","defaultBranch":"main"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/refresh":
+			_, _ = io.WriteString(w, authorizedAgentsJSON("codex"))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions":
+			_, _ = io.WriteString(w, `{"session":{"id":"demo-9","status":"idle"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/demo-9/pr/claim":
+			var req claimPRRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if req.PR != "https://github.com/aoagents/agent-orchestrator/pull/4168" {
+				t.Fatalf("claim request = %#v", req)
+			}
+			_, _ = io.WriteString(w, `{"ok":true,"sessionId":"demo-9","prs":[{"url":"https://github.com/aoagents/agent-orchestrator/pull/4168","number":4168,"state":"draft","ci":"pending","review":"none","mergeability":"unknown","reviewComments":false,"updatedAt":"2026-08-20T12:00:00Z"}],"branchChanged":false,"takenOverFrom":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "spawn", "--project", "demo", "--agent", "codex", "--name", "worker", "--claim-pr", "4168")
+	if err != nil {
+		t.Fatalf("spawn claim-pr draft failed: %v stderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, "claimed https://github.com/aoagents/agent-orchestrator/pull/4168") {
+		t.Fatalf("output missing claimed label: %s", out)
+	}
+	// No rollback: the draft claim succeeded.
+	want := []string{"GET /api/v1/projects/demo", "POST /api/v1/agents/refresh", "POST /api/v1/sessions", "POST /api/v1/sessions/demo-9/pr/claim"}
+	if !reflect.DeepEqual(requests, want) {
+		t.Fatalf("requests=%#v want %#v", requests, want)
+	}
+}
+
 func TestSpawnClaimPR_GitLab(t *testing.T) {
 	cfg := setConfigEnv(t)
 	var capturedReq claimPRRequest

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -20,7 +20,8 @@ var (
 	ErrInvalidPRRef = errors.New("session: invalid pr ref")
 	// ErrPRNotFound is returned when the SCM provider has no matching pull request.
 	ErrPRNotFound = errors.New("session: pr not found")
-	// ErrPRNotOpen is returned when a PR is draft, merged, or closed and therefore cannot be claimed.
+	// ErrPRNotOpen is returned when a PR is merged or closed and therefore cannot be claimed.
+	// Draft PRs are open work and remain claimable.
 	ErrPRNotOpen = errors.New("session: pr not open")
 	// ErrSCMUnavailable is returned when live SCM facts cannot be fetched.
 	ErrSCMUnavailable = errors.New("session: scm unavailable")
@@ -110,7 +111,10 @@ func (s *Service) ClaimPR(ctx context.Context, id domain.SessionID, ref string, 
 	if obs.PR.URL == "" {
 		obs.PR.URL = prURL
 	}
-	if obs.PR.Draft || obs.PR.Merged || obs.PR.Closed {
+	// Draft PRs are still open work: workers must be able to claim them without
+	// first marking the PR ready for review. Only terminal states are rejected;
+	// the draft fact itself is preserved on the persisted PR row below.
+	if obs.PR.Merged || obs.PR.Closed {
 		return ClaimPRResult{}, ErrPRNotOpen
 	}
 	reviewMode, err := s.enrichClaimReviews(ctx, refSpec, &obs)

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -2807,6 +2807,7 @@ func TestDelegateTaskPassesAttachmentsToSpawnConfig(t *testing.T) {
 type fakePRClaimer struct {
 	out        errorFreeClaimOutcome
 	err        error
+	gotPR      domain.PullRequest
 	gotMode    ports.ReviewWriteMode
 	gotThreads []domain.PullRequestReviewThread
 	called     bool
@@ -2816,7 +2817,8 @@ type errorFreeClaimOutcome struct {
 	ports.ClaimOutcome
 }
 
-func (f *fakePRClaimer) ClaimPR(_ context.Context, _ domain.PullRequest, _ []domain.PullRequestCheck, _ []domain.PullRequestReview, threads []domain.PullRequestReviewThread, _ []domain.PullRequestComment, mode ports.ReviewWriteMode, _ bool) (ports.ClaimOutcome, error) {
+func (f *fakePRClaimer) ClaimPR(_ context.Context, pr domain.PullRequest, _ []domain.PullRequestCheck, _ []domain.PullRequestReview, threads []domain.PullRequestReviewThread, _ []domain.PullRequestComment, mode ports.ReviewWriteMode, _ bool) (ports.ClaimOutcome, error) {
+	f.gotPR = pr
 	f.gotMode = mode
 	f.gotThreads = threads
 	f.called = true
@@ -2933,6 +2935,9 @@ func TestClaimPRMapsObserverAndStoreErrors(t *testing.T) {
 		{"missing scm", NewWithDeps(Deps{Store: st}), ErrSCMUnavailable},
 		{"not found", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{}, SCM: fakeSCM{fetchErr: ports.ErrSCMNotFound}}), ErrPRNotFound},
 		{"closed", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{}, SCM: fakeSCM{obs: ports.SCMObservation{Fetched: true, Provider: "github", Host: "github.com", Repo: "acme/repo", PR: ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7, Closed: true}}}}), ErrPRNotOpen},
+		{"merged", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{}, SCM: fakeSCM{obs: ports.SCMObservation{Fetched: true, Provider: "github", Host: "github.com", Repo: "acme/repo", PR: ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7, Merged: true}}}}), ErrPRNotOpen},
+		{"draft merged", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{}, SCM: fakeSCM{obs: ports.SCMObservation{Fetched: true, Provider: "github", Host: "github.com", Repo: "acme/repo", PR: ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7, Draft: true, Merged: true}}}}), ErrPRNotOpen},
+		{"draft closed", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{}, SCM: fakeSCM{obs: ports.SCMObservation{Fetched: true, Provider: "github", Host: "github.com", Repo: "acme/repo", PR: ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7, Draft: true, Closed: true}}}}), ErrPRNotOpen},
 		{"active owner", NewWithDeps(Deps{Store: st, PRClaimer: &fakePRClaimer{err: ports.PRClaimedByActiveSessionError{Owner: "mer-2"}}, SCM: fakeSCM{obs: ports.SCMObservation{Fetched: true, Provider: "github", Host: "github.com", Repo: "acme/repo", PR: ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7}}}}), ports.ErrPRClaimedByActiveSession},
 	}
 	for _, tc := range cases {
@@ -2952,6 +2957,45 @@ func TestClaimPRMapsObserverAndStoreErrors(t *testing.T) {
 	}
 	if len(res.TakenOverFrom) != 1 || res.TakenOverFrom[0] != "mer-2" || len(res.PRs) != 1 || res.PRs[0].URL == "" {
 		t.Fatalf("claim result = %+v", res)
+	}
+}
+
+// TestClaimPRAllowsDraftPR pins the fix for #4171: a draft PR is open work and
+// must be claimable, with the draft fact carried onto the persisted PR row and
+// the returned read model rather than being rejected as PR_NOT_OPEN.
+func TestClaimPRAllowsDraftPR(t *testing.T) {
+	st := newFakeStore()
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, Metadata: domain.SessionMetadata{WorkspacePath: "/ws"}}
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", RepoOriginURL: "https://github.com/acme/repo"}
+	// Stands in for the row the claimer would have written.
+	st.pr["mer-1"] = domain.PRFacts{URL: "https://github.com/acme/repo/pull/7", Number: 7, Draft: true, CI: domain.CIPending, UpdatedAt: now}
+
+	claimer := &fakePRClaimer{out: errorFreeClaimOutcome{ports.ClaimOutcome{}}}
+	svc := NewWithDeps(Deps{
+		Store:     st,
+		PRClaimer: claimer,
+		SCM: fakeSCM{obs: ports.SCMObservation{
+			Fetched:  true,
+			Provider: "github",
+			Host:     "github.com",
+			Repo:     "acme/repo",
+			PR:       ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7, Draft: true},
+		}},
+	})
+
+	res, err := svc.ClaimPR(context.Background(), "mer-1", "7", ClaimPROptions{})
+	if err != nil {
+		t.Fatalf("claim draft PR: %v", err)
+	}
+	if !claimer.called {
+		t.Fatal("ClaimPR was not called for a draft PR")
+	}
+	if !claimer.gotPR.Draft || claimer.gotPR.Merged || claimer.gotPR.Closed {
+		t.Fatalf("persisted PR = %+v, want draft preserved and not merged/closed", claimer.gotPR)
+	}
+	if len(res.PRs) != 1 || res.PRs[0].URL != "https://github.com/acme/repo/pull/7" || !res.PRs[0].Draft {
+		t.Fatalf("claim result = %+v, want the draft PR", res.PRs)
 	}
 }
 


### PR DESCRIPTION
Fixes #4171

## Summary
`ao spawn --claim-pr` and `ao session claim-pr` rejected draft PRs with `PR_NOT_OPEN`, so a worker could not be attached to a PR until it was marked ready for review. The claim guard in `backend/internal/service/session/claim_pr.go` was stricter than the rest of the system — the SCM/domain model already preserves draft state and the status pipeline (`pr_summary.go`, `prState`) treats draft as a valid open-PR state.

The guard now rejects only terminal states:

```go
if obs.PR.Merged || obs.PR.Closed {
    return ClaimPRResult{}, ErrPRNotOpen
}
```

Draft facts are preserved end to end — `claimRowsFromSCM` already sets `Draft: obs.PR.Draft` on the persisted PR row and `pullRequestFacts` carries it into the read model, so the API/CLI still report `state: "draft"` after a successful claim. The `ErrPRNotOpen` doc comment was updated to match.

## Tests
- `TestClaimPRAllowsDraftPR` (new, service): claiming a draft PR succeeds, the persisted PR row keeps `Draft: true` and is not merged/closed, and the returned read model reports the draft PR. Verified this test fails against the old guard with `session: pr not open`.
- `TestClaimPRMapsObserverAndStoreErrors` (extended): retains the `closed` rejection case and adds `merged`, `draft merged`, and `draft closed` — draft alone no longer blocks a claim, but draft + terminal still does.
- `TestSessionClaimPR_Draft` (new, CLI): `ao session claim-pr` on a draft PR succeeds and `--json` output preserves `"state":"draft"`.
- `TestSpawnClaimPR_Draft` (new, CLI): `ao spawn --claim-pr` on a draft PR keeps the spawned session — no rollback request is issued.

Test results:
- `go build ./...` — clean.
- `go test ./...` (backend) — all packages pass.
- Note: running the suite from inside a live AO worker session leaks `AO_SESSION_ID`/`AO_PROJECT_ID`/`AO_RUNTIME_LAUNCH_ID` into `internal/cli` and `internal/httpd` tests, which causes pre-existing, unrelated failures. With those variables cleared the full suite is green.

## Risks / follow-ups
- Low risk: one guard condition narrowed; merged/closed rejection is unchanged and still covered.
- Not addressed here: the generic `PR_NOT_OPEN` message remains generic, but it now only fires for merged/closed PRs, which the message describes accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxMQTfCjcvwNjhWVjfD2sh