### PR TITLE
fix(cli): carry reviewers through project set-config (#4277)

### DIFF
--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -94,6 +94,11 @@ type trackerIntakeConfig struct {
 	Assignee string `json:"assignee,omitempty"`
 }
 
+// reviewerConfig mirrors domain.ReviewerConfig.
+type reviewerConfig struct {
+	Harness string `json:"harness"`
+}
+
 // projectConfig mirrors the daemon's typed domain.ProjectConfig for the CLI
 // client. The CLI sets common fields via flags and the whole object via
 // --config-json.
@@ -111,6 +116,7 @@ type projectConfig struct {
 	Orchestrator      roleOverride        `json:"orchestrator,omitempty"`
 	TrackerIntake     trackerIntakeConfig `json:"trackerIntake,omitempty"`
 	AutoReview        bool                `json:"autoReview,omitempty"`
+	Reviewers         []reviewerConfig    `json:"reviewers,omitempty"`
 }
 
 // setConfigRequest mirrors the daemon's SetConfigInput body for
@@ -135,6 +141,7 @@ type projectSetConfigOptions struct {
 	trackerIntake     bool
 	trackerRepo       string
 	trackerAssignee   string
+	reviewers         []string
 	configJSON        string
 	clear             bool
 	json              bool
@@ -279,7 +286,7 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 		Use:   "set-config <id>",
 		Short: "Set the per-project config",
 		Long: "Replace a project's per-project config (branch, session prefix, env, " +
-			"symlinks, post-create, rules, agent model/permissions, role overrides, tracker intake). The config " +
+			"symlinks, post-create, rules, agent model/permissions, role overrides, tracker intake, reviewers). The config " +
 			"is resolved when a session spawns.\n\n" +
 			"Set fields via flags, pass the whole object with --config-json, or --clear " +
 			"to remove all config.",
@@ -326,6 +333,7 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 	f.BoolVar(&opts.trackerIntake, "tracker-intake", false, "Enable GitHub issue intake for matching issues")
 	f.StringVar(&opts.trackerRepo, "tracker-repo", "", "GitHub repo for issue intake (owner/repo; default: derive from git origin)")
 	f.StringVar(&opts.trackerAssignee, "tracker-assignee", "", "GitHub issue assignee required for intake eligibility")
+	f.StringArrayVar(&opts.reviewers, "reviewer", nil, "Reviewer harness that reviews worker PRs (repeatable; e.g. claude-code)")
 	f.StringVar(&opts.configJSON, "config-json", "", "Full config as a JSON object (overrides field flags)")
 	f.BoolVar(&opts.clear, "clear", false, "Clear all config")
 	f.BoolVar(&opts.json, "json", false, "Output the updated project as JSON")
@@ -370,6 +378,7 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 			Repo:     opts.trackerRepo,
 			Assignee: opts.trackerAssignee,
 		},
+		Reviewers: reviewersForFlags(opts.reviewers),
 	}
 	if reflect.DeepEqual(cfg, projectConfig{}) {
 		return projectConfig{}, usageError{errors.New("usage: provide at least one config flag, --config-json, or --clear")}
@@ -382,6 +391,26 @@ func trackerProviderForFlags(opts projectSetConfigOptions) string {
 		return "github"
 	}
 	return ""
+}
+
+// reviewersForFlags turns repeated --reviewer harness values into the config
+// shape. The daemon validates the harness vocabulary.
+func reviewersForFlags(harnesses []string) []reviewerConfig {
+	if len(harnesses) == 0 {
+		return nil
+	}
+	reviewers := make([]reviewerConfig, 0, len(harnesses))
+	for _, harness := range harnesses {
+		harness = strings.TrimSpace(harness)
+		if harness == "" {
+			continue
+		}
+		reviewers = append(reviewers, reviewerConfig{Harness: harness})
+	}
+	if len(reviewers) == 0 {
+		return nil
+	}
+	return reviewers
 }
 
 // parseEnvPairs turns repeated KEY=VALUE flags into a map.

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -266,6 +266,46 @@ func TestProjectSetConfig_RulesFlags(t *testing.T) {
 	}
 }
 
+func TestProjectSetConfig_ReviewerJSON(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectServer(t, http.StatusOK, `{"status":"ok","project":{"id":"demo","config":{"sessionPrefix":"work","reviewers":[{"harness":"claude-code"}]}}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--config-json", `{"reviewers":[{"harness":"claude-code"}],"sessionPrefix":"work"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if len(got.Config.Reviewers) != 1 || got.Config.Reviewers[0].Harness != "claude-code" {
+		t.Fatalf("reviewers config = %#v, want claude-code reviewer preserved", got.Config.Reviewers)
+	}
+}
+
+func TestProjectSetConfig_ReviewerFlags(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectServer(t, http.StatusOK, `{"status":"ok","project":{"id":"demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--reviewer", "claude-code")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request body: %v\nbody=%s", err, capture.body)
+	}
+	if len(got.Config.Reviewers) != 1 || got.Config.Reviewers[0].Harness != "claude-code" {
+		t.Fatalf("reviewers config = %#v, want single claude-code reviewer", got.Config.Reviewers)
+	}
+}
+
 func TestProjectRemove_RequiresID(t *testing.T) {
 	setConfigEnv(t)
 	_, _, err := executeCLI(t, Deps{}, "project", "rm")


### PR DESCRIPTION
Fixes #4277

## Root cause

The CLI is a thin daemon client that hand-mirrors daemon DTOs. Its mirror struct `projectConfig` in `backend/internal/cli/project.go` had no `Reviewers` field, so:

1. `ao project set-config --config-json '{"reviewers":[...]}'` unmarshals into that struct and `encoding/json` silently discards the unknown `reviewers` key.
2. The CLI then PUTs the reviewers-less config to `PUT /api/v1/projects/{id}/config`, which replaces the whole config.

Result: `status: ok` with reviewers never persisted, while the identical payload through the daemon API works. The daemon API was correct; this was purely a CLI DTO gap. Notably, `reviewers` pins cross-family review, so the silent drop meant the review loop quietly never ran.

## Fix

- Add `reviewerConfig` (mirrors `domain.ReviewerConfig`) and `Reviewers []reviewerConfig` (`json:"reviewers,omitempty"`) to the CLI's `projectConfig`, so `--config-json` round-trips reviewers like every other field.
- Add a repeatable `--reviewer <harness>` flag to `project set-config`, wired through `buildProjectConfig`. Harness vocabulary validation stays daemon-side per the thin-client convention.
- Tests: `TestProjectSetConfig_ReviewerJSON` (the issue's repro) and `TestProjectSetConfig_ReviewerFlags`.

## Intentional omissions

- No CLI-side validation of reviewer harness names; the daemon already rejects unknown harnesses via its error envelope.
- `--reviewer` only applies on the flags path; per existing behavior `--config-json` overrides field flags.

## Verification

- `cd backend && go build ./...`
- `go test ./internal/cli/ -count=1` - full package passes, including the two new tests