### PR TITLE
fix(terminal): auto-scroll the pane while a selection drag is held

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -70,6 +70,12 @@ vi.mock("@xterm/xterm", () => ({
 		loadAddon() {}
 		open(host: HTMLElement) {
 			host.appendChild(document.createElement("textarea"));
+			// Selection drag auto-scroll measures the pointer against the screen
+			// element's box, exactly as xterm's own drag scroll does. jsdom reports a
+			// zero rect, so the test that exercises it stubs a real one.
+			const screenEl = document.createElement("div");
+			screenEl.className = "xterm-screen";
+			host.appendChild(screenEl);
 		}
 		write() {}
 		writeln() {}
@@ -1013,6 +1019,165 @@ describe("XtermTerminal", () => {
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+	});
+
+	// Selection drag auto-scroll (#4265). xterm's built-in drag scroll only moves
+	// its OWN scrollback, which is permanently empty on the alt-buffer,
+	// mouse-tracking panes every `tmux attach` produces — so the pane has to be
+	// scrolled the same way the wheel already scrolls it.
+	//
+	// Screen box is stubbed at top=100, height=200 (jsdom reports a zero rect), so
+	// clientY 60 is 40px above it and clientY 340 is 40px below: 40/50 of the way
+	// to full speed => sign + round(0.8 * (3 - 1)) = 3 lines.
+	function dragSelectionTo(clientY: number, ticks = 1) {
+		const screenEl = document.querySelector<HTMLElement>(".xterm-screen")!;
+		screenEl.getBoundingClientRect = () => ({ top: 100, height: 200 }) as DOMRect;
+		// xterm mounts into the inner host; the drag listener sits on the shell that
+		// wraps it, so the mousedown has to bubble the same way a real one does.
+		const host = screenEl.parentElement!;
+		act(() => {
+			host.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+			window.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientY }));
+			vi.advanceTimersByTime(50 * ticks);
+		});
+	}
+
+	it("auto-scrolls a mouse-tracking pane while a selection drag is held past the edge", () => {
+		vi.useFakeTimers();
+		try {
+			const onInput = vi.fn();
+			render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+			// What `tmux attach` gives us: alternate screen + SGR mouse tracking.
+			state.lastTerminal!.modes.mouseTrackingMode = "any";
+			state.lastTerminal!.buffer.active.type = "alternate";
+			state.lastTerminal!.selection = "selected";
+			onInput.mockClear();
+
+			dragSelectionTo(60);
+
+			expect(onInput).toHaveBeenCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("scrolls the other way when the selection drag is held below the terminal", () => {
+		vi.useFakeTimers();
+		try {
+			const onInput = vi.fn();
+			render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+			state.lastTerminal!.modes.mouseTrackingMode = "any";
+			state.lastTerminal!.buffer.active.type = "alternate";
+			state.lastTerminal!.selection = "selected";
+			onInput.mockClear();
+
+			dragSelectionTo(340);
+
+			expect(onInput).toHaveBeenCalledWith("\x1b[<65;1;1M".repeat(3), "wheel");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps auto-scrolling every tick while the drag is held, and stops on mouseup", () => {
+		vi.useFakeTimers();
+		try {
+			const onInput = vi.fn();
+			render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+			state.lastTerminal!.modes.mouseTrackingMode = "any";
+			state.lastTerminal!.buffer.active.type = "alternate";
+			state.lastTerminal!.selection = "selected";
+			onInput.mockClear();
+
+			dragSelectionTo(60, 4);
+			expect(onInput).toHaveBeenCalledTimes(4);
+
+			act(() => {
+				window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+				vi.advanceTimersByTime(500);
+			});
+			expect(onInput).toHaveBeenCalledTimes(4);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not auto-scroll while the selection drag stays inside the terminal", () => {
+		vi.useFakeTimers();
+		try {
+			const onInput = vi.fn();
+			render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+			state.lastTerminal!.modes.mouseTrackingMode = "any";
+			state.lastTerminal!.buffer.active.type = "alternate";
+			state.lastTerminal!.selection = "selected";
+			onInput.mockClear();
+
+			// Inside the stubbed 100..300 box: an ordinary in-pane drag must stay a
+			// plain selection and must not move the pane.
+			dragSelectionTo(200, 10);
+
+			expect(onInput).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not auto-scroll without a selection, so a click-and-hold never moves the pane", () => {
+		vi.useFakeTimers();
+		try {
+			const onInput = vi.fn();
+			render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+			state.lastTerminal!.modes.mouseTrackingMode = "any";
+			state.lastTerminal!.buffer.active.type = "alternate";
+			state.lastTerminal!.selection = "";
+			onInput.mockClear();
+
+			dragSelectionTo(60, 10);
+
+			expect(onInput).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("leaves normal-buffer panes to xterm's own drag scroll instead of double-scrolling them", () => {
+		vi.useFakeTimers();
+		try {
+			const onInput = vi.fn();
+			render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+			// codex / a plain shell / a Windows conpty shell: xterm holds the
+			// scrollback and its built-in drag scroll already moves it.
+			state.lastTerminal!.modes.mouseTrackingMode = "none";
+			state.lastTerminal!.buffer.active.type = "normal";
+			state.lastTerminal!.selection = "selected";
+			onInput.mockClear();
+
+			dragSelectionTo(60, 10);
+
+			expect(onInput).not.toHaveBeenCalled();
+			expect(state.lastTerminal!.scrollLines).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("paces page keys for keyboard-scroll panes so a held drag is not twenty screens a second", () => {
+		vi.useFakeTimers();
+		try {
+			const onInput = vi.fn();
+			render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
+			state.lastTerminal!.modes.mouseTrackingMode = "any";
+			state.lastTerminal!.selection = "selected";
+			onInput.mockClear();
+
+			// One page key on the first tick, then one every eighth: 9 ticks => 2.
+			dragSelectionTo(60, 9);
+
+			expect(onInput).toHaveBeenCalledTimes(2);
+			expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("routes web links to the AO browser and does not open the system browser", () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -259,6 +259,77 @@ function pageKeyReport(lines: number): string {
 	return lines < 0 ? PAGE_UP : PAGE_DOWN;
 }
 
+// How a pane's transcript moves. Both scroll gestures (wheel and selection
+// drag) have to agree on this, so the decision lives in one place: they used to
+// differ, and the drag silently scrolled nothing on every tmux pane (#4265).
+//  - "local"       xterm owns the scrollback and scrolls it itself.
+//  - "mouseReport" the pane tracks the mouse and acts on SGR wheel reports.
+//  - "pageKeys"    the pane scrolls its own transcript by keyboard only.
+type PaneScrollMode = "local" | "mouseReport" | "pageKeys";
+
+function paneScrollMode(term: Terminal, scrollsByKeyboard: boolean): PaneScrollMode {
+	// A full-screen TUI that keeps its own transcript and scrolls it only by
+	// keyboard (opencode) ignores wheel/mouse reports on every platform. Kept
+	// first so opencode is unaffected by the buffer-aware paths below.
+	if (scrollsByKeyboard) return "pageKeys";
+	// A normal-buffer pane with mouse tracking off (codex, a plain shell) prints
+	// its transcript and relies on the terminal's own scrollback — the way it
+	// scrolls in a raw terminal. Requires scrollback > 0 (see Terminal opts).
+	if (term.modes.mouseTrackingMode === "none" && term.buffer.active.type === "normal") return "local";
+	// Mouse tracking on: the pane (tmux/zellij copy-mode, or any app that tracks
+	// the mouse) acts on SGR wheel reports. On Windows conpty this reaches the
+	// app directly; under a mux it drives copy-mode.
+	if (term.modes.mouseTrackingMode !== "none") return "mouseReport";
+	// Alt-buffer pane with mouse tracking off and no keyboard-scroll hint: no
+	// scrollback to move locally, so fall back to page keys.
+	return "pageKeys";
+}
+
+// The bytes that scroll a pane by `lines` (negative = up). Only meaningful for
+// the two modes where the pane, not xterm, does the scrolling.
+function paneScrollReport(mode: Exclude<PaneScrollMode, "local">, lines: number): string {
+	if (mode === "pageKeys") return pageKeyReport(lines);
+	return sgrWheelReport(lines < 0 ? SGR_WHEEL_UP : SGR_WHEEL_DOWN, Math.abs(lines));
+}
+
+// Selection drag auto-scroll.
+//
+// xterm auto-scrolls its OWN viewport when a selection drag leaves the screen
+// box (SelectionService._dragScroll -> BufferService.scrollLines). That only
+// moves lines xterm holds in its scrollback, and every AO terminal on
+// macOS/Linux is a `tmux attach-session` client: tmux drives the attaching
+// terminal into the alternate screen (the attach stream opens with ESC[?1049h
+// plus ESC[?1000h/?1002h/?1006h), where ybase and ydisp are permanently 0, so
+// BufferService.scrollLines returns without moving anything and the pane sits
+// still under a live drag. The scrollback lives in tmux, so the drag has to
+// reach it the same way the wheel already does — by reporting to the pane.
+const SELECTION_DRAG_SCROLL_INTERVAL_MS = 50;
+// Distance past the edge at which the drag scrolls at full speed. Mirrors
+// xterm's own DRAG_SCROLL_MAX_THRESHOLD so the gesture feels unchanged on the
+// "local" panes where xterm still does the scrolling.
+const SELECTION_DRAG_MAX_THRESHOLD_PX = 50;
+// Far below xterm's local max of 15 because each line here becomes a wheel
+// report the PANE acts on, and one report moves more than one line: tmux
+// copy-mode scrolls 5. Measured against a real `tmux attach` PTY, 3 reports per
+// 50ms tick moves ~14 lines per tick — i.e. this lands back on xterm's own
+// full-speed drag scroll rather than 5x past it.
+const SELECTION_DRAG_MAX_SPEED = 3;
+// A page key moves a whole screen, so a keyboard-scroll pane gets one every N
+// ticks instead of one per tick.
+const SELECTION_DRAG_PAGE_TICKS = 8;
+
+// Lines to scroll for a pointer at `clientY`, given the screen element's box.
+// Zero while the pointer is still inside it. Same shape as xterm's
+// SelectionService._getMouseEventScrollAmount, against the same element.
+function selectionDragScrollLines(clientY: number, screen: DOMRect): number {
+	let offset = clientY - screen.top;
+	if (offset >= 0 && offset <= screen.height) return 0;
+	if (offset > screen.height) offset -= screen.height;
+	offset = Math.min(Math.max(offset, -SELECTION_DRAG_MAX_THRESHOLD_PX), SELECTION_DRAG_MAX_THRESHOLD_PX);
+	offset /= SELECTION_DRAG_MAX_THRESHOLD_PX;
+	return Math.sign(offset) + Math.round(offset * (SELECTION_DRAG_MAX_SPEED - 1));
+}
+
 function forceSelectionMode(term: Terminal): void {
 	const internal = term as XtermInternal;
 	const selectionService = internal._core?._selectionService;
@@ -799,35 +870,63 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				wheelAccumPx -= lines * rowHeight;
 			}
 			if (lines === 0) return false;
-			// A full-screen TUI that keeps its own transcript and scrolls it only by
-			// keyboard (opencode) ignores wheel/mouse reports on every platform; route
-			// its wheel to page keys. Kept first so opencode is unaffected by the
-			// buffer-aware paths below.
-			if (callbacksRef.current.paneScrollsByKeyboard) {
-				emitUserInput(pageKeyReport(lines), "wheel");
-				return false;
-			}
-			// A normal-buffer pane with mouse tracking off (codex, a plain shell)
-			// prints its transcript and relies on the terminal's own scrollback — the
-			// way it scrolls in a raw terminal. Scroll xterm's viewport locally; the
-			// pane never sees these bytes. Requires scrollback > 0 (see Terminal opts).
-			if (term.modes.mouseTrackingMode === "none" && term.buffer.active.type === "normal") {
+			// Which of the three routes this pane needs is the same question the
+			// selection drag below asks, so both read it from paneScrollMode().
+			const mode = paneScrollMode(term, callbacksRef.current.paneScrollsByKeyboard === true);
+			if (mode === "local") {
+				// The pane never sees these bytes; we move xterm's own scrollback.
 				term.scrollLines(lines);
 				return false;
 			}
-			// Mouse tracking on: the pane (tmux/zellij copy-mode, or any app that
-			// tracks the mouse) acts on SGR wheel reports. On Windows conpty this
-			// reaches the app directly; under a mux it drives copy-mode.
-			if (term.modes.mouseTrackingMode !== "none") {
-				const button = lines < 0 ? SGR_WHEEL_UP : SGR_WHEEL_DOWN;
-				emitUserInput(sgrWheelReport(button, Math.abs(lines)), "wheel");
-				return false;
-			}
-			// Alt-buffer pane with mouse tracking off and no keyboard-scroll hint:
-			// no scrollback to move locally, so fall back to page keys.
-			emitUserInput(pageKeyReport(lines), "wheel");
+			emitUserInput(paneScrollReport(mode, lines), "wheel");
 			return false;
 		});
+
+		// Selection drag auto-scroll: supply the scroll a pane-owned scrollback
+		// never receives from xterm's built-in drag scroll (see the constants above).
+		// xterm keeps owning the selection model — its own _dragScroll re-pins
+		// selectionEnd to the viewport edge on every tick — so all this adds is the
+		// pane scroll itself.
+		let selectionDragLines = 0;
+		let selectionDragTicks = 0;
+		let selectionDragTimer: number | null = null;
+		const trackSelectionDrag = (event: MouseEvent) => {
+			const screen = host.querySelector<HTMLElement>(".xterm-screen");
+			selectionDragLines = screen ? selectionDragScrollLines(event.clientY, screen.getBoundingClientRect()) : 0;
+		};
+		const stopSelectionDragScroll = () => {
+			if (selectionDragTimer !== null) {
+				window.clearInterval(selectionDragTimer);
+				selectionDragTimer = null;
+			}
+			selectionDragLines = 0;
+			selectionDragTicks = 0;
+			// Capture phase on both, matching how they were added.
+			window.removeEventListener("mousemove", trackSelectionDrag, true);
+			window.removeEventListener("mouseup", stopSelectionDragScroll, true);
+		};
+		const selectionDragTick = () => {
+			if (selectionDragLines === 0 || !term.hasSelection()) return;
+			const mode = paneScrollMode(term, callbacksRef.current.paneScrollsByKeyboard === true);
+			// A "local" pane still has xterm's built-in drag scroll, which already
+			// works against its own scrollback; emitting here would scroll it twice.
+			if (mode === "local") return;
+			// One page key per tick would be twenty screens a second.
+			if (mode === "pageKeys" && selectionDragTicks++ % SELECTION_DRAG_PAGE_TICKS !== 0) return;
+			emitUserInput(paneScrollReport(mode, selectionDragLines), "wheel");
+		};
+		const startSelectionDragScroll = (event: MouseEvent) => {
+			if (event.button !== 0 || selectionDragTimer !== null) return;
+			selectionDragLines = 0;
+			selectionDragTicks = 0;
+			// Capture phase: xterm's own document-level mousemove listener calls
+			// stopImmediatePropagation() for the whole duration of a selection drag,
+			// which would silently drop a bubble-phase listener on window.
+			window.addEventListener("mousemove", trackSelectionDrag, true);
+			window.addEventListener("mouseup", stopSelectionDragScroll, true);
+			selectionDragTimer = window.setInterval(selectionDragTick, SELECTION_DRAG_SCROLL_INTERVAL_MS);
+		};
+		shell.addEventListener("mousedown", startSelectionDragScroll);
 		const pasteInput = (event: ClipboardEvent) => {
 			event.preventDefault();
 			event.stopPropagation();
@@ -985,6 +1084,10 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			shell.removeEventListener("compositionend", compositionInput, true);
 			shell.removeEventListener("dragover", dragOverInput);
 			shell.removeEventListener("drop", dropInput);
+			shell.removeEventListener("mousedown", startSelectionDragScroll);
+			// Also drops the window-level drag listeners and the tick interval if the
+			// terminal is torn down mid-drag.
+			stopSelectionDragScroll();
 			contextMenuActionsRef.current = null;
 			cancelActivationPreparation?.();
 			clearSuppressNativePaste();


### PR DESCRIPTION
Fixes #4265

## Summary

Dragging a text selection past the top/bottom edge of an AO terminal did not auto-scroll the pane, so a selection could never grow past what was already on screen. Ordinary selection and ordinary wheel scrolling both worked.

xterm's built-in selection drag-scroll (`SelectionService._dragScroll`) fires `onRequestScrollLines` → `Terminal.scrollLines` → `BufferService.scrollLines`, which only moves lines xterm holds in its **own** scrollback:

```ts
if (disp < 0) { if (buffer.ydisp === 0) return; }
buffer.ydisp = Math.max(Math.min(buffer.ydisp + disp, buffer.ybase), 0);
if (oldYdisp === buffer.ydisp) return;
```

Every AO terminal on macOS/Linux is a `tmux attach-session` client (`backend/internal/adapters/runtime/tmux/tmux.go:702`, and `backend/internal/daemon/daemon.go:300` gives shell terminals the same adapter). Capturing that attach stream from a real PTY shows tmux immediately driving the client into the alternate screen with SGR mouse tracking on:

```
b'\x1b[?1049h\x1b[22;0;0t\x1b[?1h\x1b=\x1b[H\x1b[2J...'
  ALT SCREEN (1049h): YES   mouse 1000h/1002h/1006h: YES
```

In the alternate buffer `ybase === ydisp === 0` forever, so `scrollLines` is a guaranteed no-op and the pane sits still under a live drag. tmux never hears about it either, because AO does not forward the drag to the PTY (`forceSelectionMode`, the patch behind #3640).

The **wheel** already solved exactly this: `attachCustomWheelEventHandler` branches on pane kind and reports to the pane rather than scrolling locally. That is why "normal scrolling works". The selection drag was simply never given the same route.

## What changed

`frontend/src/renderer/components/XtermTerminal.tsx`

- Extracted the wheel handler's pane-kind decision into `paneScrollMode()` (`local` / `mouseReport` / `pageKeys`) and its emission into `paneScrollReport()`, so both scroll gestures read one decision and cannot drift apart again. **Wheel behavior is byte-for-byte unchanged** — the existing wheel tests pin those bytes and pass untouched.
- A left-button selection drag held outside the `.xterm-screen` box now emits the same bytes the wheel would for that many lines, on xterm's own 50ms drag cadence.
  - `local` panes (codex, a plain shell, a Windows conpty shell) are **skipped** — xterm's built-in drag-scroll already moves their scrollback, so emitting would scroll them twice.
  - `pageKeys` panes get one page key every 8th tick; one per tick would be twenty screens a second.
  - Distance→speed curve mirrors xterm's own `DRAG_SCROLL_MAX_THRESHOLD`, with the speed cap at 3 instead of 15 because each line becomes a report the *pane* acts on and tmux copy-mode moves 5 lines per report. Measured against a real tmux PTY: 3 reports/tick ≈ 14 lines/tick, i.e. this lands back on xterm's native full-speed drag rate rather than 5× past it.
- Drag tracking uses **capture-phase** `mousemove`/`mouseup` on `window`: xterm's own document-level `mousemove` listener calls `stopImmediatePropagation()` for the whole duration of a drag, which would silently drop a bubble-phase listener.
- Teardown removes the `mousedown` listener and calls `stopSelectionDragScroll()`, so a terminal disposed mid-drag leaves no window listeners or interval behind.

xterm keeps owning the selection model — its `_dragScroll` re-pins `selectionEnd` to the viewport edge every tick — so this only supplies the scroll the pane never received.

## Verification

**Reproduced the bug in a real Chromium** against the shipped `@xterm/xterm@5.5.0` build with AO's `forceSelectionMode` patch applied, synthesizing a held drag 40px above the screen box for 600ms:

| case | buffer / mouse tracking | `viewportY` before → after | auto-scrolled |
|---|---|---|---|
| A — plain shell / codex | `normal`, tracking `none` | 377 → 245 | **YES** |
| B — `tmux attach` (every AO terminal on macOS/Linux) | `alternate`, tracking `drag` | 0 → 0 | **NO** |

Case A proves `forceSelectionMode`, the hidden-scrollbar CSS and `removeHiddenScrollbarReservation` do **not** break xterm's native drag-scroll — the failure was entirely the routing gap. Not Electron-specific.

**Verified the fix's output against a live tmux.** Writing exactly what the fix emits per tick (`\x1b[<64;1;1M` × 3) into a real `tmux attach` PTY, six ticks apart:

```
attached; visible markers: (478, 500)
after 6 drag ticks; markers repainted: (393, 491)
tmux pane_in_mode: 1   scroll_position: 85
```

The pane enters copy-mode and scrolls back 85 lines — the scroll the drag never used to produce.

**Tests** (`npx vitest run --config vite.renderer.config.ts`):
- `XtermTerminal.test.tsx` — 64 passed, 7 new: auto-scrolls a mouse-tracking pane on a held drag; correct direction above vs. below the box; keeps ticking while held and stops on `mouseup`; does **not** fire while the pointer stays inside the box; does **not** fire without a selection (click-and-hold never moves the pane); leaves `local` panes to xterm instead of double-scrolling; paces page keys for keyboard-scroll panes.
- `TerminalPane.test.tsx`, `ShellTerminalTab.test.tsx`, `useTerminalSession.test.tsx` — 98 passed, unchanged.
- `npm --prefix frontend run typecheck` — clean on the implementation.

## Known limitation (not introduced here, not removed here)

Over a tmux pane the selection still cannot accumulate *beyond one screen*: xterm's selection anchors are buffer rows and tmux repaints the alternate screen in place, so scrolling changes the text under a fixed anchor rather than adding rows above it. After this change the pane scrolls under a live drag and the highlight stays WYSIWYG with what gets copied — as far as xterm-level selection can go while the scrollback lives in tmux. Genuinely unbounded selection needs the pane's native transcript: #3791.

## Risk / follow-ups

- The minimum drag speed is ~100 lines/s (1 report/tick × tmux's 5 lines) versus xterm's local 20 lines/s, because tmux's lines-per-wheel-report is not something this layer controls. Fine-grained control right at the edge is coarser than on a `local` pane; worth a tuning pass if it feels fast in practice.
- Windows (conpty) is untested on hardware. A plain conpty shell stays a `local` pane and is unaffected by this change; a conpty agent TUI that enables mouse tracking takes the new `mouseReport` path.

## Related

- #3640 — `forceSelectionMode` suppresses mouse reporting to the PTY. Same patch that makes local selection possible over a mouse-tracking pane, so changes there interact with this.
- #3791 — copy full prompt/response by reading the agent's native transcript.
- #1221 — terminal selection offset from the overlay scrollbar mismatch.
- Separate from the non-terminal UI text-selection issue being triaged in parallel; no shared code — that one is app-chrome CSS, this one is xterm scroll routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yaidvsj2EAxdKNHEQqgQ6Y
