### PR TITLE
feat(sidebar): remember expanded projects

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -173,6 +173,7 @@ function renderSidebar({
 	workspaces = [workspace],
 	initialOpen = true,
 	autoCompact = false,
+	expandedProjectIds,
 }: {
 	onCloneProject?: CloneProjectHandler;
 	onCreateProject?: CreateProjectHandler;
@@ -182,7 +183,14 @@ function renderSidebar({
 	workspaces?: WorkspaceSummary[];
 	initialOpen?: boolean;
 	autoCompact?: boolean;
+	expandedProjectIds?: string[];
 } = {}) {
+	// Most legacy sidebar tests exercise session rows and assume their fixture
+	// project was previously open. Tests for the empty-store behavior opt out.
+	window.localStorage.setItem(
+		"ao.sidebar.expanded-projects",
+		JSON.stringify(expandedProjectIds ?? workspaces.map(({ id }) => id)),
+	);
 	const queryClient = new QueryClient({
 		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 	});
@@ -204,11 +212,11 @@ function renderSidebar({
 	}
 	render(
 		<QueryClientProvider client={queryClient}>
-				<SidebarProvider defaultOpen={initialOpen}>
-					<Sidebar
-						autoCompact={autoCompact}
-						onCloneProject={onCloneProject}
-						onCreateProject={onCreateProject}
+			<SidebarProvider defaultOpen={initialOpen}>
+				<Sidebar
+					autoCompact={autoCompact}
+					onCloneProject={onCloneProject}
+					onCreateProject={onCreateProject}
 					onInitializeProject={onInitializeProject}
 					onRemoveProject={onRemoveProject}
 					workspaces={workspaces}
@@ -219,7 +227,7 @@ function renderSidebar({
 	return onRemoveProject;
 }
 
-/** Projects render collapsed; open one to list all of its sessions. */
+/** Projects restore their persisted disclosure state. */
 
 async function chooseOption(trigger: HTMLElement, optionName: string) {
 	await userEvent.click(trigger);
@@ -1612,6 +1620,39 @@ describe("Sidebar", () => {
 
 		expect(screen.queryByLabelText("Open fix login")).not.toBeInTheDocument();
 		expect(screen.queryByLabelText("Open second task")).not.toBeInTheDocument();
+	});
+
+	it("starts every project collapsed when the expanded-project store is empty", () => {
+		renderSidebar({
+			expandedProjectIds: [],
+			workspaces: [{ ...workspace, sessions: [session] }],
+		});
+
+		expect(screen.queryByLabelText("Open fix login")).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Toggle Project One sessions" })).toHaveAttribute(
+			"aria-expanded",
+			"false",
+		);
+	});
+
+	it("restores only the projects saved as expanded and persists toggles", async () => {
+		const user = userEvent.setup();
+		const secondWorkspace = {
+			...workspace,
+			id: "proj-2",
+			name: "Project Two",
+			sessions: [{ ...session, id: "proj-2-1", title: "second task" }],
+		};
+		renderSidebar({
+			expandedProjectIds: [workspace.id],
+			workspaces: [{ ...workspace, sessions: [session] }, secondWorkspace],
+		});
+
+		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();
+		expect(screen.queryByLabelText("Open second task")).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Toggle Project One sessions" }));
+		expect(JSON.parse(window.localStorage.getItem("ao.sidebar.expanded-projects") ?? "null")).toEqual([]);
 	});
 
 	it("hides all sessions when project is collapsed via folder icon", async () => {

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1635,6 +1635,21 @@ describe("Sidebar", () => {
 		);
 	});
 
+	it("reveals the active project when opening a worker-session deep link", () => {
+		mockParams.projectId = workspace.id;
+		mockParams.sessionId = session.id;
+		renderSidebar({
+			expandedProjectIds: [],
+			workspaces: [{ ...workspace, sessions: [session] }],
+		});
+
+		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Toggle Project One sessions" })).toHaveAttribute(
+			"aria-expanded",
+			"true",
+		);
+	});
+
 	it("restores only the projects saved as expanded and persists toggles", async () => {
 		const user = userEvent.setup();
 		const secondWorkspace = {

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1635,7 +1635,8 @@ describe("Sidebar", () => {
 		);
 	});
 
-	it("reveals the active project when opening a worker-session deep link", () => {
+	it("reveals the active project when opening a worker-session deep link", async () => {
+		const user = userEvent.setup();
 		mockParams.projectId = workspace.id;
 		mockParams.sessionId = session.id;
 		renderSidebar({
@@ -1647,6 +1648,13 @@ describe("Sidebar", () => {
 		expect(screen.getByRole("button", { name: "Toggle Project One sessions" })).toHaveAttribute(
 			"aria-expanded",
 			"true",
+		);
+
+		await user.click(screen.getByRole("button", { name: "Toggle Project One sessions" }));
+		expect(screen.queryByLabelText("Open fix login")).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Toggle Project One sessions" })).toHaveAttribute(
+			"aria-expanded",
+			"false",
 		);
 	});
 

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -210,6 +210,9 @@ export function Sidebar({
 	const daemonStatus = useShellMaybe()?.daemonStatus ?? null;
 	const commandPaletteEnabled = useCommandPaletteEnabled();
 	const setCommandPaletteOpen = useUiStore((s) => s.setCommandPaletteOpen);
+	const initialActiveSessionProjectId = useRef(
+		selection.activeSessionId ? selection.activeProjectId : undefined,
+	).current;
 	useLayoutEffect(() => {
 		// Offcanvas: the panel slides off-screen on collapse — no need to hide content.
 		// Reveal immediately on expand so there's no fade-in delay.
@@ -221,6 +224,9 @@ export function Sidebar({
 	// Disclosure state is persisted as the IDs of projects that were expanded.
 	// An empty/missing store intentionally means all projects start collapsed.
 	const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => readExpandedProjectIds());
+	const [dismissedInitialActiveProjectIds, setDismissedInitialActiveProjectIds] = useState<ReadonlySet<string>>(
+		() => new Set(),
+	);
 	const toggleCollapsed = (id: string) =>
 		setExpandedIds((prev) => {
 			const next = new Set(prev);
@@ -228,6 +234,13 @@ export function Sidebar({
 			if (typeof window !== "undefined") {
 				window.localStorage?.setItem(expandedProjectsStorageKey, JSON.stringify([...next]));
 			}
+			return next;
+		});
+	const toggleInitialActiveProject = (id: string) =>
+		setDismissedInitialActiveProjectIds((prev) => {
+			if (initialActiveSessionProjectId !== id) return prev;
+			const next = new Set(prev);
+			prev.has(id) ? next.delete(id) : next.add(id);
 			return next;
 		});
 	// Section disclosure: Pinned header collapses its body. Projects stays open.
@@ -414,10 +427,17 @@ export function Sidebar({
 									<ProjectItem
 										key={workspace.id}
 										workspace={workspace}
-										expanded={expandedIds.has(workspace.id)}
+										expanded={
+											expandedIds.has(workspace.id) ||
+											(initialActiveSessionProjectId === workspace.id &&
+												!dismissedInitialActiveProjectIds.has(workspace.id))
+										}
 										suppressInitialExpandAnimation={expandedIds.has(workspace.id)}
 										selection={selection}
-										onToggle={() => toggleCollapsed(workspace.id)}
+										onToggle={() => {
+											toggleCollapsed(workspace.id);
+											toggleInitialActiveProject(workspace.id);
+										}}
 										onRemoveProject={onRemoveProject}
 									/>
 								))}

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -227,22 +227,25 @@ export function Sidebar({
 	const [dismissedInitialActiveProjectIds, setDismissedInitialActiveProjectIds] = useState<ReadonlySet<string>>(
 		() => new Set(),
 	);
-	const toggleCollapsed = (id: string) =>
+	const toggleProjectDisclosure = (id: string) => {
+		const routeFallbackActive =
+			initialActiveSessionProjectId === id && !dismissedInitialActiveProjectIds.has(id);
+		const currentlyExpanded = expandedIds.has(id) || routeFallbackActive;
 		setExpandedIds((prev) => {
 			const next = new Set(prev);
-			next.has(id) ? next.delete(id) : next.add(id);
+			currentlyExpanded ? next.delete(id) : next.add(id);
 			if (typeof window !== "undefined") {
 				window.localStorage?.setItem(expandedProjectsStorageKey, JSON.stringify([...next]));
 			}
 			return next;
 		});
-	const toggleInitialActiveProject = (id: string) =>
 		setDismissedInitialActiveProjectIds((prev) => {
 			if (initialActiveSessionProjectId !== id) return prev;
 			const next = new Set(prev);
-			prev.has(id) ? next.delete(id) : next.add(id);
+			currentlyExpanded ? next.add(id) : next.delete(id);
 			return next;
 		});
+	};
 	// Section disclosure: Pinned header collapses its body. Projects stays open.
 	const [pinnedOpen, setPinnedOpen] = useState(true);
 	// Fetch the running app version to derive the build channel. Channel is
@@ -434,10 +437,7 @@ export function Sidebar({
 										}
 										suppressInitialExpandAnimation={expandedIds.has(workspace.id)}
 										selection={selection}
-										onToggle={() => {
-											toggleCollapsed(workspace.id);
-											toggleInitialActiveProject(workspace.id);
-										}}
+										onToggle={() => toggleProjectDisclosure(workspace.id)}
 										onRemoveProject={onRemoveProject}
 									/>
 								))}

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -114,6 +114,17 @@ const MAX_DISPLAY_NAME_LEN = 20;
 export const SIDEBAR_DEFAULT_WIDTH = 240;
 export const SIDEBAR_MIN_WIDTH = 200;
 export const SIDEBAR_MAX_WIDTH = 420;
+const expandedProjectsStorageKey = "ao.sidebar.expanded-projects";
+
+function readExpandedProjectIds(): ReadonlySet<string> {
+	if (typeof window === "undefined" || !window.localStorage) return new Set();
+	try {
+		const value: unknown = JSON.parse(window.localStorage.getItem(expandedProjectsStorageKey) ?? "null");
+		return new Set(Array.isArray(value) ? value.filter((id): id is string => typeof id === "string") : []);
+	} catch {
+		return new Set();
+	}
+}
 
 type SidebarProps = {
 	/** Hide the sidebar's right edge stroke on the welcome board inset chrome. */
@@ -207,13 +218,16 @@ export function Sidebar({
 		}
 	}, [isCollapsed]);
 
-	// Disclosure state: projects are expanded by default; a project id present in
-	// this set is collapsed (sessions hidden).
-	const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(() => new Set());
+	// Disclosure state is persisted as the IDs of projects that were expanded.
+	// An empty/missing store intentionally means all projects start collapsed.
+	const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => readExpandedProjectIds());
 	const toggleCollapsed = (id: string) =>
-		setCollapsedIds((prev) => {
+		setExpandedIds((prev) => {
 			const next = new Set(prev);
 			next.has(id) ? next.delete(id) : next.add(id);
+			if (typeof window !== "undefined") {
+				window.localStorage?.setItem(expandedProjectsStorageKey, JSON.stringify([...next]));
+			}
 			return next;
 		});
 	// Section disclosure: Pinned header collapses its body. Projects stays open.
@@ -400,7 +414,8 @@ export function Sidebar({
 									<ProjectItem
 										key={workspace.id}
 										workspace={workspace}
-										expanded={!collapsedIds.has(workspace.id)}
+										expanded={expandedIds.has(workspace.id)}
+										suppressInitialExpandAnimation={expandedIds.has(workspace.id)}
 										selection={selection}
 										onToggle={() => toggleCollapsed(workspace.id)}
 										onRemoveProject={onRemoveProject}
@@ -522,12 +537,14 @@ function ProjectItem({
 	selection,
 	onToggle,
 	onRemoveProject,
+	suppressInitialExpandAnimation,
 }: {
 	workspace: WorkspaceSummary;
 	expanded: boolean;
 	selection: Selection;
 	onToggle: () => void;
 	onRemoveProject: (projectId: string) => Promise<void>;
+	suppressInitialExpandAnimation: boolean;
 }) {
 	const { t } = useTranslation();
 	const prefersReducedMotion = useReducedMotion();
@@ -550,6 +567,7 @@ function ProjectItem({
 	// want them to slide in on every sidebar load. Only animate on subsequent
 	// expand/collapse toggles.
 	const [animReady, setAnimReady] = useState(false);
+	const hasInteractedWithDisclosure = useRef(false);
 	useEffect(() => {
 		const id = requestAnimationFrame(() => setAnimReady(true));
 		return () => cancelAnimationFrame(id);
@@ -564,6 +582,10 @@ function ProjectItem({
 	// The project's live orchestrator (if any) backs the hover Orchestrator
 	// button: navigate to it when present, otherwise spawn one first.
 	const orchestrator = newestActiveOrchestrator(workspace.sessions);
+	const toggleDisclosure = () => {
+		hasInteractedWithDisclosure.current = true;
+		onToggle();
+	};
 
 	// Mirrors ShellTopbar's launcher: attach to the running orchestrator, or
 	// spawn one via the daemon and follow it once the workspace refetches.
@@ -571,7 +593,7 @@ function ProjectItem({
 	// session list — otherwise the tree stays shut while you're inside it.
 	const openOrchestrator = async () => {
 		if (isProjectRestarting) return;
-		if (!expanded) onToggle();
+		if (!expanded) toggleDisclosure();
 		if (orchestrator) {
 			selection.goSession(workspace.id, orchestrator.id);
 			return;
@@ -598,10 +620,10 @@ function ProjectItem({
 	// one-click path back from the orchestrator button.
 	const onProjectClick = () => {
 		if (!expanded) {
-			onToggle();
+			toggleDisclosure();
 			selection.goProject(workspace.id);
 		} else if (dashboardActive) {
-			onToggle();
+			toggleDisclosure();
 		} else {
 			selection.goProject(workspace.id);
 		}
@@ -612,7 +634,7 @@ function ProjectItem({
 	// select click then a second click (felt like a double-click).
 	const onFolderClick = (event: MouseEvent) => {
 		event.stopPropagation();
-		onToggle();
+		toggleDisclosure();
 	};
 
 	const onProjectKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
@@ -816,7 +838,9 @@ function ProjectItem({
 			{expanded && sessions.length > 0 && (
 				<motion.div
 					key="sessions"
-					initial={animReady ? { height: 0 } : false}
+					initial={
+						animReady && (!suppressInitialExpandAnimation || hasInteractedWithDisclosure.current) ? { height: 0 } : false
+					}
 					animate={{ height: "auto" }}
 					exit={{ height: 0 }}
 					transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.14, ease: [0.25, 0.46, 0.45, 0.94] }}
@@ -824,7 +848,11 @@ function ProjectItem({
 					className="sidebar-expanded-chrome"
 				>
 					<motion.div
-						initial={animReady ? { y: -12, opacity: 0 } : false}
+						initial={
+							animReady && (!suppressInitialExpandAnimation || hasInteractedWithDisclosure.current)
+								? { y: -12, opacity: 0 }
+								: false
+						}
 						animate={{ y: 0, opacity: 1 }}
 						exit={{ y: -12, opacity: 0 }}
 						transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.14, ease: [0.25, 0.46, 0.45, 0.94] }}


### PR DESCRIPTION
## Summary
- persist expanded project IDs in local storage
- restore only previously expanded projects; empty storage starts all collapsed
- suppress initial animations for restored project session lists

<img width="457" height="451" alt="image" src="https://github.com/user-attachments/assets/57dda313-9398-4dad-bae0-36f58a565a60" />


## Validation
- `git diff --check`
- Sidebar suite: 64 tests passed
- Full typecheck is blocked by missing workspace dependencies and existing packages/product-ui errors