### PR TITLE
fix(projects): use per-project orchestrator agent override, not daemon default

### DIFF
--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -720,6 +720,16 @@ func (m *Service) projectFromRow(ctx context.Context, row domain.ProjectRecord) 
 			}
 		}
 	}
+	// Agent reports the project's *effective* orchestrator harness: its own
+	// override when set, falling back to the daemon-wide default otherwise.
+	// Bug fix: this used to report the daemon default unconditionally,
+	// ignoring row.Config.Orchestrator.Harness, so a saved per-project
+	// override never showed up here (List()'s Summary.OrchestratorAgent got
+	// this right all along; only this single-project view did not).
+	agent := row.Config.Orchestrator.Harness
+	if agent == "" {
+		agent = m.defaultHarness
+	}
 	p := Project{
 		ID:            domain.ProjectID(row.ID),
 		Name:          displayName(row),
@@ -727,7 +737,7 @@ func (m *Service) projectFromRow(ctx context.Context, row domain.ProjectRecord) 
 		Path:          row.Path,
 		Repo:          row.RepoOriginURL,
 		DefaultBranch: defaultBranch,
-		Agent:         string(m.defaultHarness),
+		Agent:         string(agent),
 	}
 	p.Config = projectConfigPtr(row.Config)
 	return p

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -574,6 +574,69 @@ func TestManager_GetUsesConfiguredDefaultHarness(t *testing.T) {
 	}
 }
 
+// TestManager_GetIgnoresProjectOrchestratorAgentOverride reproduces a bug: a
+// project's saved orchestrator-agent override (Config.Orchestrator.Harness)
+// is correctly persisted and correctly reflected by List(), but Get() (and
+// therefore UpdateSettings()'s own response) ignores it and always reports
+// the daemon-wide default harness instead. A user who overrides the
+// orchestrator agent in Project Settings sees the change silently "not take"
+// because the very API response that confirms the save shows the old value.
+func TestManager_GetIgnoresProjectOrchestratorAgentOverride(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlitetest.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	// Daemon-wide default is codex; the project overrides its orchestrator
+	// agent to claude-code. Any response reporting "codex" here is reporting
+	// the daemon default, not this project's own setting.
+	m := project.NewWithDeps(project.Deps{Store: store, DefaultHarness: domain.HarnessCodex})
+	repo := gitRepo(t)
+
+	if _, err := m.Add(ctx, project.AddInput{Path: repo, ProjectID: ptr("ao")}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	updated, err := m.UpdateSettings(ctx, "ao", project.UpdateSettingsInput{
+		DisplayName: "AO Project",
+		Config: domain.ProjectConfig{
+			Orchestrator: domain.RoleOverride{Harness: domain.HarnessClaudeCode},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
+	}
+
+	// The saved config correctly holds the override.
+	if updated.Config == nil || updated.Config.Orchestrator.Harness != domain.HarnessClaudeCode {
+		t.Fatalf("saved config orchestrator harness = %#v, want claude-code", updated.Config)
+	}
+
+	// List() (GET /api/v1/projects) gets this right today.
+	summaries, err := m.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(summaries) != 1 || summaries[0].OrchestratorAgent != domain.HarnessClaudeCode {
+		t.Fatalf("List orchestrator agent = %#v, want claude-code", summaries)
+	}
+
+	// BUG: UpdateSettings' own response and a subsequent Get() (GET
+	// /api/v1/projects/{id}) both report the daemon default instead of the
+	// project's saved override.
+	if updated.Agent != string(domain.HarnessClaudeCode) {
+		t.Fatalf("BUG: UpdateSettings response Agent = %q, want %q (the saved override)", updated.Agent, domain.HarnessClaudeCode)
+	}
+	got, err := m.Get(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Project == nil || got.Project.Agent != string(domain.HarnessClaudeCode) {
+		t.Fatalf("BUG: Get().Agent = %q, want %q (the saved override)", got.Project.Agent, domain.HarnessClaudeCode)
+	}
+}
+
 func TestManager_AddDoesNotTreatCurrentBranchAsAutomaticDefault(t *testing.T) {
 	ctx := context.Background()
 	m := newManager(t)


### PR DESCRIPTION
## What

`GET /api/v1/projects/{id}` (and thus `UpdateSettings`'s own response) always reported the daemon-wide default harness for a project's `agent` field, ignoring the project's own saved `config.orchestrator.agent` override. `List()` (`GET /api/v1/projects`) already read it correctly — only the single-project view did not.

## Why

Fixes #4316. Saving a different orchestrator agent in Project Settings appeared to silently not take: the save response and any subsequent fetch echoed back the old (daemon default) value instead of what was just persisted.

## How

`projectFromRow` in `backend/internal/service/project/service.go` set `Agent: string(m.defaultHarness)` unconditionally. Changed it to prefer `row.Config.Orchestrator.Harness`, falling back to `m.defaultHarness` only when the project has no override — mirroring what `List()` already does, and preserving the existing "falls back to daemon default when unset" contract that `TestManager_GetUsesConfiguredDefaultHarness` already covers.

## Testing

- New regression test `TestManager_GetIgnoresProjectOrchestratorAgentOverride`: fails on the old code, passes with the fix.
- `go test ./internal/service/project/...` — green except pre-existing, environment-specific failures unrelated to this change (network-dependent clone tests, a Windows path-separator assertion) — confirmed identical on `main` without this change.
- Manually replayed the exact save the bug describes directly against a running daemon (before/after): before, the response echoed the daemon default; after, it correctly echoes the saved override.

## Checklist

- [x] Branched from `main`
- [x] One focused change; closes #4316
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Test added for the user-visible behavior
- [ ] CI (not run locally beyond `go test`/`go build` for the touched package)
