### PR TITLE
fix(reaper): dedupe missing-handle warnings

### DIFF
--- a/backend/internal/observe/reaper/reaper.go
+++ b/backend/internal/observe/reaper/reaper.go
@@ -9,6 +9,7 @@ package reaper
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -69,18 +70,24 @@ type Reaper struct {
 	tick     time.Duration
 	clock    func() time.Time
 	logger   *slog.Logger
+
+	// The periodic loop and boot-time reconciliation may call Tick on the same
+	// Reaper concurrently, so the per-run warning set needs synchronization.
+	missingHandleMu     sync.Mutex
+	warnedMissingHandle map[domain.SessionID]struct{}
 }
 
 // New constructs a Reaper. sink is the lifecycle fact destination; sessions
 // supplies the rows to probe; runtime checks whether a stored handle is alive.
 func New(sink runtimeObservationSink, sessions sessionSource, runtime runtimeProber, cfg Config) *Reaper {
 	r := &Reaper{
-		sink:     sink,
-		sessions: sessions,
-		runtime:  runtime,
-		tick:     cfg.Tick,
-		clock:    cfg.Clock,
-		logger:   cfg.Logger,
+		sink:                sink,
+		sessions:            sessions,
+		runtime:             runtime,
+		tick:                cfg.Tick,
+		clock:               cfg.Clock,
+		logger:              cfg.Logger,
+		warnedMissingHandle: make(map[domain.SessionID]struct{}),
 	}
 	if workload, ok := runtime.(ports.SupervisedProcessInspector); ok {
 		r.workload = workload
@@ -206,8 +213,7 @@ func (r *Reaper) probeOne(ctx context.Context, sess domain.SessionRecord, now ti
 		// A session in the running-set without a handle is an anomaly worth
 		// surfacing (MarkSpawned should have set both keys). Warn rather
 		// than Debug so it doesn't hide behind a noisy log level.
-		r.logger.Warn("reaper: session has no runtime handle metadata, skipping",
-			"session", sess.ID)
+		r.warnMissingHandleOnce(sess.ID)
 		return ports.RuntimeFacts{}, false
 	}
 	alive, probeErr := r.runtime.IsAlive(ctx, handle)
@@ -244,6 +250,20 @@ func (r *Reaper) probeOne(ctx context.Context, sess domain.SessionRecord, now ti
 	}
 
 	return facts, true
+}
+
+// warnMissingHandleOnce logs at most once per session for this Reaper's lifetime.
+func (r *Reaper) warnMissingHandleOnce(id domain.SessionID) {
+	r.missingHandleMu.Lock()
+	if _, warned := r.warnedMissingHandle[id]; warned {
+		r.missingHandleMu.Unlock()
+		return
+	}
+	r.warnedMissingHandle[id] = struct{}{}
+	r.missingHandleMu.Unlock()
+
+	r.logger.Warn("reaper: session has no runtime handle metadata, skipping",
+		"session", id)
 }
 
 // handleFromRecord reconstructs the RuntimeHandle stored on the session by

--- a/backend/internal/observe/reaper/reaper_test.go
+++ b/backend/internal/observe/reaper/reaper_test.go
@@ -1,10 +1,12 @@
 package reaper
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -227,5 +229,38 @@ func TestTick_SkipsSessionWithoutHandle(t *testing.T) {
 	}
 	if _, probed := lcm.observed["mer-1"]; probed {
 		t.Fatal("a session without a runtime handle must be skipped")
+	}
+}
+
+func TestTick_WarnsOnlyOnceForSessionWithoutHandle(t *testing.T) {
+	lcm := &fakeLCM{}
+	sessions := fakeSessions{
+		rows: []domain.SessionRecord{
+			{ID: "mer-1"},
+			{ID: "mer-2"},
+		},
+	}
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+
+	r := New(lcm, sessions, fakeRuntime{alive: true}, Config{
+		Logger: logger,
+	})
+
+	for range 3 {
+		if err := r.Tick(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const warning = "reaper: session has no runtime handle metadata, skipping"
+	if got := strings.Count(logs.String(), warning); got != 2 {
+		t.Fatalf("warning count = %d, want 2; logs:\n%s", got, logs.String())
+	}
+	for _, id := range []domain.SessionID{"mer-1", "mer-2"} {
+		if got := strings.Count(logs.String(), "session="+string(id)); got != 1 {
+			t.Fatalf("warning count for %s = %d, want 1; logs:\n%s", id, got, logs.String())
+		}
 	}
 }


### PR DESCRIPTION
## What

Deduplicate missing-runtime-handle warnings per session and daemon run.

## Why

Repeated reaper warnings can evict useful startup diagnostics from the supervisor output buffer.

This addresses the warning-spam portion of [#4187](https://github.com/Untrivial-ai/agent-orchestrator/issues/4187). The startup reconciliation hang remains out of scope.

## How

Track warned session IDs in a mutex-protected, reaper-local set.

## Testing

- `cd backend && go build ./...`
- `cd backend && go test ./...`
- `cd backend && go test -race ./internal/observe/reaper -count=1`
- `npm run lint`

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added for the changed behavior
- [x] Relevant backend checks pass