### PR TITLE
fix(chat): restore navigation to root conversation branches

### DIFF
--- a/backend/internal/httpd/controllers/conversation_history_test.go
+++ b/backend/internal/httpd/controllers/conversation_history_test.go
@@ -218,6 +218,19 @@ func TestActivateConversationBranchRouteResumesWithoutBody(t *testing.T) {
 	}
 }
 
+func TestActivateConversationBranchRouteDecodesEscapedBranchID(t *testing.T) {
+	svc := &fakeChatService{activate: "conversation-1:root"}
+	srv := newChatTestServer(t, svc)
+	body, status, _ := doRequest(t, srv, http.MethodPost,
+		"/api/v1/sessions/ao-1/conversation/branches/conversation-1%3Aroot/activate", "")
+	if status != http.StatusAccepted {
+		t.Fatalf("status = %d, body = %s", status, body)
+	}
+	if svc.gotBranchID != "conversation-1:root" {
+		t.Fatalf("branch id = %q, want decoded root id", svc.gotBranchID)
+	}
+}
+
 func TestActivateConversationBranchRouteReportsMissingBranch(t *testing.T) {
 	svc := &fakeChatService{activateErr: domain.ErrNoConversationBranch}
 	srv := newChatTestServer(t, svc)

--- a/backend/internal/httpd/controllers/conversations.go
+++ b/backend/internal/httpd/controllers/conversations.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -119,8 +120,14 @@ func (c *ConversationsController) activateBranch(w http.ResponseWriter, r *http.
 			"/api/v1/sessions/{sessionId}/conversation/branches/{branchId}/activate")
 		return
 	}
+	branchID, err := url.PathUnescape(chi.URLParam(r, "branchId"))
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "validation",
+			"CHAT_BRANCH_INVALID", "conversation branch identifier is invalid", nil)
+		return
+	}
 	active, err := c.Svc.ActivateBranch(r.Context(), domain.SessionID(chi.URLParam(r, "sessionId")),
-		chi.URLParam(r, "branchId"))
+		branchID)
 	if errors.Is(err, domain.ErrNoConversationBranch) {
 		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found",
 			"CHAT_BRANCH_NOT_FOUND", "that conversation branch does not exist", nil)

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -168,6 +168,7 @@ vi.mock("./TerminalSwitchAgentButton", () => ({
 }));
 vi.mock("./chat/SessionChatSurface", () => ({
 	SessionChatSurface: ({
+		session,
 		onOpenShell,
 		headerActions,
 		reviewerTerminal,
@@ -178,6 +179,7 @@ vi.mock("./chat/SessionChatSurface", () => ({
 		shellTarget,
 		onSelectShellTerminal,
 	}: {
+		session: WorkspaceSession;
 		onOpenShell?: () => void;
 		headerActions?: ReactNode;
 		reviewerTerminal?: { handleId: string; harness: string };
@@ -188,7 +190,14 @@ vi.mock("./chat/SessionChatSurface", () => ({
 		shellTarget?: { kind: "shell"; handleId: string };
 		onSelectShellTerminal?: (handleId: string) => void;
 	}) => (
-		<div data-testid="chat-surface">
+		<div
+			data-testid="chat-surface"
+			ref={(node) => {
+				if (node && !node.dataset.mountedSessionId) {
+					node.dataset.mountedSessionId = session.id;
+				}
+			}}
+		>
 			chat surface
 			{headerActions}
 			{reviewerTerminal ? (
@@ -565,6 +574,23 @@ describe("SessionView", () => {
 		fireEvent.click(screen.getByRole("button", { name: "select chat tab" }));
 		expect(screen.getByTestId("chat-surface")).toBeInTheDocument();
 		expect(screen.queryByTestId("terminal-target")).not.toBeInTheDocument();
+	});
+
+	it("starts with fresh Chat state when navigating to another session", () => {
+		workspaces[0].sessions[0].mode = "chat";
+		workspaces[0].sessions[1].mode = "chat";
+		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		expect(screen.getByTestId("chat-surface")).toHaveAttribute(
+			"data-mounted-session-id",
+			"sess-1",
+		);
+
+		rerender(<SessionView sessionId="sess-2" />);
+
+		expect(screen.getByTestId("chat-surface")).toHaveAttribute(
+			"data-mounted-session-id",
+			"sess-2",
+		);
 	});
 
 	// The strip only ever shows the session on screen — pinning another session's

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -858,6 +858,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 							    reviewer targets remain terminal surfaces in either mode. */}
 							{showChatSurface ? (
 								<SessionChatSurface
+									key={session.id}
 									session={session}
 									reviewerTerminal={reviewerTerminal}
 									onOpenReviewerTerminal={selectReviewerTerminal}


### PR DESCRIPTION
## What

Fix conversation branch navigation so a user can move from an edited branch (`2 / 2`) back to the root branch (`1 / 2`). Also reset the Chat surface when navigating between sessions so conversation-scoped mutation state cannot leak across tasks.

## Root cause

Root branch IDs use the form `<conversation-id>:root`. The generated frontend client correctly percent-encodes the colon as `%3A`, but Chi exposes that route parameter in encoded form. The controller passed the encoded value directly to the service, so SQLite searched for `<conversation-id>%3Aroot`, did not find it, and returned `CHAT_BRANCH_NOT_FOUND` even though `<conversation-id>:root` existed.

## How

- Decode the branch route parameter at the HTTP controller boundary before the conversation-scoped service lookup.
- Add a router-level regression test proving an encoded `%3Aroot` ID reaches the service as `:root`.
- Key `SessionChatSurface` by `session.id` so changing tasks creates a fresh conversation hook boundary.
- Add a frontend regression test covering that remount.

## Verification

- `go test ./internal/httpd/...`
- `go test ./internal/adapters/agent/fake -run TestFullLifecycleSpawnToTermination -count=1`
- `npm run typecheck` in `frontend/`
- `npm test -- --maxWorkers=1` in `frontend/` — 2,773 passed, 1 skipped
- Rebuilt and launched the isolated AO Electron app, restored the affected scratch session, activated its child branch, then activated the root through the formerly failing `%3Aroot` URL; both requests returned `202 Accepted` and the root response contained the decoded `:root` ID.

The full backend sweep encountered the unrelated timing-sensitive `TestFullLifecycleSpawnToTermination` failure under concurrent load; it passed immediately when rerun in isolation.

## Checklist

- [x] Branched from `main`
- [x] One focused bug fix
- [x] Regression tests added for the affected HTTP and UI boundaries
- [x] Relevant backend and frontend checks pass
