### PR TITLE
fix(session): escape inconclusive agent switch recovery

### DIFF
--- a/backend/internal/session_manager/agent_switching.go
+++ b/backend/internal/session_manager/agent_switching.go
@@ -3062,12 +3062,15 @@ func (m *Manager) reconcileStoppingSource(ctx context.Context, store ports.Agent
 	handle := ports.RuntimeHandle{ID: rec.Metadata.RuntimeHandleID}
 	alive, err := m.runtime.IsAlive(ctx, handle)
 	if err != nil {
-		if _, markerErr := m.markSourceStopUnconfirmed(ctx, store, sw); markerErr != nil {
-			m.logger.Warn("agent switch recovery: could not persist source-stop marker", "sessionID", sw.SessionID, "switchID", sw.ID, "error", markerErr)
-		}
-		// The source may still be live, and no target exists yet. Keep the gate
-		// closed until a later explicit recovery can prove the source boundary.
-		return false, nil
+		// Target creation is ordered strictly after the source-stopped
+		// transaction, so an inconclusive source probe cannot imply dual
+		// ownership here. Keep the durable source owner/handle unchanged and close
+		// the switch instead of fencing the session forever. Do not retry Destroy
+		// or relaunch the source: a runtime-level outage can leave the original
+		// provider alive outside the terminal adapter, and guessing otherwise
+		// would create the duplicate controller this gate exists to prevent.
+		_, failErr := m.failAgentSwitch(ctx, store, sw, domain.AgentSwitchErrorSourceStopUnconfirmed)
+		return failErr == nil, failErr
 	}
 	if alive {
 		// Target creation is ordered strictly after the source-stopped

--- a/backend/internal/session_manager/agent_switching_test.go
+++ b/backend/internal/session_manager/agent_switching_test.go
@@ -3319,6 +3319,49 @@ func TestSwitchAgentMarksAndRecoversUnconfirmedSourceStop(t *testing.T) {
 	}
 }
 
+func TestRecoverAgentSwitchReleasesSourceWhenProbeRemainsInconclusive(t *testing.T) {
+	probeErr := errors.New("runtime probe unavailable")
+	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{
+		destroyErr: errors.New("teardown unavailable"),
+		aliveErr:   probeErr,
+	}}
+	manager, store, _ := newSwitchTestManager(t, runtime)
+
+	sw, err := switchAgentSynchronously(context.Background(), manager, "proj-1", SwitchAgentConfig{
+		TargetHarness: domain.HarnessCodex, IdempotencyKey: "stop-probe-stays-inconclusive",
+	})
+	if !errors.Is(err, ErrSwitchSourceStopUnconfirmed) {
+		t.Fatalf("switch error = %v, want ErrSwitchSourceStopUnconfirmed", err)
+	}
+	if sw.State != domain.AgentSwitchStoppingSource || !sw.RequiresSourceStopRecovery() {
+		t.Fatalf("switch = state %q code %q, want retained source-stop recovery", sw.State, sw.ErrorCode)
+	}
+	destroyedBeforeRecovery := runtime.destroyed
+
+	if _, err := manager.RecoverAgentSwitch(context.Background(), "proj-1", sw.ID); err != nil {
+		t.Fatalf("recover retained source stop: %v", err)
+	}
+	waitForSwitchWorkers(t, manager)
+
+	recovered := store.switches[sw.ID]
+	if recovered.State != domain.AgentSwitchFailed || recovered.ErrorCode != domain.AgentSwitchErrorSourceStopUnconfirmed {
+		t.Fatalf("recovered switch = state %q code %q, want failed/source_stop_unconfirmed",
+			recovered.State, recovered.ErrorCode)
+	}
+	if got := store.sessions["proj-1"]; got.Harness != domain.HarnessClaudeCode || got.Metadata.RuntimeHandleID != "proj-1" {
+		t.Fatalf("source ownership changed during inconclusive recovery: %+v", got)
+	}
+	if runtime.created != 0 {
+		t.Fatalf("target or replacement runtime created %d times, want none", runtime.created)
+	}
+	if runtime.destroyed != destroyedBeforeRecovery {
+		t.Fatalf("recovery retried ambiguous teardown: destroy calls = %d, want %d", runtime.destroyed, destroyedBeforeRecovery)
+	}
+	if manager.SessionMutationInProgress("proj-1") {
+		t.Fatal("inconclusive source probe left the switch input gate closed")
+	}
+}
+
 func TestSwitchAgentInstallsTargetWorkspaceOnlyAfterFinalSourceSnapshot(t *testing.T) {
 	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{}}
 	manager, _, _ := newSwitchTestManager(t, runtime)
@@ -3536,7 +3579,7 @@ func TestReconcileAgentSwitchesUsesDurableBoundaries(t *testing.T) {
 		{name: "stopped source is restored", state: domain.AgentSwitchStoppingSource, runtimeAlive: false, wantState: domain.AgentSwitchFailed, wantHarness: domain.HarnessClaudeCode, wantErrorCode: "daemon_restart_post_stop", wantActivity: domain.ActivityIdle},
 		{name: "failed source restore remains recoverable", state: domain.AgentSwitchStoppingSource, runtimeAlive: false, rollbackErr: errors.New("source relaunch unavailable"), wantState: domain.AgentSwitchSourceStopped, wantHarness: domain.HarnessClaudeCode, wantErrorCode: domain.AgentSwitchErrorSourceRestoreUnconfirmed, wantError: "source relaunch unavailable", wantGated: true, wantActivity: domain.ActivityExited},
 		{name: "missing rollback project remains recoverable", state: domain.AgentSwitchStoppingSource, runtimeAlive: false, projectErr: errors.New("project unavailable"), wantState: domain.AgentSwitchSourceStopped, wantHarness: domain.HarnessClaudeCode, wantErrorCode: domain.AgentSwitchErrorSourceRestoreUnconfirmed, wantError: "project unavailable", wantGated: true, wantActivity: domain.ActivityExited},
-		{name: "inconclusive source probe remains available for explicit recovery", state: domain.AgentSwitchStoppingSource, runtimeErr: errors.New("probe unavailable"), wantState: domain.AgentSwitchStoppingSource, wantHarness: domain.HarnessClaudeCode, wantErrorCode: domain.AgentSwitchErrorSourceStopUnconfirmed, wantGated: true},
+		{name: "inconclusive source probe returns ownership to source", state: domain.AgentSwitchStoppingSource, runtimeErr: errors.New("probe unavailable"), wantState: domain.AgentSwitchFailed, wantHarness: domain.HarnessClaudeCode, wantErrorCode: domain.AgentSwitchErrorSourceStopUnconfirmed},
 		{name: "exact starting target is adopted by opaque handle without delivery", state: domain.AgentSwitchStartingTarget, runtimeAlive: true, targetHandle: "opaque-target-handle", wantState: domain.AgentSwitchFailed, wantHarness: domain.HarnessCodex, wantHandle: "opaque-target-handle", wantErrorCode: "daemon_restart_before_delivery"},
 		{name: "starting target without a durable handle requires recovery", state: domain.AgentSwitchStartingTarget, runtimeAlive: true, wantState: domain.AgentSwitchStartingTarget, wantHarness: domain.HarnessClaudeCode, wantErrorCode: domain.AgentSwitchErrorTargetStartUnconfirmed, wantGated: true},
 		{name: "acknowledged delivery completes", state: domain.AgentSwitchDelivering, runtimeAlive: true, acknowledged: true, wantState: domain.AgentSwitchCompleted, wantHarness: domain.HarnessCodex},

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -608,6 +608,7 @@ export function CenterPane({
 			{session ? (
 				<TerminalSwitchAgentButton
 					key={session.id}
+					agentSwitch={selectedCurrentAgentSwitch}
 					container={switchSelectorContainer}
 					onOpenChange={setSwitchSelectorOpen}
 					open={switchSelectorOpen}

--- a/frontend/src/renderer/components/SwitchAgentDialog.test.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { agentModelsQueryKey } from "../hooks/useAgentModelsQuery";
-import type { WorkspaceSession } from "../types/workspace";
+import type { AgentSwitchSummary, WorkspaceSession } from "../types/workspace";
 import { SwitchAgentDialog } from "./SwitchAgentDialog";
 
 const switchMocks = vi.hoisted(() => ({
@@ -47,7 +47,11 @@ const worker: WorkspaceSession = {
 	workspaceName: "my-app",
 };
 
-function renderDialog(session: WorkspaceSession = worker, onOpenChange = vi.fn()) {
+function renderDialog(
+	session: WorkspaceSession = worker,
+	onOpenChange = vi.fn(),
+	agentSwitch?: AgentSwitchSummary,
+) {
 	const queryClient = new QueryClient({
 		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
 	});
@@ -70,7 +74,13 @@ function renderDialog(session: WorkspaceSession = worker, onOpenChange = vi.fn()
 	}
 	const result = render(
 		<QueryClientProvider client={queryClient}>
-			<SwitchAgentDialog container={document.body} onOpenChange={onOpenChange} open session={session} />
+			<SwitchAgentDialog
+				agentSwitch={agentSwitch}
+				container={document.body}
+				onOpenChange={onOpenChange}
+				open
+				session={session}
+			/>
 		</QueryClientProvider>,
 	);
 	return { ...result, onOpenChange, queryClient };
@@ -286,5 +296,30 @@ describe("SwitchAgentDialog", () => {
 			sessionId: "sess-1",
 			switchId: "switch-source-stop-recovery",
 		});
+	});
+
+	it("releases stale recovery UI when switch history observes terminal recovery", () => {
+		const recoverySession = {
+			...worker,
+			activeAgentSwitch: {
+				agentHandoffStatus: "received",
+				errorCode: "source_stop_unconfirmed",
+				fromHarness: "claude-code",
+				id: "switch-source-stop-recovery",
+				state: "stopping_source",
+				targetHarness: "codex",
+			},
+		} satisfies WorkspaceSession;
+		const recoveredSwitch = {
+			...recoverySession.activeAgentSwitch,
+			state: "failed",
+		} satisfies AgentSwitchSummary;
+
+		renderDialog(recoverySession, vi.fn(), recoveredSwitch);
+		const dialog = screen.getByRole("dialog", { name: "Switch agent" });
+
+		expect(within(dialog).queryByText("Claude Code status could not be confirmed")).not.toBeInTheDocument();
+		expect(within(dialog).queryByRole("button", { name: "Check Claude Code" })).not.toBeInTheDocument();
+		expect(within(dialog).getByRole("button", { name: "Target agent" })).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/SwitchAgentDialog.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import {
 	agentSwitchesQueryKey,
 	agentSwitchNeedsRecovery,
+	agentSwitchNeedsSourceRecovery,
 	agentSwitchNeedsSourceStopRecovery,
 	agentSwitchNeedsSourceRestore,
 	isTerminalAgentSwitch,
@@ -19,7 +20,7 @@ import {
 } from "../hooks/useSwitchAgent";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { AGENT_LABELS, AGENT_OPTIONS, agentLabel } from "../lib/agent-options";
-import type { WorkspaceSession } from "../types/workspace";
+import type { AgentSwitchSummary, WorkspaceSession } from "../types/workspace";
 import { AgentAvatar } from "./AgentAvatar";
 import { AgentModelPicker } from "./AgentModelPicker";
 import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
@@ -107,13 +108,14 @@ function SwitchTargetPicker({
 }
 
 type SwitchAgentDialogProps = {
+	agentSwitch?: AgentSwitchSummary;
 	container: HTMLElement;
 	open: boolean;
 	session: WorkspaceSession;
 	onOpenChange: (open: boolean) => void;
 };
 
-export function SwitchAgentDialog({ container, open, session, onOpenChange }: SwitchAgentDialogProps) {
+export function SwitchAgentDialog({ agentSwitch, container, open, session, onOpenChange }: SwitchAgentDialogProps) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const defaultTargetHarness: SwitchAgentHarness = session.provider === "claude-code" ? "codex" : "claude-code";
@@ -125,11 +127,14 @@ export function SwitchAgentDialog({ container, open, session, onOpenChange }: Sw
 	const recoverAgentSwitch = useRecoverAgentSwitch();
 	const switchMutation = useSwitchAgentState(session.id);
 	const admissionPending = switchMutation.isPending;
-	const durableSwitch = session.activeAgentSwitch;
+	// Agent-switch history has its own bounded polling fallback. Prefer that
+	// observation over the compact workspace projection so a settled recovery
+	// cannot leave this dialog pinned to an older recovery-required snapshot.
+	const durableSwitch = agentSwitch ?? session.activeAgentSwitch;
 	const recoveryRequired = durableSwitch ? agentSwitchNeedsRecovery(durableSwitch) : false;
 	const sourceStopRecoveryRequired = durableSwitch ? agentSwitchNeedsSourceStopRecovery(durableSwitch) : false;
 	const sourceRestoreRequired = durableSwitch ? agentSwitchNeedsSourceRestore(durableSwitch) : false;
-	const sourceRecoveryRequired = sourceStopRecoveryRequired || sourceRestoreRequired;
+	const sourceRecoveryRequired = durableSwitch ? agentSwitchNeedsSourceRecovery(durableSwitch) : false;
 	const sourceLabel = durableSwitch
 		? agentLabel(durableSwitch.fromHarness)
 		: agentLabel(session.provider);

--- a/frontend/src/renderer/components/TerminalSwitchAgentButton.tsx
+++ b/frontend/src/renderer/components/TerminalSwitchAgentButton.tsx
@@ -5,12 +5,13 @@ import { useTranslation } from "react-i18next";
 import { clearSwitchAgentState } from "../hooks/useSwitchAgent";
 import type { AgentSwitchPresentation } from "../lib/agent-switch-presentation";
 import { cn } from "../lib/utils";
-import { sessionIsActive, type WorkspaceSession } from "../types/workspace";
+import { sessionIsActive, type AgentSwitchSummary, type WorkspaceSession } from "../types/workspace";
 import { canSwitchAgentHarness, SwitchAgentDialog } from "./SwitchAgentDialog";
 import { TopbarButton } from "./TopbarButton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 type TerminalSwitchAgentButtonProps = {
+	agentSwitch?: AgentSwitchSummary;
 	container: HTMLElement | null | undefined;
 	onOpenChange: ((open: boolean) => void) | undefined;
 	open: boolean;
@@ -20,6 +21,7 @@ type TerminalSwitchAgentButtonProps = {
 };
 
 export function TerminalSwitchAgentButton({
+	agentSwitch,
 	container,
 	onOpenChange,
 	open,
@@ -91,7 +93,13 @@ export function TerminalSwitchAgentButton({
 				<TooltipContent>{label}</TooltipContent>
 			</Tooltip>
 			{open && container ? (
-				<SwitchAgentDialog container={container} onOpenChange={handleOpenChange} open session={session} />
+				<SwitchAgentDialog
+					agentSwitch={agentSwitch}
+					container={container}
+					onOpenChange={handleOpenChange}
+					open
+					session={session}
+				/>
 			) : null}
 		</>
 	);

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -266,6 +266,7 @@ export function SessionChatSurface({
 				onRenameShellTerminal={onRenameShellTerminal}
 				switchAgentControl={
 					<TerminalSwitchAgentButton
+						agentSwitch={selectedDurableAgentSwitch}
 						container={switchSelectorContainer}
 						onOpenChange={setSwitchSelectorOpen}
 						open={switchSelectorOpen}

--- a/frontend/src/renderer/hooks/useAgentSwitches.test.ts
+++ b/frontend/src/renderer/hooks/useAgentSwitches.test.ts
@@ -20,9 +20,9 @@ function switchRecord(overrides: Partial<AgentSwitch> = {}): AgentSwitch {
 describe("agentSwitchesRefetchInterval", () => {
 	it.each([
 		["polls an ordinary active switch", {}, 1_000],
-		["stops eager polling when a durable recovery marker is present", { errorCode: "target_start_unconfirmed" }, false],
-		["stops eager polling while source shutdown is unconfirmed", { errorCode: "source_stop_unconfirmed", state: "stopping_source" }, false],
-		["stops eager polling while the source needs restoration", { errorCode: "source_restore_unconfirmed", state: "source_stopped" }, false],
+		["does not poll a target recovery with no asynchronous worker", { errorCode: "target_start_unconfirmed" }, false],
+		["polls while source shutdown recovery may be running", { errorCode: "source_stop_unconfirmed", state: "stopping_source" }, 1_000],
+		["polls while source restoration may be running", { errorCode: "source_restore_unconfirmed", state: "source_stopped" }, 1_000],
 		["does not poll terminal history", { state: "completed" }, false],
 		["keeps polling a protected future state", { state: "future_phase" }, 1_000],
 	] as const)("%s", (_name, overrides, expected) => {

--- a/frontend/src/renderer/hooks/useAgentSwitches.ts
+++ b/frontend/src/renderer/hooks/useAgentSwitches.ts
@@ -17,9 +17,12 @@ export function isTerminalAgentSwitch(agentSwitch: AgentSwitch): boolean {
 export function agentSwitchNeedsRecovery(agentSwitch: AgentSwitch): boolean {
 	return (
 		agentSwitchNeedsTargetStartRecovery(agentSwitch) ||
-		agentSwitchNeedsSourceStopRecovery(agentSwitch) ||
-		agentSwitchNeedsSourceRestore(agentSwitch)
+		agentSwitchNeedsSourceRecovery(agentSwitch)
 	);
+}
+
+export function agentSwitchNeedsSourceRecovery(agentSwitch: AgentSwitch): boolean {
+	return agentSwitchNeedsSourceStopRecovery(agentSwitch) || agentSwitchNeedsSourceRestore(agentSwitch);
 }
 
 export function agentSwitchNeedsTargetStartRecovery(agentSwitch: AgentSwitch): boolean {
@@ -67,7 +70,9 @@ export function selectDurableAgentSwitch(
 }
 
 export function agentSwitchesRefetchInterval(agentSwitches: AgentSwitch[]): 1_000 | false {
-	return findActiveAgentSwitch(agentSwitches) ? 1_000 : false;
+	return findActiveAgentSwitch(agentSwitches) || agentSwitches.some(agentSwitchNeedsSourceRecovery)
+		? 1_000
+		: false;
 }
 
 async function fetchAgentSwitches(sessionId: string): Promise<AgentSwitch[]> {
@@ -85,9 +90,9 @@ export function useAgentSwitches(sessionId: string) {
 		queryKey: agentSwitchesQueryKey(sessionId),
 		enabled: Boolean(sessionId),
 		queryFn: () => (usesPreviewWorkspaceData ? Promise.resolve([]) : fetchAgentSwitches(sessionId)),
-		// Once a durable saga is active, keep its phase fresh even if the CDC
-		// connection is temporarily unavailable. Recovery-required records are
-		// intentionally static until an external recovery changes them.
+		// Keep active sagas fresh even if the CDC connection is temporarily
+		// unavailable. Source-recovery endpoints accept work asynchronously, so
+		// those recovery rows must also poll until their worker settles.
 		refetchInterval: (query) =>
 			agentSwitchesRefetchInterval((query.state.data as AgentSwitch[] | undefined) ?? []),
 		retry: 1,


### PR DESCRIPTION
## Summary

- close an inconclusive `stopping_source` switch as failed while preserving the source owner and runtime handle
- avoid unsafe teardown retries or source relaunches when the runtime adapter cannot prove liveness
- poll asynchronous source-recovery rows and prefer detailed switch history over a stale workspace projection in the dialog

## Independent triage

The durable boundary in `stopping_source` is earlier than target creation: AO cannot have created the target until the source-stopped transaction commits. A failed source liveness probe therefore does **not** make controller ownership ambiguous; the durable session row still owns the original source harness and handle.

Retrying `Destroy` or relaunching the source is unsafe. In particular, #3475 deliberately classifies tmux server-level failures as inconclusive because the provider process can outlive the tmux server. `Destroy` may also treat a missing server as an already-absent tmux session, which still cannot prove that an orphan provider exited. Relaunching at that point can create two controllers. The same ownership rule applies to ConPTY and other adapters.

The dead-end came from retaining a nonterminal switch gate after that probe error. The safe escape is to terminalize the switch without changing source ownership or guessing liveness. This reopens session operations (including termination/retry) and boot reconciliation automatically releases already-persisted rows after upgrade.

The recovery endpoint returns 202 before its worker settles. The UI previously stopped polling recovery rows, and the dialog only read the compact workspace snapshot, so it could keep rendering the old recovery prompt even after switch history changed. Source recovery rows now poll until terminal, and the dialog prefers the detailed history record for the same switch.

## Tests

- `cd backend && go test ./internal/session_manager -run 'Test(RecoverAgentSwitchReleasesSourceWhenProbeRemainsInconclusive|SwitchAgentMarksAndRecoversUnconfirmedSourceStop|ReconcileAgentSwitchesUsesDurableBoundaries)$' -count=1 -v`
- `cd frontend && npm test -- --run src/renderer/hooks/useAgentSwitches.test.ts src/renderer/components/SwitchAgentDialog.test.tsx src/renderer/components/TerminalSwitchAgentButton.test.tsx src/renderer/components/CenterPane.test.tsx src/renderer/components/chat/SessionChatSurface.test.tsx`
- `npm run frontend:typecheck`
- `cd backend && go test ./internal/session_manager -count=1`
- `git diff --check`

## Risk / intentional omission

This does not guess that an unreachable runtime is dead and does not force-kill or relaunch it. If the underlying adapter is still unavailable, the preserved source controller may remain disconnected, but the durable switch fence is released so the user can terminate or retry without risking a duplicate controller.

Closes #4258
