### PR TITLE
fix(daemon): report degraded readiness and degrade spawn preflight on catalog failure

### DIFF
--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -375,6 +375,11 @@ func resolveSpawnHarness(explicit, kind string, project projectDetails) (string,
 func (c *commandContext) preflightSpawnAgentAuth(ctx context.Context, cmd *cobra.Command, agentID string) error {
 	inv, err := c.fetchAgentInventory(ctx, true)
 	if err != nil {
+		// The catalog is advisory for spawn: a refresh failure (schema drift,
+		// transient DB error) must not turn into an opaque INTERNAL_ERROR that
+		// blocks the core workflow. Warn and let spawn validate runtime
+		// readiness, mirroring the agentProbeUnavailable degradation below.
+		_, err = fmt.Fprintf(cmd.ErrOrStderr(), "warning: agent catalog refresh failed (%v); skipping preflight and letting spawn validate runtime readiness\n", err)
 		return err
 	}
 	state := agentCatalogStateFor(inv, agentID)

--- a/backend/internal/cli/spawn_test.go
+++ b/backend/internal/cli/spawn_test.go
@@ -807,6 +807,48 @@ func TestSpawnFreshProbeServerErrorBlocks(t *testing.T) {
 	}
 }
 
+// TestSpawnCatalogRefreshFailureDegradesToWarning verifies that a failed
+// agent-catalog refresh (the preflight dependency of spawn) does not block
+// spawn with an opaque error: the CLI warns and lets spawn validate runtime
+// readiness, mirroring the agentProbeUnavailable degradation.
+func TestSpawnCatalogRefreshFailureDegradesToWarning(t *testing.T) {
+	cfg := setConfigEnv(t)
+	var requests []string
+	var req spawnRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appendPrimaryRequest(&requests, r)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/demo":
+			_, _ = io.WriteString(w, `{"status":"ok","project":{"id":"demo","name":"Demo","path":"/repo/demo"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/refresh":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"message":"Internal server error","code":"INTERNAL_ERROR","requestId":"req-1"}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions":
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.WriteString(w, `{"session":{"id":"demo-15","status":"idle"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "spawn", "--project", "demo", "--agent", "codex", "--name", "worker")
+	if err != nil {
+		t.Fatalf("spawn failed on catalog refresh: %v stderr=%s", err, errOut)
+	}
+	if !strings.Contains(errOut, "warning: agent catalog refresh failed") {
+		t.Fatalf("stderr = %q, want catalog refresh warning", errOut)
+	}
+	want := []string{"GET /api/v1/projects/demo", "POST /api/v1/agents/refresh", "POST /api/v1/sessions"}
+	if !reflect.DeepEqual(requests, want) {
+		t.Fatalf("requests=%#v want %#v", requests, want)
+	}
+}
+
 func TestSpawnSkipAgentCheckBypassesOnlyPreflight(t *testing.T) {
 	cfg := setConfigEnv(t)
 	var requests []string

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -323,6 +323,16 @@ func Run() error {
 	lcStack.trackerDone = startTrackerIntake(ctx, store, sessionSvc, tracker, log)
 
 	agentSvc := agentsvc.NewWithDeps(agentsvc.Deps{Cache: store, InventoryCache: store, Discoverer: modelcatalog.Discoverer{}, Projects: store, Sessions: store})
+	// The agent catalog is the preflight dependency of ao spawn. A failure here
+	// must not be swallowed into a WARN nothing else reads: mark the daemon
+	// degraded so /readyz stops reporting ready until the catalog recovers.
+	readiness := httpd.NewReadiness()
+	go func() {
+		if _, err := agentSvc.Refresh(ctx); err != nil {
+			log.Warn("initial agent catalog refresh failed", "err", err)
+			readiness.SetDegraded("agent catalog refresh failed: " + err.Error())
+		}
+	}()
 	hostCommands := systemexec.Adapter{}
 	systemChecks := systemcheck.New(agentSvc, hostCommands)
 	systemInstall := systeminstall.New(hostCommands, hostCommands)
@@ -507,6 +517,7 @@ func Run() error {
 		Browser:             browserService,
 		PreviewServer:       managedPreview,
 		SessionCapabilities: browserAuthority,
+		Readiness:           readiness,
 	})
 	if err != nil {
 		stop()

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -59,6 +59,11 @@ type APIDeps struct {
 	// DeviceRoster and DeviceLive back the desktop-only mobile device roster.
 	DeviceRoster controllers.DeviceRoster
 	DeviceLive   controllers.LiveSet
+
+	// Readiness is the daemon's self-reported readiness state, reflected by
+	// /readyz. Nil means the daemon reports ready unconditionally (the default
+	// in tests and in callers that predate the state).
+	Readiness *Readiness
 }
 
 // normalizeAPIDeps closes the Presence/DeviceLive duplication trap structurally.

--- a/backend/internal/httpd/readiness.go
+++ b/backend/internal/httpd/readiness.go
@@ -1,0 +1,41 @@
+package httpd
+
+import "sync"
+
+// Readiness is the daemon's self-reported readiness state. It starts ready
+// and can be marked degraded with a reason; /readyz reflects it so a daemon
+// whose core dependency failed at startup does not keep reporting ready.
+//
+// The daemon wires this in at startup: a failed agent-catalog refresh (the
+// preflight dependency of ao spawn) marks it degraded instead of being
+// swallowed into a WARN that nothing else ever reads.
+type Readiness struct {
+	mu     sync.Mutex
+	status string // "ready" | "degraded"
+	reason string
+}
+
+// NewReadiness returns a readiness state that starts ready.
+func NewReadiness() *Readiness {
+	return &Readiness{status: "ready"}
+}
+
+// SetDegraded marks the daemon degraded with a human-readable reason. It is
+// idempotent: the first reason wins, so a later transient failure does not
+// overwrite the original cause.
+func (r *Readiness) SetDegraded(reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.status == "degraded" {
+		return
+	}
+	r.status = "degraded"
+	r.reason = reason
+}
+
+// Snapshot returns the current status and reason (empty when ready).
+func (r *Readiness) Snapshot() (status, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.status, r.reason
+}

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -60,7 +60,7 @@ func NewRouterWithControl(cfg config.Config, log *slog.Logger, termMgr *terminal
 	r.NotFound(notFoundJSON)
 	r.MethodNotAllowed(methodNotAllowedJSON)
 
-	mountHealth(r, cfg)
+	mountHealth(r, cfg, deps.Readiness)
 	mountTerminalMux(r, termMgr, log)
 	mountControl(r, control)
 	mountTelemetry(r, cfg, deps.Telemetry)
@@ -83,12 +83,23 @@ func previewOriginMiddleware(sessions *controllers.SessionsController) func(http
 }
 
 // mountHealth registers the liveness and readiness probes the Electron
-// supervisor polls before letting the renderer connect.
-func mountHealth(r chi.Router, cfg config.Config) {
+// supervisor polls before letting the renderer connect. /healthz is liveness
+// (the process is up); /readyz is readiness (the daemon can do its job).
+func mountHealth(r chi.Router, cfg config.Config, readiness *Readiness) {
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		envelope.WriteJSON(w, http.StatusOK, daemonProbePayload("ok", cfg))
 	})
 	r.Get("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		status, reason := "ready", ""
+		if readiness != nil {
+			status, reason = readiness.Snapshot()
+		}
+		if status == "degraded" {
+			payload := daemonProbePayload("degraded", cfg)
+			payload["reason"] = reason
+			envelope.WriteJSON(w, http.StatusServiceUnavailable, payload)
+			return
+		}
 		envelope.WriteJSON(w, http.StatusOK, daemonProbePayload("ready", cfg))
 	})
 }

--- a/backend/internal/httpd/server_test.go
+++ b/backend/internal/httpd/server_test.go
@@ -41,6 +41,39 @@ func TestHealthProbes(t *testing.T) {
 	}
 }
 
+// TestReadyzReflectsDegraded verifies that /readyz reports a degraded daemon
+// as not ready (503 + reason) instead of unconditionally returning 200. A
+// daemon whose core dependency failed at startup must not keep reporting
+// ready to the supervisor and to clients gating on the probe.
+func TestReadyzReflectsDegraded(t *testing.T) {
+	readiness := NewReadiness()
+	readiness.SetDegraded("agent catalog refresh failed: no such table: agent_inventory_cache")
+
+	router := NewRouterWithControl(config.Config{}, discardLogger(), nil,
+		APIDeps{Readiness: readiness}, ControlDeps{})
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("GET /readyz = %d, want 503 for a degraded daemon", resp.StatusCode)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /readyz payload: %v", err)
+	}
+	if payload["status"] != "degraded" {
+		t.Errorf("status = %v, want degraded", payload["status"])
+	}
+	if payload["reason"] != "agent catalog refresh failed: no such table: agent_inventory_cache" {
+		t.Errorf("reason = %v, want the degraded cause", payload["reason"])
+	}
+}
+
 func TestHealthProbesIncludeDaemonIdentity(t *testing.T) {
 	router := newTestRouter(config.Config{StartupWorkingDirectory: "/startup"}, discardLogger(), nil)
 	srv := httptest.NewServer(router)


### PR DESCRIPTION
## What

Follow-up to #4336, addressing the remaining items of #4335. The agent catalog is the preflight dependency of `ao spawn`, but a refresh failure was swallowed into a fire-and-forget WARN while `/readyz` kept reporting ready — so a daemon that could not spawn still passed readiness, and the CLI surfaced the failure as an opaque `INTERNAL_ERROR`.

1. **`/readyz` reflects real readiness** — new `Readiness` state in `httpd` (starts ready, can be marked degraded with a reason). `/readyz` returns `503` + `status: "degraded"` + `reason` when degraded, instead of unconditionally `200`. Nil readiness (the test default and pre-existing callers) keeps the old behavior.
2. **Daemon marks itself degraded** — when the initial agent-catalog refresh fails, the daemon records the cause on `Readiness`, so the failure is visible to the supervisor and to clients gating on the probe instead of dying in a WARN nothing reads.
3. **Spawn preflight degrades instead of blocking** — when the catalog refresh fails, `ao spawn` warns and continues, letting spawn validate runtime readiness (mirroring the existing `agentProbeUnavailable` degradation). The service-side contract ("published = cached") is intentionally encoded by `TestRefreshPublishesOnlyAfterInventoryPersistenceSucceeds`, so the fix lives in the CLI path, not the service.

## Why

Part of #4335: a failure in a core dependency must not be both invisible (`/readyz` green) and blocking (`INTERNAL_ERROR`) at the same time.

## Red → green

- `TestReadyzReflectsDegraded` — `/readyz` returned `200` for a degraded daemon; now `503` + reason.
- `TestSpawnCatalogRefreshFailureDegradesToWarning` — spawn failed on a `500` refresh; now warns and spawns.
- Both tests are killed by reverting their fix (mutation check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
