### PR TITLE
fix(cli): refuse --url on commands that only ever act on this machine

### DIFF
--- a/backend/internal/cli/agent_process.go
+++ b/backend/internal/cli/agent_process.go
@@ -38,6 +38,11 @@ func newAgentProcessSuperviseCommand(ctx *commandContext) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// The exit report names a session owned by the local daemon: AO_URL is
+			// ignored, --url is refused, and neither ever reaches the child.
+			if err := ctx.pinToLocalDaemon("ao agent-process supervise"); err != nil {
+				return err
+			}
 			sessionID = strings.TrimSpace(sessionID)
 			launchID = strings.TrimSpace(launchID)
 			if !sessionIDPattern.MatchString(sessionID) {

--- a/backend/internal/cli/client.go
+++ b/backend/internal/cli/client.go
@@ -91,7 +91,37 @@ func (c *commandContext) doJSON(ctx context.Context, method, path string, body, 
 }
 
 func (c *commandContext) postLoopbackJSON(ctx context.Context, path string, body any) error {
+	// These are loopback-only control routes (/internal/*), 404'd at the LAN
+	// socket by design — and CLI telemetry has no business reaching a daemon on
+	// someone else's machine. Drop them when a remote target is set.
+	if c.remote != nil {
+		return nil
+	}
 	return c.doJSONPath(ctx, http.MethodPost, path, body, nil)
+}
+
+// daemonBase returns the base URL every daemon call targets. With a remote
+// target it is the given URL; otherwise it is the loopback daemon discovered
+// through the run-file, gated on a live local PID as before.
+func (c *commandContext) daemonBase() (string, error) {
+	if c.remote != nil {
+		return c.remote.baseURL, nil
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return "", err
+	}
+	info, err := runfile.Read(cfg.RunFilePath)
+	if err != nil {
+		return "", err
+	}
+	if info == nil {
+		return "", fmt.Errorf("AO daemon is not running — start it with `ao start`")
+	}
+	if !c.deps.ProcessAlive(info.PID) {
+		return "", fmt.Errorf("AO daemon is not running (stale run-file at %s) — start it with `ao start`", cfg.RunFilePath)
+	}
+	return fmt.Sprintf("http://%s:%d", config.LoopbackHost, info.Port), nil
 }
 
 func (c *commandContext) doJSONPath(ctx context.Context, method, path string, body, out any) error {
@@ -114,19 +144,9 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 	headers map[string]string,
 	timeout time.Duration,
 ) error {
-	cfg, err := config.Load()
+	base, err := c.daemonBase()
 	if err != nil {
 		return err
-	}
-	info, err := runfile.Read(cfg.RunFilePath)
-	if err != nil {
-		return err
-	}
-	if info == nil {
-		return fmt.Errorf("AO daemon is not running — start it with `ao start`")
-	}
-	if !c.deps.ProcessAlive(info.PID) {
-		return fmt.Errorf("AO daemon is not running (stale run-file at %s) — start it with `ao start`", cfg.RunFilePath)
 	}
 
 	var reader io.Reader = http.NoBody
@@ -137,14 +157,14 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 		}
 		reader = bytes.NewReader(payload)
 	}
-	url := fmt.Sprintf("http://%s:%d%s", config.LoopbackHost, info.Port, path)
-	req, err := http.NewRequestWithContext(ctx, method, url, reader) // #nosec G704 -- daemon host is fixed loopback; path is an internal API route.
+	req, err := http.NewRequestWithContext(ctx, method, base+path, reader) // #nosec G704 -- host is loopback or an explicitly configured daemon URL; path is an internal API route.
 	if err != nil {
 		return err
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	c.authorize(req)
 	for name, value := range headers {
 		req.Header.Set(name, value)
 	}
@@ -153,7 +173,7 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 	// give daemon API calls far more headroom than the 2s status-probe timeout.
 	client := *c.deps.HTTPClient
 	client.Timeout = timeout
-	resp, err := client.Do(req) // #nosec G704 -- request target is the fixed loopback daemon URL above.
+	resp, err := client.Do(req) // #nosec G704 -- request target is the daemon base URL resolved above.
 	if err != nil {
 		return fmt.Errorf("call daemon: %w", err)
 	}

--- a/backend/internal/cli/dev.go
+++ b/backend/internal/cli/dev.go
@@ -61,6 +61,22 @@ func newDevImportProjectsCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) runDevImportProjects(cmd *cobra.Command, opts devImportProjectsOptions) error {
+	// Before config.Load and before any path resolution below: both data dirs are
+	// expanded, made absolute and symlink-resolved against THIS machine's
+	// filesystem, compared here, and then the local source path is POSTed to the
+	// daemon as a bare string for it to open on its OWN disk. Every step of that
+	// is wrong for a remote target, and the same-dir check would be comparing a
+	// local path against a local path to guard a remote import.
+	//
+	// /api/v1/dev is on the LAN block list today, so this fails loudly anyway —
+	// but with ROUTE_NOT_FOUND, which explains none of the above, and the block
+	// is not this command's to depend on.
+	if err := c.refuseLocalOnly("ao dev import-projects",
+		"resolves both data dir paths on the machine running the CLI and then hands that "+
+			"local path to the daemon to open on its own disk, where it would name a different "+
+			"directory or none at all. Run it on the machine running that daemon"); err != nil {
+		return err
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return err

--- a/backend/internal/cli/dev_test.go
+++ b/backend/internal/cli/dev_test.go
@@ -167,6 +167,61 @@ func TestDevImportProjectsDaemonError(t *testing.T) {
 	}
 }
 
+// `ao dev import-projects --url` resolves BOTH data dirs against the local
+// filesystem and then POSTs the local source path for the remote daemon to open
+// on its own disk. The real assertion is the empty request log: /api/v1/dev is
+// on the LAN block list today, so a request that escapes this guard comes back
+// ROUTE_NOT_FOUND and looks, from the exit status alone, exactly like a refusal.
+//
+// The second case is the ordering proof. Pointing --from-data-dir at the target
+// data dir is the input that trips the local same-dir check; if any path
+// resolution had run before the guard, that is the error we would see instead.
+func TestDevImportProjectsRefusesRemoteTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		sourceIsTheTarget bool
+	}{
+		{name: "default source"},
+		{name: "source equal to target", sourceIsTheTarget: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			aoHome(t)
+			cfg := setConfigEnv(t)
+			t.Setenv("AO_TOKEN", "tok")
+			var args []string
+			if tc.sourceIsTheTarget {
+				args = []string{"--from-data-dir", cfg.dataDir}
+			}
+
+			var requests int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				http.NotFound(w, r)
+			}))
+			t.Cleanup(srv.Close)
+
+			_, _, err := executeCLI(t, Deps{}, append([]string{"dev", "import-projects", "--url", srv.URL}, args...)...)
+			if err == nil {
+				t.Fatal("dev import-projects --url succeeded, want a refusal")
+			}
+			if requests != 0 {
+				t.Fatalf("refused dev import-projects still contacted the remote daemon (%d requests)", requests)
+			}
+			if code := ExitCode(err); code != 2 {
+				t.Errorf("exit code = %d, want 2 (usage)", code)
+			}
+			if strings.Contains(err.Error(), "source and target data dirs are the same") {
+				t.Errorf("local path resolution ran before the remote refusal: %v", err)
+			}
+			for _, want := range []string{"--url", srv.URL, "ao dev import-projects"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not name %q", err, want)
+				}
+			}
+		})
+	}
+}
+
 func TestDevImportProjectsRefusesSameSourceAndTargetDataDir(t *testing.T) {
 	cfg := setConfigEnv(t)
 	if err := runfile.Write(cfg.runFile, runfile.Info{PID: os.Getpid(), Port: 3002, StartedAt: time.Now()}); err != nil {

--- a/backend/internal/cli/doctor.go
+++ b/backend/internal/cli/doctor.go
@@ -77,6 +77,21 @@ func newDoctorCommand(ctx *commandContext) *cobra.Command {
 		Short: "Run local AO health checks",
 		Args:  noArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Refuse rather than label. Every check but `daemon` reads this
+			// machine's config, filesystem and PATH, so a labelled report
+			// against a remote target is a page of answers to a question the
+			// operator did not ask — and `doctor` is precisely the command they
+			// reach for to ask "is the remote host set up right?". Labelling
+			// would also have to add a host field to --json, changing an output
+			// scripts parse, to keep a report whose one honest line
+			// `ao status --url` already gives.
+			if err := ctx.refuseLocalOnly("ao doctor",
+				"probes the machine running the CLI — its config, data directory, PATH, git, "+
+					"terminal runtime and agent harnesses all describe THIS host, so every check but "+
+					"`daemon` would answer about the wrong machine. Run `ao doctor` on the host running "+
+					"that daemon; to check that daemon's health from here, use `ao status --url`"); err != nil {
+				return err
+			}
 			checks := ctx.runDoctor(cmd.Context())
 			failures := 0
 			for _, check := range checks {

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -336,6 +336,11 @@ func newHooksCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) runHook(ctx context.Context, agent, event string) error {
+	// Before anything else, including reading stdin: a hook reports on a session
+	// owned by the local daemon, so AO_URL is ignored and --url is refused.
+	if err := c.pinToLocalDaemon("ao hooks"); err != nil {
+		return err
+	}
 	if isAgyModernHookEvent(agent, event) {
 		// AGY requires every modern hook handler to return a JSON object, even
 		// when the command is running outside an AO-managed session.
@@ -578,6 +583,21 @@ func (c *commandContext) reportHookFailure(agent, event, sessionID string, cause
 	}
 	line := fmt.Sprintf("%s session=%s %s\n", time.Now().UTC().Format(time.RFC3339), sessionID, msg)
 	appendHooksLog(dataDir, line)
+}
+
+// noteIgnoredRemoteTarget records an AO_URL that pinToLocalDaemon ignored, so
+// an operator debugging a dead activity feed has one place that says so.
+//
+// hooks.log only, deliberately not stderr: an agent's hook runner swallows
+// stderr, and `ao agent-process supervise` shares the user's terminal, where a
+// line on every agent launch would be noise.
+func noteIgnoredRemoteTarget(command, target string) {
+	dataDir := strings.TrimSpace(os.Getenv("AO_DATA_DIR"))
+	if dataDir == "" {
+		return
+	}
+	appendHooksLog(dataDir, fmt.Sprintf("%s %s: AO_URL=%s ignored — daemon-local callback, reported to the local daemon\n",
+		time.Now().UTC().Format(time.RFC3339), command, target))
 }
 
 // appendHooksLog appends one line to the hooks log, truncating first when the

--- a/backend/internal/cli/import.go
+++ b/backend/internal/cli/import.go
@@ -46,6 +46,16 @@ func newImportCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) runImport(cmd *cobra.Command, opts importOptions) error {
+	// Before the run-file check below, which names the LOCAL daemon's pid and
+	// tells the operator to run `ao stop` — advice that cannot be followed with
+	// --url still set, because `ao stop` refuses a remote target outright.
+	if err := c.refuseLocalOnly("ao import",
+		"reads the legacy store on the machine running the CLI and writes THIS machine's AO "+
+			"database directly; it is the one command that never goes through a daemon's HTTP API, "+
+			"so it cannot import anything on that host. Run `ao import` on the machine running that "+
+			"daemon, with that daemon stopped"); err != nil {
+		return err
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return err

--- a/backend/internal/cli/preview.go
+++ b/backend/internal/cli/preview.go
@@ -128,7 +128,7 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) openPreview(ctx context.Context, target string) error {
-	path, err := sessionPreviewPath()
+	path, err := c.sessionPreviewPath()
 	if err != nil {
 		return err
 	}
@@ -138,14 +138,31 @@ func (c *commandContext) openPreview(ctx context.Context, target string) error {
 // clearPreview empties the desktop browser panel for the current session
 // (`ao preview clear`) by deleting the session's stored preview target.
 func (c *commandContext) clearPreview(ctx context.Context) error {
-	path, err := sessionPreviewPath()
+	path, err := c.sessionPreviewPath()
 	if err != nil {
 		return err
 	}
 	return c.deleteJSON(ctx, path, nil)
 }
 
-func sessionPreviewPath() (string, error) {
+// sessionPreviewPath is the single chokepoint for every `ao preview`
+// subcommand, so the remote refusal lives here rather than in five RunEs.
+//
+// `ao preview --url` can never be right, on two counts: AO_SESSION_ID names a
+// session on THIS machine (ids are `<project>-<n>`, which collide across hosts
+// readily), and the panel it drives belongs to the local desktop app, which is
+// not a client of the remote daemon. So even a request that lands sets a
+// preview target nobody will look at — on a stranger's session, if the id
+// happens to exist there. `preview start|status|stop` are blocked at the LAN
+// listener today and report ROUTE_NOT_FOUND, which reads as "that daemon is too
+// old"; they come through here too and now say what is actually wrong.
+func (c *commandContext) sessionPreviewPath() (string, error) {
+	if err := c.refuseLocalOnly("ao preview",
+		"drives the browser panel of the desktop app running on THIS machine, which is not a client "+
+			"of that daemon, and it addresses $AO_SESSION_ID — a session id on this machine. Run "+
+			"`ao preview` from inside a session on the host running that daemon"); err != nil {
+		return "", err
+	}
 	sessionID := strings.TrimSpace(os.Getenv("AO_SESSION_ID"))
 	if sessionID == "" {
 		return "", usageError{errors.New("ao preview must run inside an AO session (AO_SESSION_ID is not set)")}
@@ -155,8 +172,8 @@ func sessionPreviewPath() (string, error) {
 	return "sessions/" + url.PathEscape(sessionID) + "/preview", nil
 }
 
-func previewServerPath() (string, error) {
-	path, err := sessionPreviewPath()
+func (c *commandContext) previewServerPath() (string, error) {
+	path, err := c.sessionPreviewPath()
 	if err != nil {
 		return "", err
 	}
@@ -167,7 +184,7 @@ func (c *commandContext) startPreviewServer(
 	ctx context.Context,
 	configuration string,
 ) (previewServerStatusDTO, error) {
-	path, err := previewServerPath()
+	path, err := c.previewServerPath()
 	if err != nil {
 		return previewServerStatusDTO{}, err
 	}
@@ -188,7 +205,7 @@ func (c *commandContext) startPreviewServer(
 }
 
 func (c *commandContext) previewServerStatus(ctx context.Context) (previewServerStatusDTO, error) {
-	path, err := previewServerPath()
+	path, err := c.previewServerPath()
 	if err != nil {
 		return previewServerStatusDTO{}, err
 	}
@@ -202,7 +219,7 @@ func (c *commandContext) previewServerStatus(ctx context.Context) (previewServer
 }
 
 func (c *commandContext) stopPreviewServer(ctx context.Context) (previewServerStatusDTO, error) {
-	path, err := previewServerPath()
+	path, err := c.previewServerPath()
 	if err != nil {
 		return previewServerStatusDTO{}, err
 	}

--- a/backend/internal/cli/remote.go
+++ b/backend/internal/cli/remote.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+)
+
+// A remote target replaces the local run-file handshake: instead of reading
+// running.json and gating on a live local PID, every daemon call goes to the
+// given base URL carrying the daemon's connection password as a Bearer token —
+// the same credential channel the mobile client uses (ADR 0001).
+//
+// It is opt-in and never inferred: with no --url and no AO_URL, the CLI keeps
+// its loopback-only behavior exactly as before.
+type remoteTarget struct {
+	baseURL string
+	token   string
+	// source names where the URL came from ("--url" or "AO_URL") so an error can
+	// tell the user which one is pointing them off-box.
+	source string
+}
+
+// remotesFileName holds saved remote daemons under the AO home directory. It
+// carries connection passwords in plaintext, so it must be mode 0600.
+const remotesFileName = "remotes.json"
+
+// remotesFile mirrors the mobile app's multi-node store
+// (packages/mobile/lib/config.ts): a list of saved nodes, each labelled, each
+// with its own connection password. The CLI has no OS keystore to split the
+// secret into, so the password lives in the file and the file must be 0600.
+type remotesFile struct {
+	Remotes []remoteEntry `json:"remotes"`
+}
+
+type remoteEntry struct {
+	Label    string `json:"label,omitempty"`
+	URL      string `json:"url"`
+	Password string `json:"password"`
+}
+
+// resolveRemoteTarget resolves the remote daemon this invocation targets, or
+// nil for the default local daemon. The URL comes from --url or AO_URL; the
+// credential from AO_TOKEN or a matching entry in ~/.ao/remotes.json.
+func resolveRemoteTarget(flagURL string) (*remoteTarget, error) {
+	raw, source := strings.TrimSpace(flagURL), "--url"
+	if raw == "" {
+		raw, source = strings.TrimSpace(os.Getenv("AO_URL")), "AO_URL"
+	}
+	if raw == "" {
+		return nil, nil
+	}
+	base, err := normalizeRemoteURL(raw)
+	if err != nil {
+		return nil, err
+	}
+	token := strings.TrimSpace(os.Getenv("AO_TOKEN"))
+	if token == "" {
+		entry, err := lookupRemoteEntry(base)
+		if err != nil {
+			return nil, err
+		}
+		path, _ := remotesFilePath()
+		switch {
+		case entry == nil:
+			return nil, fmt.Errorf("no connection password for %s — set AO_TOKEN or add an entry for it to %s", base, path)
+		case strings.TrimSpace(entry.Password) == "":
+			return nil, fmt.Errorf("the entry for %s in %s has an empty password — set its password, or use AO_TOKEN", base, path)
+		}
+		token = strings.TrimSpace(entry.Password)
+	}
+	return &remoteTarget{baseURL: base, token: token, source: source}, nil
+}
+
+// normalizeRemoteURL turns a user-supplied target into a base URL with no
+// trailing slash. A bare "host:3011" is accepted and assumed plaintext http,
+// matching the LAN listener (ADR 0001 is deliberately http-only).
+func normalizeRemoteURL(raw string) (string, error) {
+	// A URL-embedded credential is never trusted — the connection password comes
+	// from AO_TOKEN or remotes.json. Silently dropping it would leave the user
+	// certain they had passed a password and then told there was none, so say so
+	// instead. Checked first, and reported without quoting the URL, so no later
+	// error path can echo the credential into a message or a log line.
+	if hasUserinfo(raw) {
+		return "", errors.New("invalid daemon URL: it must not carry a username or password — " +
+			"pass the connection password in AO_TOKEN or a ~/.ao/remotes.json entry")
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid daemon URL %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("invalid daemon URL %q: scheme must be http or https", raw)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("invalid daemon URL %q: missing host", raw)
+	}
+	return strings.TrimRight(u.Scheme+"://"+u.Host+u.Path, "/"), nil
+}
+
+// hasUserinfo reports whether raw's authority component carries userinfo. It
+// works textually, before url.Parse, so that a malformed URL cannot slip a
+// credential into the parse error — and it catches the scheme-less form
+// ("user:pw@host:3011") too. An "@" in the path or query is not authority.
+func hasUserinfo(raw string) bool {
+	authority := raw
+	if i := strings.Index(authority, "://"); i >= 0 {
+		authority = authority[i+3:]
+	}
+	if i := strings.IndexAny(authority, "/?#"); i >= 0 {
+		authority = authority[:i]
+	}
+	return strings.Contains(authority, "@")
+}
+
+func remotesFilePath() (string, error) {
+	dir, err := config.StateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, remotesFileName), nil
+}
+
+// lookupRemoteEntry returns the saved entry for base, or nil when the file does
+// not exist or holds no entry for it. A nil entry and an entry with an empty
+// password are different problems, so the caller can say which one it is. A file
+// readable by anyone but the owner is refused rather than used: it is a
+// plaintext credential store.
+func lookupRemoteEntry(base string) (*remoteEntry, error) {
+	path, err := remotesFilePath()
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	// Windows file modes do not carry meaningful group/other bits, so the check
+	// would reject every file there.
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("%s holds connection passwords and is readable by others (mode %04o) — run: chmod 600 %s",
+			path, info.Mode().Perm(), path)
+	}
+	raw, err := os.ReadFile(path) // #nosec G304 -- fixed path under the AO home directory.
+	if err != nil {
+		return nil, err
+	}
+	var file remotesFile
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	for _, entry := range file.Remotes {
+		saved, err := normalizeRemoteURL(entry.URL)
+		if err != nil {
+			continue // a hand-edited entry must not break every other one
+		}
+		if saved == base {
+			return &entry, nil
+		}
+	}
+	return nil, nil
+}
+
+// authorize presents the remote connection password. Loopback calls carry no
+// credential: the local daemon's loopback listener has no auth at all.
+func (c *commandContext) authorize(req *http.Request) {
+	if c.remote != nil {
+		req.Header.Set("Authorization", "Bearer "+c.remote.token)
+	}
+}

--- a/backend/internal/cli/remote.go
+++ b/backend/internal/cli/remote.go
@@ -175,6 +175,81 @@ func lookupRemoteEntry(base string) (*remoteEntry, error) {
 	return nil, nil
 }
 
+// refuseLocalOnly refuses a command that acts on the machine running the CLI
+// and therefore cannot honour a remote target.
+//
+// These commands do not fail against --url: they succeed, on the wrong machine,
+// and say nothing about it. `ao doctor --url` reports the laptop's git, tmux and
+// data dir; `ao import --url` opens the laptop's database; `ao start --url`
+// opens the laptop's desktop app. A command that acts on the wrong host is
+// undetectable after the fact, which is the defect class the other --url
+// refusals cover — so the message names the flag (--url or AO_URL), names the URL
+// it points at, and says where to run the command instead. It never guesses at
+// a remote equivalent.
+//
+// Exit code 2 (usage), like every other --url refusal: passing --url to a command that
+// cannot use it is misuse of a flag, not a runtime failure.
+func (c *commandContext) refuseLocalOnly(command, why string) error {
+	if c.remote == nil {
+		return nil
+	}
+	return usageError{fmt.Errorf("%s targets the remote daemon at %s, but `%s` %s",
+		c.remote.source, c.remote.baseURL, command, why)}
+}
+
+// refuseDaemonURLFlag is refuseLocalOnly for `ao daemon`, narrowed to an
+// explicit --url and deliberately ignoring AO_URL.
+//
+// The one asymmetry among the local-only refusals. An explicit --url is a
+// keystroke and always misuse. AO_URL is an exported shell variable — the very
+// foot-gun a remote-access guide creates — and `ao daemon` is spawned by the
+// desktop app, not typed. Refusing it on AO_URL would take an operator's
+// working remote setup and turn it into a dead desktop app on their own
+// machine, which is worse than the ignored flag this refuses.
+func (c *commandContext) refuseDaemonURLFlag() error {
+	if c.remote == nil || c.remote.source != "--url" {
+		return nil
+	}
+	return c.refuseLocalOnly("ao daemon",
+		"runs a daemon process on the machine executing it and makes no outbound call — "+
+			"there is nothing it could do with that URL. Start the daemon on that host")
+}
+
+// pinToLocalDaemon keeps a daemon-local callback on the local daemon.
+//
+// `ao hooks` and `ao agent-process supervise` are hidden commands an agent
+// process fires at the daemon that started it: they report activity for a
+// session that exists on THIS machine. Sending that to a remote daemon is never
+// right — measured, it reports SESSION_NOT_FOUND and exits 0, so the local UI's
+// activity feed simply goes dead while the agent keeps working.
+//
+// The split is the same one refuseDaemonURLFlag makes, for the same reason, and
+// it is the whole point of this helper:
+//
+//   - AO_URL is ignored. These commands are spawned by the harness, not typed,
+//     and an operator who exports AO_URL in a shell profile — the natural thing
+//     to do after reading the remote-access guide — must not have every local
+//     agent broken by it. Refusing here would break the user's agent, the exact
+//     thing hooks are designed never to do. The ignore is logged to hooks.log so
+//     it is discoverable rather than silent.
+//   - An explicit --url is refused (exit 2). A typed flag on a hidden,
+//     agent-invoked command is misuse, and nothing in AO constructs one:
+//     session_manager builds the supervise argv itself, with fixed arguments.
+func (c *commandContext) pinToLocalDaemon(command string) error {
+	if c.remote == nil {
+		return nil
+	}
+	if c.remote.source == "--url" {
+		return c.refuseLocalOnly(command,
+			"reports on a session owned by the daemon that started it, so it can only ever mean the local "+
+				"daemon — there is no remote form. Drop the flag")
+	}
+	target := c.remote.baseURL
+	c.remote = nil
+	noteIgnoredRemoteTarget(command, target)
+	return nil
+}
+
 // authorize presents the remote connection password. Loopback calls carry no
 // credential: the local daemon's loopback listener has no auth at all.
 func (c *commandContext) authorize(req *http.Request) {

--- a/backend/internal/cli/remote_callbacks_test.go
+++ b/backend/internal/cli/remote_callbacks_test.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"errors"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The daemon-local callbacks — `ao hooks` and `ao agent-process supervise` —
+// report on a session owned by the daemon on THIS machine. They must never
+// follow a remote target.
+//
+// Every assertion below that matters is on the REMOTE request log being empty.
+// Output cannot distinguish "ignored the remote target" from "sent to the wrong
+// host and got a plausible answer": measured, a hook against a remote daemon
+// prints SESSION_NOT_FOUND and exits 0, which is indistinguishable from a
+// harmless no-op unless you count requests.
+
+// countingRemote is a stand-in remote daemon that answers nothing and counts
+// every request that reaches it.
+func countingRemote(t *testing.T) (*httptest.Server, *int) {
+	t.Helper()
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// superviseArgs builds an `ao agent-process supervise` invocation. The child is
+// deliberately a command that exists on no OS: the supervisor publishes the
+// exit report whether the child fails to start or runs to completion
+// (runSupervisedProcess calls reportSupervisedExit on both paths), and WHERE
+// that report goes is the whole subject of these tests. Nothing is spawned, so
+// there is no binary to build, no PATH assumption, and no per-OS command.
+func superviseArgs(extra ...string) []string {
+	args := []string{"agent-process", "supervise", "--session", "ao-7", "--launch", "launch-1"}
+	args = append(args, extra...)
+	return append(args, "--", "ao-test-no-such-agent-command")
+}
+
+func hooksLogContents(t *testing.T, cfg testConfig) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(cfg.dataDir, hooksLogName))
+	if err != nil {
+		t.Fatalf("hooks.log not written: %v", err)
+	}
+	return string(data)
+}
+
+func requireNoHooksLog(t *testing.T, cfg testConfig) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(cfg.dataDir, hooksLogName))
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("hooks.log should not exist, got err=%v data=%q", err, data)
+	}
+}
+
+// An exported AO_URL is ignored, not obeyed and not refused: these commands are
+// spawned by the harness, so refusing would break the user's agent — the one
+// thing hooks are designed never to do. The report goes to the LOCAL daemon and
+// the ignore is recorded in hooks.log.
+func TestDaemonLocalCallbacksIgnoreAOURL(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantLog string
+	}{
+		{"hooks", []string{"hooks", "claude-code", "session-end"}, "ao hooks"},
+		{"agent-process supervise", superviseArgs(), "ao agent-process supervise"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			aoHome(t)
+			cfg := setConfigEnv(t)
+			t.Setenv("AO_SESSION_ID", "ao-7")
+			t.Setenv("AO_TOKEN", "tok")
+			remote, remoteHits := countingRemote(t)
+			t.Setenv("AO_URL", remote.URL)
+
+			local, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+			writeRunFileFor(t, cfg, local)
+
+			_, errOut, err := executeCLI(t, Deps{
+				In:           strings.NewReader(`{"reason":"logout"}`),
+				ProcessAlive: func(int) bool { return true },
+			}, tc.args...)
+			if err != nil {
+				t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+			}
+			if *remoteHits != 0 {
+				t.Errorf("%d request(s) reached the remote daemon, want 0", *remoteHits)
+			}
+			if capture.hits != 1 {
+				t.Fatalf("local daemon got %d activity request(s), want 1", capture.hits)
+			}
+			if capture.path != "/api/v1/sessions/ao-7/activity" {
+				t.Errorf("path = %q, want /api/v1/sessions/ao-7/activity", capture.path)
+			}
+			log := hooksLogContents(t, cfg)
+			for _, want := range []string{tc.wantLog, "AO_URL=" + remote.URL, "ignored"} {
+				if !strings.Contains(log, want) {
+					t.Errorf("hooks.log missing %q:\n%s", want, log)
+				}
+			}
+		})
+	}
+}
+
+// A typed --url on a hidden, agent-invoked command is always misuse: refuse it,
+// exit 2, and name the flag and the URL. Nothing is sent anywhere, and for
+// supervise the child process is never started.
+func TestDaemonLocalCallbacksRefuseURLFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    func(url string) []string
+		wantCmd string
+	}{
+		{
+			name:    "hooks",
+			args:    func(url string) []string { return []string{"hooks", "claude-code", "session-end", "--url", url} },
+			wantCmd: "ao hooks",
+		},
+		{
+			name:    "agent-process supervise",
+			args:    func(url string) []string { return superviseArgs("--url", url) },
+			wantCmd: "ao agent-process supervise",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			aoHome(t)
+			cfg := setConfigEnv(t)
+			t.Setenv("AO_SESSION_ID", "ao-7")
+			t.Setenv("AO_TOKEN", "tok")
+			remote, remoteHits := countingRemote(t)
+
+			local, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+			writeRunFileFor(t, cfg, local)
+
+			_, _, err := executeCLI(t, Deps{
+				In:           strings.NewReader(`{"reason":"logout"}`),
+				ProcessAlive: func(int) bool { return true },
+			}, tc.args(remote.URL)...)
+			if err == nil {
+				t.Fatalf("%s --url succeeded, want a refusal", tc.wantCmd)
+			}
+			for _, want := range []string{"--url", remote.URL, tc.wantCmd} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not name %q", err, want)
+				}
+			}
+			if got := ExitCode(err); got != 2 {
+				t.Errorf("exit code = %d, want 2 (usage)", got)
+			}
+			if *remoteHits != 0 {
+				t.Errorf("%d request(s) reached the remote daemon, want 0", *remoteHits)
+			}
+			if capture.hits != 0 {
+				t.Errorf("%d request(s) reached the local daemon, want 0", capture.hits)
+			}
+			// A refusal is not an ignore, so it leaves no ignore line behind.
+			requireNoHooksLog(t, cfg)
+		})
+	}
+}
+
+// The property that must not regress: an ignored AO_URL plus a dead local
+// daemon still exits 0. Both facts land in hooks.log.
+func TestDaemonLocalCallbacksStayBestEffortUnderIgnoredAOURL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"hooks", []string{"hooks", "claude-code", "session-end"}},
+		{"agent-process supervise", superviseArgs()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			aoHome(t)
+			cfg := setConfigEnv(t) // no run-file: the local daemon is down
+			t.Setenv("AO_SESSION_ID", "ao-7")
+			t.Setenv("AO_TOKEN", "tok")
+			remote, remoteHits := countingRemote(t)
+			t.Setenv("AO_URL", remote.URL)
+
+			_, _, err := executeCLI(t, Deps{
+				In: strings.NewReader(`{"reason":"logout"}`),
+			}, tc.args...)
+			if err != nil {
+				t.Fatalf("must exit 0 when the local daemon is down, got: %v", err)
+			}
+			if *remoteHits != 0 {
+				t.Errorf("%d request(s) reached the remote daemon, want 0", *remoteHits)
+			}
+			log := hooksLogContents(t, cfg)
+			for _, want := range []string{"AO_URL=" + remote.URL, "not running"} {
+				if !strings.Contains(log, want) {
+					t.Errorf("hooks.log missing %q:\n%s", want, log)
+				}
+			}
+		})
+	}
+}
+
+// With no remote target, behavior is what it was: the report reaches the local
+// daemon and nothing is written to hooks.log.
+func TestDaemonLocalCallbacksUnchangedWithoutRemoteTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"hooks", []string{"hooks", "claude-code", "session-end"}},
+		{"agent-process supervise", superviseArgs()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			aoHome(t) // clears AO_URL / AO_TOKEN
+			cfg := setConfigEnv(t)
+			t.Setenv("AO_SESSION_ID", "ao-7")
+			local, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+			writeRunFileFor(t, cfg, local)
+
+			_, errOut, err := executeCLI(t, Deps{
+				In:           strings.NewReader(`{"reason":"logout"}`),
+				ProcessAlive: func(int) bool { return true },
+			}, tc.args...)
+			if err != nil {
+				t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+			}
+			if capture.hits != 1 || capture.path != "/api/v1/sessions/ao-7/activity" {
+				t.Fatalf("local daemon got %d request(s) at %q, want 1 at /api/v1/sessions/ao-7/activity",
+					capture.hits, capture.path)
+			}
+			requireNoHooksLog(t, cfg)
+		})
+	}
+}

--- a/backend/internal/cli/remote_test.go
+++ b/backend/internal/cli/remote_test.go
@@ -1,0 +1,447 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/daemonmeta"
+	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+)
+
+// aoHome points the AO home directory (and therefore remotes.json) at a temp
+// dir, and clears the remote env vars so a developer's real AO_URL/AO_TOKEN
+// cannot leak into a test.
+func aoHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // os.UserHomeDir on Windows
+	t.Setenv("AO_URL", "")
+	t.Setenv("AO_TOKEN", "")
+	return dir
+}
+
+func writeRemotes(t *testing.T, home string, perm os.FileMode, entries ...remoteEntry) {
+	t.Helper()
+	raw, err := json.Marshal(remotesFile{Remotes: entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".ao"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".ao", remotesFileName)
+	if err := os.WriteFile(path, raw, perm); err != nil {
+		t.Fatal(err)
+	}
+	// WriteFile honors umask, so force the mode the test asked for.
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNormalizeRemoteURL(t *testing.T) {
+	ok := map[string]string{
+		"http://host:3011":         "http://host:3011",
+		"http://host:3011/":        "http://host:3011",
+		"host:3011":                "http://host:3011", // bare host defaults to plaintext http
+		"https://box.ts.net":       "https://box.ts.net",
+		"http://host:3011/ao/":     "http://host:3011/ao",
+		"HTTP://Host:3011":         "http://Host:3011",
+		"http://100.64.0.1:3011//": "http://100.64.0.1:3011",
+	}
+	for in, want := range ok {
+		got, err := normalizeRemoteURL(in)
+		if err != nil {
+			t.Fatalf("normalizeRemoteURL(%q): %v", in, err)
+		}
+		if got != want {
+			t.Errorf("normalizeRemoteURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+	for _, in := range []string{"ftp://host", "ws://host:3011", "http://", "://x"} {
+		if got, err := normalizeRemoteURL(in); err == nil {
+			t.Errorf("normalizeRemoteURL(%q) = %q, want error", in, got)
+		}
+	}
+
+	// An "@" outside the authority is not userinfo and must still parse.
+	for _, in := range []string{"http://host:3011/a@b", "http://host:3011/x?q=a@b"} {
+		if _, err := normalizeRemoteURL(in); err != nil {
+			t.Errorf("normalizeRemoteURL(%q): %v", in, err)
+		}
+	}
+}
+
+// A credential typed into the URL is rejected outright rather than silently
+// dropped — and the error must never echo it back.
+func TestNormalizeRemoteURLRejectsUserinfo(t *testing.T) {
+	for _, in := range []string{
+		"http://user:hunter2@host:3011",
+		"https://user:hunter2@host:3011/path",
+		"user:hunter2@host:3011", // scheme-less form
+		"http://hunter2@host:3011",
+	} {
+		_, err := normalizeRemoteURL(in)
+		if err == nil {
+			t.Fatalf("normalizeRemoteURL(%q) succeeded, want a userinfo rejection", in)
+		}
+		if !strings.Contains(err.Error(), "must not carry a username or password") {
+			t.Errorf("normalizeRemoteURL(%q) error = %q, want a userinfo rejection", in, err)
+		}
+		if strings.Contains(err.Error(), "hunter2") {
+			t.Errorf("normalizeRemoteURL(%q) echoed the credential: %q", in, err)
+		}
+	}
+}
+
+// The same rejection must reach the user through the real resolution path, with
+// the credential still absent from the message.
+func TestResolveRemoteTargetRejectsUserinfo(t *testing.T) {
+	aoHome(t)
+	_, err := resolveRemoteTarget("http://user:hunter2@host:3011")
+	if err == nil || strings.Contains(err.Error(), "hunter2") {
+		t.Fatalf("err = %v, want a rejection that does not echo the password", err)
+	}
+}
+
+// No --url and no AO_URL must resolve to nil: that is what keeps every local
+// invocation on the run-file path it has always used.
+func TestResolveRemoteTargetDefaultsToLocal(t *testing.T) {
+	aoHome(t)
+	got, err := resolveRemoteTarget("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("resolveRemoteTarget = %+v, want nil (local)", got)
+	}
+}
+
+func TestResolveRemoteTargetCredentialSources(t *testing.T) {
+	t.Run("AO_TOKEN wins over remotes.json", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600, remoteEntry{URL: "http://host:3011", Password: "fromfile"})
+		t.Setenv("AO_TOKEN", "fromenv")
+
+		got, err := resolveRemoteTarget("http://host:3011")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.token != "fromenv" || got.baseURL != "http://host:3011" || got.source != "--url" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("remotes.json entry matched by URL", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600,
+			remoteEntry{Label: "other", URL: "http://elsewhere:3011", Password: "nope"},
+			// Stored with a trailing slash: matching is on the normalized URL.
+			remoteEntry{Label: "desk", URL: "http://host:3011/", Password: "s3cret12"},
+		)
+		got, err := resolveRemoteTarget("host:3011")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.token != "s3cret12" {
+			t.Fatalf("token = %q, want s3cret12", got.token)
+		}
+	})
+
+	t.Run("AO_URL when no flag", func(t *testing.T) {
+		aoHome(t)
+		t.Setenv("AO_URL", "http://host:3011")
+		t.Setenv("AO_TOKEN", "tok")
+
+		got, err := resolveRemoteTarget("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.source != "AO_URL" {
+			t.Fatalf("source = %q, want AO_URL", got.source)
+		}
+	})
+
+	t.Run("no credential is an error", func(t *testing.T) {
+		aoHome(t)
+		_, err := resolveRemoteTarget("http://host:3011")
+		if err == nil || !strings.Contains(err.Error(), "AO_TOKEN") {
+			t.Fatalf("err = %v, want a missing-credential error naming AO_TOKEN", err)
+		}
+	})
+
+	t.Run("unknown host in remotes.json is an error", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600, remoteEntry{URL: "http://elsewhere:3011", Password: "nope"})
+		_, err := resolveRemoteTarget("http://host:3011")
+		if err == nil || !strings.Contains(err.Error(), "no connection password") {
+			t.Fatalf("err = %v, want the missing-entry error", err)
+		}
+	})
+
+	// An entry that exists but carries no password is a different problem from
+	// no entry at all, and must not be told to add the entry it already has.
+	t.Run("matching entry with an empty password says so", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600, remoteEntry{Label: "desk", URL: "http://host:3011", Password: ""})
+		_, err := resolveRemoteTarget("http://host:3011")
+		if err == nil {
+			t.Fatal("want an error for an entry with an empty password")
+		}
+		if !strings.Contains(err.Error(), "has an empty password") {
+			t.Fatalf("err = %q, want it to name the empty password", err)
+		}
+		if strings.Contains(err.Error(), "add an entry") {
+			t.Fatalf("err = %q, must not tell the user to add an entry that already exists", err)
+		}
+	})
+}
+
+// remotes.json holds connection passwords in plaintext, so a group/other
+// readable file is refused rather than silently used.
+func TestResolveRemoteTargetRejectsLooseRemotesFilePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits are not meaningful on Windows")
+	}
+	home := aoHome(t)
+	writeRemotes(t, home, 0o644, remoteEntry{URL: "http://host:3011", Password: "s3cret12"})
+
+	_, err := resolveRemoteTarget("http://host:3011")
+	if err == nil || !strings.Contains(err.Error(), "chmod 600") {
+		t.Fatalf("err = %v, want a permissions refusal", err)
+	}
+}
+
+// With no remote target, daemonBase must still go through the run-file and the
+// local liveness gate — byte-identical to the pre-remote behavior.
+func TestDaemonBaseLocalUsesRunFile(t *testing.T) {
+	dir := aoHome(t)
+	runFile := filepath.Join(dir, "running.json")
+	t.Setenv("AO_RUN_FILE", runFile)
+	t.Setenv("AO_DATA_DIR", filepath.Join(dir, "data"))
+
+	c := &commandContext{deps: Deps{ProcessAlive: func(int) bool { return true }}.withDefaults()}
+
+	if _, err := c.daemonBase(); err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("err = %v, want 'not running' with no run-file", err)
+	}
+
+	if err := runfile.Write(runFile, runfile.Info{PID: 4242, Port: 3999, StartedAt: time.Unix(100, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+	base, err := c.daemonBase()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base != "http://127.0.0.1:3999" {
+		t.Fatalf("base = %q, want the loopback daemon URL", base)
+	}
+
+	dead := &commandContext{deps: Deps{ProcessAlive: func(int) bool { return false }}.withDefaults()}
+	if _, err := dead.daemonBase(); err == nil || !strings.Contains(err.Error(), "stale run-file") {
+		t.Fatalf("err = %v, want the stale run-file error", err)
+	}
+}
+
+// A remote target skips the run-file read and the local ProcessAlive gate
+// entirely: neither exists on the machine running the command.
+func TestDaemonBaseRemoteSkipsRunFile(t *testing.T) {
+	dir := aoHome(t)
+	t.Setenv("AO_RUN_FILE", filepath.Join(dir, "no-such-running.json"))
+
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("ProcessAlive must not be consulted for a remote"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "--url"},
+	}
+	base, err := c.daemonBase()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base != "http://host:3011" {
+		t.Fatalf("base = %q", base)
+	}
+}
+
+// `ao status --url ...` must work on a machine with no local run file at all,
+// and must present the connection password as a Bearer token.
+func TestStatusRemoteWithoutLocalRunFile(t *testing.T) {
+	dir := aoHome(t)
+	t.Setenv("AO_RUN_FILE", filepath.Join(dir, "no-such-running.json"))
+
+	var gotAuth []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		status := "ok"
+		if r.URL.Path == "/readyz" {
+			status = "ready"
+		}
+		_ = json.NewEncoder(w).Encode(probeResult{Status: status, Service: daemonmeta.ServiceName, PID: 777})
+	}))
+	defer srv.Close()
+
+	t.Setenv("AO_TOKEN", "s3cret12")
+	var out bytes.Buffer
+	err := executeWithDeps(Deps{
+		Out: &out,
+		Err: &out,
+		// A remote invocation must never consult local process liveness.
+		ProcessAlive: func(int) bool { t.Error("ProcessAlive called for a remote target"); return false },
+	}, []string{"status", "--url", srv.URL})
+	if err != nil {
+		t.Fatalf("ao status --url: %v\n%s", err, out.String())
+	}
+
+	if want := []string{"Bearer s3cret12", "Bearer s3cret12"}; len(gotAuth) != 2 || gotAuth[0] != want[0] || gotAuth[1] != want[1] {
+		t.Fatalf("Authorization headers = %q, want %q", gotAuth, want)
+	}
+	for _, want := range []string{"AO daemon: ready", "url: " + srv.URL, "pid: 777"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("status output missing %q:\n%s", want, out.String())
+		}
+	}
+	// There is no local run-file or data dir to report for a remote daemon.
+	if strings.Contains(out.String(), "run file:") {
+		t.Fatalf("remote status reported a local run file:\n%s", out.String())
+	}
+}
+
+// A daemon that answers but is not ours must not be reported as a healthy AO.
+func TestStatusRemoteRejectsForeignService(t *testing.T) {
+	aoHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(probeResult{Status: "ok", Service: "something-else"})
+	}))
+	defer srv.Close()
+
+	c := &commandContext{
+		deps:   Deps{}.withDefaults(),
+		remote: &remoteTarget{baseURL: srv.URL, token: "tok"},
+	}
+	st := c.inspectRemoteDaemon(context.Background())
+	if st.State != stateUnhealthy || !strings.Contains(st.Error, "not from AO daemon") {
+		t.Fatalf("state = %q, error = %q", st.State, st.Error)
+	}
+}
+
+// A 429 from a remote daemon is the LAN listener's per-source lockout, not an
+// unhealthy daemon. Reporting it as "unhealthy" inverts the diagnosis.
+func TestStatusRemoteReportsLockoutDistinctly(t *testing.T) {
+	aoHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := &commandContext{
+		deps:   Deps{}.withDefaults(),
+		remote: &remoteTarget{baseURL: srv.URL, token: "tok"},
+	}
+	st := c.inspectRemoteDaemon(context.Background())
+	if st.State != stateLockedOut {
+		t.Fatalf("state = %q, want %q", st.State, stateLockedOut)
+	}
+	if !strings.Contains(st.Error, "locked out") {
+		t.Fatalf("error = %q, want it to name the lockout", st.Error)
+	}
+	// The whole point: it must not send the user to debug a healthy daemon.
+	if strings.Contains(string(st.State), "unhealthy") || strings.Contains(st.Error, "HTTP 429") {
+		t.Fatalf("lockout still rendered as a daemon fault: state=%q error=%q", st.State, st.Error)
+	}
+}
+
+// ...and the LOCAL path must render the very same 429 exactly as before. The
+// lockout cannot occur on loopback, so nothing about local status may change.
+func TestStatusLocalUnchangedForSameHTTPStatus(t *testing.T) {
+	dir := aoHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	port, err := strconv.Atoi(srv.URL[strings.LastIndex(srv.URL, ":")+1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	runFile := filepath.Join(dir, "running.json")
+	t.Setenv("AO_RUN_FILE", runFile)
+	t.Setenv("AO_DATA_DIR", filepath.Join(dir, "data"))
+	if err := runfile.Write(runFile, runfile.Info{PID: os.Getpid(), Port: port, StartedAt: time.Unix(100, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &commandContext{deps: Deps{
+		ProcessAlive: func(int) bool { return true },
+		Now:          func() time.Time { return time.Unix(200, 0).UTC() },
+	}.withDefaults()}
+
+	st, err := c.inspectDaemon(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != stateUnhealthy {
+		t.Fatalf("local state = %q, want unhealthy (unchanged)", st.State)
+	}
+	if st.Error != "healthz: HTTP 429" {
+		t.Fatalf("local error = %q, want the byte-identical %q", st.Error, "healthz: HTTP 429")
+	}
+}
+
+// A stray --url must never shut down someone else's daemon.
+func TestStopRefusesRemoteTarget(t *testing.T) {
+	aoHome(t)
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("stop must refuse before touching local state"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "AO_URL"},
+	}
+	_, err := c.stopDaemon(context.Background(), stopOptions{})
+	if err == nil {
+		t.Fatal("ao stop --url must refuse")
+	}
+	for _, want := range []string{"refusing to stop a remote daemon", "AO_URL", "http://host:3011"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+	// The message must not assert anything about what the target exposes: a
+	// loopback --url refuses too, and there /shutdown IS reachable.
+	if strings.Contains(err.Error(), "/shutdown") {
+		t.Fatalf("error %q claims something about the target's routes", err.Error())
+	}
+}
+
+// The refusal is unconditional: a --url that happens to name loopback is still
+// not the daemon `ao stop` discovered locally, and must not be stopped.
+func TestStopRefusesLoopbackURLToo(t *testing.T) {
+	aoHome(t)
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("stop must refuse before touching local state"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://127.0.0.1:3001", token: "tok", source: "--url"},
+	}
+	if _, err := c.stopDaemon(context.Background(), stopOptions{}); err == nil {
+		t.Fatal("ao stop --url http://127.0.0.1:3001 must refuse")
+	}
+}
+
+// CLI telemetry posts to loopback-only /internal routes, which are 404'd at the
+// LAN socket — and must not be sent to another machine's daemon regardless.
+func TestPostLoopbackJSONSkippedForRemote(t *testing.T) {
+	aoHome(t)
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("telemetry must not reach a remote daemon"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok"},
+	}
+	if err := c.postLoopbackJSON(context.Background(), "/internal/telemetry/cli-invoked", map[string]string{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/cli/remote_test.go
+++ b/backend/internal/cli/remote_test.go
@@ -445,3 +445,129 @@ func TestPostLoopbackJSONSkippedForRemote(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// refuseLocalOnly is the whole point of the local-only refusals: the operator
+// must be able to see, from the message alone, which flag pointed them off-box
+// and where it pointed. Exit code 2, like every other --url refusal.
+func TestRefuseLocalOnlyNamesFlagAndURL(t *testing.T) {
+	local := &commandContext{deps: Deps{}.withDefaults()}
+	if err := local.refuseLocalOnly("ao doctor", "is local"); err != nil {
+		t.Fatalf("local refuseLocalOnly = %v, want nil (local behavior must not change)", err)
+	}
+	if err := local.refuseDaemonURLFlag(); err != nil {
+		t.Fatalf("local refuseDaemonURLFlag = %v, want nil", err)
+	}
+
+	for _, source := range []string{"--url", "AO_URL"} {
+		remote := &commandContext{
+			deps:   Deps{}.withDefaults(),
+			remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: source},
+		}
+		err := remote.refuseLocalOnly("ao doctor", "probes this machine")
+		if err == nil {
+			t.Fatalf("source %s: refuseLocalOnly = nil, want a refusal", source)
+		}
+		for _, want := range []string{source, "http://host:3011", "ao doctor", "probes this machine"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("source %s: error %q does not name %q", source, err, want)
+			}
+		}
+		if got := ExitCode(err); got != 2 {
+			t.Errorf("source %s: exit code = %d, want 2 (usage)", source, got)
+		}
+	}
+
+	// `ao daemon` alone refuses the flag and ignores the environment variable:
+	// it is spawned by the desktop app, so an exported AO_URL must not brick it.
+	flagged := &commandContext{
+		deps:   Deps{}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "--url"},
+	}
+	if err := flagged.refuseDaemonURLFlag(); err == nil {
+		t.Error("refuseDaemonURLFlag with --url = nil, want a refusal")
+	}
+	exported := &commandContext{
+		deps:   Deps{}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "AO_URL"},
+	}
+	if err := exported.refuseDaemonURLFlag(); err != nil {
+		t.Errorf("refuseDaemonURLFlag with AO_URL = %v, want nil (must not brick a spawned daemon)", err)
+	}
+}
+
+// End to end: each command that acts only on this machine must refuse --url
+// before it reaches the network. The real assertion is the EMPTY request log —
+// `ao preview --url` reaching a remote daemon sets a preview target on a session
+// that is not the operator's, and nothing in its output would say so.
+//
+// Deliberately path-free (no filepath, no t.Chdir, no absolute-path literals):
+// judging a path with filepath.IsAbs is a Windows-only break waiting to happen,
+// so these assert identically on every runner OS.
+func TestLocalOnlyCommandsRefuseRemoteTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"doctor", []string{"doctor"}},
+		{"preview", []string{"preview", "README.md"}},
+		{"preview clear", []string{"preview", "clear"}},
+		{"preview status", []string{"preview", "status"}},
+		{"import", []string{"import", "--yes"}},
+		{"start", []string{"start"}},
+		{"daemon", []string{"daemon"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			aoHome(t)
+			setConfigEnv(t)
+			// Set, to prove the refusal beats the local session id rather than
+			// falling out of preview's "not inside a session" error.
+			t.Setenv("AO_SESSION_ID", "local-1")
+			t.Setenv("AO_TOKEN", "tok")
+
+			var requests int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				http.NotFound(w, r)
+			}))
+			t.Cleanup(srv.Close)
+
+			_, _, err := executeCLI(t, Deps{}, append(tc.args, "--url", srv.URL)...)
+			if err == nil {
+				t.Fatalf("ao %s --url succeeded, want a refusal", strings.Join(tc.args, " "))
+			}
+			if !strings.Contains(err.Error(), "targets the remote daemon at "+srv.URL) {
+				t.Fatalf("error = %v, want it to name --url and %s", err, srv.URL)
+			}
+			if got := ExitCode(err); got != 2 {
+				t.Errorf("exit code = %d, want 2 (usage)", got)
+			}
+			if requests != 0 {
+				t.Errorf("%d request(s) reached the remote daemon, want 0", requests)
+			}
+		})
+	}
+}
+
+// Local behavior is untouched: with no remote target, every one of these
+// commands must fail (or not) for exactly the reasons it did before.
+func TestLocalOnlyCommandsUnchangedWithoutRemoteTarget(t *testing.T) {
+	aoHome(t)
+	setConfigEnv(t)
+	t.Setenv("AO_SESSION_ID", "")
+
+	// preview still reports the missing session id, not a remote refusal.
+	_, _, err := executeCLI(t, Deps{}, "preview", "README.md")
+	if err == nil || !strings.Contains(err.Error(), "AO_SESSION_ID is not set") {
+		t.Fatalf("local ao preview error = %v, want the missing-session-id usage error", err)
+	}
+
+	// doctor still runs its checks. Which ones pass depends on the runner, so
+	// the assertion is only that it did not refuse and did print a report.
+	out, _, err := executeCLI(t, Deps{}, "doctor")
+	if err != nil && strings.Contains(err.Error(), "targets the remote daemon") {
+		t.Fatalf("local ao doctor refused: %v", err)
+	}
+	if !strings.Contains(out, "Core:") {
+		t.Fatalf("local ao doctor output = %q, want the Core section", out)
+	}
+}

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -197,7 +197,7 @@ func NewRootCommand(deps Deps) *cobra.Command {
 		return usageError{err}
 	})
 
-	root.AddCommand(newDaemonCommand())
+	root.AddCommand(newDaemonCommand(ctx))
 	root.AddCommand(newStartCommand(ctx))
 	root.AddCommand(newStopCommand(ctx))
 	root.AddCommand(newStatusCommand(ctx))
@@ -333,13 +333,17 @@ func atMostOneArg(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func newDaemonCommand() *cobra.Command {
+func newDaemonCommand(ctx *commandContext) *cobra.Command {
 	return &cobra.Command{
 		Use:    "daemon",
 		Short:  "Run the AO backend daemon",
 		Hidden: true,
 		Args:   noArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Flag-only, not AO_URL — see refuseDaemonURLFlag.
+			if err := ctx.refuseDaemonURLFlag(); err != nil {
+				return err
+			}
 			return daemon.Run()
 		},
 	}

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -162,6 +162,7 @@ func (d Deps) withDefaults() Deps {
 func NewRootCommand(deps Deps) *cobra.Command {
 	deps = deps.withDefaults()
 	ctx := &commandContext{deps: deps}
+	var remoteURL string
 
 	root := &cobra.Command{
 		Use:           "ao",
@@ -171,12 +172,21 @@ func NewRootCommand(deps Deps) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Resolve before anything else: every daemon call below, telemetry
+			// included, depends on which daemon this invocation targets.
+			remote, err := resolveRemoteTarget(remoteURL)
+			if err != nil {
+				return err
+			}
+			ctx.remote = remote
 			if shouldEmitCLIInvocation(cmd) {
 				ctx.emitCLIInvoked(cmd.Context(), cmd)
 			}
 			return nil
 		},
 	}
+	root.PersistentFlags().StringVar(&remoteURL, "url", "",
+		"Base URL of a remote AO daemon, e.g. http://host:3011 (env AO_URL); credential from AO_TOKEN or ~/.ao/remotes.json")
 	root.SetIn(deps.In)
 	root.SetOut(deps.Out)
 	root.SetErr(deps.Err)
@@ -217,6 +227,8 @@ func NewRootCommand(deps Deps) *cobra.Command {
 
 type commandContext struct {
 	deps Deps
+	// remote is nil for the default local daemon; see remote.go.
+	remote *remoteTarget
 }
 
 func shouldEmitCLIInvocation(cmd *cobra.Command) bool {

--- a/backend/internal/cli/start.go
+++ b/backend/internal/cli/start.go
@@ -85,6 +85,12 @@ func newStartCommand(ctx *commandContext) *cobra.Command {
 // it if absent, open it, then print the deprecation notice. It never blocks or
 // supervises the launched app.
 func (c *commandContext) runStart(ctx context.Context, cmd *cobra.Command, opts startOptions) error {
+	if err := c.refuseLocalOnly("ao start",
+		"resolves and opens the desktop app installed on the machine running the CLI, and that app "+
+			"owns its own local daemon — it can neither start nor reach a daemon on that host. Open "+
+			"the desktop app on the machine running that daemon"); err != nil {
+		return err
+	}
 	out := cmd.OutOrStdout()
 	res := startResult{}
 

--- a/backend/internal/cli/status.go
+++ b/backend/internal/cli/status.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -28,7 +29,22 @@ const (
 	stateStale     daemonState = "stale"
 	stateUnhealthy daemonState = "unhealthy"
 	stateNotReady  daemonState = "not_ready"
+	// stateLockedOut is reachable only for a remote target: the per-source
+	// lockout lives in the LAN listener's auth middleware, which the loopback
+	// path never reaches. See remoteProbeFailure.
+	stateLockedOut daemonState = "locked_out"
 )
+
+// probeHTTPError is a non-2xx probe response. Its message is deliberately
+// identical to the plain error it replaces, so the local path renders
+// byte-for-byte as before; it exists so the remote path can read the status code
+// back out and tell a lockout apart from an unhealthy daemon.
+type probeHTTPError struct {
+	path   string
+	status int
+}
+
+func (e probeHTTPError) Error() string { return fmt.Sprintf("%s: HTTP %d", e.path, e.status) }
 
 type daemonStatus struct {
 	State     daemonState `json:"state"`
@@ -36,12 +52,15 @@ type daemonStatus struct {
 	Port      int         `json:"port,omitempty"`
 	StartedAt *time.Time  `json:"startedAt,omitempty"`
 	Uptime    string      `json:"uptime,omitempty"`
-	RunFile   string      `json:"runFile"`
-	DataDir   string      `json:"dataDir"`
-	Health    string      `json:"health,omitempty"`
-	Ready     string      `json:"ready,omitempty"`
-	Error     string      `json:"error,omitempty"`
-	owned     bool
+	RunFile   string      `json:"runFile,omitempty"`
+	DataDir   string      `json:"dataDir,omitempty"`
+	// URL is set only for a remote target, where there is no local run-file or
+	// data dir to report.
+	URL    string `json:"url,omitempty"`
+	Health string `json:"health,omitempty"`
+	Ready  string `json:"ready,omitempty"`
+	Error  string `json:"error,omitempty"`
+	owned  bool
 }
 
 type probeResult struct {
@@ -74,6 +93,9 @@ func newStatusCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error) {
+	if c.remote != nil {
+		return c.inspectRemoteDaemon(ctx), nil
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return daemonStatus{}, err
@@ -100,7 +122,7 @@ func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error
 		return st, nil
 	}
 
-	health, err := c.readProbe(ctx, info.Port, "healthz")
+	health, err := c.readProbe(ctx, loopbackBase(info.Port), "healthz")
 	if err != nil {
 		st.State = stateUnhealthy
 		st.Error = err.Error()
@@ -118,7 +140,7 @@ func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error
 		return st, nil
 	}
 
-	ready, err := c.readProbe(ctx, info.Port, "readyz")
+	ready, err := c.readProbe(ctx, loopbackBase(info.Port), "readyz")
 	if err != nil {
 		st.State = stateNotReady
 		st.Error = err.Error()
@@ -139,21 +161,81 @@ func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error
 	return st, nil
 }
 
-func (c *commandContext) readProbe(ctx context.Context, port int, path string) (probeResult, error) {
+func loopbackBase(port int) string {
+	return fmt.Sprintf("http://%s:%d", config.LoopbackHost, port)
+}
+
+// inspectRemoteDaemon reports the state of a daemon reached over the network.
+// There is no run-file and no local PID to gate on, so liveness comes entirely
+// from the authenticated /healthz and /readyz probes.
+func (c *commandContext) inspectRemoteDaemon(ctx context.Context) daemonStatus {
+	st := daemonStatus{State: stateStopped, URL: c.remote.baseURL}
+
+	health, err := c.readProbe(ctx, c.remote.baseURL, "healthz")
+	if err != nil {
+		return remoteProbeFailure(st, err, stateUnhealthy)
+	}
+	if health.Service != daemonmeta.ServiceName {
+		st.State = stateUnhealthy
+		st.Error = "healthz: response is not from AO daemon"
+		return st
+	}
+	st.PID = health.PID
+	st.Health = health.Status
+	if health.Status != "ok" {
+		st.State = stateUnhealthy
+		return st
+	}
+
+	ready, err := c.readProbe(ctx, c.remote.baseURL, "readyz")
+	if err != nil {
+		return remoteProbeFailure(st, err, stateNotReady)
+	}
+	st.Ready = ready.Status
+	if ready.Status == string(stateReady) {
+		st.State = stateReady
+		return st
+	}
+	st.State = stateNotReady
+	return st
+}
+
+// remoteProbeFailure classifies a failed probe against a remote daemon. A 429 is
+// the LAN listener's per-source lockout after repeated bad connection passwords:
+// the daemon is healthy, so reporting "unhealthy" inverts the diagnosis and
+// sends a user who fat-fingered a password off to investigate a daemon that is
+// fine. Remote-only by construction — the lockout lives in the authenticated
+// listener's middleware, which the loopback path never reaches — so local status
+// is untouched.
+func remoteProbeFailure(st daemonStatus, err error, fallback daemonState) daemonStatus {
+	var httpErr probeHTTPError
+	if errors.As(err, &httpErr) && httpErr.status == http.StatusTooManyRequests {
+		st.State = stateLockedOut
+		st.Error = "too many failed connection passwords from this machine; it is temporarily locked out — " +
+			"wait for the lockout to clear, then retry with the correct password. The daemon itself is fine."
+		return st
+	}
+	st.State = fallback
+	st.Error = err.Error()
+	return st
+}
+
+func (c *commandContext) readProbe(ctx context.Context, base, path string) (probeResult, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf("http://%s:%d/%s", config.LoopbackHost, port, path), http.NoBody)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+"/"+path, http.NoBody) // #nosec G704 -- base is loopback or an explicitly configured daemon URL.
 	if err != nil {
 		return probeResult{}, err
 	}
+	c.authorize(req)
 	resp, err := c.deps.HTTPClient.Do(req)
 	if err != nil {
 		return probeResult{}, fmt.Errorf("%s: %w", path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return probeResult{}, fmt.Errorf("%s: HTTP %d", path, resp.StatusCode)
+		return probeResult{}, probeHTTPError{path: path, status: resp.StatusCode}
 	}
 	var body probeResult
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
@@ -200,11 +282,20 @@ func writeStatus(cmd *cobra.Command, st daemonStatus) error {
 			return err
 		}
 	}
-	if _, err := fmt.Fprintf(out, "  run file: %s\n", st.RunFile); err != nil {
-		return err
+	if st.URL != "" {
+		if _, err := fmt.Fprintf(out, "  url: %s\n", st.URL); err != nil {
+			return err
+		}
 	}
-	if _, err := fmt.Fprintf(out, "  data dir: %s\n", st.DataDir); err != nil {
-		return err
+	if st.RunFile != "" {
+		if _, err := fmt.Fprintf(out, "  run file: %s\n", st.RunFile); err != nil {
+			return err
+		}
+	}
+	if st.DataDir != "" {
+		if _, err := fmt.Fprintf(out, "  data dir: %s\n", st.DataDir); err != nil {
+			return err
+		}
 	}
 	if st.Health != "" {
 		if _, err := fmt.Fprintf(out, "  healthz: %s\n", st.Health); err != nil {

--- a/backend/internal/cli/stop.go
+++ b/backend/internal/cli/stop.go
@@ -46,6 +46,19 @@ func newStopCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) stopDaemon(ctx context.Context, opts stopOptions) (daemonStatus, error) {
+	// `ao stop` is the one command that must never follow a stray --url/AO_URL:
+	// silently shutting down a daemon on someone else's machine is not a
+	// recoverable mistake. The refusal is unconditional, and deliberately does
+	// NOT branch on whether the URL looks like loopback — --url means "a daemon
+	// other than the one I discovered locally", and letting the single
+	// destructive verb behave differently based on how a string happens to look
+	// is exactly the surprise worth refusing.
+	if c.remote != nil {
+		return daemonStatus{}, fmt.Errorf(
+			"refusing to stop a remote daemon: %s targets %s. `ao stop` only ever stops the local daemon "+
+				"it discovers through the run-file, never a --url/AO_URL target — stop that daemon on the machine running it",
+			c.remote.source, c.remote.baseURL)
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return daemonStatus{}, err

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -518,6 +518,11 @@ func resolveDataDir() (string, error) {
 	return filepath.Join(stateDir, "data"), nil
 }
 
+// StateDir returns the canonical AO home directory (~/.ao) that holds
+// running.json, the data dir, and the CLI's remotes file. Exported for callers
+// that need the directory itself rather than a path Load already resolves.
+func StateDir() (string, error) { return defaultStateDir() }
+
 func defaultStateDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -17,6 +17,48 @@ go build -o ./bin/ao ./cmd/ao
 ./bin/ao agent ls
 ```
 
+## Targeting a remote daemon
+
+By default every command talks to the local daemon: it reads `running.json`,
+checks the PID is alive, and calls `127.0.0.1`. The global `--url` flag (or
+`AO_URL`) points the same commands at another machine's LAN listener instead
+(see [ADR 0001](../adr/0001-lan-listener-for-mobile.md)), skipping the run-file
+and the local liveness check entirely — so it works on a machine that has never
+run AO:
+
+```bash
+ao status --url http://100.64.0.1:3011
+AO_URL=http://100.64.0.1:3011 ao agent ls
+```
+
+The credential is the daemon's connection password — the same one the mobile app
+pairs with — sent as `Authorization: Bearer <password>`. It comes from `AO_TOKEN`,
+or from `~/.ao/remotes.json`, which mirrors the mobile app's saved-node list and
+must be mode `0600` (the CLI refuses to read it otherwise):
+
+```json
+{
+  "remotes": [
+    { "label": "desk", "url": "http://100.64.0.1:3011", "password": "abcd1234" }
+  ]
+}
+```
+
+Notes:
+
+- The link is plain HTTP by design (ADR 0001, home network / Tailscale only).
+  There is no TLS or certificate pinning.
+- The URL must not carry a username or password. A credential belongs in
+  `AO_TOKEN` or the `remotes.json` entry, so `--url http://user:pw@host:3011` is
+  rejected rather than silently stripped.
+- `ao stop` only ever stops the local daemon it found through `running.json`. A
+  `--url` / `AO_URL` target is refused — including one that names loopback, so
+  the single destructive verb never changes behavior based on how the URL looks.
+- CLI telemetry (`/internal/*`) is never sent to a remote daemon.
+- Repeated bad passwords lock your source address out of the LAN listener for a
+  minute. `ao status` reports that as `locked_out` rather than `unhealthy` — the
+  daemon is fine; wait and retry. This state cannot occur against a local daemon.
+
 ## Current commands
 
 Every product command resolves to a daemon HTTP route. Run `ao <command>


### PR DESCRIPTION
## Ticket

No upstream issue. [RFC](https://github.com/AronPerez/agent-orchestrator/blob/plan/2026-08-24-wave3/docs/upstreaming-rfc-remote-hosts.md). Stacked on #4358.

## Problem

`ao doctor`, `preview`, `import`, `start`, `dev import-projects` and the hidden `daemon` command do not fail against `--url`: they succeed, on the wrong machine, and say nothing about it. `ao doctor --url` reports the laptop's git and data dir; `ao import --url` opens the laptop's database. A command that acted on the wrong host cannot be caught after the fact — the output looks exactly like success.

## Solution

Each of those commands now refuses a remote target outright, naming the flag, the URL, and where to run it instead, at exit code 2. `ao hooks` and `ao agent-process supervise` are daemon-local callbacks and pin to the local daemon regardless of an exported `AO_URL`, since they report activity for a session that only exists on this machine.

## How Has This Been Tested?

`cd backend && go build ./... && go vet ./... && go test ./... && go test -race ./internal/cli/` on the current `main` (`c9a0adb2`): 158 packages ok, `gofmt -l` clean. Eight new tests cover the message shape, exit code, end-to-end refusals asserting an empty request log, and the daemon-local-callback split between an ignored `AO_URL` and a refused `--url`.

## Artifacts (if appropriate):

No renderable surface: Go CLI code only, no files under `frontend/src`. Behaviour is covered by the tests above.
