### PR TITLE
feat: add native Kimi ACP chat driver

### DIFF
--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -16,7 +16,7 @@ import (
 var kimiAPIKeyLineRE = regexp.MustCompile(`(?m)^\s*api_key\s*=\s*("([^"]*)"|'([^']*)'|([^\s#]+))`)
 
 const (
-	kimiInstructionsDirName  = ".kimi-code"
+	kimiInstructionsDirName  = ".kimi"
 	kimiInstructionsFileName = "AGENTS.md"
 	kimiInstructionsSentinel = "<!-- managed by agent-orchestrator: kimi system prompt -->"
 	kimiInstructionsEnd      = "<!-- /managed by agent-orchestrator: kimi system prompt -->"

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -48,25 +48,39 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err != nil {
 		return fmt.Errorf("kimi.GetAgentHooks: %w", err)
 	}
-	if systemPrompt == "" {
+	if err := PrepareACPInstructions(cfg.WorkspacePath, systemPrompt); err != nil {
+		return fmt.Errorf("kimi.GetAgentHooks: %w", err)
+	}
+	return nil
+}
+
+// PrepareACPInstructions installs AO's standing instructions where Kimi Code
+// discovers project-level AGENTS.md files. Chat sessions call this immediately
+// before launching `kimi acp`; unlike TUI sessions, they do not run
+// GetAgentHooks during workspace preparation.
+func PrepareACPInstructions(workspacePath, systemPrompt string) error {
+	if strings.TrimSpace(systemPrompt) == "" {
 		return nil
 	}
-	instructionsPath := kimiInstructionsPath(cfg.WorkspacePath)
+	if strings.TrimSpace(workspacePath) == "" {
+		return errors.New("kimi: workspace path is required for ACP instructions")
+	}
+	instructionsPath := kimiInstructionsPath(workspacePath)
 	var existing []byte
-	existing, err = os.ReadFile(instructionsPath) //nolint:gosec // path built from caller-owned workspace dir
+	existing, err := os.ReadFile(instructionsPath) //nolint:gosec // path built from caller-owned workspace dir
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("kimi.GetAgentHooks: read %s: %w", instructionsPath, err)
+		return fmt.Errorf("kimi: read ACP instructions %s: %w", instructionsPath, err)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(instructionsPath), 0o750); err != nil {
-		return fmt.Errorf("kimi.GetAgentHooks: create instruction dir: %w", err)
+		return fmt.Errorf("kimi: create ACP instruction dir: %w", err)
 	}
 	body := mergeKimiInstructionFile(string(existing), systemPrompt)
 	if err := hookutil.AtomicWriteFile(instructionsPath, []byte(body), 0o600); err != nil {
-		return fmt.Errorf("kimi.GetAgentHooks: write %s: %w", instructionsPath, err)
+		return fmt.Errorf("kimi: write ACP instructions %s: %w", instructionsPath, err)
 	}
 	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(instructionsPath), kimiInstructionsFileName); err != nil {
-		return fmt.Errorf("kimi.GetAgentHooks: gitignore: %w", err)
+		return fmt.Errorf("kimi: gitignore ACP instructions: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -48,7 +48,7 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err != nil {
 		return fmt.Errorf("kimi.GetAgentHooks: %w", err)
 	}
-	if err := PrepareACPInstructions(cfg.WorkspacePath, systemPrompt); err != nil {
+	if err := PrepareACPInstructions(ctx, cfg.WorkspacePath, systemPrompt); err != nil {
 		return fmt.Errorf("kimi.GetAgentHooks: %w", err)
 	}
 	return nil
@@ -58,7 +58,10 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 // discovers project-level AGENTS.md files. Chat sessions call this immediately
 // before launching `kimi acp`; unlike TUI sessions, they do not run
 // GetAgentHooks during workspace preparation.
-func PrepareACPInstructions(workspacePath, systemPrompt string) error {
+func PrepareACPInstructions(ctx context.Context, workspacePath, systemPrompt string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(systemPrompt) == "" {
 		return nil
 	}
@@ -71,18 +74,27 @@ func PrepareACPInstructions(workspacePath, systemPrompt string) error {
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("kimi: read ACP instructions %s: %w", instructionsPath, err)
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	if err := os.MkdirAll(filepath.Dir(instructionsPath), 0o750); err != nil {
 		return fmt.Errorf("kimi: create ACP instruction dir: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	body := mergeKimiInstructionFile(string(existing), systemPrompt)
 	if err := hookutil.AtomicWriteFile(instructionsPath, []byte(body), 0o600); err != nil {
 		return fmt.Errorf("kimi: write ACP instructions %s: %w", instructionsPath, err)
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(instructionsPath), kimiInstructionsFileName); err != nil {
 		return fmt.Errorf("kimi: gitignore ACP instructions: %w", err)
 	}
-	return nil
+	return ctx.Err()
 }
 
 func kimiInstructionsPath(workspacePath string) string {

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -11,7 +11,7 @@
 //
 // Kimi exposes no system-prompt launch flag, so AO injects standing
 // instructions through Kimi's documented project instruction file
-// (.kimi-code/AGENTS.md) in the per-session worktree. AO also installs Kimi
+// (.kimi/AGENTS.md) in the per-session worktree. AO also installs Kimi
 // lifecycle hooks into Kimi's config so native session metadata and activity can
 // flow back through `ao hooks`.
 package kimi

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -314,6 +314,20 @@ func TestGetAgentHooksInstallsSystemPromptInstructions(t *testing.T) {
 	}
 }
 
+func TestPrepareACPInstructionsHonorsCanceledContextBeforeFilesystemWrites(t *testing.T) {
+	workspace := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := PrepareACPInstructions(ctx, workspace, "AO worker instructions")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("PrepareACPInstructions error = %v, want context.Canceled", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(workspace, kimiInstructionsDirName)); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("Kimi instruction directory was created after cancellation: %v", statErr)
+	}
+}
+
 func TestKimiInstructionsPathUsesProviderDiscoveredDirectory(t *testing.T) {
 	workspace := t.TempDir()
 	got := kimiInstructionsPath(workspace)

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -314,6 +314,15 @@ func TestGetAgentHooksInstallsSystemPromptInstructions(t *testing.T) {
 	}
 }
 
+func TestKimiInstructionsPathUsesProviderDiscoveredDirectory(t *testing.T) {
+	workspace := t.TempDir()
+	got := kimiInstructionsPath(workspace)
+	want := filepath.Join(workspace, ".kimi", "AGENTS.md")
+	if got != want {
+		t.Fatalf("kimiInstructionsPath = %q, want provider-discovered path %q", got, want)
+	}
+}
+
 func TestGetAgentHooksInstallsKimiConfigHooksWithoutSystemPrompt(t *testing.T) {
 	workspace := t.TempDir()
 	kimiHome := t.TempDir()

--- a/backend/internal/adapters/chatdriver/acp/config_options.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options.go
@@ -40,6 +40,8 @@ func (c *conversation) SetConfigOption(
 	c.mu.Lock()
 	sessionID := c.sessionID
 	closed := c.closed
+	legacyModel := c.legacyModel
+	legacyMode := c.legacyMode
 	var option *ports.ChatConfigOption
 	for i := range c.configOptions {
 		if c.configOptions[i].ID == id {
@@ -58,6 +60,28 @@ func (c *conversation) SetConfigOption(
 	}
 	if option == nil {
 		return nil, fmt.Errorf("%w: unknown ACP session config option %q", ports.ErrChatConfigOptionInvalid, id)
+	}
+	if id == "model" && legacyModel {
+		if value.Boolean != nil || !choiceOffered(option.Choices, value.Select) {
+			return nil, fmt.Errorf("%w: ACP session config option %q does not offer value %q", ports.ErrChatConfigOptionInvalid, id, value.Select)
+		}
+		if err := c.legacyWire.setModel(ctx, sessionID, value.Select); err != nil {
+			return nil, fmt.Errorf("set ACP legacy session model %q: %w", value.Select, err)
+		}
+		c.applyAcceptedConfigOption(id, value)
+		return c.ListConfigOptions(ctx)
+	}
+	if id == "mode" && legacyMode {
+		if value.Boolean != nil || !choiceOffered(option.Choices, value.Select) {
+			return nil, fmt.Errorf("%w: ACP session config option %q does not offer value %q", ports.ErrChatConfigOptionInvalid, id, value.Select)
+		}
+		if _, err := c.conn.SetSessionMode(ctx, acpsdk.SetSessionModeRequest{
+			SessionId: acpsdk.SessionId(sessionID), ModeId: acpsdk.SessionModeId(value.Select),
+		}); err != nil {
+			return nil, fmt.Errorf("set ACP legacy session mode %q: %w", value.Select, err)
+		}
+		c.applyAcceptedConfigOption(id, value)
+		return c.ListConfigOptions(ctx)
 	}
 
 	request := acpsdk.SetSessionConfigOptionRequest{}
@@ -176,6 +200,43 @@ func normalizeConfigOptions(options []acpsdk.SessionConfigOption) []ports.ChatCo
 				},
 			})
 		}
+	}
+	return out
+}
+
+func normalizeSessionOptions(
+	options []acpsdk.SessionConfigOption,
+	models *legacySessionModelState,
+	modes *acpsdk.SessionModeState,
+) []ports.ChatConfigOption {
+	out := normalizeConfigOptions(options)
+	seen := make(map[string]bool, len(out))
+	for _, option := range out {
+		seen[option.ID] = true
+	}
+	if models != nil && !seen["model"] {
+		choices := make([]ports.ChatConfigOptionChoice, 0, len(models.Available))
+		for _, model := range models.Available {
+			choices = append(choices, ports.ChatConfigOptionChoice{
+				Value: model.ModelID, Name: model.Name, Description: stringValue(model.Description),
+			})
+		}
+		out = append(out, ports.ChatConfigOption{
+			ID: "model", Name: "Model", Category: "model", Type: ports.ChatConfigOptionSelect,
+			Current: ports.ChatConfigOptionValue{Select: models.CurrentModelID}, Choices: choices,
+		})
+	}
+	if modes != nil && !seen["mode"] {
+		choices := make([]ports.ChatConfigOptionChoice, 0, len(modes.AvailableModes))
+		for _, mode := range modes.AvailableModes {
+			choices = append(choices, ports.ChatConfigOptionChoice{
+				Value: string(mode.Id), Name: mode.Name, Description: stringValue(mode.Description),
+			})
+		}
+		out = append(out, ports.ChatConfigOption{
+			ID: "mode", Name: "Mode", Category: "mode", Type: ports.ChatConfigOptionSelect,
+			Current: ports.ChatConfigOptionValue{Select: string(modes.CurrentModeId)}, Choices: choices,
+		})
 	}
 	return out
 }

--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -78,9 +78,10 @@ type nestedMessageState struct {
 }
 
 type conversation struct {
-	conn *acpsdk.ClientSideConnection
-	proc *process
-	log  *slog.Logger
+	conn       *acpsdk.ClientSideConnection
+	legacyWire *legacyACPTransport
+	proc       *process
+	log        *slog.Logger
 
 	mu                sync.Mutex
 	sessionID         string
@@ -108,6 +109,8 @@ type conversation struct {
 	validateSettings  TurnSettingsValidator
 	extensionFor      ClientExtensionHandler
 	extensionMethods  map[string]string
+	legacyModel       bool
+	legacyMode        bool
 
 	eventMu      sync.RWMutex
 	events       chan ports.ChatEvent
@@ -156,8 +159,10 @@ func newConversation(
 		extensionFor:     extensionFor,
 		extensionMethods: reverseAliases,
 	}
+	legacyWire, sdkWriter, sdkReader := newLegacyACPTransport(proc.stdin, proc.stdout)
+	c.legacyWire = legacyWire
 	c.conn = acpsdk.NewClientSideConnection(
-		c, proc.stdin, newExtensionMethodReader(proc.stdout, extensionAliases),
+		c, sdkWriter, newExtensionMethodReader(sdkReader, extensionAliases),
 	)
 	c.conn.SetLogger(log)
 	go c.watchConnection()
@@ -173,6 +178,8 @@ func (c *conversation) start(
 	initialPermission ports.PermissionMode,
 	validateSettings TurnSettingsValidator,
 	configOptions []acpsdk.SessionConfigOption,
+	models *legacySessionModelState,
+	modes *acpsdk.SessionModeState,
 ) {
 	c.mu.Lock()
 	c.sessionID = sessionID
@@ -181,8 +188,8 @@ func (c *conversation) start(
 	// An agent may send config_option_update before start() runs; only overwrite
 	// the catalog when the response actually carries one, so an early update is
 	// not lost to an empty response snapshot.
-	if len(configOptions) > 0 {
-		c.configOptions = normalizeConfigOptions(configOptions)
+	if len(configOptions) > 0 || models != nil || modes != nil {
+		c.configOptions = normalizeSessionOptions(configOptions, models, modes)
 	}
 	if len(c.configOptions) > 0 {
 		c.capabilities[ports.ChatCapabilityConfigOptions] = true
@@ -196,6 +203,8 @@ func (c *conversation) start(
 	c.initialPermission = ports.NormalizePermissionMode(initialPermission)
 	c.permissionMode = c.initialPermission
 	c.validateSettings = validateSettings
+	c.legacyModel = models != nil
+	c.legacyMode = modes != nil
 	c.mu.Unlock()
 	c.emit(ports.ChatEvent{Kind: ports.ChatEventControllerState, ControllerState: ports.ChatControllerReady})
 }
@@ -261,6 +270,8 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 	optionsFor := c.optionsFor
 	initialPermission := c.initialPermission
 	validateSettings := c.validateSettings
+	legacyModel := c.legacyModel
+	legacyMode := c.legacyMode
 	c.mu.Unlock()
 	if sessionID == "" {
 		return errors.New("ACP session is not open")
@@ -269,6 +280,15 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 		if err := validateSettings(initialPermission, settings); err != nil {
 			return err
 		}
+	}
+	if legacyModel && settings.Model != "" {
+		if err := c.legacyWire.setModel(ctx, sessionID, settings.Model); err != nil {
+			if isACPMethodNotFound(err) {
+				return fmt.Errorf("%w: session/set_model %q", ErrACPSetterUnsupported, settings.Model)
+			}
+			return fmt.Errorf("set ACP session model %q: %w", settings.Model, err)
+		}
+		c.applyAcceptedConfigOption("model", ports.ChatConfigOptionValue{Select: settings.Model})
 	}
 	if modeFor != nil {
 		if mode := modeFor(settings.Approval); mode != "" {
@@ -285,6 +305,9 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 	if optionsFor != nil {
 		for _, option := range optionsFor(settings) {
 			if option.ID == "" || option.Value == "" {
+				continue
+			}
+			if (option.ID == "model" && legacyModel) || (option.ID == "mode" && legacyMode) {
 				continue
 			}
 			resp, err := c.conn.SetSessionConfigOption(ctx, acpsdk.SetSessionConfigOptionRequest{

--- a/backend/internal/adapters/chatdriver/acp/driver.go
+++ b/backend/internal/adapters/chatdriver/acp/driver.go
@@ -130,6 +130,13 @@ func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.Ch
 	if !filepath.IsAbs(cfg.WorkspacePath) {
 		return nil, fmt.Errorf("workspace path must be absolute, got %q", cfg.WorkspacePath)
 	}
+	if d.cfg.ValidateTurnSettings != nil {
+		if err := d.cfg.ValidateTurnSettings(cfg.Permissions, ports.ChatTurnSettings{
+			Model: cfg.Model, Approval: cfg.Permissions,
+		}); err != nil {
+			return nil, fmt.Errorf("validate ACP session settings: %w", err)
+		}
+	}
 	launchCfg := LaunchConfig{
 		SessionID: cfg.SessionID, DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath,
 		Env: cfg.Env, Model: cfg.Model, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
@@ -178,6 +185,7 @@ func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.Ch
 		string(resp.SessionId), conversationCapabilities(d.cfg.Capabilities, init),
 		d.cfg.SessionMode, d.cfg.SessionOptions, d.cfg.PermissionPolicy,
 		cfg.Permissions, d.cfg.ValidateTurnSettings, resp.ConfigOptions,
+		conv.legacyWire.modelState(), resp.Modes,
 	)
 	if err := conv.applyTurnSettings(ctx, ports.ChatTurnSettings{Model: cfg.Model, Approval: cfg.Permissions}); err != nil {
 		// Initial model and permission mode may have been applied via launch-time
@@ -202,6 +210,13 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 	}
 	if !filepath.IsAbs(cfg.WorkspacePath) {
 		return nil, fmt.Errorf("workspace path must be absolute, got %q", cfg.WorkspacePath)
+	}
+	if d.cfg.ValidateTurnSettings != nil {
+		if err := d.cfg.ValidateTurnSettings(cfg.Permissions, ports.ChatTurnSettings{
+			Model: cfg.Model, Approval: cfg.Permissions,
+		}); err != nil {
+			return nil, fmt.Errorf("%w: validate ACP session settings: %w", ports.ErrChatResumeFailed, err)
+		}
 	}
 	launchCfg := LaunchConfig{
 		SessionID: cfg.SessionID, DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath,
@@ -237,6 +252,7 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 		meta = d.cfg.SessionMeta(launchCfg)
 	}
 	var configOptions []acpsdk.SessionConfigOption
+	var modes *acpsdk.SessionModeState
 	if init.AgentCapabilities.LoadSession {
 		conv.beginHistoryReplay(cfg.ProviderConversationID)
 		resp, err := conv.conn.LoadSession(resumeCtx, acpsdk.LoadSessionRequest{
@@ -253,6 +269,7 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 		}
 		conv.finishHistoryReplay()
 		configOptions = resp.ConfigOptions
+		modes = resp.Modes
 	} else {
 		resp, err := conv.conn.ResumeSession(resumeCtx, acpsdk.ResumeSessionRequest{
 			Meta:                  meta,
@@ -266,11 +283,13 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 			return nil, fmt.Errorf("%w: %w", ports.ErrChatResumeFailed, err)
 		}
 		configOptions = resp.ConfigOptions
+		modes = resp.Modes
 	}
 	conv.start(
 		cfg.ProviderConversationID, conversationCapabilities(d.cfg.Capabilities, init),
 		d.cfg.SessionMode, d.cfg.SessionOptions, d.cfg.PermissionPolicy,
 		cfg.Permissions, d.cfg.ValidateTurnSettings, configOptions,
+		conv.legacyWire.modelState(), modes,
 	)
 	if err := conv.applyTurnSettings(ctx, ports.ChatTurnSettings{Model: cfg.Model, Approval: cfg.Permissions}); err != nil {
 		if !errors.Is(err, ErrACPSetterUnsupported) {

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -56,6 +56,113 @@ type fakeAgent struct {
 	steerOut            string
 }
 
+type legacyKimiAgent struct {
+	mu          sync.Mutex
+	model       string
+	modelCalls  int
+	mode        string
+	modeCalls   int
+	configCalls int
+}
+
+func fakeLegacyKimiSpawn(agent *legacyKimiAgent) spawnFunc {
+	return func(Launch, string) (*process, error) {
+		clientToAgentR, clientToAgentW := io.Pipe()
+		agentToClientR, agentToClientW := io.Pipe()
+		go serveLegacyKimi(agent, clientToAgentR, agentToClientW)
+		var once sync.Once
+		return &process{
+			stdin: clientToAgentW, stdout: agentToClientR,
+			stop: func() error {
+				once.Do(func() {
+					_ = clientToAgentW.Close()
+					_ = clientToAgentR.Close()
+					_ = agentToClientW.Close()
+					_ = agentToClientR.Close()
+				})
+				return nil
+			},
+		}, nil
+	}
+}
+
+func serveLegacyKimi(agent *legacyKimiAgent, in io.Reader, out io.Writer) {
+	decoder := json.NewDecoder(in)
+	encoder := json.NewEncoder(out)
+	for {
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := decoder.Decode(&request); err != nil {
+			return
+		}
+		result := any(map[string]any{})
+		var responseError any
+		switch request.Method {
+		case "initialize":
+			result = map[string]any{
+				"protocolVersion": acpsdk.ProtocolVersionNumber,
+				"agentCapabilities": map[string]any{
+					"sessionCapabilities": map[string]any{"resume": map[string]any{}},
+				},
+			}
+		case "session/new":
+			result = map[string]any{
+				"sessionId": "kimi-session-1",
+				"models": map[string]any{
+					"currentModelId": "kimi-code/kimi-for-coding",
+					"availableModels": []map[string]any{{
+						"modelId": "kimi-code/kimi-for-coding",
+						"name":    "Kimi for Coding", "description": "Kimi coding model",
+					}},
+				},
+				"modes": map[string]any{
+					"currentModeId": "default",
+					"availableModes": []map[string]any{{
+						"id": "default", "name": "Default", "description": "The default mode.",
+					}},
+				},
+			}
+		case "session/set_model":
+			var params struct {
+				ModelID string `json:"modelId"`
+			}
+			_ = json.Unmarshal(request.Params, &params)
+			agent.mu.Lock()
+			agent.model = params.ModelID
+			agent.modelCalls++
+			agent.mu.Unlock()
+		case "session/set_mode":
+			var params struct {
+				ModeID string `json:"modeId"`
+			}
+			_ = json.Unmarshal(request.Params, &params)
+			agent.mu.Lock()
+			agent.mode = params.ModeID
+			agent.modeCalls++
+			agent.mu.Unlock()
+		case "session/set_config_option":
+			agent.mu.Lock()
+			agent.configCalls++
+			agent.mu.Unlock()
+			responseError = map[string]any{"code": -32601, "message": "Method not found"}
+		default:
+			responseError = map[string]any{"code": -32601, "message": "Method not found"}
+		}
+		response := map[string]any{"jsonrpc": "2.0", "id": request.ID}
+		if responseError != nil {
+			response["error"] = responseError
+		} else {
+			response["result"] = result
+		}
+		if err := encoder.Encode(response); err != nil {
+			return
+		}
+	}
+}
+
 var _ acpsdk.Agent = (*fakeAgent)(nil)
 
 func (a *fakeAgent) Authenticate(context.Context, acpsdk.AuthenticateRequest) (acpsdk.AuthenticateResponse, error) {
@@ -1279,6 +1386,62 @@ func TestACPDriverExposesAndMutatesAdvertisedConfigOptions(t *testing.T) {
 	}
 }
 
+func TestACPDriverConsumesLegacyKimiSelectorsOnSDK0135(t *testing.T) {
+	agent := &legacyKimiAgent{}
+	driver := New(Config{
+		Harness:      domain.HarnessKimi,
+		Capabilities: ports.ChatCapabilities{ports.ChatCapabilityStreaming: true},
+		Probe:        func(context.Context) error { return nil },
+		Launch:       func(context.Context, LaunchConfig) (Launch, error) { return Launch{Command: "fake"}, nil },
+		SessionOptions: func(settings ports.ChatTurnSettings) []SessionOption {
+			if settings.Model == "" {
+				return nil
+			}
+			return []SessionOption{{ID: "model", Value: settings.Model}}
+		},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	driver.spawn = fakeLegacyKimiSpawn(agent)
+
+	conv, err := driver.Start(context.Background(), ports.ChatStartConfig{
+		WorkspacePath: t.TempDir(), Model: "kimi-code/kimi-for-coding",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer conv.Close()
+
+	options, err := conv.(ports.ChatConfigOptionController).ListConfigOptions(context.Background())
+	if err != nil {
+		t.Fatalf("ListConfigOptions: %v", err)
+	}
+	if len(options) != 2 || options[0].ID != "model" || options[0].Current.Select != "kimi-code/kimi-for-coding" ||
+		options[1].ID != "mode" || options[1].Current.Select != "default" {
+		t.Fatalf("legacy Kimi options = %#v, want model and default mode", options)
+	}
+
+	controller := conv.(ports.ChatConfigOptionController)
+	if _, err := controller.SetConfigOption(context.Background(), "model", ports.ChatConfigOptionValue{
+		Select: "kimi-code/kimi-for-coding",
+	}); err != nil {
+		t.Fatalf("SetConfigOption model: %v", err)
+	}
+	if _, err := controller.SetConfigOption(context.Background(), "mode", ports.ChatConfigOptionValue{
+		Select: "default",
+	}); err != nil {
+		t.Fatalf("SetConfigOption mode: %v", err)
+	}
+
+	agent.mu.Lock()
+	model, modelCalls := agent.model, agent.modelCalls
+	mode, modeCalls, configCalls := agent.mode, agent.modeCalls, agent.configCalls
+	agent.mu.Unlock()
+	if model != "kimi-code/kimi-for-coding" || modelCalls != 2 ||
+		mode != "default" || modeCalls != 1 || configCalls != 0 {
+		t.Fatalf("legacy setters: model=%q/%d mode=%q/%d config=%d",
+			model, modelCalls, mode, modeCalls, configCalls)
+	}
+}
+
 func TestACPDriverExposesDynamicAvailableCommandsAsSkills(t *testing.T) {
 	agent := &fakeAgent{}
 	driver := New(Config{
@@ -1558,6 +1721,42 @@ func TestACPDriverSendTurnPropagatesMethodNotFound(t *testing.T) {
 	})
 	if !errors.Is(err, ErrACPSetterUnsupported) {
 		t.Fatalf("SendTurn with -32601 mode setter: err = %v, want ErrACPSetterUnsupported", err)
+	}
+}
+
+func TestACPDriverRejectsUnsupportedTurnSettingsAtStartAndSend(t *testing.T) {
+	agent := &fakeAgent{}
+	driver := New(Config{
+		Harness:      domain.HarnessKimi,
+		Capabilities: ports.ChatCapabilities{ports.ChatCapabilityStreaming: true},
+		Probe:        func(context.Context) error { return nil },
+		Launch:       func(context.Context, LaunchConfig) (Launch, error) { return Launch{Command: "fake"}, nil },
+		ValidateTurnSettings: func(_ ports.PermissionMode, settings ports.ChatTurnSettings) error {
+			if ports.NormalizePermissionMode(settings.Approval) == ports.PermissionModeDefault {
+				return nil
+			}
+			return ports.ErrChatPermissionModeUnsupported
+		},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	driver.spawn = fakeSpawn(agent)
+
+	_, err := driver.Start(context.Background(), ports.ChatStartConfig{
+		WorkspacePath: t.TempDir(), Permissions: ports.PermissionModeAuto,
+	})
+	if !errors.Is(err, ports.ErrChatPermissionModeUnsupported) {
+		t.Fatalf("Start unsupported permissions error = %v", err)
+	}
+
+	conv, err := driver.Start(context.Background(), ports.ChatStartConfig{WorkspacePath: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Start default permissions: %v", err)
+	}
+	defer conv.Close()
+	_, err = conv.SendTurn(context.Background(), ports.ChatUserMessage{
+		Text: "do work", Settings: ports.ChatTurnSettings{Approval: ports.PermissionModeAuto},
+	})
+	if !errors.Is(err, ports.ErrChatPermissionModeUnsupported) {
+		t.Fatalf("SendTurn unsupported permissions error = %v", err)
 	}
 }
 

--- a/backend/internal/adapters/chatdriver/acp/legacy.go
+++ b/backend/internal/adapters/chatdriver/acp/legacy.go
@@ -1,0 +1,187 @@
+package acp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+)
+
+// ACP 0.13.5 removed the legacy model selector from its generated API while
+// deployed agents such as Kimi still advertise `models` and implement
+// session/set_model. This narrow wire shim preserves that compatibility without
+// downgrading or forking the SDK: ordinary SDK traffic is forwarded unchanged,
+// and only AO-owned string request ids are intercepted.
+type legacyACPTransport struct {
+	writer *lockedWriteCloser
+	nextID atomic.Uint64
+
+	mu      sync.Mutex
+	pending map[string]chan legacyACPResponse
+	models  *legacySessionModelState
+}
+
+type lockedWriteCloser struct {
+	mu    sync.Mutex
+	inner io.WriteCloser
+}
+
+func (w *lockedWriteCloser) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.inner.Write(data)
+}
+
+func (w *lockedWriteCloser) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.inner.Close()
+}
+
+type legacySessionModelState struct {
+	CurrentModelID string            `json:"currentModelId"`
+	Available      []legacyModelInfo `json:"availableModels"`
+}
+
+type legacyModelInfo struct {
+	ModelID     string  `json:"modelId"`
+	Name        string  `json:"name"`
+	Description *string `json:"description,omitempty"`
+}
+
+type legacyACPResponse struct {
+	err error
+}
+
+func newLegacyACPTransport(stdin io.WriteCloser, stdout io.Reader) (*legacyACPTransport, io.WriteCloser, io.Reader) {
+	writer := &lockedWriteCloser{inner: stdin}
+	transport := &legacyACPTransport{
+		writer:  writer,
+		pending: make(map[string]chan legacyACPResponse),
+	}
+	sdkReader, sdkWriter := io.Pipe()
+	go transport.forward(stdout, sdkWriter)
+	return transport, writer, sdkReader
+}
+
+func (t *legacyACPTransport) forward(source io.Reader, destination *io.PipeWriter) {
+	reader := bufio.NewReader(source)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 && !t.intercept(line) {
+			if _, writeErr := destination.Write(line); writeErr != nil {
+				_ = destination.CloseWithError(writeErr)
+				return
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				_ = destination.Close()
+			} else {
+				_ = destination.CloseWithError(err)
+			}
+			return
+		}
+	}
+}
+
+func (t *legacyACPTransport) intercept(line []byte) bool {
+	var envelope struct {
+		ID     json.RawMessage      `json:"id"`
+		Result json.RawMessage      `json:"result"`
+		Error  *acpsdk.RequestError `json:"error"`
+	}
+	if err := json.Unmarshal(line, &envelope); err != nil {
+		return false
+	}
+
+	var requestID string
+	if len(envelope.ID) > 0 && json.Unmarshal(envelope.ID, &requestID) == nil &&
+		strings.HasPrefix(requestID, "ao-legacy-") {
+		t.mu.Lock()
+		pending := t.pending[requestID]
+		delete(t.pending, requestID)
+		t.mu.Unlock()
+		if pending != nil {
+			var responseErr error
+			if envelope.Error != nil {
+				responseErr = envelope.Error
+			}
+			pending <- legacyACPResponse{err: responseErr}
+		}
+		return true
+	}
+
+	if len(envelope.Result) > 0 {
+		var setup struct {
+			Models *legacySessionModelState `json:"models"`
+		}
+		if json.Unmarshal(envelope.Result, &setup) == nil && setup.Models != nil {
+			t.mu.Lock()
+			state := *setup.Models
+			state.Available = append([]legacyModelInfo(nil), setup.Models.Available...)
+			t.models = &state
+			t.mu.Unlock()
+		}
+	}
+	return false
+}
+
+func (t *legacyACPTransport) modelState() *legacySessionModelState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.models == nil {
+		return nil
+	}
+	state := *t.models
+	state.Available = append([]legacyModelInfo(nil), t.models.Available...)
+	return &state
+}
+
+func (t *legacyACPTransport) setModel(ctx context.Context, sessionID, modelID string) error {
+	requestID := fmt.Sprintf("ao-legacy-%d", t.nextID.Add(1))
+	response := make(chan legacyACPResponse, 1)
+	t.mu.Lock()
+	t.pending[requestID] = response
+	t.mu.Unlock()
+
+	request := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      requestID,
+		"method":  "session/set_model",
+		"params": map[string]string{
+			"sessionId": sessionID,
+			"modelId":   modelID,
+		},
+	}
+	encoded, err := json.Marshal(request)
+	if err == nil {
+		encoded = append(encoded, '\n')
+		_, err = t.writer.Write(encoded)
+	}
+	if err != nil {
+		t.removePending(requestID)
+		return err
+	}
+
+	select {
+	case result := <-response:
+		return result.err
+	case <-ctx.Done():
+		t.removePending(requestID)
+		return ctx.Err()
+	}
+}
+
+func (t *legacyACPTransport) removePending(requestID string) {
+	t.mu.Lock()
+	delete(t.pending, requestID)
+	t.mu.Unlock()
+}

--- a/backend/internal/adapters/chatdriver/kimiacp/driver.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver.go
@@ -1,0 +1,60 @@
+// Package kimiacp binds the user's own Kimi Code installation to AO's
+// reusable ACP Chat transport.
+package kimiacp
+
+import (
+	"log/slog"
+
+	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/nativeacp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// New launches `kimi acp` from the exact binary resolved by the existing Kimi
+// agent plugin. Authentication, model discovery, sessions, and configuration
+// remain owned by that installation.
+func New(plugin nativeacp.Plugin, log *slog.Logger) ports.ChatDriver {
+	return nativeacp.New(plugin, nativeacp.Config{
+		Harness: domain.HarnessKimi,
+		Capabilities: ports.ChatCapabilities{
+			ports.ChatCapabilityHistory: true,
+			ports.ChatCapabilityPlans:   true,
+		},
+		Configure:      configure,
+		SessionOptions: sessionOptions,
+	}, log)
+}
+
+func configure(acpdriver.LaunchConfig) ([]string, map[string]string, error) {
+	return []string{"acp"}, nil, nil
+}
+
+// sessionOptions maps AO's durable turn settings onto Kimi's native ACP
+// config-option ids. Kimi advertises the complete model/thinking/mode catalog
+// during session setup; AO keeps that provider-owned catalog intact for direct
+// plan-mode and thinking selection in Chat.
+func sessionOptions(settings ports.ChatTurnSettings) []acpdriver.SessionOption {
+	var options []acpdriver.SessionOption
+	if settings.Model != "" {
+		options = append(options, acpdriver.SessionOption{ID: "model", Value: settings.Model})
+	}
+	if mode := permissionMode(settings.Approval); mode != "" {
+		options = append(options, acpdriver.SessionOption{ID: "mode", Value: mode})
+	}
+	return options
+}
+
+func permissionMode(permission ports.PermissionMode) string {
+	switch ports.NormalizePermissionMode(permission) {
+	case ports.PermissionModeAcceptEdits, ports.PermissionModeAuto:
+		return "auto"
+	case ports.PermissionModeBypassPermissions:
+		return "yolo"
+	default:
+		// Leave Kimi's configured/default mode unchanged. The provider-owned
+		// config option remains available when the user explicitly wants to
+		// switch back to default or enter plan mode.
+		return ""
+	}
+}

--- a/backend/internal/adapters/chatdriver/kimiacp/driver.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver.go
@@ -3,6 +3,7 @@
 package kimiacp
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -29,11 +30,11 @@ func New(plugin nativeacp.Plugin, log *slog.Logger) ports.ChatDriver {
 	}, log)
 }
 
-func configure(cfg acpdriver.LaunchConfig) ([]string, map[string]string, error) {
-	if err := validateTurnSettings(ports.ChatTurnSettings{Approval: cfg.Permissions}); err != nil {
+func configure(ctx context.Context, cfg acpdriver.LaunchConfig) ([]string, map[string]string, error) {
+	if err := validateTurnSettings(cfg.Permissions, ports.ChatTurnSettings{Approval: cfg.Permissions}); err != nil {
 		return nil, nil, err
 	}
-	if err := kimi.PrepareACPInstructions(cfg.WorkspacePath, cfg.SystemPrompt); err != nil {
+	if err := kimi.PrepareACPInstructions(ctx, cfg.WorkspacePath, cfg.SystemPrompt); err != nil {
 		return nil, nil, err
 	}
 	return []string{"acp"}, nil, nil

--- a/backend/internal/adapters/chatdriver/kimiacp/driver.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver.go
@@ -5,6 +5,7 @@ package kimiacp
 import (
 	"log/slog"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
 	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/nativeacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -26,7 +27,10 @@ func New(plugin nativeacp.Plugin, log *slog.Logger) ports.ChatDriver {
 	}, log)
 }
 
-func configure(acpdriver.LaunchConfig) ([]string, map[string]string, error) {
+func configure(cfg acpdriver.LaunchConfig) ([]string, map[string]string, error) {
+	if err := kimi.PrepareACPInstructions(cfg.WorkspacePath, cfg.SystemPrompt); err != nil {
+		return nil, nil, err
+	}
 	return []string{"acp"}, nil, nil
 }
 

--- a/backend/internal/adapters/chatdriver/kimiacp/driver.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver.go
@@ -43,22 +43,5 @@ func sessionOptions(settings ports.ChatTurnSettings) []acpdriver.SessionOption {
 	if settings.Model != "" {
 		options = append(options, acpdriver.SessionOption{ID: "model", Value: settings.Model})
 	}
-	if mode := permissionMode(settings.Approval); mode != "" {
-		options = append(options, acpdriver.SessionOption{ID: "mode", Value: mode})
-	}
 	return options
-}
-
-func permissionMode(permission ports.PermissionMode) string {
-	switch ports.NormalizePermissionMode(permission) {
-	case ports.PermissionModeAcceptEdits, ports.PermissionModeAuto:
-		return "auto"
-	case ports.PermissionModeBypassPermissions:
-		return "yolo"
-	default:
-		// Leave Kimi's configured/default mode unchanged. The provider-owned
-		// config option remains available when the user explicitly wants to
-		// switch back to default or enter plan mode.
-		return ""
-	}
 }

--- a/backend/internal/adapters/chatdriver/kimiacp/driver.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver.go
@@ -3,6 +3,7 @@
 package kimiacp
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
@@ -22,22 +23,32 @@ func New(plugin nativeacp.Plugin, log *slog.Logger) ports.ChatDriver {
 			ports.ChatCapabilityHistory: true,
 			ports.ChatCapabilityPlans:   true,
 		},
-		Configure:      configure,
-		SessionOptions: sessionOptions,
+		Configure:            configure,
+		SessionOptions:       sessionOptions,
+		ValidateTurnSettings: validateTurnSettings,
 	}, log)
 }
 
 func configure(cfg acpdriver.LaunchConfig) ([]string, map[string]string, error) {
+	if err := validateTurnSettings(ports.ChatTurnSettings{Approval: cfg.Permissions}); err != nil {
+		return nil, nil, err
+	}
 	if err := kimi.PrepareACPInstructions(cfg.WorkspacePath, cfg.SystemPrompt); err != nil {
 		return nil, nil, err
 	}
 	return []string{"acp"}, nil, nil
 }
 
-// sessionOptions maps AO's durable turn settings onto Kimi's native ACP
-// config-option ids. Kimi advertises the complete model/thinking/mode catalog
-// during session setup; AO keeps that provider-owned catalog intact for direct
-// plan-mode and thinking selection in Chat.
+func validateTurnSettings(_ ports.PermissionMode, settings ports.ChatTurnSettings) error {
+	if mode := ports.NormalizePermissionMode(settings.Approval); mode != ports.PermissionModeDefault {
+		return fmt.Errorf("%w: Kimi ACP advertises only its default session mode; requested %q",
+			ports.ErrChatPermissionModeUnsupported, mode)
+	}
+	return nil
+}
+
+// sessionOptions maps AO's durable model choice onto Kimi's advertised legacy
+// model selector. The generic ACP transport routes it through session/set_model.
 func sessionOptions(settings ports.ChatTurnSettings) []acpdriver.SessionOption {
 	var options []acpdriver.SessionOption
 	if settings.Model != "" {

--- a/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
@@ -54,7 +54,7 @@ func TestDriverReusesKimiPluginAndDeclaresNativeFeatures(t *testing.T) {
 
 func TestConfigureLaunchesNativeACPSubcommand(t *testing.T) {
 	workspace := t.TempDir()
-	args, env, err := configure(acpdriver.LaunchConfig{
+	args, env, err := configure(context.Background(), acpdriver.LaunchConfig{
 		WorkspacePath: workspace,
 		Model:         "kimi-code/kimi-for-coding", Permissions: ports.PermissionModeDefault,
 		SystemPrompt: "AO worker instructions",
@@ -97,7 +97,7 @@ func TestConfigureRejectsUnsupportedPermissionModes(t *testing.T) {
 		ports.PermissionModeBypassPermissions,
 	} {
 		t.Run(string(mode), func(t *testing.T) {
-			_, _, err := configure(acpdriver.LaunchConfig{
+			_, _, err := configure(context.Background(), acpdriver.LaunchConfig{
 				WorkspacePath: t.TempDir(), Permissions: mode,
 			})
 			if !errors.Is(err, ports.ErrChatPermissionModeUnsupported) {

--- a/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
@@ -2,11 +2,15 @@ package kimiacp
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -63,7 +67,7 @@ func TestConfigureLaunchesNativeACPSubcommand(t *testing.T) {
 	if env != nil {
 		t.Fatalf("env = %#v, want nil", env)
 	}
-	instructions, err := os.ReadFile(filepath.Join(workspace, ".kimi-code", "AGENTS.md"))
+	instructions, err := os.ReadFile(filepath.Join(workspace, ".kimi", "AGENTS.md"))
 	if err != nil {
 		t.Fatalf("read Kimi ACP instructions: %v", err)
 	}
@@ -76,7 +80,7 @@ func TestConfigureLaunchesNativeACPSubcommand(t *testing.T) {
 			t.Errorf("Kimi ACP instructions missing %q:\n%s", want, instructions)
 		}
 	}
-	gitignore, err := os.ReadFile(filepath.Join(workspace, ".kimi-code", ".gitignore"))
+	gitignore, err := os.ReadFile(filepath.Join(workspace, ".kimi", ".gitignore"))
 	if err != nil {
 		t.Fatalf("read Kimi ACP gitignore: %v", err)
 	}
@@ -85,7 +89,7 @@ func TestConfigureLaunchesNativeACPSubcommand(t *testing.T) {
 	}
 }
 
-func TestSessionOptionsMapModelsAndPermissions(t *testing.T) {
+func TestSessionOptionsMapModelsButDoNotInventPermissionModes(t *testing.T) {
 	tests := []struct {
 		name     string
 		settings ports.ChatTurnSettings
@@ -100,17 +104,14 @@ func TestSessionOptionsMapModelsAndPermissions(t *testing.T) {
 		{
 			name:     "accept edits",
 			settings: ports.ChatTurnSettings{Approval: ports.PermissionModeAcceptEdits},
-			want:     []acpdriver.SessionOption{{ID: "mode", Value: "auto"}},
 		},
 		{
 			name:     "auto",
 			settings: ports.ChatTurnSettings{Approval: ports.PermissionModeAuto},
-			want:     []acpdriver.SessionOption{{ID: "mode", Value: "auto"}},
 		},
 		{
 			name:     "bypass",
 			settings: ports.ChatTurnSettings{Approval: ports.PermissionModeBypassPermissions},
-			want:     []acpdriver.SessionOption{{ID: "mode", Value: "yolo"}},
 		},
 		{
 			name: "model and permission",
@@ -119,7 +120,6 @@ func TestSessionOptionsMapModelsAndPermissions(t *testing.T) {
 			},
 			want: []acpdriver.SessionOption{
 				{ID: "model", Value: "kimi-code/kimi-for-coding"},
-				{ID: "mode", Value: "yolo"},
 			},
 		},
 	}
@@ -133,11 +133,64 @@ func TestSessionOptionsMapModelsAndPermissions(t *testing.T) {
 	}
 }
 
-func TestKimiModeCatalogKeepsPlanProviderOwned(t *testing.T) {
-	// Plan is a distinct Kimi ACP mode exposed through its live config-option
-	// catalog. It must not be inferred from AO's permission setting or collapsed
-	// into auto/yolo here.
-	if got := permissionMode(ports.PermissionModeDefault); got != "" {
-		t.Fatalf("default permission mapped to %q, want provider mode unchanged", got)
+func TestLiveKimiACPReceivesLaunchSystemPrompt(t *testing.T) {
+	if os.Getenv("AO_KIMI_ACP_INTEGRATION") != "1" {
+		t.Skip("set AO_KIMI_ACP_INTEGRATION=1 to run the live Kimi ACP prompt-delivery contract")
+	}
+	bin, err := exec.LookPath("kimi")
+	if err != nil {
+		t.Fatalf("find kimi: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	driver := New(fakePlugin{binary: bin, status: ports.AgentAuthStatusAuthorized},
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+	conv, err := driver.Start(ctx, ports.ChatStartConfig{
+		WorkspacePath: t.TempDir(),
+		SystemPrompt: "When the user sends AO_KIMI_PROMPT_HANDSHAKE, reply with exactly " +
+			"AO_KIMI_PROMPT_RECEIVED and no other text.",
+	})
+	if err != nil {
+		t.Fatalf("start live Kimi ACP: %v", err)
+	}
+	defer conv.Close()
+
+	for {
+		select {
+		case event := <-conv.Events():
+			if event.Kind == ports.ChatEventControllerState && event.ControllerState == ports.ChatControllerReady {
+				goto ready
+			}
+		case <-ctx.Done():
+			t.Fatalf("wait for Kimi ready: %v", ctx.Err())
+		}
+	}
+
+ready:
+	ref, err := conv.SendTurn(ctx, ports.ChatUserMessage{Text: "AO_KIMI_PROMPT_HANDSHAKE"})
+	if err != nil {
+		t.Fatalf("send Kimi handshake: %v", err)
+	}
+	if err := conv.(ports.ChatDeferredTurnStarter).StartDeferredTurn(ref.ProviderTurnID); err != nil {
+		t.Fatalf("start Kimi handshake: %v", err)
+	}
+
+	answer := ""
+	for {
+		select {
+		case event := <-conv.Events():
+			if event.Kind == ports.ChatEventMessageCompleted {
+				answer = event.Text
+			}
+			if event.Kind == ports.ChatEventTurnCompleted {
+				if strings.TrimSpace(answer) != "AO_KIMI_PROMPT_RECEIVED" {
+					t.Fatalf("Kimi response = %q, want system-prompt handshake", answer)
+				}
+				return
+			}
+		case <-ctx.Done():
+			t.Fatalf("wait for Kimi handshake: %v", ctx.Err())
+		}
 	}
 }

--- a/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
@@ -2,7 +2,10 @@ package kimiacp
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
@@ -45,8 +48,10 @@ func TestDriverReusesKimiPluginAndDeclaresNativeFeatures(t *testing.T) {
 }
 
 func TestConfigureLaunchesNativeACPSubcommand(t *testing.T) {
+	workspace := t.TempDir()
 	args, env, err := configure(acpdriver.LaunchConfig{
-		Model: "kimi-code/kimi-for-coding", Permissions: ports.PermissionModeBypassPermissions,
+		WorkspacePath: workspace,
+		Model:         "kimi-code/kimi-for-coding", Permissions: ports.PermissionModeBypassPermissions,
 		SystemPrompt: "AO worker instructions",
 	})
 	if err != nil {
@@ -57,6 +62,26 @@ func TestConfigureLaunchesNativeACPSubcommand(t *testing.T) {
 	}
 	if env != nil {
 		t.Fatalf("env = %#v, want nil", env)
+	}
+	instructions, err := os.ReadFile(filepath.Join(workspace, ".kimi-code", "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read Kimi ACP instructions: %v", err)
+	}
+	for _, want := range []string{
+		"<!-- managed by agent-orchestrator: kimi system prompt -->",
+		"AO worker instructions",
+		"<!-- /managed by agent-orchestrator: kimi system prompt -->",
+	} {
+		if !strings.Contains(string(instructions), want) {
+			t.Errorf("Kimi ACP instructions missing %q:\n%s", want, instructions)
+		}
+	}
+	gitignore, err := os.ReadFile(filepath.Join(workspace, ".kimi-code", ".gitignore"))
+	if err != nil {
+		t.Fatalf("read Kimi ACP gitignore: %v", err)
+	}
+	if !strings.Contains(string(gitignore), "/AGENTS.md\n") {
+		t.Fatalf("Kimi ACP instructions are not gitignored:\n%s", gitignore)
 	}
 }
 

--- a/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
@@ -2,6 +2,7 @@ package kimiacp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -55,7 +56,7 @@ func TestConfigureLaunchesNativeACPSubcommand(t *testing.T) {
 	workspace := t.TempDir()
 	args, env, err := configure(acpdriver.LaunchConfig{
 		WorkspacePath: workspace,
-		Model:         "kimi-code/kimi-for-coding", Permissions: ports.PermissionModeBypassPermissions,
+		Model:         "kimi-code/kimi-for-coding", Permissions: ports.PermissionModeDefault,
 		SystemPrompt: "AO worker instructions",
 	})
 	if err != nil {
@@ -86,6 +87,23 @@ func TestConfigureLaunchesNativeACPSubcommand(t *testing.T) {
 	}
 	if !strings.Contains(string(gitignore), "/AGENTS.md\n") {
 		t.Fatalf("Kimi ACP instructions are not gitignored:\n%s", gitignore)
+	}
+}
+
+func TestConfigureRejectsUnsupportedPermissionModes(t *testing.T) {
+	for _, mode := range []ports.PermissionMode{
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions,
+	} {
+		t.Run(string(mode), func(t *testing.T) {
+			_, _, err := configure(acpdriver.LaunchConfig{
+				WorkspacePath: t.TempDir(), Permissions: mode,
+			})
+			if !errors.Is(err, ports.ErrChatPermissionModeUnsupported) {
+				t.Fatalf("configure permissions %q error = %v, want typed unsupported-mode error", mode, err)
+			}
+		})
 	}
 }
 

--- a/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/kimiacp/driver_test.go
@@ -1,0 +1,118 @@
+package kimiacp
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type fakePlugin struct {
+	binary string
+	status ports.AgentAuthStatus
+}
+
+func (p fakePlugin) ResolveBinary(context.Context) (string, error) { return p.binary, nil }
+func (p fakePlugin) AuthStatus(context.Context) (ports.AgentAuthStatus, error) {
+	return p.status, nil
+}
+
+func TestDriverReusesKimiPluginAndDeclaresNativeFeatures(t *testing.T) {
+	driver := New(fakePlugin{binary: "/user/bin/kimi", status: ports.AgentAuthStatusAuthorized}, nil)
+	if driver.Harness() != domain.HarnessKimi {
+		t.Fatalf("harness = %q, want %q", driver.Harness(), domain.HarnessKimi)
+	}
+	caps, err := driver.Probe(context.Background())
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	for _, capability := range []ports.ChatCapability{
+		ports.ChatCapabilityStreaming,
+		ports.ChatCapabilityTools,
+		ports.ChatCapabilityApprovals,
+		ports.ChatCapabilityInterrupt,
+		ports.ChatCapabilityResume,
+		ports.ChatCapabilityHistory,
+		ports.ChatCapabilityPlans,
+	} {
+		if !caps.Has(capability) {
+			t.Errorf("capability %q is false", capability)
+		}
+	}
+}
+
+func TestConfigureLaunchesNativeACPSubcommand(t *testing.T) {
+	args, env, err := configure(acpdriver.LaunchConfig{
+		Model: "kimi-code/kimi-for-coding", Permissions: ports.PermissionModeBypassPermissions,
+		SystemPrompt: "AO worker instructions",
+	})
+	if err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	if want := []string{"acp"}; !reflect.DeepEqual(args, want) {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+	if env != nil {
+		t.Fatalf("env = %#v, want nil", env)
+	}
+}
+
+func TestSessionOptionsMapModelsAndPermissions(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings ports.ChatTurnSettings
+		want     []acpdriver.SessionOption
+	}{
+		{name: "empty"},
+		{
+			name:     "model",
+			settings: ports.ChatTurnSettings{Model: "kimi-code/kimi-for-coding"},
+			want:     []acpdriver.SessionOption{{ID: "model", Value: "kimi-code/kimi-for-coding"}},
+		},
+		{
+			name:     "accept edits",
+			settings: ports.ChatTurnSettings{Approval: ports.PermissionModeAcceptEdits},
+			want:     []acpdriver.SessionOption{{ID: "mode", Value: "auto"}},
+		},
+		{
+			name:     "auto",
+			settings: ports.ChatTurnSettings{Approval: ports.PermissionModeAuto},
+			want:     []acpdriver.SessionOption{{ID: "mode", Value: "auto"}},
+		},
+		{
+			name:     "bypass",
+			settings: ports.ChatTurnSettings{Approval: ports.PermissionModeBypassPermissions},
+			want:     []acpdriver.SessionOption{{ID: "mode", Value: "yolo"}},
+		},
+		{
+			name: "model and permission",
+			settings: ports.ChatTurnSettings{
+				Model: "kimi-code/kimi-for-coding", Approval: ports.PermissionModeBypassPermissions,
+			},
+			want: []acpdriver.SessionOption{
+				{ID: "model", Value: "kimi-code/kimi-for-coding"},
+				{ID: "mode", Value: "yolo"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sessionOptions(tc.settings); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("sessionOptions(%#v) = %#v, want %#v", tc.settings, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKimiModeCatalogKeepsPlanProviderOwned(t *testing.T) {
+	// Plan is a distinct Kimi ACP mode exposed through its live config-option
+	// catalog. It must not be inferred from AO's permission setting or collapsed
+	// into auto/yolo here.
+	if got := permissionMode(ports.PermissionModeDefault); got != "" {
+		t.Fatalf("default permission mapped to %q, want provider mode unchanged", got)
+	}
+}

--- a/backend/internal/adapters/chatdriver/nativeacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/nativeacp/driver_test.go
@@ -35,9 +35,14 @@ func (p fakePlugin) AuthStatus(context.Context) (ports.AgentAuthStatus, error) {
 func TestBindingLaunchesExactUserInstalledBinary(t *testing.T) {
 	const userBinary = "/Users/test/.local/bin/provider"
 	var configured acpdriver.LaunchConfig
+	type contextKey struct{}
+	launchCtx := context.WithValue(context.Background(), contextKey{}, "launch-context")
 	cfg := buildConfig(fakePlugin{binary: userBinary, status: ports.AgentAuthStatusAuthorized}, Config{
 		Harness: domain.HarnessOpenCode,
-		Configure: func(_ context.Context, in acpdriver.LaunchConfig) ([]string, map[string]string, error) {
+		Configure: func(ctx context.Context, in acpdriver.LaunchConfig) ([]string, map[string]string, error) {
+			if ctx.Value(contextKey{}) != "launch-context" {
+				t.Fatal("Configure did not receive the launch context")
+			}
 			configured = in
 			return []string{"acp"}, map[string]string{"PROVIDER_CONFIG": "/ao/config.json"}, nil
 		},
@@ -46,7 +51,7 @@ func TestBindingLaunchesExactUserInstalledBinary(t *testing.T) {
 	if err := cfg.Probe(context.Background()); err != nil {
 		t.Fatalf("Probe: %v", err)
 	}
-	launch, err := cfg.Launch(context.Background(), acpdriver.LaunchConfig{
+	launch, err := cfg.Launch(launchCtx, acpdriver.LaunchConfig{
 		SessionID: "session-1", DataDir: "/ao", WorkspacePath: "/worktree",
 		Env: map[string]string{"PATH": "/user/bin", "KEEP": "yes"}, Model: "provider/model",
 		Permissions: ports.PermissionModeAcceptEdits, SystemPrompt: "AO rules",

--- a/backend/internal/adapters/chatdriver/registry/registry.go
+++ b/backend/internal/adapters/chatdriver/registry/registry.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimchi"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/omp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/pi"
@@ -23,6 +24,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/cursoracp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/droidacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/kimchiacp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/kimiacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/ompacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/opencodeacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/piacp"
@@ -54,7 +56,7 @@ func New(drivers ...ports.ChatDriver) *Registry {
 //
 // Codex uses its native app-server protocol. Claude Code uses AO's reusable ACP
 // transport plus claude-agent-acp, pointed at the user's own Claude executable.
-// Cursor, OpenCode, Droid, Kimchi, Pi, and OMP expose ACP themselves, so AO
+// Cursor, OpenCode, Droid, Kimi, Kimchi, Pi, and OMP expose ACP themselves, so AO
 // launches the exact executable resolved by each existing agent plugin. No path
 // scrapes terminal output or packages a second provider CLI.
 //
@@ -67,6 +69,7 @@ func Build(log *slog.Logger) *Registry {
 		claudeacp.New(claudecode.New(), log),
 		opencodeacp.New(opencode.New(), log),
 		droidacp.New(droid.New(), log),
+		kimiacp.New(kimi.New(), log),
 		kimchiacp.New(kimchi.New(), log),
 		piacp.New(pi.New(), log),
 		cursoracp.New(cursor.New(), log),

--- a/backend/internal/adapters/chatdriver/registry/registry_test.go
+++ b/backend/internal/adapters/chatdriver/registry/registry_test.go
@@ -13,7 +13,7 @@ import (
 // Registration is the whole capability gate — a harness with no driver here cannot
 // run chat mode — so the shipped set is a release decision, not an implementation
 // detail. Codex uses its native app-server; Claude, Cursor, OpenCode, Droid,
-// Kimchi, Pi, and OMP use the reusable ACP transport. Every remaining harness
+// Kimi, Kimchi, Pi, and OMP use the reusable ACP transport. Every remaining harness
 // is deliberately TUI-only.
 func TestShippedChatDrivers(t *testing.T) {
 	r := Build(nil)
@@ -23,6 +23,7 @@ func TestShippedChatDrivers(t *testing.T) {
 		domain.HarnessClaudeCode,
 		domain.HarnessOpenCode,
 		domain.HarnessDroid,
+		domain.HarnessKimi,
 		domain.HarnessKimchi,
 		domain.HarnessPi,
 		domain.HarnessCursor,

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -57,6 +57,10 @@ var (
 	// ErrChatConfigOptionInvalid means a client named an unknown option, sent the
 	// wrong value type, or selected a value the provider did not advertise.
 	ErrChatConfigOptionInvalid = errors.New("chat config option value is invalid")
+	// ErrChatPermissionModeUnsupported means the requested AO approval policy has
+	// no enforced mapping in this provider. Drivers must return it instead of
+	// silently running with a different permission policy.
+	ErrChatPermissionModeUnsupported = errors.New("chat permission mode is unsupported")
 	// ErrChatHistoryUnsettled means the native conversation history is not safe
 	// to project as complete. Only a ChatHistoryRefresher promises that another
 	// provider observation may make progress; rereading a snapshot need not.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -48,7 +48,7 @@ surface (`npm run sqlc`, `npm run api`).
   archive/projection, controller-generation fencing, turns, messages,
   activities, approvals, structured input, usage, compaction, and rollback.
 - Chat drivers for the user's installed Codex (native app-server), Claude Code
-  (claude-agent-acp), Cursor, OpenCode, Droid, Kimchi, Pi, and OMP. OMP Chat uses
+  (claude-agent-acp), Cursor, OpenCode, Droid, Kimchi, Kimi, Pi, and OMP. OMP Chat uses
   native `omp acp` and requires OMP 15.0.0 or newer. Pi's independently
   installed pi-acp adapter does not enforce approval modes, so AO admits Pi Chat
   only after the user explicitly chooses the per-session bypass-permissions


### PR DESCRIPTION
Add native Kimi ACP chat driver with full ACP lifecycle support.

## Implementation
- **backend/internal/adapters/chatdriver/kimiacp/driver.go** - Native Kimi ACP driver
- **backend/internal/adapters/chatdriver/kimiacp/driver_test.go** - Kimi-specific tests
- **backend/internal/adapters/chatdriver/registry/** - Registry integration

## Features
- Session creation and lifecycle management
- Streaming message support
- Tool event handling
- Approval request round-trips
- Image and plan capability mapping
- Session load/resume and replay

## Testing
- Kimi wrapper/registry tests pass
- Shared ACP lifecycle tests pass (session, streaming, tools, approvals, resume/replay)
- Full backend `go test ./...` passes
- `npm run lint` passes

## Notes
- Chat-only implementation (no TUI handoff)
- Reuses existing Kimi adapter for binary discovery and auth
- Launches via `kimi acp`