### PR TITLE
fix(ci): make gitleaks scans incremental

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -16,19 +16,34 @@ jobs:
         with:
           fetch-depth: 0
 
-      # gitleaks-action v1 scans the symmetric base...HEAD range, which also
-      # includes new base-branch commits when a queued PR merge ref is stale.
-      # Rewind only the runner's tracking ref to the merge-base so the action
-      # scans the proposed PR commits and not unrelated commits from main.
-      - name: Restrict pull request scan to proposed commits
-        if: github.event_name == 'pull_request'
+      # The legacy v1 action scans both sides of base...HEAD for PRs and every
+      # fetched ref for pushes. Build the range here so each run checks only the
+      # commits introduced by that PR or push.
+      - name: Select commits to scan
         shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          base_ref="refs/remotes/origin/${GITHUB_BASE_REF}"
-          merge_base="$(git merge-base HEAD "${base_ref}")"
-          git update-ref "${base_ref}" "${merge_base}"
+          commits_file=".git/gitleaks-commits.txt"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            git rev-list --right-only --cherry-pick \
+              "refs/remotes/origin/${GITHUB_BASE_REF}...HEAD" > "${commits_file}"
+          elif [[ -n "${BEFORE_SHA}" && ! "${BEFORE_SHA}" =~ ^0+$ ]] && \
+            git cat-file -e "${BEFORE_SHA}^{commit}"; then
+            git rev-list "${BEFORE_SHA}..${GITHUB_SHA}" > "${commits_file}"
+          else
+            printf '%s\n' "${GITHUB_SHA}" > "${commits_file}"
+          fi
+          echo "Scanning $(wc -l < "${commits_file}") commit(s)"
 
-      # gitleaks-action v1 scans for committed secrets and needs no license
-      # key (v2 requires GITLEAKS_LICENSE for organization repos).
-      - name: Scan for secrets
-        uses: zricethezav/gitleaks-action@v1.6.0
+      # Run the same license-free gitleaks v7.4 image used by the old v1 action,
+      # pinned to the digest observed in that action's Dockerfile build.
+      - name: Scan selected commits for secrets
+        uses: docker://zricethezav/gitleaks:v7.4.0@sha256:ffe35a0d42974c19da37b3fb5ca1ff1e781ae6dffaf80164568129a2714eca61
+        with:
+          args: >-
+            --path=/github/workspace
+            --verbose
+            --redact
+            --commits-file=/github/workspace/.git/gitleaks-commits.txt
+            --config-path=/github/workspace/.github/.gitleaks.toml

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -16,6 +16,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # gitleaks-action v1 scans the symmetric base...HEAD range, which also
+      # includes new base-branch commits when a queued PR merge ref is stale.
+      # Rewind only the runner's tracking ref to the merge-base so the action
+      # scans the proposed PR commits and not unrelated commits from main.
+      - name: Restrict pull request scan to proposed commits
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          base_ref="refs/remotes/origin/${GITHUB_BASE_REF}"
+          merge_base="$(git merge-base HEAD "${base_ref}")"
+          git update-ref "${base_ref}" "${merge_base}"
+
       # gitleaks-action v1 scans for committed secrets and needs no license
       # key (v2 requires GITLEAKS_LICENSE for organization repos).
       - name: Scan for secrets


### PR DESCRIPTION
## What

Replace the legacy gitleaks v1 wrapper with its same license-free, pinned gitleaks v7.4 container and an explicit commit list:

- pull requests scan only commits introduced by the PR;
- pushes to `main` scan only commits introduced by that push (`before..after`).

The repository's existing `.gitleaks.toml` rules and redacted output remain unchanged.

## Why

The legacy wrapper does two repository-wide things that make unrelated history break current work:

1. On pull requests it scans both sides of `base...HEAD`, so newer base-only commits can fail a queued or stale PR.
2. On every push to `main` it scans every fetched ref. Recent runs scanned roughly 8,100 commits, took about 6.5 minutes, and repeatedly failed on an old placeholder RSA header in commit `56f64bd` rather than the newly merged change.

That makes every subsequent merge inherit the same historical failure. Incremental ranges preserve secret detection for all new code without repeatedly rescanning unrelated history.

## Testing

- Reproduced the current gitleaks v7.4 failure directly against historical commit `56f64bd`.
- Replayed the previous `main` push range (`5240327..63b5ffb`): one new commit selected, no leaks found in 16 ms.
- Replayed a stale PR range: base-only commits excluded and all PR-side commits retained.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/gitleaks.yml`
- The PR's own gitleaks workflow runs the new container path.
