### PR TITLE
fix: default new sessions to chat UI

### DIFF
--- a/backend/internal/domain/sessionmode.go
+++ b/backend/internal/domain/sessionmode.go
@@ -22,8 +22,9 @@ const (
 	SessionModeChat SessionMode = "chat"
 )
 
-// DefaultSessionMode is what a session gets when no mode was requested. It stays
-// TUI so an upgrade never changes how existing workflows behave.
+// DefaultSessionMode is the compatibility fallback when the daemon-owned
+// preference is unavailable or invalid. Keep it TUI so a settings read failure
+// cannot turn a working terminal spawn into a Chat-only failure.
 const DefaultSessionMode = SessionModeTUI
 
 // Valid reports whether mode is one AO knows how to dispatch.

--- a/backend/internal/domain/sessionmode_test.go
+++ b/backend/internal/domain/sessionmode_test.go
@@ -69,9 +69,9 @@ func TestParseSessionModeRejectsUnknownInsteadOfFallingBack(t *testing.T) {
 	}
 }
 
-func TestDefaultSessionModeIsTUIForUpgradeCompatibility(t *testing.T) {
+func TestDefaultSessionModeIsTUIForSettingsFailureCompatibility(t *testing.T) {
 	if DefaultSessionMode != SessionModeTUI {
-		t.Fatalf("DefaultSessionMode = %q, want %q so an upgrade changes no existing workflow",
+		t.Fatalf("DefaultSessionMode = %q, want %q so a settings failure keeps terminal spawns working",
 			DefaultSessionMode, SessionModeTUI)
 	}
 }

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -189,11 +189,11 @@ type SpawnSessionRequest struct {
 	Branch          string                 `json:"branch,omitempty"`
 	// Mode picks the conversation controller: chat talks to the agent over a
 	// structured connection, tui opens the agent's native terminal interface.
-	// Omitted resolves to the daemon default (tui), which is why an upgrade
-	// changes nothing. Compatible sessions may later switch through the durable
-	// interface-transition endpoint; the default never mutates existing sessions
-	// automatically. An unsupported explicit request fails rather than quietly
-	// producing the other kind of session.
+	// Omitted resolves to the daemon-owned preference, which defaults to Chat for
+	// new sessions and falls back to TUI when Chat is unavailable. The preference
+	// never mutates existing sessions automatically; compatible sessions may later
+	// switch through the durable interface-transition endpoint. An unsupported
+	// explicit request fails rather than quietly producing the other kind of session.
 	Mode   domain.SessionMode `json:"mode,omitempty" enum:"chat,tui"`
 	Prompt string             `json:"prompt,omitempty" maxLength:"4096"`
 	// Model is an optional agent model override scoped to this single spawn. Empty

--- a/backend/internal/session_manager/chat_spawn_test.go
+++ b/backend/internal/session_manager/chat_spawn_test.go
@@ -32,6 +32,12 @@ func newChatManager(chat ChatLauncher) (*Manager, *fakeStore, *fakeRuntime) {
 
 const chatTestProject = domain.ProjectID("mer")
 
+type fixedSessionModeDefaults domain.SessionMode
+
+func (d fixedSessionModeDefaults) DefaultSessionMode(context.Context) domain.SessionMode {
+	return domain.SessionMode(d)
+}
+
 // The load-bearing property of the split: exactly one controller starts. A chat
 // spawn must not touch the terminal runtime, and a TUI spawn must not touch the
 // chat launcher. Anything else means two writers on one conversation.
@@ -352,6 +358,74 @@ func TestChatSpawnWithoutLauncherIsRefusedNotDowngraded(t *testing.T) {
 	}
 	if runtime.created != 0 {
 		t.Fatalf("a refused chat spawn created %d runtimes — it downgraded to TUI", runtime.created)
+	}
+}
+
+func TestDefaultChatSpawnFallsBackToTUIWhenUnavailable(t *testing.T) {
+	tests := []struct {
+		name            string
+		withoutLauncher bool
+		preflightErr    error
+	}{
+		{name: "launcher not configured", withoutLauncher: true},
+		{name: "harness unsupported", preflightErr: ports.ErrChatUnsupported},
+		{name: "driver unavailable", preflightErr: ports.ErrChatDriverUnavailable},
+		{name: "driver incompatible", preflightErr: ports.ErrChatDriverIncompatible},
+		{name: "authentication required", preflightErr: ports.ErrChatAuthRequired},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			launcher := &recordingLauncher{preflightErr: tt.preflightErr}
+			var chat ChatLauncher = launcher
+			if tt.withoutLauncher {
+				chat = nil
+			}
+			mgr, _, runtime := newChatManager(chat)
+			mgr.defaults = fixedSessionModeDefaults(domain.SessionModeChat)
+
+			rec, _, _, err := mgr.Spawn(context.Background(), ports.SpawnConfig{
+				ProjectID: chatTestProject,
+				Kind:      domain.KindWorker,
+				Harness:   domain.HarnessCodex,
+			})
+			if err != nil {
+				t.Fatalf("Spawn: %v", err)
+			}
+			if rec.Mode != domain.SessionModeTUI {
+				t.Fatalf("mode = %q, want TUI fallback", rec.Mode)
+			}
+			if runtime.created == 0 {
+				t.Fatal("TUI fallback created no terminal runtime")
+			}
+			if len(launcher.started) != 0 {
+				t.Fatalf("fallback started %d Chat controllers, want 0", len(launcher.started))
+			}
+		})
+	}
+}
+
+func TestDefaultChatSpawnUsesChatWhenAvailable(t *testing.T) {
+	launcher := &recordingLauncher{}
+	mgr, _, runtime := newChatManager(launcher)
+	mgr.defaults = fixedSessionModeDefaults(domain.SessionModeChat)
+
+	rec, _, _, err := mgr.Spawn(context.Background(), ports.SpawnConfig{
+		ProjectID: chatTestProject,
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessCodex,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if rec.Mode != domain.SessionModeChat {
+		t.Fatalf("mode = %q, want chat", rec.Mode)
+	}
+	if runtime.created != 0 {
+		t.Fatalf("default Chat spawn created %d terminal runtimes, want 0", runtime.created)
+	}
+	if len(launcher.preflighted) != 1 || len(launcher.started) != 1 {
+		t.Fatalf("default Chat dispatch: preflight=%v started=%d, want one of each",
+			launcher.preflighted, len(launcher.started))
 	}
 }
 

--- a/backend/internal/session_manager/chat_spawn_test.go
+++ b/backend/internal/session_manager/chat_spawn_test.go
@@ -404,6 +404,32 @@ func TestDefaultChatSpawnFallsBackToTUIWhenUnavailable(t *testing.T) {
 	}
 }
 
+func TestDefaultChatSpawnReturnsUnexpectedPreflightError(t *testing.T) {
+	preflightErr := errors.New("probe state corrupted")
+	launcher := &recordingLauncher{preflightErr: preflightErr}
+	mgr, store, runtime := newChatManager(launcher)
+	mgr.defaults = fixedSessionModeDefaults(domain.SessionModeChat)
+
+	_, _, _, err := mgr.Spawn(context.Background(), ports.SpawnConfig{
+		ProjectID: chatTestProject,
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessCodex,
+	})
+	if !errors.Is(err, preflightErr) {
+		t.Fatalf("Spawn error = %v, want unexpected preflight error", err)
+	}
+	if runtime.created != 0 {
+		t.Fatalf("unexpected preflight failure created %d terminal runtimes, want 0", runtime.created)
+	}
+	sessions, listErr := store.ListAllSessions(context.Background())
+	if listErr != nil {
+		t.Fatalf("list sessions: %v", listErr)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("unexpected preflight failure left %d session rows, want 0", len(sessions))
+	}
+}
+
 func TestDefaultChatSpawnUsesChatWhenAvailable(t *testing.T) {
 	launcher := &recordingLauncher{}
 	mgr, _, runtime := newChatManager(launcher)

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -748,7 +748,12 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 				"harness", cfg.Harness, "error", ports.ErrChatUnsupported)
 			mode = domain.SessionModeTUI
 		} else if err := m.chat.PreflightChat(ctx, cfg.Harness); err != nil {
-			if modeExplicitlyRequested || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			fallbackAllowed := errors.Is(err, ports.ErrChatUnsupported) ||
+				errors.Is(err, ports.ErrChatDriverUnavailable) ||
+				errors.Is(err, ports.ErrChatDriverIncompatible) ||
+				errors.Is(err, ports.ErrChatAuthRequired)
+			if modeExplicitlyRequested || !fallbackAllowed ||
+				errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: %w", err)
 			}
 			m.logger.Warn("spawn: default Chat unavailable; falling back to TUI",

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -310,8 +310,8 @@ type Manager struct {
 	// admitted path while ordinary input remains fenced out.
 	messenger *sessionguard.Guard
 	// chat launches the structured controller for a chat-mode session. Nil means
-	// this build cannot run chat sessions, and a chat spawn is refused rather
-	// than silently downgraded to a terminal.
+	// this build cannot run chat sessions. Explicit Chat requests are refused;
+	// an inherited Chat preference falls back to TUI.
 	// defaults resolves the daemon-owned default session interface for a spawn
 	// that names no mode. Nil falls back to the compatibility default, so a build
 	// without it behaves exactly as before.
@@ -572,8 +572,8 @@ type Deps struct {
 	// name no mode. Nil means always use the compatibility default.
 	Defaults SessionModeDefaults
 	// Chat launches the structured controller for a chat-mode session. Nil means
-	// chat mode is unavailable, and a chat spawn is refused rather than silently
-	// downgraded to a terminal.
+	// chat mode is unavailable. Explicit Chat requests are refused; an inherited
+	// Chat preference falls back to TUI.
 	Chat                ChatLauncher
 	Lifecycle           lifecycleRecorder
 	Preview             PreviewLifecycle
@@ -733,17 +733,27 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	adapterConfig := normalizeAgentConfigForHarness(cfg.Harness, agentConfig)
 
 	// Resolve the controller mode here, before anything durable is created, for
-	// the same reason an unknown harness is rejected above: a chat request AO
-	// cannot honor should cost nothing, not leave a terminated row and a worktree
-	// behind. It never falls back to TUI — that would put the user in a terminal
-	// they deliberately did not ask for.
+	// the same reason an unknown harness is rejected above: an explicit Chat
+	// request AO cannot honor should cost nothing, not leave a terminated row and
+	// a worktree behind. Chat inherited from the daemon preference is best-effort:
+	// if it is unavailable for this harness or installation, fall back to TUI.
+	modeExplicitlyRequested := cfg.RequestedMode.Valid()
 	mode := m.resolveSessionMode(ctx, cfg.RequestedMode)
 	if mode == domain.SessionModeChat {
 		if m.chat == nil {
-			return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: %w: chat mode is not available in this build", ports.ErrChatUnsupported)
-		}
-		if err := m.chat.PreflightChat(ctx, cfg.Harness); err != nil {
-			return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: %w", err)
+			if modeExplicitlyRequested {
+				return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: %w: chat mode is not available in this build", ports.ErrChatUnsupported)
+			}
+			m.logger.Warn("spawn: default Chat unavailable; falling back to TUI",
+				"harness", cfg.Harness, "error", ports.ErrChatUnsupported)
+			mode = domain.SessionModeTUI
+		} else if err := m.chat.PreflightChat(ctx, cfg.Harness); err != nil {
+			if modeExplicitlyRequested || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: %w", err)
+			}
+			m.logger.Warn("spawn: default Chat unavailable; falling back to TUI",
+				"harness", cfg.Harness, "error", err)
+			mode = domain.SessionModeTUI
 		}
 	}
 	cfg.RequestedMode = mode

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -108,6 +108,7 @@ var shippedMigrations = map[int64]string{
 	102: "0102_canonical_usage.sql",
 	103: "0103_review_run_cdc.sql",
 	104: "0104_agent_inventory_cache.sql",
+	105: "0105_default_session_mode_chat.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_chat_renumber_test.go
+++ b/backend/internal/storage/sqlite/migrate_chat_renumber_test.go
@@ -41,6 +41,20 @@ DELETE FROM goose_db_version WHERE version_id = 52 OR version_id BETWEEN 66 AND 
 		}
 	}
 
+	// Assert the repair itself preserves the preference before later migrations
+	// run. The product-default migration writes Chat too, so a final-state-only
+	// assertion would no longer detect a repair that reset this row first.
+	if err := repairRenumberedChatMigrationHistory(db); err != nil {
+		t.Fatalf("repair pre-renumbered Chat migration history: %v", err)
+	}
+	var preservedMode string
+	if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&preservedMode); err != nil {
+		t.Fatalf("read app setting after repair: %v", err)
+	}
+	if preservedMode != "chat" {
+		t.Fatalf("default mode after repair = %q, want preserved chat", preservedMode)
+	}
+
 	if err := migrate(db); err != nil {
 		t.Fatalf("migrate pre-renumbered Chat database: %v", err)
 	}

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -38,6 +38,65 @@ var expectedUsageTableColumns = map[string][]string{
 	},
 }
 
+func TestMigrateDefaultsSessionInterfaceToChat(t *testing.T) {
+	db := openMigratedTestDB(t)
+
+	var mode string
+	if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&mode); err != nil {
+		t.Fatalf("read default session mode: %v", err)
+	}
+	if mode != "chat" {
+		t.Fatalf("default session mode = %q, want chat", mode)
+	}
+}
+
+func TestMigrateUpdatesExistingSessionInterfaceDefaultToChat(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 103)
+
+	if _, err := db.Exec(`UPDATE app_settings SET default_session_mode = 'tui' WHERE id = 1`); err != nil {
+		t.Fatalf("seed existing TUI default: %v", err)
+	}
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate existing database: %v", err)
+	}
+
+	var mode string
+	if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&mode); err != nil {
+		t.Fatalf("read default session mode: %v", err)
+	}
+	if mode != "chat" {
+		t.Fatalf("default session mode = %q, want chat after upgrade", mode)
+	}
+}
+
+func TestMigrateRollbackPreservesSessionInterfacePreference(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 103)
+
+	if _, err := db.Exec(`UPDATE app_settings SET default_session_mode = 'chat' WHERE id = 1`); err != nil {
+		t.Fatalf("seed deliberate Chat default: %v", err)
+	}
+	upTo(t, db, 105)
+	downTo(t, db, 104)
+
+	var mode string
+	if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&mode); err != nil {
+		t.Fatalf("read default session mode: %v", err)
+	}
+	if mode != "chat" {
+		t.Fatalf("default session mode after rollback = %q, want preserved chat", mode)
+	}
+}
+
 func TestUsageTablesKeepOnlyDurableCollectionState(t *testing.T) {
 	db := openMigratedTestDB(t)
 	for table, wantColumns := range expectedUsageTableColumns {

--- a/backend/internal/storage/sqlite/migrations/0105_default_session_mode_chat.sql
+++ b/backend/internal/storage/sqlite/migrations/0105_default_session_mode_chat.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+UPDATE app_settings
+SET default_session_mode = 'chat', updated_at = CURRENT_TIMESTAMP
+WHERE id = 1;
+
+-- +goose Down
+-- The previous preference cannot be reconstructed safely. Preserve it rather
+-- than replacing a deliberate Chat choice during rollback.
+SELECT 1;


### PR DESCRIPTION
## What

Make Chat UI the daemon-owned preferred interface for newly created sessions, including orchestrators.

## Behavior

- Spawns with no explicit mode try Chat first.
- If Chat is unsupported or preflight reports an unavailable, incompatible, or unauthenticated driver, the spawn falls back to TUI.
- Explicit Chat requests remain strict and return the preflight error instead of changing interfaces.
- Existing sessions are untouched.
- The migration intentionally updates the saved default to Chat for existing installations as well as fresh installations.

## How

- Add append-only migration `0104_default_session_mode_chat.sql` after the migrations currently on `main`.
- Make the session manager distinguish an inherited default from an explicitly requested mode.
- Preserve the saved preference on migration rollback because its previous value cannot be reconstructed safely.
- Cover successful inherited Chat, TUI fallback paths, upgrade behavior, and the pre-renumber migration preservation check.

## Testing

- `go test ./internal/session_manager ./internal/storage/sqlite ./internal/domain ./internal/httpd/controllers`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs` — 0 issues

## Checklist

- [x] Rebased onto current `main`
- [x] One focused change
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Regression coverage for the changed default and fallback behavior
