### PR TITLE
fix: stop opening the collapsed sidebar on hover

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -118,12 +118,9 @@ export const SIDEBAR_MAX_WIDTH = 420;
 type SidebarProps = {
 	/** Hide the sidebar's right edge stroke on the welcome board inset chrome. */
 	hideEdgeBorder?: boolean;
-	/** Render the expanded sidebar over content without reserving layout width. */
-	isOverlay?: boolean;
 	underTopbar?: boolean;
 	/** Chrome height to clear when underTopbar is set. Defaults to --size-toolbar. */
 	topbarOffset?: "toolbar" | "titlebar" | "trafficLights" | "session";
-	onPreviewLeave?: () => void;
 	workspaceError?: string;
 	workspaces: WorkspaceSummary[];
 	onCloneProject: (input: CloneProjectInput) => Promise<void>;
@@ -169,15 +166,11 @@ function SessionStatusDot({ session }: { session: WorkspaceSession }) {
 }
 
 // Built on shadcn's sidebar primitives (components/ui/sidebar): the provider in
-// _shell owns the persistent open state plus a transient hover-preview state.
-// Collapsed sidebars move fully off-canvas; previews return as overlays without
-// reserving layout width.
+// _shell owns the persistent open state. Collapsed sidebars move fully off-canvas.
 export function Sidebar({
 	hideEdgeBorder = false,
-	isOverlay = false,
 	underTopbar = true,
 	topbarOffset = "toolbar",
-	onPreviewLeave,
 	workspaceError,
 	workspaces,
 	onCloneProject,
@@ -256,30 +249,20 @@ export function Sidebar({
 		});
 
 	return (
-		// Pinned sidebars start below shell chrome. Hover previews paint a
-		// full-height surface behind the titlebar while their content keeps the
-		// same chrome clearance, leaving the titlebar controls unobstructed.
+		// Pinned sidebars start below shell chrome.
 		<SidebarRoot
 			collapsible="offcanvas"
 			data-expanded-chrome={expandedChromeVisible ? "visible" : "hidden"}
 			data-topbar-offset={underTopbar ? topbarOffset : undefined}
-			onPointerLeave={onPreviewLeave}
-			overlay={isOverlay}
 			className={cn(
 				"sidebar-focusless",
 				hideEdgeBorder ? "border-transparent" : "border-r-0 group-data-[side=left]:border-r-0",
-				isOverlay && "z-sidebar-preview shadow-2xl",
-				isOverlay || !underTopbar
+				!underTopbar
 					? "top-0 h-svh!"
 					: "top-(--sidebar-chrome-offset) h-[calc(100svh-var(--sidebar-chrome-offset))]!",
 			)}
 		>
-			<SidebarHeader
-				className={cn(
-					"gap-0 p-0 px-3 pt-2 group-data-[collapsible=icon]:px-1.5 group-data-[collapsible=icon]:pt-2",
-					isOverlay && underTopbar && "pt-(--sidebar-chrome-offset)!",
-				)}
-			>
+			<SidebarHeader className="gap-0 p-0 px-3 pt-2 group-data-[collapsible=icon]:px-1.5 group-data-[collapsible=icon]:pt-2">
 				{/* Brand (project-sidebar__brand); in the icon rail it becomes the old
             36px board button wrapping the 22px accent mark. */}
 				<div

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -12,9 +12,9 @@ const noDragStyle = isMac
   : undefined;
 
 // Sidebar chrome cluster (sidebar toggle + history arrows). It stays fixed while
-// the sidebar expands, collapses, or appears as a hover preview. macOS pins it
-// beside the traffic lights; Linux has no traffic lights, so it sits at the
-// sidebar's top-left. (Windows keeps these controls in its own titlebar.)
+// the sidebar expands or collapses. macOS pins it beside the traffic lights;
+// Linux has no traffic lights, so it sits at the sidebar's top-left. (Windows
+// keeps these controls in its own titlebar.)
 // The installed router has no useCanGoForward, and deriving one as
 // `__TSR_index < history.length - 1` (the upstream hook's approach) is wrong
 // here: window.history.length also counts entries the router never created —
@@ -42,12 +42,10 @@ export function TitlebarNav({
   historyLocked = false,
   hasSessionTopbar = false,
   isFullScreen = false,
-  onSidebarPreviewEnter,
 }: {
   historyLocked?: boolean;
   hasSessionTopbar?: boolean;
   isFullScreen?: boolean;
-  onSidebarPreviewEnter?: React.PointerEventHandler<HTMLButtonElement>;
 }) {
   const { t } = useTranslation();
   const { isSidebarOpen, toggleSidebar } = useUiStore();
@@ -92,7 +90,6 @@ export function TitlebarNav({
           isSidebarOpen ? t("shell.collapseSidebar") : t("shell.expandSidebar")
         }
         onClick={toggleSidebar}
-        onPointerEnter={onSidebarPreviewEnter}
         title={
           isSidebarOpen
             ? t("titlebar.collapseSidebarShortcut")
@@ -127,7 +124,6 @@ function TitlebarButton({
   disabled,
   tabIndex,
   onClick,
-  onPointerEnter,
   children,
 }: {
   label: string;
@@ -135,7 +131,6 @@ function TitlebarButton({
   disabled?: boolean;
   tabIndex?: number;
   onClick: () => void;
-  onPointerEnter?: React.PointerEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
 }) {
   return (
@@ -145,7 +140,6 @@ function TitlebarButton({
       className="grid size-control-md place-items-center rounded-md text-passive transition-colors hover:bg-interactive-hover hover:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:bg-transparent disabled:hover:text-passive"
       disabled={disabled}
       onClick={onClick}
-      onPointerEnter={onPointerEnter}
       style={noDragStyle}
       tabIndex={tabIndex}
       title={title}

--- a/frontend/src/renderer/components/WindowTitlebar.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.tsx
@@ -138,11 +138,7 @@ function WindowControls({
   );
 }
 
-export function WindowTitlebar({
-  onSidebarPreviewEnter,
-}: {
-  onSidebarPreviewEnter?: React.PointerEventHandler<HTMLButtonElement>;
-}) {
+export function WindowTitlebar() {
   const { t } = useTranslation();
   const { isSidebarOpen, toggleSidebar } = useUiStore();
   const router = useRouter();
@@ -191,7 +187,6 @@ export function WindowTitlebar({
         }
         className="window-titlebar__toggle"
         onClick={toggleSidebar}
-        onPointerEnter={onSidebarPreviewEnter}
         title={
           isSidebarOpen
             ? t("shell.collapseSidebarTitle")

--- a/frontend/src/renderer/components/ui/sidebar.tsx
+++ b/frontend/src/renderer/components/ui/sidebar.tsx
@@ -154,7 +154,6 @@ function Sidebar({
 	side = "left",
 	variant = "sidebar",
 	collapsible = "offcanvas",
-	overlay = false,
 	className,
 	children,
 	...props
@@ -162,7 +161,6 @@ function Sidebar({
 	side?: "left" | "right";
 	variant?: "sidebar" | "floating" | "inset";
 	collapsible?: "offcanvas" | "icon" | "none";
-	overlay?: boolean;
 }) {
 	const { t } = useTranslation();
 	const prefersReducedMotion = useReducedMotion();
@@ -214,7 +212,7 @@ function Sidebar({
 	// Target width for the gap placeholder. Animating the actual width lets the
 	// flex sibling <main> follow in real time instead of snapping separately.
 	const gapTargetWidth =
-		overlay || isOffcanvasCollapsed
+		isOffcanvasCollapsed
 			? 0
 			: isIconCollapsed
 				? variant === "floating" || variant === "inset"
@@ -232,7 +230,6 @@ function Sidebar({
 			className="group peer hidden text-sidebar-foreground md:block"
 			data-state={state}
 			data-collapsible={state === "collapsed" ? collapsible : ""}
-			data-overlay={overlay ? "true" : "false"}
 			data-variant={variant}
 			data-side={side}
 			data-slot="sidebar"

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -142,8 +142,6 @@ function ShellLayout() {
 	const handledShellNonceRef = useRef(newShellTerminalNonce);
 	const [isKeyboardShortcutsOpen, setIsKeyboardShortcutsOpen] = useState(false);
 	const [isKeyboardShortcutsSettingsOpen, setIsKeyboardShortcutsSettingsOpen] = useState(false);
-	const [isSidebarPeekOpen, setIsSidebarPeekOpen] = useState(false);
-	const sidebarPeekCloseTimerRef = useRef<number | undefined>(undefined);
 	const routeParams = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
 	useEffect(() => {
 		document.addEventListener("click", handleModifierLinkClick);
@@ -262,27 +260,6 @@ function ShellLayout() {
 		!usesPreviewWorkspaceData &&
 		!daemonStatus.code &&
 		(daemonStatus.state !== "ready" || workspaceStartupState === "loading");
-	const cancelSidebarPeekClose = useCallback(() => {
-		if (sidebarPeekCloseTimerRef.current === undefined) return;
-		window.clearTimeout(sidebarPeekCloseTimerRef.current);
-		sidebarPeekCloseTimerRef.current = undefined;
-	}, []);
-
-	const previewSidebar = useCallback(() => {
-		if (isSidebarOpen) return;
-		cancelSidebarPeekClose();
-		setIsSidebarPeekOpen(true);
-	}, [cancelSidebarPeekClose, isSidebarOpen]);
-
-	const scheduleSidebarPeekClose = useCallback(() => {
-		if (isSidebarOpen) return;
-		cancelSidebarPeekClose();
-		sidebarPeekCloseTimerRef.current = window.setTimeout(() => {
-			setIsSidebarPeekOpen(false);
-			sidebarPeekCloseTimerRef.current = undefined;
-		}, 140);
-	}, [cancelSidebarPeekClose, isSidebarOpen]);
-
 	const navigateSession = useCallback(
 		(direction: -1 | 1) => {
 			if (!scopedProjectId) return;
@@ -599,47 +576,6 @@ function ShellLayout() {
 	}, [themePreference]);
 
 	useEffect(() => {
-		if (!isSidebarOpen) return;
-		cancelSidebarPeekClose();
-		setIsSidebarPeekOpen(false);
-	}, [cancelSidebarPeekClose, isSidebarOpen]);
-
-	useEffect(() => cancelSidebarPeekClose, [cancelSidebarPeekClose]);
-
-	useEffect(() => {
-		if (!isSidebarPeekOpen || isSidebarOpen) return;
-
-		const handlePointerMove = (event: PointerEvent) => {
-			const target = event.target instanceof Element ? event.target : null;
-			const isInSidebarPortal = Boolean(target?.closest('[role="dialog"], [role="listbox"], [role="menu"]'));
-			// TitlebarNav / WindowTitlebar sit above the peek in z-order; keep the
-			// preview open while the pointer is on those controls so hover→click
-			// to pin still works.
-			const isInTitlebarChrome = Boolean(
-				target?.closest("[data-slot='titlebar-nav'], .window-titlebar"),
-			);
-			const sidebar = document.querySelector<HTMLElement>('[data-slot="sidebar-container"]');
-			const bounds = sidebar?.getBoundingClientRect();
-			const isInSidebar = Boolean(
-				bounds &&
-				event.clientX >= bounds.left &&
-				event.clientX <= bounds.right &&
-				event.clientY >= bounds.top &&
-				event.clientY <= bounds.bottom,
-			);
-
-			if (isInSidebar || isInSidebarPortal || isInTitlebarChrome) {
-				cancelSidebarPeekClose();
-				return;
-			}
-			scheduleSidebarPeekClose();
-		};
-
-		window.addEventListener("pointermove", handlePointerMove);
-		return () => window.removeEventListener("pointermove", handlePointerMove);
-	}, [cancelSidebarPeekClose, isSidebarOpen, isSidebarPeekOpen, scheduleSidebarPeekClose]);
-
-	useEffect(() => {
 		if (daemonStatus.state !== "ready" || !daemonStatus.port) return;
 		if (agentCatalogPortRef.current === daemonStatus.port) return;
 
@@ -830,7 +766,7 @@ function ShellLayout() {
 				{/* Windows-only custom title bar (sidebar toggle + File/Edit/View/…
             menu); paints the chrome the frameless window drops. Renders null on
             macOS/Linux. */}
-				<WindowTitlebar onSidebarPreviewEnter={previewSidebar} />
+				<WindowTitlebar />
 				{/* App routes render their topbar inside the framed panel, matching the board chrome across platforms while leaving OS titlebars native. */}
 				{!framedAppTopbar && !hideShellTopbar && !routeParams.sessionId ? <ShellTopbar /> : null}
 				{/* Controlled by the ui-store so TitlebarNav / Topbar toggles (which
@@ -840,11 +776,9 @@ function ShellLayout() {
 					className="min-h-0 flex-1 flex-col overflow-x-hidden"
 					keyboardShortcut={false}
 					onOpenChange={(open) => {
-						cancelSidebarPeekClose();
-						setIsSidebarPeekOpen(false);
 						if (open !== isSidebarOpen) toggleSidebar();
 					}}
-					open={!isStartupLoading && (isSidebarOpen || isSidebarPeekOpen)}
+					open={!isStartupLoading && isSidebarOpen}
 					style={
 						{
 							"--sidebar-width": "var(--ao-sidebar-w, var(--size-sidebar-default))",
@@ -858,8 +792,6 @@ function ShellLayout() {
               below its custom titlebar. */}
 				<Sidebar
 					hideEdgeBorder={isWelcomeBoard}
-					isOverlay={isSidebarPeekOpen && !isSidebarOpen}
-					onPreviewLeave={scheduleSidebarPeekClose}
 					underTopbar={isMac || isWindows || isLinux}
 						topbarOffset={isWindows ? "titlebar" : hideShellTopbar ? "trafficLights" : "toolbar"}
 						onCloneProject={cloneProject}
@@ -930,7 +862,6 @@ function ShellLayout() {
 						hasSessionTopbar={Boolean(routeParams.sessionId)}
 						historyLocked={isWelcomeBoard}
 						isFullScreen={isFullScreen}
-						onSidebarPreviewEnter={previewSidebar}
 					/>
 				</SidebarProvider>
 				<OrchestratorReplacementDialog

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -455,7 +455,7 @@
 }
 
 /* A fully hidden sidebar no longer contributes a left layout gutter. Restore
- * the shared frame inset while transient hover previews overlay this surface. */
+ * the shared frame inset. */
 .sidebar-hidden .center-panel-shell {
 	padding-left: var(--size-center-panel-inline-inset);
 }

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -162,14 +162,13 @@ vi.mock("../components/ShellTopbar", () => ({ ShellTopbar: () => null }));
 vi.mock("../components/TitlebarNav", async () => {
 	const { useUiStore: useStore } = await vi.importActual<typeof import("../stores/ui-store")>("../stores/ui-store");
 	return {
-		TitlebarNav: ({ onSidebarPreviewEnter }: { onSidebarPreviewEnter?: () => void }) => {
+		TitlebarNav: () => {
 			const isSidebarOpen = useStore((state) => state.isSidebarOpen);
 			const toggleSidebar = useStore((state) => state.toggleSidebar);
 			return (
 				<button
 					aria-label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
 					onClick={toggleSidebar}
-					onPointerEnter={onSidebarPreviewEnter}
 					type="button"
 				/>
 			);
@@ -208,11 +207,11 @@ vi.mock("../components/GlobalNewTaskDialog", async () => {
 vi.mock("../components/Sidebar", async () => {
 	const { useUiStore: useStore } = await vi.importActual<typeof import("../stores/ui-store")>("../stores/ui-store");
 	return {
-		Sidebar: ({ isOverlay, onPreviewLeave, topbarOffset }: { isOverlay?: boolean; onPreviewLeave?: () => void; topbarOffset?: string }) => {
+		Sidebar: ({ topbarOffset }: { topbarOffset?: string }) => {
 			const nonce = useStore((state) => state.createProjectNonce);
 			const folderDropRequest = useStore((state) => state.folderDropRequest);
 			return (
-				<div data-overlay={isOverlay ? "true" : "false"} data-testid="sidebar" data-topbar-offset={topbarOffset} onPointerLeave={onPreviewLeave}>
+				<div data-testid="sidebar" data-topbar-offset={topbarOffset}>
 					{nonce > 0 || folderDropRequest ? (
 						<div data-path={folderDropRequest?.path} data-testid="create-project-flow" />
 					) : null}
@@ -424,35 +423,26 @@ describe("shell workspace startup", () => {
 	});
 });
 
-describe("shell sidebar hover preview", () => {
-	it("temporarily overlays a collapsed sidebar from the titlebar toggle and closes after pointer leave", async () => {
+describe("shell sidebar toggle", () => {
+	it("does not open a collapsed sidebar on titlebar hover", async () => {
 		useUiStore.setState({ isSidebarOpen: false });
 		await renderShell();
 
 		const provider = screen.getByTestId("sidebar-provider");
-		const sidebar = screen.getByTestId("sidebar");
-		const previewTrigger = screen.getByRole("button", { name: "Expand sidebar" });
-		expect(screen.queryByRole("button", { name: "Preview sidebar" })).not.toBeInTheDocument();
+		const expandTrigger = screen.getByRole("button", { name: "Expand sidebar" });
 
 		expect(provider).toHaveAttribute("data-open", "false");
-		fireEvent.pointerEnter(previewTrigger);
+		fireEvent.pointerEnter(expandTrigger);
 
-		expect(provider).toHaveAttribute("data-open", "true");
-		expect(sidebar).toHaveAttribute("data-overlay", "true");
-		expect(useUiStore.getState().isSidebarOpen).toBe(false);
-
-		fireEvent.pointerMove(window, { clientX: 500, clientY: 300 });
-		await waitFor(() => expect(provider).toHaveAttribute("data-open", "false"));
+		expect(provider).toHaveAttribute("data-open", "false");
 		expect(useUiStore.getState().isSidebarOpen).toBe(false);
 	});
 
-	it("pins the sidebar open when the titlebar toggle is clicked", async () => {
+	it("opens the sidebar when the titlebar toggle is clicked", async () => {
 		useUiStore.setState({ isSidebarOpen: false });
 		await renderShell();
 
-		const previewTrigger = screen.getByRole("button", { name: "Expand sidebar" });
-		fireEvent.pointerEnter(previewTrigger);
-		fireEvent.click(previewTrigger);
+		fireEvent.click(screen.getByRole("button", { name: "Expand sidebar" }));
 
 		expect(useUiStore.getState().isSidebarOpen).toBe(true);
 		expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "true");


### PR DESCRIPTION
## Summary
- Remove the collapsed-sidebar hover peek so the left panel stays closed until the titlebar toggle is clicked (or the keyboard shortcut is used).
- Drop the overlay/peek wiring from the shell, macOS/Linux `TitlebarNav`, and Windows `WindowTitlebar`.
- Cover the new behavior: hover does not open; click still does.

## Test plan
- [ ] Collapse the sidebar on macOS, Windows, and Linux
- [ ] Hover the sidebar toggle and confirm the panel does not open
- [ ] Click the toggle and confirm it still opens/closes
- [ ] Confirm the keyboard shortcut still toggles the sidebar