### PR TITLE
feat: add Pi token usage observability

### DIFF
--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -535,11 +535,16 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	// rule, while their tracking side effects still land. Untagged signals
 	// (old CLIs, adapters without tool identity) pass through untouched —
 	// last-writer-wins, exactly as before.
-	metadataChanged := (s.AgentSessionID != "" && rec.Metadata.AgentSessionID != s.AgentSessionID) ||
-		(s.AgentSessionID != "" && rec.Metadata.AgentSessionIDLaunchID != s.LaunchID) ||
+	nativeSessionChanged := s.AgentSessionID != "" &&
+		(rec.Metadata.AgentSessionID != s.AgentSessionID || rec.Metadata.AgentSessionIDLaunchID != s.LaunchID)
+	metadataChanged := nativeSessionChanged ||
 		(s.LatestUserPrompt != "" && rec.Metadata.LatestUserPrompt != s.LatestUserPrompt) ||
 		(s.LatestAssistantUpdate != "" && rec.Metadata.LatestAssistantUpdate != s.LatestAssistantUpdate) ||
 		(s.TranscriptPath != "" && rec.Metadata.NativeTranscriptPath != s.TranscriptPath)
+	var usageReactivator sessionUsageReactivator
+	if nativeSessionChanged {
+		usageReactivator = m.usageReactivator
+	}
 	if s.Valid {
 		s = m.applyToolPrecedenceLocked(id, rec.Activity.State, s)
 	}
@@ -552,6 +557,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		rec.UpdatedAt = now
 		_, err := m.store.UpdateSessionFromActivitySignal(ctx, rec)
 		m.mu.Unlock()
+		if err == nil {
+			reactivateSessionUsage(ctx, id, rec.Metadata.RuntimeLaunchID, usageReactivator)
+		}
 		return err
 	}
 	if metadataChanged {
@@ -578,6 +586,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 			}
 			if !applied {
 				return nil
+			}
+			if nativeSessionChanged {
+				reactivateSessionUsage(ctx, id, rec.Metadata.RuntimeLaunchID, usageReactivator)
 			}
 			return m.acknowledgeAgentSwitchTarget(ctx, id, s, now)
 		}
@@ -623,6 +634,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	resolutions := needsInputResolutions(rec, next, now)
 	waitingEvents := m.waitingInputEvents(next, prevState, prevAt, now)
 	m.mu.Unlock()
+	if nativeSessionChanged {
+		reactivateSessionUsage(ctx, id, next.Metadata.RuntimeLaunchID, usageReactivator)
+	}
 	if err := m.acknowledgeAgentSwitchTarget(ctx, id, s, now); err != nil {
 		return err
 	}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -1470,6 +1470,27 @@ func TestMarkSpawnedReactivatesUsageAfterLifecycleTransition(t *testing.T) {
 	}
 }
 
+func TestApplyActivitySignalNativeSessionIDReactivatesUsageDiscovery(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	rec.Metadata.RuntimeLaunchID = "launch-1"
+	st.sessions[rec.ID] = rec
+	usage := &fakeUsageLifecycle{fakeUsageFinalizer: fakeUsageFinalizer{store: st}}
+	m.SetUsageFinalizer(usage)
+
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		AgentSessionID: "pi-native-1",
+		LaunchID:       "launch-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if usage.reactivateCalls != 1 || usage.reactivateID != rec.ID ||
+		usage.reactivateLaunch != "launch-1" || !usage.sawLive {
+		t.Fatalf("usage discovery = calls:%d id:%q launch:%q live:%v",
+			usage.reactivateCalls, usage.reactivateID, usage.reactivateLaunch, usage.sawLive)
+	}
+}
+
 func TestMarkTerminatedFinalizesUsageBeforeLifecycleTransition(t *testing.T) {
 	m, st, _ := newManager()
 	rec := working("mer-1")

--- a/backend/internal/observe/usage/ingestor_integration_test.go
+++ b/backend/internal/observe/usage/ingestor_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
 	usagesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/usage"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
@@ -624,6 +626,73 @@ func TestCoordinatorCollectsCodexUsageFromFilesystemEvents(t *testing.T) {
 	waitForTokenAggregate(t, store, session.ID, 180)
 }
 
+func TestPipelineRetriesPiDiscoveryAfterMarkSpawnedRace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	now := time.Now().UTC()
+	store, session := seedUsageTestSession(
+		t, t.TempDir(), "usage", domain.HarnessPi, domain.ActivityIdle, "", now,
+	)
+	workspace := t.TempDir()
+	piRoot := t.TempDir()
+	pipelineStore := &pendingDiscoverySignalStore{
+		Store:   store,
+		checked: make(chan struct{}, 8),
+	}
+
+	var pipeline *Pipeline
+	collector := usagesvc.NewCollector(store, usagesvc.SourceRoots{PiSessions: piRoot}, func(reconcile bool) {
+		if pipeline == nil {
+			return
+		}
+		if reconcile {
+			pipeline.NotifySourcesChanged()
+			return
+		}
+		pipeline.NotifyInventoryChanged()
+	})
+	pipeline = NewPipeline(pipelineStore, NewIngestor(store, IngestorConfig{}), []string{piRoot}, CoordinatorConfig{
+		Workers:    1,
+		RetryDelay: 20 * time.Millisecond,
+		Initialize: collector.BackfillActive,
+		Reconcile: func(reconcileCtx context.Context) error {
+			return collector.ReconcileSources(reconcileCtx, 0)
+		},
+		ReconcilePath: collector.ReconcilePath,
+	})
+	done := pipeline.Start(ctx)
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("usage pipeline did not stop")
+		}
+	})
+	waitForPendingDiscoveryCheck(t, pipelineStore.checked)
+
+	manager := lifecycle.New(store, nil)
+	manager.SetUsageFinalizer(collector)
+	mustNoError(t, manager.MarkSpawned(ctx, session.ID, domain.SessionMetadata{
+		RuntimeLaunchID: "launch-pi-late",
+		WorkspacePath:   workspace,
+	}))
+	waitForPendingDiscoveryCheck(t, pipelineStore.checked)
+
+	path := filepath.Join(piRoot, "project", "late.jsonl")
+	mustNoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	mustNoError(t, os.WriteFile(path, []byte(fmt.Sprintf(
+		`{"type":"session","id":"pi-late","cwd":%q,"version":3}`+"\n", workspace,
+	)), 0o600))
+
+	waitForUsageBinding(t, store, session.ID, "pi-late")
+	pending, err := store.HasPendingUsageDiscovery(ctx)
+	mustNoError(t, err)
+	if pending {
+		t.Fatal("Pi discovery remained pending after binding was registered")
+	}
+}
+
 func TestIngestorPersistsAppendOnlyUsageAcrossRestartAndFinalization(t *testing.T) {
 	ctx := context.Background()
 	now := time.Unix(1700000000, 0).UTC()
@@ -1030,6 +1099,45 @@ func waitForWatchableSource(ctx context.Context, t *testing.T, store *sqlite.Sto
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("usage source %q was not registered", path)
+}
+
+func waitForUsageBinding(t *testing.T, store *sqlite.Store, sessionID domain.SessionID, nativeRootID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		bindings, err := store.ListUsageBindingsForSession(context.Background(), sessionID)
+		mustNoError(t, err)
+		for _, binding := range bindings {
+			if binding.NativeRootID == nativeRootID {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("usage binding %q was not registered for session %q", nativeRootID, sessionID)
+}
+
+type pendingDiscoverySignalStore struct {
+	*sqlite.Store
+	checked chan struct{}
+}
+
+func (s *pendingDiscoverySignalStore) HasPendingUsageDiscovery(ctx context.Context) (bool, error) {
+	pending, err := s.Store.HasPendingUsageDiscovery(ctx)
+	select {
+	case s.checked <- struct{}{}:
+	default:
+	}
+	return pending, err
+}
+
+func waitForPendingDiscoveryCheck(t *testing.T, checked <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-checked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("usage pipeline did not check pending discovery")
+	}
 }
 
 func appendJSONLRecord(t *testing.T, path string, record []byte) {

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -47,6 +47,8 @@ func parseRecordsWithState(
 		parseCopilot(source, records, state.Copilot, &result)
 	case domain.UsageSourceKimiWire:
 		parseKimi(source, records, &result)
+	case domain.UsageSourcePiSession:
+		parsePi(source, records, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -216,7 +218,7 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 				return nil, errors.New("copilot state has invalid model baseline")
 			}
 		}
-	case domain.UsageSourceKimiWire:
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession:
 		if state.Claude != nil || state.Codex != nil || state.Copilot != nil {
 			return nil, errors.New("append-only state has invalid parser payload")
 		}
@@ -241,7 +243,7 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 		}
 	case domain.UsageSourceCopilotShutdown:
 		state.Copilot = &copilotParserStateV1{Models: make(map[string]copilotTokenVector)}
-	case domain.UsageSourceKimiWire:
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession:
 		// Append-only sources derive replay-stable event keys from native record IDs
 		// and do not need a provider-specific parser baseline.
 	default:

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -49,6 +49,8 @@ func parseRecordsWithState(
 		parseKimi(source, records, &result)
 	case domain.UsageSourcePiSession:
 		parsePi(source, records, &result)
+	case domain.UsageSourceQwenMonthly:
+		parseQwen(source, records, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -218,7 +220,7 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 				return nil, errors.New("copilot state has invalid model baseline")
 			}
 		}
-	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession:
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession, domain.UsageSourceQwenMonthly:
 		if state.Claude != nil || state.Codex != nil || state.Copilot != nil {
 			return nil, errors.New("append-only state has invalid parser payload")
 		}
@@ -243,7 +245,7 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 		}
 	case domain.UsageSourceCopilotShutdown:
 		state.Copilot = &copilotParserStateV1{Models: make(map[string]copilotTokenVector)}
-	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession:
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession, domain.UsageSourceQwenMonthly:
 		// Append-only sources derive replay-stable event keys from native record IDs
 		// and do not need a provider-specific parser baseline.
 	default:

--- a/backend/internal/observe/usage/parser_pi.go
+++ b/backend/internal/observe/usage/parser_pi.go
@@ -1,0 +1,77 @@
+package usage
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type piSessionRecord struct {
+	Type    string `json:"type"`
+	ID      string `json:"id"`
+	Message *struct {
+		Role     string `json:"role"`
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+		Usage    *struct {
+			Input      int64 `json:"input"`
+			Output     int64 `json:"output"`
+			CacheRead  int64 `json:"cacheRead"`
+			CacheWrite int64 `json:"cacheWrite"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+func parsePi(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	for _, record := range records {
+		var native piSessionRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "message" || native.Message == nil || native.Message.Role != "assistant" {
+			continue
+		}
+		message := native.Message
+		model := firstNonEmpty(message.Model)
+		if model == "" || message.Usage == nil {
+			recordMalformed(result)
+			continue
+		}
+		provider := firstNonEmpty(message.Provider)
+		if provider != "" {
+			model = provider + "/" + model
+		}
+		usage := message.Usage
+		input, ok := sumNonNegative(usage.Input, usage.CacheRead, usage.CacheWrite)
+		if !ok || usage.Output < 0 {
+			recordMalformed(result)
+			continue
+		}
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         input,
+			UncachedInputTokens: usage.Input,
+			CacheReadTokens:     usage.CacheRead,
+			CacheWriteTokens:    usage.CacheWrite,
+			OutputTokens:        usage.Output,
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		identity := firstNonEmpty(native.ID, strconv.FormatInt(record.Offset, 10))
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"pi",
+				source.NativeRootID,
+				identity,
+				strings.TrimSpace(message.Provider),
+				strings.TrimSpace(message.Model),
+			),
+		})
+	}
+}

--- a/backend/internal/observe/usage/parser_qwen.go
+++ b/backend/internal/observe/usage/parser_qwen.go
@@ -1,0 +1,65 @@
+package usage
+
+import (
+	"encoding/json"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type qwenUsageRecord struct {
+	SchemaVersion  int    `json:"schemaVersion"`
+	ID             string `json:"id"`
+	Timestamp      string `json:"timestamp"`
+	SessionID      string `json:"sessionId"`
+	Model          string `json:"model"`
+	InputTokens    int64  `json:"inputTokens"`
+	OutputTokens   int64  `json:"outputTokens"`
+	CachedTokens   int64  `json:"cachedTokens"`
+	ThoughtsTokens int64  `json:"thoughtsTokens"`
+	TotalTokens    *int64 `json:"totalTokens"`
+}
+
+func parseQwen(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	for _, record := range records {
+		var native qwenUsageRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.SessionID != source.NativeRootID {
+			continue
+		}
+		model := firstNonEmpty(native.Model)
+		identity := firstNonEmpty(native.ID)
+		if native.SchemaVersion != 1 || model == "" || identity == "" ||
+			native.InputTokens < 0 || native.OutputTokens < 0 || native.CachedTokens < 0 ||
+			native.ThoughtsTokens < 0 ||
+			native.CachedTokens > native.InputTokens ||
+			native.TotalTokens != nil && (*native.TotalTokens < 0 ||
+				*native.TotalTokens != native.InputTokens+native.OutputTokens+native.ThoughtsTokens) {
+			recordMalformed(result)
+			continue
+		}
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         native.InputTokens,
+			UncachedInputTokens: native.InputTokens - native.CachedTokens,
+			CacheReadTokens:     native.CachedTokens,
+			OutputTokens:        native.OutputTokens + native.ThoughtsTokens,
+			ReasoningTokens:     int64Ptr(native.ThoughtsTokens),
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"qwen",
+				source.NativeRootID,
+				identity,
+				model,
+			),
+		})
+	}
+}

--- a/backend/internal/observe/usage/pi_parser_test.go
+++ b/backend/internal/observe/usage/pi_parser_test.go
@@ -1,0 +1,38 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestParsePiAssistantUsage(t *testing.T) {
+	source := usageSource(domain.UsageSourcePiSession)
+	records := []jsonlRecord{
+		{Data: []byte(`{"type":"session","id":"pi-session","cwd":"/repo","version":3}`)},
+		{Offset: 100, Data: []byte(`{"type":"message","id":"msg-1","message":{"role":"assistant","provider":"zai-glm","model":"glm-4.5","usage":{"input":11,"output":7,"cacheRead":5,"cacheWrite":3,"totalTokens":26,"cost":{"total":99}}}}`)},
+		{Offset: 200, Data: []byte(`{"type":"message","id":"msg-2","message":{"role":"user","usage":{"input":100}}}`)},
+	}
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.Events[0]
+	if event.ModelID != "zai-glm/glm-4.5" || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	if got := event.Tokens; got.InputTokens != 19 || got.UncachedInputTokens != 11 ||
+		got.CacheReadTokens != 5 || got.CacheWriteTokens != 3 || got.OutputTokens != 7 || got.ReasoningTokens != nil {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParsePiRejectsInvalidUsage(t *testing.T) {
+	source := usageSource(domain.UsageSourcePiSession)
+	record := jsonlRecord{Data: []byte(`{"type":"message","id":"bad","message":{"role":"assistant","model":"m","usage":{"input":-1,"output":1}}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/backend/internal/observe/usage/qwen_parser_test.go
+++ b/backend/internal/observe/usage/qwen_parser_test.go
@@ -1,0 +1,73 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestParseQwenUsageForBoundSession(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "qwen-session"
+	records := []jsonlRecord{
+		{Data: []byte(`{"schemaVersion":1,"id":"other","sessionId":"another","model":"qwen3","inputTokens":999,"outputTokens":999,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":1998}`)},
+		{Offset: 100, Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"qwen-session","model":"qwen3-coder","inputTokens":30,"outputTokens":12,"cachedTokens":9,"thoughtsTokens":4,"totalTokens":46}`)},
+	}
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.Events[0]
+	if event.ModelID != "qwen3-coder" || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	if got := event.Tokens; got.InputTokens != 30 || got.UncachedInputTokens != 21 ||
+		got.CacheReadTokens != 9 || got.CacheWriteTokens != 0 || got.OutputTokens != 16 ||
+		got.ReasoningTokens == nil || *got.ReasoningTokens != 4 {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseQwenNormalizesThoughtsIntoOutputTokens(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":4,"totalTokens":9}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := result.Events[0].Tokens; got.OutputTokens != 6 || got.ReasoningTokens == nil || *got.ReasoningTokens != 4 {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseQwenRejectsInconsistentTotals(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"bad","sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":4,"thoughtsTokens":0,"totalTokens":5}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestParseQwenAllowsOmittedTotalTokens(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"native-root","source":"managed-auto-memory-extractor","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":0}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestParseQwenRequiresNativeRecordID(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":0,"totalTokens":5}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot, domain.HarnessKimi:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot, domain.HarnessKimi, domain.HarnessPi:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot, domain.HarnessKimi, domain.HarnessPi:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot, domain.HarnessKimi, domain.HarnessPi, domain.HarnessQwen:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1913,6 +1913,234 @@ func TestCollectorRejectsKimiWireOutsideCanonicalSessionsDirectory(t *testing.T)
 	}
 }
 
+func TestCollectorDiscoversPiSessionByHeaderID(t *testing.T) {
+	const nativeID = "pi-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessPi, nativeID, false)
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "2026-08-09_"+nativeID+".jsonl")
+	writeUsageFixture(t, path, `{"type":"session","id":"`+nativeID+`","cwd":"/repo","version":3}`+"\n")
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessPi, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if len(bindings) != 1 {
+		t.Fatalf("bindings = %+v", bindings)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourcePiSession {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorPiDiscoveryCapsNewestFilesByModificationTime(t *testing.T) {
+	const nativeID = "pi-newest-session"
+	root := t.TempDir()
+	newest := filepath.Join(root, "a-project", "000-newest.jsonl")
+	writeUsageFixture(t, newest, `{"type":"session","id":"`+nativeID+`","cwd":"/repo","version":3}`+"\n")
+	old := time.Now().Add(-time.Hour)
+	for index := 0; index < 256; index++ {
+		path := filepath.Join(root, fmt.Sprintf("z-project-%03d", index), "old.jsonl")
+		writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"old-%03d","cwd":"/repo","version":3}`+"\n", index))
+		mustNoError(t, os.Chtimes(path, old, old))
+	}
+	newTime := time.Now().Add(time.Hour)
+	mustNoError(t, os.Chtimes(newest, newTime, newTime))
+	collector := NewCollector(collectorTestStore(t), SourceRoots{PiSessions: root}, nil)
+
+	path, err := collector.discoverPath(context.Background(), domain.HarnessPi, nativeID)
+	mustNoError(t, err)
+	if path != newest {
+		t.Fatalf("discovered %q, want newest %q", path, newest)
+	}
+}
+
+func TestCollectorReconcilePiPathMatchesExactlyOneLivePiWorkspace(t *testing.T) {
+	const nativeID = "pi-session-from-header"
+	store := collectorTestStore(t)
+	matchingWorkspace := t.TempDir()
+	otherWorkspace := t.TempDir()
+	matching := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	matching.Metadata.WorkspacePath = matchingWorkspace
+	mustNoError(t, store.UpdateSession(context.Background(), matching))
+	other := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	other.Metadata.WorkspacePath = otherWorkspace
+	mustNoError(t, store.UpdateSession(context.Background(), other))
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "session.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":%q,"cwd":%q,"version":3}`+"\n", nativeID, matchingWorkspace))
+
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+	mustNoError(t, collector.ReconcilePath(context.Background(), path))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), matching.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != nativeID {
+		t.Fatalf("matching bindings=%+v err=%v", bindings, err)
+	}
+	otherBindings, err := store.ListUsageBindingsForSession(context.Background(), other.ID)
+	if err != nil || len(otherBindings) != 0 {
+		t.Fatalf("other bindings=%+v err=%v", otherBindings, err)
+	}
+}
+
+func TestCollectorReconcilePiPathIgnoresAmbiguousOrNonPiWorkspace(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		harnesses []domain.AgentHarness
+	}{
+		{name: "ambiguous", harnesses: []domain.AgentHarness{domain.HarnessPi, domain.HarnessPi}},
+		{name: "non-pi", harnesses: []domain.AgentHarness{domain.HarnessQwen}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := collectorTestStore(t)
+			workspace := t.TempDir()
+			var sessions []domain.SessionRecord
+			for _, harness := range tc.harnesses {
+				session := collectorTestSession(t, store, harness, "", false)
+				session.Metadata.WorkspacePath = workspace
+				mustNoError(t, store.UpdateSession(context.Background(), session))
+				sessions = append(sessions, session)
+			}
+			root := t.TempDir()
+			path := filepath.Join(root, "project", "session.jsonl")
+			writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-native","cwd":%q,"version":3}`+"\n", workspace))
+			collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+			mustNoError(t, collector.ReconcilePath(context.Background(), path))
+			for _, session := range sessions {
+				bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+				if err != nil || len(bindings) != 0 {
+					t.Fatalf("session %s bindings=%+v err=%v", session.ID, bindings, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCollectorBackfillFindsPiSessionWithoutCapturedNativeID(t *testing.T) {
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session.Metadata.WorkspacePath = workspace
+	mustNoError(t, store.UpdateSession(context.Background(), session))
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "existing.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-existing","cwd":%q,"version":3}`+"\n", workspace))
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+
+	mustNoError(t, collector.BackfillActive(context.Background()))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-existing" {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
+func TestCollectorReconcileFindsPiSessionWithoutCapturedNativeID(t *testing.T) {
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session.Metadata.WorkspacePath = workspace
+	mustNoError(t, store.UpdateSession(context.Background(), session))
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "existing.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-existing","cwd":%q,"version":3}`+"\n", workspace))
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-existing" {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
+func TestCollectorMarkSpawnedFindsExistingPiSessionWithoutCapturedNativeID(t *testing.T) {
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "existing.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-existing","cwd":%q,"version":3}`+"\n", workspace))
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+	manager := lifecycle.New(store, nil)
+	manager.SetUsageFinalizer(collector)
+
+	mustNoError(t, manager.MarkSpawned(context.Background(), session.ID, domain.SessionMetadata{
+		RuntimeLaunchID: "launch-1",
+		WorkspacePath:   workspace,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-existing" {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorMarkSpawnedRetriesPiSessionCreatedLater(t *testing.T) {
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	root := t.TempDir()
+	wakes := 0
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, func(reconcile bool) {
+		if reconcile {
+			wakes++
+		}
+	})
+	manager := lifecycle.New(store, nil)
+	manager.SetUsageFinalizer(collector)
+
+	mustNoError(t, manager.MarkSpawned(context.Background(), session.ID, domain.SessionMetadata{
+		RuntimeLaunchID: "launch-1",
+		WorkspacePath:   workspace,
+	}))
+	if wakes != 1 {
+		t.Fatalf("reconcile wakes = %d, want 1", wakes)
+	}
+	if bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID); err != nil || len(bindings) != 0 {
+		t.Fatalf("early bindings=%+v err=%v", bindings, err)
+	}
+
+	path := filepath.Join(root, "project", "late.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":"pi-late","cwd":%q,"version":3}`+"\n", workspace))
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-late" {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
+func TestCollectorBindsPiWhenLifecycleCapturesNativeSessionID(t *testing.T) {
+	const nativeID = "pi-captured"
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session.Metadata.WorkspacePath = workspace
+	session.Metadata.RuntimeLaunchID = "launch-1"
+	mustNoError(t, store.UpdateSession(context.Background(), session))
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "captured.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(`{"type":"session","id":%q,"cwd":%q,"version":3}`+"\n", nativeID, workspace))
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+	manager := lifecycle.New(store, nil)
+	manager.SetUsageFinalizer(collector)
+
+	mustNoError(t, manager.ApplyActivitySignal(context.Background(), session.ID, ports.ActivitySignal{
+		AgentSessionID: nativeID,
+		LaunchID:       "launch-1",
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != nativeID {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
 func differentHarness(harness domain.AgentHarness) domain.AgentHarness {
 	if harness == domain.HarnessCopilot {
 		return domain.HarnessKimi

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -2141,6 +2141,71 @@ func TestCollectorBindsPiWhenLifecycleCapturesNativeSessionID(t *testing.T) {
 	}
 }
 
+func TestCollectorDiscoversQwenSharedMonthlyUsage(t *testing.T) {
+	const nativeID = "qwen-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessQwen, nativeID, false)
+	root := t.TempDir()
+	path := filepath.Join(root, "token-usage-2026-08.jsonl")
+	writeUsageFixture(t, path, `{"schemaVersion":1,"id":"turn-1","sessionId":"`+nativeID+`","model":"qwen3","inputTokens":1,"outputTokens":1,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":2}`+"\n")
+	collector := NewCollector(store, SourceRoots{QwenUsage: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessQwen, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if len(bindings) != 1 {
+		t.Fatalf("bindings = %+v", bindings)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourceQwenMonthly {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorQwenRegistersNewestMonthAndLaterRollover(t *testing.T) {
+	const nativeID = "qwen-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessQwen, nativeID, false)
+	root := t.TempDir()
+	june := filepath.Join(root, "token-usage-2026-06.jsonl")
+	july := filepath.Join(root, "token-usage-2026-07.jsonl")
+	writeUsageFixture(t, june, "{}\n")
+	writeUsageFixture(t, july, "{}\n")
+	future := time.Now().Add(24 * time.Hour)
+	mustNoError(t, os.Chtimes(june, future, future))
+	collector := NewCollector(store, SourceRoots{QwenUsage: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessQwen, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, july) {
+		t.Fatalf("initial sources=%+v err=%v", sources, err)
+	}
+
+	august := filepath.Join(root, "token-usage-2026-08.jsonl")
+	writeUsageFixture(t, august, "{}\n")
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+	sources, err = store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("rollover sources=%+v err=%v", sources, err)
+	}
+	gotPaths := []string{sources[0].ArtifactPath, sources[1].ArtifactPath}
+	slices.Sort(gotPaths)
+	wantPaths := []string{canonicalUsagePath(t, july), canonicalUsagePath(t, august)}
+	slices.Sort(wantPaths)
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("paths=%v want=%v", gotPaths, wantPaths)
+	}
+	for _, source := range sources {
+		if source.State != domain.UsageSourceActive && source.State != domain.UsageSourcePending {
+			t.Fatalf("source state=%s, want active or newly pending", source.State)
+		}
+	}
+}
+
 func differentHarness(harness domain.AgentHarness) domain.AgentHarness {
 	if harness == domain.HarnessCopilot {
 		return domain.HarnessKimi

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -402,6 +402,19 @@ SELECT CAST(EXISTS (
                 )
           )
       )
+) OR EXISTS (
+    SELECT 1
+    FROM sessions s
+    WHERE s.is_terminated = 0
+      AND s.activity_state <> 'exited'
+      AND s.harness = 'pi'
+      AND trim(s.workspace_path) <> ''
+      AND NOT EXISTS (
+          SELECT 1
+          FROM usage_bindings ub
+          WHERE ub.session_id = s.id
+            AND ub.harness = 'pi'
+      )
 ) AS INTEGER)
 `
 

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -132,6 +132,19 @@ SELECT CAST(EXISTS (
                 )
           )
       )
+) OR EXISTS (
+    SELECT 1
+    FROM sessions s
+    WHERE s.is_terminated = 0
+      AND s.activity_state <> 'exited'
+      AND s.harness = 'pi'
+      AND trim(s.workspace_path) <> ''
+      AND NOT EXISTS (
+          SELECT 1
+          FROM usage_bindings ub
+          WHERE ub.session_id = s.id
+            AND ub.harness = 'pi'
+      )
 ) AS INTEGER);
 
 -- name: ListLatestRetiredCodexReplacementClaimsByPath :many


### PR DESCRIPTION
## What

Add the focused Pi layer on top of the Kimi stack in #4183.

- Parse Pi session events into normalized token usage.
- Enable Pi as a certified usage harness.
- Discover sessions by native header ID and correlate missing IDs through a unique live workspace.
- Retry late-created Pi artifacts and cap discovery to the newest files.
- Reactivate usage discovery when lifecycle hooks persist the Pi native session ID without blocking concurrent finalization.

## Stack

- Base: #4183
- This PR: Pi
- Next: feat/qwen-token-usage-observability

This replaces the Pi portion of #3778.

## Testing

- go test ./internal/observe/usage ./internal/service/usage ./internal/lifecycle