### PR TITLE
fix: hide chat history markers when inspector is open

### DIFF
--- a/frontend/e2e/chat-scroll-overflow.spec.ts
+++ b/frontend/e2e/chat-scroll-overflow.spec.ts
@@ -87,6 +87,9 @@ test("chat minimap does not make the session pane scroll horizontally", async ({
 	await page.goto(`/#/projects/fake-proj/sessions/${sessionId}`);
 	await expect(page.getByRole("log", { name: "Conversation" })).toBeVisible();
 
+	// Minimap markers only render when the inspector rail is closed.
+	await page.getByRole("button", { name: "Close inspector panel" }).click();
+
 	const marker = page.locator("[data-chat-scroll-marker]").first();
 	await expect(marker).toBeVisible();
 	await marker.hover();

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -107,7 +107,7 @@ beforeEach(() => {
 	terminalPaneState.props = undefined;
 	window.localStorage.clear();
 	setApiBaseUrl("http://127.0.0.1:3001");
-	useUiStore.setState({ isSidebarOpen: true });
+	useUiStore.setState({ isSidebarOpen: true, inspectorSessions: {} });
 });
 
 afterEach(() => setApiBaseUrl(null));
@@ -392,6 +392,9 @@ describe("ChatWorkspace timeline", () => {
 	});
 
 	it("provides an interactive conversation minimap", () => {
+		useUiStore.setState({
+			inspectorSessions: { "ao-long": { isOpen: false, view: "summary" } },
+		});
 		render(<ChatWorkspace snapshot={chatFixtureLongHistory(8)} />);
 		const log = screen.getByRole("log");
 		const scrollbar = screen.getByRole("scrollbar", { name: "Conversation scrollbar" });
@@ -417,7 +420,24 @@ describe("ChatWorkspace timeline", () => {
 		expect(scrollbar).toHaveAttribute("aria-valuenow", "100");
 	});
 
+	it("hides conversation minimap markers while the inspector is open", () => {
+		useUiStore.setState({
+			inspectorSessions: { "ao-long": { isOpen: true, view: "summary" } },
+		});
+		render(<ChatWorkspace snapshot={chatFixtureLongHistory(8)} />);
+		const log = screen.getByRole("log");
+		const scrollbar = screen.getByRole("scrollbar", { name: "Conversation scrollbar" });
+		stubGeometry(log, { scrollHeight: 4000, clientHeight: 800, scrollTop: 1000 });
+		stubGeometry(scrollbar, { scrollHeight: 800, clientHeight: 800, scrollTop: 0 });
+		fireEvent.scroll(log);
+
+		expect(scrollbar.querySelectorAll("[data-chat-scroll-marker]")).toHaveLength(0);
+	});
+
 	it("previews the request and response for a hovered conversation marker", () => {
+		useUiStore.setState({
+			inspectorSessions: { "ao-long": { isOpen: false, view: "summary" } },
+		});
 		render(<ChatWorkspace snapshot={chatFixtureLongHistory(4)} />);
 		const log = screen.getByRole("log");
 		const scrollbar = screen.getByRole("scrollbar", { name: "Conversation scrollbar" });
@@ -456,6 +476,9 @@ describe("ChatWorkspace timeline", () => {
 			status: "completed",
 			summary: "Automatic compaction completed",
 			createdAt: "2026-08-08T00:00:00Z",
+		});
+		useUiStore.setState({
+			inspectorSessions: { [snapshot.sessionId]: { isOpen: false, view: "summary" } },
 		});
 		render(<ChatWorkspace snapshot={snapshot} />);
 		const log = screen.getByRole("log");

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1217,6 +1217,9 @@ function Timeline({
 	const [pinned, setPinned] = useState(true);
 	const [hoveredMarker, setHoveredMarker] = useState<number | null>(null);
 	const [messageEdit, setMessageEdit] = useState<MessageEditDraft>();
+	const isInspectorOpen = useUiStore(
+		(state) => state.inspectorSessions[snapshot.sessionId]?.isOpen ?? true,
+	);
 	const turn = activeTurn(snapshot);
 	const [scrollbar, setScrollbar] = useState({
 		visible: false,
@@ -1570,33 +1573,39 @@ function Timeline({
 				)}
 			>
 				<div className="absolute inset-0 cursor-grab group-active/scroll:cursor-grabbing">
-					{scrollbar.markers.map((marker, index) => {
-						const distance = hoveredMarker === null ? Number.POSITIVE_INFINITY : Math.abs(index - hoveredMarker);
-						return (
-							<span
-								key={index}
-								data-chat-scroll-marker=""
-								data-scroll-target={marker.scrollTop}
-								onPointerEnter={() => setHoveredMarker(index)}
-								className="chat-scroll-marker-hit"
-								style={{ top: marker.top }}
-							>
-								<span
-									aria-hidden="true"
-									className={cn(
-										"chat-scroll-marker",
-										marker.visible && "chat-scroll-marker-visible",
-										distance === 0 && "chat-scroll-marker-active",
-										distance === 1 && "chat-scroll-marker-adjacent",
-										distance === 2 && "chat-scroll-marker-near",
-									)}
-								/>
-							</span>
-						);
-					})}
+					{!isInspectorOpen
+						? scrollbar.markers.map((marker, index) => {
+								const distance =
+									hoveredMarker === null ? Number.POSITIVE_INFINITY : Math.abs(index - hoveredMarker);
+								return (
+									<span
+										key={index}
+										data-chat-scroll-marker=""
+										data-scroll-target={marker.scrollTop}
+										onPointerEnter={() => setHoveredMarker(index)}
+										className="chat-scroll-marker-hit"
+										style={{ top: marker.top }}
+									>
+										<span
+											aria-hidden="true"
+											className={cn(
+												"chat-scroll-marker",
+												marker.visible && "chat-scroll-marker-visible",
+												distance === 0 && "chat-scroll-marker-active",
+												distance === 1 && "chat-scroll-marker-adjacent",
+												distance === 2 && "chat-scroll-marker-near",
+											)}
+										/>
+									</span>
+								);
+							})
+						: null}
 				</div>
 
-				{hoveredMarker !== null && scrollbar.markers[hoveredMarker] && previews[hoveredMarker] ? (
+				{!isInspectorOpen &&
+				hoveredMarker !== null &&
+				scrollbar.markers[hoveredMarker] &&
+				previews[hoveredMarker] ? (
 					<div
 						role="tooltip"
 						className="chat-scroll-preview pointer-events-none absolute right-full z-20 mr-3 w-80 rounded-xl border border-border-strong bg-raised px-3.5 py-3 shadow-lg"


### PR DESCRIPTION
## Summary
- Hide conversation minimap markers (chat history dashes) when the session inspector is open
- Show them again when the inspector is closed
- No changes to the inspector panel or navbar toggle — chat timeline only

## Test plan
- [ ] Open a chat session with enough history to show minimap markers
- [ ] With the inspector open, confirm markers are gone
- [ ] Close the inspector and confirm markers reappear
- [ ] Hover a marker with inspector closed and confirm the preview still works
- [ ] `npx vitest run src/renderer/components/chat/ChatWorkspace.test.tsx -t "minimap|marker|inspector is open"`