### PR TITLE
fix(frontend): detect fresh nightly releases promptly

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import nodePath from "node:path";
 
@@ -28,6 +28,7 @@ type AutoUpdaterMock = {
   checkForUpdates: ReturnType<typeof vi.fn>;
   downloadUpdate: ReturnType<typeof vi.fn>;
   quitAndInstall: ReturnType<typeof vi.fn>;
+  setFeedURL: ReturnType<typeof vi.fn>;
   channel: string;
   allowPrerelease: boolean;
   allowDowngrade: boolean;
@@ -41,6 +42,7 @@ function createAutoUpdaterMock(): AutoUpdaterMock {
     checkForUpdates: vi.fn(() => Promise.resolve()),
     downloadUpdate: vi.fn(() => Promise.resolve()),
     quitAndInstall: vi.fn(),
+    setFeedURL: vi.fn(),
     channel: "",
     allowPrerelease: false,
     allowDowngrade: false,
@@ -202,7 +204,7 @@ describe("startAutoUpdates", () => {
     expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
   });
 
-  it("schedules the next automatic check only after the fixed 1-2 hour cadence", async () => {
+  it("keeps stable automatic checks on the hourly cadence", async () => {
     vi.useFakeTimers();
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
     const { module, autoUpdater } = await importAutoUpdater();
@@ -217,6 +219,106 @@ describe("startAutoUpdates", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+  });
+
+  it("rechecks the nightly channel within 15 minutes", async () => {
+    vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const { module, autoUpdater } = await importAutoUpdater({
+      enabled: true,
+      channel: "nightly",
+      nightlyAck: true,
+      feature: null,
+    });
+
+    await module.startAutoUpdates(stateDir);
+    const { delay } = latestInterval(setIntervalSpy);
+
+    expect(delay).toBe(15 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(delay - 1);
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+  });
+
+  it("manual nightly checks resolve the newest completed release without the Atom feed", async () => {
+    const resourcesPath = mkdtempSync(
+      nodePath.join(os.tmpdir(), "ao-nightly-feed-"),
+    );
+    writeFileSync(
+      nodePath.join(resourcesPath, "app-update.yml"),
+      "provider: github\nowner: Untrivial-ai\nrepo: agent-orchestrator\n",
+    );
+    const originalResourcesPath = Object.getOwnPropertyDescriptor(
+      process,
+      "resourcesPath",
+    );
+    Object.defineProperty(process, "resourcesPath", {
+      configurable: true,
+      value: resourcesPath,
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            tag_name: "v1.0.1-nightly.202608231518",
+            draft: false,
+            prerelease: true,
+            assets: [{ name: "Agent.Orchestrator.dmg" }],
+          },
+          {
+            tag_name: "v1.0.1-nightly.202608231517",
+            draft: false,
+            prerelease: true,
+            assets: [{ name: "nightly-mac.yml" }],
+          },
+          {
+            tag_name: "v1.0.1-nightly.202608231350",
+            draft: false,
+            prerelease: true,
+            assets: [{ name: "nightly-mac.yml" }],
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const { module, autoUpdater } = await importAutoUpdater({
+        enabled: true,
+        channel: "nightly",
+        nightlyAck: true,
+        feature: null,
+      });
+
+      await module.checkForUpdatesNow(stateDir);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.github.com/repos/Untrivial-ai/agent-orchestrator/releases?per_page=100",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      expect(autoUpdater.setFeedURL).toHaveBeenNthCalledWith(1, {
+        provider: "generic",
+        url: "https://github.com/Untrivial-ai/agent-orchestrator/releases/download/v1.0.1-nightly.202608231517",
+        channel: "nightly",
+        useMultipleRangeRequest: false,
+      });
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(autoUpdater.setFeedURL).toHaveBeenNthCalledWith(2, {
+        provider: "github",
+        owner: "Untrivial-ai",
+        repo: "agent-orchestrator",
+      });
+    } finally {
+      if (originalResourcesPath) {
+        Object.defineProperty(process, "resourcesPath", originalResourcesPath);
+      } else {
+        Reflect.deleteProperty(process, "resourcesPath");
+      }
+      rmSync(resourcesPath, { recursive: true, force: true });
+    }
   });
 
   it("schedules only feature-pin retirement polling when automatic updates are disabled", async () => {
@@ -1252,7 +1354,7 @@ describe("startAutoUpdates", () => {
     );
   });
 
-  it("starts and stops the hourly scheduler when settings are enabled at runtime", async () => {
+  it("reconciles the automatic scheduler when settings change at runtime", async () => {
     vi.useFakeTimers();
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
     const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
@@ -1278,6 +1380,13 @@ describe("startAutoUpdates", () => {
     expect(setIntervalSpy.mock.calls.map(([, delay]) => delay)).toContain(
       60 * 60 * 1000,
     );
+
+    await module.setUpdateSettings(stateDir, {
+      ...current,
+      channel: "nightly",
+      nightlyAck: true,
+    });
+    expect(latestInterval(setIntervalSpy).delay).toBe(15 * 60 * 1000);
 
     await module.setUpdateSettings(stateDir, { ...current, enabled: false });
     expect(clearIntervalSpy).toHaveBeenCalled();

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -243,6 +243,12 @@ describe("startAutoUpdates", () => {
   });
 
   it("manual nightly checks resolve the newest completed release without the Atom feed", async () => {
+    const platformManifest =
+      process.platform === "darwin"
+        ? "nightly-mac.yml"
+        : process.platform === "linux"
+          ? "nightly-linux.yml"
+          : "nightly.yml";
     const resourcesPath = mkdtempSync(
       nodePath.join(os.tmpdir(), "ao-nightly-feed-"),
     );
@@ -271,13 +277,13 @@ describe("startAutoUpdates", () => {
             tag_name: "v1.0.1-nightly.202608231517",
             draft: false,
             prerelease: true,
-            assets: [{ name: "nightly-mac.yml" }],
+            assets: [{ name: platformManifest }],
           },
           {
             tag_name: "v1.0.1-nightly.202608231350",
             draft: false,
             prerelease: true,
-            assets: [{ name: "nightly-mac.yml" }],
+            assets: [{ name: platformManifest }],
           },
         ]),
         { status: 200 },

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -3,6 +3,7 @@ import { app, BrowserWindow, dialog } from "electron";
 import { accessSync, constants as fsConstants, existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import semver from "semver";
 import {
   readUpdateSettings,
   updateUpdateSettings,
@@ -92,8 +93,10 @@ let stagedEscalated = false;
 let stagedRequestId: string | undefined;
 let escalationTimer: ReturnType<typeof setInterval> | undefined;
 let escalationStateDir: string | undefined;
-const AUTOMATIC_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const STABLE_AUTOMATIC_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const NIGHTLY_AUTOMATIC_UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000;
 let automaticUpdateTimer: ReturnType<typeof setInterval> | undefined;
+let automaticUpdateTimerIntervalMs: number | undefined;
 type UpdaterOperation =
   | "automatic-check"
   | "manual-check"
@@ -111,7 +114,7 @@ let automaticCheckInFlight = false;
 // restarts, and automatic failures are UI-suppressed, so the install goes
 // silently stale (#3526). At the threshold, statuses carry staleCheckNudge so
 // the renderer can suggest a restart.
-const STALE_CHECK_NUDGE_THRESHOLD = 3; // hourly checks → ~3h of staleness
+const STALE_CHECK_NUDGE_THRESHOLD = 3;
 let consecutiveAutomaticNetFailures = 0;
 // One automatic check can both emit an "error" event and reject
 // checkForUpdates(); count that as a single failure.
@@ -221,6 +224,101 @@ async function readAppUpdateYml(): Promise<
   } catch {
     return undefined;
   }
+}
+
+interface GitHubReleaseSummary {
+  tag_name: string;
+  draft: boolean;
+  prerelease: boolean;
+  assets?: Array<{ name?: string }>;
+}
+
+/**
+ * Resolve a completed Nightly release through GitHub's API. electron-updater's
+ * GitHub provider discovers prereleases through releases.atom, which can lag
+ * behind a just-published release even when the release and manifest are ready.
+ * This is used only for user-requested checks; failures fall back to the normal
+ * provider so API rate limits or an outage never break update checks.
+ */
+async function fetchLatestCompletedNightlyTag(
+  owner: string,
+  repo: string,
+): Promise<string | undefined> {
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`,
+      {
+        cache: "no-store",
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "User-Agent": `ao-desktop/${app.getVersion()}`,
+        },
+        signal: AbortSignal.timeout(10000),
+      },
+    );
+    if (!response.ok) return undefined;
+    const releases = (await response.json()) as GitHubReleaseSummary[];
+    const manifestName = `nightly${platformSuffix()}.yml`;
+    return releases
+      .filter((release) => {
+        const parsed = semver.valid(release.tag_name);
+        return (
+          !release.draft &&
+          release.prerelease &&
+          parsed !== null &&
+          semver.prerelease(parsed)?.[0] === "nightly" &&
+          release.assets?.some((asset) => asset.name === manifestName) === true
+        );
+      })
+      .sort((left, right) => semver.rcompare(left.tag_name, right.tag_name))[0]
+      ?.tag_name;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Point one manual Nightly check directly at the newest completed release.
+ * The returned reset restores the normal GitHub provider for later background
+ * checks; electron-updater retains the direct provider with the discovered
+ * update, so a subsequent Download action still uses the correct asset URLs.
+ */
+async function configureDirectManualNightlyFeed(
+  settings: UpdateSettings,
+): Promise<(() => void) | undefined> {
+  if (settings.channel !== "nightly" || settings.feature !== null) {
+    return undefined;
+  }
+  const coordinates = await readAppUpdateYml();
+  if (!coordinates) return undefined;
+  const tag = await fetchLatestCompletedNightlyTag(
+    coordinates.owner,
+    coordinates.repo,
+  );
+  if (!tag) return undefined;
+  const runningVersion = app.getVersion();
+  if (
+    semver.valid(runningVersion) !== null &&
+    semver.prerelease(runningVersion)?.[0] === "nightly" &&
+    semver.lt(tag, runningVersion)
+  ) {
+    return undefined;
+  }
+
+  autoUpdater.setFeedURL({
+    provider: "generic",
+    url: `https://github.com/${coordinates.owner}/${coordinates.repo}/releases/download/${tag}`,
+    channel: "nightly",
+    useMultipleRangeRequest: false,
+  });
+  return () => {
+    autoUpdater.setFeedURL({
+      provider: "github",
+      owner: coordinates.owner,
+      repo: coordinates.repo,
+    });
+  };
 }
 
 /** Platform suffix matching the feed.mjs naming convention. */
@@ -545,7 +643,7 @@ function wireUpdaterEvents(): void {
     // Never crash on update failure (offline, unsigned macOS, etc.).
     // Automatic failures restore the previous status so the UI does not flash
     // an error the user never asked for. That suppression is a UI decision and
-    // must not suppress the telemetry: automatic checks run hourly and are the
+    // must not suppress the telemetry: automatic checks are the
     // main way an install goes silently stale.
     emitUpdateFailure(err);
     if (activeUpdaterOperation === "automatic-check") {
@@ -600,8 +698,18 @@ export function getUpdateStatus(): UpdateStatus {
     : lastStatus;
 }
 
-async function runAutomaticUpdateCheck(stateDir: string): Promise<boolean> {
+function automaticUpdateCheckInterval(settings: UpdateSettings): number {
+  return settings.channel === "nightly" && settings.feature === null
+    ? NIGHTLY_AUTOMATIC_UPDATE_CHECK_INTERVAL_MS
+    : STABLE_AUTOMATIC_UPDATE_CHECK_INTERVAL_MS;
+}
+
+async function runAutomaticUpdateCheck(
+  stateDir: string,
+): Promise<number | undefined> {
   let shouldSchedule = true;
+  let nextIntervalMs =
+    automaticUpdateTimerIntervalMs ?? STABLE_AUTOMATIC_UPDATE_CHECK_INTERVAL_MS;
   try {
     await runSerializedUpdaterOperation("automatic-check", async () => {
       const settings = await reconcileAndPersist(
@@ -615,6 +723,7 @@ async function runAutomaticUpdateCheck(stateDir: string): Promise<boolean> {
         stopPeriodicAutomaticUpdateCheck();
         return;
       }
+      nextIntervalMs = automaticUpdateCheckInterval(settings);
 
       escalationStateDir = stateDir;
       wireUpdaterEvents();
@@ -638,15 +747,27 @@ async function runAutomaticUpdateCheck(stateDir: string): Promise<boolean> {
   } catch (err) {
     console.error("auto-update check failed:", err);
   }
-  return shouldSchedule;
+  return shouldSchedule ? nextIntervalMs : undefined;
 }
 
-function schedulePeriodicAutomaticUpdateCheck(stateDir: string): void {
-  if (automaticUpdateTimer !== undefined) return;
-  automaticUpdateTimer = setInterval(
-    () => void requestAutomaticUpdateCheck(stateDir),
-    AUTOMATIC_UPDATE_CHECK_INTERVAL_MS,
-  );
+function schedulePeriodicAutomaticUpdateCheck(
+  stateDir: string,
+  intervalMs: number,
+): void {
+  if (
+    automaticUpdateTimer !== undefined &&
+    automaticUpdateTimerIntervalMs === intervalMs
+  ) {
+    return;
+  }
+  stopPeriodicAutomaticUpdateCheck();
+  automaticUpdateTimerIntervalMs = intervalMs;
+  automaticUpdateTimer = setInterval(() => {
+    void requestAutomaticUpdateCheck(stateDir).then((nextIntervalMs) => {
+      if (nextIntervalMs !== undefined)
+        schedulePeriodicAutomaticUpdateCheck(stateDir, nextIntervalMs);
+    });
+  }, intervalMs);
   automaticUpdateTimer.unref?.();
 }
 
@@ -654,19 +775,24 @@ function stopPeriodicAutomaticUpdateCheck(): void {
   if (automaticUpdateTimer === undefined) return;
   clearInterval(automaticUpdateTimer);
   automaticUpdateTimer = undefined;
+  automaticUpdateTimerIntervalMs = undefined;
 }
 
 function reconcileAutomaticUpdateSchedule(
   stateDir: string,
-  enabled: boolean,
+  settings: UpdateSettings,
 ): void {
-  if (enabled) schedulePeriodicAutomaticUpdateCheck(stateDir);
+  if (settings.enabled)
+    schedulePeriodicAutomaticUpdateCheck(
+      stateDir,
+      automaticUpdateCheckInterval(settings),
+    );
   else stopPeriodicAutomaticUpdateCheck();
 }
 
 async function requestAutomaticUpdateCheck(
   stateDir: string,
-): Promise<boolean | undefined> {
+): Promise<number | undefined> {
   if (automaticCheckInFlight) return undefined;
   automaticCheckInFlight = true;
   try {
@@ -681,8 +807,9 @@ async function requestAutomaticUpdateCheck(
 // Caller guards on app.isPackaged.
 export async function startAutoUpdates(stateDir: string): Promise<void> {
   startRetirementPollTimer(stateDir);
-  const shouldSchedule = await requestAutomaticUpdateCheck(stateDir);
-  if (shouldSchedule === true) schedulePeriodicAutomaticUpdateCheck(stateDir);
+  const intervalMs = await requestAutomaticUpdateCheck(stateDir);
+  if (intervalMs !== undefined)
+    schedulePeriodicAutomaticUpdateCheck(stateDir, intervalMs);
 }
 
 async function persistUpdaterSettings(
@@ -691,7 +818,7 @@ async function persistUpdaterSettings(
 ): Promise<void> {
   await writeUpdateSettings(stateDir, settings);
   configureFeed(settings);
-  reconcileAutomaticUpdateSchedule(stateDir, settings.enabled);
+  reconcileAutomaticUpdateSchedule(stateDir, settings);
 }
 
 /** Persist settings and reconcile the live updater feed/timer as one updater operation. */
@@ -744,12 +871,17 @@ export async function checkForUpdatesNow(
           stateDir,
           options.settings ?? (await readUpdateSettings(stateDir)),
         );
-        reconcileAutomaticUpdateSchedule(stateDir, settings.enabled);
+        reconcileAutomaticUpdateSchedule(stateDir, settings);
         configureFeed(settings);
         autoUpdater.autoDownload = false;
         applyInstallOnQuitPolicy();
         broadcastUpdaterStatus({ state: "checking" });
-        await autoUpdater.checkForUpdates();
+        const restoreFeed = await configureDirectManualNightlyFeed(settings);
+        try {
+          await autoUpdater.checkForUpdates();
+        } finally {
+          restoreFeed?.();
+        }
       },
       options.requestId,
     );
@@ -808,7 +940,7 @@ export async function returnToHome(
           current.feature ? { ...current, feature: null } : current,
         );
         const settings = await reconcileAndPersist(stateDir, cleared);
-        reconcileAutomaticUpdateSchedule(stateDir, settings.enabled);
+        reconcileAutomaticUpdateSchedule(stateDir, settings);
         configureFeed(settings);
         autoUpdater.autoDownload = false;
         applyInstallOnQuitPolicy();


### PR DESCRIPTION
Fixes #3938

## Summary

- check the Nightly channel every 15 minutes while keeping Stable and feature builds on the existing hourly cadence
- make a user-requested Nightly check resolve the newest completed GitHub release directly instead of depending on the lagging prerelease Atom feed
- require the platform manifest asset before selecting a release, fall back to the existing provider on API/rate-limit/network failures, and restore the normal provider after the check
- reschedule the live timer when the user changes update channels

## Root cause

The reported app launched and checked at about 8:17 PM. `v0.12.7-nightly.202608231517` published at 9:01 PM, but Nightly shared Stable's one-hour timer, so the next automatic check was not due until 9:17 PM. The running app then detected the release on that exact tick and staged its 167,055,860-byte ZIP by 9:18:40 PM. Automatic detection was working, but its policy created a stale window of up to one hour.

Manual prerelease discovery was separately coupled to `electron-updater`'s `releases.atom` path. GitHub can expose a completed release and its manifest through the Releases API before that generated Atom view catches up. The existing issue's proposed missing `Cache-Control` cause is not present in `electron-updater@6.8.9`: `builder-util-runtime` already adds `Cache-Control: no-cache` to GETs, so adding the same header again would not fix server-side feed propagation.

The reported `…1350` build also predates #4285's manual-request status correlation, which explains why the click itself appeared inert. This PR addresses the remaining detection path.

## Reproduction evidence

The scheduling regression test used an enabled Nightly install. Before the fix:

```text
expected 3600000 to be 900000
```

That is the shipped 60-minute timer versus the required 15-minute Nightly timer.

The manual-check regression exposed a completed newer Nightly with the platform manifest. Before the fix, the updater made zero Releases API requests and remained dependent on Atom discovery:

```text
expected fetch mock to have been called
Number of calls: 0
```

Live evidence from the reported machine:

```text
running: 0.12.7-nightly.202608231350
published: 0.12.7-nightly.202608231517 at 21:01 IST
launch/initial check: ~20:17 IST
next hourly check: ~21:17 IST
staged: ~/Library/Caches/agent-orchestrator-updater/pending/Agent.Orchestrator-darwin-arm64-0.12.7-nightly.202608231517.zip at 21:18:40 IST
```

## Fix evidence

Both deterministic reproductions now pass. The manual fixture also proves an even newer but incomplete release (missing the platform manifest) is ignored.

A real Electron + `electron-updater@6.8.9` check then exercised the fixed direct completed-release route against the public release:

```text
Checking for update
Found version 0.12.7-nightly.202608231517 (url: Agent.Orchestrator-darwin-arm64-0.12.7-nightly.202608231517.zip, Agent.Orchestrator-darwin-x64-0.12.7-nightly.202608231517.zip)
PASS direct completed release 0.12.7-nightly.202608231350 -> 0.12.7-nightly.202608231517
```

Release: https://github.com/Untrivial-ai/agent-orchestrator/releases/tag/v0.12.7-nightly.202608231517

## Tests

- focused updater suite — 58 passed
- frontend CI Vitest suite — 209 files, 2,767 tests passed
- frontend and E2E TypeScript checks — passed
- renderer smoke — passed
- product UI verification — 10 files, 64 tests passed
- gitleaks scan — passed
