### PR TITLE
fix: simplify reconnect status rows

### DIFF
--- a/frontend/src/renderer/components/chat/ChatProviderSignal.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatProviderSignal.test.tsx
@@ -319,7 +319,7 @@ describe("provider error", () => {
 			/>,
 		);
 		expect(screen.getByText("Reconnecting... [1/5]")).toBeInTheDocument();
-		expect(screen.getByText(/You have no credits remaining/i)).toBeInTheDocument();
+		expect(screen.queryByText(/You have no credits remaining/i)).not.toBeInTheDocument();
 		// The raw envelope must not paint as the row label — that is what overflowed the column.
 		expect(screen.queryByText(/codexErrorInfo/i)).not.toBeInTheDocument();
 		expect(screen.queryByText(/provider error:/i)).not.toBeInTheDocument();
@@ -341,7 +341,7 @@ describe("provider error", () => {
 			/>,
 		);
 		expect(screen.getByText("Reconnecting... [1/5]")).toBeInTheDocument();
-		expect(screen.getByText(/You have no credits remaining/i)).toBeInTheDocument();
+		expect(screen.queryByText(/You have no credits remaining/i)).not.toBeInTheDocument();
 		expect(screen.queryByText(/codexErrorInfo/i)).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -1268,18 +1268,10 @@ function RerouteRow({ activity }: { activity: ConversationActivity }) {
  * reconnect row as `role="alert"` would interrupt a screen reader once per attempt.
  */
 function ErrorActivityRow({ activity }: { activity: ConversationActivity }) {
-	const { headline, detail } = providerErrorCopy(activity);
+	const { headline } = providerErrorCopy(activity);
 	return (
-		<div className="flex min-w-0 max-w-full items-start gap-2.5 overflow-hidden rounded-md border border-destructive/40 bg-surface px-3 py-2">
-			<AlertTriangle aria-hidden="true" className="mt-0.5 size-3.5 shrink-0 text-destructive" />
-			<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-				<strong className="wrap-anywhere text-[11px] font-medium leading-snug text-destructive">
-					{headline}
-				</strong>
-				{detail ? (
-					<p className="wrap-anywhere text-[10.5px] leading-snug text-muted-foreground">{detail}</p>
-				) : null}
-			</div>
+		<div className="flex min-w-0 max-w-full items-baseline overflow-hidden py-0.5 text-[11.5px] leading-snug text-muted-foreground">
+			<span className="wrap-anywhere min-w-0">{headline}</span>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- Replace boxed reconnect error cards with a plain muted text row.
- Show only the reconnect headline, such as `Reconnecting... 2/5`.
- Keep provider error parsing and durable error details unchanged.

## Validation

- `git diff --check` passes.
- Focused Vitest test could not run in the isolated worktree because `vitest` is not installed; the existing checkout's test environment is also blocked by Node 18.16 lacking `node:util.styleText`.
