### PR TITLE
fix: rank agents by usage frequency

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -267,7 +267,7 @@ func Run() error {
 	}
 	lcStack.trackerDone = startTrackerIntake(ctx, store, sessionSvc, log)
 
-	agentSvc := agentsvc.NewWithDeps(agentsvc.Deps{Cache: store, Discoverer: modelcatalog.Discoverer{}, Projects: store})
+	agentSvc := agentsvc.NewWithDeps(agentsvc.Deps{Cache: store, Discoverer: modelcatalog.Discoverer{}, Projects: store, Sessions: store})
 	go func() {
 		if _, err := agentSvc.Refresh(ctx); err != nil {
 			log.Warn("initial agent catalog refresh failed", "err", err)

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -5187,6 +5187,16 @@ components:
           type: string
         label:
           type: string
+        lastUsedAt:
+          description: Creation time of the newest retained session currently attributed
+            to this agent.
+          format: date-time
+          type:
+          - "null"
+          - string
+        usageCount:
+          description: Number of retained sessions currently attributed to this agent.
+          type: integer
       required:
       - id
       - label

--- a/backend/internal/service/agent/catalog_test.go
+++ b/backend/internal/service/agent/catalog_test.go
@@ -66,6 +66,15 @@ type fakeProjectLookup struct {
 	err     error
 }
 
+type fakeSessionUsageLookup struct {
+	records []domain.SessionRecord
+	err     error
+}
+
+func (f fakeSessionUsageLookup) ListAllSessions(context.Context) ([]domain.SessionRecord, error) {
+	return f.records, f.err
+}
+
 type fakeModelDiscoverer struct {
 	version                string
 	catalog                ports.AgentModelCatalog
@@ -368,6 +377,45 @@ func TestRefreshDoesNotWaitForSlowAgentProbe(t *testing.T) {
 	}
 	if len(got.Installed) != 1 || got.Installed[0].ID != "codex" {
 		t.Fatalf("installed = %#v, want only codex", got.Installed)
+	}
+}
+
+func TestListRanksAgentsByRetainedSessionUsage(t *testing.T) {
+	older := time.Date(2026, time.August, 18, 10, 0, 0, 0, time.UTC)
+	newer := older.Add(24 * time.Hour)
+	svc := NewWithAgents([]agentregistry.HarnessAgent{
+		harnessAgent("claude-code", "Claude Code", nil),
+		harnessAgent("codex", "Codex", nil),
+		harnessAgent("goose", "Goose", nil),
+	})
+	svc.sessions = fakeSessionUsageLookup{records: []domain.SessionRecord{
+		{Harness: domain.AgentHarness("claude-code"), CreatedAt: newer},
+		{Harness: domain.AgentHarness("codex"), CreatedAt: older},
+		{Harness: domain.AgentHarness("codex"), CreatedAt: newer},
+	}}
+
+	got, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if ids := []string{got.Supported[0].ID, got.Supported[1].ID, got.Supported[2].ID}; !reflect.DeepEqual(ids, []string{"codex", "claude-code", "goose"}) {
+		t.Fatalf("supported order = %v, want frequency then unused fallback", ids)
+	}
+	if got.Supported[0].UsageCount != 2 || got.Supported[0].LastUsedAt == nil || !got.Supported[0].LastUsedAt.Equal(newer) {
+		t.Fatalf("codex usage = %#v, want count 2 and latest use %s", got.Supported[0], newer)
+	}
+	if got.Supported[2].UsageCount != 0 || got.Supported[2].LastUsedAt != nil {
+		t.Fatalf("unused agent usage = %#v, want empty usage metadata", got.Supported[2])
+	}
+}
+
+func TestListReturnsSessionUsageReadFailure(t *testing.T) {
+	svc := NewWithAgents([]agentregistry.HarnessAgent{harnessAgent("codex", "Codex", nil)})
+	svc.sessions = fakeSessionUsageLookup{err: errors.New("database unavailable")}
+
+	_, err := svc.List(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "list sessions for agent usage") {
+		t.Fatalf("List error = %v, want session usage context", err)
 	}
 }
 

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -66,6 +66,8 @@ type Info struct {
 	ID         string                `json:"id"`
 	Label      string                `json:"label"`
 	AuthStatus ports.AgentAuthStatus `json:"authStatus,omitempty" enum:"authorized,unauthorized,unknown" description:"Advisory local auth probe result. authorized means a recent local probe passed; spawn remains the authoritative validation point."`
+	UsageCount int                   `json:"usageCount,omitempty" description:"Number of retained sessions currently attributed to this agent."`
+	LastUsedAt *time.Time            `json:"lastUsedAt,omitempty" format:"date-time" description:"Creation time of the newest retained session currently attributed to this agent."`
 }
 
 // Inventory describes all daemon-supported agents and best-effort local probe
@@ -85,6 +87,7 @@ type Service struct {
 	cache       ports.AgentModelCatalogCache
 	discoverer  ports.AgentModelDiscoverer
 	projects    ProjectLookup
+	sessions    SessionUsageLookup
 	resolverMu  map[string]*sync.Mutex
 	modelCallMu sync.Mutex
 	modelCalls  map[string]*modelCatalogCall
@@ -100,12 +103,19 @@ type Deps struct {
 	Cache      ports.AgentModelCatalogCache
 	Discoverer ports.AgentModelDiscoverer
 	Projects   ProjectLookup
+	Sessions   SessionUsageLookup
 }
 
 // ProjectLookup resolves the registered working directory used for model
 // discovery. The SQLite store satisfies this narrow read boundary.
 type ProjectLookup interface {
 	GetProject(ctx context.Context, id string) (domain.ProjectRecord, bool, error)
+}
+
+// SessionUsageLookup provides durable session facts used to rank agent choices.
+// The SQLite store satisfies this narrow read boundary.
+type SessionUsageLookup interface {
+	ListAllSessions(ctx context.Context) ([]domain.SessionRecord, error)
 }
 
 // New returns an agent inventory service backed by the daemon's shipped
@@ -116,7 +126,9 @@ func New() *Service {
 
 // NewWithDeps returns the production service with durable model-catalog cache.
 func NewWithDeps(deps Deps) *Service {
-	return newService(agentregistry.Harnessed(), deps.Cache, deps.Projects, deps.Discoverer)
+	svc := newService(agentregistry.Harnessed(), deps.Cache, deps.Projects, deps.Discoverer)
+	svc.sessions = deps.Sessions
+	return svc
 }
 
 // NewWithAgents returns an inventory service over a caller-provided adapter
@@ -146,8 +158,9 @@ func (s *Service) List(ctx context.Context) (Inventory, error) {
 		return Inventory{}, err
 	}
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return cloneInventory(s.inventory), nil
+	inventory := cloneInventory(s.inventory)
+	s.mu.RUnlock()
+	return s.withSessionUsage(ctx, inventory)
 }
 
 // Refresh runs the bounded local binary/auth probes, updates the cached
@@ -164,7 +177,7 @@ func (s *Service) Refresh(ctx context.Context) (Inventory, error) {
 	if !s.lastRefresh.IsZero() && time.Since(s.lastRefresh) < agentRefreshMinInterval {
 		cached := cloneInventory(s.inventory)
 		s.mu.RUnlock()
-		return cached, nil
+		return s.withSessionUsage(ctx, cached)
 	}
 	s.mu.RUnlock()
 
@@ -207,7 +220,49 @@ func (s *Service) Refresh(ctx context.Context) (Inventory, error) {
 	s.inventory = cloneInventory(next)
 	s.lastRefresh = time.Now()
 	s.mu.Unlock()
-	return next, nil
+	return s.withSessionUsage(ctx, next)
+}
+
+type sessionUsage struct {
+	count      int
+	lastUsedAt time.Time
+}
+
+func (s *Service) withSessionUsage(ctx context.Context, inventory Inventory) (Inventory, error) {
+	if s.sessions == nil {
+		return inventory, nil
+	}
+	records, err := s.sessions.ListAllSessions(ctx)
+	if err != nil {
+		return Inventory{}, fmt.Errorf("list sessions for agent usage: %w", err)
+	}
+	usageByAgent := make(map[string]sessionUsage)
+	for _, record := range records {
+		if record.Harness == "" {
+			continue
+		}
+		usage := usageByAgent[string(record.Harness)]
+		usage.count++
+		if record.CreatedAt.After(usage.lastUsedAt) {
+			usage.lastUsedAt = record.CreatedAt
+		}
+		usageByAgent[string(record.Harness)] = usage
+	}
+	decorate := func(infos []Info) {
+		for i := range infos {
+			usage := usageByAgent[infos[i].ID]
+			infos[i].UsageCount = usage.count
+			if !usage.lastUsedAt.IsZero() {
+				lastUsedAt := usage.lastUsedAt
+				infos[i].LastUsedAt = &lastUsedAt
+			}
+		}
+		sortInfosByUsage(infos)
+	}
+	decorate(inventory.Supported)
+	decorate(inventory.Installed)
+	decorate(inventory.Authorized)
+	return inventory, nil
 }
 
 // Probe runs a fresh bounded binary/auth probe for one agent, bypassing the
@@ -530,6 +585,28 @@ func authStatus(ctx context.Context, a ports.Agent) ports.AgentAuthStatus {
 
 func sortInfos(infos []Info) {
 	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].ID < infos[j].ID
+	})
+}
+
+func sortInfosByUsage(infos []Info) {
+	sort.SliceStable(infos, func(i, j int) bool {
+		if infos[i].UsageCount != infos[j].UsageCount {
+			return infos[i].UsageCount > infos[j].UsageCount
+		}
+		var left, right time.Time
+		if infos[i].LastUsedAt != nil {
+			left = *infos[i].LastUsedAt
+		}
+		if infos[j].LastUsedAt != nil {
+			right = *infos[j].LastUsedAt
+		}
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		if infos[i].Label != infos[j].Label {
+			return infos[i].Label < infos[j].Label
+		}
 		return infos[i].ID < infos[j].ID
 	})
 }

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1728,6 +1728,13 @@ export interface components {
             authStatus?: "authorized" | "unauthorized" | "unknown";
             id: string;
             label: string;
+            /**
+             * Format: date-time
+             * @description Creation time of the newest retained session currently attributed to this agent.
+             */
+            lastUsedAt?: null | string;
+            /** @description Number of retained sessions currently attributed to this agent. */
+            usageCount?: number;
         };
         AgentModelInfo: {
             id: string;

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
@@ -54,6 +54,15 @@ describe("CreateProjectAgentSheet", () => {
 		).toBe("codex");
 	});
 
+	it("chooses the most frequently used authorized agent by default", () => {
+		expect(
+			defaultAuthorizedAgent([
+				{ id: "claude-code", label: "Claude Code", authStatus: "authorized", usageCount: 1 },
+				{ id: "codex", label: "Codex", authStatus: "authorized", usageCount: 3 },
+			]),
+		).toBe("codex");
+	});
+
 	it("falls back to the alphabetically first authorized agent when no priority agent is authorized", () => {
 		expect(
 			defaultAuthorizedAgent([

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -13,8 +13,8 @@ import { agentsQueryKey, agentsQueryOptions, refreshAgentsIfStale } from "../hoo
 import { AGENT_OPTIONS } from "../lib/agent-options";
 import {
 	agentLabelCompare,
+	agentUsageCompare,
 	buildRankedAgentOptions,
-	DEFAULT_AGENT_PRIORITY,
 	DEFAULT_AGENT_PRIORITY_RANK,
 } from "../lib/agent-select-options";
 import { cn } from "../lib/utils";
@@ -542,8 +542,12 @@ export const RequiredAgentField = memo(function RequiredAgentField({
 });
 
 export function defaultAuthorizedAgent(authorizedAgents: AgentInfo[]): string {
-	const authorizedIds = new Set(authorizedAgents.map((agent) => agent.id));
-	const prioritized = DEFAULT_AGENT_PRIORITY.find((agent) => authorizedIds.has(agent));
-	if (prioritized) return prioritized;
-	return [...authorizedAgents].sort(agentLabelCompare)[0]?.id ?? "";
+	return [...authorizedAgents]
+		.sort(
+			(a, b) =>
+				agentUsageCompare(a, b) ||
+				(DEFAULT_AGENT_PRIORITY_RANK.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+					(DEFAULT_AGENT_PRIORITY_RANK.get(b.id) ?? Number.MAX_SAFE_INTEGER) ||
+				agentLabelCompare(a, b),
+		)[0]?.id ?? "";
 }

--- a/frontend/src/renderer/lib/agent-select-options.test.ts
+++ b/frontend/src/renderer/lib/agent-select-options.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { buildRankedAgentOptions } from "./agent-select-options";
+
+const priorityRank = new Map([
+	["claude-code", 0],
+	["codex", 1],
+]);
+
+describe("buildRankedAgentOptions", () => {
+	it("ranks selectable agents by frequency before the static cold-start priority", () => {
+		const agents = [
+			{ id: "claude-code", label: "Claude Code", authStatus: "authorized" as const, usageCount: 1 },
+			{ id: "codex", label: "Codex", authStatus: "authorized" as const, usageCount: 4 },
+		];
+
+		const options = buildRankedAgentOptions({
+			supported: agents,
+			installed: agents,
+			authorized: agents,
+			priorityRank,
+			fallbackAgents: [],
+		});
+
+		expect(options.map((agent) => agent.id)).toEqual(["codex", "claude-code"]);
+	});
+
+	it("uses most recent usage to break frequency ties", () => {
+		const agents = [
+			{
+				id: "claude-code",
+				label: "Claude Code",
+				authStatus: "authorized" as const,
+				usageCount: 2,
+				lastUsedAt: "2026-08-18T10:00:00Z",
+			},
+			{
+				id: "codex",
+				label: "Codex",
+				authStatus: "authorized" as const,
+				usageCount: 2,
+				lastUsedAt: "2026-08-19T10:00:00Z",
+			},
+		];
+
+		const options = buildRankedAgentOptions({
+			supported: agents,
+			installed: agents,
+			authorized: agents,
+			priorityRank,
+			fallbackAgents: [],
+		});
+
+		expect(options.map((agent) => agent.id)).toEqual(["codex", "claude-code"]);
+	});
+
+	it("keeps unavailable agents below selectable agents regardless of usage", () => {
+		const supported = [
+			{ id: "claude-code", label: "Claude Code", usageCount: 1 },
+			{ id: "codex", label: "Codex", usageCount: 10 },
+		];
+
+		const options = buildRankedAgentOptions({
+			supported,
+			installed: [{ ...supported[0], authStatus: "authorized" as const }],
+			authorized: [{ ...supported[0], authStatus: "authorized" as const }],
+			priorityRank,
+			fallbackAgents: [],
+		});
+
+		expect(options.map((agent) => agent.id)).toEqual(["claude-code", "codex"]);
+	});
+});

--- a/frontend/src/renderer/lib/agent-select-options.ts
+++ b/frontend/src/renderer/lib/agent-select-options.ts
@@ -21,6 +21,14 @@ export function agentLabelCompare(a: AgentInfo, b: AgentInfo): number {
 	return a.label.localeCompare(b.label) || a.id.localeCompare(b.id);
 }
 
+export function agentUsageCompare(a: AgentInfo, b: AgentInfo): number {
+	const byFrequency = (b.usageCount ?? 0) - (a.usageCount ?? 0);
+	if (byFrequency !== 0) return byFrequency;
+	const byRecency = (b.lastUsedAt ?? "").localeCompare(a.lastUsedAt ?? "");
+	if (byRecency !== 0) return byRecency;
+	return 0;
+}
+
 function agentStatus(
 	installedAgent: AgentInfo | undefined,
 	isAuthorized: boolean,
@@ -76,5 +84,11 @@ export function buildRankedAgentOptions({
 				...agentStatus(installedAgent, isAuthorized, isAuthUnknown),
 			};
 		})
-		.sort((a, b) => a.rank - b.rank || a.priorityRank - b.priorityRank || agentLabelCompare(a, b));
+		.sort(
+			(a, b) =>
+				a.rank - b.rank ||
+				agentUsageCompare(a, b) ||
+				a.priorityRank - b.priorityRank ||
+				agentLabelCompare(a, b),
+		);
 }


### PR DESCRIPTION
## What

Rank agent choices by retained-session usage instead of relying primarily on a static preference list and alphabetical ordering.

The agent catalog now reports `usageCount` and `lastUsedAt`, and agent pickers order selectable agents by frequency, then recency. The existing static priority and alphabetical order remain as cold-start tie-breakers. The create-project default follows the same ranking.

## Why

Frequently used agents should be quicker to select and should become the default naturally, while new installations still need deterministic ordering before any usage history exists.

## How

- Derive usage at agent-catalog read time from durable session records; no new stored display state or migration.
- Count retained sessions by their current harness and use the newest retained session creation time as the recency tie-breaker.
- Preserve availability/auth grouping ahead of usage so an unavailable agent never outranks a selectable one.
- Regenerate OpenAPI and frontend TypeScript types for the new metadata.

Intentional scope: usage reflects retained AO sessions currently attributed to each harness. Deleted sessions and historical source harnesses after an agent switch are not counted.

## Testing

- `go test ./internal/service/agent ./internal/daemon`
- `go test ./internal/httpd/...`
- `go test ./internal/service/agent ./internal/httpd/apispec/...`
- `npm --prefix frontend test -- --run src/renderer/lib/agent-select-options.test.ts src/renderer/components/CreateProjectAgentSheet.test.tsx` (12 tests passed)
- `npm --prefix frontend run typecheck`
- `git diff --check`

A full `go test ./...` was also attempted in the restricted workspace; unrelated socket/tmux tests could not bind local sockets and a few timing-sensitive adapter tests timed out. All touched-package tests passed.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
