### PR TITLE
fix(cli): keep daemon-down out of hook stderr

### DIFF
--- a/backend/internal/cli/client.go
+++ b/backend/internal/cli/client.go
@@ -20,6 +20,12 @@ import (
 // status probe timeout.
 const commandTimeout = 2 * time.Minute
 
+// ErrDaemonNotRunning marks the "no daemon to talk to" condition — either no
+// run-file at all, or one whose PID is dead. Callers that must not treat a
+// daemon restart as a failure (hooks, which fire during the desktop app's
+// daemon takeover) test for it with errors.Is.
+var ErrDaemonNotRunning = errors.New("AO daemon is not running")
+
 // maxDrainedBodyBytes bounds how much of an unused response body the CLI
 // discards for keep-alive reuse without an unbounded read.
 const maxDrainedBodyBytes = 4 << 10
@@ -128,10 +134,10 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 		return err
 	}
 	if info == nil {
-		return fmt.Errorf("AO daemon is not running — start it with `ao start`")
+		return fmt.Errorf("%w — start it with `ao start`", ErrDaemonNotRunning)
 	}
 	if !c.deps.ProcessAlive(info.PID) {
-		return fmt.Errorf("AO daemon is not running (stale run-file at %s) — start it with `ao start`", cfg.RunFilePath)
+		return fmt.Errorf("%w (stale run-file at %s) — start it with `ao start`", ErrDaemonNotRunning, cfg.RunFilePath)
 	}
 
 	var reader io.Reader = http.NoBody

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -571,7 +572,13 @@ func (c *commandContext) emitSessionStartContext(agent, event, sessionID string)
 // $AO_DATA_DIR/hooks.log so the failure can be diagnosed after the fact.
 func (c *commandContext) reportHookFailure(agent, event, sessionID string, cause error) {
 	msg := fmt.Sprintf("ao hooks %s %s: %v", agent, event, cause)
-	_, _ = fmt.Fprintln(c.deps.Err, msg)
+	// A daemon that is not running is expected, not a failure: it flaps on every
+	// desktop takeover, and reconciliation recovers the missed activity from
+	// process state. Keep it out of stderr so the notice does not land in the
+	// agent's own context as a spurious error, but still record it below.
+	if !errors.Is(cause, ErrDaemonNotRunning) {
+		_, _ = fmt.Fprintln(c.deps.Err, msg)
+	}
 	dataDir := strings.TrimSpace(os.Getenv("AO_DATA_DIR"))
 	if dataDir == "" {
 		return

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/pricing"
+	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 )
 
 type activityCapture struct {
@@ -1428,6 +1429,63 @@ func TestHooks_CursorTerminalFailureReportsCorrelatedCompletion(t *testing.T) {
 			}
 			if req.State != "active" || req.Event != tt.wantEvent || req.ToolName != tt.wantTool {
 				t.Fatalf("terminal-failure activity = %+v, want state=active event=%q toolName=%q", req, tt.wantEvent, tt.wantTool)
+			}
+		})
+	}
+}
+
+// A daemon that is simply not running is not a hook failure: the daemon flaps
+// on every desktop takeover, and reconciliation recovers the missed activity
+// from process state. Surfacing it on stderr injects a spurious "AO daemon is
+// not running" error into the agent's own context, so the notice belongs in
+// hooks.log only.
+func TestHooks_DaemonNotRunningStaysOutOfStderr(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, cfg testConfig)
+		alive func(int) bool
+	}{
+		{
+			name: "stale run-file",
+			setup: func(t *testing.T, cfg testConfig) {
+				if err := runfile.Write(cfg.runFile, runfile.Info{
+					PID: 999999, Port: 3001, StartedAt: time.Unix(100, 0).UTC(),
+				}); err != nil {
+					t.Fatalf("write run-file: %v", err)
+				}
+			},
+			alive: func(int) bool { return false },
+		},
+		{
+			name:  "no run-file",
+			setup: func(t *testing.T, cfg testConfig) {},
+			alive: func(int) bool { return true },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AO_SESSION_ID", "ao-7")
+			cfg := setConfigEnv(t)
+			tc.setup(t, cfg)
+
+			_, errOut, err := executeCLI(t, Deps{
+				In:           strings.NewReader(`{"reason":"logout"}`),
+				ProcessAlive: tc.alive,
+			}, "hooks", "claude-code", "session-end")
+			if err != nil {
+				t.Fatalf("hooks must exit 0 when the daemon is down, got: %v", err)
+			}
+			if errOut != "" {
+				t.Errorf("daemon-down must not reach the agent's stderr, got %q", errOut)
+			}
+
+			logged, err := os.ReadFile(filepath.Join(cfg.dataDir, hooksLogName))
+			if err != nil {
+				t.Fatalf("daemon-down must still be recorded in hooks.log: %v", err)
+			}
+			if !strings.Contains(string(logged), "daemon is not running") {
+				t.Errorf("hooks.log missing the daemon-down notice, got %q", logged)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #4210.

Hooks run inside the agent's own process, so anything they write to stderr lands in the agent's context. During the desktop app's daemon takeover the run-file briefly points at a dead PID, and every hook firing in that window printed `AO daemon is not running (stale run-file at ...)` at the agent — even though the hook exits 0 and reconciliation recovers the missed activity from process state.

## Change

`doJSONPathWithHeadersAndTimeout` returned an untyped `fmt.Errorf` for both daemon-down branches, so `reportHookFailure` could not tell a restart apart from a real delivery failure.

- Add `ErrDaemonNotRunning` and wrap it with `%w` in both branches (`info == nil`, dead PID). Message text is unchanged, so interactive commands read exactly as before.
- In `reportHookFailure`, skip the stderr write when `errors.Is(cause, ErrDaemonNotRunning)`. The notice still goes to `hooks.log`, so the event stays diagnosable.

Genuine daemon errors (HTTP 5xx, transport failures) keep reaching stderr — covered by the existing `TestHooks_DaemonErrorIsSwallowed`, which is untouched and still asserts stderr is written.

## Tests

`TestHooks_DaemonNotRunningStaysOutOfStderr` is table-driven over both branches and needs no live daemon — `ProcessAlive` is injectable via `Deps`. It asserts exit 0, empty stderr, and a recorded `hooks.log` line.

Verified red before the fix (both sub-cases), green after. Mutation-checked: removing the `errors.Is` guard fails the test.

`go test ./internal/cli/` passes; `gofmt -l .` and `go vet ./...` are clean across the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6faenFPv6YaGeihrDeLK5
