### PR TITLE
fix(lifecycle): fence chat activity by controller generation

### DIFF
--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -547,9 +547,16 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		m.mu.Unlock()
 		return nil
 	}
-	if s.ControllerGeneration != "" &&
-		(domain.NormalizeSessionMode(rec.Mode) != domain.SessionModeChat ||
-			s.ControllerGeneration != rec.Metadata.ControllerGeneration) {
+	mode := domain.NormalizeSessionMode(rec.Mode)
+	currentChatController := mode == domain.SessionModeChat &&
+		s.ControllerGeneration != "" &&
+		s.ControllerGeneration == rec.Metadata.ControllerGeneration
+	// Chat has no supervised runtime launch to fence inherited workspace hooks.
+	// Its in-process controller always supplies the generation it durably claimed,
+	// while provider hooks never receive that internal credential. Requiring it in
+	// Chat mode therefore rejects both stale controllers and nested agent processes.
+	if (mode == domain.SessionModeChat && !currentChatController) ||
+		(mode != domain.SessionModeChat && s.ControllerGeneration != "") {
 		m.mu.Unlock()
 		return nil
 	}
@@ -558,11 +565,13 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		m.mu.Unlock()
 		return nil
 	}
-	// An explicit prompt submission is proof that an agent was relaunched in the
-	// preserved shell. Other same-generation callbacks may have been delayed
-	// behind the process-exit report and cannot resurrect an exited workload.
+	// An explicit prompt submission is proof that a TUI agent was relaunched in
+	// the preserved shell. Other TUI callbacks may have been delayed behind the
+	// process-exit report and cannot resurrect an exited workload. Chat activity
+	// is emitted synchronously by its current generation-fenced controller, so a
+	// non-exited signal from that owner is direct evidence that it is still live.
 	if rec.Activity.State == domain.ActivityExited && s.Valid && s.State != domain.ActivityExited &&
-		(s.State != domain.ActivityActive || s.Event != "user-prompt-submit") {
+		!currentChatController && (s.State != domain.ActivityActive || s.Event != "user-prompt-submit") {
 		m.mu.Unlock()
 		return nil
 	}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -3845,3 +3845,79 @@ func TestEmitTelemetryStampsRequestID(t *testing.T) {
 		})
 	}
 }
+
+func TestActivitySignalRejectsHookWithoutChatControllerGeneration(t *testing.T) {
+	ctx := context.Background()
+	st := newFakeStore()
+	rec := domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", Mode: domain.SessionModeChat,
+		Metadata: domain.SessionMetadata{
+			AgentSessionID:         "parent-native-session",
+			NativeTranscriptPath:   "/transcripts/parent.jsonl",
+			ProviderConversationID: "parent-native-session",
+			ControllerGeneration:   "chat-generation-1",
+		},
+		Activity: domain.Activity{State: domain.ActivityActive},
+	}
+	st.sessions[rec.ID] = rec
+	m := New(st, nil)
+
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		Valid:          true,
+		State:          domain.ActivityExited,
+		Event:          "session-end",
+		AgentSessionID: "nested-native-session",
+		TranscriptPath: "/transcripts/nested.jsonl",
+	}); err != nil {
+		t.Fatalf("foreign hook signal: %v", err)
+	}
+
+	if got := st.sessions[rec.ID]; got != rec {
+		t.Fatalf("foreign hook mutated Chat session:\n got: %+v\nwant: %+v", got, rec)
+	}
+}
+
+func TestActivitySignalCurrentChatControllerResurrectsExitedSession(t *testing.T) {
+	tests := []struct {
+		name  string
+		state domain.ActivityState
+		event string
+	}{
+		{name: "turn started", state: domain.ActivityActive, event: "chat.turn.started"},
+		{name: "turn completed", state: domain.ActivityIdle, event: "chat.turn.completed"},
+		{name: "approval requested", state: domain.ActivityWaitingInput, event: "chat.approval.requested"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := newFakeStore()
+			rec := domain.SessionRecord{
+				ID: "mer-1", ProjectID: "mer", Mode: domain.SessionModeChat,
+				Metadata: domain.SessionMetadata{ControllerGeneration: "chat-generation-1"},
+				Activity: domain.Activity{State: domain.ActivityExited},
+			}
+			st.sessions[rec.ID] = rec
+			m := New(st, nil)
+			signalAt := time.Unix(123, 0).UTC()
+
+			if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+				Valid:                true,
+				State:                test.state,
+				Event:                test.event,
+				Timestamp:            signalAt,
+				ControllerGeneration: "chat-generation-1",
+			}); err != nil {
+				t.Fatalf("current Chat controller signal: %v", err)
+			}
+
+			got := st.sessions[rec.ID]
+			if got.Activity.State != test.state {
+				t.Fatalf("live Chat controller left activity at %q, want %q", got.Activity.State, test.state)
+			}
+			if !got.Activity.LastActivityAt.Equal(signalAt) {
+				t.Fatalf("last activity = %v, want %v", got.Activity.LastActivityAt, signalAt)
+			}
+		})
+	}
+}

--- a/backend/internal/ports/runtime_observations.go
+++ b/backend/internal/ports/runtime_observations.go
@@ -59,9 +59,9 @@ type ActivitySignal struct {
 	// LaunchID is set by AO's process supervisor. Lifecycle rejects a signal
 	// from an older process generation of the same session.
 	LaunchID string
-	// ControllerGeneration is the equivalent fence for a runtime-less Chat
-	// controller. It is intentionally internal (provider events never call the
-	// public hook endpoint): lifecycle rejects it after a mode handoff or Chat
-	// controller replacement.
+	// ControllerGeneration is the required ownership fence for a runtime-less
+	// Chat controller. It is intentionally internal (provider events never call
+	// the public hook endpoint): lifecycle rejects a Chat signal without the
+	// current generation, as well as one received after a handoff or replacement.
 	ControllerGeneration string
 }

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -1773,6 +1773,11 @@ func (c *Controller) Interrupt(ctx context.Context) error {
 	c.sendMu.Lock()
 	cutoff := c.now()
 	c.mu.Lock()
+	if c.state == ports.ChatControllerStopped {
+		c.mu.Unlock()
+		c.sendMu.Unlock()
+		return ErrNoActiveTurn
+	}
 	turn := c.pendingTurnID
 	if turn != "" {
 		// Publish the queue cutoff before releasing sendMu. A completion can then
@@ -1820,10 +1825,18 @@ func (c *Controller) Interrupt(ctx context.Context) error {
 			c.sendMu.Lock()
 			defer c.sendMu.Unlock()
 
+			// The event stream may have ended while the provider's interrupt answer
+			// was in flight. Shutdown owns the terminal transition; a stale refusal
+			// from this generation must not reconcile the dead controller to ready.
+			c.mu.Lock()
+			if c.state == ports.ChatControllerStopped {
+				c.mu.Unlock()
+				return ErrNoActiveTurn
+			}
+
 			// A committed completion may have won the sendMu race after the
 			// provider answered. It already consumed the cutoff and drained the
 			// queue, so do not overwrite its terminal state or a successor turn.
-			c.mu.Lock()
 			stillPending := c.pendingTurnID == turn
 			c.mu.Unlock()
 			if !stillPending {
@@ -2112,7 +2125,9 @@ func (c *Controller) project() {
 		// A lifecycle event and a concurrent Send must agree on whether the root
 		// conversation is busy. Holding the same lock Send/dispatch use closes the
 		// window between the durable projection and the in-memory ownership update.
-		lifecycle := event.Kind == ports.ChatEventTurnStarted || event.Kind == ports.ChatEventTurnCompleted
+		lifecycle := event.Kind == ports.ChatEventTurnStarted ||
+			event.Kind == ports.ChatEventTurnCompleted ||
+			(event.Kind == ports.ChatEventControllerState && event.ControllerState == ports.ChatControllerStopped)
 		if lifecycle {
 			c.sendMu.Lock()
 		}
@@ -2131,6 +2146,12 @@ func (c *Controller) project() {
 		}
 	}
 
+	// Ending the stream is the terminal command for this controller generation.
+	// Serialize it with Send, Interrupt, and lifecycle projection so every command
+	// that won the lock first finishes before exited, while every command that
+	// arrives later observes stopped and cannot resurrect the controller.
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
 	c.mu.Lock()
 	c.state = ports.ChatControllerStopped
 	suppressStoppedActivity := c.suppressStoppedActivity

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -4216,6 +4216,65 @@ func TestProviderRefusalReconcilesTheDurableTurnAsInterrupted(t *testing.T) {
 	}
 }
 
+// A provider stream can end while Interrupt is waiting for the provider to
+// answer. Once shutdown has reported exited, the stale refusal must not reconcile
+// the same controller generation back to ready/idle. In production the service
+// drops this controller after Wait, but an Interrupt that already obtained the
+// pointer is still allowed to finish concurrently.
+func TestStreamClosureWinsAgainstConcurrentInterruptReconciliation(t *testing.T) {
+	conv := newBlockingInterruptRefusalConversation()
+	t.Cleanup(conv.unblock)
+	h := newHarnessWithConversation(t, conv)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "running", ClientMessageID: "shutdown-race",
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateRunning
+	})
+
+	interruptDone := make(chan error, 1)
+	go func() { interruptDone <- h.svc.Interrupt(ctx, testSession) }()
+	select {
+	case <-conv.started:
+	case <-time.After(4 * time.Second):
+		t.Fatal("provider interrupt did not start")
+	}
+
+	// The provider dies while its interrupt response is in flight. Waiting for the
+	// projector proves exited has already been emitted before the stale refusal is
+	// allowed to continue.
+	if err := conv.Close(); err != nil {
+		t.Fatalf("Close provider stream: %v", err)
+	}
+	h.ctrl.Wait()
+	conv.unblock()
+	if err := <-interruptDone; err != nil && !errors.Is(err, chatsvc.ErrNoActiveTurn) {
+		t.Fatalf("Interrupt after shutdown: %v", err)
+	}
+
+	if got := h.ctrl.State(); got != ports.ChatControllerStopped {
+		t.Errorf("controller state after shutdown race = %q, want stopped", got)
+	}
+	signals := h.activity.snapshot()
+	exited := -1
+	for i, signal := range signals {
+		if signal.State == domain.ActivityExited && signal.Event == "chat.controller.stopped" {
+			exited = i
+		}
+	}
+	if exited < 0 {
+		t.Fatalf("shutdown emitted no exited signal: %+v", signals)
+	}
+	if exited != len(signals)-1 {
+		t.Fatalf("activity emitted after exited: %+v", signals[exited+1:])
+	}
+}
+
 // The recovery path must keep the same cutoff as the Stop request. The composer
 // remains available while provider cancellation is pending, and a later prompt
 // is new user intent rather than part of the queue that Stop was asked to clear.


### PR DESCRIPTION
Fixes #4125

## Summary
- require every Chat lifecycle signal to carry the current internal controller generation, so inherited provider hooks cannot rewrite the parent session identity or activity
- treat non-exited activity from that current controller as liveness evidence, allowing a live Chat session to recover from a stale `exited`
- add regressions for foreign `session-end` metadata/state corruption and active, idle, and waiting-input resurrection

## Root cause
The reducer only validated `ControllerGeneration` when the incoming signal supplied one. Public provider hooks never supply it, and Chat sessions have no runtime launch ID, so those signals bypassed both ownership checks. The SQLite write fence could not compensate because it compared against the generation copied from the already-read session row.

## Tests
- `go test ./internal/lifecycle -run 'TestActivitySignal(RejectsHookWithoutChatControllerGeneration|CurrentChatControllerResurrectsExitedSession)$' -count=10`
- `go test ./internal/lifecycle ./internal/service/chat ./internal/httpd/controllers ./internal/integration`
- `env -u AO_ISSUE_ID -u AO_PROJECT_ID -u AO_SESSION_ID -u AO_OWNER go test -p 1 ./...`
- `go test -race -count=1 ./internal/lifecycle ./internal/service/chat`
- `golangci-lint v2.12.2` with an isolated cache: 0 issues

## Risk
TUI hook semantics are unchanged. Chat controller generations are already claimed before event consumption and included on every internal activity report; no API or schema change is required.