### PR TITLE
Enable interface switching after Codex resumes

### DIFF
--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -300,6 +300,26 @@ func (p *nativeHistoryCheckpoint) captureAOHighWater(
 	messages []domain.ConversationMessage,
 	activities []domain.ConversationActivity,
 ) {
+	turnsByID := make(map[string]*domain.ConversationTurn, len(turns))
+	for i := range turns {
+		turnsByID[turns[i].ID] = &turns[i]
+	}
+	// An agent switch starts a new provider-native thread with an AO coordination
+	// turn. Completed turns before it belong to the previous provider: their
+	// opaque ids remain useful timeline facts, but the new provider cannot replay
+	// them and they must not gate this native-history import.
+	var providerBoundary time.Time
+	for _, message := range messages {
+		turn := turnsByID[message.TurnID]
+		if turn == nil || message.Role != domain.MessageRoleUser ||
+			!nativeHistoryCoordinationMessage(message.Text) {
+			continue
+		}
+		if turn.RequestedAt.After(providerBoundary) {
+			providerBoundary = turn.RequestedAt
+		}
+	}
+
 	var latest *domain.ConversationTurn
 	for i := range turns {
 		turn := &turns[i]
@@ -309,7 +329,8 @@ func (p *nativeHistoryCheckpoint) captureAOHighWater(
 		// pre-failure transcript entry, leaving the failed turn (e.g. a synthetic
 		// auth-error message) on a dead branch that session/load never replays.
 		// Requiring one of those items would make every future switch time out.
-		if turn.HandledBySessionID != sessionID || turn.State != domain.TurnStateCompleted || turn.ProviderTurnID == "" {
+		if turn.HandledBySessionID != sessionID || turn.State != domain.TurnStateCompleted || turn.ProviderTurnID == "" ||
+			(!providerBoundary.IsZero() && !turn.RequestedAt.After(providerBoundary)) {
 			continue
 		}
 		if latest == nil || turn.RequestedAt.After(latest.RequestedAt) {

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -1106,6 +1106,126 @@ func TestInterfaceHandoffDoesNotAnchorReplayCheckpointOnFailedTurn(t *testing.T)
 	}
 }
 
+func TestInterfaceHandoffDoesNotAnchorReplayBeforeProviderCoordinationBoundary(t *testing.T) {
+	st := openStore(t)
+	now := time.Date(2026, 8, 23, 17, 0, 0, 0, time.UTC)
+	existing, err := st.CreateConversation(context.Background(), "provider-boundary-conversation",
+		domain.ConversationScopeSession, testProject, testSession, now)
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if err := st.ClaimChatControllerGeneration(context.Background(), testSession, "old-generation", now); err != nil {
+		t.Fatalf("ClaimChatControllerGeneration: %v", err)
+	}
+
+	// This completed turn belongs to the provider that owned the session before
+	// the agent switch. The new provider receives it through hidden handoff
+	// instructions, so its native thread cannot replay the old provider IDs.
+	created, err := st.AppendUserMessage(context.Background(), existing.ID, testSession, "old-generation",
+		domain.ConversationMessage{
+			ID: "old-provider-user", Text: "Finish the earlier task.", Origin: domain.MessageOriginHuman,
+			ClientMessageID: "old-provider-client",
+		}, "old-provider-turn", now)
+	if err != nil || !created {
+		t.Fatalf("AppendUserMessage old provider: created=%v err=%v", created, err)
+	}
+	if err := st.BindTurnToProvider(context.Background(), "old-provider-turn", "old-provider-turn-id", now); err != nil {
+		t.Fatalf("BindTurnToProvider old provider: %v", err)
+	}
+	if err := st.SettleAssistantMessage(context.Background(), existing.ID,
+		"old-provider-answer-id", "old-provider-turn-id", "Earlier work finished.", "old-provider-answer", now); err != nil {
+		t.Fatalf("SettleAssistantMessage old provider: %v", err)
+	}
+	if err := st.SettleTurn(context.Background(), existing.ID, "old-provider-turn-id",
+		domain.TurnStateCompleted, "", now); err != nil {
+		t.Fatalf("SettleTurn old provider: %v", err)
+	}
+
+	// The first native turn in the replacement provider is AO's handoff marker.
+	// It is a durable boundary even when the provider rejected that turn.
+	boundaryAt := now.Add(time.Minute)
+	created, err = st.AppendUserMessage(context.Background(), existing.ID, testSession, "old-generation",
+		domain.ConversationMessage{
+			ID:     "coordination-user",
+			Text:   "AO transferred the previous agent's context in hidden system instructions. Continue the task.",
+			Origin: domain.MessageOriginDaemon, ClientMessageID: "coordination-client",
+		}, "coordination-turn", boundaryAt)
+	if err != nil || !created {
+		t.Fatalf("AppendUserMessage coordination: created=%v err=%v", created, err)
+	}
+	if err := st.BindTurnToProvider(context.Background(), "coordination-turn", "new-provider-boundary", boundaryAt); err != nil {
+		t.Fatalf("BindTurnToProvider coordination: %v", err)
+	}
+	if err := st.SettleTurn(context.Background(), existing.ID, "new-provider-boundary",
+		domain.TurnStateFailed, "unsupported model", boundaryAt); err != nil {
+		t.Fatalf("SettleTurn coordination: %v", err)
+	}
+
+	rec, found, err := st.GetSession(context.Background(), testSession)
+	if err != nil || !found {
+		t.Fatalf("load session: found=%v err=%v", found, err)
+	}
+	rec.Metadata.LatestUserPrompt = "Run the current provider check."
+	if err := st.UpdateSession(context.Background(), rec); err != nil {
+		t.Fatalf("seed native replay checkpoint: %v", err)
+	}
+
+	conv := &nativeHistoryConversation{
+		fakeConversation: newFakeConversation(),
+		events: []ports.ChatEvent{
+			{Kind: ports.ChatEventTurnStarted, ProviderEventID: "boundary-start", ProviderTurnID: "new-provider-boundary"},
+			{
+				Kind: ports.ChatEventUserMessageCompleted, ProviderEventID: "boundary-user",
+				ProviderTurnID: "new-provider-boundary", ProviderItemID: "boundary-item",
+				Text: "AO transferred the previous agent's context in hidden system instructions. Continue the task.",
+			},
+			{
+				Kind: ports.ChatEventTurnCompleted, ProviderEventID: "boundary-complete",
+				ProviderTurnID: "new-provider-boundary", TurnState: domain.TurnStateFailed,
+			},
+			{Kind: ports.ChatEventTurnStarted, ProviderEventID: "current-start", ProviderTurnID: "new-provider-turn"},
+			{
+				Kind: ports.ChatEventUserMessageCompleted, ProviderEventID: "current-user",
+				ProviderTurnID: "new-provider-turn", ProviderItemID: "current-user-item",
+				Text: "Run the current provider check.",
+			},
+			{
+				Kind: ports.ChatEventMessageCompleted, ProviderEventID: "current-answer",
+				ProviderTurnID: "new-provider-turn", ProviderItemID: "current-answer-item",
+				Text: "The current provider check passed.",
+			},
+			{
+				Kind: ports.ChatEventTurnCompleted, ProviderEventID: "current-complete",
+				ProviderTurnID: "new-provider-turn", TurnState: domain.TurnStateCompleted,
+			},
+		},
+	}
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Reader: chatsvc.SnapshotReaderFunc(func(ctx context.Context, conversationID string) (chatsvc.ConversationRows, error) {
+			rows, err := st.LoadConversationSnapshot(ctx, conversationID)
+			if err != nil {
+				return chatsvc.ConversationRows{}, err
+			}
+			return chatsvc.ConversationRows{
+				Conversation: rows.Conversation,
+				Turns:        rows.Turns, Messages: rows.Messages, Activities: rows.Activities,
+			}, nil
+		}),
+		Drivers: fakeRegistry{driver: fakeDriver{conv: conv}},
+		Log:     slog.New(slog.DiscardHandler),
+		NewID:   func() string { return fmt.Sprintf("provider-boundary-%d", time.Now().UnixNano()) },
+	})
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+
+	if _, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(), ProviderConversationID: "new-provider-thread", RequireNativeHistory: true,
+	}); err != nil {
+		t.Fatalf("Start resume = %v, want success after the replacement-provider boundary", err)
+	}
+}
+
 func TestSlowNativeHistoryDoesNotBlockOtherControllerLookups(t *testing.T) {
 	st := openStore(t)
 	conv := &blockingHistoryConversation{

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2037,14 +2037,14 @@ func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation strin
 		Prompt:                    rec.Metadata.Prompt,
 		BrowserCapabilityVerifier: browserCapabilityVerifier,
 	}
-	// The interface coordinator has already frozen and stopped the Chat source,
-	// transferred its structured provider id, and required native history for
-	// this exact restore. Bind that id to the target launch immediately: passive
-	// TUI resumes do not necessarily emit a provider SessionStart hook until the
-	// next user turn, which would otherwise make an already-correct round trip
-	// appear unverified forever. Ordinary restores do not take this path and must
-	// still receive current-generation identity proof from their hooks.
-	if requireNativeHistory && !forceFresh && strings.TrimSpace(metadata.AgentSessionID) != "" {
+	// Bind an exact native resume to the target launch immediately. Passive Codex
+	// resumes do not necessarily emit SessionStart until the next user turn, but
+	// `codex resume <id>` cannot silently select a different conversation. The
+	// interface coordinator provides the same guarantee after it freezes Chat and
+	// transfers the required native history. Fresh and fallback launches still
+	// require current-generation identity proof from their hooks.
+	bindNativeIdentity := mode == RestoreModeNative && rec.Harness == domain.HarnessCodex
+	if (bindNativeIdentity || (requireNativeHistory && !forceFresh)) && strings.TrimSpace(metadata.AgentSessionID) != "" {
 		metadata.AgentSessionIDLaunchID = launchID
 	}
 	if err := m.lcm.MarkSpawned(ctx, rec.ID, metadata); err != nil {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1541,6 +1541,9 @@ func TestRestore_RotatesSupervisedAgentGeneration(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
 	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x", RuntimeLaunchID: "launch-old"})
+	rec := st.sessions["mer-1"]
+	rec.Harness = domain.HarnessCodex
+	st.sessions["mer-1"] = rec
 	rt := &fakeRuntime{}
 	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
 	m := New(Deps{
@@ -1557,6 +1560,9 @@ func TestRestore_RotatesSupervisedAgentGeneration(t *testing.T) {
 	}
 	if result.Session.Metadata.RuntimeLaunchID != "launch-new" {
 		t.Fatalf("restored launch id = %q, want launch-new", result.Session.Metadata.RuntimeLaunchID)
+	}
+	if result.Session.Metadata.AgentSessionIDLaunchID != "launch-new" {
+		t.Fatalf("restored native identity launch = %q, want launch-new", result.Session.Metadata.AgentSessionIDLaunchID)
 	}
 	if got := rt.lastCfg.Env[EnvRuntimeLaunchID]; got != "launch-new" {
 		t.Fatalf("restored launch env = %q, want launch-new", got)
@@ -1636,6 +1642,9 @@ func TestResumeAgent_RestartsRuntimeWithManagedGeneration(t *testing.T) {
 	}
 	if got.Metadata.RuntimeHandleID != "tmux-mer-1" || got.Metadata.RuntimeLaunchID != "launch-new" {
 		t.Fatalf("resumed metadata = %+v", got.Metadata)
+	}
+	if got.Metadata.AgentSessionIDLaunchID != "launch-new" {
+		t.Fatalf("native Codex resume identity launch = %q, want launch-new", got.Metadata.AgentSessionIDLaunchID)
 	}
 	if result.Mode != RestoreModeNative {
 		t.Fatalf("resume mode = %q, want native", result.Mode)

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -783,6 +783,33 @@ describe("SessionView", () => {
 		expect(screen.queryByText(transition.errorDetail)).not.toBeInTheDocument();
 	});
 
+	it("returns to the source terminal while a failed Chat switch mode refetch settles", () => {
+		const session = workerSession("sess-1");
+		// The workspace cache observed the transition's intermediate mode commit,
+		// but the durable transition already says the target failed and rolled back.
+		session.mode = "chat";
+		const transition = {
+			id: "transition-failed",
+			sessionId: "sess-1",
+			sourceMode: "tui" as const,
+			targetMode: "chat" as const,
+			policy: "drain" as const,
+			phase: "failed" as const,
+			errorCode: "TARGET_HISTORY_UNSETTLED",
+			errorDetail: "The native conversation history did not settle.",
+			createdAt: "2026-08-23T17:00:00Z",
+			updatedAt: "2026-08-23T17:01:00Z",
+			completedAt: "2026-08-23T17:01:00Z",
+		};
+		interfaceTransitionState.status = { supported: true, targetMode: "chat", transition };
+
+		render(<SessionView sessionId="sess-1" />);
+
+		expect(screen.getByText("terminal center")).toBeInTheDocument();
+		expect(screen.queryByTestId("chat-surface")).not.toBeInTheDocument();
+		expect(screen.getByText(transition.errorDetail)).toBeInTheDocument();
+	});
+
 	it.each([
 		["worker", "sess-1"],
 		["orchestrator", "sess-orch"],

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -628,8 +628,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// targets. A terminal pane (reviewer or shell) renders as a tab inside the
 	// chat surface, so opening one never costs the user the conversation.
 	const chatTargetKind = routedTerminalTarget.kind;
+	const renderedSessionMode =
+		interfaceSwitch.transition?.phase === "failed"
+			? interfaceSwitch.transition.sourceMode
+			: session?.mode;
 	const showChatSurface =
-		session?.mode === "chat" &&
+		session !== undefined &&
+		renderedSessionMode === "chat" &&
 		(chatTargetKind === "worker" || chatTargetKind === "reviewer" || chatTargetKind === "shell");
 
 	// The pane shows one terminal at a time, so selecting a shell or the reviewer


### PR DESCRIPTION
## What

Bind exact native Codex resumes to the active runtime generation so restored terminal sessions are immediately eligible for interface switching. Add regression coverage for both restored and restarted supervised sessions.

## Why

Passive Codex resumes may not emit a `SessionStart` hook until the next user turn. AO therefore retained the correct thread ID but treated it as unverified for the new launch, leaving the interface switch disabled.

## How

Only native Codex resume paths establish launch identity immediately. Existing coordinated handoffs retain their behavior, while fresh and fallback launches still require current-generation hook proof.

## Testing

- `cd backend && GOCACHE=/tmp/ao-codex-fix-gocache go test ./...`

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)