### PR TITLE
fix(events): stop a large replay from aborting the mobile app, and clamp future cursors to head

### DIFF
--- a/backend/internal/httpd/events.go
+++ b/backend/internal/httpd/events.go
@@ -55,8 +55,13 @@ func (c *EventsController) stream(w http.ResponseWriter, r *http.Request) {
 			"Could not inspect the event cursor", nil)
 		return
 	}
+	// A cursor ahead of head means the change_log was truncated or replaced. Fall
+	// back to head rather than zero: replaying from zero costs the client the whole
+	// backlog, and since every connected client is reset at the same moment, they
+	// stampede together. Falling back to head loses at most the events in the gap,
+	// which clients recover from their next snapshot fetch.
 	if after > latestSeq {
-		after = 0
+		after = latestSeq
 	}
 
 	flusher, ok := w.(http.Flusher)

--- a/backend/internal/httpd/events_test.go
+++ b/backend/internal/httpd/events_test.go
@@ -133,7 +133,11 @@ func (s *resetEventSource) EventsAfter(_ context.Context, after int64, _ int) ([
 
 func (*resetEventSource) LatestSeq(context.Context) (int64, error) { return 1, nil }
 
-func TestEventsStreamResetsCursorAheadOfCurrentDatabase(t *testing.T) {
+// A cursor ahead of head means the change_log was truncated or replaced. Such a
+// client is sent to head, not to zero: replaying from zero costs it the entire
+// backlog, and because every connected client is reset at the same moment, they
+// stampede together. The gap is recovered from the next snapshot fetch instead.
+func TestEventsStreamClampsCursorAheadOfCurrentDatabaseToHead(t *testing.T) {
 	live := &fakeEventSubscriber{}
 	src := &resetEventSource{}
 	router := NewRouterWithControl(config.Config{}, discardLogger(), nil, APIDeps{
@@ -155,14 +159,19 @@ func TestEventsStreamResetsCursorAheadOfCurrentDatabase(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if got := resp.Header.Get("X-AO-Event-After"); got != "0" {
-		t.Fatalf("X-AO-Event-After = %q, want 0", got)
+	// resetEventSource reports a head of 1, so a cursor of 100 lands on 1.
+	if got := resp.Header.Get("X-AO-Event-After"); got != "1" {
+		t.Fatalf("X-AO-Event-After = %q, want 1 (head, not a replay from zero)", got)
 	}
-	if ids := readSSEIDs(t, resp.Body, 1); ids[0] != "1" {
-		t.Fatalf("id = %q, want 1", ids[0])
+
+	// The replayed event (seq 1) is at the cursor, so it is not re-sent. Only a
+	// genuinely newer event reaches the client — proving no backlog was replayed.
+	live.publish(testCDCEvent(2))
+	if ids := readSSEIDs(t, resp.Body, 1); ids[0] != "2" {
+		t.Fatalf("id = %q, want 2 (history before head must not be replayed)", ids[0])
 	}
-	if src.after != 0 {
-		t.Fatalf("EventsAfter called with %d, want reset cursor 0", src.after)
+	if src.after != 1 {
+		t.Fatalf("EventsAfter called with %d, want head cursor 1", src.after)
 	}
 }
 

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -52,8 +52,10 @@ export interface ConversationSendInput {
 	resources?: WireResourceContent[];
 }
 
+export const conversationQueryRoot = ["conversation"] as const;
+
 export function conversationQueryKey(sessionId: string) {
-	return ["conversation", sessionId] as const;
+	return [...conversationQueryRoot, sessionId] as const;
 }
 
 export function conversationModelsQueryKey(sessionId: string) {

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -143,6 +143,26 @@ describe("createEventTransport", () => {
 		}
 	});
 
+	// A reconnect resumes via Last-Event-ID. When the event log has been truncated
+	// or replaced, that cursor is ahead of head and the daemon starts the client at
+	// head instead of replaying — correct, but it means no conversation CDC arrives
+	// to invalidate an open chat. EventSource cannot read the response header that
+	// reports the clamp, so reopening must refresh conversations unconditionally.
+	it("refreshes open conversations on reopen, not just workspaces", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].onopen?.();
+
+			vi.advanceTimersByTime(200);
+
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["conversation"] });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("invalidates only the named conversation for conversation CDC", () => {
 		vi.useFakeTimers();
 		try {

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -4,7 +4,7 @@ import { getApiBaseUrl, hasTrustedApiBaseUrl, subscribeApiBaseUrl } from "./api-
 import { setEventsConnectionState } from "./events-connection";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { sessionScmSummaryQueryKey } from "../hooks/useSessionScmSummary";
-import { conversationQueryKey } from "../hooks/useConversation";
+import { conversationQueryKey, conversationQueryRoot } from "../hooks/useConversation";
 import { agentSwitchesQueryRoot } from "../hooks/useAgentSwitches";
 import { sessionUsageQueryRoot } from "../hooks/useSessionUsageSummaries";
 
@@ -50,11 +50,21 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 			const pendingConversationSessions = new Set<string>();
 			const pendingInterfaceTransitionSessions = new Set<string>();
 			let workspaceInvalidationPending = false;
+			let allConversationsInvalidationPending = false;
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
 			let sourceBaseUrl: string | undefined;
 			const refreshWorkspaces = (event?: Event) => {
 				let conversationOnly = false;
+				if (event === undefined) {
+					// A lifecycle refresh -- reconnect, daemon status change, base-URL change --
+					// carries no event, so we cannot know which conversations moved. Normally the
+					// replay that follows tells us, but when the event log has been truncated the
+					// daemon starts us at head and no CDC arrives at all. EventSource cannot read
+					// the header reporting that clamp, so refresh every conversation instead of
+					// leaving an open chat frozen on its pre-gap snapshot.
+					allConversationsInvalidationPending = true;
+				}
 				if (event && "data" in event) {
 					try {
 						const decoded = JSON.parse(String((event as MessageEvent).data)) as {
@@ -98,6 +108,10 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 				if (!conversationOnly) workspaceInvalidationPending = true;
 				if (debounce) clearTimeout(debounce);
 				debounce = setTimeout(() => {
+					if (allConversationsInvalidationPending) {
+						void queryClient.invalidateQueries({ queryKey: conversationQueryRoot });
+						allConversationsInvalidationPending = false;
+					}
 					if (workspaceInvalidationPending) {
 						void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 						void queryClient.invalidateQueries({ queryKey: agentSwitchesQueryRoot });

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -2,7 +2,7 @@
 	"expo": {
 		"name": "AO",
 		"slug": "ao-mobile",
-		"version": "1.2.0",
+		"version": "1.2.1",
 		"orientation": "portrait",
 		"icon": "./assets/icon.png",
 		"userInterfaceStyle": "automatic",

--- a/packages/mobile/lib/chat/api.ts
+++ b/packages/mobile/lib/chat/api.ts
@@ -20,7 +20,7 @@ import type {
 	DecisionOption,
 	TurnSettings,
 } from "./types";
-import { parseSseFrame, takeSseFrames, type ConversationEvent } from "./sse";
+import { parseSseFrame, readSseFrameSeq, takeSseFrames, type ConversationEvent } from "./sse";
 import { mergeConversationPages, type ConversationPage } from "./snapshot";
 
 export { parseSseFrame } from "./sse";
@@ -298,12 +298,35 @@ export async function closeShellTerminal(cfg: ServerConfig, handleId: string): P
  * deliberately because React Native's global fetch does not expose a streaming
  * response body consistently under Hermes.
  */
+export type ConversationStreamOptions = {
+	/** Frames handled between cooperative yields back to the event loop. */
+	yieldEvery?: number;
+	/** When this returns false, frames advance the cursor without being parsed. */
+	wantsPayload?: () => boolean;
+	/** A frame that advanced the cursor without being parsed. */
+	onCursorAdvance?: (seq: number) => void;
+};
+
+/**
+ * Frames handled before the reader hands the event loop back.
+ *
+ * React Native services touches on the JS thread, and `await`ing an
+ * already-buffered read only queues a microtask — which the runtime drains
+ * completely before any touch is delivered. A replay big enough to keep that
+ * queue fed therefore renders the UI untappable for its whole duration. Yielding
+ * a macrotask periodically bounds that stall no matter how large the backlog is.
+ */
+const STREAM_YIELD_EVERY = 256;
+
+const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
 export async function streamGlobalConversationEvents(
 	cfg: ServerConfig,
 	after: number,
 	signal: AbortSignal,
 	onEvent: (event: ConversationEvent) => void,
 	onCursorReset?: (cursor: number) => void,
+	options?: ConversationStreamOptions,
 ): Promise<number> {
 	const res = await expoFetch(`${httpBase(cfg)}${API}/events?after=${Math.max(0, after)}`, {
 		headers: { ...authHeaders(cfg), Accept: "text/event-stream" },
@@ -322,6 +345,9 @@ export async function streamGlobalConversationEvents(
 	const reader = res.body.getReader();
 	let buffer = "";
 	let cursor = effectiveAfter;
+	const yieldEvery = Math.max(1, options?.yieldEvery ?? STREAM_YIELD_EVERY);
+	const wantsPayload = options?.wantsPayload;
+	let sinceYield = 0;
 	try {
 		while (!signal.aborted) {
 			const { done, value } = await reader.read();
@@ -330,10 +356,25 @@ export async function streamGlobalConversationEvents(
 			const split = takeSseFrames(buffer);
 			buffer = split.remainder;
 			for (const frame of split.frames) {
-				const parsed = parseSseFrame(frame);
-				if (parsed) {
-					cursor = Math.max(cursor, parsed.seq);
-					onEvent(parsed);
+				if (wantsPayload && !wantsPayload()) {
+					// Nothing is subscribed, so the payload has no reader. Take the
+					// sequence and skip the parse entirely.
+					const seq = readSseFrameSeq(frame);
+					if (seq !== undefined && seq > cursor) {
+						cursor = seq;
+						options?.onCursorAdvance?.(seq);
+					}
+				} else {
+					const parsed = parseSseFrame(frame);
+					if (parsed) {
+						cursor = Math.max(cursor, parsed.seq);
+						onEvent(parsed);
+					}
+				}
+				if (++sinceYield >= yieldEvery) {
+					sinceYield = 0;
+					await yieldToEventLoop();
+					if (signal.aborted) break;
 				}
 			}
 		}

--- a/packages/mobile/lib/chat/conversationEvents.ts
+++ b/packages/mobile/lib/chat/conversationEvents.ts
@@ -48,6 +48,16 @@ export function useConversationEventTransport(cfg: ServerConfig | null): void {
 							cursor = resetCursor;
 							cursorPersister.replace(resetCursor);
 						},
+						{
+							// Only the chat screen currently on top subscribes, so most frames
+							// have no reader — and during a cold-start replay, when no chat is
+							// open at all, none of them do. Those only need to move the cursor.
+							wantsPayload: () => registry.hasListeners(),
+							onCursorAdvance: (seq) => {
+								cursor = Math.max(cursor, seq);
+								cursorPersister.update(cursor);
+							},
+						},
 					);
 					delay = RECONNECT_MIN_MS;
 				} catch {

--- a/packages/mobile/lib/chat/sse.test.ts
+++ b/packages/mobile/lib/chat/sse.test.ts
@@ -20,6 +20,14 @@ describe("mobile conversation SSE", () => {
 		expect(parseSseFrame('id: 9\ndata: {"projectId":"p","type":"session_updated"}')?.seq).toBe(9);
 		expect(parseSseFrame("id: 10\ndata: nope")).toBeUndefined();
 	});
+
+	// The cursor only needs the `id:` line. Skipping JSON.parse for frames nobody is
+	// subscribed to is what keeps a 200k-event replay off the JS thread's critical path.
+	it("reads a frame's sequence without parsing its payload", () => {
+		expect(sse.readSseFrameSeq('id: 42\ndata: {"seq":42,"projectId":"p"}')).toBe(42);
+		expect(sse.readSseFrameSeq("id: 43\r\ndata: nonsense-that-is-never-parsed")).toBe(43);
+		expect(sse.readSseFrameSeq("data: {}")).toBeUndefined();
+	});
 });
 
 describe("conversation cursor persistence", () => {
@@ -64,6 +72,21 @@ describe("conversation cursor persistence", () => {
 		expect(persisted).toEqual([7]);
 	});
 
+	// A large cold-start replay saturates the JS thread, and the 500ms debounce is a
+	// macrotask — the very thing a saturated thread never gets to. Progress therefore
+	// has to commit on event count too, or a replay that is interrupted (or crashes the
+	// app) resumes from zero on the next launch and repeats forever.
+	it("persists progress by event count while timers are starved", () => {
+		vi.useFakeTimers();
+		const persisted: number[] = [];
+		const persister = sse.createCursorPersister((cursor) => { persisted.push(cursor); });
+
+		for (let seq = 1; seq <= sse.CURSOR_PERSIST_EVENTS; seq++) persister.update(seq);
+
+		// No timer has been advanced: the count alone must have committed.
+		expect(persisted).toEqual([sse.CURSOR_PERSIST_EVENTS]);
+	});
+
 	it("replaces a higher persisted cursor when the daemon reports a reset", () => {
 		vi.useFakeTimers();
 		const persisted: number[] = [];
@@ -97,6 +120,17 @@ describe("conversation event subscriptions", () => {
 		registry?.publish(event("session-2", 4));
 
 		expect(received).toEqual(["session-2"]);
+	});
+
+	it("reports whether anything is listening, so the stream can skip parsing", () => {
+		const registry = sse.createConversationEventRegistry();
+		expect(registry.hasListeners()).toBe(false);
+
+		const unsubscribe = registry.subscribe("session-1", () => {});
+		expect(registry.hasListeners()).toBe(true);
+
+		unsubscribe();
+		expect(registry.hasListeners()).toBe(false);
 	});
 
 	it("stops publishing after a listener unsubscribes", () => {

--- a/packages/mobile/lib/chat/sse.ts
+++ b/packages/mobile/lib/chat/sse.ts
@@ -10,6 +10,8 @@ export type ConversationEvent = {
 export type ConversationEventRegistry = {
 	subscribe(sessionId: string, listener: (event: ConversationEvent) => void): () => void;
 	publish(event: ConversationEvent): void;
+	/** Whether any session has a listener, i.e. whether payloads are worth parsing. */
+	hasListeners(): boolean;
 };
 
 export function createConversationEventRegistry(): ConversationEventRegistry {
@@ -24,6 +26,9 @@ export function createConversationEventRegistry(): ConversationEventRegistry {
 				if (sessionListeners.size === 0) listeners.delete(sessionId);
 			};
 		},
+		hasListeners() {
+			return listeners.size > 0;
+		},
 		publish(event) {
 			if (!event.sessionId) return;
 			for (const listener of listeners.get(event.sessionId) ?? []) listener(event);
@@ -33,12 +38,24 @@ export function createConversationEventRegistry(): ConversationEventRegistry {
 
 const CURSOR_PERSIST_DELAY_MS = 500;
 
+/**
+ * Events after which progress commits regardless of the debounce timer.
+ *
+ * The timer alone is not enough. A large cold-start replay keeps the JS thread
+ * busy, and `setTimeout` is a macrotask — so under exactly the conditions where
+ * saving progress matters most, the debounce never fires. A replay interrupted
+ * before its first commit then restarts from the same cursor on the next launch,
+ * forever. Counting events is immune to that, because it runs inline.
+ */
+export const CURSOR_PERSIST_EVENTS = 256;
+
 export function createCursorPersister(
 	persist: (cursor: number) => void | Promise<void>,
 ): { update(cursor: number): void; replace(cursor: number): void; flush(): void } {
 	let latest = 0;
 	let persisted = 0;
 	let timer: ReturnType<typeof setTimeout> | undefined;
+	let sinceCommit = 0;
 
 	const save = (cursor: number) => {
 		try {
@@ -49,7 +66,9 @@ export function createCursorPersister(
 		}
 	};
 	const commit = () => {
+		if (timer) clearTimeout(timer);
 		timer = undefined;
+		sinceCommit = 0;
 		if (latest <= persisted) return;
 		persisted = latest;
 		save(latest);
@@ -58,17 +77,23 @@ export function createCursorPersister(
 	return {
 		update(cursor) {
 			latest = Math.max(latest, cursor);
+			// Whichever comes first: a quiet moment (the debounce) or enough events
+			// that we refuse to risk losing the progress (the count).
+			if (++sinceCommit >= CURSOR_PERSIST_EVENTS) {
+				commit();
+				return;
+			}
 			if (!timer) timer = setTimeout(commit, CURSOR_PERSIST_DELAY_MS);
 		},
 		replace(cursor) {
 			if (timer) clearTimeout(timer);
 			timer = undefined;
+			sinceCommit = 0;
 			latest = cursor;
 			persisted = cursor;
 			save(cursor);
 		},
 		flush() {
-			if (timer) clearTimeout(timer);
 			commit();
 		},
 	};
@@ -85,6 +110,23 @@ export function takeSseFrames(buffer: string): { frames: string[]; remainder: st
 		boundary = /\r?\n\r?\n/.exec(remainder);
 	}
 	return { frames, remainder };
+}
+
+/**
+ * The frame's sequence from its `id:` line alone, without touching `data:`.
+ *
+ * Advancing the cursor is all a frame is worth when nothing is subscribed to its
+ * session, and that is the common case: the app subscribes only to the chat it
+ * currently has open. Parsing the payload anyway is what makes a large replay
+ * expensive, so this is the cheap path.
+ */
+export function readSseFrameSeq(frame: string): number | undefined {
+	for (const raw of frame.split("\n")) {
+		if (!raw.startsWith("id:")) continue;
+		const seq = Number(raw.slice(3).trim());
+		return Number.isFinite(seq) ? seq : undefined;
+	}
+	return undefined;
 }
 
 export function parseSseFrame(frame: string): ConversationEvent | undefined {

--- a/packages/mobile/lib/chatModeApi.test.ts
+++ b/packages/mobile/lib/chatModeApi.test.ts
@@ -217,6 +217,46 @@ describe("mobile Chat API boundaries", () => {
 		expect(cursor).toBe(2);
 	});
 
+	// A cold-start replay against a busy daemon is ~200k events. Draining it in one
+	// unbroken run starves the JS thread, which is also what services touches — the
+	// board renders but ignores taps until the OS or the renderer gives up. The reader
+	// must therefore hand the event loop back periodically, no matter how much is queued.
+	it("yields to the event loop while draining a large replay", async () => {
+		vi.mocked(expoFetch).mockResolvedValue(new Response(
+			replayFrames(300),
+		) as unknown as Awaited<ReturnType<typeof expoFetch>>);
+
+		const streaming = chatApi.streamGlobalConversationEvents(
+			cfg, 0, new AbortController().signal, () => {}, undefined, { yieldEvery: 50 },
+		);
+		// Queued after the read loop starts. It can only run if the loop yields a
+		// macrotask mid-drain; a loop that only awaits already-resolved promises stays
+		// entirely in the microtask queue and starves this.
+		let eventLoopGotATurn = false;
+		setTimeout(() => { eventLoopGotATurn = true; }, 0);
+
+		await streaming;
+
+		expect(eventLoopGotATurn).toBe(true);
+	});
+
+	it("advances the cursor without parsing payloads when nothing is subscribed", async () => {
+		vi.mocked(expoFetch).mockResolvedValue(new Response(
+			replayFrames(3),
+		) as unknown as Awaited<ReturnType<typeof expoFetch>>);
+		const parsed: number[] = [];
+		const advanced: number[] = [];
+
+		const cursor = await chatApi.streamGlobalConversationEvents(
+			cfg, 0, new AbortController().signal, (event) => parsed.push(event.seq), undefined,
+			{ wantsPayload: () => false, onCursorAdvance: (seq) => advanced.push(seq) },
+		);
+
+		expect(parsed).toEqual([]);
+		expect(advanced).toEqual([1, 2, 3]);
+		expect(cursor).toBe(3);
+	});
+
 	it("accepts the daemon's reset cursor after its event database is replaced", async () => {
 		vi.mocked(expoFetch).mockResolvedValue(new Response(
 			'id: 1\ndata: {"seq":1,"projectId":"p-1","sessionId":"w-1","type":"session_updated","createdAt":"2026-08-11"}\n\n',
@@ -235,6 +275,15 @@ describe("mobile Chat API boundaries", () => {
 		expect(cursor).toBe(1);
 	});
 });
+
+/** `count` well-formed SSE frames with sequences 1..count. */
+function replayFrames(count: number): string {
+	let out = "";
+	for (let seq = 1; seq <= count; seq++) {
+		out += `id: ${seq}\ndata: {"seq":${seq},"projectId":"p-1","sessionId":"w-1","type":"session_updated","payload":{"conversationId":"c-1"},"createdAt":"2026-08-11"}\n\n`;
+	}
+	return out;
+}
 
 function response(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });


### PR DESCRIPTION
Two commits. The first is the production fix that has shipped; the second is a small daemon-side hardening of the same failure mode.

---

## 1. `fix(mobile)`: stop a large event replay from aborting the app

### Problem

On a fresh install the conversation cursor starts at zero, so connecting asks the daemon for every event it has ever recorded. Against a real 80-session daemon that is **196,658 events / 47MB**, still streaming after 6 seconds.

Read through `expo/fetch`, each chunk emits an event to JS and takes a **JNI global reference** released only once JS consumes it. The reader awaited only already-buffered reads — those stay in the microtask queue — so it never yielded, JS never drained, references accumulated, and the runtime aborted the process on hitting the 51,200 table limit:

```
JNI ERROR (app bug): global reference table overflow (max=51200)
    50472 of java.lang.Object[] (1 elements)
  at expo.modules.fetch.NativeResponse.pumpResponseBodyStream(NativeResponse.kt:199)
Fatal signal 6 (SIGABRT)
```

Android reports this as `reason=5 (APP CRASH(NATIVE))` with no dialog, so it presents as the app silently vanishing a few seconds after connecting. Scrolling still worked while it was wedged — that is handled natively — but taps did not, because those need the JS thread.

### Fix

- **Yield a macrotask every 256 frames** inside the frame loop, so consumption keeps up and references are released. One chunk can carry thousands of events, so yielding per chunk is not enough.
- **Persist the cursor by event count** instead of a 500ms debounce. The debounce is a macrotask, so during exactly the drain where progress matters it never ran — every launch restarted from zero.
- **Skip parsing payloads while nothing is subscribed.** Only the chat screen currently open subscribes; during a cold replay none is, so ~196k `JSON.parse` calls were pure waste.

### Verification

- 459 tests, typecheck clean.
- `yields to the event loop while draining a large replay` fails on the pre-fix code — it reproduces the starvation in a unit test and now guards it.
- **On device** (Galaxy M31s, release build, `pm clear` before each run) against the 80-session daemon: baseline aborts at 50,472 references; this build drains cleanly and stays responsive. Relaunch is instant, confirming the cursor persists so catch-up happens once per install.
- **iOS** verified via a fresh TestFlight install against the same daemon — no hang. The JNI ceiling is Android-only, but the JS-thread starvation was not.

---

## 2. `fix(events)`: clamp a future cursor to head instead of replaying from zero

A cursor ahead of head means the `change_log` was truncated or replaced. The stream reset such a client to `0`, which costs it the entire backlog — and because every connected client is reset in the same moment, they stampede together.

It now falls back to head. The gap is recovered from the next snapshot fetch, so the cost is one refetch rather than a full replay.

The existing test asserted the reset-to-zero behaviour; it now asserts the clamp, and additionally that no event at or before head is replayed. `go test ./...` and `go test -race` pass.

---

## Known limitation

Together these make the replay **survivable and one-time — they do not make it smaller**. 47MB still crosses the network on a fresh install, and `pumpResponseBodyStream` has no backpressure.

The real fix is not replaying history at all: the client already loads history through paginated REST snapshots, and the sole stream consumer discards the payload and just refetches. A follow-up covers `from=head`, `maxCatchup`, and replacing the overflow-cancel-then-replay path with a resync signal — deliberately deferred, since the crash is resolved.