### PR TITLE
feat: add Qwen token usage observability

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -388,6 +388,7 @@ func Run() error {
 			roots.ClaudeProjects,
 			roots.CodexSessions,
 			roots.CodexArchived,
+			roots.QwenUsage,
 		}, usagepipeline.CoordinatorConfig{
 			Logger:     log,
 			Initialize: usageCollector.BackfillActive,

--- a/backend/internal/domain/usage.go
+++ b/backend/internal/domain/usage.go
@@ -15,6 +15,7 @@ const (
 	UsageSourceClaudeMain     UsageSourceKind = "claude_main"
 	UsageSourceClaudeSubagent UsageSourceKind = "claude_subagent"
 	UsageSourceCodexRollout   UsageSourceKind = "codex_rollout"
+	UsageSourceQwenMonthly    UsageSourceKind = "qwen_monthly"
 )
 
 // UsageBindingState tracks the root native-session binding lifecycle.

--- a/backend/internal/observe/usage/parser.go
+++ b/backend/internal/observe/usage/parser.go
@@ -44,6 +44,8 @@ func parseRecordsWithState(
 	case domain.UsageSourceCodexRollout:
 		parseCodex(source, records, state.Codex, &result)
 		result.pendingCodexSpawnCalls = len(state.Codex.PendingSpawnCallIDs)
+	case domain.UsageSourceQwenMonthly:
+		parseQwen(source, records, &result)
 	default:
 		result.Cursor.AnomalyCount++
 		result.Cursor.LastErrorCode = domain.UsageErrorUnsupportedSourceFormat
@@ -197,6 +199,10 @@ func decodeParserState(source domain.UsageSourceRecord) (*parserStateEnvelope, e
 		if err := validateCodexDirectParent(source, state.Codex); err != nil {
 			return nil, err
 		}
+	case domain.UsageSourceQwenMonthly:
+		if state.Claude != nil || state.Codex != nil {
+			return nil, errors.New("append-only state has invalid parser payload")
+		}
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", source.Kind)
 	}
@@ -216,6 +222,8 @@ func newParserState(kind domain.UsageSourceKind) (*parserStateEnvelope, error) {
 			PendingSpawnCallIDs: []string{},
 			DiscoveredChildIDs:  []string{},
 		}
+	case domain.UsageSourceQwenMonthly:
+		// Qwen records carry replay-stable native usage IDs.
 	default:
 		return nil, fmt.Errorf("unsupported source kind %q", kind)
 	}

--- a/backend/internal/observe/usage/parser_qwen.go
+++ b/backend/internal/observe/usage/parser_qwen.go
@@ -1,0 +1,77 @@
+package usage
+
+import (
+	"encoding/json"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type qwenUsageRecord struct {
+	SchemaVersion  int    `json:"schemaVersion"`
+	ID             string `json:"id"`
+	Timestamp      string `json:"timestamp"`
+	SessionID      string `json:"sessionId"`
+	Model          string `json:"model"`
+	InputTokens    int64  `json:"inputTokens"`
+	OutputTokens   int64  `json:"outputTokens"`
+	CachedTokens   int64  `json:"cachedTokens"`
+	ThoughtsTokens int64  `json:"thoughtsTokens"`
+	TotalTokens    *int64 `json:"totalTokens"`
+}
+
+func parseQwen(source domain.UsageSourceContext, records []jsonlRecord, result *parseResult) {
+	eventsByKey := make(map[string]domain.ModelUsageEvent)
+	for _, record := range records {
+		var native qwenUsageRecord
+		if err := json.Unmarshal(record.Data, &native); err != nil {
+			recordMalformed(result)
+			continue
+		}
+		if native.SessionID != source.NativeRootID {
+			continue
+		}
+		model := firstNonEmpty(native.Model)
+		identity := firstNonEmpty(native.ID)
+		if native.SchemaVersion != 1 || model == "" || identity == "" ||
+			native.InputTokens < 0 || native.OutputTokens < 0 ||
+			native.CachedTokens < 0 || native.ThoughtsTokens < 0 {
+			recordMalformed(result)
+			continue
+		}
+		output, ok := sumNonNegative(native.OutputTokens, native.ThoughtsTokens)
+		if !ok {
+			recordMalformed(result)
+			continue
+		}
+		reportedTotal := int64(0)
+		if native.TotalTokens != nil {
+			reportedTotal = *native.TotalTokens
+		}
+		tokens, details, ok := normalizeOpenAIUsage(
+			native.InputTokens, native.CachedTokens, 0, output, native.ThoughtsTokens, reportedTotal,
+		)
+		if !ok {
+			recordMalformed(result)
+			continue
+		}
+		event := domain.ModelUsageEvent{
+			ProviderID:      domain.UsageProviderOpenAI,
+			ModelID:         model,
+			Tokens:          tokens,
+			ProviderDetails: domain.UsageProviderDetails{OpenAI: &details},
+			CreatedAt:       parseUsageTimestamp(native.Timestamp),
+			SourceEventKey: stableSourceEventKey(
+				"qwen", source.NativeRootID, identity, model,
+			),
+		}
+		if existing, duplicate := eventsByKey[event.SourceEventKey]; duplicate {
+			if !usageEventsEqual(existing, event) {
+				result.Cursor.AnomalyCount++
+				result.Cursor.LastErrorCode = domain.UsageErrorSourceEventConflict
+			}
+			continue
+		}
+		eventsByKey[event.SourceEventKey] = event
+		result.Events = append(result.Events, event)
+	}
+}

--- a/backend/internal/observe/usage/parser_qwen.go
+++ b/backend/internal/observe/usage/parser_qwen.go
@@ -43,23 +43,25 @@ func parseQwen(source domain.UsageSourceContext, records []jsonlRecord, result *
 			recordMalformed(result)
 			continue
 		}
-		reportedTotal := int64(0)
-		if native.TotalTokens != nil {
-			reportedTotal = *native.TotalTokens
+		computedTotal, ok := sumNonNegative(native.InputTokens, output)
+		if !ok || native.TotalTokens != nil && (*native.TotalTokens < 0 || *native.TotalTokens != computedTotal) {
+			recordMalformed(result)
+			continue
 		}
-		tokens, details, ok := normalizeOpenAIUsage(
-			native.InputTokens, native.CachedTokens, 0, output, native.ThoughtsTokens, reportedTotal,
+		tokens, ok := normalizeOpenAIUsage(
+			native.InputTokens, native.CachedTokens, 0, output,
 		)
 		if !ok {
 			recordMalformed(result)
 			continue
 		}
 		event := domain.ModelUsageEvent{
-			ProviderID:      domain.UsageProviderOpenAI,
-			ModelID:         model,
-			Tokens:          tokens,
-			ProviderDetails: domain.UsageProviderDetails{OpenAI: &details},
-			CreatedAt:       parseUsageTimestamp(native.Timestamp),
+			ProviderID:        domain.UsageProviderOpenAI,
+			ModelID:           model,
+			MeasurementKind:   domain.UsageMeasurementNativeReported,
+			Tokens:            tokens,
+			ProviderUsageJSON: boundedProviderUsage(record.Data),
+			CreatedAt:         parseUsageTimestamp(native.Timestamp),
 			SourceEventKey: stableSourceEventKey(
 				"qwen", source.NativeRootID, identity, model,
 			),

--- a/backend/internal/observe/usage/qwen_parser_test.go
+++ b/backend/internal/observe/usage/qwen_parser_test.go
@@ -26,15 +26,18 @@ func TestParseQwenUsageForBoundSession(t *testing.T) {
 		event.CreatedAt != time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC) || event.SourceEventKey == "" {
 		t.Fatalf("event = %+v", event)
 	}
-	assertQwenMetric(t, "input", event.Tokens.InputTokens, 30, event.Tokens.Provenance.InputTokens, domain.UsageMetricReported)
-	assertQwenMetric(t, "cached input", event.Tokens.CachedInputTokens, 9, event.Tokens.Provenance.CachedInputTokens, domain.UsageMetricReported)
-	assertQwenMetric(t, "uncached input", event.Tokens.UncachedInputTokens, 21, event.Tokens.Provenance.UncachedInputTokens, domain.UsageMetricDerived)
-	assertQwenMetric(t, "output", event.Tokens.OutputTokens, 16, event.Tokens.Provenance.OutputTokens, domain.UsageMetricReported)
-	details := event.ProviderDetails.OpenAI
-	if details == nil || details.ReasoningOutputTokens == nil || *details.ReasoningOutputTokens != 4 ||
-		details.ReportedTotalTokens == nil || *details.ReportedTotalTokens != 46 ||
-		event.ProviderDetails.Anthropic != nil {
-		t.Fatalf("provider details = %+v", event.ProviderDetails)
+	if tokenValue(event.Tokens.InputTokens) != 30 ||
+		tokenValue(event.Tokens.CachedInputTokens) != 9 ||
+		tokenValue(event.Tokens.UncachedInputTokens) != 21 ||
+		tokenValue(event.Tokens.OutputTokens) != 16 {
+		t.Fatalf("tokens = %+v", event.Tokens)
+	}
+	if event.MeasurementKind != domain.UsageMeasurementNativeReported {
+		t.Fatalf("measurement kind = %q, want native_reported", event.MeasurementKind)
+	}
+	if providerUsageTokens(t, event.ProviderUsageJSON, "thoughtsTokens") != 4 ||
+		providerUsageTokens(t, event.ProviderUsageJSON, "totalTokens") != 46 {
+		t.Fatalf("provider usage = %s", event.ProviderUsageJSON)
 	}
 }
 
@@ -59,19 +62,5 @@ func TestParseQwenAllowsOmittedTotalTokens(t *testing.T) {
 	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
 	if result.err != nil || len(result.Events) != 1 {
 		t.Fatalf("result = %+v", result)
-	}
-}
-
-func assertQwenMetric(
-	t *testing.T,
-	name string,
-	value *int64,
-	want int64,
-	provenance domain.UsageMetricProvenance,
-	wantProvenance domain.UsageMetricProvenance,
-) {
-	t.Helper()
-	if value == nil || *value != want || provenance != wantProvenance {
-		t.Fatalf("%s = %v (%s), want %d (%s)", name, value, provenance, want, wantProvenance)
 	}
 }

--- a/backend/internal/observe/usage/qwen_parser_test.go
+++ b/backend/internal/observe/usage/qwen_parser_test.go
@@ -1,0 +1,77 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// TestParseQwenUsageForBoundSession catches cross-session attribution and
+// preserves Qwen's cached and reasoning token buckets.
+func TestParseQwenUsageForBoundSession(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "qwen-session"
+	records := []jsonlRecord{
+		{Data: []byte(`{"schemaVersion":1,"id":"other","sessionId":"another","model":"qwen3","inputTokens":999,"outputTokens":999,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":1998}`)},
+		{Offset: 100, Data: []byte(`{"schemaVersion":1,"id":"turn-1","timestamp":"2026-08-09T10:00:00Z","sessionId":"qwen-session","model":"qwen3-coder","inputTokens":30,"outputTokens":12,"cachedTokens":9,"thoughtsTokens":4,"totalTokens":46}`)},
+	}
+
+	result := parseRecords(source, records, 300, time.Unix(1700000000, 0).UTC())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	event := result.Events[0]
+	if event.ProviderID != domain.UsageProviderOpenAI || event.ModelID != "qwen3-coder" ||
+		event.CreatedAt != time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC) || event.SourceEventKey == "" {
+		t.Fatalf("event = %+v", event)
+	}
+	assertQwenMetric(t, "input", event.Tokens.InputTokens, 30, event.Tokens.Provenance.InputTokens, domain.UsageMetricReported)
+	assertQwenMetric(t, "cached input", event.Tokens.CachedInputTokens, 9, event.Tokens.Provenance.CachedInputTokens, domain.UsageMetricReported)
+	assertQwenMetric(t, "uncached input", event.Tokens.UncachedInputTokens, 21, event.Tokens.Provenance.UncachedInputTokens, domain.UsageMetricDerived)
+	assertQwenMetric(t, "output", event.Tokens.OutputTokens, 16, event.Tokens.Provenance.OutputTokens, domain.UsageMetricReported)
+	details := event.ProviderDetails.OpenAI
+	if details == nil || details.ReasoningOutputTokens == nil || *details.ReasoningOutputTokens != 4 ||
+		details.ReportedTotalTokens == nil || *details.ReportedTotalTokens != 46 ||
+		event.ProviderDetails.Anthropic != nil {
+		t.Fatalf("provider details = %+v", event.ProviderDetails)
+	}
+}
+
+func TestParseQwenRejectsInconsistentTotals(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"bad","sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":4,"thoughtsTokens":0,"totalTokens":5}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if len(result.Events) != 0 || result.Cursor.AnomalyCount != 1 ||
+		result.Cursor.LastErrorCode != domain.UsageErrorMalformedJSONL {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestParseQwenAllowsOmittedTotalTokens(t *testing.T) {
+	source := usageSource(domain.UsageSourceQwenMonthly)
+	source.NativeRootID = "native-root"
+	record := jsonlRecord{Data: []byte(`{"schemaVersion":1,"id":"turn-1","sessionId":"native-root","model":"qwen3","inputTokens":3,"outputTokens":2,"cachedTokens":1,"thoughtsTokens":0}`)}
+	result := parseRecords(source, []jsonlRecord{record}, 100, time.Now())
+	if result.err != nil || len(result.Events) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func assertQwenMetric(
+	t *testing.T,
+	name string,
+	value *int64,
+	want int64,
+	provenance domain.UsageMetricProvenance,
+	wantProvenance domain.UsageMetricProvenance,
+) {
+	t.Helper()
+	if value == nil || *value != want || provenance != wantProvenance {
+		t.Fatalf("%s = %v (%s), want %d (%s)", name, value, provenance, want, wantProvenance)
+	}
+}

--- a/backend/internal/service/usage/capabilities.go
+++ b/backend/internal/service/usage/capabilities.go
@@ -5,7 +5,7 @@ import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 // SupportedHarness reports whether the harness has a certified usage pipeline.
 func SupportedHarness(h domain.AgentHarness) bool {
 	switch h {
-	case domain.HarnessClaudeCode, domain.HarnessCodex:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessQwen:
 		return true
 	default:
 		return false

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -62,6 +62,7 @@ type SourceRoots struct {
 	ClaudeProjects string
 	CodexSessions  string
 	CodexArchived  string
+	QwenUsage      string
 }
 
 // DefaultSourceRoots resolves the native Claude Code and Codex transcript
@@ -82,6 +83,7 @@ func DefaultSourceRoots(ctx context.Context) (SourceRoots, error) {
 		ClaudeProjects: filepath.Join(home, ".claude", "projects"),
 		CodexSessions:  filepath.Join(codexHome, "sessions"),
 		CodexArchived:  filepath.Join(codexHome, "archived_sessions"),
+		QwenUsage:      filepath.Join(home, ".qwen", "usage"),
 	}, nil
 }
 
@@ -275,7 +277,8 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 		}
 	}
 	if signal.NativeSessionID != "" && mainPath == "" &&
-		(session.Harness == domain.HarnessCodex || finalizing && !existsForDiscovery) {
+		(session.Harness == domain.HarnessCodex || session.Harness == domain.HarnessQwen ||
+			finalizing && !existsForDiscovery) {
 		mainPath, err = c.discoverPath(ctx, session.Harness, signal.NativeSessionID)
 		if err != nil {
 			return err
@@ -368,8 +371,11 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 
 	if mainArtifact != nil {
 		kind := domain.UsageSourceClaudeMain
-		if session.Harness == domain.HarnessCodex {
+		switch session.Harness {
+		case domain.HarnessCodex:
 			kind = domain.UsageSourceCodexRollout
+		case domain.HarnessQwen:
+			kind = domain.UsageSourceQwenMonthly
 		}
 		changed, err := c.registerHookSource(
 			ctx,
@@ -612,18 +618,24 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 	}
 
 	kind := domain.UsageSourceClaudeMain
-	if session.Harness == domain.HarnessCodex {
+	switch session.Harness {
+	case domain.HarnessCodex:
 		kind = domain.UsageSourceCodexRollout
+	case domain.HarnessQwen:
+		kind = domain.UsageSourceQwenMonthly
 	}
 	if _, err := c.registerSource(ctx, binding, kind, nativeID, "", path, now, false); err != nil {
 		return err
 	}
-	if session.Harness == domain.HarnessClaudeCode {
+	switch session.Harness {
+	case domain.HarnessClaudeCode:
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
-		return err
+	case domain.HarnessCodex:
+		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
 	}
 	if state == domain.UsageBindingFinalizing {
 		return c.settleFinalizingBinding(ctx, binding.ID, now)
@@ -861,18 +873,24 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 	}
 
 	kind := domain.UsageSourceClaudeMain
-	if binding.Harness == domain.HarnessCodex {
+	switch binding.Harness {
+	case domain.HarnessCodex:
 		kind = domain.UsageSourceCodexRollout
+	case domain.HarnessQwen:
+		kind = domain.UsageSourceQwenMonthly
 	}
 	if _, err := c.registerSource(ctx, binding, kind, binding.NativeRootID, "", path, now, false); err != nil {
 		return err
 	}
-	if binding.Harness == domain.HarnessClaudeCode {
+	switch binding.Harness {
+	case domain.HarnessClaudeCode:
 		if err := c.registerDiscoveredClaudeSubagents(ctx, binding, path, now, false); err != nil {
 			return err
 		}
-	} else if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
-		return err
+	case domain.HarnessCodex:
+		if err := c.registerDiscoveredCodexChildren(ctx, binding, now); err != nil {
+			return err
+		}
 	}
 	lastErrorCode := ""
 	if binding.Harness == domain.HarnessCodex &&
@@ -1698,6 +1716,11 @@ func validateSourceAttribution(
 			filepath.Base(resolved) != "agent-"+subagentID+".jsonl" {
 			return rejected()
 		}
+	case domain.UsageSourceQwenMonthly:
+		if binding.Harness != domain.HarnessQwen || nativeSessionID != binding.NativeRootID ||
+			subagentID != "" || !qwenUsageFilename(filepath.Base(resolved)) {
+			return rejected()
+		}
 	default:
 		return rejected()
 	}
@@ -1710,6 +1733,8 @@ func (c *Collector) allowedRoots(harness domain.AgentHarness) []string {
 		return []string{c.roots.ClaudeProjects}
 	case domain.HarnessCodex:
 		return []string{c.roots.CodexSessions, c.roots.CodexArchived}
+	case domain.HarnessQwen:
+		return []string{c.roots.QwenUsage}
 	default:
 		return nil
 	}
@@ -1757,6 +1782,8 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		patterns = []string{filepath.Join(c.roots.ClaudeProjects, "*", nativeID+".jsonl")}
 	case domain.HarnessCodex:
 		return c.discoverCodexPath(ctx, nativeID, "")
+	case domain.HarnessQwen:
+		return c.discoverQwenPath(ctx)
 	}
 	type candidate struct {
 		path string
@@ -1788,6 +1815,42 @@ func (c *Collector) discoverPath(ctx context.Context, harness domain.AgentHarnes
 		return "", nil
 	}
 	return matches[0].path, nil
+}
+
+func qwenUsageFilename(name string) bool {
+	if !strings.HasPrefix(name, "token-usage-") || !strings.HasSuffix(name, ".jsonl") {
+		return false
+	}
+	month := strings.TrimSuffix(strings.TrimPrefix(name, "token-usage-"), ".jsonl")
+	if len(month) != 7 || month[4] != '-' {
+		return false
+	}
+	_, err := time.Parse("2006-01", month)
+	return err == nil
+}
+
+func (c *Collector) discoverQwenPath(ctx context.Context) (string, error) {
+	paths, err := filepath.Glob(filepath.Join(c.roots.QwenUsage, "token-usage-*.jsonl"))
+	if err != nil {
+		return "", err
+	}
+	valid := paths[:0]
+	for _, path := range paths {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if !qwenUsageFilename(filepath.Base(path)) {
+			continue
+		}
+		if info, statErr := os.Stat(path); statErr == nil && info.Mode().IsRegular() {
+			valid = append(valid, path)
+		}
+	}
+	if len(valid) == 0 {
+		return "", nil
+	}
+	sort.Strings(valid)
+	return valid[len(valid)-1], nil
 }
 
 func (c *Collector) discoverCodexPath(ctx context.Context, nativeID, parentID string) (string, error) {

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -79,12 +79,60 @@ func DefaultSourceRoots(ctx context.Context) (SourceRoots, error) {
 	if codexHome == "" {
 		codexHome = filepath.Join(home, ".codex")
 	}
+	qwenRuntime := qwenRuntimeBaseDir(home)
 	return SourceRoots{
 		ClaudeProjects: filepath.Join(home, ".claude", "projects"),
 		CodexSessions:  filepath.Join(codexHome, "sessions"),
 		CodexArchived:  filepath.Join(codexHome, "archived_sessions"),
-		QwenUsage:      filepath.Join(home, ".qwen", "usage"),
+		QwenUsage:      filepath.Join(qwenRuntime, "usage"),
 	}, nil
+}
+
+func qwenRuntimeBaseDir(home string) string {
+	if runtimeDir := strings.TrimSpace(os.Getenv("QWEN_RUNTIME_DIR")); runtimeDir != "" {
+		return resolveQwenStoragePath(runtimeDir, home)
+	}
+
+	qwenHome := filepath.Join(home, ".qwen")
+	if configuredHome := strings.TrimSpace(os.Getenv("QWEN_HOME")); configuredHome != "" {
+		qwenHome = resolveQwenStoragePath(configuredHome, home)
+	}
+
+	data, err := os.ReadFile(filepath.Join(qwenHome, "settings.json"))
+	if err == nil {
+		var settings struct {
+			Advanced struct {
+				RuntimeOutputDir string `json:"runtimeOutputDir"`
+			} `json:"advanced"`
+		}
+		if json.Unmarshal(data, &settings) == nil {
+			if runtimeDir := strings.TrimSpace(settings.Advanced.RuntimeOutputDir); runtimeDir != "" {
+				return resolveQwenStoragePath(runtimeDir, home)
+			}
+		}
+	}
+	return qwenHome
+}
+
+func resolveQwenStoragePath(path, home string) string {
+	path = strings.TrimSpace(path)
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") || strings.HasPrefix(path, `~\`) {
+		segments := strings.FieldsFunc(path[2:], func(r rune) bool {
+			return r == '/' || r == '\\'
+		})
+		return filepath.Join(append([]string{home}, segments...)...)
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return resolved
 }
 
 type collectorStore interface {

--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -370,12 +370,9 @@ func (c *Collector) RecordHook(ctx context.Context, sessionID domain.SessionID, 
 	}
 
 	if mainArtifact != nil {
-		kind := domain.UsageSourceClaudeMain
-		switch session.Harness {
-		case domain.HarnessCodex:
-			kind = domain.UsageSourceCodexRollout
-		case domain.HarnessQwen:
-			kind = domain.UsageSourceQwenMonthly
+		kind, ok := sourceKindForHarness(session.Harness)
+		if !ok {
+			return fmt.Errorf("usage: unsupported harness %q", session.Harness)
 		}
 		changed, err := c.registerHookSource(
 			ctx,
@@ -617,12 +614,9 @@ func (c *Collector) backfillSession(ctx context.Context, session domain.SessionR
 		return nil
 	}
 
-	kind := domain.UsageSourceClaudeMain
-	switch session.Harness {
-	case domain.HarnessCodex:
-		kind = domain.UsageSourceCodexRollout
-	case domain.HarnessQwen:
-		kind = domain.UsageSourceQwenMonthly
+	kind, ok := sourceKindForHarness(session.Harness)
+	if !ok {
+		return fmt.Errorf("usage: unsupported harness %q", session.Harness)
 	}
 	if _, err := c.registerSource(ctx, binding, kind, nativeID, "", path, now, false); err != nil {
 		return err
@@ -872,12 +866,9 @@ func (c *Collector) reconcileBinding(ctx context.Context, binding domain.UsageBi
 		targetState = domain.UsageBindingActive
 	}
 
-	kind := domain.UsageSourceClaudeMain
-	switch binding.Harness {
-	case domain.HarnessCodex:
-		kind = domain.UsageSourceCodexRollout
-	case domain.HarnessQwen:
-		kind = domain.UsageSourceQwenMonthly
+	kind, ok := sourceKindForHarness(binding.Harness)
+	if !ok {
+		return fmt.Errorf("usage: unsupported harness %q", binding.Harness)
 	}
 	if _, err := c.registerSource(ctx, binding, kind, binding.NativeRootID, "", path, now, false); err != nil {
 		return err
@@ -1737,6 +1728,19 @@ func (c *Collector) allowedRoots(harness domain.AgentHarness) []string {
 		return []string{c.roots.QwenUsage}
 	default:
 		return nil
+	}
+}
+
+func sourceKindForHarness(harness domain.AgentHarness) (domain.UsageSourceKind, bool) {
+	switch harness {
+	case domain.HarnessClaudeCode:
+		return domain.UsageSourceClaudeMain, true
+	case domain.HarnessCodex:
+		return domain.UsageSourceCodexRollout, true
+	case domain.HarnessQwen:
+		return domain.UsageSourceQwenMonthly, true
+	default:
+		return "", false
 	}
 }
 

--- a/backend/internal/service/usage/collector_qwen_test.go
+++ b/backend/internal/service/usage/collector_qwen_test.go
@@ -1,0 +1,74 @@
+package usage
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestDefaultSourceRootsIncludesQwenUsage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+
+	got, err := DefaultSourceRoots(context.Background())
+	mustNoError(t, err)
+	if got.QwenUsage != filepath.Join(home, ".qwen", "usage") {
+		t.Fatalf("Qwen usage root = %q", got.QwenUsage)
+	}
+}
+
+func TestCollectorDiscoversQwenSharedMonthlyUsage(t *testing.T) {
+	const nativeID = "qwen-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessQwen, nativeID, false)
+	root := t.TempDir()
+	path := filepath.Join(root, "token-usage-2026-08.jsonl")
+	writeUsageFixture(t, path, `{"schemaVersion":1,"id":"turn-1","sessionId":"`+nativeID+`","model":"qwen3","inputTokens":1,"outputTokens":1,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":2}`+"\n")
+	collector := NewCollector(store, SourceRoots{QwenUsage: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessQwen, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, err := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	if err != nil || len(bindings) != 1 {
+		t.Fatalf("bindings=%+v err=%v", bindings, err)
+	}
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 1 || sources[0].Kind != domain.UsageSourceQwenMonthly {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+}
+
+func TestCollectorQwenRegistersLaterMonthlyRollover(t *testing.T) {
+	const nativeID = "qwen-session-1"
+	store := collectorTestStore(t)
+	session := collectorTestSession(t, store, domain.HarnessQwen, nativeID, false)
+	root := t.TempDir()
+	july := filepath.Join(root, "token-usage-2026-07.jsonl")
+	writeUsageFixture(t, july, "{}\n")
+	collector := NewCollector(store, SourceRoots{QwenUsage: root}, nil)
+
+	mustNoError(t, collector.RecordHook(context.Background(), session.ID, HookSignal{
+		Harness: domain.HarnessQwen, Event: "session-start", NativeSessionID: nativeID,
+	}))
+	bindings, _ := store.ListUsageBindingsForSession(context.Background(), session.ID)
+	august := filepath.Join(root, "token-usage-2026-08.jsonl")
+	writeUsageFixture(t, august, "{}\n")
+	mustNoError(t, collector.ReconcileSources(context.Background(), -1))
+
+	sources, err := store.ListUsageSourcesForBinding(context.Background(), bindings[0].ID)
+	if err != nil || len(sources) != 2 {
+		t.Fatalf("sources=%+v err=%v", sources, err)
+	}
+	got := []string{sources[0].ArtifactPath, sources[1].ArtifactPath}
+	slices.Sort(got)
+	want := []string{canonicalUsagePath(t, july), canonicalUsagePath(t, august)}
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Fatalf("paths=%v want=%v", got, want)
+	}
+}

--- a/backend/internal/service/usage/collector_qwen_test.go
+++ b/backend/internal/service/usage/collector_qwen_test.go
@@ -2,6 +2,8 @@ package usage
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -13,11 +15,67 @@ func TestDefaultSourceRootsIncludesQwenUsage(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("CODEX_HOME", "")
+	t.Setenv("QWEN_HOME", "")
+	t.Setenv("QWEN_RUNTIME_DIR", "")
 
 	got, err := DefaultSourceRoots(context.Background())
 	mustNoError(t, err)
 	if got.QwenUsage != filepath.Join(home, ".qwen", "usage") {
 		t.Fatalf("Qwen usage root = %q", got.QwenUsage)
+	}
+}
+
+func TestDefaultSourceRootsUsesQwenHome(t *testing.T) {
+	home := t.TempDir()
+	qwenHome := filepath.Join(t.TempDir(), "qwen-home")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("QWEN_HOME", qwenHome)
+	t.Setenv("QWEN_RUNTIME_DIR", "")
+
+	got, err := DefaultSourceRoots(context.Background())
+	mustNoError(t, err)
+	if got.QwenUsage != filepath.Join(qwenHome, "usage") {
+		t.Fatalf("Qwen usage root = %q, want QWEN_HOME usage", got.QwenUsage)
+	}
+}
+
+func TestDefaultSourceRootsUsesConfiguredQwenRuntimeDirectory(t *testing.T) {
+	home := t.TempDir()
+	qwenHome := filepath.Join(t.TempDir(), "qwen-home")
+	runtimeDir := filepath.Join(t.TempDir(), "qwen-runtime")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("QWEN_HOME", qwenHome)
+	t.Setenv("QWEN_RUNTIME_DIR", "")
+	if err := os.MkdirAll(qwenHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := []byte(`{"advanced":{"runtimeOutputDir":` + fmt.Sprintf("%q", runtimeDir) + `}}`)
+	if err := os.WriteFile(filepath.Join(qwenHome, "settings.json"), settings, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := DefaultSourceRoots(context.Background())
+	mustNoError(t, err)
+	if got.QwenUsage != filepath.Join(runtimeDir, "usage") {
+		t.Fatalf("Qwen usage root = %q, want configured runtime usage", got.QwenUsage)
+	}
+}
+
+func TestDefaultSourceRootsQwenRuntimeEnvironmentTakesPrecedence(t *testing.T) {
+	home := t.TempDir()
+	qwenHome := filepath.Join(t.TempDir(), "qwen-home")
+	runtimeDir := filepath.Join(t.TempDir(), "qwen-runtime")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("QWEN_HOME", qwenHome)
+	t.Setenv("QWEN_RUNTIME_DIR", runtimeDir)
+
+	got, err := DefaultSourceRoots(context.Background())
+	mustNoError(t, err)
+	if got.QwenUsage != filepath.Join(runtimeDir, "usage") {
+		t.Fatalf("Qwen usage root = %q, want QWEN_RUNTIME_DIR usage", got.QwenUsage)
 	}
 }
 

--- a/backend/internal/service/usage/collector_qwen_test.go
+++ b/backend/internal/service/usage/collector_qwen_test.go
@@ -72,3 +72,22 @@ func TestCollectorQwenRegistersLaterMonthlyRollover(t *testing.T) {
 		t.Fatalf("paths=%v want=%v", got, want)
 	}
 }
+
+func TestSourceKindForHarness(t *testing.T) {
+	tests := []struct {
+		harness domain.AgentHarness
+		want    domain.UsageSourceKind
+		ok      bool
+	}{
+		{harness: domain.HarnessClaudeCode, want: domain.UsageSourceClaudeMain, ok: true},
+		{harness: domain.HarnessCodex, want: domain.UsageSourceCodexRollout, ok: true},
+		{harness: domain.HarnessQwen, want: domain.UsageSourceQwenMonthly, ok: true},
+		{harness: domain.HarnessAider, ok: false},
+	}
+	for _, tt := range tests {
+		got, ok := sourceKindForHarness(tt.harness)
+		if got != tt.want || ok != tt.ok {
+			t.Fatalf("sourceKindForHarness(%q) = %q, %v; want %q, %v", tt.harness, got, ok, tt.want, tt.ok)
+		}
+	}
+}

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -494,7 +494,7 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex')
+      AND ub.harness IN ('claude-code', 'codex', 'qwen')
       AND (
           ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
@@ -1130,13 +1130,13 @@ SELECT ub.id, ub.session_id, ub.harness, ub.native_root_id, ub.initial_model_id,
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.harness IN ('claude-code', 'codex', 'qwen')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness = 'claude-code'
+      ub.harness IN ('claude-code', 'qwen')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -121,6 +121,7 @@ var shippedMigrations = map[int64]string{
 	114: "0114_usage_cost_candidate_canonical_index.sql",
 	115: "0115_usage_measurement_and_provider_usage.sql",
 	116: "0116_usage_billing_provider_source.sql",
+	117: "0117_allow_qwen_usage.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_qwen_usage_test.go
+++ b/backend/internal/storage/sqlite/migrate_qwen_usage_test.go
@@ -5,11 +5,11 @@ import (
 	"time"
 )
 
-// TestMigration0110DownPreservesKimiAndPiUsage catches rolling back Qwen by
+// TestMigration0117DownPreservesKimiAndPiUsage catches rolling back Qwen by
 // deleting sibling-provider usage owned by still-applied migrations.
-func TestMigration0110DownPreservesKimiAndPiUsage(t *testing.T) {
+func TestMigration0117DownPreservesKimiAndPiUsage(t *testing.T) {
 	db := openTestDB(t)
-	upTo(t, db, 110)
+	upTo(t, db, 117)
 	now := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
 	if _, err := db.Exec(`INSERT INTO projects (id, path, display_name, registered_at) VALUES ('usage-migration', '/tmp/usage-migration', 'usage', ?)`, now); err != nil {
 		t.Fatal(err)
@@ -30,17 +30,19 @@ func TestMigration0110DownPreservesKimiAndPiUsage(t *testing.T) {
 			t.Fatalf("seed %s source: %v", harness, err)
 		}
 		sourceID, _ := result.LastInsertId()
-		result, err = db.Exec(`INSERT INTO model_usage_events (binding_id, usage_source_id, provider_id, model_id, input_tokens, input_provenance, cached_input_tokens, cached_input_provenance, uncached_input_tokens, uncached_input_provenance, output_tokens, output_provenance, source_event_key, created_at) VALUES (?, ?, 'openai', 'model', 3, 'reported', 1, 'reported', 2, 'reported', 1, 'reported', ?, ?)`, bindingID, sourceID, "event-"+harness, now)
+		_, err = db.Exec(`INSERT INTO model_usage_events (
+            binding_id, usage_source_id, provider_id, model_id,
+            usage_measurement_kind, input_tokens, cached_input_tokens,
+            uncached_input_tokens, output_tokens, provider_usage_json,
+            source_event_key, created_at
+        ) VALUES (?, ?, 'openai', 'model', 'native_reported', 3, 1, 2, 1,
+                  '{"totalTokens":4}', ?, ?)`, bindingID, sourceID, "event-"+harness, now)
 		if err != nil {
 			t.Fatalf("seed %s event: %v", harness, err)
 		}
-		eventID, _ := result.LastInsertId()
-		if _, err := db.Exec(`INSERT INTO openai_usage_event_details (event_id, openai_reported_total_tokens) VALUES (?, 4)`, eventID); err != nil {
-			t.Fatalf("seed %s details: %v", harness, err)
-		}
 	}
 
-	downTo(t, db, 107)
+	downTo(t, db, 116)
 	counts := map[string]int{}
 	for _, harness := range harnesses {
 		var count int

--- a/backend/internal/storage/sqlite/migrate_qwen_usage_test.go
+++ b/backend/internal/storage/sqlite/migrate_qwen_usage_test.go
@@ -1,0 +1,55 @@
+package sqlite
+
+import (
+	"testing"
+	"time"
+)
+
+// TestMigration0110DownPreservesKimiAndPiUsage catches rolling back Qwen by
+// deleting sibling-provider usage owned by still-applied migrations.
+func TestMigration0110DownPreservesKimiAndPiUsage(t *testing.T) {
+	db := openTestDB(t)
+	upTo(t, db, 110)
+	now := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+	if _, err := db.Exec(`INSERT INTO projects (id, path, display_name, registered_at) VALUES ('usage-migration', '/tmp/usage-migration', 'usage', ?)`, now); err != nil {
+		t.Fatal(err)
+	}
+	harnesses := []string{"kimi", "pi", "qwen"}
+	kinds := map[string]string{"kimi": "kimi_wire", "pi": "pi_session", "qwen": "qwen_monthly"}
+	for index, harness := range harnesses {
+		if _, err := db.Exec(`INSERT INTO sessions (id, project_id, num, kind, harness, activity_state, activity_last_at, is_terminated, created_at, updated_at) VALUES (?, 'usage-migration', ?, 'worker', ?, 'active', ?, 0, ?, ?)`, "session-"+harness, index+1, harness, now, now, now); err != nil {
+			t.Fatalf("seed %s session: %v", harness, err)
+		}
+		result, err := db.Exec(`INSERT INTO usage_bindings (session_id, harness, native_root_id, state, updated_at) VALUES (?, ?, ?, 'active', ?)`, "session-"+harness, harness, "native-"+harness, now)
+		if err != nil {
+			t.Fatalf("seed %s binding: %v", harness, err)
+		}
+		bindingID, _ := result.LastInsertId()
+		result, err = db.Exec(`INSERT INTO usage_sources (binding_id, kind, native_session_id, artifact_path, state, updated_at) VALUES (?, ?, ?, ?, 'active', ?)`, bindingID, kinds[harness], "native-"+harness, "/tmp/"+harness+".jsonl", now)
+		if err != nil {
+			t.Fatalf("seed %s source: %v", harness, err)
+		}
+		sourceID, _ := result.LastInsertId()
+		result, err = db.Exec(`INSERT INTO model_usage_events (binding_id, usage_source_id, provider_id, model_id, input_tokens, input_provenance, cached_input_tokens, cached_input_provenance, uncached_input_tokens, uncached_input_provenance, output_tokens, output_provenance, source_event_key, created_at) VALUES (?, ?, 'openai', 'model', 3, 'reported', 1, 'reported', 2, 'reported', 1, 'reported', ?, ?)`, bindingID, sourceID, "event-"+harness, now)
+		if err != nil {
+			t.Fatalf("seed %s event: %v", harness, err)
+		}
+		eventID, _ := result.LastInsertId()
+		if _, err := db.Exec(`INSERT INTO openai_usage_event_details (event_id, openai_reported_total_tokens) VALUES (?, 4)`, eventID); err != nil {
+			t.Fatalf("seed %s details: %v", harness, err)
+		}
+	}
+
+	downTo(t, db, 107)
+	counts := map[string]int{}
+	for _, harness := range harnesses {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM model_usage_events event JOIN usage_bindings binding ON binding.id = event.binding_id WHERE binding.harness = ?`, harness).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		counts[harness] = count
+	}
+	if counts["kimi"] != 1 || counts["pi"] != 1 || counts["qwen"] != 0 {
+		t.Fatalf("events after Qwen rollback = %+v, want kimi:1 pi:1 qwen:0", counts)
+	}
+}

--- a/backend/internal/storage/sqlite/migrations/0117_allow_qwen_usage.sql
+++ b/backend/internal/storage/sqlite/migrations/0117_allow_qwen_usage.sql
@@ -18,6 +18,7 @@ CREATE TABLE usage_bindings_next (
     state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
     last_error_code    TEXT NOT NULL DEFAULT '',
     updated_at         TIMESTAMP NOT NULL,
+    provider_hint      TEXT NOT NULL DEFAULT '',
     UNIQUE (session_id, harness, native_root_id)
 );
 
@@ -46,7 +47,7 @@ CREATE TABLE usage_sources_next (
 
 INSERT INTO usage_bindings_next
 SELECT id, session_id, harness, native_root_id, initial_model_id,
-       state, last_error_code, updated_at
+       state, last_error_code, updated_at, provider_hint
 FROM usage_bindings;
 
 INSERT INTO usage_sources_next
@@ -101,18 +102,6 @@ DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
 DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
 DROP TRIGGER IF EXISTS usage_sources_cdc_update;
 
-DELETE FROM anthropic_usage_event_details
-WHERE event_id IN (
-    SELECT event.id FROM model_usage_events event
-    JOIN usage_bindings binding ON binding.id = event.binding_id
-    WHERE binding.harness = 'qwen'
-);
-DELETE FROM openai_usage_event_details
-WHERE event_id IN (
-    SELECT event.id FROM model_usage_events event
-    JOIN usage_bindings binding ON binding.id = event.binding_id
-    WHERE binding.harness = 'qwen'
-);
 DELETE FROM model_usage_events
 WHERE binding_id IN (
     SELECT id FROM usage_bindings WHERE harness = 'qwen'
@@ -127,6 +116,7 @@ CREATE TABLE usage_bindings_previous (
     state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
     last_error_code    TEXT NOT NULL DEFAULT '',
     updated_at         TIMESTAMP NOT NULL,
+    provider_hint      TEXT NOT NULL DEFAULT '',
     UNIQUE (session_id, harness, native_root_id)
 );
 
@@ -155,7 +145,7 @@ CREATE TABLE usage_sources_previous (
 
 INSERT INTO usage_bindings_previous
 SELECT id, session_id, harness, native_root_id, initial_model_id,
-       state, last_error_code, updated_at
+       state, last_error_code, updated_at, provider_hint
 FROM usage_bindings
 WHERE harness IN ('claude-code', 'codex', 'kimi', 'pi');
 

--- a/backend/internal/storage/sqlite/migrations/0117_allow_qwen_usage.sql
+++ b/backend/internal/storage/sqlite/migrations/0117_allow_qwen_usage.sql
@@ -1,0 +1,204 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+PRAGMA foreign_keys=OFF;
+PRAGMA legacy_alter_table=ON;
+BEGIN IMMEDIATE;
+
+DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
+DROP TRIGGER IF EXISTS usage_sources_cdc_update;
+
+CREATE TABLE usage_bindings_next (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex', 'kimi', 'pi', 'qwen')),
+    native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id   TEXT NOT NULL DEFAULT '',
+    state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code    TEXT NOT NULL DEFAULT '',
+    updated_at         TIMESTAMP NOT NULL,
+    UNIQUE (session_id, harness, native_root_id)
+);
+
+CREATE TABLE usage_sources_next (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind                TEXT NOT NULL CHECK (kind IN (
+                            'claude_main', 'claude_subagent', 'codex_rollout',
+                            'kimi_wire', 'pi_session', 'qwen_monthly'
+                        )),
+    native_session_id   TEXT NOT NULL DEFAULT '',
+    subagent_id         TEXT NOT NULL DEFAULT '',
+    artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity       TEXT NOT NULL DEFAULT '',
+    generation          INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset         INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    parser_state_json   TEXT NOT NULL DEFAULT '{}',
+    state               TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count       INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count       INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at       TIMESTAMP,
+    last_error_code     TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+
+INSERT INTO usage_bindings_next
+SELECT id, session_id, harness, native_root_id, initial_model_id,
+       state, last_error_code, updated_at
+FROM usage_bindings;
+
+INSERT INTO usage_sources_next
+SELECT id, binding_id, kind, native_session_id, subagent_id, artifact_path,
+       file_identity, generation, byte_offset, parser_state_json, state,
+       failure_count, anomaly_count, next_retry_at, last_error_code, updated_at
+FROM usage_sources;
+
+DROP TABLE usage_sources;
+DROP TABLE usage_bindings;
+ALTER TABLE usage_bindings_next RENAME TO usage_bindings;
+ALTER TABLE usage_sources_next RENAME TO usage_sources;
+
+CREATE INDEX idx_usage_bindings_session_state ON usage_bindings (session_id, state);
+CREATE INDEX idx_usage_sources_state_retry ON usage_sources (state, next_retry_at);
+CREATE INDEX idx_usage_sources_binding_kind ON usage_sources (binding_id, kind);
+CREATE INDEX idx_usage_sources_codex_native_latest
+    ON usage_sources (kind, native_session_id, binding_id, generation DESC, id DESC);
+
+CREATE TRIGGER usage_bindings_cdc_insert AFTER INSERT ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_bindings_cdc_update AFTER UPDATE ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_sources_cdc_update AFTER UPDATE ON usage_sources
+WHEN OLD.anomaly_count IS NOT NEW.anomaly_count
+  OR OLD.last_error_code IS NOT NEW.last_error_code
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, ub.session_id, 'session_updated', json_object('id', ub.session_id), NEW.updated_at
+    FROM usage_bindings ub JOIN sessions s ON s.id = ub.session_id WHERE ub.id = NEW.binding_id;
+END;
+
+COMMIT;
+PRAGMA legacy_alter_table=OFF;
+PRAGMA foreign_keys=ON;
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+PRAGMA foreign_keys=OFF;
+PRAGMA legacy_alter_table=ON;
+BEGIN IMMEDIATE;
+
+DROP TRIGGER IF EXISTS usage_bindings_cdc_insert;
+DROP TRIGGER IF EXISTS usage_bindings_cdc_update;
+DROP TRIGGER IF EXISTS usage_sources_cdc_update;
+
+DELETE FROM anthropic_usage_event_details
+WHERE event_id IN (
+    SELECT event.id FROM model_usage_events event
+    JOIN usage_bindings binding ON binding.id = event.binding_id
+    WHERE binding.harness IN ('kimi', 'pi', 'qwen')
+);
+DELETE FROM openai_usage_event_details
+WHERE event_id IN (
+    SELECT event.id FROM model_usage_events event
+    JOIN usage_bindings binding ON binding.id = event.binding_id
+    WHERE binding.harness IN ('kimi', 'pi', 'qwen')
+);
+DELETE FROM model_usage_events
+WHERE binding_id IN (
+    SELECT id FROM usage_bindings WHERE harness IN ('kimi', 'pi', 'qwen')
+);
+
+CREATE TABLE usage_bindings_previous (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex')),
+    native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
+    initial_model_id   TEXT NOT NULL DEFAULT '',
+    state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
+    last_error_code    TEXT NOT NULL DEFAULT '',
+    updated_at         TIMESTAMP NOT NULL,
+    UNIQUE (session_id, harness, native_root_id)
+);
+
+CREATE TABLE usage_sources_previous (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
+    kind                TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout')),
+    native_session_id   TEXT NOT NULL DEFAULT '',
+    subagent_id         TEXT NOT NULL DEFAULT '',
+    artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
+    file_identity       TEXT NOT NULL DEFAULT '',
+    generation          INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    byte_offset         INTEGER NOT NULL DEFAULT 0 CHECK (byte_offset >= 0),
+    parser_state_json   TEXT NOT NULL DEFAULT '{}',
+    state               TEXT NOT NULL CHECK (state IN ('pending', 'active', 'complete', 'error')),
+    failure_count       INTEGER NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+    anomaly_count       INTEGER NOT NULL DEFAULT 0 CHECK (anomaly_count >= 0),
+    next_retry_at       TIMESTAMP,
+    last_error_code     TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE (binding_id, artifact_path, generation)
+);
+
+INSERT INTO usage_bindings_previous
+SELECT id, session_id, harness, native_root_id, initial_model_id,
+       state, last_error_code, updated_at
+FROM usage_bindings
+WHERE harness IN ('claude-code', 'codex');
+
+INSERT INTO usage_sources_previous
+SELECT source.id, source.binding_id, source.kind, source.native_session_id,
+       source.subagent_id, source.artifact_path, source.file_identity,
+       source.generation, source.byte_offset, source.parser_state_json,
+       source.state, source.failure_count, source.anomaly_count,
+       source.next_retry_at, source.last_error_code, source.updated_at
+FROM usage_sources source
+JOIN usage_bindings_previous binding ON binding.id = source.binding_id
+WHERE source.kind IN ('claude_main', 'claude_subagent', 'codex_rollout');
+
+DROP TABLE usage_sources;
+DROP TABLE usage_bindings;
+ALTER TABLE usage_bindings_previous RENAME TO usage_bindings;
+ALTER TABLE usage_sources_previous RENAME TO usage_sources;
+
+CREATE INDEX idx_usage_bindings_session_state ON usage_bindings (session_id, state);
+CREATE INDEX idx_usage_sources_state_retry ON usage_sources (state, next_retry_at);
+CREATE INDEX idx_usage_sources_binding_kind ON usage_sources (binding_id, kind);
+CREATE INDEX idx_usage_sources_codex_native_latest
+    ON usage_sources (kind, native_session_id, binding_id, generation DESC, id DESC);
+
+CREATE TRIGGER usage_bindings_cdc_insert AFTER INSERT ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_bindings_cdc_update AFTER UPDATE ON usage_bindings BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id),
+            NEW.session_id, 'session_updated', json_object('id', NEW.session_id), NEW.updated_at);
+END;
+
+CREATE TRIGGER usage_sources_cdc_update AFTER UPDATE ON usage_sources
+WHEN OLD.anomaly_count IS NOT NEW.anomaly_count
+  OR OLD.last_error_code IS NOT NEW.last_error_code
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    SELECT s.project_id, ub.session_id, 'session_updated', json_object('id', ub.session_id), NEW.updated_at
+    FROM usage_bindings ub JOIN sessions s ON s.id = ub.session_id WHERE ub.id = NEW.binding_id;
+END;
+
+COMMIT;
+PRAGMA legacy_alter_table=OFF;
+PRAGMA foreign_keys=ON;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/migrations/0117_allow_qwen_usage.sql
+++ b/backend/internal/storage/sqlite/migrations/0117_allow_qwen_usage.sql
@@ -105,23 +105,23 @@ DELETE FROM anthropic_usage_event_details
 WHERE event_id IN (
     SELECT event.id FROM model_usage_events event
     JOIN usage_bindings binding ON binding.id = event.binding_id
-    WHERE binding.harness IN ('kimi', 'pi', 'qwen')
+    WHERE binding.harness = 'qwen'
 );
 DELETE FROM openai_usage_event_details
 WHERE event_id IN (
     SELECT event.id FROM model_usage_events event
     JOIN usage_bindings binding ON binding.id = event.binding_id
-    WHERE binding.harness IN ('kimi', 'pi', 'qwen')
+    WHERE binding.harness = 'qwen'
 );
 DELETE FROM model_usage_events
 WHERE binding_id IN (
-    SELECT id FROM usage_bindings WHERE harness IN ('kimi', 'pi', 'qwen')
+    SELECT id FROM usage_bindings WHERE harness = 'qwen'
 );
 
 CREATE TABLE usage_bindings_previous (
     id                 INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id         TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
-    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex')),
+    harness            TEXT NOT NULL CHECK (harness IN ('claude-code', 'codex', 'kimi', 'pi')),
     native_root_id     TEXT NOT NULL CHECK (trim(native_root_id) <> ''),
     initial_model_id   TEXT NOT NULL DEFAULT '',
     state              TEXT NOT NULL CHECK (state IN ('discovering', 'active', 'finalizing', 'complete', 'partial')),
@@ -133,7 +133,10 @@ CREATE TABLE usage_bindings_previous (
 CREATE TABLE usage_sources_previous (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     binding_id          INTEGER NOT NULL REFERENCES usage_bindings (id) ON DELETE CASCADE,
-    kind                TEXT NOT NULL CHECK (kind IN ('claude_main', 'claude_subagent', 'codex_rollout')),
+    kind                TEXT NOT NULL CHECK (kind IN (
+                            'claude_main', 'claude_subagent', 'codex_rollout',
+                            'kimi_wire', 'pi_session'
+                        )),
     native_session_id   TEXT NOT NULL DEFAULT '',
     subagent_id         TEXT NOT NULL DEFAULT '',
     artifact_path       TEXT NOT NULL CHECK (trim(artifact_path) <> ''),
@@ -154,7 +157,7 @@ INSERT INTO usage_bindings_previous
 SELECT id, session_id, harness, native_root_id, initial_model_id,
        state, last_error_code, updated_at
 FROM usage_bindings
-WHERE harness IN ('claude-code', 'codex');
+WHERE harness IN ('claude-code', 'codex', 'kimi', 'pi');
 
 INSERT INTO usage_sources_previous
 SELECT source.id, source.binding_id, source.kind, source.native_session_id,
@@ -164,7 +167,7 @@ SELECT source.id, source.binding_id, source.kind, source.native_session_id,
        source.next_retry_at, source.last_error_code, source.updated_at
 FROM usage_sources source
 JOIN usage_bindings_previous binding ON binding.id = source.binding_id
-WHERE source.kind IN ('claude_main', 'claude_subagent', 'codex_rollout');
+WHERE source.kind IN ('claude_main', 'claude_subagent', 'codex_rollout', 'kimi_wire', 'pi_session');
 
 DROP TABLE usage_sources;
 DROP TABLE usage_bindings;

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -111,7 +111,7 @@ SELECT CAST(EXISTS (
     FROM usage_bindings ub
     JOIN sessions s ON s.id = ub.session_id
     WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-      AND ub.harness IN ('claude-code', 'codex')
+      AND ub.harness IN ('claude-code', 'codex', 'qwen')
       AND (
           ub.state = 'discovering'
           OR ub.last_error_code = 'source_discovery_pending'
@@ -161,13 +161,13 @@ SELECT ub.*
 FROM usage_bindings ub
 JOIN sessions s ON s.id = ub.session_id
 WHERE (s.is_terminated = 0 OR ub.state = 'finalizing')
-  AND ub.harness IN ('claude-code', 'codex')
+  AND ub.harness IN ('claude-code', 'codex', 'qwen')
   AND (
       ub.state IN ('discovering', 'active', 'finalizing')
       OR (ub.state = 'partial' AND ub.last_error_code = 'codex_source_budget_exceeded')
   )
   AND (
-      ub.harness = 'claude-code'
+      ub.harness IN ('claude-code', 'qwen')
       OR ub.state = 'discovering'
       OR ub.state = 'finalizing'
       OR ub.last_error_code = 'codex_source_budget_exceeded'

--- a/backend/internal/storage/sqlite/store/usage_store.go
+++ b/backend/internal/storage/sqlite/store/usage_store.go
@@ -976,7 +976,7 @@ func usageAggregateFromGen(row gen.AggregateUsageBySessionHarnessModelRow) domai
 
 func validateUsageEvent(harness domain.AgentHarness, event domain.ModelUsageEvent) error {
 	expectedProvider := domain.UsageProviderAnthropic
-	if harness == domain.HarnessCodex {
+	if harness == domain.HarnessCodex || harness == domain.HarnessQwen {
 		expectedProvider = domain.UsageProviderOpenAI
 	}
 	if event.ProviderID != expectedProvider || event.ModelID == "" || event.SourceEventKey == "" {

--- a/backend/internal/storage/sqlite/store/usage_store_test.go
+++ b/backend/internal/storage/sqlite/store/usage_store_test.go
@@ -1678,6 +1678,39 @@ func seedUsageSession(t *testing.T, s *sqlite.Store, harness domain.AgentHarness
 	return got
 }
 
+func TestQwenUsageEventRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	session := seedUsageSession(t, s, domain.HarnessQwen)
+	binding := mustUpsertUsageBinding(t, s, session, now, domain.UsageBindingRecord{
+		NativeRootID: "qwen-session",
+		State:        domain.UsageBindingActive,
+	})
+	source := mustInsertUsageSource(t, s, now, domain.UsageSourceRecord{
+		BindingID:       binding.ID,
+		Kind:            domain.UsageSourceQwenMonthly,
+		NativeSessionID: "qwen-session",
+		ArtifactPath:    "/tmp/qwen/token-usage-2026-08.jsonl",
+		FileIdentity:    "dev:ino",
+		State:           domain.UsageSourcePending,
+	})
+	event := usageEvent("qwen-event", canonicalUsageTokens(30, 9, 21, 16))
+	event.ModelID = "qwen3-coder"
+	if err := s.ApplyUsageChunk(context.Background(), source.ID, 0, source.UpdatedAt, domain.SourceCursorState{
+		ByteOffset: 100, State: domain.UsageSourceActive, ParserStateJSON: `{}`, UpdatedAt: now,
+	}, []domain.ModelUsageEvent{event}); err != nil {
+		t.Fatalf("apply Qwen usage: %v", err)
+	}
+	models, err := s.ListUsageModelAggregates(context.Background(), session.ID)
+	mustNoError(t, err)
+	if len(models) != 1 || models[0].Harness != domain.HarnessQwen ||
+		models[0].ModelID != "qwen3-coder" ||
+		usageTokenValue(models[0].Tokens.InputTokens) != 30 ||
+		usageTokenValue(models[0].Tokens.OutputTokens) != 16 {
+		t.Fatalf("Qwen aggregate = %+v", models)
+	}
+}
+
 func seedUsageSource(t *testing.T, s *sqlite.Store, sess domain.SessionRecord, now time.Time) domain.UsageSourceRecord {
 	t.Helper()
 	initialModelID := "gpt-5"


### PR DESCRIPTION
## What

Adds Qwen token-usage observability as a standalone change based on the latest `main`.

- parses Qwen monthly token-usage JSONL and attributes records by bound session ID
- discovers the current monthly usage file under `~/.qwen/usage`
- supports month rollover and missing-source retry
- persists and aggregates Qwen usage through the shared collector and SQLite store
- adds parser, discovery, rollover, migration, and storage coverage

## Why this PR was recreated

The earlier provider PRs were stacked on one another instead of being based cleanly on `main`. That made them difficult to review and prevented them from merging independently into `main`.

This replaces the earlier Qwen PR #4185 without carrying Kimi or Pi branch history. Qwen can now be reviewed, tested, merged, or reverted independently.

## Related PRs and merge order

1. **Kimi:** #4311
2. **Pi:** #4326
3. **Qwen:** #4327 (this PR)

All three target `main`; the order above is recommended for the provider-usage migrations.

## Implementation

Qwen's shared monthly records are filtered by the bound session ID and normalized into the shared token model. Discovery selects the latest valid monthly file and continues across month rollover. Migration 0110 is intentionally relative to the Kimi and Pi migrations: it adds Qwen support on upgrade and removes only Qwen usage on rollback, preserving Kimi and Pi data and constraints.

## Testing

- `go test ./internal/observe/usage ./internal/service/usage ./internal/storage/sqlite ./internal/storage/sqlite/store -count=1`
- `go test ./internal/daemon -count=1`
- `go vet` over all changed backend packages
- golangci-lint v2.12.2 over all changed packages: `0 issues`
- `git diff --check`

The full backend run only encountered the repository's pre-existing timing-sensitive fake-agent lifecycle test under concurrent machine load. All directly affected packages pass.

## Checklist

- [x] Based on the latest `main`
- [x] Contains only Qwen provider logic
- [x] Tests added for the changed behavior
- [x] Relevant local checks pass
