### PR TITLE
fix: hide inactive cloud sign-in controls

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -22,8 +22,15 @@ import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { agentsQueryKey } from "../hooks/useAgentsQuery";
 import { useUiStore } from "../stores/ui-store";
 
-const { getMock, navigateMock, mockParams, renameSessionMock, spawnMock, updateStatusMock, commandPaletteEnabled } = vi.hoisted(
+const { cloudSessionState, getMock, navigateMock, mockParams, renameSessionMock, spawnMock, updateStatusMock, commandPaletteEnabled } = vi.hoisted(
 	() => ({
+		cloudSessionState: {
+			configured: false,
+			session: null as null | { user: { email: string } },
+			status: "unauthenticated" as "authenticated" | "loading" | "unauthenticated",
+			signIn: vi.fn(),
+			signOut: vi.fn().mockResolvedValue(undefined),
+		},
 		getMock: vi.fn(),
 		navigateMock: vi.fn(),
 		mockParams: { projectId: undefined as string | undefined, sessionId: undefined as string | undefined },
@@ -36,6 +43,7 @@ const { getMock, navigateMock, mockParams, renameSessionMock, spawnMock, updateS
 
 vi.mock("../lib/rename-session", () => ({ renameSession: renameSessionMock }));
 vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: spawnMock }));
+vi.mock("../lib/cloud-session", () => ({ useCloudSession: () => cloudSessionState }));
 
 vi.mock("../hooks/useCommandPaletteEnabled", () => ({
 	useCommandPaletteEnabled: () => commandPaletteEnabled.current,
@@ -241,6 +249,11 @@ beforeEach(() => {
 	window.localStorage.clear();
 	document.documentElement.style.removeProperty("--ao-sidebar-w");
 	commandPaletteEnabled.current = true;
+	cloudSessionState.configured = false;
+	cloudSessionState.session = null;
+	cloudSessionState.status = "unauthenticated";
+	cloudSessionState.signIn.mockReset();
+	cloudSessionState.signOut.mockReset().mockResolvedValue(undefined);
 	useUiStore.setState({ isCommandPaletteOpen: false, settingsModal: null });
 	getMock.mockReset();
 	getMock.mockResolvedValue({
@@ -273,6 +286,14 @@ afterEach(() => {
 });
 
 describe("Sidebar", () => {
+	it("does not show cloud sign-in controls while signed out", () => {
+		cloudSessionState.configured = true;
+		renderSidebar();
+
+		expect(screen.queryByLabelText("Sign in to AO Cloud")).not.toBeInTheDocument();
+		expect(screen.queryByText("Sign in")).not.toBeInTheDocument();
+	});
+
 	it("suppresses focus chrome without removing keyboard focusability", () => {
 		renderSidebar();
 

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -294,6 +294,15 @@ describe("Sidebar", () => {
 		expect(screen.queryByText("Sign in")).not.toBeInTheDocument();
 	});
 
+	it("keeps cloud account controls visible while signed in", () => {
+		cloudSessionState.configured = true;
+		cloudSessionState.status = "authenticated";
+		cloudSessionState.session = { user: { email: "user@example.com" } };
+		renderSidebar();
+
+		expect(screen.getAllByLabelText("Signed in as user@example.com")).toHaveLength(2);
+	});
+
 	it("suppresses focus chrome without removing keyboard focusability", () => {
 		renderSidebar();
 

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -8,7 +8,6 @@ import {
 	ChevronRight,
 	Folder,
 	FolderOpen,
-	LogIn,
 	LogOut,
 	MoreVertical,
 	Pencil,
@@ -1051,38 +1050,13 @@ function SessionRow({
 	);
 }
 
-// CloudAccountRow: shown above the Settings button. When unauthenticated it
-// starts the native WorkOS PKCE flow. When authenticated it shows the user's
-// email with a sign-out action in a dropdown.
+// CloudAccountRow: shown above the Settings button for an existing cloud
+// session. The unauthenticated sign-in entry stays hidden until that flow is
+// ready to expose in the app again.
 function CloudAccountRow({ tabIndex }: { tabIndex: number }) {
 	const { t } = useTranslation();
-	const { configured, session, status, signIn, signOut } = useCloudSession();
-	if (!configured || status === "loading") return null;
-
-	if (status === "unauthenticated") {
-		return (
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						aria-label={t("shell.signInToAOCloud")}
-						className={cn(
-							NAV_ROW_CLASS,
-							"flex h-9 w-full items-center text-left [&_svg]:size-icon-md [&_svg]:shrink-0",
-						)}
-						onClick={() => signIn()}
-						tabIndex={tabIndex}
-						type="button"
-					>
-						<User aria-hidden="true" />
-						<span className="tracking-tight">{t("shell.signIn")}</span>
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="right" hidden={tabIndex !== -1}>
-					{t("shell.signInToAOCloud")}
-				</TooltipContent>
-			</Tooltip>
-		);
-	}
+	const { configured, session, status, signOut } = useCloudSession();
+	if (!configured || status !== "authenticated") return null;
 
 	return (
 		<DropdownMenu>
@@ -1118,27 +1092,8 @@ function CloudAccountRow({ tabIndex }: { tabIndex: number }) {
 // Icon-rail variant for collapsed sidebar.
 function CloudAccountRailButton({ tabIndex }: { tabIndex: number }) {
 	const { t } = useTranslation();
-	const { configured, session, status, signIn, signOut } = useCloudSession();
-	if (!configured || status === "loading") return null;
-
-	if (status === "unauthenticated") {
-		return (
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						aria-label={t("shell.signInToAOCloud")}
-						className="grid size-control-board place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground [&_svg]:size-icon-base"
-						onClick={() => signIn()}
-						tabIndex={tabIndex}
-						type="button"
-					>
-						<LogIn aria-hidden="true" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="right">{t("shell.signInToAOCloud")}</TooltipContent>
-			</Tooltip>
-		);
-	}
+	const { configured, session, status, signOut } = useCloudSession();
+	if (!configured || status !== "authenticated") return null;
 
 	return (
 		<Tooltip>

--- a/frontend/src/renderer/lib/cloud-session.ts
+++ b/frontend/src/renderer/lib/cloud-session.ts
@@ -48,6 +48,7 @@ export function useCloudSession(): UseCloudSessionResult {
     };
   }, []);
 
+  // Parked while the sidebar sign-in entry point is intentionally hidden.
   const signIn = () => {
     void aoBridge.cloud.signIn();
   };


### PR DESCRIPTION
## Summary

- hide the nonfunctional AO Cloud sign-in row from the expanded sidebar
- hide the matching sign-in icon from the collapsed sidebar rail
- preserve account and sign-out controls for existing authenticated sessions
- add regression coverage for the configured-but-signed-out state

## Tests

- `npm test -- src/renderer/components/Sidebar.test.tsx` (60 passed)
- `npm run frontend:typecheck`

## Risks / follow-ups

- The sign-in UI remains intentionally hidden until the cloud authentication flow is ready to expose again.