### PR TITLE
fix(chat): keep Codex prompt forks on one writer

### DIFF
--- a/backend/internal/adapters/chatdriver/codexappserver/conversation.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conversation.go
@@ -46,8 +46,10 @@ type conversation struct {
 	proc *process
 	log  *slog.Logger
 
-	threadID string
-	events   chan ports.ChatEvent
+	threadMu      sync.RWMutex
+	threadID      string
+	loadedThreads map[string]struct{}
+	events        chan ports.ChatEvent
 	// Effective defaults returned when Codex opened or resumed this thread.
 	threadModel, threadEffort string
 
@@ -104,11 +106,12 @@ var _ ports.ChatMCPReloader = (*conversation)(nil)
 
 func newConversation(proc *process, log *slog.Logger) *conversation {
 	c := &conversation{
-		proc:     proc,
-		log:      log,
-		events:   make(chan ports.ChatEvent, eventBuffer),
-		pending:  make(map[string]*parkedRequest),
-		pumpDone: make(chan struct{}),
+		proc:          proc,
+		log:           log,
+		loadedThreads: make(map[string]struct{}),
+		events:        make(chan ports.ChatEvent, eventBuffer),
+		pending:       make(map[string]*parkedRequest),
+		pumpDone:      make(chan struct{}),
 	}
 	c.conn = newConn(proc.stdin, proc.stdout, log, c.handleServerRequest)
 	return c
@@ -118,14 +121,47 @@ func newConversation(proc *process, log *slog.Logger) *conversation {
 // called once, after the thread is open, so no event is emitted for a
 // conversation the caller does not yet have a handle to.
 func (c *conversation) start(threadID, model, effort string) {
+	c.threadMu.Lock()
 	c.threadID = threadID
+	c.loadedThreads[threadID] = struct{}{}
+	c.threadMu.Unlock()
 	c.threadModel = model
 	c.threadEffort = effort
 	go c.pump()
 }
 
 // ProviderConversationID is the Codex thread id AO persists for resume.
-func (c *conversation) ProviderConversationID() string { return c.threadID }
+func (c *conversation) ProviderConversationID() string {
+	c.threadMu.RLock()
+	defer c.threadMu.RUnlock()
+	return c.threadID
+}
+
+// BindProviderConversation retargets this live connection to a thread the same
+// app-server process already loaded. Codex thread/fork loads and writer-locks the
+// fork immediately, so handing its id to a second process is invalid while this
+// connection remains alive.
+func (c *conversation) BindProviderConversation(providerConversationID string) bool {
+	providerConversationID = strings.TrimSpace(providerConversationID)
+	if providerConversationID == "" {
+		return false
+	}
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	c.threadMu.Lock()
+	defer c.threadMu.Unlock()
+	if _, ok := c.loadedThreads[providerConversationID]; !ok {
+		return false
+	}
+	c.threadID = providerConversationID
+	return true
+}
+
+func (c *conversation) rememberLoadedThread(providerConversationID string) {
+	c.threadMu.Lock()
+	c.loadedThreads[providerConversationID] = struct{}{}
+	c.threadMu.Unlock()
+}
 
 // Capabilities reports what this conversation can do.
 func (c *conversation) Capabilities() ports.ChatCapabilities { return capabilities() }
@@ -149,7 +185,7 @@ func (c *conversation) pump() {
 		// as an absolute instant and has to become a remaining duration, and a
 		// normalizer that reads the clock itself cannot be tested deterministically.
 		for _, ev := range normalizeNotification(n, time.Now()) {
-			rootConversation := ev.ProviderConversationID == "" || ev.ProviderConversationID == c.threadID
+			rootConversation := ev.ProviderConversationID == "" || ev.ProviderConversationID == c.ProviderConversationID()
 			if ev.Kind == ports.ChatEventTurnStarted && ev.ProviderTurnID != "" && rootConversation {
 				c.mu.Lock()
 				c.activeTurn = ev.ProviderTurnID
@@ -233,7 +269,7 @@ func (c *conversation) SendTurn(ctx context.Context, msg ports.ChatUserMessage) 
 	defer c.sendMu.Unlock()
 
 	params := map[string]any{
-		"threadId": c.threadID,
+		"threadId": c.ProviderConversationID(),
 		"input":    []any{map[string]any{"type": "text", "text": msg.Text}},
 	}
 	if msg.ClientMessageID != "" {
@@ -407,7 +443,7 @@ func (c *conversation) Compact(ctx context.Context) (ports.ChatCompactionResult,
 	// id: compaction is a property of the thread, and passing turn-shaped params
 	// here is rejected.
 	if err := c.conn.request(ctx, "thread/compact/start", map[string]any{
-		"threadId": c.threadID,
+		"threadId": c.ProviderConversationID(),
 	}, nil); err != nil {
 		return ports.ChatCompactionResult{}, fmt.Errorf("thread/compact/start: %w", err)
 	}
@@ -503,7 +539,7 @@ func (c *conversation) Interrupt(ctx context.Context, providerTurnID string) err
 		return ports.ErrChatNoActiveTurn
 	}
 	if err := c.conn.request(ctx, "turn/interrupt", map[string]any{
-		"threadId": c.threadID,
+		"threadId": c.ProviderConversationID(),
 		"turnId":   providerTurnID,
 	}, nil); err != nil {
 		// The provider refuses an interrupt for a turn it does not consider
@@ -748,7 +784,7 @@ func (c *conversation) ReloadMCPServers(ctx context.Context) ([]ports.ChatMCPSer
 		// The summary form: the full one returns every tool's JSON Schema, which for a
 		// handful of servers is hundreds of kilobytes AO would immediately discard.
 		"detail":   "summary",
-		"threadId": c.threadID,
+		"threadId": c.ProviderConversationID(),
 	}, &resp); err != nil {
 		// The reload itself succeeded, and that is the part the caller asked for. The
 		// pushed notifications will report the outcome regardless.

--- a/backend/internal/adapters/chatdriver/codexappserver/history.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/history.go
@@ -45,11 +45,12 @@ import (
 // feature-detects each interface, and a missing method would read as "the provider
 // cannot do this" with nothing anywhere to notice.
 var (
-	_ ports.ChatRollbacker       = (*conversation)(nil)
-	_ ports.ChatForker           = (*conversation)(nil)
-	_ ports.ChatRenamer          = (*conversation)(nil)
-	_ ports.ChatHistoryReader    = (*conversation)(nil)
-	_ ports.ChatHistoryRefresher = (*conversation)(nil)
+	_ ports.ChatRollbacker         = (*conversation)(nil)
+	_ ports.ChatForker             = (*conversation)(nil)
+	_ ports.ChatConversationBinder = (*conversation)(nil)
+	_ ports.ChatRenamer            = (*conversation)(nil)
+	_ ports.ChatHistoryReader      = (*conversation)(nil)
+	_ ports.ChatHistoryRefresher   = (*conversation)(nil)
 )
 
 // providerRefusal marks a request the provider rejected on its own terms, as
@@ -105,10 +106,11 @@ type providerTurn struct {
 // terminal visible in AO's structured timeline as well; resuming the thread alone
 // preserves model context but does not make app-server re-emit old notifications.
 func (c *conversation) ReadHistory(ctx context.Context) ([]ports.ChatEvent, error) {
+	threadID := c.ProviderConversationID()
 	var resp codexproto.ThreadReadResponse
 	includeTurns := true
 	if err := c.conn.request(ctx, codexproto.MethodThreadRead, codexproto.ThreadReadParams{
-		ThreadID:     c.threadID,
+		ThreadID:     threadID,
 		IncludeTurns: &includeTurns,
 	}, &resp); err != nil {
 		return nil, asRefusal(fmt.Errorf("thread/read history: %w", err))
@@ -127,7 +129,7 @@ func (c *conversation) ReadHistory(ctx context.Context) ([]ports.ChatEvent, erro
 
 		events = append(events, ports.ChatEvent{
 			Kind:            ports.ChatEventTurnStarted,
-			ProviderEventID: historyEventID(c.threadID, turn.ID, "started"),
+			ProviderEventID: historyEventID(threadID, turn.ID, "started"),
 			ProviderTurnID:  turn.ID,
 		})
 
@@ -152,11 +154,11 @@ func (c *conversation) ReadHistory(ctx context.Context) ([]ports.ChatEvent, erro
 				}
 				clientID := deref(item.ClientID)
 				if clientID == "" {
-					clientID = historyEventID(c.threadID, turn.ID, "user", eventItemID)
+					clientID = historyEventID(threadID, turn.ID, "user", eventItemID)
 				}
 				events = append(events, ports.ChatEvent{
 					Kind:            ports.ChatEventUserMessageCompleted,
-					ProviderEventID: historyEventID(c.threadID, turn.ID, "user", eventItemID),
+					ProviderEventID: historyEventID(threadID, turn.ID, "user", eventItemID),
 					ProviderTurnID:  turn.ID,
 					ProviderItemID:  itemID,
 					ClientMessageID: clientID,
@@ -166,7 +168,7 @@ func (c *conversation) ReadHistory(ctx context.Context) ([]ports.ChatEvent, erro
 			}
 
 			params, err := json.Marshal(map[string]any{
-				"threadId": c.threadID,
+				"threadId": threadID,
 				"turnId":   turn.ID,
 				"item":     item,
 			})
@@ -175,14 +177,14 @@ func (c *conversation) ReadHistory(ctx context.Context) ([]ports.ChatEvent, erro
 			}
 			for eventIndex, event := range normalizeItem(params, true) {
 				event.ProviderEventID = historyEventID(
-					c.threadID, turn.ID, "item", eventItemID, string(event.Kind), fmt.Sprint(eventIndex))
+					threadID, turn.ID, "item", eventItemID, string(event.Kind), fmt.Sprint(eventIndex))
 				events = append(events, event)
 			}
 		}
 
 		completed := ports.ChatEvent{
 			Kind:            ports.ChatEventTurnCompleted,
-			ProviderEventID: historyEventID(c.threadID, turn.ID, "completed"),
+			ProviderEventID: historyEventID(threadID, turn.ID, "completed"),
 			ProviderTurnID:  turn.ID,
 			TurnState:       state,
 		}
@@ -284,7 +286,7 @@ func (c *conversation) Rollback(ctx context.Context, providerTurnID string) erro
 	}
 
 	if err := c.conn.request(ctx, "thread/rollback", map[string]any{
-		"threadId": c.threadID,
+		"threadId": c.ProviderConversationID(),
 		"numTurns": discard,
 	}, nil); err != nil {
 		return asRefusal(fmt.Errorf("thread/rollback: %w", err))
@@ -305,7 +307,7 @@ func (c *conversation) readTurns(ctx context.Context) ([]providerTurn, error) {
 		} `json:"thread"`
 	}
 	if err := c.conn.request(ctx, "thread/read", map[string]any{
-		"threadId":     c.threadID,
+		"threadId":     c.ProviderConversationID(),
 		"includeTurns": true,
 	}, &resp); err != nil {
 		return nil, asRefusal(fmt.Errorf("thread/read: %w", err))
@@ -322,7 +324,7 @@ func (c *conversation) Fork(ctx context.Context, lastProviderTurnID *string) (st
 	c.sendMu.Lock()
 	defer c.sendMu.Unlock()
 
-	params := codexproto.ThreadForkParams{ThreadID: c.threadID}
+	params := codexproto.ThreadForkParams{ThreadID: c.ProviderConversationID()}
 	if lastProviderTurnID != nil {
 		anchor := strings.TrimSpace(*lastProviderTurnID)
 		if anchor == "" {
@@ -340,6 +342,7 @@ func (c *conversation) Fork(ctx context.Context, lastProviderTurnID *string) (st
 	if resp.Thread.ID == "" {
 		return "", errors.New("thread/fork returned no thread id")
 	}
+	c.rememberLoadedThread(resp.Thread.ID)
 	return resp.Thread.ID, nil
 }
 
@@ -360,7 +363,7 @@ func (c *conversation) SetTitle(ctx context.Context, title string) error {
 	defer c.sendMu.Unlock()
 
 	if err := c.conn.request(ctx, "thread/name/set", map[string]any{
-		"threadId": c.threadID,
+		"threadId": c.ProviderConversationID(),
 		"name":     trimmed,
 	}, nil); err != nil {
 		return asRefusal(fmt.Errorf("thread/name/set: %w", err))

--- a/backend/internal/adapters/chatdriver/codexappserver/history_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/history_test.go
@@ -328,6 +328,40 @@ func TestForkThroughTurnSendsLastTurnID(t *testing.T) {
 	}
 }
 
+func TestLoadedForkCanBecomeTheLiveConversationWithoutResume(t *testing.T) {
+	conv, srv := openConversation(t)
+	srv.reply("thread/fork", `{"thread":{"id":"thread-2"},"cwd":"/tmp/ws"}`)
+
+	forked, err := conv.Fork(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	if !conv.BindProviderConversation(forked) {
+		t.Fatalf("BindProviderConversation(%q) = false", forked)
+	}
+	if got := conv.ProviderConversationID(); got != "thread-2" {
+		t.Fatalf("provider conversation = %q, want thread-2", got)
+	}
+	if conv.BindProviderConversation("thread-not-loaded") {
+		t.Fatal("bound a provider conversation this app-server did not load")
+	}
+
+	srv.reply("thread/name/set", `{}`)
+	if err := conv.SetTitle(context.Background(), "fork title"); err != nil {
+		t.Fatalf("SetTitle on bound fork: %v", err)
+	}
+	frame := srv.awaitFrame(func(f frame) bool { return f.Method == "thread/name/set" })
+	var params struct {
+		ThreadID string `json:"threadId"`
+	}
+	if err := json.Unmarshal(frame.Params, &params); err != nil {
+		t.Fatalf("decode thread/name/set: %v", err)
+	}
+	if params.ThreadID != "thread-2" {
+		t.Fatalf("thread/name/set target = %q, want bound fork", params.ThreadID)
+	}
+}
+
 func TestForkRejectsAResponseWithNoThreadID(t *testing.T) {
 	conv, srv := openConversation(t)
 	srv.reply("thread/fork", `{"thread":{}}`)

--- a/backend/internal/adapters/chatdriver/codexappserver/live_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/live_test.go
@@ -2,6 +2,7 @@ package codexappserver
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -167,6 +168,7 @@ collect:
 	}); err != nil {
 		t.Fatalf("SendTurn on loaded fork: %v", err)
 	}
+forkComplete:
 	for {
 		select {
 		case ev, ok := <-resumed.Events():
@@ -177,7 +179,7 @@ collect:
 				if ev.TurnState != domain.TurnStateCompleted {
 					t.Fatalf("fork turn state = %q", ev.TurnState)
 				}
-				return
+				break forkComplete
 			}
 			if ev.Kind == ports.ChatEventControllerState && ev.ControllerState == ports.ChatControllerStopped {
 				t.Fatalf("controller stopped before fork turn completed: %v", ev.Err)
@@ -186,6 +188,39 @@ collect:
 			t.Fatalf("waiting for fork turn: %v", ctx.Err())
 		}
 	}
+
+	// A fork is loaded and writer-owned by the app-server that created it. Starting
+	// another app-server against the same thread must fail until that creator exits;
+	// this is the production boundary that made resume-after-fork lose edited sends.
+	forkResumeConfig := ports.ChatResumeConfig{
+		SessionID:              "ao-live-fork-resume",
+		ProviderConversationID: forkedID,
+		WorkspacePath:          workspace,
+		Env:                    envMap(),
+		Permissions:            ports.PermissionModeDefault,
+	}
+	contender, err := d.Resume(ctx, forkResumeConfig)
+	if err == nil {
+		_ = contender.Close()
+		t.Fatalf("second app-server resumed writer-owned fork %s", forkedID)
+	}
+	if !errors.Is(err, ports.ErrChatResumeFailed) {
+		t.Fatalf("resume writer-owned fork error = %v, want ErrChatResumeFailed", err)
+	}
+	t.Logf("second app-server rejected while fork owner remained open: %v", err)
+
+	if err := resumed.Close(); err != nil {
+		t.Fatalf("Close fork owner: %v", err)
+	}
+	released, err := d.Resume(ctx, forkResumeConfig)
+	if err != nil {
+		t.Fatalf("Resume fork after owner close: %v", err)
+	}
+	defer func() { _ = released.Close() }()
+	if got := released.ProviderConversationID(); got != forkedID {
+		t.Fatalf("resumed released fork = %q, want %q", got, forkedID)
+	}
+	t.Logf("resumed fork %s after creator app-server closed", forkedID)
 }
 
 // livePlugin stands in for AO's Codex agent plugin so this test exercises the

--- a/backend/internal/adapters/chatdriver/codexappserver/live_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/live_test.go
@@ -76,8 +76,9 @@ func TestLiveCodexAppServer(t *testing.T) {
 	}
 
 	var (
-		sawDelta bool
-		state    domain.TurnState
+		sawDelta                bool
+		state                   domain.TurnState
+		completedProviderTurnID string
 	)
 collect:
 	for {
@@ -96,6 +97,7 @@ collect:
 				_ = conv.ResolveRequest(ctx, ev.RequestID, ports.ChatDecision{ID: "accept"})
 			case ports.ChatEventTurnCompleted:
 				state = ev.TurnState
+				completedProviderTurnID = ev.ProviderTurnID
 				break collect
 			case ports.ChatEventControllerState:
 				if ev.ControllerState == ports.ChatControllerStopped {
@@ -136,6 +138,54 @@ collect:
 		t.Fatalf("resumed thread = %q, want %q", got, threadID)
 	}
 	t.Logf("resumed thread %s on a fresh app-server process", threadID)
+
+	// thread/fork loads and writer-locks the fork in this same app-server. AO must
+	// therefore rebind this live connection instead of trying to resume the fork in
+	// a second process, which Codex rejects as another active writer.
+	forker, ok := resumed.(ports.ChatForker)
+	if !ok {
+		t.Fatal("live Codex conversation does not implement ChatForker")
+	}
+	binder, ok := resumed.(ports.ChatConversationBinder)
+	if !ok {
+		t.Fatal("live Codex conversation does not implement ChatConversationBinder")
+	}
+	forkedID, err := forker.Fork(ctx, &completedProviderTurnID)
+	if err != nil {
+		t.Fatalf("Fork through completed turn: %v", err)
+	}
+	if !binder.BindProviderConversation(forkedID) {
+		t.Fatalf("bind loaded fork %s", forkedID)
+	}
+	if got := resumed.ProviderConversationID(); got != forkedID {
+		t.Fatalf("bound thread = %q, want fork %q", got, forkedID)
+	}
+	if _, err := resumed.SendTurn(ctx, ports.ChatUserMessage{
+		Text:            "Reply with exactly the word: forked",
+		ClientMessageID: "live-fork-1",
+		Origin:          domain.MessageOriginHuman,
+	}); err != nil {
+		t.Fatalf("SendTurn on loaded fork: %v", err)
+	}
+	for {
+		select {
+		case ev, ok := <-resumed.Events():
+			if !ok {
+				t.Fatal("fork event stream closed before the turn completed")
+			}
+			if ev.Kind == ports.ChatEventTurnCompleted {
+				if ev.TurnState != domain.TurnStateCompleted {
+					t.Fatalf("fork turn state = %q", ev.TurnState)
+				}
+				return
+			}
+			if ev.Kind == ports.ChatEventControllerState && ev.ControllerState == ports.ChatControllerStopped {
+				t.Fatalf("controller stopped before fork turn completed: %v", ev.Err)
+			}
+		case <-ctx.Done():
+			t.Fatalf("waiting for fork turn: %v", ctx.Err())
+		}
+	}
 }
 
 // livePlugin stands in for AO's Codex agent plugin so this test exercises the

--- a/backend/internal/adapters/chatdriver/codexappserver/steer.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/steer.go
@@ -84,7 +84,7 @@ func (c *conversation) Steer(
 		return ports.ChatTurnRef{}, err
 	}
 	params := codexproto.TurnSteerParams{
-		ThreadID:       c.threadID,
+		ThreadID:       c.ProviderConversationID(),
 		ExpectedTurnID: providerTurnID,
 		Input:          input,
 	}

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -559,6 +559,14 @@ type (
 	ChatForker interface {
 		Fork(ctx context.Context, lastProviderTurnID *string) (providerConversationID string, err error)
 	}
+	// ChatConversationBinder rebinds a live provider connection to another
+	// conversation that connection already loaded. Some providers make a fork live
+	// immediately and retain its writer lock in the creating process; attempting to
+	// resume that fork through a second process is therefore invalid. False means
+	// the conversation is not loaded here and the caller must use ordinary resume.
+	ChatConversationBinder interface {
+		BindProviderConversation(providerConversationID string) bool
+	}
 	// ChatRenamer sets or reads a human title the provider derived for the thread.
 	ChatRenamer interface {
 		SetTitle(ctx context.Context, title string) error

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -920,7 +920,11 @@ func (c *Controller) ProviderConversationID() string { return c.conv.ProviderCon
 func (c *Controller) ConversationID() string { return c.conversation.ID }
 
 // Generation fences events from a controller that has been replaced.
-func (c *Controller) Generation() string { return c.generation }
+func (c *Controller) Generation() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.generation
+}
 
 // State reports controller health.
 func (c *Controller) State() ports.ChatControllerState {
@@ -975,7 +979,7 @@ func (c *Controller) Send(ctx context.Context, msg ports.ChatUserMessage) (domai
 	}
 
 	created, err := c.store.AppendUserMessage(
-		ctx, c.conversation.ID, c.sessionID, c.generation, record, turnID, now)
+		ctx, c.conversation.ID, c.sessionID, c.Generation(), record, turnID, now)
 	if err != nil {
 		return domain.ConversationTurn{}, fmt.Errorf("record user message: %w", err)
 	}
@@ -1548,6 +1552,21 @@ func (c *Controller) AbortHandoff() {
 	}
 }
 
+// CommitIdleBranchHandoff moves this controller's durable fence and visible
+// branch together after the store has committed the same ownership change. It is
+// used when the provider can keep the fork on the existing live connection, so
+// replacing the controller process would violate the provider's one-writer rule.
+func (c *Controller) CommitIdleBranchHandoff(branchID, generation string) {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+
+	c.mu.Lock()
+	c.conversation.ActiveBranchID = branchID
+	c.generation = generation
+	c.handoff = controllerHandoffNone
+	c.mu.Unlock()
+}
+
 // Resolve answers a pending approval. The provider is told first: if it rejects
 // the decision, AO must not have already recorded the approval as answered.
 func (c *Controller) Resolve(ctx context.Context, requestID string, decision ports.ChatDecision) error {
@@ -2057,7 +2076,7 @@ func (c *Controller) projectEvent(ctx context.Context, event ports.ChatEvent) (b
 		return false, false, fmt.Errorf("encode provider event archive: %w", err)
 	}
 	projected, err := c.store.ProjectProviderEvent(ctx, c.conversation.ID, c.sessionID,
-		c.generation, event.ProviderEventID, string(event.Kind), string(payload), c.now(),
+		c.Generation(), event.ProviderEventID, string(event.Kind), string(payload), c.now(),
 		func(txCtx context.Context) error { return c.apply(txCtx, event) })
 	if err != nil || !projected {
 		return projected, false, err
@@ -2127,7 +2146,7 @@ func (c *Controller) apply(ctx context.Context, event ports.ChatEvent) error {
 				// correlated, and without that the activities arrive with no turn and the
 				// timeline quietly stops grouping them.
 				if err := c.store.AdoptProviderTurn(ctx, c.conversation.ID, c.sessionID,
-					c.generation, c.newID(), event.ProviderTurnID, now); err != nil {
+					c.Generation(), c.newID(), event.ProviderTurnID, now); err != nil {
 					return fmt.Errorf("adopt provider-started turn %s: %w", event.ProviderTurnID, err)
 				}
 			}
@@ -2906,7 +2925,7 @@ func (c *Controller) reportActivity(
 		State:                state,
 		Timestamp:            now,
 		Event:                event,
-		ControllerGeneration: c.generation,
+		ControllerGeneration: c.Generation(),
 	}); err != nil {
 		c.log.Debug("chat activity signal rejected",
 			"session", c.sessionID, "event", event, "error", err)

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -977,6 +977,72 @@ func (c *Controller) Send(ctx context.Context, msg ports.ChatUserMessage) (domai
 	if handoff {
 		return domain.ConversationTurn{}, ErrControllerHandoff
 	}
+	return c.sendLocked(ctx, msg)
+}
+
+// sendAfterIdleBranchHandoff atomically consumes an edit fence and sends on the
+// branch that was validated while the fence was held. ActivateBranch also takes
+// sendMu, so it cannot rebind the provider between this check and SendTurn.
+func (c *Controller) sendAfterIdleBranchHandoff(
+	ctx context.Context,
+	expectedBranchID string,
+	msg ports.ChatUserMessage,
+) (domain.ConversationTurn, error) {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	if err := c.finishIdleBranchHandoff(expectedBranchID, "", ""); err != nil {
+		return domain.ConversationTurn{}, err
+	}
+	return c.sendLocked(ctx, msg)
+}
+
+// commitIdleBranchHandoffAndSend moves a reused controller to its durable fork
+// and sends the edited prompt without reopening an activation window between
+// those operations.
+func (c *Controller) commitIdleBranchHandoffAndSend(
+	ctx context.Context,
+	expectedBranchID, branchID, generation string,
+	msg ports.ChatUserMessage,
+) (domain.ConversationTurn, error) {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	if err := c.finishIdleBranchHandoff(expectedBranchID, branchID, generation); err != nil {
+		return domain.ConversationTurn{}, err
+	}
+	return c.sendLocked(ctx, msg)
+}
+
+// finishIdleBranchHandoff validates and consumes an edit fence. Callers hold
+// sendMu. A branch mismatch reopens intake before returning: leaving a published
+// controller fenced after detecting stale state would turn a refused edit into a
+// permanently wedged session.
+func (c *Controller) finishIdleBranchHandoff(
+	expectedBranchID, branchID, generation string,
+) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.handoff != controllerHandoffIdleBranch {
+		return ErrControllerHandoff
+	}
+	if c.conversation.ActiveBranchID != expectedBranchID {
+		c.handoff = controllerHandoffNone
+		return fmt.Errorf("%w: active branch changed from %s to %s",
+			ErrControllerHandoff, expectedBranchID, c.conversation.ActiveBranchID)
+	}
+	if branchID != "" {
+		c.conversation.ActiveBranchID = branchID
+		c.generation = generation
+	}
+	c.handoff = controllerHandoffNone
+	return nil
+}
+
+// sendLocked records and dispatches one message. Callers hold sendMu and have
+// already established that no controller handoff can redirect the provider.
+func (c *Controller) sendLocked(
+	ctx context.Context,
+	msg ports.ChatUserMessage,
+) (domain.ConversationTurn, error) {
 
 	now := c.now()
 	turnID := c.newID()

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -919,6 +919,24 @@ func (c *Controller) ProviderConversationID() string { return c.conv.ProviderCon
 // ConversationID is the durable conversation this controller writes to.
 func (c *Controller) ConversationID() string { return c.conversation.ID }
 
+// ActiveBranchID reports the branch this published controller currently owns.
+// Branch binding can move without replacing the controller, so this cache field
+// follows the same mutex as generation and the handoff fence.
+func (c *Controller) ActiveBranchID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conversation.ActiveBranchID
+}
+
+// conversationSnapshot returns a coherent copy for constructing a replacement
+// controller. ActiveBranchID is mutable after publication; copying the record
+// directly would read that field outside the controller mutex.
+func (c *Controller) conversationSnapshot() domain.ConversationRecord {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conversation
+}
+
 // Generation fences events from a controller that has been replaced.
 func (c *Controller) Generation() string {
 	c.mu.Lock()
@@ -1925,7 +1943,7 @@ func (c *Controller) Rollback(ctx context.Context, turnID string) (int, error) {
 			return 0, fmt.Errorf("load rollback turn branch: %w", branchErr)
 		}
 		activeBranch, branchErr := c.store.ConversationBranch(
-			ctx, c.conversation.ID, c.conversation.ActiveBranchID)
+			ctx, c.conversation.ID, c.ActiveBranchID())
 		if branchErr != nil {
 			return 0, fmt.Errorf("load active rollback branch: %w", branchErr)
 		}

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -2160,6 +2160,37 @@ func TestStaleControllerEventsDoNotReachTheTimeline(t *testing.T) {
 	}
 }
 
+func TestCommitIdleBranchHandoffSynchronizesPublishedBranchState(t *testing.T) {
+	h := newHarness(t)
+
+	const commits = 500
+	done := make(chan struct{})
+	var readers sync.WaitGroup
+	for range 4 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = h.ctrl.ActiveBranchID()
+				}
+			}
+		}()
+	}
+	for i := range commits {
+		h.ctrl.CommitIdleBranchHandoff(fmt.Sprintf("branch-%03d", i), fmt.Sprintf("generation-%03d", i))
+	}
+	close(done)
+	readers.Wait()
+
+	if got, want := h.ctrl.ActiveBranchID(), "branch-499"; got != want {
+		t.Fatalf("active branch = %q, want %q", got, want)
+	}
+}
+
 /* ---- tests ------------------------------------------------------------- */
 
 // The whole point: a message goes out, provider events come back, and the durable

--- a/backend/internal/service/chat/history.go
+++ b/backend/internal/service/chat/history.go
@@ -290,7 +290,7 @@ func (s *Service) EditMessage(
 		branch.ReplayCutoffSequence = anchor.ForkAfterSequence
 		branch.ReplayTruncated = replayTruncated
 	}
-	conversation := source.conversation
+	conversation := source.conversationSnapshot()
 	conversation.ActiveBranchID = branchID
 	if boundProvider != nil {
 		if err := s.store.CreateAndActivateConversationBranch(ctx, id, branch, generation, s.now()); err != nil {
@@ -525,23 +525,11 @@ func (s *Service) ActivateBranch(ctx context.Context, id domain.SessionID, branc
 	if err != nil {
 		return "", err
 	}
-	activeBranch, err := s.store.ConversationBranch(
-		ctx, source.conversation.ID, source.conversation.ActiveBranchID)
-	if err != nil {
-		return "", fmt.Errorf("load active conversation branch: %w", err)
-	}
-	if branch.Active {
+	// The fast path is safe through the synchronized cache. Recheck after arming
+	// the handoff below, because another branch request can commit between this
+	// read and BeginIdleBranchHandoff.
+	if branch.ID == source.ActiveBranchID() {
 		return branch.ID, nil
-	}
-	cfg, driver, err := s.branchLaunchConfig(id, source)
-	if err != nil {
-		return "", err
-	}
-	if branch.ProviderBindingID != activeBranch.ProviderBindingID {
-		// Provider scopes may differ between approximate siblings, but their
-		// durable binding epoch must match. Crossing it could hand an opaque
-		// conversation handle to a different adapter/configuration owner.
-		return "", ErrBranchProviderMismatch
 	}
 	if err := source.BeginIdleBranchHandoff(ctx); err != nil {
 		return "", err
@@ -552,6 +540,27 @@ func (s *Service) ActivateBranch(ctx context.Context, id domain.SessionID, branc
 			source.AbortHandoff()
 		}
 	}()
+	sourceBranchID := source.ActiveBranchID()
+	if branch.ID == sourceBranchID {
+		source.AbortHandoff()
+		abortSource = false
+		return branch.ID, nil
+	}
+	activeBranch, err := s.store.ConversationBranch(
+		ctx, source.conversation.ID, sourceBranchID)
+	if err != nil {
+		return "", fmt.Errorf("load active conversation branch: %w", err)
+	}
+	if branch.ProviderBindingID != activeBranch.ProviderBindingID {
+		// Provider scopes may differ between approximate siblings, but their
+		// durable binding epoch must match. Crossing it could hand an opaque
+		// conversation handle to a different adapter/configuration owner.
+		return "", ErrBranchProviderMismatch
+	}
+	cfg, driver, err := s.branchLaunchConfig(id, source)
+	if err != nil {
+		return "", err
+	}
 	sourceProviderConversationID := source.ProviderConversationID()
 	if binder, ok := source.conv.(ports.ChatConversationBinder); ok &&
 		binder.BindProviderConversation(branch.ProviderConversationID) {
@@ -578,7 +587,7 @@ func (s *Service) ActivateBranch(ctx context.Context, id domain.SessionID, branc
 		return "", fmt.Errorf("resume conversation branch %s: %w", branchID, err)
 	}
 	generation := s.newID()
-	conversation := source.conversation
+	conversation := source.conversationSnapshot()
 	conversation.ActiveBranchID = branch.ID
 	replacement := newController(id, conversation, generation, provider, s.store, s.activity, s.log, s.newID, s.now)
 	if err := s.store.ActivateConversationBranch(ctx, id, conversation.ID, branch.ID,
@@ -586,7 +595,7 @@ func (s *Service) ActivateBranch(ctx context.Context, id domain.SessionID, branc
 		_ = provider.Close()
 		return "", err
 	}
-	if err := s.installBranchController(ctx, id, source, replacement, source.conversation.ActiveBranchID); err != nil {
+	if err := s.installBranchController(ctx, id, source, replacement, sourceBranchID); err != nil {
 		return "", err
 	}
 	abortSource = false

--- a/backend/internal/service/chat/history.go
+++ b/backend/internal/service/chat/history.go
@@ -160,18 +160,34 @@ func (s *Service) EditMessage(
 		return EditMessageResult{}, err
 	}
 	forker, canFork := source.conv.(ports.ChatForker)
-	canReplay := supportsApproximateReplay(source.conv)
-	anchor, err := s.store.ConversationEditAnchor(ctx, source.conversation.ID, turnID)
-	if err != nil {
-		return EditMessageResult{}, fmt.Errorf("%w: %w", ErrEditTurnInvalid, err)
+	// Preserve fast validation for missing turns and corrupt stored content, but
+	// do not make any branch-dependent decision from this unfenced snapshot.
+	if _, _, err := s.editMessageAnchor(ctx, source.conversation.ID, turnID); err != nil {
+		return EditMessageResult{}, err
 	}
-	var content []ports.ChatContent
-	if anchor.OriginalDeliveryContentJSON != "" {
-		if err := json.Unmarshal([]byte(anchor.OriginalDeliveryContentJSON), &content); err != nil {
-			return EditMessageResult{}, fmt.Errorf("%w: decode stored prompt content: %w", ErrEditTurnInvalid, err)
+	if err := source.BeginIdleBranchHandoff(ctx); err != nil {
+		return EditMessageResult{}, err
+	}
+	abortSource := true
+	defer func() {
+		if abortSource {
+			source.AbortHandoff()
 		}
+	}()
+
+	// Controller lookup and the active lineage can both change during a branch
+	// activation. Validate that this fenced controller is still published, then
+	// resolve the authoritative anchor while activation is unable to move it.
+	cfg, driver, err := s.branchLaunchConfig(id, source)
+	if err != nil {
+		return EditMessageResult{}, err
+	}
+	anchor, content, err := s.editMessageAnchor(ctx, source.conversation.ID, turnID)
+	if err != nil {
+		return EditMessageResult{}, err
 	}
 	msg.Content = withoutInternalReplayContent(content)
+	canReplay := supportsApproximateReplay(source.conv)
 	if anchor.RetryActiveBranch {
 		branch, err := s.store.ConversationBranch(ctx, source.conversation.ID, anchor.SourceBranchID)
 		if err != nil {
@@ -188,7 +204,11 @@ func (s *Service) EditMessage(
 			}
 			msg.Content = append([]ports.ChatContent{replay}, msg.Content...)
 		}
-		return s.sendEditedMessage(ctx, branch.ParentBranchID, branch.ID, source, msg, true)
+		// The helper owns fence cleanup from this point. Disarm the generic
+		// defer so it cannot erase a newer handoff after the send returns.
+		abortSource = false
+		turn, sendErr := source.sendAfterIdleBranchHandoff(ctx, anchor.SourceBranchID, msg)
+		return s.finishEditedMessage(ctx, branch.ParentBranchID, branch.ID, source, turn, sendErr, true)
 	}
 	sourceBranch, err := s.store.ConversationBranch(ctx, source.conversation.ID, anchor.SourceBranchID)
 	if err != nil {
@@ -199,20 +219,6 @@ func (s *Service) EditMessage(
 	needsReplay := !canNativeFork && needsPriorContext
 	if needsReplay && !canReplay {
 		return EditMessageResult{}, ErrForkUnsupported
-	}
-	if err := source.BeginIdleBranchHandoff(ctx); err != nil {
-		return EditMessageResult{}, err
-	}
-	abortSource := true
-	defer func() {
-		if abortSource {
-			source.AbortHandoff()
-		}
-	}()
-
-	cfg, driver, err := s.branchLaunchConfig(id, source)
-	if err != nil {
-		return EditMessageResult{}, err
 	}
 	sourceProviderConversationID := source.ProviderConversationID()
 	var providerConversationID string
@@ -299,9 +305,12 @@ func (s *Service) EditMessage(
 			}
 			return EditMessageResult{}, fmt.Errorf("activate edited conversation: %w", err)
 		}
-		source.CommitIdleBranchHandoff(branchID, generation)
+		// The helper owns fence cleanup from this point. Disarm the generic
+		// defer so it cannot erase a newer handoff after the send returns.
 		abortSource = false
-		return s.sendEditedMessage(ctx, anchor.SourceBranchID, branchID, source, msg, true)
+		turn, sendErr := source.commitIdleBranchHandoffAndSend(
+			ctx, anchor.SourceBranchID, branchID, generation, msg)
+		return s.finishEditedMessage(ctx, anchor.SourceBranchID, branchID, source, turn, sendErr, true)
 	}
 	replacement := newController(id, conversation, generation, provider, s.store, s.activity, s.log, s.newID, s.now)
 	if err := s.store.CreateAndActivateConversationBranch(ctx, id, branch, generation, s.now()); err != nil {
@@ -341,6 +350,24 @@ func (s *Service) EditMessage(
 	}
 	abortSource = false
 	return result, sendErr
+}
+
+func (s *Service) editMessageAnchor(
+	ctx context.Context,
+	conversationID, turnID string,
+) (domain.ConversationEditAnchor, []ports.ChatContent, error) {
+	anchor, err := s.store.ConversationEditAnchor(ctx, conversationID, turnID)
+	if err != nil {
+		return domain.ConversationEditAnchor{}, nil, fmt.Errorf("%w: %w", ErrEditTurnInvalid, err)
+	}
+	var content []ports.ChatContent
+	if anchor.OriginalDeliveryContentJSON != "" {
+		if err := json.Unmarshal([]byte(anchor.OriginalDeliveryContentJSON), &content); err != nil {
+			return domain.ConversationEditAnchor{}, nil,
+				fmt.Errorf("%w: decode stored prompt content: %w", ErrEditTurnInvalid, err)
+		}
+	}
+	return anchor, content, nil
 }
 
 // approximateReplayContent renders only the durable textual transcript before the
@@ -465,6 +492,18 @@ func (s *Service) sendEditedMessage(
 	restoreConclusiveFailure bool,
 ) (EditMessageResult, error) {
 	turn, sendErr := controller.Send(ctx, msg)
+	return s.finishEditedMessage(
+		ctx, sourceBranchID, activeBranchID, controller, turn, sendErr, restoreConclusiveFailure)
+}
+
+func (s *Service) finishEditedMessage(
+	ctx context.Context,
+	sourceBranchID, activeBranchID string,
+	controller *Controller,
+	turn domain.ConversationTurn,
+	sendErr error,
+	restoreConclusiveFailure bool,
+) (EditMessageResult, error) {
 	result := EditMessageResult{
 		SourceBranchID: sourceBranchID,
 		ActiveBranchID: activeBranchID,

--- a/backend/internal/service/chat/history.go
+++ b/backend/internal/service/chat/history.go
@@ -214,22 +214,31 @@ func (s *Service) EditMessage(
 	if err != nil {
 		return EditMessageResult{}, err
 	}
+	sourceProviderConversationID := source.ProviderConversationID()
 	var providerConversationID string
 	var provider ports.ChatConversation
+	var boundProvider ports.ChatConversationBinder
 	var replayContent ports.ChatContent
 	var replayTruncated bool
 	var providerScopeID string
 	if canNativeFork {
+		providerScopeID = sourceBranch.ProviderScopeID
 		forkAnchor := anchor.PreviousProviderTurnID
 		providerConversationID, err = forker.Fork(ctx, &forkAnchor)
 		if err == nil {
-			provider, err = driver.Resume(ctx, ports.ChatResumeConfig{
-				SessionID: cfg.SessionID, ProviderConversationID: providerConversationID,
-				DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath, Env: cfg.Env,
-				Model: cfg.Model, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
-				ProviderScopeID:       sourceBranch.ProviderScopeID,
-				AdditionalDirectories: cfg.AdditionalDirectories, MCPServers: cfg.MCPServers,
-			})
+			if binder, ok := source.conv.(ports.ChatConversationBinder); ok &&
+				binder.BindProviderConversation(providerConversationID) {
+				provider = source.conv
+				boundProvider = binder
+			} else {
+				provider, err = driver.Resume(ctx, ports.ChatResumeConfig{
+					SessionID: cfg.SessionID, ProviderConversationID: providerConversationID,
+					DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath, Env: cfg.Env,
+					Model: cfg.Model, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
+					ProviderScopeID:       sourceBranch.ProviderScopeID,
+					AdditionalDirectories: cfg.AdditionalDirectories, MCPServers: cfg.MCPServers,
+				})
+			}
 		}
 	} else {
 		// Every Start owns a fresh namespace for provider-issued turn/item IDs,
@@ -283,6 +292,17 @@ func (s *Service) EditMessage(
 	}
 	conversation := source.conversation
 	conversation.ActiveBranchID = branchID
+	if boundProvider != nil {
+		if err := s.store.CreateAndActivateConversationBranch(ctx, id, branch, generation, s.now()); err != nil {
+			if !boundProvider.BindProviderConversation(sourceProviderConversationID) {
+				err = errors.Join(err, errors.New("restore source provider conversation binding"))
+			}
+			return EditMessageResult{}, fmt.Errorf("activate edited conversation: %w", err)
+		}
+		source.CommitIdleBranchHandoff(branchID, generation)
+		abortSource = false
+		return s.sendEditedMessage(ctx, anchor.SourceBranchID, branchID, source, msg, true)
+	}
 	replacement := newController(id, conversation, generation, provider, s.store, s.activity, s.log, s.newID, s.now)
 	if err := s.store.CreateAndActivateConversationBranch(ctx, id, branch, generation, s.now()); err != nil {
 		_ = provider.Close()
@@ -299,7 +319,7 @@ func (s *Service) EditMessage(
 		ctx, anchor.SourceBranchID, branchID, replacement, msg, false)
 	if result.Turn.ID == "" || errors.Is(sendErr, ErrProviderRefused) {
 		if err := s.store.ActivateConversationBranch(ctx, id, source.conversation.ID,
-			anchor.SourceBranchID, source.ProviderConversationID(), source.generation, s.now()); err != nil {
+			anchor.SourceBranchID, source.ProviderConversationID(), source.Generation(), s.now()); err != nil {
 			sendErr = errors.Join(sendErr, fmt.Errorf("restore source after rejected edit: %w", err))
 			// The durable head still belongs to the child. Publish its controller
 			// rather than reopening a source generation the store just rejected.
@@ -532,6 +552,21 @@ func (s *Service) ActivateBranch(ctx context.Context, id domain.SessionID, branc
 			source.AbortHandoff()
 		}
 	}()
+	sourceProviderConversationID := source.ProviderConversationID()
+	if binder, ok := source.conv.(ports.ChatConversationBinder); ok &&
+		binder.BindProviderConversation(branch.ProviderConversationID) {
+		generation := s.newID()
+		if err := s.store.ActivateConversationBranch(ctx, id, source.conversation.ID, branch.ID,
+			branch.ProviderConversationID, generation, s.now()); err != nil {
+			if !binder.BindProviderConversation(sourceProviderConversationID) {
+				err = errors.Join(err, errors.New("restore source provider conversation binding"))
+			}
+			return "", err
+		}
+		source.CommitIdleBranchHandoff(branch.ID, generation)
+		abortSource = false
+		return branch.ID, nil
+	}
 	provider, err := driver.Resume(ctx, ports.ChatResumeConfig{
 		SessionID: cfg.SessionID, ProviderConversationID: branch.ProviderConversationID,
 		DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath, Env: cfg.Env,
@@ -601,7 +636,7 @@ func (s *Service) installStartedBranchController(
 		s.mu.Unlock()
 		_ = replacement.Close(ctx)
 		if err := s.store.ActivateConversationBranch(ctx, id, source.conversation.ID,
-			sourceBranchID, source.ProviderConversationID(), source.generation, s.now()); err != nil {
+			sourceBranchID, source.ProviderConversationID(), source.Generation(), s.now()); err != nil {
 			return fmt.Errorf("restore source branch after controller swap conflict: %w", err)
 		}
 		return ErrControllerHandoff

--- a/backend/internal/service/chat/history_adversarial_test.go
+++ b/backend/internal/service/chat/history_adversarial_test.go
@@ -43,21 +43,23 @@ func TestEditMessagePrefersNativeForkWhenReplayIsAlsoAvailable(t *testing.T) {
 	driver.mu.Lock()
 	starts := append([]ports.ChatStartConfig(nil), driver.startConfigs...)
 	resumes := append([]ports.ChatResumeConfig(nil), driver.resumeCalls...)
-	replacement := driver.resumed["thread-forked"]
 	driver.mu.Unlock()
 	if len(starts) != 1 {
 		t.Fatalf("provider Start calls = %d, want only the initial start", len(starts))
 	}
-	if len(resumes) != 1 || resumes[0].ProviderConversationID != "thread-forked" {
-		t.Fatalf("provider Resume calls = %#v, want one native fork resume", resumes)
+	if len(resumes) != 0 {
+		t.Fatalf("provider Resume calls = %#v, want native fork on its existing writer", resumes)
 	}
-	sent := replacement.sentMessages()
-	if len(sent) != 1 || sent[0].Text != "B edited" {
+	if bound := source.boundProviderThreads(); len(bound) != 1 || bound[0] != "thread-forked" {
+		t.Fatalf("provider bindings = %#v, want thread-forked", bound)
+	}
+	sent := source.sentMessages()
+	if len(sent) != 3 || sent[2].Text != "B edited" {
 		t.Fatalf("native replacement sends = %#v", sent)
 	}
-	for _, content := range sent[0].Content {
+	for _, content := range sent[2].Content {
 		if ports.IsInternalReplayContent(content) {
-			t.Fatalf("native fork received approximate replay content: %#v", sent[0].Content)
+			t.Fatalf("native fork received approximate replay content: %#v", sent[2].Content)
 		}
 	}
 	branch, err := h.st.ConversationBranch(ctx, h.ctrl.ConversationID(), result.ActiveBranchID)

--- a/backend/internal/service/chat/history_test.go
+++ b/backend/internal/service/chat/history_test.go
@@ -621,6 +621,40 @@ type blockingEditAnchorStore struct {
 	release   chan struct{}
 }
 
+type blockingEditReplacementStore struct {
+	*store.Store
+	mu      sync.Mutex
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingEditReplacementStore) blockReplacement() (<-chan struct{}, chan<- struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entered = make(chan struct{})
+	s.release = make(chan struct{})
+	return s.entered, s.release
+}
+
+func (s *blockingEditReplacementStore) UpdateConversationBranchReplacement(
+	ctx context.Context,
+	branchID, turnID string,
+) error {
+	s.mu.Lock()
+	entered, release := s.entered, s.release
+	s.entered, s.release = nil, nil
+	s.mu.Unlock()
+	if entered != nil {
+		close(entered)
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return s.Store.UpdateConversationBranchReplacement(ctx, branchID, turnID)
+}
+
 func (s *blockingEditAnchorStore) blockAnchor(read int) (<-chan struct{}, chan<- struct{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1639,6 +1673,104 @@ func TestEditFencesConcurrentBranchActivation(t *testing.T) {
 	}
 	if got := source.ProviderConversationID(); got != "thread-forked" {
 		t.Fatalf("provider binding after edit race = %q, want thread-forked", got)
+	}
+}
+
+func TestEditSendCleanupDoesNotAbortNewerHandoff(t *testing.T) {
+	for _, retry := range []bool{false, true} {
+		name := "bound fork"
+		if retry {
+			name = "retry"
+		}
+		t.Run(name, func(t *testing.T) {
+			var replacementStore *blockingEditReplacementStore
+			h, source, _ := newEditHarnessWithStore(t, false, func(st *store.Store) chatsvc.Store {
+				replacementStore = &blockingEditReplacementStore{Store: st}
+				return replacementStore
+			})
+			ctx := context.Background()
+			completeTurn(t, h, "A", "provider-turn-1")
+			h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+			second := completeTurn(t, h, "B", "provider-turn-2")
+			h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 4 })
+
+			if retry {
+				conversation, err := h.st.ConversationForSession(ctx, testSession)
+				if err != nil {
+					t.Fatalf("ConversationForSession: %v", err)
+				}
+				anchor, err := h.st.ConversationEditAnchor(ctx, conversation.ID, second)
+				if err != nil {
+					t.Fatalf("ConversationEditAnchor: %v", err)
+				}
+				sourceBranch, err := h.st.ConversationBranch(ctx, conversation.ID, anchor.SourceBranchID)
+				if err != nil {
+					t.Fatalf("ConversationBranch: %v", err)
+				}
+				forkAnchor := anchor.PreviousProviderTurnID
+				providerConversationID, err := source.Fork(ctx, &forkAnchor)
+				if err != nil || !source.BindProviderConversation(providerConversationID) {
+					t.Fatalf("prepare pending provider fork: id=%q err=%v", providerConversationID, err)
+				}
+				child := domain.ConversationBranch{
+					ID: "pending-edit", ConversationID: conversation.ID, SessionID: testSession,
+					ProviderConversationID: providerConversationID,
+					ParentBranchID:         anchor.SourceBranchID,
+					ReplacedTurnID:         second,
+					ForkAfterSequence:      anchor.ForkAfterSequence,
+					Strategy:               domain.ConversationBranchStrategyNative,
+					ProviderBindingID:      sourceBranch.ProviderBindingID,
+					ProviderScopeID:        sourceBranch.ProviderScopeID,
+					CreatedAt:              h.clock,
+				}
+				const generation = "pending-edit-generation"
+				if err := h.st.CreateAndActivateConversationBranch(
+					ctx, testSession, child, generation, h.clock); err != nil {
+					t.Fatalf("CreateAndActivateConversationBranch: %v", err)
+				}
+				if err := h.ctrl.BeginIdleBranchHandoff(ctx); err != nil {
+					t.Fatalf("fence pending edit branch: %v", err)
+				}
+				h.ctrl.CommitIdleBranchHandoff(child.ID, generation)
+			}
+
+			source.mu.Lock()
+			source.sendErr = errors.New("provider unavailable")
+			source.mu.Unlock()
+			replacementEntered, releaseReplacement := replacementStore.blockReplacement()
+			editDone := make(chan error, 1)
+			go func() {
+				_, editErr := h.svc.EditMessage(ctx, testSession, second, ports.ChatUserMessage{
+					Text: "B edited", ClientMessageID: "edit-cleanup-race", Origin: domain.MessageOriginHuman,
+				})
+				editDone <- editErr
+			}()
+			select {
+			case <-replacementEntered:
+			case <-time.After(3 * time.Second):
+				t.Fatal("EditMessage did not reach replacement metadata update")
+			}
+
+			if err := h.ctrl.BeginIdleBranchHandoff(ctx); err != nil {
+				t.Fatalf("establish newer branch handoff: %v", err)
+			}
+			close(releaseReplacement)
+			select {
+			case editErr := <-editDone:
+				if editErr == nil {
+					t.Fatal("EditMessage succeeded after provider send failure")
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("EditMessage did not finish after releasing replacement update")
+			}
+
+			if _, err := h.ctrl.Send(ctx, ports.ChatUserMessage{
+				Text: "must remain fenced", ClientMessageID: "edit-cleanup-probe",
+			}); !errors.Is(err, chatsvc.ErrControllerHandoff) {
+				t.Fatalf("Send after newer handoff = %v, want ErrControllerHandoff", err)
+			}
+			h.ctrl.AbortHandoff()
+		})
 	}
 }
 

--- a/backend/internal/service/chat/history_test.go
+++ b/backend/internal/service/chat/history_test.go
@@ -613,6 +613,53 @@ type editDriverState struct {
 	resumed      map[string]*ownedFakeConversation
 }
 
+type blockingEditAnchorStore struct {
+	*store.Store
+	mu        sync.Mutex
+	remaining int
+	entered   chan struct{}
+	release   chan struct{}
+}
+
+func (s *blockingEditAnchorStore) blockAnchor(read int) (<-chan struct{}, chan<- struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.remaining = read
+	s.entered = make(chan struct{})
+	s.release = make(chan struct{})
+	return s.entered, s.release
+}
+
+func (s *blockingEditAnchorStore) ConversationEditAnchor(
+	ctx context.Context,
+	conversationID, replacedTurnID string,
+) (domain.ConversationEditAnchor, error) {
+	anchor, err := s.Store.ConversationEditAnchor(ctx, conversationID, replacedTurnID)
+	if err != nil {
+		return domain.ConversationEditAnchor{}, err
+	}
+	s.mu.Lock()
+	if s.entered == nil {
+		s.mu.Unlock()
+		return anchor, nil
+	}
+	s.remaining--
+	if s.remaining > 0 {
+		s.mu.Unlock()
+		return anchor, nil
+	}
+	entered, release := s.entered, s.release
+	s.entered, s.release = nil, nil
+	s.mu.Unlock()
+	close(entered)
+	select {
+	case <-release:
+		return anchor, nil
+	case <-ctx.Done():
+		return domain.ConversationEditAnchor{}, ctx.Err()
+	}
+}
+
 type ownedFakeConversation struct {
 	*fakeConversation
 	writers *providerWriterRegistry
@@ -655,8 +702,20 @@ func (s *editDriverState) resumeConversation(
 }
 
 func newEditHarness(t *testing.T, supportsPromptReplay bool) (*harness, *historyRecorder, *editDriverState) {
+	return newEditHarnessWithStore(t, supportsPromptReplay, nil)
+}
+
+func newEditHarnessWithStore(
+	t *testing.T,
+	supportsPromptReplay bool,
+	wrapStore func(*store.Store) chatsvc.Store,
+) (*harness, *historyRecorder, *editDriverState) {
 	t.Helper()
 	st := openStore(t)
+	chatStore := chatsvc.Store(st)
+	if wrapStore != nil {
+		chatStore = wrapStore(st)
+	}
 	source := newHistoryRecorder()
 	if supportsPromptReplay {
 		sourceCapabilities := productionCaps()
@@ -724,7 +783,7 @@ func newEditHarness(t *testing.T, supportsPromptReplay bool) (*harness, *history
 	var idMu sync.Mutex
 	nextID := 0
 	svc := chatsvc.New(chatsvc.Options{
-		Store: st, Sessions: st,
+		Store: chatStore, Sessions: st,
 		Reader: chatsvc.SnapshotReaderFunc(func(ctx context.Context, conversationID string) (chatsvc.ConversationRows, error) {
 			snapshot, err := st.LoadConversationSnapshot(ctx, conversationID)
 			if err != nil {
@@ -1510,6 +1569,76 @@ func TestEditMessageUndispatchedAttemptRestoresSourceBranch(t *testing.T) {
 	requireMessageTexts(t, snapshot.Messages, []string{"A", "reply to A", "B", "reply to B"})
 	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{Text: "source remains usable"}); err != nil {
 		t.Fatalf("Send on restored source: %v", err)
+	}
+}
+
+func TestEditFencesConcurrentBranchActivation(t *testing.T) {
+	var anchorStore *blockingEditAnchorStore
+	h, source, _ := newEditHarnessWithStore(t, false, func(st *store.Store) chatsvc.Store {
+		anchorStore = &blockingEditAnchorStore{Store: st}
+		return anchorStore
+	})
+	ctx := context.Background()
+	completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	second := completeTurn(t, h, "B", "provider-turn-2")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 4 })
+
+	source.mu.Lock()
+	source.sendErr = refusedError{msg: "provider declined edit"}
+	source.mu.Unlock()
+	failed, err := h.svc.EditMessage(ctx, testSession, second, ports.ChatUserMessage{
+		Text: "B refused", ClientMessageID: "edit-race-refused", Origin: domain.MessageOriginHuman,
+	})
+	if !errors.Is(err, chatsvc.ErrProviderRefused) {
+		t.Fatalf("priming EditMessage error = %v, want ErrProviderRefused", err)
+	}
+	source.mu.Lock()
+	source.sendErr = nil
+	source.mu.Unlock()
+
+	// The first read preserves fast validation. The second is authoritative and
+	// must happen only after EditMessage owns the idle-branch fence.
+	anchorRead, releaseAnchor := anchorStore.blockAnchor(2)
+	type editOutcome struct {
+		result chatsvc.EditMessageResult
+		err    error
+	}
+	editDone := make(chan editOutcome, 1)
+	go func() {
+		result, editErr := h.svc.EditMessage(ctx, testSession, second, ports.ChatUserMessage{
+			Text: "B edited", ClientMessageID: "edit-race-success", Origin: domain.MessageOriginHuman,
+		})
+		editDone <- editOutcome{result: result, err: editErr}
+	}()
+	select {
+	case <-anchorRead:
+	case outcome := <-editDone:
+		t.Fatalf("EditMessage finished before fenced anchor read: result=%+v err=%v", outcome.result, outcome.err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("EditMessage did not reach the fenced anchor read")
+	}
+
+	_, activateErr := h.svc.ActivateBranch(ctx, testSession, failed.ActiveBranchID)
+	close(releaseAnchor)
+	var retried editOutcome
+	select {
+	case retried = <-editDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("EditMessage did not finish after releasing the anchor read")
+	}
+	if !errors.Is(activateErr, chatsvc.ErrControllerHandoff) {
+		t.Fatalf("concurrent ActivateBranch error = %v, want ErrControllerHandoff", activateErr)
+	}
+	if retried.err != nil {
+		t.Fatalf("EditMessage after releasing anchor: %v", retried.err)
+	}
+	if retried.result.SourceBranchID != failed.SourceBranchID ||
+		retried.result.ActiveBranchID == failed.ActiveBranchID {
+		t.Fatalf("edit used stale lineage: refused=%+v edited=%+v", failed, retried.result)
+	}
+	if got := source.ProviderConversationID(); got != "thread-forked" {
+		t.Fatalf("provider binding after edit race = %q, want thread-forked", got)
 	}
 }
 

--- a/backend/internal/service/chat/history_test.go
+++ b/backend/internal/service/chat/history_test.go
@@ -31,6 +31,7 @@ type historyRecorder struct {
 	setTitleErr  error
 	forkErr      error
 	forkAnchors  []*string
+	boundThreads []string
 	echoRenameTo string
 }
 
@@ -75,6 +76,23 @@ func (h *historyRecorder) lastForkAnchor() *string {
 	}
 	anchorCopy := *anchor
 	return &anchorCopy
+}
+
+func (h *historyRecorder) BindProviderConversation(providerConversationID string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if providerConversationID != h.forkedTo && providerConversationID != "thread-1" {
+		return false
+	}
+	h.providerConversationID = providerConversationID
+	h.boundThreads = append(h.boundThreads, providerConversationID)
+	return true
+}
+
+func (h *historyRecorder) boundProviderThreads() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.boundThreads...)
 }
 
 // SetTitle records the name and, like the real provider, reports it back on the event
@@ -1127,22 +1145,19 @@ func TestEditMessageForksBeforeMiddlePromptAndReusesStoredContent(t *testing.T) 
 		t.Fatalf("editing called rollback: %v", got)
 	}
 	driver.mu.Lock()
-	replacement := driver.resumed["thread-forked"]
 	resumes := append([]ports.ChatResumeConfig(nil), driver.resumeCalls...)
 	driver.mu.Unlock()
-	sent := replacement.sentMessages()
-	if len(sent) != 1 || sent[0].Text != "B edited" || len(sent[0].Content) != 2 ||
-		sent[0].Content[0].Text != `{"userSupplied":true}` ||
-		sent[0].Content[1].Data != "data:image/png;base64,AA==" {
-		t.Fatalf("replacement send = %#v", sent)
+	sent := source.sentMessages()
+	if len(sent) != 3 || sent[2].Text != "B edited" || len(sent[2].Content) != 2 ||
+		sent[2].Content[0].Text != `{"userSupplied":true}` ||
+		sent[2].Content[1].Data != "data:image/png;base64,AA==" {
+		t.Fatalf("bound provider send = %#v", sent)
 	}
-	driver.mu.Lock()
-	starts := append([]ports.ChatStartConfig(nil), driver.startConfigs...)
-	driver.mu.Unlock()
-	if len(resumes) != 1 || resumes[0].WorkspacePath == "" || resumes[0].Env["AO_EDIT_TEST"] != "yes" ||
-		resumes[0].SystemPrompt != "preserved prompt" || resumes[0].ProviderScopeID == "" ||
-		len(starts) != 1 || resumes[0].ProviderScopeID != starts[0].ProviderScopeID {
-		t.Fatalf("resume config = %#v", resumes)
+	if len(resumes) != 0 {
+		t.Fatalf("fork already loaded by provider was resumed on a second writer: %#v", resumes)
+	}
+	if got := source.boundProviderThreads(); len(got) != 1 || got[0] != "thread-forked" {
+		t.Fatalf("bound provider threads = %v", got)
 	}
 }
 
@@ -1281,19 +1296,16 @@ func TestEditMessageForkFailureReopensSource(t *testing.T) {
 }
 
 func TestEditMessageExplicitRefusalRestoresSourceBranch(t *testing.T) {
-	h, _, driver := newEditHarness(t, false)
+	h, source, _ := newEditHarness(t, false)
 	ctx := context.Background()
 	completeTurn(t, h, "A", "provider-turn-1")
 	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
 	second := completeTurn(t, h, "B", "provider-turn-2")
 	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 4 })
 
-	driver.mu.Lock()
-	replacement := driver.resumed["thread-forked"]
-	replacement.mu.Lock()
-	replacement.sendErr = refusedError{msg: "provider declined edit"}
-	replacement.mu.Unlock()
-	driver.mu.Unlock()
+	source.mu.Lock()
+	source.sendErr = refusedError{msg: "provider declined edit"}
+	source.mu.Unlock()
 
 	failed, err := h.svc.EditMessage(ctx, testSession, second, ports.ChatUserMessage{
 		Text: "B edited", ClientMessageID: "edit-b-failed", Origin: domain.MessageOriginHuman,
@@ -1316,6 +1328,9 @@ func TestEditMessageExplicitRefusalRestoresSourceBranch(t *testing.T) {
 	if snapshot.ActiveBranch.ID != failed.SourceBranchID {
 		t.Fatalf("active branch after explicit refusal = %q, want source %q", snapshot.ActiveBranch.ID, failed.SourceBranchID)
 	}
+	source.mu.Lock()
+	source.sendErr = nil
+	source.mu.Unlock()
 	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{Text: "source remains usable"}); err != nil {
 		t.Fatalf("Send on restored source: %v", err)
 	}
@@ -1545,6 +1560,49 @@ func TestActivateBranchSwitchesBetweenCompatibleApproximateProviderScopes(t *tes
 		t.Fatalf("Snapshot edited branch again: %v", err)
 	}
 	requireBranchPoint(t, editedSnapshot, edited.Turn.ID, edited.SourceBranchID, "")
+}
+
+func TestActivateLoadedBranchRebindsWithoutSecondProviderWriter(t *testing.T) {
+	h, source, driver := newEditHarness(t, false)
+	ctx := context.Background()
+	completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	second := completeTurn(t, h, "B", "provider-turn-2")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 4 })
+
+	edited, err := h.svc.EditMessage(ctx, testSession, second, ports.ChatUserMessage{
+		Text: "B edited", ClientMessageID: "edit-b", Origin: domain.MessageOriginHuman,
+	})
+	if err != nil {
+		t.Fatalf("EditMessage: %v", err)
+	}
+	source.emit(
+		ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: edited.Turn.ProviderTurnID},
+		ports.ChatEvent{Kind: ports.ChatEventTurnCompleted, ProviderTurnID: edited.Turn.ProviderTurnID, TurnState: domain.TurnStateCompleted},
+	)
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 2 && s.Turns[1].State.Terminal()
+	})
+
+	active, err := h.svc.ActivateBranch(ctx, testSession, edited.SourceBranchID)
+	if err != nil {
+		t.Fatalf("ActivateBranch source: %v", err)
+	}
+	if active != edited.SourceBranchID {
+		t.Fatalf("active branch = %q, want %q", active, edited.SourceBranchID)
+	}
+	driver.mu.Lock()
+	resumeCount := len(driver.resumeCalls)
+	driver.mu.Unlock()
+	if resumeCount != 0 {
+		t.Fatalf("loaded source branch resumed on a second provider writer: %d calls", resumeCount)
+	}
+	if got := source.boundProviderThreads(); len(got) != 2 || got[0] != "thread-forked" || got[1] != "thread-1" {
+		t.Fatalf("bound provider threads = %v", got)
+	}
+	if sent := source.sentTexts(); len(sent) != 3 {
+		t.Fatalf("branch activation sent a message: %v", sent)
+	}
 }
 
 func TestApproximateBranchScopePersistsAcrossServiceRestartAndSwitching(t *testing.T) {

--- a/backend/internal/service/chat/history_test.go
+++ b/backend/internal/service/chat/history_test.go
@@ -20,10 +20,48 @@ import (
 // can tell "the driver refuses" from "the driver does not offer this at all". The
 // plain fakeConversation implements none of the three, which is what the unsupported
 // paths exercise.
+var errProviderConversationOwned = errors.New("provider conversation already has a writer")
+
+type providerWriterRegistry struct {
+	mu     sync.Mutex
+	owners map[string]any
+}
+
+func newProviderWriterRegistry() *providerWriterRegistry {
+	return &providerWriterRegistry{owners: make(map[string]any)}
+}
+
+func (r *providerWriterRegistry) claim(providerConversationID string, owner any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if current, ok := r.owners[providerConversationID]; ok && current != owner {
+		return fmt.Errorf("%w: %s", errProviderConversationOwned, providerConversationID)
+	}
+	r.owners[providerConversationID] = owner
+	return nil
+}
+
+func (r *providerWriterRegistry) ownedBy(providerConversationID string, owner any) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.owners[providerConversationID] == owner
+}
+
+func (r *providerWriterRegistry) release(owner any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for providerConversationID, current := range r.owners {
+		if current == owner {
+			delete(r.owners, providerConversationID)
+		}
+	}
+}
+
 type historyRecorder struct {
 	*fakeConversation
 
 	mu           sync.Mutex
+	writers      *providerWriterRegistry
 	rolledBack   []string
 	titles       []string
 	forkedTo     string
@@ -36,7 +74,16 @@ type historyRecorder struct {
 }
 
 func newHistoryRecorder() *historyRecorder {
-	return &historyRecorder{fakeConversation: newFakeConversation(), forkedTo: "thread-forked"}
+	writers := newProviderWriterRegistry()
+	recorder := &historyRecorder{
+		fakeConversation: newFakeConversation(),
+		writers:          writers,
+		forkedTo:         "thread-forked",
+	}
+	if err := writers.claim(recorder.providerConversationID, recorder); err != nil {
+		panic(err)
+	}
+	return recorder
 }
 
 func (h *historyRecorder) Rollback(_ context.Context, providerTurnID string) error {
@@ -61,6 +108,9 @@ func (h *historyRecorder) Fork(_ context.Context, anchor *string) (string, error
 	if h.forkErr != nil {
 		return "", h.forkErr
 	}
+	if err := h.writers.claim(h.forkedTo, h); err != nil {
+		return "", err
+	}
 	return h.forkedTo, nil
 }
 
@@ -81,12 +131,23 @@ func (h *historyRecorder) lastForkAnchor() *string {
 func (h *historyRecorder) BindProviderConversation(providerConversationID string) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if providerConversationID != h.forkedTo && providerConversationID != "thread-1" {
+	if !h.writers.ownedBy(providerConversationID, h) {
 		return false
 	}
 	h.providerConversationID = providerConversationID
 	h.boundThreads = append(h.boundThreads, providerConversationID)
 	return true
+}
+
+func (h *historyRecorder) ProviderConversationID() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.providerConversationID
+}
+
+func (h *historyRecorder) Close() error {
+	h.writers.release(h)
+	return h.fakeConversation.Close()
 }
 
 func (h *historyRecorder) boundProviderThreads() []string {
@@ -548,8 +609,49 @@ type editDriverState struct {
 	startCalls   int
 	startConfigs []ports.ChatStartConfig
 	resumeCalls  []ports.ChatResumeConfig
-	fresh        *fakeConversation
-	resumed      map[string]*fakeConversation
+	fresh        *ownedFakeConversation
+	resumed      map[string]*ownedFakeConversation
+}
+
+type ownedFakeConversation struct {
+	*fakeConversation
+	writers *providerWriterRegistry
+}
+
+func newOwnedFakeConversation(
+	writers *providerWriterRegistry,
+	providerConversationID string,
+	turnSeq int,
+) *ownedFakeConversation {
+	conversation := newFakeConversation()
+	conversation.providerConversationID = providerConversationID
+	conversation.turnSeq = turnSeq
+	return &ownedFakeConversation{fakeConversation: conversation, writers: writers}
+}
+
+func (c *ownedFakeConversation) acquire() error {
+	return c.writers.claim(c.providerConversationID, c)
+}
+
+func (c *ownedFakeConversation) Close() error {
+	c.writers.release(c)
+	return c.fakeConversation.Close()
+}
+
+func (s *editDriverState) resumeConversation(
+	cfg ports.ChatResumeConfig,
+) (ports.ChatConversation, error) {
+	s.mu.Lock()
+	s.resumeCalls = append(s.resumeCalls, cfg)
+	conversation := s.resumed[cfg.ProviderConversationID]
+	s.mu.Unlock()
+	if conversation == nil {
+		return nil, errors.New("unexpected provider conversation: " + cfg.ProviderConversationID)
+	}
+	if err := conversation.acquire(); err != nil {
+		return nil, err
+	}
+	return conversation, nil
 }
 
 func newEditHarness(t *testing.T, supportsPromptReplay bool) (*harness, *historyRecorder, *editDriverState) {
@@ -562,21 +664,16 @@ func newEditHarness(t *testing.T, supportsPromptReplay bool) (*harness, *history
 		sourceCapabilities[ports.ChatCapabilityEmbeddedContext] = true
 		source.setCapabilities(sourceCapabilities)
 	}
-	fresh := newFakeConversation()
-	fresh.providerConversationID = "thread-fresh"
-	fresh.turnSeq = 100
+	writers := source.writers
+	fresh := newOwnedFakeConversation(writers, "thread-fresh", 100)
 	if supportsPromptReplay {
 		fresh.setCapabilities(source.Capabilities())
 	}
-	forked := newFakeConversation()
-	forked.providerConversationID = "thread-forked"
-	forked.turnSeq = 200
-	root := newFakeConversation()
-	root.providerConversationID = "thread-1"
-	root.turnSeq = 300
+	forked := newOwnedFakeConversation(writers, "thread-forked", 200)
+	root := newOwnedFakeConversation(writers, "thread-1", 300)
 	state := &editDriverState{
 		fresh: fresh,
-		resumed: map[string]*fakeConversation{
+		resumed: map[string]*ownedFakeConversation{
 			"thread-forked": forked,
 			"thread-1":      root,
 		},
@@ -585,7 +682,15 @@ func newEditHarness(t *testing.T, supportsPromptReplay bool) (*harness, *history
 	if supportsPromptReplay {
 		// Use the plain conversation for this scenario: historyRecorder implements
 		// native fork, while the real Claude path does not.
-		initial = source.fakeConversation
+		source.writers.release(source)
+		replayInitial := &ownedFakeConversation{
+			fakeConversation: source.fakeConversation,
+			writers:          source.writers,
+		}
+		if err := replayInitial.acquire(); err != nil {
+			t.Fatalf("claim initial replay provider writer: %v", err)
+		}
+		initial = replayInitial
 	}
 	driver := fakeDriver{conv: initial}
 	driver.start = func(cfg ports.ChatStartConfig) (ports.ChatConversation, error) {
@@ -597,27 +702,23 @@ func newEditHarness(t *testing.T, supportsPromptReplay bool) (*harness, *history
 			return initial, nil
 		}
 		if state.startCalls == 2 {
+			if err := state.fresh.acquire(); err != nil {
+				return nil, err
+			}
 			return state.fresh, nil
 		}
-		freshBranch := newFakeConversation()
-		freshBranch.providerConversationID = fmt.Sprintf("thread-fresh-%d", state.startCalls)
-		freshBranch.turnSeq = state.startCalls * 100
+		freshBranch := newOwnedFakeConversation(
+			writers, fmt.Sprintf("thread-fresh-%d", state.startCalls), state.startCalls*100)
 		if supportsPromptReplay {
 			freshBranch.setCapabilities(source.Capabilities())
+		}
+		if err := freshBranch.acquire(); err != nil {
+			return nil, err
 		}
 		state.fresh = freshBranch
 		return freshBranch, nil
 	}
-	driver.resume = func(cfg ports.ChatResumeConfig) (ports.ChatConversation, error) {
-		state.mu.Lock()
-		defer state.mu.Unlock()
-		state.resumeCalls = append(state.resumeCalls, cfg)
-		conv := state.resumed[cfg.ProviderConversationID]
-		if conv == nil {
-			return nil, errors.New("unexpected provider conversation: " + cfg.ProviderConversationID)
-		}
-		return conv, nil
-	}
+	driver.resume = state.resumeConversation
 
 	clock := time.Date(2026, 8, 9, 15, 0, 0, 0, time.UTC)
 	var idMu sync.Mutex
@@ -666,6 +767,42 @@ func newEditHarness(t *testing.T, supportsPromptReplay bool) (*harness, *history
 	}
 	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
 	return &harness{svc: svc, st: st, conv: source.fakeConversation, ctrl: ctrl, clock: clock}, source, state
+}
+
+func TestEditProviderWriterOwnershipRequiresForkAndClose(t *testing.T) {
+	_, source, driver := newEditHarness(t, false)
+	ctx := context.Background()
+
+	if source.BindProviderConversation("thread-forked") {
+		t.Fatal("unforked provider conversation accepted a writer binding")
+	}
+	forked, err := source.Fork(ctx, nil)
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	if _, err := driver.resumeConversation(ports.ChatResumeConfig{
+		ProviderConversationID: forked,
+	}); !errors.Is(err, errProviderConversationOwned) {
+		t.Fatalf("concurrent Resume error = %v, want errProviderConversationOwned", err)
+	}
+	if !source.BindProviderConversation(forked) {
+		t.Fatal("fork owner could not bind its provider conversation")
+	}
+	if err := source.Close(); err != nil {
+		t.Fatalf("Close fork owner: %v", err)
+	}
+	resumed, err := driver.resumeConversation(ports.ChatResumeConfig{
+		ProviderConversationID: forked,
+	})
+	if err != nil {
+		t.Fatalf("Resume after owner close: %v", err)
+	}
+	if resumed.ProviderConversationID() != forked {
+		t.Fatalf("resumed provider conversation = %q, want %q", resumed.ProviderConversationID(), forked)
+	}
+	if err := resumed.Close(); err != nil {
+		t.Fatalf("Close resumed writer: %v", err)
+	}
 }
 
 func TestEditMessageReplaysDurableContextWhenNativeForkIsUnavailable(t *testing.T) {
@@ -1485,7 +1622,7 @@ func TestActivateBranchResumeFailureKeepsCurrentControllerActive(t *testing.T) {
 }
 
 func TestActivateBranchSwitchesBetweenCompatibleApproximateProviderScopes(t *testing.T) {
-	h, _, driver := newEditHarness(t, true)
+	h, source, driver := newEditHarness(t, true)
 	ctx := context.Background()
 	completeTurn(t, h, "A", "provider-turn-1")
 	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
@@ -1519,8 +1656,7 @@ func TestActivateBranchSwitchesBetweenCompatibleApproximateProviderScopes(t *tes
 		t.Fatalf("Snapshot original branch: %v", err)
 	}
 	requireBranchPoint(t, originalSnapshot, second, "", edited.ActiveBranchID)
-	resumedEdit := newFakeConversation()
-	resumedEdit.providerConversationID = "thread-fresh"
+	resumedEdit := newOwnedFakeConversation(source.writers, "thread-fresh", 400)
 	driver.mu.Lock()
 	driver.resumed["thread-fresh"] = resumedEdit
 	driver.mu.Unlock()
@@ -1532,8 +1668,7 @@ func TestActivateBranchSwitchesBetweenCompatibleApproximateProviderScopes(t *tes
 		t.Fatalf("Snapshot edited branch: %v", err)
 	}
 	requireBranchPoint(t, editedSnapshot, edited.Turn.ID, edited.SourceBranchID, "")
-	resumedOriginal := newFakeConversation()
-	resumedOriginal.providerConversationID = "thread-1"
+	resumedOriginal := newOwnedFakeConversation(source.writers, "thread-1", 500)
 	driver.mu.Lock()
 	driver.resumed["thread-1"] = resumedOriginal
 	driver.mu.Unlock()
@@ -1545,8 +1680,7 @@ func TestActivateBranchSwitchesBetweenCompatibleApproximateProviderScopes(t *tes
 		t.Fatalf("Snapshot original branch again: %v", err)
 	}
 	requireBranchPoint(t, originalSnapshot, second, "", edited.ActiveBranchID)
-	resumedEditAgain := newFakeConversation()
-	resumedEditAgain.providerConversationID = "thread-fresh"
+	resumedEditAgain := newOwnedFakeConversation(source.writers, "thread-fresh", 600)
 	driver.mu.Lock()
 	driver.resumed["thread-fresh"] = resumedEditAgain
 	driver.mu.Unlock()


### PR DESCRIPTION
Fixes #4299

## Summary

- keep a Codex prompt-edit fork on the app-server connection that created it and already owns its writer lock
- atomically move the live controller to the forked branch without starting a second Codex writer
- preserve the existing resume fallback for providers that do not expose a loaded-fork binding, with unit and live Codex regression coverage

## Root cause

Codex `thread/fork` immediately loads and subscribes the forked thread in the creating app-server process. AO then tried to `thread/resume` that same fork through a second app-server process. Codex correctly rejected the second writer, which AO surfaced in the chat editor as `CHAT_RESUME_FAILED`.

## Local Electron evidence

Both screenshots are from the same isolated local desktop session while editing the second user prompt (the fork path).

| Before | After |
| --- | --- |
| Baseline build: the edit fails with `the stored provider conversation could not be resumed (CHAT_RESUME_FAILED)`. | Fixed build: the edited prompt is accepted and Codex replies `EDITED SECOND RESPONSE`. |
| ![Before: later prompt edit fails with CHAT_RESUME_FAILED](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-codex-edit-active-writer/.issue-assets/codex-edit-active-writer/before-local.png) | ![After: later prompt edit completes successfully](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-codex-edit-active-writer/.issue-assets/codex-edit-active-writer/after-local.png) |

## Verification

- `npm run lint` (clean AO environment): all Go tests and golangci-lint pass
- `cd backend && go build ./...`
- `go test -race ./internal/service/chat ./internal/adapters/chatdriver/codexappserver -count=1`
- `AO_CODEX_LIVE=1 go test ./internal/adapters/chatdriver/codexappserver -run '^TestLiveCodexAppServer$' -count=1 -v`
- real Electron before/after run against isolated `~/.ao/dev` state

## Risk

The new binding is optional and feature-detected. Non-Codex drivers retain the existing start/resume behavior, and no API, storage schema, or frontend contract changes are included.
