### PR TITLE
feat: polish chat UI interactions and typography

### DIFF
--- a/docs/chat-ui-improvements-checklist.md
+++ b/docs/chat-ui-improvements-checklist.md
@@ -15,5 +15,6 @@
 - [x] Set user messages and AI responses to 14px.
 - [x] Keep chat composer text explicitly at 16px.
 - [x] Set all bottom composer controls to 14px.
+- [x] Keep chat composer dropdown triggers and menu labels at 12px.
 - [x] Make the composer fade an overlay so it does not add layout padding.
 - [x] Run focused tests and review the final diff. Frontend typecheck was attempted but is blocked by missing workspace dependencies (`react`/`motion` in `packages/product-ui`).

--- a/docs/chat-ui-improvements-checklist.md
+++ b/docs/chat-ui-improvements-checklist.md
@@ -14,5 +14,6 @@
 - [x] Replace composer top padding with a 10px background-to-transparent fade.
 - [x] Set user messages and AI responses to 14px.
 - [x] Keep chat composer text explicitly at 16px.
+- [x] Set all bottom composer controls to 14px.
 - [x] Make the composer fade an overlay so it does not add layout padding.
 - [x] Run focused tests and review the final diff. Frontend typecheck was attempted but is blocked by missing workspace dependencies (`react`/`motion` in `packages/product-ui`).

--- a/docs/chat-ui-improvements-checklist.md
+++ b/docs/chat-ui-improvements-checklist.md
@@ -9,5 +9,10 @@
 - [x] Increase chat UI typography beyond the composer.
 - [x] Show user and assistant message sent times on hover in 24-hour format.
 - [x] Show the 24-hour sent time on hover beside the copy button without shifting permanent controls.
-- [ ] Use `HH:MM` today, `Yesterday` yesterday, and a date for older messages.
+- [x] Use `HH:MM` today, `Yesterday` yesterday, and a date for older messages.
+- [x] Increase the right-side history trigger width.
+- [x] Replace composer top padding with a 10px background-to-transparent fade.
+- [x] Set user messages and AI responses to 14px.
+- [x] Keep chat composer text explicitly at 16px.
+- [x] Make the composer fade an overlay so it does not add layout padding.
 - [x] Run focused tests and review the final diff. Frontend typecheck was attempted but is blocked by missing workspace dependencies (`react`/`motion` in `packages/product-ui`).

--- a/docs/chat-ui-improvements-checklist.md
+++ b/docs/chat-ui-improvements-checklist.md
@@ -1,0 +1,13 @@
+# Chat UI improvements checklist
+
+- [x] Make response and message action buttons square, with equal heights for text controls.
+- [x] Add tactile micro-interactions to chat buttons, composer controls, and related interactive controls.
+- [x] Make the right-side conversation preview carousel expand from its right origin toward the chat.
+- [x] Reduce vertical padding on user messages.
+- [x] Animate newly sent user messages from `scale(0.9)` to `scale(1)`.
+- [x] Remove borders from tiered/queued user messages.
+- [x] Increase chat UI typography beyond the composer.
+- [x] Show user and assistant message sent times on hover in 24-hour format.
+- [x] Show the 24-hour sent time on hover beside the copy button without shifting permanent controls.
+- [ ] Use `HH:MM` today, `Yesterday` yesterday, and a date for older messages.
+- [x] Run focused tests and review the final diff. Frontend typecheck was attempted but is blocked by missing workspace dependencies (`react`/`motion` in `packages/product-ui`).

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -789,7 +789,7 @@ export function DeliveryChoice({
 		>
 			<span
 				className={cn(
-					"inline-flex h-7 items-center gap-1.5 rounded-lg px-3 text-xs leading-none transition-colors",
+					"inline-flex h-7 items-center gap-1.5 rounded-lg px-3 text-sm leading-none transition-colors",
 					disabled && "opacity-50",
 					value === "queue" ? "bg-white/5 text-foreground" : "text-muted-foreground",
 				)}
@@ -801,7 +801,7 @@ export function DeliveryChoice({
 			</span>
 			<span
 				className={cn(
-					"inline-flex h-7 items-center gap-1.5 rounded-lg px-3 text-xs leading-none transition-colors",
+					"inline-flex h-7 items-center gap-1.5 rounded-lg px-3 text-sm leading-none transition-colors",
 					disabled && "opacity-50",
 					value === "steer" ? "bg-white/5 text-foreground" : "text-muted-foreground",
 				)}

--- a/frontend/src/renderer/components/chat/ChatMarkdown.tsx
+++ b/frontend/src/renderer/components/chat/ChatMarkdown.tsx
@@ -149,7 +149,7 @@ function CodeBlock({ code, language }: { code: string; language?: string }) {
 						aria-label="Wrap long lines"
 						title="Wrap long lines"
 						className={cn(
-							"flex items-center rounded px-1.5 py-0.5 transition-colors hover:bg-interactive-hover hover:text-foreground",
+							"flex size-7 items-center justify-center rounded-md transition-[background-color,color,transform] hover:bg-interactive-hover hover:text-foreground",
 							wrap ? "text-accent" : "text-muted-foreground",
 						)}
 					>

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -88,8 +88,14 @@ import {
 } from "../../types/conversation";
 
 const timeFormatter = new Intl.DateTimeFormat(undefined, {
-	hour: "numeric",
+	hour: "2-digit",
 	minute: "2-digit",
+	hourCycle: "h23",
+});
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
 });
 
 const ORIGIN_REPORT_COLLAPSE_AT = 600;
@@ -151,6 +157,18 @@ function formatDuration(ms: number): string {
 function formatTime(iso: string): string {
 	const parsed = new Date(iso);
 	return Number.isNaN(parsed.getTime()) ? "" : timeFormatter.format(parsed);
+}
+
+function formatMessageTimestamp(iso: string, now = new Date()): string {
+	const parsed = new Date(iso);
+	if (Number.isNaN(parsed.getTime())) return "";
+
+	const messageDay = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()).getTime();
+	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+	const daysAgo = Math.round((today - messageDay) / 86_400_000);
+	if (daysAgo === 0) return timeFormatter.format(parsed);
+	if (daysAgo === 1) return "Yesterday";
+	return dateFormatter.format(parsed);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -219,10 +237,11 @@ export function HumanMessage({
 				/>
 			) : (
 				<div
+					title={formatMessageTimestamp(message.createdAt) || undefined}
 					className={cn(
-						"cursor-chat-human-message w-fit max-w-[min(78%,560px)] rounded-[10px] px-3 py-2.5 text-sm leading-[1.55]",
+						"cursor-chat-human-message chat-human-message-enter w-fit max-w-[min(78%,560px)] rounded-[10px] px-3 py-2 text-sm leading-[1.55]",
 						queued
-							? "border border-dashed border-border-strong bg-transparent text-muted-foreground"
+							? "bg-transparent text-muted-foreground"
 							: "bg-raised text-foreground",
 					)}
 				>
@@ -247,7 +266,7 @@ export function HumanMessage({
 				</div>
 			)}
 			{editing ? null : (
-				<div className="mt-2 flex h-[18px] items-center gap-1">
+				<div className="mt-1 flex h-7 items-center gap-1">
 					<div className="flex items-center gap-1 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover/message:opacity-100">
 						{onEdit && onEditStart && message.turnId ? (
 							<button
@@ -255,11 +274,17 @@ export function HumanMessage({
 								onClick={onEditStart}
 								aria-label="Edit user message"
 								title="Edit user message"
-								className="flex items-center rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground"
+								className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[background-color,color,transform] hover:bg-interactive-hover hover:text-foreground"
 							>
 								<Pencil aria-hidden="true" className="size-3" />
 							</button>
 						) : null}
+						<span
+							className="w-12 shrink-0 px-1 text-right text-[11px] tabular-nums text-muted-foreground/75 opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100"
+							aria-label={`Sent ${formatMessageTimestamp(message.createdAt)}`}
+						>
+							{formatMessageTimestamp(message.createdAt)}
+						</span>
 						<CopyButton text={message.text} label="Copy user message" compact />
 					</div>
 					{branchPoint && onActivateBranch ? (
@@ -356,7 +381,10 @@ export function AssistantMessage({
 	const hasDuration = durationMs !== undefined && durationMs > 0;
 	const showActions = !visiblyStreaming && (showCopy || Boolean(onRollback) || hasDuration);
 	return (
-		<div className={cn("group/message relative", visiblyStreaming && hasText && "chat-assistant-streaming")}>
+		<div
+			title={formatMessageTimestamp(message.createdAt) || undefined}
+			className={cn("group/message relative", visiblyStreaming && hasText && "chat-assistant-streaming")}
+		>
 			<ChatMarkdown text={message.text} streaming={message.streaming} />
 			{visiblyStreaming ? (
 				hasText ? (
@@ -375,16 +403,18 @@ export function AssistantMessage({
 				// One action row for the completed answer, not one after every prose
 				// fragment the provider emitted while working. Always visible: hover-only
 				// chrome is easy to miss next to a short reply.
-				<div className="mt-2 flex h-[18px] items-center gap-0.5">
+				<div className="mt-1 flex h-7 items-center gap-0.5">
 					{showCopy ? (
-						/* The stored markdown, not a re-serialization of what was rendered:
-						   pasting it into an editor has to give back what the agent wrote. */
-						<CopyButton
-							text={message.text}
-							label="Copy message as markdown"
-							compact
-							className="-ml-1.5"
-						/>
+						<>
+							{/* The stored markdown, not a re-serialization of what was rendered:
+							   pasting it into an editor has to give back what the agent wrote. */}
+							<CopyButton
+								text={message.text}
+								label="Copy message as markdown"
+								compact
+								className="-ml-1.5"
+							/>
+						</>
 					) : null}
 					{onRollback ? (
 						<button
@@ -392,12 +422,18 @@ export function AssistantMessage({
 							onClick={onRollback}
 							aria-label="Roll back to here"
 							title="Roll back to here"
-							className="flex items-center rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground"
+							className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[background-color,color,transform] hover:bg-interactive-hover hover:text-foreground"
 						>
 							<Undo2 aria-hidden="true" className="size-3" />
 						</button>
 					) : null}
 					{hasDuration ? <TurnDuration durationMs={durationMs} /> : null}
+					<span
+						className="w-12 shrink-0 px-1 text-[11px] tabular-nums text-muted-foreground/75 opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100"
+						aria-label={`Sent ${formatMessageTimestamp(message.createdAt)}`}
+					>
+						{formatMessageTimestamp(message.createdAt)}
+					</span>
 				</div>
 			) : null}
 		</div>

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -181,6 +181,7 @@ export function HumanMessage({
 	sessionId,
 	apiBaseUrl = getApiBaseUrl(),
 	queued,
+	animateIn = false,
 	onEdit,
 	editing = false,
 	editText,
@@ -202,6 +203,8 @@ export function HumanMessage({
 	apiBaseUrl?: string;
 	/** Typed while the agent was busy, and not sent yet. */
 	queued?: boolean;
+	/** True only for a human message added after the timeline first mounted. */
+	animateIn?: boolean;
 	onEdit?: (turnId: string, text: string) => Promise<unknown> | void;
 	editing?: boolean;
 	editText?: string;
@@ -239,7 +242,8 @@ export function HumanMessage({
 				<div
 					title={formatMessageTimestamp(message.createdAt) || undefined}
 					className={cn(
-						"cursor-chat-human-message chat-human-message-enter w-fit max-w-[min(78%,560px)] rounded-[10px] px-3 py-2 text-sm leading-[1.55]",
+						"cursor-chat-human-message w-fit max-w-[min(78%,560px)] rounded-[10px] px-3 py-2 text-sm leading-[1.55]",
+						animateIn && "chat-human-message-enter",
 						queued
 							? "bg-transparent text-muted-foreground"
 							: "bg-raised text-foreground",

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatWorkspace, promptSpacerHeight, promptTopInset } from "./ChatWorkspace";
-import { HumanMessage, OriginMessage } from "./ChatTimelineItems";
+import { AssistantMessage, HumanMessage, OriginMessage } from "./ChatTimelineItems";
 import {
 	chatFixture,
 	chatFixtureEmpty,
@@ -223,6 +223,60 @@ describe("HumanMessage attachments", () => {
 	});
 });
 
+describe("Chat message timestamps", () => {
+	it("exposes user and assistant sent times as 24-hour hover labels", () => {
+		const today = new Date().toISOString();
+		const user = { ...humanMessage("user message"), createdAt: today };
+		const assistant = {
+			...user,
+			id: "assistant-message",
+			role: "assistant",
+			origin: "assistant",
+			text: "assistant message",
+		} satisfies ConversationMessage;
+		const { container } = render(
+			<>
+				<HumanMessage message={user} sessionId="ao-1" />
+				<AssistantMessage message={assistant} />
+			</>,
+		);
+
+		const messageTimes = Array.from(container.querySelectorAll("div[title]")).map((element) =>
+			element.getAttribute("title"),
+		);
+		expect(messageTimes).toHaveLength(2);
+		for (const time of messageTimes) {
+			expect(time).toHaveLength(5);
+			expect(time?.[2]).toBe(":");
+		}
+	});
+
+	it("labels yesterday and older messages with calendar dates", () => {
+		const now = new Date();
+		const relativeDate = (daysAgo: number) => {
+			const date = new Date(now);
+			date.setDate(date.getDate() - daysAgo);
+			return date.toISOString();
+		};
+		const messages = [
+			{ ...humanMessage("yesterday"), id: "yesterday", createdAt: relativeDate(1) },
+			{ ...humanMessage("older"), id: "older", createdAt: relativeDate(3) },
+		];
+		const { container } = render(
+			<>
+				{messages.map((message) => (
+					<HumanMessage key={message.id} message={message} sessionId="ao-1" />
+				))}
+			</>,
+		);
+
+		const titles = Array.from(container.querySelectorAll("div[title]"), (element) => element.getAttribute("title"));
+		expect(titles[0]).toBe("Yesterday");
+		expect(titles[1]).not.toBe("Yesterday");
+		expect(titles[1]?.includes(":")).toBe(false);
+	});
+});
+
 describe("ChatWorkspace timeline", () => {
 	it("makes composer and history controls inert while a durable agent switch owns input", () => {
 		render(<ChatWorkspace snapshot={idleSnapshot()} agentInputDisabled />);
@@ -272,11 +326,11 @@ describe("ChatWorkspace timeline", () => {
 		expect(screen.queryByRole("button", { name: "Fullscreen" })).not.toBeInTheDocument();
 	});
 
-	it("starts chat text at 12px without a topbar font control", () => {
+	it("starts chat text at 13px without a topbar font control", () => {
 		render(<ChatWorkspace snapshot={chatFixture} />);
 		const chat = screen.getByLabelText("Chat");
 
-		expect(chat.style.getPropertyValue("--chat-font-size")).toBe("12px");
+		expect(chat.style.getPropertyValue("--chat-font-size")).toBe("13px");
 	});
 
 	it("keeps the composer aligned to the readable conversation width", () => {

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -326,11 +326,11 @@ describe("ChatWorkspace timeline", () => {
 		expect(screen.queryByRole("button", { name: "Fullscreen" })).not.toBeInTheDocument();
 	});
 
-	it("starts chat text at 13px without a topbar font control", () => {
+	it("starts chat text at 14px without a topbar font control", () => {
 		render(<ChatWorkspace snapshot={chatFixture} />);
 		const chat = screen.getByLabelText("Chat");
 
-		expect(chat.style.getPropertyValue("--chat-font-size")).toBe("13px");
+		expect(chat.style.getPropertyValue("--chat-font-size")).toBe("14px");
 	});
 
 	it("keeps the composer aligned to the readable conversation width", () => {

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -231,7 +231,7 @@ describe("Chat message timestamps", () => {
 			...user,
 			id: "assistant-message",
 			role: "assistant",
-			origin: "assistant",
+			origin: "provider",
 			text: "assistant message",
 		} satisfies ConversationMessage;
 		const { container } = render(

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1351,12 +1351,30 @@ function Timeline({
 
 	const readable = useMemo(() => readableItems(snapshot), [snapshot]);
 	const items = useStableList(readable, itemKey, sameContent);
+	const seenHumanMessageIds = useRef<Set<string> | undefined>(undefined);
+	const [newHumanMessageIds, setNewHumanMessageIds] = useState<ReadonlySet<string>>(new Set());
 	const editedMessageVisible = Boolean(
 		messageEdit &&
 			items.some(
 				(item) => item.kind === "message" && item.role === "user" && item.turnId === messageEdit.turnId,
 			),
 	);
+	useEffect(() => {
+		const humanMessageIds = new Set(
+			items
+				.filter((item): item is ConversationMessage => item.kind === "message" && item.role === "user" && item.origin === "human")
+				.map((item) => item.id),
+		);
+		if (!seenHumanMessageIds.current) {
+			seenHumanMessageIds.current = humanMessageIds;
+			return;
+		}
+		const added = new Set(
+			[...humanMessageIds].filter((id) => !seenHumanMessageIds.current?.has(id)),
+		);
+		seenHumanMessageIds.current = humanMessageIds;
+		if (added.size > 0) setNewHumanMessageIds(added);
+	}, [items]);
 	const grouped = useMemo(() => groupByTurn({ ...snapshot, items }), [snapshot, items]);
 	const groups = useStableList(grouped, groupKey, sameGroup);
 	const navigableGroups = useMemo(() => groups.filter(groupHasHumanPrompt), [groups]);
@@ -1622,6 +1640,7 @@ function Timeline({
 								editError={editError}
 								branchPoints={branchPoints}
 								editableTurns={editableTurns}
+								newHumanMessageIds={newHumanMessageIds}
 								onActivateBranch={canActivateBranch ? activateBranch : undefined}
 								activateBranchPending={activateBranchPending}
 								activateBranchError={activateBranchError}
@@ -1794,6 +1813,7 @@ const TurnGroup = memo(function TurnGroup({
 	canRollback,
 	busy,
 	queued,
+	newHumanMessageIds,
 }: {
 	group: TimelineGroup;
 	sessionId: string;
@@ -1822,6 +1842,7 @@ const TurnGroup = memo(function TurnGroup({
 	busy?: boolean;
 	/** This turn was recorded but not sent, so its message can say so. */
 	queued: boolean;
+	newHumanMessageIds: ReadonlySet<string>;
 }) {
 	const runs = useMemo(() => runsOf(group.items), [group.items]);
 	const copyableMessageId = group.outcome
@@ -1862,8 +1883,9 @@ const TurnGroup = memo(function TurnGroup({
 						onActivateBranch={onActivateBranch}
 						activateBranchPending={activateBranchPending}
 						activateBranchError={activateBranchError}
-						busy={busy}
-						queued={queued}
+										busy={busy}
+										queued={queued}
+										newHumanMessageIds={newHumanMessageIds}
 						showCopy={run.items[0]?.id === copyableMessageId}
 						onRollback={
 							canRollback && run.items[0]?.id === copyableMessageId
@@ -1998,6 +2020,7 @@ function TimelineItem({
 	activateBranchError,
 	busy,
 	queued,
+	newHumanMessageIds,
 	showCopy,
 	onRollback,
 	durationMs,
@@ -2028,6 +2051,7 @@ function TimelineItem({
 	 * so. A group is one turn, so this holds for every item in it.
 	 */
 	queued?: boolean;
+	newHumanMessageIds: ReadonlySet<string>;
 	/** This is the final assistant response of a turn that has finished. */
 	showCopy?: boolean;
 	/** Undo this finished turn from the answer that owns its copy action. */
@@ -2063,6 +2087,7 @@ function TimelineItem({
 					sessionId={sessionId}
 					apiBaseUrl={apiBaseUrl}
 					queued={queued}
+					animateIn={newHumanMessageIds.has(item.id)}
 					onEdit={editAvailable ? (_turnID, text) => onSubmitMessageEdit(text) : undefined}
 					editing={editing}
 					editText={editing ? messageEdit?.text : undefined}

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -104,7 +104,7 @@ import {
 	type TurnSettings,
 } from "../../types/conversation";
 
-const CHAT_FONT_SIZE_DEFAULT = 12;
+const CHAT_FONT_SIZE_DEFAULT = 13;
 
 // Reviewer panes share the terminal font-size preference with CenterPane, so a
 // reviewer opened inside the Chat surface matches a reviewer opened in TUI mode.

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1352,6 +1352,7 @@ function Timeline({
 	const readable = useMemo(() => readableItems(snapshot), [snapshot]);
 	const items = useStableList(readable, itemKey, sameContent);
 	const seenHumanMessageIds = useRef<Set<string> | undefined>(undefined);
+	const lastSeenLatestSequence = useRef<number | undefined>(undefined);
 	const [newHumanMessageIds, setNewHumanMessageIds] = useState<ReadonlySet<string>>(new Set());
 	const editedMessageVisible = Boolean(
 		messageEdit &&
@@ -1360,21 +1361,29 @@ function Timeline({
 			),
 	);
 	useEffect(() => {
-		const humanMessageIds = new Set(
-			items
-				.filter((item): item is ConversationMessage => item.kind === "message" && item.role === "user" && item.origin === "human")
-				.map((item) => item.id),
+		const humanMessages = items.filter(
+			(item): item is ConversationMessage =>
+				item.kind === "message" && item.role === "user" && item.origin === "human",
 		);
+		const humanMessageIds = new Set(humanMessages.map((item) => item.id));
 		if (!seenHumanMessageIds.current) {
 			seenHumanMessageIds.current = humanMessageIds;
+			lastSeenLatestSequence.current = snapshot.latestSequence;
 			return;
 		}
 		const added = new Set(
-			[...humanMessageIds].filter((id) => !seenHumanMessageIds.current?.has(id)),
+			humanMessages
+				.filter(
+					(item) =>
+						!seenHumanMessageIds.current?.has(item.id) &&
+						item.sequence > (lastSeenLatestSequence.current ?? -Infinity),
+				)
+				.map((item) => item.id),
 		);
 		seenHumanMessageIds.current = humanMessageIds;
+		lastSeenLatestSequence.current = snapshot.latestSequence;
 		if (added.size > 0) setNewHumanMessageIds(added);
-	}, [items]);
+	}, [items, snapshot.latestSequence]);
 	const grouped = useMemo(() => groupByTurn({ ...snapshot, items }), [snapshot, items]);
 	const groups = useStableList(grouped, groupKey, sameGroup);
 	const navigableGroups = useMemo(() => groups.filter(groupHasHumanPrompt), [groups]);

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -104,7 +104,7 @@ import {
 	type TurnSettings,
 } from "../../types/conversation";
 
-const CHAT_FONT_SIZE_DEFAULT = 13;
+const CHAT_FONT_SIZE_DEFAULT = 14;
 
 // Reviewer panes share the terminal font-size preference with CenterPane, so a
 // reviewer opened inside the Chat surface matches a reviewer opened in TUI mode.
@@ -767,8 +767,9 @@ export function ChatWorkspace({
 
 					<div
 						ref={composerDockRef}
-						className="cursor-chat-composer-dock shrink-0 px-4 pb-3 pt-2"
+						className="cursor-chat-composer-dock shrink-0 px-4 pb-3"
 					>
+						<div aria-hidden="true" className="chat-composer-fade" />
 						<div
 							data-empty={conversationEmpty || undefined}
 							className="mx-auto flex w-full max-w-3xl flex-col gap-2 transition-[max-width] duration-500 ease-out data-[empty]:max-w-2xl"
@@ -1688,7 +1689,7 @@ function Timeline({
 				onBlur={() => setHoveredMarker(null)}
 				onPointerLeave={() => setHoveredMarker(null)}
 				className={cn(
-					"group/scroll absolute inset-y-3 right-1 z-10 w-4 touch-none rounded-full outline-none transition-opacity focus-visible:ring-1 focus-visible:ring-logo-accent/60",
+					"group/scroll absolute inset-y-3 right-1 z-10 w-6 touch-none rounded-full outline-none transition-opacity focus-visible:ring-1 focus-visible:ring-logo-accent/60",
 					scrollbar.visible ? "cursor-pointer opacity-100" : "pointer-events-none opacity-0",
 				)}
 			>

--- a/frontend/src/renderer/components/chat/ConversationBranchNavigator.tsx
+++ b/frontend/src/renderer/components/chat/ConversationBranchNavigator.tsx
@@ -26,7 +26,7 @@ export function ConversationBranchNavigator({
 				}}
 				aria-label={t("chat.branch.previous")}
 				title={t("chat.branch.previous")}
-				className="rounded p-0.5 transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-logo-accent/40 disabled:opacity-45"
+				className="flex size-7 items-center justify-center rounded-md transition-[background-color,color,transform] hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-logo-accent/40 disabled:opacity-45"
 			>
 				<ChevronLeft aria-hidden="true" className="size-3.5" />
 			</button>
@@ -46,7 +46,7 @@ export function ConversationBranchNavigator({
 				}}
 				aria-label={t("chat.branch.next")}
 				title={t("chat.branch.next")}
-				className="rounded p-0.5 transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-logo-accent/40 disabled:opacity-45"
+				className="flex size-7 items-center justify-center rounded-md transition-[background-color,color,transform] hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-logo-accent/40 disabled:opacity-45"
 			>
 				<ChevronRight aria-hidden="true" className="size-3.5" />
 			</button>

--- a/frontend/src/renderer/components/chat/CopyButton.tsx
+++ b/frontend/src/renderer/components/chat/CopyButton.tsx
@@ -56,7 +56,9 @@ export function CopyButton({
 			// tooltip carries the label there and only there.
 			title={compact ? label : undefined}
 			className={cn(
-				"flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground",
+				compact
+					? "flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[background-color,color,transform] hover:bg-interactive-hover hover:text-foreground"
+					: "flex h-7 items-center gap-1 rounded-md px-2 text-[10.5px] text-muted-foreground transition-[background-color,color,transform] hover:bg-interactive-hover hover:text-foreground",
 				className,
 			)}
 		>

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
@@ -58,7 +58,7 @@ const APPROVAL_ORDER: ApprovalMode[] = [
 ];
 
 const TRIGGER_CLASS =
-	"h-7 gap-1 bg-transparent rounded-lg px-3 text-sm leading-none text-muted-foreground hover:bg-white/5 hover:text-foreground data-[state=open]:bg-white/5 data-[state=open]:text-foreground";
+	"h-7 gap-1 bg-transparent rounded-lg px-3 text-[12px]! leading-none text-muted-foreground hover:bg-white/5 hover:text-foreground data-[state=open]:bg-white/5 data-[state=open]:text-foreground";
 
 export function TurnSettingsBar({
 	models,
@@ -185,7 +185,7 @@ export function TurnSettingsBar({
 									>
 										<span
 											className={cn(
-												"text-xs",
+														"text-xs",
 												mode === (settings.approvalMode ?? "default")
 													? "text-foreground"
 													: "text-muted-foreground",
@@ -313,7 +313,7 @@ function ModelEffortPicker({
 										<span className="flex w-full items-baseline gap-2">
 											<span
 												className={cn(
-													"text-xs",
+																"text-xs",
 													model.id === settings.model
 														? "text-foreground"
 														: "text-muted-foreground",

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
@@ -59,6 +59,7 @@ const APPROVAL_ORDER: ApprovalMode[] = [
 
 const TRIGGER_CLASS =
 	"h-7 gap-1 bg-transparent rounded-lg px-3 text-[12px]! leading-none text-muted-foreground hover:bg-white/5 hover:text-foreground data-[state=open]:bg-white/5 data-[state=open]:text-foreground";
+const CHAT_MENU_CLASS = "chat-settings-menu text-[12px]!";
 
 export function TurnSettingsBar({
 	models,
@@ -170,7 +171,7 @@ export function TurnSettingsBar({
 								disabled={disabled}
 							>
 								<OptionMenuLabel
-									className={cn("flex items-baseline justify-between gap-2")}
+									className={cn("flex items-baseline justify-between gap-2 text-[12px]!")}
 								>
 									<span>Approvals</span>
 									<span className="text-[11px] font-normal text-muted-foreground">
@@ -289,12 +290,12 @@ function ModelEffortPicker({
 						/>
 					) : null}
 				</OptionMenuTrigger>
-			<OptionMenuContent align="start" >
+			<OptionMenuContent align="start" className={CHAT_MENU_CLASS}>
 				<OptionMenuSub onOpenChange={setModelSubOpen}>
 					<OptionMenuSubTrigger label="Model" value={modelLabel} />
 					{/* Scroll on an inner strip: the surface utility caps height but wheel
 					    events do not reliably reach an outer overflow on nested submenus. */}
-					<OptionMenuSubContent scrollable>
+					<OptionMenuSubContent scrollable className={CHAT_MENU_CLASS}>
 						<div className="relative grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)] overflow-hidden">
 							<div
 								ref={modelScrollRef}
@@ -346,7 +347,7 @@ function ModelEffortPicker({
 				{efforts.length > 0 ? (
 					<OptionMenuSub>
 						<OptionMenuSubTrigger label="Effort" value={effortLabel ? capitalize(effortLabel) : "Effort"} />
-						<OptionMenuSubContent>
+						<OptionMenuSubContent className={CHAT_MENU_CLASS}>
 							{efforts.map((effort) => (
 								<OptionMenuItem
 									key={effort}
@@ -418,7 +419,7 @@ function ClubbedConfigPicker({
 				>
 					<span className="min-w-0 max-w-[22ch] truncate">{groupLabel}</span>
 				</OptionMenuTrigger>
-			<OptionMenuContent align="start" >
+			<OptionMenuContent align="start" className={CHAT_MENU_CLASS}>
 				{modelOptions.map((option) => (
 					<OptionSubmenu key={option.id} option={option} onChange={onChange} scrollable />
 				))}
@@ -443,7 +444,7 @@ function MoreOptionsSubmenu({
 	return (
 		<OptionMenuSub>
 			<OptionMenuSubTrigger label="More" />
-			<OptionMenuSubContent >
+			<OptionMenuSubContent className={CHAT_MENU_CLASS}>
 				{options.map((option) => (
 					<OptionSubmenu key={option.id} option={option} onChange={onChange} />
 				))}
@@ -465,7 +466,7 @@ function OptionSubmenu({
 	return (
 		<OptionMenuSub>
 			<OptionMenuSubTrigger label={option.name} value={current} />
-			<OptionMenuSubContent scrollable={scrollable}>
+			<OptionMenuSubContent scrollable={scrollable} className={CHAT_MENU_CLASS}>
 				{scrollable ? (
 					<div className="relative grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)] overflow-hidden">
 						<div className="model-menu-scroll flex min-h-0 flex-col gap-px overflow-y-auto overscroll-contain pb-1">
@@ -606,7 +607,7 @@ function Picker({
 					<span className="min-w-0 max-w-[16ch] truncate">{label}</span>
 					{badge}
 				</OptionMenuTrigger>
-			<OptionMenuContent align="end" >
+			<OptionMenuContent align="end" className={CHAT_MENU_CLASS}>
 				{children}
 			</OptionMenuContent>
 		</OptionMenu>

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
@@ -58,7 +58,7 @@ const APPROVAL_ORDER: ApprovalMode[] = [
 ];
 
 const TRIGGER_CLASS =
-	"h-7 gap-1 bg-transparent rounded-lg px-3 text-xs leading-none text-muted-foreground hover:bg-white/5 hover:text-foreground data-[state=open]:bg-white/5 data-[state=open]:text-foreground";
+	"h-7 gap-1 bg-transparent rounded-lg px-3 text-sm leading-none text-muted-foreground hover:bg-white/5 hover:text-foreground data-[state=open]:bg-white/5 data-[state=open]:text-foreground";
 
 export function TurnSettingsBar({
 	models,

--- a/frontend/src/renderer/components/ui/button.tsx
+++ b/frontend/src/renderer/components/ui/button.tsx
@@ -7,7 +7,7 @@ import { cn } from "../../lib/utils";
 // (primary). Footer variants match settings/modal action chrome tokens.
 // See DESIGN.md → Spacing / Color.
 const buttonVariants = cva(
-	"group/button inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent bg-clip-padding text-sm font-normal transition-[background-color,border-color,color,box-shadow,transform,opacity] duration-[100ms] ease-out outline-none select-none focus-visible:outline-none active:not-aria-[haspopup]:scale-[0.97] active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+	"group/button inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent bg-clip-padding text-sm font-normal transition-[background-color,border-color,color,box-shadow,transform,opacity] duration-[100ms] ease-out outline-none select-none focus-visible:outline-none active:not-aria-[haspopup]:scale-[0.96] active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {

--- a/frontend/src/renderer/components/ui/option-menu.tsx
+++ b/frontend/src/renderer/components/ui/option-menu.tsx
@@ -4,13 +4,13 @@ import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 import { cn } from "../../lib/utils";
 
 const SURFACE =
-	"settings-menu-surface min-w-[14rem] rounded-(--radius-settings-panel) border-settings-menu bg-settings-menu p-1 gap-px text-[12px]!";
+	"settings-menu-surface min-w-[14rem] rounded-(--radius-settings-panel) border-settings-menu bg-settings-menu p-1 gap-px";
 
 const ROW =
-	"min-w-0 cursor-default rounded-[10px] px-3 py-2 text-[12px]! outline-none whitespace-nowrap focus:bg-settings-menu-selected focus:text-settings-title focus:text-foreground data-highlighted:bg-settings-menu-selected data-highlighted:text-settings-title data-highlighted:text-foreground data-[active=true]:bg-settings-menu-selected data-[active=true]:text-foreground";
+	"min-w-0 cursor-default rounded-[10px] px-3 py-2 outline-none whitespace-nowrap focus:bg-settings-menu-selected focus:text-settings-title focus:text-foreground data-highlighted:bg-settings-menu-selected data-highlighted:text-settings-title data-highlighted:text-foreground data-[active=true]:bg-settings-menu-selected data-[active=true]:text-foreground";
 
 const LABEL =
-	"px-3 py-2 text-[12px]! font-normal tracking-normal text-settings-muted";
+	"px-3 py-2 text-[length:var(--font-size-base)] font-normal tracking-normal text-settings-muted";
 
 /**
  * The quiet filled trigger both this menu and the Settings pickers wear —
@@ -132,7 +132,7 @@ export function OptionMenuSubTrigger({
 }) {
 	return (
 		<DropdownMenuPrimitive.SubTrigger
-			className={cn(ROW, "flex items-center justify-between gap-3 text-[12px]! text-foreground data-[state=open]:bg-settings-menu-selected data-[state=open]:text-foreground", className)}
+			className={cn(ROW, "flex items-center justify-between gap-3 text-xs text-foreground data-[state=open]:bg-settings-menu-selected data-[state=open]:text-foreground", className)}
 			// Stop the click reaching the composer's click-to-focus handler without
 			// calling preventDefault, which Radix's composeEventHandlers reads as a
 			// signal to skip its own open/close handling.

--- a/frontend/src/renderer/components/ui/option-menu.tsx
+++ b/frontend/src/renderer/components/ui/option-menu.tsx
@@ -4,13 +4,13 @@ import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 import { cn } from "../../lib/utils";
 
 const SURFACE =
-	"settings-menu-surface min-w-[14rem] rounded-(--radius-settings-panel) border-settings-menu bg-settings-menu p-1 gap-px";
+	"settings-menu-surface min-w-[14rem] rounded-(--radius-settings-panel) border-settings-menu bg-settings-menu p-1 gap-px text-[12px]!";
 
 const ROW =
-	"min-w-0 cursor-default rounded-[10px] px-3 py-2 outline-none whitespace-nowrap focus:bg-settings-menu-selected focus:text-settings-title focus:text-foreground data-highlighted:bg-settings-menu-selected data-highlighted:text-settings-title data-highlighted:text-foreground data-[active=true]:bg-settings-menu-selected data-[active=true]:text-foreground";
+	"min-w-0 cursor-default rounded-[10px] px-3 py-2 text-[12px]! outline-none whitespace-nowrap focus:bg-settings-menu-selected focus:text-settings-title focus:text-foreground data-highlighted:bg-settings-menu-selected data-highlighted:text-settings-title data-highlighted:text-foreground data-[active=true]:bg-settings-menu-selected data-[active=true]:text-foreground";
 
 const LABEL =
-	"px-3 py-2 text-[length:var(--font-size-base)] font-normal tracking-normal text-settings-muted";
+	"px-3 py-2 text-[12px]! font-normal tracking-normal text-settings-muted";
 
 /**
  * The quiet filled trigger both this menu and the Settings pickers wear —
@@ -132,7 +132,7 @@ export function OptionMenuSubTrigger({
 }) {
 	return (
 		<DropdownMenuPrimitive.SubTrigger
-			className={cn(ROW, "flex items-center justify-between gap-3 text-xs text-foreground data-[state=open]:bg-settings-menu-selected data-[state=open]:text-foreground", className)}
+			className={cn(ROW, "flex items-center justify-between gap-3 text-[12px]! text-foreground data-[state=open]:bg-settings-menu-selected data-[state=open]:text-foreground", className)}
 			// Stop the click reaching the composer's click-to-focus handler without
 			// calling preventDefault, which Radix's composeEventHandlers reads as a
 			// signal to skip its own open/close handling.

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1978,6 +1978,30 @@ body.is-resizing-x [data-slot="inspector-container"] {
 	border-color: var(--color-border) !important;
 }
 
+/* Keep every chat control tactile, including the small native buttons embedded
+   in message rows and activity summaries. The shared Button primitive owns its
+   own transition, but this makes the same interaction contract hold at the
+   thinner timeline boundaries too. */
+.cursor-chat-surface button:not(:disabled) {
+	transition-property: background-color, border-color, color, box-shadow, transform, opacity;
+	transition-duration: 100ms;
+	transition-timing-function: ease-out;
+}
+
+.cursor-chat-surface button:not(:disabled):active {
+	transform: scale(0.96);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cursor-chat-surface button:not(:disabled) {
+		transition: none;
+	}
+
+	.cursor-chat-surface button:not(:disabled):active {
+		transform: none;
+	}
+}
+
 .cursor-chat-header {
 	border-bottom: 1px solid var(--color-border);
 	background: transparent;
@@ -2130,6 +2154,23 @@ body.is-resizing-x [data-slot="inspector-container"] {
 .cursor-chat-human-message {
 	background: color-mix(in srgb, var(--color-bg-elevated) 72%, var(--color-bg-secondary));
 	border-color: color-mix(in srgb, var(--color-border-strong) 85%, transparent);
+}
+
+.chat-human-message-enter {
+	animation: chat-human-message-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes chat-human-message-in {
+	from {
+		opacity: 0;
+		transform: scale(0.9);
+		transform-origin: 100% 100%;
+	}
+	to {
+		opacity: 1;
+		transform: scale(1);
+		transform-origin: 100% 100%;
+	}
 }
 
 .cursor-chat-origin-message,
@@ -2314,19 +2355,21 @@ body.is-resizing-x [data-slot="inspector-container"] {
 }
 
 .chat-scroll-preview {
-	transform: translate(-6px, -50%) scale(0.98);
-	transform-origin: right center;
+	transform: translate(-6px, -50%);
+	clip-path: inset(0 0 0 0);
 	animation: chat-scroll-preview-in 140ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
 @keyframes chat-scroll-preview-in {
 	from {
 		opacity: 0;
-		transform: translate(2px, -50%) scale(0.98);
+		transform: translate(-6px, -50%);
+		clip-path: inset(0 0 0 100%);
 	}
 	to {
 		opacity: 1;
-		transform: translate(-6px, -50%) scale(1);
+		transform: translate(-6px, -50%);
+		clip-path: inset(0 0 0 0);
 	}
 }
 
@@ -2339,6 +2382,11 @@ body.is-resizing-x [data-slot="inspector-container"] {
 		animation: none;
 		opacity: 1;
 		transform: translate(-6px, -50%);
+		clip-path: none;
+	}
+
+	.chat-human-message-enter {
+		animation: none;
 	}
 }
 

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2058,10 +2058,30 @@ body.is-resizing-x [data-slot="inspector-container"] {
 	font-size: var(--chat-readable-code-font-size);
 }
 
+.cursor-chat-timeline .cursor-chat-human-message {
+	font-size: 14px;
+}
+
 /* The dock is layout only. The composer paints its own surface, so a filled
    strip behind it read as a second black box around the rounded prompt. */
 .cursor-chat-composer-dock {
+	position: relative;
+	z-index: 1;
 	background: transparent;
+}
+
+.chat-composer-fade {
+	position: absolute;
+	right: 0;
+	bottom: 100%;
+	left: 0;
+	height: 10px;
+	background: linear-gradient(to top, var(--color-bg-primary), transparent);
+	pointer-events: none;
+}
+
+.cursor-chat-composer textarea {
+	font-size: 16px !important;
 }
 
 /* FLIP docking uses transform only so the move stays on the compositor. */
@@ -2294,11 +2314,11 @@ body.is-resizing-x [data-slot="inspector-container"] {
 
 .chat-scroll-marker {
 	position: absolute;
-	left: 50%;
+	right: 0;
 	top: 50%;
 	width: 7px;
 	height: 2px;
-	transform: translate(-50%, -50%);
+	transform: translateY(-50%);
 	border-radius: 999px;
 	background: color-mix(in srgb, var(--color-text-muted) 54%, transparent);
 	opacity: 0.76;
@@ -2356,33 +2376,11 @@ body.is-resizing-x [data-slot="inspector-container"] {
 
 .chat-scroll-preview {
 	transform: translate(-6px, -50%);
-	clip-path: inset(0 0 0 0);
-	animation: chat-scroll-preview-in 140ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-@keyframes chat-scroll-preview-in {
-	from {
-		opacity: 0;
-		transform: translate(-6px, -50%);
-		clip-path: inset(0 0 0 100%);
-	}
-	to {
-		opacity: 1;
-		transform: translate(-6px, -50%);
-		clip-path: inset(0 0 0 0);
-	}
 }
 
 @media (prefers-reduced-motion: reduce) {
 	.chat-scroll-marker {
 		transition: none;
-	}
-
-	.chat-scroll-preview {
-		animation: none;
-		opacity: 1;
-		transform: translate(-6px, -50%);
-		clip-path: none;
 	}
 
 	.chat-human-message-enter {


### PR DESCRIPTION
## Summary
- polish chat message action buttons and micro-interactions
- align history markers and composer fade behavior
- tune chat/message/composer typography and dropdown sizing
- add persistent chat UI checklist and focused regression coverage

<img width="421" height="376" alt="image" src="https://github.com/user-attachments/assets/b04aea49-0a00-41f2-928c-dcda259b8e6c" />

<img width="795" height="811" alt="image" src="https://github.com/user-attachments/assets/6a9da8ad-def8-424e-8eaa-366f0f41d075" />


## Verification
- `npm --prefix frontend test -- --run src/renderer/components/chat/ChatWorkspace.test.tsx src/renderer/components/chat/ChatMarkdown.test.tsx src/renderer/components/chat/ChatComposer.test.tsx`
- `npm --prefix frontend test -- --run src/renderer/components/chat/TurnSettingsBar.test.tsx src/renderer/components/chat/ChatComposer.test.tsx`

Note: the unrelated pre-existing `frontend/package-lock.json` change is not included.