### PR TITLE
fix(desktop): prevent macOS DevTools menu crash

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -99,7 +99,7 @@ import { keepDaemonAlive, shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 import { dockBounceType, shouldReplaceBounce, shouldSignalAttention, shouldToast } from "./main/notification-signals";
-import { buildWindowsAppMenuTemplate } from "./main/menu";
+import { buildMacAppMenuTemplate, buildWindowsAppMenuTemplate } from "./main/menu";
 import { ancestorRepositorySetupWarning, scanImportFolder } from "./main/import-folder-scan";
 import { parseOpenFolderPathArg } from "./main/open-folder-arg";
 
@@ -350,19 +350,27 @@ function appendDaemonOutput(text: string): void {
 	if (nextStatus !== daemonStatus) setDaemonStatus(nextStatus);
 }
 
-// Menu installed on Windows where the native menu bar is hidden. The bar stays
-// out of sight, but the roles keep their accelerators alive (Reload, zoom, full
-// screen, edit commands). DevTools uses the AO browser toggle so the focused
-// Browser panel opens the same native Chromium surface as the toolbar.
+// Electron's built-in toggleDevTools role assumes focus belongs to a
+// BrowserWindow. AO uses WebContentsView children, so every native DevTools
+// command must go through a guarded target selection instead.
+function toggleDevToolsForFocusedSurface(): void {
+	const fallback = () => getShellWebContents()?.toggleDevTools();
+	const host = browserViewHost;
+	if (!host) {
+		fallback();
+		return;
+	}
+	void host.toggleDevToolsForLastFocused().then((state) => {
+		if (!state) fallback();
+	}).catch(fallback);
+}
+
 function buildWindowsAppMenu(): Menu {
-	return Menu.buildFromTemplate(
-		buildWindowsAppMenuTemplate(() => {
-			const fallback = () => getShellWebContents()?.toggleDevTools();
-			void browserViewHost?.toggleDevToolsForLastFocused().then((state) => {
-				if (!state) fallback();
-			}).catch(fallback);
-		}),
-	);
+	return Menu.buildFromTemplate(buildWindowsAppMenuTemplate(toggleDevToolsForFocusedSurface));
+}
+
+function buildMacAppMenu(): Menu {
+	return Menu.buildFromTemplate(buildMacAppMenuTemplate(toggleDevToolsForFocusedSurface));
 }
 
 async function disposeBrowserViewHost(): Promise<void> {
@@ -444,11 +452,14 @@ async function createWindowInternal(): Promise<void> {
 	// On Windows the app paints its own title bar (WindowTitlebar), so the native
 	// menu bar is hidden (autoHideMenuBar above). The role-based menu is still
 	// installed so its accelerators keep working and act on the focused pane;
-	// setMenuBarVisibility(false) keeps the strip itself out of view. macOS/Linux
-	// keep their native menus.
+	// setMenuBarVisibility(false) keeps the strip itself out of view. macOS gets
+	// an explicit menu so DevTools avoids Electron's unsafe built-in role; Linux
+	// keeps its native menu.
 	if (process.platform === "win32") {
 		Menu.setApplicationMenu(buildWindowsAppMenu());
 		mainWindow.setMenuBarVisibility(false);
+	} else if (process.platform === "darwin") {
+		Menu.setApplicationMenu(buildMacAppMenu());
 	}
 
 	// Harden navigation: never let renderer/terminal content open in-app windows or

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -350,27 +350,19 @@ function appendDaemonOutput(text: string): void {
 	if (nextStatus !== daemonStatus) setDaemonStatus(nextStatus);
 }
 
-// Electron's built-in toggleDevTools role assumes focus belongs to a
-// BrowserWindow. AO uses WebContentsView children, so every native DevTools
-// command must go through a guarded target selection instead.
-function toggleDevToolsForFocusedSurface(): void {
-	const fallback = () => getShellWebContents()?.toggleDevTools();
-	const host = browserViewHost;
-	if (!host) {
-		fallback();
-		return;
-	}
-	void host.toggleDevToolsForLastFocused().then((state) => {
-		if (!state) fallback();
-	}).catch(fallback);
-}
-
+// Menu installed on Windows where the native menu bar is hidden. The bar stays
+// out of sight, but the roles keep their accelerators alive (Reload, zoom, full
+// screen, edit commands). DevTools uses the AO browser toggle so the focused
+// Browser panel opens the same native Chromium surface as the toolbar.
 function buildWindowsAppMenu(): Menu {
-	return Menu.buildFromTemplate(buildWindowsAppMenuTemplate(toggleDevToolsForFocusedSurface));
-}
-
-function buildMacAppMenu(): Menu {
-	return Menu.buildFromTemplate(buildMacAppMenuTemplate(toggleDevToolsForFocusedSurface));
+	return Menu.buildFromTemplate(
+		buildWindowsAppMenuTemplate(() => {
+			const fallback = () => getShellWebContents()?.toggleDevTools();
+			void browserViewHost?.toggleDevToolsForLastFocused().then((state) => {
+				if (!state) fallback();
+			}).catch(fallback);
+		}),
+	);
 }
 
 async function disposeBrowserViewHost(): Promise<void> {
@@ -459,7 +451,21 @@ async function createWindowInternal(): Promise<void> {
 		Menu.setApplicationMenu(buildWindowsAppMenu());
 		mainWindow.setMenuBarVisibility(false);
 	} else if (process.platform === "darwin") {
-		Menu.setApplicationMenu(buildMacAppMenu());
+		Menu.setApplicationMenu(
+			Menu.buildFromTemplate(
+				buildMacAppMenuTemplate(() => {
+					const fallback = () => getShellWebContents()?.toggleDevTools();
+					const host = browserViewHost;
+					if (!host) {
+						fallback();
+						return;
+					}
+					void host.toggleDevToolsForLastFocused().then((state) => {
+						if (!state) fallback();
+					}).catch(fallback);
+				}),
+			),
+		);
 	}
 
 	// Harden navigation: never let renderer/terminal content open in-app windows or

--- a/frontend/src/main/menu.test.ts
+++ b/frontend/src/main/menu.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { buildWindowsAppMenuTemplate } from "./menu";
+import { describe, expect, it, vi } from "vitest";
+import { buildMacAppMenuTemplate, buildWindowsAppMenuTemplate } from "./menu";
 
 type MenuItem = ReturnType<typeof buildWindowsAppMenuTemplate>[number];
 type SubmenuItem = NonNullable<Extract<MenuItem["submenu"], readonly unknown[]>>[number];
@@ -26,5 +26,42 @@ describe("buildWindowsAppMenuTemplate", () => {
 
 	it("keeps the direct minus accelerator for zoom out", () => {
 		expect(viewSubmenu()).toContainEqual(expect.objectContaining({ accelerator: "Ctrl+-", role: "zoomOut" }));
+	});
+});
+
+describe("buildMacAppMenuTemplate", () => {
+	function macViewSubmenu(onToggleDevTools = () => undefined): readonly SubmenuItem[] {
+		const viewMenu = buildMacAppMenuTemplate(onToggleDevTools).find(
+			(item) => item.label === "View",
+		);
+		if (!viewMenu || !Array.isArray(viewMenu.submenu)) {
+			throw new Error("View menu not found");
+		}
+		return viewMenu.submenu;
+	}
+
+	it("uses a guarded click handler instead of Electron's crashing DevTools role", () => {
+		const onToggleDevTools = vi.fn();
+		const devtoolsItems = macViewSubmenu(onToggleDevTools).filter(
+			(item) => item.label === "Toggle Developer Tools" || item.role === "toggleDevTools",
+		);
+
+		expect(devtoolsItems).toHaveLength(1);
+		expect(devtoolsItems[0]).toMatchObject({
+			accelerator: "Alt+Command+I",
+			label: "Toggle Developer Tools",
+		});
+		expect(devtoolsItems[0].role).toBeUndefined();
+
+		devtoolsItems[0].click?.(undefined as never, undefined as never, undefined as never);
+		expect(onToggleDevTools).toHaveBeenCalledOnce();
+	});
+
+	it("preserves Electron's complete standard macOS menus", () => {
+		const template = buildMacAppMenuTemplate(() => undefined);
+
+		expect(template.map((item) => item.role)).toEqual(
+			expect.arrayContaining(["appMenu", "fileMenu", "editMenu", "windowMenu"]),
+		);
 	});
 });

--- a/frontend/src/main/menu.test.ts
+++ b/frontend/src/main/menu.test.ts
@@ -63,5 +63,6 @@ describe("buildMacAppMenuTemplate", () => {
 		expect(template.map((item) => item.role)).toEqual(
 			expect.arrayContaining(["appMenu", "fileMenu", "editMenu", "windowMenu"]),
 		);
+		expect(macViewSubmenu()).toContainEqual(expect.objectContaining({ role: "forceReload" }));
 	});
 });

--- a/frontend/src/main/menu.ts
+++ b/frontend/src/main/menu.ts
@@ -14,6 +14,7 @@ export function buildMacAppMenuTemplate(onToggleDevTools: () => void): MenuItemC
 			label: "View",
 			submenu: [
 				{ role: "reload" },
+				{ role: "forceReload" },
 				{
 					label: "Toggle Developer Tools",
 					accelerator: "Alt+Command+I",

--- a/frontend/src/main/menu.ts
+++ b/frontend/src/main/menu.ts
@@ -1,5 +1,36 @@
 import type { MenuItemConstructorOptions } from "electron";
 
+// Electron's built-in toggleDevTools role assumes the focused surface belongs
+// to a BrowserWindow. AO uses BaseWindow with WebContentsView children, so the
+// role can receive no focused window and crash the main process. Keep Electron's
+// complete standard menus through their top-level roles, but replace View so
+// DevTools routes through AO's guarded handler.
+export function buildMacAppMenuTemplate(onToggleDevTools: () => void): MenuItemConstructorOptions[] {
+	return [
+		{ role: "appMenu" },
+		{ role: "fileMenu" },
+		{ role: "editMenu" },
+		{
+			label: "View",
+			submenu: [
+				{ role: "reload" },
+				{
+					label: "Toggle Developer Tools",
+					accelerator: "Alt+Command+I",
+					click: onToggleDevTools,
+				},
+				{ type: "separator" },
+				{ role: "resetZoom" },
+				{ role: "zoomIn" },
+				{ role: "zoomOut" },
+				{ type: "separator" },
+				{ role: "togglefullscreen" },
+			],
+		},
+		{ role: "windowMenu" },
+	];
+}
+
 export function buildWindowsAppMenuTemplate(onToggleDevTools?: () => void): MenuItemConstructorOptions[] {
 	const devtoolsItem: MenuItemConstructorOptions = onToggleDevTools
 		? {


### PR DESCRIPTION
Fixes [#4308](https://github.com/Untrivial-ai/agent-orchestrator/issues/4308).

## Summary

- install an explicit macOS application menu so Electron's unsafe default `toggleDevTools` role is not used
- route the native menu and accelerator through AO's guarded last-focused-browser handler, with the shell web contents as fallback
- preserve Electron's complete standard macOS App, File, Edit, and Window menus through their top-level roles
- add regression coverage proving the DevTools item has a click handler and no `toggleDevTools` role

## Root cause

AO composes its desktop window from a `BaseWindow` and `WebContentsView` children. Electron's default macOS DevTools role assumes focus belongs to a `BrowserWindow`; when focus belongs to an AO child view, Electron resolves no focused window and dereferences `toggleDevTools` on an undefined target in the main process.

## Related

- [PR #3910](https://github.com/Untrivial-ai/agent-orchestrator/pull/3910) has the same core diagnosis. This implementation preserves the complete Electron-provided macOS menus via `appMenu`, `fileMenu`, `editMenu`, and `windowMenu` instead of reconstructing a subset of their commands.

## Verification

- `npm test -- --run src/main/menu.test.ts` — 4 tests passed
- `npm run typecheck` — passed
- `npm run typecheck:e2e` — passed
- `npx vitest run` — 209 files and 2,767 tests passed
- launched the real Electron checkout in isolated mode with the daemon healthy on `127.0.0.1:3002`
- Electron-native harness installed the generated macOS menu and directly invoked its DevTools item: one handler call, no `toggleDevTools` role, all four standard menu roles present