### PR TITLE
fix(storage): recreate tables and columns skipped by burned migration versions

### DIFF
--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -938,6 +938,35 @@ BEGIN
 		addDDL: `ALTER TABLE conversation_turns ADD COLUMN promotion_started_at TIMESTAMP`},
 	{version: 89, table: "conversation_turns", column: "promoted_to_turn_id",
 		addDDL: `ALTER TABLE conversation_turns ADD COLUMN promoted_to_turn_id TEXT REFERENCES conversation_turns(id) ON DELETE SET NULL`},
+	// 0106_pr_comment_review_id.sql. Version 106 is recorded as applied on
+	// profiles where the physical column never landed — a burned/skipped
+	// migration — and preparePRCommentReviewIDMigration only repairs the mirror
+	// case (column present, ledger entry missing). The generated PR comment
+	// queries select review_id, so every PR read then 500s.
+	{version: 106, table: "pr_comment", column: "review_id",
+		addDDL: `ALTER TABLE pr_comment ADD COLUMN review_id TEXT NOT NULL DEFAULT ''`},
+}
+
+// tableRepairs is the table-level counterpart of schemaRepairs: migrations
+// whose schema effects are whole tables, recorded as applied on installs where
+// the table never physically landed. reconcileSchema's column check cannot see
+// this drift — pragma_table_info on an absent table returns zero rows and is
+// treated as healthy — so without this list a burned version leaves the daemon
+// green while every query against the missing table 500s.
+var tableRepairs = []struct {
+	version   int64
+	table     string
+	createDDL string
+}{
+	// 0104_agent_inventory_cache.sql. Profiles that recorded version 104 as
+	// applied without the table fail every agent-catalog refresh — the preflight
+	// dependency of ao spawn — while /readyz stays green (#4335).
+	{version: 104, table: "agent_inventory_cache",
+		createDDL: `CREATE TABLE agent_inventory_cache (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    inventory_json TEXT NOT NULL,
+    observed_at TIMESTAMP NOT NULL
+)`},
 }
 
 // reconcileSchema verifies that the columns in schemaRepairs physically exist
@@ -967,6 +996,23 @@ func reconcileSchema(db *sql.DB) error {
 			if _, err := db.Exec(stmt); err != nil {
 				return fmt.Errorf("schema repair: replay skipped migration effects for %s.%s: %w", rc.table, rc.column, err)
 			}
+		}
+	}
+	for _, tr := range tableRepairs {
+		var count int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, tr.table,
+		).Scan(&count); err != nil {
+			return fmt.Errorf("schema verification: inspect table %s: %w", tr.table, err)
+		}
+		if count > 0 {
+			continue
+		}
+		if _, err := db.Exec(tr.createDDL); err != nil {
+			return fmt.Errorf(
+				"schema repair: table %s is missing (a burned goose version skipped the migration that creates it, see #3475) and could not be created: %w",
+				tr.table, err,
+			)
 		}
 	}
 	if err := reconcileHarnessConstraint(db); err != nil {

--- a/backend/internal/storage/sqlite/migrate_schema_repairs_guard_test.go
+++ b/backend/internal/storage/sqlite/migrate_schema_repairs_guard_test.go
@@ -1,0 +1,87 @@
+package sqlite
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+)
+
+// guardMigrationFiles indexes migration files by goose version.
+func guardMigrationFiles(t *testing.T) map[int64]string {
+	t.Helper()
+	entries, err := migrationsFS.ReadDir("migrations")
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+	files := map[int64]string{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		version, err := goose.NumericComponent(e.Name())
+		if err != nil {
+			t.Fatalf("parse version from %q: %v", e.Name(), err)
+		}
+		files[version] = e.Name()
+	}
+	return files
+}
+
+// guardReadMigration returns the raw contents of an embedded migration file.
+func guardReadMigration(t *testing.T, name string) string {
+	t.Helper()
+	content, err := migrationsFS.ReadFile("migrations/" + name)
+	if err != nil {
+		t.Fatalf("read migration %s: %v", name, err)
+	}
+	return string(content)
+}
+
+// TestSchemaRepairsCorrespondToMigrations is the completeness guard for the
+// manual schemaRepairs/tableRepairs lists: every repair entry must name a
+// table and object that the migration file at that version actually mentions.
+// An entry whose objects do not exist in the migration is either a typo (the
+// repair silently no-ops at boot) or points at the wrong version (the repair
+// replays the wrong DDL). Neither is catchable at boot, because reconcileSchema
+// only acts on databases that are already drifted — this test catches it at
+// review time instead.
+//
+// A version with no migration file is expected for burned numbers: the repair
+// entry is then the only recovery path, and there is nothing to compare
+// against.
+func TestSchemaRepairsCorrespondToMigrations(t *testing.T) {
+	files := guardMigrationFiles(t)
+
+	checkColumn := func(table, column string, version int64) {
+		t.Helper()
+		file, ok := files[version]
+		if !ok {
+			return
+		}
+		content := guardReadMigration(t, file)
+		if !strings.Contains(content, table) || !strings.Contains(content, column) {
+			t.Errorf("schemaRepairs entry %s.%s (v%d) names objects absent from %s: "+
+				"the repair would no-op or replay the wrong DDL", table, column, version, file)
+		}
+	}
+	checkTable := func(table string, version int64) {
+		t.Helper()
+		file, ok := files[version]
+		if !ok {
+			return
+		}
+		content := guardReadMigration(t, file)
+		if !strings.Contains(content, "CREATE TABLE "+table) {
+			t.Errorf("tableRepairs entry %s (v%d) does not match %s: no CREATE TABLE %s in the migration",
+				table, version, file, table)
+		}
+	}
+
+	for _, rc := range schemaRepairs {
+		checkColumn(rc.table, rc.column, rc.version)
+	}
+	for _, tr := range tableRepairs {
+		checkTable(tr.table, tr.version)
+	}
+}

--- a/backend/internal/storage/sqlite/migrate_schema_table_repair_test.go
+++ b/backend/internal/storage/sqlite/migrate_schema_table_repair_test.go
@@ -1,0 +1,97 @@
+package sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// reconcileTableExists reports whether a table is physically present in the
+// database. reconcileSchema's table-level check uses the same probe, so a
+// missing table here is exactly the drift reconcile is expected to repair.
+func reconcileTableExists(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, name,
+	).Scan(&count); err != nil {
+		t.Fatalf("inspect table %s: %v", name, err)
+	}
+	return count > 0
+}
+
+// reconcileColumnExists reports whether a column is physically present.
+func reconcileColumnExists(t *testing.T, db *sql.DB, table, column string) bool {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`, table, column,
+	).Scan(&count); err != nil {
+		t.Fatalf("inspect %s.%s: %v", table, column, err)
+	}
+	return count > 0
+}
+
+// TestMigrateReconcilesMissingInventoryCacheTable covers a drift that took
+// down ao spawn on a real profile: goose_db_version records migration 0104 as
+// applied, but the agent_inventory_cache table is physically absent. The
+// agent-catalog refresh then 500s, spawn reports INTERNAL_ERROR, and /readyz
+// stays green. reconcileSchema must recreate the table on startup (or fail
+// loudly) instead of treating the drifted database as healthy.
+func TestMigrateReconcilesMissingInventoryCacheTable(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Bring the schema to just before 0104, then burn the version the way a
+	// renumbered/skipped migration would: goose will think 0104 already ran
+	// and never create the table itself.
+	upTo(t, db, 103)
+	if _, err := db.Exec(
+		`INSERT INTO goose_db_version (version_id, is_applied) VALUES (104, 1)`,
+	); err != nil {
+		t.Fatalf("burn version 104: %v", err)
+	}
+	if reconcileTableExists(t, db, "agent_inventory_cache") {
+		t.Fatalf("precondition: agent_inventory_cache exists before version 104; the burn was not set up")
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate with version 104 burned: %v", err)
+	}
+	if !reconcileTableExists(t, db, "agent_inventory_cache") {
+		t.Fatalf("agent_inventory_cache missing after migrate: a burned 0104 must be recreated by schema reconciliation, or startup must fail with a specific error instead of 500ing on spawn")
+	}
+}
+
+// TestMigrateReconcilesMissingPRCommentReviewIDColumn is the column-side
+// counterpart: migration 0106 is recorded applied but pr_comment.review_id
+// does not exist. preparePRCommentReviewIDMigration only handles the mirror
+// case (column physically present, ledger entry missing), so nothing repairs
+// this direction unless reconcileSchema knows about the column.
+func TestMigrateReconcilesMissingPRCommentReviewIDColumn(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	upTo(t, db, 105)
+	if _, err := db.Exec(
+		`INSERT INTO goose_db_version (version_id, is_applied) VALUES (106, 1)`,
+	); err != nil {
+		t.Fatalf("burn version 106: %v", err)
+	}
+	if reconcileColumnExists(t, db, "pr_comment", "review_id") {
+		t.Fatalf("precondition: pr_comment.review_id exists before version 106; the burn was not set up")
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate with version 106 burned: %v", err)
+	}
+	if !reconcileColumnExists(t, db, "pr_comment", "review_id") {
+		t.Fatalf("pr_comment.review_id missing after migrate: a burned 0106 must be recreated by schema reconciliation")
+	}
+}


### PR DESCRIPTION
## What

`reconcileSchema` (`backend/internal/storage/sqlite/db.go`) only verified **columns** from the manual `schemaRepairs` list, via `pragma_table_info`. A whole missing **table** (or a column outside the list) passed the boot check as healthy: the daemon came up green, and the first query against the missing object 500'd — for `agent_inventory_cache` that is every `ao spawn` (`INTERNAL_ERROR`) while `/readyz` stays ready.

This adds:
1. `tableRepairs` — a table-level counterpart to `schemaRepairs`, checked against `sqlite_master` and recreated when absent (idempotent, same as the column path).
2. Repair entries for the two drift casualties found in the field:
   - `0104` `agent_inventory_cache` (whole table missing)
   - `0106` `pr_comment.review_id` (column missing; `preparePRCommentReviewIDMigration` only repaired the mirror case — column present, ledger entry missing)

## Why

Part of #4335: a schema drift must not survive into a green daemon whose core workflow (`ao spawn`) 500s. This is the reconciliation gap, not the WARN/`/readyz` items the issue also lists — those are separate follow-ups.

## Red → green

`TestMigrateReconcilesMissingInventoryCacheTable` and `TestMigrateReconcilesMissingPRCommentReviewIDColumn` simulate the drift by burning the version (`INSERT INTO goose_db_version`) and requiring `migrate()` to leave the object present. Both failed before the fix, pass after. Both are killed by removing their repair entry (mutation check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
