### PR TITLE
feat: add Pi token usage observability

### DIFF
--- a/backend/internal/adapters/agent/pi/hooks.go
+++ b/backend/internal/adapters/agent/pi/hooks.go
@@ -79,6 +79,17 @@ func appendPiSessionDirFlag(cmd *[]string, dataDir string) {
 	*cmd = append(*cmd, "--session-dir", filepath.Join(dataDir, "pi", "sessions"))
 }
 
+func piTranscriptInManagedDir(transcriptPath, dataDir string) bool {
+	transcriptPath = strings.TrimSpace(transcriptPath)
+	dataDir = strings.TrimSpace(dataDir)
+	if transcriptPath == "" || dataDir == "" {
+		return false
+	}
+	root := filepath.Join(dataDir, "pi", "sessions")
+	rel, err := filepath.Rel(root, filepath.Clean(transcriptPath))
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 func (p *Plugin) piAgentSettledSupported(ctx context.Context) (bool, error) {
 	binary, err := p.piBinary(ctx)
 	if err != nil {

--- a/backend/internal/adapters/agent/pi/hooks.go
+++ b/backend/internal/adapters/agent/pi/hooks.go
@@ -72,6 +72,13 @@ func appendPiExtensionFlag(cmd *[]string, workspacePath string) {
 	*cmd = append(*cmd, "--extension", piExtensionPath(workspacePath))
 }
 
+func appendPiSessionDirFlag(cmd *[]string, dataDir string) {
+	if strings.TrimSpace(dataDir) == "" {
+		return
+	}
+	*cmd = append(*cmd, "--session-dir", filepath.Join(dataDir, "pi", "sessions"))
+}
+
 func (p *Plugin) piAgentSettledSupported(ctx context.Context) (bool, error) {
 	binary, err := p.piBinary(ctx)
 	if err != nil {
@@ -150,25 +157,33 @@ function sessionID(ctx: any): string {
   return ctx.sessionManager.getSessionId() ?? "";
 }
 
+function usagePayload(ctx: any, payload: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    session_id: sessionID(ctx),
+    transcript_path: ctx.sessionManager.getSessionFile?.() ?? "",
+    ...payload,
+  };
+}
+
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
-    callHookSync("session-start", { session_id: sessionID(ctx) });
+    callHookSync("session-start", usagePayload(ctx));
   });
   pi.on("before_agent_start", async (event, ctx) => {
-    callHookSync("user-prompt-submit", { session_id: sessionID(ctx), prompt: event.prompt });
+    callHookSync("user-prompt-submit", usagePayload(ctx, { prompt: event.prompt }));
   });
   // agent_end is the completion event in Pi 0.80.x. Newer releases may retry,
   // compact, or queue follow-up work after it; a subsequent start immediately
   // reactivates AO, while agent_settled below confirms the final idle state.
   pi.on("agent_end", async (_event, ctx) => {
-	    if (!AGENT_SETTLED_SUPPORTED) callHookSync("stop", { session_id: sessionID(ctx) });
+	    if (!AGENT_SETTLED_SUPPORTED) callHookSync("stop", usagePayload(ctx));
   });
   pi.on("agent_settled", async (_event, ctx) => {
-	    if (AGENT_SETTLED_SUPPORTED) callHookSync("stop", { session_id: sessionID(ctx) });
+	    if (AGENT_SETTLED_SUPPORTED) callHookSync("stop", usagePayload(ctx));
   });
   pi.on("session_shutdown", async (event, ctx) => {
 	    if (event.reason === "quit") {
-	      callHookSync("session-end", { session_id: sessionID(ctx), reason: event.reason });
+	      callHookSync("session-end", usagePayload(ctx, { reason: event.reason }));
 	    }
   });
 }

--- a/backend/internal/adapters/agent/pi/hooks_test.go
+++ b/backend/internal/adapters/agent/pi/hooks_test.go
@@ -85,6 +85,7 @@ func TestPiExtensionStopEventOrderingFollowsProbedSupport(t *testing.T) {
 				`import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";`+"\n", "",
 				`function callHookSync(hookName: string, payload: Record<string, unknown>)`, `function callHookSync(hookName, payload)`,
 				`function sessionID(ctx: any): string`, `function sessionID(ctx)`,
+				`function usagePayload(ctx: any, payload: Record<string, unknown> = {}): Record<string, unknown>`, `function usagePayload(ctx, payload = {})`,
 				`export default function (pi: ExtensionAPI)`, `export default function (pi)`,
 			).Replace(piActivityExtensionSource(tc.settledSupported))
 			if err := os.WriteFile(modulePath, []byte(source), 0o600); err != nil {
@@ -107,7 +108,10 @@ process.stdin.on("end", () => {
 const handlers = new Map();
 const loaded = await import(pathToFileURL(process.argv[2]).href);
 loaded.default({ on(name, handler) { handlers.set(name, handler); } });
-const ctx = { sessionManager: { getSessionId() { return "pi-session-1"; } } };
+const ctx = { sessionManager: {
+  getSessionId() { return "pi-session-1"; },
+  getSessionFile() { return "/ao/data/pi/sessions/pi-session-1.jsonl"; }
+} };
 process.env.PI_EVENT_SOURCE = "session_start";
 await handlers.get("session_start")({}, ctx);
 process.env.PI_EVENT_SOURCE = "before_agent_start";
@@ -142,6 +146,9 @@ await handlers.get("session_shutdown")({ reason: "quit" }, ctx);
 			}
 			if !strings.Contains(text, `["hooks","pi","session-start"]`) || !strings.Contains(text, `["hooks","pi","user-prompt-submit"]`) || !strings.Contains(text, `["hooks","pi","session-end"]`) {
 				t.Fatalf("expected lifecycle hook calls missing:\n%s", text)
+			}
+			if !strings.Contains(text, `\"transcript_path\":\"/ao/data/pi/sessions/pi-session-1.jsonl\"`) {
+				t.Fatalf("Pi transcript path missing from hook payloads:\n%s", text)
 			}
 		})
 	}

--- a/backend/internal/adapters/agent/pi/pi.go
+++ b/backend/internal/adapters/agent/pi/pi.go
@@ -137,7 +137,9 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 	cmd = []string{binary}
-	appendPiSessionDirFlag(&cmd, cfg.DataDir)
+	if piTranscriptInManagedDir(cfg.Session.Metadata[ports.MetadataKeyNativeTranscriptPath], cfg.DataDir) {
+		appendPiSessionDirFlag(&cmd, cfg.DataDir)
+	}
 	appendPiExtensionFlag(&cmd, cfg.Session.WorkspacePath)
 	if cfg.SystemPrompt != "" {
 		cmd = append(cmd, "--append-system-prompt", cfg.SystemPrompt)

--- a/backend/internal/adapters/agent/pi/pi.go
+++ b/backend/internal/adapters/agent/pi/pi.go
@@ -16,7 +16,7 @@
 // confirmation flows are built via TypeScript extensions), so AO emits no
 // permission flag and defers to Pi's own behavior.
 //
-// Restore: Pi persists sessions to ~/.pi/agent/sessions/ and resumes
+// Restore: AO pins Pi sessions under its configured data directory and resumes
 // interactively by id with `--session <id>` (partial UUIDs accepted). The native
 // session id is emitted on the first line of `--mode json` output as
 // {"type":"session","id":"<uuid>",...} and is captured into session metadata
@@ -89,7 +89,7 @@ func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 
 // GetLaunchCommand builds the argv to start a new interactive Pi session:
 //
-//	pi [--append-system-prompt <system prompt>] [--model <model>] [<prompt>]
+//	pi --session-dir <ao data>/pi/sessions [--append-system-prompt <system prompt>] [--model <model>] [<prompt>]
 //
 // The prompt is delivered in-command as a trailing positional message. Pi does
 // not honor a `--` options terminator, so the prompt must not begin with "-".
@@ -101,6 +101,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	}
 
 	cmd = []string{binary}
+	appendPiSessionDirFlag(&cmd, cfg.DataDir)
 	appendPiExtensionFlag(&cmd, cfg.WorkspacePath)
 	if cfg.SystemPrompt != "" {
 		cmd = append(cmd, "--append-system-prompt", cfg.SystemPrompt)
@@ -136,6 +137,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 	cmd = []string{binary}
+	appendPiSessionDirFlag(&cmd, cfg.DataDir)
 	appendPiExtensionFlag(&cmd, cfg.Session.WorkspacePath)
 	if cfg.SystemPrompt != "" {
 		cmd = append(cmd, "--append-system-prompt", cfg.SystemPrompt)

--- a/backend/internal/adapters/agent/pi/pi_test.go
+++ b/backend/internal/adapters/agent/pi/pi_test.go
@@ -308,7 +308,10 @@ func TestGetRestoreCommandExplicitlyLoadsManagedExtension(t *testing.T) {
 		DataDir: dataDir,
 		Session: ports.SessionRef{
 			WorkspacePath: workspace,
-			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "native-pi-1"},
+			Metadata: map[string]string{
+				ports.MetadataKeyAgentSessionID:       "native-pi-1",
+				ports.MetadataKeyNativeTranscriptPath: filepath.Join(dataDir, "pi", "sessions", "native-pi-1.jsonl"),
+			},
 		},
 	})
 	if err != nil {
@@ -318,6 +321,26 @@ func TestGetRestoreCommandExplicitlyLoadsManagedExtension(t *testing.T) {
 		t.Fatal("ok=false, want true")
 	}
 	want := []string{"pi", "--session-dir", filepath.Join(dataDir, "pi", "sessions"), "--extension", filepath.Join(workspace, ".pi", "extensions", "ao-activity.ts"), "--session", "native-pi-1"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandKeepsLegacySessionDirectory(t *testing.T) {
+	workspace := t.TempDir()
+	dataDir := t.TempDir()
+	p := &Plugin{resolvedBinary: "pi"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		DataDir: dataDir,
+		Session: ports.SessionRef{
+			WorkspacePath: workspace,
+			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "legacy-pi-1"},
+		},
+	})
+	if err != nil || !ok {
+		t.Fatalf("restore = %#v, ok=%v err=%v", cmd, ok, err)
+	}
+	want := []string{"pi", "--extension", filepath.Join(workspace, ".pi", "extensions", "ao-activity.ts"), "--session", "legacy-pi-1"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}

--- a/backend/internal/adapters/agent/pi/pi_test.go
+++ b/backend/internal/adapters/agent/pi/pi_test.go
@@ -284,15 +284,17 @@ func TestGetRestoreCommandNoID(t *testing.T) {
 
 func TestGetLaunchCommandExplicitlyLoadsManagedExtension(t *testing.T) {
 	workspace := t.TempDir()
+	dataDir := t.TempDir()
 	p := &Plugin{resolvedBinary: "pi"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		WorkspacePath: workspace,
+		DataDir:       dataDir,
 		Prompt:        "fix the bug",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"pi", "--extension", filepath.Join(workspace, ".pi", "extensions", "ao-activity.ts"), "fix the bug"}
+	want := []string{"pi", "--session-dir", filepath.Join(dataDir, "pi", "sessions"), "--extension", filepath.Join(workspace, ".pi", "extensions", "ao-activity.ts"), "fix the bug"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
@@ -300,8 +302,10 @@ func TestGetLaunchCommandExplicitlyLoadsManagedExtension(t *testing.T) {
 
 func TestGetRestoreCommandExplicitlyLoadsManagedExtension(t *testing.T) {
 	workspace := t.TempDir()
+	dataDir := t.TempDir()
 	p := &Plugin{resolvedBinary: "pi"}
 	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		DataDir: dataDir,
 		Session: ports.SessionRef{
 			WorkspacePath: workspace,
 			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "native-pi-1"},
@@ -313,7 +317,7 @@ func TestGetRestoreCommandExplicitlyLoadsManagedExtension(t *testing.T) {
 	if !ok {
 		t.Fatal("ok=false, want true")
 	}
-	want := []string{"pi", "--extension", filepath.Join(workspace, ".pi", "extensions", "ao-activity.ts"), "--session", "native-pi-1"}
+	want := []string{"pi", "--session-dir", filepath.Join(dataDir, "pi", "sessions"), "--extension", filepath.Join(workspace, ".pi", "extensions", "ao-activity.ts"), "--session", "native-pi-1"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -158,7 +158,7 @@ func hookLaunchID(payload []byte) string {
 // a malformed field in one projection while the other remains useful.
 func hookUsageMetadata(agent string, payload []byte) *usageHookMetadata {
 	harness := domain.AgentHarness(agent)
-	if harness != domain.HarnessClaudeCode && harness != domain.HarnessCodex {
+	if harness != domain.HarnessClaudeCode && harness != domain.HarnessCodex && harness != domain.HarnessPi {
 		return nil
 	}
 	var native struct {
@@ -176,6 +176,15 @@ func hookUsageMetadata(agent string, payload []byte) *usageHookMetadata {
 		ModelID:                strings.TrimSpace(native.Model),
 		SubagentID:             strings.TrimSpace(native.SubagentID),
 		SubagentTranscriptPath: strings.TrimSpace(native.SubagentTranscriptPath),
+	}
+	if harness == domain.HarnessPi {
+		meta.ModelID = ""
+		meta.SubagentID = ""
+		meta.SubagentTranscriptPath = ""
+		if meta.TranscriptPath == "" {
+			return nil
+		}
+		return meta
 	}
 	if meta.TranscriptPath == "" && meta.SubagentTranscriptPath == "" && meta.ModelID == "" {
 		return nil

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -408,7 +408,7 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 	}
 	conversation := hookConversationSnapshot{}
 	switch domain.AgentHarness(agent) {
-	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessContinue:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessContinue, domain.HarnessPi:
 		conversation = hookConversationFacts(payload)
 	}
 	path := "sessions/" + url.PathEscape(sessionID) + "/activity"

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -729,7 +729,7 @@ func TestHooks_PiSessionStartReportsUsageTranscriptPath(t *testing.T) {
 	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
 		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
 	}
-	if req.AgentSessionID != "pi-native-1" || req.Usage == nil ||
+	if req.AgentSessionID != "pi-native-1" || req.TranscriptPath != "/ao/data/pi/sessions/pi-native-1.jsonl" || req.Usage == nil ||
 		req.Usage.Harness != "pi" || req.Usage.TranscriptPath != "/ao/data/pi/sessions/pi-native-1.jsonl" {
 		t.Fatalf("body = %+v", req)
 	}

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -709,6 +709,32 @@ func TestHooks_CodexSessionStartReportsAgentSessionID(t *testing.T) {
 	}
 }
 
+func TestHooks_PiSessionStartReportsUsageTranscriptPath(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In: strings.NewReader(`{
+			"session_id":"pi-native-1",
+			"transcript_path":"/ao/data/pi/sessions/pi-native-1.jsonl"
+		}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "pi", "session-start")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+	}
+	if req.AgentSessionID != "pi-native-1" || req.Usage == nil ||
+		req.Usage.Harness != "pi" || req.Usage.TranscriptPath != "/ao/data/pi/sessions/pi-native-1.jsonl" {
+		t.Fatalf("body = %+v", req)
+	}
+}
+
 func TestHooks_CodexBlankSessionIDIsIgnored(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	cfg := setConfigEnv(t)

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -631,6 +631,7 @@ func usagePipelineWatchRoots(roots usagesvc.SourceRoots) []string {
 		roots.CodexSessions,
 		roots.CodexArchived,
 		roots.KimiHome,
+		roots.PiSessions,
 	}
 }
 

--- a/backend/internal/daemon/usage_wiring_test.go
+++ b/backend/internal/daemon/usage_wiring_test.go
@@ -29,6 +29,7 @@ func TestUsagePipelineWatchRootsIncludesKimiWrites(t *testing.T) {
 		CodexSessions:  t.TempDir(),
 		CodexArchived:  t.TempDir(),
 		KimiHome:       kimiHome,
+		PiSessions:     t.TempDir(),
 	}
 	watcher, err := usagepipeline.NewTranscriptWatcher(
 		context.Background(), usagePipelineWatchRoots(roots),

--- a/backend/internal/domain/usage.go
+++ b/backend/internal/domain/usage.go
@@ -16,6 +16,7 @@ const (
 	UsageSourceClaudeSubagent UsageSourceKind = "claude_subagent"
 	UsageSourceCodexRollout   UsageSourceKind = "codex_rollout"
 	UsageSourceKimiWire       UsageSourceKind = "kimi_wire"
+	UsageSourcePiSession      UsageSourceKind = "pi_session"
 )
 
 // UsageBindingState tracks the root native-session binding lifecycle.

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -571,12 +571,17 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	// (old CLIs, adapters without tool identity) pass through untouched —
 	// last-writer-wins, exactly as before.
 	promptAt := timeOr(s.Timestamp, now)
-	metadataChanged := (s.AgentSessionID != "" && rec.Metadata.AgentSessionID != s.AgentSessionID) ||
-		(s.AgentSessionID != "" && rec.Metadata.AgentSessionIDLaunchID != s.LaunchID) ||
+	nativeSessionChanged := s.AgentSessionID != "" &&
+		(rec.Metadata.AgentSessionID != s.AgentSessionID || rec.Metadata.AgentSessionIDLaunchID != s.LaunchID)
+	metadataChanged := nativeSessionChanged ||
 		(s.LatestUserPrompt != "" && (rec.Metadata.LatestUserPrompt != s.LatestUserPrompt ||
 			(s.Event == "user-prompt-submit" && promptAt.After(rec.Metadata.LatestUserPromptAt)))) ||
 		(s.LatestAssistantUpdate != "" && rec.Metadata.LatestAssistantUpdate != s.LatestAssistantUpdate) ||
 		(s.TranscriptPath != "" && rec.Metadata.NativeTranscriptPath != s.TranscriptPath)
+	var usageReactivator sessionUsageReactivator
+	if nativeSessionChanged {
+		usageReactivator = m.usageReactivator
+	}
 	if s.Valid {
 		s = m.applyToolPrecedenceLocked(id, rec.Activity.State, s)
 	}
@@ -589,6 +594,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		rec.UpdatedAt = now
 		_, err := m.store.UpdateSessionFromActivitySignal(ctx, rec)
 		m.mu.Unlock()
+		if err == nil {
+			reactivateSessionUsage(ctx, id, rec.Metadata.RuntimeLaunchID, usageReactivator)
+		}
 		return err
 	}
 	if metadataChanged {
@@ -615,6 +623,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 			}
 			if !applied {
 				return nil
+			}
+			if nativeSessionChanged {
+				reactivateSessionUsage(ctx, id, rec.Metadata.RuntimeLaunchID, usageReactivator)
 			}
 			return m.acknowledgeAgentSwitchTarget(ctx, id, s, now)
 		}
@@ -660,6 +671,9 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	resolutions := needsInputResolutions(rec, next, now)
 	waitingEvents := m.waitingInputEvents(next, prevState, prevAt, now)
 	m.mu.Unlock()
+	if nativeSessionChanged {
+		reactivateSessionUsage(ctx, id, next.Metadata.RuntimeLaunchID, usageReactivator)
+	}
 	if err := m.acknowledgeAgentSwitchTarget(ctx, id, s, now); err != nil {
 		return err
 	}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -1522,6 +1522,27 @@ func TestMarkSpawnedReactivatesUsageAfterLifecycleTransition(t *testing.T) {
 	}
 }
 
+func TestApplyActivitySignalNativeSessionIDReactivatesUsageDiscovery(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	rec.Metadata.RuntimeLaunchID = "launch-1"
+	st.sessions[rec.ID] = rec
+	usage := &fakeUsageLifecycle{fakeUsageFinalizer: fakeUsageFinalizer{store: st}}
+	m.SetUsageFinalizer(usage)
+
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		AgentSessionID: "pi-native-1",
+		LaunchID:       "launch-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if usage.reactivateCalls != 1 || usage.reactivateID != rec.ID ||
+		usage.reactivateLaunch != "launch-1" || !usage.sawLive {
+		t.Fatalf("usage discovery = calls:%d id:%q launch:%q live:%v",
+			usage.reactivateCalls, usage.reactivateID, usage.reactivateLaunch, usage.sawLive)
+	}
+}
+
 func TestMarkTerminatedFinalizesUsageBeforeLifecycleTransition(t *testing.T) {
 	m, st, _ := newManager()
 	rec := working("mer-1")

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -1532,6 +1532,7 @@ func TestApplyActivitySignalNativeSessionIDReactivatesUsageDiscovery(t *testing.
 
 	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
 		AgentSessionID: "pi-native-1",
+		TranscriptPath: "/ao/data/pi/sessions/pi-native-1.jsonl",
 		LaunchID:       "launch-1",
 	}); err != nil {
 		t.Fatal(err)
@@ -1540,6 +1541,9 @@ func TestApplyActivitySignalNativeSessionIDReactivatesUsageDiscovery(t *testing.
 		usage.reactivateLaunch != "launch-1" || !usage.sawLive {
 		t.Fatalf("usage discovery = calls:%d id:%q launch:%q live:%v",
 			usage.reactivateCalls, usage.reactivateID, usage.reactivateLaunch, usage.sawLive)
+	}
+	if got := st.sessions[rec.ID].Metadata.NativeTranscriptPath; got != "/ao/data/pi/sessions/pi-native-1.jsonl" {
+		t.Fatalf("native transcript path = %q", got)
 	}
 }
 

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -46,6 +46,8 @@ func parseRecordsWithState(
 		result.pendingCodexSpawnCalls = len(state.Codex.PendingSpawnCallIDs)
 	case domain.UsageSourceKimiWire:
 		parseKimi(source, records, &result)
+	case domain.UsageSourcePiSession:
+		parsePi(source, records, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -199,7 +201,7 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 		if err := validateCodexDirectParent(source, state.Codex); err != nil {
 			return nil, err
 		}
-	case domain.UsageSourceKimiWire:
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession:
 		if state.Claude != nil || state.Codex != nil {
 			return nil, errors.New("append-only state has invalid parser payload")
 		}
@@ -222,8 +224,8 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 			PendingSpawnCallIDs: []string{},
 			DiscoveredChildIDs:  []string{},
 		}
-	case domain.UsageSourceKimiWire:
-		// Kimi records carry stable native IDs, so no provider-specific
+	case domain.UsageSourceKimiWire, domain.UsageSourcePiSession:
+		// Both formats carry replay-stable native IDs, so no provider-specific
 		// cumulative baseline is required.
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", kind)

--- a/backend/internal/observe/usage/parser_pi.go
+++ b/backend/internal/observe/usage/parser_pi.go
@@ -8,22 +8,27 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
+const piUnattributedUsageModel = "Tools/summaries"
+
 type piSessionRecord struct {
-	Type      string `json:"type"`
-	ID        string `json:"id"`
-	Timestamp string `json:"timestamp"`
+	Type      string          `json:"type"`
+	ID        string          `json:"id"`
+	Timestamp string          `json:"timestamp"`
+	Usage     json.RawMessage `json:"usage"`
 	Message   *struct {
-		Role     string `json:"role"`
-		Provider string `json:"provider"`
-		Model    string `json:"model"`
-		Usage    *struct {
-			Input       int64  `json:"input"`
-			Output      int64  `json:"output"`
-			CacheRead   int64  `json:"cacheRead"`
-			CacheWrite  int64  `json:"cacheWrite"`
-			TotalTokens *int64 `json:"totalTokens"`
-		} `json:"usage"`
+		Role          string          `json:"role"`
+		Provider      string          `json:"provider"`
+		Model         string          `json:"model"`
+		ResponseModel string          `json:"responseModel"`
+		Usage         json.RawMessage `json:"usage"`
 	} `json:"message"`
+}
+
+type piNativeUsage struct {
+	Input      int64 `json:"input"`
+	Output     int64 `json:"output"`
+	CacheRead  int64 `json:"cacheRead"`
+	CacheWrite int64 `json:"cacheWrite"`
 }
 
 func parsePi(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
@@ -34,62 +39,70 @@ func parsePi(source domain.UsageSourceContext, records []jsonlRecord, result *pa
 			recordMalformed(result)
 			continue
 		}
-		if native.Type != "message" || native.Message == nil || native.Message.Role != "assistant" {
+
+		var provider, model string
+		var usageRaw json.RawMessage
+		switch {
+		case native.Type == "message" && native.Message != nil && native.Message.Role == "assistant":
+			provider = strings.TrimSpace(native.Message.Provider)
+			model = firstNonEmpty(native.Message.ResponseModel, native.Message.Model)
+			usageRaw = native.Message.Usage
+			if model == "" || !jsonValueReported(usageRaw) {
+				recordMalformed(result)
+				continue
+			}
+		case native.Type == "message" && native.Message != nil && native.Message.Role == "toolResult" &&
+			jsonValueReported(native.Message.Usage):
+			model = piUnattributedUsageModel
+			usageRaw = native.Message.Usage
+		case (native.Type == "compaction" || native.Type == "branch_summary") && jsonValueReported(native.Usage):
+			model = piUnattributedUsageModel
+			usageRaw = native.Usage
+		default:
 			continue
 		}
-		message := native.Message
-		model := firstNonEmpty(message.Model)
-		if model == "" || message.Usage == nil {
+
+		var usage piNativeUsage
+		if err := json.Unmarshal(usageRaw, &usage); err != nil {
 			recordMalformed(result)
 			continue
 		}
-		provider := strings.TrimSpace(message.Provider)
-		if provider != "" {
-			model = provider + "/" + model
-		}
-		usage := message.Usage
 		input, ok := sumNonNegative(usage.Input, usage.CacheRead, usage.CacheWrite)
 		if !ok {
 			recordMalformed(result)
 			continue
 		}
 		providerID := domain.UsageProviderOpenAI
-		providerDetails := domain.UsageProviderDetails{}
 		var tokens domain.UsageTokenMetrics
 		if strings.EqualFold(provider, "anthropic") {
-			var details domain.AnthropicUsageDetails
-			tokens, details, ok = normalizeAnthropicUsage(
+			providerID = domain.UsageProviderAnthropic
+			tokens, ok = normalizeAnthropicUsage(
 				usage.Input, usage.CacheWrite, usage.CacheRead, usage.Output, nil, nil,
 			)
-			providerID = domain.UsageProviderAnthropic
-			providerDetails.Anthropic = &details
 		} else {
-			reportedTotal := int64(0)
-			if usage.TotalTokens != nil {
-				reportedTotal = *usage.TotalTokens
-			}
-			var details domain.OpenAIUsageDetails
-			tokens, details, ok = normalizeOpenAIUsage(
-				input, usage.CacheRead, usage.CacheWrite, usage.Output, 0, reportedTotal,
-			)
-			// Pi reports direct input and cache buckets separately, so its
-			// canonical total input is derived rather than directly reported.
-			tokens.Provenance.InputTokens = domain.UsageMetricDerived
-			providerDetails.OpenAI = &details
+			tokens, ok = normalizeOpenAIUsage(input, usage.CacheRead, usage.CacheWrite, usage.Output)
 		}
 		if !ok {
 			recordMalformed(result)
 			continue
 		}
+
+		billingProvider := ""
+		if model != piUnattributedUsageModel {
+			billingProvider = canonicalBillingProvider(provider)
+		}
 		identity := firstNonEmpty(native.ID, strconv.FormatInt(record.Offset, 10))
 		event := domain.ModelUsageEvent{
-			ProviderID:      providerID,
-			ModelID:         model,
-			Tokens:          tokens,
-			ProviderDetails: providerDetails,
-			CreatedAt:       parseUsageTimestamp(native.Timestamp),
+			ProviderID:            providerID,
+			BillingProviderID:     billingProvider,
+			BillingProviderSource: domain.ObservedBillingProviderSource(billingProvider),
+			ModelID:               model,
+			MeasurementKind:       domain.UsageMeasurementNativeReported,
+			Tokens:                tokens,
+			ProviderUsageJSON:     boundedProviderUsage(usageRaw),
+			CreatedAt:             parseUsageTimestamp(native.Timestamp),
 			SourceEventKey: stableSourceEventKey(
-				"pi", source.NativeRootID, identity, provider, strings.TrimSpace(message.Model),
+				"pi", source.NativeRootID, native.Type, identity,
 			),
 		}
 		if existing, duplicate := eventsByKey[event.SourceEventKey]; duplicate {

--- a/backend/internal/observe/usage/parser_pi.go
+++ b/backend/internal/observe/usage/parser_pi.go
@@ -1,0 +1,105 @@
+package usage
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type piSessionRecord struct {
+	Type      string `json:"type"`
+	ID        string `json:"id"`
+	Timestamp string `json:"timestamp"`
+	Message   *struct {
+		Role     string `json:"role"`
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+		Usage    *struct {
+			Input       int64  `json:"input"`
+			Output      int64  `json:"output"`
+			CacheRead   int64  `json:"cacheRead"`
+			CacheWrite  int64  `json:"cacheWrite"`
+			TotalTokens *int64 `json:"totalTokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+func parsePi(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	eventsByKey := make(map[string]domain.ModelUsageEvent)
+	for _, record := range records {
+		var native piSessionRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.Type != "message" || native.Message == nil || native.Message.Role != "assistant" {
+			continue
+		}
+		message := native.Message
+		model := firstNonEmpty(message.Model)
+		if model == "" || message.Usage == nil {
+			recordMalformed(result)
+			continue
+		}
+		provider := strings.TrimSpace(message.Provider)
+		if provider != "" {
+			model = provider + "/" + model
+		}
+		usage := message.Usage
+		input, ok := sumNonNegative(usage.Input, usage.CacheRead, usage.CacheWrite)
+		if !ok {
+			recordMalformed(result)
+			continue
+		}
+		providerID := domain.UsageProviderOpenAI
+		providerDetails := domain.UsageProviderDetails{}
+		var tokens domain.UsageTokenMetrics
+		if strings.EqualFold(provider, "anthropic") {
+			var details domain.AnthropicUsageDetails
+			tokens, details, ok = normalizeAnthropicUsage(
+				usage.Input, usage.CacheWrite, usage.CacheRead, usage.Output, nil, nil,
+			)
+			providerID = domain.UsageProviderAnthropic
+			providerDetails.Anthropic = &details
+		} else {
+			reportedTotal := int64(0)
+			if usage.TotalTokens != nil {
+				reportedTotal = *usage.TotalTokens
+			}
+			var details domain.OpenAIUsageDetails
+			tokens, details, ok = normalizeOpenAIUsage(
+				input, usage.CacheRead, usage.CacheWrite, usage.Output, 0, reportedTotal,
+			)
+			// Pi reports direct input and cache buckets separately, so its
+			// canonical total input is derived rather than directly reported.
+			tokens.Provenance.InputTokens = domain.UsageMetricDerived
+			providerDetails.OpenAI = &details
+		}
+		if !ok {
+			recordMalformed(result)
+			continue
+		}
+		identity := firstNonEmpty(native.ID, strconv.FormatInt(record.Offset, 10))
+		event := domain.ModelUsageEvent{
+			ProviderID:      providerID,
+			ModelID:         model,
+			Tokens:          tokens,
+			ProviderDetails: providerDetails,
+			CreatedAt:       parseUsageTimestamp(native.Timestamp),
+			SourceEventKey: stableSourceEventKey(
+				"pi", source.NativeRootID, identity, provider, strings.TrimSpace(message.Model),
+			),
+		}
+		if existing, duplicate := eventsByKey[event.SourceEventKey]; duplicate {
+			if !usageEventsEqual(existing, event) {
+				result.Cursor.AnomalyCount++
+				result.Cursor.LastErrorCode = domain.UsageErrorSourceEventConflict
+			}
+			continue
+		}
+		eventsByKey[event.SourceEventKey] = event
+		result.Events = append(result.Events, event)
+	}
+}

--- a/backend/internal/observe/usage/pi_parser_test.go
+++ b/backend/internal/observe/usage/pi_parser_test.go
@@ -1,0 +1,88 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// TestParsePiAssistantUsage catches dropping Pi cache-write input or treating
+// non-assistant messages as model usage.
+func TestParsePiAssistantUsage(t *testing.T) {
+	source := usageSource(domain.UsageSourcePiSession)
+	source.NativeRootID = "pi-session"
+	records := []jsonlRecord{
+		{Data: []byte(`{"type":"session","id":"pi-session","cwd":"/repo","version":3}`)},
+		{Offset: 100, Data: []byte(`{"type":"message","id":"msg-1","timestamp":"2026-08-09T10:00:00Z","message":{"role":"assistant","provider":"zai-glm","model":"glm-4.5","usage":{"input":11,"output":7,"cacheRead":5,"cacheWrite":3,"totalTokens":26}}}`)},
+		{Offset: 200, Data: []byte(`{"type":"message","id":"msg-2","message":{"role":"user","usage":{"input":100}}}`)},
+	}
+
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.Events[0]
+	if event.ProviderID != domain.UsageProviderOpenAI || event.ModelID != "zai-glm/glm-4.5" ||
+		event.CreatedAt != time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC) || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	assertUsageMetric(t, "input", event.Tokens.InputTokens, 19, event.Tokens.Provenance.InputTokens, domain.UsageMetricDerived)
+	assertUsageMetric(t, "cached input", event.Tokens.CachedInputTokens, 5, event.Tokens.Provenance.CachedInputTokens, domain.UsageMetricReported)
+	assertUsageMetric(t, "uncached input", event.Tokens.UncachedInputTokens, 14, event.Tokens.Provenance.UncachedInputTokens, domain.UsageMetricDerived)
+	assertUsageMetric(t, "output", event.Tokens.OutputTokens, 7, event.Tokens.Provenance.OutputTokens, domain.UsageMetricReported)
+	details := event.ProviderDetails.OpenAI
+	if details == nil || details.CacheWriteInputTokens == nil || *details.CacheWriteInputTokens != 3 ||
+		details.ReasoningOutputTokens == nil || *details.ReasoningOutputTokens != 0 ||
+		event.ProviderDetails.Anthropic != nil {
+		t.Fatalf("provider details = %+v", event.ProviderDetails)
+	}
+}
+
+func TestParsePiRejectsInvalidUsage(t *testing.T) {
+	source := usageSource(domain.UsageSourcePiSession)
+	record := jsonlRecord{Data: []byte(`{"type":"message","id":"bad","message":{"role":"assistant","model":"m","usage":{"input":-1,"output":1}}}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 ||
+		result.Cursor.LastErrorCode != domain.UsageErrorMalformedJSONL {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestParsePiAnthropicUsageUsesAnthropicVocabulary(t *testing.T) {
+	source := usageSource(domain.UsageSourcePiSession)
+	source.NativeRootID = "pi-session"
+	record := jsonlRecord{Data: []byte(`{"type":"message","id":"msg-1","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet","usage":{"input":11,"output":7,"cacheRead":5,"cacheWrite":3,"totalTokens":26}}}`)}
+
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.Events[0]
+	if event.ProviderID != domain.UsageProviderAnthropic || event.ProviderDetails.OpenAI != nil {
+		t.Fatalf("event = %+v", event)
+	}
+	details := event.ProviderDetails.Anthropic
+	if details == nil || details.DirectUncachedInputTokens == nil ||
+		*details.DirectUncachedInputTokens != 11 || details.CacheCreationInputTokens == nil ||
+		*details.CacheCreationInputTokens != 3 {
+		t.Fatalf("details = %+v", details)
+	}
+}
+
+func assertUsageMetric(
+	t *testing.T,
+	name string,
+	value *int64,
+	want int64,
+	provenance domain.UsageMetricProvenance,
+	wantProvenance domain.UsageMetricProvenance,
+) {
+	t.Helper()
+	if value == nil || *value != want || provenance != wantProvenance {
+		t.Fatalf("%s = %v (%s), want %d (%s)", name, value, provenance, want, wantProvenance)
+	}
+}

--- a/backend/internal/observe/usage/pi_parser_test.go
+++ b/backend/internal/observe/usage/pi_parser_test.go
@@ -7,36 +7,69 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
-// TestParsePiAssistantUsage catches dropping Pi cache-write input or treating
-// non-assistant messages as model usage.
-func TestParsePiAssistantUsage(t *testing.T) {
+// TestParsePiUsageBearingEntries catches omitting Pi's nested tool/summarizer
+// usage and attributing an assistant response to its requested model.
+func TestParsePiUsageBearingEntries(t *testing.T) {
 	source := usageSource(domain.UsageSourcePiSession)
 	source.NativeRootID = "pi-session"
 	records := []jsonlRecord{
 		{Data: []byte(`{"type":"session","id":"pi-session","cwd":"/repo","version":3}`)},
-		{Offset: 100, Data: []byte(`{"type":"message","id":"msg-1","timestamp":"2026-08-09T10:00:00Z","message":{"role":"assistant","provider":"zai-glm","model":"glm-4.5","usage":{"input":11,"output":7,"cacheRead":5,"cacheWrite":3,"totalTokens":26}}}`)},
-		{Offset: 200, Data: []byte(`{"type":"message","id":"msg-2","message":{"role":"user","usage":{"input":100}}}`)},
+		{Offset: 100, Data: []byte(`{"type":"message","id":"assistant-1","timestamp":"2026-08-29T10:00:00Z","message":{"role":"assistant","provider":"openai","model":"requested-model","responseModel":"responding-model","usage":{"input":11,"output":7,"cacheRead":5,"cacheWrite":3,"totalTokens":26,"cost":{"total":0.01}}}}`)},
+		{Offset: 200, Data: []byte(`{"type":"message","id":"tool-1","timestamp":"2026-08-29T10:01:00Z","message":{"role":"toolResult","toolName":"nested-agent","usage":{"input":2,"output":1,"cacheRead":4,"cacheWrite":3,"totalTokens":10,"cost":{"total":0.02}}}}`)},
+		{Offset: 300, Data: []byte(`{"type":"compaction","id":"compact-1","timestamp":"2026-08-29T10:02:00Z","usage":{"input":6,"output":2,"cacheRead":1,"cacheWrite":1,"totalTokens":10,"cost":{"total":0.03}}}`)},
+		{Offset: 400, Data: []byte(`{"type":"branch_summary","id":"branch-1","timestamp":"2026-08-29T10:03:00Z","usage":{"input":8,"output":3,"cacheRead":2,"cacheWrite":1,"totalTokens":14,"cost":{"total":0.04}}}`)},
+		{Offset: 500, Data: []byte(`{"type":"message","id":"user-1","message":{"role":"user","content":"ignored"}}`)},
 	}
 
-	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	result := parseRecords(source, records, 600, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 4 {
+		t.Fatalf("result = %+v", result)
+	}
+	assistant := result.Events[0]
+	if assistant.ProviderID != domain.UsageProviderOpenAI || assistant.BillingProviderID != "openai" ||
+		assistant.BillingProviderSource != domain.UsageBillingProviderObserved ||
+		assistant.ModelID != "responding-model" || assistant.MeasurementKind != domain.UsageMeasurementNativeReported ||
+		assistant.CreatedAt != time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC) ||
+		assistant.SourceEventKey == "" || assistant.ProviderUsageJSON == "" {
+		t.Fatalf("assistant event = %+v", assistant)
+	}
+	assertPiTokens(t, assistant.Tokens, 19, 5, 14, 7)
+	if providerUsageTokens(t, assistant.ProviderUsageJSON, "cacheWrite") != 3 {
+		t.Fatalf("assistant provider usage = %s", assistant.ProviderUsageJSON)
+	}
+
+	wants := []domain.UsageTokenMetrics{
+		{InputTokens: int64Ptr(9), CachedInputTokens: int64Ptr(4), UncachedInputTokens: int64Ptr(5), OutputTokens: int64Ptr(1)},
+		{InputTokens: int64Ptr(8), CachedInputTokens: int64Ptr(1), UncachedInputTokens: int64Ptr(7), OutputTokens: int64Ptr(2)},
+		{InputTokens: int64Ptr(11), CachedInputTokens: int64Ptr(2), UncachedInputTokens: int64Ptr(9), OutputTokens: int64Ptr(3)},
+	}
+	for index, event := range result.Events[1:] {
+		if event.ProviderID != domain.UsageProviderOpenAI || event.BillingProviderID != "" ||
+			event.BillingProviderSource != "" || event.ModelID != "Tools/summaries" ||
+			event.MeasurementKind != domain.UsageMeasurementNativeReported || event.ProviderUsageJSON == "" ||
+			event.SourceEventKey == "" {
+			t.Fatalf("unattributed event %d = %+v", index, event)
+		}
+		assertPiTokenMetricsEqual(t, event.Tokens, wants[index])
+	}
+}
+
+func TestParsePiAnthropicAssistantUsesResponseModel(t *testing.T) {
+	source := usageSource(domain.UsageSourcePiSession)
+	source.NativeRootID = "pi-session"
+	record := jsonlRecord{Data: []byte(`{"type":"message","id":"assistant-1","message":{"role":"assistant","provider":"anthropic","model":"requested","responseModel":"claude-sonnet","usage":{"input":11,"output":7,"cacheRead":5,"cacheWrite":3,"totalTokens":26}}}`)}
+
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
 	if result.err != nil || len(result.Events) != 1 {
 		t.Fatalf("result = %+v", result)
 	}
 	event := result.Events[0]
-	if event.ProviderID != domain.UsageProviderOpenAI || event.ModelID != "zai-glm/glm-4.5" ||
-		event.CreatedAt != time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC) || event.SourceEventKey == "" {
+	if event.ProviderID != domain.UsageProviderAnthropic || event.BillingProviderID != "anthropic" ||
+		event.BillingProviderSource != domain.UsageBillingProviderObserved || event.ModelID != "claude-sonnet" ||
+		event.MeasurementKind != domain.UsageMeasurementNativeReported {
 		t.Fatalf("event = %+v", event)
 	}
-	assertUsageMetric(t, "input", event.Tokens.InputTokens, 19, event.Tokens.Provenance.InputTokens, domain.UsageMetricDerived)
-	assertUsageMetric(t, "cached input", event.Tokens.CachedInputTokens, 5, event.Tokens.Provenance.CachedInputTokens, domain.UsageMetricReported)
-	assertUsageMetric(t, "uncached input", event.Tokens.UncachedInputTokens, 14, event.Tokens.Provenance.UncachedInputTokens, domain.UsageMetricDerived)
-	assertUsageMetric(t, "output", event.Tokens.OutputTokens, 7, event.Tokens.Provenance.OutputTokens, domain.UsageMetricReported)
-	details := event.ProviderDetails.OpenAI
-	if details == nil || details.CacheWriteInputTokens == nil || *details.CacheWriteInputTokens != 3 ||
-		details.ReasoningOutputTokens == nil || *details.ReasoningOutputTokens != 0 ||
-		event.ProviderDetails.Anthropic != nil {
-		t.Fatalf("provider details = %+v", event.ProviderDetails)
-	}
+	assertPiTokens(t, event.Tokens, 19, 5, 14, 7)
 }
 
 func TestParsePiRejectsInvalidUsage(t *testing.T) {
@@ -52,37 +85,22 @@ func TestParsePiRejectsInvalidUsage(t *testing.T) {
 	}
 }
 
-func TestParsePiAnthropicUsageUsesAnthropicVocabulary(t *testing.T) {
-	source := usageSource(domain.UsageSourcePiSession)
-	source.NativeRootID = "pi-session"
-	record := jsonlRecord{Data: []byte(`{"type":"message","id":"msg-1","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet","usage":{"input":11,"output":7,"cacheRead":5,"cacheWrite":3,"totalTokens":26}}}`)}
-
-	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
-	if result.err != nil || len(result.Events) != 1 {
-		t.Fatalf("result = %+v", result)
-	}
-	event := result.Events[0]
-	if event.ProviderID != domain.UsageProviderAnthropic || event.ProviderDetails.OpenAI != nil {
-		t.Fatalf("event = %+v", event)
-	}
-	details := event.ProviderDetails.Anthropic
-	if details == nil || details.DirectUncachedInputTokens == nil ||
-		*details.DirectUncachedInputTokens != 11 || details.CacheCreationInputTokens == nil ||
-		*details.CacheCreationInputTokens != 3 {
-		t.Fatalf("details = %+v", details)
-	}
+func assertPiTokens(t *testing.T, got domain.UsageTokenMetrics, input, cached, uncached, output int64) {
+	t.Helper()
+	assertPiTokenMetricsEqual(t, got, domain.UsageTokenMetrics{
+		InputTokens: int64Ptr(input), CachedInputTokens: int64Ptr(cached),
+		UncachedInputTokens: int64Ptr(uncached), OutputTokens: int64Ptr(output),
+	})
 }
 
-func assertUsageMetric(
-	t *testing.T,
-	name string,
-	value *int64,
-	want int64,
-	provenance domain.UsageMetricProvenance,
-	wantProvenance domain.UsageMetricProvenance,
-) {
+func assertPiTokenMetricsEqual(t *testing.T, got, want domain.UsageTokenMetrics) {
 	t.Helper()
-	if value == nil || *value != want || provenance != wantProvenance {
-		t.Fatalf("%s = %v (%s), want %d (%s)", name, value, provenance, want, wantProvenance)
+	for name, values := range map[string][2]*int64{
+		"input": {got.InputTokens, want.InputTokens}, "cached": {got.CachedInputTokens, want.CachedInputTokens},
+		"uncached": {got.UncachedInputTokens, want.UncachedInputTokens}, "output": {got.OutputTokens, want.OutputTokens},
+	} {
+		if values[0] == nil || values[1] == nil || *values[0] != *values[1] {
+			t.Fatalf("%s tokens = %v, want %v", name, values[0], values[1])
+		}
 	}
 }

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -347,12 +347,13 @@ type ActiveTurnSteerer interface {
 	SteersActiveTurn() bool
 }
 
-// MetadataKeyAgentSessionID is the SessionRef.Metadata key that carries an
-// agent's native session id. It matches the json tag on
-// domain.SessionMetadata.AgentSessionID and the key the adapters read, so the
-// Session Manager can bridge its typed metadata onto a SessionRef without
-// either side hard-coding the other's vocabulary.
-const MetadataKeyAgentSessionID = "agentSessionId"
+// MetadataKeyAgentSessionID and MetadataKeyNativeTranscriptPath bridge typed
+// session metadata onto SessionRef without adapters hard-coding domain JSON
+// vocabulary.
+const (
+	MetadataKeyAgentSessionID       = "agentSessionId"
+	MetadataKeyNativeTranscriptPath = "nativeTranscriptPath"
+)
 
 // MetadataKeyTitle and MetadataKeySummary are the SessionRef.Metadata keys
 // carrying a session's human title and one-line summary. They are the shared

--- a/backend/internal/ports/agent_test.go
+++ b/backend/internal/ports/agent_test.go
@@ -22,3 +22,14 @@ func TestMetadataKeyAgentSessionIDMatchesDomainJSONTag(t *testing.T) {
 		t.Fatalf("json tag %q != ports.MetadataKeyAgentSessionID %q", name, ports.MetadataKeyAgentSessionID)
 	}
 }
+
+func TestMetadataKeyNativeTranscriptPathMatchesDomainJSONTag(t *testing.T) {
+	field, ok := reflect.TypeOf(domain.SessionMetadata{}).FieldByName("NativeTranscriptPath")
+	if !ok {
+		t.Fatalf("domain.SessionMetadata has no NativeTranscriptPath field")
+	}
+	name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+	if name != ports.MetadataKeyNativeTranscriptPath {
+		t.Fatalf("json tag %q != ports.MetadataKeyNativeTranscriptPath %q", name, ports.MetadataKeyNativeTranscriptPath)
+	}
+}

--- a/backend/internal/pricing/runtime.go
+++ b/backend/internal/pricing/runtime.go
@@ -455,6 +455,7 @@ func cacheWriteSplitFor(event domain.ModelUsageEvent) cacheWriteSplit {
 		var usage struct {
 			CacheCreationInputTokens *int64 `json:"cache_creation_input_tokens"`
 			PiCacheWrite             *int64 `json:"cacheWrite"`
+			PiCacheWrite1H           *int64 `json:"cacheWrite1h"`
 			CacheCreation            *struct {
 				Ephemeral5mInputTokens *int64 `json:"ephemeral_5m_input_tokens"`
 				Ephemeral1hInputTokens *int64 `json:"ephemeral_1h_input_tokens"`
@@ -471,6 +472,11 @@ func cacheWriteSplitFor(event domain.ModelUsageEvent) cacheWriteSplit {
 		if usage.CacheCreation != nil {
 			split.fiveM = usage.CacheCreation.Ephemeral5mInputTokens
 			split.oneH = usage.CacheCreation.Ephemeral1hInputTokens
+		} else if usage.PiCacheWrite != nil && usage.PiCacheWrite1H != nil &&
+			*usage.PiCacheWrite1H >= 0 && *usage.PiCacheWrite1H <= *usage.PiCacheWrite {
+			fiveM := *usage.PiCacheWrite - *usage.PiCacheWrite1H
+			split.fiveM = &fiveM
+			split.oneH = usage.PiCacheWrite1H
 		}
 		return split
 	case domain.UsageProviderOpenAI:

--- a/backend/internal/pricing/runtime.go
+++ b/backend/internal/pricing/runtime.go
@@ -454,6 +454,7 @@ func cacheWriteSplitFor(event domain.ModelUsageEvent) cacheWriteSplit {
 	case domain.UsageProviderAnthropic:
 		var usage struct {
 			CacheCreationInputTokens *int64 `json:"cache_creation_input_tokens"`
+			PiCacheWrite             *int64 `json:"cacheWrite"`
 			CacheCreation            *struct {
 				Ephemeral5mInputTokens *int64 `json:"ephemeral_5m_input_tokens"`
 				Ephemeral1hInputTokens *int64 `json:"ephemeral_1h_input_tokens"`
@@ -462,7 +463,11 @@ func cacheWriteSplitFor(event domain.ModelUsageEvent) cacheWriteSplit {
 		if err := json.Unmarshal([]byte(event.ProviderUsageJSON), &usage); err != nil {
 			return cacheWriteSplit{}
 		}
-		split := cacheWriteSplit{total: usage.CacheCreationInputTokens}
+		total := usage.CacheCreationInputTokens
+		if total == nil {
+			total = usage.PiCacheWrite
+		}
+		split := cacheWriteSplit{total: total}
 		if usage.CacheCreation != nil {
 			split.fiveM = usage.CacheCreation.Ephemeral5mInputTokens
 			split.oneH = usage.CacheCreation.Ephemeral1hInputTokens
@@ -479,15 +484,19 @@ func cacheWriteSplitFor(event domain.ModelUsageEvent) cacheWriteSplit {
 			Last *struct {
 				CacheWriteInputTokens *int64 `json:"cache_write_input_tokens"`
 			} `json:"last_token_usage"`
-			Derived *int64 `json:"ao_derived_cache_write_input_tokens"`
+			Derived      *int64 `json:"ao_derived_cache_write_input_tokens"`
+			PiCacheWrite *int64 `json:"cacheWrite"`
 		}
 		if err := json.Unmarshal([]byte(event.ProviderUsageJSON), &usage); err != nil {
 			return cacheWriteSplit{}
 		}
-		if usage.Last != nil {
+		if usage.Last != nil && usage.Last.CacheWriteInputTokens != nil {
 			return cacheWriteSplit{total: usage.Last.CacheWriteInputTokens}
 		}
-		return cacheWriteSplit{total: usage.Derived}
+		if usage.Derived != nil {
+			return cacheWriteSplit{total: usage.Derived}
+		}
+		return cacheWriteSplit{total: usage.PiCacheWrite}
 	default:
 		return cacheWriteSplit{}
 	}

--- a/backend/internal/pricing/runtime_test.go
+++ b/backend/internal/pricing/runtime_test.go
@@ -213,6 +213,29 @@ func TestEstimateReadsPiCacheWriteUsage(t *testing.T) {
 	}
 }
 
+func TestEstimateReadsPiOneHourCacheWriteUsage(t *testing.T) {
+	snapshot := decodeTestSnapshot(t, map[string][]testModel{
+		"anthropic": {{
+			ID: "claude-test", Input: "0.000001", Read: strptr("0.0000001"),
+			Write: strptr("0.000002"), Write1H: strptr("0.000004"), Output: "0.000003",
+		}},
+		"openai": {{ID: "gpt-test", Input: "0.1", Output: "0.2"}},
+		"zai":    {{ID: "glm-test", Input: "0.1", Output: "0.2"}},
+	})
+	estimate, err := snapshot.Estimate(domain.ModelUsageEvent{
+		ProviderID: domain.UsageProviderAnthropic, BillingProviderID: "anthropic", ModelID: "claude-test",
+		Tokens:            pricingTokens(1000, 400, 600, 200),
+		ProviderUsageJSON: `{"input":500,"cacheRead":400,"cacheWrite":100,"cacheWrite1h":40,"output":200}`,
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	assertCost(t, "input", estimate.InputNanos, 780_000)
+	assertCost(t, "cached input", estimate.CachedInputNanos, 40_000)
+	assertCost(t, "output", estimate.OutputNanos, 600_000)
+	assertCost(t, "total", estimate.TotalNanos, 1_420_000)
+}
+
 func TestEstimateKeepsUnknownBucketsUnknownAndZeroBucketsKnown(t *testing.T) {
 	snapshot := decodeTestSnapshot(t, map[string][]testModel{
 		"anthropic": {{ID: "claude-test", Input: "0.1", Output: "0.2"}},

--- a/backend/internal/pricing/runtime_test.go
+++ b/backend/internal/pricing/runtime_test.go
@@ -178,6 +178,41 @@ func TestEstimateLeavesInputUnknownWhenAPricedWriteSplitIsMissing(t *testing.T) 
 	assertCost(t, "total", priced.TotalNanos, 4_995_000)
 }
 
+// TestEstimateReadsPiCacheWriteUsage catches treating Pi's emitted camelCase
+// usage object as if it were a Claude or Codex transcript object. A model with
+// a distinct write rate cannot be priced unless that native split survives.
+func TestEstimateReadsPiCacheWriteUsage(t *testing.T) {
+	snapshot := decodeTestSnapshot(t, map[string][]testModel{
+		"anthropic": {{ID: "claude-test", Input: "0.000001", Read: strptr("0.0000001"), Write: strptr("0.000002"), Output: "0.000003"}},
+		"openai":    {{ID: "gpt-test", Input: "0.000001", Read: strptr("0.0000001"), Write: strptr("0.000002"), Output: "0.000003"}},
+		"zai":       {{ID: "glm-test", Input: "0.1", Output: "0.2"}},
+	})
+	for _, tc := range []struct {
+		name       string
+		providerID domain.UsageProviderID
+		billingID  string
+		modelID    string
+	}{
+		{name: "Anthropic vocabulary", providerID: domain.UsageProviderAnthropic, billingID: "anthropic", modelID: "claude-test"},
+		{name: "OpenAI vocabulary", providerID: domain.UsageProviderOpenAI, billingID: "openai", modelID: "gpt-test"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			estimate, err := snapshot.Estimate(domain.ModelUsageEvent{
+				ProviderID: tc.providerID, BillingProviderID: tc.billingID, ModelID: tc.modelID,
+				Tokens:            pricingTokens(1000, 400, 600, 200),
+				ProviderUsageJSON: `{"input":500,"cacheRead":400,"cacheWrite":100,"output":200}`,
+			})
+			if err != nil {
+				t.Fatalf("Estimate: %v", err)
+			}
+			assertCost(t, "input", estimate.InputNanos, 700_000)
+			assertCost(t, "cached input", estimate.CachedInputNanos, 40_000)
+			assertCost(t, "output", estimate.OutputNanos, 600_000)
+			assertCost(t, "total", estimate.TotalNanos, 1_340_000)
+		})
+	}
+}
+
 func TestEstimateKeepsUnknownBucketsUnknownAndZeroBucketsKnown(t *testing.T) {
 	snapshot := decodeTestSnapshot(t, map[string][]testModel{
 		"anthropic": {{ID: "claude-test", Input: "0.1", Output: "0.2"}},

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessKimi:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessKimi, domain.HarnessPi:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -158,10 +158,6 @@ func newContextMutex() contextMutex {
 	return contextMutex{token: token}
 }
 
-func (m *contextMutex) Lock() {
-	<-m.token
-}
-
 func (m *contextMutex) LockContext(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
@@ -209,7 +205,9 @@ func (c *Collector) FinalizeSession(
 	expectedRuntimeLaunchID string,
 	expectedSessionRevision time.Time,
 ) error {
-	c.mu.Lock()
+	if err := c.mu.LockContext(ctx); err != nil {
+		return err
+	}
 	defer c.mu.Unlock()
 
 	now := c.now().UTC()
@@ -353,7 +351,9 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 		}
 	}
 
-	c.mu.Lock()
+	if err := c.mu.LockContext(ctx); err != nil {
+		return err
+	}
 	defer c.mu.Unlock()
 	session, proceed, err = c.hookSession(ctx, sessionID, signal, finalizing)
 	if err != nil || !proceed {
@@ -568,7 +568,9 @@ func (c *Collector) validateHookArtifact(
 // BackfillActive discovers transcript files only for live/resumable AO
 // sessions. It deliberately does not import terminated session history.
 func (c *Collector) BackfillActive(ctx context.Context) error {
-	c.mu.Lock()
+	if err := c.mu.LockContext(ctx); err != nil {
+		return err
+	}
 	defer c.mu.Unlock()
 
 	sessions, err := c.store.ListAllSessions(ctx)
@@ -724,7 +726,9 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 // A negative limit reconciles every eligible binding; zero uses the bounded
 // default.
 func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
-	c.mu.Lock()
+	if err := c.mu.LockContext(ctx); err != nil {
+		return err
+	}
 	defer c.mu.Unlock()
 
 	var errs []error
@@ -750,7 +754,9 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 // ReconcilePath uses Codex rollout metadata to validate replacements and reach
 // newly-created child bindings independently of the bounded discovery queue.
 func (c *Collector) ReconcilePath(ctx context.Context, path string) error {
-	c.mu.Lock()
+	if err := c.mu.LockContext(ctx); err != nil {
+		return err
+	}
 	defer c.mu.Unlock()
 	if pathWithinRoot(ctx, path, c.roots.PiSessions) {
 		return c.reconcilePiPath(ctx, path)
@@ -818,34 +824,26 @@ func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
 	if !ok {
 		return nil
 	}
-	startedAt, validTimestamp := piSessionStartedAt(meta)
-	if !validTimestamp {
-		return nil // Pi session attribution requires its provider timestamp.
-	}
-	workspace, err := filepath.EvalSymlinks(filepath.Clean(meta.CWD))
-	if err != nil {
-		return nil //nolint:nilerr // Ignore stale provider metadata.
-	}
 	sessions, err := c.store.ListAllSessions(ctx)
 	if err != nil {
 		return err
 	}
-	matches := make([]domain.SessionRecord, 0, 1)
+	var match *domain.SessionRecord
 	for _, session := range sessions {
 		if session.Harness != domain.HarnessPi || session.IsTerminated ||
-			session.Activity.State == domain.ActivityExited || session.Metadata.WorkspacePath == "" ||
-			startedAt.Before(session.CreatedAt.Add(-5*time.Second)) {
+			session.Activity.State == domain.ActivityExited || usageNativeSessionID(session) != meta.ID {
 			continue
 		}
-		candidate, candidateErr := filepath.EvalSymlinks(filepath.Clean(session.Metadata.WorkspacePath))
-		if candidateErr == nil && candidate == workspace {
-			matches = append(matches, session)
+		if match != nil {
+			return nil // Native identity must resolve to exactly one live AO session.
 		}
+		candidate := session
+		match = &candidate
 	}
-	if len(matches) != 1 {
+	if match == nil {
 		return nil
 	}
-	existing, err := c.store.ListUsageBindingsForSession(ctx, matches[0].ID)
+	existing, err := c.store.ListUsageBindingsForSession(ctx, match.ID)
 	if err != nil {
 		return err
 	}
@@ -856,7 +854,7 @@ func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
 	}
 	now := c.now().UTC()
 	binding, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
-		SessionID: matches[0].ID, Harness: domain.HarnessPi, NativeRootID: meta.ID,
+		SessionID: match.ID, Harness: domain.HarnessPi, NativeRootID: meta.ID,
 		State: domain.UsageBindingActive, UpdatedAt: now,
 	})
 	if err != nil {
@@ -2133,14 +2131,6 @@ type piSessionMeta struct {
 	ID        string `json:"id"`
 	Timestamp string `json:"timestamp"`
 	CWD       string `json:"cwd"`
-}
-
-func piSessionStartedAt(meta piSessionMeta) (time.Time, bool) {
-	startedAt, err := time.Parse(time.RFC3339Nano, meta.Timestamp)
-	if err != nil {
-		return time.Time{}, false
-	}
-	return startedAt.UTC(), true
 }
 
 func readPiSessionMeta(ctx context.Context, path string) (piSessionMeta, bool) {

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -83,16 +83,12 @@ func DefaultSourceRoots(ctx context.Context, dataDir string) (SourceRoots, error
 	if strings.TrimSpace(dataDir) == "" {
 		dataDir = filepath.Join(home, ".ao", "data")
 	}
-	piHome := strings.TrimSpace(os.Getenv("PI_CODING_AGENT_DIR"))
-	if piHome == "" {
-		piHome = filepath.Join(home, ".pi", "agent")
-	}
 	return SourceRoots{
 		ClaudeProjects: filepath.Join(home, ".claude", "projects"),
 		CodexSessions:  filepath.Join(codexHome, "sessions"),
 		CodexArchived:  filepath.Join(codexHome, "archived_sessions"),
 		KimiHome:       filepath.Join(dataDir, "kimi"),
-		PiSessions:     filepath.Join(piHome, "sessions"),
+		PiSessions:     filepath.Join(dataDir, "pi", "sessions"),
 	}, nil
 }
 
@@ -392,7 +388,8 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 	inventoryChanged := !exists || state != existing.State
 	needsReconcile := false
 	lastErrorCode := ""
-	if session.Harness == domain.HarnessCodex && strings.TrimSpace(signal.TranscriptPath) == "" {
+	if (session.Harness == domain.HarnessCodex || session.Harness == domain.HarnessPi) &&
+		strings.TrimSpace(signal.TranscriptPath) == "" {
 		lastErrorCode = domain.UsageErrorSourceDiscoveryPending
 	}
 	// A binding that existed without a billable route, and now has one, owns

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -125,7 +124,7 @@ type Collector struct {
 	notifyRouteResolved     func()
 	codexLogicalSourceLimit int
 	now                     func() time.Time
-	mu                      sync.Mutex
+	mu                      contextMutex
 	// Guarded separately from mu, which RecordHook holds across the whole hook.
 	routeMu sync.RWMutex
 }
@@ -149,6 +148,33 @@ func (c *Collector) routeResolvedHandler() func() {
 	return c.notifyRouteResolved
 }
 
+type contextMutex struct {
+	token chan struct{}
+}
+
+func newContextMutex() contextMutex {
+	token := make(chan struct{}, 1)
+	token <- struct{}{}
+	return contextMutex{token: token}
+}
+
+func (m *contextMutex) Lock() {
+	<-m.token
+}
+
+func (m *contextMutex) LockContext(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.token:
+		return nil
+	}
+}
+
+func (m *contextMutex) Unlock() {
+	m.token <- struct{}{}
+}
+
 // NewCollector constructs a transcript source registrar.
 func NewCollector(store collectorStore, roots SourceRoots, notifySourcesChanged func(reconcile bool)) *Collector {
 	return newCollectorWithCodexSourceLimit(store, roots, notifySourcesChanged, defaultCodexLogicalSourceLimit)
@@ -169,6 +195,7 @@ func newCollectorWithCodexSourceLimit(
 		notifySourcesChanged:    notifySourcesChanged,
 		codexLogicalSourceLimit: limit,
 		now:                     time.Now,
+		mu:                      newContextMutex(),
 	}
 }
 
@@ -215,19 +242,8 @@ func (c *Collector) ReactivateSession(
 	sessionID domain.SessionID,
 	expectedRuntimeLaunchID string,
 ) error {
-	if !c.mu.TryLock() {
-		go func() {
-			c.mu.Lock()
-			defer c.mu.Unlock()
-			if err := c.reactivateSessionLocked(context.WithoutCancel(ctx), sessionID, expectedRuntimeLaunchID); err != nil {
-				slog.Default().Warn(
-					"usage: reactivate session after concurrent finalization",
-					"session", sessionID,
-					"err", err,
-				)
-			}
-		}()
-		return nil
+	if err := c.mu.LockContext(ctx); err != nil {
+		return err
 	}
 	defer c.mu.Unlock()
 	return c.reactivateSessionLocked(ctx, sessionID, expectedRuntimeLaunchID)
@@ -798,9 +814,13 @@ func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
 	if err != nil {
 		return nil //nolint:nilerr // Watch notifications may target another provider.
 	}
-	meta, ok := readPiSessionMeta(resolved)
+	meta, ok := readPiSessionMeta(ctx, resolved)
 	if !ok {
 		return nil
+	}
+	startedAt, validTimestamp := piSessionStartedAt(meta)
+	if !validTimestamp {
+		return nil // Pi session attribution requires its provider timestamp.
 	}
 	workspace, err := filepath.EvalSymlinks(filepath.Clean(meta.CWD))
 	if err != nil {
@@ -813,7 +833,8 @@ func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
 	matches := make([]domain.SessionRecord, 0, 1)
 	for _, session := range sessions {
 		if session.Harness != domain.HarnessPi || session.IsTerminated ||
-			session.Activity.State == domain.ActivityExited || session.Metadata.WorkspacePath == "" {
+			session.Activity.State == domain.ActivityExited || session.Metadata.WorkspacePath == "" ||
+			startedAt.Before(session.CreatedAt.Add(-5*time.Second)) {
 			continue
 		}
 		candidate, candidateErr := filepath.EvalSymlinks(filepath.Clean(session.Metadata.WorkspacePath))
@@ -823,6 +844,15 @@ func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
 	}
 	if len(matches) != 1 {
 		return nil
+	}
+	existing, err := c.store.ListUsageBindingsForSession(ctx, matches[0].ID)
+	if err != nil {
+		return err
+	}
+	for _, binding := range existing {
+		if binding.Harness == domain.HarnessPi && binding.NativeRootID != meta.ID {
+			return nil
+		}
 	}
 	now := c.now().UTC()
 	binding, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
@@ -1233,6 +1263,7 @@ func (c *Collector) registerHookSource(
 		expectedParentID = binding.NativeRootID
 	}
 	if err := c.validateSourceAttribution(
+		ctx,
 		binding,
 		kind,
 		nativeSessionID,
@@ -1278,6 +1309,7 @@ func (c *Collector) registerSourceWithExpectedParent(
 		return false, err
 	}
 	if err := c.validateSourceAttribution(
+		ctx,
 		binding,
 		kind,
 		nativeSessionID,
@@ -1324,6 +1356,7 @@ func (c *Collector) registerSourceWithInventory(
 		return false, err
 	}
 	if err := c.validateSourceAttribution(
+		ctx,
 		binding,
 		kind,
 		nativeSessionID,
@@ -1838,6 +1871,7 @@ func (c *Collector) validateSourcePath(ctx context.Context, harness domain.Agent
 }
 
 func validateSourceAttribution(
+	ctx context.Context,
 	binding domain.UsageBindingRecord,
 	kind domain.UsageSourceKind,
 	nativeSessionID string,
@@ -1891,7 +1925,7 @@ func validateSourceAttribution(
 			return rejected()
 		}
 	case domain.UsageSourcePiSession:
-		meta, ok := readPiSessionMeta(resolved)
+		meta, ok := readPiSessionMeta(ctx, resolved)
 		if binding.Harness != domain.HarnessPi || nativeSessionID != binding.NativeRootID ||
 			subagentID != "" || !ok || meta.ID != nativeSessionID {
 			return rejected()
@@ -1903,6 +1937,7 @@ func validateSourceAttribution(
 }
 
 func (c *Collector) validateSourceAttribution(
+	ctx context.Context,
 	binding domain.UsageBindingRecord,
 	kind domain.UsageSourceKind,
 	nativeSessionID string,
@@ -1911,6 +1946,7 @@ func (c *Collector) validateSourceAttribution(
 	expectedParentID string,
 ) error {
 	if err := validateSourceAttribution(
+		ctx,
 		binding,
 		kind,
 		nativeSessionID,
@@ -2093,12 +2129,24 @@ func (c *Collector) discoverKimiPath(ctx context.Context, nativeID string) (stri
 }
 
 type piSessionMeta struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
-	CWD  string `json:"cwd"`
+	Type      string `json:"type"`
+	ID        string `json:"id"`
+	Timestamp string `json:"timestamp"`
+	CWD       string `json:"cwd"`
 }
 
-func readPiSessionMeta(path string) (piSessionMeta, bool) {
+func piSessionStartedAt(meta piSessionMeta) (time.Time, bool) {
+	startedAt, err := time.Parse(time.RFC3339Nano, meta.Timestamp)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return startedAt.UTC(), true
+}
+
+func readPiSessionMeta(ctx context.Context, path string) (piSessionMeta, bool) {
+	if ctx.Err() != nil {
+		return piSessionMeta{}, false
+	}
 	file, err := os.Open(path) //nolint:gosec // validated provider-owned path.
 	if err != nil {
 		return piSessionMeta{}, false
@@ -2107,6 +2155,9 @@ func readPiSessionMeta(path string) (piSessionMeta, bool) {
 	reader := bufio.NewReader(io.LimitReader(file, 64<<10))
 	line, err := reader.ReadBytes('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
+		return piSessionMeta{}, false
+	}
+	if ctx.Err() != nil {
 		return piSessionMeta{}, false
 	}
 	var meta piSessionMeta
@@ -2126,7 +2177,7 @@ func (c *Collector) discoverPiPath(ctx context.Context, nativeID string) (string
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
-		if meta, ok := readPiSessionMeta(path); ok && meta.ID == nativeID {
+		if meta, ok := readPiSessionMeta(ctx, path); ok && meta.ID == nativeID {
 			return path, nil
 		}
 	}

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -63,6 +64,7 @@ type SourceRoots struct {
 	CodexSessions  string
 	CodexArchived  string
 	KimiHome       string
+	PiSessions     string
 }
 
 // DefaultSourceRoots resolves provider-owned transcript directories. dataDir
@@ -82,11 +84,16 @@ func DefaultSourceRoots(ctx context.Context, dataDir string) (SourceRoots, error
 	if strings.TrimSpace(dataDir) == "" {
 		dataDir = filepath.Join(home, ".ao", "data")
 	}
+	piHome := strings.TrimSpace(os.Getenv("PI_CODING_AGENT_DIR"))
+	if piHome == "" {
+		piHome = filepath.Join(home, ".pi", "agent")
+	}
 	return SourceRoots{
 		ClaudeProjects: filepath.Join(home, ".claude", "projects"),
 		CodexSessions:  filepath.Join(codexHome, "sessions"),
 		CodexArchived:  filepath.Join(codexHome, "archived_sessions"),
 		KimiHome:       filepath.Join(dataDir, "kimi"),
+		PiSessions:     filepath.Join(piHome, "sessions"),
 	}, nil
 }
 
@@ -208,9 +215,29 @@ func (c *Collector) ReactivateSession(
 	sessionID domain.SessionID,
 	expectedRuntimeLaunchID string,
 ) error {
-	c.mu.Lock()
+	if !c.mu.TryLock() {
+		go func() {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			if err := c.reactivateSessionLocked(context.WithoutCancel(ctx), sessionID, expectedRuntimeLaunchID); err != nil {
+				slog.Default().Warn(
+					"usage: reactivate session after concurrent finalization",
+					"session", sessionID,
+					"err", err,
+				)
+			}
+		}()
+		return nil
+	}
 	defer c.mu.Unlock()
+	return c.reactivateSessionLocked(ctx, sessionID, expectedRuntimeLaunchID)
+}
 
+func (c *Collector) reactivateSessionLocked(
+	ctx context.Context,
+	sessionID domain.SessionID,
+	expectedRuntimeLaunchID string,
+) error {
 	session, ok, err := c.store.GetSession(ctx, sessionID)
 	if err != nil {
 		return err
@@ -243,6 +270,10 @@ func (c *Collector) ReactivateSession(
 		}
 	} else if nativeID != "" && nativeUsageIDPattern.MatchString(nativeID) {
 		if err := c.backfillSession(ctx, session, nativeID); err != nil {
+			return err
+		}
+	} else if session.Harness == domain.HarnessPi {
+		if err := c.backfillPiPaths(ctx); err != nil {
 			return err
 		}
 	} else {
@@ -280,7 +311,7 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 		}
 	}
 	if signal.NativeSessionID != "" && mainPath == "" &&
-		(session.Harness == domain.HarnessCodex || session.Harness == domain.HarnessKimi ||
+		(session.Harness == domain.HarnessCodex || session.Harness == domain.HarnessKimi || session.Harness == domain.HarnessPi ||
 			finalizing && !existsForDiscovery) {
 		mainPath, err = c.discoverPath(ctx, session.Harness, signal.NativeSessionID)
 		if err != nil {
@@ -534,6 +565,12 @@ func (c *Collector) BackfillActive(ctx context.Context) error {
 			continue
 		}
 		nativeID := usageNativeSessionID(session)
+		if nativeID == "" && session.Harness == domain.HarnessPi {
+			if err := c.backfillPiPaths(ctx); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
 		if nativeID == "" || !nativeUsageIDPattern.MatchString(nativeID) {
 			continue
 		}
@@ -557,6 +594,23 @@ func usageNativeSessionID(session domain.SessionRecord) string {
 		nativeID = session.Metadata.ProviderConversationID
 	}
 	return boundedUsageMetadata(nativeID)
+}
+
+func (c *Collector) backfillPiPaths(ctx context.Context) error {
+	paths, err := newestPiPaths(ctx, c.roots.PiSessions, 256)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := c.reconcilePiPath(ctx, path); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (c *Collector) backfillSession(ctx context.Context, session domain.SessionRecord, nativeID string) error {
@@ -657,6 +711,10 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	var errs []error
+	if err := c.backfillPiPaths(ctx); err != nil {
+		errs = append(errs, err)
+	}
 	if limit == 0 {
 		limit = defaultDiscoveryLimit
 	}
@@ -665,7 +723,6 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 		return err
 	}
 	now := c.now().UTC()
-	var errs []error
 	for _, binding := range bindings {
 		if err := c.reconcileBinding(ctx, binding, now); err != nil {
 			errs = append(errs, err)
@@ -679,6 +736,9 @@ func (c *Collector) ReconcileSources(ctx context.Context, limit int64) error {
 func (c *Collector) ReconcilePath(ctx context.Context, path string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if pathWithinRoot(ctx, path, c.roots.PiSessions) {
+		return c.reconcilePiPath(ctx, path)
+	}
 
 	resolved, _, _, err := c.validateSourcePath(ctx, domain.HarnessCodex, path)
 	if err != nil {
@@ -731,6 +791,57 @@ func (c *Collector) ReconcilePath(ctx context.Context, path string) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (c *Collector) reconcilePiPath(ctx context.Context, path string) error {
+	resolved, _, _, err := c.validateSourcePath(ctx, domain.HarnessPi, path)
+	if err != nil {
+		return nil //nolint:nilerr // Watch notifications may target another provider.
+	}
+	meta, ok := readPiSessionMeta(resolved)
+	if !ok {
+		return nil
+	}
+	workspace, err := filepath.EvalSymlinks(filepath.Clean(meta.CWD))
+	if err != nil {
+		return nil //nolint:nilerr // Ignore stale provider metadata.
+	}
+	sessions, err := c.store.ListAllSessions(ctx)
+	if err != nil {
+		return err
+	}
+	matches := make([]domain.SessionRecord, 0, 1)
+	for _, session := range sessions {
+		if session.Harness != domain.HarnessPi || session.IsTerminated ||
+			session.Activity.State == domain.ActivityExited || session.Metadata.WorkspacePath == "" {
+			continue
+		}
+		candidate, candidateErr := filepath.EvalSymlinks(filepath.Clean(session.Metadata.WorkspacePath))
+		if candidateErr == nil && candidate == workspace {
+			matches = append(matches, session)
+		}
+	}
+	if len(matches) != 1 {
+		return nil
+	}
+	now := c.now().UTC()
+	binding, err := c.store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
+		SessionID: matches[0].ID, Harness: domain.HarnessPi, NativeRootID: meta.ID,
+		State: domain.UsageBindingActive, UpdatedAt: now,
+	})
+	if err != nil {
+		return err
+	}
+	changed, err := c.registerSource(
+		ctx, binding, domain.UsageSourcePiSession, meta.ID, "", resolved, now, false,
+	)
+	if err != nil {
+		return err
+	}
+	if changed {
+		c.notifySourceInventory(false)
+	}
+	return nil
 }
 
 func (c *Collector) reconcileRetiredCodexClaims(
@@ -1779,6 +1890,12 @@ func validateSourceAttribution(
 			filepath.Base(sessionDir) != binding.NativeRootID || subagentID != wantSubagent {
 			return rejected()
 		}
+	case domain.UsageSourcePiSession:
+		meta, ok := readPiSessionMeta(resolved)
+		if binding.Harness != domain.HarnessPi || nativeSessionID != binding.NativeRootID ||
+			subagentID != "" || !ok || meta.ID != nativeSessionID {
+			return rejected()
+		}
 	default:
 		return rejected()
 	}
@@ -1826,6 +1943,8 @@ func (c *Collector) allowedRoots(harness domain.AgentHarness) []string {
 		return []string{c.roots.CodexSessions, c.roots.CodexArchived}
 	case domain.HarnessKimi:
 		return []string{c.roots.KimiHome}
+	case domain.HarnessPi:
+		return []string{c.roots.PiSessions}
 	default:
 		return nil
 	}
@@ -1839,6 +1958,8 @@ func sourceKindForHarness(harness domain.AgentHarness) (domain.UsageSourceKind, 
 		return domain.UsageSourceCodexRollout, true
 	case domain.HarnessKimi:
 		return domain.UsageSourceKimiWire, true
+	case domain.HarnessPi:
+		return domain.UsageSourcePiSession, true
 	default:
 		return "", false
 	}
@@ -1888,6 +2009,8 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		return c.discoverCodexPath(ctx, nativeID, "")
 	case domain.HarnessKimi:
 		return c.discoverKimiPath(ctx, nativeID)
+	case domain.HarnessPi:
+		return c.discoverPiPath(ctx, nativeID)
 	}
 	type candidate struct {
 		path string
@@ -1967,6 +2090,81 @@ func (c *Collector) discoverKimiPath(ctx context.Context, nativeID string) (stri
 	}
 	sort.Strings(paths)
 	return paths[0], nil
+}
+
+type piSessionMeta struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	CWD  string `json:"cwd"`
+}
+
+func readPiSessionMeta(path string) (piSessionMeta, bool) {
+	file, err := os.Open(path) //nolint:gosec // validated provider-owned path.
+	if err != nil {
+		return piSessionMeta{}, false
+	}
+	defer func() { _ = file.Close() }()
+	reader := bufio.NewReader(io.LimitReader(file, 64<<10))
+	line, err := reader.ReadBytes('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return piSessionMeta{}, false
+	}
+	var meta piSessionMeta
+	if json.Unmarshal(bytes.TrimSpace(line), &meta) != nil || meta.Type != "session" ||
+		!nativeUsageIDPattern.MatchString(meta.ID) || !filepath.IsAbs(meta.CWD) {
+		return piSessionMeta{}, false
+	}
+	return meta, true
+}
+
+func (c *Collector) discoverPiPath(ctx context.Context, nativeID string) (string, error) {
+	paths, err := newestPiPaths(ctx, c.roots.PiSessions, 256)
+	if err != nil {
+		return "", err
+	}
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if meta, ok := readPiSessionMeta(path); ok && meta.ID == nativeID {
+			return path, nil
+		}
+	}
+	return "", nil
+}
+
+func newestPiPaths(ctx context.Context, root string, limit int) ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(root, "*", "*.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	type candidate struct {
+		path string
+		mod  time.Time
+	}
+	candidates := make([]candidate, 0, len(paths))
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if info, statErr := os.Stat(path); statErr == nil && info.Mode().IsRegular() {
+			candidates = append(candidates, candidate{path: path, mod: info.ModTime()})
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].mod.Equal(candidates[j].mod) {
+			return candidates[i].path > candidates[j].path
+		}
+		return candidates[i].mod.After(candidates[j].mod)
+	})
+	if limit > 0 && len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	result := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, candidate.path)
+	}
+	return result, nil
 }
 
 func (c *Collector) discoverCodexPath(ctx context.Context, nativeID, parentID string) (string, error) {

--- a/backend/internal/service/usage/collector_pi_test.go
+++ b/backend/internal/service/usage/collector_pi_test.go
@@ -2,11 +2,8 @@ package usage
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
@@ -50,19 +47,16 @@ func TestCollectorDiscoversPiSessionByHeaderID(t *testing.T) {
 	}
 }
 
-func TestCollectorReconcilePiPathMatchesLiveWorkspace(t *testing.T) {
+func TestCollectorReconcilePiPathMatchesDurableNativeID(t *testing.T) {
 	const nativeID = "pi-session-from-header"
 	store := collectorTestStore(t)
 	workspace := t.TempDir()
-	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session := collectorTestSession(t, store, domain.HarnessPi, nativeID, false)
 	session.Metadata.WorkspacePath = workspace
 	mustNoError(t, store.UpdateSession(context.Background(), session))
 	root := t.TempDir()
 	path := filepath.Join(root, "project", "session.jsonl")
-	writeUsageFixture(t, path, fmt.Sprintf(
-		`{"type":"session","id":%q,"timestamp":%q,"cwd":%q,"version":3}`+"\n",
-		nativeID, session.CreatedAt.Add(time.Second).Format(time.RFC3339Nano), workspace,
-	))
+	writeUsageFixture(t, path, `{"type":"session","id":"`+nativeID+`","cwd":"`+workspace+`","version":3}`+"\n")
 
 	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
 	mustNoError(t, collector.ReconcilePath(context.Background(), path))
@@ -72,32 +66,29 @@ func TestCollectorReconcilePiPathMatchesLiveWorkspace(t *testing.T) {
 	}
 }
 
-// TestCollectorPiBackfillBindsOnlyCurrentWorkspaceSession catches importing
-// every historical Pi file merely because it shares the live AO workspace.
-func TestCollectorPiBackfillBindsOnlyCurrentWorkspaceSession(t *testing.T) {
+// TestCollectorPiBackfillRejectsUnrelatedSameWorkspaceSession catches binding
+// a later manual Pi invocation merely because it shares the live AO workspace.
+func TestCollectorPiBackfillRejectsUnrelatedSameWorkspaceSession(t *testing.T) {
 	store := collectorTestStore(t)
 	workspace := t.TempDir()
-	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session := collectorTestSession(t, store, domain.HarnessPi, "pi-current", false)
 	session.Metadata.WorkspacePath = workspace
 	mustNoError(t, store.UpdateSession(context.Background(), session))
 
 	root := t.TempDir()
-	oldPath := filepath.Join(root, "project", "old.jsonl")
 	currentPath := filepath.Join(root, "project", "current.jsonl")
-	writeUsageFixture(t, oldPath, fmt.Sprintf(
-		`{"type":"session","id":"pi-old","timestamp":%q,"cwd":%q,"version":3}`+"\n",
-		session.CreatedAt.Add(-time.Hour).Format(time.RFC3339Nano), workspace,
-	))
-	writeUsageFixture(t, currentPath, fmt.Sprintf(
-		`{"type":"session","id":"pi-current","timestamp":%q,"cwd":%q,"version":3}`+"\n",
-		session.CreatedAt.Add(time.Second).Format(time.RFC3339Nano), workspace,
-	))
-	mustNoError(t, os.Chtimes(oldPath, session.CreatedAt.Add(-time.Hour), session.CreatedAt.Add(-time.Hour)))
-	mustNoError(t, os.Chtimes(currentPath, session.CreatedAt.Add(time.Second), session.CreatedAt.Add(time.Second)))
+	manualPath := filepath.Join(root, "project", "manual.jsonl")
+	writeUsageFixture(t, currentPath, `{"type":"session","id":"pi-current","cwd":"`+workspace+`","version":3}`+"\n")
+	writeUsageFixture(t, manualPath, `{"type":"session","id":"pi-manual","cwd":"`+workspace+`","version":3}`+"\n")
 
 	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
-	mustNoError(t, collector.BackfillActive(context.Background()))
+	mustNoError(t, collector.ReconcilePath(context.Background(), manualPath))
 	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 0 {
+		t.Fatalf("manual same-workspace path created bindings=%+v err=%v", bindings, err)
+	}
+	mustNoError(t, collector.BackfillActive(context.Background()))
+	bindings, err = store.ListUsageBindingsForSession(context.Background(), session.ID)
 	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-current" {
 		t.Fatalf("bindings=%+v err=%v, want only current Pi session", bindings, err)
 	}

--- a/backend/internal/service/usage/collector_pi_test.go
+++ b/backend/internal/service/usage/collector_pi_test.go
@@ -1,0 +1,70 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestDefaultSourceRootsIncludesPiSessions(t *testing.T) {
+	home := t.TempDir()
+	piHome := filepath.Join(home, "custom-pi")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("PI_CODING_AGENT_DIR", piHome)
+
+	got, err := DefaultSourceRoots(context.Background())
+	mustNoError(t, err)
+	if got.PiSessions != filepath.Join(piHome, "sessions") {
+		t.Fatalf("Pi sessions = %q, want %q", got.PiSessions, filepath.Join(piHome, "sessions"))
+	}
+}
+
+// TestCollectorDiscoversPiSessionByHeaderID catches filename-only discovery:
+// Pi's native session identity lives in the first JSONL record.
+func TestCollectorDiscoversPiSessionByHeaderID(t *testing.T) {
+	const nativeID = "pi-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessPi, nativeID, false)
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "session.jsonl")
+	writeUsageFixture(t, path, `{"type":"session","id":"`+nativeID+`","cwd":"/repo","version":3}`+"\n")
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessPi, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourcePiSession ||
+		sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorReconcilePiPathMatchesLiveWorkspace(t *testing.T) {
+	const nativeID = "pi-session-from-header"
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session.Metadata.WorkspacePath = workspace
+	mustNoError(t, store.UpdateSession(context.Background(), session))
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "session.jsonl")
+	writeUsageFixture(t, path, fmt.Sprintf(
+		`{"type":"session","id":%q,"cwd":%q,"version":3}`+"\n", nativeID, workspace,
+	))
+
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+	mustNoError(t, collector.ReconcilePath(context.Background(), path))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != nativeID {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}

--- a/backend/internal/service/usage/collector_pi_test.go
+++ b/backend/internal/service/usage/collector_pi_test.go
@@ -10,15 +10,14 @@ import (
 
 func TestDefaultSourceRootsIncludesPiSessions(t *testing.T) {
 	home := t.TempDir()
-	piHome := filepath.Join(home, "custom-pi")
+	dataDir := filepath.Join(home, "ao-data")
 	t.Setenv("HOME", home)
 	t.Setenv("CODEX_HOME", "")
-	t.Setenv("PI_CODING_AGENT_DIR", piHome)
 
-	got, err := DefaultSourceRoots(context.Background(), "")
+	got, err := DefaultSourceRoots(context.Background(), dataDir)
 	mustNoError(t, err)
-	if got.PiSessions != filepath.Join(piHome, "sessions") {
-		t.Fatalf("Pi sessions = %q, want %q", got.PiSessions, filepath.Join(piHome, "sessions"))
+	if got.PiSessions != filepath.Join(dataDir, "pi", "sessions") {
+		t.Fatalf("Pi sessions = %q, want %q", got.PiSessions, filepath.Join(dataDir, "pi", "sessions"))
 	}
 }
 
@@ -44,6 +43,31 @@ func TestCollectorDiscoversPiSessionByHeaderID(t *testing.T) {
 	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourcePiSession ||
 		sources[0].ArtifactPath != canonicalUsagePath(t, path) {
 		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorReconcilesPiTranscriptCreatedAfterHook(t *testing.T) {
+	const nativeID = "pi-late-session"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessPi, nativeID, false)
+	root := t.TempDir()
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessPi, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].LastErrorCode != domain.UsageErrorSourceDiscoveryPending {
+		t.Fatalf("binding before transcript = %+v, err=%v", bindings, err)
+	}
+	path := filepath.Join(root, "project", "session.jsonl")
+	writeUsageFixture(t, path, `{"type":"session","id":"`+nativeID+`","cwd":"/repo","version":3}`+"\n")
+
+	mustNoError(t, collector.ReconcileSources(context.Background(), 8))
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourcePiSession ||
+		sources[0].ArtifactPath != canonicalUsagePath(t, path) {
+		t.Fatalf("sources after late transcript = %+v, err=%v", sources, err)
 	}
 }
 

--- a/backend/internal/service/usage/collector_pi_test.go
+++ b/backend/internal/service/usage/collector_pi_test.go
@@ -15,7 +15,7 @@ func TestDefaultSourceRootsIncludesPiSessions(t *testing.T) {
 	t.Setenv("CODEX_HOME", "")
 	t.Setenv("PI_CODING_AGENT_DIR", piHome)
 
-	got, err := DefaultSourceRoots(context.Background())
+	got, err := DefaultSourceRoots(context.Background(), "")
 	mustNoError(t, err)
 	if got.PiSessions != filepath.Join(piHome, "sessions") {
 		t.Fatalf("Pi sessions = %q, want %q", got.PiSessions, filepath.Join(piHome, "sessions"))
@@ -102,24 +102,5 @@ func TestReadPiSessionMetaHonorsCanceledContext(t *testing.T) {
 
 	if _, ok := readPiSessionMeta(ctx, path); ok {
 		t.Fatal("canceled Pi metadata read succeeded")
-	}
-}
-
-func TestSourceKindForHarness(t *testing.T) {
-	tests := []struct {
-		harness domain.AgentHarness
-		want    domain.UsageSourceKind
-		ok      bool
-	}{
-		{harness: domain.HarnessClaudeCode, want: domain.UsageSourceClaudeMain, ok: true},
-		{harness: domain.HarnessCodex, want: domain.UsageSourceCodexRollout, ok: true},
-		{harness: domain.HarnessPi, want: domain.UsageSourcePiSession, ok: true},
-		{harness: domain.HarnessAider, ok: false},
-	}
-	for _, tt := range tests {
-		got, ok := sourceKindForHarness(tt.harness)
-		if got != tt.want || ok != tt.ok {
-			t.Fatalf("sourceKindForHarness(%q) = %q, %v; want %q, %v", tt.harness, got, ok, tt.want, tt.ok)
-		}
 	}
 }

--- a/backend/internal/service/usage/collector_pi_test.go
+++ b/backend/internal/service/usage/collector_pi_test.go
@@ -3,8 +3,10 @@ package usage
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
@@ -58,7 +60,8 @@ func TestCollectorReconcilePiPathMatchesLiveWorkspace(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "project", "session.jsonl")
 	writeUsageFixture(t, path, fmt.Sprintf(
-		`{"type":"session","id":%q,"cwd":%q,"version":3}`+"\n", nativeID, workspace,
+		`{"type":"session","id":%q,"timestamp":%q,"cwd":%q,"version":3}`+"\n",
+		nativeID, session.CreatedAt.Add(time.Second).Format(time.RFC3339Nano), workspace,
 	))
 
 	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
@@ -66,5 +69,66 @@ func TestCollectorReconcilePiPathMatchesLiveWorkspace(t *testing.T) {
 	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
 	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != nativeID {
 		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+}
+
+// TestCollectorPiBackfillBindsOnlyCurrentWorkspaceSession catches importing
+// every historical Pi file merely because it shares the live AO workspace.
+func TestCollectorPiBackfillBindsOnlyCurrentWorkspaceSession(t *testing.T) {
+	store := collectorTestStore(t)
+	workspace := t.TempDir()
+	session := collectorTestSession(t, store, domain.HarnessPi, "", false)
+	session.Metadata.WorkspacePath = workspace
+	mustNoError(t, store.UpdateSession(context.Background(), session))
+
+	root := t.TempDir()
+	oldPath := filepath.Join(root, "project", "old.jsonl")
+	currentPath := filepath.Join(root, "project", "current.jsonl")
+	writeUsageFixture(t, oldPath, fmt.Sprintf(
+		`{"type":"session","id":"pi-old","timestamp":%q,"cwd":%q,"version":3}`+"\n",
+		session.CreatedAt.Add(-time.Hour).Format(time.RFC3339Nano), workspace,
+	))
+	writeUsageFixture(t, currentPath, fmt.Sprintf(
+		`{"type":"session","id":"pi-current","timestamp":%q,"cwd":%q,"version":3}`+"\n",
+		session.CreatedAt.Add(time.Second).Format(time.RFC3339Nano), workspace,
+	))
+	mustNoError(t, os.Chtimes(oldPath, session.CreatedAt.Add(-time.Hour), session.CreatedAt.Add(-time.Hour)))
+	mustNoError(t, os.Chtimes(currentPath, session.CreatedAt.Add(time.Second), session.CreatedAt.Add(time.Second)))
+
+	collector := NewCollector(store, SourceRoots{PiSessions: root}, nil)
+	mustNoError(t, collector.BackfillActive(context.Background()))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 || bindings[0].NativeRootID != "pi-current" {
+		t.Fatalf("bindings=%+v err=%v, want only current Pi session", bindings, err)
+	}
+}
+
+func TestReadPiSessionMetaHonorsCanceledContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	writeUsageFixture(t, path, `{"type":"session","id":"pi-context","timestamp":"2026-08-24T10:00:00Z","cwd":"/repo","version":3}`+"\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, ok := readPiSessionMeta(ctx, path); ok {
+		t.Fatal("canceled Pi metadata read succeeded")
+	}
+}
+
+func TestSourceKindForHarness(t *testing.T) {
+	tests := []struct {
+		harness domain.AgentHarness
+		want    domain.UsageSourceKind
+		ok      bool
+	}{
+		{harness: domain.HarnessClaudeCode, want: domain.UsageSourceClaudeMain, ok: true},
+		{harness: domain.HarnessCodex, want: domain.UsageSourceCodexRollout, ok: true},
+		{harness: domain.HarnessPi, want: domain.UsageSourcePiSession, ok: true},
+		{harness: domain.HarnessAider, ok: false},
+	}
+	for _, tt := range tests {
+		got, ok := sourceKindForHarness(tt.harness)
+		if got != tt.want || ok != tt.ok {
+			t.Fatalf("sourceKindForHarness(%q) = %q, %v; want %q, %v", tt.harness, got, ok, tt.want, tt.ok)
+		}
 	}
 }

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -2071,6 +2071,7 @@ func TestSourceKindForHarness(t *testing.T) {
 		{harness: domain.HarnessClaudeCode, want: domain.UsageSourceClaudeMain, ok: true},
 		{harness: domain.HarnessCodex, want: domain.UsageSourceCodexRollout, ok: true},
 		{harness: domain.HarnessKimi, want: domain.UsageSourceKimiWire, ok: true},
+		{harness: domain.HarnessPi, want: domain.UsageSourcePiSession, ok: true},
 		{harness: domain.HarnessAider, ok: false},
 	}
 	for _, tt := range tests {

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -590,7 +590,7 @@ func TestCollectorReactivateSessionWaitsForLockAndHonorsCancellation(t *testing.
 	collector := NewCollector(store, SourceRoots{}, nil)
 
 	t.Run("waits and reports completion", func(t *testing.T) {
-		collector.mu.Lock()
+		mustNoError(t, collector.mu.LockContext(context.Background()))
 		done := make(chan error, 1)
 		go func() {
 			done <- collector.ReactivateSession(context.Background(), session.ID, "launch-current")
@@ -606,7 +606,7 @@ func TestCollectorReactivateSessionWaitsForLockAndHonorsCancellation(t *testing.
 	})
 
 	t.Run("canceled waiter returns context error", func(t *testing.T) {
-		collector.mu.Lock()
+		mustNoError(t, collector.mu.LockContext(context.Background()))
 		defer collector.mu.Unlock()
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -614,6 +614,31 @@ func TestCollectorReactivateSessionWaitsForLockAndHonorsCancellation(t *testing.
 			t.Fatalf("ReactivateSession error = %v, want context.Canceled", err)
 		}
 	})
+}
+
+func TestCollectorFinalizeSessionHonorsCancellationWhileWaitingForLock(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCodex, "native-contended", false)
+	collector := NewCollector(store, SourceRoots{}, nil)
+	mustNoError(t, collector.mu.LockContext(context.Background()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- collector.FinalizeSession(ctx, session.ID, "", time.Time{})
+	}()
+	select {
+	case err := <-done:
+		collector.mu.Unlock()
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("FinalizeSession error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		collector.mu.Unlock()
+		<-done
+		t.Fatal("FinalizeSession did not observe cancellation while waiting for collector lock")
+	}
 }
 
 func TestCollectorHookLifecycleTransitions(t *testing.T) {

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -581,6 +582,40 @@ func TestCollectorReactivateSessionRejectsStaleLaunch(t *testing.T) {
 	}
 }
 
+func TestCollectorReactivateSessionWaitsForLockAndHonorsCancellation(t *testing.T) {
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessCodex, "native-contended", false)
+	session.Metadata.RuntimeLaunchID = "launch-current"
+	mustNoError(t, store.UpdateSession(context.Background(), session))
+	collector := NewCollector(store, SourceRoots{}, nil)
+
+	t.Run("waits and reports completion", func(t *testing.T) {
+		collector.mu.Lock()
+		done := make(chan error, 1)
+		go func() {
+			done <- collector.ReactivateSession(context.Background(), session.ID, "launch-current")
+		}()
+		select {
+		case err := <-done:
+			collector.mu.Unlock()
+			t.Fatalf("reactivation returned before serialized work ran: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+		collector.mu.Unlock()
+		mustNoError(t, <-done)
+	})
+
+	t.Run("canceled waiter returns context error", func(t *testing.T) {
+		collector.mu.Lock()
+		defer collector.mu.Unlock()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := collector.ReactivateSession(ctx, session.ID, "launch-current"); !errors.Is(err, context.Canceled) {
+			t.Fatalf("ReactivateSession error = %v, want context.Canceled", err)
+		}
+	})
+}
+
 func TestCollectorHookLifecycleTransitions(t *testing.T) {
 	complete, active := domain.UsageSourceComplete, domain.UsageSourceActive
 	tests := []struct {
@@ -751,7 +786,6 @@ func TestCollectorCurrentActivityReactivatesBindingDuringReaperFinalization(t *t
 		t.Fatalf("binding during finalization=%s, want finalizing", during.State)
 	}
 
-	activityApplied := make(chan struct{})
 	hookDone := make(chan error, 1)
 	go func() {
 		err := manager.ApplyActivitySignal(context.Background(), session.ID, ports.ActivitySignal{
@@ -762,7 +796,6 @@ func TestCollectorCurrentActivityReactivatesBindingDuringReaperFinalization(t *t
 			AgentSessionID: "native-race",
 			LaunchID:       "launch-current",
 		})
-		close(activityApplied)
 		if err == nil {
 			err = collector.RecordHook(context.Background(), session.ID, HookSignal{
 				Event:           "post-tool-use",
@@ -772,10 +805,19 @@ func TestCollectorCurrentActivityReactivatesBindingDuringReaperFinalization(t *t
 		}
 		hookDone <- err
 	}()
-	select {
-	case <-activityApplied:
-	case <-time.After(2 * time.Second):
-		t.Fatal("current activity did not persist while finalizer was blocked")
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		persisted, ok, err := store.GetSession(context.Background(), session.ID)
+		if err != nil || !ok {
+			t.Fatalf("session during contention ok=%v err=%v", ok, err)
+		}
+		if persisted.Activity.State == domain.ActivityActive {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("current activity did not persist while finalizer was blocked")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 	close(release)
 	mustNoError(t, <-reaperDone)

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -4265,7 +4265,10 @@ func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, wo
 	ref := ports.SessionRef{
 		ID:            string(id),
 		WorkspacePath: workspacePath,
-		Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: meta.AgentSessionID},
+		Metadata: map[string]string{
+			ports.MetadataKeyAgentSessionID:       meta.AgentSessionID,
+			ports.MetadataKeyNativeTranscriptPath: meta.NativeTranscriptPath,
+		},
 	}
 	cmd, ok, err := agent.GetRestoreCommand(ctx, ports.RestoreConfig{Session: ref, Kind: kind, DataDir: dataDir, SystemPrompt: systemPrompt, SystemPromptFile: systemPromptFile, Config: agentConfig, Permissions: agentConfig.Permissions})
 	if err != nil {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -4266,7 +4266,10 @@ func TestRestore_OrchestratorRederivesSystemPrompt(t *testing.T) {
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: cfg}
 	st.sessions["mer-1"] = domain.SessionRecord{
 		ID: "mer-1", ProjectID: "mer", Kind: domain.KindOrchestrator, IsTerminated: true,
-		Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x"},
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x",
+			NativeTranscriptPath: "/ao/data/pi/sessions/agent-x.jsonl",
+		},
 	}
 	agent := &recordingAgent{}
 	dataDir := t.TempDir()
@@ -4281,6 +4284,9 @@ func TestRestore_OrchestratorRederivesSystemPrompt(t *testing.T) {
 	}
 	if !strings.Contains(agent.lastRestore.SystemPrompt, "Use workers for implementation.") {
 		t.Fatalf("restore system prompt missing project rules:\n%s", agent.lastRestore.SystemPrompt)
+	}
+	if got := agent.lastRestore.Session.Metadata[ports.MetadataKeyNativeTranscriptPath]; got != "/ao/data/pi/sessions/agent-x.jsonl" {
+		t.Fatalf("restore transcript path = %q", got)
 	}
 	wantPath := filepath.Join(dataDir, "prompts", "mer-1", "system.md")
 	if agent.lastRestore.SystemPromptFile != wantPath {

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -520,6 +520,19 @@ SELECT CAST(EXISTS (
                 )
           )
       )
+) OR EXISTS (
+    SELECT 1
+    FROM sessions s
+    WHERE s.is_terminated = 0
+      AND s.activity_state <> 'exited'
+      AND s.harness = 'pi'
+      AND trim(s.workspace_path) <> ''
+      AND NOT EXISTS (
+          SELECT 1
+          FROM usage_bindings ub
+          WHERE ub.session_id = s.id
+            AND ub.harness = 'pi'
+      )
 ) AS INTEGER)
 `
 

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -494,11 +494,20 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex', 'kimi')
+      AND ub.harness IN ('claude-code', 'codex', 'kimi', 'pi')
       AND (
           ub.harness = 'kimi'
           OR ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
+          OR (
+              ub.harness = 'pi'
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM usage_sources source
+                  WHERE source.binding_id = ub.id
+                    AND source.kind = 'pi_session'
+              )
+          )
           OR EXISTS (
               SELECT 1
               FROM usage_codex_pending_children pending
@@ -1148,7 +1157,7 @@ SELECT ub.id, ub.session_id, ub.harness, ub.native_root_id, ub.initial_model_id,
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex', 'kimi')
+  AND ub.harness IN ('claude-code', 'codex', 'kimi', 'pi')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
@@ -1159,17 +1168,26 @@ WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'
       OR ub.last_error_code = 'source_discovery_pending'
-      OR NOT EXISTS (
+      OR (ub.harness = 'codex' AND NOT EXISTS (
           SELECT 1
           FROM usage_sources us
           WHERE us.binding_id = ub.id
             AND us.kind = 'codex_rollout'
-      )
+      ))
+      OR (ub.harness = 'pi' AND NOT EXISTS (
+          SELECT 1
+          FROM usage_sources us
+          WHERE us.binding_id = ub.id
+            AND us.kind = 'pi_session'
+      ))
       OR EXISTS (
           SELECT 1
           FROM usage_sources us
           WHERE us.binding_id = ub.id
-            AND us.kind = 'codex_rollout'
+            AND (
+                ub.harness = 'codex' AND us.kind = 'codex_rollout'
+                OR ub.harness = 'pi' AND us.kind = 'pi_session'
+            )
             AND us.state = 'error'
             AND us.last_error_code IN ('artifact_missing', 'source_read_failed')
       )

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -526,7 +526,11 @@ SELECT CAST(EXISTS (
     WHERE s.is_terminated = 0
       AND s.activity_state <> 'exited'
       AND s.harness = 'pi'
-      AND trim(s.workspace_path) <> ''
+      AND trim(s.agent_session_id) <> ''
+      AND (
+          trim(s.runtime_launch_id) = ''
+          OR s.agent_session_id_launch_id = s.runtime_launch_id
+      )
       AND NOT EXISTS (
           SELECT 1
           FROM usage_bindings ub

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -122,6 +122,7 @@ var shippedMigrations = map[int64]string{
 	115: "0115_usage_measurement_and_provider_usage.sql",
 	116: "0116_usage_billing_provider_source.sql",
 	117: "0117_allow_kimi_usage.sql",
+	118: "0118_allow_pi_usage.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_pi_usage_test.go
+++ b/backend/internal/storage/sqlite/migrate_pi_usage_test.go
@@ -1,53 +1,128 @@
 package sqlite
 
 import (
+	"database/sql"
+	"reflect"
 	"testing"
 	"time"
 )
 
-// TestMigration0109DownPreservesKimiUsage catches rolling back Pi by deleting
-// sibling-provider usage that belongs to the still-applied Kimi migration.
-func TestMigration0109DownPreservesKimiUsage(t *testing.T) {
+// TestMigration0118AddsPiAndPreservesKimiUsage verifies the declared Kimi → Pi
+// merge order in both directions. Rebuilding the constrained collection tables
+// must preserve Kimi row IDs and events while adding and removing only Pi.
+func TestMigration0118AddsPiAndPreservesKimiUsage(t *testing.T) {
 	db := openTestDB(t)
-	upTo(t, db, 109)
-	now := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
-	if _, err := db.Exec(`INSERT INTO projects (id, path, display_name, registered_at) VALUES ('usage-migration', '/tmp/usage-migration', 'usage', ?)`, now); err != nil {
+	upTo(t, db, 117)
+	now := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
+	if _, err := db.Exec(`INSERT INTO projects (id, path, display_name, registered_at)
+		VALUES ('usage-migration', '/tmp/usage-migration', 'usage', ?)`, now); err != nil {
 		t.Fatal(err)
 	}
-	for _, harness := range []string{"kimi", "pi"} {
-		if _, err := db.Exec(`INSERT INTO sessions (id, project_id, num, kind, harness, activity_state, activity_last_at, is_terminated, created_at, updated_at) VALUES (?, 'usage-migration', ?, 'worker', ?, 'active', ?, 0, ?, ?)`, "session-"+harness, map[string]int{"kimi": 1, "pi": 2}[harness], harness, now, now, now); err != nil {
+	for number, harness := range []string{"kimi", "pi"} {
+		if _, err := db.Exec(`INSERT INTO sessions (
+			id, project_id, num, kind, harness, activity_state, activity_last_at,
+			is_terminated, created_at, updated_at
+		) VALUES (?, 'usage-migration', ?, 'worker', ?, 'active', ?, 0, ?, ?)`,
+			"session-"+harness, number+1, harness, now, now, now); err != nil {
 			t.Fatalf("seed %s session: %v", harness, err)
-		}
-		result, err := db.Exec(`INSERT INTO usage_bindings (session_id, harness, native_root_id, state, updated_at) VALUES (?, ?, ?, 'active', ?)`, "session-"+harness, harness, "native-"+harness, now)
-		if err != nil {
-			t.Fatalf("seed %s binding: %v", harness, err)
-		}
-		bindingID, _ := result.LastInsertId()
-		kind := map[string]string{"kimi": "kimi_wire", "pi": "pi_session"}[harness]
-		result, err = db.Exec(`INSERT INTO usage_sources (binding_id, kind, native_session_id, artifact_path, state, updated_at) VALUES (?, ?, ?, ?, 'active', ?)`, bindingID, kind, "native-"+harness, "/tmp/"+harness+".jsonl", now)
-		if err != nil {
-			t.Fatalf("seed %s source: %v", harness, err)
-		}
-		sourceID, _ := result.LastInsertId()
-		result, err = db.Exec(`INSERT INTO model_usage_events (binding_id, usage_source_id, provider_id, model_id, input_tokens, input_provenance, cached_input_tokens, cached_input_provenance, uncached_input_tokens, uncached_input_provenance, output_tokens, output_provenance, source_event_key, created_at) VALUES (?, ?, 'anthropic', 'model', 3, 'reported', 1, 'reported', 2, 'reported', 1, 'reported', ?, ?)`, bindingID, sourceID, "event-"+harness, now)
-		if err != nil {
-			t.Fatalf("seed %s event: %v", harness, err)
-		}
-		eventID, _ := result.LastInsertId()
-		if _, err := db.Exec(`INSERT INTO anthropic_usage_event_details (event_id, anthropic_direct_uncached_input_tokens) VALUES (?, 2)`, eventID); err != nil {
-			t.Fatalf("seed %s details: %v", harness, err)
 		}
 	}
 
-	downTo(t, db, 107)
-	var kimiEvents, piEvents int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM model_usage_events event JOIN usage_bindings binding ON binding.id = event.binding_id WHERE binding.harness = 'kimi'`).Scan(&kimiEvents); err != nil {
+	kimiBindingResult, err := db.Exec(`INSERT INTO usage_bindings (
+		session_id, harness, native_root_id, provider_hint, state, updated_at
+	) VALUES ('session-kimi', 'kimi', 'native-kimi', 'moonshot', 'active', ?)`, now)
+	if err != nil {
+		t.Fatalf("seed Kimi binding: %v", err)
+	}
+	kimiBindingID, _ := kimiBindingResult.LastInsertId()
+	kimiSourceResult, err := db.Exec(`INSERT INTO usage_sources (
+		binding_id, kind, native_session_id, artifact_path, state, updated_at
+	) VALUES (?, 'kimi_wire', 'native-kimi', '/tmp/kimi.jsonl', 'active', ?)`, kimiBindingID, now)
+	if err != nil {
+		t.Fatalf("seed Kimi source: %v", err)
+	}
+	kimiSourceID, _ := kimiSourceResult.LastInsertId()
+	kimiEventResult, err := db.Exec(`INSERT INTO model_usage_events (
+		binding_id, usage_source_id, provider_id, billing_provider_id,
+		billing_provider_source, model_id, usage_measurement_kind,
+		input_tokens, cached_input_tokens, uncached_input_tokens, output_tokens,
+		provider_usage_json, source_event_key, created_at,
+		input_cost_nanos, cached_input_cost_nanos, output_cost_nanos,
+		estimated_cost_nanos, pricing_version
+	) VALUES (?, ?, 'anthropic', 'moonshot', 'observed', 'kimi-test',
+		'native_reported', 3, 1, 2, 1, '{"input_tokens":2}', 'event-kimi', ?,
+		20, 5, 10, 35, 'catalog-v1')`, kimiBindingID, kimiSourceID, now)
+	if err != nil {
+		t.Fatalf("seed Kimi event: %v", err)
+	}
+	kimiEventID, _ := kimiEventResult.LastInsertId()
+
+	upTo(t, db, 118)
+	for table, wantColumns := range expectedUsageTableColumns {
+		if got := tableColumns(t, db, table); !reflect.DeepEqual(got, wantColumns) {
+			t.Fatalf("%s columns after Pi migration = %v, want %v", table, got, wantColumns)
+		}
+	}
+	assertKimiMigrationRows(t, db, kimiBindingID, kimiSourceID, kimiEventID)
+
+	piBindingResult, err := db.Exec(`INSERT INTO usage_bindings (
+		session_id, harness, native_root_id, state, updated_at
+	) VALUES ('session-pi', 'pi', 'native-pi', 'active', ?)`, now)
+	if err != nil {
+		t.Fatalf("seed Pi binding: %v", err)
+	}
+	piBindingID, _ := piBindingResult.LastInsertId()
+	piSourceResult, err := db.Exec(`INSERT INTO usage_sources (
+		binding_id, kind, native_session_id, artifact_path, state, updated_at
+	) VALUES (?, 'pi_session', 'native-pi', '/tmp/pi.jsonl', 'active', ?)`, piBindingID, now)
+	if err != nil {
+		t.Fatalf("seed Pi source: %v", err)
+	}
+	piSourceID, _ := piSourceResult.LastInsertId()
+	if _, err := db.Exec(`INSERT INTO model_usage_events (
+		binding_id, usage_source_id, provider_id, model_id, usage_measurement_kind,
+		input_tokens, cached_input_tokens, uncached_input_tokens, output_tokens,
+		provider_usage_json, source_event_key, created_at
+	) VALUES (?, ?, 'openai', 'gpt-test', 'native_reported', 3, 1, 2, 1,
+		'{"input":2,"cacheRead":1}', 'event-pi', ?)`, piBindingID, piSourceID, now); err != nil {
+		t.Fatalf("seed Pi event: %v", err)
+	}
+
+	downTo(t, db, 117)
+	assertKimiMigrationRows(t, db, kimiBindingID, kimiSourceID, kimiEventID)
+	var piEvents int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM model_usage_events WHERE source_event_key = 'event-pi'`).Scan(&piEvents); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.QueryRow(`SELECT COUNT(*) FROM model_usage_events event JOIN usage_bindings binding ON binding.id = event.binding_id WHERE binding.harness = 'pi'`).Scan(&piEvents); err != nil {
-		t.Fatal(err)
+	if piEvents != 0 {
+		t.Fatalf("Pi events after rollback = %d, want 0", piEvents)
 	}
-	if kimiEvents != 1 || piEvents != 0 {
-		t.Fatalf("events after Pi rollback = kimi:%d pi:%d, want 1/0", kimiEvents, piEvents)
+	if _, err := db.Exec(`INSERT INTO usage_bindings (
+		session_id, harness, native_root_id, state, updated_at
+	) VALUES ('session-pi', 'pi', 'pi-after-down', 'active', ?)`, now); err == nil {
+		t.Fatal("Pi binding remained allowed after rolling migration 0118 back")
+	}
+}
+
+func assertKimiMigrationRows(t *testing.T, db *sql.DB, bindingID, sourceID, eventID int64) {
+	t.Helper()
+	var gotBindingID, gotSourceID, gotEventID int64
+	var providerHint, sourceKind, sourceEventKey string
+	if err := db.QueryRow(`SELECT id, provider_hint FROM usage_bindings
+		WHERE native_root_id = 'native-kimi'`).Scan(&gotBindingID, &providerHint); err != nil {
+		t.Fatalf("read Kimi binding: %v", err)
+	}
+	if err := db.QueryRow(`SELECT id, kind FROM usage_sources
+		WHERE native_session_id = 'native-kimi'`).Scan(&gotSourceID, &sourceKind); err != nil {
+		t.Fatalf("read Kimi source: %v", err)
+	}
+	if err := db.QueryRow(`SELECT id, source_event_key FROM model_usage_events
+		WHERE binding_id = ? AND usage_source_id = ?`, bindingID, sourceID).Scan(&gotEventID, &sourceEventKey); err != nil {
+		t.Fatalf("read Kimi event: %v", err)
+	}
+	if gotBindingID != bindingID || gotSourceID != sourceID || gotEventID != eventID ||
+		providerHint != "moonshot" || sourceKind != "kimi_wire" || sourceEventKey != "event-kimi" {
+		t.Fatalf("Kimi rows = binding:%d source:%d event:%d provider:%q kind:%q key:%q",
+			gotBindingID, gotSourceID, gotEventID, providerHint, sourceKind, sourceEventKey)
 	}
 }

--- a/backend/internal/storage/sqlite/migrate_pi_usage_test.go
+++ b/backend/internal/storage/sqlite/migrate_pi_usage_test.go
@@ -1,0 +1,53 @@
+package sqlite
+
+import (
+	"testing"
+	"time"
+)
+
+// TestMigration0109DownPreservesKimiUsage catches rolling back Pi by deleting
+// sibling-provider usage that belongs to the still-applied Kimi migration.
+func TestMigration0109DownPreservesKimiUsage(t *testing.T) {
+	db := openTestDB(t)
+	upTo(t, db, 109)
+	now := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+	if _, err := db.Exec(`INSERT INTO projects (id, path, display_name, registered_at) VALUES ('usage-migration', '/tmp/usage-migration', 'usage', ?)`, now); err != nil {
+		t.Fatal(err)
+	}
+	for _, harness := range []string{"kimi", "pi"} {
+		if _, err := db.Exec(`INSERT INTO sessions (id, project_id, num, kind, harness, activity_state, activity_last_at, is_terminated, created_at, updated_at) VALUES (?, 'usage-migration', ?, 'worker', ?, 'active', ?, 0, ?, ?)`, "session-"+harness, map[string]int{"kimi": 1, "pi": 2}[harness], harness, now, now, now); err != nil {
+			t.Fatalf("seed %s session: %v", harness, err)
+		}
+		result, err := db.Exec(`INSERT INTO usage_bindings (session_id, harness, native_root_id, state, updated_at) VALUES (?, ?, ?, 'active', ?)`, "session-"+harness, harness, "native-"+harness, now)
+		if err != nil {
+			t.Fatalf("seed %s binding: %v", harness, err)
+		}
+		bindingID, _ := result.LastInsertId()
+		kind := map[string]string{"kimi": "kimi_wire", "pi": "pi_session"}[harness]
+		result, err = db.Exec(`INSERT INTO usage_sources (binding_id, kind, native_session_id, artifact_path, state, updated_at) VALUES (?, ?, ?, ?, 'active', ?)`, bindingID, kind, "native-"+harness, "/tmp/"+harness+".jsonl", now)
+		if err != nil {
+			t.Fatalf("seed %s source: %v", harness, err)
+		}
+		sourceID, _ := result.LastInsertId()
+		result, err = db.Exec(`INSERT INTO model_usage_events (binding_id, usage_source_id, provider_id, model_id, input_tokens, input_provenance, cached_input_tokens, cached_input_provenance, uncached_input_tokens, uncached_input_provenance, output_tokens, output_provenance, source_event_key, created_at) VALUES (?, ?, 'anthropic', 'model', 3, 'reported', 1, 'reported', 2, 'reported', 1, 'reported', ?, ?)`, bindingID, sourceID, "event-"+harness, now)
+		if err != nil {
+			t.Fatalf("seed %s event: %v", harness, err)
+		}
+		eventID, _ := result.LastInsertId()
+		if _, err := db.Exec(`INSERT INTO anthropic_usage_event_details (event_id, anthropic_direct_uncached_input_tokens) VALUES (?, 2)`, eventID); err != nil {
+			t.Fatalf("seed %s details: %v", harness, err)
+		}
+	}
+
+	downTo(t, db, 107)
+	var kimiEvents, piEvents int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM model_usage_events event JOIN usage_bindings binding ON binding.id = event.binding_id WHERE binding.harness = 'kimi'`).Scan(&kimiEvents); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM model_usage_events event JOIN usage_bindings binding ON binding.id = event.binding_id WHERE binding.harness = 'pi'`).Scan(&piEvents); err != nil {
+		t.Fatal(err)
+	}
+	if kimiEvents != 1 || piEvents != 0 {
+		t.Fatalf("events after Pi rollback = kimi:%d pi:%d, want 1/0", kimiEvents, piEvents)
+	}
+}

--- a/backend/internal/storage/sqlite/migrations/0109_allow_provider_usage.sql
+++ b/backend/internal/storage/sqlite/migrations/0109_allow_provider_usage.sql
@@ -12,7 +12,7 @@ DROP TRIGGER IF EXISTS usage_sources_cdc_update;
 CREATE TABLE usage_bindings_next (
     id                 INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
-    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex', 'kimi', 'pi', 'qwen')),
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex', 'kimi', 'pi')),
     native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
     initial_model_id   TEXT NOT NULL DEFAULT '',
     state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
@@ -26,7 +26,7 @@ CREATE TABLE usage_sources_next (
     binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
     kind                TEXT NOT NULL CHECK (kind IN (
                             'claude_main', 'claude_subagent', 'codex_rollout',
-                            'kimi_wire', 'pi_session', 'qwen_monthly'
+                            'kimi_wire', 'pi_session'
                         )),
     native_session_id   TEXT NOT NULL DEFAULT '',
     subagent_id         TEXT NOT NULL DEFAULT '',
@@ -106,23 +106,23 @@ DELETE FROM anthropic_usage_event_details
 WHERE event_id IN (
     SELECT event.id FROM model_usage_events event
     JOIN usage_bindings binding ON binding.id = event.binding_id
-    WHERE binding.harness IN ('kimi', 'pi', 'qwen')
+    WHERE binding.harness = 'pi'
 );
 DELETE FROM openai_usage_event_details
 WHERE event_id IN (
     SELECT event.id FROM model_usage_events event
     JOIN usage_bindings binding ON binding.id = event.binding_id
-    WHERE binding.harness IN ('kimi', 'pi', 'qwen')
+    WHERE binding.harness = 'pi'
 );
 DELETE FROM model_usage_events
 WHERE binding_id IN (
-    SELECT id FROM usage_bindings WHERE harness IN ('kimi', 'pi', 'qwen')
+    SELECT id FROM usage_bindings WHERE harness = 'pi'
 );
 
 CREATE TABLE usage_bindings_previous (
     id                 INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
-    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex')),
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex', 'kimi')),
     native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
     initial_model_id   TEXT NOT NULL DEFAULT '',
     state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
@@ -134,7 +134,7 @@ CREATE TABLE usage_bindings_previous (
 CREATE TABLE usage_sources_previous (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
-    kind                TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout')),
+    kind                TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout', 'kimi_wire')),
     native_session_id   TEXT NOT NULL DEFAULT '',
     subagent_id         TEXT NOT NULL DEFAULT '',
     artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
@@ -155,7 +155,7 @@ INSERT INTO usage_bindings_previous
 SELECT id, session_id, harness, native_root_id, initial_model_id,
        state, last_error_code, updated_at
 FROM usage_bindings
-WHERE harness IN ('claude-code', 'codex');
+WHERE harness IN ('claude-code', 'codex', 'kimi');
 
 INSERT INTO usage_sources_previous
 SELECT source.id, source.binding_id, source.kind, source.native_session_id,
@@ -165,7 +165,7 @@ SELECT source.id, source.binding_id, source.kind, source.native_session_id,
        source.next_retry_at, source.last_error_code, source.updated_at
 FROM usage_sources source
 JOIN usage_bindings_previous binding ON binding.id = source.binding_id
-WHERE source.kind IN ('claude_main', 'claude_subagent', 'codex_rollout');
+WHERE source.kind IN ('claude_main', 'claude_subagent', 'codex_rollout', 'kimi_wire');
 
 DROP TABLE usage_sources;
 DROP TABLE usage_bindings;

--- a/backend/internal/storage/sqlite/migrations/0109_allow_provider_usage.sql
+++ b/backend/internal/storage/sqlite/migrations/0109_allow_provider_usage.sql
@@ -1,0 +1,205 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+PRAGMA foreign_keys=OFF;
+PRAGMA legacy_alter_table=ON;
+BEGIN IMMEDIATE;
+
+DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
+DROP TRIGGER IF EXISTS usage_sources_cdc_update;
+
+CREATE TABLE usage_bindings_next (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex', 'kimi', 'pi', 'qwen')),
+    native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id   TEXT NOT NULL DEFAULT '',
+    state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code    TEXT NOT NULL DEFAULT '',
+    updated_at         TIMESTAMP NOT NULL,
+    UNIQUE (session_id, harness, native_root_id)
+);
+
+CREATE TABLE usage_sources_next (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind                TEXT NOT NULL CHECK (kind IN (
+                            'claude_main', 'claude_subagent', 'codex_rollout',
+                            'kimi_wire', 'pi_session', 'qwen_monthly'
+                        )),
+    native_session_id   TEXT NOT NULL DEFAULT '',
+    subagent_id         TEXT NOT NULL DEFAULT '',
+    artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity       TEXT NOT NULL DEFAULT '',
+    generation          INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset         INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    parser_state_json   TEXT NOT NULL DEFAULT '{}',
+    state               TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count       INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count       INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at       TIMESTAMP,
+    last_error_code     TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+
+INSERT INTO usage_bindings_next
+SELECT id, session_id, harness, native_root_id, initial_model_id,
+       state, last_error_code, updated_at
+FROM usage_bindings;
+
+INSERT INTO usage_sources_next
+SELECT id, binding_id, kind, native_session_id, subagent_id, artifact_path,
+       file_identity, generation, byte_offset, parser_state_json, state,
+       failure_count, anomaly_count, next_retry_at, last_error_code, updated_at
+FROM usage_sources;
+
+DROP TABLE usage_sources;
+DROP TABLE usage_bindings;
+ALTER TABLE usage_bindings_next RENAME TO usage_bindings;
+ALTER TABLE usage_sources_next RENAME TO usage_sources;
+
+CREATE INDEX idx_usage_bindings_session_state ON usage_bindings (session_id, state);
+CREATE INDEX idx_usage_sources_state_retry ON usage_sources (state, next_retry_at);
+CREATE INDEX idx_usage_sources_binding_kind ON usage_sources (binding_id, kind);
+CREATE INDEX idx_usage_sources_codex_native_latest
+    ON usage_sources (kind, native_session_id, binding_id, generation DESC, id DESC);
+
+CREATE TRIGGER usage_bindings_cdc_insert AFTER INSERT ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_bindings_cdc_update AFTER UPDATE ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_sources_cdc_update AFTER UPDATE ON usage_sources
+WHEN OLD.anomaly_count IS NOT NEW.anomaly_count
+  OR OLD.last_error_code IS NOT NEW.last_error_code
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, ub.session_id, 'session_updated', json_object('id', ub.session_id), NEW.updated_at
+    FROM usage_bindings ub JOIN sessions s ON s.id = ub.session_id WHERE ub.id = NEW.binding_id;
+END;
+
+COMMIT;
+PRAGMA legacy_alter_table=OFF;
+PRAGMA foreign_keys=ON;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+PRAGMA foreign_keys=OFF;
+PRAGMA legacy_alter_table=ON;
+BEGIN IMMEDIATE;
+
+DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
+DROP TRIGGER IF EXISTS usage_sources_cdc_update;
+
+DELETE FROM anthropic_usage_event_details
+WHERE event_id IN (
+    SELECT event.id FROM model_usage_events event
+    JOIN usage_bindings binding ON binding.id = event.binding_id
+    WHERE binding.harness IN ('kimi', 'pi', 'qwen')
+);
+DELETE FROM openai_usage_event_details
+WHERE event_id IN (
+    SELECT event.id FROM model_usage_events event
+    JOIN usage_bindings binding ON binding.id = event.binding_id
+    WHERE binding.harness IN ('kimi', 'pi', 'qwen')
+);
+DELETE FROM model_usage_events
+WHERE binding_id IN (
+    SELECT id FROM usage_bindings WHERE harness IN ('kimi', 'pi', 'qwen')
+);
+
+CREATE TABLE usage_bindings_previous (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex')),
+    native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id   TEXT NOT NULL DEFAULT '',
+    state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code    TEXT NOT NULL DEFAULT '',
+    updated_at         TIMESTAMP NOT NULL,
+    UNIQUE (session_id, harness, native_root_id)
+);
+
+CREATE TABLE usage_sources_previous (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind                TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout')),
+    native_session_id   TEXT NOT NULL DEFAULT '',
+    subagent_id         TEXT NOT NULL DEFAULT '',
+    artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity       TEXT NOT NULL DEFAULT '',
+    generation          INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset         INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    parser_state_json   TEXT NOT NULL DEFAULT '{}',
+    state               TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count       INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count       INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at       TIMESTAMP,
+    last_error_code     TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+
+INSERT INTO usage_bindings_previous
+SELECT id, session_id, harness, native_root_id, initial_model_id,
+       state, last_error_code, updated_at
+FROM usage_bindings
+WHERE harness IN ('claude-code', 'codex');
+
+INSERT INTO usage_sources_previous
+SELECT source.id, source.binding_id, source.kind, source.native_session_id,
+       source.subagent_id, source.artifact_path, source.file_identity,
+       source.generation, source.byte_offset, source.parser_state_json,
+       source.state, source.failure_count, source.anomaly_count,
+       source.next_retry_at, source.last_error_code, source.updated_at
+FROM usage_sources source
+JOIN usage_bindings_previous binding ON binding.id = source.binding_id
+WHERE source.kind IN ('claude_main', 'claude_subagent', 'codex_rollout');
+
+DROP TABLE usage_sources;
+DROP TABLE usage_bindings;
+ALTER TABLE usage_bindings_previous RENAME TO usage_bindings;
+ALTER TABLE usage_sources_previous RENAME TO usage_sources;
+
+CREATE INDEX idx_usage_bindings_session_state ON usage_bindings (session_id, state);
+CREATE INDEX idx_usage_sources_state_retry ON usage_sources (state, next_retry_at);
+CREATE INDEX idx_usage_sources_binding_kind ON usage_sources (binding_id, kind);
+CREATE INDEX idx_usage_sources_codex_native_latest
+    ON usage_sources (kind, native_session_id, binding_id, generation DESC, id DESC);
+
+CREATE TRIGGER usage_bindings_cdc_insert AFTER INSERT ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_bindings_cdc_update AFTER UPDATE ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_sources_cdc_update AFTER UPDATE ON usage_sources
+WHEN OLD.anomaly_count IS NOT NEW.anomaly_count
+  OR OLD.last_error_code IS NOT NEW.last_error_code
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, ub.session_id, 'session_updated', json_object('id', ub.session_id), NEW.updated_at
+    FROM usage_bindings ub JOIN sessions s ON s.id = ub.session_id WHERE ub.id = NEW.binding_id;
+END;
+
+COMMIT;
+PRAGMA legacy_alter_table=OFF;
+PRAGMA foreign_keys=ON;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/migrations/0118_allow_pi_usage.sql
+++ b/backend/internal/storage/sqlite/migrations/0118_allow_pi_usage.sql
@@ -9,6 +9,9 @@ DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
 DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
 DROP TRIGGER IF EXISTS usage_sources_cdc_update;
 
+-- SQLite cannot widen a CHECK constraint in place. Rebuild only the two
+-- collection tables; the current event table (including measurement, bounded
+-- provider usage, billing attribution, and cost columns) remains untouched.
 CREATE TABLE usage_bindings_next (
     id                 INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
@@ -18,6 +21,7 @@ CREATE TABLE usage_bindings_next (
     state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
     last_error_code    TEXT NOT NULL DEFAULT '',
     updated_at         TIMESTAMP NOT NULL,
+    provider_hint      TEXT NOT NULL DEFAULT '',
     UNIQUE (session_id, harness, native_root_id)
 );
 
@@ -25,8 +29,7 @@ CREATE TABLE usage_sources_next (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
     kind                TEXT NOT NULL CHECK (kind IN (
-                            'claude_main', 'claude_subagent', 'codex_rollout',
-                            'kimi_wire', 'pi_session'
+                            'claude_main', 'claude_subagent', 'codex_rollout', 'kimi_wire', 'pi_session'
                         )),
     native_session_id   TEXT NOT NULL DEFAULT '',
     subagent_id         TEXT NOT NULL DEFAULT '',
@@ -46,7 +49,7 @@ CREATE TABLE usage_sources_next (
 
 INSERT INTO usage_bindings_next
 SELECT id, session_id, harness, native_root_id, initial_model_id,
-       state, last_error_code, updated_at
+       state, last_error_code, updated_at, provider_hint
 FROM usage_bindings;
 
 INSERT INTO usage_sources_next
@@ -102,22 +105,10 @@ DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
 DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
 DROP TRIGGER IF EXISTS usage_sources_cdc_update;
 
-DELETE FROM anthropic_usage_event_details
-WHERE event_id IN (
-    SELECT event.id FROM model_usage_events event
-    JOIN usage_bindings binding ON binding.id = event.binding_id
-    WHERE binding.harness = 'pi'
-);
-DELETE FROM openai_usage_event_details
-WHERE event_id IN (
-    SELECT event.id FROM model_usage_events event
-    JOIN usage_bindings binding ON binding.id = event.binding_id
-    WHERE binding.harness = 'pi'
-);
+-- Remove only Pi-owned rows before narrowing the collection constraints. All
+-- current-schema events owned by Claude, Codex, and Kimi retain their IDs and facts.
 DELETE FROM model_usage_events
-WHERE binding_id IN (
-    SELECT id FROM usage_bindings WHERE harness = 'pi'
-);
+WHERE binding_id IN (SELECT id FROM usage_bindings WHERE harness = 'pi');
 
 CREATE TABLE usage_bindings_previous (
     id                 INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -128,6 +119,7 @@ CREATE TABLE usage_bindings_previous (
     state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
     last_error_code    TEXT NOT NULL DEFAULT '',
     updated_at         TIMESTAMP NOT NULL,
+    provider_hint      TEXT NOT NULL DEFAULT '',
     UNIQUE (session_id, harness, native_root_id)
 );
 
@@ -153,7 +145,7 @@ CREATE TABLE usage_sources_previous (
 
 INSERT INTO usage_bindings_previous
 SELECT id, session_id, harness, native_root_id, initial_model_id,
-       state, last_error_code, updated_at
+       state, last_error_code, updated_at, provider_hint
 FROM usage_bindings
 WHERE harness IN ('claude-code', 'codex', 'kimi');
 

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -143,7 +143,11 @@ SELECT CAST(EXISTS (
     WHERE s.is_terminated = 0
       AND s.activity_state <> 'exited'
       AND s.harness = 'pi'
-      AND trim(s.workspace_path) <> ''
+      AND trim(s.agent_session_id) <> ''
+      AND (
+          trim(s.runtime_launch_id) = ''
+          OR s.agent_session_id_launch_id = s.runtime_launch_id
+      )
       AND NOT EXISTS (
           SELECT 1
           FROM usage_bindings ub

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -111,11 +111,20 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex', 'kimi')
+      AND ub.harness IN ('claude-code', 'codex', 'kimi', 'pi')
       AND (
           ub.harness = 'kimi'
           OR ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
+          OR (
+              ub.harness = 'pi'
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM usage_sources source
+                  WHERE source.binding_id = ub.id
+                    AND source.kind = 'pi_session'
+              )
+          )
           OR EXISTS (
               SELECT 1
               FROM usage_codex_pending_children pending
@@ -179,7 +188,7 @@ SELECT ub.*
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex', 'kimi')
+  AND ub.harness IN ('claude-code', 'codex', 'kimi', 'pi')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
@@ -190,17 +199,26 @@ WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'
       OR ub.last_error_code = 'source_discovery_pending'
-      OR NOT EXISTS (
+      OR (ub.harness = 'codex' AND NOT EXISTS (
           SELECT 1
           FROM usage_sources us
           WHERE us.binding_id = ub.id
             AND us.kind = 'codex_rollout'
-      )
+      ))
+      OR (ub.harness = 'pi' AND NOT EXISTS (
+          SELECT 1
+          FROM usage_sources us
+          WHERE us.binding_id = ub.id
+            AND us.kind = 'pi_session'
+      ))
       OR EXISTS (
           SELECT 1
           FROM usage_sources us
           WHERE us.binding_id = ub.id
-            AND us.kind = 'codex_rollout'
+            AND (
+                ub.harness = 'codex' AND us.kind = 'codex_rollout'
+                OR ub.harness = 'pi' AND us.kind = 'pi_session'
+            )
             AND us.state = 'error'
             AND us.last_error_code IN ('artifact_missing', 'source_read_failed')
       )

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -137,6 +137,19 @@ SELECT CAST(EXISTS (
                 )
           )
       )
+) OR EXISTS (
+    SELECT 1
+    FROM sessions s
+    WHERE s.is_terminated = 0
+      AND s.activity_state <> 'exited'
+      AND s.harness = 'pi'
+      AND trim(s.workspace_path) <> ''
+      AND NOT EXISTS (
+          SELECT 1
+          FROM usage_bindings ub
+          WHERE ub.session_id = s.id
+            AND ub.harness = 'pi'
+      )
 ) AS INTEGER);
 
 -- name: ListLatestRetiredCodexReplacementClaimsByPath :many

--- a/backend/internal/storage/sqlite/store/usage_store.go
+++ b/backend/internal/storage/sqlite/store/usage_store.go
@@ -979,7 +979,12 @@ func validateUsageEvent(harness domain.AgentHarness, event domain.ModelUsageEven
 	if harness == domain.HarnessCodex {
 		expectedProvider = domain.UsageProviderOpenAI
 	}
-	if event.ProviderID != expectedProvider || event.ModelID == "" || event.SourceEventKey == "" {
+	validProvider := event.ProviderID == expectedProvider
+	if harness == domain.HarnessPi {
+		validProvider = event.ProviderID == domain.UsageProviderOpenAI ||
+			event.ProviderID == domain.UsageProviderAnthropic
+	}
+	if !validProvider || event.ModelID == "" || event.SourceEventKey == "" {
 		return fmt.Errorf("invalid usage event identity for %s", harness)
 	}
 	switch event.MeasurementKind {

--- a/backend/internal/storage/sqlite/store/usage_store_test.go
+++ b/backend/internal/storage/sqlite/store/usage_store_test.go
@@ -211,17 +211,27 @@ func TestListLatestRetiredCodexReplacementClaimsByPath(t *testing.T) {
 	assertClaims()
 }
 
-func TestPiSessionWithoutBindingKeepsDiscoveryPending(t *testing.T) {
+func TestCurrentPiNativeIdentityWithoutBindingKeepsDiscoveryPending(t *testing.T) {
 	s := newTestStore(t)
 	session := seedUsageSession(t, s, domain.HarnessPi)
-	session.Metadata.WorkspacePath = t.TempDir()
+	session.Metadata.AgentSessionID = "pi-current"
+	session.Metadata.RuntimeLaunchID = "launch-current"
+	session.Metadata.AgentSessionIDLaunchID = "launch-current"
 	session.Activity.State = domain.ActivityIdle
 	mustNoError(t, s.UpdateSession(context.Background(), session))
 
 	pending, err := s.HasPendingUsageDiscovery(context.Background())
 	mustNoError(t, err)
 	if !pending {
-		t.Fatal("live Pi session without a usage binding did not request discovery")
+		t.Fatal("live Pi session with a current native identity did not request discovery")
+	}
+
+	session.Metadata.AgentSessionIDLaunchID = "launch-stale"
+	mustNoError(t, s.UpdateSession(context.Background(), session))
+	pending, err = s.HasPendingUsageDiscovery(context.Background())
+	mustNoError(t, err)
+	if pending {
+		t.Fatal("stale Pi native identity requested discovery for the current launch")
 	}
 }
 

--- a/backend/internal/storage/sqlite/store/usage_store_test.go
+++ b/backend/internal/storage/sqlite/store/usage_store_test.go
@@ -137,6 +137,29 @@ func TestActiveKimiBindingRemainsDiscoverable(t *testing.T) {
 	}
 }
 
+func TestSourceLessPiBindingRemainsDiscoverable(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	sess := seedUsageSession(t, s, domain.HarnessPi)
+	now := time.Unix(1700000000, 0).UTC()
+	binding := mustUpsertUsageBinding(t, s, sess, now, domain.UsageBindingRecord{
+		NativeRootID:  "pi-late-transcript",
+		State:         domain.UsageBindingActive,
+		LastErrorCode: domain.UsageErrorSourceDiscoveryPending,
+	})
+
+	pending, err := s.HasPendingUsageDiscovery(ctx)
+	mustNoError(t, err)
+	if !pending {
+		t.Fatal("source-less Pi binding did not request discovery retry")
+	}
+	discovery, err := s.ListUsageDiscoveryBindings(ctx, 8)
+	mustNoError(t, err)
+	if len(discovery) != 1 || discovery[0].ID != binding.ID {
+		t.Fatalf("discovery bindings = %+v, want Pi binding %d", discovery, binding.ID)
+	}
+}
+
 func TestListLatestRetiredCodexReplacementClaimsByPath(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/backend/internal/storage/sqlite/store/usage_store_test.go
+++ b/backend/internal/storage/sqlite/store/usage_store_test.go
@@ -211,6 +211,20 @@ func TestListLatestRetiredCodexReplacementClaimsByPath(t *testing.T) {
 	assertClaims()
 }
 
+func TestPiSessionWithoutBindingKeepsDiscoveryPending(t *testing.T) {
+	s := newTestStore(t)
+	session := seedUsageSession(t, s, domain.HarnessPi)
+	session.Metadata.WorkspacePath = t.TempDir()
+	session.Activity.State = domain.ActivityIdle
+	mustNoError(t, s.UpdateSession(context.Background(), session))
+
+	pending, err := s.HasPendingUsageDiscovery(context.Background())
+	mustNoError(t, err)
+	if !pending {
+		t.Fatal("live Pi session without a usage binding did not request discovery")
+	}
+}
+
 func TestUsageBindingUpsertDoesNotRegressSettledLifecycle(t *testing.T) {
 	s := newTestStore(t)
 	sess := seedUsageSession(t, s, domain.HarnessCodex)
@@ -1746,6 +1760,39 @@ func TestKimiUsageEventRoundTrip(t *testing.T) {
 		usageTokenValue(models[0].Tokens.UncachedInputTokens) != 21 ||
 		usageTokenValue(models[0].Tokens.OutputTokens) != 5 {
 		t.Fatalf("Kimi aggregate = %+v", models)
+	}
+}
+
+func TestPiUsageEventRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	session := seedUsageSession(t, s, domain.HarnessPi)
+	binding := mustUpsertUsageBinding(t, s, session, now, domain.UsageBindingRecord{
+		NativeRootID: "pi-session",
+		State:        domain.UsageBindingActive,
+	})
+	source := mustInsertUsageSource(t, s, now, domain.UsageSourceRecord{
+		BindingID:       binding.ID,
+		Kind:            domain.UsageSourcePiSession,
+		NativeSessionID: "pi-session",
+		ArtifactPath:    "/tmp/pi/session.jsonl",
+		FileIdentity:    "dev:ino",
+		State:           domain.UsageSourcePending,
+	})
+	event := usageEvent("pi-event", canonicalUsageTokens(19, 5, 14, 7))
+	event.ModelID = "zai-glm/glm-4.5"
+	anthropicEvent := anthropicUsageEvent("pi-anthropic-event", 11, 3, 5, 7)
+	anthropicEvent.ModelID = "anthropic/claude-sonnet"
+	if err := s.ApplyUsageChunk(context.Background(), source.ID, 0, source.UpdatedAt, domain.SourceCursorState{
+		ByteOffset: 100, State: domain.UsageSourceActive, ParserStateJSON: `{}`, UpdatedAt: now,
+	}, []domain.ModelUsageEvent{event, anthropicEvent}); err != nil {
+		t.Fatalf("apply Pi usage: %v", err)
+	}
+	models, err := s.ListUsageModelAggregates(context.Background(), session.ID)
+	mustNoError(t, err)
+	if len(models) != 2 || models[0].Harness != domain.HarnessPi ||
+		models[1].Harness != domain.HarnessPi {
+		t.Fatalf("Pi aggregate = %+v", models)
 	}
 }
 


### PR DESCRIPTION
## What

Adds Pi token-usage observability as a standalone change based on the latest `main`.

- parses Pi session JSONL for OpenAI-compatible and Anthropic providers
- discovers sessions from `PI_CODING_AGENT_DIR` or `~/.pi/agent/sessions`
- supports late session-ID discovery and lifecycle reactivation
- persists and aggregates Pi usage through the shared collector and SQLite store
- adds parser, discovery, lifecycle, migration, and storage coverage

## Why this PR was recreated

The earlier provider PRs were stacked on one another instead of being based cleanly on `main`. That made them difficult to review and prevented them from merging independently into `main`.

This replaces the earlier Pi PR #4184 without carrying Kimi or Qwen branch history. Pi can now be reviewed, tested, merged, or reverted independently.

## Related PRs and merge order

1. **Kimi:** #4311
2. **Pi:** #4326 (this PR)
3. **Qwen:** #4327

All three target `main`; the order above is recommended for the provider-usage migrations.

## Implementation

Pi messages are normalized into the shared token model. The collector supports explicit session IDs and late discovery by matching Pi session metadata to a live AO workspace. Migration 0109 is intentionally relative to the Kimi migration: it adds Pi support on upgrade and removes only Pi usage on rollback, preserving Kimi data and constraints.

## Testing

- `go test ./internal/observe/usage ./internal/service/usage ./internal/storage/sqlite ./internal/storage/sqlite/store ./internal/lifecycle -count=1`
- `go test ./internal/daemon -count=1`
- `go vet` over all changed backend packages
- golangci-lint v2.12.2 over all changed packages: `0 issues`
- `git diff --check`

The full backend run only encountered the repository's pre-existing timing-sensitive fake-agent lifecycle test under concurrent machine load. All directly affected packages pass.

## Checklist

- [x] Based on the latest `main`
- [x] Contains only Pi provider logic
- [x] Tests added for the changed behavior
- [x] Relevant local checks pass
