### PR TITLE
fix: restore muted Files Changed header on turn card

### DIFF
--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -1908,9 +1908,9 @@ function fileChangeVerb(status: DiffStatus): string {
 /**
  * What a turn changed on disk.
  *
- * FileDiff icon, white “N files changed”, and +/− totals on the header; the
- * file list stays visible below. Review opens the Files rail, and clicking a
- * row focuses that path.
+ * A bordered summary card at the end of the turn (kept near rollback), not the
+ * compact explore line used for mid-turn activity. Always shows the changed
+ * files; Review opens the Files rail, and clicking a row focuses that path.
  *
  * Rendered only when the daemon reported a diff. An agent that cannot report one
  * gets no empty panel implying it changed nothing.
@@ -1942,15 +1942,12 @@ export function TurnChangedFiles({
 	const previewLimit = 4;
 	const hidden = Math.max(0, diff.files.length - previewLimit);
 	const visible = expanded ? diff.files : diff.files.slice(0, previewLimit);
-	const additions = diff.files.reduce((sum, file) => sum + file.additions, 0);
-	const deletions = diff.files.reduce((sum, file) => sum + file.deletions, 0);
 
 	return (
 		<div className="overflow-hidden rounded-lg bg-surface">
 			<div className="flex items-center gap-2 px-3 py-2">
-				<FileDiff aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
-				<span className="text-xs font-semibold text-foreground">
-					{diff.files.length === 1 ? "1 file changed" : `${diff.files.length} files changed`}
+				<span className="shrink-0 text-[11px] text-muted-foreground">
+					{diff.files.length === 1 ? "1 File Changed" : `${diff.files.length} Files Changed`}
 				</span>
 				{live ? (
 					<Loader2
@@ -1959,10 +1956,6 @@ export function TurnChangedFiles({
 					/>
 				) : null}
 				<span className="flex-1" />
-				<span className="shrink-0 font-mono text-[10.5px] tabular-nums">
-					<span className="text-success">+{additions}</span>{" "}
-					<span className="text-destructive">&minus;{deletions}</span>
-				</span>
 				{onReview ? (
 					<button
 						type="button"

--- a/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
@@ -38,15 +38,13 @@ function commandActivity(
 
 describe("TurnChangedFiles", () => {
 	it("shows the bordered summary with files visible", () => {
-		const { container } = render(<TurnChangedFiles diff={diff()} />);
-		expect(container.querySelector(".lucide-file-diff")).toBeTruthy();
-		expect(screen.getByText("2 files changed")).toHaveClass("text-xs", "font-semibold", "text-foreground");
+		render(<TurnChangedFiles diff={diff()} />);
+		expect(screen.getByText("2 Files Changed")).toBeInTheDocument();
 		expect(screen.getByText("a.ts")).toBeInTheDocument();
 		expect(screen.getByText("new.ts")).toBeInTheDocument();
-		expect(screen.getByText("+52")).toBeInTheDocument();
 		expect(screen.getByText("+12")).toBeInTheDocument();
 		expect(screen.getByText("+40")).toBeInTheDocument();
-		expect(screen.getAllByText("−3")).toHaveLength(2);
+		expect(screen.getByText("−3")).toBeInTheDocument();
 	});
 
 	it("offers Review when a handler is provided", async () => {
@@ -146,7 +144,7 @@ describe("TurnChangedFiles", () => {
 				}}
 			/>,
 		);
-		expect(screen.getByText("1 file changed")).toBeInTheDocument();
+		expect(screen.getByText("1 File Changed")).toBeInTheDocument();
 		expect(screen.getByText("new.ts")).toBeInTheDocument();
 		await user.hover(screen.getByText("new.ts"));
 		expect(await screen.findByRole("tooltip")).toHaveTextContent("src/old.ts → src/new.ts");


### PR DESCRIPTION
## Summary
- Restore the turn changed-files card header to muted title-case “N Files Changed”.
- Remove the FileDiff icon and aggregate +/- totals from the header (per-file stats in the list stay).

## Test plan
- [ ] Complete a turn that edits files → card header reads “N Files Changed” in muted text
- [ ] Confirm no FileDiff icon / header +/- totals
- [ ] Per-file rows still show basename, +/-, and Review / open-in-Files
- [ ] `cd frontend && npm run test -- src/renderer/components/chat/TurnChangedFiles.test.tsx`