### PR TITLE
fix: keep desktop update feedback in sync

### DIFF
--- a/frontend/src/main/update-settings.ts
+++ b/frontend/src/main/update-settings.ts
@@ -17,8 +17,8 @@ export interface UpdateSettings {
 	feature: FeaturePin | null;
 }
 
-// Live state of a manual update check/download, streamed to the renderer so the
-// Global Settings "Check for updates" / "Update" buttons can reflect progress.
+// Live state of an automatic or manual update check/download, streamed to the
+// renderer so Settings and the sidebar can reflect progress.
 export type UpdateState =
 	"idle" | "checking" | "available" | "not-available" | "downloading" | "downloaded" | "error" | "unsupported";
 

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -344,6 +344,29 @@ describe("GlobalSettingsForm", () => {
 		await waitFor(() => expect(button).toBeEnabled());
 	});
 
+	it("stops manual loading when the updater completes before the check invocation settles", async () => {
+		let emit: (status: { state: string; checkedAt?: number; requestId?: string }) => void = () => undefined;
+		updOnStatus.mockImplementation((listener: (status: unknown) => void) => {
+			emit = listener as typeof emit;
+			return () => undefined;
+		});
+		updCheck.mockReturnValue(new Promise<void>(() => undefined));
+		renderForm();
+		const button = await screen.findByRole("button", { name: "Check for updates" });
+
+		await userEvent.click(button);
+		const requestId = updCheck.mock.calls[0]?.[0]?.requestId;
+		expect(requestId).toMatch(/^manual-update-/);
+		act(() => emit({ state: "not-available", checkedAt: Date.now() }));
+		expect(screen.getByRole("status")).toHaveTextContent("Checking for updates…");
+		expect(button).toBeDisabled();
+
+		act(() => emit({ state: "not-available", checkedAt: Date.now(), requestId }));
+
+		expect(screen.getByRole("status")).toHaveTextContent("You're on the latest version.");
+		expect(button).toBeEnabled();
+	});
+
 	it("shows when the updater last completed a check", async () => {
 		const checkedAt = new Date("2026-08-19T12:51:00.000Z").getTime();
 		updGetStatus.mockResolvedValue({ state: "not-available", checkedAt });

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1596,11 +1596,21 @@ describe("Sidebar", () => {
 		expect(screen.queryByLabelText("Open merged terminated task")).not.toBeInTheDocument();
 	});
 
-	it("does not render the restart-to-update row unless an update is downloaded", async () => {
+	it("shows update activity before an available update finishes downloading", async () => {
 		updateStatusMock.mockResolvedValue({ state: "available", version: "9.9.9" });
 		renderSidebar();
 
 		await waitFor(() => expect(updateStatusMock).toHaveBeenCalled());
+		expect(screen.getByText("Update available (v9.9.9).")).toBeInTheDocument();
+		expect(screen.queryByLabelText(/Restart to install update/)).not.toBeInTheDocument();
+	});
+
+	it("keeps showing update activity while the automatic download is in progress", async () => {
+		updateStatusMock.mockResolvedValue({ state: "downloading", version: "9.9.9", percent: 42 });
+		renderSidebar();
+
+		await waitFor(() => expect(updateStatusMock).toHaveBeenCalled());
+		expect(screen.getByText("Downloading… 42%")).toBeInTheDocument();
 		expect(screen.queryByLabelText(/Restart to install update/)).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
 import {
 	ChevronRight,
+	Download,
 	Folder,
 	FolderOpen,
 	LogOut,
@@ -429,7 +430,7 @@ export function Sidebar({
 					aria-hidden={isCollapsed || undefined}
 					className="sidebar-expanded-chrome relative flex w-full min-w-46.5 flex-col gap-0.5 transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0"
 				>
-					<RestartToUpdateRow status={updateStatus} tabIndex={isCollapsed ? -1 : 0} />
+					<UpdateStatusRow status={updateStatus} tabIndex={isCollapsed ? -1 : 0} />
 					<CloudAccountRow tabIndex={isCollapsed ? -1 : 0} />
 					<button
 						aria-label={t("shell.settings")}
@@ -449,7 +450,7 @@ export function Sidebar({
 					aria-hidden={!isCollapsed || undefined}
 					className="pointer-events-none absolute inset-x-1.5 bottom-0 top-auto flex min-h-row-md flex-col items-center justify-end gap-1 opacity-0 transition-opacity duration-150 ease-out group-data-[collapsible=icon]:pointer-events-auto group-data-[collapsible=icon]:opacity-100"
 				>
-					<RestartToUpdateRailButton status={updateStatus} tabIndex={isCollapsed ? 0 : -1} />
+					<UpdateStatusRail status={updateStatus} tabIndex={isCollapsed ? 0 : -1} />
 					<CloudAccountRailButton tabIndex={isCollapsed ? 0 : -1} />
 					<Tooltip>
 						<TooltipTrigger asChild>
@@ -1098,13 +1099,30 @@ function CloudAccountRailButton({ tabIndex }: { tabIndex: number }) {
 	);
 }
 
-// RestartToUpdateRow sits directly above the Settings row when an update is
-// downloaded and staged. Transparent while fresh; orange (working tokens) once
-// the main-process evaluator flags it escalated. Clicking installs immediately;
-// the row itself is the prompt, so no confirmation dialog. Renders nothing in
-// every other update state.
-function RestartToUpdateRow({ status, tabIndex }: { status: UpdateStatus; tabIndex: number }) {
+// UpdateStatusRow makes automatic update activity visible before the build is
+// staged, then becomes the existing restart action once installation is ready.
+// Idle/checking states stay quiet so routine background checks do not flash in
+// the sidebar.
+function UpdateStatusRow({ status, tabIndex }: { status: UpdateStatus; tabIndex: number }) {
 	const { t } = useTranslation();
+	if (status.state === "available" || status.state === "downloading") {
+		const label =
+			status.state === "available"
+				? t("settings.updates.available", { version: status.version ? ` (v${status.version})` : "" })
+				: t("settings.updates.downloading", { percent: status.percent ?? 0 });
+		return (
+			<div
+				aria-live="polite"
+				className="flex w-full items-center gap-2.5 rounded-lg p-2.5 text-left text-control font-medium text-passive"
+				role="status"
+			>
+				<Download aria-hidden="true" className="size-icon-lg shrink-0" />
+				<span className={cn("min-w-0 flex-1 truncate", status.state === "downloading" && "tabular-nums")}>
+					{label}
+				</span>
+			</div>
+		);
+	}
 	if (status.state !== "downloaded") return null;
 	const escalated = status.escalated === true;
 	return (
@@ -1141,10 +1159,31 @@ function RestartToUpdateRow({ status, tabIndex }: { status: UpdateStatus; tabInd
 	);
 }
 
-// Icon-rail variant of RestartToUpdateRow for the collapsed sidebar: icon-only
-// with the two-line copy in the tooltip.
-function RestartToUpdateRailButton({ status, tabIndex }: { status: UpdateStatus; tabIndex: number }) {
+// Icon-rail variant of UpdateStatusRow. Pre-download states are informational;
+// only a staged update becomes a button.
+function UpdateStatusRail({ status, tabIndex }: { status: UpdateStatus; tabIndex: number }) {
 	const { t } = useTranslation();
+	if (status.state === "available" || status.state === "downloading") {
+		const label =
+			status.state === "available"
+				? t("settings.updates.available", { version: status.version ? ` (v${status.version})` : "" })
+				: t("settings.updates.downloading", { percent: status.percent ?? 0 });
+		return (
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span
+						aria-label={label}
+						aria-live="polite"
+						className="grid size-9 place-items-center rounded-lg text-passive [&_svg]:size-4"
+						role="status"
+					>
+						<Download aria-hidden="true" />
+					</span>
+				</TooltipTrigger>
+				<TooltipContent side="right">{label}</TooltipContent>
+			</Tooltip>
+		);
+	}
 	if (status.state !== "downloaded") return null;
 	const escalated = status.escalated === true;
 	return (

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -24,9 +24,9 @@ const DEFAULT_SETTINGS: UpdateSettings = { enabled: false, channel: "latest", ni
 
 let updateRequestSequence = 0;
 
-function nextUpdateRequestId(): string {
+function nextUpdateRequestId(prefix = "feature-update"): string {
 	updateRequestSequence += 1;
-	return `feature-update-${updateRequestSequence}`;
+	return `${prefix}-${updateRequestSequence}`;
 }
 
 export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) {
@@ -289,8 +289,9 @@ function FeatureBuildsSelect({
 function UpdateActions({ status }: { status: UpdateStatus }) {
 	const { t, i18n } = useTranslation();
 	const version = useQuery({ queryKey: ["app-version"], queryFn: () => aoBridge.app.getVersion() });
-	const [manualCheckPending, setManualCheckPending] = useState(false);
+	const [manualCheckRequestId, setManualCheckRequestId] = useState<string | null>(null);
 
+	const manualCheckPending = manualCheckRequestId !== null;
 	const checking = status.state === "checking" || manualCheckPending;
 	const downloading = status.state === "downloading";
 	const busy = checking || downloading;
@@ -304,14 +305,20 @@ function UpdateActions({ status }: { status: UpdateStatus }) {
 			}).format(status.checkedAt)
 		: null;
 
+	useEffect(() => {
+		if (manualCheckRequestId === null || status.requestId !== manualCheckRequestId) return;
+		if (status.state !== "checking") setManualCheckRequestId(null);
+	}, [manualCheckRequestId, status.requestId, status.state]);
+
 	const checkNow = async () => {
-		setManualCheckPending(true);
+		const requestId = nextUpdateRequestId("manual-update");
+		setManualCheckRequestId(requestId);
 		try {
-			await aoBridge.updates.check();
+			await aoBridge.updates.check({ requestId });
 		} catch {
 			// The main process publishes the actionable updater error state.
 		} finally {
-			setManualCheckPending(false);
+			setManualCheckRequestId((pending) => (pending === requestId ? null : pending));
 		}
 	};
 


### PR DESCRIPTION
Fixes #4284

## Summary

- correlate manual update checks with request IDs so a terminal updater event clears loading even when the IPC invocation settles late
- show available and downloading update states in the sidebar before the existing restart-to-update action becomes available
- keep pre-download sidebar states informational and accessible; installation remains possible only after the update is staged

## Root cause

The Settings view kept a renderer-local loading flag tied to the IPC promise, which could outlive the matching terminal updater status. Separately, the sidebar explicitly returned nothing for every update state except `downloaded`, so successful automatic checks and downloads appeared inactive.

## Tests

- `cd frontend && npm test -- --run src/renderer/components/Sidebar.test.tsx src/renderer/components/GlobalSettingsForm.test.tsx src/main/auto-updater.test.ts` — 147 passed
- `cd frontend && npm run typecheck` — passed

## Known follow-up

Automatic updater network failures remain intentionally suppressed from the sidebar. The existing recovery nudge from #3526 is still visible only in Settings and is not changed by this PR.