### PR TITLE
fix(renderer): fetch-based workspace SSE — stop on 4xx, honor 503 (completes #4323)

### DIFF
--- a/frontend/src/renderer/lib/sse-parse.test.ts
+++ b/frontend/src/renderer/lib/sse-parse.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseSseFrames } from "./sse-parse";
+
+describe("parseSseFrames", () => {
+	it("parses a complete event frame and leaves no remainder", () => {
+		const { events, rest } = parseSseFrames("event: workspace_changed\ndata: {}\n\n");
+		expect(events).toEqual([{ event: "workspace_changed", data: "{}", id: undefined }]);
+		expect(rest).toBe("");
+	});
+
+	it("retains a partial trailing frame in rest", () => {
+		const { events, rest } = parseSseFrames("event: a\ndata: 1\n\nevent: partial");
+		expect(events).toHaveLength(1);
+		expect(rest).toBe("event: partial");
+	});
+
+	it("ignores keepalive comment lines", () => {
+		const { events } = parseSseFrames(": keepalive\n\n");
+		expect(events).toEqual([]);
+	});
+
+	it("normalizes CRLF and strips one leading space after the colon", () => {
+		const { events } = parseSseFrames("event:workspace_changed\r\ndata: x\r\n\r\n");
+		expect(events[0]).toMatchObject({ event: "workspace_changed", data: "x" });
+	});
+
+	it("joins multi-line data and defaults the event name to message", () => {
+		const { events } = parseSseFrames("data: a\ndata: b\n\n");
+		expect(events[0]).toMatchObject({ event: "message", data: "a\nb" });
+	});
+
+	it("parses two frames from one buffer", () => {
+		const { events } = parseSseFrames("event: a\ndata: 1\n\nevent: b\ndata: 2\n\n");
+		expect(events.map((e) => e.event)).toEqual(["a", "b"]);
+	});
+});

--- a/frontend/src/renderer/lib/sse-parse.ts
+++ b/frontend/src/renderer/lib/sse-parse.ts
@@ -1,0 +1,70 @@
+// Minimal Server-Sent-Events frame parser, used by the fetch-based workspace
+// stream reader. Native EventSource hides the HTTP status on error, so we read
+// the stream with fetch() instead and parse the frames ourselves — this parser
+// is the part that turns a byte buffer into events.
+//
+// A frame is a run of lines terminated by a blank line. Within a frame:
+//   - `field: value`   (a leading space after the colon is stripped, per spec)
+//   - `data:` lines accumulate, joined with "\n"
+//   - lines starting with ":" are comments (keepalives) and ignored
+// Kept pure and dependency-free so it is trivially unit-testable.
+
+export type SseEvent = {
+	event: string; // defaults to "message" when no event field is present
+	data: string;
+	id?: string;
+};
+
+/**
+ * Consume complete frames from `buffer` and return the parsed events plus the
+ * unparsed remainder (a partial frame not yet terminated by a blank line). Call
+ * repeatedly as more bytes arrive, feeding the returned remainder back in.
+ */
+export function parseSseFrames(buffer: string): { events: SseEvent[]; rest: string } {
+	// Normalise CRLF / lone CR to LF so frame/line splitting is uniform.
+	const normalized = buffer.replace(/\r\n?/g, "\n");
+	const events: SseEvent[] = [];
+	let searchFrom = 0;
+	let boundary = normalized.indexOf("\n\n", searchFrom);
+	while (boundary !== -1) {
+		const frame = normalized.slice(searchFrom, boundary);
+		const ev = parseFrame(frame);
+		if (ev) events.push(ev);
+		searchFrom = boundary + 2;
+		boundary = normalized.indexOf("\n\n", searchFrom);
+	}
+	return { events, rest: normalized.slice(searchFrom) };
+}
+
+function parseFrame(frame: string): SseEvent | null {
+	let event = "";
+	const dataLines: string[] = [];
+	let id: string | undefined;
+	let sawField = false;
+	for (const rawLine of frame.split("\n")) {
+		if (rawLine === "" || rawLine.startsWith(":")) continue; // blank or comment
+		const colon = rawLine.indexOf(":");
+		const field = colon === -1 ? rawLine : rawLine.slice(0, colon);
+		let value = colon === -1 ? "" : rawLine.slice(colon + 1);
+		if (value.startsWith(" ")) value = value.slice(1);
+		switch (field) {
+			case "event":
+				event = value;
+				sawField = true;
+				break;
+			case "data":
+				dataLines.push(value);
+				sawField = true;
+				break;
+			case "id":
+				id = value;
+				sawField = true;
+				break;
+			default:
+				// Unknown fields are ignored per spec.
+				break;
+		}
+	}
+	if (!sawField) return null;
+	return { event: event || "message", data: dataLines.join("\n"), id };
+}

--- a/frontend/src/renderer/lib/workspace-file-events.test.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.test.ts
@@ -17,87 +17,139 @@ vi.mock("./api-client", () => ({
 
 import { subscribeWorkspaceFileChanges } from "./workspace-file-events";
 
-class EventSourceStub {
-	static instances: EventSourceStub[] = [];
-	url: string;
-	closed = false;
-	readyState = 0;
-	onopen: (() => void) | null = null;
-	onerror: (() => void) | null = null;
-	listeners = new Map<string, Set<() => void>>();
+// A manually-driven readable-stream body: the test pushes SSE text and ends it.
+function makeStreamBody() {
+	const encoder = new TextEncoder();
+	const queued: Uint8Array[] = [];
+	let waiting: ((r: { value?: Uint8Array; done: boolean }) => void) | null = null;
+	let ended = false;
+	return {
+		push(text: string) {
+			const chunk = encoder.encode(text);
+			if (waiting) {
+				const resolve = waiting;
+				waiting = null;
+				resolve({ value: chunk, done: false });
+			} else {
+				queued.push(chunk);
+			}
+		},
+		end() {
+			ended = true;
+			if (waiting) {
+				const resolve = waiting;
+				waiting = null;
+				resolve({ value: undefined, done: true });
+			}
+		},
+		body: {
+			getReader() {
+				return {
+					read: () =>
+						new Promise<{ value?: Uint8Array; done: boolean }>((resolve) => {
+							if (queued.length) return resolve({ value: queued.shift(), done: false });
+							if (ended) return resolve({ value: undefined, done: true });
+							waiting = resolve;
+						}),
+					cancel: () => {},
+				};
+			},
+		},
+	};
+}
 
-	constructor(url: string) {
-		this.url = url;
-		EventSourceStub.instances.push(this);
-	}
-
-	addEventListener(type: string, listener: () => void) {
-		const listeners = this.listeners.get(type) ?? new Set();
-		listeners.add(listener);
-		this.listeners.set(type, listeners);
-	}
-
-	dispatch(type: string) {
-		for (const listener of this.listeners.get(type) ?? []) listener();
-	}
-
-	close() {
-		this.closed = true;
-		this.readyState = 2;
-	}
+function response(status: number, body: unknown = null, headers: Record<string, string> = {}): Response {
+	return {
+		status,
+		ok: status >= 200 && status < 300,
+		body,
+		headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+	} as unknown as Response;
 }
 
 function fakeQueryClient() {
 	return { invalidateQueries: vi.fn() } as unknown as Parameters<typeof subscribeWorkspaceFileChanges>[1];
 }
 
+let fetchMock: ReturnType<typeof vi.fn>;
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
 beforeEach(() => {
-	EventSourceStub.instances = [];
 	getApiBaseUrlMock.mockReset().mockReturnValue("http://127.0.0.1:3001");
 	hasTrustedApiBaseUrlMock.mockReset().mockReturnValue(true);
 	subscribeApiBaseUrlMock.mockReset().mockReturnValue(unsubscribeBaseUrlMock);
 	unsubscribeBaseUrlMock.mockReset();
-	(globalThis as unknown as { EventSource: unknown }).EventSource = EventSourceStub;
+	fetchMock = vi.fn();
+	vi.stubGlobal("fetch", fetchMock);
 });
 
 afterEach(() => {
 	vi.useRealTimers();
-	delete (globalThis as unknown as { EventSource?: unknown }).EventSource;
+	vi.unstubAllGlobals();
 });
 
 describe("subscribeWorkspaceFileChanges", () => {
-	it("shares one daemon stream until the final Files view unmounts", () => {
+	it("opens one stream shared across views and aborts it on the final unmount", async () => {
+		const stream = makeStreamBody();
+		fetchMock.mockResolvedValue(response(200, stream.body));
 		const queryClient = fakeQueryClient();
-		const unsubscribeRail = subscribeWorkspaceFileChanges("session/a", queryClient);
-		const unsubscribeMaximized = subscribeWorkspaceFileChanges("session/a", queryClient);
 
-		expect(EventSourceStub.instances).toHaveLength(1);
-		expect(EventSourceStub.instances[0].url).toBe(
-			"http://127.0.0.1:3001/api/v1/sessions/session%2Fa/workspace/events",
-		);
+		const unsubA = subscribeWorkspaceFileChanges("session/a", queryClient);
+		const unsubB = subscribeWorkspaceFileChanges("session/a", queryClient);
+		await flush();
 
-		unsubscribeRail();
-		expect(EventSourceStub.instances[0].closed).toBe(false);
-		unsubscribeMaximized();
-		expect(EventSourceStub.instances[0].closed).toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe("http://127.0.0.1:3001/api/v1/sessions/session%2Fa/workspace/events");
+		const signal = (init as RequestInit).signal as AbortSignal;
+
+		unsubA();
+		expect(signal.aborted).toBe(false); // still referenced by view B
+		unsubB();
+		expect(signal.aborted).toBe(true); // last view gone -> stream aborted
 		expect(unsubscribeBaseUrlMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("coalesces filesystem events and invalidates the list plus visible details", () => {
-		vi.useFakeTimers();
+	it("coalesces workspace_changed events into one debounced invalidation", async () => {
+		const stream = makeStreamBody();
+		fetchMock.mockResolvedValue(response(200, stream.body));
 		const queryClient = fakeQueryClient();
-		const unsubscribe = subscribeWorkspaceFileChanges("sess-1", queryClient);
-		const source = EventSourceStub.instances[0];
 
-		source.dispatch("workspace_changed");
-		source.dispatch("workspace_changed");
-		vi.advanceTimersByTime(149);
-		expect(queryClient.invalidateQueries).not.toHaveBeenCalled();
-		vi.advanceTimersByTime(1);
+		const unsub = subscribeWorkspaceFileChanges("sess-1", queryClient);
+		await flush(); // let fetch resolve and the read loop start
+		stream.push("event: workspace_changed\ndata: {}\n\n");
+		stream.push("event: workspace_changed\ndata: {}\n\n");
+		await flush();
+		await new Promise((r) => setTimeout(r, 200)); // debounce (150ms) elapses
 
-		expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(2);
 		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-files", "sess-1"] });
 		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-file", "sess-1"] });
-		unsubscribe();
+		unsub();
+	});
+
+	it("stops (does not reconnect) on a 4xx — session/workspace gone", async () => {
+		vi.useFakeTimers();
+		fetchMock.mockResolvedValue(response(404, null));
+		const queryClient = fakeQueryClient();
+
+		const unsub = subscribeWorkspaceFileChanges("gone", queryClient);
+		await vi.advanceTimersByTimeAsync(0); // resolve the 404
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(120_000); // well past any backoff window
+		expect(fetchMock).toHaveBeenCalledTimes(1); // never retried
+		unsub();
+	});
+
+	it("backs off and reconnects on a 5xx", async () => {
+		vi.useFakeTimers();
+		fetchMock.mockResolvedValue(response(500, null));
+		const queryClient = fakeQueryClient();
+
+		const unsub = subscribeWorkspaceFileChanges("busy", queryClient);
+		await vi.advanceTimersByTimeAsync(0); // resolve the first 500
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(60_000); // exceed the max backoff step
+		expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2); // retried
+		unsub();
 	});
 });

--- a/frontend/src/renderer/lib/workspace-file-events.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.ts
@@ -1,16 +1,20 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { getApiBaseUrl, hasTrustedApiBaseUrl, subscribeApiBaseUrl } from "./api-client";
 import { computeBackoffDelayMs } from "./sse-backoff";
+import { parseSseFrames } from "./sse-parse";
 
 const INVALIDATE_DEBOUNCE_MS = 150;
-const EVENTSOURCE_CLOSED = 2;
 
 type WorkspaceStream = {
 	refs: number;
 	disposed: boolean;
+	// stopped is sticky for the life of a base URL: a 4xx means the session or
+	// its workspace is gone, so reconnecting can never succeed. It is cleared
+	// when the daemon base URL changes (a restarted daemon deserves a fresh try).
+	stopped: boolean;
 	failures: number;
-	source?: EventSource;
-	sourceBaseUrl?: string;
+	controller?: AbortController;
+	connectedBaseUrl?: string;
 	debounce?: ReturnType<typeof setTimeout>;
 	retry?: ReturnType<typeof setTimeout>;
 	disconnectBaseUrl: () => void;
@@ -23,6 +27,12 @@ const streams = new Map<string, WorkspaceStream>();
 // Shares one daemon watcher between the rail and maximized copies of a Files
 // view. The daemon sends only invalidation edges; Git status and visible diffs
 // are then refetched through the existing typed queries.
+//
+// The stream is read with fetch() + a ReadableStream rather than EventSource so
+// the HTTP status is visible on failure: a 4xx (session/workspace gone) stops
+// reconnecting entirely, while a 5xx/network failure backs off (honoring
+// Retry-After). Native EventSource exposes no status, so it could only ever
+// blindly reconnect.
 export function subscribeWorkspaceFileChanges(sessionId: string, queryClient: QueryClient): () => void {
 	let stream = streams.get(sessionId);
 	if (!stream) {
@@ -41,8 +51,19 @@ export function subscribeWorkspaceFileChanges(sessionId: string, queryClient: Qu
 	};
 }
 
+function retryAfterMs(response: Response): number | undefined {
+	const header = response.headers.get("retry-after");
+	if (!header) return undefined;
+	const seconds = Number(header);
+	if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+	const date = Date.parse(header);
+	if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+	return undefined;
+}
+
 function createWorkspaceStream(sessionId: string, queryClient: QueryClient): WorkspaceStream {
 	const stream = {} as WorkspaceStream;
+
 	const invalidate = () => {
 		if (stream.debounce) clearTimeout(stream.debounce);
 		stream.debounce = setTimeout(() => {
@@ -50,63 +71,128 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 			void queryClient.invalidateQueries({ queryKey: ["session-workspace-file", sessionId] });
 		}, INVALIDATE_DEBOUNCE_MS);
 	};
-	const scheduleRetry = () => {
-		if (stream.disposed || stream.retry) return;
-		// Exponential backoff + jitter, keyed on consecutive failures, so a
-		// persistently failing stream slows down instead of hammering the daemon
-		// every 5s forever. Reset to a fast retry on a successful open.
-		const delay = computeBackoffDelayMs(stream.failures);
+
+	// scheduleRetry backs off unless an explicit delay (e.g. from Retry-After)
+	// is supplied. It no-ops once the stream is stopped or disposed.
+	const scheduleRetry = (overrideMs?: number) => {
+		if (stream.disposed || stream.stopped || stream.retry) return;
+		const delay = overrideMs ?? computeBackoffDelayMs(stream.failures);
 		stream.failures += 1;
 		stream.retry = setTimeout(() => {
 			stream.retry = undefined;
 			stream.connect();
 		}, delay);
 	};
+
+	const runStream = async (controller: AbortController) => {
+		const baseUrl = stream.connectedBaseUrl;
+		if (!baseUrl) return;
+		const url = `${baseUrl.replace(/\/+$/, "")}/api/v1/sessions/${encodeURIComponent(sessionId)}/workspace/events`;
+
+		// Release this attempt's controller slot (only if we still own it) so a
+		// scheduled retry's connect() is not blocked by the "already connecting"
+		// guard. Must run before scheduleRetry on every current-owner exit.
+		const release = () => {
+			if (stream.controller === controller) stream.controller = undefined;
+		};
+
+		let response: Response;
+		try {
+			response = await fetch(url, { headers: { Accept: "text/event-stream" }, signal: controller.signal });
+		} catch {
+			// Network error or abort. If we were aborted/disposed/superseded, stay
+			// quiet; otherwise this is a transient failure — back off and retry.
+			if (!isCurrent(controller)) return;
+			release();
+			scheduleRetry();
+			return;
+		}
+		if (!isCurrent(controller)) return;
+
+		if (response.status >= 400 && response.status < 500) {
+			// The session or its workspace is gone (or the request is invalid).
+			// Reconnecting can never succeed, so stop instead of looping.
+			release();
+			stream.stopped = true;
+			return;
+		}
+		if (!response.ok || !response.body) {
+			// 5xx (or a bodiless response): transient. Honor Retry-After if the
+			// server sent one, else exponential backoff.
+			release();
+			scheduleRetry(retryAfterMs(response));
+			return;
+		}
+
+		// Healthy stream: reset backoff and refresh once, then read events.
+		stream.failures = 0;
+		invalidate();
+		try {
+			const reader = response.body.getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+			for (;;) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+				const { events, rest } = parseSseFrames(buffer);
+				buffer = rest;
+				for (const ev of events) {
+					if (ev.event === "workspace_changed" && isCurrent(controller)) invalidate();
+				}
+				if (!isCurrent(controller)) return;
+			}
+		} catch {
+			// Read error mid-stream; fall through to reconnect.
+		}
+		if (!isCurrent(controller)) return;
+		// The server closed a previously-healthy stream (e.g. keepalive lapse).
+		// failures was reset on open, so this reconnects promptly.
+		release();
+		scheduleRetry();
+	};
+
+	const isCurrent = (controller: AbortController): boolean =>
+		!stream.disposed && !controller.signal.aborted && stream.controller === controller;
+
 	stream.refs = 0;
 	stream.disposed = false;
+	stream.stopped = false;
 	stream.failures = 0;
+
 	stream.connect = () => {
-		if (stream.disposed || typeof EventSource === "undefined") return;
+		if (stream.disposed || stream.stopped || typeof fetch === "undefined") return;
 		if (!hasTrustedApiBaseUrl()) {
-			stream.source?.close();
-			stream.source = undefined;
-			stream.sourceBaseUrl = undefined;
+			stream.controller?.abort();
+			stream.controller = undefined;
+			stream.connectedBaseUrl = undefined;
 			return;
 		}
 		const baseUrl = getApiBaseUrl();
-		if (stream.source && stream.sourceBaseUrl === baseUrl && stream.source.readyState !== EVENTSOURCE_CLOSED) return;
-		stream.source?.close();
-		stream.sourceBaseUrl = baseUrl;
-		try {
-			const source = new EventSource(
-				`${baseUrl.replace(/\/+$/, "")}/api/v1/sessions/${encodeURIComponent(sessionId)}/workspace/events`,
-			);
-			stream.source = source;
-			source.onopen = () => {
-				if (!stream.disposed && stream.source === source) {
-					stream.failures = 0; // healthy again: next retry starts fast
-					invalidate();
-				}
-			};
-			source.onerror = () => {
-				if (!stream.disposed && stream.source === source && source.readyState === EVENTSOURCE_CLOSED) scheduleRetry();
-			};
-			source.addEventListener("workspace_changed", () => {
-				if (!stream.disposed && stream.source === source) invalidate();
-			});
-		} catch {
-			stream.source = undefined;
-			scheduleRetry();
+		// A new daemon (base URL changed) resets the sticky stop and the backoff:
+		// a restarted daemon deserves a fresh attempt.
+		if (baseUrl !== stream.connectedBaseUrl) {
+			stream.stopped = false;
+			stream.failures = 0;
+		} else if (stream.controller) {
+			return; // already connected/connecting to this base URL
 		}
+		stream.controller?.abort();
+		const controller = new AbortController();
+		stream.controller = controller;
+		stream.connectedBaseUrl = baseUrl;
+		void runStream(controller);
 	};
+
 	stream.disconnectBaseUrl = subscribeApiBaseUrl(stream.connect);
 	stream.dispose = () => {
 		stream.disposed = true;
 		if (stream.debounce) clearTimeout(stream.debounce);
 		if (stream.retry) clearTimeout(stream.retry);
 		stream.disconnectBaseUrl();
-		stream.source?.close();
+		stream.controller?.abort();
 	};
+
 	stream.connect();
 	return stream;
 }


### PR DESCRIPTION
Builds on #4340 (backoff) and completes #4323. **Stacked on `ao/ao-25/sse-backoff`** — review/merge #4340 first (or retarget to `main` after it lands).

## Why
Native `EventSource` hides the HTTP status on error, so the workspace stream could only ever blindly reconnect. #4340 added backoff to stop the *storm*; this adds the *smart stop* by reading the stream with `fetch()` + a `ReadableStream`, which exposes the status.

## Behavior
- **4xx** (session/workspace gone): stop reconnecting entirely — sticky until the daemon base URL changes (a restarted daemon still gets a fresh attempt).
- **5xx / network**: back off (reuses `computeBackoffDelayMs`) and honor a `Retry-After` header when present. This is where **#4325's typed 503 becomes usable on the client**.
- **200**: reset backoff, stream events; a healthy stream that closes reconnects promptly.
- `AbortController` drives clean teardown on unmount and base-URL change.

New dependency-free `sse-parse.ts` turns the byte stream into SSE frames (CRLF / comment-keepalive / multi-line `data` handling).

## Verification (local)
- Pure `sse-parse` and `sse-backoff` invariants: **100 runs each** via `tsx`.
- Full lib test suite — parser, backoff, and the fetch-stream integration tests (shared-stream + abort-on-unmount, event coalescing, **4xx → no reconnect**, **5xx → backed-off reconnect**) — ran **100/100 with zero flakiness**.
- Caught and fixed a real bug during testing: the retry's `connect()` was blocked by the "already connecting" guard because the aborted attempt's controller wasn't released; the 5xx→reconnect test now proves it reconnects.

## Note
Native EventSource is fully replaced here; response-body streaming works in Electron's Chromium `fetch` (the `duplex` limitation only affects request-body streaming, which this doesn't use).
