### PR TITLE
feat(observability): Sentry-ready error capture + triage classification (mobile)

### DIFF
--- a/packages/mobile/lib/TelemetryManager.tsx
+++ b/packages/mobile/lib/TelemetryManager.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { AppState, type AppStateStatus } from "react-native";
+import { initMobileSentry } from "./sentry";
 import { initMobileTelemetry, mobileTelemetry, telemetryActiveStorage } from "./telemetry/runtime";
 
 // Headless. Mounted once in the app shell beside PushManager. Initialises the
@@ -10,6 +11,9 @@ export function TelemetryManager() {
 	useEffect(() => {
 		initMobileTelemetry();
 		void mobileTelemetry()?.active(telemetryActiveStorage);
+		// Same consent gate as telemetry (only when the client is active). No-op
+		// unless EXPO_PUBLIC_SENTRY_DSN is set.
+		if (mobileTelemetry()) void initMobileSentry();
 
 		const onChange = (state: AppStateStatus) => {
 			if (state === "active") void mobileTelemetry()?.active(telemetryActiveStorage);

--- a/packages/mobile/lib/TelemetryManager.tsx
+++ b/packages/mobile/lib/TelemetryManager.tsx
@@ -1,7 +1,14 @@
+import Constants from "expo-constants";
 import { useEffect } from "react";
 import { AppState, type AppStateStatus } from "react-native";
-import { initMobileSentry } from "./sentry";
+import { captureMobileException, initMobileSentry } from "./sentry";
 import { initMobileTelemetry, mobileTelemetry, telemetryActiveStorage } from "./telemetry/runtime";
+
+// RN's global JS error hook. Typed locally so we don't depend on RN internals.
+type ErrorUtilsLike = {
+	getGlobalHandler?: () => ((error: unknown, isFatal?: boolean) => void) | undefined;
+	setGlobalHandler?: (handler: (error: unknown, isFatal?: boolean) => void) => void;
+};
 
 // Headless. Mounted once in the app shell beside PushManager. Initialises the
 // PostHog client and emits the daily-active heartbeat on launch and on each
@@ -13,7 +20,16 @@ export function TelemetryManager() {
 		void mobileTelemetry()?.active(telemetryActiveStorage);
 		// Same consent gate as telemetry (only when the client is active). No-op
 		// unless EXPO_PUBLIC_SENTRY_DSN is set.
-		if (mobileTelemetry()) void initMobileSentry();
+		if (mobileTelemetry()) {
+			void initMobileSentry({ release: Constants.expoConfig?.version ?? undefined });
+			// Forward uncaught JS errors, preserving RN's own handler.
+			const errorUtils = (globalThis as unknown as { ErrorUtils?: ErrorUtilsLike }).ErrorUtils;
+			const prev = errorUtils?.getGlobalHandler?.();
+			errorUtils?.setGlobalHandler?.((error, isFatal) => {
+				captureMobileException(error, { category: "native_crash", unhandled: true });
+				prev?.(error, isFatal);
+			});
+		}
 
 		const onChange = (state: AppStateStatus) => {
 			if (state === "active") void mobileTelemetry()?.active(telemetryActiveStorage);

--- a/packages/mobile/lib/api.ts
+++ b/packages/mobile/lib/api.ts
@@ -1,5 +1,6 @@
 import { authHeaders, httpBase, normalizeServerHost, type ServerConfig } from "./config";
 import { cachedInstallId, getInstallId } from "./installId";
+import { captureMobileApiError, httpCategory } from "./sentry";
 import type { AttentionLevel } from "./theme";
 
 // ---- Types (subset of AO's DashboardSession we use on the phone) ------------
@@ -296,8 +297,12 @@ async function req(cfg: ServerConfig, path: string, init?: RequestInit, timeoutM
 		});
 	} catch (e) {
 		if ((e as { name?: string })?.name === "AbortError") {
+			// Timed out reaching the host (commonly a sleeping Tailscale peer).
+			captureMobileApiError(path, "timeout");
 			throw new Error("Request timed out - is the server reachable?", { cause: e });
 		}
+		// fetch threw without reaching the server: DNS/refused/offline.
+		captureMobileApiError(path, "offline");
 		throw e;
 	} finally {
 		clearTimeout(timer);
@@ -315,6 +320,8 @@ async function req(cfg: ServerConfig, path: string, init?: RequestInit, timeoutM
 		} catch {
 			/* ignore */
 		}
+		// Server answered with an error: classify by status + daemon code.
+		captureMobileApiError(path, httpCategory(res.status), res.status, code);
 		throw new ApiError(
 			res.status,
 			`${res.status} ${res.statusText}${detail ? ` - ${detail}` : ""}`,

--- a/packages/mobile/lib/api.ts
+++ b/packages/mobile/lib/api.ts
@@ -320,8 +320,9 @@ async function req(cfg: ServerConfig, path: string, init?: RequestInit, timeoutM
 		} catch {
 			/* ignore */
 		}
-		// Server answered with an error: classify by status + daemon code.
-		captureMobileApiError(path, httpCategory(res.status), res.status, code);
+		// Server answered with an error: classify by status + daemon code, and tag
+		// the requestId so a mobile event pivots to the daemon's own capture.
+		captureMobileApiError(path, httpCategory(res.status), res.status, code, requestId);
 		throw new ApiError(
 			res.status,
 			`${res.status} ${res.statusText}${detail ? ` - ${detail}` : ""}`,

--- a/packages/mobile/lib/observability.test.ts
+++ b/packages/mobile/lib/observability.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyError } from "./observability";
+
+describe("classifyError — severity + owner", () => {
+	it("crashes are P0/ours and reported", () => {
+		for (const category of ["native_crash", "render_crash"]) {
+			const t = classifyError({ category });
+			expect(t.severity).toBe("P0");
+			expect(t.owner).toBe("ours");
+			expect(t.level).toBe("fatal");
+			expect(t.report).toBe(true);
+		}
+	});
+
+	it("server 5xx and agent-runtime failures are P1/ours", () => {
+		expect(classifyError({ category: "http_5xx" })).toMatchObject({ severity: "P1", owner: "ours", report: true });
+		expect(classifyError({ category: "agent_runtime" })).toMatchObject({ severity: "P1", owner: "ours" });
+	});
+
+	it("daemon unavailable is P1 but environment (usually not running)", () => {
+		expect(classifyError({ category: "daemon_unavailable" })).toMatchObject({ severity: "P1", owner: "environment" });
+	});
+
+	it("transient connectivity is a breadcrumb, not an issue", () => {
+		for (const category of ["offline", "network_error", "timeout"]) {
+			const t = classifyError({ category });
+			expect(t.transient).toBe(true);
+			expect(t.report).toBe(false);
+		}
+	});
+
+	it("validation / 4xx / not_found ride as P3 breadcrumbs", () => {
+		expect(classifyError({ category: "validation" })).toMatchObject({ severity: "P3", owner: "user", report: false });
+		expect(classifyError({ category: "http_4xx" })).toMatchObject({ severity: "P3", report: false });
+		expect(classifyError({ category: "not_found" })).toMatchObject({ severity: "P3", report: false });
+	});
+});
+
+describe("classifyError — code overrides", () => {
+	it("agent binary / prereq missing is P1 but the user's setup", () => {
+		expect(classifyError({ category: "agent_runtime", code: "AGENT_BINARY_NOT_FOUND" })).toMatchObject({
+			severity: "P1",
+			owner: "user",
+		});
+		expect(classifyError({ category: "validation", code: "RUNTIME_PREREQUISITE_MISSING" })).toMatchObject({
+			severity: "P1",
+			owner: "user",
+		});
+	});
+
+	it("worktree lock/contention is P1/ours (the multi-session case)", () => {
+		expect(classifyError({ category: "conflict", code: "WORKSPACE_LOCKED" })).toMatchObject({
+			severity: "P1",
+			owner: "ours",
+			report: true,
+		});
+	});
+
+	it("wrong pairing password is the user, not external", () => {
+		expect(classifyError({ category: "auth", code: "BAD_PASSWORD" })).toMatchObject({ owner: "user" });
+		expect(classifyError({ category: "auth" })).toMatchObject({ owner: "external" }); // default without code
+	});
+
+	it("SCM/PR operation failures are external", () => {
+		expect(classifyError({ category: "http_5xx", code: "SCM_UNAVAILABLE" })).toMatchObject({ owner: "external", severity: "P1" });
+		expect(classifyError({ category: "http_5xx", code: "PR_OPERATION_FAILED" })).toMatchObject({ owner: "external" });
+	});
+
+	it("not-a-git-repo is the user's setup", () => {
+		expect(classifyError({ category: "validation", code: "NOT_A_GIT_REPO" })).toMatchObject({ owner: "user", severity: "P2" });
+	});
+});
+
+describe("classifyError — escalation rules & fallbacks", () => {
+	it("an unhandled error is never below P1", () => {
+		expect(classifyError({ category: "validation", unhandled: true }).severity).toBe("P1");
+		expect(classifyError({ unhandled: true }).severity).toBe("P1");
+	});
+
+	it("a 5xx status floors severity at P1", () => {
+		expect(classifyError({ category: "integration", httpStatus: 500 }).severity).toBe("P1");
+	});
+
+	it("falls back to apierr kind, then to a safe P2/ours default", () => {
+		expect(classifyError({ kind: "invalid" })).toMatchObject({ severity: "P3", owner: "user" });
+		expect(classifyError({ kind: "internal" })).toMatchObject({ severity: "P1", owner: "ours" });
+		expect(classifyError({})).toMatchObject({ severity: "P2", owner: "ours", report: true }); // nothing known -> visible, ours
+	});
+
+	it("code override beats category", () => {
+		// category says P3/user, code says P1/ours
+		expect(classifyError({ category: "validation", code: "INTERNAL_ERROR" })).toMatchObject({
+			severity: "P1",
+			owner: "ours",
+		});
+	});
+});

--- a/packages/mobile/lib/observability.test.ts
+++ b/packages/mobile/lib/observability.test.ts
@@ -30,6 +30,26 @@ describe("classifyError — severity + owner", () => {
 		}
 	});
 
+	it("daemon 503 backpressure is a breadcrumb, not a paged issue", () => {
+		for (const meta of [
+			{ code: "SERVICE_UNAVAILABLE", httpStatus: 503 },
+			{ category: "http_5xx", code: "SERVICE_UNAVAILABLE", httpStatus: 503 },
+			{ category: "http_5xx", httpStatus: 503 },
+		]) {
+			const t = classifyError(meta);
+			expect(t.transient).toBe(true);
+			expect(t.report).toBe(false);
+			expect(t.severity).toBe("P2");
+		}
+	});
+
+	it("a genuinely unreachable daemon (503 synthetic) still pages as P1", () => {
+		const t = classifyError({ category: "daemon_unavailable", httpStatus: 503 });
+		expect(t.severity).toBe("P1");
+		expect(t.owner).toBe("environment");
+		expect(t.report).toBe(true);
+	});
+
 	it("validation / 4xx / not_found ride as P3 breadcrumbs", () => {
 		expect(classifyError({ category: "validation" })).toMatchObject({ severity: "P3", owner: "user", report: false });
 		expect(classifyError({ category: "http_4xx" })).toMatchObject({ severity: "P3", report: false });

--- a/packages/mobile/lib/observability.ts
+++ b/packages/mobile/lib/observability.ts
@@ -122,13 +122,27 @@ export function classifyError(input: ClassifyInput): Triage {
 	// Code override wins where present.
 	if (code && CODE[code]) base = { ...base, ...CODE[code] };
 
+	// A daemon 503 is deliberate backpressure, not a fault: the daemon returns a
+	// typed SERVICE_UNAVAILABLE for retryable contention (#4325/#4334) and skips it
+	// in its own Sentry capture. Mirror that here so it rides as a breadcrumb and
+	// never becomes a paged issue — otherwise every contention spike, the exact
+	// thing 503 exists to absorb, would flood Sentry. Scoped to the daemon's own
+	// backpressure signal; the synthetic `daemon_unavailable` category (couldn't
+	// reach the daemon at all) is distinct and keeps its own P1 routing.
+	const unavailable =
+		code === "SERVICE_UNAVAILABLE" || (input.httpStatus === 503 && category !== "daemon_unavailable");
+
 	// An unhandled crash is always at least P1 (the app hit something it didn't expect).
 	let severity = base.severity;
 	if (input.unhandled && (severity === "P2" || severity === "P3")) severity = "P1";
-	// A 5xx status is never below P1 even if the category was coarse.
-	if (input.httpStatus && input.httpStatus >= 500 && severity === "P2") severity = "P1";
+	// A 5xx status is never below P1 even if the category was coarse — but 503 is
+	// backpressure, handled above, so it is excluded from the escalation.
+	if (input.httpStatus && input.httpStatus >= 500 && input.httpStatus !== 503 && severity === "P2")
+		severity = "P1";
+	// Cap backpressure at P2 so it can be suppressed as a breadcrumb below.
+	if (unavailable) severity = "P2";
 
-	const transient = category ? TRANSIENT.has(category) : false;
+	const transient = (category ? TRANSIENT.has(category) : false) || unavailable;
 	// Report as an issue for P0/P1 always; for P2 unless it's transient; never for P3.
 	const report = severity === "P0" || severity === "P1" || (severity === "P2" && !transient);
 

--- a/packages/mobile/lib/observability.ts
+++ b/packages/mobile/lib/observability.ts
@@ -1,0 +1,136 @@
+// Error triage classification, shared across renderer, main, and (later) the
+// daemon bridge. Pure and dependency-free so it is trivially unit-testable and
+// identical everywhere.
+//
+// It answers the two questions a person watching Sentry actually has:
+//   severity — how bad is it?      (drives alerting + priority)
+//   owner    — whose problem is it? (drives routing)
+// on top of the technical `category`/`code` we already produce. It is additive:
+// an unforeseen error still classifies via its category (or the safe default),
+// so new failures never go unlabelled.
+
+/** How bad, worst to least. P0 pages, P3 is a breadcrumb. */
+export type Severity = "P0" | "P1" | "P2" | "P3";
+
+/** Where a fix (if any) belongs. */
+export type FaultOwner = "ours" | "user" | "external" | "environment";
+
+/** Sentry event level per severity. */
+export type SentryLevel = "fatal" | "error" | "warning" | "info";
+
+export type Triage = {
+	severity: Severity;
+	owner: FaultOwner;
+	level: SentryLevel;
+	/** Transient connectivity-ish failures that self-recover; kept as breadcrumbs. */
+	transient: boolean;
+	/** Whether to send as an issue (true) or only record as a breadcrumb (false). */
+	report: boolean;
+};
+
+export type ClassifyInput = {
+	/** Transport/type category, e.g. from api-client.ts or a boundary. */
+	category?: string;
+	/** Exact daemon error code, e.g. WORKSPACE_LOCKED, PR_NOT_MERGEABLE. */
+	code?: string;
+	/** HTTP status when known. */
+	httpStatus?: number;
+	/** apierr.Kind name if surfaced (invalid/not_found/conflict/forbidden/internal). */
+	kind?: string;
+	/** True for window.onerror / unhandledrejection / native crashes. */
+	unhandled?: boolean;
+};
+
+const LEVEL: Record<Severity, SentryLevel> = { P0: "fatal", P1: "error", P2: "warning", P3: "info" };
+
+// Categories that are connectivity/environment blips: real, but they self-recover
+// and would drown the signal, so they ride as breadcrumbs unless they spike
+// (spike detection is a server-side alert rule, not a client decision).
+const TRANSIENT = new Set(["offline", "network_error", "timeout"]);
+
+type Base = { severity: Severity; owner: FaultOwner };
+
+// Default triage per technical category. The safe fallback for anything unknown
+// is P2/ours — visible, and pointed at us to investigate, never silently dropped.
+const CATEGORY: Record<string, Base> = {
+	native_crash: { severity: "P0", owner: "ours" },
+	render_crash: { severity: "P0", owner: "ours" },
+	daemon_unavailable: { severity: "P1", owner: "environment" },
+	http_5xx: { severity: "P1", owner: "ours" },
+	agent_runtime: { severity: "P1", owner: "ours" },
+	update: { severity: "P1", owner: "ours" },
+	integration: { severity: "P2", owner: "external" },
+	rate_limited: { severity: "P2", owner: "external" },
+	auth: { severity: "P2", owner: "external" },
+	conflict: { severity: "P2", owner: "ours" },
+	timeout: { severity: "P2", owner: "environment" },
+	network_error: { severity: "P2", owner: "environment" },
+	version_skew: { severity: "P2", owner: "ours" },
+	push: { severity: "P3", owner: "environment" },
+	http_4xx: { severity: "P3", owner: "user" },
+	not_found: { severity: "P3", owner: "ours" },
+	validation: { severity: "P3", owner: "user" },
+	permission: { severity: "P3", owner: "environment" },
+	offline: { severity: "P3", owner: "environment" },
+};
+
+// Code-specific overrides where the category alone gets owner/severity wrong.
+// e.g. an `auth` failure is `external` by default (a GitHub token), but a wrong
+// pairing password is squarely the user.
+const CODE: Record<string, Partial<Base>> = {
+	// spawn / runtime setup — blocks the user, and it's their environment to fix
+	AGENT_BINARY_NOT_FOUND: { severity: "P1", owner: "user" },
+	RUNTIME_PREREQUISITE_MISSING: { severity: "P1", owner: "user" },
+	// spawn / worktree contention and drift — our state machine
+	WORKSPACE_LOCKED: { severity: "P1", owner: "ours" },
+	BRANCH_CHECKED_OUT_ELSEWHERE: { severity: "P1", owner: "ours" },
+	WORKSPACE_CWD_MISMATCH: { severity: "P1", owner: "ours" },
+	// git / project setup — user
+	NOT_A_GIT_REPO: { severity: "P2", owner: "user" },
+	BRANCH_NOT_FETCHED: { severity: "P2", owner: "user" },
+	INVALID_BRANCH: { severity: "P2", owner: "user" },
+	PROJECT_NOT_RESOLVABLE: { severity: "P2", owner: "user" },
+	// pairing auth — user
+	BAD_PASSWORD: { severity: "P2", owner: "user" },
+	LOCKED_OUT: { severity: "P2", owner: "user" },
+	// external SCM
+	SCM_UNAVAILABLE: { severity: "P1", owner: "external" },
+	PR_OPERATION_FAILED: { severity: "P2", owner: "external" },
+	REVIEW_OPERATION_FAILED: { severity: "P2", owner: "external" },
+	// unmapped/internal server error — ours, high
+	INTERNAL_ERROR: { severity: "P1", owner: "ours" },
+};
+
+// apierr.Kind is a coarse safety net when no category/code override applies.
+const KIND: Record<string, Base> = {
+	internal: { severity: "P1", owner: "ours" },
+	conflict: { severity: "P2", owner: "ours" },
+	forbidden: { severity: "P2", owner: "external" },
+	not_found: { severity: "P3", owner: "ours" },
+	invalid: { severity: "P3", owner: "user" },
+};
+
+/** Classify a raw error into severity + owner + reporting policy. */
+export function classifyError(input: ClassifyInput): Triage {
+	const category = input.category?.trim();
+	const code = input.code?.trim();
+
+	// Base from category, then kind, then the safe default.
+	let base: Base =
+		(category && CATEGORY[category]) || (input.kind && KIND[input.kind]) || { severity: "P2", owner: "ours" };
+
+	// Code override wins where present.
+	if (code && CODE[code]) base = { ...base, ...CODE[code] };
+
+	// An unhandled crash is always at least P1 (the app hit something it didn't expect).
+	let severity = base.severity;
+	if (input.unhandled && (severity === "P2" || severity === "P3")) severity = "P1";
+	// A 5xx status is never below P1 even if the category was coarse.
+	if (input.httpStatus && input.httpStatus >= 500 && severity === "P2") severity = "P1";
+
+	const transient = category ? TRANSIENT.has(category) : false;
+	// Report as an issue for P0/P1 always; for P2 unless it's transient; never for P3.
+	const report = severity === "P0" || severity === "P1" || (severity === "P2" && !transient);
+
+	return { severity, owner: base.owner, level: LEVEL[severity], transient, report };
+}

--- a/packages/mobile/lib/sentry.ts
+++ b/packages/mobile/lib/sentry.ts
@@ -49,8 +49,12 @@ export async function initMobileSentry(context: MobileObservabilityContext = {})
 	if (!d) return;
 	initStarted = true;
 	try {
+		// Dormant placeholder: Metro only bundles a dynamic import() with a static
+		// string literal, so this computed specifier is intentionally NOT bundled
+		// today (keeps the package dependency-free). SHIP STEP: install the SDK and
+		// replace this line with `const mod = await import("@sentry/react-native")`.
 		const spec = ["@sentry", "react-native"].join("/");
-		const mod = (await import(/* @vite-ignore */ spec)) as unknown as SentryLike;
+		const mod = (await import(spec)) as unknown as SentryLike;
 		mod.init({
 			dsn: d,
 			release: context.release,
@@ -75,9 +79,20 @@ function tagsFor(meta: CaptureMeta, triage: Triage) {
 		category: meta.category,
 		code: meta.code,
 		http_status: meta.httpStatus,
+		apierr_kind: meta.kind,
 		severity: triage.severity,
 		owner: triage.owner,
 	};
+}
+
+// Collapse id-like path segments to :id so the operation is a low-cardinality
+// route template, never a per-request value (no session ids in tags, no tag
+// cardinality blow-up). Mirrors the renderer's normalizeApiOperation.
+function normalizePath(path: string): string {
+	return path
+		.split("/")
+		.map((seg) => (/^[0-9]+$/.test(seg) || /^[0-9a-fA-F-]{6,}$/.test(seg) ? ":id" : seg))
+		.join("/");
 }
 
 export function captureMobileException(error: unknown, meta: CaptureMeta = {}): void {
@@ -91,10 +106,11 @@ export function captureMobileException(error: unknown, meta: CaptureMeta = {}): 
 /** Capture a classified API failure from the mobile request helper. */
 export function captureMobileApiError(path: string, category: string, status?: number, code?: string): void {
 	if (!sentry) return;
+	const template = normalizePath(path.split("?")[0]);
 	// domain = first meaningful path segment (…/api/v1/<domain>/…)
-	const parts = path.split("?")[0].split("/").filter(Boolean);
+	const parts = template.split("/").filter(Boolean);
 	const domain = parts.includes("v1") ? parts[parts.indexOf("v1") + 1] : parts[0];
-	const meta: CaptureMeta = { operation: path.split("?")[0], domain, category, httpStatus: status, code };
+	const meta: CaptureMeta = { operation: template, domain, category, httpStatus: status, code };
 	const triage = classifyError(meta);
 	const tags = tagsFor(meta, triage);
 	if (triage.report) sentry.captureMessage(`${meta.operation} failed: ${category}${status ? ` (${status})` : ""}`, { level: triage.level, tags });

--- a/packages/mobile/lib/sentry.ts
+++ b/packages/mobile/lib/sentry.ts
@@ -2,8 +2,20 @@
 // so both classify errors identically. No-op until BOTH hold:
 //   1. a DSN is configured via EXPO_PUBLIC_SENTRY_DSN, and
 //   2. the @sentry/react-native SDK is installed.
-// Ship-time steps (no code change): `npx expo install @sentry/react-native`,
-// set EXPO_PUBLIC_SENTRY_DSN, and add source-map upload for OTA builds.
+//
+// The SDK is intentionally NOT added to package.json yet: @sentry/react-native
+// is a native module, so installing it correctly means `npx expo install
+// @sentry/react-native` (to pick the SDK-54-compatible version) plus a prebuild
+// cycle to regenerate the committed native projects, and the config plugin for
+// source maps. Adding it without that would leave the committed ios/ prebuild
+// inconsistent. Ship steps, in order:
+//   1. `npx expo install @sentry/react-native`  (do not hand-pin the version)
+//   2. add the @sentry/react-native Expo config plugin, then `npx expo prebuild`
+//   3. wire EAS build-time source-map upload (there is no OTA: no expo-updates,
+//      so maps are keyed by release + dist at EAS build time, not at OTA push)
+//   4. set EXPO_PUBLIC_SENTRY_DSN and update the store Data-Safety / App-Privacy
+//      declarations (a second processor gates the mobile release)
+// Until then this file compiles and runs as a no-op with no native dependency.
 
 import { classifyError, type ClassifyInput, type Triage } from "./observability";
 
@@ -38,8 +50,28 @@ function scrubEvent(event: Record<string, unknown>): Record<string, unknown> {
 	return event;
 }
 
-export type MobileObservabilityContext = { release?: string; distinctId?: string };
+export type MobileObservabilityContext = { release?: string; distinctId?: string; daemonVersion?: string };
 let ctx: MobileObservabilityContext = {};
+
+// A nightly/edge/pr release is not stable; keep those out of stable release
+// health. release on mobile is version@build.
+function channelOf(release: string): string {
+	const v = release.toLowerCase();
+	if (v.includes("nightly")) return "nightly";
+	if (v.includes("edge") || v.includes("pr")) return "development";
+	return "stable";
+}
+
+/**
+ * The mobile app talks to the user's own daemon over Tailscale, which can be
+ * older than the app. A mobile issue is uninterpretable without knowing which
+ * daemon produced the failure, so it rides every event as a tag. Set it once
+ * the paired daemon's version is known (desktop bundles its daemon, so this is
+ * mobile-only).
+ */
+export function setMobileDaemonVersion(version: string): void {
+	ctx = { ...ctx, daemonVersion: version };
+}
 
 /** Initialize once. No DSN → stays a no-op forever. */
 export async function initMobileSentry(context: MobileObservabilityContext = {}): Promise<void> {
@@ -58,7 +90,19 @@ export async function initMobileSentry(context: MobileObservabilityContext = {})
 		mod.init({
 			dsn: d,
 			release: context.release,
+			environment: channelOf(context.release ?? ""),
 			enableAutoSessionTracking: false,
+			// No PII (no device name, no IP-derived fields we can avoid).
+			sendDefaultPii: false,
+			// Deny-by-default. @sentry/react-native auto-captures fetch/XHR
+			// breadcrumbs with FULL URLs — on mobile that is the user's Tailscale
+			// host, exactly what must never leave the device. Cap breadcrumbs to
+			// zero (none retained or sent) and turn off auto performance/HTTP
+			// tracing rather than relying on scrubbing. Events reach Sentry only
+			// through our capture seams with safe enum/id tags.
+			maxBreadcrumbs: 0,
+			enableAutoPerformanceTracing: false,
+			tracesSampleRate: 0,
 			beforeSend: (event: Record<string, unknown>) => scrubEvent(event),
 			beforeBreadcrumb: (crumb: Record<string, unknown> | null) => (crumb ? scrubEvent(crumb) : crumb),
 		});
@@ -82,6 +126,7 @@ function tagsFor(meta: CaptureMeta, triage: Triage) {
 		apierr_kind: meta.kind,
 		severity: triage.severity,
 		owner: triage.owner,
+		daemon_version: ctx.daemonVersion,
 	};
 }
 

--- a/packages/mobile/lib/sentry.ts
+++ b/packages/mobile/lib/sentry.ts
@@ -112,7 +112,7 @@ export async function initMobileSentry(context: MobileObservabilityContext = {})
 	}
 }
 
-type CaptureMeta = ClassifyInput & { operation?: string; surface?: string; domain?: string };
+type CaptureMeta = ClassifyInput & { operation?: string; surface?: string; domain?: string; requestId?: string };
 
 function tagsFor(meta: CaptureMeta, triage: Triage) {
 	return {
@@ -124,6 +124,8 @@ function tagsFor(meta: CaptureMeta, triage: Triage) {
 		code: meta.code,
 		http_status: meta.httpStatus,
 		apierr_kind: meta.kind,
+		// Correlates with the daemon's own request_id tag on the matching capture.
+		request_id: meta.requestId,
 		severity: triage.severity,
 		owner: triage.owner,
 		daemon_version: ctx.daemonVersion,
@@ -149,13 +151,19 @@ export function captureMobileException(error: unknown, meta: CaptureMeta = {}): 
 }
 
 /** Capture a classified API failure from the mobile request helper. */
-export function captureMobileApiError(path: string, category: string, status?: number, code?: string): void {
+export function captureMobileApiError(
+	path: string,
+	category: string,
+	status?: number,
+	code?: string,
+	requestId?: string,
+): void {
 	if (!sentry) return;
 	const template = normalizePath(path.split("?")[0]);
 	// domain = first meaningful path segment (…/api/v1/<domain>/…)
 	const parts = template.split("/").filter(Boolean);
 	const domain = parts.includes("v1") ? parts[parts.indexOf("v1") + 1] : parts[0];
-	const meta: CaptureMeta = { operation: template, domain, category, httpStatus: status, code };
+	const meta: CaptureMeta = { operation: template, domain, category, httpStatus: status, code, requestId };
 	const triage = classifyError(meta);
 	const tags = tagsFor(meta, triage);
 	if (triage.report) sentry.captureMessage(`${meta.operation} failed: ${category}${status ? ` (${status})` : ""}`, { level: triage.level, tags });

--- a/packages/mobile/lib/sentry.ts
+++ b/packages/mobile/lib/sentry.ts
@@ -1,0 +1,107 @@
+// Mobile Sentry sink (@sentry/react-native), mirroring the desktop renderer sink
+// so both classify errors identically. No-op until BOTH hold:
+//   1. a DSN is configured via EXPO_PUBLIC_SENTRY_DSN, and
+//   2. the @sentry/react-native SDK is installed.
+// Ship-time steps (no code change): `npx expo install @sentry/react-native`,
+// set EXPO_PUBLIC_SENTRY_DSN, and add source-map upload for OTA builds.
+
+import { classifyError, type ClassifyInput, type Triage } from "./observability";
+
+type SentryLike = {
+	init: (opts: Record<string, unknown>) => void;
+	captureException: (err: unknown, hint?: Record<string, unknown>) => void;
+	captureMessage: (msg: string, hint?: Record<string, unknown>) => void;
+	addBreadcrumb: (crumb: Record<string, unknown>) => void;
+};
+
+let sentry: SentryLike | null = null;
+let initStarted = false;
+
+function dsn(): string {
+	try {
+		return process.env.EXPO_PUBLIC_SENTRY_DSN ?? "";
+	} catch {
+		return "";
+	}
+}
+
+const LOCAL_URL = /(?:\bhttps?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]|100\.\d+\.\d+\.\d+|[^\s/]+\.ts\.net)(?::\d+)?\S*)/gi;
+const HOME_PATH = /\/(?:Users|home|data\/data)\/[^\s"']+/g;
+function scrub(value: unknown): unknown {
+	if (typeof value === "string") return value.replace(LOCAL_URL, "[redacted-url]").replace(HOME_PATH, "[redacted-path]");
+	return value;
+}
+function scrubEvent(event: Record<string, unknown>): Record<string, unknown> {
+	if (typeof event.message === "string") event.message = scrub(event.message) as string;
+	const exception = event.exception as { values?: Array<{ value?: unknown }> } | undefined;
+	for (const v of exception?.values ?? []) if (typeof v.value === "string") v.value = scrub(v.value);
+	return event;
+}
+
+export type MobileObservabilityContext = { release?: string; distinctId?: string };
+let ctx: MobileObservabilityContext = {};
+
+/** Initialize once. No DSN → stays a no-op forever. */
+export async function initMobileSentry(context: MobileObservabilityContext = {}): Promise<void> {
+	ctx = context;
+	if (initStarted || sentry) return;
+	const d = dsn();
+	if (!d) return;
+	initStarted = true;
+	try {
+		const spec = ["@sentry", "react-native"].join("/");
+		const mod = (await import(/* @vite-ignore */ spec)) as unknown as SentryLike;
+		mod.init({
+			dsn: d,
+			release: context.release,
+			enableAutoSessionTracking: false,
+			beforeSend: (event: Record<string, unknown>) => scrubEvent(event),
+			beforeBreadcrumb: (crumb: Record<string, unknown> | null) => (crumb ? scrubEvent(crumb) : crumb),
+		});
+		sentry = mod;
+	} catch {
+		sentry = null;
+	}
+}
+
+type CaptureMeta = ClassifyInput & { operation?: string; surface?: string; domain?: string };
+
+function tagsFor(meta: CaptureMeta, triage: Triage) {
+	return {
+		platform: "mobile",
+		surface: meta.surface,
+		domain: meta.domain,
+		operation: meta.operation,
+		category: meta.category,
+		code: meta.code,
+		http_status: meta.httpStatus,
+		severity: triage.severity,
+		owner: triage.owner,
+	};
+}
+
+export function captureMobileException(error: unknown, meta: CaptureMeta = {}): void {
+	if (!sentry) return;
+	const triage = classifyError(meta);
+	const tags = tagsFor(meta, triage);
+	if (triage.report) sentry.captureException(error, { level: triage.level, tags });
+	else sentry.addBreadcrumb({ category: "handled", level: triage.level, message: String((error as Error)?.message ?? error), data: tags });
+}
+
+/** Capture a classified API failure from the mobile request helper. */
+export function captureMobileApiError(path: string, category: string, status?: number, code?: string): void {
+	if (!sentry) return;
+	// domain = first meaningful path segment (…/api/v1/<domain>/…)
+	const parts = path.split("?")[0].split("/").filter(Boolean);
+	const domain = parts.includes("v1") ? parts[parts.indexOf("v1") + 1] : parts[0];
+	const meta: CaptureMeta = { operation: path.split("?")[0], domain, category, httpStatus: status, code };
+	const triage = classifyError(meta);
+	const tags = tagsFor(meta, triage);
+	if (triage.report) sentry.captureMessage(`${meta.operation} failed: ${category}${status ? ` (${status})` : ""}`, { level: triage.level, tags });
+	else sentry.addBreadcrumb({ category: "api", level: triage.level, message: `${meta.operation} ${category}`, data: tags });
+}
+
+/** Map an HTTP status to a transport category. */
+export function httpCategory(status: number): string {
+	return status >= 500 ? "http_5xx" : "http_4xx";
+}


### PR DESCRIPTION
Mobile counterpart to the desktop renderer Sentry slice (#4180), in **its own PR** so mobile and desktop ship independently. Dormant until a DSN exists.

## What this adds
- **`packages/mobile/lib/observability.ts`** — the same pure `classifyError()` (severity P0-P3 + fault owner ours/user/external/environment) as desktop. Duplicated rather than imported because the Expo/Metro bundle can't reach `frontend/src`; the shared unit tests come with it so the two copies can't drift silently.
- **`packages/mobile/lib/sentry.ts`** — an `@sentry/react-native` sink, lazy-loaded, no-op unless `EXPO_PUBLIC_SENTRY_DSN` is set. Scrubs local/Tailscale URLs + home paths; safe enum/id tags only.
- **Wiring** — the central request helper `req()` at its three failure points: `timeout` (sleeping Tailscale host), `offline` (fetch threw), and server error (`ApiError` + daemon `code`); initialized from `TelemetryManager` under the same consent gate as mobile telemetry.

## Why no `@sentry/react-native` dependency yet
Loaded lazily only when a DSN is present, so this builds with no new dependency today.

## Ship steps (when the DSN arrives)
1. `npx expo install @sentry/react-native` (make the lazy import static).
2. Set `EXPO_PUBLIC_SENTRY_DSN`; add source-map upload for OTA builds (EAS).
3. Verify with a forced error on device.

## Verification
- Classification: 14/14 unit tests (mobile copy).
- Mobile typecheck runs in CI.

Pairs with the desktop PR #4180. Follow-up: daemon (`sentry-go`) + request-id correlation.
