### PR TITLE
fix(renderer): toast spawn failures instead of a truncated topbar error

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,6 +57,7 @@
 				"rehype-slug": "^6.0.0",
 				"remark-gfm": "^4.0.1",
 				"semver": "^7.8.5",
+				"sonner": "^2.0.8",
 				"tailwind-merge": "^3.6.0",
 				"ws": "^8.21.1",
 				"zustand": "^5.0.14"
@@ -17007,6 +17008,22 @@
 			},
 			"engines": {
 				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/sonner": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.8.tgz",
+			"integrity": "sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^18.0.0 || ^19.0.0",
+				"react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+				"react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/source-map": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -110,6 +110,7 @@
 		"rehype-slug": "^6.0.0",
 		"remark-gfm": "^4.0.1",
 		"semver": "^7.8.5",
+		"sonner": "^2.0.8",
 		"tailwind-merge": "^3.6.0",
 		"ws": "^8.21.1",
 		"zustand": "^5.0.14"

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -21,6 +21,7 @@ const {
 	workspaceQueryMock,
 	usageQueryMock,
 	boardActionsInPanelMock,
+	spawnOrchestratorMock,
 } = vi.hoisted(() => ({
 	navigateMock: vi.fn(),
 	notificationShowMock: vi.fn(),
@@ -28,6 +29,12 @@ const {
 	workspaceQueryMock: vi.fn(),
 	usageQueryMock: vi.fn(),
 	boardActionsInPanelMock: vi.fn(() => false),
+	spawnOrchestratorMock: vi.fn(),
+}));
+
+vi.mock("../lib/spawn-orchestrator", () => ({
+	spawnOrchestrator: (...args: unknown[]) => spawnOrchestratorMock(...args),
+	isChatPreflightError: () => false,
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -71,6 +78,7 @@ vi.mock("../lib/platform", async (importOriginal) => {
 import { archiveToggleHeightClassName, archiveToggleOffsetClassName } from "@aoagents/product-ui";
 import { SessionsBoard } from "./SessionsBoard";
 import { TooltipProvider } from "./ui/tooltip";
+import { Toaster } from "./ui/sonner";
 
 function renderBoard(projectId?: string) {
 	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -102,6 +110,7 @@ beforeEach(() => {
 	usageQueryMock.mockReset().mockReturnValue({ data: new Map() });
 	window.localStorage.removeItem("ao.board.archive.layout");
 	boardActionsInPanelMock.mockReset().mockReturnValue(false);
+	spawnOrchestratorMock.mockReset().mockResolvedValue("s-orchestrator");
 });
 
 describe("SessionsBoard", () => {
@@ -1327,6 +1336,47 @@ describe("SessionsBoard", () => {
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 		expect(await screen.findByRole("alert")).toHaveTextContent("Failed to terminate session (500)");
 		expect(screen.getByRole("button", { name: "Terminate merged worker" })).toBeEnabled();
+	});
+
+	// The topbar already shows spawn failures, but as caption-sized text with
+	// `truncate`, so a long daemon message — the actionable case, e.g. a worktree
+	// conflict naming the offending path — is cut off. The toast carries the whole
+	// message. Assert on the full text, since truncation is what this fixes.
+	it("toasts the full spawn failure message when the board is not empty", async () => {
+		const message =
+			'workspace: gitworktree: worktree add branch "ao/radic-7/root" failed: fatal: ' +
+			"'ao/radic-7/root' is already checked out at '/tmp/radic-worktrees/radic-7'";
+		spawnOrchestratorMock.mockRejectedValue(new Error(message));
+		// The spawn control lives in the board's own actions row, which only
+		// renders in the in-panel topbar layout.
+		boardActionsInPanelMock.mockReturnValue(true);
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					...workspaceWithSessions([boardSession({ id: "s-worker", title: "worker", status: "working" })]),
+					orchestratorAgent: "claude-code",
+				},
+			],
+			isError: false,
+		});
+
+		render(
+			<QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+				<TooltipProvider>
+					<SessionsBoard projectId="p1" />
+					<Toaster />
+				</TooltipProvider>
+			</QueryClientProvider>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Spawn Orchestrator" }));
+
+		await waitFor(() => expect(spawnOrchestratorMock).toHaveBeenCalledTimes(1));
+
+		// Scoped to the toaster: the topbar renders this message too, so an
+		// unscoped query matches both.
+		const toaster = document.querySelector("[data-sonner-toaster]") as HTMLElement;
+		expect(await within(toaster).findByText(message)).toBeInTheDocument();
 	});
 });
 

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useRef, useState, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
 import {
 	SessionsArchiveView,
 	SessionsBoardGridView,
@@ -189,7 +190,9 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			// Never fail silently: the daemon's message (e.g. a worktree/branch
 			// conflict) is the only actionable signal the user gets.
 			console.error("Failed to spawn orchestrator:", error);
-			setSpawnError(error instanceof Error ? error.message : t("shell.couldNotSpawn"));
+			const message = error instanceof Error ? error.message : t("shell.couldNotSpawn");
+			setSpawnError(message);
+			toast.error(message);
 			setCanCreateAsTui(isChatPreflightError(error));
 		} finally {
 			setIsSpawning(false);

--- a/frontend/src/renderer/components/ui/sonner.tsx
+++ b/frontend/src/renderer/components/ui/sonner.tsx
@@ -1,0 +1,23 @@
+import type { CSSProperties } from "react";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+// Colors piggyback on the app's own tokens (DESIGN.md) so toasts stay in sync
+// with theme/style switches without their own light/dark branching.
+export function Toaster(props: ToasterProps) {
+	return (
+		<Sonner
+			className="toaster group"
+			style={
+				{
+					"--normal-bg": "var(--popover)",
+					"--normal-text": "var(--popover-foreground)",
+					"--normal-border": "var(--border)",
+					"--error-bg": "var(--popover)",
+					"--error-text": "var(--red)",
+					"--error-border": "color-mix(in srgb, var(--red) 30%, var(--border))",
+				} as CSSProperties
+			}
+			{...props}
+		/>
+	);
+}

--- a/frontend/src/renderer/routes/__root.tsx
+++ b/frontend/src/renderer/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRouteWithContext, Outlet, useRouterState } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { TooltipProvider } from "../components/ui/tooltip";
+import { Toaster } from "../components/ui/sonner";
 import type { QueryClient } from "@tanstack/react-query";
 import { captureRendererEvent, routeSurface } from "../lib/telemetry";
 import { useKeybindingsStore } from "../stores/keybindings-store";
@@ -28,6 +29,7 @@ function RootComponent() {
 	return (
 		<TooltipProvider>
 			<Outlet />
+			<Toaster position="bottom-right" />
 		</TooltipProvider>
 	);
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -3,6 +3,7 @@ import { isCancelledError, useQueryClient } from "@tanstack/react-query";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { FolderPlus } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { CommandPalette } from "../components/CommandPalette";
 import { CenterPanelShell } from "../components/CenterPanelShell";
 import { DaemonFailureBanner } from "../components/DaemonFailureBanner";
@@ -349,6 +350,7 @@ function ShellLayout() {
 				const message = spawnError instanceof Error ? spawnError.message : "Could not start orchestrator";
 				const startupMessage = `Project added, but orchestrator did not start: ${message}`;
 				setOrchestratorStartupError(workspace.id, startupMessage);
+				toast.error(startupMessage);
 			}
 		},
 		[navigate, queryClient, setOrchestratorStartupError, updateWorkspaces],


### PR DESCRIPTION
## What

When starting a session fails, show the daemon's full error in a toast, instead of relying only on the truncated inline error.

## Why

The message is already surfaced — but on a board that has sessions it renders as `TopbarActionError` in the actions row (`SessionsBoard.tsx:214`), which is caption-sized, single-line, and `truncate`d with a `title` tooltip.

The actionable failures are exactly the long ones. A real worktree conflict is ~700 characters:

```
spawn imagedemo-3: workspace: gitworktree: worktree add branch "ao/dev/imagedemo-orchestrator"
from "refs/remotes/origin/master": git -C ... worktree add -b ... : exit status 255:
Preparing worktree (new branch 'ao/dev/imagedemo-orchestrator')
error: could not lock config file .git/config: File exists
error: unable to write upstream branch configuration
hint: After fixing the error cause you may try to fix up
hint: the remote tracking information by invoking:
hint:   git branch --set-upstream-to=origin/refs/heads/master
```

So the part that tells you what to do is the part that gets cut off, reachable only by hovering.

## How

- `components/ui/sonner.tsx` — shadcn sonner primitive, themed from the app's own CSS tokens rather than `next-themes`, so it tracks theme/style switches without its own light/dark branching.
- Mounted once at the router root (`__root.tsx`).
- `toast.error(message)` at the two spawn sites where the message can be clipped or missed: the board's spawn path (`SessionsBoard.tsx`) and project creation (`_shell.tsx`). The existing inline error is kept in both.

### Deliberate omissions

Two other spawn paths are intentionally left without a toast, because in both the error is already in view and un-truncated:

- **`TaskComposer`** renders inside a modal Radix dialog. Radix marks outside-tree siblings `aria-hidden` and `pointer-events: none`, so a toast fired from there would be non-interactive and hidden from assistive tech while the dialog is open.
- **`CommandPalette`** (`CommandPalette.tsx:284`) catches the failure and calls `setError`, displaying it inside the palette overlay, which stays open.

## Scope change from the first revision

This PR previously also carried a backend commit retrying `tmux new-session` on `context.DeadlineExceeded`. It has been dropped and parked on a separate branch:

- The reporter retested #2699 on `main` and confirmed the timeout half is resolved — spawn is now 0.59–1.07s on tmux — so the retry addresses a condition that no longer reproduces.
- With `defaultTimeout = 5s` and 3 attempts, plus two `kill-session` calls that each get their own 5s budget, the worst case grows to roughly 15–25s before producing the same failure.
- It still ends as `SPAWN_TIMEOUT`, so it does not change what the user sees.

That work deserves its own latency discussion rather than gating this fix.

## Relationship to #2699

**References #2699; does not close it.** Most of what that issue asked for already landed:

- `INTERNAL_ERROR` on spawn was fixed by #3998 (`toSpawnAPIError`). Verified here: a forced failure returns `WORKSPACE_CREATE_FAILED`, not `INTERNAL_ERROR`.
- Failed-spawn cleanup already works. Verified here: the rolled-back session does not survive in the session list.

Two of the reporter's points remain open and are **not** addressed by this PR:

1. `SPAWN_TIMEOUT` is checked at `service.go:1057`, before the `ErrRuntimeCreate` stage sentinel at `:1085`. Since `wrapSpawnStage` wraps both, the deadline check wins and the underlying runtime cause is dropped from the user-facing message.
2. `ao doctor`'s `checkTmux` (`cli/doctor.go:312`) only runs `LookPath` + `tmux -V`, so a tmux server that is alive but hung on `new-session` passes clean.

## Testing

- `SessionsBoard.test.tsx` — asserts the full untruncated message reaches the toast, scoped to the toaster since the topbar renders the same text. First toast coverage in the repo.
- `npm test` — 218 files, 2874 passed, 1 skipped.
- `npm run typecheck` — clean.
- Manually reproduced the failure above against a local daemon by planting a stale `.git/config.lock` in a test repo.

## Checklist

- [x] Branched from `main` (rebased onto current `upstream/main`)
- [x] One focused change; references the related issue
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for user-visible behavior
- [x] Relevant CI checks pass for the area touched (frontend; no Go changes remain)
