### PR TITLE
fix: tidy chat message chrome and turn duration display

### DIFF
--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -131,7 +131,10 @@ function shortenPaths(text: string): string {
 
 function formatDuration(ms: number): string {
 	if (ms < 1000) return `${ms}ms`;
-	if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+	if (ms < 60_000) {
+		// Drop a trailing ".0" so whole seconds read as "3s", not "3.0s".
+		return `${(ms / 1000).toFixed(1).replace(/\.0$/, "")}s`;
+	}
 	return `${Math.round(ms / 60_000)}m`;
 }
 
@@ -207,10 +210,10 @@ export function HumanMessage({
 			) : (
 				<div
 					className={cn(
-						"cursor-chat-human-message w-fit max-w-[min(78%,560px)] rounded-[10px] border px-3 py-2.5 text-sm leading-[1.55]",
+						"cursor-chat-human-message w-fit max-w-[min(78%,560px)] rounded-[10px] px-3 py-2.5 text-sm leading-[1.55]",
 						queued
-							? "border-dashed border-border-strong bg-transparent text-muted-foreground"
-							: "border-border bg-raised text-foreground",
+							? "border border-dashed border-border-strong bg-transparent text-muted-foreground"
+							: "bg-raised text-foreground",
 					)}
 				>
 					{body ? <p className="break-words whitespace-pre-wrap text-pretty">{body}</p> : null}
@@ -241,13 +244,13 @@ export function HumanMessage({
 								type="button"
 								onClick={onEditStart}
 								aria-label="Edit user message"
-								className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground"
+								title="Edit user message"
+								className="flex items-center rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground"
 							>
 								<Pencil aria-hidden="true" className="size-3" />
-								Edit
 							</button>
 						) : null}
-						<CopyButton text={message.text} label="Copy user message" />
+						<CopyButton text={message.text} label="Copy user message" compact />
 					</div>
 					{branchPoint && onActivateBranch ? (
 						<ConversationBranchNavigator
@@ -321,6 +324,7 @@ export function AssistantMessage({
 	message,
 	showCopy = false,
 	onRollback,
+	durationMs,
 	showStreamingIndicator = message.streaming,
 }: {
 	message: ConversationMessage;
@@ -331,13 +335,16 @@ export function AssistantMessage({
 	 * answer owns both "keep this" and "undo from here".
 	 */
 	onRollback?: () => void;
+	/** How long the finished turn took; sits next to rollback on the action row. */
+	durationMs?: number;
 	/** Only the newest item can still be visibly writing; older streaming fragments
 	 * are waiting on a tool rather than missing content. */
 	showStreamingIndicator?: boolean;
 }) {
 	const visiblyStreaming = message.streaming && showStreamingIndicator;
 	const hasText = message.text.trim().length > 0;
-	const showActions = !visiblyStreaming && (showCopy || Boolean(onRollback));
+	const hasDuration = durationMs !== undefined && durationMs > 0;
+	const showActions = !visiblyStreaming && (showCopy || Boolean(onRollback) || hasDuration);
 	return (
 		<div className={cn("group/message relative", visiblyStreaming && hasText && "chat-assistant-streaming")}>
 			<ChatMarkdown text={message.text} streaming={message.streaming} />
@@ -380,6 +387,7 @@ export function AssistantMessage({
 							<Undo2 aria-hidden="true" className="size-3" />
 						</button>
 					) : null}
+					{hasDuration ? <TurnDuration durationMs={durationMs} /> : null}
 				</div>
 			) : null}
 		</div>
@@ -1696,22 +1704,29 @@ function formatTokens(tokens: number): string {
 /* turn boundary                                                               */
 /* -------------------------------------------------------------------------- */
 
+/** Turn wall-clock duration; lives on the action row next to rollback, not the Done divider. */
+export function TurnDuration({ durationMs }: { durationMs: number }) {
+	if (durationMs <= 0) return null;
+	return (
+		<span className="shrink-0 px-1 font-sans text-[12px] leading-none tabular-nums text-muted-foreground">
+			{formatDuration(durationMs)}
+		</span>
+	);
+}
+
 /**
- * How a turn ended. `interrupted` is reported as its own outcome because the
- * provider reports it that way — relabelling it as failed would misattribute a
- * deliberate cancellation.
+ * How a turn ended when it did not complete cleanly. Successful turns skip this —
+ * their duration already sits on the answer action row. `interrupted` is kept
+ * distinct from failed because the provider reports it that way.
  */
 export function TurnOutcome({
 	state,
-	durationMs,
 	error,
 }: {
-	state: "completed" | "interrupted" | "failed";
-	durationMs?: number;
+	state: "interrupted" | "failed";
 	error?: string;
 }) {
 	const copy = {
-		completed: { label: "Done", tone: "text-muted-foreground/70" },
 		interrupted: { label: "Stopped", tone: "text-muted-foreground/70" },
 		failed: { label: "Failed", tone: "text-destructive" },
 	}[state];
@@ -1722,11 +1737,6 @@ export function TurnOutcome({
 			<span className={cn("shrink-0 text-[10px] uppercase tracking-[0.08em]", copy.tone)}>
 				{copy.label}
 			</span>
-			{durationMs !== undefined && durationMs > 0 ? (
-				<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/70">
-					{formatDuration(durationMs)}
-				</span>
-			) : null}
 			{error ? (
 				<span className="max-w-[40%] shrink truncate text-[10px] text-destructive" title={error}>
 					{error}

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -65,6 +65,7 @@ import {
 	OriginMessage,
 	SteerMessage,
 	TurnChangedFiles,
+	TurnDuration,
 	TurnOutcome,
 } from "./ChatTimelineItems";
 import { HumanMessageEditor } from "./HumanMessageEditor";
@@ -1821,6 +1822,11 @@ const TurnGroup = memo(function TurnGroup({
 								? () => onRollback(group.turnId as string)
 								: undefined
 						}
+						durationMs={
+							run.items[0]?.id === copyableMessageId
+								? group.outcome?.durationMs
+								: undefined
+						}
 						showStreamingIndicator={group.live && run.items[0]?.id === latestItemId}
 					/>
 				),
@@ -1836,27 +1842,34 @@ const TurnGroup = memo(function TurnGroup({
 			{group.live ? (
 				<TurnLiveStatus startedAt={group.liveStartedAt} blocked={group.blocked} />
 			) : null}
-			{/* No assistant prose to hang the undo on — still offer it before the outcome
-			    divider so a tool-only turn is not stuck without a way back. */}
-			{canRollback && !copyableMessageId ? (
-				<div className="mt-2 flex h-[18px] items-center">
-					<button
-						type="button"
-						onClick={() => onRollback(group.turnId as string)}
-						aria-label="Roll back to here"
-						title="Roll back to here"
-						className="flex items-center rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground"
-					>
-						<Undo2 aria-hidden="true" className="size-3" />
-					</button>
+			{/* No assistant prose to hang the undo / duration on — still offer them
+			    before the outcome divider so a tool-only turn is not stuck without a
+			    way back or a record of how long it took. */}
+			{!copyableMessageId &&
+			(canRollback ||
+				(group.outcome?.durationMs !== undefined && group.outcome.durationMs > 0)) ? (
+				<div className="mt-2 flex h-[18px] items-center gap-0.5">
+					{canRollback ? (
+						<button
+							type="button"
+							onClick={() => onRollback(group.turnId as string)}
+							aria-label="Roll back to here"
+							title="Roll back to here"
+							className="flex items-center rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground"
+						>
+							<Undo2 aria-hidden="true" className="size-3" />
+						</button>
+					) : null}
+					{group.outcome?.durationMs !== undefined && group.outcome.durationMs > 0 ? (
+						<TurnDuration durationMs={group.outcome.durationMs} />
+					) : null}
 				</div>
 			) : null}
-			{group.outcome ? (
-				<TurnOutcome
-					state={group.outcome.state}
-					durationMs={group.outcome.durationMs}
-					error={group.outcome.error}
-				/>
+			{/* Completed turns need no divider — duration lives on the action row.
+			    Interrupted/failed still get a labelled boundary so the reader can see
+			    how the turn ended. */}
+			{group.outcome && group.outcome.state !== "completed" ? (
+				<TurnOutcome state={group.outcome.state} error={group.outcome.error} />
 			) : null}
 		</div>
 	);
@@ -1932,6 +1945,7 @@ function TimelineItem({
 	queued,
 	showCopy,
 	onRollback,
+	durationMs,
 	showStreamingIndicator,
 }: {
 	item: ConversationItem;
@@ -1963,6 +1977,8 @@ function TimelineItem({
 	showCopy?: boolean;
 	/** Undo this finished turn from the answer that owns its copy action. */
 	onRollback?: () => void;
+	/** Finished-turn duration; shown next to rollback on the final answer. */
+	durationMs?: number;
 	/** This message is the live edge of its turn, rather than an earlier fragment
 	 * followed by tool activity. */
 	showStreamingIndicator?: boolean;
@@ -1974,6 +1990,7 @@ function TimelineItem({
 					message={item}
 					showCopy={showCopy}
 					onRollback={onRollback}
+					durationMs={durationMs}
 					showStreamingIndicator={showStreamingIndicator}
 				/>
 			);


### PR DESCRIPTION
## Summary
- Move finished-turn duration onto the answer action row (next to copy/rollback) in Geist Sans; show whole seconds as `3s` instead of `3.0s`
- Drop the border on user message bubbles
- Make user edit/copy actions icon-only to match assistant actions

## Test plan
- [ ] Send a short chat turn and confirm duration shows as `Ns` when whole seconds, `N.Ms` when fractional
- [ ] Confirm duration sits on the assistant action row, not a Done divider
- [ ] Hover a user message: edit and copy are icon-only; bubble has no border
- [ ] Queued user messages still show the dashed border

## Screenshot 

<img width="916" height="365" alt="image" src="https://github.com/user-attachments/assets/5d94c599-0a47-48cc-bf08-59365b338c75" />
