### PR TITLE
feat: add Kimi token usage observability

### DIFF
--- a/backend/internal/observe/usage/kimi_parser_test.go
+++ b/backend/internal/observe/usage/kimi_parser_test.go
@@ -1,0 +1,78 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// TestParseKimiUsageRecord catches omitting cache buckets from Kimi's ordinary
+// input field or counting unrelated wire records as usage.
+func TestParseKimiUsageRecord(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	records := []jsonlRecord{
+		{Offset: 0, Data: []byte(`{"id":"message-1","time":"2026-08-09T09:59:00Z","type":"message.create","message":{}}`)},
+		{Offset: 100, Data: []byte(`{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":13,"inputCacheRead":21,"inputCacheCreation":8,"output":5},"usageScope":"turn"}`)},
+	}
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %+v, want one usage record", result.Events)
+	}
+	event := result.Events[0]
+	if event.ModelID != "kimi-for-coding" || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	if got := event.Tokens; got.InputTokens != 42 || got.UncachedInputTokens != 13 ||
+		got.CacheReadTokens != 21 || got.CacheWriteTokens != 8 || got.OutputTokens != 5 ||
+		got.ReasoningTokens != nil {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseKimiUsageRecordWithNumericTime(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	record := jsonlRecord{Offset: 100, Data: []byte(`{"time":1797038183476.96,"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":6697,"output":39,"inputCacheRead":19200,"inputCacheCreation":0},"usageScope":"turn"}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %+v, want one usage record", result.Events)
+	}
+	if got := result.Events[0].Tokens; got.InputTokens != 25897 || got.UncachedInputTokens != 6697 ||
+		got.CacheReadTokens != 19200 || got.CacheWriteTokens != 0 || got.OutputTokens != 39 {
+		t.Fatalf("tokens = %+v", got)
+	}
+	if result.Events[0].SourceEventKey == "" {
+		t.Fatalf("event key is empty")
+	}
+}
+
+func TestParseKimiUsageRecordHasReplayStableKey(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	record := jsonlRecord{Offset: 100, Data: []byte(`{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":1,"inputCacheRead":2,"inputCacheCreation":3,"output":4}}`)}
+	first := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000000, 0).UTC())
+	second := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000001, 0).UTC())
+	if first.err != nil || second.err != nil || len(first.Events) != 1 || len(second.Events) != 1 {
+		t.Fatalf("first=%+v second=%+v", first, second)
+	}
+	if first.Events[0].SourceEventKey != second.Events[0].SourceEventKey {
+		t.Fatalf("keys = %q/%q", first.Events[0].SourceEventKey, second.Events[0].SourceEventKey)
+	}
+}
+
+func TestParseKimiRejectsNegativeUsage(t *testing.T) {
+	source := usageSource(domain.UsageSourceKimiWire)
+	record := jsonlRecord{Data: []byte(`{"id":"usage-bad","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":-1,"inputCacheRead":0,"inputCacheCreation":0,"output":1}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 || result.Cursor.LastErrorCode != domain.UsageErrorMalformedJSONL {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -45,6 +45,8 @@ func parseRecordsWithState(
 		result.pendingCodexSpawnCalls = len(state.Codex.PendingSpawnCallIDs)
 	case domain.UsageSourceCopilotShutdown:
 		parseCopilot(source, records, state.Copilot, &result)
+	case domain.UsageSourceKimiWire:
+		parseKimi(source, records, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -214,6 +216,10 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 				return nil, errors.New("copilot state has invalid model baseline")
 			}
 		}
+	case domain.UsageSourceKimiWire:
+		if state.Claude != nil || state.Codex != nil || state.Copilot != nil {
+			return nil, errors.New("append-only state has invalid parser payload")
+		}
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", source.Kind)
 	}
@@ -235,6 +241,9 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 		}
 	case domain.UsageSourceCopilotShutdown:
 		state.Copilot = &copilotParserStateV1{Models: make(map[string]copilotTokenVector)}
+	case domain.UsageSourceKimiWire:
+		// Append-only sources derive replay-stable event keys from native record IDs
+		// and do not need a provider-specific parser baseline.
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", kind)
 	}

--- a/backend/internal/observe/usage/parser_kimi.go
+++ b/backend/internal/observe/usage/parser_kimi.go
@@ -1,0 +1,83 @@
+package usage
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type kimiWireRecord struct {
+	ID    string          `json:"id"`
+	Time  json.RawMessage `json:"time"`
+	Type  string          `json:"type"`
+	Model string          `json:"model"`
+	Usage *struct {
+		InputOther         int64 `json:"inputOther"`
+		InputCacheRead     int64 `json:"inputCacheRead"`
+		InputCacheCreation int64 `json:"inputCacheCreation"`
+		Output             int64 `json:"output"`
+	} `json:"usage"`
+}
+
+func parseKimi(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	for _, record := range records {
+		var native kimiWireRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "usage.record" {
+			continue
+		}
+		model := firstNonEmpty(native.Model)
+		if model == "" || native.Usage == nil {
+			recordMalformed(result)
+			continue
+		}
+		usage := native.Usage
+		input, ok := sumNonNegative(usage.InputOther, usage.InputCacheRead, usage.InputCacheCreation)
+		if !ok || usage.Output < 0 {
+			recordMalformed(result)
+			continue
+		}
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         input,
+			UncachedInputTokens: usage.InputOther,
+			CacheReadTokens:     usage.InputCacheRead,
+			CacheWriteTokens:    usage.InputCacheCreation,
+			OutputTokens:        usage.Output,
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		identity := firstNonEmpty(native.ID, kimiRecordTimeIdentity(native.Time), strconv.FormatInt(record.Offset, 10))
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"kimi",
+				source.NativeRootID,
+				source.Source.SubagentID,
+				identity,
+				model,
+			),
+		})
+	}
+}
+
+func kimiRecordTimeIdentity(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String()
+	}
+	return ""
+}

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot, domain.HarnessKimi:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1,12 +1,14 @@
 package usage
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1804,6 +1806,110 @@ func TestCollectorRejectsCopilotSourceForDifferentNativeSession(t *testing.T) {
 	binding := domain.UsageBindingRecord{Harness: domain.HarnessCopilot, NativeRootID: "bound-native"}
 	if err := validateSourceAttribution(binding, domain.UsageSourceCopilotShutdown, "bound-native", "", canonicalUsagePath(t, path), ""); err == nil {
 		t.Fatal("accepted Copilot events file from a different native session")
+	}
+}
+
+func TestCollectorDiscoversKimiWireSourcesFromSessionIndex(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessKimi, nativeID, false)
+	home := t.TempDir()
+	sessionDir := filepath.Join(home, "sessions", "wd_agent-orchestrator-379_1f71c05c08c2", nativeID)
+	mainPath := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
+	childPath := filepath.Join(sessionDir, "agents", "researcher", "wire.jsonl")
+	writeUsageFixture(t, mainPath, "{}\n")
+	writeUsageFixture(t, childPath, "{}\n")
+	writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"),
+		fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q,"workDir":"/repo"}`+"\n", nativeID, sessionDir))
+	collector := NewCollector(store, SourceRoots{KimiHome: home}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessKimi, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+	gotSubagents := []string{sources[0].SubagentID, sources[1].SubagentID}
+	slices.Sort(gotSubagents)
+	if !reflect.DeepEqual(gotSubagents, []string{"", "researcher"}) {
+		t.Fatalf("subagent IDs = %v", gotSubagents)
+	}
+}
+
+func TestCollectorKimiIndexRejectsDeletedAndEscapingSessions(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	tests := []struct {
+		name    string
+		records func(home string) string
+	}{
+		{
+			name: "last record deletes session",
+			records: func(home string) string {
+				dir := filepath.Join(home, "sessions", nativeID)
+				return fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n"+`{"sessionId":%q,"deleted":true}`+"\n", nativeID, dir, nativeID)
+			},
+		},
+		{
+			name: "session directory escapes root",
+			records: func(home string) string {
+				dir := filepath.Join(filepath.Dir(home), nativeID)
+				return fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n", nativeID, dir)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			escapingDir := filepath.Join(filepath.Dir(home), nativeID)
+			t.Cleanup(func() { _ = os.RemoveAll(escapingDir) })
+			writeUsageFixture(t, filepath.Join(home, "sessions", nativeID, "agents", "main", "wire.jsonl"), "{}\n")
+			writeUsageFixture(t, filepath.Join(escapingDir, "agents", "main", "wire.jsonl"), "{}\n")
+			writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"), tc.records(home))
+			collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+			path, err := collector.discoverPath(context.Background(), domain.HarnessKimi, nativeID)
+			mustNoError(t, err)
+			if path != "" {
+				t.Fatalf("discovered rejected session path %q", path)
+			}
+		})
+	}
+}
+
+func TestCollectorKimiIndexReplaysRecordsBeyondEightMiB(t *testing.T) {
+	const nativeID = "kimi-late-session"
+	home := t.TempDir()
+	sessionDir := filepath.Join(home, "sessions", nativeID)
+	wire := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
+	writeUsageFixture(t, wire, "{}\n")
+	fillerLine := []byte(`{"sessionId":"unrelated","deleted":true}` + "\n")
+	filler := bytes.Repeat(fillerLine, (8<<20)/len(fillerLine)+1)
+	late := []byte(fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n", nativeID, sessionDir))
+	writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"), string(append(filler, late...)))
+	collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+
+	path, err := collector.discoverPath(context.Background(), domain.HarnessKimi, nativeID)
+	mustNoError(t, err)
+	if path != wire {
+		t.Fatalf("discovered %q, want late-index wire %q", path, wire)
+	}
+}
+
+func TestCollectorRejectsKimiWireOutsideCanonicalSessionsDirectory(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	home := t.TempDir()
+	path := filepath.Join(home, "attacker", "sessions", nativeID, "agents", "main", "wire.jsonl")
+	writeUsageFixture(t, path, "{}\n")
+	binding := domain.UsageBindingRecord{Harness: domain.HarnessKimi, NativeRootID: nativeID}
+	collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+	if err := collector.validateSourceAttribution(
+		binding, domain.UsageSourceKimiWire, nativeID, "", canonicalUsagePath(t, path), "",
+	); err == nil {
+		t.Fatal("accepted Kimi wire outside <KimiHome>/sessions/<native-id>")
 	}
 }
 


### PR DESCRIPTION
## What

Add the focused Kimi layer on top of the shared usage foundation in #4182.

- Parse Kimi wire events into normalized token usage.
- Enable Kimi as a certified usage harness.
- Discover main and subagent wire files from the append-only session index.
- Fence attribution to the canonical Kimi sessions root.
- Replay large session indexes and reject deleted or escaping entries.

## Stack

- Base: #4182
- This PR: Kimi
- Next: feat/pi-token-usage-observability
- Then: feat/qwen-token-usage-observability

This replaces the Kimi portion of #3778.

## Testing

- go test ./internal/observe/usage ./internal/service/usage