### PR TITLE
fix(usage): accept switch-sized Codex metadata

### DIFF
--- a/backend/internal/service/usage/collector.go
+++ b/backend/internal/service/usage/collector.go
@@ -25,7 +25,7 @@ import (
 const (
 	maxUsageMetadataBytes          = 256
 	maxUsagePathBytes              = 4096
-	maxCodexSessionMeta            = 64 << 10
+	maxCodexSessionMeta            = 1 << 20
 	maxCodexChildIDs               = 4096
 	defaultCodexLogicalSourceLimit = 4096
 	defaultDiscoveryLimit          = 64

--- a/backend/internal/service/usage/collector_test.go
+++ b/backend/internal/service/usage/collector_test.go
@@ -1672,6 +1672,26 @@ func TestCodexSessionMetaMatchesLargeRollout(t *testing.T) {
 	}
 }
 
+func TestCodexSessionMetaMatchesLargeFirstRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-large-meta.jsonl")
+	line, err := json.Marshal(map[string]any{
+		"type": "session_meta",
+		"payload": map[string]any{
+			"id":             "native-large-meta",
+			"model_provider": "openai",
+			"base_instructions": map[string]any{
+				"text": strings.Repeat("x", 96<<10),
+			},
+		},
+	})
+	mustNoError(t, err)
+	writeUsageFixture(t, path, string(line)+"\n")
+
+	if !codexSessionMetaMatches(path, "native-large-meta", "") {
+		t.Fatal("valid session_meta record with a switch-sized system prompt was rejected")
+	}
+}
+
 func TestDiscoverCodexPathRequiresConfiguredRoots(t *testing.T) {
 	const nativeID = "11111111-1111-4111-8111-111111111111"
 	t.Chdir(t.TempDir())


### PR DESCRIPTION
## What

Increase the bounded Codex `session_meta` discovery limit from 64 KiB to 1 MiB and add a regression fixture with a switch-sized (96 KiB) hidden system prompt.

## Why

Fixes #4343.

Agent switches can legally append up to 96 KiB of handoff continuation before Codex serializes the complete system prompt into the first rollout record. The usage collector rejected that valid first record at 64 KiB, preventing source registration, ingestion, ledger rows, API aggregation, and Summary visibility.

## How

- Keep discovery bounded and first-record-only, but align its ceiling with the usage ingestor's existing 1 MiB record limit.
- Preserve provider-root validation, native/parent identity matching, and all existing rejection behavior.
- Exercise a production-shaped `session_meta` envelope whose `base_instructions.text` is 96 KiB; this test failed against the old limit and passes with the new limit.

Intentional omissions: this focused PR does not change integrity-state reporting or add sanitized diagnostics for records above 1 MiB; those are follow-up hardening items documented in the RCA.

## Testing

- `cd backend && go test ./internal/service/usage -run '^TestCodexSessionMetaMatchesLargeFirstRecord$' -count=1`
- `cd backend && go test ./internal/service/usage -count=1`
- `cd backend && go test -race ./internal/service/usage -count=1`
- `cd backend && go build ./...`
- `cd backend && go test ./...`
- `cd backend && go vet ./internal/service/usage`
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs --timeout=10m` (`0 issues`)

A separate `npm run lint` attempt encountered unrelated environment/timing-sensitive backend test failures before reaching the linter; the same full backend suite passed on rerun, and the linter passed when run directly.

## Risk

Low and bounded: discovery may now read at most 1 MiB rather than 64 KiB for each finite Codex candidate. It does not log or persist prompt contents and does not change ingestion semantics.

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Regression test added for the affected boundary
- [x] Relevant backend checks pass for the touched area
