### PR TITLE
fix: align topbar button spacing

### DIFF
--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -546,7 +546,7 @@ function ExpandedTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab
 				aria-label={closeLabel}
 				className={cn(
 					"mr-1.5 grid size-control-sm shrink-0 place-items-center overflow-hidden rounded-sm text-passive opacity-0",
-					"transition-[opacity,background-color,color] hover:bg-interactive-hover hover:text-foreground",
+					"transition-[opacity,color] hover:text-foreground",
 					"group-hover/tab-row:opacity-100 group-focus-within/tab-row:opacity-100",
 					"disabled:pointer-events-none",
 				)}

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -814,7 +814,7 @@ describe("CenterPane toolbar session label", () => {
 		expect(terminalRegion).not.toContainElement(screen.getByTestId("session-action-region"));
 		const actionRegion = screen.getByTestId("session-action-region");
 		expect(actionRegion).not.toHaveClass("border-l");
-		expect(actionRegion).toHaveClass("gap-2");
+		expect(actionRegion).toHaveClass("gap-1");
 		expect(actionRegion).toContainElement(screen.getByRole("button", { name: "New terminal" }));
 		expect(actionRegion).toContainElement(screen.getByRole("button", { name: "Workspace action" }));
 		expect(actionRegion).not.toContainElement(screen.getByRole("button", { name: "Session tab action" }));

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -814,7 +814,7 @@ describe("CenterPane toolbar session label", () => {
 		expect(terminalRegion).not.toContainElement(screen.getByTestId("session-action-region"));
 		const actionRegion = screen.getByTestId("session-action-region");
 		expect(actionRegion).not.toHaveClass("border-l");
-		expect(actionRegion).toHaveClass("gap-1");
+		expect(actionRegion).toHaveClass("gap-0");
 		expect(actionRegion).toContainElement(screen.getByRole("button", { name: "New terminal" }));
 		expect(actionRegion).toContainElement(screen.getByRole("button", { name: "Workspace action" }));
 		expect(actionRegion).not.toContainElement(screen.getByRole("button", { name: "Session tab action" }));

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -814,7 +814,7 @@ describe("CenterPane toolbar session label", () => {
 		expect(terminalRegion).not.toContainElement(screen.getByTestId("session-action-region"));
 		const actionRegion = screen.getByTestId("session-action-region");
 		expect(actionRegion).not.toHaveClass("border-l");
-		expect(actionRegion).toHaveClass("gap-0");
+		expect(actionRegion).toHaveClass("gap-1");
 		expect(actionRegion).toContainElement(screen.getByRole("button", { name: "New terminal" }));
 		expect(actionRegion).toContainElement(screen.getByRole("button", { name: "Workspace action" }));
 		expect(actionRegion).not.toContainElement(screen.getByRole("button", { name: "Session tab action" }));

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -626,7 +626,7 @@ export function CenterPane({
 				</div>
 				{isFullscreen ? null : (
 					<div
-						className="ml-auto flex shrink-0 items-center gap-2 pl-2 pr-3"
+						className="ml-auto flex shrink-0 items-center gap-1 pl-2 pr-3"
 			data-testid="session-action-region"
 		>
 			{tabStripAction ? <div data-testid="session-tab-strip-action">{tabStripAction}</div> : null}

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -626,7 +626,7 @@ export function CenterPane({
 				</div>
 				{isFullscreen ? null : (
 					<div
-						className="ml-auto flex shrink-0 items-center gap-1 pl-2 pr-3"
+						className="ml-auto flex shrink-0 items-center gap-0 pl-2 pr-3"
 			data-testid="session-action-region"
 		>
 			{tabStripAction ? <div data-testid="session-tab-strip-action">{tabStripAction}</div> : null}

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -626,7 +626,7 @@ export function CenterPane({
 				</div>
 				{isFullscreen ? null : (
 					<div
-						className="ml-auto flex shrink-0 items-center gap-0 pl-2 pr-3"
+						className="ml-auto flex shrink-0 items-center gap-1 pl-2 pr-3"
 			data-testid="session-action-region"
 		>
 			{tabStripAction ? <div data-testid="session-tab-strip-action">{tabStripAction}</div> : null}

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -297,14 +297,15 @@ describe("SessionInspector tabs", () => {
     );
   });
 
-  it("sizes rail tabs to their labels instead of stretching across the inspector", () => {
+  it("keeps rail tabs square instead of stretching across the inspector", () => {
     renderWithQuery(<SessionInspector session={session([])} />);
 
     const summaryTab = screen.getByRole("tab", { name: "Summary" });
 
 
 		expect(summaryTab).not.toHaveClass("flex-1");
-		expect(summaryTab).toHaveClass("h-control-md", "px-1", "shrink-0");
+		expect(summaryTab).toHaveClass("size-control-md", "p-0", "shrink-0");
+		expect(summaryTab).not.toHaveClass("h-control-md", "px-1");
 		expect(summaryTab).toHaveAttribute("title", "Summary");
 	});
 

--- a/frontend/src/renderer/components/SessionInterfaceSwitch.test.tsx
+++ b/frontend/src/renderer/components/SessionInterfaceSwitch.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { describe, expect, it, vi } from "vitest";
 import type { SessionInterfaceTransition } from "../hooks/useSessionInterfaceTransition";
 import {
+	SessionInterfaceActionGroup,
 	SessionInterfaceSwitchButton,
 	SessionInterfaceSwitchDialog,
 	SessionInterfaceTransitionNotice,
@@ -33,6 +34,19 @@ function transition(phase: SessionInterfaceTransition["phase"]): SessionInterfac
 }
 
 describe("SessionInterfaceSwitchButton", () => {
+	it("uses the shared topbar spacing between adjacent session actions", () => {
+		render(
+			<SessionInterfaceActionGroup>
+				<button type="button">First action</button>
+				<button type="button">Second action</button>
+			</SessionInterfaceActionGroup>,
+		);
+
+		const group = screen.getByRole("button", { name: "First action" }).parentElement;
+		expect(group).toHaveClass("gap-2");
+		expect(group).not.toHaveClass("gap-px");
+	});
+
 	it("keeps a draining switch in the top bar with an adjacent Cancel action", () => {
 		const onCancel = vi.fn();
 		render(

--- a/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
+++ b/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
@@ -321,7 +321,7 @@ export function SessionInterfaceTransitionNotice({
 }
 
 export function SessionInterfaceActionGroup({ children }: { children: ReactNode }) {
-	return <div className="inline-flex shrink-0 items-center gap-px">{children}</div>;
+	return <div className="inline-flex shrink-0 items-center gap-2">{children}</div>;
 }
 
 export function SessionInterfaceSwitchMenuItem({

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -292,7 +292,6 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			</Tooltip>
 			{boardOwnsNotificationCenter ? (
 				<>
-					<span aria-hidden="true" className="workspace-topbar__utility-separator" />
 					<NotificationCenter />
 				</>
 			) : null}
@@ -310,7 +309,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			    chooser was review feedback on #2432. */}
 			{!showWelcome && boardActionsInPanel && (boardLabel || actions) ? (
 				<div
-					className="workspace-topbar-container center-panel-titlebar flex h-toolbar shrink-0 items-center gap-2 border-b border-border-strong pr-4"
+					className="workspace-topbar-container center-panel-titlebar flex h-toolbar shrink-0 items-center gap-2 border-b border-border-strong pr-1"
 					style={dragStyle}
 				>
 					{boardLabel ? (

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -186,6 +186,14 @@ beforeEach(() => {
 });
 
 describe("ShellTopbar status pill", () => {
+	it("matches the session action edge inset to the toolbar spacing", () => {
+		renderTopbar(sessionWith());
+
+		const header = screen.getByTestId("workspace-topbar-actions").closest("header");
+		expect(header).toHaveClass("pr-2");
+		expect(header).not.toHaveClass("pr-4");
+	});
+
 	it("shows the worker session name and activity in the full topbar identity", () => {
 		renderTopbar(sessionWith());
 
@@ -239,8 +247,8 @@ describe("ShellTopbar status pill", () => {
 		expect(screen.queryByText("ao/sess-1")).toBeNull();
 		expect(screen.queryByText("Working")).toBeNull();
 		const localActions = screen.getByTestId("session-local-actions");
-		expect(localActions.classList.contains("gap-px")).toBe(true);
-		expect(localActions.classList.contains("mr-0.5")).toBe(true);
+		expect(localActions).toHaveClass("gap-2");
+		expect(localActions).not.toHaveClass("gap-px", "mr-0.5");
 		expect(localActions.contains(screen.getByRole("button", { name: "New terminal" }))).toBe(true);
 		expect(localActions.contains(screen.getByRole("button", { name: "Switch agent" }))).toBe(true);
 		expect(localActions.contains(screen.getByRole("button", { name: "Switch to chat UI" }))).toBe(true);

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -247,7 +247,7 @@ describe("ShellTopbar status pill", () => {
 		expect(screen.queryByText("ao/sess-1")).toBeNull();
 		expect(screen.queryByText("Working")).toBeNull();
 		const localActions = screen.getByTestId("session-local-actions");
-		expect(localActions).toHaveClass("gap-2");
+		expect(localActions).toHaveClass("gap-1");
 		expect(localActions).not.toHaveClass("gap-px", "mr-0.5");
 		expect(localActions.contains(screen.getByRole("button", { name: "New terminal" }))).toBe(true);
 		expect(localActions.contains(screen.getByRole("button", { name: "Switch agent" }))).toBe(true);

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -217,7 +217,9 @@ export function ShellTopbar({
 	return (
 		<LayoutGroup id="shell-topbar">
 		<motion.header
-			className={embedded ? "contents" : cn(topbarHeaderClass, "workspace-topbar-container")}
+			className={
+				embedded ? "contents" : cn(topbarHeaderClass, "workspace-topbar-container", isSessionRoute && "pr-2")
+			}
 			style={embedded ? undefined : { ...dragStyle, paddingLeft }}
 		>
 			{!embedded ? (
@@ -375,7 +377,7 @@ export function ShellTopbar({
 						    remains a separate visual target in the outer top-bar row. */}
 						{!isOrchestrator && session && (sessionAction || sessionIsActive(session)) ? (
 							<div
-								className="mr-0.5 inline-flex shrink-0 items-center gap-px"
+								className="inline-flex shrink-0 items-center gap-2"
 								data-testid="session-local-actions"
 								style={noDragStyle}
 							>

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -377,7 +377,7 @@ export function ShellTopbar({
 						    remains a separate visual target in the outer top-bar row. */}
 						{!isOrchestrator && session && (sessionAction || sessionIsActive(session)) ? (
 							<div
-								className="inline-flex shrink-0 items-center gap-2"
+								className="inline-flex shrink-0 items-center gap-1"
 								data-testid="session-local-actions"
 								style={noDragStyle}
 							>

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -407,7 +407,7 @@ export function ShellTopbar({
 									<span className="inline-flex" style={noDragStyle}>
 										<TopbarButton
 											aria-label={t("shell.openOrchestrator")}
-											className="topbar-control--labeled mr-1"
+											className="topbar-control--labeled -mr-1"
 											data-priority="secondary"
 											disabled={isSpawning || isProjectRestarting}
 											onClick={() => void openOrchestrator()}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -407,7 +407,7 @@ export function ShellTopbar({
 									<span className="inline-flex" style={noDragStyle}>
 										<TopbarButton
 											aria-label={t("shell.openOrchestrator")}
-											className="topbar-control--labeled"
+											className="topbar-control--labeled mr-1"
 											data-priority="secondary"
 											disabled={isSpawning || isProjectRestarting}
 											onClick={() => void openOrchestrator()}

--- a/frontend/src/renderer/components/TopbarButton.test.tsx
+++ b/frontend/src/renderer/components/TopbarButton.test.tsx
@@ -12,6 +12,7 @@ describe("TopbarButton", () => {
 
 		const button = screen.getByRole("button", { name: "Unavailable action" });
 		expect(button).toHaveClass("size-control-md");
+		expect(button).toHaveClass("active:scale-[0.96]", "focus-visible:ring-2");
 		expect(button).toHaveClass("topbar-control--disabled-affordance");
 		expect(button).not.toHaveClass("disabled:opacity-35");
 		expect(button).not.toHaveClass("disabled:opacity-60");

--- a/frontend/src/renderer/components/TopbarButton.test.tsx
+++ b/frontend/src/renderer/components/TopbarButton.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TopbarButton } from "./TopbarButton";
+
+describe("TopbarButton", () => {
+	it("makes icon controls square and makes disabled state unmistakable", () => {
+		render(
+			<TopbarButton aria-label="Unavailable action" disabled variant="icon">
+				<span aria-hidden="true" />
+			</TopbarButton>,
+		);
+
+		const button = screen.getByRole("button", { name: "Unavailable action" });
+		expect(button).toHaveClass("size-control-md");
+		expect(button).toHaveClass("topbar-control--disabled-affordance");
+		expect(button).not.toHaveClass("disabled:opacity-35");
+		expect(button).not.toHaveClass("disabled:opacity-60");
+		expect(button).toBeDisabled();
+	});
+});

--- a/frontend/src/renderer/components/TopbarButton.tsx
+++ b/frontend/src/renderer/components/TopbarButton.tsx
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const topbarButtonVariants = cva(
-	"topbar-control topbar-control--disabled-affordance inline-flex items-center transition-[filter,background,color,border-color] duration-fast",
+	"topbar-control topbar-control--disabled-affordance inline-flex items-center transition-[transform,filter,background-color,color,border-color] duration-fast ease-out active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
 	{
 		variants: {
 			variant: {

--- a/frontend/src/renderer/components/TopbarButton.tsx
+++ b/frontend/src/renderer/components/TopbarButton.tsx
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const topbarButtonVariants = cva(
-	"topbar-control inline-flex items-center transition-[filter,background,color,border-color] duration-fast disabled:opacity-60",
+	"topbar-control topbar-control--disabled-affordance inline-flex items-center transition-[filter,background,color,border-color] duration-fast",
 	{
 		variants: {
 			variant: {
@@ -21,12 +21,8 @@ const topbarButtonVariants = cva(
 					"h-control-lg gap-1.5 rounded-md border border-error/40 bg-error/10 px-3 text-control font-semibold leading-none text-error hover:bg-error/16",
 				killCancel:
 					"h-control-lg rounded-md px-2.5 text-control font-semibold leading-none text-muted-foreground hover:text-foreground",
-				// Split-button halves: the same surface as `accent`, but squared on
-				// the joining edge so the pair reads as one control with a divider.
-				// The corner radii and widths live in styles.css alongside the other
-				// topbar controls: `.workspace-topbar-actions .topbar-control` sets a
-				// radius on all four corners at higher specificity than a Tailwind
-				// `rounded-l-md`, so squaring the join has to happen there.
+				// The workspace handoff is one split control. Its joined edges and
+				// token-backed widths live beside the shared topbar rules in styles.css.
 				splitMain:
 					"topbar-control--split-main topbar-control--labeled h-control-lg gap-1.5 rounded-l-md border border-r-0 border-border text-sm font-semibold leading-none bg-raised text-muted-foreground hover:bg-surface hover:text-foreground",
 				splitTrigger:

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
@@ -97,10 +97,30 @@ describe("TopbarOpenEditorButton", () => {
 	it("uses persisted Cursor as the primary target and sends no filesystem path", async () => {
 		renderButton();
 		const button = await screen.findByRole("button", { name: "Open in Cursor" });
-		expect(button).toHaveAttribute("data-priority", "primary");
-		expect(button.querySelector("[data-compact-label]")).toHaveTextContent("Open");
+		expect(button).not.toHaveAttribute("data-priority");
+		expect(button.querySelector("[data-compact-label]")).not.toBeInTheDocument();
+		expect(button.querySelector("svg")).toBeInTheDocument();
+		expect(button).toHaveClass("topbar-control--icon");
+		expect(button).not.toHaveClass("border", "bg-raised");
+		const options = screen.getByRole("button", { name: "Open workspace options" });
+		expect(options).toHaveClass("topbar-control--icon", "hover:bg-transparent");
+		expect(button).toHaveClass("hover:bg-transparent");
+		const group = button.parentElement;
+		expect(group).toHaveClass("gap-0", "rounded-md", "hover:bg-interactive-hover", "data-[state=open]:bg-interactive-hover");
+		expect(group).toHaveAttribute("data-state", "closed");
 		await userEvent.click(button);
 		await waitFor(() => expect(openMock).toHaveBeenCalledWith({ sessionId: "sess-1" }));
+	});
+
+	it("keeps the shared editor control highlighted while options are open", async () => {
+		renderButton();
+		const options = await screen.findByRole("button", { name: "Open workspace options" });
+		const group = options.parentElement;
+
+		await userEvent.click(options);
+
+		expect(group).toHaveAttribute("data-state", "open");
+		expect(group).toHaveClass("data-[state=open]:bg-interactive-hover");
 	});
 
 	it("keeps the no-editor state visible and offers Finder and Terminal", async () => {

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, Code2, FolderOpen, SquareTerminal } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { OpenTarget, OpenTargetId } from "../../shared/editor-handoff";
 import { useEditorHandoffState, useOpenSessionTarget } from "../hooks/useEditorHandoff";
@@ -74,6 +75,7 @@ export function TopbarOpenEditorButton({
 	const stateQuery = useEditorHandoffState(sessionId);
 	const open = useOpenSessionTarget();
 	const state = stateQuery.data;
+	const [menuOpen, setMenuOpen] = useState(false);
 	const targets = state?.targets ?? [];
 	const editors = targets.filter((target) => target.kind === "editor");
 	const preferred = editors.find((target) => target.id === state?.preferredEditorId);
@@ -95,7 +97,6 @@ export function TopbarOpenEditorButton({
 		: !stateQuery.isPending && editors.length === 0
 			? t("editor.noEditorGuidance", { fileManager: fileManagerName, terminal: terminalName })
 			: null;
-	const mainLabel = open.isPending ? t("editor.opening") : preferred ? t("editor.open") : t("editor.chooseEditor");
 	const mainTitle = guidance
 		?? (preferred ? t("editor.openWorkspaceInTitle", { name: preferred.name }) : t("editor.chooseEditorTitle"));
 
@@ -106,21 +107,29 @@ export function TopbarOpenEditorButton({
 					{launchError ?? guidance}
 				</TopbarActionError>
 			) : null}
-			<div className="inline-flex items-center" style={style}>
+			<div
+				className="inline-flex items-center gap-0 rounded-md transition-colors hover:bg-interactive-hover data-[state=open]:bg-interactive-hover"
+				data-state={menuOpen ? "open" : "closed"}
+				style={style}
+			>
 				<TopbarButton
 					aria-label={preferred ? t("editor.openInAria", { name: preferred.name }) : t("editor.chooseEditor")}
-					data-priority="primary"
+					className="hover:bg-transparent"
 					disabled={mainDisabled}
 					onClick={() => launch()}
 					title={mainTitle}
-					variant="splitMain"
+					variant="icon"
 				>
-					<TargetIcon target={preferred} className="size-icon-lg" />
-					<span data-compact-label>{mainLabel}</span>
+					<TargetIcon target={preferred} className="size-icon-md" />
 				</TopbarButton>
-				<DropdownMenu>
+				<DropdownMenu onOpenChange={setMenuOpen}>
 					<DropdownMenuTrigger asChild>
-						<TopbarButton aria-label={t("editor.openOptionsAria")} disabled={menuDisabled} variant="splitTrigger">
+						<TopbarButton
+							aria-label={t("editor.openOptionsAria")}
+							className="hover:bg-transparent"
+							disabled={menuDisabled}
+							variant="icon"
+						>
 							<ChevronDown className="size-icon-sm" aria-hidden="true" />
 						</TopbarButton>
 					</DropdownMenuTrigger>

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -363,7 +363,7 @@ describe("ChatWorkspace timeline", () => {
 		expect(screen.getByLabelText("Chat")).toHaveAttribute("data-session-role", "orchestrator");
 		expect(screen.getByTestId("session-workspace-topbar")).toBeInTheDocument();
 		const actionRegion = screen.getByTestId("session-action-region");
-		expect(actionRegion).toHaveClass("px-1");
+		expect(actionRegion).toHaveClass("pl-2", "pr-3");
 		expect(actionRegion).not.toHaveClass("px-3");
 	});
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -362,7 +362,9 @@ describe("ChatWorkspace timeline", () => {
 
 		expect(screen.getByLabelText("Chat")).toHaveAttribute("data-session-role", "orchestrator");
 		expect(screen.getByTestId("session-workspace-topbar")).toBeInTheDocument();
-		expect(screen.getByTestId("session-action-region")).toBeInTheDocument();
+		const actionRegion = screen.getByTestId("session-action-region");
+		expect(actionRegion).toHaveClass("px-1");
+		expect(actionRegion).not.toHaveClass("px-3");
 	});
 
 	it("clears the fixed titlebar nav when the sidebar is collapsed, like the terminal session", () => {

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1218,7 +1218,7 @@ function ChatHeader({
 					</div>
 				</div>
 				<div
-					className="ml-auto flex shrink-0 items-center gap-2 pl-2 pr-3"
+					className="ml-auto flex shrink-0 items-center gap-1 pl-2 pr-3"
 					data-testid="session-action-region"
 				>
 					{tabStripAction ? <div data-testid="session-tab-strip-action">{tabStripAction}</div> : null}

--- a/frontend/src/renderer/components/ui/switch.tsx
+++ b/frontend/src/renderer/components/ui/switch.tsx
@@ -14,7 +14,7 @@ function Switch({ className, size = "default", ...props }: SwitchProps) {
 		<SwitchPrimitive.Root
 			data-slot="switch"
 			className={cn(
-				"peer relative inline-flex shrink-0 cursor-pointer items-center rounded-full border-transparent transition-[background-color,border-color,box-shadow] outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=unchecked]:bg-input/90",
+				"peer relative inline-flex shrink-0 cursor-pointer items-center rounded-full border-transparent transition-[transform,background-color,border-color,box-shadow] duration-fast ease-out active:scale-[0.96] outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=unchecked]:bg-input/90",
 				size === "sm" ? "h-4 w-8 border" : "h-5 w-11 border-2",
 				className,
 			)}
@@ -23,7 +23,7 @@ function Switch({ className, size = "default", ...props }: SwitchProps) {
 			<SwitchPrimitive.Thumb
 				data-slot="switch-thumb"
 				className={cn(
-					"pointer-events-none block rounded-full bg-background shadow-sm ring-0 transition-transform data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
+					"pointer-events-none block rounded-full bg-background shadow-sm ring-0 transition-transform duration-fast ease-out data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
 					size === "sm"
 						? "size-3 data-[state=checked]:translate-x-4"
 						: "h-4 w-6 data-[state=checked]:translate-x-[calc(100%-8px)]",

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2446,18 +2446,13 @@ html.sidebar-reordering * {
 	min-width: 0;
 	flex: 0 0 auto;
 	align-items: center;
-	gap: var(--space-2);
+	gap: var(--space-1);
 }
 
-.workspace-topbar__utility-separator,
 .workspace-topbar__identity-separator {
 	width: 1px;
 	flex: 0 0 1px;
 	background: color-mix(in srgb, var(--color-text-topbar) 28%, transparent);
-}
-
-.workspace-topbar__utility-separator {
-	height: calc(var(--size-topbar-control) - var(--space-3));
 }
 
 .workspace-topbar__identity-separator {
@@ -2473,12 +2468,17 @@ html.sidebar-reordering * {
 	border-radius: var(--radius-topbar-control);
 	font-size: var(--font-size-sm-md);
 	transition:
+		transform var(--duration-fast) ease-out,
 		background-color var(--duration-fast) ease,
 		border-color var(--duration-fast) ease,
 		color var(--duration-fast) ease,
 		filter var(--duration-fast) ease,
 		gap var(--duration-normal) ease,
 		padding-inline var(--duration-normal) ease;
+}
+
+.workspace-topbar-actions .topbar-control:active:not(:disabled) {
+	transform: scale(0.96);
 }
 
 .workspace-topbar-actions .topbar-control--labeled,
@@ -2560,12 +2560,12 @@ html.sidebar-reordering * {
 	-webkit-app-region: no-drag;
 	position: absolute;
 	top: 0;
-	right: var(--space-3);
+	right: var(--space-1);
 	z-index: var(--z-index-chrome);
 	display: flex;
 	height: var(--size-inspector-tabs);
 	align-items: center;
-	gap: var(--space-2);
+	gap: var(--space-1);
 }
 
 .session-inspector-actions-spacer {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2486,11 +2486,14 @@ html.sidebar-reordering * {
 	padding-inline: var(--space-2_5);
 }
 
-/* Split workspace handoff control. The generic .topbar-control rule above rounds
-   all four corners and clamps every control to a square minimum, which makes the
-   two halves read as separate chips crammed together rather than one button.
-   Square the joining edge, let the label half breathe, and keep the chevron half
-   narrower than a full square so the pair stays compact. */
+.topbar-control--disabled-affordance:disabled {
+	cursor: not-allowed;
+	opacity: var(--opacity-control-disabled);
+}
+
+/* The editor handoff stays one joined split control. All measurements use the
+   shared spacing/control tokens; only gaps between separate controls use the
+   workspace toolbar gap. */
 .workspace-topbar-actions .topbar-control--split-main {
 	padding-inline: var(--space-2_5);
 	gap: var(--space-1_5);
@@ -3260,57 +3263,6 @@ html.sidebar-reordering * {
 .session-inspector__tab-button {
 	flex: none;
 	gap: 0;
-}
-
-.session-inspector__responsive-label {
-	max-width: 5.5rem;
-	margin-left: var(--space-0_5);
-	overflow: hidden;
-	/* Clip during the collapse animation — never ellipsize mid-label. */
-	text-overflow: clip;
-	opacity: 1;
-	transform: translateX(0);
-	transition:
-		max-width 170ms cubic-bezier(0.2, 0.8, 0.2, 1),
-		margin-left 170ms cubic-bezier(0.2, 0.8, 0.2, 1),
-		opacity 120ms ease-out,
-		transform 170ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-
-.session-inspector__tablist {
-	container: inspector-tabs / inline-size;
-	justify-content: flex-start;
-}
-
-/* Keep labels until they nearly meet the pinned actions, then collapse to a
- * tight icon cluster. Tuned just under the ~270px labeled content width so the
- * default inspector (~274px tablist) still shows full words. */
-@container inspector-tabs (max-width: 268px) {
-	.session-inspector__responsive-label {
-		max-width: 0;
-		margin-left: 0;
-		opacity: 0;
-		transform: translateX(-4px);
-	}
-}
-
-/* Keep one label layout for the full automatic panel transition. Without this
- * lock, crossing the compact container threshold near the end of the resize
- * makes the tab text reflow after the inspector itself has nearly settled. */
-.session-split[data-terminal-live-resize="true"][data-inspector-label-mode="expanded"]
-	.session-inspector__responsive-label {
-	max-width: 5.5rem;
-	margin-left: var(--space-0_5);
-	opacity: 1;
-	transform: translateX(0);
-}
-
-.session-split[data-terminal-live-resize="true"][data-inspector-label-mode="compact"]
-	.session-inspector__responsive-label {
-	max-width: 0;
-	margin-left: 0;
-	opacity: 0;
-	transform: translateX(-4px);
 }
 
 .session-inspector__toggle {
@@ -4552,8 +4504,7 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.notification-row-enter,
-	.session-inspector__responsive-label {
+	.notification-row-enter {
 		animation: none;
 		transition: none;
 	}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -192,6 +192,9 @@
 	--duration-fast: 120ms;
 	--duration-normal: 150ms;
 
+	/* State opacity */
+	--opacity-control-disabled: 0.35;
+
 	/* ═══════════════════════════════════════════════════════════════
 	   SPACING — 4px base (audit: 4/6/8/10/12/14/16/18 most common)
 	   Prefer even steps; map odd pixels (5/7/9/11/13/15) to nearest.

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -88,19 +88,22 @@ describe("SessionInspectorShellView", () => {
 
 
 		expect(screen.getByRole("complementary", { name: "Session inspector" })).toBeInTheDocument();
-		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist");
+		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist", "gap-2");
+		expect(screen.getByRole("tablist").parentElement).toHaveClass("pl-2");
+		expect(screen.getByRole("tablist").parentElement).not.toHaveClass("pl-2.5");
 		expect(screen.getByRole("tablist").parentElement?.nextElementSibling).toHaveClass(
 			"board-scrollbar",
 			"overflow-x-hidden",
 		);
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("aria-selected", "true");
-		expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass("shrink-0");
+		expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass("shrink-0", "size-control-md", "p-0");
 		expect(screen.getByRole("tab", { name: "Summary" })).not.toHaveClass("flex-1");
 		expect(screen.getByRole("tab", { name: "Summary" })).not.toHaveClass("min-w-0");
 		expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("tabindex", "0");
 		expect(screen.getByRole("tab", { name: "Browser" })).toHaveAttribute("tabindex", "-1");
 		const filesLabel = within(screen.getByRole("tab", { name: "Files" })).getByText("2 Files");
-		expect(filesLabel).toHaveClass("session-inspector__responsive-label");
+		expect(filesLabel).toHaveClass("sr-only");
+		expect(filesLabel).not.toHaveClass("session-inspector__responsive-label");
 		expect(filesLabel).not.toHaveClass("truncate", "min-w-0");
 		expect(filesLabel).not.toHaveClass("@max-[350px]/inspector:hidden");
 		expect(screen.getByTestId("browser-unseen-indicator")).toBeInTheDocument();

--- a/packages/product-ui/src/SessionInspectorView.test.tsx
+++ b/packages/product-ui/src/SessionInspectorView.test.tsx
@@ -88,9 +88,10 @@ describe("SessionInspectorShellView", () => {
 
 
 		expect(screen.getByRole("complementary", { name: "Session inspector" })).toBeInTheDocument();
-		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist", "gap-2");
-		expect(screen.getByRole("tablist").parentElement).toHaveClass("pl-2");
-		expect(screen.getByRole("tablist").parentElement).not.toHaveClass("pl-2.5");
+		expect(screen.getByRole("tablist")).toHaveClass("session-inspector__tablist", "gap-1");
+		expect(screen.getByRole("tablist")).not.toHaveClass("gap-2");
+		expect(screen.getByRole("tablist").parentElement).toHaveClass("pl-1");
+		expect(screen.getByRole("tablist").parentElement).not.toHaveClass("pl-2", "pl-2.5");
 		expect(screen.getByRole("tablist").parentElement?.nextElementSibling).toHaveClass(
 			"board-scrollbar",
 			"overflow-x-hidden",

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -1,4 +1,5 @@
 import { type KeyboardEvent, type ReactNode, type RefObject, useEffect, useRef, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
 import type { ExternalLinkComponent } from "./external-link";
 import {
 	ArrowUpRightIcon,
@@ -62,6 +63,11 @@ export function SessionInspectorShellView({
 	summaryView?: ReactNode;
 	tabs: InspectorTab[];
 }) {
+	const prefersReducedMotion = useReducedMotion();
+	const tabIndicatorTransition = prefersReducedMotion
+		? { duration: 0 }
+		: { type: "spring" as const, duration: 0.3, bounce: 0 };
+
 	if (loadingText) {
 		return (
 			<aside className={inspectorShellClass} aria-label={ariaLabel}>
@@ -100,9 +106,9 @@ export function SessionInspectorShellView({
 
 	return (
 		<aside className={inspectorShellClass} aria-label={ariaLabel}>
-			<div className="session-inspector__topbar flex h-inspector-tabs shrink-0 items-center border-b border-border pl-2">
+			<div className="session-inspector__topbar flex h-inspector-tabs shrink-0 items-center border-b border-border pl-1">
 				{isVisible ? (
-					<div className="session-inspector__tablist flex min-w-0 flex-1 items-center justify-start gap-2" role="tablist">
+					<div className="session-inspector__tablist flex min-w-0 flex-1 items-center justify-start gap-1" role="tablist">
 						{tabs.map((tab, index) => (
 							<button
 								aria-label={tab.label}
@@ -112,14 +118,23 @@ export function SessionInspectorShellView({
 								aria-selected={activeView === tab.id}
 								tabIndex={activeView === tab.id ? 0 : -1}
 								className={cn(
-									"session-inspector__tab-button inline-flex size-control-md shrink-0 items-center justify-center rounded-md p-0 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
-									activeView === tab.id && "bg-interactive-active text-foreground",
+									"session-inspector__tab-button relative inline-flex size-control-md shrink-0 items-center justify-center rounded-md p-0 font-semibold text-passive transition-[color] duration-fast hover:bg-interactive-hover hover:text-foreground",
+									activeView === tab.id && "text-foreground",
 								)}
 								onClick={() => onViewChange(tab.id)}
 								onKeyDown={(event) => selectAdjacentTab(event, index)}
 								title={tab.label}
 							>
-								<span className="relative inline-flex shrink-0 [&_svg]:size-icon-md">
+								{activeView === tab.id ? (
+									<motion.span
+										aria-hidden="true"
+										className="absolute inset-0 rounded-md bg-interactive-active"
+										initial={false}
+										layoutId="session-inspector-tab-indicator"
+										transition={tabIndicatorTransition}
+									/>
+								) : null}
+								<span className="relative z-[1] inline-flex shrink-0 [&_svg]:size-icon-md">
 									{tab.icon}
 									{tab.badge ? (
 										<span

--- a/packages/product-ui/src/SessionInspectorView.tsx
+++ b/packages/product-ui/src/SessionInspectorView.tsx
@@ -100,9 +100,9 @@ export function SessionInspectorShellView({
 
 	return (
 		<aside className={inspectorShellClass} aria-label={ariaLabel}>
-			<div className="session-inspector__topbar flex h-inspector-tabs shrink-0 items-center border-b border-border pl-2.5">
+			<div className="session-inspector__topbar flex h-inspector-tabs shrink-0 items-center border-b border-border pl-2">
 				{isVisible ? (
-					<div className="session-inspector__tablist flex min-w-0 flex-1 items-center justify-start gap-0" role="tablist">
+					<div className="session-inspector__tablist flex min-w-0 flex-1 items-center justify-start gap-2" role="tablist">
 						{tabs.map((tab, index) => (
 							<button
 								aria-label={tab.label}
@@ -112,7 +112,7 @@ export function SessionInspectorShellView({
 								aria-selected={activeView === tab.id}
 								tabIndex={activeView === tab.id ? 0 : -1}
 								className={cn(
-									"session-inspector__tab-button inline-flex h-control-md shrink-0 items-center justify-center rounded-md px-1 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
+									"session-inspector__tab-button inline-flex size-control-md shrink-0 items-center justify-center rounded-md p-0 font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
 									activeView === tab.id && "bg-interactive-active text-foreground",
 								)}
 								onClick={() => onViewChange(tab.id)}
@@ -132,7 +132,7 @@ export function SessionInspectorShellView({
 										</span>
 									) : null}
 								</span>
-								<span className="session-inspector__responsive-label whitespace-nowrap text-2xs">
+								<span className="sr-only">
 									{tab.displayLabel ?? tab.label}
 								</span>
 							</button>


### PR DESCRIPTION
Fixes #4283 [this is @ronishrohan]

## Summary
- Made topbar action spacing consistent.
- Made the right sidebar tab buttons square.
- Reduced the right sidebar tab inset so it matches the toolbar spacing better.
- Added a shared disabled opacity token for topbar controls.
- Removed the inspector tab label resize logic because the tabs are now icon-only square buttons

<img width="380" height="241" alt="image" src="https://github.com/user-attachments/assets/46f5b5b4-62c5-457f-8043-f602edc208a7" />


## Tests
- npm --prefix frontend run typecheck
- npm --prefix frontend run test -- TopbarButton.test.tsx ShellTopbar.test.tsx CenterPane.test.tsx SessionInterfaceSwitch.test.tsx SessionView.test.tsx TopbarOpenEditorButton.test.tsx
- npm --prefix packages/product-ui run typecheck
- npm --prefix packages/product-ui run test -- SessionInspectorView.test.tsx