### PR TITLE
fix(desktop): defer agent auth probes until selection

### DIFF
--- a/backend/internal/adapters/agent/muse/install.go
+++ b/backend/internal/adapters/agent/muse/install.go
@@ -1,8 +1,18 @@
 package muse
 
-import "context"
+import (
+	"context"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
+)
 
 // ResolveBinary resolves the executable path for the plugin.
 func (p *Plugin) ResolveBinary(ctx context.Context) (string, error) {
 	return p.museBinary(ctx)
+}
+
+// ResolveBinaryPresence resolves a local Muse executable without running its
+// version-signature check. Full resolution still validates Muse before launch.
+func (p *Plugin) ResolveBinaryPresence(ctx context.Context) (string, error) {
+	return binaryutil.ResolveBinary(ctx, museBinarySpec)
 }

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -270,12 +270,10 @@ func Run() error {
 	}
 	lcStack.trackerDone = startTrackerIntake(ctx, store, sessionSvc, log)
 
+	// Keep full agent binary/auth probing off daemon startup. The requirements
+	// gate performs a path-only check, and agent-selection surfaces request a
+	// fresh inventory when the user opens them.
 	agentSvc := agentsvc.NewWithDeps(agentsvc.Deps{Cache: store, InventoryCache: store, Discoverer: modelcatalog.Discoverer{}, Projects: store, Sessions: store})
-	go func() {
-		if _, err := agentSvc.Refresh(ctx); err != nil {
-			log.Warn("initial agent catalog refresh failed", "err", err)
-		}
-	}()
 	hostCommands := systemexec.Adapter{}
 	systemChecks := systemcheck.New(agentSvc, hostCommands)
 	systemInstall := systeminstall.New(hostCommands, hostCommands)

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -71,6 +71,13 @@ type AgentBinaryResolver interface {
 	ResolveBinary(ctx context.Context) (path string, err error)
 }
 
+// AgentBinaryPresenceResolver is an optional startup-only refinement for an
+// adapter whose normal binary resolution performs additional validation. It
+// must only inspect local executable paths; it must not start the agent CLI.
+type AgentBinaryPresenceResolver interface {
+	ResolveBinaryPresence(ctx context.Context) (path string, err error)
+}
+
 // AgentNativeSessionTerminator is an optional adapter capability used before
 // AO destroys a terminal runtime or worktree whose agent may keep running in a
 // detached native process. Implementations must affect only the supplied

--- a/backend/internal/service/agent/catalog_test.go
+++ b/backend/internal/service/agent/catalog_test.go
@@ -30,6 +30,15 @@ type fakeAuthAgent struct {
 	authDelay time.Duration
 }
 
+type panicAuthAgent struct {
+	fakeAgent
+}
+
+type presenceOnlyAgent struct {
+	fakeAgent
+	path string
+}
+
 type probeTrackingAgent struct {
 	fakeAgent
 	onProbe func()
@@ -277,6 +286,14 @@ func (f fakeAuthAgent) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, e
 	return f.status, f.authErr
 }
 
+func (panicAuthAgent) AuthStatus(context.Context) (ports.AgentAuthStatus, error) {
+	panic("startup binary presence probe must not check authentication")
+}
+
+func (f presenceOnlyAgent) ResolveBinaryPresence(context.Context) (string, error) {
+	return f.path, nil
+}
+
 func TestListReturnsInitialSupportedInventoryWithoutProbing(t *testing.T) {
 	probed := false
 	svc := NewWithAgents([]agentregistry.HarnessAgent{
@@ -308,6 +325,42 @@ func TestListReturnsInitialSupportedInventoryWithoutProbing(t *testing.T) {
 	}
 	if got.Authorized == nil {
 		t.Fatal("Authorized = nil, want empty slice")
+	}
+}
+
+func TestFindInstalledBinaryDoesNotProbeAuthOrMutateInventory(t *testing.T) {
+	svc := NewWithAgents([]agentregistry.HarnessAgent{{
+		Harness:  domain.AgentHarness("codex"),
+		Manifest: adapters.Manifest{ID: "codex", Name: "Codex"},
+		Agent:    panicAuthAgent{},
+	}})
+
+	got, ok := svc.FindInstalledBinary(context.Background())
+	if !ok || got.ID != "codex" || got.Label != "Codex" {
+		t.Fatalf("FindInstalledBinary() = (%#v, %v), want Codex", got, ok)
+	}
+	inventory, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inventory.Installed) != 0 || len(inventory.Authorized) != 0 {
+		t.Fatalf("inventory = %#v, want no inventory/auth refresh", inventory)
+	}
+}
+
+func TestFindInstalledBinaryUsesPresenceOnlyResolver(t *testing.T) {
+	svc := NewWithAgents([]agentregistry.HarnessAgent{{
+		Harness:  domain.AgentHarness("muse"),
+		Manifest: adapters.Manifest{ID: "muse", Name: "Muse Code"},
+		Agent: presenceOnlyAgent{
+			fakeAgent: fakeAgent{err: errors.New("full resolution must not run")},
+			path:      "/usr/local/bin/muse",
+		},
+	}})
+
+	got, ok := svc.FindInstalledBinary(context.Background())
+	if !ok || got.ID != "muse" {
+		t.Fatalf("FindInstalledBinary() = (%#v, %v), want Muse", got, ok)
 	}
 }
 

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -17,10 +17,11 @@ import (
 )
 
 var (
-	agentInstallProbeTimeout = 2 * time.Second
-	agentAuthProbeTimeout    = 10 * time.Second
-	agentRefreshMinInterval  = 10 * time.Second
-	modelCatalogLoadTimeout  = 30 * time.Second
+	agentInstallProbeTimeout  = 2 * time.Second
+	agentAuthProbeTimeout     = 10 * time.Second
+	startupBinaryProbeTimeout = 500 * time.Millisecond
+	agentRefreshMinInterval   = 10 * time.Second
+	modelCatalogLoadTimeout   = 30 * time.Second
 	// How long a cached catalog is trusted before AO asks a cache-first client to
 	// revalidate in the background. Long, because rediscovery runs an agent CLI:
 	// this covers drift a fingerprint cannot see, not routine correctness.
@@ -194,6 +195,62 @@ func (s *Service) Refresh(ctx context.Context) (Inventory, error) {
 // checks after an install may have changed PATH-visible binaries.
 func (s *Service) RefreshFresh(ctx context.Context) (Inventory, error) {
 	return s.refresh(ctx, true)
+}
+
+// FindInstalledBinary returns one installed agent CLI without running an
+// agent process, probing authentication, or mutating the cached inventory.
+// The desktop startup gate uses this bounded path-only probe; selection
+// surfaces request the richer inventory when the user opens them.
+func (s *Service) FindInstalledBinary(ctx context.Context) (Info, bool) {
+	if ctx.Err() != nil {
+		return Info{}, false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, startupBinaryProbeTimeout)
+	defer cancel()
+
+	results := make(chan Info, len(s.agents))
+	var wg sync.WaitGroup
+	for _, item := range s.agents {
+		resolver, canResolve := item.Agent.(ports.AgentBinaryResolver)
+		presenceResolver, hasPresenceResolver := item.Agent.(ports.AgentBinaryPresenceResolver)
+		if !canResolve && !hasPresenceResolver {
+			continue
+		}
+		wg.Add(1)
+		go func(item agentregistry.HarnessAgent) {
+			defer wg.Done()
+			var path string
+			var err error
+			if hasPresenceResolver {
+				path, err = presenceResolver.ResolveBinaryPresence(probeCtx)
+			} else {
+				path, err = resolver.ResolveBinary(probeCtx)
+			}
+			if err != nil || path == "" {
+				return
+			}
+			label := item.Manifest.Name
+			if label == "" {
+				label = string(item.Harness)
+			}
+			results <- Info{ID: string(item.Harness), Label: label}
+		}(item)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case info := <-results:
+		return info, true
+	case <-done:
+		return Info{}, false
+	case <-probeCtx.Done():
+		return Info{}, false
+	}
 }
 
 func (s *Service) refresh(ctx context.Context, force bool) (Inventory, error) {

--- a/backend/internal/service/systemcheck/systemcheck.go
+++ b/backend/internal/service/systemcheck/systemcheck.go
@@ -2,15 +2,13 @@
 // prerequisites AO needs before the desktop app shows the board: git, tmux
 // (macOS/Linux only), and at least one installed agent-harness CLI. It also
 // probes for gh (the GitHub CLI), which is advisory only and never blocks
-// readiness. It is the backend gate the Electron loading screen polls; the
-// checks are pure existence probes (LookPath), not the deeper
-// version/compatibility checks `ao doctor` runs.
+// readiness. These checks only resolve executable paths; agent authentication
+// and compatibility probes are deferred until the user opens an agent picker.
 package systemcheck
 
 import (
 	"context"
 	"runtime"
-	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	agentsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/agent"
@@ -31,11 +29,10 @@ type Report struct {
 	Requirements []Requirement `json:"requirements" description:"Individual checks, in stable order: git, tmux, harness, gh."`
 }
 
-// HarnessCatalog is the subset of agent.Service the harness requirement needs.
-// agent.Service satisfies this with a forced refresh so a user-triggered
-// recheck cannot be answered by the normal short-lived inventory cache.
+// HarnessCatalog is the path-only subset of agent.Service the startup harness
+// requirement needs.
 type HarnessCatalog interface {
-	RefreshFresh(ctx context.Context) (agentsvc.Inventory, error)
+	FindInstalledBinary(ctx context.Context) (agentsvc.Info, bool)
 }
 
 // Service runs the startup requirements gate.
@@ -114,21 +111,14 @@ func (s *Service) checkTmux() Requirement {
 
 func (s *Service) checkHarness(ctx context.Context) Requirement {
 	const label = "agent harness"
-	inv, err := s.harnesses.RefreshFresh(ctx)
-	if err != nil {
-		return Requirement{ID: "harness", Label: label, Required: true, Detail: err.Error()}
-	}
-	if len(inv.Installed) == 0 {
+	info, ok := s.harnesses.FindInstalledBinary(ctx)
+	if !ok {
 		return Requirement{
 			ID: "harness", Label: label, Required: true,
-			Detail: "No agent CLI (Claude Code, Codex, etc.) was found on PATH.",
+			Detail: "No agent CLI (Claude Code, Codex, etc.) was found on PATH or in a supported install location.",
 		}
 	}
-	labels := make([]string, 0, len(inv.Installed))
-	for _, info := range inv.Installed {
-		labels = append(labels, info.Label)
-	}
-	return Requirement{ID: "harness", Label: label, Satisfied: true, Required: true, Detail: strings.Join(labels, ", ")}
+	return Requirement{ID: "harness", Label: label, Satisfied: true, Required: true, Detail: info.Label}
 }
 
 // checkGH probes for the GitHub CLI. It is advisory only (Required: false):

--- a/backend/internal/service/systemcheck/systemcheck_test.go
+++ b/backend/internal/service/systemcheck/systemcheck_test.go
@@ -10,11 +10,13 @@ import (
 
 type fakeHarnessCatalog struct {
 	inventory agentsvc.Inventory
-	err       error
 }
 
-func (f *fakeHarnessCatalog) RefreshFresh(context.Context) (agentsvc.Inventory, error) {
-	return f.inventory, f.err
+func (f *fakeHarnessCatalog) FindInstalledBinary(context.Context) (agentsvc.Info, bool) {
+	if len(f.inventory.Installed) == 0 {
+		return agentsvc.Info{}, false
+	}
+	return f.inventory.Installed[0], true
 }
 
 func lookPathFound(paths map[string]string) func(string) (string, error) {
@@ -132,29 +134,6 @@ func TestCheck_NoHarnessInstalled(t *testing.T) {
 	}
 	if harness.Detail == "" {
 		t.Fatalf("harness.Detail is empty, want a not-found message")
-	}
-}
-
-func TestCheck_HarnessCatalogError(t *testing.T) {
-	catalog := &fakeHarnessCatalog{err: errors.New("probe boom")}
-	svc := NewWithLookPath(catalog, lookPathFound(map[string]string{
-		"git":  "/usr/bin/git",
-		"tmux": "/usr/bin/tmux",
-	}))
-
-	report, err := svc.Check(context.Background())
-	if err != nil {
-		t.Fatalf("Check() error = %v, want nil (harness errors fold into the requirement)", err)
-	}
-	if report.Ready {
-		t.Fatalf("Ready = true, want false")
-	}
-	harness := requirementByID(t, report, "harness")
-	if harness.Satisfied {
-		t.Fatalf("harness.Satisfied = true, want false")
-	}
-	if harness.Detail != "probe boom" {
-		t.Fatalf("harness.Detail = %q, want %q", harness.Detail, "probe boom")
 	}
 }
 

--- a/frontend/src/renderer/hooks/useAgentsQuery.ts
+++ b/frontend/src/renderer/hooks/useAgentsQuery.ts
@@ -18,10 +18,10 @@ export async function refreshAgents(): Promise<AgentCatalog> {
 	return data as AgentCatalog;
 }
 
-// The daemon probes agent binaries once at boot, so an agent installed or
-// authenticated afterwards stays invisible until something re-probes. Surfaces
-// that ask the user to pick an agent freshen the inventory on open instead of
-// offering a "Refresh agents" link: probing is the app's job, not the reader's.
+// Full binary/auth probing is deliberately off the app-startup path. Surfaces
+// that ask the user to pick an agent freshen the cached inventory on open
+// instead of offering a "Refresh agents" link: probing is the app's job, not
+// the reader's.
 // Throttled because a probe spawns one subprocess per supported agent.
 const AGENT_REFRESH_THROTTLE_MS = 5 * 60 * 1000;
 let lastAgentRefreshAt = 0;

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -20,7 +20,6 @@ import { SidebarProvider } from "../components/ui/sidebar";
 import { TitlebarNav } from "../components/TitlebarNav";
 import { WindowTitlebar } from "../components/WindowTitlebar";
 import { TerminalCacheProvider } from "../components/TerminalPane";
-import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { agentModelsQueryOptions } from "../hooks/useAgentModelsQuery";
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useOpenShellTerminal } from "../hooks/useShellTerminals";
@@ -102,7 +101,6 @@ function ShellLayout() {
 	const daemonStatus = useDaemonStatus(queryClient);
 	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
 	const workspaceStartupBaselineRef = useRef(0);
-	const agentCatalogPortRef = useRef<number | undefined>(undefined);
 	const { themePreference, resolvedTheme, themeStyle, isSidebarOpen, toggleSidebar } = useUiStore();
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
@@ -574,15 +572,6 @@ function ShellLayout() {
 	useEffect(() => {
 		void aoBridge.theme?.set(themePreference);
 	}, [themePreference]);
-
-	useEffect(() => {
-		if (daemonStatus.state !== "ready" || !daemonStatus.port) return;
-		if (agentCatalogPortRef.current === daemonStatus.port) return;
-
-		agentCatalogPortRef.current = daemonStatus.port;
-		void queryClient.invalidateQueries({ queryKey: agentsQueryKey });
-		void queryClient.fetchQuery({ ...agentsQueryOptions, queryFn: refreshAgents });
-	}, [daemonStatus.port, daemonStatus.state, queryClient]);
 
 	// Follow OS appearance while the user keeps Theme on System — updates
 	// resolvedTheme (and thus React consumers) without writing light/dark to storage.

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -34,6 +34,7 @@ const shellMocks = vi.hoisted(() => {
 	};
 	return {
 		navigate: vi.fn(),
+		refreshAgents: vi.fn(),
 		onNewSessionShortcut: vi.fn((listener: () => void) => {
 			state.newSessionListener = listener;
 			return vi.fn();
@@ -147,8 +148,8 @@ vi.mock("../hooks/useShellTerminals", () => ({
 
 vi.mock("../hooks/useAgentsQuery", () => ({
 	agentsQueryKey: ["agents"],
-	agentsQueryOptions: {},
-	refreshAgents: vi.fn(),
+	agentsQueryOptions: { queryKey: ["agents"] },
+	refreshAgents: shellMocks.refreshAgents,
 	// The shell reports the install's agent inventory once per launch, so the
 	// mock has to answer this too. Undefined data means the hook reports nothing,
 	// which keeps these shortcut tests free of telemetry side effects.
@@ -271,6 +272,7 @@ function emitShortcut() {
 
 beforeEach(() => {
 	shellMocks.navigate.mockReset();
+	shellMocks.refreshAgents.mockReset();
 	shellMocks.onNewSessionShortcut.mockClear();
 	shellMocks.onKeyboardShortcutsHelp.mockClear();
 	shellMocks.onNewShellTerminalShortcut.mockClear();
@@ -313,6 +315,17 @@ beforeEach(() => {
 });
 
 describe("shell workspace startup", () => {
+	it("does not schedule a full agent/auth refresh during shell startup", async () => {
+		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };
+		shellMocks.queryClient.fetchQuery.mockResolvedValue(workspaces);
+
+		await renderShell();
+
+		expect(shellMocks.queryClient.fetchQuery).not.toHaveBeenCalledWith(
+			expect.objectContaining({ queryFn: shellMocks.refreshAgents }),
+		);
+	});
+
 	it("leaves the session topbar row to the session split instead of reserving a full-width shell row", async () => {
 		shellMocks.state.routeParams = { sessionId: "sess-1" };
 		await renderShell();


### PR DESCRIPTION
Fixes #4341

## Summary
- replace the startup gate's full agent inventory/auth refresh with a bounded executable-presence-only probe
- remove the duplicate full catalog refreshes from daemon boot and shell startup
- keep full binary/auth discovery on the existing agent-selection surfaces, which refresh the cached inventory when opened
- preserve Muse's full version-signature validation for actual launches while allowing startup to use a path-only presence check

This isolates the auth-probe regression from the broader startup reconciliation and layout changes proposed in #4330.

## Test
- `cd backend && go build ./...`
- `cd backend && go vet ./...`
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs`
- `cd backend && go test -race ./internal/service/agent ./internal/service/systemcheck`
- `cd backend && go test ./internal/httpd/controllers ./internal/daemon`
- `cd frontend && npx vitest run src/renderer/test/shell-new-session-shortcut.test.tsx src/renderer/components/DaemonStartupLoader.test.tsx`
- `cd frontend && npx vitest run src/renderer/components/CreateProjectAgentSheet.test.tsx src/renderer/components/TaskComposer.test.tsx src/renderer/components/ProjectSettingsForm.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npx vite build --config vite.renderer.config.ts`

## Full-suite note
`cd backend && go test ./...` passed every package except the unrelated timing-sensitive `internal/adapters/agent/fake` lifecycle speed assertion while the build, vet, tests, and race checks were running concurrently. Re-running that package alone passed.
