### PR TITLE
fix: move Queue/Steer chips inside the composer toolbar

### DIFF
--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -28,6 +28,8 @@
  */
 
 import {
+	cloneElement,
+	isValidElement,
 	useCallback,
 	useEffect,
 	useId,
@@ -144,7 +146,7 @@ export function ChatComposer({
 	commandError?: string;
 	/** A queued-message dock owns the shared rounded top edge. */
 	attachedTop?: boolean;
-	/** Queued messages rendered above the composer, below the delivery choice. */
+	/** Queued messages rendered above the composer. */
 	queuedDock?: ReactNode;
 	/** Run AO's built-in `/compact` command instead of sending it to the agent. */
 	onCompact?: () => void | Promise<unknown>;
@@ -543,7 +545,10 @@ export function ChatComposer({
 		canSteer && onSteer ? (
 			<DeliveryChoice value={activeDelivery} disabled={steerPending} />
 		) : null;
-	const settingsNode = settings;
+	const settingsNode =
+		settings && deliveryChoice && isValidElement(settings)
+			? cloneElement(settings, undefined, deliveryChoice)
+			: settings;
 
 	if (approval) {
 		return (
@@ -567,7 +572,6 @@ export function ChatComposer({
 
 	return (
 		<>
-		{deliveryChoice}
 		{queuedDock}
 		<form
 			// Clicking send while Cmd/Ctrl is held has to mean what the indicator
@@ -714,6 +718,7 @@ export function ChatComposer({
 						</>
 					) : null}
 					{settingsNode}
+					{!settings && deliveryChoice}
 				</div>
 
 				<div

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
@@ -91,7 +91,7 @@ export function TurnSettingsBar({
 	configPending?: boolean;
 	error?: string;
 	disabled?: boolean;
-	/** Inline controls that belong on the model row, such as queue vs steer. */
+	/** Inline controls on the right model row, before the mode/approval picker — queue vs steer. */
 	children?: ReactNode;
 }) {
 	const selected = models.find((model) => model.id === settings.model);
@@ -119,7 +119,7 @@ export function TurnSettingsBar({
 	const nativeModelMenu = Boolean(onChange && models.length > 0 && grouped.model.length === 0);
 	const clubbedLeft = grouped.model.length > 0 || grouped.effort.length > 0 || grouped.extra.length > 0;
 	const modeOption = grouped.mode;
-	const showRight = Boolean(onChange || modeOption);
+	const showRightDropdown = Boolean(onChange || modeOption);
 
 	return (
 		<div role="group" aria-label="Turn settings" className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -143,8 +143,6 @@ export function TurnSettingsBar({
 						/>
 					) : null}
 
-					{children}
-
 					{onChangeConfigOption && clubbedLeft && !nativeModelMenu ? (
 						<ClubbedConfigPicker
 							modelOptions={grouped.model}
@@ -156,8 +154,9 @@ export function TurnSettingsBar({
 					) : null}
 				</div>
 
-				{showRight ? (
+				{showRightDropdown || children ? (
 					<div className="flex h-7 shrink-0 items-center gap-1">
+						{children}
 						{modeOption && onChangeConfigOption ? (
 							<ConfigOptionPicker
 								option={modeOption}


### PR DESCRIPTION
## Summary
- Move Queue/Steer from above the composer into the bottom toolbar, immediately before the right-side mode/approval dropdown.
- Pass delivery chips through `TurnSettingsBar` children; fall back to the tools row when settings are absent.

## Test plan
- [ ] Start a chat turn so Queue/Steer appears
- [ ] Confirm chips sit inside the composer, left of the Default/approvals control
- [ ] Confirm Cmd/Ctrl+Enter still steers and bare Enter still queues
- [ ] `npx vitest run src/renderer/components/chat/ChatSteer.test.tsx src/renderer/components/chat/ChatComposer.test.tsx src/renderer/components/chat/TurnSettingsBar.test.tsx`

## screenshot
<img width="680" height="225" alt="image" src="https://github.com/user-attachments/assets/e59f4e7d-f9a3-4b45-ace6-9e4b5997b667" />
