### PR TITLE
fix(session): do not apply a role override's model across harnesses

### DIFF
--- a/backend/internal/session_manager/agent_switching.go
+++ b/backend/internal/session_manager/agent_switching.go
@@ -1139,11 +1139,7 @@ func (m *Manager) prepareTargetActivation(ctx context.Context, store ports.Agent
 	if err != nil {
 		return preparedTargetActivation{}, fmt.Errorf("system prompt file: %w", err)
 	}
-	config := effectiveAgentConfig(rec.Kind, project.Config)
-	if roleOverride(rec.Kind, project.Config).Harness != harness {
-		config.Model = ""
-		config.Mode = ""
-	}
+	config := effectiveAgentConfig(harness, rec.Kind, project.Config)
 	if model := strings.TrimSpace(modelOverride); model != "" {
 		config.Model = model
 	}

--- a/backend/internal/session_manager/agent_switching_chat.go
+++ b/backend/internal/session_manager/agent_switching_chat.go
@@ -143,11 +143,7 @@ func (m *Manager) executeChatAgentSwitch(
 		return result, fmt.Errorf("switch Chat agent %s: system prompt: %w", id, err)
 	}
 	systemPrompt = appendAgentContinuationProtocol(systemPrompt)
-	agentConfig := effectiveAgentConfig(rec.Kind, project.Config)
-	if roleOverride(rec.Kind, project.Config).Harness != cfg.TargetHarness {
-		agentConfig.Model = ""
-		agentConfig.Mode = ""
-	}
+	agentConfig := effectiveAgentConfig(cfg.TargetHarness, rec.Kind, project.Config)
 	if model := strings.TrimSpace(cfg.Model); model != "" {
 		agentConfig.Model = model
 	}
@@ -489,7 +485,7 @@ func (m *Manager) rollbackStoppedChatAgentSwitchSource(
 	if err != nil {
 		return err
 	}
-	agentConfig := effectiveAgentConfig(rec.Kind, project.Config)
+	agentConfig := effectiveAgentConfig(rec.Harness, rec.Kind, project.Config)
 	env := m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env)
 	m.augmentAgentRuntimeEnv(sourceAgent, env)
 	if err := m.prepareWorkspace(

--- a/backend/internal/session_manager/chat_spawn.go
+++ b/backend/internal/session_manager/chat_spawn.go
@@ -126,7 +126,7 @@ type chatSpawn struct {
 func (m *Manager) launchChatController(ctx context.Context, in chatSpawn) (domain.SessionRecord, error) {
 	id := in.record.ID
 	agentConfig := applySpawnAgentConfig(
-		effectiveAgentConfig(in.cfg.Kind, in.project.Config),
+		effectiveAgentConfig(in.cfg.Harness, in.cfg.Kind, in.project.Config),
 		in.cfg.AgentConfig,
 	)
 
@@ -312,7 +312,7 @@ func (m *Manager) resumeChatController(
 		return RestoreResult{}, fmt.Errorf("%s %s: switched continuation: %w", operation, rec.ID, err)
 	}
 
-	agentConfig := effectiveAgentConfig(rec.Kind, project.Config)
+	agentConfig := effectiveAgentConfig(rec.Harness, rec.Kind, project.Config)
 	additionalDirectories, err := m.restoredWorkspaceProjectDirectories(ctx, rec, project, ws.Path)
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("%s %s: workspace roots: %w", operation, rec.ID, err)

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -643,7 +643,7 @@ func (m *Manager) preflightInterfaceTarget(
 	if err != nil {
 		return err
 	}
-	config := effectiveAgentConfig(rec.Kind, project.Config)
+	config := effectiveAgentConfig(rec.Harness, rec.Kind, project.Config)
 	var cmd []string
 	if transition.NativeConversationID == "" {
 		cmd, _, _, err = freshLaunchArgv(ctx, agent, rec.ID, rec.Metadata.WorkspacePath,

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -722,7 +722,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	// Resolve the effective agent config (project base + role override + spawn
 	// override) and validate the model before any durable state is created. A
 	// model the harness cannot honor should not leave a seed row behind.
-	agentConfig := applySpawnAgentConfig(effectiveAgentConfig(cfg.Kind, project.Config), cfg.AgentConfig)
+	agentConfig := applySpawnAgentConfig(effectiveAgentConfig(cfg.Harness, cfg.Kind, project.Config), cfg.AgentConfig)
 	if err := validateSpawnModel(cfg.Harness, agentConfig.Model); err != nil {
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: %w: %s", ErrUnsupportedModel, err.Error())
 	}
@@ -1251,17 +1251,33 @@ func roleConfigName(kind domain.SessionKind) string {
 
 // effectiveAgentConfig merges the role override's agent config over the
 // project's base agent config; set override fields win.
-func effectiveAgentConfig(kind domain.SessionKind, cfg domain.ProjectConfig) ports.AgentConfig {
+//
+// The override's Model and Mode are chosen FOR its pinned harness. When the
+// session resolves to a different harness — an explicit spawn harness, a
+// restored switched continuation, or an agent-switch target — they are skipped:
+// launching one harness with another's model ids fails at launch (the bug that
+// let a codex/gpt role override break explicit claude-code spawns). Permissions
+// stay: they are not harness-specific. An override with no pinned harness keeps
+// its old apply-unconditionally behavior.
+func effectiveAgentConfig(harness domain.AgentHarness, kind domain.SessionKind, cfg domain.ProjectConfig) ports.AgentConfig {
 	merged := cfg.AgentConfig
-	override := roleOverride(kind, cfg).AgentConfig
-	if override.Model != "" {
-		merged.Model = override.Model
+	override := roleOverride(kind, cfg)
+	if override.Harness == "" || override.Harness == harness {
+		if override.AgentConfig.Model != "" {
+			merged.Model = override.AgentConfig.Model
+		}
+		if override.AgentConfig.Mode != "" {
+			merged.Mode = override.AgentConfig.Mode
+		}
 	}
-	if override.Mode != "" {
-		merged.Mode = override.Mode
-	}
-	if override.Permissions != "" {
-		merged.Permissions = override.Permissions
+	// Permissions are harness-agnostic — PermissionMode is an abstract enum that
+	// each adapter maps onto its own agent's native approval flags — so they are
+	// applied outside the harness gate. Returning early on a mismatch would
+	// silently substitute the project baseline for the role's permission, and
+	// one direction of that substitution (role "default" over a baseline of
+	// "bypass-permissions") is a privilege escalation.
+	if override.AgentConfig.Permissions != "" {
+		merged.Permissions = override.AgentConfig.Permissions
 	}
 	return merged
 }
@@ -1917,7 +1933,7 @@ func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation strin
 
 	// Restore re-applies the project's resolved agent config so a configured
 	// model/permissions carry across a restore, matching fresh spawn.
-	agentConfig := effectiveAgentConfig(rec.Kind, project.Config)
+	agentConfig := effectiveAgentConfig(rec.Harness, rec.Kind, project.Config)
 	env, browserCapabilityVerifier, err := m.launchRuntimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env)
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("%s %s: browser capability: %w", operation, rec.ID, err)

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1252,6 +1252,156 @@ func TestSpawn_ResolvesProjectConfig(t *testing.T) {
 	}
 }
 
+// TestSpawn_CrossHarnessRoleOverride verifies that when a project's role override
+// pins one harness with a model/mode, an explicit spawn for a different harness
+// launches with the project's baseline model/mode instead of leaking the override's
+// harness-specific model/mode. It also verifies that harness-agnostic permissions
+// configured on the role override still survive across the harness mismatch, and that
+// spawns matching the role override's pinned harness receive the full override.
+func TestSpawn_CrossHarnessRoleOverride(t *testing.T) {
+	st := newFakeStore()
+	st.projects["proj"] = domain.ProjectRecord{
+		ID: "proj",
+		Config: domain.ProjectConfig{
+			AgentConfig: domain.AgentConfig{
+				Model:       "base-model",
+				Mode:        "low",
+				Permissions: domain.PermissionModeAuto,
+			},
+			// Worker role override pins Codex and specifies codex model/mode and default permissions.
+			// Permissions intentionally differs from the baseline ("auto" vs "default") so the
+			// assertion fails if the override permissions are dropped or ignored.
+			Worker: domain.RoleOverride{
+				Harness: domain.HarnessCodex,
+				AgentConfig: domain.AgentConfig{
+					Model:       "codex-model",
+					Mode:        "high",
+					Permissions: domain.PermissionModeDefault,
+				},
+			},
+		},
+	}
+	agent := &recordingAgent{}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    singleAgent{agent: agent},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: &fakeLCM{store: st},
+		LookPath:  lookPath,
+	})
+
+	// 1. Cross-harness spawn: worker role override pins Codex, but spawn explicitly asks for Claude Code.
+	// Model and Mode must NOT leak from the Codex override; they must fall back to the project baseline.
+	// Permissions is harness-agnostic, so the override's "default" permission MUST still apply.
+	recCross, _, _, err := m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "proj",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+	})
+	if err != nil {
+		t.Fatalf("cross-harness spawn: %v", err)
+	}
+
+	if recCross.Harness != domain.HarnessClaudeCode {
+		t.Fatalf("cross-harness rec.Harness = %q, want %q", recCross.Harness, domain.HarnessClaudeCode)
+	}
+	if durable, ok := st.sessions[recCross.ID]; !ok {
+		t.Fatalf("cross-harness session %s not found in store", recCross.ID)
+	} else if durable.Harness != domain.HarnessClaudeCode {
+		t.Fatalf("cross-harness durable Harness = %q, want %q", durable.Harness, domain.HarnessClaudeCode)
+	} else if durable.Metadata.Model != "base-model" {
+		t.Fatalf("cross-harness durable metadata model = %q, want baseline base-model", durable.Metadata.Model)
+	}
+
+	if recCross.Metadata.Model != "base-model" {
+		t.Fatalf("cross-harness rec.Metadata.Model = %q, want baseline base-model", recCross.Metadata.Model)
+	}
+	if agent.lastConfig.Model != "base-model" {
+		t.Fatalf("cross-harness launch config model = %q, want baseline base-model (no override leak)", agent.lastConfig.Model)
+	}
+	if agent.lastConfig.Mode != "low" {
+		t.Fatalf("cross-harness launch config mode = %q, want baseline low (no override leak)", agent.lastConfig.Mode)
+	}
+	if agent.lastConfig.Permissions != domain.PermissionModeDefault {
+		t.Fatalf("cross-harness launch config permissions = %q, want override default", agent.lastConfig.Permissions)
+	}
+	if agent.lastLaunch.Permissions != domain.PermissionModeDefault {
+		t.Fatalf("cross-harness launch permissions = %q, want override default", agent.lastLaunch.Permissions)
+	}
+
+	// 2. Matching-harness spawn (implicit harness from worker role override).
+	// Model, Mode, and Permissions from the Codex override must all apply.
+	agent.lastConfig = ports.AgentConfig{}
+	agent.lastLaunch = ports.LaunchConfig{}
+	recMatch, _, _, err := m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "proj",
+		Kind:      domain.KindWorker,
+	})
+	if err != nil {
+		t.Fatalf("matching-harness spawn: %v", err)
+	}
+
+	if recMatch.Harness != domain.HarnessCodex {
+		t.Fatalf("matching-harness rec.Harness = %q, want %q", recMatch.Harness, domain.HarnessCodex)
+	}
+	if durable, ok := st.sessions[recMatch.ID]; !ok {
+		t.Fatalf("matching-harness session %s not found in store", recMatch.ID)
+	} else if durable.Harness != domain.HarnessCodex {
+		t.Fatalf("matching-harness durable Harness = %q, want %q", durable.Harness, domain.HarnessCodex)
+	} else if durable.Metadata.Model != "codex-model" {
+		t.Fatalf("matching-harness durable metadata model = %q, want override codex-model", durable.Metadata.Model)
+	}
+
+	if recMatch.Metadata.Model != "codex-model" {
+		t.Fatalf("matching-harness rec.Metadata.Model = %q, want override codex-model", recMatch.Metadata.Model)
+	}
+	if agent.lastConfig.Model != "codex-model" {
+		t.Fatalf("matching-harness launch config model = %q, want override codex-model", agent.lastConfig.Model)
+	}
+	if agent.lastConfig.Mode != "high" {
+		t.Fatalf("matching-harness launch config mode = %q, want override high", agent.lastConfig.Mode)
+	}
+	if agent.lastConfig.Permissions != domain.PermissionModeDefault {
+		t.Fatalf("matching-harness launch config permissions = %q, want override default", agent.lastConfig.Permissions)
+	}
+	if agent.lastLaunch.Permissions != domain.PermissionModeDefault {
+		t.Fatalf("matching-harness launch permissions = %q, want override default", agent.lastLaunch.Permissions)
+	}
+
+	// 3. Explicit matching-harness spawn (explicit Harness: domain.HarnessCodex).
+	agent.lastConfig = ports.AgentConfig{}
+	agent.lastLaunch = ports.LaunchConfig{}
+	recExplicitMatch, _, _, err := m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "proj",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessCodex,
+	})
+	if err != nil {
+		t.Fatalf("explicit matching-harness spawn: %v", err)
+	}
+
+	if recExplicitMatch.Harness != domain.HarnessCodex {
+		t.Fatalf("explicit matching-harness rec.Harness = %q, want %q", recExplicitMatch.Harness, domain.HarnessCodex)
+	}
+	if agent.lastConfig.Model != "codex-model" {
+		t.Fatalf("explicit matching-harness launch config model = %q, want override codex-model", agent.lastConfig.Model)
+	}
+	if agent.lastConfig.Mode != "high" {
+		t.Fatalf("explicit matching-harness launch config mode = %q, want override high", agent.lastConfig.Mode)
+	}
+	if agent.lastConfig.Permissions != domain.PermissionModeDefault {
+		t.Fatalf("explicit matching-harness launch config permissions = %q, want override default", agent.lastConfig.Permissions)
+	}
+	if agent.lastLaunch.Permissions != domain.PermissionModeDefault {
+		t.Fatalf("explicit matching-harness launch permissions = %q, want override default", agent.lastLaunch.Permissions)
+	}
+}
+
 // TestSpawnModelValidation asserts spawn rejects models a fixed-catalog harness
 // cannot honor, while harnesses that accept arbitrary model ids pass through.
 func TestSpawnModelValidation(t *testing.T) {

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -162,7 +162,10 @@ func TestHookPATH(t *testing.T) {
 func TestEffectiveHarnessAndAgentConfig(t *testing.T) {
 	cfg := domain.ProjectConfig{
 		AgentConfig:  domain.AgentConfig{Model: "base", Mode: "low", Permissions: domain.PermissionModeAuto},
-		Worker:       domain.RoleOverride{Harness: domain.HarnessCodex, AgentConfig: domain.AgentConfig{Model: "worker", Mode: "high"}},
+		// Permissions differs from the base on purpose: with it unset, every
+		// assertion below about permissions would pass trivially by reading the
+		// base value back, whether or not the override was applied at all.
+		Worker:       domain.RoleOverride{Harness: domain.HarnessCodex, AgentConfig: domain.AgentConfig{Model: "worker", Mode: "high", Permissions: domain.PermissionModeDefault}},
 		Orchestrator: domain.RoleOverride{Harness: domain.HarnessClaudeCode},
 	}
 
@@ -178,14 +181,39 @@ func TestEffectiveHarnessAndAgentConfig(t *testing.T) {
 		t.Fatalf("orchestrator harness = %q, want claude-code", h)
 	}
 
-	// Role override merges over the base agent config (set fields win; unset keep base).
-	got := effectiveAgentConfig(domain.KindWorker, cfg)
-	if got.Model != "worker" || got.Mode != "high" || got.Permissions != domain.PermissionModeAuto {
-		t.Fatalf("merged worker config = %#v, want model=worker mode=high permissions=auto", got)
+	// Role override merges over the base agent config when the session's harness
+	// matches the override's pinned harness (set fields win; unset keep base).
+	got := effectiveAgentConfig(domain.HarnessCodex, domain.KindWorker, cfg)
+	if got.Model != "worker" || got.Mode != "high" || got.Permissions != domain.PermissionModeDefault {
+		t.Fatalf("merged worker config = %#v, want model=worker mode=high permissions=default", got)
 	}
 	// Orchestrator has no agent-config override, so the base config is used as-is.
-	if got := effectiveAgentConfig(domain.KindOrchestrator, cfg); got.Model != "base" {
+	if got := effectiveAgentConfig(domain.HarnessClaudeCode, domain.KindOrchestrator, cfg); got.Model != "base" {
 		t.Fatalf("orchestrator config = %#v, want base", got)
+	}
+
+	// A session that resolves to a harness OTHER than the override's pinned one
+	// must not inherit the override's model/mode — model ids are harness-specific.
+	// Regression: an explicit claude-code spawn in a project whose worker override
+	// pins codex+gpt used to launch claude-code with a codex model id.
+	if got := effectiveAgentConfig(domain.HarnessClaudeCode, domain.KindWorker, cfg); got.Model != "base" || got.Mode != "low" {
+		t.Fatalf("cross-harness worker config = %#v, want base model/mode (no override leak)", got)
+	}
+	// Permissions ARE harness-agnostic, so the override's permission survives a
+	// harness mismatch even though its model and mode do not. The base is "auto"
+	// and the override is "default", so this fails if the override is dropped —
+	// unlike the earlier version of this assertion, where the override set no
+	// permission at all and reading the base back looked like success.
+	if got := effectiveAgentConfig(domain.HarnessClaudeCode, domain.KindWorker, cfg); got.Permissions != domain.PermissionModeDefault {
+		t.Fatalf("cross-harness worker permissions = %#v, want the override's default (permissions are not harness-specific)", got)
+	}
+	// An override with no pinned harness keeps its apply-unconditionally behavior.
+	unpinned := domain.ProjectConfig{
+		AgentConfig: domain.AgentConfig{Model: "base"},
+		Worker:      domain.RoleOverride{AgentConfig: domain.AgentConfig{Model: "worker"}},
+	}
+	if got := effectiveAgentConfig(domain.HarnessClaudeCode, domain.KindWorker, unpinned); got.Model != "worker" {
+		t.Fatalf("unpinned override config = %#v, want model=worker", got)
 	}
 }
 


### PR DESCRIPTION
## The bug

A project role override pins a harness and carries an agent config chosen **for that harness**. `effectiveHarness` already honors an explicit spawn harness, but `effectiveAgentConfig` applied the override's agent config unconditionally.

So in a project whose worker role pins `codex` with a codex model id, an explicit `claude-code` spawn inherited that model id and **launched broken**. Found while exercising two concurrent workers on different harnesses in one project.

## The fix

`Model` and `Mode` are applied only when the resolved harness matches the override's pinned harness. An override with no pinned harness keeps its apply-unconditionally behavior, so existing single-harness projects are unaffected.

Every caller now passes the harness actually resolved for that session — the explicit spawn harness, the durable `rec.Harness` on restore and interface transitions, and the target harness on an agent switch.

## Why `Permissions` stays outside the gate

`PermissionMode` is an abstract enum that each adapter maps onto its own agent's native approval flags, so it is not harness-specific. Skipping it on a mismatch would silently substitute the project baseline for the role's permission — and one direction of that substitution, a role pinning `default` over a baseline of `bypass-permissions`, is a **privilege escalation**.

## On the test

The fixture gives the worker override a permission that differs from the base. That detail is load-bearing: with it unset, every permission assertion passes trivially by reading the base value back, whether or not the override was applied at all.

Verified by reverting the function and confirming the test fails; `go build`, `go vet` and `go test ./internal/session_manager/...` (including `-race`) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)