### PR TITLE
feat: add Kimi token usage observability

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -384,11 +384,7 @@ func Run() error {
 			ingestorConfig.RequestAttributionRepair = usagePricing.RepairLegacyAttribution
 		}
 		ingestor := usagepipeline.NewIngestor(store, ingestorConfig)
-		usagePipeline = usagepipeline.NewPipeline(store, ingestor, []string{
-			roots.ClaudeProjects,
-			roots.CodexSessions,
-			roots.CodexArchived,
-		}, usagepipeline.CoordinatorConfig{
+		usagePipeline = usagepipeline.NewPipeline(store, ingestor, usagePipelineWatchRoots(roots), usagepipeline.CoordinatorConfig{
 			Logger:     log,
 			Initialize: usageCollector.BackfillActive,
 			Reconcile: func(reconcileCtx context.Context) error {
@@ -627,6 +623,15 @@ func Run() error {
 		log.Error("cdc pipeline shutdown", "err", err)
 	}
 	return runErr
+}
+
+func usagePipelineWatchRoots(roots usagesvc.SourceRoots) []string {
+	return []string{
+		roots.ClaudeProjects,
+		roots.CodexSessions,
+		roots.CodexArchived,
+		roots.KimiHome,
+	}
 }
 
 func seedScratchProjectOnBoot(ctx context.Context, cfg config.Config, projects *projectsvc.Service) error {

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -359,7 +359,7 @@ func Run() error {
 			usagePricing.Wait()
 		}()
 	}
-	if roots, rootsErr := usagesvc.DefaultSourceRoots(ctx); rootsErr != nil {
+	if roots, rootsErr := usagesvc.DefaultSourceRoots(ctx, cfg.DataDir); rootsErr != nil {
 		log.Warn("usage collection disabled", "err", rootsErr)
 	} else {
 		usageCollector = usagesvc.NewCollector(store, roots, func(reconcile bool) {

--- a/backend/internal/daemon/usage_wiring_test.go
+++ b/backend/internal/daemon/usage_wiring_test.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	usagepipeline "github.com/aoagents/agent-orchestrator/backend/internal/observe/usage"
+	usagesvc "github.com/aoagents/agent-orchestrator/backend/internal/service/usage"
+)
+
+// TestUsagePipelineWatchRootsIncludesKimiWrites catches daemon wiring that
+// registers Kimi sources but omits their managed root from the file watcher.
+func TestUsagePipelineWatchRootsIncludesKimiWrites(t *testing.T) {
+	kimiHome := filepath.Join(t.TempDir(), "kimi")
+	wireDir := filepath.Join(kimiHome, "sessions", "native-1", "agents", "main")
+	if err := os.MkdirAll(wireDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	wirePath := filepath.Join(wireDir, "wire.jsonl")
+	if err := os.WriteFile(wirePath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	roots := usagesvc.SourceRoots{
+		ClaudeProjects: t.TempDir(),
+		CodexSessions:  t.TempDir(),
+		CodexArchived:  t.TempDir(),
+		KimiHome:       kimiHome,
+	}
+	watcher, err := usagepipeline.NewTranscriptWatcher(
+		context.Background(), usagePipelineWatchRoots(roots),
+	)
+	if err != nil {
+		t.Fatalf("create usage watcher: %v", err)
+	}
+	if err := watcher.Rebuild(context.Background(), []string{wirePath}); err != nil {
+		t.Fatalf("rebuild usage watcher: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := watcher.Start(ctx)
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("usage watcher did not stop")
+		}
+	})
+
+	if err := os.WriteFile(wirePath, []byte("{\"updated\":true}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wantPath, err := filepath.EvalSymlinks(wirePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case event := <-watcher.Events():
+		if event.Path != wantPath {
+			t.Fatalf("usage event path = %q, want %q", event.Path, wantPath)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Kimi wire write did not reach the usage watcher")
+	}
+}

--- a/backend/internal/domain/usage.go
+++ b/backend/internal/domain/usage.go
@@ -15,6 +15,7 @@ const (
 	UsageSourceClaudeMain     UsageSourceKind = "claude_main"
 	UsageSourceClaudeSubagent UsageSourceKind = "claude_subagent"
 	UsageSourceCodexRollout   UsageSourceKind = "codex_rollout"
+	UsageSourceKimiWire       UsageSourceKind = "kimi_wire"
 )
 
 // UsageBindingState tracks the root native-session binding lifecycle.

--- a/backend/internal/observe/usage/kimi_parser_test.go
+++ b/backend/internal/observe/usage/kimi_parser_test.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -55,6 +56,55 @@ func TestParseKimiUsageRecordHasReplayStableKey(t *testing.T) {
 	}
 	if first.Events[0].SourceEventKey != second.Events[0].SourceEventKey {
 		t.Fatalf("keys = %q/%q", first.Events[0].SourceEventKey, second.Events[0].SourceEventKey)
+	}
+}
+
+// TestParseKimiUsageRecordWithEpochMilliseconds catches treating Kimi's
+// numeric time field as RFC3339 text and silently dropping CreatedAt.
+func TestParseKimiUsageRecordWithEpochMilliseconds(t *testing.T) {
+	source := usageSource(testKimiWireSource)
+	source.NativeRootID = "kimi-session"
+	record := jsonlRecord{Offset: 100, Data: []byte(`{"id":"usage-epoch","time":1786269600123,"type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":1,"inputCacheRead":2,"inputCacheCreation":3,"output":4}}`)}
+
+	result := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	want := time.UnixMilli(1786269600123).UTC()
+	if got := result.Events[0].CreatedAt; !got.Equal(want) {
+		t.Fatalf("CreatedAt = %v, want %v", got, want)
+	}
+}
+
+// TestDecodeKimiRecordTime catches timestamp identity and event time being
+// decoded by separate format rules.
+func TestDecodeKimiRecordTime(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          json.RawMessage
+		wantIdentity string
+		wantTime     time.Time
+	}{
+		{
+			name:         "RFC3339",
+			raw:          json.RawMessage(`"2026-08-09T10:00:00Z"`),
+			wantIdentity: "2026-08-09T10:00:00Z",
+			wantTime:     time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			name:         "epoch milliseconds",
+			raw:          json.RawMessage(`1786269600123`),
+			wantIdentity: "1786269600123",
+			wantTime:     time.UnixMilli(1786269600123).UTC(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := decodeKimiRecordTime(test.raw)
+			if got.Identity != test.wantIdentity || !got.Time.Equal(test.wantTime) {
+				t.Fatalf("decoded time = %+v, want identity %q and time %v", got, test.wantIdentity, test.wantTime)
+			}
+		})
 	}
 }
 

--- a/backend/internal/observe/usage/kimi_parser_test.go
+++ b/backend/internal/observe/usage/kimi_parser_test.go
@@ -1,0 +1,71 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+const testKimiWireSource domain.UsageSourceKind = "kimi_wire"
+
+// TestParseKimiUsageRecord catches dropping Kimi's cache buckets or counting
+// non-usage wire records as model usage.
+func TestParseKimiUsageRecord(t *testing.T) {
+	source := usageSource(testKimiWireSource)
+	source.NativeRootID = "kimi-session"
+	records := []jsonlRecord{
+		{Offset: 0, Data: []byte(`{"id":"message-1","time":"2026-08-09T09:59:00Z","type":"message.create","message":{}}`)},
+		{Offset: 100, Data: []byte(`{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":13,"inputCacheRead":21,"inputCacheCreation":8,"output":5},"usageScope":"turn"}`)},
+	}
+
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %+v, want one usage record", result.Events)
+	}
+	event := result.Events[0]
+	if event.ProviderID != domain.UsageProviderAnthropic || event.ModelID != "kimi-for-coding" ||
+		event.MeasurementKind != domain.UsageMeasurementNativeReported ||
+		event.CreatedAt != time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC) || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	if tokenValue(event.Tokens.InputTokens) != 42 || tokenValue(event.Tokens.CachedInputTokens) != 21 ||
+		tokenValue(event.Tokens.UncachedInputTokens) != 21 || tokenValue(event.Tokens.OutputTokens) != 5 {
+		t.Fatalf("tokens = %+v", event.Tokens)
+	}
+	if providerUsageTokens(t, event.ProviderUsageJSON, "inputOther") != 13 ||
+		providerUsageTokens(t, event.ProviderUsageJSON, "inputCacheRead") != 21 ||
+		providerUsageTokens(t, event.ProviderUsageJSON, "inputCacheCreation") != 8 ||
+		providerUsageTokens(t, event.ProviderUsageJSON, "output") != 5 {
+		t.Fatalf("provider usage = %s", event.ProviderUsageJSON)
+	}
+}
+
+func TestParseKimiUsageRecordHasReplayStableKey(t *testing.T) {
+	source := usageSource(testKimiWireSource)
+	source.NativeRootID = "kimi-session"
+	record := jsonlRecord{Offset: 100, Data: []byte(`{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":1,"inputCacheRead":2,"inputCacheCreation":3,"output":4}}`)}
+	first := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000000, 0).UTC())
+	second := parseRecords(source, []jsonlRecord{record}, 200, time.Unix(1700000001, 0).UTC())
+	if first.err != nil || second.err != nil || len(first.Events) != 1 || len(second.Events) != 1 {
+		t.Fatalf("first=%+v second=%+v", first, second)
+	}
+	if first.Events[0].SourceEventKey != second.Events[0].SourceEventKey {
+		t.Fatalf("keys = %q/%q", first.Events[0].SourceEventKey, second.Events[0].SourceEventKey)
+	}
+}
+
+func TestParseKimiRejectsNegativeUsage(t *testing.T) {
+	source := usageSource(testKimiWireSource)
+	record := jsonlRecord{Data: []byte(`{"id":"usage-bad","type":"usage.record","model":"kimi-for-coding","usage":{"inputOther":-1,"inputCacheRead":0,"inputCacheCreation":0,"output":1}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Unix(1700000000, 0).UTC())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 || result.Cursor.LastErrorCode != domain.UsageErrorMalformedJSONL {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -44,6 +44,8 @@ func parseRecordsWithState(
 	case domain.UsageSourceCodexRollout:
 		parseCodex(source, records, state.Codex, &result)
 		result.pendingCodexSpawnCalls = len(state.Codex.PendingSpawnCallIDs)
+	case domain.UsageSourceKimiWire:
+		parseKimi(source, records, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -197,6 +199,10 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 		if err := validateCodexDirectParent(source, state.Codex); err != nil {
 			return nil, err
 		}
+	case domain.UsageSourceKimiWire:
+		if state.Claude != nil || state.Codex != nil {
+			return nil, errors.New("append-only state has invalid parser payload")
+		}
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", source.Kind)
 	}
@@ -216,6 +222,9 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 			PendingSpawnCallIDs: []string{},
 			DiscoveredChildIDs:  []string{},
 		}
+	case domain.UsageSourceKimiWire:
+		// Kimi records carry stable native IDs, so no provider-specific
+		// cumulative baseline is required.
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", kind)
 	}

--- a/backend/internal/observe/usage/parser_kimi.go
+++ b/backend/internal/observe/usage/parser_kimi.go
@@ -1,0 +1,99 @@
+package usage
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type kimiWireRecord struct {
+	ID    string          `json:"id"`
+	Time  json.RawMessage `json:"time"`
+	Type  string          `json:"type"`
+	Model string          `json:"model"`
+	Usage json.RawMessage `json:"usage"`
+}
+
+type kimiNativeUsage struct {
+	InputOther         int64 `json:"inputOther"`
+	InputCacheRead     int64 `json:"inputCacheRead"`
+	InputCacheCreation int64 `json:"inputCacheCreation"`
+	Output             int64 `json:"output"`
+}
+
+func parseKimi(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	eventsByKey := make(map[string]domain.ModelUsageEvent)
+	for _, record := range records {
+		var native kimiWireRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "usage.record" {
+			continue
+		}
+		model := firstNonEmpty(native.Model)
+		if model == "" || !jsonValueReported(native.Usage) {
+			recordMalformed(result)
+			continue
+		}
+		var usage kimiNativeUsage
+		if err := json.Unmarshal(native.Usage, &usage); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		tokens, ok := normalizeAnthropicUsage(
+			usage.InputOther,
+			usage.InputCacheCreation,
+			usage.InputCacheRead,
+			usage.Output,
+			nil,
+			nil,
+		)
+		if !ok {
+			recordMalformed(result)
+			continue
+		}
+		identity := firstNonEmpty(native.ID, kimiRecordTimeIdentity(native.Time), strconv.FormatInt(record.Offset, 10))
+		event := domain.ModelUsageEvent{
+			ProviderID:        domain.UsageProviderAnthropic,
+			ModelID:           model,
+			MeasurementKind:   domain.UsageMeasurementNativeReported,
+			Tokens:            tokens,
+			ProviderUsageJSON: boundedProviderUsage(native.Usage),
+			CreatedAt:         parseUsageTimestamp(kimiRecordTimeIdentity(native.Time)),
+			SourceEventKey: stableSourceEventKey(
+				"kimi",
+				source.NativeRootID,
+				source.Source.SubagentID,
+				identity,
+				model,
+			),
+		}
+		if existing, duplicate := eventsByKey[event.SourceEventKey]; duplicate {
+			if !usageEventsEqual(existing, event) {
+				result.Cursor.AnomalyCount++
+				result.Cursor.LastErrorCode = domain.UsageErrorSourceEventConflict
+			}
+			continue
+		}
+		eventsByKey[event.SourceEventKey] = event
+		result.Events = append(result.Events, event)
+	}
+}
+
+func kimiRecordTimeIdentity(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String()
+	}
+	return ""
+}

--- a/backend/internal/observe/usage/parser_kimi.go
+++ b/backend/internal/observe/usage/parser_kimi.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"encoding/json"
 	"strconv"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
@@ -55,14 +56,15 @@ func parseKimi(source domain.UsageSourceContext, records []jsonlRecord, result *
 			recordMalformed(result)
 			continue
 		}
-		identity := firstNonEmpty(native.ID, kimiRecordTimeIdentity(native.Time), strconv.FormatInt(record.Offset, 10))
+		recordTime := decodeKimiRecordTime(native.Time)
+		identity := firstNonEmpty(native.ID, recordTime.Identity, strconv.FormatInt(record.Offset, 10))
 		event := domain.ModelUsageEvent{
 			ProviderID:        domain.UsageProviderAnthropic,
 			ModelID:           model,
 			MeasurementKind:   domain.UsageMeasurementNativeReported,
 			Tokens:            tokens,
 			ProviderUsageJSON: boundedProviderUsage(native.Usage),
-			CreatedAt:         parseUsageTimestamp(kimiRecordTimeIdentity(native.Time)),
+			CreatedAt:         recordTime.Time,
 			SourceEventKey: stableSourceEventKey(
 				"kimi",
 				source.NativeRootID,
@@ -83,17 +85,28 @@ func parseKimi(source domain.UsageSourceContext, records []jsonlRecord, result *
 	}
 }
 
-func kimiRecordTimeIdentity(raw json.RawMessage) string {
+type kimiRecordTime struct {
+	Identity string
+	Time     time.Time
+}
+
+func decodeKimiRecordTime(raw json.RawMessage) kimiRecordTime {
 	if len(raw) == 0 || string(raw) == "null" {
-		return ""
+		return kimiRecordTime{}
 	}
 	var text string
 	if err := json.Unmarshal(raw, &text); err == nil {
-		return text
+		return kimiRecordTime{Identity: text, Time: parseUsageTimestamp(text)}
 	}
 	var number json.Number
-	if err := json.Unmarshal(raw, &number); err == nil {
-		return number.String()
+	if err := json.Unmarshal(raw, &number); err != nil {
+		return kimiRecordTime{}
 	}
-	return ""
+	decoded := kimiRecordTime{Identity: number.String()}
+	milliseconds, err := number.Int64()
+	if err != nil {
+		return decoded
+	}
+	decoded.Time = time.UnixMilli(milliseconds).UTC()
+	return decoded
 }

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessKimi:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -62,11 +62,12 @@ type SourceRoots struct {
 	ClaudeProjects string
 	CodexSessions  string
 	CodexArchived  string
+	KimiHome       string
 }
 
-// DefaultSourceRoots resolves the native Claude Code and Codex transcript
-// directories for the current user.
-func DefaultSourceRoots(ctx context.Context) (SourceRoots, error) {
+// DefaultSourceRoots resolves provider-owned transcript directories. dataDir
+// is AO's already-resolved durable data directory.
+func DefaultSourceRoots(ctx context.Context, dataDir string) (SourceRoots, error) {
 	if err := ctx.Err(); err != nil {
 		return SourceRoots{}, err
 	}
@@ -78,10 +79,14 @@ func DefaultSourceRoots(ctx context.Context) (SourceRoots, error) {
 	if codexHome == "" {
 		codexHome = filepath.Join(home, ".codex")
 	}
+	if strings.TrimSpace(dataDir) == "" {
+		dataDir = filepath.Join(home, ".ao", "data")
+	}
 	return SourceRoots{
 		ClaudeProjects: filepath.Join(home, ".claude", "projects"),
 		CodexSessions:  filepath.Join(codexHome, "sessions"),
 		CodexArchived:  filepath.Join(codexHome, "archived_sessions"),
+		KimiHome:       filepath.Join(dataDir, "kimi"),
 	}, nil
 }
 
@@ -275,7 +280,8 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 		}
 	}
 	if signal.NativeSessionID != "" && mainPath == "" &&
-		(session.Harness == domain.HarnessCodex || finalizing && !existsForDiscovery) {
+		(session.Harness == domain.HarnessCodex || session.Harness == domain.HarnessKimi ||
+			finalizing && !existsForDiscovery) {
 		mainPath, err = c.discoverPath(ctx, session.Harness, signal.NativeSessionID)
 		if err != nil {
 			return err
@@ -368,8 +374,11 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 
 	if mainArtifact != nil {
 		kind := domain.UsageSourceClaudeMain
-		if session.Harness == domain.HarnessCodex {
+		switch session.Harness {
+		case domain.HarnessCodex:
 			kind = domain.UsageSourceCodexRollout
+		case domain.HarnessKimi:
+			kind = domain.UsageSourceKimiWire
 		}
 		changed, err := c.registerHookSource(
 			ctx,
@@ -386,6 +395,11 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 			return err
 		}
 		inventoryChanged = inventoryChanged || changed
+		if session.Harness == domain.HarnessKimi {
+			if err := c.registerDiscoveredKimiAgents(ctx, binding, mainArtifact.path, now, false); err != nil {
+				return err
+			}
+		}
 		sourceErrorCode := ""
 		if c.codexDiscoveryStillPending(ctx, signal.Event, signal.TranscriptPath, mainPath) {
 			sourceErrorCode = domain.UsageErrorSourceDiscoveryPending
@@ -612,18 +626,28 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 	}
 
 	kind := domain.UsageSourceClaudeMain
-	if session.Harness == domain.HarnessCodex {
+	switch session.Harness {
+	case domain.HarnessCodex:
 		kind = domain.UsageSourceCodexRollout
+	case domain.HarnessKimi:
+		kind = domain.UsageSourceKimiWire
 	}
 	if _, err := c.registerSource(ctx, binding, kind, nativeID, "", path, now, false); err != nil {
 		return err
 	}
-	if session.Harness == domain.HarnessClaudeCode {
+	switch session.Harness {
+	case domain.HarnessClaudeCode:
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
-		return err
+	case domain.HarnessCodex:
+		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
+	case domain.HarnessKimi:
+		if err := c.registerDiscoveredKimiAgents(ctx, binding, path, now, false); err != nil {
+			return err
+		}
 	}
 	if state == domain.UsageBindingFinalizing {
 		return c.settleFinalizingBinding(ctx, binding.ID, now)
@@ -861,18 +885,28 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 	}
 
 	kind := domain.UsageSourceClaudeMain
-	if binding.Harness == domain.HarnessCodex {
+	switch binding.Harness {
+	case domain.HarnessCodex:
 		kind = domain.UsageSourceCodexRollout
+	case domain.HarnessKimi:
+		kind = domain.UsageSourceKimiWire
 	}
 	if _, err := c.registerSource(ctx, binding, kind, binding.NativeRootID, "", path, now, false); err != nil {
 		return err
 	}
-	if binding.Harness == domain.HarnessClaudeCode {
+	switch binding.Harness {
+	case domain.HarnessClaudeCode:
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
-		return err
+	case domain.HarnessCodex:
+		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
+	case domain.HarnessKimi:
+		if err := c.registerDiscoveredKimiAgents(ctx, binding, path, now, false); err != nil {
+			return err
+		}
 	}
 	lastErrorCode := ""
 	if binding.Harness == domain.HarnessCodex &&
@@ -1096,7 +1130,7 @@ func (c *Collector) registerHookSource(
 	if kind == domain.UsageSourceCodexRollout && subagentID != "" {
 		expectedParentID = binding.NativeRootID
 	}
-	if err := validateSourceAttribution(
+	if err := c.validateSourceAttribution(
 		binding,
 		kind,
 		nativeSessionID,
@@ -1141,7 +1175,7 @@ func (c *Collector) registerSourceWithExpectedParent(
 	if err != nil {
 		return false, err
 	}
-	if err := validateSourceAttribution(
+	if err := c.validateSourceAttribution(
 		binding,
 		kind,
 		nativeSessionID,
@@ -1187,7 +1221,7 @@ func (c *Collector) registerSourceWithInventory(
 	if err != nil {
 		return false, err
 	}
-	if err := validateSourceAttribution(
+	if err := c.validateSourceAttribution(
 		binding,
 		kind,
 		nativeSessionID,
@@ -1377,6 +1411,48 @@ func (c *Collector) registerDiscoveredClaudeSubagents(
 			domain.UsageSourceClaudeSubagent,
 			binding.NativeRootID,
 			boundedUsageMetadata(subagentID),
+			path,
+			now,
+			reactivateExisting,
+		); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *Collector) registerDiscoveredKimiAgents(
+	ctx context.Context,
+	binding domain.UsageBindingRecord,
+	mainPath string,
+	now time.Time,
+	reactivateExisting bool,
+) error {
+	sessionDir := filepath.Dir(filepath.Dir(filepath.Dir(mainPath)))
+	paths, err := filepath.Glob(filepath.Join(sessionDir, "agents", "*", "wire.jsonl"))
+	if err != nil {
+		return err
+	}
+	sort.Strings(paths)
+	var errs []error
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		agentID := boundedUsageMetadata(filepath.Base(filepath.Dir(path)))
+		if agentID == "" || !nativeUsageIDPattern.MatchString(agentID) {
+			continue
+		}
+		subagentID := agentID
+		if agentID == "main" {
+			subagentID = ""
+		}
+		if _, err := c.registerSource(
+			ctx,
+			binding,
+			domain.UsageSourceKimiWire,
+			binding.NativeRootID,
+			subagentID,
 			path,
 			now,
 			reactivateExisting,
@@ -1698,8 +1774,55 @@ func validateSourceAttribution(
 			filepath.Base(resolved) != "agent-"+subagentID+".jsonl" {
 			return rejected()
 		}
+	case domain.UsageSourceKimiWire:
+		agentDir := filepath.Dir(resolved)
+		agentsDir := filepath.Dir(agentDir)
+		sessionDir := filepath.Dir(agentsDir)
+		agentID := filepath.Base(agentDir)
+		wantSubagent := agentID
+		if agentID == "main" {
+			wantSubagent = ""
+		}
+		if binding.Harness != domain.HarnessKimi || nativeSessionID != binding.NativeRootID ||
+			filepath.Base(resolved) != "wire.jsonl" || filepath.Base(agentsDir) != "agents" ||
+			filepath.Base(sessionDir) != binding.NativeRootID || subagentID != wantSubagent {
+			return rejected()
+		}
 	default:
 		return rejected()
+	}
+	return nil
+}
+
+func (c *Collector) validateSourceAttribution(
+	binding domain.UsageBindingRecord,
+	kind domain.UsageSourceKind,
+	nativeSessionID string,
+	subagentID string,
+	resolved string,
+	expectedParentID string,
+) error {
+	if err := validateSourceAttribution(
+		binding,
+		kind,
+		nativeSessionID,
+		subagentID,
+		resolved,
+		expectedParentID,
+	); err != nil {
+		return err
+	}
+	if kind != domain.UsageSourceKimiWire {
+		return nil
+	}
+	expectedRoot, err := filepath.EvalSymlinks(filepath.Join(c.roots.KimiHome, "sessions"))
+	if err != nil {
+		return errors.New(domain.UsageErrorArtifactPathRejected)
+	}
+	actualSessionDir := filepath.Dir(filepath.Dir(filepath.Dir(resolved)))
+	rel, err := filepath.Rel(expectedRoot, actualSessionDir)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return errors.New(domain.UsageErrorArtifactPathRejected)
 	}
 	return nil
 }
@@ -1710,6 +1833,8 @@ func (c *Collector) allowedRoots(harness domain.AgentHarness) []string {
 		return []string{c.roots.ClaudeProjects}
 	case domain.HarnessCodex:
 		return []string{c.roots.CodexSessions, c.roots.CodexArchived}
+	case domain.HarnessKimi:
+		return []string{c.roots.KimiHome}
 	default:
 		return nil
 	}
@@ -1757,6 +1882,8 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		patterns = []string{filepath.Join(c.roots.ClaudeProjects, "*", nativeID+".jsonl")}
 	case domain.HarnessCodex:
 		return c.discoverCodexPath(ctx, nativeID, "")
+	case domain.HarnessKimi:
+		return c.discoverKimiPath(ctx, nativeID)
 	}
 	type candidate struct {
 		path string
@@ -1788,6 +1915,54 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		return "", nil
 	}
 	return matches[0].path, nil
+}
+
+type kimiIndexRecord struct {
+	SessionID  string `json:"sessionId"`
+	SessionDir string `json:"sessionDir"`
+	Deleted    bool   `json:"deleted"`
+}
+
+func (c *Collector) discoverKimiPath(ctx context.Context, nativeID string) (string, error) {
+	index, err := os.Open(filepath.Join(c.roots.KimiHome, "session_index.jsonl")) //nolint:gosec // configured provider-owned root.
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = index.Close() }()
+
+	var latest kimiIndexRecord
+	scanner := bufio.NewScanner(index)
+	scanner.Buffer(make([]byte, 4096), 64<<10)
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		var record kimiIndexRecord
+		if json.Unmarshal(scanner.Bytes(), &record) == nil && record.SessionID == nativeID {
+			latest = record
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if latest.Deleted || latest.SessionID == "" || !filepath.IsAbs(latest.SessionDir) ||
+		filepath.Base(filepath.Clean(latest.SessionDir)) != nativeID ||
+		!pathWithinRoot(ctx, latest.SessionDir, filepath.Join(c.roots.KimiHome, "sessions")) {
+		return "", nil
+	}
+	mainPath := filepath.Join(latest.SessionDir, "agents", "main", "wire.jsonl")
+	if info, err := os.Stat(mainPath); err == nil && info.Mode().IsRegular() {
+		return mainPath, nil
+	}
+	paths, err := filepath.Glob(filepath.Join(latest.SessionDir, "agents", "*", "wire.jsonl"))
+	if err != nil || len(paths) == 0 {
+		return "", err
+	}
+	sort.Strings(paths)
+	return paths[0], nil
 }
 
 func (c *Collector) discoverCodexPath(ctx context.Context, nativeID, parentID string) (string, error) {

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -373,12 +373,9 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 	}
 
 	if mainArtifact != nil {
-		kind := domain.UsageSourceClaudeMain
-		switch session.Harness {
-		case domain.HarnessCodex:
-			kind = domain.UsageSourceCodexRollout
-		case domain.HarnessKimi:
-			kind = domain.UsageSourceKimiWire
+		kind, ok := sourceKindForHarness(session.Harness)
+		if !ok {
+			return fmt.Errorf("usage: unsupported harness %q", session.Harness)
 		}
 		changed, err := c.registerHookSource(
 			ctx,
@@ -625,12 +622,9 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 		return nil
 	}
 
-	kind := domain.UsageSourceClaudeMain
-	switch session.Harness {
-	case domain.HarnessCodex:
-		kind = domain.UsageSourceCodexRollout
-	case domain.HarnessKimi:
-		kind = domain.UsageSourceKimiWire
+	kind, ok := sourceKindForHarness(session.Harness)
+	if !ok {
+		return fmt.Errorf("usage: unsupported harness %q", session.Harness)
 	}
 	if _, err := c.registerSource(ctx, binding, kind, nativeID, "", path, now, false); err != nil {
 		return err
@@ -884,12 +878,9 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 		targetState = domain.UsageBindingActive
 	}
 
-	kind := domain.UsageSourceClaudeMain
-	switch binding.Harness {
-	case domain.HarnessCodex:
-		kind = domain.UsageSourceCodexRollout
-	case domain.HarnessKimi:
-		kind = domain.UsageSourceKimiWire
+	kind, ok := sourceKindForHarness(binding.Harness)
+	if !ok {
+		return fmt.Errorf("usage: unsupported harness %q", binding.Harness)
 	}
 	if _, err := c.registerSource(ctx, binding, kind, binding.NativeRootID, "", path, now, false); err != nil {
 		return err
@@ -1837,6 +1828,19 @@ func (c *Collector) allowedRoots(harness domain.AgentHarness) []string {
 		return []string{c.roots.KimiHome}
 	default:
 		return nil
+	}
+}
+
+func sourceKindForHarness(harness domain.AgentHarness) (domain.UsageSourceKind, bool) {
+	switch harness {
+	case domain.HarnessClaudeCode:
+		return domain.UsageSourceClaudeMain, true
+	case domain.HarnessCodex:
+		return domain.UsageSourceCodexRollout, true
+	case domain.HarnessKimi:
+		return domain.UsageSourceKimiWire, true
+	default:
+		return "", false
 	}
 }
 

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1896,6 +1896,124 @@ func TestCollectorDiscoversKimiWireSourcesFromSessionIndex(t *testing.T) {
 	}
 }
 
+// TestCollectorReconcileDiscoversKimiChildCreatedAfterStart catches dropping
+// child agents that appear after the initial Kimi source scan.
+func TestCollectorReconcileDiscoversKimiChildCreatedAfterStart(t *testing.T) {
+	const nativeID = "kimi-session-late-child"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessKimi, nativeID, false)
+	home := t.TempDir()
+	sessionDir := filepath.Join(home, "sessions", "wd_agent-orchestrator", nativeID)
+	mainPath := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
+	childPath := filepath.Join(sessionDir, "agents", "researcher", "wire.jsonl")
+	writeUsageFixture(t, mainPath, "{}\n")
+	writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"),
+		fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q,"workDir":"/repo"}`+"\n", nativeID, sessionDir))
+	collector := NewCollector(store, SourceRoots{KimiHome: home}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessKimi, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	writeUsageFixture(t, childPath, "{}\n")
+	mustNoError(t, collector.ReconcileSources(context.Background(), 8))
+
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("sources=%+v err=%v, want main and late child", sources, err)
+	}
+	subagents := map[string]bool{}
+	for _, source := range sources {
+		subagents[source.SubagentID] = true
+	}
+	if !subagents[""] || !subagents["researcher"] {
+		t.Fatalf("sources=%+v, want main and researcher", sources)
+	}
+}
+
+func TestDiscoverKimiPathRejectsUntrustedIndexRecords(t *testing.T) {
+	const nativeID = "kimi-session-untrusted"
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, home string) string
+	}{
+		{
+			name: "absolute path outside sessions root",
+			setup: func(t *testing.T, home string) string {
+				t.Helper()
+				outside := filepath.Join(t.TempDir(), nativeID)
+				writeUsageFixture(t, filepath.Join(outside, "agents", "main", "wire.jsonl"), "{}\n")
+				return fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n", nativeID, outside)
+			},
+		},
+		{
+			name: "symlink escape",
+			setup: func(t *testing.T, home string) string {
+				t.Helper()
+				outside := filepath.Join(t.TempDir(), nativeID)
+				writeUsageFixture(t, filepath.Join(outside, "agents", "main", "wire.jsonl"), "{}\n")
+				link := filepath.Join(home, "sessions", nativeID)
+				mustNoError(t, os.MkdirAll(filepath.Dir(link), 0o700))
+				if err := os.Symlink(outside, link); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+				return fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n", nativeID, link)
+			},
+		},
+		{
+			name: "deleted latest record",
+			setup: func(t *testing.T, home string) string {
+				t.Helper()
+				sessionDir := filepath.Join(home, "sessions", nativeID)
+				writeUsageFixture(t, filepath.Join(sessionDir, "agents", "main", "wire.jsonl"), "{}\n")
+				return fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q}`+"\n"+`{"sessionId":%q,"sessionDir":%q,"deleted":true}`+"\n", nativeID, sessionDir, nativeID, sessionDir)
+			},
+		},
+		{
+			name: "malformed index",
+			setup: func(t *testing.T, _ string) string {
+				t.Helper()
+				return `{"sessionId":` + "\n"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"), tt.setup(t, home))
+			collector := NewCollector(collectorTestStore(t), SourceRoots{KimiHome: home}, nil)
+
+			path, err := collector.discoverKimiPath(context.Background(), nativeID)
+			mustNoError(t, err)
+			if path != "" {
+				t.Fatalf("untrusted index record discovered %q", path)
+			}
+		})
+	}
+}
+
+func TestSourceKindForHarness(t *testing.T) {
+	tests := []struct {
+		harness domain.AgentHarness
+		want    domain.UsageSourceKind
+		ok      bool
+	}{
+		{harness: domain.HarnessClaudeCode, want: domain.UsageSourceClaudeMain, ok: true},
+		{harness: domain.HarnessCodex, want: domain.UsageSourceCodexRollout, ok: true},
+		{harness: domain.HarnessKimi, want: domain.UsageSourceKimiWire, ok: true},
+		{harness: domain.HarnessAider, ok: false},
+	}
+	for _, tt := range tests {
+		got, ok := sourceKindForHarness(tt.harness)
+		if got != tt.want || ok != tt.ok {
+			t.Fatalf("sourceKindForHarness(%q) = %q, %v; want %q, %v", tt.harness, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
 func TestDiscoverClaudePathRejectsGlobMetadata(t *testing.T) {
 	root := t.TempDir()
 	writeUsageFixture(t, filepath.Join(root, "project", "native-session.jsonl"), "{}\n")

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1845,6 +1845,57 @@ func TestDiscoverCodexPathRequiresConfiguredRoots(t *testing.T) {
 	}
 }
 
+func TestDefaultSourceRootsIncludesManagedKimiHome(t *testing.T) {
+	home := t.TempDir()
+	dataDir := filepath.Join(home, ".ao", "data")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+
+	got, err := DefaultSourceRoots(context.Background(), dataDir)
+	mustNoError(t, err)
+	if got.KimiHome != filepath.Join(dataDir, "kimi") {
+		t.Fatalf("Kimi home = %q, want %q", got.KimiHome, filepath.Join(dataDir, "kimi"))
+	}
+}
+
+func TestCollectorDiscoversKimiWireSourcesFromSessionIndex(t *testing.T) {
+	const nativeID = "kimi-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessKimi, nativeID, false)
+	home := t.TempDir()
+	sessionDir := filepath.Join(home, "sessions", "wd_agent-orchestrator", nativeID)
+	mainPath := filepath.Join(sessionDir, "agents", "main", "wire.jsonl")
+	childPath := filepath.Join(sessionDir, "agents", "researcher", "wire.jsonl")
+	writeUsageFixture(t, mainPath, "{}\n")
+	writeUsageFixture(t, childPath, "{}\n")
+	writeUsageFixture(t, filepath.Join(home, "session_index.jsonl"),
+		fmt.Sprintf(`{"sessionId":%q,"sessionDir":%q,"workDir":"/repo"}`+"\n", nativeID, sessionDir))
+	collector := NewCollector(store, SourceRoots{KimiHome: home}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessKimi, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+	pathsBySubagent := make(map[string]string, len(sources))
+	for _, source := range sources {
+		if source.Kind != domain.UsageSourceKimiWire || source.NativeSessionID != nativeID {
+			t.Fatalf("source=%+v", source)
+		}
+		pathsBySubagent[source.SubagentID] = source.ArtifactPath
+	}
+	if pathsBySubagent[""] != canonicalUsagePath(t, mainPath) ||
+		pathsBySubagent["researcher"] != canonicalUsagePath(t, childPath) {
+		t.Fatalf("paths by subagent = %+v", pathsBySubagent)
+	}
+}
+
 func TestDiscoverClaudePathRejectsGlobMetadata(t *testing.T) {
 	root := t.TempDir()
 	writeUsageFixture(t, filepath.Join(root, "project", "native-session.jsonl"), "{}\n")

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -494,9 +494,10 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex')
+      AND ub.harness IN ('claude-code', 'codex', 'kimi')
       AND (
-          ub.state = 'discovering'
+          ub.harness = 'kimi'
+          OR ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
           OR EXISTS (
               SELECT 1
@@ -1130,13 +1131,13 @@ SELECT ub.id, ub.session_id, ub.harness, ub.native_root_id, ub.initial_model_id,
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.harness IN ('claude-code', 'codex', 'kimi')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness = 'claude-code'
+      ub.harness IN ('claude-code', 'kimi')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -121,6 +121,7 @@ var shippedMigrations = map[int64]string{
 	114: "0114_usage_cost_candidate_canonical_index.sql",
 	115: "0115_usage_measurement_and_provider_usage.sql",
 	116: "0116_usage_billing_provider_source.sql",
+	117: "0117_allow_kimi_usage.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -539,6 +539,74 @@ INSERT INTO model_usage_events (
 	}
 }
 
+// TestKimiUsageMigrationPreservesCurrentUsageFacts covers 0117 directly. The
+// harness/source enum rebuild must retain columns introduced by 0113-0116 and
+// leave the bounded provider usage object untouched.
+func TestKimiUsageMigrationPreservesCurrentUsageFacts(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 116)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(`
+INSERT INTO projects (id, path, registered_at, config) VALUES ('kimi-migration', '/repo/kimi', ?, '{}');
+INSERT INTO sessions (id, project_id, num, harness, activity_last_at, created_at, updated_at)
+VALUES ('kimi-migration-1', 'kimi-migration', 1, 'claude-code', ?, ?, ?);
+INSERT INTO usage_bindings (
+    id, session_id, harness, native_root_id, state, updated_at, provider_hint
+) VALUES (1, 'kimi-migration-1', 'claude-code', 'root', 'complete', ?, 'anthropic');
+INSERT INTO usage_sources (id, binding_id, kind, artifact_path, state, updated_at)
+VALUES (1, 1, 'claude_main', '/tmp/claude.jsonl', 'complete', ?);
+INSERT INTO model_usage_events (
+    id, binding_id, usage_source_id, provider_id, billing_provider_id,
+    billing_provider_source, model_id, usage_measurement_kind,
+    input_tokens, cached_input_tokens, uncached_input_tokens, output_tokens,
+    provider_usage_json, source_event_key
+) VALUES (
+    1, 1, 1, 'anthropic', 'anthropic', 'observed', 'claude-test',
+    'native_reported', 100, 40, 60, 20,
+    '{"input_tokens":60,"cache_read_input_tokens":40,"output_tokens":20}',
+    'pre-kimi'
+);`, now, now, now, now, now, now); err != nil {
+		t.Fatalf("seed pre-Kimi usage schema: %v", err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("apply Kimi usage migration: %v", err)
+	}
+
+	var providerHint, measurementKind, providerUsage, billingSource string
+	if err := db.QueryRow(`
+SELECT binding.provider_hint, event.usage_measurement_kind,
+       event.provider_usage_json, event.billing_provider_source
+FROM usage_bindings binding
+JOIN model_usage_events event ON event.binding_id = binding.id
+WHERE event.source_event_key = 'pre-kimi'`).Scan(
+		&providerHint, &measurementKind, &providerUsage, &billingSource,
+	); err != nil {
+		t.Fatalf("read usage facts after Kimi migration: %v", err)
+	}
+	if providerHint != "anthropic" || measurementKind != "native_reported" ||
+		providerUsage != `{"input_tokens":60,"cache_read_input_tokens":40,"output_tokens":20}` ||
+		billingSource != "observed" {
+		t.Fatalf("migrated usage facts = hint:%q kind:%q usage:%q billing-source:%q",
+			providerHint, measurementKind, providerUsage, billingSource)
+	}
+
+	if _, err := db.Exec(`
+INSERT INTO usage_bindings (session_id, harness, native_root_id, state, updated_at)
+VALUES ('kimi-migration-1', 'kimi', 'kimi-root', 'active', ?);
+INSERT INTO usage_sources (binding_id, kind, artifact_path, state, updated_at)
+SELECT id, 'kimi_wire', '/tmp/kimi/wire.jsonl', 'active', ?
+FROM usage_bindings WHERE harness = 'kimi';`, now, now); err != nil {
+		t.Fatalf("insert Kimi usage binding and source: %v", err)
+	}
+}
+
 func openMigratedTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)

--- a/backend/internal/storage/sqlite/migrations/0117_allow_kimi_usage.sql
+++ b/backend/internal/storage/sqlite/migrations/0117_allow_kimi_usage.sql
@@ -1,0 +1,190 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+PRAGMA foreign_keys=OFF;
+PRAGMA legacy_alter_table=ON;
+BEGIN IMMEDIATE;
+
+DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
+DROP TRIGGER IF EXISTS usage_sources_cdc_update;
+
+CREATE TABLE usage_bindings_next (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex', 'kimi')),
+    native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id   TEXT NOT NULL DEFAULT '',
+    state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code    TEXT NOT NULL DEFAULT '',
+    updated_at         TIMESTAMP NOT NULL,
+    provider_hint      TEXT NOT NULL DEFAULT '',
+    UNIQUE (session_id, harness, native_root_id)
+);
+
+CREATE TABLE usage_sources_next (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind                TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout', 'kimi_wire')),
+    native_session_id   TEXT NOT NULL DEFAULT '',
+    subagent_id         TEXT NOT NULL DEFAULT '',
+    artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity       TEXT NOT NULL DEFAULT '',
+    generation          INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset         INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    parser_state_json   TEXT NOT NULL DEFAULT '{}',
+    state               TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count       INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count       INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at       TIMESTAMP,
+    last_error_code     TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+
+INSERT INTO usage_bindings_next
+SELECT id, session_id, harness, native_root_id, initial_model_id,
+       state, last_error_code, updated_at, provider_hint
+FROM usage_bindings;
+
+INSERT INTO usage_sources_next
+SELECT id, binding_id, kind, native_session_id, subagent_id, artifact_path,
+       file_identity, generation, byte_offset, parser_state_json, state,
+       failure_count, anomaly_count, next_retry_at, last_error_code, updated_at
+FROM usage_sources;
+
+DROP TABLE usage_sources;
+DROP TABLE usage_bindings;
+ALTER TABLE usage_bindings_next RENAME TO usage_bindings;
+ALTER TABLE usage_sources_next RENAME TO usage_sources;
+
+CREATE INDEX idx_usage_bindings_session_state ON usage_bindings (session_id, state);
+CREATE INDEX idx_usage_sources_state_retry ON usage_sources (state, next_retry_at);
+CREATE INDEX idx_usage_sources_binding_kind ON usage_sources (binding_id, kind);
+CREATE INDEX idx_usage_sources_codex_native_latest
+    ON usage_sources (kind, native_session_id, binding_id, generation DESC, id DESC);
+
+CREATE TRIGGER usage_bindings_cdc_insert AFTER INSERT ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_bindings_cdc_update AFTER UPDATE ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_sources_cdc_update AFTER UPDATE ON usage_sources
+WHEN OLD.anomaly_count IS NOT NEW.anomaly_count
+  OR OLD.last_error_code IS NOT NEW.last_error_code
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, ub.session_id, 'session_updated', json_object('id', ub.session_id), NEW.updated_at
+    FROM usage_bindings ub JOIN sessions s ON s.id = ub.session_id WHERE ub.id = NEW.binding_id;
+END;
+
+COMMIT;
+PRAGMA legacy_alter_table=OFF;
+PRAGMA foreign_keys=ON;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+PRAGMA foreign_keys=OFF;
+PRAGMA legacy_alter_table=ON;
+BEGIN IMMEDIATE;
+
+DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
+DROP TRIGGER IF EXISTS usage_sources_cdc_update;
+
+DELETE FROM model_usage_events
+WHERE binding_id IN (SELECT id FROM usage_bindings WHERE harness = 'kimi');
+
+CREATE TABLE usage_bindings_previous (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex')),
+    native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id   TEXT NOT NULL DEFAULT '',
+    state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code    TEXT NOT NULL DEFAULT '',
+    updated_at         TIMESTAMP NOT NULL,
+    provider_hint      TEXT NOT NULL DEFAULT '',
+    UNIQUE (session_id, harness, native_root_id)
+);
+
+CREATE TABLE usage_sources_previous (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind                TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout')),
+    native_session_id   TEXT NOT NULL DEFAULT '',
+    subagent_id         TEXT NOT NULL DEFAULT '',
+    artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity       TEXT NOT NULL DEFAULT '',
+    generation          INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset         INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    parser_state_json   TEXT NOT NULL DEFAULT '{}',
+    state               TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count       INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count       INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at       TIMESTAMP,
+    last_error_code     TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+
+INSERT INTO usage_bindings_previous
+SELECT id, session_id, harness, native_root_id, initial_model_id,
+       state, last_error_code, updated_at, provider_hint
+FROM usage_bindings
+WHERE harness IN ('claude-code', 'codex');
+
+INSERT INTO usage_sources_previous
+SELECT source.id, source.binding_id, source.kind, source.native_session_id,
+       source.subagent_id, source.artifact_path, source.file_identity,
+       source.generation, source.byte_offset, source.parser_state_json,
+       source.state, source.failure_count, source.anomaly_count,
+       source.next_retry_at, source.last_error_code, source.updated_at
+FROM usage_sources source
+JOIN usage_bindings_previous binding ON binding.id = source.binding_id
+WHERE source.kind IN ('claude_main', 'claude_subagent', 'codex_rollout');
+
+DROP TABLE usage_sources;
+DROP TABLE usage_bindings;
+ALTER TABLE usage_bindings_previous RENAME TO usage_bindings;
+ALTER TABLE usage_sources_previous RENAME TO usage_sources;
+
+CREATE INDEX idx_usage_bindings_session_state ON usage_bindings (session_id, state);
+CREATE INDEX idx_usage_sources_state_retry ON usage_sources (state, next_retry_at);
+CREATE INDEX idx_usage_sources_binding_kind ON usage_sources (binding_id, kind);
+CREATE INDEX idx_usage_sources_codex_native_latest
+    ON usage_sources (kind, native_session_id, binding_id, generation DESC, id DESC);
+
+CREATE TRIGGER usage_bindings_cdc_insert AFTER INSERT ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_bindings_cdc_update AFTER UPDATE ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_sources_cdc_update AFTER UPDATE ON usage_sources
+WHEN OLD.anomaly_count IS NOT NEW.anomaly_count
+  OR OLD.last_error_code IS NOT NEW.last_error_code
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, ub.session_id, 'session_updated', json_object('id', ub.session_id), NEW.updated_at
+    FROM usage_bindings ub JOIN sessions s ON s.id = ub.session_id WHERE ub.id = NEW.binding_id;
+END;
+
+COMMIT;
+PRAGMA legacy_alter_table=OFF;
+PRAGMA foreign_keys=ON;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -111,9 +111,10 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex')
+      AND ub.harness IN ('claude-code', 'codex', 'kimi')
       AND (
-          ub.state = 'discovering'
+          ub.harness = 'kimi'
+          OR ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
           OR EXISTS (
               SELECT 1
@@ -161,13 +162,13 @@ SELECT ub.*
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.harness IN ('claude-code', 'codex', 'kimi')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness = 'claude-code'
+      ub.harness IN ('claude-code', 'kimi')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'

--- a/backend/internal/storage/sqlite/store/usage_store.go
+++ b/backend/internal/storage/sqlite/store/usage_store.go
@@ -228,8 +228,8 @@ func (s *Store) ListWatchableUsageSources(ctx context.Context) ([]domain.UsageSo
 }
 
 // HasPendingUsageDiscovery reports whether a live binding has a durable reason
-// to retry source discovery. It excludes healthy active bindings, so retries do
-// not degrade into global transcript polling.
+// to retry source discovery. Healthy active bindings are excluded unless their
+// provider has a dynamic child inventory, such as Kimi agents.
 func (s *Store) HasPendingUsageDiscovery(ctx context.Context) (bool, error) {
 	pending, err := s.qr.HasPendingUsageDiscovery(ctx)
 	if err != nil {

--- a/backend/internal/storage/sqlite/store/usage_store_test.go
+++ b/backend/internal/storage/sqlite/store/usage_store_test.go
@@ -1678,6 +1678,45 @@ func seedUsageSession(t *testing.T, s *sqlite.Store, harness domain.AgentHarness
 	return got
 }
 
+// TestKimiUsageEventRoundTrip catches schema or validation changes that accept
+// Kimi sessions in the app but reject their certified usage source or canonical
+// Anthropic-shaped token event at the storage boundary.
+func TestKimiUsageEventRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	session := seedUsageSession(t, s, domain.HarnessKimi)
+	binding := mustUpsertUsageBinding(t, s, session, now, domain.UsageBindingRecord{
+		NativeRootID: "kimi-session",
+		State:        domain.UsageBindingActive,
+	})
+	source := mustInsertUsageSource(t, s, now, domain.UsageSourceRecord{
+		BindingID:       binding.ID,
+		Kind:            domain.UsageSourceKimiWire,
+		NativeSessionID: "kimi-session",
+		ArtifactPath:    "/tmp/kimi/sessions/kimi-session/agents/main/wire.jsonl",
+		FileIdentity:    "dev:ino",
+		State:           domain.UsageSourcePending,
+	})
+	event := anthropicUsageEvent("kimi-event", 13, 8, 21, 5)
+	event.ModelID = "kimi-for-coding"
+	if err := s.ApplyUsageChunk(context.Background(), source.ID, 0, source.UpdatedAt, domain.SourceCursorState{
+		ByteOffset: 100, State: domain.UsageSourceActive, ParserStateJSON: `{}`,
+		UpdatedAt: now,
+	}, []domain.ModelUsageEvent{event}); err != nil {
+		t.Fatalf("apply Kimi usage: %v", err)
+	}
+
+	models, err := s.ListUsageModelAggregates(context.Background(), session.ID)
+	mustNoError(t, err)
+	if len(models) != 1 || models[0].Harness != domain.HarnessKimi || models[0].ModelID != "kimi-for-coding" ||
+		usageTokenValue(models[0].Tokens.InputTokens) != 42 ||
+		usageTokenValue(models[0].Tokens.CachedInputTokens) != 21 ||
+		usageTokenValue(models[0].Tokens.UncachedInputTokens) != 21 ||
+		usageTokenValue(models[0].Tokens.OutputTokens) != 5 {
+		t.Fatalf("Kimi aggregate = %+v", models)
+	}
+}
+
 func seedUsageSource(t *testing.T, s *sqlite.Store, sess domain.SessionRecord, now time.Time) domain.UsageSourceRecord {
 	t.Helper()
 	initialModelID := "gpt-5"

--- a/backend/internal/storage/sqlite/store/usage_store_test.go
+++ b/backend/internal/storage/sqlite/store/usage_store_test.go
@@ -105,6 +105,38 @@ func TestUsageBindingAndSourceIdempotency(t *testing.T) {
 	}
 }
 
+// TestActiveKimiBindingRemainsDiscoverable catches removing live Kimi
+// bindings from the bounded reconciliation queue after the main source exists.
+func TestActiveKimiBindingRemainsDiscoverable(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	sess := seedUsageSession(t, s, domain.HarnessKimi)
+	now := time.Unix(1700000000, 0).UTC()
+	binding := mustUpsertUsageBinding(t, s, sess, now, domain.UsageBindingRecord{
+		NativeRootID: "kimi-live",
+		State:        domain.UsageBindingActive,
+	})
+	mustInsertUsageSource(t, s, now, domain.UsageSourceRecord{
+		BindingID:       binding.ID,
+		Kind:            domain.UsageSourceKimiWire,
+		NativeSessionID: binding.NativeRootID,
+		ArtifactPath:    "/tmp/kimi/main/wire.jsonl",
+		FileIdentity:    "kimi-main",
+		State:           domain.UsageSourceActive,
+	})
+
+	pending, err := s.HasPendingUsageDiscovery(ctx)
+	mustNoError(t, err)
+	if !pending {
+		t.Fatal("active Kimi binding did not keep bounded child discovery active")
+	}
+	discovery, err := s.ListUsageDiscoveryBindings(ctx, 8)
+	mustNoError(t, err)
+	if len(discovery) != 1 || discovery[0].ID != binding.ID {
+		t.Fatalf("discovery bindings = %+v, want Kimi binding %d", discovery, binding.ID)
+	}
+}
+
 func TestListLatestRetiredCodexReplacementClaimsByPath(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## What

Adds Kimi token-usage observability using the shared token-source foundation.

- discovers Kimi main and child-agent `wire.jsonl` sources
- parses `usage.record` events into the canonical token model
- persists and aggregates Kimi usage through the shared collector and SQLite store
- adds parser, discovery, migration, and storage coverage

## Why this PR was recreated

The earlier provider PRs were stacked on one another instead of being based cleanly on `main`. That made them difficult to review and prevented them from merging independently into `main`.

This is the clean replacement for the earlier Kimi work. Pi and Qwen were also recreated as separate PRs so each provider can be reviewed, tested, merged, or reverted independently.

## Related PRs and merge order

1. **Kimi:** #4311 (this PR)
2. **Pi:** #4326
3. **Qwen:** #4327

All three target `main`; the order above is recommended for the provider-usage migrations.

## Implementation

Kimi wire usage is normalized through the existing shared token-source contracts. Cache reads remain cached input; direct input plus cache creation form derived uncached input; all input buckets form total input.

The storage migration preserves existing usage rows, IDs, indexes, views, and change-data-capture triggers while widening the supported harness and source-kind constraints.

## Testing

- `go test ./internal/observe/usage ./internal/service/usage ./internal/storage/sqlite ./internal/storage/sqlite/store ./internal/daemon -count=1`
- `go vet ./...`
- focused golangci-lint over all changed packages: `0 issues`
- `git diff --check`

The full backend run only encountered the repository's pre-existing timing-sensitive fake-agent lifecycle test; the same failure was reproduced on unchanged `main`. All directly affected packages pass.

## Checklist

- [x] Based on `main`
- [x] One provider-focused change
- [x] Tests added for the changed behavior
- [x] Relevant local checks pass
