### PR TITLE
feat(frontend): syntax-highlight the diff review panel

### DIFF
--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -38,14 +38,20 @@ import {
 	type WorkspaceFileSummary,
 } from "../hooks/useSessionWorkspaceFiles";
 import { useParsedDiff } from "../hooks/useParsedDiff";
+import { useDiffHighlight } from "../hooks/useDiffHighlight";
 import { cn } from "../lib/utils";
-import type { DiffRow, DiffRowKind, DiffSegment } from "../lib/diff-parser";
+import type { DiffRow, DiffRowKind } from "../lib/diff-parser";
+import type { DiffRun } from "../lib/diff-highlight";
 import type { DiffSelectionLine } from "../../shared/diff-selection";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "./ui/accordion";
 import { subscribeWorkspaceFileChanges } from "../lib/workspace-file-events";
 import { Button } from "./ui/button";
 import { DiffSelectionMenu } from "./DiffSelectionMenu";
 import { Input } from "./ui/input";
+// The token colours live with the engine rather than with one caller: they are
+// scoped under `.chat-code`/`.diff-code`, so anything rendering these class names
+// has to be inside one of those containers and has to have loaded this sheet.
+import "./chat/code-theme.css";
 
 type WorkspaceFileDetail = components["schemas"]["WorkspaceFileResponse"] & {
 	previousPath?: string;
@@ -746,6 +752,7 @@ function DiffView({
 	const [menuState, setMenuState] = useState<DiffViewMenuState | null>(null);
 	const shouldVirtualize = !split && rows.length > ROW_VIRTUALIZE_THRESHOLD;
 	const { listRef, virtualizer } = useSharedScrollRowVirtualizer(containerRef, rows.length, shouldVirtualize);
+	const runs = useDiffHighlight(rows, path);
 
 	useEffect(() => {
 		const onSelectionChange = () => {
@@ -805,12 +812,12 @@ function DiffView({
 				</div>
 			) : null}
 			<div
-				className="session-files-diff-scrollbar overflow-x-auto overflow-y-visible bg-terminal font-mono text-xs leading-row text-terminal-foreground"
+				className="diff-code session-files-diff-scrollbar overflow-x-auto overflow-y-visible bg-terminal font-mono text-xs leading-row text-terminal-foreground"
 				onContextMenu={onContextMenu}
 				ref={containerRef}
 			>
 				{split ? (
-					<SplitDiff annotation={annotation} path={path} previousPath={previousPath} rows={rows} t={t} />
+					<SplitDiff annotation={annotation} path={path} previousPath={previousPath} rows={rows} runs={runs} t={t} />
 				) : shouldVirtualize ? (
 					<div
 						className={cn("relative", !wrap && "min-w-max")}
@@ -838,6 +845,7 @@ function DiffView({
 										path={path}
 										previousPath={previousPath}
 										row={row}
+										runs={runs[virtualRow.index]}
 										t={t}
 										wrap={wrap}
 									/>
@@ -855,6 +863,7 @@ function DiffView({
 								path={path}
 								previousPath={previousPath}
 								row={row}
+								runs={runs[index]}
 								t={t}
 								wrap={wrap}
 							/>
@@ -890,13 +899,14 @@ type DiffRowContentProps = {
 	path: string;
 	previousPath?: string;
 	row: DiffRow;
+	runs: DiffRun[];
 	t: TFunction;
 	wrap: boolean;
 };
 
 // One unified-view diff row, shared between the plain (non-virtualized) and
 // virtualized render paths so they can't drift apart from each other.
-function DiffRowContentInner({ annotation, index, path, previousPath, row, t, wrap }: DiffRowContentProps) {
+function DiffRowContentInner({ annotation, index, path, previousPath, row, runs, t, wrap }: DiffRowContentProps) {
 	if (row.kind === "hunk") return <HunkBand row={row} />;
 	return (
 		<div>
@@ -927,7 +937,7 @@ function DiffRowContentInner({ annotation, index, path, previousPath, row, t, wr
 					{diffMarkerGlyph[row.kind]}
 				</span>
 				<span className={cn("pr-3", wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre")}>
-					{row.segments ? <DiffLineSegments add={row.kind === "add"} segments={row.segments} /> : row.text || " "}
+					{renderDiffRuns(runs, row.kind === "add")}
 				</span>
 			</div>
 			{isAnnotationRow(annotation.target, path, index) ? <FileAnnotationComposer annotation={annotation} /> : null}
@@ -941,16 +951,19 @@ function DiffRowContentInner({ annotation, index, path, previousPath, row, t, wr
 // anywhere in the panel, on top of every scroll tick. Only a row that IS or
 // WAS the active annotation target actually needs to re-render when
 // `annotation` changes; every other row only cares about `row`/`index`/
-// `path`/`previousPath`/`wrap`, which are stable across scroll-driven
-// re-renders. This is what actually lets scrolling skip re-running the
-// i18next calls, cn() calls, and nested Button for rows that are already
-// mounted and unchanged.
+// `path`/`previousPath`/`runs`/`wrap`, which are stable across scroll-driven
+// re-renders (`runs` only gets a new reference when useDiffHighlight actually
+// recomputes — unchanged rows and settled diffs keep the same array). This is
+// what actually lets scrolling skip re-running the i18next calls, cn() calls,
+// and nested Button for rows that are already mounted and unchanged, while
+// still picking up the color pop-in once a grammar chunk finishes loading.
 const DiffRowContent = memo(DiffRowContentInner, (prev, next) => {
 	if (
 		prev.row !== next.row ||
 		prev.index !== next.index ||
 		prev.path !== next.path ||
 		prev.previousPath !== next.previousPath ||
+		prev.runs !== next.runs ||
 		prev.wrap !== next.wrap
 	) {
 		return false;
@@ -1010,12 +1023,14 @@ function SplitDiff({
 	path,
 	previousPath,
 	rows,
+	runs,
 	t,
 }: {
 	annotation: FileAnnotationModel;
 	path: string;
 	previousPath?: string;
 	rows: DiffRow[];
+	runs: DiffRun[][];
 	t: TFunction;
 }) {
 	const splitRows = useMemo(() => toSplitRows(rows), [rows]);
@@ -1033,6 +1048,7 @@ function SplitDiff({
 								previousPath={previousPath}
 								row={splitRow.left}
 								rowIndex={splitRow.leftIndex}
+								runs={splitRow.leftIndex === null ? null : runs[splitRow.leftIndex]}
 								side="old"
 								t={t}
 							/>
@@ -1042,6 +1058,7 @@ function SplitDiff({
 								previousPath={previousPath}
 								row={splitRow.right}
 								rowIndex={splitRow.rightIndex}
+								runs={splitRow.rightIndex === null ? null : runs[splitRow.rightIndex]}
 								side="new"
 								t={t}
 							/>
@@ -1063,6 +1080,7 @@ function SplitSide({
 	previousPath,
 	row,
 	rowIndex,
+	runs,
 	side,
 	t,
 }: {
@@ -1071,10 +1089,11 @@ function SplitSide({
 	previousPath?: string;
 	row: DiffRow | null;
 	rowIndex: number | null;
+	runs: DiffRun[] | null;
 	side: "old" | "new";
 	t: TFunction;
 }) {
-	if (!row || rowIndex === null) return <div className="bg-surface-faint/20" aria-hidden="true" />;
+	if (!row || rowIndex === null || !runs) return <div className="bg-surface-faint/20" aria-hidden="true" />;
 	const lineNo = side === "old" ? row.oldNo : row.newNo;
 	const tone = row.kind === "hunk" ? "" : diffRowTone[row.kind];
 	const target = lineNo == null ? null : lineAnnotationTarget(path, previousPath, row, rowIndex, side);
@@ -1098,9 +1117,7 @@ function SplitSide({
 			<span className="w-9 shrink-0 select-none border-r border-border/50 bg-terminal px-1.5 text-right text-passive/70 tabular-nums">
 				{lineNo ?? ""}
 			</span>
-			<span className="min-w-0 whitespace-pre-wrap break-all px-1.5">
-				{row.segments ? <DiffLineSegments add={row.kind === "add"} segments={row.segments} /> : row.text || " "}
-			</span>
+			<span className="min-w-0 whitespace-pre-wrap break-all px-1.5">{renderDiffRuns(runs, row.kind === "add")}</span>
 		</div>
 	);
 }
@@ -1237,19 +1254,24 @@ function FileAnnotationComposer({ annotation }: { annotation: FileAnnotationMode
 	);
 }
 
-function DiffLineSegments({ add, segments }: { add: boolean; segments: DiffSegment[] }) {
-	return (
-		<>
-			{segments.map((segment, index) =>
-				segment.changed ? (
-					<span className={cn("rounded-sm", add ? "bg-success/35" : "bg-error/35")} key={index}>
-						{segment.text}
-					</span>
-				) : (
-					<span key={index}>{segment.text}</span>
-				),
-			)}
-		</>
+// Renders a diff line's composed runs: a highlight.js class when the line could
+// be tokenized, layered with the existing exact-changed-word background tint. A
+// run with neither renders as a bare string, matching the plain-text output this
+// replaces exactly (no highlighting available for the file's language, or the
+// row is unchanged context with nothing to tokenize against).
+function renderDiffRuns(runs: DiffRun[], add: boolean): ReactNode {
+	return runs.map((run, index) =>
+		run.changed ? (
+			<span className={cn(run.className, "rounded-sm", add ? "bg-success/35" : "bg-error/35")} key={index}>
+				{run.text}
+			</span>
+		) : run.className ? (
+			<span className={run.className} key={index}>
+				{run.text}
+			</span>
+		) : (
+			run.text
+		),
 	);
 }
 

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -752,7 +752,14 @@ function DiffView({
 	const [menuState, setMenuState] = useState<DiffViewMenuState | null>(null);
 	const shouldVirtualize = !split && rows.length > ROW_VIRTUALIZE_THRESHOLD;
 	const { listRef, virtualizer } = useSharedScrollRowVirtualizer(containerRef, rows.length, shouldVirtualize);
-	const runs = useDiffHighlight(rows, path);
+	const highlight = useDiffHighlight(rows, path, previousPath);
+	// Unified view shows each row once, so a del row reads its old-file color and
+	// every other row (context, add) reads its new-file color — same convention
+	// toSplitRows already uses to decide which side "owns" a context row.
+	const runs = useMemo(
+		() => rows.map((row, index) => (row.kind === "del" ? highlight.oldSide[index] : highlight.newSide[index])),
+		[rows, highlight],
+	);
 
 	useEffect(() => {
 		const onSelectionChange = () => {
@@ -817,7 +824,15 @@ function DiffView({
 				ref={containerRef}
 			>
 				{split ? (
-					<SplitDiff annotation={annotation} path={path} previousPath={previousPath} rows={rows} runs={runs} t={t} />
+					<SplitDiff
+						annotation={annotation}
+						newRuns={highlight.newSide}
+						oldRuns={highlight.oldSide}
+						path={path}
+						previousPath={previousPath}
+						rows={rows}
+						t={t}
+					/>
 				) : shouldVirtualize ? (
 					<div
 						className={cn("relative", !wrap && "min-w-max")}
@@ -1020,17 +1035,19 @@ function toSplitRows(rows: DiffRow[]): SplitRow[] {
 
 function SplitDiff({
 	annotation,
+	newRuns,
+	oldRuns,
 	path,
 	previousPath,
 	rows,
-	runs,
 	t,
 }: {
 	annotation: FileAnnotationModel;
+	newRuns: DiffRun[][];
+	oldRuns: DiffRun[][];
 	path: string;
 	previousPath?: string;
 	rows: DiffRow[];
-	runs: DiffRun[][];
 	t: TFunction;
 }) {
 	const splitRows = useMemo(() => toSplitRows(rows), [rows]);
@@ -1048,7 +1065,7 @@ function SplitDiff({
 								previousPath={previousPath}
 								row={splitRow.left}
 								rowIndex={splitRow.leftIndex}
-								runs={splitRow.leftIndex === null ? null : runs[splitRow.leftIndex]}
+								runs={splitRow.leftIndex === null ? null : oldRuns[splitRow.leftIndex]}
 								side="old"
 								t={t}
 							/>
@@ -1058,7 +1075,7 @@ function SplitDiff({
 								previousPath={previousPath}
 								row={splitRow.right}
 								rowIndex={splitRow.rightIndex}
-								runs={splitRow.rightIndex === null ? null : runs[splitRow.rightIndex]}
+								runs={splitRow.rightIndex === null ? null : newRuns[splitRow.rightIndex]}
 								side="new"
 								t={t}
 							/>

--- a/frontend/src/renderer/components/chat/code-theme.css
+++ b/frontend/src/renderer/components/chat/code-theme.css
@@ -1,5 +1,5 @@
 /*
- * Syntax colours for chat code blocks.
+ * Syntax colours for chat code blocks and the file-diff review panel.
  *
  * Built on the terminal ANSI tokens rather than on product roles, for the reason
  * tokens.css gives for keeping that palette separate: a code block is closer to
@@ -10,8 +10,10 @@
  * Highlighting is class-based on purpose. Colours resolve at paint time from CSS
  * variables, so flipping the theme re-paints; it does not re-tokenize.
  *
- * Scoped under `.chat-code` so highlight.js class names cannot leak styling into
- * any other surface that happens to use them.
+ * Scoped under `.chat-code` and `.diff-code` so highlight.js class names cannot
+ * leak styling into any other surface that happens to use them — both are
+ * deliberate, chosen consumers of the same engine (code-highlight.ts) and the
+ * same colour mapping, not a leak.
  */
 
 .chat-code pre {
@@ -28,7 +30,9 @@
 }
 
 .chat-code .hljs-comment,
-.chat-code .hljs-quote {
+.chat-code .hljs-quote,
+.diff-code .hljs-comment,
+.diff-code .hljs-quote {
 	color: var(--color-text-passive);
 	font-style: italic;
 }
@@ -39,7 +43,14 @@
 .chat-code .hljs-section,
 .chat-code .hljs-name,
 .chat-code .hljs-tag,
-.chat-code .hljs-selector-tag {
+.chat-code .hljs-selector-tag,
+.diff-code .hljs-keyword,
+.diff-code .hljs-literal,
+.diff-code .hljs-doctag,
+.diff-code .hljs-section,
+.diff-code .hljs-name,
+.diff-code .hljs-tag,
+.diff-code .hljs-selector-tag {
 	color: var(--color-term-magenta);
 }
 
@@ -47,20 +58,32 @@
 .chat-code .hljs-regexp,
 .chat-code .hljs-char.escape_,
 .chat-code .hljs-addition,
-.chat-code .hljs-template-tag {
+.chat-code .hljs-template-tag,
+.diff-code .hljs-string,
+.diff-code .hljs-regexp,
+.diff-code .hljs-char.escape_,
+.diff-code .hljs-addition,
+.diff-code .hljs-template-tag {
 	color: var(--color-term-green);
 }
 
 .chat-code .hljs-number,
 .chat-code .hljs-symbol,
 .chat-code .hljs-bullet,
-.chat-code .hljs-link {
+.chat-code .hljs-link,
+.diff-code .hljs-number,
+.diff-code .hljs-symbol,
+.diff-code .hljs-bullet,
+.diff-code .hljs-link {
 	color: var(--color-term-yellow);
 }
 
 .chat-code .hljs-title,
 .chat-code .hljs-title.function_,
-.chat-code .hljs-function .hljs-title {
+.chat-code .hljs-function .hljs-title,
+.diff-code .hljs-title,
+.diff-code .hljs-title.function_,
+.diff-code .hljs-function .hljs-title {
 	color: var(--color-term-blue);
 }
 
@@ -68,7 +91,12 @@
 .chat-code .hljs-title.class_,
 .chat-code .hljs-class .hljs-title,
 .chat-code .hljs-built_in,
-.chat-code .hljs-formula {
+.chat-code .hljs-formula,
+.diff-code .hljs-type,
+.diff-code .hljs-title.class_,
+.diff-code .hljs-class .hljs-title,
+.diff-code .hljs-built_in,
+.diff-code .hljs-formula {
 	color: var(--color-term-cyan);
 }
 
@@ -80,11 +108,21 @@
 .chat-code .hljs-selector-attr,
 .chat-code .hljs-selector-class,
 .chat-code .hljs-selector-id,
-.chat-code .hljs-selector-pseudo {
+.chat-code .hljs-selector-pseudo,
+.diff-code .hljs-attr,
+.diff-code .hljs-attribute,
+.diff-code .hljs-property,
+.diff-code .hljs-variable,
+.diff-code .hljs-template-variable,
+.diff-code .hljs-selector-attr,
+.diff-code .hljs-selector-class,
+.diff-code .hljs-selector-id,
+.diff-code .hljs-selector-pseudo {
 	color: var(--color-term-red);
 }
 
-.chat-code .hljs-deletion {
+.chat-code .hljs-deletion,
+.diff-code .hljs-deletion {
 	color: var(--color-term-red);
 }
 
@@ -93,14 +131,21 @@
 .chat-code .hljs-meta .hljs-keyword,
 .chat-code .hljs-punctuation,
 .chat-code .hljs-operator,
-.chat-code .hljs-params {
+.chat-code .hljs-params,
+.diff-code .hljs-meta,
+.diff-code .hljs-meta .hljs-keyword,
+.diff-code .hljs-punctuation,
+.diff-code .hljs-operator,
+.diff-code .hljs-params {
 	color: var(--color-text-muted);
 }
 
-.chat-code .hljs-emphasis {
+.chat-code .hljs-emphasis,
+.diff-code .hljs-emphasis {
 	font-style: italic;
 }
 
-.chat-code .hljs-strong {
+.chat-code .hljs-strong,
+.diff-code .hljs-strong {
 	font-weight: var(--font-weight-semibold);
 }

--- a/frontend/src/renderer/hooks/useDiffHighlight.test.ts
+++ b/frontend/src/renderer/hooks/useDiffHighlight.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { parseUnifiedDiff } from "../lib/diff-parser";
+import { useDiffHighlight } from "./useDiffHighlight";
+
+function classesOf(runs: { className?: string }[]): string[] {
+	return runs.flatMap((run) => run.className?.split(" ") ?? []);
+}
+
+describe("useDiffHighlight", () => {
+	it("falls back to plain text runs for a file whose extension has no bundled grammar", () => {
+		const rows = parseUnifiedDiff("@@ -1,1 +1,1 @@\n-old\n+new\n");
+		const { result } = renderHook(() => useDiffHighlight(rows, "notes.unknown"));
+		expect(result.current).toHaveLength(rows.length);
+		// No grammar resolved -> never colored, but the existing word-diff highlight
+		// (the "changed" flag) must still come through unaffected.
+		const delRun = result.current[rows.findIndex((r) => r.kind === "del")];
+		expect(classesOf(delRun)).toEqual([]);
+		expect(delRun.some((run) => run.changed)).toBe(true);
+	});
+
+	it("colors a del line using state carried over from a preceding context line", async () => {
+		// "old body" is only recognizable as a comment when tokenized together with
+		// the opening "/* start" context line in the same call — this is the
+		// per-hunk-side (not per-line) tokenization the design depends on.
+		const diff = "@@ -1,4 +1,4 @@\n /* start\n-old body\n+new body\n end */\n";
+		const rows = parseUnifiedDiff(diff);
+		const { result, rerender } = renderHook(({ r, p }) => useDiffHighlight(r, p), {
+			initialProps: { r: rows, p: "src/App.ts" },
+		});
+
+		await waitFor(
+			() => {
+				const delIndex = rows.findIndex((r) => r.kind === "del");
+				const classes = classesOf(result.current[delIndex]);
+				expect(classes.some((c) => c === "hljs-comment")).toBe(true);
+			},
+			{ timeout: 5000 },
+		);
+
+		// The paired add line resolves through the new-side blob the same way.
+		const addIndex = rows.findIndex((r) => r.kind === "add");
+		expect(classesOf(result.current[addIndex])).toContain("hljs-comment");
+
+		// A second render with the identical rows array and path must not throw and
+		// must keep returning the same shape (memoized — no re-tokenization needed).
+		act(() => rerender({ r: rows, p: "src/App.ts" }));
+		expect(result.current).toHaveLength(rows.length);
+	});
+
+	it("still applies the intra-line word-diff highlight on a colored line", async () => {
+		const diff = "@@ -1,1 +1,1 @@\n-const value = 0;\n+const value = 1;\n";
+		const rows = parseUnifiedDiff(diff);
+		const { result } = renderHook(() => useDiffHighlight(rows, "src/App.ts"));
+
+		await waitFor(() => {
+			const delIndex = rows.findIndex((r) => r.kind === "del");
+			expect(classesOf(result.current[delIndex]).length).toBeGreaterThan(0);
+		});
+
+		const delIndex = rows.findIndex((r) => r.kind === "del");
+		const addIndex = rows.findIndex((r) => r.kind === "add");
+		const changedDel = result.current[delIndex].filter((run) => run.changed);
+		const changedAdd = result.current[addIndex].filter((run) => run.changed);
+		expect(changedDel.map((run) => run.text).join("")).toBe("0");
+		expect(changedAdd.map((run) => run.text).join("")).toBe("1");
+	});
+});

--- a/frontend/src/renderer/hooks/useDiffHighlight.test.ts
+++ b/frontend/src/renderer/hooks/useDiffHighlight.test.ts
@@ -1,20 +1,27 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseUnifiedDiff } from "../lib/diff-parser";
+import * as codeHighlight from "../lib/code-highlight";
 import { useDiffHighlight } from "./useDiffHighlight";
 
 function classesOf(runs: { className?: string }[]): string[] {
 	return runs.flatMap((run) => run.className?.split(" ") ?? []);
 }
 
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
 describe("useDiffHighlight", () => {
 	it("falls back to plain text runs for a file whose extension has no bundled grammar", () => {
 		const rows = parseUnifiedDiff("@@ -1,1 +1,1 @@\n-old\n+new\n");
-		const { result } = renderHook(() => useDiffHighlight(rows, "notes.unknown"));
-		expect(result.current).toHaveLength(rows.length);
+		const { result } = renderHook(() => useDiffHighlight(rows, "notes.unknown", undefined));
+		expect(result.current.newSide).toHaveLength(rows.length);
+		expect(result.current.oldSide).toHaveLength(rows.length);
 		// No grammar resolved -> never colored, but the existing word-diff highlight
 		// (the "changed" flag) must still come through unaffected.
-		const delRun = result.current[rows.findIndex((r) => r.kind === "del")];
+		const delIndex = rows.findIndex((r) => r.kind === "del");
+		const delRun = result.current.oldSide[delIndex];
 		expect(classesOf(delRun)).toEqual([]);
 		expect(delRun.some((run) => run.changed)).toBe(true);
 	});
@@ -25,14 +32,14 @@ describe("useDiffHighlight", () => {
 		// per-hunk-side (not per-line) tokenization the design depends on.
 		const diff = "@@ -1,4 +1,4 @@\n /* start\n-old body\n+new body\n end */\n";
 		const rows = parseUnifiedDiff(diff);
-		const { result, rerender } = renderHook(({ r, p }) => useDiffHighlight(r, p), {
+		const { result, rerender } = renderHook(({ r, p }) => useDiffHighlight(r, p, undefined), {
 			initialProps: { r: rows, p: "src/App.ts" },
 		});
 
 		await waitFor(
 			() => {
 				const delIndex = rows.findIndex((r) => r.kind === "del");
-				const classes = classesOf(result.current[delIndex]);
+				const classes = classesOf(result.current.oldSide[delIndex]);
 				expect(classes.some((c) => c === "hljs-comment")).toBe(true);
 			},
 			{ timeout: 5000 },
@@ -40,29 +47,75 @@ describe("useDiffHighlight", () => {
 
 		// The paired add line resolves through the new-side blob the same way.
 		const addIndex = rows.findIndex((r) => r.kind === "add");
-		expect(classesOf(result.current[addIndex])).toContain("hljs-comment");
+		expect(classesOf(result.current.newSide[addIndex])).toContain("hljs-comment");
 
 		// A second render with the identical rows array and path must not throw and
 		// must keep returning the same shape (memoized — no re-tokenization needed).
 		act(() => rerender({ r: rows, p: "src/App.ts" }));
-		expect(result.current).toHaveLength(rows.length);
+		expect(result.current.newSide).toHaveLength(rows.length);
 	});
 
 	it("still applies the intra-line word-diff highlight on a colored line", async () => {
 		const diff = "@@ -1,1 +1,1 @@\n-const value = 0;\n+const value = 1;\n";
 		const rows = parseUnifiedDiff(diff);
-		const { result } = renderHook(() => useDiffHighlight(rows, "src/App.ts"));
+		const { result } = renderHook(() => useDiffHighlight(rows, "src/App.ts", undefined));
 
 		await waitFor(() => {
 			const delIndex = rows.findIndex((r) => r.kind === "del");
-			expect(classesOf(result.current[delIndex]).length).toBeGreaterThan(0);
+			expect(classesOf(result.current.oldSide[delIndex]).length).toBeGreaterThan(0);
 		});
 
 		const delIndex = rows.findIndex((r) => r.kind === "del");
 		const addIndex = rows.findIndex((r) => r.kind === "add");
-		const changedDel = result.current[delIndex].filter((run) => run.changed);
-		const changedAdd = result.current[addIndex].filter((run) => run.changed);
+		const changedDel = result.current.oldSide[delIndex].filter((run) => run.changed);
+		const changedAdd = result.current.newSide[addIndex].filter((run) => run.changed);
 		expect(changedDel.map((run) => run.text).join("")).toBe("0");
 		expect(changedAdd.map((run) => run.text).join("")).toBe("1");
+	});
+
+	it("keeps old-side and new-side syntax state independent for a shared context row", async () => {
+		// The change opens a comment that only exists on the old side: "shared
+		// context" is inside a /* ... */ block on the old side, but not on the new
+		// side (the new side never opens a comment before it). A single shared
+		// `runs[rowIndex]` can only hold one answer; split view needs both.
+		const diff = "@@ -1,3 +1,3 @@\n-/* old-only\n+const value = 1;\n shared context\n end */\n";
+		const rows = parseUnifiedDiff(diff);
+		const { result } = renderHook(() => useDiffHighlight(rows, "src/App.ts", undefined));
+
+		const contextIndex = rows.findIndex((r) => r.text === "shared context");
+		await waitFor(() => {
+			expect(classesOf(result.current.oldSide[contextIndex])).toContain("hljs-comment");
+		});
+		expect(classesOf(result.current.newSide[contextIndex])).not.toContain("hljs-comment");
+	});
+
+	it("does not retry forever once the engine reports highlighting unavailable", async () => {
+		const highlightSyncSpy = vi.spyOn(codeHighlight, "highlightSync").mockReturnValue(undefined);
+		const highlightSpy = vi
+			.spyOn(codeHighlight, "highlight")
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce(undefined)
+			.mockReturnValue(new Promise(() => {})); // any further call would hang the test if made
+
+		const rows = parseUnifiedDiff("@@ -1,1 +1,1 @@\n-const before = 0;\n+const after = 1;\n");
+		renderHook(() => useDiffHighlight(rows, "src/App.ts", undefined));
+
+		// One highlight() call per hunk side (old, new); both resolve to undefined
+		// (highlighting unavailable) so there is nothing to retry from.
+		await waitFor(() => expect(highlightSpy).toHaveBeenCalledTimes(2));
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(highlightSpy).toHaveBeenCalledTimes(2);
+		expect(highlightSyncSpy).toHaveBeenCalled();
+	});
+
+	it("uses the previous extension's grammar for the old side of an extension-changing rename", async () => {
+		const diff = "@@ -1,1 +1,1 @@\n-const oldValue = 0;\n+# heading\n";
+		const rows = parseUnifiedDiff(diff);
+		const { result } = renderHook(() => useDiffHighlight(rows, "docs/new.md", "src/old.ts"));
+
+		const delIndex = rows.findIndex((r) => r.kind === "del");
+		await waitFor(() => {
+			expect(classesOf(result.current.oldSide[delIndex])).toContain("hljs-keyword");
+		});
 	});
 });

--- a/frontend/src/renderer/hooks/useDiffHighlight.ts
+++ b/frontend/src/renderer/hooks/useDiffHighlight.ts
@@ -1,0 +1,71 @@
+import { useMemo, useReducer } from "react";
+import { highlight, highlightSync } from "../lib/code-highlight";
+import { composeLineRuns, languageForPath, splitHastByLine, type DiffRun } from "../lib/diff-highlight";
+import type { DiffRow } from "../lib/diff-parser";
+
+type HunkLine = { text: string; rowIndex: number };
+type Hunk = { old: HunkLine[]; new: HunkLine[] };
+
+// Groups rows into per-hunk old/new line sequences. A hunk's old-side sequence
+// (context + del, in order) and new-side sequence (context + add, in order) each
+// reconstruct a contiguous excerpt of the real file, which is what lets tokenizing
+// each side as one blob carry highlight.js's state (inside a string, a block
+// comment, ...) correctly across line breaks.
+function groupHunks(rows: DiffRow[]): Hunk[] {
+	const hunks: Hunk[] = [];
+	let current: Hunk | null = null;
+	rows.forEach((row, rowIndex) => {
+		if (row.kind === "hunk") {
+			current = { old: [], new: [] };
+			hunks.push(current);
+			return;
+		}
+		if (!current) return;
+		if (row.kind === "context") {
+			current.old.push({ text: row.text, rowIndex });
+			current.new.push({ text: row.text, rowIndex });
+		} else if (row.kind === "del") {
+			current.old.push({ text: row.text, rowIndex });
+		} else if (row.kind === "add") {
+			current.new.push({ text: row.text, rowIndex });
+		}
+	});
+	return hunks;
+}
+
+// Composed syntax + word-diff runs for every row in a diff, parallel to `rows`.
+// Colors a row as soon as its hunk-side blob can be tokenized; a diff that opens
+// before the grammar chunk has loaded renders in plain/segment-only form first and
+// pops in colored once loading resolves, matching HighlightedCode's existing
+// chat-code-block behavior rather than inventing a new loading pattern.
+export function useDiffHighlight(rows: DiffRow[], path: string): DiffRun[][] {
+	const lang = useMemo(() => languageForPath(path), [path]);
+	const [rereadCount, reread] = useReducer((count: number) => count + 1, 0);
+
+	return useMemo(() => {
+		const runs: DiffRun[][] = rows.map((row) => composeLineRuns(undefined, row.segments, row.text));
+		if (!lang) return runs;
+
+		for (const hunk of groupHunks(rows)) {
+			for (const side of [hunk.old, hunk.new]) {
+				if (side.length === 0) continue;
+				const blob = side.map((line) => line.text).join("\n");
+				const tree = highlightSync(blob, lang);
+				if (!tree) {
+					void highlight(blob, lang).then(() => reread());
+					continue;
+				}
+				const perLine = splitHastByLine(tree, side.length);
+				side.forEach((line, i) => {
+					const row = rows[line.rowIndex];
+					runs[line.rowIndex] = composeLineRuns(perLine[i], row.segments, row.text);
+				});
+			}
+		}
+		return runs;
+		// rereadCount forces a recompute once a pending highlight() resolves; the
+		// underlying highlightSync cache makes that recompute cheap (already-loaded
+		// blobs hit the cache instead of re-tokenizing).
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [rows, lang, rereadCount]);
+}

--- a/frontend/src/renderer/hooks/useDiffHighlight.ts
+++ b/frontend/src/renderer/hooks/useDiffHighlight.ts
@@ -1,6 +1,7 @@
 import { useMemo, useReducer } from "react";
 import { highlight, highlightSync } from "../lib/code-highlight";
 import { composeLineRuns, languageForPath, splitHastByLine, type DiffRun } from "../lib/diff-highlight";
+import type { GrammarName } from "../lib/code-highlight";
 import type { DiffRow } from "../lib/diff-parser";
 
 type HunkLine = { text: string; rowIndex: number };
@@ -33,39 +34,75 @@ function groupHunks(rows: DiffRow[]): Hunk[] {
 	return hunks;
 }
 
-// Composed syntax + word-diff runs for every row in a diff, parallel to `rows`.
-// Colors a row as soon as its hunk-side blob can be tokenized; a diff that opens
-// before the grammar chunk has loaded renders in plain/segment-only form first and
-// pops in colored once loading resolves, matching HighlightedCode's existing
-// chat-code-block behavior rather than inventing a new loading pattern.
-export function useDiffHighlight(rows: DiffRow[], path: string): DiffRun[][] {
-	const lang = useMemo(() => languageForPath(path), [path]);
+// Composed syntax + word-diff runs for one side (old or new) of every row, parallel
+// to `rows`. A row that isn't part of this side's hunk sequences (e.g. a pure add
+// on the old side) simply keeps the plain/segment-only fallback — nothing ever
+// reads it, since callers pick old for del rows and new for add/context rows.
+function highlightSide(
+	hunks: Hunk[],
+	rows: DiffRow[],
+	pickSide: (hunk: Hunk) => HunkLine[],
+	lang: GrammarName | undefined,
+	reread: () => void,
+): DiffRun[][] {
+	const runs: DiffRun[][] = rows.map((row) => composeLineRuns(undefined, row.segments, row.text));
+	if (!lang) return runs;
+
+	for (const hunk of hunks) {
+		const side = pickSide(hunk);
+		if (side.length === 0) continue;
+		const blob = side.map((line) => line.text).join("\n");
+		const tree = highlightSync(blob, lang);
+		if (!tree) {
+			// Only schedule a recompute if this attempt could actually change the
+			// outcome. If it resolves to another "unavailable" (engine failed to
+			// load, blob too large, ...) there is nothing new to render, and
+			// rereading anyway would recompute this same failed lookup forever.
+			void highlight(blob, lang).then((resolved) => {
+				if (resolved) reread();
+			});
+			continue;
+		}
+		const perLine = splitHastByLine(tree, side.length);
+		side.forEach((line, i) => {
+			const row = rows[line.rowIndex];
+			runs[line.rowIndex] = composeLineRuns(perLine[i], row.segments, row.text);
+		});
+	}
+	return runs;
+}
+
+export type DiffHighlight = {
+	/** Meaningful for context and del rows — the old-file syntax state. */
+	oldSide: DiffRun[][];
+	/** Meaningful for context and add rows — the new-file syntax state. */
+	newSide: DiffRun[][];
+};
+
+// Composed syntax + word-diff runs for every row in a diff, split by old/new side.
+// Old and new are tokenized independently, each against its own file's language
+// (a rename that changes extension can legitimately use a different grammar per
+// side) and each producing its own colors — a context line's syntax role can
+// legitimately differ between old and new when the change alters multi-line state
+// (opens or closes a comment/string) around it, so a single shared answer per row
+// would be wrong for one side of a split diff. Colors a row as soon as its
+// hunk-side blob can be tokenized; a diff that opens before the grammar chunk has
+// loaded renders in plain/segment-only form first and pops in colored once loading
+// resolves, matching HighlightedCode's existing chat-code-block behavior.
+export function useDiffHighlight(rows: DiffRow[], path: string, previousPath: string | undefined): DiffHighlight {
+	const oldLang = useMemo(() => languageForPath(previousPath ?? path), [previousPath, path]);
+	const newLang = useMemo(() => languageForPath(path), [path]);
 	const [rereadCount, reread] = useReducer((count: number) => count + 1, 0);
 
 	return useMemo(() => {
-		const runs: DiffRun[][] = rows.map((row) => composeLineRuns(undefined, row.segments, row.text));
-		if (!lang) return runs;
-
-		for (const hunk of groupHunks(rows)) {
-			for (const side of [hunk.old, hunk.new]) {
-				if (side.length === 0) continue;
-				const blob = side.map((line) => line.text).join("\n");
-				const tree = highlightSync(blob, lang);
-				if (!tree) {
-					void highlight(blob, lang).then(() => reread());
-					continue;
-				}
-				const perLine = splitHastByLine(tree, side.length);
-				side.forEach((line, i) => {
-					const row = rows[line.rowIndex];
-					runs[line.rowIndex] = composeLineRuns(perLine[i], row.segments, row.text);
-				});
-			}
-		}
-		return runs;
+		const hunks = groupHunks(rows);
+		return {
+			oldSide: highlightSide(hunks, rows, (hunk) => hunk.old, oldLang, reread),
+			newSide: highlightSide(hunks, rows, (hunk) => hunk.new, newLang, reread),
+		};
 		// rereadCount forces a recompute once a pending highlight() resolves; the
 		// underlying highlightSync cache makes that recompute cheap (already-loaded
 		// blobs hit the cache instead of re-tokenizing).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [rows, lang, rereadCount]);
+	}, [rows, oldLang, newLang, rereadCount]);
 }

--- a/frontend/src/renderer/lib/diff-highlight.test.ts
+++ b/frontend/src/renderer/lib/diff-highlight.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import type { Root } from "hast";
+import { composeLineRuns, languageForPath, splitHastByLine } from "./diff-highlight";
+import type { DiffSegment } from "./diff-parser";
+
+// Hand-built hast fixtures — small enough to not need hastscript, and pinning the
+// exact shape splitHastByLine walks (root -> element[className] -> text).
+function el(className: string, children: Root["children"]): Root["children"][number] {
+	return { type: "element", tagName: "span", properties: { className: [className] }, children } as never;
+}
+function text(value: string): Root["children"][number] {
+	return { type: "text", value } as never;
+}
+function root(children: Root["children"]): Root {
+	return { type: "root", children };
+}
+
+describe("languageForPath", () => {
+	it("resolves common extensions to the grammar highlight.js already bundles", () => {
+		expect(languageForPath("src/App.tsx")).toBe("typescript");
+		expect(languageForPath("main.go")).toBe("go");
+		expect(languageForPath("README.md")).toBe("markdown");
+		expect(languageForPath("script.py")).toBe("python");
+	});
+
+	it("is case-insensitive, matching canonicalLanguage", () => {
+		expect(languageForPath("data.JSON")).toBe("json");
+	});
+
+	it("returns undefined for a file with no extension, never a guess", () => {
+		expect(languageForPath("Makefile")).toBeUndefined();
+	});
+
+	it("returns undefined for an extension with no bundled grammar", () => {
+		expect(languageForPath("vendor/pkg.unknown")).toBeUndefined();
+	});
+
+	it("uses the last dot in the filename, not in a parent directory", () => {
+		expect(languageForPath("src/v1.2/main.rs")).toBe("rust");
+	});
+});
+
+describe("splitHastByLine", () => {
+	it("splits a single line into its leaf runs", () => {
+		const tree = root([el("hljs-keyword", [text("func")]), text(" main() {}")]);
+		expect(splitHastByLine(tree, 1)).toEqual([
+			[
+				{ text: "func", className: "hljs-keyword" },
+				{ text: " main() {}", className: undefined },
+			],
+		]);
+	});
+
+	it("reopens an ancestor class on every line it spans", () => {
+		// One element wraps a 3-line multi-line string, exactly like a template
+		// literal or triple-quoted string tokenized by highlight.js in one call.
+		const tree = root([el("hljs-string", [text("`line1\nline2\nline3`")])]);
+		expect(splitHastByLine(tree, 3)).toEqual([
+			[{ text: "`line1", className: "hljs-string" }],
+			[{ text: "line2", className: "hljs-string" }],
+			[{ text: "line3`", className: "hljs-string" }],
+		]);
+	});
+
+	it("handles plain text mixed with classed elements across lines", () => {
+		const tree = root([text("a\n"), el("hljs-comment", [text("// b")])]);
+		expect(splitHastByLine(tree, 2)).toEqual([
+			[{ text: "a", className: undefined }],
+			[{ text: "// b", className: "hljs-comment" }],
+		]);
+	});
+
+	it("produces an empty line array for a blank source line", () => {
+		const tree = root([text("a\n\nb")]);
+		expect(splitHastByLine(tree, 3)).toEqual([
+			[{ text: "a", className: undefined }],
+			[],
+			[{ text: "b", className: undefined }],
+		]);
+	});
+});
+
+describe("composeLineRuns", () => {
+	const seg = (text: string, changed: boolean): DiffSegment => ({ text, changed });
+
+	it("falls back to plain text when neither tokens nor segments are available", () => {
+		expect(composeLineRuns(undefined, undefined, "const value = 1;")).toEqual([
+			{ text: "const value = 1;", className: undefined, changed: false },
+		]);
+	});
+
+	it("falls back to a single space for a blank line", () => {
+		expect(composeLineRuns(undefined, undefined, "")).toEqual([{ text: " ", changed: false }]);
+	});
+
+	it("applies only segment highlighting when tokens are unavailable (unsupported language)", () => {
+		const segments = [seg("const value = ", false), seg("1", true), seg(";", false)];
+		expect(composeLineRuns(undefined, segments, "const value = 1;")).toEqual([
+			{ text: "const value = ", className: undefined, changed: false },
+			{ text: "1", className: undefined, changed: true },
+			{ text: ";", className: undefined, changed: false },
+		]);
+	});
+
+	it("applies only syntax color when segments are unavailable (context row)", () => {
+		const tokens = [
+			{ text: "const", className: "hljs-keyword" },
+			{ text: " value = 1;", className: undefined },
+		];
+		expect(composeLineRuns(tokens, undefined, "const value = 1;")).toEqual([
+			{ text: "const", className: "hljs-keyword", changed: false },
+			{ text: " value = 1;", className: undefined, changed: false },
+		]);
+	});
+
+	it("composes a token spanning multiple segments", () => {
+		// "value1" is one hljs token but split by the segment boundary after "value".
+		const tokens = [{ text: "value1", className: "hljs-variable" }];
+		const segments = [seg("value", false), seg("1", true)];
+		expect(composeLineRuns(tokens, segments, "value1")).toEqual([
+			{ text: "value", className: "hljs-variable", changed: false },
+			{ text: "1", className: "hljs-variable", changed: true },
+		]);
+	});
+
+	it("composes a segment spanning multiple tokens", () => {
+		// "a+b" is one changed segment but two hljs tokens (identifier, operator, identifier).
+		const tokens = [
+			{ text: "a", className: "hljs-variable" },
+			{ text: "+", className: "hljs-operator" },
+			{ text: "b", className: "hljs-variable" },
+		];
+		const segments = [seg("a+b", true)];
+		expect(composeLineRuns(tokens, segments, "a+b")).toEqual([
+			{ text: "a", className: "hljs-variable", changed: true },
+			{ text: "+", className: "hljs-operator", changed: true },
+			{ text: "b", className: "hljs-variable", changed: true },
+		]);
+	});
+
+	it("composes boundary-aligned tokens and segments without an off-by-one", () => {
+		const tokens = [
+			{ text: "old", className: "hljs-variable" },
+			{ text: "New", className: "hljs-variable" },
+		];
+		const segments = [seg("old", false), seg("New", true)];
+		expect(composeLineRuns(tokens, segments, "oldNew")).toEqual([
+			{ text: "old", className: "hljs-variable", changed: false },
+			{ text: "New", className: "hljs-variable", changed: true },
+		]);
+	});
+});

--- a/frontend/src/renderer/lib/diff-highlight.ts
+++ b/frontend/src/renderer/lib/diff-highlight.ts
@@ -1,0 +1,121 @@
+// Syntax coloring for diff lines, layered on top of the structural diff
+// (diff-parser.ts) and the chat surface's highlight.js engine (code-highlight.ts).
+// Pure, no React, no DOM — the sync/async orchestration lives in
+// hooks/useDiffHighlight.ts.
+
+import type { Root, RootContent } from "hast";
+import { canonicalLanguage, type GrammarName } from "./code-highlight";
+import type { DiffSegment } from "./diff-parser";
+
+/** One leaf run of a tokenized diff line: its text and highlight.js class, if any. */
+export type LineToken = { text: string; className?: string };
+
+/** One rendered run of a diff line: text, optional syntax class, and whether it changed. */
+export type DiffRun = { text: string; className?: string; changed: boolean };
+
+// A file extension is already what canonicalLanguage's alias table expects (it
+// resolves fence labels like "ts"/"go"/"py", which are the same strings as the
+// extensions themselves) — no separate map to maintain. A path with no extension,
+// or one canonicalLanguage doesn't recognize, resolves to undefined: those rows
+// render exactly as they do today, never a guess.
+export function languageForPath(path: string): GrammarName | undefined {
+	const base = path.slice(path.lastIndexOf("/") + 1);
+	const dot = base.lastIndexOf(".");
+	if (dot === -1) return undefined;
+	return canonicalLanguage(base.slice(dot + 1));
+}
+
+// Splits a hast tree produced by tokenizing a whole multi-line blob in one call
+// into one leaf-run array per source line. Walking the tree once and only
+// resetting the line accumulator (never the ancestor class list) on a newline is
+// what lets an element spanning multiple lines — a multi-line string or block
+// comment — correctly "reopen" on every line it covers.
+export function splitHastByLine(root: Root, lineCount: number): LineToken[][] {
+	const lines: LineToken[][] = Array.from({ length: lineCount }, () => []);
+	let lineIndex = 0;
+
+	function pushRun(text: string, className: string | undefined): void {
+		if (text === "") return;
+		const line = lines[lineIndex];
+		if (!line) return; // defensive: more line breaks than the caller expected
+		const last = line[line.length - 1];
+		if (last && last.className === className) last.text += text;
+		else line.push({ text, className });
+	}
+
+	function walk(nodes: readonly RootContent[], classNames: readonly string[]): void {
+		for (const node of nodes) {
+			if (node.type === "text") {
+				const parts = node.value.split("\n");
+				const className = classNames.length ? classNames.join(" ") : undefined;
+				parts.forEach((part, i) => {
+					if (i > 0) lineIndex += 1;
+					pushRun(part, className);
+				});
+			} else if (node.type === "element") {
+				const raw = node.properties?.className;
+				const names = Array.isArray(raw) ? raw.map(String) : [];
+				walk(node.children, names.length ? [...classNames, ...names] : classNames);
+			}
+		}
+	}
+
+	walk(root.children, []);
+	return lines;
+}
+
+type TextRun = { text: string; className?: string };
+
+// Merges two independent partitions of the same string — highlight.js's token
+// boundaries and the existing LCS word-diff's segment boundaries — into their
+// finest joint partition, via a two-pointer walk that splits whichever run ends
+// first. Both inputs are guaranteed (by construction, see composeLineRuns) to
+// cover exactly the same text, so this never needs to guess where one ends.
+function mergeRuns(tokenRuns: TextRun[], segRuns: DiffSegment[]): DiffRun[] {
+	const result: DiffRun[] = [];
+	let ti = 0;
+	let si = 0;
+	let tOffset = 0;
+	let sOffset = 0;
+	while (ti < tokenRuns.length && si < segRuns.length) {
+		const t = tokenRuns[ti];
+		const s = segRuns[si];
+		const take = Math.min(t.text.length - tOffset, s.text.length - sOffset);
+		const text = t.text.slice(tOffset, tOffset + take);
+		pushMerged(result, text, t.className, s.changed);
+		tOffset += take;
+		sOffset += take;
+		if (tOffset >= t.text.length) {
+			ti += 1;
+			tOffset = 0;
+		}
+		if (sOffset >= s.text.length) {
+			si += 1;
+			sOffset = 0;
+		}
+	}
+	return result;
+}
+
+function pushMerged(result: DiffRun[], text: string, className: string | undefined, changed: boolean): void {
+	if (text === "") return;
+	const last = result[result.length - 1];
+	if (last && last.className === className && last.changed === changed) last.text += text;
+	else result.push({ text, className, changed });
+}
+
+// Composes highlight.js's per-line tokens with the existing intra-line word-diff
+// segments into what a diff row actually renders. Degenerates exactly to today's
+// output when an input is missing: no tokens -> segments-only (color-free, same as
+// the old DiffLineSegments); no segments -> colored, unhighlighted line; neither ->
+// today's plain-text fallback.
+export function composeLineRuns(
+	tokens: LineToken[] | undefined,
+	segments: DiffSegment[] | undefined,
+	text: string,
+): DiffRun[] {
+	if (text === "") return [{ text: " ", changed: false }];
+	const tokenRuns: TextRun[] = tokens && tokens.length > 0 ? tokens : [{ text, className: undefined }];
+	const segRuns: DiffSegment[] = segments && segments.length > 0 ? segments : [{ text, changed: false }];
+	return mergeRuns(tokenRuns, segRuns);
+}


### PR DESCRIPTION
## Summary
- Adds syntax highlighting to the file-diff review panel (`SessionFilesView`), composed with the existing exact-changed-word highlight.
- Reuses the app's existing `lowlight`/highlight.js engine and theme (`code-highlight.ts`, `code-theme.css`) rather than introducing Shiki — this app's CSP (`script-src 'self'`, no `wasm-unsafe-eval`) blocks Shiki's default WASM engine, which is exactly why that engine was chosen for chat code blocks in the first place. No new dependency is added.
- Diff lines are tokenized per hunk-side blob (not per line), so highlight.js's grammar state carries correctly across line breaks — a multi-line comment or string colors correctly even when a diff line inside it changed.
- `code-theme.css` is extended to a second `.diff-code` scope, so diff colors and chat code-block colors are the same palette and both follow the app's light/dark toggle instantly with no re-tokenizing.

## Test plan
- [x] `diff-highlight.test.ts` — 16 new unit tests for the pure line-splitting/composition functions
- [x] `useDiffHighlight.test.ts` — 3 new hook tests, including a real cross-line-state test through the actual highlight.js engine
- [x] Existing `SessionFilesView.test.tsx` (31 tests) passes unmodified — no regressions
- [x] Full frontend typecheck and test suite run clean (pre-existing, unrelated failures only: macOS-only packaging/updater tests on a non-macOS dev machine, and a separate `landing` sub-app missing its own dependency)
- [x] Manually verified in the real Electron app (isolated dev mode) — confirmed by the requester

🤖 Generated with [Claude Code](https://claude.com/claude-code)