### PR TITLE
fix(httpd): map transient DB-busy/deadline errors to 503, not opaque 500 (#4325)

### DIFF
--- a/backend/internal/httpd/apierr/apierr.go
+++ b/backend/internal/httpd/apierr/apierr.go
@@ -22,6 +22,11 @@ const (
 	KindConflict
 	// KindForbidden is an authenticated ownership failure; it maps to 403.
 	KindForbidden
+	// KindUnavailable is a transient failure the caller should retry (e.g. the
+	// database is momentarily busy/locked, or a server-side deadline elapsed);
+	// it maps to 503. Distinct from KindInternal so retryable contention is not
+	// counted or alerted as a server fault.
+	KindUnavailable
 )
 
 // Error is the structured error every service returns. Code is a stable machine
@@ -70,4 +75,9 @@ func Forbidden(code, message string) *Error {
 // Internal is a 500-class error.
 func Internal(code, message string) *Error {
 	return New(KindInternal, code, message, nil)
+}
+
+// Unavailable is a 503-class transient error the caller should retry.
+func Unavailable(code, message string) *Error {
+	return New(KindUnavailable, code, message, nil)
 }

--- a/backend/internal/httpd/envelope/envelope.go
+++ b/backend/internal/httpd/envelope/envelope.go
@@ -74,7 +74,42 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 		WriteAPIError(w, r, status, kind, e.Code, e.Message, e.Details)
 		return
 	}
+	// A transient failure (the database was momentarily busy/locked, or a
+	// server-side deadline elapsed) is retryable, not a server fault. Map it to
+	// 503 with a stable code so it is not counted or alerted as an
+	// INTERNAL_ERROR 500 and so clients can back off and retry.
+	if isTransient(err) {
+		WriteAPIError(w, r, http.StatusServiceUnavailable, "unavailable", "SERVICE_UNAVAILABLE",
+			"The service is momentarily unavailable, please retry.", nil)
+		return
+	}
 	WriteAPIError(w, r, http.StatusInternalServerError, "internal", "INTERNAL_ERROR", "Internal server error", nil)
+}
+
+// SQLite primary result codes for a busy/locked database. Extended codes (e.g.
+// SQLITE_BUSY_SNAPSHOT) carry these in their low byte. Declared here rather
+// than imported so the envelope layer does not depend on the DB driver; the
+// modernc.org/sqlite error type is matched structurally by its Code() method.
+const (
+	sqliteBusy   = 5
+	sqliteLocked = 6
+)
+
+// isTransient reports whether err is a retryable contention/timeout condition
+// rather than a genuine server fault. It matches the SQLite driver's error via
+// a Code() method (no driver import), plus server-side context deadlines.
+// Context cancellation (the client went away) is deliberately excluded — the
+// response never reaches that caller, and it is not retryable.
+func isTransient(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var coder interface{ Code() int }
+	if errors.As(err, &coder) {
+		c := coder.Code()
+		return c == sqliteBusy || c == sqliteLocked || c&0xFF == sqliteBusy || c&0xFF == sqliteLocked
+	}
+	return false
 }
 
 // httpStatus maps a semantic failure Kind to its HTTP status and wire word.
@@ -88,6 +123,8 @@ func httpStatus(k apierr.Kind) (int, string) {
 		return http.StatusConflict, "conflict"
 	case apierr.KindForbidden:
 		return http.StatusForbidden, "forbidden"
+	case apierr.KindUnavailable:
+		return http.StatusServiceUnavailable, "unavailable"
 	case apierr.KindInternal:
 		return http.StatusInternalServerError, "internal"
 	default:

--- a/backend/internal/httpd/envelope/envelope_test.go
+++ b/backend/internal/httpd/envelope/envelope_test.go
@@ -1,0 +1,99 @@
+package envelope
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+)
+
+// codeErr mimics the modernc.org/sqlite error surface (a Code() int method)
+// without importing the driver, so the transient detector can be tested in
+// isolation.
+type codeErr struct {
+	code int
+	msg  string
+}
+
+func (e codeErr) Error() string { return e.msg }
+func (e codeErr) Code() int     { return e.code }
+
+func statusOf(t *testing.T, err error) (int, string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/anything", nil)
+	WriteError(rec, req, err)
+	var body struct {
+		Code string `json:"code"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	return rec.Code, body.Code
+}
+
+func TestWriteError_TransientMapsTo503(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"sqlite busy", codeErr{code: sqliteBusy, msg: "database is locked"}},
+		{"sqlite locked", codeErr{code: sqliteLocked, msg: "database table is locked"}},
+		{"sqlite busy extended", codeErr{code: 261, msg: "SQLITE_BUSY_RECOVERY"}}, // 261 & 0xFF == 5
+		{"sqlite locked extended", codeErr{code: 262, msg: "SQLITE_LOCKED_SHAREDCACHE"}},
+		{"wrapped busy", fmt.Errorf("get session: %w", codeErr{code: sqliteBusy, msg: "database is locked"})},
+		{"deadline exceeded", context.DeadlineExceeded},
+		{"wrapped deadline", fmt.Errorf("query: %w", context.DeadlineExceeded)},
+		{"apierr unavailable", apierr.Unavailable("SERVICE_UNAVAILABLE", "busy")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _ := statusOf(t, tc.err)
+			if status != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want 503", status)
+			}
+		})
+	}
+}
+
+func TestWriteError_NonTransientStays500(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"plain error", errors.New("boom")},
+		// A non-busy sqlite code must NOT be treated as transient.
+		{"sqlite constraint", codeErr{code: 19, msg: "UNIQUE constraint failed"}},
+		// Client cancellation is deliberately excluded from transient.
+		{"context canceled", context.Canceled},
+		{"apierr internal", apierr.Internal("INTERNAL", "nope")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _ := statusOf(t, tc.err)
+			if status != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want 500", status)
+			}
+		})
+	}
+}
+
+func TestWriteError_TypedKindsUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		err    error
+		status int
+	}{
+		{apierr.Invalid("BAD", "x", nil), http.StatusBadRequest},
+		{apierr.NotFound("NF", "x"), http.StatusNotFound},
+		{apierr.Conflict("C", "x", nil), http.StatusConflict},
+		{apierr.Forbidden("F", "x"), http.StatusForbidden},
+	} {
+		status, _ := statusOf(t, tc.err)
+		if status != tc.status {
+			t.Fatalf("%v: status = %d, want %d", tc.err, status, tc.status)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4325.

## Problem
`envelope.WriteError` maps any non-`apierr` error to `INTERNAL_ERROR`/500. So transient SQLite busy/locked contention and server-side deadlines surface as genuine server faults — inflating the 5xx surface and making the true cause indistinguishable from a real bug.

## Change
- `apierr.KindUnavailable` (503) + `apierr.Unavailable(...)`.
- In `WriteError`, before the 500 fallback, detect transient conditions and return a typed **503 `SERVICE_UNAVAILABLE`** (retryable):
  - SQLite busy/locked, matched **structurally** via a `Code() int` method (primary code `5`/`6` or extended code low-byte), so `httpd/envelope` takes **no dependency** on the DB driver.
  - server-side `context.DeadlineExceeded`.
  - client `context.Canceled` is **excluded** on purpose (the response never reaches that caller; not retryable).

## Verification
- Real socket: a `database is locked` (Code 5) error returned via the production `WriteError` path yields `HTTP 503 SERVICE_UNAVAILABLE` across repeated attempts.
- Unit tests: busy / locked / extended-code / wrapped / deadline / `apierr.Unavailable` -> 503; plain error / non-busy sqlite code (constraint) / `context.Canceled` / `apierr.Internal` -> 500; existing typed kinds (400/404/409/403) unchanged. Run deterministically at `-count=100`.
- Full `internal/httpd/...` suite passes (no spec drift).

## Scope
Pure daemon HTTP classification. No route/DTO changes. Companion to #3963 (the DB contention this reclassifies) and #4323 (the SSE reconnect amplifier); #4180/#4181 (Sentry) give the remaining genuine 500s a grouped stack.
