### PR TITLE
fix(review): discover sibling-named stacked PRs

### DIFF
--- a/backend/internal/autoreview/coordinator.go
+++ b/backend/internal/autoreview/coordinator.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -51,6 +52,8 @@ type Coordinator struct {
 	idleThreshold time.Duration
 	sweepInterval time.Duration
 	logger        *slog.Logger
+	decisionMu    sync.Mutex
+	lastDecisions map[domain.SessionID]string
 }
 
 // Config customizes coordinator timing and logging.
@@ -63,7 +66,7 @@ type Config struct {
 
 // New constructs an auto-review coordinator.
 func New(store Store, reviews Trigger, cfg Config) *Coordinator {
-	c := &Coordinator{store: store, reviews: reviews, clock: cfg.Clock, idleThreshold: cfg.IdleThreshold, sweepInterval: cfg.SweepInterval, logger: cfg.Logger}
+	c := &Coordinator{store: store, reviews: reviews, clock: cfg.Clock, idleThreshold: cfg.IdleThreshold, sweepInterval: cfg.SweepInterval, logger: cfg.Logger, lastDecisions: make(map[domain.SessionID]string)}
 	if c.clock == nil {
 		c.clock = time.Now
 	}
@@ -254,14 +257,33 @@ func (c *Coordinator) Sweep(ctx context.Context) error {
 		return err
 	}
 	for _, session := range sessions {
-		if reason := sessionGate(session, c.clock(), c.idleThreshold); reason != "" {
+		if !session.AutoReviewEnabled {
 			continue
 		}
-		if _, err := c.EvaluateSession(ctx, session.ID); err != nil {
+		result, err := c.EvaluateSession(ctx, session.ID)
+		if err != nil {
 			c.logger.Error("auto-review: evaluate session failed", "session_id", session.ID, "err", err)
+			continue
 		}
+		c.logDecision(session, result)
 	}
 	return nil
+}
+
+func (c *Coordinator) logDecision(session domain.SessionRecord, result Result) {
+	c.decisionMu.Lock()
+	if c.lastDecisions[session.ID] == result.Reason {
+		c.decisionMu.Unlock()
+		return
+	}
+	c.lastDecisions[session.ID] = result.Reason
+	c.decisionMu.Unlock()
+	c.logger.Info("auto-review: decision",
+		"session_id", session.ID,
+		"reason", result.Reason,
+		"triggered", result.Triggered,
+		"activity", session.Activity.State,
+	)
 }
 
 // Start evaluates persisted session and PR facts on the configured cadence

--- a/backend/internal/autoreview/coordinator_test.go
+++ b/backend/internal/autoreview/coordinator_test.go
@@ -1,7 +1,10 @@
 package autoreview
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -225,4 +228,37 @@ func TestCoordinatorPeriodicallyEvaluatesPersistedFacts(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+func TestSweepLogsAutoReviewDecisionOnlyWhenItChanges(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		session: domain.SessionRecord{ID: "s1", ProjectID: "p1", Kind: domain.KindWorker, Harness: domain.HarnessCodex, AutoReviewEnabled: true, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}},
+		project: domain.ProjectRecord{ID: "p1"},
+		prs:     []domain.PullRequest{{URL: "pr1", Number: 1, HeadSHA: "sha1"}},
+	}
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	coordinator := New(store, &fakeTrigger{}, Config{Clock: func() time.Time { return now }, Logger: logger})
+
+	if err := coordinator.Sweep(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.Sweep(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(logs.String(), "auto-review: decision"); got != 1 {
+		t.Fatalf("decision log count = %d, want 1; logs=%s", got, logs.String())
+	}
+	if !strings.Contains(logs.String(), "reason=not_idle") || !strings.Contains(logs.String(), "session_id=s1") {
+		t.Fatalf("decision log lacks skip evidence: %s", logs.String())
+	}
+
+	store.session.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now.Add(-time.Minute)}
+	if err := coordinator.Sweep(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(logs.String(), "auto-review: decision"); got != 2 || !strings.Contains(logs.String(), "reason=triggered") {
+		t.Fatalf("changed decision was not logged once: %s", logs.String())
+	}
 }

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -1095,7 +1095,7 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 			// dropped (as is an empty head repo from a deleted fork), preserving
 			// the no-misattribution guarantee.
 			eligible := candidatesForHeadRepo(byRepo[repoKey], pr.HeadRepo)
-			sr, ok := matchSession(eligible, pr.SourceBranch)
+			sr, ok := matchSession(eligible, pr.SourceBranch, pr.TargetBranch)
 			if !ok {
 				continue
 			}
@@ -1224,7 +1224,7 @@ func candidatesForHeadRepo(candidates []sessionRepo, headRepo string) []sessionR
 	return out
 }
 
-func matchSession(candidates []sessionRepo, sourceBranch string) (sessionRepo, bool) {
+func matchSession(candidates []sessionRepo, sourceBranch, targetBranch string) (sessionRepo, bool) {
 	for _, sr := range candidates {
 		if sr.branch != "" && sr.branch == sourceBranch {
 			return sr, true
@@ -1245,7 +1245,19 @@ func matchSession(candidates []sessionRepo, sourceBranch string) (sessionRepo, b
 			}
 		}
 	}
-	return best, bestLen >= 0
+	if bestLen >= 0 {
+		return best, true
+	}
+	// A stacked child can use any source-branch name; its explicit stack edge is
+	// the base branch pointing at the parent session branch. Prefer source
+	// ownership above, then use this exact-only fallback so an unrelated branch
+	// cannot be captured merely because its name shares a prefix.
+	for _, sr := range candidates {
+		if sr.branch != "" && sr.branch == targetBranch {
+			return sr, true
+		}
+	}
+	return sessionRepo{}, false
 }
 
 func sessionBranchPrefixes(branch string) []string {

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -745,6 +745,31 @@ func TestPoll_DiscoversStackedChildByBranchPrefix(t *testing.T) {
 	}
 }
 
+func TestPoll_DiscoversSiblingNamedStackedChildByTargetBranch(t *testing.T) {
+	store := testStoreWithSession()
+	childObs := testObs(2)
+	childObs.PR.SourceBranch = "feat-aws-staging"
+	childObs.PR.TargetBranch = "feat"
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "v2"}},
+		openPRs: map[string][]ports.SCMPRObservation{prKey(testRepo, 0): {
+			{URL: "https://github.com/o/r/pull/2", Number: 2, SourceBranch: "feat-aws-staging", HeadRepo: "o/r", TargetBranch: "feat", HeadSHA: "sha2"},
+		}},
+		observations: map[string]ports.SCMObservation{prKey(testRepo, 2): childObs},
+	}
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.writes) == 0 || store.writes[0].pr.Number != 2 {
+		t.Fatalf("stacked child was not attributed to the parent session: writes=%#v", store.writes)
+	}
+	if len(lc.observed) != 1 {
+		t.Fatalf("lifecycle observations = %d, want 1", len(lc.observed))
+	}
+}
+
 func TestPoll_DiscoversSiblingUnderRootSessionNamespace(t *testing.T) {
 	store := testStoreWithSession()
 	store.sessions[0].Metadata.Branch = "ao/p-1/root"
@@ -780,7 +805,7 @@ func TestPoll_DiscoversSiblingUnderRootSessionNamespace(t *testing.T) {
 func TestMatchSession_PrefersExactBranchOverNamespaceMatch(t *testing.T) {
 	exact := sessionRepo{session: domain.SessionRecord{ID: "exact"}, branch: "ao/p-1"}
 	namespace := sessionRepo{session: domain.SessionRecord{ID: "namespace"}, branch: "ao/p-1/root"}
-	got, ok := matchSession([]sessionRepo{namespace, exact}, "ao/p-1")
+	got, ok := matchSession([]sessionRepo{namespace, exact}, "ao/p-1", "main")
 	if !ok {
 		t.Fatal("expected a matching session")
 	}


### PR DESCRIPTION
Fixes #4236

## Summary

- discover sibling-named stacked child PRs when their target branch exactly matches the owning session branch
- preserve source-branch precedence plus existing authenticated-author and head-repository attribution guards
- log auto-review decisions when their reason changes, including normal skips and successful triggers
- cover stacked-child discovery and deduplicated decision logging

## Root cause

AO only attributed untracked PRs when their source branch equaled the session branch or was a slash descendant. PR #4166 used a sibling-style branch name but targeted the session's root PR branch, so it remained outside AO's PR table for more than 30 hours. During the worker's idle window, the coordinator therefore saw only the already-approved root PR and skipped with `already_approved`.

## Tests

- `cd backend && go build ./...`
- `cd backend && env -u <all exported AO_* variables> go test ./...`
- `env -u <all exported AO_* variables> npm run lint`

## Risks / follow-ups

- The target-branch fallback is exact-only and runs after source attribution, limiting it to explicit stack edges.
- The latest decision is now present in daemon logs but not yet in the desktop Reviews inspector; tracked in #4237.
