### PR TITLE
fix(chat): classify transient Codex transport failures

### DIFF
--- a/backend/internal/adapters/chatdriver/codexappserver/normalize.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/normalize.go
@@ -155,6 +155,17 @@ func normalizeNotification(n notification, now time.Time) []ports.ChatEvent {
 		}
 		if p.Turn.Error != nil && p.Turn.Error.Message != "" {
 			ev.Err = fmt.Errorf("%s", p.Turn.Error.Message)
+			if isTransientTransportFailure(p.Turn.Error.Message) {
+				connectionLost := true
+				connectionEvent := ports.ChatEvent{
+					Kind: ports.ChatEventThreadState,
+					ThreadState: &ports.ChatThreadState{
+						Status:         domain.ThreadStatusIdle,
+						ConnectionLost: &connectionLost,
+					},
+				}
+				return []ports.ChatEvent{ev, connectionEvent}
+			}
 		}
 		return []ports.ChatEvent{ev}
 
@@ -959,6 +970,23 @@ func threadStatusFrom(status codexproto.ThreadStatusType) domain.ThreadStatus {
 	default:
 		return ""
 	}
+}
+
+// isTransientTransportFailure identifies failures that end one response stream
+// without invalidating its thread. Codex precedes these with a systemError thread
+// report, then accepts another turn normally once the network returns. Keep the
+// match deliberately narrow: an unclassified provider error retains systemError
+// rather than being optimistically called recoverable.
+func isTransientTransportFailure(message string) bool {
+	lower := strings.ToLower(message)
+	if !strings.Contains(lower, "stream disconnected before completion") {
+		return false
+	}
+	return strings.Contains(lower, "failed to lookup address information") ||
+		strings.Contains(lower, "error sending request for url") ||
+		strings.Contains(lower, "connection reset") ||
+		strings.Contains(lower, "connection closed") ||
+		strings.Contains(lower, "timed out")
 }
 
 // waitingOnFrom maps the provider's active flags onto AO's spelling.

--- a/backend/internal/adapters/chatdriver/codexappserver/normalize_ingest_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/normalize_ingest_test.go
@@ -554,6 +554,12 @@ func TestNormalizeThreadStatusChanged(t *testing.T) {
 		t.Fatalf("status = %q", idle.ThreadState.Status)
 	}
 
+	systemError := normalizeOne(t, codexproto.MethodThreadStatusChanged,
+		`{"threadId":"019fc432","status":{"type":"systemError"}}`)
+	if systemError.ThreadState.Status != domain.ThreadStatusSystemError {
+		t.Fatalf("status = %q", systemError.ThreadState.Status)
+	}
+
 	// A thread can be working AND blocked on a person; those are different states.
 	blocked := normalizeOne(t, codexproto.MethodThreadStatusChanged,
 		`{"threadId":"th","status":{"type":"active","activeFlags":["waitingOnApproval"]}}`)

--- a/backend/internal/adapters/chatdriver/codexappserver/normalize_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/normalize_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/codexappserver/codexproto"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -46,6 +47,57 @@ func TestNormalizeTurnLifecycle(t *testing.T) {
 	if done.Kind != ports.ChatEventTurnCompleted || done.TurnState != domain.TurnStateCompleted ||
 		done.ProviderConversationID != "th1" {
 		t.Fatalf("turn/completed -> %+v", done)
+	}
+}
+
+// Captured from a real turn after clamshell sleep dropped Wi-Fi. Codex reports a
+// systemError immediately before this completion, but the same thread accepts the
+// next turn once connectivity returns.
+func TestNormalizeTransientTransportFailureKeepsThreadReusable(t *testing.T) {
+	events := normalizeNotification(notification{Method: codexproto.MethodTurnCompleted, Params: json.RawMessage(
+		`{"threadId":"th1","turn":{"id":"tu1","status":"failed","items":[],"error":{"message":"stream disconnected before completion: error sending request for url (https://chatgpt.com/backend-api/codex/responses)","codexErrorInfo":"other"}}}`,
+	)}, testNow)
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want failed turn and recoverable thread state", len(events))
+	}
+	if events[0].Kind != ports.ChatEventTurnCompleted || events[0].TurnState != domain.TurnStateFailed || events[0].Err == nil {
+		t.Fatalf("turn event = %+v", events[0])
+	}
+	state := events[1].ThreadState
+	if events[1].Kind != ports.ChatEventThreadState || state == nil ||
+		state.Status != domain.ThreadStatusIdle || state.ConnectionLost == nil || !*state.ConnectionLost {
+		t.Fatalf("thread event = %+v", events[1])
+	}
+}
+
+func TestNormalizeUnclassifiedFailureDoesNotRepairSystemError(t *testing.T) {
+	events := normalizeNotification(notification{Method: codexproto.MethodTurnCompleted, Params: json.RawMessage(
+		`{"threadId":"th1","turn":{"id":"tu1","status":"failed","items":[],"error":{"message":"provider database corrupted"}}}`,
+	)}, testNow)
+	if len(events) != 1 || events[0].Kind != ports.ChatEventTurnCompleted {
+		t.Fatalf("events = %+v, want only failed turn", events)
+	}
+}
+
+func TestTransientTransportFailureSignatures(t *testing.T) {
+	for _, message := range []string{
+		"stream disconnected before completion: failed to lookup address information: nodename nor servname provided",
+		"stream disconnected before completion: error sending request for url (https://chatgpt.com/backend-api/codex/responses)",
+		"stream disconnected before completion: connection reset by peer",
+		"stream disconnected before completion: operation timed out",
+	} {
+		if !isTransientTransportFailure(message) {
+			t.Errorf("did not classify %q", message)
+		}
+	}
+	for _, message := range []string{
+		"provider database corrupted",
+		"stream disconnected before completion: You have no credits remaining",
+		"error sending request for url (https://chatgpt.com/backend-api/codex/responses)",
+	} {
+		if isTransientTransportFailure(message) {
+			t.Errorf("misclassified %q", message)
+		}
 	}
 }
 

--- a/backend/internal/domain/conversation.go
+++ b/backend/internal/domain/conversation.go
@@ -348,8 +348,8 @@ const (
 	ThreadStatusClosed      ThreadStatus = "closed"
 )
 
-// ConversationThreadState is what the provider says about the thread itself, as
-// opposed to about a turn.
+// ConversationThreadState is what the provider says about the thread itself, plus
+// AO's interpretation when a provider status is explained by a turn-level failure.
 type ConversationThreadState struct {
 	Status ThreadStatus `json:"status,omitempty"`
 	// WaitingOn are the provider's active flags, e.g. "waiting_on_approval". A
@@ -362,8 +362,12 @@ type ConversationThreadState struct {
 	// ClosedAt is when the provider dropped the thread. Recorded rather than acted
 	// on: AO has never observed this notification, so tearing a controller down on
 	// the strength of it would be guessing.
-	ClosedAt  *time.Time `json:"closedAt,omitempty"`
-	UpdatedAt time.Time  `json:"updatedAt"`
+	ClosedAt *time.Time `json:"closedAt,omitempty"`
+	// ConnectionLostAt is the recoverable failure of the most recent attempted
+	// turn. Unlike system_error it says nothing is wrong with the thread itself;
+	// the next turn may proceed and clears this notice when it starts.
+	ConnectionLostAt *time.Time `json:"connectionLostAt,omitempty"`
+	UpdatedAt        time.Time  `json:"updatedAt"`
 }
 
 // ConversationMCPServer is one tool server's startup state.

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6225,6 +6225,10 @@ components:
           type:
           - "null"
           - string
+        connectionLostAt:
+          type:
+          - "null"
+          - string
         status:
           enum:
           - active

--- a/backend/internal/httpd/controllers/conversation_provider_state_test.go
+++ b/backend/internal/httpd/controllers/conversation_provider_state_test.go
@@ -160,14 +160,16 @@ func TestSnapshotExposesAccountAndReauthDemand(t *testing.T) {
 // be read from one snapshot, which is why they must not be conflated.
 func TestSnapshotExposesThreadState(t *testing.T) {
 	archived := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	connectionLost := time.Date(2026, 8, 2, 12, 1, 0, 0, time.UTC)
 	body := conversationSnapshotBody(t, chatsvc.Snapshot{
 		SessionID: domain.SessionID("p1-1"),
 		Mode:      domain.SessionModeChat,
 		Conversation: domain.ConversationRecord{
 			ThreadState: &domain.ConversationThreadState{
-				Status:     domain.ThreadStatusActive,
-				WaitingOn:  []string{"waiting_on_approval"},
-				ArchivedAt: &archived,
+				Status:           domain.ThreadStatusActive,
+				WaitingOn:        []string{"waiting_on_approval"},
+				ArchivedAt:       &archived,
+				ConnectionLostAt: &connectionLost,
 			},
 		},
 	})
@@ -185,6 +187,9 @@ func TestSnapshotExposesThreadState(t *testing.T) {
 	}
 	if state["archivedAt"] != "2026-08-02T12:00:00Z" {
 		t.Errorf("archivedAt = %#v", state["archivedAt"])
+	}
+	if state["connectionLostAt"] != "2026-08-02T12:01:00Z" {
+		t.Errorf("connectionLostAt = %#v", state["connectionLostAt"])
 	}
 	if _, present := state["closedAt"]; present {
 		t.Error("a thread that was never closed reported a closedAt")

--- a/backend/internal/httpd/controllers/conversations.go
+++ b/backend/internal/httpd/controllers/conversations.go
@@ -1002,10 +1002,11 @@ func threadStatePayload(state *domain.ConversationThreadState) *ConversationThre
 		return nil
 	}
 	return &ConversationThreadStatePayload{
-		Status:     string(state.Status),
-		WaitingOn:  state.WaitingOn,
-		ArchivedAt: optionalTimestamp(state.ArchivedAt),
-		ClosedAt:   optionalTimestamp(state.ClosedAt),
+		Status:           string(state.Status),
+		WaitingOn:        state.WaitingOn,
+		ArchivedAt:       optionalTimestamp(state.ArchivedAt),
+		ClosedAt:         optionalTimestamp(state.ClosedAt),
+		ConnectionLostAt: optionalTimestamp(state.ConnectionLostAt),
 	}
 }
 

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1703,6 +1703,9 @@ type ConversationThreadStatePayload struct {
 	// on: the daemon has never observed this, so tearing a controller down on the
 	// strength of it would be a guess.
 	ClosedAt *string `json:"closedAt,omitempty"`
+	// ConnectionLostAt marks a recoverable transport failure in the most recent
+	// turn. The thread remains healthy and the next turn clears the notice.
+	ConnectionLostAt *string `json:"connectionLostAt,omitempty"`
 }
 
 // ConversationMCPServerPayload is one tool server's startup state.

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -441,6 +441,10 @@ type ChatThreadState struct {
 	Archived *bool
 	// Closed is set only by a report that the thread was closed.
 	Closed bool
+	// ConnectionLost is tri-state. True means the last turn failed because the
+	// provider lost its network connection but the thread remains reusable. False
+	// clears an earlier report; nil says nothing about it.
+	ConnectionLost *bool
 }
 
 // ChatMCPServer is one tool server's startup state.

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -2363,6 +2363,9 @@ func (c *Controller) applyThreadState(
 		// that is no longer waiting on an approval reports active with no flags, and
 		// keeping the old list would leave it looking blocked forever.
 		c.threadState.WaitingOn = update.WaitingOn
+		if update.Status == domain.ThreadStatusActive {
+			c.threadState.ConnectionLostAt = nil
+		}
 	}
 	if update.Archived != nil {
 		if *update.Archived {
@@ -2375,6 +2378,14 @@ func (c *Controller) applyThreadState(
 	if update.Closed && c.threadState.ClosedAt == nil {
 		at := now
 		c.threadState.ClosedAt = &at
+	}
+	if update.ConnectionLost != nil {
+		if *update.ConnectionLost {
+			at := now
+			c.threadState.ConnectionLostAt = &at
+		} else {
+			c.threadState.ConnectionLostAt = nil
+		}
 	}
 	c.threadState.UpdatedAt = now
 	state := c.threadState

--- a/backend/internal/service/chat/provider_state_test.go
+++ b/backend/internal/service/chat/provider_state_test.go
@@ -373,6 +373,35 @@ func TestThreadStateReportsAreTriState(t *testing.T) {
 	}
 }
 
+func TestRecoverableConnectionLossLeavesThreadHealthyUntilNextTurn(t *testing.T) {
+	h := newHarness(t)
+
+	h.conv.emit(ports.ChatEvent{Kind: ports.ChatEventThreadState,
+		ThreadState: &ports.ChatThreadState{Status: domain.ThreadStatusSystemError}})
+	connectionLost := true
+	h.conv.emit(ports.ChatEvent{Kind: ports.ChatEventThreadState,
+		ThreadState: &ports.ChatThreadState{
+			Status: domain.ThreadStatusIdle, ConnectionLost: &connectionLost,
+		}})
+
+	lost := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return s.Conversation.ThreadState != nil && s.Conversation.ThreadState.ConnectionLostAt != nil
+	})
+	if lost.Conversation.ThreadState.Status != domain.ThreadStatusIdle {
+		t.Fatalf("status = %q, want healthy idle", lost.Conversation.ThreadState.Status)
+	}
+
+	h.conv.emit(ports.ChatEvent{Kind: ports.ChatEventThreadState,
+		ThreadState: &ports.ChatThreadState{Status: domain.ThreadStatusActive}})
+	recovered := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return s.Conversation.ThreadState.Status == domain.ThreadStatusActive &&
+			s.Conversation.ThreadState.ConnectionLostAt == nil
+	})
+	if recovered.Conversation.ThreadState.ConnectionLostAt != nil {
+		t.Fatal("the next active turn did not clear the connection-loss notice")
+	}
+}
+
 // A closed thread is recorded, not acted on. Tearing a controller down on a
 // notification no probe has ever seen would turn a provider quirk into a lost
 // session.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2106,6 +2106,7 @@ export interface components {
         ConversationThreadStatePayload: {
             archivedAt?: null | string;
             closedAt?: null | string;
+            connectionLostAt?: null | string;
             /** @enum {string} */
             status?: "active" | "idle" | "not_loaded" | "system_error" | "closed";
             waitingOn?: string[];

--- a/frontend/src/renderer/components/chat/ChatStatusBanners.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatStatusBanners.test.tsx
@@ -54,6 +54,18 @@ describe("ReauthBanner", () => {
 });
 
 describe("ThreadStateBanner", () => {
+	it("reports transient connection loss without condemning the thread", () => {
+		render(
+			<ThreadStateBanner
+				threadState={{ status: "idle", connectionLostAt: "2026-08-20T22:24:33Z" }}
+			/>,
+		);
+		expect(screen.getByText(/connection lost during this turn/i)).toBeInTheDocument();
+		expect(screen.getByText(/thread is still healthy/i)).toBeInTheDocument();
+		expect(screen.getByText(/send your message again to retry/i)).toBeInTheDocument();
+		expect(screen.queryByText(/new turns will usually fail/i)).not.toBeInTheDocument();
+	});
+
 	it("reports a provider-side fault as the provider's, not AO's connection", () => {
 		render(<ThreadStateBanner threadState={{ status: "system_error" }} />);
 		expect(screen.getByText(/thread hit an internal error/i)).toBeInTheDocument();

--- a/frontend/src/renderer/components/chat/ChatStatusBanners.tsx
+++ b/frontend/src/renderer/components/chat/ChatStatusBanners.tsx
@@ -101,9 +101,8 @@ function signInCommand(harness: string): string | undefined {
  * healthy controller can be attached to a thread the provider has already given up
  * on, and that combination is precisely the one a user cannot diagnose unaided.
  *
- * Only `system_error` and `closed` are drawn. `active`, `idle` and `not_loaded` are
- * the ordinary run of a session and a banner for each would be noise that teaches
- * readers to ignore this row.
+ * `system_error`, `closed`, and recoverable connection loss are drawn. Ordinary
+ * `active`, `idle` and `not_loaded` states remain silent.
  */
 export const ThreadStateBanner = memo(function ThreadStateBanner({
 	threadState,
@@ -111,10 +110,15 @@ export const ThreadStateBanner = memo(function ThreadStateBanner({
 	threadState: ConversationThreadState;
 }) {
 	const status = threadState.status;
-	if (status !== "system_error" && status !== "closed") return null;
+	if (!threadState.connectionLostAt && status !== "system_error" && status !== "closed") return null;
 
 	const copy =
-		status === "system_error"
+		threadState.connectionLostAt
+			? {
+					title: "Connection lost during this turn",
+					body: "The turn failed after Codex lost its network connection. The thread is still healthy — send your message again to retry.",
+				}
+			: status === "system_error"
 			? {
 					title: "The agent's thread hit an internal error",
 					body: "The provider reported a fault in this thread, not in AO's connection to it. New turns will usually fail; the conversation and the worktree are kept.",

--- a/frontend/src/renderer/hooks/useConversation.test.tsx
+++ b/frontend/src/renderer/hooks/useConversation.test.tsx
@@ -154,6 +154,7 @@ describe("useConversation snapshot mapping", () => {
 			waitingOn: ["user_input"],
 			archivedAt: undefined,
 			closedAt: undefined,
+			connectionLostAt: undefined,
 		});
 		expect(snapshot.mcpServers).toHaveLength(2);
 		expect(snapshot.turns[0]!.plan?.steps).toEqual([

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -737,6 +737,7 @@ function toSnapshot(wire: WireSnapshot): ConversationSnapshot {
 					waitingOn: wire.threadState.waitingOn?.length ? wire.threadState.waitingOn : undefined,
 					archivedAt: wire.threadState.archivedAt ?? undefined,
 					closedAt: wire.threadState.closedAt ?? undefined,
+					connectionLostAt: wire.threadState.connectionLostAt ?? undefined,
 				}
 			: undefined,
 		mcpServers: wire.mcpServers?.length

--- a/frontend/src/renderer/types/conversation.ts
+++ b/frontend/src/renderer/types/conversation.ts
@@ -639,6 +639,8 @@ export interface ConversationThreadState {
 	waitingOn?: string[];
 	archivedAt?: string;
 	closedAt?: string;
+	/** The last turn lost its network connection; the thread itself remains reusable. */
+	connectionLostAt?: string;
 }
 
 /** One tool server's startup state. */


### PR DESCRIPTION
Fixes [#4212](https://github.com/Untrivial-ai/agent-orchestrator/issues/4212).

## Summary

- classify narrow Codex response-stream transport signatures after the provider reports `systemError`
- preserve the failed turn and exact provider error while restoring the reusable thread to healthy `idle`
- retain a recoverable connection-loss notice until the next turn becomes active
- render accurate recovery guidance instead of predicting that future turns will fail
- leave genuine/unclassified provider `systemError` behavior unchanged
- regenerate OpenAPI and renderer API types for the optional connection-loss timestamp

## Evidence

In session `agent-orchestrator-140`, Codex emitted `thread/status/changed = systemError` immediately before a failed `turn/completed` with `stream disconnected before completion: error sending request for url (...)`. The same provider conversation accepted the next turn, became active, completed normally, and returned to idle. The durable AO event order confirms the status came from Codex; AO's fault was retaining and presenting it without the transport context reported milliseconds later.

## Tests

- `cd backend && go build ./...`
- `env -u AO_SESSION_ID -u AO_PROJECT_ID -u AO_DAEMON_URL -u AO_RUN_FILE -u AO_DATA_DIR -u AO_PORT npm run lint`
- `env -u AO_SESSION_ID -u AO_PROJECT_ID -u AO_DAEMON_URL -u AO_RUN_FILE -u AO_DATA_DIR -u AO_PORT sh -c 'cd backend && go test -race ./...'`
- `npm run api`
- `npm run frontend:typecheck`
- `cd frontend && npm test` — 2,630 passed, 1 skipped

## Risk / follow-up

Classification is intentionally limited to response-stream failures with known DNS/send/reset/closed/timeout transport signatures. Unknown errors continue to display the provider's genuine `systemError` state.

A one-click retry action is intentionally separate because it needs a daemon-owned, idempotent history/dispatch operation: [#4215](https://github.com/Untrivial-ai/agent-orchestrator/issues/4215).
