### PR TITLE
feat: add OMP ACP chat driver

### DIFF
--- a/backend/internal/adapters/chatdriver/ompacp/driver.go
+++ b/backend/internal/adapters/chatdriver/ompacp/driver.go
@@ -1,0 +1,81 @@
+// Package ompacp binds the user's own OMP installation to AO's reusable ACP
+// Chat transport.
+package ompacp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/nativeacp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// New launches `omp acp` from the exact binary resolved by the existing OMP
+// agent plugin. OMP keeps filesystem and terminal execution in its own process;
+// AO advertises neither ACP client capability and receives only typed session
+// updates and permission requests.
+func New(plugin nativeacp.Plugin, log *slog.Logger) ports.ChatDriver {
+	return newDriver(plugin, versionProbe, log)
+}
+
+func newDriver(plugin nativeacp.Plugin, probe nativeacp.VersionProbe, log *slog.Logger) ports.ChatDriver {
+	return nativeacp.New(plugin, nativeacp.Config{
+		Harness: domain.HarnessOMP,
+		Capabilities: ports.ChatCapabilities{
+			ports.ChatCapabilityUsage: true,
+			ports.ChatCapabilityDiffs: true,
+			ports.ChatCapabilityPlans: true,
+		},
+		Configure:            configure,
+		SessionOptions:       sessionOptions,
+		ValidateTurnSettings: validateTurnSettings,
+		VersionProbe:         probe,
+	}, log)
+}
+
+func configure(_ context.Context, cfg acpdriver.LaunchConfig) ([]string, map[string]string, error) {
+	args := []string{"acp"}
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		args = append(args, "--model", model)
+	}
+	if prompt := strings.TrimSpace(cfg.SystemPrompt); prompt != "" {
+		args = append(args, "--append-system-prompt", prompt)
+	}
+	switch ports.NormalizePermissionMode(cfg.Permissions) {
+	case ports.PermissionModeAcceptEdits, ports.PermissionModeAuto:
+		args = append(args, "--approval-mode", "write")
+	case ports.PermissionModeBypassPermissions:
+		args = append(args, "--approval-mode", "yolo")
+	}
+	return args, nil, nil
+}
+
+func sessionOptions(settings ports.ChatTurnSettings) []acpdriver.SessionOption {
+	if model := strings.TrimSpace(settings.Model); model != "" {
+		return []acpdriver.SessionOption{{ID: "model", Value: model}}
+	}
+	return nil
+}
+
+func validateTurnSettings(initial ports.PermissionMode, settings ports.ChatTurnSettings) error {
+	if settings.Approval == "" || ompApprovalMode(settings.Approval) == ompApprovalMode(initial) {
+		return nil
+	}
+	return fmt.Errorf("%w: OMP ACP approval mode is fixed at process launch (%s); restart Chat to change it to %s",
+		acpdriver.ErrACPSetterUnsupported, ompApprovalMode(initial), ompApprovalMode(settings.Approval))
+}
+
+func ompApprovalMode(mode ports.PermissionMode) string {
+	switch ports.NormalizePermissionMode(mode) {
+	case ports.PermissionModeAcceptEdits, ports.PermissionModeAuto:
+		return "write"
+	case ports.PermissionModeBypassPermissions:
+		return "yolo"
+	default:
+		return "default"
+	}
+}

--- a/backend/internal/adapters/chatdriver/ompacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/ompacp/driver_test.go
@@ -1,0 +1,150 @@
+package ompacp
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestConfigureUsesNativeACP(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  acpdriver.LaunchConfig
+		want []string
+	}{
+		{name: "defaults", want: []string{"acp"}},
+		{
+			name: "model prompt and write approvals",
+			cfg: acpdriver.LaunchConfig{
+				Model: "anthropic/claude-sonnet", SystemPrompt: "Follow AO rules.",
+				Permissions: ports.PermissionModeAcceptEdits,
+			},
+			want: []string{"acp", "--model", "anthropic/claude-sonnet", "--append-system-prompt", "Follow AO rules.", "--approval-mode", "write"},
+		},
+		{
+			name: "auto uses write approvals",
+			cfg:  acpdriver.LaunchConfig{Permissions: ports.PermissionModeAuto},
+			want: []string{"acp", "--approval-mode", "write"},
+		},
+		{
+			name: "bypass uses yolo",
+			cfg:  acpdriver.LaunchConfig{Permissions: ports.PermissionModeBypassPermissions},
+			want: []string{"acp", "--approval-mode", "yolo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, env, err := configure(context.Background(), tt.cfg)
+			if err != nil {
+				t.Fatalf("configure: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) || env != nil {
+				t.Fatalf("args/env = %#v, %#v; want %#v, nil", got, env, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionOptionsUseAdvertisedModelOption(t *testing.T) {
+	if got := sessionOptions(ports.ChatTurnSettings{}); got != nil {
+		t.Fatalf("empty settings = %#v", got)
+	}
+	got := sessionOptions(ports.ChatTurnSettings{Model: "zai/glm-5.2"})
+	want := []acpdriver.SessionOption{{ID: "model", Value: "zai/glm-5.2"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("settings = %#v, want %#v", got, want)
+	}
+}
+
+func TestValidateTurnSettingsRejectsApprovalModeChange(t *testing.T) {
+	tests := []struct {
+		name      string
+		initial   ports.PermissionMode
+		requested ports.PermissionMode
+		wantErr   bool
+	}{
+		{name: "empty keeps launch mode", initial: ports.PermissionModeAcceptEdits},
+		{name: "same default", initial: ports.PermissionModeDefault, requested: ports.PermissionModeDefault},
+		{name: "same write spelling", initial: ports.PermissionModeAcceptEdits, requested: ports.PermissionModeAuto},
+		{name: "same yolo", initial: ports.PermissionModeBypassPermissions, requested: ports.PermissionModeBypassPermissions},
+		{name: "write to yolo", initial: ports.PermissionModeAcceptEdits, requested: ports.PermissionModeBypassPermissions, wantErr: true},
+		{name: "write back to default", initial: ports.PermissionModeAuto, requested: ports.PermissionModeDefault, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTurnSettings(tt.initial, ports.ChatTurnSettings{Approval: tt.requested})
+			if tt.wantErr && !errors.Is(err, acpdriver.ErrACPSetterUnsupported) {
+				t.Fatalf("error = %v, want ErrACPSetterUnsupported", err)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestDriverReusesOMPPluginForProbe(t *testing.T) {
+	plugin := &fakePlugin{status: ports.AgentAuthStatusAuthorized, binary: "/usr/bin/omp"}
+	versionCalls := 0
+	driver := newDriver(plugin, func(_ context.Context, bin string) error {
+		versionCalls++
+		if bin != "/usr/bin/omp" {
+			t.Fatalf("version probe binary = %q, want /usr/bin/omp", bin)
+		}
+		return nil
+	}, nil)
+
+	caps, err := driver.Probe(context.Background())
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if driver.Harness() != domain.HarnessOMP {
+		t.Fatalf("harness = %q", driver.Harness())
+	}
+	for _, capability := range []ports.ChatCapability{
+		ports.ChatCapabilityStreaming, ports.ChatCapabilityTools, ports.ChatCapabilityApprovals,
+		ports.ChatCapabilityInterrupt, ports.ChatCapabilityResume, ports.ChatCapabilityUsage,
+		ports.ChatCapabilityDiffs, ports.ChatCapabilityPlans,
+	} {
+		if !caps.Has(capability) {
+			t.Errorf("missing capability %q", capability)
+		}
+	}
+	if plugin.resolveCalls != 1 || plugin.authCalls != 1 || versionCalls != 1 {
+		t.Fatalf("plugin calls = resolve %d, auth %d, version %d; want one each",
+			plugin.resolveCalls, plugin.authCalls, versionCalls)
+	}
+}
+
+func TestDriverRejectsUnauthenticatedOMP(t *testing.T) {
+	driver := newDriver(
+		&fakePlugin{status: ports.AgentAuthStatusUnauthorized, binary: "/usr/bin/omp"},
+		func(context.Context, string) error { return nil },
+		nil,
+	)
+	if _, err := driver.Probe(context.Background()); !errors.Is(err, ports.ErrChatAuthRequired) {
+		t.Fatalf("Probe error = %v, want ErrChatAuthRequired", err)
+	}
+}
+
+type fakePlugin struct {
+	binary       string
+	status       ports.AgentAuthStatus
+	resolveCalls int
+	authCalls    int
+}
+
+func (p *fakePlugin) ResolveBinary(context.Context) (string, error) {
+	p.resolveCalls++
+	return p.binary, nil
+}
+
+func (p *fakePlugin) AuthStatus(context.Context) (ports.AgentAuthStatus, error) {
+	p.authCalls++
+	return p.status, nil
+}

--- a/backend/internal/adapters/chatdriver/ompacp/live_test.go
+++ b/backend/internal/adapters/chatdriver/ompacp/live_test.go
@@ -1,0 +1,83 @@
+package ompacp
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/omp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Run explicitly with AO_LIVE_OMP_ACP=1. It uses the user's existing OMP
+// executable, settings, models, and credentials; CI never depends on them.
+func TestLiveOMPACP(t *testing.T) {
+	if os.Getenv("AO_LIVE_OMP_ACP") != "1" {
+		t.Skip("set AO_LIVE_OMP_ACP=1 to run against the local OMP account")
+	}
+
+	driver := New(omp.New(), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	if _, err := driver.Probe(ctx); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	conversation, err := driver.Start(ctx, ports.ChatStartConfig{
+		SessionID: "live-omp-acp", DataDir: t.TempDir(), WorkspacePath: t.TempDir(),
+		Env: envMap(), Permissions: ports.PermissionModeBypassPermissions,
+		SystemPrompt: "Answer in one short sentence.",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer conversation.Close()
+
+	ref, err := conversation.SendTurn(ctx, ports.ChatUserMessage{
+		Text: "Reply with exactly: AO OMP ACP works", ClientMessageID: "live-1",
+		Origin: domain.MessageOriginHuman,
+	})
+	if err != nil {
+		t.Fatalf("SendTurn: %v", err)
+	}
+	if err := conversation.(ports.ChatDeferredTurnStarter).StartDeferredTurn(ref.ProviderTurnID); err != nil {
+		t.Fatalf("StartDeferredTurn: %v", err)
+	}
+
+	var answer strings.Builder
+	for {
+		select {
+		case event, ok := <-conversation.Events():
+			if !ok {
+				t.Fatalf("controller closed before completion; answer=%q", answer.String())
+			}
+			switch event.Kind {
+			case ports.ChatEventMessageDelta:
+				answer.WriteString(event.Delta)
+			case ports.ChatEventTurnCompleted:
+				if event.TurnState != domain.TurnStateCompleted {
+					t.Fatalf("turn state = %q; answer=%q", event.TurnState, answer.String())
+				}
+				if !strings.Contains(answer.String(), "AO OMP ACP works") {
+					t.Fatalf("answer = %q", answer.String())
+				}
+				return
+			}
+		case <-ctx.Done():
+			t.Fatalf("live turn timed out: %v; answer=%q", ctx.Err(), answer.String())
+		}
+	}
+}
+
+func envMap() map[string]string {
+	out := make(map[string]string)
+	for _, pair := range os.Environ() {
+		name, value, ok := strings.Cut(pair, "=")
+		if ok {
+			out[name] = value
+		}
+	}
+	return out
+}

--- a/backend/internal/adapters/chatdriver/ompacp/version.go
+++ b/backend/internal/adapters/chatdriver/ompacp/version.go
@@ -1,0 +1,71 @@
+package ompacp
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+// minimumOMPVersion is the first tagged OMP release that contains the native
+// `omp acp` command. Older builds exposed a different RPC mode whose session,
+// approval, and replay semantics are not treated as interchangeable.
+const minimumOMPVersion = "15.0.0"
+
+var versionPattern = regexp.MustCompile(`\b(\d+)\.(\d+)\.(\d+)\b`)
+
+func versionProbe(ctx context.Context, bin string) error {
+	output, err := aoprocess.CommandContext(ctx, bin, "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("read OMP version: %w", err)
+	}
+	return validateVersionOutput(string(output))
+}
+
+func validateVersionOutput(output string) error {
+	installed, ok := parseVersion(output)
+	if !ok {
+		return fmt.Errorf("unrecognized OMP version %q (AO requires %s or newer)",
+			strings.TrimSpace(output), minimumOMPVersion)
+	}
+	minimum, _ := parseVersion(minimumOMPVersion)
+	if installed.less(minimum) {
+		return fmt.Errorf("OMP %s is older than AO's tested minimum %s",
+			installed, minimumOMPVersion)
+	}
+	return nil
+}
+
+type version [3]int
+
+func parseVersion(output string) (version, bool) {
+	match := versionPattern.FindStringSubmatch(output)
+	if len(match) != 4 {
+		return version{}, false
+	}
+	var parsed version
+	for i := range parsed {
+		value, err := strconv.Atoi(match[i+1])
+		if err != nil {
+			return version{}, false
+		}
+		parsed[i] = value
+	}
+	return parsed, true
+}
+
+func (v version) less(other version) bool {
+	for i := range v {
+		if v[i] != other[i] {
+			return v[i] < other[i]
+		}
+	}
+	return false
+}
+
+func (v version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v[0], v[1], v[2])
+}

--- a/backend/internal/adapters/chatdriver/ompacp/version_test.go
+++ b/backend/internal/adapters/chatdriver/ompacp/version_test.go
@@ -1,0 +1,19 @@
+package ompacp
+
+import "testing"
+
+func TestValidateVersionOutputAcceptsNativeACPMinimum(t *testing.T) {
+	for _, output := range []string{"omp/15.0.0", "omp/17.3.5", "omp 18.0.0"} {
+		if err := validateVersionOutput(output); err != nil {
+			t.Errorf("validateVersionOutput(%q): %v", output, err)
+		}
+	}
+}
+
+func TestValidateVersionOutputRejectsBuildsWithoutNativeACP(t *testing.T) {
+	for _, output := range []string{"omp/14.9.9", "omp/3.15.1", "unknown"} {
+		if err := validateVersionOutput(output); err == nil {
+			t.Errorf("validateVersionOutput(%q) = nil, want incompatible version", output)
+		}
+	}
+}

--- a/backend/internal/adapters/chatdriver/registry/registry.go
+++ b/backend/internal/adapters/chatdriver/registry/registry.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimchi"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/omp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/pi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/claudeacp"
@@ -22,6 +23,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/cursoracp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/droidacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/kimchiacp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/ompacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/opencodeacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/piacp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -52,9 +54,9 @@ func New(drivers ...ports.ChatDriver) *Registry {
 //
 // Codex uses its native app-server protocol. Claude Code uses AO's reusable ACP
 // transport plus claude-agent-acp, pointed at the user's own Claude executable.
-// Cursor, OpenCode, Droid, Kimchi, and Pi expose ACP themselves, so AO launches
-// the exact executable resolved by each existing agent plugin. No path scrapes
-// terminal output or packages a second provider CLI.
+// Cursor, OpenCode, Droid, Kimchi, Pi, and OMP expose ACP themselves, so AO
+// launches the exact executable resolved by each existing agent plugin. No path
+// scrapes terminal output or packages a second provider CLI.
 //
 // Every other harness stays TUI-only until the same is true of it. The driver
 // reuses the harness's existing agent plugin for binary resolution and auth, so
@@ -68,6 +70,7 @@ func Build(log *slog.Logger) *Registry {
 		kimchiacp.New(kimchi.New(), log),
 		piacp.New(pi.New(), log),
 		cursoracp.New(cursor.New(), log),
+		ompacp.New(omp.New(), log),
 	)
 }
 

--- a/backend/internal/adapters/chatdriver/registry/registry_test.go
+++ b/backend/internal/adapters/chatdriver/registry/registry_test.go
@@ -13,8 +13,8 @@ import (
 // Registration is the whole capability gate — a harness with no driver here cannot
 // run chat mode — so the shipped set is a release decision, not an implementation
 // detail. Codex uses its native app-server; Claude, Cursor, OpenCode, Droid,
-// Kimchi, and Pi use the reusable ACP transport. Every remaining harness is
-// deliberately TUI-only.
+// Kimchi, Pi, and OMP use the reusable ACP transport. Every remaining harness
+// is deliberately TUI-only.
 func TestShippedChatDrivers(t *testing.T) {
 	r := Build(nil)
 
@@ -26,6 +26,7 @@ func TestShippedChatDrivers(t *testing.T) {
 		domain.HarnessKimchi,
 		domain.HarnessPi,
 		domain.HarnessCursor,
+		domain.HarnessOMP,
 	} {
 		if !r.SupportsChat(harness) {
 			t.Errorf("%s has no chat driver", harness)

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6651,6 +6651,7 @@ components:
           - vibe
           - pi
           - kimchi
+          - omp
           - prime-agent
           - autohand
           - fake
@@ -8633,6 +8634,7 @@ components:
           - vibe
           - pi
           - kimchi
+          - omp
           - prime-agent
           - autohand
           type: string

--- a/backend/internal/httpd/apispec/specgen/build_test.go
+++ b/backend/internal/httpd/apispec/specgen/build_test.go
@@ -60,6 +60,45 @@ func TestBuild_DelegateAgentEnumIncludesPrimeAgent(t *testing.T) {
 	}
 }
 
+func TestBuild_OMPIsPubliclySpawnable(t *testing.T) {
+	doc := buildSchemas(t)
+	harnesses := doc.Components.Schemas["SpawnSessionRequest"].Properties["harness"].Enum
+	if !slices.Contains(harnesses, "omp") {
+		t.Fatalf("SpawnSessionRequest harness enum = %v, want omp", harnesses)
+	}
+}
+
+func TestBuild_OMPIsPubliclyDelegatable(t *testing.T) {
+	doc := buildSchemas(t)
+	agents := doc.Components.Schemas["DelegateTaskRequest"].Properties["agent"].Enum
+	if !slices.Contains(agents, "omp") {
+		t.Fatalf("DelegateTaskRequest agent enum = %v, want omp", agents)
+	}
+}
+
+type schemaDocument struct {
+	Components struct {
+		Schemas map[string]struct {
+			Properties map[string]struct {
+				Enum []string `yaml:"enum"`
+			} `yaml:"properties"`
+		} `yaml:"schemas"`
+	} `yaml:"components"`
+}
+
+func buildSchemas(t *testing.T) schemaDocument {
+	t.Helper()
+	got, err := specgen.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	var doc schemaDocument
+	if err := yaml.Unmarshal(got, &doc); err != nil {
+		t.Fatalf("parse generated OpenAPI: %v", err)
+	}
+	return doc
+}
+
 // TestBuild_Deterministic guards against nondeterministic output (which would
 // make the drift check flaky in CI).
 func TestBuild_Deterministic(t *testing.T) {

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -185,7 +185,7 @@ type SpawnSessionRequest struct {
 	IssueID         domain.IssueID         `json:"issueId,omitempty"`
 	TrackerProvider domain.TrackerProvider `json:"trackerProvider,omitempty" enum:"github,gitlab"`
 	Kind            domain.SessionKind     `json:"kind,omitempty" enum:"worker,orchestrator"`
-	Harness         domain.AgentHarness    `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,muse,kiro,kilocode,vibe,pi,kimchi,prime-agent,autohand"`
+	Harness         domain.AgentHarness    `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,muse,kiro,kilocode,vibe,pi,kimchi,omp,prime-agent,autohand"`
 	Branch          string                 `json:"branch,omitempty"`
 	// Mode picks the conversation controller: chat talks to the agent over a
 	// structured connection, tui opens the agent's native terminal interface.
@@ -629,7 +629,7 @@ type SendSessionMessageResponse struct {
 type DelegateTaskRequest struct {
 	ProjectID domain.ProjectID    `json:"projectId"`
 	Brief     string              `json:"brief" maxLength:"4096"`
-	Agent     domain.AgentHarness `json:"agent,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,muse,kiro,kilocode,vibe,pi,kimchi,prime-agent,autohand,fake"`
+	Agent     domain.AgentHarness `json:"agent,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,muse,kiro,kilocode,vibe,pi,kimchi,omp,prime-agent,autohand,fake"`
 	Model     string              `json:"model,omitempty" maxLength:"256"`
 	// ApprovalMode is an optional per-session override. The UI uses the explicit
 	// bypass value only after the user accepts an approval-less Chat fallback.

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -1176,6 +1176,20 @@ func TestSessionsAPI_SpawnRejectsUnknownExplicitMode(t *testing.T) {
 	}
 }
 
+func TestSessionsAPI_SpawnsOMPChat(t *testing.T) {
+	svc := newFakeSessionService()
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, http.MethodPost, "/api/v1/sessions",
+		`{"projectId":"ao","harness":"omp","mode":"chat","prompt":"fix"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("spawn OMP Chat = %d, want 201; body=%s", status, body)
+	}
+	if svc.lastSpawn.Harness != domain.HarnessOMP || svc.lastSpawn.RequestedMode != domain.SessionModeChat {
+		t.Fatalf("spawn config = %#v, want OMP Chat", svc.lastSpawn)
+	}
+}
+
 func TestSessionsAPI_SpawnPassesModelToService(t *testing.T) {
 	svc := newFakeSessionService()
 	srv := newSessionTestServer(t, svc)
@@ -2426,6 +2440,20 @@ func TestSessionsAPI_DelegateTask(t *testing.T) {
 	}
 	if got := svc.delegationInput.Attachments[0]; got.Ext != ".png" || string(got.Data) != "\x01\x02\x03" {
 		t.Fatalf("attachment = %#v, want decoded png", got)
+	}
+}
+
+func TestSessionsAPI_DelegatesOMPChat(t *testing.T) {
+	svc := newFakeSessionService()
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, http.MethodPost, "/api/v1/orchestrators/delegate",
+		`{"projectId":"ao","brief":"Fix it","agent":"omp","mode":"chat"}`)
+	if status != http.StatusAccepted {
+		t.Fatalf("delegate OMP Chat = %d, want 202; body=%s", status, body)
+	}
+	if svc.delegationInput.RequestedAgent != domain.HarnessOMP || svc.delegationInput.RequestedMode != domain.SessionModeChat {
+		t.Fatalf("delegation input = %#v, want OMP Chat", svc.delegationInput)
 	}
 }
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -48,7 +48,8 @@ surface (`npm run sqlc`, `npm run api`).
   archive/projection, controller-generation fencing, turns, messages,
   activities, approvals, structured input, usage, compaction, and rollback.
 - Chat drivers for the user's installed Codex (native app-server), Claude Code
-  (claude-agent-acp), Cursor, OpenCode, Droid, Kimchi, and Pi. Pi's independently
+  (claude-agent-acp), Cursor, OpenCode, Droid, Kimchi, Pi, and OMP. OMP Chat uses
+  native `omp acp` and requires OMP 15.0.0 or newer. Pi's independently
   installed pi-acp adapter does not enforce approval modes, so AO admits Pi Chat
   only after the user explicitly chooses the per-session bypass-permissions
   fallback. The binding reuses the existing Pi config environment and auth

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2246,7 +2246,7 @@ export interface components {
         };
         DelegateTaskRequest: {
             /** @enum {string} */
-            agent?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "muse" | "kiro" | "kilocode" | "vibe" | "pi" | "kimchi" | "prime-agent" | "autohand" | "fake";
+            agent?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "muse" | "kiro" | "kilocode" | "vibe" | "pi" | "kimchi" | "omp" | "prime-agent" | "autohand" | "fake";
             /** @enum {string} */
             approvalMode?: "default" | "accept-edits" | "auto" | "bypass-permissions";
             attachments?: components["schemas"]["AttachmentInput"][];
@@ -3010,7 +3010,7 @@ export interface components {
             branch?: string;
             displayName?: string;
             /** @enum {string} */
-            harness?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "muse" | "kiro" | "kilocode" | "vibe" | "pi" | "kimchi" | "prime-agent" | "autohand";
+            harness?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "muse" | "kiro" | "kilocode" | "vibe" | "pi" | "kimchi" | "omp" | "prime-agent" | "autohand";
             issueId?: string;
             /** @enum {string} */
             kind?: "worker" | "orchestrator";


### PR DESCRIPTION
Add OMP Chat through its native ACP server, using the exact binary and authentication resolved by the existing OMP adapter.

## Implementation
- Launch only native `omp acp`; no RPC fallback is attempted.
- Require OMP 15.0.0 or newer, the tested minimum containing the native ACP command.
- Fix approval policy at process launch and reject incompatible per-turn changes.
- Register OMP in the shipped Chat-driver set and canonical STATUS list.
- Expose OMP in spawn/delegation DTO enums, generated OpenAPI, and frontend schema types.
- Add controller/spec contract tests plus OMP launch, version, approval, registry, and opt-in live tests.

## Shared ACP prerequisite

This branch is rebased onto current `main`, including #4194's shared ACP replay implementation. #4194 owns recovered turn/activity states, migration 0107, storage/API/frontend propagation, user-only and provider-output replay-tail handling, and preservation of known durable outcomes. This PR no longer duplicates or modifies those shared lifecycle files.

## Verification
- `npm run api`
- `npm run lint` (full backend tests plus golangci-lint: 0 issues)
- `npm run frontend:typecheck`
- focused ACP/native ACP/OMP/registry/HTTP/domain/storage tests
- focused `go vet`

The branch is one OMP-only commit on current `main`.
