### PR TITLE
fix(chat): fail fast on immutable history replay

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -623,6 +623,9 @@ func TestACPDriverLoadsSettledHistoryWhenTheAgentCanReplayIt(t *testing.T) {
 		t.Fatalf("Resume: %v", err)
 	}
 	defer conv.Close()
+	if _, ok := conv.(ports.ChatHistoryRefresher); ok {
+		t.Fatal("ACP session/load replay is a frozen snapshot, not refreshable history")
+	}
 
 	agent.mu.Lock()
 	loadCalls, resumeCalls := agent.loadCalls, agent.resumeCalls

--- a/backend/internal/adapters/chatdriver/codexappserver/history.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/history.go
@@ -45,10 +45,11 @@ import (
 // feature-detects each interface, and a missing method would read as "the provider
 // cannot do this" with nothing anywhere to notice.
 var (
-	_ ports.ChatRollbacker    = (*conversation)(nil)
-	_ ports.ChatForker        = (*conversation)(nil)
-	_ ports.ChatRenamer       = (*conversation)(nil)
-	_ ports.ChatHistoryReader = (*conversation)(nil)
+	_ ports.ChatRollbacker       = (*conversation)(nil)
+	_ ports.ChatForker           = (*conversation)(nil)
+	_ ports.ChatRenamer          = (*conversation)(nil)
+	_ ports.ChatHistoryReader    = (*conversation)(nil)
+	_ ports.ChatHistoryRefresher = (*conversation)(nil)
 )
 
 // providerRefusal marks a request the provider rejected on its own terms, as
@@ -191,6 +192,13 @@ func (c *conversation) ReadHistory(ctx context.Context) ([]ports.ChatEvent, erro
 		events = append(events, completed)
 	}
 	return events, nil
+}
+
+// RefreshHistory performs another authoritative thread/read. Codex exposes a
+// repeatable native read rather than a replay captured during resume, so bounded
+// settle polling can observe provider progress here.
+func (c *conversation) RefreshHistory(ctx context.Context) ([]ports.ChatEvent, error) {
+	return c.ReadHistory(ctx)
 }
 
 func historyEventID(parts ...string) string {

--- a/backend/internal/adapters/chatdriver/codexappserver/history_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/history_test.go
@@ -120,6 +120,41 @@ func TestReadHistoryRejectsAnUnsettledNativeTurnInsteadOfOmittingIt(t *testing.T
 	}
 }
 
+func TestRefreshHistoryPerformsANewThreadRead(t *testing.T) {
+	conv, srv := openConversation(t)
+	srv.reply("thread/read", `{"thread":{"id":"thread-1","turns":[`+
+		`{"id":"turn-a","status":"inProgress"}`+
+		`]}}`)
+
+	if _, err := conv.ReadHistory(context.Background()); !errors.Is(err, ports.ErrChatHistoryUnsettled) {
+		t.Fatalf("ReadHistory error = %v, want ErrChatHistoryUnsettled", err)
+	}
+
+	srv.reply("thread/read", `{"thread":{"id":"thread-1","turns":[`+
+		`{"id":"turn-a","status":"completed"}`+
+		`]}}`)
+	events, err := conv.RefreshHistory(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshHistory: %v", err)
+	}
+	if len(events) != 2 || events[0].Kind != ports.ChatEventTurnStarted ||
+		events[1].Kind != ports.ChatEventTurnCompleted || events[1].TurnState != "completed" {
+		t.Fatalf("refreshed events = %#v, want settled turn replay", events)
+	}
+
+	srv.mu.Lock()
+	reads := 0
+	for _, seen := range srv.seen {
+		if seen.Method == "thread/read" {
+			reads++
+		}
+	}
+	srv.mu.Unlock()
+	if reads != 2 {
+		t.Fatalf("thread/read requests = %d, want one initial read and one refresh", reads)
+	}
+}
+
 // The provider takes a COUNT from the end of the thread, not a turn id, so the whole
 // correctness of rollback rests on turning the named turn into the right number.
 // Naming the middle of three turns must discard that turn and the one after it.

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -56,9 +56,9 @@ var (
 	// ErrChatConfigOptionInvalid means a client named an unknown option, sent the
 	// wrong value type, or selected a value the provider did not advertise.
 	ErrChatConfigOptionInvalid = errors.New("chat config option value is invalid")
-	// ErrChatHistoryUnsettled means the native conversation still contains a
-	// running or queued turn. Callers may retry until the provider reaches a
-	// settled boundary; they must not project a partial replay as complete.
+	// ErrChatHistoryUnsettled means the native conversation history is not safe
+	// to project as complete. Only a ChatHistoryRefresher promises that another
+	// provider observation may make progress; rereading a snapshot need not.
 	ErrChatHistoryUnsettled = errors.New("chat conversation history is not settled")
 	// ErrChatHistoryUnavailable means the provider can resume its model context
 	// but cannot replay that context as typed history. ACP session/resume has this
@@ -843,6 +843,15 @@ type ChatConversation interface {
 // into the Chat service.
 type ChatHistoryReader interface {
 	ReadHistory(ctx context.Context) ([]ChatEvent, error)
+}
+
+// ChatHistoryRefresher refines ChatHistoryReader for a provider that can make a
+// new authoritative history observation. RefreshHistory must perform provider
+// I/O or wait for a real provider signal; returning the previous capture does not
+// qualify. Callers may use it for bounded convergence after an unsettled read.
+type ChatHistoryRefresher interface {
+	ChatHistoryReader
+	RefreshHistory(ctx context.Context) ([]ChatEvent, error)
 }
 
 // ChatDriverRegistry resolves the driver for a harness.

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -467,14 +467,10 @@ func (c *Controller) importNativeHistory(
 	}
 	historyCtx, cancel := context.WithTimeout(ctx, nativeHistorySettleLimit)
 	defer cancel()
-	var events []ports.ChatEvent
+	events, err := reader.ReadHistory(historyCtx)
+	refresher, refreshable := reader.(ports.ChatHistoryRefresher)
 	sawUnsettled := false
-	for {
-		var err error
-		events, err = reader.ReadHistory(historyCtx)
-		if err == nil && (!required || checkpoint.reached(events)) {
-			break
-		}
+	for err != nil || (required && !checkpoint.reached(events)) {
 		if err == nil {
 			err = ports.ErrChatHistoryUnsettled
 		}
@@ -489,6 +485,9 @@ func (c *Controller) importNativeHistory(
 			return fmt.Errorf("read native conversation history: %w", err)
 		}
 		sawUnsettled = true
+		if !refreshable {
+			return fmt.Errorf("native conversation history snapshot is incomplete and cannot be refreshed: %w", err)
+		}
 
 		timer := time.NewTimer(nativeHistorySettlePoll)
 		select {
@@ -498,6 +497,7 @@ func (c *Controller) importNativeHistory(
 				ports.ErrChatHistoryUnsettled, historyCtx.Err())
 		case <-timer.C:
 		}
+		events, err = refresher.RefreshHistory(historyCtx)
 	}
 	events = reconcileNativeHistory(
 		events, existingTurns, existingMessages, existingActivities,

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,14 +74,19 @@ type nativeHistoryConversation struct {
 	*fakeConversation
 	events []ports.ChatEvent
 	err    error
-	onRead func()
+	reads  atomic.Int32
+	onRead func(int)
 }
 
 type convergingHistoryConversation struct {
 	*fakeConversation
-	mu       sync.Mutex
-	attempts int
-	events   []ports.ChatEvent
+	mu             sync.Mutex
+	reads          int
+	refreshes      int
+	initialSettled bool
+	initialEvents  []ports.ChatEvent
+	events         []ports.ChatEvent
+	onRead         func()
 }
 
 type blockingHistoryConversation struct {
@@ -100,26 +106,50 @@ func (c *blockingHistoryConversation) ReadHistory(ctx context.Context) ([]ports.
 }
 
 func (c *nativeHistoryConversation) ReadHistory(context.Context) ([]ports.ChatEvent, error) {
+	reads := int(c.reads.Add(1))
 	if c.onRead != nil {
-		c.onRead()
+		c.onRead(reads)
 	}
 	return c.events, c.err
 }
 
 func (c *convergingHistoryConversation) ReadHistory(context.Context) ([]ports.ChatEvent, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.attempts++
-	if c.attempts == 1 {
+	c.reads++
+	reads := c.reads
+	onRead := c.onRead
+	initialSettled := c.initialSettled
+	initialEvents := append([]ports.ChatEvent(nil), c.initialEvents...)
+	events := append([]ports.ChatEvent(nil), c.events...)
+	c.mu.Unlock()
+	if onRead != nil {
+		onRead()
+	}
+	if reads == 1 {
+		if initialSettled {
+			return initialEvents, nil
+		}
 		return nil, ports.ErrChatHistoryUnsettled
 	}
-	return append([]ports.ChatEvent(nil), c.events...), nil
+	return events, nil
 }
 
-func (c *convergingHistoryConversation) readAttempts() int {
+func (c *convergingHistoryConversation) RefreshHistory(context.Context) ([]ports.ChatEvent, error) {
+	c.mu.Lock()
+	c.refreshes++
+	events := append([]ports.ChatEvent(nil), c.events...)
+	c.mu.Unlock()
+	return events, nil
+}
+
+func (c *convergingHistoryConversation) historyAttempts() (reads, refreshes int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.attempts
+	return c.reads, c.refreshes
+}
+
+func (c *nativeHistoryConversation) historyReads() int {
+	return int(c.reads.Load())
 }
 
 type deferredConversation struct {
@@ -412,7 +442,7 @@ func TestResumeCanSkipNativeHistoryImportWithoutStartingFresh(t *testing.T) {
 		events: []ports.ChatEvent{{
 			Kind: ports.ChatEventTurnStarted, ProviderTurnID: "old-target-turn",
 		}},
-		onRead: func() { historyReads++ },
+		onRead: func(int) { historyReads++ },
 	}
 	conv.providerConversationID = "target-native-thread"
 	var started ports.ChatStartConfig
@@ -585,7 +615,7 @@ func TestResumeImportsNativeHistoryBeforeTheChatControllerStarts(t *testing.T) {
 	}
 }
 
-func TestInterfaceHandoffWaitsForNativeHistoryToSettleBeforeStartingChat(t *testing.T) {
+func TestInterfaceHandoffRefreshesNativeHistoryUntilSettledBeforeStartingChat(t *testing.T) {
 	st := openStore(t)
 	rec, found, err := st.GetSession(context.Background(), testSession)
 	if err != nil || !found {
@@ -636,8 +666,10 @@ func TestInterfaceHandoffWaitsForNativeHistoryToSettleBeforeStartingChat(t *test
 	if err != nil {
 		t.Fatalf("Start handoff: %v", err)
 	}
-	if got := conv.readAttempts(); got != 2 {
-		t.Fatalf("ReadHistory attempts = %d, want one unsettled read followed by convergence", got)
+	reads, refreshes := conv.historyAttempts()
+	if reads != 1 || refreshes != 1 {
+		t.Fatalf("history attempts = %d reads, %d refreshes; want one initial read followed by one refresh",
+			reads, refreshes)
 	}
 	snapshot, err := st.LoadConversationSnapshot(context.Background(), ctrl.ConversationID())
 	if err != nil {
@@ -649,6 +681,72 @@ func TestInterfaceHandoffWaitsForNativeHistoryToSettleBeforeStartingChat(t *test
 	}
 	if len(snapshot.Turns) != 1 || snapshot.Turns[0].State != domain.TurnStateCompleted {
 		t.Fatalf("turns = %#v, want one completed native turn", snapshot.Turns)
+	}
+}
+
+func TestInterfaceHandoffRefreshesNativeHistoryUntilItReachesTheCheckpoint(t *testing.T) {
+	st := openStore(t)
+	rec, found, err := st.GetSession(context.Background(), testSession)
+	if err != nil || !found {
+		t.Fatalf("load session: found=%v err=%v", found, err)
+	}
+	rec.Metadata.LatestUserPrompt = "Run the final verification."
+	rec.Metadata.LatestAssistantUpdate = "The final verification passed."
+	if err := st.UpdateSession(context.Background(), rec); err != nil {
+		t.Fatalf("seed native replay checkpoint: %v", err)
+	}
+
+	conv := &convergingHistoryConversation{
+		fakeConversation: newFakeConversation(),
+		initialSettled:   true,
+		// The first authoritative observation is internally settled but stale.
+		// RefreshHistory performs the provider read that reaches AO's checkpoint.
+		initialEvents: nil,
+		events: []ports.ChatEvent{
+			{Kind: ports.ChatEventTurnStarted, ProviderEventID: "history-start", ProviderTurnID: "native-turn-1"},
+			{
+				Kind: ports.ChatEventUserMessageCompleted, ProviderEventID: "history-user",
+				ProviderTurnID: "native-turn-1", ProviderItemID: "native-user-1",
+				Text: "Run the final verification.",
+			},
+			{
+				Kind: ports.ChatEventMessageCompleted, ProviderEventID: "history-answer",
+				ProviderTurnID: "native-turn-1", ProviderItemID: "native-answer-1",
+				Text: "The final verification passed.",
+			},
+			{
+				Kind: ports.ChatEventTurnCompleted, ProviderEventID: "history-complete",
+				ProviderTurnID: "native-turn-1", TurnState: domain.TurnStateCompleted,
+			},
+		},
+	}
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers: fakeRegistry{driver: fakeDriver{conv: conv}},
+		Log:     slog.New(slog.DiscardHandler),
+		NewID:   func() string { return fmt.Sprintf("checkpoint-refresh-%d", time.Now().UnixNano()) },
+	})
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+
+	ctrl, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(), ProviderConversationID: "thread-1", RequireNativeHistory: true,
+	})
+	if err != nil {
+		t.Fatalf("Start handoff: %v", err)
+	}
+	reads, refreshes := conv.historyAttempts()
+	if reads != 1 || refreshes != 1 {
+		t.Fatalf("history attempts = %d reads, %d refreshes; want one stale read followed by one refresh",
+			reads, refreshes)
+	}
+	snapshot, err := st.LoadConversationSnapshot(context.Background(), ctrl.ConversationID())
+	if err != nil {
+		t.Fatalf("LoadConversationSnapshot: %v", err)
+	}
+	if len(snapshot.Messages) != 2 || snapshot.Messages[0].Text != "Run the final verification." ||
+		snapshot.Messages[1].Text != "The final verification passed." {
+		t.Fatalf("messages = %#v, want refreshed checkpoint transcript", snapshot.Messages)
 	}
 }
 
@@ -740,13 +838,12 @@ func TestOrdinaryResumeAllowsACPContextWithoutHistoryReplay(t *testing.T) {
 	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
 }
 
-func TestInterfaceHandoffReportsUnsettledHistoryWhenContextEndsDuringConvergence(t *testing.T) {
+func TestInterfaceHandoffReportsUnsettledHistoryWhenContextEndsBeforeRefresh(t *testing.T) {
 	st := openStore(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	conv := &nativeHistoryConversation{
+	conv := &convergingHistoryConversation{
 		fakeConversation: newFakeConversation(),
-		err:              ports.ErrChatHistoryUnsettled,
 		// End the request only after native history import is reached. A tiny
 		// wall-clock deadline here used to expire during SQLite setup under the
 		// race runner and test ClaimChatControllerGeneration instead.
@@ -764,6 +861,47 @@ func TestInterfaceHandoffReportsUnsettledHistoryWhenContextEndsDuringConvergence
 	})
 	if !errors.Is(err, ports.ErrChatHistoryUnsettled) {
 		t.Fatalf("Start error = %v, want ErrChatHistoryUnsettled", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start error = %v, want context cancellation cause", err)
+	}
+	reads, refreshes := conv.historyAttempts()
+	if reads != 1 || refreshes != 0 {
+		t.Fatalf("history attempts = %d reads, %d refreshes; want cancellation before refresh",
+			reads, refreshes)
+	}
+}
+
+func TestInterfaceHandoffRejectsUnsettledImmutableHistoryWithoutRereading(t *testing.T) {
+	st := openStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conv := &nativeHistoryConversation{
+		fakeConversation: newFakeConversation(),
+		err:              ports.ErrChatHistoryUnsettled,
+		// Cancel a forbidden second read so the test fails quickly instead of
+		// waiting the full 45s settle limit on a regression.
+		onRead: func(reads int) {
+			if reads == 2 {
+				cancel()
+			}
+		},
+	}
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers: fakeRegistry{driver: fakeDriver{conv: conv}},
+		Log:     slog.New(slog.DiscardHandler),
+		NewID:   func() string { return fmt.Sprintf("immutable-unsettled-%d", time.Now().UnixNano()) },
+	})
+	_, err := svc.Start(ctx, chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(), ProviderConversationID: "thread-1", RequireNativeHistory: true,
+	})
+	if !errors.Is(err, ports.ErrChatHistoryUnsettled) {
+		t.Fatalf("Start error = %v, want ErrChatHistoryUnsettled", err)
+	}
+	if reads := conv.historyReads(); reads != 1 {
+		t.Fatalf("immutable history reads = %d, want exactly one", reads)
 	}
 }
 
@@ -787,7 +925,13 @@ func TestInterfaceHandoffRejectsSettledReplayBeforeLatestSessionCheckpoint(t *te
 		// on-disk transcript is still being flushed. Empty is the strongest form of
 		// that failure: no replay event reaches the hook facts AO already observed.
 		events: nil,
-		onRead: cancel,
+		// Cancel a forbidden second read so the test fails quickly instead of
+		// waiting the full 45s settle limit on a regression.
+		onRead: func(reads int) {
+			if reads == 2 {
+				cancel()
+			}
+		},
 	}
 	svc := chatsvc.New(chatsvc.Options{
 		Store: st, Sessions: st,
@@ -803,6 +947,9 @@ func TestInterfaceHandoffRejectsSettledReplayBeforeLatestSessionCheckpoint(t *te
 	})
 	if !errors.Is(err, ports.ErrChatHistoryUnsettled) {
 		t.Fatalf("Start error = %v, want ErrChatHistoryUnsettled for stale settled replay", err)
+	}
+	if reads := conv.historyReads(); reads != 1 {
+		t.Fatalf("immutable history reads = %d, want exactly one", reads)
 	}
 }
 


### PR DESCRIPTION
## What

- add an optional `ChatHistoryRefresher` port for history sources that can make a new authoritative provider observation
- read every native history source once, then retry only through that explicit refresh operation
- keep ACP `session/load` replay snapshot-only so an incomplete replay fails immediately instead of polling the same cache for 45 seconds
- make Codex refreshable through its real `thread/read`, preserving bounded convergence where it can actually make progress

## Why

Fixes #4123.

ACP captures replay once during `Resume`; every later `ReadHistory` returns the same frozen events. The generic settle loop nevertheless reread that cache every 100ms for up to 45 seconds when it was unsettled or missed AO's checkpoint. That delayed a guaranteed handoff failure and rollback without observing any new provider fact.

## How

This follows ACP v1's actual boundary: [`session/load` is a finite replay whose response follows the replayed entries](https://github.com/agentclientprotocol/agent-client-protocol/blob/main/docs/protocol/v1/session-setup.mdx), not a standardized repeatable history read.

- `ChatHistoryReader` represents one authoritative history observation.
- `ChatHistoryRefresher` promises that `RefreshHistory` performs provider I/O or waits for a real provider signal.
- `Controller.importNativeHistory` keeps its bounded timeout around the initial read and refresh loop, but immediately returns `ErrChatHistoryUnsettled` when an incomplete source cannot refresh.
- Codex implements refresh by issuing another `thread/read(includeTurns: true)`.
- ACP deliberately does not implement refresh; the PR never reissues `session/load`, adds a grace sleep, or infers provider state from a load response.

Intentional omissions: this focused fix does not change trailing-user-only turn classification, introduce load-versus-resume intent, or adopt draft ACP v2 lifecycle/replay types. Those require separate state/evidence contracts and should not be coupled to #4123.

## Testing

- `cd backend && go build ./...`
- `cd backend && go test ./internal/service/chat ./internal/adapters/chatdriver/acp ./internal/adapters/chatdriver/codexappserver -count=1`
- `cd backend && go test -race ./internal/ports ./internal/service/chat ./internal/adapters/chatdriver/acp ./internal/adapters/chatdriver/codexappserver -count=1`
- `GOLANGCI_LINT_CACHE=/tmp/ao-lint-cache-4123-fresh npm run lint` — full backend tests and golangci-lint, 0 issues

Regression coverage verifies:

- an immutable unsettled replay is read exactly once and fails immediately
- an immutable settled replay behind AO's checkpoint is read exactly once and fails immediately
- a refreshable unsettled source converges through one initial read plus one refresh
- a refreshable settled-but-stale source refreshes until it reaches AO's checkpoint
- cancellation before refresh preserves the typed unsettled error and context cause
- Codex refresh performs a second wire `thread/read`
- ACP conversations do not advertise refreshability

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added for the changed boundary and user-visible failure behavior
- [x] Relevant build, race, test, and lint checks pass
