### PR TITLE
feat: add Cursor subscription usage

### DIFF
--- a/backend/internal/adapters/agent/cursor/subscription_usage.go
+++ b/backend/internal/adapters/agent/cursor/subscription_usage.go
@@ -1,0 +1,182 @@
+package cursor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const cursorSubscriptionUsageTimeout = 20 * time.Second
+
+type cursorUsagePlugin interface {
+	ResolveBinary(context.Context) (string, error)
+	AuthStatus(context.Context) (ports.AgentAuthStatus, error)
+}
+
+type cursorBuildReader func(context.Context, string) (string, error)
+type cursorUsageClientFactory func(string, string, string, usageCommandRunner) (cursorUsageClient, error)
+
+// SubscriptionUsageReader reads Cursor's local authenticated dashboard model
+// without opening an AO session or retaining raw provider output.
+type SubscriptionUsageReader struct {
+	plugin        cursorUsagePlugin
+	readBuild     cursorBuildReader
+	newClient     cursorUsageClientFactory
+	runtimeDir    string
+	now           func() time.Time
+	commandRunner usageCommandRunner
+}
+
+// NewSubscriptionUsageReader creates the daemon-owned Cursor capacity reader.
+func NewSubscriptionUsageReader(plugin cursorUsagePlugin) *SubscriptionUsageReader {
+	return &SubscriptionUsageReader{
+		plugin: plugin, readBuild: readCursorBuild, newClient: newCursorUsageClient,
+		runtimeDir: cursorUsageRuntimeDirectory(), now: func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// ReadSubscriptionUsage returns only normalized, display-safe usage fields.
+func (r *SubscriptionUsageReader) ReadSubscriptionUsage(ctx context.Context) (ports.SubscriptionUsageObservation, error) {
+	if r == nil || r.plugin == nil || strings.TrimSpace(os.Getenv("CURSOR_API_KEY")) != "" {
+		return ports.SubscriptionUsageObservation{}, ports.ErrSubscriptionUsageUnsupported
+	}
+	binary, err := r.plugin.ResolveBinary(ctx)
+	if err != nil {
+		if errors.Is(err, ports.ErrAgentBinaryNotFound) {
+			return ports.SubscriptionUsageObservation{}, ports.ErrSubscriptionUsageUnsupported
+		}
+		return ports.SubscriptionUsageObservation{}, err
+	}
+	auth, err := r.plugin.AuthStatus(ctx)
+	if err != nil {
+		return ports.SubscriptionUsageObservation{}, err
+	}
+	if auth != ports.AgentAuthStatusAuthorized {
+		return ports.SubscriptionUsageObservation{}, ports.ErrSubscriptionUsageUnsupported
+	}
+	build, err := r.readBuild(ctx, binary)
+	if err != nil {
+		return ports.SubscriptionUsageObservation{}, err
+	}
+	client, err := r.newClient(binary, build, r.runtimeDir, r.commandRunner)
+	if err != nil {
+		if errors.Is(err, errCursorUsageBuildUnsupported) {
+			return ports.SubscriptionUsageObservation{}, ports.ErrSubscriptionUsageUnsupported
+		}
+		return ports.SubscriptionUsageObservation{}, err
+	}
+	readCtx, cancel := context.WithTimeout(ctx, cursorSubscriptionUsageTimeout)
+	defer cancel()
+	raw, err := client.ReadUsage(readCtx)
+	if err != nil {
+		return ports.SubscriptionUsageObservation{}, err
+	}
+	return normalizeCursorSubscriptionUsage(raw, r.now())
+}
+
+func normalizeCursorSubscriptionUsage(raw rawCursorUsage, observedAt time.Time) (ports.SubscriptionUsageObservation, error) {
+	if observedAt.IsZero() {
+		return ports.SubscriptionUsageObservation{}, errors.New("cursor usage observation time is required")
+	}
+	reset := parseCursorResetLabel(raw.ResetLabel, observedAt)
+	limits := make([]domain.SubscriptionUsageLimit, 0, 4)
+	if raw.Included != nil {
+		for _, entry := range []struct {
+			id   string
+			name string
+			used *float64
+		}{
+			{"included", "Included", raw.Included.TotalPercentUsed},
+			{"auto", "Auto", raw.Included.AutoPercentUsed},
+			{"api", "API", raw.Included.APIPercentUsed},
+		} {
+			if entry.used == nil {
+				continue
+			}
+			used := clampPercentage(*entry.used)
+			remaining := 100 - used
+			limits = append(limits, domain.SubscriptionUsageLimit{
+				ID: entry.id, Name: entry.name, State: domain.SubscriptionLimitActive,
+				UsedPercent: &used, RemainingPercent: &remaining, ResetsAt: reset,
+			})
+		}
+	}
+	if raw.OnDemand != nil {
+		limit := domain.SubscriptionUsageLimit{ID: "on_demand", Name: "On-Demand", Unit: "USD"}
+		if raw.OnDemand.UsedDollars != nil && *raw.OnDemand.UsedDollars >= 0 {
+			value := *raw.OnDemand.UsedDollars
+			limit.UsedValue = &value
+		}
+		switch raw.OnDemand.Kind {
+		case "fixed":
+			limit.State = domain.SubscriptionLimitActive
+			total := math.Max(0, *raw.OnDemand.LimitDollars)
+			used := math.Max(0, *raw.OnDemand.UsedDollars)
+			remaining := math.Max(0, total-used)
+			limit.UsedValue, limit.TotalValue, limit.RemainingValue = &used, &total, &remaining
+			if total > 0 {
+				usedPercent := clampPercentage(used / total * 100)
+				remainingPercent := 100 - usedPercent
+				limit.UsedPercent, limit.RemainingPercent = &usedPercent, &remainingPercent
+			}
+		case "unlimited":
+			limit.State = domain.SubscriptionLimitUnlimited
+		case "disabled":
+			limit.State = domain.SubscriptionLimitDisabled
+		case "unavailable":
+			limit.State = domain.SubscriptionLimitUnavailable
+		default:
+			return ports.SubscriptionUsageObservation{}, fmt.Errorf("unsupported Cursor on-demand usage state %q", raw.OnDemand.Kind)
+		}
+		limits = append(limits, limit)
+	}
+	if len(limits) == 0 {
+		return ports.SubscriptionUsageObservation{}, errors.New("cursor usage contains no capacity categories")
+	}
+	plan := strings.TrimSpace(raw.PlanName)
+	var planValue *string
+	if plan != "" {
+		planValue = &plan
+	}
+	return ports.SubscriptionUsageObservation{Plan: planValue, Limits: limits, ObservedAt: observedAt.UTC()}, nil
+}
+
+func clampPercentage(value float64) float64 { return math.Min(100, math.Max(0, value)) }
+
+func parseCursorResetLabel(label string, observedAt time.Time) *time.Time {
+	value := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(label), "Resets "))
+	parsed, err := time.ParseInLocation("Jan 2 2006", value+" "+fmt.Sprint(observedAt.Year()), time.UTC)
+	if err != nil {
+		return nil
+	}
+	day := time.Date(observedAt.Year(), observedAt.Month(), observedAt.Day(), 0, 0, 0, 0, time.UTC)
+	if parsed.Before(day) {
+		parsed = parsed.AddDate(1, 0, 0)
+	}
+	return &parsed
+}
+
+func cursorUsageRuntimeDirectory() string {
+	if configured := strings.TrimSpace(os.Getenv("AO_ACP_RUNTIME_DIR")); configured != "" {
+		return configured
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	resources := filepath.Dir(filepath.Dir(executable))
+	for _, candidate := range []string{filepath.Join(resources, "acp-runtime"), filepath.Join(resources, "resources", "acp-runtime")} {
+		if info, statErr := os.Stat(candidate); statErr == nil && info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}

--- a/backend/internal/adapters/agent/cursor/subscription_usage_protocol.go
+++ b/backend/internal/adapters/agent/cursor/subscription_usage_protocol.go
@@ -1,0 +1,222 @@
+package cursor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+const maxCursorUsageOutput = 64 << 10
+
+var (
+	errCursorUsageBuildUnsupported = errors.New("cursor build does not expose a verified usage protocol")
+	supportedCursorUsageBuilds     = map[string]struct{}{
+		"2026.08.11-e8db854": {},
+		"2026.08.25-3e8eec8": {},
+	}
+)
+
+type cursorUsageClient interface {
+	ReadUsage(context.Context) (rawCursorUsage, error)
+}
+
+type rawCursorUsage struct {
+	PlanName   string
+	ResetLabel string
+	Included   *rawIncludedUsage
+	OnDemand   *rawOnDemandUsage
+}
+
+type rawIncludedUsage struct {
+	TotalPercentUsed *float64 `json:"totalPercentUsed"`
+	AutoPercentUsed  *float64 `json:"autoPercentUsed"`
+	APIPercentUsed   *float64 `json:"apiPercentUsed"`
+}
+
+type rawOnDemandUsage struct {
+	Kind         string   `json:"kind"`
+	UsedDollars  *float64 `json:"usedDollars"`
+	LimitDollars *float64 `json:"limitDollars"`
+}
+
+type usageCommandRunner func(context.Context, string, string, string) ([]byte, error)
+
+type privateCursorUsageClient struct {
+	binaryPath string
+	build      string
+	runtimeDir string
+	run        usageCommandRunner
+}
+
+func newCursorUsageClient(binaryPath, build, runtimeDir string, runner usageCommandRunner) (cursorUsageClient, error) {
+	build = strings.TrimSpace(build)
+	if _, ok := supportedCursorUsageBuilds[build]; !ok {
+		return nil, fmt.Errorf("%w: %s", errCursorUsageBuildUnsupported, build)
+	}
+	if runner == nil {
+		runner = runCursorUsageHelper
+	}
+	return &privateCursorUsageClient{binaryPath: binaryPath, build: build, runtimeDir: runtimeDir, run: runner}, nil
+}
+
+func (c *privateCursorUsageClient) ReadUsage(ctx context.Context) (rawCursorUsage, error) {
+	out, err := c.run(ctx, c.binaryPath, c.build, c.runtimeDir)
+	if err != nil {
+		return rawCursorUsage{}, fmt.Errorf("cursor usage helper failed: %w", err)
+	}
+	if len(out) > maxCursorUsageOutput {
+		return rawCursorUsage{}, errors.New("cursor usage helper returned oversized output")
+	}
+	var envelope struct {
+		CLIVersion string `json:"cliVersion"`
+		Usage      *struct {
+			Kind  string `json:"kind"`
+			Model *struct {
+				Kind       string            `json:"kind"`
+				PlanName   string            `json:"planName"`
+				ResetLabel string            `json:"resetLabel"`
+				Included   *rawIncludedUsage `json:"included"`
+				OnDemand   *rawOnDemandUsage `json:"onDemand"`
+			} `json:"model"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(out, &envelope); err != nil {
+		return rawCursorUsage{}, fmt.Errorf("decode Cursor usage helper output: %w", err)
+	}
+	if envelope.CLIVersion != c.build {
+		return rawCursorUsage{}, errors.New("cursor usage helper build identity changed")
+	}
+	if envelope.Usage == nil || envelope.Usage.Kind != "available" || envelope.Usage.Model == nil || envelope.Usage.Model.Kind != "standard" {
+		return rawCursorUsage{}, errors.New("cursor usage is unavailable for this account")
+	}
+	raw := rawCursorUsage{
+		PlanName: envelope.Usage.Model.PlanName, ResetLabel: envelope.Usage.Model.ResetLabel,
+		Included: envelope.Usage.Model.Included, OnDemand: envelope.Usage.Model.OnDemand,
+	}
+	if err := validateRawCursorUsage(raw); err != nil {
+		return rawCursorUsage{}, err
+	}
+	return raw, nil
+}
+
+func validateRawCursorUsage(raw rawCursorUsage) error {
+	reported := false
+	if raw.Included != nil {
+		for _, value := range []*float64{raw.Included.TotalPercentUsed, raw.Included.AutoPercentUsed, raw.Included.APIPercentUsed} {
+			if value == nil {
+				continue
+			}
+			if math.IsNaN(*value) || math.IsInf(*value, 0) {
+				return errors.New("cursor usage contains a non-finite percentage")
+			}
+			reported = true
+		}
+	}
+	if raw.OnDemand != nil {
+		if raw.OnDemand.Kind == "" {
+			return errors.New("cursor on-demand usage has no state")
+		}
+		for _, value := range []*float64{raw.OnDemand.UsedDollars, raw.OnDemand.LimitDollars} {
+			if value != nil && (math.IsNaN(*value) || math.IsInf(*value, 0)) {
+				return errors.New("cursor usage contains a non-finite spend value")
+			}
+		}
+		if raw.OnDemand.Kind == "fixed" && (raw.OnDemand.UsedDollars == nil || raw.OnDemand.LimitDollars == nil) {
+			return errors.New("cursor fixed on-demand usage is incomplete")
+		}
+		reported = true
+	}
+	if !reported {
+		return errors.New("cursor usage helper returned no capacity categories")
+	}
+	return nil
+}
+
+func runCursorUsageHelper(ctx context.Context, binaryPath, build, runtimeDir string) ([]byte, error) {
+	resolved, err := filepath.EvalSymlinks(binaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve Cursor executable: %w", err)
+	}
+	cursorDir := filepath.Dir(resolved)
+	node := filepath.Join(cursorDir, "node")
+	if runtime.GOOS == "windows" {
+		node = filepath.Join(cursorDir, "node.exe")
+	}
+	helper := filepath.Join(runtimeDir, "ao-cursor-subscription-usage.cjs")
+	for path, label := range map[string]string{node: "Cursor Node runtime", helper: "AO Cursor usage helper"} {
+		info, statErr := os.Stat(path)
+		if statErr != nil || info.IsDir() {
+			return nil, fmt.Errorf("%s is unavailable", label)
+		}
+	}
+	cmd := aoprocess.CommandContext(ctx, node, helper, cursorDir, build) //nolint:gosec // fixed AO helper and resolved Cursor runtime.
+	cmd.Env = cursorUsageHelperEnv(os.Environ())
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, errors.New("could not capture helper output")
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, errors.New("could not execute helper")
+	}
+	out, readErr := io.ReadAll(io.LimitReader(stdout, maxCursorUsageOutput+1))
+	if len(out) > maxCursorUsageOutput {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, errors.New("cursor usage helper returned oversized output")
+	}
+	err = cmd.Wait()
+	if readErr != nil {
+		return nil, errors.New("could not read helper output")
+	}
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, ctx.Err()
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("helper exited with status %d", exitErr.ExitCode())
+		}
+		return nil, errors.New("could not execute helper")
+	}
+	return out, nil
+}
+
+func cursorUsageHelperEnv(source []string) []string {
+	allowed := map[string]bool{
+		"HOME": true, "USER": true, "LOGNAME": true, "PATH": true, "TMPDIR": true,
+		"XDG_CONFIG_HOME": true, "XDG_DATA_HOME": true, "XDG_CACHE_HOME": true,
+		"APPDATA": true, "LOCALAPPDATA": true, "USERPROFILE": true, "SYSTEMROOT": true, "WINDIR": true,
+		"LANG": true, "LC_ALL": true, "LC_CTYPE": true, "SHELL": true, cursorDataDirEnv: true,
+	}
+	out := make([]string, 0, len(allowed))
+	for _, entry := range source {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && allowed[strings.ToUpper(key)] {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func readCursorBuild(ctx context.Context, binary string) (string, error) {
+	if resolved, err := filepath.EvalSymlinks(binary); err == nil {
+		if build := filepath.Base(filepath.Dir(resolved)); strings.HasPrefix(build, "20") && strings.Contains(build, "-") {
+			return build, nil
+		}
+	}
+	out, err := aoprocess.CommandContext(ctx, binary, "--version").Output()
+	if err != nil {
+		return "", errors.New("could not read Cursor version")
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/backend/internal/adapters/agent/cursor/subscription_usage_test.go
+++ b/backend/internal/adapters/agent/cursor/subscription_usage_test.go
@@ -1,0 +1,120 @@
+package cursor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type fakeCursorUsagePlugin struct {
+	binary string
+	auth   ports.AgentAuthStatus
+}
+
+func (f fakeCursorUsagePlugin) ResolveBinary(context.Context) (string, error) { return f.binary, nil }
+func (f fakeCursorUsagePlugin) AuthStatus(context.Context) (ports.AgentAuthStatus, error) {
+	return f.auth, nil
+}
+
+func TestNormalizeCursorSubscriptionUsage(t *testing.T) {
+	observedAt := time.Date(2026, 8, 24, 4, 1, 34, 0, time.UTC)
+	observation, err := normalizeCursorSubscriptionUsage(rawCursorUsage{
+		PlanName: "Pro+", ResetLabel: "Resets Aug 25",
+		Included: &rawIncludedUsage{TotalPercentUsed: float64Ptr(21), AutoPercentUsed: float64Ptr(10), APIPercentUsed: float64Ptr(100)},
+		OnDemand: &rawOnDemandUsage{Kind: "fixed", UsedDollars: float64Ptr(333.68), LimitDollars: float64Ptr(1)},
+	}, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.Plan == nil || *observation.Plan != "Pro+" || len(observation.Limits) != 4 {
+		t.Fatalf("observation = %+v", observation)
+	}
+	if got := observation.Limits[2].UsedPercent; got == nil || *got != 100 {
+		t.Fatalf("API percentage = %v", got)
+	}
+	spend := observation.Limits[3]
+	if spend.State != domain.SubscriptionLimitActive || spend.RemainingValue == nil || *spend.RemainingValue != 0 {
+		t.Fatalf("spend = %+v", spend)
+	}
+	if observation.Limits[0].ResetsAt == nil || !observation.Limits[0].ResetsAt.Equal(time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("reset = %v", observation.Limits[0].ResetsAt)
+	}
+}
+
+func TestCursorSubscriptionUsageRejectsAPIKeyModeBeforePrivateProtocol(t *testing.T) {
+	t.Setenv("CURSOR_API_KEY", "secret")
+	reader := NewSubscriptionUsageReader(fakeCursorUsagePlugin{binary: "/cursor-agent", auth: ports.AgentAuthStatusAuthorized})
+	reader.readBuild = func(context.Context, string) (string, error) {
+		t.Fatal("API-key mode must not probe the private dashboard protocol")
+		return "", nil
+	}
+	_, err := reader.ReadSubscriptionUsage(context.Background())
+	if !errors.Is(err, ports.ErrSubscriptionUsageUnsupported) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCursorUsageProtocolAcceptsOnlyVerifiedBuilds(t *testing.T) {
+	for _, build := range []string{"2026.08.11-e8db854", "2026.08.25-3e8eec8"} {
+		if _, err := newCursorUsageClient("cursor-agent", build, "/runtime", nil); err != nil {
+			t.Fatalf("verified build %s rejected: %v", build, err)
+		}
+	}
+	if _, err := newCursorUsageClient("cursor-agent", "2026.09.01-unknown", "/runtime", nil); !errors.Is(err, errCursorUsageBuildUnsupported) {
+		t.Fatalf("unknown build error = %v", err)
+	}
+}
+
+func TestCursorUsageProtocolDecodesOnlySanitizedUsage(t *testing.T) {
+	runner := func(context.Context, string, string, string) ([]byte, error) {
+		return []byte(`{"cliVersion":"2026.08.25-3e8eec8","usage":{"kind":"available","model":{"kind":"standard","planName":"Pro+","resetLabel":"Resets Sep 25","included":{"totalPercentUsed":21},"onDemand":{"kind":"fixed","usedDollars":3,"limitDollars":10}}}}`), nil
+	}
+	client, err := newCursorUsageClient("cursor-agent", "2026.08.25-3e8eec8", "/runtime", runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage, err := client.ReadUsage(context.Background())
+	if err != nil || usage.PlanName != "Pro+" || usage.Included == nil || usage.OnDemand == nil {
+		t.Fatalf("usage = %#v, err = %v", usage, err)
+	}
+}
+
+func TestCursorUsageRunnerCapsOutputAndEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses a POSIX shell")
+	}
+	dir := t.TempDir()
+	for name, fixture := range map[string]struct {
+		contents string
+		mode     os.FileMode
+	}{
+		"cursor-agent": {contents: "fixture", mode: 0o600},
+		"node":         {contents: "#!/bin/sh\nhead -c 70000 /dev/zero\n", mode: 0o700},
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(fixture.contents), fixture.mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runtimeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(runtimeDir, "ao-cursor-subscription-usage.cjs"), []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runCursorUsageHelper(context.Background(), filepath.Join(dir, "cursor-agent"), "2026.08.25-3e8eec8", runtimeDir)
+	if err == nil || !strings.Contains(err.Error(), "oversized") {
+		t.Fatalf("error = %v, want bounded output failure", err)
+	}
+	env := strings.Join(cursorUsageHelperEnv([]string{"HOME=/home/me", "CURSOR_DATA_DIR=/profile", "CURSOR_API_KEY=secret", "OTHER=value"}), "\n")
+	if !strings.Contains(env, "HOME=/home/me") || !strings.Contains(env, "CURSOR_DATA_DIR=/profile") || strings.Contains(env, "secret") || strings.Contains(env, "OTHER=") {
+		t.Fatalf("filtered environment = %q", env)
+	}
+}
+
+func float64Ptr(value float64) *float64 { return &value }

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 
 	codexagent "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	cursoragent "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/modelcatalog"
 	chatdriveracp "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/codexappserver"
@@ -465,6 +466,7 @@ func Run() error {
 	// (issue #2685).
 	tracker := newMultiTracker(cfg.GitLab, log)
 	codexPlugin := codexagent.New()
+	cursorPlugin := cursoragent.New()
 	codexHome, err := codexPlugin.NativeSessionConfigDir(ctx, nil)
 	if err != nil {
 		stop()
@@ -484,7 +486,8 @@ func Run() error {
 		CodexAccounts: codexappserver.NewAccountFactoryWithResolver(func(resolveCtx context.Context) (string, error) {
 			return codexagent.New().ResolveBinary(resolveCtx)
 		}, log),
-		CodexOperationGate: codexOperationGate,
+		CodexOperationGate:      codexOperationGate,
+		CursorSubscriptionUsage: cursoragent.NewSubscriptionUsageReader(cursorPlugin),
 	}
 	agentSvc = agentsvc.NewWithDeps(agentDeps)
 	agentSvc.WarmModelCatalogs(ctx)

--- a/backend/internal/domain/agent_readiness.go
+++ b/backend/internal/domain/agent_readiness.go
@@ -115,6 +115,7 @@ type AgentReadinessSnapshot struct {
 	Installation       AgentInstallationObservation   `json:"installation"`
 	Authentication     AgentAuthenticationObservation `json:"authentication"`
 	EffectiveReadiness AgentEffectiveReadiness        `json:"effectiveReadiness" enum:"ready,not_ready,unknown"`
+	SubscriptionUsage  *SubscriptionUsageSnapshot     `json:"subscriptionUsage,omitempty"`
 	UsageCount         int                            `json:"usageCount"`
 	LastUsedAt         *time.Time                     `json:"lastUsedAt,omitempty" format:"date-time"`
 }

--- a/backend/internal/domain/subscription_usage.go
+++ b/backend/internal/domain/subscription_usage.go
@@ -1,0 +1,76 @@
+package domain
+
+import "time"
+
+// SubscriptionUsageState is the display-safe classification of one harness
+// account's provider-reported subscription capacity. It is advisory and never
+// participates in launch admission.
+type SubscriptionUsageState string
+
+// Subscription usage states classify the provider-reported overall capacity.
+const (
+	SubscriptionUsageAvailable   SubscriptionUsageState = "available"
+	SubscriptionUsageNearLimit   SubscriptionUsageState = "near_limit"
+	SubscriptionUsageExhausted   SubscriptionUsageState = "exhausted"
+	SubscriptionUsageUnknown     SubscriptionUsageState = "unknown"
+	SubscriptionUsageUnsupported SubscriptionUsageState = "unsupported"
+)
+
+// SubscriptionLimitState represents provider states that cannot be expressed
+// as a percentage, such as unlimited or disabled on-demand spend.
+type SubscriptionLimitState string
+
+// Subscription limit states normalize numeric and non-numeric provider limits.
+const (
+	SubscriptionLimitActive      SubscriptionLimitState = "active"
+	SubscriptionLimitUnlimited   SubscriptionLimitState = "unlimited"
+	SubscriptionLimitDisabled    SubscriptionLimitState = "disabled"
+	SubscriptionLimitUnavailable SubscriptionLimitState = "unavailable"
+)
+
+// SubscriptionUsageLimit is one provider meter. Percentage and absolute-value
+// fields are optional because providers expose different subscription models.
+type SubscriptionUsageLimit struct {
+	ID               string                 `json:"id"`
+	Name             string                 `json:"name"`
+	State            SubscriptionLimitState `json:"state" enum:"active,unlimited,disabled,unavailable"`
+	UsedPercent      *float64               `json:"usedPercent,omitempty" minimum:"0" maximum:"100"`
+	RemainingPercent *float64               `json:"remainingPercent,omitempty" minimum:"0" maximum:"100"`
+	UsedValue        *float64               `json:"usedValue,omitempty" minimum:"0"`
+	TotalValue       *float64               `json:"totalValue,omitempty" minimum:"0"`
+	RemainingValue   *float64               `json:"remainingValue,omitempty" minimum:"0"`
+	Unit             string                 `json:"unit,omitempty"`
+	ResetsAt         *time.Time             `json:"resetsAt,omitempty" format:"date-time"`
+}
+
+// SubscriptionUsageSnapshot is the daemon-memory capacity observation exposed
+// with a harness readiness snapshot. Raw provider payloads and credentials are
+// deliberately absent.
+type SubscriptionUsageSnapshot struct {
+	State            SubscriptionUsageState   `json:"state" enum:"available,near_limit,exhausted,unknown,unsupported"`
+	Freshness        AgentReadinessFreshness  `json:"freshness" enum:"fresh,stale,checking"`
+	Plan             *string                  `json:"plan,omitempty"`
+	UsedPercent      *float64                 `json:"usedPercent,omitempty" minimum:"0" maximum:"100"`
+	RemainingPercent *float64                 `json:"remainingPercent,omitempty" minimum:"0" maximum:"100"`
+	ObservedAt       *time.Time               `json:"observedAt,omitempty" format:"date-time"`
+	CheckedAt        *time.Time               `json:"checkedAt,omitempty" format:"date-time"`
+	AttemptedAt      *time.Time               `json:"attemptedAt,omitempty" format:"date-time"`
+	ReasonCode       string                   `json:"reasonCode"`
+	Reason           string                   `json:"reason"`
+	Limits           []SubscriptionUsageLimit `json:"limits"`
+}
+
+// Subscription usage reason codes are stable, display-safe explanations.
+const (
+	SubscriptionUsageReasonNotChecked        = "subscription_usage_not_checked"
+	SubscriptionUsageReasonChecking          = "subscription_usage_checking"
+	SubscriptionUsageReasonAvailable         = "subscription_usage_available"
+	SubscriptionUsageReasonNearLimit         = "subscription_usage_near_limit"
+	SubscriptionUsageReasonExhausted         = "subscription_usage_exhausted"
+	SubscriptionUsageReasonUnsupported       = "subscription_usage_unsupported"
+	SubscriptionUsageReasonSignedOut         = "subscription_usage_signed_out"
+	SubscriptionUsageReasonAuthUnknown       = "subscription_usage_auth_unknown"
+	SubscriptionUsageReasonCheckFailed       = "subscription_usage_check_failed"
+	SubscriptionUsageReasonCheckTimeout      = "subscription_usage_check_timeout"
+	SubscriptionUsageReasonCheckInconclusive = "subscription_usage_check_inconclusive"
+)

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6953,6 +6953,8 @@ components:
           type:
           - "null"
           - string
+        subscriptionUsage:
+          $ref: '#/components/schemas/SubscriptionUsageSnapshot'
         usageCount:
           type: integer
       required:
@@ -11348,6 +11350,120 @@ components:
       required:
       - runId
       - verdict
+      type: object
+    SubscriptionUsageLimit:
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        remainingPercent:
+          maximum: 100
+          minimum: 0
+          type:
+          - "null"
+          - number
+        remainingValue:
+          minimum: 0
+          type:
+          - "null"
+          - number
+        resetsAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        state:
+          enum:
+          - active
+          - unlimited
+          - disabled
+          - unavailable
+          type: string
+        totalValue:
+          minimum: 0
+          type:
+          - "null"
+          - number
+        unit:
+          type: string
+        usedPercent:
+          maximum: 100
+          minimum: 0
+          type:
+          - "null"
+          - number
+        usedValue:
+          minimum: 0
+          type:
+          - "null"
+          - number
+      required:
+      - id
+      - name
+      - state
+      type: object
+    SubscriptionUsageSnapshot:
+      properties:
+        attemptedAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        checkedAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        freshness:
+          enum:
+          - fresh
+          - stale
+          - checking
+          type: string
+        limits:
+          items:
+            $ref: '#/components/schemas/SubscriptionUsageLimit'
+          type: array
+        observedAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        plan:
+          type:
+          - "null"
+          - string
+        reason:
+          type: string
+        reasonCode:
+          type: string
+        remainingPercent:
+          maximum: 100
+          minimum: 0
+          type:
+          - "null"
+          - number
+        state:
+          enum:
+          - available
+          - near_limit
+          - exhausted
+          - unknown
+          - unsupported
+          type: string
+        usedPercent:
+          maximum: 100
+          minimum: 0
+          type:
+          - "null"
+          - number
+      required:
+      - state
+      - freshness
+      - reasonCode
+      - reason
+      - limits
       type: object
     SwitchAgentRequest:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -327,6 +327,8 @@ var schemaNames = map[string]string{ //nolint:gosec // Public OpenAPI type names
 	"DomainAgentReadinessSnapshot":                        "AgentReadinessSnapshot",
 	"DomainAgentInstallationObservation":                  "AgentInstallationObservation",
 	"DomainAgentAuthenticationObservation":                "AgentAuthenticationObservation",
+	"DomainSubscriptionUsageSnapshot":                     "SubscriptionUsageSnapshot",
+	"DomainSubscriptionUsageLimit":                        "SubscriptionUsageLimit",
 	// service/systemcheck: "SystemcheckReport" is a generic default name that
 	// reads like an internal type, not a wire response — rename to match the
 	// endpoint it serves, same treatment as AgentInventory above.

--- a/backend/internal/ports/subscription_usage.go
+++ b/backend/internal/ports/subscription_usage.go
@@ -1,0 +1,26 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// ErrSubscriptionUsageUnsupported means the installed harness or current
+// authentication method has no AO-verified structured usage reader.
+var ErrSubscriptionUsageUnsupported = errors.New("subscription usage is unsupported")
+
+// SubscriptionUsageObservation is normalized provider data before cache
+// freshness and display-safe reasons are applied by the service coordinator.
+type SubscriptionUsageObservation struct {
+	Plan       *string
+	Limits     []domain.SubscriptionUsageLimit
+	ObservedAt time.Time
+}
+
+// SubscriptionUsageReader reads a credential-free subscription usage model.
+type SubscriptionUsageReader interface {
+	ReadSubscriptionUsage(context.Context) (SubscriptionUsageObservation, error)
+}

--- a/backend/internal/service/agent/cursor_subscription_usage.go
+++ b/backend/internal/service/agent/cursor_subscription_usage.go
@@ -1,0 +1,216 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	cursorSubscriptionUsageTTL     = 2 * time.Minute
+	cursorSubscriptionUsageTimeout = 20 * time.Second
+)
+
+type cursorSubscriptionUsageCall struct{ done chan struct{} }
+
+type cursorSubscriptionUsageCoordinator struct {
+	ctx    context.Context
+	reader ports.SubscriptionUsageReader
+	now    func() time.Time
+
+	mu          sync.Mutex
+	snapshot    domain.SubscriptionUsageSnapshot
+	invalidated bool
+	call        *cursorSubscriptionUsageCall
+}
+
+func newCursorSubscriptionUsageCoordinator(ctx context.Context, reader ports.SubscriptionUsageReader) *cursorSubscriptionUsageCoordinator {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &cursorSubscriptionUsageCoordinator{
+		ctx: ctx, reader: reader, now: func() time.Time { return time.Now().UTC() },
+		snapshot: uncheckedSubscriptionUsage(), invalidated: true,
+	}
+}
+
+func uncheckedSubscriptionUsage() domain.SubscriptionUsageSnapshot {
+	return domain.SubscriptionUsageSnapshot{
+		State: domain.SubscriptionUsageUnknown, Freshness: domain.AgentReadinessStale,
+		ReasonCode: domain.SubscriptionUsageReasonNotChecked, Reason: "Cursor subscription usage has not been checked yet.",
+		Limits: []domain.SubscriptionUsageLimit{},
+	}
+}
+
+func staticSubscriptionUsage(state domain.SubscriptionUsageState, code, reason string) domain.SubscriptionUsageSnapshot {
+	return domain.SubscriptionUsageSnapshot{
+		State: state, Freshness: domain.AgentReadinessFresh, ReasonCode: code, Reason: reason,
+		Limits: []domain.SubscriptionUsageLimit{},
+	}
+}
+
+func (c *cursorSubscriptionUsageCoordinator) cached() domain.SubscriptionUsageSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return cloneSubscriptionUsage(c.snapshot)
+}
+
+func (c *cursorSubscriptionUsageCoordinator) invalidate() {
+	c.mu.Lock()
+	c.invalidated = true
+	if c.snapshot.CheckedAt != nil {
+		c.snapshot.Freshness = domain.AgentReadinessStale
+	}
+	c.mu.Unlock()
+}
+
+func (c *cursorSubscriptionUsageCoordinator) ensure(ctx context.Context, readiness domain.AgentReadinessSnapshot, force bool) domain.SubscriptionUsageSnapshot {
+	if readiness.Installation.State == domain.AgentInstallationNotInstalled {
+		return c.replace(staticSubscriptionUsage(domain.SubscriptionUsageUnsupported, domain.SubscriptionUsageReasonUnsupported, "Install Cursor Agent to see subscription usage."))
+	}
+	switch readiness.Authentication.State {
+	case domain.AgentAuthenticationUnauthorized:
+		return c.replace(staticSubscriptionUsage(domain.SubscriptionUsageUnknown, domain.SubscriptionUsageReasonSignedOut, "Sign in to Cursor to see subscription usage."))
+	case domain.AgentAuthenticationUnknown:
+		return c.preserveFailure(domain.SubscriptionUsageReasonAuthUnknown, "Confirm Cursor authentication before checking subscription usage.")
+	}
+
+	c.mu.Lock()
+	now := c.now()
+	fresh := c.snapshot.CheckedAt != nil && now.Sub(*c.snapshot.CheckedAt) < cursorSubscriptionUsageTTL
+	if !force && !c.invalidated && fresh {
+		result := cloneSubscriptionUsage(c.snapshot)
+		c.mu.Unlock()
+		return result
+	}
+	if c.call != nil {
+		call := c.call
+		c.mu.Unlock()
+		select {
+		case <-call.done:
+			return c.cached()
+		case <-ctx.Done():
+			return c.cached()
+		}
+	}
+	call := &cursorSubscriptionUsageCall{done: make(chan struct{})}
+	c.call = call
+	attemptedAt := now.UTC()
+	c.snapshot.Freshness = domain.AgentReadinessChecking
+	c.snapshot.ReasonCode = domain.SubscriptionUsageReasonChecking
+	c.snapshot.Reason = "Checking Cursor subscription usage."
+	c.snapshot.AttemptedAt = &attemptedAt
+	c.mu.Unlock()
+
+	go c.runRead(call, attemptedAt)
+	select {
+	case <-call.done:
+		return c.cached()
+	case <-ctx.Done():
+		return c.cached()
+	}
+}
+
+func (c *cursorSubscriptionUsageCoordinator) runRead(call *cursorSubscriptionUsageCall, attemptedAt time.Time) {
+	readCtx, cancel := context.WithTimeout(c.ctx, cursorSubscriptionUsageTimeout)
+	defer cancel()
+	observation, err := c.reader.ReadSubscriptionUsage(readCtx)
+	checkedAt := c.now().UTC()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.call != call {
+		return
+	}
+	defer func() { c.call = nil; close(call.done) }()
+	if err != nil {
+		if errors.Is(err, ports.ErrSubscriptionUsageUnsupported) {
+			c.snapshot = staticSubscriptionUsage(domain.SubscriptionUsageUnsupported, domain.SubscriptionUsageReasonUnsupported, "Subscription usage is not supported by this Cursor version or authentication method.")
+			c.invalidated = false
+			return
+		}
+		if c.snapshot.CheckedAt == nil {
+			c.snapshot = uncheckedSubscriptionUsage()
+		} else {
+			c.snapshot.Freshness = domain.AgentReadinessStale
+		}
+		c.snapshot.AttemptedAt = &attemptedAt
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(readCtx.Err(), context.DeadlineExceeded) {
+			c.snapshot.ReasonCode, c.snapshot.Reason = domain.SubscriptionUsageReasonCheckTimeout, "Cursor subscription usage check timed out."
+		} else {
+			c.snapshot.ReasonCode, c.snapshot.Reason = domain.SubscriptionUsageReasonCheckFailed, "Cursor subscription usage could not be checked."
+		}
+		c.invalidated = true
+		return
+	}
+	c.snapshot = subscriptionUsageSnapshot(observation, attemptedAt, checkedAt)
+	c.invalidated = false
+}
+
+func subscriptionUsageSnapshot(observation ports.SubscriptionUsageObservation, attemptedAt, checkedAt time.Time) domain.SubscriptionUsageSnapshot {
+	observedAt := observation.ObservedAt.UTC()
+	if observedAt.IsZero() {
+		observedAt = checkedAt
+	}
+	snapshot := domain.SubscriptionUsageSnapshot{
+		State: domain.SubscriptionUsageUnknown, Freshness: domain.AgentReadinessFresh,
+		Plan: observation.Plan, ObservedAt: &observedAt, CheckedAt: &checkedAt, AttemptedAt: &attemptedAt,
+		ReasonCode: domain.SubscriptionUsageReasonCheckInconclusive,
+		Reason:     "Cursor did not report a trustworthy subscription capacity meter.",
+		Limits:     append([]domain.SubscriptionUsageLimit(nil), observation.Limits...),
+	}
+	var worst *float64
+	for i := range snapshot.Limits {
+		used := snapshot.Limits[i].UsedPercent
+		if used != nil && (worst == nil || *used > *worst) {
+			value := math.Min(100, math.Max(0, *used))
+			worst = &value
+		}
+	}
+	if worst == nil {
+		return snapshot
+	}
+	used, remaining := *worst, 100-*worst
+	snapshot.UsedPercent, snapshot.RemainingPercent = &used, &remaining
+	switch {
+	case used >= 100:
+		snapshot.State, snapshot.ReasonCode, snapshot.Reason = domain.SubscriptionUsageExhausted, domain.SubscriptionUsageReasonExhausted, "Cursor reports that subscription capacity is exhausted."
+	case used >= 75:
+		snapshot.State, snapshot.ReasonCode, snapshot.Reason = domain.SubscriptionUsageNearLimit, domain.SubscriptionUsageReasonNearLimit, "Cursor reports that subscription capacity is near its limit."
+	default:
+		snapshot.State, snapshot.ReasonCode, snapshot.Reason = domain.SubscriptionUsageAvailable, domain.SubscriptionUsageReasonAvailable, "Cursor subscription capacity is available."
+	}
+	return snapshot
+}
+
+func (c *cursorSubscriptionUsageCoordinator) replace(snapshot domain.SubscriptionUsageSnapshot) domain.SubscriptionUsageSnapshot {
+	c.mu.Lock()
+	c.snapshot = snapshot
+	c.invalidated = false
+	c.mu.Unlock()
+	return cloneSubscriptionUsage(snapshot)
+}
+
+func (c *cursorSubscriptionUsageCoordinator) preserveFailure(code, reason string) domain.SubscriptionUsageSnapshot {
+	c.mu.Lock()
+	if c.snapshot.CheckedAt == nil {
+		c.snapshot = uncheckedSubscriptionUsage()
+	} else {
+		c.snapshot.Freshness = domain.AgentReadinessStale
+	}
+	c.snapshot.ReasonCode, c.snapshot.Reason = code, reason
+	c.invalidated = true
+	result := cloneSubscriptionUsage(c.snapshot)
+	c.mu.Unlock()
+	return result
+}
+
+func cloneSubscriptionUsage(snapshot domain.SubscriptionUsageSnapshot) domain.SubscriptionUsageSnapshot {
+	snapshot.Limits = append([]domain.SubscriptionUsageLimit(nil), snapshot.Limits...)
+	return snapshot
+}

--- a/backend/internal/service/agent/cursor_subscription_usage_test.go
+++ b/backend/internal/service/agent/cursor_subscription_usage_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type fakeSubscriptionUsageReader struct {
+	mu          sync.Mutex
+	calls       int
+	observation ports.SubscriptionUsageObservation
+	err         error
+}
+
+func (f *fakeSubscriptionUsageReader) ReadSubscriptionUsage(context.Context) (ports.SubscriptionUsageObservation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.observation, f.err
+}
+
+func TestCursorSubscriptionUsageCachesAndClassifiesWorstMeter(t *testing.T) {
+	reader := &fakeSubscriptionUsageReader{observation: ports.SubscriptionUsageObservation{
+		Limits: []domain.SubscriptionUsageLimit{
+			{ID: "included", State: domain.SubscriptionLimitActive, UsedPercent: usageFloat(20)},
+			{ID: "api", State: domain.SubscriptionLimitActive, UsedPercent: usageFloat(90)},
+		},
+		ObservedAt: time.Date(2026, 9, 4, 8, 0, 0, 0, time.UTC),
+	}}
+	coordinator := newCursorSubscriptionUsageCoordinator(context.Background(), reader)
+	coordinator.now = func() time.Time { return time.Date(2026, 9, 4, 8, 1, 0, 0, time.UTC) }
+	readiness := readyCursorSnapshot()
+
+	first := coordinator.ensure(context.Background(), readiness, false)
+	second := coordinator.ensure(context.Background(), readiness, false)
+	if reader.calls != 1 {
+		t.Fatalf("calls = %d, want 1", reader.calls)
+	}
+	if first.State != domain.SubscriptionUsageNearLimit || first.RemainingPercent == nil || *first.RemainingPercent != 10 {
+		t.Fatalf("first = %+v", first)
+	}
+	if second.State != first.State {
+		t.Fatalf("cached = %+v", second)
+	}
+}
+
+func TestCursorSubscriptionUsageAuthGateAndUnsupportedReader(t *testing.T) {
+	reader := &fakeSubscriptionUsageReader{err: ports.ErrSubscriptionUsageUnsupported}
+	coordinator := newCursorSubscriptionUsageCoordinator(context.Background(), reader)
+	unauthorized := readyCursorSnapshot()
+	unauthorized.Authentication.State = domain.AgentAuthenticationUnauthorized
+	if got := coordinator.ensure(context.Background(), unauthorized, false); got.ReasonCode != domain.SubscriptionUsageReasonSignedOut || reader.calls != 0 {
+		t.Fatalf("unauthorized = %+v, calls = %d", got, reader.calls)
+	}
+	if got := coordinator.ensure(context.Background(), readyCursorSnapshot(), true); got.State != domain.SubscriptionUsageUnsupported || reader.calls != 1 {
+		t.Fatalf("unsupported = %+v, calls = %d", got, reader.calls)
+	}
+}
+
+func readyCursorSnapshot() domain.AgentReadinessSnapshot {
+	return domain.AgentReadinessSnapshot{
+		ID:             string(domain.HarnessCursor),
+		Installation:   domain.AgentInstallationObservation{State: domain.AgentInstallationInstalled},
+		Authentication: domain.AgentAuthenticationObservation{State: domain.AgentAuthenticationAuthorized},
+	}
+}
+
+func usageFloat(value float64) *float64 { return &value }

--- a/backend/internal/service/agent/readiness.go
+++ b/backend/internal/service/agent/readiness.go
@@ -67,6 +67,9 @@ func (s *Service) EnsureReadiness(ctx context.Context, agentIDs []string, purpos
 		}
 		return Readiness{}, err
 	}
+	if purpose == domain.AgentReadinessPurposeDisplay {
+		s.ensureCursorSubscriptionUsage(ctx, items, false)
+	}
 	return s.withReadinessUsage(ctx, items)
 }
 
@@ -87,6 +90,9 @@ func (s *Service) InvalidateAgentInstallation(agentID string) {
 // InvalidateAgentAuthentication marks an agent's authentication observation stale.
 func (s *Service) InvalidateAgentAuthentication(agentID string) {
 	s.readiness.Invalidate(agentID, readinessInvalidateAuthentication)
+	if agentID == string(domain.HarnessCursor) && s.cursorUsage != nil {
+		s.cursorUsage.invalidate()
+	}
 	if agentID == string(domain.HarnessCodex) && s.codexAccounts != nil {
 		if accountID := s.codexAccounts.activeAccountID(); accountID != "" {
 			s.codexAccounts.invalidate(accountID)
@@ -105,6 +111,7 @@ func (s *Service) RecheckAgent(agentID string) {
 func (s *Service) WarmReadiness() { s.readiness.Warm() }
 
 func (s *Service) withReadinessUsage(ctx context.Context, snapshots []domain.AgentReadinessSnapshot) (Readiness, error) {
+	s.attachCursorSubscriptionUsage(snapshots)
 	if s.sessions == nil {
 		return Readiness{Agents: snapshots}, nil
 	}
@@ -151,11 +158,38 @@ func (s *Service) Refresh(ctx context.Context) (Inventory, error) {
 	if err != nil {
 		return Inventory{}, err
 	}
+	s.ensureCursorSubscriptionUsage(ctx, items, true)
 	readiness, err := s.withReadinessUsage(ctx, items)
 	if err != nil {
 		return Inventory{}, err
 	}
 	return projectInventory(readiness.Agents), nil
+}
+
+func (s *Service) ensureCursorSubscriptionUsage(ctx context.Context, snapshots []domain.AgentReadinessSnapshot, force bool) {
+	if s.cursorUsage == nil {
+		return
+	}
+	for i := range snapshots {
+		if snapshots[i].ID != string(domain.HarnessCursor) {
+			continue
+		}
+		usage := s.cursorUsage.ensure(ctx, snapshots[i], force)
+		snapshots[i].SubscriptionUsage = &usage
+		return
+	}
+}
+
+func (s *Service) attachCursorSubscriptionUsage(snapshots []domain.AgentReadinessSnapshot) {
+	if s.cursorUsage == nil {
+		return
+	}
+	for i := range snapshots {
+		if snapshots[i].ID == string(domain.HarnessCursor) {
+			usage := s.cursorUsage.cached()
+			snapshots[i].SubscriptionUsage = &usage
+		}
+	}
 }
 
 // RefreshFresh is retained for the system-check compatibility boundary.

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -61,6 +61,7 @@ type Service struct {
 	modelCalls    map[string]*modelCatalogCall
 	codexAccounts *codexAccountManager
 	codexSwitches CodexAccountSwitchCoordinator
+	cursorUsage   *cursorSubscriptionUsageCoordinator
 }
 
 // CodexAccountSwitchCoordinator owns global switch execution and recovery.
@@ -73,19 +74,20 @@ type CodexAccountSwitchCoordinator interface {
 
 // Deps contains optional durable dependencies for the agent catalog service.
 type Deps struct {
-	Cache                  ports.AgentModelCatalogCache
-	Discoverer             ports.AgentModelDiscoverer
-	Projects               ProjectLookup
-	Sessions               SessionUsageLookup
-	Context                context.Context
-	Logger                 *slog.Logger
-	CodexAccountRoot       string
-	CodexPendingRoot       string
-	CodexSwitchStagingRoot string
-	CodexGlobalHome        string
-	CodexAccounts          ports.CodexAccountClientFactory
-	CodexAccountState      CodexAccountStateStore
-	CodexOperationGate     ports.CodexOperationGate
+	Cache                   ports.AgentModelCatalogCache
+	Discoverer              ports.AgentModelDiscoverer
+	Projects                ProjectLookup
+	Sessions                SessionUsageLookup
+	Context                 context.Context
+	Logger                  *slog.Logger
+	CodexAccountRoot        string
+	CodexPendingRoot        string
+	CodexSwitchStagingRoot  string
+	CodexGlobalHome         string
+	CodexAccounts           ports.CodexAccountClientFactory
+	CodexAccountState       CodexAccountStateStore
+	CodexOperationGate      ports.CodexOperationGate
+	CursorSubscriptionUsage ports.SubscriptionUsageReader
 }
 
 // ProjectLookup resolves the registered working directory used for model
@@ -117,6 +119,9 @@ func NewWithDeps(deps Deps) *Service {
 		Agents: agents, Factory: agentregistry.Harnessed, Context: deps.Context, Logger: deps.Logger,
 		AuthenticationCheck: svc.structuredCodexAuthentication,
 	})
+	if deps.CursorSubscriptionUsage != nil {
+		svc.cursorUsage = newCursorSubscriptionUsageCoordinator(deps.Context, deps.CursorSubscriptionUsage)
+	}
 	svc.sessions = deps.Sessions
 	return svc
 }

--- a/frontend/acp-runtime/ao-cursor-subscription-usage.cjs
+++ b/frontend/acp-runtime/ao-cursor-subscription-usage.cjs
@@ -1,0 +1,71 @@
+"use strict";
+
+const fs = require("node:fs");
+const Module = require("node:module");
+const path = require("node:path");
+
+const builds = {
+	"2026.08.11-e8db854": {
+		aboutChunk: "5105.index.js",
+		usageChunk: 6260,
+		patch(source) {
+			const importNeedle = ',u=l("./src/utils/terminal-environment.ts"),d=function';
+			const importReplacement = ',u=l("./src/utils/terminal-environment.ts"),usageModule=l.e(6260).then(()=>l("./src/usage/usage-data.ts")),d=function';
+			const returnNeedle = "return{cliVersion:f,model:b,subscriptionTier:A,osPlatform:p,osArch:h,userEmail:y,terminalProgram:q,shell:I,lastRequestId:R}";
+			const returnReplacement = 'const usage=yield usageModule,usageResult=yield usage.d({client:l,locale:"en-US"});return{cliVersion:f,usage:usageResult}';
+			return replaceExactly(source, importNeedle, importReplacement, returnNeedle, returnReplacement);
+		},
+	},
+	"2026.08.25-3e8eec8": {
+		aboutChunk: "4374.index.js",
+		usageChunk: 89,
+		patch(source) {
+			const importNeedle = ',c=n("./src/utils/terminal-environment.ts"),u=n("./src/commands/update-core.ts"),d=function';
+			const importReplacement = ',c=n("./src/utils/terminal-environment.ts"),u=n("./src/commands/update-core.ts"),usageModule=n.e(89).then(()=>n("./src/usage/usage-data.ts")),d=function';
+			const promiseNeedle = "[S,I]=yield Promise.all([(0,u.resolveLatestVersionStatus)(n,{channel:m.channel,product:r}),p(e,n)]);";
+			const promiseReplacement = "[S,I,usageModuleValue]=yield Promise.all([(0,u.resolveLatestVersionStatus)(n,{channel:m.channel,product:r}),p(e,n),usageModule]);";
+			const resultPattern = /return Object\.assign\(Object\.assign\(\{cliVersion:f\},function\(e\)\{.*?\}\(S\)\),\{model:h,subscriptionTier:I\.subscriptionTier,osPlatform:v,osArch:g,userEmail:I\.userEmail,terminalProgram:y,shell:b,lastRequestId:w\}\)/;
+			if (!source.includes(importNeedle) || !source.includes(promiseNeedle) || !resultPattern.test(source)) {
+				throw new Error("unsupported Cursor about module shape");
+			}
+			return source
+				.replace(importNeedle, importReplacement)
+				.replace(promiseNeedle, promiseReplacement)
+				.replace(resultPattern, 'return{cliVersion:f,usage:yield usageModuleValue.d({client:n,locale:"en-US"})}');
+		},
+	},
+};
+
+function replaceExactly(source, firstNeedle, firstReplacement, secondNeedle, secondReplacement) {
+	if (!source.includes(firstNeedle) || !source.includes(secondNeedle)) {
+		throw new Error("unsupported Cursor about module shape");
+	}
+	return source.replace(firstNeedle, firstReplacement).replace(secondNeedle, secondReplacement);
+}
+
+function patchAboutSource(source, build) {
+	const spec = builds[build];
+	if (!spec) throw new Error("unsupported Cursor build");
+	return spec.patch(source);
+}
+
+function run(cursorDir, build) {
+	const spec = builds[build];
+	if (!cursorDir || !spec) throw new Error("supported Cursor runtime and build are required");
+	const entry = path.join(cursorDir, "index.js");
+	const aboutChunk = path.join(cursorDir, spec.aboutChunk);
+	const originalLoader = Module._extensions[".js"];
+	Module._extensions[".js"] = function cursorUsageLoader(module, filename) {
+		if (filename === aboutChunk) {
+			module._compile(patchAboutSource(fs.readFileSync(filename, "utf8"), build), filename);
+			return;
+		}
+		originalLoader(module, filename);
+	};
+	process.argv = [process.execPath, entry, "about", "--format", "json"];
+	require(entry);
+}
+
+module.exports = { builds, patchAboutSource };
+
+if (require.main === module) run(process.argv[2], process.argv[3]);

--- a/frontend/acp-runtime/ao-cursor-subscription-usage.node.cjs
+++ b/frontend/acp-runtime/ao-cursor-subscription-usage.node.cjs
@@ -1,0 +1,26 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { patchAboutSource } = require("./ao-cursor-subscription-usage.cjs");
+
+test("patches the original supported build without retaining account identity", () => {
+	const source = 'x,u=l("./src/utils/terminal-environment.ts"),d=function y return{cliVersion:f,model:b,subscriptionTier:A,osPlatform:p,osArch:h,userEmail:y,terminalProgram:q,shell:I,lastRequestId:R} z';
+	const patched = patchAboutSource(source, "2026.08.11-e8db854");
+	assert.match(patched, /usageModule=l\.e\(6260\)/);
+	assert.match(patched, /return\{cliVersion:f,usage:usageResult\}/);
+	assert.doesNotMatch(patched, /userEmail/);
+});
+
+test("patches the current supported build without retaining account identity", () => {
+	const source = 'x,c=n("./src/utils/terminal-environment.ts"),u=n("./src/commands/update-core.ts"),d=function y [S,I]=yield Promise.all([(0,u.resolveLatestVersionStatus)(n,{channel:m.channel,product:r}),p(e,n)]);return Object.assign(Object.assign({cliVersion:f},function(e){switch(e.status){case"up_to_date":return{latestStatus:e.status}}}(S)),{model:h,subscriptionTier:I.subscriptionTier,osPlatform:v,osArch:g,userEmail:I.userEmail,terminalProgram:y,shell:b,lastRequestId:w}) z';
+	const patched = patchAboutSource(source, "2026.08.25-3e8eec8");
+	assert.match(patched, /usageModule=n\.e\(89\)/);
+	assert.match(patched, /return\{cliVersion:f,usage:yield usageModuleValue\.d/);
+	assert.doesNotMatch(patched, /userEmail/);
+});
+
+test("rejects unknown builds and bundle shapes", () => {
+	assert.throws(() => patchAboutSource("different build", "2026.08.25-3e8eec8"), /unsupported Cursor/);
+	assert.throws(() => patchAboutSource("different build", "2099.01.01-unknown"), /unsupported Cursor/);
+});

--- a/frontend/scripts/build-acp-runtime-helpers.mjs
+++ b/frontend/scripts/build-acp-runtime-helpers.mjs
@@ -6,7 +6,11 @@ const BIN_BUILD_TOOLS = ["corepack", "npm", "npx"];
 const BUILD_ONLY_CONTENT = ["include", "lib", "node_modules", "share", "CHANGELOG.md", "README.md"];
 
 export function runtimeSourceFiles() {
-	return ["package.json", "package-lock.json"];
+	return [
+		"package.json",
+		"package-lock.json",
+		"ao-cursor-subscription-usage.cjs",
+	];
 }
 
 export function createWorkDirectory(outputRoot) {

--- a/frontend/scripts/build-acp-runtime-helpers.test.mjs
+++ b/frontend/scripts/build-acp-runtime-helpers.test.mjs
@@ -39,10 +39,11 @@ describe("createWorkDirectory", () => {
 });
 
 describe("runtimeSourceFiles", () => {
-	it("packages and fingerprints the ACP runtime manifest", () => {
+	it("packages and fingerprints the ACP runtime manifest and Cursor helper", () => {
 		expect(runtimeSourceFiles()).toEqual([
 			"package.json",
 			"package-lock.json",
+			"ao-cursor-subscription-usage.cjs",
 		]);
 	});
 });

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2452,6 +2452,7 @@ export interface components {
             label: string;
             /** Format: date-time */
             lastUsedAt?: null | string;
+            subscriptionUsage?: components["schemas"]["SubscriptionUsageSnapshot"];
             usageCount: number;
         };
         AgentSwitch: {
@@ -4075,6 +4076,38 @@ export interface components {
             runId: string;
             /** @description Review verdict: approved or changes_requested. */
             verdict: string;
+        };
+        SubscriptionUsageLimit: {
+            id: string;
+            name: string;
+            remainingPercent?: null | number;
+            remainingValue?: null | number;
+            /** Format: date-time */
+            resetsAt?: null | string;
+            /** @enum {string} */
+            state: "active" | "unlimited" | "disabled" | "unavailable";
+            totalValue?: null | number;
+            unit?: string;
+            usedPercent?: null | number;
+            usedValue?: null | number;
+        };
+        SubscriptionUsageSnapshot: {
+            /** Format: date-time */
+            attemptedAt?: null | string;
+            /** Format: date-time */
+            checkedAt?: null | string;
+            /** @enum {string} */
+            freshness: "fresh" | "stale" | "checking";
+            limits: components["schemas"]["SubscriptionUsageLimit"][];
+            /** Format: date-time */
+            observedAt?: null | string;
+            plan?: null | string;
+            reason: string;
+            reasonCode: string;
+            remainingPercent?: null | number;
+            /** @enum {string} */
+            state: "available" | "near_limit" | "exhausted" | "unknown" | "unsupported";
+            usedPercent?: null | number;
         };
         SwitchAgentRequest: {
             /** @description Optional retry key. Reusing it with a different request is rejected. */

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -5,6 +5,7 @@ import { GeneralSettingsSection } from "./settings/GeneralSettingsSection";
 import { HarnessSettingsSection } from "./settings/HarnessSettingsSection";
 import { CloudCredentialsSection } from "./settings/CloudCredentialsSection";
 import { CodexAccountsSection } from "./settings/CodexAccountsSection";
+import { CursorSubscriptionUsageSection } from "./settings/CursorSubscriptionUsageSection";
 import { ConnectMobileContent } from "./settings/ConnectMobileContent";
 import { KeyboardShortcutsContent } from "./settings/KeyboardShortcutsContent";
 import { MobileDevicesSection } from "./settings/MobileDevicesSection";
@@ -47,6 +48,7 @@ export function GlobalSettingsForm({
 			{(all || section === "harness") && <HarnessSettingsSection titleHidden={titleHidden} />}
 
 			{(all || section === "agents") && <CodexAccountsSection titleHidden={titleHidden} />}
+			{(all || section === "agents") && <CursorSubscriptionUsageSection titleHidden={titleHidden} />}
 
 			{(all || section === "browserProfiles") && <BrowserProfilesSection titleHidden={titleHidden} />}
 			{(all || section === "cloud") && <CloudCredentialsSection titleHidden={titleHidden} />}

--- a/frontend/src/renderer/components/settings/CursorSubscriptionUsageSection.test.tsx
+++ b/frontend/src/renderer/components/settings/CursorSubscriptionUsageSection.test.tsx
@@ -1,0 +1,45 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, expect, it, vi } from "vitest";
+import { CursorSubscriptionUsageSection } from "./CursorSubscriptionUsageSection";
+
+const { getMock, postMock } = vi.hoisted(() => ({ getMock: vi.fn(), postMock: vi.fn() }));
+
+vi.mock("../../lib/api-client", () => ({
+	apiClient: { GET: getMock, POST: postMock },
+	apiErrorMessage: () => "request failed",
+}));
+
+const cursorReadiness = {
+	agents: [{
+		id: "cursor", label: "Cursor", usageCount: 2, effectiveReadiness: "ready",
+		installation: { state: "installed", freshness: "fresh", checkedAt: null, attemptedAt: null, reasonCode: "installed", reason: "Installed." },
+		authentication: { state: "authorized", freshness: "fresh", checkedAt: null, attemptedAt: null, reasonCode: "authorized", reason: "Signed in." },
+		subscriptionUsage: {
+			state: "available", freshness: "fresh", plan: "Pro+", usedPercent: 5, remainingPercent: 95,
+			observedAt: "2026-09-04T08:00:00Z", checkedAt: "2026-09-04T08:00:00Z", attemptedAt: "2026-09-04T08:00:00Z",
+			reasonCode: "subscription_usage_available", reason: "Cursor subscription capacity is available.",
+			limits: [
+				{ id: "included", name: "Included", state: "active", usedPercent: 5, remainingPercent: 95, resetsAt: "2026-09-25T00:00:00Z" },
+				{ id: "on_demand", name: "On-Demand", state: "active", usedValue: 0, totalValue: 1, remainingValue: 1, usedPercent: 0, remainingPercent: 100, unit: "USD" },
+			],
+		},
+	}],
+};
+
+beforeEach(() => {
+	getMock.mockReset().mockResolvedValue({ data: cursorReadiness });
+	postMock.mockReset().mockResolvedValue({ data: cursorReadiness });
+});
+
+it("shows Cursor capacity in the same settings vocabulary as Codex", async () => {
+	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	render(<QueryClientProvider client={queryClient}><CursorSubscriptionUsageSection /></QueryClientProvider>);
+
+	expect(await screen.findByText("Pro+")).toBeInTheDocument();
+	expect(screen.getAllByText(/95% remaining/).length).toBeGreaterThan(0);
+	expect(screen.getByText("Included")).toBeInTheDocument();
+	expect(screen.getByText("On-Demand")).toBeInTheDocument();
+	expect(screen.getByText("$0.00 / $1.00")).toBeInTheDocument();
+	await waitFor(() => expect(postMock).toHaveBeenCalledWith("/api/v1/agents/readiness/ensure", { body: { agentIds: ["cursor"], purpose: "display" } }));
+});

--- a/frontend/src/renderer/components/settings/CursorSubscriptionUsageSection.tsx
+++ b/frontend/src/renderer/components/settings/CursorSubscriptionUsageSection.tsx
@@ -1,0 +1,105 @@
+import { CircleAlert, LoaderCircle } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { components } from "../../../api/schema";
+import { useAgentReadinessQuery, useEnsureAgentReadiness } from "../../hooks/useAgentReadinessQuery";
+import { AgentProviderGroup } from "./AgentProviderGroup";
+import { formatPercentage, formatPlanName } from "./CodexAccountDetails";
+import { SettingsSection } from "./SettingsSection";
+
+type SubscriptionUsage = components["schemas"]["SubscriptionUsageSnapshot"];
+type SubscriptionLimit = components["schemas"]["SubscriptionUsageLimit"];
+
+export function CursorSubscriptionUsageSection({ titleHidden }: { titleHidden?: boolean }) {
+	const { t, i18n } = useTranslation();
+	const readiness = useAgentReadinessQuery();
+	useEnsureAgentReadiness({ agentIds: ["cursor"], purpose: "display" });
+	const [expanded, setExpanded] = useState(true);
+	const cursor = readiness.data?.agents.find((agent) => agent.id === "cursor");
+	const usage = cursor?.subscriptionUsage;
+	const plan = formatPlanName(usage?.plan);
+	const summary = usage
+		? [plan, usage.remainingPercent == null ? null : `${formatPercentage(usage.remainingPercent, i18n.language)} ${t("settings.codexAccounts.remaining")}`].filter(Boolean).join(" · ") || usage.reason
+		: readiness.isLoading ? t("settings.codexAccounts.loading") : t("settings.codexAccounts.usageDetailsUnavailable");
+
+	return (
+		<SettingsSection title="Cursor" sectionId="cursor-subscription-usage" titleHidden={titleHidden}>
+			<AgentProviderGroup provider="cursor" name="Cursor" summary={summary} expanded={expanded} onExpandedChange={setExpanded}>
+				<div className="px-4 py-4">
+					{usage ? <CursorSubscriptionUsageDetails usage={usage} locale={i18n.language} /> : (
+						<p className="text-xs text-muted-foreground">{t("settings.codexAccounts.usageDetailsUnavailable")}</p>
+					)}
+				</div>
+			</AgentProviderGroup>
+		</SettingsSection>
+	);
+}
+
+function CursorSubscriptionUsageDetails({ usage, locale }: { usage: SubscriptionUsage; locale: string }) {
+	const { t } = useTranslation();
+	const notice = usage.freshness !== "fresh" || usage.state === "unknown" || usage.state === "unsupported";
+	return (
+		<div className="space-y-5 text-xs">
+			{notice ? (
+				<p className="flex items-start gap-2 rounded-md border border-border bg-muted/20 px-3 py-2.5 leading-5 text-muted-foreground" role="status">
+					{usage.freshness === "checking" ? <LoaderCircle className="mt-0.5 size-3.5 shrink-0 animate-spin" aria-label={t("settings.codexAccounts.checking")} /> : <CircleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />}
+					<span>{usage.reason}</span>
+				</p>
+			) : null}
+			{usage.plan ? (
+				<section>
+					<h4 className="mb-2 font-medium text-foreground">{t("settings.codexAccounts.yourPlan")}</h4>
+					<div className="rounded-md border border-border/70 bg-muted/15 px-3.5 py-3 text-sm font-medium text-foreground">{formatPlanName(usage.plan)}</div>
+				</section>
+			) : null}
+			{usage.limits.length > 0 ? (
+				<section>
+					<h4 className="mb-2 font-medium text-foreground">{t("settings.codexAccounts.generalUsageLimits")}</h4>
+					<div className="divide-y divide-border/70 overflow-hidden rounded-md border border-border/70 bg-muted/15">
+						{usage.limits.map((limit) => <CursorLimitRow key={limit.id} limit={limit} locale={locale} />)}
+					</div>
+				</section>
+			) : null}
+		</div>
+	);
+}
+
+function CursorLimitRow({ limit, locale }: { limit: SubscriptionLimit; locale: string }) {
+	const { t } = useTranslation();
+	if (limit.usedValue != null || limit.usedPercent == null || limit.remainingPercent == null) {
+		const value = absoluteLimitValue(limit, locale, t("settings.updates.disabled"), t("usage.unavailable"));
+		return <div className="flex items-center justify-between gap-4 px-3.5 py-3"><p className="font-medium text-foreground">{limit.name}</p><p className="text-right font-medium tabular-nums text-muted-foreground">{value}</p></div>;
+	}
+	const remaining = Math.max(0, Math.min(100, limit.remainingPercent));
+	const percentage = formatPercentage(remaining, locale);
+	const reset = formatResetTime(limit.resetsAt, locale);
+	const fillClass = remaining <= 0 ? "bg-error" : remaining <= 25 ? "bg-warning" : "bg-foreground/80";
+	const valueClass = remaining <= 0 ? "text-error" : remaining <= 25 ? "text-warning" : "text-muted-foreground";
+	return (
+		<div className="grid gap-2 px-3.5 py-3 sm:grid-cols-[minmax(0,1fr)_minmax(8rem,11rem)_auto] sm:items-center sm:gap-4">
+			<div className="min-w-0"><p className="font-medium text-foreground">{limit.name}</p>{reset ? <p className="mt-0.5 text-muted-foreground" title={reset.full}>{t("settings.codexAccounts.capacityResets", { value: reset.visible })}</p> : null}</div>
+			<div role="progressbar" aria-label={t("settings.codexAccounts.remainingForLimit", { label: limit.name, value: percentage })} aria-valuemin={0} aria-valuemax={100} aria-valuenow={remaining} className="h-1.5 w-full overflow-hidden rounded-full bg-muted"><div className={`h-full rounded-full transition-[width] ${fillClass}`} style={{ width: `${remaining}%` }} /></div>
+			<p className={`whitespace-nowrap text-right tabular-nums ${valueClass}`}>{t("settings.codexAccounts.percentLeft", { value: percentage })}</p>
+		</div>
+	);
+}
+
+function absoluteLimitValue(limit: SubscriptionLimit, locale: string, disabled: string, unavailable: string): string {
+	if (limit.state === "unlimited") return "Unlimited";
+	if (limit.state === "disabled") return disabled;
+	if (limit.state === "unavailable") return unavailable;
+	const format = (value: number) => new Intl.NumberFormat(locale, { style: "currency", currency: limit.unit || "USD", maximumFractionDigits: 2 }).format(value);
+	if (limit.usedValue != null && limit.totalValue != null) return `${format(limit.usedValue)} / ${format(limit.totalValue)}`;
+	if (limit.usedValue != null) return format(limit.usedValue);
+	return unavailable;
+}
+
+function formatResetTime(value: string | null | undefined, locale: string): { visible: string; full: string } | null {
+	if (!value) return null;
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return null;
+	return {
+		visible: new Intl.DateTimeFormat(locale, { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" }).format(date),
+		full: new Intl.DateTimeFormat(locale, { dateStyle: "full", timeStyle: "long" }).format(date),
+	};
+}


### PR DESCRIPTION
## Summary

- rebuild the change on the latest upstream main and remove the obsolete provider-neutral quota page and pipeline
- read Cursor subscription usage on demand through the daemon, with a two-minute in-memory cache and coalesced refreshes matching the current Codex capacity pattern
- surface the Cursor plan, Included, Auto, API, and On-Demand limits in Settings > Subscriptions beside Codex
- keep subscription capacity advisory so it never blocks launching a Cursor session

## Safety and compatibility

- support only the exact verified Cursor builds 2026.08.11-e8db854 and 2026.08.25-3e8eec8; unknown builds and API-key-only authentication report unsupported
- invoke the Cursor structured local client through a packaged helper instead of scraping terminal output
- expose only the plan and normalized usage fields; raw provider payloads, account identity, and credentials never enter the API model
- cap helper output at 64 KiB and pass a minimal environment allowlist without provider API keys or tokens

## Verification

- focused Go adapter, service, daemon, and HTTP suites: passed
- golangci-lint v2.12.2: 0 issues
- frontend TypeScript check: passed
- Cursor settings and ACP runtime packaging tests: 9 passed
- packaged Cursor helper tests: 3 passed
- sanitized live helper probes against both supported Cursor builds: passed
- isolated real Electron app: visually verified the live Pro+ plan, remaining capacity meters, reset date, and On-Demand spend
- full backend suite: one unrelated load-sensitive fake lifecycle timing assertion failed under the saturated run; its isolated rerun passed