### PR TITLE
fix: drop hover fill on compact chat activity rows

### DIFF
--- a/frontend/src/renderer/components/chat/activity-command.ts
+++ b/frontend/src/renderer/components/chat/activity-command.ts
@@ -5,7 +5,7 @@ export type CommandCategory = "read" | "search" | "vcs" | "run";
 
 /** Shared chrome for one command summary and a collapsed run of commands. */
 export const ACTIVITY_SUMMARY_BUTTON_CLASS =
-	"group/run flex w-full items-center gap-1.5 rounded-sm py-0.5 pr-1 text-left outline-none transition-colors hover:bg-interactive-hover focus-visible:outline-none";
+	"group/run flex w-full items-center gap-1.5 rounded-sm py-0.5 pr-1 text-left outline-none focus-visible:outline-none";
 
 /** A completed shell command that reported an ordinary non-zero process exit. */
 export function isNonzeroCommandExit(activity: ConversationActivity): boolean {


### PR DESCRIPTION
## Summary
- Remove `hover:bg-interactive-hover` from `ACTIVITY_SUMMARY_BUTTON_CLASS`, used by compact command/file-change rows and collapsed `ActivityRun` groups.
- Keeps the chevron hover affordance; only the row background fill is gone.

## Test plan
- [ ] Hover “Edited N files” / “Ran command” rows — no background pill
- [ ] Click still expands the row; chevron still brightens on hover
- [ ] Grouped activity runs behave the same