### PR TITLE
feat: add Copilot token usage observability

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -300,7 +300,7 @@ func Run() error {
 		usageCollector *usagesvc.Collector
 		usagePipeline  *usagepipeline.Pipeline
 	)
-	if roots, rootsErr := usagesvc.DefaultSourceRoots(ctx); rootsErr != nil {
+	if roots, rootsErr := usagesvc.DefaultSourceRoots(ctx, cfg.DataDir); rootsErr != nil {
 		log.Warn("usage collection disabled", "err", rootsErr)
 	} else {
 		usageCollector = usagesvc.NewCollector(store, roots, func(reconcile bool) {
@@ -318,6 +318,10 @@ func Run() error {
 			roots.ClaudeProjects,
 			roots.CodexSessions,
 			roots.CodexArchived,
+			roots.CopilotSessions,
+			roots.KimiHome,
+			roots.PiSessions,
+			roots.QwenUsage,
 		}, usagepipeline.CoordinatorConfig{
 			Logger:     log,
 			Initialize: usageCollector.BackfillActive,

--- a/backend/internal/domain/usage.go
+++ b/backend/internal/domain/usage.go
@@ -12,9 +12,13 @@ type UsageSourceKind string
 
 // UsageSourceKind values identify certified native usage artifact shapes.
 const (
-	UsageSourceClaudeMain     UsageSourceKind = "claude_main"
-	UsageSourceClaudeSubagent UsageSourceKind = "claude_subagent"
-	UsageSourceCodexRollout   UsageSourceKind = "codex_rollout"
+	UsageSourceClaudeMain      UsageSourceKind = "claude_main"
+	UsageSourceClaudeSubagent  UsageSourceKind = "claude_subagent"
+	UsageSourceCodexRollout    UsageSourceKind = "codex_rollout"
+	UsageSourceCopilotShutdown UsageSourceKind = "copilot_shutdown"
+	UsageSourceKimiWire        UsageSourceKind = "kimi_wire"
+	UsageSourcePiSession       UsageSourceKind = "pi_session"
+	UsageSourceQwenMonthly     UsageSourceKind = "qwen_monthly"
 )
 
 // UsageBindingState tracks the root native-session binding lifecycle.
@@ -117,6 +121,16 @@ type UsageTokenMetrics struct {
 	CacheWriteTokens    int64
 	OutputTokens        int64
 	ReasoningTokens     *int64
+}
+
+// UsageMetricCoverage describes which optional token buckets a harness's
+// certified native source can report. It is derived at read time so a source
+// that lacks a metric is not presented as a reported zero.
+type UsageMetricCoverage struct {
+	UncachedInput bool
+	CacheRead     bool
+	CacheWrite    bool
+	Reasoning     bool
 }
 
 // ModelUsageEvent is one append-only normalized usage fact.

--- a/backend/internal/observe/usage/copilot_parser_test.go
+++ b/backend/internal/observe/usage/copilot_parser_test.go
@@ -1,0 +1,97 @@
+package usage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// TestParseCopilotCumulativeShutdownDeltas catches counting repeated shutdown
+// summaries twice or treating inclusive input as ordinary input.
+func TestParseCopilotCumulativeShutdownDeltas(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	records := []jsonlRecord{
+		{Offset: 0, Data: copilotShutdownLine("claude-haiku-4.5", 111529, 86021, 25483, 901, 251)},
+		{Offset: 100, Data: copilotShutdownLine("claude-haiku-4.5", 111529, 86021, 25483, 901, 251)},
+		{Offset: 200, Data: copilotShutdownLine("claude-haiku-4.5", 120000, 90000, 26000, 950, 275)},
+	}
+
+	result := parseRecords(source, records, 300, now)
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("events = %d, want initial total and one positive delta", len(result.Events))
+	}
+	first := result.Events[0]
+	if first.ModelID != "claude-haiku-4.5" {
+		t.Fatalf("model = %q", first.ModelID)
+	}
+	if got := first.Tokens; got.InputTokens != 111529 || got.UncachedInputTokens != 25 ||
+		got.CacheReadTokens != 86021 || got.CacheWriteTokens != 25483 ||
+		got.OutputTokens != 901 || got.ReasoningTokens == nil || *got.ReasoningTokens != 251 {
+		t.Fatalf("first tokens = %+v", got)
+	}
+	if got := result.Events[1].Tokens; got.InputTokens != 8471 || got.UncachedInputTokens != 3975 ||
+		got.CacheReadTokens != 3979 || got.CacheWriteTokens != 517 ||
+		got.OutputTokens != 49 || got.ReasoningTokens == nil || *got.ReasoningTokens != 24 {
+		t.Fatalf("delta tokens = %+v", got)
+	}
+	if first.SourceEventKey == "" || first.SourceEventKey == result.Events[1].SourceEventKey {
+		t.Fatalf("event keys = %q/%q", first.SourceEventKey, result.Events[1].SourceEventKey)
+	}
+}
+
+// TestParseCopilotTracksModelsIndependently catches one model switch replacing
+// the baseline for another model in the same native session.
+func TestParseCopilotTracksModelsIndependently(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	record := jsonlRecord{Data: []byte(`{"type":"session.shutdown","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":100,"outputTokens":20,"cacheReadTokens":60,"cacheWriteTokens":10,"reasoningTokens":5}},"claude-haiku-4.5":{"usage":{"inputTokens":40,"outputTokens":8,"cacheReadTokens":20,"cacheWriteTokens":5,"reasoningTokens":2}}}}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("events = %+v, want one event per model", result.Events)
+	}
+	state := parserStateFromResult(t, result, domain.UsageSourceCopilotShutdown)
+	if len(state.Copilot.Models) != 2 || state.Copilot.Models["gpt-5-mini"].InputTokens != 100 {
+		t.Fatalf("state = %+v", state.Copilot)
+	}
+}
+
+// TestParseCopilotCounterRegressionResetsBaseline catches negative usage deltas
+// after Copilot starts a new cumulative epoch.
+func TestParseCopilotCounterRegressionResetsBaseline(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	first := parseRecords(source, []jsonlRecord{{Data: copilotShutdownLine("gpt-5-mini", 100, 60, 10, 20, 5)}}, 100, time.Unix(1700000000, 0).UTC())
+	if first.err != nil || len(first.Events) != 1 {
+		t.Fatalf("first parse = %+v", first)
+	}
+	source.Source.ParserStateJSON = first.Cursor.ParserStateJSON
+	reset := parseRecords(source, []jsonlRecord{{Data: copilotShutdownLine("gpt-5-mini", 10, 5, 0, 2, 1)}}, 200, time.Unix(1700000001, 0).UTC())
+	if reset.err != nil {
+		t.Fatal(reset.err)
+	}
+	if len(reset.Events) != 0 || reset.Cursor.AnomalyCount != 1 ||
+		reset.Cursor.LastErrorCode != domain.UsageErrorNonMonotonicCumulativeUsage {
+		t.Fatalf("reset result = %+v", reset)
+	}
+	state := parserStateFromResult(t, reset, domain.UsageSourceCopilotShutdown)
+	if state.Copilot.Models["gpt-5-mini"].InputTokens != 10 {
+		t.Fatalf("reset state = %+v", state.Copilot)
+	}
+}
+
+func copilotShutdownLine(model string, input, cacheRead, cacheWrite, output, reasoning int64) []byte {
+	return []byte(`{"type":"session.shutdown","data":{"modelMetrics":{"` + model + `":{"usage":{"inputTokens":` +
+		intString(input) + `,"outputTokens":` + intString(output) + `,"cacheReadTokens":` + intString(cacheRead) +
+		`,"cacheWriteTokens":` + intString(cacheWrite) + `,"reasoningTokens":` + intString(reasoning) + `}}}}}`)
+}
+
+func intString(value int64) string {
+	return fmt.Sprintf("%d", value)
+}

--- a/backend/internal/observe/usage/copilot_parser_test.go
+++ b/backend/internal/observe/usage/copilot_parser_test.go
@@ -63,6 +63,67 @@ func TestParseCopilotTracksModelsIndependently(t *testing.T) {
 	}
 }
 
+func TestParseCopilotAssistantMessageOutputTokens(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	records := []jsonlRecord{
+		{Data: []byte(`{"type":"assistant.message","id":"message-1","data":{"model":"gpt-5-mini","outputTokens":944}}`)},
+		{Data: []byte(`{"type":"assistant.message","id":"message-2","data":{"model":"gpt-5-mini","outputTokens":17}}`)},
+	}
+	result := parseRecords(source, records, 200, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("events = %+v, want one usage event per assistant message", result.Events)
+	}
+	if got := result.Events[0].Tokens; got.InputTokens != 0 || got.OutputTokens != 944 || got.ReasoningTokens != nil {
+		t.Fatalf("first tokens = %+v", got)
+	}
+	if got := result.Events[1].Tokens; got.InputTokens != 0 || got.OutputTokens != 17 || got.ReasoningTokens != nil {
+		t.Fatalf("second tokens = %+v", got)
+	}
+	if result.Events[0].SourceEventKey == "" || result.Events[0].SourceEventKey == result.Events[1].SourceEventKey {
+		t.Fatalf("event keys = %q/%q", result.Events[0].SourceEventKey, result.Events[1].SourceEventKey)
+	}
+}
+
+func TestParseCopilotPrefersShutdownRollupOverAssistantMessages(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	records := []jsonlRecord{
+		{Data: []byte(`{"type":"assistant.message","id":"message-1","data":{"model":"gpt-5-mini","outputTokens":17}}`)},
+		{Data: copilotShutdownLine("gpt-5-mini", 100, 60, 10, 17, 5)},
+	}
+	result := parseRecords(source, records, 200, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := result.Events[0].Tokens; got.InputTokens != 100 || got.OutputTokens != 17 || got.ReasoningTokens == nil || *got.ReasoningTokens != 5 {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseCopilotLaterShutdownSuppressesAlreadyParsedAssistantMessage(t *testing.T) {
+	source := usageSource(domain.UsageSourceCopilotShutdown)
+	first := parseRecords(source, []jsonlRecord{
+		{Offset: 0, Data: []byte(`{"type":"assistant.message","id":"message-1","data":{"model":"gpt-5-mini","outputTokens":17}}`)},
+	}, 100, time.Unix(1700000000, 0).UTC())
+	if first.err != nil || len(first.Events) != 1 {
+		t.Fatalf("first result = %+v", first)
+	}
+
+	source.Source.ParserStateJSON = first.Cursor.ParserStateJSON
+	second := parseRecords(source, []jsonlRecord{
+		{Offset: 100, Data: copilotShutdownLine("gpt-5-mini", 100, 60, 10, 17, 5)},
+	}, 200, time.Unix(1700000001, 0).UTC())
+	if second.err != nil || len(second.Events) != 1 {
+		t.Fatalf("second result = %+v", second)
+	}
+	if got := second.Events[0].Tokens; got.InputTokens != 100 || got.OutputTokens != 0 ||
+		got.ReasoningTokens == nil || *got.ReasoningTokens != 0 {
+		t.Fatalf("shutdown delta tokens = %+v", got)
+	}
+}
+
 // TestParseCopilotCounterRegressionResetsBaseline catches negative usage deltas
 // after Copilot starts a new cumulative epoch.
 func TestParseCopilotCounterRegressionResetsBaseline(t *testing.T) {

--- a/backend/internal/observe/usage/kimi_parser_test.go
+++ b/backend/internal/observe/usage/kimi_parser_test.go
@@ -1,0 +1,78 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// TestParseKimiUsageRecord catches omitting cache buckets from Kimi's ordinary
+// input field or counting unrelated wire records as usage.
+func TestParseKimiUsageRecord(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	records := []jsonlRecord{
+		{Offset: 0, Data: []byte(`{"id":"message-1","time":"2026-08-09T09:59:00Z","type":"message.create","message":{}}`)},
+		{Offset: 100, Data: []byte(`{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":13,"inputCacheRead":21,"inputCacheCreation":8,"output":5},"usageScope":"turn"}`)},
+	}
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %+v, want one usage record", result.Events)
+	}
+	event := result.Events[0]
+	if event.ModelID != "kimi-for-coding" || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	if got := event.Tokens; got.InputTokens != 42 || got.UncachedInputTokens != 13 ||
+		got.CacheReadTokens != 21 || got.CacheWriteTokens != 8 || got.OutputTokens != 5 ||
+		got.ReasoningTokens != nil {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseKimiUsageRecordWithNumericTime(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	record := jsonlRecord{Offset: 100, Data: []byte(`{"time":1797038183476.96,"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":6697,"output":39,"inputCacheRead":19200,"inputCacheCreation":0},"usageScope":"turn"}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %+v, want one usage record", result.Events)
+	}
+	if got := result.Events[0].Tokens; got.InputTokens != 25897 || got.UncachedInputTokens != 6697 ||
+		got.CacheReadTokens != 19200 || got.CacheWriteTokens != 0 || got.OutputTokens != 39 {
+		t.Fatalf("tokens = %+v", got)
+	}
+	if result.Events[0].SourceEventKey == "" {
+		t.Fatalf("event key is empty")
+	}
+}
+
+func TestParseKimiUsageRecordHasReplayStableKey(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	record := jsonlRecord{Offset: 100, Data: []byte(`{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":1,"inputCacheRead":2,"inputCacheCreation":3,"output":4}}`)}
+	first := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000000, 0).UTC())
+	second := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000001, 0).UTC())
+	if first.err != nil || second.err != nil || len(first.Events) != 1 || len(second.Events) != 1 {
+		t.Fatalf("first=%+v second=%+v", first, second)
+	}
+	if first.Events[0].SourceEventKey != second.Events[0].SourceEventKey {
+		t.Fatalf("keys = %q/%q", first.Events[0].SourceEventKey, second.Events[0].SourceEventKey)
+	}
+}
+
+func TestParseKimiRejectsNegativeUsage(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	record := jsonlRecord{Data: []byte(`{"id":"usage-bad","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":-1,"inputCacheRead":0,"inputCacheCreation":0,"output":1}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 || result.Cursor.LastErrorCode != domain.UsageErrorMalformedJSONL {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -45,6 +45,8 @@ func parseRecordsWithState(
 		result.pendingCodexSpawnCalls = len(state.Codex.PendingSpawnCallIDs)
 	case domain.UsageSourceCopilotShutdown:
 		parseCopilot(source, records, state.Copilot, &result)
+	case domain.UsageSourceKimiWire:
+		parseKimi(source, records, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -214,6 +216,10 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 				return nil, errors.New("copilot state has invalid model baseline")
 			}
 		}
+	case domain.UsageSourceKimiWire:
+		if state.Claude != nil || state.Codex != nil || state.Copilot != nil {
+			return nil, errors.New("append-only state has invalid parser payload")
+		}
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", source.Kind)
 	}
@@ -235,6 +241,9 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 		}
 	case domain.UsageSourceCopilotShutdown:
 		state.Copilot = &copilotParserStateV1{Models: make(map[string]copilotTokenVector)}
+	case domain.UsageSourceKimiWire:
+		// Append-only sources derive replay-stable event keys from native record IDs
+		// and do not need a provider-specific parser baseline.
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", kind)
 	}

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -43,6 +43,8 @@ func parseRecordsWithState(
 	case domain.UsageSourceCodexRollout:
 		parseCodex(source, records, state.Codex, &result)
 		result.pendingCodexSpawnCalls = len(state.Codex.PendingSpawnCallIDs)
+	case domain.UsageSourceCopilotShutdown:
+		parseCopilot(source, records, state.Copilot, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -89,6 +91,7 @@ type parserStateEnvelope struct {
 	Integrity  *parserIntegrityStateV1 `json:"integrity,omitempty"`
 	Claude     *claudeParserStateV1    `json:"claude,omitempty"`
 	Codex      *codexParserStateV1     `json:"codex,omitempty"`
+	Copilot    *copilotParserStateV1   `json:"copilot,omitempty"`
 }
 
 type parserIntegrityStateV1 struct {
@@ -123,6 +126,18 @@ type codexParserStateV1 struct {
 	DirectParentID      string           `json:"direct_parent_id,omitempty"`
 	PendingSpawnCallIDs []string         `json:"pending_spawn_call_ids"`
 	DiscoveredChildIDs  []string         `json:"discovered_child_ids"`
+}
+
+type copilotTokenVector struct {
+	InputTokens      int64 `json:"input_tokens"`
+	CacheReadTokens  int64 `json:"cache_read_tokens"`
+	CacheWriteTokens int64 `json:"cache_write_tokens"`
+	OutputTokens     int64 `json:"output_tokens"`
+	ReasoningTokens  int64 `json:"reasoning_tokens"`
+}
+
+type copilotParserStateV1 struct {
+	Models map[string]copilotTokenVector `json:"models"`
 }
 
 func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, error) {
@@ -166,12 +181,12 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 	}
 	switch source.Kind {
 	case domain.UsageSourceClaudeMain, domain.UsageSourceClaudeSubagent:
-		if state.Claude == nil || state.Codex != nil {
+		if state.Claude == nil || state.Codex != nil || state.Copilot != nil {
 			return nil, errors.New("claude state has invalid parser payload")
 		}
 		state.Claude.LegacyProvider = ""
 	case domain.UsageSourceCodexRollout:
-		if state.Codex == nil || state.Claude != nil {
+		if state.Codex == nil || state.Claude != nil || state.Copilot != nil {
 			return nil, errors.New("codex state has invalid parser payload")
 		}
 		if state.Codex.PendingSpawnCallIDs == nil {
@@ -186,6 +201,18 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 		}
 		if err := validateCodexDirectParent(source, state.Codex); err != nil {
 			return nil, err
+		}
+	case domain.UsageSourceCopilotShutdown:
+		if state.Copilot == nil || state.Claude != nil || state.Codex != nil {
+			return nil, errors.New("copilot state has invalid parser payload")
+		}
+		if state.Copilot.Models == nil {
+			state.Copilot.Models = make(map[string]copilotTokenVector)
+		}
+		for model, total := range state.Copilot.Models {
+			if firstNonEmpty(model) == "" || !validCopilotTotal(total) {
+				return nil, errors.New("copilot state has invalid model baseline")
+			}
 		}
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", source.Kind)
@@ -206,6 +233,8 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 			PendingSpawnCallIDs: []string{},
 			DiscoveredChildIDs:  []string{},
 		}
+	case domain.UsageSourceCopilotShutdown:
+		state.Copilot = &copilotParserStateV1{Models: make(map[string]copilotTokenVector)}
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", kind)
 	}

--- a/backend/internal/observe/usage/parser_copilot.go
+++ b/backend/internal/observe/usage/parser_copilot.go
@@ -1,0 +1,125 @@
+package usage
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type copilotTranscriptRecord struct {
+	Type string `json:"type"`
+	Data struct {
+		ModelMetrics map[string]struct {
+			Usage *struct {
+				InputTokens      int64 `json:"inputTokens"`
+				OutputTokens     int64 `json:"outputTokens"`
+				CacheReadTokens  int64 `json:"cacheReadTokens"`
+				CacheWriteTokens int64 `json:"cacheWriteTokens"`
+				ReasoningTokens  int64 `json:"reasoningTokens"`
+			} `json:"usage"`
+		} `json:"modelMetrics"`
+	} `json:"data"`
+}
+
+func parseCopilot(
+	source domain.UsageSourceContext,
+	records []jsonlRecord,
+	state *copilotParserStateV1,
+	result *parseResult,
+) {
+	for _, record := range records {
+		var native copilotTranscriptRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "session.shutdown" {
+			continue
+		}
+		for nativeModel, metrics := range native.Data.ModelMetrics {
+			model := firstNonEmpty(nativeModel)
+			if model == "" || metrics.Usage == nil {
+				recordMalformed(result)
+				continue
+			}
+			usage := metrics.Usage
+			total := copilotTokenVector{
+				InputTokens:      usage.InputTokens,
+				CacheReadTokens:  usage.CacheReadTokens,
+				CacheWriteTokens: usage.CacheWriteTokens,
+				OutputTokens:     usage.OutputTokens,
+				ReasoningTokens:  usage.ReasoningTokens,
+			}
+			if !validCopilotTotal(total) {
+				recordMalformed(result)
+				continue
+			}
+			baseline := state.Models[model]
+			if copilotCounterRegressed(total, baseline) {
+				state.Models[model] = total
+				result.Cursor.AnomalyCount++
+				result.Cursor.LastErrorCode = domain.UsageErrorNonMonotonicCumulativeUsage
+				continue
+			}
+			delta := subtractCopilotTotal(total, baseline)
+			state.Models[model] = total
+			if delta.InputTokens == 0 && delta.OutputTokens == 0 && delta.CacheWriteTokens == 0 {
+				continue
+			}
+			uncached := delta.InputTokens - delta.CacheReadTokens - delta.CacheWriteTokens
+			tokens := domain.UsageTokenMetrics{
+				InputTokens:         delta.InputTokens,
+				UncachedInputTokens: uncached,
+				CacheReadTokens:     delta.CacheReadTokens,
+				CacheWriteTokens:    delta.CacheWriteTokens,
+				OutputTokens:        delta.OutputTokens,
+				ReasoningTokens:     int64Ptr(delta.ReasoningTokens),
+			}
+			if !validTokenMetrics(tokens) {
+				recordMalformed(result)
+				continue
+			}
+			result.Events = append(result.Events, domain.ModelUsageEvent{
+				ModelID: model,
+				Tokens:  tokens,
+				SourceEventKey: stableSourceEventKey(
+					"copilot",
+					source.NativeRootID,
+					model,
+					strconv.FormatInt(total.InputTokens, 10),
+					strconv.FormatInt(total.CacheReadTokens, 10),
+					strconv.FormatInt(total.CacheWriteTokens, 10),
+					strconv.FormatInt(total.OutputTokens, 10),
+					strconv.FormatInt(total.ReasoningTokens, 10),
+				),
+			})
+		}
+	}
+}
+
+func validCopilotTotal(total copilotTokenVector) bool {
+	return total.InputTokens >= 0 && total.CacheReadTokens >= 0 && total.CacheWriteTokens >= 0 &&
+		total.OutputTokens >= 0 && total.ReasoningTokens >= 0 &&
+		total.CacheReadTokens <= total.InputTokens &&
+		total.CacheWriteTokens <= total.InputTokens-total.CacheReadTokens &&
+		total.ReasoningTokens <= total.OutputTokens
+}
+
+func copilotCounterRegressed(total, baseline copilotTokenVector) bool {
+	return total.InputTokens < baseline.InputTokens ||
+		total.CacheReadTokens < baseline.CacheReadTokens ||
+		total.CacheWriteTokens < baseline.CacheWriteTokens ||
+		total.OutputTokens < baseline.OutputTokens ||
+		total.ReasoningTokens < baseline.ReasoningTokens
+}
+
+func subtractCopilotTotal(total, baseline copilotTokenVector) copilotTokenVector {
+	return copilotTokenVector{
+		InputTokens:      total.InputTokens - baseline.InputTokens,
+		CacheReadTokens:  total.CacheReadTokens - baseline.CacheReadTokens,
+		CacheWriteTokens: total.CacheWriteTokens - baseline.CacheWriteTokens,
+		OutputTokens:     total.OutputTokens - baseline.OutputTokens,
+		ReasoningTokens:  total.ReasoningTokens - baseline.ReasoningTokens,
+	}
+}

--- a/backend/internal/observe/usage/parser_copilot.go
+++ b/backend/internal/observe/usage/parser_copilot.go
@@ -8,9 +8,14 @@ import (
 )
 
 type copilotTranscriptRecord struct {
+	ID   string `json:"id"`
 	Type string `json:"type"`
 	Data struct {
-		ModelMetrics map[string]struct {
+		Model           string `json:"model"`
+		InputTokens     int64  `json:"inputTokens"`
+		OutputTokens    int64  `json:"outputTokens"`
+		ReasoningTokens *int64 `json:"reasoningTokens"`
+		ModelMetrics    map[string]struct {
 			Usage *struct {
 				InputTokens      int64 `json:"inputTokens"`
 				OutputTokens     int64 `json:"outputTokens"`
@@ -28,73 +33,145 @@ func parseCopilot(
 	state *copilotParserStateV1,
 	result *parseResult,
 ) {
+	hasShutdown := false
+	for _, record := range records {
+		var native copilotTranscriptRecord
+		if json.Unmarshal(record.Data, &native) == nil && native.Type == "session.shutdown" {
+			hasShutdown = true
+			break
+		}
+	}
 	for _, record := range records {
 		var native copilotTranscriptRecord
 		if err := json.Unmarshal(record.Data, &native); err != nil {
 			recordMalformed(result)
 			continue
 		}
-		if native.Type != "session.shutdown" {
+		switch native.Type {
+		case "assistant.message":
+			if !hasShutdown {
+				appendCopilotAssistantMessageUsage(source, record, native, state, result)
+			}
+		case "session.shutdown":
+			parseCopilotShutdownUsage(source, native, state, result)
+		default:
 			continue
 		}
-		for nativeModel, metrics := range native.Data.ModelMetrics {
-			model := firstNonEmpty(nativeModel)
-			if model == "" || metrics.Usage == nil {
-				recordMalformed(result)
-				continue
-			}
-			usage := metrics.Usage
-			total := copilotTokenVector{
-				InputTokens:      usage.InputTokens,
-				CacheReadTokens:  usage.CacheReadTokens,
-				CacheWriteTokens: usage.CacheWriteTokens,
-				OutputTokens:     usage.OutputTokens,
-				ReasoningTokens:  usage.ReasoningTokens,
-			}
-			if !validCopilotTotal(total) {
-				recordMalformed(result)
-				continue
-			}
-			baseline := state.Models[model]
-			if copilotCounterRegressed(total, baseline) {
-				state.Models[model] = total
-				result.Cursor.AnomalyCount++
-				result.Cursor.LastErrorCode = domain.UsageErrorNonMonotonicCumulativeUsage
-				continue
-			}
-			delta := subtractCopilotTotal(total, baseline)
-			state.Models[model] = total
-			if delta.InputTokens == 0 && delta.OutputTokens == 0 && delta.CacheWriteTokens == 0 {
-				continue
-			}
-			uncached := delta.InputTokens - delta.CacheReadTokens - delta.CacheWriteTokens
-			tokens := domain.UsageTokenMetrics{
-				InputTokens:         delta.InputTokens,
-				UncachedInputTokens: uncached,
-				CacheReadTokens:     delta.CacheReadTokens,
-				CacheWriteTokens:    delta.CacheWriteTokens,
-				OutputTokens:        delta.OutputTokens,
-				ReasoningTokens:     int64Ptr(delta.ReasoningTokens),
-			}
-			if !validTokenMetrics(tokens) {
-				recordMalformed(result)
-				continue
-			}
-			result.Events = append(result.Events, domain.ModelUsageEvent{
-				ModelID: model,
-				Tokens:  tokens,
-				SourceEventKey: stableSourceEventKey(
-					"copilot",
-					source.NativeRootID,
-					model,
-					strconv.FormatInt(total.InputTokens, 10),
-					strconv.FormatInt(total.CacheReadTokens, 10),
-					strconv.FormatInt(total.CacheWriteTokens, 10),
-					strconv.FormatInt(total.OutputTokens, 10),
-					strconv.FormatInt(total.ReasoningTokens, 10),
-				),
-			})
+	}
+}
+
+func appendCopilotAssistantMessageUsage(
+	source domain.UsageSourceContext,
+	record jsonlRecord,
+	native copilotTranscriptRecord,
+	state *copilotParserStateV1,
+	result *parseResult,
+) {
+	model := firstNonEmpty(native.Data.Model)
+	if model == "" || native.Data.InputTokens < 0 || native.Data.OutputTokens < 0 ||
+		(native.Data.ReasoningTokens != nil && (*native.Data.ReasoningTokens < 0 || *native.Data.ReasoningTokens > native.Data.OutputTokens)) {
+		recordMalformed(result)
+		return
+	}
+	if native.Data.InputTokens == 0 && native.Data.OutputTokens == 0 {
+		return
+	}
+	tokens := domain.UsageTokenMetrics{
+		InputTokens:         native.Data.InputTokens,
+		UncachedInputTokens: native.Data.InputTokens,
+		OutputTokens:        native.Data.OutputTokens,
+		ReasoningTokens:     native.Data.ReasoningTokens,
+	}
+	if !validTokenMetrics(tokens) {
+		recordMalformed(result)
+		return
+	}
+	baseline := state.Models[model]
+	baseline.InputTokens += native.Data.InputTokens
+	baseline.OutputTokens += native.Data.OutputTokens
+	if native.Data.ReasoningTokens != nil {
+		baseline.ReasoningTokens += *native.Data.ReasoningTokens
+	}
+	state.Models[model] = baseline
+	identity := firstNonEmpty(native.ID, strconv.FormatInt(record.Offset, 10))
+	result.Events = append(result.Events, domain.ModelUsageEvent{
+		ModelID: model,
+		Tokens:  tokens,
+		SourceEventKey: stableSourceEventKey(
+			"copilot-message",
+			source.NativeRootID,
+			model,
+			identity,
+		),
+	})
+}
+
+func parseCopilotShutdownUsage(
+	source domain.UsageSourceContext,
+	native copilotTranscriptRecord,
+	state *copilotParserStateV1,
+	result *parseResult,
+) {
+	for nativeModel, metrics := range native.Data.ModelMetrics {
+		model := firstNonEmpty(nativeModel)
+		if model == "" || metrics.Usage == nil {
+			recordMalformed(result)
+			continue
 		}
+		usage := metrics.Usage
+		total := copilotTokenVector{
+			InputTokens:      usage.InputTokens,
+			CacheReadTokens:  usage.CacheReadTokens,
+			CacheWriteTokens: usage.CacheWriteTokens,
+			OutputTokens:     usage.OutputTokens,
+			ReasoningTokens:  usage.ReasoningTokens,
+		}
+		if !validCopilotTotal(total) {
+			recordMalformed(result)
+			continue
+		}
+		baseline := state.Models[model]
+		if copilotCounterRegressed(total, baseline) {
+			state.Models[model] = total
+			result.Cursor.AnomalyCount++
+			result.Cursor.LastErrorCode = domain.UsageErrorNonMonotonicCumulativeUsage
+			continue
+		}
+		delta := subtractCopilotTotal(total, baseline)
+		if delta.ReasoningTokens > delta.OutputTokens {
+			delta.ReasoningTokens = delta.OutputTokens
+		}
+		state.Models[model] = total
+		if delta.InputTokens == 0 && delta.OutputTokens == 0 && delta.CacheWriteTokens == 0 {
+			continue
+		}
+		uncached := delta.InputTokens - delta.CacheReadTokens - delta.CacheWriteTokens
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         delta.InputTokens,
+			UncachedInputTokens: uncached,
+			CacheReadTokens:     delta.CacheReadTokens,
+			CacheWriteTokens:    delta.CacheWriteTokens,
+			OutputTokens:        delta.OutputTokens,
+			ReasoningTokens:     int64Ptr(delta.ReasoningTokens),
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"copilot",
+				source.NativeRootID,
+				model,
+				strconv.FormatInt(total.InputTokens, 10),
+				strconv.FormatInt(total.CacheReadTokens, 10),
+				strconv.FormatInt(total.CacheWriteTokens, 10),
+				strconv.FormatInt(total.OutputTokens, 10),
+				strconv.FormatInt(total.ReasoningTokens, 10),
+			),
+		})
 	}
 }
 

--- a/backend/internal/observe/usage/parser_kimi.go
+++ b/backend/internal/observe/usage/parser_kimi.go
@@ -1,0 +1,83 @@
+package usage
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type kimiWireRecord struct {
+	ID    string          `json:"id"`
+	Time  json.RawMessage `json:"time"`
+	Type  string          `json:"type"`
+	Model string          `json:"model"`
+	Usage *struct {
+		InputOther         int64 `json:"inputOther"`
+		InputCacheRead     int64 `json:"inputCacheRead"`
+		InputCacheCreation int64 `json:"inputCacheCreation"`
+		Output             int64 `json:"output"`
+	} `json:"usage"`
+}
+
+func parseKimi(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	for _, record := range records {
+		var native kimiWireRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "usage.record" {
+			continue
+		}
+		model := firstNonEmpty(native.Model)
+		if model == "" || native.Usage == nil {
+			recordMalformed(result)
+			continue
+		}
+		usage := native.Usage
+		input, ok := sumNonNegative(usage.InputOther, usage.InputCacheRead, usage.InputCacheCreation)
+		if !ok || usage.Output < 0 {
+			recordMalformed(result)
+			continue
+		}
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         input,
+			UncachedInputTokens: usage.InputOther,
+			CacheReadTokens:     usage.InputCacheRead,
+			CacheWriteTokens:    usage.InputCacheCreation,
+			OutputTokens:        usage.Output,
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		identity := firstNonEmpty(native.ID, kimiRecordTimeIdentity(native.Time), strconv.FormatInt(record.Offset, 10))
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"kimi",
+				source.NativeRootID,
+				source.Source.SubagentID,
+				identity,
+				model,
+			),
+		})
+	}
+}
+
+func kimiRecordTimeIdentity(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String()
+	}
+	return ""
+}

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -11,3 +11,19 @@ func SupportedHarness(h domain.AgentHarness) bool {
 		return false
 	}
 }
+
+// MetricCoverage reports the optional token buckets present in each certified
+// native format. Source support is enabled separately by SupportedHarness so a
+// parser can be developed without exposing an incomplete collection pipeline.
+func MetricCoverage(h domain.AgentHarness) domain.UsageMetricCoverage {
+	switch h {
+	case domain.HarnessClaudeCode, domain.HarnessKimi, domain.HarnessPi:
+		return domain.UsageMetricCoverage{UncachedInput: true, CacheRead: true, CacheWrite: true}
+	case domain.HarnessCodex, domain.HarnessCopilot:
+		return domain.UsageMetricCoverage{UncachedInput: true, CacheRead: true, CacheWrite: true, Reasoning: true}
+	case domain.HarnessQwen:
+		return domain.UsageMetricCoverage{UncachedInput: true, CacheRead: true, Reasoning: true}
+	default:
+		return domain.UsageMetricCoverage{}
+	}
+}

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot, domain.HarnessKimi:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -194,9 +195,25 @@ func (c *Collector) ReactivateSession(
 	sessionID domain.SessionID,
 	expectedRuntimeLaunchID string,
 ) error {
-	c.mu.Lock()
+	if !c.mu.TryLock() {
+		go func() {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			if err := c.reactivateSessionLocked(context.WithoutCancel(ctx), sessionID, expectedRuntimeLaunchID); err != nil {
+				slog.Default().Warn("usage: reactivate session after concurrent finalization", "session", sessionID, "err", err)
+			}
+		}()
+		return nil
+	}
 	defer c.mu.Unlock()
+	return c.reactivateSessionLocked(ctx, sessionID, expectedRuntimeLaunchID)
+}
 
+func (c *Collector) reactivateSessionLocked(
+	ctx context.Context,
+	sessionID domain.SessionID,
+	expectedRuntimeLaunchID string,
+) error {
 	session, ok, err := c.store.GetSession(ctx, sessionID)
 	if err != nil {
 		return err
@@ -229,6 +246,10 @@ func (c *Collector) ReactivateSession(
 		}
 	} else if nativeID != "" && nativeUsageIDPattern.MatchString(nativeID) {
 		if err := c.backfillSession(ctx, session, nativeID); err != nil {
+			return err
+		}
+	} else if session.Harness == domain.HarnessPi {
+		if err := c.backfillPiPaths(ctx); err != nil {
 			return err
 		}
 	} else {
@@ -365,6 +386,11 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 			return err
 		}
 		inventoryChanged = inventoryChanged || changed
+		if session.Harness == domain.HarnessKimi {
+			if err := c.registerDiscoveredKimiAgents(ctx, binding, mainArtifact.path, now, false); err != nil {
+				return err
+			}
+		}
 		sourceErrorCode := ""
 		if c.codexDiscoveryStillPending(ctx, signal.Event, signal.TranscriptPath, mainPath) {
 			sourceErrorCode = domain.UsageErrorSourceDiscoveryPending
@@ -495,6 +521,12 @@ func (c *Collector) BackfillActive(ctx context.Context) error {
 			continue
 		}
 		nativeID := usageNativeSessionID(session)
+		if nativeID == "" && session.Harness == domain.HarnessPi {
+			if err := c.backfillPiPaths(ctx); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
 		if nativeID == "" || !nativeUsageIDPattern.MatchString(nativeID) {
 			continue
 		}
@@ -518,6 +550,23 @@ func usageNativeSessionID(session domain.SessionRecord) string {
 		nativeID = session.Metadata.ProviderConversationID
 	}
 	return boundedUsageMetadata(nativeID)
+}
+
+func (c *Collector) backfillPiPaths(ctx context.Context) error {
+	paths, err := newestPiPaths(ctx, c.roots.PiSessions, 256)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := c.reconcilePiPath(ctx, path); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (c *Collector) backfillSession(ctx context.Context, session domain.SessionRecord, nativeID string) error {
@@ -589,12 +638,17 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 	if _, err := c.registerSource(ctx, binding, kind, nativeID, "", path, now, false); err != nil {
 		return err
 	}
-	if session.Harness == domain.HarnessClaudeCode {
+	switch session.Harness {
+	case domain.HarnessClaudeCode:
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if session.Harness == domain.HarnessCodex {
+	case domain.HarnessCodex:
 		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
+	case domain.HarnessKimi:
+		if err := c.registerDiscoveredKimiAgents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
 	}
@@ -612,6 +666,10 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	var errs []error
+	if err := c.backfillPiPaths(ctx); err != nil {
+		errs = append(errs, err)
+	}
 	if limit == 0 {
 		limit = defaultDiscoveryLimit
 	}
@@ -620,7 +678,6 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 		return err
 	}
 	now := c.now().UTC()
-	var errs []error
 	for _, binding := range bindings {
 		if err := c.reconcileBinding(ctx, binding, now); err != nil {
 			errs = append(errs, err)
@@ -629,15 +686,19 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 	return errors.Join(errs...)
 }
 
-// ReconcilePath uses Codex rollout metadata to validate replacements and reach
-// newly-created child bindings independently of the bounded discovery queue.
+// ReconcilePath uses provider metadata to validate sources that appear outside
+// the bounded discovery queue. Codex supplies thread ancestry; Pi supplies a
+// session header whose cwd can be correlated to one live AO worktree.
 func (c *Collector) ReconcilePath(ctx context.Context, path string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if pathWithinRoot(ctx, path, c.roots.PiSessions) {
+		return c.reconcilePiPath(ctx, path)
+	}
 
 	resolved, _, _, err := c.validateSourcePath(ctx, domain.HarnessCodex, path)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // Watch notifications may be for another provider's path.
 	}
 	meta, ok := readCodexSessionMeta(resolved)
 	if !ok || len(meta.NativeSessionID) > maxUsageMetadataBytes ||
@@ -686,6 +747,60 @@ func (c *Collector) ReconcilePath(ctx context.Context, path string) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
+	resolved, _, _, err := c.validateSourcePath(ctx, domain.HarnessPi, path)
+	if err != nil {
+		return nil //nolint:nilerr // Watch notifications may be for another provider's path.
+	}
+	meta, ok := readPiSessionMeta(resolved)
+	if !ok {
+		return nil
+	}
+	workspace, err := filepath.EvalSymlinks(filepath.Clean(meta.CWD))
+	if err != nil {
+		return nil //nolint:nilerr // Ignore stale or malformed provider session metadata.
+	}
+	sessions, err := c.store.ListAllSessions(ctx)
+	if err != nil {
+		return err
+	}
+	matches := make([]domain.SessionRecord, 0, 1)
+	for _, session := range sessions {
+		if session.Harness != domain.HarnessPi || session.IsTerminated ||
+			session.Activity.State == domain.ActivityExited || session.Metadata.WorkspacePath == "" {
+			continue
+		}
+		candidate, err := filepath.EvalSymlinks(filepath.Clean(session.Metadata.WorkspacePath))
+		if err == nil && candidate == workspace {
+			matches = append(matches, session)
+		}
+	}
+	if len(matches) != 1 {
+		return nil
+	}
+	now := c.now().UTC()
+	binding, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
+		SessionID:    matches[0].ID,
+		Harness:      domain.HarnessPi,
+		NativeRootID: meta.ID,
+		State:        domain.UsageBindingActive,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		return err
+	}
+	changed, err := c.registerSource(
+		ctx, binding, domain.UsageSourcePiSession, meta.ID, "", resolved, now, false,
+	)
+	if err != nil {
+		return err
+	}
+	if changed {
+		c.notifySourceInventory(false)
+	}
+	return nil
 }
 
 func (c *Collector) reconcileRetiredCodexClaims(
@@ -840,12 +955,17 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 	if _, err := c.registerSource(ctx, binding, kind, binding.NativeRootID, "", path, now, false); err != nil {
 		return err
 	}
-	if binding.Harness == domain.HarnessClaudeCode {
+	switch binding.Harness {
+	case domain.HarnessClaudeCode:
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if binding.Harness == domain.HarnessCodex {
+	case domain.HarnessCodex:
 		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
+	case domain.HarnessKimi:
+		if err := c.registerDiscoveredKimiAgents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
 	}
@@ -1071,7 +1191,7 @@ func (c *Collector) registerHookSource(
 	if kind == domain.UsageSourceCodexRollout && subagentID != "" {
 		expectedParentID = binding.NativeRootID
 	}
-	if err := validateSourceAttribution(
+	if err := c.validateSourceAttribution(
 		binding,
 		kind,
 		nativeSessionID,
@@ -1116,7 +1236,7 @@ func (c *Collector) registerSourceWithExpectedParent(
 	if err != nil {
 		return false, err
 	}
-	if err := validateSourceAttribution(
+	if err := c.validateSourceAttribution(
 		binding,
 		kind,
 		nativeSessionID,
@@ -1162,7 +1282,7 @@ func (c *Collector) registerSourceWithInventory(
 	if err != nil {
 		return false, err
 	}
-	if err := validateSourceAttribution(
+	if err := c.validateSourceAttribution(
 		binding,
 		kind,
 		nativeSessionID,
@@ -1391,6 +1511,42 @@ func discoverClaudeSubagentPaths(ctx context.Context, mainPath string) ([]string
 		result = append(result, candidate.path)
 	}
 	return result, nil
+}
+
+func (c *Collector) registerDiscoveredKimiAgents(
+	ctx context.Context,
+	binding domain.UsageBindingRecord,
+	mainPath string,
+	now time.Time,
+	reactivateExisting bool,
+) error {
+	sessionDir := filepath.Dir(filepath.Dir(filepath.Dir(mainPath)))
+	paths, err := filepath.Glob(filepath.Join(sessionDir, "agents", "*", "wire.jsonl"))
+	if err != nil {
+		return err
+	}
+	sort.Strings(paths)
+	var errs []error
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		agentID := boundedUsageMetadata(filepath.Base(filepath.Dir(path)))
+		if agentID == "" || !nativeUsageIDPattern.MatchString(agentID) {
+			continue
+		}
+		subagentID := agentID
+		if agentID == "main" {
+			subagentID = ""
+		}
+		if _, err := c.registerSource(
+			ctx, binding, domain.UsageSourceKimiWire, binding.NativeRootID,
+			subagentID, path, now, reactivateExisting,
+		); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (c *Collector) registerDiscoveredCodexChildren(
@@ -1679,8 +1835,61 @@ func validateSourceAttribution(
 			filepath.Base(resolved) != "events.jsonl" {
 			return rejected()
 		}
+	case domain.UsageSourceKimiWire:
+		agentDir := filepath.Dir(resolved)
+		agentsDir := filepath.Dir(agentDir)
+		sessionDir := filepath.Dir(agentsDir)
+		agentID := filepath.Base(agentDir)
+		wantSubagent := agentID
+		if agentID == "main" {
+			wantSubagent = ""
+		}
+		if binding.Harness != domain.HarnessKimi || nativeSessionID != binding.NativeRootID ||
+			filepath.Base(resolved) != "wire.jsonl" || filepath.Base(agentsDir) != "agents" ||
+			filepath.Base(sessionDir) != binding.NativeRootID || subagentID != wantSubagent {
+			return rejected()
+		}
+	case domain.UsageSourcePiSession:
+		meta, ok := readPiSessionMeta(resolved)
+		if binding.Harness != domain.HarnessPi || nativeSessionID != binding.NativeRootID ||
+			subagentID != "" || !ok || meta.ID != nativeSessionID {
+			return rejected()
+		}
+	case domain.UsageSourceQwenMonthly:
+		if binding.Harness != domain.HarnessQwen || nativeSessionID != binding.NativeRootID ||
+			subagentID != "" || !qwenUsageFilename(filepath.Base(resolved)) {
+			return rejected()
+		}
 	default:
 		return rejected()
+	}
+	return nil
+}
+
+func (c *Collector) validateSourceAttribution(
+	binding domain.UsageBindingRecord,
+	kind domain.UsageSourceKind,
+	nativeSessionID string,
+	subagentID string,
+	resolved string,
+	expectedParentID string,
+) error {
+	if err := validateSourceAttribution(
+		binding, kind, nativeSessionID, subagentID, resolved, expectedParentID,
+	); err != nil {
+		return err
+	}
+	if kind != domain.UsageSourceKimiWire {
+		return nil
+	}
+	expectedRoot, err := filepath.EvalSymlinks(filepath.Join(c.roots.KimiHome, "sessions"))
+	if err != nil {
+		return errors.New(domain.UsageErrorArtifactPathRejected)
+	}
+	actualSessionDir := filepath.Dir(filepath.Dir(filepath.Dir(resolved)))
+	rel, err := filepath.Rel(expectedRoot, actualSessionDir)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return errors.New(domain.UsageErrorArtifactPathRejected)
 	}
 	return nil
 }
@@ -1748,6 +1957,12 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		return c.discoverCodexPath(ctx, nativeID, "")
 	case domain.HarnessCopilot:
 		patterns = []string{filepath.Join(c.roots.CopilotSessions, nativeID, "events.jsonl")}
+	case domain.HarnessKimi:
+		return c.discoverKimiPath(ctx, nativeID)
+	case domain.HarnessPi:
+		return c.discoverPiPath(ctx, nativeID)
+	case domain.HarnessQwen:
+		return c.discoverQwenPath(ctx)
 	}
 	type candidate struct {
 		path string
@@ -1779,6 +1994,170 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		return "", nil
 	}
 	return matches[0].path, nil
+}
+
+type kimiIndexRecord struct {
+	SessionID  string `json:"sessionId"`
+	SessionDir string `json:"sessionDir"`
+	Deleted    bool   `json:"deleted"`
+}
+
+func (c *Collector) discoverKimiPath(ctx context.Context, nativeID string) (string, error) {
+	index, err := os.Open(filepath.Join(c.roots.KimiHome, "session_index.jsonl"))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = index.Close() }()
+
+	var latest kimiIndexRecord
+	// Replay the full append-only index so the last record for this session
+	// wins even after the file grows. Memory remains bounded by the scanner's
+	// per-record cap; provider index size does not become an allocation.
+	scanner := bufio.NewScanner(index)
+	scanner.Buffer(make([]byte, 4096), 64<<10)
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		var record kimiIndexRecord
+		if json.Unmarshal(scanner.Bytes(), &record) == nil && record.SessionID == nativeID {
+			latest = record
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if latest.Deleted || latest.SessionID == "" || !filepath.IsAbs(latest.SessionDir) ||
+		filepath.Base(filepath.Clean(latest.SessionDir)) != nativeID ||
+		!pathWithinRoot(ctx, latest.SessionDir, filepath.Join(c.roots.KimiHome, "sessions")) {
+		return "", nil
+	}
+	main := filepath.Join(latest.SessionDir, "agents", "main", "wire.jsonl")
+	if info, err := os.Stat(main); err == nil && info.Mode().IsRegular() {
+		return main, nil
+	}
+	paths, err := filepath.Glob(filepath.Join(latest.SessionDir, "agents", "*", "wire.jsonl"))
+	if err != nil || len(paths) == 0 {
+		return "", err
+	}
+	sort.Strings(paths)
+	return paths[0], nil
+}
+
+type piSessionMeta struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	CWD  string `json:"cwd"`
+}
+
+func readPiSessionMeta(path string) (piSessionMeta, bool) {
+	file, err := os.Open(path)
+	if err != nil {
+		return piSessionMeta{}, false
+	}
+	defer func() { _ = file.Close() }()
+	reader := bufio.NewReader(io.LimitReader(file, 64<<10))
+	line, err := reader.ReadBytes('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return piSessionMeta{}, false
+	}
+	var meta piSessionMeta
+	if json.Unmarshal(bytes.TrimSpace(line), &meta) != nil || meta.Type != "session" ||
+		!nativeUsageIDPattern.MatchString(meta.ID) || !filepath.IsAbs(meta.CWD) {
+		return piSessionMeta{}, false
+	}
+	return meta, true
+}
+
+func (c *Collector) discoverPiPath(ctx context.Context, nativeID string) (string, error) {
+	paths, err := newestPiPaths(ctx, c.roots.PiSessions, 256)
+	if err != nil {
+		return "", err
+	}
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if meta, ok := readPiSessionMeta(path); ok && meta.ID == nativeID {
+			return path, nil
+		}
+	}
+	return "", nil
+}
+
+func newestPiPaths(ctx context.Context, root string, limit int) ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(root, "*", "*.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	type candidate struct {
+		path string
+		mod  time.Time
+	}
+	candidates := make([]candidate, 0, len(paths))
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() {
+			candidates = append(candidates, candidate{path: path, mod: info.ModTime()})
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].mod.Equal(candidates[j].mod) {
+			return candidates[i].path > candidates[j].path
+		}
+		return candidates[i].mod.After(candidates[j].mod)
+	})
+	if limit > 0 && len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	result := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, candidate.path)
+	}
+	return result, nil
+}
+
+func qwenUsageFilename(name string) bool {
+	if !strings.HasPrefix(name, "token-usage-") || !strings.HasSuffix(name, ".jsonl") {
+		return false
+	}
+	month := strings.TrimSuffix(strings.TrimPrefix(name, "token-usage-"), ".jsonl")
+	if len(month) != 7 || month[4] != '-' {
+		return false
+	}
+	_, err := time.Parse("2006-01", month)
+	return err == nil
+}
+
+func (c *Collector) discoverQwenPath(ctx context.Context) (string, error) {
+	paths, err := filepath.Glob(filepath.Join(c.roots.QwenUsage, "token-usage-*.jsonl"))
+	if err != nil {
+		return "", err
+	}
+	valid := paths[:0]
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if !qwenUsageFilename(filepath.Base(path)) {
+			continue
+		}
+		if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() {
+			valid = append(valid, path)
+		}
+	}
+	sort.Slice(valid, func(i, j int) bool {
+		return filepath.Base(valid[i]) > filepath.Base(valid[j])
+	})
+	if len(valid) == 0 {
+		return "", nil
+	}
+	return valid[0], nil
 }
 
 func (c *Collector) discoverCodexPath(ctx context.Context, nativeID, parentID string) (string, error) {

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -265,7 +265,7 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 		}
 	}
 	if signal.NativeSessionID != "" && mainPath == "" &&
-		(session.Harness == domain.HarnessCodex || finalizing && !existsForDiscovery) {
+		(session.Harness != domain.HarnessClaudeCode || finalizing && !existsForDiscovery) {
 		mainPath, err = c.discoverPath(ctx, session.Harness, signal.NativeSessionID)
 		if err != nil {
 			return err
@@ -593,8 +593,10 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
-		return err
+	} else if session.Harness == domain.HarnessCodex {
+		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
 	}
 	if state == domain.UsageBindingFinalizing {
 		return c.settleFinalizingBinding(ctx, binding.ID, now)
@@ -842,8 +844,10 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
-		return err
+	} else if binding.Harness == domain.HarnessCodex {
+		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
 	}
 	lastErrorCode := ""
 	if binding.Harness == domain.HarnessCodex &&
@@ -1669,6 +1673,12 @@ func validateSourceAttribution(
 			filepath.Base(resolved) != "agent-"+subagentID+".jsonl" {
 			return rejected()
 		}
+	case domain.UsageSourceCopilotShutdown:
+		if binding.Harness != domain.HarnessCopilot || nativeSessionID != binding.NativeRootID ||
+			filepath.Base(filepath.Dir(resolved)) != binding.NativeRootID ||
+			filepath.Base(resolved) != "events.jsonl" {
+			return rejected()
+		}
 	default:
 		return rejected()
 	}
@@ -1736,6 +1746,8 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		patterns = []string{filepath.Join(c.roots.ClaudeProjects, "*", nativeID+".jsonl")}
 	case domain.HarnessCodex:
 		return c.discoverCodexPath(ctx, nativeID, "")
+	case domain.HarnessCopilot:
+		patterns = []string{filepath.Join(c.roots.CopilotSessions, nativeID, "events.jsonl")}
 	}
 	type candidate struct {
 		path string

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -57,14 +57,18 @@ type HookSignal struct {
 // SourceRoots are the provider-owned directories from which AO may read usage
 // transcripts.
 type SourceRoots struct {
-	ClaudeProjects string
-	CodexSessions  string
-	CodexArchived  string
+	ClaudeProjects  string
+	CodexSessions   string
+	CodexArchived   string
+	CopilotSessions string
+	KimiHome        string
+	PiSessions      string
+	QwenUsage       string
 }
 
-// DefaultSourceRoots resolves the native Claude Code and Codex transcript
-// directories for the current user.
-func DefaultSourceRoots(ctx context.Context) (SourceRoots, error) {
+// DefaultSourceRoots resolves the native transcript and usage directories for
+// the current user. dataDir is AO's already-resolved durable data directory.
+func DefaultSourceRoots(ctx context.Context, dataDir string) (SourceRoots, error) {
 	if err := ctx.Err(); err != nil {
 		return SourceRoots{}, err
 	}
@@ -76,10 +80,21 @@ func DefaultSourceRoots(ctx context.Context) (SourceRoots, error) {
 	if codexHome == "" {
 		codexHome = filepath.Join(home, ".codex")
 	}
+	piHome := strings.TrimSpace(os.Getenv("PI_CODING_AGENT_DIR"))
+	if piHome == "" {
+		piHome = filepath.Join(home, ".pi", "agent")
+	}
+	if strings.TrimSpace(dataDir) == "" {
+		dataDir = filepath.Join(home, ".ao", "data")
+	}
 	return SourceRoots{
-		ClaudeProjects: filepath.Join(home, ".claude", "projects"),
-		CodexSessions:  filepath.Join(codexHome, "sessions"),
-		CodexArchived:  filepath.Join(codexHome, "archived_sessions"),
+		ClaudeProjects:  filepath.Join(home, ".claude", "projects"),
+		CodexSessions:   filepath.Join(codexHome, "sessions"),
+		CodexArchived:   filepath.Join(codexHome, "archived_sessions"),
+		CopilotSessions: filepath.Join(home, ".copilot", "session-state"),
+		KimiHome:        filepath.Join(dataDir, "kimi"),
+		PiSessions:      filepath.Join(piHome, "sessions"),
+		QwenUsage:       filepath.Join(home, ".qwen", "usage"),
 	}, nil
 }
 
@@ -331,9 +346,9 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 	}
 
 	if mainArtifact != nil {
-		kind := domain.UsageSourceClaudeMain
-		if session.Harness == domain.HarnessCodex {
-			kind = domain.UsageSourceCodexRollout
+		kind, supported := sourceKindForHarness(session.Harness)
+		if !supported {
+			return nil
 		}
 		changed, err := c.registerHookSource(
 			ctx,
@@ -567,9 +582,9 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 		return nil
 	}
 
-	kind := domain.UsageSourceClaudeMain
-	if session.Harness == domain.HarnessCodex {
-		kind = domain.UsageSourceCodexRollout
+	kind, supported := sourceKindForHarness(session.Harness)
+	if !supported {
+		return nil
 	}
 	if _, err := c.registerSource(ctx, binding, kind, nativeID, "", path, now, false); err != nil {
 		return err
@@ -816,9 +831,9 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 		targetState = domain.UsageBindingActive
 	}
 
-	kind := domain.UsageSourceClaudeMain
-	if binding.Harness == domain.HarnessCodex {
-		kind = domain.UsageSourceCodexRollout
+	kind, supported := sourceKindForHarness(binding.Harness)
+	if !supported {
+		return nil
 	}
 	if _, err := c.registerSource(ctx, binding, kind, binding.NativeRootID, "", path, now, false); err != nil {
 		return err
@@ -1666,6 +1681,14 @@ func (c *Collector) allowedRoots(harness domain.AgentHarness) []string {
 		return []string{c.roots.ClaudeProjects}
 	case domain.HarnessCodex:
 		return []string{c.roots.CodexSessions, c.roots.CodexArchived}
+	case domain.HarnessCopilot:
+		return []string{c.roots.CopilotSessions}
+	case domain.HarnessKimi:
+		return []string{c.roots.KimiHome}
+	case domain.HarnessPi:
+		return []string{c.roots.PiSessions}
+	case domain.HarnessQwen:
+		return []string{c.roots.QwenUsage}
 	default:
 		return nil
 	}

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -1684,6 +1685,66 @@ func TestDiscoverCodexPathRequiresConfiguredRoots(t *testing.T) {
 	if got != "" {
 		t.Fatalf("unconfigured Codex roots discovered %q", got)
 	}
+}
+
+// TestDefaultSourceRootsIncludesFileBackedAgents catches launching the daemon
+// without watching a provider's actual durable usage directory.
+func TestDefaultSourceRootsIncludesFileBackedAgents(t *testing.T) {
+	home := t.TempDir()
+	dataDir := filepath.Join(home, ".ao", "data")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+
+	got, err := DefaultSourceRoots(context.Background(), dataDir)
+	mustNoError(t, err)
+	want := SourceRoots{
+		ClaudeProjects:  filepath.Join(home, ".claude", "projects"),
+		CodexSessions:   filepath.Join(home, ".codex", "sessions"),
+		CodexArchived:   filepath.Join(home, ".codex", "archived_sessions"),
+		CopilotSessions: filepath.Join(home, ".copilot", "session-state"),
+		KimiHome:        filepath.Join(dataDir, "kimi"),
+		PiSessions:      filepath.Join(home, ".pi", "agent", "sessions"),
+		QwenUsage:       filepath.Join(home, ".qwen", "usage"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("roots = %+v, want %+v", got, want)
+	}
+}
+
+func TestValidateSourcePathAcceptsOnlyMatchingProviderRoot(t *testing.T) {
+	root := t.TempDir()
+	files := map[domain.AgentHarness]string{
+		domain.HarnessCopilot: filepath.Join(root, "copilot", "native", "events.jsonl"),
+		domain.HarnessKimi:    filepath.Join(root, "kimi", "sessions", "native", "agents", "main", "wire.jsonl"),
+		domain.HarnessPi:      filepath.Join(root, "pi", "worktree", "session.jsonl"),
+		domain.HarnessQwen:    filepath.Join(root, "qwen", "token-usage-2026-08.jsonl"),
+	}
+	for _, path := range files {
+		writeUsageFixture(t, path, "{}\n")
+	}
+	collector := NewCollector(collectorTestStore(t), SourceRoots{
+		CopilotSessions: filepath.Join(root, "copilot"),
+		KimiHome:        filepath.Join(root, "kimi"),
+		PiSessions:      filepath.Join(root, "pi"),
+		QwenUsage:       filepath.Join(root, "qwen"),
+	}, nil)
+
+	for harness, path := range files {
+		if _, _, _, err := collector.validateSourcePath(context.Background(), harness, path); err != nil {
+			t.Errorf("validate %s path: %v", harness, err)
+		}
+		if _, _, _, err := collector.validateSourcePath(context.Background(), harness, files[differentHarness(harness)]); err == nil {
+			t.Errorf("%s accepted another provider's root", harness)
+		}
+	}
+}
+
+func differentHarness(harness domain.AgentHarness) domain.AgentHarness {
+	if harness == domain.HarnessCopilot {
+		return domain.HarnessKimi
+	}
+	return domain.HarnessCopilot
 }
 
 func TestDiscoverClaudePathRejectsGlobMetadata(t *testing.T) {

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1740,6 +1740,45 @@ func TestValidateSourcePathAcceptsOnlyMatchingProviderRoot(t *testing.T) {
 	}
 }
 
+// TestCollectorDiscoversCopilotShutdownSource catches accepting the native
+// Copilot hook ID without binding its per-session events file.
+func TestCollectorDiscoversCopilotShutdownSource(t *testing.T) {
+	const nativeID = "11111111-1111-4111-8111-111111111111"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCopilot, nativeID, false)
+	root := filepath.Join(t.TempDir(), "session-state")
+	path := filepath.Join(root, nativeID, "events.jsonl")
+	writeUsageFixture(t, path, `{"type":"session.shutdown","data":{"modelMetrics":{}}}`+"\n")
+	collector := NewCollector(store, SourceRoots{CopilotSessions: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness:         domain.HarnessCopilot,
+		Event:           "session-start",
+		NativeSessionID: nativeID,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings = %+v, err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 {
+		t.Fatalf("sources = %+v, err=%v", sources, err)
+	}
+	if sources[0].Kind != domain.UsageSourceCopilotShutdown || sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("source = %+v", sources[0])
+	}
+}
+
+func TestCollectorRejectsCopilotSourceForDifferentNativeSession(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "session-state")
+	path := filepath.Join(root, "other-native", "events.jsonl")
+	writeUsageFixture(t, path, "{}\n")
+	binding := domain.UsageBindingRecord{Harness: domain.HarnessCopilot, NativeRootID: "bound-native"}
+	if err := validateSourceAttribution(binding, domain.UsageSourceCopilotShutdown, "bound-native", "", canonicalUsagePath(t, path), ""); err == nil {
+		t.Fatal("accepted Copilot events file from a different native session")
+	}
+}
+
 func differentHarness(harness domain.AgentHarness) domain.AgentHarness {
 	if harness == domain.HarnessCopilot {
 		return domain.HarnessKimi

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1,12 +1,14 @@
 package usage
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1804,6 +1806,110 @@ func TestCollectorRejectsCopilotSourceForDifferentNativeSession(t *testing.T) {
 	binding := domain.UsageBindingRecord{Harness: domain.HarnessCopilot, NativeRootID: "bound-native"}
 	if err := validateSourceAttribution(binding, domain.UsageSourceCopilotShutdown, "bound-native", "", canonicalUsagePath(t, path), ""); err == nil {
 		t.Fatal("accepted Copilot events file from a different native session")
+	}
+}
+
+func TestCollectorDiscoversKimiWireSourcesFromSessionIndex(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessKimi, nativeID, false)
+	home := t.TempDir()
+	sessionDir := filepath.Join(home, "sessions", "wd_agent-orchestrator-379_1f71c05c08c2", nativeID)
+	mainPath := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
+	childPath := filepath.Join(sessionDir, "agents", "researcher", "wire.jsonl")
+	writeUsageFixture(t, mainPath, "{}\n")
+	writeUsageFixture(t, childPath, "{}\n")
+	writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"),
+		fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q,"workDir":"/repo"}`+"\n", nativeID, sessionDir))
+	collector := NewCollector(store, SourceRoots{KimiHome: home}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessKimi, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+	gotSubagents := []string{sources[0].SubagentID, sources[1].SubagentID}
+	slices.Sort(gotSubagents)
+	if !reflect.DeepEqual(gotSubagents, []string{"", "researcher"}) {
+		t.Fatalf("subagent IDs = %v", gotSubagents)
+	}
+}
+
+func TestCollectorKimiIndexRejectsDeletedAndEscapingSessions(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	tests := []struct {
+		name    string
+		records func(home string) string
+	}{
+		{
+			name: "last record deletes session",
+			records: func(home string) string {
+				dir := filepath.Join(home, "sessions", nativeID)
+				return fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n"+`{"sessionId":%q,"deleted":true}`+"\n", nativeID, dir, nativeID)
+			},
+		},
+		{
+			name: "session directory escapes root",
+			records: func(home string) string {
+				dir := filepath.Join(filepath.Dir(home), nativeID)
+				return fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n", nativeID, dir)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			escapingDir := filepath.Join(filepath.Dir(home), nativeID)
+			t.Cleanup(func() { _ = os.RemoveAll(escapingDir) })
+			writeUsageFixture(t, filepath.Join(home, "sessions", nativeID, "agents", "main", "wire.jsonl"), "{}\n")
+			writeUsageFixture(t, filepath.Join(escapingDir, "agents", "main", "wire.jsonl"), "{}\n")
+			writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"), tc.records(home))
+			collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+			path, err := collector.discoverPath(context.Background(), domain.HarnessKimi, nativeID)
+			mustNoError(t, err)
+			if path != "" {
+				t.Fatalf("discovered rejected session path %q", path)
+			}
+		})
+	}
+}
+
+func TestCollectorKimiIndexReplaysRecordsBeyondEightMiB(t *testing.T) {
+	const nativeID = "kimi-late-session"
+	home := t.TempDir()
+	sessionDir := filepath.Join(home, "sessions", nativeID)
+	wire := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
+	writeUsageFixture(t, wire, "{}\n")
+	fillerLine := []byte(`{"sessionId":"unrelated","deleted":true}` + "\n")
+	filler := bytes.Repeat(fillerLine, (8<<20)/len(fillerLine)+1)
+	late := []byte(fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n", nativeID, sessionDir))
+	writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"), string(append(filler, late...)))
+	collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+
+	path, err := collector.discoverPath(context.Background(), domain.HarnessKimi, nativeID)
+	mustNoError(t, err)
+	if path != wire {
+		t.Fatalf("discovered %q, want late-index wire %q", path, wire)
+	}
+}
+
+func TestCollectorRejectsKimiWireOutsideCanonicalSessionsDirectory(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	home := t.TempDir()
+	path := filepath.Join(home, "attacker", "sessions", nativeID, "agents", "main", "wire.jsonl")
+	writeUsageFixture(t, path, "{}\n")
+	binding := domain.UsageBindingRecord{Harness: domain.HarnessKimi, NativeRootID: nativeID}
+	collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+	if err := collector.validateSourceAttribution(
+		binding, domain.UsageSourceKimiWire, nativeID, "", canonicalUsagePath(t, path), "",
+	); err == nil {
+		t.Fatal("accepted Kimi wire outside <KimiHome>/sessions/<native-id>")
 	}
 }
 

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1769,6 +1769,34 @@ func TestCollectorDiscoversCopilotShutdownSource(t *testing.T) {
 	}
 }
 
+func TestCollectorRetriesCopilotSourceCreatedAfterSessionStart(t *testing.T) {
+	const nativeID = "11111111-1111-4111-8111-111111111111"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCopilot, nativeID, false)
+	root := filepath.Join(t.TempDir(), "session-state")
+	collector := NewCollector(store, SourceRoots{CopilotSessions: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessCopilot, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	pending, err := store.HasPendingUsageDiscovery(context.Background())
+	if err != nil || !pending {
+		t.Fatalf("pending=%v err=%v, want durable discovery retry", pending, err)
+	}
+	path := filepath.Join(root, nativeID, "events.jsonl")
+	writeUsageFixture(t, path, `{"type":"session.shutdown","data":{"modelMetrics":{}}}`+"\n")
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
 func TestCollectorRejectsCopilotSourceForDifferentNativeSession(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "session-state")
 	path := filepath.Join(root, "other-native", "events.jsonl")

--- a/backend/internal/service/usage/source_profile.go
+++ b/backend/internal/service/usage/source_profile.go
@@ -1,0 +1,24 @@
+package usage
+
+import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
+// sourceKindForHarness returns the root usage artifact shape for a harness.
+// Claude and Codex may register additional child sources after the root.
+func sourceKindForHarness(h domain.AgentHarness) (domain.UsageSourceKind, bool) {
+	switch h {
+	case domain.HarnessClaudeCode:
+		return domain.UsageSourceClaudeMain, true
+	case domain.HarnessCodex:
+		return domain.UsageSourceCodexRollout, true
+	case domain.HarnessCopilot:
+		return domain.UsageSourceCopilotShutdown, true
+	case domain.HarnessKimi:
+		return domain.UsageSourceKimiWire, true
+	case domain.HarnessPi:
+		return domain.UsageSourcePiSession, true
+	case domain.HarnessQwen:
+		return domain.UsageSourceQwenMonthly, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/service/usage/summary.go
+++ b/backend/internal/service/usage/summary.go
@@ -55,8 +55,11 @@ func (r *SummaryReader) Get(ctx context.Context, sessionID domain.SessionID) (do
 }
 
 func usageTotals(models []domain.UsageModelAggregate) domain.UsageMetricTotals {
+	if len(models) == 0 {
+		return domain.UsageMetricTotals{}
+	}
 	var input, uncached, cacheRead, cacheWrite, output, reasoning, reasoningEvents int64
-	var uncachedAvailable, cacheReadAvailable, cacheWriteAvailable, reasoningAvailable bool
+	uncachedAvailable, cacheReadAvailable, cacheWriteAvailable, reasoningAvailable := true, true, true, true
 	for _, model := range models {
 		coverage := MetricCoverage(model.Harness)
 		input += model.Tokens.InputTokens
@@ -64,17 +67,14 @@ func usageTotals(models []domain.UsageModelAggregate) domain.UsageMetricTotals {
 		cacheRead += model.Tokens.CacheReadTokens
 		cacheWrite += model.Tokens.CacheWriteTokens
 		output += model.Tokens.OutputTokens
-		uncachedAvailable = uncachedAvailable || coverage.UncachedInput
-		cacheReadAvailable = cacheReadAvailable || coverage.CacheRead
-		cacheWriteAvailable = cacheWriteAvailable || coverage.CacheWrite
-		reasoningAvailable = reasoningAvailable || coverage.Reasoning
+		uncachedAvailable = uncachedAvailable && coverage.UncachedInput
+		cacheReadAvailable = cacheReadAvailable && coverage.CacheRead
+		cacheWriteAvailable = cacheWriteAvailable && coverage.CacheWrite
+		reasoningAvailable = reasoningAvailable && coverage.Reasoning
 		if model.Tokens.ReasoningTokens != nil {
 			reasoning += *model.Tokens.ReasoningTokens
 		}
 		reasoningEvents += model.ReasoningEventCount
-	}
-	if len(models) == 0 {
-		return domain.UsageMetricTotals{}
 	}
 	totals := domain.UsageMetricTotals{
 		InputTokens: &input, OutputTokens: &output,

--- a/backend/internal/service/usage/summary.go
+++ b/backend/internal/service/usage/summary.go
@@ -56,12 +56,18 @@ func (r *SummaryReader) Get(ctx context.Context, sessionID domain.SessionID) (do
 
 func usageTotals(models []domain.UsageModelAggregate) domain.UsageMetricTotals {
 	var input, uncached, cacheRead, cacheWrite, output, reasoning, reasoningEvents int64
+	var uncachedAvailable, cacheReadAvailable, cacheWriteAvailable, reasoningAvailable bool
 	for _, model := range models {
+		coverage := MetricCoverage(model.Harness)
 		input += model.Tokens.InputTokens
 		uncached += model.Tokens.UncachedInputTokens
 		cacheRead += model.Tokens.CacheReadTokens
 		cacheWrite += model.Tokens.CacheWriteTokens
 		output += model.Tokens.OutputTokens
+		uncachedAvailable = uncachedAvailable || coverage.UncachedInput
+		cacheReadAvailable = cacheReadAvailable || coverage.CacheRead
+		cacheWriteAvailable = cacheWriteAvailable || coverage.CacheWrite
+		reasoningAvailable = reasoningAvailable || coverage.Reasoning
 		if model.Tokens.ReasoningTokens != nil {
 			reasoning += *model.Tokens.ReasoningTokens
 		}
@@ -71,10 +77,18 @@ func usageTotals(models []domain.UsageModelAggregate) domain.UsageMetricTotals {
 		return domain.UsageMetricTotals{}
 	}
 	totals := domain.UsageMetricTotals{
-		InputTokens: &input, UncachedInputTokens: &uncached, CacheReadTokens: &cacheRead,
-		CacheWriteTokens: &cacheWrite, OutputTokens: &output,
+		InputTokens: &input, OutputTokens: &output,
 	}
-	if reasoningEvents > 0 {
+	if uncachedAvailable {
+		totals.UncachedInputTokens = &uncached
+	}
+	if cacheReadAvailable {
+		totals.CacheReadTokens = &cacheRead
+	}
+	if cacheWriteAvailable {
+		totals.CacheWriteTokens = &cacheWrite
+	}
+	if reasoningAvailable && reasoningEvents > 0 {
 		totals.ReasoningTokens = &reasoning
 	}
 	return totals

--- a/backend/internal/service/usage/summary_test.go
+++ b/backend/internal/service/usage/summary_test.go
@@ -76,7 +76,7 @@ func TestSummaryReaderGetAggregatesModelsAndIntegrity(t *testing.T) {
 	}
 	if got.Totals.InputTokens == nil || *got.Totals.InputTokens != 1100 ||
 		got.Totals.OutputTokens == nil || *got.Totals.OutputTokens != 225 ||
-		got.Totals.ReasoningTokens == nil || *got.Totals.ReasoningTokens != 40 {
+		got.Totals.ReasoningTokens != nil {
 		t.Fatalf("totals = %+v", got.Totals)
 	}
 	if len(got.Harnesses) != 2 || got.Harnesses[0].Models[0].ModelID != "gpt-5.6" {
@@ -127,6 +127,9 @@ func TestSummaryReaderGetAppliesHarnessMetricCoverage(t *testing.T) {
 	mustNoError(t, err)
 	if len(got.Harnesses) != 2 {
 		t.Fatalf("harnesses = %+v", got.Harnesses)
+	}
+	if got.Totals.CacheWriteTokens != nil || got.Totals.ReasoningTokens != nil {
+		t.Fatalf("mixed-harness totals expose partial metrics = %+v", got.Totals)
 	}
 	qwen := got.Harnesses[0].Totals
 	if qwen.CacheWriteTokens != nil {

--- a/backend/internal/service/usage/summary_test.go
+++ b/backend/internal/service/usage/summary_test.go
@@ -95,3 +95,51 @@ func TestSummaryReaderGetReturnsUnavailableMetricsWithoutEvents(t *testing.T) {
 		t.Fatalf("empty usage = %+v", got)
 	}
 }
+
+// TestSummaryReaderGetAppliesHarnessMetricCoverage catches treating a metric
+// the native source never reports as a real zero. Native zeroes for supported
+// metrics must remain distinguishable from unavailable metrics.
+func TestSummaryReaderGetAppliesHarnessMetricCoverage(t *testing.T) {
+	zero := int64(0)
+	store := &usageSummaryStoreStub{
+		found:   true,
+		session: domain.SessionRecord{ID: "coverage", Harness: domain.HarnessQwen},
+		models: []domain.UsageModelAggregate{
+			{
+				Harness: domain.HarnessQwen, ModelID: "qwen3-coder",
+				Tokens: domain.UsageTokenMetrics{
+					InputTokens: 10, UncachedInputTokens: 4, CacheReadTokens: 6,
+					OutputTokens: 2, ReasoningTokens: &zero,
+				},
+				ReasoningEventCount: 1,
+			},
+			{
+				Harness: domain.HarnessKimi, ModelID: "kimi-for-coding",
+				Tokens: domain.UsageTokenMetrics{
+					InputTokens: 8, UncachedInputTokens: 3, CacheReadTokens: 4,
+					CacheWriteTokens: 1, OutputTokens: 2,
+				},
+			},
+		},
+	}
+
+	got, err := NewSummaryReader(store).Get(context.Background(), "coverage")
+	mustNoError(t, err)
+	if len(got.Harnesses) != 2 {
+		t.Fatalf("harnesses = %+v", got.Harnesses)
+	}
+	qwen := got.Harnesses[0].Totals
+	if qwen.CacheWriteTokens != nil {
+		t.Fatalf("qwen cache write = %v, want unavailable", *qwen.CacheWriteTokens)
+	}
+	if qwen.ReasoningTokens == nil || *qwen.ReasoningTokens != 0 {
+		t.Fatalf("qwen reasoning = %v, want reported zero", qwen.ReasoningTokens)
+	}
+	kimi := got.Harnesses[1].Totals
+	if kimi.CacheWriteTokens == nil || *kimi.CacheWriteTokens != 1 {
+		t.Fatalf("kimi cache write = %v, want 1", kimi.CacheWriteTokens)
+	}
+	if kimi.ReasoningTokens != nil {
+		t.Fatalf("kimi reasoning = %v, want unavailable", *kimi.ReasoningTokens)
+	}
+}

--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -931,6 +931,253 @@ func reconcileSchema(db *sql.DB) error {
 	if err := reconcileHarnessConstraint(db); err != nil {
 		return err
 	}
+	if err := reconcileUsageSchema(db); err != nil {
+		return err
+	}
+	return nil
+}
+
+func reconcileUsageSchema(db *sql.DB) error {
+	var usageBindings int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'usage_bindings'`,
+	).Scan(&usageBindings); err != nil {
+		return fmt.Errorf("schema verification: inspect usage_bindings table: %w", err)
+	}
+	if usageBindings == 0 {
+		return nil
+	}
+
+	checks := []struct {
+		kind string
+		name string
+	}{
+		{kind: "table", name: "usage_sources"},
+		{kind: "table", name: "model_usage_events"},
+		{kind: "view", name: "usage_codex_source_discovery"},
+		{kind: "view", name: "usage_codex_pending_children"},
+		{kind: "view", name: "usage_session_integrity"},
+	}
+	needsRepair := false
+	for _, check := range checks {
+		var count int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master WHERE type = ? AND name = ?`, check.kind, check.name,
+		).Scan(&count); err != nil {
+			return fmt.Errorf("schema verification: inspect %s %s: %w", check.kind, check.name, err)
+		}
+		if count == 0 {
+			needsRepair = true
+			break
+		}
+	}
+	if !needsRepair {
+		var parserState int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('usage_sources') WHERE name = 'parser_state_json'`,
+		).Scan(&parserState); err != nil {
+			return fmt.Errorf("schema verification: inspect usage_sources.parser_state_json: %w", err)
+		}
+		needsRepair = parserState == 0
+	}
+	if !needsRepair {
+		return nil
+	}
+
+	var parserState int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('usage_sources') WHERE name = 'parser_state_json'`,
+	).Scan(&parserState); err != nil {
+		return fmt.Errorf("schema verification: inspect usage_sources.parser_state_json before repair: %w", err)
+	}
+	parserStateExpr := `'{}'`
+	if parserState > 0 {
+		parserStateExpr = "parser_state_json"
+	}
+
+	_, err := db.Exec(fmt.Sprintf(`
+PRAGMA foreign_keys=OFF;
+BEGIN IMMEDIATE;
+
+DROP VIEW IF EXISTS usage_session_integrity;
+DROP VIEW IF EXISTS usage_codex_pending_children;
+DROP VIEW IF EXISTS usage_codex_source_discovery;
+DROP TRIGGER IF EXISTS model_usage_events_cdc_insert;
+DROP TRIGGER IF EXISTS usage_sources_cdc_update;
+DROP TRIGGER IF EXISTS usage_sources_cdc_insert;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
+
+CREATE TABLE usage_bindings_next (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')),
+    native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id   TEXT NOT NULL DEFAULT '',
+    state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code    TEXT NOT NULL DEFAULT '',
+    updated_at         TIMESTAMP NOT NULL,
+    UNIQUE (session_id, harness, native_root_id)
+);
+
+CREATE TABLE usage_sources_next (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind                TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout', 'copilot_shutdown', 'kimi_wire', 'pi_session', 'qwen_monthly')),
+    native_session_id   TEXT NOT NULL DEFAULT '',
+    subagent_id         TEXT NOT NULL DEFAULT '',
+    artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity       TEXT NOT NULL DEFAULT '',
+    generation          INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset         INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    parser_state_json   TEXT NOT NULL DEFAULT '{}',
+    state               TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count       INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count       INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at       TIMESTAMP,
+    last_error_code     TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+
+CREATE TABLE model_usage_events_next (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id              INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    usage_source_id         INTEGER NOT NULL REFERENCES usage_sources (id) ON DELETE CASCADE,
+    model_id                TEXT NOT NULL CHECK (trim(model_id) <> ''),
+    input_tokens            INTEGER NOT NULL CHECK (input_tokens >= 0),
+    uncached_input_tokens   INTEGER NOT NULL CHECK (uncached_input_tokens >= 0 AND uncached_input_tokens <= input_tokens),
+    cache_read_tokens       INTEGER NOT NULL CHECK (cache_read_tokens >= 0 AND cache_read_tokens <= input_tokens),
+    cache_write_tokens      INTEGER NOT NULL CHECK (cache_write_tokens >= 0 AND cache_write_tokens <= input_tokens),
+    output_tokens           INTEGER NOT NULL CHECK (output_tokens >= 0),
+    reasoning_tokens        INTEGER CHECK (reasoning_tokens IS NULL OR (reasoning_tokens >= 0 AND reasoning_tokens <= output_tokens)),
+    source_event_key        TEXT NOT NULL CHECK (trim(source_event_key) <> ''),
+    UNIQUE (binding_id, source_event_key)
+);
+
+INSERT INTO usage_bindings_next
+SELECT id, session_id, harness, native_root_id, initial_model_id, state,
+       last_error_code, updated_at
+FROM usage_bindings;
+
+INSERT INTO usage_sources_next
+SELECT id, binding_id, kind, native_session_id, subagent_id, artifact_path,
+       file_identity, generation, byte_offset, %s,
+       state, failure_count, anomaly_count, next_retry_at, last_error_code, updated_at
+FROM usage_sources;
+
+INSERT INTO model_usage_events_next
+SELECT id, binding_id, usage_source_id, model_id, input_tokens,
+       uncached_input_tokens, cache_read_tokens, cache_write_tokens,
+       output_tokens, reasoning_tokens, source_event_key
+FROM model_usage_events;
+
+DROP TABLE model_usage_events;
+DROP TABLE usage_sources;
+DROP TABLE usage_bindings;
+ALTER TABLE usage_bindings_next RENAME TO usage_bindings;
+ALTER TABLE usage_sources_next RENAME TO usage_sources;
+ALTER TABLE model_usage_events_next RENAME TO model_usage_events;
+
+CREATE INDEX IF NOT EXISTS idx_usage_bindings_session_state ON usage_bindings (session_id, state);
+CREATE INDEX IF NOT EXISTS idx_usage_sources_state_retry ON usage_sources (state, next_retry_at);
+CREATE INDEX IF NOT EXISTS idx_usage_sources_binding_kind ON usage_sources (binding_id, kind);
+CREATE INDEX IF NOT EXISTS idx_usage_sources_codex_native_latest
+    ON usage_sources (kind, native_session_id, binding_id, generation DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_binding_model ON model_usage_events (binding_id, model_id);
+CREATE INDEX IF NOT EXISTS idx_model_usage_events_usage_source ON model_usage_events (usage_source_id);
+
+CREATE VIEW usage_codex_source_discovery AS
+SELECT source_id, binding_id, native_session_id,
+    CASE WHEN child_ids_json IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM json_each(child_ids_json) WHERE type <> 'text'
+    ) THEN child_ids_json ELSE '[]' END AS discovered_child_ids_json,
+    CASE WHEN child_ids_json IS NOT NULL AND EXISTS (
+        SELECT 1 FROM json_each(child_ids_json) WHERE type <> 'text'
+    ) THEN 1 ELSE 0 END AS has_mixed_child_types
+FROM (
+    SELECT id AS source_id, binding_id, native_session_id,
+        CASE WHEN json_valid(parser_state_json)
+          AND json_type(parser_state_json, '$') = 'object'
+          AND json_type(parser_state_json, '$.version') = 'integer'
+          AND json_extract(parser_state_json, '$.version') = 1
+          AND json_type(parser_state_json, '$.source_kind') = 'text'
+          AND json_extract(parser_state_json, '$.source_kind') = 'codex_rollout'
+          AND json_type(parser_state_json, '$.codex') = 'object'
+          AND json_type(parser_state_json, '$.codex.discovered_child_ids') = 'array'
+        THEN json_extract(parser_state_json, '$.codex.discovered_child_ids') END AS child_ids_json
+    FROM usage_sources WHERE kind = 'codex_rollout'
+);
+
+CREATE VIEW usage_codex_pending_children AS
+SELECT spawning.binding_id, CAST(discovered.value AS TEXT) AS native_session_id
+FROM usage_codex_source_discovery spawning
+JOIN json_each(spawning.discovered_child_ids_json) discovered
+WHERE discovered.type = 'text'
+  AND length(discovered.value) = 36
+  AND substr(discovered.value, 9, 1) = '-'
+  AND substr(discovered.value, 14, 1) = '-'
+  AND substr(discovered.value, 19, 1) = '-'
+  AND substr(discovered.value, 24, 1) = '-'
+  AND lower(discovered.value) = discovered.value
+  AND length(replace(discovered.value, '-', '')) = 32
+  AND replace(discovered.value, '-', '') NOT GLOB '*[^0-9a-f]*'
+  AND spawning.source_id = (
+      SELECT latest.id FROM usage_sources latest
+      WHERE latest.binding_id = spawning.binding_id
+        AND latest.kind = 'codex_rollout'
+        AND latest.native_session_id = spawning.native_session_id
+      ORDER BY latest.generation DESC, latest.id DESC LIMIT 1
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM usage_sources registered
+      WHERE registered.binding_id = spawning.binding_id
+        AND registered.kind = 'codex_rollout'
+        AND registered.native_session_id = CAST(discovered.value AS TEXT)
+  );
+
+CREATE VIEW usage_session_integrity AS
+SELECT ub.session_id,
+    CAST(MAX(CASE
+        WHEN ub.state = 'partial'
+          OR ub.last_error_code NOT IN ('', 'source_discovery_pending', 'artifact_missing', 'source_read_failed')
+          OR (us.last_error_code <> 'artifact_replaced' AND (
+              us.anomaly_count > 0
+              OR us.last_error_code NOT IN ('', 'source_discovery_pending', 'artifact_missing', 'source_read_failed')
+          ))
+        THEN 1 ELSE 0
+    END) AS INTEGER) AS incomplete
+FROM usage_bindings ub
+LEFT JOIN usage_sources us ON us.binding_id = ub.id
+GROUP BY ub.session_id;
+
+CREATE TRIGGER usage_bindings_cdc_insert AFTER INSERT ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+CREATE TRIGGER usage_bindings_cdc_update AFTER UPDATE ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+CREATE TRIGGER usage_sources_cdc_update AFTER UPDATE ON usage_sources
+WHEN OLD.anomaly_count IS NOT NEW.anomaly_count
+  OR OLD.last_error_code IS NOT NEW.last_error_code
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, ub.session_id, 'session_updated', json_object('id', ub.session_id), NEW.updated_at
+    FROM usage_bindings ub JOIN sessions s ON s.id = ub.session_id WHERE ub.id = NEW.binding_id;
+END;
+
+COMMIT;
+PRAGMA foreign_keys=ON;
+`, parserStateExpr))
+	if err != nil {
+		_, _ = db.Exec(`ROLLBACK`)
+		_, _ = db.Exec(`PRAGMA foreign_keys=ON`)
+		return fmt.Errorf("schema repair: rebuild usage schema: %w", err)
+	}
 	return nil
 }
 

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -377,7 +377,7 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex')
+      AND ub.harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')
       AND (
           ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
@@ -730,13 +730,13 @@ SELECT ub.id, ub.session_id, ub.harness, ub.native_root_id, ub.initial_model_id,
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness = 'claude-code'
+      ub.harness IN ('claude-code', 'copilot', 'kimi', 'pi', 'qwen')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -105,6 +105,7 @@ var shippedMigrations = map[int64]string{
 	99:  "0099_interface_transition_notice_acknowledgement.sql",
 	100: "0100_session_model.sql",
 	101: "0101_conversation_provider_ownership_epochs.sql",
+	102: "0102_multi_agent_usage.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_multi_agent_usage_test.go
+++ b/backend/internal/storage/sqlite/migrate_multi_agent_usage_test.go
@@ -1,0 +1,98 @@
+package sqlite
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// TestMultiAgentUsageMigrationAcceptsCertifiedSourceValues catches a migration
+// that reports success without actually widening the usage CHECK constraints.
+// The production change that makes this fail is dropping any certified harness
+// or source kind from the rebuilt schema.
+func TestMultiAgentUsageMigrationAcceptsCertifiedSourceValues(t *testing.T) {
+	db := openMigratedTestDB(t)
+	now := time.Unix(100, 0).UTC()
+	if _, err := db.Exec(`
+INSERT INTO projects (id, path, registered_at, config)
+VALUES ('usage-project', '/repo/usage-project', ?, '{}');
+`, now); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+
+	tests := []struct {
+		harness domain.AgentHarness
+		kind    domain.UsageSourceKind
+	}{
+		{domain.HarnessCopilot, domain.UsageSourceCopilotShutdown},
+		{domain.HarnessKimi, domain.UsageSourceKimiWire},
+		{domain.HarnessPi, domain.UsageSourcePiSession},
+		{domain.HarnessQwen, domain.UsageSourceQwenMonthly},
+	}
+	for index, test := range tests {
+		sessionID := "usage-session-" + string(rune('a'+index))
+		if _, err := db.Exec(`
+INSERT INTO sessions (id, project_id, num, harness, activity_last_at, created_at, updated_at)
+VALUES (?, 'usage-project', ?, ?, ?, ?, ?)
+`, sessionID, index+1, test.harness, now, now, now); err != nil {
+			t.Fatalf("insert %s session: %v", test.harness, err)
+		}
+		result, err := db.Exec(`
+INSERT INTO usage_bindings
+    (session_id, harness, native_root_id, state, updated_at)
+VALUES (?, ?, ?, 'active', ?)
+`, sessionID, test.harness, "native-"+sessionID, now)
+		if err != nil {
+			t.Fatalf("insert %s binding: %v", test.harness, err)
+		}
+		bindingID, err := result.LastInsertId()
+		if err != nil {
+			t.Fatalf("read %s binding id: %v", test.harness, err)
+		}
+		if _, err := db.Exec(`
+INSERT INTO usage_sources
+    (binding_id, kind, native_session_id, artifact_path, state, updated_at)
+VALUES (?, ?, ?, ?, 'active', ?)
+`, bindingID, test.kind, "native-"+sessionID, "/tmp/"+sessionID+".jsonl", now); err != nil {
+			t.Fatalf("insert %s source %s: %v", test.harness, test.kind, err)
+		}
+	}
+}
+
+func TestMultiAgentUsageMigrationRejectsUnknownValues(t *testing.T) {
+	db := openMigratedTestDB(t)
+	now := time.Unix(100, 0).UTC()
+	if _, err := db.Exec(`
+INSERT INTO projects (id, path, registered_at, config)
+VALUES ('usage-project', '/repo/usage-project', ?, '{}');
+INSERT INTO sessions (id, project_id, num, harness, activity_last_at, created_at, updated_at)
+VALUES ('usage-session', 'usage-project', 1, 'codex', ?, ?, ?);
+INSERT INTO usage_bindings
+    (session_id, harness, native_root_id, state, updated_at)
+VALUES ('usage-session', 'codex', 'native-session', 'active', ?);
+`, now, now, now, now, now); err != nil {
+		t.Fatalf("seed usage binding: %v", err)
+	}
+
+	assertCheckFailure(t, db, `
+INSERT INTO usage_bindings
+    (session_id, harness, native_root_id, state, updated_at)
+VALUES ('usage-session', 'unknown-agent', 'unknown-native', 'active', ?)
+`, now)
+	assertCheckFailure(t, db, `
+INSERT INTO usage_sources
+    (binding_id, kind, native_session_id, artifact_path, state, updated_at)
+VALUES (1, 'unknown_source', 'native-session', '/tmp/unknown.jsonl', 'active', ?)
+`, now)
+}
+
+func assertCheckFailure(t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	_, err := db.Exec(query, args...)
+	if err == nil || !strings.Contains(err.Error(), "CHECK constraint failed") {
+		t.Fatalf("error = %v, want CHECK constraint failure", err)
+	}
+}

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -135,6 +135,124 @@ VALUES (1, 1, 1, 'gpt-test', 120, 100, 20, 0, 30, 'event-1');
 	}
 }
 
+func TestMigrateRepairsAppliedButStaleUsageSchema(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 43)
+
+	if _, err := db.Exec(`
+CREATE TABLE usage_bindings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex')),
+    native_root_id TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id TEXT NOT NULL DEFAULT '',
+    source_cli_version TEXT NOT NULL DEFAULT '',
+    state TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code TEXT NOT NULL DEFAULT '',
+    first_seen_at TIMESTAMP NOT NULL,
+    last_seen_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    UNIQUE (session_id, harness, native_root_id)
+);
+CREATE TABLE usage_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout')),
+    native_session_id TEXT NOT NULL DEFAULT '',
+    subagent_id TEXT NOT NULL DEFAULT '',
+    artifact_path TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity TEXT NOT NULL DEFAULT '',
+    generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    baseline_input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_input_tokens >= 0),
+    baseline_cached_input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_cached_input_tokens >= 0),
+    baseline_cache_write_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_cache_write_tokens >= 0),
+    baseline_output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_output_tokens >= 0),
+    baseline_reasoning_tokens INTEGER NOT NULL DEFAULT 0 CHECK (baseline_reasoning_tokens >= 0),
+    current_model_id TEXT NOT NULL DEFAULT '',
+    current_provider TEXT NOT NULL DEFAULT '',
+    parser_version TEXT NOT NULL CHECK (trim(parser_version) <> ''),
+    state TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at TIMESTAMP,
+    last_error_code TEXT NOT NULL DEFAULT '',
+    last_observed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+CREATE TABLE model_usage_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    usage_source_id INTEGER NOT NULL REFERENCES usage_sources (id) ON DELETE CASCADE,
+    model_id TEXT NOT NULL CHECK (trim(model_id) <> ''),
+    input_tokens INTEGER NOT NULL CHECK (input_tokens >= 0),
+    uncached_input_tokens INTEGER NOT NULL CHECK (uncached_input_tokens >= 0 AND uncached_input_tokens <= input_tokens),
+    cache_read_tokens INTEGER NOT NULL CHECK (cache_read_tokens >= 0 AND cache_read_tokens <= input_tokens),
+    cache_write_tokens INTEGER NOT NULL CHECK (cache_write_tokens >= 0 AND cache_write_tokens <= input_tokens),
+    output_tokens INTEGER NOT NULL CHECK (output_tokens >= 0),
+    reasoning_tokens INTEGER CHECK (reasoning_tokens IS NULL OR (reasoning_tokens >= 0 AND reasoning_tokens <= output_tokens)),
+    source_event_key TEXT NOT NULL CHECK (trim(source_event_key) <> ''),
+    UNIQUE (binding_id, source_event_key)
+);
+INSERT INTO projects (id, path, registered_at, config)
+VALUES ('agent-orchestrator', '/repo/agent-orchestrator', '2026-08-01T00:00:00Z', '{}');
+INSERT INTO sessions (id, project_id, num, harness, activity_last_at, created_at, updated_at)
+VALUES ('agent-orchestrator-1', 'agent-orchestrator', 1, 'codex', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z');
+INSERT INTO usage_bindings
+    (id, session_id, harness, native_root_id, state, first_seen_at, last_seen_at, updated_at)
+VALUES (1, 'agent-orchestrator-1', 'codex', 'native-1', 'active', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z');
+INSERT INTO usage_sources
+    (id, binding_id, kind, native_session_id, artifact_path, parser_version, state, created_at, updated_at)
+VALUES (1, 1, 'codex_rollout', 'native-1', '/tmp/rollout.jsonl', 'legacy', 'active', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z');
+INSERT INTO model_usage_events
+    (id, binding_id, usage_source_id, model_id, input_tokens, uncached_input_tokens,
+     cache_read_tokens, cache_write_tokens, output_tokens, source_event_key)
+VALUES (1, 1, 1, 'gpt-test', 120, 100, 20, 0, 30, 'event-1');
+`); err != nil {
+		t.Fatalf("seed stale usage schema: %v", err)
+	}
+	for version := 44; version <= 52; version++ {
+		if _, err := db.Exec(
+			`INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, 1)`, version,
+		); err != nil {
+			t.Fatalf("seed migration %d: %v", version, err)
+		}
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate stale applied usage schema: %v", err)
+	}
+	for table, wantColumns := range expectedUsageTableColumns {
+		if got := tableColumns(t, db, table); !reflect.DeepEqual(got, wantColumns) {
+			t.Errorf("%s columns = %v, want %v", table, got, wantColumns)
+		}
+	}
+	for _, view := range []string{"usage_codex_source_discovery", "usage_codex_pending_children", "usage_session_integrity"} {
+		var viewCount int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master WHERE type = 'view' AND name = ?`, view,
+		).Scan(&viewCount); err != nil || viewCount != 1 {
+			t.Fatalf("%s view count = %d, err = %v", view, viewCount, err)
+		}
+	}
+	if _, err := db.Exec(`
+INSERT INTO usage_bindings
+    (session_id, harness, native_root_id, state, updated_at)
+VALUES ('agent-orchestrator-1', 'copilot', 'copilot-native-1', 'active', '2026-08-01T00:00:00Z');
+INSERT INTO usage_sources
+    (binding_id, kind, artifact_path, state, updated_at)
+VALUES ((SELECT id FROM usage_bindings WHERE harness = 'copilot'), 'copilot_shutdown', '/tmp/copilot.jsonl', 'active', '2026-08-01T00:00:00Z');
+`); err != nil {
+		t.Fatalf("insert copilot usage after repair: %v", err)
+	}
+}
+
 func openMigratedTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)

--- a/backend/internal/storage/sqlite/migrations/0102_multi_agent_usage.sql
+++ b/backend/internal/storage/sqlite/migrations/0102_multi_agent_usage.sql
@@ -1,0 +1,57 @@
+-- Widen the token-usage source constraints for the file-backed agent
+-- collectors. The tables otherwise remain byte-for-byte compatible, so follow
+-- the repository's established writable_schema pattern for CHECK-only changes
+-- instead of rebuilding append-only usage rows and their foreign keys.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (harness IN (''claude-code'', ''codex''))',
+    'CHECK (harness IN (''claude-code'', ''codex'', ''copilot'', ''kimi'', ''pi'', ''qwen''))'
+)
+WHERE type = 'table' AND name = 'usage_bindings';
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (kind IN (''claude_main'', ''claude_subagent'', ''codex_rollout''))',
+    'CHECK (kind IN (''claude_main'', ''claude_subagent'', ''codex_rollout'', ''copilot_shutdown'', ''kimi_wire'', ''pi_session'', ''qwen_monthly''))'
+)
+WHERE type = 'table' AND name = 'usage_sources';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (harness IN (''claude-code'', ''codex'', ''copilot'', ''kimi'', ''pi'', ''qwen''))',
+    'CHECK (harness IN (''claude-code'', ''codex''))'
+)
+WHERE type = 'table' AND name = 'usage_bindings';
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (kind IN (''claude_main'', ''claude_subagent'', ''codex_rollout'', ''copilot_shutdown'', ''kimi_wire'', ''pi_session'', ''qwen_monthly''))',
+    'CHECK (kind IN (''claude_main'', ''claude_subagent'', ''codex_rollout''))'
+)
+WHERE type = 'table' AND name = 'usage_sources';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -107,7 +107,7 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex')
+      AND ub.harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')
       AND (
           ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
@@ -157,13 +157,13 @@ SELECT ub.*
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.harness IN ('claude-code', 'codex', 'copilot', 'kimi', 'pi', 'qwen')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness = 'claude-code'
+      ub.harness IN ('claude-code', 'copilot', 'kimi', 'pi', 'qwen')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'


### PR DESCRIPTION
## What

Add file-backed Copilot token usage observability and the shared source-contract, migration, summary, and discovery foundations required by the follow-up provider PRs.

- Parse Copilot session.shutdown model metrics into the existing usage model.
- Track cumulative per-model baselines and emit replay-stable deltas.
- Retry Copilot artifacts that appear after session startup.
- Preserve optional metric availability in mixed-harness summaries.
- Widen usage source constraints through migration 0102.

The Kimi, Pi, and Qwen collectors remain disabled here; their focused PRs enable and test each provider in sequence.

## Stack

1. Copilot: this PR, based on main
2. Kimi: feat/kimi-token-usage-observability
3. Pi: feat/pi-token-usage-observability
4. Qwen: feat/qwen-token-usage-observability

This replaces the Copilot and shared-foundation portion of #3778.

## Testing

- go test ./internal/observe/usage ./internal/service/usage ./internal/lifecycle ./internal/storage/sqlite
- Full npm run lint was attempted; unrelated timing-sensitive tests failed in agent/fake, agent/kilocode, and agent/opencode, and the long-running ptyexec package was interrupted after 358 seconds. All touched packages passed.