### PR TITLE
fix(frontend): make dev:web start on Windows

### DIFF
--- a/frontend/npm-scripts-portability.test.ts
+++ b/frontend/npm-scripts-portability.test.ts
@@ -1,0 +1,32 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..");
+
+// npm runs scripts through cmd.exe on Windows, which has no `VAR=value command`
+// syntax: such a script dies with "'VAR' is not recognized as an internal or
+// external command" before the tool it prefixes ever starts. The prefix works on
+// macOS and Linux and CI runs Linux only, so nothing else catches it — `dev:web`
+// carried one for months and took `npm run test:e2e` down with it on Windows.
+//
+// Pass the value through the tool's own interface instead (vite reads `--mode`,
+// and the renderer config turns that into the define), or read it from a config
+// file. Matching only at a command boundary keeps flag values such as
+// `--path-mode=abs` and `-o src/api/schema.ts` out of the net.
+const POSIX_ENV_PREFIX = /(?:^|&&\s*|\|\|\s*|;\s*|\|\s*)[A-Za-z_][A-Za-z0-9_]*=/;
+
+describe("npm scripts stay cross-platform", () => {
+	for (const manifest of ["package.json", "frontend/package.json"]) {
+		it(`${manifest} sets no environment variable with a POSIX prefix`, async () => {
+			const contents = await readFile(path.join(repositoryRoot, manifest), "utf8");
+			const scripts: Record<string, string> = JSON.parse(contents).scripts ?? {};
+
+			const offenders = Object.entries(scripts)
+				.filter(([, command]) => POSIX_ENV_PREFIX.test(command))
+				.map(([name, command]) => `${name}: ${command}`);
+
+			expect(offenders).toEqual([]);
+		});
+	}
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
 		"build:daemon": "node ./scripts/build-daemon.mjs",
 		"predev": "npm run build:daemon -- --dev && node ./scripts/ensure-browser-runtime.mjs && npm run build:acp-runtime",
 		"dev": "electron-forge start",
-		"dev:web": "VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts",
+		"dev:web": "vite --config vite.renderer.config.ts --mode web",
 		"prepackage": "npm run build:daemon && npm run browser-runtime:prepare && npm run build:acp-runtime",
 		"package": "electron-forge package",
 		"premake": "npm run build:daemon && npm run browser-runtime:prepare && npm run build:acp-runtime",

--- a/frontend/vite.renderer.config.ts
+++ b/frontend/vite.renderer.config.ts
@@ -97,7 +97,15 @@ const productUiReactBoundary: Plugin = {
 	},
 };
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+	// `dev:web` asks for the Electron-free browser preview with `--mode web`, and
+	// the flag is injected here rather than as a `VITE_NO_ELECTRON=1` shell
+	// prefix in package.json: npm runs scripts through cmd.exe on Windows, which
+	// has no env-prefix syntax, so the prefix form fails before vite ever starts.
+	// An .env file would be the other option, but .gitignore excludes .env* so it
+	// could not be tracked. Only "web" defines the key; every other mode
+	// (electron-forge dev/package, vitest) leaves it undefined exactly as before.
+	define: mode === "web" ? { "import.meta.env.VITE_NO_ELECTRON": '"1"' } : {},
 	// "@/" → the renderer root (src/renderer), the shadcn/ui import convention.
 	resolve: {
 		alias: {
@@ -146,4 +154,4 @@ export default defineConfig({
 		globals: true,
 		setupFiles: "./src/renderer/test/setup.ts",
 	},
-});
+}));


### PR DESCRIPTION
## What

Make `npm run dev:web` start on Windows, and add a test so the bug class cannot come back.

## Why

`dev:web` set the renderer's browser-preview flag with a POSIX env prefix:

```json
"dev:web": "VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts"
```

npm runs scripts through `cmd.exe` on Windows, which has no env-prefix syntax, so the script died before vite ever started:

```
> VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts --port 5199 --host 127.0.0.1
'VITE_NO_ELECTRON' is not recognized as an internal or external command,
operable program or batch file.
```

That also took `npm run test:e2e` down with it, since the Playwright `webServer` boots `dev:web`. A Windows contributor has no renderer-only dev loop and no renderer e2e suite today.

## How

Pass `--mode web` and let the renderer config inject the flag, so the value reaches `import.meta.env` on every platform:

```ts
define: mode === "web" ? { "import.meta.env.VITE_NO_ELECTRON": '"1"' } : {},
```

Only `web` defines the key. electron-forge dev/package and vitest run under other modes and leave it undefined exactly as before, so the packaged renderer is untouched and the comment in `useWorkspaceQuery.ts` still holds.

Two alternatives I discarded, in case they come up in review:

- **A tracked `.env` file** — `.gitignore` excludes `.env*` (only `.env.example` is negated), so it could not be committed.
- **`cross-env`** — I tried it and backed it out. Any dependency change rewrites `package-lock.json` on Windows, and that rewrite drops the optional `@emnapi/*` entries bundled under `@tailwindcss/oxide-wasm32-wasi`, which Linux installs need. The lockfile churn was worse than the fix. The config route needs no dependency and leaves the lockfile untouched.

The second commit adds `frontend/npm-scripts-portability.test.ts`, modelled on `release-workflows.test.ts`: it reads the root and frontend manifests and fails on any script that sets an environment variable with a POSIX prefix. Nothing else catches this class — the prefix is valid `sh` and CI is Linux-only.

## Testing

Windows 11, Node 24.13.0, npm 11.6.2, Go 1.27.0.

- `npm run dev:web -- --port 5199 --host 127.0.0.1` — starts (previously exit 1). Confirmed the flag actually lands by fetching a transformed module from the dev server:
  ```
  import.meta.env = {"BASE_URL":"/","DEV":true,"MODE":"web","PROD":false,"SSR":false,"VITE_NO_ELECTRON":"1"}
  ```
- `npm run typecheck` and `npm run typecheck:e2e` — both clean.
- `npx vitest run` — 2612 passed / 2625 total, exactly +2 from the new test versus the pre-change baseline of 2610 / 2623. The 12 remaining failures are the pre-existing macOS/POSIX-only specs (maker-dmg, relocation, auto-updater translocation, supervisor-link unix sockets, the `verify-mac-artifact.sh` exec-bit check) and are identical before and after this change.
- New test verified by reintroducing the prefix: it fails and names the offending script.
- `npm run dev` — full Electron app launches from this branch, daemon on 127.0.0.1:3002, renderer serving `/api/v1/projects` and `/api/v1/sessions` 200s.

I could not run the Playwright renderer suite end to end here (no browsers installed on this machine), so the `test:e2e` claim covers the `webServer` command starting, not the specs passing.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
