### PR TITLE
fix(desktop): restore text selection outside the terminal

### DIFF
--- a/frontend/e2e/text-selection.spec.ts
+++ b/frontend/e2e/text-selection.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+// Regression for #4268. PR #3508 put `user-select: none` on <body> to stop drags
+// from painting a highlight over sidebar/board chrome. `user-select` inherits, so
+// it also killed selection on every content surface: session details, status
+// text, error copy, PR metadata — nothing outside inputs and the terminal could
+// be selected or copied. These cases pin both halves of the contract: readable
+// content selects, and the chrome the pointer acts on still does not.
+
+/** Drag across an element the way a user would when selecting its text. */
+async function dragSelect(page: Page, locator: Locator): Promise<void> {
+	await locator.scrollIntoViewIfNeeded();
+	const box = await locator.boundingBox();
+	if (!box) throw new Error("target has no layout box");
+	await page.mouse.move(box.x + 2, box.y + box.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width - 2, box.y + box.height / 2, { steps: 12 });
+	await page.mouse.up();
+}
+
+async function selectedText(page: Page): Promise<string> {
+	return page.evaluate(() => window.getSelection()?.toString() ?? "");
+}
+
+async function clearSelection(page: Page): Promise<void> {
+	await page.evaluate(() => window.getSelection()?.removeAllRanges());
+}
+
+function userSelectOf(locator: Locator): Promise<string> {
+	return locator.evaluate((el) => getComputedStyle(el).userSelect);
+}
+
+test("readable content is selectable and copyable, chrome is not", async ({ page }) => {
+	await page.goto("/");
+
+	// The root default is what #3508 inverted. It is back to the initial value,
+	// so the assertion is "not switched off" rather than a specific keyword.
+	expect(await page.evaluate(() => getComputedStyle(document.body).userSelect)).not.toBe("none");
+
+	// A board card is a click surface: dragging it must open nothing and select
+	// nothing, so its text stays out of reach even though the page is selectable.
+	const card = page.locator('[data-testid="board-session-card"]').first();
+	await expect(card).toBeVisible();
+	expect(await userSelectOf(card)).toBe("none");
+	await dragSelect(page, card);
+	expect(await selectedText(page)).toBe("");
+	await expect(page).toHaveURL(/#\/?$|projects/);
+
+	// Open a session so the inspector rail — the surface the report named — mounts.
+	await clearSelection(page);
+	await card.click();
+	const inspector = page.locator("#inspector");
+	await expect(inspector).toBeVisible();
+
+	// Inspector body copy is content: a drag selects it and Copy puts it on the
+	// clipboard. This is the case that was impossible before the fix.
+	const section = inspector.locator('[data-testid="inspector-section"]').first();
+	await expect(section).toBeVisible();
+	expect(await userSelectOf(section)).not.toBe("none");
+
+	// Drag a single line of body copy — the PR section's status line — rather than
+	// the whole section, so the gesture stays on text instead of crossing rows.
+	const line = section.locator("p").first();
+	await expect(line).toBeVisible();
+	await dragSelect(page, line);
+	const selection = await selectedText(page);
+	expect(selection.trim()).not.toBe("");
+	// The drag must not have activated the section it crossed.
+	await expect(inspector).toBeVisible();
+
+	// And the selection reaches the clipboard over the ordinary Copy shortcut.
+	await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+	await page.keyboard.press(process.platform === "darwin" ? "Meta+C" : "Control+C");
+	const clipboard = await page.evaluate(() => navigator.clipboard.readText().catch(() => ""));
+	expect(clipboard.trim()).toBe(selection.trim());
+});
+
+test("controls and drag surfaces stay unselectable", async ({ page }) => {
+	await page.goto("/");
+	const card = page.locator('[data-testid="board-session-card"]').first();
+	await expect(card).toBeVisible();
+	await card.click();
+	await expect(page.locator("#inspector")).toBeVisible();
+
+	// Buttons: a drag across a control must never leave text selected behind it.
+	const button = page.getByRole("button").first();
+	await expect(button).toBeAttached();
+	expect(await userSelectOf(button)).toBe("none");
+
+	// The sidebar rows #3508 was actually filed about.
+	const sidebarRow = page.locator('[data-sidebar="menu-button"]').first();
+	if ((await sidebarRow.count()) > 0) {
+		expect(await userSelectOf(sidebarRow)).toBe("none");
+	}
+
+	// The inspector/sidebar resize handles are pointer-drag surfaces.
+	const resizeHandle = page.locator('[data-slot="resize-handle"]').first();
+	if ((await resizeHandle.count()) > 0) {
+		expect(await userSelectOf(resizeHandle)).toBe("none");
+	}
+});
+
+test("the terminal keeps its own selection model", async ({ page }) => {
+	await page.goto("/");
+	const card = page.locator('[data-testid="board-session-card"]').first();
+	await expect(card).toBeVisible();
+	await card.click();
+
+	// xterm.css sets `.xterm { user-select: none }` itself and drives selection
+	// through its own layer, so the body default must not leak in and change it.
+	const xterm = page.locator(".xterm").first();
+	if ((await xterm.count()) > 0) {
+		await expect(xterm).toBeVisible();
+		expect(await userSelectOf(xterm)).toBe("none");
+	}
+});

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1390,8 +1390,6 @@ body {
 	font-size: var(--font-size-md);
 	line-height: var(--line-height-normal);
 	-webkit-font-smoothing: antialiased;
-	-webkit-user-select: none;
-	user-select: none;
 }
 
 button,
@@ -1406,6 +1404,30 @@ textarea,
 [contenteditable="true"] {
 	-webkit-user-select: text;
 	user-select: text;
+}
+
+/* Readable content stays selectable so session details, status text, error
+ * copy, and PR metadata can be copied out of the app. #3508 turned selection
+ * off on <body> to stop drags from painting a highlight over sidebar/board
+ * chrome, but `user-select` inherits, so that also took out every content
+ * surface. The opt-out below names the chrome instead: controls and drag
+ * surfaces must act on a drag, not select text under it. Deliberately excludes
+ * a[href] — links sit inside prose (chat transcript, review markdown), and
+ * making them unselectable would punch holes in a copied paragraph. See #4268. */
+:is(
+		button,
+		summary,
+		select,
+		[role="button"],
+		[data-slot="select-trigger"],
+		[data-slot="select-item"],
+		[data-slot="dropdown-menu-item"],
+		[data-slot="resize-handle"],
+		[data-sidebar="menu-button"],
+		[data-sidebar="menu-sub-button"]
+	) {
+	-webkit-user-select: none;
+	user-select: none;
 }
 
 :is(

--- a/packages/product-ui/src/SessionsBoardView.test.tsx
+++ b/packages/product-ui/src/SessionsBoardView.test.tsx
@@ -238,4 +238,47 @@ describe("SessionsBoardView", () => {
 		expect(lastArchiveMotionTransition.current).toEqual({ duration: 0 });
 		expect(archiveButton.querySelector("svg")).toHaveClass("transition-none");
 	});
+
+	// The renderer makes content selectable again (#4268). A clickable card is a
+	// click target, not content: a drag that ends inside it still fires click, so
+	// selecting card text would open the session. Non-interactive cards carry no
+	// click handler and stay selectable.
+	it("keeps a clickable card unselectable and leaves a non-interactive card selectable", () => {
+		const labels = {
+			formatTime: () => "5m ago",
+			intakeIssue: (id: string) => `Issue ${id}`,
+			pr: {
+				short: "PR",
+				states: { closed: "closed", draft: "draft", merged: "merged", open: "open" },
+			},
+			updatedAt: (timestamp: string) => `Updated ${timestamp}`,
+		};
+		const renderAvatar = (provider: string) => (
+			<span role="img" aria-label={provider}>
+				C
+			</span>
+		);
+
+		const { rerender } = render(
+			<SessionCardView
+				externalLink={ExternalLink}
+				labels={labels}
+				onOpen={vi.fn()}
+				renderAvatar={renderAvatar}
+				session={baseSession}
+			/>,
+		);
+		expect(screen.getByTestId("board-session-card")).toHaveClass("select-none");
+
+		rerender(
+			<SessionCardView
+				externalLink={ExternalLink}
+				interactive={false}
+				labels={labels}
+				renderAvatar={renderAvatar}
+				session={baseSession}
+			/>,
+		);
+		expect(screen.getByTestId("board-session-card")).not.toHaveClass("select-none");
+	});
 });

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -443,8 +443,11 @@ export function SessionCardView({
 			className={cn(
 				"group relative w-full rounded-lg border text-left transition-[border-color,box-shadow]",
 				badge.cardClassName ?? "border-border bg-surface",
+				// The whole card is the click target, and a drag that ends inside it
+				// still fires click — so a drag-select here would open the session
+				// instead of selecting. The same text is selectable in the inspector.
 				interactive &&
-					"cursor-pointer hover:border-border-strong hover:shadow-sm focus-within:border-border-strong focus-within:ring-2 focus-within:ring-ring/60",
+					"cursor-pointer select-none hover:border-border-strong hover:shadow-sm focus-within:border-border-strong focus-within:ring-2 focus-within:ring-ring/60",
 			)}
 			data-testid="board-session-card"
 			data-session-id={session.id}


### PR DESCRIPTION
Fixes #4268

## Summary

`body { user-select: none }` — added by [PR #3508](https://github.com/Untrivial-ai/agent-orchestrator/pull/3508) to stop drags from painting a highlight over sidebar/board chrome — inherits into every descendant. Nothing outside `input`/`textarea`/`[contenteditable]` and the terminal could be selected or copied: session details, status text, error messages, PR metadata. It also left the Files-tab diff selection menu unreachable, since `SessionFilesView` gates that menu on a live DOM selection inside a container that had no `select-text`.

This restores the selectable default and moves #3508's intent into an explicit opt-out list for controls and drag surfaces, so chrome behaves exactly as it does today.

## Changes

- `frontend/src/renderer/styles.css` — drop `user-select: none` from `body`; add an opt-out for `button`, `summary`, `select`, `[role="button"]`, the `data-slot` control set, `[data-slot="resize-handle"]`, and the sidebar menu buttons.
- `packages/product-ui/src/SessionsBoardView.tsx` — `select-none` on **interactive** board cards only. The card is the click target and a drag ending inside it still fires `click`, so a drag-select there would open the session. Non-interactive (archive) cards stay selectable.
- `frontend/e2e/text-selection.spec.ts` — new.
- `packages/product-ui/src/SessionsBoardView.test.tsx` — card contract test.

`a[href]` is deliberately **not** in the opt-out: links sit inside prose (chat transcript, review markdown), and `user-select: none` on them punches holes in a copied paragraph.

## Deliberately unchanged

- **Terminal** — `xterm.css` sets `.xterm { user-select: none }` itself, so xterm owns terminal selection regardless of the `body` value.
- **Titlebar / drag regions** — `.window-titlebar` and `.session-inspector__topbar` already carry their own `user-select: none`.
- **Resize drags** — `body.is-resizing-x { user-select: none }` still suppresses selection for the duration of a drag.
- **Marketing site** — `frontend/src/landing/.../globals.css` keeps its own rule; out of scope.

One behavior change worth flagging: board **column headers** ("WORKING", counts) are now selectable. They are not interactive, so there is no conflict, but #3508's description mentioned them. Happy to add `select-none` there if reviewers prefer the old look.

## Verification

Run on macOS 26.6 (arm64) against `85fab5e29`.

- `frontend/e2e/text-selection.spec.ts` — **3 passed**. Drives real mouse drags and reads `window.getSelection()`:
  - inspector body copy selects and reaches the clipboard over the ordinary Copy shortcut
  - board card drag selects nothing and navigates nowhere
  - buttons, `[data-sidebar="menu-button"]`, and `[data-slot="resize-handle"]` compute `user-select: none`
  - `.xterm` still computes `user-select: none`
- **Non-vacuous check** — reverted `styles.css` to `origin/main` and reran: the content-selection case fails, the two chrome cases still pass. Restored and reran: all 3 pass.
- `packages/product-ui` — `SessionsBoardView.test.tsx` **7 passed**; `tsc --noEmit` clean.
- `frontend` — `tsc --noEmit` clean; `tsc --noEmit -p tsconfig.e2e.json` clean.
- `SessionsBoard.test.tsx` **38 passed**, `ChatWorkspace.test.tsx` + `SessionFilesView.test.tsx` pass (one archive-expansion timeout appeared only under a 3-file parallel run and reproduces on `origin/main` without this change; passes in isolation both with and without it).

## Gaps

- **Windows/Linux unverified.** `user-select` is platform-independent Chromium CSS and the rule has no platform guard, so no divergence is expected — but neither was exercised.
- Verified through the `dev:web` renderer harness, not a packaged Electron build. The `-webkit-app-region` drag strip is untouched by this diff, but a packaged smoke test would confirm the titlebar directly.
- Pre-existing and unrelated: `frontend/e2e/multi-pr.spec.ts` fails on `origin/main` — its "auth stack" fixture is gone from the mock dataset. Not touched here.

## Related

- [#4265](https://github.com/Untrivial-ai/agent-orchestrator/issues/4265) — terminal selection drag auto-scroll. Separate subsystem (xterm owns its selection); no shared code with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhZxfD2jzZRk5FTpfgJA8f
