### PR TITLE
fix(session_manager): stop the replaced orchestrator's process on Windows

### DIFF
--- a/backend/internal/adapters/runtime/conpty/host_conpty_windows.go
+++ b/backend/internal/adapters/runtime/conpty/host_conpty_windows.go
@@ -5,8 +5,10 @@ package conpty
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"sync"
-	"unsafe"
+	"syscall"
 
 	gopty "github.com/aymanbagabas/go-pty"
 	"golang.org/x/sys/windows"
@@ -17,18 +19,6 @@ import (
 type conptyConn struct {
 	pty gopty.ConPty
 	cmd *gopty.Cmd
-
-	// job groups the ConPTY child and every process it spawns (e.g. the
-	// "agent-process supervise" wrapper and, under that, the actual agent
-	// binary) so Close can terminate the whole tree atomically. Without this,
-	// killing only cmd.Process (TerminateProcess, no signal, no propagation)
-	// orphans grandchildren, which can keep holding open file handles in the
-	// session's git worktree well past its removal retry budget, failing
-	// orchestrator replacement with "process cannot access the file". See
-	// windows.INVALID_HANDLE_VALUE check in newConPTY: job stays 0 if it
-	// could not be created/assigned, and Close falls back to the old
-	// single-process kill so a job-object failure never blocks teardown.
-	job windows.Handle
 
 	once     sync.Once
 	doneC    chan struct{}
@@ -72,54 +62,25 @@ func newConPTY(cwd, shellCmd string, shellArgs []string) (ptyConn, error) {
 		cmd:   cmd,
 		doneC: make(chan struct{}),
 	}
-	// Best-effort: a job-object failure (permissions, exotic sandboxing) must
-	// not fail the session start. c.job stays its zero value and Close falls
-	// back to killing only cmd.Process, matching the pre-job-object behavior.
-	c.job = newKillOnCloseJob(cmd.Process.Pid)
 
 	go c.wait()
 	return c, nil
 }
 
-// newKillOnCloseJob creates a Windows Job Object with
-// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE and assigns pid to it, so every process
-// pid spawns (and every process those spawn, recursively) dies together when
-// the job is terminated or its last handle closes. Returns 0 if the job
-// could not be created or the process could not be assigned — the caller
-// treats that as "no job", not a fatal error.
-func newKillOnCloseJob(pid int) windows.Handle {
-	job, err := windows.CreateJobObject(nil, nil)
-	if err != nil {
-		return 0
+// killProcessTree taskkills pid's whole process tree. Node/the ConPTY child
+// launches its own children (e.g. the "agent-process supervise" wrapper and,
+// under that, the actual agent binary), and cmd.Process.Kill() alone
+// (TerminateProcess) does not propagate to them. /T walks the tree from pid;
+// /F forces it. Mirrors killProcessTree in
+// adapters/chatdriver/acp/process_windows.go, the same fix for the same
+// class of problem in a sibling package.
+func killProcessTree(pid int) error {
+	kill := exec.Command("taskkill", "/PID", strconv.Itoa(pid), "/T", "/F")
+	kill.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NO_WINDOW,
+		HideWindow:    true,
 	}
-	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
-		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
-			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-		},
-	}
-	if _, err := windows.SetInformationJobObject(
-		job,
-		windows.JobObjectExtendedLimitInformation,
-		uintptr(unsafe.Pointer(&info)),
-		uint32(unsafe.Sizeof(info)),
-	); err != nil {
-		_ = windows.CloseHandle(job)
-		return 0
-	}
-	// PROCESS_TERMINATE + PROCESS_SET_QUOTA are the documented minimum rights
-	// AssignProcessToJobObject requires. This handle is only needed for the
-	// assignment call itself; the job keeps the process bound after it closes.
-	proc, err := windows.OpenProcess(windows.PROCESS_TERMINATE|windows.PROCESS_SET_QUOTA, false, uint32(pid))
-	if err != nil {
-		_ = windows.CloseHandle(job)
-		return 0
-	}
-	defer windows.CloseHandle(proc)
-	if err := windows.AssignProcessToJobObject(job, proc); err != nil {
-		_ = windows.CloseHandle(job)
-		return 0
-	}
-	return job
+	return kill.Run()
 }
 
 func (c *conptyConn) wait() {
@@ -142,20 +103,15 @@ func (c *conptyConn) Close() error {
 	// Best-effort kill: a child that ignores ConPTY EOF still gets terminated
 	// so Done() fires. Mirrors pty.kill() in pty-host.ts.
 	//
-	// Prefer the job object: TerminateJobObject kills cmd.Process AND every
-	// process it spawned (e.g. "agent-process supervise" and, under that, the
-	// actual agent binary) atomically. cmd.Process.Kill() alone only reaches
-	// the direct child — TerminateProcess does not propagate to descendants,
-	// so on Windows the actual agent process is orphaned, keeps running, and
-	// can hold the session's worktree files open well past the caller's
-	// force-remove retry budget (surfaces as "process cannot access the
-	// file" when replacing/retiring the session). Falls back to the old
-	// single-process kill when no job was created (see newKillOnCloseJob).
-	if c.job != 0 {
-		_ = windows.TerminateJobObject(c.job, 1)
-		_ = windows.CloseHandle(c.job)
-	} else if c.cmd.Process != nil {
-		_ = c.cmd.Process.Kill()
+	// killProcessTree, not cmd.Process.Kill(): the ConPTY child spawns its own
+	// children (e.g. "agent-process supervise" and, under that, the actual
+	// agent binary), and TerminateProcess does not propagate to descendants.
+	// Killing only the direct child orphaned the real agent process, which
+	// could then hold the session's worktree files open well past the
+	// caller's force-remove retry budget (surfaces as "process cannot access
+	// the file" when replacing/retiring the session).
+	if c.cmd.Process != nil {
+		_ = killProcessTree(c.cmd.Process.Pid)
 	}
 	return err
 }

--- a/backend/internal/adapters/runtime/conpty/host_conpty_windows.go
+++ b/backend/internal/adapters/runtime/conpty/host_conpty_windows.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"unsafe"
 
 	gopty "github.com/aymanbagabas/go-pty"
+	"golang.org/x/sys/windows"
 )
 
 // conptyConn is the real ptyConn implementation backed by go-pty's ConPty
@@ -15,6 +17,18 @@ import (
 type conptyConn struct {
 	pty gopty.ConPty
 	cmd *gopty.Cmd
+
+	// job groups the ConPTY child and every process it spawns (e.g. the
+	// "agent-process supervise" wrapper and, under that, the actual agent
+	// binary) so Close can terminate the whole tree atomically. Without this,
+	// killing only cmd.Process (TerminateProcess, no signal, no propagation)
+	// orphans grandchildren, which can keep holding open file handles in the
+	// session's git worktree well past its removal retry budget, failing
+	// orchestrator replacement with "process cannot access the file". See
+	// windows.INVALID_HANDLE_VALUE check in newConPTY: job stays 0 if it
+	// could not be created/assigned, and Close falls back to the old
+	// single-process kill so a job-object failure never blocks teardown.
+	job windows.Handle
 
 	once     sync.Once
 	doneC    chan struct{}
@@ -58,9 +72,54 @@ func newConPTY(cwd, shellCmd string, shellArgs []string) (ptyConn, error) {
 		cmd:   cmd,
 		doneC: make(chan struct{}),
 	}
+	// Best-effort: a job-object failure (permissions, exotic sandboxing) must
+	// not fail the session start. c.job stays its zero value and Close falls
+	// back to killing only cmd.Process, matching the pre-job-object behavior.
+	c.job = newKillOnCloseJob(cmd.Process.Pid)
 
 	go c.wait()
 	return c, nil
+}
+
+// newKillOnCloseJob creates a Windows Job Object with
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE and assigns pid to it, so every process
+// pid spawns (and every process those spawn, recursively) dies together when
+// the job is terminated or its last handle closes. Returns 0 if the job
+// could not be created or the process could not be assigned — the caller
+// treats that as "no job", not a fatal error.
+func newKillOnCloseJob(pid int) windows.Handle {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0
+	}
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return 0
+	}
+	// PROCESS_TERMINATE + PROCESS_SET_QUOTA are the documented minimum rights
+	// AssignProcessToJobObject requires. This handle is only needed for the
+	// assignment call itself; the job keeps the process bound after it closes.
+	proc, err := windows.OpenProcess(windows.PROCESS_TERMINATE|windows.PROCESS_SET_QUOTA, false, uint32(pid))
+	if err != nil {
+		_ = windows.CloseHandle(job)
+		return 0
+	}
+	defer windows.CloseHandle(proc)
+	if err := windows.AssignProcessToJobObject(job, proc); err != nil {
+		_ = windows.CloseHandle(job)
+		return 0
+	}
+	return job
 }
 
 func (c *conptyConn) wait() {
@@ -82,7 +141,20 @@ func (c *conptyConn) Close() error {
 	err := c.pty.Close()
 	// Best-effort kill: a child that ignores ConPTY EOF still gets terminated
 	// so Done() fires. Mirrors pty.kill() in pty-host.ts.
-	if c.cmd.Process != nil {
+	//
+	// Prefer the job object: TerminateJobObject kills cmd.Process AND every
+	// process it spawned (e.g. "agent-process supervise" and, under that, the
+	// actual agent binary) atomically. cmd.Process.Kill() alone only reaches
+	// the direct child — TerminateProcess does not propagate to descendants,
+	// so on Windows the actual agent process is orphaned, keeps running, and
+	// can hold the session's worktree files open well past the caller's
+	// force-remove retry budget (surfaces as "process cannot access the
+	// file" when replacing/retiring the session). Falls back to the old
+	// single-process kill when no job was created (see newKillOnCloseJob).
+	if c.job != 0 {
+		_ = windows.TerminateJobObject(c.job, 1)
+		_ = windows.CloseHandle(c.job)
+	} else if c.cmd.Process != nil {
 		_ = c.cmd.Process.Kill()
 	}
 	return err

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1656,7 +1656,13 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 		if err := m.terminateNativeSession(ctx, rec); err != nil {
 			return fmt.Errorf("retire replacement %s: native session: %w", id, err)
 		}
-		if handle.ID != "" {
+		// A chat session has no runtime handle (see the mirrored branch in
+		// Kill): its controller owns an app-server child process directly, not
+		// through m.runtime. Without this, the process is simply never asked
+		// to stop.
+		if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
+			m.stopChatBestEffort(ctx, id)
+		} else if handle.ID != "" {
 			if err := m.runtime.Destroy(ctx, handle); err != nil {
 				return fmt.Errorf("retire replacement %s: runtime: %w", id, err)
 			}
@@ -1701,8 +1707,16 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 		staleWorkspace = true
 		m.logger.Warn("retire replacement: stale workspace; skipping preserve", "sessionID", id, "path", ws.Path, "error", err)
 	}
+	// A chat session's process is owned by its chat controller, not the
+	// runtime port — it never has a runtime handle (see the mirrored branch
+	// in Kill). Skipping this for chat sessions left the real agent process
+	// running with its cwd inside ws.Path, so the ForceDestroy below could
+	// fail on Windows ("process cannot access the file") against a directory
+	// an orphaned agent process still had open.
 	handle := runtimeHandle(rec.Metadata)
-	if handle.ID != "" {
+	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
+		m.stopChatBestEffort(ctx, id)
+	} else if handle.ID != "" {
 		if err := m.runtime.Destroy(ctx, handle); err != nil {
 			return fmt.Errorf("retire replacement %s: runtime: %w", id, err)
 		}
@@ -1779,8 +1793,14 @@ func (m *Manager) retireWorkspaceProjectForReplacement(ctx context.Context, rec 
 			m.logger.Warn("retire replacement: stale workspace repo; skipping preserve", "sessionID", rec.ID, "repo", row.RepoName, "path", row.Path, "error", err)
 		}
 	}
+	// See the identical branch in RetireForReplacement: a chat session has no
+	// runtime handle, so without this its agent process is never stopped and
+	// can hold the workspace repos' files open through the force destroys
+	// below.
 	handle := runtimeHandle(rec.Metadata)
-	if handle.ID != "" {
+	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
+		m.stopChatBestEffort(ctx, rec.ID)
+	} else if handle.ID != "" {
 		if err := m.runtime.Destroy(ctx, handle); err != nil {
 			return fmt.Errorf("retire replacement %s: runtime: %w", rec.ID, err)
 		}

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -5977,6 +5977,77 @@ func TestRetireForReplacementCapturesAndReleasesWorkspace(t *testing.T) {
 	}
 }
 
+// fakeRetireChatLauncher is a minimal ChatLauncher that only records StopChat
+// calls; every other method is unused by RetireForReplacement and returns a
+// zero value.
+type fakeRetireChatLauncher struct {
+	stopped []domain.SessionID
+	stopErr error
+}
+
+func (f *fakeRetireChatLauncher) SupportsChat(domain.AgentHarness) bool { return true }
+func (f *fakeRetireChatLauncher) PreflightChat(context.Context, domain.AgentHarness) error {
+	return nil
+}
+func (f *fakeRetireChatLauncher) StartChat(context.Context, ChatStart) (ChatStarted, error) {
+	return ChatStarted{}, nil
+}
+func (f *fakeRetireChatLauncher) StartChatTurn(context.Context, domain.SessionID, string) (string, error) {
+	return "", nil
+}
+func (f *fakeRetireChatLauncher) RelayChatTurn(context.Context, domain.SessionID, string) (string, error) {
+	return "", nil
+}
+func (f *fakeRetireChatLauncher) RelayChatTurnWithID(context.Context, domain.SessionID, string, string) (string, error) {
+	return "", nil
+}
+func (f *fakeRetireChatLauncher) HasLiveChatController(domain.SessionID) bool { return false }
+func (f *fakeRetireChatLauncher) StopChat(_ context.Context, id domain.SessionID) error {
+	f.stopped = append(f.stopped, id)
+	return f.stopErr
+}
+
+// TestRetireForReplacementStopsChatSessionInsteadOfRuntimeDestroy reproduces
+// the bug fixed alongside this test: a chat-mode orchestrator has no runtime
+// handle (its controller owns an app-server child process directly, not
+// through the runtime port — see the identical branch in Kill). Before the
+// fix, RetireForReplacement only ever called runtime.Destroy, so for a chat
+// session it silently skipped stopping the process entirely: the real agent
+// process kept running with its cwd inside the worktree ForceDestroy was
+// about to remove, which on Windows fails with "process cannot access the
+// file" against a directory an orphaned process still has open.
+func TestRetireForReplacementStopsChatSessionInsteadOfRuntimeDestroy(t *testing.T) {
+	m, st, rt, ws := newLifecycleManager()
+	chat := &fakeRetireChatLauncher{}
+	m.chat = chat
+	ws.stashRef = "refs/ao/preserved/mer-chat"
+	st.sessions["mer-chat"] = domain.SessionRecord{
+		ID:        "mer-chat",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		Mode:      domain.SessionModeChat,
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-chat", Branch: "ao/mer-chat-orchestrator"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+
+	if err := m.RetireForReplacement(ctx, "mer-chat"); err != nil {
+		t.Fatalf("RetireForReplacement err = %v", err)
+	}
+
+	if len(chat.stopped) != 1 || chat.stopped[0] != "mer-chat" {
+		t.Fatalf("chat.StopChat calls = %v, want exactly one call for mer-chat", chat.stopped)
+	}
+	if rt.destroyed != 0 {
+		t.Fatalf("runtime.Destroy calls = %d, want 0 for a chat session (it has no runtime handle)", rt.destroyed)
+	}
+	if !st.sessions["mer-chat"].IsTerminated {
+		t.Fatal("retired chat orchestrator must be marked terminated")
+	}
+	if len(ws.calls) == 0 {
+		t.Fatal("ForceDestroy must still run for the chat session's worktree")
+	}
+}
+
 func TestRetireForReplacement_NativeTerminationFailurePreservesRuntimeAndWorkspace(t *testing.T) {
 	m, st, rt, ws := newLifecycleManager()
 	agent := &nativeTerminatingAgent{wantID: "native-7", err: errors.New("prime stop failed")}


### PR DESCRIPTION
## What

Orchestrator replacement (`RetireForReplacement` and its workspace-project sibling, `backend/internal/session_manager/manager.go`) could leave the previous orchestrator's agent process running on Windows, which then holds files open in the worktree the replacement is about to force-remove.

## Why

Fixes #4317. Replacing a project's orchestrator (e.g. via changing its configured agent while a session is active) could fail with:
```
retire replacement <session>: force destroy: gitworktree: force remove path "...":
The process cannot access the file because it is being used by another process.
```
When this happens mid-flight the old orchestrator can end up retired with no new one successfully created.

## How

Two independent, unrelated root causes, both fixed here since they produce the same symptom:

1. **TUI/conpty sessions** (`backend/internal/adapters/runtime/conpty/host_conpty_windows.go`): `Close()` killed only the ConPTY's direct child via `cmd.Process.Kill()` (`TerminateProcess`), which does not propagate to that process's own children (the actual `claude.exe`/`codex.exe`, spawned by the `agent-process supervise` wrapper). Fixed by killing the whole tree with `taskkill /PID <pid> /T /F` — mirroring the identical, already-established pattern in the sibling `adapters/chatdriver/acp/process_windows.go` (deliberately not a Windows Job Object: that also worked but had no precedent anywhere in this codebase).
2. **Chat-mode sessions**: a chat session has no runtime handle at all — its controller owns an app-server child process directly (`ChatLauncher`/`chatSvc`), not through the runtime port. `RetireForReplacement` never branched on this, unlike `Kill`, which already has the correct `if mode == chat { stopChatBestEffort } else if handle.ID != "" { runtime.Destroy }` pattern (with a comment explicitly calling out the Windows directory-lock risk). Mirrored that branch into `RetireForReplacement` and `retireWorkspaceProjectForReplacement` (3 call sites total).

## Testing

- New regression test `TestRetireForReplacementStopsChatSessionInsteadOfRuntimeDestroy`: fails on the old code (chat.StopChat never called), passes with the fix.
- `go test ./internal/session_manager/... ./internal/adapters/runtime/conpty/...` — green except pre-existing, environment-specific failures unrelated to this change (confirmed identical on `main` without it).
- Verified live end-to-end against a packaged Windows build, for both fixes independently and together:
  - Reproduced the original failure on a **chat**-mode orchestrator (the exact repro from #4317), confirmed the fix resolves it and the old agent process is actually gone (`Get-Process` on its PID) after replacement succeeds.
  - Reproduced the same failure on a **TUI**-mode orchestrator, confirmed the fix resolves it and the old process tree (wrapper + agent binary) is actually gone after replacement succeeds.
  - Re-verified after refactoring the conpty fix from a Job Object to `taskkill /T /F` that both repros still pass.

## Checklist

- [x] Branched from `main`
- [x] One focused change (two root causes, one symptom, one issue); closes #4317
- [x] Follows AGENTS.md conventions and PR hygiene; conpty fix intentionally mirrors the existing `acp/process_windows.go` pattern rather than introducing a new one
- [x] Tests added for the user-visible behavior
- [ ] CI (not run locally beyond `go test`/`go build`/`go vet` for the touched packages)

## Note for reviewers

This touches session-teardown/process-lifecycle code with real risk if wrong. Flagging for extra scrutiny before merge rather than treating it as routine — happy to split further or add more test coverage if requested.
