### PR TITLE
fix(updater): check disk space before update and surface failed installs (#3528)

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -1,8 +1,24 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import nodePath from "node:path";
+
+// node:fs's ESM namespace is not configurable, so statfsSync is mocked at the
+// module level instead of via spyOn.
+const statfsMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, statfsSync: statfsMock as unknown as typeof actual.statfsSync };
+});
 
 type UpdateSettings = {
   enabled: boolean;
@@ -21,6 +37,9 @@ type ImportOptions = {
     settings: UpdateSettings,
   ) => Promise<{ settings: UpdateSettings; cleared: boolean }>;
   isPackaged?: boolean;
+  // Backs app.getPath in the electron mock; unset makes getPath throw, which
+  // the updater's marker/preflight paths must tolerate (fail open).
+  getPath?: (name: string) => string;
 };
 
 type AutoUpdaterMock = {
@@ -93,6 +112,9 @@ async function importAutoUpdater(
     app: {
       isPackaged: options.isPackaged ?? true,
       getVersion: () => "1.0.0",
+      getPath: options.getPath ?? (() => {
+        throw new Error("getPath not available in test");
+      }),
     },
     BrowserWindow,
     dialog,
@@ -1651,3 +1673,206 @@ describe("install-on-quit policy", () => {
     }
   });
 });
+
+// #3528: a full disk truncated Squirrel's extraction into a bogus
+// "The file ... doesn't exist" install failure no UI ever saw. The preflight
+// below turns that into an actionable dialog plus install-phase telemetry; a
+// persisted install-attempt marker makes the post-quit failure reportable on
+// the next launch.
+function stubStatfs(freeBytes: number | "throw"): void {
+  statfsMock.mockReset();
+  if (freeBytes === "throw") {
+    statfsMock.mockImplementation(() => {
+      throw new Error("statfs unavailable");
+    });
+  } else {
+    const bsize = 4096;
+    statfsMock.mockImplementation(() => ({ bsize, bavail: Math.floor(freeBytes / bsize) }));
+  }
+}
+
+const AMPLE_BYTES = 3 * 1024 * 1024 * 1024;
+
+// Real userData/cache dirs behind the electron getPath mock, so the marker and
+// ShipIt log tests exercise the filesystem rather than stubs.
+function makeElectronPaths(): {
+  userData: string;
+  cache: string;
+  getPath: (name: string) => string;
+  cleanup: () => void;
+} {
+  const base = mkdtempSync(nodePath.join(os.tmpdir(), "ao-updater-paths-"));
+  const userData = nodePath.join(base, "userData");
+  const cache = nodePath.join(base, "cache");
+  mkdirSync(userData, { recursive: true });
+  mkdirSync(cache, { recursive: true });
+  return {
+    userData,
+    cache,
+    getPath: (name: string) => {
+      if (name === "userData") return userData;
+      if (name === "cache") return cache;
+      throw new Error(`unexpected getPath("${name}")`);
+    },
+    cleanup: () => rmSync(base, { recursive: true, force: true }),
+  };
+}
+
+describe("disk-space install preflight (#3528)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("blocks quitAndInstall with an actionable dialog and install-phase telemetry when free space is low", async () => {
+    const { root, execPath } = makeBundle();
+    const restore = stubProcess("darwin", execPath);
+    const paths = makeElectronPaths();
+    stubStatfs(50 * 1024 * 1024); // 50MB << ~1.5GB reserve
+    try {
+      const { module, autoUpdater, dialog, telemetryMessages } =
+        await importAutoUpdater(undefined, { getPath: paths.getPath });
+
+      module.quitAndInstallUpdate();
+
+      expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+      expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+      const box = dialog.showMessageBox.mock.calls[0][0] as { message: string; detail: string };
+      expect(box.message).toContain("disk space");
+      expect(box.detail).toContain("Free up");
+      const install = telemetryMessages().filter(
+        (m) => (m.payload as { phase?: string }).phase === "install",
+      );
+      expect(install).toHaveLength(1);
+      expect((install[0].payload as { error_category?: string }).error_category).toBe("disk_space");
+    } finally {
+      restore();
+      rmSync(root, { recursive: true, force: true });
+      paths.cleanup();
+    }
+  });
+
+  it("installs and persists the attempt marker when free space is ample", async () => {
+    const { root, execPath } = makeBundle();
+    const restore = stubProcess("darwin", execPath);
+    const paths = makeElectronPaths();
+    stubStatfs(AMPLE_BYTES);
+    try {
+      const { module, autoUpdater, updaterEvents } = await importAutoUpdater(undefined, {
+        getPath: paths.getPath,
+      });
+      // Wire the updater event handlers (a check path does this) before
+      // simulating the staged download that quitAndInstallUpdate marks.
+      await module.checkForUpdatesNow(paths.userData);
+      updaterEvents.get("update-downloaded")?.({ version: "2.0.0" });
+
+      module.quitAndInstallUpdate();
+
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+      const marker = nodePath.join(paths.userData, "update-install-attempt.json");
+      expect(existsSync(marker)).toBe(true);
+      expect(JSON.parse(readFileSync(marker, "utf8")).version).toBe("2.0.0");
+    } finally {
+      restore();
+      rmSync(root, { recursive: true, force: true });
+      paths.cleanup();
+    }
+  });
+
+  it("fails open (installs anyway) when statfs errors", async () => {
+    const { root, execPath } = makeBundle();
+    const restore = stubProcess("darwin", execPath);
+    const paths = makeElectronPaths();
+    stubStatfs("throw");
+    try {
+      const { module, autoUpdater } = await importAutoUpdater(undefined, {
+        getPath: paths.getPath,
+      });
+
+      module.quitAndInstallUpdate();
+
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+    } finally {
+      restore();
+      rmSync(root, { recursive: true, force: true });
+      paths.cleanup();
+    }
+  });
+});
+
+describe("post-quit install failure surfacing (#3528)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("reports a failed install attempt on next launch, with the ShipIt log tail", async () => {
+    const paths = makeElectronPaths();
+    stubStatfs(AMPLE_BYTES);
+    mkdirSync(nodePath.join(`${paths.cache}.ShipIt`), { recursive: true });
+    writeFileSync(
+      nodePath.join(`${paths.cache}.ShipIt`, "ShipIt_stderr.log"),
+      '2026-08-03 15:05:43 SQRLInstallerErrorDomain Code=-1 Failed to copy bundle: The file "af.lproj" doesn\'t exist.\n',
+    );
+    writeFileSync(
+      nodePath.join(paths.userData, "update-install-attempt.json"),
+      `${JSON.stringify({ version: "9.9.9", attemptedAt: 1754235943000 })}\n`,
+    );
+    try {
+      const { module, dialog, telemetryMessages } = await importAutoUpdater(undefined, {
+        getPath: paths.getPath,
+      });
+
+      await module.startAutoUpdates(paths.userData);
+
+      expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+      const box = dialog.showMessageBox.mock.calls[0][0] as { message: string; detail?: string };
+      expect(box.message).toBe("The last update didn't install");
+      expect(box.detail).toContain("af.lproj");
+      // Reported exactly once: the marker is cleared.
+      expect(existsSync(nodePath.join(paths.userData, "update-install-attempt.json"))).toBe(false);
+      const install = telemetryMessages().filter(
+        (m) => (m.payload as { phase?: string }).phase === "install",
+      );
+      expect(install).toHaveLength(1);
+      expect((install[0].payload as { to_version?: string }).to_version).toBe("9.9.9");
+    } finally {
+      paths.cleanup();
+    }
+  });
+
+  it("stays silent when the attempted version is now the running version", async () => {
+    const paths = makeElectronPaths();
+    stubStatfs(AMPLE_BYTES);
+    writeFileSync(
+      nodePath.join(paths.userData, "update-install-attempt.json"),
+      `${JSON.stringify({ version: "1.0.0", attemptedAt: Date.now() })}\n`,
+    );
+    try {
+      const { module, dialog } = await importAutoUpdater(undefined, { getPath: paths.getPath });
+
+      await module.startAutoUpdates(paths.userData);
+
+      expect(dialog.showMessageBox).not.toHaveBeenCalled();
+      // Marker still cleared so it cannot resurface.
+      expect(existsSync(nodePath.join(paths.userData, "update-install-attempt.json"))).toBe(false);
+    } finally {
+      paths.cleanup();
+    }
+  });
+
+  it("does nothing on a clean launch (no marker)", async () => {
+    const paths = makeElectronPaths();
+    stubStatfs(AMPLE_BYTES);
+    try {
+      const { module, dialog } = await importAutoUpdater(undefined, { getPath: paths.getPath });
+
+      await module.startAutoUpdates(paths.userData);
+
+      expect(dialog.showMessageBox).not.toHaveBeenCalled();
+    } finally {
+      paths.cleanup();
+    }
+  });
+});
+

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1,8 +1,36 @@
 import { autoUpdater } from "electron-updater";
 import { app, BrowserWindow, dialog } from "electron";
-import { accessSync, constants as fsConstants, existsSync } from "node:fs";
+import {
+  accessSync,
+  constants as fsConstants,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import {
+  DOWNLOAD_RESERVE_BYTES,
+  INSTALL_RESERVE_BYTES,
+  freeBytesOnVolume,
+  gbRoundedUp,
+  minFreeBytes,
+} from "./update-disk-space";
+
+// Electron's getPath type union omits "cache" even though it is a valid runtime
+// name (~/Library/Caches/<bundle-id> on macOS); Squirrel stages ShipIt data
+// next to it, so that is the volume the preflight must statfs (#3528).
+const CACHE_PATH_NAME = "cache" as Parameters<typeof app.getPath>[0];
+
+function cacheDirPath(): string | undefined {
+  try {
+    return app.getPath(CACHE_PATH_NAME);
+  } catch {
+    return undefined;
+  }
+}
 import {
   readUpdateSettings,
   updateUpdateSettings,
@@ -16,7 +44,9 @@ import { reconcileFeaturePin } from "./feature-builds";
 import { evaluateEscalation } from "./escalation-evaluator";
 import {
   isNetErrorMessage,
+  updateFailureCategory,
   updateFailureOutcome,
+  type UpdateFailureCategory,
   type UpdateOutcome,
   type UpdatePhase,
   type UpdateTrigger,
@@ -143,6 +173,22 @@ function emitUpdateFailure(err: unknown): void {
   );
 }
 
+// emitInstallBlockedOutcome reports an install attempt that was stopped by a
+// preflight blocker, so the install phase stops being a telemetry blind spot
+// (#3528: UpdatePhase was previously only check|download).
+function emitInstallBlockedOutcome(
+  reason: string,
+  category: UpdateFailureCategory = updateFailureCategory(reason),
+): void {
+  emitUpdateOutcome({
+    event: "ao.renderer.update_failed",
+    phase: "install",
+    trigger: "manual",
+    error_category: category,
+    ...(stagedVersion ? { to_version: stagedVersion } : {}),
+  });
+}
+
 // broadcast pushes the latest update status to every renderer window so the
 // Global Settings Updates section can reflect check/download progress live.
 function broadcast(
@@ -252,13 +298,17 @@ async function fetchNightlyImportant(
 
 // stagedDownloadedStatus rebuilds the enriched downloaded status from module
 // state, so transient check states can restore the row without recomputing.
+// When an install blocker is active the status carries the reason (#3528):
+// "restart to update" would otherwise promise an install that cannot land.
 function stagedDownloadedStatus(): UpdateStatus {
+  const blockedReason = installBlockerReason();
   return {
     state: "downloaded",
     version: stagedVersion,
     stagedAt: stagedAtMs,
     escalated: stagedEscalated,
     ...(stagedRequestId === undefined ? {} : { requestId: stagedRequestId }),
+    ...(blockedReason === undefined ? {} : { installBlockedReason: blockedReason }),
   };
 }
 
@@ -607,7 +657,20 @@ async function runAutomaticUpdateCheck(stateDir: string): Promise<boolean> {
       escalationStateDir = stateDir;
       wireUpdaterEvents();
       configureFeed(settings);
-      autoUpdater.autoDownload = true;
+      // Disk preflight (#3528): with no room for the ~110MB zip, an automatic
+      // download truncates and the failure only surfaces after quit. Still run
+      // the check (statuses stay live); the download waits for space.
+      const downloadBlocker = getDiskSpaceDownloadBlocker();
+      autoUpdater.autoDownload = downloadBlocker === undefined;
+      if (downloadBlocker !== undefined) {
+        console.warn("automatic update download skipped:", downloadBlocker);
+        emitUpdateOutcome({
+          event: "ao.renderer.update_failed",
+          phase: "download",
+          trigger: "automatic",
+          error_category: "disk_space",
+        });
+      }
       applyInstallOnQuitPolicy();
       try {
         const result = await autoUpdater.checkForUpdates();
@@ -668,6 +731,10 @@ async function requestAutomaticUpdateCheck(
 // It is a thin shell: all policy (channel, opt-in) comes from update-settings.
 // Caller guards on app.isPackaged.
 export async function startAutoUpdates(stateDir: string): Promise<void> {
+  // First, close the loop on any install attempted last session: ShipIt runs
+  // after quit, so this launch is the first moment that can report its failure
+  // (#3528).
+  reportFailedInstallAttempt();
   startRetirementPollTimer(stateDir);
   const shouldSchedule = await requestAutomaticUpdateCheck(stateDir);
   if (shouldSchedule === true) schedulePeriodicAutomaticUpdateCheck(stateDir);
@@ -831,6 +898,20 @@ export async function downloadUpdateNow(requestId?: string): Promise<void> {
     });
     return;
   }
+  // Disk preflight (#3528): fail the download up front with an actionable
+  // message instead of letting it truncate on a full disk.
+  const downloadBlocker = getDiskSpaceDownloadBlocker();
+  if (downloadBlocker !== undefined) {
+    emitUpdateOutcome({
+      event: "ao.renderer.update_failed",
+      phase: "download",
+      trigger: "manual",
+      error_category: "disk_space",
+      ...(pendingUpdateVersion ? { to_version: pendingUpdateVersion } : {}),
+    });
+    broadcast({ state: "error", message: downloadBlocker, requestId });
+    return;
+  }
   try {
     await runSerializedUpdaterOperation(
       "manual-download",
@@ -909,14 +990,153 @@ export function getMacInstallBlocker(): string | undefined {
   return undefined;
 }
 
+// getDiskSpaceInstallBlocker is the disk-space half of the install preflight
+// (#3528). Squirrel needs roughly 3x the app size for extraction + staging +
+// the old-bundle backup (~1.5GB ballpark); below that, extraction truncates
+// and ShipIt fails AFTER the app has quit with a bogus "The file ...
+// doesn't exist" error no UI ever shows. Returns the user-facing message when
+// free space is below the reserve; undefined to proceed. Fails open: a statfs
+// problem never blocks the install.
+export function getDiskSpaceInstallBlocker(): string | undefined {
+  const dirs = [path.dirname(process.execPath)];
+  const cacheDir = cacheDirPath();
+  if (cacheDir !== undefined) dirs.push(cacheDir);
+  const free = minFreeBytes(dirs);
+  if (free === undefined || free >= INSTALL_RESERVE_BYTES) return undefined;
+  const gbNeeded = gbRoundedUp(INSTALL_RESERVE_BYTES);
+  return (
+    "Installing the update needs room to extract and stage it on this disk " +
+    `(about ${gbNeeded} GB), but only ${(free / (1024 * 1024 * 1024)).toFixed(1)} GB ` +
+    `is free. Free up at least ${gbNeeded} GB of space, then restart to update again.`
+  );
+}
+
+// getDiskSpaceDownloadBlocker is the pre-download preflight (#3528): the
+// ~110MB zip (plus temp headroom) must fit on the cache volume. Fails open.
+export function getDiskSpaceDownloadBlocker(): string | undefined {
+  const cacheDir = cacheDirPath();
+  if (cacheDir === undefined) return undefined;
+  const free = freeBytesOnVolume(cacheDir);
+  if (free === undefined || free >= DOWNLOAD_RESERVE_BYTES) return undefined;
+  const gbNeeded = gbRoundedUp(DOWNLOAD_RESERVE_BYTES);
+  return (
+    "Downloading the update needs about " +
+    `${gbNeeded} GB of free disk space, but only ` +
+    `${(free / (1024 * 1024 * 1024)).toFixed(2)} GB is free. Free up space, then check ` +
+    "for updates again."
+  );
+}
+
+// installBlockerReason is whatever currently prevents quitAndInstall from
+// landing: the macOS location blocker (#3527) or low disk space (#3528).
+// Used both for the install-on-quit policy and the "downloaded" status so the
+// restart row stops promising an install that cannot work.
+function installBlockerReason(): string | undefined {
+  return getMacInstallBlocker() ?? getDiskSpaceInstallBlocker();
+}
+
+// --- Post-quit install-failure surfacing (#3528) ---
+// ShipIt installs AFTER the app quits, so an ENOSPC-truncated extraction fails
+// where no in-app UI exists to report it. quitAndInstallUpdate persists a
+// marker first; on the next launch, a marker whose version is still newer than
+// the running app proves the install never landed, and the user finally hears
+// about it, with the ShipIt stderr tail that says why.
+const INSTALL_ATTEMPT_MARKER_FILE = "update-install-attempt.json";
+
+function installAttemptMarkerPath(): string | undefined {
+  try {
+    return path.join(app.getPath("userData"), INSTALL_ATTEMPT_MARKER_FILE);
+  } catch {
+    return undefined;
+  }
+}
+
+function writeInstallAttemptMarker(version: string | undefined): void {
+  const file = installAttemptMarkerPath();
+  if (file === undefined || version === undefined) return;
+  try {
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(
+      file,
+      `${JSON.stringify({ version, attemptedAt: Date.now() })}\n`,
+    );
+  } catch (err) {
+    // Marker is best-effort; losing it only loses failure *reporting*, which
+    // is exactly the status quo before this change.
+    console.debug("could not write install-attempt marker:", err);
+  }
+}
+
+// shipItLogTail reads the tail of Squirrel.Mac's ShipIt stderr log, where
+// install failures land (#3528; e.g. SQRLInstallerErrorDomain "The file
+// \"af.lproj\" doesn't exist", the tell of a truncated extraction). Returns
+// undefined off macOS, when absent, or on any read error.
+function shipItLogTail(maxChars = 400): string | undefined {
+  if (process.platform !== "darwin") return undefined;
+  const cacheDir = cacheDirPath();
+  if (cacheDir === undefined) return undefined;
+  try {
+    const logPath = path.join(`${cacheDir}.ShipIt`, "ShipIt_stderr.log");
+    if (!existsSync(logPath)) return undefined;
+    const text = readFileSync(logPath, "utf8").trimEnd();
+    if (text === "") return undefined;
+    return text.length > maxChars ? `…${text.slice(-maxChars)}` : text;
+  } catch {
+    return undefined;
+  }
+}
+
+// reportFailedInstallAttempt surfaces a failed post-quit install on launch
+// (#3528). Cleared in every path so a single failure reports exactly once.
+export function reportFailedInstallAttempt(): void {
+  const file = installAttemptMarkerPath();
+  if (file === undefined || !existsSync(file)) return;
+  let attemptedVersion: string | undefined;
+  try {
+    attemptedVersion = (
+      JSON.parse(readFileSync(file, "utf8")) as { version?: string }
+    ).version;
+  } catch {
+    attemptedVersion = undefined;
+  }
+  try {
+    rmSync(file, { force: true });
+  } catch {
+    // If the marker cannot be removed it is re-read next launch; harmless.
+  }
+  if (attemptedVersion === undefined) return;
+  // If the app now runs the attempted version, the install succeeded.
+  if (attemptedVersion === app.getVersion()) return;
+  const detail = shipItLogTail();
+  emitUpdateOutcome({
+    event: "ao.renderer.update_failed",
+    phase: "install",
+    // quitAndInstall is only reachable from the user-facing restart flow.
+    trigger: "manual",
+    error_category: updateFailureCategory(detail),
+    to_version: attemptedVersion,
+  });
+  void dialog.showMessageBox({
+    type: "warning",
+    message: "The last update didn't install",
+    detail:
+      detail ??
+      `Version ${attemptedVersion} was downloaded but could not be installed. ` +
+        "This is often caused by not enough free disk space. Free up a few GB, " +
+        "then check for updates again.",
+    buttons: ["OK"],
+  });
+}
+
 // applyInstallOnQuitPolicy keeps autoInstallOnAppQuit honest. Every check path
 // sets it to true, and the "downloaded" status row tells the user the build
 // installs on quit. When the install cannot work from this location that is a
 // lie in both directions: the quit-time install fails as silently as the button
 // did, and #3527's dialog only ever covered the button. Turning it off makes
-// the staged build wait for a location it can actually install from.
+// the staged build wait for a location it can actually install from. The same
+// applies to a disk too full for Squirrel's extract+stage+backup (#3528).
 function applyInstallOnQuitPolicy(): void {
-  const blocker = getMacInstallBlocker();
+  const blocker = installBlockerReason();
   autoUpdater.autoInstallOnAppQuit = blocker === undefined;
   if (blocker !== undefined) {
     console.warn(
@@ -938,6 +1158,7 @@ export function quitAndInstallUpdate(): void {
     // retry affordance) without guaranteeing the user ever sees the message.
     // The staged build stays staged; after the user moves the app the same
     // row installs it.
+    emitInstallBlockedOutcome(blocker);
     void dialog.showMessageBox({
       type: "warning",
       message: "The update can't be installed from this location",
@@ -946,6 +1167,25 @@ export function quitAndInstallUpdate(): void {
     });
     return;
   }
+  const diskBlocker = getDiskSpaceInstallBlocker();
+  if (diskBlocker !== undefined) {
+    // Same dialog-not-broadcast policy as the location blocker, for the same
+    // reasons (#3528: a full disk must fail visibly and actionably, never as
+    // the post-quit invisible ShipIt failure).
+    console.warn("update install blocked:", diskBlocker);
+    emitInstallBlockedOutcome(diskBlocker, "disk_space");
+    void dialog.showMessageBox({
+      type: "warning",
+      message: "The update can't be installed. Not enough disk space",
+      detail: diskBlocker,
+      buttons: ["OK"],
+    });
+    return;
+  }
+  // Persist the attempt BEFORE handing off: ShipIt runs after this process is
+  // gone, so the marker is the only way the next launch can tell "install
+  // failed" from "user never restarted" (#3528).
+  writeInstallAttemptMarker(stagedVersion);
   autoUpdater.quitAndInstall(false, true);
 }
 

--- a/frontend/src/main/update-disk-space.test.ts
+++ b/frontend/src/main/update-disk-space.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import os from "node:os";
+import {
+  DOWNLOAD_RESERVE_BYTES,
+  INSTALL_RESERVE_BYTES,
+  freeBytesOnVolume,
+  gbRoundedUp,
+  minFreeBytes,
+} from "./update-disk-space";
+
+// node:fs's ESM namespace is not configurable, so statfsSync is mocked at the
+// module level instead of via spyOn.
+const statfsMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, statfsSync: statfsMock as unknown as typeof actual.statfsSync };
+});
+
+const BSIZE = 4096;
+
+function stubStatfsBytes(freeBytes: number | "throw"): void {
+  statfsMock.mockReset();
+  if (freeBytes === "throw") {
+    statfsMock.mockImplementation(() => {
+      throw new Error("statfs unavailable");
+    });
+  } else {
+    statfsMock.mockImplementation(() => ({ bsize: BSIZE, bavail: Math.floor(freeBytes / BSIZE) }));
+  }
+}
+
+describe("update-disk-space (#3528)", () => {
+  it("computes free bytes from statfs bavail*bsize", () => {
+    stubStatfsBytes(2 * BSIZE);
+    expect(freeBytesOnVolume(os.tmpdir())).toBe(2 * BSIZE);
+  });
+
+  it("returns undefined (fail open) when statfs errors", () => {
+    stubStatfsBytes("throw");
+    expect(freeBytesOnVolume(os.tmpdir())).toBeUndefined();
+  });
+
+  it("minFreeBytes takes the smallest across volumes and skips failed ones", () => {
+    statfsMock.mockReset();
+    statfsMock.mockImplementation(((p: unknown) => {
+      if (String(p).includes("big")) return { bsize: BSIZE, bavail: 4 };
+      if (String(p).includes("small")) return { bsize: BSIZE, bavail: 1 };
+      throw new Error("statfs unavailable");
+    }) as never);
+    expect(minFreeBytes(["a", "big", "small", "b"])).toBe(BSIZE);
+    expect(minFreeBytes(["a", "b"])).toBeUndefined();
+  });
+
+  it("gbRoundedUp rounds up with a floor of 1", () => {
+    expect(gbRoundedUp(1)).toBe(1);
+    expect(gbRoundedUp(1.5 * 1024 ** 3)).toBe(2);
+  });
+
+  it("keeps the reserves the issue sized: ~250MB download, ~1.5GB install", () => {
+    expect(DOWNLOAD_RESERVE_BYTES).toBe(250 * 1024 * 1024);
+    expect(INSTALL_RESERVE_BYTES).toBe(1.5 * 1024 * 1024 * 1024);
+  });
+});

--- a/frontend/src/main/update-disk-space.ts
+++ b/frontend/src/main/update-disk-space.ts
@@ -1,0 +1,58 @@
+import { statfsSync } from "node:fs";
+
+/**
+ * Disk-space preflight for the updater (#3528).
+ *
+ * Squirrel.Mac's ShipIt extracts the update zip and stages copies under
+ * /var/folders and ~/Library/Caches/<bundle-id>.ShipIt. With no space left,
+ * extraction silently truncates and the install fails with a bogus
+ * whether the missing file is whichever locale
+ * directory falls off the end, e.g. af.lproj). This happens after the app has
+ * quit, where no UI can report it. These checks make that failure mode visible
+ * and actionable BEFORE the app hands control to ShipIt.
+ *
+ * Every check fails open: if statfs is unavailable or errors, the update
+ * proceeds exactly as it did before.
+ */
+
+/** Download needs the ~110MB zip plus temp-file headroom. */
+export const DOWNLOAD_RESERVE_BYTES = 250 * 1024 * 1024;
+
+/**
+ * Install needs room for extraction + staging + the old-bundle backup:
+ * roughly 3x the extracted app size, ballpark 1.5GB (#3528).
+ */
+export const INSTALL_RESERVE_BYTES = 1.5 * 1024 * 1024 * 1024;
+
+const GIB = 1024 * 1024 * 1024;
+
+/** Free bytes on the volume containing `dir`; undefined when statfs fails (fail open). */
+export function freeBytesOnVolume(dir: string): number | undefined {
+	try {
+		const stats = statfsSync(dir);
+		const free = Number(stats.bavail) * Number(stats.bsize);
+		return Number.isFinite(free) && free >= 0 ? free : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Smallest free-byte count across the volumes the update must touch; undefined
+ * when every statfs failed (fail open). A volume whose statfs fails is skipped
+ * rather than treated as full.
+ */
+export function minFreeBytes(dirs: string[]): number | undefined {
+	let min: number | undefined;
+	for (const dir of dirs) {
+		const free = freeBytesOnVolume(dir);
+		if (free === undefined) continue;
+		min = min === undefined ? free : Math.min(min, free);
+	}
+	return min;
+}
+
+/** User-facing "free up N GB" figure, rounded up, minimum 1. */
+export function gbRoundedUp(bytes: number): number {
+	return Math.max(1, Math.ceil(bytes / GIB));
+}

--- a/frontend/src/main/update-settings.ts
+++ b/frontend/src/main/update-settings.ts
@@ -42,6 +42,11 @@ export interface UpdateStatus {
 	// network-stack error (net::ERR_*). The renderer localizes restart guidance
 	// from this flag instead of receiving pre-built English prose (#3526).
 	netError?: boolean;
+	// Present only when state === "downloaded" but the install cannot proceed
+	// yet: not enough free disk space for Squirrel's extract+stage+backup
+	// (#3528). Prose from the main process (same policy as the install blocker
+	// dialogs); the renderer shows it instead of a bare "restart to update".
+	installBlockedReason?: string;
 }
 
 /** File holding the user's auto-update preferences under the ~/.ao state dir. */

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -360,7 +360,14 @@ function UpdateStatusLine({ status }: { status: UpdateStatus }) {
 		case "downloading":
 			return <span className="text-xs text-settings-muted">{t("settings.updates.downloading", { percent: status.percent ?? 0 })}</span>;
 		case "downloaded":
-			return <span className="text-xs text-success">{t("settings.updates.downloaded")}</span>;
+			// installBlockedReason (#3528) carries main-process prose explaining why
+			// the staged build cannot install yet (disk space / location), same
+			// policy as the install-blocker dialogs.
+			return status.installBlockedReason ? (
+				<span className="text-xs text-error">{status.installBlockedReason}</span>
+			) : (
+				<span className="text-xs text-success">{t("settings.updates.downloaded")}</span>
+			);
 		case "not-available":
 			return <span className="text-xs text-settings-muted">{t("settings.updates.latest")}</span>;
 		case "unsupported":

--- a/frontend/src/shared/update-telemetry.ts
+++ b/frontend/src/shared/update-telemetry.ts
@@ -29,8 +29,13 @@ export type UpdateFailureCategory =
 	| "not_supported"
 	| "unknown";
 
-/** Which stage of the update was running when the outcome occurred. */
-export type UpdatePhase = "check" | "download";
+/**
+ * Which stage of the update was running when the outcome occurred. "install"
+ * covers quit-time and post-quit install failures (#3528): Squirrel's install
+ * runs after the app exits, so this phase is reported either pre-quit (disk
+ * preflight) or on the next launch (persisted install-attempt marker).
+ */
+export type UpdatePhase = "check" | "download" | "install";
 
 /** Whether the update ran on the hourly timer or because the user asked. */
 export type UpdateTrigger = "automatic" | "manual";


### PR DESCRIPTION
## What

When the disk is nearly full, the updater now checks free space before downloading and before installing, and reports install failures that happened after the app quit, which previously were invisible to the user.

## Why

Fixes #3528. Squirrel.Mac extracts the update into temporary folders and stages a backup of the app, needing about 1.5 GB. With no room, the extraction truncates and the install fails after the app has quit, so nothing in the app ever surfaces it. The user just sees the "Restart to update" row again with no explanation, and retries keep failing.

## How

- Before an automatic or manual download, the updater checks free space on the cache volume against a 250 MB reserve. Below that, the download is skipped with an actionable "free up space" message instead of truncating mid-way.
- Before quitAndInstall, free space is checked on the app volume and the cache volume against a 1.5 GB reserve. Below that, a dialog says how much space to free instead of handing the update to a doomed post-quit install.
- quitAndInstall now writes a small install-attempt marker first. On the next launch, if the attempted version never became the running version, the app shows "The last update didn't install" together with the tail of the Squirrel ShipIt stderr log (this is where the misleading "file ... doesn't exist" error appears).
- The telemetry phase set now includes "install", so install failures are measurable instead of being a blind spot (it was previously only check|download). See shared/update-telemetry.ts.
- Every check fails open: if statfs reports nothing, the update proceeds exactly as it did before.

## Testing

- 80 vitest tests pass across the updater suites: auto-updater, update-disk-space, update-settings, update-telemetry.
- New tests cover the blocked-install dialog and telemetry, the fail-open path, install-attempt marker persistence, and the launch-time failure report with the ShipIt log tail.
- Typecheck passes for all touched files.
- Live behavior on an actual full disk was not exercised; that needs a packaged build.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)