### PR TITLE
feat(daemon): read-only directory listing at GET /api/v1/fs/dirs

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -42,6 +42,7 @@ import (
 	browsersvc "github.com/aoagents/agent-orchestrator/backend/internal/service/browser"
 	chatsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/chat"
 	devimportsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/devimport"
+	fsbrowsersvc "github.com/aoagents/agent-orchestrator/backend/internal/service/fsbrowser"
 	importsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/importer"
 	notificationsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/notification"
 	prsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pr"
@@ -555,6 +556,7 @@ func Run() error {
 		DeviceRoster:       deviceRoster,
 		DeviceLive:         presenceTracker,
 		Import:             importsvc.New(importsvc.Deps{Store: store}),
+		Directories:        fsbrowsersvc.New(),
 		ShellTerminals:     shellTermSvc,
 		Conversations:      chatSvc,
 		Settings:           settingsSvc,

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -35,6 +35,7 @@ type APIDeps struct {
 	NotificationStream controllers.NotificationStream
 	Push               controllers.PushRegistry
 	Import             controllers.ImportService
+	Directories        controllers.DirectoryBrowserService
 	ShellTerminals     controllers.ShellTerminalService
 	// Conversations is nil until a Chat driver is wired; the controller then
 	// answers 501 rather than panicking, matching the other optional surfaces.
@@ -151,7 +152,7 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 		notifications: &controllers.NotificationsController{Svc: deps.Notifications, Stream: deps.NotificationStream},
 		push:          &controllers.PushController{Registry: deps.Push},
 		imports:       &controllers.ImportController{Svc: deps.Import},
-		fs:            &controllers.FSController{},
+		fs:            &controllers.FSController{Svc: deps.Directories},
 		shellTerms:    &controllers.ShellTerminalsController{Svc: deps.ShellTerminals},
 		conversations: &controllers.ConversationsController{Svc: deps.Conversations},
 		settings:      &controllers.SettingsController{Svc: deps.Settings},

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -110,6 +110,7 @@ type API struct {
 	notifications *controllers.NotificationsController
 	push          *controllers.PushController
 	imports       *controllers.ImportController
+	fs            *controllers.FSController
 	shellTerms    *controllers.ShellTerminalsController
 	conversations *controllers.ConversationsController
 	settings      *controllers.SettingsController
@@ -150,6 +151,7 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 		notifications: &controllers.NotificationsController{Svc: deps.Notifications, Stream: deps.NotificationStream},
 		push:          &controllers.PushController{Registry: deps.Push},
 		imports:       &controllers.ImportController{Svc: deps.Import},
+		fs:            &controllers.FSController{},
 		shellTerms:    &controllers.ShellTerminalsController{Svc: deps.ShellTerminals},
 		conversations: &controllers.ConversationsController{Svc: deps.Conversations},
 		settings:      &controllers.SettingsController{Svc: deps.Settings},
@@ -187,6 +189,7 @@ func (a *API) Register(root chi.Router) {
 			a.notifications.Register(r)
 			a.push.Register(r)
 			a.imports.Register(r)
+			a.fs.Register(r)
 			a.shellTerms.Register(r)
 			a.conversations.Register(r)
 			a.settings.Register(r)

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -711,6 +711,52 @@ paths:
       summary: Stream CDC events with durable replay
       tags:
       - events
+  /api/v1/fs/dirs:
+    get:
+      operationId: listDirs
+      parameters:
+      - description: Absolute directory on the daemon host to list. When omitted,
+          the daemon user's home directory.
+        in: query
+        name: path
+        schema:
+          description: Absolute directory on the daemon host to list. When omitted,
+            the daemon user's home directory.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListDirsResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+      summary: List the subdirectories of a directory on the daemon host
+      tags:
+      - fs
   /api/v1/identity:
     get:
       operationId: getIdentity
@@ -7785,6 +7831,23 @@ components:
       - coverage
       - providerAttribution
       type: object
+    FSEntry:
+      properties:
+        gitRepo:
+          description: True when the directory carries a .git entry (clone or worktree
+            checkout).
+          type: boolean
+        name:
+          description: Directory name.
+          type: string
+        path:
+          description: Absolute path of the directory on the daemon host.
+          type: string
+      required:
+      - name
+      - path
+      - gitRepo
+      type: object
     IdentityResponse:
       properties:
         apiVersion:
@@ -8004,6 +8067,29 @@ components:
           type: array
       required:
       - sessions
+      type: object
+    ListDirsResponse:
+      properties:
+        entries:
+          description: Subdirectories, excluding dotted names.
+          items:
+            $ref: '#/components/schemas/FSEntry'
+          type: array
+        parent:
+          description: Absolute path of the listed directory's parent; equals path
+            at the filesystem root.
+          type: string
+        path:
+          description: Absolute path that was listed.
+          type: string
+        truncated:
+          description: True when the listing hit the entry cap and more subdirectories
+            exist.
+          type: boolean
+      required:
+      - path
+      - parent
+      - entries
       type: object
     ListNotificationsResponse:
       properties:
@@ -10449,6 +10535,8 @@ tags:
   name: mobile
 - description: Target-isolated desktop browser runtime (loopback only)
   name: browser
+- description: Read-only filesystem browsing for remote clients
+  name: fs
 - description: Local machine readiness checks the desktop app runs before showing
     the board
   name: system

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -83,6 +83,8 @@ func Build() ([]byte, error) {
 			"Connect Mobile LAN bridge control (loopback/desktop only)"),
 		*(&openapi31.Tag{Name: "browser"}).WithDescription(
 			"Target-isolated desktop browser runtime (loopback only)"),
+		*(&openapi31.Tag{Name: "fs"}).WithDescription(
+			"Read-only filesystem browsing for remote clients"),
 		*(&openapi31.Tag{Name: "system"}).WithDescription(
 			"Local machine readiness checks the desktop app runs before showing the board"),
 	}
@@ -211,6 +213,9 @@ var schemaNames = map[string]string{
 	"ControllersGetProjectResponse":                       "ProjectGetResponse",
 	"ControllersProjectOrDegraded":                        "ProjectOrDegraded",
 	"ControllersListSessionsQuery":                        "ListSessionsQuery",
+	"ControllersListDirsQuery":                            "ListDirsQuery",
+	"ControllersListDirsResponse":                         "ListDirsResponse",
+	"ControllersFSEntry":                                  "FSEntry",
 	"ControllersCleanupSessionsQuery":                     "CleanupSessionsQuery",
 	"ControllersListSessionsResponse":                     "ListSessionsResponse",
 	"ControllersSpawnSessionRequest":                      "SpawnSessionRequest",
@@ -501,6 +506,7 @@ func operations() []operation {
 	ops = append(ops, usageOperations()...)
 	ops = append(ops, pushOperations()...)
 	ops = append(ops, importOperations()...)
+	ops = append(ops, fsOperations()...)
 	ops = append(ops, devOperations()...)
 	ops = append(ops, mobileOperations()...)
 	ops = append(ops, mobileDeviceOperations()...)
@@ -1276,6 +1282,25 @@ func importOperations() []operation {
 				{http.StatusOK, controllers.ImportRunResponse{}},
 				{http.StatusInternalServerError, envelope.APIError{}},
 				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+	}
+}
+
+// fsOperations declares the read-only filesystem-browsing operations. Must stay
+// 1:1 with the routes FSController.Register mounts (enforced by the parity test).
+func fsOperations() []operation {
+	return []operation{
+		{
+			method: http.MethodGet, path: "/api/v1/fs/dirs", id: "listDirs", tag: "fs",
+			summary:    "List the subdirectories of a directory on the daemon host",
+			pathParams: []any{controllers.ListDirsQuery{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.ListDirsResponse{}},
+				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusForbidden, envelope.APIError{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
 			},
 		},
 	}

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1312,6 +1312,26 @@ type ImportRunResponse struct {
 	Report legacyimport.Report `json:"report"`
 }
 
+// ListDirsQuery is the query string accepted by GET /api/v1/fs/dirs.
+type ListDirsQuery struct {
+	Path string `query:"path,omitempty" description:"Absolute directory on the daemon host to list. When omitted, the daemon user's home directory."`
+}
+
+// FSEntry is one directory in a /api/v1/fs/dirs listing.
+type FSEntry struct {
+	Name    string `json:"name" description:"Directory name."`
+	Path    string `json:"path" description:"Absolute path of the directory on the daemon host."`
+	GitRepo bool   `json:"gitRepo" description:"True when the directory carries a .git entry (clone or worktree checkout)."`
+}
+
+// ListDirsResponse is the body of GET /api/v1/fs/dirs.
+type ListDirsResponse struct {
+	Path      string    `json:"path" description:"Absolute path that was listed."`
+	Parent    string    `json:"parent" description:"Absolute path of the listed directory's parent; equals path at the filesystem root."`
+	Entries   []FSEntry `json:"entries" description:"Subdirectories, excluding dotted names."`
+	Truncated bool      `json:"truncated,omitempty" description:"True when the listing hit the entry cap and more subdirectories exist."`
+}
+
 // DevImportProjectsRequest is the body of POST /api/v1/dev/import-projects.
 type DevImportProjectsRequest struct {
 	SourceDataDir string `json:"sourceDataDir" minLength:"1"`

--- a/backend/internal/httpd/controllers/fs.go
+++ b/backend/internal/httpd/controllers/fs.go
@@ -1,20 +1,20 @@
 package controllers
 
 import (
-	"errors"
+	"context"
 	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	fsbrowsersvc "github.com/aoagents/agent-orchestrator/backend/internal/service/fsbrowser"
 )
 
-// maxDirEntries bounds a single listing; deeper trees are reached by walking.
-const maxDirEntries = 500
+// DirectoryBrowserService lists directories on the daemon host.
+type DirectoryBrowserService interface {
+	List(ctx context.Context, path string) (fsbrowsersvc.Listing, error)
+}
 
 // FSController owns the read-only /fs routes used by remote clients to browse
 // for a project path. Listing is directories-only and dotfile-free by design:
@@ -22,8 +22,7 @@ const maxDirEntries = 500
 // so this reveals nothing new — but there is no reason to serve more than the
 // picker needs.
 type FSController struct {
-	// Home supplies the default browse root; nil falls back to os.UserHomeDir.
-	Home func() (string, error)
+	Svc DirectoryBrowserService
 }
 
 // Register mounts fs REST routes on the supplied router.
@@ -32,55 +31,19 @@ func (c *FSController) Register(r chi.Router) {
 }
 
 func (c *FSController) listDirs(w http.ResponseWriter, r *http.Request) {
-	dir := r.URL.Query().Get("path")
-	if dir == "" {
-		home := os.UserHomeDir
-		if c.Home != nil {
-			home = c.Home
-		}
-		resolved, err := home()
-		if err != nil {
-			envelope.WriteError(w, r, err)
-			return
-		}
-		dir = resolved
-	}
-	// The daemon judges the path by its own OS's rules — the client must never
-	// pre-judge it, since a remote picker has no idea what a valid absolute path
-	// looks like on the host it is browsing.
-	if !filepath.IsAbs(dir) {
-		envelope.WriteError(w, r, apierr.Invalid("FS_PATH_NOT_ABSOLUTE", "path must be absolute on the daemon host", nil))
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, http.MethodGet, "/api/v1/fs/dirs")
 		return
 	}
-	dir = filepath.Clean(dir)
-
-	entries, err := os.ReadDir(dir)
+	listing, err := c.Svc.List(r.Context(), r.URL.Query().Get("path"))
 	if err != nil {
-		switch {
-		case errors.Is(err, os.ErrNotExist):
-			envelope.WriteError(w, r, apierr.NotFound("FS_NOT_FOUND", "no such directory on the daemon host"))
-		case errors.Is(err, os.ErrPermission):
-			envelope.WriteError(w, r, apierr.Forbidden("FS_FORBIDDEN", "the daemon may not read that directory"))
-		default:
-			// ENOTDIR and friends: the path exists but is not browsable.
-			envelope.WriteError(w, r, apierr.Invalid("FS_NOT_A_DIRECTORY", "not a directory", nil))
-		}
+		envelope.WriteError(w, r, err)
 		return
 	}
 
-	out := ListDirsResponse{Path: dir, Parent: filepath.Dir(dir), Entries: []FSEntry{}}
-	for _, entry := range entries {
-		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
-			continue
-		}
-		if len(out.Entries) == maxDirEntries {
-			out.Truncated = true
-			break
-		}
-		child := filepath.Join(dir, entry.Name())
-		// .git may be a directory (normal clone) or a file (worktree): both are repos.
-		_, gitErr := os.Stat(filepath.Join(child, ".git"))
-		out.Entries = append(out.Entries, FSEntry{Name: entry.Name(), Path: child, GitRepo: gitErr == nil})
+	out := ListDirsResponse{Path: listing.Path, Parent: listing.Parent, Entries: make([]FSEntry, len(listing.Entries)), Truncated: listing.Truncated}
+	for i, entry := range listing.Entries {
+		out.Entries[i] = FSEntry{Name: entry.Name, Path: entry.Path, GitRepo: entry.GitRepo}
 	}
 	envelope.WriteJSON(w, http.StatusOK, out)
 }

--- a/backend/internal/httpd/controllers/fs.go
+++ b/backend/internal/httpd/controllers/fs.go
@@ -1,0 +1,86 @@
+package controllers
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+)
+
+// maxDirEntries bounds a single listing; deeper trees are reached by walking.
+const maxDirEntries = 500
+
+// FSController owns the read-only /fs routes used by remote clients to browse
+// for a project path. Listing is directories-only and dotfile-free by design:
+// the connection credential already authorizes spawning agents (shell access),
+// so this reveals nothing new — but there is no reason to serve more than the
+// picker needs.
+type FSController struct {
+	// Home supplies the default browse root; nil falls back to os.UserHomeDir.
+	Home func() (string, error)
+}
+
+// Register mounts fs REST routes on the supplied router.
+func (c *FSController) Register(r chi.Router) {
+	r.Get("/fs/dirs", c.listDirs)
+}
+
+func (c *FSController) listDirs(w http.ResponseWriter, r *http.Request) {
+	dir := r.URL.Query().Get("path")
+	if dir == "" {
+		home := os.UserHomeDir
+		if c.Home != nil {
+			home = c.Home
+		}
+		resolved, err := home()
+		if err != nil {
+			envelope.WriteError(w, r, err)
+			return
+		}
+		dir = resolved
+	}
+	// The daemon judges the path by its own OS's rules — the client must never
+	// pre-judge it, since a remote picker has no idea what a valid absolute path
+	// looks like on the host it is browsing.
+	if !filepath.IsAbs(dir) {
+		envelope.WriteError(w, r, apierr.Invalid("FS_PATH_NOT_ABSOLUTE", "path must be absolute on the daemon host", nil))
+		return
+	}
+	dir = filepath.Clean(dir)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			envelope.WriteError(w, r, apierr.NotFound("FS_NOT_FOUND", "no such directory on the daemon host"))
+		case errors.Is(err, os.ErrPermission):
+			envelope.WriteError(w, r, apierr.Forbidden("FS_FORBIDDEN", "the daemon may not read that directory"))
+		default:
+			// ENOTDIR and friends: the path exists but is not browsable.
+			envelope.WriteError(w, r, apierr.Invalid("FS_NOT_A_DIRECTORY", "not a directory", nil))
+		}
+		return
+	}
+
+	out := ListDirsResponse{Path: dir, Parent: filepath.Dir(dir), Entries: []FSEntry{}}
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if len(out.Entries) == maxDirEntries {
+			out.Truncated = true
+			break
+		}
+		child := filepath.Join(dir, entry.Name())
+		// .git may be a directory (normal clone) or a file (worktree): both are repos.
+		_, gitErr := os.Stat(filepath.Join(child, ".git"))
+		out.Entries = append(out.Entries, FSEntry{Name: entry.Name(), Path: child, GitRepo: gitErr == nil})
+	}
+	envelope.WriteJSON(w, http.StatusOK, out)
+}

--- a/backend/internal/httpd/controllers/fs_test.go
+++ b/backend/internal/httpd/controllers/fs_test.go
@@ -8,21 +8,25 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	fsbrowsersvc "github.com/aoagents/agent-orchestrator/backend/internal/service/fsbrowser"
 )
 
-func newFSRig(t *testing.T, home string) *httptest.Server {
+func newFSRig(t *testing.T) *httptest.Server {
 	t.Helper()
 	r := chi.NewRouter()
-	(&FSController{Home: func() (string, error) { return home, nil }}).Register(r)
+	(&FSController{Svc: fsbrowsersvc.New()}).Register(r)
 	srv := httptest.NewServer(r)
 	t.Cleanup(srv.Close)
 	return srv
 }
 
-func listDirs(t *testing.T, srv *httptest.Server, path string) (int, ListDirsResponse) {
+func listDirs(t *testing.T, srv *httptest.Server, path string) (int, ListDirsResponse, envelope.APIError) {
 	t.Helper()
 	q := ""
 	if path != "" {
@@ -34,12 +38,15 @@ func listDirs(t *testing.T, srv *httptest.Server, path string) (int, ListDirsRes
 	}
 	defer resp.Body.Close()
 	var body ListDirsResponse
+	var apiErr envelope.APIError
 	if resp.StatusCode == http.StatusOK {
 		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 			t.Fatal(err)
 		}
+	} else if err := json.NewDecoder(resp.Body).Decode(&apiErr); err != nil {
+		t.Fatal(err)
 	}
-	return resp.StatusCode, body
+	return resp.StatusCode, body, apiErr
 }
 
 // padName zero-pads so the cap test's directory names sort deterministically.
@@ -62,7 +69,7 @@ func TestListDirsShowsDirectoriesOnlyWithGitDetection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status, body := listDirs(t, newFSRig(t, home), home)
+	status, body, _ := listDirs(t, newFSRig(t), home)
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
@@ -85,15 +92,15 @@ func TestListDirsShowsDirectoriesOnlyWithGitDetection(t *testing.T) {
 }
 
 func TestListDirsDefaultsToHome(t *testing.T) {
-	home := t.TempDir()
-	if err := os.Mkdir(filepath.Join(home, "sub"), 0o755); err != nil {
+	home, err := os.UserHomeDir()
+	if err != nil {
 		t.Fatal(err)
 	}
-	status, body := listDirs(t, newFSRig(t, home), "")
+	status, body, _ := listDirs(t, newFSRig(t), "")
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
-	if body.Path != home {
+	if body.Path != filepath.Clean(home) {
 		t.Errorf("path = %q, want home %q", body.Path, home)
 	}
 	if body.Parent != filepath.Dir(home) {
@@ -103,32 +110,60 @@ func TestListDirsDefaultsToHome(t *testing.T) {
 
 func TestListDirsRejectsRelativeAndMissingPaths(t *testing.T) {
 	home := t.TempDir()
-	srv := newFSRig(t, home)
-
-	if status, _ := listDirs(t, srv, "relative/path"); status != http.StatusBadRequest {
-		t.Errorf("relative path status = %d, want 400", status)
-	}
-	if status, _ := listDirs(t, srv, filepath.Join(home, "nope")); status != http.StatusNotFound {
-		t.Errorf("missing path status = %d, want 404", status)
-	}
+	srv := newFSRig(t)
 	// A file is not browsable.
 	f := filepath.Join(home, "f.txt")
 	if err := os.WriteFile(f, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if status, _ := listDirs(t, srv, f); status != http.StatusBadRequest {
-		t.Errorf("file path status = %d, want 400", status)
+
+	for _, tc := range []struct {
+		name       string
+		path       string
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "relative", path: "relative/path", wantStatus: http.StatusBadRequest, wantCode: "FS_PATH_NOT_ABSOLUTE"},
+		{name: "missing", path: filepath.Join(home, "nope"), wantStatus: http.StatusNotFound, wantCode: "FS_NOT_FOUND"},
+		{name: "file", path: f, wantStatus: http.StatusBadRequest, wantCode: "FS_NOT_A_DIRECTORY"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _, apiErr := listDirs(t, srv, tc.path)
+			if status != tc.wantStatus || apiErr.Code != tc.wantCode {
+				t.Fatalf("status/code = %d/%q, want %d/%q", status, apiErr.Code, tc.wantStatus, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestListDirsRejectsPermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not enforce Unix directory mode bits")
+	}
+	dir := filepath.Join(t.TempDir(), "forbidden")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	status, _, apiErr := listDirs(t, newFSRig(t), dir)
+	if status != http.StatusForbidden || apiErr.Code != "FS_FORBIDDEN" {
+		t.Fatalf("status/code = %d/%q, want 403/FS_FORBIDDEN", status, apiErr.Code)
 	}
 }
 
 func TestListDirsCapsEntries(t *testing.T) {
+	const maxDirEntries = 500
 	home := t.TempDir()
 	for i := 0; i < maxDirEntries+10; i++ {
 		if err := os.Mkdir(filepath.Join(home, "d"+padName(i)), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
-	status, body := listDirs(t, newFSRig(t, home), home)
+	status, body, _ := listDirs(t, newFSRig(t), home)
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}

--- a/backend/internal/httpd/controllers/fs_test.go
+++ b/backend/internal/httpd/controllers/fs_test.go
@@ -1,0 +1,138 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func newFSRig(t *testing.T, home string) *httptest.Server {
+	t.Helper()
+	r := chi.NewRouter()
+	(&FSController{Home: func() (string, error) { return home, nil }}).Register(r)
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func listDirs(t *testing.T, srv *httptest.Server, path string) (int, ListDirsResponse) {
+	t.Helper()
+	q := ""
+	if path != "" {
+		q = "?path=" + url.QueryEscape(path)
+	}
+	resp, err := http.Get(srv.URL + "/fs/dirs" + q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body ListDirsResponse
+	if resp.StatusCode == http.StatusOK {
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return resp.StatusCode, body
+}
+
+// padName zero-pads so the cap test's directory names sort deterministically.
+func padName(i int) string { return fmt.Sprintf("%04d", i) }
+
+func TestListDirsShowsDirectoriesOnlyWithGitDetection(t *testing.T) {
+	home := t.TempDir()
+	// A plain dir, a git repo (.git directory), a worktree checkout (.git FILE),
+	// a dotdir that must be skipped, and a plain file that must not appear.
+	for _, d := range []string{"plain", "repo/.git", "worktree", ".hidden"} {
+		if err := os.MkdirAll(filepath.Join(home, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Worktrees carry `.git` as a FILE ("gitdir: ..."), not a directory. Both count.
+	if err := os.WriteFile(filepath.Join(home, "worktree", ".git"), []byte("gitdir: /elsewhere\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "loose.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	status, body := listDirs(t, newFSRig(t, home), home)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	got := map[string]bool{}
+	for _, e := range body.Entries {
+		got[e.Name] = e.GitRepo
+		if e.Path != filepath.Join(home, e.Name) {
+			t.Errorf("entry %q path = %q, want %q", e.Name, e.Path, filepath.Join(home, e.Name))
+		}
+	}
+	want := map[string]bool{"plain": false, "repo": true, "worktree": true}
+	if len(got) != len(want) {
+		t.Fatalf("entries = %v, want exactly %v (no dotdirs, no files)", got, want)
+	}
+	for name, gitRepo := range want {
+		if got[name] != gitRepo {
+			t.Errorf("entry %q gitRepo = %v, want %v", name, got[name], gitRepo)
+		}
+	}
+}
+
+func TestListDirsDefaultsToHome(t *testing.T) {
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(home, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	status, body := listDirs(t, newFSRig(t, home), "")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if body.Path != home {
+		t.Errorf("path = %q, want home %q", body.Path, home)
+	}
+	if body.Parent != filepath.Dir(home) {
+		t.Errorf("parent = %q, want %q", body.Parent, filepath.Dir(home))
+	}
+}
+
+func TestListDirsRejectsRelativeAndMissingPaths(t *testing.T) {
+	home := t.TempDir()
+	srv := newFSRig(t, home)
+
+	if status, _ := listDirs(t, srv, "relative/path"); status != http.StatusBadRequest {
+		t.Errorf("relative path status = %d, want 400", status)
+	}
+	if status, _ := listDirs(t, srv, filepath.Join(home, "nope")); status != http.StatusNotFound {
+		t.Errorf("missing path status = %d, want 404", status)
+	}
+	// A file is not browsable.
+	f := filepath.Join(home, "f.txt")
+	if err := os.WriteFile(f, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if status, _ := listDirs(t, srv, f); status != http.StatusBadRequest {
+		t.Errorf("file path status = %d, want 400", status)
+	}
+}
+
+func TestListDirsCapsEntries(t *testing.T) {
+	home := t.TempDir()
+	for i := 0; i < maxDirEntries+10; i++ {
+		if err := os.Mkdir(filepath.Join(home, "d"+padName(i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	status, body := listDirs(t, newFSRig(t, home), home)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if len(body.Entries) != maxDirEntries || !body.Truncated {
+		t.Errorf("entries = %d truncated = %v, want %d/true", len(body.Entries), body.Truncated, maxDirEntries)
+	}
+}

--- a/backend/internal/httpd/lan_listener_test.go
+++ b/backend/internal/httpd/lan_listener_test.go
@@ -111,6 +111,27 @@ func TestLANManagerBlocksLoopbackOnlyControlRoutes(t *testing.T) {
 		t.Fatalf("/api/v1/sessions: got 404, should not be blocked by the control-route filter")
 	}
 
+	// Browsing a remote host for a project path is the whole point of fs/dirs,
+	// so it must behave like every other data route: credential-gated, and
+	// specifically NOT a loopback-only control route. A 404 here would be a
+	// silent feature kill that no loopback-side test could catch.
+	fsReq, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/api/v1/fs/dirs", port), nil)
+	fsReq.Host = "127.0.0.1" // spoofed loopback Host, as above
+	fsReq.Header.Set("Authorization", "Bearer secret12")
+	fsResp, err := http.DefaultClient.Do(fsReq)
+	if err != nil {
+		t.Fatalf("fs/dirs: request failed: %v", err)
+	}
+	if fsResp.StatusCode == http.StatusNotFound {
+		t.Fatal("/api/v1/fs/dirs: got 404 — remote folder browsing needs it reachable over the LAN")
+	}
+	fsNoAuth, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/api/v1/fs/dirs", port))
+	if err != nil {
+		t.Fatalf("fs/dirs unauthenticated: request failed: %v", err)
+	}
+	if fsNoAuth.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("/api/v1/fs/dirs unauthenticated: got %d want 401", fsNoAuth.StatusCode)
+	}
 }
 
 func TestLANManagerStartStopIdempotent(t *testing.T) {

--- a/backend/internal/service/fsbrowser/service.go
+++ b/backend/internal/service/fsbrowser/service.go
@@ -1,0 +1,82 @@
+// Package fsbrowser provides read-only directory listings for remote clients.
+package fsbrowser
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+)
+
+const maxEntries = 500
+
+// Entry is one visible subdirectory.
+type Entry struct {
+	Name    string
+	Path    string
+	GitRepo bool
+}
+
+// Listing is a bounded directory listing on the daemon host.
+type Listing struct {
+	Path      string
+	Parent    string
+	Entries   []Entry
+	Truncated bool
+}
+
+// Service browses the daemon host's filesystem without exposing file contents.
+type Service struct{}
+
+// New constructs a directory browser backed by the host filesystem.
+func New() *Service { return &Service{} }
+
+// List returns the visible subdirectories of path. An empty path uses the
+// daemon user's home directory.
+func (*Service) List(ctx context.Context, path string) (Listing, error) {
+	if err := ctx.Err(); err != nil {
+		return Listing{}, err
+	}
+	if path == "" {
+		var err error
+		path, err = os.UserHomeDir()
+		if err != nil {
+			return Listing{}, err
+		}
+	}
+	if !filepath.IsAbs(path) {
+		return Listing{}, apierr.Invalid("FS_PATH_NOT_ABSOLUTE", "path must be absolute on the daemon host", nil)
+	}
+	path = filepath.Clean(path)
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			return Listing{}, apierr.NotFound("FS_NOT_FOUND", "no such directory on the daemon host")
+		case errors.Is(err, os.ErrPermission):
+			return Listing{}, apierr.Forbidden("FS_FORBIDDEN", "the daemon may not read that directory")
+		default:
+			return Listing{}, apierr.Invalid("FS_NOT_A_DIRECTORY", "not a directory", nil)
+		}
+	}
+
+	out := Listing{Path: path, Parent: filepath.Dir(path), Entries: []Entry{}}
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if len(out.Entries) == maxEntries {
+			out.Truncated = true
+			break
+		}
+		child := filepath.Join(path, entry.Name())
+		// .git may be a directory (normal clone) or a file (worktree): both are repos.
+		_, gitErr := os.Stat(filepath.Join(child, ".git"))
+		out.Entries = append(out.Entries, Entry{Name: entry.Name(), Path: child, GitRepo: gitErr == nil})
+	}
+	return out, nil
+}

--- a/docs/adr/0001-lan-listener-for-mobile.md
+++ b/docs/adr/0001-lan-listener-for-mobile.md
@@ -41,6 +41,10 @@ Security posture:
   must not be able to lock out the real phone).
 - **App API only** on the LAN Listener; daemon-control routes keep their existing
   loopback-only guard (`localControlRequest`) with no change.
+- The authenticated app API includes `GET /api/v1/fs/dirs` for remote folder
+  selection. Its bounded response identifies the listed absolute path and parent,
+  plus each visible subdirectory's name, absolute path, and `.git` presence; it
+  does not expose file contents, sizes, timestamps, files, or dotted names.
 - **Plaintext transport (HTTP), accepted.** No TLS. The feature is
   **home-network-only** and the UI says so. The Pairing QR therefore carries only
   host+port (non-secret); the Connection Password is delivered out-of-band (read off

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -294,6 +294,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/fs/dirs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the subdirectories of a directory on the daemon host */
+        get: operations["listDirs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/identity": {
         parameters: {
             query?: never;
@@ -2678,6 +2695,14 @@ export interface components {
             /** Format: int64 */
             totalNanos: number;
         };
+        FSEntry: {
+            /** @description True when the directory carries a .git entry (clone or worktree checkout). */
+            gitRepo: boolean;
+            /** @description Directory name. */
+            name: string;
+            /** @description Absolute path of the directory on the daemon host. */
+            path: string;
+        };
         IdentityResponse: {
             apiVersion: number;
             hostId: string;
@@ -2756,6 +2781,16 @@ export interface components {
         };
         ListCompactSessionUsageResponse: {
             sessions: components["schemas"]["CompactSessionUsageResponse"][];
+        };
+        ListDirsResponse: {
+            /** @description Subdirectories, excluding dotted names. */
+            entries: components["schemas"]["FSEntry"][];
+            /** @description Absolute path of the listed directory's parent; equals path at the filesystem root. */
+            parent: string;
+            /** @description Absolute path that was listed. */
+            path: string;
+            /** @description True when the listing hit the entry cap and more subdirectories exist. */
+            truncated?: boolean;
         };
         ListNotificationsResponse: {
             nextCursor?: string;
@@ -4607,6 +4642,65 @@ export interface operations {
             };
             /** @description Not Implemented */
             501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    listDirs: {
+        parameters: {
+            query?: {
+                /** @description Absolute directory on the daemon host to list. When omitted, the daemon user's home directory. */
+                path?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListDirsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Ticket

No upstream issue yet. Design note: [remote hosts RFC](https://github.com/AronPerez/agent-orchestrator/blob/plan/2026-08-24-wave3/docs/upstreaming-rfc-remote-hosts.md).

## Problem

A client connected to a daemon on another machine cannot see that machine's filesystem, so an absolute project path over there has to be typed blind — with no way to tell a typo from a folder that is really missing, and no way to know whether a directory is already a checkout. Anyone adding a project on a second machine is guessing.

## Solution

A read-only `GET /api/v1/fs/dirs` answers with the subdirectories of one absolute path: names, paths, and whether each carries a `.git` entry (a directory for a clone, a file for a worktree checkout). Dotted names are skipped, files are never listed, and a listing is capped at 500 entries with `truncated` set. It is additive and sits behind the connection credential that already exists.

## How Has This Been Tested?

`cd backend && go build ./... && go vet ./... && go test ./...` on the current `main` (`c9a0adb2`): 158 packages ok, 0 failures, `gofmt -l` empty. That includes `TestListDirs` x4 and the LAN policy assertion. Regeneration is idempotent on this base: `go generate ./internal/httpd/apispec/...` followed by `npm run api:ts` leaves the working tree clean, so `TestRouteSpecParity` and the `api-drift` job both hold.

## Artifacts (if appropriate):

No renderable surface: Go plus two generated API files. The only `frontend/src` change is the regenerated `api/schema.ts`.

## Implementation notes

**Is this an escalation?** No. It sits behind the same connection credential that already authorises spawning an agent — that is, a shell — on the host, so it grants no reach that credential did not already have. It reads directory names and nothing else: no file contents, no sizes, no timestamps, no dotted names.

The daemon judges the path by its own OS's rules. A remote client cannot know what a valid absolute path looks like over there, so a relative path is refused by the daemon (`FS_PATH_NOT_ABSOLUTE`) rather than pre-judged client-side. `ENOENT`, `EACCES` and `ENOTDIR` are separated into 404 / 403 / 400 so a caller can tell "no such folder" from "may not read it" from "that is a file".

The route is declared in `specgen` beside the others and the spec and `schema.ts` are regenerated rather than hand-written.

The LAN test pins both halves of the policy: credential-gated like every other data route, and specifically **not** on `lanControlBlockedPrefixes`. That second half is the one worth having — a `ROUTE_LOOPBACK_ONLY` answer would kill remote browsing silently, and no loopback-side test could catch it. The assertion was falsified before it was trusted: adding `/api/v1/fs` to the blocked prefixes makes it fail.

Follow-up, not included here: nothing calls this endpoint yet. The client that uses it is a separate PR in the same series.
