### PR TITLE
fix(workspace): serialize worktree adds per repo and surface WORKSPACE_CREATE_FAILED

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -81,6 +82,35 @@ type Workspace struct {
 	managedRoot string
 	repos       RepoResolver
 	run         commandRunner
+
+	// repoLocksMu guards repoLocks. repoLocks serializes git operations that
+	// mutate shared repo state (.git/config, worktree registrations, packed
+	// refs) per repository path: concurrent spawns each run `git worktree add
+	// -b`, which writes branch.<name> config at the end of checkout, and the
+	// losers of the .git/config.lock race fail with exit 255 (#4350). Tests
+	// construct Workspace as a zero value, so access is nil-map safe.
+	repoLocksMu sync.Mutex
+	repoLocks   map[string]*sync.Mutex
+}
+
+// lockRepo returns a release function for the per-repo git mutation lock. Every
+// caller must be safe to serialize against any other caller on the same repo
+// path; cross-repo spawns still run concurrently. Paths are cleaned so
+// equivalent spellings of one repo share one lock.
+func (w *Workspace) lockRepo(repo string) func() {
+	key := filepath.Clean(repo)
+	w.repoLocksMu.Lock()
+	if w.repoLocks == nil {
+		w.repoLocks = map[string]*sync.Mutex{}
+	}
+	mu, ok := w.repoLocks[key]
+	if !ok {
+		mu = &sync.Mutex{}
+		w.repoLocks[key] = mu
+	}
+	w.repoLocksMu.Unlock()
+	mu.Lock()
+	return mu.Unlock
 }
 
 type commandRunner func(ctx context.Context, binary string, args ...string) ([]byte, error)
@@ -178,6 +208,12 @@ func (w *Workspace) FetchDefaultBranch(ctx context.Context, repoPath string, tar
 	if err := w.validateBranch(ctx, repo, target.Branch); err != nil {
 		return err
 	}
+	// Serialize with worktree adds on the same repo: a fetch rewrites
+	// packed-refs (packed-refs.lock) and can also take .git/config.lock, so
+	// concurrent spawn-time fetches race worktree adds on the same clone
+	// (#4350).
+	unlock := w.lockRepo(repo)
+	defer unlock()
 	if _, err := w.run(ctx, w.binary, fetchBranchArgs(repo, target.Remote, target.Branch)...); err != nil {
 		return fmt.Errorf("gitworktree: fetch %s %s: %w", target.Remote, target.Branch, err)
 	}
@@ -969,6 +1005,12 @@ func registeredWorktreeDirMissing(rec worktreeRecord) (bool, error) {
 }
 
 func (w *Workspace) addWorktree(ctx context.Context, repo, path, branch, baseBranch, baseRef string, resolveExistingBase bool) (string, error) {
+	// Serialize worktree mutations per repo: `git worktree add -b` writes
+	// branch.<name> config under .git/config.lock, and concurrent adds on one
+	// repo race on that lock (#4350). The ref-resolution reads inside are safe
+	// to hold the lock across: they are local reads with a bounded budget.
+	unlock := w.lockRepo(repo)
+	defer unlock()
 	// Refuse early if the branch is already checked out in another worktree:
 	// `git worktree add` will fail, but its stderr leaks through as an opaque
 	// 500. A typed sentinel lets the HTTP layer surface a 409.
@@ -1009,7 +1051,7 @@ func (w *Workspace) addWorktree(ctx context.Context, repo, path, branch, baseBra
 			baseRef = refs.baseRef
 		}
 		if _, err := w.run(ctx, w.binary, worktreeAddBranchArgs(repo, path, branch, force)...); err != nil {
-			return "", fmt.Errorf("gitworktree: worktree add existing branch %q: %w", branch, err)
+			return "", fmt.Errorf("%w: gitworktree: worktree add existing branch %q: %w", ports.ErrWorkspaceCreateFailed, branch, err)
 		}
 		return baseRef, nil
 	}
@@ -1024,7 +1066,7 @@ func (w *Workspace) addWorktree(ctx context.Context, repo, path, branch, baseBra
 		}
 		baseRef = refs.baseRef
 		if err := w.addNewBranchWorktree(ctx, repo, branch, path, refs.seedRef, force); err != nil {
-			return "", fmt.Errorf("gitworktree: worktree add branch %q from %q: %w", branch, refs.seedRef, err)
+			return "", fmt.Errorf("%w: gitworktree: worktree add branch %q from %q: %w", ports.ErrWorkspaceCreateFailed, branch, refs.seedRef, err)
 		}
 		return baseRef, nil
 	}
@@ -1040,7 +1082,7 @@ func (w *Workspace) addWorktree(ctx context.Context, repo, path, branch, baseBra
 	// comparison ref remains. Fresh creation returns above after resolving its
 	// seed and comparison refs independently.
 	if err := w.addNewBranchWorktree(ctx, repo, branch, path, seedRef, force); err != nil {
-		return "", fmt.Errorf("gitworktree: worktree add branch %q from %q: %w", branch, seedRef, err)
+		return "", fmt.Errorf("%w: gitworktree: worktree add branch %q from %q: %w", ports.ErrWorkspaceCreateFailed, branch, seedRef, err)
 	}
 	return baseRef, nil
 }
@@ -1172,6 +1214,10 @@ func (w *Workspace) workspaceProjectBranchFree(ctx context.Context, repos []work
 }
 
 func (w *Workspace) createWorkspaceProjectRepo(ctx context.Context, repo workspaceProjectRepo, branch string) (string, error) {
+	// Same per-repo serialization as addWorktree: this path runs its own
+	// `git worktree add -b` and races the same .git/config.lock (#4350).
+	unlock := w.lockRepo(repo.repoPath)
+	defer unlock()
 	baseRef := strings.TrimSpace(repo.baseRef)
 	if baseRef == "" {
 		return "", errors.New("gitworktree: workspace repository base was not resolved before creation")
@@ -1199,7 +1245,7 @@ func (w *Workspace) createWorkspaceProjectRepo(ctx context.Context, repo workspa
 	// prune this used to run, which would also drop sibling sessions'
 	// registrations.
 	if err := w.addNewBranchWorktree(ctx, repo.repoPath, branch, repo.outputPath, seedRef, force); err != nil {
-		return "", fmt.Errorf("gitworktree: workspace repo %q worktree add branch %q from %q: %w", repo.name, branch, seedRef, err)
+		return "", fmt.Errorf("%w: gitworktree: workspace repo %q worktree add branch %q from %q: %w", ports.ErrWorkspaceCreateFailed, repo.name, branch, seedRef, err)
 	}
 	return baseSHA, nil
 }

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -3,13 +3,16 @@ package gitworktree
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -1119,4 +1122,71 @@ func TestGitWorktreeExitStatusOneHelper(t *testing.T) {
 		return
 	}
 	os.Exit(1)
+}
+
+// TestCreateSerializesWorktreeAddPerRepo reproduces the #4350 shape: concurrent
+// spawns each run `git worktree add -b` on the same repo, which collide on
+// .git/config.lock in real git. The per-repo lock must serialize the add
+// invocations; the fake runner below fails the whole test if two worktree adds
+// overlap.
+func TestCreateSerializesWorktreeAddPerRepo(t *testing.T) {
+	dir := t.TempDir()
+	managed := filepath.Join(dir, "wt")
+	if err := os.MkdirAll(managed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repo := filepath.Join(dir, "repo")
+
+	var mu sync.Mutex
+	inFlight := 0
+	maxInFlight := 0
+	ws := &Workspace{
+		binary:      "git",
+		managedRoot: managed,
+		repos:       StaticRepoResolver{"p-1": repo},
+		run: func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			joined := strings.Join(args, " ")
+			if !strings.Contains(joined, "worktree add") {
+				return []byte("abc123\n"), nil
+			}
+			mu.Lock()
+			inFlight++
+			if inFlight > maxInFlight {
+				maxInFlight = inFlight
+			}
+			mu.Unlock()
+			time.Sleep(20 * time.Millisecond) // widen the race window
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+			return []byte("abc123\n"), nil
+		},
+	}
+
+	const spawns = 15
+	var wg sync.WaitGroup
+	errs := make(chan error, spawns)
+	for i := 0; i < spawns; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			_, err := ws.Create(context.Background(), ports.WorkspaceConfig{
+				ProjectID:  "p-1",
+				SessionID:  domain.SessionID(fmt.Sprintf("p-1-%d", n)),
+				Branch:     fmt.Sprintf("ao/p-1-%d/root", n),
+				BaseBranch: "main",
+			})
+			errs <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Create: %v", err)
+		}
+	}
+	if maxInFlight != 1 {
+		t.Fatalf("worktree adds overlapped: max in-flight = %d, want 1 (per-repo lock must serialize)", maxInFlight)
+	}
 }

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -296,6 +296,13 @@ var (
 	// ErrWorkspaceBranchInvalid reports the requested branch name is not a valid
 	// git ref (rejected by `git check-ref-format`).
 	ErrWorkspaceBranchInvalid = errors.New("workspace: invalid branch name")
+	// ErrWorkspaceCreateFailed reports that materializing the session worktree
+	// (`git worktree add`) failed. Distinct from the typed preconditions above:
+	// by the time this fires, git itself refused — e.g. lock contention on
+	// .git/config from concurrent operations, a corrupted clone, or a full
+	// disk. Callers should surface the underlying git error to the user rather
+	// than collapsing it to a generic internal error (#4350).
+	ErrWorkspaceCreateFailed = errors.New("workspace: worktree creation failed")
 	// ErrWorkspaceDirty reports Destroy refused to remove a workspace because
 	// it holds uncommitted changes or untracked files. Teardown is never
 	// forced; callers treat the workspace as intentionally preserved.

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -1000,6 +1000,11 @@ func toAPIError(err error) error {
 		return apierr.Invalid("BRANCH_NOT_FETCHED", err.Error(), nil)
 	case errors.Is(err, ports.ErrWorkspaceBranchInvalid):
 		return apierr.Invalid("INVALID_BRANCH", err.Error(), nil)
+	case errors.Is(err, ports.ErrWorkspaceCreateFailed):
+		// The underlying git error (lock contention, corrupted clone, full
+		// disk...) is the only actionable signal; keep it in the message so
+		// spawn failures stop collapsing to an opaque 500 (#4350).
+		return apierr.Conflict("WORKSPACE_CREATE_FAILED", err.Error(), nil)
 	case errors.Is(err, ports.ErrAgentBinaryNotFound):
 		return apierr.Invalid("AGENT_BINARY_NOT_FOUND", err.Error(), nil)
 	case errors.Is(err, ports.ErrRuntimePrerequisite):

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -2650,6 +2650,7 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 		{"default branch unresolved", fmt.Errorf("spawn mer-1: %w: configure defaultBranch", ports.ErrWorkspaceDefaultBranchUnresolved), apierr.KindInvalid, "DEFAULT_BRANCH_UNRESOLVED"},
 		{"not fetched", fmt.Errorf("spawn mer-1: workspace: %w: \"x\" has no local head", ports.ErrWorkspaceBranchNotFetched), apierr.KindInvalid, "BRANCH_NOT_FETCHED"},
 		{"invalid branch", fmt.Errorf("spawn mer-1: workspace: %w: \"bad!!\" (exit 1)", ports.ErrWorkspaceBranchInvalid), apierr.KindInvalid, "INVALID_BRANCH"},
+		{"workspace create failed", fmt.Errorf("spawn mer-1: %w: gitworktree: worktree add branch %q from %q: exit status 255: could not lock config file .git/config: File exists", ports.ErrWorkspaceCreateFailed, "ao/mer-1/root", "refs/remotes/origin/main"), apierr.KindConflict, "WORKSPACE_CREATE_FAILED"},
 		{"agent binary not found", fmt.Errorf("spawn mer-1: %w", ports.ErrAgentBinaryNotFound), apierr.KindInvalid, "AGENT_BINARY_NOT_FOUND"},
 		{"runtime prerequisite missing", fmt.Errorf("spawn: %w: tmux required on macOS/Linux but not in PATH", ports.ErrRuntimePrerequisite), apierr.KindInvalid, "RUNTIME_PREREQUISITE_MISSING"},
 		{"runtime workspace cwd mismatch", fmt.Errorf("spawn mer-1: runtime: %w: session mer-1 started in \"/deleted/shipit\", want \"/tmp/ws\"", ports.ErrRuntimeWorkspaceCwdMismatch), apierr.KindConflict, "WORKSPACE_CWD_MISMATCH"},


### PR DESCRIPTION
Fixes #4350

## Summary

Concurrent `ao spawn` calls race on `git worktree add -b` against the same clone: each spawn runs an unserialized `git fetch` + `git worktree add -b`, the adds collide on `.git/config.lock`, and the losers fail with exit 255 (`could not lock config file .git/config: File exists`). The service layer then collapses the git error into an opaque `500 INTERNAL_ERROR` — the CLI shows no actionable cause.

Two changes:

1. **Per-repo serialization in the gitworktree adapter.** A keyed mutex (`Workspace.lockRepo`) serializes `addWorktree`, `createWorkspaceProjectRepo`, and `FetchDefaultBranch` per repo path. All spawns funnel through the one daemon process, so an in-process lock fully removes the race; different repos still spawn concurrently. Lock map access is nil-safe because tests construct `Workspace` as a zero value.
2. **Typed error instead of 500.** New `ports.ErrWorkspaceCreateFailed` sentinel wraps every failed worktree-add return; `toAPIError` maps it to `409 WORKSPACE_CREATE_FAILED` carrying the underlying git error text, so the CLI finally shows the real cause.

Deadlock safety: the three lock sites never call each other (`addWorktree` → `addNewBranchWorktree` takes no lock; `createWorkspaceProjectRepo` is a sibling entry point; `FetchDefaultBranch` is only called before `createSessionWorkspace` in the spawn flow, never from within a lock). Ref resolution happens under the lock but is bounded local reads (`resolveWorktreeRefsWithBudget`, 5s budget).

## Test

cd backend && go build ./... && go test ./...

- New `TestCreateSerializesWorktreeAddPerRepo`: 15 parallel `Create` calls on one repo; the fake runner fails the test if two `worktree add` invocations overlap (max in-flight must be 1). Reproduces the #4350 shape (15 concurrent spawns) in miniature.
- New `toAPIError` table case: `ErrWorkspaceCreateFailed` → `409 WORKSPACE_CREATE_FAILED`, message retains the git error.
- Existing gitworktree + session service suites pass unchanged.
