### PR TITLE
feat: add Qwen token usage observability

### DIFF
--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -49,6 +49,8 @@ func parseRecordsWithState(
 		parseKimi(source, records, &result)
 	case domain.UsageSourcePiSession:
 		parsePi(source, records, &result)
+	case domain.UsageSourceQwenMonthly:
+		parseQwen(source, records, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -218,7 +220,7 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 				return nil, errors.New("copilot state has invalid model baseline")
 			}
 		}
-	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession:
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession, domain.UsageSourceQwenMonthly:
 		if state.Claude != nil || state.Codex != nil || state.Copilot != nil {
 			return nil, errors.New("append-only state has invalid parser payload")
 		}
@@ -243,7 +245,7 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 		}
 	case domain.UsageSourceCopilotShutdown:
 		state.Copilot = &copilotParserStateV1{Models: make(map[string]copilotTokenVector)}
-	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession:
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession, domain.UsageSourceQwenMonthly:
 		// Append-only sources derive replay-stable event keys from native record IDs
 		// and do not need a provider-specific parser baseline.
 	default:

--- a/backend/internal/observe/usage/parser_qwen.go
+++ b/backend/internal/observe/usage/parser_qwen.go
@@ -1,0 +1,65 @@
+package usage
+
+import (
+	"encoding/json"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type qwenUsageRecord struct {
+	SchemaVersion  int    `json:"schemaVersion"`
+	ID             string `json:"id"`
+	Timestamp      string `json:"timestamp"`
+	SessionID      string `json:"sessionId"`
+	Model          string `json:"model"`
+	InputTokens    int64  `json:"inputTokens"`
+	OutputTokens   int64  `json:"outputTokens"`
+	CachedTokens   int64  `json:"cachedTokens"`
+	ThoughtsTokens int64  `json:"thoughtsTokens"`
+	TotalTokens    *int64 `json:"totalTokens"`
+}
+
+func parseQwen(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	for _, record := range records {
+		var native qwenUsageRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.SessionID != source.NativeRootID {
+			continue
+		}
+		model := firstNonEmpty(native.Model)
+		identity := firstNonEmpty(native.ID)
+		if native.SchemaVersion != 1 || model == "" || identity == "" ||
+			native.InputTokens < 0 || native.OutputTokens < 0 || native.CachedTokens < 0 ||
+			native.ThoughtsTokens < 0 ||
+			native.CachedTokens > native.InputTokens ||
+			native.TotalTokens != nil && (*native.TotalTokens < 0 ||
+				*native.TotalTokens != native.InputTokens+native.OutputTokens+native.ThoughtsTokens) {
+			recordMalformed(result)
+			continue
+		}
+		tokens := domain.UsageTokenMetrics{
+			InputTokens:         native.InputTokens,
+			UncachedInputTokens: native.InputTokens - native.CachedTokens,
+			CacheReadTokens:     native.CachedTokens,
+			OutputTokens:        native.OutputTokens + native.ThoughtsTokens,
+			ReasoningTokens:     int64Ptr(native.ThoughtsTokens),
+		}
+		if !validTokenMetrics(tokens) {
+			recordMalformed(result)
+			continue
+		}
+		result.Events = append(result.Events, domain.ModelUsageEvent{
+			ModelID: model,
+			Tokens:  tokens,
+			SourceEventKey: stableSourceEventKey(
+				"qwen",
+				source.NativeRootID,
+				identity,
+				model,
+			),
+		})
+	}
+}

--- a/backend/internal/observe/usage/qwen_parser_test.go
+++ b/backend/internal/observe/usage/qwen_parser_test.go
@@ -1,0 +1,73 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestParseQwenUsageForBoundSession(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "qwen-session"
+	records := []jsonlRecord{
+		{Data: []byte(`{"schemaVersion":1,"id":"other","sessionId":"another","model":"qwen3","inputTokens":999,"outputTokens":999,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":1998}`)},
+		{Offset: 100, Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"qwen-session","model":"qwen3-coder","inputTokens":30,"outputTokens":12,"cachedTokens":9,"thoughtsTokens":4,"totalTokens":46}`)},
+	}
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.Events[0]
+	if event.ModelID != "qwen3-coder" || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	if got := event.Tokens; got.InputTokens != 30 || got.UncachedInputTokens != 21 ||
+		got.CacheReadTokens != 9 || got.CacheWriteTokens != 0 || got.OutputTokens != 16 ||
+		got.ReasoningTokens == nil || *got.ReasoningTokens != 4 {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseQwenNormalizesThoughtsIntoOutputTokens(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":4,"totalTokens":9}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := result.Events[0].Tokens; got.OutputTokens != 6 || got.ReasoningTokens == nil || *got.ReasoningTokens != 4 {
+		t.Fatalf("tokens = %+v", got)
+	}
+}
+
+func TestParseQwenRejectsInconsistentTotals(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"bad","sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":4,"thoughtsTokens":0,"totalTokens":5}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestParseQwenAllowsOmittedTotalTokens(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"native-root","source":"managed-auto-memory-extractor","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":0}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestParseQwenRequiresNativeRecordID(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":0,"totalTokens":5}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot, domain.HarnessKimi, domain.HarnessPi:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessCopilot, domain.HarnessKimi, domain.HarnessPi, domain.HarnessQwen:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -2141,6 +2141,71 @@ func TestCollectorBindsPiWhenLifecycleCapturesNativeSessionID(t *testing.T) {
 	}
 }
 
+func TestCollectorDiscoversQwenSharedMonthlyUsage(t *testing.T) {
+	const nativeID = "qwen-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessQwen, nativeID, false)
+	root := t.TempDir()
+	path := filepath.Join(root, "token-usage-2026-08.jsonl")
+	writeUsageFixture(t, path, `{"schemaVersion":1,"id":"turn-1","sessionId":"`+nativeID+`","model":"qwen3","inputTokens":1,"outputTokens":1,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":2}`+"\n")
+	collector := NewCollector(store, SourceRoots{QwenUsage: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessQwen, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if len(bindings) != 1 {
+		t.Fatalf("bindings = %+v", bindings)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourceQwenMonthly {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorQwenRegistersNewestMonthAndLaterRollover(t *testing.T) {
+	const nativeID = "qwen-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessQwen, nativeID, false)
+	root := t.TempDir()
+	june := filepath.Join(root, "token-usage-2026-06.jsonl")
+	july := filepath.Join(root, "token-usage-2026-07.jsonl")
+	writeUsageFixture(t, june, "{}\n")
+	writeUsageFixture(t, july, "{}\n")
+	future := time.Now().Add(24 * time.Hour)
+	mustNoError(t, os.Chtimes(june, future, future))
+	collector := NewCollector(store, SourceRoots{QwenUsage: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessQwen, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].ArtifactPath != canonicalUsagePath(t, july) {
+		t.Fatalf("initial sources=%+v err=%v", sources, err)
+	}
+
+	august := filepath.Join(root, "token-usage-2026-08.jsonl")
+	writeUsageFixture(t, august, "{}\n")
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+	sources, err = store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("rollover sources=%+v err=%v", sources, err)
+	}
+	gotPaths := []string{sources[0].ArtifactPath, sources[1].ArtifactPath}
+	slices.Sort(gotPaths)
+	wantPaths := []string{canonicalUsagePath(t, july), canonicalUsagePath(t, august)}
+	slices.Sort(wantPaths)
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("paths=%v want=%v", gotPaths, wantPaths)
+	}
+	for _, source := range sources {
+		if source.State != domain.UsageSourceActive && source.State != domain.UsageSourcePending {
+			t.Fatalf("source state=%s, want active or newly pending", source.State)
+		}
+	}
+}
+
 func differentHarness(harness domain.AgentHarness) domain.AgentHarness {
 	if harness == domain.HarnessCopilot {
 		return domain.HarnessKimi


### PR DESCRIPTION
## What

Add the focused Qwen layer on top of the Pi stack in #4184.

- Parse Qwen monthly usage records into normalized token usage.
- Enable Qwen as a certified usage harness.
- Discover the newest valid monthly usage file.
- Register later month rollovers without dropping prior source history.
- Preserve cache and reasoning metric coverage for Qwen summaries.

## Stack

- Base: #4184
- This PR: Qwen and the final stack layer

This replaces the Qwen portion of #3778.

## Testing

- go test ./internal/observe/usage ./internal/service/usage ./internal/lifecycle ./internal/storage/sqlite